### PR TITLE
[MoE/B12X] Auto-select direct B12X NVFP4 MoE before Marlin

### DIFF
--- a/docs/features/quantization/b12x.md
+++ b/docs/features/quantization/b12x.md
@@ -7,9 +7,10 @@ NVIDIA SM120 and SM121 GPUs. Install the dependency with:
 uv pip install "vllm[b12x]"
 ```
 
-b12x linear kernels participate in automatic selection after established
-optimized backends and before emulation. Select the linear and MoE backends
-explicitly with:
+b12x linear and MoE kernels participate in automatic selection when the
+optional package is installed and the deployment is supported. They are tried
+after established optimized backends and before fallback or emulation kernels.
+Select either backend explicitly with:
 
 ```bash
 vllm serve <model> \

--- a/tests/kernels/moe/test_b12x.py
+++ b/tests/kernels/moe/test_b12x.py
@@ -574,6 +574,56 @@ def test_explicit_b12x_nvfp4_selection(
 
 
 @pytest.mark.parametrize(
+    "b12x_supported,expected_backend",
+    [
+        (True, NvFp4MoeBackend.B12X),
+        (False, NvFp4MoeBackend.MARLIN),
+    ],
+)
+def test_auto_b12x_nvfp4_selection_precedes_marlin(
+    monkeypatch: pytest.MonkeyPatch,
+    b12x_supported: bool,
+    expected_backend: NvFp4MoeBackend,
+) -> None:
+    selected_backends: list[NvFp4MoeBackend] = []
+
+    class CandidateExperts:
+        @staticmethod
+        def is_supported_config(
+            cls, config, weight_key, activation_key, activation_format
+        ):
+            backend = selected_backends[-1]
+            if backend == NvFp4MoeBackend.B12X:
+                return b12x_supported, None if b12x_supported else "unavailable"
+            if backend == NvFp4MoeBackend.MARLIN:
+                return True, None
+            return False, "unsupported in selector-order test"
+
+    def backend_to_kernel_cls(backend: NvFp4MoeBackend):
+        selected_backends.append(backend)
+        return [CandidateExperts]
+
+    monkeypatch.setattr(nvfp4_oracle, "backend_to_kernel_cls", backend_to_kernel_cls)
+    config = make_dummy_moe_config(hidden_dim=128, intermediate_size=64)
+
+    backend, experts_cls = select_nvfp4_moe_backend(
+        config,
+        weight_key=kNvfp4Static,
+        activation_key=None,
+    )
+
+    assert backend == expected_backend
+    assert experts_cls is CandidateExperts
+    assert NvFp4MoeBackend.B12X in selected_backends
+    if b12x_supported:
+        assert NvFp4MoeBackend.MARLIN not in selected_backends
+    else:
+        assert selected_backends.index(NvFp4MoeBackend.B12X) < selected_backends.index(
+            NvFp4MoeBackend.MARLIN
+        )
+
+
+@pytest.mark.parametrize(
     "force_a16,expected_quant_dtype", [(False, "nvfp4"), (True, None)]
 )
 def test_b12x_nvfp4_force_a16_updates_quant_config(

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -199,6 +199,11 @@ def select_nvfp4_moe_backend(
         NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
         NvFp4MoeBackend.FLASHINFER_CUTLASS,
         NvFp4MoeBackend.VLLM_CUTLASS,
+        # B12X is optional. Its support predicate checks that the package,
+        # device, quantization scheme, shape, and parallel configuration are
+        # all compatible, so an unavailable installation falls through
+        # without changing the existing Marlin fallback.
+        NvFp4MoeBackend.B12X,
         NvFp4MoeBackend.MARLIN,
         NvFp4MoeBackend.HUMMING,
         NvFp4MoeBackend.EMULATION,


### PR DESCRIPTION
## Summary

- consider the already-merged direct B12X NVFP4 MoE backend before Marlin during automatic backend selection
- preserve the existing B12X support predicate as the authority for package, device, quantization, shape, and parallel-configuration compatibility
- add selector-order coverage for both B12X acceptance and unsupported fall-through to Marlin
- document automatic B12X MoE selection

Related issue: #54666  
Related crash reports: #49926, #50925, #50934, #52225, #49070

## Why this is not a duplicate

#47577 auto-selects the older FlashInfer B12X implementation on exact SM120 and deliberately excludes SM121. This change exposes the newer direct B12X backend merged in #52018. Its existing support predicate covers both SM120 and SM121 and remains the sole compatibility authority.

No open pull request found in the duplicate search adds `NvFp4MoeBackend.B12X` to the automatic NVFP4 MoE preference list.

## Verification performed

- pre-commit checks passed for all three changed files: Ruff, formatting, typos, markdownlint, SPDX, and mypy
- focused SM121 GPU suite: 39/39 passed, covering selection, W4A16 correctness, and CUDA-graph replay
- explicit B12X Holo3.1 stress: 100/100 files, 524 tool calls, 18,499,772 prompt tokens, 106,838 generated tokens, peak engine concurrency 3, and no CUDA illegal-memory-access traceback
- automatic selection with this patch chose `B12X` while `moe_backend='auto'`, completed piecewise and full CUDA-graph capture, warmed the B12X MoE signature, and returned HTTP 200 from `/health`

The patch was rebased onto current `main`; none of the three affected files changed between the tested base and the current base.

## Limits

The measurements do not identify the specific Marlin instruction responsible for the asynchronous illegal-memory-access fault, nor do they establish multi-day B12X stability. They show that a supported, merged backend is currently unreachable through automatic selection on this deployment while the Marlin fallback repeatedly faults.

## AI-assistance disclosure

OpenAI Codex was used to develop, test, document, and prepare this change. This submission makes no claim of independent human line-by-line review; the full patch and evidence were first published for maintainer discussion in #54666.
