### PR TITLE
[Bugfix][Security] Bound the validation-error response body

### DIFF
--- a/tests/entrypoints/serve/exception_handling/test_validation_exception_handler.py
+++ b/tests/entrypoints/serve/exception_handling/test_validation_exception_handler.py
@@ -239,3 +239,33 @@ class TestValidationErrorBodyIsBounded:
 
         assert "not-a-list" in message
         assert "[truncated]" not in message
+
+    @pytest.mark.asyncio
+    async def test_union_loc_is_cleaned_in_the_message(self):
+        """A union-typed field spells every branch out in `loc`.
+
+        Left raw, that is ~800 characters of type names per entry and it
+        dominates the bounded message. `param` is already cleaned this way.
+        """
+        loc = (
+            "body",
+            "input",
+            "list[union[EasyInputMessageParam,Message,ResponseOutputMessageParam]]",
+            0,
+            "content",
+        )
+        errors = [
+            {
+                "type": "string_type",
+                "loc": loc,
+                "msg": "Input should be a valid string",
+                "input": 12345,
+            }
+        ]
+        exc = RequestValidationError(errors)
+
+        response = await validation_exception_handler(_fake_request(), exc)
+        message = json.loads(response.body)["error"]["message"]
+
+        assert "'loc': 'body.input.0.content'" in message
+        assert "EasyInputMessageParam" not in message

--- a/tests/entrypoints/serve/exception_handling/test_validation_exception_handler.py
+++ b/tests/entrypoints/serve/exception_handling/test_validation_exception_handler.py
@@ -151,3 +151,91 @@ class TestValidationErrorDoesNotLeakServerPaths:
 
         assert "missing" in message
         assert "Field required" in message
+
+
+class TestValidationErrorBodyIsBounded:
+    """A malformed request must not produce an unbounded 400 body.
+
+    Pydantic repeats the whole offending value under `input` in every
+    error entry, so an input that fails per-element echoes itself once
+    per error. On `/v1/responses` a 4,475-byte body produced 12,001
+    errors and a 23.6 MB response before this was bounded. See #49239.
+    """
+
+    @pytest.mark.asyncio
+    async def test_many_errors_are_capped(self):
+        big_input = [{"type": "input_text", "text": 1} for _ in range(500)]
+        errors = [
+            {
+                "type": "string_type",
+                "loc": ("body", "input", i),
+                "msg": "Input should be a valid string",
+                "input": big_input,
+            }
+            for i in range(5000)
+        ]
+        exc = RequestValidationError(errors)
+
+        response = await validation_exception_handler(_fake_request(), exc)
+        body = json.loads(response.body)
+        message = body["error"]["message"]
+
+        assert len(response.body) < 32_000, f"body was {len(response.body)} bytes"
+        # The true count is still reported, and the remainder acknowledged.
+        assert message.startswith("5000 validation errors:")
+        assert "more errors" in message
+
+    @pytest.mark.asyncio
+    async def test_container_input_is_described_not_echoed(self):
+        errors = [
+            {
+                "type": "string_type",
+                "loc": ("body", "input"),
+                "msg": "Input should be a valid string",
+                "input": [{"text": "payload"} for _ in range(300)],
+            }
+        ]
+        exc = RequestValidationError(errors)
+
+        response = await validation_exception_handler(_fake_request(), exc)
+        message = json.loads(response.body)["error"]["message"]
+
+        assert "<list of 300 items>" in message
+        assert "payload" not in message
+
+    @pytest.mark.asyncio
+    async def test_long_string_input_is_truncated(self):
+        errors = [
+            {
+                "type": "int_type",
+                "loc": ("body", "max_tokens"),
+                "msg": "Input should be a valid integer",
+                "input": "A" * 100_000,
+            }
+        ]
+        exc = RequestValidationError(errors)
+
+        response = await validation_exception_handler(_fake_request(), exc)
+        message = json.loads(response.body)["error"]["message"]
+
+        assert "[truncated]" in message
+        assert len(message) < 4_000
+
+    @pytest.mark.asyncio
+    async def test_small_input_is_still_reported_verbatim(self):
+        """Bounding must not cost legitimate clients their diagnostics."""
+        errors = [
+            {
+                "type": "list_type",
+                "loc": ("body", "messages"),
+                "msg": "Input should be a valid list",
+                "input": "not-a-list",
+            }
+        ]
+        exc = RequestValidationError(errors)
+
+        response = await validation_exception_handler(_fake_request(), exc)
+        message = json.loads(response.body)["error"]["message"]
+
+        assert "not-a-list" in message
+        assert "[truncated]" not in message

--- a/vllm/entrypoints/serve/exception_handling/handlers/validation.py
+++ b/vllm/entrypoints/serve/exception_handling/handlers/validation.py
@@ -108,8 +108,16 @@ def _summarize_error_input(value: object) -> object:
 
 def _format_error(err: object) -> str:
     """Render one validation error, bounded in size."""
-    if isinstance(err, dict) and "input" in err:
-        err = {**err, "input": _summarize_error_input(err["input"])}
+    if isinstance(err, dict):
+        err = dict(err)
+        if "input" in err:
+            err["input"] = _summarize_error_input(err["input"])
+        loc = err.get("loc")
+        if isinstance(loc, (tuple, list)):
+            # For a union-typed field pydantic spells every branch out in
+            # `loc`, which is ~800 characters of type names per entry here.
+            # `param` is already cleaned this way.
+            err["loc"] = clean_loc_for_param(tuple(loc))
     text = str(err)
     if len(text) > _MAX_ERROR_CHARS:
         text = text[:_MAX_ERROR_CHARS] + "...[truncated]"

--- a/vllm/entrypoints/serve/exception_handling/handlers/validation.py
+++ b/vllm/entrypoints/serve/exception_handling/handlers/validation.py
@@ -70,6 +70,52 @@ _INTERNAL_LOC_MARKERS = frozenset(
 )
 
 
+# Pydantic repeats the whole offending value under `input` in *every*
+# error entry, so one malformed request whose input fails per-element
+# echoes that input once per error. Measured on `/v1/responses`: a
+# 4,475-byte body produced 12,001 errors and a 23.6 MB response, an
+# amplification of ~5,300x that scales linearly with the request size.
+# Bound both the number of entries reported and the value echoed in each.
+_MAX_REPORTED_ERRORS = 10
+_MAX_ERROR_INPUT_CHARS = 200
+_MAX_ERROR_CHARS = 1000
+
+
+def _summarize_error_input(value: object) -> object:
+    """A size-bounded stand-in for a validation error's `input` value.
+
+    Containers are described rather than rendered: `repr()` of a large
+    list materializes the whole string first, which is the cost this is
+    meant to avoid.
+    """
+    if isinstance(value, str):
+        if len(value) > _MAX_ERROR_INPUT_CHARS:
+            return value[:_MAX_ERROR_INPUT_CHARS] + "...[truncated]"
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return f"<{type(value).__name__} of {len(value)} bytes>"
+    if isinstance(value, (list, tuple, set, frozenset, dict)):
+        return f"<{type(value).__name__} of {len(value)} items>"
+    try:
+        text = str(value)
+    except Exception:
+        # e.g. an int past `sys.get_int_max_str_digits()`.
+        return f"<{type(value).__name__}>"
+    if len(text) > _MAX_ERROR_INPUT_CHARS:
+        return text[:_MAX_ERROR_INPUT_CHARS] + "...[truncated]"
+    return text
+
+
+def _format_error(err: object) -> str:
+    """Render one validation error, bounded in size."""
+    if isinstance(err, dict) and "input" in err:
+        err = {**err, "input": _summarize_error_input(err["input"])}
+    text = str(err)
+    if len(text) > _MAX_ERROR_CHARS:
+        text = text[:_MAX_ERROR_CHARS] + "...[truncated]"
+    return text
+
+
 def _is_internal_loc_segment(segment: str) -> bool:
     """True if `segment` is a Pydantic-internal wrapper/union-branch
     marker rather than a user-meaningful field name or list index."""
@@ -121,8 +167,11 @@ async def validation_exception_handler(req: Request, exc: RequestValidationError
     if errors:
         count = len(errors)
         label = "error" if count == 1 else "errors"
+        reported = errors[:_MAX_REPORTED_ERRORS]
         message = f"{count} validation {label}:\n"
-        message += "".join(f"  {err}\n" for err in errors)
+        message += "".join(f"  {_format_error(err)}\n" for err in reported)
+        if count > len(reported):
+            message += f"  ...and {count - len(reported)} more {label}\n"
         message = message.rstrip()
     else:
         message = "Validation error"


### PR DESCRIPTION
## Purpose

Fixes #49239.

`validation_exception_handler` renders **every** entry of `exc.errors()` into the
400 body:

```python
message = f"{count} validation {label}:\n"
message += "".join(f"  {err}\n" for err in errors)
```

Pydantic puts the whole offending value under `input` in *each* error entry, so a
request whose `input` fails per-element echoes that input once per error. The
response grows with `request_size × error_count` while the request stays small.

Measured on `main` by validating a malformed `/v1/responses` body with the real
`ResponsesRequest` model and passing the resulting errors to the real handler:

| `input` items | request bytes | errors | response bytes | amplification | handler time |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 114 | 241 | 473,222 | 4,151x | 0.011 s |
| 10 | 915 | 2,401 | 4,729,926 | 5,169x | 0.091 s |
| 50 | 4,475 | 12,001 | 23,658,207 | 5,287x | 0.488 s |
| 200 | 17,825 | 48,001 | 94,663,257 | 5,311x | 1.986 s |
| 800 | 71,225 | 192,001 | 378,731,458 | 5,317x | 7.024 s |

The amplification factor is flat at ~5,300x, so it scales linearly with request
size: whatever body limit sits in front of the server, the 400 is ~5,000 times
larger. The reporter observed 12,047 errors and a ~114 MB body in production,
which stalled the proxy in front of vLLM.

There is a second cost on the server itself. Building the string is `O(request ×
errors)`, and `sanitize_message` then runs several regexes over the whole thing —
7 seconds of event-loop time at 800 items, for a request that is only 71 KB.

### The fix

Bound both factors in the handler:

- report at most `_MAX_REPORTED_ERRORS` (10) entries, then `...and N more errors`
  — the true count still leads the message, so nothing is hidden
- replace each entry's `input` with a bounded summary before rendering
- cap each rendered entry at `_MAX_ERROR_CHARS` (1000) as a backstop, since
  `loc` tuples for union-typed fields are long on their own

`_summarize_error_input` *describes* containers (`<list of 300 items>`) instead of
rendering them. That is deliberate: `repr()` of a large list materializes the
whole string first, which is exactly the cost being avoided. Strings are sliced
before being rendered, and `str()` on a scalar is wrapped because it can raise —
an integer past `sys.get_int_max_str_digits()` would otherwise turn the error
handler itself into a 500.

A union-typed field is also spelled out branch-by-branch in `loc` — ~800
characters of type names per entry on `/v1/responses`, which dominated what was
left. `clean_loc_for_param` already exists in this module and is already applied
to `param` for exactly that reason, so the rendered `loc` now goes through it
too. That is what turns the entry from noise into something a caller can act on.

After the fix the same measurement is flat:

| `input` items | request bytes | errors | response bytes | handler time |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 114 | 241 | 2,386 | 0.002 s |
| 50 | 4,475 | 12,001 | 2,391 | 0.003 s |
| 800 | 71,225 | 192,001 | 2,394 | 0.022 s |

Small `input` values are still echoed verbatim, so a client debugging a genuine
mistake loses nothing.

### What the error body actually looks like

Requested by @DarkLight1337. Produced by validating a malformed body with the
real `ResponsesRequest` model and passing the result to the real handler; only
line-wrapping and the `<...>` elisions are mine.

**Case A — the shape from #49239**: `/v1/responses` with `input` = 50
message-shaped objects whose `content[].text` is an int instead of a string.
Request body is 4,475 bytes and produces 12,001 validation errors.

Before — **23,658,207 bytes**:

```
12001 validation errors:
  {'type': 'string_type', 'loc': ('input', 'str'), 'msg': 'Input should be a valid string', 'input': [{'type': 'message', 'role': 'user', 'content': [{'type': 'input_text', 'text': 12345}]}, {'type': 'message', 'role': ' <...4389 more chars on this line: the whole input, again...>
  {'type': 'string_type', 'loc': ('input', 'list[union[EasyInputMessageParam,Message,ResponseOutputMessageParam,ResponseFileSearchToolCallParam,ResponseComputerToolCallParam,ComputerCallOutput,ResponseFunctionWebSearchPa <...1379 more chars...>
  {'type': 'string_type', 'loc': ('input', 'list[union[EasyInputMessageParam,Message,ResponseOutputMessageParam,ResponseFileSearchToolCallParam,ResponseComputerToolCallParam,ComputerCallOutput,ResponseFunctionWebSearchPa <...1461 more chars...>
  <...11,997 more lines...>
  {'type': 'missing', 'loc': ('input', 'list[union[EasyInputMessageParam,Message,ResponseOutputMessageParam,... <...>
```

After — **2,391 bytes**:

```
12001 validation errors:
  {'type': 'string_type', 'loc': 'input', 'msg': 'Input should be a valid string', 'input': '<list of 50 items>', 'url': 'https://errors.pydantic.dev/2.13/v/string_type'}
  {'type': 'string_type', 'loc': 'input.0.EasyInputMessageParam.content', 'msg': 'Input should be a valid string', 'input': '<list of 1 items>', 'url': 'https://errors.pydantic.dev/2.13/v/string_type'}
  {'type': 'string_type', 'loc': 'input.0.EasyInputMessageParam.content.0.ResponseInputTextParam.text', 'msg': 'Input should be a valid string', 'input': '12345', 'url': 'https://errors.pydantic.dev/2.13/v/string_type'}
  <...7 more entries...>
  ...and 11991 more errors
```

The third entry is the actual mistake, and it now names the field and shows the
offending value.

**Case B — an ordinary small mistake**: `{"model": "m", "input": 123}`.

Before — 1,769 bytes:

```
2 validation errors:
  {'type': 'string_type', 'loc': ('input', 'str'), 'msg': 'Input should be a valid string', 'input': 123, 'url': 'https://errors.pydantic.dev/2.13/v/string_type'}
  {'type': 'list_type', 'loc': ('input', 'list[union[EasyInputMessageParam,Message,ResponseOutputMessageParam,ResponseFileSearchToolCallParam,ResponseComputerToolCallParam,ComputerCallOutput,ResponseFunctionWebSearchPara <...1291 more chars...>
```

After — 400 bytes:

```
2 validation errors:
  {'type': 'string_type', 'loc': 'input', 'msg': 'Input should be a valid string', 'input': '123', 'url': 'https://errors.pydantic.dev/2.13/v/string_type'}
  {'type': 'list_type', 'loc': 'input', 'msg': 'Input should be a valid list', 'input': '123', 'url': 'https://errors.pydantic.dev/2.13/v/list_type'}
```

The value is still there; nothing a caller needs was dropped.

This handler is registered for `RequestValidationError` app-wide, so the bound
applies to every endpoint, not just `/v1/responses`.

I checked for overlap: #52120 also touches validation-error handling but changes
`sanitize_message`'s regex in `vllm/entrypoints/serve/utils/api_utils.py`, a
different file and a different problem (ReDoS in the sanitizer). The two are
complementary — bounding the message before it reaches the sanitizer reduces the
input that PR has to sanitize. #45390 adds request input-size bounds in
`sampling_params.py`/`protocol.py`, also disjoint.

## Test Plan

```bash
pytest tests/entrypoints/serve/exception_handling/ -v
```

Four tests added to the existing file as `TestValidationErrorBodyIsBounded`:

- `test_many_errors_are_capped` — 5,000 errors each carrying a 500-item input;
  the whole body must stay under 32 KB and still report the real count
- `test_container_input_is_described_not_echoed` — a 300-item list becomes
  `<list of 300 items>` and its contents do not appear
- `test_long_string_input_is_truncated` — a 100 KB string input is truncated
- `test_small_input_is_still_reported_verbatim` — the diagnostics a legitimate
  client needs are unchanged
- `test_union_loc_is_cleaned_in_the_message` — a union `loc` renders as
  `body.input.0.content`, not 800 characters of branch names

## Test Result

Whole directory passes with the fix:

```
$ pytest tests/entrypoints/serve/exception_handling/ -q
44 passed, 15 warnings in 11.36s
```

Reverting only `handlers/validation.py` to `main` and running the new class:

```
$ pytest .../test_validation_exception_handler.py -q -k TestValidationErrorBodyIsBounded
FAILED ...::test_many_errors_are_capped
FAILED ...::test_container_input_is_described_not_echoed
FAILED ...::test_long_string_input_is_truncated
3 failed, 1 passed, 12 deselected, 15 warnings in 5.14s
```

`test_small_input_is_still_reported_verbatim` passes both before and after, which
is the point — the bound does not cost legitimate clients their diagnostics.

```
$ ruff check <touched files>          # All checks passed!
$ ruff format --check <touched files> # 2 files already formatted
```
