### PR TITLE
[Attention] Add B12X sparse MLA and DSA backends

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -139,7 +139,10 @@ Priority is **1 = highest** (tried first).
 ### b12x
 
 The optional [b12x](https://pypi.org/project/b12x/) backend supports causal
-decoder attention on NVIDIA SM120 and SM121 GPUs. Install and select it with:
+decoder attention on NVIDIA SM120 and SM121 GPUs. The `B12X` selector chooses
+dense paged attention or non-compressed sparse MLA with a DSA indexer from the
+model's attention contract; users do not select a separate sparse backend.
+Install and select it with:
 
 ```bash
 uv pip install "vllm[b12x]"

--- a/setup.py
+++ b/setup.py
@@ -1524,7 +1524,7 @@ setup(
         # only; also needs system GStreamer + libv4l (see docs).
         "deepstream": ["nvidia-deepstream-videodecode-cu13>=9.0.2"],
         "flashinfer": [],  # Kept for backwards compatibility
-        "b12x": ["b12x==1.3.0"],
+        "b12x": ["b12x==1.4.0"],
         # Optional deps for Helion kernel development
         # NOTE: When updating helion version, also update CI files:
         #   - .buildkite/test_areas/kernels.yaml

--- a/tests/v1/attention/test_b12x.py
+++ b/tests/v1/attention/test_b12x.py
@@ -12,7 +12,19 @@ from tests.v1.attention.test_attention_backends import (
     _test_backend_correctness,
 )
 from tests.v1.attention.utils import BatchSpec
-from vllm.config import ModelConfig
+from vllm.config import AttentionConfig, ModelConfig, set_current_vllm_config
+from vllm.model_executor.kernels.attention import b12x_mla_query
+from vllm.model_executor.layers.attention import mla_attention
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLAAttention,
+    _canonicalize_sparse_mla_kv_cache_dtype,
+)
+from vllm.models.deepseek_v32.attention import DeepseekV32Attention
+from vllm.models.deepseek_v32.nvidia.b12x import (
+    B12xDSAIndexer,
+    DeepseekV32B12xAttention,
+)
+from vllm.models.deepseek_v32.nvidia.model import _get_attention_cls
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.b12x import get_b12x_paged_attention
@@ -22,6 +34,18 @@ from vllm.v1.attention.backends.b12x import (
     B12xPagedAttentionImpl,
     _kv_page_size,
     _max_page_table_width,
+)
+from vllm.v1.attention.backends.mla import (
+    b12x_indexer,
+    b12x_mla_sparse,
+)
+from vllm.v1.attention.backends.mla import (
+    indexer as mla_indexer,
+)
+from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+    B12xMLASparseBackend,
+    B12xMLASparseImpl,
+    B12xMLASparseMetadata,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheLayout
@@ -39,6 +63,570 @@ def _require_b12x_paged_attention() -> None:
     paged_attention = get_b12x_paged_attention()
     if paged_attention is None or not paged_attention.is_supported():
         pytest.skip("b12x paged attention is not available.")
+
+
+class _Workspace:
+    def get_simultaneous(self, *shapes_and_dtypes):
+        return [torch.empty(shape, dtype=dtype) for shape, dtype in shapes_and_dtypes]
+
+
+def test_b12x_bf16_mla_query_uses_public_run_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    module = SimpleNamespace(run=lambda *args: calls.append(args))
+    monkeypatch.setattr(b12x_mla_query, "get_b12x_mla_query_projection", lambda: module)
+    q_nope = torch.empty((8, 2, 192), dtype=torch.bfloat16)
+    weight = torch.empty((8, 192, 512), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
+    output = torch.empty((2, 8, 576), dtype=torch.bfloat16)
+
+    b12x_mla_query._b12x_bf16_mla_query_impl(q_nope, weight, q_pe, output)
+
+    assert calls == [(q_nope, weight, q_pe, output)]
+
+
+def test_b12x_bf16_mla_query_uses_backend_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.q_pad_num_heads = None
+    layer.kv_lora_rank = 512
+    layer.qk_rope_head_dim = 64
+    layer.W_UK_T = torch.nn.Parameter(
+        torch.empty((8, 192, 512), dtype=torch.bfloat16), requires_grad=False
+    )
+    workspace = torch.empty((2, 8, 576), dtype=torch.bfloat16)
+    layer.impl = SimpleNamespace(
+        supports_fused_mla_query_output=lambda *args: True,
+        get_fused_mla_query_output=lambda *args: workspace,
+    )
+    calls = []
+    monkeypatch.setattr(
+        mla_attention, "can_implement_bf16_mla_query", lambda **kwargs: True
+    )
+
+    def run_query(*args):
+        calls.append(args)
+        return args[-1]
+
+    monkeypatch.setattr(
+        mla_attention,
+        "run_bf16_mla_query",
+        run_query,
+    )
+    q_nope = torch.empty((8, 2, 192), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
+
+    result = layer._try_fused_mla_query(q_nope, q_pe)
+
+    assert result is workspace
+    assert calls == [(q_nope, layer.W_UK_T, q_pe, workspace)]
+
+
+def test_b12x_bf16_mla_query_requires_backend_capability() -> None:
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.q_pad_num_heads = None
+    layer.impl = SimpleNamespace()
+
+    q_nope = torch.empty((8, 2, 192), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
+
+    assert layer._try_fused_mla_query(q_nope, q_pe) is None
+
+
+def test_mla_preallocates_absorbed_weights_before_dequantization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.impl = SimpleNamespace(
+        process_weights_after_loading=lambda dtype: None,
+        warmup=lambda token_counts: None,
+    )
+    layer.is_amx_bmm_enabled = False
+    layer.kv_lora_rank = 2
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 3
+    layer.v_head_dim = 4
+    layer.kv_b_proj = torch.nn.Module()
+    layer.kv_b_proj.qweight = torch.nn.Parameter(
+        torch.ones((14, 2), dtype=torch.int8), requires_grad=False
+    )
+    layer.kv_b_proj.quant_method = object()
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.dcp_q_replicate = False
+    layer.quant_config = None
+    layer.layer_name = "test"
+    dequantized = torch.arange(28.0, dtype=torch.float32).reshape(14, 2)
+    events = []
+    preallocated = []
+    preallocate = mla_attention._preallocate_absorbed_mla_weights
+
+    def track_preallocation(*args, **kwargs):
+        events.append("preallocate")
+        weights = preallocate(*args, **kwargs)
+        preallocated.extend(weights)
+        return weights
+
+    def fake_dequant(*args, **kwargs):
+        events.append("dequantize")
+        return dequantized
+
+    monkeypatch.setattr(
+        mla_attention,
+        "_preallocate_absorbed_mla_weights",
+        track_preallocation,
+    )
+    monkeypatch.setattr(mla_attention, "get_and_maybe_dequant_weights", fake_dequant)
+    monkeypatch.setattr(mla_attention, "set_default_quant_scales", lambda *a, **k: None)
+
+    with torch.no_grad():
+        layer.process_weights_after_loading(torch.float32)
+
+    assert events == ["preallocate", "dequantize"]
+    assert layer.W_UV.data_ptr() == preallocated[0].data_ptr()
+    assert layer.W_UK_T.data_ptr() == preallocated[1].data_ptr()
+    assert layer.b12x_warmup_provider is layer
+    assert "b12x_warmup_provider" not in layer._modules
+
+
+def test_b12x_selector_routes_glm_dsa_internally() -> None:
+    config = SimpleNamespace(
+        attention_config=AttentionConfig(backend="b12x"),
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(model_type="glm_moe_dsa")
+        ),
+    )
+
+    assert config.attention_config.backend == AttentionBackendEnum.B12X
+    assert AttentionBackendEnum.B12X.get_class() is B12xPagedAttentionBackend
+    assert _get_attention_cls(config) is DeepseekV32B12xAttention
+    assert DeepseekV32B12xAttention.indexer_cls is B12xDSAIndexer
+    assert B12xMLASparseBackend.get_name() == "B12X"
+
+    config.attention_config = AttentionConfig()
+    assert _get_attention_cls(config) is DeepseekV32Attention
+
+
+def test_b12x_sparse_mla_accepts_glm_dsa_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        b12x_mla_sparse,
+        "get_b12x_sparse_mla",
+        lambda: SimpleNamespace(is_supported=lambda: True),
+    )
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                model_type="glm_moe_dsa",
+                index_topk=2048,
+                kv_lora_rank=512,
+                qk_rope_head_dim=64,
+            )
+        )
+    )
+
+    with set_current_vllm_config(config):
+        reason = B12xMLASparseBackend.supports_combination(
+            head_size=576,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="fp8",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            device_capability=DeviceCapability(12, 0),
+        )
+
+    assert reason is None
+    assert B12xMLASparseBackend.get_preferred_block_size(16) == 64
+    assert (
+        _canonicalize_sparse_mla_kv_cache_dtype(B12xMLASparseBackend, "auto")
+        == "fp8_ds_mla"
+    )
+
+
+def test_b12x_dsa_uses_rank_local_physical_slots_with_dcp() -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=SimpleNamespace(index_n_heads=16)),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=2,
+            prefill_context_parallel_size=1,
+        ),
+    )
+
+    kwargs = B12xDSAIndexer.get_indexer_op_kwargs(config)
+
+    assert kwargs["output_physical_slots"] is True
+
+
+def test_b12x_sparse_mla_writes_rank_local_selected_lengths() -> None:
+    global_lengths = torch.tensor([1, 2, 3, 4, 4097], dtype=torch.int32)
+    output = torch.empty_like(global_lengths)
+
+    b12x_mla_sparse._write_rank_local_selected_lengths(
+        global_lengths,
+        output,
+        dcp_size=2,
+        dcp_rank=0,
+        interleave_size=1,
+        topk=2048,
+    )
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([1, 1, 2, 2, 2048], dtype=torch.int32),
+    )
+
+
+def test_b12x_sparse_mla_replans_for_bound_page_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    planned = []
+
+    class FakeCaps(SimpleNamespace):
+        pass
+
+    class FakeModule:
+        Caps = FakeCaps
+
+        @staticmethod
+        def plan(caps):
+            planned.append(caps)
+            return SimpleNamespace(caps=caps, layout=SimpleNamespace(nbytes=96))
+
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._module = FakeModule
+    impl._kernel_page_size = 0
+    impl._input_num_heads = 8
+    impl._max_tokens = 16
+    impl._max_seqs = 4
+    impl._topk_tokens = 2048
+    impl._kv_dtype = torch.uint8
+    impl._q_head_dim = 576
+    impl.kv_lora_rank = 512
+    impl.scale = 576**-0.5
+    impl.need_to_return_lse_for_decode = False
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 0)
+
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.impl = impl
+    layer._vllm_config = SimpleNamespace(
+        kernel_config=SimpleNamespace(enable_jit_warmup=False)
+    )
+    layer.bind_kv_cache(torch.empty((2, 1, 128, 656), dtype=torch.uint8))
+
+    assert impl._kernel_page_size == 128
+    assert layer.kv_cache.shape == (2, 128, 656)
+    assert [(caps.mode, caps.page_size) for caps in planned] == [
+        ("decode", 128),
+        ("extend", 128),
+    ]
+    assert B12xMLASparseBackend.supported_kv_cache_layouts() == (KVCacheLayout.BLHNC,)
+
+
+def test_b12x_sparse_mla_dcp_uses_local_selection_and_returns_lse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {}
+    physical_indices = torch.zeros((2, 4), dtype=torch.int32)
+    active_counts = torch.tensor([2, 3], dtype=torch.int32)
+    expected_output = torch.empty((2, 4, 512))
+    expected_lse = torch.empty((2, 4))
+
+    def bind(plan, **kwargs):
+        calls["bind"] = kwargs
+        return object()
+
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._decode_plan = object()
+    impl._extend_plan = object()
+    impl._scratch_nbytes = 64
+    impl._q_spec = ((2, 4, 576), torch.bfloat16)
+    impl._scratch_spec = ((64,), torch.uint8)
+    impl._max_tokens = 2
+    impl._input_num_heads = 4
+    impl._q_head_dim = 576
+    impl._topk_tokens = 4
+    impl.topk_indices_buffer = physical_indices
+    impl.dcp_world_size = 2
+    impl._kernel_page_size = 64
+    impl.kv_lora_rank = 512
+    impl.scale = 576**-0.5
+    impl.need_to_return_lse_for_decode = True
+    impl._bind = bind
+    impl._run = lambda binding: (expected_output, expected_lse)
+
+    monkeypatch.setattr(
+        b12x_mla_sparse, "current_workspace_manager", lambda: _Workspace()
+    )
+    metadata = SimpleNamespace(
+        max_query_len=1,
+        num_reqs=2,
+        num_prefills=0,
+        num_decode_tokens=2,
+        seq_lens=torch.tensor([64, 64], dtype=torch.int32),
+        req_id_per_token=torch.tensor([0, 1], dtype=torch.int32),
+        block_table=torch.zeros((2, 1), dtype=torch.int32),
+        block_size=64,
+        cp_kv_cache_interleave_size=1,
+        cache_seq_lens_per_token=active_counts,
+    )
+
+    output, lse = impl.forward_mqa(
+        (
+            torch.empty((2, 4, 576), dtype=torch.bfloat16),
+            torch.empty((2, 4, 0), dtype=torch.bfloat16),
+        ),
+        torch.empty((2, 64, 656), dtype=torch.uint8),
+        metadata,
+        SimpleNamespace(),
+    )
+
+    assert calls["bind"]["selected_indices"].data_ptr() == physical_indices.data_ptr()
+    assert calls["bind"]["selected_lengths"].data_ptr() == active_counts.data_ptr()
+    assert output is expected_output
+    assert lse is expected_lse
+
+
+def test_b12x_dsa_indexer_writes_to_caller_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {}
+
+    binding = object()
+
+    def bind(plan, **kwargs):
+        calls["plan"] = plan
+        calls["bind"] = kwargs
+        return binding
+
+    plan = SimpleNamespace(shapes_and_dtypes=lambda: (((64,), torch.uint8),))
+
+    def run(actual_binding):
+        calls["run"] = actual_binding
+        calls["bind"]["output_indices"].fill_(11)
+
+    module = SimpleNamespace(
+        PAGED_INDEX_PAGE_SIZE=64,
+        bind=bind,
+        run=run,
+    )
+    monkeypatch.setattr(b12x_indexer, "current_workspace_manager", _Workspace)
+
+    output = torch.empty((3, 4), dtype=torch.int32)
+    b12x_indexer._run_paged_topk(
+        module=module,
+        plan=plan,
+        q=torch.empty((3, 16, 128), dtype=torch.float8_e4m3fn),
+        weights=torch.empty((3, 16), dtype=torch.float32),
+        kv_cache=torch.empty((4, 64, 132), dtype=torch.uint8),
+        seq_lens=torch.full((3,), 128, dtype=torch.int32),
+        block_table=torch.zeros((3, 2), dtype=torch.int32),
+        active_width=torch.tensor([128], dtype=torch.int32),
+        output=output,
+    )
+
+    assert calls["plan"] is plan
+    assert calls["bind"]["output_indices"] is output
+    assert calls["run"] is binding
+    assert torch.count_nonzero(output != 11) == 0
+
+
+def test_b12x_dsa_indexer_owns_prefill_width_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = SimpleNamespace(
+        Caps=lambda **kwargs: SimpleNamespace(**kwargs),
+        plan=lambda caps: SimpleNamespace(caps=caps),
+    )
+    monkeypatch.setattr(b12x_indexer, "_require_b12x_indexer", lambda: module)
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=8,
+            max_num_seqs=8,
+        ),
+        compilation_config=SimpleNamespace(cudagraph_capture_sizes=[1, 2, 4, 8]),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            cp_kv_cache_interleave_size=1,
+        ),
+    )
+
+    with set_current_vllm_config(config):
+        indexer = b12x_indexer.B12xSparseIndexer(
+            k_cache=object(),
+            quant_block_size=128,
+            scale_fmt="ue8m0",
+            topk_tokens=4,
+            head_dim=128,
+            max_model_len=4096,
+            max_total_seq_len=4096,
+            topk_indices_buffer=torch.empty((8, 4), dtype=torch.int32),
+            skip_k_cache_insert=True,
+            num_q_heads=16,
+            output_physical_slots=True,
+        )
+
+    torch.testing.assert_close(
+        indexer.active_width_cap,
+        torch.tensor([4096], dtype=torch.int32),
+    )
+    assert all(
+        plan.caps.output_index_space == "physical"
+        for plan in indexer._decode_plans.values()
+    )
+    assert indexer._decode_plans[8].caps.max_q_rows == 8
+    assert max(indexer._prefill_plans) == 8
+    assert indexer.b12x_warmup_provider is indexer
+    assert "b12x_warmup_provider" not in indexer._modules
+
+
+def test_b12x_metadata_builder_uses_backend_prefill_chunking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = object.__new__(b12x_indexer.B12xIndexerMetadataBuilder)
+    builder.compress_ratio = 1
+    builder.use_pcp = False
+    builder.max_prefill_buffer_size = 1024
+    builder.dcp_rank = 0
+    builder.dcp_world_size = 1
+    builder.cp_kv_cache_interleave_size = 1
+    builder.decode_threshold = 1
+    builder.use_flattening = False
+    builder.supports_varlen = False
+    builder.active_width_buffer = torch.zeros((1,), dtype=torch.int32)
+    builder.cache_seq_lens_per_token_buffer = torch.empty((2,), dtype=torch.int32)
+
+    monkeypatch.setattr(
+        mla_indexer,
+        "split_decodes_and_prefills",
+        lambda *args, **kwargs: (0, 2, 0, 2),
+    )
+    chunk_requests = []
+
+    def build_chunk(start_idx, end_idx, *args, **kwargs):
+        chunk_requests.append((start_idx, end_idx))
+        return SimpleNamespace()
+
+    monkeypatch.setattr(mla_indexer, "build_prefill_chunk_metadata", build_chunk)
+    common = SimpleNamespace(
+        num_reqs=2,
+        num_actual_tokens=2,
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([32, 64], dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([32, 64], dtype=torch.int32),
+        slot_mapping=torch.tensor([0, 1], dtype=torch.int64),
+        block_table_tensor=torch.zeros((2, 2), dtype=torch.int32),
+        dcp_local_seq_lens=None,
+        max_seq_len=64,
+        positions=torch.tensor([0, 0], dtype=torch.int64),
+    )
+
+    metadata = builder.build(common_prefix_len=0, common_attn_metadata=common)
+
+    assert chunk_requests == [(0, 1), (1, 2)]
+    assert metadata.prefill is not None
+    assert len(metadata.prefill.chunks) == 2
+
+
+def test_b12x_sparse_mla_prefill_binds_request_sequence_lengths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {}
+
+    def bind(plan, **kwargs):
+        calls["plan"] = plan
+        calls["bind"] = kwargs
+        return object()
+
+    plan = SimpleNamespace(
+        shapes_and_dtypes=lambda: (((64,), torch.uint8),),
+    )
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._decode_plan = object()
+    impl._extend_plan = plan
+    impl._scratch_nbytes = 64
+    impl._q_spec = ((8, 2, 576), torch.bfloat16)
+    impl._scratch_spec = ((64,), torch.uint8)
+    impl._max_tokens = 8
+    impl._input_num_heads = 2
+    impl._q_head_dim = 576
+    impl._topk_tokens = 4
+    impl.topk_indices_buffer = torch.zeros((8, 4), dtype=torch.int32)
+    impl.dcp_world_size = 1
+    impl._kernel_page_size = 64
+    impl.kv_lora_rank = 512
+    impl.scale = 576**-0.5
+    impl.need_to_return_lse_for_decode = False
+    impl._bind = bind
+    impl._run = lambda binding: torch.empty((8, 2, 512))
+
+    monkeypatch.setattr(
+        b12x_mla_sparse, "current_workspace_manager", lambda: _Workspace()
+    )
+    metadata = SimpleNamespace(
+        max_query_len=8,
+        num_reqs=1,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        req_id_per_token=torch.zeros(8, dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        block_size=64,
+        cp_kv_cache_interleave_size=1,
+        cache_seq_lens_per_token=torch.arange(1, 9, dtype=torch.int32),
+    )
+    q = torch.empty((8, 2, 576), dtype=torch.bfloat16)
+    kv_cache = torch.empty((1, 64, 576), dtype=torch.uint8)
+
+    impl.forward_mqa(q, kv_cache, metadata, SimpleNamespace())
+
+    assert calls["plan"] is plan
+    torch.testing.assert_close(calls["bind"]["cache_lengths"], metadata.seq_lens)
+    assert calls["bind"]["cache_lengths"].shape == (1,)
+    assert (
+        calls["bind"]["selected_indices"].data_ptr()
+        == impl.topk_indices_buffer.data_ptr()
+    )
+    assert (
+        calls["bind"]["selected_lengths"].data_ptr()
+        == metadata.cache_seq_lens_per_token.data_ptr()
+    )
+
+
+def test_b12x_sparse_mla_metadata_defers_per_token_lengths() -> None:
+    metadata = B12xMLASparseMetadata(
+        num_reqs=1,
+        max_query_len=1,
+        max_seq_len=1,
+        num_actual_tokens=1,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        slot_mapping=torch.tensor([0], dtype=torch.int64),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        req_id_per_token=torch.tensor([0], dtype=torch.int32),
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        num_decodes=1,
+        num_prefills=0,
+        num_decode_tokens=1,
+    )
+
+    metadata.cache_seq_lens_per_token = torch.tensor([1], dtype=torch.int32)
+
+    torch.testing.assert_close(
+        metadata.cache_seq_lens_per_token,
+        torch.tensor([1], dtype=torch.int32),
+    )
 
 
 def _causal_mask(

--- a/vllm/model_executor/kernels/attention/b12x_mla_query.py
+++ b/vllm/model_executor/kernels/attention/b12x_mla_query.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""B12X BF16 MLA query projection and assembly."""
+
+from collections.abc import Iterable
+
+import torch
+
+from vllm.utils.b12x import get_b12x_mla_query_projection
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def can_implement_bf16_mla_query(
+    *,
+    num_heads: int,
+    max_m: int,
+    nope_dim: int,
+    latent_dim: int,
+    output_dtype: torch.dtype,
+    device: torch.device,
+) -> bool:
+    module = get_b12x_mla_query_projection()
+    return bool(
+        module is not None
+        and module.can_implement(
+            num_heads=num_heads,
+            max_m=max_m,
+            nope_dim=nope_dim,
+            latent_dim=latent_dim,
+            output_dtype=output_dtype,
+            weight_format="bf16",
+            device=device,
+        )
+    )
+
+
+def _b12x_bf16_mla_query_impl(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    module = get_b12x_mla_query_projection()
+    if module is None:
+        raise ImportError("b12x.gemm.mla_query_projection is not available")
+    module.run(q_nope, weight, q_pe, output)
+
+
+def _b12x_bf16_mla_query_fake(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    del q_nope, weight, q_pe, output
+
+
+direct_register_custom_op(
+    op_name="b12x_bf16_mla_query",
+    op_func=_b12x_bf16_mla_query_impl,
+    mutates_args=["output"],
+    fake_impl=_b12x_bf16_mla_query_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+def run_bf16_mla_query(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    torch.ops.vllm.b12x_bf16_mla_query(q_nope, weight, q_pe, output)
+    return output
+
+
+def prewarm_bf16_mla_query(
+    weight: torch.Tensor,
+    m_values: Iterable[int],
+    *,
+    output_dtype: torch.dtype = torch.bfloat16,
+) -> int:
+    module = get_b12x_mla_query_projection()
+    if module is None:
+        return 0
+    return int(module.prewarm(weight, m_values, output_dtype=output_dtype))
+
+
+__all__ = [
+    "can_implement_bf16_mla_query",
+    "prewarm_bf16_mla_query",
+    "run_bf16_mla_query",
+]

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -233,6 +233,11 @@ from vllm.distributed.parallel_state import (
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.kernels.attention.b12x_mla_query import (
+    can_implement_bf16_mla_query,
+    prewarm_bf16_mla_query,
+    run_bf16_mla_query,
+)
 from vllm.model_executor.layers.attention.attention import (
     _init_kv_cache_quant,
     get_attention_context,
@@ -259,6 +264,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
+from vllm.utils.b12x import B12xWarmupUnit
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.math_utils import cdiv, round_down, round_up
 from vllm.utils.torch_utils import (
@@ -310,6 +316,68 @@ logger = init_logger(__name__)
 _FP8_DTYPE = current_platform.fp8_dtype()
 
 
+def _find_linear_weight_device(layer: torch.nn.Module) -> torch.device | None:
+    while hasattr(layer, "base_layer") and hasattr(layer.base_layer, "quant_method"):
+        layer = layer.base_layer
+
+    for name in ("weight", "qweight", "weight_packed"):
+        weight = getattr(layer, name, None)
+        if isinstance(weight, torch.Tensor):
+            return weight.device
+    for parameter in layer.parameters(recurse=False):
+        return parameter.device
+    for buffer in layer.buffers(recurse=False):
+        return buffer.device
+    return None
+
+
+def _preallocate_absorbed_mla_weights(
+    layer: "MLAAttention", act_dtype: torch.dtype
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    num_heads = getattr(layer, "num_local_heads", layer.num_heads)
+    w_uv_shape = (num_heads, layer.kv_lora_rank, layer.v_head_dim)
+    w_uk_t_shape = (
+        num_heads,
+        layer.qk_nope_head_dim,
+        layer.kv_lora_rank,
+    )
+    current_w_uv = getattr(layer, "W_UV", None)
+    current_w_uk_t = getattr(layer, "W_UK_T", None)
+
+    device = _find_linear_weight_device(layer.kv_b_proj)
+    if device is None:
+        current_devices = {
+            weight.device
+            for weight in (current_w_uv, current_w_uk_t)
+            if isinstance(weight, torch.Tensor)
+        }
+        if len(current_devices) != 1:
+            raise RuntimeError(
+                "Cannot determine the device for absorbed MLA projection weights."
+            )
+        device = current_devices.pop()
+
+    def needs_storage(weight: object, shape: tuple[int, ...]) -> bool:
+        return not (
+            isinstance(weight, torch.Tensor)
+            and weight.shape == shape
+            and weight.dtype == act_dtype
+            and weight.device == device
+        )
+
+    pre_w_uv = (
+        torch.empty(w_uv_shape, dtype=act_dtype, device=device)
+        if needs_storage(current_w_uv, w_uv_shape)
+        else None
+    )
+    pre_w_uk_t = (
+        torch.empty(w_uk_t_shape, dtype=act_dtype, device=device)
+        if needs_storage(current_w_uk_t, w_uk_t_shape)
+        else None
+    )
+    return pre_w_uv, pre_w_uk_t
+
+
 def _detect_output_quant_key(
     output: torch.Tensor,
     output_scale: torch.Tensor | None,
@@ -358,6 +426,12 @@ def _canonicalize_sparse_mla_kv_cache_dtype(
             return kv_cache_dtype
         return "fp8_ds_mla"
     if backend_name == "FLASHINFER_MLA_SPARSE_SM120" and kv_cache_dtype in (
+        "auto",
+        "fp8",
+        "fp8_e4m3",
+    ):
+        return "fp8_ds_mla"
+    if backend_name == "B12X" and kv_cache_dtype in (
         "auto",
         "fp8",
         "fp8_e4m3",
@@ -689,6 +763,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
     def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
         # [B, H=1, N, C] -> [B, N, C]
         self.kv_cache = kv_cache.squeeze(1)
+        bind_impl = getattr(self.impl, "bind_kv_cache", None)
+        if bind_impl is not None:
+            bind_impl(self.kv_cache)
         if (
             self._vllm_config.kernel_config.enable_jit_warmup
             and self.attn_backend.get_name()
@@ -797,6 +874,44 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 q_dcp_replicated=q_dcp_replicated,
             )
             return output
+
+    def _try_fused_mla_query(
+        self,
+        q_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if self.is_aiter_triton_fp4_bmm_enabled or self.is_aiter_triton_fp8_bmm_enabled:
+            return None
+        if self.q_pad_num_heads is not None:
+            return None
+
+        num_heads, num_tokens, nope_dim = q_nope.shape
+        supports_output = getattr(self.impl, "supports_fused_mla_query_output", None)
+        if not callable(supports_output) or not supports_output(
+            num_heads, torch.bfloat16
+        ):
+            return None
+        workspace_getter = getattr(self.impl, "get_fused_mla_query_output", None)
+        if not callable(workspace_getter):
+            return None
+
+        weight = getattr(self, "W_UK_T", None)
+        if not isinstance(weight, torch.Tensor) or weight.dtype != torch.bfloat16:
+            return None
+        if not can_implement_bf16_mla_query(
+            num_heads=num_heads,
+            max_m=num_tokens,
+            nope_dim=nope_dim,
+            latent_dim=self.kv_lora_rank,
+            output_dtype=torch.bfloat16,
+            device=q_nope.device,
+        ):
+            return None
+
+        output = workspace_getter(num_tokens, num_heads, torch.bfloat16)
+        if output is None:
+            return None
+        return run_bf16_mla_query(q_nope, weight, q_pe, output)
 
     def forward_impl(
         self,
@@ -950,7 +1065,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 mqa_pe_padded.copy_(mqa_q_pe)
                 mqa_q_pe = mqa_pe_padded
 
-            if self.is_aiter_triton_fp4_bmm_enabled:
+            fused_mqa_q = None
+            if not qrep_decode:
+                fused_mqa_q = self._try_fused_mla_query(mqa_q_nope, mqa_q_pe)
+
+            if fused_mqa_q is not None:
+                mqa_q = fused_mqa_q
+            elif self.is_aiter_triton_fp4_bmm_enabled:
                 from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
 
                 mqa_ql_nope = batched_gemm_a16wfp4(
@@ -1003,14 +1124,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 # Convert from (N, B, L) to (B, N, L)
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
 
-            if fp8_attention and self.impl.supports_quant_query_input:
-                assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
-                assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
-                mqa_q = self._decode_concat_quant_fp8_op(
-                    mqa_ql_nope, mqa_q_pe, self._q_scale
-                )
-            else:
-                mqa_q = (mqa_ql_nope, mqa_q_pe)
+            if fused_mqa_q is None:
+                if fp8_attention and self.impl.supports_quant_query_input:
+                    assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
+                    assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
+                    mqa_q = self._decode_concat_quant_fp8_op(
+                        mqa_ql_nope, mqa_q_pe, self._q_scale
+                    )
+                else:
+                    mqa_q = (mqa_ql_nope, mqa_q_pe)
             # concatenate nope + pe -> (B, N, L + P) (fp8 op above may have fused)
             if self.impl.dcp_world_size > 1:
                 assert self.dcp_manager is not None
@@ -1144,6 +1266,12 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
             return
 
+        pre_w_uv = pre_w_uk_t = None
+        if not (
+            self.is_aiter_triton_fp4_bmm_enabled or self.is_aiter_triton_fp8_bmm_enabled
+        ):
+            pre_w_uv, pre_w_uk_t = _preallocate_absorbed_mla_weights(self, act_dtype)
+
         # we currently do not have quantized bmm's which are needed for
         # `W_UV` and `W_UK_T`, we just store fp16/bf16 copies and perform
         # the bmm's in 16-bit, the extra memory overhead of this is fairly low
@@ -1243,9 +1371,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
         else:
             # Convert from (L, N, V) to (N, L, V)
-            replace_parameter(self, "W_UV", W_UV.transpose(0, 1), prefer_copy=True)
+            w_uv = W_UV.transpose(0, 1)
+            if pre_w_uv is not None:
+                pre_w_uv.copy_(w_uv)
+                w_uv = pre_w_uv
+            replace_parameter(self, "W_UV", w_uv, prefer_copy=True)
             # Convert from (L, N, P) to (N, P, L)
-            replace_parameter(self, "W_UK_T", W_UK.permute(1, 2, 0), prefer_copy=True)
+            w_uk_t = W_UK.permute(1, 2, 0)
+            if pre_w_uk_t is not None:
+                pre_w_uk_t.copy_(w_uk_t)
+                w_uk_t = pre_w_uk_t
+            replace_parameter(self, "W_UK_T", w_uk_t, prefer_copy=True)
             if self.dcp_q_replicate:
                 self.W_UK_T_dcp_qrep = get_dcp_group().all_gather(
                     self.W_UK_T.contiguous(), dim=0
@@ -1261,6 +1397,77 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         )
         if not should_load_quant_weights(quant_method):
             set_default_quant_scales(self, register_buffer=False)
+
+        weight = getattr(self, "W_UK_T", None)
+        impl_warmup = getattr(self.impl, "warmup", None)
+        supports_output = getattr(self.impl, "supports_fused_mla_query_output", None)
+        supports_fused_query = (
+            isinstance(weight, torch.Tensor)
+            and callable(supports_output)
+            and supports_output(int(weight.shape[0]), torch.bfloat16)
+        )
+        if (
+            isinstance(weight, torch.Tensor)
+            and supports_fused_query
+            and weight.dtype == torch.bfloat16
+            and can_implement_bf16_mla_query(
+                num_heads=int(weight.shape[0]),
+                max_m=1,
+                nope_dim=int(weight.shape[1]),
+                latent_dim=int(weight.shape[2]),
+                output_dtype=torch.bfloat16,
+                device=weight.device,
+            )
+        ) or callable(impl_warmup):
+            object.__setattr__(self, "b12x_warmup_provider", self)
+
+    def get_b12x_warmup_unit(
+        self,
+        layer: torch.nn.Module,
+        token_counts: tuple[int, ...],
+        output_dtype: torch.dtype,
+    ) -> B12xWarmupUnit:
+        del layer, output_dtype
+        weight = getattr(self, "W_UK_T", None)
+        fused_query_rows = tuple(rows for rows in token_counts if 0 < rows <= 32)
+        impl_warmup = getattr(self.impl, "warmup", None)
+        impl_key_getter = getattr(self.impl, "b12x_warmup_key", None)
+        impl_key = impl_key_getter() if callable(impl_key_getter) else None
+        supports_output = getattr(self.impl, "supports_fused_mla_query_output", None)
+        supports_fused_query = (
+            isinstance(weight, torch.Tensor)
+            and callable(supports_output)
+            and supports_output(int(weight.shape[0]), torch.bfloat16)
+        )
+
+        def compile() -> None:
+            if (
+                isinstance(weight, torch.Tensor)
+                and supports_fused_query
+                and fused_query_rows
+                and can_implement_bf16_mla_query(
+                    num_heads=int(weight.shape[0]),
+                    max_m=max(fused_query_rows),
+                    nope_dim=int(weight.shape[1]),
+                    latent_dim=int(weight.shape[2]),
+                    output_dtype=torch.bfloat16,
+                    device=weight.device,
+                )
+            ):
+                prewarm_bf16_mla_query(weight, fused_query_rows)
+            if callable(impl_warmup):
+                impl_warmup(token_counts)
+
+        weight_key = (
+            (tuple(weight.shape), weight.dtype, weight.device)
+            if isinstance(weight, torch.Tensor) and supports_fused_query
+            else None
+        )
+        return B12xWarmupUnit(
+            name="MLA",
+            key=(type(self), weight_key, impl_key),
+            compile=compile,
+        )
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 import torch.nn as nn
@@ -46,6 +46,12 @@ if TYPE_CHECKING:
 
 class DeepseekV32Indexer(nn.Module):
     indexer_cache_cls = DeepseekV32IndexerCache
+    indexer_op_cls = SparseAttnIndexer
+
+    @staticmethod
+    def get_indexer_op_kwargs(vllm_config: VllmConfig) -> dict[str, Any]:
+        del vllm_config
+        return {}
 
     def __init__(
         self,
@@ -103,7 +109,7 @@ class DeepseekV32Indexer(nn.Module):
         )
 
         self.max_total_seq_len = get_max_prefill_buffer_size(vllm_config)
-        self.indexer_op = SparseAttnIndexer(
+        self.indexer_op = type(self).indexer_op_cls(
             self.k_cache,
             self.quant_block_size,
             self.scale_fmt,
@@ -112,6 +118,48 @@ class DeepseekV32Indexer(nn.Module):
             self.max_model_len,
             self.max_total_seq_len,
             self.topk_indices_buffer,
+            **type(self).get_indexer_op_kwargs(vllm_config),
+        )
+
+    def run_indexer(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor | None,
+        weights: torch.Tensor,
+        *,
+        use_pcp: bool,
+        dense_mha_metadata_layer_name: str,
+        dcp_rank: int,
+        dcp_world_size: int,
+        cp_kv_cache_interleave_size: int,
+    ) -> torch.Tensor:
+        if not isinstance(q_quant, torch.Tensor):
+            q_values, q_scale = q_quant
+        else:
+            q_values, q_scale = q_quant, None
+        return sparse_attn_indexer(
+            hidden_states,
+            self.k_cache.prefix,
+            self.k_cache.kv_cache,
+            q_values,
+            q_scale,
+            k,
+            weights,
+            self.quant_block_size,
+            self.scale_fmt,
+            self.topk_tokens,
+            self.head_dim,
+            self.max_model_len,
+            self.max_total_seq_len,
+            self.topk_indices_buffer,
+            skip_k_cache_insert=not use_pcp,
+            use_pcp=use_pcp,
+            dense_mha_metadata_layer_name=dense_mha_metadata_layer_name,
+            dcp_rank=dcp_rank,
+            dcp_world_size=dcp_world_size,
+            cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+            skip_topk_buffer_clear=True,
         )
 
 
@@ -428,22 +476,11 @@ class DeepseekV32Attention(MLAAttention):
             assert index_weights_out is not None
             if self.use_pcp:
                 assert index_k is not None
-            sparse_attn_indexer(
+            self.indexer.run_indexer(
                 q_c,
-                self.indexer.k_cache.prefix,
-                self.indexer.k_cache.kv_cache,
                 index_q_fp8,
-                None,
                 index_k,
                 index_weights_out,
-                self.indexer.quant_block_size,
-                self.indexer.scale_fmt,
-                self.indexer.topk_tokens,
-                self.indexer.head_dim,
-                self.indexer.max_model_len,
-                self.indexer.max_total_seq_len,
-                self.topk_indices_buffer,
-                skip_k_cache_insert=not self.use_pcp,
                 use_pcp=self.use_pcp,
                 dense_mha_metadata_layer_name=self._dense_mha_metadata_layer_name,
                 dcp_rank=(
@@ -457,7 +494,6 @@ class DeepseekV32Attention(MLAAttention):
                 cp_kv_cache_interleave_size=(
                     self._vllm_config.parallel_config.cp_kv_cache_interleave_size
                 ),
-                skip_topk_buffer_clear=True,
             )
 
         attn_metadata, _, kv_cache, layer_slot_mapping = get_attention_context(

--- a/vllm/models/deepseek_v32/nvidia/b12x.py
+++ b/vllm/models/deepseek_v32/nvidia/b12x.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""B12x sparse-MLA components for DSA models on NVIDIA GPUs."""
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.models.deepseek_v32.attention import (
+    DeepseekV32Attention,
+    DeepseekV32Indexer,
+)
+from vllm.v1.attention.backends.mla.b12x_indexer import (
+    B12xIndexerCache,
+    B12xSparseIndexer,
+)
+from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseBackend
+
+
+class B12xDSAIndexer(DeepseekV32Indexer):
+    indexer_cache_cls = B12xIndexerCache
+    indexer_op_cls = B12xSparseIndexer
+
+    @staticmethod
+    def get_indexer_op_kwargs(vllm_config: VllmConfig) -> dict[str, int | bool]:
+        if vllm_config.parallel_config.prefill_context_parallel_size > 1:
+            raise NotImplementedError("B12X sparse MLA does not support PCP.")
+        return {
+            "skip_k_cache_insert": True,
+            "num_q_heads": int(vllm_config.model_config.hf_text_config.index_n_heads),
+            # DCP selects from each rank's local KV shard. MLA combines the
+            # rank-local attention states using their LSE values.
+            "output_physical_slots": True,
+        }
+
+    def run_indexer(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor | None,
+        weights: torch.Tensor,
+        *,
+        use_pcp: bool,
+        dense_mha_metadata_layer_name: str,
+        dcp_rank: int,
+        dcp_world_size: int,
+        cp_kv_cache_interleave_size: int,
+    ) -> torch.Tensor:
+        del (
+            use_pcp,
+            dense_mha_metadata_layer_name,
+            dcp_rank,
+            dcp_world_size,
+            cp_kv_cache_interleave_size,
+        )
+        return self.indexer_op(hidden_states, q_quant, k, weights)
+
+
+class DeepseekV32B12xAttention(DeepseekV32Attention):
+    indexer_cls = B12xDSAIndexer
+
+    def __init__(self, vllm_config, config, prefix, topk_indices_buffer=None):
+        super().__init__(
+            vllm_config,
+            config,
+            prefix,
+            topk_indices_buffer,
+            attn_backend=B12xMLASparseBackend,
+        )
+
+
+__all__ = ["B12xDSAIndexer", "DeepseekV32B12xAttention"]

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -46,8 +46,18 @@ from vllm.models.common.ops.sequence_parallel import (
 )
 from vllm.models.deepseek_v32.attention import DeepseekV32Attention
 from vllm.sequence import IntermediateTensors
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
+from .b12x import DeepseekV32B12xAttention
 from .glm52_low_latency_gemm import enable_glm52_low_latency_gemm
+
+
+def _get_attention_cls(
+    vllm_config: VllmConfig,
+) -> type[DeepseekV32Attention]:
+    if vllm_config.attention_config.backend == AttentionBackendEnum.B12X:
+        return DeepseekV32B12xAttention
+    return DeepseekV32Attention
 
 
 class DeepseekV32DecoderLayer(torch.nn.Module):
@@ -75,7 +85,7 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
             and parallel_config.pipeline_parallel_size == 1
         )
 
-        self.self_attn = DeepseekV32Attention(
+        self.self_attn = _get_attention_cls(vllm_config)(
             vllm_config=vllm_config,
             config=config,
             prefix=f"{prefix}.self_attn",

--- a/vllm/utils/b12x.py
+++ b/vllm/utils/b12x.py
@@ -35,6 +35,9 @@ _B12X_SUBMODULES = {
     module_name: _import_submodule(module_name)
     for module_name in (
         "b12x.attention.paged",
+        "b12x.attention.sparse_mla",
+        "b12x.attention.dsa_indexer",
+        "b12x.gemm.mla_query_projection",
         "b12x.gemm.blockscaled",
         # TODO: Remove once B12X exposes the scale-swizzle API publicly.
         "b12x._lib.intrinsics",
@@ -56,6 +59,18 @@ def _get_submodule(module_name: str) -> ModuleType | None:
 
 def get_b12x_blockscaled() -> ModuleType | None:
     return _get_submodule("b12x.gemm.blockscaled")
+
+
+def get_b12x_sparse_mla() -> ModuleType | None:
+    return _get_submodule("b12x.attention.sparse_mla")
+
+
+def get_b12x_dsa_indexer() -> ModuleType | None:
+    return _get_submodule("b12x.attention.dsa_indexer")
+
+
+def get_b12x_mla_query_projection() -> ModuleType | None:
+    return _get_submodule("b12x.gemm.mla_query_projection")
 
 
 def get_b12x_intrinsics() -> ModuleType | None:

--- a/vllm/v1/attention/backends/mla/b12x_indexer.py
+++ b/vllm/v1/attention/backends/mla/b12x_indexer.py
@@ -1,0 +1,502 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""B12x DSA indexer for non-compressed sparse MLA models."""
+
+import bisect
+import os
+from dataclasses import dataclass
+from typing import Any, cast
+
+import torch
+from torch import nn
+
+import vllm.envs as envs
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+from vllm.utils.b12x import B12xWarmupUnit, get_b12x_dsa_indexer
+from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerBackend,
+    DeepSeekV32IndexerDecodeMetadata,
+    DeepseekV32IndexerMetadata,
+    DeepseekV32IndexerMetadataBuilder,
+    split_indexer_prefill_chunks,
+)
+from vllm.v1.kv_cache_interface import KVCacheSpec
+from vllm.v1.worker.workspace import current_workspace_manager
+
+_INDEX_HEAD_DIM = 128
+_INDEX_SCALE_BYTES = 4
+_INDEX_PAGE_SIZE = 64
+_INDEX_PAGE_WIDTH = _INDEX_PAGE_SIZE * (_INDEX_HEAD_DIM + _INDEX_SCALE_BYTES)
+_PREFILL_PROFILE_SUPERTILE_K = 32 * 1024
+
+
+def _prefill_profile_q_rows(max_q_rows: int) -> int:
+    max_logits_elems = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024 // 4
+    supertile_k = int(
+        os.environ.get("B12X_PAGED_INDEX_SUPERTILE_K", _PREFILL_PROFILE_SUPERTILE_K)
+    )
+    supertile_k = max(supertile_k, 256)
+    return min(max(int(max_q_rows), 1), max(1, max_logits_elems // supertile_k))
+
+
+def _is_current_stream_capturing(tensor: torch.Tensor) -> bool:
+    return tensor.is_cuda and torch.cuda.is_current_stream_capturing()
+
+
+@dataclass
+class B12xIndexerDecodeMetadata(DeepSeekV32IndexerDecodeMetadata):
+    active_width: torch.Tensor | None = None
+
+
+class B12xIndexerMetadataBuilder(DeepseekV32IndexerMetadataBuilder):
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: KVCacheSpec,
+    ) -> AttentionCGSupport:
+        return AttentionCGSupport.ALWAYS
+
+    def __init__(self, *args, block_table_width: int, **kwargs) -> None:
+        super().__init__(*args, block_table_width=block_table_width, **kwargs)
+        self.use_flattening = False
+        self.supports_varlen = False
+        self.active_width_buffer = torch.zeros(
+            (1,), dtype=torch.int32, device=self.device
+        )
+
+    def _supports_native_decode(self, next_n: int) -> bool:
+        return True
+
+    def _split_prefill_chunks(
+        self,
+        compressed_seq_lens_cpu: torch.Tensor,
+        prefill_query_lens_cpu: torch.Tensor,
+        num_decodes: int,
+        max_logits_bytes: int,
+    ) -> list[tuple[slice, slice]]:
+        return [
+            chunk
+            for prefill_idx in range(len(prefill_query_lens_cpu))
+            for chunk in split_indexer_prefill_chunks(
+                compressed_seq_lens_cpu[
+                    num_decodes + prefill_idx : num_decodes + prefill_idx + 1
+                ],
+                prefill_query_lens_cpu[prefill_idx : prefill_idx + 1],
+                self.max_prefill_buffer_size,
+                max_logits_bytes,
+                request_offset=num_decodes + prefill_idx,
+            )
+        ]
+
+    def build(self, *args, **kwargs) -> DeepseekV32IndexerMetadata:
+        metadata = super().build(*args, **kwargs)
+        self.active_width_buffer.fill_(int(metadata.max_seq_len))
+        if metadata.decode is not None:
+            decode = metadata.decode
+            seq_lens = decode.seq_lens.reshape(-1).contiguous()
+            fields = vars(decode).copy()
+            fields["seq_lens"] = seq_lens
+            fields["schedule_metadata"] = None
+            metadata.decode = B12xIndexerDecodeMetadata(
+                **fields,
+                active_width=self.active_width_buffer,
+            )
+        return metadata
+
+
+class B12xIndexerBackend(DeepseekV32IndexerBackend):
+    @classmethod
+    def supports_pcp(cls) -> bool:
+        return False
+
+    @classmethod
+    def supports_device_cpu_query_lens_mismatch(cls) -> bool:
+        return False
+
+    @staticmethod
+    def get_name() -> str:
+        return "B12X_INDEXER"
+
+    @staticmethod
+    def get_builder_cls() -> type[B12xIndexerMetadataBuilder]:
+        return B12xIndexerMetadataBuilder
+
+
+class B12xIndexerCache(DeepseekV32IndexerCache):
+    def get_attn_backend(self) -> type[B12xIndexerBackend]:
+        return B12xIndexerBackend
+
+
+def _require_b12x_indexer() -> Any:
+    module = get_b12x_dsa_indexer()
+    if module is None:
+        raise RuntimeError("B12X sparse MLA requires `pip install vllm[b12x]`.")
+    if not module.is_supported():
+        raise RuntimeError("B12X sparse indexer is not supported on this device.")
+    if int(module.PAGED_INDEX_PAGE_SIZE) != _INDEX_PAGE_SIZE:
+        raise RuntimeError(
+            "B12X sparse indexer page size changed: expected "
+            f"{_INDEX_PAGE_SIZE}, got {module.PAGED_INDEX_PAGE_SIZE}."
+        )
+    for name in (
+        "Caps",
+        "bind",
+        "plan",
+        "run",
+    ):
+        getattr(module, name)
+    return module
+
+
+def _flatten_index_cache(kv_cache: torch.Tensor) -> torch.Tensor:
+    expected_tail = (_INDEX_PAGE_SIZE, _INDEX_HEAD_DIM + _INDEX_SCALE_BYTES)
+    if (
+        kv_cache.ndim != 3
+        or kv_cache.dtype != torch.uint8
+        or tuple(kv_cache.shape[1:]) != expected_tail
+    ):
+        raise RuntimeError(
+            "B12X indexer cache must have shape "
+            f"[num_blocks, {expected_tail[0]}, {expected_tail[1]}] and dtype "
+            f"uint8, got shape={tuple(kv_cache.shape)} dtype={kv_cache.dtype}."
+        )
+    if kv_cache.stride(1) != expected_tail[1] or kv_cache.stride(2) != 1:
+        raise RuntimeError(
+            "B12X indexer cache requires contiguous page payloads, got stride "
+            f"{tuple(kv_cache.stride())}."
+        )
+    return kv_cache.as_strided(
+        (int(kv_cache.shape[0]), _INDEX_PAGE_WIDTH),
+        (int(kv_cache.stride(0)), 1),
+    )
+
+
+def _run_paged_topk(
+    *,
+    module: Any,
+    plan: Any,
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    kv_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    active_width: torch.Tensor | None,
+    output: torch.Tensor,
+) -> None:
+    scratch = current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+    if active_width is None:
+        raise RuntimeError("B12X DSA requires a device active-width scalar.")
+    binding = module.bind(
+        plan,
+        scratch=scratch,
+        q_fp8=q,
+        query_weights=weights,
+        index_k_cache=_flatten_index_cache(kv_cache),
+        page_table=block_table,
+        cache_lengths=seq_lens,
+        active_width=active_width,
+        output_indices=output,
+    )
+    module.run(binding)
+
+
+class B12xSparseIndexer(nn.Module):
+    def __init__(
+        self,
+        k_cache,
+        quant_block_size: int,
+        scale_fmt: str,
+        topk_tokens: int,
+        head_dim: int,
+        max_model_len: int,
+        max_total_seq_len: int,
+        topk_indices_buffer: torch.Tensor | None,
+        skip_k_cache_insert: bool = False,
+        use_fp4_cache: bool = False,
+        compress_ratio: int = 1,
+        num_q_heads: int | None = None,
+        output_physical_slots: bool = True,
+    ) -> None:
+        super().__init__()
+        del quant_block_size, scale_fmt, max_total_seq_len
+        if not skip_k_cache_insert:
+            raise ValueError("B12X requires the fused DSA index-cache insert path.")
+        if use_fp4_cache:
+            raise ValueError("B12X indexing requires the FP8 index cache.")
+        if compress_ratio != 1:
+            raise ValueError(
+                "The non-compressed B12X indexer requires compress_ratio=1."
+            )
+        if head_dim != _INDEX_HEAD_DIM:
+            raise ValueError(
+                f"B12X indexing requires head_dim={_INDEX_HEAD_DIM}, got {head_dim}."
+            )
+        if topk_indices_buffer is None:
+            raise ValueError("B12X indexing requires a top-k output buffer.")
+        if num_q_heads is None or int(num_q_heads) <= 0:
+            raise ValueError(
+                "B12X indexing requires a positive index query head count."
+            )
+        if not output_physical_slots:
+            raise ValueError(
+                "B12X sparse MLA requires rank-local physical indexer output."
+            )
+        self._module = _require_b12x_indexer()
+        self.k_cache = k_cache
+        self.topk_tokens = int(topk_tokens)
+        self.max_model_len = int(max_model_len)
+        self.topk_indices_buffer = topk_indices_buffer
+        self.output_physical_slots = bool(output_physical_slots)
+        self.active_width_cap = torch.full(
+            (1,),
+            self.max_model_len,
+            dtype=torch.int32,
+            device=topk_indices_buffer.device,
+        )
+        max_q_rows = int(topk_indices_buffer.shape[0])
+        max_page_table_width = max(
+            1, (self.max_model_len + _INDEX_PAGE_SIZE - 1) // _INDEX_PAGE_SIZE
+        )
+        from vllm.config import get_current_vllm_config
+
+        vllm_config = get_current_vllm_config()
+        scheduler_config = vllm_config.scheduler_config
+        parallel_config = vllm_config.parallel_config
+        max_num_seqs = int(scheduler_config.max_num_seqs)
+
+        def make_plan(*, mode: str, q_rows: int):
+            return self._module.plan(
+                self._module.Caps(
+                    device=topk_indices_buffer.device,
+                    num_q_heads=int(num_q_heads),
+                    max_q_rows=q_rows,
+                    max_page_table_width=max_page_table_width,
+                    topk=self.topk_tokens,
+                    mode=mode,
+                    max_batch=q_rows if mode == "decode" else max_num_seqs,
+                    output_index_space=(
+                        "physical" if self.output_physical_slots else "logical"
+                    ),
+                )
+            )
+
+        self._make_plan = make_plan
+        capture_sizes = vllm_config.compilation_config.cudagraph_capture_sizes or []
+        decode_plan_sizes = {
+            int(size) for size in capture_sizes if 0 < int(size) <= max_num_seqs
+        }
+        decode_plan_sizes.add(max_num_seqs)
+        self._decode_plan_sizes = sorted(decode_plan_sizes)
+        self._decode_plans = {
+            rows: make_plan(mode="decode", q_rows=rows)
+            for rows in self._decode_plan_sizes
+        }
+        prefill_profile_rows = _prefill_profile_q_rows(max_q_rows)
+        self._prefill_plans = {
+            prefill_profile_rows: make_plan(mode="prefill", q_rows=prefill_profile_rows)
+        }
+        self._prefill_plan_sizes = [prefill_profile_rows]
+        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        object.__setattr__(self, "b12x_warmup_provider", self)
+
+    def _get_plan(self, mode: str, q_rows: int) -> Any:
+        q_rows = int(q_rows)
+        if mode == "decode":
+            index = bisect.bisect_left(self._decode_plan_sizes, q_rows)
+            if index < len(self._decode_plan_sizes):
+                return self._decode_plans[self._decode_plan_sizes[index]]
+            plans = self._decode_plans
+            plan_sizes = self._decode_plan_sizes
+        else:
+            index = bisect.bisect_left(self._prefill_plan_sizes, q_rows)
+            if index < len(self._prefill_plan_sizes):
+                return self._prefill_plans[self._prefill_plan_sizes[index]]
+            plans = self._prefill_plans
+            plan_sizes = self._prefill_plan_sizes
+        if _is_current_stream_capturing(self.topk_indices_buffer):
+            raise RuntimeError(
+                f"B12X DSA {mode} plan for {q_rows} rows was not prepared before "
+                "CUDA graph capture."
+            )
+        plan = self._make_plan(mode=mode, q_rows=q_rows)
+        plans[q_rows] = plan
+        bisect.insort(plan_sizes, q_rows)
+        return plan
+
+    def _reserve_profile_workspace(self) -> None:
+        for plan in (*self._decode_plans.values(), *self._prefill_plans.values()):
+            current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+
+    def get_b12x_warmup_unit(
+        self,
+        layer: torch.nn.Module,
+        token_counts: tuple[int, ...],
+        output_dtype: torch.dtype,
+    ) -> B12xWarmupUnit:
+        del layer, token_counts, output_dtype
+
+        def compile() -> None:
+            kv_cache = self.k_cache.kv_cache
+            if kv_cache.numel() == 0:
+                raise RuntimeError(
+                    "B12X DSA warmup requires the finalized index KV cache."
+                )
+            plans = (*self._decode_plans.values(), *self._prefill_plans.values())
+            for plan in plans:
+                caps = plan.caps
+                rows = int(caps.max_q_rows)
+                mode = str(caps.mode)
+                q = torch.zeros(
+                    (rows, int(caps.num_q_heads), _INDEX_HEAD_DIM),
+                    dtype=torch.float8_e4m3fn,
+                    device=caps.device,
+                )
+                weights = torch.zeros(
+                    (rows, int(caps.num_q_heads)),
+                    dtype=torch.float32,
+                    device=caps.device,
+                )
+                cache_lengths = torch.full(
+                    (rows,),
+                    min(self.max_model_len, _INDEX_PAGE_SIZE),
+                    dtype=torch.int32,
+                    device=caps.device,
+                )
+                page_rows = rows if mode == "decode" else 1
+                page_table = torch.zeros(
+                    (page_rows, int(caps.max_page_table_width)),
+                    dtype=torch.int32,
+                    device=caps.device,
+                )
+                if mode == "prefill":
+                    page_table = page_table.expand(rows, -1)
+                output = torch.empty(
+                    (rows, self.topk_tokens),
+                    dtype=torch.int32,
+                    device=caps.device,
+                )
+                _run_paged_topk(
+                    module=self._module,
+                    plan=plan,
+                    q=q,
+                    weights=weights,
+                    kv_cache=kv_cache,
+                    seq_lens=cache_lengths,
+                    block_table=page_table,
+                    active_width=self.active_width_cap,
+                    output=output,
+                )
+
+        plan_key = tuple(
+            (
+                str(plan.caps.mode),
+                int(plan.caps.max_q_rows),
+                int(plan.caps.max_page_table_width),
+                getattr(plan.layout, "route", None),
+            )
+            for plan in (*self._decode_plans.values(), *self._prefill_plans.values())
+        )
+        return B12xWarmupUnit(
+            name="DSA indexer",
+            key=(
+                type(self),
+                self.topk_indices_buffer.device,
+                self.topk_tokens,
+                self.output_physical_slots,
+                plan_key,
+            ),
+            compile=compile,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor | None,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        del hidden_states
+        if not isinstance(q_quant, torch.Tensor):
+            raise ValueError("B12X indexing requires FP8 index queries.")
+        if k is not None:
+            raise ValueError("B12X index K must be written by the fused cache path.")
+
+        forward_context = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if not isinstance(attn_metadata, dict):
+            if (
+                forward_context.cudagraph_runtime_mode == CUDAGraphMode.NONE
+                and forward_context.batch_descriptor is not None
+            ):
+                self._reserve_profile_workspace()
+            return self.topk_indices_buffer
+
+        metadata = cast(DeepseekV32IndexerMetadata, attn_metadata[self.k_cache.prefix])
+        if metadata.prefill is not None:
+            for chunk in metadata.prefill.chunks:
+                if chunk.num_reqs != 1:
+                    raise RuntimeError(
+                        "B12X sparse prefill requires single-request chunks."
+                    )
+                start, end = chunk.token_start, chunk.token_end
+                q_chunk = q_quant[start:end].contiguous()
+                weights_chunk = weights[start:end].contiguous()
+                output = self.topk_indices_buffer[start:end, : self.topk_tokens]
+                seq_lens = (chunk.cu_seqlen_ke - chunk.cu_seqlen_ks).contiguous()
+                local_rows = (
+                    chunk.local_total_seq_lens
+                    if self.dcp_world_size > 1
+                    else chunk.total_seq_lens
+                )
+                active_pages = max(
+                    1, (int(local_rows) + _INDEX_PAGE_SIZE - 1) // _INDEX_PAGE_SIZE
+                )
+                active_pages = min(active_pages, int(chunk.block_table.shape[1]))
+                block_table = chunk.block_table[:1, :active_pages].expand(
+                    int(q_chunk.shape[0]), active_pages
+                )
+                _run_paged_topk(
+                    module=self._module,
+                    plan=self._get_plan("prefill", int(q_chunk.shape[0])),
+                    q=q_chunk,
+                    weights=weights_chunk,
+                    kv_cache=self.k_cache.kv_cache,
+                    seq_lens=seq_lens,
+                    block_table=block_table,
+                    active_width=self.active_width_cap,
+                    output=output,
+                )
+
+        if metadata.decode is not None:
+            decode = metadata.decode
+            if decode.requires_padding:
+                raise RuntimeError("B12X sparse decode does not support padded rows.")
+            seq_lens = decode.seq_lens.reshape(-1).contiguous()
+            block_table = decode.block_table
+            if int(block_table.shape[0]) != int(seq_lens.shape[0]):
+                if int(seq_lens.shape[0]) % int(block_table.shape[0]) != 0:
+                    raise RuntimeError(
+                        "B12X sparse decode could not align lengths and page tables."
+                    )
+                block_table = block_table.repeat_interleave(
+                    int(seq_lens.shape[0]) // int(block_table.shape[0]), dim=0
+                )
+            num_tokens = metadata.num_decode_tokens
+            output = self.topk_indices_buffer[:num_tokens, : self.topk_tokens]
+            _run_paged_topk(
+                module=self._module,
+                plan=self._get_plan("decode", num_tokens),
+                q=q_quant[:num_tokens].contiguous(),
+                weights=weights[:num_tokens].contiguous(),
+                kv_cache=self.k_cache.kv_cache,
+                seq_lens=seq_lens[:num_tokens],
+                block_table=block_table[:num_tokens].contiguous(),
+                active_width=getattr(decode, "active_width", None),
+                output=output,
+            )
+
+        return self.topk_indices_buffer

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1,0 +1,538 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""B12x sparse MLA attention backend."""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.config import VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.distributed import get_dcp_group
+from vllm.model_executor.layers.attention.mla_attention import MLACommonPrefillMetadata
+from vllm.model_executor.layers.attention.sparse_mla_attention import (
+    SparseMLACommonImpl,
+    SparseMLACommonMetadataBuilder,
+)
+from vllm.platforms.interface import DeviceCapability
+from vllm.utils.b12x import get_b12x_sparse_mla
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionLayer,
+    AttentionMetadata,
+    AttentionType,
+    CommonAttentionMetadata,
+    MLAAttentionImpl,
+    MultipleOf,
+)
+from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
+from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.kv_cache_layout import KVCacheLayout
+from vllm.v1.worker.workspace import current_workspace_manager
+
+if TYPE_CHECKING:
+    from vllm.model_executor.models.deepseek_v2 import Indexer
+
+
+class B12xMLASparseBackend(AttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "fp8",
+        "fp8_e4m3",
+        "fp8_ds_mla",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "B12X"
+
+    @staticmethod
+    def get_impl_cls() -> type[MLAAttentionImpl]:
+        return B12xMLASparseImpl
+
+    @staticmethod
+    def get_builder_cls() -> type["B12xMLASparseMetadataBuilder"]:
+        return B12xMLASparseMetadataBuilder
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [576]
+
+    @classmethod
+    def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
+        return (KVCacheLayout.BLHNC,)
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [64]
+
+    @classmethod
+    def is_mla(cls) -> bool:
+        return True
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_device_cpu_query_lens_mismatch(cls) -> bool:
+        return False
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        return (capability.major, capability.minor) in ((12, 0), (12, 1))
+
+    @classmethod
+    def supports_combination(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        kv_cache_dtype: CacheDType | None,
+        block_size: int | None,
+        use_mla: bool,
+        has_sink: bool,
+        use_sparse: bool,
+        use_mm_prefix: bool,
+        device_capability: DeviceCapability,
+    ) -> str | None:
+        from vllm.config import get_current_vllm_config
+
+        module = get_b12x_sparse_mla()
+        if module is None:
+            return "B12X sparse MLA requires the optional b12x package"
+        if not module.is_supported():
+            return "B12X sparse MLA is not supported on the current device"
+        vllm_config = get_current_vllm_config()
+        if vllm_config.model_config is not None:
+            hf_config = vllm_config.model_config.hf_text_config
+            if getattr(hf_config, "index_topk", None) is None:
+                return "B12X sparse MLA requires a model with index_topk"
+            if int(getattr(hf_config, "kv_lora_rank", 0)) != 512:
+                return "B12X sparse MLA requires kv_lora_rank=512"
+            if int(getattr(hf_config, "qk_rope_head_dim", 0)) != 64:
+                return "B12X sparse MLA requires qk_rope_head_dim=64"
+        return None
+
+
+@dataclass
+class B12xMLASparseMetadata(AttentionMetadata):
+    num_reqs: int
+    max_query_len: int
+    max_seq_len: int
+    num_actual_tokens: int
+    query_start_loc: torch.Tensor
+    slot_mapping: torch.Tensor
+    block_table: torch.Tensor
+    req_id_per_token: torch.Tensor
+    seq_lens: torch.Tensor
+    cache_seq_lens_per_token: torch.Tensor = field(init=False)
+    num_decodes: int
+    num_prefills: int
+    num_decode_tokens: int
+    prefill_max_seq_len: int = 0
+    prefill: MLACommonPrefillMetadata | None = None
+    block_size: int = 64
+    topk_tokens: int = 2048
+    cp_kv_cache_interleave_size: int = 1
+
+
+def _write_rank_local_selected_lengths(
+    global_lengths: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    dcp_size: int,
+    dcp_rank: int,
+    interleave_size: int,
+    topk: int,
+) -> None:
+    lengths = global_lengths
+    if dcp_size > 1:
+        lengths = get_dcp_local_seq_lens(
+            global_lengths,
+            dcp_size,
+            dcp_rank,
+            interleave_size,
+        )
+    torch.clamp(lengths, min=0, max=topk, out=output)
+
+
+class B12xMLASparseMetadataBuilder(
+    SparseMLACommonMetadataBuilder[B12xMLASparseMetadata]
+):
+    metadata_cls = B12xMLASparseMetadata
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        num_q_heads = vllm_config.model_config.get_num_attention_heads(
+            vllm_config.parallel_config
+        )
+        threshold = {8: 128, 16: 128, 32: 128, 64: 256, 128: 1024}.get(
+            num_q_heads, 1024
+        )
+        self._init_reorder_batch_threshold(
+            threshold,
+            supports_spec_as_decode=True,
+            supports_dcp_with_varlen=True,
+        )
+        self.cache_seq_lens_per_token_buffer = torch.empty(
+            (vllm_config.scheduler_config.max_num_batched_tokens,),
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> B12xMLASparseMetadata:
+        metadata = super().build(
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build,
+        )
+        num_tokens = metadata.num_actual_tokens
+        positions = common_attn_metadata.positions
+        if positions is None:
+            raise RuntimeError("B12X sparse MLA metadata requires token positions.")
+        positions = positions[:num_tokens]
+        cache_seq_lens_per_token = self.cache_seq_lens_per_token_buffer[:num_tokens]
+        cache_seq_lens_per_token.copy_(positions, non_blocking=True)
+        cache_seq_lens_per_token.add_(1)
+        _write_rank_local_selected_lengths(
+            cache_seq_lens_per_token,
+            cache_seq_lens_per_token,
+            dcp_size=self.dcp_world_size,
+            dcp_rank=self.dcp_rank,
+            interleave_size=self.cp_kv_cache_interleave_size,
+            topk=self.topk_tokens,
+        )
+        metadata.cache_seq_lens_per_token = cache_seq_lens_per_token
+        return metadata
+
+
+class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
+    can_return_lse_for_decode = True
+    lse_base_on_e = True
+    supports_dense_mha_prefill = False
+    supports_pcp = False
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None,
+        attn_type: str,
+        kv_sharing_target_layer_name: str | None,
+        topk_indices_buffer: torch.Tensor | None = None,
+        indexer: "Indexer | None" = None,
+        **mla_args,
+    ) -> None:
+        if any((alibi_slopes, sliding_window, logits_soft_cap)):
+            raise NotImplementedError(
+                "B12X sparse MLA does not support ALiBi, sliding window, or "
+                "logit soft caps."
+            )
+        if attn_type != AttentionType.DECODER:
+            raise NotImplementedError(
+                "B12X sparse MLA supports decoder self-attention only."
+            )
+
+        super().__init__(
+            num_heads,
+            head_size,
+            scale,
+            num_kv_heads,
+            alibi_slopes,
+            sliding_window,
+            kv_cache_dtype,
+            logits_soft_cap,
+            attn_type,
+            kv_sharing_target_layer_name,
+            indexer=indexer,
+            topk_indices_buffer=topk_indices_buffer,
+            **mla_args,
+        )
+        from vllm.config import get_current_vllm_config
+
+        vllm_config = get_current_vllm_config()
+        if self.kv_lora_rank != 512 or self.qk_rope_head_dim != 64:
+            raise ValueError(
+                "B12X sparse MLA requires kv_lora_rank=512 and qk_rope_head_dim=64."
+            )
+        if head_size != 576:
+            raise ValueError("B12X sparse MLA requires head_size=576.")
+        if self.topk_indices_buffer is None:
+            raise ValueError("B12X sparse MLA requires a top-k index buffer.")
+        if kv_cache_dtype != "fp8_ds_mla":
+            raise ValueError(
+                "B12X sparse MLA requires the packed fp8_ds_mla KV cache; "
+                f"got kv_cache_dtype={kv_cache_dtype!r}."
+            )
+
+        module = get_b12x_sparse_mla()
+        if module is None:
+            raise RuntimeError("B12X sparse MLA requires `pip install vllm[b12x]`.")
+        if not module.is_supported():
+            raise RuntimeError("B12X sparse MLA is not supported on this device.")
+        for name in ("Caps", "bind", "plan", "run"):
+            getattr(module, name)
+        self._bind = module.bind
+        self._run = module.run
+        self._module = module
+
+        scheduler_config = vllm_config.scheduler_config
+        max_tokens = int(scheduler_config.max_num_batched_tokens)
+        max_seqs = int(scheduler_config.max_num_seqs)
+        self._input_num_heads = self.num_heads * self.dcp_world_size
+        self._q_head_dim = self.kv_lora_rank + self.qk_rope_head_dim
+        self._topk_tokens = int(self.topk_indices_buffer.shape[-1])
+        self._max_tokens = max_tokens
+        self._max_seqs = max_seqs
+        self._kv_dtype = torch.uint8
+        self._kernel_page_size = 0
+        self.supports_quant_query_input = False
+
+    def _set_kernel_page_size(self, kernel_page_size: int) -> None:
+        if kernel_page_size <= 0 or kernel_page_size % 64:
+            raise ValueError(
+                "B12X sparse MLA kernel page size must be a positive multiple "
+                f"of 64, got {kernel_page_size}."
+            )
+        if kernel_page_size == self._kernel_page_size:
+            return
+
+        def make_plan(mode: str, max_q_rows: int, max_batch: int):
+            return self._module.plan(
+                self._module.Caps(
+                    device=torch.device(
+                        "cuda", torch.accelerator.current_device_index()
+                    ),
+                    num_q_heads=self._input_num_heads,
+                    max_q_rows=max_q_rows,
+                    max_width=self._topk_tokens,
+                    softmax_scale=self.scale,
+                    dtype=torch.bfloat16,
+                    kv_dtype=self._kv_dtype,
+                    head_dim=self._q_head_dim,
+                    v_head_dim=self.kv_lora_rank,
+                    mode=mode,
+                    max_batch=max_batch,
+                    max_chunks_per_row=max(1, (self._topk_tokens + 63) // 64),
+                    page_size=kernel_page_size,
+                    return_lse=self.need_to_return_lse_for_decode,
+                    lse_scale="natural",
+                )
+            )
+
+        self._decode_plan = make_plan("decode", self._max_seqs, self._max_seqs)
+        self._extend_plan = make_plan("extend", self._max_tokens, self._max_seqs)
+        self._scratch_nbytes = max(
+            int(self._decode_plan.layout.nbytes),
+            int(self._extend_plan.layout.nbytes),
+        )
+        self._q_spec = (
+            (self._max_tokens, self._input_num_heads, self._q_head_dim),
+            torch.bfloat16,
+        )
+        self._scratch_spec = ((self._scratch_nbytes,), torch.uint8)
+        self._device = self._decode_plan.caps.device
+        self._kernel_page_size = kernel_page_size
+
+    def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        if kv_cache.numel() == 0:
+            return
+        if kv_cache.ndim < 2:
+            raise ValueError(
+                "B12X sparse MLA cache must expose its page dimension, got "
+                f"shape={tuple(kv_cache.shape)}."
+            )
+        self._set_kernel_page_size(int(kv_cache.shape[1]))
+
+    def _borrow_workspaces(self) -> tuple[torch.Tensor, torch.Tensor]:
+        q_buffer, scratch = current_workspace_manager().get_simultaneous(
+            self._q_spec, self._scratch_spec
+        )
+        return q_buffer, scratch
+
+    def supports_fused_mla_query_output(
+        self,
+        num_heads: int,
+        output_dtype: torch.dtype,
+    ) -> bool:
+        return bool(
+            self.dcp_world_size == 1
+            and output_dtype == torch.bfloat16
+            and num_heads == self._input_num_heads
+            and self._q_head_dim == 576
+        )
+
+    def get_fused_mla_query_output(
+        self,
+        num_tokens: int,
+        num_heads: int,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor | None:
+        if (
+            not self.supports_fused_mla_query_output(num_heads, output_dtype)
+            or num_tokens <= 0
+            or num_tokens > self._max_tokens
+        ):
+            return None
+        q_buffer, _ = self._borrow_workspaces()
+        output = q_buffer[:num_tokens, :num_heads]
+        if not output.is_contiguous():
+            raise RuntimeError("B12X fused MLA query output must be contiguous.")
+        return output
+
+    def b12x_warmup_key(self) -> tuple[object, ...]:
+        return (
+            type(self),
+            self._device,
+            self._input_num_heads,
+            self._q_head_dim,
+            self._topk_tokens,
+            self._max_tokens,
+            self._decode_plan.caps.max_q_rows,
+            self.need_to_return_lse_for_decode,
+            self._kernel_page_size,
+        )
+
+    def warmup(self, token_counts: tuple[int, ...]) -> None:
+        decode_capacity = int(self._decode_plan.caps.max_q_rows)
+        decode_rows = {
+            int(rows) for rows in token_counts if 0 < int(rows) <= decode_capacity
+        }
+        decode_rows.add(1)
+        extend_rows = {1, 2, 4, self._max_tokens}
+        kv_cache = torch.zeros(
+            (1, self._kernel_page_size, 656),
+            dtype=torch.uint8,
+            device=self._device,
+        )
+        q_buffer, scratch = self._borrow_workspaces()
+
+        for plan, rows_to_warm in (
+            (self._decode_plan, sorted(decode_rows)),
+            (self._extend_plan, sorted(extend_rows)),
+        ):
+            for rows in rows_to_warm:
+                if rows > int(plan.caps.max_q_rows):
+                    continue
+                q = q_buffer[:rows]
+                q.zero_()
+                selected_indices = torch.zeros(
+                    (rows, self._topk_tokens),
+                    dtype=torch.int32,
+                    device=self._device,
+                )
+                cache_lengths = torch.full(
+                    (rows if plan is self._decode_plan else 1,),
+                    self._kernel_page_size,
+                    dtype=torch.int32,
+                    device=self._device,
+                )
+                selected_lengths = torch.ones(
+                    (rows,), dtype=torch.int32, device=self._device
+                )
+                binding = self._bind(
+                    plan,
+                    scratch=scratch,
+                    q=q,
+                    kv_cache=kv_cache,
+                    selected_indices=selected_indices,
+                    cache_lengths=cache_lengths,
+                    selected_lengths=selected_lengths,
+                )
+                self._run(binding)
+
+    def forward_mqa(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: B12xMLASparseMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        del layer
+        cache_page_size = int(kv_c_and_k_pe_cache.shape[1])
+        metadata_page_size = int(attn_metadata.block_size)
+        if (
+            cache_page_size != self._kernel_page_size
+            or metadata_page_size != self._kernel_page_size
+        ):
+            raise RuntimeError(
+                "B12X sparse MLA page geometry does not match the bound plan: "
+                f"cache={cache_page_size}, metadata={metadata_page_size}, "
+                f"plan={self._kernel_page_size}."
+            )
+        plan = (
+            self._decode_plan if attn_metadata.max_query_len <= 1 else self._extend_plan
+        )
+        q_buffer, scratch = self._borrow_workspaces()
+
+        if isinstance(q, tuple):
+            q_nope, q_pe = q
+            num_tokens = int(q_nope.shape[0])
+            q_all = q_buffer[:num_tokens]
+            if int(q_pe.shape[-1]) == 0:
+                q_all.copy_(q_nope)
+            else:
+                ops.concat_mla_q(q_nope, q_pe, q_all)
+        else:
+            num_tokens = int(q.shape[0])
+            q_all = q_buffer[:num_tokens]
+            exact_workspace_alias = (
+                tuple(q.shape) == tuple(q_all.shape)
+                and tuple(q.stride()) == tuple(q_all.stride())
+                and q.dtype == q_all.dtype
+                and q.device == q_all.device
+                and q.untyped_storage().data_ptr() == q_all.untyped_storage().data_ptr()
+                and q.storage_offset() == q_all.storage_offset()
+            )
+            if not exact_workspace_alias:
+                q_all.copy_(q)
+
+        if int(q_all.shape[1]) != self._input_num_heads:
+            raise ValueError(
+                "B12X sparse MLA query heads do not match the planned head "
+                f"count: {q_all.shape[1]} != {self._input_num_heads}."
+            )
+
+        assert self.topk_indices_buffer is not None
+        selected_indices = self.topk_indices_buffer[:num_tokens]
+        active_counts = attn_metadata.cache_seq_lens_per_token[:num_tokens]
+
+        # Cache lengths are request-sized; active counts are query-row-sized.
+        cache_seq_lens = attn_metadata.seq_lens[: attn_metadata.num_reqs].contiguous()
+        binding = self._bind(
+            plan,
+            scratch=scratch,
+            q=q_all,
+            kv_cache=kv_c_and_k_pe_cache,
+            selected_indices=selected_indices,
+            cache_lengths=cache_seq_lens,
+            selected_lengths=active_counts,
+        )
+        result = self._run(binding)
+        if self.need_to_return_lse_for_decode:
+            output, lse = result
+            return output, lse
+        assert isinstance(result, torch.Tensor)
+        return result, None

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -871,6 +871,21 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         self.global_decode_seq_lens_buffer[actual_expanded:num_decode_tokens] = 0
         return self.global_decode_seq_lens_buffer[:num_decode_tokens]
 
+    def _split_prefill_chunks(
+        self,
+        compressed_seq_lens_cpu: torch.Tensor,
+        prefill_query_lens_cpu: torch.Tensor,
+        num_decodes: int,
+        max_logits_bytes: int,
+    ) -> list[tuple[slice, slice]]:
+        return split_indexer_prefill_chunks(
+            compressed_seq_lens_cpu[num_decodes:],
+            prefill_query_lens_cpu,
+            self.max_prefill_buffer_size,
+            max_logits_bytes,
+            request_offset=num_decodes,
+        )
+
     def _build_varlen_decode_indices(
         self,
         decode_lens: torch.Tensor,
@@ -961,12 +976,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # slice below).
             assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
-            chunk_specs = split_indexer_prefill_chunks(
-                compressed_seq_lens_cpu[num_decodes:],
+            chunk_specs = self._split_prefill_chunks(
+                compressed_seq_lens_cpu,
                 prefill_query_lens_cpu,
-                self.max_prefill_buffer_size,
+                num_decodes,
                 max_logits_bytes,
-                request_offset=num_decodes,
             )
 
             chunks = []


### PR DESCRIPTION


## Purpose

This PR extends the optional B12X attention backend on NVIDIA SM120 and SM121
GPUs with non-compressed sparse MLA and its DSA indexer. The existing `B12X`
selector chooses dense paged attention or sparse MLA from the model's attention
contract; users do not select separate B12X attention implementations.

The integration:

- Adds B12X sparse-MLA and paged-DSA backend implementations using B12X's
  `Caps -> plan -> bind -> run` APIs and caller-owned workspaces.
- Routes DeepSeek-V3.2-family sparse attention through the NVIDIA model hook,
  which also covers compatible GLM-5.2 and non-Flash GLM-5.3 configurations.
- Emits physical KV-cache slots directly from the DSA indexer.
- Supports decode context parallelism with rank-local selection and the existing
  LSE-based attention reduction, without adding global candidate reranking or
  model-specific DCP optimizations.
- Fuses BF16 absorbed query projection and RoPE assembly directly into the B12X
  query workspace when the selected attention implementation advertises that
  capability.
- Plans against the finalized KV-cache page geometry and warms the decode,
  extend, and indexer signatures needed by CUDA graph execution.

This does not duplicate #54929. That PR adds a portable Triton fallback behind
`FLASHMLA_SPARSE`; this PR integrates the separately packaged B12X sparse-MLA
and DSA implementations behind the existing optional `B12X` backend.

AI assistance from OpenAI Codex was used while developing this PR. I reviewed
every changed line and am responsible for understanding and defending the
integration end-to-end.

## Test Plan

Run the focused attention tests against the B12X 1.4.0 API contract. The test
below used an editable checkout of the revision being released as 1.4.0:

```bash
uv run --with pytest --with tblib --no-sync python -m pytest \
  tests/v1/attention/test_b12x.py -q
```

Run all configured checks over the changed files:

```bash
mapfile -t changed_files < <(git diff --name-only upstream/main...HEAD)
.venv/bin/pre-commit run --files "${changed_files[@]}"
git diff --check upstream/main...HEAD
```

Serve GLM-5.2-NVFP4 with TP=8 on eight RTX PRO 6000 Blackwell GPUs and verify
both DCP=1 and DCP=2. For the performance comparison, keep B12X linear and MoE
backends fixed and change only the attention stack between
`FLASHINFER_MLA_SPARSE_SM120` and `B12X`.

The pure-prefill workload uses four concurrent requests with 65,536 input
tokens and one output token. The pure-decode workload first primes the prefix
cache, then uses four concurrent requests with a cached 65,536-token context
and 1,024 output tokens. Each result is the mean of two repetitions.

## Test Result

Focused tests on the rebased PR head:

```text
55 passed, 15 warnings in 34.49s
```

All changed-file pre-commit hooks passed, including Ruff, formatting, mypy,
markdownlint, SPDX, forbidden-import, and CUDA API checks. `git diff --check`
and Python compilation/import checks also passed.

GLM-5.2-NVFP4 TP=8/DCP=2 started with the default collective implementation,
warmed the B12X MLA and DSA signatures, and completed `/v1/models` and a
20-token-input/32-token-output request successfully. DCP uses rank-local
physical selection and LSE reduction; no optimized DCP candidate exchange is
included.

End-to-end throughput; higher is better:

| Workload | FlashInfer MLA + stock DSA | B12X MLA + DSA | Change |
| --- | ---: | ---: | ---: |
| Pure prefill | 4,147.89 input tok/s | 4,737.78 input tok/s | +14.22% |
| Cached 64K decode | 184.61 output tok/s | 194.89 output tok/s | +5.57% |

The B12X decode repetitions were 194.60 and 195.18 output tok/s, or
approximately 195 output tok/s. The comparison excludes the experimental CTA
redistribution because its end-to-end effect was within run noise.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan, including commands.
- [x] The test and performance results.
- [x] The necessary documentation update.

</details>
