### PR TITLE
[Bugfix] Fix RoPE construction for deepseek-v4 sparse SWA layers

### DIFF
--- a/vllm/models/deepseek_v4/common/rope.py
+++ b/vllm/models/deepseek_v4/common/rope.py
@@ -28,20 +28,15 @@ def build_deepseek_v4_rope(
     rope_parameters["rope_theta"] = (
         config.compress_rope_theta if compress_ratio > 1 else config.rope_theta
     )
-    if compress_ratio > 1:
+    if compress_ratio > 1 and rope_parameters["rope_type"] != "default":
         # YaRN applies only to compressor (CSA/HCA) layers.
-        if rope_parameters["rope_type"] != "default":
-            rope_parameters["rope_type"] = (
-                "deepseek_yarn"
-                if rope_parameters.get("apply_yarn_scaling", True)
-                else "deepseek_llama_scaling"
-            )
+        rope_parameters["rope_type"] = (
+            "deepseek_yarn"
+            if rope_parameters.get("apply_yarn_scaling", True)
+            else "deepseek_llama_scaling"
+        )
     else:
         # Sliding-window layers use plain RoPE (theta=rope_theta, no YaRN).
-        # factor=1.0 makes the deepseek yarn inv_freq an exact identity while
-        # keeping the fp32 cos_sin_cache layout the fused kernels require.
-        # original_max_position_embeddings is overridden so the cache covers
-        # max_position_embeddings positions (cache len = original * factor).
         rope_parameters["rope_type"] = "deepseek_yarn"
         rope_parameters["factor"] = 1.0
         rope_parameters["original_max_position_embeddings"] = max_position_embeddings

--- a/vllm/models/deepseek_v4/common/rope.py
+++ b/vllm/models/deepseek_v4/common/rope.py
@@ -15,15 +15,36 @@ def build_deepseek_v4_rope(
     compress_ratio: int,
 ) -> RotaryEmbedding:
     rope_parameters = config.rope_parameters
+    # Newer checkpoints nest per-layer-type rope dicts ({"main", "compress"});
+    # older ones ship a single flat dict shared by all layer types.
+    if isinstance(rope_parameters.get("main"), dict) and isinstance(
+        rope_parameters.get("compress"), dict
+    ):
+        key = "compress" if compress_ratio > 1 else "main"
+        rope_parameters = dict(rope_parameters[key])
+    else:
+        rope_parameters = dict(rope_parameters)
+
     rope_parameters["rope_theta"] = (
         config.compress_rope_theta if compress_ratio > 1 else config.rope_theta
     )
-    if rope_parameters["rope_type"] != "default":
-        rope_parameters["rope_type"] = (
-            "deepseek_yarn"
-            if rope_parameters.get("apply_yarn_scaling", True)
-            else "deepseek_llama_scaling"
-        )
+    if compress_ratio > 1:
+        # YaRN applies only to compressor (CSA/HCA) layers.
+        if rope_parameters["rope_type"] != "default":
+            rope_parameters["rope_type"] = (
+                "deepseek_yarn"
+                if rope_parameters.get("apply_yarn_scaling", True)
+                else "deepseek_llama_scaling"
+            )
+    else:
+        # Sliding-window layers use plain RoPE (theta=rope_theta, no YaRN).
+        # factor=1.0 makes the deepseek yarn inv_freq an exact identity while
+        # keeping the fp32 cos_sin_cache layout the fused kernels require.
+        # original_max_position_embeddings is overridden so the cache covers
+        # max_position_embeddings positions (cache len = original * factor).
+        rope_parameters["rope_type"] = "deepseek_yarn"
+        rope_parameters["factor"] = 1.0
+        rope_parameters["original_max_position_embeddings"] = max_position_embeddings
     rope_parameters["mscale"] = 0  # Disable mscale
     rope_parameters["mscale_all_dim"] = 0  # Disable mscale
     rope_parameters["is_deepseek_v4"] = True


### PR DESCRIPTION



## Purpose
- Refer to https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/inference/model.py#L481-L485 and https://github.com/huggingface/transformers/pull/45892, deepseek-v4 should use plain RoPE without YaRN for sparse SWA layer

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

