### PR TITLE
[CI/Build][ROCm] Guard the two CUDA-only tests in test_bf16_skinny_gemm

### DIFF
--- a/tests/kernels/test_bf16_skinny_gemm.py
+++ b/tests/kernels/test_bf16_skinny_gemm.py
@@ -18,6 +18,7 @@ from vllm.models.deepseek_v32.nvidia import glm52_low_latency_gemm as glm52_gemm
 from vllm.models.kimi_k3.nvidia import low_latency_gemm as k3_gemm
 from vllm.models.kimi_k3.nvidia.low_latency_gemm import KIMI_K3_PROJECTIONS
 from vllm.models.qwen4_exp.nvidia import low_latency_gemm as qwen4_exp_gemm
+from vllm.platforms import current_platform
 
 # Keyed by local (N, K): (cute token counts, dsv3 token counts). 1536x7168 is
 # the unified shared_gate_up_proj/mla_g_proj entry (dsv3 M1..16).
@@ -284,7 +285,7 @@ def test_kda_projection_overlap_is_tp8_only(tp_size: int) -> None:
 def test_kda_qkvg_autotune_enables_full_overlap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import flashinfer.gemm
+    flashinfer_gemm = pytest.importorskip("flashinfer.gemm")
 
     from vllm.models.kimi_k3.nvidia.kda import KimiK3DeltaAttention
 
@@ -302,7 +303,7 @@ def test_kda_qkvg_autotune_enables_full_overlap(
         calls.append((a.shape, b.shape, pdl, backend))
         return torch.empty(a.shape[0], b.shape[1], dtype=a.dtype)
 
-    monkeypatch.setattr(flashinfer.gemm, "mm_bf16", fake_mm_bf16)
+    monkeypatch.setattr(flashinfer_gemm, "mm_bf16", fake_mm_bf16)
 
     k3_gemm.autotune_kda_qkvg(kda)
 
@@ -1216,6 +1217,12 @@ def test_residual_dispatch_falls_back_to_addmm(
     assert output is fallback
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="The base UnquantizedLinearMethod is platform-dispatched: on ROCm it "
+    "goes through the vllm::rocm_unquantized_gemm custom op, which has no CPU "
+    "kernel, so the CPU-tensor fallback cannot be exercised there.",
+)
 def test_fallback_preserves_default_method() -> None:
     x = torch.randn(2, 4)
     weight = torch.randn(3, 4)


### PR DESCRIPTION
## Purpose

The `(MI355) Miscellaneous Kernels` job fails on two tests in
`tests/kernels/test_bf16_skinny_gemm.py`. Neither failure indicates a bug in
the code under test. Both are unstated CUDA assumptions inside the tests
themselves.

That job is added by [#50519](https://github.com/vllm-project/vllm/pull/50519), which extends ROCm CI coverage to the portable
parts of upstream CUDA test groups.

Failing run: https://buildkite.com/vllm/amd-ci/builds/12548

## test_kda_qkvg_autotune_enables_full_overlap

The test body does a bare `import flashinfer.gemm`. FlashInfer is an optional
dependency, so the test errors instead of skipping whenever it is absent. That
is always the case on ROCm, and it is possible on CUDA too.

The test is FlashInfer-only by construction. `autotune_kda_qkvg` does
`from flashinfer.gemm import mm_bf16` itself, and the assertion pins the
`"cute-dsl"` backend. Replaced with `pytest.importorskip`, matching the
existing idiom in `tests/kernels/attention/test_mha_attn.py` and
`tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py`.

## test_fallback_preserves_default_method

The test builds CPU tensors so that `_runtime_ok` fails and the mixin defers to
`UnquantizedLinearMethod`, then asserts the output equals `F.linear`.

That base method is platform dispatched in `dispatch_unquantized_gemm`. On CUDA
it resolves to `default_unquantized_gemm`, a plain `F.linear` that is happy
with CPU tensors. On ROCm it resolves to `rocm_unquantized_gemm`, which calls
the `vllm::rocm_unquantized_gemm` custom op. That op is registered only for the
CUDA and Meta dispatch keys, so CPU tensors raise `NotImplementedError`.

The premise is CUDA-specific, so the test is gated on
`current_platform.is_cuda()` and its body is unchanged. The method under test
lives in `vllm/models/kimi_k3/nvidia/` and is not installed on ROCm, so gating
costs no real coverage.

## Test Plan

`pytest tests/kernels/test_bf16_skinny_gemm.py` on MI355X (gfx950).

## Test Result

Before: 2 failed. After: 125 passed, 265 skipped, with both tests reporting
their skip reason.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

