### PR TITLE
[Bugfix] Fix ColQwen3.5 pooler projector initialization

### DIFF
--- a/vllm/model_executor/models/colqwen3_5.py
+++ b/vllm/model_executor/models/colqwen3_5.py
@@ -123,8 +123,11 @@ class ColQwen3_5Model(
 
     The model produces L2-normalized per-token embeddings by:
     1. Running the Qwen3.5 backbone (vision + language) to get hidden states
-    2. Projecting hidden states through a linear layer (hidden_size -> embed_dim)
-    3. L2-normalizing the projected embeddings
+    2. Projection and L2-normalization via the pooler (TokenEmbeddingPoolerHead)
+
+    Attributes:
+        custom_text_proj: Linear projection from hidden_size to embed_dim.
+            This is passed to the pooler as pooler.head.projector.
     """
 
     # Mark this as a pooling model so vLLM routes to pooler path

--- a/vllm/model_executor/models/colqwen3_5.py
+++ b/vllm/model_executor/models/colqwen3_5.py
@@ -121,13 +121,10 @@ class ColQwen3_5Model(
     linear projection layer for per-token embeddings. It supports:
     - "token_embed" task: Per-token embeddings for late interaction scoring
 
-    The model produces per-token embeddings by:
+    The model produces L2-normalized per-token embeddings by:
     1. Running the Qwen3.5 backbone (vision + language) to get hidden states
     2. Projecting hidden states through a linear layer (hidden_size -> embed_dim)
-    3. L2 normalization is handled by the pooler via PoolerNormalize
-
-    Attributes:
-        custom_text_proj: Linear projection from hidden_size to embed_dim
+    3. L2-normalizing the projected embeddings
     """
 
     # Mark this as a pooling model so vLLM routes to pooler path
@@ -187,7 +184,7 @@ class ColQwen3_5Model(
         assert pooler_config is not None
         self.pooler = pooler_for_token_embed(
             pooler_config,
-            projector=None,
+            projector=self.custom_text_proj,
         )
 
     def forward(
@@ -198,24 +195,14 @@ class ColQwen3_5Model(
         inputs_embeds: torch.Tensor | None = None,
         **kwargs: object,
     ) -> torch.Tensor:
-        """Run forward pass producing per-token embeddings."""
-        hidden_states = super().forward(
+        """Run forward pass returning hidden states for pooler."""
+        return super().forward(
             input_ids=input_ids,
             positions=positions,
             intermediate_tensors=intermediate_tensors,
             inputs_embeds=inputs_embeds,
             **kwargs,
         )
-
-        if not isinstance(hidden_states, torch.Tensor):
-            return hidden_states  # type: ignore
-
-        proj_dtype = self.custom_text_proj.weight.dtype
-        if hidden_states.dtype != proj_dtype:
-            hidden_states = hidden_states.to(proj_dtype)
-
-        # Project to embedding dimension (normalization handled by pooler)
-        return self.custom_text_proj(hidden_states)
 
     # Names used for the projection layer across different ColQwen3.5 variants
     _PROJ_LAYER_NAMES = {
@@ -249,5 +236,8 @@ class ColQwen3_5Model(
                 weight = weight.to(device=param.device, dtype=param.dtype)
                 default_weight_loader(param, weight)
                 loaded.add(f"custom_text_proj.{param_name}")
+                # Also mark as loaded under pooler path since custom_text_proj
+                # is assigned to pooler.head.projector
+                loaded.add(f"pooler.head.projector.{param_name}")
 
         return loaded


### PR DESCRIPTION
**Issue:** ColQwen3.5 model loading failed with missing weight errors (pooler.head.projector.0.weight/bias) and runtime shape mismatches due to double-projection.

**Root cause:** The model created `custom_text_proj` but passed `projector=None` to `pooler_for_token_embed()`, causing `_load_st_projector()` to create an uninitialized ST projector in the pooler head. The model then applied projection in forward(), resulting in incompatible dimensions.

  **Fix**: Pass `projector=self.custom_text_proj` to the pooler (matching ColPali's pattern) and let the pooler handle projection. Remove projection logic from forward() so it returns raw hidden states. Mark weights as loaded under both `custom_text_proj.*` and `pooler.head.projector.*` paths.

All tests in test_colqwen3_5.py pass, including the previously failing:
```
test_colqwen3_5.py::test_colqwen3_5_token_embed[athrael-soju/colqwen3.5-4.5B-v3], 
test_colqwen3_5.py::test_colqwen3_5_late_interaction_scoring[athrael-soju/colqwen3.5-4.5B-v3], 
test_colqwen3_5.py::test_colqwen3_5_relevance_ordering[athrael-soju/colqwen3.5-4.5B-v3] 
```