### PR TITLE
[Docs] Fix stale disaggregated encoder example script names

### DIFF
--- a/docs/features/disagg_encoder.md
+++ b/docs/features/disagg_encoder.md
@@ -53,7 +53,7 @@ Disaggregated encoding is implemented by running two parts:
 
 * **Encoder instance** – a vLLM instance to performs vision encoding.  
 * **Prefill/Decode (PD) instance(s)** – runs language pre-fill and decode.
-    * PD can be in either a single normal instance with `disagg_encoder_example.sh` (E->PD) or in disaggregated instances with `disagg_epd_example.sh` (E->P->D)
+    * PD can be in either a single normal instance with `disagg_1e1pd_example.sh` (E->PD) or in disaggregated instances with `disagg_1e1p1d_example.sh` (E->P->D)
 
 A connector transfers encoder-cache (EC) embeddings from the encoder instance to the PD instance.  
 All related code is under `vllm/distributed/ec_transfer`.

--- a/examples/disaggregated/disaggregated_encoder/README.md
+++ b/examples/disaggregated/disaggregated_encoder/README.md
@@ -53,7 +53,7 @@ To support local image inputs (from your ```MEDIA_PATH``` directory), add the fo
 --allowed-local-media-path $MEDIA_PATH
 ```
 
-The vllm instances and `disagg_encoder_proxy` supports local URIs with ```{"url": "file://'"$MEDIA_PATH_FILENAME"'}``` as multimodal inputs. Each URI is passed unchanged from the `disagg_encoder_proxy` to the encoder instance so that the encoder can load the media locally.
+The vllm instances and `disagg_epd_proxy.py` supports local URIs with ```{"url": "file://'"$MEDIA_PATH_FILENAME"'}``` as multimodal inputs. Each URI is passed unchanged from the `disagg_epd_proxy.py` to the encoder instance so that the encoder can load the media locally.
 
 ## EC connector and KV transfer
 
@@ -110,7 +110,7 @@ Example usage:
 For E + PD setup:
 
 ```bash
-$ python disagg_encoder_proxy.py \
+$ python disagg_epd_proxy.py \
       --encode-servers-urls "http://e1:8001,http://e2:8002" \
       --prefill-servers-urls "disable" \
       --decode-servers-urls "http://pd1:8003,http://pd2:8004"
@@ -119,7 +119,7 @@ $ python disagg_encoder_proxy.py \
 For E + P + D setup:
 
 ```bash
-$ python disagg_encoder_proxy.py \
+$ python disagg_epd_proxy.py \
       --encode-servers-urls "http://e1:8001,http://e2:8001" \
       --prefill-servers-urls "http://p1:8003,http://p2:8004" \ 
       --decode-servers-urls "http://d1:8005,http://d2:8006"


### PR DESCRIPTION
## Purpose

Disaggregated encoder docs still named example scripts that are not on `main`, so those references 404.

Verified against `vllm-project/vllm` default `main` HEAD `4ac452ad9883864bb3ab0412a45a63cbf62d730a` via the GitHub Contents API (`GET /repos/vllm-project/vllm/contents/examples/disaggregated/disaggregated_encoder`):

Files present on HEAD:

- `disagg_epd_proxy.py`
- `disagg_1e1pd_example.sh`
- `disagg_1e1p1d_example.sh`

Files that 404 on HEAD:

- `disagg_encoder_proxy.py`
- `disagg_encoder_example.sh`
- `disagg_epd_example.sh`

## Changes

- `examples/disaggregated/disaggregated_encoder/README.md`: `disagg_encoder_proxy` / `disagg_encoder_proxy.py` -> `disagg_epd_proxy.py`
- `docs/features/disagg_encoder.md`: `disagg_encoder_example.sh` -> `disagg_1e1pd_example.sh` (E+PD), `disagg_epd_example.sh` -> `disagg_1e1p1d_example.sh` (E+P+D)

Docs-only; example scripts themselves are unchanged.

## Test Plan

- Contents API directory listing of `examples/disaggregated/disaggregated_encoder/` on `main`
- Contents API 404 for the old filenames on the same SHA
- Re-read both updated files on this branch to confirm only the stale names were rewritten