### PR TITLE
[Bugfix][V1] Register accepted spec-decode tokens before terminal cleanup

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -487,7 +487,13 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert num_computed == 0
-    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    assert manager.allocate_slots(req0, 4, num_computed, computed_blocks) is not None
+
+    # Async chunked prefill may publish a new boundary while the preceding
+    # chunk is still in flight. This first registration must remain enabled.
+    req0.num_computed_tokens = 4
+    req0.num_in_flight_tokens = 4
+    assert manager.allocate_slots(req0, 2) is not None
 
     partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
     partial_mamba_block = manager.block_pool.get_cached_block(
@@ -497,8 +503,11 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     partial_mamba_block_id = partial_mamba_block[0].block_id
     assert manager.get_blocks("0").get_block_ids()[1][1] == partial_mamba_block_id
 
+    # The next run-ahead allocation moves the boundary to a durable CoW block.
+    # Its end-of-allocation cache pass must not reattach the same hash to the
+    # mutable request-table source.
     req0.num_computed_tokens = 6
-    req0.append_output_token_ids([3])
+    req0.num_in_flight_tokens = 6
     new_blocks = manager.allocate_slots(req0, 1)
     assert new_blocks is not None
 
@@ -521,6 +530,17 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     assert get_block_hash(moved[0].block_hash) == partial_mamba_hash
     assert get_group_id(moved[0].block_hash) == 1
     assert moved[0].block_hash_num_tokens == 6
+
+    # The output-time cache path can retry the same settled boundary while a
+    # later step remains in flight; that must remain idempotent too.
+    req0.num_in_flight_tokens = 1
+    manager.cache_blocks(req0, 6)
+    grouped_hash = moved[0].block_hash
+    assert grouped_hash is not None
+    cache = manager.block_pool.cached_block_hash_to_block
+    assert cache.contain(grouped_hash, cow_copy.dst_block_id)
+    assert not cache.contain(grouped_hash, partial_mamba_block_id)
+    assert partial_mamba_block[0].block_hash is None
 
 
 def test_partial_hit_then_internal_checkpoint_uses_distinct_mamba_blocks():

--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -13,7 +13,7 @@ from vllm.v1.request import RequestStatus
 from vllm.v1.structured_output import StructuredOutputGrammar
 from vllm.v1.utils import ConstantList
 
-from .utils import create_requests, create_scheduler, mock_kv
+from .utils import EOS_TOKEN_ID, create_requests, create_scheduler, mock_kv
 
 pytestmark = pytest.mark.cpu_test
 
@@ -64,6 +64,42 @@ def test_stop_by_max_tokens(max_tokens: int):
     assert req1.num_output_tokens == max_tokens
     # Ensure we aren't scheduling more tokens than necessary.
     assert total_num_scheduled_tokens == expected_total_num_scheduled_tokens
+
+
+def test_finished_request_does_not_cache_in_flight_tokens():
+    """A terminal output must not publish KV from a later in-flight step."""
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        enable_prefix_caching=True,
+        block_size=16,
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=31,
+        max_tokens=10,
+        same_prompt=True,
+        block_size=16,
+    )
+    scheduler.add_request(request)
+
+    first_step = scheduler.schedule()
+    second_step = scheduler.schedule()
+    assert second_step.num_scheduled_tokens[request.request_id] == 1
+
+    model_output = _make_model_runner_output(first_step)
+    model_output.sampled_token_ids = [[EOS_TOKEN_ID]]
+    scheduler.update_from_output(first_step, model_output)
+    assert request.status == RequestStatus.FINISHED_STOPPED
+    assert request.num_in_flight_tokens == 1
+
+    (repeat,) = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        same_prompt=True,
+        block_size=16,
+    )
+    _, num_cached_tokens, _ = scheduler.kv_cache_manager.get_computed_blocks(repeat)
+    assert num_cached_tokens == 16
 
 
 def test_no_spec_decode_padding_up_to_max_model_len():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1610,6 +1610,87 @@ def test_schedule_spec_decoding_stats(
         assert "per_step_accepted" not in payload  # summary level
 
 
+@pytest.mark.parametrize(
+    (
+        "async_scheduling",
+        "prompt_tokens",
+        "num_reprefillable_tokens",
+        "expected_cached_tokens",
+        "run_spec_verify",
+    ),
+    [
+        (False, 44, 0, 48, True),
+        (False, 30, 2, 16, True),
+        (False, 28, 2, 0, True),
+        (True, 30, 2, 16, True),
+        (False, 47, 0, 32, False),
+    ],
+    ids=[
+        "ordinary-spec",
+        "mtp-publish",
+        "mtp-fence",
+        "async-mtp-publish",
+        "sampled-output-fence",
+    ],
+)
+def test_finished_spec_decode_registers_accepted_tokens(
+    async_scheduling: bool,
+    prompt_tokens: int,
+    num_reprefillable_tokens: int,
+    expected_cached_tokens: int,
+    run_spec_verify: bool,
+):
+    """Terminal registration publishes all and only executed KV."""
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        block_size=16,
+        num_speculative_tokens=3,
+        speculative_method="ngram_gpu" if async_scheduling else None,
+        async_scheduling=async_scheduling,
+    )
+    if num_reprefillable_tokens:
+        # Mirror the cache-registration and lookup geometry of K=3
+        # multi-module MTP without requiring model weights or a GPU.
+        scheduler.use_eagle = True
+        scheduler.use_eagle_block_drop = True
+        scheduler.num_prefill_lookahead = num_reprefillable_tokens + 1
+        coordinator = scheduler.kv_cache_manager.coordinator
+        coordinator.num_reprefillable_tokens = num_reprefillable_tokens
+        coordinator.eagle_group_ids = {0}
+        coordinator.single_type_managers[0].use_eagle = True
+
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=prompt_tokens,
+        max_tokens=4 if run_spec_verify else 1,
+        block_size=16,
+        same_prompt=True,
+    )
+    scheduler.add_request(request)
+
+    # Prefill samples one token. Most cases then accept all three drafts on a
+    # terminal verify; the verifier's bonus token is trimmed at max_tokens=4.
+    _model_output(scheduler, scheduler.schedule(), [[0]])
+    if run_spec_verify:
+        scheduler.update_draft_token_ids(
+            DraftTokenIds([request.request_id], [[0, 0, 0]])
+        )
+        _model_output(scheduler, scheduler.schedule(), [[0, 0, 0, 0]])
+
+    # One extra token keeps the lookup's required uncomputed tail outside the
+    # finalized boundary whose reuse this test measures.
+    (continuation,) = create_requests(
+        num_requests=1,
+        num_tokens=prompt_tokens + 5,
+        block_size=16,
+        same_prompt=True,
+    )
+    _, num_cached_tokens, _ = scheduler.kv_cache_manager.get_computed_blocks(
+        continuation
+    )
+    assert num_cached_tokens == expected_cached_tokens
+
+
 def _run_spec_verify_steps(scheduler, rounds, num_invalid_per_round=None):
     """Drive prefill + one draft/verify step per round for a single request.
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2137,6 +2137,21 @@ class Scheduler(SchedulerInterface):
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
+                    if status_before_stop == RequestStatus.RUNNING:
+                        # Register finalized output tokens before releasing
+                        # their blocks. A terminal request has no later
+                        # allocation pass to do so.
+                        finalized_num_computed_tokens = min(
+                            max(
+                                0,
+                                request.num_computed_tokens
+                                - request.num_in_flight_tokens,
+                            ),
+                            request.num_tokens,
+                        )
+                        self.kv_cache_manager.cache_blocks(
+                            request, finalized_num_computed_tokens
+                        )
                     kv_transfer_params, ec_transfer_params = self._free_request(request)
 
                 if status_before_stop == RequestStatus.RUNNING:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -2039,6 +2039,17 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
     ) -> BlockHashWithGroupId | None:
+        # With async run-ahead, a boundary at or behind the optimistic
+        # computed frontier may already have been moved to a durable CoW
+        # block. Do not reattach its hash to the request-table state block,
+        # which a later in-flight step can overwrite. A boundary beyond the
+        # frontier is a first publication by the current allocation and must
+        # remain eligible.
+        if (
+            request.num_in_flight_tokens > 0
+            and num_tokens <= request.num_computed_tokens
+        ):
+            return None
         hash_block_size = self.block_pool.hash_block_size
         # Re-key the reserved block at its exported checkpoint boundary.
         checkpoint = self._checkpoints.get(request.request_id)


### PR DESCRIPTION
## Purpose

Follow-up to the local-GPU-cache investigation on #52771:
https://github.com/vllm-project/vllm/pull/52771#issuecomment-5507841294

A terminal speculative-verification response can accept draft tokens after the
last normal prefix-cache registration. If that same response finishes the
request, cleanup releases its blocks before those newly finalized boundaries
are registered. A repeated or extended prompt then recomputes KV that was
successfully produced.

The test-only 2026-09-20 `main` snapshot control reproduces the loss:

| Case | `main` with tests only | This PR |
|---|---:|---:|
| Ordinary K=3 speculative decode | 32 cached tokens | 48 |
| Emulated multi-module-MTP, synchronous | 0 cached tokens | 16 |
| Emulated multi-module-MTP, asynchronous | 0 cached tokens | 16 |

The MTP safety boundary remains at 0 and the unwritten final sampled-token case
remains at 32, so the change does not publish speculative or trimmed work.

## Fix

Immediately before freeing a request that both entered the stop path as
`RUNNING` and actually finished, register this finalized prefix through the
existing cache coordinator:

```python
min(
    max(0, request.num_computed_tokens - request.num_in_flight_tokens),
    request.num_tokens,
)
```

- Subtracting `num_in_flight_tokens` excludes work belonging to a later async
  schedule.
- Capping at `request.num_tokens` excludes verifier output trimmed by the stop
  condition.
- The existing coordinator still applies its MTP re-prefill fence.

The new terminal call also exercises an existing hybrid-Mamba retry path. With
async run-ahead, a retained partial boundary may already have moved to a durable
copy-on-write block while the request-table state block remains mutable. The
Mamba guard prevents that settled boundary from being reattached to mutable
state while work is in flight, while preserving first publication beyond the
current computed frontier. On current main, the guard runs only after the
mandatory `retention_interval == 0` transient-checkpoint eviction, so a retry
cannot leave a findable hash on a slot whose state is about to be overwritten.
The guard is covered by the exact-main copy-on-write negative control; its
placement after transient-checkpoint cleanup is covered by a focused ablation
on a patch-equivalent candidate.

This PR covers local/core automatic prefix-cache registration. It does not
claim that a newly registered terminal Mamba boundary is propagated through an
external KV connector.

## Not a duplicate

On 2026-09-20 I reread the originating #52771 thread and repeated searches over
open and merged work for terminal speculative acceptance, cache registration,
cleanup, and Mamba checkpoint retention. No other PR implements this generic
lifecycle fix.

- #50551 predates this PR and independently retains a finalized decode
  checkpoint for sparse-retention Mamba align mode. It uses the same
  `max(0, num_computed_tokens - num_in_flight_tokens)` processed-token
  frontier and deserves explicit credit for that Mamba-specific lifecycle.
  Its feature is opt-in, recurrent-only, and currently excludes hidden-state
  speculative decoding; it does not register the ordinary attention/ngram or
  emulated-MTP terminal cases reproduced here.
- #52244 predates this PR and deserves explicit credit for its fine-grained
  write-side prompt-tail/replay correction for hybrid GDN under MTP. It does
  not add terminal accepted-token registration; the two fixes address
  different lifecycle boundaries. Its current head overlaps the scheduler and
  Mamba-manager files and does not merge cleanly with this current-main
  candidate, so if it lands first this branch must be rebased while preserving
  both lifecycle fixes.
- #56525 is newer concurrent work that fences Mamba prefix-cache hits until
  the GPU step that published them commits. It does not add terminal
  accepted-token registration, but it touches the same Mamba hash-lifecycle
  path and will need composition if it lands first.
- #56531 corrects worker-side recurrent-state selection on zero-draft
  speculative steps; it does not change scheduler KV-cache publication.
- #57180 is newer MTP lookup/registration work for saved Mamba prompt tails.
  It changes replay reachability, not terminal accepted-token registration.
- #56137 and #56195 are newer concurrent work in the terminal
  speculative-output path. They correct acceptance metrics after EOS/stop
  truncation but do not call `cache_blocks` or change KV-cache state.
- #57646 is newer offload-metadata work and explicitly identifies #54979 as a
  separate GPU-cache registration change. It exposes the processed prefix to
  offload backends but does not register it in the local prefix cache.
- #50897 publishes output-time blocks only under its successor-aware EAGLE hash
  protocol when drafter KV is reported materialized; it does not repair the
  generic registration path exercised here, including ordinary ngram
  speculation.
- #43569 tracks rollback and commit of eager registrations. Its normal finish
  path remains unchanged and it does not register accepted terminal draft
  tokens.
- The merged #53945 and #56794, and open #54076, change where Mamba boundaries
  are materialized or retained, not the missing terminal registration. The
  exact current-main negative control below still reproduces both production
  defects.

## Test Plan

Candidate publication head: `70863469a82ff030dde36cc37febc5315f3ea582`,
parent `10e6a7f21094b76c65efb029b39b3f2227516418`.

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/core/test_scheduler.py::test_finished_spec_decode_registers_accepted_tokens \
  tests/v1/core/test_async_scheduler.py::test_finished_request_does_not_cache_in_flight_tokens \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_transient_checkpoint_evicts_retained_boundary_hash \
  -q

VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/core/prefix_cache/test_mamba_eagle_resume_checkpoint.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py \
  tests/v1/core/test_async_scheduler.py -q

VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/v1/core/test_prefix_caching.py -q

VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/core/test_scheduler.py -q

.venv/bin/pre-commit run --files \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py \
  tests/v1/core/test_async_scheduler.py \
  tests/v1/core/test_scheduler.py \
  vllm/v1/core/sched/scheduler.py \
  vllm/v1/core/single_type_kv_cache_manager.py
```

## Test Result

- Focused regression and safety cases: `8 passed`.
- Same tests on the test-only `10e6a7f21094` control: `4 failed, 4 passed`.
  The failures are ordinary terminal publication (`32 != 48`), synchronous and
  asynchronous emulated-MTP publication (`0 != 16`), and Mamba copy-on-write
  ownership. The three original safety cases and current main's transient
  cleanup pass.
- On candidate `1737b77c561f` (parent `e378275a8f20`, stable patch ID identical
  to this head), moving the async guard ahead of transient-checkpoint cleanup
  produced `1 failed, 7 passed`, exactly the stale-hash interaction.
- Mamba/EAGLE, partial-prefix, and async-scheduler group: `82 passed`.
- Mamba align chunk-split and prefix-caching group: `206 passed`.
- Full scheduler file: `140 passed, 39 failed`; an exact-main control excluding
  this PR's five new parameter cases produced `135 passed, 39 failed`. The same
  39 multimodal/encoder-connector tests fail locally because `torchvision` is
  not installed; this PR adds no failure.
- All applicable changed-file pre-commit hooks and `git diff --check` passed.

### Model evaluation

On 2026-09-10, one controlled A/B run per arm on an NVIDIA RTX A6000 used
`Qwen/Qwen3-0.6B` at revision
`c1899de289a04d12100db370d81485cdf75e47ca`, fp16, PyTorch
`2.13.0+cu130`, eager synchronous V1 execution, block size 16, APC, ngram
speculation with K=3, and greedy sampling.

The exact-source baseline `9e257065601` reused 32 tokens. The patched pod head
`38be1bf93a2` (the same scheduler hunk as this refresh) reused 48. Both arms
accepted all three draft tokens in one speculative step and returned identical
token IDs and text for both requests. That attention-only run did not exercise
the current-main Mamba ordering adaptation.

Both arms loaded the same compatible precompiled CUDA extension artifacts from
`08b3e67b669`; their Python source came from the exact heads above. This was
`n=1` per arm on one A6000. It validates the ordinary full-attention ngram reuse
boundary, not throughput or hybrid/Mamba/real-MTP behavior. The GPU run was not
repeated for the 2026-09-20 rebase; the current-main validation above is CPU
structural/unit coverage.

## Disclosure

AI assistance (Claude and OpenAI Codex) was used for analysis, test development,
and drafting. I reviewed and understand every changed line and ran the reported
test selections in my workspace.
