### PR TITLE
[Model Runner V2][DP] Add target execution contracts for idle EP ranks

### DIFF
--- a/tests/config/test_dp_execution_contract.py
+++ b/tests/config/test_dp_execution_contract.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+import vllm.envs as envs
+from vllm.config import VllmConfig
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def _config():
+    parallel = SimpleNamespace(
+        enable_dp_execution_contract=True,
+        data_parallel_size=2,
+        enable_expert_parallel=True,
+        all2all_backend="flashinfer_nvlink_one_sided",
+        pipeline_parallel_size=1,
+        prefill_context_parallel_size=1,
+        decode_context_parallel_size=1,
+        enable_dbo=False,
+        enable_eplb=False,
+        enable_elastic_ep=False,
+    )
+    model = SimpleNamespace(
+        is_moe=True,
+        runner_type="generate",
+        architecture="MiniMaxM3SparseForCausalLM",
+    )
+    return SimpleNamespace(
+        parallel_config=parallel,
+        model_config=model,
+        scheduler_config=SimpleNamespace(async_scheduling=False),
+        lora_config=None,
+        speculative_config=None,
+        use_v2_model_runner=True,
+    )
+
+
+def test_dp_execution_contract_accepts_validated_subset():
+    VllmConfig._verify_dp_execution_contract(_config())
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "match"),
+    [
+        (("model_config", "architecture"), "OtherMoEForCausalLM", "architecture"),
+        (("parallel_config", "all2all_backend"), "deepep_low_latency", "backend"),
+        (("scheduler_config", "async_scheduling"), True, "async scheduling"),
+    ],
+)
+def test_dp_execution_contract_rejects_unvalidated_combinations(path, value, match):
+    config = _config()
+    setattr(getattr(config, path[0]), path[1], value)
+
+    with pytest.raises(ValueError, match=match):
+        VllmConfig._verify_dp_execution_contract(config)
+
+
+def test_dp_execution_contract_requires_padding_mask(monkeypatch):
+    config = _config()
+    monkeypatch.setattr(envs, "VLLM_MOE_SKIP_PADDING", False)
+
+    with pytest.raises(ValueError, match="VLLM_MOE_SKIP_PADDING=0"):
+        VllmConfig._verify_dp_execution_contract(config)

--- a/tests/config/test_dp_execution_contract.py
+++ b/tests/config/test_dp_execution_contract.py
@@ -43,12 +43,18 @@ def test_dp_execution_contract_accepts_validated_subset():
     VllmConfig._verify_dp_execution_contract(_config())
 
 
+def test_dp_execution_contract_accepts_async_scheduling():
+    config = _config()
+    config.scheduler_config.async_scheduling = True
+
+    VllmConfig._verify_dp_execution_contract(config)
+
+
 @pytest.mark.parametrize(
     ("path", "value", "match"),
     [
         (("model_config", "architecture"), "OtherMoEForCausalLM", "architecture"),
         (("parallel_config", "all2all_backend"), "deepep_low_latency", "backend"),
-        (("scheduler_config", "async_scheduling"), True, "async scheduling"),
     ],
 )
 def test_dp_execution_contract_rejects_unvalidated_combinations(path, value, match):

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -340,9 +340,8 @@ def test_schedule_partial_requests():
 @pytest.mark.parametrize("has_running", [True, False])
 def test_schedule_prefills_gating(has_running: bool):
     """DP prefill-balancing gate: when `throttle_prefills` is True, a new
-    WAITING (prefill) request is deferred ONLY if this rank has running work to
-    protect. With no running requests, the prefill is admitted regardless (so a
-    throttled step is never wasted as a dummy), and running/decode requests are
+    WAITING (prefill) request is deferred even when the local rank is idle, so
+    prompt work remains aligned across DP ranks. Running/decode requests are
     unaffected. Once the cadence allows prefills again, the request is admitted.
     """
     scheduler = create_scheduler(max_num_seqs=16, max_num_batched_tokens=8192)
@@ -371,16 +370,14 @@ def test_schedule_prefills_gating(has_running: bool):
     scheduler.add_request(new_req)
     output = scheduler.schedule(throttle_prefills=True)
 
+    assert "new0" not in output.num_scheduled_tokens
+    assert new_req.status == RequestStatus.WAITING
     if has_running:
-        # There is running work to protect, so the new prefill is deferred...
-        assert "new0" not in output.num_scheduled_tokens
-        assert new_req.status == RequestStatus.WAITING
-        # ...while the running/decode request keeps being scheduled.
+        # The running/decode request keeps being scheduled.
         assert "run0" in output.num_scheduled_tokens
-        # When the cadence allows prefills again, the request is admitted.
-        output = scheduler.schedule()
 
-    # No running work to protect (or cadence now open): the prefill is admitted.
+    # When the cadence allows prefills again, the request is admitted.
+    output = scheduler.schedule()
     assert "new0" in output.num_scheduled_tokens
     assert any(r.req_id == "new0" for r in output.scheduled_new_reqs)
 
@@ -431,11 +428,9 @@ def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
     return scheduler
 
 
-def test_throttle_prefills_excludes_fully_transferred_remote_kv():
-    """A remote-KV resume whose whole prompt was transferred (no local prefill
-    left, e.g. the decode side of P/D disaggregation) must NOT be throttled by
-    the DP prefill cadence -- its single-token step has no prefill compute to
-    defer, so delaying it would be pointless.
+def test_throttle_prefills_defers_fully_transferred_remote_kv_prompt_tail():
+    """A remote-KV resume whose prompt was transferred still has a prompt-tail
+    step. Defer it so all prompt-related work remains cadence-aligned.
     """
     block_size = 16
     num_prompt = block_size * 2
@@ -443,7 +438,7 @@ def test_throttle_prefills_excludes_fully_transferred_remote_kv():
     scheduler = _setup_remote_kv_resume(num_prompt, matched_tokens=num_prompt)
 
     output = scheduler.schedule(throttle_prefills=True)
-    assert "r2" in output.num_scheduled_tokens
+    assert "r2" not in output.num_scheduled_tokens
     assert "r1" in output.num_scheduled_tokens
 
 
@@ -516,11 +511,8 @@ def test_throttle_defers_inflight_prefill_chunk():
     assert "chk0" in output.num_scheduled_tokens
 
 
-def test_throttle_capacity_bound_guard_admits():
-    """Saturation guard: if a cadence-aligned release step cannot drain the
-    waiting prefill queue (it ran out of token budget), the throttle backs off on
-    the next step so the backlog cannot grow into a TTFT avalanche -- prefills are
-    admitted even though throttle_prefills is set."""
+def test_throttle_after_saturated_release_still_defers():
+    """A saturated release does not bypass strict prompt cadence."""
     scheduler = create_scheduler(
         max_num_seqs=16, max_num_batched_tokens=200, enable_chunked_prefill=True
     )
@@ -533,12 +525,9 @@ def test_throttle_capacity_bound_guard_admits():
     output = scheduler.schedule()
     assert "a" in output.num_scheduled_tokens
     assert "b" not in output.num_scheduled_tokens
-    assert scheduler.prefill_capacity_bound
-
-    # Throttle. Because the previous release was capacity-bound, the guard backs
-    # off and `b` is admitted rather than stalling the backlog.
+    # The next throttled step still defers the remaining prompt.
     output = scheduler.schedule(throttle_prefills=True)
-    assert "b" in output.num_scheduled_tokens
+    assert "b" not in output.num_scheduled_tokens
 
 
 def test_no_mm_input_chunking():

--- a/tests/v1/engine/test_dp_execution_contract.py
+++ b/tests/v1/engine/test_dp_execution_contract.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.engine.core import DPEngineCoreProc
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+@pytest.mark.parametrize(
+    ("enabled", "scheduler_will_call_worker", "expected"),
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    ],
+)
+def test_scheduler_target_generation_ownership(
+    enabled: bool,
+    scheduler_will_call_worker: bool,
+    expected: bool,
+) -> None:
+    core = object.__new__(DPEngineCoreProc)
+    core.dp_execution_contract_enabled = enabled
+
+    assert (
+        core._scheduler_owns_target_generation(scheduler_will_call_worker) is expected
+    )

--- a/tests/v1/engine/test_dp_execution_contract.py
+++ b/tests/v1/engine/test_dp_execution_contract.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections import deque
+from contextlib import nullcontext
+from unittest.mock import Mock
+
 import pytest
 
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.engine.core import DPEngineCoreProc
 
 pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
@@ -28,3 +33,58 @@ def test_scheduler_target_generation_ownership(
     assert (
         core._scheduler_owns_target_generation(scheduler_will_call_worker) is expected
     )
+
+
+def _make_async_batch_queue_core() -> DPEngineCoreProc:
+    core = object.__new__(DPEngineCoreProc)
+    core.model_executor = Mock()
+    core.scheduler = Mock()
+    core.batch_queue_size = 2
+    core.batch_queue = deque(maxlen=core.batch_queue_size)
+    core.prefill_schedule_interval = 1
+    core.step_counter = 0
+    core.is_ec_consumer = True
+    core.is_pooling_model = False
+    core.check_for_draft_tokens = False
+    core.log_error_detail = Mock(return_value=nullcontext())
+    core.capture_iteration_details = Mock(return_value=nullcontext(None))
+    core._process_aborts_queue = Mock()
+    core._attach_iteration_details = Mock()
+    core.output_queue = Mock()
+    core.post_step = Mock()
+    core.step_fn = core.step_with_batch_queue
+    return core
+
+
+def test_async_engine_step_records_zero_token_worker_launch() -> None:
+    core = _make_async_batch_queue_core()
+    scheduler_output = SchedulerOutput.make_empty()
+    core.scheduler.has_requests.side_effect = [True, True, False]
+    core.scheduler.schedule.return_value = scheduler_output
+
+    model_executed, worker_call_issued = core._process_engine_step()
+
+    assert not model_executed
+    assert worker_call_issued
+    assert len(core.batch_queue) == 1
+    core.model_executor.execute_model.assert_called_once_with(
+        scheduler_output, non_block=True
+    )
+
+
+def test_async_engine_step_does_not_count_result_retirement_as_worker_launch() -> None:
+    core = _make_async_batch_queue_core()
+    core._worker_call_issued_in_step = True
+    core.scheduler.has_requests.return_value = False
+    scheduler_output = SchedulerOutput.make_empty()
+    output_future = Mock()
+    output_future.result.return_value = object()
+    core.batch_queue.append((output_future, scheduler_output, Mock()))
+    core.scheduler.update_from_output.return_value = {}
+
+    model_executed, worker_call_issued = core._process_engine_step()
+
+    assert not model_executed
+    assert not worker_call_issued
+    assert not core.batch_queue
+    core.model_executor.execute_model.assert_not_called()

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -20,6 +20,7 @@ from vllm.model_executor.models.mistral_large_3_eagle import (
 from vllm.v1.attention.backends import flash_attn as flash_attn_module
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.dp_utils import DPSyncState
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
@@ -160,6 +161,8 @@ def test_mm_support_configured_after_model_load(monkeypatch):
         speculator.dtype = torch.float32
         speculator.draft_model_config = draft_model_config
         speculator.supports_mm_inputs = False
+        speculator.dp_size = 1
+        speculator.dp_rank = 0
 
     checked_configs = []
 
@@ -375,6 +378,156 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
 
     assert generate_draft.call_count == expected_eager_calls
     assert run_fullgraph.call_count == expected_graph_replays
+
+
+def _make_async_sync_propose_speculator(monkeypatch):
+    order = []
+    prefill_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.NONE,
+        num_tokens=2,
+        num_reqs=1,
+    )
+    decode_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=2,
+        num_reqs=1,
+        uniform_token_count=1,
+    )
+    prefill_sync = DPSyncState(torch.tensor([2, 2]), 2, False)
+    decode_sync = DPSyncState(torch.tensor([2, 2]), 1, False)
+
+    monkeypatch.setattr(spec_module, "prepare_prefill_inputs", Mock())
+    monkeypatch.setattr(
+        spec_module,
+        "prepare_decode_inputs",
+        Mock(side_effect=lambda *args, **kwargs: order.append("prepare_decode")),
+    )
+    monkeypatch.setattr(
+        spec_module,
+        "get_uniform_decode_token_count",
+        lambda *args, **kwargs: 2,
+    )
+    monkeypatch.setattr(
+        spec_module,
+        "dispatch_cg_and_sync_dp",
+        Mock(return_value=(prefill_desc, prefill_sync)),
+    )
+
+    future = Mock()
+
+    def finish_sync(manager):
+        order.append("finish")
+        return decode_desc, decode_sync
+
+    def start_sync(*args, **kwargs):
+        order.append("start")
+        return future
+
+    future.result.side_effect = finish_sync
+    future.release.side_effect = lambda: order.append("release")
+    coordinator = Mock()
+    coordinator.start.side_effect = start_sync
+
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 2
+    speculator.dp_size = 2
+    speculator.dp_rank = 0
+    speculator.max_model_len = 16
+    speculator.max_num_reqs = 1
+    speculator.hidden_states = torch.zeros(2, 3)
+    speculator.last_token_indices = torch.zeros(1, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0, dtype=torch.int64)
+    speculator.input_buffers = SimpleNamespace()
+    speculator.sample_src_positions = torch.zeros(1, dtype=torch.int64)
+    speculator.draft_tokens = torch.zeros((1, 2), dtype=torch.int64)
+    speculator.prefill_cudagraph_manager = Mock()
+    speculator.decode_cudagraph_manager = Mock()
+    speculator._decode_dp_sync = coordinator
+    speculator.use_fused_multi_step_decode = False
+    speculator._copy_request_inputs = Mock()
+    speculator._prepare_eplb_forward = Mock()
+    speculator.on_prefill_begin = Mock()
+    speculator.on_prefill_end = Mock()
+    speculator.on_multi_step_decode_begin = Mock()
+    speculator.on_multi_step_decode_end = Mock()
+    speculator._prefill = Mock(
+        side_effect=lambda *args, **kwargs: order.append("prefill")
+    )
+    speculator._multi_step_decode = Mock(
+        side_effect=lambda *args, **kwargs: order.append("decode")
+    )
+
+    input_batch = SimpleNamespace(
+        num_tokens=2,
+        num_tokens_after_padding=2,
+        num_reqs=1,
+        num_scheduled_tokens=torch.tensor([2]),
+        seq_lens_cpu_upper_bound=torch.tensor([2]),
+        seq_lens=torch.tensor([2]),
+        idx_mapping=torch.tensor([0]),
+        has_prefill=False,
+    )
+    return speculator, input_batch, future, order
+
+
+@pytest.mark.cpu_test
+@pytest.mark.skip_global_cleanup
+def test_propose_overlaps_decode_dp_sync_with_draft_prefill(monkeypatch):
+    speculator, input_batch, future, order = _make_async_sync_propose_speculator(
+        monkeypatch
+    )
+
+    output = speculator.propose(
+        input_batch=input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.zeros(2, 3),
+        aux_hidden_states=None,
+        num_sampled=torch.ones(1, dtype=torch.int32),
+        num_rejected=torch.zeros(1, dtype=torch.int32),
+        last_sampled=torch.zeros(1, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(1, dtype=torch.int64),
+        temperature=torch.ones(1),
+        seeds=torch.zeros(1, dtype=torch.int64),
+    )
+
+    assert torch.equal(output, speculator.draft_tokens)
+    assert order == [
+        "start",
+        "prefill",
+        "prepare_decode",
+        "finish",
+        "decode",
+        "release",
+    ]
+    future.release.assert_called_once_with()
+
+
+@pytest.mark.cpu_test
+@pytest.mark.skip_global_cleanup
+def test_propose_releases_decode_dp_sync_when_prefill_fails(monkeypatch):
+    speculator, input_batch, future, order = _make_async_sync_propose_speculator(
+        monkeypatch
+    )
+    speculator._prefill.side_effect = RuntimeError("prefill failed")
+
+    with pytest.raises(RuntimeError, match="prefill failed"):
+        speculator.propose(
+            input_batch=input_batch,
+            attn_metadata={},
+            slot_mappings={},
+            last_hidden_states=torch.zeros(2, 3),
+            aux_hidden_states=None,
+            num_sampled=torch.ones(1, dtype=torch.int32),
+            num_rejected=torch.zeros(1, dtype=torch.int32),
+            last_sampled=torch.zeros(1, dtype=torch.int64),
+            next_prefill_tokens=torch.zeros(1, dtype=torch.int64),
+            temperature=torch.ones(1),
+            seeds=torch.zeros(1, dtype=torch.int64),
+        )
+
+    assert order == ["start", "release"]
+    future.release.assert_called_once_with()
 
 
 def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -393,7 +393,14 @@ def _make_async_sync_propose_speculator(monkeypatch):
         num_reqs=1,
         uniform_token_count=1,
     )
-    prefill_sync = DPSyncState(torch.tensor([2, 2]), 2, False)
+    prefill_sync = DPSyncState(
+        torch.tensor([2, 2]),
+        2,
+        False,
+        generation=7,
+        live_num_reqs_across_dp=(0, 1),
+        execution_num_reqs=1,
+    )
     decode_sync = DPSyncState(torch.tensor([2, 2]), 1, False)
 
     monkeypatch.setattr(spec_module, "prepare_prefill_inputs", Mock())
@@ -492,6 +499,8 @@ def test_propose_overlaps_decode_dp_sync_with_draft_prefill(monkeypatch):
     )
 
     assert torch.equal(output, speculator.draft_tokens)
+    assert speculator._decode_dp_sync.start.call_args.kwargs["parent_generation"] == 7
+    assert speculator._decode_dp_sync.start.call_args.args[1:3] == (0, 0)
     assert order == [
         "start",
         "prefill",

--- a/tests/v1/worker/test_gpu_dp_utils.py
+++ b/tests/v1/worker/test_gpu_dp_utils.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    BatchExecutionDescriptor,
+    CudaGraphManager,
+)
+from vllm.v1.worker.gpu.dp_utils import DPSyncCoordinator
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+class _Work:
+    def __init__(self, tensor: torch.Tensor, remote_tokens: int) -> None:
+        self.tensor = tensor
+        self.remote_tokens = remote_tokens
+        self.wait_calls = 0
+
+    def wait(self) -> None:
+        self.wait_calls += 1
+        self.tensor[:, 1] = torch.tensor(
+            [self.remote_tokens, CUDAGraphMode.FULL.value, 1, -1],
+            dtype=torch.int32,
+        )
+
+
+def _graph_manager() -> Mock:
+    manager = Mock(spec=CudaGraphManager)
+    manager.dispatch.side_effect = lambda num_reqs, num_tokens, *args, **kwargs: (
+        BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            uniform_token_count=1,
+        )
+    )
+    return manager
+
+
+def test_async_dp_sync_waits_on_result_and_reuses_buffer(monkeypatch):
+    tensors = []
+    works = []
+
+    def all_reduce(tensor, group, async_op):
+        assert async_op
+        tensors.append(tensor)
+        work = _Work(tensor, remote_tokens=4)
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock())
+    manager = _graph_manager()
+
+    future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+
+    assert works[0].wait_calls == 0
+    with pytest.raises(RuntimeError, match="already in flight"):
+        coordinator.start(manager, 2, 2, uniform_token_count=1)
+
+    batch_desc, sync = future.result(manager)
+
+    assert works[0].wait_calls == 1
+    assert batch_desc.num_tokens == 4
+    assert sync is not None
+    assert sync.num_tokens_across_dp.tolist() == [4, 4]
+    assert future.result(manager) == (batch_desc, sync)
+    assert works[0].wait_calls == 1
+
+    future.release()
+    next_future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    assert tensors[1] is tensors[0]
+    next_future.release()
+
+
+def test_async_dp_sync_release_waits_for_unconsumed_work(monkeypatch):
+    works = []
+
+    def all_reduce(tensor, group, async_op):
+        work = _Work(tensor, remote_tokens=2)
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock())
+    manager = _graph_manager()
+
+    future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    future.release()
+
+    assert works[0].wait_calls == 1
+    replacement = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    replacement.release()
+
+
+def test_async_dp_sync_does_not_wait_twice_after_resolution_error(monkeypatch):
+    work = None
+
+    def all_reduce(tensor, group, async_op):
+        nonlocal work
+        work = _Work(tensor, remote_tokens=2)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock())
+    manager = _graph_manager()
+    manager.dispatch.side_effect = [
+        BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=2,
+            num_reqs=2,
+            uniform_token_count=1,
+        ),
+        RuntimeError("dispatch failed"),
+    ]
+
+    future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        future.result(manager)
+    assert work is not None
+    assert work.wait_calls == 1
+
+    future.release()
+    assert work.wait_calls == 1

--- a/tests/v1/worker/test_gpu_dp_utils.py
+++ b/tests/v1/worker/test_gpu_dp_utils.py
@@ -1,33 +1,55 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 import torch
 
 from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu import dp_utils
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     CudaGraphManager,
 )
-from vllm.v1.worker.gpu.dp_utils import DPSyncCoordinator
+from vllm.v1.worker.gpu.dp_utils import (
+    DPSyncCoordinator,
+    DPSyncState,
+    dispatch_cg_and_sync_dp,
+)
 
 pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
 
 
 class _Work:
-    def __init__(self, tensor: torch.Tensor, remote_tokens: int) -> None:
+    def __init__(
+        self,
+        tensor: torch.Tensor,
+        remote_tokens: int,
+        remote_reqs: int = 2,
+        generation_delta: int = 0,
+        parent_generation_delta: int = 0,
+        remote_need_eager: bool = False,
+    ) -> None:
         self.tensor = tensor
         self.remote_tokens = remote_tokens
+        self.remote_reqs = remote_reqs
+        self.generation_delta = generation_delta
+        self.parent_generation_delta = parent_generation_delta
+        self.remote_need_eager = remote_need_eager
         self.wait_calls = 0
 
     def wait(self) -> None:
         self.wait_calls += 1
-        self.tensor[:, 1] = torch.tensor(
-            [self.remote_tokens, CUDAGraphMode.FULL.value, 1, -1],
-            dtype=torch.int32,
-        )
+        self.tensor[0, 1] = self.remote_tokens
+        self.tensor[1, 1] = CUDAGraphMode.FULL.value
+        self.tensor[2, 1] = 1
+        self.tensor[3, 1] = 1
+        self.tensor[4, 1] = self.remote_reqs
+        self.tensor[5, 1] = self.tensor[5, 0] + self.generation_delta
+        self.tensor[6, 1] = self.tensor[6, 0] + self.parent_generation_delta
+        self.tensor[7, 1] = int(self.remote_need_eager)
 
 
 def _graph_manager() -> Mock:
@@ -70,9 +92,13 @@ def test_async_dp_sync_waits_on_result_and_reuses_buffer(monkeypatch):
     assert batch_desc.num_tokens == 4
     assert sync is not None
     assert sync.num_tokens_across_dp.tolist() == [4, 4]
+    assert sync.generation == 0
+    assert sync.live_num_tokens_across_dp == (2, 4)
+    assert sync.live_num_reqs_across_dp == (2, 2)
     assert future.result(manager) == (batch_desc, sync)
     assert works[0].wait_calls == 1
 
+    future.release()
     future.release()
     next_future = coordinator.start(manager, 2, 2, uniform_token_count=1)
     assert tensors[1] is tensors[0]
@@ -128,3 +154,192 @@ def test_async_dp_sync_does_not_wait_twice_after_resolution_error(monkeypatch):
 
     future.release()
     assert work.wait_calls == 1
+
+
+def test_execution_contract_ignores_inactive_rank_graph_mode(monkeypatch):
+    def all_reduce(tensor, group, async_op):
+        return _Work(tensor, remote_tokens=3, remote_reqs=2)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    manager = Mock(spec=CudaGraphManager)
+
+    def dispatch(num_reqs, num_tokens, *args, **kwargs):
+        if num_tokens == 0:
+            return BatchExecutionDescriptor(
+                cg_mode=CUDAGraphMode.NONE,
+                num_tokens=0,
+                num_reqs=0,
+            )
+        return BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=4,
+            num_reqs=4,
+            uniform_token_count=1,
+            max_query_len=1,
+        )
+
+    manager.dispatch.side_effect = dispatch
+    coordinator = DPSyncCoordinator(2, 0, group=Mock(), execution_contract=True)
+
+    future = coordinator.start(manager, 0, 0, uniform_token_count=None)
+    batch_desc, sync = future.result(manager)
+
+    assert batch_desc.cg_mode == CUDAGraphMode.FULL
+    assert batch_desc.num_tokens == 4
+    assert batch_desc.num_reqs == 4
+    assert sync is not None
+    assert sync.num_tokens_across_dp.tolist() == [4, 4]
+    assert sync.live_num_tokens_across_dp == (0, 3)
+    assert sync.live_num_reqs_across_dp == (0, 2)
+    future.release()
+
+
+def test_async_dp_sync_rejects_generation_mismatch(monkeypatch):
+    work = None
+
+    def all_reduce(tensor, group, async_op):
+        nonlocal work
+        work = _Work(tensor, remote_tokens=2, generation_delta=1)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock())
+    manager = _graph_manager()
+
+    future = coordinator.start(manager, 2, 2, uniform_token_count=1)
+    with pytest.raises(RuntimeError, match="generation mismatch"):
+        future.result(manager)
+
+    future.release()
+    assert work is not None
+    assert work.wait_calls == 1
+
+
+def test_async_dp_sync_rejects_parent_generation_mismatch(monkeypatch):
+    def all_reduce(tensor, group, async_op):
+        return _Work(
+            tensor,
+            remote_tokens=2,
+            parent_generation_delta=1,
+        )
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock(), lane="speculator")
+    manager = _graph_manager()
+
+    future = coordinator.start(
+        manager,
+        2,
+        2,
+        uniform_token_count=1,
+        parent_generation=9,
+    )
+    with pytest.raises(RuntimeError, match="parent generation mismatch"):
+        future.result(manager)
+    future.release()
+
+
+def test_execution_contract_selects_global_eager_fallback(monkeypatch):
+    def all_reduce(tensor, group, async_op):
+        return _Work(
+            tensor,
+            remote_tokens=3,
+            remote_reqs=2,
+            remote_need_eager=True,
+        )
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    coordinator = DPSyncCoordinator(2, 0, group=Mock(), execution_contract=True)
+
+    future = coordinator.start(_graph_manager(), 0, 0, uniform_token_count=None)
+    batch_desc, sync = future.result(_graph_manager())
+
+    assert batch_desc.cg_mode == CUDAGraphMode.NONE
+    assert batch_desc.num_tokens == 3
+    assert batch_desc.num_reqs == 2
+    assert sync is not None and sync.eager
+    future.release()
+
+
+def test_execution_contract_returns_empty_when_all_ranks_are_idle(monkeypatch):
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_reduce",
+        lambda tensor, group, async_op: _Work(tensor, remote_tokens=0, remote_reqs=0),
+    )
+    coordinator = DPSyncCoordinator(2, 0, group=Mock(), execution_contract=True)
+
+    future = coordinator.start(_graph_manager(), 0, 0, uniform_token_count=None)
+    batch_desc, sync = future.result(_graph_manager())
+
+    assert batch_desc.num_tokens == 0
+    assert batch_desc.num_reqs == 0
+    assert sync is None
+    future.release()
+
+
+def test_target_and_speculator_use_distinct_collective_lanes(monkeypatch):
+    base_group = Mock()
+    speculator_group = Mock()
+    groups = []
+
+    monkeypatch.setattr(
+        dp_utils,
+        "get_dp_group",
+        lambda: SimpleNamespace(cpu_group=base_group),
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_process_group_ranks",
+        lambda group: [0, 1],
+    )
+    new_group = Mock(return_value=speculator_group)
+    monkeypatch.setattr(torch.distributed, "new_group", new_group)
+
+    work = Mock()
+    work.wait.return_value = None
+
+    def all_reduce(tensor, group, async_op):
+        groups.append(group)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+    dp_utils._DP_SYNC_GROUPS.clear()
+    try:
+        target = DPSyncCoordinator(2, 0, lane="target")
+        target.start(_graph_manager(), 1, 1, uniform_token_count=1).release()
+        speculator = DPSyncCoordinator(2, 0, lane="speculator")
+        speculator.start(_graph_manager(), 1, 1, uniform_token_count=1).release()
+    finally:
+        dp_utils._DP_SYNC_GROUPS.clear()
+
+    assert groups == [base_group, speculator_group]
+    new_group.assert_called_once_with(
+        ranks=[0, 1],
+        backend="gloo",
+        use_local_synchronization=True,
+    )
+
+
+def test_reused_execution_contract_selects_global_request_capacity():
+    manager = _graph_manager()
+    sync = DPSyncState(
+        num_tokens_across_dp=torch.tensor([4, 4]),
+        uniform_token_count=1,
+        eager=False,
+        execution_num_reqs=4,
+    )
+
+    batch_desc, reused = dispatch_cg_and_sync_dp(
+        manager,
+        num_reqs=1,
+        num_tokens=4,
+        uniform_token_count=1,
+        dp_size=2,
+        dp_rank=0,
+        dp_sync=sync,
+    )
+
+    assert batch_desc.num_reqs == 4
+    assert reused is sync
+    assert manager.dispatch.call_args.args[:2] == (4, 4)

--- a/tests/v1/worker/test_gpu_dp_utils_distributed.py
+++ b/tests/v1/worker/test_gpu_dp_utils_distributed.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import multiprocessing as mp
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch.distributed as dist
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.dp_utils import DPSyncCoordinator
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+class _GraphManager:
+    def dispatch(
+        self,
+        num_reqs,
+        num_tokens,
+        uniform_token_count,
+        num_active_loras,
+        max_query_len=None,
+    ):
+        return BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.FULL,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            uniform_token_count=uniform_token_count,
+            max_query_len=max_query_len,
+            num_active_loras=num_active_loras,
+        )
+
+
+def _run_concurrent_lanes(rank, init_path, result_queue):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_path}",
+        rank=rank,
+        world_size=2,
+    )
+    target_group = dist.new_group(ranks=[0, 1], backend="gloo")
+    speculator_group = dist.new_group(ranks=[0, 1], backend="gloo")
+    try:
+        manager = _GraphManager()
+        target = DPSyncCoordinator(
+            2,
+            rank,
+            group=target_group,
+            lane="target",
+            execution_contract=True,
+        )
+        speculator = DPSyncCoordinator(
+            2,
+            rank,
+            group=speculator_group,
+            lane="speculator",
+            execution_contract=True,
+        )
+
+        live_reqs = rank * 2
+        live_tokens = rank * 4
+
+        def start_target():
+            return target.start(
+                manager,
+                live_reqs,
+                live_tokens,
+                uniform_token_count=2 if rank else None,
+                max_query_len=2 if rank else None,
+            )
+
+        def start_speculator():
+            return speculator.start(
+                manager,
+                live_reqs,
+                live_reqs,
+                uniform_token_count=1 if rank else None,
+                parent_generation=0,
+            )
+
+        # Issue the logical stages in opposite orders. They can coexist only
+        # because each stage has its own process-group sequence.
+        if rank == 0:
+            target_future = start_target()
+            speculator_future = start_speculator()
+        else:
+            speculator_future = start_speculator()
+            target_future = start_target()
+
+        target_desc, target_sync = target_future.result(manager)
+        speculator_desc, speculator_sync = speculator_future.result(manager)
+        assert target_sync is not None
+        assert speculator_sync is not None
+        result_queue.put(
+            (
+                rank,
+                target_desc.num_tokens,
+                target_desc.num_reqs,
+                target_sync.live_num_tokens_across_dp,
+                speculator_desc.num_tokens,
+                speculator_sync.parent_generation,
+            )
+        )
+        target_future.release()
+        speculator_future.release()
+    finally:
+        dist.destroy_process_group(speculator_group)
+        dist.destroy_process_group(target_group)
+        dist.destroy_process_group()
+
+
+def test_target_and_speculator_collectives_can_overlap_on_gloo():
+    context = mp.get_context("spawn")
+    result_queue = context.Queue()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        init_path = str(Path(temp_dir) / "gloo_init")
+        processes = [
+            context.Process(
+                target=_run_concurrent_lanes,
+                args=(rank, init_path, result_queue),
+            )
+            for rank in range(2)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=30)
+            assert process.exitcode == 0
+
+    results = sorted(result_queue.get(timeout=1) for _ in range(2))
+    assert results == [
+        (0, 4, 2, (0, 4), 2, 0),
+        (1, 4, 2, (0, 4), 2, 0),
+    ]

--- a/tests/v1/worker/test_gpu_target_dp_execution_contract.py
+++ b/tests/v1/worker/test_gpu_target_dp_execution_contract.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu import model_runner as model_runner_module
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.dp_utils import DPSyncState
+from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu_worker import Worker
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def _runner(monkeypatch, order):
+    runner = object.__new__(GPUModelRunner)
+    runner._pending_target_dp_sync = None
+    runner.execute_model_state = None
+    runner.dp_execution_contract_enabled = True
+    runner.input_buffers = InputBuffers(4, 16, torch.device("cpu"))
+    runner.device = torch.device("cpu")
+    runner.dp_size = 2
+    runner.dp_rank = 0
+    runner.lora_config = None
+    runner.pcp_manager = None
+    runner.is_encoder_decoder = False
+    runner.is_first_pp_rank = True
+    runner.is_last_pp_rank = True
+    runner.uses_inputs_embeds = False
+    runner.use_aux_hidden_state_outputs = False
+    runner.routed_experts_capturer = None
+    runner.attn_groups = []
+    runner.model_config = Mock()
+    runner.kv_cache_config = Mock()
+    runner.req_states = SimpleNamespace(num_computed_tokens=SimpleNamespace(gpu=Mock()))
+    runner.model_state = Mock()
+    runner.model_state.prepare_attn.return_value = {}
+    runner.model_state.prepare_inputs.return_value = {}
+    runner.eplb = Mock()
+    runner.step_timing = Mock()
+    runner.kv_connector = Mock()
+    runner.kv_connector.no_forward.return_value = Mock()
+    runner.ec_connector = Mock()
+    runner.speculator = None
+
+    for name in (
+        "update_pp_decode_requests",
+        "finish_requests",
+        "free_states",
+        "add_requests",
+        "update_requests",
+    ):
+        setattr(runner, name, Mock())
+    runner.block_tables = Mock()
+    runner.block_tables.apply_staged_writes = Mock()
+    runner.prepare_attn = Mock(return_value=((torch.zeros(1),), torch.zeros(1)))
+    runner.prepare_dummy_attn = Mock(return_value=((torch.zeros(1),), torch.zeros(1)))
+    runner._merge_ec_connector_no_forward = Mock(return_value="empty")
+
+    manager = Mock()
+    manager.run_fullgraph.side_effect = lambda desc: (
+        order.append("forward") or torch.zeros(desc.num_tokens, 4)
+    )
+    runner.cudagraph_manager = manager
+    monkeypatch.setattr(
+        model_runner_module,
+        "build_slot_mappings_by_layer",
+        Mock(return_value={}),
+    )
+    return runner
+
+
+def _scheduler_output(num_tokens, num_reqs):
+    return SimpleNamespace(
+        total_num_scheduled_tokens=num_tokens,
+        num_scheduled_tokens={f"req-{i}": num_tokens for i in range(num_reqs)},
+        scheduled_encoder_inputs={},
+        finished_req_ids=set(),
+    )
+
+
+def _future(order, batch_desc, sync):
+    future = Mock()
+    resolved = False
+
+    def result(manager):
+        nonlocal resolved
+        if not resolved:
+            order.append("finish")
+            resolved = True
+        return batch_desc, sync
+
+    future.result.side_effect = result
+    future.release.side_effect = lambda: order.append("release")
+    return future
+
+
+def test_target_dp_sync_overlaps_local_input_preparation(monkeypatch):
+    order: list[str] = []
+    runner = _runner(monkeypatch, order)
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=2,
+        num_reqs=1,
+        uniform_token_count=2,
+    )
+    sync = DPSyncState(
+        torch.tensor([2, 2]),
+        2,
+        False,
+        generation=3,
+        live_num_tokens_across_dp=(2, 2),
+        live_num_reqs_across_dp=(1, 1),
+        execution_num_reqs=1,
+    )
+    future = _future(order, batch_desc, sync)
+    coordinator = Mock()
+
+    def start(*args, **kwargs):
+        order.append("start")
+        return future
+
+    coordinator.start.side_effect = start
+    runner._target_dp_sync = coordinator
+    batch_state = SimpleNamespace(
+        num_tokens=2,
+        num_scheduled_tokens=np.array([2], dtype=np.int32),
+        is_prefilling_np=np.array([False]),
+    )
+    runner.gather_batch_req_state = Mock(return_value=(batch_state, 2))
+    input_batch = InputBatch.make_dummy(1, 2, runner.input_buffers)
+
+    def prepare_inputs(*args):
+        order.append("prepare_local")
+        args[-1].result(runner.cudagraph_manager)
+        return input_batch
+
+    runner.prepare_inputs = Mock(side_effect=prepare_inputs)
+
+    output = runner.execute_model(_scheduler_output(2, 1))
+
+    assert output is None
+    assert order == ["start", "prepare_local", "finish", "forward"]
+    assert runner.execute_model_state is not None
+    assert runner.execute_model_state.target_dp_future is future
+    assert runner.execute_model_state.dp_sync is sync
+    assert runner._pending_target_dp_sync is None
+    future.release.assert_not_called()
+
+
+def test_zero_token_rank_executes_one_sentinel_and_releases(monkeypatch):
+    order: list[str] = []
+    runner = _runner(monkeypatch, order)
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=4,
+        num_reqs=2,
+        uniform_token_count=2,
+    )
+    sync = DPSyncState(
+        torch.tensor([4, 4]),
+        2,
+        False,
+        generation=5,
+        live_num_tokens_across_dp=(0, 4),
+        live_num_reqs_across_dp=(0, 2),
+        execution_num_reqs=2,
+    )
+    future = _future(order, batch_desc, sync)
+    coordinator = Mock()
+
+    def start(*args, **kwargs):
+        order.append("start")
+        return future
+
+    coordinator.start.side_effect = start
+    runner._target_dp_sync = coordinator
+    runner.speculator = Mock()
+
+    def dummy_speculator(**kwargs):
+        order.append("speculator")
+        assert kwargs["input_batch"].is_padding.tolist() == [False, True, True, True]
+        assert kwargs["dp_sync"] is sync
+
+    runner._execute_dummy_speculator_stage = Mock(side_effect=dummy_speculator)
+
+    output = runner.execute_model(_scheduler_output(0, 0))
+
+    assert output == "empty"
+    assert order == ["start", "finish", "forward", "speculator", "release"]
+    runner.kv_connector.pre_forward.assert_not_called()
+    assert runner.execute_model_state is None
+    assert runner._pending_target_dp_sync is None
+
+
+def test_engine_core_dummy_contributes_zero_live_work(monkeypatch):
+    order: list[str] = []
+    runner = _runner(monkeypatch, order)
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=4,
+        num_reqs=2,
+        uniform_token_count=2,
+    )
+    sync = DPSyncState(
+        torch.tensor([4, 4]),
+        2,
+        False,
+        generation=6,
+        live_num_tokens_across_dp=(0, 4),
+        live_num_reqs_across_dp=(0, 2),
+        execution_num_reqs=2,
+    )
+    future = _future(order, batch_desc, sync)
+    coordinator = Mock()
+
+    def start(*args, **kwargs):
+        order.append("start")
+        return future
+
+    coordinator.start.side_effect = start
+    runner._target_dp_sync = coordinator
+
+    output = runner.execute_model(
+        _scheduler_output(1, 1),
+        dummy_run=True,
+        dp_idle=True,
+    )
+
+    assert output == "empty"
+    assert coordinator.start.call_args.args[1:3] == (0, 0)
+    assert order == ["start", "finish", "forward", "release"]
+    assert runner._pending_target_dp_sync is None
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_worker_marks_execution_contract_dummy_as_idle(enabled):
+    worker = object.__new__(Worker)
+    worker.model_runner = SimpleNamespace(
+        uniform_decode_query_len=4,
+        dp_execution_contract_enabled=enabled,
+        _dummy_run=Mock(),
+    )
+
+    worker.execute_dummy_batch()
+
+    expected_kwargs = {"uniform_decode": True}
+    if enabled:
+        expected_kwargs["dp_idle"] = True
+    worker.model_runner._dummy_run.assert_called_once_with(4, **expected_kwargs)
+
+
+def test_target_dp_sync_releases_when_forward_fails(monkeypatch):
+    order: list[str] = []
+    runner = _runner(monkeypatch, order)
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=2,
+        num_reqs=1,
+        uniform_token_count=2,
+    )
+    sync = DPSyncState(
+        torch.tensor([2, 2]),
+        2,
+        False,
+        generation=7,
+        live_num_tokens_across_dp=(2, 2),
+        live_num_reqs_across_dp=(1, 1),
+        execution_num_reqs=1,
+    )
+    future = _future(order, batch_desc, sync)
+    coordinator = Mock()
+
+    def start(*args, **kwargs):
+        order.append("start")
+        return future
+
+    coordinator.start.side_effect = start
+    runner._target_dp_sync = coordinator
+    batch_state = SimpleNamespace(
+        num_tokens=2,
+        num_scheduled_tokens=np.array([2], dtype=np.int32),
+        is_prefilling_np=np.array([False]),
+    )
+    runner.gather_batch_req_state = Mock(return_value=(batch_state, 2))
+    input_batch = InputBatch.make_dummy(1, 2, runner.input_buffers)
+
+    def prepare_inputs(*args):
+        args[-1].result(runner.cudagraph_manager)
+        return input_batch
+
+    runner.prepare_inputs = Mock(side_effect=prepare_inputs)
+
+    def fail_forward(desc):
+        order.append("forward")
+        raise RuntimeError("forward failed")
+
+    runner.cudagraph_manager.run_fullgraph.side_effect = fail_forward
+
+    with pytest.raises(RuntimeError, match="forward failed"):
+        runner.execute_model(_scheduler_output(2, 1))
+
+    assert order == ["start", "finish", "forward", "release"]
+    assert runner._pending_target_dp_sync is None
+
+
+def test_target_dp_sync_releases_when_all_ranks_are_idle(monkeypatch):
+    order: list[str] = []
+    runner = _runner(monkeypatch, order)
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.NONE,
+        num_tokens=0,
+        num_reqs=0,
+    )
+    future = _future(order, batch_desc, None)
+    coordinator = Mock()
+
+    def start(*args, **kwargs):
+        order.append("start")
+        return future
+
+    coordinator.start.side_effect = start
+    runner._target_dp_sync = coordinator
+
+    output = runner.execute_model(_scheduler_output(0, 0))
+
+    assert output == "empty"
+    assert order == ["start", "finish", "release"]
+    runner.cudagraph_manager.run_fullgraph.assert_not_called()
+    assert runner._pending_target_dp_sync is None
+
+
+def test_target_dp_sync_releases_when_local_preparation_fails(monkeypatch):
+    order: list[str] = []
+    runner = _runner(monkeypatch, order)
+    future = Mock()
+    future.release.side_effect = lambda: order.append("release")
+    coordinator = Mock()
+
+    def start(*args, **kwargs):
+        order.append("start")
+        return future
+
+    coordinator.start.side_effect = start
+    runner._target_dp_sync = coordinator
+    batch_state = SimpleNamespace(
+        num_tokens=2,
+        num_scheduled_tokens=np.array([2], dtype=np.int32),
+        is_prefilling_np=np.array([False]),
+    )
+    runner.gather_batch_req_state = Mock(return_value=(batch_state, 2))
+    runner.prepare_inputs = Mock(side_effect=RuntimeError("prepare failed"))
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        runner.execute_model(_scheduler_output(2, 1))
+
+    assert order == ["start", "release"]
+    assert runner._pending_target_dp_sync is None

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -238,6 +238,14 @@ class ParallelConfig:
     Defaults to True when async scheduling is enabled, False otherwise.
     """
 
+    enable_dp_execution_contract: bool = False
+    """Enable rank-identical target execution contracts for DP+EP serving.
+
+    This experimental path lets locally idle ranks execute a sentinel row when
+    peers have work. It is currently limited to the validated Model Runner V2
+    and one-sided FlashInfer configuration.
+    """
+
     ray_workers_use_nsight: bool = False
     """Whether to profile Ray workers with nsight, see https://docs.ray.io/en/latest/ray-observability/user-guides/profiling.html#profiling-nsight-profiler."""
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1072,6 +1072,60 @@ class VllmConfig:
         if not self.use_v2_model_runner:
             raise ValueError("trace replay requires Model Runner V2")
 
+    def _verify_dp_execution_contract(self) -> None:
+        parallel_config = self.parallel_config
+        if not parallel_config.enable_dp_execution_contract:
+            return
+
+        unsupported = []
+        if not self.use_v2_model_runner:
+            unsupported.append("Model Runner V1")
+        if self.model_config is None or not self.model_config.is_moe:
+            unsupported.append("a non-MoE model")
+        else:
+            if self.model_config.runner_type != "generate":
+                unsupported.append(f"runner_type={self.model_config.runner_type!r}")
+            if self.model_config.architecture not in {
+                "MiniMaxM3SparseForCausalLM",
+                "MiniMaxM3SparseForConditionalGeneration",
+            }:
+                unsupported.append(f"architecture={self.model_config.architecture!r}")
+        if parallel_config.data_parallel_size <= 1:
+            unsupported.append("data_parallel_size <= 1")
+        if not parallel_config.enable_expert_parallel:
+            unsupported.append("expert parallelism disabled")
+        if not envs.VLLM_MOE_SKIP_PADDING:
+            unsupported.append("VLLM_MOE_SKIP_PADDING=0")
+        if parallel_config.all2all_backend != "flashinfer_nvlink_one_sided":
+            unsupported.append(f"all2all_backend={parallel_config.all2all_backend!r}")
+        if parallel_config.pipeline_parallel_size > 1:
+            unsupported.append("pipeline parallelism")
+        if parallel_config.prefill_context_parallel_size > 1:
+            unsupported.append("prefill context parallelism")
+        if parallel_config.decode_context_parallel_size > 1:
+            unsupported.append("decode context parallelism")
+        if parallel_config.enable_dbo:
+            unsupported.append("dual batch overlap")
+        if parallel_config.enable_eplb:
+            unsupported.append("EPLB")
+        if parallel_config.enable_elastic_ep:
+            unsupported.append("elastic expert parallelism")
+        if self.scheduler_config.async_scheduling:
+            unsupported.append("async scheduling")
+        if self.lora_config is not None:
+            unsupported.append("LoRA")
+        if (
+            self.speculative_config is not None
+            and not self.speculative_config.use_eagle()
+        ):
+            unsupported.append(f"speculative method {self.speculative_config.method!r}")
+
+        if unsupported:
+            raise ValueError(
+                "enable_dp_execution_contract does not yet support "
+                + ", ".join(unsupported)
+            )
+
     def __post_init__(self):
         """Verify configs are valid & consistent with each other."""
 
@@ -1094,6 +1148,8 @@ class VllmConfig:
             self.model_config.verify_dual_chunk_attention_config(self.load_config)
 
             self.parallel_config.is_moe_model = self.model_config.is_moe
+
+        self._verify_dp_execution_contract()
 
         if (
             self.model_config is not None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1110,8 +1110,6 @@ class VllmConfig:
             unsupported.append("EPLB")
         if parallel_config.enable_elastic_ep:
             unsupported.append("elastic expert parallelism")
-        if self.scheduler_config.async_scheduling:
-            unsupported.append("async scheduling")
         if self.lora_config is not None:
             unsupported.append("LoRA")
         if (

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -497,6 +497,7 @@ class EngineArgs:
     data_parallel_multi_port_external_lb: bool = False
     data_parallel_backend: DataParallelBackend = ParallelConfig.data_parallel_backend
     enable_expert_parallel: bool = ParallelConfig.enable_expert_parallel
+    enable_dp_execution_contract: bool = ParallelConfig.enable_dp_execution_contract
     enable_batch_sharded_sampling: bool | None = (
         ParallelConfig.enable_batch_sharded_sampling
     )
@@ -1166,6 +1167,10 @@ class EngineArgs:
             "--enable-expert-parallel",
             "-ep",
             **parallel_kwargs["enable_expert_parallel"],
+        )
+        parallel_group.add_argument(
+            "--enable-dp-execution-contract",
+            **parallel_kwargs["enable_dp_execution_contract"],
         )
         parallel_group.add_argument(
             "--enable-batch-sharded-sampling",
@@ -2302,6 +2307,7 @@ class EngineArgs:
             data_parallel_hybrid_lb=self.data_parallel_hybrid_lb,
             is_moe_model=model_config.is_moe,
             enable_expert_parallel=self.enable_expert_parallel,
+            enable_dp_execution_contract=self.enable_dp_execution_contract,
             enable_batch_sharded_sampling=self.enable_batch_sharded_sampling,
             enable_ep_weight_filter=self.enable_ep_weight_filter,
             all2all_backend=self.all2all_backend,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -321,7 +321,6 @@ class Scheduler(SchedulerInterface):
         # DP prefill balancing: Flag to track whether the last cadence-aligned
         # prefill batch fully drained the waiting queue. Prefill throttling
         # is disabled in this case.
-        self.prefill_capacity_bound = False
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
@@ -549,11 +548,9 @@ class Scheduler(SchedulerInterface):
 
         self.kv_cache_manager.new_step_starts()
 
-        # DP prefill balancing: on a throttled (non-cadence-aligned) step, defer
-        # all prefill compute unless saturated.
-        defer_prefills = (
-            throttle_prefills and not self.prefill_capacity_bound
-        ) and any(not r.is_prefill_chunk for r in self.running)
+        # Keep every source of prompt work behind the rank-identical cadence,
+        # including prompt tails on otherwise idle ranks.
+        defer_prefills = throttle_prefills
 
         # First, schedule the RUNNING requests.
         req_index = 0
@@ -954,7 +951,10 @@ class Scheduler(SchedulerInterface):
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
-                elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
+                elif defer_prefills and (
+                    request.is_prefill_chunk
+                    or num_computed_tokens < request.num_prompt_tokens
+                ):
                     # DP prefill balancing: defer this step's local prefill
                     # compute to a cadence-aligned step.
                     break
@@ -1216,11 +1216,6 @@ class Scheduler(SchedulerInterface):
             # re-queue requests skipped in this pass ahead of older skipped items.
             if step_skipped_waiting:
                 self.skipped_waiting.prepend_requests(step_skipped_waiting)
-
-            # DP prefill balancing: on a step that admitted prefills (release),
-            # record whether it was capacity-bound.
-            if not defer_prefills:
-                self.prefill_capacity_bound = bool(self.waiting)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -2021,6 +2021,9 @@ class DPEngineCoreProc(EngineCoreProc):
 
         scheduler_config = vllm_config.scheduler_config
         self.prefill_schedule_interval = scheduler_config.prefill_schedule_interval
+        self.dp_execution_contract_enabled = (
+            vllm_config.parallel_config.enable_dp_execution_contract
+        )
 
         # Counts forward-passes of the model so that we can synchronize
         # finished with DP peers every N steps.
@@ -2184,6 +2187,17 @@ class DPEngineCoreProc(EngineCoreProc):
             and self.step_counter % self.prefill_schedule_interval != 0
         )
 
+    def _scheduler_owns_target_generation(
+        self, scheduler_will_call_worker: bool
+    ) -> bool:
+        """Whether ``step()`` owns this rank's target worker call.
+
+        The execution-contract path currently rejects async scheduling, so a
+        non-empty scheduler always calls ``execute_model`` exactly once from
+        ``step()``, including when the resulting schedule contains zero tokens.
+        """
+        return self.dp_execution_contract_enabled and scheduler_will_call_worker
+
     @fault_tolerant_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore for data parallel case."""
@@ -2208,6 +2222,11 @@ class DPEngineCoreProc(EngineCoreProc):
                 elif not state.commit_requested and state.is_ready_for_switch():
                     self.process_input_queue_block = True
 
+            # A scheduler-owned worker call participates in this rank's target
+            # execution generation even when it schedules zero local tokens.
+            # Record ownership before stepping so that call is never followed
+            # by a second dummy worker RPC for the same generation.
+            scheduler_will_call_worker = self.scheduler.has_requests()
             executed = self._process_engine_step()
             self._maybe_publish_request_counts()
 
@@ -2217,9 +2236,15 @@ class DPEngineCoreProc(EngineCoreProc):
                     # All engines are idle.
                     continue
 
-                # Execute a dummy pass when no ready requests ran, unless the
-                # engine is sleeping.
-                elif not self.model_executor.is_sleeping:
+                scheduler_owns_generation = self._scheduler_owns_target_generation(
+                    scheduler_will_call_worker
+                )
+                # A rank without a scheduler-owned worker call must still issue
+                # exactly one dummy call while a peer rank may be active.
+                if (
+                    not scheduler_owns_generation
+                    and not self.model_executor.is_sleeping
+                ):
                     with self.capture_iteration_details(None) as iteration_details:
                         self.execute_dummy_batch()
                     if iteration_details is not None and not self.has_coordinator:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -235,6 +235,7 @@ class EngineCore:
         self.step_fn = (
             self.step if self.batch_queue is None else self.step_with_batch_queue
         )
+        self._worker_call_issued_in_step = False
         self.async_scheduling = vllm_config.scheduler_config.async_scheduling
 
         self.aborts_queue = queue.Queue[list[str]]()
@@ -606,6 +607,7 @@ class EngineCore:
         if not self.scheduler.has_requests():
             return {}, False
         scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
+        self._worker_call_issued_in_step = True
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         with (
@@ -665,6 +667,7 @@ class EngineCore:
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
             with self.log_error_detail(scheduler_output):
+                self._worker_call_issued_in_step = True
                 exec_future = self.model_executor.execute_model(
                     scheduler_output, non_block=True
                 )
@@ -1465,11 +1468,13 @@ class EngineCoreProc(EngineCore):
             req = self.input_queue.get_nowait()
             self._handle_client_request(*req)
 
-    def _process_engine_step(self) -> bool:
+    def _process_engine_step(self) -> tuple[bool, bool]:
         """Called only when there are unfinished local requests."""
 
         # Step the engine core.
+        self._worker_call_issued_in_step = False
         outputs, model_executed = self.step_fn()
+        worker_call_issued = self._worker_call_issued_in_step
         # Put EngineCoreOutputs into the output queue.
         for output in outputs.items() if outputs else ():
             self.output_queue.put_nowait(output)
@@ -1482,7 +1487,7 @@ class EngineCoreProc(EngineCore):
         if not model_executed and self.scheduler.has_requests():
             time.sleep(0.001)
 
-        return model_executed
+        return model_executed, worker_call_issued
 
     def _notify_idle_state_callbacks(self) -> None:
         while self._idle_state_callbacks:
@@ -2187,16 +2192,13 @@ class DPEngineCoreProc(EngineCoreProc):
             and self.step_counter % self.prefill_schedule_interval != 0
         )
 
-    def _scheduler_owns_target_generation(
-        self, scheduler_will_call_worker: bool
-    ) -> bool:
-        """Whether ``step()`` owns this rank's target worker call.
+    def _scheduler_owns_target_generation(self, worker_call_issued: bool) -> bool:
+        """Whether this step issued this rank's target worker call.
 
-        The execution-contract path currently rejects async scheduling, so a
-        non-empty scheduler always calls ``execute_model`` exactly once from
-        ``step()``, including when the resulting schedule contains zero tokens.
+        This is tracked at the worker launch rather than inferred from live
+        tokens or result retirement, which differ under async scheduling.
         """
-        return self.dp_execution_contract_enabled and scheduler_will_call_worker
+        return self.dp_execution_contract_enabled and worker_call_issued
 
     @fault_tolerant_wrapper
     def run_busy_loop(self):
@@ -2224,10 +2226,9 @@ class DPEngineCoreProc(EngineCoreProc):
 
             # A scheduler-owned worker call participates in this rank's target
             # execution generation even when it schedules zero local tokens.
-            # Record ownership before stepping so that call is never followed
-            # by a second dummy worker RPC for the same generation.
-            scheduler_will_call_worker = self.scheduler.has_requests()
-            executed = self._process_engine_step()
+            # Track the launch itself so async result retirement cannot cause a
+            # second dummy worker RPC for the same generation.
+            executed, worker_call_issued = self._process_engine_step()
             self._maybe_publish_request_counts()
 
             local_unfinished_reqs = self.scheduler.has_unfinished_requests()
@@ -2237,7 +2238,7 @@ class DPEngineCoreProc(EngineCoreProc):
                     continue
 
                 scheduler_owns_generation = self._scheduler_owns_target_generation(
-                    scheduler_will_call_worker
+                    worker_call_issued
                 )
                 # A rank without a scheduler-owned worker call must still issue
                 # exactly one dummy call while a peer rank may be active.

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -35,6 +35,173 @@ class DPSyncState:
     eager: bool
 
 
+class DPSyncFuture:
+    """An in-flight DP shape agreement backed by a reusable CPU buffer."""
+
+    def __init__(
+        self,
+        coordinator: DPSyncCoordinator,
+        local_batch_desc: BatchExecutionDescriptor,
+        num_tokens: int,
+        num_reqs: int,
+        num_active_loras: int,
+        work: dist.Work | None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._local_batch_desc = local_batch_desc
+        self._num_tokens = num_tokens
+        self._num_reqs = num_reqs
+        self._num_active_loras = num_active_loras
+        self._work = work
+        self._waited = work is None
+        self._result: tuple[BatchExecutionDescriptor, DPSyncState | None] | None = None
+        self._released = False
+
+    def result(
+        self, cudagraph_manager: CudaGraphManager | None
+    ) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
+        """Wait for and resolve the agreement without releasing its buffer.
+
+        The returned ``DPSyncState`` may contain a view into the coordinator's
+        reusable buffer and is valid only until :meth:`release` is called.
+        """
+        if self._released:
+            raise RuntimeError("Cannot resolve a released DP sync future")
+        if self._result is not None:
+            return self._result
+
+        if self._work is None:
+            self._result = self._local_batch_desc, None
+        else:
+            self._work.wait()
+            self._waited = True
+            tensor = self._coordinator._tensor
+            assert tensor is not None
+            self._result = _finish_cudagraph_and_dp_padding(
+                cudagraph_manager,
+                self._local_batch_desc,
+                tensor,
+                self._num_tokens,
+                self._num_reqs,
+                self._num_active_loras,
+            )
+        return self._result
+
+    def release(self) -> None:
+        """Wait for unfinished work and return the backing buffer."""
+        if self._released:
+            return
+        if self._work is not None and not self._waited:
+            self._work.wait()
+            self._waited = True
+        self._coordinator._release(self)
+        self._released = True
+
+
+class DPSyncCoordinator:
+    """Own one persistent CPU buffer for asynchronous DP shape agreement."""
+
+    def __init__(
+        self,
+        dp_size: int,
+        dp_rank: int,
+        *,
+        group: dist.ProcessGroup | None = None,
+    ) -> None:
+        self.dp_size = dp_size
+        self.dp_rank = dp_rank
+        self.group = group
+        self._tensor = (
+            torch.zeros(4, dp_size, dtype=torch.int32, device="cpu")
+            if dp_size > 1
+            else None
+        )
+        self._active_future: DPSyncFuture | None = None
+
+    def start(
+        self,
+        cudagraph_manager: CudaGraphManager | None,
+        num_reqs: int,
+        num_tokens: int,
+        uniform_token_count: int | None,
+        max_query_len: int | None = None,
+        need_eager: bool = False,
+        num_active_loras: int = 0,
+    ) -> DPSyncFuture:
+        """Dispatch locally and issue the DP collective without waiting."""
+        if self._active_future is not None:
+            raise RuntimeError("A DP sync is already in flight")
+
+        batch_desc = _dispatch_local_batch(
+            cudagraph_manager,
+            num_reqs,
+            num_tokens,
+            uniform_token_count,
+            max_query_len,
+            need_eager,
+            num_active_loras,
+        )
+
+        work = None
+        if self._tensor is not None:
+            tensor = self._tensor
+            tensor.zero_()
+            tensor[0][self.dp_rank] = num_tokens
+            tensor[1][self.dp_rank] = batch_desc.cg_mode.value
+            tensor[2][self.dp_rank] = uniform_token_count or 0
+            tensor[3][self.dp_rank] = max_query_len or -1
+            group = self.group
+            if group is None:
+                group = get_dp_group().cpu_group
+            work = dist.all_reduce(tensor, group=group, async_op=True)
+
+        future = DPSyncFuture(
+            self,
+            batch_desc,
+            num_tokens,
+            num_reqs,
+            num_active_loras,
+            work,
+        )
+        self._active_future = future
+        return future
+
+    def _release(self, future: DPSyncFuture) -> None:
+        if self._active_future is not future:
+            raise RuntimeError("DP sync future is not owned by this coordinator")
+        self._active_future = None
+
+
+def _dispatch_local_batch(
+    cudagraph_manager: CudaGraphManager | None,
+    num_reqs: int,
+    num_tokens: int,
+    uniform_token_count: int | None,
+    max_query_len: int | None,
+    need_eager: bool,
+    num_active_loras: int,
+) -> BatchExecutionDescriptor:
+    if need_eager:
+        return BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.NONE,
+            num_tokens=num_tokens,
+            num_reqs=num_reqs,
+            num_active_loras=num_active_loras,
+        )
+
+    assert cudagraph_manager is not None, (
+        "cudagraph_manager should only be None during profile run, "
+        "where need_eager must be True"
+    )
+    return cudagraph_manager.dispatch(
+        num_reqs,
+        num_tokens,
+        uniform_token_count,
+        num_active_loras=num_active_loras,
+        max_query_len=max_query_len,
+    )
+
+
 def sync_cudagraph_and_dp_padding(
     cudagraph_manager: CudaGraphManager | None,
     desired_batch_desc: BatchExecutionDescriptor,
@@ -60,6 +227,24 @@ def sync_cudagraph_and_dp_padding(
     tensor[3][dp_rank] = max_query_len or -1  # (-1 means None)
     dist.all_reduce(tensor, group=group)
 
+    return _finish_cudagraph_and_dp_padding(
+        cudagraph_manager,
+        desired_batch_desc,
+        tensor,
+        num_tokens,
+        num_reqs,
+        num_active_loras,
+    )
+
+
+def _finish_cudagraph_and_dp_padding(
+    cudagraph_manager: CudaGraphManager | None,
+    desired_batch_desc: BatchExecutionDescriptor,
+    tensor: torch.Tensor,
+    num_tokens: int,
+    num_reqs: int,
+    num_active_loras: int,
+) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
     num_tokens_across_dp = tensor[0]
     cg_mode_across_dp = tensor[1]
     uniform_token_counts_across_dp = tensor[2]
@@ -175,25 +360,15 @@ def dispatch_cg_and_sync_dp(
     """
     reuse_eager = dp_sync is not None and dp_sync.eager
 
-    if need_eager or reuse_eager:
-        batch_desc = BatchExecutionDescriptor(
-            cg_mode=CUDAGraphMode.NONE,
-            num_tokens=num_tokens,
-            num_reqs=num_reqs,
-            num_active_loras=num_active_loras,
-        )
-    else:
-        assert cudagraph_manager is not None, (
-            "cudagraph_manager should only be None during profile run, "
-            "where need_eager must be True"
-        )
-        batch_desc = cudagraph_manager.dispatch(
-            num_reqs,
-            num_tokens,
-            dp_sync.uniform_token_count if dp_sync is not None else uniform_token_count,
-            num_active_loras=num_active_loras,
-            max_query_len=max_query_len,
-        )
+    batch_desc = _dispatch_local_batch(
+        cudagraph_manager,
+        num_reqs,
+        num_tokens,
+        dp_sync.uniform_token_count if dp_sync is not None else uniform_token_count,
+        max_query_len,
+        need_eager or reuse_eager,
+        num_active_loras,
+    )
 
     if dp_size == 1:
         return batch_desc, None

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from typing import Literal
 
 import torch
 import torch.distributed as dist
@@ -24,8 +25,9 @@ class DPSyncState:
     value here.
     """
 
-    # Per-rank token counts, for the forward context. All entries hold the
-    # agreed padded count, unless `eager`, where nothing was padded.
+    # Per-rank token counts for the forward context. An execution contract
+    # rewrites every entry to its rank-identical execution capacity; legacy
+    # eager dispatch retains live per-rank counts.
     num_tokens_across_dp: torch.Tensor
     # Agreed uniform decode length. None means the ranks disagreed, which is an
     # answer, not "unknown".
@@ -33,6 +35,53 @@ class DPSyncState:
     # Whether the ranks agreed to run eager. A dispatch reusing this must run
     # eager too; no shape was agreed, so picking a graph per rank would diverge.
     eager: bool
+    # Sequence number within this coordinator's collective lane.
+    generation: int | None = None
+    # Target generation that owns this speculative child agreement.
+    parent_generation: int | None = None
+    # Rank-local work before execution-contract padding. These are immutable
+    # snapshots because ``num_tokens_across_dp`` may be rewritten in place.
+    live_num_tokens_across_dp: tuple[int, ...] = ()
+    live_num_reqs_across_dp: tuple[int, ...] = ()
+    # Request capacity selected by a target execution contract. Unlike
+    # ``batch_desc.num_reqs``, this is populated for PIECEWISE execution too.
+    execution_num_reqs: int | None = None
+
+
+_SYNC_NUM_TOKENS = 0
+_SYNC_CG_MODE = 1
+_SYNC_UNIFORM_TOKEN_COUNT = 2
+_SYNC_MAX_QUERY_LEN = 3
+_SYNC_NUM_REQS = 4
+_SYNC_GENERATION = 5
+_SYNC_PARENT_GENERATION = 6
+_SYNC_NEED_EAGER = 7
+_SYNC_NUM_ACTIVE_LORAS = 8
+_SYNC_NUM_FIELDS = 9
+
+_DP_SYNC_GROUPS: dict[tuple[int, str], dist.ProcessGroup] = {}
+
+
+def _get_dp_sync_group(
+    lane: Literal["target", "speculator"],
+) -> dist.ProcessGroup:
+    """Return the isolated CPU process group for a collective lane."""
+    base_group = get_dp_group().cpu_group
+    if lane == "target":
+        return base_group
+
+    key = (id(base_group), lane)
+    group = _DP_SYNC_GROUPS.get(key)
+    if group is None:
+        # Only members of this DP group construct the clone. Every member
+        # creates the speculator lane on its first speculative agreement.
+        group = dist.new_group(
+            ranks=dist.get_process_group_ranks(base_group),
+            backend="gloo",
+            use_local_synchronization=True,
+        )
+        _DP_SYNC_GROUPS[key] = group
+    return group
 
 
 class DPSyncFuture:
@@ -45,6 +94,8 @@ class DPSyncFuture:
         num_tokens: int,
         num_reqs: int,
         num_active_loras: int,
+        generation: int,
+        parent_generation: int | None,
         work: dist.Work | None,
     ) -> None:
         self._coordinator = coordinator
@@ -52,6 +103,8 @@ class DPSyncFuture:
         self._num_tokens = num_tokens
         self._num_reqs = num_reqs
         self._num_active_loras = num_active_loras
+        self.generation = generation
+        self.parent_generation = parent_generation
         self._work = work
         self._waited = work is None
         self._result: tuple[BatchExecutionDescriptor, DPSyncState | None] | None = None
@@ -77,14 +130,38 @@ class DPSyncFuture:
             self._waited = True
             tensor = self._coordinator._tensor
             assert tensor is not None
-            self._result = _finish_cudagraph_and_dp_padding(
-                cudagraph_manager,
-                self._local_batch_desc,
-                tensor,
-                self._num_tokens,
-                self._num_reqs,
-                self._num_active_loras,
-            )
+            _validate_sync_generation(tensor, self.generation, self.parent_generation)
+            if self._coordinator.execution_contract:
+                self._result = _finish_dp_execution_contract(
+                    cudagraph_manager,
+                    tensor,
+                    self.generation,
+                    self.parent_generation,
+                )
+            else:
+                live_num_tokens = tuple(
+                    int(value) for value in tensor[_SYNC_NUM_TOKENS].tolist()
+                )
+                live_num_reqs = tuple(
+                    int(value) for value in tensor[_SYNC_NUM_REQS].tolist()
+                )
+                batch_desc, sync = _finish_cudagraph_and_dp_padding(
+                    cudagraph_manager,
+                    self._local_batch_desc,
+                    tensor,
+                    self._num_tokens,
+                    self._num_reqs,
+                    self._num_active_loras,
+                )
+                if sync is not None:
+                    sync = replace(
+                        sync,
+                        generation=self.generation,
+                        parent_generation=self.parent_generation,
+                        live_num_tokens_across_dp=live_num_tokens,
+                        live_num_reqs_across_dp=live_num_reqs,
+                    )
+                self._result = batch_desc, sync
         return self._result
 
     def release(self) -> None:
@@ -107,16 +184,21 @@ class DPSyncCoordinator:
         dp_rank: int,
         *,
         group: dist.ProcessGroup | None = None,
+        lane: Literal["target", "speculator"] = "target",
+        execution_contract: bool = False,
     ) -> None:
         self.dp_size = dp_size
         self.dp_rank = dp_rank
         self.group = group
+        self.lane = lane
+        self.execution_contract = execution_contract
         self._tensor = (
-            torch.zeros(4, dp_size, dtype=torch.int32, device="cpu")
+            torch.zeros(_SYNC_NUM_FIELDS, dp_size, dtype=torch.int64, device="cpu")
             if dp_size > 1
             else None
         )
         self._active_future: DPSyncFuture | None = None
+        self._next_generation = 0
 
     def start(
         self,
@@ -127,6 +209,7 @@ class DPSyncCoordinator:
         max_query_len: int | None = None,
         need_eager: bool = False,
         num_active_loras: int = 0,
+        parent_generation: int | None = None,
     ) -> DPSyncFuture:
         """Dispatch locally and issue the DP collective without waiting."""
         if self._active_future is not None:
@@ -142,17 +225,26 @@ class DPSyncCoordinator:
             num_active_loras,
         )
 
+        generation = self._next_generation
+        self._next_generation += 1
         work = None
         if self._tensor is not None:
             tensor = self._tensor
             tensor.zero_()
-            tensor[0][self.dp_rank] = num_tokens
-            tensor[1][self.dp_rank] = batch_desc.cg_mode.value
-            tensor[2][self.dp_rank] = uniform_token_count or 0
-            tensor[3][self.dp_rank] = max_query_len or -1
+            tensor[_SYNC_NUM_TOKENS][self.dp_rank] = num_tokens
+            tensor[_SYNC_CG_MODE][self.dp_rank] = batch_desc.cg_mode.value
+            tensor[_SYNC_UNIFORM_TOKEN_COUNT][self.dp_rank] = uniform_token_count or 0
+            tensor[_SYNC_MAX_QUERY_LEN][self.dp_rank] = max_query_len or -1
+            tensor[_SYNC_NUM_REQS][self.dp_rank] = num_reqs
+            tensor[_SYNC_GENERATION][self.dp_rank] = generation
+            tensor[_SYNC_PARENT_GENERATION][self.dp_rank] = (
+                parent_generation if parent_generation is not None else -1
+            )
+            tensor[_SYNC_NEED_EAGER][self.dp_rank] = int(need_eager)
+            tensor[_SYNC_NUM_ACTIVE_LORAS][self.dp_rank] = num_active_loras
             group = self.group
             if group is None:
-                group = get_dp_group().cpu_group
+                group = _get_dp_sync_group(self.lane)
             work = dist.all_reduce(tensor, group=group, async_op=True)
 
         future = DPSyncFuture(
@@ -161,6 +253,8 @@ class DPSyncCoordinator:
             num_tokens,
             num_reqs,
             num_active_loras,
+            generation,
+            parent_generation,
             work,
         )
         self._active_future = future
@@ -170,6 +264,119 @@ class DPSyncCoordinator:
         if self._active_future is not future:
             raise RuntimeError("DP sync future is not owned by this coordinator")
         self._active_future = None
+
+
+def _validate_sync_generation(
+    tensor: torch.Tensor,
+    generation: int,
+    parent_generation: int | None,
+) -> None:
+    generations = tensor[_SYNC_GENERATION]
+    if not bool(torch.all(generations == generation).item()):
+        raise RuntimeError(
+            "DP sync generation mismatch: "
+            f"local={generation}, observed={generations.tolist()}"
+        )
+
+    expected_parent = parent_generation if parent_generation is not None else -1
+    parents = tensor[_SYNC_PARENT_GENERATION]
+    if not bool(torch.all(parents == expected_parent).item()):
+        raise RuntimeError(
+            "DP sync parent generation mismatch: "
+            f"local={expected_parent}, observed={parents.tolist()}"
+        )
+
+
+def _finish_dp_execution_contract(
+    cudagraph_manager: CudaGraphManager | None,
+    tensor: torch.Tensor,
+    generation: int,
+    parent_generation: int | None,
+) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
+    """Resolve rank-local facts into one target execution descriptor."""
+    live_num_tokens = tensor[_SYNC_NUM_TOKENS]
+    live_num_reqs = tensor[_SYNC_NUM_REQS]
+    live_tokens_tuple = tuple(int(value) for value in live_num_tokens.tolist())
+    live_reqs_tuple = tuple(int(value) for value in live_num_reqs.tolist())
+
+    active = live_num_tokens > 0
+    if not bool(torch.any(active).item()):
+        return (
+            BatchExecutionDescriptor(
+                cg_mode=CUDAGraphMode.NONE,
+                num_tokens=0,
+                num_reqs=0,
+            ),
+            None,
+        )
+
+    active_num_tokens = live_num_tokens[active]
+    active_num_reqs = live_num_reqs[active]
+    if bool(torch.any(active_num_reqs > active_num_tokens).item()):
+        raise RuntimeError(
+            "DP execution contract observed requests exceeding tokens: "
+            f"requests={active_num_reqs.tolist()}, "
+            f"tokens={active_num_tokens.tolist()}"
+        )
+
+    exec_num_tokens = int(active_num_tokens.max().item())
+    exec_num_reqs = int(active_num_reqs.max().item())
+    if exec_num_reqs <= 0:
+        raise RuntimeError("DP execution contract has active tokens but no requests")
+
+    uniform_counts = tensor[_SYNC_UNIFORM_TOKEN_COUNT][active]
+    uniform_token_count: int | None = int(uniform_counts[0].item())
+    if uniform_token_count == 0 or not bool(
+        torch.all(uniform_counts == uniform_token_count).item()
+    ):
+        uniform_token_count = None
+
+    max_query_lens = tensor[_SYNC_MAX_QUERY_LEN][active]
+    max_query_len: int | None = None
+    if bool(torch.all(max_query_lens != -1).item()):
+        max_query_len = int(max_query_lens.max().item())
+
+    num_active_loras = int(tensor[_SYNC_NUM_ACTIVE_LORAS][active].max().item())
+    need_eager = bool(torch.any(tensor[_SYNC_NEED_EAGER][active] != 0).item())
+    if need_eager:
+        batch_desc = BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.NONE,
+            num_tokens=exec_num_tokens,
+            num_reqs=exec_num_reqs,
+            uniform_token_count=uniform_token_count,
+            max_query_len=max_query_len,
+            num_active_loras=num_active_loras,
+        )
+    else:
+        assert cudagraph_manager is not None
+        batch_desc = cudagraph_manager.dispatch(
+            exec_num_reqs,
+            exec_num_tokens,
+            uniform_token_count,
+            num_active_loras=num_active_loras,
+            max_query_len=max_query_len,
+        )
+
+    exec_num_reqs = batch_desc.num_reqs or exec_num_reqs
+    if batch_desc.num_tokens <= 0 or exec_num_reqs <= 0:
+        raise RuntimeError(
+            "DP execution contract resolved invalid geometry: "
+            f"tokens={batch_desc.num_tokens}, requests={exec_num_reqs}"
+        )
+
+    # Forward-context DP metadata describes execution capacity. Preserve live
+    # occupancy above before rewriting this reusable row in place.
+    live_num_tokens.fill_(batch_desc.num_tokens)
+    return batch_desc, DPSyncState(
+        num_tokens_across_dp=live_num_tokens,
+        uniform_token_count=uniform_token_count,
+        eager=batch_desc.cg_mode == CUDAGraphMode.NONE,
+        generation=generation,
+        parent_generation=parent_generation,
+        live_num_tokens_across_dp=live_tokens_tuple,
+        live_num_reqs_across_dp=live_reqs_tuple,
+        execution_num_reqs=exec_num_reqs,
+    )
 
 
 def _dispatch_local_batch(
@@ -350,9 +557,9 @@ def dispatch_cg_and_sync_dp(
             cross-rank agreement; it never changes a bucket's token count.
         dp_sync: Agreement from a prior dispatch over this same batch, to reuse.
             Must come from a batch with this same padded `num_tokens` and the
-            same `uniform_token_count`; `num_reqs` may differ, as neither
-            depends on it. Passing a sync from a different batch is a caller
-            error and trips an assert.
+            same `uniform_token_count`. An execution contract also supplies the
+            rank-identical request capacity used for graph selection. Passing a
+            sync from a different batch is a caller error and trips an assert.
 
     Returns:
         (batch_desc, sync), where `sync` is this batch's agreement for a later
@@ -360,9 +567,14 @@ def dispatch_cg_and_sync_dp(
     """
     reuse_eager = dp_sync is not None and dp_sync.eager
 
+    dispatch_num_reqs = (
+        dp_sync.execution_num_reqs
+        if dp_sync is not None and dp_sync.execution_num_reqs is not None
+        else num_reqs
+    )
     batch_desc = _dispatch_local_batch(
         cudagraph_manager,
-        num_reqs,
+        dispatch_num_reqs,
         num_tokens,
         dp_sync.uniform_token_count if dp_sync is not None else uniform_token_count,
         max_query_len,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -20,6 +20,7 @@ instead of embedding feature-specific logic directly.
 import functools
 import gc
 import time
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from copy import deepcopy
 from typing import Any, NamedTuple
@@ -104,7 +105,12 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 from vllm.v1.worker.gpu.cudagraph_utils import (
     profile_cudagraph_memory as _profile_cudagraph_memory,
 )
-from vllm.v1.worker.gpu.dp_utils import DPSyncState, dispatch_cg_and_sync_dp
+from vllm.v1.worker.gpu.dp_utils import (
+    DPSyncCoordinator,
+    DPSyncFuture,
+    DPSyncState,
+    dispatch_cg_and_sync_dp,
+)
 from vllm.v1.worker.gpu.ec_connector import get_ec_connector
 from vllm.v1.worker.gpu.eplb_utils import EPLBController, step_eplb_after
 from vllm.v1.worker.gpu.input_batch import (
@@ -171,6 +177,37 @@ from vllm.v1.worker.workspace import use_workspace_lane
 logger = init_logger(__name__)
 
 
+def _release_target_dp_sync_on_error(
+    func: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Release model-runner-owned DP work when an execution path fails."""
+
+    @functools.wraps(func)
+    def wrapped(self: "GPUModelRunner", *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except BaseException:
+            self._release_pending_target_dp_sync()
+            raise
+
+    return wrapped
+
+
+def _release_target_dp_sync_after(
+    func: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Release model-runner-owned DP work after a consumer returns."""
+
+    @functools.wraps(func)
+    def wrapped(self: "GPUModelRunner", *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            self._release_pending_target_dp_sync()
+
+    return wrapped
+
+
 class GPUModelRunner(LoRAModelRunnerMixin):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         self.vllm_config = vllm_config
@@ -227,6 +264,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Data parallelism.
         self.dp_size = self.parallel_config.data_parallel_size
         self.dp_rank = self.parallel_config.data_parallel_rank
+        self.dp_execution_contract_enabled = (
+            self.parallel_config.enable_dp_execution_contract
+        )
+        self._target_dp_sync = (
+            DPSyncCoordinator(
+                self.dp_size,
+                self.dp_rank,
+                lane="target",
+                execution_contract=True,
+            )
+            if self.dp_execution_contract_enabled
+            else None
+        )
+        self._pending_target_dp_sync: DPSyncFuture | None = None
 
         # Detect EP all2all peer faults to prevent emitting corrupted output.
         # Only meaningful for MoE + DP with an FT-capable all2all backend.
@@ -351,6 +402,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
         self.req_states.max_model_len = max_model_len
+
+    def _release_pending_target_dp_sync(self) -> None:
+        future = self._pending_target_dp_sync
+        if future is not None:
+            future.release()
+            self._pending_target_dp_sync = None
 
     def init_routed_experts_capturer(self) -> None:
         """Initialize target-model capture on every participating worker."""
@@ -699,6 +756,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
 
     @torch.inference_mode()
+    @_release_target_dp_sync_after
     @step_eplb_after(is_dummy=True)
     def _dummy_run(
         self,
@@ -710,6 +768,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         skip_eplb: bool = False,
         is_profile: bool = False,
         valid_dummy_state_slots: bool = False,
+        dp_idle: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         if skip_attn and not is_profile:
@@ -768,8 +827,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 is_profile=is_profile,
                 context_len=context_len,
                 valid_dummy_state_slots=valid_dummy_state_slots,
+                dp_idle=dp_idle,
             )
         self.kv_connector.set_disabled(False)
+
+        if dp_idle:
+            # execute_model performed the contract-shaped sentinel and its
+            # mandatory speculative child. There is no local output to sample.
+            return None, None
 
         # Non-last PP ranks don't produce output for sampling.
         if not self.is_last_pp_rank:
@@ -782,61 +847,92 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         hidden_states = self.execute_model_state.hidden_states
         aux_hidden_states = self.execute_model_state.aux_hidden_states
         dp_sync = self.execute_model_state.dp_sync
+        target_dp_future = self.execute_model_state.target_dp_future
         self.execute_model_state = None
+        if target_dp_future is not None:
+            assert self._pending_target_dp_sync is None
+            self._pending_target_dp_sync = target_dp_future
 
         self.step_timing.forward_end()
 
-        # dummy run the eagle speculator's propose to ensure DP/EP sync.
+        # Dummy-run the speculator so every DP rank executes the same child.
         if self.speculator is not None:
-            assert self.sampler is not None
             self.step_timing.drafter_start()
-            mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
-            if self.speculator.supports_mm_inputs:
-                mm_inputs = (
-                    [],
-                    torch.zeros(
-                        input_batch.num_tokens,
-                        dtype=torch.bool,
-                        device="cpu",
-                    ),
-                )
-
-            # Let the target override the hidden state fed to the drafter
-            # (e.g. DeepSeek V4 MTP needs the pre-hc_head residual). The
-            # target returns a persistent buffer sized at max_num_batched_tokens;
-            # slice to the active token count that propose() expects.
-            spec_hidden_states = hidden_states
-            if hasattr(self.model, "get_mtp_target_hidden_states"):
-                pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
-                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            with use_workspace_lane(self._draft_workspace_lane):
-                self.speculator.propose(
-                    input_batch=input_batch,
-                    attn_metadata=attn_metadata,
-                    slot_mappings=slot_mappings_by_layer,
-                    last_hidden_states=spec_hidden_states,
-                    aux_hidden_states=aux_hidden_states,
-                    num_sampled=torch.ones(
-                        input_batch.num_reqs, dtype=torch.int32, device=self.device
-                    ),
-                    num_rejected=torch.zeros(
-                        input_batch.num_reqs, dtype=torch.int32, device=self.device
-                    ),
-                    last_sampled=self.req_states.last_sampled_tokens,
-                    next_prefill_tokens=self.req_states.next_prefill_tokens,
-                    temperature=self.sampler.sampling_states.temperature.gpu,
-                    seeds=self.sampler.sampling_states.seeds.gpu,
-                    dp_sync=dp_sync,
-                    dummy_run=True,
-                    skip_attn_for_dummy_run=skip_attn,
-                    mm_inputs=mm_inputs,
-                    is_profile=is_profile,
-                )
+            self._execute_dummy_speculator_stage(
+                input_batch=input_batch,
+                attn_metadata=attn_metadata,
+                slot_mappings_by_layer=slot_mappings_by_layer,
+                hidden_states=hidden_states,
+                aux_hidden_states=aux_hidden_states,
+                dp_sync=dp_sync,
+                skip_attn=skip_attn,
+                is_profile=is_profile,
+            )
             self.step_timing.drafter_end()
 
         assert hidden_states is not None  # Last PP rank always has hidden_states
         sample_hidden_states = hidden_states[input_batch.logits_indices]
         return hidden_states, sample_hidden_states
+
+    def _execute_dummy_speculator_stage(
+        self,
+        *,
+        input_batch: InputBatch,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings_by_layer: dict[str, torch.Tensor] | None,
+        hidden_states: torch.Tensor | None,
+        aux_hidden_states: list[torch.Tensor] | None,
+        dp_sync: DPSyncState | None,
+        skip_attn: bool,
+        is_profile: bool,
+    ) -> None:
+        """Execute the mandatory speculative child for a dummy target."""
+        assert self.speculator is not None
+        assert self.sampler is not None
+        assert hidden_states is not None
+
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
+        if self.speculator.supports_mm_inputs:
+            mm_inputs = (
+                [],
+                torch.zeros(
+                    input_batch.num_tokens,
+                    dtype=torch.bool,
+                    device="cpu",
+                ),
+            )
+
+        spec_hidden_states = hidden_states
+        if hasattr(self.model, "get_mtp_target_hidden_states"):
+            pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
+            spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]
+        with use_workspace_lane(self._draft_workspace_lane):
+            self.speculator.propose(
+                input_batch=input_batch,
+                attn_metadata=attn_metadata,
+                slot_mappings=slot_mappings_by_layer,
+                last_hidden_states=spec_hidden_states,
+                aux_hidden_states=aux_hidden_states,
+                num_sampled=torch.ones(
+                    input_batch.num_reqs,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+                num_rejected=torch.zeros(
+                    input_batch.num_reqs,
+                    dtype=torch.int32,
+                    device=self.device,
+                ),
+                last_sampled=self.req_states.last_sampled_tokens,
+                next_prefill_tokens=self.req_states.next_prefill_tokens,
+                temperature=self.sampler.sampling_states.temperature.gpu,
+                seeds=self.sampler.sampling_states.seeds.gpu,
+                dp_sync=dp_sync,
+                dummy_run=True,
+                skip_attn_for_dummy_run=skip_attn,
+                mm_inputs=mm_inputs,
+                is_profile=is_profile,
+            )
 
     @torch.inference_mode()
     def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
@@ -1173,17 +1269,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self,
         scheduler_output: SchedulerOutput,
         batch_req_state: "BatchReqState",
-        batch_desc: BatchExecutionDescriptor,
+        batch_desc_or_future: BatchExecutionDescriptor | DPSyncFuture,
     ) -> InputBatch:
         num_tokens = batch_req_state.num_tokens
-        num_tokens_after_padding = max(num_tokens, batch_desc.num_tokens)
         assert num_tokens > 0
-        if envs.VLLM_MOE_SKIP_PADDING:
-            # Mark trailing cudagraph-padding rows so kernels can skip work for
-            # them when supported.
-            is_padding = self.input_buffers.is_padding
-            is_padding[:num_tokens].fill_(False)
-            is_padding[num_tokens:num_tokens_after_padding].fill_(True)
 
         req_ids = batch_req_state.req_ids
         num_scheduled_tokens_np = batch_req_state.num_scheduled_tokens
@@ -1241,14 +1330,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 )
             )
 
-        # Get query_start_loc.
-        # num_reqs_padded is None for PIECEWISE graphs (no request padding needed)
-        num_reqs_padded = batch_desc.num_reqs or num_reqs
         query_start_loc_np = np.empty(self.max_num_reqs + 1, dtype=np.int32)
         query_start_loc_np[0] = 0
         np.cumsum(num_scheduled_tokens_np, out=query_start_loc_np[1 : num_reqs + 1])
-        # Pad for full CUDA graph mode.
-        # Some attention backends like FA3 require query_start_loc to be non-decreasing.
+        # Some attention backends require non-decreasing graph-padding entries.
         query_start_loc_np[num_reqs + 1 :] = num_tokens
         query_start_loc = self.input_buffers.query_start_loc
         async_copy_to_gpu(query_start_loc_np, out=query_start_loc)
@@ -1261,34 +1346,29 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             expanded_idx_mapping, expanded_local_pos = expand_idx_mapping(
                 idx_mapping, total_num_logits, cu_num_logits, self.decode_query_len
             )
-        query_start_loc_np = query_start_loc_np[: num_reqs_padded + 1]
-        query_start_loc = query_start_loc[: num_reqs_padded + 1]
 
-        # Get prefill tokens if any.
+        # Descriptor-independent GPU work uses only the rank-local prefix.
+        local_query_start_loc = query_start_loc[: num_reqs + 1]
         if batch_req_state.has_prefill:
             prepare_prefill_inputs(
                 self.input_buffers.input_ids,
                 self.req_states.next_prefill_tokens,
                 idx_mapping,
-                query_start_loc,
+                local_query_start_loc,
                 self.req_states.all_token_ids.gpu,
                 self.req_states.prefill_len.gpu,
                 self.req_states.num_computed_tokens.gpu,
             )
-
-        # Prepare positions and seq_lens.
         prepare_pos_seq_lens(
             idx_mapping,
-            query_start_loc,
+            local_query_start_loc,
             self.req_states.num_computed_tokens.gpu,
             self.input_buffers.positions,
             self.input_buffers.seq_lens,
         )
-        seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
+        local_seq_lens = self.input_buffers.seq_lens[:num_reqs]
 
-        dcp_local_seq_lens = None
         if self.use_dcp:
-            # Prepare dcp local seq_lens.
             prepare_dcp_local_seq_lens(
                 self.input_buffers.dcp_local_seq_lens,
                 self.input_buffers.seq_lens,
@@ -1297,16 +1377,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.dcp_rank,
                 self.cp_interleave,
             )
-            dcp_local_seq_lens = self.input_buffers.dcp_local_seq_lens[:num_reqs_padded]
 
-        # Some input token ids are directly read from the last sampled tokens
-        # and draft tokens. Also, get the logits indices to sample tokens from.
         logits_indices = combine_sampled_and_draft_tokens(
             self.input_buffers.input_ids,
             idx_mapping,
             self.req_states.last_sampled_tokens,
-            query_start_loc,
-            seq_lens,
+            local_query_start_loc,
+            local_seq_lens,
             self.req_states.prefill_len.gpu,
             self.req_states.draft_tokens,
             cu_num_logits,
@@ -1314,7 +1391,30 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.model_state.num_new_sampled_tokens_per_step,
         )
 
-        # CPU upper bound on seq_lens; padded entries left at zero.
+        # Wait only after all rank-local CPU work and GPU enqueues above.
+        # result() is cached, so execute_model retrieves the DPSyncState later
+        # without waiting twice.
+        batch_desc = (
+            batch_desc_or_future.result(self.cudagraph_manager)[0]
+            if isinstance(batch_desc_or_future, DPSyncFuture)
+            else batch_desc_or_future
+        )
+        num_reqs_padded = batch_desc.num_reqs or num_reqs
+        num_tokens_after_padding = max(num_tokens, batch_desc.num_tokens)
+        if envs.VLLM_MOE_SKIP_PADDING:
+            is_padding = self.input_buffers.is_padding
+            is_padding[:num_tokens].fill_(False)
+            is_padding[num_tokens:num_tokens_after_padding].fill_(True)
+
+        query_start_loc_np = query_start_loc_np[: num_reqs_padded + 1]
+        query_start_loc = query_start_loc[: num_reqs_padded + 1]
+        seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
+        dcp_local_seq_lens = (
+            self.input_buffers.dcp_local_seq_lens[:num_reqs_padded]
+            if self.use_dcp
+            else None
+        )
+
         num_computed_tokens_np = self.req_states.num_computed_tokens_np[idx_mapping_np]
         seq_lens_cpu_upper_bound_np = np.zeros(num_reqs_padded, dtype=np.int32)
         np.add(
@@ -1326,7 +1426,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         prompt_lens = None
         if self.model_config.rswa_window is not None:
-            # prompt_lens is only used in R-SWA case.
             prompt_lens = self.req_states.prompt_len.gpu[idx_mapping]
 
         input_batch = InputBatch(
@@ -1530,6 +1629,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
 
     @torch.inference_mode()
+    @_release_target_dp_sync_on_error
     def execute_model(
         self,
         scheduler_output: SchedulerOutput,
@@ -1539,7 +1639,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         is_profile: bool = False,
         context_len: int = 0,
         valid_dummy_state_slots: bool = False,
+        dp_idle: bool = False,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
+        assert self._pending_target_dp_sync is None
+        assert not dp_idle or (dummy_run and self.dp_execution_contract_enabled), (
+            "dp_idle is reserved for execution-contract dummy calls"
+        )
         if not dummy_run:
             # Update the request states.
             self.update_pp_decode_requests()
@@ -1548,7 +1653,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.add_requests(scheduler_output)
             self.update_requests(scheduler_output)
             self.block_tables.apply_staged_writes()
-            if scheduler_output.total_num_scheduled_tokens == 0:
+            if (
+                scheduler_output.total_num_scheduled_tokens == 0
+                and not self.dp_execution_contract_enabled
+            ):
                 # No need to run the model.
                 empty_output = self.kv_connector.no_forward(scheduler_output)
                 return self._merge_ec_connector_no_forward(
@@ -1556,12 +1664,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 )
 
         # Get batch descriptor and sync across DP ranks.
-        num_reqs = len(scheduler_output.num_scheduled_tokens)
-        num_toks = scheduler_output.total_num_scheduled_tokens
-        max_query_len = max(scheduler_output.num_scheduled_tokens.values())
-        batch_req_state, uniform_tok_count = self.gather_batch_req_state(
-            scheduler_output, dummy_run
+        num_reqs = 0 if dp_idle else len(scheduler_output.num_scheduled_tokens)
+        num_toks = 0 if dp_idle else scheduler_output.total_num_scheduled_tokens
+        max_query_len = (
+            0
+            if dp_idle
+            else max(scheduler_output.num_scheduled_tokens.values(), default=0)
         )
+        if dp_idle or (num_toks == 0 and not dummy_run):
+            batch_req_state = None
+            uniform_tok_count = None
+        else:
+            batch_req_state, uniform_tok_count = self.gather_batch_req_state(
+                scheduler_output, dummy_run
+            )
         if batch_req_state is not None:
             num_toks = batch_req_state.num_tokens
             if self.pcp_manager is not None:
@@ -1584,30 +1700,57 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # cross-attention cache with dynamic encoder outputs.
             skip_compiled = True
 
-        batch_desc, dp_sync = dispatch_cg_and_sync_dp(
-            self.cudagraph_manager,
-            num_reqs,
-            num_toks,
-            uniform_tok_count,
-            self.dp_size,
-            self.dp_rank,
-            max_query_len=max_query_len,
-            need_eager=is_profile or skip_compiled,
-            num_active_loras=num_active_loras,
-        )
+        input_batch = None
+        target_dp_future = None
+        if self._target_dp_sync is not None:
+            target_dp_future = self._target_dp_sync.start(
+                self.cudagraph_manager,
+                num_reqs,
+                num_toks,
+                uniform_tok_count,
+                max_query_len=max_query_len,
+                need_eager=is_profile or skip_compiled,
+                num_active_loras=num_active_loras,
+            )
+            self._pending_target_dp_sync = target_dp_future
+            if batch_req_state is not None and not dummy_run:
+                input_batch = self.prepare_inputs(
+                    scheduler_output, batch_req_state, target_dp_future
+                )
+            batch_desc, dp_sync = target_dp_future.result(self.cudagraph_manager)
+        else:
+            batch_desc, dp_sync = dispatch_cg_and_sync_dp(
+                self.cudagraph_manager,
+                num_reqs,
+                num_toks,
+                uniform_tok_count,
+                self.dp_size,
+                self.dp_rank,
+                max_query_len=max_query_len,
+                need_eager=is_profile or skip_compiled,
+                num_active_loras=num_active_loras,
+            )
 
         if batch_desc.num_tokens == 0:
             # All DP ranks have zero tokens to run.
+            self._release_pending_target_dp_sync()
             empty_output = self.kv_connector.no_forward(scheduler_output)
             return self._merge_ec_connector_no_forward(scheduler_output, empty_output)
 
-        if not dummy_run:
+        execution_padding_only = bool(
+            self.dp_execution_contract_enabled
+            and (dp_idle or (not dummy_run and num_toks == 0))
+        )
+        effective_dummy_run = dummy_run or execution_padding_only
+
+        if not effective_dummy_run:
             # Common case.
             # Prepare all the inputs and copy to the input buffers.
             assert batch_req_state is not None
-            input_batch = self.prepare_inputs(
-                scheduler_output, batch_req_state, batch_desc
-            )
+            if input_batch is None:
+                input_batch = self.prepare_inputs(
+                    scheduler_output, batch_req_state, batch_desc
+                )
             block_tables, slot_mappings = self.prepare_attn(input_batch)
             # Mamba "align" pre-copy: migrate recurrent state across block
             # boundaries before the forward. Runs only on real batches, and
@@ -1630,13 +1773,23 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self._set_active_loras(*lora_inputs)
         else:
             # No actual tokens to run. A dummy run for DP or memory profiling.
-            dummy_num_reqs = batch_desc.num_reqs or num_reqs
+            dummy_num_reqs = (
+                dp_sync.execution_num_reqs
+                if execution_padding_only and dp_sync is not None
+                else batch_desc.num_reqs or num_reqs
+            )
+            assert dummy_num_reqs is not None
             input_batch = InputBatch.make_dummy(
                 dummy_num_reqs,
                 batch_desc.num_tokens,
                 self.input_buffers,
                 max_query_len=batch_desc.max_query_len,
             )
+            if execution_padding_only:
+                # One executable row keeps one-sided MoE participation aligned
+                # without routing the entire synthetic graph bucket.
+                input_batch.is_padding.fill_(True)
+                input_batch.is_padding[0] = False
             if not skip_attn_for_dummy_run:
                 block_tables, slot_mappings = self.prepare_dummy_attn(
                     input_batch, valid_dummy_state_slots
@@ -1659,14 +1812,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         attn_metadata = None
         slot_mappings_by_layer = None
-        if not (dummy_run and skip_attn_for_dummy_run):
+        if not (effective_dummy_run and skip_attn_for_dummy_run):
             assert slot_mappings is not None
             slot_mappings_by_layer = build_slot_mappings_by_layer(
                 slot_mappings, self.kv_cache_config
             )
             assert block_tables is not None
             attn_groups = self.attn_groups
-            if dummy_run and is_profile:
+            if effective_dummy_run and is_profile:
                 # Mamba layers take a cheap warmup path with no metadata;
                 # attention metadata is still built so those kernels tune.
                 attn_groups = [
@@ -1683,7 +1836,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 # FULL replay reads capture-time metadata buffers. Re-stage them
                 # from the zeroed dummy block tables instead of retaining state
                 # indices from the previous real batch.
-                for_capture=dummy_run and batch_desc.cg_mode == CUDAGraphMode.FULL,
+                for_capture=(
+                    effective_dummy_run and batch_desc.cg_mode == CUDAGraphMode.FULL
+                ),
             )
 
         input_ids = input_batch.input_ids
@@ -1692,7 +1847,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.uses_inputs_embeds and self.is_first_pp_rank:
             # Prepare inputs_embeds (MM encoder outputs and/or prompt_embeds
             # overlay). Only first PP rank prepares them.
-            if dummy_run:
+            if effective_dummy_run:
                 # Obtain embeddings of correct shape for compiled model.
                 inputs_embeds = self.model_state.dummy_inputs_embeds(
                     input_batch.num_tokens_after_padding
@@ -1737,7 +1892,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             n = input_batch.num_tokens_after_padding
             new_tensors = {
                 k: v[:n]
-                if dummy_run
+                if effective_dummy_run
                 else v[:n].copy_(intermediate_tensors.tensors[k][:n])
                 for k, v in self.intermediate_tensors.tensors.items()
             }
@@ -1758,7 +1913,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # NOTE(woosuk): Here, we don't need to pass the input tensors,
             # because they are already copied to the CUDA graph input buffers.
             assert self.cudagraph_manager is not None
-            self.kv_connector.pre_forward(scheduler_output)
+            if not execution_padding_only:
+                self.kv_connector.pre_forward(scheduler_output)
             model_output = self.cudagraph_manager.run_fullgraph(batch_desc)
         else:
             # For piecewise and eager mode, just call model().
@@ -1781,7 +1937,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 skip_compiled=skip_compiled,
                 is_padding=input_batch.is_padding,
             ):
-                self.kv_connector.pre_forward(scheduler_output)
+                if not execution_padding_only:
+                    self.kv_connector.pre_forward(scheduler_output)
                 if batch_desc.cg_mode == CUDAGraphMode.PIECEWISE:
                     # Run the PIECEWISE graph (compiled PW cudagraph or breakable
                     # cudagraph, chosen inside run_pw_graph). cg_mode is only
@@ -1810,9 +1967,31 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             output_intermediate_tensors = model_output
 
         routed_experts = None
-        if not dummy_run and (capturer := self.routed_experts_capturer) is not None:
+        if (
+            not effective_dummy_run
+            and (capturer := self.routed_experts_capturer) is not None
+        ):
             assert slot_mappings is not None
             routed_experts = capturer.get_routed_experts(slot_mappings, num_toks)
+
+        if execution_padding_only:
+            self.step_timing.forward_end()
+            if self.speculator is not None:
+                self.step_timing.drafter_start()
+                self._execute_dummy_speculator_stage(
+                    input_batch=input_batch,
+                    attn_metadata=attn_metadata,
+                    slot_mappings_by_layer=slot_mappings_by_layer,
+                    hidden_states=hidden_states,
+                    aux_hidden_states=aux_hidden_states,
+                    dp_sync=dp_sync,
+                    skip_attn=skip_attn_for_dummy_run,
+                    is_profile=is_profile,
+                )
+                self.step_timing.drafter_end()
+            self._release_pending_target_dp_sync()
+            empty_output = self.kv_connector.no_forward(scheduler_output)
+            return self._merge_ec_connector_no_forward(scheduler_output, empty_output)
 
         finished_req_ids = scheduler_output.finished_req_ids
         self.execute_model_state = ExecuteModelState(
@@ -1825,7 +2004,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             finished_req_ids=finished_req_ids,
             ec_connector_output=ec_connector_output,
             routed_experts=routed_experts,
+            target_dp_future=target_dp_future,
         )
+        if target_dp_future is not None:
+            # sample_tokens(), pool(), or _dummy_run() now owns the buffer.
+            self._pending_target_dp_sync = None
 
         if not self.is_last_pp_rank:
             # Non-last PP rank: return IntermediateTensors for sending.
@@ -1833,6 +2016,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return None
 
     @torch.inference_mode()
+    @_release_target_dp_sync_after
     @step_eplb_after()
     def sample_tokens(
         self, grammar_output: GrammarOutput | None
@@ -1850,7 +2034,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         finished_req_ids = self.execute_model_state.finished_req_ids
         ec_connector_output = self.execute_model_state.ec_connector_output
         routed_experts = self.execute_model_state.routed_experts
+        target_dp_future = self.execute_model_state.target_dp_future
         self.execute_model_state = None
+        if target_dp_future is not None:
+            assert self._pending_target_dp_sync is None
+            self._pending_target_dp_sync = target_dp_future
 
         if not self.is_last_pp_rank:
             # Non-last PP rank: hidden_states is None because this rank produced
@@ -2050,6 +2238,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def shutdown(self) -> None:
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
+        state = getattr(self, "execute_model_state", None)
+        if state is not None and state.target_dp_future is not None:
+            state.target_dp_future.release()
+            self.execute_model_state = None
+        self._release_pending_target_dp_sync()
         torch.accelerator.synchronize()
         self.cudagraph_manager = None
         if hasattr(self, "kv_caches"):
@@ -2123,6 +2316,7 @@ class ExecuteModelState(NamedTuple):
     finished_req_ids: set[str]
     ec_connector_output: ECConnectorOutput | None
     routed_experts: RoutedExpertsTensors | None
+    target_dp_future: DPSyncFuture | None
 
 
 class BatchReqState(NamedTuple):

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -14,7 +14,11 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
-from vllm.v1.worker.gpu.dp_utils import DPSyncState, dispatch_cg_and_sync_dp
+from vllm.v1.worker.gpu.dp_utils import (
+    DPSyncCoordinator,
+    DPSyncState,
+    dispatch_cg_and_sync_dp,
+)
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
@@ -46,6 +50,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.use_fused_multi_step_decode = False
+        self._decode_dp_sync = (
+            DPSyncCoordinator(self.dp_size, self.dp_rank) if self.dp_size > 1 else None
+        )
 
     def load_model(self, target_model: nn.Module) -> None:
         super().load_model(target_model)
@@ -298,78 +305,99 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             else None
         )
 
-        self._prepare_eplb_forward(num_tokens)
-
-        self.on_prefill_begin(num_reqs)
-        if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
-            # Replay the full graph for draft prefill.
-            assert self.prefill_cudagraph_manager is not None
-            self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
-        else:
-            # The target model's attention metadata and slot mappings
-            # can directly be used for draft prefill, because of the
-            # identical batch shape and KV cache layout.
-            self._prefill(
+        decode_dp_future = None
+        if self.num_speculative_steps > 1 and self._decode_dp_sync is not None:
+            # The continuation shape depends only on num_reqs, so its CPU
+            # collective can overlap draft prefill and decode input preparation.
+            # It is resolved below before any continuation work is launched.
+            decode_dp_future = self._decode_dp_sync.start(
+                self.decode_cudagraph_manager,
                 num_reqs,
-                prefill_batch_desc.num_tokens,
-                attn_metadata,
-                slot_mappings,
-                num_tokens_across_dp=num_tokens_across_dp,
-                cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
-                mm_inputs=mm_inputs,
+                num_reqs,
+                uniform_token_count=1,
+                need_eager=is_profile,
             )
-        self.on_prefill_end(num_reqs)
+        try:
+            self._prepare_eplb_forward(num_tokens)
 
-        if self.num_speculative_steps == 1:
-            # Early exit.
-            return self.draft_tokens[:num_reqs, :1]
+            self.on_prefill_begin(num_reqs)
+            if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
+                # Replay the full graph for draft prefill.
+                assert self.prefill_cudagraph_manager is not None
+                self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
+            else:
+                # The target model's attention metadata and slot mappings
+                # can directly be used for draft prefill, because of the
+                # identical batch shape and KV cache layout.
+                self._prefill(
+                    num_reqs,
+                    prefill_batch_desc.num_tokens,
+                    attn_metadata,
+                    slot_mappings,
+                    num_tokens_across_dp=num_tokens_across_dp,
+                    cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
+                    mm_inputs=mm_inputs,
+                )
+            self.on_prefill_end(num_reqs)
 
-        # Prepare the inputs for the decode steps.
-        prepare_decode_inputs(
-            self.draft_tokens[:num_reqs, 0],
-            input_batch.seq_lens,
-            num_rejected,
-            self.input_buffers,
-            self.sample_src_positions,
-            self.max_model_len,
-            self.max_num_reqs,
-            advance_draft_positions=self.advance_draft_positions,
-        )
+            if self.num_speculative_steps == 1:
+                # Early exit.
+                return self.draft_tokens[:num_reqs, :1]
 
-        # Each request produces exactly 1 token per draft generation step,
-        # enabling FULL graph replay.
-        decode_batch_desc, decode_batch_sync = dispatch_cg_and_sync_dp(
-            self.decode_cudagraph_manager,
-            num_reqs,
-            num_reqs,
-            uniform_token_count=1,
-            dp_size=self.dp_size,
-            dp_rank=self.dp_rank,
-            need_eager=is_profile,
-        )
-        num_tokens_across_dp = (
-            decode_batch_sync.num_tokens_across_dp
-            if decode_batch_sync is not None
-            else None
-        )
+            # Prepare the inputs for the decode steps.
+            prepare_decode_inputs(
+                self.draft_tokens[:num_reqs, 0],
+                input_batch.seq_lens,
+                num_rejected,
+                self.input_buffers,
+                self.sample_src_positions,
+                self.max_model_len,
+                self.max_num_reqs,
+                advance_draft_positions=self.advance_draft_positions,
+            )
 
-        self.on_multi_step_decode_begin(num_reqs)
-        # Generate the remaining num_speculative_steps - 1 draft tokens.
-        decode_fn = (
-            self._fused_multi_step_decode
-            if self.use_fused_multi_step_decode
-            else self._multi_step_decode
-        )
-        decode_fn(
-            num_reqs,
-            dummy_run and skip_attn_for_dummy_run,
-            decode_batch_desc,
-            num_tokens_across_dp,
-            input_batch.seq_lens_cpu_upper_bound,
-        )
-        self.on_multi_step_decode_end(num_reqs)
+            # Each request produces exactly 1 token per draft generation step,
+            # enabling FULL graph replay.
+            if decode_dp_future is None:
+                decode_batch_desc, decode_batch_sync = dispatch_cg_and_sync_dp(
+                    self.decode_cudagraph_manager,
+                    num_reqs,
+                    num_reqs,
+                    uniform_token_count=1,
+                    dp_size=self.dp_size,
+                    dp_rank=self.dp_rank,
+                    need_eager=is_profile,
+                )
+            else:
+                decode_batch_desc, decode_batch_sync = decode_dp_future.result(
+                    self.decode_cudagraph_manager
+                )
+            num_tokens_across_dp = (
+                decode_batch_sync.num_tokens_across_dp
+                if decode_batch_sync is not None
+                else None
+            )
 
-        return self.draft_tokens[:num_reqs]
+            self.on_multi_step_decode_begin(num_reqs)
+            # Generate the remaining num_speculative_steps - 1 draft tokens.
+            decode_fn = (
+                self._fused_multi_step_decode
+                if self.use_fused_multi_step_decode
+                else self._multi_step_decode
+            )
+            decode_fn(
+                num_reqs,
+                dummy_run and skip_attn_for_dummy_run,
+                decode_batch_desc,
+                num_tokens_across_dp,
+                input_batch.seq_lens_cpu_upper_bound,
+            )
+            self.on_multi_step_decode_end(num_reqs)
+
+            return self.draft_tokens[:num_reqs]
+        finally:
+            if decode_dp_future is not None:
+                decode_dp_future.release()
 
     @torch.inference_mode()
     def _run_model(

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -51,7 +51,16 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.use_fused_multi_step_decode = False
         self._decode_dp_sync = (
-            DPSyncCoordinator(self.dp_size, self.dp_rank) if self.dp_size > 1 else None
+            DPSyncCoordinator(
+                self.dp_size,
+                self.dp_rank,
+                lane="speculator",
+                execution_contract=(
+                    vllm_config.parallel_config.enable_dp_execution_contract
+                ),
+            )
+            if self.dp_size > 1
+            else None
         )
 
     def load_model(self, target_model: nn.Module) -> None:
@@ -310,12 +319,24 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             # The continuation shape depends only on num_reqs, so its CPU
             # collective can overlap draft prefill and decode input preparation.
             # It is resolved below before any continuation work is launched.
+            live_num_reqs = num_reqs
+            if (
+                prefill_batch_sync is not None
+                and prefill_batch_sync.execution_num_reqs is not None
+                and prefill_batch_sync.live_num_reqs_across_dp
+            ):
+                live_num_reqs = prefill_batch_sync.live_num_reqs_across_dp[self.dp_rank]
             decode_dp_future = self._decode_dp_sync.start(
                 self.decode_cudagraph_manager,
-                num_reqs,
-                num_reqs,
+                live_num_reqs,
+                live_num_reqs,
                 uniform_token_count=1,
                 need_eager=is_profile,
+                parent_generation=(
+                    prefill_batch_sync.generation
+                    if prefill_batch_sync is not None
+                    else None
+                ),
             )
         try:
             self._prepare_eplb_forward(num_tokens)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1267,7 +1267,14 @@ class Worker(WorkerBase):
 
     def execute_dummy_batch(self) -> None:
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
-        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+        if getattr(self.model_runner, "dp_execution_contract_enabled", False):
+            self.model_runner._dummy_run(
+                num_tokens,
+                uniform_decode=True,
+                dp_idle=True,
+            )
+        else:
+            self.model_runner._dummy_run(num_tokens, uniform_decode=True)
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_runner.add_lora(lora_request)


### PR DESCRIPTION
## Purpose

This is a stacked follow-up to #54656.

Add an opt-in, rank-identical target execution contract for the validated
MiniMax-M3 Model Runner V2 DP+EP configuration. The contract:

- separates rank-local live occupancy from the token and request capacity
  executed by every DP rank;
- starts target shape agreement asynchronously and overlaps it with rank-local
  input preparation;
- uses distinct target and speculator Gloo process groups, with generation and
  parent-generation validation;
- makes scheduler-owned zero-token calls and EngineCore-owned dummy calls
  execute exactly one sentinel target row when a peer is active;
- supports vLLM async scheduling by recording the actual model-worker launch,
  rather than inferring collective ownership from live tokens or result
  retirement;
- reuses the global request capacity for draft-prefill graph selection and
  resolves draft continuation on the isolated speculator lane; and
- releases in-flight work on normal, idle, all-zero, failure, and shutdown
  paths.

The behavior is default-off behind `--enable-dp-execution-contract`. Initial
validation intentionally fails closed outside the current Model Runner V2,
MiniMax-M3, DP+EP, and one-sided FlashInfer subset.

This PR establishes the target contract and sentinel participation required by
the broader R14 pipeline. Early speculator-plan issue and cached/R15g scheduling
remain separate stacked follow-ups.

## Async-scheduling invariant

Async scheduling can enqueue a new worker batch while retiring an older result,
or retire a result without issuing a new worker call. The DP loop now records
the worker launch itself. For every target generation a rank therefore performs
exactly one of:

- the scheduler-issued real or zero-token execution; or
- an EngineCore-issued sentinel dummy execution when no worker call was
  launched locally.

This preserves collective generation order without adding another function
call to the model-launch hot path.

## Why this is not duplicating an existing PR

Open-PR searches for target DP execution contracts, idle EP sentinel
participation, and async DP shape planning found no other PR implementing this
protocol. Adjacent async-scheduling work uses the existing model execution path
but does not provide rank-identical target contracts or sentinel participation
for locally idle EP ranks.

## Test plan

- Focused DP coordinator tests, including generation mismatch, parent mismatch,
  eager fallback, all-idle resolution, request-capacity reuse, and future
  lifecycle.
- A real two-process CPU/Gloo test with target and speculator collectives issued
  in opposite orders on their separate groups.
- Model-runner behavior tests for overlap ordering, scheduler-zero and
  EngineCore-dummy sentinel paths, all-ranks-zero handling, and injected
  preparation/forward failures.
- Async EngineCore tests proving that a zero-token queued worker call owns its
  target generation, while retirement of an older queued result does not.
- Configuration coverage for both synchronous and async scheduling.
- GPU one-sided-MoE functional and performance canaries are required before
  moving this PR out of draft.

## Test result

```text
Focused worker and two-process CPU/Gloo tests: 40 passed
Configuration and EngineCore tests: 11 passed
Existing Model Runner V2 regression tests: 4 passed
Pre-commit hooks: passed
mypy-3.12 manual hook: passed
```

GPU functional and performance validation has not yet been run on this branch.

## AI assistance

OpenAI Codex was used to implement and test this change and to prepare this
description. The human submitter must review every changed line, be able to
defend the design, and rerun the relevant tests before moving the PR out of
draft.
