### PR TITLE
[Docs] Fix stale SkyPilot gradio path and bench sonnet dataset path

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -734,7 +734,7 @@ Using KV cache metrics for load pattern configuration:
 vllm bench throughput \
   --model NousResearch/Hermes-3-Llama-3.1-8B \
   --dataset-name sonnet \
-  --dataset-path vllm/benchmarks/sonnet.txt \
+  --dataset-path benchmarks/sonnet.txt \
   --num-prompts 10
 ```
 

--- a/docs/deployment/frameworks/skypilot.md
+++ b/docs/deployment/frameworks/skypilot.md
@@ -305,7 +305,7 @@ It is also possible to access the Llama-3 service with a separate GUI frontend, 
 
       echo 'Starting gradio server...'
       git clone https://github.com/vllm-project/vllm.git || true
-      python vllm/examples/applications/api_client/gradio_openai_chatbot_webserver.py \
+      python vllm/examples/applications/chatbot/gradio_openai_chatbot_webserver.py \
         -m $MODEL_NAME \
         --port 8811 \
         --model-url http://$ENDPOINT/v1 \


### PR DESCRIPTION
## Summary
Two docs copy-paste paths 404 on current `main`.

1. `docs/deployment/frameworks/skypilot.md` GUI example runs `vllm/examples/applications/api_client/gradio_openai_chatbot_webserver.py` after cloning the repo, but that path does not exist. The script lives under `examples/applications/chatbot/` (the serving example in the same doc already uses the correct path).
2. `docs/benchmarking/cli.md` sonnet example uses `--dataset-path vllm/benchmarks/sonnet.txt`, but the file is `benchmarks/sonnet.txt` (and the dataset table in the same page already documents that).

## Local repro
```bash
# HEAD used when verifying: f870b929 (main)
gh api repos/vllm-project/vllm/contents/examples/applications/chatbot/gradio_openai_chatbot_webserver.py --jq .path
# -> examples/applications/chatbot/gradio_openai_chatbot_webserver.py
gh api repos/vllm-project/vllm/contents/examples/applications/api_client/gradio_openai_chatbot_webserver.py
# -> 404
gh api repos/vllm-project/vllm/contents/benchmarks/sonnet.txt --jq .path
# -> benchmarks/sonnet.txt
gh api repos/vllm-project/vllm/contents/vllm/benchmarks/sonnet.txt
# -> 404
```

## Test plan
- [x] Confirmed correct paths exist via Contents API on main
- [x] Confirmed wrong paths 404
- [ ] Docs-only; no runtime tests required
