### PR TITLE
[ROCm][Perf] Kimi-K3 Enable sharded latent MoE up-projection under EP

### DIFF
--- a/tests/models/kimi_k3/test_amd_latent_moe_runner.py
+++ b/tests/models/kimi_k3/test_amd_latent_moe_runner.py
@@ -23,6 +23,7 @@ from vllm.distributed import get_tp_group
 from vllm.model_executor.layers.fused_moe.runner import moe_runner
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.models.kimi_k3.amd import latent_moe_runner
 from vllm.models.kimi_k3.amd.latent_moe_runner import ROCmLatentMoERunner
 from vllm.models.kimi_k3.amd.linear import KimiRoutedOutputTransform
 from vllm.platforms import current_platform
@@ -56,21 +57,26 @@ def _build_transform(device: torch.device) -> KimiRoutedOutputTransform:
 
 
 def _tail_runner(
-    transform: KimiRoutedOutputTransform, tp_size: int
+    transform: KimiRoutedOutputTransform, tp_world: int, use_ep: bool = False
 ) -> ROCmLatentMoERunner:
     """A runner carrying only what the tail reads, so no engine is needed.
 
     ``_maybe_reduce_final_output`` is left as the real base-class method, so the
     all-reduce that stitches the shards is the real collective.
+
+    ``tp_world`` is the size of the TP process group, which is what the hidden
+    dim is split by. Under expert parallelism the MoE config reports
+    ``tp_size=1``/``ep_size=tp_world`` for that same group, so ``use_ep`` pins
+    that the final reduce still fires.
     """
     runner = object.__new__(ROCmLatentMoERunner)
     attrs = {
         "routed_output_transform": transform,
-        "_up_proj_shard_size": HIDDEN_SIZE // tp_size,
+        "_up_proj_shard_size": HIDDEN_SIZE // tp_world,
         "_logged_sharded_tail": False,
         "moe_config": SimpleNamespace(
-            tp_size=tp_size,
-            ep_size=1,
+            tp_size=1 if use_ep else tp_world,
+            ep_size=tp_world if use_ep else 1,
             is_sequence_parallel=False,
             skip_final_all_reduce=False,
         ),
@@ -94,9 +100,11 @@ def _rank_partials(
     return routed.mul_(0.01), shared
 
 
-def _check_matches_replicated(device: torch.device, tp_size: int, rank: int) -> None:
+def _check_matches_replicated(
+    device: torch.device, tp_world: int, rank: int, use_ep: bool = False
+) -> None:
     transform = _build_transform(device)
-    runner = _tail_runner(transform, tp_size)
+    runner = _tail_runner(transform, tp_world, use_ep)
     group = get_tp_group().device_group
 
     for iteration, num_tokens in enumerate((1, 5, 8, 16, 5)):
@@ -119,13 +127,22 @@ def _check_matches_replicated(device: torch.device, tp_size: int, rank: int) -> 
         torch.testing.assert_close(actual, expected, atol=8e-2, rtol=3e-2)
 
 
+def _check_matches_replicated_under_ep(
+    device: torch.device, tp_world: int, rank: int
+) -> None:
+    """The served config: the routed experts are expert-parallel, so the MoE
+    config reports no tensor parallelism at all for a group that still splits
+    the hidden dim ``tp_world`` ways."""
+    _check_matches_replicated(device, tp_world, rank, use_ep=True)
+
+
 def _check_writes_only_its_own_shard(
-    device: torch.device, tp_size: int, rank: int
+    device: torch.device, tp_world: int, rank: int
 ) -> None:
     """Two ranks that swapped both weight rows and write offsets still sum to
     the right total, so inspect each slice before the final collective."""
     transform = _build_transform(device)
-    runner = _tail_runner(transform, tp_size)
+    runner = _tail_runner(transform, tp_world)
     group = get_tp_group().device_group
 
     torch.manual_seed(rank + 1)
@@ -149,7 +166,7 @@ def _check_writes_only_its_own_shard(
 
     assert captured["output_is_reduced"] is False
 
-    shard = HIDDEN_SIZE // tp_size
+    shard = HIDDEN_SIZE // tp_world
     start, end = rank * shard, (rank + 1) * shard
     local = captured["states"]
     projected = F.linear(latent, transform.up_proj.weight[start:end])
@@ -163,6 +180,7 @@ def _check_writes_only_its_own_shard(
 
 _CHECKS = {
     "matches_replicated": _check_matches_replicated,
+    "matches_replicated_ep": _check_matches_replicated_under_ep,
     "own_shard_only": _check_writes_only_its_own_shard,
 }
 
@@ -194,6 +212,11 @@ def test_sharded_tail_tp4_matches_replicated_projection() -> None:
 @multi_gpu_test(num_gpus=8)
 def test_sharded_tail_tp8_matches_replicated_projection() -> None:
     _run_ranks("matches_replicated", 8)
+
+
+@multi_gpu_test(num_gpus=8)
+def test_sharded_tail_tp8_ep8_matches_replicated_projection() -> None:
+    _run_ranks("matches_replicated_ep", 8)
 
 
 @multi_gpu_test(num_gpus=4)
@@ -241,12 +264,19 @@ def test_forward_shards_only_when_the_tail_is_valid(
 
 @pytest.fixture
 def build_runner(monkeypatch: pytest.MonkeyPatch):
-    """Construct through the real subclass ``__init__``, stubbing only the base."""
+    """Construct through the real subclass ``__init__``, stubbing only the base.
+
+    ``tp_world`` is the size of the TP process group and is varied independently
+    of ``moe_config.tp_size``, because under expert parallelism those two are
+    different numbers for the same eight ranks.
+    """
+    world = {"size": 8}
 
     def _base_init(
         self,
         *,
         tp_size: int = 8,
+        ep_size: int = 1,
         hidden: int = HIDDEN_SIZE,
         is_sequence_parallel: bool = False,
         has_up_proj: bool = True,
@@ -254,7 +284,9 @@ def build_runner(monkeypatch: pytest.MonkeyPatch):
         routed_scaling_factor: float = 1.0,
     ) -> None:
         self.moe_config = SimpleNamespace(
-            tp_size=tp_size, is_sequence_parallel=is_sequence_parallel
+            tp_size=tp_size,
+            ep_size=ep_size,
+            is_sequence_parallel=is_sequence_parallel,
         )
         self.routed_output_transform = SimpleNamespace(
             norm=None,
@@ -266,20 +298,63 @@ def build_runner(monkeypatch: pytest.MonkeyPatch):
         self._shared_experts = object() if has_shared_experts else None
 
     monkeypatch.setattr(moe_runner.MoERunner, "__init__", _base_init)
-    return ROCmLatentMoERunner
+    monkeypatch.setattr(
+        latent_moe_runner,
+        "get_tensor_model_parallel_world_size",
+        lambda: world["size"],
+    )
+
+    def _build(*, tp_world: int = 8, **kwargs) -> ROCmLatentMoERunner:
+        world["size"] = tp_world
+        return ROCmLatentMoERunner(**kwargs)
+
+    return _build
 
 
 def test_shards_under_the_kimi_k3_serving_config(build_runner) -> None:
-    runner = build_runner()
+    """``--tensor-parallel-size 8``, MoE experts tensor-parallel."""
+    runner = build_runner(tp_world=8, tp_size=8, ep_size=1)
 
     assert runner._tail_shardable
     assert runner._up_proj_shard_size == HIDDEN_SIZE // 8
 
 
+def test_shards_under_the_kimi_k3_serving_config_with_expert_parallel(
+    build_runner,
+) -> None:
+    """``--tensor-parallel-size 8 --enable-expert-parallel``, what is served.
+
+    EP reports ``moe_config.tp_size == 1`` because each rank owns whole experts,
+    but the hidden dim is still split across all eight TP ranks, so the tail
+    must shard exactly as it does without EP.
+    """
+    runner = build_runner(tp_world=8, tp_size=1, ep_size=8)
+
+    assert runner._tail_shardable
+    assert runner._up_proj_shard_size == HIDDEN_SIZE // 8
+
+
+def test_shards_by_the_process_group_not_the_dp_flattened_tp_size(
+    build_runner,
+) -> None:
+    """Without EP, ``moe_config.tp_size`` is flattened across DP: TP=2 x DP=2
+    reports 4 for a TP process group of 2.
+
+    Only those 2 ranks share a hidden dim and take part in the final
+    all-reduce, so sharding by 4 would leave half of it with no routed
+    contribution on either rank.
+    """
+    runner = build_runner(tp_world=2, tp_size=4, ep_size=1)
+
+    assert runner._tail_shardable
+    assert runner._up_proj_shard_size == HIDDEN_SIZE // 2
+
+
 @pytest.mark.parametrize(
     "override",
     [
-        pytest.param({"tp_size": 1}, id="no-tp"),
+        pytest.param({"tp_world": 1, "tp_size": 1}, id="single-rank"),
+        pytest.param({"tp_world": 1, "tp_size": 4}, id="dp-without-tp"),
         pytest.param({"hidden": HIDDEN_SIZE + 2}, id="hidden-not-divisible-by-tp"),
         pytest.param({"has_up_proj": False}, id="no-up-proj"),
         pytest.param({"has_shared_experts": False}, id="no-shared-partial"),
@@ -290,7 +365,12 @@ def test_shards_under_the_kimi_k3_serving_config(build_runner) -> None:
 def test_falls_back_when_the_config_breaks_the_shard(
     build_runner, override: dict
 ) -> None:
-    """Each of these makes the sharded tail wrong, not merely slower."""
+    """Each of these makes the sharded tail wrong, not merely slower.
+
+    ``dp-without-tp`` is DP=4 with no TP: the hidden dim is not split at all,
+    so there is nothing to shard and no all-reduce to stitch shards back
+    together, however large ``moe_config.tp_size`` claims to be.
+    """
     runner = build_runner(**override)
 
     assert not runner._tail_shardable

--- a/vllm/models/kimi_k3/amd/latent_moe_runner.py
+++ b/vllm/models/kimi_k3/amd/latent_moe_runner.py
@@ -34,20 +34,20 @@ class ROCmLatentMoERunner(MoERunner):
 
         transform = self.routed_output_transform
         up_proj = getattr(transform, "up_proj", None)
-        tp_world = get_tensor_model_parallel_world_size()
+        tp_size = get_tensor_model_parallel_world_size()
 
         self._up_proj_shard_size = 0
         self._tail_shardable = (
             up_proj is not None
-            and tp_world > 1
-            and up_proj.weight.shape[0] % tp_world == 0
+            and tp_size > 1
+            and up_proj.weight.shape[0] % tp_size == 0
             and self._shared_experts is not None
             and not self.moe_config.is_sequence_parallel
             and self.routed_scaling_factor == 1.0
         )
         if self._tail_shardable:
             assert up_proj is not None
-            self._up_proj_shard_size = up_proj.weight.shape[0] // tp_world
+            self._up_proj_shard_size = up_proj.weight.shape[0] // tp_size
         else:
             logger.warning_once(
                 "K3 latent-MoE tail is not shardable under this config, "

--- a/vllm/models/kimi_k3/amd/latent_moe_runner.py
+++ b/vllm/models/kimi_k3/amd/latent_moe_runner.py
@@ -6,6 +6,7 @@ import torch
 
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
 from vllm.logger import init_logger
@@ -33,20 +34,20 @@ class ROCmLatentMoERunner(MoERunner):
 
         transform = self.routed_output_transform
         up_proj = getattr(transform, "up_proj", None)
-        tp_size = self.moe_config.tp_size
+        tp_world = get_tensor_model_parallel_world_size()
 
         self._up_proj_shard_size = 0
         self._tail_shardable = (
             up_proj is not None
-            and tp_size > 1
-            and up_proj.weight.shape[0] % tp_size == 0
+            and tp_world > 1
+            and up_proj.weight.shape[0] % tp_world == 0
             and self._shared_experts is not None
             and not self.moe_config.is_sequence_parallel
             and self.routed_scaling_factor == 1.0
         )
         if self._tail_shardable:
             assert up_proj is not None
-            self._up_proj_shard_size = up_proj.weight.shape[0] // tp_size
+            self._up_proj_shard_size = up_proj.weight.shape[0] // tp_world
         else:
             logger.warning_once(
                 "K3 latent-MoE tail is not shardable under this config, "


### PR DESCRIPTION
## Purpose

`ROCmLatentMoERunner` has a column-parallel tail that splits the routed-expert
up-projection across ranks and accumulates each rank's shard into its slice of
the shared-expert output with `addmm_`, so the shared+routed combine costs no
extra kernel. It was gated on `moe_config.tp_size > 1`, which vLLM sets to `1` under
expert parallelism, so under `--tensor-parallel-size 8 --enable-expert-parallel`
the tail has never run: every rank computed the full 3584 -> 7168 projection and
then added the shared output in a separate elementwise kernel.

`moe_config.tp_size` describes how the *experts* are split. How many ranks share
the hidden dimension is a different question, and its answer is the TP process
group world size — which is also the group that `get_tensor_model_parallel_rank()`
indexes and that `tensor_model_parallel_all_reduce()` reduces over. This derives
the gate and the shard size from that world size instead. `_shard_up_proj_tail`
needs no change; it already indexes with the TP rank, which is now consistent
with the shard size.

The arithmetic is unchanged and holds under EP: the latent is all-reduced before
the up-projection so its input is replicated, `shared_output` is still an
unreduced TP partial because the dense layers and the shared expert stay at TP=8,
and the final all-reduce still fires (`ep_size > 1`).

Before:

<img width="1688" height="435" alt="before_EP" src="https://github.com/user-attachments/assets/31aaf0c6-f0ce-4b74-9762-8865297f3623" />


After:

<img width="1705" height="450" alt="after_EP" src="https://github.com/user-attachments/assets/235fdadc-78bb-455d-8b8e-936c36c4c800" />


This also fixes two configurations that were silently wrong before, because
`moe_config.tp_size` is flattened across DP without EP while the TP group is not:

| config | `moe.tp_size` | TP world | before | after |
|---|---|---|---|---|
| TP=8 | 8 | 8 | shards correctly | unchanged |
| TP=8 + EP | 1 | 8 | replicated (this bug) | shards correctly |
| TP=2 x DP=2 | 4 | 2 | shards by 4, covers half the hidden dim | shards correctly |
| DP=4, TP=1 | 4 | 1 | shards by 4 with no group to reduce over | replicated |


## Test Plan

`pytest tests/models/kimi_k3/test_amd_latent_moe_runner.py` on 8x MI325X.

The existing TP4/TP8 tests that assert the sharded tail equals the replicated
projection are unchanged — a wrong shard offset or a
dropped accumulation still runs and still produces plausible text. Added:

- `test_shards_under_the_kimi_k3_serving_config_with_expert_parallel` — the gate
  regression this PR fixes. Fails before the change.
- `test_sharded_tail_tp8_ep8_matches_replicated_projection` — the real
  distributed path at TP8 with an EP-shaped MoE config, so the final reduce is
  exercised rather than assumed.
- `test_shards_by_the_process_group_not_the_dp_flattened_tp_size` and a
  `dp-without-tp` fallback case for the two DP rows above.
- The `no-tp` fallback case became a genuine single-rank case, since
  `moe_config.tp_size == 1` no longer means "there is no tensor parallelism".

## Test Results

18 passed. Startup now logs the sharded-tail `info_once` and not the fallback
`warning_once`.

gsm8k on MI325X:

local-completions ({'model': 'kimi-k3', 'base_url': 'http://localhost:8000/v1/completions', 'num_concurrent': 32, 'max_retries': 10, 'max_gen_toks': 2048, 'tokenizer_backend': 'None', 'tokenized_requests': 'False'}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9598|±  |0.0054|
|     |       |strict-match    |     5|exact_match|↑  |0.9598|±  |0.0054|


**128K ISL / 1K OSL** on MI325X, TP8 + EP, before vs after:

| concurrency | TTFT | TPOT | output tok/s |
|---|---|---|---|
| 2 | −3.2% (28.92 → 28.01 s) | −5.2% (51.81 → 49.10 ms) | +4.2% |
| 4 | −2.4% (31.54 → 30.80 s) | −4.8% (100.30 → 95.53 ms) | +4.3% |
| 6 | −2.2% (30.69 → 30.00 s) | −3.8% (153.62 → 147.71 ms) | +3.8% |
| 8 | −0.8% (30.12 → 29.89 s) | −3.9% (202.74 → 194.93 ms) | +3.7% |


This PR was made with help of AI. All code was reviewed by a human, and tests run by a human.
