### PR TITLE
[DecodeBenchConnector] Fix HMA cache-group mapping

### DIFF
--- a/tests/v1/kv_connector/unit/test_decode_bench_connector.py
+++ b/tests/v1/kv_connector/unit/test_decode_bench_connector.py
@@ -7,6 +7,8 @@ Tests the functionality of the DecodeBenchConnector which fills KV cache
 with dummy values for decode performance benchmarking.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 import torch
 
@@ -231,6 +233,47 @@ def test_decode_bench_connector_fills_each_hma_group():
     assert torch.count_nonzero(group_0_cache[5]) == 0
     assert torch.count_nonzero(group_1_cache[1]) == 0
     assert torch.allclose(group_1_cache[5], torch.tensor(0.015))
+
+
+def test_decode_bench_connector_uses_per_group_block_sizes():
+    """Scheduler selects only the blocks covering each group's token span."""
+    vllm_config = create_vllm_config(
+        block_size=16,
+        max_num_batched_tokens=1000,
+        kv_connector="DecodeBenchConnector",
+    )
+    kv_cache_groups = [
+        KVCacheGroupSpec(
+            [f"group_{group_idx}_layer"],
+            FullAttentionSpec(
+                block_size=block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        )
+        for group_idx, block_size in enumerate((16, 32))
+    ]
+    connector = DecodeBenchConnector(
+        vllm_config,
+        KVConnectorRole.SCHEDULER,
+        KVCacheConfig(
+            num_blocks=8,
+            kv_cache_tensors=[],
+            kv_cache_groups=kv_cache_groups,
+        ),
+    )
+    request = MagicMock(request_id="request")
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = ([0, 1], [2, 3])
+
+    connector.update_state_after_alloc(request, blocks, num_external_tokens=17)
+    metadata = connector.build_connector_meta(MagicMock())
+
+    assert isinstance(metadata, DecodeBenchConnectorMetadata)
+    block_ids_per_group, num_tokens = metadata.reqs_to_fill["request"]
+    assert block_ids_per_group == ([0, 1], [2])
+    assert num_tokens == 17
 
 
 def test_decode_bench_connector_no_refill():

--- a/tests/v1/kv_connector/unit/test_decode_bench_connector.py
+++ b/tests/v1/kv_connector/unit/test_decode_bench_connector.py
@@ -70,11 +70,10 @@ class DecodeBenchTestRunner:
         # Using simplified shape for testing
         num_heads = 4
         head_dim = 64
+        layer_names = self.scheduler.kv_cache_config.kv_cache_groups[0].layer_names
         self.kv_caches = {
-            f"layer_{i}": torch.zeros(
-                num_gpu_blocks, 2, num_heads, block_size, head_dim
-            )
-            for i in range(2)  # 2 layers for testing
+            layer_name: torch.zeros(num_gpu_blocks, 2, num_heads, block_size, head_dim)
+            for layer_name in layer_names
         }
 
         # Register KV caches with worker connector

--- a/tests/v1/kv_connector/unit/test_decode_bench_connector.py
+++ b/tests/v1/kv_connector/unit/test_decode_bench_connector.py
@@ -22,6 +22,11 @@ from vllm.forward_context import ForwardContext
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
 from vllm.v1.request import Request
 
 from .utils import (
@@ -177,6 +182,56 @@ def test_decode_bench_connector_basic():
             block_data = kv_cache[block_id]
             # Should be filled with constant value 0.015
             assert torch.allclose(block_data, torch.tensor(0.015))
+
+
+def test_decode_bench_connector_fills_each_hma_group():
+    """Each cache group is filled using its own block IDs."""
+    block_size = 16
+    num_gpu_blocks = 8
+    vllm_config = create_vllm_config(
+        block_size=block_size,
+        max_num_batched_tokens=1000,
+        kv_connector="DecodeBenchConnector",
+    )
+    kv_cache_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_gpu_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["group_0_layer"], kv_cache_spec),
+            KVCacheGroupSpec(["group_1_layer"], kv_cache_spec),
+        ],
+    )
+    connector = DecodeBenchConnector(
+        vllm_config,
+        KVConnectorRole.WORKER,
+        kv_cache_config,
+    )
+    group_0_cache = torch.zeros(num_gpu_blocks, 2)
+    group_1_cache = torch.zeros(num_gpu_blocks, 2)
+    connector.register_kv_caches(
+        {
+            "group_0_layer": group_0_cache,
+            "group_1_layer": group_1_cache,
+        }
+    )
+    connector.bind_connector_metadata(
+        DecodeBenchConnectorMetadata(reqs_to_fill={"request": (([1], [5]), block_size)})
+    )
+
+    connector.start_load_kv(
+        ForwardContext(no_compile_layers={}, attn_metadata={}, slot_mapping={})
+    )
+
+    assert torch.allclose(group_0_cache[1], torch.tensor(0.015))
+    assert torch.count_nonzero(group_0_cache[5]) == 0
+    assert torch.count_nonzero(group_1_cache[1]) == 0
+    assert torch.allclose(group_1_cache[5], torch.tensor(0.015))
 
 
 def test_decode_bench_connector_no_refill():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -95,7 +95,9 @@ class DecodeBenchConnector(KVConnectorBase_V1, SupportsHMA):
         self.connector_worker: DecodeBenchConnectorWorker | None = None
 
         if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler = DecodeBenchConnectorScheduler(vllm_config)
+            self.connector_scheduler = DecodeBenchConnectorScheduler(
+                vllm_config, kv_cache_config
+            )
         elif role == KVConnectorRole.WORKER:
             self.connector_worker = DecodeBenchConnectorWorker(
                 vllm_config, kv_cache_config
@@ -184,9 +186,11 @@ class DecodeBenchConnector(KVConnectorBase_V1, SupportsHMA):
 class DecodeBenchConnectorScheduler:
     """Scheduler-side implementation for DecodeBenchConnector."""
 
-    def __init__(self, vllm_config: "VllmConfig"):
+    def __init__(self, vllm_config: "VllmConfig", kv_cache_config: "KVCacheConfig"):
         self.vllm_config = vllm_config
-        self.block_size = vllm_config.cache_config.block_size
+        self.group_block_sizes = tuple(
+            group.kv_cache_spec.block_size for group in kv_cache_config.kv_cache_groups
+        )
 
         # Track which requests have already been filled
         self._filled_requests: set[str] = set()
@@ -249,13 +253,12 @@ class DecodeBenchConnectorScheduler:
         # block_groups is a tuple of lists, one per KV cache group
         block_groups = blocks.get_block_ids()
 
-        # Calculate how many blocks we need to fill
-        # num_external_tokens are the tokens we said we'd provide
-        num_blocks_to_fill = cdiv(num_external_tokens, self.block_size)
-
-        # Extract up to num_blocks_to_fill independently from each group
+        # Extract the blocks covering num_external_tokens from each group
         block_ids_per_group = tuple(
-            group_blocks[:num_blocks_to_fill] for group_blocks in block_groups
+            group_blocks[: cdiv(num_external_tokens, group_block_size)]
+            for group_blocks, group_block_size in zip(
+                block_groups, self.group_block_sizes, strict=True
+            )
         )
 
         # Store the blocks to fill for all group. _pending_fills doesn't need cleanup
@@ -267,9 +270,9 @@ class DecodeBenchConnectorScheduler:
         self._filled_requests.add(req_id)
 
         logger.debug(
-            "DecodeBenchConnector: Allocated %d blocks across %d KV cache groups "
+            "DecodeBenchConnector: Allocated %s blocks across %d KV cache groups "
             "for request %s",
-            num_blocks_to_fill,
+            tuple(len(block_ids) for block_ids in block_ids_per_group),
             len(block_groups),
             req_id,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -69,8 +69,8 @@ class DecodeBenchConnectorMetadata(KVConnectorMetadata):
 
     # request_id -> (block_ids_per_group, num_tokens_to_fill)
     # block_ids_per_group is a tuple of lists, one per KV cache group
-    # For standard attention: single group, e.g., ([1, 2, 3],)
-    # For MLA: multiple groups, e.g., ([1, 2], [1, 2])
+    # One group: ([1, 2, 3],)
+    # Multiple groups: ([1, 2], [5, 6])
     reqs_to_fill: dict[str, tuple[tuple[list[int], ...], int]]
 
 
@@ -238,8 +238,7 @@ class DecodeBenchConnectorScheduler:
         Called after blocks are allocated. Store the block IDs so we can
         fill them with dummy values.
 
-        Supports both standard attention (single KV cache group) and MLA
-        (multiple KV cache groups).
+        Supports both single- and multi-group KV cache configurations.
         """
         req_id = request.request_id
 
@@ -248,16 +247,13 @@ class DecodeBenchConnectorScheduler:
 
         # Get the block IDs that were allocated
         # block_groups is a tuple of lists, one per KV cache group
-        # For standard attention: 1 group
-        # For MLA: multiple groups (one per attention type)
         block_groups = blocks.get_block_ids()
 
         # Calculate how many blocks we need to fill
         # num_external_tokens are the tokens we said we'd provide
         num_blocks_to_fill = cdiv(num_external_tokens, self.block_size)
 
-        # Extract the first num_blocks_to_fill blocks from each group
-        # All groups should have the same block IDs for the same request
+        # Extract up to num_blocks_to_fill independently from each group
         block_ids_per_group = tuple(
             group_blocks[:num_blocks_to_fill] for group_blocks in block_groups
         )
@@ -337,7 +333,7 @@ class DecodeBenchConnectorWorker:
         This simulates having a populated KV cache from a prefill phase,
         allowing decode performance testing with larger context sizes.
 
-        Supports both standard attention (single group) and MLA (multiple groups).
+        Supports both single- and multi-group KV cache configurations.
         """
         if not metadata.reqs_to_fill:
             return

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -97,7 +97,9 @@ class DecodeBenchConnector(KVConnectorBase_V1, SupportsHMA):
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler = DecodeBenchConnectorScheduler(vllm_config)
         elif role == KVConnectorRole.WORKER:
-            self.connector_worker = DecodeBenchConnectorWorker(vllm_config)
+            self.connector_worker = DecodeBenchConnectorWorker(
+                vllm_config, kv_cache_config
+            )
 
     # ==============================
     # Worker-side methods
@@ -300,7 +302,7 @@ class DecodeBenchConnectorScheduler:
 class DecodeBenchConnectorWorker:
     """Worker-side implementation for DecodeBenchConnector."""
 
-    def __init__(self, vllm_config: "VllmConfig"):
+    def __init__(self, vllm_config: "VllmConfig", kv_cache_config: "KVCacheConfig"):
         self.vllm_config = vllm_config
         self.block_size = vllm_config.cache_config.block_size
 
@@ -314,16 +316,14 @@ class DecodeBenchConnectorWorker:
         self.kv_caches: dict[str, torch.Tensor] | None = None
 
         # Mapping from KV cache group index to list of layer names in that group
-        self.group_to_layers: dict[int, list[str]] | None = None
+        self.group_to_layers = {
+            group_idx: list(group.layer_names)
+            for group_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+        }
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        """Store references to the KV cache tensors and build group mapping."""
+        """Store references to the KV cache tensors."""
         self.kv_caches = kv_caches
-
-        # For simplicity, assume all layers belong to group 0 (standard attention)
-        # For MLA models with multiple groups, the metadata will handle the mapping
-        # We just need to fill the blocks specified in the metadata
-        self.group_to_layers = {0: list(kv_caches.keys())}
 
         logger.debug(
             "DecodeBenchConnector: Registered %d KV cache layers",
@@ -343,7 +343,6 @@ class DecodeBenchConnectorWorker:
             return
 
         assert self.kv_caches is not None, "KV caches must be registered before filling"
-        assert self.group_to_layers is not None, "Group mapping must be initialized"
 
         for req_id, (block_ids_per_group, num_tokens) in metadata.reqs_to_fill.items():
             # Fill blocks for each KV cache group
@@ -372,7 +371,6 @@ class DecodeBenchConnectorWorker:
             return
 
         assert self.kv_caches is not None
-        assert self.group_to_layers is not None
 
         # Get the layers that belong to this group
         layer_names = self.group_to_layers.get(group_idx, [])


### PR DESCRIPTION
### Purpose

`DecodeBenchConnector` advertises HMA support, but its worker currently assigns
every registered KV cache layer to group 0. The scheduler preserves block IDs per
KV cache group, so hybrid models can fill an attention cache using group 0's
block IDs while leaving the row requested for another group untouched.

Build the worker's group-to-layer mapping from
`KVCacheConfig.kv_cache_groups`. This keeps each layer aligned with the group
index used by scheduler metadata. Add a two-group regression test using distinct
block IDs (`group0=[1]`, `group1=[5]`) and update the existing test fixture to
register the layer names declared by its cache configuration.

No public API or configuration behavior changes, so no documentation update is
needed.

### Duplicate-work check

No linked issue exists for this bug. The following searches returned no matching
open PR or issue:

```bash
gh pr list --repo vllm-project/vllm --state open \
  --search 'DecodeBenchConnector HMA group mapping'
gh pr list --repo vllm-project/vllm --state open \
  --search 'DecodeBenchConnector hybrid cache groups'
gh issue list --repo vllm-project/vllm --state open \
  --search 'DecodeBenchConnector HMA group mapping'
```

Related merged work does not duplicate this fix:

- #41770 opted `DecodeBenchConnector` into `SupportsHMA`, but did not build a
  worker-side cache-group mapping.
- #45080 added list/tuple filling for Mamba/KDA state tensors, but retained the
  group-0 assignment.

## Test Plan

Run formatting, lint, syntax, and the connector unit suite:

```bash
uvx --from ruff==0.14.0 ruff check \
  vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py \
  tests/v1/kv_connector/unit/test_decode_bench_connector.py
uvx --from ruff==0.14.0 ruff format --check \
  vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py \
  tests/v1/kv_connector/unit/test_decode_bench_connector.py
.venv/bin/python -m compileall -q \
  vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py \
  tests/v1/kv_connector/unit/test_decode_bench_connector.py
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_decode_bench_connector.py -v
```

On CUDA, smoke-test a `MambaSpec` list-backed state in group 0 and a
`FullAttentionSpec` block-indexed cache in group 1 using metadata
`(([1], [5]), block_size)`.

Run an OpenAI-compatible serving E2E with the small hybrid Jamba model:

```bash
CUDA_VISIBLE_DEVICES=0 \
VLLM_ENABLE_V1_MULTIPROCESSING=0 \
VLLM_LOGGING_LEVEL=DEBUG \
.venv/bin/vllm serve ai21labs/Jamba-tiny-dev \
  --host 127.0.0.1 \
  --port 8127 \
  --dtype bfloat16 \
  --enforce-eager \
  --max-model-len 256 \
  --max-num-seqs 2 \
  --max-num-batched-tokens 256 \
  --gpu-memory-utilization 0.2 \
  --kv-transfer-config \
  '{"kv_connector":"DecodeBenchConnector","kv_role":"kv_both"}'

curl --fail http://127.0.0.1:8127/v1/completions \
  -H 'Content-Type: application/json' \
  --data-binary '{
    "model": "ai21labs/Jamba-tiny-dev",
    "prompt": "The quick brown fox crossed the quiet valley while the morning sun rose over the distant mountains. Every traveler recorded the route carefully in a notebook before asking what happened next.",
    "max_tokens": 4,
    "temperature": 0,
    "ignore_eos": true
  }'
```

## Test Result

- Ruff lint and format checks passed.
- Python compilation passed.
- `test_decode_bench_connector.py`: **9 passed**, including the new HMA
  group-routing regression.
- CUDA hybrid-cache smoke test passed on NVIDIA GB200. The KDA/Mamba-style state
  tensors were filled, MLA/attention row 1 remained zero, and requested row 5
  was filled.
- Jamba serving E2E passed on an NVIDIA GB200 allocated through Slurm:
    - 16 KV cache layers registered.
    - The scheduler allocated the request across 8 HMA groups.
    - The worker filled groups 0 through 7 and reported 33 external tokens filled
    across all 8 groups.
    - `/v1/completions` returned 4 of 4 requested tokens with
    `finish_reason="length"`.

Model-quality evaluation is not applicable. `DecodeBenchConnector`
intentionally fills caches with dummy values for decoder performance testing,
so its generated text has no semantic-accuracy expectation. The real-model E2E
instead verifies successful serving and traversal of every configured hybrid
cache group.

### AI assistance disclosure

OpenAI Codex was used for this PR.