### PR TITLE
[Test] Pin the fine-grained prefix-cache-hit gate to prefix-cacheable groups

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -21,6 +21,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.kv_cache_interface import (
+    CircularBufferSpec,
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
@@ -2046,3 +2047,99 @@ def test_boundary_states_offered_past_prompt_for_resumed_prefill():
     offered = [b for _, _, b in drain_boundary_state_offloads(manager).get("0", [])]
     assert 2 * block_size in offered
     assert req0.num_prompt_tokens < 2 * block_size
+
+
+def _fine_grained_gate_coordinator(
+    extra_group: KVCacheGroupSpec,
+    hash_block_size: int = 2,
+    mamba_block_size: int = 8,
+):
+    """Full-attention + Mamba("align") geometry that enables fine-grained hits,
+    plus one extra group for the gate to consider. Returns the coordinator and
+    the extra group's id."""
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+            extra_group,
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    return manager.coordinator, len(kv_cache_config.kv_cache_groups) - 1
+
+
+def test_scratch_group_does_not_veto_fine_grained_hits():
+    """A non-prefix-cacheable group is never looked up, so its block-aligned
+    lookup capability must not pin every other group's hits to
+    ``scheduler_block_size``."""
+    coordinator, gid = _fine_grained_gate_coordinator(
+        KVCacheGroupSpec(
+            ["compressor_state"],
+            CircularBufferSpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=8,
+                head_size_v=0,
+                dtype=torch.float32,
+            ),
+        )
+    )
+    scratch_spec = coordinator.kv_cache_config.kv_cache_groups[gid].kv_cache_spec
+    scratch_manager = coordinator.single_type_managers[gid]
+    # Exactly the shape the gate reacts to: block-aligned lookups only, and a
+    # block size that differs from the hash block size.
+    assert not scratch_spec.prefix_cacheable
+    assert not scratch_manager.supports_fine_grained_hash_lookup
+    assert scratch_manager.block_size != coordinator.hash_block_size
+
+    assert coordinator.enable_partial_hash_hits
+    assert coordinator._cache_hit_alignment_tokens == coordinator.hash_block_size
+    assert all(gid not in group.group_ids for group in coordinator.attention_groups)
+
+
+def test_prefix_cacheable_group_without_fine_lookup_still_vetoes():
+    """Negative control: a prefix-cacheable sliding-window group with the same
+    two properties is looked up, so the gate must still veto."""
+    coordinator, gid = _fine_grained_gate_coordinator(
+        KVCacheGroupSpec(
+            ["swa"],
+            SlidingWindowSpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=4,
+            ),
+        )
+    )
+    swa_spec = coordinator.kv_cache_config.kv_cache_groups[gid].kv_cache_spec
+    swa_manager = coordinator.single_type_managers[gid]
+    assert swa_spec.prefix_cacheable
+    assert not swa_manager.supports_fine_grained_hash_lookup
+    assert swa_manager.block_size != coordinator.hash_block_size
+
+    assert not coordinator.enable_partial_hash_hits
+    assert coordinator._cache_hit_alignment_tokens == coordinator.scheduler_block_size


### PR DESCRIPTION
## Purpose

Test-only. Adds a regression guard for the `prefix_cacheable` scoping of the fine-grained-hit veto that #53896 (`e126687a`) introduced in `HybridKVCacheCoordinator.__init__`. No production code changes; the fix this covers is already in `main`.

**What the gate does.** When a hybrid model has an align-mode Mamba group, the coordinator enables fine-grained (hash-block-aligned) partial hits, then scans the managers and switches them off again if any manager can only answer block-aligned lookups (`vllm/v1/core/kv_cache_coordinator.py:644-660` at `22df3a3`). Since #53896 that scan is scoped to groups whose spec is `prefix_cacheable` (`:649`), because `verify_and_split_kv_cache_groups` skips the other groups (`:675-682`) and they are never looked up, so their `supports_fine_grained_hash_lookup` cannot affect any hit.

**What is uncovered.** `grep -rn prefix_cacheable tests/` finds only `tests/v1/core/test_contiguous_kv_packing.py`, which exercises grouping, hash-granularity and truncation, not this gate. We found no assertion that a non-prefix-cacheable group leaves `enable_partial_hash_hits` on; with `and group.kv_cache_spec.prefix_cacheable` removed at `:649`, such a group reduces every other group's hit granularity from `hash_block_size` to `scheduler_block_size` (`_cache_hit_alignment_tokens`, `:665-673`) with nothing to catch it.

The regression is easy to reintroduce because the veto reads the *manager* (`supports_fine_grained_hash_lookup`, `block_size`) while the scoping reads the *spec*, and `CircularBufferManager` is exactly the shape that trips it: it subclasses `FullAttentionManager` and overrides `supports_fine_grained_hash_lookup = False` (`vllm/v1/core/single_type_kv_cache_manager.py:1118-1121`), and `CircularBufferSpec` defines `block_size` as the ring capacity (`vllm/v1/kv_cache_interface.py:753-761`), which the test sets to differ from the hash block size.

**The tests** (`tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py`, one shared helper building full-attention + Mamba("align") + one extra group):

1. `test_scratch_group_does_not_veto_fine_grained_hits` — extra group is a `CircularBufferSpec` ring (block 4, hash block 2). Asserts the preconditions the gate reacts to (`not prefix_cacheable`, `not supports_fine_grained_hash_lookup`, `block_size != hash_block_size`), then that `enable_partial_hash_hits` stays on, `_cache_hit_alignment_tokens == hash_block_size`, and that the group is absent from `attention_groups`.
2. `test_prefix_cacheable_group_without_fine_lookup_still_vetoes` — negative control: a prefix-cacheable `SlidingWindowSpec` with the same two properties must still veto, and the alignment must fall back to `scheduler_block_size`. Without it, test 1 would also pass if the whole check were deleted.

**Why it is worth a test PR.** Any hybrid model that carries a non-prefix-cacheable scratch group is exposed: before #53896, such a group pinned every warm-turn hit to scheduler-block alignment. On the deployment that surfaced it (GLM-5.3-Flash on 2× DGX Spark: a kpool-tail scratch group at block 4 next to MLA/Mamba groups at 3584 and a 64-token hash block) hits were 3584-aligned instead of 64-aligned.

**Not a duplicate.** `gh pr list --repo vllm-project/vllm --state open --search "partial hash hits"`, `--search "prefix_cacheable"`, `--search "fine-grained hash"` (2026-09-01): I found no matching open PR in those searches; nearest is #54397 (fine-grained SWA hits, draft), which works on the SWA *manager's* lookup, not on the coordinator's group scoping. If #54397 lands and `SlidingWindowManager` gains fine-grained lookup, the negative control's precondition (`not swa_manager.supports_fine_grained_hash_lookup`) will need another prefix-cacheable manager without fine-grained lookup; test 1 is unaffected.

## Test Plan

```
.venv/bin/python -m pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py -v -k "fine_grained_hits or still_vetoes"
.venv/bin/python -m pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py -q
.venv/bin/python -m pytest tests/v1/core/test_contiguous_kv_packing.py -q
```

Mutation check: remove `and group.kv_cache_spec.prefix_cacheable` at `vllm/v1/core/kv_cache_coordinator.py:649` — `test_scratch_group_does_not_veto_fine_grained_hits` must fail and `test_prefix_cacheable_group_without_fine_lookup_still_vetoes` must still pass.

## Test Result

Run on an upstream-compatible CPU environment (macOS arm64, Python 3.13 venv, `torch` 2.13 CPU wheel, `requirements/common.txt`, `PYTHONPATH` at the clone @ `22df3a3` + this commit). The repo's root `tests/conftest.py` segfaults on this host while importing the full `LLM`/multimodal stack (unrelated to these tests), so the runs below use `--noconftest`; the test file is self-contained (its own autouse `init_none_hash` fixture, helpers from `tests.v1.core.test_prefix_caching`).

```
$ .venv/bin/python -m pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py -v -k "fine_grained_hits or still_vetoes" --noconftest
tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_scratch_group_does_not_veto_fine_grained_hits PASSED
tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_prefix_cacheable_group_without_fine_lookup_still_vetoes PASSED
2 passed, 40 deselected, 15 warnings in 3.64s

$ .venv/bin/python -m pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py -q --noconftest
42 passed, 15 warnings in 2.63s

$ .venv/bin/python -m pytest tests/v1/core/test_contiguous_kv_packing.py -q --noconftest
21 passed, 15 warnings in 2.53s
```

Mutation check — with `if group.kv_cache_spec.prefix_cacheable` replaced by `if True` at `vllm/v1/core/kv_cache_coordinator.py:649`:

```
>       assert coordinator.enable_partial_hash_hits
E       assert False
FAILED tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_scratch_group_does_not_veto_fine_grained_hits
1 failed, 1 passed, 40 deselected, 15 warnings in 2.54s
```

(the negative control still passes, as intended). Lint: `pre-commit run --files tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py` (ruff-check, ruff-format, typos, mypy, SPDX) — all passed.

## Model evaluation

Not applicable: no runtime code changes.

## AI assistance

Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai); drafted with AI assistance (Claude, with an independent adversarial review pass by OpenAI Codex folded in) and reviewed line by line by the submitter, who ran the tests listed above. Every `file:line` was checked against `22df3a3`.
