### PR TITLE
[Qwen3.8-Flash-Next] Support FP8 indexer cache for QSA

### DIFF
--- a/tests/models/qwen4_exp/test_qsa_pre_indexer.py
+++ b/tests/models/qwen4_exp/test_qsa_pre_indexer.py
@@ -49,6 +49,18 @@ def _make_block_table(block_counts):
     return table, num_blocks
 
 
+def assert_fp8_within_one_ulp(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    # e4m3 is sign-magnitude, so within a sign the uint8 code order matches the
+    # value order and one ulp is one code step. In the denormal range the grid
+    # is absolute-spaced and the bf16 intermediates differ in absolute terms
+    # (cancellation in pooling/norm), so fall back to the bf16 atol there.
+    code_diff = (
+        actual.view(torch.uint8).int() - expected.view(torch.uint8).int()
+    ).abs()
+    abs_diff = (actual.float() - expected.float()).abs()
+    assert bool(((code_diff <= 1) | (abs_diff <= ATOL)).all())
+
+
 @requires_qsa_kernels
 @pytest.mark.usefixtures("default_vllm_config")
 @pytest.mark.parametrize("indexer_dtype", [torch.bfloat16, torch.float8_e4m3fn])
@@ -293,24 +305,14 @@ def test_qsa_fused_pre_indexer_matches_unfused(
         qsa_store_cache_rows(rope_positions, raw_slots, position_rows)
 
     if indexer_dtype == torch.float8_e4m3fn:
-        # Both paths round the same ~bf16 values to e4m3; fused and unfused
-        # bf16 intermediates differ by < RTOL, so allow one e4m3 ulp (2^-3
-        # relative) of disagreement after quantization.
+        # Both paths round the same ~bf16 intermediates to e4m3.
         unfused_query = unfused_query.to(indexer_dtype)
-        fp8_rtol, fp8_atol = 0.13, 0.06
-        torch.testing.assert_close(
-            fused_query.float(), unfused_query.float(), rtol=fp8_rtol, atol=fp8_atol
-        )
+        assert_fp8_within_one_ulp(fused_query, unfused_query)
     else:
         torch.testing.assert_close(fused_query, unfused_query, rtol=RTOL, atol=ATOL)
     assert torch.equal(fused_raw.view(torch.int16), unfused_raw.view(torch.int16))
     if indexer_dtype == torch.float8_e4m3fn:
-        torch.testing.assert_close(
-            fused_compressed.float(),
-            unfused_compressed.float(),
-            rtol=fp8_rtol,
-            atol=fp8_atol,
-        )
+        assert_fp8_within_one_ulp(fused_compressed, unfused_compressed)
     else:
         torch.testing.assert_close(
             fused_compressed, unfused_compressed, rtol=RTOL, atol=ATOL

--- a/tests/models/qwen4_exp/test_qsa_pre_indexer.py
+++ b/tests/models/qwen4_exp/test_qsa_pre_indexer.py
@@ -51,6 +51,7 @@ def _make_block_table(block_counts):
 
 @requires_qsa_kernels
 @pytest.mark.usefixtures("default_vllm_config")
+@pytest.mark.parametrize("indexer_dtype", [torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize(
     "mrope,is_2d_positions,cache_rope_positions,state_size,seq_lens,query_lens,history_lens",
     [
@@ -74,6 +75,7 @@ def _make_block_table(block_counts):
     ],
 )
 def test_qsa_fused_pre_indexer_matches_unfused(
+    indexer_dtype,
     mrope,
     is_2d_positions,
     cache_rope_positions,
@@ -215,7 +217,7 @@ def test_qsa_fused_pre_indexer_matches_unfused(
     fused_compressed_storage = torch.zeros(
         num_compressed_blocks,
         compressed_page_elements + 16,
-        dtype=torch.bfloat16,
+        dtype=indexer_dtype,
         device=device,
     )
     fused_compressed = torch.as_strided(
@@ -231,7 +233,7 @@ def test_qsa_fused_pre_indexer_matches_unfused(
     q_weight = torch.randn(D, dtype=torch.bfloat16, device=device) * 0.2
     k_weight = torch.randn(D, dtype=torch.bfloat16, device=device) * 0.2
 
-    fused_query = torch.empty(num_tokens, HQ, D, dtype=torch.bfloat16, device=device)
+    fused_query = torch.empty(num_tokens, HQ, D, dtype=indexer_dtype, device=device)
     qsa_pre_indexer(
         projected_qk[:, : HQ * D],
         projected_qk[:, HQ * D :],
@@ -290,8 +292,26 @@ def test_qsa_fused_pre_indexer_matches_unfused(
     if rope_positions is not None:
         qsa_store_cache_rows(rope_positions, raw_slots, position_rows)
 
-    torch.testing.assert_close(fused_query, unfused_query, rtol=RTOL, atol=ATOL)
+    if indexer_dtype == torch.float8_e4m3fn:
+        # Both paths round the same ~bf16 values to e4m3; fused and unfused
+        # bf16 intermediates differ by < RTOL, so allow one e4m3 ulp (2^-3
+        # relative) of disagreement after quantization.
+        unfused_query = unfused_query.to(indexer_dtype)
+        fp8_rtol, fp8_atol = 0.13, 0.06
+        torch.testing.assert_close(
+            fused_query.float(), unfused_query.float(), rtol=fp8_rtol, atol=fp8_atol
+        )
+    else:
+        torch.testing.assert_close(fused_query, unfused_query, rtol=RTOL, atol=ATOL)
     assert torch.equal(fused_raw.view(torch.int16), unfused_raw.view(torch.int16))
-    torch.testing.assert_close(
-        fused_compressed, unfused_compressed, rtol=RTOL, atol=ATOL
-    )
+    if indexer_dtype == torch.float8_e4m3fn:
+        torch.testing.assert_close(
+            fused_compressed.float(),
+            unfused_compressed.float(),
+            rtol=fp8_rtol,
+            atol=fp8_atol,
+        )
+    else:
+        torch.testing.assert_close(
+            fused_compressed, unfused_compressed, rtol=RTOL, atol=ATOL
+        )

--- a/tests/models/qwen4_exp/test_qsa_pre_indexer.py
+++ b/tests/models/qwen4_exp/test_qsa_pre_indexer.py
@@ -51,14 +51,14 @@ def _make_block_table(block_counts):
 
 def assert_fp8_within_one_ulp(actual: torch.Tensor, expected: torch.Tensor) -> None:
     # e4m3 is sign-magnitude, so within a sign the uint8 code order matches the
-    # value order and one ulp is one code step. In the denormal range the grid
-    # is absolute-spaced and the bf16 intermediates differ in absolute terms
-    # (cancellation in pooling/norm), so fall back to the bf16 atol there.
+    # value order and one ulp is one code step. The two paths' intermediates
+    # differ in the pooling accumulation order, which at denormal magnitudes
+    # (absolute grid step 2^-9) shows up as up to 2 code steps.
     code_diff = (
         actual.view(torch.uint8).int() - expected.view(torch.uint8).int()
     ).abs()
     abs_diff = (actual.float() - expected.float()).abs()
-    assert bool(((code_diff <= 1) | (abs_diff <= ATOL)).all())
+    assert bool(((code_diff <= 1) | (abs_diff <= 2**-8)).all())
 
 
 @requires_qsa_kernels
@@ -305,7 +305,10 @@ def test_qsa_fused_pre_indexer_matches_unfused(
         qsa_store_cache_rows(rope_positions, raw_slots, position_rows)
 
     if indexer_dtype == torch.float8_e4m3fn:
-        # Both paths round the same ~bf16 intermediates to e4m3.
+        # Both paths round the same ~bf16 intermediates to e4m3. Bitwise
+        # equality (the dsv4 indexer test's bar) does not hold here: the 1D
+        # reference rope (forward_cuda) differs from _norm_rope by up to 1
+        # bf16 ulp, and even the MRoPE pair flips a code occasionally.
         unfused_query = unfused_query.to(indexer_dtype)
         assert_fp8_within_one_ulp(fused_query, unfused_query)
     else:

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -48,6 +48,7 @@ def test_qsa_mtp_index_share_updates_cache_but_skips_selection(
         index_n_heads=1,
         index_kv_heads=1,
         index_head_dim=1,
+        indexer_dtype=torch.bfloat16,
         raw_key_cache=SimpleNamespace(
             kv_cache=torch.empty(0),
             rope_position_cache=None,
@@ -666,13 +667,16 @@ def test_qsa_fused_metadata_matches_pytorch_for_large_padded_prefill() -> None:
         (4, 33),
     ],
 )
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
 def test_qsa_decode_selection_correctness(
-    decode_query_len: int, num_requests: int
+    decode_query_len: int, num_requests: int, dtype: torch.dtype
 ) -> None:
     torch.manual_seed(1)
     heads, head_dim = 4, 128
     rows = num_requests * decode_query_len
-    q = torch.randn(rows, heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    q = torch.randn(rows, heads, head_dim, device="cuda", dtype=torch.bfloat16).to(
+        dtype
+    )
     page_size, pages_per_request, max_sequence_length = (
         (16, 40, 2560) if num_requests > 32 else (4, 20, 320)
     )
@@ -684,7 +688,7 @@ def test_qsa_decode_selection_correctness(
         head_dim,
         device="cuda",
         dtype=torch.bfloat16,
-    )
+    ).to(dtype)
     page_table = torch.randperm(num_pages, device="cuda", dtype=torch.int32).reshape(
         num_requests, pages_per_request
     )
@@ -736,14 +740,34 @@ def test_qsa_decode_selection_correctness(
         compress_ratio,
     )
 
+    if dtype == torch.float8_e4m3fn:
+        # fp8 logits tie at the top-k boundary more often than bf16, so index
+        # identity is not stable; compare the selected value multisets.
+        logits = _qsa_mqa_paged_reference(
+            q, cache, page_table, token_to_req, visible_blocks
+        )
+        for row in range(rows):
+            selected = actual[row][actual[row] >= 0]
+            wanted = expected[row][expected[row] >= 0]
+            assert selected.numel() == wanted.numel()
+            torch.testing.assert_close(
+                logits[row, selected.long()].sort().values,
+                logits[row, wanted.long()].sort().values,
+            )
+        return
+
     torch.testing.assert_close(actual.sort().values, expected.sort().values)
 
 
 @requires_qsa_kernels
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("seq_len_slack", [0, 1792])
 @pytest.mark.parametrize("force_chunk", [False, True])
 def test_qsa_prefill_selection_correctness(
-    monkeypatch: pytest.MonkeyPatch, seq_len_slack: int, force_chunk: bool
+    monkeypatch: pytest.MonkeyPatch,
+    seq_len_slack: int,
+    force_chunk: bool,
+    dtype: torch.dtype,
 ) -> None:
     # page_size=24 (does not divide the 64-aligned clipped width) and an
     # oversized page table, so the clipped logits width comes from
@@ -755,8 +779,12 @@ def test_qsa_prefill_selection_correctness(
     torch.manual_seed(2)
     query_lens = [3, 33]
     rows, heads, head_dim = sum(query_lens), 4, 128
-    q = torch.randn(rows, heads, head_dim, device="cuda", dtype=torch.bfloat16)
-    cache = torch.randn(128, 24, 1, head_dim, device="cuda", dtype=torch.bfloat16)
+    q = torch.randn(rows, heads, head_dim, device="cuda", dtype=torch.bfloat16).to(
+        dtype
+    )
+    cache = torch.randn(128, 24, 1, head_dim, device="cuda", dtype=torch.bfloat16).to(
+        dtype
+    )
     page_table = torch.randperm(128, device="cuda", dtype=torch.int32).reshape(2, 64)
     token_to_req = torch.repeat_interleave(
         torch.arange(2, device="cuda", dtype=torch.int32),
@@ -803,6 +831,22 @@ def test_qsa_prefill_selection_correctness(
         token_topk,
         compress_ratio,
     )
+
+    if dtype == torch.float8_e4m3fn:
+        # fp8 logits tie at the top-k boundary more often than bf16, so index
+        # identity is not stable; compare the selected value multisets.
+        logits = _qsa_mqa_paged_reference(
+            q, cache, page_table, token_to_req, visible_blocks
+        )
+        for row in range(rows):
+            selected = actual[row][actual[row] >= 0]
+            wanted = expected[row][expected[row] >= 0]
+            assert selected.numel() == wanted.numel()
+            torch.testing.assert_close(
+                logits[row, selected.long()].sort().values,
+                logits[row, wanted.long()].sort().values,
+            )
+        return
 
     torch.testing.assert_close(actual.sort().values, expected.sort().values)
 

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -393,6 +393,30 @@ def test_qsa_state_caches_adapt_the_unified_logical_layout() -> None:
     assert compressed_cache.kv_cache.data_ptr() == compressed_view.data_ptr()
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_qsa_compressed_cache_binds_its_spec_dtype(dtype: torch.dtype) -> None:
+    cache = qsa_cache.QSACompressedKeyCache(
+        head_size=64,
+        dtype=dtype,
+        cache_config=SimpleNamespace(block_size=32),
+        prefix=f"compressed.bind.{str(dtype).rsplit('.', 1)[-1]}",
+        vllm_config=SimpleNamespace(
+            compilation_config=SimpleNamespace(static_forward_context={})
+        ),
+        compress_ratio=4,
+    )
+    spec = cache.get_kv_cache_spec(SimpleNamespace())
+    assert spec.dtype == dtype
+    assert spec.page_size_bytes == 32 // 4 * 64 * dtype.itemsize
+    view = torch.empty(2, 1, 8, 64, dtype=dtype)
+    cache.bind_kv_cache(view)
+    assert cache.kv_cache.dtype == dtype
+    assert cache.kv_cache.data_ptr() == view.data_ptr()
+    other = torch.bfloat16 if dtype != torch.bfloat16 else torch.float8_e4m3fn
+    with pytest.raises(ValueError, match="does not match"):
+        cache.bind_kv_cache(view.to(other))
+
+
 @pytest.mark.parametrize(
     ("compress_ratio", "num_spec", "expected"),
     [(4, 0, 4), (4, 1, 8), (4, 3, 8), (4, 4, 8), (4, 5, 12), (2, 3, 6)],

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -509,6 +509,7 @@ def test_qsa_unfused_cache_update_ignores_padded_qk() -> None:
         use_fused_pre_indexer=False,
         index_n_heads=1,
         index_head_dim=64,
+        indexer_dtype=torch.bfloat16,
         q_layernorm=norm,
         k_layernorm=norm,
         rotary_emb=rope,

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -393,30 +393,6 @@ def test_qsa_state_caches_adapt_the_unified_logical_layout() -> None:
     assert compressed_cache.kv_cache.data_ptr() == compressed_view.data_ptr()
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
-def test_qsa_compressed_cache_binds_its_spec_dtype(dtype: torch.dtype) -> None:
-    cache = qsa_cache.QSACompressedKeyCache(
-        head_size=64,
-        dtype=dtype,
-        cache_config=SimpleNamespace(block_size=32),
-        prefix=f"compressed.bind.{str(dtype).rsplit('.', 1)[-1]}",
-        vllm_config=SimpleNamespace(
-            compilation_config=SimpleNamespace(static_forward_context={})
-        ),
-        compress_ratio=4,
-    )
-    spec = cache.get_kv_cache_spec(SimpleNamespace())
-    assert spec.dtype == dtype
-    assert spec.page_size_bytes == 32 // 4 * 64 * dtype.itemsize
-    view = torch.empty(2, 1, 8, 64, dtype=dtype)
-    cache.bind_kv_cache(view)
-    assert cache.kv_cache.dtype == dtype
-    assert cache.kv_cache.data_ptr() == view.data_ptr()
-    other = torch.bfloat16 if dtype != torch.bfloat16 else torch.float8_e4m3fn
-    with pytest.raises(ValueError, match="does not match"):
-        cache.bind_kv_cache(view.to(other))
-
-
 @pytest.mark.parametrize(
     ("compress_ratio", "num_spec", "expected"),
     [(4, 0, 4), (4, 1, 8), (4, 3, 8), (4, 4, 8), (4, 5, 12), (2, 3, 6)],

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -744,6 +744,9 @@ def test_qsa_decode_selection_correctness(
     if dtype == torch.float8_e4m3fn:
         # fp8 logits tie at the top-k boundary more often than bf16, so index
         # identity is not stable; compare the selected value multisets.
+        # SM90 wgmma accumulates fp8 in reduced precision (~3e-4 abs
+        # observed); SM100 tcgen05 is exact fp32.
+        rtol = atol = 1e-3 if current_platform.is_device_capability(90) else None
         logits = _qsa_mqa_paged_reference(
             q, cache, page_table, token_to_req, visible_blocks
         )
@@ -754,6 +757,8 @@ def test_qsa_decode_selection_correctness(
             torch.testing.assert_close(
                 logits[row, selected.long()].sort().values,
                 logits[row, wanted.long()].sort().values,
+                rtol=rtol,
+                atol=atol,
             )
         return
 
@@ -836,6 +841,9 @@ def test_qsa_prefill_selection_correctness(
     if dtype == torch.float8_e4m3fn:
         # fp8 logits tie at the top-k boundary more often than bf16, so index
         # identity is not stable; compare the selected value multisets.
+        # SM90 wgmma accumulates fp8 in reduced precision (~3e-4 abs
+        # observed); SM100 tcgen05 is exact fp32.
+        rtol = atol = 1e-3 if current_platform.is_device_capability(90) else None
         logits = _qsa_mqa_paged_reference(
             q, cache, page_table, token_to_req, visible_blocks
         )
@@ -846,6 +854,8 @@ def test_qsa_prefill_selection_correctness(
             torch.testing.assert_close(
                 logits[row, selected.long()].sort().values,
                 logits[row, wanted.long()].sort().values,
+                rtol=rtol,
+                atol=atol,
             )
         return
 

--- a/vllm/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm/models/qwen4_exp/common/qsa_cache.py
@@ -728,7 +728,15 @@ class QSAStateBackend(AttentionBackend):
     """Key-only dummy backend for out-of-band BF16 QSA side-cache operations."""
 
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
-    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+    # bf16 default; fp8 for the optional e4m3 compressed indexer cache
+    # (mirrors the MiniMax M3 indexer backend to keep spec validation
+    # permissive).
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "bfloat16",
+        "fp8",
+        "fp8_e4m3",
+    ]
 
     @staticmethod
     def get_name() -> str:
@@ -790,8 +798,12 @@ class _QSAStateCache(nn.Module, AttentionLayerBase):
         """Adapt the unified [B, H, N, C] view to QSA's [B, N, H, C]."""
         if kv_cache.ndim != 4 or kv_cache.shape[1] != 1:
             raise ValueError("QSA state cache must be [blocks, 1, states, width]")
-        if kv_cache.dtype != torch.bfloat16 or kv_cache.shape[3] != self.head_size:
-            raise ValueError("QSA state cache does not match its packed BF16 spec")
+        if kv_cache.dtype != self.dtype or kv_cache.shape[3] != self.head_size:
+            raise ValueError(
+                f"QSA state cache does not match its spec "
+                f"(dtype {kv_cache.dtype} != {self.dtype} or width "
+                f"{kv_cache.shape[3]} != {self.head_size})"
+            )
         super().bind_kv_cache(kv_cache.transpose(1, 2))
 
     def get_attn_backend(self) -> type[AttentionBackend]:

--- a/vllm/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm/models/qwen4_exp/common/qsa_cache.py
@@ -728,9 +728,7 @@ class QSAStateBackend(AttentionBackend):
     """Key-only dummy backend for out-of-band BF16 QSA side-cache operations."""
 
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
-    # bf16 default; fp8 for the optional e4m3 compressed indexer cache
-    # (mirrors the MiniMax M3 indexer backend to keep spec validation
-    # permissive).
+    # fp8 entries allow the optional e4m3 compressed indexer cache.
     supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
         "auto",
         "bfloat16",

--- a/vllm/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm/models/qwen4_exp/common/qsa_cache.py
@@ -725,7 +725,7 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
 
 
 class QSAStateBackend(AttentionBackend):
-    """Key-only dummy backend for out-of-band BF16 QSA side-cache operations."""
+    """Key-only dummy backend for out-of-band QSA side-cache operations."""
 
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
     # fp8 entries allow the optional e4m3 compressed indexer cache.
@@ -860,7 +860,7 @@ class QSAKeyStateCache(_QSAStateCache):
 
 
 class QSACompressedKeyCache(_QSAStateCache):
-    """Normalized, group-first-RoPE BF16 key at one row per complete group."""
+    """Normed, group-first-RoPE key at one row per complete group."""
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         del vllm_config

--- a/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -13,7 +13,6 @@ from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
-from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.qwen4_exp import (
     Qwen4ExpTextConfig,
 )
@@ -154,13 +153,6 @@ class QSAIndexer(nn.Module):
             "bf16"
         )
         if self.indexer_kv_dtype in ("fp8", "fp8_e4m3"):
-            # The fp8 indexer is only validated on SM90 and SM100-family.
-            if not current_platform.has_device_capability(
-                90
-            ) or current_platform.is_device_capability_family(120):
-                raise NotImplementedError(
-                    "Qwen4Exp QSA fp8 indexer requires SM90 or SM100-family"
-                )
             indexer_dtype = torch.float8_e4m3fn
         elif self.indexer_kv_dtype == "bf16":
             indexer_dtype = torch.bfloat16

--- a/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -148,16 +148,13 @@ class QSAIndexer(nn.Module):
 
         cache_config = vllm_config.cache_config
         cache_prefix = f"{prefix}." if prefix else ""
-        # MiniMax-M3-style plain e4m3 indexer cache: values are GemmaRMSNormed
-        # before caching, so no scale column is needed. The compressed cache
-        # and the normed Q share this dtype so the logits kernels dot fp8xfp8
-        # directly (native tcgen05 on SM100; Triton upcasts to fp16 mma.sync
-        # at smaller tile shapes).
+        # Plain e4m3 without scales: Q and the compressed K are RMSNormed
+        # before quantization, and the logits kernels dot fp8 x fp8 directly.
         self.indexer_kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype(
             "bf16"
         )
         if self.indexer_kv_dtype in ("fp8", "fp8_e4m3"):
-            # Triton cannot multiply fp8e4nv on SM120/SM121 (see #54846).
+            # The fp8 indexer is only validated on SM90 and SM100-family.
             if not current_platform.has_device_capability(
                 90
             ) or current_platform.is_device_capability_family(120):

--- a/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
+from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.qwen4_exp import (
     Qwen4ExpTextConfig,
 )
@@ -147,6 +148,31 @@ class QSAIndexer(nn.Module):
 
         cache_config = vllm_config.cache_config
         cache_prefix = f"{prefix}." if prefix else ""
+        # MiniMax-M3-style plain e4m3 indexer cache: values are GemmaRMSNormed
+        # before caching, so no scale column is needed. The compressed cache
+        # and the normed Q share this dtype so the logits kernels dot fp8xfp8
+        # directly (native tcgen05 on SM100; Triton upcasts to fp16 mma.sync
+        # at smaller tile shapes).
+        self.indexer_kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype(
+            "bf16"
+        )
+        if self.indexer_kv_dtype in ("fp8", "fp8_e4m3"):
+            # Triton cannot multiply fp8e4nv on SM120/SM121 (see #54846).
+            if not current_platform.has_device_capability(
+                90
+            ) or current_platform.is_device_capability_family(120):
+                raise NotImplementedError(
+                    "Qwen4Exp QSA fp8 indexer requires SM90 or SM100-family"
+                )
+            indexer_dtype = torch.float8_e4m3fn
+        elif self.indexer_kv_dtype == "bf16":
+            indexer_dtype = torch.bfloat16
+        else:
+            raise NotImplementedError(
+                f"indexer_kv_dtype={self.indexer_kv_dtype!r} is not supported "
+                "by the Qwen4Exp QSA indexer (only 'bf16' or 'fp8'/'fp8_e4m3')."
+            )
+        self.indexer_dtype = indexer_dtype
         self.raw_key_cache = QSAKeyStateCache(
             head_size=self.index_head_dim,
             dtype=torch.bfloat16,
@@ -158,7 +184,7 @@ class QSAIndexer(nn.Module):
         )
         self.compressed_key_cache = QSACompressedKeyCache(
             head_size=self.index_head_dim,
-            dtype=torch.bfloat16,
+            dtype=indexer_dtype,
             compress_ratio=self.compress_ratio,
             prefix=f"{cache_prefix}compressed_key_cache",
             cache_config=cache_config,
@@ -276,6 +302,7 @@ class QSAIndexer(nn.Module):
                 num_tokens,
                 self.index_n_heads,
                 self.index_head_dim,
+                dtype=self.indexer_dtype,
             )
             qsa_pre_indexer(
                 projected_q,
@@ -313,6 +340,7 @@ class QSAIndexer(nn.Module):
                 self.q_layernorm.variance_epsilon,
             ).reshape_as(q)
             q = apply_qsa_rope(self.rotary_emb, positions, q)
+            q = q.to(self.indexer_dtype)
 
             raw_key_cache = raw_key_state_cache.key_cache
             rope_position_cache = raw_key_state_cache.rope_position_cache

--- a/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -152,14 +152,14 @@ class QSAIndexer(nn.Module):
         self.indexer_kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype(
             "bf16"
         )
-        if self.indexer_kv_dtype in ("fp8", "fp8_e4m3"):
+        if self.indexer_kv_dtype == "fp8":
             indexer_dtype = torch.float8_e4m3fn
         elif self.indexer_kv_dtype == "bf16":
             indexer_dtype = torch.bfloat16
         else:
             raise NotImplementedError(
                 f"indexer_kv_dtype={self.indexer_kv_dtype!r} is not supported "
-                "by the Qwen4Exp QSA indexer (only 'bf16' or 'fp8'/'fp8_e4m3')."
+                "by the Qwen4Exp QSA indexer (only 'bf16' or 'fp8')."
             )
         self.indexer_dtype = indexer_dtype
         self.raw_key_cache = QSAKeyStateCache(

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -337,8 +337,6 @@ def warmup_qsa_mqa_paged_decode(
     for decode_query_len, num_requests in profiles:
         num_rows = decode_query_len * num_requests
         q_ptr = TritonWarmupTensor(
-            # The normed indexer Q shares the compressed cache dtype (bf16 or
-            # fp8 e4m3) so the logits kernel dots matching input dtypes.
             k_cache.dtype,
             shape=(num_rows, num_heads, head_dim),
         )

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -337,7 +337,9 @@ def warmup_qsa_mqa_paged_decode(
     for decode_query_len, num_requests in profiles:
         num_rows = decode_query_len * num_requests
         q_ptr = TritonWarmupTensor(
-            torch.bfloat16,
+            # The normed indexer Q shares the compressed cache dtype (bf16 or
+            # fp8 e4m3) so the logits kernel dots matching input dtypes.
+            k_cache.dtype,
             shape=(num_rows, num_heads, head_dim),
         )
         logits_ptr = TritonWarmupTensor(
@@ -521,6 +523,7 @@ def qsa_select_paged_decode(
     assert token_topk % compress_ratio == 0
     assert block_indices.shape == (q.shape[0], token_topk // compress_ratio)
     assert decode_query_len > 0 and q.shape[0] % decode_query_len == 0
+    assert q.dtype == k_cache.dtype, "Q and the compressed K cache must match"
     num_requests = q.shape[0] // decode_query_len
     assert page_table.shape[0] == num_requests
     assert visible_blocks.shape == (q.shape[0],)
@@ -593,6 +596,7 @@ def qsa_select_paged_prefill(
 
     assert token_topk % compress_ratio == 0
     assert block_indices.shape == (q.shape[0], token_topk // compress_ratio)
+    assert q.dtype == k_cache.dtype, "Q and the compressed K cache must match"
     rows = q.shape[0]
     # No row scores beyond cdiv(max_seq_len, compress_ratio) compressed
     # columns. Round up to 64 to keep the logits row stride

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -400,13 +400,13 @@ def _prefill_logits(
     logits = torch.empty(
         (num_queries, logits_width), dtype=torch.float32, device=q.device
     )
-    # fp8 halves the K-tile bytes; smaller row tiles + deeper pipelining win
-    # there (measured on SM103a) but slightly regress bf16, so keep the bf16
-    # constants for the bf16 cache.
+    # fp8 halves the K-tile bytes; smaller row tiles and more warps win there
+    # (measured on SM103a) but regress bf16, so keep the bf16 constants for
+    # the bf16 cache.
     if k_cache.dtype == torch.float8_e4m3fn:
-        TILE_R, STAGES = 32, 3
+        TILE_R, STAGES, num_warps = 32, 2, 8
     else:
-        TILE_R, STAGES = 64, 2
+        TILE_R, STAGES, num_warps = 64, 2, 4
     BLOCK_N = 64
     K_TILES = 16
     grid = (
@@ -435,7 +435,7 @@ def _prefill_logits(
         BLOCK_N=BLOCK_N,
         K_TILES=K_TILES,
         STAGES=STAGES,
-        num_warps=4,
+        num_warps=num_warps,
     )
     return logits
 

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -284,13 +284,6 @@ def _decode_tiles_per_program(num_requests: int, columns: int) -> int:
     return 8
 
 
-def _decode_num_warps(cache_dtype: torch.dtype) -> int:
-    # fp8 halves the K-tile bytes; a single warp per program wins on SM103a
-    # (up to 1.2x at dql=4) and is neutral at dql=1, but slightly regresses
-    # bf16, so keep 2 warps for the bf16 cache.
-    return 1 if cache_dtype == torch.float8_e4m3fn else 2
-
-
 def _qsa_decode_warmup_profiles(
     max_dql: int,
     max_num_reqs: int,
@@ -372,7 +365,8 @@ def warmup_qsa_mqa_paged_decode(
             BLOCK_N=_DECODE_BLOCK_N,
             TILES_PER_PROG=tiles_per_program,
             STAGES=2,
-            num_warps=_decode_num_warps(k_cache.dtype),
+            # fp8 cache config tuned on GB300
+            num_warps=1 if k_cache.dtype == torch.float8_e4m3fn else 2,
             grid=(
                 num_requests,
                 triton.cdiv(columns, _DECODE_BLOCK_N * tiles_per_program),
@@ -400,9 +394,7 @@ def _prefill_logits(
     logits = torch.empty(
         (num_queries, logits_width), dtype=torch.float32, device=q.device
     )
-    # fp8 halves the K-tile bytes; smaller row tiles and more warps win there
-    # (measured on SM103a) but regress bf16, so keep the bf16 constants for
-    # the bf16 cache.
+    # fp8 cache config tuned on GB300
     if k_cache.dtype == torch.float8_e4m3fn:
         TILE_R, STAGES, num_warps = 32, 2, 8
     else:
@@ -564,7 +556,8 @@ def qsa_select_paged_decode(
         BLOCK_N=_DECODE_BLOCK_N,
         TILES_PER_PROG=tiles_per_program,
         STAGES=2,
-        num_warps=_decode_num_warps(k_cache.dtype),
+        # fp8 cache config tuned on GB300
+        num_warps=1 if k_cache.dtype == torch.float8_e4m3fn else 2,
     )
     _topk(
         logits,

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -365,7 +365,7 @@ def warmup_qsa_mqa_paged_decode(
             BLOCK_N=_DECODE_BLOCK_N,
             TILES_PER_PROG=tiles_per_program,
             STAGES=2,
-            # fp8 cache config tuned on GB300
+            # tuned on GB300
             num_warps=1 if k_cache.dtype == torch.float8_e4m3fn else 2,
             grid=(
                 num_requests,
@@ -394,7 +394,7 @@ def _prefill_logits(
     logits = torch.empty(
         (num_queries, logits_width), dtype=torch.float32, device=q.device
     )
-    # fp8 cache config tuned on GB300
+    # tuned on GB300
     if k_cache.dtype == torch.float8_e4m3fn:
         TILE_R, STAGES, num_warps = 32, 2, 8
     else:
@@ -556,7 +556,7 @@ def qsa_select_paged_decode(
         BLOCK_N=_DECODE_BLOCK_N,
         TILES_PER_PROG=tiles_per_program,
         STAGES=2,
-        # fp8 cache config tuned on GB300
+        # tuned on GB300
         num_warps=1 if k_cache.dtype == torch.float8_e4m3fn else 2,
     )
     _topk(

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -284,6 +284,13 @@ def _decode_tiles_per_program(num_requests: int, columns: int) -> int:
     return 8
 
 
+def _decode_num_warps(cache_dtype: torch.dtype) -> int:
+    # fp8 halves the K-tile bytes; a single warp per program wins on SM103a
+    # (up to 1.2x at dql=4) and is neutral at dql=1, but slightly regresses
+    # bf16, so keep 2 warps for the bf16 cache.
+    return 1 if cache_dtype == torch.float8_e4m3fn else 2
+
+
 def _qsa_decode_warmup_profiles(
     max_dql: int,
     max_num_reqs: int,
@@ -365,7 +372,7 @@ def warmup_qsa_mqa_paged_decode(
             BLOCK_N=_DECODE_BLOCK_N,
             TILES_PER_PROG=tiles_per_program,
             STAGES=2,
-            num_warps=2,
+            num_warps=_decode_num_warps(k_cache.dtype),
             grid=(
                 num_requests,
                 triton.cdiv(columns, _DECODE_BLOCK_N * tiles_per_program),
@@ -393,7 +400,13 @@ def _prefill_logits(
     logits = torch.empty(
         (num_queries, logits_width), dtype=torch.float32, device=q.device
     )
-    TILE_R = 64
+    # fp8 halves the K-tile bytes; smaller row tiles + deeper pipelining win
+    # there (measured on SM103a) but slightly regress bf16, so keep the bf16
+    # constants for the bf16 cache.
+    if k_cache.dtype == torch.float8_e4m3fn:
+        TILE_R, STAGES = 32, 3
+    else:
+        TILE_R, STAGES = 64, 2
     BLOCK_N = 64
     K_TILES = 16
     grid = (
@@ -421,7 +434,7 @@ def _prefill_logits(
         TILE_R=TILE_R,
         BLOCK_N=BLOCK_N,
         K_TILES=K_TILES,
-        STAGES=2,
+        STAGES=STAGES,
         num_warps=4,
     )
     return logits
@@ -551,7 +564,7 @@ def qsa_select_paged_decode(
         BLOCK_N=_DECODE_BLOCK_N,
         TILES_PER_PROG=tiles_per_program,
         STAGES=2,
-        num_warps=2,
+        num_warps=_decode_num_warps(k_cache.dtype),
     )
     _topk(
         logits,

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -200,6 +200,9 @@ def _qsa_mqa_paged_prefill_kernel(
             other=0.0,
             eviction_policy="evict_first",
         )
+        # With an fp8 cache, SM90 lowers this dot to reduced-precision wgmma
+        # accumulation; SM100 tcgen05 accumulates in fp32. The SM90 error
+        # (~1e-4 relative) is far below the e4m3 quantization noise floor.
         scores = tl.dot(keys, query, out_dtype=tl.float32)
         scores = tl.reshape(scores, (BLOCK_N, TILE_R, NUM_HEADS_PADDED))
         score = tl.sum(tl.maximum(scores, 0.0), axis=2)


### PR DESCRIPTION
## Purpose

This PR adds FP8 support for QSA indexer. This implementation doesn't contain any scaling.

### Microbenchmarks

All measurements are done on GB300

Decode

| bs | ctx | dql=1 bf16 -> fp8 | dql=4 bf16 -> fp8 |
|---:|----:|------:|------:|
| 1 | 8k | 3.9 -> 3.7 (1.0x) | 4.0 -> 4.0 (1.0x) |
| 1 | 64k | 4.8 -> 4.3 (1.1x) | 5.0 -> 4.4 (1.1x) |
| 4 | 8k | 4.3 -> 4.0 (1.1x) | 4.4 -> 4.3 (1.0x) |
| 4 | 64k | 7.6 -> 6.1 (1.3x) | 8.2 -> 6.5 (1.3x) |
| 16 | 8k | 5.8 -> 4.8 (1.2x) | 6.0 -> 5.1 (1.2x) |
| 16 | 64k | 16.9 -> 11.1 (1.5x) | 18.4 -> 12.9 (1.4x) |

Prefill

| ctx | rows | bf16 | fp8 | speedup |
|----:|-----:|-----:|----:|--------:|
| 8k | 2048 | 27.7 | 15.8 | 1.7x |
| 8k | 8192 (chunk) | 43.2 | 31.3 | 1.4x |
| 32k | 2048 | 42.2 | 31.3 | 1.4x |
| 32k | 16384 (chunk) | 272.9 | 187.2 | 1.5x |
| 128k | 2048 | 146.5 | 98.8 | 1.5x |
| 128k | 4096 (chunk) | 260.4 | 186.6 | 1.4x |

Generally the speedup is not linear, hinting Triton's inefficiencies. Future PRs can address FP8 performance (I have WIP branches for CuteDSL decode and Triton TMA prefill)

### E2E performance

TP4 GB300, 8k-1k

| concurrency | TTFT P50 bf16 (s) | TTFT P50 fp8 (s) | TPOT P50 bf16 (ms) | TPOT P50 fp8 (ms) |
|---:|---:|---:|---:|---:|
| 1 | 0.16 | 0.16 | 4.58 | 4.58 |
| 4 | 0.34 | 0.42 | 6.36 | 6.26 |
| 16 | 0.53 | 0.59 | 10.22 | 10.20 |
| 64 | 0.61 | 0.61 | 19.88 | 19.85 |

The result is mostly noise because indexer contributes little to e2e timing at short context + we are using BF16 ckpt. TTFT at c=4 is likely an anomaly.

## Test Plan

### Unit tests

Updated in this PR

### E2E tests

BF16 checkpoint, TP4 on GB300. Both with think=false (fast eval)

Branch | GSM8K (5-shot, n=2638) | LongBench-v2 (n=503)
--|--|--
bf16 (main) | 0.9682 flex / 0.9689 strict | 0.4871
fp8 indexer (this PR)| 0.9678 / 0.9685 | 0.5050

FP8 is better. Likely within noise

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

