### PR TITLE
[Quant][NVFP4][MoE] Declare expert weight layout so W4A16/W4A4 can be selected dynamically

### DIFF
--- a/tests/kernels/moe/test_nvfp4_moe_a16_layout.py
+++ b/tests/kernels/moe/test_nvfp4_moe_a16_layout.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVFP4 MoE W4A16/W4A4 expert weight layout agreement.
+
+Picking the scheme per forward is only sound if one set of expert weights
+serves both. These tests pin why that does not hold today, so the constraint
+is not rediscovered per backend, and so the opt-in flag fails loudly instead
+of being silently ignored.
+"""
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4_a16_dispatch import (
+    can_dispatch_a16_per_forward,
+    nvfp4_moe_weight_layout_key,
+)
+
+
+def test_b12x_prepares_a_different_w13_for_each_scheme():
+    """The concrete blocker: reorder_w13 is driven by use_a16."""
+    a16 = nvfp4_moe_weight_layout_key("B12X", True)
+    a4 = nvfp4_moe_weight_layout_key("B12X", False)
+    assert a16 != a4
+    assert a16[1] == "w13_reordered" and a4[1] == "w13_checkpoint"
+
+
+def test_b12x_is_refused_with_the_responsible_step_named():
+    ok, reason = can_dispatch_a16_per_forward("B12X")
+    assert not ok
+    assert "reorder_w13" in reason
+
+
+def test_unaudited_backend_is_refused_rather_than_assumed_compatible():
+    """Failing open here would mean silently wrong numerics."""
+    ok, reason = can_dispatch_a16_per_forward("SOME_FUTURE_BACKEND")
+    assert not ok
+    assert "not been audited" in reason
+
+
+@pytest.mark.parametrize("backend", list(NvFp4MoeBackend))
+def test_no_backend_can_dispatch_per_forward_yet(backend):
+    """Guard: if one becomes sharable, the pairing must be re-reviewed."""
+    ok, _ = can_dispatch_a16_per_forward(backend.name)
+    assert not ok, (
+        f"{backend.name} now reports a shared W4A16/W4A4 expert weight layout; "
+        "verify the claim and update the dispatch path"
+    )
+
+
+def test_flag_is_off_by_default():
+    import vllm.envs as envs
+
+    assert envs.VLLM_NVFP4_MOE_A16_MAX_M == 0
+
+
+def test_setting_the_flag_fails_loudly_at_weight_conversion(monkeypatch):
+    """The flag must not be silently ignored when no backend can honour it."""
+    import vllm.envs as envs
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+        convert_to_nvfp4_moe_kernel_format,
+    )
+
+    monkeypatch.setattr(envs, "VLLM_NVFP4_MOE_A16_MAX_M", 8)
+    with pytest.raises(NotImplementedError, match="reorder_w13"):
+        convert_to_nvfp4_moe_kernel_format(
+            NvFp4MoeBackend.B12X,
+            layer=None,
+            w13=None,
+            w13_scale=None,
+            w13_scale_2=None,
+            a13_scale=None,
+            w2=None,
+            w2_scale=None,
+            w2_scale_2=None,
+            a2_scale=None,
+            is_act_and_mul=True,
+        )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -189,6 +189,7 @@ if TYPE_CHECKING:
     VLLM_HUMMING_USE_F16_ACCUM: bool = False
     VLLM_HUMMING_MOE_GEMM_TYPE: Literal["indexed", "grouped", "auto"] | None = None
     VLLM_B12X_MOE_FP4_FORCE_A16: bool = False
+    VLLM_NVFP4_MOE_A16_MAX_M: int = 0
     VLLM_DEEPEPLL_NVFP4_DISPATCH: bool = False
     VLLM_V1_USE_OUTLINES_CACHE: bool = False
     VLLM_TPU_USING_PATHWAYS: bool = False
@@ -1615,6 +1616,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_B12X_MOE_FP4_FORCE_A16": lambda: bool(
         int(os.getenv("VLLM_B12X_MOE_FP4_FORCE_A16", "0"))
     ),
+    # Token-count threshold below which NVFP4 MoE would run the weight-only
+    # (W4A16) expert path and above which it would run W4A4. 0 disables it.
+    # No backend can honour this yet: see
+    # fused_moe/oracle/nvfp4_a16_dispatch.py for why.
+    "VLLM_NVFP4_MOE_A16_MAX_M": lambda: int(os.getenv("VLLM_NVFP4_MOE_A16_MAX_M", "0")),
     # Allow use of FlashInfer MxInt4 MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_INT4": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_INT4", "0"))

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -17,6 +17,9 @@ from vllm.model_executor.layers.fused_moe.config import (
     nvfp4_moe_quant_config,
     nvfp4_w4a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4_a16_dispatch import (
+    can_dispatch_a16_per_forward,
+)
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.b12x_moe import (
     prepare_nvfp4_moe_layer_for_b12x,
@@ -335,6 +338,13 @@ def convert_to_nvfp4_moe_kernel_format(
     torch.Tensor,
 ]:
     use_a16 = _use_a16(nvfp4_backend, use_a16)
+
+    if envs.VLLM_NVFP4_MOE_A16_MAX_M > 0:
+        # Fail at load naming the preparation step responsible, rather than
+        # ignoring the flag or serving one scheme for both.
+        ok, reason = can_dispatch_a16_per_forward(nvfp4_backend.name)
+        if not ok:
+            raise NotImplementedError(f"VLLM_NVFP4_MOE_A16_MAX_M is set but {reason}")
     if nvfp4_backend == NvFp4MoeBackend.B12X:
         if a13_scale is None or a2_scale is None:
             if not use_a16:

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4_a16_dispatch.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4_a16_dispatch.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Whether NVFP4 MoE can pick W4A16 or W4A4 per forward.
+
+At small M a weight-only (W4A16) expert GEMM beats a fully quantised (W4A4)
+one, and at large M the FP4 tensor cores win. M varies per forward, so the
+choice would ideally be made per forward rather than once per server.
+
+It cannot be, today, and the reason is the expert weight layout rather than
+the selection logic. ``convert_to_nvfp4_moe_kernel_format`` passes
+``reorder_w13=use_a16`` to the B12X preparation, so the W4A16 and W4A4 paths
+produce different w13 tensors from the same checkpoint. Serving both from one
+layer would mean keeping both resident, and for expert weights that is the
+dominant memory cost in the model.
+
+This module states that constraint in code, so the dispatch question has one
+answer that tests can pin rather than being rediscovered per backend. It is
+keyed on backend *name* to stay free of an import cycle with the oracle.
+"""
+
+# Backends whose expert weight preparation is known to depend on use_a16, with
+# the specific reason. Anything absent is treated as unaudited rather than
+# compatible: wrongly claiming sharability produces silently wrong numerics.
+_LAYOUT_DIVERGES: dict[str, str] = {
+    "B12X": (
+        "prepare_nvfp4_moe_layer_for_b12x is called with reorder_w13=use_a16, "
+        "so the W4A16 and W4A4 paths produce different w13 tensors"
+    ),
+}
+
+
+def nvfp4_moe_weight_layout_key(backend_name: str, use_a16: bool) -> tuple[str, str]:
+    """Identify the on-device expert weight layout a backend prepares.
+
+    Two configurations can share one set of expert weights only if their keys
+    are equal.
+
+    Args:
+        backend_name: ``NvFp4MoeBackend`` member name.
+        use_a16: Whether the weight-only path is in use.
+
+    Returns:
+        A tuple identifying the layout. Unaudited backends get a key that
+        varies with ``use_a16``, so they are reported as not sharable.
+    """
+    if backend_name in _LAYOUT_DIVERGES:
+        return (backend_name, "w13_reordered" if use_a16 else "w13_checkpoint")
+    return (backend_name, f"unaudited_a16={use_a16}")
+
+
+def can_dispatch_a16_per_forward(backend_name: str) -> tuple[bool, str | None]:
+    """Whether one loaded layer can serve both W4A16 and W4A4 forwards.
+
+    Args:
+        backend_name: ``NvFp4MoeBackend`` member name.
+
+    Returns:
+        ``(False, reason)`` for every backend today. The reason names the
+        preparation step responsible, so it can be acted on rather than
+        merely reported.
+    """
+    if nvfp4_moe_weight_layout_key(backend_name, True) == nvfp4_moe_weight_layout_key(
+        backend_name, False
+    ):
+        return True, None
+    reason = _LAYOUT_DIVERGES.get(
+        backend_name,
+        "its expert weight preparation has not been audited for W4A16 and "
+        "W4A4 layout equality",
+    )
+    return False, f"{backend_name} cannot dispatch per forward: {reason}"


### PR DESCRIPTION
## Purpose

At small M a weight-only NVFP4 (W4A16) expert GEMM beats a fully quantised
(W4A4) one: decode is memory bound, so quantising activations buys little
while costing an extra quantise pass. At large M the FP4 tensor cores win.
M varies per forward, so the scheme would ideally be chosen per forward
rather than once per server.

It cannot be, today, and the interesting part is why.

## The constraint

In `convert_to_nvfp4_moe_kernel_format`, `prepare_nvfp4_moe_layer_for_b12x` is
called with `reorder_w13=use_a16`. The W4A16 and W4A4 paths therefore produce
**different w13 tensors from the same checkpoint**. One loaded layer cannot
serve both without keeping both resident, and for expert weights that is the
dominant memory cost in the model. The same call also synthesises unit
activation scales for the A16 path when they are absent, so the two
configurations differ in more than row ordering.

Right now that constraint lives in an argument default. Someone asking "can we
pick the scheme per forward?" has to rediscover it per backend, and the answer
is easy to get wrong in the optimistic direction, where the failure mode is
silently wrong numerics.

## What this adds

- `nvfp4_moe_weight_layout_key(backend_name, use_a16)` identifies the prepared
  expert weight layout. Two configurations can share weights only if the keys
  are equal. A backend that has not been audited gets a key that varies with
  `use_a16`, so it is reported as not sharable rather than assumed compatible.
- `can_dispatch_a16_per_forward(backend_name)` answers the question and names
  the preparation step responsible, so the answer is actionable rather than
  just a refusal.
- `VLLM_NVFP4_MOE_A16_MAX_M`, default `0`. When set, weight conversion raises
  with that reason rather than ignoring the flag or quietly serving one scheme
  for both.

No backend reports a shared layout, so **nothing changes by default**, and a
parametrized test over every `NvFp4MoeBackend` member guards that, failing if
one starts to.

The module is keyed on backend name rather than the enum to avoid an import
cycle with the oracle, which I verified by importing both directions.

## Why this is not a duplicate

I ran the checks in AGENTS.md. A search for `reorder_w13` across open PRs
returns nothing. The closest work is adjacent on a different axis:

- #42428 adds W4A16 NVFP4 fused MoE plus an `--override-activation-dtype` flag
  so a W4A4 checkpoint can be loaded through the W4A16 path. That is a static,
  per-server choice made once at load. This PR does not add or change a path
  and does not let you pick one; it states whether the two can coexist over one
  set of weights, which is the question that has to be answered before a
  per-forward choice is possible at all.
- #52240 audits which MXFP4 MoE backends require interleaved versus contiguous
  gate/up W13 layout. That is the same method applied to a different axis, and
  it is good precedent: the fix for an implicit layout requirement is to state
  it explicitly and test it. This PR does that for the NVFP4 W4A16 and W4A4
  split, which #52240 does not cover.
- #43929 supplies the B12X NVFP4 W4A16 routing this constraint sits on top of.
  It establishes the A16 path; this describes what that path costs in layout
  terms. They do not overlap.

This is the MoE counterpart to #54614, which does the same for dense linear.
The two are independent and can land in either order.

## Testing

```
pytest tests/kernels/moe/test_nvfp4_moe_a16_layout.py -v
```

15 passed. Covers: B12X producing a different layout key per scheme; the
refusal naming `reorder_w13`; an unaudited backend being refused rather than
assumed compatible; every `NvFp4MoeBackend` member currently refusing; the
flag defaulting to off; and the flag raising at weight conversion when set.

```
ruff check <changed files>   # All checks passed
ruff format <changed files>  # clean
```

I verified the integration test is not vacuous by disabling the guard, which
makes it fail rather than pass.

Not run on NVFP4 hardware. The tests are CPU-only by construction, because the
behaviour under test is layout bookkeeping rather than numerics.

## Model evaluation

None, deliberately. `VLLM_NVFP4_MOE_A16_MAX_M` defaults to `0` and no backend
reports a shared layout, so backend selection and weight preparation are
unchanged and no model output can differ. Enabling it raises at load instead of
running. Numerics belong with the first backend that can actually share a
layout.

## AI assistance

AI assistance was used to author this change. I have reviewed every changed
line, ran the tests and linters above myself, and can defend the design.
