### PR TITLE
[Docs] Fix DummyLogitsProcessor path in logits_processor example

### DIFF
--- a/examples/features/logits_processor/README.md
+++ b/examples/features/logits_processor/README.md
@@ -32,7 +32,7 @@ python examples/features/logits_processor/custom_req_init.py
 
 - **Batch-level vs. request-level**: vLLM processes logits at the batch level for efficiency. If you have a per-request processor, you need to wrap it using the patterns shown in `custom_req.py` and `custom_req_init.py`.
 - **`SamplingParams.extra_args`**: Use this to pass custom keyword arguments to your logits processor on a per-request basis (e.g., `target_token`).
-- **`DummyLogitsProcessor`**: A reference implementation available in `vllm/test_utils.py` that can be used as a starting point for custom processors.
+- **`DummyLogitsProcessor`**: A reference implementation available in `tests/v1/logits_processors/utils.py` that can be used as a starting point for custom processors.
 
 ## Further Reading
 

--- a/examples/features/logits_processor/custom.py
+++ b/examples/features/logits_processor/custom.py
@@ -5,7 +5,7 @@
 class object.
 
 For a basic example of implementing a custom logits processor, see
-the `DummyLogitsProcessor` implementation in `vllm/test_utils.py`.
+the `DummyLogitsProcessor` implementation in `tests/v1/logits_processors/utils.py`.
 
 For testing purposes, a dummy logits processor is employed which, if
 `target_token` is passed as a keyword argument to `SamplingParams.extra_args`,


### PR DESCRIPTION
## Summary
The logits processor example docs point at `vllm/test_utils.py` for `DummyLogitsProcessor`, but that path 404s on current `main`. The reference implementation lives at `tests/v1/logits_processors/utils.py`.

## Repro
1. On current `main`, open `examples/features/logits_processor/README.md` (and the docstring in `custom.py`): both cite `` `vllm/test_utils.py` ``.
2. `https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/test_utils.py` → 404.
3. `https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/logits_processors/utils.py` → 200 and defines `DummyLogitsProcessor`.

## Change
Update the path in:
- `examples/features/logits_processor/README.md`
- `examples/features/logits_processor/custom.py` (docstring)

## Test plan
- [x] Confirmed stale path 404 vs real utils module on HEAD
- [ ] Docs/comment only; no runtime suite required