### PR TITLE
[Bugfix][DCP] Align SimpleCPU offload hybrid geometry

### DIFF
--- a/tests/v1/simple_kv_offload/test_kv_events.py
+++ b/tests/v1/simple_kv_offload/test_kv_events.py
@@ -714,17 +714,8 @@ def test_disk_mode_block_removed_relabeled_storage() -> None:
         assert ev.medium == MEDIUM_STORAGE
 
 
-def test_mamba_dcp_metadata_guard() -> None:
-    """Mamba+DCP: token_ids guard emits [] when capture and emission sizes differ.
-
-    The metadata capture at _prepare_eager_store_specs uses
-    g_block_size = spec.block_size * cp_world_size = 32 * 2 = 64 to slice
-    tokens. The event emission uses block_size = spec.block_size * 1 = 32
-    for Mamba (SSM state is not CP-sharded). The guard in
-    _process_store_completion detects len(token_ids) != block_size and emits
-    token_ids=[] instead of misleading data. When #49962 fixes the capture
-    path, the guard stops triggering and correct token_ids flow through.
-    """
+def test_mamba_dcp_metadata_uses_resolved_group_size() -> None:
+    """Mamba+DCP captures event metadata with the unscaled group size."""
     vbs = BLOCK_SIZE * 2
     kv_cfg = _make_mixed_kv_cache_config(
         num_blocks=16, with_mamba=True, mamba_block_size=32
@@ -739,8 +730,8 @@ def test_mamba_dcp_metadata_guard() -> None:
     sched = fix.scheduler
     gpu_pool = fix.gpu_block_pool
 
-    # Mamba g_block_size = 32 * 2 = 64, so 2 Mamba blocks need 128 computed
-    # tokens to be "ready"; FA g_block_size = 16 * 2 = 32 needs only 64.
+    # Both resolved group sizes are 32: FA is DCP-sharded from 16, while Mamba
+    # remains replicated at its configured size.
     req = _make_cp_request(num_blocks=4, virtual_block_size=vbs)
     fa_blocks = _allocate_cp_gpu_blocks(gpu_pool, req, 2, vbs, group_id=0)
     mamba_blocks = _allocate_cp_gpu_blocks(gpu_pool, req, 2, vbs, group_id=1)
@@ -776,15 +767,24 @@ def test_mamba_dcp_metadata_guard() -> None:
             f"FA token_ids should be {vbs}, got {len(ev.token_ids)}"
         )
 
-    # Mamba group: capture size (64) != emission size (32) → guard emits [].
+    # Mamba capture and emission both use the resolved, unscaled size.
     mamba_events = by_group[1]
     assert len(mamba_events) == 2
-    for ev in mamba_events:
+    for idx, ev in enumerate(mamba_events):
         assert ev.block_size == 32
-        assert ev.token_ids == [], (
-            f"Mamba token_ids should be [] (guard), got {ev.token_ids}"
+        assert ev.token_ids == req.prompt_token_ids[idx * 32 : (idx + 1) * 32]
+        expected_hash = maybe_convert_block_hash(
+            get_block_hash(make_block_hash_with_group_id(req.block_hashes[idx], 1))
         )
-        assert ev.parent_block_hash is None, (
-            "Mamba parent_block_hash should be None (guard)"
+        assert ev.block_hashes == [expected_hash]
+        expected_parent = (
+            None
+            if idx == 0
+            else maybe_convert_block_hash(
+                get_block_hash(
+                    make_block_hash_with_group_id(req.block_hashes[idx - 1], 1)
+                )
+            )
         )
-        assert ev.extra_keys is None, "Mamba extra_keys should be None (guard)"
+        assert ev.parent_block_hash == expected_parent
+        assert ev.extra_keys is None

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -18,6 +18,7 @@ from vllm.config import (
     SchedulerConfig,
     VllmConfig,
 )
+from vllm.config.kv_events import KVEventsConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
     SimpleCPUOffloadConnector,
 )
@@ -42,6 +43,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
@@ -2128,3 +2130,146 @@ def test_cp_lazy_target_blocks_scaling(cp_world_size: int) -> None:
             f"cp_world_size={cp_world_size}: target_cp={target_cp} should be "
             f"less than target_base={target_base}"
         )
+
+
+def _make_hybrid_attention_mamba_scheduler(
+    *,
+    num_cpu_blocks: int = 8,
+    num_gpu_blocks: int = 16,
+    attention_block_size: int = BLOCK_SIZE,
+    block_size: int = 4 * BLOCK_SIZE,
+    scheduler_block_size: int | None = None,
+    hash_block_size: int | None = None,
+    dcp_world_size: int = 4,
+    lazy: bool = False,
+    mamba_cache_mode: str = "align",
+    enable_kv_cache_events: bool = False,
+) -> SchedulerFixture:
+    """Build a scheduler for one attention group plus one Mamba group."""
+    scheduler_block_size = scheduler_block_size or block_size
+    hash_block_size = hash_block_size or block_size
+    attention_spec = FullAttentionSpec(
+        block_size=attention_block_size,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode=mamba_cache_mode,
+    )
+    groups = [
+        KVCacheGroupSpec(["attention"], attention_spec),
+        KVCacheGroupSpec(["mamba"], mamba_spec),
+    ]
+    tensors = [
+        KVCacheTensor(
+            size=spec.page_size_bytes * num_gpu_blocks,
+            layers=group.layer_names,
+            layer_stride=spec.page_size_bytes * num_gpu_blocks,
+            block_stride=spec.page_size_bytes,
+        )
+        for group, spec in zip(groups, (attention_spec, mamba_spec))
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_gpu_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=groups,
+    )
+    vllm_config = _make_cp_vllm_config(dcp_world_size=dcp_world_size)
+    vllm_config.cache_config.prefix_cache_retention_interval = 0
+    vllm_config.cache_config.mamba_cache_mode = mamba_cache_mode
+    if enable_kv_cache_events:
+        vllm_config.kv_events_config = KVEventsConfig(enable_kv_cache_events=True)
+    # _derive_cpu_config() scales the requested capacity against
+    # kv_cache_tensors[0].size, so express it as a multiple of that tensor's
+    # per-block size to get exactly num_cpu_blocks.
+    cpu_capacity_bytes = tensors[0].size // num_gpu_blocks * num_cpu_blocks
+    sched = SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=cpu_capacity_bytes,
+        scheduler_block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+        lazy_offload=lazy,
+    )
+    gpu_block_pool = BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    sched.bind_gpu_block_pool(gpu_block_pool)
+    return SchedulerFixture(
+        scheduler=sched,
+        gpu_block_pool=gpu_block_pool,
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+    )
+
+
+def test_hybrid_store_uses_resolved_group_block_sizes() -> None:
+    """Replicated groups must not be scaled by the DCP world size.
+
+    ``dcp_world_size_for_kv_cache_spec`` gives full attention the process DCP
+    size and every other spec 1. Reconstructing a group's geometry as
+    ``spec.block_size * cp_world_size`` over-scales the replicated groups, so
+    the eager store scan believes far fewer of their blocks are ready and
+    silently offloads only a fraction of them.
+    """
+    attention_block_size = BLOCK_SIZE
+    mamba_block_size = 4 * BLOCK_SIZE
+    dcp_world_size = 2
+    fix = _make_hybrid_attention_mamba_scheduler(
+        num_cpu_blocks=32,
+        num_gpu_blocks=32,
+        attention_block_size=attention_block_size,
+        block_size=mamba_block_size,
+        # Every prefix-cacheable group's resolved block size must be a multiple
+        # of the hash block, so it cannot exceed the smallest of them.
+        hash_block_size=BLOCK_SIZE,
+        dcp_world_size=dcp_world_size,
+        mamba_cache_mode="all",
+    )
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+    attention_size, mamba_size = sched.group_block_sizes
+    assert attention_size == attention_block_size * dcp_world_size
+    assert mamba_size == mamba_block_size
+
+    confirmed = 2 * sched.block_size
+    req = _make_cp_request(num_blocks=8, virtual_block_size=BLOCK_SIZE)
+    attention_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool, req, confirmed // attention_size, attention_size, group_id=0
+    )
+    mamba_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool, req, confirmed // mamba_size, mamba_size, group_id=1
+    )
+    kv_blocks = KVCacheBlocks(blocks=(attention_blocks, mamba_blocks))
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+    sched.build_connector_meta(
+        make_scheduler_output(
+            {req.request_id: confirmed},
+            new_reqs={req.request_id: kv_blocks.get_block_ids()},
+        )
+    )
+    req.num_computed_tokens = confirmed
+    meta = sched.build_connector_meta(
+        make_scheduler_output(
+            {req.request_id: 1},
+            cached_req_new_blocks={req.request_id: None},
+        )
+    )
+
+    # Both groups are positionally stable here, so every confirmed block of
+    # both must be offloaded. Over-scaling the replicated group halves its
+    # count.
+    assert sched._reqs_to_store[req.request_id].num_stored_blocks == [
+        confirmed // attention_size,
+        confirmed // mamba_size,
+    ]
+    assert set(meta.store_gpu_blocks) == {
+        *(b.block_id for b in attention_blocks),
+        *(b.block_id for b in mamba_blocks),
+    }

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -155,6 +155,9 @@ class KVCacheCoordinator(ABC):
             for manager in self.single_type_managers:
                 if isinstance(manager, MambaManager):
                     manager.drop_eagle_checkpoint_block = True
+        self.group_block_sizes = tuple(
+            manager.block_size for manager in self.single_type_managers
+        )
 
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -26,6 +26,7 @@ from vllm.v1.core.kv_cache_coordinator import (
 from vllm.v1.core.kv_cache_utils import (
     BlockHashWithGroupId,
     ExternalBlockHash,
+    dcp_world_size_for_kv_cache_spec,
     generate_block_hash_extra_keys,
     get_block_hash,
     get_group_id,
@@ -141,16 +142,6 @@ class SimpleCPUOffloadScheduler:
                 self.fa_gidx = g_idx
                 break
         assert 0 <= self.fa_gidx < len(self.cpu_kv_cache_config.kv_cache_groups)
-        # FA group's own block_size; divides scheduler_block_size (the LCM)
-        # but is NOT assumed to equal it.
-        self.fa_block_size: int = (
-            self.cpu_kv_cache_config.kv_cache_groups[
-                self.fa_gidx
-            ].kv_cache_spec.block_size
-            * self.cp_world_size
-        )
-        assert self.block_size % self.fa_block_size == 0
-
         logger.info(
             "SimpleCPUOffloadScheduler: Allocating %d offload blocks "
             "(%.2f GB, mode=%s, backend=%s)",
@@ -176,6 +167,11 @@ class SimpleCPUOffloadScheduler:
             scheduler_block_size=self.block_size,
             hash_block_size=self.hash_block_size,
         )
+        self.group_block_sizes = self.cpu_coordinator.group_block_sizes
+        # FA group's own resolved block_size; divides scheduler_block_size (the
+        # LCM) but is NOT assumed to equal it.
+        self.fa_block_size: int = self.group_block_sizes[self.fa_gidx]
+        assert self.block_size % self.fa_block_size == 0
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
         # GPU block pool reference - bound after scheduler builds kv_cache_manager
         self._gpu_block_pool: BlockPool | None = None
@@ -267,7 +263,11 @@ class SimpleCPUOffloadScheduler:
         target = 0
         for g in kv_cache_config.kv_cache_groups:
             spec = g.kv_cache_spec
-            block_size = spec.block_size * cp_world_size
+            # Only full attention is sharded across DCP ranks; replicated specs
+            # (mamba, sliding window, chunked-local) keep their own block size.
+            block_size = spec.block_size * dcp_world_size_for_kv_cache_spec(
+                spec, cp_world_size
+            )
             if isinstance(spec, MambaSpec):
                 target += 2
             elif isinstance(spec, SlidingWindowSpec):
@@ -384,8 +384,6 @@ class SimpleCPUOffloadScheduler:
 
         # Build transfer pairs across all groups.
         total_computed_tokens = num_computed_tokens + num_external_tokens
-        kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
-
         # The scheduler may have accepted fewer blocks than
         # get_num_new_matched_tokens() reported.
         # (e.g. due to token budget in test_partial_gpu_prefix_plus_cpu_load).
@@ -393,9 +391,7 @@ class SimpleCPUOffloadScheduler:
         # the rest will be released along with the temp pin below.
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-            )
+            g_block_size = self.group_block_sizes[g]
             assert num_external_tokens % g_block_size == 0, (
                 f"num_external_tokens={num_external_tokens} not aligned to "
                 f"group {g} block_size={g_block_size}"
@@ -414,9 +410,7 @@ class SimpleCPUOffloadScheduler:
                 continue
 
             # Number of blocks in the computed range for this group.
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-            )
+            g_block_size = self.group_block_sizes[g]
             n_computed_g = cdiv(total_computed_tokens, g_block_size)
 
             # Back-trace: ext blocks sit at the tail of the computed range.
@@ -703,10 +697,7 @@ class SimpleCPUOffloadScheduler:
             # FIXME (yifan): handle CPU cache eviction, where
             # num_stored_blocks can be stale and omit evicted blocks in
             # the middle of the request.
-            group_size = (
-                self.cpu_kv_cache_config.kv_cache_groups[g].kv_cache_spec.block_size
-                * self.cp_world_size
-            )
+            group_size = self.group_block_sizes[g]
             ready = min(len(group_gpu_ids), aligned_tokens // group_size)
             resolved_hashes = (
                 resolve_block_hashes(
@@ -886,12 +877,7 @@ class SimpleCPUOffloadScheduler:
             if self.enable_kv_cache_events:
                 meta_by_hash = block_meta[i] if block_meta is not None else {}
                 primary_group_idx = get_group_id(primary_hash)
-                primary_spec = self.cpu_kv_cache_config.kv_cache_groups[
-                    primary_group_idx
-                ].kv_cache_spec
-                primary_block_size = primary_spec.block_size * (
-                    self.cp_world_size if not isinstance(primary_spec, MambaSpec) else 1
-                )
+                primary_block_size = self.group_block_sizes[primary_group_idx]
                 events_to_emit: list[
                     tuple[BlockHashWithGroupId, BlockStoreMeta | None, int]
                 ] = [


### PR DESCRIPTION
## Purpose

`SimpleCPUOffloadScheduler` reconstructs each cache group's block size as `spec.block_size * cp_world_size`. Only full attention is sharded across DCP ranks: `dcp_world_size_for_kv_cache_spec()` keeps Mamba, sliding-window and chunked-local specs at `dcp_world_size=1`. Scaling every group therefore maps the replicated groups onto the wrong geometry on hybrid models under DCP.

Two failure modes, depending on how the group block sizes relate:

- The per-group alignment assertion in the load path fires and engine start-up fails.
- The assertion happens to pass and recurrent state is loaded into the wrong destination blocks, which is silent.

On the store side the same expression caps how many blocks of a replicated group are ever offloaded.

## Changes

- Expose `group_block_sizes` on `KVCacheCoordinator` so the resolved per-group geometry has a single source, and use it in the SimpleCPU offload load and store paths.
- Use `dcp_world_size_for_kv_cache_spec()` in the lazy watermark estimate, which previously under-counted the blocks to reserve for sliding-window groups. The estimate runs before the coordinator exists, so it resolves the DCP size directly rather than through the coordinator.
- Emit `BlockStored` events with the resolved group block size instead of re-deriving the DCP scaling from the spec type. The previous expression special-cased `MambaSpec` only and over-reported `block_size` for other replicated specs.

## Test Plan

- `tests/v1/simple_kv_offload/test_scheduler.py`
- Kimi-K3 on 8x MI355X, TP8 / DCP8, fp8 KV cache, SimpleCPU offload enabled.

## Test Result

Unit tests: 37 passed in `tests/v1/simple_kv_offload/test_scheduler.py`; 121 passed together with `tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py` and `tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py`.

End to end on Kimi-K3, TP8 / DCP8, fp8 KV cache, per-rank attention and Mamba block 1536, so with DCP8 the effective attention block and the scheduler block are 12288 while Mamba stays at 1536; prefix-match unit 1536: the engine starts and serves requests. Without this change the same configuration either trips the per-group alignment assertion at start-up or maps replicated groups onto the wrong destination blocks.



## Post-rebase validation (2026-09-07)

Rebased onto main `8ebc5b0a1`, which includes #53614's Kimi-K3 internal checkpoint and partial-prefix changes. The only conflict was adjacent initialization in `KVCacheCoordinator`: the upstream Mamba/Eagle checkpoint setup and this PR's resolved `group_block_sizes` initialization are both preserved.

Latest head: `140d7382a`.

Focused hybrid geometry and lazy-watermark tests:

```text
4 passed, 125 deselected
```

Changed-file `ruff check`, `ruff format --check`, Python compilation, and `git diff --check` pass. The downstream #54736 stack, which contains this commit, also passes Kimi-Linear TP2/DCP2 and Kimi-K3 TP8/DCP8 real-model correctness validation.

