### PR TITLE
[Bugfix][Quark] Honor layer_quant_config for identity packed_modules_mapping entries

### DIFF
--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -1410,3 +1410,66 @@ def test_suffix_match_at_module_boundary(prefix, ignored_layer, expected):
         )
         is expected
     )
+
+
+MXFP4_GLOBAL = {"weight": {"dtype": "fp4", "qscheme": "per_group", "group_size": 32}}
+FP8_PER_BLOCK = {
+    "weight": {"dtype": "fp8_e4m3", "qscheme": "per_block", "block_size": [128, 128]}
+}
+LAYER = "language_model.model.layers.0"
+
+
+def _mixed_precision_config(
+    layer_quant_config: dict[str, dict],
+    packed_modules_mapping: dict[str, list[str]],
+) -> QuarkConfig:
+    config = QuarkConfig(
+        {
+            "global_quant_config": MXFP4_GLOBAL,
+            "layer_type_quant_config": {},
+            "layer_quant_config": layer_quant_config,
+        }
+    )
+    config.packed_modules_mapping = packed_modules_mapping
+    return config
+
+
+def test_identity_packed_mapping_uses_layer_quant_config():
+    # Regression for mixed-precision Quark checkpoints: plamo3/molmo-style
+    # models map a module to itself, so substituting the shard name is a no-op
+    # and the layer fell through to global_quant_config even when
+    # layer_quant_config named it, surfacing as a shape mismatch at load.
+    config = _mixed_precision_config(
+        {"*mlp.gate_up_proj": FP8_PER_BLOCK, "*mlp.down_proj": FP8_PER_BLOCK},
+        {"qkv_proj": ["qkv_proj"], "gate_up_proj": ["gate_up_proj"]},
+    )
+    module = torch.nn.Identity()
+    gate_up_proj = f"{LAYER}.mlp.gate_up_proj"
+
+    assert config.get_layer_quant_config_from_name(gate_up_proj) == FP8_PER_BLOCK
+    assert config._find_matched_config(gate_up_proj, module) == FP8_PER_BLOCK
+    # Sibling outside packed_modules_mapping; the two must agree.
+    assert (
+        config._find_matched_config(f"{LAYER}.mlp.down_proj", module) == FP8_PER_BLOCK
+    )
+    # An identity entry that layer_quant_config does not name keeps the global
+    # scheme.
+    assert (
+        config._find_matched_config(f"{LAYER}.self_attn.qkv_proj", module)
+        == MXFP4_GLOBAL
+    )
+
+
+def test_fused_packed_mapping_still_resolves_through_shards():
+    # A genuine fusion keeps expanding to the shard names the checkpoint
+    # actually carries.
+    config = _mixed_precision_config(
+        {"*mlp.gate_proj": FP8_PER_BLOCK, "*mlp.up_proj": FP8_PER_BLOCK},
+        {"gate_up_proj": ["gate_proj", "up_proj"]},
+    )
+    gate_up_proj = f"{LAYER}.mlp.gate_up_proj"
+
+    assert config.get_layer_quant_config_from_name(gate_up_proj) == FP8_PER_BLOCK
+    assert (
+        config._find_matched_config(gate_up_proj, torch.nn.Identity()) == FP8_PER_BLOCK
+    )

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -749,6 +749,20 @@ class QuarkConfig(QuantizationConfig):
             return quant_config[0] if len(quant_config) == 1 else None
         return quant_config
 
+    def _match_layer_quant_config(self, layer_name: str) -> dict[str, Any] | None:
+        """Match ``layer_name`` against the ``layer_quant_config`` patterns."""
+        layer_quant_config = cast(
+            dict[str, Any], self.quant_config.get("layer_quant_config") or {}
+        )
+        for name_pattern, config in layer_quant_config.items():
+            if "*" not in name_pattern:
+                matches = layer_name in name_pattern
+            else:
+                matches = fnmatch.fnmatch(layer_name, name_pattern)
+            if matches:
+                return config
+        return None
+
     def get_layer_quant_config_from_name(
         self, layer_name: str
     ) -> dict[str, Any] | None:
@@ -761,7 +775,9 @@ class QuarkConfig(QuantizationConfig):
                 if shard_name != layer_name:
                     config = self.get_layer_quant_config_from_name(shard_name)
                 else:
-                    config = None
+                    # Identity entry: the shard name is the layer name, so
+                    # recursing would not terminate. Look it up directly.
+                    config = self._match_layer_quant_config(layer_name)
                 shard_configs.append(config)
 
             matched_configs = [config for config in shard_configs if config is not None]
@@ -777,17 +793,7 @@ class QuarkConfig(QuantizationConfig):
                 return matched_configs[0]
             return None
         else:
-            layer_quant_config = cast(
-                dict[str, Any], self.quant_config.get("layer_quant_config") or {}
-            )
-            for name_pattern, config in layer_quant_config.items():
-                if "*" not in name_pattern:
-                    matches = layer_name in name_pattern
-                else:
-                    matches = fnmatch.fnmatch(layer_name, name_pattern)
-                if matches:
-                    return config
-            return None
+            return self._match_layer_quant_config(layer_name)
 
     def _find_matched_config(
         self, layer_name: str, module: torch.nn.Module | type[torch.nn.Module]
@@ -813,11 +819,12 @@ class QuarkConfig(QuantizationConfig):
             for shard_proj_name in shard_proj_names:
                 shard_name = layer_name.replace(proj_name, shard_proj_name)
                 if shard_name == layer_name:
-                    config = fallback_config
+                    # Identity entry: see get_layer_quant_config_from_name.
+                    config = self._match_layer_quant_config(layer_name)
                 else:
                     config = self.get_layer_quant_config_from_name(shard_name)
-                    if config is None:
-                        config = fallback_config
+                if config is None:
+                    config = fallback_config
                 shard_configs.append(config)
 
             if not all(


### PR DESCRIPTION
## Purpose

Addresses the identity-entry resolution reported in #54641 by @stefanskiasan. (The
`amd/GLM-5.3-Flash-Quark-MXFP4` checkpoint that surfaced it needs #56176 instead — see *Scope*.)

An identity entry in `packed_modules_mapping` (a module mapped to itself, e.g.
`"gate_up_proj": ["gate_up_proj"]`) silently disables `layer_quant_config` for that module. The
layer falls back to `global_quant_config`, so a mixed-precision Quark checkpoint that names the
module is built with the wrong scheme and only fails later, at weight load, with a shape mismatch.

Identity entries exist because the checkpoint really stores the fused tensor: GLM-4.1V ships a
pre-fused `gate_up_proj`, which is why `Glm4vForConditionalGeneration` maps it to itself. A Quark
checkpoint of such a model keys `layer_quant_config` by that fused name, and today that entry is
ignored.

**Scope.** This does *not* fix `amd/GLM-5.3-Flash-Quark-MXFP4`: that config keys the split
`gate_proj` / `up_proj` names (none `gate_up_proj`), and the actual bug there is the identity
mapping `Glm5NextForConditionalGeneration` inherits from GLM-4.1V although GLM-5.3-Flash stores
gate/up separately — fixed by the mapping override in #56176. Once the mapping expands to real
shards, the branch this PR changes is not reached; the two are complementary. The reporter's
locally produced config named the fused module (the trace in #54641 shows the key present but
`hit=False`), which is exactly the path fixed here.

Both lookup paths in `QuarkConfig` treat `shard_name == layer_name` as "no shard information":

```python
# get_layer_quant_config_from_name
if shard_name != layer_name:
    config = self.get_layer_quant_config_from_name(shard_name)
else:
    config = None              # identity entry -> no config

# _find_matched_config
if shard_name == layer_name:
    config = fallback_config   # identity entry -> global scheme
```

That guard is only there to stop the recursion, since substituting an identity entry is a no-op.
For such an entry the shard name *is* the layer name, so the lookup should resolve it rather than
give up — which is what the other two fused-name expanders already do:
`quant_utils.is_layer_skipped` special-cases a direct fused-name match, and
`quark.utils.should_ignore_layer` degenerates to the same lookup. Only `QuarkConfig` bails out.

Identity entries are an established in-tree pattern — `glm4_1v`, `plamo3`, `molmo`, `molmo2`,
`mimo_v2`, `sarvam`, `jamba`, `lfm2`, `lfm2_moe` and `granitemoehybrid` each register one or
more — and
`get_layer_quant_config_from_name` is also consumed by `quantization/utils/config_utils.py` for
the fused-shared-expert check and the OCP-MX group-size helper.

**Fix:** extract the `layer_quant_config` pattern match into `_match_layer_quant_config()` — a
verbatim move of the existing `else`-branch body, so matching semantics are unchanged — and use it
for the identity branch in both methods. Genuine fusions, and identity entries that
`layer_quant_config` does not name, behave exactly as before.

## Test Plan

```
pytest tests/quantization/test_quark.py -k packed_mapping
pytest tests/quantization/test_quark.py
pytest tests/model_executor/layers/test_fused_shared_expert.py
```

Two CPU-only regression tests added next to the existing `is_layer_skipped` fused-name tests:
`test_identity_packed_mapping_uses_layer_quant_config` (covers both patched lookup paths, the
unmapped `down_proj` sibling, and an identity entry that `layer_quant_config` does not name) and
`test_fused_packed_mapping_still_resolves_through_shards` (control: a genuine fusion still expands
to its shards).

## Test Result

Rebased onto `main` @ 701a744490 (on top of the #52958 `QuantKey` refactor); the patch applies
unchanged. Run on a CPU-only machine, so the `vllm_runner` tests in these files fail at setup
for lack of a device, and every test additionally reports a teardown error from `conftest.py`'s
`cleanup_fixture` calling `torch.accelerator.empty_cache()` with no accelerator. Both artifacts
are identical before and after; everything below is a before/after delta.

| | before | after |
|---|---|---|
| `test_identity_packed_mapping_uses_layer_quant_config` | FAILED | PASSED |
| `test_fused_packed_mapping_still_resolves_through_shards` | PASSED | PASSED |
| `tests/quantization/test_quark.py` | 2 failed, 47 passed, 8 skipped, 113 errors | 1 failed, 48 passed, 8 skipped, 113 errors |
| `tests/model_executor/layers/test_fused_shared_expert.py` | 1 failed, 33 passed, 64 errors | identical failure set |

The `test_quark.py` failure-set difference is exactly the new regression test.

For the mixed-precision config from the issue (MXFP4 globally, block-FP8 dense MLPs via
`layer_quant_config`), `get_scheme_cls` now selects `QuarkW8A8Fp8PerBlock` (fp8_e4m3/per_block)
for `...mlp.gate_up_proj` instead of `QuarkOCP_MX` (fp4/per_group), matching its `down_proj`
sibling.

`ruff==0.14.0` format and check pass; `tools/pre_commit/mypy.py 3.12` reports the same 10
pre-existing errors before and after (all in `QuarkLinearMethod`, outside the changed lines).

I do not have ROCm hardware; there is no end-to-end run here. The regression tests exercise the
exact resolution path from the reporter's trace in #54641.

---

*AI-assisted: the patch and the regression tests were produced with Claude (Claude Code); I
reviewed every changed line and ran the tests above before submitting.*
