### PR TITLE
[Examples] Fix kv_events.sh path to kv_events_subscriber.py

### DIFF
--- a/examples/disaggregated/disaggregated_serving/kv_events.sh
+++ b/examples/disaggregated/disaggregated_serving/kv_events.sh
@@ -47,7 +47,7 @@ wait_for_server 8100
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-python3 "$SCRIPT_DIR/kv_events_subscriber.py" &
+python3 "$SCRIPT_DIR/../../features/kv_events/kv_events_subscriber.py" &
 sleep 1
 
 # serve two example requests


### PR DESCRIPTION
## Summary

`examples/disaggregated/disaggregated_serving/kv_events.sh` launches the KV-events subscriber as `$SCRIPT_DIR/kv_events_subscriber.py`, but that file is not in the same directory. The subscriber lives at `examples/features/kv_events/kv_events_subscriber.py`, so the example fails with a missing-file error after the server starts.

Update the script to call the subscriber via a relative path from its directory.

## Repro steps

On current `main` (verified at `73029d42441321b631779db3475031f5ec26dd6c`):

1. Confirm the script expects a same-dir subscriber:
   ```bash
   grep -n 'kv_events_subscriber' examples/disaggregated/disaggregated_serving/kv_events.sh
   # → python3 "$SCRIPT_DIR/kv_events_subscriber.py" &
   ```
2. Confirm that path does not exist:
   ```bash
   ls examples/disaggregated/disaggregated_serving/kv_events_subscriber.py
   # → No such file or directory
   ```
3. Confirm the real subscriber location:
   ```bash
   ls examples/features/kv_events/kv_events_subscriber.py
   # → exists
   ```
4. The disagg serving README still documents `kv_events.sh` as the KV cache event publishing demo, so the broken path is user-facing.

## Test plan

- [x] Path existence check via GitHub Contents/raw against `main` (same-dir subscriber 404; `examples/features/kv_events/kv_events_subscriber.py` present)
- [x] Diff is a one-line path update in `kv_events.sh` only
- [ ] CI / example smoke as maintainers prefer