### PR TITLE
[Bugfix][XPU] Disable the static Triton launcher for UVA

### DIFF
--- a/tests/test_xpu_platform.py
+++ b/tests/test_xpu_platform.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+# XPUPlatform imports these extensions at module import time. Skip this
+# platform-specific test when the XPU runtime is not installed so generic CPU,
+# CUDA, and ROCm test collection remains unaffected.
+pytest.importorskip("vllm_xpu_kernels._C")
+pytest.importorskip("vllm_xpu_kernels._moe_C")
+pytest.importorskip("vllm_xpu_kernels._xpu_C")
+
+from vllm.config.compilation import CompilationMode
+from vllm.platforms.xpu import XPUPlatform
+
+
+def test_uva_offload_disables_static_triton_launcher(monkeypatch):
+    """The XPU UVA workaround uses the key consumed by PyTorch's bundler."""
+    pass_config = SimpleNamespace(
+        fuse_gemm_comms=False,
+        fuse_allreduce_rms=False,
+        fuse_attn_quant=False,
+        fuse_act_padding=False,
+        fuse_rope_kvcache=False,
+        fuse_rope_kvcache_cat_mla=False,
+    )
+    config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            compile_sizes=[],
+            cudagraph_mode=object(),
+            pass_config=pass_config,
+            mode=CompilationMode.DYNAMO_TRACE_ONCE,
+            inductor_compile_config={},
+        ),
+        offload_config=SimpleNamespace(
+            offload_backend="uva",
+            prefetch=SimpleNamespace(offload_group_size=0),
+            uva=SimpleNamespace(cpu_offload_gb=1),
+        ),
+        parallel_config=SimpleNamespace(worker_cls="auto"),
+        kv_transfer_config=None,
+        shutdown_timeout=1,
+    )
+
+    monkeypatch.setattr("vllm.envs.VLLM_XPU_ENABLE_XPU_GRAPH", False)
+    monkeypatch.setattr("vllm.envs.VLLM_WEIGHT_OFFLOADING_DISABLE_UVA", False)
+    monkeypatch.setattr("vllm.utils.torch_utils.supports_xpu_graph", lambda: False)
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+    XPUPlatform.check_and_update_config(config)
+
+    assert config.compilation_config.inductor_compile_config == {
+        "use_static_cuda_launcher": False,
+        "use_static_triton_launcher": False,
+    }

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -349,6 +349,11 @@ class XPUPlatform(Platform):
             compilation_config.inductor_compile_config.setdefault(
                 "use_static_cuda_launcher", False
             )
+            # PyTorch's Triton bundler reads this key. Keep the CUDA-era key
+            # above for compatibility with versions that still recognize it.
+            compilation_config.inductor_compile_config.setdefault(
+                "use_static_triton_launcher", False
+            )
             logger.info_once(
                 "Disabling Inductor's static Triton launcher because UVA "
                 "weight offloading is enabled."


### PR DESCRIPTION
## Summary

Fixes #54596.

When XPU UVA weight offloading is enabled, vLLM disables Inductor's static
Triton launcher. The existing workaround only set
`use_static_cuda_launcher`, but current PyTorch reads
`use_static_triton_launcher` in its Triton bundler. The old key is retained for
compatibility with versions that still recognize it, and the key consumed by
current PyTorch is now set as well.

Added a lightweight platform regression test that exercises the UVA branch
without requiring an XPU device.

No open or historical PR references #54596 or this `use_static_triton_launcher`
fix (checked immediately before submission). The issue's environment comment
corrects the original repro branch, but the source-level behavior is present on
current `main`.

## Validation

- `pre-commit run --files vllm/platforms/xpu.py tests/test_xpu_platform.py`
- Ruff check and formatting checks for the changed files
- Python bytecode compilation for the changed files
- `git diff --check`
- Added CPU-side regression coverage for both launcher keys.

The targeted pytest process could not complete in this Apple Silicon
environment because vLLM's test bootstrap waits while importing unavailable
optional runtime components. XPU/PyTorch 2.13 runtime validation should run in
the project's XPU CI.

AI assistance was used for repository scouting and implementation. The human
submitter reviewed the complete diff and validation before opening this PR.
