### PR TITLE
[KV Offload] Async CPU cache initialization for SimpleCPUOffloadConnector

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -43,6 +43,14 @@ Now supports 9 types of connectors:
 
   For multi-tier offloading (e.g., CPU + filesystem tier) and the full configuration reference, see the [KV Offloading Usage Guide](kv_offloading_usage.md).
 
+- **SimpleCPUOffloadConnector**: lightweight alternative to `OffloadingConnector` that offloads KV blocks to local CPU RAM or a local file on the same machine (no cross-node transfer):
+
+  ```bash
+  --kv-transfer-config '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use": 1000000000, "async_init": true}}'
+  ```
+
+  With `"async_init": true` (CUDA only), the CPU buffer is allocated and pinned in the background instead of blocking startup: the engine serves immediately with GPU-only KV cache and offloading activates once all ranks are ready. Requests admitted before that stay GPU-only for their lifetime; an initialization failure shuts the engine down.
+
 - **FlexKVConnectorV1**: refer to [examples/disaggregated/flexkv_connector/prefix_caching_flexkv.py](../../examples/disaggregated/flexkv_connector/prefix_caching_flexkv.py) for the example usage of FlexKVConnectorV1. FlexKV is a distributed KV Store and multi-level cache management system for ultra-large-scale LLM inference.
 
   ```bash

--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -31,7 +31,8 @@ vllm serve <model> \
     "kv_role": "kv_both",
     "kv_connector_extra_config": {
       "block_size": 64,
-      "cpu_bytes_to_use": 1000000000
+      "cpu_bytes_to_use": 1000000000,
+      "async_init": true
     }
   }'
 ```
@@ -68,6 +69,7 @@ vllm serve <model> \
 | --- | --- | --- | --- | --- |
 | `spec_name` | no | `CPUOffloadingSpec` | both | Set to `TieringOffloadingSpec` for multi-tier. |
 | `cpu_bytes_to_use` | yes | — | both | Total bytes of host memory reserved for the CPU tier across all workers (not per-worker). |
+| `async_init` | no | `false` | single-tier | Allocate and register CPU storage after startup. Requests admitted before initialization completes remain GPU-only for their lifetime. CUDA only. |
 | `block_size` | no | GPU block size | both | Offloaded block size in tokens; must be a multiple of the GPU block size. Mutually exclusive with `blocks_per_chunk`. |
 | `blocks_per_chunk` | no | `1` | both | Offloaded chunk size in GPU blocks; must be > 0. Alternative to `block_size` for models whose KV cache groups have different block sizes. |
 | `eviction_policy` | no | `lru` | both | Primary tier policy: built-in `lru`/`arc`, or a custom `CachePolicy` name (see [Custom Eviction Policies](#custom-eviction-policies)). |
@@ -78,6 +80,12 @@ vllm serve <model> \
 | `offload_prompt_only` | no | `true` | both | If `true`, only prompt (prefill) blocks are offloaded; decode blocks are skipped. |
 | `self_describing_kv_events` | no | `false` | both | Opt-in. When `true` *and* KV cache events are enabled (`--kv-events-config` with `enable_kv_cache_events`), the connector emits self-describing block-granular `BlockStored`/`BlockRemoved` payloads (constituent block hashes, whole-chunk `token_ids`, per-block `block_size`, parent hash, LoRA + group/cache-spec metadata) instead of the placeholder fallback, so external KV-event consumers can index offloaded blocks. Inert unless events are enabled. With `TieringOffloadingSpec`, a CPU promotion is self-describing when a local request observes its primary-tier `HIT` before event translation; otherwise its stored event may retain the placeholder, while a later `HIT` can backfill metadata for removal. Pending-removal/re-promotion races and externally initiated promotions may also produce placeholders, and consumers must ignore removals for unknown hashes. Partial recurrent tails emit the hash-aligned portion from the physical block start through the tail boundary. Other sliding-window/SSM chunks keep the placeholder fallback. In chunk mode (`block_size` > GPU block size, or `blocks_per_chunk` > 1), overlapping chunks re-announce shared per-block hashes, so consumers must reference-count (deduplicate) repeated store/remove announcements. |
 | `spec_module_path` | no | — | both | Python import path for a custom `OffloadingSpec` not in the built-in registry. Required only when `spec_name` is not built-in (advanced). |
+
+Asynchronous initialization moves CPU allocation, page population, and host
+registration off the startup path. The connector becomes active only after all
+worker ranks report ready. Initialization failure leaves the connector disabled
+while normal GPU-only serving continues. Host registration can still compete
+with inference for CPU and driver resources during this period.
 
 ## Custom Eviction Policies
 

--- a/tests/v1/kv_connector/unit/test_connector_init_status.py
+++ b/tests/v1/kv_connector/unit/test_connector_init_status.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the generic asynchronous connector-init readiness handshake."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    ConnectorInitState,
+    KVConnectorBase_V1,
+    KVConnectorRankInitStatus,
+    KVConnectorRole,
+    NoOpKVConnectorMetadata,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+class _FakeConnector(KVConnectorBase_V1):
+    """Minimal concrete connector: only the init-state hook is meaningful."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state: ConnectorInitState | None = None
+
+    def get_connector_init_state(self) -> ConnectorInitState | None:
+        return self.state
+
+    def get_num_new_matched_tokens(self, request, num_computed_tokens):
+        return 0, False
+
+    def update_state_after_alloc(self, request, blocks, num_external_tokens):
+        pass
+
+    def build_connector_meta(self, scheduler_output):
+        return NoOpKVConnectorMetadata()
+
+    def start_load_kv(self, forward_context: Any, **kwargs: Any) -> None:
+        pass
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        pass
+
+    def save_kv_layer(self, layer_name, kv_layer, attn_metadata, **kwargs):
+        pass
+
+    def wait_for_save(self):
+        pass
+
+
+def _make_connector(
+    role: KVConnectorRole, rank: int = 0, world_size: int = 2
+) -> _FakeConnector:
+    vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(is_kv_producer=True),
+        parallel_config=SimpleNamespace(rank=rank, world_size=world_size),
+    )
+    return _FakeConnector(vllm_config, role, SimpleNamespace())
+
+
+# ---------------------------------------------------------------------------
+# KVConnectorRankInitStatus.aggregate — pure union semantics
+# ---------------------------------------------------------------------------
+
+
+def test_rank_init_status_aggregate_unions_ready_ranks():
+    """aggregate() must union ready_ranks from both statuses."""
+    a = KVConnectorRankInitStatus(ready_ranks={0})
+    b = KVConnectorRankInitStatus(ready_ranks={1})
+    assert a.aggregate(b).ready_ranks == {0, 1}
+
+
+# ---------------------------------------------------------------------------
+# is_connector_ready
+# ---------------------------------------------------------------------------
+
+
+def test_is_connector_ready_true_when_async_init_disabled():
+    """Without enable_async_init(), the connector is ready immediately."""
+    connector = _make_connector(KVConnectorRole.WORKER)
+    assert connector.is_connector_ready() is True
+
+
+def test_worker_is_connector_ready_tracks_own_init_state():
+    """A worker's readiness must follow get_connector_init_state() directly."""
+    connector = _make_connector(KVConnectorRole.WORKER)
+    connector.enable_async_init()
+    connector.state = ConnectorInitState.INITIALIZING
+    assert connector.is_connector_ready() is False
+    connector.state = ConnectorInitState.READY
+    assert connector.is_connector_ready() is True
+
+
+# ---------------------------------------------------------------------------
+# build_connector_init_status — worker side
+# ---------------------------------------------------------------------------
+
+
+def test_build_connector_init_status_reports_own_rank_when_ready():
+    connector = _make_connector(KVConnectorRole.WORKER, rank=1)
+    connector.enable_async_init()
+    connector.state = ConnectorInitState.READY
+    status = connector.build_connector_init_status()
+    assert isinstance(status, KVConnectorRankInitStatus)
+    assert status.ready_ranks == {1}
+
+
+def test_build_connector_init_status_empty_while_initializing():
+    connector = _make_connector(KVConnectorRole.WORKER, rank=1)
+    connector.enable_async_init()
+    connector.state = ConnectorInitState.INITIALIZING
+    status = connector.build_connector_init_status()
+    assert status.ready_ranks == set()
+
+
+def test_build_connector_init_status_none_once_scheduler_acknowledged():
+    """Binding real metadata marks the report acknowledged; no further
+    status reports should be built afterwards."""
+    connector = _make_connector(KVConnectorRole.WORKER)
+    connector.enable_async_init()
+    connector.state = ConnectorInitState.READY
+    connector.bind_connector_metadata(SimpleNamespace())
+    assert connector.build_connector_init_status() is None
+
+
+# ---------------------------------------------------------------------------
+# update_connector_init_status — scheduler side
+# ---------------------------------------------------------------------------
+
+
+def test_update_connector_init_status_ready_once_all_ranks_report():
+    connector = _make_connector(KVConnectorRole.SCHEDULER, world_size=2)
+    connector.enable_async_init()
+    assert connector.is_connector_ready() is False
+
+    connector.update_connector_init_status(KVConnectorRankInitStatus(ready_ranks={0}))
+    assert connector.is_connector_ready() is False
+
+    connector.update_connector_init_status(KVConnectorRankInitStatus(ready_ranks={1}))
+    assert connector.is_connector_ready() is True
+
+
+def test_update_connector_init_status_noop_for_worker_role():
+    """This method only applies scheduler-side; a worker's readiness must
+    keep tracking its own init state instead."""
+    connector = _make_connector(KVConnectorRole.WORKER, world_size=1)
+    connector.enable_async_init()
+    connector.update_connector_init_status(KVConnectorRankInitStatus(ready_ranks={0}))
+    assert connector.is_connector_ready() is False

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -393,7 +393,12 @@ def test_multi_example_connector_consistency():
 def _ignore_event_collection(events: list[str]) -> list[str]:
     # Filter out per-step polling hooks that the scheduler calls repeatedly
     # and which are not meaningful state transitions for these assertions.
-    ignored = {"get_kv_connector_stats", "has_pending_push_work", "take_events"}
+    ignored = {
+        "get_kv_connector_stats",
+        "has_pending_push_work",
+        "is_connector_ready",
+        "take_events",
+    }
     return [event for event in events if event not in ignored]
 
 
@@ -855,6 +860,8 @@ def test_multi_connector_overrides_all_base_methods():
     # TODO(https://github.com/vllm-project/vllm/pull/31811): Remove
     # get_kv_connector_kv_cache_events from INHERITED_OK once implemented.
     INHERITED_OK = {
+        "enable_async_init",
+        "get_connector_init_state",
         "role",
         "has_connector_metadata",
         "get_kv_connector_kv_cache_events",

--- a/tests/v1/kv_offload/cpu/test_canonical_layout.py
+++ b/tests/v1/kv_offload/cpu/test_canonical_layout.py
@@ -19,7 +19,6 @@ from vllm.v1.kv_offload.cpu.gpu_worker import (
     _build_copy_plan,
     _canonical_block_sizes,
     _canonical_page_ids,
-    pin_mmap_region,
 )
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
@@ -239,8 +238,8 @@ def test_cross_topology_roundtrip(writer_tp: int, reader_tp: int):
         )
         regions.append(region)
         # The Triton load path dereferences CPU pointers on the GPU, which is
-        # only legal on pinned memory; production pins via CPUOffloadingWorker
-        pin_mmap_region(region)
+        # only legal on pinned memory.
+        region.pin()
         return region.create_next_canonical_view(_CANONICAL_PAGE)
 
     try:

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -10,10 +10,11 @@ import os
 import threading
 import time
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
+import vllm.v1.kv_offload.cpu.shared_offload_region as region_module
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.kv_offload.cpu.shared_offload_region import (
     SharedOffloadRegion,
@@ -223,6 +224,85 @@ def _mp_barrier_construct_and_hold(
 def iid():
     """Fresh instance ID for each test."""
     return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# pin — incremental CUDA registration
+# ---------------------------------------------------------------------------
+
+
+def _cuda_result(value: int) -> MagicMock:
+    result = MagicMock()
+    result.value = value
+    return result
+
+
+def test_pin_registers_and_unregisters_each_chunk(monkeypatch, iid):
+    """Incremental pinning must register and later unregister every range."""
+    cudart = MagicMock()
+    cudart.cudaHostRegister.return_value = _cuda_result(0)
+    cudart.cudaHostUnregister.return_value = _cuda_result(0)
+    sleep = MagicMock()
+    monkeypatch.setattr(region_module.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(region_module.torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(region_module.time, "sleep", sleep)
+
+    with _region(iid, num_blocks=5) as r:
+        base_ptr = r._base.data_ptr()
+        r.pin(chunk_size_bytes=2 * PAGE_SIZE)
+
+        assert r.is_pinned
+        assert cudart.cudaHostRegister.call_args_list == [
+            call(base_ptr, 2 * PAGE_SIZE, 0),
+            call(base_ptr + 2 * PAGE_SIZE, 2 * PAGE_SIZE, 0),
+            call(base_ptr + 4 * PAGE_SIZE, PAGE_SIZE, 0),
+        ]
+        assert sleep.call_args_list == [
+            call(region_module._HOST_REGISTER_YIELD_SECONDS),
+            call(region_module._HOST_REGISTER_YIELD_SECONDS),
+        ]
+
+    assert cudart.cudaHostUnregister.call_args_list == [
+        call(base_ptr + 4 * PAGE_SIZE),
+        call(base_ptr + 2 * PAGE_SIZE),
+        call(base_ptr),
+    ]
+
+
+def test_pin_rolls_back_registered_chunks_on_failure(monkeypatch, iid):
+    """A failed chunk must leave the region completely unregistered."""
+    cudart = MagicMock()
+    cudart.cudaHostRegister.side_effect = [_cuda_result(0), _cuda_result(2)]
+    cudart.cudaHostUnregister.return_value = _cuda_result(0)
+    monkeypatch.setattr(region_module.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(region_module.torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(region_module.time, "sleep", MagicMock())
+
+    with _region(iid, num_blocks=5) as r:
+        base_ptr = r._base.data_ptr()
+        r.pin(chunk_size_bytes=2 * PAGE_SIZE)
+
+        assert not r.is_pinned
+        assert r._registered_ptrs == []
+        cudart.cudaHostUnregister.assert_called_once_with(base_ptr)
+
+
+def test_pin_without_chunk_size_uses_one_registration(monkeypatch, iid):
+    """Synchronous initialization keeps the monolithic fast path."""
+    cudart = MagicMock()
+    cudart.cudaHostRegister.return_value = _cuda_result(0)
+    cudart.cudaHostUnregister.return_value = _cuda_result(0)
+    sleep = MagicMock()
+    monkeypatch.setattr(region_module.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(region_module.torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(region_module.time, "sleep", sleep)
+
+    with _region(iid, num_blocks=5) as r:
+        base_ptr = r._base.data_ptr()
+        r.pin()
+
+        cudart.cudaHostRegister.assert_called_once_with(base_ptr, r.total_size_bytes, 0)
+        sleep.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
+import vllm.utils.host_memory as host_memory_module
 import vllm.v1.kv_offload.cpu.shared_offload_region as region_module
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.kv_offload.cpu.shared_offload_region import (
@@ -258,8 +259,8 @@ def test_pin_registers_and_unregisters_each_chunk(monkeypatch, iid):
             call(base_ptr + 4 * PAGE_SIZE, PAGE_SIZE, 0),
         ]
         assert sleep.call_args_list == [
-            call(region_module._HOST_REGISTER_YIELD_SECONDS),
-            call(region_module._HOST_REGISTER_YIELD_SECONDS),
+            call(host_memory_module._HOST_REGISTER_YIELD_SECONDS),
+            call(host_memory_module._HOST_REGISTER_YIELD_SECONDS),
         ]
 
     assert cudart.cudaHostUnregister.call_args_list == [

--- a/tests/v1/kv_offload/test_async_host_buffer.py
+++ b/tests/v1/kv_offload/test_async_host_buffer.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for AsyncHostBuffer."""
+
+import threading
+import time
+
+import pytest
+
+from vllm.v1.kv_offload.async_host_buffer import AsyncHostBuffer
+
+pytestmark = pytest.mark.cpu_test
+
+POLL_TIMEOUT_S = 5.0
+
+
+def _poll_until_ready(buf: AsyncHostBuffer, timeout: float = POLL_TIMEOUT_S):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resource = buf.poll()
+        if resource is not None:
+            return resource
+        time.sleep(0.005)
+    pytest.fail("poll() never returned the built resource")
+
+
+# ---------------------------------------------------------------------------
+# poll() — single-owner handoff
+# ---------------------------------------------------------------------------
+
+
+def test_poll_returns_none_while_building():
+    """poll() must return None before allocate() has finished."""
+    release = threading.Event()
+    buf = AsyncHostBuffer(
+        allocate=lambda: release.wait(timeout=POLL_TIMEOUT_S) and "resource",
+        cleanup=lambda r: None,
+        thread_name="t",
+    )
+    try:
+        assert buf.poll() is None
+    finally:
+        release.set()
+        buf.close()
+
+
+def test_poll_returns_resource_once_built():
+    """poll() must return the resource once allocate() completes."""
+    buf = AsyncHostBuffer(
+        allocate=lambda: "resource", cleanup=lambda r: None, thread_name="t"
+    )
+    assert _poll_until_ready(buf) == "resource"
+
+
+def test_second_poll_returns_none_after_adoption():
+    """Once adopted, later poll() calls must return None — single owner."""
+    buf = AsyncHostBuffer(
+        allocate=lambda: "resource", cleanup=lambda r: None, thread_name="t"
+    )
+    _poll_until_ready(buf)
+    assert buf.poll() is None
+
+
+def test_poll_sets_failed_and_returns_none_when_allocate_raises():
+    """A raising allocate() must not be adopted, and must flip `failed`."""
+
+    def allocate():
+        raise RuntimeError("boom")
+
+    buf = AsyncHostBuffer(allocate=allocate, cleanup=lambda r: None, thread_name="t")
+    buf._thread.join(timeout=POLL_TIMEOUT_S)
+    assert not buf.failed  # not observed until poll() is called
+    assert buf.poll() is None
+    assert buf.failed
+
+
+# ---------------------------------------------------------------------------
+# close() — exactly-once cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_close_cleans_up_unadopted_resource():
+    """close() must invoke cleanup() on a built-but-never-adopted resource."""
+    cleaned = threading.Event()
+    buf = AsyncHostBuffer(
+        allocate=lambda: "resource",
+        cleanup=lambda r: cleaned.set(),
+        thread_name="t",
+    )
+    buf.close(timeout=POLL_TIMEOUT_S)
+    assert cleaned.is_set()
+
+
+def test_close_after_adoption_does_not_clean_up():
+    """close() must be a no-op once the caller has adopted the resource."""
+    cleaned = threading.Event()
+    buf = AsyncHostBuffer(
+        allocate=lambda: "resource",
+        cleanup=lambda r: cleaned.set(),
+        thread_name="t",
+    )
+    _poll_until_ready(buf)
+    buf.close(timeout=POLL_TIMEOUT_S)
+    assert not cleaned.is_set()
+
+
+def test_close_timeout_abandons_without_blocking_and_still_cleans_up():
+    """close() must return by `timeout` even if allocate() is still running,
+    and the background thread must clean up the resource once it finishes."""
+    release = threading.Event()
+    cleaned = threading.Event()
+    buf = AsyncHostBuffer(
+        allocate=lambda: release.wait(timeout=POLL_TIMEOUT_S) and "resource",
+        cleanup=lambda r: cleaned.set(),
+        thread_name="t",
+    )
+
+    start = time.monotonic()
+    buf.close(timeout=0.05)
+    assert time.monotonic() - start < POLL_TIMEOUT_S / 2
+
+    release.set()
+    assert cleaned.wait(timeout=POLL_TIMEOUT_S), (
+        "abandoned resource was never cleaned up"
+    )

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -386,6 +386,24 @@ def test_cpu_spec_create_worker_uses_mmap_on_cuda_alike(monkeypatch):
     assert worker_calls[0]["mmap_region"] is region
 
 
+def test_cpu_spec_async_init_pins_shared_region_incrementally(monkeypatch):
+    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
+
+    spec = _create_spec(
+        cpu_bytes_to_use=SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT * 8,
+        worker_kv_bytes_per_block=SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT,
+    )
+    assert isinstance(spec, CPUOffloadingSpec)
+    region = MagicMock()
+    monkeypatch.setattr(spec, "_create_region", MagicMock(return_value=region))
+    monkeypatch.setattr(cpu_spec_module, "PIN_MEMORY", True)
+
+    assert spec._create_pinned_region(0) is region
+    region.pin.assert_called_once_with(
+        chunk_size_bytes=cpu_spec_module._ASYNC_HOST_REGISTER_CHUNK_SIZE_BYTES
+    )
+
+
 def test_cpu_spec_create_worker_uses_tensor_path_off_cuda_alike(monkeypatch):
     import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
 

--- a/tests/v1/kv_offload/test_host_memory.py
+++ b/tests/v1/kv_offload/test_host_memory.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the chunked host-registration helpers."""
+
+from __future__ import annotations
+
+import mmap
+from unittest.mock import MagicMock
+
+import pytest
+
+import vllm.utils.host_memory as host_memory
+
+pytestmark = pytest.mark.cpu_test
+
+PAGE = mmap.PAGESIZE
+
+
+def _mock_cudart(monkeypatch, registered: list[tuple[int, int]]) -> None:
+    cudart = MagicMock()
+
+    def _register(ptr: int, size: int, _flags: int) -> MagicMock:
+        registered.append((ptr, size))
+        return MagicMock(value=0)
+
+    cudart.cudaHostRegister.side_effect = _register
+    monkeypatch.setattr(host_memory.torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(host_memory.time, "sleep", MagicMock())
+
+
+def test_chunked_registration_cuts_on_page_boundaries(monkeypatch):
+    """Interior chunk cuts must land on page boundaries even for an unaligned
+    base: cudaHostRegister locks whole pages and rejects a range overlapping
+    an already-registered page, so a mid-page cut would fail."""
+    registered: list[tuple[int, int]] = []
+    _mock_cudart(monkeypatch, registered)
+
+    base = 100 * PAGE + 64  # torch CPU allocations are only 64-byte aligned
+    nbytes = 4 * PAGE
+    ptrs = host_memory.host_register_chunked(base, nbytes, chunk_size_bytes=2 * PAGE)
+
+    assert ptrs == [ptr for ptr, _ in registered]
+    assert len(registered) > 1
+    # The ranges must tile [base, base + nbytes) with no gap or overlap.
+    pos = base
+    for ptr, size in registered:
+        assert ptr == pos
+        assert ptr == base or ptr % PAGE == 0
+        pos = ptr + size
+    assert pos == base + nbytes
+
+
+def test_chunked_registration_rejects_non_page_multiple():
+    with pytest.raises(ValueError, match="page multiple"):
+        host_memory.host_register_chunked(0, PAGE, chunk_size_bytes=100)
+
+
+def test_chunked_registration_cuts_respect_copy_units(monkeypatch):
+    """Chunking creates multiple pinned regions and a CUDA copy spanning two
+    is rejected, so with a copy unit every cut must land on both the page
+    grid and the copy-unit grid."""
+    registered: list[tuple[int, int]] = []
+    _mock_cudart(monkeypatch, registered)
+
+    copy_unit = 61 * 512  # 31232 B, not a page multiple
+    base = 4096 * PAGE  # page-aligned, as copy_unit_bytes requires
+    nbytes = 40 * copy_unit
+    ptrs = host_memory.host_register_chunked(
+        base, nbytes, chunk_size_bytes=8 * PAGE, copy_unit_bytes=copy_unit
+    )
+
+    assert ptrs == [ptr for ptr, _ in registered]
+    assert len(registered) > 1
+    pos = base
+    for ptr, size in registered:
+        assert ptr == pos
+        assert ptr % PAGE == 0
+        assert (ptr - base) % copy_unit == 0
+        pos = ptr + size
+    assert pos == base + nbytes
+
+
+def test_chunked_registration_rolls_back_on_failure(monkeypatch):
+    """A failed registration must unregister the batches pinned so far and
+    surface as HostRegisterError."""
+    registered: list[tuple[int, int]] = []
+    unregistered: list[int] = []
+    cudart = MagicMock()
+
+    def _register(ptr: int, size: int, _flags: int) -> MagicMock:
+        registered.append((ptr, size))
+        return MagicMock(value=0 if len(registered) < 2 else 2)
+
+    def _unregister(ptr: int) -> MagicMock:
+        unregistered.append(ptr)
+        return MagicMock(value=0)
+
+    cudart.cudaHostRegister.side_effect = _register
+    cudart.cudaHostUnregister.side_effect = _unregister
+    monkeypatch.setattr(host_memory.torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(host_memory.time, "sleep", MagicMock())
+
+    base = 100 * PAGE
+    with pytest.raises(host_memory.HostRegisterError):
+        host_memory.host_register_chunked(base, 4 * PAGE, chunk_size_bytes=PAGE)
+    assert unregistered == [base]
+
+
+def test_chunked_registration_rejects_unaligned_base_with_copy_unit():
+    with pytest.raises(ValueError, match="page-aligned"):
+        host_memory.host_register_chunked(
+            64, 4 * PAGE, chunk_size_bytes=PAGE, copy_unit_bytes=512
+        )
+
+
+def test_chunked_registration_rejects_non_positive_copy_unit():
+    with pytest.raises(ValueError, match="positive"):
+        host_memory.host_register_chunked(
+            0, 4 * PAGE, chunk_size_bytes=PAGE, copy_unit_bytes=0
+        )
+
+
+def test_alloc_page_aligned_zeros():
+    tensor = host_memory.alloc_page_aligned_zeros(10_000)
+    assert tensor.data_ptr() % PAGE == 0
+    assert tensor.nbytes == 10_000
+    assert tensor.count_nonzero().item() == 0

--- a/tests/v1/simple_kv_offload/test_async_init.py
+++ b/tests/v1/simple_kv_offload/test_async_init.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for asynchronous CPU cache initialization (``async_init``).
+
+Scheduler-side gating and the rank-readiness handshake are generic and covered
+by tests/v1/kv_connector/unit/test_connector_init_status.py; these tests cover
+the SimpleCPUOffloadConnector wiring and the worker-side state machine.
+"""
+
+from __future__ import annotations
+
+import mmap
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+import vllm.v1.simple_kv_offload.worker as worker_module
+from tests.v1.simple_kv_offload.test_scheduler import (
+    _make_kv_cache_config,
+    _make_vllm_config,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    ConnectorInitState,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    SimpleCPUOffloadConnector,
+)
+from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker, _CpuCaches
+
+pytestmark = pytest.mark.cpu_test
+
+_POLL_TIMEOUT_S = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_connector(
+    role: KVConnectorRole, **extra_config: Any
+) -> SimpleCPUOffloadConnector:
+    vllm_config = _make_vllm_config()
+    vllm_config.kv_transfer_config.kv_connector_extra_config = extra_config
+    return SimpleCPUOffloadConnector(vllm_config, role, _make_kv_cache_config(16))
+
+
+def _make_worker(async_init: bool = False) -> SimpleCPUOffloadWorker:
+    return SimpleCPUOffloadWorker(
+        MagicMock(), MagicMock(), cpu_capacity_bytes=1024, async_init=async_init
+    )
+
+
+def _wait_for_state(worker: SimpleCPUOffloadWorker) -> ConnectorInitState:
+    """Poll until the background initialization resolves, driving adoption."""
+    deadline = time.monotonic() + _POLL_TIMEOUT_S
+    while (state := worker.get_init_state()) is ConnectorInitState.INITIALIZING:
+        assert time.monotonic() < deadline, "async init did not resolve in time"
+        time.sleep(0.01)
+    return state
+
+
+def _cuda_platform(monkeypatch: pytest.MonkeyPatch, is_cuda: bool) -> None:
+    import vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector as connector_module  # noqa: E501
+
+    monkeypatch.setattr(connector_module.current_platform, "is_cuda", lambda: is_cuda)
+
+
+# ---------------------------------------------------------------------------
+# Connector-level config validation and wiring
+# ---------------------------------------------------------------------------
+
+
+def test_async_init_must_be_boolean():
+    with pytest.raises(ValueError, match="boolean"):
+        _make_connector(KVConnectorRole.SCHEDULER, async_init="yes")
+
+
+def test_async_init_rejected_with_disk_backend(monkeypatch, tmp_path):
+    _cuda_platform(monkeypatch, True)
+    with pytest.raises(ValueError, match="disk"):
+        _make_connector(
+            KVConnectorRole.SCHEDULER,
+            async_init=True,
+            kv_offload_backend="disk",
+            disk_path=str(tmp_path / "kv"),
+        )
+
+
+def test_async_init_rejected_off_cuda(monkeypatch):
+    _cuda_platform(monkeypatch, False)
+    with pytest.raises(ValueError, match="CUDA"):
+        _make_connector(KVConnectorRole.SCHEDULER, async_init=True)
+
+
+def test_sync_connector_is_ready_immediately():
+    connector = _make_connector(KVConnectorRole.WORKER)
+    assert connector.is_connector_ready() is True
+    assert connector.get_connector_init_state() is None
+
+
+def test_async_worker_connector_reports_ready_after_init(monkeypatch):
+    """Readiness must follow the worker handler's init state end to end."""
+    _cuda_platform(monkeypatch, True)
+    connector = _make_connector(KVConnectorRole.WORKER, async_init=True)
+    assert connector.is_connector_ready() is False
+
+    # Nothing to offload resolves initialization instantly.
+    connector.register_kv_caches({})
+    assert connector.get_connector_init_state() is ConnectorInitState.READY
+    assert connector.is_connector_ready() is True
+
+    status = connector.build_connector_init_status()
+    assert status is not None and status.ready_ranks == {0}
+
+
+# ---------------------------------------------------------------------------
+# Worker-side state machine
+# ---------------------------------------------------------------------------
+
+
+def test_worker_sync_mode_has_no_init_state():
+    assert _make_worker(async_init=False).get_init_state() is None
+
+
+def test_worker_initializing_before_register_kv_caches():
+    worker = _make_worker(async_init=True)
+    assert worker.get_init_state() is ConnectorInitState.INITIALIZING
+
+
+def test_worker_ready_when_nothing_to_offload():
+    worker = _make_worker(async_init=True)
+    worker.register_kv_caches({})
+    assert worker.get_init_state() is ConnectorInitState.READY
+
+
+def test_worker_adopts_caches_and_builds_backend_once(monkeypatch):
+    backend_cls = MagicMock()
+    monkeypatch.setattr(worker_module, "DmaCopyBackend", backend_cls)
+    worker = _make_worker(async_init=True)
+    worker.gpu_kv_caches = {"layer_0": torch.zeros(2, 32, dtype=torch.int8)}
+    caches = _CpuCaches({"layer_0": torch.zeros(2, 32, dtype=torch.int8)}, [])
+    buffer = MagicMock()
+    buffer.poll.side_effect = [None, caches]
+    buffer.failed = False
+    worker._cpu_init = buffer
+
+    assert worker.get_init_state() is ConnectorInitState.INITIALIZING
+    assert worker.get_init_state() is ConnectorInitState.READY
+    assert worker.cpu_kv_caches is caches.tensors
+
+    # Readiness must stick, and the backend must be built exactly once.
+    assert worker.get_init_state() is ConnectorInitState.READY
+    backend_cls.assert_called_once()
+
+
+def test_worker_backend_failure_at_adoption_is_terminal(monkeypatch):
+    """A backend-init failure must raise, unpin, and stay terminal."""
+    backend_cls = MagicMock()
+    backend_cls.return_value.init.side_effect = RuntimeError("backend boom")
+    monkeypatch.setattr(worker_module, "DmaCopyBackend", backend_cls)
+    worker = _make_worker(async_init=True)
+    worker.gpu_kv_caches = {"layer_0": torch.zeros(2, 32, dtype=torch.int8)}
+    caches = _CpuCaches({"layer_0": torch.zeros(2, 32, dtype=torch.int8)}, [1000])
+    buffer = MagicMock()
+    buffer.poll.return_value = caches
+    buffer.failed = False
+    worker._cpu_init = buffer
+    unregister = MagicMock()
+    monkeypatch.setattr(worker_module, "host_unregister", unregister)
+
+    with pytest.raises(RuntimeError, match="backend boom"):
+        worker.get_init_state()
+    unregister.assert_called_once_with([1000])
+    assert worker.cpu_kv_caches is None
+    with pytest.raises(RuntimeError, match="initialization failed"):
+        worker.get_init_state()
+
+
+def test_worker_shutdown_closes_unadopted_buffer():
+    worker = _make_worker(async_init=True)
+    buffer = MagicMock()
+    worker._cpu_init = buffer
+    worker.shutdown()
+    buffer.close.assert_called_once()
+
+
+def test_allocation_passes_copy_unit_and_aligned_base(monkeypatch):
+    """The worker must hand pin_tensor a page-aligned tensor and the block-row
+    size as the copy unit, so no block copy can straddle pinned regions."""
+    pins: list[tuple[int, int, int | None, int | None]] = []
+
+    def _record_pin(
+        tensor: torch.Tensor,
+        chunk: int | None = None,
+        copy_unit_bytes: int | None = None,
+    ) -> list[int]:
+        pins.append((tensor.data_ptr(), tensor.nbytes, chunk, copy_unit_bytes))
+        return []
+
+    monkeypatch.setattr(worker_module, "pin_tensor", _record_pin)
+    shape, dtype = (7, 61, 256), torch.float16  # row = 31232 B, not a page multiple
+    caches = worker_module._allocate_cpu_caches(
+        {"layer_0": (shape, dtype)}, pin_memory=True, chunk_size_bytes=256 * 2**20
+    )
+
+    ((ptr, nbytes, _chunk, copy_unit),) = pins
+    row_bytes = 61 * 256 * dtype.itemsize
+    assert ptr % mmap.PAGESIZE == 0
+    assert copy_unit == row_bytes
+    tensor = caches.tensors["layer_0"]
+    assert tensor.data_ptr() == ptr and tensor.shape == shape
+    assert nbytes == 7 * row_bytes
+
+
+# ---------------------------------------------------------------------------
+# Background allocation through a real AsyncHostBuffer
+# ---------------------------------------------------------------------------
+
+
+def test_async_build_starts_at_first_poll_not_at_register(monkeypatch):
+    """register_kv_caches must not start the background build: engine warmup
+    captures CUDA graphs after it, and a concurrent cudaHostRegister
+    invalidates an in-progress capture."""
+    monkeypatch.setattr(worker_module, "PIN_MEMORY", False)
+    builds: list[MagicMock] = []
+
+    def _fake_buffer(**kwargs: Any) -> MagicMock:
+        buffer = MagicMock()
+        buffer.poll.return_value = None
+        buffer.failed = False
+        builds.append(buffer)
+        return buffer
+
+    monkeypatch.setattr(worker_module, "AsyncHostBuffer", _fake_buffer)
+    worker = _make_worker(async_init=True)
+    worker.gpu_kv_caches = {"layer_0": torch.zeros(4, 32, dtype=torch.int8)}
+    worker.num_cpu_blocks = 2
+
+    worker._init_cpu_mode(worker.gpu_kv_caches, 32)
+    assert not builds
+
+    assert worker.get_init_state() is ConnectorInitState.INITIALIZING
+    assert len(builds) == 1
+
+
+def test_async_allocation_resolves_to_ready(monkeypatch):
+    monkeypatch.setattr(worker_module, "PIN_MEMORY", False)
+    monkeypatch.setattr(worker_module, "DmaCopyBackend", MagicMock())
+    worker = _make_worker(async_init=True)
+    worker.gpu_kv_caches = {"layer_0": torch.zeros(4, 32, dtype=torch.int8)}
+    worker.num_cpu_blocks = 2
+
+    worker._init_cpu_mode(worker.gpu_kv_caches, 32)
+
+    assert _wait_for_state(worker) is ConnectorInitState.READY
+    assert worker.cpu_kv_caches is not None
+    assert worker.cpu_kv_caches["layer_0"].shape == (2, 32)
+
+
+def test_async_allocation_failure_is_terminal(monkeypatch):
+    monkeypatch.setattr(worker_module, "PIN_MEMORY", False)
+
+    def boom(*_args: Any, **_kwargs: Any) -> _CpuCaches:
+        raise RuntimeError("allocation boom")
+
+    monkeypatch.setattr(worker_module, "_allocate_cpu_caches", boom)
+    worker = _make_worker(async_init=True)
+    worker.gpu_kv_caches = {"layer_0": torch.zeros(4, 32, dtype=torch.int8)}
+    worker.num_cpu_blocks = 2
+
+    worker._init_cpu_mode(worker.gpu_kv_caches, 32)
+
+    deadline = time.monotonic() + _POLL_TIMEOUT_S
+    while time.monotonic() < deadline:
+        try:
+            state = worker.get_init_state()
+        except RuntimeError:
+            break
+        assert state is ConnectorInitState.INITIALIZING
+        time.sleep(0.01)
+    else:
+        pytest.fail("failed async init never raised")
+    with pytest.raises(RuntimeError, match="initialization failed"):
+        worker.get_init_state()

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call
 
 import pytest
 import torch
@@ -16,6 +17,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.kv_connector import ActiveKVConnector
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 
@@ -213,3 +215,20 @@ def test_append_block_ids_rejects_write_past_row_capacity():
         )
 
     assert block_tables.num_blocks.np[0, 1] == 3
+
+
+def test_kv_connector_builds_worker_metadata_after_polling_completions():
+    """Transfer completions must be included in the current worker metadata."""
+    connector = MagicMock()
+    connector.has_connector_metadata.return_value = True
+    connector.get_finished.return_value = (set(), set())
+
+    active_connector = ActiveKVConnector.__new__(ActiveKVConnector)
+    active_connector._disabled = False
+    active_connector.kv_connector = connector
+
+    active_connector.post_forward(set())
+
+    assert connector.method_calls.index(call.get_finished(set())) < (
+        connector.method_calls.index(call.build_connector_worker_meta())
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -92,6 +92,7 @@ class KVOutputAggregator:
         finished_recving = set[str]()
         aggregated_kv_connector_stats = None
         aggregated_kv_connector_worker_meta = None
+        aggregated_kv_connector_init_status = None
         combined_kv_cache_events = None
         invalid_block_ids = set[int]()
         for model_runner_output in outputs:
@@ -142,6 +143,15 @@ class KVOutputAggregator:
                     )
                 )
 
+            if aggregated_kv_connector_init_status is None:
+                aggregated_kv_connector_init_status = kv_output.kv_connector_init_status
+            elif kv_connector_init_status := kv_output.kv_connector_init_status:
+                aggregated_kv_connector_init_status = (
+                    aggregated_kv_connector_init_status.aggregate(
+                        kv_connector_init_status
+                    )
+                )
+
             # Combine kv_cache_events from all workers.
             if combined_kv_cache_events is None:
                 # Use the first worker's kv_cache events as start event list.
@@ -167,6 +177,7 @@ class KVOutputAggregator:
             kv_connector_stats=aggregated_kv_connector_stats or None,
             kv_cache_events=combined_kv_cache_events or None,
             kv_connector_worker_meta=aggregated_kv_connector_worker_meta or None,
+            kv_connector_init_status=aggregated_kv_connector_init_status,
             invalid_block_ids=invalid_block_ids,
             expected_finished_count=self._expected_finished_count,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -43,6 +43,7 @@ The class provides the following primitives:
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -147,6 +148,48 @@ class KVConnectorMetadata(ABC):  # noqa: B024
     pass
 
 
+class NoOpKVConnectorMetadata(KVConnectorMetadata):
+    """Placeholder emitted while a connector is not ready to accept work.
+
+    Callers must detect it by type: a real connector may legitimately produce
+    empty metadata for a step, and that still has to be bound.
+    """
+
+    pass
+
+
+class ConnectorInitState(enum.Enum):
+    """Local state of a connector's asynchronous initialization.
+
+    There is no FAILED state: a worker that fails to initialize raises
+    instead, which brings down the whole engine rather than degrading.
+    """
+
+    INITIALIZING = enum.auto()
+    READY = enum.auto()
+
+
+class KVConnectorInitStatus(ABC):
+    """Worker-to-scheduler status for asynchronous connector initialization."""
+
+    @abstractmethod
+    def aggregate(self, other: "KVConnectorInitStatus") -> "KVConnectorInitStatus":
+        """Combine statuses reported by different workers."""
+
+
+@dataclass
+class KVConnectorRankInitStatus(KVConnectorInitStatus):
+    """Initialization status reported by one or more connector ranks."""
+
+    ready_ranks: set[int] = field(default_factory=set)
+
+    def aggregate(self, other: KVConnectorInitStatus) -> KVConnectorInitStatus:
+        assert isinstance(other, KVConnectorRankInitStatus)
+        return KVConnectorRankInitStatus(
+            ready_ranks=self.ready_ranks | other.ready_ranks,
+        )
+
+
 class KVConnectorWorkerMetadata(ABC):
     """
     Abstract Metadata used to communicate back
@@ -212,6 +255,36 @@ class KVConnectorBase_V1(ABC):
             raise ValueError("kv_transfer_config must be set for KVConnectorBase_V1")
         self._kv_cache_config = kv_cache_config
         self._role = role
+        self._async_init_enabled = False
+        self._connector_ready = True
+        self._connector_init_report_acknowledged = False
+        self._ready_connector_ranks: set[int] = set()
+
+    def enable_async_init(self) -> None:
+        """Enable the generic asynchronous-initialization readiness handshake."""
+        self._async_init_enabled = True
+        self._connector_ready = False
+
+    def get_connector_init_state(self) -> ConnectorInitState | None:
+        """Return this worker's initialization state, or None when synchronous."""
+        return None
+
+    def is_connector_ready(self) -> bool:
+        """Whether this connector can accept new requests.
+
+        While this returns False the scheduler skips `on_new_request`,
+        `get_num_new_matched_tokens`, `update_state_after_alloc` and
+        `request_finished` for newly admitted requests, and hands the worker a
+        `NoOpKVConnectorMetadata` instead of calling `build_connector_meta`.
+        Those requests stay connector-ineligible for their whole lifetime, so a
+        connector never sees a later chunk of a request whose earlier chunks it
+        missed.
+        """
+        if not self._async_init_enabled:
+            return True
+        if self._role == KVConnectorRole.WORKER:
+            return self.get_connector_init_state() == ConnectorInitState.READY
+        return self._connector_ready
 
     @property
     def role(self) -> KVConnectorRole:
@@ -232,6 +305,10 @@ class KVConnectorBase_V1(ABC):
             connector_metadata (dict): the connector metadata.
         """
         self._connector_metadata = connector_metadata
+        if self._async_init_enabled and self._role == KVConnectorRole.WORKER:
+            # Real metadata is the scheduler's acknowledgement that it observed
+            # readiness, so this worker can stop sending status reports.
+            self._connector_init_report_acknowledged = True
 
     def clear_connector_metadata(self) -> None:
         """Clear the connector metadata.
@@ -431,6 +508,43 @@ class KVConnectorBase_V1(ABC):
             None if no worker metadata is available.
         """
         return None
+
+    def build_connector_init_status(self) -> KVConnectorInitStatus | None:
+        """Build this worker's asynchronous-initialization status report."""
+        if (
+            not self._async_init_enabled
+            or self._connector_init_report_acknowledged
+            or self._role != KVConnectorRole.WORKER
+        ):
+            return None
+        state = self.get_connector_init_state()
+        if state is None:
+            return None
+        rank = self._vllm_config.parallel_config.rank
+        return KVConnectorRankInitStatus(
+            ready_ranks={rank} if state == ConnectorInitState.READY else set(),
+        )
+
+    def update_connector_init_status(
+        self, status: KVConnectorInitStatus | None
+    ) -> None:
+        """Apply aggregated worker initialization status on the scheduler."""
+        if not self._async_init_enabled or self._role != KVConnectorRole.SCHEDULER:
+            return
+        if status is None:
+            return
+        assert isinstance(status, KVConnectorRankInitStatus)
+        if self._connector_ready:
+            return
+        self._ready_connector_ranks |= status.ready_ranks
+        if (
+            len(self._ready_connector_ranks)
+            == self._vllm_config.parallel_config.world_size
+        ):
+            logger.info(
+                "Asynchronous connector initialization completed on all workers"
+            )
+            self._connector_ready = True
 
     # ==============================
     # Scheduler-side methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -15,9 +15,11 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     CopyBlocksOp,
     KVConnectorBase_V1,
     KVConnectorHandshakeMetadata,
+    KVConnectorInitStatus,
     KVConnectorMetadata,
     KVConnectorRole,
     KVConnectorWorkerMetadata,
+    NoOpKVConnectorMetadata,
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -66,6 +68,27 @@ class MultiKVConnectorWorkerMetadata(KVConnectorWorkerMetadata):
                 metadata_list.append(metadata1.aggregate(metadata2))
 
         return MultiKVConnectorWorkerMetadata(metadata=tuple(metadata_list))
+
+
+@dataclass
+class MultiKVConnectorInitStatus(KVConnectorInitStatus):
+    """Initialization statuses for MultiConnector's children."""
+
+    statuses: tuple[KVConnectorInitStatus | None, ...]
+
+    def aggregate(self, other: KVConnectorInitStatus) -> KVConnectorInitStatus:
+        assert isinstance(other, MultiKVConnectorInitStatus)
+        assert len(self.statuses) == len(other.statuses)
+        return MultiKVConnectorInitStatus(
+            statuses=tuple(
+                right
+                if left is None
+                else left
+                if right is None
+                else left.aggregate(right)
+                for left, right in zip(self.statuses, other.statuses)
+            )
+        )
 
 
 @dataclass
@@ -202,6 +225,14 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         # a single connector to load.
         # Propagated from scheduler to worker side via the connector metadata.
         self._extra_async_saves: dict[str, int] = {}
+        # A request can use only the child connectors that were ready when it
+        # arrived. Preserve that eligibility across all chunks of the request.
+        self._ineligible_request_ids_by_connector = [
+            set[str]() for _ in self._connectors
+        ]
+
+    def is_connector_ready(self) -> bool:
+        return any(c.is_connector_ready() for c in self._connectors)
 
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:
@@ -259,7 +290,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)
         for c, cm in zip(self._connectors, connector_metadata.metadata):
-            c.bind_connector_metadata(cm)
+            if not isinstance(cm, NoOpKVConnectorMetadata):
+                c.bind_connector_metadata(cm)
         super().bind_connector_metadata(connector_metadata)
 
     def clear_connector_metadata(self) -> None:
@@ -283,13 +315,18 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     # ==============================
     # Worker-side methods
     # ==============================
+    # A child only holds metadata if its scheduler side was ready when the step
+    # was built, and the worker side goes ready first, so bound metadata already
+    # implies readiness here.
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         for c in self._connectors:
-            c.start_load_kv(forward_context, **kwargs)
+            if c.has_connector_metadata():
+                c.start_load_kv(forward_context, **kwargs)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         for c in self._connectors:
-            c.wait_for_layer_load(layer_name)
+            if c.has_connector_metadata():
+                c.wait_for_layer_load(layer_name)
 
     def save_kv_layer(
         self,
@@ -299,11 +336,13 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         **kwargs,
     ) -> None:
         for c in self._connectors:
-            c.save_kv_layer(layer_name, kv_layer, attn_metadata, **kwargs)
+            if c.has_connector_metadata():
+                c.save_kv_layer(layer_name, kv_layer, attn_metadata, **kwargs)
 
     def wait_for_save(self):
         for c in self._connectors:
-            c.wait_for_save()
+            if c.has_connector_metadata():
+                c.wait_for_save()
 
     def get_finished(
         self, finished_req_ids: set[str]
@@ -311,6 +350,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         finished_sending: set[str] = set()
         finished_recving: set[str] = set()
         for c in self._connectors:
+            if not c.has_connector_metadata():
+                continue
             sending, recving = c.get_finished(finished_req_ids)
             if not recving and not sending:
                 continue
@@ -335,7 +376,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     def get_block_ids_with_load_errors(self) -> set[int]:
         agg_block_ids: set[int] = set()
         for c in self._connectors:
-            agg_block_ids |= c.get_block_ids_with_load_errors()
+            if c.is_connector_ready():
+                agg_block_ids |= c.get_block_ids_with_load_errors()
         return agg_block_ids
 
     def set_host_xfer_buffer_ops(self, copy_operation: CopyBlocksOp):
@@ -347,7 +389,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         """Handle preempted requests for all sub-connectors."""
         assert isinstance(kv_connector_metadata, MultiKVConnectorMetadata)
         for c, cm in zip(self._connectors, kv_connector_metadata.metadata):
-            c.handle_preemptions(cm)
+            if not isinstance(cm, NoOpKVConnectorMetadata):
+                c.handle_preemptions(cm)
 
     def get_finished_count(self) -> int | None:
         child_counts = [
@@ -375,6 +418,12 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             return None
         return MultiKVConnectorWorkerMetadata(metadata=tuple(metadata_list))
 
+    def build_connector_init_status(self) -> KVConnectorInitStatus | None:
+        statuses = tuple(c.build_connector_init_status() for c in self._connectors)
+        if not any(status is not None for status in statuses):
+            return None
+        return MultiKVConnectorInitStatus(statuses=statuses)
+
     # TODO: Add a generic implementation of 'get_kv_connector_kv_cache_events'
     # method for the MultiConnector. It should be able to get events from
     # multiple connectors, handling the case where only a subset of the
@@ -391,6 +440,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     ) -> tuple[int | None, bool]:
         to_return = (0, False)
         for i, c in enumerate(self._connectors):
+            if request.request_id in self._ineligible_request_ids_by_connector[i]:
+                continue
             toks, load_async = c.get_num_new_matched_tokens(
                 request, num_computed_tokens
             )
@@ -410,6 +461,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     ):
         chosen_connector = self._requests_to_connector.get(request.request_id, -1)
         for i, c in enumerate(self._connectors):
+            if request.request_id in self._ineligible_request_ids_by_connector[i]:
+                continue
             if i == chosen_connector:
                 # Forward call to the chosen connector (if any).
                 c.update_state_after_alloc(request, blocks, num_external_tokens)
@@ -418,15 +471,27 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
                 c.update_state_after_alloc(request, blocks, 0)
 
     def on_new_request(self, request: "Request") -> None:
-        for c in self._connectors:
-            c.on_new_request(request)
+        for i, c in enumerate(self._connectors):
+            if c.is_connector_ready():
+                c.on_new_request(request)
+            else:
+                self._ineligible_request_ids_by_connector[i].add(request.request_id)
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> MultiKVConnectorMetadata:
+        # Each child only sees the requests it was told about; a child that was
+        # unavailable when a request arrived never observed it.
         metadata = MultiKVConnectorMetadata(
             metadata=tuple(
-                c.build_connector_meta(scheduler_output) for c in self._connectors
+                c.build_connector_meta(
+                    scheduler_output.without_requests(
+                        self._ineligible_request_ids_by_connector[i]
+                    )
+                )
+                if c.is_connector_ready()
+                else NoOpKVConnectorMetadata()
+                for i, c in enumerate(self._connectors)
             )
         )
         if self._extra_async_saves:
@@ -454,6 +519,15 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         finally:
             # restore kv_connector_worker_meta
             connector_output.kv_connector_worker_meta = multi_connector_worker_meta
+
+    def update_connector_init_status(
+        self, status: KVConnectorInitStatus | None
+    ) -> None:
+        if status is None:
+            return
+        assert isinstance(status, MultiKVConnectorInitStatus)
+        for connector, child_status in zip(self._connectors, status.statuses):
+            connector.update_connector_init_status(child_status)
 
     def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
         """
@@ -491,7 +565,12 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     ) -> tuple[bool, dict[str, Any] | None]:
         async_saves = 0
         kv_txfer_params = None
-        for c in self._connectors:
+        for connector_idx, c in enumerate(self._connectors):
+            if (
+                request.request_id
+                in self._ineligible_request_ids_by_connector[connector_idx]
+            ):
+                continue
             async_save, txfer_params = per_connector_fn(c)
             if async_save:
                 async_saves += 1
@@ -510,6 +589,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             self._extra_async_saves[request.request_id] = async_saves - 1
 
         self._requests_to_connector.pop(request.request_id, None)
+        for request_ids in self._ineligible_request_ids_by_connector:
+            request_ids.discard(request.request_id)
 
         return async_saves > 0, kv_txfer_params
 
@@ -544,10 +625,14 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
 
     def take_events(self) -> Iterable["KVCacheEvent"]:
         for c in self._connectors:
-            yield from c.take_events()
+            if c.is_connector_ready():
+                yield from c.take_events()
 
     def has_pending_push_work(self) -> bool:
-        return any(c.has_pending_push_work() for c in self._connectors)
+        return any(
+            c.is_connector_ready() and c.has_pending_push_work()
+            for c in self._connectors
+        )
 
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 import torch
 
 from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import ConnectorInitState
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.canonical_mapping import (
     derive_canonical_mappings,
 )
@@ -43,11 +44,13 @@ class OffloadingConnectorWorker:
         spec: OffloadingSpec,
         vllm_config: "VllmConfig",
         kv_cache_config: KVCacheConfig,
+        async_init: bool = False,
     ):
         self.spec = spec
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
         self.worker: OffloadingWorker | None = None
+        self._async_init = async_init
         # Non-writers still ack: pending_count waits for world_size per job.
         self._is_store_writer = (
             not self.spec.replicated_layout or self.spec.config.parallel.rank == 0
@@ -61,7 +64,10 @@ class OffloadingConnectorWorker:
         self._connector_worker_meta = OffloadingWorkerMetadata()
 
     def _init_worker(self, kv_caches: CanonicalKVCaches) -> None:
-        self.worker = self.spec.get_worker(kv_caches)
+        if self._async_init:
+            self.spec.start_async_init(kv_caches)
+        else:
+            self.worker = self.spec.get_worker(kv_caches)
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         kv_cache_config = self.kv_cache_config
@@ -296,6 +302,18 @@ class OffloadingConnectorWorker:
 
         return set(), finished_recving
 
+    def get_init_state(self) -> ConnectorInitState | None:
+        """Drive asynchronous initialization and report where it stands."""
+        if not self._async_init:
+            return None
+        if self.worker is None:
+            self.worker = self.spec.poll_async_init()
+            if self.worker is None:
+                if self.spec.async_init_failed:
+                    raise RuntimeError("Asynchronous KV offload initialization failed")
+                return ConnectorInitState.INITIALIZING
+        return ConnectorInitState.READY
+
     def build_connector_worker_meta(self) -> OffloadingWorkerMetadata | None:
         """Return completed transfer job IDs since the last call."""
         if not self._connector_worker_meta.completed_jobs:
@@ -308,5 +326,8 @@ class OffloadingConnectorWorker:
         self._unsubmitted_store_jobs.clear()
         self._load_jobs.clear()
         self._connector_worker_meta = OffloadingWorkerMetadata()
+        if self._async_init:
+            # No-op once a worker adopted the buffers; it owns them from then on.
+            self.spec.close_async_init()
         if self.worker is not None:
             self.worker.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -12,7 +12,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorRole,
     SupportsHMA,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    ConnectorInitState,
+    KVConnectorMetadata,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     KVConnectorPromMetrics,
     KVConnectorStats,
@@ -37,6 +40,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker import (
     OffloadingConnectorWorker,
 )
 from vllm.forward_context import ForwardContext
+from vllm.platforms import current_platform
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -64,6 +68,15 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
         offloading_config = build_offloading_config(vllm_config, kv_cache_config)
         self._canonical_layout = offloading_config.canonical_layout
         spec = OffloadingSpecFactory.create_spec(offloading_config)
+        async_init = offloading_config.extra_config.get("async_init", False)
+        if not isinstance(async_init, bool):
+            raise ValueError("async_init must be a boolean")
+        if async_init:
+            if not spec.supports_async_init:
+                raise ValueError(f"{type(spec).__name__} does not support async_init")
+            if not current_platform.is_cuda():
+                raise ValueError("async_init is only supported on CUDA")
+            self.enable_async_init()
 
         self.connector_scheduler: OffloadingConnectorScheduler | None = None
         self.connector_worker: OffloadingConnectorWorker | None = None
@@ -73,8 +86,13 @@ class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
             )
         elif role == KVConnectorRole.WORKER:
             self.connector_worker = OffloadingConnectorWorker(
-                spec, vllm_config, kv_cache_config
+                spec, vllm_config, kv_cache_config, async_init=async_init
             )
+
+    def get_connector_init_state(self) -> ConnectorInitState | None:
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_init_state()
 
     def shutdown(self) -> None:
         if self.connector_worker is not None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -10,12 +10,14 @@ import torch
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    ConnectorInitState,
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
     SupportsHMA,
 )
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.simple_kv_offload.manager import (
@@ -121,6 +123,16 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 )
             disk_path = None
 
+        async_init = extra_config.get("async_init", False)
+        if not isinstance(async_init, bool):
+            raise ValueError("async_init must be a boolean")
+        if async_init and disk_mode:
+            raise ValueError(
+                'async_init is not supported with kv_offload_backend="disk"'
+            )
+        if async_init and not current_platform.is_cuda():
+            raise ValueError("async_init is only supported on CUDA")
+
         self.scheduler_manager: SimpleCPUOffloadScheduler | None = None
         self.worker_handler: SimpleCPUOffloadWorker | None = None
 
@@ -131,15 +143,20 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
             )
             return
 
+        if async_init:
+            self.enable_async_init()
+
         logger.info(
             "SimpleCPUOffloadConnector: role=%s, "
-            "per_rank=%.2f GB, world_size=%d, mode=%s, backend=%s, disk=%s",
+            "per_rank=%.2f GB, world_size=%d, mode=%s, backend=%s, disk=%s, "
+            "async_init=%s",
             role.name,
             cpu_capacity_per_rank / (1024**3),
             world_size,
             "lazy" if lazy_offload else "eager",
             kv_offload_backend,
             disk_path or "none",
+            async_init,
         )
 
         if role == KVConnectorRole.SCHEDULER:
@@ -168,6 +185,7 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 disk_capacity_bytes=disk_capacity_bytes,
                 disk_buffer_slots=disk_buffer_slots,
                 use_page_cache=use_page_cache,
+                async_init=async_init,
             )
 
     # --- Worker-side methods ---
@@ -227,6 +245,15 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         if self.worker_handler is not None:
             return self.worker_handler.build_connector_worker_meta()
         return None
+
+    def get_connector_init_state(self) -> ConnectorInitState | None:
+        if self.worker_handler is not None:
+            return self.worker_handler.get_init_state()
+        return None
+
+    def shutdown(self) -> None:
+        if self.worker_handler is not None:
+            self.worker_handler.shutdown()
 
     # --- Scheduler-side methods ---
 

--- a/vllm/utils/host_memory.py
+++ b/vllm/utils/host_memory.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""POSIX ``madvise`` that releases the GIL.
+
+``MADV_POPULATE_WRITE`` over a multi-hundred-GB region spends minutes in the
+kernel faulting in pages. CPython calls the syscall without
+``Py_BEGIN_ALLOW_THREADS`` (``Modules/mmapmodule.c``) — unlike ``mmap()`` in the
+same module, which does release it — so ``mmap.madvise()`` on a background
+thread would still stall the engine. ``ctypes.CDLL`` releases the GIL around
+foreign calls, so we invoke ``madvise(2)`` directly instead.
+
+Note that ``cudaHostRegister`` needs no such treatment: PyTorch already wraps it
+in ``py::gil_scoped_release``.
+"""
+
+import ctypes
+from functools import cache
+from typing import Any
+
+
+@cache
+def _get_madvise() -> Any:
+    library = ctypes.CDLL(None, use_errno=True)
+    function = library.madvise
+    function.restype = ctypes.c_int
+    function.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_int,
+    )
+    return function
+
+
+def madvise(data_ptr: int, nbytes: int, advice: int) -> None:
+    """Apply memory advice through a ctypes call that releases the GIL."""
+    if _get_madvise()(data_ptr, nbytes, advice) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, "madvise failed")

--- a/vllm/utils/host_memory.py
+++ b/vllm/utils/host_memory.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""POSIX ``madvise`` that releases the GIL.
+"""Host-memory helpers: GIL-releasing ``madvise`` and chunked host pinning.
 
 ``MADV_POPULATE_WRITE`` over a multi-hundred-GB region spends minutes in the
 kernel faulting in pages. CPython calls the syscall without
@@ -14,8 +14,22 @@ in ``py::gil_scoped_release``.
 """
 
 import ctypes
+import math
+import mmap
+import time
 from functools import cache
 from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.utils.mem_constants import MiB_bytes
+
+logger = init_logger(__name__)
+
+# cudaHostRegister serializes other CUDA API calls; keep each one short.
+HOST_REGISTER_CHUNK_SIZE_BYTES = 256 * MiB_bytes
+_HOST_REGISTER_YIELD_SECONDS = 0.001
 
 
 @cache
@@ -36,3 +50,92 @@ def madvise(data_ptr: int, nbytes: int, advice: int) -> None:
     if _get_madvise()(data_ptr, nbytes, advice) != 0:
         error = ctypes.get_errno()
         raise OSError(error, "madvise failed")
+
+
+class HostRegisterError(RuntimeError):
+    """A cudaHostRegister call failed; the memory is usable but unpinned."""
+
+
+def alloc_page_aligned_zeros(nbytes: int) -> torch.Tensor:
+    """A zeroed int8 CPU tensor whose data_ptr starts on a page boundary.
+
+    torch has no aligned-allocation API, so over-allocate by one page and
+    slice; the returned view keeps the backing storage alive. The aligned
+    start is what makes `host_register_chunked`'s copy-unit-safe batch
+    borders possible.
+    """
+    page_size = mmap.PAGESIZE
+    raw = torch.zeros(nbytes + page_size, dtype=torch.int8, device="cpu")
+    offset = -raw.data_ptr() % page_size
+    return raw[offset : offset + nbytes]
+
+
+def host_register_chunked(
+    base_ptr: int,
+    nbytes: int,
+    chunk_size_bytes: int | None = None,
+    copy_unit_bytes: int | None = None,
+) -> list[int]:
+    """Page-lock ``[base_ptr, base_ptr + nbytes)`` via cudaHostRegister.
+
+    With ``chunk_size_bytes`` set (a page multiple), pin in batches and yield
+    in between, so one huge call cannot stall other CUDA work. Batch borders
+    are placed on page boundaries: pinning locks whole pages, and two batches
+    sharing a page would fail.
+
+    Each batch becomes its own pinned region in the driver, and a copy whose
+    byte range spans two regions is rejected. Pass ``copy_unit_bytes`` (the
+    copy granularity, e.g. one KV block) to place borders only at multiples
+    of lcm(copy_unit, page size), so no copy can ever straddle one. This
+    needs a page-aligned ``base_ptr``; see `alloc_page_aligned_zeros`.
+
+    Returns:
+        The registered batch base pointers, for `host_unregister` on teardown.
+
+    Raises:
+        HostRegisterError: A registration call failed. Batches registered so
+            far are unregistered first, as they are for any other exception.
+    """
+    page_size = mmap.PAGESIZE
+    if chunk_size_bytes is not None and (
+        chunk_size_bytes <= 0 or chunk_size_bytes % page_size != 0
+    ):
+        raise ValueError("chunk_size_bytes must be a positive page multiple")
+    if copy_unit_bytes is not None and chunk_size_bytes is not None:
+        if copy_unit_bytes <= 0:
+            raise ValueError("copy_unit_bytes must be positive")
+        if base_ptr % page_size != 0:
+            raise ValueError("copy_unit_bytes requires a page-aligned base_ptr")
+        quantum = math.lcm(copy_unit_bytes, page_size)
+        chunk_size_bytes = max(quantum, chunk_size_bytes // quantum * quantum)
+
+    registered: list[int] = []
+    end = base_ptr + nbytes
+    pos = base_ptr
+    cudart = torch.cuda.cudart()
+    try:
+        while pos < end:
+            if chunk_size_bytes is None:
+                boundary = end
+            else:
+                boundary = min(end, pos - pos % page_size + chunk_size_bytes)
+            result = cudart.cudaHostRegister(pos, boundary - pos, 0).value
+            if result != 0:
+                raise HostRegisterError(f"cudaHostRegister failed (code={result})")
+            registered.append(pos)
+            pos = boundary
+            if pos < end:
+                time.sleep(_HOST_REGISTER_YIELD_SECONDS)
+    except BaseException:
+        host_unregister(registered)
+        raise
+    return registered
+
+
+def host_unregister(ptrs: list[int]) -> None:
+    """Release page-locked ranges returned by `host_register_chunked`."""
+    cudart = torch.cuda.cudart()
+    for ptr in reversed(ptrs):
+        result = cudart.cudaHostUnregister(ptr).value
+        if result != 0:
+            logger.warning("cudaHostUnregister failed (code=%d)", result)

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -294,6 +294,74 @@ class SchedulerOutput:
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int = 0
+
+    def without_requests(self, excluded: set[str]) -> "SchedulerOutput":
+        """A copy with `excluded` request ids dropped from every request view.
+
+        Lets the scheduler hide requests a KV connector never observed until ready.
+        """
+        if not excluded:
+            return self
+
+        cached = self.scheduled_cached_reqs
+        num_cached = len(cached.req_ids)
+        keep = [i for i, req_id in enumerate(cached.req_ids) if req_id not in excluded]
+        if len(keep) != num_cached:
+
+            def aligned(values: list) -> list:
+                # new_token_ids is empty unless pipeline parallelism is on.
+                return (
+                    [values[i] for i in keep] if len(values) == num_cached else values
+                )
+
+            cached = CachedRequestData(
+                req_ids=[cached.req_ids[i] for i in keep],
+                resumed_req_ids=cached.resumed_req_ids - excluded,
+                new_token_ids=aligned(cached.new_token_ids),
+                all_token_ids={
+                    r: t for r, t in cached.all_token_ids.items() if r not in excluded
+                },
+                new_block_ids=aligned(cached.new_block_ids),
+                num_computed_tokens=aligned(cached.num_computed_tokens),
+                num_output_tokens=aligned(cached.num_output_tokens),
+            )
+
+        num_scheduled_tokens = {
+            r: n for r, n in self.num_scheduled_tokens.items() if r not in excluded
+        }
+        return replace(
+            self,
+            scheduled_new_reqs=[
+                r for r in self.scheduled_new_reqs if r.req_id not in excluded
+            ],
+            scheduled_cached_reqs=cached,
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+            finished_req_ids=self.finished_req_ids - excluded,
+            preempted_req_ids=(
+                None
+                if self.preempted_req_ids is None
+                else self.preempted_req_ids - excluded
+            ),
+            kv_connector_block_state=(
+                None
+                if self.kv_connector_block_state is None
+                else KVConnectorBlockState(
+                    block_ids={
+                        r: blocks
+                        for r, blocks in self.kv_connector_block_state.block_ids.items()
+                        if r not in excluded
+                    },
+                    boundary_state_offloads={
+                        r: entries
+                        for r, entries in (
+                            self.kv_connector_block_state.boundary_state_offloads.items()
+                        )
+                        if r not in excluded
+                    },
+                )
+            ),
+        )
 
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -22,7 +22,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorRole,
     SupportsHMA,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    NoOpKVConnectorMetadata,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
@@ -137,6 +140,10 @@ class Scheduler(SchedulerInterface):
         # will have a corresponding KVConnector with Role=WORKER.
         # KV Connector pushes/pull of remote KVs for P/D and offloading.
         self.connector = None
+        # Requests admitted while the connector is unavailable remain GPU-only
+        # for their lifetime. This prevents later chunks of the same request
+        # from joining a connector that did not observe its earlier chunks.
+        self._connector_ineligible_request_ids: set[str] = set()
         self.connector_prefix_cache_stats: PrefixCacheStats | None = None
         self.recompute_kv_load_failures = True
         self.defer_block_free = False
@@ -837,15 +844,29 @@ class Scheduler(SchedulerInterface):
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
                     did_prefix_cache_lookup = True
-                    (
-                        new_computed_blocks,
-                        num_new_local_computed_tokens,
-                        request.shared_prefix_boundary,
-                        hit_diverged,
-                    ) = self._get_local_prefix_cache_hit(request)
+                    if (
+                        self.connector is not None
+                        and request_id in self._connector_ineligible_request_ids
+                    ):
+                        (
+                            new_computed_blocks,
+                            num_new_local_computed_tokens,
+                            request.shared_prefix_boundary,
+                        ) = self.kv_cache_manager.get_computed_blocks(request)
+                        hit_diverged = False
+                    else:
+                        (
+                            new_computed_blocks,
+                            num_new_local_computed_tokens,
+                            request.shared_prefix_boundary,
+                            hit_diverged,
+                        ) = self._get_local_prefix_cache_hit(request)
 
                     # Get externally-cached tokens if using a KVConnector.
-                    if self.connector is not None:
+                    if (
+                        self.connector is not None
+                        and request_id not in self._connector_ineligible_request_ids
+                    ):
                         # Present a block-aligned local hit to the connector so
                         # a strictly longer remote hit can supersede a local
                         # sub-block tail without racing its copy-on-write.
@@ -1101,7 +1122,10 @@ class Scheduler(SchedulerInterface):
                 # if a load is needed. Note that
                 # This information is used to determine if a load is
                 # needed for this request.
-                if self.connector is not None:
+                if (
+                    self.connector is not None
+                    and request_id not in self._connector_ineligible_request_ids
+                ):
                     self.connector.update_state_after_alloc(
                         request,
                         self.kv_cache_manager.get_blocks(request_id),
@@ -1281,6 +1305,14 @@ class Scheduler(SchedulerInterface):
         # they cannot be reconstructed from a connector's append-only block
         # table. Drained every step so stale offers cannot accumulate.
         boundary_state_offloads = self.kv_cache_manager.take_boundary_state_offloads()
+        if self._connector_ineligible_request_ids:
+            # Requests admitted while the connector was unavailable were never
+            # announced to it, so keep them out of the offered state.
+            boundary_state_offloads = {
+                req_id: entries
+                for req_id, entries in boundary_state_offloads.items()
+                if req_id not in self._connector_ineligible_request_ids
+            }
 
         kv_connector_block_state = None
         if self.connector is not None:
@@ -1297,6 +1329,7 @@ class Scheduler(SchedulerInterface):
             snapshot_req_ids.update(
                 req_id for req_id in boundary_state_offloads if req_id in self.requests
             )
+            snapshot_req_ids -= self._connector_ineligible_request_ids
             kv_connector_block_state = KVConnectorBlockState(
                 block_ids={
                     req_id: self.kv_cache_manager.get_block_ids(req_id)
@@ -1386,7 +1419,14 @@ class Scheduler(SchedulerInterface):
     def _build_kv_connector_meta(
         self, connector: KVConnectorBase_V1, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
-        return connector.build_connector_meta(scheduler_output)
+        if not connector.is_connector_ready():
+            return NoOpKVConnectorMetadata()
+        # Requests admitted while the connector was unavailable were never
+        # announced to it, so keep them out of view. The set drains as they
+        # finish, after which this is a no-op.
+        return connector.build_connector_meta(
+            scheduler_output.without_requests(self._connector_ineligible_request_ids)
+        )
 
     def _get_new_block_ids_to_zero(self) -> list[int] | None:
         # Drain new attention block ids every step so the manager-side list
@@ -2410,7 +2450,10 @@ class Scheduler(SchedulerInterface):
                     self.num_spec_tokens
                 )
             if self.connector is not None:
-                self.connector.on_new_request(request)
+                if self.connector.is_connector_ready():
+                    self.connector.on_new_request(request)
+                else:
+                    self._connector_ineligible_request_ids.add(request.request_id)
             if self.log_stats:
                 request.record_event(EngineCoreEventType.QUEUED)
 
@@ -2594,7 +2637,11 @@ class Scheduler(SchedulerInterface):
         return (
             self.has_unfinished_requests()
             or self.has_finished_requests()
-            or (self.connector is not None and self.connector.has_pending_push_work())
+            or (
+                self.connector is not None
+                and self.connector.is_connector_ready()
+                and self.connector.has_pending_push_work()
+            )
             or (
                 self.ec_connector is not None
                 and self.ec_connector.has_pending_push_work()
@@ -2767,6 +2814,10 @@ class Scheduler(SchedulerInterface):
         if self.connector is None:
             return False, None
 
+        if request.request_id in self._connector_ineligible_request_ids:
+            self._connector_ineligible_request_ids.discard(request.request_id)
+            return False, None
+
         # Free any out-of-window prefix blocks before we hand the block table to
         # the connector, on the processed-token basis (see `allocate_slots`).
         self.kv_cache_manager.remove_skipped_blocks(
@@ -2904,6 +2955,9 @@ class Scheduler(SchedulerInterface):
         """
 
         if self.connector is not None:
+            self.connector.update_connector_init_status(
+                kv_connector_output.kv_connector_init_status
+            )
             self.connector.update_connector_output(kv_connector_output)
 
         # KV Connector:: update recv and send status from last step.

--- a/vllm/v1/kv_offload/async_host_buffer.py
+++ b/vllm/v1/kv_offload/async_host_buffer.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import threading
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+ResourceT = TypeVar("ResourceT")
+
+DEFAULT_CLOSE_TIMEOUT_S = 5.0
+
+
+class AsyncHostBuffer(Generic[ResourceT]):
+    """Build a host-backed resource without blocking the main thread.
+
+    ``allocate`` runs on a dedicated thread and must release the GIL during its
+    long native operations. The accelerator device is thread-local, so the one selected
+    on the main thread is re-applied before ``allocate`` runs.
+
+    The resource stays reachable only from that thread until ``poll`` hands it
+    over, so it always has a single owner and teardown can never race a
+    half-built resource.
+
+    The thread is a daemon: building can take minutes, and neither shutdown nor
+    interpreter exit should wait that long.
+
+    Args:
+        allocate: Build and return the resource.
+        cleanup: Release a resource that was never adopted.
+        thread_name: Name of the initializer thread.
+    """
+
+    def __init__(
+        self,
+        allocate: Callable[[], ResourceT],
+        cleanup: Callable[[ResourceT], None],
+        thread_name: str,
+    ) -> None:
+        self._cleanup = cleanup
+        self._lock = threading.Lock()
+        self._done = threading.Event()
+        self._resource: ResourceT | None = None
+        self._failed = False
+        self._adopted = False
+        self._abandoned = False
+        self._device = (
+            torch.accelerator.current_device_index()
+            if torch.accelerator.is_available()
+            else None
+        )
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(allocate,),
+            name=thread_name,
+            daemon=True,
+        )
+        self._thread.start()
+
+    @property
+    def failed(self) -> bool:
+        return self._failed
+
+    def _run(self, allocate: Callable[[], ResourceT]) -> None:
+        resource: ResourceT | None = None
+        try:
+            try:
+                if self._device is not None:
+                    torch.accelerator.set_device_index(self._device)
+                resource = allocate()
+            except BaseException:
+                # Catch everything: leaving _done clear would strand every
+                # future poll() at "still initializing".
+                logger.exception("Asynchronous host-buffer initialization failed")
+        finally:
+            with self._lock:
+                if self._abandoned and resource is not None:
+                    # close() stopped waiting for us; nobody will adopt this.
+                    self._cleanup_safely(resource)
+                else:
+                    self._resource = resource
+                self._done.set()
+
+    def poll(self) -> ResourceT | None:
+        """Take ownership of the resource once built, else None.
+
+        Sets `failed` if the build finished without producing one.
+        """
+        if self._adopted or self._failed or not self._done.is_set():
+            return None
+        with self._lock:
+            resource = self._resource
+            self._resource = None
+        if resource is None:
+            self._failed = True
+            return None
+        self._adopted = True
+        return resource
+
+    def _cleanup_safely(self, resource: ResourceT) -> None:
+        try:
+            self._cleanup(resource)
+        except Exception:
+            logger.exception("Failed to clean up asynchronous host buffer")
+
+    def close(self, timeout: float = DEFAULT_CLOSE_TIMEOUT_S) -> None:
+        """Release an unadopted resource, waiting at most ``timeout`` seconds.
+
+        On timeout the initializer is abandoned; it releases the resource itself
+        once it finishes, so the caller never blocks on a long-running build.
+        """
+        if self._adopted:
+            return
+        if not self._done.wait(timeout):
+            with self._lock:
+                if not self._done.is_set():
+                    self._abandoned = True
+                    logger.warning(
+                        "Abandoning in-flight host-buffer initialization after "
+                        "%.1fs; it will release its own resources.",
+                        timeout,
+                    )
+                    return
+        with self._lock:
+            resource = self._resource
+            self._resource = None
+        if resource is not None:
+            self._cleanup_safely(resource)

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -624,3 +624,29 @@ class OffloadingSpec(ABC):
             An OffloadingWorker instance for this medium.
         """
         pass
+
+    ## Asynchronous initialization
+    # Servers whose host buffers take minutes to allocate can prepare them off the
+    # main thread, letting the engine serve without offloading until they land.
+
+    @property
+    def supports_async_init(self) -> bool:
+        """Whether this spec can prepare its host buffers off the main thread."""
+        return False
+
+    def start_async_init(self, kv_caches: CanonicalKVCaches) -> None:
+        """Begin preparing the worker's host buffers off the main thread."""
+        raise NotImplementedError
+
+    def poll_async_init(self) -> OffloadingWorker | None:
+        """The worker once its buffers are ready, else None while preparing."""
+        raise NotImplementedError
+
+    @property
+    def async_init_failed(self) -> bool:
+        """Whether preparation failed. Terminal: offloading stays disabled."""
+        return False
+
+    def close_async_init(self) -> None:
+        """Release buffers prepared but never handed to a worker."""
+        raise NotImplementedError

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -190,36 +190,6 @@ def _canonical_block_sizes(
     return canonical_bytes_per_block
 
 
-def pin_mmap_region(region: SharedOffloadRegion) -> None:
-    """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
-    if not current_platform.is_cuda_alike():
-        logger.info(
-            "Skipping mmap host registration on %s; cudaHostRegister is only "
-            "available on CUDA/ROCm.",
-            current_platform.device_name,
-        )
-        return
-
-    rank = region.rank
-
-    base_ptr = region._base.data_ptr()
-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
-    if result.value != 0:
-        logger.warning(
-            "cudaHostRegister failed for rank=%d (code=%d) — "
-            "transfers will still work but may be slower (unpinned DMA)",
-            rank,
-            result,
-        )
-    else:
-        logger.debug(
-            "cudaHostRegister rank=%d %.2f GB",
-            rank,
-            region.total_size_bytes / 1e9,
-        )
-        region.is_pinned = True
-
-
 def _new_descriptor_buffers(
     num_copy_ops: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -763,7 +733,8 @@ class CPUOffloadingWorker(OffloadingWorker):
         pin_memory = PIN_MEMORY
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
         if mmap_region is not None and pin_memory:
-            pin_mmap_region(mmap_region)
+            # No-op when asynchronous initialization already pinned the region.
+            mmap_region.pin()
 
         canonical_bytes_per_block = (
             _canonical_block_sizes(kv_caches.group_data_refs, len(kv_caches.tensors))

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import ctypes
 import errno
 import mmap
 import os
@@ -14,11 +15,13 @@ from vllm.distributed.device_communicators.shm_broadcast import (
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils.host_memory import madvise
 
 logger = init_logger(__name__)
 
 # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+_HOST_REGISTER_YIELD_SECONDS = 0.001
 
 
 def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
@@ -35,7 +38,11 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> N
 
 
 def _madvise_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
-    mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
+    # Goes through ctypes rather than `mmap.madvise()` because CPython holds
+    # the GIL across that syscall, which would stall the engine when
+    # population runs on a background thread (see AsyncHostBuffer).
+    base_ptr = ctypes.addressof(ctypes.c_char.from_buffer(mmap_obj))
+    madvise(base_ptr + offset, length, _MADV_POPULATE_WRITE)
 
 
 def _fallback_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
@@ -87,6 +94,7 @@ class SharedOffloadRegion:
         kv_bytes_per_block: int,
         cpu_page_size: int,
         barrier: Callable[[], None] | None = None,
+        populate: bool = True,
     ) -> None:
         self.page_size = mmap.PAGESIZE
         assert kv_bytes_per_block % self.page_size == 0
@@ -103,9 +111,19 @@ class SharedOffloadRegion:
             self._worker_offset = rank * cpu_page_size
             # exclusive upper bound for this worker's area within each row
             self._worker_area_end = (rank + 1) * cpu_page_size
+        # Set before anything that can raise, so cleanup() is safe to call on a
+        # partially built region.
+        self.fd: int | None = None
+        self.mmap_obj: mmap.mmap | None = None
+        self._base: torch.Tensor | None = None
+        self._views: list[torch.Tensor] = []
+        self._canonical_offset = 0
+        self._registered_ptrs: list[int] = []
+        self.is_pinned: bool = False
+
         try:
             try:
-                self.fd: int | None = os.open(
+                self.fd = os.open(
                     self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
                 )
             except FileExistsError:
@@ -136,14 +154,14 @@ class SharedOffloadRegion:
                     self.mmap_path,
                     self.total_size_bytes / 1e9,
                 )
-
-            self.mmap_obj: mmap.mmap | None = mmap.mmap(
+            self.mmap_obj = mmap.mmap(
                 self.fd,
                 self.total_size_bytes,
                 flags=mmap.MAP_SHARED,
                 prot=mmap.PROT_READ | mmap.PROT_WRITE,
             )
-        except Exception:
+            self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
+        except BaseException:
             if self._creator:
                 os.unlink(self.mmap_path)
                 self._creator = False
@@ -159,6 +177,8 @@ class SharedOffloadRegion:
                         "Failed to release peers waiting at the mmap barrier",
                         exc_info=True,
                     )
+            # This mapping can be hundreds of GB; never strand it.
+            self.cleanup()
             raise
 
         if barrier is not None:
@@ -167,48 +187,126 @@ class SharedOffloadRegion:
             # path — including SIGKILL — can leak the file.
             try:
                 barrier()
-            except Exception:
+            except BaseException:
                 if self._creator:
                     os.unlink(self.mmap_path)
                     self._creator = False
-                self.mmap_obj.close()
-                os.close(self.fd)
+                self.cleanup()
                 raise
             if self._creator:
                 os.unlink(self.mmap_path)
                 self._creator = False
                 logger.info("Unlinked mmap file %s", self.mmap_path)
 
-        populate_write_fn = _get_populate_write_fn(self.mmap_obj)
+        if populate:
+            self.populate(cpu_page_size)
 
-        if rank is not None:
-            # Populate only this worker's pages (one slot per block row).
-            worker_offset = rank * cpu_page_size
-            _t0 = time.perf_counter()
-            page_size = self.page_size
-            for block in range(num_blocks):
-                raw_offset = block * self._row_stride + worker_offset
-                aligned_offset = (raw_offset // page_size) * page_size
-                end = raw_offset + cpu_page_size
-                aligned_length = end - aligned_offset
-                populate_write_fn(self.mmap_obj, aligned_offset, aligned_length)
-            logger.debug(
-                "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
-                num_blocks,
-                time.perf_counter() - _t0,
-            )
-        else:
-            # No rank — populate the entire shared region in one call.
-            _t0 = time.perf_counter()
-            populate_write_fn(self.mmap_obj, 0, self.total_size_bytes)
+    def populate(self, cpu_page_size: int) -> None:
+        """Fault in writable pages up front, so transfers do not pay for them.
+
+        This does not CUDA-pin anything; see `pin`. Uses MADV_POPULATE_WRITE
+        where supported, falling back to per-page writes on older kernels
+        (see `_get_populate_write_fn`).
+        """
+        mmap_obj = self.mmap_obj
+        assert mmap_obj is not None
+        populate_write_fn = _get_populate_write_fn(mmap_obj)
+        _t0 = time.perf_counter()
+
+        if self.rank is None:
+            populate_write_fn(mmap_obj, 0, self.total_size_bytes)
             logger.debug(
                 "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
             )
+            return
 
-        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
-        self._views: list[torch.Tensor] = []
-        self._canonical_offset = 0
-        self.is_pinned: bool = False
+        # Populate only this worker's strided slot in each block row.
+        worker_offset = self.rank * cpu_page_size
+        page_size = self.page_size
+        for block in range(self.num_blocks):
+            raw_offset = block * self._row_stride + worker_offset
+            aligned_offset = (raw_offset // page_size) * page_size
+            aligned_length = raw_offset + cpu_page_size - aligned_offset
+            populate_write_fn(mmap_obj, aligned_offset, aligned_length)
+        logger.debug(
+            "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
+            self.num_blocks,
+            time.perf_counter() - _t0,
+        )
+
+    def pin(self, chunk_size_bytes: int | None = None) -> None:
+        """Page-lock the region so DMA transfers skip the bounce buffer.
+
+        Idempotent, and paired with the cudaHostUnregister in `cleanup`. Failure
+        is a warning: unpinned transfers still work, they are just slower.
+
+        Args:
+            chunk_size_bytes: When set, register the region incrementally and
+                yield between chunks so inference can submit CUDA work.
+        """
+        if self.is_pinned:
+            return
+        if not current_platform.is_cuda_alike():
+            logger.info(
+                "Skipping mmap host registration on %s; cudaHostRegister is only "
+                "available on CUDA/ROCm.",
+                current_platform.device_name,
+            )
+            return
+
+        if chunk_size_bytes is not None and (
+            chunk_size_bytes <= 0 or chunk_size_bytes % self.page_size != 0
+        ):
+            raise ValueError("chunk_size_bytes must be a positive page multiple")
+
+        assert self._base is not None
+        base_ptr = self._base.data_ptr()
+        chunk_size = chunk_size_bytes or self.total_size_bytes
+        cudart = torch.cuda.cudart()
+        try:
+            for offset in range(0, self.total_size_bytes, chunk_size):
+                size = min(chunk_size, self.total_size_bytes - offset)
+                ptr = base_ptr + offset
+                result = cudart.cudaHostRegister(ptr, size, 0).value
+                if result != 0:
+                    self._unregister_pinned_ranges()
+                    logger.warning(
+                        "cudaHostRegister failed for rank=%d (code=%d) — "
+                        "transfers will still work but may be slower (unpinned DMA)",
+                        self.rank,
+                        result,
+                    )
+                    return
+                self._registered_ptrs.append(ptr)
+                if (
+                    chunk_size_bytes is not None
+                    and offset + size < self.total_size_bytes
+                ):
+                    time.sleep(_HOST_REGISTER_YIELD_SECONDS)
+        except BaseException:
+            self._unregister_pinned_ranges()
+            raise
+        logger.debug(
+            "cudaHostRegister rank=%d %.2f GB in %d range(s)",
+            self.rank,
+            self.total_size_bytes / 1e9,
+            len(self._registered_ptrs),
+        )
+        self.is_pinned = True
+
+    def _unregister_pinned_ranges(self) -> None:
+        if current_platform.is_cuda_alike():
+            cudart = torch.cuda.cudart()
+            for ptr in reversed(self._registered_ptrs):
+                result = cudart.cudaHostUnregister(ptr).value
+                if result != 0:
+                    logger.warning(
+                        "cudaHostUnregister failed for rank=%d (code=%d)",
+                        self.rank,
+                        result,
+                    )
+        self._registered_ptrs.clear()
+        self.is_pinned = False
 
     def create_next_worker_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
@@ -233,6 +331,7 @@ class SharedOffloadRegion:
             tensor_page_size: Bytes per block for this  tensor.
         """
         assert self.rank is not None
+        assert self._base is not None
         new_offset = self._worker_offset + tensor_page_size
         assert new_offset <= self._worker_area_end, (
             f"Worker offset {new_offset} exceeds worker area end "
@@ -299,6 +398,7 @@ class SharedOffloadRegion:
         Shape: (num_blocks, row_stride_bytes). Secondary tiers address
         block *b* as ``view[b]``.
         """
+        assert self._base is not None
         kv_tensor = self._base.view(self.num_blocks, self._row_stride)
         np_arr = kv_tensor.numpy()
         assert np_arr.ctypes.data == self._base.data_ptr(), (
@@ -308,17 +408,8 @@ class SharedOffloadRegion:
         return memoryview(np_arr)
 
     def cleanup(self) -> None:
-        if self.is_pinned and self._base is not None:
-            if current_platform.is_cuda_alike():
-                base_ptr = self._base.data_ptr()
-                result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
-                if result.value != 0:
-                    logger.warning(
-                        "cudaHostUnregister failed for rank=%d (code=%d)",
-                        self.rank,
-                        result,
-                    )
-            self.is_pinned = False
+        if self._registered_ptrs:
+            self._unregister_pinned_ranges()
         # Release views before _base: each view holds a _base reference and a
         # direct StorageImpl reference.  Freeing views first lets both refcounts
         # drop so the storage (which holds the mmap_obj buffer export) is freed

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -15,13 +15,17 @@ from vllm.distributed.device_communicators.shm_broadcast import (
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.utils.host_memory import madvise
+from vllm.utils.host_memory import (
+    HostRegisterError,
+    host_register_chunked,
+    host_unregister,
+    madvise,
+)
 
 logger = init_logger(__name__)
 
 # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
-_HOST_REGISTER_YIELD_SECONDS = 0.001
 
 
 def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
@@ -254,38 +258,19 @@ class SharedOffloadRegion:
             )
             return
 
-        if chunk_size_bytes is not None and (
-            chunk_size_bytes <= 0 or chunk_size_bytes % self.page_size != 0
-        ):
-            raise ValueError("chunk_size_bytes must be a positive page multiple")
-
         assert self._base is not None
-        base_ptr = self._base.data_ptr()
-        chunk_size = chunk_size_bytes or self.total_size_bytes
-        cudart = torch.cuda.cudart()
         try:
-            for offset in range(0, self.total_size_bytes, chunk_size):
-                size = min(chunk_size, self.total_size_bytes - offset)
-                ptr = base_ptr + offset
-                result = cudart.cudaHostRegister(ptr, size, 0).value
-                if result != 0:
-                    self._unregister_pinned_ranges()
-                    logger.warning(
-                        "cudaHostRegister failed for rank=%d (code=%d) — "
-                        "transfers will still work but may be slower (unpinned DMA)",
-                        self.rank,
-                        result,
-                    )
-                    return
-                self._registered_ptrs.append(ptr)
-                if (
-                    chunk_size_bytes is not None
-                    and offset + size < self.total_size_bytes
-                ):
-                    time.sleep(_HOST_REGISTER_YIELD_SECONDS)
-        except BaseException:
-            self._unregister_pinned_ranges()
-            raise
+            self._registered_ptrs = host_register_chunked(
+                self._base.data_ptr(), self.total_size_bytes, chunk_size_bytes
+            )
+        except HostRegisterError as e:
+            logger.warning(
+                "%s for rank=%d; transfers will still work but may be "
+                "slower (unpinned DMA)",
+                e,
+                self.rank,
+            )
+            return
         logger.debug(
             "cudaHostRegister rank=%d %.2f GB in %d range(s)",
             self.rank,
@@ -296,15 +281,7 @@ class SharedOffloadRegion:
 
     def _unregister_pinned_ranges(self) -> None:
         if current_platform.is_cuda_alike():
-            cudart = torch.cuda.cudart()
-            for ptr in reversed(self._registered_ptrs):
-                result = cudart.cudaHostUnregister(ptr).value
-                if result != 0:
-                    logger.warning(
-                        "cudaHostUnregister failed for rank=%d (code=%d)",
-                        self.rank,
-                        result,
-                    )
+            host_unregister(self._registered_ptrs)
         self._registered_ptrs.clear()
         self.is_pinned = False
 

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -5,8 +5,12 @@ from typing import Any
 import torch
 from typing_extensions import override
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import round_up
+from vllm.utils.mem_constants import MiB_bytes
+from vllm.utils.torch_utils import PIN_MEMORY
+from vllm.v1.kv_offload.async_host_buffer import AsyncHostBuffer
 from vllm.v1.kv_offload.base import (
     CanonicalKVCaches,
     OffloadingCounterMetadata,
@@ -22,6 +26,12 @@ from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+
+logger = init_logger(__name__)
+
+# cudaHostRegister serializes other CUDA API calls. Keep each registration
+# short and yield between them so inference can continue during initialization.
+_ASYNC_HOST_REGISTER_CHUNK_SIZE_BYTES = 256 * MiB_bytes
 
 
 def _all_workers_barrier() -> None:
@@ -94,6 +104,10 @@ class CPUOffloadingSpec(OffloadingSpec):
     def __init__(self, config: OffloadingConfig):
         super().__init__(config)
 
+        self._region_init: AsyncHostBuffer[SharedOffloadRegion] | None = None
+        self._prepared_region: SharedOffloadRegion | None = None
+        self._async_kv_caches: CanonicalKVCaches | None = None
+
         cpu_bytes_to_use = self.extra_config.get("cpu_bytes_to_use")
         if not cpu_bytes_to_use:
             raise Exception(
@@ -164,28 +178,37 @@ class CPUOffloadingSpec(OffloadingSpec):
         per-rank tensor); replicated-layout dedup is gated on this being True."""
         return current_platform.is_cuda_alike()
 
+    def _get_worker_rank(self) -> int | None:
+        if not self._uses_shared_region() or self.num_blocks <= 0:
+            return None
+        # Replicated layout puts all ranks on slot 0 (single MLA copy);
+        # otherwise each rank takes its own slot by physical device index.
+        if self.replicated_layout:
+            return 0
+        world_size = self.config.parallel.world_size
+        return torch.accelerator.current_device_index() % world_size
+
+    def _create_region(self, rank: int, populate: bool = True) -> SharedOffloadRegion:
+        return SharedOffloadRegion(
+            engine_id=self.config.engine_id,
+            num_blocks=self.num_blocks,
+            rank=rank,
+            kv_bytes_per_block=self.kv_bytes_per_chunk,
+            cpu_page_size=self.cpu_page_size_per_worker,
+            barrier=_all_workers_barrier,
+            populate=populate,
+        )
+
     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
-        mmap_region: SharedOffloadRegion | None = None
-        # num_blocks == 0 would size the region to zero bytes, which cannot be
-        # mmap'd; fall back to the tensor path (empty tensors) as before.
-        if self._uses_shared_region() and self.num_blocks > 0:
-            # Replicated layout puts all ranks on slot 0 (single MLA copy);
-            # otherwise each rank takes its own slot by physical device index.
-            if self.replicated_layout:
-                rank = 0
-            else:
-                world_size = self.config.parallel.world_size
-                rank = torch.accelerator.current_device_index() % world_size
-            mmap_region = SharedOffloadRegion(
-                engine_id=self.config.engine_id,
-                num_blocks=self.num_blocks,
-                rank=rank,
-                kv_bytes_per_block=self.kv_bytes_per_chunk,
-                cpu_page_size=self.cpu_page_size_per_worker,
-                barrier=_all_workers_barrier,
-            )
+        mmap_region = self._prepared_region
+        if mmap_region is None:
+            rank = self._get_worker_rank()
+            # num_blocks == 0 would size the region to zero bytes, which cannot
+            # be mmap'd; fall back to the tensor path (empty tensors) as before.
+            if rank is not None:
+                mmap_region = self._create_region(rank)
         try:
-            return CPUOffloadingWorker(
+            worker = CPUOffloadingWorker(
                 kv_caches=kv_caches,
                 blocks_per_chunk=self.blocks_per_chunk,
                 num_cpu_blocks=self.num_blocks,
@@ -195,6 +218,73 @@ class CPUOffloadingSpec(OffloadingSpec):
             if mmap_region is not None:
                 mmap_region.cleanup()
             raise
+        # Only now does the worker own the region; until this point a raised
+        # exception leaves it with us, for close_async_init to release.
+        self._prepared_region = None
+        return worker
+
+    # ==============================
+    # Asynchronous initialization
+    # ==============================
+    # Faulting in and page-locking a multi-hundred-GB region takes minutes. The
+    # open/mmap/barrier handshake is a collective, so it stays on the main
+    # thread; only population and pinning, the minutes-long parts, move to a
+    # background thread. Building the worker around a ready region allocates
+    # nothing (transfer streams and descriptor buffers are lazy).
+
+    @property
+    def supports_async_init(self) -> bool:
+        return self._uses_shared_region() and self.num_blocks > 0
+
+    def start_async_init(self, kv_caches: CanonicalKVCaches) -> None:
+        rank = self._get_worker_rank()
+        assert rank is not None, "spec does not support async_init"
+        self._async_kv_caches = kv_caches
+        logger.info("Starting asynchronous KV offload host-buffer initialization")
+        region = self._create_region(rank, populate=False)
+        self._region_init = AsyncHostBuffer(
+            allocate=lambda: self._populate_and_pin(region),
+            cleanup=lambda region: region.cleanup(),
+            thread_name="vllm-kv-offload-init",
+        )
+
+    def _populate_and_pin(self, region: SharedOffloadRegion) -> SharedOffloadRegion:
+        try:
+            region.populate(self.cpu_page_size_per_worker)
+            if PIN_MEMORY:
+                region.pin(
+                    chunk_size_bytes=_ASYNC_HOST_REGISTER_CHUNK_SIZE_BYTES,
+                )
+        except BaseException:
+            region.cleanup()
+            raise
+        return region
+
+    def poll_async_init(self) -> OffloadingWorker | None:
+        if self._worker is not None:
+            return self._worker
+        if self._region_init is None:
+            # Not started, or already closed by shutdown.
+            return None
+        self._prepared_region = self._region_init.poll()
+        if self._prepared_region is None:
+            return None
+        logger.info("Asynchronous KV offload initialization completed")
+        assert self._async_kv_caches is not None
+        return self.get_worker(self._async_kv_caches)
+
+    @property
+    def async_init_failed(self) -> bool:
+        return self._region_init is not None and self._region_init.failed
+
+    def close_async_init(self) -> None:
+        if self._region_init is not None:
+            self._region_init.close()
+            self._region_init = None
+        # Prepared but never handed to a worker, so still ours to release.
+        if self._prepared_region is not None:
+            self._prepared_region.cleanup()
+            self._prepared_region = None
 
     @override
     def get_worker(self, kv_caches: CanonicalKVCaches) -> OffloadingWorker:

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -7,8 +7,8 @@ from typing_extensions import override
 
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils.host_memory import HOST_REGISTER_CHUNK_SIZE_BYTES
 from vllm.utils.math_utils import round_up
-from vllm.utils.mem_constants import MiB_bytes
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.kv_offload.async_host_buffer import AsyncHostBuffer
 from vllm.v1.kv_offload.base import (
@@ -28,10 +28,6 @@ from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 logger = init_logger(__name__)
-
-# cudaHostRegister serializes other CUDA API calls. Keep each registration
-# short and yield between them so inference can continue during initialization.
-_ASYNC_HOST_REGISTER_CHUNK_SIZE_BYTES = 256 * MiB_bytes
 
 
 def _all_workers_barrier() -> None:
@@ -253,7 +249,7 @@ class CPUOffloadingSpec(OffloadingSpec):
             region.populate(self.cpu_page_size_per_worker)
             if PIN_MEMORY:
                 region.pin(
-                    chunk_size_bytes=_ASYNC_HOST_REGISTER_CHUNK_SIZE_BYTES,
+                    chunk_size_bytes=HOST_REGISTER_CHUNK_SIZE_BYTES,
                 )
         except BaseException:
             region.cleanup()

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -382,6 +382,13 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
         # CUDA-alike check.
         return True
 
+    @property
+    @override
+    def supports_async_init(self) -> bool:
+        # create_worker below builds its own region and ignores any prepared
+        # one, so an async region would be a second, unaccounted-for opener.
+        return False
+
     @override
     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
         world_size = self.config.parallel.world_size

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -18,11 +18,13 @@ if TYPE_CHECKING:
     from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorWorkerMetadata
     from vllm.distributed.kv_events import KVConnectorKVEvents
     from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorInitStatus,
         KVConnectorWorkerMetadata,
     )
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 else:
     KVConnectorStats = object
+    KVConnectorInitStatus = object
     KVConnectorWorkerMetadata = object
     KVConnectorKVEvents = object
     ECConnectorWorkerMetadata = object
@@ -293,6 +295,7 @@ class KVConnectorOutput:
     kv_connector_stats: KVConnectorStats | None = None
     kv_cache_events: KVConnectorKVEvents | None = None
     kv_connector_worker_meta: KVConnectorWorkerMetadata | None = None
+    kv_connector_init_status: KVConnectorInitStatus | None = None
     # IDs of externally computed KV blocks that failed to load.
     # Requests referencing these blocks should be rescheduled to recompute them
     invalid_block_ids: set[int] = field(default_factory=set)
@@ -311,6 +314,7 @@ class KVConnectorOutput:
             and not self.kv_cache_events
             and not self.invalid_block_ids
             and not self.kv_connector_worker_meta
+            and self.kv_connector_init_status is None
         )
 
 

--- a/vllm/v1/simple_kv_offload/cuda_mem_ops.py
+++ b/vllm/v1/simple_kv_offload/cuda_mem_ops.py
@@ -11,6 +11,7 @@ import torch
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils.host_memory import host_register_chunked
 
 logger = init_logger(__name__)
 
@@ -21,16 +22,23 @@ CU_MEMCPY_SRC_ACCESS_ORDER_STREAM = 1
 CU_MEMCPY_SRC_ACCESS_ORDER_ANY = 3
 
 
-def pin_tensor(tensor: torch.Tensor) -> None:
+def pin_tensor(
+    tensor: torch.Tensor,
+    chunk_size_bytes: int | None = None,
+    copy_unit_bytes: int | None = None,
+) -> list[int]:
     """Pin a CPU tensor via cudaHostRegister.
 
     This bypasses PyTorch's CUDACachingHostAllocator which rounds
     every ``pin_memory=True`` allocation up to the next power of 2
     (e.g. 100 GB becomes 128 GB).
+
+    Returns the registered chunk pointers, for
+    [host_unregister][vllm.utils.host_memory.host_unregister] on teardown.
     """
-    err = torch.cuda.cudart().cudaHostRegister(tensor.data_ptr(), tensor.nbytes, 0)
-    if err.value != 0:
-        raise RuntimeError(f"cudaHostRegister failed: {err}")
+    return host_register_chunked(
+        tensor.data_ptr(), tensor.nbytes, chunk_size_bytes, copy_unit_bytes
+    )
 
 
 class _CUmemLocation(ctypes.Structure):

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -2,13 +2,21 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Worker-side handler for SimpleCPUOffloadConnector."""
 
-from typing import TYPE_CHECKING
+import math
+from typing import TYPE_CHECKING, NamedTuple
 
 import torch
 
 from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import ConnectorInitState
 from vllm.logger import init_logger
+from vllm.utils.host_memory import (
+    HOST_REGISTER_CHUNK_SIZE_BYTES,
+    alloc_page_aligned_zeros,
+    host_unregister,
+)
 from vllm.utils.torch_utils import PIN_MEMORY
+from vllm.v1.kv_offload.async_host_buffer import AsyncHostBuffer
 from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
 from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
@@ -21,6 +29,46 @@ if TYPE_CHECKING:
     from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
+
+
+class _CpuCaches(NamedTuple):
+    """CPU KV tensors plus their registered ranges, for unpinning on release."""
+
+    tensors: dict[str, torch.Tensor]
+    registered_ptrs: list[int]
+
+
+def _allocate_cpu_caches(
+    plan: dict[str, tuple[tuple[int, ...], torch.dtype]],
+    pin_memory: bool,
+    chunk_size_bytes: int | None = None,
+) -> _CpuCaches:
+    """Allocate zeroed CPU tensors and pin them in batches.
+
+    The page-aligned start plus block-aligned batch borders keep every block
+    copy inside one pinned region; see `host_register_chunked`.
+    """
+    tensors: dict[str, torch.Tensor] = {}
+    registered: list[int] = []
+    try:
+        for name, (shape, dtype) in plan.items():
+            row_bytes = math.prod(shape[1:]) * dtype.itemsize
+            nbytes = shape[0] * row_bytes
+            tensor = alloc_page_aligned_zeros(nbytes).view(dtype).view(shape)
+            if pin_memory:
+                registered += pin_tensor(
+                    tensor, chunk_size_bytes, copy_unit_bytes=row_bytes
+                )
+            tensors[name] = tensor
+    except BaseException:
+        host_unregister(registered)
+        raise
+    return _CpuCaches(tensors, registered)
+
+
+def _release_cpu_caches(caches: _CpuCaches) -> None:
+    if caches.registered_ptrs:
+        host_unregister(caches.registered_ptrs)
 
 
 class SimpleCPUOffloadWorker:
@@ -36,6 +84,7 @@ class SimpleCPUOffloadWorker:
         disk_capacity_bytes: int = 0,
         disk_buffer_slots: int = 2,
         use_page_cache: bool = False,
+        async_init: bool = False,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -45,6 +94,14 @@ class SimpleCPUOffloadWorker:
         self.disk_buffer_slots = disk_buffer_slots
         self.use_page_cache = use_page_cache
         self.disk_mode = kv_offload_backend == "disk"
+        assert not (async_init and self.disk_mode)
+
+        self._async_init = async_init
+        self._cpu_init: AsyncHostBuffer[_CpuCaches] | None = None
+        self._alloc_plan: dict[str, tuple[tuple[int, ...], torch.dtype]] | None = None
+        self._pin_memory = False
+        self._nothing_to_offload = False
+        self._init_failed = False
 
         self.gpu_kv_caches: dict[str, torch.Tensor] | None = None
         self.cpu_kv_caches: dict[str, torch.Tensor] | None = None
@@ -93,6 +150,7 @@ class SimpleCPUOffloadWorker:
         """
         if not kv_caches:
             logger.warning("No KV caches to offload.")
+            self._nothing_to_offload = True
             return
 
         self.device = next(iter(kv_caches.values())).device
@@ -148,7 +206,7 @@ class SimpleCPUOffloadWorker:
         if self.disk_mode:
             self._init_disk_mode(unique_gpu_caches, total_bytes_per_block, self.device)
         else:
-            self._init_cpu_mode(unique_gpu_caches, total_bytes_per_block, self.device)
+            self._init_cpu_mode(unique_gpu_caches, total_bytes_per_block)
 
     def _init_disk_mode(
         self,
@@ -185,7 +243,6 @@ class SimpleCPUOffloadWorker:
         self,
         unique_gpu_caches: dict[str, torch.Tensor],
         total_bytes_per_block: int,
-        device: torch.device,
     ) -> None:
         logger.info(
             "SimpleCPUOffloadWorker [CPU]: %d tensors, %d CPU blocks (%.2f GB)",
@@ -200,25 +257,78 @@ class SimpleCPUOffloadWorker:
                 "Pinned memory not available. CPU offload performance may be degraded."
             )
 
-        self.cpu_kv_caches = {}
-        for name, gpu_tensor in unique_gpu_caches.items():
-            cpu_shape = (self.num_cpu_blocks,) + gpu_tensor.shape[1:]
-            # Allocate non-pinned first, then pin via cudaHostRegister to
-            # bypass PyTorch's CUDACachingHostAllocator which rounds up to
-            # the next power of 2 (e.g. 100 GB -> 128 GB).
-            tensor = torch.zeros(cpu_shape, dtype=gpu_tensor.dtype, device="cpu")
-            if pin_memory:
-                pin_tensor(tensor)
-            self.cpu_kv_caches[name] = tensor
+        alloc_plan = {
+            name: ((self.num_cpu_blocks,) + gpu_tensor.shape[1:], gpu_tensor.dtype)
+            for name, gpu_tensor in unique_gpu_caches.items()
+        }
+        if self._async_init:
+            # Defer the background build to the first get_init_state poll:
+            # engine warmup captures CUDA graphs after register_kv_caches, and
+            # a concurrent cudaHostRegister invalidates an in-progress capture.
+            # get_init_state only runs from the step path, after all capture.
+            self._alloc_plan = alloc_plan
+            self._pin_memory = pin_memory
+            return
 
-        self._backend = DmaCopyBackend()
-        self._backend.init(
-            unique_gpu_caches,
+        self.cpu_kv_caches = _allocate_cpu_caches(alloc_plan, pin_memory).tensors
+        self._init_cpu_backend()
+
+    def _init_cpu_backend(self) -> None:
+        assert self.gpu_kv_caches is not None
+        assert self.cpu_kv_caches is not None
+        backend = DmaCopyBackend()
+        backend.init(
+            self.gpu_kv_caches,
             self.cpu_kv_caches,
-            device,
+            self.device,
             self.load_stream,
             self.store_stream,
         )
+        self._backend = backend
+
+    def get_init_state(self) -> ConnectorInitState | None:
+        """Drive asynchronous CPU-cache initialization and report its state."""
+        if not self._async_init:
+            return None
+        if self._init_failed:
+            raise RuntimeError("Asynchronous CPU KV cache initialization failed")
+        if self._backend is not None or self._nothing_to_offload:
+            return ConnectorInitState.READY
+        if self._cpu_init is None:
+            if self._alloc_plan is None:
+                return ConnectorInitState.INITIALIZING
+            logger.info("Starting asynchronous CPU KV cache initialization")
+            alloc_plan, pin_memory = self._alloc_plan, self._pin_memory
+            self._alloc_plan = None
+            self._cpu_init = AsyncHostBuffer(
+                allocate=lambda: _allocate_cpu_caches(
+                    alloc_plan, pin_memory, HOST_REGISTER_CHUNK_SIZE_BYTES
+                ),
+                cleanup=_release_cpu_caches,
+                thread_name="vllm-simple-kv-offload-init",
+            )
+            return ConnectorInitState.INITIALIZING
+        caches = self._cpu_init.poll()
+        if self._cpu_init.failed:
+            self._init_failed = True
+            raise RuntimeError("Asynchronous CPU KV cache initialization failed")
+        if caches is None:
+            return ConnectorInitState.INITIALIZING
+        self.cpu_kv_caches = caches.tensors
+        try:
+            self._init_cpu_backend()
+        except BaseException:
+            self._init_failed = True
+            self.cpu_kv_caches = None
+            _release_cpu_caches(caches)
+            raise
+        logger.info("Asynchronous CPU KV cache initialization completed")
+        return ConnectorInitState.READY
+
+    def shutdown(self) -> None:
+        """Release CPU caches that were prepared but never adopted."""
+        if self._cpu_init is not None:
+            self._cpu_init.close()
 
     def bind_connector_metadata(self, metadata: SimpleCPUOffloadMetadata) -> None:
         self._connector_metadata = metadata

--- a/vllm/v1/worker/gpu/kv_connector.py
+++ b/vllm/v1/worker/gpu/kv_connector.py
@@ -11,6 +11,7 @@ from vllm.distributed.kv_transfer import (
     kv_transfer_state,
 )
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+from vllm.distributed.kv_transfer.kv_connector.v1.base import NoOpKVConnectorMetadata
 from vllm.forward_context import (
     get_forward_context,
     is_forward_context_available,
@@ -63,6 +64,8 @@ class ActiveKVConnector(KVConnector):
 
         kv_connector_metadata = scheduler_output.kv_connector_metadata
         assert kv_connector_metadata is not None
+        if isinstance(kv_connector_metadata, NoOpKVConnectorMetadata):
+            return
         self.kv_connector.handle_preemptions(kv_connector_metadata)
         self.kv_connector.bind_connector_metadata(kv_connector_metadata)
 
@@ -93,6 +96,14 @@ class ActiveKVConnector(KVConnector):
             self._start_load_kv()
 
         output = KVConnectorOutput()
+        output.kv_connector_init_status = (
+            self.kv_connector.build_connector_init_status()
+        )
+        if not self.kv_connector.has_connector_metadata():
+            output.kv_connector_worker_meta = (
+                self.kv_connector.build_connector_worker_meta()
+            )
+            return output
         if wait_for_save:
             self.kv_connector.wait_for_save()
         output.finished_sending, output.finished_recving = (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -45,6 +45,7 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     copy_kv_blocks,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.base import NoOpKVConnectorMetadata
 from vllm.distributed.parallel_state import (
     GraphCaptureContext,
     get_dcp_group,
@@ -4277,7 +4278,8 @@ class GPUModelRunner(
         if has_kv_transfer_group():
             kv_connector_metadata = scheduler_output.kv_connector_metadata
             assert kv_connector_metadata is not None
-            get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
+            if not isinstance(kv_connector_metadata, NoOpKVConnectorMetadata):
+                get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
 
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with (

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
 from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
+from vllm.distributed.kv_transfer.kv_connector.v1.base import NoOpKVConnectorMetadata
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.v1.outputs import (
     KVConnectorOutput,
@@ -59,8 +60,9 @@ class KVConnectorModelRunnerMixin:
         """
         if has_kv_transfer_group():
             kv_connector = get_kv_transfer_group()
-            kv_connector.wait_for_save()
-            kv_connector.clear_connector_metadata()
+            if kv_connector.has_connector_metadata():
+                kv_connector.wait_for_save()
+                kv_connector.clear_connector_metadata()
 
     # This context manager must be used within an active forward context.
     # It encapsulates the entire KV connector lifecycle within execute_model
@@ -76,32 +78,36 @@ class KVConnectorModelRunnerMixin:
         # Update KVConnector with the KVConnector metadata forward().
         kv_connector = get_kv_transfer_group()
         assert isinstance(kv_connector, KVConnectorBase)
-        assert scheduler_output.kv_connector_metadata is not None
-        kv_connector.bind_connector_metadata(scheduler_output.kv_connector_metadata)
+        connector_metadata = scheduler_output.kv_connector_metadata
+        assert connector_metadata is not None
+        connector_active = not isinstance(connector_metadata, NoOpKVConnectorMetadata)
+        if connector_active:
+            kv_connector.bind_connector_metadata(connector_metadata)
 
         # Start this step's KV loads, ordered after any in-flight KV block
         # zeroing. Sync loads feed this step's forward so must precede it;
         # otherwise start (async) loads after the forward launch, keeping
         # their host-side submission cost off the critical path.
         start_after_forward = not scheduler_output.has_sync_kv_loads
-        if not start_after_forward:
+        if connector_active and not start_after_forward:
             kv_connector.start_load_kv(get_forward_context())
         try:
             yield output
         finally:
-            if start_after_forward:
+            if connector_active and start_after_forward:
                 kv_connector.start_load_kv(get_forward_context())
-            if wait_for_save and not defer_finalize:
+            if connector_active and wait_for_save and not defer_finalize:
                 kv_connector.wait_for_save()
 
-            output.finished_sending, output.finished_recving = (
-                kv_connector.get_finished(scheduler_output.finished_req_ids)
-            )
-            output.invalid_block_ids = kv_connector.get_block_ids_with_load_errors()
-
-            output.kv_connector_stats = kv_connector.get_kv_connector_stats()
-            output.kv_cache_events = kv_connector.get_kv_connector_kv_cache_events()
+            if connector_active:
+                output.finished_sending, output.finished_recving = (
+                    kv_connector.get_finished(scheduler_output.finished_req_ids)
+                )
+                output.invalid_block_ids = kv_connector.get_block_ids_with_load_errors()
+                output.kv_connector_stats = kv_connector.get_kv_connector_stats()
+                output.kv_cache_events = kv_connector.get_kv_connector_kv_cache_events()
             output.kv_connector_worker_meta = kv_connector.build_connector_worker_meta()
+            output.kv_connector_init_status = kv_connector.build_connector_init_status()
 
-            if not defer_finalize:
+            if connector_active and not defer_finalize:
                 kv_connector.clear_connector_metadata()


### PR DESCRIPTION
## Purpose

Follow-up on #42632, revision of #44127. Stacked on #51414/#54578.

Only the last 2 commits are new; [clean diff vs #54578](https://github.com/mistralai/vllm/compare/offloading-async-init...YannikHinteregger:async-init-simple-cpu-offload). The helpers commit is also offered directly into #54578 as [mistralai/vllm#2](https://github.com/mistralai/vllm/pull/2).

This PR:

* extracts #54578's chunked `cudaHostRegister` into a shared helper (`vllm/utils/host_memory.py`), with cuts aligned so no block copy can straddle two pinned regions
* implements async CPU offload initialization for `SimpleCPUOffloadConnector`, the same way #54578 does it for `OffloadingConnector`: opt-in `"async_init": true` allocates and pins the CPU buffer in the background while the engine already serves GPU-only; offloading activates once all ranks are ready

Not a duplicate: #54578 leaves this connector as a follow-up ([suggested here](https://github.com/vllm-project/vllm/pull/51414#issuecomment-5479330316)).

## Test Plan

```
pytest tests/v1/simple_kv_offload/ tests/v1/kv_offload/test_host_memory.py tests/v1/kv_connector/unit/test_connector_init_status.py
```

## Test Result

```
80 passed, 2 skipped
```

## Evaluation

```
Median results (5 runs per mode) @192GB
------------------------------------------------------------------------------------
mode               health_s   first_response_s  request_latency_s  connector_ready_s
------------------------------------------------------------------------------------
sync                 46.815             46.909              0.086             46.815
async                30.977             31.073              0.086             70.443
------------------------------------------------------------------------------------
delta               -15.837            -15.836             -0.000            +23.628
------------------------------------------------------------------------------------
```

The saving equals the synchronous alloc+pin cost, so it grows with the buffer size and on hosts with slower DRAM.

```
vllm serve Qwen/Qwen2.5-7B-Instruct --max-model-len 8192 \
    --kv-transfer-config '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":206158430208,"async_init":true}}'

1x RTX PRO 6000 Blackwell (96 GB), 282 GB DRAM, CUDA 13.0, VLLM_USE_FLASHINFER_SAMPLER=0

Accuracy comparison (baseline vs offloading; offload run is a second eval pass,
so it reloads from the CPU tier: 896,368 tokens loaded during the run)
-------------------------------------------------------------------------------
metric                                       baseline      offload        delta
-------------------------------------------------------------------------------
gsm8k/exact_match,flexible-extract             0.8256       0.8256      +0.0000
gsm8k/exact_match,strict-match                 0.7642       0.7619      -0.0023
gsm8k/sample_len                            1319.0000    1319.0000      +0.0000
-------------------------------------------------------------------------------
```
