### PR TITLE
[Examples] Use --eplb-config.num_redundant_experts in elastic EP script

### DIFF
--- a/examples/ray_serving/elastic_ep/serve_deepseek_v2.sh
+++ b/examples/ray_serving/elastic_ep/serve_deepseek_v2.sh
@@ -65,7 +65,7 @@ vllm serve "$MODEL_NAME" \
     --enable-expert-parallel \
     --enable-eplb \
     --all2all-backend allgather_reducescatter \
-    --num-redundant-experts "$REDUNDANT_EXPERTS" \
+    --eplb-config.num_redundant_experts "$REDUNDANT_EXPERTS" \
     --trust-remote-code \
     --host "$HOST" \
     --port "$PORT"


### PR DESCRIPTION
## Summary

`examples/ray_serving/elastic_ep/serve_deepseek_v2.sh` passes a flat `--num-redundant-experts` flag to `vllm serve`. That flag is not registered by the CLI; EPLB settings go through `--eplb-config` (JSON or dotted form).

This updates the script to use `--eplb-config.num_redundant_experts`, matching the documented CLI and other in-tree examples.

## Evidence

- `vllm/engine/arg_utils.py` only registers `--enable-eplb` and `--eplb-config` under the parallel group (no flat `--num-redundant-experts`).
- `docs/serving/expert_parallel_deployment.md` documents:
  - `--eplb-config '{"num_redundant_experts":N}'`
  - or `--eplb-config.num_redundant_experts N`
- `.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh` uses `--eplb-config '...'` rather than a flat redundant-experts flag.

## Local repro

```bash
# 1) Confirm the example still uses the stale flat flag on main
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/ray_serving/elastic_ep/serve_deepseek_v2.sh \
  | grep -n 'num-redundant-experts\|eplb-config'

# Expected on main (before this PR):
#   --num-redundant-experts "$REDUNDANT_EXPERTS"

# 2) Confirm CLI registration in arg_utils (raw file grep; no full install required)
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/engine/arg_utils.py \
  | grep -n 'add_argument("--enable-eplb"\|add_argument("--eplb-config"\|num-redundant-experts'

# Expected: only --enable-eplb and --eplb-config lines; no --num-redundant-experts add_argument

# 3) Confirm docs / Buildkite use dotted or JSON --eplb-config
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/serving/expert_parallel_deployment.md \
  | grep -n 'eplb-config.num_redundant_experts\|num_redundant_experts' | head
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh \
  | grep -n 'eplb-config\|num-redundant'

# Optional (if vLLM is installed locally): parser rejects the flat flag
#   vllm serve --help 2>&1 | grep -E 'eplb-config|num-redundant' || true
#   # or: python -c "from vllm.engine.arg_utils import ..." and inspect help
```

## Change

One-line update in `examples/ray_serving/elastic_ep/serve_deepseek_v2.sh`:

```diff
-    --num-redundant-experts "$REDUNDANT_EXPERTS" \
+    --eplb-config.num_redundant_experts "$REDUNDANT_EXPERTS" \
```

## Test plan

- [x] Grep `arg_utils.py` for registered EPLB flags
- [x] Compare against `docs/serving/expert_parallel_deployment.md` and Buildkite EPLB script
- [x] Confirm only this example script is changed