### PR TITLE
[Bugfix][Model] Bake real KV caches into captured fused_norm_rope under PIECEWISE (fixes silent garbage output for DSA models on multi-node TP)

### DIFF
--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -304,6 +304,7 @@ class DeepseekV32Attention(MLAAttention):
         slot_mapping = forward_context.slot_mapping
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
+        attn_metadata = forward_context.attn_metadata
 
         if self.indexer is not None and not self.skip_topk:
             has_indexer = True
@@ -326,11 +327,35 @@ class DeepseekV32Attention(MLAAttention):
             indexer_softmax_scale = 0.0
             indexer_n_head_scale = 0.0
 
-        if forward_context.attn_metadata is None or self.use_pcp:
+        if self.use_pcp:
             mla_kv_cache = None
             mla_k_scale = None
             indexer_k_cache = None
             mla_slot = None
+        elif attn_metadata is None:
+            # PIECEWISE capture runs this code without attention metadata. The
+            # cache views and slot mapping chosen here are baked into the
+            # captured fused_norm_rope launch, so they must be the real bound
+            # caches and the persistent slot-mapping buffer: during capture the
+            # buffer holds PAD_SLOT_ID (-1), which the kernel treats as
+            # "no write", and at replay it carries the real per-token slots.
+            # Passing None here would permanently disable the fused cache
+            # writes in the captured graph.
+            if mla_slot is not None and self.kv_cache.numel() > 0:
+                mla_kv_cache = self.kv_cache
+                mla_k_scale = self._k_scale
+            else:
+                mla_kv_cache = None
+                mla_k_scale = None
+                mla_slot = None
+            if (
+                mla_slot is not None
+                and self.indexer is not None
+                and self.indexer.k_cache.kv_cache.numel() > 0
+            ):
+                indexer_k_cache = self.indexer.k_cache.kv_cache
+            else:
+                indexer_k_cache = None
         else:
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale


### PR DESCRIPTION
## Purpose

Fixes silent output corruption (garbage / repetition-loop "jibberish") when serving DeepSeek-V3.2-class DSA models (DeepSeek-V3.2, GLM-5.x `GlmMoeDsaForCausalLM`) with **PIECEWISE CUDA graphs** on multi-node TP where the KV-cache write is fused into a *captured* Triton kernel (`_fused_norm_rope_kernel`).

### Root cause

Under MRV2 PIECEWISE capture, the DSA eager-break python (`_sparse_indexer_and_attn` and the captured-region code feeding it) runs with **no attention metadata**: `prepare_inputs_to_capture` builds metadata with `for_capture=False` for PIECEWISE (per the known "brittle assumption" in `cudagraph_utils.py`), and at capture time the layer python observes `forward_context.attn_metadata is None`.

`DeepseekV32Attention.forward()` treated `attn_metadata is None` as "no KV cache" and passed:

- `mla_kv_cache = None` → `fused_norm_rope` substituted a **0-element dummy tensor** with `entry_stride == 0`
- `mla_slot = None` → `slot_mapping = None`

Those arguments were **baked into the captured graph**. At every decode replay the captured `fused_norm_rope` re-executes, but its fused cache-write path (pid 0: indexer-K FP8 cache write, pid 1: MLA latent concat-and-cache) early-returns on the baked dummy/None arguments — so **decode-time KV writes never happen**. Attention then reads latent rows that are stale from prefill (or garbage from a previous request), the indexer MQA logits go wrong, and the corruption cascades (finite-but-weak attention output at the first indexer-leader layer, NaN from the second onward). Prefill and the first generated token are unaffected because chunked prefill runs with real metadata — matching the classic "first token correct, then garbage" signature.

The same `attn_metadata is None` condition can also arise for any DSA model whose attention layer python executes during capture with no metadata, so the fix is written defensively rather than tied to one backend.

### Fix

Split the `attn_metadata is None` case from the `use_pcp` case. When there is no metadata but the layer has bound cache tensors and a persistent per-layer slot-mapping buffer (always true after `initialize_kv_cache`, including during capture):

- bake the **real** `self.kv_cache` / `self.indexer.k_cache.kv_cache` views and `self._k_scale` into the captured kernel launch, and
- keep `mla_slot` pointing at the **persistent slot-mapping buffer**.

Safety during capture: `get_dummy_slot_mappings()` fills the persistent buffer with `PAD_SLOT_ID = -1` and `_fused_norm_rope_kernel` returns early for `slot < 0`, so no cache write happens at capture time (verified: the dummy/capture path never writes any slot). At replay the same persistent buffer carries the real per-step slots, so the baked in-graph kernel writes the correct rows every step. Behavior with metadata present (eager, prefill, FULL-graph capture) is unchanged.

### Results

All serving on a 4-node AGX Thor (SM110) TP=4 cluster, `--attention-backend TRITON_MLA_SPARSE --kv-cache-dtype fp8_e4m3` (canonicalized to `fp8_ds_mla`), `cudagraph_mode=PIECEWISE`, greedy decoding:

| Config | Behavior |
|---|---|
| main (80389cfedd) with PIECEWISE | jibberish: reasoning degenerates to `"1!!!"`-style repetition; ~0.1 tok/s decode |
| main + this fix | coherent: correct reasoning chains, clean final answers, ~10× faster decode |

Prompts validated end-to-end: arithmetic ("What is 2+2?" → `"2 + 2 = 4."` with a full reasoning chain), creative writing, multi-part instructions, and a 2000-token long-form technical generation that stayed coherent through the entire decode (previous corruption typically appeared within the first few decode steps). Runtime device-side probes confirmed that with the fix the per-replay `index_q_fp8`/`mqa_q` tensors are finite with sane magnitudes (previously NaN / 1e37 garbage), the indexer top-k valid count grows correctly with context (48 → 138+), and the first decode replay produces finite MLA outputs.

### Issues this may also address

The "silent corruption under PIECEWISE/FULL_AND_PIECEWISE with no errors" failure mode matches several open reports; those reporters should re-test with this fix:

- #45425 — Silent output corruption: MTP + DCP + FULL_AND_PIECEWISE cudagraphs (GLM-5.1 NVFP4, sparse MLA, fp8_ds_mla)
- #40969 — DeepSeek-V4-Flash hangs/corrupts with FULL_AND_PIECEWISE + chunked prefill on SM 12.x (GB10)
- #43631 — `enforce_eager=False` generates garbage tokens (InternVL2-8B; that one was root-caused separately in #43668, but the symptom class is the same)

(Note: #45425's own mechanism analysis points at a different trigger — varlen-decode reclassification under DCP — so this fix may be complementary rather than a complete fix there.)

## Test plan

- [x] 4-node SM110 cluster, GLM-5.2 NVFP4-AQLM-hybrid, TP=4, TRITON_MLA_SPARSE + fp8_ds_mla, PIECEWISE: server starts, greedy Q&A coherent across short/medium/2000-token generations (was: deterministic garbage within the first decode steps)
- [x] Capture-path safety: during capture the persistent slot buffer is `PAD_SLOT_ID=-1` and the kernel early-returns — verified no cache writes occur with dummy/capture inputs, and that capture-time slot values can never exceed the allocated cache blocks (dummy mappings are all `-1`; real slots come from the shared block pool, `block_id < num_gpu_blocks`)
- [x] Metadata-present paths (eager prefill, decode eager breaks, FULL capture) unchanged
- [x] `ruff check` / `ruff format --check` clean on the touched file

## AI assistance

This change was developed with the assistance of an AI coding agent (Hermes - using GLM-5.3-flash). The submitting author has reviewed all changed lines, ran the validation above on the target hardware, and understands the root cause end-to-end.

🤖 **Generated with AI assistance** — see the statement above.

<details>
<summary>Additional diagnostics that isolated the root cause (for reviewers)</summary>

- Device-side captures (copy kernels *inside* the captured region, so they hold replay-time data) showed `q_c` / `index_q_fp8` / `mqa_q` at the second indexer-leader layer were NaN or 1e37-magnitude garbage on most decode replays while the residual stream stayed finite — the signature of consumed buffers that their producer failed to rewrite.
- The MQA-logits/topk path itself is correct: the shared top-k buffer holds valid, context-growing indices every replay.
- A standalone capture+replay harness of the fused_norm_rope → fused_q chain reproduced 1e37 garbage deterministically when an out-of-bounds slot was fed by the harness; that OOB hole is real but **not** the server trigger (server slot mappings are always in-bounds or `PAD_SLOT_ID=-1`), so a separate defensive bounds-guard commit will follow.

</details>
