### PR TITLE
[Kernel][Spec Decode] Add hybrid NVFP4 LM-head sampling support

### DIFF
--- a/benchmarks/kernels/benchmark_hybrid_nvfp4_lm_head.py
+++ b/benchmarks/kernels/benchmark_hybrid_nvfp4_lm_head.py
@@ -1,0 +1,709 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from statistics import median
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+    _global_scale,
+    _select_candidate_tile,
+    indexed_bf16_dot,
+    select_lm_head_candidates,
+)
+from vllm.model_executor.layers.argmax_triton import (
+    indexed_argmax_triton,
+    reduce_global_argmax_triton,
+)
+from vllm.triton_utils import HAS_TRITON
+from vllm.utils.flashinfer import (
+    flashinfer_nvfp4_quantize_128x4,
+    flashinfer_scaled_fp4_mm,
+)
+
+_EMBEDDING_WEIGHT_KEYS = (
+    "lm_head.weight",
+    "model.language_model.embed_tokens.weight",
+    "model.embed_tokens.weight",
+)
+
+
+@dataclass
+class Nvfp4Weight:
+    weight: torch.Tensor
+    scale: torch.Tensor
+    global_scale: torch.Tensor
+    output_size: int
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(
+            f"expected a positive integer, got {value}"
+        )
+    return parsed
+
+
+def _candidate_tile(value: str) -> int | None:
+    if value == "auto":
+        return None
+    parsed = int(value)
+    if parsed not in (1, 2, 4, 8):
+        raise argparse.ArgumentTypeError(
+            f"expected auto, 1, 2, 4, or 8, got {value}"
+        )
+    return parsed
+
+
+def _resolve_weight(model_dir: Path) -> tuple[Path, str]:
+    index_paths = sorted(model_dir.glob("*safetensors.index.json"))
+    if len(index_paths) != 1:
+        raise ValueError(
+            f"expected one safetensors index in {model_dir}, got {index_paths}"
+        )
+    weight_map = json.loads(index_paths[0].read_text(encoding="utf-8"))["weight_map"]
+    for key in _EMBEDDING_WEIGHT_KEYS:
+        if key in weight_map:
+            return model_dir / weight_map[key], key
+    raise KeyError(f"none of {_EMBEDDING_WEIGHT_KEYS} is present in {index_paths[0]}")
+
+
+def _load_weight_shard(
+    model_dir: Path,
+    *,
+    tp_size: int,
+    tp_rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, int, str]:
+    shard_path, weight_key = _resolve_weight(model_dir)
+    with safe_open(shard_path, framework="pt", device="cpu") as handle:
+        weight_slice = handle.get_slice(weight_key)
+        shape = weight_slice.get_shape()
+        if len(shape) != 2:
+            raise ValueError(f"lm-head weight must be 2D, got {shape}")
+        if shape[0] % tp_size:
+            raise ValueError(
+                f"vocabulary {shape[0]} is not divisible by TP size {tp_size}"
+            )
+        rows_per_rank = shape[0] // tp_size
+        start = tp_rank * rows_per_rank
+        weight = weight_slice[start : start + rows_per_rank]
+    if weight.dtype != torch.bfloat16:
+        raise ValueError(f"expected BF16 lm-head weight, got {weight.dtype}")
+    return weight.contiguous().to(device), start, weight_key
+
+
+def _quantize_nvfp4(
+    tensor: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    global_scale = _global_scale(tensor)
+    quantized, scale = flashinfer_nvfp4_quantize_128x4(
+        tensor.contiguous(),
+        global_scale,
+    )
+    return quantized, scale, global_scale
+
+
+def _quantize_weight(weight: torch.Tensor) -> Nvfp4Weight:
+    output_size = weight.shape[0]
+    padded_output_size = (output_size + 31) // 32 * 32
+    if padded_output_size != output_size:
+        weight = F.pad(weight, (0, 0, 0, padded_output_size - output_size))
+    quantized, scale, global_scale = _quantize_nvfp4(weight)
+    return Nvfp4Weight(quantized, scale, global_scale, output_size)
+
+
+def _nvfp4_mm(
+    hidden_q: torch.Tensor,
+    hidden_scale: torch.Tensor,
+    hidden_global_scale: torch.Tensor,
+    weight: Nvfp4Weight,
+) -> torch.Tensor:
+    logits = flashinfer_scaled_fp4_mm(
+        hidden_q,
+        weight.weight,
+        hidden_scale,
+        weight.scale,
+        alpha=torch.reciprocal(hidden_global_scale * weight.global_scale),
+        out_dtype=torch.bfloat16,
+        backend="b12x",
+        block_size=16,
+        use_nvfp4=True,
+    )
+    return logits[:, : weight.output_size]
+
+
+def _nvfp4_linear(hidden: torch.Tensor, weight: Nvfp4Weight) -> torch.Tensor:
+    hidden_q, hidden_scale, hidden_global_scale = _quantize_nvfp4(hidden)
+    return _nvfp4_mm(hidden_q, hidden_scale, hidden_global_scale, weight)
+
+
+def _native_linear(hidden: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return F.linear(hidden, weight)
+
+
+def _native_topk(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    logits = _native_linear(hidden, weight)
+    if top_k > 1:
+        logits = logits.float()
+    return torch.topk(logits, top_k, dim=-1)
+
+
+def _candidate_indexed_argmax(
+    exact_logits: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    *,
+    index_offset: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        HAS_TRITON
+        and exact_logits.is_cuda
+        and 0 < exact_logits.shape[-1] <= 1024
+    ):
+        return indexed_argmax_triton(
+            exact_logits,
+            candidate_indices,
+            index_offset=index_offset,
+        )
+    values, positions = exact_logits.max(dim=-1)
+    indices = candidate_indices.gather(1, positions.unsqueeze(-1)).squeeze(-1)
+    return values.float(), indices.to(torch.int32) + index_offset
+
+
+def _refine_selected_topk(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    *,
+    top_k: int,
+    candidate_tile: int | None = None,
+    index_offset: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    exact_logits = indexed_bf16_dot(
+        hidden,
+        weight,
+        candidate_indices,
+        candidate_tile=candidate_tile,
+    )
+    if top_k == 1:
+        values, indices = _candidate_indexed_argmax(
+            exact_logits,
+            candidate_indices,
+            index_offset=index_offset,
+        )
+        return values.unsqueeze(-1), indices.unsqueeze(-1)
+    if top_k > 1:
+        exact_logits = exact_logits.float()
+    values, positions = torch.topk(exact_logits, top_k, dim=-1)
+    indices = candidate_indices.gather(1, positions).to(torch.int32) + index_offset
+    return values, indices
+
+
+def _hybrid_topk(
+    hidden: torch.Tensor,
+    bf16_weight: torch.Tensor,
+    nvfp4_weight: Nvfp4Weight,
+    *,
+    top_k: int,
+    candidates: int,
+    candidate_tile: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    coarse_logits = _nvfp4_linear(hidden, nvfp4_weight)
+    coarse_indices = select_lm_head_candidates(coarse_logits, candidates)
+    return _refine_selected_topk(
+        hidden,
+        bf16_weight,
+        coarse_indices,
+        top_k=top_k,
+        candidate_tile=candidate_tile,
+    )
+
+
+def _reduce_tp_pairs(
+    local_values: torch.Tensor,
+    global_indices: torch.Tensor,
+    tp_size: int,
+) -> torch.Tensor:
+    if tp_size == 1:
+        return global_indices.to(torch.int32)
+    local_pairs = torch.stack(
+        [local_values.float(), global_indices.float()],
+        dim=-1,
+    )
+    gathered_pairs = (
+        local_pairs[:, None, :]
+        .expand(-1, tp_size, -1)
+        .contiguous()
+        .view(local_pairs.shape[0], tp_size * 2)
+    )
+    if HAS_TRITON and gathered_pairs.is_cuda:
+        return reduce_global_argmax_triton(
+            gathered_pairs,
+            tp_size=tp_size,
+        ).to(torch.int32)
+    gathered_pairs = gathered_pairs.view(gathered_pairs.shape[0], tp_size, 2)
+    winner = gathered_pairs[:, :, 0].argmax(dim=-1, keepdim=True)
+    return gathered_pairs[:, :, 1].gather(1, winner).squeeze(1).to(torch.int32)
+
+
+def _hybrid_greedy_integrated(
+    hidden: torch.Tensor,
+    bf16_weight: torch.Tensor,
+    nvfp4_weight: Nvfp4Weight,
+    *,
+    candidates: int,
+    vocab_start: int,
+    tp_size: int,
+    candidate_tile: int | None = None,
+) -> torch.Tensor:
+    coarse_logits = _nvfp4_linear(hidden, nvfp4_weight)
+    candidate_indices = select_lm_head_candidates(coarse_logits, candidates)
+    exact_logits = indexed_bf16_dot(
+        hidden,
+        bf16_weight,
+        candidate_indices,
+        candidate_tile=candidate_tile,
+    )
+    local_values, global_indices = _candidate_indexed_argmax(
+        exact_logits,
+        candidate_indices,
+        index_offset=vocab_start,
+    )
+    return _reduce_tp_pairs(local_values, global_indices, tp_size)
+
+
+def _time_cuda_graph(
+    function: Callable[[], object],
+    *,
+    steps: int,
+    warmup: int,
+    trials: int,
+) -> dict[str, float | list[float]]:
+    outputs = function()
+    torch.cuda.synchronize()
+    del outputs
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        outputs = function()
+    torch.cuda.synchronize()
+    for _ in range(warmup):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    samples: list[float] = []
+    for _ in range(trials):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(steps):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0 / steps)
+    del outputs
+    return {
+        "median_us": median(samples),
+        "samples_us": samples,
+    }
+
+
+def _candidate_recall(
+    native_indices: torch.Tensor,
+    coarse_indices: torch.Tensor,
+) -> tuple[int, int]:
+    matches = native_indices.unsqueeze(-1) == coarse_indices.unsqueeze(-2)
+    hits = matches.any(dim=-1).sum().item()
+    return int(hits), native_indices.numel()
+
+
+def _relative_error(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+) -> dict[str, float]:
+    difference = (actual.float() - expected.float()).abs()
+    expected_abs = expected.float().abs()
+    return {
+        "max_abs": float(difference.max().item()),
+        "mean_abs": float(difference.mean().item()),
+        "rmse": float(difference.square().mean().sqrt().item()),
+        "relative_l2": float(
+            difference.square().sum().sqrt().item()
+            / expected_abs.square().sum().sqrt().clamp_min(1.0).item()
+        ),
+    }
+
+
+@torch.inference_mode()
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--tp-size", type=_positive_int, default=2)
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument(
+        "--batch-sizes",
+        type=_positive_int,
+        nargs="+",
+        default=[1, 8, 16, 32, 64],
+    )
+    parser.add_argument("--top-k", type=_positive_int, nargs="+", default=[1, 20])
+    parser.add_argument("--candidates", type=_positive_int, default=128)
+    parser.add_argument(
+        "--candidate-tiles",
+        type=_candidate_tile,
+        nargs="+",
+        default=[1, 2, 4, 8],
+    )
+    parser.add_argument("--seeds", type=_positive_int, default=20)
+    parser.add_argument("--steps", type=_positive_int, default=40)
+    parser.add_argument("--warmup", type=int, default=8)
+    parser.add_argument("--trials", type=_positive_int, default=3)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    if not 0 <= args.tp_rank < args.tp_size:
+        raise ValueError("tp-rank must be in [0, tp-size)")
+    if args.warmup < 0:
+        raise ValueError("warmup must be non-negative")
+
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+    weight, vocab_start, weight_key = _load_weight_shard(
+        args.model_dir,
+        tp_size=args.tp_size,
+        tp_rank=args.tp_rank,
+        device=device,
+    )
+    local_vocab, hidden_size = weight.shape
+    if hidden_size % 32:
+        raise ValueError(f"hidden size must be divisible by 32, got {hidden_size}")
+    if max(args.top_k) > local_vocab:
+        raise ValueError("top-k exceeds the local vocabulary")
+    if args.candidates < max(args.top_k) or args.candidates > local_vocab:
+        raise ValueError("candidates must cover top-k and fit local vocabulary")
+
+    quant_start = torch.cuda.Event(enable_timing=True)
+    quant_end = torch.cuda.Event(enable_timing=True)
+    quant_start.record()
+    nvfp4_weight = _quantize_weight(weight)
+    quant_end.record()
+    quant_end.synchronize()
+    weight_quantize_us = quant_start.elapsed_time(quant_end) * 1000.0
+
+    payload: dict[str, object] = {
+        "standard": "nvfp4-b12x-coarse-bf16-refined-lm-head",
+        "model_dir": str(args.model_dir),
+        "weight_key": weight_key,
+        "tp_size": args.tp_size,
+        "tp_rank": args.tp_rank,
+        "vocab_start": vocab_start,
+        "shape": {"n_local": local_vocab, "k": hidden_size},
+        "backend": "b12x",
+        "candidates": args.candidates,
+        "greedy_integration": {
+            "path": "coarse+select+refine+indexed_argmax+tp_pair_reduce",
+            "tp_pair_reduce": "simulated_local_pair_gather",
+        },
+        "weight_quantize_us": weight_quantize_us,
+        "results": {},
+    }
+
+    for batch_size in args.batch_sizes:
+        generator = torch.Generator(device=device).manual_seed(20260828 + batch_size)
+        hidden = torch.randn(
+            (batch_size, hidden_size),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        hidden_q, hidden_scale, hidden_global_scale = _quantize_nvfp4(hidden)
+        batch_results: dict[str, object] = {}
+
+        native_linear_timing = _time_cuda_graph(
+            partial(_native_linear, hidden, weight),
+            steps=args.steps,
+            warmup=args.warmup,
+            trials=args.trials,
+        )
+        nvfp4_gemm_timing = _time_cuda_graph(
+            partial(
+                _nvfp4_mm,
+                hidden_q,
+                hidden_scale,
+                hidden_global_scale,
+                nvfp4_weight,
+            ),
+            steps=args.steps,
+            warmup=args.warmup,
+            trials=args.trials,
+        )
+        coarse_timing = _time_cuda_graph(
+            partial(_nvfp4_linear, hidden, nvfp4_weight),
+            steps=args.steps,
+            warmup=args.warmup,
+            trials=args.trials,
+        )
+        linear_speedup = float(native_linear_timing["median_us"]) / float(
+            nvfp4_gemm_timing["median_us"]
+        )
+
+        native_logits = _native_linear(hidden, weight)
+        coarse_logits = _nvfp4_linear(hidden, nvfp4_weight)
+        coarse_error = _relative_error(coarse_logits, native_logits)
+
+        selected_indices = torch.randint(
+            0,
+            local_vocab,
+            (batch_size, args.candidates),
+            dtype=torch.int64,
+            device=device,
+            generator=generator,
+        ).contiguous()
+        refined_logits = indexed_bf16_dot(hidden, weight, selected_indices)
+        refined_reference = torch.bmm(
+            hidden.unsqueeze(1),
+            weight[selected_indices].transpose(1, 2),
+        ).squeeze(1)
+        refine_error = _relative_error(refined_logits, refined_reference)
+
+        for top_k in args.top_k:
+            exact_rows = 0
+            candidate_hits = 0
+            candidate_total = 0
+            for seed in range(args.seeds):
+                seed_generator = torch.Generator(device=device).manual_seed(seed)
+                seed_hidden = torch.randn(
+                    (batch_size, hidden_size),
+                    dtype=torch.bfloat16,
+                    device=device,
+                    generator=seed_generator,
+                )
+                native_values, native_indices = _native_topk(
+                    seed_hidden,
+                    weight,
+                    top_k=top_k,
+                )
+                seed_coarse_logits = _nvfp4_linear(seed_hidden, nvfp4_weight)
+                seed_coarse_indices = select_lm_head_candidates(
+                    seed_coarse_logits,
+                    args.candidates,
+                )
+                _, refined_indices = _refine_selected_topk(
+                    seed_hidden,
+                    weight,
+                    seed_coarse_indices,
+                    top_k=top_k,
+                    candidate_tile=None,
+                )
+                del native_values
+                hits, total = _candidate_recall(
+                    native_indices,
+                    seed_coarse_indices,
+                )
+                candidate_hits += hits
+                candidate_total += total
+                exact_matches = (
+                    refined_indices.sort(dim=-1).values
+                    == native_indices.sort(dim=-1).values
+                )
+                if exact_matches.ndim > 1:
+                    exact_matches = exact_matches.all(dim=-1)
+                exact_rows += int(exact_matches.sum().item())
+
+            native_timing = _time_cuda_graph(
+                partial(_native_topk, hidden, weight, top_k=top_k),
+                steps=args.steps,
+                warmup=args.warmup,
+                trials=args.trials,
+            )
+            coarse_indices = select_lm_head_candidates(
+                coarse_logits,
+                args.candidates,
+            )
+            selector_timing = _time_cuda_graph(
+                partial(
+                    select_lm_head_candidates,
+                    coarse_logits,
+                    args.candidates,
+                ),
+                steps=args.steps,
+                warmup=args.warmup,
+                trials=args.trials,
+            )
+            native_us = float(native_timing["median_us"])
+            result = {
+                "exact_set_rows": exact_rows,
+                "rows_tested": args.seeds * batch_size,
+                "candidate_hits": candidate_hits,
+                "candidate_total": candidate_total,
+                "native": native_timing,
+                "selected_candidate_tile": _select_candidate_tile(
+                    batch_size,
+                    args.candidates,
+                    hidden_size,
+                ),
+                "components": {
+                    "selector": selector_timing,
+                },
+            }
+            hybrid_by_tile: dict[str, object] = {}
+            refine_by_tile: dict[str, object] = {}
+            greedy_integrated_by_tile: dict[str, object] = {}
+            for candidate_tile in args.candidate_tiles:
+                tile_label = (
+                    "auto" if candidate_tile is None else str(candidate_tile)
+                )
+                refine_timing = _time_cuda_graph(
+                    partial(
+                        _refine_selected_topk,
+                        hidden,
+                        weight,
+                        coarse_indices,
+                        top_k=top_k,
+                        candidate_tile=candidate_tile,
+                    ),
+                    steps=args.steps,
+                    warmup=args.warmup,
+                    trials=args.trials,
+                )
+                hybrid_timing = _time_cuda_graph(
+                    partial(
+                        _hybrid_topk,
+                        hidden,
+                        weight,
+                        nvfp4_weight,
+                        top_k=top_k,
+                        candidates=args.candidates,
+                        candidate_tile=candidate_tile,
+                    ),
+                    steps=args.steps,
+                    warmup=args.warmup,
+                    trials=args.trials,
+                )
+                if top_k == 1:
+                    integrated_exact_logits = indexed_bf16_dot(
+                        hidden,
+                        weight,
+                        coarse_indices,
+                        candidate_tile=candidate_tile,
+                    )
+                    integrated_values, integrated_indices = _candidate_indexed_argmax(
+                        integrated_exact_logits,
+                        coarse_indices,
+                        index_offset=vocab_start,
+                    )
+                    indexed_argmax_timing = _time_cuda_graph(
+                        partial(
+                            _candidate_indexed_argmax,
+                            integrated_exact_logits,
+                            coarse_indices,
+                            index_offset=vocab_start,
+                        ),
+                        steps=args.steps,
+                        warmup=args.warmup,
+                        trials=args.trials,
+                    )
+                    pair_reduce_timing = _time_cuda_graph(
+                        partial(
+                            _reduce_tp_pairs,
+                            integrated_values,
+                            integrated_indices,
+                            args.tp_size,
+                        ),
+                        steps=args.steps,
+                        warmup=args.warmup,
+                        trials=args.trials,
+                    )
+                    integrated_timing = _time_cuda_graph(
+                        partial(
+                            _hybrid_greedy_integrated,
+                            hidden,
+                            weight,
+                            nvfp4_weight,
+                            candidates=args.candidates,
+                            vocab_start=vocab_start,
+                            tp_size=args.tp_size,
+                            candidate_tile=candidate_tile,
+                        ),
+                        steps=args.steps,
+                        warmup=args.warmup,
+                        trials=args.trials,
+                    )
+                else:
+                    indexed_argmax_timing = None
+                    pair_reduce_timing = None
+                    integrated_timing = None
+                hybrid_us = float(hybrid_timing["median_us"])
+                refine_by_tile[tile_label] = refine_timing
+                hybrid_by_tile[tile_label] = {
+                    **hybrid_timing,
+                    "speedup": native_us / hybrid_us,
+                }
+                if integrated_timing is not None:
+                    integrated_us = float(integrated_timing["median_us"])
+                    greedy_integrated_by_tile[tile_label] = {
+                        **integrated_timing,
+                        "speedup": native_us / integrated_us,
+                        "overhead_vs_head_us": integrated_us - hybrid_us,
+                        "components": {
+                            "candidate_indexed_argmax": indexed_argmax_timing,
+                            "tp_pair_reduce_simulated": pair_reduce_timing,
+                        },
+                    }
+                    print(
+                        f"m={batch_size} top_k={top_k} tile={tile_label} "
+                        f"native={native_us:.3f}us hybrid={hybrid_us:.3f}us "
+                        f"hybrid_speedup={native_us / hybrid_us:.3f}x "
+                        f"integrated={integrated_us:.3f}us "
+                        f"integrated_speedup={native_us / integrated_us:.3f}x "
+                        f"integration_overhead={integrated_us - hybrid_us:.3f}us",
+                        flush=True,
+                    )
+            result["hybrid_by_tile"] = hybrid_by_tile
+            result["components"]["refine_by_tile"] = refine_by_tile
+            if greedy_integrated_by_tile:
+                result["greedy_integrated_by_tile"] = greedy_integrated_by_tile
+            batch_results[str(top_k)] = result
+            print(
+                f"m={batch_size} top_k={top_k} candidates={args.candidates} "
+                f"exact_set={exact_rows}/{args.seeds * batch_size} "
+                f"recall={candidate_hits}/{candidate_total} "
+                f"native_gemm={native_linear_timing['median_us']:.3f}us "
+                f"nvfp4_gemm={nvfp4_gemm_timing['median_us']:.3f}us "
+                f"gemm_speedup={linear_speedup:.3f}x "
+                f"auto_tile={result['selected_candidate_tile']}",
+                flush=True,
+            )
+
+        payload["results"][str(batch_size)] = {
+            "native_linear": native_linear_timing,
+            "nvfp4_gemm": nvfp4_gemm_timing,
+            "coarse": coarse_timing,
+            "gemm_speedup": linear_speedup,
+            "coarse_error": coarse_error,
+            "indexed_refine_error": refine_error,
+            "top_k": batch_results,
+        }
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernels/benchmark_hybrid_nvfp4_lm_head.py
+++ b/benchmarks/kernels/benchmark_hybrid_nvfp4_lm_head.py
@@ -1,28 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from statistics import median
+from typing import TypedDict
 
 import torch
 import torch.nn.functional as F
 from safetensors import safe_open
 
+from vllm.model_executor.layers.argmax_triton import (
+    indexed_argmax_triton,
+    reduce_global_argmax_triton,
+)
 from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
     _global_scale,
     _select_candidate_tile,
     indexed_bf16_dot,
     select_lm_head_candidates,
-)
-from vllm.model_executor.layers.argmax_triton import (
-    indexed_argmax_triton,
-    reduce_global_argmax_triton,
 )
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.flashinfer import (
@@ -45,12 +48,15 @@ class Nvfp4Weight:
     output_size: int
 
 
+class TimingResult(TypedDict):
+    median_us: float
+    samples_us: list[float]
+
+
 def _positive_int(value: str) -> int:
     parsed = int(value)
     if parsed <= 0:
-        raise argparse.ArgumentTypeError(
-            f"expected a positive integer, got {value}"
-        )
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value}")
     return parsed
 
 
@@ -59,9 +65,7 @@ def _candidate_tile(value: str) -> int | None:
         return None
     parsed = int(value)
     if parsed not in (1, 2, 4, 8):
-        raise argparse.ArgumentTypeError(
-            f"expected auto, 1, 2, 4, or 8, got {value}"
-        )
+        raise argparse.ArgumentTypeError(f"expected auto, 1, 2, 4, or 8, got {value}")
     return parsed
 
 
@@ -170,11 +174,7 @@ def _candidate_indexed_argmax(
     *,
     index_offset: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if (
-        HAS_TRITON
-        and exact_logits.is_cuda
-        and 0 < exact_logits.shape[-1] <= 1024
-    ):
+    if HAS_TRITON and exact_logits.is_cuda and 0 < exact_logits.shape[-1] <= 1024:
         return indexed_argmax_triton(
             exact_logits,
             candidate_indices,
@@ -293,7 +293,7 @@ def _time_cuda_graph(
     steps: int,
     warmup: int,
     trials: int,
-) -> dict[str, float | list[float]]:
+) -> TimingResult:
     outputs = function()
     torch.cuda.synchronize()
     del outputs
@@ -372,6 +372,18 @@ def main() -> int:
     parser.add_argument("--steps", type=_positive_int, default=40)
     parser.add_argument("--warmup", type=int, default=8)
     parser.add_argument("--trials", type=_positive_int, default=3)
+    parser.add_argument(
+        "--min-candidate-recall",
+        type=float,
+        default=None,
+        help="Fail if the measured candidate recall is below this fraction.",
+    )
+    parser.add_argument(
+        "--min-exact-rate",
+        type=float,
+        default=None,
+        help="Fail if the measured refined top-k exact rate is below this fraction.",
+    )
     parser.add_argument("--json-out", type=Path)
     args = parser.parse_args()
 
@@ -379,6 +391,10 @@ def main() -> int:
         raise ValueError("tp-rank must be in [0, tp-size)")
     if args.warmup < 0:
         raise ValueError("warmup must be non-negative")
+    for name in ("min_candidate_recall", "min_exact_rate"):
+        threshold = getattr(args, name)
+        if threshold is not None and not 0.0 <= threshold <= 1.0:
+            raise ValueError(f"{name.replace('_', '-')} must be in [0, 1]")
 
     device = torch.device("cuda:0")
     torch.cuda.set_device(device)
@@ -404,8 +420,9 @@ def main() -> int:
     quant_end.synchronize()
     weight_quantize_us = quant_start.elapsed_time(quant_end) * 1000.0
 
+    batch_results_by_size: dict[str, object] = {}
     payload: dict[str, object] = {
-        "standard": "nvfp4-b12x-coarse-bf16-refined-lm-head",
+        "standard": "approximate-nvfp4-b12x-coarse-bf16-refined-lm-head",
         "model_dir": str(args.model_dir),
         "weight_key": weight_key,
         "tp_size": args.tp_size,
@@ -419,8 +436,9 @@ def main() -> int:
             "tp_pair_reduce": "simulated_local_pair_gather",
         },
         "weight_quantize_us": weight_quantize_us,
-        "results": {},
+        "results": batch_results_by_size,
     }
+    quality_failures: list[str] = []
 
     for batch_size in args.batch_sizes:
         generator = torch.Generator(device=device).manual_seed(20260828 + batch_size)
@@ -560,13 +578,28 @@ def main() -> int:
                     "selector": selector_timing,
                 },
             }
+            candidate_recall = candidate_hits / candidate_total
+            exact_rate = exact_rows / (args.seeds * batch_size)
+            result["candidate_recall"] = candidate_recall
+            result["exact_rate"] = exact_rate
+            if (
+                args.min_candidate_recall is not None
+                and candidate_recall < args.min_candidate_recall
+            ):
+                quality_failures.append(
+                    f"m={batch_size} top_k={top_k} candidate recall "
+                    f"{candidate_recall:.6f} < {args.min_candidate_recall:.6f}"
+                )
+            if args.min_exact_rate is not None and exact_rate < args.min_exact_rate:
+                quality_failures.append(
+                    f"m={batch_size} top_k={top_k} exact rate "
+                    f"{exact_rate:.6f} < {args.min_exact_rate:.6f}"
+                )
             hybrid_by_tile: dict[str, object] = {}
             refine_by_tile: dict[str, object] = {}
             greedy_integrated_by_tile: dict[str, object] = {}
             for candidate_tile in args.candidate_tiles:
-                tile_label = (
-                    "auto" if candidate_tile is None else str(candidate_tile)
-                )
+                tile_label = "auto" if candidate_tile is None else str(candidate_tile)
                 refine_timing = _time_cuda_graph(
                     partial(
                         _refine_selected_topk,
@@ -689,7 +722,7 @@ def main() -> int:
                 flush=True,
             )
 
-        payload["results"][str(batch_size)] = {
+        batch_results_by_size[str(batch_size)] = {
             "native_linear": native_linear_timing,
             "nvfp4_gemm": nvfp4_gemm_timing,
             "coarse": coarse_timing,
@@ -699,10 +732,16 @@ def main() -> int:
             "top_k": batch_results,
         }
 
+    payload["quality_failures"] = quality_failures
+    if quality_failures:
+        print("Quality thresholds failed:", file=sys.stderr)
+        for failure in quality_failures:
+            print(f"- {failure}", file=sys.stderr)
+
     if args.json_out is not None:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
-    return 0
+    return int(bool(quality_failures))
 
 
 if __name__ == "__main__":

--- a/tests/kernels/test_hybrid_nvfp4_lm_head.py
+++ b/tests/kernels/test_hybrid_nvfp4_lm_head.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from tests.kernels.utils import opcheck
+from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="NVFP4 custom op requires CUDA"
+)
+def test_nvfp4_quantize_128x4_opcheck() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    if torch.cuda.get_device_capability()[0] < 12:
+        pytest.skip("NVFP4 b12x is only supported on SM120+")
+    if not has_flashinfer():
+        pytest.skip("FlashInfer is unavailable")
+
+    device = torch.device("cuda")
+    activations = torch.randn((128, 128), dtype=torch.bfloat16, device=device)
+    global_scale = torch.ones((), dtype=torch.float32, device=device)
+    opcheck(
+        torch.ops.vllm.flashinfer_nvfp4_quantize_128x4.default,
+        (activations, global_scale),
+    )

--- a/tests/model_executor/test_hybrid_nvfp4_lm_head.py
+++ b/tests/model_executor/test_hybrid_nvfp4_lm_head.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
     HybridNvfp4LmHead,
     _attach_state,
     release_hybrid_nvfp4_lm_head,
+    refresh_hybrid_nvfp4_lm_head,
     select_lm_head_candidates,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -77,6 +78,38 @@ class _TopKHybridState(_RecordingHybridState):
         return exact[:, : candidate_indices.shape[1]].expand(
             hidden_states.shape[0], -1
         )
+
+
+class _PenaltyAwareHybridState(_RecordingHybridState):
+    """Small state that exposes candidate ordering to the penalty test."""
+
+    def can_use(self, *args, **kwargs) -> bool:
+        self.can_use_called = True
+        return True
+
+    def candidate_count_for_topk(self, top_k: int) -> int:
+        del top_k
+        return 2
+
+    def coarse_logits(self, hidden_states, bias):
+        del bias
+        return torch.tensor(
+            [[5.0, 4.0, 3.0, 2.0]],
+            dtype=torch.bfloat16,
+            device=hidden_states.device,
+        ).expand(hidden_states.shape[0], -1)
+
+    def select_candidates(self, coarse_logits, *, top_k):
+        del top_k
+        return torch.argsort(
+            coarse_logits, dim=-1, descending=True, stable=True
+        )[:, :2]
+
+    def refine_logits(self, hidden_states, weight, candidate_indices, bias):
+        del hidden_states, weight, bias
+        # Match the coarse values so the only ordering change comes from the
+        # presence penalty applied before candidate selection.
+        return 5.0 - candidate_indices.to(torch.float32)
 
 
 def _make_lm_head(*, added_embeddings: int = 0) -> SimpleNamespace:
@@ -157,6 +190,25 @@ def test_tp_argmax_reduction_handles_ties_and_nan(monkeypatch, default_vllm_conf
     )
 
     assert torch.equal(result, torch.tensor([3, 4], dtype=torch.int64))
+
+
+def test_tp_argmax_reduction_all_negative_inf_prefers_lower_token_id(
+    monkeypatch, default_vllm_config
+):
+    processor = _make_processor()
+    gathered = torch.tensor([[-float("inf"), 7.0, -float("inf"), 3.0]])
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather",
+        lambda pair, dim: gathered,
+    )
+
+    result = processor.reduce_local_argmax(
+        torch.tensor([-float("inf"), -float("inf")]),
+        torch.tensor([7, 3]),
+        tp_size=2,
+    )
+
+    assert torch.equal(result, torch.tensor([3], dtype=torch.int64))
 
 
 def test_large_vocab_argmax_reduction_keeps_int64_ids(monkeypatch, default_vllm_config):
@@ -495,6 +547,83 @@ def test_tied_hybrid_state_releases_after_last_attachment():
     assert not hasattr(weight, "_hybrid_nvfp4_lm_head_shared_state")
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_refresh_hybrid_state_updates_derived_buffers_in_place(monkeypatch):
+    device = torch.device("cuda")
+    layer = nn.Module()
+    layer.weight = nn.Parameter(
+        torch.zeros((4, 4), dtype=torch.bfloat16, device=device),
+        requires_grad=False,
+    )
+    state = HybridNvfp4LmHead(
+        weight=torch.ones((4, 2), dtype=torch.uint8, device=device),
+        scale=torch.ones((4, 1), dtype=torch.float32, device=device),
+        global_scale=torch.ones((), dtype=torch.float32, device=device),
+        input_size=4,
+        output_size=4,
+        candidates=2,
+    )
+    _attach_state(layer, state)
+    old_ptrs = tuple(value.data_ptr() for value in (state.weight, state.scale))
+
+    def fake_quantize(weight):
+        assert weight is layer.weight
+        return (
+            torch.full_like(state.weight, 7),
+            torch.full_like(state.scale, 2.0),
+            torch.tensor(3.0, dtype=torch.float32, device=device),
+        )
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.hybrid_nvfp4_lm_head._quantize_lm_head_weight",
+        fake_quantize,
+    )
+
+    try:
+        assert refresh_hybrid_nvfp4_lm_head(layer, candidates=3)
+        assert tuple(
+            value.data_ptr() for value in (state.weight, state.scale)
+        ) == old_ptrs
+        assert torch.equal(state.weight, torch.full_like(state.weight, 7))
+        assert torch.equal(state.scale, torch.full_like(state.scale, 2.0))
+        assert torch.equal(
+            state.global_scale,
+            torch.tensor(3.0, dtype=torch.float32, device=device),
+        )
+        assert state.candidates == 3
+    finally:
+        release_hybrid_nvfp4_lm_head(layer)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_refresh_hybrid_state_releases_on_shape_change():
+    device = torch.device("cuda")
+    layer = nn.Module()
+    layer.weight = nn.Parameter(
+        torch.zeros((4, 4), dtype=torch.bfloat16, device=device),
+        requires_grad=False,
+    )
+    state = HybridNvfp4LmHead(
+        weight=torch.ones((4, 2), dtype=torch.uint8, device=device),
+        scale=torch.ones((4, 1), dtype=torch.float32, device=device),
+        global_scale=torch.ones((), dtype=torch.float32, device=device),
+        input_size=4,
+        output_size=4,
+        candidates=2,
+    )
+    _attach_state(layer, state)
+    layer.weight = nn.Parameter(
+        torch.zeros((5, 4), dtype=torch.bfloat16, device=device),
+        requires_grad=False,
+    )
+
+    assert not refresh_hybrid_nvfp4_lm_head(layer)
+    assert not hasattr(layer, "_hybrid_nvfp4_lm_head_state")
+    assert not hasattr(layer, "_hybrid_nvfp4_lm_head_weight")
+    assert not hasattr(layer, "_hybrid_nvfp4_lm_head_scale")
+    assert not hasattr(layer, "_hybrid_nvfp4_lm_head_global_scale")
+
+
 def test_hybrid_state_row_limit_fails_closed():
     state = HybridNvfp4LmHead(
         weight=torch.ones((4, 2), dtype=torch.uint8),
@@ -570,6 +699,32 @@ def test_presence_penalty_compact_helper_uses_unique_output_ids(default_vllm_con
     assert torch.equal(candidate_logits, torch.tensor([[3.5, 3.0]]))
 
 
+def test_presence_penalty_is_applied_before_hybrid_candidate_selection(
+    monkeypatch, default_vllm_config
+):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    state = _PenaltyAwareHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+
+    values, token_ids = processor.get_topk_candidates(
+        lm_head,
+        torch.zeros(1, 4, dtype=torch.bfloat16),
+        top_k=1,
+        top_p=1.0,
+        temperature=1.0,
+        presence_penalties=torch.tensor([3.0]),
+        output_token_ids=torch.tensor([[0, 1]], dtype=torch.int64),
+    )
+
+    # Without the pre-selection penalty, candidates would be [0, 1] and the
+    # result would remain token 0.  Applying it first admits token 2.
+    assert torch.equal(token_ids, torch.tensor([[2]], dtype=torch.int64))
+    assert torch.equal(values, torch.tensor([[3.0]]))
+    assert state.can_use_called
+
+
 def _sampling_gate_stub(
     *,
     temperature: float,
@@ -629,6 +784,24 @@ def test_sampling_gate_matches_supported_penalty_modes():
     sampler, input_batch = _sampling_gate_stub(
         temperature=0.7, top_k=8, top_p=0.9, frequency=0.1
     )
+    assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None
+
+
+def test_sampling_gate_keeps_presence_penalty_greedy_on_exact_path():
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.0, top_k=1, top_p=1.0, presence=0.5
+    )
+
+    # The current hybrid greedy implementation has no penalty metadata.  Do
+    # not silently ignore presence penalty by entering the approximate path.
+    assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None
+
+
+def test_sampling_gate_rejects_top_k_above_compact_limit():
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.7, top_k=65, top_p=1.0
+    )
+
     assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None
 
 

--- a/tests/model_executor/test_hybrid_nvfp4_lm_head.py
+++ b/tests/model_executor/test_hybrid_nvfp4_lm_head.py
@@ -6,9 +6,15 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import torch
+from torch import nn
 
 import vllm.envs as envs
-from vllm.model_executor.layers.hybrid_nvfp4_lm_head import select_lm_head_candidates
+from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+    HybridNvfp4LmHead,
+    _attach_state,
+    release_hybrid_nvfp4_lm_head,
+    select_lm_head_candidates,
+)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.warmup.hybrid_nvfp4_lm_head_warmup import _row_shapes
 from vllm.v1.worker.gpu.sample.sampler import Sampler
@@ -127,6 +133,15 @@ def test_candidate_fallback_uses_lower_index_for_ties():
     assert torch.equal(candidate_indices, torch.tensor([[0, 1], [0, 1]]))
 
 
+def test_candidate_selection_masks_nan_rows():
+    coarse_logits = torch.tensor([[float("nan"), 2.0, float("nan"), 1.0]])
+
+    candidate_indices = select_lm_head_candidates(coarse_logits, candidates=3)
+
+    assert torch.equal(candidate_indices, torch.tensor([[1, 3, 0]]))
+    assert torch.isneginf(coarse_logits[0, 0])
+
+
 def test_tp_argmax_reduction_handles_ties_and_nan(monkeypatch, default_vllm_config):
     processor = _make_processor()
     gathered = torch.tensor([[1.0, 7.0, 1.0, 3.0], [float("nan"), 5.0, 2.0, 4.0]])
@@ -144,6 +159,33 @@ def test_tp_argmax_reduction_handles_ties_and_nan(monkeypatch, default_vllm_conf
     assert torch.equal(result, torch.tensor([3, 4], dtype=torch.int64))
 
 
+def test_large_vocab_argmax_reduction_keeps_int64_ids(monkeypatch, default_vllm_config):
+    processor = LogitsProcessor(1 << 24)
+    gathered_values = torch.tensor([[2.0, 2.0], [float("nan"), -float("inf")]])
+    gathered_ids = torch.tensor(
+        [[1 << 24, (1 << 24) + 1], [1 << 24, 3]], dtype=torch.int64
+    )
+    calls = []
+
+    def gather(tensor, dim):
+        del dim
+        calls.append(tensor.dtype)
+        return gathered_values if tensor.dtype.is_floating_point else gathered_ids
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather",
+        gather,
+    )
+    result = processor.reduce_local_argmax(
+        torch.tensor([2.0, float("nan")]),
+        torch.tensor([1 << 24, 3], dtype=torch.int64),
+        tp_size=2,
+    )
+
+    assert calls == [torch.float32, torch.int64]
+    assert torch.equal(result, torch.tensor([1 << 24, 3], dtype=torch.int64))
+
+
 def test_head_dtype_mismatch_disables_hybrid_state(monkeypatch, default_vllm_config):
     processor = _make_processor()
     processor.head_dtype = torch.float32
@@ -154,6 +196,23 @@ def test_head_dtype_mismatch_disables_hybrid_state(monkeypatch, default_vllm_con
     processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
 
     monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+    hidden_states = torch.zeros(4, 4, dtype=torch.bfloat16)
+    top_tokens = processor.get_top_tokens(lm_head, hidden_states)
+
+    assert torch.equal(top_tokens, logits.argmax(dim=-1))
+    assert not state.can_use_called
+
+
+def test_nan_diagnostics_disables_hybrid_state(monkeypatch, default_vllm_config):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    state = _RecordingHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+    logits = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
+
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+    monkeypatch.setattr(envs, "VLLM_COMPUTE_NANS_IN_LOGITS", True)
     hidden_states = torch.zeros(4, 4, dtype=torch.bfloat16)
     top_tokens = processor.get_top_tokens(lm_head, hidden_states)
 
@@ -196,6 +255,46 @@ def test_mixed_prefill_row_mask_keeps_decode_rows_compact(
     result = processor.get_top_tokens(lm_head, hidden_states)
 
     assert torch.equal(result, torch.tensor([2, 7], dtype=torch.int64))
+    assert state.can_use_called
+
+
+def test_mixed_prefill_presence_rows_keep_exact_fallback(
+    monkeypatch, default_vllm_config
+):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    state = _FallbackHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+
+    def apply_head(_lm_head, states, _bias=None):
+        rows = []
+        for state in states:
+            if state[0] > 0:
+                rows.append([0.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0])
+            else:
+                rows.append([8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0])
+        return torch.tensor(rows, dtype=torch.float32)
+
+    processor._apply_head = apply_head  # type: ignore[method-assign]
+    processor.hybrid_lm_head_row_mask = torch.tensor([True, False])
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+
+    hidden_states = torch.zeros(2, 4, dtype=torch.bfloat16)
+    hidden_states[1, 0] = 1
+    values, token_ids = processor.get_topk_candidates(
+        lm_head,
+        hidden_states,
+        top_k=1,
+        top_p=1.0,
+        temperature=1.0,
+        presence_penalties=torch.tensor([0.5, 0.5]),
+        output_token_ids=torch.tensor([[5], [1]], dtype=torch.int64),
+    )
+
+    # The prompt row (row 1) must use the full head: the fake hybrid state
+    # never proposes token 1, while the exact row's top token is 1.
+    assert token_ids[1, 0] == 1
+    assert values[1, 0] == pytest.approx(9.5)
     assert state.can_use_called
 
 
@@ -244,12 +343,14 @@ def test_warmup_row_shapes_respect_memory_cap(monkeypatch, default_vllm_config):
     )
     worker = SimpleNamespace(vllm_config=config)
     monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS", 512)
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_ROWS", 512)
 
     assert _row_shapes(worker) == (1, 512)
 
     config.compilation_config.cudagraph_capture_sizes = []
     monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS", 128)
-    assert max(_row_shapes(worker)) <= 128
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_ROWS", 64)
+    assert max(_row_shapes(worker)) <= 64
 
 
 def test_sampler_workspace_warmup_handles_small_vocab():
@@ -259,6 +360,19 @@ def test_sampler_workspace_warmup_handles_small_vocab():
 
     # The production warmup uses top_k=20; clamp it for toy vocabularies used
     # by CPU/unit-test runners instead of indexing beyond the logits width.
+    sampler.warmup_top_k_top_p_buffer(8)
+
+
+def test_sampler_workspace_warmup_respects_byte_cap(monkeypatch):
+    sampler = object.__new__(Sampler)
+    sampler.device = torch.device("cpu")
+    sampler.sampling_states = SimpleNamespace(vocab_size=1024)
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_WARMUP_BYTES", 1024)
+
+    def fail_allocation(*args, **kwargs):
+        raise AssertionError("warmup allocation exceeded byte cap")
+
+    monkeypatch.setattr(torch, "zeros", fail_allocation)
     sampler.warmup_top_k_top_p_buffer(8)
 
 
@@ -327,6 +441,88 @@ def test_compact_topk_hybrid_widens_transient_candidates(
     assert torch.equal(values, torch.tensor([[4.0, 3.0]]))
 
 
+def test_compact_topk_tie_breaks_by_token_id(default_vllm_config):
+    processor = _make_processor()
+    values, token_ids = processor._select_compact_topk_values_ids(
+        torch.tensor([[1.0, 1.0, 0.0]]),
+        torch.tensor([[7, 3, 5]], dtype=torch.int64),
+        top_k=2,
+        top_p=1.0,
+    )
+    assert torch.equal(values, torch.tensor([[1.0, 1.0]]))
+    assert torch.equal(token_ids, torch.tensor([[3, 7]], dtype=torch.int64))
+
+
+def test_large_vocab_compact_selection_keeps_integer_ids(default_vllm_config):
+    processor = LogitsProcessor(1 << 24)
+    values, token_ids = processor._select_compact_topk_values_ids(
+        torch.tensor([[2.0, 2.0, 1.0]]),
+        torch.tensor([[1 << 24, (1 << 24) + 1, 3]], dtype=torch.int64),
+        top_k=2,
+        top_p=1.0,
+    )
+    assert torch.equal(
+        token_ids, torch.tensor([[1 << 24, (1 << 24) + 1]], dtype=torch.int64)
+    )
+
+
+def test_tied_hybrid_state_releases_after_last_attachment():
+    weight = torch.zeros((4, 4), dtype=torch.bfloat16)
+    layer_a = nn.Module()
+    layer_b = nn.Module()
+    layer_a.weight = weight
+    layer_b.weight = weight
+    state = HybridNvfp4LmHead(
+        weight=torch.ones((4, 2), dtype=torch.uint8),
+        scale=torch.ones((4, 1), dtype=torch.float32),
+        global_scale=torch.ones((), dtype=torch.float32),
+        input_size=4,
+        output_size=4,
+        candidates=2,
+    )
+    _attach_state(layer_a, state)
+    _attach_state(layer_b, state)
+    setattr(weight, "_hybrid_nvfp4_lm_head_shared_state", state)
+
+    assert release_hybrid_nvfp4_lm_head(layer_a) == 0
+    assert getattr(layer_b, "_hybrid_nvfp4_lm_head_state") is state
+    assert getattr(weight, "_hybrid_nvfp4_lm_head_shared_state") is state
+
+    released = release_hybrid_nvfp4_lm_head(layer_b)
+    assert released == (
+        state.weight.nbytes + state.scale.nbytes + state.global_scale.nbytes
+    )
+    assert not hasattr(weight, "_hybrid_nvfp4_lm_head_shared_state")
+
+
+def test_hybrid_state_row_limit_fails_closed():
+    state = HybridNvfp4LmHead(
+        weight=torch.ones((4, 2), dtype=torch.uint8),
+        scale=torch.ones((4, 1), dtype=torch.float32),
+        global_scale=torch.ones((), dtype=torch.float32),
+        input_size=4,
+        output_size=4,
+        candidates=2,
+        max_rows=2,
+    )
+    hidden_states = SimpleNamespace(
+        ndim=2,
+        dtype=torch.bfloat16,
+        is_cuda=True,
+        is_contiguous=lambda: True,
+        shape=(3, 4),
+        device=torch.device("cpu"),
+    )
+
+    assert not state.can_use(
+        hidden_states,
+        bf16_weight=torch.zeros((4, 4), dtype=torch.bfloat16),
+        active_vocab_size=4,
+        top_k=1,
+    )
+    assert state.can_use_failure_counts["rows_exceed_limit"] == 1
+
+
 def test_presence_penalty_compact_helper_uses_output_counts(default_vllm_config):
     processor = _make_processor()
     lm_head = _make_lm_head()
@@ -382,6 +578,7 @@ def _sampling_gate_stub(
     presence: float = 0.0,
     repetition: float = 1.0,
     frequency: float = 0.0,
+    explicit_seed: bool = False,
 ):
     sampler = SimpleNamespace(
         compute_nans=False,
@@ -395,7 +592,7 @@ def _sampling_gate_stub(
             top_p=SimpleNamespace(np=np.array([top_p], np.float32)),
             min_p=SimpleNamespace(np=np.array([0.0], np.float32)),
             max_num_logprobs=lambda _: NO_LOGPROBS,
-            any_explicit_seed=lambda _: False,
+            any_explicit_seed=lambda _: explicit_seed,
         ),
         logprob_token_ids_state=SimpleNamespace(max_num_token_ids=lambda _: 0),
         logit_bias_state=SimpleNamespace(use_logit_bias=np.array([False])),
@@ -434,6 +631,14 @@ def test_sampling_gate_matches_supported_penalty_modes():
     )
     assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None
 
+
+def test_sampling_gate_accepts_explicit_seed_for_keyed_fast_path():
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.7, top_k=8, top_p=0.9, explicit_seed=True
+    )
+    result = Sampler.get_vocab_parallel_sampling_params(sampler, input_batch)
+    assert result is not None and result[0] == "topk"
+
     sampler, input_batch = _sampling_gate_stub(temperature=0.7, top_k=128, top_p=1.0)
     result = Sampler.get_vocab_parallel_sampling_params(sampler, input_batch)
     assert result is not None and result[0] == "full"
@@ -443,4 +648,25 @@ def test_sampling_gate_matches_supported_penalty_modes():
     )
     # Presence-only penalties are not representable by unrestricted local
     # Gumbel-max; they must stay on the regular full-logits sampler.
+    assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None
+
+
+def test_sampling_gate_rejects_fp64_gumbel():
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.7, top_k=8, top_p=0.9
+    )
+    sampler.use_fp64_gumbel = True
+
+    assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None
+
+
+def test_sampling_gate_fails_closed_without_triton(monkeypatch):
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.7, top_k=8, top_p=0.9, explicit_seed=True
+    )
+    sampler.device = torch.device("cuda")
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.sample.sampler.HAS_TRITON", False
+    )
+
     assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None

--- a/tests/model_executor/test_hybrid_nvfp4_lm_head.py
+++ b/tests/model_executor/test_hybrid_nvfp4_lm_head.py
@@ -1,0 +1,446 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.model_executor.layers.hybrid_nvfp4_lm_head import select_lm_head_candidates
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.warmup.hybrid_nvfp4_lm_head_warmup import _row_shapes
+from vllm.v1.worker.gpu.sample.sampler import Sampler
+from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS
+
+
+class _RecordingHybridState:
+    def __init__(self) -> None:
+        self.can_use_called = False
+
+    def can_use(self, *args, **kwargs) -> bool:
+        self.can_use_called = True
+        return True
+
+
+class _FallbackHybridState(_RecordingHybridState):
+    def coarse_logits(self, hidden_states, bias):
+        return torch.zeros((hidden_states.shape[0], 8), dtype=torch.bfloat16)
+
+    def select_candidates(self, coarse_logits, *, top_k):
+        return torch.tensor([[5, 2, 7]], dtype=torch.int64).expand(
+            coarse_logits.shape[0], -1
+        )
+
+    def refine_logits(self, hidden_states, weight, candidate_indices, bias):
+        return torch.tensor([[1.0, 1.0, float("nan")]], dtype=torch.float32).expand(
+            hidden_states.shape[0], -1
+        )
+
+
+class _TopKHybridState(_RecordingHybridState):
+    def __init__(self) -> None:
+        super().__init__()
+        self.requested_top_k: list[int] = []
+
+    def can_use(self, *args, **kwargs) -> bool:
+        self.can_use_called = True
+        return True
+
+    def candidate_count_for_topk(self, top_k: int) -> int:
+        return 4 if top_k > 1 else 2
+
+    def coarse_logits(self, hidden_states, bias):
+        return torch.tensor(
+            [[8.0, 7.0, 6.0, 5.0, 1.0, 0.0, -1.0, -2.0]],
+            dtype=torch.bfloat16,
+        ).expand(hidden_states.shape[0], -1)
+
+    def select_candidates(self, coarse_logits, *, top_k):
+        self.requested_top_k.append(top_k)
+        count = self.candidate_count_for_topk(top_k)
+        return torch.arange(count, dtype=torch.int64).expand(
+            coarse_logits.shape[0], -1
+        )
+
+    def refine_logits(self, hidden_states, weight, candidate_indices, bias):
+        exact = torch.tensor(
+            [[0.0, 4.0, 3.0, 2.0]], dtype=torch.float32
+        )
+        return exact[:, : candidate_indices.shape[1]].expand(
+            hidden_states.shape[0], -1
+        )
+
+
+def _make_lm_head(*, added_embeddings: int = 0) -> SimpleNamespace:
+    vocab_size = 8
+    org_vocab_size = vocab_size - added_embeddings - (1 if added_embeddings else 0)
+    padded_org_vocab_size = org_vocab_size if not added_embeddings else 6
+    return SimpleNamespace(
+        weight=torch.zeros(vocab_size, 4, dtype=torch.bfloat16),
+        shard_indices=SimpleNamespace(
+            num_org_vocab_padding=padded_org_vocab_size - org_vocab_size,
+            num_elements_padded=vocab_size,
+            org_vocab_start_index=0,
+            padded_org_vocab_start_index=0,
+            padded_org_vocab_end_index=padded_org_vocab_size,
+            num_org_elements=org_vocab_size,
+            num_org_elements_padded=padded_org_vocab_size,
+            added_vocab_start_index=org_vocab_size,
+            added_vocab_end_index=org_vocab_size + added_embeddings,
+            padded_added_vocab_start_index=org_vocab_size,
+            num_added_elements=added_embeddings,
+        ),
+        num_added_embeddings=added_embeddings,
+        tp_size=1,
+    )
+
+
+def _make_processor() -> LogitsProcessor:
+    processor = LogitsProcessor(8)
+    processor.head_dtype = torch.bfloat16
+    return processor
+
+
+def test_batch_invariant_disables_hybrid_state(monkeypatch, default_vllm_config):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    state = _RecordingHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+    logits = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
+
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+    hidden_states = torch.zeros(4, 4, dtype=torch.bfloat16)
+    top_tokens = processor.get_top_tokens(lm_head, hidden_states)
+
+    assert torch.equal(top_tokens, logits.argmax(dim=-1))
+    assert not state.can_use_called
+
+
+def test_candidate_fallback_uses_lower_index_for_ties():
+    coarse_logits = torch.ones((2, 4), dtype=torch.float32)
+
+    candidate_indices = select_lm_head_candidates(coarse_logits, candidates=2)
+
+    assert torch.equal(candidate_indices, torch.tensor([[0, 1], [0, 1]]))
+
+
+def test_tp_argmax_reduction_handles_ties_and_nan(monkeypatch, default_vllm_config):
+    processor = _make_processor()
+    gathered = torch.tensor([[1.0, 7.0, 1.0, 3.0], [float("nan"), 5.0, 2.0, 4.0]])
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather",
+        lambda pair, dim: gathered,
+    )
+
+    result = processor.reduce_local_argmax(
+        torch.tensor([1.0, float("nan")]),
+        torch.tensor([7, 5]),
+        tp_size=2,
+    )
+
+    assert torch.equal(result, torch.tensor([3, 4], dtype=torch.int64))
+
+
+def test_head_dtype_mismatch_disables_hybrid_state(monkeypatch, default_vllm_config):
+    processor = _make_processor()
+    processor.head_dtype = torch.float32
+    lm_head = _make_lm_head()
+    state = _RecordingHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+    logits = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
+
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+    hidden_states = torch.zeros(4, 4, dtype=torch.bfloat16)
+    top_tokens = processor.get_top_tokens(lm_head, hidden_states)
+
+    assert torch.equal(top_tokens, logits.argmax(dim=-1))
+    assert not state.can_use_called
+
+
+def test_hybrid_fallback_argmax_is_stable_and_nan_safe(
+    monkeypatch, default_vllm_config
+):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    lm_head._hybrid_nvfp4_lm_head_state = _FallbackHybridState()
+    hidden_states = torch.zeros(2, 4, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+    result = processor.get_top_tokens(lm_head, hidden_states)
+
+    assert torch.equal(result, torch.full((2,), 2, dtype=torch.int64))
+
+
+def test_mixed_prefill_row_mask_keeps_decode_rows_compact(
+    monkeypatch, default_vllm_config
+):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    state = _FallbackHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+
+    def apply_head(_lm_head, states, _bias=None):
+        return torch.arange(states.shape[0] * 8, dtype=torch.float32).reshape(
+            states.shape[0], 8
+        )
+
+    processor._apply_head = apply_head  # type: ignore[method-assign]
+    processor.hybrid_lm_head_row_mask = torch.tensor([True, False])
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+
+    hidden_states = torch.zeros(2, 4, dtype=torch.bfloat16)
+    result = processor.get_top_tokens(lm_head, hidden_states)
+
+    assert torch.equal(result, torch.tensor([2, 7], dtype=torch.int64))
+    assert state.can_use_called
+
+
+def test_added_vocab_uses_layout_aware_path(monkeypatch, default_vllm_config):
+    processor = _make_processor()
+    lm_head = _make_lm_head(added_embeddings=2)
+    state = _RecordingHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+    logits = torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0, 100.0, 6.0, 7.0]]).expand(4, -1)
+    processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
+
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+    hidden_states = torch.zeros(4, 4, dtype=torch.bfloat16)
+    top_tokens = processor.get_top_tokens(lm_head, hidden_states)
+
+    assert torch.equal(top_tokens, torch.full((4,), 6, dtype=torch.int64))
+    assert not state.can_use_called
+
+
+def test_added_vocab_shard_metadata_disables_hybrid_without_layer_alias(
+    monkeypatch, default_vllm_config
+):
+    processor = _make_processor()
+    lm_head = _make_lm_head(added_embeddings=2)
+    # Older/custom heads may not expose num_added_embeddings on the module,
+    # while shard_indices still carries the authoritative layout.
+    del lm_head.num_added_embeddings
+    state = _RecordingHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+    logits = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
+
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", False)
+    hidden_states = torch.zeros(4, 4, dtype=torch.bfloat16)
+    top_tokens = processor.get_top_tokens(lm_head, hidden_states)
+
+    assert torch.equal(top_tokens, torch.full((4,), 6, dtype=torch.int64))
+    assert not state.can_use_called
+
+
+def test_warmup_row_shapes_respect_memory_cap(monkeypatch, default_vllm_config):
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_seqs=2048),
+        speculative_config=SimpleNamespace(num_speculative_tokens=2),
+        compilation_config=SimpleNamespace(cudagraph_capture_sizes=[1, 512, 1024]),
+    )
+    worker = SimpleNamespace(vllm_config=config)
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS", 512)
+
+    assert _row_shapes(worker) == (1, 512)
+
+    config.compilation_config.cudagraph_capture_sizes = []
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS", 128)
+    assert max(_row_shapes(worker)) <= 128
+
+
+def test_sampler_workspace_warmup_handles_small_vocab():
+    sampler = object.__new__(Sampler)
+    sampler.device = torch.device("cpu")
+    sampler.sampling_states = SimpleNamespace(vocab_size=16)
+
+    # The production warmup uses top_k=20; clamp it for toy vocabularies used
+    # by CPU/unit-test runners instead of indexing beyond the logits width.
+    sampler.warmup_top_k_top_p_buffer(8)
+
+
+def test_compact_topk_native_path_applies_top_p(monkeypatch, default_vllm_config):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    logits = torch.tensor(
+        [[5.0, 4.0, 1.0, 0.0, -1.0, -2.0, -3.0, -4.0]],
+        dtype=torch.bfloat16,
+    )
+    processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
+    hidden_states = torch.zeros(1, 4, dtype=torch.bfloat16)
+
+    values, token_ids = processor.get_topk_candidates(
+        lm_head,
+        hidden_states,
+        top_k=2,
+        top_p=0.7,
+        temperature=1.0,
+    )
+
+    assert torch.equal(token_ids, torch.tensor([[0, 1]], dtype=torch.int64))
+    assert values[0, 0] == 5.0
+    assert torch.isneginf(values[0, 1])
+
+
+def test_full_vocab_sampling_uses_local_gumbel_path(default_vllm_config):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    logits = torch.tensor(
+        [[5.0, 4.0, 1.0, 0.0, -1.0, -2.0, -3.0, -4.0]],
+        dtype=torch.bfloat16,
+    )
+    processor._apply_head = lambda *args: logits  # type: ignore[method-assign]
+    hidden_states = torch.zeros(1, 4, dtype=torch.bfloat16)
+
+    sampled = processor.sample_full_tokens(
+        lm_head,
+        hidden_states,
+        temperature=0.7,
+    )
+
+    assert sampled.shape == (1,)
+    assert 0 <= int(sampled[0]) < 8
+
+
+def test_compact_topk_hybrid_widens_transient_candidates(
+    monkeypatch, default_vllm_config
+):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    state = _TopKHybridState()
+    lm_head._hybrid_nvfp4_lm_head_state = state
+    hidden_states = torch.zeros(1, 4, dtype=torch.bfloat16)
+
+    values, token_ids = processor.get_topk_candidates(
+        lm_head,
+        hidden_states,
+        top_k=2,
+        top_p=1.0,
+        temperature=1.0,
+    )
+
+    assert state.requested_top_k == [2]
+    assert torch.equal(token_ids, torch.tensor([[1, 2]], dtype=torch.int64))
+    assert torch.equal(values, torch.tensor([[4.0, 3.0]]))
+
+
+def test_presence_penalty_compact_helper_uses_output_counts(default_vllm_config):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    logits = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.float32)
+    counts = torch.tensor([[0, 1, 0, 2]], dtype=torch.int32)
+    penalties = torch.tensor([0.5], dtype=torch.float32)
+    request_indices = torch.tensor([0], dtype=torch.int64)
+
+    processor._apply_presence_penalty_from_counts(
+        logits,
+        penalties,
+        counts,
+        request_indices,
+        shard_indices=lm_head.shard_indices,
+    )
+
+    assert torch.equal(logits, torch.tensor([[1.0, 1.5, 3.0, 3.5]]))
+
+
+def test_presence_penalty_compact_helper_uses_unique_output_ids(default_vllm_config):
+    processor = _make_processor()
+    lm_head = _make_lm_head()
+    logits = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.float32)
+    output_token_ids = torch.tensor([[1, 3, 8]], dtype=torch.int64)
+    penalties = torch.tensor([0.5], dtype=torch.float32)
+
+    processor._apply_presence_penalty_from_token_ids(
+        logits,
+        penalties,
+        output_token_ids,
+        shard_indices=lm_head.shard_indices,
+    )
+
+    assert torch.equal(logits, torch.tensor([[1.0, 1.5, 3.0, 3.5]]))
+
+    candidate_logits = torch.tensor([[4.0, 3.0]], dtype=torch.float32)
+    candidate_ids = torch.tensor([[3, 6]], dtype=torch.int64)
+    processor._apply_presence_penalty_from_token_ids(
+        candidate_logits,
+        penalties,
+        output_token_ids,
+        shard_indices=lm_head.shard_indices,
+        local_token_ids=candidate_ids,
+    )
+    assert torch.equal(candidate_logits, torch.tensor([[3.5, 3.0]]))
+
+
+def _sampling_gate_stub(
+    *,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    presence: float = 0.0,
+    repetition: float = 1.0,
+    frequency: float = 0.0,
+):
+    sampler = SimpleNamespace(
+        compute_nans=False,
+        return_sampling_mask=False,
+        trace_replay_state=None,
+        use_fp64_gumbel=False,
+        sampling_states=SimpleNamespace(
+            vocab_size=128,
+            temperature=SimpleNamespace(np=np.array([temperature], np.float32)),
+            top_k=SimpleNamespace(np=np.array([top_k], np.int32)),
+            top_p=SimpleNamespace(np=np.array([top_p], np.float32)),
+            min_p=SimpleNamespace(np=np.array([0.0], np.float32)),
+            max_num_logprobs=lambda _: NO_LOGPROBS,
+            any_explicit_seed=lambda _: False,
+        ),
+        logprob_token_ids_state=SimpleNamespace(max_num_token_ids=lambda _: 0),
+        logit_bias_state=SimpleNamespace(use_logit_bias=np.array([False])),
+        bad_words_state=SimpleNamespace(
+            num_bad_words=SimpleNamespace(np=np.array([0], np.int32))
+        ),
+        thinking_budget_state=SimpleNamespace(enabled=False),
+        penalties_state=SimpleNamespace(
+            use_penalty=np.array(
+                [presence != 0.0 or repetition != 1.0 or frequency != 0.0]
+            ),
+            repetition_penalty=SimpleNamespace(np=np.array([repetition], np.float32)),
+            frequency_penalty=SimpleNamespace(np=np.array([frequency], np.float32)),
+        ),
+    )
+    input_batch = SimpleNamespace(idx_mapping_np=np.array([0], np.int32))
+    return sampler, input_batch
+
+
+def test_sampling_gate_matches_supported_penalty_modes():
+    sampler, input_batch = _sampling_gate_stub(temperature=0.7, top_k=8, top_p=0.9)
+    result = Sampler.get_vocab_parallel_sampling_params(sampler, input_batch)
+    assert result is not None
+    assert result[0] == "topk" and result[1] == 8 and not result[-1]
+    assert result[2] == pytest.approx(0.9)
+    assert result[3] == pytest.approx(0.7)
+
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.7, top_k=8, top_p=0.9, presence=0.5
+    )
+    result = Sampler.get_vocab_parallel_sampling_params(sampler, input_batch)
+    assert result is not None and result[0] == "topk" and result[-1]
+
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.7, top_k=8, top_p=0.9, frequency=0.1
+    )
+    assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None
+
+    sampler, input_batch = _sampling_gate_stub(temperature=0.7, top_k=128, top_p=1.0)
+    result = Sampler.get_vocab_parallel_sampling_params(sampler, input_batch)
+    assert result is not None and result[0] == "full"
+
+    sampler, input_batch = _sampling_gate_stub(
+        temperature=0.7, top_k=128, top_p=1.0, presence=0.5
+    )
+    # Presence-only penalties are not representable by unrestricted local
+    # Gumbel-max; they must stay on the regular full-logits sampler.
+    assert Sampler.get_vocab_parallel_sampling_params(sampler, input_batch) is None

--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
+
+import pytest
+import torch
 
 
 def test_qwen3_5_lm_head_receives_quant_config():
@@ -76,3 +80,75 @@ def test_qwen3_5_mtp_lm_head_receives_quant_config():
         MockLMHead.assert_called_once()
         call_kwargs = MockLMHead.call_args.kwargs
         assert call_kwargs["quant_config"] is mock_quant_config
+
+
+@pytest.mark.parametrize(
+    "incompatible_reason",
+    (
+        "lora",
+        "head_dtype",
+        "batch_invariant",
+        "nan_diagnostics",
+        "adaptive",
+        "added_vocab",
+        "large_vocab",
+    ),
+)
+def test_qwen3_5_does_not_prepare_hybrid_state_for_incompatible_config(
+    monkeypatch, incompatible_reason
+):
+    from vllm.model_executor.models.qwen3_5 import Qwen3_5ForCausalLMBase
+
+    hf_config = SimpleNamespace(
+        tie_word_embeddings=False,
+        vocab_size=128,
+        hidden_size=64,
+    )
+    model_config = SimpleNamespace(
+        hf_text_config=hf_config,
+        head_dtype=torch.bfloat16,
+        dtype=torch.bfloat16,
+    )
+    speculative_config = SimpleNamespace(enable_adaptive_verification=False)
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        cache_config=SimpleNamespace(mamba_cache_mode="align"),
+        scheduler_config=SimpleNamespace(),
+        quant_config=Mock(),
+        lora_config=None,
+        speculative_config=speculative_config,
+    )
+    if incompatible_reason == "lora":
+        vllm_config.lora_config = object()
+    elif incompatible_reason == "head_dtype":
+        model_config.head_dtype = torch.float32
+    elif incompatible_reason == "batch_invariant":
+        monkeypatch.setattr("vllm.envs.VLLM_BATCH_INVARIANT", True)
+    elif incompatible_reason == "nan_diagnostics":
+        monkeypatch.setattr("vllm.envs.VLLM_COMPUTE_NANS_IN_LOGITS", True)
+    elif incompatible_reason == "adaptive":
+        speculative_config.enable_adaptive_verification = True
+    elif incompatible_reason == "added_vocab":
+        # ParallelLMHead reports added embeddings after construction below.
+        pass
+    elif incompatible_reason == "large_vocab":
+        hf_config.vocab_size = 1 << 24
+
+    pp_group = SimpleNamespace(is_last_rank=True)
+    with (
+        patch("vllm.model_executor.models.qwen3_5.Qwen3_5Model") as MockModel,
+        patch("vllm.model_executor.models.qwen3_5.ParallelLMHead") as MockLMHead,
+        patch("vllm.model_executor.models.qwen3_5.LogitsProcessor"),
+        patch(
+            "vllm.model_executor.models.qwen3_5.get_pp_group",
+            return_value=pp_group,
+        ),
+    ):
+        MockModel.return_value.make_empty_intermediate_tensors = Mock()
+        MockLMHead.return_value.num_added_embeddings = (
+            1 if incompatible_reason == "added_vocab" else 0
+        )
+
+        Qwen3_5ForCausalLMBase(vllm_config=vllm_config)
+
+        assert not MockLMHead.return_value._supports_hybrid_nvfp4_lm_head

--- a/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm.config.model import PROCESSED_LOGPROBS_MODES, LogprobsMode
 from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.spec_decode import rejection_sampler as rejection_sampler_module
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
     RejectionSampler,
     _iter_request_chunks,
@@ -24,6 +25,53 @@ def test_iter_request_chunks_preserves_request_boundaries():
         (2, 3),
         (3, 4),
     ]
+
+
+def test_compact_topk_candidate_sampling_cpu(monkeypatch):
+    """Compact MTP verification must preserve draft/bonus row semantics."""
+    input_batch = SimpleNamespace(
+        num_reqs=1,
+        num_draft_tokens=1,
+        num_draft_tokens_per_req=np.array([1], dtype=np.int32),
+        cu_num_logits_np=np.array([0, 2], dtype=np.int32),
+        cu_num_logits=torch.tensor([0, 2], dtype=torch.int32),
+        input_ids=torch.tensor([0, 2], dtype=torch.int64),
+        logits_indices=torch.tensor([0, 1], dtype=torch.int64),
+        seq_lens=torch.tensor([2], dtype=torch.int32),
+        idx_mapping=torch.tensor([0], dtype=torch.int32),
+    )
+    sampler = object.__new__(RejectionSampler)
+    sampler.num_speculative_steps = 1
+    sampler.synthetic_conditional_rates = None
+    sampler.use_block_verification = False
+    sampler.sampler = SimpleNamespace(
+        req_states=SimpleNamespace(
+            prefill_len=SimpleNamespace(gpu=torch.tensor([0], dtype=torch.int32))
+        )
+    )
+    monkeypatch.setattr(
+        rejection_sampler_module,
+        "get_num_sampled_and_rejected",
+        lambda num_sampled, *_args: (
+            num_sampled,
+            torch.zeros_like(num_sampled),
+        ),
+    )
+
+    candidate_logits = torch.tensor(
+        [[3.0, 2.0, 1.0], [1.0, 0.0, -float("inf")]], dtype=torch.float32
+    )
+    candidate_ids = torch.tensor([[0, 1, 3], [4, 5, 6]], dtype=torch.int64)
+    output = sampler.sample_from_topk_candidates(
+        candidate_logits, candidate_ids, input_batch
+    )
+
+    assert output.sampled_token_ids.shape == (1, 2)
+    assert int(output.sampled_token_ids[0, 0]) in {0, 1, 3}
+    # The draft id (2) is absent from the compact target set, so it is
+    # rejected and no bonus token is emitted for this request.
+    assert int(output.sampled_token_ids[0, 1]) == -1
+    assert output.num_sampled.tolist() == [1]
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")

--- a/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
@@ -75,6 +75,26 @@ def test_compact_topk_candidate_sampling_cpu(monkeypatch):
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+def test_compact_rejection_indices_match_interleaved_layout():
+    """The fused index builder must remove exactly one bonus row per request."""
+    device = torch.device("cuda")
+    # Requests contain 0, 3 and 1 draft rows respectively, followed by one
+    # bonus row in the candidate layout.
+    cu_num_logits = torch.tensor([0, 1, 5, 7], dtype=torch.int32, device=device)
+    target_indices, bonus_indices = (
+        rejection_sampler_module._prepare_compact_rejection_indices(
+            cu_num_logits,
+            num_draft_tokens=4,
+            num_reqs=3,
+            device=device,
+        )
+    )
+    torch.cuda.synchronize()
+    assert target_indices.cpu().tolist() == [1, 2, 3, 5]
+    assert bonus_indices.cpu().tolist() == [0, 4, 6]
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
 @pytest.mark.parametrize("logprobs_mode", get_args(LogprobsMode))
 def test_chunked_scores_match_full_batch(logprobs_mode: str):
     device = torch.device("cuda")

--- a/tests/v1/worker/test_hybrid_nvfp4_lm_head_runner.py
+++ b/tests/v1/worker/test_hybrid_nvfp4_lm_head_runner.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+import vllm.envs as envs
+from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+    HybridNvfp4LmHead,
+    _attach_state,
+)
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner as V2GPUModelRunner
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner as LegacyGPUModelRunner
+
+
+def _legacy_runner_stub(
+    *,
+    top_k: int = 8,
+    top_p: float = 0.9,
+    temperature: float = 0.7,
+    presence: float = 0.0,
+    repetition: float = 1.0,
+    frequency: float = 0.0,
+    num_reqs: int = 1,
+):
+    sampling_metadata = SimpleNamespace(
+        all_random=True,
+        generators=[],
+        no_penalties=(
+            presence == 0.0 and repetition == 1.0 and frequency == 0.0
+        ),
+        max_num_logprobs=None,
+        logprob_token_ids=[],
+        allowed_token_ids_mask=None,
+        bad_words_token_ids=[],
+        logitsprocs=SimpleNamespace(all=[]),
+    )
+    input_batch = SimpleNamespace(
+        num_reqs=num_reqs,
+        sampling_metadata=sampling_metadata,
+        top_k_cpu=np.full(num_reqs, top_k, dtype=np.int32),
+        top_p_cpu=np.full(num_reqs, top_p, dtype=np.float32),
+        temperature_cpu=np.full(num_reqs, temperature, dtype=np.float32),
+        repetition_penalties_cpu=np.full(num_reqs, repetition, dtype=np.float32),
+        frequency_penalties_cpu=np.full(num_reqs, frequency, dtype=np.float32),
+        presence_penalties_cpu=np.full(num_reqs, presence, dtype=np.float32),
+    )
+    lm_head = SimpleNamespace(
+        num_added_embeddings=0,
+        shard_indices=SimpleNamespace(num_added_elements=0),
+        _hybrid_nvfp4_lm_head_state=object(),
+    )
+    return SimpleNamespace(
+        input_batch=input_batch,
+        model_config=SimpleNamespace(head_dtype=torch.bfloat16),
+        dtype=torch.bfloat16,
+        lora_config=None,
+        sampler=SimpleNamespace(use_fp64_gumbel=False, logprobs_mode=None),
+        model=SimpleNamespace(lm_head=lm_head, sample_topk_tokens=Mock()),
+        broadcast_pp_output=False,
+        vocab_size=128,
+    )
+
+
+def test_legacy_topk_gate_rejects_fp64_gumbel(monkeypatch):
+    runner = _legacy_runner_stub()
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD", True)
+    runner.sampler.use_fp64_gumbel = True
+
+    assert (
+        LegacyGPUModelRunner._get_hybrid_topk_sampling_params(
+            runner, SimpleNamespace(has_structured_output_requests=False), None
+        )
+        is None
+    )
+
+
+def test_legacy_topk_gate_accepts_presence_only_and_rejects_other_penalties(
+    monkeypatch,
+):
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD", True)
+    runner = _legacy_runner_stub(presence=0.5)
+    params = LegacyGPUModelRunner._get_hybrid_topk_sampling_params(
+        runner, SimpleNamespace(has_structured_output_requests=False), None
+    )
+    assert params == (8, pytest.approx(0.9), pytest.approx(0.7), True)
+
+    runner = _legacy_runner_stub(frequency=0.1)
+    assert (
+        LegacyGPUModelRunner._get_hybrid_topk_sampling_params(
+            runner, SimpleNamespace(has_structured_output_requests=False), None
+        )
+        is None
+    )
+
+    runner = _legacy_runner_stub(repetition=1.1)
+    assert (
+        LegacyGPUModelRunner._get_hybrid_topk_sampling_params(
+            runner, SimpleNamespace(has_structured_output_requests=False), None
+        )
+        is None
+    )
+
+
+def test_legacy_presence_output_table_deduplicates_and_filters_invalid_ids(
+    monkeypatch,
+):
+    # Keep this metadata-only test runnable on a CPU-only CI worker even when
+    # the process was configured with the CUDA target device.
+    monkeypatch.setattr("vllm.v1.worker.gpu_model_runner.PIN_MEMORY", False)
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(
+            num_reqs=2,
+            num_prompt_tokens=np.array([2, 1], dtype=np.int32),
+            num_tokens_no_spec=np.array([8, 6], dtype=np.int32),
+            token_ids_cpu=np.array(
+                [
+                    [90, 91, 5, 5, 7, -1, 128, 9],
+                    [92, 3, 4, 3, 6, 6, 0, 0],
+                ],
+                dtype=np.int64,
+            ),
+        ),
+        vocab_size=128,
+    )
+
+    output_ids = LegacyGPUModelRunner._make_hybrid_presence_output_token_ids(
+        runner, torch.zeros((2, 4), dtype=torch.bfloat16)
+    )
+
+    assert torch.equal(
+        output_ids,
+        torch.tensor([[5, 7, 9], [3, 4, 6]], dtype=torch.int64),
+    )
+
+
+def test_legacy_presence_output_table_rejects_chunked_prefill_rows():
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(
+            num_reqs=2,
+            num_prompt_tokens=np.array([0, 0], dtype=np.int32),
+            num_tokens_no_spec=np.array([1, 1], dtype=np.int32),
+            token_ids_cpu=np.zeros((2, 1), dtype=np.int64),
+        ),
+        vocab_size=128,
+    )
+
+    assert (
+        LegacyGPUModelRunner._make_hybrid_presence_output_token_ids(
+            runner, torch.zeros((3, 4), dtype=torch.bfloat16)
+        )
+        is None
+    )
+
+
+class _FakeV2Model(nn.Module):
+    def __init__(self, *, state: object | None = object()) -> None:
+        super().__init__()
+        self.lm_head = nn.Module()
+        self.lm_head.num_added_embeddings = 0
+        self.lm_head.shard_indices = SimpleNamespace(num_added_elements=0)
+        self.lm_head._hybrid_nvfp4_lm_head_state = state
+        self.topk_calls: list[dict[str, object]] = []
+        self.greedy_calls = 0
+        self.compute_logits_calls = 0
+
+    def sample_topk_tokens(self, hidden_states, **kwargs):
+        self.topk_calls.append({"hidden_states": hidden_states, **kwargs})
+        return torch.arange(hidden_states.shape[0], dtype=torch.int64)
+
+    def get_top_tokens(self, hidden_states):
+        self.greedy_calls += 1
+        return torch.full((hidden_states.shape[0],), 7, dtype=torch.int64)
+
+    def compute_logits(self, hidden_states):
+        self.compute_logits_calls += 1
+        return torch.zeros((hidden_states.shape[0], 8), dtype=torch.float32)
+
+
+class _FakeV2Sampler:
+    def __init__(self, params, *, presence_inputs=None):
+        self.params = params
+        self.presence_inputs = presence_inputs
+        self.sampling_states = SimpleNamespace(
+            seeds=SimpleNamespace(gpu=torch.tensor([123, 456], dtype=torch.int64)),
+            temperature=SimpleNamespace(gpu=torch.tensor([0.7, 0.7])),
+        )
+        self.make_calls = []
+        self.fallback_calls = 0
+
+    def get_vocab_parallel_sampling_params(self, _input_batch):
+        return self.params
+
+    def get_vocab_parallel_presence_inputs(self, _input_batch):
+        assert self.presence_inputs is not None
+        return self.presence_inputs
+
+    def make_sampler_output(self, sampled, _input_batch):
+        self.make_calls.append(sampled)
+        return SimpleNamespace(
+            sampled_token_ids=sampled,
+            num_sampled=torch.ones(sampled.shape[0], dtype=torch.int64),
+            num_rejected=torch.zeros(sampled.shape[0], dtype=torch.int64),
+        )
+
+    def __call__(self, _logits, _input_batch):
+        self.fallback_calls += 1
+        return SimpleNamespace(
+            sampled_token_ids=torch.tensor([[2]], dtype=torch.int64),
+            num_sampled=torch.ones(1, dtype=torch.int64),
+            num_rejected=torch.zeros(1, dtype=torch.int64),
+        )
+
+
+def _v2_input_batch(num_rows: int = 2):
+    return SimpleNamespace(
+        logits_indices=torch.arange(num_rows, dtype=torch.int64),
+        num_reqs=num_rows,
+        num_draft_tokens=0,
+        expanded_idx_mapping=torch.arange(num_rows, dtype=torch.int64),
+        positions=torch.arange(10, 10 + num_rows, dtype=torch.int64),
+        has_structured_output_reqs=False,
+    )
+
+
+def _v2_runner(model, sampler):
+    return SimpleNamespace(
+        model=model,
+        sampler=sampler,
+        batch_sharder=None,
+        lora_config=None,
+        adaptive_verification=None,
+        model_config=SimpleNamespace(head_dtype=torch.bfloat16),
+        dtype=torch.bfloat16,
+        vocab_size=128,
+        device=torch.device("cpu"),
+        rejection_sampler=None,
+        speculator=None,
+    )
+
+
+def test_v2_topk_presence_dispatch_passes_persistent_metadata(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD", True)
+    sampler = _FakeV2Sampler(
+        ("topk", 8, 0.9, 0.7, True),
+        presence_inputs=(
+            torch.tensor([0.5, 0.5]),
+            torch.tensor([[1, 0, 0], [0, 2, 0]], dtype=torch.int32),
+            torch.tensor([0, 1], dtype=torch.int64),
+        ),
+    )
+    model = _FakeV2Model()
+    runner = _v2_runner(model, sampler)
+
+    output, _, _ = V2GPUModelRunner.sample(
+        runner,
+        torch.zeros((2, 4), dtype=torch.bfloat16),
+        _v2_input_batch(),
+        grammar_output=None,
+    )
+
+    assert len(model.topk_calls) == 1
+    call = model.topk_calls[0]
+    assert torch.equal(call["presence_penalties"], torch.tensor([0.5, 0.5]))
+    assert torch.equal(
+        call["output_token_counts"],
+        torch.tensor([[1, 0, 0], [0, 2, 0]], dtype=torch.int32),
+    )
+    assert torch.equal(
+        call["presence_request_indices"], torch.tensor([0, 1], dtype=torch.int64)
+    )
+    assert output.sampled_token_ids.tolist() == [0, 1]
+
+
+def test_v2_greedy_speculative_dispatch_uses_target_fast_path(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD", True)
+    sampler = _FakeV2Sampler(("greedy", 128, 1.0, 0.0, False))
+    rejection_sampler = Mock()
+    rejection_sampler.draft_logits = None
+    rejection_sampler.synthetic_conditional_rates = None
+    rejection_sampler.use_block_verification = False
+    rejection_sampler.sample_from_greedy_tokens.return_value = SimpleNamespace(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int64),
+        num_sampled=torch.ones(1, dtype=torch.int64),
+        num_rejected=torch.zeros(1, dtype=torch.int64),
+    )
+    model = _FakeV2Model()
+    runner = _v2_runner(model, sampler)
+    runner.rejection_sampler = rejection_sampler
+    runner.speculator = SimpleNamespace(draft_logits=None)
+    input_batch = _v2_input_batch(1)
+    input_batch.num_draft_tokens = 2
+
+    output, _, _ = V2GPUModelRunner.sample(
+        runner,
+        torch.zeros((1, 4), dtype=torch.bfloat16),
+        input_batch,
+        grammar_output=None,
+    )
+
+    assert model.greedy_calls == 1
+    rejection_sampler.sample_from_greedy_tokens.assert_called_once()
+    assert output.sampled_token_ids.tolist() == [[7]]
+
+
+def test_v2_incompatible_runtime_config_releases_hybrid_state(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_HYBRID_NVFP4_LM_HEAD", True)
+    monkeypatch.setattr(envs, "VLLM_COMPUTE_NANS_IN_LOGITS", True)
+    model = _FakeV2Model(state=None)
+    state = HybridNvfp4LmHead(
+        weight=torch.ones((4, 2), dtype=torch.uint8),
+        scale=torch.ones((4, 1), dtype=torch.float32),
+        global_scale=torch.ones((), dtype=torch.float32),
+        input_size=4,
+        output_size=4,
+        candidates=2,
+    )
+    model.lm_head.weight = torch.zeros((4, 4), dtype=torch.bfloat16)
+    _attach_state(model.lm_head, state)
+    sampler = _FakeV2Sampler(None)
+    runner = _v2_runner(model, sampler)
+
+    output, _, _ = V2GPUModelRunner.sample(
+        runner,
+        torch.zeros((1, 4), dtype=torch.bfloat16),
+        _v2_input_batch(1),
+        grammar_output=None,
+    )
+
+    assert not hasattr(model.lm_head, "_hybrid_nvfp4_lm_head_state")
+    assert model.compute_logits_calls == 1
+    assert sampler.fallback_calls == 1
+    assert output.sampled_token_ids.tolist() == [[2]]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -191,6 +191,8 @@ if TYPE_CHECKING:
     VLLM_HUMMING_MOE_GEMM_TYPE: Literal["indexed", "grouped", "auto"] | None = None
     VLLM_B12X_MOE_FP4_FORCE_A16: bool = False
     VLLM_DEEPEPLL_NVFP4_DISPATCH: bool = False
+    VLLM_HYBRID_NVFP4_LM_HEAD: bool = False
+    VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES: int = 128
     VLLM_V1_USE_OUTLINES_CACHE: bool = False
     VLLM_TPU_USING_PATHWAYS: bool = False
     VLLM_USE_DEEP_GEMM: bool = True
@@ -849,6 +851,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, vllm will trace function calls
     # Useful for debugging
     "VLLM_TRACE_FUNCTION": lambda: int(os.getenv("VLLM_TRACE_FUNCTION", "0")),
+    "VLLM_HYBRID_NVFP4_LM_HEAD": lambda: bool(
+        int(os.getenv("VLLM_HYBRID_NVFP4_LM_HEAD", "0"))
+    ),
+    "VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES": lambda: int(
+        os.getenv("VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES", "128")
+    ),
     # Whether to use the FlashInfer top-k / top-p sampler on CUDA. Enabled
     # by default when the hardware supports it — set to 0 to opt out
     # explicitly, which forces the PyTorch-native (Triton for bs>=8) path.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -193,6 +193,7 @@ if TYPE_CHECKING:
     VLLM_DEEPEPLL_NVFP4_DISPATCH: bool = False
     VLLM_HYBRID_NVFP4_LM_HEAD: bool = False
     VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES: int = 128
+    VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS: int = 512
     VLLM_V1_USE_OUTLINES_CACHE: bool = False
     VLLM_TPU_USING_PATHWAYS: bool = False
     VLLM_USE_DEEP_GEMM: bool = True
@@ -851,11 +852,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, vllm will trace function calls
     # Useful for debugging
     "VLLM_TRACE_FUNCTION": lambda: int(os.getenv("VLLM_TRACE_FUNCTION", "0")),
+    # Experimental approximate NVFP4 coarse search plus BF16 candidate refine.
+    # It is disabled by default and only applies to explicitly compatible heads.
     "VLLM_HYBRID_NVFP4_LM_HEAD": lambda: bool(
         int(os.getenv("VLLM_HYBRID_NVFP4_LM_HEAD", "0"))
     ),
     "VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES": lambda: int(
         os.getenv("VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES", "128")
+    ),
+    "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS": lambda: int(
+        os.getenv("VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS", "512")
     ),
     # Whether to use the FlashInfer top-k / top-p sampler on CUDA. Enabled
     # by default when the hardware supports it — set to 0 to opt out

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -194,6 +194,8 @@ if TYPE_CHECKING:
     VLLM_HYBRID_NVFP4_LM_HEAD: bool = False
     VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES: int = 128
     VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS: int = 512
+    VLLM_HYBRID_NVFP4_LM_HEAD_MAX_ROWS: int = 2048
+    VLLM_HYBRID_NVFP4_LM_HEAD_MAX_WARMUP_BYTES: int = 256 * 1024 * 1024
     VLLM_V1_USE_OUTLINES_CACHE: bool = False
     VLLM_TPU_USING_PATHWAYS: bool = False
     VLLM_USE_DEEP_GEMM: bool = True
@@ -862,6 +864,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS": lambda: int(
         os.getenv("VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS", "512")
+    ),
+    "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_ROWS": lambda: int(
+        os.getenv("VLLM_HYBRID_NVFP4_LM_HEAD_MAX_ROWS", "2048")
+    ),
+    "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_WARMUP_BYTES": lambda: int(
+        os.getenv(
+            "VLLM_HYBRID_NVFP4_LM_HEAD_MAX_WARMUP_BYTES",
+            str(256 * 1024 * 1024),
+        )
     ),
     # Whether to use the FlashInfer top-k / top-p sampler on CUDA. Enabled
     # by default when the hardware supports it — set to 0 to opt out

--- a/vllm/model_executor/layers/argmax_triton.py
+++ b/vllm/model_executor/layers/argmax_triton.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.math_utils import next_power_of_2
+
+
+if HAS_TRITON:
+
+    @triton.jit
+    def _global_pair_argmax_kernel(
+        gathered_pairs,
+        out_indices,
+        pair_stride_0: tl.constexpr,
+        pair_stride_1: tl.constexpr,
+        tp_size: tl.constexpr,
+        block_tp: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        lane = tl.arange(0, block_tp)
+        mask = lane < tp_size
+        base = row * pair_stride_0 + lane * 2 * pair_stride_1
+        values = tl.load(gathered_pairs + base, mask=mask, other=-float("inf"))
+        indices = tl.load(
+            gathered_pairs + base + pair_stride_1,
+            mask=mask,
+            other=0,
+        )
+        _, lane_idx = tl.max(values, axis=0, return_indices=True)
+        token_id = tl.max(
+            tl.where(lane == lane_idx, indices, 0.0),
+            axis=0,
+        ).to(tl.int32)
+        tl.store(out_indices + row, token_id)
+
+    @triton.jit
+    def _indexed_argmax_kernel(
+        values,
+        token_ids,
+        out_values,
+        out_token_ids,
+        value_stride_0: tl.constexpr,
+        token_stride_0: tl.constexpr,
+        num_candidates: tl.constexpr,
+        block_candidates: tl.constexpr,
+        index_offset: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        lane = tl.arange(0, block_candidates)
+        mask = lane < num_candidates
+        values = tl.load(
+            values + row * value_stride_0 + lane,
+            mask=mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        token_ids = tl.load(
+            token_ids + row * token_stride_0 + lane,
+            mask=mask,
+            other=0x7FFFFFFF,
+        ).to(tl.int32)
+        values = tl.where(values == values, values, -float("inf"))
+        max_value = tl.max(values, axis=0)
+        min_token_id = tl.min(
+            tl.where(values == max_value, token_ids, 0x7FFFFFFF),
+            axis=0,
+        )
+        tl.store(out_values + row, max_value)
+        tl.store(out_token_ids + row, min_token_id + index_offset)
+
+
+def indexed_argmax_triton(
+    values: torch.Tensor,
+    token_ids: torch.Tensor,
+    *,
+    index_offset: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not HAS_TRITON:
+        raise RuntimeError("Triton is required for indexed_argmax_triton")
+    assert values.ndim == 2
+    assert values.is_cuda
+    assert values.shape == token_ids.shape
+    assert 0 < values.shape[1] <= 1024
+    if not values.is_contiguous():
+        values = values.contiguous()
+    if not token_ids.is_contiguous():
+        token_ids = token_ids.contiguous()
+
+    batch_size, num_candidates = values.shape
+    out_values = torch.empty(
+        (batch_size,),
+        device=values.device,
+        dtype=torch.float32,
+    )
+    out_token_ids = torch.empty(
+        (batch_size,),
+        device=values.device,
+        dtype=torch.int32,
+    )
+    _indexed_argmax_kernel[(batch_size,)](
+        values,
+        token_ids,
+        out_values,
+        out_token_ids,
+        value_stride_0=values.stride(0),
+        token_stride_0=token_ids.stride(0),
+        num_candidates=num_candidates,
+        block_candidates=next_power_of_2(num_candidates),
+        index_offset=index_offset,
+    )
+    return out_values, out_token_ids
+
+
+def reduce_global_argmax_triton(
+    gathered_pairs: torch.Tensor,
+    *,
+    tp_size: int,
+) -> torch.Tensor:
+    if not HAS_TRITON:
+        raise RuntimeError("Triton is required for reduce_global_argmax_triton")
+    assert gathered_pairs.ndim == 2
+    assert gathered_pairs.is_cuda
+    assert gathered_pairs.shape[1] == tp_size * 2
+    batch_size = gathered_pairs.shape[0]
+    out_indices = torch.empty(
+        (batch_size,),
+        device=gathered_pairs.device,
+        dtype=torch.int32,
+    )
+    _global_pair_argmax_kernel[(batch_size,)](
+        gathered_pairs,
+        out_indices,
+        gathered_pairs.stride(0),
+        gathered_pairs.stride(1),
+        tp_size=tp_size,
+        block_tp=next_power_of_2(tp_size),
+    )
+    return out_indices
+
+
+__all__ = [
+    "indexed_argmax_triton",
+    "reduce_global_argmax_triton",
+]

--- a/vllm/model_executor/layers/argmax_triton.py
+++ b/vllm/model_executor/layers/argmax_triton.py
@@ -1,10 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 from __future__ import annotations
 
 import torch
 
 from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.utils.math_utils import next_power_of_2
-
 
 if HAS_TRITON:
 
@@ -25,11 +27,12 @@ if HAS_TRITON:
         indices = tl.load(
             gathered_pairs + base + pair_stride_1,
             mask=mask,
-            other=0,
-        )
-        _, lane_idx = tl.max(values, axis=0, return_indices=True)
-        token_id = tl.max(
-            tl.where(lane == lane_idx, indices, 0.0),
+            other=0x7FFFFFFF,
+        ).to(tl.int32)
+        values = tl.where(values == values, values, -float("inf"))
+        max_value = tl.max(values, axis=0)
+        token_id = tl.min(
+            tl.where(values == max_value, indices, 0x7FFFFFFF),
             axis=0,
         ).to(tl.int32)
         tl.store(out_indices + row, token_id)

--- a/vllm/model_executor/layers/hybrid_nvfp4_lm_head.py
+++ b/vllm/model_executor/layers/hybrid_nvfp4_lm_head.py
@@ -1,0 +1,644 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Experimental NVFP4 b12x coarse search with BF16 lm-head refinement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from time import perf_counter
+
+import torch
+import torch.nn.functional as F
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.argmax_triton import (
+    indexed_argmax_triton,
+    reduce_global_argmax_triton,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.flashinfer import (
+    autotune_with_torch_cuda_delay,
+    flashinfer_nvfp4_quantize_128x4,
+    flashinfer_scaled_fp4_mm,
+    has_flashinfer,
+    has_flashinfer_b12x_gemm,
+)
+
+logger = init_logger(__name__)
+
+_BLOCK_SIZE = 16
+_MIN_GEMM_DIMENSION = 128
+_NVFP4_MAX_VALUE = 448.0 * 6.0
+_DEFAULT_AUTOTUNE_MAX_ROWS = 2048
+_TOPK_CANDIDATE_MULTIPLIER = 8
+_MAX_AUTO_CANDIDATES = 1024
+
+_WEIGHT_NAME = "_hybrid_nvfp4_lm_head_weight"
+_SCALE_NAME = "_hybrid_nvfp4_lm_head_scale"
+_GLOBAL_SCALE_NAME = "_hybrid_nvfp4_lm_head_global_scale"
+_STATE_NAME = "_hybrid_nvfp4_lm_head_state"
+_SHARED_STATE_NAME = "_hybrid_nvfp4_lm_head_shared_state"
+_BUFFER_NAMES = (_WEIGHT_NAME, _SCALE_NAME, _GLOBAL_SCALE_NAME)
+
+
+def _global_scale(tensor: torch.Tensor) -> torch.Tensor:
+    max_abs = tensor.abs().amax().float()
+    scaled = max_abs.clamp_min(1.0e-12).reciprocal() * _NVFP4_MAX_VALUE
+    return torch.where(max_abs > 0, scaled, torch.ones_like(max_abs))
+
+
+def _candidate_count_for_topk(
+    configured_candidates: int,
+    top_k: int,
+    *,
+    output_size: int,
+) -> int:
+    """Return a transient refinement width for a top-k request."""
+    if top_k <= 0 or configured_candidates >= _MAX_AUTO_CANDIDATES:
+        return min(configured_candidates, output_size)
+
+    desired = max(configured_candidates, top_k * _TOPK_CANDIDATE_MULTIPLIER)
+    if desired <= configured_candidates * 2:
+        return min(configured_candidates, output_size)
+    if desired >= _MAX_AUTO_CANDIDATES:
+        expanded = _MAX_AUTO_CANDIDATES
+    else:
+        expanded = 1 << (desired - 1).bit_length()
+    return min(max(configured_candidates, expanded), output_size)
+
+
+def _select_candidate_tile(
+    num_rows: int,
+    num_candidates: int,
+    input_size: int,
+) -> int:
+    if num_candidates < 64:
+        return 1
+    if input_size > 2048:
+        if num_rows <= 32:
+            return 1
+        return 2
+    if num_rows < 32:
+        return 1
+    if num_rows < 768:
+        return 2
+    if num_rows < 2048:
+        return 4
+    return 8
+
+
+if HAS_TRITON:
+
+    @triton.jit
+    def _indexed_bf16_dot_kernel(
+        hidden,
+        weight,
+        indices,
+        output,
+        hidden_stride_0: tl.constexpr,
+        weight_stride_0: tl.constexpr,
+        indices_stride_0: tl.constexpr,
+        output_stride_0: tl.constexpr,
+        num_candidates: tl.constexpr,
+        input_size: tl.constexpr,
+        block_input_size: tl.constexpr,
+    ):
+        pair_id = tl.program_id(0)
+        row = pair_id // num_candidates
+        candidate = pair_id % num_candidates
+        token_id = tl.load(indices + row * indices_stride_0 + candidate)
+        offsets = tl.arange(0, block_input_size)
+        mask = offsets < input_size
+        hidden_row = tl.load(
+            hidden + row * hidden_stride_0 + offsets,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        weight_row = tl.load(
+            weight + token_id * weight_stride_0 + offsets,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        value = tl.sum(hidden_row * weight_row, axis=0)
+        tl.store(output + row * output_stride_0 + candidate, value)
+
+    @triton.jit
+    def _tiled_indexed_bf16_dot_kernel(
+        hidden,
+        weight,
+        indices,
+        output,
+        hidden_stride_0: tl.constexpr,
+        weight_stride_0: tl.constexpr,
+        indices_stride_0: tl.constexpr,
+        output_stride_0: tl.constexpr,
+        num_candidates: tl.constexpr,
+        input_size: tl.constexpr,
+        block_input_size: tl.constexpr,
+        block_candidates: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        candidates = (
+            tl.program_id(1) * block_candidates
+            + tl.arange(0, block_candidates)
+        )
+        candidate_mask = candidates < num_candidates
+        token_ids = tl.load(
+            indices + row * indices_stride_0 + candidates,
+            mask=candidate_mask,
+            other=0,
+        )
+
+        offsets = tl.arange(0, block_input_size)
+        input_mask = offsets < input_size
+        hidden_row = tl.load(
+            hidden + row * hidden_stride_0 + offsets,
+            mask=input_mask,
+            other=0.0,
+        ).to(tl.float32)
+        weight_rows = tl.load(
+            weight + token_ids[:, None] * weight_stride_0 + offsets[None, :],
+            mask=candidate_mask[:, None] & input_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        values = tl.sum(weight_rows * hidden_row[None, :], axis=1)
+        tl.store(
+            output + row * output_stride_0 + candidates,
+            values,
+            mask=candidate_mask,
+        )
+
+
+def indexed_bf16_dot(
+    hidden_states: torch.Tensor,
+    bf16_weight: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    *,
+    candidate_tile: int | None = None,
+    num_warps: int = 8,
+) -> torch.Tensor:
+    """Compute selected BF16 logits without a full-vocabulary projection."""
+    if not HAS_TRITON:
+        selected_weight = bf16_weight[candidate_indices]
+        return torch.bmm(
+            hidden_states.unsqueeze(1), selected_weight.transpose(1, 2)
+        ).squeeze(1)
+
+    assert hidden_states.ndim == 2
+    assert bf16_weight.ndim == 2
+    assert candidate_indices.ndim == 2
+    assert hidden_states.shape[0] == candidate_indices.shape[0]
+    assert hidden_states.shape[1] == bf16_weight.shape[1]
+    assert hidden_states.dtype == torch.bfloat16
+    assert bf16_weight.dtype == torch.bfloat16
+    assert hidden_states.is_cuda
+    assert bf16_weight.is_cuda
+    assert candidate_indices.is_cuda
+    assert hidden_states.is_contiguous()
+    assert bf16_weight.is_contiguous()
+    assert candidate_indices.is_contiguous()
+    if num_warps not in (4, 8):
+        raise ValueError(f"num_warps must be 4 or 8; got {num_warps}")
+
+    num_rows, num_candidates = candidate_indices.shape
+    input_size = hidden_states.shape[1]
+    output = torch.empty(
+        (num_rows, num_candidates),
+        dtype=torch.bfloat16,
+        device=hidden_states.device,
+    )
+    block_input_size = triton.next_power_of_2(input_size)
+    if candidate_tile is None:
+        candidate_tile = _select_candidate_tile(
+            num_rows,
+            num_candidates,
+            input_size,
+        )
+
+    if candidate_tile == 1:
+        _indexed_bf16_dot_kernel[(num_rows * num_candidates,)](
+            hidden_states,
+            bf16_weight,
+            candidate_indices,
+            output,
+            hidden_stride_0=hidden_states.stride(0),
+            weight_stride_0=bf16_weight.stride(0),
+            indices_stride_0=candidate_indices.stride(0),
+            output_stride_0=output.stride(0),
+            num_candidates=num_candidates,
+            input_size=input_size,
+            block_input_size=block_input_size,
+            num_warps=num_warps,
+        )
+    else:
+        if candidate_tile not in (2, 4, 8):
+            raise ValueError(
+                "candidate_tile must be one of 1, 2, 4, or 8; "
+                f"got {candidate_tile}"
+            )
+        _tiled_indexed_bf16_dot_kernel[
+            (num_rows, triton.cdiv(num_candidates, candidate_tile))
+        ](
+            hidden_states,
+            bf16_weight,
+            candidate_indices,
+            output,
+            hidden_stride_0=hidden_states.stride(0),
+            weight_stride_0=bf16_weight.stride(0),
+            indices_stride_0=candidate_indices.stride(0),
+            output_stride_0=output.stride(0),
+            num_candidates=num_candidates,
+            input_size=input_size,
+            block_input_size=block_input_size,
+            block_candidates=candidate_tile,
+            num_warps=num_warps,
+        )
+    return output
+
+
+def select_lm_head_candidates(
+    coarse_logits: torch.Tensor,
+    candidates: int,
+) -> torch.Tensor:
+    """Select an unsorted candidate set from the coarse logits."""
+    if candidates <= 0 or candidates > coarse_logits.shape[-1]:
+        raise ValueError(
+            f"candidate count must be in [1, {coarse_logits.shape[-1]}], "
+            f"got {candidates}"
+        )
+    if coarse_logits.is_cuda and has_flashinfer():
+        try:
+            from flashinfer import top_k
+
+            _, indices = top_k(coarse_logits, candidates, sorted=False)
+            return indices.contiguous()
+        except (ImportError, RuntimeError, TypeError, ValueError) as exc:
+            logger.warning_once(
+                "FlashInfer NVFP4 lm-head candidate selection failed (%s); "
+                "using torch.topk.",
+                exc,
+            )
+    return torch.topk(coarse_logits, candidates, dim=-1, sorted=False).indices.contiguous()
+
+
+def autotune_row_buckets(max_rows: int) -> tuple[int, ...]:
+    """Return row counts that may trigger a FlashInfer FP4 tactic lookup."""
+    max_rows = max_rows or _DEFAULT_AUTOTUNE_MAX_ROWS
+    try:
+        if not (
+            current_platform.is_cuda()
+            and current_platform.has_device_capability(100)
+            and has_flashinfer()
+        ):
+            raise ImportError("FlashInfer FP4 backend is unavailable")
+        from flashinfer.fused_moe.utils import get_hybrid_num_tokens_buckets
+
+        buckets = tuple(
+            sorted({int(rows) for rows in get_hybrid_num_tokens_buckets(max_rows)})
+        )
+        if buckets:
+            return buckets
+    except (ImportError, RuntimeError, TypeError, ValueError):
+        pass
+
+    buckets = [
+        rows
+        for rows in (1, 2, 4, 8, 16, 32, 64, 128, 256)
+        if rows <= max_rows
+    ]
+    rows = 512
+    while rows <= max_rows:
+        buckets.append(rows)
+        rows += 256
+    if not buckets:
+        buckets.append(max_rows)
+    return tuple(sorted(set(buckets)))
+
+
+@dataclass
+class HybridNvfp4LmHead:
+    """Persistent NVFP4 weights plus transient BF16 candidate refinement."""
+
+    weight: torch.Tensor
+    scale: torch.Tensor
+    global_scale: torch.Tensor
+    input_size: int
+    output_size: int
+    candidates: int
+    can_use_failure_counts: dict[str, int] = field(default_factory=dict, repr=False)
+
+    def candidate_count_for_topk(self, top_k: int) -> int:
+        return _candidate_count_for_topk(
+            self.candidates,
+            top_k,
+            output_size=self.output_size,
+        )
+
+    def can_use(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        bf16_weight: torch.Tensor,
+        active_vocab_size: int,
+        top_k: int,
+    ) -> bool:
+        reason: str | None = None
+        if hidden_states.ndim != 2:
+            reason = "hidden_ndim"
+        elif hidden_states.dtype != torch.bfloat16:
+            reason = "hidden_dtype"
+        elif not hidden_states.is_cuda:
+            reason = "hidden_not_cuda"
+        elif not hidden_states.is_contiguous():
+            reason = "hidden_not_contiguous"
+        elif hidden_states.shape[1] != self.input_size:
+            reason = "hidden_width"
+        elif bf16_weight.dtype != torch.bfloat16:
+            reason = "weight_dtype"
+        elif bf16_weight.device != hidden_states.device:
+            reason = "weight_device"
+        elif not bf16_weight.is_contiguous():
+            reason = "weight_not_contiguous"
+        elif bf16_weight.shape != (self.output_size, self.input_size):
+            reason = "weight_shape"
+        elif active_vocab_size > self.output_size:
+            reason = "active_vocab_too_large"
+        else:
+            candidate_width = self.candidate_count_for_topk(top_k)
+            if top_k > candidate_width:
+                reason = "top_k_exceeds_candidates"
+            elif active_vocab_size < candidate_width:
+                reason = "active_vocab_too_small"
+        if reason is None:
+            return True
+
+        count = self.can_use_failure_counts.get(reason, 0) + 1
+        self.can_use_failure_counts[reason] = count
+        if count == 1 or count & (count - 1) == 0:
+            logger.debug(
+                "Hybrid NVFP4 lm-head compact path unavailable: reason=%s, "
+                "shape=%s, active_vocab=%d, top_k=%d.",
+                reason,
+                tuple(hidden_states.shape),
+                active_vocab_size,
+                top_k,
+            )
+        return False
+
+    def coarse_logits(
+        self,
+        hidden_states: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        hidden_global_scale = _global_scale(hidden_states)
+        hidden_q, hidden_scale = flashinfer_nvfp4_quantize_128x4(
+            hidden_states,
+            hidden_global_scale,
+        )
+        alpha = torch.reciprocal(hidden_global_scale * self.global_scale)
+        logits = flashinfer_scaled_fp4_mm(
+            hidden_q,
+            self.weight,
+            hidden_scale,
+            self.scale,
+            alpha=alpha,
+            out_dtype=torch.bfloat16,
+            backend="b12x",
+            block_size=_BLOCK_SIZE,
+            use_nvfp4=True,
+        )
+        logits = logits[:, : self.output_size]
+        if bias is not None:
+            logits = logits + bias
+        return logits
+
+    def select_candidates(
+        self,
+        coarse_logits: torch.Tensor,
+        *,
+        top_k: int | None = None,
+    ) -> torch.Tensor:
+        candidates = (
+            self.candidates
+            if top_k is None
+            else self.candidate_count_for_topk(top_k)
+        )
+        candidates = min(candidates, coarse_logits.shape[-1])
+        return select_lm_head_candidates(coarse_logits, candidates)
+
+    @staticmethod
+    def refine_logits(
+        hidden_states: torch.Tensor,
+        bf16_weight: torch.Tensor,
+        candidate_indices: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        logits = indexed_bf16_dot(
+            hidden_states,
+            bf16_weight,
+            candidate_indices,
+        )
+        if bias is not None:
+            logits = logits + bias[candidate_indices]
+        return logits
+
+
+@torch.inference_mode()
+def warmup_hybrid_nvfp4_lm_head_kernels(
+    state: HybridNvfp4LmHead,
+    bf16_weight: torch.Tensor,
+    tp_size: int = 1,
+) -> None:
+    """Compile the selector and selected-BF16 refinement kernels."""
+    hidden_states = torch.zeros(
+        (1, state.input_size),
+        dtype=torch.bfloat16,
+        device=state.weight.device,
+    )
+    coarse_logits = state.coarse_logits(hidden_states, None)
+    candidate_indices = state.select_candidates(coarse_logits)
+    exact_logits = state.refine_logits(
+        hidden_states,
+        bf16_weight,
+        candidate_indices,
+        None,
+    )
+    if HAS_TRITON and exact_logits.shape[-1] <= 1024:
+        indexed_argmax_triton(exact_logits, candidate_indices)
+
+    rows = 16
+    tiled_hidden = hidden_states.expand(rows, -1).contiguous()
+    tiled_candidates = candidate_indices.expand(rows, -1).contiguous()
+    state.refine_logits(tiled_hidden, bf16_weight, tiled_candidates, None)
+    if HAS_TRITON and tp_size > 1:
+        gathered_pairs = torch.zeros(
+            (1, tp_size * 2),
+            dtype=torch.float32,
+            device=state.weight.device,
+        )
+        reduce_global_argmax_triton(gathered_pairs, tp_size=tp_size)
+
+
+@torch.inference_mode()
+def autotune_hybrid_nvfp4_lm_head(
+    state: HybridNvfp4LmHead,
+    bf16_weight: torch.Tensor,
+    row_shapes: tuple[int, ...] | None = None,
+) -> tuple[float, tuple[int, ...]]:
+    """Tune FlashInfer NVFP4 tactics for row shapes used by the runner."""
+    if row_shapes is None:
+        row_shapes = autotune_row_buckets(_DEFAULT_AUTOTUNE_MAX_ROWS)
+    row_shapes = tuple(sorted({int(rows) for rows in row_shapes if rows > 0}))
+    if not row_shapes:
+        row_shapes = (1,)
+
+    hidden_states = torch.zeros(
+        (max(row_shapes), state.input_size),
+        dtype=torch.bfloat16,
+        device=state.weight.device,
+    )
+    started = perf_counter()
+    with autotune_with_torch_cuda_delay(tune_mode=True):
+        for rows in row_shapes:
+            hidden = hidden_states[:rows]
+            coarse_logits = state.coarse_logits(hidden, None)
+            candidate_indices = state.select_candidates(coarse_logits)
+            state.refine_logits(hidden, bf16_weight, candidate_indices, None)
+    torch.accelerator.synchronize()
+    return perf_counter() - started, row_shapes
+
+
+def _attach_state(layer: torch.nn.Module, state: HybridNvfp4LmHead) -> None:
+    for name, value in (
+        (_WEIGHT_NAME, state.weight),
+        (_SCALE_NAME, state.scale),
+        (_GLOBAL_SCALE_NAME, state.global_scale),
+    ):
+        layer.register_buffer(name, value, persistent=False)
+    setattr(layer, _STATE_NAME, state)
+
+
+def prepare_hybrid_nvfp4_lm_head(
+    layer: torch.nn.Module,
+    *,
+    candidates: int,
+) -> bool:
+    """Prepare one NVFP4 b12x lm-head copy, or keep the BF16 path."""
+    if hasattr(layer, _STATE_NAME):
+        return True
+
+    weight = layer.weight
+    shared_state = getattr(weight, _SHARED_STATE_NAME, None)
+    if isinstance(shared_state, HybridNvfp4LmHead):
+        _attach_state(layer, shared_state)
+        return True
+
+    supported = (
+        has_flashinfer()
+        and has_flashinfer_b12x_gemm()
+        and current_platform.is_cuda()
+        and current_platform.has_device_capability(120)
+        and isinstance(weight, torch.Tensor)
+        and weight.ndim == 2
+        and weight.dtype == torch.bfloat16
+        and weight.is_cuda
+        and weight.is_contiguous()
+        and not getattr(weight, "_vllm_is_uva_offloaded", False)
+        and weight.shape[0] >= _MIN_GEMM_DIMENSION
+        and weight.shape[1] >= _MIN_GEMM_DIMENSION
+        and weight.shape[1] % 32 == 0
+    )
+    if not supported:
+        logger.warning_once(
+            "Hybrid NVFP4 b12x lm-head does not support weight %s (%s on %s); "
+            "falling back to the original lm-head implementation.",
+            tuple(weight.shape),
+            weight.dtype,
+            weight.device,
+        )
+        return False
+
+    if candidates <= 0 or candidates > weight.shape[0]:
+        logger.warning_once(
+            "Hybrid NVFP4 lm-head candidate count %d is outside [1, %d]; "
+            "falling back to the original lm-head implementation.",
+            candidates,
+            weight.shape[0],
+        )
+        return False
+
+    padded_output_size = (weight.shape[0] + 31) // 32 * 32
+    weight_for_quant = weight
+    if padded_output_size != weight.shape[0]:
+        weight_for_quant = F.pad(
+            weight,
+            (0, 0, 0, padded_output_size - weight.shape[0]),
+        )
+    global_scale = _global_scale(weight_for_quant)
+    quantized, scale = flashinfer_nvfp4_quantize_128x4(
+        weight_for_quant,
+        global_scale,
+    )
+    state = HybridNvfp4LmHead(
+        weight=quantized,
+        scale=scale,
+        global_scale=global_scale,
+        input_size=weight.shape[1],
+        output_size=weight.shape[0],
+        candidates=candidates,
+    )
+    _attach_state(layer, state)
+    setattr(weight, _SHARED_STATE_NAME, state)
+
+    extra_mib = sum(
+        getattr(layer, name).nbytes for name in _BUFFER_NAMES
+    ) / (1024 * 1024)
+    logger.info_once(
+        "Prepared hybrid NVFP4 b12x lm-head for weight %s with %d candidates "
+        "and %.2f MiB auxiliary storage.",
+        tuple(weight.shape),
+        candidates,
+        extra_mib,
+    )
+    return True
+
+
+def get_hybrid_nvfp4_lm_head(
+    layer: torch.nn.Module,
+) -> HybridNvfp4LmHead | None:
+    return getattr(layer, _STATE_NAME, None)
+
+
+def release_hybrid_nvfp4_lm_head(layer: torch.nn.Module) -> int:
+    """Release a prepared auxiliary copy from a discarded lm-head."""
+    released_bytes = 0
+    state = getattr(layer, _STATE_NAME, None)
+    for name in _BUFFER_NAMES:
+        value = getattr(layer, name, None)
+        if isinstance(value, torch.Tensor):
+            released_bytes += value.nbytes
+
+    if hasattr(layer, _STATE_NAME):
+        delattr(layer, _STATE_NAME)
+    for name in _BUFFER_NAMES:
+        if hasattr(layer, name):
+            delattr(layer, name)
+
+    weight = getattr(layer, "weight", None)
+    if getattr(weight, _SHARED_STATE_NAME, None) is state:
+        delattr(weight, _SHARED_STATE_NAME)
+    return released_bytes
+
+
+__all__ = [
+    "HybridNvfp4LmHead",
+    "autotune_hybrid_nvfp4_lm_head",
+    "autotune_row_buckets",
+    "get_hybrid_nvfp4_lm_head",
+    "indexed_bf16_dot",
+    "prepare_hybrid_nvfp4_lm_head",
+    "release_hybrid_nvfp4_lm_head",
+    "select_lm_head_candidates",
+    "warmup_hybrid_nvfp4_lm_head_kernels",
+]

--- a/vllm/model_executor/layers/hybrid_nvfp4_lm_head.py
+++ b/vllm/model_executor/layers/hybrid_nvfp4_lm_head.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from time import perf_counter
+from weakref import WeakSet
 
 import torch
 import torch.nn.functional as F
@@ -284,6 +285,13 @@ def select_lm_head_candidates(
             f"candidate count must be in [1, {coarse_logits.shape[-1]}], "
             f"got {candidates}"
         )
+    # Match the argmax/reduction contract for invalid logits even when NaN
+    # diagnostics are disabled.  Passing NaNs to either FlashInfer or
+    # ``argsort`` can otherwise make candidate membership nondeterministic.
+    # This tensor is a temporary coarse projection and is not observed after
+    # candidate selection.  Normalize NaNs in place to avoid another full
+    # ``[batch, vocab]`` allocation on large vocabularies.
+    coarse_logits.nan_to_num_(nan=-float("inf"))
     if coarse_logits.is_cuda and has_flashinfer():
         try:
             from flashinfer import top_k
@@ -350,7 +358,14 @@ class HybridNvfp4LmHead:
     input_size: int
     output_size: int
     candidates: int
+    max_rows: int | None = None
     can_use_failure_counts: dict[str, int] = field(default_factory=dict, repr=False)
+    # Tied input/output embeddings can attach the same derived state to more
+    # than one module.  Keep weak references so releasing one module does not
+    # invalidate the state still owned by its tied peers.
+    attached_layers: WeakSet[torch.nn.Module] = field(
+        default_factory=WeakSet, repr=False, compare=False
+    )
 
     def candidate_count_for_topk(self, top_k: int) -> int:
         return _candidate_count_for_topk(
@@ -378,6 +393,8 @@ class HybridNvfp4LmHead:
             reason = "hidden_not_contiguous"
         elif hidden_states.shape[1] != self.input_size:
             reason = "hidden_width"
+        elif self.max_rows is not None and hidden_states.shape[0] > self.max_rows:
+            reason = "rows_exceed_limit"
         elif bf16_weight.dtype != torch.bfloat16:
             reason = "weight_dtype"
         elif bf16_weight.device != hidden_states.device:
@@ -547,15 +564,34 @@ def _attach_state(layer: torch.nn.Module, state: HybridNvfp4LmHead) -> None:
     ):
         layer.register_buffer(name, value, persistent=False)
     setattr(layer, _STATE_NAME, state)
+    state.attached_layers.add(layer)
+
+
+def _release_state_attachments(state: HybridNvfp4LmHead) -> int:
+    """Detach every module sharing ``state`` and return freed bytes."""
+    released_bytes = 0
+    # ``release_hybrid_nvfp4_lm_head`` updates the weak set while iterating;
+    # materialize it first to avoid mutating a live WeakSet iterator.
+    attached_layers = list(state.attached_layers)
+    for layer in attached_layers:
+        released_bytes += release_hybrid_nvfp4_lm_head(layer)
+    return released_bytes
 
 
 def prepare_hybrid_nvfp4_lm_head(
     layer: torch.nn.Module,
     *,
     candidates: int,
+    max_rows: int | None = None,
 ) -> bool:
     """Prepare one NVFP4 b12x lm-head copy, or keep the BF16 path."""
+    normalized_max_rows = (
+        None if max_rows is None or max_rows <= 0 else int(max_rows)
+    )
     if isinstance(getattr(layer, _STATE_NAME, None), HybridNvfp4LmHead):
+        state = getattr(layer, _STATE_NAME)
+        if max_rows is not None:
+            state.max_rows = normalized_max_rows
         if refresh_hybrid_nvfp4_lm_head(layer, candidates=candidates):
             return True
         # A changed dtype or shape cannot be refreshed in place.  Drop the
@@ -566,6 +602,8 @@ def prepare_hybrid_nvfp4_lm_head(
     weight = layer.weight
     shared_state = getattr(weight, _SHARED_STATE_NAME, None)
     if isinstance(shared_state, HybridNvfp4LmHead):
+        if max_rows is not None:
+            shared_state.max_rows = normalized_max_rows
         _attach_state(layer, shared_state)
         return True
 
@@ -611,6 +649,7 @@ def prepare_hybrid_nvfp4_lm_head(
         input_size=weight.shape[1],
         output_size=weight.shape[0],
         candidates=candidates,
+        max_rows=normalized_max_rows,
     )
     _attach_state(layer, state)
     setattr(weight, _SHARED_STATE_NAME, state)
@@ -652,7 +691,10 @@ def refresh_hybrid_nvfp4_lm_head(
         or weight.shape[0] != state.output_size
         or weight.shape[1] != state.input_size
     ):
-        release_hybrid_nvfp4_lm_head(layer)
+        if state.attached_layers:
+            _release_state_attachments(state)
+        else:
+            release_hybrid_nvfp4_lm_head(layer)
         return False
 
     quantized, scale, global_scale = _quantize_lm_head_weight(weight)
@@ -661,7 +703,10 @@ def refresh_hybrid_nvfp4_lm_head(
         or state.scale.shape != scale.shape
         or state.global_scale.shape != global_scale.shape
     ):
-        release_hybrid_nvfp4_lm_head(layer)
+        if state.attached_layers:
+            _release_state_attachments(state)
+        else:
+            release_hybrid_nvfp4_lm_head(layer)
         return False
 
     state.weight.copy_(quantized)
@@ -681,14 +726,48 @@ def refresh_hybrid_nvfp4_lm_heads(
 ) -> int:
     """Refresh each distinct prepared lm-head state in ``model``."""
     refreshed = 0
-    seen_states: set[int] = set()
+    state_layers: dict[int, tuple[HybridNvfp4LmHead, list[torch.nn.Module]]] = {}
     for layer in model.modules():
         state = getattr(layer, _STATE_NAME, None)
-        if not isinstance(state, HybridNvfp4LmHead) or id(state) in seen_states:
+        if not isinstance(state, HybridNvfp4LmHead):
             continue
-        seen_states.add(id(state))
-        refreshed += int(refresh_hybrid_nvfp4_lm_head(layer, candidates=candidates))
+        state_layers.setdefault(id(state), (state, []))[1].append(layer)
+    for state, layers in state_layers.values():
+        if refresh_hybrid_nvfp4_lm_head(layers[0], candidates=candidates):
+            refreshed += 1
+        else:
+            # The first refresh may already detach all known owners.  Keep the
+            # explicit loop for modules outside the current model traversal or
+            # stale weak-set entries.
+            _release_state_attachments(state)
+            for layer in layers:
+                release_hybrid_nvfp4_lm_head(layer)
     return refreshed
+
+
+def release_hybrid_nvfp4_lm_heads(model: torch.nn.Module) -> int:
+    """Release all distinct auxiliary states owned by ``model``."""
+    states: dict[int, tuple[HybridNvfp4LmHead, list[torch.nn.Module]]] = {}
+    for layer in model.modules():
+        state = getattr(layer, _STATE_NAME, None)
+        if isinstance(state, HybridNvfp4LmHead):
+            states.setdefault(id(state), (state, []))[1].append(layer)
+    released = 0
+    for state, layers in states.values():
+        if state.attached_layers:
+            released += _release_state_attachments(state)
+            continue
+        # Legacy/custom attachments may not have populated the weak set.  In
+        # that case count the shared storage once, then detach every owner.
+        if layers:
+            released += release_hybrid_nvfp4_lm_head(layers[0])
+            for layer in layers[1:]:
+                if hasattr(layer, _STATE_NAME):
+                    delattr(layer, _STATE_NAME)
+                for name in _BUFFER_NAMES:
+                    if hasattr(layer, name):
+                        delattr(layer, name)
+    return released
 
 
 def get_hybrid_nvfp4_lm_head(
@@ -699,21 +778,41 @@ def get_hybrid_nvfp4_lm_head(
 
 def release_hybrid_nvfp4_lm_head(layer: torch.nn.Module) -> int:
     """Release a prepared auxiliary copy from a discarded lm-head."""
-    released_bytes = 0
     state = getattr(layer, _STATE_NAME, None)
-    for name in _BUFFER_NAMES:
-        value = getattr(layer, name, None)
-        if isinstance(value, torch.Tensor):
-            released_bytes += value.nbytes
+    if not isinstance(state, HybridNvfp4LmHead):
+        # Be tolerant of callers cleaning up a partially initialized module.
+        if hasattr(layer, _STATE_NAME):
+            delattr(layer, _STATE_NAME)
+        released_bytes = 0
+        for name in _BUFFER_NAMES:
+            value = getattr(layer, name, None)
+            if isinstance(value, torch.Tensor):
+                released_bytes += value.nbytes
+            if hasattr(layer, name):
+                delattr(layer, name)
+        return released_bytes
 
-    if hasattr(layer, _STATE_NAME):
-        delattr(layer, _STATE_NAME)
+    state.attached_layers.discard(layer)
+    # Removing one tied view does not release the underlying tensors.  They
+    # remain reachable through the shared state and the other attached layer.
+    if state.attached_layers:
+        released_bytes = 0
+    else:
+        released_bytes = sum(
+            value.nbytes
+            for value in (state.weight, state.scale, state.global_scale)
+            if isinstance(value, torch.Tensor)
+        )
+
     for name in _BUFFER_NAMES:
         if hasattr(layer, name):
             delattr(layer, name)
 
+    if hasattr(layer, _STATE_NAME):
+        delattr(layer, _STATE_NAME)
+
     weight = getattr(layer, "weight", None)
-    if getattr(weight, _SHARED_STATE_NAME, None) is state:
+    if not state.attached_layers and getattr(weight, _SHARED_STATE_NAME, None) is state:
         delattr(weight, _SHARED_STATE_NAME)
     return released_bytes
 
@@ -728,6 +827,7 @@ __all__ = [
     "refresh_hybrid_nvfp4_lm_head",
     "refresh_hybrid_nvfp4_lm_heads",
     "release_hybrid_nvfp4_lm_head",
+    "release_hybrid_nvfp4_lm_heads",
     "select_lm_head_candidates",
     "warmup_hybrid_nvfp4_lm_head_kernels",
 ]

--- a/vllm/model_executor/layers/hybrid_nvfp4_lm_head.py
+++ b/vllm/model_executor/layers/hybrid_nvfp4_lm_head.py
@@ -48,6 +48,25 @@ def _global_scale(tensor: torch.Tensor) -> torch.Tensor:
     return torch.where(max_abs > 0, scaled, torch.ones_like(max_abs))
 
 
+def _quantize_lm_head_weight(
+    weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create the auxiliary NVFP4 representation for one BF16 lm-head."""
+    padded_output_size = (weight.shape[0] + 31) // 32 * 32
+    weight_for_quant = weight
+    if padded_output_size != weight.shape[0]:
+        weight_for_quant = F.pad(
+            weight,
+            (0, 0, 0, padded_output_size - weight.shape[0]),
+        )
+    global_scale = _global_scale(weight_for_quant)
+    quantized, scale = flashinfer_nvfp4_quantize_128x4(
+        weight_for_quant,
+        global_scale,
+    )
+    return quantized, scale, global_scale
+
+
 def _candidate_count_for_topk(
     configured_candidates: int,
     top_k: int,
@@ -139,9 +158,8 @@ if HAS_TRITON:
         block_candidates: tl.constexpr,
     ):
         row = tl.program_id(0)
-        candidates = (
-            tl.program_id(1) * block_candidates
-            + tl.arange(0, block_candidates)
+        candidates = tl.program_id(1) * block_candidates + tl.arange(
+            0, block_candidates
         )
         candidate_mask = candidates < num_candidates
         token_ids = tl.load(
@@ -234,8 +252,7 @@ def indexed_bf16_dot(
     else:
         if candidate_tile not in (2, 4, 8):
             raise ValueError(
-                "candidate_tile must be one of 1, 2, 4, or 8; "
-                f"got {candidate_tile}"
+                f"candidate_tile must be one of 1, 2, 4, or 8; got {candidate_tile}"
             )
         _tiled_indexed_bf16_dot_kernel[
             (num_rows, triton.cdiv(num_candidates, candidate_tile))
@@ -271,7 +288,12 @@ def select_lm_head_candidates(
         try:
             from flashinfer import top_k
 
-            _, indices = top_k(coarse_logits, candidates, sorted=False)
+            _, indices = top_k(
+                coarse_logits,
+                candidates,
+                sorted=False,
+                deterministic=True,
+            )
             return indices.contiguous()
         except (ImportError, RuntimeError, TypeError, ValueError) as exc:
             logger.warning_once(
@@ -279,7 +301,11 @@ def select_lm_head_candidates(
                 "using torch.topk.",
                 exc,
             )
-    return torch.topk(coarse_logits, candidates, dim=-1, sorted=False).indices.contiguous()
+    # Stable descending sort gives the same lower-index tie break as the
+    # regular greedy argmax when FlashInfer is unavailable.
+    return torch.argsort(coarse_logits, dim=-1, descending=True, stable=True)[
+        ..., :candidates
+    ].contiguous()
 
 
 def autotune_row_buckets(max_rows: int) -> tuple[int, ...]:
@@ -294,18 +320,16 @@ def autotune_row_buckets(max_rows: int) -> tuple[int, ...]:
             raise ImportError("FlashInfer FP4 backend is unavailable")
         from flashinfer.fused_moe.utils import get_hybrid_num_tokens_buckets
 
-        buckets = tuple(
+        flashinfer_buckets = tuple(
             sorted({int(rows) for rows in get_hybrid_num_tokens_buckets(max_rows)})
         )
-        if buckets:
-            return buckets
+        if flashinfer_buckets:
+            return flashinfer_buckets
     except (ImportError, RuntimeError, TypeError, ValueError):
         pass
 
-    buckets = [
-        rows
-        for rows in (1, 2, 4, 8, 16, 32, 64, 128, 256)
-        if rows <= max_rows
+    buckets: list[int] = [
+        rows for rows in (1, 2, 4, 8, 16, 32, 64, 128, 256) if rows <= max_rows
     ]
     rows = 512
     while rows <= max_rows:
@@ -318,7 +342,7 @@ def autotune_row_buckets(max_rows: int) -> tuple[int, ...]:
 
 @dataclass
 class HybridNvfp4LmHead:
-    """Persistent NVFP4 weights plus transient BF16 candidate refinement."""
+    """Persistent NVFP4 weights for approximate BF16 candidate refinement."""
 
     weight: torch.Tensor
     scale: torch.Tensor
@@ -420,9 +444,7 @@ class HybridNvfp4LmHead:
         top_k: int | None = None,
     ) -> torch.Tensor:
         candidates = (
-            self.candidates
-            if top_k is None
-            else self.candidate_count_for_topk(top_k)
+            self.candidates if top_k is None else self.candidate_count_for_topk(top_k)
         )
         candidates = min(candidates, coarse_logits.shape[-1])
         return select_lm_head_candidates(coarse_logits, candidates)
@@ -457,20 +479,28 @@ def warmup_hybrid_nvfp4_lm_head_kernels(
         device=state.weight.device,
     )
     coarse_logits = state.coarse_logits(hidden_states, None)
-    candidate_indices = state.select_candidates(coarse_logits)
-    exact_logits = state.refine_logits(
-        hidden_states,
-        bf16_weight,
-        candidate_indices,
-        None,
-    )
-    if HAS_TRITON and exact_logits.shape[-1] <= 1024:
-        indexed_argmax_triton(exact_logits, candidate_indices)
+    candidate_sets = [state.select_candidates(coarse_logits)]
+    # A bounded top-k request may widen the transient candidate matrix. Warm
+    # that shape once so the first random top-k request does not pay a JIT
+    # compile or an unexpected CUDA-graph allocation.
+    wide_candidates = state.select_candidates(coarse_logits, top_k=64)
+    if wide_candidates.shape[-1] != candidate_sets[0].shape[-1]:
+        candidate_sets.append(wide_candidates)
+    for candidate_indices in candidate_sets:
+        exact_logits = state.refine_logits(
+            hidden_states,
+            bf16_weight,
+            candidate_indices,
+            None,
+        )
+        if HAS_TRITON and exact_logits.shape[-1] <= 1024:
+            indexed_argmax_triton(exact_logits, candidate_indices)
 
     rows = 16
     tiled_hidden = hidden_states.expand(rows, -1).contiguous()
-    tiled_candidates = candidate_indices.expand(rows, -1).contiguous()
-    state.refine_logits(tiled_hidden, bf16_weight, tiled_candidates, None)
+    for candidate_indices in candidate_sets:
+        tiled_candidates = candidate_indices.expand(rows, -1).contiguous()
+        state.refine_logits(tiled_hidden, bf16_weight, tiled_candidates, None)
     if HAS_TRITON and tp_size > 1:
         gathered_pairs = torch.zeros(
             (1, tp_size * 2),
@@ -525,8 +555,13 @@ def prepare_hybrid_nvfp4_lm_head(
     candidates: int,
 ) -> bool:
     """Prepare one NVFP4 b12x lm-head copy, or keep the BF16 path."""
-    if hasattr(layer, _STATE_NAME):
-        return True
+    if isinstance(getattr(layer, _STATE_NAME, None), HybridNvfp4LmHead):
+        if refresh_hybrid_nvfp4_lm_head(layer, candidates=candidates):
+            return True
+        # A changed dtype or shape cannot be refreshed in place.  Drop the
+        # auxiliary state and let the normal support checks below decide
+        # whether a new state can be built.
+        release_hybrid_nvfp4_lm_head(layer)
 
     weight = layer.weight
     shared_state = getattr(weight, _SHARED_STATE_NAME, None)
@@ -568,18 +603,7 @@ def prepare_hybrid_nvfp4_lm_head(
         )
         return False
 
-    padded_output_size = (weight.shape[0] + 31) // 32 * 32
-    weight_for_quant = weight
-    if padded_output_size != weight.shape[0]:
-        weight_for_quant = F.pad(
-            weight,
-            (0, 0, 0, padded_output_size - weight.shape[0]),
-        )
-    global_scale = _global_scale(weight_for_quant)
-    quantized, scale = flashinfer_nvfp4_quantize_128x4(
-        weight_for_quant,
-        global_scale,
-    )
+    quantized, scale, global_scale = _quantize_lm_head_weight(weight)
     state = HybridNvfp4LmHead(
         weight=quantized,
         scale=scale,
@@ -591,9 +615,9 @@ def prepare_hybrid_nvfp4_lm_head(
     _attach_state(layer, state)
     setattr(weight, _SHARED_STATE_NAME, state)
 
-    extra_mib = sum(
-        getattr(layer, name).nbytes for name in _BUFFER_NAMES
-    ) / (1024 * 1024)
+    extra_mib = sum(getattr(layer, name).nbytes for name in _BUFFER_NAMES) / (
+        1024 * 1024
+    )
     logger.info_once(
         "Prepared hybrid NVFP4 b12x lm-head for weight %s with %d candidates "
         "and %.2f MiB auxiliary storage.",
@@ -602,6 +626,69 @@ def prepare_hybrid_nvfp4_lm_head(
         extra_mib,
     )
     return True
+
+
+@torch.inference_mode()
+def refresh_hybrid_nvfp4_lm_head(
+    layer: torch.nn.Module,
+    *,
+    candidates: int | None = None,
+) -> bool:
+    """Refresh a prepared auxiliary copy after the BF16 weight is updated.
+
+    The auxiliary tensors are derived state and are intentionally not part of
+    the checkpoint.  In-place updates preserve references held by tied heads
+    and CUDA-graph setup code.
+    """
+    state = getattr(layer, _STATE_NAME, None)
+    weight = getattr(layer, "weight", None)
+    if not isinstance(state, HybridNvfp4LmHead) or not isinstance(weight, torch.Tensor):
+        return False
+    if (
+        weight.dtype != torch.bfloat16
+        or not weight.is_cuda
+        or not weight.is_contiguous()
+        or weight.ndim != 2
+        or weight.shape[0] != state.output_size
+        or weight.shape[1] != state.input_size
+    ):
+        release_hybrid_nvfp4_lm_head(layer)
+        return False
+
+    quantized, scale, global_scale = _quantize_lm_head_weight(weight)
+    if (
+        state.weight.shape != quantized.shape
+        or state.scale.shape != scale.shape
+        or state.global_scale.shape != global_scale.shape
+    ):
+        release_hybrid_nvfp4_lm_head(layer)
+        return False
+
+    state.weight.copy_(quantized)
+    state.scale.copy_(scale)
+    state.global_scale.copy_(global_scale)
+    if candidates is not None:
+        state.candidates = candidates
+    state.can_use_failure_counts.clear()
+    return True
+
+
+@torch.inference_mode()
+def refresh_hybrid_nvfp4_lm_heads(
+    model: torch.nn.Module,
+    *,
+    candidates: int | None = None,
+) -> int:
+    """Refresh each distinct prepared lm-head state in ``model``."""
+    refreshed = 0
+    seen_states: set[int] = set()
+    for layer in model.modules():
+        state = getattr(layer, _STATE_NAME, None)
+        if not isinstance(state, HybridNvfp4LmHead) or id(state) in seen_states:
+            continue
+        seen_states.add(id(state))
+        refreshed += int(refresh_hybrid_nvfp4_lm_head(layer, candidates=candidates))
+    return refreshed
 
 
 def get_hybrid_nvfp4_lm_head(
@@ -638,6 +725,8 @@ __all__ = [
     "get_hybrid_nvfp4_lm_head",
     "indexed_bf16_dot",
     "prepare_hybrid_nvfp4_lm_head",
+    "refresh_hybrid_nvfp4_lm_head",
+    "refresh_hybrid_nvfp4_lm_heads",
     "release_hybrid_nvfp4_lm_head",
     "select_lm_head_candidates",
     "warmup_hybrid_nvfp4_lm_head_kernels",

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.flashinfer import has_flashinfer
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 
 indexed_argmax_triton: Any
 reduce_global_argmax_triton: Any
@@ -54,6 +55,33 @@ logger = init_logger(__name__)
 # The full local logits projection is unavoidable, but a second full-sized
 # noise/scores matrix is not.
 _FULL_SAMPLE_BLOCK_SIZE = 8192
+_MAX_FLOAT32_TOKEN_ID = 1 << 24
+
+
+def _stable_topk(
+    values: torch.Tensor,
+    k: int,
+    token_ids: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Top-k with value-descending, token-id-ascending tie handling."""
+    if k <= 0 or k > values.shape[-1]:
+        raise ValueError(f"k must be in [1, {values.shape[-1]}], got {k}")
+    rank_values = torch.where(
+        torch.isnan(values), torch.full_like(values, -float("inf")), values
+    )
+    if token_ids is None:
+        order = torch.argsort(rank_values, dim=-1, descending=True, stable=True)
+    else:
+        if token_ids.shape != values.shape:
+            raise ValueError("token_ids must have the same shape as values")
+        id_order = torch.argsort(token_ids, dim=-1, stable=True)
+        id_sorted_values = rank_values.gather(-1, id_order)
+        value_order = torch.argsort(
+            id_sorted_values, dim=-1, descending=True, stable=True
+        )
+        order = id_order.gather(-1, value_order)
+    order = order[..., :k]
+    return rank_values.gather(-1, order), order
 
 
 @cache
@@ -79,7 +107,10 @@ def _flashinfer_topk() -> Callable[..., tuple[torch.Tensor, torch.Tensor]] | Non
 def _topk(scores: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
     impl = _flashinfer_topk()
     if impl is None or not scores.is_cuda:
-        return torch.topk(scores, k, dim=-1)
+        # ``torch.topk`` does not define the order of equal values.  The
+        # stable fallback keeps local boundary candidates deterministic so a
+        # later TP merge cannot depend on kernel launch details.
+        return _stable_topk(scores, k)
     return impl(scores, k, sorted=True, deterministic=True)
 
 
@@ -337,15 +368,25 @@ class LogitsProcessor(PluggableLayer):
                 valid_mask |= (local_ids >= added_local_start) & (
                     local_ids < added_local_end
                 )
-            logits = logits.masked_fill(~valid_mask, -float("inf"))
-            local_max_vals, local_max_indices = logits.max(dim=-1)
-            global_indices = torch.where(
-                local_max_indices < num_org_padded,
-                shard_indices.padded_org_vocab_start_index + local_max_indices,
+            global_ids = torch.where(
+                local_ids < num_org_padded,
+                shard_indices.padded_org_vocab_start_index + local_ids,
                 shard_indices.padded_added_vocab_start_index
-                + local_max_indices
+                + local_ids
                 - num_org_padded,
             )
+            finite_logits = torch.where(
+                valid_mask & (logits == logits),
+                logits,
+                torch.full_like(logits, -float("inf")),
+            )
+            local_max_vals = finite_logits.max(dim=-1).values
+            tie_break_ids = torch.where(
+                valid_mask & (finite_logits == local_max_vals.unsqueeze(-1)),
+                global_ids,
+                torch.full_like(global_ids, torch.iinfo(torch.int64).max),
+            )
+            global_indices = tie_break_ids.min(dim=-1).values
             return self.reduce_local_argmax(
                 local_max_vals,
                 global_indices,
@@ -360,6 +401,7 @@ class LogitsProcessor(PluggableLayer):
             and self._is_contiguous_org_shard(lm_head)
             and self.hybrid_lm_head_enabled
             and _hybrid_enabled is not False
+            and not envs.VLLM_COMPUTE_NANS_IN_LOGITS
             and (self.head_dtype is None or self.head_dtype == hidden_states.dtype)
             and hybrid_state.can_use(
                 hidden_states,
@@ -463,6 +505,21 @@ class LogitsProcessor(PluggableLayer):
         if tp_size == 1:
             return global_indices.to(torch.int64)
 
+        # Token ids are normally packed with scores for one compact
+        # all-gather.  FP32 cannot represent every integer above 2**24, so
+        # use separate typed gathers for unusually large vocabularies rather
+        # than silently changing the argmax tie-break key.
+        if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+            gathered_values = tensor_model_parallel_all_gather(
+                local_max_vals.float(), dim=-1
+            )
+            gathered_ids = tensor_model_parallel_all_gather(
+                global_indices.to(torch.int64), dim=-1
+            )
+            return self._reduce_global_argmax_values_ids(
+                gathered_values, gathered_ids, tp_size
+            )
+
         local_pair = torch.stack(
             [local_max_vals.float(), global_indices.float()], dim=-1
         )
@@ -480,16 +537,31 @@ class LogitsProcessor(PluggableLayer):
                 torch.int64
             )
         gathered = gathered.view(gathered.shape[0], tp_size, 2)
-        values = torch.where(
-            gathered[:, :, 0] == gathered[:, :, 0],
-            gathered[:, :, 0],
-            torch.full_like(gathered[:, :, 0], -float("inf")),
+        return LogitsProcessor._reduce_global_argmax_values_ids(
+            gathered[:, :, 0], gathered[:, :, 1], tp_size
         )
+
+    @staticmethod
+    def _reduce_global_argmax_values_ids(
+        gathered_values: torch.Tensor,
+        gathered_ids: torch.Tensor,
+        tp_size: int,
+    ) -> torch.Tensor:
+        """Reduce separately typed ``(value, token_id)`` gathers."""
+        gathered_ids = gathered_ids.to(torch.int64)
+        values = torch.where(
+            gathered_values == gathered_values,
+            gathered_values,
+            torch.full_like(gathered_values, -float("inf")),
+        )
+        if values.ndim == 1:
+            values = values.view(-1, tp_size)
+            gathered_ids = gathered_ids.view(-1, tp_size)
         max_values = values.max(dim=-1, keepdim=True).values
         tie_break_ids = torch.where(
             values == max_values,
-            gathered[:, :, 1],
-            torch.full_like(gathered[:, :, 1], float("inf")),
+            gathered_ids,
+            torch.full_like(gathered_ids, torch.iinfo(torch.int64).max),
         )
         return tie_break_ids.min(dim=-1).values.to(torch.int64)
 
@@ -499,6 +571,10 @@ class LogitsProcessor(PluggableLayer):
         hidden_states: torch.Tensor,
         temperature: float,
         embedding_bias: torch.Tensor | None = None,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Sample an unrestricted distribution without gathering full logits.
 
@@ -537,19 +613,55 @@ class LogitsProcessor(PluggableLayer):
         logits.div_(temperature)
         self._mask_invalid_shard_logits(logits, active_vocab_size)
 
-        # Reuse the logits buffer for Gumbel scores. Keeping a separate
-        # ``scores`` tensor would add another full ``[batch, vocab]``
-        # allocation on top of the local logits and exponential noise.
-        for start in range(0, logits.shape[-1], _FULL_SAMPLE_BLOCK_SIZE):
-            end = min(start + _FULL_SAMPLE_BLOCK_SIZE, logits.shape[-1])
-            block = logits[..., start:end]
-            noise = torch.empty_like(block)
-            noise.exponential_()
-            block.sub_(noise.log_())
-            # Keep NaN diagnostics fail-closed without materializing another
-            # full score matrix.  The bool mask is bounded by one block.
-            block.masked_fill_(torch.isnan(block), -float("inf"))
-        local_scores, local_indices = logits.max(dim=-1)
+        if (
+            (expanded_idx_mapping is None) != (seeds is None)
+            or (expanded_idx_mapping is None) != (pos is None)
+            or (expanded_idx_mapping is None) != (temperature_state is None)
+        ):
+            raise ValueError(
+                "expanded_idx_mapping, seeds, pos, and temperature_state must be "
+                "provided together"
+            )
+
+        if (
+            expanded_idx_mapping is not None
+            and seeds is not None
+            and pos is not None
+            and logits.is_cuda
+            and HAS_TRITON
+        ):
+            if temperature_state is None:
+                raise ValueError(
+                    "temperature_state is required with keyed Gumbel metadata"
+                )
+            # Use the same keyed per-request Gumbel stream as the standard V2
+            # sampler. The local token offset makes TP shards use the global
+            # token id as the random key, so a TP=1 and TP>1 run agree.
+            gumbel_result = gumbel_sample(
+                logits,
+                expanded_idx_mapping,
+                temperature_state,
+                seeds,
+                pos,
+                apply_temperature=False,
+                use_fp64=False,
+                token_key_offset=shard_indices.org_vocab_start_index,
+                return_scores=True,
+            )
+            assert isinstance(gumbel_result, tuple)
+            local_indices, local_scores = gumbel_result
+        else:
+            # Direct callers and CPU tests do not carry V2 sampling state. Keep
+            # the bounded fallback for those users; runner fast paths always
+            # pass keyed state on CUDA.
+            for start in range(0, logits.shape[-1], _FULL_SAMPLE_BLOCK_SIZE):
+                end = min(start + _FULL_SAMPLE_BLOCK_SIZE, logits.shape[-1])
+                block = logits[..., start:end]
+                noise = torch.empty_like(block)
+                noise.exponential_()
+                block.sub_(noise.log_())
+                block.masked_fill_(torch.isnan(block), -float("inf"))
+            local_scores, local_indices = logits.max(dim=-1)
         global_indices = local_indices.to(torch.int64) + (
             shard_indices.org_vocab_start_index
         )
@@ -557,14 +669,31 @@ class LogitsProcessor(PluggableLayer):
         if tp_size == 1:
             return global_indices
 
-        local_pair = torch.stack(
-            [local_scores, global_indices.to(torch.float32)], dim=-1
-        )
-        gathered = tensor_model_parallel_gather(local_pair, dst=0, dim=-1)
+        if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+            gathered_scores = tensor_model_parallel_gather(
+                local_scores, dst=0, dim=-1
+            )
+            gathered_ids = tensor_model_parallel_gather(
+                global_indices, dst=0, dim=-1
+            )
+        else:
+            local_pair = torch.stack(
+                [local_scores, global_indices.to(torch.float32)], dim=-1
+            )
+            gathered_scores = tensor_model_parallel_gather(
+                local_pair, dst=0, dim=-1
+            )
+            gathered_ids = None
         tp_group = get_tp_group()
         if tp_group.rank_in_group == 0:
-            assert gathered is not None
-            sampled = self._reduce_global_argmax_pairs(gathered, tp_size)
+            assert gathered_scores is not None
+            if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+                assert gathered_ids is not None
+                sampled = self._reduce_global_argmax_values_ids(
+                    gathered_scores, gathered_ids, tp_size
+                )
+            else:
+                sampled = self._reduce_global_argmax_pairs(gathered_scores, tp_size)
         else:
             sampled = torch.empty(
                 (hidden_states.shape[0],),
@@ -881,19 +1010,11 @@ class LogitsProcessor(PluggableLayer):
             if _hybrid_enabled is not None
             else self._get_hybrid_lm_head_row_mask(hidden_states)
         )
-        if (
-            row_mask is not None
-            and not bool(row_mask.all())
-            and presence_penalties is None
-            and output_token_ids is None
-            and output_token_counts is None
-            and presence_request_indices is None
-            and embedding_bias is None
-        ):
-            # The common speculative top-k path has no request-dependent
-            # processors, so split decode rows from prompt-tail rows.  The
-            # latter use the exact full head while preserving one compact
-            # result tensor for the subsequent TP gather.
+        if row_mask is not None and not bool(row_mask.all()):
+            # Split decode rows from prompt-tail rows. The latter use the exact
+            # full head while preserving one compact result tensor for the
+            # subsequent TP gather. Presence metadata is row-aligned for
+            # penalties; the dense count table itself remains shared.
             local_values = torch.empty(
                 (hidden_states.shape[0], local_top_k),
                 dtype=torch.float32,
@@ -912,6 +1033,22 @@ class LogitsProcessor(PluggableLayer):
                     hidden_states[enabled_rows].contiguous(),
                     top_k=top_k,
                     temperature=temperature,
+                    presence_penalties=(
+                        presence_penalties[enabled_rows]
+                        if presence_penalties is not None
+                        else None
+                    ),
+                    output_token_ids=(
+                        output_token_ids[enabled_rows]
+                        if output_token_ids is not None
+                        else None
+                    ),
+                    output_token_counts=output_token_counts,
+                    presence_request_indices=(
+                        presence_request_indices[enabled_rows]
+                        if presence_request_indices is not None
+                        else None
+                    ),
                     embedding_bias=embedding_bias,
                     _hybrid_enabled=True,
                 )
@@ -923,6 +1060,22 @@ class LogitsProcessor(PluggableLayer):
                     hidden_states[disabled_rows].contiguous(),
                     top_k=top_k,
                     temperature=temperature,
+                    presence_penalties=(
+                        presence_penalties[disabled_rows]
+                        if presence_penalties is not None
+                        else None
+                    ),
+                    output_token_ids=(
+                        output_token_ids[disabled_rows]
+                        if output_token_ids is not None
+                        else None
+                    ),
+                    output_token_counts=output_token_counts,
+                    presence_request_indices=(
+                        presence_request_indices[disabled_rows]
+                        if presence_request_indices is not None
+                        else None
+                    ),
                     embedding_bias=embedding_bias,
                     _hybrid_enabled=False,
                 )
@@ -942,6 +1095,7 @@ class LogitsProcessor(PluggableLayer):
             and self.scale > 0.0
             and (self.head_dtype is None or self.head_dtype == hidden_states.dtype)
             and _hybrid_enabled is not False
+            and not envs.VLLM_COMPUTE_NANS_IN_LOGITS
             and hybrid_state.can_use(
                 hidden_states,
                 bf16_weight=lm_head.weight,
@@ -1015,10 +1169,10 @@ class LogitsProcessor(PluggableLayer):
                     )
             if temperature != 1.0:
                 exact_logits.div_(temperature)
-            local_vals, positions = torch.topk(
+            local_vals, positions = _stable_topk(
                 exact_logits,
                 local_top_k,
-                dim=-1,
+                candidate_indices,
             )
             return (
                 local_vals,
@@ -1065,10 +1219,26 @@ class LogitsProcessor(PluggableLayer):
         top_k: int,
         top_p: float,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        candidate_values = gathered_pairs[..., 0]
-        candidate_ids = gathered_pairs[..., 1].to(torch.int64)
+        return LogitsProcessor._select_compact_topk_values_ids(
+            gathered_pairs[..., 0], gathered_pairs[..., 1].to(torch.int64), top_k, top_p
+        )
+
+    @staticmethod
+    def _select_compact_topk_values_ids(
+        candidate_values: torch.Tensor,
+        candidate_ids: torch.Tensor,
+        top_k: int,
+        top_p: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Select compact candidates without converting integer ids to FP32."""
+        if candidate_values.shape != candidate_ids.shape:
+            raise ValueError("candidate values and ids must have matching shapes")
         top_k = min(top_k, candidate_values.shape[-1])
-        top_values, positions = torch.topk(candidate_values, top_k, dim=-1)
+        top_values, positions = _stable_topk(
+            candidate_values,
+            top_k,
+            candidate_ids,
+        )
         top_ids = candidate_ids.gather(-1, positions)
         if top_p < 1.0:
             probs = top_values.softmax(dim=-1, dtype=torch.float32)
@@ -1089,11 +1259,49 @@ class LogitsProcessor(PluggableLayer):
             [local_values, global_indices.to(torch.float32)], dim=-1
         ).flatten(start_dim=-2)
 
-    @staticmethod
     def _sample_compact_topk(
+        self,
         top_values: torch.Tensor,
         top_ids: torch.Tensor,
+        *,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if (
+            (expanded_idx_mapping is None) != (seeds is None)
+            or (expanded_idx_mapping is None) != (pos is None)
+            or (expanded_idx_mapping is None) != (temperature_state is None)
+        ):
+            raise ValueError(
+                "expanded_idx_mapping, seeds, pos, and temperature_state must be "
+                "provided together"
+            )
+        if (
+            expanded_idx_mapping is not None
+            and seeds is not None
+            and pos is not None
+            and top_values.is_cuda
+            and HAS_TRITON
+        ):
+            if temperature_state is None:
+                raise ValueError(
+                    "temperature_state is required with keyed Gumbel metadata"
+                )
+            sampled_positions = gumbel_sample(
+                top_values,
+                expanded_idx_mapping,
+                temperature_state,
+                seeds,
+                pos,
+                apply_temperature=False,
+                use_fp64=False,
+                token_keys=top_ids,
+            )
+            assert isinstance(sampled_positions, torch.Tensor)
+            return top_ids.gather(-1, sampled_positions.unsqueeze(-1)).view(-1)
+
         probs = top_values.softmax(dim=-1, dtype=torch.float32)
         noise = torch.empty_like(probs)
         noise.exponential_()
@@ -1134,10 +1342,22 @@ class LogitsProcessor(PluggableLayer):
             presence_request_indices=presence_request_indices,
             embedding_bias=embedding_bias,
         )
-        local_pairs = self._pack_topk_pairs(
-            local_values, local_indices, vocab_start
-        )
         tp_size = lm_head.tp_size
+        if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+            local_ids = local_indices.to(torch.int64) + vocab_start
+            if tp_size > 1:
+                gathered_values = tensor_model_parallel_all_gather(
+                    local_values, dim=-1
+                )
+                gathered_ids = tensor_model_parallel_all_gather(local_ids, dim=-1)
+            else:
+                gathered_values = local_values
+                gathered_ids = local_ids
+            return self._select_compact_topk_values_ids(
+                gathered_values, gathered_ids, top_k, top_p
+            )
+
+        local_pairs = self._pack_topk_pairs(local_values, local_indices, vocab_start)
         if tp_size > 1:
             gathered_pairs = tensor_model_parallel_all_gather(local_pairs, dim=-1)
             gathered_pairs = gathered_pairs.view(
@@ -1161,6 +1381,10 @@ class LogitsProcessor(PluggableLayer):
         output_token_counts: torch.Tensor | None = None,
         presence_request_indices: torch.Tensor | None = None,
         embedding_bias: torch.Tensor | None = None,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Sample from a compact uniform top-k candidate set."""
         if top_k <= 0:
@@ -1184,33 +1408,84 @@ class LogitsProcessor(PluggableLayer):
             presence_request_indices=presence_request_indices,
             embedding_bias=embedding_bias,
         )
-        local_pairs = self._pack_topk_pairs(
-            local_values, local_indices, vocab_start
-        )
         tp_size = lm_head.tp_size
+        if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+            local_ids = local_indices.to(torch.int64) + vocab_start
+            if tp_size == 1:
+                top_values, top_ids = self._select_compact_topk_values_ids(
+                    local_values, local_ids, top_k, top_p
+                )
+                return self._sample_compact_topk(
+                    top_values,
+                    top_ids,
+                    expanded_idx_mapping=expanded_idx_mapping,
+                    seeds=seeds,
+                    pos=pos,
+                    temperature_state=temperature_state,
+                )
+            gathered_values = tensor_model_parallel_gather(
+                local_values, dst=0, dim=-1
+            )
+            gathered_ids = tensor_model_parallel_gather(local_ids, dst=0, dim=-1)
+        else:
+            local_pairs = self._pack_topk_pairs(
+                local_values, local_indices, vocab_start
+            )
+            gathered_values = tensor_model_parallel_gather(local_pairs, dst=0, dim=-1)
+
         if tp_size == 1:
-            gathered_pairs = local_pairs.view(
-                hidden_states.shape[0], local_values.shape[-1], 2
+            if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+                top_values, top_ids = self._select_compact_topk_values_ids(
+                    local_values, local_ids, top_k, top_p
+                )
+            else:
+                gathered_pairs = local_pairs.view(
+                    hidden_states.shape[0], local_values.shape[-1], 2
+                )
+                top_values, top_ids = self._select_compact_topk_pairs(
+                    gathered_pairs, top_k, top_p
+                )
+            return self._sample_compact_topk(
+                top_values,
+                top_ids,
+                expanded_idx_mapping=expanded_idx_mapping,
+                seeds=seeds,
+                pos=pos,
+                temperature_state=temperature_state,
             )
-            top_values, top_ids = self._select_compact_topk_pairs(
-                gathered_pairs, top_k, top_p
-            )
-            return self._sample_compact_topk(top_values, top_ids)
 
         # Sampling must happen once and be broadcast.  Independent RNG draws
         # on TP ranks can otherwise produce different tokens even though the
         # candidate pairs are identical.
-        gathered_pairs = tensor_model_parallel_gather(local_pairs, dst=0, dim=-1)
         tp_group = get_tp_group()
         if tp_group.rank_in_group == 0:
-            assert gathered_pairs is not None
-            gathered_pairs = gathered_pairs.view(
-                hidden_states.shape[0], tp_size * local_values.shape[-1], 2
+            assert gathered_values is not None
+            if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+                assert gathered_ids is not None
+                gathered_values = gathered_values.view(
+                    hidden_states.shape[0], tp_size * local_values.shape[-1]
+                )
+                gathered_ids = gathered_ids.view(
+                    hidden_states.shape[0], tp_size * local_values.shape[-1]
+                )
+                top_values, top_ids = self._select_compact_topk_values_ids(
+                    gathered_values, gathered_ids, top_k, top_p
+                )
+            else:
+                gathered_pairs = gathered_values.view(
+                    hidden_states.shape[0], tp_size * local_values.shape[-1], 2
+                )
+                top_values, top_ids = self._select_compact_topk_pairs(
+                    gathered_pairs, top_k, top_p
+                )
+            sampled = self._sample_compact_topk(
+                top_values,
+                top_ids,
+                expanded_idx_mapping=expanded_idx_mapping,
+                seeds=seeds,
+                pos=pos,
+                temperature_state=temperature_state,
             )
-            top_values, top_ids = self._select_compact_topk_pairs(
-                gathered_pairs, top_k, top_p
-            )
-            sampled = self._sample_compact_topk(top_values, top_ids)
         else:
             sampled = torch.empty(
                 (hidden_states.shape[0],),

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -4,12 +4,15 @@
 
 from collections.abc import Callable
 from functools import cache
+from typing import Any
 
 import torch
 import torch.nn.functional as F
 
+import vllm.envs as envs
 from vllm.config import get_current_vllm_config
 from vllm.distributed import (
+    get_tp_group,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_gather,
 )
@@ -23,16 +26,34 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.flashinfer import has_flashinfer
 
+indexed_argmax_triton: Any
+reduce_global_argmax_triton: Any
+
 if HAS_TRITON:
     from vllm.model_executor.layers.argmax_triton import (
-        indexed_argmax_triton,
-        reduce_global_argmax_triton,
+        indexed_argmax_triton as _indexed_argmax_triton,
     )
+    from vllm.model_executor.layers.argmax_triton import (
+        reduce_global_argmax_triton as _reduce_global_argmax_triton,
+    )
+    from vllm.model_executor.layers.presence_penalty_triton import (
+        apply_presence_penalty_from_counts,
+    )
+
+    indexed_argmax_triton = _indexed_argmax_triton
+    reduce_global_argmax_triton = _reduce_global_argmax_triton
+    _apply_presence_penalty_from_counts = apply_presence_penalty_from_counts
 else:
     indexed_argmax_triton = None
     reduce_global_argmax_triton = None
+    _apply_presence_penalty_from_counts = None
 
 logger = init_logger(__name__)
+
+# Keep Gumbel noise bounded when the unrestricted path has a large vocabulary.
+# The full local logits projection is unavoidable, but a second full-sized
+# noise/scores matrix is not.
+_FULL_SAMPLE_BLOCK_SIZE = 8192
 
 
 @cache
@@ -103,6 +124,14 @@ class LogitsProcessor(PluggableLayer):
         # required for RL training-inference consistency.
         model_config = get_current_vllm_config().model_config
         self.head_dtype = model_config.head_dtype if model_config is not None else None
+        # Callers that must keep one execution path for a CUDA graph (for
+        # example a draft model) can disable the compact head for the whole
+        # call.  The V2 runner uses the row mask below for mixed batches.
+        self.hybrid_lm_head_enabled = True
+        # The V2 runner may install a one-call row mask for mixed prefill and
+        # decode batches.  ``True`` rows may use the compact approximate head;
+        # ``False`` rows stay on the exact full-vocabulary path.
+        self.hybrid_lm_head_row_mask: torch.Tensor | None = None
 
     def forward(
         self,
@@ -208,11 +237,51 @@ class LogitsProcessor(PluggableLayer):
         hidden_states: torch.Tensor,
         embedding_bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        row_mask = self._get_hybrid_lm_head_row_mask(hidden_states)
+        if row_mask is not None and not bool(row_mask.all()):
+            result = torch.empty(
+                hidden_states.shape[0],
+                dtype=torch.int64,
+                device=hidden_states.device,
+            )
+            enabled_rows = torch.nonzero(row_mask, as_tuple=True)[0]
+            if enabled_rows.numel() > 0:
+                result[enabled_rows] = self._get_top_tokens_single(
+                    lm_head,
+                    hidden_states[enabled_rows].contiguous(),
+                    embedding_bias=embedding_bias,
+                    _hybrid_enabled=True,
+                )
+            disabled_rows = torch.nonzero(~row_mask, as_tuple=True)[0]
+            if disabled_rows.numel() > 0:
+                result[disabled_rows] = self._get_top_tokens_single(
+                    lm_head,
+                    hidden_states[disabled_rows].contiguous(),
+                    embedding_bias=embedding_bias,
+                    _hybrid_enabled=False,
+                )
+            return result
+        return self._get_top_tokens_single(
+            lm_head,
+            hidden_states,
+            embedding_bias=embedding_bias,
+        )
+
+    def _get_top_tokens_single(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        embedding_bias: torch.Tensor | None = None,
+        *,
+        _hybrid_enabled: bool | None = None,
+    ) -> torch.Tensor:
         """Vocab-parallel argmax without all-gathering full logits.
 
         Each TP rank computes local argmax, then only the (value, index) pairs
         are gathered and reduced. Communication: O(batch * 2 * tp_size) vs
-        O(batch * vocab_size).
+        O(batch * vocab_size). The optional hybrid state uses an approximate
+        NVFP4 candidate search and is only selected for explicitly compatible
+        model configurations.
         """
         if self.scale <= 0.0 and self.scale != 1.0:
             raise ValueError(
@@ -224,6 +293,10 @@ class LogitsProcessor(PluggableLayer):
         hybrid_state = getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None)
         shard_indices = lm_head.shard_indices
         num_pad = shard_indices.num_org_vocab_padding
+        has_added_vocab = (
+            getattr(lm_head, "num_added_embeddings", 0) > 0
+            or getattr(shard_indices, "num_added_elements", 0) > 0
+        )
         local_vocab_size = getattr(shard_indices, "num_elements_padded", None)
         if local_vocab_size is None:
             local_vocab_size = getattr(
@@ -231,11 +304,63 @@ class LogitsProcessor(PluggableLayer):
                 "num_embeddings_per_partition",
                 self.vocab_size,
             )
+        assert local_vocab_size is not None
         active_vocab_size = local_vocab_size - num_pad
+        if has_added_vocab:
+            # Base and added vocabularies have separate padded regions.  Mask
+            # both regions and map the surviving local positions explicitly;
+            # treating the whole shard as ``local_id + org_vocab_start`` would
+            # return incorrect ids for LoRA-added embeddings.
+            logits = self._apply_head(lm_head, hidden_states, embedding_bias)
+            if self.soft_cap is not None:
+                logits = torch.tanh(logits / self.soft_cap) * self.soft_cap
+            if self.scale != 1.0:
+                logits = logits * self.scale
+
+            local_ids = torch.arange(logits.shape[-1], device=logits.device)
+            org_local_start = (
+                shard_indices.org_vocab_start_index
+                - shard_indices.padded_org_vocab_start_index
+            )
+            org_local_end = org_local_start + shard_indices.num_org_elements
+            valid_mask = (local_ids >= org_local_start) & (local_ids < org_local_end)
+            num_org_padded = shard_indices.num_org_elements_padded
+            if (
+                shard_indices.added_vocab_end_index
+                > shard_indices.added_vocab_start_index
+            ):
+                added_local_start = num_org_padded + (
+                    shard_indices.added_vocab_start_index
+                    - shard_indices.padded_added_vocab_start_index
+                )
+                added_local_end = added_local_start + shard_indices.num_added_elements
+                valid_mask |= (local_ids >= added_local_start) & (
+                    local_ids < added_local_end
+                )
+            logits = logits.masked_fill(~valid_mask, -float("inf"))
+            local_max_vals, local_max_indices = logits.max(dim=-1)
+            global_indices = torch.where(
+                local_max_indices < num_org_padded,
+                shard_indices.padded_org_vocab_start_index + local_max_indices,
+                shard_indices.padded_added_vocab_start_index
+                + local_max_indices
+                - num_org_padded,
+            )
+            return self.reduce_local_argmax(
+                local_max_vals,
+                global_indices,
+                tp_size=tp_size,
+            )
         if (
             hybrid_state is not None
             and self.soft_cap is None
             and self.scale > 0.0
+            and not envs.VLLM_BATCH_INVARIANT
+            and not has_added_vocab
+            and self._is_contiguous_org_shard(lm_head)
+            and self.hybrid_lm_head_enabled
+            and _hybrid_enabled is not False
+            and (self.head_dtype is None or self.head_dtype == hidden_states.dtype)
             and hybrid_state.can_use(
                 hidden_states,
                 bf16_weight=lm_head.weight,
@@ -249,7 +374,8 @@ class LogitsProcessor(PluggableLayer):
             )
             if num_pad > 0:
                 coarse_logits[..., -num_pad:] = -float("inf")
-            candidate_indices = hybrid_state.select_candidates(
+            candidate_indices = self._select_hybrid_candidates(
+                hybrid_state,
                 coarse_logits,
                 top_k=1,
             )
@@ -270,13 +396,24 @@ class LogitsProcessor(PluggableLayer):
                     index_offset=shard_indices.org_vocab_start_index,
                 )
             else:
-                local_max_vals, candidate_pos = exact_logits.max(dim=-1)
-                local_max_indices = candidate_indices.gather(
-                    -1, candidate_pos.unsqueeze(-1)
-                ).squeeze(-1)
-                global_indices = (
-                    local_max_indices + shard_indices.org_vocab_start_index
+                # Match the Triton path's NaN handling and lower-token-id
+                # tie break when the indexed kernel is unavailable.
+                finite_logits = torch.where(
+                    exact_logits == exact_logits,
+                    exact_logits,
+                    torch.full_like(exact_logits, -float("inf")),
                 )
+                local_max_vals = finite_logits.max(dim=-1).values
+                candidate_indices_i64 = candidate_indices.to(torch.int64)
+                tie_break_ids = torch.where(
+                    finite_logits == local_max_vals.unsqueeze(-1),
+                    candidate_indices_i64,
+                    torch.full_like(
+                        candidate_indices_i64, torch.iinfo(torch.int64).max
+                    ),
+                )
+                local_max_indices = tie_break_ids.min(dim=-1).values
+                global_indices = local_max_indices + shard_indices.org_vocab_start_index
             if self.scale != 1.0:
                 local_max_vals = local_max_vals * self.scale
             return self.reduce_local_argmax(
@@ -299,18 +436,22 @@ class LogitsProcessor(PluggableLayer):
         local_max_vals, local_max_indices = logits.max(dim=-1)
         vocab_start = lm_head.shard_indices.org_vocab_start_index
         global_indices = local_max_indices + vocab_start
-
-        if tp_size == 1:
-            return global_indices
-
-        local_pair = torch.stack(
-            [local_max_vals.float(), global_indices.float()], dim=-1
+        return self.reduce_local_argmax(
+            local_max_vals,
+            global_indices,
+            tp_size=tp_size,
         )
-        gathered = tensor_model_parallel_all_gather(local_pair, dim=-1)
-        gathered = gathered.view(hidden_states.shape[0], tp_size, 2)
-        max_rank_idx = gathered[:, :, 0].argmax(dim=-1, keepdim=True)
-        top_tokens = gathered[:, :, 1].gather(dim=-1, index=max_rank_idx)
-        return top_tokens.squeeze(-1).to(torch.int64)
+
+    def _get_hybrid_lm_head_row_mask(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor | None:
+        """Return a valid one-call compact-path row mask, if installed."""
+        mask = self.hybrid_lm_head_row_mask
+        if mask is None or mask.ndim != 1 or mask.shape[0] != hidden_states.shape[0]:
+            return None
+        if mask.device != hidden_states.device:
+            mask = mask.to(hidden_states.device, non_blocking=True)
+        return mask.to(dtype=torch.bool)
 
     def reduce_local_argmax(
         self,
@@ -326,14 +467,112 @@ class LogitsProcessor(PluggableLayer):
             [local_max_vals.float(), global_indices.float()], dim=-1
         )
         gathered = tensor_model_parallel_all_gather(local_pair, dim=-1)
+        return self._reduce_global_argmax_pairs(gathered, tp_size)
+
+    @staticmethod
+    def _reduce_global_argmax_pairs(
+        gathered: torch.Tensor,
+        tp_size: int,
+    ) -> torch.Tensor:
+        """Reduce ``(score, token_id)`` pairs with NaN-safe tie handling."""
         if reduce_global_argmax_triton is not None and gathered.is_cuda:
             return reduce_global_argmax_triton(gathered, tp_size=tp_size).to(
                 torch.int64
             )
         gathered = gathered.view(gathered.shape[0], tp_size, 2)
-        max_rank_idx = gathered[:, :, 0].argmax(dim=-1, keepdim=True)
-        top_tokens = gathered[:, :, 1].gather(dim=-1, index=max_rank_idx)
-        return top_tokens.squeeze(-1).to(torch.int64)
+        values = torch.where(
+            gathered[:, :, 0] == gathered[:, :, 0],
+            gathered[:, :, 0],
+            torch.full_like(gathered[:, :, 0], -float("inf")),
+        )
+        max_values = values.max(dim=-1, keepdim=True).values
+        tie_break_ids = torch.where(
+            values == max_values,
+            gathered[:, :, 1],
+            torch.full_like(gathered[:, :, 1], float("inf")),
+        )
+        return tie_break_ids.min(dim=-1).values.to(torch.int64)
+
+    def sample_full_tokens(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        temperature: float,
+        embedding_bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Sample an unrestricted distribution without gathering full logits.
+
+        Gumbel-max is evaluated independently on each TP-local shard. Only
+        one winning ``(score, global_token_id)`` pair per row is gathered and
+        the sampled id is broadcast, preserving one-token-per-request
+        semantics while avoiding the ``[batch, vocab]`` TP all-gather.
+        """
+        if hidden_states.ndim != 2:
+            raise ValueError("sample_full_tokens requires rank-2 hidden states")
+        if temperature <= 0.0:
+            raise ValueError(
+                "sample_full_tokens requires positive temperature; "
+                f"got {temperature}"
+            )
+        if not self._is_contiguous_org_shard(lm_head):
+            raise ValueError(
+                "full-distribution sampling requires a contiguous original-vocab "
+                "shard"
+            )
+
+        shard_indices = lm_head.shard_indices
+        local_vocab_size = getattr(
+            shard_indices,
+            "num_elements_padded",
+            getattr(lm_head, "num_embeddings_per_partition", self.vocab_size),
+        )
+        active_vocab_size = local_vocab_size - shard_indices.num_org_vocab_padding
+        logits = self._apply_head(lm_head, hidden_states, embedding_bias).to(
+            torch.float32
+        )
+        if self.soft_cap is not None:
+            logits = torch.tanh(logits / self.soft_cap) * self.soft_cap
+        if self.scale != 1.0:
+            logits.mul_(self.scale)
+        logits.div_(temperature)
+        self._mask_invalid_shard_logits(logits, active_vocab_size)
+
+        # Reuse the logits buffer for Gumbel scores. Keeping a separate
+        # ``scores`` tensor would add another full ``[batch, vocab]``
+        # allocation on top of the local logits and exponential noise.
+        for start in range(0, logits.shape[-1], _FULL_SAMPLE_BLOCK_SIZE):
+            end = min(start + _FULL_SAMPLE_BLOCK_SIZE, logits.shape[-1])
+            block = logits[..., start:end]
+            noise = torch.empty_like(block)
+            noise.exponential_()
+            block.sub_(noise.log_())
+            # Keep NaN diagnostics fail-closed without materializing another
+            # full score matrix.  The bool mask is bounded by one block.
+            block.masked_fill_(torch.isnan(block), -float("inf"))
+        local_scores, local_indices = logits.max(dim=-1)
+        global_indices = local_indices.to(torch.int64) + (
+            shard_indices.org_vocab_start_index
+        )
+        tp_size = lm_head.tp_size
+        if tp_size == 1:
+            return global_indices
+
+        local_pair = torch.stack(
+            [local_scores, global_indices.to(torch.float32)], dim=-1
+        )
+        gathered = tensor_model_parallel_gather(local_pair, dst=0, dim=-1)
+        tp_group = get_tp_group()
+        if tp_group.rank_in_group == 0:
+            assert gathered is not None
+            sampled = self._reduce_global_argmax_pairs(gathered, tp_size)
+        else:
+            sampled = torch.empty(
+                (hidden_states.shape[0],),
+                dtype=torch.int64,
+                device=hidden_states.device,
+            )
+        tp_group.broadcast(sampled, src=0)
+        return sampled
 
     def get_top_k_tokens(
         self,
@@ -381,6 +620,605 @@ class LogitsProcessor(PluggableLayer):
         if self.soft_cap is not None:
             values = torch.tanh(values / self.soft_cap) * self.soft_cap
         return ids, values
+
+    @staticmethod
+    def _is_contiguous_org_shard(lm_head: VocabParallelEmbedding) -> bool:
+        """Whether local logits map to one contiguous original-vocab shard."""
+        shard_indices = lm_head.shard_indices
+        # Older shard-index implementations expose only one of these fields.
+        # Treat either real or padded added-vocab entries as incompatible with
+        # the contiguous original-vocabulary fast path.
+        return (
+            getattr(shard_indices, "num_added_elements_padded", 0) == 0
+            and getattr(shard_indices, "num_added_elements", 0) == 0
+        )
+
+    @staticmethod
+    def _mask_invalid_shard_logits(
+        logits: torch.Tensor,
+        active_vocab_size: int,
+    ) -> None:
+        if active_vocab_size < logits.shape[-1]:
+            logits[..., active_vocab_size:] = -float("inf")
+
+    @staticmethod
+    def _select_hybrid_candidates(
+        hybrid_state: Any,
+        coarse_logits: torch.Tensor,
+        top_k: int,
+    ) -> torch.Tensor:
+        """Select a widened candidate set while accepting legacy test states."""
+        try:
+            return hybrid_state.select_candidates(coarse_logits, top_k=top_k)
+        except TypeError as exc:
+            # Older state objects did not expose a top_k keyword.  Keep this
+            # compatibility fallback narrow so unrelated implementation errors
+            # are not silently hidden.
+            if "top_k" not in str(exc):
+                raise
+            return hybrid_state.select_candidates(coarse_logits)
+
+    @staticmethod
+    def _apply_presence_penalty_from_counts(
+        logits: torch.Tensor,
+        presence_penalties: torch.Tensor,
+        output_token_counts: torch.Tensor,
+        presence_request_indices: torch.Tensor,
+        *,
+        shard_indices: Any,
+        local_token_ids: torch.Tensor | None = None,
+    ) -> None:
+        """Apply V2 presence penalties without constructing a dense mask on CUDA."""
+        if logits.numel() == 0:
+            return
+        if logits.ndim != 2:
+            raise ValueError("logits must be rank 2")
+        if output_token_counts is None or output_token_counts.ndim != 2:
+            raise ValueError("output_token_counts must be rank 2")
+        if presence_request_indices.shape != (logits.shape[0],):
+            raise ValueError("presence_request_indices must have one entry per row")
+        if presence_penalties.shape != (logits.shape[0],):
+            raise ValueError("presence_penalties must have one entry per row")
+        if local_token_ids is not None and local_token_ids.shape != logits.shape:
+            raise ValueError("local_token_ids must match logits")
+
+        num_org_elements = getattr(
+            shard_indices,
+            "num_org_elements",
+            logits.shape[-1] - shard_indices.num_org_vocab_padding,
+        )
+        num_org_elements_padded = getattr(
+            shard_indices,
+            "num_org_elements_padded",
+            num_org_elements + shard_indices.num_org_vocab_padding,
+        )
+        added_vocab_start = getattr(
+            shard_indices,
+            "added_vocab_start_index",
+            getattr(shard_indices, "org_vocab_end_index", num_org_elements),
+        )
+        num_added_elements = getattr(shard_indices, "num_added_elements", 0)
+
+        if (
+            _apply_presence_penalty_from_counts is not None
+            and logits.is_cuda
+            and logits.is_contiguous()
+            and output_token_counts.is_cuda
+            and presence_request_indices.is_cuda
+            and presence_penalties.is_cuda
+            and (local_token_ids is None or local_token_ids.is_cuda)
+        ):
+            _apply_presence_penalty_from_counts(
+                logits,
+                output_token_counts,
+                presence_request_indices,
+                presence_penalties,
+                org_vocab_start=shard_indices.org_vocab_start_index,
+                num_org_elements=num_org_elements,
+                num_org_elements_padded=num_org_elements_padded,
+                added_vocab_start=added_vocab_start,
+                num_added_elements=num_added_elements,
+                local_token_ids=local_token_ids,
+            )
+            return
+
+        # CPU and non-Triton fallback. This path is intentionally simple; the
+        # CUDA implementation above is the memory-sensitive one.
+        if not logits.is_contiguous():
+            raise ValueError("logits must be contiguous")
+        if local_token_ids is None:
+            local_ids = torch.arange(
+                logits.shape[-1], dtype=torch.int64, device=logits.device
+            ).expand_as(logits)
+        else:
+            local_ids = local_token_ids.to(torch.int64)
+        is_org = local_ids < num_org_elements
+        added_offsets = local_ids - num_org_elements_padded
+        is_added = (added_offsets >= 0) & (added_offsets < num_added_elements)
+        global_ids = torch.where(
+            is_org,
+            local_ids + shard_indices.org_vocab_start_index,
+            added_offsets + added_vocab_start,
+        )
+        valid = (is_org | is_added) & (global_ids >= 0)
+        valid &= global_ids < output_token_counts.shape[-1]
+        safe_ids = global_ids.clamp(0, output_token_counts.shape[-1] - 1)
+        request_indices = presence_request_indices.to(torch.int64).unsqueeze(1)
+        counts = output_token_counts[request_indices, safe_ids]
+        penalty = presence_penalties.to(logits.dtype).unsqueeze(1)
+        logits.sub_(torch.where(valid & (counts > 0), penalty, 0.0))
+
+    @staticmethod
+    def _apply_presence_penalty_from_token_ids(
+        logits: torch.Tensor,
+        presence_penalties: torch.Tensor,
+        output_token_ids: torch.Tensor,
+        *,
+        shard_indices: Any,
+        local_token_ids: torch.Tensor | None = None,
+    ) -> None:
+        """Apply presence penalties from a compact per-row token-id table.
+
+        This is used by the legacy runner, which does not maintain V2's dense
+        output-count table.  The full local-shard path uses ``scatter_add_``
+        over unique token ids, while the refined matrix only compares against
+        its at-most-1024 candidate columns.  Neither path allocates a
+        ``[batch, vocab]`` penalty mask.
+        """
+        if logits.numel() == 0:
+            return
+        if logits.ndim != 2 or not logits.is_contiguous():
+            raise ValueError("logits must be a contiguous rank-2 tensor")
+        if output_token_ids.ndim != 2:
+            raise ValueError("output_token_ids must be rank 2")
+        if output_token_ids.shape[0] != logits.shape[0]:
+            raise ValueError("output_token_ids must have one row per logits row")
+        if presence_penalties.shape != (logits.shape[0],):
+            raise ValueError("presence_penalties must have one entry per logits row")
+        if local_token_ids is not None and local_token_ids.shape != logits.shape:
+            raise ValueError("local_token_ids must match logits")
+        if output_token_ids.shape[1] == 0:
+            return
+
+        output_ids = output_token_ids.to(torch.int64)
+        org_vocab_start = shard_indices.org_vocab_start_index
+        if local_token_ids is None:
+            num_pad = shard_indices.num_org_vocab_padding
+            active_vocab_size = logits.shape[-1] - num_pad
+            local_ids = output_ids - org_vocab_start
+            valid = (local_ids >= 0) & (local_ids < active_vocab_size)
+            safe_ids = local_ids.clamp(0, max(active_vocab_size - 1, 0))
+            delta = -presence_penalties.to(logits.dtype).unsqueeze(1) * valid.to(
+                logits.dtype
+            )
+            # The caller supplies unique output ids, so scatter-add applies
+            # each presence penalty exactly once per row.
+            logits.scatter_add_(1, safe_ids, delta)
+            return
+
+        candidate_global_ids = local_token_ids.to(torch.int64) + org_vocab_start
+        valid_output = output_ids >= 0
+        sentinel = torch.iinfo(torch.int64).max
+        sorted_output_ids = torch.where(
+            valid_output,
+            output_ids,
+            torch.full_like(output_ids, sentinel),
+        ).sort(dim=-1).values
+        positions = torch.searchsorted(sorted_output_ids, candidate_global_ids)
+        safe_positions = positions.clamp(max=sorted_output_ids.shape[-1] - 1)
+        matched = sorted_output_ids.gather(1, safe_positions) == candidate_global_ids
+        logits.sub_(
+            matched.to(logits.dtype)
+            * presence_penalties.to(logits.dtype).unsqueeze(1)
+        )
+
+    def _get_local_topk(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        *,
+        top_k: int,
+        temperature: float,
+        presence_penalties: torch.Tensor | None = None,
+        output_token_ids: torch.Tensor | None = None,
+        output_token_counts: torch.Tensor | None = None,
+        presence_request_indices: torch.Tensor | None = None,
+        embedding_bias: torch.Tensor | None = None,
+        _hybrid_enabled: bool | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, int]:
+        """Compute local top-k values and ids, optionally via hybrid refine."""
+        if top_k <= 0:
+            raise ValueError(f"top_k must be positive, got {top_k}")
+        if temperature <= 0.0:
+            raise ValueError(
+                "_get_local_topk requires positive temperature; "
+                f"got {temperature}"
+            )
+        if presence_penalties is not None:
+            if (
+                output_token_counts is None
+                and output_token_ids is None
+            ) or (
+                output_token_counts is not None
+                and presence_request_indices is None
+                and output_token_ids is None
+            ):
+                raise ValueError(
+                    "presence penalties require either output token ids or "
+                    "output token counts with request indices"
+                )
+            if (
+                output_token_counts is not None
+                and presence_request_indices is not None
+            ):
+                assert presence_request_indices is not None
+            if output_token_ids is not None:
+                if output_token_ids.ndim != 2:
+                    raise ValueError("output_token_ids must be rank 2")
+                if output_token_ids.shape[0] != hidden_states.shape[0]:
+                    raise ValueError(
+                        "output_token_ids must have one row per hidden-state row"
+                    )
+
+        shard_indices = lm_head.shard_indices
+        if not self._is_contiguous_org_shard(lm_head):
+            raise ValueError(
+                "compact top-k sampling requires a contiguous original-vocab shard"
+            )
+        local_vocab_size = getattr(
+            shard_indices,
+            "num_elements_padded",
+            getattr(lm_head, "num_embeddings_per_partition", self.vocab_size),
+        )
+        num_pad = shard_indices.num_org_vocab_padding
+        active_vocab_size = local_vocab_size - num_pad
+        local_top_k = min(top_k, active_vocab_size)
+        if local_top_k <= 0:
+            raise ValueError("the local vocabulary shard is empty")
+
+        row_mask = (
+            None
+            if _hybrid_enabled is not None
+            else self._get_hybrid_lm_head_row_mask(hidden_states)
+        )
+        if (
+            row_mask is not None
+            and not bool(row_mask.all())
+            and presence_penalties is None
+            and output_token_ids is None
+            and output_token_counts is None
+            and presence_request_indices is None
+            and embedding_bias is None
+        ):
+            # The common speculative top-k path has no request-dependent
+            # processors, so split decode rows from prompt-tail rows.  The
+            # latter use the exact full head while preserving one compact
+            # result tensor for the subsequent TP gather.
+            local_values = torch.empty(
+                (hidden_states.shape[0], local_top_k),
+                dtype=torch.float32,
+                device=hidden_states.device,
+            )
+            local_indices = torch.empty(
+                (hidden_states.shape[0], local_top_k),
+                dtype=torch.int64,
+                device=hidden_states.device,
+            )
+            enabled_rows = torch.nonzero(row_mask, as_tuple=True)[0]
+            disabled_rows = torch.nonzero(~row_mask, as_tuple=True)[0]
+            if enabled_rows.numel() > 0:
+                enabled_values, enabled_indices, _ = self._get_local_topk(
+                    lm_head,
+                    hidden_states[enabled_rows].contiguous(),
+                    top_k=top_k,
+                    temperature=temperature,
+                    embedding_bias=embedding_bias,
+                    _hybrid_enabled=True,
+                )
+                local_values[enabled_rows] = enabled_values
+                local_indices[enabled_rows] = enabled_indices
+            if disabled_rows.numel() > 0:
+                disabled_values, disabled_indices, _ = self._get_local_topk(
+                    lm_head,
+                    hidden_states[disabled_rows].contiguous(),
+                    top_k=top_k,
+                    temperature=temperature,
+                    embedding_bias=embedding_bias,
+                    _hybrid_enabled=False,
+                )
+                local_values[disabled_rows] = disabled_values
+                local_indices[disabled_rows] = disabled_indices
+            return local_values, local_indices, shard_indices.org_vocab_start_index
+
+        # Added-vocabulary shards have a split physical layout and are rejected
+        # above; the runner performs the same gate before calling this method.
+        hybrid_state = getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None)
+        hybrid_eligible = (
+            hybrid_state is not None
+            and self._is_contiguous_org_shard(lm_head)
+            and not envs.VLLM_BATCH_INVARIANT
+            and getattr(self, "hybrid_lm_head_enabled", True)
+            and self.soft_cap is None
+            and self.scale > 0.0
+            and (self.head_dtype is None or self.head_dtype == hidden_states.dtype)
+            and _hybrid_enabled is not False
+            and hybrid_state.can_use(
+                hidden_states,
+                bf16_weight=lm_head.weight,
+                active_vocab_size=active_vocab_size,
+                top_k=local_top_k,
+            )
+        )
+
+        if hybrid_eligible:
+            coarse_logits = hybrid_state.coarse_logits(
+                hidden_states,
+                embedding_bias,
+            )
+            if self.scale != 1.0:
+                coarse_logits = coarse_logits.to(torch.float32) * self.scale
+            self._mask_invalid_shard_logits(coarse_logits, active_vocab_size)
+            if presence_penalties is not None:
+                if (
+                    output_token_counts is not None
+                    and presence_request_indices is not None
+                ):
+                    self._apply_presence_penalty_from_counts(
+                        coarse_logits,
+                        presence_penalties,
+                        output_token_counts,
+                        presence_request_indices,
+                        shard_indices=shard_indices,
+                    )
+                else:
+                    assert output_token_ids is not None
+                    self._apply_presence_penalty_from_token_ids(
+                        coarse_logits,
+                        presence_penalties,
+                        output_token_ids,
+                        shard_indices=shard_indices,
+                    )
+            candidate_indices = self._select_hybrid_candidates(
+                hybrid_state,
+                coarse_logits,
+                local_top_k,
+            )
+            exact_logits = hybrid_state.refine_logits(
+                hidden_states,
+                lm_head.weight,
+                candidate_indices,
+                embedding_bias,
+            ).to(torch.float32)
+            if self.scale != 1.0:
+                exact_logits.mul_(self.scale)
+            if presence_penalties is not None:
+                if (
+                    output_token_counts is not None
+                    and presence_request_indices is not None
+                ):
+                    self._apply_presence_penalty_from_counts(
+                        exact_logits,
+                        presence_penalties,
+                        output_token_counts,
+                        presence_request_indices,
+                        shard_indices=shard_indices,
+                        local_token_ids=candidate_indices,
+                    )
+                else:
+                    assert output_token_ids is not None
+                    self._apply_presence_penalty_from_token_ids(
+                        exact_logits,
+                        presence_penalties,
+                        output_token_ids,
+                        shard_indices=shard_indices,
+                        local_token_ids=candidate_indices,
+                    )
+            if temperature != 1.0:
+                exact_logits.div_(temperature)
+            local_vals, positions = torch.topk(
+                exact_logits,
+                local_top_k,
+                dim=-1,
+            )
+            return (
+                local_vals,
+                candidate_indices.gather(1, positions),
+                shard_indices.org_vocab_start_index,
+            )
+
+        logits = self._apply_head(lm_head, hidden_states, embedding_bias).to(
+            torch.float32
+        )
+        if self.soft_cap is not None:
+            logits = torch.tanh(logits / self.soft_cap) * self.soft_cap
+        if self.scale != 1.0:
+            logits = logits * self.scale
+        if presence_penalties is not None:
+            if (
+                output_token_counts is not None
+                and presence_request_indices is not None
+            ):
+                self._apply_presence_penalty_from_counts(
+                    logits,
+                    presence_penalties,
+                    output_token_counts,
+                    presence_request_indices,
+                    shard_indices=shard_indices,
+                )
+            else:
+                assert output_token_ids is not None
+                self._apply_presence_penalty_from_token_ids(
+                    logits,
+                    presence_penalties,
+                    output_token_ids,
+                    shard_indices=shard_indices,
+                )
+        if temperature != 1.0:
+            logits.div_(temperature)
+        self._mask_invalid_shard_logits(logits, active_vocab_size)
+        local_vals, local_indices = _topk(logits, local_top_k)
+        return local_vals, local_indices, shard_indices.org_vocab_start_index
+
+    @staticmethod
+    def _select_compact_topk_pairs(
+        gathered_pairs: torch.Tensor,
+        top_k: int,
+        top_p: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        candidate_values = gathered_pairs[..., 0]
+        candidate_ids = gathered_pairs[..., 1].to(torch.int64)
+        top_k = min(top_k, candidate_values.shape[-1])
+        top_values, positions = torch.topk(candidate_values, top_k, dim=-1)
+        top_ids = candidate_ids.gather(-1, positions)
+        if top_p < 1.0:
+            probs = top_values.softmax(dim=-1, dtype=torch.float32)
+            cumulative_probs = torch.cumsum(probs, dim=-1)
+            remove_mask = cumulative_probs - probs > top_p
+            top_values = top_values.masked_fill(remove_mask, -float("inf"))
+        return top_values, top_ids
+
+    @staticmethod
+    def _pack_topk_pairs(
+        local_values: torch.Tensor,
+        local_indices: torch.Tensor,
+        vocab_start: int,
+    ) -> torch.Tensor:
+        """Pack local values and global token ids for TP communication."""
+        global_indices = local_indices.to(torch.int64) + vocab_start
+        return torch.stack(
+            [local_values, global_indices.to(torch.float32)], dim=-1
+        ).flatten(start_dim=-2)
+
+    @staticmethod
+    def _sample_compact_topk(
+        top_values: torch.Tensor,
+        top_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        probs = top_values.softmax(dim=-1, dtype=torch.float32)
+        noise = torch.empty_like(probs)
+        noise.exponential_()
+        sampled_positions = probs.div(noise).argmax(dim=-1, keepdim=True)
+        return top_ids.gather(-1, sampled_positions).view(-1)
+
+    def get_topk_candidates(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        presence_penalties: torch.Tensor | None = None,
+        output_token_ids: torch.Tensor | None = None,
+        output_token_counts: torch.Tensor | None = None,
+        presence_request_indices: torch.Tensor | None = None,
+        embedding_bias: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return compact global top-k/top-p candidates.
+
+        Only ``presence_penalty`` is supported by the hybrid path. The runner
+        uses the same method for native fallback, while rejecting sampling
+        features that require the full-vocabulary logits tensor.
+        """
+        if top_k <= 0:
+            raise ValueError(f"top_k must be positive, got {top_k}")
+        if not 0.0 < top_p <= 1.0:
+            raise ValueError(f"top_p must be in (0, 1], got {top_p}")
+        local_values, local_indices, vocab_start = self._get_local_topk(
+            lm_head,
+            hidden_states,
+            top_k=top_k,
+            temperature=temperature,
+            presence_penalties=presence_penalties,
+            output_token_ids=output_token_ids,
+            output_token_counts=output_token_counts,
+            presence_request_indices=presence_request_indices,
+            embedding_bias=embedding_bias,
+        )
+        local_pairs = self._pack_topk_pairs(
+            local_values, local_indices, vocab_start
+        )
+        tp_size = lm_head.tp_size
+        if tp_size > 1:
+            gathered_pairs = tensor_model_parallel_all_gather(local_pairs, dim=-1)
+            gathered_pairs = gathered_pairs.view(
+                hidden_states.shape[0], tp_size * local_values.shape[-1], 2
+            )
+        else:
+            gathered_pairs = local_pairs.view(
+                hidden_states.shape[0], local_values.shape[-1], 2
+            )
+        return self._select_compact_topk_pairs(gathered_pairs, top_k, top_p)
+
+    def sample_topk_tokens(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        presence_penalties: torch.Tensor | None = None,
+        output_token_ids: torch.Tensor | None = None,
+        output_token_counts: torch.Tensor | None = None,
+        presence_request_indices: torch.Tensor | None = None,
+        embedding_bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Sample from a compact uniform top-k candidate set."""
+        if top_k <= 0:
+            raise ValueError(f"top_k must be positive, got {top_k}")
+        if temperature <= 0.0:
+            raise ValueError(
+                "sample_topk_tokens requires positive temperature; "
+                f"got {temperature}"
+            )
+        if not 0.0 < top_p <= 1.0:
+            raise ValueError(f"top_p must be in (0, 1], got {top_p}")
+
+        local_values, local_indices, vocab_start = self._get_local_topk(
+            lm_head,
+            hidden_states,
+            top_k=top_k,
+            temperature=temperature,
+            presence_penalties=presence_penalties,
+            output_token_ids=output_token_ids,
+            output_token_counts=output_token_counts,
+            presence_request_indices=presence_request_indices,
+            embedding_bias=embedding_bias,
+        )
+        local_pairs = self._pack_topk_pairs(
+            local_values, local_indices, vocab_start
+        )
+        tp_size = lm_head.tp_size
+        if tp_size == 1:
+            gathered_pairs = local_pairs.view(
+                hidden_states.shape[0], local_values.shape[-1], 2
+            )
+            top_values, top_ids = self._select_compact_topk_pairs(
+                gathered_pairs, top_k, top_p
+            )
+            return self._sample_compact_topk(top_values, top_ids)
+
+        # Sampling must happen once and be broadcast.  Independent RNG draws
+        # on TP ranks can otherwise produce different tokens even though the
+        # candidate pairs are identical.
+        gathered_pairs = tensor_model_parallel_gather(local_pairs, dst=0, dim=-1)
+        tp_group = get_tp_group()
+        if tp_group.rank_in_group == 0:
+            assert gathered_pairs is not None
+            gathered_pairs = gathered_pairs.view(
+                hidden_states.shape[0], tp_size * local_values.shape[-1], 2
+            )
+            top_values, top_ids = self._select_compact_topk_pairs(
+                gathered_pairs, top_k, top_p
+            )
+            sampled = self._sample_compact_topk(top_values, top_ids)
+        else:
+            sampled = torch.empty(
+                (hidden_states.shape[0],),
+                dtype=torch.int64,
+                device=hidden_states.device,
+            )
+        tp_group.broadcast(sampled, src=0)
+        return sampled
 
     def extra_repr(self) -> str:
         s = f"vocab_size={self.vocab_size}"

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -20,7 +20,17 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
 from vllm.utils.flashinfer import has_flashinfer
+
+if HAS_TRITON:
+    from vllm.model_executor.layers.argmax_triton import (
+        indexed_argmax_triton,
+        reduce_global_argmax_triton,
+    )
+else:
+    indexed_argmax_triton = None
+    reduce_global_argmax_triton = None
 
 logger = init_logger(__name__)
 
@@ -211,6 +221,70 @@ class LogitsProcessor(PluggableLayer):
             )
         tp_size = lm_head.tp_size
 
+        hybrid_state = getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None)
+        shard_indices = lm_head.shard_indices
+        num_pad = shard_indices.num_org_vocab_padding
+        local_vocab_size = getattr(shard_indices, "num_elements_padded", None)
+        if local_vocab_size is None:
+            local_vocab_size = getattr(
+                lm_head,
+                "num_embeddings_per_partition",
+                self.vocab_size,
+            )
+        active_vocab_size = local_vocab_size - num_pad
+        if (
+            hybrid_state is not None
+            and self.soft_cap is None
+            and self.scale > 0.0
+            and hybrid_state.can_use(
+                hidden_states,
+                bf16_weight=lm_head.weight,
+                active_vocab_size=active_vocab_size,
+                top_k=1,
+            )
+        ):
+            coarse_logits = hybrid_state.coarse_logits(
+                hidden_states,
+                embedding_bias,
+            )
+            if num_pad > 0:
+                coarse_logits[..., -num_pad:] = -float("inf")
+            candidate_indices = hybrid_state.select_candidates(
+                coarse_logits,
+                top_k=1,
+            )
+            exact_logits = hybrid_state.refine_logits(
+                hidden_states,
+                lm_head.weight,
+                candidate_indices,
+                embedding_bias,
+            )
+            if (
+                indexed_argmax_triton is not None
+                and exact_logits.is_cuda
+                and 0 < exact_logits.shape[-1] <= 1024
+            ):
+                local_max_vals, global_indices = indexed_argmax_triton(
+                    exact_logits,
+                    candidate_indices,
+                    index_offset=shard_indices.org_vocab_start_index,
+                )
+            else:
+                local_max_vals, candidate_pos = exact_logits.max(dim=-1)
+                local_max_indices = candidate_indices.gather(
+                    -1, candidate_pos.unsqueeze(-1)
+                ).squeeze(-1)
+                global_indices = (
+                    local_max_indices + shard_indices.org_vocab_start_index
+                )
+            if self.scale != 1.0:
+                local_max_vals = local_max_vals * self.scale
+            return self.reduce_local_argmax(
+                local_max_vals,
+                global_indices,
+                tp_size=tp_size,
+            )
+
         logits = self._apply_head(lm_head, hidden_states, embedding_bias)
         if self.soft_cap is not None:
             logits = torch.tanh(logits / self.soft_cap) * self.soft_cap
@@ -223,23 +297,40 @@ class LogitsProcessor(PluggableLayer):
             logits[..., -num_pad:] = -float("inf")
 
         local_max_vals, local_max_indices = logits.max(dim=-1)
-
-        # Convert shard-local indices to global vocab indices.
         vocab_start = lm_head.shard_indices.org_vocab_start_index
         global_indices = local_max_indices + vocab_start
 
         if tp_size == 1:
             return global_indices
 
-        # All-gather (value, index) pairs, then reduce to global argmax.
-        # Use float32 to avoid bf16 precision loss on large vocab indices.
         local_pair = torch.stack(
             [local_max_vals.float(), global_indices.float()], dim=-1
         )
-        # [batch, 2] -> [batch, 2 * tp_size]
         gathered = tensor_model_parallel_all_gather(local_pair, dim=-1)
-        # [batch, tp_size, 2] where [:, :, 0]=values, [:, :, 1]=indices
         gathered = gathered.view(hidden_states.shape[0], tp_size, 2)
+        max_rank_idx = gathered[:, :, 0].argmax(dim=-1, keepdim=True)
+        top_tokens = gathered[:, :, 1].gather(dim=-1, index=max_rank_idx)
+        return top_tokens.squeeze(-1).to(torch.int64)
+
+    def reduce_local_argmax(
+        self,
+        local_max_vals: torch.Tensor,
+        global_indices: torch.Tensor,
+        *,
+        tp_size: int,
+    ) -> torch.Tensor:
+        if tp_size == 1:
+            return global_indices.to(torch.int64)
+
+        local_pair = torch.stack(
+            [local_max_vals.float(), global_indices.float()], dim=-1
+        )
+        gathered = tensor_model_parallel_all_gather(local_pair, dim=-1)
+        if reduce_global_argmax_triton is not None and gathered.is_cuda:
+            return reduce_global_argmax_triton(gathered, tp_size=tp_size).to(
+                torch.int64
+            )
+        gathered = gathered.view(gathered.shape[0], tp_size, 2)
         max_rank_idx = gathered[:, :, 0].argmax(dim=-1, keepdim=True)
         top_tokens = gathered[:, :, 1].gather(dim=-1, index=max_rank_idx)
         return top_tokens.squeeze(-1).to(torch.int64)

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -25,7 +25,15 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.flashinfer import has_flashinfer
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.sample.gumbel import (
+    gumbel_sample,
+    gumbel_sample_compact,
+)
+from vllm.v1.worker.gpu.sample.compact_topk import (
+    pack_topk_pairs,
+    sample_compact_topk_pairs,
+    select_compact_topk_pairs,
+)
 
 indexed_argmax_triton: Any
 reduce_global_argmax_triton: Any
@@ -56,6 +64,36 @@ logger = init_logger(__name__)
 # noise/scores matrix is not.
 _FULL_SAMPLE_BLOCK_SIZE = 8192
 _MAX_FLOAT32_TOKEN_ID = 1 << 24
+
+
+def _fast_stable_topk(
+    values: torch.Tensor,
+    k: int,
+    token_ids: torch.Tensor | None = None,
+    *,
+    allow_fast: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fast top-k for compact CUDA candidates.
+
+    The compact hybrid path normally receives distinct FP32 logits.  Use the
+    native CUDA top-k in that case; the generic CPU/large-vocabulary callers
+    retain the deterministic value/token-id tie handling below.  Equal CUDA
+    logits follow ``torch.topk``'s existing ordering, as they do in the native
+    vocab-parallel sampler.
+    """
+    if (
+        not allow_fast
+        or not values.is_cuda
+        or token_ids is None
+        or values.dtype != torch.float32
+        or token_ids.dtype not in (torch.int32, torch.int64)
+    ):
+        return _stable_topk(values, k, token_ids)
+
+    rank_values = torch.where(
+        torch.isnan(values), torch.full_like(values, -float("inf")), values
+    )
+    return torch.topk(rank_values, k, dim=-1, sorted=True)
 
 
 def _stable_topk(
@@ -1169,10 +1207,11 @@ class LogitsProcessor(PluggableLayer):
                     )
             if temperature != 1.0:
                 exact_logits.div_(temperature)
-            local_vals, positions = _stable_topk(
+            local_vals, positions = _fast_stable_topk(
                 exact_logits,
                 local_top_k,
                 candidate_indices,
+                allow_fast=self.vocab_size < _MAX_FLOAT32_TOKEN_ID,
             )
             return (
                 local_vals,
@@ -1218,9 +1257,17 @@ class LogitsProcessor(PluggableLayer):
         gathered_pairs: torch.Tensor,
         top_k: int,
         top_p: float,
+        *,
+        use_fast: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if use_fast:
+            return select_compact_topk_pairs(gathered_pairs, top_k, top_p)
         return LogitsProcessor._select_compact_topk_values_ids(
-            gathered_pairs[..., 0], gathered_pairs[..., 1].to(torch.int64), top_k, top_p
+            gathered_pairs[..., 0],
+            gathered_pairs[..., 1].to(torch.int64),
+            top_k,
+            top_p,
+            use_fast=use_fast,
         )
 
     @staticmethod
@@ -1229,15 +1276,18 @@ class LogitsProcessor(PluggableLayer):
         candidate_ids: torch.Tensor,
         top_k: int,
         top_p: float,
+        *,
+        use_fast: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Select compact candidates without converting integer ids to FP32."""
         if candidate_values.shape != candidate_ids.shape:
             raise ValueError("candidate values and ids must have matching shapes")
         top_k = min(top_k, candidate_values.shape[-1])
-        top_values, positions = _stable_topk(
+        top_values, positions = _fast_stable_topk(
             candidate_values,
             top_k,
             candidate_ids,
+            allow_fast=use_fast,
         )
         top_ids = candidate_ids.gather(-1, positions)
         if top_p < 1.0:
@@ -1254,10 +1304,7 @@ class LogitsProcessor(PluggableLayer):
         vocab_start: int,
     ) -> torch.Tensor:
         """Pack local values and global token ids for TP communication."""
-        global_indices = local_indices.to(torch.int64) + vocab_start
-        return torch.stack(
-            [local_values, global_indices.to(torch.float32)], dim=-1
-        ).flatten(start_dim=-2)
+        return pack_topk_pairs(local_values, local_indices, vocab_start)
 
     def _sample_compact_topk(
         self,
@@ -1289,6 +1336,15 @@ class LogitsProcessor(PluggableLayer):
                 raise ValueError(
                     "temperature_state is required with keyed Gumbel metadata"
                 )
+            if top_values.shape[-1] <= 1024:
+                return gumbel_sample_compact(
+                    top_values,
+                    top_ids,
+                    expanded_idx_mapping,
+                    temperature_state,
+                    seeds,
+                    pos,
+                )
             sampled_positions = gumbel_sample(
                 top_values,
                 expanded_idx_mapping,
@@ -1307,6 +1363,45 @@ class LogitsProcessor(PluggableLayer):
         noise.exponential_()
         sampled_positions = probs.div(noise).argmax(dim=-1, keepdim=True)
         return top_ids.gather(-1, sampled_positions).view(-1)
+
+    def _sample_compact_topk_pairs(
+        self,
+        gathered_pairs: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        *,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Merge and sample compact pairs, fusing both operations on CUDA."""
+        if (
+            expanded_idx_mapping is not None
+            and seeds is not None
+            and pos is not None
+        ):
+            sampled = sample_compact_topk_pairs(
+                gathered_pairs,
+                top_k,
+                top_p,
+                expanded_idx_mapping,
+                seeds,
+                pos,
+            )
+            if sampled is not None:
+                return sampled
+        top_values, top_ids = self._select_compact_topk_pairs(
+            gathered_pairs, top_k, top_p
+        )
+        return self._sample_compact_topk(
+            top_values,
+            top_ids,
+            expanded_idx_mapping=expanded_idx_mapping,
+            seeds=seeds,
+            pos=pos,
+            temperature_state=temperature_state,
+        )
 
     def get_topk_candidates(
         self,
@@ -1343,23 +1438,47 @@ class LogitsProcessor(PluggableLayer):
             embedding_bias=embedding_bias,
         )
         tp_size = lm_head.tp_size
+        tp_group = get_tp_group() if tp_size > 1 else None
         if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
             local_ids = local_indices.to(torch.int64) + vocab_start
             if tp_size > 1:
-                gathered_values = tensor_model_parallel_all_gather(
+                gathered_values = tensor_model_parallel_gather(
                     local_values, dim=-1
                 )
-                gathered_ids = tensor_model_parallel_all_gather(local_ids, dim=-1)
+                gathered_ids = tensor_model_parallel_gather(local_ids, dim=-1)
+                if tp_group is not None and tp_group.rank_in_group != 0:
+                    return (
+                        torch.empty(
+                            (0, 0), dtype=torch.float32, device=hidden_states.device
+                        ),
+                        torch.empty(
+                            (0, 0), dtype=torch.int64, device=hidden_states.device
+                        ),
+                    )
             else:
                 gathered_values = local_values
                 gathered_ids = local_ids
             return self._select_compact_topk_values_ids(
-                gathered_values, gathered_ids, top_k, top_p
+                gathered_values,
+                gathered_ids,
+                top_k,
+                top_p,
+                use_fast=False,
             )
 
         local_pairs = self._pack_topk_pairs(local_values, local_indices, vocab_start)
         if tp_size > 1:
-            gathered_pairs = tensor_model_parallel_all_gather(local_pairs, dim=-1)
+            gathered_pairs = tensor_model_parallel_gather(local_pairs, dst=0, dim=-1)
+            if tp_group is not None and tp_group.rank_in_group != 0:
+                return (
+                    torch.empty(
+                        (0, 0), dtype=torch.float32, device=hidden_states.device
+                    ),
+                    torch.empty(
+                        (0, 0), dtype=torch.int64, device=hidden_states.device
+                    ),
+                )
+            assert gathered_pairs is not None
             gathered_pairs = gathered_pairs.view(
                 hidden_states.shape[0], tp_size * local_values.shape[-1], 2
             )
@@ -1367,7 +1486,12 @@ class LogitsProcessor(PluggableLayer):
             gathered_pairs = local_pairs.view(
                 hidden_states.shape[0], local_values.shape[-1], 2
             )
-        return self._select_compact_topk_pairs(gathered_pairs, top_k, top_p)
+        return self._select_compact_topk_pairs(
+            gathered_pairs,
+            top_k,
+            top_p,
+            use_fast=self.vocab_size < _MAX_FLOAT32_TOKEN_ID,
+        )
 
     def sample_topk_tokens(
         self,
@@ -1413,7 +1537,11 @@ class LogitsProcessor(PluggableLayer):
             local_ids = local_indices.to(torch.int64) + vocab_start
             if tp_size == 1:
                 top_values, top_ids = self._select_compact_topk_values_ids(
-                    local_values, local_ids, top_k, top_p
+                    local_values,
+                    local_ids,
+                    top_k,
+                    top_p,
+                    use_fast=False,
                 )
                 return self._sample_compact_topk(
                     top_values,
@@ -1431,32 +1559,47 @@ class LogitsProcessor(PluggableLayer):
             local_pairs = self._pack_topk_pairs(
                 local_values, local_indices, vocab_start
             )
-            gathered_values = tensor_model_parallel_gather(local_pairs, dst=0, dim=-1)
+            gathered_values = tensor_model_parallel_gather(
+                local_pairs, dst=0, dim=-1
+            )
 
+        # Sampling must happen once and be broadcast.  Independent RNG draws
+        # on TP ranks can otherwise produce different tokens even though the
+        # candidate pairs are identical.  The compact normal-vocabulary path
+        # fuses global merge, top-p filtering, and keyed Gumbel sampling.
         if tp_size == 1:
             if self.vocab_size >= _MAX_FLOAT32_TOKEN_ID:
+                assert gathered_values is not None and gathered_ids is not None
+                gathered_values = gathered_values.view(
+                    hidden_states.shape[0], local_values.shape[-1]
+                )
+                gathered_ids = gathered_ids.view(
+                    hidden_states.shape[0], local_values.shape[-1]
+                )
                 top_values, top_ids = self._select_compact_topk_values_ids(
-                    local_values, local_ids, top_k, top_p
+                    gathered_values, gathered_ids, top_k, top_p, use_fast=False
                 )
-            else:
-                gathered_pairs = local_pairs.view(
-                    hidden_states.shape[0], local_values.shape[-1], 2
+                return self._sample_compact_topk(
+                    top_values,
+                    top_ids,
+                    expanded_idx_mapping=expanded_idx_mapping,
+                    seeds=seeds,
+                    pos=pos,
+                    temperature_state=temperature_state,
                 )
-                top_values, top_ids = self._select_compact_topk_pairs(
-                    gathered_pairs, top_k, top_p
-                )
-            return self._sample_compact_topk(
-                top_values,
-                top_ids,
+            gathered_pairs = gathered_values.view(
+                hidden_states.shape[0], local_values.shape[-1], 2
+            )
+            return self._sample_compact_topk_pairs(
+                gathered_pairs,
+                top_k,
+                top_p,
                 expanded_idx_mapping=expanded_idx_mapping,
                 seeds=seeds,
                 pos=pos,
                 temperature_state=temperature_state,
             )
 
-        # Sampling must happen once and be broadcast.  Independent RNG draws
-        # on TP ranks can otherwise produce different tokens even though the
-        # candidate pairs are identical.
         tp_group = get_tp_group()
         if tp_group.rank_in_group == 0:
             assert gathered_values is not None
@@ -1469,23 +1612,33 @@ class LogitsProcessor(PluggableLayer):
                     hidden_states.shape[0], tp_size * local_values.shape[-1]
                 )
                 top_values, top_ids = self._select_compact_topk_values_ids(
-                    gathered_values, gathered_ids, top_k, top_p
+                    gathered_values,
+                    gathered_ids,
+                    top_k,
+                    top_p,
+                    use_fast=False,
+                )
+                sampled = self._sample_compact_topk(
+                    top_values,
+                    top_ids,
+                    expanded_idx_mapping=expanded_idx_mapping,
+                    seeds=seeds,
+                    pos=pos,
+                    temperature_state=temperature_state,
                 )
             else:
                 gathered_pairs = gathered_values.view(
                     hidden_states.shape[0], tp_size * local_values.shape[-1], 2
                 )
-                top_values, top_ids = self._select_compact_topk_pairs(
-                    gathered_pairs, top_k, top_p
+                sampled = self._sample_compact_topk_pairs(
+                    gathered_pairs,
+                    top_k,
+                    top_p,
+                    expanded_idx_mapping=expanded_idx_mapping,
+                    seeds=seeds,
+                    pos=pos,
+                    temperature_state=temperature_state,
                 )
-            sampled = self._sample_compact_topk(
-                top_values,
-                top_ids,
-                expanded_idx_mapping=expanded_idx_mapping,
-                seeds=seeds,
-                pos=pos,
-                temperature_state=temperature_state,
-            )
         else:
             sampled = torch.empty(
                 (hidden_states.shape[0],),

--- a/vllm/model_executor/layers/presence_penalty_triton.py
+++ b/vllm/model_executor/layers/presence_penalty_triton.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""In-place presence penalties for compact vocab-parallel sampling."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv
+
+
+@triton.jit
+def _apply_presence_penalty_from_counts_kernel(
+    logits_ptr,
+    logits_stride,
+    local_token_ids_ptr,
+    local_token_ids_stride,
+    output_counts_ptr,
+    output_counts_stride,
+    request_indices_ptr,
+    presence_penalties_ptr,
+    num_cols,
+    counts_vocab_size,
+    org_vocab_start,
+    num_org_elements,
+    num_org_elements_padded,
+    added_vocab_start,
+    num_added_elements,
+    BLOCK_SIZE: tl.constexpr,
+    INDEXED: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    col_mask = cols < num_cols
+
+    if INDEXED:
+        local_ids = tl.load(
+            local_token_ids_ptr + row * local_token_ids_stride + cols,
+            mask=col_mask,
+            other=0,
+        )
+    else:
+        local_ids = cols
+
+    is_org = local_ids < num_org_elements
+    added_offsets = local_ids - num_org_elements_padded
+    is_added = (added_offsets >= 0) & (added_offsets < num_added_elements)
+    global_ids = tl.where(
+        is_org,
+        org_vocab_start + local_ids,
+        added_vocab_start + added_offsets,
+    )
+    token_mask = col_mask & (is_org | is_added)
+    token_mask &= (global_ids >= 0) & (global_ids < counts_vocab_size)
+
+    request_idx = tl.load(request_indices_ptr + row)
+    counts = tl.load(
+        output_counts_ptr + request_idx * output_counts_stride + global_ids,
+        mask=token_mask,
+        other=0,
+    )
+    penalty = tl.load(presence_penalties_ptr + row)
+    logits_row = tl.load(
+        logits_ptr + row * logits_stride + cols,
+        mask=col_mask,
+        other=0.0,
+    )
+    logits_row -= tl.where(token_mask & (counts > 0), penalty, 0.0)
+    tl.store(logits_ptr + row * logits_stride + cols, logits_row, mask=col_mask)
+
+
+def apply_presence_penalty_from_counts(
+    logits: torch.Tensor,
+    output_token_counts: torch.Tensor,
+    request_indices: torch.Tensor,
+    presence_penalties: torch.Tensor,
+    *,
+    org_vocab_start: int,
+    num_org_elements: int,
+    num_org_elements_padded: int,
+    added_vocab_start: int,
+    num_added_elements: int,
+    local_token_ids: torch.Tensor | None = None,
+) -> None:
+    """Subtract presence penalties without materializing a dense mask.
+
+    ``local_token_ids`` is supplied for the compact refined candidate matrix;
+    when omitted, columns are interpreted as the physical local shard layout.
+    """
+    if logits.numel() == 0:
+        return
+    if logits.ndim != 2 or not logits.is_contiguous():
+        raise ValueError("logits must be a contiguous rank-2 tensor")
+    if output_token_counts.ndim != 2:
+        raise ValueError("output_token_counts must be rank 2")
+    if request_indices.shape != (logits.shape[0],):
+        raise ValueError("request_indices must have one entry per logits row")
+    if presence_penalties.shape != (logits.shape[0],):
+        raise ValueError("presence_penalties must have one entry per logits row")
+    if local_token_ids is not None and local_token_ids.shape != logits.shape:
+        raise ValueError("local_token_ids must match logits")
+
+    block_size = 256
+    _apply_presence_penalty_from_counts_kernel[
+        (logits.shape[0], cdiv(logits.shape[1], block_size))
+    ](
+        logits,
+        logits.stride(0),
+        local_token_ids,
+        local_token_ids.stride(0) if local_token_ids is not None else 0,
+        output_token_counts,
+        output_token_counts.stride(0),
+        request_indices,
+        presence_penalties,
+        logits.shape[1],
+        output_token_counts.shape[1],
+        org_vocab_start,
+        num_org_elements,
+        num_org_elements_padded,
+        added_vocab_start,
+        num_added_elements,
+        BLOCK_SIZE=block_size,
+        INDEXED=local_token_ids is not None,
+    )
+
+
+__all__ = ["apply_presence_penalty_from_counts"]

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -63,7 +63,11 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
             from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
 
             dispatch_cpu_unquantized_gemm(layer, remove_weight=False)
-        elif envs.VLLM_HYBRID_NVFP4_LM_HEAD and isinstance(layer, ParallelLMHead):
+        elif (
+            envs.VLLM_HYBRID_NVFP4_LM_HEAD
+            and isinstance(layer, ParallelLMHead)
+            and getattr(layer, "_supports_hybrid_nvfp4_lm_head", False)
+        ):
             from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
                 prepare_hybrid_nvfp4_lm_head,
             )
@@ -543,6 +547,10 @@ class ParallelLMHead(VocabParallelEmbedding):
         padding_size: padding size for the vocabulary.
         disable_tp: If true, tensor parallelism will be disabled for this layer.
     """
+
+    # Model implementations opt in explicitly when their lm-head layout and
+    # dtype semantics are compatible with the experimental hybrid path.
+    _supports_hybrid_nvfp4_lm_head: bool = False
 
     # --8<-- [end:parallel_lm_head]
 

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -75,6 +75,7 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
             prepare_hybrid_nvfp4_lm_head(
                 layer,
                 candidates=envs.VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES,
+                max_rows=envs.VLLM_HYBRID_NVFP4_LM_HEAD_MAX_ROWS,
             )
 
     def apply(

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -63,6 +63,15 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
             from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
 
             dispatch_cpu_unquantized_gemm(layer, remove_weight=False)
+        elif envs.VLLM_HYBRID_NVFP4_LM_HEAD and isinstance(layer, ParallelLMHead):
+            from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+                prepare_hybrid_nvfp4_lm_head,
+            )
+
+            prepare_hybrid_nvfp4_lm_head(
+                layer,
+                candidates=envs.VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES,
+            )
 
     def apply(
         self,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -29,6 +29,7 @@ from collections.abc import Iterable
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import (
@@ -352,6 +353,21 @@ class Qwen3_5ForCausalLMBase(
             )
             if config.tie_word_embeddings:
                 self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
+            # The experimental compact head is deliberately opt-in per model.
+            # Do not allocate an auxiliary copy for unrelated ParallelLMHead
+            # implementations, or when diagnostics, LoRA, adaptive
+            # verification, dtype, or batch-invariant semantics are enabled.
+            self.lm_head._supports_hybrid_nvfp4_lm_head = (
+                self.model_config.head_dtype == self.model_config.dtype
+                and not envs.VLLM_BATCH_INVARIANT
+                and not envs.VLLM_COMPUTE_NANS_IN_LOGITS
+                and self.vllm_config.lora_config is None
+                and not (
+                    self.vllm_config.speculative_config is not None
+                    and self.vllm_config.speculative_config.enable_adaptive_verification
+                )
+                and self.lm_head.num_added_embeddings == 0
+            )
         else:
             self.lm_head = PPMissingLayer()
 
@@ -437,6 +453,63 @@ class Qwen3_5ForCausalLMBase(
 
     def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.logits_processor.get_top_tokens(self.lm_head, hidden_states)
+
+    def sample_full_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        temperature: float,
+    ) -> torch.Tensor:
+        return self.logits_processor.sample_full_tokens(
+            self.lm_head,
+            hidden_states,
+            temperature=temperature,
+        )
+
+    def get_topk_candidates(
+        self,
+        hidden_states: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        presence_penalties: torch.Tensor | None = None,
+        output_token_ids: torch.Tensor | None = None,
+        output_token_counts: torch.Tensor | None = None,
+        presence_request_indices: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.logits_processor.get_topk_candidates(
+            self.lm_head,
+            hidden_states,
+            top_k=top_k,
+            top_p=top_p,
+            temperature=temperature,
+            presence_penalties=presence_penalties,
+            output_token_ids=output_token_ids,
+            output_token_counts=output_token_counts,
+            presence_request_indices=presence_request_indices,
+        )
+
+    def sample_topk_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        presence_penalties: torch.Tensor | None = None,
+        output_token_ids: torch.Tensor | None = None,
+        output_token_counts: torch.Tensor | None = None,
+        presence_request_indices: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.logits_processor.sample_topk_tokens(
+            self.lm_head,
+            hidden_states,
+            top_k=top_k,
+            top_p=top_p,
+            temperature=temperature,
+            presence_penalties=presence_penalties,
+            output_token_ids=output_token_ids,
+            output_token_counts=output_token_counts,
+            presence_request_indices=presence_request_indices,
+        )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
@@ -606,6 +679,60 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.language_model.get_top_tokens(hidden_states)
 
+    def sample_full_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        temperature: float,
+    ) -> torch.Tensor:
+        return self.language_model.sample_full_tokens(
+            hidden_states,
+            temperature=temperature,
+        )
+
+    def get_topk_candidates(
+        self,
+        hidden_states: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        presence_penalties: torch.Tensor | None = None,
+        output_token_ids: torch.Tensor | None = None,
+        output_token_counts: torch.Tensor | None = None,
+        presence_request_indices: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.language_model.get_topk_candidates(
+            hidden_states,
+            top_k=top_k,
+            top_p=top_p,
+            temperature=temperature,
+            presence_penalties=presence_penalties,
+            output_token_ids=output_token_ids,
+            output_token_counts=output_token_counts,
+            presence_request_indices=presence_request_indices,
+        )
+
+    def sample_topk_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        top_k: int,
+        top_p: float,
+        temperature: float,
+        presence_penalties: torch.Tensor | None = None,
+        output_token_ids: torch.Tensor | None = None,
+        output_token_counts: torch.Tensor | None = None,
+        presence_request_indices: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.language_model.sample_topk_tokens(
+            hidden_states,
+            top_k=top_k,
+            top_p=top_p,
+            temperature=temperature,
+            presence_penalties=presence_penalties,
+            output_token_ids=output_token_ids,
+            output_token_counts=output_token_counts,
+            presence_request_indices=presence_request_indices,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
@@ -659,7 +786,10 @@ class Qwen3_5_MoeMixtureOfExperts(MixtureOfExperts):
         num_physical_experts: int,
         num_local_physical_experts: int,
     ) -> None:
-        assert self.num_local_physical_experts == num_local_physical_experts
+        assert (
+            getattr(self, "num_local_physical_experts", None)
+            == num_local_physical_experts
+        )
         self.num_physical_experts = num_physical_experts
         self.num_local_physical_experts = num_local_physical_experts
         self.num_redundant_experts = num_physical_experts - self.num_logical_experts

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -435,6 +435,9 @@ class Qwen3_5ForCausalLMBase(
     ) -> torch.Tensor:
         return self.logits_processor(self.lm_head, hidden_states, skip_gather=True)
 
+    def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.logits_processor.get_top_tokens(self.lm_head, hidden_states)
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
@@ -599,6 +602,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
 
     def compute_logits_local(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.language_model.compute_logits_local(hidden_states)
+
+    def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.language_model.get_top_tokens(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -359,6 +359,7 @@ class Qwen3_5ForCausalLMBase(
             # verification, dtype, or batch-invariant semantics are enabled.
             self.lm_head._supports_hybrid_nvfp4_lm_head = (
                 self.model_config.head_dtype == self.model_config.dtype
+                and config.vocab_size < (1 << 24)
                 and not envs.VLLM_BATCH_INVARIANT
                 and not envs.VLLM_COMPUTE_NANS_IN_LOGITS
                 and self.vllm_config.lora_config is None
@@ -458,11 +459,19 @@ class Qwen3_5ForCausalLMBase(
         self,
         hidden_states: torch.Tensor,
         temperature: float,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.logits_processor.sample_full_tokens(
             self.lm_head,
             hidden_states,
             temperature=temperature,
+            expanded_idx_mapping=expanded_idx_mapping,
+            seeds=seeds,
+            pos=pos,
+            temperature_state=temperature_state,
         )
 
     def get_topk_candidates(
@@ -498,6 +507,10 @@ class Qwen3_5ForCausalLMBase(
         output_token_ids: torch.Tensor | None = None,
         output_token_counts: torch.Tensor | None = None,
         presence_request_indices: torch.Tensor | None = None,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.logits_processor.sample_topk_tokens(
             self.lm_head,
@@ -509,6 +522,10 @@ class Qwen3_5ForCausalLMBase(
             output_token_ids=output_token_ids,
             output_token_counts=output_token_counts,
             presence_request_indices=presence_request_indices,
+            expanded_idx_mapping=expanded_idx_mapping,
+            seeds=seeds,
+            pos=pos,
+            temperature_state=temperature_state,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -683,10 +700,18 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         self,
         hidden_states: torch.Tensor,
         temperature: float,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.language_model.sample_full_tokens(
             hidden_states,
             temperature=temperature,
+            expanded_idx_mapping=expanded_idx_mapping,
+            seeds=seeds,
+            pos=pos,
+            temperature_state=temperature_state,
         )
 
     def get_topk_candidates(
@@ -721,6 +746,10 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         output_token_ids: torch.Tensor | None = None,
         output_token_counts: torch.Tensor | None = None,
         presence_request_indices: torch.Tensor | None = None,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.language_model.sample_topk_tokens(
             hidden_states,
@@ -731,6 +760,10 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             output_token_ids=output_token_ids,
             output_token_counts=output_token_counts,
             presence_request_indices=presence_request_indices,
+            expanded_idx_mapping=expanded_idx_mapping,
+            seeds=seeds,
+            pos=pos,
+            temperature_state=temperature_state,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
+++ b/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
@@ -43,6 +43,9 @@ def _row_shapes(worker: Any) -> tuple[int, ...]:
         max(1, max_rows),
         max(1, envs.VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS),
     )
+    configured_max_rows = envs.VLLM_HYBRID_NVFP4_LM_HEAD_MAX_ROWS
+    if configured_max_rows > 0:
+        max_rows = min(max_rows, configured_max_rows)
 
     capture_sizes = config.compilation_config.cudagraph_capture_sizes or []
     shapes = sorted({int(size) for size in capture_sizes if 0 < int(size) <= max_rows})
@@ -70,10 +73,33 @@ def hybrid_nvfp4_lm_head_warmup(worker: Any) -> None:
     started = perf_counter()
     shapes = _row_shapes(worker)
     for layer, state in heads.values():
+        # Autotune materializes a BF16 coarse-logit matrix.  Keep that
+        # profile-only allocation below the same explicit budget used by the
+        # sampler workspace; otherwise a large vocabulary can evict the KV
+        # cache before graph capture even starts.
+        max_warmup_bytes = envs.VLLM_HYBRID_NVFP4_LM_HEAD_MAX_WARMUP_BYTES
+        if max_warmup_bytes > 0:
+            max_rows_by_memory = max_warmup_bytes // (state.output_size * 2)
+            if max_rows_by_memory < 1:
+                logger.warning_once(
+                    "Skipping hybrid NVFP4 lm-head warmup for output size %d: "
+                    "the configured memory budget (%d bytes) is smaller than "
+                    "one coarse-logit row.",
+                    state.output_size,
+                    max_warmup_bytes,
+                )
+                continue
+            shapes_for_state = tuple(
+                rows for rows in shapes if rows <= max_rows_by_memory
+            )
+            if not shapes_for_state:
+                shapes_for_state = (1,)
+        else:
+            shapes_for_state = shapes
         _, tuned_shapes = autotune_hybrid_nvfp4_lm_head(
             state,
             layer.weight,
-            shapes,
+            shapes_for_state,
         )
         warmup_hybrid_nvfp4_lm_head_kernels(
             state,

--- a/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
+++ b/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from time import perf_counter
+from typing import Any
 
 import torch
 
@@ -17,8 +18,8 @@ from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
     get_hybrid_nvfp4_lm_head,
     warmup_hybrid_nvfp4_lm_head_kernels,
 )
+
 logger = init_logger(__name__)
-_DEFAULT_MAX_ROWS = 2048
 
 
 def _collect_lm_heads(
@@ -32,30 +33,27 @@ def _collect_lm_heads(
     return heads
 
 
-def _row_shapes(worker: object) -> tuple[int, ...]:
-    config = getattr(worker, "vllm_config")
+def _row_shapes(worker: Any) -> tuple[int, ...]:
+    config = worker.vllm_config
     max_rows = int(config.scheduler_config.max_num_seqs)
     speculative_config = config.speculative_config
     if speculative_config is not None:
         max_rows *= speculative_config.num_speculative_tokens + 1
-    max_rows = max(1, max_rows)
+    max_rows = min(
+        max(1, max_rows),
+        max(1, envs.VLLM_HYBRID_NVFP4_LM_HEAD_MAX_AUTOTUNE_ROWS),
+    )
 
     capture_sizes = config.compilation_config.cudagraph_capture_sizes or []
-    shapes = sorted(
-        {
-            int(size)
-            for size in capture_sizes
-            if 0 < int(size) <= max_rows
-        }
-    )
+    shapes = sorted({int(size) for size in capture_sizes if 0 < int(size) <= max_rows})
     if not shapes:
-        shapes = list(autotune_row_buckets(max(256, max_rows)))
+        shapes = list(autotune_row_buckets(max_rows))
     if 1 not in shapes:
         shapes.insert(0, 1)
     return tuple(shapes)
 
 
-def hybrid_nvfp4_lm_head_warmup(worker: object) -> None:
+def hybrid_nvfp4_lm_head_warmup(worker: Any) -> None:
     """Tune and JIT the hybrid lm-head before CUDA graph capture."""
     if not envs.VLLM_HYBRID_NVFP4_LM_HEAD:
         return

--- a/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
+++ b/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Startup warmup for the optional hybrid NVFP4 lm-head path."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+import torch
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+    HybridNvfp4LmHead,
+    autotune_hybrid_nvfp4_lm_head,
+    autotune_row_buckets,
+    get_hybrid_nvfp4_lm_head,
+    warmup_hybrid_nvfp4_lm_head_kernels,
+)
+logger = init_logger(__name__)
+_DEFAULT_MAX_ROWS = 2048
+
+
+def _collect_lm_heads(
+    model: torch.nn.Module,
+) -> dict[int, tuple[torch.nn.Module, HybridNvfp4LmHead]]:
+    heads: dict[int, tuple[torch.nn.Module, HybridNvfp4LmHead]] = {}
+    for module in model.modules():
+        state = get_hybrid_nvfp4_lm_head(module)
+        if state is not None:
+            heads[id(state)] = (module, state)
+    return heads
+
+
+def _row_shapes(worker: object) -> tuple[int, ...]:
+    config = getattr(worker, "vllm_config")
+    max_rows = int(config.scheduler_config.max_num_seqs)
+    speculative_config = config.speculative_config
+    if speculative_config is not None:
+        max_rows *= speculative_config.num_speculative_tokens + 1
+    max_rows = max(1, max_rows)
+
+    capture_sizes = config.compilation_config.cudagraph_capture_sizes or []
+    shapes = sorted(
+        {
+            int(size)
+            for size in capture_sizes
+            if 0 < int(size) <= max_rows
+        }
+    )
+    if not shapes:
+        shapes = list(autotune_row_buckets(max(256, max_rows)))
+    if 1 not in shapes:
+        shapes.insert(0, 1)
+    return tuple(shapes)
+
+
+def hybrid_nvfp4_lm_head_warmup(worker: object) -> None:
+    """Tune and JIT the hybrid lm-head before CUDA graph capture."""
+    if not envs.VLLM_HYBRID_NVFP4_LM_HEAD:
+        return
+
+    heads = _collect_lm_heads(worker.get_model())
+    speculator = getattr(getattr(worker, "model_runner", None), "speculator", None)
+    draft_model = getattr(speculator, "model", None)
+    if isinstance(draft_model, torch.nn.Module):
+        heads.update(_collect_lm_heads(draft_model))
+    if not heads:
+        logger.debug("No prepared NVFP4 lm-head was found; skipping warmup.")
+        return
+
+    started = perf_counter()
+    shapes = _row_shapes(worker)
+    for layer, state in heads.values():
+        _, tuned_shapes = autotune_hybrid_nvfp4_lm_head(
+            state,
+            layer.weight,
+            shapes,
+        )
+        warmup_hybrid_nvfp4_lm_head_kernels(
+            state,
+            layer.weight,
+            tp_size=getattr(layer, "tp_size", 1),
+        )
+        logger.debug("Hybrid NVFP4 lm-head tuned row shapes: %s", tuned_shapes)
+
+    torch.accelerator.synchronize()
+    logger.info(
+        "Warmed %d hybrid NVFP4 lm-head state(s) across %d row shapes in %.2fs.",
+        len(heads),
+        len(shapes),
+        perf_counter() - started,
+    )
+
+
+__all__ = ["hybrid_nvfp4_lm_head_warmup"]

--- a/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
+++ b/vllm/model_executor/warmup/hybrid_nvfp4_lm_head_warmup.py
@@ -18,8 +18,101 @@ from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
     get_hybrid_nvfp4_lm_head,
     warmup_hybrid_nvfp4_lm_head_kernels,
 )
+from vllm.triton_utils import HAS_TRITON
 
 logger = init_logger(__name__)
+
+
+@torch.inference_mode()
+def _warmup_compact_topk_sampler(worker: Any) -> None:
+    """JIT the compact top-k/rejection kernels before graph capture."""
+    if not HAS_TRITON or worker.device.type != "cuda":
+        return
+
+    from vllm.v1.worker.gpu.sample.compact_topk import (
+        pack_topk_pairs,
+        sample_compact_topk_pairs,
+        select_compact_topk_pairs,
+    )
+    from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample_compact
+    from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
+        _compact_rejection_sample_kernel,
+        _prepare_compact_rejection_candidates,
+        _prepare_compact_rejection_indices,
+    )
+
+    device = worker.device
+    # ``_get_local_topk`` refines a wider candidate set but returns only the
+    # requested top-k values.  Thus the pack kernel sees ``top_k`` (20 by
+    # default), not the configured coarse candidate width (128), and TP=2
+    # merges 40 pairs rather than 256.  Warm the actual constexpr widths;
+    # otherwise the first real request still incurs a Triton JIT pause.
+    for top_k in (1, 8, 20, 32, 64):
+        local_values = torch.zeros(
+            (1, top_k), dtype=torch.float32, device=device
+        )
+        local_ids = torch.arange(
+            top_k, dtype=torch.int64, device=device
+        ).view(1, -1)
+        pack_topk_pairs(local_values, local_ids, 0)
+        gathered_pairs = torch.zeros(
+            (1, 2 * top_k, 2), dtype=torch.float32, device=device
+        )
+        select_compact_topk_pairs(gathered_pairs, top_k, 0.95)
+
+    candidate_logits = torch.zeros((1, 20), dtype=torch.float32, device=device)
+    candidate_ids = torch.arange(20, dtype=torch.int64, device=device).view(1, -1)
+    expanded = torch.zeros((1,), dtype=torch.int64, device=device)
+    seeds = torch.ones((1,), dtype=torch.int64, device=device)
+    positions = torch.zeros((1,), dtype=torch.int64, device=device)
+    temperatures = torch.ones((1,), dtype=torch.float32, device=device)
+    sample_compact_topk_pairs(
+        torch.zeros((1, 40, 2), dtype=torch.float32, device=device),
+        20,
+        0.95,
+        expanded,
+        seeds,
+        positions,
+    )
+    gumbel_sample_compact(
+        candidate_logits,
+        candidate_ids,
+        expanded,
+        temperatures,
+        seeds,
+        positions,
+    )
+    _prepare_compact_rejection_candidates(
+        candidate_logits,
+        candidate_ids,
+        torch.zeros((1,), dtype=torch.int64, device=device),
+    )
+    # The compact MTP layout is regular, so compile the direct index builder
+    # before graph capture as well.  Otherwise the first real rejection step
+    # can trigger a Triton JIT pause even though the sampler kernels are warm.
+    _prepare_compact_rejection_indices(
+        torch.tensor([0, 3], dtype=torch.int32, device=device),
+        num_draft_tokens=2,
+        num_reqs=1,
+        device=device,
+    )
+
+    spec_len = 2
+    sampled = torch.full(
+        (1, spec_len + 1), -1, dtype=torch.int64, device=device
+    )
+    _compact_rejection_sample_kernel[(1,)](
+        sampled,
+        torch.tensor([1], dtype=torch.int32, device=device),
+        torch.zeros((1,), dtype=torch.int64, device=device),
+        torch.ones((1,), dtype=torch.float32, device=device),
+        torch.zeros((1,), dtype=torch.int64, device=device),
+        torch.zeros((1,), dtype=torch.int64, device=device),
+        expanded,
+        positions,
+        seeds,
+        spec_len,
+    )
 
 
 def _collect_lm_heads(
@@ -108,6 +201,7 @@ def hybrid_nvfp4_lm_head_warmup(worker: Any) -> None:
         )
         logger.debug("Hybrid NVFP4 lm-head tuned row shapes: %s", tuned_shapes)
 
+    _warmup_compact_topk_sampler(worker)
     torch.accelerator.synchronize()
     logger.info(
         "Warmed %d hybrid NVFP4 lm-head state(s) across %d row shapes in %.2fs.",

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -31,6 +31,9 @@ from vllm.model_executor.warmup.flashinfer_sparse_mla_warmup import (
     deepseek_v4_sparse_mla_attention_warmup,
     flashinfer_sparse_mla_decode_autotune_warmup,
 )
+from vllm.model_executor.warmup.hybrid_nvfp4_lm_head_warmup import (
+    hybrid_nvfp4_lm_head_warmup,
+)
 from vllm.model_executor.warmup.kimi_k3_triton_warmup import (
     kimi_k3_triton_warmup,
 )
@@ -137,6 +140,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
         )
 
     qwen_triton_warmup(worker.model_runner, worker.vllm_config.model_config)
+    hybrid_nvfp4_lm_head_warmup(worker)
 
     compilation_config = worker.vllm_config.compilation_config
     cudagraph_capture_sizes = list(compilation_config.cudagraph_capture_sizes or [])

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -11,6 +11,7 @@ import importlib
 import importlib.util
 import os
 import shutil
+import threading
 from collections.abc import Callable
 from typing import Any, NoReturn
 
@@ -171,6 +172,50 @@ autotune = _lazy_import_wrapper(
     "autotune",
     fallback_fn=lambda *args, **kwargs: contextlib.nullcontext(),
 )
+
+_AUTOTUNE_DELAY_LOCK = threading.RLock()
+
+
+@contextlib.contextmanager
+def autotune_with_torch_cuda_delay(*args, **kwargs):
+    if not has_flashinfer():
+        yield
+        return
+
+    autotuner = _get_submodule("flashinfer.autotuner")
+    if autotuner is None or not hasattr(autotuner, "autotune"):
+        yield
+        return
+
+    autotune_fn = autotuner.autotune
+    implementation_name = getattr(autotune_fn, "__module__", "")
+    implementation = (
+        _get_submodule(implementation_name) if implementation_name else None
+    )
+    delay_owners = []
+    for module in (autotuner, implementation):
+        if (
+            module is not None
+            and hasattr(module, "delay_kernel")
+            and all(module is not owner for owner in delay_owners)
+        ):
+            delay_owners.append(module)
+
+    def torch_delay(microseconds: int) -> None:
+        torch.cuda._sleep(max(1, int(microseconds) * 1000))
+
+    with _AUTOTUNE_DELAY_LOCK:
+        original_delays = [owner.delay_kernel for owner in delay_owners]
+        for owner in delay_owners:
+            owner.delay_kernel = torch_delay
+        try:
+            with autotune_fn(*args, **kwargs):
+                yield
+        finally:
+            for owner, original_delay in zip(
+                delay_owners, original_delays, strict=True
+            ):
+                owner.delay_kernel = original_delay
 
 
 @functools.cache
@@ -727,6 +772,36 @@ if has_flashinfer():
         )
 
     @torch.library.custom_op(
+        "vllm::flashinfer_nvfp4_quantize_128x4",
+        mutates_args=[],
+        device_types="cuda",
+    )
+    def flashinfer_nvfp4_quantize_128x4_op(
+        a: torch.Tensor, a_global_sf: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from flashinfer import SfLayout
+        from flashinfer import nvfp4_quantize as nvfp4_quantize_
+
+        return nvfp4_quantize_(
+            a,
+            a_global_sf,
+            sfLayout=SfLayout.layout_128x4,
+            do_shuffle=False,
+        )
+
+    @torch.library.register_fake("vllm::flashinfer_nvfp4_quantize_128x4")
+    def flashinfer_nvfp4_quantize_128x4_fake(
+        a: torch.Tensor, a_global_sf: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        m, n = a.shape
+        rounded_m = cdiv(m, 128) * 128
+        scale_n = cdiv(n // 16, 4) * 4
+        return (
+            torch.empty(m, n // 2, dtype=torch.uint8, device=a.device),
+            torch.empty(rounded_m, scale_n, dtype=torch.uint8, device=a.device),
+        )
+
+    @torch.library.custom_op(
         "vllm::flashinfer_mxfp8_quantize_8x4",
         mutates_args=[],
         device_types="cuda",
@@ -985,6 +1060,16 @@ def flashinfer_quant_nvfp4_8x4_sf_layout(
     return flashinfer_nvfp4_quantize(a, a_global_sf)
 
 
+def flashinfer_nvfp4_quantize_128x4(
+    a: torch.Tensor, a_global_sf: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not has_flashinfer():
+        raise RuntimeError("FlashInfer is required for NVFP4 quantization")
+    return torch.ops.vllm.flashinfer_nvfp4_quantize_128x4.default(
+        a, a_global_sf
+    )
+
+
 flashinfer_fp8_blockscale_gemm = _lazy_import_wrapper(
     "flashinfer.gemm", "fp8_blockscale_gemm_sm90"
 )
@@ -1094,6 +1179,7 @@ __all__ = [
     "flashinfer_trtllm_batch_decode_sparse_mla_dsv4",
     "flashinfer_xqa_batch_decode_with_kv_cache",
     "autotune",
+    "autotune_with_torch_cuda_delay",
     "has_flashinfer_moe",
     "has_flashinfer_comm",
     "has_flashinfer_nvlink_two_sided",
@@ -1114,6 +1200,7 @@ __all__ = [
     "flashinfer_scaled_fp8_mm",
     "flashinfer_scaled_fp8_mm_out",
     "flashinfer_quant_nvfp4_8x4_sf_layout",
+    "flashinfer_nvfp4_quantize_128x4",
     "flashinfer_fp8_blockscale_gemm",
     "should_use_flashinfer_for_blockscale_fp8_gemm",
     "is_flashinfer_fp8_blockscale_gemm_supported",

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -1065,9 +1065,7 @@ def flashinfer_nvfp4_quantize_128x4(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if not has_flashinfer():
         raise RuntimeError("FlashInfer is required for NVFP4 quantization")
-    return torch.ops.vllm.flashinfer_nvfp4_quantize_128x4.default(
-        a, a_global_sf
-    )
+    return torch.ops.vllm.flashinfer_nvfp4_quantize_128x4.default(a, a_global_sf)
 
 
 flashinfer_fp8_blockscale_gemm = _lazy_import_wrapper(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1446,6 +1446,37 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 getattr(self.model, "language_model", None), "lm_head", None
             )
 
+        # Added-vocabulary/LoRA transformations may be applied after model
+        # construction.  Once the contiguous-original-vocab contract is
+        # broken, drop the auxiliary copy immediately instead of merely
+        # falling back while retaining its VRAM allocation.
+        if (
+            envs.VLLM_HYBRID_NVFP4_LM_HEAD
+            and getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None) is not None
+            and (
+                getattr(lm_head, "num_added_embeddings", 0) > 0
+                or getattr(
+                    getattr(lm_head, "shard_indices", None), "num_added_elements", 0
+                )
+                > 0
+                or self.vocab_size >= (1 << 24)
+                or self.lora_config is not None
+                or self.model_config.head_dtype != self.dtype
+                or getattr(self.model_config, "dtype", self.dtype) != self.dtype
+                or envs.VLLM_BATCH_INVARIANT
+                or envs.VLLM_COMPUTE_NANS_IN_LOGITS
+                or self.adaptive_verification is not None
+            )
+        ):
+            from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+                release_hybrid_nvfp4_lm_heads,
+            )
+
+            release_hybrid_nvfp4_lm_heads(self.model)
+            draft_model = getattr(getattr(self, "speculator", None), "model", None)
+            if isinstance(draft_model, nn.Module):
+                release_hybrid_nvfp4_lm_heads(draft_model)
+
         fast_path_params = None
         if (
             envs.VLLM_HYBRID_NVFP4_LM_HEAD
@@ -1456,6 +1487,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             and self.adaptive_verification is None
             and not envs.VLLM_BATCH_INVARIANT
             and self.model_config.head_dtype == self.dtype
+            and self.vocab_size < (1 << 24)
             and getattr(lm_head, "num_added_embeddings", 0) == 0
             and getattr(
                 getattr(lm_head, "shard_indices", None), "num_added_elements", 0
@@ -1558,6 +1590,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             sampled = self.model.sample_full_tokens(
                 sample_hidden_states,
                 temperature=temperature,
+                expanded_idx_mapping=input_batch.expanded_idx_mapping,
+                seeds=self.sampler.sampling_states.seeds.gpu,
+                pos=input_batch.positions[input_batch.logits_indices],
+                temperature_state=self.sampler.sampling_states.temperature.gpu,
             )
             sampler_output = self.sampler.make_sampler_output(
                 sampled.to(torch.int64), input_batch
@@ -1597,6 +1633,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 presence_penalties=presence_penalties,
                 output_token_counts=output_token_counts,
                 presence_request_indices=presence_request_indices,
+                expanded_idx_mapping=input_batch.expanded_idx_mapping,
+                seeds=self.sampler.sampling_states.seeds.gpu,
+                pos=input_batch.positions[input_batch.logits_indices],
+                temperature_state=self.sampler.sampling_states.temperature.gpu,
             )
             sampler_output = self.sampler.make_sampler_output(
                 sampled.to(torch.int64), input_batch

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -810,7 +810,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return hidden_states, sample_hidden_states
 
     @torch.inference_mode()
-    def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
+    def _dummy_sampler_run(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        warmup_top_k_top_p_rows: int | None = None,
+    ) -> None:
         num_reqs = hidden_states.shape[0]
         logits = self.model.compute_logits(hidden_states)
         dummy_input_batch = InputBatch.make_dummy(
@@ -821,6 +826,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # top_k, top_p, and logprobs, using less GPU memory than what is possible
         # during actual execution.
         assert self.sampler is not None
+        if warmup_top_k_top_p_rows is not None:
+            self.sampler.warmup_top_k_top_p_buffer(warmup_top_k_top_p_rows)
         self.sampler(logits, dummy_input_batch)
 
     @torch.inference_mode()
@@ -854,7 +861,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.is_last_pp_rank:
             assert sample_hidden_states is not None
             if self.pooling_runner is None:
-                self._dummy_sampler_run(sample_hidden_states)
+                warmup_rows = None
+                if self.num_speculative_steps > 0:
+                    # MTP verification flattens target rows for every
+                    # request. Profile that upper-bound shape before KV
+                    # cache/CUDA-graph memory is committed.
+                    warmup_rows = self.max_num_reqs * max(1, self.decode_query_len)
+                self._dummy_sampler_run(
+                    sample_hidden_states,
+                    warmup_top_k_top_p_rows=warmup_rows,
+                )
             else:
                 self._dummy_pooler_run(hidden_states)
 
@@ -1375,6 +1391,43 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
         return block_tables, slot_mappings
 
+    def _get_hybrid_lm_head_processor(self) -> Any | None:
+        """Find the target model's optional compact-head logits processor."""
+        processor = getattr(self.model, "logits_processor", None)
+        if processor is None:
+            language_model = getattr(self.model, "language_model", None)
+            processor = getattr(language_model, "logits_processor", None)
+        if processor is None or not hasattr(processor, "hybrid_lm_head_row_mask"):
+            return None
+        return processor
+
+    def _make_hybrid_lm_head_row_mask(
+        self, input_batch: InputBatch
+    ) -> torch.Tensor | None:
+        """Disable compact lm-head work for rows belonging to prefill requests.
+
+        The compact path is tuned for steady-state decode.  Keeping prompt
+        tail rows on the regular full head avoids paying activation
+        quantization/GEMM setup on TTFT-critical work while preserving the
+        compact path for decode rows in the same mixed batch.
+        """
+        if not envs.VLLM_HYBRID_NVFP4_LM_HEAD or not input_batch.has_prefill:
+            return None
+        num_logits_per_req = np.diff(input_batch.cu_num_logits_np)
+        if num_logits_per_req.shape[0] != input_batch.is_prefilling_np.shape[0]:
+            return None
+        row_mask_np = np.repeat(
+            np.logical_not(input_batch.is_prefilling_np), num_logits_per_req
+        )
+        return torch.from_numpy(row_mask_np).to(self.device, non_blocking=True)
+
+    def _set_hybrid_lm_head_row_mask(
+        self, row_mask: torch.Tensor | None
+    ) -> None:
+        processor = self._get_hybrid_lm_head_processor()
+        if processor is not None:
+            processor.hybrid_lm_head_row_mask = row_mask
+
     def sample(
         self,
         hidden_states: torch.Tensor,
@@ -1383,6 +1436,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor]:
         sample_hidden_states = hidden_states[input_batch.logits_indices]
         assert self.sampler is not None
+        sampler_output: SamplerOutput | None = None
+
+        lm_head = getattr(self.model, "lm_head", None)
+        if lm_head is None:
+            # Multimodal Qwen wrappers expose the language model below the
+            # outer conditional-generation module.
+            lm_head = getattr(
+                getattr(self.model, "language_model", None), "lm_head", None
+            )
 
         fast_path_params = None
         if (
@@ -1390,6 +1452,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             and self.batch_sharder is None
             and grammar_output is None
             and not input_batch.has_structured_output_reqs
+            and self.lora_config is None
+            and self.adaptive_verification is None
+            and not envs.VLLM_BATCH_INVARIANT
+            and self.model_config.head_dtype == self.dtype
+            and getattr(lm_head, "num_added_embeddings", 0) == 0
+            and getattr(
+                getattr(lm_head, "shard_indices", None), "num_added_elements", 0
+            )
+            == 0
+            and getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None) is not None
         ):
             fast_path_params = self.sampler.get_vocab_parallel_sampling_params(
                 input_batch
@@ -1423,8 +1495,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 and hasattr(self.model, "get_top_tokens")
             ):
                 logger.info_once(
-                    "Using the hybrid lm-head greedy speculative sampling "
-                    "fast path.",
+                    "Using the hybrid lm-head greedy speculative sampling fast path.",
                     scope="global",
                 )
                 target_token_ids = self.model.get_top_tokens(sample_hidden_states)
@@ -1437,6 +1508,104 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     sampler_output.num_sampled,
                     sampler_output.num_rejected,
                 )
+
+        if (
+            fast_path_params is not None
+            and fast_path_params[0] == "topk"
+            and not fast_path_params[4]
+            and input_batch.num_draft_tokens > 0
+            and self.rejection_sampler is not None
+            and self.speculator is not None
+            and self.speculator.draft_logits is None
+            and self.rejection_sampler.synthetic_conditional_rates is None
+            and not self.rejection_sampler.use_block_verification
+            and hasattr(self.model, "get_topk_candidates")
+        ):
+            _, top_k, top_p, temperature, _ = fast_path_params
+            logger.info_once(
+                "Using the hybrid lm-head compact top-k speculative sampling "
+                "fast path.",
+                scope="global",
+            )
+            candidate_logits, candidate_ids = self.model.get_topk_candidates(
+                sample_hidden_states,
+                top_k=top_k,
+                top_p=top_p,
+                temperature=temperature,
+            )
+            sampler_output = self.rejection_sampler.sample_from_topk_candidates(
+                candidate_logits,
+                candidate_ids,
+                input_batch,
+            )
+            return (
+                sampler_output,
+                sampler_output.num_sampled,
+                sampler_output.num_rejected,
+            )
+
+        if (
+            fast_path_params is not None
+            and fast_path_params[0] == "full"
+            and input_batch.num_draft_tokens == 0
+            and hasattr(self.model, "sample_full_tokens")
+        ):
+            _, _, _, temperature, _ = fast_path_params
+            logger.info_once(
+                "Using the hybrid lm-head full-distribution sampling fast path.",
+                scope="global",
+            )
+            sampled = self.model.sample_full_tokens(
+                sample_hidden_states,
+                temperature=temperature,
+            )
+            sampler_output = self.sampler.make_sampler_output(
+                sampled.to(torch.int64), input_batch
+            )
+            return (
+                sampler_output,
+                sampler_output.num_sampled,
+                sampler_output.num_rejected,
+            )
+
+        if (
+            fast_path_params is not None
+            and fast_path_params[0] == "topk"
+            and input_batch.num_draft_tokens == 0
+            and hasattr(self.model, "sample_topk_tokens")
+        ):
+            _, top_k, top_p, temperature, presence_only = fast_path_params
+            logger.info_once(
+                "Using the hybrid lm-head compact top-k sampling fast path.",
+                scope="global",
+            )
+            if presence_only:
+                (
+                    presence_penalties,
+                    output_token_counts,
+                    presence_request_indices,
+                ) = self.sampler.get_vocab_parallel_presence_inputs(input_batch)
+            else:
+                presence_penalties = None
+                output_token_counts = None
+                presence_request_indices = None
+            sampled = self.model.sample_topk_tokens(
+                sample_hidden_states,
+                top_k=top_k,
+                top_p=top_p,
+                temperature=temperature,
+                presence_penalties=presence_penalties,
+                output_token_counts=output_token_counts,
+                presence_request_indices=presence_request_indices,
+            )
+            sampler_output = self.sampler.make_sampler_output(
+                sampled.to(torch.int64), input_batch
+            )
+            return (
+                sampler_output,
+                sampler_output.num_sampled,
+                sampler_output.num_rejected,
+            )
 
         shard_metadata = None
         global_input_batch = input_batch
@@ -1466,7 +1635,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 grammar_output.grammar_bitmask,
             )
 
-        sampler_output: SamplerOutput | None
         if input_batch.num_reqs == 0:
             # This rank owns no requests this step. It contributes an
             # all-padding block to the gather below.
@@ -1894,9 +2062,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.pcp_manager, hidden_states, input_batch
         )
 
-        sampler_output, num_sampled, num_rejected = self.sample(
-            hidden_states, input_batch, grammar_output
+        self._set_hybrid_lm_head_row_mask(
+            self._make_hybrid_lm_head_row_mask(input_batch)
         )
+        try:
+            sampler_output, num_sampled, num_rejected = self.sample(
+                hidden_states, input_batch, grammar_output
+            )
+        finally:
+            # Prompt-logprob computation and the next draft call have a
+            # different row layout; never let a sampling-step mask leak.
+            self._set_hybrid_lm_head_row_mask(None)
 
         if self.pp_handler is not None:
             # Broadcast to non-last PP ranks (handles spec decode multi-token).

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1381,6 +1381,63 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         input_batch: InputBatch,
         grammar_output: GrammarOutput | None,
     ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor]:
+        sample_hidden_states = hidden_states[input_batch.logits_indices]
+        assert self.sampler is not None
+
+        fast_path_params = None
+        if (
+            envs.VLLM_HYBRID_NVFP4_LM_HEAD
+            and self.batch_sharder is None
+            and grammar_output is None
+            and not input_batch.has_structured_output_reqs
+        ):
+            fast_path_params = self.sampler.get_vocab_parallel_sampling_params(
+                input_batch
+            )
+
+        if fast_path_params is not None and fast_path_params[0] == "greedy":
+            if input_batch.num_draft_tokens == 0 and hasattr(
+                self.model, "get_top_tokens"
+            ):
+                logger.info_once(
+                    "Using the hybrid lm-head greedy sampling fast path.",
+                    scope="global",
+                )
+                sampled = self.model.get_top_tokens(sample_hidden_states)
+                sampler_output = self.sampler.make_sampler_output(
+                    sampled.to(torch.int64), input_batch
+                )
+                return (
+                    sampler_output,
+                    sampler_output.num_sampled,
+                    sampler_output.num_rejected,
+                )
+
+            if (
+                input_batch.num_draft_tokens > 0
+                and self.rejection_sampler is not None
+                and self.speculator is not None
+                and self.speculator.draft_logits is None
+                and self.rejection_sampler.synthetic_conditional_rates is None
+                and not self.rejection_sampler.use_block_verification
+                and hasattr(self.model, "get_top_tokens")
+            ):
+                logger.info_once(
+                    "Using the hybrid lm-head greedy speculative sampling "
+                    "fast path.",
+                    scope="global",
+                )
+                target_token_ids = self.model.get_top_tokens(sample_hidden_states)
+                sampler_output = self.rejection_sampler.sample_from_greedy_tokens(
+                    target_token_ids,
+                    input_batch,
+                )
+                return (
+                    sampler_output,
+                    sampler_output.num_sampled,
+                    sampler_output.num_rejected,
+                )
+
         shard_metadata = None
         global_input_batch = input_batch
         if self.batch_sharder is not None:
@@ -1397,7 +1454,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             logits = all_to_all_logits(local_logits, shard_metadata)
             logits = logits[:, : self.vocab_size]
         else:
-            sample_hidden_states = hidden_states[input_batch.logits_indices]
             logits = self.model.compute_logits(sample_hidden_states)
 
         if grammar_output is not None:

--- a/vllm/v1/worker/gpu/sample/compact_topk.py
+++ b/vllm/v1/worker/gpu/sample/compact_topk.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Small, CUDA-graph-friendly kernels for compact top-k candidate rows."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.v1.worker.gpu.sample.gumbel import tl_rand32, tldevice
+
+
+@triton.jit
+def _pack_topk_pairs_kernel(
+    local_values_ptr,
+    local_ids_ptr,
+    output_ptr,
+    vocab_start: tl.constexpr,
+    top_k: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < top_k
+    input_offset = row_idx * top_k + offsets
+    values = tl.load(local_values_ptr + input_offset, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    ids = tl.load(local_ids_ptr + input_offset, mask=mask, other=0).to(tl.int64)
+    output_offset = row_idx * top_k * 2 + offsets * 2
+    tl.store(output_ptr + output_offset, values, mask=mask)
+    tl.store(
+        output_ptr + output_offset + 1,
+        (ids + vocab_start).to(tl.float32),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _select_compact_topk_pairs_kernel(
+    gathered_pairs_ptr,
+    output_values_ptr,
+    output_ids_ptr,
+    num_candidates: tl.constexpr,
+    top_k: tl.constexpr,
+    top_p: tl.constexpr,
+    CANDIDATE_BLOCK: tl.constexpr,
+    TOPK_BLOCK: tl.constexpr,
+):
+    """Merge compact pairs, apply top-p, and preserve token-id tie order."""
+    row_idx = tl.program_id(0)
+    candidate_offsets = tl.arange(0, CANDIDATE_BLOCK)
+    candidate_mask = candidate_offsets < num_candidates
+    pair_offset = row_idx * num_candidates * 2 + candidate_offsets * 2
+    values = tl.load(
+        gathered_pairs_ptr + pair_offset,
+        mask=candidate_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    ids = tl.load(
+        gathered_pairs_ptr + pair_offset + 1,
+        mask=candidate_mask,
+        other=float("inf"),
+    ).to(tl.float32)
+    values = tl.where(candidate_mask & (values == values), values, -float("inf"))
+
+    top_offsets = tl.arange(0, TOPK_BLOCK)
+    top_values = tl.full((TOPK_BLOCK,), -float("inf"), tl.float32)
+    top_ids = tl.full((TOPK_BLOCK,), float("inf"), tl.float32)
+    work_values = values
+    work_ids = ids
+    for rank in tl.static_range(0, top_k):
+        max_value = tl.max(work_values, axis=0)
+        equal_max = work_values == max_value
+        # Candidate ids are exact FP32 values under the compact-path vocab gate.
+        min_id = tl.min(tl.where(equal_max, work_ids, float("inf")), axis=0)
+        winner = equal_max & (work_ids == min_id)
+        top_values = tl.where(top_offsets == rank, max_value, top_values)
+        top_ids = tl.where(top_offsets == rank, min_id, top_ids)
+        work_values = tl.where(winner, -float("inf"), work_values)
+        work_ids = tl.where(winner, float("inf"), work_ids)
+
+    valid_top = top_offsets < top_k
+    if top_p < 1.0:
+        safe_max = tl.max(
+            tl.where(valid_top & (top_values == top_values), top_values, -float("inf")),
+            axis=0,
+        )
+        finite_top = valid_top & (top_values > -float("inf"))
+        weights = tl.where(finite_top, tl.exp(top_values - safe_max), 0.0)
+        denom = tl.sum(weights, axis=0)
+        probs = tl.where(denom > 0.0, weights / denom, 0.0)
+        previous_cumulative = tl.cumsum(probs, axis=0) - probs
+        valid_top = valid_top & (previous_cumulative <= top_p)
+
+    output_offset = row_idx * top_k + top_offsets
+    output_mask = top_offsets < top_k
+    tl.store(
+        output_values_ptr + output_offset,
+        tl.where(valid_top, top_values, -float("inf")),
+        mask=output_mask,
+    )
+    tl.store(
+        output_ids_ptr + output_offset,
+        top_ids.to(tl.int64),
+        mask=output_mask,
+    )
+
+
+def pack_topk_pairs(
+    local_values: torch.Tensor,
+    local_ids: torch.Tensor,
+    vocab_start: int,
+) -> torch.Tensor:
+    """Pack local logits and ids into interleaved FP32 communication pairs."""
+    if (
+        not HAS_TRITON
+        or not local_values.is_cuda
+        or local_values.ndim != 2
+        or local_ids.shape != local_values.shape
+        or local_values.dtype != torch.float32
+        or local_ids.dtype != torch.int64
+    ):
+        global_ids = local_ids + vocab_start
+        return torch.stack(
+            [local_values, global_ids.to(torch.float32)], dim=-1
+        ).flatten(start_dim=-2)
+
+    batch_size, top_k = local_values.shape
+    output = torch.empty(
+        (batch_size, top_k * 2), dtype=torch.float32, device=local_values.device
+    )
+    if batch_size == 0 or top_k == 0:
+        return output
+    if not local_values.is_contiguous():
+        local_values = local_values.contiguous()
+    if not local_ids.is_contiguous():
+        local_ids = local_ids.contiguous()
+    _pack_topk_pairs_kernel[(batch_size,)](
+        local_values,
+        local_ids,
+        output,
+        vocab_start=int(vocab_start),
+        top_k=top_k,
+        BLOCK_SIZE=triton.next_power_of_2(top_k),
+    )
+    return output
+
+
+def select_compact_topk_pairs(
+    gathered_pairs: torch.Tensor,
+    top_k: int,
+    top_p: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge compact pair rows and apply top-p in one CUDA kernel."""
+    if (
+        not HAS_TRITON
+        or not gathered_pairs.is_cuda
+        or gathered_pairs.ndim != 3
+        or gathered_pairs.shape[-1] != 2
+        or gathered_pairs.dtype != torch.float32
+        or not 0 < top_k <= 64
+        or not top_k <= gathered_pairs.shape[1] <= 2048
+    ):
+        values = gathered_pairs[..., 0]
+        ids = gathered_pairs[..., 1].to(torch.int64)
+        top_values, positions = torch.topk(values, top_k, dim=-1)
+        top_ids = ids.gather(-1, positions)
+        if top_p < 1.0:
+            probs = top_values.softmax(dim=-1, dtype=torch.float32)
+            remove = probs.cumsum(dim=-1) - probs > top_p
+            top_values = top_values.masked_fill(remove, -float("inf"))
+        return top_values, top_ids
+
+    batch_size, num_candidates, _ = gathered_pairs.shape
+    output_values = torch.empty(
+        (batch_size, top_k), dtype=torch.float32, device=gathered_pairs.device
+    )
+    output_ids = torch.empty(
+        (batch_size, top_k), dtype=torch.int64, device=gathered_pairs.device
+    )
+    if batch_size == 0:
+        return output_values, output_ids
+    if not gathered_pairs.is_contiguous():
+        gathered_pairs = gathered_pairs.contiguous()
+    _select_compact_topk_pairs_kernel[(batch_size,)](
+        gathered_pairs,
+        output_values,
+        output_ids,
+        num_candidates=num_candidates,
+        top_k=top_k,
+        top_p=float(top_p),
+        CANDIDATE_BLOCK=triton.next_power_of_2(num_candidates),
+        TOPK_BLOCK=triton.next_power_of_2(top_k),
+    )
+    return output_values, output_ids
+
+
+@triton.jit(do_not_specialize=["num_candidates"])
+def _sample_compact_topk_pairs_kernel(
+    gathered_pairs_ptr,
+    output_token_ids_ptr,
+    expanded_idx_mapping_ptr,
+    seeds_ptr,
+    pos_ptr,
+    num_candidates,
+    top_k: tl.constexpr,
+    top_p: tl.constexpr,
+    CANDIDATE_BLOCK: tl.constexpr,
+    TOPK_BLOCK: tl.constexpr,
+):
+    """Merge compact TP pairs and sample with the keyed Gumbel stream."""
+    row_idx = tl.program_id(0).to(tl.int64)
+    candidate_offsets = tl.arange(0, CANDIDATE_BLOCK)
+    candidate_mask = candidate_offsets < num_candidates
+    pair_offset = row_idx * num_candidates * 2 + candidate_offsets * 2
+    values = tl.load(
+        gathered_pairs_ptr + pair_offset,
+        mask=candidate_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    ids = tl.load(
+        gathered_pairs_ptr + pair_offset + 1,
+        mask=candidate_mask,
+        other=float("inf"),
+    ).to(tl.float32)
+    values = tl.where(
+        candidate_mask & (values == values), values, -float("inf")
+    )
+
+    top_offsets = tl.arange(0, TOPK_BLOCK)
+    top_values = tl.full((TOPK_BLOCK,), -float("inf"), tl.float32)
+    top_ids = tl.full((TOPK_BLOCK,), float("inf"), tl.float32)
+    work_values = values
+    work_ids = ids
+    for rank in tl.static_range(0, top_k):
+        max_value = tl.max(work_values, axis=0)
+        equal_max = work_values == max_value
+        min_id = tl.min(
+            tl.where(equal_max, work_ids, float("inf")), axis=0
+        )
+        winner = equal_max & (work_ids == min_id)
+        top_values = tl.where(top_offsets == rank, max_value, top_values)
+        top_ids = tl.where(top_offsets == rank, min_id, top_ids)
+        work_values = tl.where(winner, -float("inf"), work_values)
+        work_ids = tl.where(winner, float("inf"), work_ids)
+
+    valid_top = top_offsets < top_k
+    if top_p < 1.0:
+        safe_max = tl.max(
+            tl.where(
+                valid_top & (top_values == top_values),
+                top_values,
+                -float("inf"),
+            ),
+            axis=0,
+        )
+        finite_top = valid_top & (top_values > -float("inf"))
+        weights = tl.where(finite_top, tl.exp(top_values - safe_max), 0.0)
+        denom = tl.sum(weights, axis=0)
+        probs = tl.where(denom > 0.0, weights / denom, 0.0)
+        previous_cumulative = tl.cumsum(probs, axis=0) - probs
+        valid_top = valid_top & (previous_cumulative <= top_p)
+
+    request_idx = tl.load(expanded_idx_mapping_ptr + row_idx).to(tl.int64)
+    seed = tl.load(seeds_ptr + request_idx)
+    pos = tl.load(pos_ptr + row_idx)
+    gumbel_seed = tl.randint(seed, pos)
+    u = tl_rand32(gumbel_seed, top_ids.to(tl.int64), includes_zero=False)
+    noise = -tl.log(-tldevice.log1p(-u))
+    scores = tl.where(valid_top, top_values + noise, -float("inf"))
+    _, winner_idx = tl.max(scores, axis=0, return_indices=True)
+    winner_id = tl.sum(
+        tl.where(top_offsets == winner_idx, top_ids, 0.0), axis=0
+    )
+    has_valid = tl.sum(valid_top.to(tl.int32), axis=0) > 0
+    tl.store(
+        output_token_ids_ptr + row_idx,
+        tl.where(has_valid, winner_id, 0.0).to(tl.int64),
+    )
+
+
+def sample_compact_topk_pairs(
+    gathered_pairs: torch.Tensor,
+    top_k: int,
+    top_p: float,
+    expanded_idx_mapping: torch.Tensor,
+    seeds: torch.Tensor,
+    pos: torch.Tensor,
+) -> torch.Tensor | None:
+    """Fuse compact top-k/top-p merge and keyed sampling on CUDA.
+
+    ``None`` requests the caller's reference path when the compact kernel's
+    bounded candidate shape is not applicable.
+    """
+    if (
+        not HAS_TRITON
+        or not gathered_pairs.is_cuda
+        or gathered_pairs.ndim != 3
+        or gathered_pairs.shape[-1] != 2
+        or gathered_pairs.dtype != torch.float32
+        or not 0 < top_k <= 64
+        or not top_k <= gathered_pairs.shape[1] <= 2048
+        or expanded_idx_mapping.ndim != 1
+        or expanded_idx_mapping.shape[0] != gathered_pairs.shape[0]
+        or seeds.ndim != 1
+        or pos.ndim != 1
+    ):
+        return None
+    batch_size, num_candidates, _ = gathered_pairs.shape
+    if batch_size == 0:
+        return torch.empty(
+            (0,), dtype=torch.int64, device=gathered_pairs.device
+        )
+    if not gathered_pairs.is_contiguous():
+        gathered_pairs = gathered_pairs.contiguous()
+    expanded_idx_mapping = expanded_idx_mapping.contiguous()
+    seeds = seeds.contiguous()
+    pos = pos.contiguous()
+    sampled = torch.empty(
+        (batch_size,), dtype=torch.int64, device=gathered_pairs.device
+    )
+    _sample_compact_topk_pairs_kernel[(batch_size,)](
+        gathered_pairs,
+        sampled,
+        expanded_idx_mapping,
+        seeds,
+        pos,
+        num_candidates,
+        top_k=top_k,
+        top_p=float(top_p),
+        CANDIDATE_BLOCK=triton.next_power_of_2(num_candidates),
+        TOPK_BLOCK=triton.next_power_of_2(top_k),
+    )
+    return sampled
+
+
+__all__ = [
+    "pack_topk_pairs",
+    "sample_compact_topk_pairs",
+    "select_compact_topk_pairs",
+]

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -107,6 +107,10 @@ def gumbel_noised_argmax(
     # on H100/Ada/Blackwell and empirically indistinguishable for Gumbel-max.
     if USE_FP64:
         logits = logits.to(tl.float64)
+    # Keep NaN rows fail-closed.  A NaN participating in ``tl.max`` can
+    # otherwise select an arbitrary lane and bypass the deterministic
+    # invalid-logit handling used by the regular sampler.
+    logits = tl.where(logits == logits, logits, float("-inf"))
     if temp != 0.0:
         gumbel_seed = tl.randint(seed, pos)
         if USE_FP64:
@@ -136,6 +140,9 @@ def gumbel_block_argmax(
     logits_cache_stride_0,
     logits_cache_stride_1,
     logits_cache_col_ptr,
+    token_keys_ptr,
+    token_keys_stride,
+    token_key_offset,
     vocab_size,
     APPLY_TEMPERATURE: tl.constexpr,
     USE_FP64: tl.constexpr,
@@ -166,9 +173,17 @@ def gumbel_block_argmax(
 
     seed = tl.load(seeds_ptr + req_state_idx, mask=is_valid_req, other=0)
     pos = tl.load(pos_ptr + token_idx)
+    if token_keys_ptr is None:
+        keys = block + token_key_offset
+    else:
+        keys = tl.load(
+            token_keys_ptr + token_idx * token_keys_stride + block,
+            mask=mask,
+            other=0,
+        ).to(tl.int64)
     return gumbel_noised_argmax(
         logits,
-        block,
+        keys,
         mask,
         seed,
         pos,
@@ -191,6 +206,9 @@ def _gumbel_sample_kernel(
     logits_cache_col_ptr,
     logits_ptr,
     logits_stride,
+    token_keys_ptr,
+    token_keys_stride,
+    token_key_offset,
     expanded_idx_mapping_ptr,
     seeds_ptr,
     pos_ptr,
@@ -225,6 +243,9 @@ def _gumbel_sample_kernel(
         logits_cache_stride_0,
         logits_cache_stride_1,
         logits_cache_col_ptr,
+        token_keys_ptr,
+        token_keys_stride,
+        token_key_offset,
         vocab_size,
         APPLY_TEMPERATURE=APPLY_TEMPERATURE,
         USE_FP64=USE_FP64,
@@ -245,12 +266,18 @@ def gumbel_sample(
     logits_cache: torch.Tensor | None = None,  # [max_num_reqs, num_cols, vocab_size]
     logits_cache_col: torch.Tensor | None = None,  # scalar or [num_tokens]
     use_fp64: bool = False,
-) -> torch.Tensor:
+    token_keys: torch.Tensor | None = None,
+    token_key_offset: int = 0,
+    return_scores: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     # Enforce contiguity on non-strided input tensors
     expanded_idx_mapping = expanded_idx_mapping.contiguous()
     pos = pos.contiguous()
     if logits_cache_col is not None:
         logits_cache_col = logits_cache_col.contiguous()
+    if token_keys is not None:
+        token_keys = token_keys.contiguous()
+        assert token_keys.shape == logits.shape
     num_tokens, vocab_size = logits.shape
     if logits_cache is not None:
         assert logits_cache.size(-1) >= vocab_size, (
@@ -275,6 +302,9 @@ def gumbel_sample(
         logits_cache_col,
         logits,
         logits.stride(0),
+        token_keys,
+        token_keys.stride(0) if token_keys is not None else 0,
+        token_key_offset,
         expanded_idx_mapping,
         seed,
         pos,
@@ -288,4 +318,7 @@ def gumbel_sample(
     # NOTE(woosuk): Use int64 for later indexing.
     max_block_idx = local_max.argmax(dim=-1, keepdim=True)
     sampled = local_argmax.gather(dim=-1, index=max_block_idx).view(-1)
+    if return_scores:
+        max_scores = local_max.gather(dim=-1, index=max_block_idx).view(-1)
+        return sampled, max_scores
     return sampled

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -322,3 +322,98 @@ def gumbel_sample(
         max_scores = local_max.gather(dim=-1, index=max_block_idx).view(-1)
         return sampled, max_scores
     return sampled
+
+
+@triton.jit(do_not_specialize=["num_candidates"])
+def _compact_gumbel_sample_kernel(
+    output_token_ids_ptr,
+    candidate_logits_ptr,
+    candidate_logits_stride,
+    candidate_ids_ptr,
+    candidate_ids_stride,
+    expanded_idx_mapping_ptr,
+    seeds_ptr,
+    pos_ptr,
+    num_candidates,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Sample directly from a compact, token-keyed candidate row.
+
+    Unlike :func:`gumbel_sample`, compact rows fit in one Triton program.  The
+    kernel therefore avoids materializing per-block maxima/indices and the
+    follow-up PyTorch reductions.  The keyed random stream and Gumbel formula
+    intentionally match ``gumbel_noised_argmax``.
+    """
+    row_idx = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_candidates
+    logits = tl.load(
+        candidate_logits_ptr + row_idx * candidate_logits_stride + offsets,
+        mask=mask,
+        other=float("-inf"),
+    ).to(tl.float32)
+    token_ids = tl.load(
+        candidate_ids_ptr + row_idx * candidate_ids_stride + offsets,
+        mask=mask,
+        other=0,
+    ).to(tl.int64)
+    finite = (
+        mask
+        & (logits == logits)
+        & (logits != float("inf"))
+        & (logits != float("-inf"))
+    )
+
+    request_idx = tl.load(expanded_idx_mapping_ptr + row_idx).to(tl.int64)
+    seed = tl.load(seeds_ptr + request_idx)
+    pos = tl.load(pos_ptr + row_idx)
+    gumbel_seed = tl.randint(seed, pos)
+    u = tl_rand32(gumbel_seed, token_ids, includes_zero=False)
+    noise = -tl.log(-tldevice.log1p(-u))
+    scores = tl.where(finite, logits + noise, float("-inf"))
+    winner, winner_idx = tl.max(scores, axis=0, return_indices=True)
+    has_valid = tl.sum(finite.to(tl.int32), axis=0) > 0
+    winner_id = tl.load(
+        candidate_ids_ptr + row_idx * candidate_ids_stride + winner_idx,
+        mask=has_valid,
+        other=0,
+    ).to(tl.int64)
+    tl.store(output_token_ids_ptr + row_idx, tl.where(has_valid, winner_id, 0))
+
+
+def gumbel_sample_compact(
+    logits: torch.Tensor,
+    token_ids: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    temperature: torch.Tensor,
+    seed: torch.Tensor,
+    pos: torch.Tensor,
+) -> torch.Tensor:
+    """Sample token ids from compact rows using the regular keyed Gumbel stream."""
+    if not HAS_TRITON or not logits.is_cuda:
+        raise RuntimeError("gumbel_sample_compact requires CUDA Triton inputs")
+    if logits.ndim != 2 or token_ids.shape != logits.shape:
+        raise ValueError("logits and token_ids must have matching rank-2 shapes")
+    num_tokens, num_candidates = logits.shape
+    if num_candidates == 0 or num_candidates > 1024:
+        raise ValueError(
+            "compact Gumbel sampling supports candidate widths in [1, 1024]"
+        )
+    expanded_idx_mapping = expanded_idx_mapping.contiguous()
+    pos = pos.contiguous()
+    token_ids = token_ids.contiguous()
+    output = torch.empty((num_tokens,), dtype=torch.int64, device=logits.device)
+    block_size = triton.next_power_of_2(num_candidates)
+    _compact_gumbel_sample_kernel[(num_tokens,)](
+        output,
+        logits,
+        logits.stride(0),
+        token_ids,
+        token_ids.stride(0),
+        expanded_idx_mapping,
+        seed,
+        pos,
+        num_candidates,
+        BLOCK_SIZE=block_size,
+    )
+    return output

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -8,8 +8,10 @@ import vllm.envs as envs
 from vllm.config.model import PROCESSED_LOGPROBS_MODES, LogprobsMode
 from vllm.config.reasoning import ReasoningConfig
 from vllm.sampling_params import SamplingParams
+from vllm.triton_utils import HAS_TRITON
 from vllm.v1.sample.ops.topk_topp_sampler import (
     apply_top_k_top_p,
+    apply_top_k_top_p_pytorch,
     flashinfer_sample,
     flashinfer_sampler_supported,
 )
@@ -83,6 +85,15 @@ class Sampler:
         vocab_size = self.sampling_states.vocab_size
         if vocab_size <= 0:
             return
+        max_warmup_bytes = envs.VLLM_HYBRID_NVFP4_LM_HEAD_MAX_WARMUP_BYTES
+        if max_warmup_bytes > 0:
+            # ``apply_top_k_top_p`` materializes a float32 logits workspace.
+            # Bound the profile-only allocation so speculative warmup cannot
+            # consume the KV-cache headroom on large vocabularies.
+            max_rows_by_memory = max_warmup_bytes // (vocab_size * 4)
+            if max_rows_by_memory < 8:
+                return
+            num_rows = min(num_rows, max_rows_by_memory)
         logits = torch.zeros(
             (num_rows, vocab_size), dtype=torch.float32, device=self.device
         )
@@ -92,7 +103,13 @@ class Sampler:
         top_p = torch.full(
             (num_rows,), 0.95, dtype=torch.float32, device=self.device
         )
-        apply_top_k_top_p(logits, top_k, top_p)
+        # A CPU sampler can be constructed by unit tests even when the
+        # process-wide platform is CUDA.  The dispatcher otherwise sees
+        # ``HAS_TRITON`` and attempts to launch a Triton kernel on CPU tensors.
+        if self.device.type == "cpu":
+            apply_top_k_top_p_pytorch(logits, top_k, top_p, allow_cpu_sync=True)
+        else:
+            apply_top_k_top_p(logits, top_k, top_p)
         # Profiling normally runs on CUDA, but keeping the helper usable by
         # CPU/unit-test runners avoids asking torch.accelerator to initialize
         # a nonexistent CUDA device.
@@ -144,11 +161,13 @@ class Sampler:
         """Return uniform parameters for a compact vocab-parallel sampler.
 
         The vocab-parallel path can preserve an unrestricted distribution via
-        local Gumbel-max, and a bounded top-k distribution when the only logits
-        processor is presence penalty. Repetition and frequency penalties are
-        non-constant over a token's sign/count and therefore remain on the
-        full-vocabulary path. The boolean in the return tuple indicates that
-        presence-only metadata must be passed to the model-level sampler.
+        keyed local Gumbel-max, and a bounded top-k distribution when the only
+        logits processor is presence penalty. Repetition and frequency
+        penalties are non-constant over a token's sign/count and therefore
+        remain on the full-vocabulary path. The boolean in the return tuple
+        indicates that presence-only metadata must be passed to the model-level
+        sampler. Request seeds are handled by the keyed V2 kernels; the legacy
+        runner keeps its separate generator gate.
         """
         idx_mapping_np = input_batch.idx_mapping_np
         if (
@@ -158,7 +177,13 @@ class Sampler:
             or self.trace_replay_state is not None
             or self.sampling_states.max_num_logprobs(idx_mapping_np) != NO_LOGPROBS
             or self.logprob_token_ids_state.max_num_token_ids(idx_mapping_np) > 0
-            or self.sampling_states.any_explicit_seed(idx_mapping_np)
+            # The keyed request RNG is implemented by Triton.  Do not accept
+            # a CUDA-like device without Triton and silently fall back to the
+            # global RNG, because that would violate explicit-seed semantics.
+            or (
+                getattr(getattr(self, "device", None), "type", "cpu") != "cpu"
+                and not HAS_TRITON
+            )
         ):
             return None
 

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -64,6 +64,41 @@ class Sampler:
         self.use_flashinfer = (
             not return_sampling_mask and flashinfer_sampler_supported()
         )
+        self.device = device
+
+    @torch.inference_mode()
+    def warmup_top_k_top_p_buffer(self, num_rows: int) -> None:
+        """Warm the shape-dependent top-k/top-p sampler workspace.
+
+        Speculative verification applies filters to the flattened target rows
+        (one row for each draft step plus the bonus row). The normal profile
+        sampler only uses one row per request, so a larger Triton workspace
+        could otherwise be allocated after the KV cache and CUDA graphs are
+        already committed.
+        """
+        if num_rows < 8:
+            # The dispatcher uses the eager PyTorch path for small batches.
+            return
+
+        vocab_size = self.sampling_states.vocab_size
+        if vocab_size <= 0:
+            return
+        logits = torch.zeros(
+            (num_rows, vocab_size), dtype=torch.float32, device=self.device
+        )
+        top_k = torch.full(
+            (num_rows,), min(20, vocab_size), dtype=torch.int32, device=self.device
+        )
+        top_p = torch.full(
+            (num_rows,), 0.95, dtype=torch.float32, device=self.device
+        )
+        apply_top_k_top_p(logits, top_k, top_p)
+        # Profiling normally runs on CUDA, but keeping the helper usable by
+        # CPU/unit-test runners avoids asking torch.accelerator to initialize
+        # a nonexistent CUDA device.
+        if self.device.type != "cpu":
+            torch.accelerator.synchronize()
+        del logits, top_k, top_p
 
     def add_request(
         self, req_idx: int, prompt_len: int, sampling_params: SamplingParams
@@ -106,12 +141,14 @@ class Sampler:
     def get_vocab_parallel_sampling_params(
         self, input_batch: InputBatch
     ) -> tuple[str, int, float, float, bool] | None:
-        """Return parameters for the exact vocab-parallel greedy fast path.
+        """Return uniform parameters for a compact vocab-parallel sampler.
 
-        The compact lm-head path does not materialize logits, so requests that
-        need any logits processor remain on the regular sampler.  Keeping this
-        check in the sampler makes the model runner independent of sampling
-        state details and keeps the fast path semantics narrow.
+        The vocab-parallel path can preserve an unrestricted distribution via
+        local Gumbel-max, and a bounded top-k distribution when the only logits
+        processor is presence penalty. Repetition and frequency penalties are
+        non-constant over a token's sign/count and therefore remain on the
+        full-vocabulary path. The boolean in the return tuple indicates that
+        presence-only metadata must be passed to the model-level sampler.
         """
         idx_mapping_np = input_batch.idx_mapping_np
         if (
@@ -119,31 +156,115 @@ class Sampler:
             or self.compute_nans
             or self.return_sampling_mask
             or self.trace_replay_state is not None
-            or np.any(self.needs_logits_processing[idx_mapping_np])
             or self.sampling_states.max_num_logprobs(idx_mapping_np) != NO_LOGPROBS
             or self.logprob_token_ids_state.max_num_token_ids(idx_mapping_np) > 0
             or self.sampling_states.any_explicit_seed(idx_mapping_np)
         ):
             return None
 
+        # Logit bias, bad words and thinking-budget forcing alter individual
+        # token scores and cannot be reconstructed from a compact candidate
+        # matrix. Temperature/top-k/top-p are handled below and are expected to
+        # make ``needs_logits_processing`` true for random requests.
+        if np.any(self.logit_bias_state.use_logit_bias[idx_mapping_np]):
+            return None
+        if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):
+            return None
+        if self.thinking_budget_state.enabled and np.any(
+            self.thinking_budget_state.use_thinking_budget[idx_mapping_np]
+        ):
+            return None
+
+        use_penalty = self.penalties_state.use_penalty[idx_mapping_np]
+        presence_only = False
+        if np.any(use_penalty):
+            repetition = self.penalties_state.repetition_penalty.np[idx_mapping_np]
+            frequency = self.penalties_state.frequency_penalty.np[idx_mapping_np]
+            presence_only = bool(
+                np.all(repetition == 1.0) and np.all(frequency == 0.0)
+            )
+            if not presence_only:
+                return None
+
         temperatures = self.sampling_states.temperature.np[idx_mapping_np]
         top_ks = self.sampling_states.top_k.np[idx_mapping_np]
         top_ps = self.sampling_states.top_p.np[idx_mapping_np]
         min_ps = self.sampling_states.min_p.np[idx_mapping_np]
-        if not (
-            np.all(temperatures == 0.0)
-            and np.all(top_ks == self.sampling_states.vocab_size)
+        if not np.all(min_ps == 0.0):
+            return None
+
+        default_filters = (
+            np.all(top_ks == self.sampling_states.vocab_size)
             and np.all(top_ps == 1.0)
-            and np.all(min_ps == 0.0)
+        )
+        if np.all(temperatures == 0.0):
+            # A presence penalty changes greedy argmax, so it must be applied
+            # by the regular sampler. Without penalties, top-k/top-p are
+            # argmax-invariant and the existing greedy path is safe.
+            if presence_only or not default_filters:
+                return None
+            return (
+                "greedy",
+                self.sampling_states.vocab_size,
+                1.0,
+                0.0,
+                False,
+            )
+
+        # Full-distribution random sampling is supported by a local Gumbel-max
+        # reduction; only request modes with mixed temperature remain unsafe.
+        if (
+            self.use_fp64_gumbel
+            or np.any(temperatures <= 0.0)
+            or not np.all(temperatures == temperatures[0])
         ):
             return None
 
+        top_k = int(top_ks[0])
+        top_p = float(top_ps[0])
+        temperature = float(temperatures[0])
+        if default_filters:
+            # Gumbel-max over each TP-local shard is exact for an unrestricted
+            # softmax distribution and avoids gathering the full vocabulary.
+            # A presence penalty changes every previously seen token and would
+            # require a full-vocabulary penalty application before Gumbel-max.
+            if presence_only:
+                return None
+            return (
+                "full",
+                self.sampling_states.vocab_size,
+                1.0,
+                temperature,
+                False,
+            )
+        if (
+            top_k <= 0
+            or top_k > 64
+            or top_p <= 0.0
+            or top_p > 1.0
+            or not np.all(top_ks == top_k)
+            or not np.all(top_ps == top_p)
+            or not np.all(temperatures == temperature)
+        ):
+            return None
+
+        # Presence-only penalties are supported by the compact path. This is
+        # intentionally returned only for bounded top-k, never for full random
+        # sampling where a candidate approximation would change probabilities.
+        return ("topk", top_k, top_p, temperature, presence_only)
+
+    def get_vocab_parallel_presence_inputs(
+        self, input_batch: InputBatch
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return row-aligned presence penalties and persistent output counts."""
+        request_indices = input_batch.idx_mapping.to(torch.int64)
+        presence_penalties = self.penalties_state.presence_penalty.gpu.index_select(
+            0, request_indices
+        )
         return (
-            "greedy",
-            self.sampling_states.vocab_size,
-            1.0,
-            0.0,
-            False,
+            presence_penalties,
+            self.penalties_state.output_bin_counts,
+            request_indices,
         )
 
     def make_sampler_output(

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -103,6 +103,72 @@ class Sampler:
         if self.trace_replay_state is not None:
             self.trace_replay_state.apply_staged_writes()
 
+    def get_vocab_parallel_sampling_params(
+        self, input_batch: InputBatch
+    ) -> tuple[str, int, float, float, bool] | None:
+        """Return parameters for the exact vocab-parallel greedy fast path.
+
+        The compact lm-head path does not materialize logits, so requests that
+        need any logits processor remain on the regular sampler.  Keeping this
+        check in the sampler makes the model runner independent of sampling
+        state details and keeps the fast path semantics narrow.
+        """
+        idx_mapping_np = input_batch.idx_mapping_np
+        if (
+            idx_mapping_np.size == 0
+            or self.compute_nans
+            or self.return_sampling_mask
+            or self.trace_replay_state is not None
+            or np.any(self.needs_logits_processing[idx_mapping_np])
+            or self.sampling_states.max_num_logprobs(idx_mapping_np) != NO_LOGPROBS
+            or self.logprob_token_ids_state.max_num_token_ids(idx_mapping_np) > 0
+            or self.sampling_states.any_explicit_seed(idx_mapping_np)
+        ):
+            return None
+
+        temperatures = self.sampling_states.temperature.np[idx_mapping_np]
+        top_ks = self.sampling_states.top_k.np[idx_mapping_np]
+        top_ps = self.sampling_states.top_p.np[idx_mapping_np]
+        min_ps = self.sampling_states.min_p.np[idx_mapping_np]
+        if not (
+            np.all(temperatures == 0.0)
+            and np.all(top_ks == self.sampling_states.vocab_size)
+            and np.all(top_ps == 1.0)
+            and np.all(min_ps == 0.0)
+        ):
+            return None
+
+        return (
+            "greedy",
+            self.sampling_states.vocab_size,
+            1.0,
+            0.0,
+            False,
+        )
+
+    def make_sampler_output(
+        self,
+        sampled: torch.Tensor,
+        input_batch: InputBatch,
+        *,
+        num_nans: torch.Tensor | None = None,
+    ) -> SamplerOutput:
+        """Build the standard one-token output for pre-sampled rows."""
+        num_sampled, num_rejected = get_num_sampled_and_rejected(
+            input_batch.seq_lens.new_ones(input_batch.num_reqs),
+            input_batch.seq_lens,
+            input_batch.cu_num_logits,
+            input_batch.idx_mapping,
+            self.req_states.prefill_len.gpu,
+        )
+        return SamplerOutput(
+            sampled_token_ids=sampled.view(-1, 1),
+            logprobs_tensors=None,
+            num_nans=num_nans,
+            num_sampled=num_sampled,
+            num_rejected=num_rejected,
+        )
+
     def get_logprobs_dims(
         self, idx_mapping_np: np.ndarray, include_token_ids: bool = True
     ) -> tuple[int, int] | None:

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -8,7 +8,7 @@ import torch
 from vllm.config import SpeculativeConfig
 from vllm.config.model import PROCESSED_LOGPROBS_MODES
 from vllm.distributed.parallel_state import get_tp_group
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
 from vllm.v1.worker.gpu.input_batch import (
@@ -16,6 +16,7 @@ from vllm.v1.worker.gpu.input_batch import (
     get_num_sampled_and_rejected,
 )
 from vllm.v1.worker.gpu.metrics.logits import get_num_nans
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample, tl_rand32
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_scores
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.sampler import Sampler
@@ -81,7 +82,9 @@ def _compact_rejection_sample_kernel(
     target_draft_probs_ptr,
     bonus_token_ids_ptr,
     recovered_token_ids_ptr,
-    uniform_probs_ptr,
+    target_req_indices_ptr,
+    target_pos_ptr,
+    seeds_ptr,
     max_spec_len,
 ):
     """Compact top-k rejection decisions into one output row per request."""
@@ -96,7 +99,10 @@ def _compact_rejection_sample_kernel(
             token_idx = start_idx + pos
             draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
             target_prob = tl.load(target_draft_probs_ptr + token_idx)
-            uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+            req_state_idx = tl.load(target_req_indices_ptr + token_idx).to(tl.int64)
+            token_pos = tl.load(target_pos_ptr + token_idx)
+            seed = tl.load(seeds_ptr + req_state_idx)
+            uniform_prob = tl_rand32(seed, token_pos, includes_zero=False)
             accepted = target_prob >= uniform_prob
             token_id = draft_token_id
             if not accepted:
@@ -383,12 +389,51 @@ class RejectionSampler:
             num_rejected=num_rejected,
         )
 
-    @staticmethod
     def _sample_from_candidate_logits(
+        self,
         candidate_logits: torch.Tensor,
         candidate_ids: torch.Tensor,
+        *,
+        expanded_idx_mapping: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        pos: torch.Tensor | None = None,
+        temperature_state: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Sample one token from each compact candidate row."""
+        if (
+            (expanded_idx_mapping is None) != (seeds is None)
+            or (expanded_idx_mapping is None) != (pos is None)
+            or (expanded_idx_mapping is None) != (temperature_state is None)
+        ):
+            raise ValueError(
+                "expanded_idx_mapping, seeds, pos, and temperature_state must be "
+                "provided together"
+            )
+        if (
+            expanded_idx_mapping is not None
+            and seeds is not None
+            and pos is not None
+            and candidate_logits.is_cuda
+            and HAS_TRITON
+        ):
+            if temperature_state is None:
+                raise ValueError(
+                    "temperature_state is required with keyed Gumbel metadata"
+                )
+            sampled_positions = gumbel_sample(
+                candidate_logits,
+                expanded_idx_mapping,
+                temperature_state,
+                seeds,
+                pos,
+                apply_temperature=False,
+                token_keys=candidate_ids,
+            )
+            assert isinstance(sampled_positions, torch.Tensor)
+            return candidate_ids.gather(
+                dim=-1, index=sampled_positions.unsqueeze(-1)
+            ).view(-1)
+
         valid = torch.isfinite(candidate_logits)
         noise = torch.empty_like(candidate_logits)
         noise.exponential_()
@@ -439,8 +484,36 @@ class RejectionSampler:
         draft_sampled = input_batch.input_ids[input_batch.logits_indices]
         draft_token_ids = draft_sampled[target_indices + 1]
 
+        # The compact rows are interleaved with one bonus row per request.
+        # Keep request state and absolute position alongside the filtered
+        # target rows so rejection draws use the same keyed stream as the
+        # regular V2 sampler, independent of TP rank and row packing.
+        all_expanded_idx_mapping = getattr(input_batch, "expanded_idx_mapping", None)
+        all_pos = None
+        target_req_indices = None
+        target_positions = None
+        seeds = None
+        temperature_state = None
+        if all_expanded_idx_mapping is not None:
+            all_pos = input_batch.positions[input_batch.logits_indices]
+            target_req_indices = all_expanded_idx_mapping[target_indices].contiguous()
+            target_positions = all_pos[target_indices].contiguous()
+            seeds = self.sampler.sampling_states.seeds.gpu
+            temperature_state = self.sampler.sampling_states.temperature.gpu
+
+        bonus_kwargs: dict[str, torch.Tensor | None] = {}
+        if all_expanded_idx_mapping is not None:
+            assert all_pos is not None
+            bonus_kwargs = {
+                "expanded_idx_mapping": all_expanded_idx_mapping[bonus_indices],
+                "seeds": seeds,
+                "pos": all_pos[bonus_indices],
+                "temperature_state": temperature_state,
+            }
         bonus_token_ids = self._sample_from_candidate_logits(
-            candidate_logits[bonus_indices], candidate_ids[bonus_indices]
+            candidate_logits[bonus_indices],
+            candidate_ids[bonus_indices],
+            **bonus_kwargs,
         ).to(draft_token_ids.dtype)
         target_logits = candidate_logits[target_indices]
         target_ids = candidate_ids[target_indices]
@@ -461,24 +534,27 @@ class RejectionSampler:
         )
 
         recovered_mask = valid & ~draft_mask
-        noise = torch.empty_like(target_logits)
-        noise.exponential_()
-        recovered_scores = (target_logits - noise.log()).masked_fill(
+        recovered_logits = target_logits.masked_fill(
             ~recovered_mask, -float("inf")
         )
-        recovered_pos = recovered_scores.argmax(dim=-1, keepdim=True)
-        recovered_token_ids = target_ids.gather(dim=-1, index=recovered_pos).view(-1)
+        recovered_kwargs: dict[str, torch.Tensor | None] = {}
+        if target_req_indices is not None:
+            assert target_positions is not None
+            recovered_kwargs = {
+                "expanded_idx_mapping": target_req_indices,
+                "seeds": seeds,
+                "pos": target_positions,
+                "temperature_state": temperature_state,
+            }
+        recovered_token_ids = self._sample_from_candidate_logits(
+            recovered_logits, target_ids, **recovered_kwargs
+        )
         recovered_token_ids = torch.where(
             recovered_mask.any(dim=-1),
             recovered_token_ids,
             torch.zeros_like(recovered_token_ids),
         ).to(draft_token_ids.dtype)
 
-        uniform_probs = torch.rand(
-            (input_batch.num_draft_tokens,),
-            dtype=torch.float64,
-            device=device,
-        )
         cu_num_draft_tokens = input_batch.cu_num_logits[1:] - torch.arange(
             1,
             num_reqs + 1,
@@ -491,7 +567,12 @@ class RejectionSampler:
             dtype=torch.int64,
             device=device,
         )
-        if candidate_logits.is_cuda:
+        if (
+            candidate_logits.is_cuda
+            and target_req_indices is not None
+            and HAS_TRITON
+        ):
+            assert target_positions is not None and seeds is not None
             _compact_rejection_sample_kernel[(num_reqs,)](
                 sampled,
                 cu_num_draft_tokens,
@@ -499,10 +580,17 @@ class RejectionSampler:
                 target_draft_probs,
                 bonus_token_ids,
                 recovered_token_ids,
-                uniform_probs,
+                target_req_indices,
+                target_positions,
+                seeds,
                 self.num_speculative_steps,
             )
         else:
+            uniform_probs = torch.rand(
+                (input_batch.num_draft_tokens,),
+                dtype=torch.float64,
+                device=device,
+            )
             cu_num_draft_tokens_cpu = cu_num_draft_tokens.cpu().tolist()
             sampled_cpu = sampled
             offset = 0
@@ -626,7 +714,7 @@ class RejectionSampler:
             dtype=torch.int64,
             device=target_token_ids.device,
         )
-        if target_token_ids.is_cuda:
+        if target_token_ids.is_cuda and HAS_TRITON:
             _compact_greedy_rejection_sample_kernel[(input_batch.num_reqs,)](
                 sampled,
                 target_token_ids,

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -7,6 +7,7 @@ import torch
 
 from vllm.config import SpeculativeConfig
 from vllm.config.model import PROCESSED_LOGPROBS_MODES
+from vllm.distributed.parallel_state import get_tp_group
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
@@ -73,6 +74,48 @@ def _flatten_sampled_kernel(
 
 
 @triton.jit(do_not_specialize=["max_spec_len"])
+def _compact_rejection_sample_kernel(
+    output_token_ids_ptr,
+    cu_num_draft_tokens_ptr,
+    draft_token_ids_ptr,
+    target_draft_probs_ptr,
+    bonus_token_ids_ptr,
+    recovered_token_ids_ptr,
+    uniform_probs_ptr,
+    max_spec_len,
+):
+    """Compact top-k rejection decisions into one output row per request."""
+    req_idx = tl.program_id(0)
+    start_idx = 0 if req_idx == 0 else tl.load(cu_num_draft_tokens_ptr + req_idx - 1)
+    end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
+    num_draft_tokens = end_idx - start_idx
+
+    rejected = False
+    for pos in range(num_draft_tokens):
+        if not rejected:
+            token_idx = start_idx + pos
+            draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
+            target_prob = tl.load(target_draft_probs_ptr + token_idx)
+            uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+            accepted = target_prob >= uniform_prob
+            token_id = draft_token_id
+            if not accepted:
+                rejected = True
+                token_id = tl.load(recovered_token_ids_ptr + token_idx)
+            tl.store(
+                output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
+                token_id,
+            )
+
+    if not rejected:
+        bonus_token_id = tl.load(bonus_token_ids_ptr + req_idx)
+        tl.store(
+            output_token_ids_ptr + req_idx * (max_spec_len + 1) + num_draft_tokens,
+            bonus_token_id,
+        )
+
+
+@triton.jit(do_not_specialize=["max_spec_len"])
 def _compact_greedy_rejection_sample_kernel(
     output_token_ids_ptr,
     target_token_ids_ptr,
@@ -91,9 +134,9 @@ def _compact_greedy_rejection_sample_kernel(
             target_token_id = tl.load(target_token_ids_ptr + start_idx + pos).to(
                 tl.int64
             )
-            draft_token_id = tl.load(
-                draft_sampled_ptr + start_idx + pos + 1
-            ).to(tl.int64)
+            draft_token_id = tl.load(draft_sampled_ptr + start_idx + pos + 1).to(
+                tl.int64
+            )
             accepted = target_token_id == draft_token_id
             token_id = draft_token_id
             if not accepted:
@@ -107,9 +150,7 @@ def _compact_greedy_rejection_sample_kernel(
     if not rejected:
         bonus_token_id = tl.load(target_token_ids_ptr + end_idx - 1).to(tl.int64)
         tl.store(
-            output_token_ids_ptr
-            + req_idx * (max_spec_len + 1)
-            + num_draft_tokens,
+            output_token_ids_ptr + req_idx * (max_spec_len + 1) + num_draft_tokens,
             bonus_token_id,
         )
 
@@ -338,6 +379,230 @@ class RejectionSampler:
             sampled_token_ids=sampled,
             logprobs_tensors=logprobs_tensors,
             num_nans=num_nans,
+            num_sampled=num_sampled,
+            num_rejected=num_rejected,
+        )
+
+    @staticmethod
+    def _sample_from_candidate_logits(
+        candidate_logits: torch.Tensor,
+        candidate_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Sample one token from each compact candidate row."""
+        valid = torch.isfinite(candidate_logits)
+        noise = torch.empty_like(candidate_logits)
+        noise.exponential_()
+        scores = (candidate_logits - noise.log()).masked_fill(
+            ~valid, -float("inf")
+        )
+        sample_pos = scores.argmax(dim=-1, keepdim=True)
+        return candidate_ids.gather(dim=-1, index=sample_pos).view(-1)
+
+    def _sample_from_topk_candidates_local(
+        self,
+        candidate_logits: torch.Tensor,
+        candidate_ids: torch.Tensor,
+        input_batch: InputBatch,
+    ) -> SamplerOutput:
+        """Verify one-hot drafts using compact target top-k candidates.
+
+        This is deliberately limited to the ordinary probabilistic rejection
+        sampler (no synthetic/block verification).  Candidate logits are the
+        target distribution restricted to an approximate top-k set; a missing
+        draft token therefore has zero mass and is recovered by sampling from
+        the remaining candidate set.
+        """
+        if candidate_logits.ndim != 2:
+            raise ValueError("candidate_logits must be rank 2")
+        if candidate_ids.shape != candidate_logits.shape:
+            raise ValueError("candidate_ids must match candidate_logits")
+        if candidate_logits.shape[0] != int(input_batch.cu_num_logits_np[-1]):
+            raise ValueError("candidate rows must match the logits layout")
+        if input_batch.num_draft_tokens_per_req is None:
+            raise ValueError("top-k candidate sampling requires draft tokens")
+        if self.synthetic_conditional_rates is not None or self.use_block_verification:
+            raise ValueError("compact candidates do not support this rejection mode")
+
+        num_reqs = input_batch.num_reqs
+        device = candidate_logits.device
+        bonus_indices = input_batch.cu_num_logits[1:].to(torch.int64) - 1
+        is_bonus = torch.zeros(
+            candidate_logits.shape[0], dtype=torch.bool, device=device
+        )
+        is_bonus[bonus_indices] = True
+        target_indices = torch.arange(
+            candidate_logits.shape[0], dtype=torch.int64, device=device
+        )[~is_bonus]
+        if target_indices.shape[0] != input_batch.num_draft_tokens:
+            raise ValueError("candidate rows do not match draft-token layout")
+
+        draft_sampled = input_batch.input_ids[input_batch.logits_indices]
+        draft_token_ids = draft_sampled[target_indices + 1]
+
+        bonus_token_ids = self._sample_from_candidate_logits(
+            candidate_logits[bonus_indices], candidate_ids[bonus_indices]
+        ).to(draft_token_ids.dtype)
+        target_logits = candidate_logits[target_indices]
+        target_ids = candidate_ids[target_indices]
+        draft_ids = draft_token_ids.to(target_ids.dtype).unsqueeze(-1)
+
+        valid = torch.isfinite(target_logits)
+        draft_mask = valid & (target_ids == draft_ids)
+        safe_logits = target_logits.masked_fill(~valid, -float("inf"))
+        max_logits = safe_logits.max(dim=-1, keepdim=True).values
+        weights = torch.exp(safe_logits - max_logits)
+        weights = torch.where(valid, weights, torch.zeros_like(weights))
+        denom = weights.sum(dim=-1)
+        draft_weight = torch.where(draft_mask, weights, torch.zeros_like(weights)).sum(
+            dim=-1
+        )
+        target_draft_probs = torch.where(
+            denom > 0.0, draft_weight / denom, torch.zeros_like(denom)
+        )
+
+        recovered_mask = valid & ~draft_mask
+        noise = torch.empty_like(target_logits)
+        noise.exponential_()
+        recovered_scores = (target_logits - noise.log()).masked_fill(
+            ~recovered_mask, -float("inf")
+        )
+        recovered_pos = recovered_scores.argmax(dim=-1, keepdim=True)
+        recovered_token_ids = target_ids.gather(dim=-1, index=recovered_pos).view(-1)
+        recovered_token_ids = torch.where(
+            recovered_mask.any(dim=-1),
+            recovered_token_ids,
+            torch.zeros_like(recovered_token_ids),
+        ).to(draft_token_ids.dtype)
+
+        uniform_probs = torch.rand(
+            (input_batch.num_draft_tokens,),
+            dtype=torch.float64,
+            device=device,
+        )
+        cu_num_draft_tokens = input_batch.cu_num_logits[1:] - torch.arange(
+            1,
+            num_reqs + 1,
+            dtype=input_batch.cu_num_logits.dtype,
+            device=device,
+        )
+        sampled = torch.full(
+            (num_reqs, self.num_speculative_steps + 1),
+            -1,
+            dtype=torch.int64,
+            device=device,
+        )
+        if candidate_logits.is_cuda:
+            _compact_rejection_sample_kernel[(num_reqs,)](
+                sampled,
+                cu_num_draft_tokens,
+                draft_token_ids,
+                target_draft_probs,
+                bonus_token_ids,
+                recovered_token_ids,
+                uniform_probs,
+                self.num_speculative_steps,
+            )
+        else:
+            cu_num_draft_tokens_cpu = cu_num_draft_tokens.cpu().tolist()
+            sampled_cpu = sampled
+            offset = 0
+            for req_idx, end in enumerate(cu_num_draft_tokens_cpu):
+                rejected = False
+                for pos in range(end - offset):
+                    token_idx = offset + pos
+                    if not rejected:
+                        accepted = bool(
+                            target_draft_probs[token_idx]
+                            >= uniform_probs[token_idx].to(
+                                target_draft_probs.dtype
+                            )
+                        )
+                        token_id = draft_token_ids[token_idx]
+                        if not accepted:
+                            rejected = True
+                            token_id = recovered_token_ids[token_idx]
+                        sampled_cpu[req_idx, pos] = token_id
+                if not rejected:
+                    sampled_cpu[req_idx, end - offset] = bonus_token_ids[req_idx]
+                offset = end
+
+        num_sampled = (sampled != -1).sum(dim=-1, dtype=torch.int32)
+        num_sampled, num_rejected = get_num_sampled_and_rejected(
+            num_sampled,
+            input_batch.seq_lens,
+            input_batch.cu_num_logits,
+            input_batch.idx_mapping,
+            self.sampler.req_states.prefill_len.gpu,
+        )
+        return SamplerOutput(
+            sampled_token_ids=sampled,
+            logprobs_tensors=None,
+            num_nans=None,
+            num_sampled=num_sampled,
+            num_rejected=num_rejected,
+        )
+
+    def sample_from_topk_candidates(
+        self,
+        candidate_logits: torch.Tensor,
+        candidate_ids: torch.Tensor,
+        input_batch: InputBatch,
+    ) -> SamplerOutput:
+        """Sample compact MTP candidates once, then synchronize TP ranks.
+
+        ``get_topk_candidates`` all-gathers the candidate pairs, but random
+        rejection decisions must still be made by one rank. Otherwise a
+        different CUDA RNG state on a TP rank can produce divergent sampled
+        tokens even when every rank sees identical candidates.
+        """
+        if candidate_logits.ndim != 2:
+            raise ValueError("candidate_logits must be rank 2")
+        if candidate_ids.shape != candidate_logits.shape:
+            raise ValueError("candidate_ids must match candidate_logits")
+        if candidate_logits.shape[0] != int(input_batch.cu_num_logits_np[-1]):
+            raise ValueError("candidate rows must match the logits layout")
+        if input_batch.num_draft_tokens_per_req is None:
+            raise ValueError("top-k candidate sampling requires draft tokens")
+        if self.synthetic_conditional_rates is not None or self.use_block_verification:
+            raise ValueError("compact candidates do not support this rejection mode")
+
+        try:
+            tp_group = get_tp_group()
+        except AssertionError:
+            # Keep direct CPU/unit-test use independent of distributed setup.
+            tp_group = None
+        if tp_group is None or tp_group.world_size == 1:
+            return self._sample_from_topk_candidates_local(
+                candidate_logits, candidate_ids, input_batch
+            )
+
+        if tp_group.rank_in_group == 0:
+            output = self._sample_from_topk_candidates_local(
+                candidate_logits, candidate_ids, input_batch
+            )
+            sampled = output.sampled_token_ids
+            num_sampled = output.num_sampled
+            num_rejected = output.num_rejected
+        else:
+            sampled = torch.empty(
+                (input_batch.num_reqs, self.num_speculative_steps + 1),
+                dtype=torch.int64,
+                device=candidate_logits.device,
+            )
+            num_sampled = torch.empty(
+                (input_batch.num_reqs,),
+                dtype=torch.int32,
+                device=candidate_logits.device,
+            )
+            num_rejected = torch.empty_like(num_sampled)
+
+        tp_group.broadcast(sampled, src=0)
+        tp_group.broadcast(num_sampled, src=0)
+        tp_group.broadcast(num_rejected, src=0)
+        return SamplerOutput(
+            sampled_token_ids=sampled,
+            logprobs_tensors=None,
+            num_nans=None,
             num_sampled=num_sampled,
             num_rejected=num_rejected,
         )

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -72,6 +72,48 @@ def _flatten_sampled_kernel(
         tl.store(flat_sampled_ptr + start_idx + i, token_id)
 
 
+@triton.jit(do_not_specialize=["max_spec_len"])
+def _compact_greedy_rejection_sample_kernel(
+    output_token_ids_ptr,
+    target_token_ids_ptr,
+    draft_sampled_ptr,
+    cu_num_logits_ptr,
+    max_spec_len,
+):
+    req_idx = tl.program_id(0)
+    start_idx = 0 if req_idx == 0 else tl.load(cu_num_logits_ptr + req_idx)
+    end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
+    num_draft_tokens = end_idx - start_idx - 1
+
+    rejected = False
+    for pos in range(num_draft_tokens):
+        if not rejected:
+            target_token_id = tl.load(target_token_ids_ptr + start_idx + pos).to(
+                tl.int64
+            )
+            draft_token_id = tl.load(
+                draft_sampled_ptr + start_idx + pos + 1
+            ).to(tl.int64)
+            accepted = target_token_id == draft_token_id
+            token_id = draft_token_id
+            if not accepted:
+                rejected = True
+                token_id = target_token_id
+            tl.store(
+                output_token_ids_ptr + req_idx * (max_spec_len + 1) + pos,
+                token_id,
+            )
+
+    if not rejected:
+        bonus_token_id = tl.load(target_token_ids_ptr + end_idx - 1).to(tl.int64)
+        tl.store(
+            output_token_ids_ptr
+            + req_idx * (max_spec_len + 1)
+            + num_draft_tokens,
+            bonus_token_id,
+        )
+
+
 class RejectionSampler:
     def __init__(
         self,
@@ -296,6 +338,70 @@ class RejectionSampler:
             sampled_token_ids=sampled,
             logprobs_tensors=logprobs_tensors,
             num_nans=num_nans,
+            num_sampled=num_sampled,
+            num_rejected=num_rejected,
+        )
+
+    def sample_from_greedy_tokens(
+        self,
+        target_token_ids: torch.Tensor,
+        input_batch: InputBatch,
+    ) -> SamplerOutput:
+        """Verify greedy drafts using only target token IDs."""
+        assert target_token_ids.ndim == 1
+        assert target_token_ids.shape[0] == int(input_batch.cu_num_logits_np[-1])
+        assert input_batch.num_draft_tokens_per_req is not None
+        assert self.synthetic_conditional_rates is None
+        assert not self.use_block_verification
+
+        draft_sampled = input_batch.input_ids[input_batch.logits_indices]
+        sampled = torch.full(
+            (input_batch.num_reqs, self.num_speculative_steps + 1),
+            -1,
+            dtype=torch.int64,
+            device=target_token_ids.device,
+        )
+        if target_token_ids.is_cuda:
+            _compact_greedy_rejection_sample_kernel[(input_batch.num_reqs,)](
+                sampled,
+                target_token_ids,
+                draft_sampled,
+                input_batch.cu_num_logits,
+                self.num_speculative_steps,
+            )
+        else:
+            cu_num_logits = input_batch.cu_num_logits_np
+            for req_idx in range(input_batch.num_reqs):
+                start_idx = int(cu_num_logits[req_idx])
+                end_idx = int(cu_num_logits[req_idx + 1])
+                num_draft_tokens = end_idx - start_idx - 1
+                rejected = False
+                for pos in range(num_draft_tokens):
+                    if rejected:
+                        break
+                    target_token = int(target_token_ids[start_idx + pos])
+                    draft_token = int(draft_sampled[start_idx + pos + 1])
+                    sampled[req_idx, pos] = (
+                        draft_token if target_token == draft_token else target_token
+                    )
+                    rejected = target_token != draft_token
+                if not rejected:
+                    sampled[req_idx, num_draft_tokens] = int(
+                        target_token_ids[end_idx - 1]
+                    )
+
+        num_sampled = (sampled != -1).sum(dim=-1, dtype=torch.int32)
+        num_sampled, num_rejected = get_num_sampled_and_rejected(
+            num_sampled,
+            input_batch.seq_lens,
+            input_batch.cu_num_logits,
+            input_batch.idx_mapping,
+            self.sampler.req_states.prefill_len.gpu,
+        )
+        return SamplerOutput(
+            sampled_token_ids=sampled,
+            logprobs_tensors=None,
+            num_nans=None,
             num_sampled=num_sampled,
             num_rejected=num_rejected,
         )

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -16,7 +16,11 @@ from vllm.v1.worker.gpu.input_batch import (
     get_num_sampled_and_rejected,
 )
 from vllm.v1.worker.gpu.metrics.logits import get_num_nans
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample, tl_rand32
+from vllm.v1.worker.gpu.sample.gumbel import (
+    gumbel_sample,
+    gumbel_sample_compact,
+    tl_rand32,
+)
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_scores
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.sampler import Sampler
@@ -121,6 +125,106 @@ def _compact_rejection_sample_kernel(
         )
 
 
+@triton.jit
+def _prepare_compact_rejection_indices_kernel(
+    cu_num_logits_ptr,
+    target_indices_ptr,
+    bonus_indices_ptr,
+):
+    """Build compact target/bonus row indices directly on the device.
+
+    Compact candidate rows contain one bonus row at the end of every request.
+    The previous implementation first materialized a boolean mask and then
+    filtered a full ``arange``.  Besides allocating temporary tensors, that
+    path used indexed assignment with a scalar on CUDA and could force a
+    host-side stream synchronization.  The layout is regular, so each request
+    can write its target range and bonus row without either operation.
+    """
+    req_idx = tl.program_id(0)
+    start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
+    num_draft_tokens = end_idx - start_idx - 1
+    # Removing one bonus row for every preceding request shifts the compact
+    # target output by ``req_idx``.
+    target_start_idx = start_idx - req_idx
+    for pos in range(num_draft_tokens):
+        tl.store(target_indices_ptr + target_start_idx + pos, start_idx + pos)
+    tl.store(bonus_indices_ptr + req_idx, end_idx - 1)
+
+
+@triton.jit(do_not_specialize=["num_candidates"])
+def _compact_rejection_prepare_kernel(
+    # [num_target_rows]
+    target_draft_probs_ptr,
+    target_draft_probs_stride,
+    # [num_target_rows]
+    recovered_valid_ptr,
+    # [num_target_rows, num_candidates]
+    recovered_logits_ptr,
+    recovered_logits_stride,
+    # [num_target_rows, num_candidates]
+    candidate_logits_ptr,
+    candidate_logits_stride,
+    # [num_target_rows, num_candidates]
+    candidate_ids_ptr,
+    candidate_ids_stride,
+    # [num_target_rows]
+    draft_token_ids_ptr,
+    num_candidates,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Fuse compact rejection probabilities and residual preparation."""
+    row_idx = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_candidates
+
+    logits = tl.load(
+        candidate_logits_ptr + row_idx * candidate_logits_stride + offsets,
+        mask=mask,
+        other=float("-inf"),
+    ).to(tl.float32)
+    candidate_ids = tl.load(
+        candidate_ids_ptr + row_idx * candidate_ids_stride + offsets,
+        mask=mask,
+        other=0,
+    ).to(tl.int64)
+    finite = (
+        mask
+        & (logits == logits)
+        & (logits != float("inf"))
+        & (logits != float("-inf"))
+    )
+    safe_logits = tl.where(finite, logits, float("-inf"))
+    row_max = tl.max(safe_logits, axis=0)
+    weights = tl.where(finite, tl.exp(safe_logits - row_max), 0.0)
+    denom = tl.sum(weights, axis=0)
+
+    draft_id = tl.load(draft_token_ids_ptr + row_idx).to(tl.int64)
+    draft_mask = finite & (candidate_ids == draft_id)
+    draft_logit = tl.max(tl.where(draft_mask, logits, float("-inf")), axis=0)
+    draft_prob = tl.where(
+        (denom > 0.0)
+        & (draft_logit == draft_logit)
+        & (draft_logit != float("-inf")),
+        tl.exp(draft_logit - row_max) / denom,
+        0.0,
+    )
+    tl.store(
+        target_draft_probs_ptr + row_idx * target_draft_probs_stride, draft_prob
+    )
+
+    recovered_logits = tl.where(finite & ~draft_mask, logits, float("-inf"))
+    tl.store(
+        recovered_valid_ptr + row_idx,
+        tl.sum((finite & ~draft_mask).to(tl.int32)) > 0,
+    )
+    tl.store(
+        recovered_logits_ptr + row_idx * recovered_logits_stride + offsets,
+        recovered_logits,
+        mask=mask,
+    )
+
+
 @triton.jit(do_not_specialize=["max_spec_len"])
 def _compact_greedy_rejection_sample_kernel(
     output_token_ids_ptr,
@@ -159,6 +263,85 @@ def _compact_greedy_rejection_sample_kernel(
             output_token_ids_ptr + req_idx * (max_spec_len + 1) + num_draft_tokens,
             bonus_token_id,
         )
+
+
+def _prepare_compact_rejection_candidates(
+    target_logits: torch.Tensor,
+    target_ids: torch.Tensor,
+    draft_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    """Prepare compact residual rows with one fused CUDA kernel.
+
+    Return ``None`` for unsupported inputs so CPU tests and unusually wide
+    candidate sets retain the straightforward PyTorch reference path.
+    """
+    if (
+        not HAS_TRITON
+        or not target_logits.is_cuda
+        or target_logits.ndim != 2
+        or target_ids.shape != target_logits.shape
+        or draft_ids.ndim != 1
+        or draft_ids.shape[0] != target_logits.shape[0]
+        or target_logits.shape[-1] > 1024
+    ):
+        return None
+    num_rows, num_candidates = target_logits.shape
+    if num_rows == 0:
+        return (
+            torch.empty((0,), dtype=torch.float32, device=target_logits.device),
+            torch.empty_like(target_logits),
+            torch.empty((0,), dtype=torch.bool, device=target_logits.device),
+        )
+
+    target_draft_probs = torch.empty(
+        (num_rows,), dtype=torch.float32, device=target_logits.device
+    )
+    recovered_valid = torch.empty(
+        (num_rows,), dtype=torch.bool, device=target_logits.device
+    )
+    recovered_logits = torch.empty_like(target_logits)
+    block_size = triton.next_power_of_2(num_candidates)
+    _compact_rejection_prepare_kernel[(num_rows,)](
+        target_draft_probs,
+        target_draft_probs.stride(0),
+        recovered_valid,
+        recovered_logits,
+        recovered_logits.stride(0),
+        target_logits,
+        target_logits.stride(0),
+        target_ids,
+        target_ids.stride(0),
+        draft_ids,
+        num_candidates,
+        BLOCK_SIZE=block_size,
+    )
+    return target_draft_probs, recovered_logits, recovered_valid
+
+
+def _prepare_compact_rejection_indices(
+    cu_num_logits: torch.Tensor,
+    num_draft_tokens: int,
+    num_reqs: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Prepare compact row indices without host-synchronous indexing ops."""
+    if (
+        not HAS_TRITON
+        or not cu_num_logits.is_cuda
+        or num_reqs == 0
+        or num_draft_tokens < 0
+    ):
+        return None
+    target_indices = torch.empty(
+        (num_draft_tokens,), dtype=torch.int64, device=device
+    )
+    bonus_indices = torch.empty((num_reqs,), dtype=torch.int64, device=device)
+    _prepare_compact_rejection_indices_kernel[(num_reqs,)](
+        cu_num_logits,
+        target_indices,
+        bonus_indices,
+    )
+    return target_indices, bonus_indices
 
 
 class RejectionSampler:
@@ -420,6 +603,15 @@ class RejectionSampler:
                 raise ValueError(
                     "temperature_state is required with keyed Gumbel metadata"
                 )
+            if candidate_logits.shape[-1] <= 1024:
+                return gumbel_sample_compact(
+                    candidate_logits,
+                    candidate_ids,
+                    expanded_idx_mapping,
+                    temperature_state,
+                    seeds,
+                    pos,
+                )
             sampled_positions = gumbel_sample(
                 candidate_logits,
                 expanded_idx_mapping,
@@ -470,14 +662,27 @@ class RejectionSampler:
 
         num_reqs = input_batch.num_reqs
         device = candidate_logits.device
-        bonus_indices = input_batch.cu_num_logits[1:].to(torch.int64) - 1
-        is_bonus = torch.zeros(
-            candidate_logits.shape[0], dtype=torch.bool, device=device
+        compact_indices = _prepare_compact_rejection_indices(
+            input_batch.cu_num_logits,
+            input_batch.num_draft_tokens,
+            num_reqs,
+            device,
         )
-        is_bonus[bonus_indices] = True
-        target_indices = torch.arange(
-            candidate_logits.shape[0], dtype=torch.int64, device=device
-        )[~is_bonus]
+        if compact_indices is not None:
+            target_indices, bonus_indices = compact_indices
+        else:
+            bonus_indices = input_batch.cu_num_logits[1:].to(torch.int64) - 1
+            is_bonus = torch.zeros(
+                candidate_logits.shape[0], dtype=torch.bool, device=device
+            )
+            is_bonus.scatter_(
+                0,
+                bonus_indices,
+                torch.ones_like(bonus_indices, dtype=torch.bool),
+            )
+            target_indices = torch.arange(
+                candidate_logits.shape[0], dtype=torch.int64, device=device
+            )[~is_bonus]
         if target_indices.shape[0] != input_batch.num_draft_tokens:
             raise ValueError("candidate rows do not match draft-token layout")
 
@@ -519,24 +724,31 @@ class RejectionSampler:
         target_ids = candidate_ids[target_indices]
         draft_ids = draft_token_ids.to(target_ids.dtype).unsqueeze(-1)
 
-        valid = torch.isfinite(target_logits)
-        draft_mask = valid & (target_ids == draft_ids)
-        safe_logits = target_logits.masked_fill(~valid, -float("inf"))
-        max_logits = safe_logits.max(dim=-1, keepdim=True).values
-        weights = torch.exp(safe_logits - max_logits)
-        weights = torch.where(valid, weights, torch.zeros_like(weights))
-        denom = weights.sum(dim=-1)
-        draft_weight = torch.where(draft_mask, weights, torch.zeros_like(weights)).sum(
-            dim=-1
+        prepared = _prepare_compact_rejection_candidates(
+            target_logits, target_ids, draft_token_ids
         )
-        target_draft_probs = torch.where(
-            denom > 0.0, draft_weight / denom, torch.zeros_like(denom)
-        )
+        if prepared is not None:
+            target_draft_probs, recovered_logits, recovered_valid = prepared
+        else:
+            valid = torch.isfinite(target_logits)
+            draft_mask = valid & (target_ids == draft_ids)
+            safe_logits = target_logits.masked_fill(~valid, -float("inf"))
+            max_logits = safe_logits.max(dim=-1, keepdim=True).values
+            weights = torch.exp(safe_logits - max_logits)
+            weights = torch.where(valid, weights, torch.zeros_like(weights))
+            denom = weights.sum(dim=-1)
+            draft_weight = torch.where(
+                draft_mask, weights, torch.zeros_like(weights)
+            ).sum(dim=-1)
+            target_draft_probs = torch.where(
+                denom > 0.0, draft_weight / denom, torch.zeros_like(denom)
+            )
 
-        recovered_mask = valid & ~draft_mask
-        recovered_logits = target_logits.masked_fill(
-            ~recovered_mask, -float("inf")
-        )
+            recovered_mask = valid & ~draft_mask
+            recovered_logits = target_logits.masked_fill(
+                ~recovered_mask, -float("inf")
+            )
+            recovered_valid = recovered_mask.any(dim=-1)
         recovered_kwargs: dict[str, torch.Tensor | None] = {}
         if target_req_indices is not None:
             assert target_positions is not None
@@ -550,7 +762,7 @@ class RejectionSampler:
             recovered_logits, target_ids, **recovered_kwargs
         )
         recovered_token_ids = torch.where(
-            recovered_mask.any(dim=-1),
+            recovered_valid,
             recovered_token_ids,
             torch.zeros_like(recovered_token_ids),
         ).to(draft_token_ids.dtype)
@@ -643,6 +855,40 @@ class RejectionSampler:
         different CUDA RNG state on a TP rank can produce divergent sampled
         tokens even when every rank sees identical candidates.
         """
+        try:
+            tp_group = get_tp_group()
+        except AssertionError:
+            # Keep direct CPU/unit-test use independent of distributed setup.
+            tp_group = None
+        if tp_group is not None and tp_group.world_size > 1:
+            if tp_group.rank_in_group != 0:
+                # ``get_topk_candidates`` uses a destination gather, so
+                # non-owner ranks intentionally do not retain candidate rows.
+                # Only the compact sampled output is broadcast.  The request
+                # layout and prefill state are replicated on every TP rank, so
+                # counters can be derived locally after the one synchronization.
+                sampled = torch.empty(
+                    (input_batch.num_reqs, self.num_speculative_steps + 1),
+                    dtype=torch.int64,
+                    device=input_batch.input_ids.device,
+                )
+                tp_group.broadcast(sampled, src=0)
+                num_sampled = (sampled != -1).sum(dim=-1, dtype=torch.int32)
+                num_sampled, num_rejected = get_num_sampled_and_rejected(
+                    num_sampled,
+                    input_batch.seq_lens,
+                    input_batch.cu_num_logits,
+                    input_batch.idx_mapping,
+                    self.sampler.req_states.prefill_len.gpu,
+                )
+                return SamplerOutput(
+                    sampled_token_ids=sampled,
+                    logprobs_tensors=None,
+                    num_nans=None,
+                    num_sampled=num_sampled,
+                    num_rejected=num_rejected,
+                )
+
         if candidate_logits.ndim != 2:
             raise ValueError("candidate_logits must be rank 2")
         if candidate_ids.shape != candidate_logits.shape:
@@ -654,11 +900,6 @@ class RejectionSampler:
         if self.synthetic_conditional_rates is not None or self.use_block_verification:
             raise ValueError("compact candidates do not support this rejection mode")
 
-        try:
-            tp_group = get_tp_group()
-        except AssertionError:
-            # Keep direct CPU/unit-test use independent of distributed setup.
-            tp_group = None
         if tp_group is None or tp_group.world_size == 1:
             return self._sample_from_topk_candidates_local(
                 candidate_logits, candidate_ids, input_batch
@@ -671,22 +912,14 @@ class RejectionSampler:
             sampled = output.sampled_token_ids
             num_sampled = output.num_sampled
             num_rejected = output.num_rejected
-        else:
-            sampled = torch.empty(
-                (input_batch.num_reqs, self.num_speculative_steps + 1),
-                dtype=torch.int64,
-                device=candidate_logits.device,
-            )
-            num_sampled = torch.empty(
-                (input_batch.num_reqs,),
-                dtype=torch.int32,
-                device=candidate_logits.device,
-            )
-            num_rejected = torch.empty_like(num_sampled)
+        else:  # pragma: no cover - handled by the early non-owner return above.
+            raise AssertionError("non-owner TP rank reached compact sampler")
 
+        # ``sampled`` is the only rank-dependent value.  ``num_sampled`` and
+        # ``num_rejected`` depend solely on this tensor plus replicated request
+        # metadata, and are therefore cheaper to compute locally than to send
+        # through two additional NCCL broadcasts.
         tp_group.broadcast(sampled, src=0)
-        tp_group.broadcast(num_sampled, src=0)
-        tp_group.broadcast(num_rejected, src=0)
         return SamplerOutput(
             sampled_token_ids=sampled,
             logprobs_tensors=None,

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -836,6 +836,9 @@ def _resample_kernel(
         0,  # logits_cache_stride_0
         0,  # logits_cache_stride_1
         None,  # logits_cache_col_ptr
+        None,  # token_keys_ptr
+        0,  # token_keys_stride
+        0,  # token_key_offset
         vocab_size,
         APPLY_TEMPERATURE=False,
         USE_FP64=USE_FP64,

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm import PoolingParams, SamplingParams
 from vllm.logger import init_logger
 from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
@@ -413,5 +414,62 @@ def warmup_kernels(
     cleanup_output = SchedulerOutput.make_empty()
     cleanup_output.finished_req_ids = set(req_ids)
     worker_execute_model(cleanup_output)
+
+    if (
+        envs.VLLM_HYBRID_NVFP4_LM_HEAD
+        and not model_runner.is_pooling_model
+        and hasattr(model_runner.model, "get_top_tokens")
+    ):
+        next_block_id = 1
+        req_id = "_v2_vocab_parallel_warmup_greedy_"
+        decode_block_deltas = [
+            block_count(prompt_len + decode_query_len, spec) - held
+            for spec, held in zip(kv_cache_specs, prefill_block_counts)
+        ]
+        request = NewRequestData.from_request(
+            Request(
+                req_id,
+                prompt_token_ids,
+                SamplingParams(
+                    max_tokens=max(2, decode_query_len + 1),
+                    temperature=0.0,
+                ),
+                None,
+                mm_features=warmup_mm_features,
+            ),
+            block_ids=tuple(_alloc_blocks(n) for n in prefill_block_counts),
+            prefill_token_ids=prompt_token_ids,
+        )
+        output = SchedulerOutput.make_empty()
+        output.scheduled_new_reqs = [request]
+        output.num_scheduled_tokens = {req_id: prompt_len}
+        output.total_num_scheduled_tokens = prompt_len
+        output.num_common_prefix_blocks = [0] * num_kv_cache_groups
+        worker_execute_model(output)
+        worker_sample_tokens(None)
+
+        if num_spec_steps > 0:
+            cached = CachedRequestData.make_empty()
+            cached.req_ids = [req_id]
+            cached.num_computed_tokens = [prompt_len]
+            cached.num_output_tokens = [1]
+            cached.new_block_ids = [
+                tuple(_alloc_blocks(n) for n in decode_block_deltas)
+                if any(decode_block_deltas)
+                else None
+            ]
+            decode = SchedulerOutput.make_empty()
+            decode.scheduled_cached_reqs = cached
+            decode.num_scheduled_tokens = {req_id: decode_query_len}
+            decode.scheduled_spec_decode_tokens = {req_id: [0] * num_spec_steps}
+            decode.total_num_scheduled_tokens = decode_query_len
+            decode.num_common_prefix_blocks = [0] * num_kv_cache_groups
+            worker_execute_model(decode)
+            worker_sample_tokens(None)
+
+        cleanup = SchedulerOutput.make_empty()
+        cleanup.finished_req_ids = {req_id}
+        worker_execute_model(cleanup)
+
     model_runner.kv_connector.set_disabled(False)
     torch.accelerator.synchronize()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3759,11 +3759,33 @@ class GPUModelRunner(
     ) -> bool:
         if not envs.VLLM_HYBRID_NVFP4_LM_HEAD:
             return False
+        if (
+            envs.VLLM_COMPUTE_NANS_IN_LOGITS
+            or envs.VLLM_BATCH_INVARIANT
+            or self.lora_config is not None
+            or self.model_config.head_dtype != self.dtype
+        ):
+            return False
         if self.broadcast_pp_output or spec_decode_metadata is not None:
             return False
         if scheduler_output.has_structured_output_requests:
             return False
         if not hasattr(self.model, "get_top_tokens"):
+            return False
+        lm_head = getattr(self.model, "lm_head", None)
+        if lm_head is None:
+            lm_head = getattr(
+                getattr(self.model, "language_model", None), "lm_head", None
+            )
+        if (
+            getattr(lm_head, "num_added_embeddings", 0) > 0
+            or getattr(
+                getattr(lm_head, "shard_indices", None), "num_added_elements", 0
+            )
+            > 0
+        ):
+            return False
+        if getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None) is None:
             return False
 
         sampling_metadata = self.input_batch.sampling_metadata
@@ -3802,6 +3824,235 @@ class GPUModelRunner(
         return num_reqs > 0 and bool(
             np.all(self.input_batch.temperature_cpu[:num_reqs] == 0.0)
         )
+
+    def _get_hybrid_topk_sampling_params(
+        self,
+        scheduler_output: "SchedulerOutput",
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> tuple[int, float, float, bool] | None:
+        """Return uniform top-k params for legacy V1 compact sampling.
+
+        The legacy runner does not keep V2's persistent output-count table, but
+        it does retain committed output ids on the host.  Presence-only
+        penalties can therefore use a compact per-request id table; frequency
+        and repetition penalties still require the regular full-vocabulary
+        sampler.
+        """
+        if not envs.VLLM_HYBRID_NVFP4_LM_HEAD:
+            return None
+        if (
+            envs.VLLM_COMPUTE_NANS_IN_LOGITS
+            or envs.VLLM_BATCH_INVARIANT
+            or self.lora_config is not None
+            or self.model_config.head_dtype != self.dtype
+            or self.sampler.use_fp64_gumbel
+        ):
+            return None
+        if self.broadcast_pp_output or spec_decode_metadata is not None:
+            return None
+        if scheduler_output.has_structured_output_requests:
+            return None
+        if not hasattr(self.model, "sample_topk_tokens"):
+            return None
+
+        lm_head = getattr(self.model, "lm_head", None)
+        if lm_head is None:
+            lm_head = getattr(
+                getattr(self.model, "language_model", None), "lm_head", None
+            )
+        if (
+            getattr(lm_head, "num_added_embeddings", 0) > 0
+            or getattr(
+                getattr(lm_head, "shard_indices", None), "num_added_elements", 0
+            )
+            > 0
+            or getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None) is None
+        ):
+            return None
+
+        sampling_metadata = self.input_batch.sampling_metadata
+        if not sampling_metadata.all_random or sampling_metadata.generators:
+            return None
+        if self.sampler.logprobs_mode in PROCESSED_LOGPROBS_MODES:
+            return None
+        num_reqs = self.input_batch.num_reqs
+        presence_only = False
+        if not sampling_metadata.no_penalties:
+            repetition = self.input_batch.repetition_penalties_cpu[:num_reqs]
+            frequency = self.input_batch.frequency_penalties_cpu[:num_reqs]
+            presence_only = bool(
+                np.all(repetition == 1.0) and np.all(frequency == 0.0)
+            )
+            if not presence_only:
+                return None
+        if (
+            sampling_metadata.max_num_logprobs is not None
+            or sampling_metadata.logprob_token_ids
+            or sampling_metadata.allowed_token_ids_mask is not None
+            or sampling_metadata.bad_words_token_ids
+        ):
+            return None
+
+        for logitproc in sampling_metadata.logitsprocs.all:
+            # Empty built-in processors are harmless; any active processor
+            # needs a full-vocabulary logits tensor for exact semantics.
+            biases = getattr(logitproc, "biases", None)
+            if biases is not None and not biases:
+                continue
+            min_toks = getattr(logitproc, "min_toks", None)
+            if min_toks is not None and not min_toks:
+                continue
+            min_p_count = getattr(logitproc, "min_p_count", None)
+            if min_p_count is not None and not min_p_count:
+                continue
+            return None
+
+        if num_reqs == 0:
+            return None
+        top_k_cpu = self.input_batch.top_k_cpu[:num_reqs]
+        top_p_cpu = self.input_batch.top_p_cpu[:num_reqs]
+        temperature_cpu = self.input_batch.temperature_cpu[:num_reqs]
+        top_k = int(top_k_cpu[0])
+        top_p = float(top_p_cpu[0])
+        temperature = float(temperature_cpu[0])
+        if (
+            top_k <= 0
+            or top_k > 64
+            or top_p <= 0.0
+            or top_p > 1.0
+            or temperature <= 1.0e-5
+            or not np.all(top_k_cpu == top_k)
+            or not np.all(top_p_cpu == top_p)
+            or not np.all(temperature_cpu == temperature)
+        ):
+            return None
+        return top_k, top_p, temperature, presence_only
+
+    def _make_hybrid_presence_output_token_ids(
+        self,
+        sample_hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Build a compact unique output-id table for legacy presence penalty."""
+        num_reqs = self.input_batch.num_reqs
+        if sample_hidden_states.shape[0] != num_reqs:
+            # Chunked-prefill rows do not map one-to-one to request state rows.
+            return None
+
+        rows: list[list[int]] = []
+        max_tokens = 0
+        for req_idx in range(num_reqs):
+            start = int(self.input_batch.num_prompt_tokens[req_idx])
+            end = int(self.input_batch.num_tokens_no_spec[req_idx])
+            seen: set[int] = set()
+            unique_ids: list[int] = []
+            for token_id in self.input_batch.token_ids_cpu[req_idx, start:end]:
+                token_id = int(token_id)
+                if 0 <= token_id < self.vocab_size and token_id not in seen:
+                    seen.add(token_id)
+                    unique_ids.append(token_id)
+            rows.append(unique_ids)
+            max_tokens = max(max_tokens, len(unique_ids))
+
+        if max_tokens == 0:
+            return torch.empty(
+                (num_reqs, 0), dtype=torch.int64, device=sample_hidden_states.device
+            )
+        output_ids_cpu = torch.full(
+            (num_reqs, max_tokens),
+            self.vocab_size,
+            dtype=torch.int64,
+            pin_memory=PIN_MEMORY,
+        )
+        for req_idx, unique_ids in enumerate(rows):
+            if unique_ids:
+                output_ids_cpu[req_idx, : len(unique_ids)] = torch.as_tensor(
+                    unique_ids, dtype=torch.int64
+                )
+        return output_ids_cpu.to(sample_hidden_states.device, non_blocking=True)
+
+    def _get_hybrid_full_sampling_temperature(
+        self,
+        scheduler_output: "SchedulerOutput",
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> float | None:
+        """Return a uniform temperature for unrestricted compact TP sampling."""
+        if not envs.VLLM_HYBRID_NVFP4_LM_HEAD:
+            return None
+        if (
+            envs.VLLM_COMPUTE_NANS_IN_LOGITS
+            or envs.VLLM_BATCH_INVARIANT
+            or self.lora_config is not None
+            or self.model_config.head_dtype != self.dtype
+        ):
+            return None
+        if self.broadcast_pp_output or spec_decode_metadata is not None:
+            return None
+        if scheduler_output.has_structured_output_requests:
+            return None
+        if not hasattr(self.model, "sample_full_tokens"):
+            return None
+
+        lm_head = getattr(self.model, "lm_head", None)
+        if lm_head is None:
+            lm_head = getattr(
+                getattr(self.model, "language_model", None), "lm_head", None
+            )
+        if (
+            getattr(lm_head, "num_added_embeddings", 0) > 0
+            or getattr(
+                getattr(lm_head, "shard_indices", None), "num_added_elements", 0
+            )
+            > 0
+            or getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None) is None
+        ):
+            return None
+
+        sampling_metadata = self.input_batch.sampling_metadata
+        if not sampling_metadata.all_random or sampling_metadata.generators:
+            return None
+        if self.sampler.use_fp64_gumbel:
+            return None
+        if self.sampler.logprobs_mode in PROCESSED_LOGPROBS_MODES:
+            return None
+        if (
+            sampling_metadata.max_num_logprobs is not None
+            or sampling_metadata.logprob_token_ids
+            or sampling_metadata.allowed_token_ids_mask is not None
+            or sampling_metadata.bad_words_token_ids
+            or not sampling_metadata.no_penalties
+        ):
+            return None
+
+        for logitproc in sampling_metadata.logitsprocs.all:
+            biases = getattr(logitproc, "biases", None)
+            if biases is not None and not biases:
+                continue
+            min_toks = getattr(logitproc, "min_toks", None)
+            if min_toks is not None and not min_toks:
+                continue
+            min_p_count = getattr(logitproc, "min_p_count", None)
+            if min_p_count is not None and not min_p_count:
+                continue
+            return None
+
+        holder = getattr(sampling_metadata, "thinking_budget_state_holder", None)
+        if holder is not None and holder.has_tracked_requests():
+            return None
+
+        num_reqs = self.input_batch.num_reqs
+        if num_reqs == 0:
+            return None
+        top_k_cpu = self.input_batch.top_k_cpu[:num_reqs]
+        top_p_cpu = self.input_batch.top_p_cpu[:num_reqs]
+        temperature_cpu = self.input_batch.temperature_cpu[:num_reqs]
+        if not np.all(top_k_cpu == self.vocab_size):
+            return None
+        if not np.all(top_p_cpu == 1.0):
+            return None
+        temperature = float(temperature_cpu[0])
+        if temperature <= 1.0e-5 or not np.all(temperature_cpu == temperature):
+            return None
+        return temperature
 
     def _sample(
         self,
@@ -4647,9 +4898,7 @@ class GPUModelRunner(
 
                 pre_sampled_output = None
                 sample_hidden_states = hidden_states[logits_indices]
-                if self._can_use_hybrid_greedy(
-                    scheduler_output, spec_decode_metadata
-                ):
+                if self._can_use_hybrid_greedy(scheduler_output, spec_decode_metadata):
                     logger.info_once(
                         "Using hybrid NVFP4 lm-head greedy sampling fast path.",
                         scope="global",
@@ -4661,7 +4910,70 @@ class GPUModelRunner(
                     )
                     logits = None
                 else:
-                    logits = self.model.compute_logits(sample_hidden_states)
+                    full_temperature = self._get_hybrid_full_sampling_temperature(
+                        scheduler_output, spec_decode_metadata
+                    )
+                    if full_temperature is not None:
+                        logger.info_once(
+                            "Using hybrid NVFP4 lm-head full-distribution "
+                            "sampling fast path.",
+                            scope="global",
+                        )
+                        sampled = self.model.sample_full_tokens(
+                            sample_hidden_states,
+                            temperature=full_temperature,
+                        )
+                        pre_sampled_output = SamplerOutput(
+                            sampled_token_ids=sampled.to(torch.int32).unsqueeze(-1),
+                            logprobs_tensors=None,
+                        )
+                        logits = None
+                    else:
+                        topk_params = self._get_hybrid_topk_sampling_params(
+                            scheduler_output, spec_decode_metadata
+                        )
+                        if topk_params is None:
+                            logits = self.model.compute_logits(sample_hidden_states)
+                        else:
+                            top_k, top_p, temperature, presence_only = topk_params
+                            presence_penalties = None
+                            output_token_ids = None
+                            if presence_only:
+                                output_token_ids = (
+                                    self._make_hybrid_presence_output_token_ids(
+                                        sample_hidden_states
+                                    )
+                                )
+                                if output_token_ids is None:
+                                    logits = self.model.compute_logits(
+                                        sample_hidden_states
+                                    )
+                                else:
+                                    presence_penalties = (
+                                        self.input_batch.sampling_metadata
+                                        .presence_penalties
+                                    )
+                            if not presence_only or output_token_ids is not None:
+                                logger.info_once(
+                                    "Using hybrid NVFP4 lm-head compact top-k "
+                                    "sampling fast path.",
+                                    scope="global",
+                                )
+                                sampled = self.model.sample_topk_tokens(
+                                    sample_hidden_states,
+                                    top_k=top_k,
+                                    top_p=top_p,
+                                    temperature=temperature,
+                                    presence_penalties=presence_penalties,
+                                    output_token_ids=output_token_ids,
+                                )
+                                pre_sampled_output = SamplerOutput(
+                                    sampled_token_ids=sampled.to(torch.int32).unsqueeze(
+                                        -1
+                                    ),
+                                    logprobs_tensors=None,
+                                )
+                                logits = None
             else:
                 # Rare case.
                 assert not self.is_pooling_model
@@ -5775,6 +6087,19 @@ class GPUModelRunner(
                 param = _get_parameter_for_reload(model, name)  # TODO: buffers?
                 param.copy_(loaded_weight)
                 loaded_weights.add(name)
+
+        # Checkpoint-format reload runs each quantization method's post-load
+        # hook above, which refreshes an existing hybrid state itself. Kernel
+        # format bypasses that hook and needs an explicit refresh here.
+        if envs.VLLM_HYBRID_NVFP4_LM_HEAD and not is_checkpoint_format:
+            from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+                refresh_hybrid_nvfp4_lm_heads,
+            )
+
+            refresh_hybrid_nvfp4_lm_heads(
+                model,
+                candidates=envs.VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES,
+            )
 
         self.reset_lora_state()
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -488,12 +488,13 @@ class ExecuteModelState(NamedTuple):
     sample_tokens(), after execute_model() returns None."""
 
     scheduler_output: "SchedulerOutput"
-    logits: torch.Tensor
+    logits: torch.Tensor | None
     spec_decode_metadata: SpecDecodeMetadata | None
     spec_decode_common_attn_metadata: CommonAttentionMetadata | None
     hidden_states: torch.Tensor
     sample_hidden_states: torch.Tensor
     aux_hidden_states: list[torch.Tensor] | None
+    pre_sampled_output: SamplerOutput | None
     ec_connector_output: ECConnectorOutput | None
     cudagraph_stats: CUDAGraphStat | None
     slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None
@@ -3751,16 +3752,70 @@ class GPUModelRunner(
             ec_connector_output,
         )
 
+    def _can_use_hybrid_greedy(
+        self,
+        scheduler_output: "SchedulerOutput",
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> bool:
+        if not envs.VLLM_HYBRID_NVFP4_LM_HEAD:
+            return False
+        if self.broadcast_pp_output or spec_decode_metadata is not None:
+            return False
+        if scheduler_output.has_structured_output_requests:
+            return False
+        if not hasattr(self.model, "get_top_tokens"):
+            return False
+
+        sampling_metadata = self.input_batch.sampling_metadata
+        if not sampling_metadata.all_greedy:
+            return False
+        if sampling_metadata.generators:
+            return False
+        if self.sampler.logprobs_mode in PROCESSED_LOGPROBS_MODES:
+            return False
+        if (
+            sampling_metadata.max_num_logprobs is not None
+            or sampling_metadata.logprob_token_ids
+            or sampling_metadata.allowed_token_ids_mask is not None
+            or sampling_metadata.bad_words_token_ids
+            or not sampling_metadata.no_penalties
+        ):
+            return False
+
+        for logitproc in sampling_metadata.logitsprocs.non_argmax_invariant:
+            biases = getattr(logitproc, "biases", None)
+            if biases is not None:
+                if biases:
+                    return False
+                continue
+            min_toks = getattr(logitproc, "min_toks", None)
+            if min_toks is not None:
+                if min_toks:
+                    return False
+                continue
+            return False
+
+        holder = sampling_metadata.thinking_budget_state_holder
+        if holder is not None and holder.has_tracked_requests():
+            return False
+        num_reqs = self.input_batch.num_reqs
+        return num_reqs > 0 and bool(
+            np.all(self.input_batch.temperature_cpu[:num_reqs] == 0.0)
+        )
+
     def _sample(
         self,
         logits: torch.Tensor | None,
         spec_decode_metadata: SpecDecodeMetadata | None,
+        pre_sampled_output: SamplerOutput | None = None,
     ) -> SamplerOutput:
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
         # Update output token ids with tokens sampled in last step
         # if async scheduling and required by current sampling params.
         self.input_batch.update_async_output_token_ids()
+        if pre_sampled_output is not None:
+            return pre_sampled_output
         if spec_decode_metadata is None:
             return self.sampler(
                 logits=logits,
@@ -4590,8 +4645,23 @@ class GPUModelRunner(
                         kv_connector_output,
                     )
 
+                pre_sampled_output = None
                 sample_hidden_states = hidden_states[logits_indices]
-                logits = self.model.compute_logits(sample_hidden_states)
+                if self._can_use_hybrid_greedy(
+                    scheduler_output, spec_decode_metadata
+                ):
+                    logger.info_once(
+                        "Using hybrid NVFP4 lm-head greedy sampling fast path.",
+                        scope="global",
+                    )
+                    sampled = self.model.get_top_tokens(sample_hidden_states)
+                    pre_sampled_output = SamplerOutput(
+                        sampled_token_ids=sampled.to(torch.int32).unsqueeze(-1),
+                        logprobs_tensors=None,
+                    )
+                    logits = None
+                else:
+                    logits = self.model.compute_logits(sample_hidden_states)
             else:
                 # Rare case.
                 assert not self.is_pooling_model
@@ -4621,6 +4691,7 @@ class GPUModelRunner(
                 )
                 assert broadcasted is not None
                 logits = broadcasted["logits"]
+                pre_sampled_output = None
 
         self.execute_model_state = ExecuteModelState(
             scheduler_output,
@@ -4630,6 +4701,7 @@ class GPUModelRunner(
             hidden_states,
             sample_hidden_states,
             aux_hidden_states,
+            pre_sampled_output,
             ec_connector_output,
             cudagraph_stats,
             slot_mappings,
@@ -4681,6 +4753,7 @@ class GPUModelRunner(
             hidden_states,
             sample_hidden_states,
             aux_hidden_states,
+            pre_sampled_output,
             ec_connector_output,
             cudagraph_stats,
             slot_mappings,
@@ -4690,12 +4763,15 @@ class GPUModelRunner(
 
         # Apply structured output bitmasks if present.
         if grammar_output is not None:
+            assert pre_sampled_output is None
             apply_grammar_bitmask(
                 scheduler_output, grammar_output, self.input_batch, logits
             )
 
         with record_function_or_nullcontext("gpu_model_runner: sample"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
+            sampler_output = self._sample(
+                logits, spec_decode_metadata, pre_sampled_output
+            )
 
         self._update_states_after_model_execute(
             sampler_output.sampled_token_ids, scheduler_output

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3764,6 +3764,7 @@ class GPUModelRunner(
             or envs.VLLM_BATCH_INVARIANT
             or self.lora_config is not None
             or self.model_config.head_dtype != self.dtype
+            or self.vocab_size >= (1 << 24)
         ):
             return False
         if self.broadcast_pp_output or spec_decode_metadata is not None:
@@ -3846,6 +3847,7 @@ class GPUModelRunner(
             or self.lora_config is not None
             or self.model_config.head_dtype != self.dtype
             or self.sampler.use_fp64_gumbel
+            or self.vocab_size >= (1 << 24)
         ):
             return None
         if self.broadcast_pp_output or spec_decode_metadata is not None:
@@ -3983,6 +3985,7 @@ class GPUModelRunner(
             or envs.VLLM_BATCH_INVARIANT
             or self.lora_config is not None
             or self.model_config.head_dtype != self.dtype
+            or self.vocab_size >= (1 << 24)
         ):
             return None
         if self.broadcast_pp_output or spec_decode_metadata is not None:
@@ -4898,6 +4901,41 @@ class GPUModelRunner(
 
                 pre_sampled_output = None
                 sample_hidden_states = hidden_states[logits_indices]
+                lm_head = getattr(self.model, "lm_head", None)
+                if lm_head is None:
+                    lm_head = getattr(
+                        getattr(self.model, "language_model", None), "lm_head", None
+                    )
+                if (
+                    envs.VLLM_HYBRID_NVFP4_LM_HEAD
+                    and getattr(lm_head, "_hybrid_nvfp4_lm_head_state", None)
+                    is not None
+                    and (
+                        getattr(lm_head, "num_added_embeddings", 0) > 0
+                        or getattr(
+                            getattr(lm_head, "shard_indices", None),
+                            "num_added_elements",
+                            0,
+                        )
+                        > 0
+                        or self.vocab_size >= (1 << 24)
+                        or self.lora_config is not None
+                        or self.model_config.head_dtype != self.dtype
+                        or getattr(self.model_config, "dtype", self.dtype)
+                        != self.dtype
+                        or getattr(self, "adaptive_verification", None) is not None
+                        or envs.VLLM_BATCH_INVARIANT
+                        or envs.VLLM_COMPUTE_NANS_IN_LOGITS
+                    )
+                ):
+                    from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+                        release_hybrid_nvfp4_lm_heads,
+                    )
+
+                    release_hybrid_nvfp4_lm_heads(self.model)
+                    draft_model = getattr(self.drafter, "model", None)
+                    if isinstance(draft_model, nn.Module):
+                        release_hybrid_nvfp4_lm_heads(draft_model)
                 if self._can_use_hybrid_greedy(scheduler_output, spec_decode_metadata):
                     logger.info_once(
                         "Using hybrid NVFP4 lm-head greedy sampling fast path.",
@@ -5791,6 +5829,45 @@ class GPUModelRunner(
             config = getattr(self, config_name)
             new_config = update_config(config, config_overrides)
             setattr(self, config_name, new_config)
+
+        # ``model_config`` can be changed while a worker is alive (for
+        # example by RL weight/config reload).  A previously prepared FP4
+        # copy is only valid while the model-level capability contract still
+        # holds; otherwise it is dead VRAM that the runner can no longer use.
+        if envs.VLLM_HYBRID_NVFP4_LM_HEAD and hasattr(self, "model"):
+            from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+                release_hybrid_nvfp4_lm_heads,
+            )
+
+            lm_head = getattr(self.model, "lm_head", None)
+            if lm_head is None:
+                lm_head = getattr(
+                    getattr(self.model, "language_model", None), "lm_head", None
+                )
+            speculative_config = getattr(self.vllm_config, "speculative_config", None)
+            incompatible = (
+                self.model_config.head_dtype != self.dtype
+                or getattr(self.model_config, "dtype", self.dtype) != self.dtype
+                or self.lora_config is not None
+                or self.vocab_size >= (1 << 24)
+                or envs.VLLM_BATCH_INVARIANT
+                or envs.VLLM_COMPUTE_NANS_IN_LOGITS
+                or getattr(lm_head, "num_added_embeddings", 0) > 0
+                or getattr(
+                    getattr(lm_head, "shard_indices", None), "num_added_elements", 0
+                )
+                > 0
+                or (
+                    speculative_config is not None
+                    and speculative_config.enable_adaptive_verification
+                )
+                or not getattr(lm_head, "_supports_hybrid_nvfp4_lm_head", False)
+            )
+            if incompatible:
+                release_hybrid_nvfp4_lm_heads(self.model)
+                draft_model = getattr(getattr(self, "speculator", None), "model", None)
+                if isinstance(draft_model, nn.Module):
+                    release_hybrid_nvfp4_lm_heads(draft_model)
 
     @instrument(span_name="Loading (GPU)")
     def load_model(self, load_dummy_weights: bool = False) -> None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1381,6 +1381,21 @@ class Worker(WorkerBase):
             self._weight_update_active = False
 
         # Weight transfer bypasses GPUModelRunner.reload_weights().
+        if envs.VLLM_HYBRID_NVFP4_LM_HEAD:
+            from vllm.model_executor.layers.hybrid_nvfp4_lm_head import (
+                refresh_hybrid_nvfp4_lm_heads,
+            )
+
+            updated_model = (
+                self.model_runner.get_draft_model()
+                if self._weight_update_is_draft
+                else self.model_runner.get_model()
+            )
+            if updated_model is not None:
+                refresh_hybrid_nvfp4_lm_heads(
+                    updated_model,
+                    candidates=envs.VLLM_HYBRID_NVFP4_LM_HEAD_CANDIDATES,
+                )
         if not self._weight_update_is_draft:
             self.model_runner.reset_lora_state()
 


### PR DESCRIPTION
 ## Purpose

  This Draft PR adds an opt-in hybrid NVFP4 LM-head sampling path for NVFP4-compatible Qwen
  models on SM120 GPUs.

  The implementation:

  - Uses NVFP4 coarse projection followed by BF16 candidate refinement.
  - Supports greedy, compact top-k, and Qwen MTP speculative sampling paths.
  - Adds compact rejection sampling and reduced TP synchronization.
  - Adds deterministic candidate selection and request-keyed RNG handling.
  - Adds presence-penalty handling and fail-closed fallback for unsupported penalty modes.
  - Adds compatibility gates for LoRA, added vocabulary, adaptive verification, incompatible
    `head_dtype`, `VLLM_BATCH_INVARIANT`, and `VLLM_COMPUTE_NANS_IN_LOGITS`.
  - Refreshes or releases derived NVFP4 state when model weights or runtime configuration change.
  - Adds bounded hybrid warmup and auxiliary-memory limits.
  - Adds unit tests, kernel tests, runner tests, rejection-sampler tests, and custom-op checks.

  The fast path is intentionally approximate: NVFP4 coarse candidate pruning can exclude the
  exact full-vocabulary winner. Unsupported or correctness-sensitive configurations fall back to
  the standard full-logits sampler.

  ## Test Plan

  For end-to-end validation:

  1. Start baseline and hybrid services with identical V2 Model Runner, TP=2, FlashInfer,
     Qwen MTP2, CUDA Graph, and cache settings. The only difference in hybrid enablement is
     `VLLM_HYBRID_NVFP4_LM_HEAD=0/1`. Both services explicitly pass
     `--no-enable-prefix-caching` to prevent cross-scenario KV reuse.

  2. Run fixed-seed random workloads with 3000 input tokens, 1000 output tokens, eight warmup
     requests, and 32 measured requests at BS=1 and BS=16.

  3. Test greedy, top-k (k=20), presence-penalty, and unsupported frequency-penalty requests.

  4. Compare TTFT, TPOT, ITL, and output throughput.

  ## Test Result

  ### Unit and Kernel Validation

  - CPU targeted suite: 56 passed, 8 skipped, 1 deselected.
  - SM120 CUDA targeted suite: 64 passed, 1 deselected.
  - Full CUDA suite including the FP32/NaN regression: 65 passed.
  - Custom-op and CPU sampler fallback regression: 3 passed.
  - Rejection-sampler chunking/layout regression: 7 passed.
  - compileall and git diff --check: passed.
  - Ruff was unavailable in the current environment.
  - Full repository mypy was not completed because the required Pydantic plugin dependency
    was unavailable.

  ### SM120 Service Validation

  - Qwen3.5-27B TP=2/MTP2 loaded and executed hybrid greedy and compact top-k paths.
  - Qwen3.5-35B TP=2/MTP2 loaded and executed hybrid greedy and compact top-k paths.
  - Unsupported frequency-penalty requests correctly used the standard full-logits path.
  - CUDA Graph capture and replay completed without CUDA, NCCL, or illegal-memory-access errors.
  - A short fixed prompt produced identical output and 16-token logprobs between baseline and hybrid.
  - Observed auxiliary hybrid memory was approximately 341 MiB per GPU for the 27B model and
    136 MiB per GPU for the 35B model.

  ### BS=1/16 Throughput, TTFT, and TPOT Comparison

    Values are baseline → hybrid; throughput is output tokens/s, and latency values are
    milliseconds. Percentages show the hybrid change relative to baseline.
  
      Model        Scenario           BS  Throughput (tok/s)           TTFT (ms)                   TPOT (ms)
      ━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━  ━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━
      Qwen3.5-35B  Greedy             1   456.61 → 499.11 (+9.31%)     114.97 → 117.63 (+2.32%)    2.08 → 1.89 (-9.12%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-35B  Greedy             16  3084.87 → 3292.63 (+6.73%)   532.06 → 579.31 (+8.88%)    4.37 → 4.14 (-5.37%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-35B  Top-k=20           1   357.32 → 412.19 (+15.36%)    119.49 → 118.61 (-0.74%)    2.68 → 2.31 (-13.87%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-35B  Top-k=20           16  2139.28 → 2408.09 (+12.57%)  489.63 → 535.15 (+9.30%)    5.77 → 5.16 (-10.56%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-35B  Presence + greedy  1   434.36 → 464.21 (+6.87%)     114.53 → 114.19 (-0.30%)    2.19 → 2.04 (-6.75%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-35B  Presence + greedy  16  2803.78 → 2994.65 (+6.81%)   502.45 → 503.63 (+0.23%)    4.77 → 4.58 (-3.89%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-35B  Presence + top-k   1   345.98 → 360.48 (+4.19%)     114.13 → 118.80 (+4.10%)    2.78 → 2.66 (-4.36%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-35B  Presence + top-k   16  2047.01 → 2102.92 (+2.73%)   483.85 → 492.18 (+1.72%)    6.44 → 5.86 (-9.08%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Greedy             1   169.94 → 188.43 (+10.88%)    352.75 → 355.41 (+0.75%)    5.54 → 4.96 (-10.49%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Greedy             16  1275.61 → 1339.26 (+4.99%)   1824.61 → 1882.39 (+3.17%)  10.20 → 9.49 (-6.98%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Top-k=20           1   159.75 → 180.62 (+13.07%)    352.99 → 360.39 (+2.10%)    5.91 → 5.18 (-12.37%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Top-k=20           16  1094.71 → 1175.60 (+7.39%)   1755.85 → 1798.33 (+2.42%)  10.77 → 10.08 (-6.46%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Presence + greedy  1   167.02 → 181.85 (+8.88%)     352.20 → 353.74 (+0.44%)    5.64 → 5.15 (-8.69%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Presence + greedy  16  1274.59 → 1343.70 (+5.42%)   1775.47 → 1783.08 (+0.43%)  10.18 → 9.80 (-3.76%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Presence + top-k   1   133.61 → 136.20 (+1.94%)     353.41 → 357.66 (+1.20%)    7.14 → 6.99 (-2.05%)
      ───────────  ─────────────────  ──  ───────────────────────────  ──────────────────────────  ──────────────────────
      Qwen3.5-27B  Presence + top-k   16  944.89 → 944.01 (-0.09%)     1671.04 → 1673.89 (+0.17%)  12.12 → 11.60 (-4.27%)

  The 35B model improves throughput in all tested cases, with TPOT reduced in every case.
  The 27B model improves for greedy, top-k, and presence+greedy sampling. Presence+top-k improves by +1.94% at BS=1 and is approximately neutral at BS=16 (-0.09%).

  Each point is from one paired run with identical seed, warmup, CUDA Graph shapes, workload,
  and TP=2 configuration. 

  ## Collaboration and Further Improvements

  This PR is kept as a Draft to invite review, experimentation, and collaboration.
  Suggestions, improvements, additional validation, fixes, documentation updates, and follow-up
  contributions in any area are very welcome. Please feel free to propose or implement changes
  that improve or extend this work.