### PR TITLE
[Attention] Sync FA with upstream

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -39,7 +39,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 06bdd47c0d0383daf6a2ff0c418faff9c6da16e5
+          GIT_TAG 506341a143fcabd4bb79052a7605ada727d6b3f5
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION
## Purpose

Sync vLLM's pinned FlashAttention revision with the landed [vllm-project/flash-attention#188](https://github.com/vllm-project/flash-attention/pull/188).

#188 was approved and squash-merged as `506341a143fcabd4bb79052a7605ada727d6b3f5` (tree `b4c7f467f3874ca7b8fb7471abee0d363b5113ff`). The final tree is byte-identical to the reviewed #188 head `ee391c01f50d48a13d7e3d584f072bb0dba8dc4c`; the excluded `hopper/` subtree remains unchanged, as requested in review.

## Changes

- Keep `GIT_REPOSITORY` on the official `vllm-project/flash-attention` repository.
- Advance `GIT_TAG` from `06bdd47c0d0383daf6a2ff0c418faff9c6da16e5` to the final #188 squash commit.

The resulting PR diff is one line in `cmake/external_projects/vllm_flash_attn.cmake`.

## Duplicate-work check

I searched the open vLLM PRs for the final commit, #188, and existing FlashAttention sync titles. No other open PR targets this sync.

## Validation

- The official repository's `main` resolves exactly to `506341a143fcabd4bb79052a7605ada727d6b3f5`, and GitHub reports its signature as verified.
- The final commit is two commits ahead of the previously pinned SHA with no divergence.
- `git diff --check origin/main...HEAD` passed.
- All applicable changed-file pre-commit hooks passed.
- Detached clean-worktree verification passed for exact commit `ae3c8eedfae58a6fa8097df08a94919dad7584c1` (tree `deb606b4f4bcf360ed5e10dd5516247db4255f24`).
- A clean synthetic merge with current vLLM `main` `25240513856e9aca9b07e9381f2a4513b6954bd8` changes only the intended CMake file (merge tree `9956f39814213adc6fd9939876fcce8bb0b9b802`).
- Fresh CI is requested for this exact final-pin revision.

## AI assistance

AI assistance was used to prepare and validate this mechanical dependency-pin update. The human submitter directed the exact change, reviewed every changed line, and remains responsible for reviewing and defending it end-to-end.
