### PR TITLE
[Bugfix][ROCm] Keep GLM-5.3 (GlmMoeDsaForCausalLM) on MRV2

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,8 +170,8 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
 
 
 def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
-    """ROCm keeps the DSA models (DeepSeek V3.2/V4, GLM-5.2) on their compiled
-    MRV1 paths and off breakable cudagraphs by default."""
+    """ROCm keeps DeepSeek V3.2/V4 on their compiled MRV1 paths and keeps the
+    DSA models off breakable cudagraphs by default."""
     from vllm.config.vllm import (
         ROCM_DEFAULT_MRV1_ARCHITECTURES,
         default_breakable_cudagraph_architectures,
@@ -184,7 +184,9 @@ def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
     try:
         assert "DeepseekV32ForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
         assert "DeepseekV4ForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
-        assert "GlmMoeDsaForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
+        # GLM-5.3 (GlmMoeDsaForCausalLM) produces corrupted output on MRV1,
+        # so it must stay on MRV2 by default.
+        assert "GlmMoeDsaForCausalLM" not in ROCM_DEFAULT_MRV1_ARCHITECTURES
 
         breakable_architectures = default_breakable_cudagraph_architectures()
         assert "DeepseekV32ForCausalLM" not in breakable_architectures
@@ -200,6 +202,23 @@ def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
         assert VllmConfig.use_v2_model_runner.fget(config) is False
     finally:
         default_breakable_cudagraph_architectures.cache_clear()
+
+
+def test_rocm_keeps_glm_dsa_on_mrv2(monkeypatch):
+    """GLM-5.3 generates corrupted output on MRV1, so ROCm must not opt it
+    out of MRV2 by default."""
+    from vllm.platforms import current_platform
+
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(architectures=["GlmMoeDsaForCausalLM"])
+    )
+    config._get_v2_model_runner_unsupported_features = lambda: []
+
+    assert VllmConfig.use_v2_model_runner.fget(config) is True
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -69,7 +69,7 @@ logger = init_logger(__name__)
 # TODO(rocm): These models are either unsupported by MRV2 or slower with
 # MRV2 on AMD GPUs.
 ROCM_DEFAULT_MRV1_ARCHITECTURES = frozenset(
-    {"DeepseekV32ForCausalLM", "DeepseekV4ForCausalLM", "GlmMoeDsaForCausalLM"}
+    {"DeepseekV32ForCausalLM", "DeepseekV4ForCausalLM"}
 )
 
 DEFAULT_BREAKABLE_CUDAGRAPH_ARCHITECTURES = frozenset(


### PR DESCRIPTION
## Purpose

Fixes #54924.

#53155 added `GlmMoeDsaForCausalLM` to `ROCM_DEFAULT_MRV1_ARCHITECTURES`, which
switches the default model runner for that architecture from MRV2 to MRV1 on
ROCm. GLM-5.2 and GLM-5.3 share this architecture string, so the change also
moved **GLM-5.3** onto MRV1, where it generates corrupted output: GSM8K 5-shot
accuracy drops from 91.6% to 14.9%.

This drops the architecture from the MRV1 carve-out so it stays on MRV2 by
default. The breakable-cudagraph default introduced by the same PR is left
untouched, since accuracy is unchanged with it on or off (see #54924).

Note that the MRV1 preference is intentional on ROCm (cf. #52488, #52866,
#52644). If GLM-5.2 genuinely needs MRV1 there, a discriminator finer than the
architecture string is required, because the GLM-5.3 checkpoint carries no
version field to tell the two apart. Restoring correctness for GLM-5.3 seems
the better default in the meantime.

## Test Plan

```bash
pytest tests/test_config.py \
  -k 'rocm_keeps or dsa_breakable_cudagraph_platform_default or dsa_models_default_to_mrv2'
```

End-to-end on ROCm (AMD MI350/MI355, `gfx950`, TP=4) with
[`amd/GLM-5.3-Quark-MXFP4-AttnFP8`](https://huggingface.co/amd/GLM-5.3-Quark-MXFP4-AttnFP8):

```bash
MODEL=amd/GLM-5.3-Quark-MXFP4-AttnFP8

VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_FP8BMM=0 \
VLLM_ROCM_USE_AITER_FP4BMM=0 \
python -m lm_eval --model vllm \
  --model_args "pretrained=$MODEL,tensor_parallel_size=4,dtype=auto,\
quantization=quark,max_model_len=32768,trust_remote_code=True,max_num_seqs=32" \
  --tasks gsm8k \
  --batch_size auto
```

Add `VLLM_USE_V2_MODEL_RUNNER=1` to the same command to get the post-fix
behaviour on an unpatched build.

## Test Result

`tests/test_config.py`: 14 passed. This includes a new regression test,
`test_rocm_keeps_glm_dsa_on_mrv2`, which fails if the architecture is added
back to the carve-out.

GSM8K 5-shot, full 1319 docs:

| Runner | flexible-extract | strict-match |
| --- | --- | --- |
| MRV1 (before this PR) | 0.1486 | 0.1418 |
| MRV2 (after this PR / `VLLM_USE_V2_MODEL_RUNNER=1`) | **0.9158** | **0.9143** |

For reference the model card reports 0.9128, measured on
`vllm/vllm-openai-rocm:nightly-44fe2a392b71d52a8d72faf2f8278834379482c9` with
#54556 applied. That image predates the regression, which landed 68 commits
later; re-running `44fe2a392` here reproduces 0.9158 / 0.9151.
