### PR TITLE
[Bugfix][Multimodal] Scope cache hash kwargs by modality

### DIFF
--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -1284,3 +1284,50 @@ def test_processor_inputs_hashes_partial_uuids():
             ),
         ]
     }
+
+
+def test_processor_inputs_hashes_scope_kwargs_by_modality():
+    """Changing one modality's options must not invalidate another item."""
+    rng = np.random.RandomState(0)
+    mm_data_items = MultiModalDataParser().parse_mm_data(
+        {
+            "image": [random_image(rng, min_wh=8, max_wh=9)],
+            "video": [np.zeros((2, 8, 8, 3), dtype=np.uint8)],
+        }
+    )
+    mm_uuid_items = {"image": ["image-uuid"], "video": ["video-uuid"]}
+
+    def get_hashes(video_frames: int, image_size: int, video_size: int):
+        return ProcessorInputs(
+            prompt=[],
+            mm_data_items=mm_data_items,
+            mm_uuid_items=mm_uuid_items,
+            media_io_kwargs={"video": {"num_frames": video_frames}},
+            hf_processor_mm_kwargs={
+                "images_kwargs": {"size": {"longest_edge": image_size}},
+                "videos_kwargs": {"size": {"longest_edge": video_size}},
+            },
+        ).get_mm_hashes("test-model", "blake3")
+
+    base = get_hashes(video_frames=4, image_size=224, video_size=224)
+    changed_video = get_hashes(video_frames=16, image_size=224, video_size=448)
+    changed_image = get_hashes(video_frames=4, image_size=448, video_size=224)
+
+    assert changed_video["image"] == base["image"]
+    assert changed_video["video"] != base["video"]
+    assert changed_image["image"] != base["image"]
+    assert changed_image["video"] == base["video"]
+
+
+def test_processor_inputs_hashes_ignore_unrelated_kwargs():
+    """An image-only request ignores video-only processing configuration."""
+    image = random_image(np.random.RandomState(0), min_wh=8, max_wh=9)
+    inputs = ProcessorInputs(
+        prompt=[],
+        mm_data_items=MultiModalDataParser().parse_mm_data({"image": [image]}),
+        mm_uuid_items={"image": ["image-uuid"]},
+        media_io_kwargs={"video": {"num_frames": 16}},
+        hf_processor_mm_kwargs={"videos_kwargs": {"size": {"longest_edge": 448}}},
+    )
+
+    assert inputs.get_mm_hashes("test-model", "blake3") == {"image": ["image-uuid"]}

--- a/vllm/multimodal/processing/inputs.py
+++ b/vllm/multimodal/processing/inputs.py
@@ -9,6 +9,12 @@ from vllm.inputs import MultiModalHashes
 from ..hasher import MultiModalHasher
 from ..parse import MultiModalDataItems, MultiModalUUIDItems
 
+_HF_MODALITY_PROCESSOR_KWARGS = {
+    "image": "images_kwargs",
+    "video": "videos_kwargs",
+    "audio": "audio_kwargs",
+}
+
 
 @dataclass
 class ProcessorInputs:
@@ -31,17 +37,41 @@ class ProcessorInputs:
         mm_data_items = self.mm_data_items
         mm_uuid_items = self.mm_uuid_items or {}
 
-        hash_factors = {
-            "media_io_kwargs": dict(self.media_io_kwargs),
-            "mm_processor_kwargs": dict(self.hf_processor_mm_kwargs),
-        }
-        has_hash_factors = any(hash_factors.values())
-        hash_factor_kwargs = hash_factors if has_hash_factors else {}
-
         mm_hashes = dict[str, list[str]]()
         hasher = MultiModalHasher
 
         for modality, data_items in mm_data_items.items():
+            # Each cache entry represents one item from one modality. Keep
+            # modality-scoped options out of unrelated entries, while
+            # retaining flat processor kwargs because they are shared by HF.
+            if modality in _HF_MODALITY_PROCESSOR_KWARGS:
+                modality_media_io_kwargs = self.media_io_kwargs.get(modality, {})
+                media_io_kwargs = (
+                    {modality: modality_media_io_kwargs}
+                    if modality_media_io_kwargs
+                    else {}
+                )
+                scoped_key = _HF_MODALITY_PROCESSOR_KWARGS[modality]
+                mm_processor_kwargs = {
+                    key: value
+                    for key, value in self.hf_processor_mm_kwargs.items()
+                    if key not in _HF_MODALITY_PROCESSOR_KWARGS.values()
+                    or key == scoped_key
+                }
+            else:
+                # Unified modalities such as ``vision_chunk`` can contain
+                # items originating from multiple media modalities. There is
+                # no per-item origin metadata here, so preserve all factors.
+                media_io_kwargs = dict(self.media_io_kwargs)
+                mm_processor_kwargs = dict(self.hf_processor_mm_kwargs)
+
+            hash_factors = {
+                "media_io_kwargs": media_io_kwargs,
+                "mm_processor_kwargs": mm_processor_kwargs,
+            }
+            hash_factors = {key: value for key, value in hash_factors.items() if value}
+            has_hash_factors = bool(hash_factors)
+
             uuid_items = (
                 mm_uuid_items[modality]
                 if modality in mm_uuid_items
@@ -53,8 +83,9 @@ class ProcessorInputs:
             for i, item in enumerate(data_items.get_all_items_for_hash()):
                 uuid_item = uuid_items[i]
 
-                # NOTE: Even if a uuid_item is provided, model output
-                # depends on hash_factor_kwargs, so they are taken into account.
+                # NOTE: Even if a uuid_item is provided, model output depends
+                # on the current modality's hash factors, so they are taken
+                # into account.
                 if uuid_item is None or has_hash_factors:
                     # NOTE: use provided hash string to hash with kwargs
                     # if available for better performance.
@@ -64,7 +95,7 @@ class ProcessorInputs:
                             hash_algorithm,
                             model_id=model_id,
                             **{modality: item},
-                            **hash_factor_kwargs,
+                            **hash_factors,
                         )
                     )
                 else:


### PR DESCRIPTION
## Purpose

Fix unnecessary multimodal processor cache misses caused by unrelated
modality options being included in every media item's cache hash.

The production trigger chain is:

```text
request/config media_io_kwargs or mm_processor_kwargs
  -> renderer._process_multimodal()
  -> ProcessorInputs
  -> ProcessorInputs.get_mm_hashes()
  -> multimodal processor cache hit/miss check
  -> preprocessing of cache-missing media items
```

`get_mm_hashes()` currently builds one global hash-factor dictionary containing
all `media_io_kwargs` and all HF processor kwargs, then applies it to every
modality. Consequently, a video-only option changes an image hash. For
example, an image-only request can inherit:

```bash
--media-io-kwargs '{"video":{"num_frames":16}}'
```

With multimodal processor caching enabled, repeating that request needlessly
reprocesses the image. The same issue occurs in mixed image/video requests:
changing `num_frames` or `videos_kwargs` invalidates the image cache entry.
This is a real online performance and latency bug; it does not independently
change model output.

This change scopes hash factors for ordinary modalities:

- `image` uses only image `media_io_kwargs` and `images_kwargs`;
- `video` uses only video `media_io_kwargs` and `videos_kwargs`;
- `audio` uses only audio `media_io_kwargs` and `audio_kwargs`;
- flat HF processor kwargs remain included because they are shared.

`vision_chunk` remains conservative because one list can contain both images
and videos and `ProcessorInputs` does not currently carry each item's original
modality. It may still have extra cache misses, but this change does not create
incorrect cache reuse.

## Test Plan

Run the focused multimodal processing and renderer hash tests:

```bash
python -m pytest tests/multimodal/test_processing.py -m cpu_test -q
python -m pytest tests/renderers/test_multimodal_hashes.py -m cpu_test -q
```

Run lint, formatting, and whitespace checks:

```bash
ruff check vllm/multimodal/processing/inputs.py \
  tests/multimodal/test_processing.py
ruff format --check vllm/multimodal/processing/inputs.py \
  tests/multimodal/test_processing.py
git diff --check
```

The regression tests compare identical media with changed modality-specific
options. They verify that changing video options preserves the image hash,
changing image options preserves the video hash, and video-only options are
ignored for an image-only request.

## Test Result

```text
tests/multimodal/test_processing.py -m cpu_test       98 passed
tests/renderers/test_multimodal_hashes.py -m cpu_test  1 passed
ruff check                                               passed
ruff format --check                                      passed
git diff --check                                         passed
```

The focused tests demonstrate the expected behavior at the hash boundary used
by the production cache. No media decoding or model inference semantics are
changed.

## AI-assisted contribution

This contribution was developed with AI assistance.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and production trigger chain are explained.
- [x] The test plan includes focused test and lint commands.
- [x] The test results include the focused regression results.
- [x] Documentation update considered; none is needed for this internal cache
  hash fix.

</details>

