### PR TITLE
[Bugfix] Fix Step-3.5 MTP

### DIFF
--- a/tests/config/test_step3p5_mtp_config.py
+++ b/tests/config/test_step3p5_mtp_config.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Step3p5Config crops layer_types for HF strict validation and keeps
+the MTP tail in mtp_layer_types; SpeculativeConfig.hf_config_override
+re-appends the tail for the draft, whose MTP layers index layer_types
+at [num_hidden_layers + i] (#40000).
+"""
+
+from typing import Any
+
+import pytest
+from transformers import PretrainedConfig
+
+from vllm.config.speculative import SpeculativeConfig
+from vllm.transformers_utils.configs.step3p5 import Step3p5Config
+
+# Step-3.5-Flash layout: 45 main layers + 3 MTP layers.
+_MAIN = ["sliding_attention", "full_attention"] * 22 + ["sliding_attention"]
+_MTP = ["sliding_attention"] * 3
+
+
+def _step3p5_config(**kwargs: Any) -> Step3p5Config:
+    defaults: dict[str, Any] = dict(
+        architectures=["Step3p5ForCausalLM"],
+        num_hidden_layers=45,
+        num_nextn_predict_layers=3,
+        layer_types=_MAIN + _MTP,
+    )
+    defaults.update(kwargs)
+    return Step3p5Config(**defaults)
+
+
+@pytest.mark.cpu_test
+def test_step3p5_config_crops_and_keeps_mtp_tail():
+    config = _step3p5_config()
+
+    assert config.layer_types == _MAIN
+    assert config.mtp_layer_types == _MTP
+    # The cropped config must stay HF-strict-valid.
+    config.validate()
+
+
+@pytest.mark.cpu_test
+def test_hf_config_override_restores_mtp_layer_types():
+    out = SpeculativeConfig.hf_config_override(_step3p5_config())
+
+    assert out.model_type == "step3p5_mtp"
+    assert out.architectures == ["Step3p5MTP"]
+    # Every MTP index resolves to the checkpoint's real type.
+    assert out.layer_types == _MAIN + _MTP
+
+
+@pytest.mark.cpu_test
+def test_hf_config_override_raises_without_mtp_tail():
+    # Tail-less checkpoint: actionable error, not an IndexError at
+    # draft construction.
+    config = _step3p5_config(layer_types=_MAIN)
+
+    with pytest.raises(ValueError, match="num_nextn_predict_layers"):
+        SpeculativeConfig.hf_config_override(config)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("layer_types", [_MAIN + _MTP, _MAIN])
+def test_hf_config_override_ignores_foreign_configs(layer_types):
+    # Keyed on class, not list shape: a non-Step3p5Config (Step-3.7's hub
+    # text config, future models) passes through untouched, whether its
+    # layer_types is the full list or cropped.
+    config = PretrainedConfig(
+        architectures=["Step3p7ForConditionalGeneration"],
+        model_type="step3p7",
+        num_hidden_layers=45,
+        num_nextn_predict_layers=3,
+    )
+    config.layer_types = layer_types
+
+    out = SpeculativeConfig.hf_config_override(config)
+
+    assert out is config
+    assert out.layer_types == layer_types

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -931,6 +931,8 @@ class SpeculativeConfig:
         if hf_config.model_type in ("step3p5", "step3p7") or hf_config.architectures[
             0
         ] in ("Step3p5ForCausalLM", "Step3p7ForConditionalGeneration"):
+            from vllm.transformers_utils.configs.step3p5 import Step3p5Config
+
             quantization_config = getattr(hf_config, "quantization_config", None)
             hf_config = getattr(hf_config, "text_config", hf_config)
             if (
@@ -940,6 +942,25 @@ class SpeculativeConfig:
                 hf_config.update({"quantization_config": quantization_config})
             hf_config.model_type = "step3p5_mtp"
             n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
+            # MTP layers index layer_types at [num_hidden_layers + i], but
+            # Step3p5Config crops the list for HF validation and keeps the
+            # tail in mtp_layer_types; re-append it for the draft config.
+            # Keyed on the class, not model_type: Step-3.7's HF text config
+            # also declares "step3p5" but keeps its own full list.
+            if isinstance(hf_config, Step3p5Config):
+                layer_types = hf_config.layer_types
+                if layer_types is not None:
+                    mtp_layer_types = hf_config.mtp_layer_types
+                    if len(mtp_layer_types) < n_predict:
+                        raise ValueError(
+                            "Step-3.5 MTP needs one layer_types entry per "
+                            f"MTP layer, but the checkpoint's layer_types "
+                            f"has only {len(mtp_layer_types)} entries "
+                            f"beyond num_hidden_layers="
+                            f"{hf_config.num_hidden_layers} while "
+                            f"num_nextn_predict_layers={n_predict}."
+                        )
+                    hf_config.layer_types = [*layer_types, *mtp_layer_types]
             hf_config.update({"n_predict": n_predict, "architectures": ["Step3p5MTP"]})
 
         if initial_architecture == "MistralLarge3ForCausalLM":

--- a/vllm/model_executor/models/step3p5_mtp.py
+++ b/vllm/model_executor/models/step3p5_mtp.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, replace
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -154,10 +154,11 @@ class Step3p5AMultiTokenPredictor(nn.Module):
 class Step3p5MTP(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        self.config = vllm_config.model_config.hf_config
-        self.vllm_config = vllm_config
+        draft_model_config = vllm_config.speculative_config.draft_model_config
+        self.config = draft_model_config.hf_config
         self.model = Step3p5AMultiTokenPredictor(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+            vllm_config=replace(vllm_config, model_config=draft_model_config),
+            prefix=maybe_prefix(prefix, "model"),
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm/transformers_utils/configs/step3p5.py
+++ b/vllm/transformers_utils/configs/step3p5.py
@@ -80,9 +80,14 @@ class Step3p5Config(PretrainedConfig):
 
         self.att_impl_type = att_impl_type
         self.use_head_wise_attn_gate = use_head_wise_attn_gate
-        # For some reason the checkpoint has longer layer_types than num_hidden_layers
+        # Step-3.5 checkpoints extra MTP entries in layer_types beyond
+        # num_hidden_layers. Crop to pass HF validation; keep the MTP tail for
+        # SpeculativeConfig.hf_config_override to re-append it to the draft config.
         if layer_types is not None:
+            self.mtp_layer_types = layer_types[self.num_hidden_layers :]
             layer_types = layer_types[: self.num_hidden_layers]
+        else:
+            self.mtp_layer_types = []
         self.layer_types = layer_types
         self.use_rope_layers = use_rope_layers
         self.yarn_only_types = yarn_only_types


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/40000 (stale closed). Follows the dots3 `SpeculativeConfig.hf_config_override` approach suggested in https://github.com/vllm-project/vllm/pull/53174#pullrequestreview-5065402076 (the approach suggested here https://github.com/vllm-project/vllm/pull/49642#issuecomment-5209860046 breaks strict config validation).

In addition to the config fixes, need to update the Step3P5 MTP implementation to actually read the draft config instead of the target config (so that the `hf_config_overrides` can apply).

https://github.com/vllm-project/vllm/pull/40070 also fixes #40000. This PR patches via `hf_config_override` and updates the MTP model code. #40070 patches the config directly and updates the main model code. Either approach works. #40070 might even be cleaner because it's more concise. Up to the reviewer which one to merge.

## Test Plan

`pytest tests/config/test_step3p5_mtp_config.py `

```
chg run -g 4 -- vllm serve stepfun-ai/Step-3.5-Flash-FP8 \
  --tensor-parallel-size 4 \
  --enable-expert-parallel \
  --reasoning-parser step3p5 \
  --enable-auto-tool-choice \
  --tool-call-parser step3p5 \
  --speculative_config '{"method": "step3p5_mtp", "num_speculative_tokens": 1}' \
  --quantization fp8
```

## Test Result

`5 passed, 14 warnings`

Model now serves correctly


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Step-3.5-Flash configuration handling by preserving and restoring multi-token prediction layer settings.
  * Added validation for missing or insufficient multi-token prediction layers.
  * Ensured speculative decoding uses the correct draft model configuration.
  * Maintained compatibility with standard and Step-3.7 configurations.

* **Tests**
  * Added coverage for configuration validation, layer handling, HF overrides, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->