### PR TITLE
[Bugfix][Compile] Preserve tensor metadata in piecewise create_concrete_args

### DIFF
--- a/tests/compile/test_compile_ranges.py
+++ b/tests/compile/test_compile_ranges.py
@@ -254,3 +254,45 @@ def test_inductor_cache_compile_ranges(disable_vllm_compile_cache):
         # Check that cache is used, so the number of calls
         # should be 0
         assert post_grad_range_checker.num_calls == 0
+
+
+def test_create_concrete_args_preserves_tensor_metadata():
+    """create_concrete_args rebuilds example inputs with torch.empty; tensor
+    metadata stamped on the traced example values (conj/neg bits here, backend
+    metadata for out-of-tree devices) must survive the rebuild, while inputs
+    without metadata must come back with none."""
+    from torch._subclasses.fake_tensor import FakeTensorMode
+    from torch.fx.experimental.symbolic_shapes import (
+        DimDynamic,
+        ShapeEnv,
+        StatelessSymbolicContext,
+    )
+
+    from vllm.compilation.piecewise_backend import create_concrete_args
+
+    class Model(nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return x + y.sum()
+
+    graph = fx.symbolic_trace(Model())
+    fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+
+    def dynamic_batch() -> StatelessSymbolicContext:
+        return StatelessSymbolicContext(
+            dynamic_sizes=[DimDynamic.DYNAMIC, DimDynamic.STATIC]
+        )
+
+    tagged = fake_mode.from_tensor(
+        torch.empty(4, 8, dtype=torch.complex64), symbolic_context=dynamic_batch()
+    ).conj()
+    plain = fake_mode.from_tensor(torch.empty(4, 8), symbolic_context=dynamic_batch())
+    assert torch._utils.get_tensor_metadata(tagged) == {"conj": True}
+    placeholders = [n for n in graph.graph.nodes if n.op == "placeholder"]
+    placeholders[0].meta["example_value"] = tagged
+    placeholders[1].meta["example_value"] = plain
+
+    tagged_rebuilt, plain_rebuilt = create_concrete_args(graph, 16)
+    assert tuple(tagged_rebuilt.shape) == (16, 8)
+    assert tagged_rebuilt.is_conj()
+    assert tuple(plain_rebuilt.shape) == (16, 8)
+    assert torch._utils.get_tensor_metadata(plain_rebuilt) == {}

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -70,6 +70,11 @@ def create_concrete_args(graph: fx.GraphModule, size: int) -> list[Any]:
                 )
                 t = torch.empty(needed_size, dtype=val.dtype, device=val.device)
                 t = t.as_strided(new_shape, new_strides, new_storage_offset)
+                # Out-of-tree backends may stamp backend-specific tensor metadata
+                # on the traced inputs; carry it onto the rebuilt example input.
+                metadata = torch._utils.get_tensor_metadata(val)
+                if metadata:
+                    torch._utils.set_tensor_metadata(t, metadata)
                 args.append(t)
             else:
                 args.append(val)


### PR DESCRIPTION
## Purpose

Out-of-tree accelerator backends stamp backend-specific tensor metadata on model
tensors via `torch._utils.set_tensor_metadata` (the `c10::BackendMeta` mechanism for
PrivateUse1 devices) and propagate it onto the FakeTensors Dynamo traces with. vLLM's
compile-range path hands the backend the graph's own `example_value` fakes, so the
metadata survives. The single-size path (`compile_sizes`, e.g. the size-1 decode graph)
instead rebuilds every placeholder's example input with a fresh `torch.empty` in
`create_concrete_args()` — which silently drops that metadata.

A backend that relies on that metadata at compile time therefore compiles every
`compile_sizes` graph from less information than the compile-range graphs of the same
model, and has to fall back to conservative handling of the affected inputs.

## Change

`vllm/compilation/piecewise_backend.py` (+5): after rebuilding the concrete example
input, copy `torch._utils.get_tensor_metadata(val)` onto it when non-empty. For
CUDA/CPU inputs the metadata dict is empty (conj/neg bits only, normally unset), so
this is a no-op on the default path.

`tests/compile/test_compile_ranges.py` (+42): behavioral test with no accelerator
dependency — the conj bit is metadata stock torch reports through the same call pair.
A conjugated complex example value with a symbolic batch dim must come back
concretized with `is_conj()` still set, and an untagged input must come back with no
metadata (the default-path no-op).

## Related work

- PyTorch pytorch/pytorch#186324 ("Propagate backend metadata through fake tensor conversion") fixes
  the real→fake step in core; it does not cover this fake→rebuilt-fake site, since
  `create_concrete_args` never goes through `from_real_tensor`. When its
  `torch._utils.copy_backend_meta()` API is available in vLLM's minimum torch, this
  call pair can migrate to it.

## Test Plan

```bash
pytest tests/compile/test_compile_ranges.py::test_create_concrete_args_preserves_tensor_metadata -v
```

End-to-end on out-of-tree PrivateUse1 accelerator hardware (platform plugin, Qwen3-8B,
`compile_sizes=[1]`), with the plugin's own metadata-restore workarounds disabled so
this patch is the only guard in play.

## Test Result

- The new unit test passes with the fix and fails without it (the rebuilt input
  comes back without the conj bit).
- A/B on the accelerator setup above: example inputs for `compile_sizes` entries now
  reach the backend with their tensor metadata intact — identical to what the
  compile-range path already delivers — and the end-to-end integration test passes.
  Reverting the patch reproduces the metadata loss.

## AI assistance

This PR contains AI-assisted code. The root-cause analysis, the patch, and the test
were produced with Claude (Claude Code); the submitter reviewed every changed line,
ran the tests, and validated the behaviour end-to-end on the accelerator hardware
described above.

Commits carry:

```
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
```
