### PR TITLE
[Docs] Fix invalid Python in draft model heterogeneous vocab example

### DIFF
--- a/docs/features/speculative_decoding/draft_model.md
+++ b/docs/features/speculative_decoding/draft_model.md
@@ -83,25 +83,28 @@ The code used to request completions as a client remains unchanged:
   Currently, `use_heterogeneous_vocab` requires `draft_sample_method='greedy'` (the default). Probabilistic draft sampling is not yet supported and will be added in a
   future release.
 
-  ```python
-  from vllm import LLM, SamplingParams
+```python
+from vllm import LLM, SamplingParams
 
-  llm = LLM(
-      model="Qwen/Qwen3-8B",
-      speculative_config={                               
-          "method": "draft_model",
-          "model": "HuggingFaceTB/SmolLM2-135M-Instruct",
-          "num_speculative_tokens": 3,
-          "use_heterogeneous_vocab": True,
-      },
-      gpu_memory_utilization=0.5,
-  )
-outputs = llm.generate(prompts，sampling_params)
+prompts = ["The future of AI is"]
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+llm = LLM(
+    model="Qwen/Qwen3-8B",
+    speculative_config={
+        "method": "draft_model",
+        "model": "HuggingFaceTB/SmolLM2-135M-Instruct",
+        "num_speculative_tokens": 3,
+        "use_heterogeneous_vocab": True,
+    },
+    gpu_memory_utilization=0.5,
+)
+outputs = llm.generate(prompts, sampling_params)
 
 for output in outputs:
-      prompt = output.prompt
-      generated_text = output.outputs[0].text
-      print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
 ```
 
 !!! warning


### PR DESCRIPTION
## Purpose

The heterogeneous vocab example in `docs/features/speculative_decoding/draft_model.md` is not valid Python.

On `main` the snippet is:

```python
outputs = llm.generate(prompts，sampling_params)
```

That line uses a fullwidth comma (`，`, U+FF0C) instead of ASCII `,`, so `compile()` raises `SyntaxError`. The same snippet also never defines `prompts` or `sampling_params`, unlike the offline draft-model example earlier in the same file, and the fence has mixed indentation.

This PR:

- Replaces the fullwidth comma with `,`
- Defines `prompts` and `sampling_params` to match the neighboring example
- Normalizes mixed indent so the fence is valid Python

Docs only; no runtime code changes.

## Test Plan

```bash
# Before (from main): extract the generate() line and compile it
python3 -c 'compile("outputs = llm.generate(prompts，sampling_params)", "<draft_model.md>", "exec")'

# After: compile the full heterogeneous-vocab fence
python3 -c 'import pathlib,re; t=pathlib.Path("docs/features/speculative_decoding/draft_model.md").read_text(); b=re.findall(r"```python\n(.*?)```", t, re.S)[-1]; compile(b, "<draft_model.md>", "exec"); assert "\uff0c" not in b; print("compile OK")'
```

## Test Result

Before (extracted generate line from `main`):

```
  File "<draft_model.md>", line 1
    outputs = llm.generate(prompts，sampling_params)
                                  ^
SyntaxError: invalid character '，' (U+FF0C)
```

After: `compile()` succeeds on the full fence; `prompts` / `sampling_params` are assigned; no U+FF0C remains.

Signed-off-by: ADou <ikun3.1415927@gmail.com>