### PR TITLE
[CI] Shard distributed model jobs above the 24h P90 threshold

### DIFF
--- a/.buildkite/test_areas/models_distributed.yaml
+++ b/.buildkite/test_areas/models_distributed.yaml
@@ -2,9 +2,9 @@ group: Models - Distributed
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (L4) Distributed Models"
+- label: ":nvidia: (L4) Distributed Models Shard %N"
   key: distributed-model-tests-2-gpus
-  timeout_in_minutes: 60
+  timeout_in_minutes: 35
   working_dir: "/vllm-workspace/tests"
   device: l4
   num_devices: 2
@@ -15,20 +15,30 @@ steps:
   - tests/model_executor/model_loader/test_sharded_state_loader.py
   - tests/models/
   commands:
-  - TARGET_TEST_SUITE=L4 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
-  - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m '(not slow_test)'
-  # Avoid importing model tests that cause CUDA reinitialization error
-  - pytest models/transformers/test_backend.py -v -s -m 'distributed(num_gpus=2)'
-  - pytest models/language -v -s -m 'distributed(num_gpus=2)'
-  - pytest models/multimodal/generation/test_phi4siglip.py -v -s -m 'distributed(num_gpus=2)'
-  - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_phi4siglip.py
-  - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+  - |
+    case "$$BUILDKITE_PARALLEL_JOB" in
+      0)
+        TARGET_TEST_SUITE=L4 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+        CUDA_VISIBLE_DEVICES=0,1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m '(not slow_test)'
+        ;;
+      1)
+        pytest models/transformers/test_backend.py -v -s -m 'distributed(num_gpus=2)'
+        pytest models/language -v -s -m 'distributed(num_gpus=2)'
+        ;;
+      2)
+        pytest models/multimodal/generation/test_phi4siglip.py -v -s -m 'distributed(num_gpus=2)'
+        pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_phi4siglip.py
+        VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+        ;;
+      *) exit 2 ;;
+    esac
+  parallelism: 3
   mirror:
     amd:
-      label: ":amd: (MI300) Distributed Models"
+      label: ":amd: (MI300) Distributed Models Shard %N"
       dind: false
       device: mi300_2
-      timeout_in_minutes: 75
+      timeout_in_minutes: 35
       depends_on:
       - image-build-amd
       source_file_dependencies:
@@ -43,10 +53,20 @@ steps:
       - tests/model_executor/model_loader/test_sharded_state_loader.py
       - tests/models/
       commands:
-      - TARGET_TEST_SUITE=MI300 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
-      - HIP_VISIBLE_DEVICES=0,1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m '(not slow_test)'
-      - pytest models/transformers/test_backend.py -v -s -m 'distributed(num_gpus=2)'
-      - pytest models/language -v -s -m 'distributed(num_gpus=2)'
-      - pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_phi4siglip.py
-      - pytest models/multimodal/generation/test_phi4siglip.py -v -s -m 'distributed(num_gpus=2)'
-      - VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+      - |
+        case "$$BUILDKITE_PARALLEL_JOB" in
+          0)
+            TARGET_TEST_SUITE=MI300 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+            HIP_VISIBLE_DEVICES=0,1 pytest -v -s model_executor/model_loader/test_sharded_state_loader.py -m '(not slow_test)'
+            ;;
+          1)
+            pytest models/transformers/test_backend.py -v -s -m 'distributed(num_gpus=2)'
+            pytest models/language -v -s -m 'distributed(num_gpus=2)'
+            ;;
+          2)
+            pytest models/multimodal -v -s -m 'distributed(num_gpus=2)' --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_phi4siglip.py
+            pytest models/multimodal/generation/test_phi4siglip.py -v -s -m 'distributed(num_gpus=2)'
+            VLLM_WORKER_MULTIPROC_METHOD=spawn pytest models/multimodal/generation/test_whisper.py -v -s -m 'distributed(num_gpus=2)'
+            ;;
+          *) exit 2 ;;
+        esac


### PR DESCRIPTION
## Why

In the CI dashboard's exact 24-hour window from 2026-08-31 10:31 UTC to 2026-09-01 10:31 UTC, `:amd: (MI300) Distributed Models` had a 2,864s (47.7m) P90 across 18 runs. The requested target is about 20 minutes per shard.

## What changed

The distributed-model step now runs as three structural shards on both NVIDIA and its AMD mirror:

1. Basic correctness and sharded-state loading
2. Transformers backend and language models
3. Multimodal models, Phi-4/SigLIP, and Whisper

This keeps process-sensitive suites separate, preserves every original command exactly once, and avoids relying on pytest's collection partitioning across heterogeneous commands. The linear pre-overhead target is about 15.9 minutes per AMD shard.

## Duplicate-work check

I searched open vLLM PRs for `Distributed Models` and CI sharding terms. No open PR shards this step. The older August sharding drafts do not touch `.buildkite/test_areas/models_distributed.yaml`.

## Validation

- Parsed `.buildkite/test_areas/models_distributed.yaml` with PyYAML
- Validated the step against the current ci-infra `Step` Pydantic model
- Exact command coverage assertion: all 7 NVIDIA and all 7 AMD commands occur once across the new shard cases
- Extracted both generated case blocks and validated them with `bash -n`
- `git diff --check`



## Targeted CI

[Build #86577](https://buildkite.com/vllm/ci/builds/86577) passed all three shards: `7:26, 13:14, 16:47`.

Model evaluation is not applicable: this changes CI partitioning only, not model behavior or serving output.

AI assistance was used. A human submitter must review every changed line and validate the targeted CI runs before merge.
