### PR TITLE
[Bugfix][Parser] Gemma4: parse tool calls whose opener omits the `call:` marker

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -897,3 +897,99 @@ class TestStreamingExtraction:
         }
 
         assert args_text.count("replace_all") == 1
+
+
+class TestOpenerVariants:
+    """Openers the model emits that the documented grammar does not describe.
+
+    Gemma 4's chat template writes ``<|tool_call>call:name{...}``, and every
+    official artifact uses that form. Checkpoints are nonetheless observed
+    emitting the name with a bare ``:``, with no marker at all, or after a
+    ``-``. Before this was handled the FSM parked in TOOL_PREAMBLE, which has
+    no content_events entry, so the whole span produced no tool call and no
+    content either.
+
+    Reproduces https://github.com/vllm-project/vllm/issues/53431
+    """
+
+    ARGS = 'location:<|"|>London<|"|>'
+
+    def test_bare_colon_opener(self, parser, mock_request):
+        """<|tool_call>:name{...} parses the same as the documented form."""
+        text = f"<|tool_call>:get_weather{{{self.ARGS}}}<tool_call|>"
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_weather"
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "location": "London"
+        }
+
+    def test_unmarked_opener(self, parser, mock_request):
+        """<|tool_call>name{...} with no marker at all still parses."""
+        text = f"<|tool_call>get_weather{{{self.ARGS}}}<tool_call|>"
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called
+        assert result.tool_calls[0].function.name == "get_weather"
+
+    def test_documented_opener_unchanged(self, parser, mock_request):
+        """The specified call: form must behave exactly as before."""
+        text = f"<|tool_call>call:get_weather{{{self.ARGS}}}<tool_call|>"
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called
+        assert result.tool_calls[0].function.name == "get_weather"
+
+    def test_bare_colon_with_paren_args(self, parser, mock_request):
+        """The bare opener composes with the round-bracket argument form."""
+        text = f"<|tool_call>:get_weather({self.ARGS})<tool_call|>"
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.tools_called
+        assert result.tool_calls[0].function.name == "get_weather"
+
+    def test_empty_tool_call_still_yields_nothing(self, parser, mock_request):
+        """An opener with no body must not become a tool call."""
+        result = parser.extract_tool_calls("<|tool_call><tool_call|>", mock_request)
+
+        assert not result.tools_called
+        assert not result.tool_calls
+
+    def test_colon_in_plain_content_untouched(self, parser, mock_request):
+        """A colon outside a tool span must not start or split a tool call.
+
+        Guards the alternative fix of adding a bare ":" lexer terminal, which
+        would put a colon in literal_first_chars for every state.
+        """
+        text = "Ratio is 3:1 today, no tools involved."
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert not result.tools_called
+        assert result.content == text
+
+    def test_streaming_bare_colon_opener(self, parser, mock_request):
+        """The bare opener streams the same deltas as the documented form."""
+        chunks = [
+            "<|tool_call>",
+            ":get_weather{",
+            'location:<|"|>London',
+            '<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+
+        assert self._collect_function_name(results) == "get_weather"
+        assert json.loads(self._collect_arguments(results)) == {"location": "London"}
+
+    _SPECIAL_TOKEN_IDS = TestStreamingExtraction._SPECIAL_TOKEN_IDS
+    _simulate_streaming = TestStreamingExtraction._simulate_streaming
+    _collect_arguments = TestStreamingExtraction._collect_arguments
+    _collect_function_name = TestStreamingExtraction._collect_function_name

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -394,6 +394,16 @@ class ParserEngine(Parser):
             return json.dumps(args, ensure_ascii=False)
         return args_json
 
+    def _normalize_tool_name(self, name: str) -> str:
+        """Apply the grammar's tool name normalizer, if it declares one.
+
+        Returns *name* unchanged when the config sets no
+        ``tool_name_normalizer``, so grammars that do not need one are
+        unaffected.
+        """
+        normalizer = self.parser_engine_config.tool_name_normalizer
+        return normalizer(name) if normalizer is not None else name
+
     def _is_valid_tool_name(self, name: str) -> bool:
         if not self.parser_engine_config.validate_tool_names:
             return True
@@ -797,8 +807,14 @@ class ParserEngine(Parser):
             state.history_tool_call_cnt += 1
 
     def _handle_tool_name(self, event: SemanticEvent) -> None:
+        """Append a ``TOOL_NAME`` fragment to the slot's accumulated name.
+
+        The name arrives in pieces across deltas, so normalization runs on the
+        accumulated value rather than on each fragment.
+        """
         idx = event.tool_index
-        self._tool_slots[idx].name += event.value
+        slot = self._tool_slots[idx]
+        slot.name = self._normalize_tool_name(slot.name + event.value)
 
     def _emit_name_delta(
         self,

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -100,6 +100,8 @@ class ParserEngineConfig:
     # Reject tool calls whose names are absent from the request tools.
     validate_tool_names: bool = False
 
+    tool_name_normalizer: Callable[[str], str] | None = None
+
     @cached_property
     def terminal_defs(self):
         from vllm.parser.engine.incremental_lexer import terminals_from_literals

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -292,8 +292,24 @@ def _gemma4_arg_converter(raw_args: str, partial: bool) -> str:
     return json.dumps(parsed, ensure_ascii=False)
 
 
+def _gemma4_strip_opener_marker(name: str) -> str:
+    """Drop an opener marker the grammar did not consume.
+
+    Gemma 4 is specified to write ``call:`` before the tool name, and that form
+    is a terminal, so it never reaches here. Checkpoints are observed emitting a
+    bare ``:``, a ``-``, or nothing at all, and those arrive glued to the front
+    of the accumulated name.
+    """
+    return name.strip().lstrip(":-").strip()
+
+
 @functools.cache
 def gemma4_config() -> ParserEngineConfig:
+    """Build the parser engine config for Gemma 4's reasoning and tool syntax.
+
+    Cached, because the returned config owns a lexer shape that is expensive to
+    rebuild and is shared by every parser instance.
+    """
     return ParserEngineConfig(
         name="gemma4",
         initial_state=ParserState.CONTENT,
@@ -348,6 +364,14 @@ def gemma4_config() -> ParserEngineConfig:
                 ParserState.TOOL_NAME,
                 (),
             ),
+            (ParserState.TOOL_PREAMBLE, "OPEN_BRACE"): Transition(
+                ParserState.TOOL_ARGS,
+                (),
+            ),
+            (ParserState.TOOL_PREAMBLE, "OPEN_PAREN"): Transition(
+                ParserState.TOOL_ARGS,
+                (),
+            ),
             (ParserState.TOOL_NAME, "OPEN_BRACE"): Transition(
                 ParserState.TOOL_ARGS,
                 (),
@@ -379,10 +403,12 @@ def gemma4_config() -> ParserEngineConfig:
         content_events={
             ParserState.CONTENT: EventType.TEXT_CHUNK,
             ParserState.REASONING: EventType.REASONING_CHUNK,
+            ParserState.TOOL_PREAMBLE: EventType.TOOL_NAME,
             ParserState.TOOL_NAME: EventType.TOOL_NAME,
             ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
         },
         arg_converter=_gemma4_arg_converter,
+        tool_name_normalizer=_gemma4_strip_opener_marker,
         tool_args_json=False,
         arg_structural_chars=frozenset(",:{}[]<"),
         preserve_tokens=frozenset({STRING_DELIM}),


### PR DESCRIPTION
## Purpose

Fixes #53431.

Gemma 4 sometimes writes a tool call without the documented `call:` marker. When it does, the parser discards the entire span: no tool call, no content, no error and no metric. The reporter measured 386 lost turns over 21 days in production, about 0.4% of tool-calling requests.

`vllm/parser/gemma4.py` defines one route out of `TOOL_PREAMBLE` into `TOOL_NAME` and its literal is `"call:"`. Anything else leaves the FSM parked in `TOOL_PREAMBLE`, and that state has no entry in `content_events`, so `_emit_for_state` returns `[]` for every character until the closing tag. The missing transition is why it breaks. The missing `content_events` entry is why it is silent, and that is the more consequential of the two.

The same shape exists in `qwen3.py`, `deepseek_v32.py`, `deepseek_v4.py`, `minimax_m2.py` and `kimi_k2.py`. No config in the repo maps `TOOL_PREAMBLE` to a content event, so a stuck parse is silent everywhere, not only here.

### Why this does not add a terminal per variant

The issue describes two opener forms. The raw capture in [this comment](https://github.com/vllm-project/vllm/issues/53431#issuecomment-5401799341), taken by bypassing the parser with `/tokenize` then `/v1/completions` at `skip_special_tokens: false`, contains three opener markers plus a separate variation in the arguments:

| Captured | What varies | Status |
| --- | --- | --- |
| `<\|tool_call>call:search_files` | the documented marker | parses today |
| `<\|tool_call>call:terminal(command:` | round bracket arguments | fixed by #53657, merged |
| `<\|tool_call>:search_files{pattern:` | bare colon | this issue |
| `<\|tool_call>- starting-task-overview` | dash | not covered by any open PR |

In this PR we take the following approach: let `TOOL_PREAMBLE` emit the text it is already consuming. `TOOL_PREAMBLE` gains a `content_events` entry, `OPEN_BRACE` and `OPEN_PAREN` gain transitions out of it so the name is bounded by the argument bracket, and a new optional `tool_name_normalizer` on `ParserEngineConfig` lets a grammar strip a marker the lexer did not consume.

Credit where it is due: #53444 by @wuhangxian correctly fixes the bare colon and its tests are sound. This separate approach however addresses other variations as well for Gemma4. 

## Test Plan

```
pytest tests/tool_parsers/test_gemma4_tool_parser.py
```

Plus the reproduction script from the issue body, run unmodified.

7 tests added in a new `TestOpenerVariants` class: the bare colon opener non-streaming and streaming, an unmarked opener, the documented opener unchanged, the bare colon with round bracket arguments, an empty tool call yielding nothing, and a colon in plain content that must not start or split a tool call. That last one guards the alternative fix.

## Test Result

```
61 passed
```

The 54 existing tests are unchanged and still pass.

The reproduction from the issue, run unmodified. Before:

```
--- DOCUMENTED  call: ---
  non-streaming  : {'tools_called': True, 'tool_calls': [('get_weather', '{"location": "London"}')], 'content': None}
--- BARE           : ---
  non-streaming  : {'tools_called': False, 'tool_calls': [], 'content': None}
  streaming      : {'tool_calls': [], 'content': ''}
```

After:

```
--- BARE           : ---
  non-streaming  : {'tools_called': True, 'tool_calls': [('get_weather', '{"location": "London"}')], 'content': None}
  streaming      : {'tool_calls': [('get_weather', '{"location": "London"}')], 'content': ''}
```