### PR TITLE
[CI] Shard basic model initialization tests

### DIFF
--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -26,7 +26,7 @@ steps:
 - label: ":nvidia: (H200 MIG 35GB) Basic Models (Extra Initialization) Shard %N"
   device: h200_35gb
   key: basic-models-tests-extra-initialization
-  timeout_in_minutes: 100
+  timeout_in_minutes: 30
   source_file_dependencies:
   - vllm/model_executor/models/
   - tests/models/test_initialization.py
@@ -36,7 +36,7 @@ steps:
     # subset of supported models (the complement of the small subset in the above
     # test.) Also run if model initialization test file is modified
     - pytest -v -s models/test_initialization.py -k 'not test_can_initialize_small_subset' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-  parallelism: 4
+  parallelism: 14
 
 - label: ":nvidia: (H200 MIG 35GB) Basic Models (Other)"
   device: h200_35gb


### PR DESCRIPTION
## Why

In the 24-hour CI dashboard window ending 2026-09-01 10:31 UTC, all four existing `Basic Models (Extra Initialization)` shards exceeded 45 minutes at P90:

- shard 1: 2,991s (9 runs)
- shard 2: 2,883s (9 runs)
- shard 3: 3,367s (8 runs)
- shard 4: 2,848s (9 runs)

The existing four-way pytest split is too coarse for the current model registry.

## What changed

Expand the pytest partition from 4 to 14 shards and lower the per-shard timeout to 30 minutes. The same collection is still partitioned exactly once by pytest's deterministic sharding plugin; only the fan-out changes.

This replaces draft #52351 with a current-main, name-free branch. No merged or active non-draft PR covers this job.

## Validation

- YAML parse
- current `ci-infra` Buildkite step schema
- `git diff --check`


## Targeted CI

[Build #86578](https://buildkite.com/vllm/ci/builds/86578) passed all 14 shards: `10:22, 11:03, 11:35, 11:47, 14:22, 15:58, 16:04, 16:07, 16:35, 17:22, 17:57, 18:36, 19:43, 19:51`.

This is a draft pending human review. AI assistance was used.
