### PR TITLE
[Bugfix][Spec Decode] Honour the draft's attention_backend on Model Runner V2

### DIFF
--- a/tests/v1/spec_decode/test_draft_attention_backend_override.py
+++ b/tests/v1/spec_decode/test_draft_attention_backend_override.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The draft must honour ``attention_backend`` from --speculative-config.
+
+The V1 proposer sets the draft's attention backend from the speculative config
+and never inherits the target's, because draft and target attention shapes
+differ and not every backend supports both. The V2 base speculator returned the
+target's config unchanged, so the setting was silently dropped for every
+speculator family that does not override the property itself.
+
+The property is exercised through ``fget`` on a minimal holder: constructing a
+real speculator would require a GPU, a loaded model and a KV cache, none of
+which this contract depends on.
+"""
+
+from dataclasses import dataclass
+
+from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+
+
+@dataclass
+class _AttentionConfig:
+    backend: str | None = None
+
+
+@dataclass
+class _SpeculativeConfig:
+    attention_backend: str | None = None
+
+
+@dataclass
+class _VllmConfig:
+    attention_config: _AttentionConfig
+    speculative_config: _SpeculativeConfig
+
+
+@dataclass
+class _Holder:
+    """Only the two attributes ``attn_vllm_config`` actually reads."""
+
+    vllm_config: _VllmConfig
+    speculative_config: _SpeculativeConfig
+
+
+def _holder(target_backend: str, draft_backend: str | None) -> _Holder:
+    spec = _SpeculativeConfig(attention_backend=draft_backend)
+    return _Holder(
+        vllm_config=_VllmConfig(
+            attention_config=_AttentionConfig(backend=target_backend),
+            speculative_config=spec,
+        ),
+        speculative_config=spec,
+    )
+
+
+def _draft_config(holder: _Holder) -> _VllmConfig:
+    return DraftModelSpeculator.attn_vllm_config.fget(holder)
+
+
+def test_draft_attention_backend_overrides_the_target():
+    """An explicit draft backend must reach the draft's attention config."""
+    assert _draft_config(
+        _holder("FLASHINFER", "TRITON_ATTN")
+    ).attention_config.backend == ("TRITON_ATTN")
+
+
+def test_draft_inherits_target_when_unset():
+    """No draft backend means unchanged behaviour: the target's own config."""
+    h = _holder("FLASHINFER", None)
+    assert _draft_config(h) is h.vllm_config
+
+
+def test_override_does_not_mutate_the_target_config():
+    """The target keeps its own backend after the draft config is derived."""
+    h = _holder("FLASHINFER", "TRITON_ATTN")
+    _draft_config(h)
+    assert h.vllm_config.attention_config.backend == "FLASHINFER"

--- a/tests/v1/spec_decode/test_draft_attention_backend_override.py
+++ b/tests/v1/spec_decode/test_draft_attention_backend_override.py
@@ -1,16 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""The draft model must honour ``attention_backend`` from --speculative-config.
+"""The draft must honour ``attention_backend`` from --speculative-config.
 
-The V1 proposer sets the draft's attention backend from the speculative config
-and never inherits the target's, because draft and target attention shapes
-differ and not every backend supports both. On V2 the setting was dropped.
-
-The override has to be applied before ``get_model()``: ``init_attn_backend``
-reads the backend off each constructed layer via ``get_attn_backend()`` rather
-than off the config, so anything applied after construction is inert. These
-tests therefore assert on the config that ``load_eagle_model`` actually hands
-to ``get_model``.
+``init_attn_backend`` reads the backend off each constructed layer, so these
+assert on the config ``load_eagle_model`` hands to ``get_model``.
 """
 
 from dataclasses import dataclass
@@ -62,8 +55,6 @@ def _config(target_backend: str, draft_backend: str | None) -> _VllmConfig:
 
 
 class _Captured(Exception):
-    """Stops load_eagle_model once we hold the config it would have built with."""
-
     def __init__(self, vllm_config):
         self.vllm_config = vllm_config
 
@@ -81,25 +72,19 @@ def _capture_draft_config(cfg):
 
 
 def test_draft_attention_backend_overrides_the_target():
-    """An explicit draft backend must reach the config the draft is built with."""
     used = _capture_draft_config(_config("FLASHINFER", "TRITON_ATTN"))
     assert used.attention_config.backend == "TRITON_ATTN"
 
 
-def test_unset_clears_the_backend_so_the_draft_autoselects():
-    """Unset must clear the target's backend, not inherit it.
-
-    The V1 proposer assigns the draft's backend unconditionally so that a
-    ``None`` erases the target's and the draft autoselects independently. It
-    never inherits, because draft and target attention shapes differ and not
-    every backend serves both.
-    """
-    used = _capture_draft_config(_config("FLASHINFER", None))
-    assert used.attention_config.backend is None
+def test_unset_leaves_the_target_backend_in_place():
+    """Clearing it lets the draft autoselect a KV layout the target lacks."""
+    cfg = _config("FLEX_ATTENTION", None)
+    used = _capture_draft_config(cfg)
+    assert used is cfg
+    assert used.attention_config.backend == "FLEX_ATTENTION"
 
 
 def test_override_does_not_mutate_the_target_config():
-    """The target must keep its own backend after the draft config is derived."""
     cfg = _config("FLASHINFER", "TRITON_ATTN")
     _capture_draft_config(cfg)
     assert cfg.attention_config.backend == "FLASHINFER"

--- a/tests/v1/spec_decode/test_draft_attention_backend_override.py
+++ b/tests/v1/spec_decode/test_draft_attention_backend_override.py
@@ -1,21 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""The draft must honour ``attention_backend`` from --speculative-config.
+"""The draft model must honour ``attention_backend`` from --speculative-config.
 
 The V1 proposer sets the draft's attention backend from the speculative config
 and never inherits the target's, because draft and target attention shapes
-differ and not every backend supports both. The V2 base speculator returned the
-target's config unchanged, so the setting was silently dropped for every
-speculator family that does not override the property itself.
+differ and not every backend supports both. On V2 the setting was dropped.
 
-The property is exercised through ``fget`` on a minimal holder: constructing a
-real speculator would require a GPU, a loaded model and a KV cache, none of
-which this contract depends on.
+The override has to be applied before ``get_model()``: ``init_attn_backend``
+reads the backend off each constructed layer via ``get_attn_backend()`` rather
+than off the config, so anything applied after construction is inert. These
+tests therefore assert on the config that ``load_eagle_model`` actually hands
+to ``get_model``.
 """
 
 from dataclasses import dataclass
+from unittest.mock import patch
 
-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+import pytest
+
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
 
 @dataclass
@@ -24,54 +27,79 @@ class _AttentionConfig:
 
 
 @dataclass
+class _KernelConfig:
+    moe_backend: str | None = None
+
+
+@dataclass
+class _CacheConfig:
+    cache_dtype: str = "auto"
+
+
+@dataclass
 class _SpeculativeConfig:
     attention_backend: str | None = None
+    moe_backend: str | None = None
+    kv_cache_dtype: str | None = None
+    draft_model_config: object = None
 
 
 @dataclass
 class _VllmConfig:
     attention_config: _AttentionConfig
+    kernel_config: _KernelConfig
+    cache_config: _CacheConfig
     speculative_config: _SpeculativeConfig
 
 
-@dataclass
-class _Holder:
-    """Only the two attributes ``attn_vllm_config`` actually reads."""
-
-    vllm_config: _VllmConfig
-    speculative_config: _SpeculativeConfig
-
-
-def _holder(target_backend: str, draft_backend: str | None) -> _Holder:
-    spec = _SpeculativeConfig(attention_backend=draft_backend)
-    return _Holder(
-        vllm_config=_VllmConfig(
-            attention_config=_AttentionConfig(backend=target_backend),
-            speculative_config=spec,
-        ),
-        speculative_config=spec,
+def _config(target_backend: str, draft_backend: str | None) -> _VllmConfig:
+    return _VllmConfig(
+        attention_config=_AttentionConfig(backend=target_backend),
+        kernel_config=_KernelConfig(),
+        cache_config=_CacheConfig(),
+        speculative_config=_SpeculativeConfig(attention_backend=draft_backend),
     )
 
 
-def _draft_config(holder: _Holder) -> _VllmConfig:
-    return DraftModelSpeculator.attn_vllm_config.fget(holder)
+class _Captured(Exception):
+    """Stops load_eagle_model once we hold the config it would have built with."""
+
+    def __init__(self, vllm_config):
+        self.vllm_config = vllm_config
+
+
+def _capture_draft_config(cfg):
+    def _fake_get_model(*, vllm_config, model_config):
+        raise _Captured(vllm_config)
+
+    with (
+        patch("vllm.v1.worker.gpu.spec_decode.eagle.utils.get_model", _fake_get_model),
+        pytest.raises(_Captured) as exc,
+    ):
+        load_eagle_model(object(), cfg)
+    return exc.value.vllm_config
 
 
 def test_draft_attention_backend_overrides_the_target():
-    """An explicit draft backend must reach the draft's attention config."""
-    assert _draft_config(
-        _holder("FLASHINFER", "TRITON_ATTN")
-    ).attention_config.backend == ("TRITON_ATTN")
+    """An explicit draft backend must reach the config the draft is built with."""
+    used = _capture_draft_config(_config("FLASHINFER", "TRITON_ATTN"))
+    assert used.attention_config.backend == "TRITON_ATTN"
 
 
-def test_draft_inherits_target_when_unset():
-    """No draft backend means unchanged behaviour: the target's own config."""
-    h = _holder("FLASHINFER", None)
-    assert _draft_config(h) is h.vllm_config
+def test_unset_clears_the_backend_so_the_draft_autoselects():
+    """Unset must clear the target's backend, not inherit it.
+
+    The V1 proposer assigns the draft's backend unconditionally so that a
+    ``None`` erases the target's and the draft autoselects independently. It
+    never inherits, because draft and target attention shapes differ and not
+    every backend serves both.
+    """
+    used = _capture_draft_config(_config("FLASHINFER", None))
+    assert used.attention_config.backend is None
 
 
 def test_override_does_not_mutate_the_target_config():
-    """The target keeps its own backend after the draft config is derived."""
-    h = _holder("FLASHINFER", "TRITON_ATTN")
-    _draft_config(h)
-    assert h.vllm_config.attention_config.backend == "FLASHINFER"
+    """The target must keep its own backend after the draft config is derived."""
+    cfg = _config("FLASHINFER", "TRITON_ATTN")
+    _capture_draft_config(cfg)
+    assert cfg.attention_config.backend == "FLASHINFER"

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -47,6 +47,18 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
                 cache_dtype=speculative_config.kv_cache_dtype,
             ),
         )
+    # Assigned unconditionally, mirroring the V1 proposer: a None backend
+    # clears the target's so the draft autoselects independently instead of
+    # inheriting, because draft and target attention shapes often differ.
+    # Must be applied before get_model(): init_attn_backend reads the backend
+    # off each constructed layer, so an override applied later has no effect.
+    vllm_config = replace(
+        vllm_config,
+        attention_config=replace(
+            vllm_config.attention_config,
+            backend=speculative_config.attention_backend,
+        ),
+    )
     with set_model_tag("eagle_head"):
         eagle_model = get_model(
             vllm_config=vllm_config, model_config=draft_model_config

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -47,18 +47,16 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
                 cache_dtype=speculative_config.kv_cache_dtype,
             ),
         )
-    # Assigned unconditionally, mirroring the V1 proposer: a None backend
-    # clears the target's so the draft autoselects independently instead of
-    # inheriting, because draft and target attention shapes often differ.
-    # Must be applied before get_model(): init_attn_backend reads the backend
-    # off each constructed layer, so an override applied later has no effect.
-    vllm_config = replace(
-        vllm_config,
-        attention_config=replace(
-            vllm_config.attention_config,
-            backend=speculative_config.attention_backend,
-        ),
-    )
+    if speculative_config.attention_backend is not None:
+        # Before get_model(): the backend is read off the constructed layers.
+        # Only when set, so the draft keeps a KV cache layout the target shares.
+        vllm_config = replace(
+            vllm_config,
+            attention_config=replace(
+                vllm_config.attention_config,
+                backend=speculative_config.attention_backend,
+            ),
+        )
     with set_model_tag("eagle_head"):
         eagle_model = get_model(
             vllm_config=vllm_config, model_config=draft_model_config

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config import VllmConfig, get_layers_from_vllm_config, replace
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
@@ -221,8 +221,22 @@ class DraftModelSpeculator(BaseSpeculator):
     @property
     def attn_vllm_config(self) -> VllmConfig:
         """Config for the draft's attention metadata builders. Overridden by
-        speculators whose attention mode differs from the target's."""
-        return self.vllm_config
+        speculators whose attention mode differs from the target's.
+
+        An explicit ``attention_backend`` in the speculative config applies to
+        the draft only. Without it the draft would inherit the target's
+        backend, which the V1 proposer deliberately avoids: draft and target
+        attention shapes differ and not every backend supports both.
+        """
+        backend = self.speculative_config.attention_backend
+        if backend is None:
+            return self.vllm_config
+        return replace(
+            self.vllm_config,
+            attention_config=replace(
+                self.vllm_config.attention_config, backend=backend
+            ),
+        )
 
     def set_attn(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig, get_layers_from_vllm_config, replace
+from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
@@ -221,22 +221,8 @@ class DraftModelSpeculator(BaseSpeculator):
     @property
     def attn_vllm_config(self) -> VllmConfig:
         """Config for the draft's attention metadata builders. Overridden by
-        speculators whose attention mode differs from the target's.
-
-        An explicit ``attention_backend`` in the speculative config applies to
-        the draft only. Without it the draft would inherit the target's
-        backend, which the V1 proposer deliberately avoids: draft and target
-        attention shapes differ and not every backend supports both.
-        """
-        backend = self.speculative_config.attention_backend
-        if backend is None:
-            return self.vllm_config
-        return replace(
-            self.vllm_config,
-            attention_config=replace(
-                self.vllm_config.attention_config, backend=backend
-            ),
-        )
+        speculators whose attention mode differs from the target's."""
+        return self.vllm_config
 
     def set_attn(
         self,


### PR DESCRIPTION
## Purpose

`--speculative-config '{"attention_backend": ...}'` is silently ignored on Model Runner V2.

The three draft overrides have deliberately different contracts, per `SpeculativeConfig`:

| field | when unset |
|---|---|
| `moe_backend` | inherits the target's |
| `kv_cache_dtype` | inherits the target's |
| **`attention_backend`** | **cleared, so the draft autoselects independently** |

The V1 proposer implements this in `_create_draft_vllm_config` by assigning the draft's backend
*unconditionally*, so a `None` erases the target's rather than inheriting it:

```python
# Note (matt): Never inherit the attention backend from base, because there are
# many opportunities for incompatibility, so we always independently autoselect
# unless explicitly specified in the speculative config.
```

V2 implements neither half: an explicit backend is dropped, and an unset one inherits. It affects
every speculator family that does not resolve the backend itself, which is `eagle`, **`mtp`**,
`gemma4`, `autoregressive`, `multi_module_mtp` and `dflash2`. Only `dflash` (which overrides
`attn_vllm_config`) and `dspark` (which resolves it in `dspark/utils.py`) were unaffected.

MTP is the common case and published recipes use it, e.g.
`--speculative-config '{"method":"mtp","attention_backend":"TRITON_ATTN", ...}'`. This became
user-visible when MRV2 was made the default in #53183.

## Fix

Apply the override in `load_eagle_model`, **before** `get_model()`, alongside the existing
`kv_cache_dtype` override.

Placement is the crux. `init_attn_backend` resolves the backend from each already-constructed layer:

```python
attn_backend = attn_layers[layer_name].get_attn_backend()   # v1/worker/gpu/attn_utils.py
```

and uses `vllm_config` only to look those layers up. So the backend is fixed at construction time and
any config mutated afterwards is ignored. The assignment is unconditional, mirroring V1, so the unset
case clears the target's backend instead of inheriting it.

## Validation

Unit, `tests/v1/spec_decode/test_draft_attention_backend_override.py`, which captures the config
`load_eagle_model` actually hands to `get_model`:

```
without the fix:  2 failed, 1 passed
with the fix:     3 passed
```

Both behavioural tests fail when the fix is reverted, so they are not vacuous.

Hardware, Qwen3.6-35B-A3B-NVFP4 with MTP-3 on an RTX PRO 6000 Blackwell Max-Q, V2, default MoE
backend, real routing, one node:

| arm | draft backend resolved | output tput |
|---|---|---|
| without fix, `attention_backend: TRITON_ATTN` | `FlashInferBackend` (request dropped) | 214.91 |
| with fix, `attention_backend: TRITON_ATTN` | **`TritonAttentionBackend`** | 193.69 |
| with fix, `attention_backend` unset | serves, autoselects | n/a |

Note the throughput **drops 9.9%** in the middle row, and that is the point: the draft now runs the
backend the user asked for. Previously the request was discarded and the draft silently ran
FlashInfer. A no-op change could not move throughput at all, so this is also the proof the override
takes effect. The third row is the safety check on the unconditional assignment: clearing the backend
when unset does not break the default MTP path.

## Why this is not a duplicate

I ran the checks in AGENTS.md. Nothing open touches the V2 draft attention-config path. #53450 pins
backends for components that autoselect, which is a different mechanism and config surface.

## Model evaluation

Not applicable. This changes which attention backend the *draft* uses. Under real rejection sampling
the target verifies every drafted token, so the draft's kernel choice cannot alter output; it can only
move acceptance length. Affected configurations today run a backend the user did not request, so there
is no prior baseline to regress against.

## AI assistance

AI assistance was used to author this change. I have reviewed every changed line, ran the tests and
the hardware validation above myself, and can defend the design.
