### PR TITLE
[Model Runner V2][Spec Decode] Overlap draft continuation DP sync with prefill

### DIFF
--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -20,6 +20,7 @@ from vllm.model_executor.models.mistral_large_3_eagle import (
 from vllm.v1.attention.backends import flash_attn as flash_attn_module
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.dp_utils import DPSyncState
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
@@ -160,6 +161,8 @@ def test_mm_support_configured_after_model_load(monkeypatch):
         speculator.dtype = torch.float32
         speculator.draft_model_config = draft_model_config
         speculator.supports_mm_inputs = False
+        speculator.dp_size = 1
+        speculator.dp_rank = 0
 
     checked_configs = []
 
@@ -375,6 +378,156 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
 
     assert generate_draft.call_count == expected_eager_calls
     assert run_fullgraph.call_count == expected_graph_replays
+
+
+def _make_async_sync_propose_speculator(monkeypatch):
+    order = []
+    prefill_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.NONE,
+        num_tokens=2,
+        num_reqs=1,
+    )
+    decode_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=2,
+        num_reqs=1,
+        uniform_token_count=1,
+    )
+    prefill_sync = DPSyncState(torch.tensor([2, 2]), 2, False)
+    decode_sync = DPSyncState(torch.tensor([2, 2]), 1, False)
+
+    monkeypatch.setattr(spec_module, "prepare_prefill_inputs", Mock())
+    monkeypatch.setattr(
+        spec_module,
+        "prepare_decode_inputs",
+        Mock(side_effect=lambda *args, **kwargs: order.append("prepare_decode")),
+    )
+    monkeypatch.setattr(
+        spec_module,
+        "get_uniform_decode_token_count",
+        lambda *args, **kwargs: 2,
+    )
+    monkeypatch.setattr(
+        spec_module,
+        "dispatch_cg_and_sync_dp",
+        Mock(return_value=(prefill_desc, prefill_sync)),
+    )
+
+    future = Mock()
+
+    def finish_sync(manager):
+        order.append("finish")
+        return decode_desc, decode_sync
+
+    def start_sync(*args, **kwargs):
+        order.append("start")
+        return future
+
+    future.result.side_effect = finish_sync
+    future.release.side_effect = lambda: order.append("release")
+    coordinator = Mock()
+    coordinator.start.side_effect = start_sync
+
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 2
+    speculator.dp_size = 2
+    speculator.dp_rank = 0
+    speculator.max_model_len = 16
+    speculator.max_num_reqs = 1
+    speculator.hidden_states = torch.zeros(2, 3)
+    speculator.last_token_indices = torch.zeros(1, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0, dtype=torch.int64)
+    speculator.input_buffers = SimpleNamespace()
+    speculator.sample_src_positions = torch.zeros(1, dtype=torch.int64)
+    speculator.draft_tokens = torch.zeros((1, 2), dtype=torch.int64)
+    speculator.prefill_cudagraph_manager = Mock()
+    speculator.decode_cudagraph_manager = Mock()
+    speculator._decode_dp_sync = coordinator
+    speculator.use_fused_multi_step_decode = False
+    speculator._copy_request_inputs = Mock()
+    speculator._prepare_eplb_forward = Mock()
+    speculator.on_prefill_begin = Mock()
+    speculator.on_prefill_end = Mock()
+    speculator.on_multi_step_decode_begin = Mock()
+    speculator.on_multi_step_decode_end = Mock()
+    speculator._prefill = Mock(
+        side_effect=lambda *args, **kwargs: order.append("prefill")
+    )
+    speculator._multi_step_decode = Mock(
+        side_effect=lambda *args, **kwargs: order.append("decode")
+    )
+
+    input_batch = SimpleNamespace(
+        num_tokens=2,
+        num_tokens_after_padding=2,
+        num_reqs=1,
+        num_scheduled_tokens=torch.tensor([2]),
+        seq_lens_cpu_upper_bound=torch.tensor([2]),
+        seq_lens=torch.tensor([2]),
+        idx_mapping=torch.tensor([0]),
+        has_prefill=False,
+    )
+    return speculator, input_batch, future, order
+
+
+@pytest.mark.cpu_test
+@pytest.mark.skip_global_cleanup
+def test_propose_overlaps_decode_dp_sync_with_draft_prefill(monkeypatch):
+    speculator, input_batch, future, order = _make_async_sync_propose_speculator(
+        monkeypatch
+    )
+
+    output = speculator.propose(
+        input_batch=input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.zeros(2, 3),
+        aux_hidden_states=None,
+        num_sampled=torch.ones(1, dtype=torch.int32),
+        num_rejected=torch.zeros(1, dtype=torch.int32),
+        last_sampled=torch.zeros(1, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(1, dtype=torch.int64),
+        temperature=torch.ones(1),
+        seeds=torch.zeros(1, dtype=torch.int64),
+    )
+
+    assert torch.equal(output, speculator.draft_tokens)
+    assert order == [
+        "start",
+        "prefill",
+        "prepare_decode",
+        "finish",
+        "decode",
+        "release",
+    ]
+    future.release.assert_called_once_with()
+
+
+@pytest.mark.cpu_test
+@pytest.mark.skip_global_cleanup
+def test_propose_releases_decode_dp_sync_when_prefill_fails(monkeypatch):
+    speculator, input_batch, future, order = _make_async_sync_propose_speculator(
+        monkeypatch
+    )
+    speculator._prefill.side_effect = RuntimeError("prefill failed")
+
+    with pytest.raises(RuntimeError, match="prefill failed"):
+        speculator.propose(
+            input_batch=input_batch,
+            attn_metadata={},
+            slot_mappings={},
+            last_hidden_states=torch.zeros(2, 3),
+            aux_hidden_states=None,
+            num_sampled=torch.ones(1, dtype=torch.int32),
+            num_rejected=torch.zeros(1, dtype=torch.int32),
+            last_sampled=torch.zeros(1, dtype=torch.int64),
+            next_prefill_tokens=torch.zeros(1, dtype=torch.int64),
+            temperature=torch.ones(1),
+            seeds=torch.zeros(1, dtype=torch.int64),
+        )
+
+    assert order == ["start", "release"]
+    future.release.assert_called_once_with()
 
 
 def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(

--- a/tests/v1/worker/test_gpu_dp_utils.py
+++ b/tests/v1/worker/test_gpu_dp_utils.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    BatchExecutionDescriptor,
+    CudaGraphManager,
+)
+from vllm.v1.worker.gpu.dp_utils import DPSyncCoordinator
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+class _Work:
+    def __init__(self, tensor: torch.Tensor, remote_tokens: int) -> None:
+        self.tensor = tensor
+        self.remote_tokens = remote_tokens
+        self.wait_calls = 0
+
+    def wait(self) -> None:
+        self.wait_calls += 1
+        self.tensor[:, 1] = torch.tensor(
+            [self.remote_tokens, CUDAGraphMode.FULL.value, 1, -1],
+            dtype=torch.int32,
+        )
+
+
+def _graph_manager() -> Mock:
+    manager = Mock(spec=CudaGraphManager)
+    manager.dispatch.side_effect = lambda num_reqs, num_tokens, *args, **kwargs: (
+        BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            uniform_token_count=1,
+        )
+    )
+    return manager
+
+
+def test_async_dp_sync_waits_on_result_and_reuses_buffer(monkeypatch):
+    tensors = []
+    works = []
+
+    def all_reduce(tensor, group, async_op):
+        assert async_op
+        tensors.append(tensor)
+        work = _Work(tensor, remote_tokens=4)
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock())
+    manager = _graph_manager()
+
+    future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+
+    assert works[0].wait_calls == 0
+    with pytest.raises(RuntimeError, match="already in flight"):
+        coordinator.start(manager, 2, 2, uniform_token_count=1)
+
+    batch_desc, sync = future.result(manager)
+
+    assert works[0].wait_calls == 1
+    assert batch_desc.num_tokens == 4
+    assert sync is not None
+    assert sync.num_tokens_across_dp.tolist() == [4, 4]
+    assert future.result(manager) == (batch_desc, sync)
+    assert works[0].wait_calls == 1
+
+    future.release()
+    next_future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    assert tensors[1] is tensors[0]
+    next_future.release()
+
+
+def test_async_dp_sync_release_waits_for_unconsumed_work(monkeypatch):
+    works = []
+
+    def all_reduce(tensor, group, async_op):
+        work = _Work(tensor, remote_tokens=2)
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock())
+    manager = _graph_manager()
+
+    future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    future.release()
+
+    assert works[0].wait_calls == 1
+    replacement = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    replacement.release()
+
+
+def test_async_dp_sync_does_not_wait_twice_after_resolution_error(monkeypatch):
+    work = None
+
+    def all_reduce(tensor, group, async_op):
+        nonlocal work
+        work = _Work(tensor, remote_tokens=2)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock())
+    manager = _graph_manager()
+    manager.dispatch.side_effect = [
+        BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=2,
+            num_reqs=2,
+            uniform_token_count=1,
+        ),
+        RuntimeError("dispatch failed"),
+    ]
+
+    future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        future.result(manager)
+    assert work is not None
+    assert work.wait_calls == 1
+
+    future.release()
+    assert work.wait_calls == 1

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -35,6 +35,173 @@ class DPSyncState:
     eager: bool
 
 
+class DPSyncFuture:
+    """An in-flight DP shape agreement backed by a reusable CPU buffer."""
+
+    def __init__(
+        self,
+        coordinator: DPSyncCoordinator,
+        local_batch_desc: BatchExecutionDescriptor,
+        num_tokens: int,
+        num_reqs: int,
+        num_active_loras: int,
+        work: dist.Work | None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._local_batch_desc = local_batch_desc
+        self._num_tokens = num_tokens
+        self._num_reqs = num_reqs
+        self._num_active_loras = num_active_loras
+        self._work = work
+        self._waited = work is None
+        self._result: tuple[BatchExecutionDescriptor, DPSyncState | None] | None = None
+        self._released = False
+
+    def result(
+        self, cudagraph_manager: CudaGraphManager | None
+    ) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
+        """Wait for and resolve the agreement without releasing its buffer.
+
+        The returned ``DPSyncState`` may contain a view into the coordinator's
+        reusable buffer and is valid only until :meth:`release` is called.
+        """
+        if self._released:
+            raise RuntimeError("Cannot resolve a released DP sync future")
+        if self._result is not None:
+            return self._result
+
+        if self._work is None:
+            self._result = self._local_batch_desc, None
+        else:
+            self._work.wait()
+            self._waited = True
+            tensor = self._coordinator._tensor
+            assert tensor is not None
+            self._result = _finish_cudagraph_and_dp_padding(
+                cudagraph_manager,
+                self._local_batch_desc,
+                tensor,
+                self._num_tokens,
+                self._num_reqs,
+                self._num_active_loras,
+            )
+        return self._result
+
+    def release(self) -> None:
+        """Wait for unfinished work and return the backing buffer."""
+        if self._released:
+            return
+        if self._work is not None and not self._waited:
+            self._work.wait()
+            self._waited = True
+        self._coordinator._release(self)
+        self._released = True
+
+
+class DPSyncCoordinator:
+    """Own one persistent CPU buffer for asynchronous DP shape agreement."""
+
+    def __init__(
+        self,
+        dp_size: int,
+        dp_rank: int,
+        *,
+        group: dist.ProcessGroup | None = None,
+    ) -> None:
+        self.dp_size = dp_size
+        self.dp_rank = dp_rank
+        self.group = group
+        self._tensor = (
+            torch.zeros(4, dp_size, dtype=torch.int32, device="cpu")
+            if dp_size > 1
+            else None
+        )
+        self._active_future: DPSyncFuture | None = None
+
+    def start(
+        self,
+        cudagraph_manager: CudaGraphManager | None,
+        num_reqs: int,
+        num_tokens: int,
+        uniform_token_count: int | None,
+        max_query_len: int | None = None,
+        need_eager: bool = False,
+        num_active_loras: int = 0,
+    ) -> DPSyncFuture:
+        """Dispatch locally and issue the DP collective without waiting."""
+        if self._active_future is not None:
+            raise RuntimeError("A DP sync is already in flight")
+
+        batch_desc = _dispatch_local_batch(
+            cudagraph_manager,
+            num_reqs,
+            num_tokens,
+            uniform_token_count,
+            max_query_len,
+            need_eager,
+            num_active_loras,
+        )
+
+        work = None
+        if self._tensor is not None:
+            tensor = self._tensor
+            tensor.zero_()
+            tensor[0][self.dp_rank] = num_tokens
+            tensor[1][self.dp_rank] = batch_desc.cg_mode.value
+            tensor[2][self.dp_rank] = uniform_token_count or 0
+            tensor[3][self.dp_rank] = max_query_len or -1
+            group = self.group
+            if group is None:
+                group = get_dp_group().cpu_group
+            work = dist.all_reduce(tensor, group=group, async_op=True)
+
+        future = DPSyncFuture(
+            self,
+            batch_desc,
+            num_tokens,
+            num_reqs,
+            num_active_loras,
+            work,
+        )
+        self._active_future = future
+        return future
+
+    def _release(self, future: DPSyncFuture) -> None:
+        if self._active_future is not future:
+            raise RuntimeError("DP sync future is not owned by this coordinator")
+        self._active_future = None
+
+
+def _dispatch_local_batch(
+    cudagraph_manager: CudaGraphManager | None,
+    num_reqs: int,
+    num_tokens: int,
+    uniform_token_count: int | None,
+    max_query_len: int | None,
+    need_eager: bool,
+    num_active_loras: int,
+) -> BatchExecutionDescriptor:
+    if need_eager:
+        return BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.NONE,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            num_active_loras=num_active_loras,
+        )
+
+    assert cudagraph_manager is not None, (
+        "cudagraph_manager should only be None during profile run, "
+        "where need_eager must be True"
+    )
+    return cudagraph_manager.dispatch(
+        num_reqs,
+        num_tokens,
+        uniform_token_count,
+        num_active_loras=num_active_loras,
+        max_query_len=max_query_len,
+    )
+
+
 def sync_cudagraph_and_dp_padding(
     cudagraph_manager: CudaGraphManager | None,
     desired_batch_desc: BatchExecutionDescriptor,
@@ -60,6 +227,24 @@ def sync_cudagraph_and_dp_padding(
     tensor[3][dp_rank] = max_query_len or -1  # (-1 means None)
     dist.all_reduce(tensor, group=group)
 
+    return _finish_cudagraph_and_dp_padding(
+        cudagraph_manager,
+        desired_batch_desc,
+        tensor,
+        num_tokens,
+        num_reqs,
+        num_active_loras,
+    )
+
+
+def _finish_cudagraph_and_dp_padding(
+    cudagraph_manager: CudaGraphManager | None,
+    desired_batch_desc: BatchExecutionDescriptor,
+    tensor: torch.Tensor,
+    num_tokens: int,
+    num_reqs: int,
+    num_active_loras: int,
+) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
     num_tokens_across_dp = tensor[0]
     cg_mode_across_dp = tensor[1]
     uniform_token_counts_across_dp = tensor[2]
@@ -175,25 +360,15 @@ def dispatch_cg_and_sync_dp(
     """
     reuse_eager = dp_sync is not None and dp_sync.eager
 
-    if need_eager or reuse_eager:
-        batch_desc = BatchExecutionDescriptor(
-            cg_mode=CUDAGraphMode.NONE,
-            num_tokens=num_tokens,
-            num_reqs=num_reqs,
-            num_active_loras=num_active_loras,
-        )
-    else:
-        assert cudagraph_manager is not None, (
-            "cudagraph_manager should only be None during profile run, "
-            "where need_eager must be True"
-        )
-        batch_desc = cudagraph_manager.dispatch(
-            num_reqs,
-            num_tokens,
-            dp_sync.uniform_token_count if dp_sync is not None else uniform_token_count,
-            num_active_loras=num_active_loras,
-            max_query_len=max_query_len,
-        )
+    batch_desc = _dispatch_local_batch(
+        cudagraph_manager,
+        num_reqs,
+        num_tokens,
+        dp_sync.uniform_token_count if dp_sync is not None else uniform_token_count,
+        max_query_len,
+        need_eager or reuse_eager,
+        num_active_loras,
+    )
 
     if dp_size == 1:
         return batch_desc, None

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -14,7 +14,11 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
-from vllm.v1.worker.gpu.dp_utils import DPSyncState, dispatch_cg_and_sync_dp
+from vllm.v1.worker.gpu.dp_utils import (
+    DPSyncCoordinator,
+    DPSyncState,
+    dispatch_cg_and_sync_dp,
+)
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
@@ -46,6 +50,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.use_fused_multi_step_decode = False
+        self._decode_dp_sync = (
+            DPSyncCoordinator(self.dp_size, self.dp_rank) if self.dp_size > 1 else None
+        )
 
     def load_model(self, target_model: nn.Module) -> None:
         super().load_model(target_model)
@@ -298,78 +305,99 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             else None
         )
 
-        self._prepare_eplb_forward(num_tokens)
-
-        self.on_prefill_begin(num_reqs)
-        if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
-            # Replay the full graph for draft prefill.
-            assert self.prefill_cudagraph_manager is not None
-            self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
-        else:
-            # The target model's attention metadata and slot mappings
-            # can directly be used for draft prefill, because of the
-            # identical batch shape and KV cache layout.
-            self._prefill(
+        decode_dp_future = None
+        if self.num_speculative_steps > 1 and self._decode_dp_sync is not None:
+            # The continuation shape depends only on num_reqs, so its CPU
+            # collective can overlap draft prefill and decode input preparation.
+            # It is resolved below before any continuation work is launched.
+            decode_dp_future = self._decode_dp_sync.start(
+                self.decode_cudagraph_manager,
                 num_reqs,
-                prefill_batch_desc.num_tokens,
-                attn_metadata,
-                slot_mappings,
-                num_tokens_across_dp=num_tokens_across_dp,
-                cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
-                mm_inputs=mm_inputs,
+                num_reqs,
+                uniform_token_count=1,
+                need_eager=is_profile,
             )
-        self.on_prefill_end(num_reqs)
+        try:
+            self._prepare_eplb_forward(num_tokens)
 
-        if self.num_speculative_steps == 1:
-            # Early exit.
-            return self.draft_tokens[:num_reqs, :1]
+            self.on_prefill_begin(num_reqs)
+            if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
+                # Replay the full graph for draft prefill.
+                assert self.prefill_cudagraph_manager is not None
+                self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
+            else:
+                # The target model's attention metadata and slot mappings
+                # can directly be used for draft prefill, because of the
+                # identical batch shape and KV cache layout.
+                self._prefill(
+                    num_reqs,
+                    prefill_batch_desc.num_tokens,
+                    attn_metadata,
+                    slot_mappings,
+                    num_tokens_across_dp=num_tokens_across_dp,
+                    cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
+                    mm_inputs=mm_inputs,
+                )
+            self.on_prefill_end(num_reqs)
 
-        # Prepare the inputs for the decode steps.
-        prepare_decode_inputs(
-            self.draft_tokens[:num_reqs, 0],
-            input_batch.seq_lens,
-            num_rejected,
-            self.input_buffers,
-            self.sample_src_positions,
-            self.max_model_len,
-            self.max_num_reqs,
-            advance_draft_positions=self.advance_draft_positions,
-        )
+            if self.num_speculative_steps == 1:
+                # Early exit.
+                return self.draft_tokens[:num_reqs, :1]
 
-        # Each request produces exactly 1 token per draft generation step,
-        # enabling FULL graph replay.
-        decode_batch_desc, decode_batch_sync = dispatch_cg_and_sync_dp(
-            self.decode_cudagraph_manager,
-            num_reqs,
-            num_reqs,
-            uniform_token_count=1,
-            dp_size=self.dp_size,
-            dp_rank=self.dp_rank,
-            need_eager=is_profile,
-        )
-        num_tokens_across_dp = (
-            decode_batch_sync.num_tokens_across_dp
-            if decode_batch_sync is not None
-            else None
-        )
+            # Prepare the inputs for the decode steps.
+            prepare_decode_inputs(
+                self.draft_tokens[:num_reqs, 0],
+                input_batch.seq_lens,
+                num_rejected,
+                self.input_buffers,
+                self.sample_src_positions,
+                self.max_model_len,
+                self.max_num_reqs,
+                advance_draft_positions=self.advance_draft_positions,
+            )
 
-        self.on_multi_step_decode_begin(num_reqs)
-        # Generate the remaining num_speculative_steps - 1 draft tokens.
-        decode_fn = (
-            self._fused_multi_step_decode
-            if self.use_fused_multi_step_decode
-            else self._multi_step_decode
-        )
-        decode_fn(
-            num_reqs,
-            dummy_run and skip_attn_for_dummy_run,
-            decode_batch_desc,
-            num_tokens_across_dp,
-            input_batch.seq_lens_cpu_upper_bound,
-        )
-        self.on_multi_step_decode_end(num_reqs)
+            # Each request produces exactly 1 token per draft generation step,
+            # enabling FULL graph replay.
+            if decode_dp_future is None:
+                decode_batch_desc, decode_batch_sync = dispatch_cg_and_sync_dp(
+                    self.decode_cudagraph_manager,
+                    num_reqs,
+                    num_reqs,
+                    uniform_token_count=1,
+                    dp_size=self.dp_size,
+                    dp_rank=self.dp_rank,
+                    need_eager=is_profile,
+                )
+            else:
+                decode_batch_desc, decode_batch_sync = decode_dp_future.result(
+                    self.decode_cudagraph_manager
+                )
+            num_tokens_across_dp = (
+                decode_batch_sync.num_tokens_across_dp
+                if decode_batch_sync is not None
+                else None
+            )
 
-        return self.draft_tokens[:num_reqs]
+            self.on_multi_step_decode_begin(num_reqs)
+            # Generate the remaining num_speculative_steps - 1 draft tokens.
+            decode_fn = (
+                self._fused_multi_step_decode
+                if self.use_fused_multi_step_decode
+                else self._multi_step_decode
+            )
+            decode_fn(
+                num_reqs,
+                dummy_run and skip_attn_for_dummy_run,
+                decode_batch_desc,
+                num_tokens_across_dp,
+                input_batch.seq_lens_cpu_upper_bound,
+            )
+            self.on_multi_step_decode_end(num_reqs)
+
+            return self.draft_tokens[:num_reqs]
+        finally:
+            if decode_dp_future is not None:
+                decode_dp_future.release()
 
     @torch.inference_mode()
     def _run_model(


### PR DESCRIPTION
## Purpose

With data parallelism and autoregressive speculative decoding using more than one speculative token, the draft continuation still performs a blocking CPU-group shape agreement after draft prefill. The draft continuation shape depends only on the local request count, so that agreement can be issued earlier and overlapped with draft prefill plus decode-input preparation.

This PR:

- adds an owned asynchronous DP-shape future backed by one reusable CPU tensor;
- starts the continuation agreement after the draft-prefill descriptor is known;
- resolves it immediately before continuation graph selection; and
- waits and releases the in-flight work on every exit path.

The collective group, four-row payload, graph-dispatch rules, and cross-rank result semantics are unchanged. Only the issue/wait placement changes. A coordinator permits one in-flight operation and keeps the returned tensor alive until explicit release, preventing buffer reuse while a consumer still needs it.

Current main already reuses the target DP agreement for draft prefill via #53694. This change addresses the remaining continuation agreement rather than reintroducing a second prefill collective.

### Related work / duplicate check

- #44636 moves an older Model Runner V1 DP sync to a CUDA/NCCL stream; it does not cover this Model Runner V2 autoregressive-speculator continuation path.
- Draft #54131 extends DP shape coordination for PCP topology. It is adjacent in `dp_utils.py` but addresses different topology/metadata; this PR preserves the current payload and resolver so any rebase should be localized.

AI assistance disclosure: OpenAI Codex was used under human direction to help inspect current main, implement the change, and write tests. The submitter will review the changed code and validate multi-rank GPU behavior and performance before marking the PR ready.

## Test Plan

1. Unit-test future ownership, deferred wait, buffer reuse, abandoned-work cleanup, and resolver-error cleanup.
2. Unit-test that the continuation agreement starts before draft prefill, resolves after decode-input preparation, and releases on success and prefill failure.
3. Run the complete autoregressive-speculator unit-test module plus the new DP utility tests.
4. Run pre-commit on every changed file.
5. Before moving out of draft, run a multi-rank GPU functional smoke test and a before/after performance comparison for autoregressive speculative decoding with DP.

## Test Result

```text
python -m pytest --confcutdir=tests/v1/worker -q \
  tests/v1/worker/test_gpu_autoregressive_speculator.py \
  tests/v1/worker/test_gpu_dp_utils.py

24 passed, 15 warnings in 6.46s
```

```text
pre-commit run --files \
  vllm/v1/worker/gpu/dp_utils.py \
  vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py \
  tests/v1/worker/test_gpu_dp_utils.py \
  tests/v1/worker/test_gpu_autoregressive_speculator.py

All hooks passed.
```

Multi-rank GPU performance validation has not been run yet; the PR is intentionally a draft until those results are available. No documentation or model-output evaluation is required because the change does not alter user-facing configuration, scheduling policy, or model math.
