### PR TITLE
[Bugfix] Include multimodal limits in the model compile-cache hash

### DIFF
--- a/tests/config/test_multimodal_config.py
+++ b/tests/config/test_multimodal_config.py
@@ -57,6 +57,32 @@ def test_language_model_only_affects_model_hash():
     assert base_hash != lm_only_hash
 
 
+def test_zero_mm_limits_affect_model_hash():
+    """Limiting every supported modality to 0 puts the model in text-only
+    mode, which feeds the LM `input_ids` instead of `inputs_embeds`. That is a
+    different computation graph, so it must change the model config hash --
+    otherwise a compiled artifact traced for the multimodal path is reused for
+    the text-only path."""
+    model = "llava-hf/llava-1.5-7b-hf"
+    base_hash = ModelConfig(model).compute_hash()
+    text_only_hash = ModelConfig(
+        model, limit_mm_per_prompt={"image": 0}
+    ).compute_hash()
+    assert base_hash != text_only_hash
+
+
+def test_enable_mm_embeds_affects_model_hash():
+    """enable_mm_embeds keeps the multimodal code path alive even when every
+    modality limit is 0, so it also affects the LM computation graph."""
+    model = "llava-hf/llava-1.5-7b-hf"
+    zero_limits = {"image": 0}
+    text_only_hash = ModelConfig(model, limit_mm_per_prompt=zero_limits).compute_hash()
+    mm_embeds_hash = ModelConfig(
+        model, limit_mm_per_prompt=zero_limits, enable_mm_embeds=True
+    ).compute_hash()
+    assert text_only_hash != mm_embeds_hash
+
+
 @pytest.mark.parametrize("backend_arg", ["video_backend", "backend"])
 def test_use_gpu_video_backend_from_media_io_kwargs(backend_arg: str):
     config = MultiModalConfig(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -467,6 +467,21 @@ class ModelConfig:
         # here early.
         if self.multimodal_config:
             factors["language_model_only"] = self.multimodal_config.language_model_only
+            # `language_model_only` is not the only way the MM code path gets
+            # disabled: `MultiModalRegistry.supports_multimodal_inputs` also
+            # falls back to text-only mode when every supported modality is
+            # limited to 0 (unless pre-computed embeddings are accepted via
+            # `enable_mm_embeds`). Text-only mode feeds the language model
+            # `input_ids` with `inputs_embeds=None`, while the MM path does the
+            # opposite, so these must take part in the hash as well.
+            # Only the per-modality `count` matters here: it is what decides
+            # whether a modality is disabled. The remaining dummy-data options
+            # (e.g. image width/height) only shape profiling inputs.
+            factors["mm_limit_per_prompt"] = {
+                modality: (opts if isinstance(opts, int) else opts.count)
+                for modality, opts in self.multimodal_config.limit_per_prompt.items()
+            }
+            factors["mm_enable_mm_embeds"] = self.multimodal_config.enable_mm_embeds
         return hash_factors(factors)
 
     def _update_nested(


### PR DESCRIPTION
## Purpose

`ModelConfig.compute_hash()` keys the torch.compile / AOT compilation cache. It already accounts
for `language_model_only`, with this note:

```python
# NOTE: For some models (e.g, Qwen3-VL), whether the MM code path is enabled
# affects the computation graph of the language model, therefore we add it
# here early.
if self.multimodal_config:
    factors["language_model_only"] = self.multimodal_config.language_model_only
```

The problem is that `language_model_only` is not the only switch that disables the MM code path,
and vLLM says so itself — in `MultiModalConfig`:

```python
language_model_only: bool = False
"""If True, disables all multimodal inputs by setting all modality limits to 0.
Equivalent to setting `--limit-mm-per-prompt` to 0 for every modality."""
```

So two configurations are documented as **equivalent**, but only one of them takes part in the
hash: `limit_mm_per_prompt` is listed in `ignored_factors`, and `enable_mm_embeds` is absent too.
Both feed `MultiModalRegistry.supports_multimodal_inputs()`, which falls back to text-only mode
when every supported modality is limited to 0 (unless `enable_mm_embeds` is set).

That matters because the two modes call the model with different arguments.
`GPUModelRunner._dummy_run()` takes the `_prepare_mm_inputs()` path on multimodal (passing
`inputs_embeds`, and `input_ids=None` unless the model sets `requires_raw_input_tokens`), and the
plain `input_ids` path with `inputs_embeds=None` in text-only mode. Those are structurally
different graphs and must not share a compile-cache entry.

Running a multimodal model text-only is documented usage
(`docs/configuration/conserving_memory.md`):

```python
# You can even run a multi-modal model for text-only inference:
llm = LLM(model="google/gemma-3-27b-it", limit_mm_per_prompt={"image": 0})
```

## Reproduction

Serve a multimodal model normally, then restart it with every modality limit set to 0 **under
otherwise-identical flags**:

```
INFO [registry.py:141] All limits of multimodal modalities supported by the model are set to 0,
                       running in text-only mode.
INFO [decorators.py:311] Directly load AOT compilation from path
     .../torch_aot_compile/87158a34713fb0ed/rank_0_0/model
ERROR [core.py:1346]     hidden_states = self.language_model.model(
ERROR [core.py:1346]   File ".../torch/_dynamo/utils.py", line 5543, in call_size
ERROR [core.py:1346]     return x.size(i)
ERROR [core.py:1346] AttributeError: 'NoneType' object has no attribute 'size'
RuntimeError: Engine core initialization failed.
```

> **Note for reviewers:** the cache entry must first be **primed by a multimodal run under
> identical flags**. Starting straight into text-only mode on a machine with no prior cache entry
> compiles fresh and succeeds, which hides the bug.

## Controlled experiment

Qwen2.5-VL-3B-Instruct, BF16, single H100, vLLM 0.28.0. Only the stated variable changes.

| phase | patch | mm limits | compile cache | cache hash | loaded from cache | result |
|---|---|---|---|---|---|---|
| A prime | no | default (on) | fresh | `87158a34713fb0ed` | 0 | PASS |
| **B** | no | **all 0** | primed by A | `87158a34713fb0ed` (same) | **1** | **FAIL** — `NoneType.size()` |
| **C** | no | **all 0** | `VLLM_DISABLE_COMPILE_CACHE=1` | – | 0 | **PASS** |
| D1 prime | yes | default (on) | fresh | `8546c66690f0a331` | 0 | PASS |
| **D2** | yes | **all 0** | primed by D1 | `7451af71faee32bf` (differs) | 0 | **PASS** |

* **B vs C** — identical configuration; the only difference is whether the cached artifact is
  reused. That isolates cache reuse as the cause rather than the text-only configuration itself.
* **D2 vs B** — with the patch the two modes hash differently, so text-only no longer resolves to
  the multimodal artifact, and the server starts.

## Not model-specific

The hash collision is config-layer and reproduces across models and versions
(`ModelConfig(...).compute_hash()`, with and without `limit_mm_per_prompt={"image": 0, ...}`):

| model | vLLM 0.27.1 | vLLM 0.28.0 |
|---|---|---|
| `llava-hf/llava-1.5-7b-hf` | collides | – |
| `Qwen/Qwen2.5-VL-3B-Instruct` | collides | collides (crash reproduced above) |
| `google/gemma-3-4b-it` | collides | – |
| `nvidia/Gemma-4-26B-A4B-NVFP4` | – | collides (crash first seen here) |

The crash was observed on two independent stacks: Qwen2.5-VL-3B / BF16 / H100 (sm_90) and
Gemma-4-26B-A4B / NVFP4 / RTX PRO 6000 Blackwell (sm_120).

## Fix

Extend the existing `if self.multimodal_config:` block with the two remaining switches that decide
whether the MM code path runs.

Only the per-modality `count` is hashed: it is what decides whether a modality is disabled, the
other dummy-data options (e.g. image width/height) only shape profiling inputs, and `count` keeps
the factors JSON-serializable — `hash_factors()` uses `json.dumps` while `limit_per_prompt` values
are `BaseDummyOptions` dataclasses (hashing the objects directly raises
`TypeError: Object of type AudioDummyOptions is not JSON serializable`).

## Test Plan

- New regression tests in `tests/config/test_multimodal_config.py`:
  `test_zero_mm_limits_affect_model_hash`, `test_enable_mm_embeds_affects_model_hash`.
- The existing `test_language_model_only_does_not_affect_mm_hash` still passes: this change is in
  `ModelConfig.compute_hash()`, not `MultiModalConfig.compute_hash()`, so the ViT-scoped hash is
  deliberately left untouched.
- End-to-end A/B/C/D matrix above.

## Note on cache invalidation

This changes the compile-cache key for multimodal models, so the first start after upgrading
recompiles once. Text-only models are unaffected — the block is guarded by `if self.multimodal_config`.
