### PR TITLE
[Security] Add hash collision defense for prefix cache with non-crypto hashes

### DIFF
--- a/tests/v1/core/test_hash_collision_defense.py
+++ b/tests/v1/core/test_hash_collision_defense.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for prefix-cache hash collision detection.
+
+Verifies that when verify_content_on_hit=True (automatically enabled for
+non-cryptographic hash algorithms like xxhash), the BlockPool detects and
+rejects colliding blocks with different token content.
+"""
+
+import pytest
+
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    get_request_block_hasher,
+    init_none_hash,
+    make_block_hash_with_group_id,
+)
+from vllm.v1.request import Request
+
+
+def _make_request(
+    request_id: str,
+    prompt_token_ids: list[int],
+    block_size: int,
+    hash_fn=sha256,
+):
+    sampling_params = SamplingParams(max_tokens=17)
+    sampling_params.update_from_generation_config({}, eos_token_id=100)
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=prompt_token_ids,
+        mm_features=None,
+        sampling_params=sampling_params,
+        pooling_params=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        block_hasher=get_request_block_hasher(block_size, hash_fn),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _init_hash():
+    init_none_hash(sha256)
+
+
+class TestCollisionDetection:
+    """Tests for insertion-time hash collision detection in BlockPool."""
+
+    def test_collision_detected_and_rejected(self):
+        """Two blocks with different tokens but the same hash must not
+        both be inserted when verification is enabled."""
+        block_size = 4
+        kv_cache_group_id = 0
+
+        pool = BlockPool(
+            num_gpu_blocks=4,
+            enable_caching=True,
+            hash_block_size=block_size,
+            verify_content_on_hit=True,
+        )
+
+        fake_hash = BlockHash(b"collision-hash-value")
+        key = make_block_hash_with_group_id(fake_hash, kv_cache_group_id)
+
+        block_a = pool.get_new_blocks(1)[0]
+        block_b = pool.get_new_blocks(1)[0]
+
+        fp_a = (1, 2, 3, 4)
+        fp_b = (5, 6, 7, 8)
+
+        pool._insert_block_hash(key, block_a, num_tokens=4, content_fingerprint=fp_a)
+        assert pool.cached_block_hash_to_block.get_one_block(key) is not None
+        assert key in pool._block_fingerprints
+        assert pool._block_fingerprints[key] == fp_a
+
+        # Second insertion with different content should be rejected.
+        key2 = make_block_hash_with_group_id(fake_hash, kv_cache_group_id)
+        pool._insert_block_hash(key2, block_b, num_tokens=4, content_fingerprint=fp_b)
+
+        # The original block should still be there, not overwritten.
+        cached = pool.cached_block_hash_to_block.get_one_block(key)
+        assert cached is not None
+        assert cached.block_id == block_a.block_id
+
+    def test_same_content_allowed(self):
+        """Two blocks with the same hash AND same content are both accepted
+        (this is the normal de-dup case)."""
+        block_size = 4
+        kv_cache_group_id = 0
+
+        pool = BlockPool(
+            num_gpu_blocks=4,
+            enable_caching=True,
+            hash_block_size=block_size,
+            verify_content_on_hit=True,
+        )
+
+        fake_hash = BlockHash(b"same-hash")
+        key = make_block_hash_with_group_id(fake_hash, kv_cache_group_id)
+        fp = (10, 20, 30, 40)
+
+        block_a = pool.get_new_blocks(1)[0]
+        block_b = pool.get_new_blocks(1)[0]
+
+        pool._insert_block_hash(key, block_a, num_tokens=4, content_fingerprint=fp)
+        pool._insert_block_hash(key, block_b, num_tokens=4, content_fingerprint=fp)
+
+        # Both should be in the map (different block_ids, same hash).
+        assert pool.cached_block_hash_to_block.contain(key, block_a.block_id)
+        assert pool.cached_block_hash_to_block.contain(key, block_b.block_id)
+
+    def test_no_verification_when_disabled(self):
+        """When verify_content_on_hit=False (sha256), no fingerprints are
+        stored and collisions are not checked."""
+        block_size = 4
+        kv_cache_group_id = 0
+
+        pool = BlockPool(
+            num_gpu_blocks=4,
+            enable_caching=True,
+            hash_block_size=block_size,
+            verify_content_on_hit=False,
+        )
+
+        fake_hash = BlockHash(b"noverify-hash")
+        key = make_block_hash_with_group_id(fake_hash, kv_cache_group_id)
+
+        block_a = pool.get_new_blocks(1)[0]
+        block_b = pool.get_new_blocks(1)[0]
+
+        fp_a = (1, 2, 3, 4)
+        fp_b = (5, 6, 7, 8)
+
+        pool._insert_block_hash(key, block_a, num_tokens=4, content_fingerprint=fp_a)
+        pool._insert_block_hash(key, block_b, num_tokens=4, content_fingerprint=fp_b)
+
+        # Both inserted (no collision check), no fingerprints stored.
+        assert pool.cached_block_hash_to_block.contain(key, block_a.block_id)
+        assert pool.cached_block_hash_to_block.contain(key, block_b.block_id)
+        assert len(pool._block_fingerprints) == 0
+
+    def test_fingerprints_cleaned_on_eviction(self):
+        """Fingerprints are removed when blocks are evicted."""
+        block_size = 4
+        kv_cache_group_id = 0
+
+        pool = BlockPool(
+            num_gpu_blocks=3,
+            enable_caching=True,
+            hash_block_size=block_size,
+            verify_content_on_hit=True,
+        )
+
+        fake_hash = BlockHash(b"evict-hash")
+        key = make_block_hash_with_group_id(fake_hash, kv_cache_group_id)
+        fp = (100, 200, 300, 400)
+
+        block = pool.get_new_blocks(1)[0]
+        pool._insert_block_hash(key, block, num_tokens=4, content_fingerprint=fp)
+        assert key in pool._block_fingerprints
+
+        pool._remove_cached_block_hashes(block)
+        assert key not in pool._block_fingerprints
+
+    def test_fingerprints_cleaned_on_reset(self):
+        """Fingerprints are cleared when prefix cache is reset."""
+        block_size = 4
+
+        pool = BlockPool(
+            num_gpu_blocks=3,
+            enable_caching=True,
+            hash_block_size=block_size,
+            verify_content_on_hit=True,
+        )
+
+        fake_hash = BlockHash(b"reset-hash")
+        key = make_block_hash_with_group_id(fake_hash, 0)
+        fp = (1, 2, 3, 4)
+
+        block = pool.get_new_blocks(1)[0]
+        pool._insert_block_hash(key, block, num_tokens=4, content_fingerprint=fp)
+        assert len(pool._block_fingerprints) == 1
+
+        pool.free_blocks([block])
+        pool.reset_prefix_cache()
+        assert len(pool._block_fingerprints) == 0
+
+    def test_cache_full_blocks_stores_fingerprint(self):
+        """cache_full_blocks stores fingerprints when verification is on."""
+        block_size = 4
+        kv_cache_group_id = 0
+
+        pool = BlockPool(
+            num_gpu_blocks=4,
+            enable_caching=True,
+            hash_block_size=block_size,
+            verify_content_on_hit=True,
+        )
+
+        token_ids = [10, 20, 30, 40, 50, 60, 70, 80]
+        req = _make_request("req1", token_ids, block_size)
+
+        blocks = pool.get_new_blocks(2)
+        pool.cache_full_blocks(
+            request=req,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=2,
+            block_size=block_size,
+            kv_cache_group_id=kv_cache_group_id,
+        )
+
+        assert len(pool._block_fingerprints) == 2
+
+        fps = list(pool._block_fingerprints.values())
+        assert fps[0] == tuple(token_ids[:4])
+        assert fps[1] == tuple(token_ids[4:8])

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -29,6 +29,10 @@ from vllm.v1.request import Request
 
 logger = init_logger(__name__)
 
+# Compact fingerprint for verifying block token content on hash collision.
+# Stored per cached block when using non-cryptographic hash algorithms.
+BlockContentFingerprint = tuple[int, ...]
+
 
 class BlockHashToBlockMap:
     """
@@ -156,6 +160,9 @@ class BlockPool:
             where different KV cache groups have different block sizes, the
             actual block size can be a multiple of hash_block_size.
         enable_kv_cache_events: Whether to enable kv cache events.
+        verify_content_on_hit: Whether to verify block content on cache
+            insertion to detect hash collisions. Enabled automatically when
+            using non-cryptographic hash algorithms (xxhash/xxhash_cbor).
         metrics_collector: Optional metrics collector for tracking block residency.
     """
 
@@ -165,6 +172,7 @@ class BlockPool:
         enable_caching: bool,
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
+        verify_content_on_hit: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
@@ -192,6 +200,11 @@ class BlockPool:
 
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
+
+        self.verify_content_on_hit = verify_content_on_hit
+        self._block_fingerprints: dict[
+            BlockHashWithGroupId, BlockContentFingerprint
+        ] = {}
 
         self.metrics_collector = metrics_collector
 
@@ -290,10 +303,18 @@ class BlockPool:
                 )
                 removed_hashes = self._remove_cached_block_hashes(blk)
                 self._emit_block_removed_events(removed_hashes)
+
+            content_fp: BlockContentFingerprint | None = None
+            if self.verify_content_on_hit:
+                blk_start = (num_cached_blocks + i) * block_size
+                blk_end = blk_start + block_size
+                content_fp = tuple(request.all_token_ids[blk_start:blk_end])
+
             self._insert_block_hash(
                 block_hash_with_group_id,
                 blk,
                 num_tokens=num_hash_tokens,
+                content_fingerprint=content_fp,
             )
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
@@ -505,10 +526,18 @@ class BlockPool:
         ):
             removed_hashes = self._remove_cached_block_hashes(block)
             self._emit_block_removed_events(removed_hashes)
+
+        content_fp: BlockContentFingerprint | None = None
+        if self.verify_content_on_hit:
+            blk_start = (num_hash_blocks - 1) * self.hash_block_size
+            blk_end = num_tokens
+            content_fp = tuple(request.all_token_ids[blk_start:blk_end])
+
         self._insert_block_hash(
             block_hash_with_group_id,
             block,
             num_tokens=num_hash_blocks * self.hash_block_size,
+            content_fingerprint=content_fp,
         )
         if self.enable_kv_cache_events and not already_cached:
             parent_hash, block_start = self._get_partial_block_parent_hash_and_start(
@@ -586,6 +615,7 @@ class BlockPool:
                 is not None
             ):
                 removed_hashes.append(block_hash)
+                self._block_fingerprints.pop(block_hash, None)
         block.reset_hash()
         return removed_hashes
 
@@ -609,6 +639,7 @@ class BlockPool:
         block_hash_with_group_id: BlockHashWithGroupId,
         block: KVCacheBlock,
         num_tokens: int | None,
+        content_fingerprint: BlockContentFingerprint | None = None,
     ) -> None:
         if block.block_hash == block_hash_with_group_id:
             return
@@ -618,6 +649,21 @@ class BlockPool:
         ):
             return
 
+        if (
+            self.verify_content_on_hit
+            and content_fingerprint is not None
+            and block_hash_with_group_id in self._block_fingerprints
+        ):
+            existing_fp = self._block_fingerprints[block_hash_with_group_id]
+            if existing_fp != content_fingerprint:
+                logger.warning(
+                    "Hash collision detected in prefix cache: two blocks "
+                    "with different token content produced the same hash. "
+                    "Skipping insertion of the colliding block. Consider "
+                    "switching to --prefix-caching-hash-algo sha256."
+                )
+                return
+
         if block.block_hash is None:
             block.set_block_hash(block_hash_with_group_id, num_tokens=num_tokens)
         else:
@@ -625,6 +671,9 @@ class BlockPool:
                 block_hash_with_group_id
             )
         self.cached_block_hash_to_block.insert(block_hash_with_group_id, block)
+
+        if self.verify_content_on_hit and content_fingerprint is not None:
+            self._block_fingerprints[block_hash_with_group_id] = content_fingerprint
 
     def move_block_hashes(
         self,
@@ -786,6 +835,7 @@ class BlockPool:
         # Remove all hashes so that no new blocks will hit.
         self.cached_block_hash_to_block = BlockHashToBlockMap()
         self.cached_block_hashes_by_block.clear()
+        self._block_fingerprints.clear()
 
         # Remove all hashes from all blocks.
         for block in self.blocks:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -83,6 +83,7 @@ class KVCacheCoordinator(ABC):
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
         num_prefill_lookahead: int = 0,
+        verify_hash_content: bool = False,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
@@ -101,6 +102,7 @@ class KVCacheCoordinator(ABC):
             enable_caching=enable_caching,
             hash_block_size=hash_block_size,
             enable_kv_cache_events=enable_kv_cache_events,
+            verify_content_on_hit=verify_hash_content,
             metrics_collector=metrics_collector,
         )
 
@@ -441,6 +443,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
         num_prefill_lookahead: int = 0,
+        verify_hash_content: bool = False,
     ):
         super().__init__(
             kv_cache_config,
@@ -455,6 +458,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
             num_prefill_lookahead=num_prefill_lookahead,
+            verify_hash_content=verify_hash_content,
         )
         self.num_single_type_manager = len(self.single_type_managers)
 
@@ -493,6 +497,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
         num_prefill_lookahead: int = 0,
+        verify_hash_content: bool = False,
     ):
         super().__init__(
             kv_cache_config,
@@ -507,6 +512,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
             num_prefill_lookahead=num_prefill_lookahead,
+            verify_hash_content=verify_hash_content,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
         self.dcp_world_size = self.single_type_managers[0].dcp_world_size
@@ -578,6 +584,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
         num_prefill_lookahead: int = 0,
+        verify_hash_content: bool = False,
     ):
         super().__init__(
             kv_cache_config,
@@ -592,6 +599,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
             num_prefill_lookahead=num_prefill_lookahead,
+            verify_hash_content=verify_hash_content,
         )
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -950,6 +958,7 @@ def get_kv_cache_coordinator(
     hash_block_size: int,
     metrics_collector: KVCacheMetricsCollector | None = None,
     num_prefill_lookahead: int = 0,
+    verify_hash_content: bool = False,
 ) -> KVCacheCoordinator:
     if not enable_caching:
         return KVCacheCoordinatorNoPrefixCache(
@@ -964,6 +973,7 @@ def get_kv_cache_coordinator(
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
             num_prefill_lookahead=num_prefill_lookahead,
+            verify_hash_content=verify_hash_content,
         )
     if len(kv_cache_config.kv_cache_groups) == 1:
         return UnitaryKVCacheCoordinator(
@@ -979,6 +989,7 @@ def get_kv_cache_coordinator(
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
             num_prefill_lookahead=num_prefill_lookahead,
+            verify_hash_content=verify_hash_content,
         )
     return HybridKVCacheCoordinator(
         kv_cache_config,
@@ -992,5 +1003,6 @@ def get_kv_cache_coordinator(
         scheduler_block_size=scheduler_block_size,
         hash_block_size=hash_block_size,
         metrics_collector=metrics_collector,
+        verify_hash_content=verify_hash_content,
         num_prefill_lookahead=num_prefill_lookahead,
     )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -132,6 +132,7 @@ class KVCacheManager:
         pcp_world_size: int = 1,
         metrics_collector: KVCacheMetricsCollector | None = None,
         watermark: float = 0.0,
+        verify_hash_content: bool = False,
     ) -> None:
         self.max_model_len = max_model_len
         # When unset, fall back to `max_model_len` so the recycling-aware cap
@@ -163,6 +164,7 @@ class KVCacheManager:
             hash_block_size=hash_block_size,
             metrics_collector=self.metrics_collector,
             num_prefill_lookahead=num_prefill_lookahead,
+            verify_hash_content=verify_hash_content,
         )
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -284,6 +284,10 @@ class Scheduler(SchedulerInterface):
         if hash_block_size is None:
             hash_block_size = block_size
         self.hash_block_size = hash_block_size
+        verify_hash_content = self.cache_config.prefix_caching_hash_algo in (
+            "xxhash",
+            "xxhash_cbor",
+        )
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
@@ -299,6 +303,7 @@ class Scheduler(SchedulerInterface):
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
             watermark=self.scheduler_config.watermark,
+            verify_hash_content=verify_hash_content,
         )
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.


### PR DESCRIPTION
When using non-cryptographic hash algorithms (xxhash/xxhash_cbor) for prefix caching, hash collisions can cause cache poisoning where a request receives incorrect KV cache data from an unrelated prompt.

Add insertion-time content verification that stores a token fingerprint alongside each cached block and rejects colliding insertions with a warning. The defense is automatically enabled when the configured hash algorithm is xxhash or xxhash_cbor, with zero overhead on the default sha256 path.
