### PR TITLE
[Bugfix] Fix launch render hanging on shutdown

### DIFF
--- a/vllm/entrypoints/launchers/launcher.py
+++ b/vllm/entrypoints/launchers/launcher.py
@@ -102,7 +102,12 @@ async def serve_http(
 
     loop = asyncio.get_running_loop()
 
-    watchdog_task = loop.create_task(watchdog_loop(server, app.state.engine_client))
+    engine_client = app.state.engine_client
+    watchdog_task = (
+        loop.create_task(watchdog_loop(server, engine_client))
+        if engine_client is not None
+        else None
+    )
     server_task = loop.create_task(server.serve(sockets=[sock] if sock else None))
 
     ssl_cert_refresher = (
@@ -133,25 +138,26 @@ async def serve_http(
     async def handle_shutdown() -> None:
         await shutdown_event.wait()
 
-        engine_client = app.state.engine_client
-        timeout = engine_client.vllm_config.shutdown_timeout
-        mode = "abort" if timeout == 0 else "drain"
+        if engine_client is not None:
+            timeout = engine_client.vllm_config.shutdown_timeout
+            mode = "abort" if timeout == 0 else "drain"
 
-        logger.info(
-            "[shutdown] API server: stopping engine client mode=%s timeout=%ss",
-            mode,
-            timeout,
-        )
+            logger.info(
+                "[shutdown] API server: stopping engine client mode=%s timeout=%ss",
+                mode,
+                timeout,
+            )
 
-        await loop.run_in_executor(
-            None, partial(engine_client.shutdown, timeout=timeout)
-        )
-        logger.info_once("[shutdown] API server: engine client stopped")
+            await loop.run_in_executor(
+                None, partial(engine_client.shutdown, timeout=timeout)
+            )
+            logger.info_once("[shutdown] API server: engine client stopped")
 
         server.should_exit = True
         logger.info_once("[shutdown] API server: signalling HTTP server shutdown")
         server_task.cancel()
-        watchdog_task.cancel()
+        if watchdog_task is not None:
+            watchdog_task.cancel()
         if ssl_cert_refresher:
             ssl_cert_refresher.stop()
 
@@ -174,7 +180,8 @@ async def serve_http(
         return server.shutdown()
     finally:
         shutdown_task.cancel()
-        watchdog_task.cancel()
+        if watchdog_task is not None:
+            watchdog_task.cancel()
 
 
 async def watchdog_loop(server: uvicorn.Server, engine: EngineClient):


### PR DESCRIPTION



## Purpose
[Bugfix] Fix launch render hanging on shutdown

 vllm launch render could hang after receiving SIGINT or SIGTERM.

  The render server does not create an EngineClient, so app.state.engine_client is None. However, the shared HTTP server shutdown path unconditionally accessed the engine client to determine the shutdown timeout and stop the engine.
  This raised an AttributeError before the Uvicorn server task could be cancelled, leaving the process running after Ctrl+C.

  The engine watchdog had the same assumption and could also attempt to access the missing engine client.

  This PR:

  - Skips engine shutdown when no EngineClient exists.
  - Avoids starting the engine watchdog for the render-only server.


## Test Plan
```
vllm launch render Qwen/Qwen3.8-27B \
      --served-model-name qwen3.8-27b \
      --host 0.0.0.0 \
      --port 8000 \
      --tensor-parallel-size 4 \
      --max-model-len 32768 \
      --reasoning-parser qwen3 \
      --enable-auto-tool-choice \
      --tool-call-parser qwen3_coder --max_num_queued_reqs 10 --api-server-count 1

```
before
<img width="2413" height="1147" alt="image" src="https://github.com/user-attachments/assets/108faa5b-94ff-41bd-adb1-02ab07eeff2e" />

after
<img width="2412" height="1143" alt="image" src="https://github.com/user-attachments/assets/0c5a5a7d-f197-48c3-a074-3ae46c425f9c" />



## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

