### PR TITLE
[Bugfix][Reasoning] Split leaked GLM think blocks out of content when extraction is disabled

### DIFF
--- a/tests/reasoning/test_glm4_moe_reasoning_parser.py
+++ b/tests/reasoning/test_glm4_moe_reasoning_parser.py
@@ -227,3 +227,71 @@ def test_is_reasoning_end_full_prompt(
     token_ids = glm45_tokenizer.convert_tokens_to_ids(tokens)
     check_is_reasoning_end = parser.is_reasoning_end(token_ids)
     assert check_is_reasoning_end == is_reasoning_end
+
+
+# #54744: GLM-5.3-family templates have no thinking switch at all, so a client
+# sending enable_thinking/thinking = False (honored by GLM-4.5/4.6) must not
+# switch extraction off: the model thinks anyway and the scratchpad would leak
+# into content. A template that honored the switch emits no think tags, so
+# tag-free output keeps passing through untouched.
+DISABLED_LEAK = {
+    "output": "Simple question.</think>2 + 2 = **4**",
+    "reasoning": "Simple question.",
+    "content": "2 + 2 = **4**",
+}
+
+DISABLED_EXPLICIT_TAGS = {
+    "output": "<think>Working it out</think>The answer is 4.",
+    "reasoning": "Working it out",
+    "content": "The answer is 4.",
+}
+
+DISABLED_TAG_FREE = {
+    "output": "The answer is 4.",
+    "reasoning": None,
+    "content": "The answer is 4.",
+}
+
+
+@pytest.mark.parametrize(
+    "param_dict",
+    [
+        pytest.param(DISABLED_LEAK, id="disabled_dangling_end_tag"),
+        pytest.param(DISABLED_EXPLICIT_TAGS, id="disabled_explicit_tags"),
+    ],
+)
+def test_reasoning_disabled_kwarg_still_splits_think_block(
+    param_dict: dict, glm45_tokenizer
+):
+    output = glm45_tokenizer.tokenize(param_dict["output"])
+    output_tokens: list[str] = [
+        glm45_tokenizer.convert_tokens_to_string([token]) for token in output
+    ]
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+
+    reasoning, content = run_reasoning_extraction(
+        parser_cls(glm45_tokenizer, chat_template_kwargs={"enable_thinking": False}),
+        output_tokens,
+    )
+
+    assert reasoning == param_dict["reasoning"]
+    assert content == param_dict["content"]
+    # The fallback mirrors the enabled parser exactly on tagged output.
+    assert (reasoning, content) == run_reasoning_extraction(
+        parser_cls(glm45_tokenizer), output_tokens
+    )
+
+
+def test_reasoning_disabled_kwarg_tag_free_passthrough(glm45_tokenizer):
+    output = glm45_tokenizer.tokenize(DISABLED_TAG_FREE["output"])
+    output_tokens: list[str] = [
+        glm45_tokenizer.convert_tokens_to_string([token]) for token in output
+    ]
+    parser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        glm45_tokenizer, chat_template_kwargs={"enable_thinking": False}
+    )
+
+    reasoning, content = run_reasoning_extraction(parser, output_tokens)
+
+    assert reasoning is None
+    assert content == DISABLED_TAG_FREE["content"]

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -27,6 +27,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
 
 if TYPE_CHECKING:
     from vllm.tokenizers import TokenizerLike
@@ -221,6 +222,31 @@ class Glm47MoeParser(ParserEngine):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
-        if not self.thinking_enabled:
+        if self.thinking_enabled:
+            return super().extract_reasoning(model_output, request)
+        if THINK_START not in model_output and THINK_END not in model_output:
+            # A template that honored the switch emits no think tags, so
+            # tag-free output is pure content.
             return None, model_output
-        return super().extract_reasoning(model_output, request)
+        # The caller asked to skip extraction, but the output still carries a
+        # think block: this template has no off switch (GLM-5.3 family) and
+        # thinks regardless, so passing the scratchpad through as the answer
+        # leaks it into content (#54744). Split with a thinking-armed engine
+        # instead; the request-scoped engine keeps the unarmed config, so
+        # streaming and id-space paths are untouched.
+        engine = StreamingParserEngine(
+            glm47_moe_config(thinking=True), self.model_tokenizer, vocab=self.vocab
+        )
+        events = engine.feed(model_output, [])
+        events.extend(engine.finish())
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+        for event in events:
+            if event.type == EventType.REASONING_CHUNK:
+                reasoning_parts.append(event.value)
+            elif event.type == EventType.TEXT_CHUNK:
+                content_parts.append(event.value)
+        reasoning = "".join(reasoning_parts)
+        if self._strip_trailing_reasoning_ws:
+            reasoning = reasoning.rstrip()
+        return reasoning or None, "".join(content_parts) or None


### PR DESCRIPTION
## Purpose

Fixes #54744.

With `--reasoning-parser glm45`/`glm47`, passing `chat_template_kwargs: {"enable_thinking": false}` (or `thinking: false`) disables the parser's reasoning extraction. For GLM-4.5/4.6 that is correct, because their templates honor the kwarg and the model emits no think block. GLM-5.3-family templates read neither kwarg, so the model thinks unconditionally, and the raw scratchpad plus a dangling `</think>` lands in `message.content`:

```json
{"role": "assistant", "content": "Simple question.</think>2 + 2 = **4**\n\n..."}
```

The fix is output-driven: when extraction was disabled but the output still carries a think block, split it with the thinking-armed engine config instead of passing it through. Tag-free output (a template that genuinely honored the switch) passes through byte-identically, so GLM-4.5/4.6 behavior is unchanged. The request-scoped engine keeps the unarmed config, so the streaming and id-space paths (`is_reasoning_end`, `extract_content_ids`) are untouched.

Scope boundary, stated plainly: the streaming path still cannot auto-detect this case, because by the time a dangling `</think>` arrives the scratchpad has already streamed. Auto-detection there would require buffering content for models that legitimately disabled thinking, which is worse than the leak. Operators hitting this should drop the ignored kwarg for GLM-5.3 deployments; the non-streaming leak this PR closes is the verified repro from the issue.

Relationship to existing work: #43728's alias work fixes models whose template reads one of the two kwarg names; it cannot cover GLM-5.3, which reads neither. #52410 is the same parser-template agreement class from the other direction.

## Test plan

`tests/reasoning/test_glm4_moe_reasoning_parser.py` gains three pins: kwarg-disabled with a dangling end tag (the leak shape, now split), kwarg-disabled with explicit tags, and kwarg-disabled tag-free pass-through (GLM-4.5/4.6 preserved). The tagged cases also assert the fallback's output equals the enabled parser's on the same text, so the two paths cannot drift apart.

- `pytest tests/reasoning/test_glm4_moe_reasoning_parser.py -q`: 19 passed (16 existing + 3 new), and the two split tests fail on current main as expected (pass-through verified green on both).
- `pytest tests/parser/engine/ -q`: 3822 passed.
- `pytest tests/reasoning/ -q`: 466 passed
- `ruff check` and `ruff format --check` clean on both touched files.

No GPU model eval: this environment has no GPU, so verification is parser-level only (the issue's live repro was on the reporter's side; my change sits entirely in the parser layer and does not touch sampling).

## AI assistance

Prepared with AI assistance (Kimi K3). The submitter reviewed every changed line; the mechanism was verified against current main before writing code, and the tests were verified to fail on the old code.

Co-authored-by: Kimi K3 <noreply@moonshot.ai>
