### PR TITLE
[Bugfix][ROCm][Disagg] Bootstrap DP wave 0 from coordinator at engine READY

### DIFF
--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -246,6 +246,21 @@ class DPCoordinatorProc:
             # Send ready message to engines.
             publish_back.send(b"READY")
 
+            # Wave-0 bootstrap: wake all engines (including headless child
+            # ranks) before the first client request.
+            if (
+                self.enable_wave_coordination
+                and not engines_running
+                and current_wave == 0
+            ):
+                logger.info(
+                    "DP Coordinator bootstrapping wave %d for all engines",
+                    current_wave,
+                )
+                self._send_start_wave(
+                    publish_back, current_wave, exclude_engine_index=None
+                )
+
             logger.info("All engine subscriptions received by DP coordinator")
 
             poller = zmq.Poller()


### PR DESCRIPTION
## Purpose

In multi-node MoE DP, prefill and decode span several processes. The master node runs the HTTP front-end; child nodes run `--headless` engine ranks (for example `--data-parallel-start-rank 8`). The DP coordinator normally sends `START_DP_WAVE` only when a new request wakes a paused engine. On a cold start every engine is at wave 0 and idle, so that path never runs and headless children never enter the stepping loop.

This change broadcasts `START_DP_WAVE` to all engines right after they finish subscribing, so wave 0 is active before the first client request.

## Changes

`vllm/v1/engine/coordinator.py` only:

* After READY, call `_send_start_wave` for wave 0 when lockstep coordination is enabled and engines are idle.
* Wake all engines (including headless child ranks) before the first request.

## Test Plan

MoRIIO **2P2D wide-EP** (DP16, WRITE), `ROUTER_TYPE=proxy`, image `vllm/vllm-openai-rocm:nightly`.

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_RMSNORM=1
export VLLM_DP_DISABLE_BATCH_QUEUE=1
```

Integration: after startup, every DP rank (including `--headless` children) must receive `START_DP_WAVE` at wave 0 before the first client request.

### MiniMax-M3-MXFP8 — 2P2D wide-EP DP16

```bash
# PREFILL — master (node0, DP ranks 0–7)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $PREFILL_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --no-async-scheduling \
    --no-disable-nccl-for-dp-synchronization \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'

# PREFILL — child (node1, headless, DP ranks 8–15)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --no-async-scheduling

# DECODE — master (node2, DP ranks 0–7)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $DECODE_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --no-async-scheduling \
    --no-disable-nccl-for-dp-synchronization \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'

# DECODE — child (node3, headless, DP ranks 8–15)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --no-async-scheduling
```

### GSM8K evaluation

```bash
lm_eval --model local-completions \
    --tasks gsm8k \
    --model_args "model=/data/models2/MiniMax-M3-MXFP8,base_url=http://127.0.0.1:10001/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True,timeout=7200" \
    --limit 250
```

## Test Result

MiniMax-M3-MXFP8, MoRIIO 2P2D wide-EP DP16 (proxy). GSM8K flexible-extract, threshold 0.80.

| Variant | Health | GSM8K exact_match |
| --- | --- | --- |
| No fix (wave 0 never starts on headless ranks) | Fail (no `START_DP_WAVE`; requests hang) | — |
| This fix | Pass | **0.90** (PASS) |
