### PR TITLE
[Bugfix] Load checkpoint KV-cache scales in the Qwen3.5 family

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -53,6 +53,9 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from vllm.model_executor.model_loader.weight_utils import (
+    maybe_remap_kv_scale_name,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.sequence import IntermediateTensors
 from vllm.tokenizers.registry import cached_tokenizer_from_config
@@ -285,8 +288,28 @@ class Qwen3_5Model(Qwen3NextModel):
                 n_shared_experts=1,
                 ckpt_prefix="mlp.shared_expert",
             )
+        # Checkpoints that ship calibrated KV-cache scales name them
+        # `...self_attn.{k,v}_scale`, but the runtime parameters live on the
+        # inner attention layer (`...self_attn.attn.{k,v}_scale`), and
+        # AutoWeightsLoader performs no remapping — without this the scales
+        # are silently dropped and fp8 KV runs at scale 1.0 (#54623).
+        params_dict = dict(self.named_parameters())
+
+        def _remap_kv_scale_names(
+            weights: Iterable[tuple[str, torch.Tensor]],
+        ) -> Iterable[tuple[str, torch.Tensor]]:
+            for name, weight in weights:
+                if name.endswith((".k_scale", ".v_scale", ".q_scale")):
+                    remapped = maybe_remap_kv_scale_name(name, params_dict)
+                    if remapped is None:
+                        continue
+                    name = remapped
+                yield name, weight
+
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        return loader.load_weights(
+            _remap_kv_scale_names(weights), mapper=self.hf_to_vllm_mapper
+        )
 
 
 class Qwen3_5ForCausalLMBase(


### PR DESCRIPTION
### Purpose

Fixes #54623 — the Qwen3.5 family never loads checkpoint KV-cache scales: `Qwen3_5Model.load_weights` hands the iterable straight to `AutoWeightsLoader`, which performs no scale-name remapping, so a checkpoint's `...self_attn.{k,v}_scale` tensors never reach the runtime parameters at `...self_attn.attn.{k,v}_scale`. `--kv-cache-dtype fp8` then silently runs at scale 1.0 — including for `unsloth/Qwen3.8-27B-NVFP4` (2.4M downloads), which ships 32 calibrated scale pairs.

This routes scale-suffixed names through `maybe_remap_kv_scale_name` before the loader, mirroring the existing pattern in `gemma4.py` / `gpt_oss.py`. Its default pattern (`\.([qkv])_scale$` → `.attn.\1_scale`) already handles this naming; no new remap rules are needed. No behavior change for checkpoints without scales (the suffix gate never fires).

### Test Plan

Hardware in #54623: RTX 5090 (SM_120), Qwen3.8-27B NVFP4, `--kv-cache-dtype fp8`, FLASHINFER, MTP k=3 (v0.27.1 image; the gap verified present on main by inspection).

1. Boot with a checkpoint carrying `k_scale`/`v_scale` tensors, `VLLM_LOGGING_LEVEL=DEBUG`.
2. Verify `Loaded weight layers.N.self_attn.attn.k_scale` for every full-attention layer (32 lines for this model). Note: with MTP enabled, the draft layer's scale-1.0 `warning_once` still fires legitimately — see #54623 for the diagnosis trap.
3. GSM8K greedy comparison (n=300/arm, identical flags/seed).

### Test Result

Equivalent change validated end-to-end on v0.27.1 (scale tensors pre-renamed in the checkpoint to simulate this remap): all 32 scales load, GSM8K moves 92.3% → 93.7% (bf16-KV control: 94.5%, pooled n=600). Calibrated values for this model are ~1.06–1.63, i.e. K/V amax exceeds e4m3 range at scale 1.0, so the stock behavior clips.
