### PR TITLE
[Bugfix] Fall back to the V1 model runner where UVA is unavailable

### DIFF
--- a/.buildkite/test_areas/cuda.yaml
+++ b/.buildkite/test_areas/cuda.yaml
@@ -17,6 +17,7 @@ steps:
     - pytest -v -s cuda/test_cuda_context.py
     - pytest -v -s cuda/test_platform_no_cuda_init.py
     - pytest -v -s cuda/test_cuda_compatibility_path.py
+    - pytest -v -s cuda/test_wsl2_pin_memory.py
   mirror:
     amd:
       label: ":amd: (MI355) CUDA Platform"

--- a/tests/cuda/test_wsl2_pin_memory.py
+++ b/tests/cuda/test_wsl2_pin_memory.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""On WSL2, pinned host memory follows the model runner unless
+VLLM_WSL2_ENABLE_PIN_MEMORY decides it directly.
+
+The gate is CudaPlatformBase.is_pin_memory_available; the cached wrapper in
+vllm.utils.platform_utils is not under test."""
+
+import pytest
+
+from vllm.platforms import current_platform
+
+# ROCm keeps its own WSL2 gate in vllm/platforms/rocm.py.
+pytestmark = pytest.mark.skipif(
+    current_platform.is_rocm(), reason="the gate under test is CudaPlatformBase's"
+)
+cuda_platform = pytest.importorskip("vllm.platforms.cuda")
+
+
+@pytest.fixture
+def wsl2(monkeypatch):
+    monkeypatch.setattr(cuda_platform, "in_wsl", lambda: True)
+    monkeypatch.setattr(cuda_platform, "_get_wsl_kernel_version", lambda: (6, 6, 87))
+    monkeypatch.delenv("VLLM_WSL2_ENABLE_PIN_MEMORY", raising=False)
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    return cuda_platform.CudaPlatformBase
+
+
+@pytest.mark.parametrize(
+    ("pin_memory_env", "runner_env", "expected"),
+    [
+        (None, None, True),
+        (None, "1", True),
+        (None, "0", False),
+        ("0", None, False),
+        ("0", "1", False),
+        ("1", "0", True),
+    ],
+)
+def test_wsl2_pinned_memory_follows_the_model_runner(
+    wsl2, monkeypatch, pin_memory_env, runner_env, expected
+):
+    if pin_memory_env is not None:
+        monkeypatch.setenv("VLLM_WSL2_ENABLE_PIN_MEMORY", pin_memory_env)
+    if runner_env is not None:
+        monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", runner_env)
+
+    assert wsl2.is_pin_memory_available() is expected
+
+
+def test_wsl2_kernel_without_pinned_memory_support(wsl2, monkeypatch):
+    monkeypatch.setattr(cuda_platform, "_get_wsl_kernel_version", lambda: (4, 19, 0))
+    monkeypatch.setenv("VLLM_WSL2_ENABLE_PIN_MEMORY", "1")
+
+    assert wsl2.is_pin_memory_available() is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -403,10 +403,11 @@ def test_v2_model_runner_supports_extract_hidden_states():
 
 
 def test_v2_model_runner_requires_uva(monkeypatch):
-    """Without UVA (pinned host memory, opt-in on WSL2) the V2 runner cannot
-    build its buffers and would die at init_device with a bare "UVA is not
-    available"; forcing V2 has to fail at config time with an actionable
-    message, and the default has to fall back to V1 there."""
+    """Without UVA (pinned host memory) the V2 runner cannot build its
+    buffers and would die at init_device with a bare "UVA is not available".
+    The gate sits beside the Triton one, not in the unsupported-features
+    list: forcing V2 fails at config time, and the default falls back to V1
+    with nothing listed as unsupported."""
     monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
     monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: False)
 
@@ -417,13 +418,10 @@ def test_v2_model_runner_requires_uva(monkeypatch):
 
     monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
     config = VllmConfig()
-    unsupported = config._get_v2_model_runner_unsupported_features()
-    assert any("UVA" in feature for feature in unsupported)
+    assert config._get_v2_model_runner_unsupported_features() == []
     assert config.use_v2_model_runner is False
 
-    # With UVA available the entry is the only thing that flipped.
     monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: True)
-    assert config._get_v2_model_runner_unsupported_features() == []
     assert config.use_v2_model_runner
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -402,6 +402,28 @@ def test_v2_model_runner_supports_extract_hidden_states():
     assert config._get_v2_model_runner_unsupported_features() == []
 
 
+def test_v2_model_runner_requires_uva(monkeypatch):
+    """Without UVA (pinned host memory, opt-in on WSL2) the V2 runner cannot
+    build its buffers and would die at init_device with a bare "UVA is not
+    available"; the default has to fall back to V1 at config time, and forcing
+    V2 has to fail there with an actionable message."""
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
+    monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: False)
+
+    config = VllmConfig()
+    unsupported = config._get_v2_model_runner_unsupported_features()
+    assert any("UVA" in feature for feature in unsupported)
+    assert config.use_v2_model_runner is False
+    with pytest.raises(ValueError, match="UVA"):
+        config._validate_v2_model_runner()
+
+    # With UVA available the entry is the only thing that flipped.
+    monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: True)
+    assert config._get_v2_model_runner_unsupported_features() == []
+    assert config.use_v2_model_runner
+
+
 def test_dflash2_draft_forces_v2_model_runner():
     """A DFlash2 draft must reach the V2 speculator, the only one that runs its
     candidate selector; on V1 it would draft as DFlash1 without raising."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -405,18 +405,21 @@ def test_v2_model_runner_supports_extract_hidden_states():
 def test_v2_model_runner_requires_uva(monkeypatch):
     """Without UVA (pinned host memory, opt-in on WSL2) the V2 runner cannot
     build its buffers and would die at init_device with a bare "UVA is not
-    available"; the default has to fall back to V1 at config time, and forcing
-    V2 has to fail there with an actionable message."""
-    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    available"; forcing V2 has to fail at config time with an actionable
+    message, and the default has to fall back to V1 there."""
     monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
     monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: False)
 
+    # Explicit V2 must reach the validator from __post_init__.
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    with pytest.raises(ValueError, match="UVA"):
+        VllmConfig()
+
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
     config = VllmConfig()
     unsupported = config._get_v2_model_runner_unsupported_features()
     assert any("UVA" in feature for feature in unsupported)
     assert config.use_v2_model_runner is False
-    with pytest.raises(ValueError, match="UVA"):
-        config._validate_v2_model_runner()
 
     # With UVA available the entry is the only thing that flipped.
     monkeypatch.setattr(vllm_config_module, "is_uva_available", lambda: True)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -674,6 +674,16 @@ class VllmConfig:
             )
             return False
 
+        # The V2 runner stages its host->device copies through UVA buffers,
+        # which need pinned host memory; without it the worker would die at
+        # init_device with a bare "UVA is not available".
+        if not is_uva_available():
+            logger.warning_once(
+                "Model Runner V2 requires UVA (pinned host memory); using the "
+                "V1 model runner instead."
+            )
+            return False
+
         unsupported = self._get_v2_model_runner_unsupported_features()
         if unsupported:
             logger.warning_once(
@@ -2551,16 +2561,6 @@ class VllmConfig:
         model_config = self.model_config
         speculative_config = self.speculative_config
 
-        # The V2 runner stages its host->device copies through UVA buffers,
-        # which need pinned host memory. Where the platform reports none
-        # (WSL2 keeps pinned memory opt-in), the worker would otherwise die
-        # at init_device with a bare "UVA is not available".
-        if not is_uva_available():
-            unsupported.append(
-                "platforms without UVA (pinned host memory unavailable; "
-                "on WSL2 set VLLM_WSL2_ENABLE_PIN_MEMORY=1)"
-            )
-
         if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
             unsupported.append("stock torch.compile")
 
@@ -2789,6 +2789,9 @@ class VllmConfig:
         """Check for features not yet supported by the V2 model runner."""
         if not HAS_TRITON:
             raise ValueError("Model Runner V2 requires Triton.")
+
+        if not is_uva_available():
+            raise ValueError("Model Runner V2 requires UVA (pinned host memory).")
 
         unsupported = self._get_v2_model_runner_unsupported_features()
         if unsupported:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -26,6 +26,7 @@ from vllm.transformers_utils.runai_utils import is_runai_obj_uri
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils import random_uuid
 from vllm.utils.hashing import safe_hash
+from vllm.utils.platform_utils import is_uva_available
 
 from .attention import AttentionConfig
 from .cache import CacheConfig
@@ -2549,6 +2550,16 @@ class VllmConfig:
         unsupported: list[str] = []
         model_config = self.model_config
         speculative_config = self.speculative_config
+
+        # The V2 runner stages its host->device copies through UVA buffers,
+        # which need pinned host memory. Where the platform reports none
+        # (WSL2 keeps pinned memory opt-in), the worker would otherwise die
+        # at init_device with a bare "UVA is not available".
+        if not is_uva_available():
+            unsupported.append(
+                "platforms without UVA (pinned host memory unavailable; "
+                "on WSL2 set VLLM_WSL2_ENABLE_PIN_MEMORY=1)"
+            )
 
         if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
             unsupported.append("stock torch.compile")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -304,7 +304,7 @@ if TYPE_CHECKING:
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_KV_OFFLOAD_MAX_BATCH_DESCRIPTORS: int = 0
-    VLLM_WSL2_ENABLE_PIN_MEMORY: bool = False
+    VLLM_WSL2_ENABLE_PIN_MEMORY: bool | None = None
     VLLM_DISABLE_LOG_LOGO: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
     VLLM_ENABLE_CUDA_COMPATIBILITY: bool = False
@@ -2094,11 +2094,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_KV_OFFLOAD_MAX_BATCH_DESCRIPTORS", "0")
     ),
     # On WSL2 with a compatible kernel (>= 4.19.121), pinned memory is
-    # supported but disabled by default due to a small performance regression.
-    # Set to 1 when pinned memory or UVA is required (e.g. CPU offloading
-    # or v2 model runner).
-    "VLLM_WSL2_ENABLE_PIN_MEMORY": lambda: bool(
-        int(os.getenv("VLLM_WSL2_ENABLE_PIN_MEMORY", "0"))
+    # supported at a small performance cost, so it used to be opt-in. Unset,
+    # it follows the model runner: on unless VLLM_USE_V2_MODEL_RUNNER=0,
+    # since the V2 runner needs it for UVA. Set to 1 or 0 to decide it
+    # directly (CPU offloading needs it on either runner).
+    "VLLM_WSL2_ENABLE_PIN_MEMORY": lambda: maybe_convert_bool(
+        os.getenv("VLLM_WSL2_ENABLE_PIN_MEMORY", None)
     ),
     # Disable logging of vLLM logo at server startup time.
     "VLLM_DISABLE_LOG_LOGO": lambda: bool(int(os.getenv("VLLM_DISABLE_LOG_LOGO", "0"))),

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -310,11 +310,15 @@ class CudaPlatformBase(Platform):
                     "down performance. Please run `wsl --update`."
                 )
                 return False
-            # On compatible WSL2 kernels, pinned memory is supported but
-            # disabled by default. Enable it via VLLM_WSL2_ENABLE_PIN_MEMORY=1.
-            import vllm.envs as envs
-
-            return envs.VLLM_WSL2_ENABLE_PIN_MEMORY
+            # On compatible WSL2 kernels pinned memory is supported. It
+            # follows the model runner, on unless the V1 runner is selected,
+            # since the V2 runner needs it for UVA; VLLM_WSL2_ENABLE_PIN_MEMORY
+            # decides it directly when set. This keys on the env rather than
+            # on the resolved runner: the config's runner selection reads
+            # UVA, which reads this.
+            if envs.VLLM_WSL2_ENABLE_PIN_MEMORY is not None:
+                return envs.VLLM_WSL2_ENABLE_PIN_MEMORY
+            return envs.VLLM_USE_V2_MODEL_RUNNER is not False
         return True
 
     @classmethod


### PR DESCRIPTION
## Purpose

Fixes #54652 (the same failure as #47292 and #47387).

On platforms where vLLM reports no pinned host memory, `is_uva_available()` is false, but the V2 model runner is still selected by default and dies at `init_device` with a bare `RuntimeError: UVA is not available` from `UvaBuffer`. WSL2 was the reported case: pinned memory there was opt-in behind `VLLM_WSL2_ENABLE_PIN_MEMORY`.

Two changes, per review:

- The UVA check sits beside the `HAS_TRITON` one, since UVA is a platform capability rather than a user-selected feature. With the env unset, `use_v2_model_runner` logs `Model Runner V2 requires UVA (pinned host memory); using the V1 model runner instead.` and returns False. With `VLLM_USE_V2_MODEL_RUNNER=1`, `_validate_v2_model_runner` raises `ValueError: Model Runner V2 requires UVA (pinned host memory).` at config time instead of deep in worker init. Nothing is listed as unsupported.
- On WSL2, pinned memory follows the model runner. `VLLM_WSL2_ENABLE_PIN_MEMORY` is tri-state like `VLLM_USE_V2_MODEL_RUNNER`: unset, pinned memory on a compatible kernel (>= 4.19.121) is on unless `VLLM_USE_V2_MODEL_RUNNER=0`; set to 1 or 0 it decides directly. The gate keys on the env rather than on the resolved runner because `use_v2_model_runner` reads `is_uva_available()`, which reads this gate. So a default-config serve on WSL2 now runs MRV2 with pinned memory, and the V1 fallback above covers WSL2 kernels below 4.19.121 and any platform that reports no pinned memory. When a default config falls back to V1 for some other unsupported feature, pinned memory stays on, since the env is still unset; same trade as below.

The env's comment says pinned memory on WSL2 was opt-in because of a small performance regression; that note is kept, and defaulting it on for MRV2 takes that trade on WSL2.

#47579 puts the UVA check at the same two sites and has needed a rebase since August; happy to close this one if it comes back.

## Test Plan

- `tests/test_config.py::test_v2_model_runner_requires_uva`: with `is_uva_available` patched false, `VllmConfig()` raises with `UVA` in the message under `VLLM_USE_V2_MODEL_RUNNER=1`; with the env unset, `_get_v2_model_runner_unsupported_features()` is empty and `use_v2_model_runner` is False; patched true again, V2 is selected.
- New `tests/cuda/test_wsl2_pin_memory.py`: `in_wsl` and `_get_wsl_kernel_version` patched on `vllm.platforms.cuda`, `CudaPlatformBase.is_pin_memory_available()` called directly (the cached wrapper is not under test): six env combinations plus a kernel below 4.19.121 with the env set to 1. Added to the CUDA Platform step in `.buildkite/test_areas/cuda.yaml`, which lists its files by name; skipped on ROCm, which keeps its own WSL2 gate in `vllm/platforms/rocm.py`.
- Run against the nightly wheel `0.28.1rc1.dev450+gf2e2936f9` (built from this branch's base) on a CPU-only host with `VLLM_TARGET_DEVICE=cpu`, overlaying `vllm/config/vllm.py`, `vllm/envs.py`, and `vllm/platforms/cuda.py` in place. Two controls run first: the config test against the previous commit's `vllm/config/vllm.py`, and the gate test against the base `envs.py` and `cuda.py`. On this host `vllm.platforms.cuda` only imports with `vllm._C_stable_libtorch` stubbed (no libcuda), so the gate test ran under that stub here; CI runs it for real.
- `ruff check`, `ruff format --check`, and `typos` at the pre-commit pinned versions.

## Test Result

- Installed wheel's `vllm/config/vllm.py`, `vllm/envs.py`, and `vllm/platforms/cuda.py` are byte-identical to this branch's base.
- Control, config test on the previous commit: fails at `assert config._get_v2_model_runner_unsupported_features() == []`, the entry was still collected there.
- Control, gate test on the base `envs.py` + `cuda.py`: exactly the two unset-env cases fail (`None-None-True`, `None-1-True`); the other five pass, so the change flips only what it says.
- Full change: config test passes; the `-k "v2_model_runner or v1_model_runner"` subset of `tests/test_config.py` passes, 29 tests; the gate test passes, 7 cases; `tests/test_envs.py` passes, 65 tests, with the env now tri-state.
- Both rendered messages above are captured from the real code path; `VLLM_WSL2_ENABLE_PIN_MEMORY` reads None / True / False for unset / `1` / `0`.
- ruff, ruff format, typos: clean.
- Not run on the WSL2 rig this round. The end-to-end result from the first version (`VLLM_USE_V2_MODEL_RUNNER=0` serving normally on WSL2 with an RTX 4090, detail in #53888) covers the MRV1 path; the MRV2-with-pinned-memory default on WSL2 is covered by the unit tests only.
