### PR TITLE
[Bugfix][KV Offload] Ensure tracker progress for oversized offers

### DIFF
--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -965,6 +965,28 @@ def test_filter_reused_manager():
     assert manager.counts.get(to_keys([1])[0]) == 1
 
 
+def test_filter_reused_manager_oversized_offer_makes_progress():
+    """An offer larger than the tracker capacity must not churn forever."""
+    manager = make_cpu_manager(
+        num_blocks=4,
+        cache_policy="lru",
+        store_threshold=2,
+        max_tracker_size=3,
+    )
+    keys = to_keys([1, 2, 3, 4])
+    stored_keys: set[OffloadKey] = set()
+
+    for _ in range(4):
+        remaining_keys = [key for key in keys if key not in stored_keys]
+        output = manager.prepare_store(remaining_keys, _EMPTY_REQ_CTX)
+        assert output is not None
+        if output.keys_to_store:
+            manager.complete_store(output.keys_to_store, _EMPTY_REQ_CTX)
+            stored_keys.update(output.keys_to_store)
+
+    assert stored_keys == set(keys)
+
+
 def test_evictable_cache_block_count():
     """
     Verifies _num_evictable_cache_blocks is maintained correctly through the

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -103,15 +103,25 @@ class CPUOffloadingManager(OffloadingManager):
     ) -> CPULoadStoreSpec:
         return CPULoadStoreSpec([block.block_id for block in blocks])
 
-    def _record_access(self, key: OffloadKey) -> None:
-        """Count one observation of ``key`` for store admission."""
+    def _record_accesses(self, keys: Collection[OffloadKey]) -> None:
+        """Record an offer without evicting its tracked candidates."""
         assert self.counts is not None
-        if key in self.counts:
-            self.counts.move_to_end(key)
-            self.counts[key] += 1
-        else:
+        protected: set[OffloadKey] = set()
+        for key in keys:
+            if key in self.counts:
+                self.counts.move_to_end(key)
+                self.counts[key] += 1
+                protected.add(key)
+
+        num_unprotected = len(self.counts) - len(protected)
+        for key in keys:
+            if key in self.counts:
+                continue
             if len(self.counts) >= self.max_tracker_size:
+                if num_unprotected == 0:
+                    continue
                 self.counts.popitem(last=False)
+                num_unprotected -= 1
             self.counts[key] = 1
 
     # --- OffloadingManager interface ---
@@ -173,8 +183,7 @@ class CPUOffloadingManager(OffloadingManager):
     ) -> PrepareStoreOutput | None:
         if self.counts is not None:
             num_keys = len(keys)
-            for key in keys:
-                self._record_access(key)
+            self._record_accesses(keys)
             keys = [k for k in keys if self.counts.get(k, 0) >= self.store_threshold]
             self.stores_skipped_in_current_batch += num_keys - len(keys)
         # filter out blocks that are already stored


### PR DESCRIPTION
## Purpose

When one store offer contains more candidates than `max_tracker_size`, the current per-key LRU updates can evict candidates from the same offer before the next observation. With `store_threshold > 1`, repeated identical offers then keep every count at 1 and CPU KV offload never starts.

## Change

- Update and protect already tracked candidates before admitting new keys.
- Evict only tracked candidates absent from the current offer.
- Stop admitting new keys when every tracked entry is protected by the offer.
- Add a regression test covering four candidates, tracker capacity three, and threshold two.

The tracker remains bounded by `max_tracker_size`, and processing remains linear in the number of offered keys.

## Value

This restores forward progress for valid CPU KV offload configurations. It is a liveness fix rather than a microbenchmark optimization: affected requests previously produced no CPU stores at all.

## Validation

```text
/test-venv/bin/python -m pytest tests/v1/kv_offload/cpu/test_manager.py -q
28 passed

pre-commit run ruff-check --files vllm/v1/kv_offload/cpu/manager.py tests/v1/kv_offload/cpu/test_manager.py
Passed

pre-commit run ruff-format --files vllm/v1/kv_offload/cpu/manager.py tests/v1/kv_offload/cpu/test_manager.py
Passed

pre-commit run typos --files vllm/v1/kv_offload/cpu/manager.py tests/v1/kv_offload/cpu/test_manager.py
Passed

pre-commit run mypy-3.12 --hook-stage manual --files vllm/v1/kv_offload/cpu/manager.py tests/v1/kv_offload/cpu/test_manager.py
Passed

git diff --check origin/main...HEAD
Passed
```

Serving A/B used Qwen3-0.6B in the default compiled/CUDA-graph mode with `store_threshold=2`, `max_tracker_size=3`, and six candidates per offer:

- Baseline: zero store bytes after six repeated target requests.
- Fixed: all six candidates eventually stored; 11,010,048 store bytes, 14,680,064 load bytes, and 128 external prefix-hit tokens.
- Generated token IDs remained `[13483, 25293]` in baseline and fixed runs.

## Duplicate-work check

#52227 moved reuse counting from lookup to store offers, but retained sequential per-key insertion and does not prevent churn within an oversized offer. Searches for `store_threshold max_tracker_size`, `KV offload tracker progress`, and `oversized offer` found no open PR implementing this fix. Open PRs #52103 and #53087 address event provenance and `HIT_PENDING` timeouts respectively.

## AI assistance

AI assistance was used for fix bug. The submitter reviewed every changed line and the validation results.
