### PR TITLE
[ROCm][MLA][DCP] Pad the AITER MLA decode head count to a native tile

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1558,12 +1558,14 @@ steps:
   - tests/kernels/attention/test_rocm_aiter_mla_decode.py
   - tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
   - tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
+  - tests/kernels/attention/test_rocm_aiter_mla_head_padding.py
   - tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
   commands:
   - rocm-smi
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
+  - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_head_padding.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
 
 - label: ":amd: (MI300) Attention Kernels Shard %N" # TBD
@@ -3534,12 +3536,14 @@ steps:
   - tests/kernels/attention/test_rocm_aiter_mla_decode.py
   - tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
   - tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
+  - tests/kernels/attention/test_rocm_aiter_mla_head_padding.py
   - tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
   commands:
   - rocm-smi
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
+  - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_head_padding.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
 
 - label: ":amd: (MI355) Attention Kernels Shard %N" # TBD

--- a/tests/kernels/attention/test_rocm_aiter_mla_head_padding.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_head_padding.py
@@ -355,3 +355,391 @@ def test_h12_aiter_mla_decode_matches_reference():
         atol=1e-2,
         rtol=1e-2,
     )
+
+
+# ---------------------------------------------------------------------------
+# Native-shape padding (VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE).
+#
+# AITER's ``natively_supported`` is a disjunction over
+# (arch, q fp8?, kv fp8?, num_heads, max_seqlen_qo), and a native verdict from
+# the metadata planner still has to be backed by a shipped asm kernel, so these
+# tests drive the real probes with verbatim copies of what AITER v0.1.21.post1
+# ships. That keeps them runnable off ROCm and makes them fail if the literal
+# matching in _aiter_mla_shape_is_native drifts.
+# ---------------------------------------------------------------------------
+
+# csrc/kernels/mla/metadata/v1_2_device.cuh, the ``natively_supported``
+# initializer only -- the AITER_CHECK allowlist below it in the real file is
+# deliberately excluded, since matching against it is the mistake the probe's
+# slicing exists to prevent.
+_AITER_0_1_21_PREDICATE = """
+    const bool natively_supported =
+        (num_heads == 16) ||
+        ((arch_id == "gfx942" || arch_id == "gfx950") && (num_heads == 64) &&
+         q_is_fp8 && kv_is_fp8 && (max_seqlen_qo == 1)) ||
+        ((arch_id == "gfx950") && !q_is_fp8 && !kv_is_fp8) ||
+        ((arch_id == "gfx942") && (num_heads == 128) && q_is_fp8 && kv_is_fp8) ||
+        ((arch_id == "gfx950") && q_is_fp8 && kv_is_fp8 &&
+         ((num_heads == 32) || (num_heads == 64) || (num_heads == 128))) ||
+        ((arch_id == "gfx950") && q_is_fp8 && kv_is_fp8 && (num_heads == 96) &&
+         (max_seqlen_qo <= 6)) ||
+        hk_mtp_experimental
+"""
+
+# csrc/kernels/mla/reduce.cu MLA_REDUCE_ROUTER, HEAD_DIM 512 instantiations.
+_AITER_REDUCER_HEADS = frozenset({8, 16, 24, 32, 48, 64, 80, 96, 112, 128})
+
+# hsa/gfx942/mla/mla_asm.csv, the fp8/fp8 decode rows, as
+# (qType, kvType, Gqa, ps, qSeqLen, lse). Note gqa=128 ships at lse=0 only
+# while gqa=64 ships both -- that asymmetry is the whole point of the probe.
+_AITER_GFX942_KERNELS = frozenset(
+    ("fp8", "fp8", *row)
+    for row in (
+        (16, 1, 1, 0),
+        (16, 1, 2, 0),
+        (16, 1, 4, 0),
+        (16, 0, 1, 0),
+        (16, 0, 2, 0),
+        (16, 0, 4, 0),
+        (64, 1, 1, 0),
+        (64, 1, 1, 1),
+        (128, 1, 0, 0),
+        (128, 0, 0, 0),
+        (8, 0, 1, 0),
+        (1, 1, 0, 0),
+    )
+)
+
+
+@pytest.fixture
+def aiter_0_1_21(monkeypatch):
+    """Point the native-shape probes at a known AITER revision."""
+    stripped = "".join(_AITER_0_1_21_PREDICATE.split())
+    monkeypatch.setattr(
+        rocm_aiter_mla, "_aiter_mla_native_predicate_source", lambda: stripped
+    )
+    monkeypatch.setattr(
+        rocm_aiter_mla, "_aiter_mla_reducer_head_counts", lambda: _AITER_REDUCER_HEADS
+    )
+    monkeypatch.setattr(
+        rocm_aiter_mla,
+        "_aiter_mla_asm_decode_kernels",
+        lambda arch: _AITER_GFX942_KERNELS if arch == "gfx942" else frozenset(),
+    )
+
+
+def _resolve(
+    num_heads, *, gfx942=False, gfx950=True, q_fp8, kv_fp8, max_qo_lens, needs_lse=False
+):
+    return AiterMLAHelper.resolve_padded_mla_num_heads(
+        num_heads,
+        gfx942=gfx942,
+        gfx950=gfx950,
+        q_fp8=q_fp8,
+        kv_fp8=kv_fp8,
+        max_qo_lens=max_qo_lens,
+        needs_lse=needs_lse,
+    )
+
+
+def test_head_padding_env_default_is_off(monkeypatch):
+    monkeypatch.delenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", raising=False)
+    import vllm.envs as envs
+
+    assert envs.VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE == "off"
+
+
+@pytest.mark.parametrize("num_heads", list(range(1, 257)))
+def test_off_is_bit_identical_to_the_unpadded_rule(monkeypatch, num_heads):
+    """The default must not move a single head count.
+
+    This is the whole safety argument for the knob, so assert it over the
+    entire reachable range rather than at a handful of sample points. H24 is
+    disabled by the autouse fixture, so the expected rule is a plain ceil.
+    """
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "off")
+    expected = -(-num_heads // 16) * 16
+    assert AiterMLAHelper.get_actual_mla_num_heads(num_heads) == expected
+    for gfx942, gfx950 in ((True, False), (False, True), (False, False)):
+        for fp8 in (True, False):
+            assert (
+                _resolve(
+                    num_heads,
+                    gfx942=gfx942,
+                    gfx950=gfx950,
+                    q_fp8=fp8,
+                    kv_fp8=fp8,
+                    max_qo_lens=(1, 2),
+                )
+                == expected
+            )
+
+
+# (gfx942, gfx950, q_fp8, kv_fp8, max_qo_lens, needs_lse, num_heads, expected)
+#
+# The interesting rows, per slice:
+#   gfx950 fp8 qo=1   -- 48 -> 64 is the one reachable win (Kimi-K3 TP8+DCP4);
+#                        96 stays put, AITER v0.1.21 having made it native, and
+#                        padding it to 128 measured a 6.7% regression;
+#                        80 -> 96 rather than 128, 96 being both native and
+#                        cheaper (231.7 us vs 247.2 us measured).
+#   gfx950 fp8 qo<=8  -- 96 loses its qo <= 6 clause at some reachable qlen, so
+#                        the run-level constant has to clear it: 80 and 96 go
+#                        to 128.
+#   gfx950 bf16       -- the blanket bf16 clause makes everything native, so
+#                        every row is the identity. This is the default
+#                        --kv-cache-dtype auto configuration; a pad here would
+#                        be pure loss.
+#   gfx942 fp8 qo=1   -- 32 -> 64 (the fold a fixed {16,32,64,128} tile table
+#                        misses, 32 not being native on gfx942).
+#   gfx942 fp8 + LSE  -- a DCP rank. gqa=128 ships lse=0 only, so 80/96/112 may
+#                        not pad at all; gqa=64 ships both, so 32/48 still can.
+#   gfx942 fp8 qo<=4  -- 64 loses its qo == 1 clause, so 48 must NOT go to 64
+#                        (that would swap a 3x fold for a 4x one) and 32's only
+#                        target is 128, declined by the 2x cost cap.
+#   gfx942 bf16       -- only 16 is native; padding could only raise the fold
+#                        factor, so everything is the identity.
+#   neither arch      -- no clause may fire on an arch AITER does not name.
+NATIVE_PAD_CASES = [
+    (False, True, True, True, (1,), False, 16, 16),
+    (False, True, True, True, (1,), False, 32, 32),
+    (False, True, True, True, (1,), False, 48, 64),
+    (False, True, True, True, (1,), False, 64, 64),
+    (False, True, True, True, (1,), False, 80, 96),
+    (False, True, True, True, (1,), False, 96, 96),
+    (False, True, True, True, (1,), False, 112, 128),
+    (False, True, True, True, (1,), False, 120, 128),
+    (False, True, True, True, (1,), False, 128, 128),
+    (False, True, True, True, (1,), False, 144, 144),
+    (False, True, True, True, (1,), False, 256, 256),
+    (False, True, True, True, (1,), True, 48, 64),
+    (False, True, True, True, range(1, 5), True, 48, 64),
+    (False, True, True, True, range(1, 5), True, 96, 96),
+    (False, True, True, True, range(1, 9), True, 80, 128),
+    (False, True, True, True, range(1, 9), True, 96, 128),
+    (False, True, True, True, range(1, 9), True, 128, 128),
+    (False, True, False, False, (1,), False, 48, 48),
+    (False, True, False, False, (1,), False, 80, 80),
+    (False, True, False, False, (1,), False, 96, 96),
+    (False, True, False, False, (1,), False, 112, 112),
+    (False, True, False, False, range(1, 5), False, 48, 48),
+    (False, True, True, False, (1,), False, 48, 48),
+    (True, False, True, True, (1,), False, 16, 16),
+    (True, False, True, True, (1,), False, 32, 64),
+    (True, False, True, True, (1,), False, 48, 64),
+    (True, False, True, True, (1,), False, 64, 64),
+    (True, False, True, True, (1,), False, 80, 128),
+    (True, False, True, True, (1,), False, 96, 128),
+    (True, False, True, True, (1,), False, 112, 128),
+    (True, False, True, True, (1,), False, 128, 128),
+    (True, False, True, True, (1,), True, 32, 64),
+    (True, False, True, True, (1,), True, 48, 64),
+    (True, False, True, True, (1,), True, 80, 80),
+    (True, False, True, True, (1,), True, 96, 96),
+    (True, False, True, True, (1,), True, 112, 112),
+    (True, False, True, True, range(1, 5), False, 32, 32),
+    (True, False, True, True, range(1, 5), False, 48, 48),
+    (True, False, True, True, range(1, 5), False, 64, 128),
+    (True, False, True, True, range(1, 5), False, 128, 128),
+    (True, False, False, False, (1,), False, 48, 48),
+    (True, False, False, False, (1,), False, 80, 80),
+    (True, False, False, False, (1,), False, 96, 96),
+    (True, False, False, False, (1,), False, 112, 112),
+    (False, False, True, True, (1,), False, 32, 32),
+    (False, False, True, True, (1,), False, 48, 48),
+    (False, False, True, True, (1,), False, 96, 96),
+]
+
+
+@pytest.mark.parametrize(
+    "gfx942,gfx950,q_fp8,kv_fp8,max_qo_lens,needs_lse,num_heads,expected",
+    NATIVE_PAD_CASES,
+)
+def test_auto_pads_to_a_natively_supported_shape(
+    monkeypatch,
+    aiter_0_1_21,
+    gfx942,
+    gfx950,
+    q_fp8,
+    kv_fp8,
+    max_qo_lens,
+    needs_lse,
+    num_heads,
+    expected,
+):
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "auto")
+    assert (
+        _resolve(
+            num_heads,
+            gfx942=gfx942,
+            gfx950=gfx950,
+            q_fp8=q_fp8,
+            kv_fp8=kv_fp8,
+            max_qo_lens=max_qo_lens,
+            needs_lse=needs_lse,
+        )
+        == expected
+    )
+
+
+def test_auto_never_pads_96_on_a_native_96_aiter(monkeypatch, aiter_0_1_21):
+    """Regression guard for the AITER 0.1.19 -> 0.1.21 flip.
+
+    A static tile table padded 96 -> 128 here, which was a 6x win on 0.1.19 and
+    is a measured 6.7% loss on 0.1.21. Nothing but the probe stops that from
+    silently coming back on the next bump.
+    """
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "auto")
+    assert _resolve(96, q_fp8=True, kv_fp8=True, max_qo_lens=(1,)) == 96
+
+
+def test_auto_declines_a_target_without_an_lse_kernel(monkeypatch, aiter_0_1_21):
+    """gfx942 ships gqa=128 at lse=0 only, so a DCP rank cannot land there.
+
+    The metadata planner calls 128 native on gfx942 regardless, so a mirror
+    that stopped at the planner would pad here and take out the first decode
+    with "cannot find suitable kernel". gqa=64 ships both flags, so the same
+    rank may still pad 48 -> 64.
+    """
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "auto")
+    kw = dict(gfx942=True, gfx950=False, q_fp8=True, kv_fp8=True, max_qo_lens=(1,))
+    assert _resolve(112, needs_lse=False, **kw) == 128
+    assert _resolve(112, needs_lse=True, **kw) == 112
+    assert _resolve(48, needs_lse=True, **kw) == 64
+
+
+def test_auto_requires_every_reachable_qlen_to_be_native(monkeypatch, aiter_0_1_21):
+    """One run-level constant must not fold harder at some reachable qlen.
+
+    AITER's fold factor is num_heads/16 with no qlen term, so a target that is
+    native only at qlen 1 multiplies the KV traffic of every verify pass. On
+    gfx942 with fp8, 64 heads is native at qlen 1 alone: padding 32 -> 64 wins
+    a decode-only run and loses an MTP run.
+    """
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "auto")
+    kw = dict(gfx942=True, gfx950=False, q_fp8=True, kv_fp8=True)
+    assert _resolve(32, max_qo_lens=(1,), **kw) == 64
+    assert _resolve(32, max_qo_lens=(1, 2), **kw) == 32
+
+
+def test_force_ignores_the_cost_cap(monkeypatch, aiter_0_1_21):
+    # gfx942 + fp8 + 32 heads over qlens 1..4: the only target native at every
+    # one of them is 128, a 4x head inflation against a 2x fold. "auto"
+    # declines it; "force" takes it.
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "auto")
+    kw = dict(gfx942=True, gfx950=False, q_fp8=True, kv_fp8=True, max_qo_lens=(1, 4))
+    assert _resolve(32, **kw) == 32
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "force")
+    assert _resolve(32, **kw) == 128
+
+
+@pytest.mark.parametrize("mode", ["off", "auto", "force"])
+@pytest.mark.parametrize("num_heads", list(range(1, 257)))
+def test_resolved_count_is_always_a_legal_launch_shape(
+    monkeypatch, aiter_0_1_21, mode, num_heads
+):
+    """Never below the real count, always 16-aligned, never above AITER's cap.
+
+    The 16-alignment is a correctness guard rather than an optimization: AITER
+    folds only multiples of 16 and asserts on anything else, so no policy may
+    return an unaligned value. (Native H24 is the one sanctioned exception and
+    the autouse fixture disables it here.) Padding may only grow the count,
+    since the extra lanes are sliced back off the output.
+    """
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", mode)
+    unpadded = -(-num_heads // 16) * 16
+    for gfx942, gfx950 in ((True, False), (False, True), (False, False)):
+        for fp8 in (True, False):
+            m = _resolve(
+                num_heads,
+                gfx942=gfx942,
+                gfx950=gfx950,
+                q_fp8=fp8,
+                kv_fp8=fp8,
+                max_qo_lens=(1, 4),
+            )
+            assert m >= unpadded
+            assert m % 16 == 0
+            assert m <= max(unpadded, AiterMLAHelper._AITER_MAX_PADDED_MLA_HEADS)
+
+
+@pytest.mark.parametrize("num_heads", [48, 80, 112])
+def test_pad_unpad_round_trip_at_the_resolved_count(
+    monkeypatch, aiter_0_1_21, num_heads
+):
+    """Padding to a native shape is exactly reversible for both o and lse."""
+    monkeypatch.setenv("VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE", "auto")
+    padded_heads = _resolve(num_heads, q_fp8=True, kv_fp8=True, max_qo_lens=(1,))
+    assert padded_heads > num_heads
+
+    tokens = 5
+    q = torch.randn(tokens, num_heads, QK_HEAD_DIM)
+    q_padded = AiterMLAHelper.get_mla_padded_q(num_heads, q, padded_heads)
+    assert q_padded.shape == (tokens, padded_heads, QK_HEAD_DIM)
+    torch.testing.assert_close(q_padded[:, :num_heads, :], q)
+
+    o = torch.randn(tokens, padded_heads, KV_LORA_RANK)
+    torch.testing.assert_close(
+        AiterMLAHelper.get_mla_unpadded_o(num_heads, o, padded_heads),
+        o[:, :num_heads, :],
+    )
+
+    lse = torch.randn(tokens, padded_heads)
+    torch.testing.assert_close(
+        AiterMLAHelper.get_mla_unpadded_lse(num_heads, lse, padded_heads),
+        lse[:, :num_heads],
+    )
+
+
+def test_unpad_uses_the_target_it_is_given():
+    """A resolved count threaded to one side only silently returns junk.
+
+    Pad and unpad each branch on ``m % num_heads == 0`` independently, so this
+    documents why the impl carries ``padded_num_heads`` on the metadata instead
+    of recomputing it.
+    """
+    tokens, num_heads = 3, 32
+    padded_heads = 64  # divides 32, so unpad takes a stride-2 slice
+    o = torch.arange(tokens * padded_heads * 4, dtype=torch.float32).reshape(
+        tokens, padded_heads, 4
+    )
+    torch.testing.assert_close(
+        AiterMLAHelper.get_mla_unpadded_o(num_heads, o, padded_heads), o[:, ::2, :]
+    )
+    # Without the target the helper falls back to the unpadded rule (32 == 32)
+    # and hands back the padded tensor whole.
+    assert AiterMLAHelper.get_mla_unpadded_o(num_heads, o).shape[1] == padded_heads
+
+
+@pytest.mark.skipif(
+    not (current_platform.is_rocm() and is_aiter_found()),
+    reason="reads the installed AITER JIT sources",
+)
+def test_probe_matches_the_installed_aiter():
+    """Fail when AITER moves under the mirror, rather than going quietly inert.
+
+    Every clause is admitted by a literal match, so a re-spaced or reworded
+    predicate makes them all fall through, the resolver returns the unpadded
+    count, and the feature becomes a silent no-op for someone who opted in.
+    Assert the literals themselves, not just the outcome.
+    """
+    src = rocm_aiter_mla._aiter_mla_native_predicate_source()
+    assert src.startswith(rocm_aiter_mla._AITER_NATIVE_BLOCK_START)
+    # The AITER_CHECK allowlist sits immediately below the initializer and
+    # repeats most of its text; the slice must stop before it.
+    assert "AITER_CHECK" not in src
+    for literal in (
+        '(arch_id=="gfx950")&&!q_is_fp8&&!kv_is_fp8',
+        "((num_heads==32)||(num_heads==64)||(num_heads==128))",
+        "(num_heads==96)&&(max_seqlen_qo<=6)",
+        '(arch_id=="gfx942")&&(num_heads==128)',
+        '(arch_id=="gfx942"||arch_id=="gfx950")&&(num_heads==64)&&q_is_fp8',
+    ):
+        assert literal in src, f"AITER predicate no longer contains {literal!r}"
+    assert rocm_aiter_mla._aiter_mla_reducer_head_counts() == _AITER_REDUCER_HEADS
+    from vllm.platforms.rocm import on_gfx942
+
+    if on_gfx942():
+        installed = rocm_aiter_mla._aiter_mla_asm_decode_kernels("gfx942")
+        assert ("fp8", "fp8", 64, 1, 1, 1) in installed
+        assert ("fp8", "fp8", 128, 1, 0, 1) not in installed

--- a/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
@@ -305,6 +305,7 @@ def test_single_token_dcp_decode_returns_unpadded_lse(monkeypatch):
         dcp_verify=None,
         has_persistent_metadata=False,
         attn_out_dtype=torch.bfloat16,
+        padded_num_heads=None,
     )
     attn_metadata = SimpleNamespace(decode=decode, causal=True, work_meta_data=None)
     layer = SimpleNamespace(_q_scale=torch.tensor(1.0), _k_scale=torch.tensor(1.0))
@@ -317,6 +318,20 @@ def test_single_token_dcp_decode_returns_unpadded_lse(monkeypatch):
     # gathered count the cross-rank merge expects.
     assert captured["q_heads"] == 16
     assert lse is not None
+    assert output.shape[1] == decode_heads
+    assert lse.shape == (num_tokens, decode_heads)
+
+    # The builder resolves the launch head count once and carries it on the
+    # metadata; the impl must launch at that count rather than recompute one.
+    # 48 would otherwise pass straight through (already 16-aligned), so a
+    # dropped padded_num_heads shows up here as 48 instead of 96.
+    num_heads, decode_heads = 24, 48
+    decode.padded_num_heads = 96
+    q = torch.zeros(num_tokens, decode_heads, head_dim, dtype=torch.bfloat16)
+    impl.num_heads = num_heads
+    output, lse = impl.forward_mqa(q, torch.zeros(1, 1, head_dim), attn_metadata, layer)
+
+    assert captured["q_heads"] == 96
     assert output.shape[1] == decode_heads
     assert lse.shape == (num_tokens, decode_heads)
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -142,6 +142,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_AITER_MLA_ASM_PADDING: Literal["auto", "gluon", "asm"] = "auto"
+    VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE: Literal["auto", "off", "force"] = "off"
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
     VLLM_ROCM_USE_AITER_FP8BMM: bool = True
@@ -1318,6 +1319,21 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_ROCM_AITER_MLA_ASM_PADDING",
         "auto",
         ["auto", "gluon", "asm"],
+        case_sensitive=False,
+    ),
+    # Pad the AITER MLA decode head count up to a shape AITER supports
+    # natively, instead of only to the next multiple of 16. AITER folds a
+    # non-native count down to 16 heads and every sub-pass of that fold
+    # re-reads the whole KV cache, so landing on a native shape can remove a
+    # multiple of the decode's memory traffic.
+    # "off" (default) keeps the next-multiple-of-16 behavior; "auto" pads only
+    # when the installed AITER reports the target native for this arch, KV
+    # dtype and query length, and the pad stays within
+    # AiterMLAHelper._AITER_MAX_PAD_RATIO; "force" ignores that cost cap.
+    "VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE": env_with_choices(
+        "VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE",
+        "off",
+        ["auto", "off", "force"],
         case_sensitive=False,
     ),
     # Whether to use aiter mha ops.

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import functools
+from collections.abc import Collection
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, Final
@@ -140,6 +141,242 @@ def _aiter_mla_native_h24_supported() -> bool:
     return (
         _aiter_mla_native_h24_reducer_supported()
         and _aiter_mla_native_h24_metadata_supported()
+    )
+
+
+# ---------------------------------------------------------------------------
+# AITER native-shape mirror.
+#
+# AITER's MLA metadata planner folds a head count it does not natively support
+# down to 16 heads with ``qk_batch_ratio = num_heads / 16``, multiplying
+# num_batches by the same factor. Every sub-pass of that fold re-reads the
+# whole KV -- the batch index is divided by qk_batch_ratio and the KV cursor
+# only advances on sub-head 0 -- so a folded decode costs ``num_heads / 16``
+# passes over the cache. MLA decode is KV-bandwidth bound, which is why paying
+# a few zero query heads to land on a native shape is usually a large win.
+#
+# Whether a count is native is NOT a property of the count. It is a disjunction
+# over ``(arch_id, q_is_fp8, kv_is_fp8, num_heads, max_seqlen_qo)``
+# (``csrc/kernels/mla/metadata/v1_2_device.cuh``), and it has changed in every
+# AITER release vLLM has shipped -- v0.1.21 added ``gfx950 && fp8 && 96 heads
+# && max_seqlen_qo <= 6`` (ROCm/aiter#4964), which turned what used to be a 6x
+# fold into a native shape. A static tile table in vLLM is therefore correct
+# for at most one AITER revision, and going stale is *silent*: the AITER_CHECK
+# below the fold runs after the fold has already rewritten ``num_heads = 16``,
+# so it accepts every 16-aligned count and a wrong pad target costs throughput
+# with no error anywhere.
+#
+# So: probe the shipped JIT source for the distinguishing literal of each
+# clause -- the same idiom as ``_aiter_mla_native_h24_metadata_supported``
+# above -- and then evaluate the admitted clauses in Python against the live
+# arch, dtypes and query length.
+#
+# Every grep is scoped to the ``natively_supported`` initializer. The
+# AITER_CHECK allowlist immediately below it contains near-identical text, so
+# matching against the whole file reports clauses that are only in the check
+# and were never in the predicate.
+# ---------------------------------------------------------------------------
+
+_AITER_NATIVE_BLOCK_START: Final = "constboolnatively_supported="
+
+
+@functools.lru_cache(maxsize=1)
+def _aiter_mla_native_predicate_source() -> str:
+    """Whitespace-stripped text of AITER's ``natively_supported`` initializer.
+
+    Empty when the shipped source cannot be read. Callers then admit no
+    optional clause, which degrades to "nothing is native", which in turn
+    means no padding and the historical next-multiple-of-16 behavior. That is
+    always legal: any 16-aligned count folds cleanly.
+    """
+    try:
+        from aiter.jit.core import AITER_CSRC_DIR
+
+        path = Path(AITER_CSRC_DIR) / "kernels" / "mla" / "metadata" / "v1_2_device.cuh"
+        source = "".join(path.read_text(encoding="utf-8").split())
+    except (ImportError, OSError):
+        return ""
+    start = source.find(_AITER_NATIVE_BLOCK_START)
+    if start < 0:
+        return ""
+    end = source.find(";", start)
+    return source[start : end if end > start else len(source)]
+
+
+@functools.lru_cache(maxsize=1)
+def _aiter_mla_reducer_head_counts() -> frozenset[int]:
+    """Head counts AITER's MLA reducer instantiates at ``HEAD_DIM`` 512.
+
+    The reducer and the metadata planner dispatch independently -- the same
+    split that forced the two-probe H24 check above. It matters here because
+    the planner's blanket ``gfx950 && bf16`` clause claims *any* head count is
+    native while ``reduce.cu``'s router has no case above 128, so a pad target
+    has to satisfy both.
+    """
+    try:
+        from aiter.jit.core import AITER_CSRC_DIR
+
+        path = Path(AITER_CSRC_DIR) / "kernels" / "mla" / "reduce.cu"
+        source = "".join(path.read_text(encoding="utf-8").split())
+    except (ImportError, OSError):
+        return frozenset()
+    return frozenset(
+        n
+        for n in (8, 16, 24, 32, 48, 64, 80, 96, 112, 128)
+        if f"MLA_REDUCE_CASE_EF(NUM_HEAD,{n},HEAD_DIM,512," in source
+    )
+
+
+@functools.lru_cache(maxsize=4)
+def _aiter_mla_asm_decode_kernels(
+    arch: str,
+) -> frozenset[tuple[str, str, int, int, int, int]]:
+    """``(q dtype, kv dtype, gqa, ps, qseqlen, lse)`` of every shipped asm kernel.
+
+    A native verdict from the metadata planner does not imply
+    ``mla_decode_fwd`` can dispatch: ``asm_mla.cu`` looks the shape up in this
+    table and filters on the LSE flag exactly, so a missing row is ``cannot
+    find suitable kernel`` at the first decode. The table is per-arch and moves
+    between AITER revisions independently of the planner predicate --
+    v0.1.21.post1 ships gfx942 fp8 gqa=64 rows that AITER main has since
+    dropped -- so read it rather than assume it.
+
+    Empty when the table cannot be read, which makes every clause that consults
+    it decline.
+    """
+    try:
+        from aiter.jit.core import AITER_ASM_DIR
+
+        path = Path(AITER_ASM_DIR) / arch / "mla" / "mla_asm.csv"
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (ImportError, OSError):
+        return frozenset()
+    if not lines:
+        return frozenset()
+    # The column count differs by arch (gfx950 carries an extra cprr flag), so
+    # index by header name rather than by position.
+    header = [c.strip() for c in lines[0].split(",")]
+    try:
+        cols = [
+            header.index(c) for c in ("qType", "kvType", "Gqa", "ps", "qSeqLen", "lse")
+        ]
+    except ValueError:
+        return frozenset()
+    rows = set()
+    for line in lines[1:]:
+        fields = [f.strip() for f in line.split(",")]
+        if len(fields) <= max(cols):
+            continue
+        try:
+            ints = tuple(int(fields[c]) for c in cols[2:])
+        except ValueError:
+            continue
+        rows.add((fields[cols[0]], fields[cols[1]], *ints))
+    return frozenset(rows)
+
+
+def _aiter_mla_shape_is_native(
+    num_heads: int,
+    *,
+    gfx942: bool,
+    gfx950: bool,
+    q_fp8: bool,
+    kv_fp8: bool,
+    max_qo_len: int,
+    needs_lse: bool,
+) -> bool:
+    """Mirror of AITER's ``natively_supported`` for the *installed* AITER.
+
+    Each clause is admitted only when its literal is present in the shipped
+    predicate, so a clause AITER drops stops being claimed here with no vLLM
+    change, and a clause AITER adds is picked up the same way. A clause that
+    cannot be found degrades to "not native", i.e. keep the fold -- the safe
+    direction, since padding a shape AITER did not actually make native is
+    exactly what turns this feature into a regression.
+    """
+    src = _aiter_mla_native_predicate_source()
+    if not src:
+        return False
+    if num_heads not in _aiter_mla_reducer_head_counts():
+        return False
+
+    def has_asm_kernel(gqa: int, qseqlen: int) -> bool:
+        """Whether gfx942 ships an asm kernel for this exact shape.
+
+        Only asked on gfx942. All four config remaps in ``asm_mla.cu`` are
+        guarded on ``arch_id == "gfx950"``, so on gfx942 the requested gqa and
+        the ``config_gqa_ratio`` it is looked up under are the same number and
+        the table can be consulted directly. On gfx950 the remap folds every
+        persistent fp8 decode onto gqa 16 or 32, both of which ship LSE
+        variants, so there is nothing left to check.
+        """
+        return ("fp8", "fp8", gqa, 1, qseqlen, int(needs_lse)) in (
+            _aiter_mla_asm_decode_kernels("gfx942")
+        )
+
+    # (a) 16 heads: unconditional on every arch, dtype and qlen, in every
+    #     AITER this code has seen. It is the fold target, so it has to be.
+    if num_heads == 16:
+        return True
+
+    # (b) gfx950 with bf16 q AND bf16 kv: any head count, no qlen term. This
+    #     is the default --kv-cache-dtype auto configuration on MI355X, and it
+    #     means there is no fold to remove there and padding is pure cost.
+    if (
+        gfx950
+        and not q_fp8
+        and not kv_fp8
+        and '(arch_id=="gfx950")&&!q_is_fp8&&!kv_is_fp8' in src
+    ):
+        return True
+
+    if not (q_fp8 and kv_fp8):
+        # Every remaining clause requires both q and kv fp8. A mixed
+        # fp8-q/bf16-kv configuration matches nothing and always folds.
+        return False
+
+    # (c) gfx950 + fp8: 32/64/128 with no qlen constraint.
+    if (
+        gfx950
+        and num_heads in (32, 64, 128)
+        and "((num_heads==32)||(num_heads==64)||(num_heads==128))" in src
+    ):
+        return True
+
+    # (d) gfx950 + fp8 + 96 heads, gated on qlen <= 6 (ROCm/aiter#4964,
+    #     v0.1.21+). This is the clause that makes padding 96 -> 128 a
+    #     regression on a current AITER and a large win on an older one.
+    if (
+        gfx950
+        and num_heads == 96
+        and max_qo_len <= 6
+        and "(num_heads==96)&&(max_seqlen_qo<=6)" in src
+    ):
+        return True
+
+    # (e) gfx942 + fp8 + 128 heads. The predicate carries no qlen constraint,
+    #     but gfx942 ships gqa=128 only at lse=0, so a DCP rank -- which needs
+    #     the LSE for the cross-shard merge -- has no kernel to land on.
+    if (
+        gfx942
+        and num_heads == 128
+        and '(arch_id=="gfx942")&&(num_heads==128)' in src
+        # gqa 128 sets config_max_seqlen_q = 0 unconditionally (asm_mla.cu).
+        and has_asm_kernel(128, 0)
+    ):
+        return True
+
+    # (f) 64 heads + fp8 on either arch, qlen == 1 only. Redundant with (c) on
+    #     gfx950; on gfx942 it is the only route to a native 64, and only while
+    #     the gqa=64 rows are shipped -- AITER main has already dropped them.
+    #     The arch guard is matched too: a future AITER that narrows this
+    #     clause to one arch would otherwise keep matching a bare head-count
+    #     fragment and hand back a false positive on the other.
+    return (
+        num_heads == 64
+        and max_qo_len == 1
+        and '(arch_id=="gfx942"||arch_id=="gfx950")&&(num_heads==64)&&q_is_fp8' in src
+        and (gfx950 or (gfx942 and has_asm_kernel(64, 1)))
     )
 
 
@@ -310,6 +547,9 @@ class AiterMLADecodeMetadata(MLACommonDecodeMetadata):
     use_gluon_verify: bool = False
     # Whether persistent MLA metadata was computed
     has_persistent_metadata: bool = False
+    # Head count the asm decode is launched at, resolved once by the builder
+    # (AiterMLAHelper.resolve_padded_mla_num_heads).
+    padded_num_heads: int | None = None
 
 
 @dataclass
@@ -457,11 +697,6 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         # Decode kernels consume the DCP-gathered query heads.
         self._decode_num_heads = self.num_heads * self.dcp_world_size
-        # Keep metadata sizing consistent with the padded tensor shape passed
-        # to mla_decode_fwd, including native 24-head AITER builds.
-        self._num_attention_heads = AiterMLAHelper.get_actual_mla_num_heads(
-            self._decode_num_heads
-        )
         kv_cache_dtype_str = getattr(vllm_config.cache_config, "cache_dtype", "auto")
         if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
             kv_cache_dtype_str = "fp8"
@@ -483,6 +718,35 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # wrong split/reduce metadata for the gfx950 fp8 nhead=32 fold path.
         self._mla_q_dtype = q_dtype
         self._mla_kv_dtype = kv_dtype
+
+        # Head count the decode is actually launched at. Resolved here, below
+        # the dtype block, because whether a count is native to AITER depends
+        # on the q/kv dtypes and the arch, not only on the count -- see
+        # _aiter_mla_shape_is_native. It keeps metadata sizing consistent with
+        # the padded tensor shape passed to mla_decode_fwd, including native
+        # 24-head AITER builds.
+        #
+        # One value has to serve every query length this run can produce: it
+        # sizes persistent buffers and the decode output, so a value that
+        # changed between passes would break cudagraph capture. _build_decode
+        # accepts any 1 <= max_qo_len <= _mtp_decode_qlen, and nativeness is
+        # neither monotone nor a simple function of qlen, so hand the resolver
+        # the whole reachable range rather than its endpoints.
+        #
+        # needs_lse: a DCP rank asks aiter for the LSE the cross-shard merge
+        # needs, and the asm kernel table is indexed by that flag, so it
+        # narrows which padded shapes can dispatch at all.
+        from vllm.platforms.rocm import on_gfx942, on_gfx950
+
+        self._num_attention_heads = AiterMLAHelper.resolve_padded_mla_num_heads(
+            self._decode_num_heads,
+            gfx942=on_gfx942(),
+            gfx950=on_gfx950(),
+            q_fp8=q_dtype is dtypes.fp8,
+            kv_fp8=kv_dtype is dtypes.fp8,
+            max_qo_lens=range(1, max(1, self._mtp_decode_qlen) + 1),
+            needs_lse=self.dcp_world_size > 1,
+        )
         (
             (work_meta_data_size, work_meta_data_type),
             (work_indptr_size, work_indptr_type),
@@ -1125,6 +1389,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             use_gluon_verify=use_gluon_verify,
             attn_out_dtype=self.decode_attn_out_dtype,
             has_persistent_metadata=has_persistent_metadata,
+            padded_num_heads=self._num_attention_heads,
         )
 
         return attn_metadata
@@ -1215,6 +1480,9 @@ class AiterMLAHelper:
     that padding. Small divisors of 16 retain the existing repeat_interleave and
     strided-unpad behavior. Native and aligned counts pass through without
     copies.
+
+    ``VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE`` widens that rule for the decode
+    path: see ``resolve_padded_mla_num_heads``.
     """
 
     _AITER_MIN_MLA_HEADS: Final = 16
@@ -1223,6 +1491,21 @@ class AiterMLAHelper:
     # for. Above it only the non-persistent qseqlen=8 entry exists, and the
     # fold that reaches a persistent one is gfx950-only.
     _ASM_PADDED_MAX_PS_QLEN: Final = 4
+    # Cap on padded / aligned for the "auto" policy. Justification, measured
+    # on gfx950 with fp8 q + fp8 kv, bs=52, qlen=1, 16384 KV tokens/request:
+    # the native cost curve is 136.6 / 153.6 / 171.4 / 247.2 us at 16 / 32 /
+    # 64 / 128 heads -- 8x the heads for 1.81x the time, because the kernel is
+    # KV-bandwidth bound -- while each sub-pass of a fold costs roughly
+    # 0.7-0.85x of a whole 16-head pass. So every pad within 2x beats the fold
+    # it removes by a wide margin (48 -> 64 measured 2.04x, 80 -> 128 1.78x,
+    # 112 -> 128 2.66x). Above 2x the comparison gets close enough to need
+    # measurement this change does not have: the reachable case is gfx942 with
+    # fp8 at 32 heads and qlen > 1, whose only native target is 128 -- 4x the
+    # head work against a mere 2x fold -- so "auto" declines it and "force"
+    # takes it. Note the curve is calibrated at one operating point; at short
+    # KV the kernel moves toward compute-bound and the crossover shifts
+    # against padding.
+    _AITER_MAX_PAD_RATIO: Final = 2
     _AITER_UNSUPPORTED_HEADS: ClassVar[tuple[int, ...]] = ()
 
     @staticmethod
@@ -1262,7 +1545,122 @@ class AiterMLAHelper:
         )
 
     @staticmethod
-    def get_actual_mla_num_heads(num_heads: int) -> int:
+    def _head_padding_mode() -> str:
+        """``VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE``, normalized.
+
+        ``env_with_choices`` validates case-insensitively but returns the raw
+        string, so lower it here the way ``_aiter_mla_small_head_mode`` does
+        for the adjacent ASM_PADDING knob.
+        """
+        import vllm.envs as envs
+
+        return (envs.VLLM_ROCM_AITER_MLA_PAD_TO_NATIVE_SHAPE or "off").lower()
+
+    @staticmethod
+    def resolve_padded_mla_num_heads(
+        num_heads: int,
+        *,
+        gfx942: bool,
+        gfx950: bool,
+        q_fp8: bool,
+        kv_fp8: bool,
+        max_qo_lens: Collection[int],
+        needs_lse: bool,
+    ) -> int:
+        """Head count the asm decode should actually be launched at.
+
+        Resolve this ONCE per run, in the builder's ``__init__`` and only after
+        the q/kv dtypes are known, then hand the result to every consumer. It
+        sizes the persistent metadata, the padded q, the ``o`` allocation and
+        the unpad; if two sites recompute it from different information they
+        disagree, and both ``get_mla_padded_q`` and ``_get_mla_unpadded_heads``
+        branch on ``m % num_heads == 0``, so a mismatch is silently wrong
+        values rather than an error.
+
+        ``max_qo_lens`` is every query length the run can produce, not one
+        value: ``max_seqlen_qo`` varies per ``build()`` call, while the head
+        count sizes persistent buffers and the decode output and so has to be a
+        per-run constant or cudagraph capture breaks. A target is accepted only
+        if it is native at *all* of them. Taking the largest per-qlen answer
+        instead would be wrong: AITER's fold factor is ``num_heads / 16`` with
+        no qlen term, so a target that is non-native at some reachable qlen
+        folds *harder* there than not padding at all -- e.g. gfx942 fp8 at 32
+        heads, where padding to 64 helps qlen 1 and doubles the KV traffic of
+        every qlen > 1 verify pass.
+        """
+        m = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        # Start from the historical answer, not a bare ceil: it carries the
+        # native-H24 carve-out, and every consumer that calls
+        # get_actual_mla_num_heads without a resolved value has to agree with
+        # what this returns in "off" mode.
+        aligned = AiterMLAHelper.get_actual_mla_num_heads(num_heads)
+        mode = AiterMLAHelper._head_padding_mode()
+        if mode == "off":
+            return aligned
+
+        def native(count: int) -> bool:
+            return all(
+                _aiter_mla_shape_is_native(
+                    count,
+                    gfx942=gfx942,
+                    gfx950=gfx950,
+                    q_fp8=q_fp8,
+                    kv_fp8=kv_fp8,
+                    max_qo_len=qo,
+                    needs_lse=needs_lse,
+                )
+                for qo in max_qo_lens
+            )
+
+        if native(aligned):
+            return aligned
+
+        # Smallest native target at or above the aligned count. Nothing above
+        # _AITER_MAX_PADDED_MLA_HEADS: AITER's python dispatcher folds only
+        # ``nhead in range(32, 128 + 1, 16)`` and asserts otherwise, so a
+        # larger target would not run at all.
+        ratio_cap = (
+            float("inf") if mode == "force" else AiterMLAHelper._AITER_MAX_PAD_RATIO
+        )
+        for tile in range(
+            (aligned // m + 1) * m,
+            AiterMLAHelper._AITER_MAX_PADDED_MLA_HEADS + 1,
+            m,
+        ):
+            if tile > aligned * ratio_cap:
+                break
+            if native(tile):
+                return tile
+
+        if aligned > AiterMLAHelper._AITER_MAX_PADDED_MLA_HEADS:
+            logger.warning_once(
+                "ROCM_AITER_MLA: %d decode heads has no natively-supported "
+                "target at or below %d; leaving it unpadded.",
+                aligned,
+                AiterMLAHelper._AITER_MAX_PADDED_MLA_HEADS,
+            )
+        return aligned
+
+    @staticmethod
+    def get_actual_mla_num_heads(num_heads: int, *, resolved: int | None = None) -> int:
+        """Head count the asm decode is launched at.
+
+        ``resolved`` is the per-run constant from
+        ``resolve_padded_mla_num_heads`` -- pass it wherever the answer has to
+        match the buffers the builder sized in ``__init__``. Without it this is
+        the historical arch-blind rule: native H24 when the probe says so, else
+        the next multiple of 16. Do NOT make the no-``resolved`` path
+        context-sensitive: it is shared with the sparse backend (a different
+        kernel pair, qlen always 1) and with tests, neither of which should
+        inherit the dense decode's answer.
+
+        The 16-alignment itself is unconditional and must stay that way. It is
+        a correctness guard, not an optimization: AITER can only fold multiples
+        of 16, and an unaligned count such as 120 reaches a bare
+        ``assert False`` in ``aiter/mla.py``.
+        """
+        if resolved is not None:
+            return resolved
         if num_heads == 24 and _aiter_mla_native_h24_supported():
             return num_heads
         m = AiterMLAHelper._AITER_MIN_MLA_HEADS
@@ -1281,6 +1679,11 @@ class AiterMLAHelper:
         The PS metadata in ``_init_fp8_prefill_ps_buffers``/``build()`` must be
         sized with this same function, or the work/reduce maps describe a
         different head count than the kernel is handed.
+
+        For the same reason the native-shape padding
+        (``resolve_padded_mla_num_heads``) is decode-only. The PS prefill has
+        no ``qk_batch_ratio`` fold to remove, so widening its head count would
+        be pure extra work.
 
         This function itself has no upper bound; the ceiling comes from the
         ``is_valid_num_heads`` gate, which rejects counts above
@@ -1316,12 +1719,21 @@ class AiterMLAHelper:
         return q.repeat(1, reps, 1)[:, :m, :].contiguous()
 
     @staticmethod
-    def get_mla_unpadded_o(num_heads: int, o: torch.Tensor) -> torch.Tensor:
-        return AiterMLAHelper._get_mla_unpadded_heads(num_heads, o)
+    def get_mla_unpadded_o(
+        num_heads: int, o: torch.Tensor, target_heads: int | None = None
+    ) -> torch.Tensor:
+        return AiterMLAHelper._get_mla_unpadded_heads(num_heads, o, target_heads)
 
     @staticmethod
-    def _get_mla_unpadded_heads(num_heads: int, tensor: torch.Tensor) -> torch.Tensor:
-        m = AiterMLAHelper.get_actual_mla_num_heads(num_heads)
+    def _get_mla_unpadded_heads(
+        num_heads: int, tensor: torch.Tensor, target_heads: int | None = None
+    ) -> torch.Tensor:
+        # target_heads must be the same integer get_mla_padded_q was given.
+        m = (
+            target_heads
+            if target_heads is not None
+            else AiterMLAHelper.get_actual_mla_num_heads(num_heads)
+        )
         if num_heads == m:
             return tensor
         if m % num_heads == 0:
@@ -1331,8 +1743,10 @@ class AiterMLAHelper:
         return tensor[:, :num_heads, ...]
 
     @staticmethod
-    def get_mla_unpadded_lse(num_heads: int, lse: torch.Tensor) -> torch.Tensor:
-        return AiterMLAHelper._get_mla_unpadded_heads(num_heads, lse)
+    def get_mla_unpadded_lse(
+        num_heads: int, lse: torch.Tensor, target_heads: int | None = None
+    ) -> torch.Tensor:
+        return AiterMLAHelper._get_mla_unpadded_heads(num_heads, lse, target_heads)
 
     @staticmethod
     def use_gluon_decode(num_heads: int, max_qo_len: int, kv_cache_dtype: str) -> bool:
@@ -1906,8 +2320,15 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             "ROCM_AITER_MLA decode expected the DCP-gathered query head count "
             f"{self._decode_num_heads}, got {q.shape[1]}"
         )
-        mla_padded_q = AiterMLAHelper.get_mla_padded_q(self._decode_num_heads, q)
-        mla_num_heads = AiterMLAHelper.get_actual_mla_num_heads(self._decode_num_heads)
+        # Resolved by the builder against the arch, the q/kv dtypes and the
+        # run's query lengths; recomputing it from num_heads alone would
+        # disagree with the persistent metadata whenever padding is on.
+        mla_num_heads = AiterMLAHelper.get_actual_mla_num_heads(
+            self._decode_num_heads, resolved=decode.padded_num_heads
+        )
+        mla_padded_q = AiterMLAHelper.get_mla_padded_q(
+            self._decode_num_heads, q, mla_num_heads
+        )
         o = torch.empty(
             B,
             mla_num_heads,
@@ -1975,7 +2396,11 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 **mla_kwargs,
             )
 
-        output = AiterMLAHelper.get_mla_unpadded_o(self._decode_num_heads, o)
+        output = AiterMLAHelper.get_mla_unpadded_o(
+            self._decode_num_heads, o, mla_num_heads
+        )
         if lse is not None:
-            lse = AiterMLAHelper.get_mla_unpadded_lse(self._decode_num_heads, lse)
+            lse = AiterMLAHelper.get_mla_unpadded_lse(
+                self._decode_num_heads, lse, mla_num_heads
+            )
         return output, lse


### PR DESCRIPTION
The gfx950 asm persistent decode has kernels for head tiles {16,32,64,128}. aiter accepts any 16-aligned count, but a non-native one is *folded*:

    qk_batch_ratio = nheads // 16; nheads = 16; num_batches *= qk_batch_ratio

(aiter csrc/kernels/mla/metadata/v1_2_device.cuh, mirrored in aiter/mla.py), and every sub-pass of the fold re-reads the same KV: the batch index is divided by qk_batch_ratio and the KV cursor only advances on sub-head 0.

get_actual_mla_num_heads rounds to the next multiple of 16, so a count that is already 16-aligned but not native passes straight into the fold. Under decode context parallelism the query is all-gathered to num_heads * dcp_world_size, which makes this easy to hit: Kimi-K3 at TP8/DCP8 gathers 12*8 = 96 heads and pays a 6x KV re-read on the largest kernel in the model. DeepSeek at TP8/DCP8 gathers 16*8 = 128 and is native, which is why this has gone unnoticed.

Rounding up to the next native tile instead trades a few zero query heads of compute for the entire re-read.

Measured on 8x MI355X, aiter 0.1.19, fp8 q + fp8 kv, bs=52 qlen=1, 16384 KV tokens/request, kernel identity read from rocprofv3:

  NH=16   qh16_qseqlen1_gqaratio16_lse_ps   104.32 us   FETCH  497.3 MB (1.01x)
  NH=96   qh16_qseqlen1_gqaratio16_lse_ps   464.14 us   FETCH 2970.9 MB (6.05x)
  NH=128  qh32_qseqlen4_gqaratio32_lse_ps   185.26 us   FETCH  517.2 MB (1.05x)

The FETCH_SIZE counter is the direct evidence of the re-read; the 1x reference is 52 * 16384 * 576 B = 490.73 MB.

End to end on Kimi-K3 DCP8/TP8, conc 52, ISL 131072, one image and two runs differing only by this knob, 8 ranks each:

  off: qh16_gqaratio16, MLA 459.38 us mean (8-rank spread 4.2%), 18.9% of GPU
  on : qh32_qseqlen4_gqaratio32, MLA 169.37 us (spread 2.7%), 9.6% of GPU

MLA kernel time -63.1%; median ITL 52.66 -> 43.33 ms (-17.7%); completed requests and total output tokens identical in both arms. The step-time delta (-17.3 ms/pass) is larger than the MLA delta (-7.26 ms/pass) because collective time also fell -- mscclKernel_Sum mean 57.06 -> 28.54 us at an unchanged call count -- i.e. ranks stopped waiting on the slowest MLA. Only the -7.26 is the kernel.

Off by default: it changes the kernel selected for every non-native head count, and only 96 -> 128 has been measured. 48 -> 64, 80 -> 128 and 112 -> 128 follow the same mechanism but are not measured here, and the non-gfx950 / bf16-KV combinations are not covered by aiter's native list at all.

The padded lanes never escape the backend: get_mla_unpadded_o and get_mla_unpadded_lse slice them off before forward() returns, so nothing padded reaches the DCP output combine or the LSE merge. Tests cover the rounding table and the pad/unpad round trip for o and lse.

Complementary to ROCm/aiter#4964, which teaches aiter to take gqa=96 natively (routing it to the same qh32_qseqlen4_gqaratio32 kernel) rather than padding to 128, worth a further ~15 us/call. That is merged to aiter main but is in no released aiter tag; this change works on shipped aiter.



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

