### PR TITLE
[ROCm][CI][The Rock 10] Fix (MI355) Quantized Models failure on The Rock 10 with Triton 3.8.x

### DIFF
--- a/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     mxfp8_e4m3_quantize,
 )
 from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx950
 from vllm.triton_utils import tl, triton
 
 from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
@@ -166,7 +167,12 @@ def _select_cfg(M, N, K):
         # 3.6; on triton 3.7 its large BLOCK_M register/LDS footprint spills or hits
         # "out of resources", so use 128x128x256 -- within the known-good footprint.)
         if M >= 4096 and K >= 1024 and K % 256 == 0 and occ >= 256:
-            return 128, 128, 256, 8, 3
+            # Triton 3.8.x has TRITON_HIP_USE_ASYNC_COPY enabled on gfx950 by
+            # default which uses an extra LDS buffer, need num_stages=2.
+            if on_gfx950():
+                return 128, 128, 256, 8, 2
+            else:
+                return 128, 128, 256, 8, 3
         return 128, 128, 128, 8, 3
     # large-K (K >= 2048). BLOCK_K is K-divisibility-guarded (the K-loop is unmasked):
     # served large-K is 2048/6144 (%256==0), but fall back to 128 (always divides, since
@@ -186,7 +192,12 @@ def _select_cfg(M, N, K):
     # Covers the qkv-class local N=1536 (TP=8 qkv / TP=4 shared_gate_up) and the deep-K
     # / very-large-M shapes.
     if K % 256 == 0 and (1280 < N <= 1536 or (occ >= 128 and (K >= 4096 or M >= 4096))):
-        return 128, 128, 256, 8, 3
+        # Triton 3.8.x has TRITON_HIP_USE_ASYNC_COPY enabled on gfx950 by
+        # default which uses an extra LDS buffer, need num_stages=2.
+        if on_gfx950():
+            return 128, 128, 256, 8, 2
+        else:
+            return 128, 128, 256, 8, 3
     # small local-N (e.g. TP=8 shared_gate_up N=768): a 64-wide BLOCK_N doubles the
     # N-tile count -> better CU fill than 128x128 at this mid-large M (~1.4x there).
     if N <= 1024 and K % 256 == 0:

--- a/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/rocm_native.py
@@ -19,7 +19,6 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     mxfp8_e4m3_quantize,
 )
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx950
 from vllm.triton_utils import tl, triton
 
 from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
@@ -169,10 +168,7 @@ def _select_cfg(M, N, K):
         if M >= 4096 and K >= 1024 and K % 256 == 0 and occ >= 256:
             # Triton 3.8.x has TRITON_HIP_USE_ASYNC_COPY enabled on gfx950 by
             # default which uses an extra LDS buffer, need num_stages=2.
-            if on_gfx950():
-                return 128, 128, 256, 8, 2
-            else:
-                return 128, 128, 256, 8, 3
+            return 128, 128, 256, 8, 2
         return 128, 128, 128, 8, 3
     # large-K (K >= 2048). BLOCK_K is K-divisibility-guarded (the K-loop is unmasked):
     # served large-K is 2048/6144 (%256==0), but fall back to 128 (always divides, since
@@ -194,10 +190,7 @@ def _select_cfg(M, N, K):
     if K % 256 == 0 and (1280 < N <= 1536 or (occ >= 128 and (K >= 4096 or M >= 4096))):
         # Triton 3.8.x has TRITON_HIP_USE_ASYNC_COPY enabled on gfx950 by
         # default which uses an extra LDS buffer, need num_stages=2.
-        if on_gfx950():
-            return 128, 128, 256, 8, 2
-        else:
-            return 128, 128, 256, 8, 3
+        return 128, 128, 256, 8, 2
     # small local-N (e.g. TP=8 shared_gate_up N=768): a 64-wide BLOCK_N doubles the
     # N-tile count -> better CU fill than 128x128 at this mid-large M (~1.4x there).
     if N <= 1024 and K % 256 == 0:


### PR DESCRIPTION

## Purpose
I encountered these failures:

```
FAILED models/quantization/test_mxfp8.py::test_mxfp8_logprobs[dense] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
FAILED models/quantization/test_mxfp8.py::test_mxfp8_logprobs[moe] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
FAILED models/quantization/test_mxfp8.py::test_mxfp8_generation[dense] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
FAILED models/quantization/test_mxfp8.py::test_mxfp8_generation[moe] - RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
```
in the ` (MI355) Quantized Models` test group when running `The Rock 10` with `Python 3.12`, `Ubuntu 22.04` and `Triton 3.8.x`.

On `MI355`, `TRITON_HIP_USE_ASYNC_COPY`  is enabled by default, but disabled on all other MI platforms.  It is verifiable by running the same test with` TRITON_HIP_USE_ASYNC_COPY=0 `on an MI355 which will pass. 

This PR lets MI350 use num_stages=2 instead.  

Performance should improve once moving to Triton 3.8.x.

I did a small test with `_mxfp8_linear_kernel`

| shape (M,N,K)  | (3.7.1 num_stages=3) µs| (3.8.x num_stages=2) µs| Δ |
  |----------------|-----------------:|---------------:|---------|
  | 8192,4096,1024 |             74.3 |           62.8 | -15.5%  |
  | 8192,1024,1024 |             23.4 |           20.8 | -11.1%  |
  | 8192,6144,1024 |            122.8 |          105.0 | -14.5%  |
  | 4096,2048,6144 |             91.8 |           75.0 | -18.3%  |

This async copy only affects 3.8.0 on gfx950.  The PR has been updated so that this will only use `num_stages=2` for only that case, so no regressions on 3.7.1 should occur.

I've tested on MI300 and MI350 with both 3.7.1 and 3.8.0 to ensure the correct `num_stages` value is used in each case.

## Test Plan
`pytest -sv models/quantization/test_mxfp8.py::test_mxfp8_logprobs`
## Test Result
`===== 2 passed, 26 warnings in 144.95s (0:02:24) =====`


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ X] The test plan, such as providing test command.
- [ X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

