### PR TITLE
[Bugfix][MoE] Size Triton MoE activation workspace to activation width

### DIFF
--- a/tests/kernels/moe/test_triton_moe_no_act_mul.py
+++ b/tests/kernels/moe/test_triton_moe_no_act_mul.py
@@ -155,8 +155,8 @@ def test_triton_experts_no_mul_activation(
 
     # Verify workspace shapes are correct for no_mul activation
     # workspace1 should handle activation_out_dim = N (not N//2)
-    assert ws1_shape == (m, topk, max(n, k)), (
-        f"workspace1 shape mismatch: expected {(m, topk, max(n, k))}, got {ws1_shape}"
+    assert ws1_shape == (m, topk, n), (
+        f"workspace1 shape mismatch: expected {(m, topk, n)}, got {ws1_shape}"
     )
     # workspace2 should handle max(N, K) for intermediate_cache1/cache3
     assert ws2_shape == (m, topk, max(n, k)), (
@@ -207,7 +207,7 @@ def test_workspace_shapes_no_mul_vs_gated():
     """Test that workspace shapes differ correctly between gated and non-gated."""
     from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
 
-    M, N, K, topk = 64, 256, 128, 2
+    M, N, K, topk = 64, 256, 512, 2
 
     experts = TritonExperts(
         moe_config=make_dummy_moe_config(),
@@ -224,15 +224,16 @@ def test_workspace_shapes_no_mul_vs_gated():
 
     # For no_mul: activation_out_dim = N
     # For gated: activation_out_dim = N // 2
-    # workspace1 should use max(activation_out_dim, K)
+    # workspace1 only holds the activation output. The separate output view
+    # accounts for K when the shared allocation is created.
     activation_out_dim_no_mul = N
     activation_out_dim_gated = N // 2
 
-    assert ws1_no_mul[2] == max(activation_out_dim_no_mul, K), (
-        f"no_mul workspace1 last dim should be max({activation_out_dim_no_mul}, {K})"
+    assert ws1_no_mul[2] == activation_out_dim_no_mul, (
+        f"no_mul workspace1 last dim should be {activation_out_dim_no_mul}"
     )
-    assert ws1_gated[2] == max(activation_out_dim_gated, K), (
-        f"gated workspace1 last dim should be max({activation_out_dim_gated}, {K})"
+    assert ws1_gated[2] == activation_out_dim_gated, (
+        f"gated workspace1 last dim should be {activation_out_dim_gated}"
     )
 
     # Output shapes should be the same

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -227,7 +227,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         activation: MoEActivation,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
         activation_out_dim = self.adjust_N_for_activation(N, activation)
-        workspace1 = (M, topk, max(activation_out_dim, K))
+        workspace1 = (M, topk, activation_out_dim)
         workspace2 = (M, topk, max(N, K))
         output = (M, K)
         return (workspace1, workspace2, output)


### PR DESCRIPTION
## Summary

- `workspace1` for Triton MoE experts was allocated as `(M, topk, max(activation_out_dim, K))`, but it only ever holds the activation output of width `activation_out_dim`. The K-sized storage is already covered by the shared workspace allocation's output view: the allocation takes `max(prod(workspace13), prod(fused_out))` and the second GEMM writes with `top_k=1` into an `(M, K)` buffer (see `modular_kernel.py::_allocate_output_and_expert_workspace`).
- Sizing `workspace1` to `activation_out_dim` therefore saves `topk * (K - activation_out_dim) * M` elements of live workspace. For the TP=4 WNA16 shape reported in #53241 (Qwen3.5 122B A10B, 4×RTX 3090) this removes **672 MiB** of BF16 workspace.

## Context

Split out from #53693 per @mgoin's review there, so the memory fix does not wait on the backend-comparison discussion for the dispatch path.

## Testing

- Updated `tests/kernels/moe/test_triton_moe_no_act_mul.py`: `workspace1` shape assertions now check the activation width (`N` for `no_mul`, `N // 2` for gated), and the shape test uses `K=512` so the activation width and `K` are distinguishable.
- Runtime correctness of this change was validated as part of #53693 (GSM8K parity with the Triton path, McNemar p=0.576).

---

AI-assisted development disclosure: this change was developed with AI assistance and manually reviewed.
