### PR TITLE
[Bugfix][KV Offload] Ignore stale async lookup results

### DIFF
--- a/tests/v1/kv_offload/tiering/test_async_lookup.py
+++ b/tests/v1/kv_offload/tiering/test_async_lookup.py
@@ -3,6 +3,7 @@
 """Unit tests for AsyncLookupManager."""
 
 import threading
+import time
 from collections.abc import Iterable
 
 import pytest
@@ -33,6 +34,24 @@ class InMemoryLookupManager(AsyncLookupManager):
         results = [k in self._existing for k in keys]
         self._results_ready.set()
         return results
+
+
+class DelayedLookupManager(AsyncLookupManager):
+    """Test manager whose per-request results can be released independently."""
+
+    def __init__(self, results: dict[str, bool]):
+        self._results = results
+        self._started = {req_id: threading.Event() for req_id in results}
+        self._release = {req_id: threading.Event() for req_id in results}
+        super().__init__(tier_type="test")
+
+    def batch_lookup(
+        self, keys: list[OffloadKey], req_context: ReqContext
+    ) -> Iterable[bool]:
+        req_id = req_context.req_id
+        self._started[req_id].set()
+        self._release[req_id].wait()
+        return [self._results[req_id]] * len(keys)
 
 
 class TestAsyncLookupManager:
@@ -92,17 +111,53 @@ class TestAsyncLookupManager:
         ctx_b = _ctx("req_b")
         mgr.lookup(_key(1), ctx_a)
         mgr.lookup(_key(1), ctx_b)
+        mgr.cleanup("req_a")
         mgr.flush()
         mgr._results_ready.wait()
         mgr._results_ready.clear()
-        # Drain so result is applied
-        mgr.lookup(_key(1), ctx_a)
-        mgr.cleanup("req_a")
+        # Drain so result is applied to the remaining request.
+        assert mgr.lookup(_key(1), ctx_b) is True
         # Key still present because req_b still references it
         assert _key(1) in mgr._lookup_state
         mgr.cleanup("req_b")
         assert _key(1) not in mgr._lookup_state
         mgr.shutdown()
+
+    def test_late_result_ignored_after_cleanup_and_key_reuse(self):
+        key = _key(1)
+        mgr = DelayedLookupManager({"req_a": True, "req_b": False})
+        ctx_a = _ctx("req_a")
+        ctx_b = _ctx("req_b")
+        try:
+            assert mgr.lookup(key, ctx_a) is None
+            mgr.flush()
+            assert mgr._started["req_a"].wait(timeout=5)
+
+            mgr.cleanup("req_a")
+            assert mgr.lookup(key, ctx_b) is None
+            mgr.flush()
+
+            mgr._release["req_a"].set()
+            assert mgr._started["req_b"].wait(timeout=5)
+
+            # A's result is ready while B's lookup is still blocked. It must
+            # not be applied to B's newly-created state.
+            assert mgr.lookup(key, ctx_b) is None
+
+            mgr._release["req_b"].set()
+            deadline = time.monotonic() + 5
+            result = None
+            while time.monotonic() < deadline:
+                mgr.flush()
+                result = mgr.lookup(key, ctx_b)
+                if result is not None:
+                    break
+                time.sleep(0.01)
+            assert result is False
+        finally:
+            for event in mgr._release.values():
+                event.set()
+            mgr.shutdown()
 
     def test_flush_no_queue_post_when_empty(self):
         mgr = InMemoryLookupManager()
@@ -220,7 +275,8 @@ class TestAsyncLookupManager:
 
         # (b) A stray/duplicate result for the now-decided key violates the
         # enqueue-once invariant and must trip the assert.
-        mgr._pending_results.put([(_key(1), True)])
+        generation = mgr._lookup_state[_key(1)].generation
+        mgr._pending_results.put([(_key(1), generation, True)])
         with pytest.raises(AssertionError):
             mgr.drain_results()
         mgr.shutdown()

--- a/tests/v1/kv_offload/tiering/test_async_lookup.py
+++ b/tests/v1/kv_offload/tiering/test_async_lookup.py
@@ -3,7 +3,6 @@
 """Unit tests for AsyncLookupManager."""
 
 import threading
-import time
 from collections.abc import Iterable
 
 import pytest
@@ -34,24 +33,6 @@ class InMemoryLookupManager(AsyncLookupManager):
         results = [k in self._existing for k in keys]
         self._results_ready.set()
         return results
-
-
-class DelayedLookupManager(AsyncLookupManager):
-    """Test manager whose per-request results can be released independently."""
-
-    def __init__(self, results: dict[str, bool]):
-        self._results = results
-        self._started = {req_id: threading.Event() for req_id in results}
-        self._release = {req_id: threading.Event() for req_id in results}
-        super().__init__(tier_type="test")
-
-    def batch_lookup(
-        self, keys: list[OffloadKey], req_context: ReqContext
-    ) -> Iterable[bool]:
-        req_id = req_context.req_id
-        self._started[req_id].set()
-        self._release[req_id].wait()
-        return [self._results[req_id]] * len(keys)
 
 
 class TestAsyncLookupManager:
@@ -111,53 +92,39 @@ class TestAsyncLookupManager:
         ctx_b = _ctx("req_b")
         mgr.lookup(_key(1), ctx_a)
         mgr.lookup(_key(1), ctx_b)
-        mgr.cleanup("req_a")
         mgr.flush()
         mgr._results_ready.wait()
         mgr._results_ready.clear()
-        # Drain so result is applied to the remaining request.
-        assert mgr.lookup(_key(1), ctx_b) is True
+        # Drain so result is applied
+        mgr.lookup(_key(1), ctx_a)
+        mgr.cleanup("req_a")
         # Key still present because req_b still references it
         assert _key(1) in mgr._lookup_state
         mgr.cleanup("req_b")
         assert _key(1) not in mgr._lookup_state
         mgr.shutdown()
 
-    def test_late_result_ignored_after_cleanup_and_key_reuse(self):
+    def test_stale_result_ignored_after_cleanup_and_key_reuse(self):
         key = _key(1)
-        mgr = DelayedLookupManager({"req_a": True, "req_b": False})
+        mgr = InMemoryLookupManager()
         ctx_a = _ctx("req_a")
         ctx_b = _ctx("req_b")
-        try:
-            assert mgr.lookup(key, ctx_a) is None
-            mgr.flush()
-            assert mgr._started["req_a"].wait(timeout=5)
+        assert mgr.lookup(key, ctx_a) is None
+        stale_generation = mgr._lookup_state[key].generation
+        mgr.cleanup("req_a")
 
-            mgr.cleanup("req_a")
-            assert mgr.lookup(key, ctx_b) is None
-            mgr.flush()
+        assert mgr.lookup(key, ctx_b) is None
+        generation = mgr._lookup_state[key].generation
+        assert generation != stale_generation
 
-            mgr._release["req_a"].set()
-            assert mgr._started["req_b"].wait(timeout=5)
+        mgr._pending_results.put([(key, stale_generation, True)])
+        mgr.drain_results()
+        assert mgr.lookup(key, ctx_b) is None
 
-            # A's result is ready while B's lookup is still blocked. It must
-            # not be applied to B's newly-created state.
-            assert mgr.lookup(key, ctx_b) is None
-
-            mgr._release["req_b"].set()
-            deadline = time.monotonic() + 5
-            result = None
-            while time.monotonic() < deadline:
-                mgr.flush()
-                result = mgr.lookup(key, ctx_b)
-                if result is not None:
-                    break
-                time.sleep(0.01)
-            assert result is False
-        finally:
-            for event in mgr._release.values():
-                event.set()
-            mgr.shutdown()
+        mgr._pending_results.put([(key, generation, False)])
+        mgr.drain_results()
+        assert mgr.lookup(key, ctx_b) is False
+        mgr.shutdown()
 
     def test_flush_no_queue_post_when_empty(self):
         mgr = InMemoryLookupManager()

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -45,6 +45,7 @@ logger = init_logger(__name__)
 
 @dataclass(slots=True)
 class LookupState:
+    generation: int
     result: bool | None = None  # True (found), False (not found), None
     request_ids: set[str] = field(default_factory=set)  # requests asking for the lookup
 
@@ -78,21 +79,24 @@ class AsyncLookupManager(ABC):
         self._lookup_state: dict[OffloadKey, LookupState] = {}
         # req_id → keys looked up by that request (reverse index for cleanup).
         self._req_keys: dict[str, set[OffloadKey]] = {}
+        # Results from an older state must not be applied after cleanup removes
+        # and recreates a key.
+        self._next_generation = 0
 
-        # Accumulates (key, req_context) pairs during lookup() calls.
+        # Accumulates (key, req_context, generation) triples during lookup().
         # Flushed as one queue item per step by flush().
-        self._lookup_batch: list[tuple[OffloadKey, ReqContext]] = []
+        self._lookup_batch: list[tuple[OffloadKey, ReqContext, int]] = []
 
         # Scheduler → worker: one full step's batch per item.
         # None is used as a shutdown sentinel.
         self._lookup_queue: queue.SimpleQueue[
-            list[tuple[OffloadKey, ReqContext]] | None
+            list[tuple[OffloadKey, ReqContext, int]] | None
         ] = queue.SimpleQueue()
 
         # Worker → scheduler: completed result batches.
-        # Each item is a list of (key, found) pairs.
+        # Each item is a list of (key, generation, found) triples.
         # SimpleQueue is explicitly thread-safe for one writer / one reader.
-        self._pending_results: queue.SimpleQueue[list[tuple[OffloadKey, bool]]] = (
+        self._pending_results: queue.SimpleQueue[list[tuple[OffloadKey, int, bool]]] = (
             queue.SimpleQueue()
         )
         self._need_to_drain: bool = False
@@ -137,9 +141,10 @@ class AsyncLookupManager(ABC):
         req_id = req_context.req_id
         state = self._lookup_state.get(key)
         if state is None:
-            state = LookupState()
+            state = LookupState(generation=self._next_generation)
+            self._next_generation += 1
             self._lookup_state[key] = state
-            self._lookup_batch.append((key, req_context))
+            self._lookup_batch.append((key, req_context, state.generation))
         state.request_ids.add(req_id)
         self._req_keys.setdefault(req_id, set()).add(key)
         return state.result
@@ -167,19 +172,19 @@ class AsyncLookupManager(ABC):
                 batch = self._pending_results.get_nowait()
             except queue.Empty:
                 break
-            for key, result in batch:
+            for key, generation, result in batch:
                 state = self._lookup_state.get(key)
-                if state is not None:
-                    # A key is enqueued for probing exactly once, so a decided
-                    # verdict must never receive a second result. Enforcing it
-                    # keeps a late/duplicate result from resurrecting a stale
-                    # True and reopening the failed-load livelock.
-                    assert state.result is None, (
-                        "cached key received a second lookup result; the "
-                        "enqueue-once invariant is broken and could reopen the "
-                        "failed-load livelock"
-                    )
-                    state.result = result
+                if state is None or state.generation != generation:
+                    continue
+                # Each lookup generation is enqueued exactly once. A matching
+                # generation must not receive a second result; stale
+                # generations were discarded above.
+                assert state.result is None, (
+                    "cached key received a second lookup result; the "
+                    "enqueue-once invariant is broken and could reopen the "
+                    "failed-load livelock"
+                )
+                state.result = result
 
     def mark_miss(self, keys: Collection[OffloadKey]) -> None:
         """Force the cached verdict for ``keys`` to False after a failed load, so
@@ -218,18 +223,19 @@ class AsyncLookupManager(ABC):
                 break
 
             # Group by req_id.
-            batches: dict[str, tuple[ReqContext, list[OffloadKey]]] = {}
-            for key, req_context in pending:
+            batches: dict[str, tuple[ReqContext, list[tuple[OffloadKey, int]]]] = {}
+            for key, req_context, generation in pending:
                 req_id = req_context.req_id
                 if req_id not in batches:
                     batches[req_id] = (req_context, [])
-                batches[req_id][1].append(key)
+                batches[req_id][1].append((key, generation))
 
             if not batches:
                 continue
 
-            results: list[tuple[OffloadKey, bool]] = []
-            for req_context, keys in batches.values():
+            results: list[tuple[OffloadKey, int, bool]] = []
+            for req_context, entries in batches.values():
+                keys = [key for key, _ in entries]
                 try:
                     hits = self.batch_lookup(keys, req_context)
                 except Exception as exc:
@@ -241,8 +247,8 @@ class AsyncLookupManager(ABC):
                     )
                     hits = (False for _ in keys)
 
-                for key, hit in zip(keys, hits):
-                    results.append((key, hit))
+                for (key, generation), hit in zip(entries, hits):
+                    results.append((key, generation, hit))
 
             # Post the entire batch as one item — no lock needed.
             if results:


### PR DESCRIPTION


## Purpose

Ignore stale secondary-tier lookup results after request cleanup.

### User case

1. Request A starts an async lookup for KV key `K`.
2. A is cancelled or finishes while a slow NFS/PVC/object-store lookup is
   still running; cleanup removes A's state.
3. Request B reuses `K` and starts a new lookup.
4. A's late result is applied to B because the old result carries only `K`.
   B can then use a stale verdict or hit the duplicate-result assertion when
   its own result arrives.

The fix adds a generation to each lookup state and ignores results from older
generations. Active requests sharing one pending lookup are unchanged.

This is distinct from #49176/#49328, which fixes failed-load verdict
invalidation. No open issue or PR was found for this request-cleanup race.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_offload/tiering/test_async_lookup.py -q
pre-commit run --files \
  vllm/v1/kv_offload/tiering/async_lookup.py \
  tests/v1/kv_offload/tiering/test_async_lookup.py
git diff --check
```

The regression test covers cleanup and key reuse, stale/current generation
result delivery, shared entries, and same-generation duplicate results.

## Test Result

```text
14 passed in 1.66s
pre-commit: passed
git diff --check: passed
```

Model evaluation is not applicable; this is a scheduler lifecycle fix.

AI assistance was used for code and test development. The human submitter
must review every changed line before submission.

---

<details>
<summary>Checklist</summary>

- [x] Purpose, user case, test plan, and results included.
- [x] Duplicate-work check documented.
- [x] AI assistance disclosed.

</details>
