### PR TITLE
[Bugfix] Add worker-side watchdog for wedged device kernels

### DIFF
--- a/cmake/external_projects/flashmla.cmake
+++ b/cmake/external_projects/flashmla.cmake
@@ -164,6 +164,12 @@ if(FLASH_MLA_ARCHS)
     # _flashmla_C is now ABI-stable torch 2.11+
     target_compile_definitions(_flashmla_C PRIVATE
         TORCH_TARGET_VERSION=0x020B000000000000ULL)
+
+    # Keep line info in the device code so cuda-gdb captures of resident
+    # kernels can be mapped back to FlashMLA/CUTLASS source lines (FlashMLA's
+    # own setup.py passes -lineinfo; vLLM's flags previously dropped it).
+    target_compile_options(_flashmla_C PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:-lineinfo>)
     if(VLLM_GPU_LANG STREQUAL "CUDA")
         target_compile_definitions(_flashmla_C PRIVATE USE_CUDA)
     endif()

--- a/tests/v1/worker/test_kernel_watchdog.py
+++ b/tests/v1/worker/test_kernel_watchdog.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import logging
+import time
+
+from vllm.v1.worker.kernel_watchdog import wedged_kernel_watchdog
+
+
+def test_watchdog_warns_when_section_stalls(caplog):
+    """A section that outlives the timeout must produce a diagnostic naming
+    the wedge signature; this is the only evidence a wedged non-output rank
+    leaves behind (see #51035)."""
+    with (
+        caplog.at_level(logging.ERROR),
+        wedged_kernel_watchdog(0.2, "execute_model on worker rank 3"),
+    ):
+        time.sleep(0.45)
+    messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("execute_model on worker rank 3" in m for m in messages)
+    assert any("wedged" in m and "#51035" in m for m in messages)
+
+
+def test_watchdog_silent_when_section_completes(caplog):
+    """No diagnostic may be emitted for a section that finishes in time."""
+    with (
+        caplog.at_level(logging.ERROR),
+        wedged_kernel_watchdog(5.0, "execute_model on worker rank 0"),
+    ):
+        time.sleep(0.05)
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+def test_watchdog_disabled_for_nonpositive_timeout(caplog):
+    """A non-positive timeout opts out entirely (no thread, no warning)."""
+    with (
+        caplog.at_level(logging.ERROR),
+        wedged_kernel_watchdog(0, "execute_model on worker rank 0"),
+    ):
+        time.sleep(0.05)
+    assert not caplog.records

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1706,7 +1706,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_MQ_MAX_CHUNK_BYTES_MB", "16")
     ),
     # Timeout in seconds for execute_model RPC calls in multiprocessing
-    # executor (only applies when TP > 1).
+    # executor (only applies when TP > 1). Also used as the warning
+    # interval of the worker-side wedged-kernel watchdog
+    # (vllm/v1/worker/kernel_watchdog.py).
     "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS": lambda: int(
         os.getenv("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "300")
     ),

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -72,6 +72,7 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
 )
 from vllm.v1.utils import compute_iteration_details, report_usage_stats
+from vllm.v1.worker.kernel_watchdog import wedged_kernel_watchdog
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import WorkerSentinel
 from vllm.v1.worker.startup_plan import (
     maybe_apply_startup_plan,
@@ -1081,9 +1082,13 @@ class Worker(WorkerBase):
             )
 
         with self.annotate_profile(scheduler_output):
-            output = self.model_runner.execute_model(
-                scheduler_output, intermediate_tensors
-            )
+            with wedged_kernel_watchdog(
+                envs.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS,
+                f"execute_model on worker rank {self.rank}",
+            ):
+                output = self.model_runner.execute_model(
+                    scheduler_output, intermediate_tensors
+                )
             if (
                 self.use_v2_model_runner
                 and self.model_runner.is_pooling_model

--- a/vllm/v1/worker/kernel_watchdog.py
+++ b/vllm/v1/worker/kernel_watchdog.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker-side watchdog for wedged device kernels.
+
+A device kernel that stops making forward progress blocks its worker in a
+CUDA synchronization indefinitely (e.g. the FlashMLA sparse-decode MLA
+kernel spinning in the ptxas-lowered `tcgen05.alloc.cta_group::2` TMEM
+allocation protocol, vllm-project/vllm#51035). The executor-side RPC
+timeout only observes the output rank, so a wedged non-output rank used to
+stay silent until an unrelated collective asserted elsewhere. Arming this
+watchdog around model execution gives the wedged rank its own diagnostic.
+"""
+
+import os
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@contextmanager
+def wedged_kernel_watchdog(timeout_seconds: float, context: str) -> Iterator[None]:
+    """Log a diagnostic if the wrapped section outlives `timeout_seconds`.
+
+    Re-warns every `timeout_seconds` while the section is still running so
+    the evidence survives log rotation. A non-positive timeout disables the
+    watchdog.
+    """
+    if timeout_seconds <= 0:
+        yield
+        return
+
+    done = threading.Event()
+
+    def _watch() -> None:
+        start = time.monotonic()
+        while not done.wait(timeout_seconds):
+            logger.error(
+                "%s has been running for %.0f s without completing: a device "
+                "kernel may be wedged (spinning with no forward progress, "
+                "e.g. the FlashMLA sparse-decode MLA TMEM allocation stall, "
+                "see vllm-project/vllm#51035). Check nvidia-smi for 100%% "
+                "utilization at idle-level power, and attach cuda-gdb to "
+                "pid %d to capture the resident kernel.",
+                context,
+                time.monotonic() - start,
+                os.getpid(),
+            )
+
+    thread = threading.Thread(target=_watch, daemon=True, name="WedgedKernelWatchdog")
+    thread.start()
+    try:
+        yield
+    finally:
+        done.set()
+        thread.join()


### PR DESCRIPTION
The FlashMLA sparse-decode MLA kernel can wedge silently: ptxas lowers `tcgen05.alloc.cta_group::2` into CTA-pair TMEM-allocation spin loops with no timeout, so a stalled rank spins at 100% SM utilization while the only error surfaces 300s later in an unrelated collective. The loops are ptxas-generated and cannot be bounded at source level, so this PR arms a worker-side watchdog around `execute_model` (reusing `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS`) that logs a rank-local diagnostic, and compiles FlashMLA with `-lineinfo` so cuda-gdb captures map to source.

Closes #51035
