### PR TITLE
[CI][ROCm] Prefetch safetensors weights in AMD CI

### DIFF
--- a/.buildkite/lm-eval-harness/configs/Meta-Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/.buildkite/lm-eval-harness/configs/Meta-Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -1,7 +1,7 @@
 # For hf script, without -t option (tensor parallel size).
 # bash .buildkite/lm-eval-harness/run-lm-eval-mmlupro-vllm-baseline.sh -m meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 -l 250 -t 8 -f 5
 model_name: "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
-rocm_safetensors_load_strategy: lazy
+rocm_safetensors_load_strategy: prefetch
 required_gpu_arch:
   - gfx942
   - gfx950

--- a/tests/weight_loading/models-amd.txt
+++ b/tests/weight_loading/models-amd.txt
@@ -1,6 +1,7 @@
+# quantization, model, revision[, minimum capability[, safetensors load strategy]]
 fp8, amd/Meta-Llama-3.1-8B-Instruct-FP8-KV, main
 None, amd/Llama-3.2-1B-Instruct-FP8-KV, main
-fp8, amd/Mixtral-8x7B-Instruct-v0.1-FP8-KV, main
+fp8, amd/Mixtral-8x7B-Instruct-v0.1-FP8-KV, main, 80, prefetch
 gptq, robertgshaw2/zephyr-7b-beta-channelwise-gptq, main
 gptq, TheBloke/Llama-2-7B-GPTQ, main
 gptq, TheBloke/TinyLlama-1.1B-Chat-v1.0-GPTQ, gptq-8bit--1g-actorder_True

--- a/tests/weight_loading/models-large-amd.txt
+++ b/tests/weight_loading/models-large-amd.txt
@@ -1,3 +1,4 @@
-fp8, amd/Meta-Llama-3.1-70B-Instruct-FP8-KV, main
-None, microsoft/phi-4, main
-fp8, amd/Mixtral-8x22B-Instruct-v0.1-FP8-KV, main
+# quantization, model, revision[, minimum capability[, safetensors load strategy]]
+fp8, amd/Meta-Llama-3.1-70B-Instruct-FP8-KV, main, 80, prefetch
+None, microsoft/phi-4, main, 80, prefetch
+fp8, amd/Mixtral-8x22B-Instruct-v0.1-FP8-KV, main, 80, prefetch

--- a/tests/weight_loading/run_model_weight_loading_test.sh
+++ b/tests/weight_loading/run_model_weight_loading_test.sh
@@ -28,12 +28,16 @@ do
 
     echo "=== RUNNING MODEL: $MODEL_CONFIG ==="
 
+    unset WEIGHT_LOADING_TEST_SAFETENSORS_LOAD_STRATEGY
     export QUANTIZATION=${array[0]}
     export MODEL_NAME=${array[1]}
     export REVISION=${array[2]}
     # If array length is larger than 3, then MIN_CAPABILITY is provided
     if [ ${#array[@]} -gt 3 ]; then
         export MIN_CAPABILITY=${array[3]}
+    fi
+    if [ ${#array[@]} -gt 4 ]; then
+        export WEIGHT_LOADING_TEST_SAFETENSORS_LOAD_STRATEGY=${array[4]}
     fi
     pytest -s weight_loading/test_weight_loading.py || LOCAL_SUCCESS=$?
 

--- a/tests/weight_loading/test_weight_loading.py
+++ b/tests/weight_loading/test_weight_loading.py
@@ -16,6 +16,9 @@ MODEL_NAME = os.environ.get(
 REVISION = os.environ.get("REVISION", "main")
 QUANTIZATION = os.environ.get("QUANTIZATION", "gptq_marlin")
 MIN_CAPABILITY = os.environ.get("MIN_CAPABILITY", "80")
+SAFETENSORS_LOAD_STRATEGY = os.environ.get(
+    "WEIGHT_LOADING_TEST_SAFETENSORS_LOAD_STRATEGY"
+)
 
 
 @pytest.mark.skipif(
@@ -42,6 +45,7 @@ def test_weight_loading(vllm_runner):
         quantization=None if QUANTIZATION == "None" else QUANTIZATION,
         max_model_len=MAX_MODEL_LEN,
         tensor_parallel_size=2,
+        safetensors_load_strategy=SAFETENSORS_LOAD_STRATEGY,
         # Generating 20 tokens needs a tiny KV cache, while sizing and
         # allocating a full-size one dominates this test on large devices.
         kv_cache_memory_bytes=2 * GiB_bytes,


### PR DESCRIPTION
- Use vLLM's existing safetensors prefetch strategy for the 8-GPU ROCm Llama 4 Maverick evaluation instead of forcing lazy loading.
- Add an optional safetensors loading strategy to the AMD weight-loading model lists and pass it through the existing test runner.
- Enable prefetching for the slow multishard Mixtral case and the AMD large-model weight-loading group.

AMD CI loads these large checkpoints from shared storage, where lazy mmap access can turn weight loading into many slow reads. vLLM already has a prefetch strategy that reads shards concurrently into the page cache, so this change opts in only the affected AMD jobs and leaves common model lists unchanged.

Local benchmark: DeepSeek-V4-Flash-DSpark, 155.43 GiB across 48 shards, TP4/EP4 on 4 x gfx950 GPUs with a cold page cache.

| Measurement | `lazy` before | `prefetch` after | Improvement |
| --- | ---: | ---: | ---: |
| Checkpoint loading | 73.71 s | 26.17 s | 2.82x faster |
| End-to-end cold startup | 135.57 s | 76.62 s | 1.77x faster |

AI assistance was used for research, implementation, benchmarking, testing, and PR drafting. The submitter reviewed the resulting changes and benchmark results.
