### PR TITLE
[Kimi Bug] Fix gdn build_attn_metadata `'KimiK3KDAMetadataBuilder' object has no attribute 'layer_names'`

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -92,10 +92,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         vllm_config: VllmConfig,
         device: torch.device,
     ):
-        self.vllm_config = vllm_config
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         self.compilation_config = vllm_config.compilation_config
         self.speculative_config = vllm_config.speculative_config
-        self.kv_cache_spec = kv_cache_spec
         from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
             _resolve_gdn_prefill_backend,
         )


### PR DESCRIPTION
## Purpose

`vllm serve moonshotai/Kimi-K3   --trust-remote-code   --tensor-parallel-size 8--load-format fastsafetensors   --gpu-memory-utilization 0.85   --enable-prefix-caching   --use-replayssm   --reasoning-parser kimi_k3   --enable-auto-tool-choice   --tool-call-parser kimi_k3   --host 0.0.0.0   --port 30000   --speculative-config '{"model":"RadixArk/Kimi-K3-DSpark","method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic","rejection_sample_method":"standard"}'`

Will raise 

```bash
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/model_states/mamba_hybrid.py", line 311, in prepare_attn
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]     attn_metadata = build_attn_metadata(
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]                     ^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/attn_utils.py", line 330, in build_attn_metadata
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]     metadata = attn_metadata_builder.build(
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/kda_metadata.py", line 721, in build
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]     self._get_recoverssm_context()
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/kda_metadata.py", line 346, in _get_recoverssm_context
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]     layers = [forward_context[layer_name] for layer_name in self.layer_names]
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055]                                                             ^^^^^^^^^^^^^^^^
(Worker_TP0 pid=3369154) ERROR 08-31 21:06:29 [multiproc_executor.py:1055] AttributeError: 'KimiK3KDAMetadataBuilder' object has no attribute 'layer_names'
```

This PR fixes the issue
