### PR TITLE
[Doc] Clarify partial-block caching exception for align-mode Mamba hybrids

### DIFF
--- a/docs/design/prefix_caching.md
+++ b/docs/design/prefix_caching.md
@@ -19,7 +19,11 @@ In the example above, the KV cache in the first block can be uniquely identified
 * Extra hashes: Other values required to make this block unique, such as LoRA IDs, multi-modality input hashes (see the example below), and cache salts to isolate caches in multi-tenant environments.
 
 !!! note "Note 1"
-    We only cache full blocks.
+    Only full blocks are cached in the general case. Hybrid models with a Mamba
+    group in `align` mode are an exception: when the hash block size is finer
+    than the group's block size, a partially filled tail block can be cached,
+    keyed by the fine-grained hash at that token boundary. See
+    `BlockPool.cache_partial_block`.
 
 !!! note "Note 2"
     In previous versions, the hash key was not guaranteed to be collision-free. As of v0.11, the default hashing algorithm is `sha256`, which addresses collision risks.


### PR DESCRIPTION
## Summary
Note 1 in the prefix caching design doc states "We only cache full blocks"
without exception. This clarifies that hybrid models with a Mamba group in
`align` mode are an exception: a partially filled tail block can be cached
when the hash block size is finer than the group's block size, via
`BlockPool.cache_partial_block`.

## Why this isn't duplicating existing work
Searched open PRs for `prefix_caching.md`, `cache_partial_block`, and
Mamba/align-mode doc keywords. No open PR modifies
`docs/design/prefix_caching.md` or documents `cache_partial_block`
(closest are #52898, #46778, #54738, which touch different files).

## Test plan
- `mkdocs serve` (`API_AUTONAV_EXCLUDE=vllm`) builds cleanly with this change,
  no new warnings/errors introduced.

## AI assistance disclosure
PR drafted with Claude Code.