### PR TITLE
[K3 Bug] Fix Kimi-K3 RecoverSSM startup failure `'MambaAttentionBackendEnum.GDN_ATTN declares 4 states, but provides 2 state copy funcs'`

### DIFF
--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -713,9 +713,10 @@ def validate_mamba_state_copy_funcs(
             f"missing state copy funcs for {mamba_spec.mamba_type}"
         )
         state_copy_funcs = copy_funcs[mamba_spec.mamba_type]
-        assert len(state_copy_funcs) == len(mamba_spec.shapes), (
+        assert 0 < len(state_copy_funcs) <= len(mamba_spec.shapes), (
             f"{mamba_spec.mamba_type} declares {len(mamba_spec.shapes)} states, "
-            f"but provides {len(state_copy_funcs)} state copy funcs"
+            f"but provides {len(state_copy_funcs)} state copy funcs; expected "
+            "a non-empty copyable prefix"
         )
 
 


### PR DESCRIPTION
## Purpose

`vllm serve moonshotai/Kimi-K3   --trust-remote-code   --tensor-parallel-size 8 --
load-format fastsafetensors   --gpu-memory-utilization 0.85   --enable-p
refix-caching   --use-replayssm   --reasoning-parser kimi_k3   --enable-
auto-tool-choice   --tool-call-parser kimi_k3   --host 0.0.0.0   --port
30000   --speculative-config '{"model":"RadixArk/Kimi-K3-DSpark","method
":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilist
ic","rejection_sample_method":"standard"}'`

```bash
(EngineCore pid=3344247)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 437, in get_response
(EngineCore pid=3344247)     raise RuntimeError(
(EngineCore pid=3344247) RuntimeError: Worker failed with error 'MambaAttentionBackendEnum.GDN_ATTN declares 4 states, but provides 2 state copy funcs', please check the stack trace above for the root cause
```

RecoverSSM adds two temporary workspace tensors after its two persistent states. These workspace tensors are rewritten during every speculative verification step and do not require state migration.

This PR fixes the issue.