### PR TITLE
[Bugfix][Security] Fix catastrophic backtracking in the poolside_v1 and dots tool-call regexes

### DIFF
--- a/tests/tool_parsers/test_dots_tool_parser.py
+++ b/tests/tool_parsers/test_dots_tool_parser.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import time
 from collections.abc import Iterable
 from unittest.mock import MagicMock
 
@@ -273,3 +274,70 @@ def test_streaming_emits_complete_json_before_end_marker_without_duplication(
         '{"query": "chairs"}'
     )
     assert messages[-1].tool_calls == calls
+
+
+def test_unterminated_block_with_whitespace_is_not_cubic(
+    parser: DotsToolParser,
+) -> None:
+    """A short model output must not take seconds to parse.
+
+    ``_block_regex`` matched ``\\s*(.*?)\\s*`` between the markers. Under
+    ``DOTALL`` a dot matches a space too, so those three quantifiers competed
+    for the same run of spaces and a block with no closing marker after it
+    backtracked through every way of splitting that run: a ~3 KB model output
+    cost more than a minute of CPU on the event loop.
+    """
+    request = _request([_tool("get_weather", {"city": {"type": "string"}})])
+    model_output = DotsToolParser.tool_call_start_token + " " * 4096
+
+    start = time.perf_counter()
+    result = parser.extract_tool_calls(model_output, request)
+    elapsed = time.perf_counter() - start
+
+    assert not result.tools_called
+    assert result.content == model_output
+    # Before the fix this took minutes; a generous bound keeps the test stable
+    # on slow CI machines while still failing on the old behaviour.
+    assert elapsed < 5.0, f"parsing took {elapsed:.1f}s"
+
+
+def test_adjacent_blocks_still_parsed_separately(parser: DotsToolParser) -> None:
+    """The capture must stay lazy: a block ends at the *first* closing marker.
+
+    Guards the fix against a rewrite that lets one block swallow the next.
+    """
+    request = _request([_tool("get_weather", {"city": {"type": "string"}})])
+    block = "{}<invoke name=get_weather><parameter name=city>{}</parameter></invoke>{}"
+    model_output = block.format(
+        DotsToolParser.tool_call_start_token,
+        "Paris",
+        DotsToolParser.tool_call_end_token,
+    ) + block.format(
+        DotsToolParser.tool_call_start_token,
+        "Berlin",
+        DotsToolParser.tool_call_end_token,
+    )
+
+    result = parser.extract_tool_calls(model_output, request)
+
+    assert result.tools_called
+    assert len(result.tool_calls) == 2
+    assert json.loads(result.tool_calls[0].function.arguments) == {"city": "Paris"}
+    assert json.loads(result.tool_calls[1].function.arguments) == {"city": "Berlin"}
+
+
+def test_whitespace_padded_block_content_is_still_stripped(
+    parser: DotsToolParser,
+) -> None:
+    """Making the whitespace runs possessive must not change what is captured."""
+    request = _request([_tool("get_weather", {"city": {"type": "string"}})])
+    model_output = (
+        DotsToolParser.tool_call_start_token + "\n   <invoke name=get_weather>"
+        "<parameter name=city>Paris</parameter></invoke>   \n"
+        + DotsToolParser.tool_call_end_token
+    )
+
+    result = parser.extract_tool_calls(model_output, request)
+
+    assert result.tools_called
+    assert json.loads(result.tool_calls[0].function.arguments) == {"city": "Paris"}

--- a/tests/tool_parsers/test_poolside_v1_tool_parser.py
+++ b/tests/tool_parsers/test_poolside_v1_tool_parser.py
@@ -21,6 +21,7 @@ Covers two bugs:
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 
 from openai.types.responses.tool_param import FunctionToolParam
@@ -348,3 +349,62 @@ def test_streaming_responses_request_with_logprobs_emits_empty_delta() -> None:
     result = _stream_partial_start_token(request)
     assert result is not None
     assert result.content == ""
+
+
+def test_whitespace_padded_tool_call_is_not_quadratic() -> None:
+    """A short model output must not take seconds to parse.
+
+    ``func_detail_regex`` used to allow the captured function name to match
+    whitespace, which overlapped with the ``\\s*`` runs around it. On a block
+    that cannot match, the engine then backtracked through every way of
+    splitting one run of spaces between those quantifiers, so a ~3 KB model
+    output cost more than a minute of CPU on the event loop.
+    """
+    request = _build_weather_request(tool_choice="auto")
+    parser = _make_parser(request)
+
+    # ``<x`` keeps ``func_detail_regex`` from matching, which is what forces
+    # the backtracking; ``func_call_regex`` still yields the block.
+    model_output = "<tool_call>" + " " * 4096 + "<x</tool_call>"
+
+    start = time.perf_counter()
+    result = parser.extract_tool_calls(model_output, request)
+    elapsed = time.perf_counter() - start
+
+    assert not result.tools_called
+    assert result.content == model_output
+    # Before the fix this took >100s; a generous bound keeps the test stable
+    # on slow CI machines while still failing on the old behaviour.
+    assert elapsed < 5.0, f"parsing took {elapsed:.1f}s"
+
+
+def test_whitespace_only_tool_call_name_is_rejected() -> None:
+    """A tool call whose name is only whitespace is skipped, not emitted.
+
+    The previous regex matched here and produced a ``ToolCall`` with an empty
+    function name.
+    """
+    request = _build_weather_request(tool_choice="auto")
+    parser = _make_parser(request)
+
+    result = parser.extract_tool_calls("<tool_call>   </tool_call>", request)
+
+    assert not result.tools_called
+    assert result.tool_calls == []
+
+
+def test_function_name_with_internal_whitespace_still_parses() -> None:
+    """Pinning both ends of the name must not break names containing spaces."""
+    request = _build_weather_request(tool_choice="auto")
+    parser = _make_parser(request)
+
+    model_output = (
+        "<tool_call>  get weather  "
+        "<arg_key>city</arg_key><arg_value>Paris</arg_value>"
+        "</tool_call>"
+    )
+
+    result = parser.extract_tool_calls(model_output, request)
+
+    assert result.tools_called
+    assert result.tool_calls[0].function.name == "get weather"

--- a/vllm/tool_parsers/dots_tool_parser.py
+++ b/vllm/tool_parsers/dots_tool_parser.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import regex as re
 
+import vllm.envs as envs
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.generate.base.protocol import (
     DeltaFunctionCall,
@@ -49,8 +50,13 @@ class DotsToolParser(ToolParser):
     tool_call_start_token = "<dots_function_call>"
     tool_call_end_token = "</dots_function_call>"
 
+    # The whitespace runs are possessive. With `\s*` they overlap with the
+    # `.*?` between them -- under `DOTALL` a dot matches a space too -- so a
+    # run of spaces with no closing tag after it can be split between them in
+    # O(n^3) ways and a failing match walks all of them. `.*?` stays lazy so a
+    # block still ends at the *first* closing tag rather than the last.
     _block_regex = re.compile(
-        rf"{re.escape(tool_call_start_token)}\s*(.*?)\s*"
+        rf"{re.escape(tool_call_start_token)}\s*+(.*?)\s*+"
         rf"{re.escape(tool_call_end_token)}",
         re.DOTALL,
     )
@@ -167,7 +173,10 @@ class DotsToolParser(ToolParser):
         properties, defs = self._tool_schema(name, tools)
         arguments: dict[str, Any] = {}
 
-        for parameter in self._parameter_regex.finditer(match.group("body")):
+        for parameter in self._parameter_regex.finditer(
+            match.group("body"),
+            timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS,
+        ):
             param_name = self._extract_name(parameter.group("name"))
             value = parameter.group("value").strip()
             param_type: Any = "string"
@@ -188,7 +197,9 @@ class DotsToolParser(ToolParser):
         if content.startswith("<invoke"):
             return [
                 self._parse_xml_invoke(match, tools)
-                for match in self._invoke_regex.finditer(content)
+                for match in self._invoke_regex.finditer(
+                    content, timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS
+                )
             ]
 
         parsed = json.loads(content)
@@ -229,7 +240,22 @@ class DotsToolParser(ToolParser):
             )
 
         tool_calls: list[ToolCall] = []
-        for block in self._block_regex.finditer(model_output):
+        try:
+            blocks = list(
+                self._block_regex.finditer(
+                    model_output,
+                    timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS,
+                )
+            )
+        except TimeoutError:
+            logger.warning(
+                "Regex timeout occurred when extracting tool calls; "
+                "returning the model output as content."
+            )
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+        for block in blocks:
             try:
                 for parsed in self._parse_block(block.group(1), request.tools):
                     validated = self._validated_call(parsed, request.tools)
@@ -244,7 +270,7 @@ class DotsToolParser(ToolParser):
                             )
                         )
                     )
-            except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            except (json.JSONDecodeError, TypeError, ValueError, TimeoutError) as exc:
                 logger.warning("Failed to parse Dots tool call: %s", exc)
 
         normal_text = model_output[:marker_index].strip()
@@ -414,7 +440,7 @@ class DotsToolParser(ToolParser):
 
                 if not valid_calls and not block_had_streamed_call:
                     normal_parts.append(content.strip())
-            except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            except (json.JSONDecodeError, TypeError, ValueError, TimeoutError) as exc:
                 logger.warning("Failed to parse streamed Dots tool call: %s", exc)
                 normal_parts.append(content.strip())
 

--- a/vllm/tool_parsers/poolside_v1_tool_parser.py
+++ b/vllm/tool_parsers/poolside_v1_tool_parser.py
@@ -20,6 +20,7 @@ import regex as re
 from openai.types.responses import ToolChoiceFunction
 from partial_json_parser.core.options import Allow
 
+import vllm.envs as envs
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.generate.base.protocol import (
     DeltaFunctionCall,
@@ -75,8 +76,16 @@ class PoolsideV1ToolParser(ToolParser):
         self.tool_calls_start_token = self.tool_call_start_token
 
         self.func_call_regex = re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL)
+        # The function name is a run of non-`<`, non-newline characters that
+        # neither starts nor ends with whitespace. Pinning both ends matters:
+        # if the name could also match whitespace, it would overlap with the
+        # surrounding `\s*` and a long run of spaces could be split between
+        # them in O(n^3) ways, so a failing match backtracks through all of
+        # them. `\s` already covers `\n`, so no separate `\n?` is needed.
         self.func_detail_regex = re.compile(
-            r"<tool_call>\s*([^\n<]+?)\s*\n?\s*(<arg_key>.*?)?</tool_call>", re.DOTALL
+            r"<tool_call>\s*([^\s<](?:[^\n<]*[^\s<])?)\s*"
+            r"(<arg_key>.*?)?</tool_call>",
+            re.DOTALL,
         )
         self.func_arg_regex = re.compile(
             r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>", re.DOTALL
@@ -190,12 +199,15 @@ class PoolsideV1ToolParser(ToolParser):
         model_output: str,
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
-        matched_tool_calls = self.func_call_regex.findall(model_output)
         logger.debug("model_output: %s", model_output)
+        regex_timeout = envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS
         try:
+            matched_tool_calls = self.func_call_regex.findall(
+                model_output, timeout=regex_timeout
+            )
             tool_calls: list[ToolCall] = []
             for match in matched_tool_calls:
-                tc_detail = self.func_detail_regex.search(match)
+                tc_detail = self.func_detail_regex.search(match, timeout=regex_timeout)
                 if not tc_detail:
                     logger.warning(
                         "Failed to parse tool call details from: %s",
@@ -204,7 +216,11 @@ class PoolsideV1ToolParser(ToolParser):
                     continue
                 tc_name = tc_detail.group(1).strip()
                 tc_args = tc_detail.group(2)
-                pairs = self.func_arg_regex.findall(tc_args) if tc_args else []
+                pairs = (
+                    self.func_arg_regex.findall(tc_args, timeout=regex_timeout)
+                    if tc_args
+                    else []
+                )
                 arg_dct: dict[str, Any] = {}
                 for key, value in pairs:
                     arg_key = key.strip()
@@ -225,6 +241,14 @@ class PoolsideV1ToolParser(ToolParser):
                         ),
                     )
                 )
+        except TimeoutError:
+            logger.warning(
+                "Regex timeout occurred when extracting tool calls; "
+                "returning the model output as content."
+            )
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
         except Exception:
             logger.exception("Failed to extract tool call spec")
             return ExtractedToolCallInformation(


### PR DESCRIPTION
## Purpose

Two tool parsers have a regex that backtracks catastrophically, so a few
kilobytes of model output can burn minutes of CPU on the asyncio event loop.
Same defect class, same shape, so they are fixed together.

I found them by collecting every regex the parsers actually compile at runtime
(including the ones built with f-strings, which a source scan misses) and
running `regexploit` over the set. Out of 108 distinct patterns across
`vllm/tool_parsers`, `vllm/reasoning` and `vllm/parser`, exactly these two came
back, and both reproduce.

## 1. `PoolsideV1ToolParser.func_detail_regex`

`PoolsideV1ToolParser.func_detail_regex` backtracks catastrophically, so a few
kilobytes of model output can burn minutes of CPU on the asyncio event loop.

```python
self.func_detail_regex = re.compile(
    r"<tool_call>\s*([^\n<]+?)\s*\n?\s*(<arg_key>.*?)?</tool_call>", re.DOTALL
)
```

Five adjacent variable-length quantifiers, four of which can match a space — a
space satisfies both `\s` and `[^\n<]`. One run of *n* spaces can be divided
between them in O(n³) ways, so a block that ultimately fails to match forces the
engine through all of them.

Timings on the current `main`, following the parser's own call order
(`func_call_regex.findall` first, then `func_detail_regex.search` per block):

| model output | length | `func_detail_regex.search` |
| --- | --- | --- |
| `<tool_call>` + 400 spaces + `<x</tool_call>` | 425 | 0.16 s |
| `<tool_call>` + 800 spaces + `<x</tool_call>` | 825 | 1.13 s |
| `<tool_call>` + 1600 spaces + `<x</tool_call>` | 1625 | 9.67 s |
| `<tool_call>` + 3200 spaces + `<x</tool_call>` | 3225 | **67.28 s** |

Growth is roughly n^2.8, so ~6.4 KB is minutes and ~12.8 KB is about an hour.
`func_call_regex.findall` returns a *list*, so one response carrying ten such
blocks costs ten times as much.

The trailing `<` matters. `func_call_regex` guarantees every block it yields ends
in `</tool_call>`, so a block of nothing but spaces *matches* and returns
immediately. The blow-up needs the detail match to **fail**, and a single `<`
before the closing tag does that because `[^\n<]+?` cannot cross it. A block of
newlines fails too, but instantly (`\n` is excluded from `[^\n<]`), so those two
shapes behave very differently.

`regexploit` rates the pattern quartic:

```
Worst-case complexity: 4 ⭐⭐⭐⭐ (quartic)
Repeated character: [20,09,a0,[0b-0d]]
Example: '<tool_call>' + ' ' * 3456
```

### Why it reaches the event loop

`chat_completion_full_generator` (`vllm/entrypoints/openai/chat_completion/serving.py`)
calls `parser.parse(...)` inline in an `async def`, with no executor hand-off, so
the regex blocks every other request on that server for its duration. This is the
failure mode of #18304 ("tool parsers can block the async event loop"), which is
why `VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS` was added in #18960. Only five
parsers pass it today (`llama`, `olmo3`, `lfm2`, `llama4_pythonic`, `pythonic`);
`poolside_v1` does not.

The streaming path is unaffected — `extract_tool_calls_streaming` uses `str.find`.

This needs a server started with `--tool-call-parser poolside_v1`; it is not
reachable on a default configuration. Model output is attacker-influenced in the
usual way (asking the model to echo a string).

### The fix

Define the captured function name as a run of non-`<`, non-newline characters
that neither starts nor ends with whitespace, so it can no longer compete with
the `\s*` runs around it for the same spaces:

```python
r"<tool_call>\s*([^\s<](?:[^\n<]*[^\s<])?)\s*(<arg_key>.*?)?</tool_call>"
```

`\s` already covers `\n`, so the separate `\n?` was redundant and is gone.

I measured the alternatives rather than guessing:

| candidate | semantics on the existing cases | `<tool_call>` + 6400 spaces + `<x</tool_call>` |
| --- | --- | --- |
| current pattern | ok | 3200 → 70.8 s |
| drop the redundant `\n?\s*` only | ok | 3200 → 67.6 s (**no help**) |
| possessive `\s*+` | ok | 0.0000 s |
| **name pinned at both ends (this PR)** | ok | 0.0002 s |

I picked the last one because it is ordinary regex syntax rather than a
`regex`-module possessive quantifier, and it states what a function name is
allowed to look like, which is easier to review.

Second, the three regex calls in `extract_tool_calls` now pass
`timeout=envs.VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS` and there is an explicit
`except TimeoutError` branch, matching the five parsers that already do this.
`func_call_regex.findall` also moves inside the `try`, so a timeout there
degrades to "no tool calls, return the output as content" instead of a 500. This
is belt-and-braces: with the new pattern the timeout should not fire, but it
bounds `func_arg_regex` too, which is quadratic on pathological input
(256 KB of `<arg_key>x</arg_key>` repeats takes ~16 s).

### One behaviour change

A block whose name is only whitespace (`<tool_call>   </tool_call>`) previously
matched, and `group(1).strip()` produced a `ToolCall` with an **empty function
name**. It no longer matches, so the block is skipped through the existing
"Failed to parse tool call details" warning. I think emitting a nameless tool
call was a bug, but it is a change, so there is a test pinning the new behaviour.

## 2. `DotsToolParser._block_regex`

```python
_block_regex = re.compile(
    rf"{re.escape(tool_call_start_token)}\s*(.*?)\s*"
    rf"{re.escape(tool_call_end_token)}",
    re.DOTALL,
)
```

Under `DOTALL` a dot matches a space, so the two `\s*` runs and the `.*?`
between them all compete for the same run of spaces. This one is easier to reach
than the poolside case: `extract_tool_calls` runs `finditer` on the raw model
output with no pre-filter, so **no closing marker is needed at all**.

| model output | length | `_block_regex.finditer` |
| --- | --- | --- |
| `<dots_function_call>` + 200 spaces | 220 | 0.02 s |
| `<dots_function_call>` + 800 spaces | 820 | 1.06 s |
| `<dots_function_call>` + 1600 spaces | 1620 | 8.25 s |
| `<dots_function_call>` + 3200 spaces | 3220 | **66.21 s** |

The same output *with* a closing marker matches immediately (0.0000 s at 6400
spaces), so this only bites when the block never terminates.
`_invoke_regex` and `_parameter_regex` are linear and were left alone
(6400-space inputs: 0.0001 s and 0.0000 s).

Here the fix is possessive whitespace runs. `.*?` has to stay **lazy** so a
block still ends at the *first* closing marker; the "pin the capture at both
ends" shape used for poolside makes one block swallow the next, which I only
caught because the candidate comparison included an adjacent-blocks case:

| candidate | semantics (7 cases incl. adjacent blocks) | 12800 spaces, no closing marker |
| --- | --- | --- |
| current pattern | ok | 3200 → 73.96 s |
| pin capture at both ends | **breaks adjacent blocks** | 1.08 s |
| **possessive `\s*+` (this PR)** | ok | 0.0001 s |

`TimeoutError` is also added to the exception tuples that already degrade a
failed parse to content, in both the streaming and non-streaming paths, so a
timeout cannot escape as a 500.

## Test Plan

```bash
pytest tests/tool_parsers/test_poolside_v1_tool_parser.py \
       tests/tool_parsers/test_dots_tool_parser.py -v
```

Three tests added to `test_poolside_v1_tool_parser.py`:

- `test_whitespace_padded_tool_call_is_not_quadratic` — the attack shape at 4096
  spaces must parse in under 5 s (it takes minutes on `main`)
- `test_whitespace_only_tool_call_name_is_rejected` — pins the behaviour change
- `test_function_name_with_internal_whitespace_still_parses` — pinning both ends
  of the name must not break names that contain spaces

Three tests added to `test_dots_tool_parser.py`:

- `test_unterminated_block_with_whitespace_is_not_cubic` — the attack shape at
  4096 spaces must parse in under 5 s
- `test_adjacent_blocks_still_parsed_separately` — pins the laziness, so a future
  rewrite cannot let one block swallow the next
- `test_whitespace_padded_block_content_is_still_stripped` — possessive runs must
  not change what is captured

I also ran a differential fuzz of the old and new poolside patterns over 200k randomly
assembled inputs (fragments: `<tool_call>`, `</tool_call>`, `<arg_key>`, spaces,
tabs, `\xa0`, newlines, `<`, `>`), comparing `group(1).strip()` and `group(2)`
exactly as the parser uses them.

## Test Result

With the fix, both files pass:

```
$ pytest tests/tool_parsers/test_dots_tool_parser.py \
         tests/tool_parsers/test_poolside_v1_tool_parser.py -q
29 passed, 15 warnings in 14.29s
```

Reverting only `vllm/tool_parsers/poolside_v1_tool_parser.py` to `main` and
running just the three new tests:

```
$ pytest tests/tool_parsers/test_poolside_v1_tool_parser.py -q \
    -k "whitespace_padded or whitespace_only or internal_whitespace"
FAILED ...::test_whitespace_padded_tool_call_is_not_quadratic
FAILED ...::test_whitespace_only_tool_call_name_is_rejected
2 failed, 1 passed, 13 deselected, 15 warnings in 152.83s (0:02:32)
```

Two things to note there. Those three tests take **152 s** on `main` and 13 s for
the whole 16-test file after the fix — nearly all of it is the one 4096-space
input. And `test_whitespace_only_tool_call_name_is_rejected` fails on `main` with

```
ExtractedToolCallInformation(
    tools_called=True,
    tool_calls=[ToolCall(..., function=FunctionCall(name='', arguments='{}'))],
    content=None,
)
```

which is the nameless tool call described above.
`test_function_name_with_internal_whitespace_still_parses` passes both before and
after, so pinning both ends of the name did not break names containing spaces.

Same exercise for the dots parser — revert only
`vllm/tool_parsers/dots_tool_parser.py` to `main`:

```
$ pytest tests/tool_parsers/test_dots_tool_parser.py -q \
    -k "unterminated_block or adjacent_blocks or whitespace_padded_block"
FAILED ...::test_unterminated_block_with_whitespace_is_not_cubic
1 failed, 2 passed, 10 deselected, 15 warnings in 141.56s (0:02:21)
```

The two guard tests pass before and after, which is what makes them useful: they
pin the behaviour the rewrite had to preserve.

Differential fuzz over 200k random inputs, old pattern vs new, comparing
`group(1).strip()` and `group(2)`:

```
blocks compared: same=6578  diff=713  old-pattern timeouts=0
```

All 713 differences are the whitespace-only-name case above — the old pattern
returns `('', None)`, the new one does not match. No other divergence.

`pre-commit`-relevant checks on the touched files:

```
$ ruff check <the four touched files>       # All checks passed!
$ ruff format --check <the four touched files>  # 4 files already formatted
```

The repo's local pre-commit hooks also pass on the touched files
(`check_spdx_header`, `check_init_lazy_imports`, `check_forbidden_imports`,
`check_torch_cuda`, `check_boolean_context_manager`).

