### PR TITLE
[Bugfix][DCP] Validate connector interleave capabilities

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,6 +172,10 @@ def test_pd_dcp_interleave_size_is_adjusted_to_block_size(
             kv_role="kv_both",
         ),
         KVTransferConfig(
+            kv_connector="OffloadingConnector",
+            kv_role="kv_both",
+        ),
+        KVTransferConfig(
             kv_connector="MultiConnector",
             kv_role="kv_both",
             kv_connector_extra_config={
@@ -179,12 +183,16 @@ def test_pd_dcp_interleave_size_is_adjusted_to_block_size(
                     {
                         "kv_connector": "SimpleCPUOffloadConnector",
                         "kv_role": "kv_both",
-                    }
+                    },
+                    {
+                        "kv_connector": "OffloadingConnector",
+                        "kv_role": "kv_both",
+                    },
                 ]
             },
         ),
     ],
-    ids=["direct", "multi"],
+    ids=["simple", "offloading", "multi-local"],
 )
 def test_local_offload_keeps_dcp_interleave_size(
     kv_transfer_config: KVTransferConfig,
@@ -268,6 +276,31 @@ def test_multi_connector_with_pd_uses_block_aligned_dcp_interleave():
                     },
                 ]
             },
+        ),
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=16))]
+    )
+
+    config.adjust_dcp_kv_cache_interleave_size(kv_cache_config)
+
+    assert config.parallel_config.cp_kv_cache_interleave_size == 16
+
+
+def test_empty_multi_connector_uses_block_aligned_dcp_interleave():
+    config = VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+            distributed_executor_backend="mp",
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={"connectors": []},
         ),
     )
     kv_cache_config = SimpleNamespace(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,7 +164,86 @@ def test_pd_dcp_interleave_size_is_adjusted_to_block_size(
     assert "automatically adjusted from 3 to block_size 16" in caplog.text
 
 
-def test_kv_offloading_does_not_adjust_dcp_interleave_size():
+@pytest.mark.parametrize(
+    "kv_transfer_config",
+    [
+        KVTransferConfig(
+            kv_connector="SimpleCPUOffloadConnector",
+            kv_role="kv_both",
+        ),
+        KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "SimpleCPUOffloadConnector",
+                        "kv_role": "kv_both",
+                    }
+                ]
+            },
+        ),
+    ],
+    ids=["direct", "multi"],
+)
+def test_local_offload_keeps_dcp_interleave_size(
+    kv_transfer_config: KVTransferConfig,
+):
+    config = VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+            distributed_executor_backend="mp",
+        ),
+        kv_transfer_config=kv_transfer_config,
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=16))]
+    )
+
+    config.adjust_dcp_kv_cache_interleave_size(kv_cache_config)
+    config.validate_block_size()
+
+    assert config.parallel_config.cp_kv_cache_interleave_size == 1
+
+
+@pytest.mark.parametrize(
+    "kv_transfer_config",
+    [
+        KVTransferConfig(
+            kv_connector="SimpleCPUOffloadConnector",
+            kv_role="kv_both",
+        ),
+        KVTransferConfig(
+            kv_connector="OffloadingConnector",
+            kv_role="kv_both",
+        ),
+    ],
+    ids=["simple", "offloading"],
+)
+def test_local_offload_rejects_invalid_dcp_interleave_size(
+    kv_transfer_config: KVTransferConfig,
+):
+    config = VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=3,
+            distributed_executor_backend="mp",
+        ),
+        kv_transfer_config=kv_transfer_config,
+    )
+
+    with pytest.raises(AssertionError, match="divisible"):
+        config.validate_block_size()
+
+
+def test_multi_connector_with_pd_uses_block_aligned_dcp_interleave():
     config = VllmConfig(
         cache_config=CacheConfig(block_size=16),
         device_config=DeviceConfig(device="cpu"),
@@ -175,38 +254,29 @@ def test_kv_offloading_does_not_adjust_dcp_interleave_size():
             distributed_executor_backend="mp",
         ),
         kv_transfer_config=KVTransferConfig(
-            kv_connector="OffloadingConnector",
+            kv_connector="MultiConnector",
             kv_role="kv_both",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "SimpleCPUOffloadConnector",
+                        "kv_role": "kv_both",
+                    },
+                    {
+                        "kv_connector": "NixlConnector",
+                        "kv_role": "kv_both",
+                    },
+                ]
+            },
         ),
     )
-
     kv_cache_config = SimpleNamespace(
         kv_cache_groups=[SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=16))]
     )
+
     config.adjust_dcp_kv_cache_interleave_size(kv_cache_config)
 
-    assert config.parallel_config.cp_kv_cache_interleave_size == 1
-
-
-def test_kv_offloading_does_not_skip_dcp_interleave_validation():
-    config = SimpleNamespace(
-        cache_config=SimpleNamespace(
-            block_size=16,
-            mamba_cache_mode="none",
-        ),
-        parallel_config=SimpleNamespace(
-            decode_context_parallel_size=2,
-            cp_kv_cache_interleave_size=3,
-        ),
-        scheduler_config=SimpleNamespace(disable_chunked_mm_input=False),
-        kv_transfer_config=KVTransferConfig(
-            kv_connector="OffloadingConnector",
-            kv_role="kv_both",
-        ),
-    )
-
-    with pytest.raises(AssertionError, match="divisible by"):
-        VllmConfig.validate_block_size(config)
+    assert config.parallel_config.cp_kv_cache_interleave_size == 16
 
 
 def test_compile_config_repr_succeeds():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -176,6 +176,10 @@ def test_pd_dcp_interleave_size_is_adjusted_to_block_size(
             kv_role="kv_both",
         ),
         KVTransferConfig(
+            kv_connector="DecodeBenchConnector",
+            kv_role="kv_both",
+        ),
+        KVTransferConfig(
             kv_connector="MultiConnector",
             kv_role="kv_both",
             kv_connector_extra_config={
@@ -191,8 +195,36 @@ def test_pd_dcp_interleave_size_is_adjusted_to_block_size(
                 ]
             },
         ),
+        KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "MultiConnector",
+                        "kv_role": "kv_both",
+                        "kv_connector_extra_config": {
+                            "connectors": [
+                                {
+                                    "kv_connector": "SimpleCPUOffloadConnector",
+                                    "kv_role": "kv_both",
+                                },
+                                {
+                                    "kv_connector": "DecodeBenchConnector",
+                                    "kv_role": "kv_both",
+                                },
+                            ]
+                        },
+                    },
+                    {
+                        "kv_connector": "OffloadingConnector",
+                        "kv_role": "kv_both",
+                    },
+                ]
+            },
+        ),
     ],
-    ids=["simple", "offloading", "multi-local"],
+    ids=["simple", "offloading", "decode-bench", "multi-local", "nested-multi-local"],
 )
 def test_local_offload_keeps_dcp_interleave_size(
     kv_transfer_config: KVTransferConfig,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2746,7 +2746,8 @@ class VllmConfig:
     def adjust_dcp_kv_cache_interleave_size(
         self, kv_cache_config: "KVCacheConfig"
     ) -> None:
-        """Normalize DCP interleave size against block_size for NIXL P/D.
+        """Normalize DCP interleave size against block_size for connectors
+        that require block-level alignment.
 
         Called by each worker (via ensure_kv_transfer_initialized), once it knows its
         own final block_size via kv_cache_config.
@@ -2767,9 +2768,7 @@ class VllmConfig:
                 "deprecated when PCP is fully supported."
             )
 
-        if self.kv_transfer_config is None or not self.kv_transfer_config.has_connector(
-            "NixlConnector"
-        ):
+        if self.kv_transfer_config is None:
             return
 
         # Get the kernel block_size, but don't use resolve_kv_cache_block_size to avoid
@@ -2777,7 +2776,15 @@ class VllmConfig:
         local_block_size = min(
             g.kv_cache_spec.block_size for g in kv_cache_config.kv_cache_groups
         )
-        if self.parallel_config.cp_kv_cache_interleave_size != local_block_size:
+        if self.parallel_config.cp_kv_cache_interleave_size == local_block_size:
+            return
+
+        from vllm.distributed.kv_transfer.kv_connector.factory import (
+            KVConnectorFactory,
+        )
+
+        connector_cls = KVConnectorFactory.get_connector_class(self.kv_transfer_config)
+        if connector_cls.requires_dcp_block_aligned_interleave:
             interleave = self.parallel_config.cp_kv_cache_interleave_size
             self.parallel_config.cp_kv_cache_interleave_size = local_block_size
             logger.info_once(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2827,7 +2827,8 @@ class VllmConfig:
             KVConnectorFactory,
         )
 
-        return KVConnectorFactory.requires_dcp_block_aligned_interleave(config)
+        connector_cls = KVConnectorFactory.get_connector_class(config)
+        return connector_cls.requires_dcp_block_aligned_interleave(config)
 
     @model_validator(mode="after")
     def validate_nvfp4_kv_cache_with_mla(self) -> "VllmConfig":

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2768,23 +2768,15 @@ class VllmConfig:
                 "deprecated when PCP is fully supported."
             )
 
-        if self.kv_transfer_config is None:
-            return
-
         # Get the kernel block_size, but don't use resolve_kv_cache_block_size to avoid
         # scaling by dcp_size (we need the local block_size here).
         local_block_size = min(
             g.kv_cache_spec.block_size for g in kv_cache_config.kv_cache_groups
         )
-        if self.parallel_config.cp_kv_cache_interleave_size == local_block_size:
-            return
-
-        from vllm.distributed.kv_transfer.kv_connector.factory import (
-            KVConnectorFactory,
-        )
-
-        connector_cls = KVConnectorFactory.get_connector_class(self.kv_transfer_config)
-        if connector_cls.requires_dcp_block_aligned_interleave:
+        if (
+            self._requires_dcp_block_aligned_interleave()
+            and self.parallel_config.cp_kv_cache_interleave_size != local_block_size
+        ):
             interleave = self.parallel_config.cp_kv_cache_interleave_size
             self.parallel_config.cp_kv_cache_interleave_size = local_block_size
             logger.info_once(
@@ -2805,13 +2797,10 @@ class VllmConfig:
         """
         block_size = self.cache_config.block_size
 
-        # Skip DCP interleave-size compatibility for NIXL P/D: the interleave
-        # size is pinned to block_size by each worker.
-        nixl_pd_active = (
-            self.kv_transfer_config is not None
-            and self.kv_transfer_config.has_connector("NixlConnector")
-        )
-        if self.parallel_config.decode_context_parallel_size > 1 and not nixl_pd_active:
+        if (
+            self.parallel_config.decode_context_parallel_size > 1
+            and not self._requires_dcp_block_aligned_interleave()
+        ):
             assert (
                 self.parallel_config.cp_kv_cache_interleave_size <= block_size
                 and block_size % self.parallel_config.cp_kv_cache_interleave_size == 0
@@ -2827,6 +2816,18 @@ class VllmConfig:
                 "to schedule a multiple of block_size tokens even if they are "
                 "in the middle of a mm input"
             )
+
+    def _requires_dcp_block_aligned_interleave(self) -> bool:
+        """Whether the configured connector composition needs block alignment."""
+        config = self.kv_transfer_config
+        if config is None or not config.is_kv_transfer_instance:
+            return False
+
+        from vllm.distributed.kv_transfer.kv_connector.factory import (
+            KVConnectorFactory,
+        )
+
+        return KVConnectorFactory.requires_dcp_block_aligned_interleave(config)
 
     @model_validator(mode="after")
     def validate_nvfp4_kv_cache_with_mla(self) -> "VllmConfig":

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2774,8 +2774,8 @@ class VllmConfig:
             g.kv_cache_spec.block_size for g in kv_cache_config.kv_cache_groups
         )
         if (
-            self._requires_dcp_block_aligned_interleave()
-            and self.parallel_config.cp_kv_cache_interleave_size != local_block_size
+            self.parallel_config.cp_kv_cache_interleave_size != local_block_size
+            and self._requires_dcp_block_aligned_interleave()
         ):
             interleave = self.parallel_config.cp_kv_cache_interleave_size
             self.parallel_config.cp_kv_cache_interleave_size = local_block_size

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -144,6 +144,25 @@ class KVConnectorFactory:
 
         return MultiConnector.all_children_support_hma(kv_transfer_config)
 
+    @classmethod
+    def requires_dcp_block_aligned_interleave(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        """Return whether this connector composition requires block alignment."""
+        if kv_transfer_config.kv_connector != "MultiConnector":
+            connector_cls = cls.get_connector_class(kv_transfer_config)
+            return connector_cls.requires_dcp_block_aligned_interleave
+
+        connectors = kv_transfer_config.kv_connector_extra_config.get("connectors", [])
+        if not connectors:
+            return True
+        return any(
+            cls.requires_dcp_block_aligned_interleave(
+                KVTransferConfig(**{"engine_id": kv_transfer_config.engine_id, **child})
+            )
+            for child in connectors
+        )
+
 
 # Register various connectors here.
 # The registration should not be done in each individual file, as we want to

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -153,14 +153,12 @@ class KVConnectorFactory:
             connector_cls = cls.get_connector_class(kv_transfer_config)
             return connector_cls.requires_dcp_block_aligned_interleave
 
-        connectors = kv_transfer_config.kv_connector_extra_config.get("connectors", [])
-        if not connectors:
-            return True
-        return any(
-            cls.requires_dcp_block_aligned_interleave(
-                KVTransferConfig(**{"engine_id": kv_transfer_config.engine_id, **child})
-            )
-            for child in connectors
+        from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
+            MultiConnector,
+        )
+
+        return MultiConnector.requires_dcp_block_aligned_interleave_config(
+            kv_transfer_config
         )
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -144,23 +144,6 @@ class KVConnectorFactory:
 
         return MultiConnector.all_children_support_hma(kv_transfer_config)
 
-    @classmethod
-    def requires_dcp_block_aligned_interleave(
-        cls, kv_transfer_config: "KVTransferConfig"
-    ) -> bool:
-        """Return whether this connector composition requires block alignment."""
-        if kv_transfer_config.kv_connector != "MultiConnector":
-            connector_cls = cls.get_connector_class(kv_transfer_config)
-            return connector_cls.requires_dcp_block_aligned_interleave
-
-        from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
-            MultiConnector,
-        )
-
-        return MultiConnector.requires_dcp_block_aligned_interleave_config(
-            kv_transfer_config
-        )
-
 
 # Register various connectors here.
 # The registration should not be done in each individual file, as we want to

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -173,6 +173,14 @@ class KVConnectorBase_V1(ABC):
     Base class for KV connectors.
     """
 
+    requires_dcp_block_aligned_interleave: bool = True
+    """Whether this connector needs cp_kv_cache_interleave_size pinned to block_size
+    when decode_context_parallel_size > 1.
+
+    Connectors that only move KV within the same DCP rank (e.g. CPU offloading) should
+    set this to False.
+    """
+
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:
         """Whether external hits can complete divergent local hybrid hits.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -54,6 +54,7 @@ from vllm.v1.outputs import KVConnectorOutput
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.config.kv_transfer import KVTransferConfig
     from vllm.distributed.kv_events import KVCacheEvent, KVConnectorKVEvents
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
         KVConnectorPromMetrics,
@@ -173,13 +174,16 @@ class KVConnectorBase_V1(ABC):
     Base class for KV connectors.
     """
 
-    requires_dcp_block_aligned_interleave: bool = True
-    """Whether this connector needs cp_kv_cache_interleave_size pinned to block_size
-    when decode_context_parallel_size > 1.
+    @classmethod
+    def requires_dcp_block_aligned_interleave(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        """Whether this connector needs DCP interleave pinned to block_size.
 
-    Connectors that only move KV within the same DCP rank (e.g. CPU offloading) should
-    set this to False.
-    """
+        Connectors that only move KV within the same DCP rank (e.g. CPU
+        offloading) should return False.
+        """
+        return True
 
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -182,6 +182,10 @@ class KVConnectorBase_V1(ABC):
 
         Connectors that only move KV within the same DCP rank (e.g. CPU
         offloading) should return False.
+
+        Args:
+            kv_transfer_config: The connector's own config. Composite
+                connectors use this to inspect their children.
         """
         return True
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -92,6 +92,7 @@ class DecodeBenchConnector(KVConnectorBase_V1, SupportsHMA):
     def requires_dcp_block_aligned_interleave(
         cls, kv_transfer_config: "KVTransferConfig"
     ) -> bool:
+        """Fills scheduler-allocated local blocks; no cross-rank KV transfer."""
         return False
 
     def __init__(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -54,6 +54,7 @@ from vllm.v1.core.kv_cache_utils import (
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.config.kv_transfer import KVTransferConfig
     from vllm.forward_context import ForwardContext
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -86,6 +87,12 @@ class DecodeBenchConnector(KVConnectorBase_V1, SupportsHMA):
     emulate a prefill-decode disaggregated setting, enabling performance
     testing of the decoder with larger input sequence lengths.
     """
+
+    @classmethod
+    def requires_dcp_block_aligned_interleave(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        return False
 
     def __init__(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -166,6 +166,25 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
                 return False
         return True
 
+    @classmethod
+    def requires_dcp_block_aligned_interleave_config(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        """Return True if any configured child requires block alignment."""
+        connectors_config = kv_transfer_config.kv_connector_extra_config.get(
+            "connectors", []
+        )
+        if not connectors_config:
+            return True
+        return any(
+            KVConnectorFactory.requires_dcp_block_aligned_interleave(
+                KVTransferConfig(
+                    **{"engine_id": kv_transfer_config.engine_id, **conn_config}
+                )
+            )
+            for conn_config in connectors_config
+        )
+
     def __init__(
         self,
         vllm_config: "VllmConfig",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import copy
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -151,17 +151,23 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         return False
 
     @classmethod
-    def all_children_support_hma(cls, kv_transfer_config: "KVTransferConfig") -> bool:
-        """Return True only if every configured child connector supports HMA."""
-        connectors_config = kv_transfer_config.kv_connector_extra_config.get(
+    def _iter_child_configs(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> Iterator["KVTransferConfig"]:
+        for conn_config in kv_transfer_config.kv_connector_extra_config.get(
             "connectors", []
-        )
-        if not connectors_config:
-            return False
-        for conn_config in connectors_config:
-            child_config = KVTransferConfig(
+        ):
+            yield KVTransferConfig(
                 **{"engine_id": kv_transfer_config.engine_id, **conn_config}
             )
+
+    @classmethod
+    def all_children_support_hma(cls, kv_transfer_config: "KVTransferConfig") -> bool:
+        """Return True only if every configured child connector supports HMA."""
+        child_configs = tuple(cls._iter_child_configs(kv_transfer_config))
+        if not child_configs:
+            return False
+        for child_config in child_configs:
             if not KVConnectorFactory.supports_hma_config(child_config):
                 return False
         return True
@@ -170,16 +176,16 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     def requires_dcp_block_aligned_interleave(
         cls, kv_transfer_config: "KVTransferConfig"
     ) -> bool:
-        """Return True if any configured child requires block alignment."""
-        connectors_config = kv_transfer_config.kv_connector_extra_config.get(
-            "connectors", []
-        )
-        if not connectors_config:
+        """Return True if any child requires block alignment.
+
+        An unconfigured MultiConnector conservatively requires alignment. This
+        is the opposite of the HMA default above, but both defaults choose the
+        stricter behavior for their respective capabilities.
+        """
+        child_configs = tuple(cls._iter_child_configs(kv_transfer_config))
+        if not child_configs:
             return True
-        for conn_config in connectors_config:
-            child_config = KVTransferConfig(
-                **{"engine_id": kv_transfer_config.engine_id, **conn_config}
-            )
+        for child_config in child_configs:
             child_cls = KVConnectorFactory.get_connector_class(child_config)
             if child_cls.requires_dcp_block_aligned_interleave(child_config):
                 return True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -167,7 +167,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         return True
 
     @classmethod
-    def requires_dcp_block_aligned_interleave_config(
+    def requires_dcp_block_aligned_interleave(
         cls, kv_transfer_config: "KVTransferConfig"
     ) -> bool:
         """Return True if any configured child requires block alignment."""
@@ -176,14 +176,14 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         )
         if not connectors_config:
             return True
-        return any(
-            KVConnectorFactory.requires_dcp_block_aligned_interleave(
-                KVTransferConfig(
-                    **{"engine_id": kv_transfer_config.engine_id, **conn_config}
-                )
+        for conn_config in connectors_config:
+            child_config = KVTransferConfig(
+                **{"engine_id": kv_transfer_config.engine_id, **conn_config}
             )
-            for conn_config in connectors_config
-        )
+            child_cls = KVConnectorFactory.get_connector_class(child_config)
+            if child_cls.requires_dcp_block_aligned_interleave(child_config):
+                return True
+        return False
 
     def __init__(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -47,6 +47,8 @@ from vllm.v1.request import Request
 
 
 class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
+    requires_dcp_block_aligned_interleave = False
+
     @property
     def requires_kv_delivery(self) -> bool:
         # Runs as kv_both, but is a best-effort cache: a dropped save is just a

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -45,9 +45,16 @@ from vllm.v1.kv_offload.factory import OffloadingSpecFactory
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
+if TYPE_CHECKING:
+    from vllm.config.kv_transfer import KVTransferConfig
+
 
 class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
-    requires_dcp_block_aligned_interleave = False
+    @classmethod
+    def requires_dcp_block_aligned_interleave(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        return False
 
     @property
     def requires_kv_delivery(self) -> bool:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -54,6 +54,7 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
     def requires_dcp_block_aligned_interleave(
         cls, kv_transfer_config: "KVTransferConfig"
     ) -> bool:
+        """Rank-local transfer only; KV never crosses DCP ranks."""
         return False
 
     @property

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -54,6 +54,8 @@ _DISK_ONLY_KEYS = (
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
     """CPU KV cache offloading with custom kernel transfers and BlockPool LRU."""
 
+    requires_dcp_block_aligned_interleave = False
+
     @property
     def requires_kv_delivery(self) -> bool:
         # Runs as kv_both, but is a best-effort cache: a dropped save is just a

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -59,6 +59,7 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
     def requires_dcp_block_aligned_interleave(
         cls, kv_transfer_config: "KVTransferConfig"
     ) -> bool:
+        """Rank-local transfer only; KV never crosses DCP ranks."""
         return False
 
     @property

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -29,6 +29,7 @@ from vllm.v1.simple_kv_offload.worker import (
 )
 
 if TYPE_CHECKING:
+    from vllm.config.kv_transfer import KVTransferConfig
     from vllm.forward_context import ForwardContext
     from vllm.v1.attention.backend import AttentionMetadata
     from vllm.v1.core.block_pool import BlockPool
@@ -54,7 +55,11 @@ _DISK_ONLY_KEYS = (
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
     """CPU KV cache offloading with custom kernel transfers and BlockPool LRU."""
 
-    requires_dcp_block_aligned_interleave = False
+    @classmethod
+    def requires_dcp_block_aligned_interleave(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        return False
 
     @property
     def requires_kv_delivery(self) -> bool:


### PR DESCRIPTION
# Summary

Add a connector capability for DCP KV-cache interleave alignment and use it for both adjustment and validation.

This includes the core behavior from #54457 and adds the missing validation/composition path:

- connectors that need block-aligned DCP interleave keep the existing automatic adjustment;
- `SimpleCPUOffloadConnector`, `OffloadingConnector`, and `DecodeBenchConnector` declare that they do not require block-aligned interleave;
- `validate_block_size()` uses the same connector capability predicate as `adjust_dcp_kv_cache_interleave_size()`;
- `MultiConnector` owns recursive child capability aggregation through the same connector classmethod, so mixed compositions remain conservative while all-local compositions keep valid custom interleave values.

# Why This Is Needed

With DCP enabled, the current config code always treats KV-transfer setups like block-oriented PD and widens `cp_kv_cache_interleave_size` to the local KV block size. That is correct for connectors that move block-layout KV across DCP ranks, but it is unnecessarily restrictive for local/offloading connectors that operate within the same DCP rank. This breaks production-style Kimi-K3 local offload recipes such as:

```text
--decode-context-parallel-size 8
--cp-kv-cache-interleave-size 1
```

The #54457 behavior fixes the automatic adjustment for direct local/offloading connectors, but the capability has to be used consistently by validation as well. Otherwise an invalid local-offload config such as `block_size=16` with `cp_kv_cache_interleave_size=3` can skip the divisibility check. `MultiConnector` also needs to compose child capabilities explicitly; otherwise a local child can be hidden behind the wrapper, or a mixed local + PD composition can lose the stricter child requirement.

# Correctness Notes

The default capability remains conservative: connectors return `True` unless they explicitly opt out. A connector should only return `False` if it does not require DCP block-aligned KV transfer layout.

For `MultiConnector`, the composed result is `True` if any child requires block-aligned DCP interleave. Empty compositions also return `True`. This preserves correctness for mixed setups such as `MultiConnector(SimpleCPUOffloadConnector, NixlConnector)` while allowing all-local compositions to keep finer valid interleave values.

The capability is only queried on DCP paths. `adjust_dcp_kv_cache_interleave_size()` returns before connector resolution when `decode_context_parallel_size <= 1`, and `validate_block_size()` short-circuits the same way. For DCP-enabled KV-transfer configs, resolving the connector class follows the existing config-time connector validation pattern used by CUDA graph and HMA checks; unsupported or broken connector configs should continue to fail explicitly rather than being silently treated as a conservative layout.

# Relation To #53917

This PR is split out from the original full-stack #53917. The end-to-end Kimi-K3 SimpleCPU validation on #53917 used this capability behavior so the production recipe could preserve `cp_kv_cache_interleave_size=1`. This PR is still a config-contract change, not a SimpleCPU fine-grained cache-hit implementation.

# Relation To #54457

This PR carries #54457's original commit from @cjackal and adds the follow-up validation/MultiConnector handling. It also includes the later `DecodeBenchConnector` capability update with co-author attribution.

# Validation

Initial three-revision matrix before the classmethod cleanup:

```text
main:          3 passed, 4 failed
#54457 only:   5 passed, 2 failed
this PR head:  7 passed
```

The #54457-only failures were the two cases completed by the follow-up: invalid `interleave=3` was not rejected for `block_size=16`, and `MultiConnector(SimpleCPUOffloadConnector)` did not inherit the child's capability. A mixed `MultiConnector(SimpleCPUOffloadConnector, NixlConnector)` keeps the stricter block-aligned behavior.

Latest head after rebasing over the upstream Nixl-only interleave fix:

```text
head: 96d3bdac8a29025681c56c52bd1dd8171d748a48
pytest -q tests/test_config.py -k "pd_dcp_interleave or local_offload or simple_cpu_offload or multi_connector or empty_multi_connector"
result: 11 passed, 239 deselected
```

The latest focused tests include direct `DecodeBenchConnector`, nested all-local `MultiConnector`, upstream's Nixl/MultiConnector strict-alignment coverage, and invalid local-offload validation coverage.

A Kimi-K3 TP8/DCP8 startup and completion smoke test was also run with `SimpleCPUOffloadConnector`, `cp_kv_cache_interleave_size=1`, FP8 KV cache, dummy weights, and eager execution. On the base, vLLM logged that it changed the requested interleave from `1` to `1536`. This PR preserved `1`; the server became healthy and completed the request successfully. The smoke test did not include DSpark because this PR only changes the DCP transfer-layout contract.
