### PR TITLE
[Docs] Clarify APC is enabled by default

### DIFF
--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -7,9 +7,16 @@ Automatic Prefix Caching (APC in short) caches the KV cache of existing queries,
 !!! note
     Technical details on how vLLM implements APC can be found [here](../design/prefix_caching.md).
 
-## Enabling APC in vLLM
+## Using APC in vLLM
 
-Set `enable_prefix_caching=True` in vLLM engine to enable APC. Here is an example:
+Automatic Prefix Caching is **enabled by default** (`enable_prefix_caching=True` in the cache config). You do not need to pass any extra flag for typical workloads.
+
+To disable APC:
+
+- Python: `LLM(..., enable_prefix_caching=False)`
+- CLI: `vllm serve ... --no-enable-prefix-caching`
+
+Example that demonstrates APC reuse across prompts that share a long prefix:
 
 [examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py](../../examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py)
 

--- a/examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py
+++ b/examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py
@@ -7,8 +7,9 @@ Automatic Prefix Caching (APC) allows the vLLM engine to reuse cached
 KV (key-value) pairs from previous prompts if a new query shares the same
 prefix. This reduces redundant computation and improves inference speed.
 
-To enable APC, set `enable_prefix_caching=True` when initializing the
-vLLM engine.
+APC is enabled by default (`enable_prefix_caching=True` in the cache
+config). Passing `enable_prefix_caching=True` is optional; set it to
+`False` (or use CLI `--no-enable-prefix-caching`) to disable APC.
 
 This script uses a long Markdown table as the shared prompt prefix and
 compares the generation time for two queries that share the same prefix
@@ -76,7 +77,8 @@ def get_generation_time(llm, sampling_params, prompts):
 
 
 def main():
-    # set enable_prefix_caching=True to enable APC
+    # APC is on by default; enable_prefix_caching=True is explicit/optional.
+    # Use enable_prefix_caching=False to disable.
     llm = LLM(model="lmsys/longchat-13b-16k", enable_prefix_caching=True)
 
     sampling_params = SamplingParams(temperature=0, max_tokens=100)

--- a/examples/features/automatic_prefix_caching/prefix_caching_offline.py
+++ b/examples/features/automatic_prefix_caching/prefix_caching_offline.py
@@ -35,10 +35,15 @@ sampling_params = SamplingParams(temperature=0.0)
 
 
 def main():
-    # Create an LLM without prefix caching as a baseline.
-    regular_llm = LLM(model="facebook/opt-125m", gpu_memory_utilization=0.4)
+    # Create an LLM with prefix caching disabled as a baseline.
+    # APC is on by default, so disable it explicitly with False.
+    regular_llm = LLM(
+        model="facebook/opt-125m",
+        enable_prefix_caching=False,
+        gpu_memory_utilization=0.4,
+    )
 
-    print("Results without `enable_prefix_caching`")
+    print("Results with `enable_prefix_caching=False`")
 
     # ruff: noqa: E501
     # Generate texts from the prompts. The output is a list of RequestOutput objects
@@ -59,7 +64,7 @@ def main():
     del regular_llm
     cleanup_dist_env_and_memory()
 
-    # Create an LLM with prefix caching enabled.
+    # Create an LLM with prefix caching enabled (True is also the default).
     prefix_cached_llm = LLM(
         model="facebook/opt-125m",
         enable_prefix_caching=True,
@@ -72,7 +77,7 @@ def main():
     # Generate with prefix caching.
     outputs = prefix_cached_llm.generate(generating_prompts, sampling_params)
 
-    print("Results with `enable_prefix_caching`")
+    print("Results with `enable_prefix_caching=True`")
 
     cached_generated_texts = []
     # Print the outputs. You should see the same outputs as before.


### PR DESCRIPTION
## Summary

Automatic Prefix Caching (APC) is **on by default** (`enable_prefix_caching: bool = True` in `vllm/config/cache.py`), but the feature docs and examples still tell users to set `enable_prefix_caching=True` to “enable” it. The offline baseline example also omitted `enable_prefix_caching=False`, so the supposed “without APC” run still had APC enabled.

This PR:

- Clarifies in `docs/features/automatic_prefix_caching.md` that APC is enabled by default, and documents how to disable it (`False` / `--no-enable-prefix-caching`)
- Updates comments/docstrings in `automatic_prefix_caching_offline.py` to match the default-on behavior
- Fixes `prefix_caching_offline.py` so the baseline LLM explicitly passes `enable_prefix_caching=False`

Docs/examples only; no runtime code changes.

## Local repro

Verified on `main` HEAD `aae36577`:

```bash
# 1) CacheConfig default is True
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/aae36577/vllm/config/cache.py \
  | grep -n 'enable_prefix_caching'
# → enable_prefix_caching: bool = True

# 2) Docs still say "set True to enable"
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/aae36577/docs/features/automatic_prefix_caching.md \
  | grep -n 'enable_prefix_caching'
# → Set `enable_prefix_caching=True` in vLLM engine to enable APC.

# 3) Feature example comment says "set True to enable"
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/aae36577/examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py \
  | grep -n 'enable_prefix_caching'

# 4) Baseline offline example claims "without" but never passes False
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/aae36577/examples/features/automatic_prefix_caching/prefix_caching_offline.py \
  | grep -n 'enable_prefix_caching\|without\|baseline'
# → "without prefix caching" LLM(...) has no enable_prefix_caching=False

# 5) CLI exposes BooleanOptionalAction disable flag
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/aae36577/vllm/engine/arg_utils.py \
  | grep -n 'enable-prefix-caching'
# → --enable-prefix-caching (pairs with --no-enable-prefix-caching)
```

## Test plan

- [x] Confirmed `CacheConfig.enable_prefix_caching` default is `True` on HEAD `aae36577`
- [x] Confirmed docs/examples still instruct “set True to enable”
- [x] Confirmed `prefix_caching_offline.py` baseline lacked `False`
- [x] Diff limited to the three docs/example files above
- [ ] Docs/examples only; no runtime suite required