### PR TITLE
[Bugfix][Spec Decode] Derive draft KV slots from absolute position on M-RoPE models

### DIFF
--- a/tests/v1/spec_decode/test_eagle_step_kernel.py
+++ b/tests/v1/spec_decode/test_eagle_step_kernel.py
@@ -2,10 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for the fused EAGLE slot mapping kernel."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.utils import (
     PADDING_SLOT_ID,
     eagle_step_update_slot_mapping_and_metadata,
@@ -92,6 +95,88 @@ def test_eagle_step_slot_mapping_kernel():
     assert torch.equal(seq_lens_copy, ref_seq_lens), (
         f"seq_lens: {seq_lens_copy} vs {ref_seq_lens}"
     )
+
+
+@pytest.mark.parametrize(
+    ("position", "seq_len", "expected_position", "expected_slot", "expected_seq_len"),
+    [
+        (109, 110, 110, 1710, 111),
+        (1023, 1024, 0, PADDING_SLOT_ID, 1),
+    ],
+)
+def test_eagle_step_slot_mapping_kernel_in_place_positions(
+    position: int,
+    seq_len: int,
+    expected_position: int,
+    expected_slot: int,
+    expected_seq_len: int,
+):
+    """The M-RoPE caller aliases position input and output scratch buffers."""
+    device = torch.device(DEVICE_TYPE)
+    positions = torch.tensor([position], dtype=torch.int64, device=device)
+    block_table = torch.arange(100, 164, dtype=torch.int32, device=device).unsqueeze(0)
+    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    out_slot = torch.empty(1, dtype=torch.int64, device=device)
+
+    eagle_step_update_slot_mapping_and_metadata(
+        positions_1d=positions,
+        block_table_tensor=block_table,
+        seq_lens=seq_lens,
+        block_size=16,
+        max_model_len=1024,
+        out_clamped_positions=positions,
+        out_slot_mapping=out_slot,
+    )
+
+    assert positions.tolist() == [expected_position]
+    assert out_slot.tolist() == [expected_slot]
+    assert seq_lens.tolist() == [expected_seq_len]
+
+
+def test_mrope_proposer_uses_absolute_slots_with_real_kernel():
+    """Run the fixed proposer and fused kernel together on image-style positions."""
+    device = torch.device(DEVICE_TYPE)
+    proposer = EagleProposer.__new__(EagleProposer)
+    proposer.uses_mrope = True
+    proposer.max_model_len = 1024
+    proposer._slot_positions = torch.empty(2, dtype=torch.int64, device=device)
+    proposer._slot_mapping_buffer = torch.empty(4, dtype=torch.int64, device=device)
+    proposer.mrope_positions = torch.empty((3, 5), dtype=torch.int64, device=device)
+
+    positions = torch.tensor(
+        [[19, 25], [19, 25], [19, 25]], dtype=torch.int64, device=device
+    )
+    block_table = torch.stack(
+        (
+            torch.arange(100, 164, dtype=torch.int32, device=device),
+            torch.arange(200, 264, dtype=torch.int32, device=device),
+        )
+    )
+    metadata = SimpleNamespace(
+        block_table_tensor=block_table,
+        seq_lens=torch.tensor([110, 130], dtype=torch.int32, device=device),
+        slot_mapping=None,
+        max_seq_len=130,
+        _seq_lens_cpu=None,
+        _num_computed_tokens_cpu=None,
+        seq_lens_cpu_upper_bound=None,
+    )
+
+    updated_positions = proposer._update_positions_dependent_metadata(
+        positions,
+        metadata,
+        batch_size=2,
+        input_batch_size=4,
+        block_size=16,
+    )
+
+    assert metadata.slot_mapping.tolist() == [1710, 3330]
+    assert proposer._slot_mapping_buffer[2:].tolist() == [
+        PADDING_SLOT_ID,
+        PADDING_SLOT_ID,
+    ]
+    assert metadata.seq_lens.tolist() == [111, 131]
+    assert updated_positions.tolist() == [[20, 26], [20, 26], [20, 26]]
 
 
 def test_eagle_step_slot_mapping_kernel_exceeds_max():

--- a/tests/v1/spec_decode/test_llm_base_proposer.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for SpecDecodeBaseProposer.initialize_attn_backend.
+"""Tests for SpecDecodeBaseProposer attention and slot-mapping setup.
 
 Block tables are stored at kernel-block granularity, so the proposer's
 ``block_size`` (used for slot-mapping math) must be the kernel block size,
@@ -14,12 +14,41 @@ processes, so anything derived from iteration order must not leak into
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.step3p5 import Step3p5MTPProposer
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
 
 SCHEDULER_BLOCK_SIZE = 256
 KERNEL_BLOCK_SIZE = 64
+
+
+def _cpu_step_update(
+    positions_1d,
+    block_table_tensor,
+    seq_lens,
+    block_size,
+    max_model_len,
+    out_clamped_positions,
+    out_slot_mapping,
+    input_batch_size=None,
+):
+    new_positions = positions_1d + 1
+    exceeds_max = new_positions >= max_model_len
+    clamped_positions = torch.where(
+        exceeds_max, torch.zeros_like(new_positions), new_positions
+    )
+    block_numbers = (clamped_positions // block_size).clamp(
+        max=block_table_tensor.shape[1] - 1
+    )
+    block_ids = block_table_tensor.gather(1, block_numbers[:, None]).squeeze(1)
+    slot_mapping = block_ids * block_size + clamped_positions.remainder(block_size)
+    slot_mapping.masked_fill_(exceeds_max, PADDING_SLOT_ID)
+    out_slot_mapping[: positions_1d.shape[0]].copy_(slot_mapping)
+    out_clamped_positions.copy_(clamped_positions)
+    seq_lens.copy_(torch.where(exceeds_max, torch.ones_like(seq_lens), seq_lens + 1))
 
 
 class _FakeAttentionGroup:
@@ -93,6 +122,150 @@ def test_block_size_falls_back_to_kv_cache_spec(monkeypatch: pytest.MonkeyPatch)
     )
 
     assert proposer.block_size == SCHEDULER_BLOCK_SIZE
+
+
+@pytest.mark.parametrize(
+    (
+        "mrope_position",
+        "seq_len",
+        "expected_slot",
+        "expected_seq_len",
+        "expected_mrope_position",
+    ),
+    [
+        (19, 110, 1710, 111, 20),
+        (19, 1024, PADDING_SLOT_ID, 1, 20),
+        (1023, 1024, PADDING_SLOT_ID, 1, 0),
+    ],
+)
+def test_mrope_slot_mapping_uses_absolute_sequence_position(
+    monkeypatch: pytest.MonkeyPatch,
+    mrope_position: int,
+    seq_len: int,
+    expected_slot: int,
+    expected_seq_len: int,
+    expected_mrope_position: int,
+):
+    proposer = EagleProposer.__new__(EagleProposer)
+    proposer.uses_mrope = True
+    proposer.max_model_len = 1024
+    proposer._slot_positions = torch.empty(1, dtype=torch.int64)
+    proposer._slot_mapping_buffer = torch.empty(1, dtype=torch.int64)
+    proposer.mrope_positions = torch.empty((3, 2), dtype=torch.int64)
+
+    positions = torch.full((3, 1), mrope_position, dtype=torch.int64)
+    block_size = 16
+    block_table = torch.arange(100, 164, dtype=torch.int64).unsqueeze(0)
+    metadata = SimpleNamespace(
+        block_table_tensor=block_table,
+        seq_lens=torch.tensor([seq_len], dtype=torch.int32),
+        slot_mapping=None,
+        max_seq_len=seq_len,
+        _seq_lens_cpu=None,
+        _num_computed_tokens_cpu=None,
+        seq_lens_cpu_upper_bound=None,
+    )
+
+    monkeypatch.setattr(
+        llm_base_proposer,
+        "eagle_step_update_slot_mapping_and_metadata",
+        _cpu_step_update,
+    )
+
+    updated_positions = proposer._update_positions_dependent_metadata(
+        positions,
+        metadata,
+        batch_size=1,
+        input_batch_size=1,
+        block_size=block_size,
+    )
+
+    assert metadata.slot_mapping.tolist() == [expected_slot]
+    assert metadata.seq_lens.tolist() == [expected_seq_len]
+    assert updated_positions.tolist() == [
+        [expected_mrope_position],
+        [expected_mrope_position],
+        [expected_mrope_position],
+    ]
+
+
+@pytest.mark.parametrize(
+    (
+        "uses_mrope",
+        "seq_len",
+        "expected_primary",
+        "expected_secondary",
+        "expected_seq_len",
+        "expected_positions",
+    ),
+    [
+        (True, 110, 1710, 3310, 111, [[20], [20], [20]]),
+        (True, 1024, PADDING_SLOT_ID, PADDING_SLOT_ID, 1, [[20], [20], [20]]),
+        (False, 110, 1710, 3310, 111, [110]),
+    ],
+)
+def test_step3p5_slots_use_absolute_position_for_all_groups(
+    monkeypatch: pytest.MonkeyPatch,
+    uses_mrope: bool,
+    seq_len: int,
+    expected_primary: int,
+    expected_secondary: int,
+    expected_seq_len: int,
+    expected_positions: list,
+):
+    proposer = Step3p5MTPProposer.__new__(Step3p5MTPProposer)
+    proposer.uses_mrope = uses_mrope
+    proposer.max_model_len = 1024
+    proposer.max_positions = 1
+    proposer.device = torch.device("cpu")
+    proposer._slot_mapping_buffer = torch.empty(1, dtype=torch.int64)
+    if uses_mrope:
+        proposer._slot_positions = torch.empty(1, dtype=torch.int64)
+        proposer.mrope_positions = torch.empty((3, 2), dtype=torch.int64)
+        positions = torch.full((3, 1), 19, dtype=torch.int64)
+    else:
+        proposer.positions = torch.empty(1, dtype=torch.int64)
+        positions = torch.tensor([109], dtype=torch.int64)
+    proposer.kv_cache_gid = 0
+    proposer.draft_attn_groups = [
+        SimpleNamespace(kv_cache_group_id=0),
+        SimpleNamespace(kv_cache_group_id=1),
+    ]
+    proposer._per_group_block_tables = {
+        1: torch.arange(200, 264, dtype=torch.int64).unsqueeze(0)
+    }
+    proposer._per_group_slot_mappings = {}
+    proposer._per_group_slot_mapping_buffers = {}
+
+    block_size = 16
+    metadata = SimpleNamespace(
+        block_table_tensor=torch.arange(100, 164, dtype=torch.int64).unsqueeze(0),
+        seq_lens=torch.tensor([seq_len], dtype=torch.int32),
+        slot_mapping=None,
+        max_seq_len=seq_len,
+        _seq_lens_cpu=None,
+        _num_computed_tokens_cpu=None,
+        seq_lens_cpu_upper_bound=None,
+    )
+
+    monkeypatch.setattr(
+        llm_base_proposer,
+        "eagle_step_update_slot_mapping_and_metadata",
+        _cpu_step_update,
+    )
+
+    updated_positions = proposer._update_positions_dependent_metadata(
+        positions,
+        metadata,
+        batch_size=1,
+        input_batch_size=1,
+        block_size=block_size,
+    )
+
+    assert proposer._per_group_slot_mappings[0].tolist() == [expected_primary]
+    assert proposer._per_group_slot_mappings[1].tolist() == [expected_secondary]
+    assert metadata.seq_lens.tolist() == [expected_seq_len]
+    assert updated_positions.tolist() == expected_positions
 
 
 def test_draft_layer_iteration_is_deterministic(monkeypatch: pytest.MonkeyPatch):

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -187,6 +187,13 @@ class SpecDecodeBaseProposer:
                 dtype=torch.int64,
                 device=device,
             )
+            # KV slots are addressed by absolute sequence position, which the
+            # M-RoPE temporal dim does not track once an image span has
+            # compressed it. self.positions is not allocated on this path, so
+            # the draft loop needs its own buffer for those positions.
+            self._slot_positions = torch.zeros(
+                self.max_positions, dtype=torch.int64, device=device
+            )
         else:
             # RoPE need (max_num_tokens,)
             self.positions = torch.zeros(
@@ -772,10 +779,18 @@ class SpecDecodeBaseProposer:
     ) -> torch.Tensor:
         """Update positions, slot mappings, and sequence metadata for the
         next draft step. Returns the updated positions tensor."""
-        positions_1d = positions[0] if self.uses_mrope else positions
         if self.uses_mrope:
-            out_pos = self.mrope_positions[0, :batch_size]
+            # seq_lens counts real tokens, so it recovers the absolute position
+            # the KV slot must be addressed by. Deriving it from positions[0]
+            # instead lands in the wrong slot on any prompt whose image spans
+            # M-RoPE has compressed.
+            slot_positions = self._slot_positions[:batch_size]
+            slot_positions.copy_(common_attn_metadata.seq_lens[:batch_size])
+            slot_positions.sub_(1)
+            positions_1d = slot_positions
+            out_pos = slot_positions
         else:
+            positions_1d = positions
             out_pos = self.positions[:batch_size]
         eagle_step_update_slot_mapping_and_metadata(
             positions_1d=positions_1d,
@@ -789,7 +804,13 @@ class SpecDecodeBaseProposer:
         )
         common_attn_metadata.slot_mapping = self._slot_mapping_buffer[:batch_size]
         if self.uses_mrope:
-            self.mrope_positions[1:, :batch_size] = self.mrope_positions[0, :batch_size]
+            # The kernel now consumes the absolute position, so the rope
+            # coordinates have to be advanced separately. A drafted token is
+            # always text, so every dim moves together, and the clamp mirrors
+            # the kernel's.
+            next_positions = positions + 1
+            next_positions[next_positions >= self.max_model_len] = 0
+            self.mrope_positions[:, :batch_size] = next_positions
             positions = self.mrope_positions[:, :batch_size]
         else:
             positions = self.positions[:batch_size]

--- a/vllm/v1/spec_decode/step3p5.py
+++ b/vllm/v1/spec_decode/step3p5.py
@@ -84,7 +84,13 @@ class Step3p5MTPProposer(EagleProposer):
         input_batch_size: int,
         block_size: int,
     ) -> torch.Tensor:
-        old_positions_1d = positions[0] if self.uses_mrope else positions
+        # The parent advances seq_lens in place, so capture the out-of-bounds
+        # condition first. For M-RoPE the absolute position of the token being
+        # appended is seq_lens itself, which is what the KV slot is addressed by.
+        if self.uses_mrope:
+            exceeds = common_attn_metadata.seq_lens[:batch_size] >= self.max_model_len
+        else:
+            exceeds = positions + 1 >= self.max_model_len
         positions = super()._update_positions_dependent_metadata(
             positions,
             common_attn_metadata,
@@ -97,8 +103,11 @@ class Step3p5MTPProposer(EagleProposer):
             common_attn_metadata.slot_mapping
         )
         # Recompute slot_mapping for the remaining gids using their own block tables.
-        new_positions_1d = positions[0] if self.uses_mrope else positions
-        exceeds = old_positions_1d + 1 >= self.max_model_len
+        # Every group addresses the same absolute position the parent used; the
+        # M-RoPE coordinate in positions[0] would land in a different block.
+        new_positions_1d = (
+            self._slot_positions[:batch_size] if self.uses_mrope else positions
+        )
         for attn_group in self.draft_attn_groups:
             gid = attn_group.kv_cache_group_id
             if gid == self.kv_cache_gid:

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -27,7 +27,7 @@ def next_power_of_2(n: int) -> int:
 
 @triton.jit
 def eagle_step_slot_mapping_metadata_kernel(
-    positions_ptr,  # [batch_size] - current positions (1D view for M-RoPE)
+    positions_ptr,  # [batch_size] - current absolute sequence positions
     block_table_ptr,  # [batch_size, n_blocks_per_req]
     block_table_stride,  # stride for block_table dim 1
     seq_lens_ptr,  # [batch_size] - read and write
@@ -103,7 +103,7 @@ def eagle_step_update_slot_mapping_and_metadata(
     PADDING_SLOT_ID to out_slot_mapping for cudagraph padding.
 
     Args:
-        positions_1d: [batch_size] current positions (use positions[0] for M-RoPE)
+        positions_1d: [batch_size] current absolute sequence positions
         block_table_tensor: [batch_size, n_blocks_per_req]
         seq_lens: [batch_size] updated in place
         block_size: KV cache block size


### PR DESCRIPTION
# [Bugfix][Spec Decode] Derive draft KV slots from absolute position on M-RoPE models

## Purpose

Fixes #54498.

On M-RoPE models the V1 draft loop fed `positions[0]` — the M-RoPE temporal
coordinate — to both the RoPE recurrence and the KV slot computation. Those are
two different coordinate systems. An `H x W` patch grid occupies `H*W` KV slots
but advances the M-RoPE coordinate by only `max(t, h, w)`, so on any prompt
containing an image the temporal dim falls below the absolute token index and the
drafted token is written to a slot that belongs to the prompt. Attention still
reads the full span per `seq_lens`, so the corrupted entry is read back as
context: acceptance length drops, and the drop compounds with the number of draft
steps.

### Changes

1. `SpecDecodeBaseProposer` allocates a `_slot_positions` buffer for M-RoPE and
   derives the slot coordinate from `seq_lens - 1`, which counts real tokens. No
   new data source is needed and the non-M-RoPE paths are untouched.
2. All three M-RoPE dims advance together with the kernel's clamp semantics
   (`>= max_model_len -> 0`) mirrored in torch, instead of the spatial dims being
   overwritten by the temporal one.
3. `Step3p5MTPProposer` recomputes the secondary KV cache groups' slots from the
   same absolute position the parent used, capturing the out-of-bounds condition
   *before* delegating, because the parent advances `seq_lens` in place.
4. `eagle_step_update_slot_mapping_and_metadata` documents `positions_1d` as an
   absolute sequence position at both the kernel comment and the wrapper
   docstring. The function has a single caller and no other consumer relied on
   the old "use `positions[0]` for M-RoPE" convention.

Text-only prompts are unaffected because the two coordinate systems coincide
without images — which is also the strongest causal evidence in #54498: V1
recovers on its own once the images are stripped.

XD-RoPE is deliberately out of scope. Its decode positions are the absolute index
on every dim by construction (`has_delta=False`), so the mis-addressing mechanism
does not transfer. The separate latent bug on that branch is #54555, fixed by
#54621.

### Why this is not duplicating #54519

#54519 targets the same issue. I have left these same points as a comment there.
The differences are substantive:

**1. The `llm_base_proposer.py` change originates from #54498.** The
`_slot_positions` allocation and the `seq_lens`-derived slot coordinate were
published as a diff in the issue body (section "We have a fix", 2026-08-31
03:34 UTC), 3h15m before #54519 was opened (06:49 UTC); the two are line-for-line
identical. Noting this for attribution only.

**2. #54519's `step3p5.py` change is incorrect on the out-of-bounds path.** It
computes the condition after `super()` has already advanced `seq_lens` in place:

```python
positions = super()._update_positions_dependent_metadata(...)   # seq_lens advanced here
...
exceeds = common_attn_metadata.seq_lens[:batch_size] > self.max_model_len
```

Let `S` be `seq_lens` on entry. The parent feeds `S - 1` to the kernel, which
evaluates `S >= max_model_len` and, when that holds, resets `seq_lens` to 1
(`new_seq_len = tl.where(exceeds_max, 1, seq_len + 1)`). Re-deriving the condition
afterwards therefore yields `1 > max_model_len` — `False` in exactly the case
where it must be `True` — while `new_positions_1d` becomes `seq_lens - 1 == 0`.
The subsequent `masked_fill_(exceeds, PADDING_SLOT_ID)` is a no-op, and every
secondary KV cache group writes the drafted token to
`block_table[gid][:, 0] * block_size`: slot 0 of the request's first block, live
prompt KV. That is the same class of corruption this issue is about, relocated to
the overflow path. This PR captures the condition against the untouched
`seq_lens` before delegating.

**3. #54519's tests do not execute on CPU.** Its new
`tests/v1/spec_decode/test_mrope_spec_decode.py` opens with
`pytest.skip(..., allow_module_level=True)` unless CUDA/XPU is present, so the
module is skipped entirely in CPU CI. The regression was never in the kernel — it
was the coordinate the proposer chose to feed it — and that part is CPU-testable.
This PR puts 9 cases in the existing `test_llm_base_proposer.py`, which has no
platform skips, by stubbing the fused kernel, and keeps the genuinely GPU-only
assertions in `test_eagle_step_kernel.py`. This is the split @he-yufeng asked for
in #54498.

**4.** #54519 corrects one of the two stale docstring sites in `utils.py`.

## Test Plan

```bash
# CPU: proposer coordinate selection + Step3.5 per-group slots, no platform skips
.venv/bin/python -m pytest tests/v1/spec_decode/test_llm_base_proposer.py -v

# GPU: real Triton kernel aliasing + proposer/kernel integration
CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/v1/spec_decode/test_eagle_step_kernel.py -v
```

CPU coverage stubs the fused kernel and asserts the derived slot lands in the
block of the *absolute* index, over three relationships between the M-RoPE
coordinate and `seq_lens`: compressed (image span), at the length limit, and
already at the limit on both. The Step3.5 matrix covers primary and secondary KV
groups plus a non-M-RoPE regression case. GPU coverage pins the in-place
`positions_1d` / `out_clamped_positions` aliasing the fix introduces, in both the
normal and overflow cases, and runs the proposer against the real kernel with two
requests at different image-compression offsets.

Accuracy was measured with `SpecDecoding metrics: Mean acceptance length` from the
engine log, greedy, one image per prompt, 20-30 requests per dataset. Note that
`VLLM_USE_V2_MODEL_RUNNER=1` must be set explicitly for the V2 reference (these
hybrid architectures are excluded from `DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES`)
and `VLLM_GDN_DECODE_KERNEL=triton` is required.

## Test Result

```text
tests/v1/spec_decode/test_llm_base_proposer.py    9 passed
tests/v1/spec_decode/test_eagle_step_kernel.py    6 passed
```

All pre-commit hooks pass.

### Acceptance length

V2 is shown as a reference point only, not as a target for exact numeric
alignment.

`Qwen/Qwen3.5-4B`, K=6:

| dataset | before | after | V2 | gain |
|---|---|---|---|---|
| ChartQA | 4.805 | **5.091** | 5.012 | +5.9% |
| AI2D | 3.954 | **4.221** | 4.180 | +6.8% |
| TextVQA | 3.996 | **4.189** | 4.169 | +4.8% |
| MathVista | 4.561 | **4.896** | 4.808 | +7.3% |
| MMStar | 3.615 | **3.817** | 3.765 | +5.6% |
| mean | | | | **+6.1%** |

`Qwen/Qwen3.8-27B`, K=6:

| dataset | before | after | V2 | gain |
|---|---|---|---|---|
| ChartQA | 4.578 | **4.790** | 4.747 | +4.6% |
| AI2D | 3.569 | **3.789** | 3.787 | +6.2% |
| TextVQA | 3.670 | **3.984** | 3.893 | +8.6% |
| MathVista | 4.427 | **4.606** | 4.700 | +4.0% |
| MMStar | 3.251 | **3.447** | 3.529 | +6.0% |
| mean | | | | **+5.9%** |

All 10 public (model x dataset) combinations improve, +4.0% to +8.6%. The two
model sizes show nearly identical mean gains, consistent with the mechanism: the
offset depends on how many tokens the images occupy, not on model size.

Internal production checkpoint, K=15:

| | before | after | V2 | change |
|---|---|---|---|---|
| acceptance length | 8.432 | **11.490** | 11.426 | +36.3% |
| verify steps | 1163 | **853** | ~850 | -26.7% |
| output throughput | 84.48 tok/s | **104.75 tok/s** | 102.69 tok/s | +24.0% |
| TPOT | 9.299 ms | **6.905 ms** | 6.904 ms | -25.8% |

### Control: text-only, same checkpoint, K=15

| | before | after | change |
|---|---|---|---|
| with images | 8.597 | 11.426 | **-24.8%** |
| text only | 11.385 | 11.374 | **+0.1%** |

Stripping the images makes the gap vanish, because the M-RoPE dims then equal the
absolute index and the wrong coordinate happens to be the right one.

### Per-position acceptance rate

`P(num_accepted >= i)`, production checkpoint, K=15:

```text
pos       1     2     3     4     5     6     7     8     9    10    11    12    13    14    15
current 0.996 0.979 0.950 0.911 0.782 0.703 0.601 0.491 0.322 0.230 0.162 0.114 0.083 0.059 0.048
fixed   0.999 0.987 0.974 0.957 0.887 0.846 0.788 0.725 0.668 0.581 0.536 0.444 0.393 0.368 0.336
ratio    1.00  1.01  1.03  1.05  1.13  1.20  1.31  1.48  2.07  2.52  3.31  3.89  4.76  6.20  6.99
```

Head positions are nearly unaffected while the tail differs by ~7x. That
progressive divergence is the signature of a small per-step error compounding
along the recurrence; a hard error at one step would show a cliff instead.

### Exclusion controls

`Qwen/Qwen3.5-4B` on text-only GSM8K shows <=0.6% V1/V2 difference at K=3 and
K=15, ruling out the drafting loop itself and hybrid/GDN state handling.
`XiaomiMiMo/MiMo-7B-RL` (dense, no M-RoPE) is identical between runners
(K=3 2.440/2.440, K=15 2.461/2.461).

---

AI assistance was used for this change. I have reviewed every changed line and
run the tests and evaluations reported above myself.
