### PR TITLE
[Feature] Avoid flashinfer autotune each time when vllm source change

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -438,7 +438,7 @@ class VllmConfig:
     remaining requests are aborted once the timeout is reached.
     """
 
-    def compute_hash(self) -> str:
+    def compute_hash(self, include_version: bool = True) -> str:
         """
         WARNING: Whenever a new field is added to this config,
         ensure that it is included in the factors list if
@@ -449,14 +449,18 @@ class VllmConfig:
         graph from input ids/embeddings to the final hidden states,
         excluding anything before input ids/embeddings and after
         the final hidden states.
+
+        Args:
+            include_version: Include the vLLM version in the hash.
         """
         factors: list[Any] = []
 
         # summarize vllm config
         vllm_factors: list[Any] = []
-        from vllm import __version__
+        if include_version:
+            from vllm import __version__
 
-        vllm_factors.append(__version__)
+            vllm_factors.append(__version__)
         if self.model_config:
             vllm_factors.append(self.model_config.compute_hash())
             if (

--- a/vllm/model_executor/warmup/flashinfer_autotune_cache.py
+++ b/vllm/model_executor/warmup/flashinfer_autotune_cache.py
@@ -10,15 +10,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import vllm.envs as envs
-from vllm.compilation.caching import aot_compile_hash_factors
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
 def flashinfer_autotune_cache_hash(runner: "GPUModelRunner") -> str:
-    factors = aot_compile_hash_factors(runner.vllm_config)
-    return hashlib.sha256(str(factors).encode()).hexdigest()
+    config_hash = runner.vllm_config.compute_hash(include_version=False)
+    return hashlib.sha256(config_hash.encode()).hexdigest()
 
 
 def resolve_flashinfer_autotune_file(runner: "GPUModelRunner") -> Path:


### PR DESCRIPTION
## Purpose

```bash
vllm serve moonshotai/Kimi-K3 \
  --trust-remote-code \
  -tp 8 \
  --load-format fastsafetensors \
  --enable-prefix-caching \
  --reasoning-parser kimi_k3 \
  --enable-auto-tool-choice \
  --tool-call-parser kimi_k3 \
  --host 0.0.0.0 \
  --port 30000
```

Flashinfer autotune will be enabled each time we pull from main, this costs a lot

```bash
[AutoTuner]: Tuning flashinfer::trtllm\_fp4\_block\_scale\_moe:  50%|██████████████              | 11/22 [06:15<07:51, 42.84s/profile](<EngineCore pid=2422677>) INFO 09-01 15:39:04 [shm\_broadcast.py:801] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
[AutoTuner]: Tuning flashinfer::trtllm_fp4_block_scale_moe:  55%|███████████████▎            | 12/22 [06:58<07:10, 43.03s/profile]
```

This PR fixes the issue

CC @mgoin 