### PR TITLE
[Bugfix][Frontend] Accept list-form function_call_output in Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -14,6 +14,7 @@ from openai_harmony import Author, Message, Role, TextContent
 
 from vllm.entrypoints.openai.responses.harmony import (
     harmony_to_response_output,
+    response_input_to_harmony,
     response_previous_input_to_harmony,
 )
 
@@ -91,6 +92,68 @@ class TestResponsePreviousInputToHarmony:
         assert messages[0].author.role == Role.TOOL
         assert messages[0].author.name == "functions.empty_tool"
         assert messages[0].content[0].text == ""
+
+
+class TestResponseInputToHarmony:
+    """Tests for the Responses API response_input_to_harmony function."""
+
+    @staticmethod
+    def _tool_call() -> ResponseFunctionToolCall:
+        return ResponseFunctionToolCall(
+            type="function_call",
+            call_id="call_1",
+            name="get_weather",
+            arguments='{"city": "Paris"}',
+        )
+
+    def test_function_call_output_with_string_output(self):
+        """Test parsing a function call output with string output."""
+        response_msg = {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "The weather in Paris is sunny, 18°C",
+        }
+
+        msg = response_input_to_harmony(response_msg, [self._tool_call()])
+
+        assert msg.author.role == Role.TOOL
+        assert msg.author.name == "functions.get_weather"
+        assert msg.content[0].text == "The weather in Paris is sunny, 18°C"
+
+    def test_function_call_output_with_list_output(self):
+        """Test parsing a function call output with a content part list.
+
+        The Responses API accepts `output` as either a string or a list of
+        content parts, so the parts must be flattened into a single string
+        before the Harmony message is built.
+        """
+        response_msg = {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [
+                {"type": "input_text", "text": "The weather in Paris "},
+                {"type": "input_text", "text": "is sunny, 18°C"},
+            ],
+        }
+
+        msg = response_input_to_harmony(response_msg, [self._tool_call()])
+
+        assert msg.author.role == Role.TOOL
+        assert msg.author.name == "functions.get_weather"
+        assert msg.content[0].text == "The weather in Paris is sunny, 18°C"
+
+    def test_function_call_output_with_empty_list_output(self):
+        """Test parsing a function call output with an empty content list."""
+        response_msg = {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [],
+        }
+
+        msg = response_input_to_harmony(response_msg, [self._tool_call()])
+
+        assert msg.author.role == Role.TOOL
+        assert msg.content[0].text == ""
 
 
 class TestHarmonyToResponseOutput:

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -187,7 +187,7 @@ def response_input_to_harmony(
             raise ValueError(f"No call message found for {call_id}")
         msg = Message.from_author_and_content(
             Author.new(Role.TOOL, f"functions.{call_response.name}"),
-            response_msg["output"],
+            flatten_input_text_content(response_msg["output"]) or "",
         )
         msg = msg.with_channel("commentary")
         msg = msg.with_recipient("assistant")


### PR DESCRIPTION
## Purpose

Fixes a 400 on `/v1/responses` when a tool result is sent as a list of content parts instead of a string.

`ResponsesRequest.input` validates its items against the OpenAI SDK types, and there `FunctionCallOutput.output` is `Union[str, ResponseFunctionCallOutputItemListParam]`, so the list form is a valid request. `response_input_to_harmony` passed that value straight into `Message.from_author_and_content`, which expects a string, so the request failed with:

```
1 validation error for Message
content.0
  Input should be a valid dictionary or instance of Content
  [type=model_type, input_value=[{'text': '...', 'type': 'input_text'}], input_type=list]
  https://errors.pydantic.dev/2.13/v/model_type
```

The list form is what a client produces when a tool result arrives as content blocks, which is the normal case with MCP tools, and the same request is accepted by the OpenAI Responses API, so a client that works there fails here.

The Chat Completions path already handles this: #25593 added list flattening for the tool role in `parser/harmony_utils.py`, fixing #25001, which reported the identical error. The Responses path was left as it was. `flatten_input_text_content` is already imported in `responses/harmony.py` and already used there for system and developer messages, so one call makes both surfaces behave the same.

After the change a string output passes through unchanged, a content-part list is joined into a single string, and an empty list becomes `""`, matching Chat Completions. Non-text parts (`input_image`, `input_file`) are dropped, which is also what Chat Completions does today; widening that is out of scope here.

Reproduced on v0.27.1, and the code path is identical on v0.28.0 and main.

## Test Plan

Three unit tests in `tests/entrypoints/openai/responses/test_harmony_utils.py::TestResponseInputToHarmony` covering string output, content-part list output and empty list output, modelled on the existing `test_tool_message_with_array_content` for `response_previous_input_to_harmony`.

```
pytest tests/entrypoints/openai/responses/test_harmony_utils.py
```

## Test Result

Whole module, on a CPU-only checkout with `vllm` imported as a namespace package, since the module under test is pure Python while the repository `conftest.py` needs a built vLLM.

Before the change:

```
2 failed, 86 passed
FAILED TestResponseInputToHarmony::test_function_call_output_with_list_output
FAILED TestResponseInputToHarmony::test_function_call_output_with_empty_list_output
E   Input should be a valid dictionary or instance of Content [type=model_type,
    input_value=[{'type': 'input_text', ...}], input_type=list]
```

After the change:

```
88 passed
```

`ruff check` and `ruff format --check` are clean on both files with the pinned v0.14.0.
