### PR TITLE
[Model] Qwen4Exp: fp8_e4m3 and nvfp4 KV cache on the QSA path

### DIFF
--- a/tests/models/qwen4_exp/test_qsa_kv_quant.py
+++ b/tests/models/qwen4_exp/test_qsa_kv_quant.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Numerical tests for the fp8_e4m3 and nvfp4 KV cache branches of the QSA
+sparse paged attention kernel.
+
+The kernel is compared against a float64 PyTorch reference computed on the
+*dequantized* cache contents, so the comparison measures the kernel, not the
+quantization error. The bf16 branch must stay bitwise identical with and
+without the scale arguments (the quantized branches are compiled out).
+"""
+
+import pytest
+import torch
+
+from vllm.models.qwen4_exp.nvidia import (
+    model as _qwen4_exp_model,  # noqa: F401
+)
+from vllm.models.qwen4_exp.nvidia import qsa as qsa_backend
+from vllm.models.qwen4_exp.nvidia.ops.qsa import qsa_sparse_paged_attention
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
+from vllm.utils.torch_utils import nvfp4_kv_cache_full_dim, nvfp4_split_data_scale
+
+requires_qsa_kernels = pytest.mark.skipif(
+    not current_platform.is_cuda() or not HAS_TRITON,
+    reason="QSA kernels require CUDA and Triton",
+)
+
+NUM_HEADS = 24
+NUM_KV_HEADS = 2
+HEAD_DIM = 256
+PAGE_SIZE = 64
+TOPK = 2051  # indexer budget 2048 + compress ratio 4 - 1
+NUM_REQ = 2
+SEQ_LEN = 4096
+# Query-row counts that exercise every tile profile of the wrapper
+# (BLOCK_N=16 decode profiles and the wide prefill profiles).
+TILE_PROFILE_ROWS = (2, 5, 64, 200, 300)
+
+_E2M1 = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+
+
+def _reference(q, k_cache, v_cache, indices, block_table, token_to_req):
+    """Same computation as the kernel, in float64 with plain PyTorch."""
+    rows, heads, dim = q.shape
+    group = heads // k_cache.shape[2]
+    out = torch.zeros(rows, heads, dim, dtype=torch.float64, device=q.device)
+    max_pages = block_table.shape[1]
+    for r in range(rows):
+        req = int(token_to_req[r])
+        tok = indices[r]
+        valid = tok >= 0
+        tok = tok.clamp(min=0)
+        page = tok // PAGE_SIZE
+        valid &= page < max_pages
+        offset = tok % PAGE_SIZE
+        phys = block_table[req, page.clamp(max=max_pages - 1)]
+        valid &= (phys >= 0) & (phys < k_cache.shape[0])
+        idx = valid.nonzero(as_tuple=True)[0]
+        if idx.numel() == 0:
+            continue
+        p = phys[idx].long()
+        o = offset[idx].long()
+        for kvh in range(k_cache.shape[2]):
+            keys = k_cache[p, o, kvh].to(torch.float64)
+            values = v_cache[p, o, kvh].to(torch.float64)
+            for h in range(kvh * group, (kvh + 1) * group):
+                scores = (q[r, h].to(torch.float64) @ keys.T) * (dim**-0.5)
+                w = torch.softmax(scores, dim=0)
+                out[r, h] = w @ values
+    return out
+
+
+def _rel_error(a: torch.Tensor, b: torch.Tensor) -> float:
+    d = (a.to(torch.float64) - b.to(torch.float64)).abs().mean()
+    return (d / b.to(torch.float64).abs().mean().clamp(min=1e-12)).item()
+
+
+def _e4m3_scale_to_float(bits: torch.Tensor) -> torch.Tensor:
+    payload = bits.to(torch.int32) & 0x7F
+    exp = (payload >> 3) & 0x0F
+    mant = payload & 0x07
+    normal = torch.pow(2.0, exp.float() - 7.0) * (1.0 + mant.float() / 8.0)
+    subnormal = mant.float() / 512.0
+    value = torch.where(exp == 0, subnormal, normal)
+    return torch.where(payload == 0, torch.zeros_like(value), value)
+
+
+def _scale_coords(page_size: int, scale_dim: int, swizzled: bool, device):
+    t = torch.arange(page_size, device=device).view(-1, 1)
+    s = torch.arange(scale_dim, device=device).view(1, -1)
+    if not swizzled:
+        return t.expand(page_size, scale_dim), s.expand(page_size, scale_dim)
+    g = scale_dim // 4
+    return (t // 4) * 4 + (s // g), (s % g) * 4 + (t % 4)
+
+
+def _dequantize_nvfp4(kv_cache, num_kv_heads, head_dim, k_swizzled, v_swizzled):
+    """Unpack an nvfp4 cache in PyTorch. Returns bf16 K and V of shape
+    [B, N, H, head_dim], the layout the bf16 kernel expects."""
+    dev = kv_cache.device
+    table = torch.tensor(_E2M1 + [-v for v in _E2M1], dtype=torch.float32, device=dev)
+    scale_dim = head_dim // 16
+    page_size = kv_cache.shape[2]
+    sides = (
+        (kv_cache[:, :num_kv_heads].transpose(1, 2), k_swizzled),
+        (kv_cache[:, num_kv_heads:].transpose(1, 2), v_swizzled),
+    )
+    result = []
+    for side, swizzled in sides:
+        data, scales = nvfp4_split_data_scale(side)
+        data = data.contiguous()
+        scales = scales.view(torch.uint8)
+        b, n, h, _ = data.shape
+        nibbles = torch.stack((data & 0x0F, (data >> 4) & 0x0F), dim=-1)
+        values = table[nibbles.reshape(b, n, h, head_dim).long()]
+        t_idx, s_idx = _scale_coords(page_size, scale_dim, swizzled, dev)
+        picked = scales[:, t_idx.reshape(-1), :, :]
+        picked = picked.reshape(b, page_size, scale_dim, h, scale_dim)
+        s_sel = s_idx.view(1, page_size, scale_dim, 1, 1).expand(
+            b, page_size, scale_dim, h, 1
+        )
+        picked = torch.gather(picked, 4, s_sel).squeeze(4).permute(0, 1, 3, 2)
+        factor = _e4m3_scale_to_float(picked).repeat_interleave(16, dim=3)
+        result.append((values * factor).to(torch.bfloat16))
+    return result[0], result[1]
+
+
+def _make_problem(dev, num_rows: int, seed: int = 0):
+    torch.manual_seed(seed)
+    pages_per_req = (SEQ_LEN + PAGE_SIZE - 1) // PAGE_SIZE
+    num_blocks = NUM_REQ * pages_per_req + 3
+    q = (torch.randn(num_rows, NUM_HEADS, HEAD_DIM, device=dev) * 0.5).bfloat16()
+    block_table = torch.arange(
+        NUM_REQ * pages_per_req, dtype=torch.int32, device=dev
+    ).view(NUM_REQ, pages_per_req)
+    token_to_req = torch.randint(0, NUM_REQ, (num_rows,), dtype=torch.int32, device=dev)
+    indices = torch.randint(0, SEQ_LEN, (num_rows, TOPK), dtype=torch.int32, device=dev)
+    # Part of the selection is invalid (-1), as in operation when the indexer
+    # fills less than the full width.
+    indices[:, TOPK // 2 :] = -1
+    return num_blocks, q, block_table, token_to_req, indices
+
+
+def _assert_kernel_matches(out_quant, ref_quant, out_bf16, ref_bf16) -> None:
+    r_bf16 = _rel_error(out_bf16, ref_bf16)
+    r_kernel = _rel_error(out_quant, ref_quant)
+    assert r_kernel <= max(5 * r_bf16, 5e-3), (r_kernel, r_bf16)
+
+
+@requires_qsa_kernels
+def test_qsa_fp8_kv_matches_dequantized_reference() -> None:
+    dev = torch.device("cuda")
+    num_blocks, q, block_table, token_to_req, indices = _make_problem(dev, 5)
+    k_cache = (
+        torch.randn(num_blocks, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, device=dev) * 0.5
+    ).bfloat16()
+    v_cache = (
+        torch.randn(num_blocks, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, device=dev) * 0.5
+    ).bfloat16()
+    one = torch.tensor(1.0, dtype=torch.float32, device=dev)
+
+    out_bf16 = qsa_sparse_paged_attention(
+        q, k_cache, v_cache, indices, block_table, token_to_req
+    )
+    out_bf16_scaled = qsa_sparse_paged_attention(
+        q,
+        k_cache,
+        v_cache,
+        indices,
+        block_table,
+        token_to_req,
+        k_scale=one,
+        v_scale=one,
+    )
+    # The bf16 branch must not change with the scale arguments present.
+    assert torch.equal(out_bf16, out_bf16_scaled)
+
+    # Quantized caches are allocated as uint8 by vLLM and reinterpreted right
+    # before the kernel; the test takes the same detour.
+    k_fp8 = k_cache.to(torch.float8_e4m3fn).view(torch.uint8).view(torch.float8_e4m3fn)
+    v_fp8 = v_cache.to(torch.float8_e4m3fn).view(torch.uint8).view(torch.float8_e4m3fn)
+    ref_bf16 = _reference(q, k_cache, v_cache, indices, block_table, token_to_req)
+    ref_fp8 = _reference(
+        q,
+        k_fp8.to(torch.bfloat16),
+        v_fp8.to(torch.bfloat16),
+        indices,
+        block_table,
+        token_to_req,
+    )
+    out_fp8 = qsa_sparse_paged_attention(
+        q, k_fp8, v_fp8, indices, block_table, token_to_req, k_scale=one, v_scale=one
+    )
+    _assert_kernel_matches(out_fp8, ref_fp8, out_bf16, ref_bf16)
+
+
+@requires_qsa_kernels
+@pytest.mark.parametrize("num_rows", TILE_PROFILE_ROWS)
+def test_qsa_fp8_kv_tile_profiles(num_rows: int) -> None:
+    dev = torch.device("cuda")
+    num_blocks, q, block_table, token_to_req, indices = _make_problem(dev, num_rows)
+    k_cache = (
+        torch.randn(num_blocks, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, device=dev) * 0.5
+    ).bfloat16()
+    v_cache = (
+        torch.randn(num_blocks, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, device=dev) * 0.5
+    ).bfloat16()
+    one = torch.tensor(1.0, dtype=torch.float32, device=dev)
+    k_fp8 = k_cache.to(torch.float8_e4m3fn)
+    v_fp8 = v_cache.to(torch.float8_e4m3fn)
+    out_deq = qsa_sparse_paged_attention(
+        q,
+        k_fp8.to(torch.bfloat16),
+        v_fp8.to(torch.bfloat16),
+        indices,
+        block_table,
+        token_to_req,
+    )
+    out_fp8 = qsa_sparse_paged_attention(
+        q, k_fp8, v_fp8, indices, block_table, token_to_req, k_scale=one, v_scale=one
+    )
+    assert (out_fp8.double() - out_deq.double()).abs().max().item() < 5e-3
+
+
+def _write_nvfp4_cache(kv_cache, key, value, slots, scale):
+    from vllm.v1.attention.backends.fa_utils import reshape_and_cache_flash
+
+    kv_cache.zero_()
+    reshape_and_cache_flash(
+        key,
+        value,
+        kv_cache[:, :NUM_KV_HEADS].transpose(1, 2),
+        kv_cache[:, NUM_KV_HEADS:].transpose(1, 2),
+        slots,
+        "nvfp4",
+        scale,
+        scale,
+    )
+    torch.cuda.synchronize()
+
+
+@requires_qsa_kernels
+def test_qsa_nvfp4_kv_block_scale_layout_matches_writer() -> None:
+    """The read kernel assumes linear K block scales and swizzled V block
+    scales, the layout reshape_and_cache_flash writes. Measure it instead of
+    assuming it: each 16-value group gets its own amplitude so a wrong scale
+    lookup is off by factors, not by rounding."""
+    dev = torch.device("cuda")
+    torch.manual_seed(0)
+    num_blocks = 8
+    num_slots = num_blocks * PAGE_SIZE
+    t_i = torch.arange(num_slots, device=dev).view(-1, 1, 1)
+    h_i = torch.arange(NUM_KV_HEADS, device=dev).view(1, -1, 1)
+    g_i = torch.arange(HEAD_DIM // 16, device=dev).view(1, 1, -1)
+    amp = torch.pow(4.0, ((t_i * 7 + h_i * 5 + g_i * 3) % 5).float()) * 0.05
+    amp = amp.repeat_interleave(16, dim=2)
+    key = (torch.randn(num_slots, NUM_KV_HEADS, HEAD_DIM, device=dev) * amp).bfloat16()
+    value = (
+        torch.randn(num_slots, NUM_KV_HEADS, HEAD_DIM, device=dev) * amp
+    ).bfloat16()
+    slots = torch.arange(num_slots, dtype=torch.int64, device=dev)
+    kv_cache = torch.zeros(
+        num_blocks,
+        2 * NUM_KV_HEADS,
+        PAGE_SIZE,
+        nvfp4_kv_cache_full_dim(HEAD_DIM),
+        dtype=torch.uint8,
+        device=dev,
+    )
+    one = torch.tensor(1.0, dtype=torch.float32, device=dev)
+    _write_nvfp4_cache(kv_cache, key, value, slots, one)
+
+    errors = {}
+    for k_swz in (False, True):
+        for v_swz in (False, True):
+            k_deq, v_deq = _dequantize_nvfp4(
+                kv_cache, NUM_KV_HEADS, HEAD_DIM, k_swz, v_swz
+            )
+            errors[(k_swz, v_swz)] = (
+                _rel_error(k_deq.reshape(num_slots, NUM_KV_HEADS, HEAD_DIM), key),
+                _rel_error(v_deq.reshape(num_slots, NUM_KV_HEADS, HEAD_DIM), value),
+            )
+    # Correct hypothesis: pure nvfp4 rounding noise (about 0.09 on this
+    # pattern); every wrong hypothesis lands above 1.
+    k_err, v_err = errors[(False, qsa_backend._NVFP4_V_SCALE_SWIZZLED)]
+    assert k_err < 0.3 and v_err < 0.3, errors
+    assert errors[(True, not qsa_backend._NVFP4_V_SCALE_SWIZZLED)][0] > 0.3, errors
+
+
+@requires_qsa_kernels
+@pytest.mark.parametrize("num_rows", (5,) + TILE_PROFILE_ROWS)
+def test_qsa_nvfp4_kv_matches_dequantized_reference(num_rows: int) -> None:
+    dev = torch.device("cuda")
+    num_blocks, q, block_table, token_to_req, indices = _make_problem(dev, num_rows)
+    num_slots = num_blocks * PAGE_SIZE
+    key = (torch.randn(num_slots, NUM_KV_HEADS, HEAD_DIM, device=dev) * 0.5).bfloat16()
+    value = (
+        torch.randn(num_slots, NUM_KV_HEADS, HEAD_DIM, device=dev) * 0.5
+    ).bfloat16()
+    slots = torch.arange(num_slots, dtype=torch.int64, device=dev)
+    kv_cache = torch.zeros(
+        num_blocks,
+        2 * NUM_KV_HEADS,
+        PAGE_SIZE,
+        nvfp4_kv_cache_full_dim(HEAD_DIM),
+        dtype=torch.uint8,
+        device=dev,
+    )
+    one = torch.tensor(1.0, dtype=torch.float32, device=dev)
+    _write_nvfp4_cache(kv_cache, key, value, slots, one)
+
+    v_swizzled = qsa_backend._NVFP4_V_SCALE_SWIZZLED
+    k_deq, v_deq = _dequantize_nvfp4(
+        kv_cache, NUM_KV_HEADS, HEAD_DIM, False, v_swizzled
+    )
+    k_deq = k_deq.contiguous()
+    v_deq = v_deq.contiguous()
+    k_data, k_sf, v_data, v_sf = qsa_backend._nvfp4_cache_views(kv_cache, NUM_KV_HEADS)
+
+    out_deq = qsa_sparse_paged_attention(
+        q, k_deq, v_deq, indices, block_table, token_to_req
+    )
+    out_nvfp4 = qsa_sparse_paged_attention(
+        q,
+        k_data,
+        v_data,
+        indices,
+        block_table,
+        token_to_req,
+        k_scale=one,
+        v_scale=one,
+        k_scale_cache=k_sf,
+        v_scale_cache=v_sf,
+        v_scale_swizzled=v_swizzled,
+    )
+    # Kernel against kernel on identical dequantized values: measures only the
+    # nvfp4 read branch across all tile profiles.
+    assert (out_nvfp4.double() - out_deq.double()).abs().max().item() < 5e-3
+
+    if num_rows == 5:
+        kb = key.reshape(num_blocks, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM).contiguous()
+        vb = value.reshape(num_blocks, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM).contiguous()
+        out_bf16 = qsa_sparse_paged_attention(
+            q, kb, vb, indices, block_table, token_to_req
+        )
+        ref_bf16 = _reference(q, kb, vb, indices, block_table, token_to_req)
+        ref_nvfp4 = _reference(q, k_deq, v_deq, indices, block_table, token_to_req)
+        _assert_kernel_matches(out_nvfp4, ref_nvfp4, out_bf16, ref_bf16)

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -190,10 +190,69 @@ def _expand_qsa_indices_kernel(
 
 
 @triton.jit
+def _nvfp4_decode_e2m1(nibble):
+    """Decode one FP4 E2M1 nibble (sign + 3 magnitude bits) to float32.
+
+    For magnitude >= 2 the value is 2^(exp - 1) * (1 + m / 2), i.e. the
+    float32 bit pattern (126 << 23) + (magnitude << 22); magnitudes 0 and 1
+    are the subnormals 0.0 and 0.5.
+    """
+    magnitude = nibble & 0x07
+    magnitude_i32 = magnitude.to(tl.int32)
+    sign_bits = ((nibble & 0x08).to(tl.uint32)) << 28
+    normal_bits = ((126 << 23) + (magnitude_i32 << 22)).to(tl.uint32) | sign_bits
+    normal = normal_bits.to(tl.uint32).to(tl.float32, bitcast=True)
+    subnormal_bits = ((magnitude & 0x01).to(tl.uint32) * 0x3F000000) | sign_bits
+    subnormal = subnormal_bits.to(tl.uint32).to(tl.float32, bitcast=True)
+    return tl.where(magnitude < 2, subnormal, normal)
+
+
+@triton.jit
+def _nvfp4_scale_to_float(bits):
+    """Decode an E4M3 block scale (magnitude only) to float32.
+
+    Block scales come from absolute maxima, so the sign bit is masked. Bias
+    7 -> 127 is +120 on the exponent; subnormals are mant * 2^-9.
+    """
+    payload = bits.to(tl.int32) & 0x7F
+    exp_bits = (payload >> 3) & 0x0F
+    mant = payload & 0x07
+    normal_bits = ((exp_bits + 120) << 23) | (mant << 20)
+    normal = normal_bits.to(tl.uint32).to(tl.float32, bitcast=True)
+    subnormal = mant.to(tl.float32) / 512.0
+    value = tl.where(exp_bits == 0, subnormal, normal)
+    return tl.where(payload == 0, 0.0, value)
+
+
+@triton.jit
+def _nvfp4_scale_coord(slot, group, SWIZZLED: tl.constexpr, SCALE_DIM: tl.constexpr):
+    """Storage coordinates (row, scale index) of the block scale for a
+    (row in page, 16-value group) pair.
+
+    LINEAR is the identity. SWIZZLED is the permutation within groups of four
+    rows that reshape_and_cache_flash writes for the V side:
+        (t, s) -> ((t // 4) * 4 + s // G, (s % G) * 4 + t % 4),  G = SCALE_DIM // 4
+    """
+    SWIZZLE_GROUP: tl.constexpr = SCALE_DIM // 4
+    if SWIZZLED:
+        return (slot // 4) * 4 + (group // SWIZZLE_GROUP), (
+            group % SWIZZLE_GROUP
+        ) * 4 + (slot % 4)
+    return slot + group * 0, group + slot * 0
+
+
+@triton.jit
 def _qsa_sparse_paged_gqa_splitk_kernel(
     q_ptr,
     k_cache_ptr,
     v_cache_ptr,
+    # Per-layer fp32 scales (1-element device buffers). Only read on the
+    # quantized branches; any valid pointer is passed for bf16.
+    k_scale_ptr,
+    v_scale_ptr,
+    # nvfp4 block-scale pages (raw uint8 bits), only read on the nvfp4 branch.
+    k_scale_cache_ptr,
+    v_scale_cache_ptr,
     indices_ptr,
     block_table_ptr,
     token_to_req_ptr,
@@ -208,6 +267,14 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     stride_v_block,
     stride_v_token,
     stride_v_head,
+    # Strides of the nvfp4 block-scale pages (from nvfp4_split_data_scale);
+    # data and scale regions have different row widths.
+    stride_ks_block,
+    stride_ks_token,
+    stride_ks_head,
+    stride_vs_block,
+    stride_vs_token,
+    stride_vs_head,
     stride_indices_row,
     stride_table_req,
     stride_output_row,
@@ -225,6 +292,11 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     NUM_TILES: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    # Compile-time branch selection. With both False the dequantization code
+    # is compiled out and the bf16 path is unchanged.
+    KV_QUANT_FP8: tl.constexpr = False,
+    KV_QUANT_NVFP4: tl.constexpr = False,
+    V_SCALE_SWIZZLED: tl.constexpr = True,
 ) -> None:
     row = tl.program_id(0)
     kv_head = tl.program_id(1)
@@ -279,24 +351,119 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
         valid &= (physical_page >= 0) & (physical_page < num_cache_blocks)
         # physical_page * block stride can overflow int32 for large caches.
         safe_page = tl.maximum(physical_page, 0).to(tl.int64)
-        keys = tl.load(
-            k_cache_ptr
-            + safe_page[None, :] * stride_k_block
-            + page_offset[None, :] * stride_k_token
-            + kv_head * stride_k_head
-            + dim_offsets[:, None],
-            mask=valid[None, :],
-            other=0.0,
-        )
-        values = tl.load(
-            v_cache_ptr
-            + safe_page[:, None] * stride_v_block
-            + page_offset[:, None] * stride_v_token
-            + kv_head * stride_v_head
-            + dim_offsets[None, :],
-            mask=valid[:, None],
-            other=0.0,
-        )
+        if KV_QUANT_NVFP4:
+            # A cache row holds HEAD_DIM values in HEAD_DIM // 2 bytes (two
+            # E2M1 nibbles per byte, even index in the low nibble) plus
+            # HEAD_DIM // 16 E4M3 block scales in a separate page region.
+            # value = nibble * block_scale * layer_scale. Orientation as in the
+            # bf16 branch: keys [HEAD_DIM, BLOCK_N], values [BLOCK_N, HEAD_DIM].
+            byte_offsets = dim_offsets // 2
+            k_bytes = tl.load(
+                k_cache_ptr
+                + safe_page[None, :] * stride_k_block
+                + page_offset[None, :] * stride_k_token
+                + kv_head * stride_k_head
+                + byte_offsets[:, None],
+                mask=valid[None, :],
+                other=0,
+            )
+            k_nib = tl.where(
+                (dim_offsets[:, None] & 1) == 0, k_bytes & 0x0F, (k_bytes >> 4) & 0x0F
+            )
+            v_bytes = tl.load(
+                v_cache_ptr
+                + safe_page[:, None] * stride_v_block
+                + page_offset[:, None] * stride_v_token
+                + kv_head * stride_v_head
+                + byte_offsets[None, :],
+                mask=valid[:, None],
+                other=0,
+            )
+            v_nib = tl.where(
+                (dim_offsets[None, :] & 1) == 0, v_bytes & 0x0F, (v_bytes >> 4) & 0x0F
+            )
+            # Block scales are loaded at their natural width
+            # [HEAD_DIM // 16, BLOCK_N] and broadcast to the data tile in
+            # registers: dim_offsets is tl.arange(0, HEAD_DIM), so group =
+            # dim // 16 covers 16 consecutive rows, which broadcast_to +
+            # reshape restores. Decoding and the layer-scale multiply run on
+            # HEAD_DIM // 16 rows instead of HEAD_DIM. K scales are stored
+            # linearly, V scales follow V_SCALE_SWIZZLED. HEAD_DIM // 16 is
+            # passed as an expression; a constexpr binding inside a constexpr
+            # branch is not reliable in Triton.
+            sf_groups = tl.arange(0, HEAD_DIM // 16)
+            ks_slot, ks_group = _nvfp4_scale_coord(
+                page_offset[None, :], sf_groups[:, None], False, HEAD_DIM // 16
+            )
+            k_sf = _nvfp4_scale_to_float(
+                tl.load(
+                    k_scale_cache_ptr
+                    + safe_page[None, :] * stride_ks_block
+                    + ks_slot * stride_ks_token
+                    + kv_head * stride_ks_head
+                    + ks_group,
+                    mask=valid[None, :],
+                    other=0,
+                )
+            ) * tl.load(k_scale_ptr)
+            keys = (
+                _nvfp4_decode_e2m1(k_nib)
+                * tl.reshape(
+                    tl.broadcast_to(k_sf[:, None, :], (HEAD_DIM // 16, 16, BLOCK_N)),
+                    (HEAD_DIM, BLOCK_N),
+                )
+            ).to(query.dtype)
+            vs_slot, vs_group = _nvfp4_scale_coord(
+                page_offset[:, None],
+                sf_groups[None, :],
+                V_SCALE_SWIZZLED,
+                HEAD_DIM // 16,
+            )
+            v_sf = _nvfp4_scale_to_float(
+                tl.load(
+                    v_scale_cache_ptr
+                    + safe_page[:, None] * stride_vs_block
+                    + vs_slot * stride_vs_token
+                    + kv_head * stride_vs_head
+                    + vs_group,
+                    mask=valid[:, None],
+                    other=0,
+                )
+            ) * tl.load(v_scale_ptr)
+            values = (
+                _nvfp4_decode_e2m1(v_nib)
+                * tl.reshape(
+                    tl.broadcast_to(v_sf[:, :, None], (BLOCK_N, HEAD_DIM // 16, 16)),
+                    (BLOCK_N, HEAD_DIM),
+                )
+            ).to(query.dtype)
+        else:
+            keys = tl.load(
+                k_cache_ptr
+                + safe_page[None, :] * stride_k_block
+                + page_offset[None, :] * stride_k_token
+                + kv_head * stride_k_head
+                + dim_offsets[:, None],
+                mask=valid[None, :],
+                other=0.0,
+            )
+            values = tl.load(
+                v_cache_ptr
+                + safe_page[:, None] * stride_v_block
+                + page_offset[:, None] * stride_v_token
+                + kv_head * stride_v_head
+                + dim_offsets[None, :],
+                mask=valid[:, None],
+                other=0.0,
+            )
+            if KV_QUANT_FP8:
+                # Never feed fp8 into tl.dot directly (Triton cannot multiply
+                # fp8e4nv on SM12x). Upcast to the query dtype, apply the
+                # per-layer scale, cast back.
+                keys = keys.to(query.dtype)
+                keys = (keys * tl.load(k_scale_ptr)).to(query.dtype)
+                values = values.to(query.dtype)
+                values = (values * tl.load(v_scale_ptr)).to(query.dtype)
         scores = tl.dot(query, keys)
         # Scaling scores avoids re-quantizing a scaled query to BF16.
         scores *= softmax_scale_log2
@@ -817,8 +984,20 @@ def qsa_sparse_paged_attention(
     block_table: torch.Tensor,
     token_to_req: torch.Tensor,
     out: torch.Tensor | None = None,
+    k_scale: torch.Tensor | None = None,
+    v_scale: torch.Tensor | None = None,
+    k_scale_cache: torch.Tensor | None = None,
+    v_scale_cache: torch.Tensor | None = None,
+    v_scale_swizzled: bool = True,
 ) -> torch.Tensor:
-    """Run sparse GQA directly over paged BF16 K/V caches."""
+    """Run sparse GQA directly over paged BF16, FP8-E4M3 or NVFP4 K/V caches.
+
+    ``k_scale`` / ``v_scale`` are the per-layer scales (1-element device
+    tensors), required for quantized caches. For nvfp4, ``k_cache`` /
+    ``v_cache`` are the packed data pages (uint8, last dim ``head_dim // 2``)
+    and ``k_scale_cache`` / ``v_scale_cache`` the block-scale pages (uint8,
+    last dim ``head_dim // 16``).
+    """
 
     if not q.is_cuda or not HAS_TRITON:
         raise RuntimeError("paged QSA sparse attention requires CUDA and Triton")
@@ -832,11 +1011,39 @@ def qsa_sparse_paged_attention(
         raise ValueError("QSA sparse attention cache and block table must be nonempty")
     if logical_indices.shape[1] <= 0:
         raise ValueError("QSA sparse attention requires a positive selection width")
-    if q.shape[2] != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
+    use_nvfp4 = k_scale_cache is not None
+    row_width = q.shape[2] // 2 if use_nvfp4 else q.shape[2]
+    if row_width != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
         raise ValueError("QSA sparse attention requires valid grouped-query heads")
     head_dim = q.shape[2]
     assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
-    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    assert q.dtype == torch.bfloat16
+    assert k_cache.dtype == v_cache.dtype
+    assert k_cache.dtype in (torch.bfloat16, torch.float8_e4m3fn, torch.uint8)
+    use_fp8 = k_cache.dtype == torch.float8_e4m3fn
+    if use_nvfp4:
+        if k_cache.dtype != torch.uint8:
+            raise ValueError("QSA nvfp4 KV cache must be stored as uint8")
+        if k_scale_cache is None or v_scale_cache is None:
+            raise ValueError("QSA nvfp4 KV cache requires both scale pages")
+        if k_scale_cache.dtype != torch.uint8 or v_scale_cache.dtype != torch.uint8:
+            raise ValueError("QSA nvfp4 block scales must be raw uint8 bits")
+        if k_scale_cache.shape[3] != head_dim // 16:
+            raise ValueError("QSA nvfp4 block-scale page has the wrong width")
+        if k_scale_cache.shape[:3] != k_cache.shape[:3]:
+            raise ValueError("QSA nvfp4 data and scale pages disagree in shape")
+        if k_scale_cache.stride(3) != 1 or v_scale_cache.stride(3) != 1:
+            raise ValueError("QSA nvfp4 block scales must be contiguous per row")
+    elif k_cache.dtype == torch.uint8:
+        raise ValueError("QSA uint8 K/V cache without block scales is not nvfp4")
+    quantized = use_fp8 or use_nvfp4
+    if quantized:
+        if k_scale is None or v_scale is None:
+            raise ValueError("QSA quantized KV cache requires k_scale and v_scale")
+        if k_scale.numel() != 1 or v_scale.numel() != 1:
+            raise ValueError("QSA quantized KV cache expects scalar per-layer scales")
+        if k_scale.device != q.device or v_scale.device != q.device:
+            raise ValueError("QSA KV scales must live on the query device")
     assert logical_indices.dtype == block_table.dtype == torch.int32
     assert token_to_req.dtype == torch.int32
     assert q.device == k_cache.device == v_cache.device
@@ -872,6 +1079,20 @@ def qsa_sparse_paged_attention(
     else:
         block_n, target_splits, partial_warps = 64, 1, 2
 
+    # Quantized caches need shared memory for the dequantized bf16 tiles next
+    # to the raw tiles. On SM120 the fp8 branch with BLOCK_N=64 and two
+    # pipeline stages requested 106496 B against a 101376 B limit, so the
+    # wide (prefill) profiles run with one stage; the decode profile
+    # (BLOCK_N=16) fits with two stages and keeps them. For nvfp4 the wide
+    # tile is halved to 32: with the narrow scale tile this measured 1.7x
+    # faster than 64 on SM120 (two stages at 64 were slower still,
+    # occupancy-bound).
+    num_stages = 2
+    if quantized and block_n > 16:
+        if use_nvfp4:
+            block_n = 32
+        num_stages = 1
+
     num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
     # Avoid empty splits when the selection width is smaller than the profile.
     max_useful_splits = 1 << (num_tiles.bit_length() - 1)
@@ -894,10 +1115,36 @@ def qsa_sparse_paged_attention(
         )
 
     partial_grid = (q.shape[0], k_cache.shape[2], num_splits)
+    # Triton needs an argument even for compiled-out branches; any valid
+    # tensor is passed on the bf16 path.
+    k_scale_arg = k_scale if quantized else q
+    v_scale_arg = v_scale if quantized else q
+    k_sf_arg = q
+    v_sf_arg = q
+    ks_strides = (0, 0, 0)
+    vs_strides = (0, 0, 0)
+    if use_nvfp4:
+        assert k_scale_cache is not None and v_scale_cache is not None
+        k_sf_arg = k_scale_cache
+        v_sf_arg = v_scale_cache
+        ks_strides = (
+            k_scale_cache.stride(0),
+            k_scale_cache.stride(1),
+            k_scale_cache.stride(2),
+        )
+        vs_strides = (
+            v_scale_cache.stride(0),
+            v_scale_cache.stride(1),
+            v_scale_cache.stride(2),
+        )
     _qsa_sparse_paged_gqa_splitk_kernel[partial_grid](
         q,
         k_cache,
         v_cache,
+        k_scale_arg,
+        v_scale_arg,
+        k_sf_arg,
+        v_sf_arg,
         logical_indices,
         block_table,
         token_to_req,
@@ -912,6 +1159,12 @@ def qsa_sparse_paged_attention(
         v_cache.stride(0),
         v_cache.stride(1),
         v_cache.stride(2),
+        ks_strides[0],
+        ks_strides[1],
+        ks_strides[2],
+        vs_strides[0],
+        vs_strides[1],
+        vs_strides[2],
         logical_indices.stride(0),
         block_table.stride(0),
         out.stride(0),
@@ -929,8 +1182,11 @@ def qsa_sparse_paged_attention(
         NUM_TILES=num_tiles,
         BLOCK_M=block_m,
         BLOCK_N=block_n,
+        KV_QUANT_FP8=use_fp8,
+        KV_QUANT_NVFP4=use_nvfp4,
+        V_SCALE_SWIZZLED=bool(v_scale_swizzled),
         num_warps=partial_warps,
-        num_stages=2,
+        num_stages=num_stages,
     )
     if num_splits == 1:
         return out

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -4,12 +4,13 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import ClassVar, cast
 
 import torch
 from torch import nn
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_current_vllm_config_or_none
 from vllm.config.cache import CacheDType
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
@@ -32,7 +33,10 @@ from vllm.utils.torch_utils import (
     _resolve_layer_name,
     canonicalize_singleton_dim_strides,
     direct_register_custom_op,
+    get_dtype_size,
     kv_cache_dtype_str_to_dtype,
+    nvfp4_kv_cache_full_dim,
+    nvfp4_split_data_scale,
 )
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -48,14 +52,74 @@ from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionMetadataBuilder,
 )
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     FullAttentionSpec,
     KVCacheSpec,
     get_kv_quant_mode,
+    is_quantized_kv_cache,
 )
 
 from ..common.qsa_cache import QSAForwardMetadata
 from . import model
 from .indexer_qsa import QSAIndexer
+
+# KV cache dtypes accepted for the QSA main cache. fp8_e5m2 is left out on
+# purpose (smaller mantissa, no benefit for K/V); nvfp4_4over6 changes the
+# block-scale search in the writer and has not been evaluated on this path.
+# The indexer caches are not affected: they are constructed in bf16 (the
+# key-state cache packs int64 mRoPE positions into bf16 cells).
+_QSA_KV_CACHE_DTYPES: tuple[str, ...] = ("auto", "bfloat16", "fp8", "fp8_e4m3", "nvfp4")
+
+# Storage dtypes of the main cache. Quantized caches are allocated as uint8
+# (STR_DTYPE_TO_TORCH_DTYPE); the bytes are reinterpreted right before the
+# kernel.
+_QSA_KV_STORAGE_DTYPES = (torch.bfloat16, torch.uint8, torch.float8_e4m3fn)
+
+# Block-scale layout written by reshape_and_cache_flash for nvfp4: K block
+# scales are stored linearly, V block scales are swizzled for the TRT-LLM
+# decode kernels. The read kernel follows the same convention.
+_NVFP4_V_SCALE_SWIZZLED = True
+
+
+def _nvfp4_attention_spec(spec: AttentionSpec) -> AttentionSpec:
+    """Apply the nvfp4 page geometry to a QSA main-cache spec.
+
+    K and V get separate head slots (all K heads first, then all V heads, the
+    order ``kv_cache.split(num_kv_heads, dim=1)`` expects) and a cell shrinks
+    from ``head_size + head_size_v`` bf16 values to
+    ``head_size // 2 + head_size // 16`` bytes of fp4 data plus fp8 block
+    scales. Same geometry as ``FlashInferBackend.customize_spec``. Idempotent,
+    so it does not matter whether the model runner calls ``customize_spec``
+    in addition to the owner applying it.
+    """
+    if spec.state_content_bytes is not None or not spec.kv_quant_mode.is_nvfp4:
+        return spec
+    hs_k = nvfp4_kv_cache_full_dim(spec.head_size)
+    hs_v = nvfp4_kv_cache_full_dim(spec.head_size_v)
+    assert hs_k == hs_v, "nvfp4 with asymmetric K/V head sizes not yet supported"
+    return replace(
+        spec,
+        num_head_slots=2 * spec.num_kv_heads,
+        state_content_bytes=hs_k * get_dtype_size(spec.dtype),
+    )
+
+
+def _nvfp4_cache_views(
+    kv_cache: torch.Tensor, num_kv_heads: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split a packed nvfp4 cache ``[B, 2 * H, N, 144]`` into strided views.
+
+    Returns ``(k_data, k_scales, v_data, v_scales)``, each ``[B, N, H, X]``
+    with X = ``head_size // 2`` data bytes or ``head_size // 16`` block scales.
+    The byte arithmetic is ``nvfp4_split_data_scale``, the same helper the
+    writer side uses, so both sides see one layout by construction. Scales are
+    returned as raw uint8 bits; the kernel decodes them.
+    """
+    k_side = kv_cache[:, :num_kv_heads].transpose(1, 2)
+    v_side = kv_cache[:, num_kv_heads:].transpose(1, 2)
+    k_data, k_scales = nvfp4_split_data_scale(k_side)
+    v_data, v_scales = nvfp4_split_data_scale(v_side)
+    return k_data, k_scales.view(torch.uint8), v_data, v_scales.view(torch.uint8)
 
 
 class Qwen4ExpQSAMetadataBuilder(FlashAttentionMetadataBuilder):
@@ -68,7 +132,82 @@ class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
     """FullAttentionSpec backend used by the merged QSA owner."""
 
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
-    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "bfloat16",
+        "fp8",
+        "fp8_e4m3",
+        "nvfp4",
+    ]
+
+    @classmethod
+    def customize_spec(cls, spec: AttentionSpec) -> AttentionSpec:
+        # The model runner passes every attention spec through this hook and
+        # the hybrid page alignment on the platform uses it for the per-token
+        # page size. Without the override the nvfp4 page would be declared
+        # four times too large and the GDN page padding would be wrong.
+        return _nvfp4_attention_spec(spec)
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        # The model runner asks the backend for the cache shape and
+        # reinterprets the raw buffer with it; it does not read
+        # num_head_slots / state_content_bytes from the spec. For nvfp4 the
+        # packed rows are 2 * num_kv_heads slots of
+        # head_size // 2 + head_size // 16 bytes.
+        if isinstance(cache_dtype_str, str) and cache_dtype_str.startswith("nvfp4"):
+            return (
+                num_blocks,
+                2 * num_kv_heads,
+                block_size,
+                nvfp4_kv_cache_full_dim(head_size),
+            )
+        return FlashAttentionBackend.get_kv_cache_shape(
+            num_blocks, block_size, num_kv_heads, head_size, cache_dtype_str
+        )
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        # nvfp4 needs the HND layout: a page is [K_data | K_scale | V_data |
+        # V_scale], so the K half must be one contiguous half page. Under NHD
+        # the K and V head slots interleave per token, nvfp4_split_data_scale
+        # then derives strides across all 2 * num_kv_heads slots and the scale
+        # region overlaps the data. That does not crash, it produces wrong
+        # numbers. bf16 and fp8 keep the inherited choice.
+        cfg = get_current_vllm_config_or_none()
+        cache_dtype = getattr(getattr(cfg, "cache_config", None), "cache_dtype", "auto")
+        if isinstance(cache_dtype, str) and cache_dtype.startswith("nvfp4"):
+            if include_num_layers_dimension:
+                return (1, 2, 0, 3, 4)
+            return (0, 1, 2, 3)
+        return FlashAttentionBackend.get_kv_cache_stride_order(
+            include_num_layers_dimension
+        )
+
+    @classmethod
+    def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
+        # The inherited check asks whether FlashAttention kernels can read a
+        # quantized cache on this device. The QSA main cache is only read by
+        # the Triton kernel in ops/qsa.py, which dequantizes in registers, so
+        # the FlashAttention capability is irrelevant here.
+        if kv_cache_dtype is None:
+            return True
+        return kv_cache_dtype in cls.supported_kv_cache_dtypes
+
+    @classmethod
+    def supports_combination(cls, *args, **kwargs) -> str | None:
+        # Same reason: the inherited message ("FP8 KV cache requires FA3 on
+        # SM90 or FA4 on SM100") describes FlashAttention kernels this path
+        # does not use.
+        return None
 
     @staticmethod
     def get_name() -> str:
@@ -103,16 +242,90 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
     supports_pcp: bool = False
 
     def __init__(self, *args, **kwargs) -> None:
+        # FlashAttentionImpl.__init__ rejects a quantized KV cache whenever
+        # flash_attn_supports_kv_cache_dtype() is false for the device (it
+        # knows SM90 with FA3/FA4 and SM100 with FA4). QSA never reads its
+        # main cache with a FlashAttention kernel, so the dtype is passed
+        # around the base constructor and restored afterwards; the inherited
+        # write path (reshape_and_cache_flash) reads it later. kv_cache_dtype
+        # is the seventh positional argument of FlashAttentionImpl.__init__.
+        kv_cache_dtype: str | None = None
+        if (
+            len(args) > 6
+            and isinstance(args[6], str)
+            and args[6] not in ("auto", "bfloat16")
+        ):
+            kv_cache_dtype = args[6]
+            args = (*args[:6], "auto", *args[7:])
+        elif kwargs.get("kv_cache_dtype", "auto") not in ("auto", "bfloat16"):
+            kv_cache_dtype = kwargs["kv_cache_dtype"]
+            kwargs = {**kwargs, "kv_cache_dtype": "auto"}
         super().__init__(*args, **kwargs)
+        if kv_cache_dtype is not None:
+            self.kv_cache_dtype = kv_cache_dtype
         if not is_flash_attn_varlen_func_available():
             raise NotImplementedError("Qwen4Exp QSA requires FlashAttention")
         if self.dcp_world_size != 1:
             raise NotImplementedError(
                 "Qwen4Exp QSA does not support decode context parallelism"
             )
-        if self.kv_cache_dtype not in ("auto", "bfloat16"):
-            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if self.kv_cache_dtype not in _QSA_KV_CACHE_DTYPES:
+            raise NotImplementedError(
+                "Qwen4Exp QSA requires a BF16, FP8-E4M3 or NVFP4 main KV cache"
+            )
+        # nvfp4 is a separate branch (page geometry, writer, read kernel), not
+        # fp8 with a different dtype.
+        self.kv_cache_nvfp4 = self.kv_cache_dtype.startswith("nvfp4")
+        self.kv_cache_fp8 = (
+            is_quantized_kv_cache(self.kv_cache_dtype) and not self.kv_cache_nvfp4
+        )
+        # Strided views on the packed nvfp4 cache, built once per cache buffer.
+        # as_strided is metadata only, but it would otherwise run in every
+        # decode step, and the pointers stay stable across CUDA graph capture.
+        self._nvfp4_views: tuple[int, tuple[torch.Tensor, ...]] | None = None
         self.supports_quant_query_input = False
+
+    def _nvfp4_views_for(self, kv_cache: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        key = kv_cache.data_ptr()
+        cached = self._nvfp4_views
+        if cached is None or cached[0] != key:
+            cached = (key, _nvfp4_cache_views(kv_cache, self.num_kv_heads))
+            self._nvfp4_views = cached
+        return cached[1]
+
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        if not self.kv_cache_nvfp4:
+            return super().do_kv_cache_update(layer, key, value, kv_cache, slot_mapping)
+        if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
+            return None
+        # The inherited path splits the cache with
+        # kv_cache.transpose(1, 2).split(self.head_size, dim=-1), which assumes
+        # K and V share one row of 2 * head_size values. nvfp4 stores them in
+        # separate head slots of head_size // 2 + head_size // 16 bytes, so
+        # the cache is cut by head slot here: (B, 2n, N, 144) -> two views
+        # (B, N, n, 144), the 4D shape reshape_and_cache_flash expects for
+        # nvfp4.
+        from vllm.v1.attention.backends.fa_utils import reshape_and_cache_flash
+
+        n = self.num_kv_heads
+        reshape_and_cache_flash(
+            key,
+            value,
+            kv_cache[:, :n].transpose(1, 2),
+            kv_cache[:, n:].transpose(1, 2),
+            slot_mapping,
+            self.kv_cache_dtype,
+            layer._k_scale,
+            layer._v_scale,
+        )
+        return None
 
     def forward_qsa(
         self,
@@ -145,11 +358,33 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
             raise RuntimeError("QSA owner did not provide its top-k buffer")
         logical_indices = topk_buffer[:num_tokens]
         token_to_req = token_to_req[:num_tokens]
-        key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
+        k_scale_cache: torch.Tensor | None = None
+        v_scale_cache: torch.Tensor | None = None
+        if self.kv_cache_nvfp4:
+            # Packed rows carry data and block scales for K and V in separate
+            # head slots; there is nothing to split at head_size.
+            key_cache, k_scale_cache, value_cache, v_scale_cache = (
+                self._nvfp4_views_for(kv_cache)
+            )
+        else:
+            key_cache, value_cache = kv_cache.transpose(1, 2).split(
+                self.head_size, dim=-1
+            )
         key_cache = canonicalize_singleton_dim_strides(key_cache)
         value_cache = canonicalize_singleton_dim_strides(value_cache)
-        if key_cache.dtype != torch.bfloat16 or query.dtype != torch.bfloat16:
-            raise NotImplementedError("Qwen4Exp QSA requires BF16 Q/K/V")
+        if self.kv_cache_fp8:
+            # Quantized caches are allocated as uint8; reinterpret as fp8 so
+            # the kernel decodes floats instead of integers. view() is a pure
+            # reinterpretation (1 byte to 1 byte, unit stride on the last dim).
+            # nvfp4 stays uint8: the packed nibbles are unpacked in the kernel.
+            key_cache = key_cache.view(torch.float8_e4m3fn)
+            value_cache = value_cache.view(torch.float8_e4m3fn)
+        if query.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 queries")
+        if key_cache.dtype not in (torch.bfloat16, torch.float8_e4m3fn, torch.uint8):
+            raise NotImplementedError(
+                "Qwen4Exp QSA requires BF16, FP8-E4M3 or NVFP4 K/V"
+            )
 
         from .ops.qsa import qsa_sparse_paged_attention
 
@@ -161,6 +396,14 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
             attn_metadata.block_table,
             token_to_req,
             output[:num_tokens],
+            # Per-layer scales as device buffers (1.0 from
+            # set_default_quant_scales(register_buffer=True)): no host-to-device
+            # copy on the hot path, so CUDA graph capture is unaffected.
+            k_scale=getattr(layer, "_k_scale", None),
+            v_scale=getattr(layer, "_v_scale", None),
+            k_scale_cache=k_scale_cache,
+            v_scale_cache=v_scale_cache,
+            v_scale_swizzled=_NVFP4_V_SCALE_SWIZZLED,
         )
         return output
 
@@ -187,8 +430,10 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             raise ValueError("Qwen4Exp QSA requires a paged KV cache")
         if model_config.dtype != torch.bfloat16:
             raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
-        if cache_config.cache_dtype not in ("auto", "bfloat16"):
-            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if cache_config.cache_dtype not in _QSA_KV_CACHE_DTYPES:
+            raise NotImplementedError(
+                "Qwen4Exp QSA requires a BF16, FP8-E4M3 or NVFP4 main KV cache"
+            )
         if getattr(quant_config, "kv_cache_scheme", None) is not None:
             raise NotImplementedError("Qwen4Exp QSA does not support KV quantization")
         parallel_config = vllm_config.parallel_config
@@ -282,8 +527,10 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, model_config
         )
-        if self.kv_cache_torch_dtype != torch.bfloat16:
-            raise NotImplementedError("Qwen4Exp QSA requires BF16 cache storage")
+        if self.kv_cache_torch_dtype not in _QSA_KV_STORAGE_DTYPES:
+            raise NotImplementedError(
+                "Qwen4Exp QSA requires BF16, FP8-E4M3 or NVFP4 cache storage"
+            )
         self.kv_sharing_target_layer_name = None
         self.kv_cache = torch.tensor([])
         set_default_quant_scales(self, register_buffer=True)
@@ -329,13 +576,17 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         return self.attn_backend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        return FullAttentionSpec(
-            block_size=vllm_config.cache_config.block_size,
-            num_kv_heads=self.num_kv_heads,
-            head_size=self.head_dim,
-            head_size_v=self.head_dim,
-            dtype=self.kv_cache_torch_dtype,
-            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        # The owner builds its own spec, so the nvfp4 geometry is applied here
+        # as well as in customize_spec; both are idempotent.
+        return _nvfp4_attention_spec(
+            FullAttentionSpec(
+                block_size=vllm_config.cache_config.block_size,
+                num_kv_heads=self.num_kv_heads,
+                head_size=self.head_dim,
+                head_size_v=self.head_dim,
+                dtype=self.kv_cache_torch_dtype,
+                kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+            )
         )
 
     def _run_qsa(

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -846,9 +846,29 @@ class Platform:
                 dtype=kv_cache_dtype,
                 kv_quant_mode=kv_quant_mode,
             )
-            attn_page_size_1_token = backend_cls.customize_spec(
-                attn_spec
-            ).page_size_bytes
+            aligned_spec = backend_cls.customize_spec(attn_spec)
+            if aligned_spec.state_content_bytes is None and kv_quant_mode.is_nvfp4:
+                # A backend that does not customize the nvfp4 page geometry
+                # would otherwise size the block against a page that does not
+                # exist. Same geometry as FlashInferBackend.customize_spec:
+                # K and V in separate head slots, head // 2 + head // 16 bytes
+                # per row (fp4 data plus fp8 block scales).
+                from dataclasses import replace
+
+                from vllm.utils.torch_utils import (
+                    get_dtype_size,
+                    nvfp4_kv_cache_full_dim,
+                )
+
+                aligned_spec = replace(
+                    aligned_spec,
+                    num_head_slots=2 * aligned_spec.num_kv_heads,
+                    state_content_bytes=(
+                        nvfp4_kv_cache_full_dim(aligned_spec.head_size)
+                        * get_dtype_size(aligned_spec.dtype)
+                    ),
+                )
+            attn_page_size_1_token = aligned_spec.page_size_bytes
 
         # Compute mamba page size
         model_cls, _ = ModelRegistry.resolve_model_cls(


### PR DESCRIPTION
## Purpose

Let the QSA layers of Qwen4Exp (Qwen3.8-Flash-Next) run with `--kv-cache-dtype fp8_e4m3` or `nvfp4`. Today the path hard-refuses anything but bf16 (`Qwen4Exp QSA requires a BF16 main KV cache`), although the write path (`reshape_and_cache_flash`), the KV spec (`kv_quant_mode`) and the per-layer scales are already in place. What was missing is the read side of the sparse paged GQA Triton kernel and a set of guards.

Related: #54426 (RFC with an independent fp8_e4m3 implementation on GB10, corroborated on a second GB10). This PR was developed independently on SM120 and adds nvfp4; the four integration points named there match what we hit (uint8 storage, inherited `FlashAttentionImpl` guard, shared-memory limit, indexer cache). One difference: here the indexer caches stay bf16 by construction and the selector path is not touched.

**What the change does**

- `ops/qsa.py`: two compile-time branches in `_qsa_sparse_paged_gqa_splitk_kernel` (`KV_QUANT_FP8`, `KV_QUANT_NVFP4`), compiled out for bf16.
  - fp8_e4m3: upcast the tile to the query dtype, apply the per-layer scale, cast back before `tl.dot` (Triton cannot multiply fp8e4nv on SM12x).
  - nvfp4: K and V in separate head slots of `head_size // 2 + head_size // 16` bytes (E2M1 data plus E4M3 block scales, one per 16 values). E2M1 unpack and block-scale lookup happen in the kernel; block scales are loaded at their natural width `[HEAD_DIM // 16, BLOCK_N]` and broadcast in registers. K block scales are stored linearly, V block scales swizzled, the layout the native writer produces (measured, see tests).
  - Quantized wide (prefill) tiles run with one pipeline stage: on SM120 the fp8 branch at `BLOCK_N=64` with two stages requested 106496 B against a 101376 B limit. The nvfp4 wide tile is 32 (1.7x faster than 64 at one stage on SM120; two stages at 64 were slower, occupancy-bound). The decode profile (`BLOCK_N=16`) is unchanged.
- `nvidia/qsa.py`: accept `fp8`, `fp8_e4m3`, `nvfp4`; `customize_spec` and `get_kv_cache_spec` apply the nvfp4 page geometry (same as `FlashInferBackend.customize_spec`); `get_kv_cache_shape` and an HND stride order for nvfp4 (under NHD the K/V head slots interleave and `nvfp4_split_data_scale` would overlap data and scales); an own `do_kv_cache_update` that cuts the packed cache by head slot; the inherited FlashAttention capability checks are bypassed because QSA never reads its main cache with a FlashAttention kernel. Quantized caches are reinterpreted from `uint8` right before the kernel. The indexer caches stay bf16 (`QSAKeyStateCache` packs int64 mRoPE positions into bf16 cells).
- `platforms/interface.py`: the hybrid page alignment falls back to the nvfp4 geometry when the resolved backend does not customize the spec. Without it the block size is aligned against a page that does not exist. This is the one change outside the model directory; happy to move it if there is a better place.

Not included on purpose: `fp8_e5m2` (smaller mantissa, no benefit for K/V), `nvfp4_4over6` (changes the block-scale search in the writer, not evaluated on this path), calibrated per-layer scales (scale 1.0 measured 0.0000 % saturation and underflow on this checkpoint, quality gates at parity), the AMD QSA mirror (`amd/qsa.py`, same guards, untouched).

## Test Plan

New numerical tests in `tests/models/qwen4_exp/test_qsa_kv_quant.py`:

- fp8 and nvfp4 kernel output against a float64 PyTorch reference computed on the *dequantized* cache contents (measures the kernel, not the quantization), plus kernel-vs-kernel across all tile profiles of the wrapper (2 / 5 / 64 / 200 / 300 query rows, i.e. `BLOCK_N=16` two stages and the wide one-stage profiles).
- nvfp4 layout probe: the cache is written with `reshape_and_cache_flash("nvfp4")` and unpacked under all four block-scale hypotheses (K linear/swizzled x V linear/swizzled); the assumed layout must be the one with pure rounding error.
- bf16 path bitwise identical with and without the scale arguments.

```bash
pytest tests/models/qwen4_exp/test_qsa_kv_quant.py -v
```

End-to-end (not part of CI): paired runs on one RTX PRO 6000 Blackwell (SM120, 96 GB), `RadixArk/Qwen3.8-Flash-Next-NVFP4`, TP1, MTP off, same checkpoint and start line, only `--kv-cache-dtype` varied, bf16 control run on the same day. Done on the `vllm/vllm-openai:qwen38-flash-next` build (`0.1.dev20073+g8e685d198`, module then named `qwen3_8_flash_next`); the QSA files of that build are identical to `main` apart from the module rename, and the cleaned code in this PR was re-run through the numerical tests on that build before submitting.

## Test Result

Numerical tests: `13 passed in 54 s` on SM120 (this PR's code, run on the `qwen38-flash-next` build with the module name mapped back). Values: fp8 kernel error 2.10e-3 relative vs 2.09e-3 for the bf16 kernel against the same reference; nvfp4 2.09e-3 vs 2.08e-3; all tile profiles within 1.3e-4 (fp8) and 4.9e-4 (nvfp4) max abs of the bf16 kernel on dequantized values; layout probe K linear / V swizzled at 0.090 relative error, every wrong hypothesis at 1.32; bf16 bitwise stable.

End-to-end, fp8_e4m3, scales 1.0:

| | bf16 | fp8_e4m3 | |
|---|---:|---:|---:|
| KiB per token, main KV (engine pool line) | 25.451 | **13.477** | x1.889 |
| KV pool at identical VRAM | 535,178 tokens | **1,010,693** | x1.889 |
| GSM8K, paired, n=100 | 97/100 | 96/100 | McNemar p = 1.0000, one discordant pair |
| Perplexity, three corpora, 1.49 M tokens | | +0.116 / -0.063 / -0.031 % | all CIs include 0; run-to-run self-difference +0.0995 % |
| Needle in a haystack, 65k to 235k | 50/50 | **70/70** | exhaustion 0.0 % |
| Decode, two prompt classes | 86.0 / 83.8 t/s | 85.3 / 82.5 t/s | -0.8 % / -1.6 % |
| Prefill, true cache miss, 12.8k tokens | 10,326 t/s | 9,724 t/s | -5.8 % |

End-to-end, nvfp4, scales 1.0:

| | nvfp4 | vs bf16 | vs fp8 |
|---|---:|---:|---:|
| KiB per token, main KV | **8.320** | x3.059 | x1.62 |
| KV pool at identical VRAM | **1,637,114** tokens | x3.059 | x1.62 |
| GSM8K, paired, n=100 | p = 1.0000 | | zero discordant pairs |
| Needle in a haystack | 70/70 | | |
| Perplexity | **+0.37 to +0.59 % worse**, consistent, all CIs exclude 0 | | 3.4 to 6x above run-to-run noise |
| Prefill | | | 1.75x slower at short context, 2.00x at 1M |
| Decode | flat, under 2 % | | |

nvfp4 is not free on this model: the perplexity penalty is real and does not show on the task axes we ran. Open item: on aggregation tasks near 1M our vLLM nvfp4 path scored 6/12 where SGLang on the same KV precision class scored 8/8 (Fisher exact p = 0.0769). Not resolved; more runs needed.

**Limitations / what reviewers should know**

- One machine, one architecture (SM120). The code has no SM gate (software dequant), but nothing else was measured.
- MTP / speculative decoding and batch scaling were not part of the gate chain.
- Two points where direction from the maintainers would help: (1) whether the platform-level nvfp4 fallback in `interface.py` is the right place, and (2) whether a QSA-local dequant helper (as here) or reuse of `_cast_kv_tile` from `triton_unified_attention.py` (the approach in #54426) is preferred. Either is a small change.

Code and full measurement write-up: https://github.com/andreasgru/vllm-qwen38-flash-next-kv-quant

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
