### PR TITLE
[Bugfix][CI] Set cudagraph_mode=FULL for the Ernie4.5-VL ViT cudagraph test

### DIFF
--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -236,6 +236,13 @@ MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
         # that changes the output token count, so video uses the eager path.
         modalities=["image"],
         image_prompt=ernie45_vl_chat_template("What is in this image?"),
+        # Ernie4_5_VLMoeModel is deliberately not torch-compiled, since its
+        # split of text and vision experts breaks compilation, so piecewise
+        # cudagraphs have nothing to partition. Only the encoder graphs this
+        # test covers are captured.
+        compilation_config_overrides={
+            "cudagraph_mode": 2,
+        },
         # Shrink to 1 text + 1 vision layer with random weights so the test
         # runs on any CI GPU and skips the ~56 GiB weight download. The test
         # only validates encoder CG capture/replay, not output quality.


### PR DESCRIPTION
Ernie4.5-VL ViT cudagraph test fails after #54782

Failing test: `test_vit_cudagraph_image[ernie45_vl]`

AMD CI: <https://buildkite.com/vllm/amd-ci/builds/12553/list?sid=01a0615a-019d-4492-a92c-a4018dfdcc8b&tab=output>

**The same group failed on both MI300 and MI355.**

## Error

```
RuntimeError: Ernie4_5_VLMoeForConditionalGeneration: piecewise CUDA graphs
(cudagraph_mode=FULL_AND_PIECEWISE) unavailable, model is not torch-compiled
and breakable CUDA graph is off. Set VLLM_USE_BREAKABLE_CUDAGRAPH=1 or
cudagraph_mode=NONE/FULL.
```

Raised in `vllm/v1/worker/gpu/cudagraph_utils.py`, during engine start.

## What exposed it

`1c26e57d3c` — [Bugfix] Raise for unavailable piecewise CUDA graphs (#54782).
It added a guard that raises when piecewise cudagraphs are requested for a
model with no active `@support_torch_compile` wrapper.

## Root cause

The guard is correct; the misconfiguration predates it. `Ernie4_5_VLMoeModel`
keeps its `@support_torch_compile` decorator commented out, since the model
was added in #22514:

```python
# Since Ernie VL distinguishes between text experts and vision experts,
# enabling torch.compile will cause errors.
# @support_torch_compile(
```

So the model is not compiled, piecewise cudagraphs have nothing to partition,
and the test asks for the default `FULL_AND_PIECEWISE`. Until #54782 this
silently captured nothing.

Not platform-specific: `VLLM_USE_BREAKABLE_CUDAGRAPH` defaults to `False`
everywhere and the test is gated on `is_cuda_alike()`, so CUDA should hit it
too.

Ernie is the only affected model in that file — `glm4_1v` and `step3_vl` pass,
and `deepseek_ocr` already pins `cudagraph_mode`.

## Fix

Pin the mode for the Ernie entry, the way `deepseek_ocr` in the same file
already does:

```python
compilation_config_overrides={
    "cudagraph_mode": 2,  # FULL
},
```

Verified on MI300X: fails in 31s before, passes in 40s after.



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

