### PR TITLE
[Bugfix] Chunk FP8 dummy weight initialization to bound peak memory

### DIFF
--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -5,6 +5,7 @@ import tempfile
 
 import huggingface_hub.constants
 import pytest
+import torch
 from huggingface_hub.utils import LocalEntryNotFoundError
 
 from vllm.model_executor.model_loader.weight_utils import (
@@ -279,6 +280,78 @@ class TestKvCacheScaleMapper:
             combined._map_name("model.layers.0.self_attn.k_scale")
             == "model.layers.0.self_attn.attn.k_scale"
         )
+
+
+class TestInitializeSingleDummyWeight:
+    """Tests for FP8 dummy weight initialization.
+
+    Regression tests for
+    https://github.com/vllm-project/vllm/issues/54712: large FP8 parameters
+    must be initialized in chunks instead of materializing fp16 temporaries
+    twice the parameter size.
+
+    The default [-1e-3, 1e-3] range is below the smallest positive FP8
+    e4m3fn value (~2e-3), so these tests pass a wider range explicitly.
+    Quantization may round values slightly outside (low, high), hence the
+    slack in the bounds assertions.
+    """
+
+    LOW, HIGH = -0.4, 0.4
+    SLACK = 0.07
+
+    def _assert_filled(self, param):
+        values = param.float()
+        assert (values >= self.LOW - self.SLACK).all()
+        assert (values <= self.HIGH + self.SLACK).all()
+        assert values.unique().numel() > 1
+
+    def test_fp8_chunked_init_in_range_and_deterministic(self, monkeypatch):
+        """Chunked path fills every element within (low, high) and is
+        reproducible for a fixed seed."""
+        import vllm.model_executor.model_loader.weight_utils as weight_utils
+
+        monkeypatch.setattr(weight_utils, "_FP8_DUMMY_INIT_CHUNK_SIZE", 512)
+        param = torch.empty(4096, dtype=torch.float8_e4m3fn)
+        weight_utils.initialize_single_dummy_weight(param, low=self.LOW, high=self.HIGH)
+        self._assert_filled(param)
+
+        param2 = torch.empty(4096, dtype=torch.float8_e4m3fn)
+        weight_utils.initialize_single_dummy_weight(
+            param2, low=self.LOW, high=self.HIGH
+        )
+        assert torch.equal(param, param2)
+
+    def test_fp8_chunked_init_covers_partial_last_chunk(self, monkeypatch):
+        """A numel that is not a multiple of the chunk size initializes the
+        tail correctly."""
+        import vllm.model_executor.model_loader.weight_utils as weight_utils
+
+        monkeypatch.setattr(weight_utils, "_FP8_DUMMY_INIT_CHUNK_SIZE", 128)
+        param = torch.empty(3, 100, dtype=torch.float8_e4m3fn)
+        assert param.numel() % 128 != 0
+        weight_utils.initialize_single_dummy_weight(param, low=self.LOW, high=self.HIGH)
+        self._assert_filled(param)
+
+    def test_fp8_non_contiguous_param_in_range(self, monkeypatch):
+        """Non-contiguous parameters fall back to the single-shot path and
+        are still initialized."""
+        import vllm.model_executor.model_loader.weight_utils as weight_utils
+
+        monkeypatch.setattr(weight_utils, "_FP8_DUMMY_INIT_CHUNK_SIZE", 4)
+        param = torch.empty(8, 3, dtype=torch.float8_e4m3fn).t()
+        assert not param.is_contiguous()
+        weight_utils.initialize_single_dummy_weight(param, low=self.LOW, high=self.HIGH)
+        self._assert_filled(param)
+
+    def test_fp8_small_param_in_range(self):
+        """Small contiguous parameters use the single-shot path unchanged."""
+        from vllm.model_executor.model_loader.weight_utils import (
+            initialize_single_dummy_weight,
+        )
+
+        param = torch.empty(16, dtype=torch.float8_e4m3fn)
+        initialize_single_dummy_weight(param, low=self.LOW, high=self.HIGH)
+        self._assert_filled(param)
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1314,6 +1314,11 @@ def initialize_dummy_weights(
         initialize_single_dummy_weight(param, low, high, seed)
 
 
+# Chunk size (in elements) for initializing large FP8 dummy weights. Keeps the
+# fp16 temporary at ~128 MiB instead of 2x the parameter size.
+_FP8_DUMMY_INIT_CHUNK_SIZE = 64 * 1024 * 1024
+
+
 @torch.no_grad()
 def initialize_single_dummy_weight(
     param: torch.Tensor,
@@ -1360,9 +1365,23 @@ def initialize_single_dummy_weight(
     if torch.finfo(param.data.dtype).bits < 16:
         # uniform_ doesn't support < 16-bit datatypes (FP8)
         dtype = param.data.dtype
-        tmp_param = param.data.to(torch.float16)
-        tmp_param = tmp_param.uniform_(low, high, generator=generator).to(dtype)
-        param.data.copy_(tmp_param)
+        if (
+            param.data.is_contiguous()
+            and param.data.numel() > _FP8_DUMMY_INIT_CHUNK_SIZE
+        ):
+            # Initialize in chunks to avoid materializing fp16 temporaries
+            # twice the parameter size, which OOMs on large FP8 tensors
+            # (e.g. fused embedding tables) under --load-format dummy.
+            flat = param.data.view(-1)
+            for start in range(0, flat.numel(), _FP8_DUMMY_INIT_CHUNK_SIZE):
+                chunk = flat[start : start + _FP8_DUMMY_INIT_CHUNK_SIZE]
+                tmp = chunk.to(torch.float16)
+                tmp = tmp.uniform_(low, high, generator=generator).to(dtype)
+                chunk.copy_(tmp)
+        else:
+            tmp_param = param.data.to(torch.float16)
+            tmp_param = tmp_param.uniform_(low, high, generator=generator).to(dtype)
+            param.data.copy_(tmp_param)
     else:
         param.uniform_(low, high, generator=generator)
 


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #54712.

`initialize_single_dummy_weight` materializes a full-size fp16 temporary (plus a same-size cast-back temporary) for sub-16-bit dtypes because `uniform_` does not support FP8. For a large FP8 parameter — e.g. the 47.7 GiB fused PLE embedding table of Qwen3.8-Flash-Next — that is ~95 GiB of scratch on top of the resident parameter, so `--load-format dummy` OOMs on any single GPU regardless of how the model is sharded. Dummy loading is the standard way to validate a parallelism/partition configuration without weight I/O, so it fails exactly where validation is most needed.

This PR initializes large contiguous parameters in fixed 64 Mi-element chunks, bounding peak scratch at ~128 MiB regardless of parameter size. Small parameters and non-contiguous parameters keep the existing single-shot path, so their generated values are unchanged. The chunked path consumes the RNG stream per chunk; values for large parameters therefore differ from the previous implementation, but remain deterministic for a fixed seed/shape/dtype, preserving the cross-process consistency contract in the `initialize_dummy_weights` docstring.

### Does this PR introduce _any_ user-facing change?

No output/accuracy change for real models. `--load-format dummy` now succeeds on large FP8 parameters that previously OOMed; dummy weight values for parameters larger than 64 Mi elements differ from prior versions (dummy values are random anyway).

### How was this patch tested?

Added 4 regression tests in `tests/model_executor/test_weight_utils.py` (`TestInitializeSingleDummyWeight`):
- chunked path fills all elements in range and is deterministic for a fixed seed
- partial last chunk is covered when numel is not a multiple of the chunk size
- non-contiguous parameters fall back to the single-shot path
- small parameters keep the single-shot path

```
.venv/bin/python -m pytest tests/model_executor/test_weight_utils.py::TestInitializeSingleDummyWeight -v
# 4 passed
```

(Note: run on a macOS CPU-only host, where a pre-existing segfault in the tests/conftest.py `cleanup_dist_env_and_memory` teardown — `torch.accelerator.memory.empty_host_cache` — kills the pytest process after each test result is reported; it reproduces on unmodified existing tests in the same file, e.g. `TestMaybeRemapKvScaleName::test_qkv_proj_k_scale`, and is unrelated to this change. Each of the 4 new tests reports PASSED.)

- `ruff check` / `ruff format` on both changed files: clean.

## AI Assistance

This PR was prepared with AI assistance; every changed line has been reviewed and tested by me.
