### PR TITLE
[Bugfix] Lazy-import FlashInfer PCIe IPC all-reduce in kernel_warmup

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -13,9 +13,6 @@ from typing import TYPE_CHECKING
 import torch
 
 import vllm.envs as envs
-from vllm.distributed.device_communicators.flashinfer_pcie_ipc_all_reduce import (
-    warmup_flashinfer_pcie_ipc_allreduce,
-)
 from vllm.logger import init_logger
 from vllm.model_executor.warmup.b12x_warmup import b12x_warmup
 from vllm.model_executor.warmup.cutedsl_warmup import cutedsl_warmup
@@ -194,7 +191,14 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
 
     # Allocate the exact decode-sized workspace, autotune cache misses, and
     # resolve every CUDA Graph bucket before capture begins.
-    warmup_flashinfer_pcie_ipc_allreduce(worker)
+    # Lazy import: flashinfer_pcie_ipc_all_reduce imports flashinfer.comm,
+    # which initializes CUDA at import time and must not run at module scope.
+    if envs.VLLM_ALLREDUCE_USE_FLASHINFER_PCIE_IPC:
+        from vllm.distributed.device_communicators import (
+            flashinfer_pcie_ipc_all_reduce,
+        )
+
+        flashinfer_pcie_ipc_all_reduce.warmup_flashinfer_pcie_ipc_allreduce(worker)
 
     enable_flashinfer_autotune = (
         worker.vllm_config.kernel_config.enable_flashinfer_autotune


### PR DESCRIPTION
## Purpose

Fix a deterministic L4 V1 Engine regression on main introduced by #53576 (reported by @StevenWang-CY in https://github.com/vllm-project/vllm/pull/53576#issuecomment-5502728637).

`kernel_warmup.py` imported `flashinfer_pcie_ipc_all_reduce` at module scope. That module does `import flashinfer.comm`, which initializes CUDA at import time. In pytest this initializes CUDA in the parent process; `_maybe_force_spawn()` then correctly switches EngineCore to `spawn`, but `tests/v1/engine/test_abort_final_step.py` registered `DummyKVConnector` only in the parent, so both cases fail with `Unsupported connector type: DummyKVConnector`, and later engine tests cascade with `Cannot re-initialize CUDA in forked subprocess`.

Fix: import lazily inside `kernel_warmup()`, and only when `VLLM_ALLREDUCE_USE_FLASHINFER_PCIE_IPC=1` — matching the established import-safety pattern from #47539. The default path no longer imports `flashinfer.comm` (or the PCIe IPC module) at all. Runtime gating already existed (`CudaCommunicator` only builds `fi_pcie_ipc_ar_comm` when the env var is set, and the warmup early-returns when it is `None`); this change just stops paying the import cost — and the CUDA context — unconditionally.

Not a duplicate: searched open PRs for kernel_warmup / CUDA-init / abort_final_step fixes; none address this. The narrow fix shape was proposed in the regression report and validated there with a canary FlashInfer package.

## Test plan

- `ruff check` / `ruff format` on the changed file: pass
- Reproduced the underlying mechanism locally: in a fresh process, `import flashinfer.comm` flips `torch.cuda.is_initialized()` to `True` (root-caused to a module-scope `is_cuda_tile_available()` call in `flashinfer/gemm/__init__.py` when `cuda.tile` is installed; will file a FlashInfer issue)
- Could not run `tests/v1/engine/test_abort_final_step.py` locally: it requires the gated HF model `meta-llama/Llama-3.2-1B-Instruct` (403 without access). Relying on CI for the end-to-end check.

No model output/accuracy/serving behavior change (import-time only), so no evals run.

This PR was prepared with AI assistance (Kimi Code); I reviewed every changed line and understand the change end-to-end.
