### PR TITLE
[CI] Broaden structured-output issue auto-labeling

### DIFF
--- a/.github/workflows/issue_autolabel.yml
+++ b/.github/workflows/issue_autolabel.yml
@@ -263,10 +263,46 @@ jobs:
                 ],
               },
               "structured-output": {
+                // Whole-word terms: backends, engine internals, and format
+                // vocabulary that is unambiguous inside vLLM.
+                keywords: [
+                  { term: "xgrammar",   searchIn: "title" },
+                  { term: "outlines",   searchIn: "title" },  // "this RFC outlines..." in bodies
+                  { term: "llguidance", searchIn: "title" },
+                  { term: "grammar",    searchIn: "title" },
+                  { term: "FSM",        searchIn: "title" },
+                  { term: "EBNF",       searchIn: "title" },
+                  { term: "bitmask",    searchIn: "title" },
+                ],
+                // Substrings: separator variants of the feature name, the request
+                // fields that turn it on, and traceback frames it crashes in.
                 substrings: [
-                  { term: "structured output", searchIn: "title" },
-                  { term: "guided decoding",   searchIn: "title" },
-                  { term: "JSON schema",       searchIn: "title" },
+                  { term: "structured output",      searchIn: "title" },
+                  { term: "structured-output",      searchIn: "title" },
+                  { term: "structured_output",      searchIn: "title" },
+                  { term: "structuredoutput",       searchIn: "title" },  // StructuredOutputManager
+                  { term: "structured decoding",    searchIn: "title" },
+                  { term: "structured generation",  searchIn: "title" },
+                  { term: "guided decoding",        searchIn: "title" },
+                  { term: "guided generation",      searchIn: "title" },
+                  { term: "guided_decoding",        searchIn: "title" },
+                  { term: "constrained decoding",   searchIn: "title" },
+                  { term: "json schema",            searchIn: "title" },
+                  { term: "json_schema",            searchIn: "title" },
+                  { term: "json_object",            searchIn: "title" },
+                  { term: "response_format",        searchIn: "title" },
+                  { term: "structural tag",         searchIn: "title" },
+                  { term: "guided_json",            searchIn: "both"  },
+                  { term: "guided_grammar",         searchIn: "both"  },
+                  { term: "guided_choice",          searchIn: "both"  },
+                  { term: "guided_regex",           searchIn: "both"  },
+                  { term: "structural_tag",         searchIn: "title" },
+                  { term: "lm-format-enforcer",     searchIn: "title" },
+                  { term: "backend_xgrammar",       searchIn: "body"  },
+                  { term: "apply_grammar_bitmask",  searchIn: "body"  },
+                  { term: "grammar_bitmask",        searchIn: "body"  },
+                  { term: "Failed to advance FSM",  searchIn: "body"  },
+                  { term: "StructuredOutputsParams", searchIn: "body" },
                 ],
               },
               "tool-calling": {


### PR DESCRIPTION
## Purpose
The `structured-output` keyword rule added in #51459 only matches three title substrings: `structured output`, `guided decoding`, `JSON schema`. That misses most structured-output issues, so they never reach the Structured Output board.

Scored against the 2,584 issues opened since 2026-05-01, the current rule fires on 22 of the 57 that are structured-output. The gaps:
- **Separator variants** — `structured output` is a literal substring, so
  `structured-output` (#51693, #54003) and `StructuredOutputManager` (#48197)
  do not match.
- **Request fields** — no `response_format`, `json_schema`, `json_object`,
  `guided_json`. `JSON schema` also fails to match the real API field name.
- **Backends** — no `xgrammar` (53 issues), `outlines` (28), `llguidance`,
  `lm-format-enforcer`.
- **Symptoms** — no `grammar`, `FSM`, `bitmask`, `EBNF`.

## Changes
Replaces the three substrings with 7 keywords + 27 substrings.

## Test Result

Ran the workflow's own `findMatchingTermsWithLines` over all 2,584 issues:

| | fires on | precision | catches currently-labeled |
|---|---|---|---|
| current | 22 | 100% | 4/6 |
| this PR | 57 | 98% | 6/6 |