### PR TITLE
Enable NVFP4 KV cache on SM120 (consumer Blackwell)

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -490,6 +490,9 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is not None and kv_cache_dtype.startswith("nvfp4"):
+            if current_platform.is_device_capability_family(120):
+                # SM120: XQA decode (native nvfp4-KV) + fa2 prefill.
+                return supports_trtllm_attention(is_prefill=False)
             return (
                 current_platform.is_device_capability_family(100)
                 and supports_trtllm_attention(is_prefill=True)
@@ -764,7 +767,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype.startswith("nvfp4")
             if self.is_kvcache_nvfp4:
-                if (
+                if current_platform.is_device_capability_family(120):
+                    # SM120: XQA decode + fa2 prefill.
+                    pass
+                elif (
                     force_use_trtllm_attention() is False
                     or not supports_trtllm_attention(is_prefill=True)
                     or not supports_trtllm_attention(is_prefill=False)


### PR DESCRIPTION
SM120 (RTX PRO 4500/5090, compute 12.0) ships FlashInfer XQA nvfp4-KV decode kernels (xqa.py asserts cc==12) but vLLM gates --kv-cache-dtype nvfp4 to SM100 only. The SM120 path uses XQA decode + fa2 prefill, mirroring the existing SM90 XQA pattern.

Fixes: kv_cache_dtype not supported on SM120
Related: #49011, #43562




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

