### PR TITLE
[Bugfix][Speculative Decoding] Fix Gemma4 MTP hidden-state buffer sizing

### DIFF
--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -106,6 +106,13 @@ class SpecDecodeBaseProposer:
         ):
             self.hidden_size = self.hidden_size * draft_hf_config.hc_mult
 
+        # Gemma4 MTP drafters have a decoder hidden_size smaller than the
+        # target model's backbone hidden_size (e.g. 1024 vs 5376) and consume
+        # the target's backbone-dim hidden states, so size the hidden-state
+        # buffer by the backbone hidden size.
+        if hasattr(draft_hf_config, "backbone_hidden_size"):
+            self.hidden_size = draft_hf_config.backbone_hidden_size
+
         # Unifying eagle, draft model, and parallel drafting support.
         # DFlash always uses parallel drafting (all tokens in one pass),
         # but has an additional slot for the next_token_id (does not shift like EAGLE)


### PR DESCRIPTION
Size the spec-decode hidden-state buffer by the target model's backbone_hidden_size for Gemma4 MTP. The Gemma4 assistant drafter has a decoder hidden_size smaller than the target's backbone hidden_size and consumes the target's backbone-dim hidden states, so the current draft_model_config.get_hidden_size() undersizes the buffer and engine initialization fails during profile_run/dummy_run with:

`RuntimeError: mat1 and mat2 shapes cannot be multiplied (2048x6400 and 10752x1024)`

Mirrors the existing DeepSeek-V4 hc_mult special-case. Guarded with hasattr so it is a no-op for all non-Gemma4 models.
