### PR TITLE
[Bugfix][Spec Decode] Isolate ngram_gpu compile cache

### DIFF
--- a/tests/compile/fullgraph/test_multiple_graphs.py
+++ b/tests/compile/fullgraph/test_multiple_graphs.py
@@ -5,10 +5,14 @@ Test (piecewise) compilation with a simple model where multiple submodules
 are compiled and graph captured separately.
 """
 
+from pathlib import Path
+
 import pytest
 import torch
 from torch import nn
+from transformers import OPTConfig
 
+import vllm.envs as envs
 from vllm.compilation.backends import set_model_tag
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.decorators import ignore_torch_compile, support_torch_compile
@@ -16,11 +20,16 @@ from vllm.config import (
     CompilationConfig,
     CompilationMode,
     CUDAGraphMode,
+    ModelConfig,
+    SchedulerConfig,
+    SpeculativeConfig,
     VllmConfig,
     set_current_vllm_config,
 )
 from vllm.forward_context import BatchDescriptor, set_forward_context
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
+from vllm.v1.spec_decode.ngram_proposer_gpu import NgramProposerGPU
 
 from ...utils import create_new_process_for_each_test
 
@@ -102,6 +111,15 @@ class CompiledAttention(nn.Module):
 class CompiledAttentionTwo(CompiledAttention):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.attn(x) + x
+
+
+@support_torch_compile
+class CacheBackbone(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "", **kwargs) -> None:
+        super().__init__()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + 7
 
 
 @ignore_torch_compile
@@ -324,3 +342,58 @@ def test_multi_graph_piecewise_compile(
 
     # Expect bitwise equivalence using inductor w/ and w/o cudagraph
     assert torch.equal(outputs[0], outputs[2])
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@create_new_process_for_each_test("spawn")
+def test_ngram_gpu_uses_separate_compile_cache(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("VLLM_CACHE_ROOT", str(tmp_path / "vllm_cache"))
+    monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    envs.disable_envs_cache()
+
+    model_dir = tmp_path / "model"
+    OPTConfig(
+        architectures=["OPTForCausalLM"],
+        hidden_size=16,
+        ffn_dim=32,
+        num_attention_heads=1,
+        num_hidden_layers=1,
+        max_position_embeddings=16,
+        vocab_size=32,
+    ).save_pretrained(model_dir)
+    model_config = ModelConfig(model=str(model_dir), max_model_len=16)
+    speculative_config = SpeculativeConfig(
+        method="ngram_gpu",
+        num_speculative_tokens=3,
+        prompt_lookup_min=1,
+        prompt_lookup_max=3,
+    )
+    scheduler_config = SchedulerConfig.default_factory(
+        max_num_seqs=4,
+        max_num_batched_tokens=16,
+    )
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        speculative_config=speculative_config,
+        scheduler_config=scheduler_config,
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            cudagraph_mode=CUDAGraphMode.NONE,
+        ),
+    )
+
+    with set_current_vllm_config(vllm_config):
+        backbone = CacheBackbone(vllm_config=vllm_config).eval().cuda()
+        backbone_input = torch.arange(4, device="cuda").unsqueeze(0)
+        with set_forward_context(None, vllm_config):
+            backbone_output = backbone(backbone_input)
+
+        proposer = NgramProposerGPU(vllm_config, torch.device("cuda"))
+
+    assert torch.equal(backbone_output, backbone_input + 7)
+    assert proposer.kernel.compiled
+
+    cache_dir = Path(vllm_config.compilation_config.cache_dir) / "rank_0_0"
+    assert (cache_dir / "backbone" / "vllm_compile_cache.py").is_file()
+    assert (cache_dir / "ngram_gpu_kernel" / "vllm_compile_cache.py").is_file()

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1081,13 +1081,6 @@ class VllmBackend:
         # Honors opt-outs such as CompilationMode.NONE or VLLM_DISABLE_COMPILE_CACHE.
         disable_cache = not is_compile_cache_enabled(self.inductor_config)
 
-        # TODO(patchy): ngram gpu kernel will cause vllm torch compile cache errors.
-        is_ngram_gpu_enabled = (
-            vllm_config.speculative_config is not None
-            and vllm_config.speculative_config.use_ngram_gpu()
-        )
-        disable_cache = disable_cache or is_ngram_gpu_enabled
-
         if disable_cache:
             logger.info_once("vLLM's torch.compile cache is disabled.")
         else:

--- a/vllm/v1/spec_decode/ngram_proposer_gpu.py
+++ b/vllm/v1/spec_decode/ngram_proposer_gpu.py
@@ -253,9 +253,14 @@ class NgramProposerGPU:
         self.max_num_seqs = vllm_config.scheduler_config.max_num_seqs
         self.device = device
 
-        self.kernel = NgramGPUKernel(
-            vllm_config=self.vllm_config, prefix="ngram_gpu_kernel", device=device
-        )
+        from vllm.compilation.backends import set_model_tag
+
+        with set_model_tag("ngram_gpu_kernel"):
+            self.kernel = NgramGPUKernel(
+                vllm_config=self.vllm_config,
+                prefix="ngram_gpu_kernel",
+                device=device,
+            )
         self.kernel.to(device)
         self.kernel.eval()
 


### PR DESCRIPTION
## Summary

- Give the V1 `ngram_gpu` kernel its own torch.compile cache namespace.
- Remove the blanket compile-cache opt-out for `ngram_gpu`.
- Add a production-path regression test that verifies the backbone and ngram kernel write separate cache manifests.

The V1 ngram kernel and target model otherwise both default to the `backbone` namespace. Once cache reuse is enabled, the ngram kernel can load the target model's cached graph and fail due to an incompatible graph signature. Scoping kernel construction with `set_model_tag("ngram_gpu_kernel")` uses the existing multi-model cache isolation mechanism.

## Why this is not a duplicate

This follows up on the cache workaround and review discussion in #29184. Open PR #40704 adds the ModelRunner V2 ngram implementation; it deliberately keeps the cache disabled for the existing V1 proposer and does not isolate the V1 compile cache. The changes are therefore complementary rather than duplicate.

I also checked open PRs for `ngram_gpu` compile-cache, cache namespace, and model-tag fixes and found no PR implementing this V1 fix.

## Testing

- `.venv/bin/python -m pytest tests/compile/fullgraph/test_multiple_graphs.py -v`: 5 passed
- `.venv/bin/python -m pytest tests/v1/spec_decode/test_ngram.py -v`: 2 passed
- `.venv/bin/pre-commit run --files vllm/compilation/backends.py vllm/v1/spec_decode/ngram_proposer_gpu.py tests/compile/fullgraph/test_multiple_graphs.py`: passed
- `git diff --check`: passed

The tests were run on one NVIDIA B200. Local Hugging Face, Triton, and vLLM cache directories were redirected to writable workspace paths.

## Model validation

With `facebook/opt-125m` and `ngram_gpu` on B200, both default-AOT cold/warm runs and AOT-disabled cold/warm runs produced identical token IDs and text. In the AOT-disabled warm run, the backbone and ngram kernel reused their separate cache entries successfully.

AI assistance was used for code analysis and test drafting; the author reviewed the changes and ran the reported validation.