### PR TITLE
[Rust][Metrics] Consume LoRA load events in the Rust frontend

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -394,6 +394,17 @@ Encoding a running/waiting counts for multiple adapters in a
 comma-separated string seems quite misguided - we could use labels to
 distinguish between per-adapter counts. This should be revisited.
 
+That metric is now deprecated in favour of three gauges fed by the
+engine notification channel (`vllm/v1/notifications.py`), which the
+worker updates whenever its adapter caches change, including on an
+idle engine with statically configured adapters:
+
+- `vllm:lora_adapter_loaded{adapter_name, level="gpu"|"cpu", pinned}`:
+  one series per resident adapter, present while it is loaded and
+  removed when it is evicted.
+- `vllm:num_gpu_loaded_lora_adapters` and
+  `vllm:num_cpu_loaded_lora_adapters`: counts per tier.
+
 Note that `multiprocess_mode="livemostrecent"` is used - the most
 recent metric is used, but only from currently running processes.
 

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -399,9 +399,10 @@ engine notification channel (`vllm/v1/notifications.py`), which the
 worker updates whenever its adapter caches change, including on an
 idle engine with statically configured adapters:
 
-- `vllm:lora_adapter_loaded{adapter_name, level="gpu"|"cpu", pinned}`:
+- `vllm:lora_adapter_loaded{adapter_name, level="gpu"|"cpu", pinned, rank}`:
   one series per resident adapter, present while it is loaded and
-  removed when it is evicted.
+  removed when it is evicted; `rank` is the adapter's LoRA rank, a
+  proxy for its size and load cost.
 - `vllm:num_gpu_loaded_lora_adapters` and
   `vllm:num_cpu_loaded_lora_adapters`: counts per tier.
 - `vllm:max_gpu_lora_adapters` and `vllm:max_cpu_lora_adapters`: the

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -409,6 +409,11 @@ idle engine with statically configured adapters:
   so a router can compare occupancy against capacity before the first
   request; the `max_lora` label on the deprecated gauge above only
   appears once an adapter has served.
+- `vllm:lora_adapter_load_seconds{transition="load"|"activate"}`: a
+  histogram of how long each adapter transition took on the worker,
+  `load` for disk into the CPU cache and `activate` for the CPU cache
+  into a GPU slot. A router can turn this into the expected cost of
+  sending a request to a server that has to load the adapter first.
 
 Note that `multiprocess_mode="livemostrecent"` is used - the most
 recent metric is used, but only from currently running processes.

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -404,6 +404,11 @@ idle engine with statically configured adapters:
   removed when it is evicted.
 - `vllm:num_gpu_loaded_lora_adapters` and
   `vllm:num_cpu_loaded_lora_adapters`: counts per tier.
+- `vllm:max_gpu_lora_adapters` and `vllm:max_cpu_lora_adapters`: the
+  slot capacity per tier (`max_loras`, `max_cpu_loras`), set at startup
+  so a router can compare occupancy against capacity before the first
+  request; the `max_lora` label on the deprecated gauge above only
+  appears once an adapter has served.
 
 Note that `multiprocess_mode="livemostrecent"` is used - the most
 recent metric is used, but only from currently running processes.

--- a/rust/src/engine-core-client/src/client/imp.rs
+++ b/rust/src/engine-core-client/src/client/imp.rs
@@ -19,8 +19,9 @@ use crate::client::state::{OutputReceiver, RequestRegistry, UtilityReceiver, Uti
 use crate::client::stream::EngineCoreStreamOutput;
 use crate::client::{AbortCause, AbortRequest};
 use crate::error::{client_closed, dispatcher_closed, unexpected_dispatcher_output};
-use crate::metrics::{LoraInfoExporter, SchedulerStatsRecorder};
+use crate::metrics::{LoraInfoExporter, LoraLoadedExporter, SchedulerStatsRecorder};
 use crate::protocol::encode_msgpack;
+use crate::protocol::notifications::EngineNotification;
 use crate::protocol::output::{EngineCoreOutput, EngineCoreOutputs};
 use crate::protocol::request::{EngineCoreRequest, EngineCoreRequestType};
 use crate::protocol::stats::SchedulerStats;
@@ -403,6 +404,7 @@ pub(crate) async fn run_output_dispatcher_loop(
     mut output_rx: mpsc::Receiver<Result<EngineCoreOutputs>>,
 ) {
     let mut lora_info = LoraInfoExporter::default();
+    let mut lora_loaded = LoraLoadedExporter::default();
 
     let result: Result<()> = async {
         loop {
@@ -459,6 +461,27 @@ pub(crate) async fn run_output_dispatcher_loop(
                     // request tracking instead.
                     let (running, waiting) = inner.lora_adapter_states();
                     lora_info.update(&METRICS.scheduler, running, waiting);
+
+                    if let Some(engine_notifications) = batch.engine_notifications.as_ref() {
+                        for event in engine_notifications {
+                            match event {
+                                EngineNotification::LoraLoadEvent(event) => {
+                                    lora_loaded.update(
+                                        &METRICS.scheduler,
+                                        inner.model_name(),
+                                        batch.engine_index,
+                                        event,
+                                    );
+                                }
+                                EngineNotification::Custom(custom) => {
+                                    trace!(
+                                        key = %custom.key,
+                                        "ignoring custom engine notification"
+                                    );
+                                }
+                            }
+                        }
+                    }
                 }
                 EngineCoreOutputs::Utility(utility) => {
                     let call_id = utility.output.call_id;

--- a/rust/src/engine-core-client/src/metrics.rs
+++ b/rust/src/engine-core-client/src/metrics.rs
@@ -8,9 +8,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use vllm_metrics::{
     EngineLabels, EnginePositionLabels, F64Gauge, Family, HistogramMetric, LoraAdapterNames,
-    LoraInfoLabels, LoraLoadedLabels, LoraLoadedLevel, MooncakeOperationCounterFamily,
-    MooncakeOperationHistogramFamily, MooncakeOperationLabels, SchedulerLogStatsAccumulator,
-    SchedulerMetrics, U64Counter, U64Gauge, WaitingReasonLabels,
+    LoraInfoLabels, LoraLoadTransitionLabels, LoraLoadedLabels, LoraLoadedLevel,
+    MooncakeOperationCounterFamily, MooncakeOperationHistogramFamily, MooncakeOperationLabels,
+    SchedulerLogStatsAccumulator, SchedulerMetrics, U64Counter, U64Gauge, WaitingReasonLabels,
 };
 
 use crate::protocol::notifications::LoraLoadEvent;
@@ -415,6 +415,17 @@ impl LoraLoadedExporter {
     ) {
         let model_name = model_name.into();
 
+        for timing in &event.loads {
+            metrics
+                .lora_load_seconds
+                .get_or_create(&LoraLoadTransitionLabels {
+                    model_name: model_name.clone(),
+                    engine,
+                    transition: timing.transition.clone(),
+                })
+                .observe(timing.seconds);
+        }
+
         let engine_labels = EngineLabels {
             model_name: model_name.clone(),
             engine,
@@ -497,6 +508,61 @@ mod tests {
     }
 
     #[test]
+    fn lora_load_timings_land_in_the_transition_histogram() {
+        use crate::metrics::LoraLoadedExporter;
+        use crate::protocol::notifications::{LoraLoadEvent, LoraLoadTiming};
+
+        let metrics = Metrics::new();
+        let mut exporter = LoraLoadedExporter::default();
+        exporter.update(
+            &metrics.scheduler,
+            "model",
+            0,
+            &LoraLoadEvent {
+                gpu_adapters: vec!["a".to_string()],
+                cpu_adapters: vec!["a".to_string()],
+                loads: vec![
+                    LoraLoadTiming {
+                        adapter_name: "a".to_string(),
+                        transition: "load".to_string(),
+                        seconds: 0.4,
+                    },
+                    LoraLoadTiming {
+                        adapter_name: "a".to_string(),
+                        transition: "activate".to_string(),
+                        seconds: 0.05,
+                    },
+                ],
+                ..Default::default()
+            },
+        );
+        let rendered = metrics.render().unwrap();
+        assert!(rendered.contains(
+            r#"vllm:lora_adapter_load_seconds_count{model_name="model",engine="0",transition="load"} 1"#
+        ));
+        assert!(rendered.contains(
+            r#"vllm:lora_adapter_load_seconds_sum{model_name="model",engine="0",transition="load"} 0.4"#
+        ));
+        assert!(rendered.contains(
+            r#"vllm:lora_adapter_load_seconds_sum{model_name="model",engine="0",transition="activate"} 0.05"#
+        ));
+        // A residency-only event leaves the histogram untouched.
+        exporter.update(
+            &metrics.scheduler,
+            "model",
+            0,
+            &LoraLoadEvent {
+                gpu_adapters: vec![],
+                cpu_adapters: vec!["a".to_string()],
+                ..Default::default()
+            },
+        );
+        assert!(metrics.render().unwrap().contains(
+            r#"vllm:lora_adapter_load_seconds_count{model_name="model",engine="0",transition="load"} 1"#
+        ));
+    }
+
+    #[test]
     fn lora_loaded_emits_levels_and_clears_stale() {
         use crate::metrics::LoraLoadedExporter;
         use crate::protocol::notifications::LoraLoadEvent;
@@ -523,6 +589,7 @@ mod tests {
                 gpu_adapters: vec!["a".to_string()],
                 cpu_adapters: vec!["a".to_string(), "b".to_string()],
                 pinned_adapters: vec!["a".to_string()],
+                ..Default::default()
             },
         );
         let rendered = metrics.render().unwrap();
@@ -549,6 +616,7 @@ mod tests {
                 gpu_adapters: vec![],
                 cpu_adapters: vec!["a".to_string()],
                 pinned_adapters: vec![],
+                ..Default::default()
             },
         );
         let rendered = metrics.render().unwrap();

--- a/rust/src/engine-core-client/src/metrics.rs
+++ b/rust/src/engine-core-client/src/metrics.rs
@@ -3,15 +3,17 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use vllm_metrics::{
     EngineLabels, EnginePositionLabels, F64Gauge, Family, HistogramMetric, LoraAdapterNames,
-    LoraInfoLabels, MooncakeOperationCounterFamily, MooncakeOperationHistogramFamily,
-    MooncakeOperationLabels, SchedulerLogStatsAccumulator, SchedulerMetrics, U64Counter, U64Gauge,
-    WaitingReasonLabels,
+    LoraInfoLabels, LoraLoadedLabels, LoraLoadedLevel, MooncakeOperationCounterFamily,
+    MooncakeOperationHistogramFamily, MooncakeOperationLabels, SchedulerLogStatsAccumulator,
+    SchedulerMetrics, U64Counter, U64Gauge, WaitingReasonLabels,
 };
 
+use crate::protocol::notifications::LoraLoadEvent;
 use crate::protocol::stats::{
     KvConnectorStats, MooncakeStats, MultiConnectorStats, NixlStats, SchedulerStats,
 };
@@ -92,10 +94,17 @@ impl SchedulerStatsRecorder {
         let engines = engines
             .iter()
             .filter_map(|engine| {
-                let engine = engine.engine_id.engine_index()?;
+                let index = engine.engine_id.engine_index()?;
+                metrics
+                    .lora_gpu_slots
+                    .get_or_create(&EngineLabels {
+                        model_name: model_name.to_string(),
+                        engine: index,
+                    })
+                    .set(u64::from(engine.ready_response.max_loras));
                 Some((
-                    engine,
-                    resolve_scheduler_stats_handles(metrics, model_name, engine),
+                    index,
+                    resolve_scheduler_stats_handles(metrics, model_name, index),
                 ))
             })
             .collect();
@@ -385,6 +394,69 @@ impl LoraInfoExporter {
     }
 }
 
+/// Exports the loaded-LoRA-adapter gauges from
+/// `EngineNotification::LoraLoadEvent` events.
+///
+/// Each event carries the complete current state for one engine, so the
+/// exporter diffs against the previously emitted series to drop adapters
+/// that were evicted since the last event.
+#[derive(Default)]
+pub(crate) struct LoraLoadedExporter {
+    current: HashMap<u32, BTreeSet<LoraLoadedLabels>>,
+}
+
+impl LoraLoadedExporter {
+    pub(crate) fn update(
+        &mut self,
+        metrics: &SchedulerMetrics,
+        model_name: impl Into<String>,
+        engine: u32,
+        event: &LoraLoadEvent,
+    ) {
+        let model_name = model_name.into();
+
+        let engine_labels = EngineLabels {
+            model_name: model_name.clone(),
+            engine,
+        };
+        metrics
+            .lora_gpu_adapters
+            .get_or_create(&engine_labels)
+            .set(event.gpu_adapters.len() as u64);
+        metrics
+            .lora_cpu_adapters
+            .get_or_create(&engine_labels)
+            .set(event.cpu_adapters.len() as u64);
+
+        let gpu: BTreeSet<&str> = event.gpu_adapters.iter().map(String::as_str).collect();
+        let pinned: BTreeSet<&str> = event.pinned_adapters.iter().map(String::as_str).collect();
+        let next: BTreeSet<LoraLoadedLabels> = event
+            .cpu_adapters
+            .iter()
+            .map(|adapter_name| LoraLoadedLabels {
+                model_name: model_name.clone(),
+                engine,
+                adapter_name: adapter_name.clone(),
+                level: if gpu.contains(adapter_name.as_str()) {
+                    LoraLoadedLevel::Gpu
+                } else {
+                    LoraLoadedLevel::Cpu
+                },
+                pinned: pinned.contains(adapter_name.as_str()),
+            })
+            .collect();
+
+        let prev = self.current.entry(engine).or_default();
+        for stale in prev.difference(&next) {
+            metrics.lora_adapter_loaded.remove(stale);
+        }
+        for labels in &next {
+            metrics.lora_adapter_loaded.get_or_create(labels).set(1);
+        }
+        *prev = next;
+    }
+}
+
 fn now_unix_secs() -> f64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -399,7 +471,8 @@ mod tests {
     use expect_test::expect;
     use vllm_metrics::Metrics;
 
-    use crate::metrics::LoraInfoExporter;
+    use crate::metrics::{LoraInfoExporter, SchedulerStatsRecorder};
+    use crate::mock_engine::default_ready_response;
     use crate::protocol::stats::{
         KvConnectorStats, MooncakeOperation, MooncakeRecord, MooncakeStats, MooncakeStatus,
         MultiConnectorStats, NixlStats, SchedulerStats,
@@ -421,6 +494,103 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn lora_loaded_emits_levels_and_clears_stale() {
+        use crate::metrics::LoraLoadedExporter;
+        use crate::protocol::notifications::LoraLoadEvent;
+
+        let metrics = Metrics::new();
+        let mut exporter = LoraLoadedExporter::default();
+
+        // Family iteration order is not deterministic; sort for snapshots.
+        let loaded_series = |rendered: &str| {
+            let mut lines = rendered
+                .lines()
+                .filter(|l| l.starts_with("vllm:lora_adapter_loaded{"))
+                .collect::<Vec<_>>();
+            lines.sort_unstable();
+            lines.join("\n")
+        };
+
+        // "a" active on GPU and pinned, "b" only in the CPU cache.
+        exporter.update(
+            &metrics.scheduler,
+            "model",
+            0,
+            &LoraLoadEvent {
+                gpu_adapters: vec!["a".to_string()],
+                cpu_adapters: vec!["a".to_string(), "b".to_string()],
+                pinned_adapters: vec!["a".to_string()],
+            },
+        );
+        let rendered = metrics.render().unwrap();
+        expect![[r#"
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="gpu",pinned="true"} 1
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="b",level="cpu",pinned="false"} 1"#]]
+        .assert_eq(&loaded_series(&rendered));
+        assert!(
+            rendered
+                .contains(r#"vllm:num_gpu_loaded_lora_adapters{model_name="model",engine="0"} 1"#)
+        );
+        assert!(
+            rendered
+                .contains(r#"vllm:num_cpu_loaded_lora_adapters{model_name="model",engine="0"} 2"#)
+        );
+
+        // "a" evicted from GPU to CPU (and unpinned), "b" evicted entirely:
+        // the stale series must disappear.
+        exporter.update(
+            &metrics.scheduler,
+            "model",
+            0,
+            &LoraLoadEvent {
+                gpu_adapters: vec![],
+                cpu_adapters: vec!["a".to_string()],
+                pinned_adapters: vec![],
+            },
+        );
+        let rendered = metrics.render().unwrap();
+        expect![[r#"
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="cpu",pinned="false"} 1"#]]
+        .assert_eq(&loaded_series(&rendered));
+        assert!(
+            rendered
+                .contains(r#"vllm:num_gpu_loaded_lora_adapters{model_name="model",engine="0"} 0"#)
+        );
+        assert!(
+            rendered
+                .contains(r#"vllm:num_cpu_loaded_lora_adapters{model_name="model",engine="0"} 1"#)
+        );
+    }
+
+    #[test]
+    fn slot_capacity_is_published_per_engine_at_startup() {
+        use crate::transport::{ConnectedEngine, EngineId};
+
+        let metrics = Metrics::new();
+        let mut ready = default_ready_response();
+        ready.max_loras = 4;
+        let _recorder = SchedulerStatsRecorder::new(
+            &metrics.scheduler,
+            "test-model",
+            &[ConnectedEngine {
+                engine_id: EngineId::from(b"engine-0"),
+                ready_response: ready,
+            }],
+        );
+
+        let rendered = metrics.render().expect("render metrics");
+        let line = rendered
+            .lines()
+            .find(|l| l.starts_with("vllm:max_gpu_lora_adapters{"))
+            .expect("slot capacity gauge rendered");
+        assert!(line.ends_with(" 4"), "{line}");
+        assert!(
+            line.contains("model_name=\"test-model\"") && line.contains("engine=\"0\""),
+            "{line}"
+        );
     }
 
     #[test]

--- a/rust/src/engine-core-client/src/metrics.rs
+++ b/rust/src/engine-core-client/src/metrics.rs
@@ -454,6 +454,7 @@ impl LoraLoadedExporter {
                     LoraLoadedLevel::Cpu
                 },
                 pinned: pinned.contains(adapter_name.as_str()),
+                rank: event.ranks.get(adapter_name).copied().unwrap_or(0),
             })
             .collect();
 
@@ -589,13 +590,14 @@ mod tests {
                 gpu_adapters: vec!["a".to_string()],
                 cpu_adapters: vec!["a".to_string(), "b".to_string()],
                 pinned_adapters: vec!["a".to_string()],
+                ranks: BTreeMap::from([("a".to_string(), 64)]),
                 ..Default::default()
             },
         );
         let rendered = metrics.render().unwrap();
         expect![[r#"
-            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="gpu",pinned="true"} 1
-            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="b",level="cpu",pinned="false"} 1"#]]
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="gpu",pinned="true",rank="64"} 1
+            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="b",level="cpu",pinned="false",rank="0"} 1"#]]
         .assert_eq(&loaded_series(&rendered));
         assert!(
             rendered
@@ -620,8 +622,7 @@ mod tests {
             },
         );
         let rendered = metrics.render().unwrap();
-        expect![[r#"
-            vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="cpu",pinned="false"} 1"#]]
+        expect![[r#"vllm:lora_adapter_loaded{model_name="model",engine="0",adapter_name="a",level="cpu",pinned="false",rank="0"} 1"#]]
         .assert_eq(&loaded_series(&rendered));
         assert!(
             rendered

--- a/rust/src/engine-core-client/src/metrics.rs
+++ b/rust/src/engine-core-client/src/metrics.rs
@@ -576,7 +576,7 @@ mod tests {
             &metrics.scheduler,
             "test-model",
             &[ConnectedEngine {
-                engine_id: EngineId::from(b"engine-0"),
+                engine_id: EngineId::from_engine_index(0),
                 ready_response: ready,
             }],
         );
@@ -585,7 +585,7 @@ mod tests {
         let line = rendered
             .lines()
             .find(|l| l.starts_with("vllm:max_gpu_lora_adapters{"))
-            .expect("slot capacity gauge rendered");
+            .unwrap_or_else(|| panic!("slot capacity gauge missing from:\n{rendered}"));
         assert!(line.ends_with(" 4"), "{line}");
         assert!(
             line.contains("model_name=\"test-model\"") && line.contains("engine=\"0\""),

--- a/rust/src/engine-core-client/src/protocol/mod.rs
+++ b/rust/src/engine-core-client/src/protocol/mod.rs
@@ -27,6 +27,7 @@ pub mod handshake;
 pub mod logprobs;
 pub mod lora;
 pub mod multimodal;
+pub mod notifications;
 pub mod output;
 pub mod request;
 pub mod sampling;

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Open escape hatch for out-of-tree producers (plugins).
+///
+/// The union fails fast on unknown tags, so plugins can't add their own struct
+/// type. They emit this instead: namespace under `key`, arbitrary `payload`.
+/// Frontends that don't know the `key` ignore it. `payload` is Python's
+/// `dict[str, Any]` with `omit_defaults=True`, hence `#[serde(default)]`.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CustomNotification {
+    /// Producer-chosen namespace, e.g. the plugin name.
+    pub key: String,
+    /// Arbitrary msgpack data, opaque to this frontend.
+    #[serde(default)]
+    pub payload: BTreeMap<String, rmpv::Value>,
+}
+
+/// Rare engine-level event notifications carried on
+/// `EngineCoreOutputs::engine_notifications`.
+///
+/// These are engine-scoped state transitions (as opposed to the per-request
+/// lifecycle events in `EngineCoreOutput::events` and the per-step sampling
+/// in `SchedulerStats`). The union is map-encoded with a `"type"`
+/// discriminator field; msgspec dispatches on each struct's tag. Like the
+/// rest of `EngineCoreOutputs`, the union is version-lockstep with the
+/// engine: an unknown tag is a deployment error and fails the decode.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EngineNotification {
+    Custom(CustomNotification),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::decode_msgpack;
+
+    fn hex_bytes(hex: &str) -> Vec<u8> {
+        hex::decode(hex).unwrap()
+    }
+
+    /// Captured from Python:
+    /// `msgspec.msgpack.encode(CustomNotification(key="my_plugin",
+    /// payload={"count": 5, "name": "foo"}))`
+    const PYTHON_CUSTOM: &str = "83a474797065a6637573746f6da36b6579a96d795f706c7567696ea77061796c6f616482a5636f756e7405a46e616d65a3666f6f";
+
+    /// Captured from Python:
+    /// `msgspec.msgpack.encode(CustomNotification(key="my_plugin"))`,
+    /// where `omit_defaults=True` strips the empty payload.
+    const PYTHON_CUSTOM_EMPTY: &str = "82a474797065a6637573746f6da36b6579a96d795f706c7567696e";
+
+    #[test]
+    fn engine_event_decodes_python_custom_notification() {
+        let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_CUSTOM)).unwrap();
+        expect_test::expect![[r#"
+            Custom(
+                CustomNotification {
+                    key: "my_plugin",
+                    payload: {
+                        "count": Integer(
+                            PosInt(
+                                5,
+                            ),
+                        ),
+                        "name": String(
+                            Utf8String {
+                                s: Ok(
+                                    "foo",
+                                ),
+                            },
+                        ),
+                    },
+                },
+            )
+        "#]]
+        .assert_debug_eq(&event);
+    }
+
+    #[test]
+    fn engine_event_decodes_custom_omitted_payload() {
+        let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_CUSTOM_EMPTY)).unwrap();
+        assert_eq!(
+            event,
+            EngineNotification::Custom(CustomNotification {
+                key: "my_plugin".to_string(),
+                payload: BTreeMap::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn engine_event_unknown_tag_fails_fast() {
+        // The union is version-lockstep with the engine; an event type this
+        // frontend does not know about must fail the decode, not be skipped.
+        let value = rmpv::Value::Map(vec![
+            (
+                rmpv::Value::from("type"),
+                rmpv::Value::from("graceful_shutdown_started"),
+            ),
+            (rmpv::Value::from("deadline_seconds"), rmpv::Value::from(30)),
+        ]);
+        let mut bytes = Vec::new();
+        rmpv::encode::write_value(&mut bytes, &value).unwrap();
+
+        let result: Result<EngineNotification, _> = decode_msgpack(&bytes);
+        assert!(result.is_err());
+    }
+}

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -5,36 +5,22 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-/// Open escape hatch for out-of-tree producers (plugins).
+/// Open escape hatch for out-of-tree producers.
 ///
-/// The union fails fast on unknown tags, so plugins can't add their own struct
-/// type. They emit this instead: namespace under `key`, arbitrary `payload`.
-/// Frontends that don't know the `key` ignore it. `payload` is Python's
-/// `dict[str, Any]` with `omit_defaults=True`, hence `#[serde(default)]`.
-///
-/// Original Python definition:
-/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
+/// Plugins namespace under `key`; frontends ignore keys they don't know.
+/// Mirrors `CustomNotification` in vllm/v1/notifications.py.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct CustomNotification {
-    /// Producer-chosen namespace, e.g. the plugin name.
     pub key: String,
-    /// Arbitrary msgpack data, opaque to this frontend.
     #[serde(default)]
     pub payload: BTreeMap<String, rmpv::Value>,
 }
 
-/// Rare engine-level event notifications carried on
-/// `EngineCoreOutputs::engine_notifications`.
+/// Engine-level events carried on `EngineCoreOutputs::engine_notifications`.
 ///
-/// These are engine-scoped state transitions (as opposed to the per-request
-/// lifecycle events in `EngineCoreOutput::events` and the per-step sampling
-/// in `SchedulerStats`). The union is map-encoded with a `"type"`
-/// discriminator field; msgspec dispatches on each struct's tag. Like the
-/// rest of `EngineCoreOutputs`, the union is version-lockstep with the
+/// Map-encoded with a `"type"` discriminator. Version-lockstep with the
 /// engine: an unknown tag is a deployment error and fails the decode.
-///
-/// Original Python definition:
-/// <https://github.com/vllm-project/vllm/blob/main/vllm/v1/notifications.py>
+/// Mirrors vllm/v1/notifications.py.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EngineNotification {
@@ -50,14 +36,12 @@ mod tests {
         hex::decode(hex).unwrap()
     }
 
-    /// Captured from Python:
-    /// `msgspec.msgpack.encode(CustomNotification(key="my_plugin",
+    /// Python: `encode(CustomNotification(key="my_plugin",
     /// payload={"count": 5, "name": "foo"}))`
     const PYTHON_CUSTOM: &str = "83a474797065a6637573746f6da36b6579a96d795f706c7567696ea77061796c6f616482a5636f756e7405a46e616d65a3666f6f";
 
-    /// Captured from Python:
-    /// `msgspec.msgpack.encode(CustomNotification(key="my_plugin"))`,
-    /// where `omit_defaults=True` strips the empty payload.
+    /// Python: `encode(CustomNotification(key="my_plugin"))`, where
+    /// `omit_defaults=True` strips the empty payload.
     const PYTHON_CUSTOM_EMPTY: &str = "82a474797065a6637573746f6da36b6579a96d795f706c7567696e";
 
     #[test]
@@ -101,8 +85,7 @@ mod tests {
 
     #[test]
     fn engine_event_unknown_tag_fails_fast() {
-        // The union is version-lockstep with the engine; an event type this
-        // frontend does not know about must fail the decode, not be skipped.
+        // An unknown event type must fail the decode, not be skipped.
         let value = rmpv::Value::Map(vec![
             (
                 rmpv::Value::from("type"),

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -5,6 +5,25 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+/// The set of loaded LoRA adapters changed.
+///
+/// A full snapshot of the worker's adapter caches, so consumers replace their
+/// state rather than merge. Python encodes it with `omit_defaults=True`, so
+/// every field needs `#[serde(default)]`. Mirrors `LoRALoadEvent` in
+/// vllm/v1/notifications.py.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LoraLoadEvent {
+    /// Adapters activated into GPU slots (sorted).
+    #[serde(default)]
+    pub gpu_adapters: Vec<String>,
+    /// Adapters resident in the CPU cache (sorted, superset of `gpu_adapters`).
+    #[serde(default)]
+    pub cpu_adapters: Vec<String>,
+    /// Adapters pinned in the caches (sorted).
+    #[serde(default)]
+    pub pinned_adapters: Vec<String>,
+}
+
 /// Open escape hatch for out-of-tree producers.
 ///
 /// Plugins namespace under `key`; frontends ignore keys they don't know.
@@ -24,6 +43,7 @@ pub struct CustomNotification {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EngineNotification {
+    LoraLoadEvent(LoraLoadEvent),
     Custom(CustomNotification),
 }
 
@@ -34,6 +54,46 @@ mod tests {
 
     fn hex_bytes(hex: &str) -> Vec<u8> {
         hex::decode(hex).unwrap()
+    }
+
+    /// Python: `encode(LoRALoadEvent(gpu_adapters=["alpha"],
+    /// cpu_adapters=["alpha", "beta"], pinned_adapters=["alpha"]))`
+    const PYTHON_LORA_LOAD_EVENT: &str = "84a474797065af6c6f72615f6c6f61645f6576656e74ac6770755f616461707465727391a5616c706861ac6370755f616461707465727392a5616c706861a462657461af70696e6e65645f616461707465727391a5616c706861";
+
+    /// Python: `encode(LoRALoadEvent())`, where `omit_defaults=True` strips
+    /// everything but the tag.
+    const PYTHON_LORA_LOAD_EVENT_EMPTY: &str = "81a474797065af6c6f72615f6c6f61645f6576656e74";
+
+    #[test]
+    fn engine_event_decodes_python_lora_load_event() {
+        let event: EngineNotification = decode_msgpack(&hex_bytes(PYTHON_LORA_LOAD_EVENT)).unwrap();
+        expect_test::expect![[r#"
+            LoraLoadEvent(
+                LoraLoadEvent {
+                    gpu_adapters: [
+                        "alpha",
+                    ],
+                    cpu_adapters: [
+                        "alpha",
+                        "beta",
+                    ],
+                    pinned_adapters: [
+                        "alpha",
+                    ],
+                },
+            )
+        "#]]
+        .assert_debug_eq(&event);
+    }
+
+    #[test]
+    fn engine_event_decodes_lora_load_event_omitted_defaults() {
+        let event: EngineNotification =
+            decode_msgpack(&hex_bytes(PYTHON_LORA_LOAD_EVENT_EMPTY)).unwrap();
+        assert_eq!(
+            event,
+            EngineNotification::LoraLoadEvent(LoraLoadEvent::default())
+        );
     }
 
     /// Python: `encode(CustomNotification(key="my_plugin",

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -5,7 +5,19 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-/// The set of loaded LoRA adapters changed.
+/// One measured adapter transition on the worker. Mirrors `LoRALoadTiming`
+/// in vllm/v1/notifications.py.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoraLoadTiming {
+    pub adapter_name: String,
+    /// `load`: read from disk into the CPU cache. `activate`: moved from the
+    /// CPU cache into a GPU slot.
+    pub transition: String,
+    pub seconds: f64,
+}
+
+/// The set of loaded LoRA adapters changed, or an adapter transition
+/// completed.
 ///
 /// A full snapshot of the worker's adapter caches, so consumers replace their
 /// state rather than merge. Python encodes it with `omit_defaults=True`, so
@@ -22,6 +34,9 @@ pub struct LoraLoadEvent {
     /// Adapters pinned in the caches (sorted).
     #[serde(default)]
     pub pinned_adapters: Vec<String>,
+    /// Adapter transitions completed since the previous event, in order.
+    #[serde(default)]
+    pub loads: Vec<LoraLoadTiming>,
 }
 
 /// Open escape hatch for out-of-tree producers.
@@ -80,10 +95,41 @@ mod tests {
                     pinned_adapters: [
                         "alpha",
                     ],
+                    loads: [],
                 },
             )
         "#]]
         .assert_debug_eq(&event);
+    }
+
+    /// Python: `encode(LoRALoadEvent(gpu_adapters=["alpha"], cpu_adapters=["alpha"],
+    /// loads=[LoRALoadTiming("alpha", "load", 0.25), LoRALoadTiming("alpha", "activate", 0.5)]))`
+    const PYTHON_LORA_LOAD_EVENT_WITH_LOADS: &str = "84a474797065af6c6f72615f6c6f61645f6576656e74ac6770755f616461707465727391a5616c706861ac6370755f616461707465727391a5616c706861a56c6f6164739283ac616461707465725f6e616d65a5616c706861aa7472616e736974696f6ea46c6f6164a77365636f6e6473cb3fd000000000000083ac616461707465725f6e616d65a5616c706861aa7472616e736974696f6ea86163746976617465a77365636f6e6473cb3fe0000000000000";
+
+    #[test]
+    fn engine_event_decodes_python_lora_load_event_with_timings() {
+        let event: EngineNotification =
+            decode_msgpack(&hex_bytes(PYTHON_LORA_LOAD_EVENT_WITH_LOADS)).unwrap();
+        assert_eq!(
+            event,
+            EngineNotification::LoraLoadEvent(LoraLoadEvent {
+                gpu_adapters: vec!["alpha".to_string()],
+                cpu_adapters: vec!["alpha".to_string()],
+                pinned_adapters: vec![],
+                loads: vec![
+                    LoraLoadTiming {
+                        adapter_name: "alpha".to_string(),
+                        transition: "load".to_string(),
+                        seconds: 0.25,
+                    },
+                    LoraLoadTiming {
+                        adapter_name: "alpha".to_string(),
+                        transition: "activate".to_string(),
+                        seconds: 0.5,
+                    },
+                ],
+            })
+        );
     }
 
     #[test]

--- a/rust/src/engine-core-client/src/protocol/notifications.rs
+++ b/rust/src/engine-core-client/src/protocol/notifications.rs
@@ -34,6 +34,9 @@ pub struct LoraLoadEvent {
     /// Adapters pinned in the caches (sorted).
     #[serde(default)]
     pub pinned_adapters: Vec<String>,
+    /// LoRA rank of each resident adapter, keyed by name.
+    #[serde(default)]
+    pub ranks: BTreeMap<String, u32>,
     /// Adapter transitions completed since the previous event, in order.
     #[serde(default)]
     pub loads: Vec<LoraLoadTiming>,
@@ -95,6 +98,7 @@ mod tests {
                     pinned_adapters: [
                         "alpha",
                     ],
+                    ranks: {},
                     loads: [],
                 },
             )
@@ -116,6 +120,7 @@ mod tests {
                 gpu_adapters: vec!["alpha".to_string()],
                 cpu_adapters: vec!["alpha".to_string()],
                 pinned_adapters: vec![],
+                ranks: BTreeMap::new(),
                 loads: vec![
                     LoraLoadTiming {
                         adapter_name: "alpha".to_string(),
@@ -128,6 +133,24 @@ mod tests {
                         seconds: 0.5,
                     },
                 ],
+            })
+        );
+    }
+
+    /// Python: `encode(LoRALoadEvent(gpu_adapters=["alpha"], cpu_adapters=["alpha"], ranks={"alpha": 64}))`
+    const PYTHON_LORA_LOAD_EVENT_WITH_RANKS: &str = "84a474797065af6c6f72615f6c6f61645f6576656e74ac6770755f616461707465727391a5616c706861ac6370755f616461707465727391a5616c706861a572616e6b7381a5616c70686140";
+
+    #[test]
+    fn engine_event_decodes_python_lora_load_event_with_ranks() {
+        let event: EngineNotification =
+            decode_msgpack(&hex_bytes(PYTHON_LORA_LOAD_EVENT_WITH_RANKS)).unwrap();
+        assert_eq!(
+            event,
+            EngineNotification::LoraLoadEvent(LoraLoadEvent {
+                gpu_adapters: vec!["alpha".to_string()],
+                cpu_adapters: vec!["alpha".to_string()],
+                ranks: BTreeMap::from([("alpha".to_string(), 64)]),
+                ..Default::default()
             })
         );
     }

--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -13,6 +13,7 @@ use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use super::utility::UtilityOutput;
 use crate::error::{Error, Result, ext_value_decode};
 use crate::protocol::logprobs::MaybeWireLogprobs;
+use crate::protocol::notifications::EngineNotification;
 use crate::protocol::stats::{PrefillStats, SchedulerStats};
 use crate::protocol::{OpaqueValue, decode_msgpack};
 
@@ -179,6 +180,9 @@ struct WireEngineCoreOutputs {
     /// wave needs to start in other engines.
     #[serde(default)]
     start_wave: Option<u32>,
+    /// Rare engine-level event notifications (see `notifications.rs`).
+    #[serde(default)]
+    engine_notifications: Option<Vec<EngineNotification>>,
 }
 
 /// Data-parallel control notifications multiplexed through `EngineCoreOutputs`.
@@ -195,6 +199,7 @@ pub struct RequestBatchOutputs {
     pub scheduler_stats: Option<Box<SchedulerStats>>,
     pub timestamp: f64,
     pub finished_requests: Option<BTreeSet<String>>,
+    pub engine_notifications: Option<Vec<EngineNotification>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -261,7 +266,8 @@ impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
     fn try_from(value: WireEngineCoreOutputs) -> Result<Self> {
         let has_request_payload = !value.outputs.is_empty()
             || value.scheduler_stats.is_some()
-            || value.finished_requests.is_some();
+            || value.finished_requests.is_some()
+            || value.engine_notifications.is_some();
 
         match (
             has_request_payload,
@@ -275,6 +281,7 @@ impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
                 scheduler_stats: value.scheduler_stats,
                 timestamp: value.timestamp,
                 finished_requests: value.finished_requests,
+                engine_notifications: value.engine_notifications,
             }
             .into()),
             (false, Some(_), None, None) => Ok(UtilityCallOutput {
@@ -313,6 +320,7 @@ impl From<EngineCoreOutputs> for WireEngineCoreOutputs {
                 scheduler_stats: batch.scheduler_stats,
                 timestamp: batch.timestamp,
                 finished_requests: batch.finished_requests,
+                engine_notifications: batch.engine_notifications,
                 ..Default::default()
             },
             EngineCoreOutputs::Utility(utility) => Self {
@@ -373,6 +381,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::*;
+    use crate::protocol::notifications::CustomNotification;
     use crate::protocol::output::EngineCoreOutput;
     use crate::protocol::{decode_msgpack, encode_msgpack};
 
@@ -450,6 +459,7 @@ mod tests {
                             "req-1",
                         },
                     ),
+                    engine_notifications: None,
                 },
             )
         "#]]
@@ -525,5 +535,39 @@ mod tests {
             r#"messagepack decode failed for EngineCoreOutputs: invalid wire shape"#
         ]]
         .assert_eq(&error.to_string());
+    }
+
+    #[test]
+    fn engine_core_outputs_classify_event_only_as_request_batch() {
+        let outputs = WireEngineCoreOutputs {
+            engine_notifications: Some(vec![EngineNotification::Custom(CustomNotification {
+                key: "my_plugin".to_string(),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        };
+
+        expect_test::expect![[r#"
+            RequestBatch(
+                RequestBatchOutputs {
+                    engine_index: 0,
+                    outputs: [],
+                    scheduler_stats: None,
+                    timestamp: 0.0,
+                    finished_requests: None,
+                    engine_notifications: Some(
+                        [
+                            Custom(
+                                CustomNotification {
+                                    key: "my_plugin",
+                                    payload: {},
+                                },
+                            ),
+                        ],
+                    ),
+                },
+            )
+        "#]]
+        .assert_debug_eq(&EngineCoreOutputs::try_from(outputs).unwrap());
     }
 }

--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -180,7 +180,6 @@ struct WireEngineCoreOutputs {
     /// wave needs to start in other engines.
     #[serde(default)]
     start_wave: Option<u32>,
-    /// Rare engine-level event notifications (see `notifications.rs`).
     #[serde(default)]
     engine_notifications: Option<Vec<EngineNotification>>,
 }

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2757,6 +2757,7 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                         "req-1",
                     },
                 ),
+                engine_notifications: None,
             },
         )
     "#]]

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2757,7 +2757,22 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                         "req-1",
                     },
                 ),
-                engine_notifications: None,
+                engine_notifications: Some(
+                    [
+                        Custom(
+                            CustomNotification {
+                                key: "my_plugin",
+                                payload: {
+                                    "count": Integer(
+                                        PosInt(
+                                            5,
+                                        ),
+                                    ),
+                                },
+                            },
+                        ),
+                    ],
+                ),
             },
         )
     "#]]

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2769,6 +2769,7 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                                     "beta",
                                 ],
                                 pinned_adapters: [],
+                                ranks: {},
                                 loads: [],
                             },
                         ),

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2769,6 +2769,7 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                                     "beta",
                                 ],
                                 pinned_adapters: [],
+                                loads: [],
                             },
                         ),
                         Custom(

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2759,6 +2759,18 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                 ),
                 engine_notifications: Some(
                     [
+                        LoraLoadEvent(
+                            LoraLoadEvent {
+                                gpu_adapters: [
+                                    "alpha",
+                                ],
+                                cpu_adapters: [
+                                    "alpha",
+                                    "beta",
+                                ],
+                                pinned_adapters: [],
+                            },
+                        ),
                         Custom(
                             CustomNotification {
                                 key: "my_plugin",

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -102,6 +102,19 @@ class EngineCoreOutput(
     new_sampling_mask: object | None = None
 
 
+class CustomNotification(
+    msgspec.Struct,
+    tag="custom",
+    omit_defaults=True,
+):
+    key: str
+    payload: dict[str, object] = {}
+
+
+# Union of engine-level event types; mirrors vllm/v1/notifications.py.
+EngineNotification = CustomNotification
+
+
 class EngineCoreOutputs(
     msgspec.Struct,
     array_like=True,
@@ -115,6 +128,7 @@ class EngineCoreOutputs(
     finished_requests: set[str] | None = None
     wave_complete: int | None = None
     start_wave: int | None = None
+    engine_notifications: list[EngineNotification] | None = None
 
 
 request = EngineCoreRequest(
@@ -203,6 +217,9 @@ outputs = EngineCoreOutputs(
         )
     ],
     finished_requests={"req-1"},
+    engine_notifications=[
+        CustomNotification(key="my_plugin", payload={"count": 5}),
+    ],
 )
 
 sampling_mask_wire = [

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -102,6 +102,16 @@ class EngineCoreOutput(
     new_sampling_mask: object | None = None
 
 
+class LoRALoadEvent(
+    msgspec.Struct,
+    tag="lora_load_event",
+    omit_defaults=True,
+):
+    gpu_adapters: list[str] = []
+    cpu_adapters: list[str] = []
+    pinned_adapters: list[str] = []
+
+
 class CustomNotification(
     msgspec.Struct,
     tag="custom",
@@ -112,7 +122,7 @@ class CustomNotification(
 
 
 # Union of engine-level event types; mirrors vllm/v1/notifications.py.
-EngineNotification = CustomNotification
+EngineNotification = LoRALoadEvent | CustomNotification
 
 
 class EngineCoreOutputs(
@@ -218,6 +228,7 @@ outputs = EngineCoreOutputs(
     ],
     finished_requests={"req-1"},
     engine_notifications=[
+        LoRALoadEvent(gpu_adapters=["alpha"], cpu_adapters=["alpha", "beta"]),
         CustomNotification(key="my_plugin", payload={"count": 5}),
     ],
 )

--- a/rust/src/metrics/src/scheduler.rs
+++ b/rust/src/metrics/src/scheduler.rs
@@ -241,6 +241,25 @@ impl EncodeLabelValue for LoraLoadedLevel {
     }
 }
 
+/// Labels for `vllm:lora_adapter_load_seconds`.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct LoraLoadTransitionLabels {
+    pub model_name: String,
+    pub engine: u32,
+    /// `load` (disk into the CPU cache) or `activate` (CPU cache into a GPU slot).
+    pub transition: String,
+}
+
+pub type LoraLoadTransitionHistogramFamily =
+    Family<LoraLoadTransitionLabels, Histogram, fn() -> Histogram>;
+
+const LORA_LOAD_SECONDS_BUCKETS: [f64; 10] =
+    [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0];
+
+fn lora_load_seconds_histogram() -> Histogram {
+    Histogram::new(LORA_LOAD_SECONDS_BUCKETS.iter().copied())
+}
+
 /// Labels for `vllm:lora_adapter_loaded`, one series per resident adapter.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
 pub struct LoraLoadedLabels {
@@ -270,6 +289,7 @@ pub struct SchedulerMetrics {
     pub lora_cpu_adapters: Family<EngineLabels, U64Gauge>,
     pub lora_gpu_slots: Family<EngineLabels, U64Gauge>,
     pub lora_adapter_loaded: Family<LoraLoadedLabels, U64Gauge>,
+    pub lora_load_seconds: LoraLoadTransitionHistogramFamily,
 
     // Prefix-cache counters, including the connector-backed external cache path.
     pub prefix_cache_queries: Family<EngineLabels, U64Counter>,
@@ -382,6 +402,13 @@ impl SchedulerMetrics {
             "vllm:lora_adapter_loaded",
             "Residency of individual LoRA adapters in the worker's adapter caches. The series exists (value 1) while the adapter is resident; 'level' is 'gpu' when the adapter is active in a GPU slot and 'cpu' when it is only in the host cache.",
             lora_adapter_loaded.clone(),
+        );
+        let lora_load_seconds =
+            Family::new_with_constructor(lora_load_seconds_histogram as fn() -> Histogram);
+        registry.register(
+            "vllm:lora_adapter_load_seconds",
+            "Histogram of LoRA adapter transition time in seconds. 'transition' is 'load' for a read from disk into the CPU cache and 'activate' for a move from the CPU cache into a GPU slot.",
+            lora_load_seconds.clone(),
         );
 
         // Prefix-cache counters, including the connector-backed external cache path.
@@ -596,6 +623,7 @@ impl SchedulerMetrics {
             lora_cpu_adapters,
             lora_gpu_slots,
             lora_adapter_loaded,
+            lora_load_seconds,
             prefix_cache_queries,
             prefix_cache_hits,
             external_prefix_cache_queries,

--- a/rust/src/metrics/src/scheduler.rs
+++ b/rust/src/metrics/src/scheduler.rs
@@ -220,6 +220,38 @@ impl SchedulerLogStatsAccumulator {
     }
 }
 
+/// Where a LoRA adapter is resident, encoded as the `level` label value.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LoraLoadedLevel {
+    /// Active in a GPU slot.
+    Gpu,
+    /// Only resident in the host cache.
+    Cpu,
+}
+
+impl EncodeLabelValue for LoraLoadedLevel {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(
+            &match self {
+                Self::Gpu => "gpu",
+                Self::Cpu => "cpu",
+            },
+            encoder,
+        )
+    }
+}
+
+/// Labels for `vllm:lora_adapter_loaded`, one series per resident adapter.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
+pub struct LoraLoadedLabels {
+    pub model_name: String,
+    pub engine: u32,
+    pub adapter_name: String,
+    pub level: LoraLoadedLevel,
+    /// Whether the adapter is pinned in the caches.
+    pub pinned: bool,
+}
+
 /// Scheduler/batch-scoped Prometheus families exported from `SchedulerStats`.
 pub struct SchedulerMetrics {
     // Scheduler state gauges.
@@ -231,6 +263,13 @@ pub struct SchedulerMetrics {
     /// `vllm:lora_requests_info`. Value is the emit-time unix timestamp in
     /// seconds.
     pub lora_info: Family<LoraInfoLabels, F64Gauge>,
+
+    // Worker-side LoRA adapter cache residency, driven by
+    // `EngineNotification::LoraLoadEvent` events.
+    pub lora_gpu_adapters: Family<EngineLabels, U64Gauge>,
+    pub lora_cpu_adapters: Family<EngineLabels, U64Gauge>,
+    pub lora_gpu_slots: Family<EngineLabels, U64Gauge>,
+    pub lora_adapter_loaded: Family<LoraLoadedLabels, U64Gauge>,
 
     // Prefix-cache counters, including the connector-backed external cache path.
     pub prefix_cache_queries: Family<EngineLabels, U64Counter>,
@@ -313,8 +352,36 @@ impl SchedulerMetrics {
         let lora_info = Family::default();
         registry.register(
             "vllm:lora_requests_info",
-            "Running stats on lora requests.",
+            "Running stats on lora requests. DEPRECATED: encodes adapter names into comma-separated label values; superseded by vllm:lora_adapter_loaded, vllm:num_gpu_loaded_lora_adapters and vllm:num_cpu_loaded_lora_adapters.",
             lora_info.clone(),
+        );
+
+        let lora_gpu_adapters = Family::default();
+        registry.register(
+            "vllm:num_gpu_loaded_lora_adapters",
+            "Number of LoRA adapters currently loaded into GPU slots.",
+            lora_gpu_adapters.clone(),
+        );
+
+        let lora_cpu_adapters = Family::default();
+        registry.register(
+            "vllm:num_cpu_loaded_lora_adapters",
+            "Number of LoRA adapters currently resident in the worker's CPU cache (superset of the GPU-loaded set).",
+            lora_cpu_adapters.clone(),
+        );
+
+        let lora_gpu_slots = Family::default();
+        registry.register(
+            "vllm:max_gpu_lora_adapters",
+            "Number of GPU LoRA slots (max_loras).",
+            lora_gpu_slots.clone(),
+        );
+
+        let lora_adapter_loaded = Family::default();
+        registry.register(
+            "vllm:lora_adapter_loaded",
+            "Residency of individual LoRA adapters in the worker's adapter caches. The series exists (value 1) while the adapter is resident; 'level' is 'gpu' when the adapter is active in a GPU slot and 'cpu' when it is only in the host cache.",
+            lora_adapter_loaded.clone(),
         );
 
         // Prefix-cache counters, including the connector-backed external cache path.
@@ -525,6 +592,10 @@ impl SchedulerMetrics {
             scheduler_waiting_by_reason,
             kv_cache_usage,
             lora_info,
+            lora_gpu_adapters,
+            lora_cpu_adapters,
+            lora_gpu_slots,
+            lora_adapter_loaded,
             prefix_cache_queries,
             prefix_cache_hits,
             external_prefix_cache_queries,

--- a/rust/src/metrics/src/scheduler.rs
+++ b/rust/src/metrics/src/scheduler.rs
@@ -269,6 +269,8 @@ pub struct LoraLoadedLabels {
     pub level: LoraLoadedLevel,
     /// Whether the adapter is pinned in the caches.
     pub pinned: bool,
+    /// The adapter's LoRA rank (0 when the worker did not report one).
+    pub rank: u32,
 }
 
 /// Scheduler/batch-scoped Prometheus families exported from `SchedulerStats`.

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -1103,3 +1103,134 @@ def test_target_modules_match_packed_runtime_modules(
         ],
         vllm_config=default_vllm_config,
     )
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_lru_cache_worker_adapter_manager_loaded_state(
+    dist_init, dummy_model, device, tmp_path
+):
+    """get_loaded_state/get_loaded_names track both cache tiers, pinning,
+    and forget names once an adapter is evicted."""
+    lora_config = LoRAConfig(
+        max_lora_rank=8, max_cpu_loras=3, max_loras=2, lora_dtype=DEFAULT_DTYPE
+    )
+
+    dummy_lora_files = f"{tmp_path}/lora_adapter"
+    os.makedirs(dummy_lora_files, exist_ok=True)
+    create_peft_lora(
+        dummy_model,
+        save_dir=dummy_lora_files,
+        target_modules=["layer1.dense1", "dense2"],
+        lora_dtype=DEFAULT_DTYPE,
+    )
+
+    model_config = ModelConfig(max_model_len=16)
+    vllm_config = VllmConfig(model_config=model_config, lora_config=lora_config)
+    vllm_config.scheduler_config.max_num_seqs = 4
+    vllm_config.scheduler_config.max_num_batched_tokens = 2
+    manager = LRUCacheWorkerLoRAManager(vllm_config, device, EMBEDDING_MODULES)
+    manager.create_lora_manager(dummy_model, vllm_config)
+
+    def request(i: int) -> LoRARequest:
+        return LoRARequest(f"adapter-{i}", i, dummy_lora_files)
+
+    def names():
+        return manager.get_loaded_names(manager.get_loaded_state())
+
+    assert names() == ([], [], [])
+
+    manager.add_adapter(request(1))
+    manager.add_adapter(request(2))
+    assert names() == (["adapter-1", "adapter-2"], ["adapter-1", "adapter-2"], [])
+
+    # Third add: GPU slots are full, so 1 drops to the CPU tier.
+    manager.add_adapter(request(3))
+    assert names() == (
+        ["adapter-2", "adapter-3"],
+        ["adapter-1", "adapter-2", "adapter-3"],
+        [],
+    )
+
+    manager.pin_adapter(1)
+    gpu, cpu, pinned = names()
+    assert "adapter-1" in gpu
+    assert pinned == ["adapter-1"]
+
+    # Fourth add: CPU capacity is 3, so the oldest unpinned adapter is
+    # evicted and its name forgotten.
+    manager.add_adapter(request(4))
+    gpu, cpu, pinned = names()
+    assert "adapter-4" in gpu
+    assert len(cpu) == 3 and "adapter-1" in cpu and "adapter-4" in cpu
+    assert set(manager._adapter_names) == set(manager.list_adapters())
+
+    manager.remove_all_adapters()
+    assert names() == ([], [], [])
+    assert manager._adapter_names == {}
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_model_runner_mixin_publishes_lora_load_events(
+    dist_init, dummy_model, device, tmp_path
+):
+    """The mixin publishes one LoRALoadEvent per change of the loaded set
+    and nothing when the set is unchanged."""
+    from vllm.v1.notifications import LoRALoadEvent, take_worker_notifications
+    from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+
+    lora_config = LoRAConfig(
+        max_lora_rank=8, max_cpu_loras=3, max_loras=2, lora_dtype=DEFAULT_DTYPE
+    )
+    dummy_lora_files = f"{tmp_path}/lora_adapter"
+    os.makedirs(dummy_lora_files, exist_ok=True)
+    create_peft_lora(
+        dummy_model,
+        save_dir=dummy_lora_files,
+        target_modules=["layer1.dense1", "dense2"],
+        lora_dtype=DEFAULT_DTYPE,
+    )
+    model_config = ModelConfig(max_model_len=16)
+    vllm_config = VllmConfig(model_config=model_config, lora_config=lora_config)
+    vllm_config.scheduler_config.max_num_seqs = 4
+    vllm_config.scheduler_config.max_num_batched_tokens = 2
+
+    runner = LoRAModelRunnerMixin.__new__(LoRAModelRunnerMixin)
+    runner.lora_config = lora_config
+    runner.lora_manager = LRUCacheWorkerLoRAManager(
+        vllm_config, device, EMBEDDING_MODULES
+    )
+    runner.lora_manager.create_lora_manager(dummy_model, vllm_config)
+    take_worker_notifications()
+
+    assert runner.add_lora(LoRARequest("adapter-1", 1, dummy_lora_files))
+    assert take_worker_notifications() == [
+        LoRALoadEvent(gpu_adapters=["adapter-1"], cpu_adapters=["adapter-1"])
+    ]
+
+    # Re-adding a loaded adapter changes nothing, so no event.
+    assert not runner.add_lora(LoRARequest("adapter-1", 1, dummy_lora_files))
+    assert take_worker_notifications() is None
+
+    assert runner.pin_lora(1)
+    assert take_worker_notifications() == [
+        LoRALoadEvent(
+            gpu_adapters=["adapter-1"],
+            cpu_adapters=["adapter-1"],
+            pinned_adapters=["adapter-1"],
+        )
+    ]
+
+    assert runner.remove_lora(1)
+    assert take_worker_notifications() == [LoRALoadEvent()]
+
+    # Step-time activation goes through _set_active_loras (both model runners
+    # call it), so it must publish as well.
+    runner._set_active_loras(
+        (2,), (2,), {LoRARequest("adapter-2", 2, dummy_lora_files)}
+    )
+    assert take_worker_notifications() == [
+        LoRALoadEvent(gpu_adapters=["adapter-2"], cpu_adapters=["adapter-2"])
+    ]
+
+    runner.maybe_remove_all_loras(lora_config)
+    assert take_worker_notifications() == [LoRALoadEvent()]

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -1138,10 +1138,15 @@ def test_lru_cache_worker_adapter_manager_loaded_state(
         return manager.get_loaded_names(manager.get_loaded_state())
 
     assert names() == ([], [], [])
+    assert manager.get_loaded_ranks(manager.get_loaded_state()) == {}
 
     manager.add_adapter(request(1))
     manager.add_adapter(request(2))
     assert names() == (["adapter-1", "adapter-2"], ["adapter-1", "adapter-2"], [])
+    assert manager.get_loaded_ranks(manager.get_loaded_state()) == {
+        "adapter-1": 8,
+        "adapter-2": 8,
+    }
 
     # Third add: GPU slots are full, so 1 drops to the CPU tier.
     manager.add_adapter(request(3))

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -1234,3 +1234,59 @@ def test_model_runner_mixin_publishes_lora_load_events(
 
     runner.maybe_remove_all_loras(lora_config)
     assert take_worker_notifications() == [LoRALoadEvent()]
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_lru_cache_worker_adapter_manager_load_timings(
+    dist_init, dummy_model, device, tmp_path
+):
+    """Every disk load and every CPU-to-GPU activation is timed once, a
+    warm re-add is not, and draining empties the buffer."""
+    lora_config = LoRAConfig(
+        max_lora_rank=8, max_cpu_loras=3, max_loras=2, lora_dtype=DEFAULT_DTYPE
+    )
+    dummy_lora_files = f"{tmp_path}/lora_adapter"
+    os.makedirs(dummy_lora_files, exist_ok=True)
+    create_peft_lora(
+        dummy_model,
+        save_dir=dummy_lora_files,
+        target_modules=["layer1.dense1", "dense2"],
+        lora_dtype=DEFAULT_DTYPE,
+    )
+    model_config = ModelConfig(max_model_len=16)
+    vllm_config = VllmConfig(model_config=model_config, lora_config=lora_config)
+    vllm_config.scheduler_config.max_num_seqs = 4
+    vllm_config.scheduler_config.max_num_batched_tokens = 2
+    manager = LRUCacheWorkerLoRAManager(vllm_config, device, EMBEDDING_MODULES)
+    manager.create_lora_manager(dummy_model, vllm_config)
+
+    def request(i: int) -> LoRARequest:
+        return LoRARequest(f"adapter-{i}", i, dummy_lora_files)
+
+    def transitions() -> list[tuple[str, str]]:
+        timings = manager.drain_load_timings()
+        assert all(t.seconds >= 0 for t in timings)
+        return [(t.adapter_name, t.transition) for t in timings]
+
+    assert transitions() == []
+
+    manager.add_adapter(request(1))
+    assert transitions() == [("adapter-1", "load"), ("adapter-1", "activate")]
+
+    # Warm re-add: already in a GPU slot, nothing to time.
+    manager.add_adapter(request(1))
+    assert transitions() == []
+
+    manager.add_adapter(request(2))
+    manager.add_adapter(request(3))  # evicts adapter-1 from its GPU slot
+    assert transitions() == [
+        ("adapter-2", "load"),
+        ("adapter-2", "activate"),
+        ("adapter-3", "load"),
+        ("adapter-3", "activate"),
+    ]
+
+    # adapter-1 is still in the CPU cache: activation only.
+    manager.add_adapter(request(1))
+    assert transitions() == [("adapter-1", "activate")]
+    assert manager.drain_load_timings() == []

--- a/tests/lora/test_lora_metrics.py
+++ b/tests/lora/test_lora_metrics.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Loaded-adapter metrics reach the frontend's Prometheus registry through
+the engine notification channel, with no request traffic."""
+
+import time
+from collections.abc import Callable
+
+from vllm.engine.arg_utils import EngineArgs
+from vllm.lora.request import LoRARequest
+from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.metrics.reader import Gauge
+
+MODEL_PATH = "Qwen/Qwen3-0.6B"
+LORA_MODULE_PATH = "charent/self_cognition_Alice"
+LORA_RANK = 8
+
+
+def make_lora_request(lora_id: int):
+    return LoRARequest(
+        lora_name=f"adapter-{lora_id}", lora_int_id=lora_id, lora_path=LORA_MODULE_PATH
+    )
+
+
+def _loaded_series(llm: LLMEngine) -> dict[tuple[str, str, str], float]:
+    """(adapter_name, level, pinned) -> value, for the live series."""
+    return {
+        (m.labels["adapter_name"], m.labels["level"], m.labels["pinned"]): m.value
+        for m in llm.get_metrics()
+        if isinstance(m, Gauge) and m.name == "vllm:lora_adapter_loaded"
+    }
+
+
+def _gauge(llm: LLMEngine, name: str) -> float:
+    for m in llm.get_metrics():
+        if isinstance(m, Gauge) and m.name == name:
+            return m.value
+    raise AssertionError(f"missing gauge {name}")
+
+
+def test_lora_load_metrics_track_adapter_changes():
+    engine_args = EngineArgs(
+        model=MODEL_PATH,
+        enable_lora=True,
+        max_loras=2,
+        max_cpu_loras=3,
+        max_lora_rank=LORA_RANK,
+        max_model_len=128,
+        gpu_memory_utilization=0.8,
+        enforce_eager=True,
+        disable_log_stats=False,
+    )
+    llm = LLMEngine.from_engine_args(engine_args)
+
+    def series_after(expected: Callable[[dict], bool], timeout_s: float = 60.0):
+        """Step the idle engine, one notification-only output per step, until
+        the loaded series satisfy `expected`."""
+        deadline = time.monotonic() + timeout_s
+        series = _loaded_series(llm)
+        while not expected(series):
+            assert time.monotonic() < deadline, f"metrics never converged: {series}"
+            llm.step()
+            series = _loaded_series(llm)
+        return series
+
+    llm.add_lora(make_lora_request(1))
+    llm.add_lora(make_lora_request(2))
+    assert series_after(lambda s: len(s) == 2) == {
+        ("adapter-1", "gpu", "false"): 1.0,
+        ("adapter-2", "gpu", "false"): 1.0,
+    }
+
+    # GPU slots are full: the third add evicts adapter-1 to the CPU tier.
+    llm.add_lora(make_lora_request(3))
+    assert series_after(lambda s: len(s) == 3) == {
+        ("adapter-1", "cpu", "false"): 1.0,
+        ("adapter-2", "gpu", "false"): 1.0,
+        ("adapter-3", "gpu", "false"): 1.0,
+    }
+    assert _gauge(llm, "vllm:num_gpu_loaded_lora_adapters") == 2
+    assert _gauge(llm, "vllm:num_cpu_loaded_lora_adapters") == 3
+
+    llm.pin_lora(1)
+    series = series_after(lambda s: ("adapter-1", "gpu", "true") in s)
+    assert ("adapter-1", "cpu", "false") not in series
+
+    llm.remove_lora(2)
+    series = series_after(lambda s: not any(n == "adapter-2" for n, _, _ in s))
+    assert len(series) == 2
+    assert _gauge(llm, "vllm:num_cpu_loaded_lora_adapters") == 2

--- a/tests/lora/test_lora_metrics.py
+++ b/tests/lora/test_lora_metrics.py
@@ -78,6 +78,8 @@ def test_lora_load_metrics_track_adapter_changes():
         ("adapter-3", "gpu", "false"): 1.0,
     }
     assert _gauge(llm, "vllm:num_gpu_loaded_lora_adapters") == 2
+    assert _gauge(llm, "vllm:max_gpu_lora_adapters") == 2
+    assert _gauge(llm, "vllm:max_cpu_lora_adapters") == 3
     assert _gauge(llm, "vllm:num_cpu_loaded_lora_adapters") == 3
 
     llm.pin_lora(1)

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -6,16 +6,20 @@ Hits the real `EngineCore` buffer helpers without a model: they only touch
 `_pending_notifications`, so a bare instance is enough.
 """
 
+import queue
+from types import SimpleNamespace
+
+import msgspec
 import pytest
 
 from vllm.v1.engine import EngineCoreOutputs
-from vllm.v1.engine.core import EngineCore
+from vllm.v1.engine.core import EngineCore, EngineCoreProc
 from vllm.v1.notifications import (
     CustomNotification,
     publish_worker_notification,
     take_worker_notifications,
 )
-from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
+from vllm.v1.outputs import ModelRunnerOutput
 
 
 @pytest.fixture(autouse=True)
@@ -115,17 +119,68 @@ def test_worker_notifications_survive_until_the_first_drain():
     assert take_worker_notifications() == [first, second]
 
 
+def _model_output(
+    notifications: list[CustomNotification] | None = None,
+) -> ModelRunnerOutput:
+    return ModelRunnerOutput(
+        req_ids=[], req_id_to_index={}, worker_notifications=notifications
+    )
+
+
 def test_collect_forwards_worker_notifications():
     """Worker-sourced events flow out through EngineCore."""
     engine_core = _bare_engine_core()
 
     event = CustomNotification(key="my_plugin", payload={"n": 1})
-    model_output = EMPTY_MODEL_RUNNER_OUTPUT
-    model_output.worker_notifications = [event]
-    try:
-        outputs: dict[int, EngineCoreOutputs] = {}
-        engine_core._collect_step_notifications(model_output, outputs)
-    finally:
-        model_output.worker_notifications = None
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._collect_step_notifications(_model_output([event]), outputs)
 
     assert outputs[0].engine_notifications == [event]
+
+
+def test_collect_is_noop_without_worker_notifications():
+    """A step that produced no events must not manufacture an outputs entry."""
+    engine_core = _bare_engine_core()
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._collect_step_notifications(_model_output(), outputs)
+
+    assert outputs == {}
+
+
+def test_engine_core_outputs_round_trip_over_the_wire():
+    """EngineCoreOutputs is array_like, so the appended field is positional.
+
+    omit_defaults does not trim trailing fields for array_like structs, so
+    every message carries the extra element once this field exists; non-Python
+    frontends decode by position and reject a longer array than they know.
+    """
+    event = CustomNotification(key="my_plugin", payload={"count": 5})
+    encoded = msgspec.msgpack.encode(
+        EngineCoreOutputs(engine_index=1, engine_notifications=[event])
+    )
+
+    as_array = msgspec.msgpack.decode(encoded)
+    assert isinstance(as_array, list)
+    assert as_array[-1] == [
+        {"type": "custom", "key": "my_plugin", "payload": {"count": 5}}
+    ]
+
+    decoded = msgspec.msgpack.decode(encoded, type=EngineCoreOutputs)
+    assert decoded.engine_notifications == [event]
+
+
+def test_proc_broadcasts_to_every_frontend():
+    """One-shot events must reach all API servers, not just one client's
+    step outputs, or every other frontend stays permanently stale."""
+    proc = EngineCoreProc.__new__(EngineCoreProc)
+    proc.addresses = SimpleNamespace(outputs=["a", "b", "c"])
+    proc.output_queue = queue.Queue()
+
+    event = CustomNotification(key="my_plugin")
+    proc._publish_notifications([event])
+
+    delivered = [proc.output_queue.get_nowait() for _ in range(3)]
+    assert [client_index for client_index, _ in delivered] == [0, 1, 2]
+    assert all(out.engine_notifications == [event] for _, out in delivered)
+    assert proc.output_queue.empty()

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -19,7 +19,6 @@ from vllm.v1.notifications import (
     publish_worker_notification,
     take_worker_notifications,
 )
-from vllm.v1.outputs import ModelRunnerOutput
 
 
 @pytest.fixture(autouse=True)
@@ -124,32 +123,66 @@ def test_worker_notifications_survive_until_the_first_drain():
     assert take_worker_notifications() == [first, second]
 
 
-def _model_output(
-    notifications: list[CustomNotification] | None = None,
-) -> ModelRunnerOutput:
-    return ModelRunnerOutput(
-        req_ids=[], req_id_to_index={}, worker_notifications=notifications
-    )
-
-
-def test_collect_forwards_worker_notifications():
-    """Worker-sourced events flow out through EngineCore."""
+def _gathering_engine_core(per_rank) -> EngineCore:
+    """An EngineCore whose executor answers take_notifications with per_rank."""
     engine_core = _bare_engine_core()
+    executor = SimpleNamespace(collective_rpc=lambda method: per_rank)
+    engine_core.model_executor = executor
+    return engine_core
 
-    event = CustomNotification(key="my_plugin", payload={"n": 1})
+
+def test_gather_keeps_every_rank():
+    """The point of gathering: a rank-0-only reply would drop the rest.
+
+    Per-rank producers (e.g. a weight loader reporting each TP rank's transfer)
+    are the reason this cannot collapse to outputs[0].
+    """
+    rank0 = CustomNotification(key="my_plugin", payload={"rank": 0})
+    rank1 = CustomNotification(key="my_plugin", payload={"rank": 1})
+    rank2 = CustomNotification(key="my_plugin", payload={"rank": 2})
+    engine_core = _gathering_engine_core([[rank0], [rank1], [rank2]])
+
+    engine_core.gather_worker_notifications()
+
     outputs: dict[int, EngineCoreOutputs] = {}
-    engine_core._collect_step_notifications(_model_output([event]), outputs)
+    engine_core._flush_notifications(outputs)
+    assert outputs[0].engine_notifications == [rank0, rank1, rank2]
 
+
+def test_gather_publishes_nothing_when_all_ranks_are_quiet():
+    engine_core = _gathering_engine_core([[], [], []])
+
+    engine_core.gather_worker_notifications()
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
+    assert outputs == {}
+
+
+def test_gather_tolerates_ranks_that_cannot_report():
+    """Workers without the method reply None; that must not break the merge."""
+    event = CustomNotification(key="my_plugin", payload={"rank": 1})
+    engine_core = _gathering_engine_core([None, [event]])
+
+    engine_core.gather_worker_notifications()
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
     assert outputs[0].engine_notifications == [event]
 
 
-def test_collect_is_noop_without_worker_notifications():
-    """A step that produced no events must not manufacture an outputs entry."""
+def test_gather_never_raises_into_the_engine():
+    """A metrics channel must not take down an engine operation."""
     engine_core = _bare_engine_core()
 
-    outputs: dict[int, EngineCoreOutputs] = {}
-    engine_core._collect_step_notifications(_model_output(), outputs)
+    def boom(method):
+        raise RuntimeError("executor is gone")
 
+    engine_core.model_executor = SimpleNamespace(collective_rpc=boom)
+    engine_core.gather_worker_notifications()
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
     assert outputs == {}
 
 

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for the in-process engine-notification buffer.
+"""Tests for the engine-notification buffer and cross-rank gather.
 
-Hits the real `EngineCore` buffer helpers without a model: they only touch
-`_pending_notifications`, so a bare instance is enough.
+Bare `EngineCore` instances: the helpers only touch `_pending_notifications`,
+so no model is needed.
 """
 
 import queue
@@ -23,7 +23,7 @@ from vllm.v1.notifications import (
 
 @pytest.fixture(autouse=True)
 def _drain_worker_buffer():
-    """The worker buffer is process-local; don't leak events between tests."""
+    """Process-local buffer; don't leak events between tests."""
     take_worker_notifications()
     yield
     take_worker_notifications()
@@ -36,11 +36,7 @@ def _bare_engine_core() -> EngineCore:
 
 
 def test_notifications_accumulate_additively():
-    """Everything queued before a flush comes out, in order.
-
-    The additive contract: no coalescing (e.g. latest-per-type), or counter
-    increments would get lost.
-    """
+    """Additive: no coalescing, or counter increments would get lost."""
     engine_core = _bare_engine_core()
 
     first = CustomNotification(key="my_plugin", payload={"n": 1})
@@ -103,18 +99,17 @@ def test_worker_publish_take_roundtrip():
     publish_worker_notification(event)
 
     assert take_worker_notifications() == [event]
-    # Second take drained; None rather than [] keeps the empty step allocation-free.
+    # None rather than [], so the quiet path allocates nothing.
     assert take_worker_notifications() is None
 
 
 def test_empty_drain_allocates_nothing():
-    """The per-step common case: no producer installed, no list built."""
+    """No producer installed builds no list."""
     assert take_worker_notifications() is None
 
 
 def test_worker_notifications_survive_until_the_first_drain():
-    """Producers that only run during model load publish before any step, so
-    the buffer must hold rather than require a step to be in flight."""
+    """Load-time producers publish before any gather runs."""
     first = CustomNotification(key="my_plugin", payload={"n": 1})
     second = CustomNotification(key="my_plugin", payload={"n": 2})
     publish_worker_notification(first)
@@ -124,7 +119,7 @@ def test_worker_notifications_survive_until_the_first_drain():
 
 
 def _gathering_engine_core(per_rank) -> EngineCore:
-    """An EngineCore whose executor answers take_notifications with per_rank."""
+    """EngineCore whose executor answers take_notifications with per_rank."""
     engine_core = _bare_engine_core()
     executor = SimpleNamespace(collective_rpc=lambda method: per_rank)
     engine_core.model_executor = executor
@@ -132,11 +127,7 @@ def _gathering_engine_core(per_rank) -> EngineCore:
 
 
 def test_gather_keeps_every_rank():
-    """The point of gathering: a rank-0-only reply would drop the rest.
-
-    Per-rank producers (e.g. a weight loader reporting each TP rank's transfer)
-    are the reason this cannot collapse to outputs[0].
-    """
+    """A rank-0-only reply would drop per-rank producers entirely."""
     rank0 = CustomNotification(key="my_plugin", payload={"rank": 0})
     rank1 = CustomNotification(key="my_plugin", payload={"rank": 1})
     rank2 = CustomNotification(key="my_plugin", payload={"rank": 2})
@@ -160,7 +151,7 @@ def test_gather_publishes_nothing_when_all_ranks_are_quiet():
 
 
 def test_gather_tolerates_ranks_that_cannot_report():
-    """Workers without the method reply None; that must not break the merge."""
+    """A worker without the method replies None."""
     event = CustomNotification(key="my_plugin", payload={"rank": 1})
     engine_core = _gathering_engine_core([None, [event]])
 
@@ -187,11 +178,10 @@ def test_gather_never_raises_into_the_engine():
 
 
 def test_engine_core_outputs_round_trip_over_the_wire():
-    """EngineCoreOutputs is array_like, so the appended field is positional.
+    """array_like, so the field is positional and always present.
 
-    omit_defaults does not trim trailing fields for array_like structs, so
-    every message carries the extra element once this field exists; non-Python
-    frontends decode by position and reject a longer array than they know.
+    omit_defaults does not trim trailing fields, and non-Python frontends
+    reject an array longer than they know.
     """
     event = CustomNotification(key="my_plugin", payload={"count": 5})
     encoded = msgspec.msgpack.encode(
@@ -209,8 +199,7 @@ def test_engine_core_outputs_round_trip_over_the_wire():
 
 
 def test_proc_broadcasts_to_every_frontend():
-    """One-shot events must reach all API servers, not just one client's
-    step outputs, or every other frontend stays permanently stale."""
+    """Every API server gets the event, not just one."""
     proc = EngineCoreProc.__new__(EngineCoreProc)
     proc.addresses = SimpleNamespace(outputs=["a", "b", "c"])
     proc.output_queue = queue.Queue()

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -104,8 +104,13 @@ def test_worker_publish_take_roundtrip():
     publish_worker_notification(event)
 
     assert take_worker_notifications() == [event]
-    # Second take is empty, it drained.
-    assert take_worker_notifications() == []
+    # Second take drained; None rather than [] keeps the empty step allocation-free.
+    assert take_worker_notifications() is None
+
+
+def test_empty_drain_allocates_nothing():
+    """The per-step common case: no producer installed, no list built."""
+    assert take_worker_notifications() is None
 
 
 def test_worker_notifications_survive_until_the_first_drain():

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the in-process engine-notification buffer.
+
+Hits the real `EngineCore` buffer helpers without a model: they only touch
+`_pending_notifications`, so a bare instance is enough.
+"""
+
+import pytest
+
+from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.notifications import (
+    CustomNotification,
+    publish_worker_notification,
+    take_worker_notifications,
+)
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
+
+
+@pytest.fixture(autouse=True)
+def _drain_worker_buffer():
+    """The worker buffer is process-local; don't leak events between tests."""
+    take_worker_notifications()
+    yield
+    take_worker_notifications()
+
+
+def _bare_engine_core() -> EngineCore:
+    engine_core = EngineCore.__new__(EngineCore)
+    engine_core._pending_notifications = []
+    return engine_core
+
+
+def test_notifications_accumulate_additively():
+    """Everything queued before a flush comes out, in order.
+
+    The additive contract: no coalescing (e.g. latest-per-type), or counter
+    increments would get lost.
+    """
+    engine_core = _bare_engine_core()
+
+    first = CustomNotification(key="my_plugin", payload={"n": 1})
+    second = CustomNotification(key="my_plugin", payload={"n": 2})
+    engine_core._publish_notifications([first])
+    engine_core._publish_notifications([second])
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
+
+    assert outputs[0].engine_notifications == [first, second]
+
+
+def test_flush_clears_buffer_between_steps():
+    """A flush drains the buffer; later events are independent."""
+    engine_core = _bare_engine_core()
+
+    engine_core._publish_notifications([CustomNotification(key="my_plugin")])
+    first_outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(first_outputs)
+
+    second_outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(second_outputs)
+    assert second_outputs == {}
+
+    later = CustomNotification(key="my_plugin", payload={"n": 3})
+    engine_core._publish_notifications([later])
+    third_outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(third_outputs)
+    assert third_outputs[0].engine_notifications == [later]
+
+
+def test_flush_reuses_existing_outputs():
+    """Notifications attach to an existing per-engine outputs entry."""
+    engine_core = _bare_engine_core()
+
+    event = CustomNotification(key="my_plugin")
+    engine_core._publish_notifications([event])
+
+    existing = EngineCoreOutputs(engine_index=2)
+    outputs = {2: existing}
+    engine_core._flush_notifications(outputs)
+
+    assert outputs == {2: existing}
+    assert existing.engine_notifications == [event]
+
+
+def test_flush_noop_when_empty():
+    """Nothing is added to outputs when the buffer is empty."""
+    engine_core = _bare_engine_core()
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
+    assert outputs == {}
+
+
+def test_worker_publish_take_roundtrip():
+    """The out-of-tree producer path."""
+    event = CustomNotification(key="my_plugin", payload={"bytes": 1})
+    publish_worker_notification(event)
+
+    assert take_worker_notifications() == [event]
+    # Second take is empty, it drained.
+    assert take_worker_notifications() == []
+
+
+def test_worker_notifications_survive_until_the_first_drain():
+    """Producers that only run during model load publish before any step, so
+    the buffer must hold rather than require a step to be in flight."""
+    first = CustomNotification(key="my_plugin", payload={"n": 1})
+    second = CustomNotification(key="my_plugin", payload={"n": 2})
+    publish_worker_notification(first)
+    publish_worker_notification(second)
+
+    assert take_worker_notifications() == [first, second]
+
+
+def test_collect_forwards_worker_notifications():
+    """Worker-sourced events flow out through EngineCore."""
+    engine_core = _bare_engine_core()
+
+    event = CustomNotification(key="my_plugin", payload={"n": 1})
+    model_output = EMPTY_MODEL_RUNNER_OUTPUT
+    model_output.worker_notifications = [event]
+    try:
+        outputs: dict[int, EngineCoreOutputs] = {}
+        engine_core._collect_step_notifications(model_output, outputs)
+    finally:
+        model_output.worker_notifications = None
+
+    assert outputs[0].engine_notifications == [event]

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -8,18 +8,28 @@ so no model is needed.
 
 import queue
 import time
+import uuid
 from types import SimpleNamespace
 
 import msgspec
 import pytest
 
-from vllm.v1.engine import EngineCoreOutputs, core
+from vllm import SamplingParams
+from vllm.engine.arg_utils import EngineArgs
+from vllm.platforms import current_platform
+from vllm.usage.usage_lib import UsageContext
+from vllm.utils.torch_utils import set_default_torch_num_threads
+from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequest, core
 from vllm.v1.engine.core import DPEngineCoreProc, EngineCore, EngineCoreProc
+from vllm.v1.engine.core_client import EngineCoreClient
+from vllm.v1.executor.abstract import Executor
 from vllm.v1.notifications import (
     CustomNotification,
     publish_worker_notification,
     take_worker_notifications,
 )
+
+from ...utils import create_new_process_for_each_test
 
 
 @pytest.fixture(autouse=True)
@@ -276,3 +286,82 @@ def test_poll_interval_gates_the_rpc(monkeypatch):
 
     proc._maybe_gather_worker_notifications()
     assert len(gathered) == 1, "gathered again inside the interval"
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Requires a CUDA-alike platform to run a real engine.",
+)
+@create_new_process_for_each_test("spawn")
+def test_custom_notification_reaches_frontend(monkeypatch: pytest.MonkeyPatch):
+    """Full path with a real engine: a plugin-style publish inside the worker
+    process, the interval poll gather, the msgpack wire, and delivery on the
+    frontend client, interleaved with normal generation traffic."""
+    monkeypatch.setenv("VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", "0.001")
+    # The publish callable rides collective_rpc as a cloudpickle payload.
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+    engine_args = EngineArgs(model="Qwen/Qwen3-0.6B", enforce_eager=True)
+    vllm_config = engine_args.create_engine_config(UsageContext.UNKNOWN_CONTEXT)
+    executor_class = Executor.get_class(vllm_config)
+
+    with set_default_torch_num_threads(1):
+        client = EngineCoreClient.make_client(
+            multiprocess_mode=True,
+            asyncio_mode=False,
+            vllm_config=vllm_config,
+            executor_class=executor_class,
+            log_stats=False,
+        )
+
+    try:
+        # What a LoRA-hotswap plugin would emit after landing an adapter,
+        # so a router can steer matching requests to this worker.
+        adapter_loaded = {
+            "event": "adapter_loaded",
+            "adapter": "shakespeare-insults-v2",
+            "rank": 0,
+            "load_ms": 128,
+        }
+
+        def publish(worker):
+            from vllm.v1.notifications import (
+                CustomNotification,
+                publish_worker_notification,
+            )
+
+            publish_worker_notification(
+                CustomNotification(key="lora_hotswap", payload=adapter_loaded)
+            )
+            return "published"
+
+        assert client.collective_rpc(publish) == ["published"]
+
+        request_id = f"request-{uuid.uuid4()}"
+        client.add_request(
+            EngineCoreRequest(
+                request_id=request_id,
+                external_req_id=request_id,
+                prompt_token_ids=list(range(10, 30)),
+                mm_features=None,
+                sampling_params=SamplingParams(max_tokens=5),
+                pooling_params=None,
+                arrival_time=time.time(),
+                lora_request=None,
+                cache_salt=None,
+                data_parallel_rank=None,
+            )
+        )
+
+        notifications: list[CustomNotification] = []
+        finished = False
+        while not (notifications and finished):
+            outputs = client.get_output()
+            notifications.extend(outputs.engine_notifications or ())
+            finished |= any(out.finished for out in outputs.outputs)
+
+        assert notifications == [
+            CustomNotification(key="lora_hotswap", payload=adapter_loaded)
+        ]
+    finally:
+        client.shutdown()

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -7,6 +7,7 @@ so no model is needed.
 """
 
 import queue
+import threading
 import time
 import uuid
 from types import SimpleNamespace
@@ -24,6 +25,7 @@ from vllm.v1.engine.core import DPEngineCoreProc, EngineCore, EngineCoreProc
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.notifications import (
+    MAX_BUFFERED_NOTIFICATIONS,
     CustomNotification,
     publish_worker_notification,
     take_worker_notifications,
@@ -114,6 +116,18 @@ def test_worker_publish_take_roundtrip():
     assert take_worker_notifications() is None
 
 
+def test_publish_drops_oldest_at_capacity():
+    """Overflow drops the oldest so an undrained buffer stays bounded."""
+    for i in range(MAX_BUFFERED_NOTIFICATIONS + 2):
+        publish_worker_notification(CustomNotification(key="k", payload={"n": i}))
+
+    taken = take_worker_notifications()
+    assert taken is not None
+    assert len(taken) == MAX_BUFFERED_NOTIFICATIONS
+    assert taken[0].payload == {"n": 2}
+    assert taken[-1].payload == {"n": MAX_BUFFERED_NOTIFICATIONS + 1}
+
+
 def test_worker_notifications_survive_until_the_first_drain():
     """Load-time producers publish before any gather runs."""
     first = CustomNotification(key="my_plugin", payload={"n": 1})
@@ -156,31 +170,17 @@ def test_gather_publishes_nothing_when_all_ranks_are_quiet():
     assert outputs == {}
 
 
-def test_gather_tolerates_ranks_that_cannot_report():
-    """A worker without the method replies None."""
-    event = CustomNotification(key="my_plugin", payload={"rank": 1})
-    engine_core = _gathering_engine_core([None, [event]])
-
-    engine_core.gather_worker_notifications()
-
-    outputs: dict[int, EngineCoreOutputs] = {}
-    engine_core._flush_notifications(outputs)
-    assert outputs[0].engine_notifications == [event]
-
-
-def test_gather_never_raises_into_the_engine():
-    """A metrics channel must not take down an engine operation."""
+def test_gather_propagates_executor_failure():
+    """A swallowed failure would leave stale rank replies queued for the
+    next collective."""
     engine_core = _bare_engine_core()
 
     def boom(method):
         raise RuntimeError("executor is gone")
 
     engine_core.model_executor = SimpleNamespace(collective_rpc=boom)
-    engine_core.gather_worker_notifications()
-
-    outputs: dict[int, EngineCoreOutputs] = {}
-    engine_core._flush_notifications(outputs)
-    assert outputs == {}
+    with pytest.raises(RuntimeError, match="executor is gone"):
+        engine_core.gather_worker_notifications()
 
 
 def test_engine_core_outputs_round_trip_over_the_wire():
@@ -220,11 +220,7 @@ def test_proc_broadcasts_to_every_frontend():
 
 
 def test_dp_busy_loop_gathers_on_startup():
-    """The DP override of run_busy_loop shipped without either gather call
-    once; pin the startup gather so it cannot regress. Pre-loop placement is
-    the point: the ordering test below cannot tell pre-loop from
-    first-iteration, and a first-iteration gather would be an unthrottled rpc
-    per iteration."""
+    """Pre-loop placement: an in-loop gather would be an unthrottled rpc."""
     proc = DPEngineCoreProc.__new__(DPEngineCoreProc)
     gathered = []
     proc.gather_worker_notifications = lambda: gathered.append("startup")
@@ -236,28 +232,41 @@ def test_dp_busy_loop_gathers_on_startup():
     assert gathered == ["startup"]
 
 
-def test_dp_busy_loop_polls_inside_each_iteration():
-    """The interval poll sits between input processing and the step, matching
-    the non-DP loop."""
-    proc = DPEngineCoreProc.__new__(DPEngineCoreProc)
-    calls = []
-    proc.gather_worker_notifications = lambda: calls.append("startup")
-    proc._handle_shutdown = lambda: True
-    proc._process_input_queue = lambda: calls.append("input")
-    proc._maybe_publish_request_counts = lambda: None
+def test_post_step_polls_for_notifications():
+    """Both engine flavors route through post_step, so the poll lives there."""
+    engine_core = _bare_engine_core()
+    engine_core.check_for_draft_tokens = False
+    polled = []
+    engine_core._maybe_gather_worker_notifications = lambda: polled.append(1)
+
+    engine_core.post_step(model_executed=True)
+
+    assert polled == [1]
+
+
+def test_idle_wait_polls_for_notifications(monkeypatch):
+    """The idle input-queue wait must reach the poll, or idle-published
+    events sit until the next request arrives."""
+    monkeypatch.setattr(core.envs, "VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", 0.01)
+    proc = EngineCoreProc.__new__(EngineCoreProc)
+    proc.input_queue = queue.Queue()
+    proc.aborts_queue = queue.Queue()
+    proc.process_input_queue_block = True
+    proc.has_work = lambda: False
+    proc.is_running = lambda: True
+    proc._notify_idle_state_callbacks = lambda: None
+    polled = []
 
     def poll():
-        calls.append("poll")
-        # The rest of the iteration needs a scheduler and an executor; the
-        # wiring is proven by reaching here, so stop the loop.
+        polled.append(1)
         raise SystemExit
 
     proc._maybe_gather_worker_notifications = poll
 
     with pytest.raises(SystemExit):
-        proc.run_busy_loop()
+        proc._process_input_queue()
 
-    assert calls == ["startup", "input", "poll"]
+    assert polled == [1]
 
 
 def test_poll_is_off_by_default(monkeypatch):
@@ -288,16 +297,33 @@ def test_poll_interval_gates_the_rpc(monkeypatch):
     assert len(gathered) == 1, "gathered again inside the interval"
 
 
+def _wait_for_outputs(client, predicate, timeout_s: float = 180.0):
+    """Bounded drain of client.get_output(), which otherwise blocks forever."""
+    box: list = []
+    done = threading.Event()
+
+    def drain():
+        while not done.is_set():
+            outputs = client.get_output()
+            if result := predicate(outputs):
+                box.append(result)
+                done.set()
+
+    threading.Thread(target=drain, daemon=True).start()
+    assert done.wait(timeout_s), "timed out waiting for engine output"
+    return box[0]
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
     reason="Requires a CUDA-alike platform to run a real engine.",
 )
 @create_new_process_for_each_test("spawn")
 def test_custom_notification_reaches_frontend(monkeypatch: pytest.MonkeyPatch):
-    """Full path with a real engine: a plugin-style publish inside the worker
-    process, the interval poll gather, the msgpack wire, and delivery on the
-    frontend client, interleaved with normal generation traffic."""
-    monkeypatch.setenv("VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", "0.001")
+    """Full path with a real engine: worker-side publishes delivered through
+    both the idle-wait poll and the post-step poll, msgpack-decoded at the
+    frontend client."""
+    monkeypatch.setenv("VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", "0.05")
     # The publish callable rides collective_rpc as a cloudpickle payload.
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
@@ -315,8 +341,7 @@ def test_custom_notification_reaches_frontend(monkeypatch: pytest.MonkeyPatch):
         )
 
     try:
-        # What a LoRA-hotswap plugin would emit after landing an adapter,
-        # so a router can steer matching requests to this worker.
+        # What a LoRA-hotswap plugin would emit after landing an adapter.
         adapter_loaded = {
             "event": "adapter_loaded",
             "adapter": "shakespeare-insults-v2",
@@ -324,19 +349,32 @@ def test_custom_notification_reaches_frontend(monkeypatch: pytest.MonkeyPatch):
             "load_ms": 128,
         }
 
-        def publish(worker):
+        def publish(worker, payload):
             from vllm.v1.notifications import (
                 CustomNotification,
                 publish_worker_notification,
             )
 
             publish_worker_notification(
-                CustomNotification(key="lora_hotswap", payload=adapter_loaded)
+                CustomNotification(key="lora_hotswap", payload=payload)
             )
             return "published"
 
-        assert client.collective_rpc(publish) == ["published"]
+        assert client.collective_rpc(publish, args=(adapter_loaded,)) == ["published"]
 
+        # Nothing queued: only the idle-wait poll can deliver this.
+        notifications = _wait_for_outputs(
+            client, lambda outputs: outputs.engine_notifications
+        )
+        assert notifications == [
+            CustomNotification(key="lora_hotswap", payload=adapter_loaded)
+        ]
+
+        # Published mid-generation: the post-step poll delivers this one.
+        adapter_evicted = {
+            "event": "adapter_evicted",
+            "adapter": "shakespeare-insults-v2",
+        }
         request_id = f"request-{uuid.uuid4()}"
         client.add_request(
             EngineCoreRequest(
@@ -344,7 +382,7 @@ def test_custom_notification_reaches_frontend(monkeypatch: pytest.MonkeyPatch):
                 external_req_id=request_id,
                 prompt_token_ids=list(range(10, 30)),
                 mm_features=None,
-                sampling_params=SamplingParams(max_tokens=5),
+                sampling_params=SamplingParams(max_tokens=64),
                 pooling_params=None,
                 arrival_time=time.time(),
                 lora_request=None,
@@ -352,16 +390,18 @@ def test_custom_notification_reaches_frontend(monkeypatch: pytest.MonkeyPatch):
                 data_parallel_rank=None,
             )
         )
+        assert client.collective_rpc(publish, args=(adapter_evicted,)) == ["published"]
 
-        notifications: list[CustomNotification] = []
-        finished = False
-        while not (notifications and finished):
-            outputs = client.get_output()
-            notifications.extend(outputs.engine_notifications or ())
-            finished |= any(out.finished for out in outputs.outputs)
+        seen: dict = {"notifications": [], "finished": False}
 
-        assert notifications == [
-            CustomNotification(key="lora_hotswap", payload=adapter_loaded)
+        def notified_and_finished(outputs):
+            seen["notifications"].extend(outputs.engine_notifications or ())
+            seen["finished"] |= any(out.finished for out in outputs.outputs)
+            return seen["notifications"] and seen["finished"]
+
+        _wait_for_outputs(client, notified_and_finished)
+        assert seen["notifications"] == [
+            CustomNotification(key="lora_hotswap", payload=adapter_evicted)
         ]
     finally:
         client.shutdown()

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -7,13 +7,14 @@ so no model is needed.
 """
 
 import queue
+import time
 from types import SimpleNamespace
 
 import msgspec
 import pytest
 
-from vllm.v1.engine import EngineCoreOutputs
-from vllm.v1.engine.core import EngineCore, EngineCoreProc
+from vllm.v1.engine import EngineCoreOutputs, core
+from vllm.v1.engine.core import DPEngineCoreProc, EngineCore, EngineCoreProc
 from vllm.v1.notifications import (
     CustomNotification,
     publish_worker_notification,
@@ -100,11 +101,6 @@ def test_worker_publish_take_roundtrip():
 
     assert take_worker_notifications() == [event]
     # None rather than [], so the quiet path allocates nothing.
-    assert take_worker_notifications() is None
-
-
-def test_empty_drain_allocates_nothing():
-    """No producer installed builds no list."""
     assert take_worker_notifications() is None
 
 
@@ -211,3 +207,72 @@ def test_proc_broadcasts_to_every_frontend():
     assert [client_index for client_index, _ in delivered] == [0, 1, 2]
     assert all(out.engine_notifications == [event] for _, out in delivered)
     assert proc.output_queue.empty()
+
+
+def test_dp_busy_loop_gathers_on_startup():
+    """The DP override of run_busy_loop shipped without either gather call
+    once; pin the startup gather so it cannot regress. Pre-loop placement is
+    the point: the ordering test below cannot tell pre-loop from
+    first-iteration, and a first-iteration gather would be an unthrottled rpc
+    per iteration."""
+    proc = DPEngineCoreProc.__new__(DPEngineCoreProc)
+    gathered = []
+    proc.gather_worker_notifications = lambda: gathered.append("startup")
+    proc._handle_shutdown = lambda: False
+
+    with pytest.raises(SystemExit):
+        proc.run_busy_loop()
+
+    assert gathered == ["startup"]
+
+
+def test_dp_busy_loop_polls_inside_each_iteration():
+    """The interval poll sits between input processing and the step, matching
+    the non-DP loop."""
+    proc = DPEngineCoreProc.__new__(DPEngineCoreProc)
+    calls = []
+    proc.gather_worker_notifications = lambda: calls.append("startup")
+    proc._handle_shutdown = lambda: True
+    proc._process_input_queue = lambda: calls.append("input")
+    proc._maybe_publish_request_counts = lambda: None
+
+    def poll():
+        calls.append("poll")
+        # The rest of the iteration needs a scheduler and an executor; the
+        # wiring is proven by reaching here, so stop the loop.
+        raise SystemExit
+
+    proc._maybe_gather_worker_notifications = poll
+
+    with pytest.raises(SystemExit):
+        proc.run_busy_loop()
+
+    assert calls == ["startup", "input", "poll"]
+
+
+def test_poll_is_off_by_default(monkeypatch):
+    """Interval 0 must mean no gather rpc at all, however overdue."""
+    monkeypatch.setattr(core.envs, "VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", 0.0)
+    proc = EngineCoreProc.__new__(EngineCoreProc)
+    proc._last_notification_gather = float("-inf")
+    gathered = []
+    proc.gather_worker_notifications = lambda: gathered.append(1)
+
+    proc._maybe_gather_worker_notifications()
+
+    assert gathered == []
+
+
+def test_poll_interval_gates_the_rpc(monkeypatch):
+    """One gather when due, then nothing until the interval passes again."""
+    monkeypatch.setattr(core.envs, "VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", 60.0)
+    proc = EngineCoreProc.__new__(EngineCoreProc)
+    proc._last_notification_gather = time.monotonic() - 120.0
+    gathered = []
+    proc.gather_worker_notifications = lambda: gathered.append(1)
+
+    proc._maybe_gather_worker_notifications()
+    assert len(gathered) == 1
+
+    proc._maybe_gather_worker_notifications()
+    assert len(gathered) == 1, "gathered again inside the interval"

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -22,7 +22,7 @@ from vllm.usage.usage_lib import UsageContext
 from vllm.utils.torch_utils import set_default_torch_num_threads
 from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequest, core
 from vllm.v1.engine.core import DPEngineCoreProc, EngineCore, EngineCoreProc
-from vllm.v1.engine.core_client import EngineCoreClient
+from vllm.v1.engine.core_client import EngineCoreClient, InprocClient
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.notifications import (
     MAX_BUFFERED_NOTIFICATIONS,
@@ -126,6 +126,57 @@ def test_publish_drops_oldest_at_capacity():
     assert len(taken) == MAX_BUFFERED_NOTIFICATIONS
     assert taken[0].payload == {"n": 2}
     assert taken[-1].payload == {"n": MAX_BUFFERED_NOTIFICATIONS + 1}
+
+
+def test_publish_take_race_is_safe():
+    """Concurrent producers and a drainer share the buffer; per-producer
+    order must survive and nothing may raise or duplicate."""
+    errors: list[BaseException] = []
+    received: list[CustomNotification] = []
+
+    def produce(key: str):
+        try:
+            for i in range(2000):
+                publish_worker_notification(
+                    CustomNotification(key=key, payload={"n": i})
+                )
+        except BaseException as e:
+            errors.append(e)
+
+    producers = [
+        threading.Thread(target=produce, args=(f"producer-{i}",)) for i in range(4)
+    ]
+    for producer in producers:
+        producer.start()
+    while any(producer.is_alive() for producer in producers):
+        received.extend(take_worker_notifications() or ())
+    for producer in producers:
+        producer.join()
+    received.extend(take_worker_notifications() or ())
+
+    assert not errors
+    assert take_worker_notifications() is None
+    # Strictly increasing per producer: no duplicates, no reordering; gaps
+    # are legal (the cap drops the oldest).
+    last_seen: dict[str, int] = {}
+    for event in received:
+        assert event.payload["n"] > last_seen.get(event.key, -1)
+        last_seen[event.key] = event.payload["n"]
+
+
+def test_inproc_get_output_flushes_post_step_notifications():
+    """A notification gathered in post_step must ride the same get_output
+    call; a request-less frontend has no reason to call again."""
+    event = CustomNotification(key="my_plugin")
+    engine_core = _bare_engine_core()
+    engine_core.step_fn = lambda: ({}, False)
+    engine_core.post_step = lambda model_executed: engine_core._publish_notifications(
+        [event]
+    )
+    client = InprocClient.__new__(InprocClient)
+    client.engine_core = engine_core
+
+    assert client.get_output().engine_notifications == [event]
 
 
 def test_worker_notifications_survive_until_the_first_drain():
@@ -300,18 +351,37 @@ def test_poll_interval_gates_the_rpc(monkeypatch):
 def _wait_for_outputs(client, predicate, timeout_s: float = 180.0):
     """Bounded drain of client.get_output(), which otherwise blocks forever."""
     box: list = []
+    error: list[BaseException] = []
     done = threading.Event()
 
     def drain():
-        while not done.is_set():
-            outputs = client.get_output()
-            if result := predicate(outputs):
-                box.append(result)
-                done.set()
+        try:
+            while not done.is_set():
+                outputs = client.get_output()
+                if result := predicate(outputs):
+                    box.append(result)
+                    return
+        except BaseException as e:
+            error.append(e)
+        finally:
+            done.set()
 
     threading.Thread(target=drain, daemon=True).start()
     assert done.wait(timeout_s), "timed out waiting for engine output"
+    if error:
+        raise error[0]
     return box[0]
+
+
+def test_wait_for_outputs_reraises_drain_errors():
+    """An engine failure must surface as itself, not as a timeout."""
+
+    class FailingClient:
+        def get_output(self):
+            raise RuntimeError("engine died")
+
+    with pytest.raises(RuntimeError, match="engine died"):
+        _wait_for_outputs(FailingClient(), lambda outputs: True, timeout_s=5.0)
 
 
 @pytest.mark.skipif(

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -27,9 +27,13 @@ from vllm.v1.executor.abstract import Executor
 from vllm.v1.notifications import (
     MAX_BUFFERED_NOTIFICATIONS,
     CustomNotification,
+    EngineNotification,
+    LoRALoadEvent,
+    has_pending_worker_notifications,
     publish_worker_notification,
     take_worker_notifications,
 )
+from vllm.v1.outputs import ModelRunnerOutput
 
 from ...utils import create_new_process_for_each_test
 
@@ -456,3 +460,104 @@ def test_custom_notification_reaches_frontend(monkeypatch: pytest.MonkeyPatch):
         ]
     finally:
         client.shutdown()
+
+
+def test_lora_load_event_round_trips_through_msgpack():
+    """Tagged map inside the array_like outputs; omit_defaults trims empties."""
+    event = LoRALoadEvent(
+        gpu_adapters=["alpha"],
+        cpu_adapters=["alpha", "beta"],
+        pinned_adapters=["alpha"],
+    )
+    encoded = msgspec.msgpack.encode(
+        EngineCoreOutputs(engine_index=1, engine_notifications=[event])
+    )
+
+    as_array = msgspec.msgpack.decode(encoded)
+    assert as_array[-1] == [
+        {
+            "type": "lora_load_event",
+            "gpu_adapters": ["alpha"],
+            "cpu_adapters": ["alpha", "beta"],
+            "pinned_adapters": ["alpha"],
+        }
+    ]
+    decoded = msgspec.msgpack.decode(encoded, type=EngineCoreOutputs)
+    assert decoded.engine_notifications == [event]
+
+    empty = msgspec.msgpack.decode(msgspec.msgpack.encode(LoRALoadEvent()))
+    assert empty == {"type": "lora_load_event"}
+
+
+def test_unknown_notification_tag_fails_fast():
+    """The union is version-lockstep with the engine, like the rest of
+    EngineCoreOutputs; a skipped event would hide a deployment mismatch."""
+    future_event = msgspec.msgpack.encode({"type": "graceful_shutdown", "step": 1})
+    with pytest.raises(msgspec.ValidationError):
+        msgspec.msgpack.decode(future_event, type=EngineNotification)
+
+
+def test_doorbell_check_does_not_drain():
+    publish_worker_notification(CustomNotification(key="my_plugin"))
+    assert has_pending_worker_notifications()
+    assert has_pending_worker_notifications(), "the check must not consume"
+    take_worker_notifications()
+    assert not has_pending_worker_notifications()
+
+
+def test_step_gathers_when_output_rank_rings_doorbell():
+    """The step path gathers only on the doorbell, so a quiet step costs no
+    rpc, and a rung one delivers in the same step's outputs."""
+    event = LoRALoadEvent(gpu_adapters=["alpha"], cpu_adapters=["alpha"])
+    rpcs: list[str] = []
+
+    def collective_rpc(method):
+        rpcs.append(method)
+        return [[event], []]
+
+    engine_core = _bare_engine_core()
+    engine_core.model_executor = SimpleNamespace(collective_rpc=collective_rpc)
+
+    quiet = ModelRunnerOutput(req_ids=[], req_id_to_index={})
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._collect_step_notifications(quiet, outputs)
+    assert rpcs == []
+    assert outputs == {}
+
+    rung = ModelRunnerOutput(
+        req_ids=[], req_id_to_index={}, worker_notifications_pending=True
+    )
+    engine_core._collect_step_notifications(rung, outputs)
+    assert rpcs == ["take_notifications"]
+    assert outputs[0].engine_notifications == [event]
+
+
+@pytest.mark.parametrize(
+    ("method", "arg"),
+    [("add_lora", "lora-request"), ("remove_lora", 7), ("pin_lora", 7)],
+)
+def test_lora_rpcs_gather_after_the_executor_call(method, arg):
+    """Adapter changes on an idle engine have no step to ring the doorbell,
+    so the rpc itself triggers the gather, after the executor mutation."""
+    event = LoRALoadEvent(cpu_adapters=["alpha"])
+    calls: list[tuple] = []
+
+    def executor_op(value):
+        calls.append((method, value))
+        return "executor-result"
+
+    def collective_rpc(name):
+        calls.append(("collective_rpc", name))
+        return [[event]]
+
+    engine_core = _bare_engine_core()
+    engine_core.model_executor = SimpleNamespace(
+        collective_rpc=collective_rpc, **{method: executor_op}
+    )
+
+    assert getattr(engine_core, method)(arg) == "executor-result"
+    assert calls == [(method, arg), ("collective_rpc", "take_notifications")]
+
+    outputs: dict[int, EngineCoreOutputs] = {}
+    engine_core._flush_notifications(outputs)
+    assert outputs[0].engine_notifications == [event]

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -97,15 +97,6 @@ def test_flush_reuses_existing_outputs():
     assert existing.engine_notifications == [event]
 
 
-def test_flush_noop_when_empty():
-    """Nothing is added to outputs when the buffer is empty."""
-    engine_core = _bare_engine_core()
-
-    outputs: dict[int, EngineCoreOutputs] = {}
-    engine_core._flush_notifications(outputs)
-    assert outputs == {}
-
-
 def test_worker_publish_take_roundtrip():
     """The out-of-tree producer path."""
     event = CustomNotification(key="my_plugin", payload={"bytes": 1})
@@ -177,16 +168,6 @@ def test_inproc_get_output_flushes_post_step_notifications():
     client.engine_core = engine_core
 
     assert client.get_output().engine_notifications == [event]
-
-
-def test_worker_notifications_survive_until_the_first_drain():
-    """Load-time producers publish before any gather runs."""
-    first = CustomNotification(key="my_plugin", payload={"n": 1})
-    second = CustomNotification(key="my_plugin", payload={"n": 2})
-    publish_worker_notification(first)
-    publish_worker_notification(second)
-
-    assert take_worker_notifications() == [first, second]
 
 
 def _gathering_engine_core(per_rank) -> EngineCore:

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -469,6 +469,7 @@ def test_lora_load_event_round_trips_through_msgpack():
         gpu_adapters=["alpha"],
         cpu_adapters=["alpha", "beta"],
         pinned_adapters=["alpha"],
+        ranks={"alpha": 8, "beta": 16},
         loads=[LoRALoadTiming("beta", "load", 0.25)],
     )
     encoded = msgspec.msgpack.encode(
@@ -482,6 +483,7 @@ def test_lora_load_event_round_trips_through_msgpack():
             "gpu_adapters": ["alpha"],
             "cpu_adapters": ["alpha", "beta"],
             "pinned_adapters": ["alpha"],
+            "ranks": {"alpha": 8, "beta": 16},
             "loads": [{"adapter_name": "beta", "transition": "load", "seconds": 0.25}],
         }
     ]

--- a/tests/v1/engine/test_notifications.py
+++ b/tests/v1/engine/test_notifications.py
@@ -29,6 +29,7 @@ from vllm.v1.notifications import (
     CustomNotification,
     EngineNotification,
     LoRALoadEvent,
+    LoRALoadTiming,
     has_pending_worker_notifications,
     publish_worker_notification,
     take_worker_notifications,
@@ -468,6 +469,7 @@ def test_lora_load_event_round_trips_through_msgpack():
         gpu_adapters=["alpha"],
         cpu_adapters=["alpha", "beta"],
         pinned_adapters=["alpha"],
+        loads=[LoRALoadTiming("beta", "load", 0.25)],
     )
     encoded = msgspec.msgpack.encode(
         EngineCoreOutputs(engine_index=1, engine_notifications=[event])
@@ -480,6 +482,7 @@ def test_lora_load_event_round_trips_through_msgpack():
             "gpu_adapters": ["alpha"],
             "cpu_adapters": ["alpha", "beta"],
             "pinned_adapters": ["alpha"],
+            "loads": [{"adapter_name": "beta", "transition": "load", "seconds": 0.25}],
         }
     ]
     decoded = msgspec.msgpack.decode(encoded, type=EngineCoreOutputs)

--- a/tests/v1/metrics/test_lora_metrics.py
+++ b/tests/v1/metrics/test_lora_metrics.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PrometheusStatLogger's LoRA load-event consumer, on a private registry so
+the test does not fight the process-global one."""
+
+import pytest
+from prometheus_client import CollectorRegistry, Gauge
+
+from vllm.v1.metrics.loggers import PrometheusStatLogger
+from vllm.v1.notifications import CustomNotification, LoRALoadEvent
+
+LABELNAMES = ["model_name", "engine"]
+
+
+def _lora_logger(registry: CollectorRegistry, engine_indexes=(0,)):
+    """A PrometheusStatLogger with only the LoRA gauges, built the way
+    __init__ builds them."""
+    logger = PrometheusStatLogger.__new__(PrometheusStatLogger)
+    logger.per_engine_labelvalues = {
+        idx: ["test-model", str(idx)] for idx in engine_indexes
+    }
+    gpu = Gauge("vllm:num_gpu_loaded_lora_adapters", "", LABELNAMES, registry=registry)
+    cpu = Gauge("vllm:num_cpu_loaded_lora_adapters", "", LABELNAMES, registry=registry)
+    logger.gauge_lora_gpu_adapters = {
+        idx: gpu.labels(*labels)
+        for idx, labels in logger.per_engine_labelvalues.items()
+    }
+    logger.gauge_lora_cpu_adapters = {
+        idx: cpu.labels(*labels)
+        for idx, labels in logger.per_engine_labelvalues.items()
+    }
+    logger.gauge_lora_adapter_loaded = Gauge(
+        "vllm:lora_adapter_loaded",
+        "",
+        LABELNAMES + ["adapter_name", "level", "pinned"],
+        registry=registry,
+    )
+    logger._lora_loaded_series = {}
+    return logger
+
+
+def _loaded_series(registry: CollectorRegistry) -> dict[tuple[str, str, str], float]:
+    """(adapter_name, level, pinned) -> value for every live series."""
+    return {
+        (s.labels["adapter_name"], s.labels["level"], s.labels["pinned"]): s.value
+        for metric in registry.collect()
+        if metric.name == "vllm:lora_adapter_loaded"
+        for s in metric.samples
+    }
+
+
+def _count(registry: CollectorRegistry, name: str, engine: str = "0") -> float:
+    for metric in registry.collect():
+        if metric.name == name:
+            for s in metric.samples:
+                if s.labels["engine"] == engine:
+                    return s.value
+    raise AssertionError(f"{name} has no sample for engine {engine}")
+
+
+def test_load_event_publishes_one_series_per_resident_adapter():
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry)
+
+    logger.record_engine_notifications(
+        [
+            LoRALoadEvent(
+                gpu_adapters=["alpha", "beta"],
+                cpu_adapters=["alpha", "beta", "gamma"],
+                pinned_adapters=["alpha"],
+            )
+        ]
+    )
+
+    assert _loaded_series(registry) == {
+        ("alpha", "gpu", "true"): 1.0,
+        ("beta", "gpu", "false"): 1.0,
+        ("gamma", "cpu", "false"): 1.0,
+    }
+    assert _count(registry, "vllm:num_gpu_loaded_lora_adapters") == 2
+    assert _count(registry, "vllm:num_cpu_loaded_lora_adapters") == 3
+
+
+def test_eviction_removes_the_series():
+    """A snapshot replaces the previous one: evicted adapters must not keep
+    reading as resident, and a tier change must not leave the old series."""
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry)
+    logger.record_engine_notifications(
+        [LoRALoadEvent(gpu_adapters=["alpha", "beta"], cpu_adapters=["alpha", "beta"])]
+    )
+
+    logger.record_engine_notifications(
+        [LoRALoadEvent(gpu_adapters=["gamma"], cpu_adapters=["beta", "gamma"])]
+    )
+
+    assert _loaded_series(registry) == {
+        ("beta", "cpu", "false"): 1.0,
+        ("gamma", "gpu", "false"): 1.0,
+    }
+    assert _count(registry, "vllm:num_gpu_loaded_lora_adapters") == 1
+    assert _count(registry, "vllm:num_cpu_loaded_lora_adapters") == 2
+
+
+def test_empty_snapshot_clears_everything():
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry)
+    logger.record_engine_notifications(
+        [LoRALoadEvent(gpu_adapters=["alpha"], cpu_adapters=["alpha"])]
+    )
+
+    logger.record_engine_notifications([LoRALoadEvent()])
+
+    assert _loaded_series(registry) == {}
+    assert _count(registry, "vllm:num_gpu_loaded_lora_adapters") == 0
+    assert _count(registry, "vllm:num_cpu_loaded_lora_adapters") == 0
+
+
+def test_events_apply_in_order_within_one_batch():
+    """Additive delivery: the last snapshot in a batch wins."""
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry)
+
+    logger.record_engine_notifications(
+        [
+            LoRALoadEvent(gpu_adapters=["alpha"], cpu_adapters=["alpha"]),
+            LoRALoadEvent(gpu_adapters=["beta"], cpu_adapters=["beta"]),
+        ]
+    )
+
+    assert _loaded_series(registry) == {("beta", "gpu", "false"): 1.0}
+
+
+def test_engines_are_tracked_independently():
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry, engine_indexes=(0, 1))
+
+    logger.record_engine_notifications(
+        [LoRALoadEvent(gpu_adapters=["alpha"], cpu_adapters=["alpha"])], engine_idx=0
+    )
+    logger.record_engine_notifications(
+        [LoRALoadEvent(gpu_adapters=["beta"], cpu_adapters=["beta"])], engine_idx=1
+    )
+    logger.record_engine_notifications([LoRALoadEvent()], engine_idx=0)
+
+    assert _loaded_series(registry) == {("beta", "gpu", "false"): 1.0}
+    assert _count(registry, "vllm:num_gpu_loaded_lora_adapters", engine="0") == 0
+    assert _count(registry, "vllm:num_gpu_loaded_lora_adapters", engine="1") == 1
+
+
+def test_custom_notifications_are_ignored():
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry)
+
+    logger.record_engine_notifications([CustomNotification(key="my_plugin")])
+
+    assert _loaded_series(registry) == {}
+
+
+def test_load_event_without_lora_config_is_a_noop():
+    """Engines started without --enable-lora register no LoRA gauges."""
+    logger = PrometheusStatLogger.__new__(PrometheusStatLogger)
+    logger.gauge_lora_adapter_loaded = None
+
+    logger.record_engine_notifications([LoRALoadEvent(cpu_adapters=["alpha"])])
+
+
+@pytest.mark.parametrize("pinned", [True, False])
+def test_pinned_label_tracks_the_event(pinned):
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry)
+
+    logger.record_engine_notifications(
+        [
+            LoRALoadEvent(
+                gpu_adapters=["alpha"],
+                cpu_adapters=["alpha"],
+                pinned_adapters=["alpha"] if pinned else [],
+            )
+        ]
+    )
+
+    assert _loaded_series(registry) == {("alpha", "gpu", str(pinned).lower()): 1.0}

--- a/tests/v1/metrics/test_lora_metrics.py
+++ b/tests/v1/metrics/test_lora_metrics.py
@@ -4,10 +4,10 @@
 the test does not fight the process-global one."""
 
 import pytest
-from prometheus_client import CollectorRegistry, Gauge
+from prometheus_client import CollectorRegistry, Gauge, Histogram
 
 from vllm.v1.metrics.loggers import PrometheusStatLogger
-from vllm.v1.notifications import CustomNotification, LoRALoadEvent
+from vllm.v1.notifications import CustomNotification, LoRALoadEvent, LoRALoadTiming
 
 LABELNAMES = ["model_name", "engine"]
 
@@ -36,7 +36,39 @@ def _lora_logger(registry: CollectorRegistry, engine_indexes=(0,)):
         registry=registry,
     )
     logger._lora_loaded_series = {}
+    load_seconds = Histogram(
+        "vllm:lora_adapter_load_seconds",
+        "",
+        LABELNAMES + ["transition"],
+        buckets=[0.1, 1.0],
+        registry=registry,
+    )
+    logger.histogram_lora_load_seconds = {
+        idx: load_seconds.labels(*labels, "load")
+        for idx, labels in logger.per_engine_labelvalues.items()
+    }
+    logger.histogram_lora_activate_seconds = {
+        idx: load_seconds.labels(*labels, "activate")
+        for idx, labels in logger.per_engine_labelvalues.items()
+    }
     return logger
+
+
+def _load_seconds(
+    registry: CollectorRegistry,
+) -> dict[tuple[str, str], tuple[float, float]]:
+    """(engine, transition) -> (count, sum) for the load histogram."""
+    out: dict[tuple[str, str], list[float]] = {}
+    for metric in registry.collect():
+        if metric.name != "vllm:lora_adapter_load_seconds":
+            continue
+        for s in metric.samples:
+            key = (s.labels["engine"], s.labels["transition"])
+            if s.name.endswith("_count"):
+                out.setdefault(key, [0.0, 0.0])[0] = s.value
+            elif s.name.endswith("_sum"):
+                out.setdefault(key, [0.0, 0.0])[1] = s.value
+    return {k: (v[0], v[1]) for k, v in out.items()}
 
 
 def _loaded_series(registry: CollectorRegistry) -> dict[tuple[str, str, str], float]:
@@ -181,3 +213,32 @@ def test_pinned_label_tracks_the_event(pinned):
     )
 
     assert _loaded_series(registry) == {("alpha", "gpu", str(pinned).lower()): 1.0}
+
+
+def test_load_timings_land_in_the_histogram_per_engine_and_transition():
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry, engine_indexes=(0, 1))
+    logger.record_engine_notifications(
+        [
+            LoRALoadEvent(
+                gpu_adapters=["alpha"],
+                cpu_adapters=["alpha"],
+                loads=[
+                    LoRALoadTiming("alpha", "load", 0.4),
+                    LoRALoadTiming("alpha", "activate", 0.05),
+                ],
+            )
+        ],
+        engine_idx=0,
+    )
+    logger.record_engine_notifications(
+        [LoRALoadEvent(loads=[LoRALoadTiming("beta", "load", 1.5)])], engine_idx=1
+    )
+
+    observed = _load_seconds(registry)
+    assert observed[("0", "load")] == (1.0, pytest.approx(0.4))
+    assert observed[("0", "activate")] == (1.0, pytest.approx(0.05))
+    assert observed[("1", "load")] == (1.0, pytest.approx(1.5))
+    assert observed[("1", "activate")] == (0.0, 0.0)
+    # A timing-only event leaves the residency series alone.
+    assert _loaded_series(registry) == {("alpha", "gpu", "false"): 1.0}

--- a/tests/v1/metrics/test_lora_metrics.py
+++ b/tests/v1/metrics/test_lora_metrics.py
@@ -32,7 +32,7 @@ def _lora_logger(registry: CollectorRegistry, engine_indexes=(0,)):
     logger.gauge_lora_adapter_loaded = Gauge(
         "vllm:lora_adapter_loaded",
         "",
-        LABELNAMES + ["adapter_name", "level", "pinned"],
+        LABELNAMES + ["adapter_name", "level", "pinned", "rank"],
         registry=registry,
     )
     logger._lora_loaded_series = {}
@@ -242,3 +242,24 @@ def test_load_timings_land_in_the_histogram_per_engine_and_transition():
     assert observed[("1", "activate")] == (0.0, 0.0)
     # A timing-only event leaves the residency series alone.
     assert _loaded_series(registry) == {("alpha", "gpu", "false"): 1.0}
+
+
+def test_rank_label_comes_from_the_event_and_defaults_to_zero():
+    registry = CollectorRegistry()
+    logger = _lora_logger(registry)
+    logger.record_engine_notifications(
+        [
+            LoRALoadEvent(
+                gpu_adapters=["alpha"],
+                cpu_adapters=["alpha", "beta"],
+                ranks={"alpha": 64},
+            )
+        ]
+    )
+    ranks = {
+        s.labels["adapter_name"]: s.labels["rank"]
+        for metric in registry.collect()
+        if metric.name == "vllm:lora_adapter_loaded"
+        for s in metric.samples
+    }
+    assert ranks == {"alpha": "64", "beta": "0"}

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -859,8 +859,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if (val := float(os.getenv("VLLM_LOG_STATS_INTERVAL", "10."))) > 0.0
         else 10.0
     ),
-    # Seconds between engine-core polls for worker notifications, 0 to
-    # disable. See vllm/v1/notifications.py.
+    # Upper bound in seconds on how long a worker notification can sit
+    # before the engine core gathers it, busy or idle. 0 disables polling.
+    # See vllm/v1/notifications.py.
     "VLLM_WORKER_NOTIFICATION_POLL_INTERVAL": lambda: max(
         0.0, float(os.getenv("VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", "0."))
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -859,10 +859,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if (val := float(os.getenv("VLLM_LOG_STATS_INTERVAL", "10."))) > 0.0
         else 10.0
     ),
-    # Interval in seconds at which the engine core polls workers for
-    # notifications (see vllm/v1/notifications.py). 0 disables polling; events
-    # from producers that publish during model load are still gathered once at
-    # startup, and in-tree producers gather on their own state changes.
+    # Seconds between engine-core polls for worker notifications, 0 to
+    # disable. See vllm/v1/notifications.py.
     "VLLM_WORKER_NOTIFICATION_POLL_INTERVAL": lambda: max(
         0.0, float(os.getenv("VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", "0."))
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     VLLM_LOGGING_COLOR: str = "auto"
     NO_COLOR: bool = False
     VLLM_LOG_STATS_INTERVAL: float = 10.0
+    VLLM_WORKER_NOTIFICATION_POLL_INTERVAL: float = 0.0
     VLLM_TRACE_FUNCTION: int = 0
     VLLM_USE_FLASHINFER_SAMPLER: bool = True
     VLLM_PP_LAYER_PARTITION: str | None = None
@@ -857,6 +858,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
         val
         if (val := float(os.getenv("VLLM_LOG_STATS_INTERVAL", "10."))) > 0.0
         else 10.0
+    ),
+    # Interval in seconds at which the engine core polls workers for
+    # notifications (see vllm/v1/notifications.py). 0 disables polling; events
+    # from producers that publish during model load are still gathered once at
+    # startup, and in-tree producers gather on their own state changes.
+    "VLLM_WORKER_NOTIFICATION_POLL_INTERVAL": lambda: max(
+        0.0, float(os.getenv("VLLM_WORKER_NOTIFICATION_POLL_INTERVAL", "0."))
     ),
     # Trace function calls
     # If set to 1, vllm will trace function calls
@@ -2331,6 +2339,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_LOGGING_CONFIG_PATH",
         "VLLM_LOGGING_COLOR",
         "VLLM_LOG_STATS_INTERVAL",
+        "VLLM_WORKER_NOTIFICATION_POLL_INTERVAL",
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",
         "VLLM_TUNED_CONFIG_FOLDER",
         "VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR",

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -3,6 +3,7 @@
 
 import math
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TypeVar
 
 import torch
@@ -55,6 +56,20 @@ class SupportsLoRAModel(nn.Module, SupportsLoRA): ...
 
 
 class SupportsLoRAMultiModalModel(SupportsLoRAModel, SupportsMultiModal): ...
+
+
+@dataclass
+class LoRALoadedState:
+    """Adapter int ids resident in each tier of a LoRA manager's caches."""
+
+    active_ids: set[int]
+    """Adapters activated into GPU slots."""
+
+    registered_ids: set[int]
+    """Adapters resident in the CPU cache (superset of `active_ids`)."""
+
+    pinned_ids: set[int]
+    """Adapters pinned in the caches."""
 
 
 class AdapterLRUCache(LRUCache[int, T]):
@@ -1198,6 +1213,13 @@ class LoRAModelManager:
 
     def list_adapters(self) -> dict[int, LoRAModel]:
         return dict(self._registered_adapters.cache)
+
+    def get_loaded_state(self) -> LoRALoadedState:
+        return LoRALoadedState(
+            active_ids=set(self._active_adapters),
+            registered_ids=set(self._registered_adapters),
+            pinned_ids=set(self._registered_adapters.pinned_items),
+        )
 
     def get_adapter(self, adapter_id: int) -> LoRAModel | None:
         return self._registered_adapters.get(adapter_id)

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -12,6 +12,7 @@ from vllm.exceptions import LoRAAdapterNotFoundError
 from vllm.logger import init_logger
 from vllm.lora.lora_model import LoRAModel
 from vllm.lora.model_manager import (
+    LoRALoadedState,
     LoRAModelManager,
     LRUCacheLoRAModelManager,
     create_lora_manager,
@@ -68,6 +69,9 @@ class WorkerLoRAManager:
                 text_config, "max_position_embeddings", None
             )
         self.device = device
+        # Adapter int id -> adapter name; pruned to the registered set on
+        # each get_loaded_names() call.
+        self._adapter_names: dict[int, str] = {}
         # Lazily initialized by create_lora_manager.
         self._adapter_manager: LoRAModelManager
 
@@ -169,6 +173,7 @@ class WorkerLoRAManager:
         except Exception as e:
             raise e
 
+        self._adapter_names[lora_request.lora_int_id] = lora_request.lora_name
         return lora
 
     def add_dummy_lora(self, lora_request: LoRARequest, rank: int) -> bool:
@@ -238,6 +243,32 @@ class WorkerLoRAManager:
 
     def list_adapters(self) -> set[int]:
         return set(self._adapter_manager.list_adapters())
+
+    def get_loaded_state(self) -> LoRALoadedState:
+        return self._adapter_manager.get_loaded_state()
+
+    def get_loaded_names(
+        self, state: LoRALoadedState
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Resolve a loaded state into sorted `(gpu, cpu, pinned)` name lists.
+
+        Dummy/warmup adapters never go through `_load_adapter`, so they fall
+        back to their int id.
+        """
+        self._adapter_names = {
+            lora_id: name
+            for lora_id, name in self._adapter_names.items()
+            if lora_id in state.registered_ids
+        }
+
+        def names(ids: set[int]) -> list[str]:
+            return sorted({self._adapter_names.get(i, str(i)) for i in ids})
+
+        return (
+            names(state.active_ids),
+            names(state.registered_ids),
+            names(state.pinned_ids),
+        )
 
 
 class LRUCacheWorkerLoRAManager(WorkerLoRAManager):

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -299,6 +299,15 @@ class WorkerLoRAManager:
             names(state.pinned_ids),
         )
 
+    def get_loaded_ranks(self, state: LoRALoadedState) -> dict[str, int]:
+        """Rank of every resident adapter, keyed like `get_loaded_names`."""
+        ranks: dict[str, int] = {}
+        for lora_id in state.registered_ids:
+            adapter = self._adapter_manager.get_adapter(lora_id)
+            if adapter is not None:
+                ranks[self._adapter_names.get(lora_id, str(lora_id))] = adapter.rank
+        return ranks
+
 
 class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
     """WorkerLoRAManager that manages LoRA models on the worker side.

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import time
 from contextlib import contextmanager
 from typing import Any, Literal
 
@@ -21,6 +22,7 @@ from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.request import LoRARequest
 from vllm.lora.utils import get_adapter_absolute_path
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+from vllm.v1.notifications import LoRALoadTiming
 
 logger = init_logger(__name__)
 
@@ -69,6 +71,7 @@ class WorkerLoRAManager:
                 text_config, "max_position_embeddings", None
             )
         self.device = device
+        self._load_timings: list[LoRALoadTiming] = []
         # Adapter int id -> adapter name; pruned to the registered set on
         # each get_loaded_names() call.
         self._adapter_names: dict[int, str] = {}
@@ -230,10 +233,36 @@ class WorkerLoRAManager:
             return False
         # One-time per adapter
         with gpu_sync_allowed():
-            loaded_adapter = self._load_adapter(adapter_request)
+            loaded_adapter = self._timed_load_adapter(adapter_request)
             loaded = self._adapter_manager.add_adapter(loaded_adapter)
-            self._adapter_manager.activate_adapter(loaded_adapter.id)
+            self._timed_activate_adapter(adapter_request)
         return loaded
+
+    def _timed_load_adapter(self, lora_request: Any) -> LoRAModel:
+        start = time.perf_counter()
+        lora = self._load_adapter(lora_request)
+        self._record_load_timing(lora_request, "load", start)
+        return lora
+
+    def _timed_activate_adapter(self, lora_request: Any) -> None:
+        start = time.perf_counter()
+        if self._adapter_manager.activate_adapter(lora_request.lora_int_id):
+            self._record_load_timing(lora_request, "activate", start)
+
+    def _record_load_timing(self, lora_request: Any, transition: str, start: float):
+        self._load_timings.append(
+            LoRALoadTiming(
+                adapter_name=lora_request.lora_name,
+                transition=transition,
+                seconds=time.perf_counter() - start,
+            )
+        )
+
+    def drain_load_timings(self) -> list[LoRALoadTiming]:
+        """Adapter transitions measured since the last drain, oldest first."""
+        timings = self._load_timings
+        self._load_timings = []
+        return timings
 
     def remove_adapter(self, adapter_id: int) -> bool:
         return self._adapter_manager.remove_adapter(adapter_id)
@@ -330,7 +359,7 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
                 # evicting any existing adapters.
                 # This may cause the # of loaded lora adapters to very temporarily
                 # exceed `--max-cpu-loras`.
-                lora = self._load_adapter(lora_request)
+                lora = self._timed_load_adapter(lora_request)
 
                 # Remove the existing adapter if it exists
                 # Use case for LoRA inplace
@@ -350,5 +379,5 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
                     self._adapter_manager.get_adapter(lora_request.lora_int_id)
                     is not None
                 )
-            self._adapter_manager.activate_adapter(lora_request.lora_int_id)
+            self._timed_activate_adapter(lora_request)
         return loaded

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -277,9 +277,7 @@ class EngineCoreOutputs(
     # "old" wave, so the next wave needs to be started in other engines.
     start_wave: int | None = None
 
-    # Rare engine-level event notifications (see vllm/v1/notifications.py).
-    # This struct is array_like, so field order is load-bearing for
-    # non-Python frontends; new fields must be appended.
+    # array_like: field order is load-bearing for non-Python frontends.
     engine_notifications: list[EngineNotification] | None = None
 
     def __post_init__(self):

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -21,6 +21,7 @@ from vllm.v1.metrics.stats import (
     RequestSpecDecodeMetrics,
     SchedulerStats,
 )
+from vllm.v1.notifications import EngineNotification
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplingMaskLists
 from vllm.v1.serial_utils import UtilityResult
 
@@ -275,6 +276,11 @@ class EngineCoreOutputs(
     # In DP case, used to signal that a request was received for an
     # "old" wave, so the next wave needs to be started in other engines.
     start_wave: int | None = None
+
+    # Rare engine-level event notifications (see vllm/v1/notifications.py).
+    # This struct is array_like, so field order is load-bearing for
+    # non-Python frontends; new fields must be appended.
+    engine_notifications: list[EngineNotification] | None = None
 
     def __post_init__(self):
         if self.timestamp == 0.0:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -818,6 +818,11 @@ class AsyncLLM(EngineClient):
                     # TODO(rob): make into a coroutine and launch it in
                     # background thread once Prometheus overhead is non-trivial.
                     if logger_ref[0]:
+                        if outputs.engine_notifications:
+                            logger_ref[0].record_engine_notifications(
+                                outputs.engine_notifications,
+                                engine_idx=outputs.engine_index,
+                            )
                         logger_ref[0].record(
                             engine_idx=outputs.engine_index,
                             scheduler_stats=outputs.scheduler_stats,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -242,9 +242,7 @@ class EngineCore:
 
         self._idle_state_callbacks: list[Callable] = []
 
-        # Notifications waiting on the in-process frontend (EngineCoreProc
-        # overrides _publish_notifications to broadcast instead). Additive in
-        # emission order, like scheduler_stats: nothing dropped.
+        # In-process frontend only; EngineCoreProc broadcasts instead.
         self._pending_notifications: list[EngineNotification] = []
         self._last_notification_gather = 0.0
 
@@ -772,12 +770,7 @@ class EngineCore:
         return engine_core_outputs, model_executed
 
     def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
-        """Queue notifications for the frontend.
-
-        Additive (like scheduler_stats): nothing gets dropped. The in-process
-        engine buffers until the next step's outputs; EngineCoreProc overrides
-        this to broadcast to every frontend right away.
-        """
+        """Queue notifications for the frontend."""
         self._pending_notifications.extend(notifications)
 
     def _flush_notifications(
@@ -794,16 +787,12 @@ class EngineCore:
     def gather_worker_notifications(self) -> None:
         """Collect notifications from every worker rank and publish them.
 
-        A rank-0-only reply would discard producers on the other ranks (e.g.
-        per-rank transfer metrics from a weight-loader plugin), so this keeps
-        all of them. Callers own the cadence: this is an rpc round trip, not
-        something to run per step.
+        An rpc round trip; callers own the cadence.
         """
         try:
             per_rank = self.model_executor.collective_rpc("take_notifications")
         except Exception:
-            # Never fail an engine operation for a metrics channel. Workers
-            # without the method (e.g. out-of-tree platforms) land here too.
+            # Workers without the method (out-of-tree platforms) land here.
             logger.warning_once(
                 "Could not gather worker notifications; events published in "
                 "workers will not reach the frontend."
@@ -1471,8 +1460,7 @@ class EngineCoreProc(EngineCore):
     @fault_tolerant_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore."""
-        # Producers that publish during model load have already run, and no
-        # event will prompt a gather on their behalf.
+        # Load-time producers have already run; nothing else will gather them.
         self.gather_worker_notifications()
         while self._handle_shutdown():
             # 1) Poll the input queue until there is work to do.
@@ -1489,10 +1477,8 @@ class EngineCoreProc(EngineCore):
     def _maybe_gather_worker_notifications(self) -> None:
         """Poll workers for spontaneously published notifications.
 
-        Off unless VLLM_WORKER_NOTIFICATION_POLL_INTERVAL is set. Deliberately
-        here rather than inside step(): the gather is an rpc that queues behind
-        any in-flight execute_model, so issuing it between steps keeps it to a
-        round trip instead of stalling on a rank mid-forward.
+        Between steps, not inside one: the rpc queues behind any in-flight
+        execute_model and would otherwise stall on a rank mid-forward.
         """
         interval = envs.VLLM_WORKER_NOTIFICATION_POLL_INTERVAL
         if not interval:
@@ -1997,12 +1983,10 @@ class EngineCoreProc(EngineCore):
         return tracker
 
     def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
-        """Broadcast notifications to every connected frontend.
+        """Broadcast to every frontend.
 
-        One-shot deltas must reach all clients: attaching to a single
-        client's step outputs (as scheduler_stats does) would leave every
-        other frontend permanently stale, and an idle engine has no step
-        outputs at all.
+        Attaching to one client's step outputs would leave the others stale,
+        and an idle engine has no step outputs at all.
         """
         for client_index in range(len(self.addresses.outputs)):
             self.output_queue.put_nowait(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -785,10 +785,8 @@ class EngineCore:
         self._pending_notifications = []
 
     def gather_worker_notifications(self) -> None:
-        """Collect notifications from every worker rank and publish them.
-
-        An rpc round trip; callers own the cadence.
-        """
+        """Collect and publish every rank's notifications; an rpc round trip,
+        so callers own the cadence."""
         try:
             per_rank = self.model_executor.collective_rpc("take_notifications")
         except Exception:
@@ -1475,11 +1473,8 @@ class EngineCoreProc(EngineCore):
         raise SystemExit
 
     def _maybe_gather_worker_notifications(self) -> None:
-        """Poll workers for spontaneously published notifications.
-
-        Between steps, not inside one: the rpc queues behind any in-flight
-        execute_model and would otherwise stall on a rank mid-forward.
-        """
+        """Poll workers on an interval, between steps so the rpc cannot
+        stall a rank mid-forward."""
         interval = envs.VLLM_WORKER_NOTIFICATION_POLL_INTERVAL
         if not interval:
             return
@@ -1983,11 +1978,8 @@ class EngineCoreProc(EngineCore):
         return tracker
 
     def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
-        """Broadcast to every frontend.
-
-        Attaching to one client's step outputs would leave the others stale,
-        and an idle engine has no step outputs at all.
-        """
+        """Broadcast to every frontend; attaching to one client's step
+        outputs would leave the others stale."""
         for client_index in range(len(self.addresses.outputs)):
             self.output_queue.put_nowait(
                 (client_index, EngineCoreOutputs(engine_notifications=notifications))
@@ -2266,7 +2258,8 @@ class DPEngineCoreProc(EngineCoreProc):
     @fault_tolerant_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore for data parallel case."""
-
+        # Load-time producers have already run; nothing else will gather them.
+        self.gather_worker_notifications()
         # Loop until process is sent a SIGINT or SIGTERM
         while self._handle_shutdown():
             # 1) Poll the input queue until there is work to do.
@@ -2274,6 +2267,7 @@ class DPEngineCoreProc(EngineCoreProc):
             self._process_input_queue()
             # Publish request counts before and after GPU step to ensure freshness.
             self._maybe_publish_request_counts()
+            self._maybe_gather_worker_notifications()
 
             if self.eep_scaling_state is not None:
                 state = self.eep_scaling_state

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -639,7 +639,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
-        self._flush_notifications(engine_core_outputs)
+        self._collect_step_notifications(model_output, engine_core_outputs)
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 
@@ -743,7 +743,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
-        self._flush_notifications(engine_core_outputs)
+        self._collect_step_notifications(model_output, engine_core_outputs)
 
         # NOTE(nick): We can either handle the deferred tasks here or save
         # in a field and do it immediately once step_with_batch_queue is
@@ -784,6 +784,16 @@ class EngineCore:
             engine_core_outputs[0] = eco = EngineCoreOutputs()
         eco.engine_notifications = self._pending_notifications
         self._pending_notifications = []
+
+    def _collect_step_notifications(
+        self,
+        model_output: ModelRunnerOutput,
+        engine_core_outputs: dict[int, EngineCoreOutputs],
+    ) -> None:
+        """Gather when the output rank rang the doorbell, then flush."""
+        if model_output.worker_notifications_pending:
+            self.gather_worker_notifications()
+        self._flush_notifications(engine_core_outputs)
 
     def gather_worker_notifications(self) -> None:
         """Collect and publish every rank's notifications; an rpc round trip,
@@ -1001,16 +1011,22 @@ class EngineCore:
         self.model_executor.execute_dummy_batch()
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
-        return self.model_executor.add_lora(lora_request)
+        added = self.model_executor.add_lora(lora_request)
+        self.gather_worker_notifications()
+        return added
 
     def remove_lora(self, lora_id: int) -> bool:
-        return self.model_executor.remove_lora(lora_id)
+        removed = self.model_executor.remove_lora(lora_id)
+        self.gather_worker_notifications()
+        return removed
 
     def list_loras(self) -> set[int]:
         return self.model_executor.list_loras()
 
     def pin_lora(self, lora_id: int) -> bool:
-        return self.model_executor.pin_lora(lora_id)
+        pinned = self.model_executor.pin_lora(lora_id)
+        self.gather_worker_notifications()
+        return pinned
 
     def save_sharded_state(
         self,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -644,6 +644,7 @@ class EngineCore:
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 
     def post_step(self, model_executed: bool) -> None:
+        self._maybe_gather_worker_notifications()
         # When using async scheduling we can't get draft token ids in advance,
         # so we update draft token ids in the worker process and don't
         # need to update draft token ids here.
@@ -787,17 +788,21 @@ class EngineCore:
     def gather_worker_notifications(self) -> None:
         """Collect and publish every rank's notifications; an rpc round trip,
         so callers own the cadence."""
-        try:
-            per_rank = self.model_executor.collective_rpc("take_notifications")
-        except Exception:
-            # Workers without the method (out-of-tree platforms) land here.
-            logger.warning_once(
-                "Could not gather worker notifications; events published in "
-                "workers will not reach the frontend."
-            )
-            return
-        if notifications := [n for rank in per_rank or () for n in rank or ()]:
+        per_rank = self.model_executor.collective_rpc("take_notifications")
+        if notifications := [n for rank in per_rank for n in rank]:
             self._publish_notifications(notifications)
+
+    def _maybe_gather_worker_notifications(self) -> None:
+        """Poll workers on an interval, between steps so the rpc cannot
+        stall a rank mid-forward."""
+        interval = envs.VLLM_WORKER_NOTIFICATION_POLL_INTERVAL
+        if not interval:
+            return
+        now = time.monotonic()
+        if now - self._last_notification_gather < interval:
+            return
+        self._last_notification_gather = now
+        self.gather_worker_notifications()
 
     def _process_aborts_queue(self):
         if not self.aborts_queue.empty():
@@ -1465,24 +1470,11 @@ class EngineCoreProc(EngineCore):
             self._process_input_queue()
             # Publish request counts before and after GPU step to ensure freshness.
             self._maybe_publish_request_counts()
-            self._maybe_gather_worker_notifications()
             # 2) Step the engine core and return the outputs.
             self._process_engine_step()
             self._maybe_publish_request_counts()
 
         raise SystemExit
-
-    def _maybe_gather_worker_notifications(self) -> None:
-        """Poll workers on an interval, between steps so the rpc cannot
-        stall a rank mid-forward."""
-        interval = envs.VLLM_WORKER_NOTIFICATION_POLL_INTERVAL
-        if not interval:
-            return
-        now = time.monotonic()
-        if now - self._last_notification_gather < interval:
-            return
-        self._last_notification_gather = now
-        self.gather_worker_notifications()
 
     def _maybe_publish_request_counts(self):
         if not self.publish_dp_lb_stats:
@@ -1513,9 +1505,13 @@ class EngineCoreProc(EngineCore):
                     waited = True
             block = self.process_input_queue_block
             try:
-                req = self.input_queue.get(block=block)
+                poll_interval = envs.VLLM_WORKER_NOTIFICATION_POLL_INTERVAL
+                req = self.input_queue.get(block=block, timeout=poll_interval or None)
                 self._handle_client_request(*req)
             except queue.Empty:
+                if block:
+                    self._maybe_gather_worker_notifications()
+                    continue
                 break
             if not block:
                 break
@@ -2267,7 +2263,6 @@ class DPEngineCoreProc(EngineCoreProc):
             self._process_input_queue()
             # Publish request counts before and after GPU step to ensure freshness.
             self._maybe_publish_request_counts()
-            self._maybe_gather_worker_notifications()
 
             if self.eep_scaling_state is not None:
                 state = self.eep_scaling_state

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -246,6 +246,7 @@ class EngineCore:
         # overrides _publish_notifications to broadcast instead). Additive in
         # emission order, like scheduler_stats: nothing dropped.
         self._pending_notifications: list[EngineNotification] = []
+        self._last_notification_gather = 0.0
 
         # Mark the startup heap as static so that it's ignored by GC.
         # Reduces pause times of oldest generation collections.
@@ -640,7 +641,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
-        self._collect_step_notifications(model_output, engine_core_outputs)
+        self._flush_notifications(engine_core_outputs)
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 
@@ -743,7 +744,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
-        self._collect_step_notifications(model_output, engine_core_outputs)
+        self._flush_notifications(engine_core_outputs)
 
         # NOTE(nick): We can either handle the deferred tasks here or save
         # in a field and do it immediately once step_with_batch_queue is
@@ -790,14 +791,26 @@ class EngineCore:
         eco.engine_notifications = self._pending_notifications
         self._pending_notifications = []
 
-    def _collect_step_notifications(
-        self,
-        model_output: ModelRunnerOutput,
-        engine_core_outputs: dict[int, EngineCoreOutputs],
-    ) -> None:
-        if model_output.worker_notifications:
-            self._publish_notifications(model_output.worker_notifications)
-        self._flush_notifications(engine_core_outputs)
+    def gather_worker_notifications(self) -> None:
+        """Collect notifications from every worker rank and publish them.
+
+        A rank-0-only reply would discard producers on the other ranks (e.g.
+        per-rank transfer metrics from a weight-loader plugin), so this keeps
+        all of them. Callers own the cadence: this is an rpc round trip, not
+        something to run per step.
+        """
+        try:
+            per_rank = self.model_executor.collective_rpc("take_notifications")
+        except Exception:
+            # Never fail an engine operation for a metrics channel. Workers
+            # without the method (e.g. out-of-tree platforms) land here too.
+            logger.warning_once(
+                "Could not gather worker notifications; events published in "
+                "workers will not reach the frontend."
+            )
+            return
+        if notifications := [n for rank in per_rank or () for n in rank or ()]:
+            self._publish_notifications(notifications)
 
     def _process_aborts_queue(self):
         if not self.aborts_queue.empty():
@@ -1458,16 +1471,37 @@ class EngineCoreProc(EngineCore):
     @fault_tolerant_wrapper
     def run_busy_loop(self):
         """Core busy loop of the EngineCore."""
+        # Producers that publish during model load have already run, and no
+        # event will prompt a gather on their behalf.
+        self.gather_worker_notifications()
         while self._handle_shutdown():
             # 1) Poll the input queue until there is work to do.
             self._process_input_queue()
             # Publish request counts before and after GPU step to ensure freshness.
             self._maybe_publish_request_counts()
+            self._maybe_gather_worker_notifications()
             # 2) Step the engine core and return the outputs.
             self._process_engine_step()
             self._maybe_publish_request_counts()
 
         raise SystemExit
+
+    def _maybe_gather_worker_notifications(self) -> None:
+        """Poll workers for spontaneously published notifications.
+
+        Off unless VLLM_WORKER_NOTIFICATION_POLL_INTERVAL is set. Deliberately
+        here rather than inside step(): the gather is an rpc that queues behind
+        any in-flight execute_model, so issuing it between steps keeps it to a
+        round trip instead of stalling on a rank mid-forward.
+        """
+        interval = envs.VLLM_WORKER_NOTIFICATION_POLL_INTERVAL
+        if not interval:
+            return
+        now = time.monotonic()
+        if now - self._last_notification_gather < interval:
+            return
+        self._last_notification_gather = now
+        self.gather_worker_notifications()
 
     def _maybe_publish_request_counts(self):
         if not self.publish_dp_lb_stats:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -87,6 +87,7 @@ from vllm.v1.fault_tolerance.engine_core_sentinel import (
 )
 from vllm.v1.kv_cache_interface import KVCacheConfig, get_kv_cache_spec_kind
 from vllm.v1.metrics.stats import SchedulerIterationDetails, SchedulerStats
+from vllm.v1.notifications import EngineNotification
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder, bytestr
@@ -240,6 +241,11 @@ class EngineCore:
         self.aborts_queue = queue.Queue[list[str]]()
 
         self._idle_state_callbacks: list[Callable] = []
+
+        # Notifications waiting on the in-process frontend (EngineCoreProc
+        # overrides _publish_notifications to broadcast instead). Additive in
+        # emission order, like scheduler_stats: nothing dropped.
+        self._pending_notifications: list[EngineNotification] = []
 
         # Mark the startup heap as static so that it's ignored by GC.
         # Reduces pause times of oldest generation collections.
@@ -634,6 +640,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
+        self._collect_step_notifications(model_output, engine_core_outputs)
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 
@@ -736,6 +743,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         self._attach_iteration_details(engine_core_outputs, iteration_details)
+        self._collect_step_notifications(model_output, engine_core_outputs)
 
         # NOTE(nick): We can either handle the deferred tasks here or save
         # in a field and do it immediately once step_with_batch_queue is
@@ -761,6 +769,35 @@ class EngineCore:
             batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
 
         return engine_core_outputs, model_executed
+
+    def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
+        """Queue notifications for the frontend.
+
+        Additive (like scheduler_stats): nothing gets dropped. The in-process
+        engine buffers until the next step's outputs; EngineCoreProc overrides
+        this to broadcast to every frontend right away.
+        """
+        self._pending_notifications.extend(notifications)
+
+    def _flush_notifications(
+        self, engine_core_outputs: dict[int, EngineCoreOutputs]
+    ) -> None:
+        """Attach pending notifications to the in-process frontend's outputs."""
+        if not self._pending_notifications:
+            return
+        if (eco := next(iter(engine_core_outputs.values()), None)) is None:
+            engine_core_outputs[0] = eco = EngineCoreOutputs()
+        eco.engine_notifications = self._pending_notifications
+        self._pending_notifications = []
+
+    def _collect_step_notifications(
+        self,
+        model_output: ModelRunnerOutput,
+        engine_core_outputs: dict[int, EngineCoreOutputs],
+    ) -> None:
+        if model_output.worker_notifications:
+            self._publish_notifications(model_output.worker_notifications)
+        self._flush_notifications(engine_core_outputs)
 
     def _process_aborts_queue(self):
         if not self.aborts_queue.empty():
@@ -1924,6 +1961,19 @@ class EngineCoreProc(EngineCore):
         if more_flag:
             socket.send_multipart(buffers[1:], copy=False)
         return tracker
+
+    def _publish_notifications(self, notifications: list[EngineNotification]) -> None:
+        """Broadcast notifications to every connected frontend.
+
+        One-shot deltas must reach all clients: attaching to a single
+        client's step outputs (as scheduler_stats does) would leave every
+        other frontend permanently stale, and an idle engine has no step
+        outputs at all.
+        """
+        for client_index in range(len(self.addresses.outputs)):
+            self.output_queue.put_nowait(
+                (client_index, EngineCoreOutputs(engine_notifications=notifications))
+            )
 
     def _handle_request_preproc_error(self, request: EngineCoreRequest) -> None:
         """Log and return a request-scoped error response for exceptions raised

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -357,6 +357,7 @@ class InprocClient(EngineCoreClient):
             log_stats,
             executor_fail_callback=executor_fail_callback,
         )
+        self.engine_core.gather_worker_notifications()
 
     def get_output(self) -> EngineCoreOutputs:
         outputs, model_executed = self.engine_core.step_fn()

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -362,7 +362,10 @@ class InprocClient(EngineCoreClient):
     def get_output(self) -> EngineCoreOutputs:
         outputs, model_executed = self.engine_core.step_fn()
         self.engine_core.post_step(model_executed=model_executed)
-        return outputs and outputs.get(0) or EngineCoreOutputs()
+        # post_step may have gathered notifications
+        outputs = outputs or {}
+        self.engine_core._flush_notifications(outputs)
+        return outputs.get(0) or EngineCoreOutputs()
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.engine_core.get_supported_tasks()

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1153,7 +1153,11 @@ class AsyncMPClient(MPClient):
                             return
                         await output_handler(_self, outputs)
 
-                    if outputs.outputs or outputs.scheduler_stats:
+                    if (
+                        outputs.outputs
+                        or outputs.scheduler_stats
+                        or outputs.engine_notifications
+                    ):
                         outputs_queue.put_nowait(outputs)
             except Exception as e:
                 outputs_queue.put_nowait(e)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -329,6 +329,10 @@ class LLMEngine:
 
         # 4) Record stats
         with record_function_or_nullcontext("llm_engine step: record_stats"):
+            if self.logger_manager is not None and outputs.engine_notifications:
+                self.logger_manager.record_engine_notifications(
+                    outputs.engine_notifications
+                )
             if self.logger_manager is not None and outputs.scheduler_stats is not None:
                 # Record even when this step produced no request outputs.
                 self.logger_manager.record(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -27,7 +27,8 @@ from vllm.v1.metrics.stats import (
     PromptTokenStats,
     SchedulerStats,
 )
-from vllm.v1.metrics.utils import create_metric_per_engine
+from vllm.v1.metrics.utils import PromMetric, create_metric_per_engine
+from vllm.v1.notifications import EngineNotification, LoRALoadEvent
 from vllm.v1.spec_decode.metrics import SpecDecodingLogging, SpecDecodingProm
 
 logger = init_logger(__name__)
@@ -68,6 +69,11 @@ class StatLoggerBase(ABC):
         pass
 
     def record_sleep_state(self, is_awake: int, level: int):  # noqa
+        pass
+
+    def record_engine_notifications(  # noqa
+        self, engine_notifications: list[EngineNotification], engine_idx: int = 0
+    ):
         pass
 
 
@@ -1062,6 +1068,12 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         # TODO: This metric might be incorrect in case of using multiple
         # api_server counts which uses prometheus mp.
         self.gauge_lora_info: Gauge | None = None
+        self.gauge_lora_adapter_loaded: Gauge | None = None
+        self.gauge_lora_gpu_adapters: dict[int, PromMetric] = {}
+        self.gauge_lora_cpu_adapters: dict[int, PromMetric] = {}
+        # Label tuples emitted by the last load event, per engine, so series
+        # for evicted adapters can be removed.
+        self._lora_loaded_series: dict[int, set[tuple[str, str, str, str, str]]] = {}
         if vllm_config.lora_config is not None:
             if len(self.engine_indexes) > 1:
                 logger.warning(
@@ -1074,7 +1086,13 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.max_lora = vllm_config.lora_config.max_loras
             self.gauge_lora_info = self._gauge_cls(
                 name="vllm:lora_requests_info",
-                documentation="Running stats on lora requests.",
+                documentation=(
+                    "Running stats on lora requests. "
+                    "DEPRECATED: encodes adapter names into comma-separated "
+                    "label values; superseded by vllm:lora_adapter_loaded, "
+                    "vllm:num_gpu_loaded_lora_adapters and "
+                    "vllm:num_cpu_loaded_lora_adapters."
+                ),
                 multiprocess_mode="sum",
                 labelnames=[
                     self.labelname_max_lora,
@@ -1082,6 +1100,79 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_running_lora_adapters,
                 ],
             )
+
+            gauge_lora_gpu_adapters = self._gauge_cls(
+                name="vllm:num_gpu_loaded_lora_adapters",
+                documentation="Number of LoRA adapters loaded into GPU slots.",
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_lora_gpu_adapters = create_metric_per_engine(
+                gauge_lora_gpu_adapters, per_engine_labelvalues
+            )
+
+            gauge_lora_cpu_adapters = self._gauge_cls(
+                name="vllm:num_cpu_loaded_lora_adapters",
+                documentation=(
+                    "Number of LoRA adapters resident in the worker's CPU "
+                    "cache (superset of the GPU-loaded set)."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauge_lora_cpu_adapters = create_metric_per_engine(
+                gauge_lora_cpu_adapters, per_engine_labelvalues
+            )
+
+            self.gauge_lora_adapter_loaded = self._gauge_cls(
+                name="vllm:lora_adapter_loaded",
+                documentation=(
+                    "Whether a LoRA adapter is loaded in the worker's adapter "
+                    "caches. The series exists (value 1) while the adapter is "
+                    "resident; 'level' is 'gpu' when the adapter is active in "
+                    "a GPU slot and 'cpu' when it is only in the host cache."
+                ),
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames + ["adapter_name", "level", "pinned"],
+            )
+
+    def record_engine_notifications(
+        self, engine_notifications: list[EngineNotification], engine_idx: int = 0
+    ):
+        for notification in engine_notifications:
+            if isinstance(notification, LoRALoadEvent):
+                self._record_lora_load_event(notification, engine_idx)
+
+    def _record_lora_load_event(self, event: LoRALoadEvent, engine_idx: int):
+        if self.gauge_lora_adapter_loaded is None:
+            return
+        self.gauge_lora_gpu_adapters[engine_idx].set(len(event.gpu_adapters))
+        self.gauge_lora_cpu_adapters[engine_idx].set(len(event.cpu_adapters))
+
+        model_name, engine_label = self.per_engine_labelvalues[engine_idx]
+        gpu_adapters = set(event.gpu_adapters)
+        pinned_adapters = set(event.pinned_adapters)
+        new_series = {
+            (
+                str(model_name),
+                str(engine_label),
+                adapter_name,
+                "gpu" if adapter_name in gpu_adapters else "cpu",
+                str(adapter_name in pinned_adapters).lower(),
+            )
+            for adapter_name in event.cpu_adapters
+        }
+        prev_series = self._lora_loaded_series.get(engine_idx, set())
+        for labels in prev_series - new_series:
+            # Zero before removing: under prometheus multiprocess mode
+            # remove() only deletes the in-process child while the
+            # mmap-backed sample keeps its last value, and the Ray backend
+            # cannot delete series at all.
+            self.gauge_lora_adapter_loaded.labels(*labels).set(0)
+            self.gauge_lora_adapter_loaded.remove(*labels)
+        for labels in new_series:
+            self.gauge_lora_adapter_loaded.labels(*labels).set(1)
+        self._lora_loaded_series[engine_idx] = new_series
 
     def log_metrics_info(self, type: str, config_obj: SupportsMetricsInfo):
         metrics_info = config_obj.metrics_info()
@@ -1405,6 +1496,12 @@ class StatLoggerManager:
     def record_sleep_state(self, sleep: int = 0, level: int = 0):
         for logger in self.stat_loggers:
             logger.record_sleep_state(sleep, level)
+
+    def record_engine_notifications(
+        self, engine_notifications: list[EngineNotification], engine_idx: int = 0
+    ):
+        for logger in self.stat_loggers:
+            logger.record_engine_notifications(engine_notifications, engine_idx)
 
     def log(self):
         for logger in self.stat_loggers:

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1075,7 +1075,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         self.gauge_lora_cpu_adapters: dict[int, PromMetric] = {}
         # Label tuples emitted by the last load event, per engine, so series
         # for evicted adapters can be removed.
-        self._lora_loaded_series: dict[int, set[tuple[str, str, str, str, str]]] = {}
+        self._lora_loaded_series: dict[
+            int, set[tuple[str, str, str, str, str, str]]
+        ] = {}
         if vllm_config.lora_config is not None:
             if len(self.engine_indexes) > 1:
                 logger.warning(
@@ -1154,10 +1156,11 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     "Whether a LoRA adapter is loaded in the worker's adapter "
                     "caches. The series exists (value 1) while the adapter is "
                     "resident; 'level' is 'gpu' when the adapter is active in "
-                    "a GPU slot and 'cpu' when it is only in the host cache."
+                    "a GPU slot and 'cpu' when it is only in the host cache. "
+                    "'rank' is the adapter's LoRA rank."
                 ),
                 multiprocess_mode="mostrecent",
-                labelnames=labelnames + ["adapter_name", "level", "pinned"],
+                labelnames=labelnames + ["adapter_name", "level", "pinned", "rank"],
             )
 
             histogram_lora_load_seconds = self._histogram_cls(
@@ -1210,6 +1213,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 adapter_name,
                 "gpu" if adapter_name in gpu_adapters else "cpu",
                 str(adapter_name in pinned_adapters).lower(),
+                str(event.ranks.get(adapter_name, 0)),
             )
             for adapter_name in event.cpu_adapters
         }

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1069,6 +1069,8 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         # api_server counts which uses prometheus mp.
         self.gauge_lora_info: Gauge | None = None
         self.gauge_lora_adapter_loaded: Gauge | None = None
+        self.histogram_lora_load_seconds: dict[int, Histogram] = {}
+        self.histogram_lora_activate_seconds: dict[int, Histogram] = {}
         self.gauge_lora_gpu_adapters: dict[int, PromMetric] = {}
         self.gauge_lora_cpu_adapters: dict[int, PromMetric] = {}
         # Label tuples emitted by the last load event, per engine, so series
@@ -1158,6 +1160,26 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 labelnames=labelnames + ["adapter_name", "level", "pinned"],
             )
 
+            histogram_lora_load_seconds = self._histogram_cls(
+                name="vllm:lora_adapter_load_seconds",
+                documentation=(
+                    "Histogram of LoRA adapter transition time in seconds. "
+                    "'transition' is 'load' for a read from disk into the "
+                    "CPU cache and 'activate' for a move from the CPU cache "
+                    "into a GPU slot."
+                ),
+                buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+                labelnames=labelnames + ["transition"],
+            )
+            self.histogram_lora_load_seconds = {
+                idx: histogram_lora_load_seconds.labels(*labelvalues, "load")
+                for idx, labelvalues in per_engine_labelvalues.items()
+            }
+            self.histogram_lora_activate_seconds = {
+                idx: histogram_lora_load_seconds.labels(*labelvalues, "activate")
+                for idx, labelvalues in per_engine_labelvalues.items()
+            }
+
     def record_engine_notifications(
         self, engine_notifications: list[EngineNotification], engine_idx: int = 0
     ):
@@ -1168,6 +1190,13 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
     def _record_lora_load_event(self, event: LoRALoadEvent, engine_idx: int):
         if self.gauge_lora_adapter_loaded is None:
             return
+        for timing in event.loads:
+            histograms = (
+                self.histogram_lora_load_seconds
+                if timing.transition == "load"
+                else self.histogram_lora_activate_seconds
+            )
+            histograms[engine_idx].observe(timing.seconds)
         self.gauge_lora_gpu_adapters[engine_idx].set(len(event.gpu_adapters))
         self.gauge_lora_cpu_adapters[engine_idx].set(len(event.cpu_adapters))
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1124,6 +1124,28 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 gauge_lora_cpu_adapters, per_engine_labelvalues
             )
 
+            gauge_lora_gpu_slots = self._gauge_cls(
+                name="vllm:max_gpu_lora_adapters",
+                documentation="Number of GPU LoRA slots (max_loras).",
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            for gauge in create_metric_per_engine(
+                gauge_lora_gpu_slots, per_engine_labelvalues
+            ).values():
+                gauge.set(vllm_config.lora_config.max_loras)
+
+            gauge_lora_cpu_slots = self._gauge_cls(
+                name="vllm:max_cpu_lora_adapters",
+                documentation="Number of CPU cache LoRA slots (max_cpu_loras).",
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            for gauge in create_metric_per_engine(
+                gauge_lora_cpu_slots, per_engine_labelvalues
+            ).values():
+                gauge.set(vllm_config.lora_config.max_cpu_loras)
+
             self.gauge_lora_adapter_loaded = self._gauge_cls(
                 name="vllm:lora_adapter_loaded",
                 documentation=(

--- a/vllm/v1/metrics/ray_wrappers.py
+++ b/vllm/v1/metrics/ray_wrappers.py
@@ -115,6 +115,10 @@ class RayGaugeWrapper(RayPrometheusMetric):
         # ray metrics doesn't have set_to_current time, https://docs.ray.io/en/latest/_modules/ray/util/metrics.html
         return self.set(time.time())
 
+    def remove(self, *labels):
+        # Ray metrics cannot delete series; callers zero the series first.
+        pass
+
 
 class RayCounterWrapper(RayPrometheusMetric):
     """Wraps around ray.util.metrics.Counter to provide same API as

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -2,60 +2,35 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Engine-level event notifications.
 
-Engine-scoped state transitions (unlike per-request `EngineCoreEvent` or
-per-step `SchedulerStats`), forwarded to frontends on
-`EngineCoreOutputs.engine_notifications`. A producer fires one whenever its
-state changes.
+Engine-scoped state transitions, forwarded to frontends on
+`EngineCoreOutputs.engine_notifications`. Tagged msgspec structs, map-encoded
+with a `"type"` field; an unknown tag fails the decode rather than being
+skipped, so the union stays version-lockstep with the engine. The Rust frontend
+mirrors it. Plugins use the open `custom` tag. Delivery is additive: everything
+queued arrives in emission order.
 
-Each event is a tagged msgspec Struct, map-encoded with a `"type"` field. The
-union is version-lockstep with the engine like the rest of `EngineCoreOutputs`:
-an unknown tag fails the decode loudly instead of getting skipped. The Rust
-frontend mirrors it. Plugins that can't add a tag use the open `custom` one.
-
-Events are additive (like `SchedulerStats`): everything queued gets delivered
-in order, nothing dropped. So an event can be a full snapshot (consumer
-replaces its state) or a delta (consumer applies each one). Producers throttle
-themselves.
-
-Worker-side producers publish into a process-local buffer, which the engine
-core drains from every rank. A weight-loader plugin reporting per-rank
-transfer throughput, for example:
-
-    from vllm.v1.notifications import (
-        CustomNotification,
-        publish_worker_notification,
-    )
+Worker-side producers publish into a process-local buffer that the engine core
+drains from every rank:
 
     def on_weights_loaded(rank, elapsed_s, num_bytes):
         publish_worker_notification(
             CustomNotification(
                 key="my_loader",
-                payload={
-                    "rank": rank,
-                    "gbps": num_bytes * 8 / elapsed_s / 1e9,
-                },
+                payload={"rank": rank, "gbps": num_bytes * 8 / elapsed_s / 1e9},
             )
         )
-
-Rank identity belongs in the payload: the gather flattens every rank's events
-into one list, so an event that does not say where it came from cannot be told
-apart from its peers.
-
-The frontend side is a stat logger, which sees the events from every rank:
 
     class MyLoaderStatLogger(StatLoggerBase):
         def record(self, *, engine_notifications=None, **kwargs):
             for event in engine_notifications or ():
-                if isinstance(event, CustomNotification) and event.key == "my_loader":
+                if event.key == "my_loader":
                     self.gbps.labels(rank=event.payload["rank"]).set(
                         event.payload["gbps"]
                     )
 
-Delivery: producers that publish during model load are gathered once before
-the engine serves, and in-tree producers gather on their own state changes.
-A producer that publishes at arbitrary later times needs
-`VLLM_WORKER_NOTIFICATION_POLL_INTERVAL` set, since nothing else prompts a
-gather on its behalf.
+The gather flattens all ranks into one list, so rank identity has to live in
+the payload. Producers that publish after model load need
+`VLLM_WORKER_NOTIFICATION_POLL_INTERVAL`; nothing else prompts a gather.
 """
 
 from typing import Any
@@ -68,51 +43,30 @@ class CustomNotification(
     tag="custom",
     omit_defaults=True,  # type: ignore[call-arg]
 ):
-    """Open escape hatch for out-of-tree producers (plugins).
+    """Open escape hatch for out-of-tree producers.
 
-    The union fails fast on unknown tags, so plugins can't add their own struct
-    type. Instead they emit this: namespace under `key`, and place event data
-    in `payload`. Frontends that don't know the `key` just ignore it.
-
-    Left GC-tracked, unlike its siblings: `payload` is arbitrary
-    plugin-supplied data, and a cycle routed through an untracked struct would
-    never be collected.
+    Plugins cannot add a tag to the union, so they namespace under `key` and
+    put event data in `payload`. Frontends ignore keys they do not know. Left
+    GC-tracked, unlike its siblings: `payload` is plugin-supplied, and a cycle
+    routed through an untracked struct is never collected.
     """
 
     key: str
-    """Producer-chosen namespace, e.g. the plugin name."""
-
     payload: dict[str, Any] = {}
-    """Arbitrary msgpack-encodable event data, opaque to anyone who doesn't
-    know `key`."""
 
 
-# All engine-level event types; msgspec dispatches on each struct's tag.
 EngineNotification = CustomNotification
 
-
-# Process-local: worker-side producers get no handle to the runner. A model
-# loader or platform plugin runs several frames below load_model().
 _worker_notifications: list[EngineNotification] = []
 
 
 def publish_worker_notification(notification: EngineNotification) -> None:
-    """Queue a notification from inside the worker process.
-
-    The model runner forwards it on the next `ModelRunnerOutput`. Publishing
-    before the first step is fine, which is the point for producers that only
-    run during model load. Additive and unbounded; producers throttle
-    themselves.
-    """
+    """Queue a notification from inside the worker process."""
     _worker_notifications.append(notification)
 
 
 def take_worker_notifications() -> list[EngineNotification] | None:
-    """Drain everything queued in this worker process since the last call.
-
-    Returns None rather than an empty list so the common case (no producer
-    installed) allocates nothing on the per-step path.
-    """
+    """Drain what this worker process queued since the last call."""
     global _worker_notifications
     if not _worker_notifications:
         return None

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -27,13 +27,16 @@ class CustomNotification(
     msgspec.Struct,
     tag="custom",
     omit_defaults=True,  # type: ignore[call-arg]
-    gc=False,
-):  # type: ignore[call-arg]
+):
     """Open escape hatch for out-of-tree producers (plugins).
 
     The union fails fast on unknown tags, so plugins can't add their own struct
     type. Instead they emit this: namespace under `key`, and place event data
     in `payload`. Frontends that don't know the `key` just ignore it.
+
+    Left GC-tracked, unlike its siblings: `payload` is arbitrary
+    plugin-supplied data, and a cycle routed through an untracked struct would
+    never be collected.
     """
 
     key: str
@@ -64,9 +67,15 @@ def publish_worker_notification(notification: EngineNotification) -> None:
     _worker_notifications.append(notification)
 
 
-def take_worker_notifications() -> list[EngineNotification]:
-    """Drain everything queued in this worker process since the last call."""
+def take_worker_notifications() -> list[EngineNotification] | None:
+    """Drain everything queued in this worker process since the last call.
+
+    Returns None rather than an empty list so the common case (no producer
+    installed) allocates nothing on the per-step path.
+    """
     global _worker_notifications
+    if not _worker_notifications:
+        return None
     pending = _worker_notifications
     _worker_notifications = []
     return pending

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Engine-level event notifications.
+
+Engine-scoped state transitions (unlike per-request `EngineCoreEvent` or
+per-step `SchedulerStats`), forwarded to frontends on
+`EngineCoreOutputs.engine_notifications`. A producer fires one whenever its
+state changes.
+
+Each event is a tagged msgspec Struct, map-encoded with a `"type"` field. The
+union is version-lockstep with the engine like the rest of `EngineCoreOutputs`:
+an unknown tag fails the decode loudly instead of getting skipped. The Rust
+frontend mirrors it. Plugins that can't add a tag use the open `custom` one.
+
+Events are additive (like `SchedulerStats`): everything queued gets delivered
+in order, nothing dropped. So an event can be a full snapshot (consumer
+replaces its state) or a delta (consumer applies each one). Producers throttle
+themselves.
+"""
+
+from typing import Any
+
+import msgspec
+
+
+class CustomNotification(
+    msgspec.Struct,
+    tag="custom",
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):  # type: ignore[call-arg]
+    """Open escape hatch for out-of-tree producers (plugins).
+
+    The union fails fast on unknown tags, so plugins can't add their own struct
+    type. Instead they emit this: namespace under `key`, and place event data
+    in `payload`. Frontends that don't know the `key` just ignore it.
+    """
+
+    key: str
+    """Producer-chosen namespace, e.g. the plugin name."""
+
+    payload: dict[str, Any] = {}
+    """Arbitrary msgpack-encodable event data, opaque to anyone who doesn't
+    know `key`."""
+
+
+# All engine-level event types; msgspec dispatches on each struct's tag.
+EngineNotification = CustomNotification
+
+
+# Process-local: worker-side producers get no handle to the runner. A model
+# loader or platform plugin runs several frames below load_model().
+_worker_notifications: list[EngineNotification] = []
+
+
+def publish_worker_notification(notification: EngineNotification) -> None:
+    """Queue a notification from inside the worker process.
+
+    The model runner forwards it on the next `ModelRunnerOutput`. Publishing
+    before the first step is fine, which is the point for producers that only
+    run during model load. Additive and unbounded; producers throttle
+    themselves.
+    """
+    _worker_notifications.append(notification)
+
+
+def take_worker_notifications() -> list[EngineNotification]:
+    """Drain everything queued in this worker process since the last call."""
+    global _worker_notifications
+    pending = _worker_notifications
+    _worker_notifications = []
+    return pending

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -16,6 +16,46 @@ Events are additive (like `SchedulerStats`): everything queued gets delivered
 in order, nothing dropped. So an event can be a full snapshot (consumer
 replaces its state) or a delta (consumer applies each one). Producers throttle
 themselves.
+
+Worker-side producers publish into a process-local buffer, which the engine
+core drains from every rank. A weight-loader plugin reporting per-rank
+transfer throughput, for example:
+
+    from vllm.v1.notifications import (
+        CustomNotification,
+        publish_worker_notification,
+    )
+
+    def on_weights_loaded(rank, elapsed_s, num_bytes):
+        publish_worker_notification(
+            CustomNotification(
+                key="my_loader",
+                payload={
+                    "rank": rank,
+                    "gbps": num_bytes * 8 / elapsed_s / 1e9,
+                },
+            )
+        )
+
+Rank identity belongs in the payload: the gather flattens every rank's events
+into one list, so an event that does not say where it came from cannot be told
+apart from its peers.
+
+The frontend side is a stat logger, which sees the events from every rank:
+
+    class MyLoaderStatLogger(StatLoggerBase):
+        def record(self, *, engine_notifications=None, **kwargs):
+            for event in engine_notifications or ():
+                if isinstance(event, CustomNotification) and event.key == "my_loader":
+                    self.gbps.labels(rank=event.payload["rank"]).set(
+                        event.payload["gbps"]
+                    )
+
+Delivery: producers that publish during model load are gathered once before
+the engine serves, and in-tree producers gather on their own state changes.
+A producer that publishes at arbitrary later times needs
+`VLLM_WORKER_NOTIFICATION_POLL_INTERVAL` set, since nothing else prompts a
+gather on its behalf.
 """
 
 from typing import Any

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -26,6 +26,8 @@ identity has to live in the payload. Producers that publish after model load
 need `VLLM_WORKER_NOTIFICATION_POLL_INTERVAL`; nothing else prompts a gather.
 """
 
+import threading
+from collections import deque
 from typing import Any
 
 import msgspec
@@ -59,27 +61,33 @@ EngineNotification = CustomNotification
 
 MAX_BUFFERED_NOTIFICATIONS = 1024
 
-_worker_notifications: list[EngineNotification] = []
+_worker_notifications: deque[EngineNotification] = deque(
+    maxlen=MAX_BUFFERED_NOTIFICATIONS
+)
+_worker_notifications_lock = threading.Lock()
 
 
 def publish_worker_notification(notification: EngineNotification) -> None:
-    """Queue a notification from inside the worker process."""
-    if len(_worker_notifications) >= MAX_BUFFERED_NOTIFICATIONS:
-        logger.warning_once(
-            "Worker notification buffer is full (%d); dropping the oldest "
-            "notification. Set VLLM_WORKER_NOTIFICATION_POLL_INTERVAL so the "
-            "engine drains the buffer.",
-            MAX_BUFFERED_NOTIFICATIONS,
-        )
-        del _worker_notifications[0]
-    _worker_notifications.append(notification)
+    """Queue a notification from inside the worker process.
+
+    Safe to call from any thread; producers such as transfer callbacks
+    publish concurrently with the engine's drain."""
+    with _worker_notifications_lock:
+        if len(_worker_notifications) == MAX_BUFFERED_NOTIFICATIONS:
+            logger.warning_once(
+                "Worker notification buffer is full (%d); dropping the oldest "
+                "notification. Set VLLM_WORKER_NOTIFICATION_POLL_INTERVAL so "
+                "the engine drains the buffer.",
+                MAX_BUFFERED_NOTIFICATIONS,
+            )
+        _worker_notifications.append(notification)
 
 
 def take_worker_notifications() -> list[EngineNotification] | None:
     """Drain what this worker process queued since the last call."""
-    global _worker_notifications
-    if not _worker_notifications:
-        return None
-    pending = _worker_notifications
-    _worker_notifications = []
-    return pending
+    with _worker_notifications_lock:
+        if not _worker_notifications:
+            return None
+        pending = list(_worker_notifications)
+        _worker_notifications.clear()
+        return pending

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -20,17 +20,10 @@ drains from every rank:
             )
         )
 
-    class MyLoaderStatLogger(StatLoggerBase):
-        def record(self, *, engine_notifications=None, **kwargs):
-            for event in engine_notifications or ():
-                if event.key == "my_loader":
-                    self.gbps.labels(rank=event.payload["rank"]).set(
-                        event.payload["gbps"]
-                    )
-
-The gather flattens all ranks into one list, so rank identity has to live in
-the payload. Producers that publish after model load need
-`VLLM_WORKER_NOTIFICATION_POLL_INTERVAL`; nothing else prompts a gather.
+Consumers read them off `EngineCoreOutputs.engine_notifications` in the
+frontend process. The gather flattens all ranks into one list, so rank
+identity has to live in the payload. Producers that publish after model load
+need `VLLM_WORKER_NOTIFICATION_POLL_INTERVAL`; nothing else prompts a gather.
 """
 
 from typing import Any

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -30,6 +30,10 @@ from typing import Any
 
 import msgspec
 
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
 
 class CustomNotification(
     msgspec.Struct,
@@ -42,6 +46,9 @@ class CustomNotification(
     put event data in `payload`. Frontends ignore keys they do not know. Left
     GC-tracked, unlike its siblings: `payload` is plugin-supplied, and a cycle
     routed through an untracked struct is never collected.
+
+    `payload` must hold string keys and msgpack-encodable values; this is
+    checked only when the engine serializes it, not at construction.
     """
 
     key: str
@@ -50,11 +57,21 @@ class CustomNotification(
 
 EngineNotification = CustomNotification
 
+MAX_BUFFERED_NOTIFICATIONS = 1024
+
 _worker_notifications: list[EngineNotification] = []
 
 
 def publish_worker_notification(notification: EngineNotification) -> None:
     """Queue a notification from inside the worker process."""
+    if len(_worker_notifications) >= MAX_BUFFERED_NOTIFICATIONS:
+        logger.warning_once(
+            "Worker notification buffer is full (%d); dropping the oldest "
+            "notification. Set VLLM_WORKER_NOTIFICATION_POLL_INTERVAL so the "
+            "engine drains the buffer.",
+            MAX_BUFFERED_NOTIFICATIONS,
+        )
+        del _worker_notifications[0]
     _worker_notifications.append(notification)
 
 

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -6,8 +6,9 @@ Engine-scoped state transitions, forwarded to frontends on
 `EngineCoreOutputs.engine_notifications`. Tagged msgspec structs, map-encoded
 with a `"type"` field; an unknown tag fails the decode rather than being
 skipped, so the union stays version-lockstep with the engine. The Rust frontend
-mirrors it. Plugins use the open `custom` tag. Delivery is additive: everything
-queued arrives in emission order.
+mirrors it. In-tree producers get their own tag (`LoRALoadEvent`); plugins use
+the open `custom` tag. Delivery is additive: everything queued arrives in
+emission order.
 
 Worker-side producers publish into a process-local buffer that the engine core
 drains from every rank:
@@ -22,8 +23,13 @@ drains from every rank:
 
 Consumers read them off `EngineCoreOutputs.engine_notifications` in the
 frontend process. The gather flattens all ranks into one list, so rank
-identity has to live in the payload. Producers that publish after model load
-need `VLLM_WORKER_NOTIFICATION_POLL_INTERVAL`; nothing else prompts a gather.
+identity has to live in the payload.
+
+The engine core gathers once before serving, after every add/remove/pin LoRA
+call, and after any step whose `ModelRunnerOutput` reports
+`worker_notifications_pending` (the output rank rings that doorbell when its
+buffer is non-empty). Producers on other ranks that publish outside a step
+need `VLLM_WORKER_NOTIFICATION_POLL_INTERVAL`.
 """
 
 import threading
@@ -35,6 +41,28 @@ import msgspec
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+class LoRALoadEvent(
+    msgspec.Struct,
+    tag="lora_load_event",
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):
+    """The set of loaded LoRA adapters changed.
+
+    A full snapshot of the worker's adapter caches, so consumers replace their
+    state rather than merge. Adapters are keyed by name.
+    """
+
+    gpu_adapters: list[str] = []
+    """Adapters activated into GPU slots (sorted)."""
+
+    cpu_adapters: list[str] = []
+    """Adapters resident in the CPU cache (sorted, superset of gpu_adapters)."""
+
+    pinned_adapters: list[str] = []
+    """Adapters pinned in the caches (sorted)."""
 
 
 class CustomNotification(
@@ -57,7 +85,7 @@ class CustomNotification(
     payload: dict[str, Any] = {}
 
 
-EngineNotification = CustomNotification
+EngineNotification = LoRALoadEvent | CustomNotification
 
 MAX_BUFFERED_NOTIFICATIONS = 1024
 
@@ -81,6 +109,12 @@ def publish_worker_notification(notification: EngineNotification) -> None:
                 MAX_BUFFERED_NOTIFICATIONS,
             )
         _worker_notifications.append(notification)
+
+
+def has_pending_worker_notifications() -> bool:
+    """Cheap doorbell check for the step path; no lock, a stale answer only
+    delays the gather to the next step."""
+    return bool(_worker_notifications)
 
 
 def take_worker_notifications() -> list[EngineNotification] | None:

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -80,6 +80,9 @@ class LoRALoadEvent(
     pinned_adapters: list[str] = []
     """Adapters pinned in the caches (sorted)."""
 
+    ranks: dict[str, int] = {}
+    """LoRA rank of each resident adapter, keyed by name."""
+
     loads: list[LoRALoadTiming] = []
     """Adapter transitions completed since the previous event, in order."""
 

--- a/vllm/v1/notifications.py
+++ b/vllm/v1/notifications.py
@@ -43,16 +43,32 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
+class LoRALoadTiming(
+    msgspec.Struct,
+    omit_defaults=True,  # type: ignore[call-arg]
+    gc=False,
+):
+    """One measured adapter transition on the worker."""
+
+    adapter_name: str
+    transition: str
+    """`load`: read from disk into the CPU cache. `activate`: moved from the
+    CPU cache into a GPU slot."""
+    seconds: float
+
+
 class LoRALoadEvent(
     msgspec.Struct,
     tag="lora_load_event",
     omit_defaults=True,  # type: ignore[call-arg]
     gc=False,
 ):
-    """The set of loaded LoRA adapters changed.
+    """The set of loaded LoRA adapters changed, or an adapter transition
+    completed.
 
     A full snapshot of the worker's adapter caches, so consumers replace their
-    state rather than merge. Adapters are keyed by name.
+    state rather than merge. Adapters are keyed by name. `loads` carries the
+    transitions measured since the previous event.
     """
 
     gpu_adapters: list[str] = []
@@ -63,6 +79,9 @@ class LoRALoadEvent(
 
     pinned_adapters: list[str] = []
     """Adapters pinned in the caches (sorted)."""
+
+    loads: list[LoRALoadTiming] = []
+    """Adapter transitions completed since the previous event, in order."""
 
 
 class CustomNotification(

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -369,6 +369,10 @@ class ModelRunnerOutput:
     # ``None`` when ``return_sampling_mask`` is off.
     sampling_masks: SamplingMaskLists | None = None
 
+    # Doorbell: this worker's notification buffer is non-empty, so the engine
+    # core should gather from every rank after this step.
+    worker_notifications_pending: bool = False
+
     @staticmethod
     def with_kv_conn_output_only(
         kv_connector_output: KVConnectorOutput | None,

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -13,7 +13,6 @@ import torch
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.notifications import EngineNotification
 
 if TYPE_CHECKING:
     from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorWorkerMetadata
@@ -355,10 +354,6 @@ class ModelRunnerOutput:
 
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
-
-    # Worker-originated engine events, forwarded by the engine core to
-    # frontends on EngineCoreOutputs.engine_notifications.
-    worker_notifications: list[EngineNotification] | None = None
 
     # Per-step routed experts data captured by the worker.
     # ``routing_data`` shape: (num_scheduled_tokens, num_layers,

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -13,6 +13,7 @@ import torch
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.notifications import EngineNotification
 
 if TYPE_CHECKING:
     from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorWorkerMetadata
@@ -354,6 +355,10 @@ class ModelRunnerOutput:
 
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
+
+    # Worker-originated engine events, forwarded by the engine core to
+    # frontends on EngineCoreOutputs.engine_notifications.
+    worker_notifications: list[EngineNotification] | None = None
 
     # Per-step routed experts data captured by the worker.
     # ``routing_data`` shape: (num_scheduled_tokens, num_layers,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -72,6 +72,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
+from vllm.v1.notifications import has_pending_worker_notifications
 from vllm.v1.outputs import (
     DraftTokenIds,
     ECConnectorOutput,
@@ -1969,6 +1970,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             sampled_token_ids=None,  # type: ignore
             prompt_logprobs_dict=prompt_logprobs_dict,  # type: ignore[arg-type]
             cudagraph_stats=cudagraph_stats,
+            worker_notifications_pending=has_pending_worker_notifications(),
         )
         # Start async output copy here so that it can overlap with speculator proposal.
         async_output = AsyncOutput(
@@ -2092,6 +2094,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
             kv_connector_output=kv_connector_output,
             ec_connector_output=ec_connector_output,
+            worker_notifications_pending=has_pending_worker_notifications(),
         )
         async_output = AsyncPoolingOutput(
             model_runner_output=model_runner_output,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -72,6 +72,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
+from vllm.v1.notifications import take_worker_notifications
 from vllm.v1.outputs import (
     DraftTokenIds,
     ECConnectorOutput,
@@ -2054,6 +2055,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
         model_runner_output.kv_connector_output = kv_connector_output
         model_runner_output.ec_connector_output = ec_connector_output
+        model_runner_output.worker_notifications = take_worker_notifications() or None
 
         return async_output
 
@@ -2092,6 +2094,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
             kv_connector_output=kv_connector_output,
             ec_connector_output=ec_connector_output,
+            worker_notifications=take_worker_notifications() or None,
         )
         async_output = AsyncPoolingOutput(
             model_runner_output=model_runner_output,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -2055,7 +2055,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
         model_runner_output.kv_connector_output = kv_connector_output
         model_runner_output.ec_connector_output = ec_connector_output
-        model_runner_output.worker_notifications = take_worker_notifications() or None
+        model_runner_output.worker_notifications = take_worker_notifications()
 
         return async_output
 
@@ -2094,7 +2094,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
             kv_connector_output=kv_connector_output,
             ec_connector_output=ec_connector_output,
-            worker_notifications=take_worker_notifications() or None,
+            worker_notifications=take_worker_notifications(),
         )
         async_output = AsyncPoolingOutput(
             model_runner_output=model_runner_output,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -72,7 +72,6 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
-from vllm.v1.notifications import take_worker_notifications
 from vllm.v1.outputs import (
     DraftTokenIds,
     ECConnectorOutput,
@@ -2055,7 +2054,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
         model_runner_output.kv_connector_output = kv_connector_output
         model_runner_output.ec_connector_output = ec_connector_output
-        model_runner_output.worker_notifications = take_worker_notifications()
 
         return async_output
 
@@ -2094,7 +2092,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             req_id_to_index={req_id: i for i, req_id in enumerate(input_batch.req_ids)},
             kv_connector_output=kv_connector_output,
             ec_connector_output=ec_connector_output,
-            worker_notifications=take_worker_notifications(),
         )
         async_output = AsyncPoolingOutput(
             model_runner_output=model_runner_output,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3554,7 +3554,7 @@ class GPUModelRunner(
             req_ids=self.input_batch.req_ids.copy(),
             req_id_to_index=self.input_batch.req_id_to_index.copy(),
             kv_connector_output=kv_connector_output,
-            worker_notifications=take_worker_notifications() or None,
+            worker_notifications=take_worker_notifications(),
         )
 
         if raw_pooler_output is None or not any(finished_mask):
@@ -4879,7 +4879,7 @@ class GPUModelRunner(
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
-                worker_notifications=take_worker_notifications() or None,
+                worker_notifications=take_worker_notifications(),
                 routed_experts=None,
             )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -173,6 +173,7 @@ from vllm.v1.kv_cache_interface import (
     get_kv_cache_spec_kind,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+from vllm.v1.notifications import has_pending_worker_notifications
 from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
     AsyncModelRunnerOutput,
@@ -3553,6 +3554,7 @@ class GPUModelRunner(
             req_ids=self.input_batch.req_ids.copy(),
             req_id_to_index=self.input_batch.req_id_to_index.copy(),
             kv_connector_output=kv_connector_output,
+            worker_notifications_pending=has_pending_worker_notifications(),
         )
 
         if raw_pooler_output is None or not any(finished_mask):
@@ -4878,6 +4880,7 @@ class GPUModelRunner(
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts=None,
+                worker_notifications_pending=has_pending_worker_notifications(),
             )
 
         if not self.use_async_scheduling:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -173,6 +173,7 @@ from vllm.v1.kv_cache_interface import (
     get_kv_cache_spec_kind,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+from vllm.v1.notifications import take_worker_notifications
 from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
     AsyncModelRunnerOutput,
@@ -3553,6 +3554,7 @@ class GPUModelRunner(
             req_ids=self.input_batch.req_ids.copy(),
             req_id_to_index=self.input_batch.req_id_to_index.copy(),
             kv_connector_output=kv_connector_output,
+            worker_notifications=take_worker_notifications() or None,
         )
 
         if raw_pooler_output is None or not any(finished_mask):
@@ -4877,6 +4879,7 @@ class GPUModelRunner(
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
+                worker_notifications=take_worker_notifications() or None,
                 routed_experts=None,
             )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -173,7 +173,6 @@ from vllm.v1.kv_cache_interface import (
     get_kv_cache_spec_kind,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
-from vllm.v1.notifications import take_worker_notifications
 from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
     AsyncModelRunnerOutput,
@@ -3554,7 +3553,6 @@ class GPUModelRunner(
             req_ids=self.input_batch.req_ids.copy(),
             req_id_to_index=self.input_batch.req_id_to_index.copy(),
             kv_connector_output=kv_connector_output,
-            worker_notifications=take_worker_notifications(),
         )
 
         if raw_pooler_output is None or not any(finished_mask):
@@ -4879,7 +4877,6 @@ class GPUModelRunner(
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
-                worker_notifications=take_worker_notifications(),
                 routed_experts=None,
             )
 

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -16,9 +16,11 @@ from vllm.config import VllmConfig
 from vllm.config.lora import LoRAConfig
 from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping, LoRAMappingType
+from vllm.lora.model_manager import LoRALoadedState
 from vllm.lora.request import LoRARequest
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor.models import supports_lora
+from vllm.v1.notifications import LoRALoadEvent, publish_worker_notification
 from vllm.v1.worker.gpu_input_batch import InputBatch as GPUInputBatch
 from vllm.v1.worker.tpu_input_batch import InputBatch as TPUInputBatch
 
@@ -31,6 +33,7 @@ logger = init_logger(__name__)
 class LoRAModelRunnerMixin:
     lora_config: LoRAConfig | None
     get_model: Callable[[], nn.Module]
+    _last_lora_loaded_state: LoRALoadedState | None = None
 
     def reset_lora_state(self) -> None:
         """Invalidate LoRA state after base weights are replaced."""
@@ -43,6 +46,25 @@ class LoRAModelRunnerMixin:
         for module in self.get_model().modules():
             if isinstance(module, LogitsProcessorWithLoRA):
                 module.reset_sharded_to_full_mapping()
+        self._publish_lora_load_event()
+
+    def _publish_lora_load_event(self) -> None:
+        """Publish a LoRALoadEvent if the loaded set changed since the last
+        publish. Unchanged costs three small set copies and a compare."""
+        state = self.lora_manager.get_loaded_state()
+        if state == self._last_lora_loaded_state:
+            return
+        self._last_lora_loaded_state = state
+        gpu_adapters, cpu_adapters, pinned_adapters = (
+            self.lora_manager.get_loaded_names(state)
+        )
+        publish_worker_notification(
+            LoRALoadEvent(
+                gpu_adapters=gpu_adapters,
+                cpu_adapters=cpu_adapters,
+                pinned_adapters=pinned_adapters,
+            )
+        )
 
     def load_lora_model(
         self,
@@ -81,6 +103,7 @@ class LoRAModelRunnerMixin:
             type=mapping_type,
         )
         self.lora_manager.set_active_adapters(lora_requests, lora_mapping)
+        self._publish_lora_load_event()
 
     def _ensure_lora_enabled(self) -> None:
         if not hasattr(self, "lora_manager"):
@@ -286,18 +309,25 @@ class LoRAModelRunnerMixin:
         if lora_config is None:
             return
         self.lora_manager.remove_all_adapters()
+        self._publish_lora_load_event()
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         self._ensure_lora_enabled()
-        return self.lora_manager.add_adapter(lora_request)
+        added = self.lora_manager.add_adapter(lora_request)
+        self._publish_lora_load_event()
+        return added
 
     def remove_lora(self, lora_id: int) -> bool:
         self._ensure_lora_enabled()
-        return self.lora_manager.remove_adapter(lora_id)
+        removed = self.lora_manager.remove_adapter(lora_id)
+        self._publish_lora_load_event()
+        return removed
 
     def pin_lora(self, lora_id: int) -> bool:
         self._ensure_lora_enabled()
-        return self.lora_manager.pin_adapter(lora_id)
+        pinned = self.lora_manager.pin_adapter(lora_id)
+        self._publish_lora_load_event()
+        return pinned
 
     def list_loras(self) -> set[int]:
         self._ensure_lora_enabled()

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -65,6 +65,7 @@ class LoRAModelRunnerMixin:
                 gpu_adapters=gpu_adapters,
                 cpu_adapters=cpu_adapters,
                 pinned_adapters=pinned_adapters,
+                ranks=self.lora_manager.get_loaded_ranks(state),
                 loads=loads,
             )
         )

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -50,9 +50,11 @@ class LoRAModelRunnerMixin:
 
     def _publish_lora_load_event(self) -> None:
         """Publish a LoRALoadEvent if the loaded set changed since the last
-        publish. Unchanged costs three small set copies and a compare."""
+        publish or a transition was timed. Unchanged costs three small set
+        copies and a compare."""
         state = self.lora_manager.get_loaded_state()
-        if state == self._last_lora_loaded_state:
+        loads = self.lora_manager.drain_load_timings()
+        if state == self._last_lora_loaded_state and not loads:
             return
         self._last_lora_loaded_state = state
         gpu_adapters, cpu_adapters, pinned_adapters = (
@@ -63,6 +65,7 @@ class LoRAModelRunnerMixin:
                 gpu_adapters=gpu_adapters,
                 cpu_adapters=cpu_adapters,
                 pinned_adapters=pinned_adapters,
+                loads=loads,
             )
         )
 

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -200,11 +200,7 @@ class WorkerBase:
         raise NotImplementedError
 
     def take_notifications(self) -> list["EngineNotification"]:
-        """Drain notifications published in this worker process.
-
-        Gathered from every rank, so producers on non-output ranks are not
-        discarded. See vllm/v1/notifications.py.
-        """
+        """Drain notifications published in this worker process."""
         return take_worker_notifications() or []
 
     @property

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -21,6 +21,7 @@ from vllm.v1.attention.backends.utils import (
     record_kv_cache_layout,
 )
 from vllm.v1.kv_cache_interface import KVCacheSpec
+from vllm.v1.notifications import EngineNotification, take_worker_notifications
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -197,6 +198,14 @@ class WorkerBase:
 
     def list_loras(self) -> set[int]:
         raise NotImplementedError
+
+    def take_notifications(self) -> list["EngineNotification"]:
+        """Drain notifications published in this worker process.
+
+        Gathered from every rank, so producers on non-output ranks are not
+        discarded. See vllm/v1/notifications.py.
+        """
+        return take_worker_notifications() or []
 
     @property
     def vocab_size(self) -> int:


### PR DESCRIPTION
## Stack

1. #51433 engine notification channel 
2. #54830 LoRA load events, doorbell, and Python Prometheus metrics
3. #54833 Rust frontend consumer for the same metrics (this PR)

Each PR is based on `main` and includes the commits of the ones before it; review only the last commits of each.

End-to-end testing on the Rust frontend needs #54836 (`--lora-modules` support), tracked separately.
