### PR TITLE
[Kimi Bug] Fix `cannot access local variable 'active_non_spec_mask_cpu'`

### DIFF
--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from dataclasses import fields
-from unittest.mock import Mock
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -21,6 +22,7 @@ from vllm.models.kimi_k3.nvidia.kda_metadata import (
     _mamba_get_block_table_tensor,
     stage_spec_decode_metadata,
 )
+from vllm.models.kimi_k3.nvidia.model import KimiLinearForCausalLM
 from vllm.v1.attention.backend import AttentionMetadataBuilder
 from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionBackend,
@@ -30,11 +32,13 @@ from vllm.v1.attention.backends.gdn_attn import (
 from vllm.v1.attention.backends.recoverssm_metadata import (
     RecoverSSMPostprocessMetadata,
 )
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     mamba_get_block_table_tensor,
 )
 from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.worker.mamba_utils import validate_mamba_state_copy_funcs
 
 BLOCK_SIZE = 16
 DEVICE = torch.device("cpu")
@@ -121,6 +125,144 @@ def _make_builder(
         assert isinstance(builder, KimiK3KDAMetadataBuilder)
         builder.recoverssm_context = Mock()
     return builder
+
+
+def test_kda_recoverssm_startup_metadata_flow_without_model(monkeypatch):
+    """Exercise KDA RecoverSSM startup without loading Kimi-K3 weights."""
+    monkeypatch.setattr("vllm.utils.torch_utils.PIN_MEMORY", False)
+    monkeypatch.setattr("vllm.v1.attention.backends.utils.PIN_MEMORY", False)
+    layout_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            dtype=torch.bfloat16,
+            hf_config=SimpleNamespace(
+                linear_attn_config={
+                    "num_heads": 4,
+                    "head_dim": 32,
+                    "short_conv_kernel_size": 4,
+                }
+            ),
+        ),
+        cache_config=SimpleNamespace(
+            mamba_cache_dtype="auto",
+            use_kda_recoverssm=True,
+        ),
+        parallel_config=SimpleNamespace(tensor_parallel_size=1),
+        speculative_config=SimpleNamespace(num_speculative_tokens=2),
+    )
+    kv_cache_spec = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=KimiLinearForCausalLM.get_mamba_state_shape_from_config(layout_config),
+        dtypes=KimiLinearForCausalLM.get_mamba_state_dtype_from_config(layout_config),
+        mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+        mamba_cache_mode="align",
+        num_prefill_checkpoint_blocks=1,
+    )
+
+    # This is the same compatibility check performed while initializing the
+    # model runner. RecoverSSM adds two workspace states that are not copied.
+    validate_mamba_state_copy_funcs(
+        {kv_cache_spec: [0]},
+        {
+            MambaAttentionBackendEnum.GDN_ATTN: (
+                KimiLinearForCausalLM.get_mamba_state_copy_func()
+            )
+        },
+    )
+    assert len(kv_cache_spec.shapes) == 4
+
+    builder_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(linear_key_head_dim=32)
+        ),
+        cache_config=SimpleNamespace(
+            mamba_cache_mode="align",
+            use_kda_recoverssm=True,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens=2,
+            parallel_drafting=False,
+        ),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.NONE,
+            max_cudagraph_capture_size=None,
+            static_forward_context={},
+        ),
+        scheduler_config=SimpleNamespace(max_num_seqs=4),
+        additional_config={},
+        num_speculative_tokens=2,
+        use_v2_model_runner=False,
+    )
+    builder = KimiK3KDAMetadataBuilder(
+        kv_cache_spec=kv_cache_spec,
+        layer_names=["layer.0"],
+        vllm_config=builder_config,
+        device=DEVICE,
+    )
+
+    # An all-prefill speculative batch used to leave an all-false spec mask
+    # alive, then access active_non_spec_mask_cpu before it was initialized.
+    prefill_common = create_common_attn_metadata(
+        BatchSpec(seq_lens=[50], query_lens=[50]),
+        BLOCK_SIZE,
+        DEVICE,
+        arange_block_indices=True,
+    ).replace(is_prefilling=torch.tensor([True]))
+    builder.mamba_aligned_state_indices = mamba_get_block_table_tensor(
+        prefill_common.block_table_tensor,
+        prefill_common.seq_lens,
+        kv_cache_spec,
+        "align",
+    )
+    prefill_metadata = builder.build(
+        0,
+        prefill_common,
+        num_decode_draft_tokens_cpu=torch.tensor([-1], dtype=torch.int32),
+        num_accepted_tokens=torch.ones(1, dtype=torch.int32),
+    )
+    assert prefill_metadata.num_prefills == 1
+    assert prefill_metadata.num_spec_decodes == 0
+    assert prefill_metadata.checkpoint is not None
+
+    # Creating the commit context is the first metadata path that consumes the
+    # builder's layer_names. Mock only the GPU-cache-dependent constructor.
+    builder.recoverssm_context = None
+    forward_layer = Mock()
+    builder.vllm_config.compilation_config.static_forward_context["layer.0"] = (
+        forward_layer
+    )
+    spec_common = create_common_attn_metadata(
+        BatchSpec(seq_lens=[20], query_lens=[3]),
+        BLOCK_SIZE,
+        DEVICE,
+        arange_block_indices=True,
+    ).replace(is_prefilling=torch.tensor([False]))
+    builder.mamba_aligned_state_indices = mamba_get_block_table_tensor(
+        spec_common.block_table_tensor,
+        spec_common.seq_lens,
+        kv_cache_spec,
+        "align",
+    )
+    recoverssm_context = Mock()
+    with patch(
+        "vllm.models.kimi_k3.nvidia.ops.recoverssm.KDARecoverSSMCommitContext.create",
+        return_value=recoverssm_context,
+    ) as create_context:
+        spec_metadata = builder.build(
+            0,
+            spec_common,
+            num_decode_draft_tokens_cpu=torch.tensor([2], dtype=torch.int32),
+            num_accepted_tokens=torch.ones(1, dtype=torch.int32),
+        )
+
+    assert spec_metadata.num_spec_decodes == 1
+    assert spec_metadata.recoverssm_commit is not None
+    assert spec_metadata.recoverssm_context is recoverssm_context
+    create_context.assert_called_once_with(
+        [forward_layer],
+        spec_query_len=3,
+        max_num_reqs=builder.vllm_config.scheduler_config.max_num_seqs,
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -409,6 +409,8 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 num_spec_decodes = 0
             else:
                 num_spec_decodes = spec_sequence_masks_cpu.sum().item()
+                if num_spec_decodes == 0:
+                    spec_sequence_masks_cpu = None
 
         spec_request_indices = None
         if num_spec_decodes == 0:


### PR DESCRIPTION
## Purpose


```bash
vllm serve moonshotai/Kimi-K3 \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --load-format fastsafetensors \
  --gpu-memory-utilization 0.92 \
  --enable-prefix-caching \
  --use-replayssm \
  --reasoning-parser kimi_k3 \
  --enable-auto-tool-choice \
  --tool-call-parser kimi_k3 \
  --host 0.0.0.0 \
  --port 30000 \
  --speculative-config '{"model":"RedHatAI/Kimi-K3-speculator.dspark","method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic","rejection_sample_method":"standard"}'
```

Will raise

```bash
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 99, in result
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]     return super().result()
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]            ^^^^^^^^^^^^^^^^
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]   File "/home/yewentao256/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]     return self.__get_result()
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]   File "/home/yewentao256/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]     raise self._exception
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 103, in _wait_for_response
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]     response = self.aggregate(self.get_response())
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]                               ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 437, in get_response
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374]     raise RuntimeError(
(EngineCore pid=2038744) ERROR 09-01 13:39:55 [core.py:1374] RuntimeError: Worker failed with error 'cannot access local variable 'active_non_spec_mask_cpu' where it is not associated with a value', please check the stack trace above for the root cause
```

This PR fixes the issue, all prefill requests will not initialize `spec_sequence_masks_cpu `

## Test

In this branch

```bash
ompletions HTTP/1.1" 200 OK
(APIServer pid=2099752) INFO 09-01 14:00:03 [loggers.py:310] Engine000: Avg prompt throughput: 4043.4 tokens/s, Avg generation throughput: 326.9 tokens/s, Running: 4 reqs, Waiting: 0 reqs, GPU KV cache usage: 4.3%, Prefix cache hit rate: 0.0%
(APIServer pid=2099752) INFO 09-01 14:00:03 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 2.96, Accepted throughput: 216.27 tokens/s, Drafted throughput: 773.40 tokens/s, Accepted: 2163 tokens, Drafted: 7735 tokens, Per-position acceptance rate: 0.710, 0.454, 0.286, 0.191, 0.134, 0.101, 0.081, Avg Draft acceptance rate: 28.0%
(APIServer pid=2099752) INFO:     127.0.0.1:51124 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```