### PR TITLE
[Spec Decode] Make the dynamic SD schedule observable

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2565,6 +2565,39 @@ def test_eagle_block_drop_can_be_disabled_without_disabling_eagle(
     assert speculative_config.use_eagle_block_drop() is not disable_eagle_block_drop
 
 
+def test_repr_omits_absent_dynamic_sd_schedule():
+    speculative_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=3,
+    )
+    assert speculative_config.num_speculative_tokens_per_batch_size is None
+    assert repr(speculative_config) == (
+        f"SpeculativeConfig(method={speculative_config.method!r}, model=None, "
+        f"num_spec_tokens={speculative_config.num_speculative_tokens})"
+    )
+
+
+def test_repr_reports_resolved_dynamic_sd_schedule():
+    """The startup banner is the only place a served config surfaces this.
+
+    Without it there is no way to tell from the logs whether a schedule was
+    passed at all, or whether it survived config resolution -- it can still be
+    dropped after parsing, e.g. under data parallelism.
+    """
+    speculative_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=6,
+        num_speculative_tokens_per_batch_size=[(1, 8, 6), (9, 32, 4), (33, 128, 3)],
+    )
+    resolved = speculative_config.num_speculative_tokens_per_batch_size
+    assert resolved == [(1, 8, 6), (9, 32, 4), (33, 128, 3)]
+    assert repr(speculative_config) == (
+        f"SpeculativeConfig(method={speculative_config.method!r}, model=None, "
+        f"num_spec_tokens={speculative_config.num_speculative_tokens}, "
+        f"num_speculative_tokens_per_batch_size={resolved})"
+    )
+
+
 def test_draft_sample_method_gumbel_is_rejected():
     with pytest.raises(ValidationError):
         SpeculativeConfig(

--- a/tests/v1/spec_decode/test_scheduled_k_metric.py
+++ b/tests/v1/spec_decode/test_scheduled_k_metric.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The dynamic-SD schedule's K is recorded even when it selects 0."""
+
+from types import SimpleNamespace
+
+import prometheus_client
+import pytest
+
+from vllm.v1.spec_decode.metrics import SpecDecodingProm
+
+
+@pytest.fixture
+def prom():
+    registry = prometheus_client.CollectorRegistry()
+    original = SpecDecodingProm._counter_cls
+
+    class _Counter(prometheus_client.Counter):
+        def __init__(self, *args, **kwargs):
+            kwargs["registry"] = registry
+            super().__init__(*args, **kwargs)
+
+    SpecDecodingProm._counter_cls = _Counter
+    try:
+        yield (
+            SpecDecodingProm(
+                speculative_config=SimpleNamespace(num_speculative_tokens=3),
+                labelnames=["model"],
+                per_engine_labelvalues={0: ["m"]},
+            ),
+            registry,
+        )
+    finally:
+        SpecDecodingProm._counter_cls = original
+
+
+def _value(registry, k):
+    return registry.get_sample_value(
+        "vllm:spec_decode_scheduled_steps_total",
+        {"model": "m", "num_spec_tokens": str(k)},
+    )
+
+
+def test_every_k_including_zero_has_a_counter(prom):
+    _, registry = prom
+    for k in range(4):
+        assert _value(registry, k) == 0.0
+
+
+def test_k_zero_steps_are_counted(prom):
+    p, registry = prom
+    for _ in range(5):
+        p.observe_scheduled_k(0)
+    p.observe_scheduled_k(3)
+
+    assert _value(registry, 0) == 5.0
+    assert _value(registry, 3) == 1.0
+    assert _value(registry, 1) == 0.0
+
+
+def test_out_of_range_k_is_ignored(prom):
+    p, registry = prom
+    p.observe_scheduled_k(4)
+    p.observe_scheduled_k(-1)
+
+    for k in range(4):
+        assert _value(registry, k) == 0.0
+
+
+def test_unknown_engine_is_ignored(prom):
+    p, registry = prom
+    p.observe_scheduled_k(1, engine_idx=7)
+
+    assert _value(registry, 1) == 0.0

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1905,4 +1905,10 @@ class SpeculativeConfig:
             else self.draft_model_config.model
         )
         num_spec_tokens = self.num_speculative_tokens
-        return f"SpeculativeConfig({method=}, {model=}, {num_spec_tokens=})"
+        schedule = self.num_speculative_tokens_per_batch_size
+        if schedule is None:
+            return f"SpeculativeConfig({method=}, {model=}, {num_spec_tokens=})"
+        return (
+            f"SpeculativeConfig({method=}, {model=}, {num_spec_tokens=}, "
+            f"num_speculative_tokens_per_batch_size={schedule})"
+        )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2281,6 +2281,11 @@ class Scheduler(SchedulerInterface):
                 kv_connector_stats,
                 cudagraph_stats,
                 perf_stats,
+                spec_decode_scheduled_k=(
+                    scheduler_output.num_spec_tokens_to_schedule
+                    if self.dynamic_sd_lookup is not None
+                    else None
+                ),
             )
         ) is not None:
             # Return stats to only one of the front-ends.
@@ -2765,6 +2770,7 @@ class Scheduler(SchedulerInterface):
         kv_connector_stats: KVConnectorStats | None = None,
         cudagraph_stats: CUDAGraphStat | None = None,
         perf_stats: PerfStats | None = None,
+        spec_decode_scheduled_k: int | None = None,
     ) -> SchedulerStats | None:
         if not self.log_stats:
             return None
@@ -2792,6 +2798,7 @@ class Scheduler(SchedulerInterface):
             connector_prefix_cache_stats=connector_prefix_cache_stats,
             kv_cache_eviction_events=eviction_events,
             spec_decoding_stats=spec_stats,
+            spec_decode_scheduled_k=spec_decode_scheduled_k,
             kv_connector_stats=connector_stats_payload,
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1152,6 +1152,11 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     scheduler_stats.spec_decoding_stats, engine_idx
                 )
 
+            if scheduler_stats.spec_decode_scheduled_k is not None:
+                self.spec_decoding_prom.observe_scheduled_k(
+                    scheduler_stats.spec_decode_scheduled_k, engine_idx
+                )
+
             if scheduler_stats.kv_connector_stats is not None:
                 self.kv_connector_prom.observe(
                     scheduler_stats.kv_connector_stats, engine_idx

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -204,6 +204,11 @@ class SchedulerStats:
     kv_cache_eviction_events: list[KVCacheEvictionEvent] = field(default_factory=list)
 
     spec_decoding_stats: SpecDecodingStats | None = None
+    # K the dynamic-SD schedule selected for this step, or None when dynamic SD
+    # is not in use. Recorded separately from spec_decoding_stats because that
+    # is only built for steps that produced draft tokens, so steps the schedule
+    # sends to K=0 leave no trace in it.
+    spec_decode_scheduled_k: int | None = None
     kv_connector_stats: dict[str, Any] | None = None
 
     waiting_lora_adapters: dict[str, int] = field(default_factory=dict)

--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -247,6 +247,9 @@ class SpecDecodingProm:
         self.counter_spec_decode_num_accepted_tokens_per_pos: dict[
             int, list[prometheus_client.Counter]
         ] = {}
+        self.counter_spec_decode_scheduled_steps: dict[
+            int, list[prometheus_client.Counter]
+        ] = {}
         if not is_diffusion:
             assert speculative_config is not None
             num_spec_tokens = speculative_config.num_speculative_tokens
@@ -262,6 +265,37 @@ class SpecDecodingProm:
                 ]
                 for idx, lv in per_engine_labelvalues.items()
             }
+
+            k_labelnames = labelnames + ["num_spec_tokens"]
+            scheduled_counter = self._counter_cls(
+                name="vllm:spec_decode_scheduled_steps",
+                documentation=(
+                    "Scheduler steps by the number of speculative tokens the "
+                    "dynamic-SD schedule selected, including 0."
+                ),
+                labelnames=k_labelnames,
+            )
+            self.counter_spec_decode_scheduled_steps = {
+                idx: [
+                    scheduled_counter.labels(*lv, str(k))
+                    for k in range(num_spec_tokens + 1)
+                ]
+                for idx, lv in per_engine_labelvalues.items()
+            }
+
+    def observe_scheduled_k(self, scheduled_k: int, engine_idx: int = 0):
+        """Record the K the dynamic-SD schedule selected for one step.
+
+        Steps the schedule sends to K=0 produce no drafts, so they are absent
+        from every other spec-decode counter; without this one a schedule that
+        has stopped speculating is indistinguishable from one that is not
+        configured."""
+        if not self.spec_decoding_enabled:
+            return
+        counters = self.counter_spec_decode_scheduled_steps.get(engine_idx)
+        if counters is None or not 0 <= scheduled_k < len(counters):
+            return
+        counters[scheduled_k].inc()
 
     def observe(self, spec_decoding_stats: SpecDecodingStats, engine_idx: int = 0):
         if not self.spec_decoding_enabled:


### PR DESCRIPTION
A served dynamic-SD config is opaque in two directions, and this PR closes both. Neither is
visible without the other: the first says what schedule the engine resolved, the second says
what it did with it.

1. **The resolved schedule is never printed**, so you cannot tell from the logs whether the
   table you passed survived config resolution.
2. **Steps the schedule sent to K=0 increment no counter**, so "the schedule stopped
   speculating on purpose" and "speculation is not running" look identical in metrics.

---

## 1. The resolved schedule is never printed

`SpeculativeConfig.__repr__` returns only method, model and `num_spec_tokens`, so the startup
banner shows `num_spec_tokens=6` and nothing about the schedule. That is reported in #48494 by
an operator running `[[1,8,6],[9,32,4],[33,128,3]]` on MI355X, who had to read
`/proc/1/cmdline` inside the container to confirm the table had been passed at all, and then
compare acceptance lengths against fixed-k runs to confirm it was being used.

Printing it also answers a question the flag alone cannot: the schedule can be dropped *after*
parsing. `_maybe_disable_dynamic_sd_for_data_parallel` sets
`num_speculative_tokens_per_batch_size = None` under DP, so a config that was accepted at the
command line may not be the config that is running. The banner is rendered from the resolved
object, so it reports what the engine actually has.

```text
before: SpeculativeConfig(method='mtp', model='...', num_spec_tokens=6)
after:  SpeculativeConfig(method='mtp', model='...', num_spec_tokens=6, num_speculative_tokens_per_batch_size=[(1, 8, 6), (9, 32, 4), (33, 128, 3)])
```

The line is byte-identical when no schedule is set, which is every non-DSD config.

I offered this one to the reporter first on #48494 and am putting it up rather than leaving it
blocked on a reply; happy to hand it over or drop this commit if they would rather own it.

---

## 2. Steps at K=0 increment no counter

`make_spec_decoding_stats` returns early when a request produced no draft tokens:

```python
# vllm/v1/core/sched/scheduler.py
if not self.log_stats or not num_draft_tokens:
    return None
```

With a static `num_speculative_tokens` that only happens transiently. With a
dynamic schedule it is a *decision*: `[[1,64,3],[65,128,1],[129,512,0]]` sends
every step above batch 128 to K=0 on purpose. Those steps build no
`SpecDecodingStats`, so `vllm:spec_decode_num_drafts`,
`num_draft_tokens`, `num_accepted_tokens` and the per-position vector all stay
flat.

The result is that these two situations produce identical metrics:

- a dynamic schedule that is working as configured and has stopped speculating
  because the batch is large,
- speculative decoding that is silently not running at all.

K=0 is also the tier a batch-keyed schedule reaches *first* under load, so the
blind spot covers the regime an operator most wants to inspect. And there is no
way to answer "how much of my traffic hit each tier of my schedule?" — which is
the question you have to answer to tune one.

## The counter this adds

Add `vllm:spec_decode_scheduled_steps`, a counter over scheduler steps labelled
by the number of speculative tokens the schedule selected, including 0.

```
vllm:spec_decode_scheduled_steps_total{num_spec_tokens="0"} 41213
vllm:spec_decode_scheduled_steps_total{num_spec_tokens="1"} 0
vllm:spec_decode_scheduled_steps_total{num_spec_tokens="3"} 8022
```

No new plumbing was needed. The value already exists as
`SchedulerOutput.num_spec_tokens_to_schedule`, set from the dynamic-SD lookup in
`schedule()`. It is read in `update_from_output`, which receives the
`SchedulerOutput` paired with the model output it is processing, so the count is
attributed to the step that made the decision rather than to whichever step is
currently being scheduled — this matters under async scheduling.

The counter is declared whenever spec decoding is enabled and skipped on the
diffusion path, which reuses these counters with different semantics. It is only
incremented when a dynamic schedule is actually in use — with a static
`num_speculative_tokens` the scheduler reports no selected K and every series
stays at zero.

## Scope

Purely additive — 58 lines of source and 107 lines of test. The single deleted
line is the old `return` in `__repr__`, replaced by the two-branch version above.
No existing counter changes value or
meaning: at K=0 there was previously no stats object and there still is not; the
new counter is independent of `SpecDecodingStats` rather than an extension of
it, so the logging path's behaviour is unchanged.

## Tests

`tests/test_config.py` — two cases: the banner line is unchanged when no schedule is
set, and reports the resolved schedule when one is. I ran the modified `__repr__`
standalone over both, plus the `mtp` variant where `model` is not `None`, and
confirmed the no-schedule output is byte-identical to the current format.

`tests/v1/spec_decode/test_scheduled_k_metric.py` — four cases: every K from 0
to `num_speculative_tokens` gets a counter; K=0 steps are counted; out-of-range
K is ignored rather than raising; an unknown engine index is ignored.

I ran the metric logic locally against a real `CollectorRegistry` (5 steps at
K=0 plus 1 at K=3 gives `{0: 5, 1: 0, 2: 0, 3: 1}`, and both the out-of-range
and unknown-engine calls leave the counters untouched). I could not run the
full pytest suite on this machine — my local torch is too old for current
`main`, which fails at import in `vllm/utils/torch_utils.py::direct_register_custom_op` —
so CI is the first full run.

## Why I ran into this

I have been measuring dynamic-SD schedules (#48627, #48944) and trying to
calibrate a cost model that picks K. The coefficients were guesses and the model
picked the wrong tier; there is no counter that would have told me so from
inside vLLM. Both pieces here are the smallest parts of that gap that stand on their own, and
both are independent of anything I have proposed about the schedule format. #48494
is independent confirmation that the same two blind spots bite in production.

## AI assistance

This change was drafted with the help of an AI coding assistant (Anthropic
Claude) and reviewed line-by-line before this PR was opened. All code, tests,
commit message, and PR text were reviewed by me; the verification described
above was run by me on this branch. Filing this disclosure per vLLM's
`AGENTS.md` requirement for AI-assisted contributions.

