### PR TITLE
[Warmup] Fix FlashInfer autotune deadlock under TP with a warm cache

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -322,7 +322,13 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     if cached_results is not None:
         write_flashinfer_autotune_cache(cache_path, cached_results)
         world.barrier()
-        tuner.load_configs(str(cache_path))
+        # Only load with one rank. Under expert parallelism the per-rank MoE
+        # problem shapes differ, so with a warm cache some ranks hit and skip
+        # profiling while others miss and profile. The autotuner's per-tactic
+        # all-reduce then fires a different number of times per rank and the
+        # warmup deadlocks.
+        if world.world_size == 1:
+            tuner.load_configs(str(cache_path))
 
     group = world.cpu_group if world.world_size > 1 else None
     set_autotune_process_group(group)


### PR DESCRIPTION
## Purpose

`flashinfer_autotune()` loads a persisted autotune cache into the tuner before the warmup forward. With more than one rank this can deadlock the warmup.

The distributed autotuner averages each tactic's timing across ranks with a per-tactic all-reduce (`AutoTuner._profile_single_kernel`), so every rank has to profile the same tactics in lockstep. That invariant only holds when the tuner starts empty on every rank. A warm cache breaks it. The autotuner has a fast path for a cache hit that skips the whole profiling loop, and its all-reduce with it. Under tensor and expert parallelism the per-rank MoE problem shapes differ, so the same cache is hit on some ranks and missed on others. The ranks that hit skip profiling while the rest keep going, the per-tactic all-reduce counts stop matching, and the run hangs.

Because the cache is only written after a run finishes, a cold first run tunes fine and then leaves a cache that makes the next start hang, which is why the failure looks intermittent.

Note this is a different skip than the one the existing `randomize_inputs=True` already handles. Randomized inputs keep every expert non-empty so no rank skips a kernel for lack of tokens under EP. That does not help here, because a cache hit skips profiling even when the expert is busy. The two are complementary, they cover different skip causes.

Fix: only load the cache when there is a single rank. With more ranks we tune cold so every rank stays in lockstep and honors the per-tactic all-reduce invariant. The cache file is still written, so a later single-rank run can reuse it.

## Test Plan

Serve an NVFP4 MoE model with tensor parallelism on a GPU where FlashInfer autotune runs (SM 9.0+), start it once to populate the autotune cache, then restart so the second start loads the warm cache during warmup.

## Test Result

Reproduced and fixed on 4x RTX PRO 6000 (sm120, TP4) with an NVFP4 MoE model. With a warm cache the warmup deadlocked, rank 0 past the autotuner and blocked in the model output all-reduce while the other ranks sat in the autotuner all-reduce (GPU 0 at 100 percent, the rest idle). Clearing the cache to force a cold run let all four ranks tune together and generate normally. With this change the warm restart tunes cold across all ranks and no longer hangs, cold tuning cost was about 14s here.

This change was written with AI assistance and reviewed and tested by me on sm120 hardware.