### PR TITLE
[XPU] Refactor MXFP8 linear to use QuantFP8 CustomOp

### DIFF
--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -21,6 +21,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8DynamicTensorSym,
     kFp8DynamicTokenSym,
     kFp8StaticTensorSym,
+    kMxfp8Dynamic,
     kNvfp4Dynamic,
 )
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
@@ -41,6 +42,7 @@ QUANT_OPS: dict[QuantKey, OpOverload] = {
 if hasattr(torch.ops._C, "per_token_group_fp8_quant"):
     QUANT_OPS[kFp8Dynamic128Sym] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501
     QUANT_OPS[kFp8Dynamic64Sym] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501
+    QUANT_OPS[kMxfp8Dynamic] = torch.ops._C.per_token_group_fp8_quant.default  # noqa: E501
 
 if current_platform.is_cuda() and hasattr(torch.ops._C, "scaled_fp4_quant"):
     QUANT_OPS[kNvfp4Dynamic] = torch.ops._C.scaled_fp4_quant.out  # noqa: E501

--- a/vllm/model_executor/kernels/linear/mxfp8/xpu.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/xpu.py
@@ -3,13 +3,14 @@
 
 import torch
 
-from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
-    xpu_mxfp8_quantize as quant_mxfp8,
-)
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 
 from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
+
+_MXFP8_GROUP_SIZE = 32
 
 
 class XPUMxFp8LinearKernel(Mxfp8LinearKernel):
@@ -26,6 +27,14 @@ class XPUMxFp8LinearKernel(Mxfp8LinearKernel):
     @classmethod
     def can_implement(cls, c: Mxfp8LinearLayerConfig) -> tuple[bool, str | None]:
         return True, None
+
+    def __init__(self, config: Mxfp8LinearLayerConfig):
+        super().__init__(config)
+        self._quant = QuantFP8(
+            static=False,
+            group_shape=GroupShape(1, _MXFP8_GROUP_SIZE),
+            use_ue8m0=True,
+        )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Checkpoint scale is [N, K//32] (one E8M0 scale per 32 elements).
@@ -68,10 +77,8 @@ class XPUMxFp8LinearKernel(Mxfp8LinearKernel):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         out_dtype = x.dtype
-        x_fp8, x_scale = quant_mxfp8(x)
-        # Weight is [N, K]; .t() gives a [K, N] view without copying.
-        # Scale is stored as [N, K//32]; .t() recovers the contiguous
-        # [K//32, N] buffer that oneDNN expects.
+        x_fp8, x_scale = self._quant(x)
+        x_scale = x_scale.to(torch.float8_e8m0fnu)
         return torch.ops._xpu_C.fp8_gemm(
             x_fp8,
             layer.weight.t(),


### PR DESCRIPTION
## Summary

Replace the XPU-specific `xpu_mxfp8_quantize` op with the standard `QuantFP8` CustomOp in `XPUMxFp8LinearKernel.apply_weights`.

Both paths call the same underlying `per_token_group_fp8_quant` C kernel with `group_size=32, scale_ue8m0=True`, so the output is **numerically identical**.

## Changes

1. **`matcher_utils.py`**: Register `kMxfp8Dynamic` in `QUANT_OPS` → `per_token_group_fp8_quant`
2. **`mxfp8/xpu.py`**: Replace `quant_mxfp8(x)` with `QuantFP8(static=False, group_shape=GroupShape(1,32), use_ue8m0=True)`

## Motivation

- Aligns MXFP8 activation quantization with the standard `QuantFP8` path used by block FP8
- Enables `MatcherQuantFP8(kMxfp8Dynamic, is_e8m0=True)` for SP pattern matching (follow-up PR)
- Removes dependency on the XPU-only `xpu_mxfp8_quantize` custom op for linear kernels

## Verification Plan

- [ ] Micro: bit-exact comparison of old vs new quantize output
- [ ] Macro: `vllm bench serve` throughput/latency with `INCModel/Qwen3-32B-MXFP8-CT-AutoRound`, tp=4
- [ ] Accuracy: GSM8K 5-shot, 250 questions

AI assistance was used for this PR.