### PR TITLE
[Feature] Expose XGrammar bitmask backend selection

### DIFF
--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -39,6 +39,27 @@ request. You may also choose a specific backend, along with
 some options. A full set of options is available in the `vllm serve --help`
 text.
 
+### Selecting the XGrammar bitmask backend
+
+`--structured-outputs-config.bitmask_backend` selects the implementation used
+when vLLM applies an XGrammar token bitmask to logits. The default value,
+`auto`, preserves the optimized default for the active model runner. Set an
+explicit value only to evaluate an alternative implementation or work around a
+backend-specific issue. For example, the following starts a server that uses
+XGrammar's `torch_native` implementation when the XGrammar path is used:
+
+```bash
+vllm serve <model> \\
+  --structured-outputs-config.bitmask_backend=torch_native
+```
+
+The accepted values are `auto`, `cpu`, `cuda`, `triton`, `torch_compile`, and
+`torch_native`. Availability depends on the active hardware and the installed
+XGrammar version; an incompatible explicit value produces an error from the
+selected backend. This option controls only token-bitmask application and does
+not select the structured-output engine itself; use
+`--structured-outputs-config.backend` for that purpose.
+
 Now let's see an example for each of the cases, starting with the `choice`, as it's the easiest one:
 
 ??? code

--- a/tests/v1/structured_output/test_validation.py
+++ b/tests/v1/structured_output/test_validation.py
@@ -6,6 +6,7 @@ import pytest
 
 from vllm.config import StructuredOutputsConfig
 from vllm.exceptions import VLLMClientError, VLLMValidationError
+from vllm.platforms.cpu import CpuPlatform
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 
 pytestmark = pytest.mark.cpu_test
@@ -160,3 +161,19 @@ def test_auto_backend_falls_back_on_unsupported_schema(schema, expected_backend)
         tokenizer=object(),
     )
     assert params.structured_outputs._backend == expected_backend
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["auto", "cpu", "cuda", "triton", "torch_compile", "torch_native"],
+)
+def test_xgrammar_bitmask_backend_choices(backend: str):
+    config = StructuredOutputsConfig(bitmask_backend=backend)
+
+    assert config.bitmask_backend == backend
+    assert CpuPlatform.get_xgrammar_bitmask_backend(config.bitmask_backend) == backend
+
+
+def test_invalid_xgrammar_bitmask_backend_rejected():
+    with pytest.raises(ValueError, match="bitmask_backend"):
+        StructuredOutputsConfig(bitmask_backend="invalid")

--- a/tests/v1/worker/test_gpu_structured_outputs.py
+++ b/tests/v1/worker/test_gpu_structured_outputs.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_explicit_xgrammar_backend_uses_v2_logit_mapping(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "Stream", lambda: object())
+    worker = StructuredOutputsWorker(
+        max_num_logits=4,
+        vocab_size=32,
+        device=torch.device("cpu"),
+        mask_stride=2,
+        num_bonus_tokens=1,
+        bitmask_backend="torch_native",
+    )
+    captured: dict[str, object] = {}
+
+    def apply_token_bitmask_inplace(logits, bitmask, *, indices, backend):
+        captured["logits"] = logits
+        captured["bitmask"] = bitmask.clone()
+        captured["indices"] = indices.clone()
+        captured["backend"] = backend
+
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.structured_outputs.xgr",
+        SimpleNamespace(apply_token_bitmask_inplace=apply_token_bitmask_inplace),
+    )
+
+    logits = torch.zeros((2, 32), dtype=torch.float32)
+    bitmask = torch.tensor([[1], [2], [4], [8]], dtype=torch.int32)
+    mapping = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+    cu_num_logits = torch.tensor([0, 1, 2], dtype=torch.int32)
+
+    worker._apply_xgrammar_bitmask(logits, bitmask, mapping, cu_num_logits)
+
+    assert captured["logits"] is logits
+    assert captured["backend"] == "torch_native"
+    torch.testing.assert_close(
+        captured["indices"], torch.tensor([0, 1], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        captured["bitmask"], torch.tensor([[1], [4]], dtype=torch.int32)
+    )

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -13,6 +13,10 @@ StructuredOutputsBackend = Literal[
     "auto", "xgrammar", "guidance", "outlines", "lm-format-enforcer"
 ]
 
+XGrammarBitmaskBackend = Literal[
+    "auto", "cpu", "cuda", "triton", "torch_compile", "torch_native"
+]
+
 
 @config
 class StructuredOutputsConfig:
@@ -23,6 +27,10 @@ class StructuredOutputsConfig:
     regex, etc) by default. With "auto", we will make opinionated choices
     based on request contents and what the backend libraries currently support,
     so the behavior is subject to change in each release."""
+    bitmask_backend: XGrammarBitmaskBackend = "auto"
+    """Backend for applying XGrammar token bitmasks. With "auto", vLLM uses
+    its default optimized path. Set an explicit XGrammar backend to work around
+    a backend-specific issue or evaluate an alternative implementation."""
     disable_any_whitespace: bool = False
     """If `True`, json output will always be compact without any whitespace.
     If `False`, the model may generate whitespace between JSON fields,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from vllm.config import VllmConfig
     from vllm.config.kernel import IrOpPriorityConfig
+    from vllm.config.structured_outputs import XGrammarBitmaskBackend
     from vllm.inputs import EngineInput
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams
@@ -415,6 +416,18 @@ class Platform:
             f"Using default backend {AttentionBackendEnum.TORCH_SDPA} for vit attention"
         )
         return AttentionBackendEnum.TORCH_SDPA
+
+    @classmethod
+    def get_xgrammar_bitmask_backend(
+        cls, backend: "XGrammarBitmaskBackend"
+    ) -> "XGrammarBitmaskBackend":
+        """Resolve the XGrammar token-bitmask backend for this platform.
+
+        Platforms can override this hook to select a platform-specific default
+        or reject backends that are unavailable on their hardware. The base
+        implementation preserves the configured value, including ``"auto"``.
+        """
+        return backend
 
     @classmethod
     def get_device_capability(

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -89,6 +89,7 @@ def apply_grammar_bitmask(
     grammar_output: GrammarOutput,
     input_batch: InputBatch,
     logits: torch.Tensor,
+    bitmask_backend: str = "auto",
 ) -> None:
     """
     Apply grammar bitmask to output logits of the model with xgrammar function.
@@ -97,6 +98,7 @@ def apply_grammar_bitmask(
         scheduler_output (SchedulerOutput): The result of engine scheduling.
         input_batch (InputBatch): The input of model runner.
         logits (torch.Tensor): The output logits of model forward.
+        bitmask_backend: The XGrammar backend used to apply the token bitmask.
     """
     # Serialization of np.ndarray is much more efficient than a tensor,
     # so we receive it in that format.
@@ -159,7 +161,12 @@ def apply_grammar_bitmask(
                 out_indices, dtype=torch.int32, device=logits.device
             )
 
-        xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=index_tensor)
+        xgr.apply_token_bitmask_inplace(
+            logits,
+            grammar_bitmask,
+            indices=index_tensor,
+            backend=bitmask_backend,
+        )
         return
 
     # CPU case, use list for indices.
@@ -169,11 +176,21 @@ def apply_grammar_bitmask(
     if logits.dtype != torch.float32:
         # Convert to float32, apply bitmask, then convert back
         logits_fp32 = logits.to(torch.float32)
-        xgr.apply_token_bitmask_inplace(logits_fp32, grammar_bitmask, indices=indices)
+        xgr.apply_token_bitmask_inplace(
+            logits_fp32,
+            grammar_bitmask,
+            indices=indices,
+            backend=bitmask_backend,
+        )
         # Copy the modified values back to the original tensor
         logits.copy_(logits_fp32.to(logits.dtype))
     else:
-        xgr.apply_token_bitmask_inplace(logits, grammar_bitmask, indices=indices)
+        xgr.apply_token_bitmask_inplace(
+            logits,
+            grammar_bitmask,
+            indices=indices,
+            backend=bitmask_backend,
+        )
 
 
 class OutlinesVocabulary:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -59,6 +59,7 @@ from vllm.multimodal.encoder_budget import (
     MultiModalBudget,
     get_dummy_encoder_profile_inputs,
 )
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.gc_utils import freeze_gc_for_cudagraph_capture
@@ -186,6 +187,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.speculative_config is not None and self.speculative_config.use_dspark()
         )
         self.observability_config = vllm_config.observability_config
+        self.xgrammar_bitmask_backend = current_platform.get_xgrammar_bitmask_backend(
+            vllm_config.structured_outputs_config.bitmask_backend
+        )
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
 
         self.device = device
@@ -470,6 +474,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 device=self.device,
                 mask_stride=self.decode_query_len,
                 num_bonus_tokens=self.model_state.num_new_sampled_tokens_per_step,
+                bitmask_backend=self.xgrammar_bitmask_backend,
             )
 
         if self.is_pooling_model and self.is_last_pp_rank:

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -4,10 +4,13 @@ import numpy as np
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.utils.import_utils import LazyLoader
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
+
+xgr = LazyLoader("xgr", globals(), "xgrammar")
 
 
 def _build_grammar_mapping(
@@ -44,6 +47,7 @@ class StructuredOutputsWorker:
         device: torch.device,
         mask_stride: int,
         num_bonus_tokens: int,
+        bitmask_backend: str = "auto",
     ):
         self.logits_indices = torch.zeros(
             max_num_logits, dtype=torch.int32, device=device
@@ -51,6 +55,16 @@ class StructuredOutputsWorker:
         self.grammar_bitmask = torch.zeros(
             (max_num_logits, cdiv(vocab_size, 32)), dtype=torch.int32, device=device
         )
+        self.xgrammar_bitmask = (
+            torch.empty(
+                (max_num_logits, cdiv(vocab_size, 32)),
+                dtype=torch.int32,
+                device=device,
+            )
+            if bitmask_backend != "auto"
+            else None
+        )
+        self.bitmask_backend = bitmask_backend
         self.device = device
         self.copy_stream = torch.cuda.Stream()
         self.mask_stride = mask_stride
@@ -103,21 +117,61 @@ class StructuredOutputsWorker:
         vocab_size = logits.shape[-1]
         BLOCK_SIZE = 8192
         grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))
-        _apply_grammar_bitmask_kernel[grid](
-            logits,
-            logits.stride(0),
-            logits_indices,
-            input_batch.cu_num_logits,
-            bitmask,
-            bitmask.stride(0),
-            vocab_size,
-            MASK_STRIDE=self.mask_stride,
-            BLOCK_SIZE=BLOCK_SIZE,
-        )
+        if self.bitmask_backend == "auto":
+            _apply_grammar_bitmask_kernel[grid](
+                logits,
+                logits.stride(0),
+                logits_indices,
+                input_batch.cu_num_logits,
+                bitmask,
+                bitmask.stride(0),
+                vocab_size,
+                MASK_STRIDE=self.mask_stride,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+        else:
+            self._apply_xgrammar_bitmask(
+                logits, bitmask, logits_indices, input_batch.cu_num_logits
+            )
 
         # Ensure the copy stream waits for the device tensors to finish being used
         # before it re-uses or deallocates them
         self.copy_stream.wait_stream(current_stream)
+
+    def _apply_xgrammar_bitmask(
+        self,
+        logits: torch.Tensor,
+        bitmask: torch.Tensor,
+        mapping: torch.Tensor,
+        cu_num_logits: torch.Tensor,
+    ) -> None:
+        """Apply a selected XGrammar backend using the V2 request-to-logit map."""
+        assert self.xgrammar_bitmask is not None
+
+        request_indices = torch.div(
+            mapping, self.mask_stride, rounding_mode="floor"
+        ).to(torch.long)
+        position_indices = torch.remainder(mapping, self.mask_stride)
+        logit_starts = cu_num_logits[request_indices]
+        num_request_logits = cu_num_logits[request_indices + 1] - logit_starts
+        valid = position_indices < num_request_logits
+        logit_indices = (logit_starts + position_indices)[valid]
+
+        # XGrammar indexes the bitmask with the output-logit indices. Build a
+        # dense, aligned view because V2's source bitmasks are request-ordered.
+        aligned_bitmask = self.xgrammar_bitmask[: logits.shape[0]]
+        aligned_bitmask.fill_(-1)
+        aligned_bitmask.index_copy_(
+            0,
+            logit_indices.to(torch.long),
+            bitmask[valid],
+        )
+        xgr.apply_token_bitmask_inplace(
+            logits,
+            aligned_bitmask,
+            indices=logit_indices,
+            backend=self.bitmask_backend,
+        )
 
 
 # Adapted from

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -519,6 +519,9 @@ class GPUModelRunner(
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
+        self.xgrammar_bitmask_backend = current_platform.get_xgrammar_bitmask_backend(
+            vllm_config.structured_outputs_config.bitmask_backend
+        )
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
 
         model_config = self.model_config
@@ -4658,7 +4661,11 @@ class GPUModelRunner(
         # Apply structured output bitmasks if present.
         if grammar_output is not None:
             apply_grammar_bitmask(
-                scheduler_output, grammar_output, self.input_batch, logits
+                scheduler_output,
+                grammar_output,
+                self.input_batch,
+                logits,
+                bitmask_backend=self.xgrammar_bitmask_backend,
             )
 
         with record_function_or_nullcontext("gpu_model_runner: sample"):


### PR DESCRIPTION
## Purpose

FIX #37650

This reworks and supersedes #37664 on top of the current `main` branch. It adds `--structured-outputs-config.bitmask_backend` so users can choose the XGrammar implementation used to apply token bitmasks.

The default remains `auto`. On Model Runner V2, `auto` keeps vLLM's existing local Triton kernel. An explicit value routes the operation through XGrammar so users can try another implementation when diagnosing a backend-specific problem.

The platform hook is deliberately centralized in `Platform.get_xgrammar_bitmask_backend()`. Hardware platforms can override the hook when they need a different policy, without duplicating the default implementation across CPU, CUDA, ROCm, and XPU.

## Changes

- Add the typed `bitmask_backend` field to `StructuredOutputsConfig`.
- Pass the resolved value through both the legacy model runner and Model Runner V2.
- Align Model Runner V2's request-ordered masks with XGrammar's logit-indexed interface before dispatching an explicit backend.
- Document the CLI option, supported values, and its relationship to `structured_outputs_config.backend`.
- Add unit coverage for config validation, the platform resolver, and Model Runner V2 mask alignment.

## Test Plan

```bash
python -m pre_commit run --files \
  docs/features/structured_outputs.md \
  tests/v1/structured_output/test_validation.py \
  tests/v1/worker/test_gpu_structured_outputs.py \
  vllm/config/structured_outputs.py \
  vllm/platforms/interface.py \
  vllm/v1/structured_output/utils.py \
  vllm/v1/worker/gpu/model_runner.py \
  vllm/v1/worker/gpu/structured_outputs.py \
  vllm/v1/worker/gpu_model_runner.py

python -m pytest -q \
  tests/v1/structured_output/test_validation.py \
  tests/v1/worker/test_gpu_structured_outputs.py
```

## Test Result

- All selected pre-commit hooks passed, including Ruff, Markdown linting, mypy, configuration validation, and the forbidden-import check.
- `26 passed` in the targeted unit tests.
- The Model Runner V2 dispatch test uses a mocked XGrammar call on CPU. GPU hardware was not available for an end-to-end backend run.
