### PR TITLE
[Bugfix][Spec Decode] Honor configured tokenizer revisions in TLI mapping

### DIFF
--- a/tests/v1/spec_decode/test_draft_model.py
+++ b/tests/v1/spec_decode/test_draft_model.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.v1.spec_decode import draft_model as draft_model_module
+from vllm.v1.spec_decode.draft_model import DraftModelProposer
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_heterogeneous_vocab_tokenizers_honor_model_configs(monkeypatch):
+    target_config = MagicMock(
+        tokenizer="target-tokenizer",
+        tokenizer_mode="mistral",
+        tokenizer_revision="target-revision",
+    )
+    draft_config = MagicMock(
+        model="draft-model",
+        tokenizer="draft-model",
+        tokenizer_revision="target-revision",
+        revision="draft-revision",
+    )
+    speculative_config = MagicMock(
+        use_heterogeneous_vocab=True,
+        target_model_config=target_config,
+        draft_model_config=draft_config,
+    )
+
+    monkeypatch.setattr(
+        SpecDecodeBaseProposer,
+        "__init__",
+        lambda self, **_: setattr(self, "speculative_config", speculative_config),
+    )
+    monkeypatch.setattr(DraftModelProposer, "_raise_if_draft_tp_mismatch", MagicMock())
+    get_tokenizer = MagicMock(side_effect=["target-tokenizer", "draft-tokenizer"])
+    monkeypatch.setattr(draft_model_module, "get_tokenizer", get_tokenizer)
+    monkeypatch.setattr(draft_model_module, "VocabMapping", MagicMock())
+    DraftModelProposer(MagicMock(), MagicMock())
+
+    target_call, draft_call = get_tokenizer.call_args_list
+    assert target_call.kwargs["tokenizer_mode"] == "mistral"
+    assert target_call.kwargs["revision"] == "target-revision"
+    assert draft_call.args == ("draft-model",)
+    assert draft_call.kwargs["tokenizer_mode"] == "auto"
+    assert draft_call.kwargs["revision"] == "draft-revision"

--- a/vllm/v1/spec_decode/draft_model.py
+++ b/vllm/v1/spec_decode/draft_model.py
@@ -40,10 +40,14 @@ class DraftModelProposer(SpecDecodeBaseProposer):
             # to the intersection so rejection sampling stays lossless.
             target_tokenizer = get_tokenizer(
                 spec.target_model_config.tokenizer,
+                tokenizer_mode=spec.target_model_config.tokenizer_mode,
+                revision=spec.target_model_config.tokenizer_revision,
                 trust_remote_code=spec.target_model_config.trust_remote_code,
             )
             draft_tokenizer = get_tokenizer(
-                spec.draft_model_config.model,
+                spec.draft_model_config.tokenizer,
+                tokenizer_mode="auto",
+                revision=spec.draft_model_config.revision,
                 trust_remote_code=spec.draft_model_config.trust_remote_code,
             )
             self.vocab_mapping: VocabMapping | None = VocabMapping(


### PR DESCRIPTION
## Purpose

When `use_heterogeneous_vocab=True`, `DraftModelProposer` builds the TLI `VocabMapping` by loading target and draft tokenizers again. Those calls currently use implicit defaults, so the mapping can be built from tokenizer snapshots that differ from the model configurations used by the engine.

This PR binds both tokenizer loads to their corresponding model configuration:

- target: configured tokenizer path, tokenizer mode, tokenizer revision, and trust setting;
- draft: configured draft tokenizer path, automatic tokenizer mode detection, draft model revision, and trust setting.

For heterogeneous vocabularies, `SpeculativeConfig` points `draft_model_config.tokenizer` at the draft model while `draft_model_config.tokenizer_revision` is inherited from the target tokenizer configuration. Using `draft_model_config.revision` therefore keeps the draft tokenizer on the draft model snapshot instead of accidentally selecting the target tokenizer revision.

## Reproduction

The focused test constructs heterogeneous-vocabulary configs with distinct values:

- target tokenizer: `target-tokenizer`, mode `mistral`, revision `target-revision`;
- draft tokenizer/model: `draft-model`, inherited tokenizer revision `target-revision`, model revision `draft-revision`.

On the current-main baseline, the captured calls are equivalent to:

```python
get_tokenizer("target-tokenizer", trust_remote_code=...)
get_tokenizer("draft-model", trust_remote_code=...)
```

The captured baseline calls omit the target mode and both configured revisions. With this PR, the same test captures the configured target mode/revision and loads the draft tokenizer with `revision="draft-revision"`, rather than the target tokenizer revision inherited by the draft config.

This behavior occurs while `DraftModelProposer` constructs `VocabMapping`, before model execution or any CUDA-dependent generation step. The deterministic CPU red/green test therefore exercises the faulty boundary directly; a GPU run would add model-download and generation variables without changing this configuration-wiring result.

### Related work

Open PR [#45018](https://github.com/vllm-project/vllm/pull/45018) refactors the same heterogeneous-vocabulary initializer for SLEM. Its current patch still loads both tokenizers without mode or revision arguments, so it is not a semantic duplicate.

Open PR [#51564](https://github.com/vllm-project/vllm/pull/51564) rejects an incompatible local-argmax configuration and does not change tokenizer loading.

## Test Plan

Run from the repository root in a vLLM test environment:

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest -o addopts= --confcutdir=tests/v1/spec_decode -q tests/v1/spec_decode/test_draft_model.py tests/v1/spec_decode/test_vocab_mapping.py

ruff check vllm/v1/spec_decode/draft_model.py tests/v1/spec_decode/test_draft_model.py
ruff format --check vllm/v1/spec_decode/draft_model.py tests/v1/spec_decode/test_draft_model.py
```

## Test Result

The exact new test file was overlaid unchanged onto current-main production code to demonstrate the regression.

| Code endpoint | New focused test | Observation |
|---|---:|---|
| `191cecd51e250de77618dda924359214b4d88119` (current-main baseline) | `1 failed` | Both tokenizer calls omit the configured mode/revision arguments |
| `c4e49e1fd4bb8dc4eeb8c985077048cdb07aedfc` (this PR) | `1 passed` | Both calls use the expected tokenizer identity and revision |

Additional exact-head checks:

- focused test plus existing `test_vocab_mapping.py`: `6 passed`;
- Ruff check: `All checks passed`;
- Ruff format check: `2 files already formatted`.

This is deterministic CPU configuration-wiring evidence. GPU execution is not required for this initialization-path fix. 