### PR TITLE
[Bugfix][Spec Decode] Implement SupportsPP on more MTP drafters (Kimi-K3, MiniMax-M3, GLM4-MoE)

### DIFF
--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -54,7 +54,12 @@ from .glm4_moe import (
     Glm4MoE,
     Glm4MoeDecoderLayer,
 )
-from .utils import get_spec_layer_idx_from_weight_name, maybe_prefix
+from .interfaces import SupportsPP
+from .utils import (
+    get_spec_layer_idx_from_weight_name,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 
 
 class SharedHead(nn.Module):
@@ -191,12 +196,17 @@ class Glm4MoeMultiTokenPredictor(nn.Module):
         return logits
 
 
-class Glm4MoeMTP(nn.Module, Glm4MixtureOfExperts):
+class Glm4MoeMTP(nn.Module, SupportsPP, Glm4MixtureOfExperts):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
         self.model = Glm4MoeMultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
         )
 
         # Set MoE hyperparameters
@@ -224,7 +234,7 @@ class Glm4MoeMTP(nn.Module, Glm4MixtureOfExperts):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/models/kimi_k3/amd/mtp.py
+++ b/vllm/models/kimi_k3/amd/mtp.py
@@ -24,7 +24,12 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
-from vllm.model_executor.models.utils import get_pp_missing_layer_names, maybe_prefix
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.utils import (
+    get_pp_missing_layer_names,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 
@@ -175,7 +180,7 @@ class KimiK3MultiTokenPredictor(nn.Module):
         return logits
 
 
-class KimiK3MTP(nn.Module):
+class KimiK3MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_text_config
@@ -183,11 +188,16 @@ class KimiK3MTP(nn.Module):
         self.model = KimiK3MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/models/kimi_k3/nvidia/mtp.py
+++ b/vllm/models/kimi_k3/nvidia/mtp.py
@@ -27,7 +27,12 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
-from vllm.model_executor.models.utils import get_pp_missing_layer_names, maybe_prefix
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.utils import (
+    get_pp_missing_layer_names,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.models.common.ops.sequence_parallel import (
     sp_all_gather,
     sp_padding_mask,
@@ -211,7 +216,7 @@ class KimiK3MultiTokenPredictor(nn.Module):
         return logits
 
 
-class KimiK3MTP(nn.Module):
+class KimiK3MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_text_config
@@ -220,11 +225,16 @@ class KimiK3MTP(nn.Module):
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
         enable_kimi_k3_low_latency_gemm(self, vllm_config.model_config.dtype)
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/models/minimax_m3/amd/mtp.py
+++ b/vllm/models/minimax_m3/amd/mtp.py
@@ -42,7 +42,9 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
+from vllm.model_executor.models.interfaces import SupportsPP
 from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
 from vllm.sequence import IntermediateTensors
@@ -160,7 +162,7 @@ class MiniMaxM3MultiTokenPredictor(nn.Module):
         )
 
 
-class MiniMaxM3MTP(nn.Module):
+class MiniMaxM3MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -177,11 +179,16 @@ class MiniMaxM3MTP(nn.Module):
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/models/minimax_m3/nvidia/mtp.py
+++ b/vllm/models/minimax_m3/nvidia/mtp.py
@@ -26,7 +26,9 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
+from vllm.model_executor.models.interfaces import SupportsPP
 from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
 from vllm.sequence import IntermediateTensors
@@ -142,7 +144,7 @@ class MiniMaxM3MultiTokenPredictor(nn.Module):
         )
 
 
-class MiniMaxM3MTP(nn.Module):
+class MiniMaxM3MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -159,11 +161,16 @@ class MiniMaxM3MTP(nn.Module):
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,


### PR DESCRIPTION
## Summary

Extends the SupportsPP treatment from #46994 (DeepSeek + Qwen3.5) and #53408 (DSv4) to five more MTP draft classes. Without it, running any of these models under `--pipeline-parallel-size > 1` with `--speculative-config method:mtp` fails in `create_engine_config` with:

```
NotImplementedError: Pipeline parallelism is not supported for this model.
Supported models implement the `SupportsPP` interface.
```

## Files

- `vllm/models/kimi_k3/nvidia/mtp.py` (`KimiK3MTP`)
- `vllm/models/kimi_k3/amd/mtp.py` (`KimiK3MTP`)
- `vllm/models/minimax_m3/nvidia/mtp.py` (`MiniMaxM3MTP`)
- `vllm/models/minimax_m3/amd/mtp.py` (`MiniMaxM3MTP`)
- `vllm/model_executor/models/glm4_moe_mtp.py` (`Glm4MoeMTP`)

Same mechanical fix per class:
1. `SupportsPP` mixin on the outer MTP class.
2. `make_empty_intermediate_tensors_factory(["hidden_states", "residual"], self.config.hidden_size)` wired in `__init__`.
3. `# type: ignore[override]` on `forward` because MTP drafts take an extra positional `hidden_states` (Liskov violation vs the `SupportsPP` protocol).

The drafter is only ever built on the last PP stage (`is_last_pp_rank` guard in `model_runner.py`), so the SupportsPP-shaped `forward` is never called; the mixin and factory only satisfy the config verification path that copies `pipeline_parallel_size` from the target into `draft_parallel_config`. Same rationale as #46994 point (1).

## Duplicate-work check

Searched open PRs for each target file and for `MTP SupportsPP`. Only #46994 (DeepSeek + Qwen3.5) and #53408 (DSv4) are in flight; both cover disjoint files.

## Testing

- `.venv/bin/python -m pre_commit run --files <the five files>` — passed (ruff, mypy, typos, SPDX, etc.)

Mechanical, per-class mixin add; no behavior change on the actual per-request path (draft forward call site is untouched).

## Remaining MTP classes

Same audit turned up ~15 more MTP variants still missing SupportsPP (`ernie_mtp`, `exaone*_mtp`, `gemma4_mtp`, `hy_v3_mtp` / `hy_v4/nvidia`, `longcat_flash_mtp`, `mimo_mtp`, `mimo_v2_mtp`, `openpangu_mtp`, `step3p5_mtp`, `deepseek_v32/{amd,nvidia}`, `dots3_note/nvidia`, `inkling/{amd,nvidia}`). Happy to send a follow-up covering those if this shape is agreeable; kept the current batch to five popular families for a small first review.

AI assistance was used for code search and drafting; every line was reviewed by the submitter.
