### PR TITLE
[Misc] Emit OpenTelemetry JSON logs via VLLM_LOGGING_FORMAT

### DIFF
--- a/docs/design/otel_json_stdout.md
+++ b/docs/design/otel_json_stdout.md
@@ -1,0 +1,36 @@
+# OpenTelemetry JSON stdout profile
+
+The JSON log formatter emits one JSON object per line. This is an application
+stdout profile of the OpenTelemetry Logs Data Model; it is not OTLP/JSON. A log
+collector must apply the mapping below before exporting OTLP.
+
+## Record contract
+
+| JSON field | Type | OpenTelemetry field |
+| --- | --- | --- |
+| `timestamp` | RFC 3339 UTC string | `Timestamp` |
+| `severity_text` | string | `SeverityText` |
+| `severity_number` | integer | `SeverityNumber` |
+| `body` | string | `Body` |
+| `service.name` | string | `Resource.Attributes["service.name"]` |
+| `logger` | string | `InstrumentationScope.Name` |
+| `trace_id` | optional 32-character lowercase hex string | `TraceId` |
+| `span_id` | optional 16-character lowercase hex string | `SpanId` |
+| all other fields | any JSON value | `Attributes` |
+
+Collectors must parse `timestamp`, move `service.name` to the resource, move
+`logger` to the instrumentation scope, decode valid trace and span identifiers,
+and retain every other application field as a log attribute.
+
+Severity numbers use the OpenTelemetry bands: `TRACE=1`, `DEBUG=5`, `INFO=9`,
+`WARN=13`, `ERROR=17`, and `FATAL=21`. Zap `DPANIC` and `PANIC` retain their
+defined intermediate values, 18 and 19. `severity_text` uses these uppercase
+names; `DPANIC` and `PANIC` are retained where the source runtime exposes them.
+
+Example:
+
+```json
+{"timestamp":"2026-09-11T11:34:56.123Z","severity_text":"INFO","severity_number":9,"body":"request complete","logger":"vllm.engine","service.name":"vllm","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7"}
+```
+
+Trace fields are omitted when no valid span is active.

--- a/examples/features/logging_configuration.md
+++ b/examples/features/logging_configuration.md
@@ -3,7 +3,7 @@
 vLLM leverages Python's `logging.config.dictConfig` functionality to enable
 robust and flexible configuration of the various loggers used by vLLM.
 
-vLLM offers two environment variables that can be used to accommodate a range
+vLLM offers environment variables that can be used to accommodate a range
 of logging configurations that range from simple-and-inflexible to
 more-complex-and-more-flexible.
 
@@ -11,6 +11,8 @@ more-complex-and-more-flexible.
     - Set `VLLM_CONFIGURE_LOGGING=0` (leaving `VLLM_LOGGING_CONFIG_PATH` unset)
 - vLLM's default logging configuration (simple and inflexible)
     - Leave `VLLM_CONFIGURE_LOGGING` unset or set `VLLM_CONFIGURE_LOGGING=1`
+- OpenTelemetry JSON logs on stdout
+    - Set `VLLM_LOGGING_FORMAT=json` (optional OpenTelemetry service name override)
 - Fine-grained custom logging configuration (more complex, more flexible)
     - Leave `VLLM_CONFIGURE_LOGGING` unset or set `VLLM_CONFIGURE_LOGGING=1` and
     set `VLLM_LOGGING_CONFIG_PATH=<path-to-logging-config.json>`
@@ -43,6 +45,21 @@ schema](https://docs.python.org/3/library/logging.config.html#dictionary-schema-
 
 If `VLLM_LOGGING_CONFIG_PATH` is specified, but `VLLM_CONFIGURE_LOGGING` is
 disabled, an error will occur while starting vLLM.
+
+### `VLLM_LOGGING_FORMAT`
+
+`VLLM_LOGGING_FORMAT` selects the encoding of the default vLLM root logger.
+
+- `text` (default): human-readable formatter, with color when the stream is a TTY
+- `json`: one OpenTelemetry Logs Data Model JSON object per line, including
+  `trace_id` and `span_id` when a span is active on the current context.
+  `service.name` follows OpenTelemetry environment precedence:
+  `OTEL_SERVICE_NAME`, then `service.name` in `OTEL_RESOURCE_ATTRIBUTES`, then
+  the `vllm` fallback.
+
+```bash
+VLLM_LOGGING_FORMAT=json vllm serve mistralai/Mistral-7B-v0.1 --max-model-len 2048
+```
 
 ## Examples
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -22,7 +22,7 @@ from vllm.logger import (
     enable_trace_function_call,
     init_logger,
 )
-from vllm.logging_utils import NewLineFormatter
+from vllm.logging_utils import NewLineFormatter, OTelJSONFormatter
 from vllm.logging_utils.dump_input import prepare_object_to_dump
 
 
@@ -232,6 +232,112 @@ def test_custom_logging_config_causes_an_error_if_configure_logging_is_off(monke
         assert other_logger.handlers != root_logger.handlers
         assert other_logger.level != root_logger.level
         assert other_logger.propagate
+
+
+def test_json_logging_format_uses_otel_formatter(monkeypatch):
+    monkeypatch.setenv("VLLM_LOGGING_FORMAT", "json")
+    monkeypatch.setenv("VLLM_LOGGING_COLOR", "0")
+    _configure_vllm_root_logger()
+
+    formatter = logging.getLogger("vllm").handlers[0].formatter
+    assert isinstance(formatter, OTelJSONFormatter)
+
+
+@pytest.mark.parametrize(
+    ("level", "severity_text", "severity_number"),
+    [
+        (logging.DEBUG, "DEBUG", 5),
+        (logging.INFO, "INFO", 9),
+        (logging.WARNING, "WARN", 13),
+        (logging.ERROR, "ERROR", 17),
+        (logging.CRITICAL, "FATAL", 21),
+    ],
+)
+def test_otel_json_formatter_schema_and_severity(
+    level: int, severity_text: str, severity_number: int, monkeypatch
+):
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+    monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+    formatter = OTelJSONFormatter()
+    record = logging.LogRecord(
+        name="vllm.engine",
+        level=level,
+        pathname="engine.py",
+        lineno=10,
+        msg="kv cache full",
+        args=(),
+        exc_info=None,
+    )
+    payload = json.loads(formatter.format(record))
+    assert payload["body"] == "kv cache full"
+    assert payload["severity_text"] == severity_text
+    assert payload["severity_number"] == severity_number
+    assert payload["logger"] == "vllm.engine"
+    assert payload["service.name"] == "vllm"
+    assert payload["timestamp"].endswith("Z")
+    assert "trace_id" not in payload
+    assert "span_id" not in payload
+
+
+def test_otel_json_formatter_service_name_override(monkeypatch):
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "rhoai-vllm")
+    monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=ignored")
+    formatter = OTelJSONFormatter()
+    record = logging.LogRecord(
+        name="vllm",
+        level=logging.INFO,
+        pathname="logger.py",
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    payload = json.loads(formatter.format(record))
+    assert payload["service.name"] == "rhoai-vllm"
+
+
+def test_otel_json_formatter_service_name_from_resource_attributes(monkeypatch):
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+    monkeypatch.setenv(
+        "OTEL_RESOURCE_ATTRIBUTES",
+        "deployment.environment.name=dev,service.name=rhoai%2Dvllm",
+    )
+    formatter = OTelJSONFormatter()
+    record = logging.LogRecord(
+        name="vllm",
+        level=logging.INFO,
+        pathname="logger.py",
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["service.name"] == "rhoai-vllm"
+
+
+def test_otel_json_formatter_injects_active_span():
+    pytest.importorskip("opentelemetry.sdk")
+    from opentelemetry.sdk.trace import TracerProvider
+
+    tracer = TracerProvider().get_tracer("vllm-test")
+    formatter = OTelJSONFormatter()
+    record = logging.LogRecord(
+        name="vllm",
+        level=logging.INFO,
+        pathname="logger.py",
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    with tracer.start_as_current_span("unit") as span:
+        payload = json.loads(formatter.format(record))
+        ctx = span.get_span_context()
+    assert payload["trace_id"] == format(ctx.trace_id, "032x")
+    assert payload["span_id"] == format(ctx.span_id, "016x")
 
 
 def test_prepare_object_to_dump():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     VLLM_LOGGING_STREAM: str = "ext://sys.stdout"
     VLLM_LOGGING_CONFIG_PATH: str | None = None
     VLLM_LOGGING_COLOR: str = "auto"
+    VLLM_LOGGING_FORMAT: Literal["text", "json"] = "text"
     NO_COLOR: bool = False
     VLLM_LOG_STATS_INTERVAL: float = 10.0
     VLLM_TRACE_FUNCTION: int = 0
@@ -839,6 +840,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Controls colored logging output. Options: "auto" (default, colors when terminal),
     # "1" (always use colors), "0" (never use colors)
     "VLLM_LOGGING_COLOR": lambda: os.getenv("VLLM_LOGGING_COLOR", "auto"),
+    # Log record encoding. "text" (default) uses the human-readable formatter;
+    # "json" emits OpenTelemetry Logs Data Model JSON on the configured stream.
+    "VLLM_LOGGING_FORMAT": lambda: os.getenv("VLLM_LOGGING_FORMAT", "text").lower(),
     # Standard unix flag for disabling ANSI color codes
     "NO_COLOR": lambda: os.getenv("NO_COLOR", "0") != "0",
     # If set, vllm will log stats at this interval in seconds
@@ -2313,6 +2317,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_LOGGING_STREAM",
         "VLLM_LOGGING_CONFIG_PATH",
         "VLLM_LOGGING_COLOR",
+        "VLLM_LOGGING_FORMAT",
         "VLLM_LOG_STATS_INTERVAL",
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",
         "VLLM_TUNED_CONFIG_FOLDER",

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -38,6 +38,13 @@ def _use_color() -> bool:
     return False
 
 
+def _formatter_name() -> str:
+    """Select the default formatter. JSON is opt-in to keep TTY text logs."""
+    if envs.VLLM_LOGGING_FORMAT == "json":
+        return "vllm_json"
+    return "vllm_color" if _use_color() else "vllm"
+
+
 DEFAULT_LOGGING_CONFIG: dict[str, dict[str, Any] | Any] = {
     "formatters": {
         "vllm": {
@@ -50,12 +57,15 @@ DEFAULT_LOGGING_CONFIG: dict[str, dict[str, Any] | Any] = {
             "datefmt": _DATE_FORMAT,
             "format": _FORMAT,
         },
+        "vllm_json": {
+            "class": "vllm.logging_utils.OTelJSONFormatter",
+        },
     },
     "handlers": {
         "vllm": {
             "class": "logging.StreamHandler",
-            # Choose formatter based on color setting.
-            "formatter": "vllm_color" if _use_color() else "vllm",
+            # Choose formatter based on format/color setting.
+            "formatter": _formatter_name(),
             "level": envs.VLLM_LOGGING_LEVEL,
             "stream": envs.VLLM_LOGGING_STREAM,
         },
@@ -171,7 +181,7 @@ def _configure_vllm_root_logger() -> None:
         # Refresh these values in case env vars have changed.
         vllm_handler["level"] = envs.VLLM_LOGGING_LEVEL
         vllm_handler["stream"] = envs.VLLM_LOGGING_STREAM
-        vllm_handler["formatter"] = "vllm_color" if _use_color() else "vllm"
+        vllm_handler["formatter"] = _formatter_name()
 
         vllm_loggers = logging_config["loggers"]["vllm"]
         vllm_loggers["level"] = envs.VLLM_LOGGING_LEVEL

--- a/vllm/logging_utils/__init__.py
+++ b/vllm/logging_utils/__init__.py
@@ -8,11 +8,13 @@ from vllm.logging_utils.access_log_filter import (
 from vllm.logging_utils.formatter import ColoredFormatter, NewLineFormatter
 from vllm.logging_utils.lazy import lazy
 from vllm.logging_utils.log_time import logtime
+from vllm.logging_utils.oteljson import OTelJSONFormatter
 from vllm.logging_utils.torch_tensor import tensors_str_no_data
 
 __all__ = [
     "NewLineFormatter",
     "ColoredFormatter",
+    "OTelJSONFormatter",
     "UvicornAccessLogFilter",
     "create_uvicorn_log_config",
     "lazy",

--- a/vllm/logging_utils/oteljson.py
+++ b/vllm/logging_utils/oteljson.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""OpenTelemetry Logs Data Model JSON formatter."""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import unquote
+
+_SEVERITY = {
+    logging.DEBUG: ("DEBUG", 5),
+    logging.INFO: ("INFO", 9),
+    logging.WARNING: ("WARN", 13),
+    logging.ERROR: ("ERROR", 17),
+    logging.CRITICAL: ("FATAL", 21),
+}
+
+
+def _severity(levelno: int) -> tuple[str, int]:
+    if levelno >= logging.CRITICAL:
+        return _SEVERITY[logging.CRITICAL]
+    if levelno >= logging.ERROR:
+        return _SEVERITY[logging.ERROR]
+    if levelno >= logging.WARNING:
+        return _SEVERITY[logging.WARNING]
+    if levelno >= logging.INFO:
+        return _SEVERITY[logging.INFO]
+    return _SEVERITY[logging.DEBUG]
+
+
+def _trace_fields() -> dict[str, str]:
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return {}
+    ctx = trace.get_current_span().get_span_context()
+    if not ctx.is_valid:
+        return {}
+    return {
+        "trace_id": format(ctx.trace_id, "032x"),
+        "span_id": format(ctx.span_id, "016x"),
+    }
+
+
+def _service_name() -> str:
+    if service_name := os.getenv("OTEL_SERVICE_NAME"):
+        return service_name
+
+    for item in os.getenv("OTEL_RESOURCE_ATTRIBUTES", "").split(","):
+        key, separator, value = item.partition("=")
+        if (
+            separator
+            and unquote(key) == "service.name"
+            and (decoded_value := unquote(value))
+        ):
+            return decoded_value
+
+    return "vllm"
+
+
+class OTelJSONFormatter(logging.Formatter):
+    """Emit one JSON object per log record using OTel field names."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        severity_text, severity_number = _severity(record.levelno)
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "severity_text": severity_text,
+            "severity_number": severity_number,
+            "body": record.getMessage(),
+            "logger": record.name,
+            "service.name": _service_name(),
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        payload.update(_trace_fields())
+        return json.dumps(payload, default=str)


### PR DESCRIPTION
## Summary
- Add an `OTelJSONFormatter` that writes one OpenTelemetry Logs Data Model JSON object per line (`timestamp`, `body`, `severity_text`, `severity_number`, `service.name`), including `trace_id`/`span_id` when a span is on the current context.
- Opt in with `VLLM_LOGGING_FORMAT=json` so the default TTY/text formatter is unchanged. `OTEL_SERVICE_NAME` overrides `service.name`.
- This is not a duplicate of #32761. That PR adds Python-logging JSON (`asctime`, `levelname`, `message`) via `python-json-logger` and does not inject trace context or OTel severity numbers. This change uses stdlib `json` and the OTel field names needed by log pipelines that correlate with traces.

## Test plan
- [ ] `uvx ruff check` / `uvx ruff format --check` on the touched files (passed locally)
- [ ] Formatter smoke test: schema, severity mapping, and live span injection via `opentelemetry.sdk` (passed locally without torch)
- [ ] `pytest tests/test_logger.py -k otel` in CI (needs the full vLLM test env / torch)
- [ ] `VLLM_LOGGING_FORMAT=json vllm serve ...` emits JSON on stdout; unset keeps text logs
- [ ] With an active OTel span, log lines include `trace_id` and `span_id`

N/A for model eval: logging format only, no change to model output or serving accuracy.

AI assistance was used to draft the formatter, tests, and this PR.