### PR TITLE
[Bugfix][Frontend] Preserve token offset origins after left text pre-trimming

### DIFF
--- a/tests/renderers/test_token_offsets.py
+++ b/tests/renderers/test_token_offsets.py
@@ -8,6 +8,8 @@ forwarding chain. Endpoint-level coverage lives in
 ``tests/entrypoints/scale_out/render/test_render.py``.
 """
 
+import asyncio
+
 import pytest
 
 from vllm.renderers.params import TokenizeParams
@@ -50,6 +52,21 @@ def _make_base_renderer_with(tokenizer):
             raise NotImplementedError
 
     return _StubRenderer(tokenizer)
+
+
+class _OffsetTokenizer:
+    """Small deterministic fast tokenizer for pre-tokenization tests."""
+
+    is_fast = True
+    max_chars_per_token = 1
+    truncation_side = "right"
+    pad_token_id = 0
+
+    def __call__(self, text, **kwargs):
+        return {
+            "input_ids": list(range(len(text))),
+            "offset_mapping": [(i, i + 1) for i in range(len(text))],
+        }
 
 
 class TestTokenizePromptOffsets:
@@ -239,3 +256,44 @@ class TestTruncationKeepsOffsetsAligned:
         # belonging to the surviving tokens.
         expected = full_offsets[-keep:] if side == "left" else full_offsets[:keep]
         assert offsets == expected
+
+    @pytest.mark.parametrize(
+        ("side", "expected_offsets"),
+        [
+            ("left", [(36, 37), (37, 38), (38, 39), (39, 40)]),
+            ("right", [(0, 1), (1, 2), (2, 3), (3, 4)]),
+        ],
+    )
+    def test_text_pretrim_preserves_source_offsets(self, side, expected_offsets):
+        renderer = _make_base_renderer_with(_OffsetTokenizer())
+        text = "0123456789" * 4
+        params = TokenizeParams(
+            max_total_tokens=16,
+            return_token_offsets=True,
+            truncate_prompt_tokens=4,
+            truncation_side=side,
+            add_special_tokens=False,
+        )
+
+        result = renderer.tokenize_prompt({"prompt": text}, params)
+
+        assert result["prompt_token_offsets"] == expected_offsets
+
+    def test_async_left_text_pretrim_preserves_source_offsets(self):
+        renderer = _make_base_renderer_with(_OffsetTokenizer())
+        text = "0123456789" * 4
+        params = TokenizeParams(
+            max_total_tokens=16,
+            return_token_offsets=True,
+            truncate_prompt_tokens=4,
+            truncation_side="left",
+        )
+
+        result = asyncio.run(renderer.tokenize_prompt_async({"prompt": text}, params))
+
+        assert result["prompt_token_offsets"] == [
+            (36, 37),
+            (37, 38),
+            (38, 39),
+            (39, 40),
+        ]

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -468,6 +468,27 @@ class BaseRenderer(ABC, Generic[_T]):
             )
         return TokensPrompt(prompt_token_ids=list(token_ids), **prompt)
 
+    @staticmethod
+    def _apply_prompt_char_offset(
+        prompt: TokensPrompt, char_offset: int
+    ) -> TokensPrompt:
+        """Map token offsets back to the original prompt after a text pre-trim."""
+        if char_offset == 0:
+            return prompt
+
+        offsets = prompt.get("prompt_token_offsets")
+        if offsets is not None:
+            prompt["prompt_token_offsets"] = [
+                # Fast tokenizers use (0, 0) for special tokens, which are
+                # not character spans in the source prompt.
+                (start, end)
+                if (start, end) == (0, 0)
+                else (start + char_offset, end + char_offset)
+                for start, end in offsets
+            ]
+
+        return prompt
+
     def _tokenize_prompt(
         self,
         prompt: TextPrompt,
@@ -523,8 +544,12 @@ class BaseRenderer(ABC, Generic[_T]):
                     "Expected prompt['prompt'] to be a string before tokenization; "
                     "use 'prompt_token_ids' for token ID inputs"
                 )
+            prompt_char_offset = params._get_text_truncation_offset(
+                self.tokenizer, prompt["prompt"]
+            )
             prompt = params.apply_pre_tokenization(self.tokenizer, prompt)  # type: ignore[arg-type]
             prompt = self._tokenize_prompt(prompt, params)
+            prompt = self._apply_prompt_char_offset(prompt, prompt_char_offset)
 
         if params.needs_detokenization and "prompt" not in prompt:
             if "prompt_token_ids" not in prompt:
@@ -559,8 +584,12 @@ class BaseRenderer(ABC, Generic[_T]):
                     "Expected prompt['prompt'] to be a string before tokenization; "
                     "use 'prompt_token_ids' for token ID inputs"
                 )
+            prompt_char_offset = params._get_text_truncation_offset(
+                self.tokenizer, prompt["prompt"]
+            )
             prompt = params.apply_pre_tokenization(self.tokenizer, prompt)  # type: ignore[arg-type]
             prompt = await self._tokenize_prompt_async(prompt, params)
+            prompt = self._apply_prompt_char_offset(prompt, prompt_char_offset)
 
         if params.needs_detokenization and "prompt" not in prompt:
             if "prompt_token_ids" not in prompt:

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -369,6 +369,31 @@ class TokenizeParams:
 
         return text
 
+    def _get_text_truncation_offset(
+        self, tokenizer: TokenizerLike | None, text: str
+    ) -> int:
+        """Return the number of source characters removed from the left.
+
+        ``_text_len_check`` pre-truncates long text before tokenization when
+        an explicit truncation side is requested. Fast-tokenizer offsets are
+        then relative to that shortened string, so callers need this prefix
+        length to map them back to the original prompt.
+        """
+        max_input_tokens = self.max_input_tokens
+        if (
+            max_input_tokens is None
+            or tokenizer is None
+            or self.truncate_prompt_tokens is None
+            or self.truncation_side != "left"
+        ):
+            return 0
+
+        max_input_chars = max_input_tokens * tokenizer.max_chars_per_token
+        if max_input_chars <= 0:
+            return 0
+
+        return max(len(text) - max_input_chars, 0)
+
     def _text_lowercase(self, tokenizer: TokenizerLike | None, text: str) -> str:
         """Apply lowercase to prompt text if necessary."""
         return text.lower() if self.do_lower_case else text


### PR DESCRIPTION


## Purpose

Fix incorrect character offsets returned by `/v1/completions/render` and
`/v1/chat/completions/render` when a request combines:

```text
return_token_offsets=true
truncate_prompt_tokens=<N>
truncation_side="left"
```

When an explicit truncation side is requested, vLLM disables tokenizer-level
truncation so it can apply the requested side consistently after tokenization.
To keep tokenizer work bounded, `_text_len_check` first trims text whose
character length exceeds:

```text
max_input_tokens * tokenizer.max_chars_per_token
```

After left pre-trimming, fast-tokenizer offsets are relative to the retained
suffix. vLLM currently returns those offsets without restoring the removed
prefix length, so a successful response contains offsets that point to the
wrong characters in the original prompt. The number of offsets still matches
the number of token IDs, making this a silent data-corruption issue.

This change records how many source characters were removed from the left and
adds that value back to each character span after tokenization. `(0, 0)`
offsets used for special tokens remain unchanged. Token IDs, truncation
semantics, and the tokenizer work bound are unaffected.

The issue is reachable through the public GPU-less render server. With
`max_model_len=128`, `max_tokens=1`, and a tokenizer whose
`max_chars_per_token` is 128, character pre-trimming starts above 16,256
characters. The following 21,037-character prompt reproduces it with
`truncate_prompt_tokens=16`:

```text
"prefix-" * 3000 + "KEEP this suffix with distinct words."
```

Before and after the fix use identical token IDs:

| Version | Tokens | Offsets | Last offset | Original source character |
| --- | ---: | ---: | --- | --- |
| `main` | 16 | 16 | `[16255, 16256]` | `r` (incorrect) |
| This PR | 16 | 16 | `[21036, 21037]` | `.` (correct) |

This is related to, but does not duplicate, #54407. That PR keeps
`prompt_token_offsets` aligned with token IDs during token-level truncation;
this PR restores the coordinate origin after the earlier character-level
pre-trimming step. Searches for open PRs using `prompt_token_offsets`,
`token offset` with `truncation`, and `truncation_side` with `offset` found no
existing fix for this issue. Open PR #54539 addresses truncation of
`assistant_tokens_mask` and does not restore character-offset origins.

## Test Plan

Run the focused renderer and request-protocol test suites:

```bash
.venv/bin/python -m pytest tests/renderers/test_token_offsets.py -ra
.venv/bin/python -m pytest tests/renderers/test_completions.py -q
.venv/bin/python -m pytest \
  tests/entrypoints/openai/test_render_token_offsets.py -q
```

Run the pre-commit hooks selected for the changed production files:

```bash
.venv/bin/pre-commit run --files \
  vllm/renderers/base.py \
  vllm/renderers/params.py \
  tests/renderers/test_token_offsets.py
```

Start the GPU-less render server with `max_model_len=128`, submit the long
prompt above to `/v1/completions/render`, and verify that the returned offsets
index the original prompt while token IDs remain unchanged.

## Test Result

```text
tests/renderers/test_token_offsets.py                 15 passed
tests/renderers/test_completions.py                   28 passed
tests/entrypoints/openai/test_render_token_offsets.py  4 passed
pre-commit hooks on all changed files                     passed
```

The pre-commit run included `ruff check`, `ruff format`, `typos`, mypy, SPDX,
and the other hooks selected for these files.

End-to-end GPU-less render result using the Qwen3-0.6B tokenizer:

```text
HTTP status:       200
prompt length:     21037
token count:       16
offset count:      16
last offset:       [21036, 21037]
source character:  .
```

The comparison confirmed that token IDs are identical before and after the
fix. A model-accuracy evaluation is not applicable because this change does
not affect model inputs, model outputs, weights, kernels, or sampling; it only
corrects character-coordinate metadata returned by the render API.

## AI-assisted contribution

This contribution was developed with AI assistance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and affected public API behavior are explained.
- [x] The test plan includes the commands and end-to-end scenario used.
- [x] The test results include before-and-after and end-to-end evidence.
- [x] No documentation page update is required; this restores the expected
  coordinate origin of an existing response field.

</details>

