### PR TITLE
[Bugfix] Implicitly close DeepSeek DSML parameters

### DIFF
--- a/tests/parser/engine/test_deepseek_v32.py
+++ b/tests/parser/engine/test_deepseek_v32.py
@@ -181,6 +181,25 @@ class TestInitialState:
 
 
 class TestStreaming:
+    def test_split_parameter_start_is_buffered(self, mock_tokenizer, mock_request):
+        chunks = [
+            DSML_FUNC_START,
+            f"{DSML_INVOKE_PREFIX}edit{DSML_INVOKE_NAME_END}",
+            f"<{_PARAM_OPEN.format(name='expr', is_str='true')}a<b><｜DSML｜parameter",
+            ' name="date" string="true">tomorrow',
+            _PARAM_CLOSE,
+            DSML_INVOKE_END,
+            DSML_FUNC_END,
+        ]
+
+        results = simulate_tool_streaming(
+            DeepSeekV32Parser(mock_tokenizer), mock_request, chunks
+        )
+
+        arguments = collect_tool_arguments(results)
+        assert "<｜DSML｜parameter" not in arguments
+        assert json.loads(arguments) == {"expr": "a<b>", "date": "tomorrow"}
+
     def test_single_tool_streaming(self, mock_tokenizer, mock_request):
         text = _func_calls(
             _invoke("get_weather", _param("city", "true", "SF")),

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -154,6 +154,26 @@ class TestArgConverter:
         assert result["city"] == "Tokyo"
         assert result["expr"] == "x<5"
 
+    def test_next_parameter_prefix_implicitly_closes_previous(self):
+        raw = (
+            f"<{_PARAM_OPEN.format(name='city', is_str='true')}Tokyo\n"
+            "<｜DSML｜parameter name="
+        )
+        result = json.loads(_dsml_arg_converter(raw, partial=False))
+        assert result == {"city": "Tokyo\n"}
+
+    def test_implicit_close_preserves_malformed_text(self):
+        raw = (
+            f"<{_PARAM_OPEN.format(name='city', is_str='true')}"
+            "Tokyo</｜DSML｜parameter\n"
+            f"<{_PARAM_OPEN.format(name='unit', is_str='true')}celsius{_PARAM_CLOSE}"
+        )
+        result = json.loads(_dsml_arg_converter(raw, partial=False))
+        assert result == {
+            "city": "Tokyo</｜DSML｜parameter\n",
+            "unit": "celsius",
+        }
+
     def test_null_string_false(self):
         raw = self._raw(("val", "false", "null"))
         result = json.loads(_dsml_arg_converter(raw, partial=False))
@@ -164,6 +184,51 @@ class TestArgConverter:
         result = json.loads(_dsml_arg_converter(raw, partial=False))
         assert result["n"] == "42"
         assert isinstance(result["n"], str)
+
+
+class TestImplicitParameterClose:
+    def test_non_streaming_recovers_next_parameter(self, mock_tokenizer, mock_request):
+        text = (
+            f"{DSML_TOOL_START}"
+            f"{DSML_INVOKE_PREFIX}get_weather{DSML_INVOKE_NAME_END}\n"
+            f"<{_PARAM_OPEN.format(name='location', is_str='true')}Paris "
+            f"<{_PARAM_OPEN.format(name='date', is_str='true')}"
+            f"tomorrow{_PARAM_CLOSE}"
+            f"{DSML_INVOKE_END}{DSML_TOOL_END}"
+        )
+
+        result = DeepSeekV4Parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "location": "Paris ",
+            "date": "tomorrow",
+        }
+
+    def test_streaming_split_next_parameter_tag_is_buffered(
+        self, mock_tokenizer, mock_request
+    ):
+        chunks = [
+            DSML_TOOL_START,
+            f"{DSML_INVOKE_PREFIX}get_weather{DSML_INVOKE_NAME_END}\n",
+            f"<{_PARAM_OPEN.format(name='location', is_str='true')}Paris ",
+            "<｜DSML｜param",
+            'eter name="date" string="true">tomorrow',
+            _PARAM_CLOSE,
+            DSML_INVOKE_END,
+            DSML_TOOL_END,
+        ]
+
+        results = simulate_tool_streaming(
+            DeepSeekV4Parser(mock_tokenizer), mock_request, chunks
+        )
+
+        arguments = collect_tool_arguments(results)
+        assert "<｜DSML｜param" not in arguments
+        assert json.loads(arguments) == {
+            "location": "Paris ",
+            "date": "tomorrow",
+        }
 
 
 # ── Bare </think> absorption and duplicate <think> absorption ─────────

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -211,9 +211,9 @@ class TestImplicitParameterClose:
         chunks = [
             DSML_TOOL_START,
             f"{DSML_INVOKE_PREFIX}get_weather{DSML_INVOKE_NAME_END}\n",
-            f"<{_PARAM_OPEN.format(name='location', is_str='true')}Paris ",
-            "<｜DSML｜param",
-            'eter name="date" string="true">tomorrow',
+            f"<{_PARAM_OPEN.format(name='location', is_str='true')}"
+            "Paris a<b><｜DSML｜parameter",
+            ' name="date" string="true">tomorrow',
             _PARAM_CLOSE,
             DSML_INVOKE_END,
             DSML_TOOL_END,
@@ -226,7 +226,7 @@ class TestImplicitParameterClose:
         arguments = collect_tool_arguments(results)
         assert "<｜DSML｜param" not in arguments
         assert json.loads(arguments) == {
-            "location": "Paris ",
+            "location": "Paris a<b>",
             "date": "tomorrow",
         }
 

--- a/vllm/parser/deepseek_v32.py
+++ b/vllm/parser/deepseek_v32.py
@@ -26,6 +26,7 @@ from vllm.parser.deepseek_v4 import (
     DSML_INVOKE_NAME_END,
     DSML_INVOKE_PREFIX,
     DSML_PARAM_CLOSE,
+    DSML_PARAM_START,
     _dsml_arg_converter,
     _unwrap_wrapper_args,
 )
@@ -58,6 +59,7 @@ def deepseek_v32_config() -> ParserEngineConfig:
             "INVOKE_PREFIX": DSML_INVOKE_PREFIX,
             "INVOKE_NAME_END": DSML_INVOKE_NAME_END,
             "INVOKE_END": DSML_INVOKE_END,
+            "PARAM_START": DSML_PARAM_START,
             "PARAM_CLOSE": DSML_PARAM_CLOSE,
         },
         token_id_terminals={

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -47,6 +47,7 @@ DSML_TOOL_END = f"</{_DSML}tool_calls>"
 DSML_INVOKE_PREFIX = f'<{_DSML}invoke name="'
 DSML_INVOKE_NAME_END = '">'
 DSML_INVOKE_END = f"</{_DSML}invoke>"
+DSML_PARAM_START = f"<{_DSML}parameter"
 DSML_PARAM_CLOSE = f"</{_DSML}parameter>"
 
 _ESCAPED_DSML = re.escape(_DSML)
@@ -135,6 +136,7 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
             "INVOKE_PREFIX": DSML_INVOKE_PREFIX,
             "INVOKE_NAME_END": DSML_INVOKE_NAME_END,
             "INVOKE_END": DSML_INVOKE_END,
+            "PARAM_START": DSML_PARAM_START,
             "PARAM_CLOSE": DSML_PARAM_CLOSE,
         },
         token_id_terminals={

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -52,7 +52,8 @@ DSML_PARAM_CLOSE = f"</{_DSML}parameter>"
 _ESCAPED_DSML = re.escape(_DSML)
 _PARAM_RE = re.compile(
     rf'<{_ESCAPED_DSML}parameter\s+name="([^"]+)"\s+string="(true|false)">'
-    rf"(.*?)</{_ESCAPED_DSML}parameter>",
+    rf"(.*?)"
+    rf"(?:</{_ESCAPED_DSML}parameter>|(?=<{_ESCAPED_DSML}parameter\s+name=))",
     re.DOTALL,
 )
 _PARTIAL_PARAM_RE = re.compile(


### PR DESCRIPTION
## Purpose
Partially fix #53227.
Allow a DeepSeek DSML parameter to end implicitly when the next parameter begins. This prevents a missing parameter closer from swallowing the following parameter.  The shared converter also applies this behavior to DeepSeek V3.2.

## Test Plan
### Unit tests
```
pytest tests/parser/ tests/tool_parsers/test_deepseekv4_tool_parser.py
       tests/tool_parsers/test_deepseekv32_tool_parser.py -q
```

### Live server validation

Validated against a live `deepseek-ai/DeepSeek-V4-Flash` server.

**End-to-end:** 8 prompt shapes (parallel calls, 3-param calls, values containing `<`/XML markup, multi-line values, unicode, numeric/bool params, long values) × {streaming, non-streaming} × {`tool_choice: auto`, `required`} — 32 request pairs. No DSML markup in arguments, all arguments valid JSON, all keys within the tool schema.

**Chunk-boundary correctness:** the server only exercises one token split, so 64 raw generations were captured unparsed (via `/tokenize` → `/v1/completions`) and replayed through the parser at splits of 1/2/3/7/17 chars plus randomized splits — 704 replays per corpus — asserting chunk-size invariance and no terminal leakage.

| Corpus | main | this PR |
|---|---|---|
| 64 real generations, 704 replays | pass | pass |
| same, one `</｜DSML｜parameter>` dropped, 704 replays | **421 failures** | pass |
| parameter recovery across the 64 malformed samples | **64 lost/corrupted** | 64 recovered |