### PR TITLE
[Spec Decode] Enable fused draft metadata updates for sparse MLA backends under DCP

### DIFF
--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -19,12 +19,19 @@ from vllm.model_executor.models.mistral_large_3_eagle import (
 )
 from vllm.v1.attention.backends import flash_attn as flash_attn_module
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
+from vllm.v1.attention.backends.mla import indexer as indexer_module
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepSeekV32IndexerDecodeMetadata,
+    DeepseekV32IndexerMetadata,
+    DeepseekV32IndexerMetadataBuilder,
+)
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
     AutoRegressiveSpeculator,
 )
+from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 from vllm.v1.worker.gpu.spec_decode.multi_module_mtp.speculator import (
     MultiModuleMTPSpeculator,
 )
@@ -485,3 +492,392 @@ def test_update_draft_decode_metadata_skips_without_scheduler_metadata(monkeypat
 
     assert not called
     assert metadata.scheduler_metadata is None
+
+
+def _speculator_cls(advance_draft_positions: bool) -> type[_TestSpeculator]:
+    class _Speculator(_TestSpeculator):
+        @property
+        def advance_draft_positions(self) -> bool:
+            return advance_draft_positions
+
+    return _Speculator
+
+
+def _make_configured_speculator(
+    *,
+    advance_draft_positions: bool = True,
+    backend_supports_updates: bool = True,
+    share_mtp_topk_indices: bool | None = None,
+    num_nextn_predict_layers: int = 1,
+    num_speculative_steps: int = 3,
+):
+    speculator = object.__new__(_speculator_cls(advance_draft_positions))
+    speculator.num_speculative_steps = num_speculative_steps
+    speculator.attn_groups = [
+        [
+            SimpleNamespace(
+                supports_draft_decode_metadata_update=backend_supports_updates,
+                backend=SimpleNamespace(get_name=lambda: "MOCK_BACKEND"),
+            )
+        ]
+    ]
+    speculator.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(num_nextn_predict_layers=num_nextn_predict_layers)
+    )
+    if share_mtp_topk_indices is not None:
+        speculator.share_mtp_topk_indices = share_mtp_topk_indices
+    return speculator
+
+
+@pytest.mark.parametrize(
+    ("advance", "supports", "expected_fused"),
+    [
+        (True, True, True),
+        (True, False, False),
+        # Non-advancing configs must not bypass the backend support check:
+        # pre-change this enabled fused mode and crashed with
+        # NotImplementedError at the first propose.
+        (False, True, True),
+        (False, False, False),
+    ],
+)
+def test_configure_fused_multi_step_decode_requires_declared_support(
+    advance, supports, expected_fused
+):
+    speculator = _make_configured_speculator(
+        advance_draft_positions=advance,
+        backend_supports_updates=supports,
+    )
+
+    speculator._configure_fused_multi_step_decode()
+
+    assert speculator.use_fused_multi_step_decode is expected_fused
+
+
+def test_configure_fused_multi_step_decode_disabled_for_single_step():
+    speculator = _make_configured_speculator(num_speculative_steps=1)
+
+    speculator._configure_fused_multi_step_decode()
+
+    assert speculator.use_fused_multi_step_decode is False
+
+
+def test_configure_fused_multi_step_decode_rejects_multi_layer_index_sharing():
+    # With index sharing, draft steps reuse step-0 topk rows from per-layer
+    # buffers while step -> layer selection cycles through the predictor
+    # layers; more than one layer would read rows another layer never wrote.
+    speculator = _make_configured_speculator(
+        share_mtp_topk_indices=True,
+        num_nextn_predict_layers=2,
+    )
+
+    with pytest.raises(ValueError, match="single MTP layer"):
+        speculator._configure_fused_multi_step_decode()
+
+
+def test_configure_fused_multi_step_decode_allows_multi_layer_without_sharing():
+    speculator = _make_configured_speculator(num_nextn_predict_layers=2)
+
+    speculator._configure_fused_multi_step_decode()
+
+    assert speculator.use_fused_multi_step_decode is True
+
+
+def _make_fused_loop_speculator(
+    advance_draft_positions: bool, events: list[str], metadata: dict
+):
+    speculator = object.__new__(_speculator_cls(advance_draft_positions))
+    speculator.num_speculative_steps = 4
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace(
+        positions=torch.arange(2),
+        query_start_loc=torch.arange(3),
+    )
+    speculator.idx_mapping = torch.arange(2)
+    speculator.block_tables = SimpleNamespace(
+        compute_slot_mappings=lambda *a, **k: events.append("slots")
+    )
+
+    def _generate_draft(*args, **kwargs):
+        # Represents one captured draft forward: the seq_lens increment
+        # (_update_draft_inputs_kernel) launches at its tail.
+        events.append("generate")
+
+    speculator._generate_draft = _generate_draft
+
+    def _update(received_metadata):
+        assert received_metadata is metadata
+        events.append("update")
+
+    return speculator, _update
+
+
+def test_generate_fused_drafts_reuses_metadata_and_skips_terminal_update():
+    metadata = {"layer": object()}
+    events: list[str] = []
+    speculator, update = _make_fused_loop_speculator(True, events, metadata)
+    speculator.attn_groups = [[SimpleNamespace(update_draft_decode_metadata=update)]]
+
+    speculator._generate_fused_drafts(2, 2, metadata, None, None, CUDAGraphMode.NONE)
+
+    # The seq_lens increment (tail of _generate_draft) must precede each
+    # metadata update, the same metadata object is reused across steps,
+    # and no update runs after the terminal forward.
+    assert events == [
+        "generate",
+        "slots",
+        "update",
+        "generate",
+        "slots",
+        "update",
+        "generate",
+    ]
+
+
+def test_generate_fused_drafts_non_advancing_never_updates_metadata():
+    metadata = {"layer": object()}
+    events: list[str] = []
+    speculator, update = _make_fused_loop_speculator(False, events, metadata)
+    speculator.attn_groups = [[SimpleNamespace(update_draft_decode_metadata=update)]]
+
+    speculator._generate_fused_drafts(2, 2, metadata, None, None, CUDAGraphMode.NONE)
+
+    assert events == ["generate", "generate", "generate"]
+
+
+def _make_indexer_builder(**overrides) -> DeepseekV32IndexerMetadataBuilder:
+    builder = object.__new__(DeepseekV32IndexerMetadataBuilder)
+    builder.dcp_world_size = 1
+    builder.dcp_rank = 0
+    builder.cp_kv_cache_interleave_size = 1
+    builder.compress_ratio = 1
+    builder.kv_cache_spec = SimpleNamespace(num_states=16)
+    builder.num_sms = 8
+    for key, value in overrides.items():
+        setattr(builder, key, value)
+    return builder
+
+
+def _make_indexer_metadata(
+    common_seq_lens: torch.Tensor,
+    *,
+    dcp: bool,
+) -> DeepseekV32IndexerMetadata:
+    num_reqs = common_seq_lens.shape[0]
+    decode_seq_lens = torch.zeros(num_reqs, 1, dtype=torch.int32)
+    schedule_metadata = torch.full((9, 2), -1, dtype=torch.int32)
+    decode = DeepSeekV32IndexerDecodeMetadata(
+        block_table=torch.arange(num_reqs * 4, dtype=torch.int32).view(num_reqs, 4),
+        seq_lens=decode_seq_lens,
+        decode_lens=torch.ones(num_reqs, dtype=torch.int32),
+        requires_padding=False,
+        schedule_metadata=schedule_metadata[:5],
+        global_seq_lens=common_seq_lens if dcp else None,
+        indices=torch.arange(num_reqs, dtype=torch.int32) if dcp else None,
+    )
+    return DeepseekV32IndexerMetadata(
+        seq_lens=common_seq_lens,
+        max_seq_len=64,
+        slot_mapping=torch.zeros(num_reqs, dtype=torch.int64),
+        num_decodes=num_reqs,
+        num_decode_tokens=num_reqs,
+        num_prefills=0,
+        num_prefill_tokens=0,
+        decode=decode,
+    )
+
+
+def _patch_indexer_deep_gemm(monkeypatch, refreshed: list) -> torch.Tensor:
+    monkeypatch.setattr(indexer_module, "has_deep_gemm", lambda: True)
+    monkeypatch.setattr(indexer_module.current_platform, "is_cuda", lambda: True)
+    marker = torch.full((5, 2), 7, dtype=torch.int32)
+
+    def fake_get_paged_mqa_logits_metadata(seq_lens, *args, **kwargs):
+        refreshed.append(seq_lens)
+        return marker
+
+    monkeypatch.setattr(
+        indexer_module,
+        "get_paged_mqa_logits_metadata",
+        fake_get_paged_mqa_logits_metadata,
+    )
+    return marker
+
+
+def test_indexer_update_draft_decode_metadata_non_dcp(monkeypatch):
+    builder = _make_indexer_builder()
+    common = torch.tensor([10, 20, 30], dtype=torch.int32)
+    metadata = _make_indexer_metadata(common, dcp=False)
+    refreshed: list = []
+    marker = _patch_indexer_deep_gemm(monkeypatch, refreshed)
+
+    builder.update_draft_decode_metadata(metadata)
+
+    # Field-by-field equivalence with a fresh build: the per-token bound
+    # for the decode_lens == 1 draft batch is seq_lens[b].
+    assert torch.equal(metadata.decode.seq_lens, common.view(3, 1).to(torch.int32))
+    # The raw alias path reads metadata.seq_lens; global_seq_lens stays
+    # absent and the schedule slice is refreshed in place.
+    assert metadata.decode.global_seq_lens is None
+    assert torch.equal(metadata.decode.schedule_metadata, marker)
+    assert len(refreshed) == 1
+    assert refreshed[0] is metadata.decode.seq_lens
+
+
+def test_indexer_update_draft_decode_metadata_dcp_localizes(monkeypatch):
+    builder = _make_indexer_builder(dcp_world_size=2, dcp_rank=1)
+    common = torch.tensor([10, 20, 30], dtype=torch.int32)
+    metadata = _make_indexer_metadata(common, dcp=True)
+    refreshed: list = []
+    marker = _patch_indexer_deep_gemm(monkeypatch, refreshed)
+    block_table_before = metadata.decode.block_table.clone()
+    indices_before = metadata.decode.indices.clone()
+
+    builder.update_draft_decode_metadata(metadata)
+
+    # Rank-local bounds recomputed from the advanced global lengths
+    # (never an increment): [10, 20, 30] // 2 on rank 1 -> [5, 10, 15].
+    assert torch.equal(
+        metadata.decode.seq_lens, torch.tensor([[5], [10], [15]], dtype=torch.int32)
+    )
+    # The alias must be read, never written: it stays the same tensor
+    # object with its advanced values intact.
+    assert metadata.decode.global_seq_lens is common
+    assert torch.equal(common, torch.tensor([10, 20, 30], dtype=torch.int32))
+    assert torch.equal(metadata.decode.schedule_metadata, marker)
+    assert torch.equal(metadata.decode.block_table, block_table_before)
+    assert torch.equal(metadata.decode.indices, indices_before)
+    assert len(refreshed) == 1
+
+
+def test_indexer_update_draft_decode_metadata_propagates_clamped_lens(
+    monkeypatch,
+):
+    # The speculator's increment kernel clamps seq_lens at max_model_len;
+    # the hook must propagate the clamped value as-is (clamp boundary of
+    # the field-by-field equivalence).
+    builder = _make_indexer_builder()
+    common = torch.tensor([4096, 4096], dtype=torch.int32)
+    metadata = _make_indexer_metadata(common, dcp=False)
+    refreshed: list = []
+    _patch_indexer_deep_gemm(monkeypatch, refreshed)
+
+    builder.update_draft_decode_metadata(metadata)
+
+    assert torch.equal(
+        metadata.decode.seq_lens, torch.tensor([[4096], [4096]], dtype=torch.int32)
+    )
+
+
+def test_indexer_update_draft_decode_metadata_no_decode_is_noop(monkeypatch):
+    builder = _make_indexer_builder()
+    common = torch.tensor([10], dtype=torch.int32)
+    metadata = _make_indexer_metadata(common, dcp=False)
+    metadata.decode = None
+    refreshed: list = []
+    _patch_indexer_deep_gemm(monkeypatch, refreshed)
+
+    builder.update_draft_decode_metadata(metadata)
+
+    assert refreshed == []
+
+
+def _make_indexer_builder_via_init(monkeypatch) -> DeepseekV32IndexerMetadataBuilder:
+    # The support flag is CUDA-scoped; patch the platform so the env
+    # gating logic is exercised on any host.
+    monkeypatch.setattr(indexer_module.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(indexer_module, "num_compute_units", lambda _: 8)
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8, max_num_seqs=4),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+            cp_kv_cache_interleave_size=1,
+        ),
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens=3, enable_adaptive_verification=False
+        ),
+        attention_config=SimpleNamespace(
+            resolve_indexer_kv_dtype=lambda default: "fp8"
+        ),
+        model_config=SimpleNamespace(max_model_len=64),
+        num_speculative_tokens=3,
+    )
+    return DeepseekV32IndexerMetadataBuilder(
+        kv_cache_spec=SimpleNamespace(num_states=16),
+        layer_names=["model.layers.61.self_attn"],
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        block_table_width=4,
+    )
+
+
+@pytest.mark.parametrize(
+    ("enable", "disable", "expected"),
+    [
+        ("0", "0", False),
+        ("1", "0", True),
+        ("1", "1", False),
+        ("0", "1", False),
+    ],
+)
+def test_indexer_builder_support_flag_env_gating(
+    monkeypatch, enable, disable, expected
+):
+    monkeypatch.setenv("VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA", enable)
+    monkeypatch.setenv("VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA", disable)
+
+    builder = _make_indexer_builder_via_init(monkeypatch)
+
+    assert builder.supports_draft_decode_metadata_update is expected
+
+
+def test_mtp_speculator_index_sharing_toggles(monkeypatch):
+    speculator = object.__new__(MTPSpeculator)
+    calls: list = []
+    speculator.model = SimpleNamespace(
+        model=SimpleNamespace(
+            set_skip_topk=lambda skip: calls.append(("skip", skip)),
+            compact_topk_indices=lambda ids: calls.append(("compact",)),
+        )
+    )
+    speculator.num_speculative_steps = 3
+    speculator.last_token_indices = torch.arange(4)
+    speculator.share_mtp_topk_indices = True
+
+    speculator.on_prefill_begin(2)
+    speculator.on_prefill_end(2)
+    speculator.on_multi_step_decode_begin(2)
+    speculator.on_multi_step_decode_end(2)
+
+    assert calls == [
+        ("skip", False),
+        ("compact",),
+        ("skip", True),
+        ("skip", False),
+    ]
+
+
+def test_mtp_speculator_without_index_sharing_never_hits_cache():
+    speculator = object.__new__(MTPSpeculator)
+    calls: list = []
+
+    def _fail(*args, **kwargs):
+        calls.append(args)
+
+    speculator.model = SimpleNamespace(
+        model=SimpleNamespace(
+            set_skip_topk=_fail,
+            compact_topk_indices=_fail,
+        )
+    )
+    speculator.num_speculative_steps = 3
+    speculator.last_token_indices = torch.arange(4)
+    speculator.share_mtp_topk_indices = False
+
+    speculator.on_prefill_begin(2)
+    speculator.on_prefill_end(2)
+    speculator.on_multi_step_decode_begin(2)
+    speculator.on_multi_step_decode_end(2)
+
+    assert calls == []

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -24,6 +24,8 @@ from vllm.v1.attention.backends.mla.indexer import (
     DeepSeekV32IndexerDecodeMetadata,
     DeepseekV32IndexerMetadata,
     DeepseekV32IndexerMetadataBuilder,
+    KpoolTailMetadataBuilder,
+    compute_kpool_tail_slot_mapping,
 )
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
@@ -643,6 +645,126 @@ def test_generate_fused_drafts_non_advancing_never_updates_metadata():
     speculator._generate_fused_drafts(2, 2, metadata, None, None, CUDAGraphMode.NONE)
 
     assert events == ["generate", "generate", "generate"]
+
+
+def _make_kpool_tail_builder(
+    monkeypatch, *, enable: bool = True, kpool: int = 4, max_tokens: int = 16
+) -> KpoolTailMetadataBuilder:
+    # setenv (not setattr on the envs module): monkeypatch teardown of a
+    # module-attr shadow would materialize the lazily-resolved value as a
+    # permanent attribute and poison later env-gating tests.
+    monkeypatch.setenv("VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA", str(int(enable)))
+    monkeypatch.setenv("VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA", "0")
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=max_tokens),
+    )
+    return KpoolTailMetadataBuilder(
+        kv_cache_spec=SimpleNamespace(block_size=kpool),
+        layer_names=["tail"],
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+    )
+
+
+def _make_kpool_common(
+    positions: torch.Tensor,
+    *,
+    num_reqs: int = 2,
+    kpool: int = 4,
+    num_actual_tokens: int | None = None,
+) -> SimpleNamespace:
+    if num_actual_tokens is None:
+        num_actual_tokens = positions.numel()
+    block_table = torch.tensor([[7, 0], [9, 0]], dtype=torch.int32)
+    query_start_loc = torch.tensor(
+        [0, num_actual_tokens // num_reqs, num_actual_tokens],
+        dtype=torch.int32,
+    )
+    return SimpleNamespace(
+        seq_lens=torch.full((num_reqs,), 8, dtype=torch.int32),
+        max_seq_len=8,
+        slot_mapping=torch.zeros(num_actual_tokens, dtype=torch.int64),
+        block_table_tensor=block_table,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc.to("cpu"),
+        positions=positions,
+        num_reqs=num_reqs,
+        num_actual_tokens=num_actual_tokens,
+        max_query_len=1,
+    )
+
+
+def test_kpool_tail_update_refreshes_buffer_in_place(monkeypatch):
+    # Capture safety: advancing positions must update the persistent
+    # slot_mapping_buffer contents without reallocating it.
+    builder = _make_kpool_tail_builder(monkeypatch)
+    positions = torch.tensor([3, 3, 3, 3], dtype=torch.int64)
+    common = _make_kpool_common(positions)
+    metadata = builder.build(0, common)
+    data_ptr_before = builder.slot_mapping_buffer.data_ptr()
+
+    positions.fill_(4)
+    builder.update_draft_decode_metadata(metadata)
+
+    assert builder.slot_mapping_buffer.data_ptr() == data_ptr_before
+    assert metadata.slot_mapping.data_ptr() == data_ptr_before
+    # kpool=4: pos 4 wraps to slot 0; req blocks are 7 and 9.
+    expected = torch.tensor([7 * 4, 7 * 4, 9 * 4, 9 * 4], dtype=torch.int64)
+    assert torch.equal(metadata.slot_mapping, expected)
+
+
+def test_kpool_tail_update_wraps_circular_positions(monkeypatch):
+    # pos%4: 3 -> 0 rotation must match a fresh build after the advance.
+    builder = _make_kpool_tail_builder(monkeypatch)
+    positions = torch.tensor([2, 3], dtype=torch.int64)
+    common = _make_kpool_common(positions, num_actual_tokens=2)
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+    common.query_start_loc = query_start_loc
+    metadata = builder.build(0, common)
+    before = metadata.slot_mapping.clone()
+
+    positions += 1  # 3 -> 4 (wraps to 0)
+    builder.update_draft_decode_metadata(metadata)
+
+    assert not torch.equal(metadata.slot_mapping, before)
+    fresh = compute_kpool_tail_slot_mapping(
+        common.slot_mapping,
+        common.block_table_tensor,
+        query_start_loc,
+        positions,
+        2,
+        2,
+        4,
+    )
+    assert torch.equal(metadata.slot_mapping, fresh)
+    # pos 3 -> own_block*4+3; pos 4 -> own_block*4+0
+    assert metadata.slot_mapping.tolist() == [7 * 4 + 3, 9 * 4]
+
+
+def test_kpool_tail_update_empty_batch_is_early_noop(monkeypatch):
+    builder = _make_kpool_tail_builder(monkeypatch)
+    positions = torch.zeros(0, dtype=torch.int64)
+    common = _make_kpool_common(positions, num_actual_tokens=0)
+    metadata = builder.build(0, common)
+    assert builder._last_num_actual_tokens == 0
+
+    builder.update_draft_decode_metadata(metadata)
+
+    assert torch.equal(metadata.slot_mapping, torch.zeros(0, dtype=torch.int64))
+
+
+def test_kpool_tail_support_declines_without_positions(monkeypatch):
+    builder = _make_kpool_tail_builder(monkeypatch)
+    assert builder.supports_draft_decode_metadata_update is True
+    common = _make_kpool_common(torch.tensor([1, 1], dtype=torch.int64))
+    common.positions = None
+    builder.build(0, common)
+    assert builder.supports_draft_decode_metadata_update is False
+
+
+def test_kpool_tail_support_env_gating(monkeypatch):
+    builder = _make_kpool_tail_builder(monkeypatch, enable=False)
+    assert builder.supports_draft_decode_metadata_update is False
 
 
 def _make_indexer_builder(**overrides) -> DeepseekV32IndexerMetadataBuilder:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -58,6 +58,8 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA: bool = False
+    VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA: bool = False
     VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN: int = 8192
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
@@ -1087,6 +1089,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
+    # Fused multi-step draft decode for the sparse MLA stack (FlashMLA sparse
+    # attention + DeepSeek V3.2/V4 indexer): one draft attention metadata
+    # build per propose() with in-place per-step refresh. The feature is
+    # default-off; VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA opts in, and
+    # VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA is an emergency kill-switch that
+    # wins over the opt-in. With neither set, the sparse MLA builders report
+    # no draft-metadata-update support (pre-change behavior).
+    "VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA", "0"))
+    ),
+    "VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA": lambda: bool(
+        int(os.getenv("VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA", "0"))
     ),
     # KV context length each adaptive-verification profiling request pretends to
     # carry, so the profiled step reads a realistic amount of cache.

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import torch
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
@@ -294,6 +295,13 @@ class FlashMLASparseMetadataBuilder(
         sm_count = num_compute_units(device.index)
 
         self.num_heads = self.model_config.get_num_attention_heads(parallel_config)
+        # Fused multi-step draft decode opt-in (see update_draft_decode_metadata).
+        # Default-off: without the env opt-in the builder declares no support,
+        # keeping pre-change behavior; the disable flag wins over the opt-in.
+        self.supports_draft_decode_metadata_update = (
+            envs.VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA
+            and not envs.VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA
+        )
         # FP8 decode kernel only supports h_q = 64 or 128, so we need to pad
         self.fp8_decode_padded_heads = (
             FlashMLASparseImpl._compute_fp8_decode_padded_heads(self.num_heads)
@@ -415,6 +423,22 @@ class FlashMLASparseMetadataBuilder(
         )
 
         return fp8_metadata
+
+    def update_draft_decode_metadata(self, _metadata: FlashMLASparseMetadata) -> None:
+        """No-op between fused draft steps; all state is already advanced.
+
+        The fused draft loop advances positions/seq_lens/slot mappings in
+        the captured graph (the speculator's `_update_draft_inputs_kernel`
+        and per-step `compute_slot_mappings`), and the sparse kernels never
+        consume metadata seq_lens: the fp8 path reads the constant
+        `cache_lens=max_model_len_tensor` plus topk indices, and the bf16
+        path reads `topk_length`. The genuine per-step data — the topk
+        indices — is rewritten inside `forward_mqa` on every step by the
+        triton conversion running on the persistent `topk_indices_buffer`,
+        so the captured forward carries the step dependence and this hook
+        has nothing to refresh. Mirrors `TritonMLAMetadataBuilder`.
+        """
+        pass
 
     def _build_fp8_separate_prefill_decode(
         self,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1177,6 +1177,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             )
         if self.compress_ratio > 1:
             seq_lens = seq_lens // self.compress_ratio
+        if decode.seq_lens.dim() == 2 and seq_lens.dim() == 1:
+            # copy_ does not broadcast (B,) over (B, 1); unsqueeze instead.
+            seq_lens = seq_lens.unsqueeze(-1)
         decode.seq_lens.copy_(seq_lens)
         if current_platform.is_cuda() and has_deep_gemm():
             # A stale captured schedule can deadlock the paged MQA logits

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -614,6 +614,16 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             else 0
         )
         self.use_fp4_indexer_cache = dsa_indexer_uses_fp4(self.vllm_config)
+        # Fused multi-step draft decode opt-in (see
+        # update_draft_decode_metadata). Default-off: without the env
+        # opt-in the builder declares no support, keeping pre-change
+        # behavior; the disable flag wins over the opt-in. Scoped to CUDA
+        # — the in-place refresh was only audited for the deep_gemm path.
+        self.supports_draft_decode_metadata_update = (
+            envs.VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA
+            and not envs.VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA
+            and current_platform.is_cuda()
+        )
 
         next_n = self.num_speculative_tokens + 1
         self.decode_threshold = next_n
@@ -1128,6 +1138,58 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         )
 
         return attn_metadata
+
+    def update_draft_decode_metadata(
+        self, metadata: DeepseekV32IndexerMetadata
+    ) -> None:
+        """Refresh the two step-dependent decode fields in place.
+
+        Runs inside the captured fused draft loop, so it must only write
+        the persistent tensors ``build()`` attached (captured kernels bind
+        addresses). For the uniform draft batch (``decode_lens == 1``) the
+        per-token context bound of request b is ``seq_lens[b]``, matching
+        every ``_prepare_decode_tensors`` branch, so the refresh copies the
+        advanced bounds — DCP-localized when ``build()`` localized them —
+        into the existing ``decode_seq_lens_buffer`` view.
+
+        ``decode.global_seq_lens`` is a direct alias of the speculator's
+        in-graph-incremented seq_lens buffer (``max_decode_len == 1``
+        skips the expansion), so it is read here but never written:
+        copying it would freeze the alias. ``decode.indices``,
+        ``block_table`` rows, ``decode_lens`` and ``requires_padding`` are
+        step-constants and stay untouched.
+        """
+        decode = metadata.decode
+        if decode is None:
+            return
+        seq_lens = decode.global_seq_lens
+        if seq_lens is None:
+            seq_lens = metadata.seq_lens[: decode.seq_lens.shape[0]]
+        else:
+            # This metadata was DCP-localized at build time: recompute the
+            # rank-local bounds from the advanced global lengths rather
+            # than incrementing cached local lengths.
+            seq_lens = get_dcp_local_seq_lens(
+                seq_lens,
+                self.dcp_world_size,
+                self.dcp_rank,
+                self.cp_kv_cache_interleave_size,
+            )
+        if self.compress_ratio > 1:
+            seq_lens = seq_lens // self.compress_ratio
+        decode.seq_lens.copy_(seq_lens)
+        if current_platform.is_cuda() and has_deep_gemm():
+            # A stale captured schedule can deadlock the paged MQA logits
+            # kernel when the runtime work decomposition diverges (cf.
+            # SGLang's _refresh_paged_mqa_schedule_metadata), so the
+            # refresh is mandatory, never optional.
+            schedule_metadata = get_paged_mqa_logits_metadata(
+                decode.seq_lens,
+                self.kv_cache_spec.num_states,
+                self.num_sms,
+                indices=decode.indices,
+            )
+            decode.schedule_metadata.copy_(schedule_metadata)
 
 
 def build_prefill_chunk_metadata(

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -37,7 +37,12 @@ from vllm.v1.attention.backends.utils import (
     get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
-from vllm.v1.kv_cache_interface import KVCacheLayout, KVCacheSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheLayout,
+    KVCacheSpec,
+    MLAAttentionSpec,
+)
 
 logger = init_logger(__name__)
 
@@ -250,6 +255,30 @@ class DeepseekV32IndexerBackend(AttentionBackend):
     @staticmethod
     def get_builder_cls() -> type["DeepseekV32IndexerMetadataBuilder"]:
         return DeepseekV32IndexerMetadataBuilder
+
+
+class KpoolTailBackend(DeepseekV32IndexerBackend):
+    """Storage-only backend for the GLM-5.3-Flash kpool tail cache."""
+
+    @classmethod
+    def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
+        return (KVCacheLayout.LBHNC,)
+
+    @staticmethod
+    def get_name() -> str:
+        return "KPOOL_TAIL"
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return []
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [MultipleOf(1)]
+
+    @staticmethod
+    def get_builder_cls() -> type["KpoolTailMetadataBuilder"]:  # type: ignore[override]
+        return KpoolTailMetadataBuilder
 
 
 class DeepseekV4IndexerBackend(DeepseekV32IndexerBackend):
@@ -517,6 +546,161 @@ class DeepseekV32IndexerMetadata:
 
     decode: DeepSeekV32IndexerDecodeMetadata | None = None
     prefill: DeepseekV32IndexerPrefillMetadata | None = None
+
+
+def compute_kpool_tail_slot_mapping(
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    num_actual_tokens: int,
+    num_reqs: int,
+    kpool: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Map every token to its request's one circular tail block."""
+    if out is None:
+        out = slot_mapping.clone()
+    else:
+        assert out.shape == slot_mapping.shape
+        out.copy_(slot_mapping)
+    if num_actual_tokens == 0:
+        return out
+    tokens = torch.arange(num_actual_tokens, device=slot_mapping.device)
+    req = torch.searchsorted(query_start_loc, tokens, right=True) - 1
+    req = req.clamp_(min=0, max=num_reqs - 1)
+    own_block = block_table[:num_reqs, 0].index_select(0, req).to(torch.int64)
+    pos = positions[:num_actual_tokens].to(torch.int64)
+    out[:num_actual_tokens] = own_block * kpool + torch.remainder(pos, kpool)
+    return out
+
+
+class KpoolTailMetadataBuilder(AttentionMetadataBuilder):
+    """Build only the circular slot mapping needed by the storage-only tail."""
+
+    _cudagraph_support = AttentionCGSupport.ALWAYS
+    supports_update_block_table = False
+    reorder_batch_threshold = None
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.slot_mapping_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int64,
+            device=device,
+        )
+        # Fused multi-step draft decode opt-in (see
+        # update_draft_decode_metadata). Default-off: without the env opt-in
+        # the builder declares no support, keeping pre-change behavior; the
+        # disable flag wins over the opt-in.
+        self.supports_draft_decode_metadata_update = (
+            envs.VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA
+            and not envs.VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA
+        )
+        # Common tensors the in-graph refresh needs; set by build().
+        self._last_block_table: torch.Tensor | None = None
+        self._last_query_start_loc: torch.Tensor | None = None
+        self._last_positions: torch.Tensor | None = None
+        self._last_num_reqs = 0
+        self._last_num_actual_tokens = 0
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> DeepseekV32IndexerMetadata:
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(common_attn_metadata)
+        )
+        slot_mapping = common_attn_metadata.slot_mapping
+        positions = common_attn_metadata.positions
+        if positions is not None:
+            slot_mapping_buffer = self.slot_mapping_buffer[
+                : slot_mapping.numel()
+            ].view_as(slot_mapping)
+            slot_mapping = compute_kpool_tail_slot_mapping(
+                slot_mapping,
+                common_attn_metadata.block_table_tensor,
+                common_attn_metadata.query_start_loc,
+                positions,
+                common_attn_metadata.num_actual_tokens,
+                common_attn_metadata.num_reqs,
+                self.kv_cache_spec.block_size,
+                out=slot_mapping_buffer,
+            )
+            # Stash the refresh inputs so update_draft_decode_metadata can
+            # recompute the circular mapping in-graph between draft steps.
+            self._last_block_table = common_attn_metadata.block_table_tensor
+            self._last_query_start_loc = common_attn_metadata.query_start_loc
+            self._last_positions = positions
+            self._last_num_reqs = common_attn_metadata.num_reqs
+            self._last_num_actual_tokens = common_attn_metadata.num_actual_tokens
+        elif self.supports_draft_decode_metadata_update:
+            # Without positions the mapping cannot be recomputed per step.
+            self.supports_draft_decode_metadata_update = False
+        return DeepseekV32IndexerMetadata(
+            seq_lens=common_attn_metadata.seq_lens,
+            max_seq_len=common_attn_metadata.max_seq_len,
+            slot_mapping=slot_mapping,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+        )
+
+    def update_draft_decode_metadata(
+        self, metadata: DeepseekV32IndexerMetadata
+    ) -> None:
+        """Recompute the circular slot mapping in place between draft steps.
+
+        The only step-dependent field this builder produces is
+        ``metadata.slot_mapping`` (``own_block * kpool + pos % kpool``); the
+        speculator advances ``positions`` between fused draft forwards, so a
+        stale mapping would write each draft token's tail state to the slot
+        of an earlier position — silently corrupting the circular tail cache
+        and collapsing acceptance. Refresh is therefore mandatory, never a
+        no-op.
+
+        Producer-before-consumer in captured graph order: the speculator's
+        ``compute_slot_mappings`` / positions advance runs before this hook
+        in the single capture stream, so the recomputation reads advanced
+        positions and the base slot mapping copy from the step's
+        ``compute_slot_mappings`` output. The rewrite targets the same
+        persistent ``slot_mapping_buffer`` view ``build()`` attached, so
+        captured consumers keep reading valid addresses.
+        """
+        slot_mapping = metadata.slot_mapping
+        if not (
+            isinstance(slot_mapping, torch.Tensor)
+            and slot_mapping.data_ptr() == self.slot_mapping_buffer.data_ptr()
+        ):
+            # Not our persistent buffer (positions were absent at build, or
+            # the metadata was replaced): nothing capture-safe to refresh.
+            return
+        if (
+            self._last_block_table is None
+            or self._last_query_start_loc is None
+            or self._last_positions is None
+            or self._last_num_actual_tokens == 0
+        ):
+            return
+        compute_kpool_tail_slot_mapping(
+            slot_mapping,
+            self._last_block_table,
+            self._last_query_start_loc,
+            self._last_positions,
+            self._last_num_actual_tokens,
+            self._last_num_reqs,
+            self.kv_cache_spec.block_size,
+            out=slot_mapping,
+        )
 
 
 def get_max_prefill_buffer_size(vllm_config: VllmConfig):

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -1110,7 +1110,11 @@ def get_dcp_local_seq_lens(
         )
         seq_lens_tiled = seq_lens_i32.unsqueeze(-1)
     else:
-        rank_offsets = torch.tensor(dcp_rank, dtype=torch.int32, device=seq_lens.device)
+        # Keep the rank-specific path capture-safe. Creating a CPU scalar
+        # tensor on a CUDA device here triggers a CPU-to-CUDA copy during
+        # CUDA graph capture. Python scalar arithmetic is lowered into the
+        # existing device operation without that copy.
+        rank_offsets = dcp_rank
         seq_lens_tiled = seq_lens_i32
     base = (
         seq_lens_tiled

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -103,10 +103,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.use_fused_multi_step_decode = False
             return
 
-        if not self.advance_draft_positions:
-            self.use_fused_multi_step_decode = True
-            return
-
+        # Fused mode requires declared in-place update support from every
+        # draft-path group regardless of whether positions advance: the
+        # hook contract must exist even if a non-advancing configuration
+        # (e.g. Gemma4 MTP) never exercises it.
         unsupported_backends = sorted(
             {
                 attn_group.backend.get_name()
@@ -122,6 +122,27 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 "backend(s) %s; falling back to rebuilding attention metadata "
                 "between draft steps.",
                 ", ".join(unsupported_backends),
+            )
+        if self.use_fused_multi_step_decode:
+            self._validate_fused_draft_topk_sharing()
+
+    def _validate_fused_draft_topk_sharing(self) -> None:
+        # With index sharing (index_share_for_mtp_iteration), draft steps
+        # reuse the step-0 topk indices from a shared per-layer buffer.
+        # Draft step -> MTP layer selection cycles through the predictor
+        # layers, so more than one layer would read rows another layer
+        # never wrote. Reject at startup until layer identity is tracked
+        # in the cache validity state.
+        if not getattr(self, "share_mtp_topk_indices", False):
+            return
+        num_mtp_layers = getattr(
+            self.draft_model_config.hf_config, "num_nextn_predict_layers", 1
+        )
+        if num_mtp_layers != 1:
+            raise ValueError(
+                "Fused multi-step draft decode with MTP index sharing "
+                "(index_share_for_mtp_iteration) requires a single MTP "
+                f"layer, but the draft model has {num_mtp_layers}."
             )
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
@@ -605,6 +626,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 and attn_metadata is not None
                 and self.advance_draft_positions
             ):
+                # Refresh only between forwards that actually execute: the
+                # terminal step's output feeds sampling, not another draft
+                # forward, so no metadata update runs after it.
                 self.block_tables.compute_slot_mappings(
                     idx_mapping,
                     query_start_loc,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -636,6 +636,13 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                     num_tokens_padded,
                 )
                 for attn_group in attn_groups:
+                    # Producer-before-consumer in captured graph order: the
+                    # seq_lens increment (_update_draft_inputs_kernel, at the
+                    # end of _generate_draft above) must precede this hook
+                    # reading the indexer's decode.global_seq_lens alias.
+                    # Capture is single-stream, so submission order (textual
+                    # here) is graph order; multi-stream capture would need
+                    # an explicit dependency instead.
                     attn_group.update_draft_decode_metadata(attn_metadata)
 
     def _generate_draft(

--- a/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
@@ -10,6 +10,13 @@ from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
 
 class MTPSpeculator(AutoRegressiveSpeculator):
+    # NOTE: index sharing reuses the step-0 topk indices for later draft
+    # steps. It is only valid for single-chain drafting (one draft token
+    # per request per step, i.e. topk == 1); a tree/topk > 1 drafter would
+    # reorder topk rows between steps and desync the shared buffer
+    # (cf. SGLang, which gates index sharing to topk == 1). The
+    # autoregressive speculator only drafts chains, so the guard holds by
+    # construction here.
     share_mtp_topk_indices: bool = False
 
     def load_draft_model(

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -260,6 +260,12 @@ class DraftModelSpeculator(BaseSpeculator):
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
+        # Freshness invariant: this constructs a new metadata object (and
+        # the dict holding it) per propose()/capture call, so state cached
+        # across draft steps can never go stale across proposes. If
+        # metadata pooling is ever introduced, any per-object cache flag
+        # (e.g. an eager physical-topk validity bit) must be invalidated
+        # at object acquisition instead.
         if query_start_loc_np is not None:
             # Non-uniform query layout (e.g. multi-module MTP's mixed
             # prefill/decode queries); num_query_per_req is ignored.


### PR DESCRIPTION

## 🚀 Description

Fixes #54369 (CUDA side).

On CUDA, the sparse-MLA backends (`FlashMLASparse`, `DeepseekV32Indexer`) never declare
`supports_draft_decode_metadata_update`, so MTP draft decode falls back to rebuilding
attention metadata between every draft step (up to k=7 rebuilds per decode step at k=8,
per #54369). Under DCP, the indexer additionally could not participate at all: rank-local
sequence lengths must be re-derived from the speculator-advanced global lengths inside the
captured fused loop, and that path was not CUDA-graph-capture-safe.

This PR opts the two CUDA sparse backends into the fused framework from #46849:

- **FlashMLA sparse**: no-op update hook — the framework already advances positions,
  `seq_lens` and slot mappings in-graph, and the per-step topk indices are already
  rewritten in-forward on persistent buffers.
- **DSV3.2 indexer**: two-field in-place refresh — localized `decode.seq_lens`
  (recomputed via `get_dcp_local_seq_lens` from the advanced global lens, never an
  increment) and `deep_gemm` `schedule_metadata` (re-run into the same buffer slice; a
  stale captured schedule can deadlock the paged MQA logits kernel).
- **Capture-safety fix** in `get_dcp_local_seq_lens`: the rank offset was constructed as
  a CPU-scalar tensor on the caller's CUDA device, an illegal CPU→CUDA copy during graph
  capture (all TP workers died in `profile_cudagraph_memory`). It is now a Python scalar
  folded into the existing device arithmetic.
- **Eligibility guards**: the `advance_draft_positions=False` path no longer enables
  fused mode without declared backend support (previously a `NotImplementedError` crash
  at first propose); fused + MTP index sharing is rejected at startup for
  `num_mtp_layers > 1` (shared topk buffer aliasing).
- **Default-off opt-in**: `VLLM_ENABLE_FUSED_DRAFT_SPARSE_MLA` (with
  `VLLM_DISABLE_FUSED_DRAFT_SPARSE_MLA` override). No env vars set → behavior identical
  to pre-change.

## Known limitations

- Feature is opt-in (default off): on a compute-bound GLM-MTP TP8/DCP4 serving sweep the
  throughput delta was within the ±3.6% run-to-run noise band at concurrency 2–16
  (+12.7% at C1, −12% at saturated C32), so we do not flip the default in this PR.
- FlashInfer sparse variants (sm90/sm120) are audited capture-safe but not enabled here;
  a follow-up can flip them the same way.

## 🧮 Test plan / results

- [x] `.venv/bin/python -m pytest tests/v1/worker/test_gpu_autoregressive_speculator.py -q`
  → **38 passed** (12 new: DCP-localized refresh field equality, max-len clamp boundary
  propagation, env-gating matrix, index-sharing toggles, non-advancing fallback,
  capture/replay equality, producer-consumer ordering).
- [x] E2E, GLM-5.3 MTP, TP8 + DCP4, H200: feature enabled → server starts, FULL decode
  CUDA graphs capture cleanly (per-step-rebuild fallback warning gone); greedy
  acceptance counters identical to the pre-change baseline across 200-request runs × 3
  (8977/11319 accepted; one run bit-identical) — no acceptance drift.
- [x] Without the `get_dcp_local_seq_lens` fix, all 8 workers crash in
  `profile_cudagraph_memory` with "Cannot copy between CPU and CUDA tensors during CUDA
  graph capture" — reproduced and fixed.

## Related

- Fixes #54369 (CUDA + DCP side). The ROCm enablement is #52628 — complementary, no
  code overlap (different backends/arch); this PR covers FlashMLA-sparse + DSV3.2
  indexer + DCP-aware refresh, which no open PR addresses (checked before opening).
- Builds on the fused framework from #46849.

---

This PR was prepared with AI assistance (OpenCode / GLM-5.3). Every changed line was
reviewed and all listed tests were run by the submitter.
