### PR TITLE
[Bugfix][Frontend] Fix assistant_tokens_mask generation-tag detection and fallback

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -910,3 +910,101 @@ class TestConsolidateSystemMessages:
         assert len(conversation) == original_len
         assert conversation[0]["role"] == "user"
         assert conversation[1]["role"] == "system"
+
+
+GENERATION_TAG_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'assistant' %}"
+    "{% generation %}{{ message['content'] }}{% endgeneration %}"
+    "{% else %}{{ message['content'] }}{% endif %}"
+    "{% endfor %}"
+)
+
+WHITESPACE_CONTROL_GENERATION_TAG_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'assistant' %}"
+    "{%- generation -%}{{ message['content'] }}{%- endgeneration -%}"
+    "{% else %}{{ message['content'] }}{% endif %}"
+    "{% endfor %}"
+)
+
+NO_GENERATION_TAG_TEMPLATE = (
+    "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+    "{% if add_generation_prompt %}gen{% endif %}"
+)
+
+
+class _StubTokenizer:
+    def get_chat_template(self, chat_template=None, tools=None):
+        return chat_template
+
+
+class _MaskCapableTokenizer(_StubTokenizer):
+    """Minimal HF-like tokenizer that supports assistant token masks."""
+
+    def apply_chat_template(self, conversation, **kwargs):
+        if kwargs.get("return_assistant_tokens_mask"):
+            return {"input_ids": [1, 2, 3], "assistant_masks": [0, 1, 1]}
+        return [1, 2, 3]
+
+
+class _MaskRejectingTokenizer(_StubTokenizer):
+    """Rejects assistant-mask requests like a slow tokenizer does."""
+
+    def apply_chat_template(self, conversation, **kwargs):
+        if kwargs.get("return_assistant_tokens_mask"):
+            raise ValueError("assistant masks require a fast tokenizer")
+        if kwargs.get("return_dict"):
+            return {"input_ids": [1, 2, 3]}
+        return [1, 2, 3]
+
+
+class TestSafeApplyChatTemplateAssistantTokensMask:
+    """Contract: with return_assistant_tokens_mask=True, templates using the
+    Jinja generation tag (in any spelling) yield (token_ids, mask), and a
+    tokenizer that cannot produce masks degrades to (token_ids, None) instead
+    of failing the request."""
+
+    @pytest.fixture
+    def model_config(self):
+        from unittest.mock import MagicMock
+
+        return MagicMock()
+
+    def _apply(self, model_config, tokenizer, template):
+        return safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ],
+            chat_template=template,
+            return_assistant_tokens_mask=True,
+        )
+
+    def test_mask_returned_for_generation_tag(self, model_config):
+        result = self._apply(
+            model_config, _MaskCapableTokenizer(), GENERATION_TAG_TEMPLATE
+        )
+        assert result == ([1, 2, 3], [0, 1, 1])
+
+    def test_mask_returned_for_whitespace_control_tag(self, model_config):
+        result = self._apply(
+            model_config,
+            _MaskCapableTokenizer(),
+            WHITESPACE_CONTROL_GENERATION_TAG_TEMPLATE,
+        )
+        assert result == ([1, 2, 3], [0, 1, 1])
+
+    def test_add_generation_prompt_does_not_trigger_mask_path(self, model_config):
+        result = self._apply(
+            model_config, _MaskCapableTokenizer(), NO_GENERATION_TAG_TEMPLATE
+        )
+        assert result == ([1, 2, 3], None)
+
+    def test_fallback_when_tokenizer_rejects_mask(self, model_config):
+        result = self._apply(
+            model_config, _MaskRejectingTokenizer(), GENERATION_TAG_TEMPLATE
+        )
+        assert result == ([1, 2, 3], None)

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -17,6 +17,7 @@ import jinja2.meta
 import jinja2.nodes
 import jinja2.parser
 import jinja2.sandbox
+import regex as re
 import torch
 from typing_extensions import override
 
@@ -606,6 +607,12 @@ class AssistantTracker(jinja2.ext.Extension):
         return call_block.set_lineno(lineno)
 
 
+# Matches the Jinja `generation` tag in any of its whitespace-control
+# spellings ({% generation %}, {%- generation -%}, ...), mirroring the
+# detection regex used by `transformers`.
+_GENERATION_TAG_RE = re.compile(r"\{\%-?\s*generation\s*-?\%\}")
+
+
 def _resolve_chat_template_kwargs(chat_template: str) -> Set[str]:
     env = jinja2.sandbox.ImmutableSandboxedEnvironment(
         trim_blocks=True,
@@ -753,17 +760,22 @@ def safe_apply_chat_template(
     # request assistant_tokens_mask via return_dict.
     # Check for the actual Jinja tag, not just the word "generation"
     # (which also appears in add_generation_prompt).
-    if return_assistant_tokens_mask and "{% generation %}" in chat_template:
-        resolved_kwargs["return_assistant_tokens_mask"] = True
-        resolved_kwargs["return_dict"] = True
-        resolved_kwargs.pop("tokenize", None)
+    # Keep the mask-specific kwargs out of `resolved_kwargs` so a failed
+    # attempt cannot leak them into the plain fallback call below.
+    if return_assistant_tokens_mask and _GENERATION_TAG_RE.search(chat_template):
+        mask_kwargs = {
+            **resolved_kwargs,
+            "return_assistant_tokens_mask": True,
+            "return_dict": True,
+        }
+        mask_kwargs.pop("tokenize", None)
         try:
             result = tokenizer.apply_chat_template(
                 conversation=conversation,  # type: ignore[arg-type]
                 tools=tools,  # type: ignore[arg-type]
                 chat_template=chat_template,
                 tokenize=True,
-                **resolved_kwargs,
+                **mask_kwargs,
             )
         except (TypeError, ValueError) as exc:
             logger.warning(


### PR DESCRIPTION
## Purpose

Fix two related defects in `safe_apply_chat_template` that break the `return_assistant_tokens_mask` feature (`vllm/renderers/hf.py`):

1. **Generation-tag detection missed valid spellings.** The gate used an exact substring match on `{% generation %}`, so templates written with Jinja whitespace-control markers (`{%- generation -%}`, `{% generation -%}`, ...) — which the `AssistantTracker` extension and `transformers` fully support — silently returned `assistant_tokens_mask: null`. Detection now uses the same regex as `transformers` (`\{\%-?\s*generation\s*-?\%\}`), still without matching the unrelated `add_generation_prompt` variable.

2. **A failed mask attempt poisoned the fallback call.** The mask attempt mutated `resolved_kwargs` in place (`return_assistant_tokens_mask=True`, `return_dict=True`). When the call raised `TypeError`/`ValueError` (e.g. a slow tokenizer, since assistant masks require a fast tokenizer), the intended graceful fallback re-sent the exact kwargs that had just failed: either the same error recurred and was converted into a hard request failure, or the call returned a `BatchEncoding` and tripped `assert isinstance(plain, list)`. The mask-specific kwargs are now built in a local copy, so the fallback degrades to `(token_ids, None)` as intended.

**Not a duplicate:** searched open and closed PRs and issues for `assistant_tokens_mask` and generation-tag detection; nothing addresses these defects. The only nearby work is the merged #54539 (mask truncation), which is orthogonal.

No model-output changes: this only affects prompt preprocessing metadata (`assistant_tokens_mask`) returned by the render endpoints, so no model evals are applicable.

## Test Plan

New regression tests (stub tokenizers, no network) in `tests/renderers/test_hf.py::TestSafeApplyChatTemplateAssistantTokensMask`:

```bash
pytest tests/renderers/test_hf.py -q
pytest tests/entrypoints/scale_out/render/test_render.py -q
pre-commit run --files vllm/renderers/hf.py tests/renderers/test_hf.py
pre-commit run mypy-3.12 --files vllm/renderers/hf.py --hook-stage manual
```

## Test Result

- `tests/renderers/test_hf.py`: **66 passed** (incl. 4 new), 1 pre-existing failure (`test_resolve_content_format_fallbacks[facebook/chameleon-7b-string]`) that fails identically on clean `main`, unrelated to this change.
- Both regression tests were verified to **fail against the unfixed code** (whitespace-control template → mask `null`; mask-rejecting tokenizer → request fails with `ValueError` from the poisoned fallback) and pass with the fix.
- `tests/entrypoints/scale_out/render/test_render.py` (end-to-end `/render` server): **18 passed**.
- All pre-commit hooks passed, including CI-style `mypy-3.12` (manual stage).

## AI-assisted contribution

This change was developed with AI assistance (Claude Code). Every changed line was reviewed by the submitter, who ran the tests above.
