### PR TITLE
[Docs] Use current Qwen3-0.6B HuggingFace id in Open WebUI guide

### DIFF
--- a/docs/deployment/frameworks/open-webui.md
+++ b/docs/deployment/frameworks/open-webui.md
@@ -12,7 +12,7 @@ To get started with Open WebUI using vLLM, follow these steps:
 2. Start the vLLM server with a supported chat completion model:
 
     ```console
-    vllm serve Qwen/Qwen3-0.6B-Chat
+    vllm serve Qwen/Qwen3-0.6B
     ```
 
     !!! note
@@ -37,6 +37,6 @@ To get started with Open WebUI using vLLM, follow these steps:
 
 4. Open it in the browser: <http://open-webui-host:3000/>
 
-    At the top of the page, you should see the model `Qwen/Qwen3-0.6B-Chat`.
+    At the top of the page, you should see the model `Qwen/Qwen3-0.6B`.
 
-    ![Web portal of model Qwen/Qwen3-0.6B-Chat](../../assets/deployment/open_webui.png)
+    ![Web portal of model Qwen/Qwen3-0.6B](../../assets/deployment/open_webui.png)


### PR DESCRIPTION
## Purpose

`docs/deployment/frameworks/open-webui.md` still uses the stale HuggingFace id `Qwen/Qwen3-0.6B-Chat`. The current model name is `Qwen/Qwen3-0.6B` (no `-Chat`).

## Reproduce

On `main` (`188716ace7475593dc22f8a72bf1d692f5c9b5ee`), the Open WebUI guide still says:

```console
vllm serve Qwen/Qwen3-0.6B-Chat
```

and later:

```
At the top of the page, you should see the model `Qwen/Qwen3-0.6B-Chat`.
```

Neighboring vLLM docs already use the current id. For example, `docs/features/reasoning_outputs.md`:

```bash
vllm serve Qwen/Qwen3-0.6B \
    --reasoning-parser qwen3 \
```

and `docs/features/sleep_mode.md`:

```python
llm = LLM("Qwen/Qwen3-0.6B", enable_sleep_mode=True)
```

HuggingFace also publishes the model as [`Qwen/Qwen3-0.6B`](https://huggingface.co/Qwen/Qwen3-0.6B). There is no current `Qwen/Qwen3-0.6B-Chat` repo.

## Change

Replace `Qwen/Qwen3-0.6B-Chat` with `Qwen/Qwen3-0.6B` in the Open WebUI deployment guide (serve command, expected UI model name, and image alt text).