### PR TITLE
[Bugfix][NIXL] Harden handshake listener against bad requests

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -6,6 +6,7 @@ import inspect
 import os
 import tempfile
 import textwrap
+import threading
 import time
 import uuid
 from collections import defaultdict
@@ -18,6 +19,7 @@ import numpy as np
 import pytest
 import ray
 import torch
+import zmq
 
 from tests.v1.attention.utils import dense_kv_cache_views
 from vllm import LLM
@@ -44,6 +46,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlKVConnectorStats,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    GET_META_MSG,
     compute_nixl_compatibility_hash,
 )
 from vllm.distributed.kv_transfer.kv_transfer_state import (
@@ -3380,6 +3383,128 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
                 f"got {notif!r} (expected {expected_notif!r}, "
                 f"buggy form would be {bad_notif!r})"
             )
+
+
+def _start_handshake_listener(port: int) -> tuple[threading.Thread, threading.Event]:
+    encoded_data = {(0, 0): b"fake-metadata-blob"}
+    ready_event = threading.Event()
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=NixlConnectorScheduler._nixl_handshake_listener,
+        args=(encoded_data, ready_event, stop_event, "127.0.0.1", port),
+        daemon=True,
+    )
+    thread.start()
+    assert ready_event.wait(timeout=5), "listener did not start"
+    return thread, stop_event
+
+
+def _ask_handshake_listener(port: int, timeout_ms: int = 2000):
+    """Send a real GET_META_MSG request, like a decode worker would."""
+    ctx = zmq.Context()
+    sock = ctx.socket(zmq.REQ)
+    sock.setsockopt(zmq.RCVTIMEO, timeout_ms)
+    sock.setsockopt(zmq.LINGER, 0)
+    sock.connect(f"tcp://127.0.0.1:{port}")
+    sock.send(msgspec.msgpack.encode((GET_META_MSG, 0, 0)))
+    try:
+        reply = sock.recv_multipart()
+    except zmq.Again:
+        reply = None
+    sock.close()
+    ctx.term()
+    return reply
+
+
+def test_handshake_listener_survives_bad_envelope():
+    """A peer that doesn't speak the REQ/ROUTER envelope (e.g. a bare
+    DEALER socket, which doesn't auto-add the empty delimiter frame the
+    way REQ does) must not kill the listener thread. Reproduces the
+    production crash: ValueError: not enough values to unpack."""
+    port = 15700
+    thread, stop_event = _start_handshake_listener(port)
+    try:
+        # Sanity check: the listener is healthy before the bad message.
+        reply = _ask_handshake_listener(port)
+        assert reply is not None and reply[0] == b"fake-metadata-blob"
+
+        ctx = zmq.Context()
+        stray = ctx.socket(zmq.DEALER)
+        stray.connect(f"tcp://127.0.0.1:{port}")
+        stray.send(b"whatever")
+        time.sleep(0.3)
+        stray.setsockopt(zmq.LINGER, 0)
+        stray.close()
+        ctx.term()
+        time.sleep(0.3)
+
+        assert thread.is_alive(), "listener died on a bad envelope"
+
+        reply = _ask_handshake_listener(port)
+        assert reply is not None and reply[0] == b"fake-metadata-blob"
+    finally:
+        stop_event.set()
+        thread.join(timeout=3)
+
+
+def test_handshake_listener_survives_malformed_content():
+    """A well-formed REQ envelope carrying malformed msgpack content must
+    also not kill the listener thread."""
+    port = 15701
+    thread, stop_event = _start_handshake_listener(port)
+    try:
+        ctx = zmq.Context()
+        sock = ctx.socket(zmq.REQ)
+        sock.setsockopt(zmq.RCVTIMEO, 1000)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.connect(f"tcp://127.0.0.1:{port}")
+        sock.send(b"not valid msgpack")
+        with contextlib.suppress(zmq.Again):
+            sock.recv_multipart()
+        sock.close()
+        ctx.term()
+        time.sleep(0.3)
+
+        assert thread.is_alive(), "listener died on malformed content"
+
+        reply = _ask_handshake_listener(port)
+        assert reply is not None and reply[0] == b"fake-metadata-blob"
+    finally:
+        stop_event.set()
+        thread.join(timeout=3)
+
+
+def test_handshake_listener_shutdown_with_continuous_bad_requests():
+    """stop_event must be observed even while bad requests keep arriving
+    back-to-back with no receive timeout in between, or shutdown() blocks
+    on thread.join() forever. Reproduces a review finding: a DEALER client
+    that never stops sending bad frames means recv_multipart() never
+    raises zmq.Again, so a stop check gated behind that exception never
+    runs."""
+    port = 15702
+    thread, stop_event = _start_handshake_listener(port)
+    spam_stop = threading.Event()
+
+    def spam():
+        ctx = zmq.Context()
+        sock = ctx.socket(zmq.DEALER)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.connect(f"tcp://127.0.0.1:{port}")
+        while not spam_stop.is_set():
+            sock.send(b"bad frame")
+        sock.close()
+        ctx.term()
+
+    spammer = threading.Thread(target=spam, daemon=True)
+    spammer.start()
+    try:
+        time.sleep(0.3)
+        stop_event.set()
+        thread.join(timeout=3)
+        assert not thread.is_alive(), "shutdown blocked on continuous bad requests"
+    finally:
+        spam_stop.set()
+        spammer.join(timeout=3)
 
 
 @patch(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -355,29 +355,66 @@ class NixlBaseConnectorScheduler:
             sock.setsockopt(zmq.RCVTIMEO, 1000)
             ready_event.set()
             while True:
+                if stop_event.is_set():
+                    break
                 try:
-                    identity, _, msg = sock.recv_multipart()
+                    # Left unpacked here: a peer that isn't a well-behaved
+                    # REQ socket (e.g. a bare DEALER) can send a different
+                    # number of frames, and unpacking that must not be
+                    # allowed to kill this thread either.
+                    frames = sock.recv_multipart()
                 except zmq.Again:
-                    if stop_event.is_set():
-                        break
                     continue
-                # Decode (GET_META_MSG, pp_rank, tp_rank).
-                msg, target_pp_rank, target_tp_rank = msgspec.msgpack.decode(msg)
-                logger.debug(
-                    "Received message for pp rank %s, tp rank %s",
-                    target_pp_rank,
-                    target_tp_rank,
-                )
-                if msg != GET_META_MSG:
-                    logger.warning("Connection listener got unexpected message %s", msg)
-                # Echo our perf_counter so P can estimate the clock offset.
-                # perf_counter is only comparable within a process, so this
-                # listener must run in the same process that stamps the block
-                # expiry deadline (`_reqs_need_send`).
-                ts = msgspec.msgpack.encode(time.perf_counter())
-                sock.send_multipart(
-                    (identity, b"", encoded_data[(target_pp_rank, target_tp_rank)], ts)
-                )
+                try:
+                    identity, _, msg = frames
+                    # Decode (GET_META_MSG, pp_rank, tp_rank).
+                    decoded_msg, target_pp_rank, target_tp_rank = (
+                        msgspec.msgpack.decode(msg)
+                    )
+                    logger.debug(
+                        "Received message for pp rank %s, tp rank %s",
+                        target_pp_rank,
+                        target_tp_rank,
+                    )
+                    if decoded_msg != GET_META_MSG:
+                        logger.warning(
+                            "Connection listener got unexpected message %s",
+                            decoded_msg,
+                        )
+                    # Echo our perf_counter so P can estimate the clock offset.
+                    # perf_counter is only comparable within a process, so this
+                    # listener must run in the same process that stamps the
+                    # block expiry deadline (`_reqs_need_send`).
+                    ts = msgspec.msgpack.encode(time.perf_counter())
+                    sock.send_multipart(
+                        (
+                            identity,
+                            b"",
+                            encoded_data[(target_pp_rank, target_tp_rank)],
+                            ts,
+                        )
+                    )
+                except (
+                    msgspec.DecodeError,
+                    ValueError,
+                    TypeError,
+                    KeyError,
+                    zmq.ZMQError,
+                ):
+                    # A single malformed or unexpected request (e.g. a stray
+                    # non-NIXL client, one that doesn't speak the REQ/ROUTER
+                    # envelope, or a request for a pp/tp rank this engine
+                    # doesn't serve) must not take down the listener: every
+                    # remote's handshake depends on this thread staying alive
+                    # for the lifetime of the process. Anything outside this
+                    # list is a genuine bug and should still crash the thread
+                    # loudly rather than be swallowed here.
+                    logger.exception(
+                        "Error handling NIXL handshake request "
+                        "(raw=%.200r); ignoring it and continuing to listen on %s",
+                        frames[-1],
+                        path,
+                    )
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
         """D-side only. Returns N-1 for Mamba models since the decoder

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -764,10 +764,24 @@ class NixlBaseConnectorWorker:
                     (GET_META_MSG, remote_pp_rank, remote_rank)
                 )
                 # Set receive timeout to 5 seconds to avoid hanging on dead server
-                sock.setsockopt(zmq.RCVTIMEO, 5000)  # milliseconds
+                handshake_timeout_ms = 5000
+                sock.setsockopt(zmq.RCVTIMEO, handshake_timeout_ms)
                 start_time = time.perf_counter()
                 sock.send(msg)
-                reply_parts = sock.recv_multipart()
+                try:
+                    reply_parts = sock.recv_multipart()
+                except zmq.error.Again as e:
+                    # ZMQ hides the underlying connection state, so this
+                    # timeout is all we get; point at the probe script
+                    # instead of a bare "Resource temporarily unavailable".
+                    raise RuntimeError(
+                        f"No reply from NIXL handshake listener at {path} "
+                        f"(pp_rank={remote_pp_rank}, tp_rank={remote_rank}) "
+                        f"after {handshake_timeout_ms}ms. Probe it with "
+                        "tests/v1/kv_connector/nixl_integration/"
+                        f"nixl_side_channel_probe.py --host {host} --port {port} "
+                        f"--pp-rank {remote_pp_rank} --rank {remote_rank}."
+                    ) from e
                 recv_time = time.perf_counter()
                 assert len(reply_parts) == 2
                 handshake_bytes = reply_parts[0]


### PR DESCRIPTION


## Purpose

The prefill-side NIXL handshake listener (`_nixl_handshake_listener` in `base_scheduler.py`) is a single background thread, per engine, that lives for the whole process and answers metadata queries from every decode worker that needs to pull KV cache from it. Its only exception handling covered the idle-poll timeout; any exception raised while actually processing a received message killed the thread silently, with nothing to restart or report it.

This fails whenever anything reaches the side-channel port that isn't a well-formed request from a real `REQ` client: a malformed message, a request for a pp/tp rank this engine doesn't serve, or a peer that doesn't speak the `REQ`/`ROUTER` envelope (a `REQ` socket always auto-adds an empty delimiter frame; anything that doesn't, such as a bare `DEALER` socket, produces a different frame count on the `ROUTER` side). Once the thread dies, every subsequent handshake against that engine times out and fails for every decode worker until the process is restarted: a single bad request causing a lasting, silent, engine-wide DoS.

This isn't tied to an existing filed issue. It was found via production investigation, reproduced locally, and checked against `vllm-project/vllm` (issues, PRs, current `main`) for existing work on this listener's exception handling; nothing addresses it. The closest related work, vllm-project/vllm#48633 and vllm-project/vllm#49238 / vllm-project/vllm#50047, covers different NIXL reliability gaps (push-mode handshake latency, stale peer state after a restart), not this one.

Changes:
- `base_scheduler.py`: move the frame unpacking and message handling into a guarded block, narrowed to the concrete failure modes a bad request can trigger (`msgspec.DecodeError`, `ValueError`/`TypeError`, `KeyError`, `zmq.ZMQError`). A bad request is now logged (with the raw bytes that triggered it, safely escaped and capped) and dropped, instead of taking the whole side channel down. Anything outside that list still crashes the thread loudly, since that's a genuine bug rather than a bad peer.
- `base_worker.py`: wrap the decode-side handshake timeout (`zmq.error.Again`) with the remote address/rank and a pointer to the existing side-channel probe script (`tests/v1/kv_connector/nixl_integration/nixl_side_channel_probe.py`), since ZMQ hides the underlying connection state and the bare timeout gives no way to triage which of several possible causes it was.
- `tests/v1/kv_connector/unit/test_nixl_connector.py`: two new regression tests (`test_handshake_listener_survives_bad_envelope`, `test_handshake_listener_survives_malformed_content`) that run the real listener against a live socket and a stray non-`REQ` client. Verified both fail against the unpatched listener (thread dies) and pass against the fix.

AI assistance was used to investigate, reproduce, and implement this fix.

## Test Plan

- `ruff check` / `ruff format --check` / `pyright` on changed files.
- `python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py -v` (full file).
- `python -m pytest tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py -v` (full file; calls `_nixl_handshake` and `_nixl_handshake_listener` directly).
- Live reproduction: ran the actual (unpatched) `_nixl_handshake_listener` against a real `ROUTER` socket, connected with a `DEALER` client (no `REQ` envelope) to reproduce the crash, then reran the same scenario against the patched listener to confirm it survives and keeps serving; now captured permanently as the two new regression tests above.

## Test Result

- `ruff`/`pyright`: clean (0 errors).
- Full suites, run on NVIDIA GPU hardware:
  ```
  python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py -v
  ================= 140 passed, 16 warnings in 207.38s (0:03:27) =================
  ```
- New regression tests confirmed to fail against the unpatched listener (`ValueError`/`msgspec.DecodeError`, thread dies) and pass against the fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan, with test commands.
- [x] The test results, including full-suite results on GPU hardware.
- [ ] (N/A) Documentation update.
</details>




