### PR TITLE
[Bugfix][Frontend] Honor skip_decoder_start_token in async encoder-decoder rendering

### DIFF
--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -881,6 +881,15 @@ class BaseRenderer(ABC, Generic[_T]):
 
         return await self._process_tokens_async(prompt, skip_mm_cache=skip_mm_cache)  # type: ignore[arg-type]
 
+    def _get_skip_decoder_start_token(self) -> bool:
+        """Whether the multimodal processor supplies a complete decoder prefix."""
+        if self.mm_processor is not None:
+            from vllm.multimodal.processing import EncDecMultiModalProcessor
+
+            if isinstance(self.mm_processor, EncDecMultiModalProcessor):
+                return self.mm_processor.skip_decoder_start_token
+        return False
+
     def _process_enc_dec(
         self,
         prompt: EncoderDecoderTokPrompt,
@@ -889,13 +898,6 @@ class BaseRenderer(ABC, Generic[_T]):
     ) -> EncoderDecoderInput:
         enc_prompt = prompt["encoder_prompt"]
         dec_prompt = prompt["decoder_prompt"]
-
-        skip_decoder_start_token = False
-        if self.mm_processor is not None:
-            from vllm.multimodal.processing import EncDecMultiModalProcessor
-
-            if isinstance(self.mm_processor, EncDecMultiModalProcessor):
-                skip_decoder_start_token = self.mm_processor.skip_decoder_start_token
 
         return build_enc_dec_input(
             encoder_input=self._process_singleton(
@@ -907,7 +909,7 @@ class BaseRenderer(ABC, Generic[_T]):
                 else self._process_singleton(dec_prompt, skip_mm_cache=skip_mm_cache)
             ),
             decoder_start_token_id=self.get_dec_start_token_id(),
-            skip_decoder_start_token=skip_decoder_start_token,
+            skip_decoder_start_token=self._get_skip_decoder_start_token(),
         )
 
     async def _process_enc_dec_async(
@@ -934,6 +936,7 @@ class BaseRenderer(ABC, Generic[_T]):
             encoder_input=encoder_input,
             decoder_input=decoder_input,
             decoder_start_token_id=self.get_dec_start_token_id(),
+            skip_decoder_start_token=self._get_skip_decoder_start_token(),
         )
 
     def process_for_engine(


### PR DESCRIPTION


## Purpose

Make asynchronous encoder-decoder rendering honor the multimodal processor's
`skip_decoder_start_token` policy, matching the existing synchronous path.

`EncDecMultiModalProcessor` uses this flag when a processor already supplies a
complete decoder prefix. The synchronous renderer passes the flag to
`build_enc_dec_input`, but `_process_enc_dec_async` omitted it and therefore
used the default value of `False`.

This bug is exercised by the normal online transcription path:

```text
/v1/audio/transcriptions
  -> speech-to-text preprocessing
  -> render_cmpl_async()
  -> _process_enc_dec_async()
  -> build_enc_dec_input()
```

Cohere ASR sets `skip_decoder_start_token = True`, so every Cohere ASR
transcription request enters the affected path. For long audio, preprocessing
splits the input into chunks and each chunk independently passes through the
same async renderer path.

With `CohereLabs/cohere-transcribe-03-2026`, the correct 10-token decoder prefix
is:

```text
[13764, 7, 4, 16, 62, 62, 5, 9, 11, 13]
```

Before this change, the async path incorrectly prepended BOS token `4`, making
the decoder prompt 11 tokens long:

```text
[4, 13764, 7, 4, 16, 62, 62, 5, 9, 11, 13]
```

This is a deterministic decoder-input error. The extra token changes decoder
positions, self-attention state, and the model probability distribution, and it
adds one decoder prefill token per request or audio chunk. It does not imply
that the final greedy transcript will visibly change for every audio sample.

This PR extracts the existing policy lookup into a shared helper and uses it in
both synchronous and asynchronous encoder-decoder rendering. Behavior remains
unchanged for Whisper and other processors that keep the default value of
`False`, as well as renderers without an encoder-decoder multimodal processor.

## Test Plan

Focused renderer tests:

```bash
python -m pytest \
  tests/renderers/inputs/test_preprocess.py \
  tests/renderers/test_completions.py -q
```

Lint and static checks:

```bash
python -m pre_commit run \
  --files vllm/renderers/base.py
```

The real Cohere ASR renderer was also exercised with the model processor,
tokenizer, and demo WAV from `CohereLabs/cohere-transcribe-03-2026`. A V1
`AsyncLLM` A/B run compared the fixed 10-token decoder prompt with the previous
behavior simulated by prepending BOS.

## Test Result

Focused renderer tests:

```text
37 passed, 14 warnings in 7.81s
```

All applicable pre-commit hooks passed.

The real Cohere ASR renderer produced the expected result:

| Path | Decoder prompt length | Decoder prompt prefix |
| --- | ---: | --- |
| Fixed async path | 10 | `[13764, 7, 4, 16, 62, 62, 5, 9, 11, 13]` |
| Previous async behavior | 11 | `[4, 13764, 7, 4, 16, 62, 62, 5, 9, 11, 13]` |

On an NVIDIA A100 40 GB using BF16 and greedy decoding, five audio variants
(full, first half, second half, reduced amplitude, and silence) completed in
both A/B cases. The first-token
log probability for the full sample changed:

| Decoder input | First generated token | Log probability |
| --- | --- | ---: |
| Fixed 10-token prefix | `If` (1617) | -0.0413764976 |
| Previous behavior with BOS | `If` (1617) | -0.0406677909 |

This confirms that the bug deterministically changes the online decoder input.

## AI-assisted contribution

This contribution was developed with AI assistance.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] Documentation update considered; none is needed for this internal correctness fix.
</details>

