### PR TITLE
[Bugfix][Frontend] Malformed `$defs` in a tool schema should be a 400, not a 500

### DIFF
--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -11,6 +11,7 @@ from pydantic import TypeAdapter
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
 from vllm.tool_parsers.utils import (
     find_tool_properties,
@@ -394,3 +395,107 @@ class TestNonFunctionToolsSkipped:
         any_of = schema["items"]["anyOf"]
         assert len(any_of) == 1
         assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+
+
+class TestMalformedToolSchemaDefs:
+    """`parameters` is an arbitrary caller-supplied dict, so `$defs` is
+    whatever the request said it was.
+
+    `_get_tool_schema_defs` defaulted it with `params.pop("$defs", {})`, which
+    only covers the key being *absent*. An explicit `"$defs": null` reached
+    `.items()` and raised `AttributeError`. Nothing between
+    `get_json_schema_from_tools` and the route catches that
+    (`ToolParser.adjust_request` -> `OnlineRenderer.render_chat` ->
+    `render_chat_request` -> `create_chat_completion`), so it surfaced as a
+    500 for a request the caller got wrong.
+    """
+
+    @staticmethod
+    def _tool(params: dict) -> ChatCompletionToolsParam:
+        return TypeAdapter(ChatCompletionToolsParam).validate_python(
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": params,
+                },
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "defs",
+        [
+            pytest.param(None, id="null"),
+            pytest.param([], id="list"),
+            pytest.param("nope", id="string"),
+            pytest.param(1, id="int"),
+        ],
+    )
+    def test_non_object_defs_is_a_client_error(self, defs):
+        tools = [
+            self._tool(
+                {
+                    "type": "object",
+                    "properties": {"a": {"type": "string"}},
+                    "$defs": defs,
+                }
+            )
+        ]
+
+        with pytest.raises(VLLMValidationError) as exc_info:
+            get_json_schema_from_tools(tools=tools, tool_choice="required")
+
+        assert exc_info.value.parameter == "tools"
+        assert "$defs" in str(exc_info.value)
+        assert "get_weather" in str(exc_info.value)
+
+    def test_duplicate_def_names_is_a_client_error(self):
+        """Also caller-caused, and it used to raise a plain `ValueError`."""
+        tools = [
+            self._tool(
+                {
+                    "type": "object",
+                    "properties": {"a": {"$ref": "#/$defs/D"}},
+                    "$defs": {"D": {"type": "string"}},
+                }
+            ),
+            self._tool(
+                {
+                    "type": "object",
+                    "properties": {"b": {"$ref": "#/$defs/D"}},
+                    "$defs": {"D": {"type": "integer"}},
+                }
+            ),
+        ]
+
+        with pytest.raises(VLLMValidationError) as exc_info:
+            get_json_schema_from_tools(tools=tools, tool_choice="required")
+
+        assert exc_info.value.parameter == "tools"
+        assert "multiple schemas" in str(exc_info.value)
+
+    def test_well_formed_defs_still_hoisted(self):
+        """The type check must not reject the shape it is guarding."""
+        tools = [
+            self._tool(
+                {
+                    "type": "object",
+                    "properties": {"a": {"$ref": "#/$defs/D"}},
+                    "$defs": {"D": {"type": "string"}},
+                }
+            )
+        ]
+
+        schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
+
+        assert schema["$defs"] == {"D": {"type": "string"}}
+
+    def test_absent_defs_still_works(self):
+        tools = [
+            self._tool({"type": "object", "properties": {"a": {"type": "string"}}})
+        ]
+
+        schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
+
+        assert isinstance(schema, dict)

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -29,6 +29,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 
 Tool: TypeAlias = ChatCompletionToolsParam | ResponsesTool
@@ -334,15 +335,29 @@ def _get_tool_schema_defs(
 ) -> dict:
     all_defs: dict[str, dict[str, Any]] = {}
     for tool in tools:
-        _, params = _extract_tool_info(tool)
+        name, params = _extract_tool_info(tool)
         if params is None:
             continue
         defs = params.pop("$defs", {})
+        # `parameters` is an arbitrary caller-supplied dict, so `$defs` is
+        # whatever the request said it was. The `{}` default only covers the
+        # key being absent; an explicit `"$defs": null` (or a list, or a
+        # string) reaches `.items()` below and raises `AttributeError`, which
+        # is not caught between here and the route and so becomes a 500.
+        if not isinstance(defs, dict):
+            raise VLLMValidationError(
+                f"`$defs` in the parameters of tool '{name}' must be an "
+                f"object, got {type(defs).__name__}.",
+                parameter="tools",
+            )
         for def_name, def_schema in defs.items():
             if def_name in all_defs and all_defs[def_name] != def_schema:
-                raise ValueError(
+                # Also caller-caused, so a 400 rather than the 500 a plain
+                # ValueError produced here.
+                raise VLLMValidationError(
                     f"Tool definition '{def_name}' has multiple schemas, "
-                    "which is not supported."
+                    "which is not supported.",
+                    parameter="tools",
                 )
             all_defs[def_name] = def_schema
     return all_defs


### PR DESCRIPTION
## Purpose

A tool schema containing `"$defs": null` turns a caller mistake into a 500.

`tools[].function.parameters` is an arbitrary caller-supplied dict, so `$defs` is whatever the request said it was. `_get_tool_schema_defs` read it as:

```python
defs = params.pop("$defs", {})
for def_name, def_schema in defs.items():
```

The `{}` default only covers the key being **absent**. An explicit `"$defs": null` — or a list, or a string — reaches `.items()` and raises `AttributeError`.

Nothing catches it on the way out:

`ToolParser.adjust_request` → `OnlineRenderer.render_chat` → `ChatCompletionServing.render_chat_request` → `create_chat_completion`

so the client gets a 500 for a request it simply got wrong.

```console
$ curl -s localhost:8000/v1/chat/completions -d '{
    "model": "...", "messages": [{"role":"user","content":"hi"}],
    "tool_choice": "required",
    "tools": [{"type":"function","function":{"name":"get_weather",
      "parameters":{"type":"object","properties":{"a":{"type":"string"}},"$defs":null}}}]
  }'
# AttributeError: 'NoneType' object has no attribute 'items'  ->  500
```

`_get_tool_schema_defs` is shared, so this reaches roughly 35 of the registered tool parsers. I found it by fuzzing `adjust_request` with malformed tool schemas across every parser in the registry; every one of them that got that far failed on the same input.

The boundary is narrow, and I checked the neighbours rather than assuming:

| `parameters` | `tool_choice="auto"` | `"none"` | `"required"` |
| --- | --- | --- | --- |
| `{"$defs": null}` | ok | ok | **AttributeError** |
| `{"$defs": []}` | ok | ok | **AttributeError** |
| `{"$defs": "x"}` | ok | ok | **AttributeError** |
| `{"properties": null}` | ok | ok | ok |
| `{"required": null}` | ok | ok | ok |
| `parameters: null` | ok | ok | ok |

Only `$defs`, and only on the path that actually builds the JSON schema. A named `tool_choice` takes a different branch and is unaffected.

## The fix

Reject a non-object `$defs` with `VLLMValidationError`, which
`create_error_response` maps to a 400 naming `tools` as the offending parameter.

The duplicate-definition check right below it raised a plain `ValueError`:

```python
raise ValueError(
    f"Tool definition '{def_name}' has multiple schemas, which is not supported."
)
```

That is also caller-caused — two tools declaring the same `$defs` name with different schemas — and it also became a 500, so it moves to the same exception. I checked that nothing catches `ValueError` from this call, so the type change is not load-bearing anywhere.

### Overlap I checked

Three open PRs touch this function, and none of them fixes this:

- **#46170** (Avoid mutating tool parameters in `_get_tool_schema_defs`) replaces the `pop` with a non-mutating form but keeps `params.get("$defs", {})`, so the crash survives it verbatim. Last updated July 5, `mergeable_state=blocked`.
- **#50933** (Resolve `$ref`/`$defs` in tool schemas) adds ref resolution downstream and does not type-check `$defs`.
- **#49602** is scoped to the Cohere reasoning parser.

This change is one `isinstance` guard plus an exception type, so it should rebase cleanly onto whichever of those lands.

## Test Plan

```bash
pytest tests/tool_use/test_tool_choice_required.py -v
```

`TestMalformedToolSchemaDefs` added to the file that already tests
`get_json_schema_from_tools`:

- `test_non_object_defs_is_a_client_error` — parametrized over `null`, `[]`, `"nope"`, `1`; asserts `VLLMValidationError` with `parameter == "tools"` and a message naming the tool
- `test_duplicate_def_names_is_a_client_error` — the `ValueError` → `VLLMValidationError` move
- `test_well_formed_defs_still_hoisted` — a real `$defs` is still hoisted to the top-level schema
- `test_absent_defs_still_works` — the common case, no `$defs` at all

## Test Result

```
$ pytest tests/tool_use/test_tool_choice_required.py -q
170 passed, 15 warnings in 58.94s

$ pytest tests/tool_parsers/test_utils.py tests/tool_use/test_tool_choice_required.py -q
344 passed, 16 warnings in 120.42s
```

Reverting only `vllm/tool_parsers/utils.py` and running the new class:

```
$ pytest tests/tool_use/test_tool_choice_required.py -q -k MalformedToolSchemaDefs
FAILED ...::test_non_object_defs_is_a_client_error[null]
FAILED ...::test_non_object_defs_is_a_client_error[list]
FAILED ...::test_non_object_defs_is_a_client_error[string]
FAILED ...::test_non_object_defs_is_a_client_error[int]
FAILED ...::test_duplicate_def_names_is_a_client_error
5 failed, 2 passed, 163 deselected
```

The two that pass before and after are `well_formed_defs_still_hoisted` and
`absent_defs_still_works`, which is what makes them worth having.

Re-running the schema fuzz after the change, across every parser in the registry and two seeds, `adjust_request` no longer raises anything that is not a `VLLMClientError`.

```
$ ruff check <touched files>            # All checks passed!
$ ruff format --check <touched files>   # 2 files already formatted
```

The repo's local pre-commit hooks pass on the touched files (`check_spdx_header`, `check_init_lazy_imports`, `check_forbidden_imports`, `check_torch_cuda`, `check_boolean_context_manager`).
