### PR TITLE
[Docs] Document missing vllm bench subcommands in CLI README

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -124,14 +124,14 @@ See [vllm complete](./complete.md) for the full reference of all available argum
 
 ## bench
 
-Run benchmark tests for latency online serving throughput and offline inference throughput.
+Run benchmark tests for latency, online serving throughput, offline inference throughput, startup time, multimodal processor latency, and parameter sweeps.
 
 To use benchmark commands, please install with extra dependencies using `pip install vllm[bench]`.
 
 Available Commands:
 
 ```bash
-vllm bench {latency, serve, throughput}
+vllm bench {latency, serve, throughput, startup, mm-processor, sweep}
 ```
 
 ### latency
@@ -179,6 +179,55 @@ vllm bench throughput \
 ```
 
 See [vllm bench throughput](./bench/throughput.md) for the full reference of all available arguments.
+
+### startup
+
+Benchmark the startup time of vLLM models.
+
+```bash
+vllm bench startup \
+    --model meta-llama/Llama-3.2-1B-Instruct
+```
+
+See [vllm bench startup](./bench/startup.md) for the full reference of all available arguments.
+
+### mm-processor
+
+Benchmark multimodal processor latency across different configurations.
+
+```bash
+vllm bench mm-processor \
+    --model Qwen/Qwen2-VL-7B-Instruct \
+    --dataset-name random-mm \
+    --num-prompts 50 \
+    --random-input-len 300 \
+    --random-output-len 40 \
+    --random-mm-base-items-per-request 2 \
+    --random-mm-limit-mm-per-prompt '{"image": 3, "video": 0}' \
+    --random-mm-bucket-config '{(256, 256, 1): 0.7, (720, 1280, 1): 0.3}'
+```
+
+See [vllm bench mm-processor](./bench/mm-processor.md) for the full reference of all available arguments.
+
+### sweep
+
+Benchmark for a parameter sweep.
+
+Available Commands:
+
+```bash
+vllm bench sweep {serve, serve_workload, startup, plot, plot_pareto}
+```
+
+```bash
+vllm bench sweep serve \
+    --serve-cmd 'vllm serve meta-llama/Llama-2-7b-chat-hf' \
+    --bench-cmd 'vllm bench serve --model meta-llama/Llama-2-7b-chat-hf --backend vllm --endpoint /v1/completions --dataset-name sharegpt --dataset-path benchmarks/ShareGPT_V3_unfiltered_cleaned_split.json' \
+    --output-dir benchmarks/results \
+    --experiment-name demo
+```
+
+See [vllm bench sweep](./bench/sweep.md) for the full reference of all available arguments.
 
 ## collect-env
 


### PR DESCRIPTION
## Purpose

`docs/cli/README.md` on `main` documents only three `vllm bench` subcommands, but the CLI registers six.

**README (`docs/cli/README.md`):**

```bash
vllm bench {latency, serve, throughput}
```

**CLI registration (`vllm/entrypoints/cli/benchmark/main.py` `_import_bench_subcommand_modules`):**

```python
import vllm.entrypoints.cli.benchmark.latency
import vllm.entrypoints.cli.benchmark.mm_processor
import vllm.entrypoints.cli.benchmark.serve
import vllm.entrypoints.cli.benchmark.startup
import vllm.entrypoints.cli.benchmark.sweep
import vllm.entrypoints.cli.benchmark.throughput
```

Each module's `BenchmarkSubcommandBase.name`:

| Module | `name` | `help` |
| --- | --- | --- |
| `latency.py` | `latency` | Benchmark the latency of a single batch of requests. |
| `serve.py` | `serve` | (already documented) |
| `throughput.py` | `throughput` | (already documented) |
| `startup.py` | `startup` | Benchmark the startup time of vLLM models. |
| `mm_processor.py` | `mm-processor` | Benchmark multimodal processor latency across different configurations. |
| `sweep.py` | `sweep` | Benchmark for a parameter sweep. |

`vllm bench sweep` further registers (`vllm/benchmarks/sweep/cli.py` `SUBCOMMANDS`): `serve`, `serve_workload`, `startup`, `plot`, `plot_pareto`.

This PR updates the CLI README in the same style as the existing latency/serve/throughput sections. Example flags are copied from the registered CLI / existing benchmarking docs (not invented).

## Test Plan

- [x] Confirm README on `main` still lists only `{latency, serve, throughput}`
- [x] Confirm `_import_bench_subcommand_modules` imports latency, mm_processor, serve, startup, sweep, throughput
- [x] Confirm `name` attributes: `startup`, `mm-processor`, `sweep`
- [x] Confirm sweep nested `parser_name`s: `serve`, `serve_workload`, `startup`, `plot`, `plot_pareto`
- [ ] `vllm bench --help` lists the six subcommands after install with `vllm[bench]`