### PR TITLE
[AMD][DCP] Close two decode-LSE holes left by AITER DCP support

### DIFF
--- a/tests/v1/attention/test_rocm_aiter_mla_fp8_decode_routing.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_fp8_decode_routing.py
@@ -176,3 +176,53 @@ def test_pad_unpad_round_trip_preserves_head_order(num_heads):
 
     assert unpadded.shape == q.shape
     torch.testing.assert_close(unpadded, q)
+
+
+@pytest.mark.parametrize("kv_cache_dtype", UNQUANTIZED_DTYPES)
+@pytest.mark.parametrize("num_heads", [1, 2, 4, 8])
+@pytest.mark.parametrize("dcp_world_size", [2, 4, 8])
+def test_dcp_decode_leaves_gluon(
+    gluon_available, kv_cache_dtype, num_heads, dcp_world_size
+):
+    """DCP decode must not take Gluon, which returns no LSE.
+
+    These are exactly the shapes that keep Gluon without DCP, so the head count
+    is not what excludes them. The cross-shard combine needs an LSE per partial
+    output, and the Gluon single-token branch has none to give -- without this
+    the layer hits a bare assertion at the first decoded token.
+    """
+    assert AiterMLAHelper.use_gluon_decode(num_heads, 1, kv_cache_dtype)
+    assert not AiterMLAHelper.use_gluon_decode(
+        num_heads, 1, kv_cache_dtype, dcp_world_size
+    )
+
+
+@pytest.mark.parametrize("kv_cache_dtype", UNQUANTIZED_DTYPES)
+@pytest.mark.parametrize("num_heads", [1, 2, 4, 8])
+def test_dcp_world_size_one_is_the_non_dcp_answer(
+    gluon_available, kv_cache_dtype, num_heads
+):
+    """A world size of 1 is not DCP and must not change routing."""
+    assert AiterMLAHelper.use_gluon_decode(
+        num_heads, 1, kv_cache_dtype, 1
+    ) == AiterMLAHelper.use_gluon_decode(num_heads, 1, kv_cache_dtype)
+
+
+@pytest.mark.parametrize("kv_cache_dtype", UNQUANTIZED_DTYPES)
+@pytest.mark.parametrize("num_heads", [1, 2, 4, 5, 8, 12])
+@pytest.mark.parametrize("dcp_world_size", [2, 8])
+def test_neither_gluon_entry_point_serves_dcp(
+    gluon_available, kv_cache_dtype, num_heads, dcp_world_size
+):
+    """Both Gluon entry points are closed to DCP, at every query length.
+
+    Verify already excluded it; decode now matches. DCP is served by the asm
+    persistent decode and, for multi-token verification, by segmented MLA.
+    """
+    for max_qo_len in (1, 2, 8):
+        assert not AiterMLAHelper.use_gluon_decode(
+            num_heads, max_qo_len, kv_cache_dtype, dcp_world_size
+        )
+        assert not AiterMLAHelper.use_gluon_verify(
+            num_heads, max_qo_len, kv_cache_dtype, dcp_world_size
+        )

--- a/tests/v1/attention/test_rocm_aiter_mla_fp8_decode_routing.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_fp8_decode_routing.py
@@ -186,10 +186,8 @@ def test_dcp_decode_leaves_gluon(
 ):
     """DCP decode must not take Gluon, which returns no LSE.
 
-    These are exactly the shapes that keep Gluon without DCP, so the head count
-    is not what excludes them. The cross-shard combine needs an LSE per partial
-    output, and the Gluon single-token branch has none to give -- without this
-    the layer hits a bare assertion at the first decoded token.
+    These shapes keep Gluon without DCP, so the head count is not what
+    excludes them.
     """
     assert AiterMLAHelper.use_gluon_decode(num_heads, 1, kv_cache_dtype)
     assert not AiterMLAHelper.use_gluon_decode(
@@ -216,8 +214,7 @@ def test_neither_gluon_entry_point_serves_dcp(
 ):
     """Both Gluon entry points are closed to DCP, at every query length.
 
-    Verify already excluded it; decode now matches. DCP is served by the asm
-    persistent decode and, for multi-token verification, by segmented MLA.
+    DCP is served by the asm persistent decode, and verify by segmented MLA.
     """
     for max_qo_len in (1, 2, 8):
         assert not AiterMLAHelper.use_gluon_decode(

--- a/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
@@ -975,11 +975,7 @@ def test_decode_lse_probe_reads_the_aiter_signature(monkeypatch):
 
 
 def test_decode_lse_probe_survives_a_broken_aiter(monkeypatch):
-    """An aiter that cannot even be imported reads as unsupported, not a crash.
-
-    The probe runs at configuration time on hosts where the import may fail for
-    reasons unrelated to DCP, so it must degrade rather than propagate.
-    """
+    """An aiter that cannot be imported reads as unsupported, not a crash."""
 
     def explode():
         raise ImportError("no aiter here")
@@ -994,12 +990,7 @@ def test_decode_lse_probe_survives_a_broken_aiter(monkeypatch):
 
 @pytest.mark.parametrize("dcp_world_size", [2, 8])
 def test_dcp_without_decode_lse_fails_at_startup(monkeypatch, dcp_world_size):
-    """An aiter build with no decode LSE must be rejected while it is cheap.
-
-    Reaching the first decoded token instead costs a whole model load and
-    surfaces as a bare assertion inside the attention layer, which says nothing
-    about the aiter build being the cause.
-    """
+    """An aiter build with no decode LSE must be rejected before a model load."""
 
     def without_lse(q, kv, out, *args, **kwargs):
         return None

--- a/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
@@ -949,3 +949,66 @@ def test_persistent_metadata_gate_without_gluon_build(
 
     assert metadata.has_persistent_metadata is expect_persistent
     assert get_mla_metadata_v1.called is expect_persistent
+
+
+def _decode_lse_probe(monkeypatch, fn):
+    """Point the LSE capability probe at ``fn`` and clear its cache."""
+    monkeypatch.setattr(rocm_aiter_mla, "_get_aiter_mla_decode", lambda: fn)
+    rocm_aiter_mla._decode_lse_supported.cache_clear()
+    return rocm_aiter_mla._decode_lse_supported
+
+
+def test_decode_lse_probe_reads_the_aiter_signature(monkeypatch):
+    """The probe answers from the installed aiter's signature, not a version."""
+
+    def with_lse(q, kv, out, *args, return_lse=False, **kwargs):
+        return None, None
+
+    def without_lse(q, kv, out, *args, **kwargs):
+        return None
+
+    try:
+        assert _decode_lse_probe(monkeypatch, with_lse)()
+        assert not _decode_lse_probe(monkeypatch, without_lse)()
+    finally:
+        rocm_aiter_mla._decode_lse_supported.cache_clear()
+
+
+def test_decode_lse_probe_survives_a_broken_aiter(monkeypatch):
+    """An aiter that cannot even be imported reads as unsupported, not a crash.
+
+    The probe runs at configuration time on hosts where the import may fail for
+    reasons unrelated to DCP, so it must degrade rather than propagate.
+    """
+
+    def explode():
+        raise ImportError("no aiter here")
+
+    monkeypatch.setattr(rocm_aiter_mla, "_get_aiter_mla_decode", explode)
+    rocm_aiter_mla._decode_lse_supported.cache_clear()
+    try:
+        assert not rocm_aiter_mla._decode_lse_supported()
+    finally:
+        rocm_aiter_mla._decode_lse_supported.cache_clear()
+
+
+@pytest.mark.parametrize("dcp_world_size", [2, 8])
+def test_dcp_without_decode_lse_fails_at_startup(monkeypatch, dcp_world_size):
+    """An aiter build with no decode LSE must be rejected while it is cheap.
+
+    Reaching the first decoded token instead costs a whole model load and
+    surfaces as a bare assertion inside the attention layer, which says nothing
+    about the aiter build being the cause.
+    """
+
+    def without_lse(q, kv, out, *args, **kwargs):
+        return None
+
+    _decode_lse_probe(monkeypatch, without_lse)
+    try:
+        with pytest.raises(ValueError, match="return_lse"):
+            AiterMLAImpl._check_dcp_decode_lse(dcp_world_size)
+        # Not DCP: the probe is irrelevant and must not block startup.
+        AiterMLAImpl._check_dcp_decode_lse(1)
+    finally:
+        rocm_aiter_mla._decode_lse_supported.cache_clear()

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import functools
+import inspect
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, Final
@@ -183,6 +184,22 @@ def _segmented_mla_decode_supported() -> bool:
     except Exception:  # noqa: BLE001
         return False
     return True
+
+
+@functools.lru_cache(maxsize=1)
+def _decode_lse_supported() -> bool:
+    """Whether AITER's MLA decode can return the LSE the DCP merge needs.
+
+    ``mla_decode_fwd(..., return_lse=True)`` is what lets a DCP rank hand its
+    partial output to the cross-shard combine. Older AITER builds have no such
+    keyword, and the resulting failure is a bare assertion at the first decode
+    step rather than at startup, so probe the signature once at configuration
+    time instead.
+    """
+    try:
+        return "return_lse" in inspect.signature(_get_aiter_mla_decode()).parameters
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _segmented_dcp_verify_supported(dcp_world_size: int, cp_interleave: int) -> bool:
@@ -958,6 +975,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             self._decode_num_heads,
             int(max_qo_len),
             self._kv_cache_dtype_str,
+            self.dcp_world_size,
         )
         use_gluon_verify = AiterMLAHelper.use_gluon_verify(
             self._decode_num_heads,
@@ -1331,12 +1349,25 @@ class AiterMLAHelper:
         return AiterMLAHelper._get_mla_unpadded_heads(num_heads, lse)
 
     @staticmethod
-    def use_gluon_decode(num_heads: int, max_qo_len: int, kv_cache_dtype: str) -> bool:
+    def use_gluon_decode(
+        num_heads: int,
+        max_qo_len: int,
+        kv_cache_dtype: str,
+        dcp_world_size: int = 1,
+    ) -> bool:
         # Small-head (<16) single-token decode takes either the Gluon kernel or
         # the padded asm persistent decode, selected by
         # VLLM_ROCM_AITER_MLA_ASM_PADDING and the arch (Gluon is gfx950 only).
+        #
+        # DCP decode is excluded: the Gluon branch in forward_mqa returns no
+        # LSE, and the cross-rank combine needs one. Today this is also true
+        # arithmetically -- the caller passes the gathered head count, which is
+        # >= 16 for every realistic DCP layout -- but that is a coincidence of
+        # head counts, not a guarantee, and the failure mode without this guard
+        # is a bare `assert lse is not None` in the MLA layer. Mirrors the same
+        # exclusion in use_gluon_verify.
         m = AiterMLAHelper._AITER_MIN_MLA_HEADS
-        if num_heads >= m or max_qo_len != 1:
+        if num_heads >= m or max_qo_len != 1 or dcp_world_size > 1:
             return False
         # Gluon's only fp8-KV regime, bh16bn128, is a bf16-query kernel with a
         # hardcoded scale that asserts batch_size == 1, so it cannot serve a
@@ -1428,6 +1459,23 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         """Return the query-head count after DCP gathering."""
         return self.num_heads * self.dcp_world_size
 
+    @staticmethod
+    def _check_dcp_decode_lse(dcp_world_size: int) -> None:
+        """Reject a DCP config whose AITER build cannot return a decode LSE.
+
+        Every DCP decode step merges partial attention across shards, which
+        needs the LSE. Raising here costs a config check; discovering it at the
+        first decoded token costs a model load and surfaces as an assertion
+        inside the attention layer that names nothing useful.
+        """
+        if dcp_world_size > 1 and not _decode_lse_supported():
+            raise ValueError(
+                "Decode context parallelism on the AITER MLA backend requires "
+                "an AITER build whose mla_decode_fwd accepts return_lse=True; "
+                "the installed build does not. Upgrade AITER, or select a "
+                "different MLA attention backend."
+            )
+
     def __init__(
         self,
         num_heads: int,
@@ -1458,6 +1506,8 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         )
         AiterMLAHelper.check_num_heads_validity(num_heads)
         AiterMLAHelper.check_num_heads_validity(self._decode_num_heads)
+
+        AiterMLAImpl._check_dcp_decode_lse(self.dcp_world_size)
 
         unsupported_features = [alibi_slopes, sliding_window, logits_soft_cap]
         if any(unsupported_features):

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -190,11 +190,8 @@ def _segmented_mla_decode_supported() -> bool:
 def _decode_lse_supported() -> bool:
     """Whether AITER's MLA decode can return the LSE the DCP merge needs.
 
-    ``mla_decode_fwd(..., return_lse=True)`` is what lets a DCP rank hand its
-    partial output to the cross-shard combine. Older AITER builds have no such
-    keyword, and the resulting failure is a bare assertion at the first decode
-    step rather than at startup, so probe the signature once at configuration
-    time instead.
+    Older builds lack the keyword and fail on an assert at the first decode
+    step, so probe the signature at configuration time instead.
     """
     try:
         return "return_lse" in inspect.signature(_get_aiter_mla_decode()).parameters
@@ -1359,13 +1356,10 @@ class AiterMLAHelper:
         # the padded asm persistent decode, selected by
         # VLLM_ROCM_AITER_MLA_ASM_PADDING and the arch (Gluon is gfx950 only).
         #
-        # DCP decode is excluded: the Gluon branch in forward_mqa returns no
-        # LSE, and the cross-rank combine needs one. Today this is also true
-        # arithmetically -- the caller passes the gathered head count, which is
-        # >= 16 for every realistic DCP layout -- but that is a coincidence of
-        # head counts, not a guarantee, and the failure mode without this guard
-        # is a bare `assert lse is not None` in the MLA layer. Mirrors the same
-        # exclusion in use_gluon_verify.
+        # DCP is excluded: the Gluon branch in forward_mqa returns no LSE, and
+        # the cross-rank combine needs one. The head check below also excludes
+        # it at every realistic gathered head count, but that is a coincidence,
+        # not a guarantee. Mirrors use_gluon_verify.
         m = AiterMLAHelper._AITER_MIN_MLA_HEADS
         if num_heads >= m or max_qo_len != 1 or dcp_world_size > 1:
             return False
@@ -1464,16 +1458,13 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         """Reject a DCP config whose AITER build cannot return a decode LSE.
 
         Every DCP decode step merges partial attention across shards, which
-        needs the LSE. Raising here costs a config check; discovering it at the
-        first decoded token costs a model load and surfaces as an assertion
-        inside the attention layer that names nothing useful.
+        needs the LSE. Raising here beats asserting after a model load.
         """
         if dcp_world_size > 1 and not _decode_lse_supported():
             raise ValueError(
-                "Decode context parallelism on the AITER MLA backend requires "
-                "an AITER build whose mla_decode_fwd accepts return_lse=True; "
-                "the installed build does not. Upgrade AITER, or select a "
-                "different MLA attention backend."
+                "AITER MLA with decode context parallelism needs an AITER "
+                "build whose mla_decode_fwd accepts return_lse=True. Upgrade "
+                "AITER, or pick another MLA backend."
             )
 
     def __init__(


### PR DESCRIPTION
#51705 gave the AITER MLA backend a decode LSE under decode context parallelism, so a DCP rank can hand its partial attention to the cross-shard merge. Two ways to reach that merge without an LSE remain.

Gluon. `use_gluon_decode` takes no DCP argument, unlike its sibling `use_gluon_verify`, and the Gluon single-token branch in `forward_mqa` ends `return o, None`. Nothing structural keeps DCP off it -- only arithmetic: the builder passes the gathered head count, and Gluon bails at >= 16 heads, which every realistic DCP layout exceeds (Kimi-K3 at TP8/DCP8 gathers 12 x 8 = 96). At 6 local heads and DCP2 it gathers 12 and Gluon takes the batch, returning no LSE and tripping a bare `assert lse is not None` in the MLA layer. That shape is not hypothetical; it is the one the existing DCP decode test uses. Give the predicate a `dcp_world_size` and exclude DCP, matching verify.

AITER capability. The DCP branch needs an AITER build whose `mla_decode_fwd` accepts `return_lse=True`. Nothing checks that at configuration time, so an older build loads the whole model and fails at the first decoded token on an assertion that names neither AITER nor the version. Probe the signature once and raise at construction instead.

Neither changes any kernel selection for a supported configuration.

## Test Plan
Test: tests/v1/attention/test_rocm_aiter_mla_fp8_decode_routing.py
      tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
      565 passed, against 505 on the same commit without this change --
      the delta is exactly the added cases, no regressions.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

