### PR TITLE
[XPU] env to control block size alignment for mamba

### DIFF
--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -432,6 +432,7 @@ def run_ref_mamba_state_in_subprocess() -> None:
 def _run_ref_mamba_state_worker():
     try:
         os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+        os.environ["VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN"] = "0"
         num_generated_tokens = 8000
         num_prompt_tokens = 500
         sampling_params = SamplingParams(
@@ -512,6 +513,8 @@ class TestConfig:
 
 def apply_patch(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    # step_actions are hand-derived for BLOCK_SIZE; keep XPU from rounding it up.
+    monkeypatch.setenv("VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN", "0")
 
     fake_sample_fn = get_fake_sample_fn()
     monkeypatch.setattr(GPUModelRunner, "_sample", fake_sample_fn)
@@ -955,6 +958,8 @@ def _run_mamba_prefix_cache_mrv2(
     async_scheduling_mode = async_scheduling
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
     monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    # step_actions are hand-derived for BLOCK_SIZE; keep XPU from rounding it up.
+    monkeypatch.setenv("VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN", "0")
     envs.disable_envs_cache()
 
     from vllm.v1.worker.gpu.model_runner import GPUModelRunner as MRV2GPUModelRunner

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -319,6 +319,7 @@ if TYPE_CHECKING:
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_FORCE_N_CONTIG_WEIGHT: bool = False
+    VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN: bool = True
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
     VLLM_XPU_INC_WNA16_BACKEND: Literal["auto", "ark", "w4a16", "w4a8"] = "auto"
     VLLM_LORA_ENABLE_DUAL_STREAM: bool = False
@@ -2150,6 +2151,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Force N-contiguous weight layout for all XPU unquantized linears.
     "VLLM_XPU_FORCE_N_CONTIG_WEIGHT": lambda: bool(
         int(os.getenv("VLLM_XPU_FORCE_N_CONTIG_WEIGHT", "0"))
+    ),
+    # Round the KV block size up to a multiple of 64 when a GDN attention layer
+    # is present, as the XPU GDN kernel requires.
+    "VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN": lambda: bool(
+        int(os.getenv("VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN", "1"))
     ),
     # whether use xpu specific sample kernel
     "VLLM_XPU_USE_SAMPLER_KERNEL": lambda: bool(

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -414,6 +414,9 @@ class XPUPlatform(Platform):
         if new_block_size == cache_config.block_size:
             return
 
+        if not envs.VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN:
+            return
+
         if cache_config.mamba_cache_mode == "align":
             cache_config.mamba_block_size = new_block_size
         original_mamba_page_size_padded = cache_config.mamba_page_size_padded


### PR DESCRIPTION



## Purpose
Add an environment variable, `VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN`, to control block size alignment for mamba on XPU. Alignment is enabled by default and can be disabled by setting `VLLM_XPU_ALIGN_BLOCK_SIZE_FOR_GDN=0`.

## Test Plan
`pytest -sv tests/v1/e2e/general/test_mamba_prefix_cache.py`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

