### PR TITLE
[Core][V1] Apply prefill_schedule_interval outside data parallelism

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -388,6 +388,108 @@ def test_schedule_prefills_gating(has_running: bool):
     assert any(r.req_id == "new0" for r in output.scheduled_new_reqs)
 
 
+def _decode_one(scheduler, output, req_ids: list[str]) -> None:
+    """Feed back one sampled token per request, so they keep decoding."""
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+            sampled_token_ids=[[0] for _ in req_ids],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+
+def _start_decoding(scheduler, req_id: str = "run0"):
+    """Prefill one request and take it into the decode state."""
+    (request,) = create_requests(
+        num_requests=1, num_tokens=8, max_tokens=100, req_ids=[req_id]
+    )
+    scheduler.add_request(request)
+    output = scheduler.schedule()
+    assert req_id in output.num_scheduled_tokens
+    _decode_one(scheduler, output, [req_id])
+    assert len(scheduler.running) == 1
+    return output
+
+
+@pytest.mark.parametrize("interval", [2, 4])
+def test_local_prefill_interval_holds_prefill_between_bursts(interval: int):
+    """A single engine applies `prefill_schedule_interval` in the scheduler,
+    timed from the last prefill-carrying step: a waiting prefill is held for the
+    remainder of the interval while running requests keep decoding, then
+    admitted once the interval has elapsed.
+    """
+    scheduler = create_scheduler(prefill_schedule_interval=interval)
+    # This prefill starts the interval.
+    _start_decoding(scheduler)
+    assert scheduler.last_prefill_step == scheduler.current_step
+
+    (new_req,) = create_requests(num_requests=1, num_tokens=8, req_ids=["new0"])
+    scheduler.add_request(new_req)
+
+    # Steps inside the interval decode alone; the waiting prefill is held.
+    for _ in range(interval - 1):
+        output = scheduler.schedule()
+        assert "new0" not in output.num_scheduled_tokens
+        assert "run0" in output.num_scheduled_tokens
+        assert new_req.status == RequestStatus.WAITING
+        _decode_one(scheduler, output, ["run0"])
+
+    # The interval has now elapsed, so prefill is admitted again.
+    output = scheduler.schedule()
+    assert "new0" in output.num_scheduled_tokens
+    assert scheduler.last_prefill_step == scheduler.current_step
+
+
+def test_local_prefill_interval_defaults_to_no_gating():
+    """The default interval of 1 leaves admission exactly as it was: a waiting
+    prefill is admitted on the very next step.
+    """
+    scheduler = create_scheduler()
+    assert scheduler.local_prefill_interval == 1
+    _start_decoding(scheduler)
+
+    (new_req,) = create_requests(num_requests=1, num_tokens=8, req_ids=["new0"])
+    scheduler.add_request(new_req)
+    output = scheduler.schedule()
+    assert "new0" in output.num_scheduled_tokens
+
+
+def test_local_prefill_interval_left_to_engine_under_dp():
+    """Under data parallelism the cadence must stay aligned across ranks, so the
+    DP engine core drives it and the scheduler must not gate on its own.
+    """
+    scheduler = create_scheduler(prefill_schedule_interval=4, data_parallel_size=2)
+    assert scheduler.local_prefill_interval == 1
+    _start_decoding(scheduler)
+
+    (new_req,) = create_requests(num_requests=1, num_tokens=8, req_ids=["new0"])
+    scheduler.add_request(new_req)
+    output = scheduler.schedule()
+    assert "new0" in output.num_scheduled_tokens
+
+
+def test_local_prefill_interval_never_idles_the_model():
+    """With nothing running to decode in prefill's place, the interval must not
+    hold prefill back, or the step would be wasted entirely.
+    """
+    scheduler = create_scheduler(prefill_schedule_interval=8)
+    _start_decoding(scheduler)
+
+    # Finish the only running request, leaving nothing to decode.
+    scheduler.finish_requests("run0", RequestStatus.FINISHED_ABORTED)
+    assert not scheduler.running
+
+    (new_req,) = create_requests(num_requests=1, num_tokens=8, req_ids=["new0"])
+    scheduler.add_request(new_req)
+    output = scheduler.schedule()
+    assert "new0" in output.num_scheduled_tokens
+
+
 def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
     """Drive a remote-KV request `r2` to the resume point (async load complete)
     while another request `r1` is already decoding, so the step is throttle-

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -75,6 +75,7 @@ def create_scheduler(
     use_v2_model_runner: bool | None = None,
     kv_cache_spec: KVCacheSpec | None = None,
     per_request_spec_decode_metrics: str = "none",
+    prefill_schedule_interval: int = 1,
     scheduling_policy: SchedulerPolicy = "fcfs",
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
@@ -113,6 +114,7 @@ def create_scheduler(
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        prefill_schedule_interval=prefill_schedule_interval,
         # Ensure admission/preemption mechanics are deterministic
         watermark=0.0,
         policy=scheduling_policy,

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -183,9 +183,16 @@ class SchedulerConfig:
     (the default) disables the watermark."""
 
     prefill_schedule_interval: int = Field(default=1, ge=1)
-    """For data-parallel deployments, only admit new prefill requests
-    once every N engine steps, aligned across DP ranks, to better balance
-    per-step forward-pass times."""
+    """Only admit new prefill requests once every N engine steps, leaving the
+    steps in between to decode alone. 1 (the default) admits prefill on every
+    step.
+
+    For data-parallel deployments the cadence is aligned across DP ranks, to
+    better balance per-step forward-pass times. For a single engine there is no
+    alignment requirement, so the interval is instead measured from the last
+    step that carried prefill. Either way, prefill is only deferred when at
+    least one running request can decode in its place, so the interval never
+    leaves the model idle."""
 
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -330,6 +330,17 @@ class Scheduler(SchedulerInterface):
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
         self.prefill_capacity_bound = False
+        # `prefill_schedule_interval` is driven by the DP engine core, which
+        # aligns it across ranks from a shared step counter. A single engine has
+        # no such counter and never throttles, so apply the interval here
+        # instead, timed from the last prefill-carrying step.
+        self.local_prefill_interval = (
+            self.scheduler_config.prefill_schedule_interval
+            if self.parallel_config.data_parallel_size == 1
+            else 1
+        )
+        # A full interval back, so the first step is never gated.
+        self.last_prefill_step = -self.local_prefill_interval
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
@@ -595,6 +606,9 @@ class Scheduler(SchedulerInterface):
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
+        # Whether a waiting request was admitted with prompt left to compute.
+        # Separate from `prefill_scheduled`, which covers only the running loop.
+        prefill_admitted = False
         # Whether any scheduled request has a synchronous connector KV load.
         has_sync_kv_loads = False
 
@@ -608,6 +622,19 @@ class Scheduler(SchedulerInterface):
         defer_prefills = (
             throttle_prefills and not self.prefill_capacity_bound
         ) and any(not r.is_prefill_chunk for r in self.running)
+
+        # Single-engine prefill cadence: hold prefill until the interval since
+        # the last prefill-carrying step has elapsed, so decode runs in long
+        # uninterrupted stretches. As above, only defer when something else can
+        # decode in prefill's place.
+        if (
+            not defer_prefills
+            and self.local_prefill_interval > 1
+            and self.current_step - self.last_prefill_step
+            < self.local_prefill_interval
+            and any(not r.is_prefill_chunk for r in self.running)
+        ):
+            defer_prefills = True
 
         # First, schedule the RUNNING requests.
         req_index = 0
@@ -1264,6 +1291,8 @@ class Scheduler(SchedulerInterface):
                     scheduled_spec_decode_tokens[request_id] = [
                         -1
                     ] * self.num_spec_tokens
+                # A resumed request past its prompt is decode work, not prefill.
+                prefill_admitted |= num_computed_tokens < request.num_prompt_tokens
                 # Only track requests that will still be prefilling after this chunk.
                 if num_computed_tokens + num_new_tokens < request.num_tokens:
                     self._inflight_prefills.add(request)
@@ -1291,6 +1320,11 @@ class Scheduler(SchedulerInterface):
             # record whether it was capacity-bound.
             if not defer_prefills:
                 self.prefill_capacity_bound = bool(self.waiting)
+
+        # Restart the cadence interval from any step that carried prefill,
+        # whether a new admission or a running chunk.
+        if self.local_prefill_interval > 1 and (prefill_scheduled or prefill_admitted):
+            self.last_prefill_step = self.current_step
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -630,8 +630,7 @@ class Scheduler(SchedulerInterface):
         if (
             not defer_prefills
             and self.local_prefill_interval > 1
-            and self.current_step - self.last_prefill_step
-            < self.local_prefill_interval
+            and self.current_step - self.last_prefill_step < self.local_prefill_interval
             and any(not r.is_prefill_chunk for r in self.running)
         ):
             defer_prefills = True


### PR DESCRIPTION
## Purpose

`prefill_schedule_interval` defers new prefills to every Nth engine step, so that decode
runs in longer uninterrupted stretches instead of meeting prefill on most steps. Today it
only takes effect under data parallelism: `DPEngineCoreProc._should_throttle_prefills()`
drives the cadence from a `step_counter` shared across ranks, while the base
`EngineCore._should_throttle_prefills()` returns `False` unconditionally. Setting the
option on a single engine is silently a no-op, with no warning.

This applies the same interval in the scheduler when `data_parallel_size == 1`. Without
peers there is nothing to align to, so the interval is measured from the last step that
carried prefill rather than against a global grid, which means no shared counter is
needed. Data-parallel deployments are untouched and keep their rank-aligned cadence.

As with the existing DP gate, prefill is deferred only when a running request can decode
in its place (`any(not r.is_prefill_chunk for r in self.running)`), so the interval never
leaves the model idle. The default interval of `1` disables the gate, leaving admission
behavior unchanged.

The motivating deployment is a single engine using decode context parallelism
(`--decode-context-parallel-size 8`). DCP is parallelism *within* one engine, so the
existing DP-only wiring never reaches it, even though the workload benefits from the
cadence as much as a DP deployment does.

## Why this is not duplicating an existing PR

No open PR touches `prefill_schedule_interval` or `_should_throttle_prefills`. The only
open PR matching `throttle_prefills` is #52969, an unrelated fix for aborted requests.

Two open PRs are adjacent but solve different problems:

- **#49075** (`max_num_partial_prefills` / `max_long_partial_prefills` in V1) bounds *how
  many* prefills run concurrently. This PR controls *how often* a step carries prefill at
  all. The two compose, and neither subsumes the other. Note that #49075 edits both
  scheduling loops, so a textual conflict is possible depending on merge order.
- **#53571** (SLO-aware scheduling policy) reorders the waiting queue by TTFT target,
  changing *which* request is admitted. This PR changes *whether* prefill is admitted on
  a given step, and does not reorder anything.

Checks run (`gh` was not authenticated in my environment, so these were run against the
public search API; the equivalent `gh` invocations are):

```bash
gh pr list --repo vllm-project/vllm --state open --search "prefill gate scheduler"
gh pr list --repo vllm-project/vllm --state open --search "throttle_prefills"
gh pr list --repo vllm-project/vllm --state open --search "prefill cadence"
```

## Test Plan

Five new tests in `tests/v1/core/test_scheduler.py`, covering the behavior contract:

- `test_local_prefill_interval_holds_prefill_between_bursts[2,4]` — a waiting prefill is
  held for the remainder of the interval while running requests keep decoding, then
  admitted once it elapses.
- `test_local_prefill_interval_defaults_to_no_gating` — the default of 1 admits on the
  next step, i.e. no behavior change.
- `test_local_prefill_interval_left_to_engine_under_dp` — at `data_parallel_size > 1` the
  scheduler does not gate, leaving the rank-aligned cadence to the engine.
- `test_local_prefill_interval_never_idles_the_model` — with nothing running to decode,
  prefill is admitted regardless of the interval.

`create_scheduler` gains a `prefill_schedule_interval` parameter.

## Test Result

All green. Commands and results:

```
pytest tests/v1/core/test_scheduler.py                     162 passed  (157 pre-existing + 5 new)
pytest tests/v1/core/test_async_scheduler.py \
       tests/v1/core/test_priority_preemption_bug.py \
       tests/v1/core/test_deferred_block_free.py            30 passed
pytest tests/v1/core/test_priority_scheduler_random.py      12 passed
```

Environment note: the host for these runs has no `torch`, so tests ran inside the
`vllm/vllm-openai-rocm:nightly` image (vllm `0.28.1rc1.dev108+g1dc464d42`, torch 2.12.0,
Python 3.12) with this checkout's sources overlaid on the installed package, whose build
is a direct ancestor of this branch. This deviates from the `uv`/`.venv` workflow in
`AGENTS.md`; I intend to re-run under the standard workflow before merge.

A single pytest process over all of `tests/v1/core` is SIGKILLed partway through on this
machine, on `main` as well as on this branch, so the suite was run per-file. Each file
passes on its own.

## Serving results

Kimi-K3 FP4, 8x MI355X, a single engine with DCP=8, replaying an agentic-coding trace at
concurrency 52 over a 3600s measured window. Interactivity is per-user output speed at
the 90th percentile; higher is better on both metrics.

| `prefill_schedule_interval` | tok/s/GPU | p90 interactivity (tok/s/user) |
| --- | --- | --- |
| 1 (default) | 8,001 | 10.98 |
| 17 | 8,121 (+1.5%) | 11.85 (+7.9%) |
| 29 | 7,983 (−0.2%) | 12.56 (+14.4%) |

Interactivity improves monotonically with the interval while throughput stays roughly
flat — the same trade-off the option already offers under DP, now reachable without it.

No accuracy eval was run. Neither the model computation nor sampling is touched; the
change affects only which requests are admitted on a given step. Batch composition does
change, as with any scheduling change, so outputs are not bit-identical. I am happy to
run `tests/evals` or a gsm8k pass if reviewers would like that confirmed.

## AI assistance

AI assistance (Cursor) was used to write this change, its tests and this description. I
have reviewed every changed line and can defend the design.
