### PR TITLE
[Perf][MoE] Scale the default MoE N tile with batch size

### DIFF
--- a/tests/kernels/moe/test_moe_default_config.py
+++ b/tests/kernels/moe/test_moe_default_config.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Gating rules for the fused-MoE default-config N tile.
+
+`get_default_config` widens `BLOCK_SIZE_N` to 256 for large batches. The wider
+tile is a 2-9% regression below the batch threshold and does not fit every
+device's shared memory, so both gates have to hold or the change would make
+small-batch and consumer-GPU configs worse.
+"""
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe import fused_moe
+
+# Qwen3-30B-A3B: E=128, hidden=2048, moe_intermediate=768, topk=8.
+SHAPE = dict(E=128, N=2 * 768, K=2048, topk=8)
+
+# Hopper/A100 hold the wider tile; consumer Ampere/Ada (101376 B) do not.
+BIG_SMEM = 232448
+SMALL_SMEM = 101376
+
+
+@pytest.fixture
+def smem(monkeypatch):
+    """Pin the device shared-memory budget so the test is host-independent."""
+
+    def _set(nbytes):
+        # raising=False so the invariant tests below still exercise a build
+        # that does not consult shared memory at all -- they must hold either
+        # way, and only the widening tests should depend on this symbol.
+        monkeypatch.setattr(
+            fused_moe,
+            "get_max_shared_memory_bytes",
+            lambda *a, **k: nbytes,
+            raising=False,
+        )
+        monkeypatch.setattr(fused_moe.current_platform, "is_cuda_alike", lambda: True)
+
+    return _set
+
+
+def cfg(M, dtype=None):
+    return fused_moe.get_default_config(M=M, dtype=dtype, **SHAPE)
+
+
+@pytest.mark.parametrize("M", [1, 64, 128, 512])
+def test_small_batches_keep_the_narrow_tile(smem, M):
+    """Below the threshold the wider tile measured 2-9% slower on two shapes."""
+    smem(BIG_SMEM)
+    assert cfg(M)["BLOCK_SIZE_N"] == (64 if M <= 64 else 128)
+
+
+@pytest.mark.parametrize("M", [1024, 2048, 8192])
+def test_large_batches_widen_the_n_tile(smem, M):
+    smem(BIG_SMEM)
+    assert cfg(M)["BLOCK_SIZE_N"] == 256
+
+
+@pytest.mark.parametrize("M", [1024, 8192])
+def test_devices_without_shared_memory_are_unchanged(smem, M):
+    """Consumer Ampere/Ada cannot hold the wider tile and must be untouched."""
+    smem(SMALL_SMEM)
+    assert cfg(M)["BLOCK_SIZE_N"] == 128
+
+
+def test_widening_fits_the_reported_shared_memory(smem):
+    """The tile the heuristic picks must actually fit what it checked."""
+    smem(BIG_SMEM)
+    c = cfg(2048)
+    operands = (
+        c["BLOCK_SIZE_M"] * c["BLOCK_SIZE_K"] + c["BLOCK_SIZE_K"] * c["BLOCK_SIZE_N"]
+    )
+    assert operands * 2 * c["num_stages"] <= BIG_SMEM
+
+
+@pytest.mark.parametrize("dtype", ["fp8_w8a8", "int8_w8a16", "int4_w4a16"])
+def test_quantized_dtypes_are_unchanged(smem, dtype):
+    """Only bf16/fp16 was measured; quantized tiles keep today's config."""
+    smem(BIG_SMEM)
+    assert cfg(8192, dtype=dtype)["BLOCK_SIZE_N"] != 256

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -35,6 +35,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.math_utils import next_power_of_2
+from vllm.utils.mem_utils import get_max_shared_memory_bytes
 from vllm.utils.platform_utils import get_device_name_as_file_name
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -1406,6 +1407,21 @@ def get_default_config(
             num_stages = 4
         else:
             num_stages = 3
+
+        # `block_n` above saturates at 128, so the N tile stops scaling with
+        # the batch even though this branch's comment promises large batches
+        # more output parallelism. Widening it to 256 once each expert's GEMM
+        # has the rows to fill it measured 1.04-1.09x (Qwen3-30B-A3B,
+        # E=128/topk=8) and 1.16-1.19x (Mixtral 8x7B, E=8/topk=2) on H100 for
+        # M >= 1024. Below that the same tile is a 2-9% regression on both
+        # shapes, so the batch gate carries the change rather than the tile
+        # size alone. Raising num_stages was measured separately and is a
+        # 4-6% regression on its own, so only N moves here. bf16/fp16 only;
+        # quantized tiles are unmeasured and keep today's config.
+        if dtype is None and M >= 1024 and current_platform.is_cuda_alike():
+            wide_n_bytes = (block_m * block_k + block_k * 256) * 2 * num_stages
+            if wide_n_bytes <= get_max_shared_memory_bytes():
+                block_n = 256
 
         config = {
             "BLOCK_SIZE_M": block_m,


### PR DESCRIPTION
### Purpose

`get_default_config` picks `BLOCK_SIZE_N = 64 if M <= 64 else 128`, so the N tile stops scaling at M=65 and never grows again, whether M is 512 or 65536.

Every other dimension in the same branch does scale with the batch, and the comment directly above the line says large batches are compute-bound and "prefer more output parallelism" — the code just never gives them any in N.

This matters because the fallback heuristic runs constantly: the shipped tuned-config table is ~332 files over 30 devices x 90 (E,N) pairs, and there is no `E=128,N=768` entry for any H100, so Qwen3-30B-A3B on H100 takes this path for every MoE GEMM.

`#44830` (merged) already measured the default config ~25% slower than tuned on H100 for a real model and fixed one shape with a tuned config file. This fixes the fallback instead.

### Change

Widen `BLOCK_SIZE_N` to 256 for `M >= 1024`, gated on the tile fitting the device's shared memory.

Both gates are load-bearing and were measured, not assumed:

- **Batch gate** — below M=1024 the wider tile is a 2-9% regression on both shapes tested.
- **Shared-memory gate** — the wider tile needs ~147 KB; consumer Ampere/Ada expose 101376 B and stay bit-identical to today at every M. This follows the existing precedent in `fused_moe_lora_op.py`, which gates `num_stages` on `get_max_shared_memory_bytes()` the same way.

Scope is deliberately narrow: bf16/fp16 only (`dtype is None`). Quantized paths are unmeasured and keep today's config.

### Results

Kernel-level, `fused_experts` end to end, in-process CUPTI, order-balanced, per-point noise floor measured as the control arm's self-spread:

| M | Qwen3-30B-A3B (E=128, topk=8) | Mixtral 8x7B (E=8, topk=2) |
|---|---|---|
| 256 | 0.945x | 0.963x |
| 512 | 0.947x | 1.030x (ns) |
| 1024 | **1.040x** | 1.004x (ns) |
| 2048 | **1.047x** | **1.181x** |
| 4096 | **1.052x** | **1.160x** |
| 8192 | **1.087x** | **1.193x** |

The regressions below M=1024 are exactly why the batch gate is there.

End to end, `vllm bench throughput`, Qwen3-30B-A3B bf16 on H100 NVL, ABBA + BAAB pooled (8 runs, 4 per arm):

| workload | baseline | patched | delta |
|---|---|---|---|
| 1024 in / 128 out, n=64 | 15.12-15.18 req/s | 15.35-15.40 req/s | **+1.58%** |
| 4096 in / 8 out, n=256 | 9.11, 9.21 req/s | 9.34, 9.59 req/s | **+3.33%** |

On the first workload the baseline and patched ranges do not overlap across 8 runs.

The prefill-heavy workload gains more, which is what the M >= 1024 gate predicts: a 1024-token workload barely reaches the threshold, while 4096-token prefills sit well above it. Note the patched arm's spread on that workload is 2.7% against the baseline's 1.1%, so treat +3.33% as approximate.

### Output equivalence

Greedy decode (temperature 0, fixed seed), baseline vs patched, with ~2000-token prompts so prefill clears the M >= 1024 gate:

```
exact token-ID match: 10/10 prompts
```

The change alters the tile shape, not the reduction order along K, so output is identical rather than merely close.

### Test plan

```
pytest tests/kernels/moe/test_moe_default_config.py     # 13 passed
```

New file. The invariant cases (small batches unchanged, low-shared-memory devices unchanged, quantized dtypes unchanged) pass on both the old and new code, so they guard behaviour rather than the presence of a symbol. The three cases asserting the widening fail without the change:

```
without the patch: 3 failed, 10 passed
with the patch:   13 passed
```

### What I did not verify

- A100 clears the shared-memory gate and would get the wider tile, but every measurement here is H100. If reviewers would rather restrict this to sm_90 until someone measures Ampere, say so and I will add the capability check.
- Only two MoE shapes were measured.
- Quantized paths are untouched by design.

### Notes

Not a duplicate: `#47593` changes `BLOCK_SIZE_M` in the fp8 block-quant branch; this changes `BLOCK_SIZE_N` in the bf16/fp16 branch. Different branch, different dimension. The ~10 other open MoE PRs add tuned config *files* rather than touching the fallback.

*This PR description was formatted with AI assistance.*