### PR TITLE
[Model Runner V2][Spec Decode] Skip DP sync for all speculator uniform decodes

### DIFF
--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -33,6 +33,9 @@ class DPSyncState:
     # Whether the ranks agreed to run eager. A dispatch reusing this must run
     # eager too; no shape was agreed, so picking a graph per rank would diverge.
     eager: bool
+    # Agreed upper bound on any rank's request count. Holds the padded count when
+    # a FULL descriptor imposed one, else the most any rank scheduled.
+    num_reqs: int
 
 
 def sync_cudagraph_and_dp_padding(
@@ -53,17 +56,19 @@ def sync_cudagraph_and_dp_padding(
     """
     assert dp_size > 1, "DP size must be greater than 1"
     group = get_dp_group().cpu_group
-    tensor = torch.zeros(4, dp_size, dtype=torch.int32, device="cpu")
+    tensor = torch.zeros(5, dp_size, dtype=torch.int32, device="cpu")
     tensor[0][dp_rank] = num_tokens
     tensor[1][dp_rank] = desired_batch_desc.cg_mode.value
     tensor[2][dp_rank] = uniform_token_count or 0  # (0 means None)
     tensor[3][dp_rank] = max_query_len or -1  # (-1 means None)
+    tensor[4][dp_rank] = num_reqs
     dist.all_reduce(tensor, group=group)
 
     num_tokens_across_dp = tensor[0]
     cg_mode_across_dp = tensor[1]
     uniform_token_counts_across_dp = tensor[2]
     max_query_lens_across_dp = tensor[3]
+    num_reqs_across_dp = tensor[4]
 
     # If ranks disagree on the uniform token count, or its 0 (means None) set to None
     synced_uniform_token_count: int | None = int(uniform_token_counts_across_dp[0])
@@ -93,6 +98,7 @@ def sync_cudagraph_and_dp_padding(
                 num_tokens_across_dp=num_tokens_across_dp,
                 uniform_token_count=synced_uniform_token_count,
                 eager=True,
+                num_reqs=int(num_reqs_across_dp.max().item()),
             ),
         )
 
@@ -126,6 +132,12 @@ def sync_cudagraph_and_dp_padding(
         num_tokens_across_dp=num_tokens_across_dp,
         uniform_token_count=synced_uniform_token_count,
         eager=False,
+        num_reqs=(
+            synced_desc.num_reqs
+            if synced_desc.cg_mode == CUDAGraphMode.FULL
+            and synced_desc.num_reqs is not None
+            else int(num_reqs_across_dp.max().item())
+        ),
     )
 
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -336,16 +336,22 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             advance_draft_positions=self.advance_draft_positions,
         )
 
+        decode_batch_sync, num_batch_tokens = (
+            self._build_uniform_batch_dp_sync(dp_sync, num_reqs, num_query_per_req=1)
+            if dp_sync is not None
+            else (None, num_reqs)
+        )
         # Each request produces exactly 1 token per draft generation step,
         # enabling FULL graph replay.
         decode_batch_desc, decode_batch_sync = dispatch_cg_and_sync_dp(
             self.decode_cudagraph_manager,
             num_reqs,
-            num_reqs,
+            num_batch_tokens,
             uniform_token_count=1,
             dp_size=self.dp_size,
             dp_rank=self.dp_rank,
             need_eager=is_profile,
+            dp_sync=decode_batch_sync,
         )
         num_tokens_across_dp = (
             decode_batch_sync.num_tokens_across_dp

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -367,9 +367,7 @@ class DFlashSpeculator(DraftModelSpeculator):
                 num_query_tokens,
                 attn_metadata=None,
                 slot_mappings=None,
-                num_tokens_across_dp=(
-                    dp_sync.num_tokens_across_dp if dp_sync is not None else None
-                ),
+                num_tokens_across_dp=None,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
             )
             return self.draft_tokens[:num_reqs]
@@ -429,17 +427,22 @@ class DFlashSpeculator(DraftModelSpeculator):
             context_slots,
         )
 
+        batch_sync, num_batch_tokens = (
+            self._build_uniform_batch_dp_sync(dp_sync, num_reqs, self.num_query_per_req)
+            if dp_sync is not None
+            else (None, num_query_tokens)
+        )
         # Every DFlash step has exactly num_query_per_req tokens, so we can use FULL CGs
         batch_desc, batch_sync = dispatch_cg_and_sync_dp(
             self.query_cudagraph_manager,
             num_reqs,
-            num_query_tokens,
+            num_batch_tokens,
             uniform_token_count=self.num_query_per_req,
             dp_size=self.dp_size,
             dp_rank=self.dp_rank,
             need_eager=is_profile,
+            dp_sync=batch_sync,
         )
-
         num_reqs_padded = batch_desc.num_reqs or num_reqs
         num_tokens_padded = batch_desc.num_tokens
         num_tokens_across_dp = (

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Any
 
 import numpy as np
@@ -409,3 +410,22 @@ class DraftModelSpeculator(BaseSpeculator):
         # idx_mapping for CG padded requests points to -1, which is ignored
         # during sampling to prevent writing stale values to draft logits.
         self.idx_mapping[num_reqs:].fill_(-1)
+
+    def _build_uniform_batch_dp_sync(
+        self,
+        target_dp_sync: DPSyncState,
+        num_reqs: int,
+        num_query_per_req: int = 1,
+    ) -> tuple[DPSyncState, int]:
+        num_batch_tokens = target_dp_sync.num_reqs * num_query_per_req
+        assert num_reqs * num_query_per_req <= num_batch_tokens, (
+            "reusing a DP sync that does not cover this batch's requests"
+        )
+        return replace(
+            target_dp_sync,
+            num_tokens_across_dp=torch.full_like(
+                target_dp_sync.num_tokens_across_dp, num_batch_tokens
+            ),
+            uniform_token_count=num_query_per_req,
+            eager=False,
+        ), num_batch_tokens


### PR DESCRIPTION
# Summary
Continuation of https://github.com/vllm-project/vllm/pull/53694, which removed the DP sync for MTP/EAGLE draft prefill. This PR removes the remaining DP syncs for the rest of the speculators: MTP, EAGLE, DFlash 1 & 2, DSpark. In the MTP/EAGLE case, it removes the DP sync before the multi-step-decode loop to draft the last N-1 tokens. In the DFlash/DSpark case, it removes the DP sync before drafting the B x N tokens in a single model forward.

# This PR
Extends the DP sync state to contain the agreed-upon number of requests between DP ranks. This is computed right before the GPUModelRunner's target model forward, during the call to `dispatch_cg_and_sync_dp`. That same state is used by the `AutoRegressiveSpeculator` and `DFlashSpeculator` to construct the uniform batch DP state needed to fetch the correct batch descriptor (`_build_uniform_batch_dp_sync`).

# Evals/Benchmarks

**Setup.** GSM8K (1319 questions), `dp=2, tp=2, --enable-expert-parallel` on 4×GB200. Perf via `vllm bench serve --dataset-name custom --dataset-path gsm8k.jsonl --backend openai-chat --request-rate inf --max-concurrency 64 --num-warmups 64 --num-prompts 1319 --custom-output-len 2048 --temperature 0 --top-p 1.0`. Perf figures are the **median of 6 runs (2 servers × 3 reps) per side**, run back-to-back in ABBA order (after → before → before → after) so run position cannot be mistaken for a branch effect; accuracy is one full-dataset pass per server. 

## DeepSeek-V4-Flash + MTP=3 + DP=2 (`AutoRegressiveSpeculator`)

| metric | before | after | Δ |
| --- | ---: | ---: | ---: |
| **GSM8K accuracy** | 0.944 / 0.948 | **0.946 / 0.950** | +0.002 |
| Invalid responses | 0.001 / 0.000 | 0.000 / 0.000 | — |
| Output token throughput (tok/s) | 2888.72 | **2949.16** | **+2.1%** |
| Mean TPOT (ms) | 21.06 | 20.66 | −1.9% |
| Median TPOT (ms) | 21.58 | 21.13 | −2.1% |
| P99 TPOT (ms) | 26.89 | 25.77 | −4.2% |
| Mean TTFT (ms) | 368.48 | 358.22 | −2.8% |
| Acceptance rate | 60.20% | 60.20% | 0.00pp |
| Acceptance length | 2.81 | 2.81 | — |
| Per-position acceptance | 89.00 / 63.11 / 28.46 | 88.98 / 63.08 / 28.53 | flat |

**Draft DP-syncs eliminated.** Counting both exits of `dispatch_cg_and_sync_dp` over a full run — speculator-side collectives go to zero, the target's own sync is untouched:

```
ModelCudaGraphManager:collect            833   <- target's own, irreducible
SpeculatorCudaGraphManager:reuse_padded 1366
SpeculatorCudaGraphManager:reuse_eager   298   = 2 × 832 target steps
SpeculatorCudaGraphManager:collect      ABSENT
```

<details><summary>individual runs (output tok/s)</summary>

```
before: 2848.07, 2867.45, 2875.74, 2901.70, 2922.46, 2922.66
after:  2879.50, 2900.86, 2937.61, 2960.72, 2971.21, 2989.20
```
</details>

## DeepSeek-V4-Flash-DSpark + DSpark N=5 + DP=2 (`DSparkSpeculator`)

| metric | before | after | Δ |
| --- | ---: | ---: | ---: |
| **GSM8K accuracy** | 0.955 / 0.947 | **0.945 / 0.954** | −0.002 |
| Invalid responses | 0.000 / 0.000 | 0.000 / 0.000 | — |
| Output token throughput (tok/s) | 3384.32 | **3425.93** | **+1.2%** |
| Mean TPOT (ms) | 17.70 | 17.46 | −1.4% |
| Median TPOT (ms) | 18.04 | 17.84 | −1.1% |
| P99 TPOT (ms) | 23.21 | 22.87 | −1.5% |
| Mean TTFT (ms) | 378.38 | 381.53 | +0.8% |
| Acceptance rate | 60.28% | 60.14% | −0.14pp |
| Acceptance length | 4.01 | 4.01 | — |
| Per-position acceptance | 87.45 / 72.66 / 58.78 / 46.59 / 35.89 | 87.39 / 72.67 / 58.61 / 46.40 / 35.69 | flat |

**Draft DP-syncs eliminated.** Counting both exits of `dispatch_cg_and_sync_dp` over a full run — speculator-side collectives go to zero, the target's own sync is untouched:

```
ModelCudaGraphManager:collect            500   <- target's own, irreducible
DFlashCudaGraphManager:reuse_padded      499   = 1 × ~500 target steps
DFlashCudaGraphManager:collect        ABSENT
```

<details><summary>individual runs (output tok/s)</summary>

```
before: 3297.92, 3342.87, 3369.18, 3399.47, 3475.75, 3500.59
after:  3382.73, 3390.52, 3422.76, 3429.09, 3429.75, 3459.46
```
</details>
