### PR TITLE
[Docs] Point disagg encoder examples at real script names

### DIFF
--- a/docs/features/disagg_encoder.md
+++ b/docs/features/disagg_encoder.md
@@ -53,7 +53,7 @@ Disaggregated encoding is implemented by running two parts:
 
 * **Encoder instance** – a vLLM instance to performs vision encoding.  
 * **Prefill/Decode (PD) instance(s)** – runs language pre-fill and decode.
-    * PD can be in either a single normal instance with `disagg_encoder_example.sh` (E->PD) or in disaggregated instances with `disagg_epd_example.sh` (E->P->D)
+    * PD can be in either a single normal instance with `disagg_1e1pd_example.sh` (E->PD) or in disaggregated instances with `disagg_1e1p1d_example.sh` (E->P->D)
 
 A connector transfers encoder-cache (EC) embeddings from the encoder instance to the PD instance.  
 All related code is under `vllm/distributed/ec_transfer`.

--- a/examples/disaggregated/disaggregated_encoder/README.md
+++ b/examples/disaggregated/disaggregated_encoder/README.md
@@ -53,7 +53,7 @@ To support local image inputs (from your ```MEDIA_PATH``` directory), add the fo
 --allowed-local-media-path $MEDIA_PATH
 ```
 
-The vllm instances and `disagg_encoder_proxy` supports local URIs with ```{"url": "file://'"$MEDIA_PATH_FILENAME"'}``` as multimodal inputs. Each URI is passed unchanged from the `disagg_encoder_proxy` to the encoder instance so that the encoder can load the media locally.
+The vllm instances and `disagg_epd_proxy.py` supports local URIs with ```{"url": "file://'"$MEDIA_PATH_FILENAME"'}``` as multimodal inputs. Each URI is passed unchanged from the `disagg_epd_proxy.py` to the encoder instance so that the encoder can load the media locally.
 
 ## EC connector and KV transfer
 
@@ -110,7 +110,7 @@ Example usage:
 For E + PD setup:
 
 ```bash
-$ python disagg_encoder_proxy.py \
+$ python disagg_epd_proxy.py \
       --encode-servers-urls "http://e1:8001,http://e2:8002" \
       --prefill-servers-urls "disable" \
       --decode-servers-urls "http://pd1:8003,http://pd2:8004"
@@ -119,7 +119,7 @@ $ python disagg_encoder_proxy.py \
 For E + P + D setup:
 
 ```bash
-$ python disagg_encoder_proxy.py \
+$ python disagg_epd_proxy.py \
       --encode-servers-urls "http://e1:8001,http://e2:8001" \
       --prefill-servers-urls "http://p1:8003,http://p2:8004" \ 
       --decode-servers-urls "http://d1:8005,http://d2:8006"

--- a/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
+++ b/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-disagg_encoder_proxy.py
+disagg_epd_proxy.py
 
 Proxy that routes OpenAI-compatible “/v1/chat/completions” requests to two
 clusters:


### PR DESCRIPTION
## Purpose

Docs and examples on `main` still name scripts that are not in the tree. The live files are under `examples/disaggregated/disaggregated_encoder/`.

**Stale names quoted from `main` (`dc9114b2011928842a87d64776e3b0ef48224e93`):**

`examples/disaggregated/disaggregated_encoder/README.md`:

```bash
$ python disagg_encoder_proxy.py \
```

and prose `` `disagg_encoder_proxy` ``.

`examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py` docstring:

```
disagg_encoder_proxy.py
```

`docs/features/disagg_encoder.md`:

```
`disagg_encoder_example.sh` (E->PD) ... `disagg_epd_example.sh` (E->P->D)
```

**Contents API vs tree:**

| Path | Result |
| --- | --- |
| `examples/disaggregated/disagg_encoder_proxy.py` | 404 |
| `examples/disaggregated/disaggregated_encoder/disagg_encoder_proxy.py` | 404 |
| `examples/disaggregated/disaggregated_encoder/disagg_encoder_example.sh` | 404 |
| `examples/disaggregated/disaggregated_encoder/disagg_epd_example.sh` | 404 |
| `examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py` | exists |
| `examples/disaggregated/disaggregated_encoder/disagg_1e1pd_example.sh` | exists |
| `examples/disaggregated/disaggregated_encoder/disagg_1e1p1d_example.sh` | exists |

This PR only retargets those references to the filenames that are actually present. Same-directory listings already used the correct names.

## Test Plan

- [x] GitHub Contents API: old names 404, new names exist on `main`
- [x] Code search for `disagg_encoder_proxy` hits README + the proxy module docstring
- [x] Confirm `docs/features/disagg_encoder.md` Usage Example section already points at `disagg_1e1pd_example.sh` / `disagg_1e1p1d_example.sh`
- [ ] Visual check of the three hunks in this PR

## Test Result

Reproduced on `main` SHA `dc9114b2011928842a87d64776e3b0ef48224e93`. After this change, the three files name `disagg_epd_proxy.py`, `disagg_1e1pd_example.sh`, and `disagg_1e1p1d_example.sh` only.