### PR TITLE
[ROCm][DSV4][Perf] Use FP8 WO_A output projection

### DIFF
--- a/tests/models/test_deepseek_v4_rocm_wo_a.py
+++ b/tests/models/test_deepseek_v4_rocm_wo_a.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.amd.rocm import _wo_a_block_scale_to_e8m0
+
+
+def test_wo_a_block_scale_to_e8m0_from_float():
+    scale = torch.tensor([[0.5, 1.0, 2.0, 4.0]], dtype=torch.float32)
+
+    encoded = _wo_a_block_scale_to_e8m0(scale)
+
+    assert encoded is not None
+    torch.testing.assert_close(
+        encoded,
+        torch.tensor([[126, 127, 128, 129]], dtype=torch.uint8),
+    )
+    assert encoded.is_contiguous()
+
+
+def test_wo_a_block_scale_to_e8m0_preserves_encoded_scales():
+    raw = torch.tensor([[125, 127, 131]], dtype=torch.uint8)
+    encoded = raw.view(torch.float8_e8m0fnu)
+
+    converted = _wo_a_block_scale_to_e8m0(encoded)
+
+    assert converted is not None
+    torch.testing.assert_close(converted, raw)
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        torch.tensor([[0.0, 1.0]]),
+        torch.tensor([[-1.0, 1.0]]),
+        torch.tensor([[0.75, 1.0]]),
+        torch.tensor([[float("inf"), 1.0]]),
+        torch.ones(1, dtype=torch.int32),
+    ],
+)
+def test_wo_a_block_scale_to_e8m0_rejects_invalid_scales(scale: torch.Tensor):
+    assert _wo_a_block_scale_to_e8m0(scale) is None

--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import torch
 
+from vllm import envs
 from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
@@ -39,6 +40,27 @@ from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
 from vllm.v1.worker.workspace import current_workspace_manager
 
 logger = init_logger(__name__)
+
+
+def _wo_a_block_scale_to_e8m0(scale: torch.Tensor) -> torch.Tensor | None:
+    """Return raw E8M0 exponent bytes for a WO_A block-scale tensor."""
+    if scale.dtype == torch.float8_e8m0fnu:
+        return scale.view(torch.uint8).contiguous()
+    if scale.dtype == torch.uint8:
+        return scale.contiguous()
+    if not scale.dtype.is_floating_point:
+        return None
+
+    scale_f32 = scale.detach().float()
+    if not bool(torch.isfinite(scale_f32).all()) or bool((scale_f32 <= 0).any()):
+        return None
+    exponent = torch.round(torch.log2(scale_f32))
+    if not torch.equal(torch.exp2(exponent), scale_f32):
+        return None
+    biased = exponent.to(torch.int32) + 127
+    if int(biased.min()) < 0 or int(biased.max()) > 255:
+        return None
+    return biased.to(torch.uint8).contiguous()
 
 
 def _trust_dsv4_extra_cache_nan_free(
@@ -520,6 +542,10 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
         # Block scale for the preshuffled weight; None = not preshuffled.
         self._wqa_wkv_scale: torch.Tensor | None = None
         self._wo_b_scale: torch.Tensor | None = None
+        self._wo_a_fp8_weight: torch.Tensor | None = None
+        self._wo_a_e8m0_scale: torch.Tensor | None = None
+        self._wo_a_cos_cache: torch.Tensor | None = None
+        self._wo_a_sin_cache: torch.Tensor | None = None
         self._fused_compressor_weight: torch.Tensor | None
         self.register_buffer("_fused_compressor_weight", None, persistent=False)
         self._fused_compressor_split_sizes: tuple[int, int] | None = None
@@ -560,6 +586,61 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
 
         self._wqa_wkv_scale = _prep(self.fused_wqa_wkv)
         self._wo_b_scale = _prep(self.wo_b)
+        if _ON_GFX950 and envs.VLLM_ROCM_USE_AITER_FP8BMM:
+            self._prepare_fp8_wo_a()
+
+    def _prepare_fp8_wo_a(self) -> None:
+        try:
+            from aiter.ops.batched_gemm_op_a8w8 import (
+                batched_gemm_a8w8_mxscale as mxscale_op,
+            )
+            from aiter.ops.inverse_rope_group_quant import (
+                inverse_rope_group_quant as inverse_quant_op,
+            )
+        except ImportError:
+            logger.warning_once(
+                "The DeepSeek V4 FP8 WO_A path requires AITER >= 0.1.20; "
+                "falling back to BF16 WO_A."
+            )
+            return
+        del mxscale_op, inverse_quant_op
+
+        weight = getattr(self.wo_a, "weight", None)
+        scale = getattr(self.wo_a, "weight_scale_inv", None)
+        if (
+            weight is None
+            or scale is None
+            or weight.dim() != 2
+            or scale.dim() != 2
+            or weight.dtype not in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+        ):
+            return
+
+        groups = self.n_local_groups
+        out_per_group = self.o_lora_rank
+        out_features, in_features = weight.shape
+        if (
+            out_features != groups * out_per_group
+            or out_per_group % 128 != 0
+            or in_features % 128 != 0
+            or scale.shape != (out_features // 128, in_features // 128)
+        ):
+            return
+
+        e8m0_scale = _wo_a_block_scale_to_e8m0(scale)
+        if e8m0_scale is None:
+            return
+
+        self._wo_a_fp8_weight = weight.view(groups, out_per_group, in_features)
+        self._wo_a_e8m0_scale = e8m0_scale.view(
+            groups, out_per_group // 128, in_features // 128
+        )
+        cache = getattr(self.rotary_emb, "cos_sin_cache_bf16", None)
+        if cache is None:
+            cache = self.rotary_emb.cos_sin_cache.to(dtype=torch.bfloat16)
+        cos_cache, sin_cache = cache.chunk(2, dim=-1)
+        self._wo_a_cos_cache = cos_cache.contiguous()
+        self._wo_a_sin_cache = sin_cache.contiguous()
 
     def prepare_compressor_gemm_fusion(self) -> bool:
         if self._fused_compressor_weight is not None:
@@ -718,17 +799,44 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
         )
 
     def _o_proj(self, o: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
-        # ROCm BF16 reference wo_a path (inverse RoPE + einsum) + wo_b.
-        z = rocm_inv_rope_einsum(
-            self.rotary_emb,
-            o,
-            positions,
-            self.rope_head_dim,
-            self.n_local_groups,
-            self.o_lora_rank,
-            self.wo_a,
-        )
-        zf = z.flatten(1)
+        if self._wo_a_fp8_weight is not None:
+            from aiter.ops.batched_gemm_op_a8w8 import (
+                batched_gemm_a8w8_mxscale,
+            )
+            from aiter.ops.inverse_rope_group_quant import (
+                inverse_rope_group_quant,
+            )
+
+            assert self._wo_a_cos_cache is not None
+            assert self._wo_a_sin_cache is not None
+            o_fp8, o_scale = inverse_rope_group_quant(
+                o.view(o.shape[0], self.n_local_heads, self.head_dim),
+                positions.to(torch.int64),
+                self._wo_a_cos_cache,
+                self._wo_a_sin_cache,
+                num_groups=self.n_local_groups,
+                quant_group_size=128,
+            )
+            assert self._wo_a_e8m0_scale is not None
+            zf = batched_gemm_a8w8_mxscale(
+                o_fp8,
+                self._wo_a_fp8_weight,
+                o_scale,
+                self._wo_a_e8m0_scale,
+                dtype=o.dtype,
+            ).flatten(1)
+        else:
+            # ROCm BF16 reference wo_a path (inverse RoPE + einsum) + wo_b.
+            z = rocm_inv_rope_einsum(
+                self.rotary_emb,
+                o,
+                positions,
+                self.rope_head_dim,
+                self.n_local_groups,
+                self.o_lora_rank,
+                self.wo_a,
+            )
+            zf = z.flatten(1)
         if self._wo_b_scale is not None and zf.dim() == 2:
             return self._bpre_attn_gemm(self.wo_b.weight, self._wo_b_scale, zf, True)
         return self.wo_b(zf)


### PR DESCRIPTION
## Summary

Replace the ROCm DeepSeek V4 BF16 `wo_a` output-projection path on gfx950 with:

1. AITER `inverse_rope_group_quant`, which fuses inverse RoPE with per-token
   E8M0 group quantization.
2. AITER `batched_gemm_a8w8_mxscale`, which consumes the quantized activation
   and the checkpoint's native FP8 `wo_a` weight.

This removes the BF16 grouped einsum and keeps `wo_a` in its checkpoint FP8
form. Unsupported weights, scales, devices, and older AITER installations
retain the existing BF16 fallback.

## Dependency

This fast path requires AITER >= 0.1.20, which added the MX-scale batched GEMM.
It therefore depends on #52826. Current `main` remains safe: the capability
probe logs once and falls back to BF16 when the op is unavailable.

## Implementation

- Reuse the existing `VLLM_ROCM_USE_AITER_FP8BMM` gate and restrict the path to
  gfx950.
- Accept native `float8_e8m0fnu`/`uint8` scales, or losslessly convert positive
  power-of-two FP32 scales to biased E8M0 exponent bytes.
- Validate the group-128 weight and scale layouts before enabling the path.
- Cache contiguous BF16 cosine/sine cache views once after weight loading.
- Preserve the existing `rocm_inv_rope_einsum` path as the fallback.

## Performance

Measured on 8 x MI355X, TP1/PP8, one 100,000-token prefill request, 8K prefill
chunks, prefix caching disabled, three runs:

| Path | TTFT runs (ms) | Median TTFT | Input throughput |
|---|---:|---:|---:|
| OPUS sparse MLA + tuned GEMMs | 2470.2 / 2457.9 / 2459.0 | 2459.0 ms | 40,667.0 tok/s |
| + FP8 `wo_a` | 2288.8 / 2276.1 / 2278.4 | 2278.4 ms | 43,891.0 tok/s |

Delta: **TTFT -7.35%** and **input throughput +7.93%**.

### TP8/PP1 prefill concurrency

Measured on 8 x MI355X with TP8/PP1, fixed 8,192-token prompts and one output
token, prefix caching disabled, and 10 requests per concurrency slot. Both arms
use the same image and differ only in the FP8 `wo_a` gate.

| Max concurrency | BF16 `wo_a` total tok/s | FP8 `wo_a` total tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 16,218.62 | 16,345.65 | +0.78% |
| 2 | 23,337.44 | 23,782.97 | +1.91% |
| 4 | 23,618.92 | 24,004.20 | +1.63% |
| 8 | 23,621.81 | 24,051.77 | +1.82% |
| 16 | 23,623.62 | 24,069.49 | +1.89% |
| 32 | 23,624.64 | 24,069.36 | +1.88% |
| 48 | 23,621.17 | 24,069.38 | +1.90% |

All 1,110 requests in each arm completed without errors.

Revisions and runtime:

- vLLM PR commit: `a9cf3bc3498eb71bb2d6f5d44c4b0049b62feb7a`
- ROCm nightly base digest:
  `sha256:cef549da00e0efaeadd9338ac8f351f2b96ff71a5ab8651a99bf989458bf1684`
- AITER commit: `a6d2b564fd671724a3720b8edf70e8d674e4d694`
- FlyDSL: `0.3.1`
- Image ID: `sha256:0f851f268bc6bdb41c5ed22663a106339b3b269a88afbef17dbda156f2fb7893`
- Common settings: TP8/PP1/DCP1/PCP1/EP1, FP8 KV cache, AITER MoE,
  Triton sparse prefill, 8K max batched tokens, no prefix cache
- A/B gates: `VLLM_ROCM_USE_AITER_FP8BMM=0/1`

The enabled-arm logs load `module_inverse_rope_group_quant` and
`opus_bmm_a8w8_mxscale`; neither appears in the disabled-arm logs.

### TP1/PP8 prefill concurrency

Measured with the same fixed 8,192-token prompts, one output token, disabled
prefix caching, and 10 requests per concurrency slot. The image, revisions,
runtime settings, and A/B gate are identical to the TP8/PP1 measurements above;
only the topology changes to TP1/PP8.

| Max concurrency | BF16 `wo_a` total tok/s | FP8 `wo_a` total tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 4,119.72 | 4,271.13 | +3.68% |
| 2 | 6,436.17 | 6,865.25 | +6.67% |
| 4 | 6,461.36 | 6,896.31 | +6.73% |
| 8 | 6,460.00 | 6,891.96 | +6.69% |
| 16 | 6,457.00 | 6,891.06 | +6.72% |
| 32 | 6,459.55 | 6,889.21 | +6.65% |
| 48 | 6,460.06 | 6,889.74 | +6.65% |

All 1,110 requests in each arm completed without errors. The enabled-arm logs
load `module_inverse_rope_group_quant` and `opus_bmm_a8w8_mxscale` on all eight
pipeline stages; neither appears in the disabled-arm logs.

## Correctness

Greedy GSM8K, zero invalid responses:

- 100-question gate: **93/100**
- Full 1319 questions: **1256/1319 = 95.22%**
- Clean fixed-stack reference: **1249/1319 = 94.69%**

### TP8/PP1 GSM8K

Topology-matched greedy 5-shot evaluation on the TP8 stack above:

| Path | Accuracy | Correct | Invalid |
|---|---:|---:|---:|
| BF16 `wo_a` | 93.9348% | 1239/1319 | 0 |
| FP8 `wo_a` | 94.9204% | 1252/1319 | 1 |

The FP8 candidate first passed the 100-question gate at **93/100 with zero
invalid responses**. Full-set accuracy was +0.99 percentage points versus the
topology-matched BF16 reference; one response did not contain a parseable
answer.

## Validation

- `git diff --check`: passed
- pre-commit hooks for both changed files: passed
- `tests/models/test_deepseek_v4_rocm_wo_a.py`: **7 passed**
- TP1/PP8 100K prefill: 3/3 requests completed
- GSM8K-1319: zero invalid responses

## Related work

#45103 fused inverse RoPE and cached a BF16 `wo_a`; this PR retains that path as
fallback and uses the native FP8 weight on supported gfx950 configurations.

## AI assistance

Cursor assisted with implementation, testing, benchmark analysis, and drafting.
The human submitter reviewed the resulting change and is responsible for it.



---

# Re-measurement on the older `DeepSeek-V4-Pro` checkpoint

> **Scope note.** Everything **above** this heading was measured on the
> **0813** checkpoint. Everything **below** was re-measured on the older
> `DeepSeek-V4-Pro` snapshot
> (`models--deepseek-ai--DeepSeek-V4-Pro/snapshots/b5968e9190ef611bbf34a7229255be88a0e937c1`,
> staged locally as `DeepSeek-V4-Pro-old`). The two sets are **not**
> interchangeable; they are reported side by side so the gate can be judged on
> both checkpoints. Nothing above has been edited.

## Setup

| Item | Value |
|---|---|
| Hardware | 8 x MI355X (gfx950), single node |
| Image | `vllm/vllm-openai-rocm:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36` |
| vLLM | `0.28.1rc1.dev472+gd9105ea80` + this PR applied to `vllm/models/deepseek_v4/amd/rocm.py` |
| ROCm / torch | 7.2.3 / 2.12.0+git6bbd260 |
| Model | `DeepSeek-V4-Pro` (older snapshot), FP4 |
| A/B gate | `VLLM_ROCM_USE_AITER_FP8BMM=0` vs `=1`, same image and same patched file |
| Tuned GEMMs | `AITER_CONFIG_GEMM_A8W8_BLOCKSCALE` pointed at a merged a8w8-blockscale tuning table |
| Workload | Identical to the tables above: fixed 8,192-token prompts, one output token, prefix caching disabled, 10 requests per concurrency slot |

Fast-path confirmation: the enabled arm's server log loads
`module_inverse_rope_group_quant` and the `mxscale` BMM; the disabled arm's log
contains neither (verified per run).

## TP8/PP1 prefill concurrency

| Max concurrency | BF16 `wo_a` total tok/s | FP8 `wo_a` total tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 15,544.93 | 15,623.10 | +0.50% |
| 2 | 20,474.39 | 21,122.52 | +3.17% |
| 4 | 20,883.86 | 20,965.92 | +0.39% |
| 8 | 20,963.71 | 21,157.26 | +0.92% |
| 16 | 20,959.80 | 21,099.28 | +0.67% |
| 32 | 20,845.46 | 21,224.69 | +1.82% |
| 48 | 20,848.19 | 21,178.18 | +1.58% |

Mean gain across the sweep: **+1.29%**. All 1,110 requests per arm completed successfully.

## TP1/PP8 prefill concurrency

| Max concurrency | BF16 `wo_a` total tok/s | FP8 `wo_a` total tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 4,228.93 | 4,403.25 | +4.12% |
| 2 | 6,179.04 | 6,528.63 | +5.66% |
| 4 | 6,176.99 | 6,595.96 | +6.78% |
| 8 | 6,189.02 | 6,591.95 | +6.51% |
| 16 | 6,188.72 | 6,591.11 | +6.50% |
| 32 | 6,190.38 | 6,591.60 | +6.48% |
| 48 | 6,190.03 | 6,596.08 | +6.56% |

Mean gain across the sweep: **+6.09%**. All 1,110 requests per arm completed successfully.

## TP8/PP1 decode performance (8K input / 1K output)

Re-measured for the reviewer-requested TPOT comparison on the old checkpoint,
8 x MI355X, TP8/PP1, prefix caching disabled. Each concurrency uses four
measured waves (at least 16 requests) after a full unmeasured wave with a
different random seed. The only A/B variable is
`VLLM_ROCM_USE_AITER_FP8BMM=0/1`. The enabled log loads
`module_inverse_rope_group_quant` and `opus_bmm_a8w8_mxscale`.

| Concurrency | BF16 `wo_a` output tok/s | FP8 `wo_a` output tok/s | Throughput change | BF16 TPOT | FP8 TPOT | TPOT change | BF16 TTFT | FP8 TTFT |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 63.35 | 64.55 | **+1.89%** | 15.43 ms | 15.15 ms | **-1.85%** | 375.74 ms | 367.52 ms |
| 4 | 213.53 | 219.99 | **+3.02%** | 17.76 ms | 17.23 ms | **-2.97%** | 1009.75 ms | 986.39 ms |
| 16 | 662.89 | 677.29 | **+2.17%** | 22.27 ms | 21.75 ms | **-2.34%** | 1899.74 ms | 1908.81 ms |
| 64 | 1386.37 | 1431.21 | **+3.23%** | 42.15 ms | 40.72 ms | **-3.39%** | 3999.62 ms | 3984.62 ms |

The FP8 `wo_a` path improves mean TPOT by **1.85%-3.39%** and output
throughput by **1.89%-3.23%** across the measured decode concurrency sweep.

## TP1/PP8 single 100,000-token prefill

Three runs per arm, 8K prefill chunks, prefix caching disabled. The first run of
each arm carries a cold-start spike (~13.8 s on both arms) and is excluded from
the median.

| Path | TTFT runs (ms) | Median TTFT | Input throughput |
|---|---:|---:|---:|
| BF16 `wo_a` | 13878.3 / 4309.2 / 4328.5 | 4328.5 ms | 23,100.5 tok/s |
| FP8 `wo_a` | 13757.7 / 4096.0 / 4203.3 | 4203.3 ms | 23,789.1 tok/s |

Delta: **TTFT -2.89%**, input throughput **+2.98%**.

## GSM8K (full 1,319, greedy, 5-shot)

Re-run after the E8M0 conversion documentation update on the exact old
checkpoint and the same TP8/PP1 stack used for the decode table. Prefix caching
was disabled; both arms used seed 42 and concurrency 64. The only A/B variable
was `VLLM_ROCM_USE_AITER_FP8BMM=0/1`.

| Path | Accuracy | Correct | Invalid | Output tok/s |
|---|---:|---:|---:|---:|
| BF16 `wo_a` | 94.7688% | 1250/1319 | 0 | 879.44 |
| FP8 `wo_a` | 94.7688% | 1250/1319 | 0 | 889.21 |

The FP8 WO_A path is accuracy-neutral in this full-set run, with zero invalid
responses in both arms. Output token throughput improves by **1.11%**.

## Summary on this checkpoint

| Measurement | Result |
|---|---|
| TP8/PP1 throughput | +1.29% mean (+0.39% to +3.17%) |
| TP1/PP8 throughput | +6.09% mean (+4.12% to +6.78%) |
| 100K prefill TTFT | -2.89% |
| GSM8K full 1319 | 94.7688% for both arms; zero invalid responses |

The direction and magnitude match the 0813 numbers above: a small gain at
TP8/PP1 and a larger one at TP1/PP8, with accuracy at or above the BF16
reference.


