### PR TITLE
[Bugfix] Restore `weight_dtype` in `QuarkW8A8Fp8MoEMethod` to fix GPT-OSS FP8 MoE weight loading

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -243,6 +243,7 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
         activation_quant_key: QuantKey | None,
     ):
         super().__init__(moe, weight_quant_key, activation_quant_key)
+        self.weight_dtype = "fp8"
         self.weight_qscheme = (
             "per_channel" if weight_quant_key == kFp8StaticChannelSym else "per_tensor"
         )


### PR DESCRIPTION

#52958 refactored `QuarkConfig`/`QuarkMoEMethod` to dispatch quant schemes via `QuantKey`. As part of that refactor, `QuarkW8A8Fp8MoEMethod.__init__` dropped the `self.weight_dtype` attribute it used to set. `GptOssForCausalLM._load_weights_quark` relies on `hasattr(quant_method, "weight_dtype")` via `_get_moe_weight_dtype()`
to decide which loading branch to use for MoE weights. With `weight_dtype` missing, `_get_moe_weight_dtype()` returns `None` instead of `"fp8"`, so the `moe_quant_method == "fp8"` branch is skipped. This causes loading to go through the generic path which raises:
```
RuntimeError: The size of tensor a (2880) must match the size of tensor b (5760) at non-singleton dimension 0
```

This addresses the CI failure for `models/quantization/test_gpt_oss.py::test_gpt_oss_attention_quantization[amd/gpt-oss-20b-WFP8-AFP8-KVFP8-0.89-1]`
(see https://buildkite.com/vllm/amd-ci/builds/12514/canvas?tab=output&jid=01a05de2-00fb-435d-bf03-08d51f300bd8#L2666)

With this change, the test is passing.