### PR TITLE
[Bugfix] Reject tokenless chat and audio streams

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -374,13 +374,13 @@ async def async_request_openai_chat_completions(
     output.prompt_len = request_func_input.prompt_len
 
     generated_text = ""
-    ttft = 0.0
     st = time.perf_counter()
     output.start_time = st
     most_recent_timestamp = st
     try:
         async with session.post(url=api_url, json=payload, headers=headers) as response:
             if response.status == 200:
+                first_chunk_received = False
                 handler = StreamedResponseHandler()
                 async for chunk_bytes in response.content.iter_any():
                     chunk_bytes = chunk_bytes.strip()
@@ -404,9 +404,9 @@ async def async_request_openai_chat_completions(
                             if choices := data.get("choices"):
                                 content = choices[0]["delta"].get("content")
                                 # First token
-                                if ttft == 0.0:
-                                    ttft = timestamp - st
-                                    output.ttft = ttft
+                                if not first_chunk_received:
+                                    first_chunk_received = True
+                                    output.ttft = timestamp - st
 
                                 # Decoding phase
                                 else:
@@ -421,7 +421,14 @@ async def async_request_openai_chat_completions(
                             most_recent_timestamp = timestamp
 
                 output.generated_text = generated_text
-                output.success = True
+                if first_chunk_received:
+                    output.success = True
+                else:
+                    output.success = False
+                    output.error = (
+                        "Never received a valid chunk to calculate TTFT."
+                        "This response will be marked as failed!"
+                    )
                 output.latency = most_recent_timestamp - st
             else:
                 output.error = response.reason or ""
@@ -492,7 +499,6 @@ async def async_request_openai_audio(
         output.input_audio_duration = input_audio_duration
 
         generated_text = ""
-        ttft = 0.0
         st = time.perf_counter()
         output.start_time = st
         most_recent_timestamp = st
@@ -501,6 +507,7 @@ async def async_request_openai_audio(
                 url=api_url, data=form, headers=headers
             ) as response:
                 if response.status == 200:
+                    first_chunk_received = False
                     handler = StreamedResponseHandler()
 
                     async for chunk_bytes in response.content.iter_any():
@@ -520,9 +527,9 @@ async def async_request_openai_audio(
                                 if choices := data.get("choices"):
                                     content = choices[0]["delta"].get("content")
                                     # First token
-                                    if ttft == 0.0:
-                                        ttft = timestamp - st
-                                        output.ttft = ttft
+                                    if not first_chunk_received:
+                                        first_chunk_received = True
+                                        output.ttft = timestamp - st
 
                                     # Decoding phase
                                     else:
@@ -539,7 +546,14 @@ async def async_request_openai_audio(
                                 most_recent_timestamp = timestamp
 
                     output.generated_text = generated_text
-                    output.success = True
+                    if first_chunk_received:
+                        output.success = True
+                    else:
+                        output.success = False
+                        output.error = (
+                            "Never received a valid chunk to calculate TTFT."
+                            "This response will be marked as failed!"
+                        )
                     output.latency = most_recent_timestamp - st
                 else:
                     output.error = response.reason or ""


### PR DESCRIPTION
## Purpose

HTTP 200 chat and audio streams containing no `choices` chunks were incorrectly recorded as successful by `vllm bench serve`, contributing a zero TTFT and inflating completed-request throughput.

Track whether a valid `choices` chunk was received and apply the existing completions-handler behavior: mark streams without one as failed. Non-text choices, such as tool-call-only deltas, remain successful.

## Reproducer

Run against `main` and this branch:

```bash
PATH="$PWD/.venv/bin:$PATH" .venv/bin/python - <<'PY'
import asyncio

import numpy as np

import vllm.benchmarks.lib.endpoint_request_func as request_func
from vllm.benchmarks.lib.endpoint_request_func import RequestFuncInput


class Form:
    def add_field(self, *args, **kwargs):
        pass


class Content:
    async def iter_any(self):
        yield b"data: [DONE]\n\n"


class Response:
    status = 200
    reason = "OK"
    content = Content()

    async def __aenter__(self):
        return self

    async def __aexit__(self, *args):
        return False


class Session:
    def post(self, **kwargs):
        return Response()


async def main():
    session = Session()

    chat_request = RequestFuncInput(
        prompt="test",
        api_url="http://localhost/v1/chat/completions",
        prompt_len=1,
        output_len=8,
        model="test",
    )
    chat = await request_func.async_request_openai_chat_completions(
        chat_request, session
    )

    request_func.aiohttp.FormData = Form
    audio_request = RequestFuncInput(
        prompt="",
        api_url="http://localhost/v1/audio/transcriptions",
        prompt_len=1,
        output_len=8,
        model="test",
        multi_modal_content={
            "audio": (np.zeros(1600, dtype=np.float32), 16000)
        },
    )
    audio = await request_func.async_request_openai_audio(
        audio_request, session
    )

    for name, output in (("chat", chat), ("audio", audio)):
        print(
            f"{name} success={output.success} "
            f"ttft={output.ttft} error={output.error!r}"
        )


asyncio.run(main())
PY
```

## Output on main

```text
chat success=True ttft=0.0 error=''
audio success=True ttft=0.0 error=''
```

## Output on branch

```text
chat success=False ttft=0.0 error='Never received a valid chunk to calculate TTFT.This response will be marked as failed!'
audio success=False ttft=0.0 error='Never received a valid chunk to calculate TTFT.This response will be marked as failed!'
```

## Test Plan

```bash
PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest \
  tests/benchmarks/test_audio_dataset.py \
  tests/benchmarks/test_bfcl_dataset.py -q

pre-commit run --all-files
pre-commit run mypy-3.12 --all-files --hook-stage manual
```

Results:

```text
15 passed in 3.66s
All pre-commit hooks passed
Python 3.12 mypy passed
```

The complete `tests/benchmarks/` directory was also attempted:

```text
135 passed, 2 failed, 3 errors in 416.55s
```

## AI assistance disclosure

OpenAI Codex assisted in drafting this change. All changed lines were human-reviewed, and the tests above were human-run.