### PR TITLE
[CI] Surface why the CRCR nightly report cannot read its Buildkite secret

### DIFF
--- a/.buildkite/scripts/crcr-report.sh
+++ b/.buildkite/scripts/crcr-report.sh
@@ -50,12 +50,14 @@ if [[ -z "${BK_TOKEN}" ]]; then
         echo "buildkite-agent is not on PATH; cannot read secret '${TOKEN_SECRET_KEY}'"
     else
         secret_err="$(mktemp)"
-        # --skip-redaction because the step runs under the docker plugin, which
-        # does not expose the Job API socket to the container. Without it the
-        # agent fetches the secret and then refuses to print it, having no way
-        # to register the value with the log redactor. The value only ever
-        # reaches BK_TOKEN and a curl header, so it cannot land in the log.
-        if BK_TOKEN="$(buildkite-agent secret get --skip-redaction "${TOKEN_SECRET_KEY}" 2>"${secret_err}")"; then
+        # Deliberately not passing --skip-redaction. On the deployed agent
+        # (v3.73.1) the flag cannot help: secret_get.go creates the Job API
+        # client unconditionally and only checks SkipRedaction afterwards, so
+        # under the docker plugin -- which does not expose the Job API socket to
+        # the container -- it fails before the flag is read. That ordering was
+        # only fixed in v3.107.0. Skipping redaction would also stop the token
+        # being registered with the log redactor, for no gain here.
+        if BK_TOKEN="$(buildkite-agent secret get "${TOKEN_SECRET_KEY}" 2>"${secret_err}")"; then
             if [[ -z "${BK_TOKEN}" ]]; then
                 echo "secret '${TOKEN_SECRET_KEY}' resolved but is empty"
             fi

--- a/.buildkite/scripts/crcr-report.sh
+++ b/.buildkite/scripts/crcr-report.sh
@@ -39,10 +39,34 @@ fi
 # the agent exposes only its own step, so the job list comes from the REST API.
 TOKEN_SECRET_KEY="${CRCR_BUILDKITE_TOKEN_SECRET_KEY:-CRCR_BUILDKITE_API_TOKEN}"
 BK_TOKEN="${BUILDKITE_API_TOKEN:-}"
-if [[ -z "${BK_TOKEN}" ]] && command -v buildkite-agent >/dev/null 2>&1; then
+if [[ -z "${BK_TOKEN}" ]]; then
     # Not in the job environment, so read it from a Buildkite secret. The agent
     # redacts values fetched this way from the log.
-    BK_TOKEN="$(buildkite-agent secret get "${TOKEN_SECRET_KEY}" 2>/dev/null)" || BK_TOKEN=""
+    #
+    # Report why a lookup failed. Swallowing stderr made a missing secret, a
+    # denied policy and an unusable agent indistinguishable, all surfacing as the
+    # same "no token" line. Only stderr is echoed -- stdout is the secret.
+    if ! command -v buildkite-agent >/dev/null 2>&1; then
+        echo "buildkite-agent is not on PATH; cannot read secret '${TOKEN_SECRET_KEY}'"
+    else
+        secret_err="$(mktemp)"
+        # --skip-redaction because the step runs under the docker plugin, which
+        # does not expose the Job API socket to the container. Without it the
+        # agent fetches the secret and then refuses to print it, having no way
+        # to register the value with the log redactor. The value only ever
+        # reaches BK_TOKEN and a curl header, so it cannot land in the log.
+        if BK_TOKEN="$(buildkite-agent secret get --skip-redaction "${TOKEN_SECRET_KEY}" 2>"${secret_err}")"; then
+            if [[ -z "${BK_TOKEN}" ]]; then
+                echo "secret '${TOKEN_SECRET_KEY}' resolved but is empty"
+            fi
+        else
+            BK_TOKEN=""
+            echo "buildkite-agent secret get '${TOKEN_SECRET_KEY}' failed" \
+                "(agent $(buildkite-agent --version 2>&1 | head -1)):"
+            sed 's/^/    /' "${secret_err}"
+        fi
+        rm -f "${secret_err}"
+    fi
 fi
 if [[ -z "${BK_TOKEN}" ]]; then
     echo "no Buildkite API token (env BUILDKITE_API_TOKEN or secret" \


### PR DESCRIPTION
## Problem

The CRCR nightly report never posts. `crcr-report.sh` swallowed stderr when reading the API token:

```bash
BK_TOKEN="$(buildkite-agent secret get "${TOKEN_SECRET_KEY}" 2>/dev/null)" || BK_TOKEN=""
```

so a missing secret, a denied access policy, an agent that is not on PATH, and an agent that cannot reach the Job API all collapse into the same `no Buildkite API token` line. We spent a day eliminating the secret's existence, its key name, the cluster, the agent binary, the agent version and the access policy without ever seeing the actual error.

## Change

Report *why* the lookup failed:

- distinguish "not on PATH" from "the command ran and failed"
- capture stderr to a temp file and echo it, indented, on failure
- include `buildkite-agent --version` in the failure line
- distinguish "resolved but empty" from "failed"

stdout is still captured into `BK_TOKEN` and never echoed, so the token cannot reach the log.

## Why not `--skip-redaction`

An earlier revision of this PR passed `--skip-redaction`, on the theory that the docker plugin does not expose the Job API socket to the container and the agent therefore refuses to print a value it cannot register with the log redactor.

That is the right diagnosis but the wrong fix, and it cannot work on the deployed agent. In **v3.73.1** the Job API client is created *unconditionally*, before `SkipRedaction` is consulted:

```go
secret, _, err := agentClient.GetSecret(ctx, ...)
if err != nil { return err }

jobClient, err := jobapi.NewDefaultClient(ctx)                        // unconditional
if err != nil {
    return fmt.Errorf("failed to create Job API client: %w", err)     // exits here
}

if !cfg.SkipRedaction {                                               // never reached
    AddToRedactor(...)
}
```

With no socket it returns before the flag is read, so the flag is inert. The ordering was only corrected in **v3.107.0**, which moves `NewDefaultClient` inside the `!SkipRedaction` branch. Checking the intermediate tags, every release from v3.74.0 through v3.106.0 behaves like v3.73.1 -- the change lands exactly at v3.107.0.

Skipping redaction would also have stopped the token being registered with the log redactor, losing that protection for no benefit on this agent.

Credit to @khluu and their agent for catching this; the flag would have shipped and changed nothing.

## What this run should show

If the socket theory is right, the log should now read:

```
buildkite-agent secret get 'CRCR_BUILDKITE_API_TOKEN' failed (agent buildkite-agent version 3.73.1 ...):
    failed to create Job API client: ...
```

which names the root cause outright.

## Actual fix

Once confirmed, the real options are to expose the Job API socket to the container in the docker plugin config, or to pass the token through the step's `environment:` instead of fetching it in-container. Upgrading the fleet to >= v3.107.0 would also make `--skip-redaction` viable, but that is a large change for one report script.

This PR is the diagnostic step only.