### PR TITLE
[WIP][Model] Validate weight mapping in model initialization tests

### DIFF
--- a/tests/models/multimodal/processing/test_tensor_schema.py
+++ b/tests/models/multimodal/processing/test_tensor_schema.py
@@ -1,29 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import tempfile
+
 from collections.abc import Iterable
-from contextlib import contextmanager
 from functools import partial
 from typing import Any, TypeAlias
 
 import numpy as np
 import pytest
-import torch
-import torch.nn as nn
 from PIL import Image
 
-from vllm.config import ModelConfig, VllmConfig, set_current_vllm_config
-from vllm.config.cache import CacheConfig
+from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.config.multimodal import (
     AudioDummyOptions,
     BaseDummyOptions,
     ImageDummyOptions,
     VideoDummyOptions,
-)
-from vllm.distributed import (
-    cleanup_dist_env_and_memory,
-    init_distributed_environment,
-    initialize_model_parallel,
 )
 from vllm.model_executor.models.interfaces import supports_multimodal
 from vllm.multimodal import MULTIMODAL_REGISTRY, BatchedTensorInputs
@@ -32,11 +23,10 @@ from vllm.multimodal.utils import group_and_batch_mm_kwargs
 from vllm.platforms import current_platform
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.utils.collection_utils import is_list_of
-from vllm.utils.torch_utils import set_default_torch_dtype
 
 from ....utils import create_new_process_for_each_test
 from ...registry import HF_EXAMPLE_MODELS
-from ...utils import dummy_hf_overrides
+from ...utils import dummy_hf_overrides, initialize_dummy_model
 from .test_common import get_model_ids_to_test, get_token_prompt
 
 ImageInput = list[Image.Image]
@@ -122,37 +112,6 @@ def create_batched_mm_kwargs(
             for item in mm_kwargs[modality]
         ]
     )
-
-
-# TODO(Isotr0py): Don't initialize model during test
-@contextmanager
-def initialize_dummy_model(
-    model_cls: type[nn.Module],
-    model_config: ModelConfig,
-):
-    temp_file = tempfile.mkstemp()[1]
-    current_device = torch.get_default_device()
-    vllm_config = VllmConfig(
-        model_config=model_config, cache_config=CacheConfig(block_size=16)
-    )
-    with set_current_vllm_config(vllm_config=vllm_config):
-        init_distributed_environment(
-            world_size=1,
-            rank=0,
-            distributed_init_method=f"file://{temp_file}",
-            local_rank=0,
-            backend="nccl",
-        )
-        initialize_model_parallel(tensor_model_parallel_size=1)
-
-        with set_default_torch_dtype(model_config.dtype):
-            torch.set_default_device(current_platform.device_type)
-            model = model_cls(vllm_config=vllm_config)
-            torch.set_default_device(current_device)
-        yield model
-
-    del model
-    cleanup_dist_env_and_memory()
 
 
 @create_new_process_for_each_test()
@@ -245,7 +204,13 @@ def test_model_tensor_schema(model_id: str):
     }
     processor = factories.build_processor(ctx, cache=None)
 
-    with initialize_dummy_model(model_cls, model_config) as model:
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(block_size=16),
+    )
+
+    # TODO(Isotr0py): Don't initialize model during test
+    with initialize_dummy_model(model_cls, vllm_config) as model:
         for modality, _, mm_kwargs in create_batched_mm_kwargs(model_config, processor):
             for method_name in inputs_parse_methods:
                 print(

--- a/tests/models/test_initialization.py
+++ b/tests/models/test_initialization.py
@@ -126,20 +126,21 @@ def _load_dummy_weights(vllm_config: VllmConfig):
     target_device = torch.device(load_device)
     model_config = vllm_config.model_config
 
-    model = initialize_model(
-        vllm_config=vllm_config,
-        model_config=model_config,
-        prefix="",
-    )
+    with torch.device("meta"):
+        model = initialize_model(
+            vllm_config=vllm_config,
+            model_config=model_config,
+            prefix="",
+        )
 
-    weights_it = _get_dummy_weights(model, model_config)
-    loaded_weights = model.load_weights(weights_it)
-    validate_weights_loading(model, loaded_weights)
+        weights_it = _get_dummy_weights(model, model_config)
+        loaded_weights = model.load_weights(weights_it)
+        validate_weights_loading(model, loaded_weights)
 
-    if _has_online_quant(model):
-        finalize_layerwise_processing(model, model_config)
+        if _has_online_quant(model):
+            finalize_layerwise_processing(model, model_config)
 
-    process_weights_after_loading(model, model_config, target_device)
+        process_weights_after_loading(model, model_config, target_device)
 
     return model
 
@@ -229,7 +230,7 @@ def can_initialize(model_arch: str, EXAMPLE_MODELS: HfExampleModels):
 
     try:
         # TODO: Handle speculative model
-        with initialize_dummy_model(_load_dummy_weights, vllm_config, device="meta"):
+        with initialize_dummy_model(_load_dummy_weights, vllm_config):
             pass
     except _SkipValidation as e:
         logger.warning(

--- a/tests/models/test_initialization.py
+++ b/tests/models/test_initialization.py
@@ -1,28 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from functools import partial
-from unittest.mock import patch
+from collections.abc import Generator, Iterable
+from typing import cast
 
 import pytest
+import torch
+import torch.nn as nn
+from safetensors.torch import _TYPES as _SAFETENSORS_TO_TORCH_DTYPE
 
-from vllm import LLM
-from vllm.utils.mem_constants import GiB_bytes
-from vllm.v1.attention.backends.utils import resolve_kv_cache_layout
-from vllm.v1.core.kv_cache_utils import (
-    generate_scheduler_kv_cache_config,
-    get_kv_cache_configs,
+from vllm import EngineArgs
+from vllm.config import AttentionConfig, ModelConfig, VllmConfig
+from vllm.entrypoints.chat_utils import load_chat_template
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.base_loader import _has_online_quant
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
+from vllm.model_executor.model_loader.reload import finalize_layerwise_processing
+from vllm.model_executor.model_loader.utils import (
+    initialize_model,
+    process_weights_after_loading,
+    validate_weights_loading,
 )
-from vllm.v1.engine.core import EngineCore as V1EngineCore
+from vllm.renderers import ChatParams, renderer_from_config
+from vllm.transformers_utils.config import get_safetensors_params_metadata
 
-from ..utils import create_new_process_for_each_test, requires_spawn_multiprocessing
+from ..utils import create_new_process_for_each_test
 from .registry import (
     _TRANSFORMERS_BACKEND_MODELS,
     AUTO_EXAMPLE_MODELS,
     HF_EXAMPLE_MODELS,
     HfExampleModels,
 )
-from .utils import dummy_hf_overrides
+from .utils import initialize_dummy_model
+
+logger = init_logger(__name__)
 
 # This minimal list of model architectures is smaller than the total list of
 # supported models. The intention is that in the "typical" regression testing
@@ -53,18 +64,93 @@ OTHER_MODEL_ARCH_LIST = set(HF_EXAMPLE_MODELS.get_supported_archs()) - set(
 )
 
 
-@create_new_process_for_each_test()
-def can_initialize(
-    model_arch: str, monkeypatch: pytest.MonkeyPatch, EXAMPLE_MODELS: HfExampleModels
-):
-    """The reason for using create_new_process_for_each_test is to avoid
-    the WARNING:
-        "We must use the 'spawn' multiprocessing start method. Overriding
-        VLLM_WORKER_MULTIPROC_METHOD to 'spawn'."
-    The spawn process causes the _initialize_kv_caches_v1 function below to
-    become ineffective.
-    """
+class _SkipValidation(Exception):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
 
+        self.reason = reason
+
+
+def _get_weights_iterator(
+    source: DefaultModelLoader.Source,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    metadata = get_safetensors_params_metadata(
+        source.model_or_path,
+        revision=source.revision,
+    )
+    if not metadata:
+        raise _SkipValidation("Missing safetensors metadata")
+
+    for name, info in metadata.items():
+        if "dtype" not in info:
+            raise _SkipValidation(f"Missing safetensors dtype metadata for {name=}")
+
+        dtype = info["dtype"]
+        if dtype not in _SAFETENSORS_TO_TORCH_DTYPE:
+            raise _SkipValidation(
+                f"Unrecognized safetensors dtype metadata for {name=}: {dtype=}"
+            )
+
+        yield (
+            name,
+            torch.empty(info["shape"], dtype=_SAFETENSORS_TO_TORCH_DTYPE[dtype]),
+        )
+
+
+def _get_dummy_weights(model: nn.Module, model_config: ModelConfig):
+    primary_weights = DefaultModelLoader.Source(
+        model_config.model,
+        model_config.revision,
+        prefix="",
+        fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
+        allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
+    )
+    yield from _get_weights_iterator(primary_weights)
+
+    secondary_weights = cast(
+        Iterable[DefaultModelLoader.Source],
+        getattr(model, "secondary_weights", ()),
+    )
+    for source in secondary_weights:
+        yield from _get_weights_iterator(source)
+
+
+def _load_dummy_weights(vllm_config: VllmConfig):
+    """
+    Imitate `DefaultModelLoader.load_weights` so we can use dummy weights
+    to validate the weight mapping.
+    """
+    device_config = vllm_config.device_config
+    load_config = vllm_config.load_config
+    load_device = (
+        device_config.device if load_config.device is None else load_config.device
+    )
+    target_device = torch.device(load_device)
+    model_config = vllm_config.model_config
+
+    model = initialize_model(
+        vllm_config=vllm_config,
+        model_config=model_config,
+        prefix="",
+    )
+
+    weights_it = _get_dummy_weights(model, model_config)
+    loaded_weights = model.load_weights(weights_it)
+    validate_weights_loading(model, loaded_weights)
+
+    if _has_online_quant(model):
+        finalize_layerwise_processing(model, model_config)
+
+    process_weights_after_loading(model, model_config, target_device)
+
+    return model
+
+
+@create_new_process_for_each_test()
+def can_initialize(model_arch: str, EXAMPLE_MODELS: HfExampleModels):
+    """
+    create_new_process_for_each_test can avoid CUDA re-initialization error.
+    """
     model_info = EXAMPLE_MODELS.get_hf_info(model_arch)
     model_info.check_available_online(on_fail="skip")
     model_info.check_transformers_version(
@@ -72,38 +158,6 @@ def can_initialize(
         check_max_version=False,
         check_version_reason="vllm",
     )
-
-    hf_overrides_fn = partial(
-        dummy_hf_overrides,
-        model_arch=model_arch,
-        exist_overrides=model_info.hf_overrides,
-        use_original_num_layers=getattr(model_info, "use_original_num_layers", False),
-    )
-
-    # Avoid calling model.forward()
-    def _initialize_kv_caches_v1(self, vllm_config):
-        kv_cache_specs = self.model_executor.get_kv_cache_specs()
-        layout = resolve_kv_cache_layout(
-            vllm_config,
-            self.model_executor.get_supported_kv_cache_layouts(),
-            [spec for worker_specs in kv_cache_specs for spec in worker_specs.values()],
-        )
-        self.model_executor.set_kv_cache_layout(layout.name)
-        kv_cache_configs = get_kv_cache_configs(
-            vllm_config,
-            kv_cache_specs,
-            [10 * GiB_bytes],
-        )
-        scheduler_kv_cache_config = generate_scheduler_kv_cache_config(kv_cache_configs)
-        vllm_config.cache_config.num_gpu_blocks = scheduler_kv_cache_config.num_blocks
-        kv_cache_groups = scheduler_kv_cache_config.kv_cache_groups
-        if kv_cache_groups:
-            vllm_config.cache_config.block_size = min(
-                g.kv_cache_spec.block_size for g in kv_cache_groups
-            )
-
-        vllm_config.validate_block_size()
-        return scheduler_kv_cache_config
 
     if model_arch == "MoonshotKimiaForCausalLM":
         pytest.skip(
@@ -132,81 +186,78 @@ def can_initialize(
                 f"capability {capability.major}.{capability.minor}"
             )
 
-    with (
-        patch.object(V1EngineCore, "_initialize_kv_caches", _initialize_kv_caches_v1),
-        monkeypatch.context() as m,
-    ):
-        if requires_spawn_multiprocessing():
-            # The EngineCore subprocess re-imports the class and does not
-            # inherit the KV-cache patch above, so it OOMs. Run in-process
-            # so the patch applies.
-            m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    # FIXME: A hack to bypass FA3 assertion because our CI's L4 GPU
+    # has cc==8.9 which hasn't supported FA3 yet. Remove this hack when
+    # L4 supports FA3.
+    # Step1ForCausalLM requires TRITON_ATTN for use_alibi_sqrt support.
+    attention_config = (
+        AttentionConfig(backend="TRITON_ATTN")
+        if model_arch in ("GptOssForCausalLM", "Step1ForCausalLM")
+        else AttentionConfig()
+    )
 
-        # FIXME: A hack to bypass FA3 assertion because our CI's L4 GPU
-        # has cc==8.9 which hasn't supported FA3 yet. Remove this hack when
-        # L4 supports FA3.
-        # Step1ForCausalLM requires TRITON_ATTN for use_alibi_sqrt support.
-        attention_config = (
-            {"backend": "TRITON_ATTN"}
-            if model_arch in ("GptOssForCausalLM", "Step1ForCausalLM")
-            else None
-        )
-        if model_arch == "WhisperForConditionalGeneration":
-            m.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+    engine_args = EngineArgs(
+        model=model_info.default,
+        tokenizer=model_info.tokenizer,
+        tokenizer_mode=model_info.tokenizer_mode,
+        revision=model_info.revision,
+        enforce_eager=model_info.enforce_eager,
+        skip_tokenizer_init=model_info.require_embed_inputs,
+        enable_prompt_embeds=model_info.require_embed_inputs,
+        enable_mm_embeds=model_info.require_embed_inputs,
+        dtype=model_info.dtype,
+        speculative_config={
+            "model": model_info.speculative_model,
+            "method": model_info.speculative_method,
+            "num_speculative_tokens": 1,
+        }
+        if model_info.speculative_model
+        else None,
+        trust_remote_code=model_info.trust_remote_code,
+        enable_prefix_caching=model_info.enable_prefix_caching,
+        max_model_len=model_info.max_model_len,
+        max_num_batched_tokens=model_info.max_num_batched_tokens,
+        load_format="dummy",
+        model_impl="transformers"
+        if model_arch in _TRANSFORMERS_BACKEND_MODELS
+        else "vllm",
+        hf_overrides=model_info.hf_overrides,
+        max_num_seqs=model_info.max_num_seqs,
+        attention_config=attention_config,
+    )
+    vllm_config = engine_args.create_engine_config()
 
-        kwargs = {}
-        if not model_info.enable_prefix_caching:
-            kwargs["enable_prefix_caching"] = False
+    renderer = renderer_from_config(vllm_config)
+    renderer.warmup(ChatParams(chat_template=load_chat_template(None)))
 
-        LLM(
-            model_info.default,
-            tokenizer=model_info.tokenizer,
-            tokenizer_mode=model_info.tokenizer_mode,
-            revision=model_info.revision,
-            enforce_eager=model_info.enforce_eager,
-            skip_tokenizer_init=model_info.require_embed_inputs,
-            enable_prompt_embeds=model_info.require_embed_inputs,
-            enable_mm_embeds=model_info.require_embed_inputs,
-            dtype=model_info.dtype,
-            speculative_config={
-                "model": model_info.speculative_model,
-                "method": model_info.speculative_method,
-                "num_speculative_tokens": 1,
-            }
-            if model_info.speculative_model
-            else None,
-            trust_remote_code=model_info.trust_remote_code,
-            max_model_len=model_info.max_model_len,
-            max_num_batched_tokens=model_info.max_num_batched_tokens,
-            # these tests seem to produce leftover memory
-            gpu_memory_utilization=0.80,
-            load_format="dummy",
-            model_impl="transformers"
-            if model_arch in _TRANSFORMERS_BACKEND_MODELS
-            else "vllm",
-            hf_overrides=hf_overrides_fn,
-            max_num_seqs=model_info.max_num_seqs,
-            attention_config=attention_config,
-            **kwargs,
+    try:
+        # TODO: Handle speculative model
+        with initialize_dummy_model(_load_dummy_weights, vllm_config):
+            pass
+    except _SkipValidation as e:
+        logger.warning(
+            "Skipping validation when loading dummy weights for %s. Reason: %s",
+            vllm_config.model_config.model,
+            e.reason,
         )
 
 
 @pytest.mark.parametrize("model_arch", MINIMAL_MODEL_ARCH_LIST)
-def test_can_initialize_small_subset(model_arch: str, monkeypatch: pytest.MonkeyPatch):
+def test_can_initialize_small_subset(model_arch: str):
     """Test initializing small subset of supported models"""
-    can_initialize(model_arch, monkeypatch, HF_EXAMPLE_MODELS)
+    can_initialize(model_arch, HF_EXAMPLE_MODELS)
 
 
 @pytest.mark.parametrize("model_arch", OTHER_MODEL_ARCH_LIST)
-def test_can_initialize_large_subset(model_arch: str, monkeypatch: pytest.MonkeyPatch):
+def test_can_initialize_large_subset(model_arch: str):
     """Test initializing large subset of supported models
 
     This test covers the complement of the tests covered in the "small subset"
     test.
     """
-    can_initialize(model_arch, monkeypatch, HF_EXAMPLE_MODELS)
+    can_initialize(model_arch, HF_EXAMPLE_MODELS)
 
 
 @pytest.mark.parametrize("model_arch", AUTO_EXAMPLE_MODELS.get_supported_archs())
-def test_implicit_converted_models(model_arch: str, monkeypatch: pytest.MonkeyPatch):
-    can_initialize(model_arch, monkeypatch, AUTO_EXAMPLE_MODELS)
+def test_implicit_converted_models(model_arch: str):
+    can_initialize(model_arch, AUTO_EXAMPLE_MODELS)

--- a/tests/models/test_initialization.py
+++ b/tests/models/test_initialization.py
@@ -24,7 +24,6 @@ from vllm.model_executor.model_loader.utils import (
 from vllm.renderers import ChatParams, renderer_from_config
 from vllm.transformers_utils.config import get_safetensors_params_metadata
 
-from ..utils import create_new_process_for_each_test
 from .registry import (
     _TRANSFORMERS_BACKEND_MODELS,
     AUTO_EXAMPLE_MODELS,
@@ -85,16 +84,15 @@ def _get_weights_iterator(
         if "dtype" not in info:
             raise _SkipValidation(f"Missing safetensors dtype metadata for {name=}")
 
-        dtype = info["dtype"]
-        if dtype not in _SAFETENSORS_TO_TORCH_DTYPE:
+        dtype = _SAFETENSORS_TO_TORCH_DTYPE.get(info["dtype"])
+        if dtype is None:
             raise _SkipValidation(
-                f"Unrecognized safetensors dtype metadata for {name=}: {dtype=}"
+                f"Unrecognized safetensors dtype for {name=}: {info['dtype']}"
             )
 
-        yield (
-            name,
-            torch.empty(info["shape"], dtype=_SAFETENSORS_TO_TORCH_DTYPE[dtype]),
-        )
+        weight = torch.empty(info["shape"], dtype=dtype)
+
+        yield name, weight
 
 
 def _get_dummy_weights(model: nn.Module, model_config: ModelConfig):
@@ -146,7 +144,6 @@ def _load_dummy_weights(vllm_config: VllmConfig):
     return model
 
 
-@create_new_process_for_each_test()
 def can_initialize(model_arch: str, EXAMPLE_MODELS: HfExampleModels):
     """
     create_new_process_for_each_test can avoid CUDA re-initialization error.
@@ -232,7 +229,7 @@ def can_initialize(model_arch: str, EXAMPLE_MODELS: HfExampleModels):
 
     try:
         # TODO: Handle speculative model
-        with initialize_dummy_model(_load_dummy_weights, vllm_config):
+        with initialize_dummy_model(_load_dummy_weights, vllm_config, device="meta"):
             pass
     except _SkipValidation as e:
         logger.warning(

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -1,20 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
+import tempfile
 import warnings
 from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 from transformers import PretrainedConfig
 
+from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.config.model import AttnTypeStr, ModelConfig, ModelDType, RunnerOption
 from vllm.config.pooler import SequencePoolingType, TokenPoolingType
+from vllm.distributed import (
+    cleanup_dist_env_and_memory,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
 from vllm.logprobs import Logprob, PromptLogprobs, SampleLogprobs
 from vllm.multimodal.processing import InputProcessingContext
+from vllm.platforms import current_platform
 from vllm.tokenizers import cached_tokenizer_from_config
+from vllm.utils.torch_utils import set_default_torch_dtype
 
 from .. import ci_envs
 from .registry import HF_EXAMPLE_MODELS
@@ -619,3 +629,35 @@ def check_transformers_version(
         min_transformers_version=min_transformers_version,
         max_transformers_version=max_transformers_version,
     ).check_transformers_version(on_fail="skip")
+
+
+class VllmModelLike(Protocol):
+    def __call__(self, vllm_config: VllmConfig) -> nn.Module: ...
+
+
+@contextmanager
+def initialize_dummy_model(
+    model_cls: VllmModelLike,
+    vllm_config: VllmConfig,
+):
+    temp_file = tempfile.mkstemp()[1]
+    current_device = torch.get_default_device()
+
+    with set_current_vllm_config(vllm_config=vllm_config):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            distributed_init_method=f"file://{temp_file}",
+            local_rank=0,
+            backend="nccl",
+        )
+        initialize_model_parallel(tensor_model_parallel_size=1)
+
+        with set_default_torch_dtype(vllm_config.model_config.dtype):
+            torch.set_default_device(current_platform.device_type)
+            model = model_cls(vllm_config=vllm_config)
+            torch.set_default_device(current_device)
+        yield model
+
+    del model
+    cleanup_dist_env_and_memory()

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -639,14 +639,9 @@ class VllmModelLike(Protocol):
 def initialize_dummy_model(
     model_cls: VllmModelLike,
     vllm_config: VllmConfig,
-    *,
-    device: str | None = None,
 ):
     temp_file = tempfile.mkstemp()[1]
     current_device = torch.get_default_device()
-
-    if device is None:
-        device = current_platform.device_type
 
     with set_current_vllm_config(vllm_config=vllm_config):
         init_distributed_environment(
@@ -659,7 +654,7 @@ def initialize_dummy_model(
         initialize_model_parallel(tensor_model_parallel_size=1)
 
         with set_default_torch_dtype(vllm_config.model_config.dtype):
-            torch.set_default_device(device)
+            torch.set_default_device(current_platform.device_type)
             model = model_cls(vllm_config=vllm_config)
             torch.set_default_device(current_device)
         yield model

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -639,9 +639,14 @@ class VllmModelLike(Protocol):
 def initialize_dummy_model(
     model_cls: VllmModelLike,
     vllm_config: VllmConfig,
+    *,
+    device: str | None = None,
 ):
     temp_file = tempfile.mkstemp()[1]
     current_device = torch.get_default_device()
+
+    if device is None:
+        device = current_platform.device_type
 
     with set_current_vllm_config(vllm_config=vllm_config):
         init_distributed_environment(
@@ -654,7 +659,7 @@ def initialize_dummy_model(
         initialize_model_parallel(tensor_model_parallel_size=1)
 
         with set_default_torch_dtype(vllm_config.model_config.dtype):
-            torch.set_default_device(current_platform.device_type)
+            torch.set_default_device(device)
             model = model_cls(vllm_config=vllm_config)
             torch.set_default_device(current_device)
         yield model

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -19,6 +19,7 @@ from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.ep_weight_filter import (
     compute_local_expert_ids,
 )
+from vllm.model_executor.model_loader.utils import validate_weights_loading
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
@@ -442,29 +443,4 @@ class DefaultModelLoader(BaseModelLoader):
             else default_enable_weights_track
         )
         if enable_weights_track:
-            self.track_weights_loading(model, loaded_weights)
-
-    def track_weights_loading(
-        self, model: nn.Module, loaded_weights: set[str] | None
-    ) -> None:
-        weights_to_load = {name for name, _ in model.named_parameters()}
-        if loaded_weights is not None:
-            # ignore online quantization scales
-            for name, module in model.named_modules():
-                quant_method = getattr(module, "quant_method", None)
-                has_online_quant = getattr(quant_method, "uses_meta_device", False)
-                has_postprocess_quant = getattr(
-                    quant_method, "process_weights_after_loading", None
-                )
-                # ignore kv_cache scale and online quant scale,
-                # which can be missing in checkpoints
-                if has_online_quant or has_postprocess_quant:
-                    for param_name, _ in module.named_parameters():
-                        full_name = f"{name}.{param_name}" if name else param_name
-                        loaded_weights.add(full_name)
-            weights_not_loaded = weights_to_load - loaded_weights
-            if weights_not_loaded:
-                raise ValueError(
-                    "Following weights were not initialized from "
-                    f"checkpoint: {weights_not_loaded}"
-                )
+            validate_weights_loading(model, loaded_weights)

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -93,6 +93,8 @@ class DummyModelLoader(BaseModelLoader):
         model_config: ModelConfig,
         model: nn.Module,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        from .default_loader import DefaultModelLoader
+
         primary_weights = DefaultModelLoader.Source(
             model_config.model,
             model_config.revision,

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -1,15 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Generator, Iterable
-from typing import TYPE_CHECKING, cast
-
-import torch
 import torch.nn as nn
-from safetensors.torch import _TYPES as _SAFETENSORS_TO_TORCH_DTYPE
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
-from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.reload.layerwise import (
@@ -19,24 +13,10 @@ from vllm.model_executor.model_loader.reload.layerwise import (
 from vllm.model_executor.model_loader.reload.meta import materialize_layer
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
-from vllm.model_executor.model_loader.utils import validate_weights_loading
 from vllm.model_executor.model_loader.weight_utils import (
     initialize_dummy_weights,
     initialize_single_dummy_weight,
 )
-from vllm.transformers_utils.config import get_safetensors_params_metadata
-
-if TYPE_CHECKING:
-    from .default_loader import DefaultModelLoader
-
-logger = init_logger(__name__)
-
-
-class _SkipValidation(Exception):
-    def __init__(self, reason: str) -> None:
-        super().__init__(reason)
-
-        self.reason = reason
 
 
 class DummyModelLoader(BaseModelLoader):
@@ -59,82 +39,7 @@ class DummyModelLoader(BaseModelLoader):
     def download_model(self, model_config: ModelConfig) -> None:
         pass  # Nothing to download
 
-    def _get_weights_iterator(
-        self, source: "DefaultModelLoader.Source"
-    ) -> Generator[tuple[str, torch.Tensor], None, None]:
-        metadata = get_safetensors_params_metadata(
-            source.model_or_path,
-            revision=source.revision,
-        )
-        if not metadata:
-            raise _SkipValidation("Missing safetensors metadata")
-
-        for name, info in metadata.items():
-            if "dtype" not in info:
-                raise _SkipValidation(f"Missing safetensors dtype metadata for {name=}")
-
-            dtype = info["dtype"]
-            if dtype not in _SAFETENSORS_TO_TORCH_DTYPE:
-                raise _SkipValidation(
-                    f"Unrecognized safetensors dtype metadata for {name=}: {dtype=}"
-                )
-
-            yield (
-                name,
-                torch.empty(info["shape"], dtype=_SAFETENSORS_TO_TORCH_DTYPE[dtype]),
-            )
-
-    def get_all_weights(
-        self,
-        model_config: ModelConfig,
-        model: nn.Module,
-    ) -> Generator[tuple[str, torch.Tensor], None, None]:
-        from .default_loader import DefaultModelLoader
-
-        primary_weights = DefaultModelLoader.Source(
-            model_config.model,
-            model_config.revision,
-            prefix="",
-            fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
-            allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
-        )
-        yield from self._get_weights_iterator(primary_weights)
-
-        secondary_weights = cast(
-            Iterable[DefaultModelLoader.Source],
-            getattr(model, "secondary_weights", ()),
-        )
-        for source in secondary_weights:
-            yield from self._get_weights_iterator(source)
-
-    def validate_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
-        """
-        Imitate `DefaultModelLoader.load_weights` so we can use dummy weights
-        to validate the weight mapping.
-        """
-        loaded_weights = model.load_weights(self.get_all_weights(model_config, model))
-
-        default_enable_weights_track = (
-            model_config.quantization is None and loaded_weights is not None
-        )
-        enable_weights_track = (
-            self.enable_weights_track
-            if self.enable_weights_track is not None
-            else default_enable_weights_track
-        )
-        if enable_weights_track:
-            validate_weights_loading(model, loaded_weights)
-
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
-        try:
-            self.validate_weights(model, model_config)
-        except _SkipValidation as e:
-            logger.info(
-                "Skipping validation when loading dummy weights for %s. Reason: %s",
-                model_config.model,
-                e.reason,
-            )
-
         for layer in model.modules():
             info = get_layerwise_info(layer)
             if info.can_load():

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -24,17 +24,11 @@ class DummyModelLoader(BaseModelLoader):
 
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
-
-        extra_config = load_config.model_loader_extra_config
-        if not isinstance(extra_config, dict):
+        if load_config.model_loader_extra_config:
             raise ValueError(
-                f"model_loader_extra_config must be a dict for load format "
-                f"{load_config.load_format}, got {type(extra_config).__name__}"
+                f"Model loader extra config is not supported for "
+                f"load format {load_config.load_format}"
             )
-
-        self.enable_weights_track: bool | None = extra_config.get(
-            "enable_weights_track", None
-        )
 
     def download_model(self, model_config: ModelConfig) -> None:
         pass  # Nothing to download

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Generator, Iterable
+from typing import TYPE_CHECKING, cast
+
+import torch
 import torch.nn as nn
+from safetensors.torch import _TYPES as _SAFETENSORS_TO_TORCH_DTYPE
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.reload.layerwise import (
@@ -13,10 +19,24 @@ from vllm.model_executor.model_loader.reload.layerwise import (
 from vllm.model_executor.model_loader.reload.meta import materialize_layer
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
+from vllm.model_executor.model_loader.utils import validate_weights_loading
 from vllm.model_executor.model_loader.weight_utils import (
     initialize_dummy_weights,
     initialize_single_dummy_weight,
 )
+from vllm.transformers_utils.config import get_safetensors_params_metadata
+
+if TYPE_CHECKING:
+    from .default_loader import DefaultModelLoader
+
+logger = init_logger(__name__)
+
+
+class _SkipValidation(Exception):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+
+        self.reason = reason
 
 
 class DummyModelLoader(BaseModelLoader):
@@ -24,16 +44,99 @@ class DummyModelLoader(BaseModelLoader):
 
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
-        if load_config.model_loader_extra_config:
+
+        extra_config = load_config.model_loader_extra_config
+        if not isinstance(extra_config, dict):
             raise ValueError(
-                f"Model loader extra config is not supported for "
-                f"load format {load_config.load_format}"
+                f"model_loader_extra_config must be a dict for load format "
+                f"{load_config.load_format}, got {type(extra_config).__name__}"
             )
+
+        self.enable_weights_track: bool | None = extra_config.get(
+            "enable_weights_track", None
+        )
 
     def download_model(self, model_config: ModelConfig) -> None:
         pass  # Nothing to download
 
+    def _get_weights_iterator(
+        self, source: "DefaultModelLoader.Source"
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        metadata = get_safetensors_params_metadata(
+            source.model_or_path,
+            revision=source.revision,
+        )
+        if not metadata:
+            raise _SkipValidation("Missing safetensors metadata")
+
+        for name, info in metadata.items():
+            if "dtype" not in info:
+                raise _SkipValidation(f"Missing safetensors dtype metadata for {name=}")
+
+            dtype = info["dtype"]
+            if _SAFETENSORS_TO_TORCH_DTYPE not in dtype:
+                raise _SkipValidation(
+                    f"Unrecognized safetensors dtype metadata for {name=}: {dtype=}"
+                )
+
+            yield (
+                name,
+                torch.empty(
+                    info["shape"],
+                    dtype=_SAFETENSORS_TO_TORCH_DTYPE[dtype],
+                    device="meta",
+                ),
+            )
+
+    def get_all_weights(
+        self,
+        model_config: ModelConfig,
+        model: nn.Module,
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        primary_weights = DefaultModelLoader.Source(
+            model_config.model,
+            model_config.revision,
+            prefix="",
+            fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
+            allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
+        )
+        yield from self._get_weights_iterator(primary_weights)
+
+        secondary_weights = cast(
+            Iterable[DefaultModelLoader.Source],
+            getattr(model, "secondary_weights", ()),
+        )
+        for source in secondary_weights:
+            yield from self._get_weights_iterator(source)
+
+    def validate_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        """
+        Imitate `DefaultModelLoader.load_weights` so we can use dummy weights
+        to validate the weight mapping.
+        """
+        loaded_weights = model.load_weights(self.get_all_weights(model_config, model))
+
+        default_enable_weights_track = (
+            model_config.quantization is None and loaded_weights is not None
+        )
+        enable_weights_track = (
+            self.enable_weights_track
+            if self.enable_weights_track is not None
+            else default_enable_weights_track
+        )
+        if enable_weights_track:
+            validate_weights_loading(model, loaded_weights)
+
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        try:
+            self.validate_weights(model, model_config)
+        except _SkipValidation as e:
+            logger.info(
+                "Skipping validation when loading dummy weights for %s. Reason: %s",
+                model_config.model,
+                e.reason,
+            )
+
         for layer in model.modules():
             info = get_layerwise_info(layer)
             if info.can_load():

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -81,11 +81,7 @@ class DummyModelLoader(BaseModelLoader):
 
             yield (
                 name,
-                torch.empty(
-                    info["shape"],
-                    dtype=_SAFETENSORS_TO_TORCH_DTYPE[dtype],
-                    device="meta",
-                ),
+                torch.empty(info["shape"], dtype=_SAFETENSORS_TO_TORCH_DTYPE[dtype]),
             )
 
     def get_all_weights(

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -74,7 +74,7 @@ class DummyModelLoader(BaseModelLoader):
                 raise _SkipValidation(f"Missing safetensors dtype metadata for {name=}")
 
             dtype = info["dtype"]
-            if _SAFETENSORS_TO_TORCH_DTYPE not in dtype:
+            if dtype not in _SAFETENSORS_TO_TORCH_DTYPE:
                 raise _SkipValidation(
                     f"Unrecognized safetensors dtype metadata for {name=}: {dtype=}"
                 )

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -285,3 +285,35 @@ def configure_quant_config(
             quant_config.apply_vllm_mapper(hf_to_vllm_mapper.get_rename_mapper())
         if packed_mapping is not None:
             quant_config.packed_modules_mapping = packed_mapping
+
+
+def validate_weights_loading(
+    model: nn.Module,
+    loaded_weights: set[str] | None,
+) -> None:
+    """
+    Raise an error if some weights in the model were not loaded,
+    usually indicating a weight mapping issue.
+    """
+    weights_to_load = {name for name, _ in model.named_parameters()}
+    if loaded_weights is not None:
+        # ignore online quantization scales
+        for name, module in model.named_modules():
+            quant_method = getattr(module, "quant_method", None)
+            has_online_quant = getattr(quant_method, "uses_meta_device", False)
+            has_postprocess_quant = getattr(
+                quant_method, "process_weights_after_loading", None
+            )
+            # ignore kv_cache scale and online quant scale,
+            # which can be missing in checkpoints
+            if has_online_quant or has_postprocess_quant:
+                for param_name, _ in module.named_parameters():
+                    full_name = f"{name}.{param_name}" if name else param_name
+                    loaded_weights.add(full_name)
+
+        weights_not_loaded = weights_to_load - loaded_weights
+        if weights_not_loaded:
+            raise ValueError(
+                "Following weights were not initialized from "
+                f"checkpoint: {weights_not_loaded}"
+            )


### PR DESCRIPTION



## Purpose

Improve the coverage of model initialization tests by using the original HF config (without pruning any layers) and calling `model.load_weights` during the model initialization tests.

- To avoid weights download, we query the weights metadata via safetensors and create dummy tensors with the corresponding shape and dtype.
- To avoid OOM, we initialize the model on the meta device,

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

