### PR TITLE
[Bugfix][KV Offload] Register mixed page sizes in one cache group

### DIFF
--- a/tests/v1/attention/utils.py
+++ b/tests/v1/attention/utils.py
@@ -426,6 +426,26 @@ class MockMambaBuilder(BaseMambaAttentionMetadataBuilder[BaseMambaAttentionMetad
         return builder.build(0, common_metadata)
 
 
+def dense_kv_cache_tensor(
+    raw: torch.Tensor,
+    spec: KVCacheSpec,
+    num_blocks: int,
+    num_layers: int,
+    layout: KVCacheLayout,
+    layer_names: list[str] | None = None,
+) -> KVCacheTensor:
+    """The ``KVCacheTensor`` for a dense allocation of ``num_layers`` layers."""
+    layer_stride, block_stride, _, _, _ = compute_layout_strides(
+        spec, num_blocks, num_layers, layout
+    )
+    return KVCacheTensor(
+        size=raw.numel(),
+        layers=layer_names or [str(i) for i in range(num_layers)],
+        layer_stride=layer_stride,
+        block_stride=block_stride,
+    )
+
+
 def dense_kv_cache_views(
     raw: torch.Tensor,
     spec: KVCacheSpec,
@@ -435,15 +455,7 @@ def dense_kv_cache_views(
     kernel_block_size: int | None = None,
 ) -> list[torch.Tensor]:
     """``create_kv_cache_views`` for a dense allocation of ``num_layers`` layers."""
-    layer_stride, block_stride, _, _, _ = compute_layout_strides(
-        spec, num_blocks, num_layers, layout
-    )
-    tensor = KVCacheTensor(
-        size=raw.numel(),
-        layers=[str(i) for i in range(num_layers)],
-        layer_stride=layer_stride,
-        block_stride=block_stride,
-    )
+    tensor = dense_kv_cache_tensor(raw, spec, num_blocks, num_layers, layout)
     return create_kv_cache_views(
         raw,
         spec,

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -20,8 +20,21 @@ from vllm.platforms import current_platform
 if not current_platform.is_cuda_alike():
     pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
 
-from tests.v1.attention.utils import dense_kv_cache_views
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheLayout
+from tests.v1.attention.utils import dense_kv_cache_tensor, dense_kv_cache_views
+from vllm.config import CacheConfig
+from vllm.v1.core.kv_cache_utils import (
+    get_kv_cache_config_from_groups,
+    is_kv_cache_spec_uniform,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheGroupSpec,
+    KVCacheLayout,
+    KVCacheSpec,
+    KVCacheTensor,
+    MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
 from vllm.v1.simple_kv_offload.cuda_mem_ops import (
     CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
@@ -31,6 +44,7 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
 )
 from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadMetadata
 from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
+from vllm.v1.worker.utils import allocate_kv_cache
 
 NUM_BLOCKS = 64
 BLOCK_BYTES = 4096
@@ -210,9 +224,14 @@ def test_register_shared_kv_cache_storage(monkeypatch, layout: KVCacheLayout):
         device="cuda",
     )
     caches = dense_kv_cache_views(raw, spec, num_blocks, num_layers, layout)
+    layer_names = [f"layer.{i}" for i in range(num_layers)]
     cache_config = MagicMock(
         num_blocks=num_blocks,
-        kv_cache_tensors=[MagicMock(size=raw.nbytes)],
+        kv_cache_tensors=[
+            dense_kv_cache_tensor(
+                raw, spec, num_blocks, num_layers, layout, layer_names
+            )
+        ],
     )
     worker = SimpleCPUOffloadWorker(
         vllm_config=None,
@@ -252,7 +271,14 @@ def test_register_kv_cache_storage_with_trailing_padding(monkeypatch):
         vllm_config=None,
         kv_cache_config=MagicMock(
             num_blocks=num_blocks,
-            kv_cache_tensors=[MagicMock(size=cache_bytes)],
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=cache_bytes,
+                    layers=["layer.0"],
+                    layer_stride=cache_bytes,
+                    block_stride=block_bytes,
+                )
+            ],
         ),
         cpu_capacity_bytes=cache_bytes,
     )
@@ -286,11 +312,16 @@ def test_register_separate_kv_head_groups(monkeypatch):
         device="cuda",
     )
     caches = dense_kv_cache_views(raw, spec, num_blocks, num_layers, layout)
+    layer_names = [f"layer.{i}" for i in range(num_layers)]
     worker = SimpleCPUOffloadWorker(
         vllm_config=None,
         kv_cache_config=MagicMock(
             num_blocks=num_blocks,
-            kv_cache_tensors=[MagicMock(size=raw.nbytes)],
+            kv_cache_tensors=[
+                dense_kv_cache_tensor(
+                    raw, spec, num_blocks, num_layers, layout, layer_names
+                )
+            ],
         ),
         cpu_capacity_bytes=raw.nbytes,
     )
@@ -309,3 +340,95 @@ def test_register_separate_kv_head_groups(monkeypatch):
     assert {cache.shape for cache in worker.gpu_kv_caches.values()} == {
         (num_blocks, per_group_block_bytes)
     }
+
+
+def _dsa_specs(num_layers: int, block_size: int) -> dict[str, KVCacheSpec]:
+    """A DSA model's per-layer specs (DeepSeek-V3.2, GLM-5.2).
+
+    Each decoder layer contributes an MLA latent cache and the indexer's key
+    cache, whose pages differ in size (``MLAAttentionSpec`` off ``head_size``:
+    512 + 64 for the latent, 128 fp8 keys + one fp32 scale per 128 elements for
+    the indexer). Both are ``MLAAttentionSpec`` with the same block size, so the
+    hybrid allocator puts them in one ``UniformTypeKVCacheSpecs`` cache group.
+    See ``DeepseekV32IndexerCache.get_kv_cache_spec`` and
+    ``MLAAttention.get_kv_cache_spec``.
+    """
+    specs: dict[str, KVCacheSpec] = {}
+    for i in range(num_layers):
+        specs[f"model.layers.{i}.self_attn.attn"] = MLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=512 + 64,
+            dtype=torch.uint8,
+            cache_dtype_str="fp8",
+        )
+        specs[f"model.layers.{i}.self_attn.indexer.k_cache"] = MLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=128 + 128 // 128 * 4,
+            dtype=torch.uint8,
+        )
+    return specs
+
+
+def test_register_mixed_page_sizes_in_one_cache_group(monkeypatch):
+    """Sparse-MLA models mix page sizes inside one cache group.
+
+    The MLA latent and indexer key caches of a layer have different page sizes,
+    so the allocation has no single per-layer block size to reinterpret it with:
+    ``num_layers * (mla_page + indexer_page)`` is not a multiple of either page.
+    Registration must derive each region from the placement metadata instead.
+    """
+    num_layers = 4
+    block_size = 64
+    specs = _dsa_specs(num_layers, block_size)
+    # Differing head sizes make the specs non-identical but same-type, which is
+    # what lands both caches of a layer in one group.
+    assert not is_kv_cache_spec_uniform(specs)
+    assert UniformTypeKVCacheSpecs.is_uniform_type(specs)
+    group = KVCacheGroupSpec(
+        list(specs),
+        UniformTypeKVCacheSpecs(block_size=block_size, kv_cache_specs=specs),
+    )
+
+    # DEEPSEEK_V32_INDEXER declares no supported layouts, so resolution lands on
+    # the default preference: layer-outermost, one region per layer.
+    layout = KVCacheLayout.LBNHC
+    vllm_config = MagicMock()
+    vllm_config.cache_config = CacheConfig()
+    vllm_config.cache_config.kv_cache_layout = layout.name
+    vllm_config.cache_config.num_gpu_blocks_override = None
+
+    pages = [spec.page_size_bytes for spec in specs.values()]
+    num_blocks = 4
+    kv_cache_config = get_kv_cache_config_from_groups(
+        vllm_config, [group], sum(pages) * num_blocks
+    )
+    assert kv_cache_config.num_blocks == num_blocks
+    assert len(set(pages)) > 1, "the mixed page sizes are what this test covers"
+
+    kv_caches = allocate_kv_cache(kv_cache_config, torch.device("cuda"), layout)
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=sum(pages) * num_blocks,
+    )
+    worker._backend = MagicMock()
+    monkeypatch.setattr("vllm.v1.simple_kv_offload.worker.PIN_MEMORY", False)
+
+    worker.register_kv_caches(kv_caches)
+
+    assert worker.gpu_kv_caches is not None
+    # One region per layer, each with that layer's own page as its block stride.
+    assert sorted(worker.gpu_kv_caches) == sorted(specs)
+    assert {name: cache.shape[1] for name, cache in worker.gpu_kv_caches.items()} == {
+        name: spec.page_size_bytes for name, spec in specs.items()
+    }
+    assert all(cache.shape[0] == num_blocks for cache in worker.gpu_kv_caches.values())
+
+    # Every registered region must alias the bytes the model writes through, or
+    # offloaded blocks would be copied from the wrong place.
+    for name, cache in kv_caches.items():
+        region = worker.gpu_kv_caches[name]
+        assert region.data_ptr() == cache.data_ptr()
+        assert region.stride(0) == specs[name].page_size_bytes

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -25,6 +25,7 @@ from vllm.config import CacheConfig
 from vllm.v1.core.kv_cache_utils import (
     get_kv_cache_config_from_groups,
     is_kv_cache_spec_uniform,
+    resolve_kv_cache_block_sizes,
 )
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -432,3 +433,89 @@ def test_register_mixed_page_sizes_in_one_cache_group(monkeypatch):
         region = worker.gpu_kv_caches[name]
         assert region.data_ptr() == cache.data_ptr()
         assert region.stride(0) == specs[name].page_size_bytes
+
+
+@pytest.mark.parametrize("rank_blocks", [1, 5])
+def test_register_mixed_page_sizes_odd_block_counts(monkeypatch, rank_blocks):
+    """Registration holds at block counts that are not powers of two.
+
+    ``num_blocks`` comes out of ``available_memory // bytes_per_block``, so
+    any integer is reachable. Registration derives regions from the config's
+    own block count and strides, and the CPU pool rounds down from the same
+    per-block byte total; none of it assumes anything about how the count
+    was reached.
+    """
+    num_layers = 4
+    block_size = 64
+    specs = _dsa_specs(num_layers, block_size)
+    group = KVCacheGroupSpec(
+        list(specs),
+        UniformTypeKVCacheSpecs(block_size=block_size, kv_cache_specs=specs),
+    )
+    layout = KVCacheLayout.LBNHC
+    vllm_config = MagicMock()
+    vllm_config.cache_config = CacheConfig()
+    vllm_config.cache_config.kv_cache_layout = layout.name
+    vllm_config.cache_config.num_gpu_blocks_override = None
+
+    pages = [spec.page_size_bytes for spec in specs.values()]
+    kv_cache_config = get_kv_cache_config_from_groups(
+        vllm_config, [group], sum(pages) * rank_blocks
+    )
+    assert kv_cache_config.num_blocks == rank_blocks
+
+    kv_caches = allocate_kv_cache(kv_cache_config, torch.device("cuda"), layout)
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=sum(pages) * rank_blocks,
+    )
+    worker._backend = MagicMock()
+    monkeypatch.setattr("vllm.v1.simple_kv_offload.worker.PIN_MEMORY", False)
+
+    worker.register_kv_caches(kv_caches)
+
+    assert worker.gpu_kv_caches is not None
+    assert {n: c.shape for n, c in worker.gpu_kv_caches.items()} == {
+        name: (rank_blocks, spec.page_size_bytes) for name, spec in specs.items()
+    }
+    assert worker.num_cpu_blocks == rank_blocks
+
+
+def test_mixed_page_byte_placement_is_dcp_invariant():
+    """DCP scales a block's token span, not its byte placement.
+
+    ``get_kv_cache_config_from_groups`` never reads
+    ``decode_context_parallel_size``, so every placement field registration
+    derives regions from is identical at dcp=1 and dcp=2. What DCP scales is
+    the block's token span, reported by ``resolve_kv_cache_block_sizes``;
+    checking that it doubles proves DCP was actually in effect, or the
+    identity above would be trivially true.
+    """
+    specs = _dsa_specs(4, block_size=128)
+
+    placements = []
+    for dcp_size in (1, 2):
+        group = KVCacheGroupSpec(
+            list(specs),
+            UniformTypeKVCacheSpecs(block_size=128, kv_cache_specs=specs),
+        )
+        vllm_config = MagicMock()
+        vllm_config.cache_config = CacheConfig()
+        vllm_config.cache_config.block_size = 128
+        vllm_config.cache_config.kv_cache_layout = KVCacheLayout.LBNHC.name
+        vllm_config.cache_config.num_gpu_blocks_override = None
+        vllm_config.parallel_config.decode_context_parallel_size = dcp_size
+
+        page_bytes = sum(spec.page_size_bytes for spec in specs.values())
+        config = get_kv_cache_config_from_groups(vllm_config, [group], page_bytes * 4)
+        scheduler_block_size, _ = resolve_kv_cache_block_sizes(config, vllm_config)
+        assert scheduler_block_size == 128 * dcp_size
+        placements.append(
+            [
+                (t.size, tuple(t.layers), t.layer_stride, t.block_stride, t.offset)
+                for t in config.kv_cache_tensors
+            ]
+        )
+
+    assert placements[0] == placements[1]

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -100,33 +100,64 @@ class SimpleCPUOffloadWorker:
         assert self.kv_cache_config is not None
         num_blocks = self.kv_cache_config.num_blocks
         assert self.kv_cache_config.kv_cache_tensors
-        logical_storage_bytes = self.kv_cache_config.kv_cache_tensors[0].size
 
-        # The DMA backend copies whole blocks as base + block_id * stride(0),
-        # so view each unique allocation as [num_blocks, block_bytes].
+        # The DMA backend copies whole blocks as base + block_id * stride(0), so
+        # every region is a [num_blocks, block_bytes] view. Which bytes form one
+        # region depends on the layout, so take it from each tensor's placement
+        # metadata instead of reinterpreting the whole allocation with a single
+        # layer's block size. Layers of one allocation can have different page
+        # sizes -- a DSA model's MLA latent and indexer key caches share a cache
+        # group -- so a shared block size does not exist.
         unique_gpu_caches: dict[str, torch.Tensor] = {}
         seen: set[tuple[torch.device, int]] = set()
-        for name, tensor in kv_caches.items():
-            storage = tensor.untyped_storage()
-            key = (tensor.device, storage.data_ptr())
-            if key in seen:
+        for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
+            name = next((n for n in kv_cache_tensor.layers if n in kv_caches), None)
+            if name is None:
                 continue
-            seen.add(key)
+            num_layers = len(kv_cache_tensor.layers)
+            block_bytes = kv_cache_tensor.block_stride
+            blocks_span = num_blocks * block_bytes
+            if kv_cache_tensor.layer_stride >= blocks_span:
+                # Layer-outermost: each layer owns a contiguous region, or one per
+                # KV head group when the head dim is hoisted out of the block dim
+                # (LHBNC).
+                start = kv_cache_tensor.offset
+                span = num_layers * kv_cache_tensor.layer_stride
+                layer_names = kv_cache_tensor.layers
+            else:
+                # Block-outermost: every layer's page sits inside each block, so
+                # one region with a block stride spanning them all covers it.
+                start = 0
+                span = blocks_span
+                layer_names = kv_cache_tensor.layers[:1]
 
-            physical_per_block, remainder = divmod(tensor.shape[0], num_blocks)
+            cache = kv_caches[name]
+            raw = torch.empty(0, dtype=torch.int8, device=cache.device).set_(
+                cache.untyped_storage()
+            )
+            assert raw.numel() >= start + span, (
+                f"KV cache {name!r} storage has {raw.numel()} bytes, smaller than "
+                f"the {span} bytes it places at offset {start}"
+            )
+            regions = raw[start : start + span].view(-1, num_blocks, block_bytes)
+            groups_per_layer, remainder = divmod(len(regions), len(layer_names))
             assert remainder == 0, (
-                f"KV cache {name!r} has {tensor.shape[0]} physical blocks, which "
-                f"is not divisible by {num_blocks} scheduler blocks"
+                f"KV cache {name!r} places {len(layer_names)} layers in "
+                f"{len(regions)} block-strided regions"
             )
-            block_bytes = tensor.stride(0) * tensor.element_size() * physical_per_block
-            raw = torch.empty(0, dtype=torch.int8, device=tensor.device).set_(storage)
-            assert raw.numel() >= logical_storage_bytes, (
-                f"KV cache {name!r} storage has {raw.numel()} bytes, smaller "
-                f"than the configured {logical_storage_bytes}-byte allocation"
-            )
-            regions = raw[:logical_storage_bytes].view(-1, num_blocks, block_bytes)
             for idx, region in enumerate(regions):
-                key_name = name if len(regions) == 1 else f"{name}.{idx}"
+                key = (region.device, region.data_ptr())
+                if key in seen:
+                    # Cache groups overlay each other; whichever registered these
+                    # bytes first already covers them.
+                    continue
+                seen.add(key)
+                layer_name = layer_names[idx // groups_per_layer]
+                key_name = (
+                    layer_name
+                    if groups_per_layer == 1
+                    else f"{layer_name}.{idx % groups_per_layer}"
+                )
                 unique_gpu_caches[key_name] = region
 
         # Compute per-tensor bytes_per_block. Tensors may have different

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -101,13 +101,9 @@ class SimpleCPUOffloadWorker:
         num_blocks = self.kv_cache_config.num_blocks
         assert self.kv_cache_config.kv_cache_tensors
 
-        # The DMA backend copies whole blocks as base + block_id * stride(0), so
-        # every region is a [num_blocks, block_bytes] view. Which bytes form one
-        # region depends on the layout, so take it from each tensor's placement
-        # metadata instead of reinterpreting the whole allocation with a single
-        # layer's block size. Layers of one allocation can have different page
-        # sizes -- a DSA model's MLA latent and indexer key caches share a cache
-        # group -- so a shared block size does not exist.
+        # The DMA backend copies blocks as base + block_id * stride(0), so every
+        # region is a [num_blocks, block_bytes] view. Block bytes come from each
+        # tensor's placement -- layers in one allocation can differ in page size.
         unique_gpu_caches: dict[str, torch.Tensor] = {}
         seen: set[tuple[torch.device, int]] = set()
         for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
@@ -117,16 +113,13 @@ class SimpleCPUOffloadWorker:
             num_layers = len(kv_cache_tensor.layers)
             block_bytes = kv_cache_tensor.block_stride
             blocks_span = num_blocks * block_bytes
-            if kv_cache_tensor.layer_stride >= blocks_span:
-                # Layer-outermost: each layer owns a contiguous region, or one per
-                # KV head group when the head dim is hoisted out of the block dim
-                # (LHBNC).
+            layer_outermost = kv_cache_tensor.layer_stride >= blocks_span
+            if layer_outermost:
+                # One region per layer, or per KV head group under LHBNC.
                 start = kv_cache_tensor.offset
                 span = num_layers * kv_cache_tensor.layer_stride
                 layer_names = kv_cache_tensor.layers
             else:
-                # Block-outermost: every layer's page sits inside each block, so
-                # one region with a block stride spanning them all covers it.
                 start = 0
                 span = blocks_span
                 layer_names = kv_cache_tensor.layers[:1]
@@ -148,8 +141,6 @@ class SimpleCPUOffloadWorker:
             for idx, region in enumerate(regions):
                 key = (region.device, region.data_ptr())
                 if key in seen:
-                    # Cache groups overlay each other; whichever registered these
-                    # bytes first already covers them.
                     continue
                 seen.add(key)
                 layer_name = layer_names[idx // groups_per_layer]


### PR DESCRIPTION
## Purpose

Fix a startup crash of `SimpleCPUOffloadConnector` on sparse-MLA (DSA) models (DeepSeek-V3.2, GLM-5/5.2). With the connector enabled, the engine dies in `register_kv_caches` before serving (GLM-5.2-FP8, TP=8):

```
RuntimeError: shape '[-1, 42072, 8448]' is invalid for input of size 130343768064
```

Root cause: registration reinterpreted the whole KV allocation with a single layer's block size,

```python
regions = raw[:tensors[0].size].view(-1, num_blocks, block_bytes)
```

which only divides evenly when every layer in the allocation has the same page size. DSA models break that assumption: a layer's MLA latent cache and its indexer key cache are both `MLAAttentionSpec` with the same block size, so they land in one `UniformTypeKVCacheSpecs` group whose page size is their sum, while the individual pages differ (576 vs 132 bytes/token, i.e. 36864 vs 8448 bytes at block size 64). With a layer-outermost layout the group's layers alias one allocation, and `num_layers * (mla_page + indexer_page)` is a multiple of neither page, so `view()` raises.

`--kv-cache-dtype fp8` is not a precondition. The indexer key cache is always `uint8` (128 fp8 keys plus one fp32 scale per 128 elements), so it does not scale with the KV cache dtype; at bf16 the pages become 73728 / 8448 and `gcd` is still 768.

Registration now derives each region from the placement metadata #51718 put on `KVCacheTensor` (`layers`/`layer_stride`/`block_stride`/`offset`) instead of reinterpreting the allocation with one layer's block size:

- a layer-outermost tensor splits into one `[num_blocks, block_bytes]` region per layer (per KV head group under LHBNC), using the tensor's own block stride;
- a block-outermost tensor stays a single region, as before;
- regions are deduplicated by address, so overlaid cache groups still register once.

This also fixes a latent misregistration in mixed groups where the division happens to succeed. Dedup was keyed on backing storage, so only the first layer of a shared allocation was processed, and its block stride was used to split the whole allocation — producing regions whose boundaries do not align with layer boundaries, all filed under the first layer's name. Gemma-4 under `--disable-hybrid-kv-cache-manager` hits this: its two page sizes (524288 / 1048576) are an exact 1:2 ratio, so `view()` never raises and 8 layers register as 7 regions, with total bytes reconciling either way (1071644672). One layer's base address lands mid-region, so offloaded blocks map onto the wrong layer.

|                        | regions | distinct ptrs | layers whose base ptr is a region base |
|------------------------|---------|---------------|----------------------------------------|
| before this PR (LBNHC) | 7       | 7             | 7 / 8                                  |
| after  this PR (LBNHC) | 8       | 8             | 8 / 8                                  |

Why didn't existing coverage catch this? The four `SimpleCPUOffloadConnector` entries in `tests/evals/gsm8k/test_gsm8k_offloading.py` are `simple-nemotron-h-8b`, `simple-gemma-4-e4b-it`, `simple-qwen3.5-35b`, and `simple-deepseek-v4-flash`. No DSA model is among them. Gemma-4 splits into uniform-page groups under the default hybrid KV cache manager, so it does not mix at all there; the mixing only appears with `--disable-hybrid-kv-cache-manager`, and even then its 1:2 page ratio divides evenly. DeepSeek-V4-Flash does mix page sizes but escapes: `DeepseekV4IndexerBackend` declares block-outermost layouts (`vllm/v1/attention/backends/mla/indexer.py`), where a block stride spans every layer's page, so the leading `-1` degenerates to 1. No entry pairs mixed page sizes with a layer-outermost layout — exactly the DSA combination, since `DeepseekV32IndexerBackend` declares no layouts and resolution takes the default layer-outermost preference. The unit tests likewise only built uniform-page allocations, so the mixed-page path was never exercised.

Merge timing: the offending reinterpretation was introduced by #51718 (`8bdc70ec7b`), which is currently only in the v0.28.1rc0 prerelease — no stable release contains it (latest stable is v0.28.0). Landing this before v0.28.1 ships keeps the regression out of a stable release.

Non-duplication: searched open PRs and issues for `SimpleCPUOffload`, `register_kv_caches`, and `mixed page sizes`. The closest are #53532 (scheduler-side eager flush), #40075 (cross-layer layout feature), and #51361 (NIXL heterogeneous regions) — none touch this registration path.

## Test Plan

1. In-repo regression test (requires CUDA):

       .venv/bin/python -m pytest tests/v1/simple_kv_offload/test_worker.py -v

   The new `test_register_mixed_page_sizes_in_one_cache_group` drives the real
   `get_kv_cache_config_from_groups -> allocate_kv_cache -> register_kv_caches`
   path with a DSA spec set (MLA latent 36864 B + indexer key 8448 B pages in
   one cache group). Existing registration tests are updated to supply
   `KVCacheTensor` placement metadata.

2. Startup repro on a stock upstream image (RTX 4090), one GPU, no weights
   needed. The two commands differ only by a read-only bind mount of this PR's
   `worker.py` over the one in the image; the digest is pinned because `:nightly`
   rolls daily:

       IMG=vllm/vllm-openai:nightly-7c5dc571cbd1064ecc8a9b1045637ff647aa22cb

       # before (stock image):
       docker run --rm --entrypoint python3 --gpus 'device=0' \
         -v $PWD:/repro $IMG /repro/repro_offload_mixed_pages.py

       # after (same image, this PR's worker.py mounted over it):
       docker run --rm --entrypoint python3 --gpus 'device=0' \
         -v $PWD:/repro \
         -v $PWD/worker.py:/usr/local/lib/python3.12/dist-packages/vllm/v1/simple_kv_offload/worker.py:ro \
         $IMG /repro/repro_offload_mixed_pages.py

3. Real-model serving, 8× B300, official GLM-5.2-FP8 checkpoint. Before the
   fix: stock upstream image, digest-pinned
   `vllm/vllm-openai:nightly-7c5dc571cbd1064ecc8a9b1045637ff647aa22cb`
   (`sha256:383e409fc7695d6e40cd40d452f3ec277a3d1c462d7b1510034768d26f2cd397`).
   After the fix: the same image with only this PR's `worker.py` applied. The command below is reduced to the flags that take effect before initialize_kv_cache; the serving and profiling flags omitted from it all act after that point, past the crash. Identical in both runs:

       vllm serve /path/to/GLM-5.2-FP8 \
         --tensor-parallel-size 8 \
         --kv-transfer-config '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use_per_rank":85899345920}}'

## Test Result

1. The new pytest reproduces the mixed-page group in-repo and asserts that
   every registered region aliases the layer's own KV bytes (`data_ptr`,
   `stride(0)` equality). It requires CUDA and runs on GPU runners.

2. RTX 4090 repro:
   - before: `RuntimeError: shape '[-1, 4, 36864]' is invalid for input of size
     724992` — each block holds `36864 + 8448 = 45312` bytes and the allocation
     is `4 * 4 * 45312 = 724992`, which is a multiple of neither page, so
     `view()` raises;
   - after: registration succeeds, 8 regions, one per layer-cache, each with
     its own page as block stride:

     <details>
     <summary>repro output (after)</summary>

     ```
     vLLM 0.28.1rc1.dev199+g7c5dc571c
     MLA latent page   : 36864 B  (576 B/token)
     indexer key page  : 8448 B  (132 B/token)
     distinct pages    : [8448, 36864]  <- the trigger

     layout            : LBNHC (layer-outermost)
     num_blocks        : 4
     bytes_per_block   : 181248
     allocation        : 724992 B

     what the buggy line computes -- view(-1, num_blocks, block_bytes):
       block_bytes= 36864 (MLA    ): 724992 / (4 * 36864) = 4.9167  -> NOT an integer, view() raises
       block_bytes=  8448 (indexer): 724992 / (4 * 8448) = 21.4545  -> NOT an integer, view() raises

     calling SimpleCPUOffloadWorker.register_kv_caches() ...
     INFO [worker.py:221] SimpleCPUOffloadWorker [CPU]: 8 tensors, 4 CPU blocks (0.00 GB)

     No crash. Registered 8 regions (expected 8, one per layer-cache).
       model.layers.0.self_attn.attn                        (4, 36864)  page=36864
       model.layers.0.self_attn.indexer.k_cache             (4, 8448)  page=8448
       model.layers.1.self_attn.attn                        (4, 36864)  page=36864
       model.layers.1.self_attn.indexer.k_cache             (4, 8448)  page=8448
       model.layers.2.self_attn.attn                        (4, 36864)  page=36864
       model.layers.2.self_attn.indexer.k_cache             (4, 8448)  page=8448
       model.layers.3.self_attn.attn                        (4, 36864)  page=36864
       model.layers.3.self_attn.indexer.k_cache             (4, 8448)  page=8448

     FIXED: every layer registered with its own page as block stride.
     ```

     </details>

3. GLM-5.2-FP8 on 8× B300:
   - before (stock image): every TP worker dies in `register_kv_caches`
     during startup and the engine never comes up:

         SimpleCPUOffloadConnector: role=WORKER, per_rank=80.00 GB,
         world_size=8, backend=cpu
         ...
         File ".../vllm/v1/simple_kv_offload/worker.py", line 127, in
         register_kv_caches
           regions = raw[:logical_storage_bytes].view(-1, num_blocks, block_bytes)
         RuntimeError: shape '[-1, 42072, 8448]' is invalid for input of
         size 130343768064
         ...
         EngineCore failed to start.

     The last INFO lines before the crash establish the layout and geometry:

         [utils.py:306]           Using LBNHC KV cache layout.
         [interface.py:635]       Setting kv cache block size to 64 for DEEPSEEK_V32_INDEXER backend.
         [gpu_worker.py:622]      Available KV cache memory: 121.39 GiB
         [kv_cache_utils.py:2042] GPU KV cache size: 2,692,608 tokens

     `130343768064 / 42072 = 3098112` bytes per block exactly, and
     `3098112 / 8448 = 366.73`, `3098112 / 36864 = 84.04` — neither integral,
     which is what `view()` reports.
   - after (stock image + this PR's `worker.py`): registration succeeds on all
     8 ranks and the server serves with the connector active:

         SimpleCPUOffloadWorker [CPU]: 101 tensors, 27726 CPU blocks (80.00 GB)

     Sizing reconciles: `80 GiB // 3098112 = 27726` blocks and
     `27726 * 3098112 = 80.00 GB`, both matching the log. Prefix-cache reuse
     works through the registered regions — the same 2882-token prefix sent
     three times gives `cached_tokens=0` cold, then `cached_tokens=2816`
     (44 blocks × 64) on both repeats, with identical correct responses. So the
     per-layer boundaries are right, not merely non-crashing.

 A second run that left slightly less device memory for KV landed on a different block count (41676 instead of 42072) and failed identically on the unpatched code — the crash is not specific to one memory configuration. Bytes per block is the same in both (129116915712 / 41676 = 3098112), confirming this patch changes only how the allocation is divided into regions, not the geometry.

Model-output evals: not applicable beyond the above — the change only re-derives byte ranges at registration time; range correctness is asserted by `data_ptr`/`stride(0)` equality against the model's own KV views, and by prefix-cache reuse returning identical correct output on the real model. A full smoke suite against the fixed build was not collected.

AI assistance: developed with AI assistance (Kimi); every changed line reviewed by the human submitter, tests run as listed above.
