### PR TITLE
[CI] Use PR head label for Buildkite branch to avoid main collision

### DIFF
--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -606,7 +606,10 @@ def create_build_payload(
     }
     return {
         "commit": pr["head"]["sha"],
-        "branch": pr["head"]["ref"],
+        # Use the head label (owner:branch) rather than the bare ref so a PR
+        # whose fork branch is named e.g. "main" does not collide with the
+        # upstream branch of the same name.
+        "branch": pr["head"].get("label") or pr["head"]["ref"],
         "message": f"PR #{pr['number']} {command} by @{actor}",
         "pull_request_id": pr["number"],
         "pull_request_base_branch": pr["base"]["ref"],
@@ -969,12 +972,13 @@ def handle_cancel_ci(
 ) -> str:
     ci_name = ci_name_for_command(command)
     branch = pr["head"]["ref"]
+    # Builds are created under the head label (owner:branch); also match the
+    # bare ref so builds created before that change can still be cancelled.
     branches = [branch]
+    head_label = pr["head"].get("label")
+    if head_label and head_label not in branches:
+        branches.insert(0, str(head_label))
     states = CANCELABLE_BUILD_STATES
-    if command in AMD_CI_COMMANDS:
-        head_label = pr["head"].get("label")
-        if head_label and head_label not in branches:
-            branches.append(str(head_label))
 
     builds_by_number: dict[int, dict[str, Any]] = {}
     for candidate_branch in branches:

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -45,6 +45,7 @@ def make_pr(**overrides: Any) -> dict[str, Any]:
         "base": {"ref": "main"},
         "draft": False,
         "head": {
+            "label": "contributor:feature",
             "ref": "feature",
             "repo": {"clone_url": "https://github.com/contributor/vllm.git"},
             "sha": "0123456789abcdef",
@@ -479,7 +480,7 @@ class RunCiCommandTest(unittest.TestCase):
             payload,
             {
                 "commit": "0123456789abcdef",
-                "branch": "feature",
+                "branch": "contributor:feature",
                 "message": "PR #42 /ci run by @reviewer",
                 "pull_request_id": 42,
                 "pull_request_base_branch": "main",
@@ -497,6 +498,23 @@ class RunCiCommandTest(unittest.TestCase):
                 },
             },
         )
+
+    def test_build_payload_uses_head_label_to_avoid_branch_collision(self) -> None:
+        pr = make_pr()
+        pr["head"]["ref"] = "main"
+        pr["head"]["label"] = "contributor:main"
+
+        payload = create_build_payload(actor="reviewer", comment_id=99, pr=pr)
+
+        self.assertEqual(payload["branch"], "contributor:main")
+
+    def test_build_payload_falls_back_to_ref_without_label(self) -> None:
+        pr = make_pr()
+        del pr["head"]["label"]
+
+        payload = create_build_payload(actor="reviewer", comment_id=99, pr=pr)
+
+        self.assertEqual(payload["branch"], "feature")
 
     def test_write_reviewer_runs_ci_without_delegation(self) -> None:
         github = FakeGitHub()
@@ -1039,56 +1057,65 @@ class RunCiCommandTest(unittest.TestCase):
         github = FakeGitHub()
         buildkite = FakeBuildkite(
             [
+                # Builds created under the head label (owner:branch).
                 [
                     {
-                        "branch": "feature",
+                        "branch": "contributor:feature",
                         "number": 123,
                         "pull_request": {"id": 42},
                         "state": "running",
                         "web_url": "https://buildkite.example/builds/123",
                     },
                     {
-                        "branch": "feature",
+                        "branch": "contributor:feature",
                         "number": 124,
                         "meta_data": {"github-pr-number": "42"},
                         "state": "failing",
                         "web_url": "https://buildkite.example/builds/124",
                     },
                     {
-                        "branch": "feature",
+                        "branch": "contributor:feature",
                         "number": 125,
                         "pull_request": {"id": 43},
                         "state": "running",
                         "web_url": "https://buildkite.example/builds/125",
                     },
                     {
-                        "branch": "other-branch",
-                        "number": 126,
-                        "pull_request": {"id": 42},
-                        "state": "running",
-                        "web_url": "https://buildkite.example/builds/126",
-                    },
-                    {
-                        "branch": "feature",
+                        "branch": "contributor:feature",
                         "number": 127,
                         "pull_request": {"id": 42},
                         "state": "passed",
                         "web_url": "https://buildkite.example/builds/127",
                     },
-                ]
+                ],
+                # Legacy builds created under the bare ref before the label change.
+                [
+                    {
+                        "branch": "feature",
+                        "number": 126,
+                        "pull_request": {"id": 42},
+                        "state": "running",
+                        "web_url": "https://buildkite.example/builds/126",
+                    },
+                ],
             ]
         )
 
         run(make_event(COMMAND_CANCEL_CI), github, buildkite)
 
-        self.assertEqual(buildkite.cancel_calls, [123, 124])
-        self.assertIn("Requested cancellation of 2 CI builds", github.comments[0])
+        self.assertEqual(buildkite.cancel_calls, [123, 124, 126])
+        self.assertEqual(
+            [request["branch"] for request in buildkite.list_requests],
+            ["contributor:feature", "feature"],
+        )
+        self.assertIn("Requested cancellation of 3 CI builds", github.comments[0])
         self.assertIn("#123", github.comments[0])
         self.assertIn("#124", github.comments[0])
+        self.assertIn("#126", github.comments[0])
 
     def test_ci_cancel_is_a_noop_without_active_builds(self) -> None:
         github = FakeGitHub()
-        buildkite = FakeBuildkite([[]])
+        buildkite = FakeBuildkite([[], []])
 
         run(make_event(COMMAND_CANCEL_CI), github, buildkite)
 
@@ -1103,15 +1130,6 @@ class RunCiCommandTest(unittest.TestCase):
             [
                 [
                     {
-                        "branch": "feature",
-                        "number": 321,
-                        "pull_request": {"id": 42},
-                        "state": "running",
-                        "web_url": "https://buildkite.example/amd-ci/builds/321",
-                    }
-                ],
-                [
-                    {
                         "branch": "contributor:feature",
                         "number": 322,
                         "pull_request": {"id": 42},
@@ -1119,15 +1137,24 @@ class RunCiCommandTest(unittest.TestCase):
                         "web_url": "https://buildkite.example/amd-ci/builds/322",
                     }
                 ],
+                [
+                    {
+                        "branch": "feature",
+                        "number": 321,
+                        "pull_request": {"id": 42},
+                        "state": "running",
+                        "web_url": "https://buildkite.example/amd-ci/builds/321",
+                    }
+                ],
             ]
         )
 
         run(make_event(COMMAND_CANCEL_AMD_CI), github, buildkite)
 
-        self.assertEqual(buildkite.cancel_calls, [321, 322])
+        self.assertEqual(buildkite.cancel_calls, [322, 321])
         self.assertEqual(
             [request["branch"] for request in buildkite.list_requests],
-            ["feature", "contributor:feature"],
+            ["contributor:feature", "feature"],
         )
         self.assertTrue(
             all(


### PR DESCRIPTION
## Problem

The `/ci run` comment bot (`run_ci_command.py`) sets the Buildkite build's `branch` to the PR head **ref** (`pr["head"]["ref"]`). When a contributor opens a PR from a fork branch named `main` (e.g. `tanyuqian:main`), the build is created on branch `main`, colliding with the real upstream `main` branch in the Buildkite UI, branch filters, and `cancel_running_branch_builds`.

Example: https://buildkite.com/vllm/ci/builds/86746 was triggered by `/ci run` on https://github.com/vllm-project/vllm/pull/53806 (head `tanyuqian:main`) but shows up as a build on branch `main`. The build does check out the correct commit (`pull_request_repository` points at the fork), so this is primarily a confusing/incorrect branch label — but it also makes `/ci cancel` match on the same branch name as production `main` builds.

## Fix

Use the PR head **label** (`owner:branch`, e.g. `tanyuqian:main`) as the Buildkite `branch` instead of the bare ref. The label is always present on GitHub PR payloads, is unique per fork, and never collides with an upstream branch name. This matches the convention already used by webhook-created AMD CI builds (which `handle_cancel_ci` already matches via `head.label`).

`handle_cancel_ci` now matches both the label and the bare ref so builds created before this change can still be cancelled, and the AMD-only special case there is removed since both flows now behave the same.

## Why this is not a duplicate

Searched open PRs/issues for `run_ci_command branch`, `buildkite branch head ref`, and `ci run branch main fork` — none address this.

## Testing

```
.venv/bin/python -m pytest .github/workflows/scripts/test_run_ci_command.py -q
# 48 passed, 25 subtests passed
```

Added tests:
- `test_build_payload_uses_head_label_to_avoid_branch_collision` — a fork branch named `main` yields Buildkite branch `contributor:main`.
- `test_build_payload_falls_back_to_ref_without_label` — missing label falls back to the bare ref.
- Updated cancel tests to cover label-branch builds and legacy ref-branch builds.

`pre-commit run` on the two changed files passes (ruff, mypy, SPDX, etc.).

No model-affecting change; CI-bot behavior only, so no model evals were run.

## AI assistance

This change was developed with AI assistance (Kimi Code). I reviewed every changed line and ran the tests above.
