### PR TITLE
[Feature][Model][Kernel] Inkling: fp8 e4m3 KV cache with per-tensor scales on SM100

### DIFF
--- a/tests/models/inkling/test_fa4_rel_attention.py
+++ b/tests/models/inkling/test_fa4_rel_attention.py
@@ -588,6 +588,18 @@ def test_fp8_gate_rejects_e5m2(monkeypatch):
         InklingAttention._validate_quantized_kv_cache_dtype("fp8_e5m2")
 
 
+def test_amd_gate_rejects_quantized_kv_cache_dtype():
+    amd_attention = pytest.importorskip(
+        "vllm.models.inkling.amd.attention",
+        reason="ROCm attention module not importable on this platform",
+    )
+    for dtype in ("auto", "float16", "bfloat16"):
+        amd_attention.InklingAttention._validate_kv_cache_dtype(dtype)
+    for dtype in ("fp8", "fp8_e4m3", "fp8_e5m2", "fp8_inc"):
+        with pytest.raises(NotImplementedError, match="ROCm"):
+            amd_attention.InklingAttention._validate_kv_cache_dtype(dtype)
+
+
 @pytest.mark.parametrize("major", [9, 12])
 def test_fp8_gate_rejects_non_sm100(monkeypatch, major):
     monkeypatch.setattr(

--- a/tests/models/inkling/test_fa4_rel_attention.py
+++ b/tests/models/inkling/test_fa4_rel_attention.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Correctness test for the Inkling FA4 relative-attention score-mod kernel.
+"""Correctness and gating tests for the Inkling FA4 relative-attention kernels.
 
-Checks ``_INKLING_FA4_REL_ATTENTION_KERNEL`` against a pure-PyTorch reference
-that implements the relative bias exactly as documented in the Inkling architecture
-guide::
+Covers the cute score-mod and sheared tml-fa4 paths, bf16 and fp8 KV
+(numerics, platform gates, warmup and cache-spec wiring), checking
+``_INKLING_FA4_REL_ATTENTION_KERNEL`` against a pure-PyTorch reference
+that implements the relative bias exactly as documented in the Inkling
+architecture guide::
 
     logit(i, j, h) = (1 / head_dim) * dot(q[i, h], k[j, h]) + rel_bias(i, j, h)
     rel_bias(i, j, h) = rel_logits[i, h, i - j]   if 0 <= i - j < rel_extent
@@ -39,6 +41,18 @@ HEAD_DIM = 128
 BLOCK_SIZE = 16
 DTYPE = torch.bfloat16
 
+FP8_DTYPE = torch.float8_e4m3fn
+FP8_MAX = 448.0
+# (q_scale, k_scale, v_scale) per-tensor scale sets for the fp8 tests.
+# The second set has q_scale * k_scale != 1 so a dropped or swapped QK
+# descale is detectable, and v_scale distinct from the QK product so
+# QK/V descale cross-swaps are detectable.
+FP8_SCALES = [(1.0, 1.0, 1.0), (0.5, 0.5, 1.5)]
+
+
+def _quantize_fp8(x: torch.Tensor, scale: float) -> torch.Tensor:
+    return (x.float() / scale).clamp(-FP8_MAX, FP8_MAX).to(FP8_DTYPE)
+
 
 def test_log_scaling_tau_matches_reference():
     positions = torch.tensor([0, 127999, 128000, 999999], dtype=torch.int64)
@@ -53,6 +67,7 @@ def test_split_packed_kv_cache():
     attention = InklingAttention.__new__(InklingAttention)
     torch.nn.Module.__init__(attention)
     attention.head_dim = 8
+    attention.kv_cache_quantized = False
     attention.kv_cache = torch.arange(2 * 3 * 4 * 16).reshape(2, 3, 4, 16)
 
     key_cache, value_cache = attention._split_kv_cache()
@@ -226,7 +241,15 @@ def _ref_rel_attn(
     return out
 
 
-def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0):
+def _run_case(
+    seq_lens,
+    num_heads,
+    num_kv_heads,
+    rel_extent,
+    window_left,
+    seed=0,
+    fp8_scales=None,
+):
     torch.manual_seed(seed)
     device = "cuda"
     q_lens = [s[0] for s in seq_lens]
@@ -270,7 +293,35 @@ def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0
 
     window_size = (-1, -1) if window_left is None else (window_left, 0)
 
-    preallocated_out = torch.empty_like(q)
+    descale_kwargs = {}
+    if fp8_scales is None:
+        kernel_q, kernel_k, kernel_v = q, key_cache, value_cache
+        ref_q, ref_k, ref_v = q, key_cache, value_cache
+        # bf16 kernel vs fp32 reference tolerance.
+        atol = rtol = 2e-2
+    else:
+        q_scale, k_scale, v_scale = fp8_scales
+        kernel_q = _quantize_fp8(q, q_scale)
+        kernel_k = _quantize_fp8(key_cache, k_scale)
+        kernel_v = _quantize_fp8(value_cache, v_scale)
+        # The reference consumes the dequantized kernel inputs, so input
+        # quantization error cancels; the remaining error is in-kernel
+        # (fp8 MMA and probability quantization). vLLM's fp8 attention
+        # tolerance convention applies.
+        ref_q = kernel_q.float() * q_scale
+        ref_k = kernel_k.float() * k_scale
+        ref_v = kernel_v.float() * v_scale
+        atol = rtol = 0.15
+        descale_kwargs = dict(
+            q_descale=q_scale,
+            k_descale=k_scale,
+            v_descale=v_scale,
+        )
+
+    # Output stays in the model dtype on every path.
+    preallocated_out = torch.empty(
+        total_q, num_heads, HEAD_DIM, device=device, dtype=DTYPE
+    )
     num_splits = inkling_fa4_num_splits(
         is_local=window_left is not None,
         batch_size=num_seqs,
@@ -280,9 +331,9 @@ def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0
         max_kv_len=max(kv_lens),
     )
     out = _INKLING_FA4_REL_ATTENTION_KERNEL(
-        q,
-        key_cache,
-        value_cache,
+        kernel_q,
+        kernel_k,
+        kernel_v,
         block_table=block_table,
         cache_seqlens=cache_seqlens,
         cu_seqlens_q=cu_seqlens_q,
@@ -294,14 +345,15 @@ def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0
         rel_logits=rel_logits,
         num_splits=num_splits,
         out=preallocated_out,
+        **descale_kwargs,
     )
     assert out.data_ptr() == preallocated_out.data_ptr()
     out = out.view(total_q, num_heads, HEAD_DIM)
 
     ref = _ref_rel_attn(
-        q,
-        key_cache,
-        value_cache,
+        ref_q,
+        ref_k,
+        ref_v,
         rel_logits,
         q_lens=q_lens,
         kv_lens=kv_lens,
@@ -311,7 +363,7 @@ def _run_case(seq_lens, num_heads, num_kv_heads, rel_extent, window_left, seed=0
         window_left=window_left,
     )
 
-    torch.testing.assert_close(out.float(), ref.float(), atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(out.float(), ref.float(), atol=atol, rtol=rtol)
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
@@ -426,3 +478,142 @@ def test_sliding_window(seq_lens, num_heads, local_extent):
 def test_decode(seq_lens, num_heads, rel_extent):
     # q_len=1 with kv_len>q_len: the score-mod's seqlen_k - seqlen_q offset path.
     _run_case(seq_lens, num_heads[0], num_heads[1], rel_extent, window_left=None)
+
+
+requires_sm100 = pytest.mark.skipif(
+    _cap is None or _cap.major != 10,
+    reason="Inkling fp8 KV requires an SM100-family GPU",
+)
+
+# Both fp8 kernel paths are supported on SM100: the tml-fa4 sheared-bias
+# default and the cute score-mod path.
+FP8_PATHS = ["sheared", "scoremod"]
+
+
+def _force_fp8_path(monkeypatch, fp8_path):
+    if fp8_path == "scoremod":
+        module = importlib.import_module(
+            "vllm.models.inkling.nvidia.ops.fa4_rel_attention"
+        )
+        monkeypatch.setattr(module, "_use_sheared_bias", lambda: False)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+@requires_sm100
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize(
+    "seq_lens",
+    [
+        [(64, 64)],  # single full prefill
+        [(200, 512), (50, 300), (1, 400)],  # mixed chunked + decode
+        [(1, 512), (1, 333)],  # decode, exercises the split-KV descale path
+    ],
+)
+@pytest.mark.parametrize("fp8_scales", FP8_SCALES)
+@pytest.mark.parametrize("rel_extent", GLOBAL_REL_EXTENTS)
+@pytest.mark.parametrize("fp8_path", FP8_PATHS)
+@torch.inference_mode()
+def test_fp8_kv_full_attention(
+    monkeypatch, seq_lens, num_heads, fp8_scales, rel_extent, fp8_path
+):
+    # rel_extent=1024 is the production global-layer extent; 128 exercises
+    # the out-of-range zero-bias path against descaled scores.
+    _force_fp8_path(monkeypatch, fp8_path)
+    _run_case(
+        seq_lens,
+        num_heads[0],
+        num_heads[1],
+        rel_extent=rel_extent,
+        window_left=None,
+        fp8_scales=fp8_scales,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+@requires_sm100
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("fp8_scales", FP8_SCALES)
+@pytest.mark.parametrize("fp8_path", FP8_PATHS)
+@torch.inference_mode()
+def test_fp8_kv_sliding_window(monkeypatch, num_heads, fp8_scales, fp8_path):
+    _force_fp8_path(monkeypatch, fp8_path)
+    _run_case(
+        [(512, 512), (1, 512)],
+        num_heads[0],
+        num_heads[1],
+        rel_extent=128,
+        window_left=127,
+        fp8_scales=fp8_scales,
+    )
+
+
+def test_get_kv_cache_spec_fp8_sets_quant_mode():
+    from types import SimpleNamespace
+
+    from vllm.v1.kv_cache_interface import KVQuantMode
+
+    for is_local in (False, True):
+        attention = InklingAttention.__new__(InklingAttention)
+        torch.nn.Module.__init__(attention)
+        attention.num_kv_heads = 8
+        attention.head_dim = 128
+        attention.is_local = is_local
+        attention.local_extent = 512 if is_local else None
+        attention.kv_cache_dtype = "fp8"
+        attention.kv_cache_torch_dtype = torch.uint8
+        vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=16))
+        spec = attention.get_kv_cache_spec(vllm_config)
+        # Allocation dtype stays uint8; quantization is carried by the mode.
+        assert spec.dtype == torch.uint8
+        assert spec.kv_quant_mode == KVQuantMode.FP8_PER_TENSOR
+
+
+def test_fp8_gate_accepts_e4m3_on_sm100(monkeypatch):
+    monkeypatch.setattr(
+        current_platform,
+        "get_device_capability",
+        lambda: DeviceCapability(major=10, minor=0),
+    )
+    InklingAttention._validate_quantized_kv_cache_dtype("fp8")
+    InklingAttention._validate_quantized_kv_cache_dtype("fp8_e4m3")
+
+
+def test_fp8_gate_rejects_e5m2(monkeypatch):
+    monkeypatch.setattr(
+        current_platform,
+        "get_device_capability",
+        lambda: DeviceCapability(major=10, minor=0),
+    )
+    with pytest.raises(NotImplementedError, match="e4m3"):
+        InklingAttention._validate_quantized_kv_cache_dtype("fp8_e5m2")
+
+
+@pytest.mark.parametrize("major", [9, 12])
+def test_fp8_gate_rejects_non_sm100(monkeypatch, major):
+    monkeypatch.setattr(
+        current_platform,
+        "get_device_capability",
+        lambda: DeviceCapability(major=major, minor=0),
+    )
+    with pytest.raises(NotImplementedError, match="SM100"):
+        InklingAttention._validate_quantized_kv_cache_dtype("fp8")
+
+
+def test_fp8_kv_requires_descales():
+    q = torch.empty(1, 4, HEAD_DIM, dtype=FP8_DTYPE)
+    kv = torch.empty(1, BLOCK_SIZE, 4, HEAD_DIM, dtype=FP8_DTYPE)
+    with pytest.raises(AssertionError):
+        _INKLING_FA4_REL_ATTENTION_KERNEL.kernel(
+            q,
+            kv,
+            kv,
+            block_table=torch.empty(1, 1, dtype=torch.int32),
+            cache_seqlens=torch.empty(1, dtype=torch.int32),
+            cu_seqlens_q=torch.empty(2, dtype=torch.int32),
+            max_seqlen_q=1,
+            softmax_scale=1.0 / HEAD_DIM,
+            causal=True,
+            window_size=(-1, -1),
+            rel_extent=128,
+            rel_logits=torch.empty(1, 4, 128, dtype=DTYPE),
+        )

--- a/tests/models/inkling/test_fa4_warmup.py
+++ b/tests/models/inkling/test_fa4_warmup.py
@@ -34,7 +34,7 @@ def _vllm_config_from_reference_config(config: SimpleNamespace) -> SimpleNamespa
             dtype=config.dtype,
         ),
         cache_config=SimpleNamespace(
-            cache_dtype="auto",
+            cache_dtype=getattr(config, "cache_dtype", "auto"),
             block_size=config.block_size,
         ),
         scheduler_config=SimpleNamespace(
@@ -56,6 +56,36 @@ def test_bucket_max_seqlen_q():
         8,
         16,
     ]
+
+
+def test_warmup_keys_fp8_kv_dtype(monkeypatch):
+    # fp8 caches are allocated as uint8; warmup must compile against the
+    # viewed e4m3 dtype, never uint8.
+    monkeypatch.setattr(
+        fa4_rel_attention,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    config = SimpleNamespace(
+        num_heads=16,
+        num_kv_heads=2,
+        head_dim=128,
+        rel_extent=1024,
+        window_size=(-1, -1),
+        is_local=False,
+        max_kv_len=65536,
+        dtype=torch.bfloat16,
+        kv_dtype=torch.bfloat16,
+        block_size=16,
+        max_num_reqs=8,
+        max_num_batched_tokens=192,
+        cache_dtype="fp8",
+    )
+    vllm_config = _vllm_config_from_reference_config(config)
+    keys = InklingFA4RelAttentionKernel().get_warmup_keys(vllm_config)
+    assert keys
+    assert all(key.kv_dtype == torch.float8_e4m3fn for key in keys)
+    assert all(key.dtype == torch.bfloat16 for key in keys)
 
 
 def test_warmup_enumerates_every_runtime_compile_class(monkeypatch):

--- a/tests/models/inkling/test_qkvr_prep.py
+++ b/tests/models/inkling/test_qkvr_prep.py
@@ -256,3 +256,72 @@ def test_rel_projection_schedule_crossover(
 ):
     assert not qkvr_prep.use_rel_proj_throughput(last_latency_rows, rel_extent)
     assert qkvr_prep.use_rel_proj_throughput(first_throughput_rows, rel_extent)
+
+
+FP8_DTYPE = torch.float8_e4m3fn
+
+
+@pytest.mark.skipif(
+    _cap is None,
+    reason="Inkling QKVR prep kernels require CUDA",
+)
+@pytest.mark.parametrize(
+    ("is_local", "tokens"),
+    [
+        (True, 9),  # fused small-batch path
+        (False, 9),
+        (True, 128),  # tiled path
+        (False, 640),
+    ],
+)
+@pytest.mark.parametrize(("k_scale_val", "v_scale_val"), [(1.0, 1.0), (0.5, 2.0)])
+@torch.inference_mode()
+def test_qkvr_prep_fp8_cache_write(is_local, tokens, k_scale_val, v_scale_val):
+    """fp8 quant-on-store: dequantized cache contents match the bf16 run,
+    q/rel outputs are unaffected, and the conv cache stays bf16-identical."""
+    args = list(_make_inputs(is_local=is_local, tokens=tokens, tp_size=4))
+    kv_heads = args[8]
+    head_dim = args[9]
+
+    bf16_args = list(args)
+    bf16_args[11] = args[11].clone()
+    bf16_args[12] = args[12].clone()
+    bf16_args[13] = args[13].clone()
+    q_bf16, rel_bf16 = qkvr_prep.fused_qkvr_prep(*bf16_args)
+
+    args[12] = torch.zeros_like(bf16_args[12], dtype=FP8_DTYPE)
+    args[13] = torch.zeros_like(bf16_args[13], dtype=FP8_DTYPE)
+    k_scale = torch.tensor(k_scale_val, dtype=torch.float32, device="cuda")
+    v_scale = torch.tensor(v_scale_val, dtype=torch.float32, device="cuda")
+    q_fp8, rel_fp8 = qkvr_prep.fused_qkvr_prep(*args, k_scale=k_scale, v_scale=v_scale)
+
+    # The q/rel path does not depend on the cache dtype.
+    torch.testing.assert_close(q_fp8, q_bf16, rtol=0, atol=0)
+    torch.testing.assert_close(rel_fp8, rel_bf16, rtol=0, atol=0)
+
+    # Conv state is pinned to the model dtype and must be byte-identical.
+    torch.testing.assert_close(args[11], bf16_args[11], rtol=0, atol=0)
+
+    # Dequantized fp8 contents vs the bf16 stores at the written slots.
+    # e4m3 half-ulp relative error is 2**-4; atol covers the subnormal
+    # granularity floor after descaling.
+    written = slice(0, tokens)
+    for cache_fp8, cache_bf16, scale in (
+        (args[12], bf16_args[12], k_scale_val),
+        (args[13], bf16_args[13], v_scale_val),
+    ):
+        dequant = cache_fp8.view(-1, kv_heads, head_dim)[written].float() * scale
+        expected = cache_bf16.view(-1, kv_heads, head_dim)[written].float()
+        torch.testing.assert_close(dequant, expected, rtol=0.07, atol=0.02)
+
+
+@pytest.mark.skipif(
+    _cap is None,
+    reason="Inkling QKVR prep kernels require CUDA",
+)
+def test_qkvr_prep_fp8_requires_scales():
+    args = list(_make_inputs(is_local=True, tokens=9))
+    args[12] = torch.zeros_like(args[12], dtype=FP8_DTYPE)
+    args[13] = torch.zeros_like(args[13], dtype=FP8_DTYPE)
+    with pytest.raises(AssertionError):
+        qkvr_prep.fused_qkvr_prep(*args)

--- a/vllm/models/inkling/amd/attention.py
+++ b/vllm/models/inkling/amd/attention.py
@@ -30,6 +30,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheSpec,
     SlidingWindowSpec,
+    is_quantized_kv_cache,
 )
 
 from ..configs import InklingModelConfig
@@ -166,6 +167,7 @@ class InklingAttention(nn.Module, AttentionLayerBase):
         self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )
+        self._validate_kv_cache_dtype(self.kv_cache_dtype)
         self.register_buffer("k_scale", torch.ones((), dtype=torch.float32))
         self.register_buffer("v_scale", torch.ones((), dtype=torch.float32))
 
@@ -193,6 +195,19 @@ class InklingAttention(nn.Module, AttentionLayerBase):
                 ),
             )
         )
+
+    @staticmethod
+    def _validate_kv_cache_dtype(kv_cache_dtype: str) -> None:
+        # No quantized KV path is wired for the ROCm kernels; without
+        # this gate a uint8 cache reaches them and dies at warmup with
+        # a dtype error far from the cause. Non-quantized overrides
+        # ("float16"/"bfloat16") pass through unchanged.
+        if is_quantized_kv_cache(kv_cache_dtype):
+            raise NotImplementedError(
+                "Inkling on ROCm does not support a quantized KV cache; "
+                f"--kv-cache-dtype {kv_cache_dtype!r} is not implemented "
+                "on this platform"
+            )
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return FlashAttentionBackend

--- a/vllm/models/inkling/nvidia/attention.py
+++ b/vllm/models/inkling/nvidia/attention.py
@@ -17,6 +17,9 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
     canonicalize_singleton_dim_strides,
     kv_cache_dtype_str_to_dtype,
@@ -29,7 +32,9 @@ from vllm.v1.attention.backends.flash_attn import (
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheSpec,
+    KVQuantMode,
     SlidingWindowSpec,
+    get_kv_quant_mode,
 )
 
 from ..configs import InklingModelConfig
@@ -167,6 +172,20 @@ class InklingAttention(nn.Module, AttentionLayerBase):
         )
         self.register_buffer("k_scale", torch.ones((), dtype=torch.float32))
         self.register_buffer("v_scale", torch.ones((), dtype=torch.float32))
+        self.register_buffer("q_scale", torch.ones((), dtype=torch.float32))
+
+        self.kv_cache_quantized = (
+            get_kv_quant_mode(self.kv_cache_dtype) != KVQuantMode.NONE
+        )
+        self.query_quant: QuantFP8 | None = None
+        if self.kv_cache_quantized:
+            self._validate_quantized_kv_cache_dtype(self.kv_cache_dtype)
+            # FA4 fp8 requires q.dtype == kv dtype, so q is quantized in
+            # the layer with a static per-tensor scale.
+            self.query_quant = QuantFP8(static=True, group_shape=GroupShape.PER_TENSOR)
+        # Scalar copies of the (static) scale buffers, read once after
+        # weight loading so the hot path never syncs on a GPU scalar.
+        self._scale_floats: tuple[float, float, float] | None = None
 
         compilation_config = vllm_config.compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -177,11 +196,33 @@ class InklingAttention(nn.Module, AttentionLayerBase):
         if vllm_config.kernel_config.enable_jit_warmup:
             _INKLING_FA4_REL_ATTENTION_KERNEL.register_warmup()
 
+    @staticmethod
+    def _validate_quantized_kv_cache_dtype(kv_cache_dtype: str) -> None:
+        # Only per-tensor e4m3 is wired up: the cache is viewed as the
+        # platform e4m3 dtype and the store clamp uses the e4m3 range, so
+        # every other quantized cache dtype must fail fast rather than
+        # run as e4m3.
+        if kv_cache_dtype not in ("fp8", "fp8_e4m3"):
+            raise NotImplementedError(
+                "Inkling fp8 KV cache supports only per-tensor e4m3 "
+                f"('fp8'/'fp8_e4m3'), got {kv_cache_dtype!r}"
+            )
+        capability = current_platform.get_device_capability()
+        if capability is None or capability.major != 10:
+            # fp8 kernels exist only for the SM100 family; Hopper and
+            # SM12x have no fp8 path in either FA4 backend.
+            cap_str = capability.as_version_str() if capability is not None else None
+            raise NotImplementedError(
+                "Inkling fp8 KV cache requires an SM100-family GPU, got "
+                f"compute capability {cap_str}"
+            )
+
     def get_attn_backend(self) -> type[AttentionBackend]:
         return FlashAttentionBackend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         block_size = vllm_config.cache_config.block_size
+        quant_mode = get_kv_quant_mode(self.kv_cache_dtype)
         if self.is_local:
             assert self.local_extent is not None
             return SlidingWindowSpec(
@@ -190,18 +231,22 @@ class InklingAttention(nn.Module, AttentionLayerBase):
                 head_size=self.head_dim,
                 dtype=self.kv_cache_torch_dtype,
                 sliding_window=self.local_extent,
+                kv_quant_mode=quant_mode,
             )
         return FullAttentionSpec(
             block_size=block_size,
             num_kv_heads=self.num_kv_heads,
             head_size=self.head_dim,
             dtype=self.kv_cache_torch_dtype,
+            kv_quant_mode=quant_mode,
         )
 
     def _split_kv_cache(self) -> tuple[torch.Tensor, torch.Tensor]:
-        key_cache, value_cache = self.kv_cache.transpose(1, 2).split(
-            self.head_dim, dim=-1
-        )
+        kv_cache = self.kv_cache
+        if self.kv_cache_quantized:
+            # Allocated as uint8; the kernels consume the platform fp8 dtype.
+            kv_cache = kv_cache.view(current_platform.fp8_dtype())
+        key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_dim, dim=-1)
         return (
             canonicalize_singleton_dim_strides(key_cache),
             canonicalize_singleton_dim_strides(value_cache),
@@ -262,6 +307,8 @@ class InklingAttention(nn.Module, AttentionLayerBase):
                 off_v,
                 self.conv_owner.block_size,
                 log_scaling if not self.is_local else None,
+                k_scale=self.k_scale if self.kv_cache_quantized else None,
+                v_scale=self.v_scale if self.kv_cache_quantized else None,
             )
             q = q.view(num_tokens, self.num_heads, self.head_dim)
             self._attention(q, rel_logits, attn_output)
@@ -292,6 +339,25 @@ class InklingAttention(nn.Module, AttentionLayerBase):
             num_kv_heads=self.num_kv_heads,
             max_kv_len=self._max_kv_len,
         )
+        descale_kwargs: dict[str, float] = {}
+        if self.query_quant is not None:
+            # cute FA4 fp8 requires q in the KV dtype. The plain torch
+            # quantization lets torch.compile fuse it into preceding ops.
+            num_tokens = q.shape[0]
+            q_quantized, _ = self.query_quant(q.view(num_tokens, -1), self.q_scale)
+            q = q_quantized.view(num_tokens, self.num_heads, self.head_dim)
+            if self._scale_floats is None:
+                self._scale_floats = (
+                    float(self.q_scale),
+                    float(self.k_scale),
+                    float(self.v_scale),
+                )
+            q_scale, k_scale, v_scale = self._scale_floats
+            descale_kwargs = dict(
+                q_descale=q_scale,
+                k_descale=k_scale,
+                v_descale=v_scale,
+            )
         _INKLING_FA4_REL_ATTENTION_KERNEL(
             q[:nt],
             key_cache,
@@ -307,4 +373,5 @@ class InklingAttention(nn.Module, AttentionLayerBase):
             rel_logits=rel_logits[:nt],
             num_splits=num_splits,
             out=output[:nt],
+            **descale_kwargs,
         )

--- a/vllm/models/inkling/nvidia/model.py
+++ b/vllm/models/inkling/nvidia/model.py
@@ -20,6 +20,7 @@ from vllm.distributed import (
     tensor_model_parallel_reduce_scatter,
 )
 from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.interfaces import (
@@ -56,6 +57,8 @@ from .ops.lamport import get_lamport_rs_conv, initialize_lamport_rs_conv
 from .ops.norm import add_rmsnorm, embed_rmsnorm
 from .sconv_swa_attn import _ATTN, _MLP, InklingConvState, InklingSconvMetadata
 from .short_conv import InklingShortConv
+
+logger = init_logger(__name__)
 
 InklingDelta: TypeAlias = torch.Tensor | tuple[torch.Tensor, torch.Tensor]
 
@@ -701,6 +704,48 @@ def _load_inkling_weights(
     for moe_name, moe in moe_modules.items():
         for rel in moe.finalize_load():
             loaded.add(f"{moe_name}.{rel}")
+
+    attn_layers = [mod for mod in module.modules() if isinstance(mod, InklingAttention)]
+    # Scales may have just been (re)loaded into the buffers; drop the
+    # cached scalar copies so the next forward re-reads them (covers
+    # in-place weight reload).
+    for mod in attn_layers:
+        mod._scale_floats = None
+
+    quantized = [mod for mod in attn_layers if mod.kv_cache_quantized]
+    if quantized:
+        # A malformed scale would degrade outputs silently; fail at load.
+        for mod in quantized:
+            for buf_name in ("q_scale", "k_scale", "v_scale"):
+                val = getattr(mod, buf_name)
+                if not torch.isfinite(val).all() or (val <= 0).any():
+                    raise ValueError(
+                        f"{mod.prefix}.{buf_name} is {val.item()!r}; KV "
+                        "cache scales must be finite and positive"
+                    )
+        # Warn when the checkpoint ships KV scale tensors for fewer
+        # layers than run quantized. Coverage comes from the loader's
+        # return value, not from buffer values: a calibrated checkpoint
+        # can legitimately carry scales that equal 1.0, and buffer
+        # defaults are also 1.0, so value equality cannot distinguish
+        # the two. V is the stream measured to exceed the e4m3 range at
+        # unity scale, so its shortfall is warned about even when k
+        # scales are present.
+        n_v = sum(1 for name in loaded if name.endswith(".attn.v_scale"))
+        n_k = sum(1 for name in loaded if name.endswith(".attn.k_scale"))
+        if n_v < len(quantized):
+            missing = "k_scale/v_scale" if n_k < len(quantized) else "v_scale"
+            logger.warning(
+                "fp8 KV cache is enabled but the checkpoint provides %s "
+                "tensors for %d of %d attention layers; the uncovered "
+                "layers run at unity scale. V activations can exceed the "
+                "e4m3 range and clip, which measurably degrades "
+                "long-derivation tasks. Calibrate per-layer scales into "
+                "the checkpoint before serving.",
+                missing,
+                n_v,
+                len(quantized),
+            )
     return loaded
 
 

--- a/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
+++ b/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
@@ -21,6 +21,10 @@ from vllm.utils.torch_utils import kv_cache_dtype_str_to_dtype
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
+# fp8 KV caches are allocated as uint8 and viewed as e4m3 at the layer
+# before reaching this kernel; other fp8 variants are rejected there.
+_FP8_KV_DTYPES = (torch.float8_e4m3fn,)
+
 
 def bucket_max_seqlen_q(max_seqlen_q: int) -> int:
     """Round the FA4 scheduling bound up to a power of two."""
@@ -150,6 +154,9 @@ class InklingFA4RelAttentionKernel(
         rel_logits: torch.Tensor,
         num_splits: int = 32,
         out: torch.Tensor | None = None,
+        q_descale: float | None = None,
+        k_descale: float | None = None,
+        v_descale: float | None = None,
     ) -> torch.Tensor:
         """Paged varlen FA4 over the bound K/V cache with the Inkling relative bias.
 
@@ -160,10 +167,33 @@ class InklingFA4RelAttentionKernel(
         ``(num_tokens, num_heads, rel_extent)``.
 
         Hopper uses standard FA4's score-mod gather. Blackwell uses tml-fa4's
-        sheared relative-bias layout.
+        sheared relative-bias layout for both bf16 and fp8 (plain-fp8
+        support lands in the vendored tml-fa4 via the companion kernel
+        PR, adapted from closed tml-fa4 PR #1); the cute score-mod path
+        also supports fp8 on SM100 and remains the cross-check and
+        non-sheared fallback.
+
+        ``q_descale``/``k_descale``/``v_descale`` are per-tensor scalar
+        descales, required for fp8 and rejected otherwise. Neither vendored
+        varlen entry has descale parameters, so the QK descale is folded
+        into ``softmax_scale`` (identical to an in-kernel fold: scores are
+        scaled before the exact bf16 bias is added) and the V descale is
+        applied to the output, which is linear in V. The fold sits outside
+        the backend branch and is path-independent.
         """
         # cute uses (None, None) to mean "no window".
         cute_window = (None, None) if window_size == (-1, -1) else window_size
+
+        kv_is_fp8 = key_cache.dtype in _FP8_KV_DTYPES
+        if kv_is_fp8:
+            assert q.dtype == key_cache.dtype, (
+                "cute FA4 fp8 requires the query quantized to the KV dtype"
+            )
+            assert q_descale is not None
+            assert k_descale is not None and v_descale is not None
+            softmax_scale = softmax_scale * q_descale * k_descale
+        else:
+            assert q_descale is None and k_descale is None and v_descale is None
 
         rel_logits = rel_logits.contiguous()
         flash_attn_varlen_func: Callable[..., Any]
@@ -201,9 +231,11 @@ class InklingFA4RelAttentionKernel(
             out=out,
             **bias_kwargs,
         )
-        if isinstance(ret, tuple):
-            return ret[0]
-        return ret
+        result = ret[0] if isinstance(ret, tuple) else ret
+        if kv_is_fp8 and v_descale != 1.0:
+            # out = P @ (V_fp8 * v_descale) = v_descale * (P @ V_fp8).
+            result.mul_(v_descale)
+        return result
 
     def dispatch(  # type: ignore[override]
         self,
@@ -271,6 +303,12 @@ class InklingFA4RelAttentionKernel(
             vllm_config.cache_config.cache_dtype,
             vllm_config.model_config,
         )
+        if vllm_config.cache_config.cache_dtype in ("fp8", "fp8_e4m3"):
+            # The accepted e4m3 caches are allocated as uint8 and viewed as
+            # the platform fp8 dtype at the layer; warmup must compile the
+            # viewed dtype. Other quantized dtypes are rejected at layer
+            # construction.
+            kv_dtype = current_platform.fp8_dtype()
         block_size = vllm_config.cache_config.block_size
         local_extent = config.sliding_window_size
 
@@ -344,13 +382,21 @@ class InklingFA4RelAttentionKernel(
         with FakeTensorMode():
             device = torch.accelerator.current_accelerator()
             total_q = compile_key.max_seqlen_q + num_reqs - 1
+            kv_is_fp8 = compile_key.kv_dtype in _FP8_KV_DTYPES
+            # With fp8 KV the layer quantizes q to the KV dtype; rel_logits
+            # stay in the model dtype on every path.
             q = torch.empty(
                 total_q,
                 compile_key.num_heads,
                 compile_key.head_dim,
-                dtype=compile_key.dtype,
+                dtype=compile_key.kv_dtype if kv_is_fp8 else compile_key.dtype,
                 device=device,
             )
+            descale_kwargs: dict[str, Any] = {}
+            if kv_is_fp8:
+                # Scalar descales; 1.0 keeps the warmup output-scale
+                # branch identical to the runtime default-scale case.
+                descale_kwargs = dict(q_descale=1.0, k_descale=1.0, v_descale=1.0)
             kv = torch.empty(
                 1,
                 2,
@@ -394,7 +440,16 @@ class InklingFA4RelAttentionKernel(
                     device=device,
                 ),
                 num_splits=compile_key.num_splits,
-                out=torch.empty_like(q),
+                # Output stays in the model dtype on every path; cute
+                # produces bf16 output for fp8 inputs.
+                out=torch.empty(
+                    total_q,
+                    compile_key.num_heads,
+                    compile_key.head_dim,
+                    dtype=compile_key.dtype,
+                    device=device,
+                ),
+                **descale_kwargs,
             )
 
     def __call__(
@@ -414,6 +469,9 @@ class InklingFA4RelAttentionKernel(
         rel_logits: torch.Tensor,
         num_splits: int = 32,
         out: torch.Tensor | None = None,
+        q_descale: float | None = None,
+        k_descale: float | None = None,
+        v_descale: float | None = None,
     ) -> torch.Tensor:
         return self.kernel(
             q,
@@ -430,6 +488,9 @@ class InklingFA4RelAttentionKernel(
             rel_logits=rel_logits,
             num_splits=num_splits,
             out=out,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
         )
 
 

--- a/vllm/models/inkling/nvidia/ops/qkvr_prep.py
+++ b/vllm/models/inkling/nvidia/ops/qkvr_prep.py
@@ -6,6 +6,16 @@ import torch
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import aux_stream
 
+# Finite range of float8_e4m3fn. Values are clamped before the store
+# cast, matching vLLM's other fp8 cache-write kernels; fp8 cast
+# saturation is backend-dependent, so it is not relied on. Globals
+# referenced inside @triton.jit must be tl.constexpr instances.
+_FP8_MAX = tl.constexpr(448.0)
+
+# e4m3 only: the layer rejects other fp8 variants, and the clamp above is
+# wrong for e5m2.
+_FP8_KV_DTYPES = (torch.float8_e4m3fn,)
+
 LOW_BLOCK_M = 32
 LOW_BLOCK_N = 64
 LOW_NUM_WARPS = 4
@@ -206,6 +216,8 @@ def _qkvr_qkv_kernel(
     conv_block_table_ptr,
     query_start_ptr,
     attention_slot_mapping_ptr,
+    k_scale_ptr,
+    v_scale_ptr,
     log_scaling_ptr,
     tokens,
     eps,
@@ -236,6 +248,7 @@ def _qkvr_qkv_kernel(
     D_REL: tl.constexpr,
     REL_EXTENT: tl.constexpr,
     REL_EXTENT_PADDED: tl.constexpr,
+    KV_CACHE_FP8: tl.constexpr,
 ):
     block = tl.program_id(0)
     num_q_rows = tokens * NUM_Q_HEADS
@@ -370,14 +383,28 @@ def _qkvr_qkv_kernel(
                 acc_k += source_k * k_weight
                 acc_v += source_v * v_weight
 
+            v_float = acc_v + v_value.to(tl.float32)
             k_rounded = (acc_k + k_value.to(tl.float32)).to(qkvr_ptr.dtype.element_ty)
-            v_rounded = (acc_v + v_value.to(tl.float32)).to(qkvr_ptr.dtype.element_ty)
             k_float = k_rounded.to(tl.float32)
             k_norm_weight = tl.load(k_norm_weight_ptr + dims).to(tl.float32)
             rstd = tl.rsqrt(tl.sum(k_float * k_float, axis=0) / HEAD_DIM + eps)
-            k_normalized = (k_float * rstd * k_norm_weight).to(
-                qkvr_ptr.dtype.element_ty
-            )
+            k_normalized = k_float * rstd * k_norm_weight
+
+            if KV_CACHE_FP8:
+                # Per-tensor fp8 quantization on store. Scales are fp32
+                # scalars; the cache pointers carry an fp8 element type,
+                # so the store cast performs the fp32-to-fp8 rounding.
+                k_inv = 1.0 / tl.load(k_scale_ptr)
+                v_inv = 1.0 / tl.load(v_scale_ptr)
+                k_store = tl.clamp(k_normalized * k_inv, -_FP8_MAX, _FP8_MAX).to(
+                    key_cache_ptr.dtype.element_ty
+                )
+                v_store = tl.clamp(v_float * v_inv, -_FP8_MAX, _FP8_MAX).to(
+                    value_cache_ptr.dtype.element_ty
+                )
+            else:
+                k_store = k_normalized.to(qkvr_ptr.dtype.element_ty)
+                v_store = v_float.to(qkvr_ptr.dtype.element_ty)
 
             safe_attention_slot = tl.maximum(attention_slot, 0)
             attention_block = safe_attention_slot // attention_page_size
@@ -388,7 +415,7 @@ def _qkvr_qkv_kernel(
                 + attention_offset * stride_kc_token
                 + head * stride_kc_head
                 + dims,
-                k_normalized,
+                k_store,
                 mask=attention_slot >= 0,
             )
             tl.store(
@@ -397,7 +424,7 @@ def _qkvr_qkv_kernel(
                 + attention_offset * stride_vc_token
                 + head * stride_vc_head
                 + dims,
-                v_rounded,
+                v_store,
                 mask=attention_slot >= 0,
             )
 
@@ -458,6 +485,8 @@ def _kv_kernel(
     conv_block_table_ptr,
     query_start_ptr,
     attention_slot_mapping_ptr,
+    k_scale_ptr,
+    v_scale_ptr,
     tokens,
     eps,
     stride_x_t,
@@ -483,6 +512,7 @@ def _kv_kernel(
     OFF_K: tl.constexpr,
     OFF_V: tl.constexpr,
     BLOCK_ROWS: tl.constexpr,
+    KV_CACHE_FP8: tl.constexpr,
 ):
     token = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
     dims = tl.arange(0, HEAD_DIM)
@@ -579,14 +609,26 @@ def _kv_kernel(
         acc_k += source_k * k_weight[None, :]
         acc_v += source_v * v_weight[None, :]
 
+    v_float = acc_v + v_value.to(tl.float32)
     k_rounded = (acc_k + k_value.to(tl.float32)).to(qkvr_ptr.dtype.element_ty)
-    v_rounded = (acc_v + v_value.to(tl.float32)).to(qkvr_ptr.dtype.element_ty)
     k_float = k_rounded.to(tl.float32)
     k_norm_weight = tl.load(k_norm_weight_ptr + dims).to(tl.float32)
     rstd = tl.rsqrt(tl.sum(k_float * k_float, axis=1) / HEAD_DIM + eps)
-    k_normalized = (k_float * rstd[:, None] * k_norm_weight[None, :]).to(
-        qkvr_ptr.dtype.element_ty
-    )
+    k_normalized = k_float * rstd[:, None] * k_norm_weight[None, :]
+
+    if KV_CACHE_FP8:
+        # Per-tensor fp8 quantization on store. See _qkvr_qkv_kernel.
+        k_inv = 1.0 / tl.load(k_scale_ptr)
+        v_inv = 1.0 / tl.load(v_scale_ptr)
+        k_store = tl.clamp(k_normalized * k_inv, -_FP8_MAX, _FP8_MAX).to(
+            key_cache_ptr.dtype.element_ty
+        )
+        v_store = tl.clamp(v_float * v_inv, -_FP8_MAX, _FP8_MAX).to(
+            value_cache_ptr.dtype.element_ty
+        )
+    else:
+        k_store = k_normalized.to(qkvr_ptr.dtype.element_ty)
+        v_store = v_float.to(qkvr_ptr.dtype.element_ty)
 
     safe_attention_slot = tl.maximum(attention_slot, 0)
     attention_block = safe_attention_slot // attention_page_size
@@ -598,7 +640,7 @@ def _kv_kernel(
         + attention_offset[:, None] * stride_kc_token
         + head[:, None] * stride_kc_head
         + dims[None, :],
-        k_normalized,
+        k_store,
         mask=attention_mask[:, None],
     )
     tl.store(
@@ -607,7 +649,7 @@ def _kv_kernel(
         + attention_offset[:, None] * stride_vc_token
         + head[:, None] * stride_vc_head
         + dims[None, :],
-        v_rounded,
+        v_store,
         mask=attention_mask[:, None],
     )
 
@@ -654,6 +696,8 @@ def _run_tiled_kv(
     conv_block_table: torch.Tensor,
     query_start: torch.Tensor,
     attention_slot_mapping: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
     *,
     eps: float,
     num_q_heads: int,
@@ -662,6 +706,7 @@ def _run_tiled_kv(
     off_k: int,
     off_v: int,
     conv_block_size: int,
+    kv_cache_fp8: bool,
 ) -> None:
     tokens = qkvr.shape[0]
     _kv_kernel[(triton.cdiv(tokens, KV_BLOCK_ROWS), num_kv_heads)](
@@ -678,6 +723,8 @@ def _run_tiled_kv(
         conv_block_table,
         query_start,
         attention_slot_mapping,
+        k_scale,
+        v_scale,
         tokens,
         eps,
         qkvr.stride(0),
@@ -703,6 +750,7 @@ def _run_tiled_kv(
         OFF_K=off_k,
         OFF_V=off_v,
         BLOCK_ROWS=KV_BLOCK_ROWS,
+        KV_CACHE_FP8=kv_cache_fp8,
         num_warps=KV_NUM_WARPS,
     )
 
@@ -725,6 +773,8 @@ def _run_fused_small(
     conv_block_table: torch.Tensor,
     query_start: torch.Tensor,
     attention_slot_mapping: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
     *,
     eps: float,
     num_q_heads: int,
@@ -734,6 +784,7 @@ def _run_fused_small(
     off_v: int,
     conv_block_size: int,
     log_scaling: torch.Tensor | None,
+    kv_cache_fp8: bool,
 ) -> None:
     tokens = qkvr.shape[0]
 
@@ -757,6 +808,8 @@ def _run_fused_small(
         conv_block_table,
         query_start,
         attention_slot_mapping,
+        k_scale,
+        v_scale,
         log_scaling if log_scaling is not None else positions,
         tokens,
         eps,
@@ -787,6 +840,7 @@ def _run_fused_small(
         D_REL=16,
         REL_EXTENT=rel_proj.shape[1],
         REL_EXTENT_PADDED=triton.next_power_of_2(rel_proj.shape[1]),
+        KV_CACHE_FP8=kv_cache_fp8,
         num_warps=SMALL_NUM_WARPS,
     )
 
@@ -816,6 +870,8 @@ def fused_qkvr_prep(
     off_v: int,
     conv_block_size: int,
     log_scaling: torch.Tensor | None = None,
+    k_scale: torch.Tensor | None = None,
+    v_scale: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert d_rel == 16 and rel_proj.shape[0] == 16
     assert head_dim == 128
@@ -825,6 +881,16 @@ def fused_qkvr_prep(
     assert rel_proj.stride() == (rel_proj.shape[1], 1)
     assert conv_cache.stride(3) == 1
     assert key_cache.stride(3) == 1 and value_cache.stride(3) == 1
+    assert value_cache.dtype == key_cache.dtype
+    kv_cache_fp8 = key_cache.dtype in _FP8_KV_DTYPES
+    if kv_cache_fp8:
+        assert k_scale is not None and v_scale is not None
+        assert k_scale.dtype == torch.float32 and v_scale.dtype == torch.float32
+    else:
+        # Placeholder pointers; the kernels do not load them when
+        # KV_CACHE_FP8 is false.
+        k_scale = k_norm_weight
+        v_scale = k_norm_weight
     tokens = qkvr.shape[0]
     q_out = torch.empty(
         (tokens, num_q_heads * head_dim), dtype=qkvr.dtype, device=qkvr.device
@@ -856,6 +922,8 @@ def fused_qkvr_prep(
             conv_block_table,
             query_start,
             attention_slot_mapping,
+            k_scale,
+            v_scale,
             eps=eps,
             num_q_heads=num_q_heads,
             num_kv_heads=num_kv_heads,
@@ -864,6 +932,7 @@ def fused_qkvr_prep(
             off_v=off_v,
             conv_block_size=conv_block_size,
             log_scaling=log_scaling,
+            kv_cache_fp8=kv_cache_fp8,
         )
         return q_out, rel_out
 
@@ -886,6 +955,8 @@ def fused_qkvr_prep(
             conv_block_table,
             query_start,
             attention_slot_mapping,
+            k_scale,
+            v_scale,
             eps=eps,
             num_q_heads=num_q_heads,
             num_kv_heads=num_kv_heads,
@@ -893,6 +964,7 @@ def fused_qkvr_prep(
             off_k=off_k,
             off_v=off_v,
             conv_block_size=conv_block_size,
+            kv_cache_fp8=kv_cache_fp8,
         )
     _run_tiled_q(
         qkvr,


### PR DESCRIPTION
> Depends on vllm-project/tml-fa4#4 (fp8 kernel port with the `rescale_threshold` fix). Draft until that merges and the pin is bumped; see the dependency section. RFC: #54704.

## Purpose

Add opt-in fp8 e4m3 KV cache support for the Inkling model on SM100-family GPUs (`--kv-cache-dtype fp8`). bf16 remains the default and its behavior is unchanged. Halves attention KV cache bytes (7,168 -> 3,584 bytes/token/rank at TP4; the marginal per-token cost is carried by the 7 full-attention layers at 1,024 bytes/token/layer, while the 35 sliding-window layers hold only their 512-token window); conv state stays bf16, so realized pool gains depend on serving settings. Measured effects below.

What the wiring does:

- Gate (`vllm/models/inkling/nvidia/attention.py`): per-tensor e4m3 only (`fp8`/`fp8_e4m3`), SM100 family only. Other fp8 variants and other compute capabilities raise `NotImplementedError` at layer construction instead of running with wrong numerics (the store clamp is e4m3-specific, and no fp8 kernel path exists off SM100).
- Query quantization (`attention.py`): the FA4 fp8 entry points require q in the KV dtype, so the layer statically quantizes q via `QuantFP8` (per-tensor, plain torch ops so `torch.compile` can fuse it into preceding ops). Adds a per-layer `q_scale` buffer alongside the existing `k_scale`/`v_scale` buffers. Scalar descales are cached once after weight load so the hot path never syncs on a GPU scalar.
- Quant-on-store (`vllm/models/inkling/nvidia/ops/qkvr_prep.py`): both Triton write kernels (fused small-batch and tiled) quantize K/V to the cache dtype on store, clamped to the e4m3 finite range because Triton float-to-fp8 store casts do not saturate. Conv-state stores stay bf16. The fp8 branch is a `tl.constexpr` flag; the bf16 store path is unchanged.
- Descale handling (`vllm/models/inkling/nvidia/ops/fa4_rel_attention.py`): neither vendored varlen entry exposes descale parameters, so the QK descale is folded into `softmax_scale` (equivalent to an in-kernel fold: scores are descaled before the exact bf16 relative bias is added) and the V descale is post-multiplied on the output, which is linear in V. The fold sits outside the backend branch and is path-independent. fp8 routes to the sheared-bias tml-fa4 path on SM100; the cute score-mod path also supports fp8 and remains the cross-check and non-sheared fallback. Warmup compiles against the viewed e4m3 dtype and keeps output in the model dtype.
- Cache plumbing (`attention.py`): fp8 caches are allocated as uint8 and viewed as the platform e4m3 dtype at the layer; `kv_quant_mode` is set on both `FullAttentionSpec` and `SlidingWindowSpec`.
- Unity-scale warning (`vllm/models/inkling/nvidia/model.py`): with fp8 KV enabled, a load-time warning is emitted when the checkpoint ships `v_scale` tensors for fewer layers than run quantized. Coverage comes from the loader's return value, not buffer values, since calibrated scales can legitimately equal 1.0. Loaded scales are also validated finite and positive at load, and the cached scalar descales are re-read after any (re)load. V is the stream measured to exceed the e4m3 range at unity scale (see accuracy notes).

### Dependency on tml-fa4

vLLM consumes tml-fa4 as a build-time fetch pinned by `GIT_TAG` in `cmake/external_projects/tml_fa4.cmake` (installed into `vllm/third_party/tml_fa4/`). The pin is currently `b206834...`, which is exactly tml-fa4 main as of 2026-08-28, so once vllm-project/tml-fa4#4 merges, the pin bump to its merge commit is a one-line fast-forward with no interleaved upstream changes. Sequencing follows the workflow from vllm-project/tml-fa4#3: merge the kernel PR first, then bump the pin (in this PR or as its own commit), then land this PR. Without the bump the fp8 path fails at kernel invocation, so this PR stays in draft until the pin is updated.

### Accuracy

Kernel and unit level: 160/160 tests in the three test files this PR touches (`test_fa4_rel_attention.py`, `test_qkvr_prep.py`, `test_fa4_warmup.py`) on B200 (coverage described in the test plan).

Task level, fp8 KV vs bf16 KV, paired runs on B200: parity on GSM8K, MMLU (14,042 questions), IFEval, HumanEval, NIAH, and a 500-call tool-use replay, with paired statistics. Comparisons are like-for-like raw completions without the chat template or reasoning mode, so absolute scores sit below published chat-template baselines; the paired deltas are the measurement.

Known limitation: MATH-500 drops 4.2 points at unity scale (run-level p between 0.05 and 0.10). Root cause is V-outlier clipping in the global-attention layers (measured max |V| = 1,272 vs the e4m3 max of 448). A calibration A/B with a per-tensor `v_scale` of 3.0, sized from that measured range, recovers about half of the gap (37.7 -> 39.7 vs bf16 41.9). This is why the load-time warning above exists and why calibrated checkpoints are recommended for long-derivation workloads.

### Performance

Attention kernel speedups up to 1.45x at long KV (benchmarks in the tml-fa4 PR). Serving throughput is at parity (within +/-1.1%) at contexts up to 32K, and short-context latency has two regressions worth stating plainly (single-run benchmarks): decode-workload median TTFT is 10.2% worse under fp8 (143.7 -> 158.3 ms, though p99 improves 280.8 -> 188.8 ms) and mid-workload median TTFT is 2.7% worse (1,015.6 -> 1,043.1 ms). The end-to-end case is capacity and long context: KV capacity gains range from +5.9% (short `max_model_len`) to +73% depending on serving settings; the sensitivity table in the evidence document tabulates the settings. Live 1M-context validation: +73.06% capacity measured vs +73.1% predicted, 27/27 paired NIAH retrievals to 950K-token depth, TTFT 0.84x relative to bf16 at 1M.

### Scale calibration

Default scales are 1.0. Calibration stays out-of-tree, consistent with the documented KV cache quantization pathway (`docs/features/quantization/quantized_kvcache.md` recommends llm-compressor for scale calibration). A standalone script measures per-layer K/V ranges, derives scales from them, and writes the scales into the checkpoint as `model.llm.layers.<i>.attn.{k,v}_scale` tensors, which the existing loader picks up with no flags; a checkpoint calibrated this way loads correctly (warning stays silent) and holds GSM8K inside the healthy band. A follow-up can add an Inkling note to `quantized_kvcache.md` if maintainers want one.

### Rebase status

Runtime validation was done on the v0.28.0 base. Rebased onto main as of 2026-09-07 (51da0ca6). Conflicts with #53565 (FA4 warmup migration) were resolved by hand in `vllm/models/inkling/nvidia/attention.py` (the new `register_warmup()` call stays at the end of `__init__`, after the fp8 gate and scale buffers) and `tests/models/inkling/test_fa4_rel_attention.py` (adopted the renamed `_INKLING_FA4_REL_ATTENTION_KERNEL`). fp8 warmup keys now flow through the per-layer `register_warmup()`/`JitWarmupRegistry` mechanism that replaced the deleted `fa4_cutedsl_warmup` driver; the fp8 `CompileKey` handling in `get_warmup_keys()`/`compile()` is unchanged. The earlier `model.py` loader adaptation (`AutoWeightsLoader` `skip_prefixes` -> `WeightsMapper`) carries over. Aside from these merge adaptations the diff is unchanged from the previous revision. It has not been runtime-revalidated on main; CI on this PR is the confirmation.

### Not affected

Changes are under `vllm/models/inkling/nvidia/` and `tests/models/inkling/`, plus one small ROCm-side gate in `vllm/models/inkling/amd/attention.py` (second commit: quantized KV dtypes now fail at layer construction with an explicit `NotImplementedError` instead of a dtype error deep in the ROCm kernels; CPU test included). The bf16 path is untouched (fp8 branches compile out via `tl.constexpr` when disabled). On ROCm every previously working configuration behaves identically, including the non-quantized `float16`/`bfloat16` cache overrides; the only behavior change is that quantized dtypes now fail fast.

## Test Plan

All tests live under `tests/models/inkling/`, which the existing `:nvidia: (B200) Inkling` Buildkite entry (`.buildkite/test_areas/models_basic.yaml`, key `inkling-unit-tests-b200`) already registers via its `tests/models/inkling/` and `vllm/models/inkling/` source-file dependencies. No CI YAML change is needed.

- `test_qkvr_prep.py::test_qkvr_prep_fp8_cache_write`: quant-on-store roundtrip on both write kernels (fused small-batch and tiled) at unity and non-unity scales; dequantized cache contents match the bf16 run within e4m3 tolerance; q/rel outputs are bit-identical; conv state stays byte-identical bf16.
- `test_fa4_rel_attention.py`: fp8 attention numerics vs a dequantized-input fp32 reference across kernel paths (sheared tml-fa4, cute score-mod) x scale sets, with rel extents {128, 1024} for full attention and the sliding-window case at extent 128; spec test that fp8 sets `kv_quant_mode`; gate tests (accepts e4m3 on SM100, rejects e5m2, rejects SM90/SM120); ROCm gate test (quantized dtypes raise at layer construction, non-quantized dtypes pass; importorskip where the ROCm module cannot import); descales-required assertion test.
- `test_fa4_warmup.py::test_warmup_keys_fp8_kv_dtype`: warmup compile keys use the viewed e4m3 dtype for fp8 caches.

Command: `pytest -v -s tests/models/inkling` (the fp8 FA4 kernel tests require SM100 and skip elsewhere; the bf16 FA4 tests require SM90+; CI runs this on B200).

## Test Result

160/160 in the three test files this PR touches (`test_fa4_rel_attention.py`, `test_qkvr_prep.py`, `test_fa4_warmup.py`) on B200, run log `full_suite4.log` (v0.28.0 base plus the tml-fa4 kernel commit, with both wiring commits applied; the count includes the second commit's ROCm gate test). The 87 pre-existing tests within those files are unchanged and passing. CI runs the whole `tests/models/inkling/` directory, which contains additional pre-existing test files beyond these three, so the directory-wide CI count will exceed 160. Task-level eval results are summarized above; the full evidence document (methodology, pre-registered gate scorecard, per-run artifacts index) is attached below in a collapsed section.

## AI assistance disclosure

This PR includes AI-generated code. AI assistance (Claude) was used to implement, test, benchmark, and document the change. The submitter has reviewed every changed line and validated behavior end-to-end on B200 hardware. Commits carry `Co-Authored-By` trailers alongside `Signed-off-by`.

---


<details>
<summary>Evidence document (methodology, gate scorecard, per-run artifacts index)</summary>

## FP8 KV cache for Inkling: measured results

All numbers measured on Nebius B200 (SM100). Serving comparisons use two
identical vLLM v0.28.0 servers on one 8x B200 host: bf16 KV on GPUs 0-3
(port 8000), fp8 KV (`--kv-cache-dtype fp8`) on GPUs 4-7 (port 8001),
TP4, nvfp4 weights, max_model_len 131072, max_num_seqs 16, prefix caching
on, greedy decoding, seed 1234. Kernel-path coverage: GSM8K, MMLU,
IFEval, HumanEval, Tier 3 v2, and NIAH ran with both servers pinned to
the cute score-mod path (single-variable dtype comparison); GSM8K,
MATH-500, MMLU (rerun), tool calling, Tier 3 v3, NIAH (rerun), and the serving benches
ran on the production tml-fa4 sheared path after the pin was removed.
Kernel-level numbers are from the 1x B200 host. Raw artifacts live in
`evals/results/` and scripts in `evals/` of the submitter's evaluation
archive (not part of this PR; available on request); the pre-registered
plan (EVAL_PLAN.md) ships in the same archive. This document was revised after
an internal review that independently re-verified the measurements; the
"Pre-registered gate scorecard" section discloses every deviation from
EVAL_PLAN.md.

### Tier 0: kernel correctness

160/160 tests green on the final tree (`full_suite4.log`; earlier runs:
`full_suite3.log` 160/160, `full_suite2.log` 159/159 pre-ROCm-gate-test),
covering both FA4 backends
(tml-fa4 sheared-bias, cute score-mod), fp8 x {sheared, scoremod} x
scale sets {(1,1,1), (0.5,0.5,1.5)} x rel extents {128, 1024} at
atol/rtol 0.15 vs a dequantized-input fp32 reference, plus qkvr_prep
write-path roundtrip and gate tests (including the ROCm-side
quantized-KV rejection gate). `collect_3files.log` pins the 160 to
exactly the three test files this contribution touches (the base
tree's subset of those files collects 87); tests/models/inkling/ also
holds pre-existing test files outside this count, so a directory-wide
CI run counts more than 160.

Includes the correctness fix over abandoned upstream PR
vllm-project/tml-fa4#1: with fp8 P pre-scaled by 2**max_offset
(max_offset = 8),
lazy-rescale slack is bounded by log2(448) - 8 = 0.807, but that PR set
rescale_threshold=4.0. Attention bias makes row-max jumps below the
threshold routine, clipping P (six deterministic failures, 0.3-0.7 abs
error). Fixed with rescale_threshold=0.75 for fp8; root cause proven
by zero-bias diagnostic plus three-arm bisection: threshold=0 fixes,
max_offset=0 fixes, and disabling the ex2 emulation tuning does not
(the original ex2 arm failed to apply per bisect.log; it was rerun
with a fixed harness at the bug threshold and the 6 failures persist
with ex2 tuning off; regate_validate.log). Artifacts: `bisect.log`,
`diag_bias.py`, `regate_validate.log`; the zero-bias diagnostic runs
are archived as `diag_bias_bugthreshold.log` (kernel at the PR #1
threshold 4.0: bias-on cases fail with 0.30-0.49 abs error, bias-off
cases pass) and `diag_bias.log` (shipped 0.75 kernel: all cases pass).

On the choice of 0.75: the 0.807 bound is the design invariant that
guarantees zero P clipping; it is not an empirically sharp cliff at
test tolerance. A threshold bracket (`bracket.log`) shows 0.75, 0.80,
and 0.81 all pass the fp8-sheared suite (a 0.003 (log2 units) violation clips
only values within 0.2% of the e4m3 ceiling, below the 0.15 test
tolerance); the extended bracket (`bracket2.log`) locates the
empirical failure onset between 1.5 and 2.0 with monotonic
dose-response beyond it (1.0 pass, 1.5 pass, 2.0: 4 failures, 3.0: 6
failures; the original 4.0 threshold fails 6, per the pre-fix suite
`fa4_suite.log`). 0.75 is chosen to guarantee the invariant
with margin for compiler reassociation rather than to sit at the
empirical edge.

### Tier 1: kernel performance

Attention kernel (`bench_kernel_results.jsonl`, 20 cases): fp8-sheared
is faster than bf16-sheared in 18 of 20 cases and slower in 2:
decode_kv65536_b1_tp4 (105.5 -> 108.2 us, +2.6%) and
local_prefill_q8192_tp1 (340.7 -> 341.6 us, +0.3%). Best cases: 1.45x
batched decode at kv=64K b=32 (1,658 -> 1,140 us), 1.41x at 32K b=32,
1.23x chunked prefill 64K (1,855 -> 1,509 us), ~1.05x single-stream
decode. The cute score-mod path is ~7x slower than sheared at prefill,
which is why the tml-fa4 port was required rather than score-mod-only
fp8.

Write path (`bench_qkvr_results.jsonl`, 12 cases: 2 head configs x
{sliding, global} x {33, 2048, 16384} tokens): fp8 quant-on-store costs
-1.3% to +2.0% vs bf16 store (median ratio 1.01). The added
multiply+clamp+convert is offset by halved write bytes.

### Tier 2: KV value range at unity scale

The nvfp4 checkpoint carries no k/v scale tensors, so serving runs at
k_scale = v_scale = 1.0. Measured by hooking fused_qkvr_prep during a
24K-token PG19 prefill and gathering exactly the stored values at each
call's slot mapping (do not scan the cache pool: one layer's view spans
the whole shared pool including conv pages; that reads other groups'
raw activations and poisons the stats).

An internal review found the first hooked run keyed accumulators by
cache data_ptr, which collides across the 6 layers sharing each KV
cache group tensor; that run's per-layer rows and sliding/global split
were invalid, and its "subnormal" counter actually measured values
below e4m3's minimum representable magnitude. The corrected rerun
(layer-identity keying with loud invariants, exact e4m3 band counters
at scale 1.0 and 3.0, position-unbiased sampling) gives, per true
layer, pooled within layer type:

| type.stream | max abs | p99.99 (worst layer) | clip @s=1 (pooled / worst layer) | flush-to-zero @s=1 | clip @s=3 | flush @s=3 | rt err |
|---|---|---|---|---|---|---|---|
| sliding.K (35) | 55.8 | 50.8 | 0 / 0 | 2.8e-4 | 0 | 8.5e-4 | 2.3% |
| sliding.V (35) | 812.0 | 312.0 | 1.8e-7 / 2.7e-6 | 1.9e-3 | 0 | 5.7e-3 | 2.6% |
| global.K (7) | 73.5 | 51.8 | 0 / 0 | 2.2e-4 | 0 | 6.5e-4 | 2.3% |
| global.V (7) | 1272.0 | 624.0 | 1.3e-4 / 9.1e-4 | 6.1e-4 | 0 | 1.8e-3 | 2.4% |

K never clips at unity scale, anywhere. V clipping concentrates in the
global attention layers: worst single global layer clips 9.1e-4 of its
V elements (about 1 in 1,100) at unity scale, while sliding-layer V
clipping is ~300x rarer in the worst layer (and ~700x rarer pooled). Global layers carry the long-range
information, which is consistent with the deficit surfacing on
long-derivation math and nowhere else. At v_scale = 3.0, clipping is
exactly zero in every layer and the flush-to-zero band grows ~3x
(quantified above); the calibration A/B empirically bounds that
side-effect as harmless (MATH-500 improved, GSM8K held).

### Tier 3: position-stratified prompt logprobs (long context)

Scripts: `evals/tier3_ppl.py` (v1), `evals/tier3_ppl_v2.py` (v2, adds a
same-server control arm and per-position dumps). PG19 books truncated
at 129K tokens (longest document 121K) via the server tokenizer;
per-position actual-token NLL
and top-5 from both servers; buckets [0,4K), [4K,16K), [16K,64K),
[64K,128K).

v2 (10 docs, 860K scored positions, three arms per doc: bf16 twice as
a control, fp8 once; distinct nonce prefix per pass to force cache
misses), score-mod path:

| bucket | n | dNLL ctrl (bf16 rerun) | dNLL fp8 | top1 agree ctrl | top1 agree fp8 |
|---|---|---|---|---|---|
| 0-4K | 40,960 | +0.0201 | +0.0082 | 88.4% | 88.0% |
| 4K-16K | 122,880 | +0.0130 | -0.0042 | 88.2% | 87.3% |
| 16K-64K | 471,857 | +0.0090 | -0.0048 | 88.2% | 87.2% |
| 64K-128K | 224,400 | -0.0210 | +0.0078 | 90.5% | 89.6% |

Point-estimate fp8 deltas are within +/-0.0083 nats (<=0.83% PPL) per
bucket and |dNLL fp8| < |dNLL ctrl| in all four buckets. Per-doc
hardening (from the review): the doc-level exact sign-flip test on fp8
log-PPL deltas gives p = 0.85 (6+/4-, mean -0.26%); paired |fp8 delta|
vs |control delta| gives p = 0.59 with fp8 the smaller divergence on
average. Two caveats the review established: (a) the control spread is
not batching: the three passes were sequential on idle servers, which
Tier 7 shows is deterministic; the a1-vs-a2 spread comes from the
distinct nonce prefixes shifting conditioning and chunk boundaries
(same-server per-doc PPL moved up to 21% under a one-line prefix
change, a sensitivity result in its own right). (b) This design's
doc-clustered 95% CI on the fp8 effect is roughly +/-2% PPL, so it
bounds the fp8 effect at ~2% but cannot certify the pre-registered 1%
margin; the measured point estimates are all inside 1%, and the
position trend is confounded by bucket composition (the deepest bucket
draws from 8 of 10 docs).

v3 (`evals/tier3_ppl_v3.py`, authoritative) removes the noise
entirely: one shared nonce per document sent to both servers,
sequential and cache-missed (a probe validates determinism and
cache-hit logprob integrity first), so the per-position delta is the
pure dtype effect. Run on the production sheared path against both
fp8 configs (unity and v_scale=3.0), same 10 documents.

Documents split cleanly into two regimes. The split keys on a
dtype-independent property: the cross-run replication spread of the
bf16 control arm on identical text. Five stable documents
(baseline PPL 8-19) replicate tightly across both fp8 configs and
give the clean dtype measurement. Five replication-unstable documents
(one at PPL 14, four at PPL 35-143) are chaotic amplifiers: their measured "fp8 effect"
swings between -13.6% and +13.1% across three near-identical fp8
configurations on identical text (doc 0: -13.6% score-mod unity vs
the mean of the two bf16 control passes, +1.9% sheared unity, +13.0%
sheared cal; the +13.1% endpoint is doc 8 under sheared cal), the
same instability the
v2 control showed under a one-line prefix change. Corpus-pooled PPL
through such documents is an unstable instrument regardless of dtype.

Stable-document, position-stratified, pure-dtype deltas (positive =
fp8 worse):

| bucket | n | unity dNLL (%PPL) | cal dNLL (%PPL) | top1 agree |
|---|---|---|---|---|
| 0-4K | 20,480 | -0.70% | +0.71% | 91% |
| 4K-16K | 61,440 | -0.44% | +0.08% | 93% |
| 16K-64K | 234,615 | +0.05% | +0.004% | 94% |
| 64K-128K | 95,490 | +0.09% | +0.04% | 94% |

Every bucket is inside the pre-registered 1% margin under a
noise-free design; the deepest bucket shows ~0.1% or less on both
configs; top-1 agreement rises with depth. No compounding of fp8 KV
error over context depth is observed on the shipped kernel path.
Median per-document PPL delta across all 10 docs: +0.21% (unity),
+0.16% (cal). v1 (6 docs, no control; `tier3_ppl_results.json`) and
v2 are kept in evals/results/ for provenance.

### Tier 4: task accuracy, paired per-sample

Both servers answer every question from identical prompts; outcomes pair
by doc_id. McNemar exact test on discordant pairs.

| task (n) | bf16 | fp8 | discordant (bf16/fp8) | McNemar p |
|---|---|---|---|---|
| GSM8K strict, 5-shot (1319) | 82.79% | 84.61% | 82 / 106 | 0.093 |
| GSM8K flexible (1319) | 79.30% | 81.12% | 109 / 133 | 0.139 |
| MMLU-generative (14,042) | 79.05% | 79.18% | 342 / 360 | 0.521 |
| IFEval prompt-strict (541) | 29.57% | 29.76% | 35 / 36 | 1.000 |
| HumanEval pass@1 (164) | 10.98% | 15.24% | 3 / 10 | 0.092 |

No individually significant difference on any of these tasks. Note the
caveats: all runs share seed 1234 and a per-task fixed few-shot prefix
with prefix caching on, so paired samples within a task are not fully
independent draws, and five comparisons across four tasks constitute
multiple comparisons (the
per-task p-values are reported uncorrected).

Control (same bf16 server, GSM8K run twice, same seed): 82.79% vs
82.41% (91/86 discordant, p=0.76), and only 22.7% of greedy generations
byte-identical across reruns. Batching nondeterminism alone flips most
long greedy generations; bf16-vs-fp8 divergence (14.5% byte-identical)
is close to that same-server baseline. MMLU short answers: 92.4%
byte-identical across bf16 vs fp8. Per-sample outputs for the MMLU and
HumanEval pairs are archived under evals/results/tier4_samples/; the
paired counts and byte-identity figures re-derive from them via
evals/paired_mmlu.py, evals/paired_mmlu_sheared.py, and
evals/paired_analysis.py.

IFEval and HumanEval absolute scores are low because prompts go through
the raw completions endpoint without a chat template (HumanEval also
drops the fifth stop string "\nprint": the OpenAI completions API caps
`stop` at 4; the humaneval_4stop task is stock HumanEval with four stop
sequences, per-sample outputs under `evals/results/tier4_samples/`);
the comparison between
servers is still like-for-like.

Production kernel path (tml-fa4 sheared-bias with the threshold fix;
servers restarted with the score-mod pin removed), GSM8K 5-shot and MMLU:

| pair | A | B | discordant | McNemar p |
|---|---|---|---|---|
| GSM8K sheared bf16 vs sheared fp8 (strict) | 83.32% | 82.49% | 92 / 81 | 0.447 |
| GSM8K sheared bf16 vs sheared fp8 (flexible) | 79.00% | 78.85% | 119 / 117 | 0.948 |
| MMLU-generative (14,042) sheared bf16 vs sheared fp8-calibrated | 78.91% | 79.11% | 332 / 360 | 0.305 |

The MMLU rerun closes the kernel-path coverage gap at the largest
sample size in the battery, on the recommended configuration
(calibrated fp8), with 92.3% byte-identical generations. The original
run's 18-hour wall time was diagnosed as unauthenticated HF dataset
downloads under rate limiting; with the datasets cached, the rerun's
evaluation time was ~6.5 minutes per arm (total_evaluation_time_seconds
in the archived results).

Dtype parity holds on the production path, with the point estimate
landing on bf16's side this time. The kernel-swap contrasts, measured
rather than asserted: at fixed fp8 the swap moves GSM8K -2.1pt
(p=0.051); at fixed bf16 it moves +0.53pt (p=0.664); the dtype-x-kernel
interaction from the paired 2x2 is +2.65pt +/- 1.40 (z=1.89, p=0.059);
not established at one run per cell against a ~1pt same-config
noise floor, and not ruled out. The score-mod fp8 run (84.61) is the
highest of eight GSM8K runs, and both borderline p-values are that same
run re-cut. Sheared-path Tier 3 v3, NIAH, and MMLU (n=14,042, p=0.30)
now cover the shipped configuration directly.

minerva_math500 (sheared servers, math_verify metric) is the one
regression the program surfaced, established with triplicate runs per
server. Not pre-registered in EVAL_PLAN (added after GSM8K showed
parity, to probe harder math); statistics below use run-level
inference because per-question outcomes within a run share run-level
shocks (fixed seed, shared few-shot prefix under prefix caching), which
a review showed inflates question-level sign tests:

- bf16 runs: 41.8%, 42.0%, 42.0% (math_verify; the same runs spread
  17.0-20.8% on the stricter exact_match metric, so run-to-run swings
  of ~19 questions occur even at fixed dtype)
- fp8 runs: 36.0%, 39.4%, 37.8%
- Run-level Welch t on run scores: p = 0.051. Exact run-label
  permutation: p = 0.10, the floor any 3-vs-3 design can reach.
  bf16's worst run beats fp8's best run in all 9 cross-run pairings on
  both metrics. Descriptively, pooling the three runs per side, bf16
  wins the per-question correct-count on 114 questions vs 73 for fp8
  (313 tied); the question-level sign test on those counts (p=0.0033)
  overstates significance because the 187 signs are not independent.

A ~4 point mean deficit on hard competition math, consistent in
direction across every run pairing, while GSM8K (easier math, 3
independent comparisons), MMLU (n=14,042), IFEval, HumanEval, tool
calling, and NIAH all show parity. Long multi-step derivations are
where small per-token perturbations compound into derailment.
Generation-length analysis rules out truncation (distributions
near-identical, no cap hits). Per-question samples for all nine runs
and the analysis scripts are archived under
evals/results/math500_samples/.

Tier 2 supplied the mechanism candidate (V outliers clip at unity
scale, see Tier 2 above) and the calibration A/B validated it. The fp8
server was relaunched with a per-tensor v_scale = 3.0 (sized from the
measured max |V| = 1,272 vs the e4m3 max 448) and MATH-500 rerun in
triplicate:

| config | runs | mean | descriptive per-question counts vs bf16 |
|---|---|---|---|
| bf16 | 41.8 / 42.0 / 42.0 | 41.9 | - |
| fp8 unity | 36.0 / 39.4 / 37.8 | 37.7 | 114 / 73 bf16-favored |
| fp8 v_scale=3.0 | 41.0 / 38.4 / 39.8 | 39.7 | 116 / 91 bf16-favored |

Calibration recovers about half the mean deficit (37.7 -> 39.7); its
best run (41.0) comes within 0.8pt of the weakest bf16 run, which
unity never approaches (best 39.4), and
cal beats unity head-to-head on 116 vs 95 questions. (The same
run-level caveat applies to all per-question counts here; at 3 runs per
arm no cal-vs-bf16 or cal-vs-unity contrast reaches run-level
significance either way.) GSM8K on the calibrated server is 83.55%
strict, dead center of the healthy band, so the calibration costs
nothing elsewhere. The residual ~2pt mean gap is not statistically
established at n=500x3; e4m3's inherent mantissa roundtrip error on V
is a candidate explanation but is not established either.

PR framing this supports: the patch wires per-tensor k/v scales end to
end; checkpoints without calibrated KV scales run at unity and can
degrade on long-derivation tasks when V outliers clip (measured here:
-4.2pt mean on MATH-500, run-level p=0.05-0.10, direction consistent
across all 9 run pairings; everything else at parity); calibrating
v_scale from observed ranges recovers about half of that and moves the
comparison inside the noise band. The patch closes its own loop:
loading fp8 KV from a checkpoint that provides v_scale tensors for
fewer layers than run quantized logs a warning naming the failure
mode (a count-based coverage check at the model level from the
loader's return value, since buffer values cannot distinguish
defaults from calibrated 1.0 scales), and
the standalone calibration script (out of tree, in the evaluation
archive as tools/calibrate_kv_scales.py) measures real per-layer K/V ranges (the
Tier 2 hook), derives per-layer scales that map the observed range
into e4m3 clip-free, and writes them into the checkpoint as
`model.llm.layers.<i>.attn.{k,v}_scale` tensors, which the existing
loader picks up with no flags.

Calibration of this checkpoint touches only what needs touching: at
the shipped safety-1.3 rule, 14 of 42 layers get a non-unity v_scale
(layer 29, global, owns the max |V| = 1,272 outlier at scale 3.69;
next: layer 37 at 2.36, layer 35 at 2.05), no layer needs a k_scale,
and V ranges trend upward with depth (0.6 at layer 0 to hundreds
past layer 25). Strictly finer than the global v_scale = 3.0 used in
the A/B, which over-scaled 41 layers.

The warn/load matrix is verified on live engines: uncalibrated
checkpoint -> buffers read unity and the warning fires; calibrated
checkpoint -> per-layer values load through the standard
AutoWeightsLoader path (spot-checked layer 29 post-load) and the
warning stays silent. GSM8K on a per-layer-calibrated server: 82.41%
strict, and a confirmation run on the final boot scored 82.34% strict
/ 78.47% flexible (final_check.log,
gsm8k_fp8_final_results.json), both inside the healthy band (82.3-84.6
across the runs reported here).
Artifacts: calibrate.log, check_scales.log, warn_test.log,
gsm8k_fp8_percal_results.json, recal_verify.log.

The warning and utility were re-reviewed against upstream conventions
and fixed
accordingly: the warning keys on tensor coverage from the loader's
return value, not buffer values (a calibrated checkpoint can
legitimately carry scales equal to 1.0, indistinguishable by value
from defaults), and fires when the checkpoint provides v_scale
tensors for fewer attention layers than run quantized, V being the
measured clipping stream; load-time validation additionally rejects
non-finite and non-positive scales, and the cached scalar descales
are invalidated on (re)load; the utility rejects
index-less checkpoints before writing anything and updates the index
atomically (tmp + fsync + rename); the scale rule was rewidened to
s = max(1, max|x| * 1.3 / 448) and its docstring rescoped from
"guarantee" to
an empirical, sample-scoped bound (the earlier 2% headroom over a
single document's max was thin against heavy-tailed V; the A/B already
showed ~3x over-scale costs nothing). Two earlier live-caught bugs are
part of the record: a per-layer forward-path warning that mis-fired on
calibrated checkpoints, and the value-vs-presence confusion above.

Upstream-convention findings (from the research pass, with citations
in the review artifacts): the emitted tensor names are already vLLM's
canonical post-remap form and load with no remapping; v0.28.0 has no
runtime KV-scale calculation, so static checkpoint scales are the
designed mechanism; llm-compressor cannot calibrate this model because
its HF-side observers never see Inkling's post-norm/post-conv fused
store sites, which is exactly what the hook measures; and an opt-in
--declare-kv-scheme flag records kv_cache_quant_algo=FP8 so
kv_cache_dtype="auto" resolves to fp8 for consumers of the checkpoint.

Tool calling, 500-call gateway replay (evals/tier4_toolcall_replay500.py,
the pre-registered instrument: deterministic corpus of 450 positive +
50 negative scenarios over 10 schemas, scored by the serving
gateway's tool-call validator with the corrective-retry loop
disabled so dtype-induced malformations cannot be masked; primary
pass requires a well-formed call on tool-expected prompts (valid
JSON arguments conforming to the called tool's schema) and correct
silence on negatives; selection of the expected tool is reported
separately below;
run against the 1M-boot sheared pair, calibrated fp8):

- primary pass: bf16 475/500 vs fp8 474/500; McNemar discordant 2/1,
  p = 1.0 (parity)
- every emitted call on both arms: 100% JSON-valid, 100% schema-valid,
  zero repairs invoked
- negatives: 50/50 correctly silent on both arms
- expected-tool selection: fp8 424/450 vs bf16 418/450
- decision agreement 497/500; exact-argument agreement 409/423 of
  both-called
- one symmetric model finding: the send_report nested-object schema
  passes only ~20/45 on both arms (a model property, not a dtype one)

The earlier 20-prompt smoke (tier4_toolcall.py) is superseded.

### Tier 7: determinism

Tier 7 sits here, after Tier 4, because it interprets the
byte-identity numbers above. Repeating the same prompt sequentially
with no concurrent load is byte-identical on both servers (one
distinct output per server); repeating it under concurrent noise load
yields 2 distinct outputs on both servers (tier7.log,
tier7_determinism.log). Greedy decoding is deterministic at
fixed batch composition for bf16 and fp8 alike; batching composition is
the sole source of nondeterminism and is dtype-independent.

### Tier 5: needle-in-a-haystack retrieval

`evals/tier5_niah.py`: paired retrieval of a 6-digit code planted in
PG19 haystacks. Grid: lengths {16K, 64K, 120K} tokens x depths
{10, 30, 50, 70, 90}% x 8 trials = 120 paired prompts. This is a custom
single-needle test substituted for the pre-registered RULER suite (see
scorecard); it does not cover multi-needle, variable tracking, or
aggregation.

bf16 120/120, fp8 120/120 on the score-mod path, and again 120/120 vs
120/120 on the production sheared path (fp8 unity;
`tier5_niah_sheared_results.json`). The task is saturated for this
model, so the result rules out catastrophic retrieval failure under
fp8 at any depth up to 120K; it has no sensitivity to graded
degradation. Tier 3 v3's per-position logprobs are the graded
long-context instrument.

### Tier 6: end-to-end serving performance

`vllm bench serve`, random dataset, greedy, both servers on the
production sheared path, TP4 (results in evals/results/bench_serve/):

| workload | metric | bf16 | fp8 |
|---|---|---|---|
| decode: 1K in / 1K out, conc 16 | output tok/s | 1,769.8 | 1,776.0 |
| | median TPOT ms | 8.89 | 8.86 |
| mid: 8K in / 256 out, conc 16 | total tok/s | 34,754.6 | 34,377.1 |
| | median TTFT ms | 1,015.6 | 1,043.1 |
| long: 32K in / 128 out, conc 8 | total tok/s | 71,639.1 | 71,533.3 |
| | median TTFT ms | 1,734.8 | 1,726.8 |
| xl: 100K in / 64 out, conc 4 | total tok/s | 87,164.5 | 89,079.9 |
| | median TTFT ms | 2,894.5 | 2,826.9 |
| | median TPOT ms | 26.5 | 25.9 |

Throughput parity within +/-1.1% at contexts up to 32K; latency mostly
at parity with two exceptions: decode-workload
median TTFT is 10.2% worse under fp8 (143.7 -> 158.3 ms; mean +3.4%,
though p99 improves 280.8 -> 188.8 ms), and mid-workload median TTFT is
2.7% worse (1,015.6 -> 1,043.1 ms). Attention is a minor share of
end-to-end time for a 12B-active MoE at TP4 in these regimes, so the
kernel-level fp8 wins (which grow with KV length; 1.45x at kv=64K) do
not surface there. At 100K-token prefills the win shows end-to-end:
+2.2% total throughput, -2.3% median TTFT, -2.0% median TPOT. All
figures are single benchmark runs per cell; the serving-level case for
fp8 KV is capacity (see below) plus long-context headroom.

### 1M-context live validation

Both servers rebooted at max_model_len 1,048,576 (max_num_seqs 8,
production sheared path, calibrated fp8), plan written and reviewed
before the runs (evals/tier5_1m_plan.md). Results
(tier5_niah_1m_results.json, onem_stage.log):

Capacity, live pool lines vs the offline sensitivity model:

| boot | bf16 pool | fp8 pool | live gain | predicted |
|---|---|---|---|---|
| mnbt 2,048 | 14,780,269 (14.10x) | 25,578,250 (24.39x) | +73.06% | +73.1% |
| mnbt 8,192 | 9,594,537 (9.15x) | 13,606,845 (12.98x) | +41.8% | +41.9% |

Both ratios match the model to a tenth of a point; absolutes sit
2.5-4.4% above the table because the smaller profiling pass frees
activation memory (predicted in the plan). The same hardware holds 24 concurrent
1M-token requests under fp8 vs 14 under bf16.

Needle retrieval, paired, cache-cold (per-trial nonce), 27 prompts:
256K/512K x depths {0.1,0.5,0.9} x 2 + 1M x depths
{0.05,0.25,0.5,0.75,0.95} x 3. Result: bf16 27/27, fp8 27/27,
including needles ~950K tokens behind the query. Zero preemption, OOM,
or CUDA errors on either server during the grid.

Time to first token (median, true TTFT from first SSE chunk,
single cold request):

| context | bf16 | fp8 | ratio |
|---|---|---|---|
| 256K | 5.1 s | 4.9 s | 0.96x |
| 512K | 12.3 s | 11.2 s | 0.91x |
| 1M | 31.3 s | 26.2 s | 0.84x |

The fp8 prefill advantage grows monotonically with context length,
reaching -16% at 1M, consistent with the kernel-level scaling (fp8
attention gains grow with KV length).

Capacity gate closure: the offline scan (capacity_analysis_1m.py) reproduces all
four logged pool counts token-exactly through vLLM's own
get_kv_cache_configs, at scanned memory values consistent with the
freed activation footprint (119.4 / 117.3 GiB vs the archived 114.4
at 16,384-token chunks). Artifacts: cap1m_scan.log, onem_stage.log.

### Capacity: pool accounting, reconstructed through vLLM's own code

`evals/capacity_analysis.py` rebuilds the servers' KV pool through
vLLM's own get_kv_cache_configs. Available memory is not logged at
byte precision, so the script scans it (one free parameter per config)
and checks whether the logged outputs fall out. They do, jointly: the
exact token count and the concurrency figure for both servers, at
scanned memory values (114.402 / 114.370 GiB) that land inside the
GiB-rounded values the servers logged (114.4 / 114.37). With one knob
matching three observables per config, the group structure and
per-request block math below are corroborated, not fitted.

Where the blocks go per max-length request (131,072 tokens):

| group | bf16 blocks | fp8 blocks |
|---|---|---|
| conv state, 6 groups x 7 layers | 49,164 | 49,164 |
| sliding attention, 5 groups x 7 layers | 5,205 | 2,605 |
| full attention, 1 group x 7 layers | 4,096 | 2,048 |
| total | 58,465 | 53,817 |

fp8 halves the attention terms (exactly for full attention; to within
per-group rounding for sliding). The pool is dominated by the
sconv state groups: SlidingWindowSpec(window=4, block_size=4) with a
32 KiB page (4 packed streams, head width pow2-padded 1280 -> 2048, bf16
pinned) must reserve cdiv(min(window-1+max_in_flight_tokens, mml), 4)+1
blocks per request, and max_in_flight_tokens = 2 async batches x 16,384
batched tokens = 32,768. The conv page also sets the uniform page size,
scaling attention block_size to 32 (bf16) / 64 (fp8).

Capacity gain vs serving settings (same memory, vLLM's own math):

| max_model_len | batched tokens | bf16 pool | fp8 pool | gain |
|---|---|---|---|---|
| 8,192 | 16,384 | 317,012 | 335,644 | +5.9% |
| 131,072 | 16,384 | 1,200,271 | 1,303,934 | +8.6% |
| 131,072 | 8,192 | 2,239,900 | 2,509,704 | +12.0% |
| 131,072 | 2,048 | 6,392,807 | 8,189,269 | +28.1% |
| 524,288 | 16,384 | 3,967,258 | 4,681,299 | +18.0% |
| 1,048,576 | 16,384 | 6,442,622 | 8,237,213 | +27.9% |
| 1,048,576 | 8,192 | 9,356,357 | 13,272,591 | +41.9% |
| 1,048,576 | 2,048 | 14,159,015 | 24,509,531 | +73.1% |

fp8 KV halves attention KV bytes (7,168 -> 3,584
bytes/token/rank at TP4; the marginal per-token cost, carried by the 7 full-attention layers, with sliding-window layers capped at their 512-token window); the realized pool
gain depends on how much of the pool the model's conv-state admission
reserve consumes, which is orthogonal to this change.

### Pre-registered gate scorecard

Every acceptance threshold in EVAL_PLAN.md (the pre-registered plan
ships in the artifact archive), plus the tier-level deliverables that
changed, with verdicts and deviations declared. The plan's Tier 3 KL
metric was superseded by the per-position dNLL/top-1 design; the Tier
6 and Tier 7 deliverables are covered in their sections above:

| gate (as pre-registered) | verdict |
|---|---|
| Teacher-forced PPL delta <= 1.0% (wikitext-103, long-doc) | PASS, certified by Tier 3 v3 (noise-free pure-dtype design, production path, both fp8 configs): every stable-document bucket within +/-0.71%, deepest bucket ~0.1%. Declared deviations: PG19 book-length documents substituted for wikitext-103 (test split too short for 128K contexts); replication-unstable documents excluded from certification as demonstrated chaotic amplifiers (their swings are config-unstable and dtype-independent). |
| Top-1 agreement >= 99% (short) / >= 97% (long) | FAILED as written: observed 87.2-89.6%. The gate was ill-posed: the bf16-vs-bf16 control arm itself scores 88.2-90.5% under single-prefix perturbation, so no dtype could pass it. Reframed: fp8 top-1 agreement is within ~1pp of the same-server control in every bucket. |
| KV clip rate 0% observed at unity scale | FAILED on V: pooled 2.2e-5, worst pool 1.3e-4 (K: exact 0). The plan's own fallback (calibrated v_scale) was executed and reported; the failure is the mechanism behind the MATH-500 deficit. |
| GSM8K delta <= 1pt vs canonical evaluator | The canonical-evaluator cross-check was not run: serving is raw completions without chat template or reasoning mode, which is also why absolute GSM8K (82-85%) sits ~12pt below the model family's published baseline. Within-harness deltas: 0.83pt sheared (inside gate), 1.82pt score-mod (outside gate, fp8-favored, p=0.093). |
| RULER per-length recovery vs bf16 >= 97% (8K-64K) | NOT RUN; substituted by a custom paired single-needle NIAH (120/120 both dtypes). Declared limitation: no multi-needle, variable-tracking, or aggregation coverage. |
| Decode ITL regression at short context: none outside noise | PASS: decode-workload median TPOT 8.89 ms (bf16) vs 8.86 ms (fp8), single run per cell (Tier 6). |
| Tool-calling replay, 500 calls via gateway harness | RUN as pre-registered (see Tier 4): parity (475 vs 474 primary pass, McNemar p=1.0), 100% schema validity both arms, zero repairs. |
| Scale sweep {0.5, 1.0, 2.0} serving robustness | NOT RUN at serving level. Kernel tests sweep scales (0.5, 0.5, 1.5) and unity; serving-level scale evidence comes from the unity vs v_scale=3.0 A/B instead. |
| Optional e5m2 smoke test (storage dtype accepted, tests pass) | Deviation: the plan anticipated accepting e5m2 storage; the implementation rejects fp8_e5m2 with a clear error (e4m3 only), and the rejection gate tests pass (kernel + CPU). |
| minerva_math500 + run-level statistics | Not pre-registered; added exploratorily after GSM8K parity, then replicated (3 runs/arm) with the unity-scale V-clipping mechanism validated by the calibration A/B. Reported with run-level statistics. |

### Environment

vLLM v0.28.0, torch 2.13.0, triton 3.7.1, CUDA-capability SM100
(B200 183GB). Model: Inkling-Small 276B/12B MoE, nvfp4 checkpoint,
42 layers (35 sliding-window 512 + 7 global), 8 KV heads, head_dim 128,
sconv kernel 4, hybrid attention with learned relative position bias,
no RoPE.

</details>

