### PR TITLE
[Bugfix] Derive FA version from the worker's own device, not device 0

### DIFF
--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -3,6 +3,8 @@
 
 from typing import Any
 
+import torch
+
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -91,7 +93,16 @@ def get_flash_attn_version(
             is_fa_version_supported,
         )
 
-        device_capability = current_platform.get_device_capability()
+        # Heterogeneous rigs: the FA version must not be derived globally
+        # from device 0. Each worker holds its own GPU, and in a TPxPP grid
+        # the stages can be different compute classes — deriving from device
+        # 0 lets the weakest card dictate the kernel for every worker. On a
+        # rig with a Volta card in position 0 and Turing cards behind it,
+        # the Turing workers die with "FlashAttention version not detected"
+        # although FA2 is available to them.
+        device_capability = current_platform.get_device_capability(
+            torch.cuda.current_device() if torch.cuda.is_available() else 0
+        )
 
         assert device_capability is not None
 
@@ -229,7 +240,11 @@ def uses_fa4_hd256_kernel(
         return False
     if head_size_v is not None and head_size_v != 256:
         return False
-    capability = current_platform.get_device_capability()
+    # Same reasoning as in get_flash_attn_version(): ask the worker's own
+    # device, not device 0.
+    capability = current_platform.get_device_capability(
+        torch.cuda.current_device() if torch.cuda.is_available() else 0
+    )
     return capability is not None and capability.major in (10, 11)
 
 


### PR DESCRIPTION
`get_flash_attn_version()` and `uses_fa4_hd256_kernel()` in
`vllm/v1/attention/backends/fa_utils.py` both call
`current_platform.get_device_capability()` without an argument, which
reports **device 0**. Each worker process holds its own GPU, so on a
heterogeneous rig the card in position 0 dictates the attention kernel
for every worker.

### Symptom

On a mixed Volta + Turing rig running a TP×PP grid: with a V100 in
position 0, the Turing workers abort with `FlashAttention version not
detected` although FA2 is available to them. Changing the GPU order
changes which workers break — the capability never belonged to the
worker that used it. The same applies to the FA4 hd256 gate.

### Fix

Ask the device the worker actually selected:

```python
device_capability = current_platform.get_device_capability(
    torch.cuda.current_device() if torch.cuda.is_available() else 0
)
```

The fallback to `0` preserves the previous behaviour where CUDA is
unavailable. On homogeneous rigs there is no behaviour change, since
every device reports the same capability.

### Context

Found while enabling FA2 for Turing on a five-GPU mixed rig
(2× Quadro RTX 8000 sm75 + 3× Tesla V100 sm70). The kernel-side work is
proposed separately in vllm-project/flash-attention#190 and #191; this
change stands on its own and is not a prerequisite for either.
