### PR TITLE
[CI][ROCm] Stabilize Qwen 1.5 MoE GSM8K evals

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP4-A-MXFP6.yaml
+++ b/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP4-A-MXFP6.yaml
@@ -1,5 +1,5 @@
 model_name: "fxmarty/qwen1.5_moe_a2.7b_chat_w_fp4_a_fp6_e2m3"
 accuracy_threshold: 0.4405
-num_questions: 50
+num_questions: 1319
 num_fewshot: 5
 server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP6-A-MXFP6.yaml
+++ b/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP6-A-MXFP6.yaml
@@ -1,5 +1,5 @@
 model_name: "fxmarty/qwen1.5_moe_a2.7b_chat_w_fp6_e3m2_a_fp6_e3m2"
 accuracy_threshold: 0.5049
-num_questions: 50
+num_questions: 1319
 num_fewshot: 5
 server_args: "--enforce-eager --max-model-len 4096"


### PR DESCRIPTION
The AMD `LM Eval Large Models` step in [Buildkite build 12535](https://buildkite.com/vllm/amd-ci/builds/12535/list?sid=01a05f0d-9941-41a7-b5c8-0fb5220faf4d&tab=output) intermittently failed the Qwen 1.5 MoE OCP-MX GSM8K checks at scores of `0.36` and `0.42`. These cases were introduced by [PR #53291](https://github.com/vllm-project/vllm/pull/53291), which configured only 50 questions while retaining accuracy thresholds calibrated on the complete 1,319-question GSM8K test set. Three repeated runs with the new configs injected at the preceding nightly commit reproduced the `0.42` failure, showing that this was a flaky test configuration rather than a runtime regression from PR #52650. This change restores the sample population against which the existing thresholds were calibrated.

- Increase `num_questions` from 50 to 1,319 in both Qwen 1.5 MoE OCP-MX GSM8K configurations.
- Preserve the existing accuracy thresholds and tolerance so the tests retain their original regression sensitivity.
- Leave the model IDs, five-shot setting, server arguments, and concurrent online evaluation path unchanged.

### Test Result

| Run | MXFP4/MXFP6 | MXFP6/MXFP6 |
| --- | ---: | ---: |
| 1 | 0.4428 | 0.4973 |
| 2 | 0.4359 | 0.5011 |
| 3 | 0.4466 | 0.5004 |

All six evaluations passed with the existing thresholds and tolerance.

### AI assistance

AI assistance was used for failure triage, patch preparation, and test execution. The human submitter reviewed and understands the complete two-line diff and the reported gfx950 test results.
