### PR TITLE
[Bugfix][Frontend] Remove LoRA adapter from the engine on unload

### DIFF
--- a/tests/entrypoints/serve/lora/test_serving_models.py
+++ b/tests/entrypoints/serve/lora/test_serving_models.py
@@ -107,11 +107,48 @@ async def test_unload_lora_adapter_success():
     )
     response = await serving_models.load_lora_adapter(request)
     assert len(serving_models.lora_requests) == 1
+    lora_id = serving_models.lora_requests["adapter1"].lora_int_id
 
     request = UnloadLoRAAdapterRequest(lora_name="adapter1")
     response = await serving_models.unload_lora_adapter(request)
     assert response == LORA_UNLOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
     assert len(serving_models.lora_requests) == 0
+    # The engine must be told as well, otherwise the adapter keeps its
+    # worker-side slot until LRU eviction reclaims it.
+    serving_models.engine_client.remove_lora.assert_awaited_once_with(lora_id)
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_adapter_success_when_engine_already_evicted():
+    """An adapter the engine already evicted still unloads cleanly."""
+    serving_models = await _async_serving_models_init()
+    await serving_models.load_lora_adapter(
+        LoadLoRAAdapterRequest(lora_name="adapter1", lora_path="/path/to/adapter1")
+    )
+    serving_models.engine_client.remove_lora.return_value = False
+
+    response = await serving_models.unload_lora_adapter(
+        UnloadLoRAAdapterRequest(lora_name="adapter1")
+    )
+    assert response == LORA_UNLOADING_SUCCESS_MESSAGE.format(lora_name="adapter1")
+    assert len(serving_models.lora_requests) == 0
+
+
+@pytest.mark.asyncio
+async def test_unload_lora_adapter_engine_error():
+    """A failing engine removal surfaces as an error and keeps the adapter."""
+    serving_models = await _async_serving_models_init()
+    await serving_models.load_lora_adapter(
+        LoadLoRAAdapterRequest(lora_name="adapter1", lora_path="/path/to/adapter1")
+    )
+    serving_models.engine_client.remove_lora.side_effect = RuntimeError("boom")
+
+    response = await serving_models.unload_lora_adapter(
+        UnloadLoRAAdapterRequest(lora_name="adapter1")
+    )
+    assert isinstance(response, ErrorResponse)
+    assert response.error.code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "adapter1" in serving_models.lora_requests
 
 
 @pytest.mark.asyncio

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -200,6 +200,11 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def remove_lora(self, lora_id: int) -> bool:
+        """Remove an already loaded LoRA adapter."""
+        ...
+
+    @abstractmethod
     async def pause_generation(
         self,
         *,

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -229,6 +229,25 @@ class OpenAIServingModels:
             if error_check_ret is not None:
                 return error_check_ret
 
+            # Drop the adapter from the engine as well, otherwise its
+            # worker-side slot stays occupied until LRU eviction reclaims it.
+            lora_id = self.lora_requests[lora_name].lora_int_id
+            try:
+                removed = await self.engine_client.remove_lora(lora_id)
+            except Exception as e:
+                return create_error_response(
+                    message=str(e),
+                    err_type="InternalServerError",
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+            if not removed:
+                logger.debug(
+                    "LoRA adapter '%s' (id %d) was not registered in the engine; "
+                    "it had already been evicted.",
+                    lora_name,
+                    lora_id,
+                )
+
             # Safe to delete now since we hold the lock
             del self.lora_requests[lora_name]
             logger.info("Removed LoRA adapter: name '%s'", lora_name)


### PR DESCRIPTION
## Purpose

Closes #42633. Closes #54839.

`POST /v1/unload_lora_adapter` only drops the adapter from the frontend
registry. It never tells the engine, so the adapter keeps its worker-side slot
and CPU cache entry until LRU eviction happens to reclaim it. The adapter
vanishes from `/v1/models` while still occupying a LoRA slot no request can be
routed to.

`OpenAIServingModels.load_lora_adapter` already calls
`self.engine_client.add_lora(...)`; the unload path had no counterpart. The Rust
frontend does not have this bug — `LoraManager::unload_lora` in
`rust/src/server/src/lora.rs` calls `remove_lora` before dropping its registry
entry — so the two frontends currently disagree on what unloading means.

## Relationship to #42634

**@rayowang got here first.** #42634 (opened 2026-05-14) identifies the same bug
and takes the same approach this PR takes: add `remove_lora` to the
`EngineClient` protocol and call it from `unload_lora_adapter` before dropping
the registry entry. That design is theirs, and if maintainers prefer to land
#42634 instead, the fix below can be reduced to a review comment there — I would
rather see the bug fixed than see this PR merged.

I am opening this separately because of one behavioral difference that I believe
makes #42634 unmergeable as written, plus two smaller gaps.

### The difference that matters: `remove_lora() == False` is not an error

#42634 turns a falsy return into a 500:

```python
removed = await self.engine_client.remove_lora(lora_request.lora_int_id)
if not removed:
    return create_error_response(
        message=f"Failed to remove lora adapter '{lora_name}' from the engine.",
        err_type="InternalServerError",
        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
    )
```

`LoRAModelManager.remove_adapter` returns `False` whenever the id is no longer in
`_registered_adapters` (`vllm/lora/model_manager.py:1194`), and that state is
reachable in normal operation: when loading an adapter would exceed
`max_cpu_loras`, `LRUCacheWorkerLoRAManager` evicts the oldest one
(`vllm/lora/worker_manager.py:308-312` → `remove_oldest_adapter()` →
`_registered_adapters.remove_oldest()`).

So on `--max-cpu-loras 2`:

1. Load adapters `A`, `B`, `C`. Loading `C` evicts `A` from the worker.
2. `POST /v1/unload_lora_adapter {"lora_name": "A"}`.
3. `remove_adapter` returns `False`, and #42634 answers **500** — for a request
   that is entirely valid, on an adapter still listed in `/v1/models`.

That is the exact state this bug produces today, so the eviction path is not a
corner case here; it is the common one. This PR logs the falsy return at debug
level and still removes the registry entry, leaving the endpoint's success
contract unchanged.

Note this also differs from the Rust frontend, which returns `NotRemoved` in that
case. I think the Rust side has the same latent problem, but that is out of scope
here and I did not want to change two frontends in one PR. Happy to follow up.

### Two smaller differences

- #42634 does not wrap the engine call, so an exception from `remove_lora`
  escapes to FastAPI as an unhandled 500. This PR catches it and returns a
  structured `ErrorResponse`, matching how `load_lora_adapter` already handles
  `add_lora` failures.
- Test coverage: #42634 asserts the call happens. This PR adds the evicted-return
  and raising-engine cases, which are the two paths the difference above is
  about.

## Changes

- `EngineClient` gains an abstract `remove_lora`, mirroring the existing abstract
  `add_lora`. `AsyncLLM` is the only implementation and already defines it, so no
  implementer changes. (Same as #42634; the bot concern raised there about
  breaking subclasses was correctly rebutted by @rayowang.) The protocol
  deliberately exposes only what the entrypoints layer needs — it declares
  `add_lora` but not `list_loras`/`pin_lora` — and the unload path now needs
  `remove_lora`.
- `unload_lora_adapter` calls `engine_client.remove_lora(lora_int_id)` before
  dropping the registry entry, returning a structured 500 on exception and
  treating a falsy return as success.

`/v1/unload_lora_adapter` is the only unload entry point. The SageMaker
`register_unload_adapter_handler` in `vllm/entrypoints/serve/lora/api_router.py`
dispatches to the same method, so this single change covers both routes.

### Duplicate-work checks

Per `AGENTS.md`:

```
gh issue view 54839 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "54839 in:body"
gh pr list --repo vllm-project/vllm --state open --search "unload_lora_adapter"
```

These surface #42634 (addressed above), plus #54830 and #54833, which cite the
bug as motivation for LoRA metrics but do not touch
`vllm/entrypoints/openai/models/serving.py`. #54839 is itself a duplicate report
of #42633.

## Test Plan

`tests/entrypoints/serve/lora/test_serving_models.py` covers the endpoint with a
`MagicMock(spec=EngineClient)`, so the regression is caught at unit level without
a GPU:

- `test_unload_lora_adapter_success` — extended to assert the engine is told, via
  `remove_lora.assert_awaited_once_with(lora_id)`.
- `test_unload_lora_adapter_success_when_engine_already_evicted` — `remove_lora`
  returns `False`; the request must still succeed and clear the registry. This is
  the case #42634 would 500 on.
- `test_unload_lora_adapter_engine_error` — `remove_lora` raises; the response
  must be a structured 500 and the adapter must stay registered.

```bash
VLLM_USE_PRECOMPILED=1 uv pip install -e .
python -m pytest tests/entrypoints/serve/lora/test_serving_models.py -v
pre-commit run --files vllm/engine/protocol.py \
  vllm/entrypoints/openai/models/serving.py \
  tests/entrypoints/serve/lora/test_serving_models.py
```

## Test Result

On `main` @ `f81eb4193` + this change, Python 3.12, Ubuntu (WSL2):

```
$ python -m pytest tests/entrypoints/serve/lora/test_serving_models.py -v
...
tests/.../test_unload_lora_adapter_success PASSED                        [ 45%]
tests/.../test_unload_lora_adapter_success_when_engine_already_evicted PASSED [ 54%]
tests/.../test_unload_lora_adapter_engine_error PASSED                   [ 63%]
...
======================= 11 passed, 15 warnings in 4.35s ========================
```

Reverting only the two `vllm/` files and keeping the tests reproduces the bug:

```
FAILED tests/.../test_unload_lora_adapter_success
FAILED tests/.../test_unload_lora_adapter_success_when_engine_already_evicted
FAILED tests/.../test_unload_lora_adapter_engine_error
E   AttributeError: Mock object has no attribute 'remove_lora'
3 failed, 8 passed, 15 warnings in 4.71s
```

The `AttributeError` is the point: with `MagicMock(spec=EngineClient)` the
attribute does not exist on `main`, because nothing in the unload path ever
reaches for it.

`pre-commit run --files <the three files>` passes, including `Run mypy for Python
3.10`, `ruff`, `typos`, `Check SPDX headers` and `Check for forbidden imports`.
(The `update-dockerfile-graph` hook fails in my checkout for an unrelated local
reason — a CRLF working tree makes its shell script unrunnable. It touches none
of these files.)

Model evaluations do not apply: this changes an administrative endpoint's
engine-side cleanup only. No sampling, kernel, or model-output path is touched,
and the endpoint's HTTP response contract is unchanged.

## Notes

AI assistance was used to write this change. I reviewed every changed line and
traced the `remove_lora` path through `AsyncLLM` → `EngineCore` → `WorkerBase` →
`LoRAModelManager.remove_adapter` to confirm the `False` semantics described
above.

Credit to @rayowang for #42634, which found this bug and this fix first.
