### PR TITLE
[Bugfix][MM] Load tokenizer independently for MM processor when skip_tokenizer_init=True

### DIFF
--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -199,6 +199,24 @@ class MultiModalRegistry:
     ) -> InputProcessingContext:
         if tokenizer is None:
             tokenizer = cached_tokenizer_from_config(model_config)
+            # Multimodal HF processors (e.g. Qwen3VLProcessor) resolve image
+            # placeholder token ids at construction time via
+            # tokenizer.convert_tokens_to_ids(...). When skip_tokenizer_init=True
+            # the call above returns None, and forwarding that None into
+            # AutoProcessor.from_pretrained crashes deep inside transformers.
+            # Mirror SGLang: engine's user-facing tokenizer can still be skipped,
+            # but the multimodal processor construction path always needs a real
+            # tokenizer. Load it independently here.
+            if tokenizer is None:
+                from vllm.tokenizers import cached_get_tokenizer
+
+                tokenizer = cached_get_tokenizer(
+                    model_config.tokenizer,
+                    runner_type=model_config.runner_type,
+                    tokenizer_mode=model_config.tokenizer_mode,
+                    revision=model_config.tokenizer_revision,
+                    trust_remote_code=model_config.trust_remote_code,
+                )
 
         return InputProcessingContext(model_config, tokenizer)
 


### PR DESCRIPTION
 ## Purpose

  Multimodal engine init crashes with `AttributeError: 'NoneType' object has no attribute 'convert_tokens_to_ids'` when `skip_tokenizer_init=True` is combined with any multimodal model (verified against Qwen3-VL).

With this fix, we can avoid being blocked by Multimodal HF processor construction when we genuinely need skip_tokenizer_init=true. For example, in RL scenarios using token-in-token-out generation, setting skip_tokenizer_init=true doesn't prevent vLLM from building the tokenizer; instead, it throws an error. Like this，https://github.com/verl-project/verl/pull/7648#issuecomment-5504690866

  ## Repro

  ```python
  from vllm import LLM
  llm = LLM(model="Qwen/Qwen3-VL-30B-A3B-Instruct", skip_tokenizer_init=True)

  Fails during AsyncLLM.__init__ before any request, traceback ending at:

  File ".../transformers/models/qwen3_vl/processing_qwen3_vl.py", line 51, in __init__                                                                                                                             
      else tokenizer.convert_tokens_to_ids(self.image_token)
  AttributeError: 'NoneType' object has no attribute 'convert_tokens_to_ids'
```

  **Root cause**

  1. vllm/tokenizers/registry.py::cached_tokenizer_from_config returns None when skip_tokenizer_init=True.
  2. vllm/multimodal/registry.py::MultiModalRegistry._create_processing_ctx builds InputProcessingContext(model_config, tokenizer=None).
  3. During MultiModalBudget computation at engine init, Qwen3-VL's processing info calls ctx.get_hf_processor(...).
  4. InputProcessingContext.get_hf_processor (processing/context.py:197) reads tokenizer = self.tokenizer (which is None) and passes tokenizer=None to cached_processor_from_config.
  5. That flows into AutoProcessor.from_pretrained(..., tokenizer=None) and finally Qwen3VLProcessor.__init__(tokenizer=None), where image-placeholder id resolution calls None.convert_tokens_to_ids("<|image_pad|>") and crashes.

  Multimodal HF processors resolve image/video placeholder token ids at construction time and therefore always need a real tokenizer, independent of whether the engine exposes a user-facing tokenizer to clients.

  **Fix**

  In MultiModalRegistry._create_processing_ctx, when cached_tokenizer_from_config returns None (i.e. skip_tokenizer_init=True), independently load a real tokenizer via cached_get_tokenizer for the multimodal processor construction path only.

  The engine's user-facing tokenizer semantics are preserved:
  - cached_tokenizer_from_config still returns None when skipped.
  - The extra load is scoped to the multimodal processor context.
  - cached_get_tokenizer is lru_cache-backed → no duplicate load in the non-skip path.

  **Prior art**

  This mirrors SGLang's behavior. TokenizerManager.init_tokenizer_and_processor in sglang/srt/managers/tokenizer_manager.py (https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/tokenizer_manager.py) unconditionally builds
  the HF processor (and its bound tokenizer) before applying skip_tokenizer_init, which only nulls out the user-facing self.tokenizer / self.processor. SGLang + Qwen3-VL + skip_tokenizer_init=True works today; this PR brings vLLM to parity.

  **Behavior matrix**

  
<img width="1414" height="312" alt="image" src="https://github.com/user-attachments/assets/7a506b2f-71e6-425d-b315-4d5e5436441b" />

  Test Plan
  
  - [ ] Start Qwen3-VL with skip_tokenizer_init=True; verify engine initializes and serves token-in/token-out requests correctly.
  - [ ] Start Qwen3-VL with skip_tokenizer_init=False; verify no regression.
  - [ ] Start a text-only model with skip_tokenizer_init=True; verify no regression.