### PR TITLE
Fix DSML leaking for DeepSeek-v4 models

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -3,6 +3,7 @@
 """Tests for DeepSeek V4-specific parser engine semantics."""
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -1391,3 +1392,62 @@ class TestMalformedDsmlNoise:
         assert output.tool_calls[0]["name"] == "get_weather"
         assert json.loads(output.tool_calls[0]["arguments"]) == {"city": "Seoul"}
         assert "DSML" not in (output.content or "")
+
+
+# ── Tool-call closer as a sampling stop ───────────────────────────────
+
+
+class TestToolCallStop:
+    """The closing tool_calls tag must end the turn.
+
+    Without it the sampler keeps going after a complete tool-call block and
+    the model opens another one, repeatedly, until it hits max_tokens.
+    """
+
+    def _engine(self, mock_tokenizer):
+        return DeepSeekV4Parser(mock_tokenizer)
+
+    def _request(self, stop=None, tools=True):
+        req = MagicMock()
+        req.tools = [{"type": "function"}] if tools else None
+        req.stop = stop
+        req.include_stop_str_in_output = False
+        return req
+
+    def test_exposes_the_block_closer(self, mock_tokenizer):
+        assert self._engine(mock_tokenizer).tool_call_stop == DSML_TOOL_END
+
+    def test_adjust_request_sets_the_stop(self, mock_tokenizer):
+        """The unified parser is what serves deepseek_v4.
+
+        It is used directly as the Parser -- ``tool_parser_cls`` is None and
+        no ParserEngineToolAdapter is ever built -- so a hook that lives only
+        on the adapter never runs for this model.
+        """
+        req = self._engine(mock_tokenizer).adjust_request(self._request([]))
+        assert req.stop == [DSML_TOOL_END]
+        assert req.include_stop_str_in_output is True
+
+    def test_closer_is_added_and_kept_in_output(self, mock_tokenizer):
+        req = self._engine(mock_tokenizer)._add_tool_call_stop(self._request([]))
+        assert req.stop == [DSML_TOOL_END]
+        # the parser still has to see the closer to finish the call
+        assert req.include_stop_str_in_output is True
+
+    def test_preserves_caller_supplied_stops(self, mock_tokenizer):
+        e = self._engine(mock_tokenizer)
+        assert e._add_tool_call_stop(self._request(["A"])).stop == ["A", DSML_TOOL_END]
+        assert e._add_tool_call_stop(self._request("A")).stop == ["A", DSML_TOOL_END]
+
+    def test_idempotent(self, mock_tokenizer):
+        req = self._engine(mock_tokenizer)._add_tool_call_stop(
+            self._request([DSML_TOOL_END])
+        )
+        assert req.stop == [DSML_TOOL_END]
+
+    def test_untouched_without_tools(self, mock_tokenizer):
+        req = self._engine(mock_tokenizer)._add_tool_call_stop(
+            self._request([], tools=False)
+        )
+        assert req.stop == []
+        assert req.include_stop_str_in_output is False

--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -524,10 +524,13 @@ def test_get_structural_tag_disables_reasoning(
     assert captured == [False]
 
 
-def test_unified_parser_get_structural_tag_disables_reasoning(
+@pytest.mark.parametrize("emits_reasoning_span", [False, True])
+def test_unified_parser_get_structural_tag_reasoning_follows_reasoning_parser(
     monkeypatch: pytest.MonkeyPatch,
     sample_tools_strict: list[ChatCompletionToolsParam],
+    emits_reasoning_span: bool,
 ):
+    """The tag's reasoning span must match the request's thinking mode."""
     captured: list[bool] = []
 
     def fake_get_model_structural_tag(*, reasoning: bool, **kwargs):
@@ -549,11 +552,14 @@ def test_unified_parser_get_structural_tag_disables_reasoning(
         tool_choice="auto",
     )
     parser = TestParser(MagicMock(), tools=sample_tools_strict)
-    parser.reasoning_parser = MagicMock(adjust_request=lambda request: request)
+    parser.reasoning_parser = MagicMock(
+        adjust_request=lambda request: request,
+        emits_reasoning_span=emits_reasoning_span,
+    )
 
     parser.adjust_request(request)
 
-    assert captured == [False]
+    assert captured == [emits_reasoning_span]
 
 
 def test_xgrammar_function_parameters_are_preserved(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -578,9 +578,18 @@ class DelegatingParser(Parser):
         if not need_tool_calling:
             return request
 
+        # The two grammars are not interchangeable: with reasoning=False the
+        # free-text span carries excludes=['<think>', '</think>'], so a model
+        # whose prompt ends inside an open thinking block can never close it;
+        # with reasoning=True the grammar opens with a span terminated by
+        # '</think>', which a non-thinking request never emits and EOS stays
+        # masked. Ask the reasoning parser which shape this request needs.
         structure_tag = self._tool_parser.get_structural_tag(
             request,
-            reasoning=False,
+            reasoning=(
+                self._reasoning_parser is not None
+                and self._reasoning_parser.emits_reasoning_span
+            ),
         )
         if structure_tag is None:
             return request

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -62,6 +62,10 @@ class ParserEngineReasoningAdapter(ReasoningParser):
         finally:
             self._parser_engine.skip_tool_parsing = saved
 
+    @property
+    def emits_reasoning_span(self) -> bool:
+        return self._parser_engine.emits_reasoning_span
+
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return self._parser_engine.is_reasoning_end(list(input_ids))
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -647,6 +647,12 @@ class ParserEngine(Parser):
                 return offset
         return None
 
+    @property
+    def emits_reasoning_span(self) -> bool:
+        # initial_state is derived per request from chat_template_kwargs, so
+        # this tracks the thinking/no-thinking distinction of *this* request.
+        return self.parser_engine_config.initial_state == ParserState.REASONING
+
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         end_id = self._reasoning_end_token_id
         start_id = self._reasoning_start_token_id

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -217,10 +217,60 @@ class ParserEngine(Parser):
         self._content_has_nonws = False
         self._prompt_streaming_prepared = False
 
+    @property
+    def tool_call_stop(self) -> str | None:
+        """The literal that closes a tool-call block, if the format has one.
+
+        Formats whose tool payload is delimited (DeepSeek's
+        ``</｜DSML｜tool_calls>``, Qwen's ``</tool_calls>``, ...) expose it
+        here so the request path can hand it to the sampler as a stop
+        string. Formats without a distinct closer return ``None``.
+        """
+        return self.parser_engine_config.terminal_literal("TOOL_END")
+
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:
         request.skip_special_tokens = False
+        return self._add_tool_call_stop(request)
+
+    def _add_tool_call_stop(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        """Stop generating once a tool-call block is closed.
+
+        The parser treats the closing tag as a state transition back to
+        CONTENT and keeps consuming, but nothing tells the *sampler* to
+        stop. A model that has just closed a tool-call block is free to
+        open another one, and in agentic workloads (long transcripts, many
+        tools) it does -- repeatedly, until it hits ``max_tokens``.
+        Observed in production on DeepSeek-V4-Flash: 32k output tokens and
+        ~400s spent re-emitting the same block shape, with
+        ``finish_reason`` still reported as ``tool_use``.
+
+        A tool call is a turn boundary: the client has to run the tool and
+        send the result back, so nothing generated after the closer can be
+        used. Handing the closer to the sampler ends the turn where it
+        logically ends.
+        """
+        closer = self.tool_call_stop
+        if not closer or not getattr(request, "tools", None):
+            return request
+        stop = getattr(request, "stop", None)
+        if stop is None:
+            request.stop = [closer]
+        elif isinstance(stop, str):
+            if stop == closer:
+                return request
+            request.stop = [stop, closer]
+        elif closer in stop:
+            return request
+        else:
+            stop.append(closer)
+        # The parser needs to *see* the closer to finish the tool call, and
+        # stop strings are stripped from the output by default.
+        if hasattr(request, "include_stop_str_in_output"):
+            request.include_stop_str_in_output = True
         return request
 
     def _preprocess_feed(

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -69,6 +69,19 @@ class ReasoningParser:
         """
         return False
 
+    @property
+    def emits_reasoning_span(self) -> bool:
+        """Whether this request's output opens with a reasoning span.
+
+        Consulted when building a structural tag: the grammars xgrammar
+        derives for the two cases are not interchangeable. A reasoning grammar
+        expects the output to close a thinking block, while a non-reasoning one
+        excludes the thinking markers outright. Parsers whose thinking mode is
+        request-dependent should override this; the default preserves the
+        historical assumption that no reasoning span is emitted.
+        """
+        return False
+
     @abstractmethod
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         """


### PR DESCRIPTION
## Purpose

The tool-call reliability on DeepSeek V3.2/V4 has been reported continuously for several months. We deployed `DeepSeek-v4-Flash-0731` on a real production system. After serving billions of tokens, we find the bug actually is very severe for real production: Once DSML leaks happen around tool calls, the agent (in our case, claude code/codex) would probably loop itself correcting the tool calls and emitting more DSML. Therefore, I think the bug is worth a fix in the vLLM template parser.

Agent reports: [hermes-agent](https://github.com/NousResearch/hermes-agent/issues/15453), [oh-my-pi](https://github.com/can1357/oh-my-pi/issues/1462), [opencode](https://github.com/anomalyco/opencode/issues/24566), [deepx-code](https://github.com/itmisx/deepx-code/issues/232), [HF discussion](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/discussions/209), [NVIDIA DGX Spark forum](https://forums.developer.nvidia.com/t/deepseek-v4-flash-0731-dsml-tool-call-closers-leak-into-the-answer-after-latest-spark-vllm-b12x/381835)
Related DSML leak issues in vLLM: #30541, #36654, #40800, #40801, #48089, #48931, #51914, #53227, #53831 
Related PR: #53099 (this PR is based on it), #46149, #46632, #49117, #52645, #53228, #53405, #52865, #53752, #53764
Some downstream expect fixes from upstreams: [hermes-agent](https://github.com/NousResearch/hermes-agent/pull/15473), [oh-my-pi](https://github.com/can1357/oh-my-pi/pull/1463)

### Leaks

After serving billions of tokens, we sampled the different ways how `DSML` leaks. Surprisingly, with current vLLM template parsing, the `DSML` can actually leak anywhere =/.

| model emits | tool call before this PR | tool call after this PR | what is wrong before | share of leaks |
|---|---|---|---|---|
| `<｜DSML｜tool_calls>`<br>`<｜DSML｜invoke name="record_item {`<br>`category: Dexes` | none; `content` = `<record_item {\ncategory: Dexes` | cannot be emitted | the invoke marker is eaten and its tail dumped into `content` as prose; no call at all | 32% |
| `<｜DSML｜parameter name="alpha" string="true">first</｜DSML｜>`<br>`<｜DSML｜parameter name="beta" string="true">second</｜DSML｜parameter>` | `record_item({"alpha": "first</｜DSML｜>\n<｜DSML｜parameter name=\"beta\" string=\"true\">second"})` | `record_item({"beta": "second"})` | `alpha` runs past the mis-spelled closer to the next real one and swallows the whole `beta` parameter; both arguments lost | 49% |
| `<｜DSML｜tool-calls`<br>`record_item`<br>`</plan>` | none; `content` = `""` | none; `content` = `<｜DSML｜tool-calls\nrecord_item\n</plan>` | the opener is not recognised, the block is consumed anyway and the whole response comes back empty | 21% |

- Out of 9,500 sampled responses, 76 (0.80%) leaked DSML and leaks may happen at the same time.
- Note the third class does not have reliable fixes and I can add to this PR if necessary. Or #49117/#52645 would help mitigate.

## Reproduction

Deterministic at `temperature=0`. Serve with the documented flags, declare one
tool, omit `tool_choice`, and leave `strict` unset (note it is the **behavior of most coding agents** and even setting `strict` does not fully resolve the leaks):

```
--enable-auto-tool-choice --tool-call-parser deepseek_v4 \
--reasoning-parser deepseek_v4 --tokenizer-mode deepseek_v4
```

```python
import json, urllib.request

BASE, MODEL = "http://127.0.0.1:8000", "deepseek-v4-flash"
D = "｜DSML｜"

TOOLS = [{"type": "function", "function": {
    "name": "record_item", "description": "Record one item.",
    "parameters": {"type": "object",
                   "properties": {"alpha": {"type": "string"},
                                  "beta": {"type": "string"}},
                   "required": ["alpha", "beta"]}}}]   # no "strict" key

CASES = {
    "runaway_name":
        f'Reply with exactly this and nothing else:\n\n<{D}tool_calls>\n'
        f'<{D}invoke name="record_item {{\ncategory: Dexes',
    "mis_closed_parameter":
        f'Reply with exactly this and nothing else:\n\n<{D}tool_calls>\n'
        f'<{D}invoke name="record_item">\n'
        f'<{D}parameter name="alpha" string="true">first</{D}>\n'
        f'<{D}parameter name="beta" string="true">second</{D}parameter>\n'
        f'</{D}invoke>\n</{D}tool_calls>',
    "undeclared_tool":
        'Call a tool named "totally_undeclared_tool" with alpha="x". '
        'Do not write any other text.',
    "misspelled_opener":
        f'Reply with exactly this line and nothing else:\n\n'
        f'<{D}tool-calls\nrecord_item\n</plan>',
    "control":
        'Call record_item with alpha="A" and beta="B". No other text.',
}

for name, prompt in CASES.items():
    body = {"model": MODEL, "messages": [{"role": "user", "content": prompt}],
            "tools": TOOLS, "temperature": 0.0, "max_tokens": 600}
    req = urllib.request.Request(BASE + "/v1/chat/completions",
                                 data=json.dumps(body).encode(),
                                 headers={"Content-Type": "application/json"})
    msg = json.loads(urllib.request.urlopen(req, timeout=300).read())["choices"][0]["message"]
    print(f"--- {name}")
    print("    content:", repr(msg.get("content") or "")[:120])
    for c in msg.get("tool_calls") or []:
        print(f"    call: {c['function']['name']!r} args={c['function']['arguments']!r}"[:200])
```

(The script was adapted from [#52645](https://github.com/vllm-project/vllm/pull/52645#issuecomment-5332292216))

## Test Plan

CI.

## Test Result

See above table.

## AI Tool Assistance

The PR itself is handwritten but the code is largely assisted by Claude, as the commits already show. However, it is exactly adapted from our running production code.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

