### PR TITLE
[Bugfix][Metrics] Skip unsupported metric types instead of raising

### DIFF
--- a/tests/v1/metrics/test_metrics_reader.py
+++ b/tests/v1/metrics/test_metrics_reader.py
@@ -125,3 +125,45 @@ def test_vector_metric(test_registry, num_engines):
         assert m.labels["model"] == "llama"
         assert m.labels["engine_index"] in engine_labels
         engine_labels.remove(m.labels["engine_index"])
+
+
+def test_unsupported_metric_type_is_skipped(test_registry):
+    """A metric type the reader cannot represent must not break the snapshot.
+
+    prometheus_client ships summary, info and stateset collectors beyond the
+    three types this reader digests, and any custom collector may return one.
+    Both public callers of get_metrics_snapshot() - LLM.get_metrics() and the
+    ORCA endpoint-load-metrics header - would previously raise on such a
+    metric, over a type neither of them reads.
+    """
+    prometheus_client.Summary(
+        "vllm:test_summary",
+        "Test summary metric",
+        registry=test_registry,
+    ).observe(1.0)
+    g = prometheus_client.Gauge(
+        "vllm:test_gauge",
+        "Test gauge metric",
+        labelnames=["model"],
+        registry=test_registry,
+    )
+    g.labels(model="foo").set(98.5)
+
+    metrics = get_metrics_snapshot()
+
+    # The gauge survives; the summary is dropped rather than taking the call
+    # down with it.
+    assert [m.name for m in metrics] == ["vllm:test_gauge"]
+    assert isinstance(metrics[0], Gauge)
+    assert metrics[0].value == 98.5
+
+
+def test_unsupported_metric_type_alone_yields_empty_snapshot(test_registry):
+    """The degenerate case: nothing representable, and still no exception."""
+    prometheus_client.Info(
+        "vllm:test_info",
+        "Test info metric",
+        registry=test_registry,
+    ).info({"version": "test"})
+
+    assert get_metrics_snapshot() == []

--- a/vllm/v1/metrics/reader.py
+++ b/vllm/v1/metrics/reader.py
@@ -7,6 +7,10 @@ from prometheus_client import REGISTRY
 from prometheus_client import Metric as PromMetric
 from prometheus_client.samples import Sample
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 
 @dataclass
 class Metric:
@@ -138,7 +142,16 @@ def get_metrics_snapshot() -> list[Metric]:
                     )
                 )
         else:
-            raise AssertionError(f"Unknown metric type {metric.type}")
+            # prometheus_client also ships summary, info, stateset and untyped
+            # collectors, and any custom collector may return them. Raising here
+            # takes down two public paths - LLM.get_metrics() and the ORCA
+            # endpoint-load-metrics header - over a metric neither of them was
+            # going to read. Skip what this reader cannot represent, keep the rest.
+            logger.debug(
+                "Skipping metric %s: unsupported metric type %s",
+                metric.name,
+                metric.type,
+            )
 
     return collected
 

--- a/vllm/v1/metrics/reader.py
+++ b/vllm/v1/metrics/reader.py
@@ -74,6 +74,11 @@ class Histogram(Metric):
 def get_metrics_snapshot() -> list[Metric]:
     """An API for accessing in-memory Prometheus metrics.
 
+    Returns only the collector types this reader can represent - gauge,
+    counter and histogram. Other prometheus_client collector types
+    (summary, info, stateset, untyped) are skipped, so a metric registered
+    under the vllm: prefix with one of those types will not appear here.
+
     Example:
         >>> for metric in llm.get_metrics():
         ...     if isinstance(metric, Counter):


### PR DESCRIPTION
## Purpose

Fixes #46919.

`get_metrics_snapshot()` dispatches on `metric.type` over `gauge`, `counter` and `histogram`, and the trailing branch raises:

```python
else:
    raise AssertionError(f"Unknown metric type {metric.type}")
```

`prometheus_client` also ships `Summary`, `Info` and `StateSet` collectors, and any custom collector registered under the `vllm:` prefix may return one of those or `untyped`. Verified against the installed client: `Summary` yields `metric.type == "summary"` and `Info` yields `"info"` — neither is handled.

Two public paths take that exception, over a metric type neither of them reads:

- **`LLM.get_metrics()`** (`vllm/v1/engine/llm_engine.py:383`) — the offline library API. Every offline caller reading in-memory metrics fails.
- **`metrics_header()`** (`vllm/entrypoints/serve/utils/orca_metrics.py:90`) — a `/v1/chat/completions` request that opts into the `endpoint-load-metrics` ORCA header returns HTTP 500. That path maps exactly two gauges (`vllm:kv_cache_usage_perc`, `vllm:num_requests_waiting`) and ignores everything else, so it fails over a metric it was never going to read.

Neither caller wraps the call, so there is nothing upstream that degrades this.

The reader now logs at debug and skips what it cannot represent, keeping the metrics it can. This is the fix the issue suggests.

## Test Plan

Two tests added to `tests/v1/metrics/test_metrics_reader.py`, alongside the four that already cover the supported types. They use the existing `test_registry` fixture, so no server and no model:

```bash
pytest tests/v1/metrics/test_metrics_reader.py
```

1. `test_unsupported_metric_type_is_skipped` — a `Summary` and a `Gauge` in the same registry; asserts the gauge still comes through and the summary is dropped rather than taking the call down.
2. `test_unsupported_metric_type_alone_yields_empty_snapshot` — an `Info` alone; asserts an empty snapshot rather than an exception.

## Test Result

The dispatch behaviour was verified directly against `prometheus_client`: a `Summary` collector under the `vllm:` prefix yields `metric.type == "summary"` and an `Info` yields `"info"`, so both reach the branch that raised. With this change the same registry returns the gauge and drops the summary. The four existing tests are unaffected — the change only touches the branch that previously raised.

I do not have a GPU environment to hand for the full suite; this file is CPU-only and the change is confined to one `else` branch, but happy to run anything else you would like to see.