### PR TITLE
[Bugfix][Spec Decode] Seed both-XD-RoPE drafting from the xdrope positions buffer

### DIFF
--- a/tests/v1/spec_decode/test_xdrope_seed_positions.py
+++ b/tests/v1/spec_decode/test_xdrope_seed_positions.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Draft seed positions per RoPE flavor, and the 1D slot coordinate.
+
+The both-XD-RoPE config allocates ``xdrope_positions`` instead of the 1D
+``positions`` buffer, so the draft loop's seed must read from it (#54555).
+And because XD-RoPE decode positions are the absolute token index on every
+dim, the slot coordinate is dim 0 of that buffer, the same extraction the
+M-RoPE branch uses.
+"""
+
+import torch
+
+import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+
+def _proposer(uses_mrope: bool, uses_xdrope_dim: int, draft_xdrope_dim: int):
+    proposer = SpecDecodeBaseProposer.__new__(SpecDecodeBaseProposer)
+    proposer.uses_mrope = uses_mrope
+    proposer.uses_xdrope_dim = uses_xdrope_dim
+    proposer.draft_uses_xdrope_dim = draft_xdrope_dim
+    proposer.mrope_positions = (
+        torch.zeros((3, 64), dtype=torch.int64) if uses_mrope else None
+    )
+    proposer.xdrope_positions = (
+        torch.zeros((uses_xdrope_dim, 64), dtype=torch.int64)
+        if uses_xdrope_dim > 0 and draft_xdrope_dim > 0
+        else None
+    )
+    proposer.positions = (
+        None
+        if (uses_mrope or (uses_xdrope_dim > 0 and draft_xdrope_dim > 0))
+        else torch.zeros(64, dtype=torch.int64)
+    )
+    return proposer
+
+
+def test_seed_reads_xdrope_buffer_for_both_xdrope() -> None:
+    proposer = _proposer(uses_mrope=False, uses_xdrope_dim=4, draft_xdrope_dim=4)
+    proposer.xdrope_positions[0] = torch.arange(64)
+    idx = torch.tensor([3, 7])
+    seeded = proposer._draft_seed_positions(idx)
+    assert torch.equal(seeded[0], torch.tensor([3, 7]))
+    assert proposer.positions is None  # the 1D buffer must not be touched
+
+
+def test_seed_reads_mrope_buffer_for_mrope() -> None:
+    proposer = _proposer(uses_mrope=True, uses_xdrope_dim=0, draft_xdrope_dim=0)
+    proposer.mrope_positions[0] = torch.arange(64)
+    idx = torch.tensor([3, 7])
+    seeded = proposer._draft_seed_positions(idx)
+    assert torch.equal(seeded[0], torch.tensor([3, 7]))
+
+
+def test_seed_reads_1d_buffer_for_plain() -> None:
+    proposer = _proposer(uses_mrope=False, uses_xdrope_dim=0, draft_xdrope_dim=0)
+    proposer.positions = torch.arange(64)
+    idx = torch.tensor([3, 7])
+    seeded = proposer._draft_seed_positions(idx)
+    assert torch.equal(seeded, torch.tensor([3, 7]))
+
+
+def test_multidim_flag_covers_both_rope_flavors() -> None:
+    assert _proposer(True, 0, 0)._uses_multidim_positions() is True
+    assert _proposer(False, 4, 4)._uses_multidim_positions() is True
+    assert _proposer(False, 0, 0)._uses_multidim_positions() is False
+    # Target xdrope with a non-xdrope draft falls back to the 1D path.
+    assert _proposer(False, 4, 0)._uses_multidim_positions() is False
+
+
+def test_slot_coordinate_is_dim0_for_both_xdrope(monkeypatch) -> None:
+    """`_update_positions_dependent_metadata` feeds dim 0 to the slot kernel."""
+    proposer = _proposer(uses_mrope=False, uses_xdrope_dim=4, draft_xdrope_dim=4)
+    proposer.max_model_len = 64
+    proposer._slot_mapping_buffer = torch.zeros(2, dtype=torch.int64)
+    proposer.xdrope_positions[:, 40] = torch.tensor([40, 40, 40, 40])
+
+    captured = {}
+    monkeypatch.setattr(
+        llm_base_proposer,
+        "eagle_step_update_slot_mapping_and_metadata",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    class _Meta:
+        block_table_tensor = torch.zeros((2, 4), dtype=torch.int64)
+        seq_lens = torch.tensor([41, 41])
+        slot_mapping = None
+        max_seq_len = 41
+        _seq_lens_cpu = None
+        _num_computed_tokens_cpu = None
+        seq_lens_cpu_upper_bound = None
+
+    positions = proposer.xdrope_positions[:, 40].reshape(4, 1)
+    proposer._update_positions_dependent_metadata(
+        positions, _Meta(), batch_size=1, input_batch_size=1, block_size=16
+    )
+    assert torch.equal(captured["positions_1d"], torch.tensor([40]))

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -378,6 +378,29 @@ class SpecDecodeBaseProposer:
                 self.hidden_size, dtype=self.dtype, device=self.device
             )
 
+    def _uses_multidim_positions(self) -> bool:
+        return self.uses_mrope or (
+            self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0
+        )
+
+    def _draft_seed_positions(
+        self, token_indices_to_sample: torch.Tensor
+    ) -> torch.Tensor:
+        """Positions the draft loop seeds from, per RoPE flavor.
+
+        The both-XD-RoPE config allocates ``xdrope_positions`` instead of the
+        1D ``positions`` buffer, so seeding from ``self.positions`` there would
+        raise ``AttributeError`` on the first draft step (#54555). XD-RoPE
+        decode positions are the absolute token index on every dim
+        (``has_delta=False`` in ``RopeState``), so dim 0 feeds the slot math
+        exactly the way the M-RoPE temporal dim does not.
+        """
+        if self.uses_mrope:
+            return self.mrope_positions[:, token_indices_to_sample]
+        if self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:
+            return self.xdrope_positions[:, token_indices_to_sample]
+        return self.positions[token_indices_to_sample]
+
     def _get_positions(self, num_tokens: int):
         if self.uses_mrope:
             return self.mrope_positions[:, :num_tokens]
@@ -634,10 +657,7 @@ class SpecDecodeBaseProposer:
                 ).contiguous()
             return draft_token_ids.view(-1, self.num_speculative_tokens)
 
-        if self.uses_mrope:
-            positions = self.mrope_positions[:, token_indices_to_sample]
-        else:
-            positions = self.positions[token_indices_to_sample]
+        positions = self._draft_seed_positions(token_indices_to_sample)
         hidden_states = hidden_states[token_indices_to_sample]
 
         if self.constant_draft_positions:
@@ -784,7 +804,7 @@ class SpecDecodeBaseProposer:
     ) -> torch.Tensor:
         """Update positions, slot mappings, and sequence metadata for the
         next draft step. Returns the updated positions tensor."""
-        positions_1d = positions[0] if self.uses_mrope else positions
+        positions_1d = positions[0] if self._uses_multidim_positions() else positions
         if self.uses_mrope:
             out_pos = self.mrope_positions[0, :batch_size]
         elif self.uses_xdrope_dim > 0 and self.draft_uses_xdrope_dim > 0:


### PR DESCRIPTION
Fixes #54555.

## Purpose

The both-XD-RoPE config (target model `uses_xdrope_dim > 0` and draft model `uses_xdrope_dim > 0`) allocates `xdrope_positions` instead of the 1D `positions` buffer, but the draft loop seeds `positions` from `self.positions` for anything that is not `uses_mrope`, so the first both-XD-RoPE drafter with `num_speculative_tokens >= 2` raises `AttributeError` on its first speculative step. The seed now reads from `xdrope_positions` for that config, and `_update_positions_dependent_metadata` takes the slot coordinate from dim 0 for both multi-dim flavors: XD-RoPE decode positions are the absolute token index on every dim by construction (`get_rope_state` builds XD-RoPE with `has_delta=False`, so `_prepare_rope_positions_kernel` uses `orig_pos`), which is exactly what the slot math needs.

No model in main implements `get_xdrope_input_positions` yet, so this path cannot be exercised end-to-end today; the fix lands ahead of the first XD-RoPE drafter (HunYuan-VL family per the runner comment) instead of inside it. Non-XD-RoPE paths are byte-for-byte unchanged.

## Test Plan

New `tests/v1/spec_decode/test_xdrope_seed_positions.py`: the seed reads the xdrope buffer for the both-XD-RoPE config (and never touches the missing 1D buffer), the M-RoPE and plain paths keep their buffers, `_uses_multidim_positions` covers both flavors and excludes a target-xdrope/non-xdrope-draft mix, and `_update_positions_dependent_metadata` feeds dim 0 to the slot kernel for the both-XD-RoPE config (kernel stubbed, CPU-only).

## Verification

- `.venv/bin/python -m pytest tests/v1/spec_decode/test_xdrope_seed_positions.py tests/v1/spec_decode/test_llm_base_proposer.py -q` -> 8 passed on current main (`810bc32`).
- `ruff check` and `ruff format --check` clean on both files.
- Not run: end-to-end drafting with an XD-RoPE checkpoint (none exists in main yet); the fix is exercised at the proposer state level above.

This change was prepared with AI assistance (Kimi K3); the crash mechanism was verified by reading the buffer init, the seed path, and the XD-RoPE decode position contract before writing the fix.
