### PR TITLE
[Docs] Point sharded checkpoint conversion at save_sharded_state_offline.py

### DIFF
--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -23,7 +23,7 @@ llm = LLM(model="ibm-granite/granite-3.1-8b-instruct", tensor_parallel_size=2)
 !!! note
     With tensor parallelism enabled, each process will read the whole model and split it into chunks, which makes the disk reading time even longer (proportional to the size of tensor parallelism).
 
-    You can convert the model checkpoint to a sharded checkpoint using [examples/features/sharded_state/load_sharded_state_offline.py](../../examples/features/sharded_state/load_sharded_state_offline.py). The conversion process might take some time, but later you can load the sharded checkpoint much faster. The model loading time should remain constant regardless of the size of tensor parallelism.
+    You can convert the model checkpoint to a sharded checkpoint using [examples/features/sharded_state/save_sharded_state_offline.py](../../examples/features/sharded_state/save_sharded_state_offline.py). The conversion process might take some time, but later you can load the sharded checkpoint much faster. The model loading time should remain constant regardless of the size of tensor parallelism.
 
 ## Quantization
 


### PR DESCRIPTION
## What drifted

`docs/configuration/conserving_memory.md` tells readers to convert a checkpoint to the sharded format using `examples/features/sharded_state/load_sharded_state_offline.py`. That script **loads/validates** an already-saved sharded checkpoint; the conversion/save script is `save_sharded_state_offline.py`.

Single-line fix: link/text `load_sharded_state_offline.py` → `save_sharded_state_offline.py` (L26 only).

## Local repro

Both scripts exist under `examples/features/sharded_state/`:

```bash
gh api "repos/vllm-project/vllm/contents/examples/features/sharded_state?ref=main" --jq '.[].name'
# load_sharded_state_offline.py
# save_sharded_state_offline.py
```

Doc currently points at the load script for *conversion*:

```bash
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/configuration/conserving_memory.md \
  | rg -n 'sharded_state'
# … load_sharded_state_offline.py …
```

Docstrings confirm roles:

```bash
# save = conversion
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/sharded_state/save_sharded_state_offline.py | head -n 20
# "Saves each worker's model state dict directly to a checkpoint..."

# load = validate previously saved sharded state
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/sharded_state/load_sharded_state_offline.py | head -n 20
# "Validates the loading of a model saved with the sharded_state format."
# "...previously saved using save_sharded_state_offline.py"
```

## Change

- `docs/configuration/conserving_memory.md`: conversion note now links to `save_sharded_state_offline.py`.