### PR TITLE
[ROCm][MoE] Fix gfx950 block scale swizzle for AITER Triton MXFP4 W4A16

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a16_moe.py
@@ -152,6 +152,9 @@ def aiter_triton_kernel_w4a16_moe_forward(
     score_mode: str | None = None,
 ):
     assert quant_config is not None and rocm_aiter_ops.is_enabled()
+    from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+        should_use_cdna4_mx_scale_swizzle,
+    )
     from vllm.platforms.rocm import on_gfx1250
 
     try:
@@ -245,6 +248,11 @@ def aiter_triton_kernel_w4a16_moe_forward(
     # SILU: silu(gate) * up — same kernel, just no "+1" residual in swiglu.
     swiglu_add_residual = activation != MoEActivation.SILU
 
+    # Weight loading already swizzled the block scales on gfx950, so the kernel
+    # has to be told; the load-time swizzle and this gate must agree or the
+    # kernel indexes a swizzled buffer as if it were linear.
+    swz = "CDNA4_SCALE" if should_use_cdna4_mx_scale_swizzle() else None
+
     intermediate = moe_gemm_a16w4(
         hidden_states,
         w1_data,
@@ -256,7 +264,7 @@ def aiter_triton_kernel_w4a16_moe_forward(
         routing_data,
         gather_indx=gather_idx,
         gammas=gammas if apply_router_weight_on_input else None,
-        swizzle_mx_scale=None,
+        swizzle_mx_scale=swz,
         apply_swiglu=True,
         alpha=swiglu_alpha,
         limit=swiglu_limit,
@@ -276,7 +284,7 @@ def aiter_triton_kernel_w4a16_moe_forward(
         routing_data,
         scatter_indx=scatter_idx,
         gammas=None if apply_router_weight_on_input else gammas,
-        swizzle_mx_scale=None,
+        swizzle_mx_scale=swz,
         unpadded_N=unpadded_N_w2,
         unpadded_K=unpadded_K_w2,
     )


### PR DESCRIPTION
## Summary

The AITER Triton MXFP4 W4A16 backend crashes the process on gfx950 (MI355) with a
GPU memory access fault, because it tells the kernel its block scales are not
swizzled while weight loading has already swizzled them. This passes the existing
CDNA4 swizzle gate through to the kernel, which makes the path work on gfx950.

## The failure

Failing test: 
`tests/kernels/moe/test_ocp_mx_moe.py::test_rocm_mxfp4_moe_oracle[16-256-256-8-4-AITER_TRITON_MXFP4_BF16]`

CI failure: [AMD CI #12514](https://buildkite.com/vllm/amd-ci/builds/12514/list?jid=01a05c92-2f80-48ef-9509-81f3c2ff0de5&tab=output)

ROCm names the faulting kernel directly in the runtime message: aiter's Triton
`moe_gemm_a16w4`, entered on the first of the two GEMM calls in the expert
forward pass.

## Root cause

On gfx950 with TP <= 2, `_swizzle_mxfp4` stores the mxfp4 block scales in the
CDNA4 swizzled layout at weight load time. The kernel has to be told, and the
gate that decides this is shared: the docstring of
`should_use_cdna4_mx_scale_swizzle` states that the load-time swizzle and the
kernel argument must agree.

The a8w4 sibling path does agree, it passes `swizzle_mx_scale=swz`. The a16w4
path introduced in [#50622](https://github.com/vllm-project/vllm/pull/50622)
hardcoded `swizzle_mx_scale=None` at both of its GEMM call sites, so the kernel
indexed a swizzled scale buffer as if it were linear and walked off the end of
the allocation.

This is also why the original validation looked clean: it was run on MI300X
(gfx942), where the gate is false and no swizzle is applied, so `None` was the
correct value there. Only gfx950 swizzles, and only gfx950 faults.

## The fix

Compute the same gate the a8w4 path uses and pass it to both `moe_gemm_a16w4`
calls. When the gate is false non-gfx950, or TP >= 4 where the CDNA4 layout is
not used, the value stays `None` exactly as before, so gfx942 and gfx1250 keep
their current behaviour.

## Test results

Hardware: AMD MI355X (gfx950). 
12 passed and 0 skipped

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

