### PR TITLE
[CI/Build] Gate PR title check on ready PRs & use slim runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,4 @@ self-hosted-runner:
     - vllm-runners
     # Not yet in actionlint's known-label set.
     - macos-26
+    - ubuntu-slim

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,14 +2,29 @@ name: PR title
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [labeled, edited, reopened, ready_for_review, synchronize]
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions: {}
 
 jobs:
   check-format:
     name: Check format
-    runs-on: ubuntu-latest
+    # Triggered when:
+    # - The `ready` label is added.
+    # - A ready PR's title is edited.
+    # - A ready PR is reopened.
+    # - A draft PR with the `ready` label is marked ready for review.
+    # - New commits are pushed to a ready PR (so its latest commit has a title check status).
+    if: >-
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'ready') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ready') &&
+      (github.event.action != 'edited' || github.event.changes.title != null)
+    runs-on: ubuntu-slim
     steps:
       - name: Validate title
         env:


### PR DESCRIPTION
## Summary

- Gate the advisory PR-title check on the `ready` label.
- Keep `synchronize` so the latest commit of each ready PR has a title status.
- Use `ubuntu-slim` and cancel stale per-PR runs.

## Validation

- `pre-commit run --files .github/workflows/pr-title.yml .github/actionlint.yaml`
- `git diff --check`

No duplicate open PR was found in searches for PR-title workflow changes. AI assistance was used; I reviewed every changed line.