### PR TITLE
[Bugfix] Fix fp16 precision loss in FunASR position encoding

### DIFF
--- a/tests/model_executor/test_funasr_position_encoder.py
+++ b/tests/model_executor/test_funasr_position_encoder.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.models.funasr import SinusoidalPositionEncoder
+
+
+def test_position_encoding_fp16_matches_fp32_reference() -> None:
+    """fp16 position encodings must stay close to the fp32 reference.
+
+    Regression test for a bug where FunASR-Nano produced degenerate
+    repeated-token transcriptions under `--dtype float16`: the encoder's
+    log/exp/sin/cos math was run directly in fp16, whose limited precision
+    on the small timescale terms produced phase errors up to ~0.4 (out of
+    a [-1, 1] range) once multiplied by position indices.
+    """
+    encoder = SinusoidalPositionEncoder()
+    positions = torch.arange(1, 801)[None, :]
+    depth = 560
+
+    encoding_fp32 = encoder.encode(positions, depth, dtype=torch.float32)
+    encoding_fp16 = encoder.encode(positions, depth, dtype=torch.float16)
+
+    torch.testing.assert_close(
+        encoding_fp16.float(), encoding_fp32, atol=1e-2, rtol=1e-2
+    )

--- a/vllm/model_executor/models/funasr.py
+++ b/vllm/model_executor/models/funasr.py
@@ -265,14 +265,19 @@ class SinusoidalPositionEncoder(torch.nn.Module):
         depth: int,
         dtype: torch.dtype = torch.float32,
     ):
+        # The log/exp/sin/cos below are computed in float32 regardless of
+        # the target dtype: at low precision (e.g. float16) the timescale
+        # exponents lose enough precision to produce large phase errors,
+        # scrambling the encoder's sense of position.
+        compute_dtype = torch.float32
         batch_size = positions.size(0)
-        positions = positions.type(dtype)
+        positions = positions.type(compute_dtype)
         device = positions.device
         log_timescale_increment = torch.log(
-            torch.tensor([10000], dtype=dtype, device=device)
+            torch.tensor([10000], dtype=compute_dtype, device=device)
         ) / (depth / 2 - 1)
         inv_timescales = torch.exp(
-            torch.arange(depth / 2, device=device).type(dtype)
+            torch.arange(depth / 2, device=device).type(compute_dtype)
             * (-log_timescale_increment)
         )
         inv_timescales = torch.reshape(inv_timescales, [batch_size, -1])


### PR DESCRIPTION
## Purpose

Fixes #54569.

FunASR-Nano produces garbage/repeated-token transcriptions when served with `--dtype float16`. `SinusoidalPositionEncoder.encode` in `vllm/model_executor/models/funasr.py` computed its log/exp/sin/cos math directly in the model's runtime dtype. In fp16, the timescale terms (which span from 1 down to 1/10000) lose most of their precision, and multiplying by position indices up to several hundred amplifies that truncation into large phase errors inside sin/cos — up to ~0.42 absolute error against the fp32 reference, on a signal that should stay within [-1, 1]. That corrupts the audio encoder's sense of temporal order, and the Qwen3 decoder collapses into repeating a token.

Fix: compute the encoding in float32 internally regardless of the target dtype, and cast only the final result to the target dtype. This brings the fp16 error down to ~0.0002, consistent with normal fp16 rounding.

## Test Plan

- Added `tests/model_executor/test_funasr_position_encoder.py`, asserting the fp16 position encoding matches the fp32 reference within tolerance. Confirmed it fails against the pre-fix implementation and passes against this fix.
- `pre-commit run --files vllm/model_executor/models/funasr.py tests/model_executor/test_funasr_position_encoder.py`
- `python -m pytest tests/model_executor/test_funasr_position_encoder.py -v`
- End-to-end repro from #54569 on GPU:
  ```bash
  vllm serve <FunASR-Nano-2512-vllm path> --served-model-name fun-asr-nano \
      --host 127.0.0.1 --port 8899 --gpu-memory-utilization 0.40 \
      --enforce-eager --dtype float16
  curl -fsS http://127.0.0.1:8899/v1/audio/transcriptions \
      -F file=@zh.mp3 -F model=fun-asr-nano -F language=zh -F response_format=json

## Test Result

pre-commit: ruff check, ruff format, typos, mypy, SPDX headers, forbidden-imports check, and config validation all passed on the changed files.

pytest: 1 passed (test_position_encoding_fp16_matches_fp32_reference).

Standalone numerical check (outside the test suite): fp16 vs fp32 max absolute error in the position encoding dropped from 0.42 → 0.00024 after the fix.

GPU end-to-end transcription output: <fill in — before/after text output from the curl command above; not run in this environment, no GPU available>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>