### PR TITLE
[MoE][Quant] Consider B12X in automatic NVFP4 MoE backend selection

### DIFF
--- a/tests/kernels/moe/test_b12x.py
+++ b/tests/kernels/moe/test_b12x.py
@@ -573,6 +573,58 @@ def test_explicit_b12x_nvfp4_selection(
     assert selected_activation_keys == [expected_activation_key]
 
 
+def test_auto_b12x_nvfp4_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+        CutlassExpertsFp4,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutedsl_batched_moe import (  # noqa: E501
+        FlashInferCuteDSLBatchedExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutedsl_moe import (
+        FlashInferCuteDSLExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe import (  # noqa: E501
+        FlashInferExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.trtllm_nvfp4_moe import (
+        TrtLlmNvFp4ExpertsModular,
+        TrtLlmNvFp4ExpertsMonolithic,
+    )
+
+    mock_unsupported = lambda *args, **kwargs: (False, "mocked unsupported")
+    monkeypatch.setattr(
+        TrtLlmNvFp4ExpertsMonolithic, "is_supported_config", mock_unsupported
+    )
+    monkeypatch.setattr(
+        TrtLlmNvFp4ExpertsModular, "is_supported_config", mock_unsupported
+    )
+    monkeypatch.setattr(
+        FlashInferCuteDSLExperts, "is_supported_config", mock_unsupported
+    )
+    monkeypatch.setattr(
+        FlashInferCuteDSLBatchedExperts, "is_supported_config", mock_unsupported
+    )
+    monkeypatch.setattr(FlashInferExperts, "is_supported_config", mock_unsupported)
+    monkeypatch.setattr(CutlassExpertsFp4, "is_supported_config", mock_unsupported)
+    monkeypatch.setattr(
+        B12xExperts, "is_supported_config", lambda *args, **kwargs: (True, None)
+    )
+
+    config = make_dummy_moe_config(hidden_dim=128, intermediate_size=64)
+    config.moe_backend = "auto"
+
+    backend, experts_cls = select_nvfp4_moe_backend(
+        config,
+        weight_key=kNvfp4Static,
+        activation_key=kNvfp4Dynamic,
+    )
+
+    assert backend == NvFp4MoeBackend.B12X
+    assert experts_cls is B12xExperts
+
+
 @pytest.mark.parametrize(
     "force_a16,expected_quant_dtype", [(False, "nvfp4"), (True, None)]
 )

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -199,6 +199,7 @@ def select_nvfp4_moe_backend(
         NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
         NvFp4MoeBackend.FLASHINFER_CUTLASS,
         NvFp4MoeBackend.VLLM_CUTLASS,
+        NvFp4MoeBackend.B12X,
         NvFp4MoeBackend.MARLIN,
         NvFp4MoeBackend.HUMMING,
         NvFp4MoeBackend.EMULATION,


### PR DESCRIPTION



## Purpose
Fixes #54666

vLLM already supports the direct B12X NVFP4 fused MoE backend on NVIDIA Blackwell (SM120 and SM121) architectures.
However, `NvFp4MoeBackend.B12X` was missing from `AVAILABLE_BACKENDS` in `select_nvfp4_moe_backend()`. As a result, automatic NVFP4 MoE backend selection (`moe_backend="auto"`) on SM120/SM121 deployments silently skipped B12X and fell back to Marlin.

This PR adds `NvFp4MoeBackend.B12X` to `AVAILABLE_BACKENDS` ahead of Marlin and adds unit tests covering automatic backend selection.

## Test Plan
Run unit tests verifying that B12X is selected under `moe_backend="auto"` when supported:
```bash
pytest tests/kernels/moe/test_b12x.py -k "test_auto_b12x_nvfp4_selection"
```

## Test Result
```
tests/kernels/moe/test_b12x.py::test_auto_b12x_nvfp4_selection PASSED
INFO: Using 'B12X' NvFp4 MoE backend out of potential backends: ['FLASHINFER_TRTLLM', 'FLASHINFER_CUTEDSL', 'FLASHINFER_CUTEDSL_BATCHED', 'FLASHINFER_CUTLASS', 'VLLM_CUTLASS', 'B12X', 'MARLIN', 'HUMMING', 'EMULATION'].
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

