### PR TITLE
[Bugfix][CPU][Spec Decode] Honor use_fp64_gumbel in CPU recovered-token sampling

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -31,6 +31,8 @@ steps:
   - vllm/v1/sample/ops/topk_topp_triton.py
   - vllm/v1/sample/ops/topk_topp_sampler.py
   - tests/v1/sample/test_topk_topp_sampler.py
+  - vllm/utils/cpu_triton_utils.py
+  - tests/v1/sample/test_rejection_sampler.py
   commands:
     - |
       bash .buildkite/scripts/hardware_ci/run-cpu-test.sh 30m "
@@ -49,7 +51,8 @@ steps:
       tests/kernels/mamba/cpu/test_cpu_gdn_ops.py \
       tests/kernels/mamba/test_causal_conv1d.py \
       tests/kernels/mamba/test_mamba_ssm.py \
-      tests/v1/sample/test_topk_topp_sampler.py::TestTritonTopkTopp"
+      tests/v1/sample/test_topk_topp_sampler.py::TestTritonTopkTopp \
+      tests/v1/sample/test_rejection_sampler.py::test_cpu_sample_recovered_tokens_preserves_fp64_inv_q"
   parallelism: 2
 
 # Note: SDE can't be downloaded from CI host because of AWS WAF

--- a/csrc/cpu/spec_decode_utils.cpp
+++ b/csrc/cpu/spec_decode_utils.cpp
@@ -427,7 +427,10 @@ void expand_kernel_impl(torch::Tensor& output, const torch::Tensor& input,
   }
 }
 
-void sample_recovered_tokens_kernel_impl(
+namespace {
+
+template <typename inv_q_t>
+void sample_recovered_tokens_impl(
     torch::Tensor& output_token_ids, const torch::Tensor& cu_num_draft_tokens,
     const torch::Tensor& draft_token_ids,
     const std::optional<torch::Tensor>& draft_probs,
@@ -441,7 +444,7 @@ void sample_recovered_tokens_kernel_impl(
   const float* draft_probs_ptr =
       no_draft_probs ? nullptr : draft_probs.value().data_ptr<float>();
   const float* target_probs_ptr = target_probs.data_ptr<float>();
-  const float* inv_q_ptr = inv_q.data_ptr<float>();
+  const inv_q_t* inv_q_ptr = inv_q.data_ptr<inv_q_t>();
 
   const int64_t target_stride = target_probs.stride(0);
   const int64_t draft_probs_stride =
@@ -454,7 +457,7 @@ void sample_recovered_tokens_kernel_impl(
     int64_t end_idx = cu_draft_ptr[req_idx];
     int64_t num_draft_tokens = end_idx - start_idx;
 
-    const float* req_inv_q = inv_q_ptr + req_idx * inv_q_stride;
+    const inv_q_t* req_inv_q = inv_q_ptr + req_idx * inv_q_stride;
 
     for (int64_t pos = 0; pos < num_draft_tokens; ++pos) {
       int64_t token_idx = start_idx + pos;
@@ -467,7 +470,7 @@ void sample_recovered_tokens_kernel_impl(
                          : (draft_probs_ptr + token_idx * draft_probs_stride);
 
       int64_t best_id = 0;
-      float best_val = -1.0f;
+      inv_q_t best_val = -1;
 
       for (int64_t v = 0; v < vocab_size; ++v) {
         float prob = token_target_probs[v];
@@ -478,7 +481,7 @@ void sample_recovered_tokens_kernel_impl(
           prob = diff > 0.0f ? diff : 0.0f;
         }
 
-        float val = prob * req_inv_q[v];
+        inv_q_t val = static_cast<inv_q_t>(prob) * req_inv_q[v];
         if (val > best_val) {
           best_val = val;
           best_id = v;
@@ -487,6 +490,26 @@ void sample_recovered_tokens_kernel_impl(
       out_ptr[token_idx] = best_id;
     }
   }
+}
+
+}  // namespace
+
+void sample_recovered_tokens_kernel_impl(
+    torch::Tensor& output_token_ids, const torch::Tensor& cu_num_draft_tokens,
+    const torch::Tensor& draft_token_ids,
+    const std::optional<torch::Tensor>& draft_probs,
+    const torch::Tensor& target_probs, const torch::Tensor& inv_q,
+    const int64_t vocab_size, const bool no_draft_probs) {
+  // `inv_q` carries the exponential-race noise at the precision the caller
+  // selected via `use_fp64_gumbel`. Dispatch on its dtype so fp64 noise keeps
+  // full precision through both the score and the argmax, matching the Triton
+  // kernel. The fp32 instantiation is unchanged.
+  AT_DISPATCH_FLOATING_TYPES(
+      inv_q.scalar_type(), "sample_recovered_tokens_kernel_impl", [&] {
+        sample_recovered_tokens_impl<scalar_t>(
+            output_token_ids, cu_num_draft_tokens, draft_token_ids, draft_probs,
+            target_probs, inv_q, vocab_size, no_draft_probs);
+      });
 }
 
 }  // namespace cpu_utils

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 
 from tests.v1.sample.utils import create_allowed_token_ids
 from vllm.platforms import current_platform
+from vllm.utils import cpu_triton_utils
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
@@ -996,6 +997,50 @@ def test_sample_recovered_tokens_uses_fp64_exponential_race_when_requested():
     )
 
     assert torch.equal(actual, expected)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cpu(),
+    reason="exercises the CPU fallback kernel for sample_recovered_tokens",
+)
+@pytest.mark.parametrize(
+    "inv_q_row,fp64_choice,fp32_choice",
+    [
+        # Near-tie only fp64 can resolve: both entries round to 1.0 in fp32.
+        ([1.0, 1.0 + 1e-10, 1.0], 1, 0),
+        # Lower-tail draws whose reciprocals both overflow fp32 to +inf.
+        ([1e39, 2e39, 1.0], 1, 0),
+    ],
+)
+def test_cpu_sample_recovered_tokens_preserves_fp64_inv_q(
+    inv_q_row, fp64_choice, fp32_choice
+):
+    """fp64 gumbel noise must survive the CPU kernel, as it does on Triton.
+
+    The fp32 expectations double as a guard that the fp32 path is unchanged.
+    """
+    vocab_size = 3
+    target_probs = torch.tensor([[1.0, 1.0, 0.5]], dtype=torch.float32)
+    draft_token_ids = torch.tensor([2], dtype=torch.int64)
+    cu_num_draft_tokens = torch.tensor([1], dtype=torch.int64)
+
+    def recovered_token(dtype: torch.dtype) -> int:
+        out = torch.zeros(1, dtype=torch.int64)
+        cpu_triton_utils.sample_recovered_tokens_kernel[(1, 1)](
+            out,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            None,
+            target_probs,
+            torch.tensor([inv_q_row], dtype=dtype),
+            vocab_size,
+            NO_DRAFT_PROBS=True,
+            USE_FP64_GUMBEL=dtype is torch.float64,
+        )
+        return int(out.item())
+
+    assert recovered_token(torch.float64) == fp64_choice
+    assert recovered_token(torch.float32) == fp32_choice
 
 
 @pytest.mark.parametrize("no_draft_probs", [True, False])

--- a/vllm/utils/cpu_triton_utils.py
+++ b/vllm/utils/cpu_triton_utils.py
@@ -435,9 +435,9 @@ def _sample_recovered_tokens_kernel_impl(
     USE_FP64_GUMBEL=False,
 ):
     # USE_FP64_GUMBEL only controls the gumbel-noise precision, which the caller
-    # has already applied to `inv_q` (fp64 vs fp32). The CPU kernel consumes
-    # `inv_q` directly, so the flag is accepted for interface parity and the
-    # value is read at its existing dtype.
+    # has already applied to `inv_q` (fp64 vs fp32). The C++ kernel dispatches on
+    # that dtype, so `inv_q` is passed through unchanged to keep fp64 noise at
+    # full precision through the argmax, matching the Triton kernel.
     # C++ reads integer tensors as int64_t*; ensure correct dtype.
     orig_dtype = output_token_ids.dtype
     output_i64 = _ensure_int64(output_token_ids)
@@ -447,8 +447,7 @@ def _sample_recovered_tokens_kernel_impl(
         _ensure_int64(draft_token_ids),
         draft_probs,
         target_probs,
-        # C++ kernel reads inv_q as float32.
-        inv_q.to(torch.float32),
+        inv_q,
         vocab_size,
         NO_DRAFT_PROBS,
     )


### PR DESCRIPTION
## Purpose

Fixes #54843.

`--use-fp64-gumbel` promises fp64 exponential-race noise in spec-decode recovery sampling (#43150 extended the flag to this path). On the CPU backend the flag was silently a no-op: the CPU shim for `sample_recovered_tokens_kernel` downcast the fp64 `inv_q` to fp32 before calling the C++ kernel, which only read `float*`. The comment above the downcast claimed the value was read at its existing dtype, which was not true. With the flag on, CPU and GPU produced different recovered tokens for the same random draws in exactly the lower-tail regime the flag exists for (see the issue for the measured divergence).

This PR makes the CPU kernel honor the flag instead of guarding or warning on it:

- `csrc/cpu/spec_decode_utils.cpp`: the recovered-token loop is templated on the `inv_q` scalar type and dispatched with `AT_DISPATCH_FLOATING_TYPES` on `inv_q.scalar_type()`. The score and argmax accumulate in the noise dtype, matching the Triton kernel's `USE_FP64_GUMBEL` specialization. The fp32 instantiation is byte-for-byte the previous code path.
- `vllm/utils/cpu_triton_utils.py`: pass `inv_q` through unchanged and correct the comment.
- `tests/v1/sample/test_rejection_sampler.py`: regression test with adversarial `inv_q` rows (an fp64-resolvable near-tie, and lower-tail draws whose reciprocals overflow fp32). Random draws, as in the existing fp64 test, do not reliably expose the bug. The fp32 expectations in the same test guard that the fp32 path is unchanged.
- `.buildkite/hardware_tests/cpu.yaml`: run the new test in the CPU-Kernel Tests job. CPU CI did not previously run anything from `test_rejection_sampler.py`, and the test skips on GPU, so without this it would never run in CI.

**Why this is not a duplicate:** no open PR references #54843 or touches this kernel. The other contributor who expressed interest in the issue (@luyixiao95) proposed a warn/reject variant and has since said they are happy for this dispatch-based fix to proceed.

## Test Plan

CPU build (`VLLM_TARGET_DEVICE=cpu`, torch 2.13.0+cpu, x86-64 AVX2):

```bash
pytest -x -v -s tests/v1/sample/test_rejection_sampler.py -k test_cpu_sample_recovered_tokens_preserves_fp64_inv_q
pre-commit run --files .buildkite/hardware_tests/cpu.yaml csrc/cpu/spec_decode_utils.cpp tests/v1/sample/test_rejection_sampler.py vllm/utils/cpu_triton_utils.py
```

Plus the reproduction script from #54843 (with `import vllm._C` replaced by `current_platform.import_kernels()` so the ISA-matched `_C` variant loads), and an extra multi-request `draft_probs` case checked against a pure-torch fp64 reference.

## Test Result

New regression test, with the fix:

```
tests/v1/sample/test_rejection_sampler.py::test_cpu_sample_recovered_tokens_preserves_fp64_inv_q[inv_q_row0-1-0] PASSED
tests/v1/sample/test_rejection_sampler.py::test_cpu_sample_recovered_tokens_preserves_fp64_inv_q[inv_q_row1-1-0] PASSED
2 passed, 75 deselected
```

Same test with the `inv_q.to(torch.float32)` downcast restored (negative control): both cases fail with `assert 0 == 1`, i.e. the kernel returns the fp32 answer when fp64 was requested.

Issue repro script against the fixed shim (before the fix, arms b1 and b2 diverged):

```
(a) normal range                   shim(flag=on)=[1]  fp64_ref=[1]  fp32_ref=[1]  -> OK (fp64 parity)
(b1) near-tie below fp32 eps       shim(flag=on)=[1]  fp64_ref=[1]  fp32_ref=[0]  -> OK (fp64 parity)
(b2) overflow steals argmax        shim(flag=on)=[1]  fp64_ref=[1]  fp32_ref=[0]  -> OK (fp64 parity)
(b3) NaN probe (0 * inf entry)     shim(flag=on)=[2]  fp64_ref=[2]  fp32_ref=[0]  -> OK (fp64 parity)
(ctl) flag off                     shim(flag=off)=[0]  fp32_ref=[0]
multi-req draft_probs fp64 path matches ref: True
```

No regressions: the rest of `test_rejection_sampler.py` fails identically with and without this change on a CPU-only build (pre-existing `TypeError: 'function' object is not subscriptable` from the Triton launch syntax; those tests are not run in CPU CI). All pre-commit hooks pass (ruff, clang-format, typos, mypy, SPDX).

No model-output change on GPU. On CPU with `--use-fp64-gumbel`, recovered tokens now match the GPU Triton kernel for the same draws; with the flag off, behavior is unchanged.

---

**AI assistance disclosure:** this change was developed with AI assistance (Claude Code). I reviewed every changed line, built the CPU extension locally, and ran the tests and repro above myself.