### PR TITLE
[ROCm] Fix APU unified-memory accounting across GTT and host pressure

### DIFF
--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from vllm_test_utils.monitor import monitor
 
@@ -89,11 +90,27 @@ def test_memory_profiling():
     lib.cudaFree(handle2)
 
 
-def test_memory_snapshot_uses_psutil_on_integrated_gpu():
-    """On integrated (UMA) GPUs, free_memory should come from psutil."""
-    mock_cuda_free = 40 * 1024**3
+@pytest.mark.parametrize(
+    (
+        "is_rocm",
+        "mock_accelerator_free",
+        "mock_psutil_available",
+        "expected_free",
+    ),
+    [
+        (False, 40 * 1024**3, 100 * 1024**3, 100 * 1024**3),
+        (True, 40 * 1024**3, 100 * 1024**3, 40 * 1024**3),
+        (True, 100 * 1024**3, 40 * 1024**3, 40 * 1024**3),
+    ],
+)
+def test_memory_snapshot_on_integrated_gpu(
+    is_rocm: bool,
+    mock_accelerator_free: int,
+    mock_psutil_available: int,
+    expected_free: int,
+):
+    """Integrated GPUs should use their platform-specific available memory."""
     mock_cuda_total = 120 * 1024**3
-    mock_psutil_available = 100 * 1024**3
 
     with (
         patch("vllm.utils.mem_utils.current_platform") as mock_platform,
@@ -101,10 +118,11 @@ def test_memory_snapshot_uses_psutil_on_integrated_gpu():
         patch("torch.accelerator") as mock_accelerator,
     ):
         mock_accelerator.get_memory_info.return_value = (
-            mock_cuda_free,
+            mock_accelerator_free,
             mock_cuda_total,
         )
         mock_platform.is_integrated_gpu.return_value = True
+        mock_platform.is_rocm.return_value = is_rocm
         mock_platform.memory_stats.return_value = {
             "allocated_bytes.all.peak": 0,
         }
@@ -117,8 +135,9 @@ def test_memory_snapshot_uses_psutil_on_integrated_gpu():
 
         snapshot = MemorySnapshot(device="cuda:0")
 
-        assert snapshot.free_memory == mock_psutil_available
+        assert snapshot.free_memory == expected_free
         assert snapshot.total_memory == mock_cuda_total
+        assert snapshot.cuda_memory >= 0
         mock_psutil.virtual_memory.assert_called_once()
 
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -863,6 +863,10 @@ class RocmPlatform(Platform):
         return torch.cuda.get_device_properties(device_id).total_memory
 
     @classmethod
+    def is_integrated_gpu(cls, device_id: int = 0) -> bool:
+        return bool(torch.cuda.get_device_properties(device_id).is_integrated)
+
+    @classmethod
     def apply_config_platform_defaults(cls, vllm_config: "VllmConfig") -> None:
         from vllm._aiter_ops import rocm_aiter_ops
 

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -146,13 +146,16 @@ class MemorySnapshot:
 
         self.free_memory, self.total_memory = torch.accelerator.get_memory_info(device)
         if current_platform.is_integrated_gpu(device.index):
-            # On UMA (Unified Memory Architecture) platforms where CPU and
-            # GPU share physical memory (e.g. GH200, DGX Spark, Jetson Orin),
-            # cudaMemGetInfo underreports free memory because it does not
-            # account for reclaimable OS memory (page cache, buffers).
-            # Use psutil to get the true available memory.
+            host_available_memory = psutil.virtual_memory().available
+            # On NVIDIA UMA systems, cudaMemGetInfo does not account for
+            # reclaimable OS memory. On ROCm APUs, HIP's free memory is also
+            # bounded by the configured GTT limit, so use the lower bound.
             # https://docs.nvidia.com/cuda/cuda-for-tegra-appnote/#estimating-total-allocatable-device-memory-on-an-integrated-gpu-device
-            self.free_memory = psutil.virtual_memory().available
+            self.free_memory = (
+                min(self.free_memory, host_available_memory)
+                if current_platform.is_rocm()
+                else host_available_memory
+            )
 
         self.cuda_memory = self.total_memory - self.free_memory
 


### PR DESCRIPTION
## Summary

`RocmPlatform` does not override `is_integrated_gpu()`, so AMD APUs are treated
like discrete GPUs. This prevents vLLM from accounting for host allocations
that consume shared physical memory and disables the existing UMA
memory-pressure cache release.

This PR:

- Detects ROCm APUs using HIP's `is_integrated` device property.
- Calculates usable free memory as:

  ```python
  min(hip_free_memory, psutil.virtual_memory().available)
  ```

- Adds tests for GTT-limited and host-memory-limited configurations.

The minimum is required because ROCm APU allocations are constrained by both
the configured GTT capacity and currently available system RAM.

## Relationship to existing PRs

This extends #50320, which adds the integrated-GPU detection but uses the
existing NVIDIA `psutil`-only policy. On a GTT-limited Strix Halo system, that
can report more free memory than the GPU total and produce negative used-memory
accounting.

This also differs from #40963 by relying on HIP's device property and memory
counters instead of DRM/sysfs heuristics or fixed reserves.

## Validation

Tested on:

```text
AMD Ryzen AI MAX+ 395 / Radeon 8060S (gfx1151)
128 GiB unified memory
512 MiB BIOS carveout
~94.19 GiB effective GTT capacity
```

Validated both limiting cases:

- GPU/GTT pressure: allocations tested through 80 GiB.
- Host pressure: combined 40 GiB host and 32 GiB GPU allocations.
- Docker: latest vLLM built and tested using the ROCm 10.1 RDNA nightly image.

In every case, the snapshot selected the lower memory bound, remained within
`0 <= free <= total`, and returned to baseline after allocations were released.

Commands:

```bash
.venv/bin/python -m pytest tests/utils_/test_mem_utils.py -v \
  --confcutdir=tests/utils_

.venv/bin/pre-commit run --files \
  vllm/platforms/rocm.py \
  vllm/utils/mem_utils.py \
  tests/utils_/test_mem_utils.py
```

Results:

```text
pytest: 5 passed
pre-commit: all applicable hooks passed
```

## Model evaluation

Not applicable. This changes startup memory accounting only and does not modify
model, kernel, dtype, or numerical output paths.

## AI assistance

AI assistance was used for implementation, testing, and drafting. The final
changes were reviewed before submission.
