### PR TITLE
[Docs] Update supported Python versions to 3.10 -- 3.14

### DIFF
--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -30,7 +30,7 @@ When open a Github issue about the CPU backend, please add `[CPU Backend]` in th
 
 ## Requirements
 
-- Python: 3.10 -- 3.13
+- Python: 3.10 -- 3.14
 
 === "Intel/AMD x86"
 

--- a/docs/getting_started/installation/gpu.md
+++ b/docs/getting_started/installation/gpu.md
@@ -25,7 +25,7 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 ## Requirements
 
 - OS: Linux
-- Python: 3.10 -- 3.13
+- Python: 3.10 -- 3.14
 
 !!! note
     vLLM does not support Windows natively. To run vLLM on Windows, you can use the Windows Subsystem for Linux (WSL) with a compatible Linux distribution, or use some community-maintained forks, e.g. [https://github.com/SystemPanic/vllm-windows](https://github.com/SystemPanic/vllm-windows).

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -8,7 +8,7 @@ This guide will help you quickly get started with vLLM to perform:
 ## Prerequisites
 
 - OS: Linux
-- Python: 3.10 -- 3.13
+- Python: 3.10 -- 3.14
 
 !!! note
     vLLM also works on macOS with [vLLM-Metal](https://github.com/vllm-project/vllm-metal) for Apple Silicon GPU acceleration. See the [GPU installation guide](installation/gpu.md) and select the "Apple Silicon" tab.


### PR DESCRIPTION
## Purpose

Align getting started / install docs with `pyproject.toml`, which already supports Python 3.14.

On `main` (`45aed9b0cdbd281af6ba84ac124775f26b030879`), `pyproject.toml` has:

```toml
requires-python = ">=3.10,<3.15"
# classifiers include:
# "Programming Language :: Python :: 3.14"
```

but these docs still said `Python: 3.10 -- 3.13`:

- `docs/getting_started/quickstart.md`
- `docs/getting_started/installation/gpu.md`
- `docs/getting_started/installation/cpu.md`

This PR updates those three strings to `Python: 3.10 -- 3.14`. No code changes.

## Test Plan

```bash
# pyproject.toml on default branch
rg -n 'requires-python|Programming Language :: Python :: 3.1' pyproject.toml

# docs still listed 3.13 on main; should be 3.14 after this PR
rg -n 'Python: 3\.10' docs/getting_started/quickstart.md \
  docs/getting_started/installation/gpu.md \
  docs/getting_started/installation/cpu.md
```

## Test Result

- `pyproject.toml`: `requires-python = ">=3.10,<3.15"` and classifier `Python :: 3.14`
- Docs on `main`: `- Python: 3.10 -- 3.13`
- Docs in this PR: `- Python: 3.10 -- 3.14` (one-line change in each of the three files)

Signed-off-by: holegots <fuergaosi@gmail.com>