### PR TITLE
[KV Offload] Scope offload group configs to prefix-cacheable KV cache groups

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -14,11 +14,14 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.config import (
     build_offloading_config,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    OffloadingConnectorScheduler,
+    RequestOffloadState,
     SchedulerOffloadConfig,
     is_store_reachable_swa_chunk,
 )
 from vllm.platforms import current_platform
 from vllm.v1.kv_cache_interface import (
+    CircularBufferSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
     KVCacheConfig,
@@ -31,6 +34,7 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
+from vllm.v1.kv_offload.base import GPULoadStoreSpec, get_offload_group_idx
 
 
 def _make_vllm_config(
@@ -750,3 +754,161 @@ def test_blocks_per_chunk_must_be_positive():
 
     with pytest.raises(ValueError, match="greater than 0"):
         build_offloading_config(config, _make_kv_cache_config())
+
+
+def _make_scratch_hybrid_kv_cache_config() -> KVCacheConfig:
+    """Hybrid layout with a non-prefix-cacheable scratch group.
+
+    Mirrors sparse-MLA hybrids (e.g. GLM-5.3-Flash) where a CircularBufferSpec
+    ring holds pre-compression keys: its block size (4) does not divide the
+    hash granularity of the prefix-cacheable groups (16).
+    """
+    return KVCacheConfig(
+        num_blocks=4,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full_layer"], _full_attention_spec()),
+            KVCacheGroupSpec(
+                ["scratch_layer"],
+                CircularBufferSpec(
+                    block_size=4,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba_layer"],
+                MambaSpec(
+                    block_size=16,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_scratch_group_does_not_crash_config_translation():
+    """A non-prefix-cacheable scratch group whose block size does not divide
+    tokens_per_hash previously tripped the divisibility assert at boot. It
+    must be excluded from the offload groups, keeping original indices."""
+    offloading_config = build_offloading_config(
+        _make_vllm_config(), _make_scratch_hybrid_kv_cache_config()
+    )
+
+    assert [group.group_idx for group in offloading_config.groups] == [0, 2]
+    assert tuple(group.tokens_per_block for group in offloading_config.groups) == (
+        16,
+        16,
+    )
+    assert offloading_config.cache.tokens_per_hash == 16
+
+
+def test_scratch_group_gets_no_offload_keys():
+    """The scheduler side must neither look up nor key the scratch group,
+    while per-group runtime state still spans every KV cache group."""
+    config = _make_vllm_config()
+    config.speculative_config = None
+    kv_cache_config = _make_scratch_hybrid_kv_cache_config()
+    offloading_config = build_offloading_config(config, kv_cache_config)
+    spec = MockOffloadingSpec(offloading_config)
+
+    scheduler_config = SchedulerOffloadConfig.from_spec(spec, config, kv_cache_config)
+    assert scheduler_config.num_kv_cache_groups == 3
+    assert [gc.group_idx for gc in scheduler_config.kv_group_configs] == [0, 2]
+    assert not scheduler_config.supports_partial_tail
+
+    scheduler = OffloadingConnectorScheduler(spec, config, kv_cache_config)
+    assert scheduler._lookup_groups == (0, 2)
+
+    req = MagicMock()
+    req.kv_transfer_params = None
+    req.block_hashes = [b"hash-0", b"hash-1"]
+    req_state = RequestOffloadState(
+        config=scheduler_config,
+        req=req,
+        req_context=MagicMock(),
+        offloading_context=MagicMock(),
+    )
+    assert len(req_state.group_states) == 3
+
+    req_state.update_offload_keys()
+    assert not req_state.group_states[1].offload_keys
+    assert {
+        get_offload_group_idx(key)
+        for group_state in req_state.group_states
+        for key in group_state.offload_keys
+    } == {0, 2}
+
+
+def test_prefix_cacheable_misaligned_group_still_asserts():
+    """The divisibility assert must keep guarding prefix-cacheable groups: a
+    mamba group outside "align" mode backs the hash granularity off to the
+    scheduler block size (the LCM), which neither group's block size divides."""
+    kv_cache_config = KVCacheConfig(
+        num_blocks=4,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full_layer"], _full_attention_spec()),
+            KVCacheGroupSpec(
+                ["mamba_layer"],
+                MambaSpec(
+                    block_size=24,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                ),
+            ),
+        ],
+    )
+
+    with pytest.raises(AssertionError, match="not divisible"):
+        build_offloading_config(_make_vllm_config(), kv_cache_config)
+
+
+def test_scratch_group_gets_no_load_slots():
+    """update_state_after_alloc must emit full-length GPULoadStoreSpec group
+    arrays (matching the worker's per-group layout) with a zero-sized entry
+    for the scratch group, and draw no load keys or destination blocks from
+    it."""
+    config = _make_vllm_config()
+    config.speculative_config = None
+    kv_cache_config = _make_scratch_hybrid_kv_cache_config()
+    spec = MockOffloadingSpec(build_offloading_config(config, kv_cache_config))
+    scheduler = OffloadingConnectorScheduler(spec, config, kv_cache_config)
+
+    request = MagicMock()
+    request.request_id = "req"
+    request.kv_transfer_params = None
+    request.block_hashes = [b"hash-0", b"hash-1"]
+    scheduler.on_new_request(request)
+    req_status = scheduler._req_status["req"]
+    req_status.update_offload_keys()
+    req_status.num_locally_computed_tokens = 0
+
+    def _pending_block(block_id: int) -> MagicMock:
+        block = MagicMock()
+        block.block_id = block_id
+        block.is_null = False
+        block.block_hash = None
+        return block
+
+    blocks = MagicMock()
+    blocks.blocks = (
+        [_pending_block(11), _pending_block(12)],  # full attention (group 0)
+        [_pending_block(31)],  # scratch ring (group 1)
+        [_pending_block(21), _pending_block(22)],  # mamba (group 2)
+    )
+    scheduler.update_state_after_alloc(request, blocks, num_external_tokens=32)
+
+    [load_job] = scheduler._current_batch_load_jobs.values()
+    dst_spec = load_job.dst_spec
+    assert isinstance(dst_spec, GPULoadStoreSpec)
+    assert dst_spec.group_sizes == [2, 0, 2]
+    assert dst_spec.block_indices == [0, 0, 0]
+    assert dst_spec.block_ids.tolist() == [11, 12, 21, 22]
+    assert {get_offload_group_idx(key) for key in load_job.src_spec.offload_keys} == {
+        0,
+        2,
+    }

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -314,12 +314,18 @@ class RequestRunner:
         assert isinstance(manager, MagicMock)
         self.manager: MagicMock = manager
 
-        num_kv_groups = len(kv_cache_config.kv_cache_groups)
-        assert len(self.connector_scheduler.config.kv_group_configs) == num_kv_groups
-        for group_config, kv_cache_group in zip(
-            self.connector_scheduler.config.kv_group_configs,
-            kv_cache_config.kv_cache_groups,
-        ):
+        # The connector only builds group configs for prefix-cacheable groups,
+        # preserving their original group indices.
+        eligible_groups = [
+            (group_idx, kv_cache_group)
+            for group_idx, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups)
+            if kv_cache_group.kv_cache_spec.prefix_cacheable
+        ]
+        kv_group_configs = self.connector_scheduler.config.kv_group_configs
+        assert [group_config.group_idx for group_config in kv_group_configs] == [
+            group_idx for group_idx, _ in eligible_groups
+        ]
+        for group_config, (_, kv_cache_group) in zip(kv_group_configs, eligible_groups):
             tokens_per_block = kv_cache_group.kv_cache_spec.block_size
             assert group_config.tokens_per_block == tokens_per_block
             assert group_config.tokens_per_chunk == tokens_per_block * blocks_per_chunk

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -62,7 +62,7 @@ def _make_offloading_config(
         normalized_extra_config["cpu_bytes_to_use"] = cpu_bytes_to_use
 
     if groups is None:
-        groups = (OffloadingGroupConfig(16, ("layer",)),)
+        groups = (OffloadingGroupConfig(16, ("layer",), group_idx=0),)
 
     return OffloadingConfig(
         groups=groups,
@@ -493,8 +493,8 @@ def test_offloading_spec_has_replicated_layout_default():
 
 def test_offloading_spec_uses_normalized_chunk_geometry():
     groups = (
-        OffloadingGroupConfig(12, ("full_layer",)),
-        OffloadingGroupConfig(16, ("mla_layer",)),
+        OffloadingGroupConfig(12, ("full_layer",), group_idx=0),
+        OffloadingGroupConfig(16, ("mla_layer",), group_idx=1),
     )
     spec = _create_spec(
         groups=groups,

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -26,8 +26,11 @@ def make_mapper_from_offloading_spec(**kwargs) -> FileMapper:
             OffloadingGroupConfig(
                 tokens_per_block=tokens_per_block,
                 layer_names=(layer_name,),
+                group_idx=group_idx,
             )
-            for tokens_per_block, layer_name in kwargs.get("groups", ())
+            for group_idx, (tokens_per_block, layer_name) in enumerate(
+                kwargs.get("groups", ())
+            )
         ),
         worker_kv_bytes_per_block=0,
         enable_kv_cache_events=False,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -38,6 +38,11 @@ def build_offloading_config(
     engine_id = kv_transfer_config.engine_id
 
     parallel_config = vllm_config.parallel_config
+    # Only prefix-cacheable groups can serve offload hits: block hashes are
+    # computed over prefix-cacheable groups only (resolve_kv_cache_block_sizes),
+    # so non-cacheable scratch groups (e.g. CircularBufferSpec) have no valid
+    # hash granularity and must not be offloaded. Original group indices are
+    # preserved via group_idx.
     groups = tuple(
         OffloadingGroupConfig(
             tokens_per_block=(
@@ -49,8 +54,10 @@ def build_offloading_config(
                 )
             ),
             layer_names=tuple(group.layer_names),
+            group_idx=group_idx,
         )
-        for group in kv_cache_config.kv_cache_groups
+        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups)
+        if group.kv_cache_spec.prefix_cacheable
     )
 
     _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
@@ -85,8 +92,8 @@ def build_offloading_config(
 
         assert len(unique_tokens_per_block) == 1, (
             "If 'block_size' is specified in kv_connector_extra_config, "
-            "there must be at least one KV cache group, "
-            "and all groups must have the same block size."
+            "there must be at least one prefix-cacheable KV cache group, "
+            "and all prefix-cacheable groups must have the same block size."
         )
 
         tokens_per_block = unique_tokens_per_block.pop()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -157,20 +157,26 @@ def resolve_mamba_align_size(
     such groups agree on the same value.
     """
     mamba_align_size: int | None = None
-    for idx, tokens_per_block in enumerate(spec.tokens_per_block):
-        kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+    for group in spec.config.groups:
+        kv_spec = kv_cache_config.kv_cache_groups[group.group_idx].kv_cache_spec
         if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
             "align",
             "all",
         ):
-            tokens_per_chunk = tokens_per_block * spec.blocks_per_chunk
+            tokens_per_chunk = group.tokens_per_block * spec.blocks_per_chunk
             assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
             mamba_align_size = tokens_per_chunk
     return mamba_align_size
 
 
 class SchedulerOffloadConfig(NamedTuple):
+    # One entry per prefix-cacheable KV cache group; group_idx keeps the
+    # original index into KVCacheConfig.kv_cache_groups. Non-cacheable
+    # scratch groups are never offloaded and get no entry here.
     kv_group_configs: tuple[GroupOffloadConfig, ...]
+    # Total number of KV cache groups (including non-cacheable ones); sizes
+    # per-group structures shared with the scheduler core and the worker.
+    num_kv_cache_groups: int
     blocks_per_chunk: int
     tokens_per_hash: int
     num_workers: int
@@ -190,13 +196,15 @@ class SchedulerOffloadConfig(NamedTuple):
         # each segment can never serve a load hit. Relevant for hybrid
         # architectures like DeepSeek V4 (MLA + SWA groups).
         full_attn_tokens_per_chunk: set[int] = set()
-        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
-            kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        for group in spec.config.groups:
+            kv_spec = kv_cache_config.kv_cache_groups[group.group_idx].kv_cache_spec
             sw = get_sliding_window_size_in_chunks(
-                kv_spec, tokens_per_block * spec.blocks_per_chunk
+                kv_spec, group.tokens_per_block * spec.blocks_per_chunk
             )
             if sw is None:
-                full_attn_tokens_per_chunk.add(tokens_per_block * spec.blocks_per_chunk)
+                full_attn_tokens_per_chunk.add(
+                    group.tokens_per_block * spec.blocks_per_chunk
+                )
 
         # Only apply the optimization if there's a single consistent
         # full-attention alignment size.
@@ -239,7 +247,9 @@ class SchedulerOffloadConfig(NamedTuple):
             )
 
         kv_group_configs_list: list[GroupOffloadConfig] = []
-        for idx, tokens_per_block in enumerate(spec.tokens_per_block):
+        for group in spec.config.groups:
+            idx = group.group_idx
+            tokens_per_block = group.tokens_per_block
             kv_cache_group = kv_cache_config.kv_cache_groups[idx]
             kv_spec = kv_cache_group.kv_cache_spec
             sw = get_sliding_window_size_in_chunks(
@@ -267,6 +277,7 @@ class SchedulerOffloadConfig(NamedTuple):
                 )
             )
         kv_group_configs = tuple(kv_group_configs_list)
+        num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         group_block_sizes = {config.tokens_per_block for config in kv_group_configs}
         has_partial_recurrent_group = any(
             config.requires_cow_source
@@ -276,9 +287,11 @@ class SchedulerOffloadConfig(NamedTuple):
         # Partial tails currently require one physical block per offload chunk
         # and uniform, non-windowed groups so one boundary identifies every
         # group's source. EAGLE and DCP need additional hand-off semantics.
+        # Kept conservative: models with non-cacheable scratch groups opt out.
         supports_partial_tail = (
             spec.blocks_per_chunk == 1
             and len(group_block_sizes) == 1
+            and len(kv_group_configs) == num_kv_cache_groups
             and has_partial_recurrent_group
             and all(
                 config.sliding_window_size_in_chunks is None
@@ -292,6 +305,7 @@ class SchedulerOffloadConfig(NamedTuple):
         return cls(
             num_workers=vllm_config.parallel_config.world_size,
             kv_group_configs=kv_group_configs,
+            num_kv_cache_groups=num_kv_cache_groups,
             blocks_per_chunk=spec.blocks_per_chunk,
             tokens_per_hash=spec.tokens_per_hash,
             offload_prompt_only=spec.offload_prompt_only,
@@ -334,8 +348,11 @@ class RequestOffloadState:
     finished_signaled: bool = False
 
     def __post_init__(self) -> None:
+        # One state per KV cache group (indexed by original group index):
+        # block-id bookkeeping spans all groups, while offload keys are only
+        # ever generated for the prefix-cacheable kv_group_configs.
         self.group_states = tuple(
-            RequestGroupState() for _ in self.config.kv_group_configs
+            RequestGroupState() for _ in range(self.config.num_kv_cache_groups)
         )
         params = self.req.kv_transfer_params
 
@@ -354,9 +371,8 @@ class RequestOffloadState:
             )
 
     def update_offload_keys(self) -> None:
-        for group_config, group_state in zip(
-            self.config.kv_group_configs, self.group_states
-        ):
+        for group_config in self.config.kv_group_configs:
+            group_state = self.group_states[group_config.group_idx]
             for req_block_hash in islice(
                 self.req.block_hashes,
                 group_config.hashes_per_chunk * len(group_state.offload_keys)
@@ -411,18 +427,16 @@ class RequestOffloadState:
         # max(): at the prefill->decode transition of a chunk-aligned prompt,
         # storable_chunks drops by one (the eagle exclusion kicks in), and the
         # index must not move backwards past already-stored chunks.
-        for group_config, group_state in zip(
-            self.config.kv_group_configs, self.group_states
-        ):
+        for group_config in self.config.kv_group_configs:
+            group_state = self.group_states[group_config.group_idx]
             group_state.next_stored_chunk_idx = max(
                 group_state.next_stored_chunk_idx,
                 self.storable_chunks(group_config, group_state, num_offloadable_tokens),
             )
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
-        for group_config, group_state in zip(
-            self.config.kv_group_configs, self.group_states
-        ):
+        for group_config in self.config.kv_group_configs:
+            group_state = self.group_states[group_config.group_idx]
             group_state.num_hit_chunks = (
                 num_cached_tokens // group_config.tokens_per_chunk
             )
@@ -501,6 +515,12 @@ class OffloadingConnectorScheduler:
         self.manager: OffloadingManager = spec.get_manager()
         self._connector_stats = OffloadingConnectorStats()
 
+        # Original group index -> offload group config (cacheable groups only).
+        self._group_config_by_idx: dict[int, GroupOffloadConfig] = {
+            group_config.group_idx: group_config
+            for group_config in self.config.kv_group_configs
+        }
+
         full_attention_groups: list[int] = []
         sliding_window_groups: list[int] = []
         for group_config in self.config.kv_group_configs:
@@ -511,7 +531,7 @@ class OffloadingConnectorScheduler:
 
         # sort sliding window groups by window size in decreasing order
         def _sliding_window_sort_key(i: int) -> int:
-            val = self.config.kv_group_configs[i].sliding_window_size_in_chunks
+            val = self._group_config_by_idx[i].sliding_window_size_in_chunks
             assert val is not None
             return val
 
@@ -664,9 +684,8 @@ class OffloadingConnectorScheduler:
         return consecutive_hits if not defer_lookup else None
 
     def _touch(self, req_status: RequestOffloadState):
-        for group_config, group_state in zip(
-            self.config.kv_group_configs, req_status.group_states
-        ):
+        for group_config in self.config.kv_group_configs:
+            group_state = req_status.group_states[group_config.group_idx]
             if group_config.sliding_window_size_in_chunks is None:
                 self.manager.touch(group_state.offload_keys, req_status.req_context)
             else:
@@ -729,9 +748,7 @@ class OffloadingConnectorScheduler:
             groups_iter = iter(lookup_groups)
             lookup_groups = ()
             for group_idx in groups_iter:
-                group_config: GroupOffloadConfig = self.config.kv_group_configs[
-                    group_idx
-                ]
+                group_config: GroupOffloadConfig = self._group_config_by_idx[group_idx]
                 group_state: RequestGroupState = req_status.group_states[group_idx]
                 tokens_per_chunk = group_config.tokens_per_chunk
                 offload_keys = group_state.offload_keys
@@ -834,9 +851,8 @@ class OffloadingConnectorScheduler:
 
         # Possibly delay the request if any hit chunk is already being loaded.
         if self._chunks_being_loaded:
-            for group_config, group_state in zip(
-                self.config.kv_group_configs, req_status.group_states
-            ):
+            for group_config in self.config.kv_group_configs:
+                group_state = req_status.group_states[group_config.group_idx]
                 tokens_per_chunk = group_config.tokens_per_chunk
                 sliding_window_size_in_chunks = (
                     group_config.sliding_window_size_in_chunks
@@ -1004,19 +1020,20 @@ class OffloadingConnectorScheduler:
         if partial_tail_boundary is not None:
             assert partial_tail_boundary == num_cached_tokens
 
-        keys_to_load: list[OffloadKey] = []
-        dst_block_ids: list[int] = []
-        # per group
-        group_sizes: list[int] = []
-        block_indices: list[int] = []
-        for group_config, group_state, group_blocks in zip(
-            self.config.kv_group_configs,
-            req_status.group_states,
-            blocks.blocks,
-        ):
+        for group_blocks in blocks.blocks:
             self._current_batch_allocated_block_ids.update(
                 block.block_id for block in group_blocks if block.block_id != 0
             )
+
+        keys_to_load: list[OffloadKey] = []
+        dst_block_ids: list[int] = []
+        # per group (indexed by original group index; non-cacheable groups
+        # never load, so their entries stay zero)
+        group_sizes: list[int] = [0] * self.config.num_kv_cache_groups
+        block_indices: list[int] = [0] * self.config.num_kv_cache_groups
+        for group_config in self.config.kv_group_configs:
+            group_state = req_status.group_states[group_config.group_idx]
+            group_blocks = blocks.blocks[group_config.group_idx]
 
             tokens_per_block = group_config.tokens_per_block
             tokens_per_chunk = group_config.tokens_per_chunk
@@ -1066,8 +1083,8 @@ class OffloadingConnectorScheduler:
                     num_locally_computed_gpu_blocks:num_gpu_blocks
                 ]
             )
-            group_sizes.append(num_pending_gpu_blocks)
-            block_indices.append(num_locally_computed_gpu_blocks)
+            group_sizes[group_config.group_idx] = num_pending_gpu_blocks
+            block_indices[group_config.group_idx] = num_locally_computed_gpu_blocks
 
             # Skip prefix-hit chunks for block-level policy; for
             # request-level, next_stored_chunk_idx stays at 0 so all
@@ -1158,7 +1175,7 @@ class OffloadingConnectorScheduler:
         self, handoffs: dict[str, list[tuple[int, int, int]]]
     ) -> dict[int, TransferJob]:
         store_jobs: dict[int, TransferJob] = {}
-        num_groups = len(self.config.kv_group_configs)
+        num_groups = self.config.num_kv_cache_groups
         for req_id, entries in handoffs.items():
             req_status = self._req_status.get(req_id)
             if req_status is None:
@@ -1166,7 +1183,7 @@ class OffloadingConnectorScheduler:
             req = req_status.req
             max_boundary = self._calc_num_offloadable_tokens(req_status, req.num_tokens)
             for group_idx, block_id, boundary in entries:
-                group_config = self.config.kv_group_configs[group_idx]
+                group_config = self._group_config_by_idx[group_idx]
                 if (
                     block_id == 0
                     or boundary > max_boundary
@@ -1264,13 +1281,15 @@ class OffloadingConnectorScheduler:
                 self._make_boundary_key(req, group.group_idx, boundary)
                 for group in self.config.kv_group_configs
             ]
-            block_ids = [
-                cow_blocks[group.group_idx]
-                if group.group_idx in self._cow_source_groups
-                else req_status.group_states[group.group_idx].block_ids[block_idx]
+            block_id_by_group = {
+                group.group_idx: (
+                    cow_blocks[group.group_idx]
+                    if group.group_idx in self._cow_source_groups
+                    else req_status.group_states[group.group_idx].block_ids[block_idx]
+                )
                 for group in self.config.kv_group_configs
-            ]
-            assert all(block_id != 0 for block_id in block_ids)
+            }
+            assert all(block_id != 0 for block_id in block_id_by_group.values())
 
             store_output = self.manager.prepare_store(keys, req_status.req_context)
             if store_output is None:
@@ -1287,14 +1306,22 @@ class OffloadingConnectorScheduler:
                         req, group_config, boundary, key
                     )
 
-            group_by_key = {key: idx for idx, key in enumerate(keys)}
-            accepted_groups = [group_by_key[key] for key in store_output.keys_to_store]
-            group_sizes = [0] * len(self.config.kv_group_configs)
-            block_indices = [0] * len(self.config.kv_group_configs)
+            group_by_key = {
+                key: group.group_idx
+                for group, key in zip(self.config.kv_group_configs, keys)
+            }
+            # GPULoadStoreSpec expects blocks ordered by group index.
+            accepted_groups = sorted(
+                group_by_key[key] for key in store_output.keys_to_store
+            )
+            group_sizes = [0] * self.config.num_kv_cache_groups
+            block_indices = [0] * self.config.num_kv_cache_groups
             for group_idx in accepted_groups:
                 group_sizes[group_idx] = 1
                 block_indices[group_idx] = block_idx
-            source_blocks = [block_ids[group_idx] for group_idx in accepted_groups]
+            source_blocks = [
+                block_id_by_group[group_idx] for group_idx in accepted_groups
+            ]
 
             job_id = self._generate_job_id()
             req_status.transfer_jobs.add(job_id)
@@ -1349,9 +1376,8 @@ class OffloadingConnectorScheduler:
             # Filter out chunks skipped due to sliding window attention / SSM
             # or unreachable by the load path's alignment constraints.
             new_offload_keys: list[OffloadKey] = []
-            for group_config, group_state in zip(
-                self.config.kv_group_configs, req_status.group_states
-            ):
+            for group_config in self.config.kv_group_configs:
+                group_state = req_status.group_states[group_config.group_idx]
                 num_chunks = req_status.storable_chunks(
                     group_config, group_state, num_offloadable_tokens
                 )
@@ -1418,14 +1444,13 @@ class OffloadingConnectorScheduler:
 
             keys_to_store = set(store_output.keys_to_store)
 
-            group_sizes: list[int] = []
-            block_indices: list[int] = []
+            group_sizes: list[int] = [0] * self.config.num_kv_cache_groups
+            block_indices: list[int] = [0] * self.config.num_kv_cache_groups
             src_block_ids: list[int] = []
             fenced_block_ids: list[int] = []
             deferred_fence_block_ids: list[int] = []
-            for group_config, group_state in zip(
-                self.config.kv_group_configs, req_status.group_states
-            ):
+            for group_config in self.config.kv_group_configs:
+                group_state = req_status.group_states[group_config.group_idx]
                 is_sliding_window = (
                     group_config.sliding_window_size_in_chunks is not None
                 )
@@ -1462,8 +1487,8 @@ class OffloadingConnectorScheduler:
                         else:
                             deferred_fence_block_ids.append(block_id)
 
-                group_sizes.append(num_group_blocks)
-                block_indices.append(start_gpu_block_idx or 0)
+                group_sizes[group_config.group_idx] = num_group_blocks
+                block_indices[group_config.group_idx] = start_gpu_block_idx or 0
                 group_state.next_stored_chunk_idx = max(
                     group_state.next_stored_chunk_idx, num_chunks
                 )

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -599,6 +599,9 @@ class OffloadingSpec(ABC):
             self.extra_config.get("offload_prompt_only", True)
         )
 
+        # Aligned with config.groups, which covers prefix-cacheable KV cache
+        # groups only; use OffloadingGroupConfig.group_idx for the original
+        # index into KVCacheConfig.kv_cache_groups.
         self.tokens_per_block = tuple(group.tokens_per_block for group in config.groups)
         self.tokens_per_hash = config.cache.tokens_per_hash
         self.blocks_per_chunk = config.cache.blocks_per_chunk

--- a/vllm/v1/kv_offload/config.py
+++ b/vllm/v1/kv_offload/config.py
@@ -14,6 +14,10 @@ class OffloadingGroupConfig:
     tokens_per_block: int
     # Layer names belonging to this group.
     layer_names: tuple[str, ...]
+    # Index of this group in KVCacheConfig.kv_cache_groups. Offload keys embed
+    # this index, and GPULoadStoreSpec.group_sizes stays indexed by it, so it
+    # is preserved even when non-prefix-cacheable groups are filtered out.
+    group_idx: int
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
# [KV Offload] Scope offload group configs to prefix-cacheable KV cache groups

## Purpose

`build_offloading_config` (`vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py`) builds an `OffloadingGroupConfig` for **every** `kv_cache_group` and then asserts, for all of them:

```
assert group.tokens_per_block % tokens_per_hash == 0, (
    f"tokens_per_block={group.tokens_per_block} not divisible by "
    f"tokens_per_hash={tokens_per_hash}. "
    f"Hybrid models (e.g. Mamba+Attention) need "
    f"--enable-prefix-caching to align block sizes."
)
```

But `tokens_per_hash` comes from `resolve_kv_cache_block_sizes` (`vllm/v1/core/kv_cache_utils.py`), which derives the hash granularity from **prefix-cacheable groups only** (`hashing_sizes = [... if group.kv_cache_spec.prefix_cacheable]`). The two sides disagree about which groups are in scope, so any hybrid model with a non-prefix-cacheable scratch group (`CircularBufferSpec.prefix_cacheable == False`) whose block size does not divide the cacheable groups' hash granularity crashes at boot the moment the OffloadingConnector is enabled:

```
AssertionError: tokens_per_block=4 not divisible by tokens_per_hash=16. Hybrid models (e.g. Mamba+Attention) need --enable-prefix-caching to align block sizes.
```

Enabling prefix caching does not help — the message's advice cannot be followed, because the scratch group is excluded from hash-size resolution *by design* and its ring capacity is set by compression/lookahead geometry, not by the cache block size.

Where this bites: sparse-MLA hybrids that keep a `CircularBufferSpec` ring of pre-compression keys. We hit it deploying GLM-5.3-Flash (support proposed in #53906) on DGX Spark: per rank the layout is MLA + 4 GDN mamba groups at block size 3584 and an SWA drafter group at 64 (all prefix-cacheable, gcd → `tokens_per_hash = 64`), plus a kpool-tail scratch group at block size 4 → `4 % 64 != 0` → boot crash with any `--kv-transfer-config` offloading setup. Any future DeepSeek-V4-style model with a scratch spec of block size not dividing the cacheable gcd hits the same wall.

## Fix

Scope the offload group list to prefix-cacheable groups — the same scoping commit e126687a (#53896) applied to the fine-grained prefix-cache-hit gate in `HybridKVCacheCoordinator` (our test-only PR #54663 pins that gate). Non-cacheable groups have no valid hash granularity, so they can never be keyed, looked up, stored, or loaded; building offload configs for them was never meaningful.

Mechanically:

- `OffloadingGroupConfig` gains a `group_idx` field holding the original index into `KVCacheConfig.kv_cache_groups`. `build_offloading_config` now emits configs only for prefix-cacheable groups, preserving those indices, and keeps the divisibility assert for them.
- The connector scheduler (`offloading/scheduler.py`) iterates the (now scoped) `kv_group_configs` and pairs them with per-request `group_states` via `group_idx` instead of positional `zip`. `group_states`, `GPULoadStoreSpec.group_sizes`, and `block_indices` stay sized by the **full** KV cache group count (new `SchedulerOffloadConfig.num_kv_cache_groups`), with zero entries for scratch groups — so the worker side (`CanonicalKVCaches.group_data_refs`, `gpu_worker`'s `len(group_sizes) == len(layer_refs_per_group)` invariant) is completely unchanged.
- `supports_partial_tail` additionally requires every KV cache group to be prefix-cacheable, keeping the partial-tail CoW hand-off semantics exactly as narrow as before.
- Net behavior for models without scratch groups: identical — every group is prefix-cacheable, so the scoped list equals the old list, indices included, and the on-disk namespace hash of `FileMapper` is untouched.
- Extension contract: `OffloadingSpec.tokens_per_block` stays aligned with `config.groups` and now covers prefix-cacheable groups only (documented at the attribute; original indices via `group_idx`). No existing backend or persistent fs-tier store can observe an index shift or a namespace change from this: any layout where the scoped list differs from the full list crashed on this very assert at boot, so no offloaded bytes or spec state for such layouts exist anywhere.
- Degenerate case: a config with no prefix-cacheable group at all (not constructible with in-tree models) yields an empty group list — the connector idles with no lookup groups and no keys, and passing the optional `block_size` extra config fails loudly on the reworded "at least one prefix-cacheable KV cache group" assert.

Not a duplicate: `gh pr list`/`gh issue list` sweeps for "offloading prefix_cacheable", "build_offloading_config", "tokens_per_hash divisible", "CircularBufferSpec offload", "offloading connector hybrid assert", "offloading eligible groups" surface no PR or issue addressing this boot assert. #53889 / #50883 touch the same function for DCP block-size scaling (orthogonal); #51886 adds retention to the connector (orthogonal); #54663 is our test-only pin of the e126687a coordinator gate and changes no behavior.

## Test Plan

New tests in `tests/v1/kv_connector/unit/offloading_connector/test_config.py`, following the file's existing `MagicMock`-config style:

- `test_scratch_group_does_not_crash_config_translation` — hybrid `KVCacheConfig` (full-attention 16 + `CircularBufferSpec` block 4 + mamba-align 16) previously tripped the assert; now translates, with `group_idx == [0, 2]` and `tokens_per_hash == 16`.
- `test_scratch_group_gets_no_offload_keys` — `SchedulerOffloadConfig.from_spec` spans only groups {0, 2} while `num_kv_cache_groups == 3`; `supports_partial_tail` is off; `OffloadingConnectorScheduler` boots and `_lookup_groups == (0, 2)`; `RequestOffloadState.update_offload_keys` emits keys whose embedded group indices are exactly {0, 2} and the scratch group's state holds none.
- `test_scratch_group_gets_no_load_slots` — `update_state_after_alloc` emits full-length `GPULoadStoreSpec.group_sizes`/`block_indices` (`[2, 0, 2]` / `[0, 0, 0]`, matching the worker's per-group layout) with the scratch entry zero, and no load key or destination block is drawn from the scratch group.
- `test_prefix_cacheable_misaligned_group_still_asserts` — a mamba group outside "align" mode backs the hash size off to the LCM, and the assert still fires for prefix-cacheable groups.

Constructor updates for the new field in `tests/v1/kv_offload/test_factory.py`, `tests/v1/kv_offload/test_file_mapper.py`, and eligible-aware boot checks in the connector test harness (`utils.py`).

Environment: macOS arm64, Python 3.13, torch 2.13 CPU wheel, source tree on `PYTHONPATH` (no build). The repo root `tests/conftest.py` segfaults on macOS while importing multimodal assets, so runs use `--noconftest` (plus `-p tests.v1.kv_connector.unit.offloading_connector.conftest` where the `request_runner` fixture is needed).

```
$ python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_config.py --noconftest -q
47 passed, 15 warnings in 2.84s

$ python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_config.py --noconftest -q -k "scratch_group or misaligned"
4 passed, 43 deselected, 15 warnings in 2.83s

$ python -m pytest tests/v1/kv_offload/test_factory.py tests/v1/kv_offload/test_file_mapper.py --noconftest -q
55 passed, 1 warning in 2.29s

$ python -m pytest tests/v1/kv_connector/unit/offloading_connector/ --noconftest -p tests.v1.kv_connector.unit.offloading_connector.conftest -q
82 failed, 234 passed, 2 skipped in 29.32s

$ python -m pytest tests/v1/kv_offload/ --noconftest -q
33 failed, 472 passed, 21 skipped, 1 warning, 36 errors in 10.44s
```

The failures in the two directory-wide runs are pre-existing on this platform, not caused by this PR: the same commands on unmodified `origin/main` (4707679) produce the **byte-identical** sorted `FAILED`/`ERROR` sets (82 and 33+36 respectively; verified with `diff`; the passed counts differ only by this PR's 4 new tests). They are macOS/CPU environment limitations — `VllmConfig` rejects `disable_hybrid_kv_cache_manager=False` on this platform, which every `RequestRunner`-based test needs, plus CUDA-dependent `kv_offload/cpu` worker tests.

Mutation check — reverting the `vllm/` changes while keeping the tests reproduces the original crash:

```
$ git stash push vllm/ && python -m pytest ... -k "scratch_group or misaligned"
E  AssertionError: tokens_per_block=4 not divisible by tokens_per_hash=16. Hybrid models (e.g. Mamba+Attention) need --enable-prefix-caching to align block sizes.
2 failed, 1 passed, 43 deselected
```

Lint: `ruff check` / `ruff format --check` clean on all changed files; `uvx pre-commit run --files <changed files>` (repo hook config incl. mypy-3.10, typos, SPDX) exits 0.

## Related

- e126687a / #53896 — scoped the fine-grained-hit gate and `attention_groups` to `prefix_cacheable` groups; this PR applies the same predicate to the offloading boundary.
- #54663 — our test-only PR pinning that coordinator gate against scratch-group regressions.
- #54661 — RFC: per-group prefix-cache retention (the hybrid-offloading context this feeds into).
- #53906 — GLM-5.3-Flash support; with the OffloadingConnector enabled that model boots into this assert today.
- #53889, #50883 — open PRs to the same function for DCP scaling of uniform groups; no overlap with this scoping.
- #51886 — offloading-connector retention (not merged; unaffected).

## AI assistance disclosure

This PR was drafted with AI assistance (Claude). Submitted by nood-co1 on behalf of Blockbrain Labs (https://x.com/blockbrain_labs, GitHub org blockbrain-ai); drafted with AI assistance and reviewed by the submitter, who ran the tests listed above. The duplicate-work checks in the contribution policy were run as described above; the exact pytest commands, their full results, the pre-existing-failure baseline diff against `origin/main`, and the mutation check are reported verbatim in the Test Plan.
