### PR TITLE
[RFC][Core] Prototype runtime scheduler sequence cap

### DIFF
--- a/tests/entrypoints/serve/dev/test_runtime_config.py
+++ b/tests/entrypoints/serve/dev/test_runtime_config.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.serve.dev.runtime_config.api_router import attach_router
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make_client() -> tuple[TestClient, AsyncMock]:
+    engine = AsyncMock()
+    engine.get_runtime_config.return_value = {
+        "max_num_running_seqs": 128,
+        "max_num_seqs_capacity": 256,
+    }
+    engine.update_runtime_config.return_value = {
+        "max_num_running_seqs": 64,
+        "max_num_seqs_capacity": 256,
+    }
+    app = FastAPI()
+    app.state.engine_client = engine
+    attach_router(app)
+    return TestClient(app), engine
+
+
+def test_get_runtime_config():
+    client, engine = _make_client()
+
+    response = client.get("/v1/runtime_config")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "max_num_running_seqs": 128,
+        "max_num_seqs_capacity": 256,
+    }
+    engine.get_runtime_config.assert_awaited_once_with()
+
+
+def test_update_runtime_config():
+    client, engine = _make_client()
+
+    response = client.patch("/v1/runtime_config", json={"max_num_running_seqs": 64})
+
+    assert response.status_code == 200
+    assert response.json()["max_num_running_seqs"] == 64
+    engine.get_runtime_config.assert_awaited_once_with()
+    engine.update_runtime_config.assert_awaited_once_with(64)
+
+
+def test_update_runtime_config_reports_capacity_error():
+    client, engine = _make_client()
+
+    response = client.patch("/v1/runtime_config", json={"max_num_running_seqs": 512})
+
+    assert response.status_code == 400
+    assert "startup capacity" in response.json()["detail"]
+    engine.update_runtime_config.assert_not_awaited()
+
+
+def test_update_runtime_config_rejects_unknown_fields():
+    client, _ = _make_client()
+
+    response = client.patch(
+        "/v1/runtime_config",
+        json={"max_num_running_seqs": 64, "gpu_memory_utilization": 0.5},
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_runtime_config_rejects_boolean():
+    client, _ = _make_client()
+
+    response = client.patch("/v1/runtime_config", json={"max_num_running_seqs": True})
+
+    assert response.status_code == 422
+
+
+def test_update_runtime_config_reports_unsupported_scheduler():
+    client, engine = _make_client()
+    engine.get_runtime_config.return_value = {}
+
+    response = client.patch("/v1/runtime_config", json={"max_num_running_seqs": 64})
+
+    assert response.status_code == 501
+    engine.update_runtime_config.assert_not_awaited()

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -122,6 +122,62 @@ def test_add_requests():
         assert len(scheduler.waiting) == i + 1
 
 
+def test_runtime_max_num_running_seqs_drains_down():
+    scheduler = create_scheduler(max_num_seqs=4)
+    for request in create_requests(num_requests=5):
+        scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+    assert len(first_output.scheduled_new_reqs) == 4
+    assert len(scheduler.running) == 4
+    assert len(scheduler.waiting) == 1
+
+    runtime_config = scheduler.update_runtime_config(max_num_running_seqs=2)
+    assert runtime_config == {
+        "max_num_running_seqs": 2,
+        "max_num_seqs_capacity": 4,
+    }
+
+    second_output = scheduler.schedule()
+    assert not second_output.scheduled_new_reqs
+    assert len(scheduler.running) == 4
+    assert len(scheduler.waiting) == 1
+
+    scheduler.finish_requests(
+        [request.request_id for request in scheduler.running[:3]],
+        RequestStatus.FINISHED_ABORTED,
+    )
+    third_output = scheduler.schedule()
+    assert len(third_output.scheduled_new_reqs) == 1
+    assert len(scheduler.running) == 2
+    assert not scheduler.waiting
+
+
+def test_runtime_max_num_running_seqs_can_increase_to_capacity():
+    scheduler = create_scheduler(max_num_seqs=4)
+    scheduler.update_runtime_config(max_num_running_seqs=2)
+    for request in create_requests(num_requests=4):
+        scheduler.add_request(request)
+
+    first_output = scheduler.schedule()
+    assert len(first_output.scheduled_new_reqs) == 2
+    assert len(scheduler.waiting) == 2
+
+    scheduler.update_runtime_config(max_num_running_seqs=4)
+    second_output = scheduler.schedule()
+    assert len(second_output.scheduled_new_reqs) == 2
+    assert len(scheduler.running) == 4
+    assert not scheduler.waiting
+
+
+@pytest.mark.parametrize("value", [0, 5, True, 1.5])
+def test_runtime_max_num_running_seqs_rejects_invalid_values(value):
+    scheduler = create_scheduler(max_num_seqs=4)
+
+    with pytest.raises(ValueError, match="max_num_running_seqs"):
+        scheduler.update_runtime_config(max_num_running_seqs=value)
+
+
 def test_finish_request():
     scheduler = create_scheduler()
     requests = create_requests(num_requests=10)

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -180,6 +180,18 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def get_runtime_config(self) -> dict[str, int]:
+        """Return settings that can be changed without restarting the engine."""
+        ...
+
+    @abstractmethod
+    async def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        """Update settings that stay within startup-time resource capacity."""
+        ...
+
+    @abstractmethod
     async def sleep(self, level: int = 1, mode: "PauseMode" = "abort") -> None:
         """Sleep the engine"""
         ...

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -54,6 +54,12 @@ def register_vllm_dev_api_routers(app: FastAPI):
 
     attach_rlhf_router(app)
 
+    from .dev.runtime_config.api_router import (
+        attach_router as attach_runtime_config_router,
+    )
+
+    attach_runtime_config_router(app)
+
     from .dev.rpc.api_router import attach_router as attach_rpc_router
 
     attach_rpc_router(app)

--- a/vllm/entrypoints/serve/dev/runtime_config/__init__.py
+++ b/vllm/entrypoints/serve/dev/runtime_config/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/serve/dev/runtime_config/api_router.py
+++ b/vllm/entrypoints/serve/dev/runtime_config/api_router.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, Field
+
+from vllm.engine.protocol import EngineClient
+
+router = APIRouter()
+
+
+class RuntimeConfigUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    max_num_running_seqs: int = Field(ge=1, strict=True)
+
+
+def engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+@router.get("/v1/runtime_config")
+async def get_runtime_config(raw_request: Request) -> dict[str, int]:
+    """Return live scheduler policy and its startup-time capacity."""
+    return await engine_client(raw_request).get_runtime_config()
+
+
+@router.patch("/v1/runtime_config")
+async def update_runtime_config(
+    update: RuntimeConfigUpdate, raw_request: Request
+) -> dict[str, int]:
+    """Change scheduler policy without resizing engine resources."""
+    engine = engine_client(raw_request)
+    current_config = await engine.get_runtime_config()
+    capacity = current_config.get("max_num_seqs_capacity")
+    if capacity is None:
+        raise HTTPException(
+            status_code=501,
+            detail="The configured scheduler does not support runtime configuration",
+        )
+    if update.max_num_running_seqs > capacity:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "max_num_running_seqs cannot exceed the startup capacity "
+                f"max_num_seqs ({capacity})"
+            ),
+        )
+    return await engine.update_runtime_config(update.max_num_running_seqs)
+
+
+def attach_router(app: FastAPI) -> None:
+    app.include_router(router)

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -235,6 +235,18 @@ class SchedulerInterface(ABC):
         """Returns (num_running_reqs, num_waiting_reqs)."""
         raise NotImplementedError
 
+    def get_runtime_config(self) -> dict[str, int]:
+        """Return scheduler settings that can be changed at runtime."""
+        return {}
+
+    def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        """Update scheduler settings that do not resize engine resources."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support runtime configuration"
+        )
+
     def get_kv_cache_usage(self) -> float:
         """Returns the fraction of the KV cache currently in use (0.0-1.0)."""
         return 0.0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -116,7 +116,8 @@ class Scheduler(SchedulerInterface):
         # Track requests scheduled in prior step (MRV1-only).
         self.prev_step_scheduled_req_ids: set[str] = set()
 
-        # Scheduling constraints.
+        # Scheduling constraints. max_num_seqs is the allocation-time capacity;
+        # max_num_running_reqs is a live admission cap within that capacity.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
         self.max_num_scheduled_tokens = (
             self.scheduler_config.max_num_scheduled_tokens
@@ -1228,7 +1229,9 @@ class Scheduler(SchedulerInterface):
 
         assert token_budget >= 0
         assert input_budget >= 0
-        assert len(self.running) <= self.max_num_running_reqs
+        # A runtime cap reduction drains down naturally: requests already running
+        # keep their slots, while no new requests are admitted above the live cap.
+        assert len(self.running) <= self.scheduler_config.max_num_seqs
         # Since some requests in the RUNNING queue may not be scheduled in
         # this step, the total number of scheduled requests can be smaller than
         # len(self.running).
@@ -2579,6 +2582,37 @@ class Scheduler(SchedulerInterface):
             - self.num_waiting_for_streaming_input
         )
         return num_waiting + len(self.running)
+
+    def get_runtime_config(self) -> dict[str, int]:
+        return {
+            "max_num_running_seqs": self.max_num_running_reqs,
+            "max_num_seqs_capacity": self.scheduler_config.max_num_seqs,
+        }
+
+    def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        if max_num_running_seqs is None:
+            return self.get_runtime_config()
+        if isinstance(max_num_running_seqs, bool) or not isinstance(
+            max_num_running_seqs, int
+        ):
+            raise ValueError("max_num_running_seqs must be an integer")
+        if not 1 <= max_num_running_seqs <= self.scheduler_config.max_num_seqs:
+            raise ValueError(
+                "max_num_running_seqs must be between 1 and the startup "
+                f"max_num_seqs capacity ({self.scheduler_config.max_num_seqs})"
+            )
+
+        old_value = self.max_num_running_reqs
+        self.max_num_running_reqs = max_num_running_seqs
+        logger.info(
+            "Updated max_num_running_seqs from %d to %d (capacity: %d)",
+            old_value,
+            max_num_running_seqs,
+            self.scheduler_config.max_num_seqs,
+        )
+        return self.get_runtime_config()
 
     def has_finished_requests(self) -> bool:
         if self.finished_req_ids:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1043,6 +1043,14 @@ class AsyncLLM(EngineClient):
     async def reset_encoder_cache(self) -> None:
         await self.engine_core.reset_encoder_cache_async()
 
+    async def get_runtime_config(self) -> dict[str, int]:
+        return await self.engine_core.get_runtime_config_async()
+
+    async def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        return await self.engine_core.update_runtime_config_async(max_num_running_seqs)
+
     async def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
         if level >= 1:
             await self.renderer.clear_mm_cache_async()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -804,6 +804,14 @@ class EngineCore:
             reset_running_requests, reset_connector
         )
 
+    def get_runtime_config(self) -> dict[str, int]:
+        return self.scheduler.get_runtime_config()
+
+    def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        return self.scheduler.update_runtime_config(max_num_running_seqs)
+
     def reset_encoder_cache(self) -> None:
         """Reset the encoder cache to invalidate all cached encoder outputs.
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -164,6 +164,14 @@ class EngineCoreClient(ABC):
     def reset_encoder_cache(self) -> None:
         raise NotImplementedError
 
+    def get_runtime_config(self) -> dict[str, int]:
+        raise NotImplementedError
+
+    def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        raise NotImplementedError
+
     def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
         raise NotImplementedError
 
@@ -254,6 +262,14 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def reset_encoder_cache_async(self) -> None:
+        raise NotImplementedError
+
+    async def get_runtime_config_async(self) -> dict[str, int]:
+        raise NotImplementedError
+
+    async def update_runtime_config_async(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
         raise NotImplementedError
 
     async def sleep_async(self, level: int = 1, mode: PauseMode = "abort") -> None:
@@ -350,6 +366,14 @@ class InprocClient(EngineCoreClient):
 
     def reset_encoder_cache(self) -> None:
         self.engine_core.reset_encoder_cache()
+
+    def get_runtime_config(self) -> dict[str, int]:
+        return self.engine_core.get_runtime_config()
+
+    def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        return self.engine_core.update_runtime_config(max_num_running_seqs)
 
     def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
         if mode == "wait":
@@ -930,6 +954,14 @@ class SyncMPClient(MPClient):
     def reset_encoder_cache(self) -> None:
         self.call_utility("reset_encoder_cache")
 
+    def get_runtime_config(self) -> dict[str, int]:
+        return self.call_utility("get_runtime_config")
+
+    def update_runtime_config(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        return self.call_utility("update_runtime_config", max_num_running_seqs)
+
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.call_utility("add_lora", lora_request)
 
@@ -1183,6 +1215,16 @@ class AsyncMPClient(MPClient):
 
     async def reset_encoder_cache_async(self) -> None:
         await self.call_utility_async("reset_encoder_cache")
+
+    async def get_runtime_config_async(self) -> dict[str, int]:
+        return await self.call_utility_async("get_runtime_config")
+
+    async def update_runtime_config_async(
+        self, max_num_running_seqs: int | None = None
+    ) -> dict[str, int]:
+        return await self.call_utility_async(
+            "update_runtime_config", max_num_running_seqs
+        )
 
     async def sleep_async(self, level: int = 1, mode: PauseMode = "abort") -> None:
         await self.call_utility_async("sleep", level, mode)


### PR DESCRIPTION
## Summary

This is an exploratory prototype for changing scheduler policy without redeploying vLLM. It separates the startup-time `max_num_seqs` resource capacity from a live `max_num_running_seqs` admission cap.

The prototype adds:

- scheduler get/update methods for the live cap
- EngineCore and EngineClient utility-RPC plumbing
- dev-gated `GET /v1/runtime_config` and `PATCH /v1/runtime_config` endpoints
- validation and scheduler/API tests

## Motivation

Inspired by operator feedback that inference-engine tuning knobs are almost exclusively startup flags: https://x.com/skeptrune/status/2094620791732330889

`max_num_seqs` currently has two responsibilities: it sizes static buffers/compiled graphs and it initializes the scheduler concurrency limit. This draft tries splitting those responsibilities so the resource envelope remains immutable while policy inside that envelope can change live.

## Semantics tried here

- `--max-num-seqs` remains the startup allocation capacity.
- `max_num_running_seqs` can change from 1 through that capacity.
- Lowering below the current running count uses drain-down semantics: existing requests continue, but replacements are not admitted until the running count falls below the new cap.
- Raising is allowed only up to the startup capacity.
- Lowering does not reclaim GPU memory or resize CUDA graphs.
- Updates run in EngineCore through the existing serialized utility path, so scheduler mutation occurs at an engine iteration boundary.
- The HTTP surface is under `VLLM_SERVER_DEV_MODE`; this draft is not proposing a stable production endpoint yet. An endpoint plugin or a dedicated authenticated admin surface may be a better final API.

## Non-goals / follow-ups

This does not add a database watcher or persistence layer. The intended architecture would be for an external controller to watch desired state and apply versioned updates to replicas, while vLLM owns validation and atomic application.

Likely follow-ups if this direction is useful:

- live scheduled-token budget bounded by startup capacity
- live queue/admission limits coordinated across API frontend processes
- live effective speculative depth bounded by preloaded model capacity and pre-captured graph shapes
- versioning / compare-and-swap for distributed control planes

## Duplicate-work check

I searched open PRs for `max_num_running_seqs`, `runtime config scheduler`, and `dynamic max_num_seqs`; there is no directly overlapping implementation.

- #38147 concerns read-only configuration/runtime introspection and now favors external endpoint plugins. This prototype changes scheduler state inside EngineCore.
- #54801 changes speculative-decoding policy by sequence length; it does not provide runtime scheduler reconfiguration or a live sequence cap.

## Tests

```bash
/home/mgoin/code/vllm/.venv/bin/python -m pytest \
  tests/v1/core/test_scheduler.py \
  tests/entrypoints/serve/dev/test_runtime_config.py -q
# 169 passed

/home/mgoin/code/vllm/.venv/bin/pre-commit run --files \
  vllm/v1/core/sched/interface.py \
  vllm/v1/core/sched/scheduler.py \
  vllm/v1/engine/core.py \
  vllm/v1/engine/core_client.py \
  vllm/v1/engine/async_llm.py \
  vllm/engine/protocol.py \
  vllm/entrypoints/serve/__init__.py \
  vllm/entrypoints/serve/dev/runtime_config/__init__.py \
  vllm/entrypoints/serve/dev/runtime_config/api_router.py \
  tests/v1/core/test_scheduler.py \
  tests/entrypoints/serve/dev/test_runtime_config.py
# all hooks passed, including Ruff and mypy
```

No model evaluation was run because this prototype changes admission/scheduling concurrency policy, not model outputs, accuracy, or serving semantics for an individual request. No GPU end-to-end model test was run; the changed behavior is CPU-side scheduler/control-plane logic.

## AI assistance disclosure

AI assistance from OpenAI Codex was used to research, implement, and test this draft. The commit includes a `Co-authored-by` trailer. This must remain draft until the human submitter has reviewed every changed line and can explain and defend the design end-to-end.