### PR TITLE
[Bugfix][Spec Decode] Fix DFlash draft KV cache dtype isolation

### DIFF
--- a/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
+++ b/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """FlashInfer GQA builder: reorder threshold under DCP with spec decode."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from vllm.platforms import current_platform
@@ -19,7 +21,7 @@ from vllm.v1.attention.backends.flashinfer import (
     FlashInferMetadataBuilder,
 )
 from vllm.v1.attention.backends.utils import PerLayerParameters
-from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVQuantMode
 
 
 def test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold(monkeypatch):
@@ -73,3 +75,28 @@ def test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold(monkeypatch):
         builder.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.TRTLLM_GEN
     )
     assert builder.reorder_batch_threshold == 1
+
+
+def test_flashinfer_resolves_group_cache_dtype_without_mutating_config(monkeypatch):
+    vllm_config = SimpleNamespace(cache_config=SimpleNamespace(cache_dtype="auto"))
+
+    monkeypatch.setattr(
+        flashinfer_backend,
+        "get_kv_cache_dtype_from_layers",
+        lambda *_args, **_kwargs: "fp8",
+    )
+    kv_cache_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float8_e4m3fn,
+        kv_quant_mode=KVQuantMode.FP8_PER_TENSOR,
+    )
+    cache_dtype = flashinfer_backend._get_group_cache_dtype(
+        kv_cache_spec,
+        ["draft.layer.0"],
+        vllm_config,  # type: ignore[arg-type]
+    )
+
+    assert cache_dtype == "fp8"
+    assert vllm_config.cache_config.cache_dtype == "auto"

--- a/tests/v1/attention/test_group_head_counts.py
+++ b/tests/v1/attention/test_group_head_counts.py
@@ -14,6 +14,7 @@ from vllm.v1.attention.backends.cpu_attn import (
     CPUAttentionMetadataBuilder,
 )
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadataBuilder
+from vllm.v1.attention.backends.utils import get_kv_cache_dtype_from_layers
 
 requires_cpu = pytest.mark.skipif(
     not current_platform.is_cpu(), reason="CPU attention backend"
@@ -128,3 +129,14 @@ def test_flash_attention_geometry_comes_from_the_group():
     assert builder.num_heads_q == 16
     assert builder.num_heads_kv == 2
     assert builder.headdim == 64
+
+
+def test_kv_cache_dtype_comes_from_the_group():
+    layers = {"draft.layer.0": SimpleNamespace(kv_cache_dtype="fp8")}
+    with patch(
+        "vllm.v1.attention.backends.utils.get_layers_from_vllm_config",
+        return_value=layers,
+    ):
+        cache_dtype = get_kv_cache_dtype_from_layers(MagicMock(), ["draft.layer.0"])
+
+    assert cache_dtype == "fp8"

--- a/tests/v1/spec_decode/test_dflash_model_loading.py
+++ b/tests/v1/spec_decode/test_dflash_model_loading.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch.nn as nn
+
+from vllm.v1.worker.gpu.spec_decode.dflash import utils as dflash_utils
+
+
+@pytest.mark.parametrize("load_fails", [False, True])
+def test_dflash_draft_dtype_keeps_shared_cache_config(monkeypatch, load_fails):
+    cache_config = SimpleNamespace(cache_dtype="auto", kv_cache_layout=None)
+    draft_model_config = SimpleNamespace(hf_config=SimpleNamespace())
+    vllm_config = SimpleNamespace(
+        attention_config=SimpleNamespace(),
+        cache_config=cache_config,
+        speculative_config=SimpleNamespace(
+            attention_backend=None,
+            draft_model_config=draft_model_config,
+            kv_cache_dtype="fp8",
+        ),
+    )
+
+    captured = SimpleNamespace(cache_config=None, cache_dtype=None)
+
+    class DraftModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = nn.Module()
+
+    def get_model(*, vllm_config, model_config):
+        assert model_config is draft_model_config
+        captured.cache_config = vllm_config.cache_config
+        captured.cache_dtype = vllm_config.cache_config.cache_dtype
+        if load_fails:
+            raise RuntimeError("model load failed")
+        return DraftModel()
+
+    def replace(config, **updates):
+        values = vars(config) | updates
+        return SimpleNamespace(**values)
+
+    monkeypatch.setattr(dflash_utils, "replace", replace)
+    monkeypatch.setattr(dflash_utils, "get_model", get_model)
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_dflash.dflash_has_any_non_causal",
+        lambda _hf_config: False,
+    )
+    monkeypatch.setattr(
+        dflash_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(world_size=2),
+    )
+    monkeypatch.setattr(dflash_utils, "get_target_lm_head", lambda *_args: None)
+
+    if load_fails:
+        with pytest.raises(RuntimeError, match="model load failed"):
+            dflash_utils.load_dflash_model(  # type: ignore[arg-type]
+                nn.Module(), vllm_config
+            )
+    else:
+        dflash_utils.load_dflash_model(  # type: ignore[arg-type]
+            nn.Module(), vllm_config
+        )
+
+    assert captured.cache_config is cache_config
+    assert captured.cache_dtype == "fp8"
+    assert cache_config.cache_dtype == "auto"
+    cache_config.kv_cache_layout = "NHD"
+    assert captured.cache_config.kv_cache_layout == "NHD"

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -69,6 +69,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.utils import (
     get_dcp_local_seq_lens,
     get_flashinfer_layout_string,
+    get_kv_cache_dtype_from_layers,
     get_num_attention_heads_from_layers,
     get_per_layer_parameters,
     infer_global_hyperparameters,
@@ -98,6 +99,19 @@ FP4_DTYPE = torch.uint8
 logger = init_logger(__name__)
 
 trtllm_workspace_buffer = None
+
+
+def _get_group_cache_dtype(
+    kv_cache_spec: AttentionSpec,
+    layer_names: list[str],
+    vllm_config: VllmConfig,
+) -> str:
+    if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE:
+        return "auto"
+    return (
+        get_kv_cache_dtype_from_layers(vllm_config, layer_names)
+        or vllm_config.cache_config.cache_dtype
+    )
 
 
 def _get_trtllm_workspace_buffer():
@@ -759,7 +773,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.page_size = self.kv_cache_spec.block_size
 
         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
-            self.cache_dtype = self.cache_config.cache_dtype
+            self.cache_dtype = _get_group_cache_dtype(
+                self.kv_cache_spec, layer_names, vllm_config
+            )
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype.startswith("nvfp4")

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -388,6 +388,20 @@ def get_num_attention_heads_from_layers(
     return heads.pop()
 
 
+def get_kv_cache_dtype_from_layers(
+    vllm_config: VllmConfig, layer_names: list[str]
+) -> str | None:
+    """Return the KV cache dtype configured by this attention group."""
+    attn_layers = get_layers_from_vllm_config(
+        vllm_config,
+        AttentionLayerBase,  # type: ignore[type-abstract]
+        layer_names,
+    )
+    if not attn_layers:
+        return None
+    return cast(Any, next(iter(attn_layers.values()))).kv_cache_dtype
+
+
 def infer_global_hyperparameters(
     per_layer_params: dict[str, PerLayerParameters],
 ) -> PerLayerParameters:

--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
@@ -22,26 +22,29 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     draft_model_config = speculative_config.draft_model_config
     # Select an attention backend that supports the drafter's attention: mixing
     # a non-causal layer onto a causal-only backend would fail.
-    draft_vllm_config = replace(
-        vllm_config,
-        attention_config=replace(
-            vllm_config.attention_config,
-            use_non_causal=dflash_has_any_non_causal(draft_model_config.hf_config),
-            backend=speculative_config.attention_backend,
-        ),
-        cache_config=(
-            replace(
-                vllm_config.cache_config,
-                cache_dtype=speculative_config.kv_cache_dtype,
-            )
-            if speculative_config.kv_cache_dtype is not None
-            else vllm_config.cache_config
-        ),
-    )
-    with set_model_tag("dflash_head"):
-        dflash_model = get_model(
-            vllm_config=draft_vllm_config, model_config=draft_model_config
+    # The engine resolves the physical KV-cache layout after model construction.
+    # Keep the shared CacheConfig so the draft attention implementations observe
+    # that later update, while exposing the draft-only dtype during construction.
+    cache_config = vllm_config.cache_config
+    target_cache_dtype = cache_config.cache_dtype
+    try:
+        if speculative_config.kv_cache_dtype is not None:
+            cache_config.cache_dtype = speculative_config.kv_cache_dtype
+        draft_vllm_config = replace(
+            vllm_config,
+            attention_config=replace(
+                vllm_config.attention_config,
+                use_non_causal=dflash_has_any_non_causal(draft_model_config.hf_config),
+                backend=speculative_config.attention_backend,
+            ),
+            cache_config=cache_config,
         )
+        with set_model_tag("dflash_head"):
+            dflash_model = get_model(
+                vllm_config=draft_vllm_config, model_config=draft_model_config
+            )
+    finally:
+        cache_config.cache_dtype = target_cache_dtype
 
     target_language_model = (
         target_model.get_language_model()


### PR DESCRIPTION
## Purpose

Fixes #54690.

When DFlash uses an explicit FP8 draft KV-cache dtype while the target keeps
`kv_cache_dtype=auto`, the shared cache configuration can expose the unresolved
target value to FlashInfer metadata construction. This causes startup to fail
with `ValueError: Unrecognized dtype: auto`.

This change:

- resolves the FlashInfer cache dtype from the layers in the actual attention
  group;
- keeps target and draft KV-cache dtypes isolated while preserving the shared
  `CacheConfig` layout lifecycle required by model loading; and
- restores the target dtype even when draft model construction fails.

This is not duplicating an existing PR. The closest open DFlash changes cover
RoPE cache reuse (#53251), draft weight-quantization mapping (#53122), fused
quantized context-KV projection (#51620), or DSpark-specific MLA cache handling
(#48381); none addresses the target/draft `CacheConfig.kv_cache_dtype` lifecycle
or per-attention-group FlashInfer dtype resolution.

AI assistance was used during implementation and validation. The submitting
human reviewed every changed line, understands the change end-to-end, and
confirmed the test evidence below.

## Test Plan

Run the focused regression and worker suites:

```bash
.venv/bin/python -m pytest -q \
  tests/v1/spec_decode/test_dflash_model_loading.py \
  tests/v1/attention/test_group_head_counts.py::test_kv_cache_dtype_comes_from_the_group \
  tests/v1/attention/test_flashinfer_dcp_spec_reorder.py::test_flashinfer_resolves_group_cache_dtype_without_mutating_config \
  tests/v1/worker/test_attn_utils.py \
  tests/v1/worker/test_gpu_model_runner_v2.py
```

Run the relevant pre-commit hooks for all six changed Python files, then perform
an exact-base before/after DFlash startup and generation check on CUDA.

## Test Result

- Focused pytest suite on RTX 3090 / SM86: `23 passed, 14 warnings in 9.84s`.
- Relevant pre-commit hooks passed: Ruff check/format, SPDX, typos, filename,
  forbidden-import, `torch.cuda`, boolean-context-manager, root-lazy-import, and
  Python 3.10 mypy checks.
- `git diff --check`: passed.
- Exact-base A/B at `4ac452ad9883864bb3ab0412a45a63cbf62d730a`:
  - Before: Qwen3-8B target with `auto` KV dtype plus Qwen3-8B-DFlash-b16 draft
    with FP8 KV dtype fails in `FlashInferMetadataBuilder` with
    `ValueError: Unrecognized dtype: auto`.
  - After: the same configuration loads the target and draft, resolves the
    draft attention group to `torch.float8_e4m3fn`, allocates KV cache, warms
    up, and generates successfully.
- A TP=4 run initialized and loaded all four target/draft workers, but the
  environment then hit a stale native extension missing
  `_C.vocab_parallel_embedding`; this is not counted as a TP=4 pass.
- The reporter's native SM89 / 4x RTX 4090 path was not rerun because that node
  was unreachable. The separate explicit-target-dtype native crash described
  in the issue therefore remains unverified by this PR.
- A full all-hook pre-commit invocation was attempted but could not install an
  unrelated Go hook environment because `proxy.golang.org` timed out. No Go or
  GitHub Actions files are changed.
- No performance claim is made.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation change is required for this bug fix.
</details>

