### PR TITLE
[ROCm] Don't search MFMA-only tuning parameters on RDNA targets

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -334,6 +334,8 @@ def benchmark_config(
 
 
 def get_rocm_tuning_space(use_fp16):
+    from vllm.platforms.rocm import on_cdna
+
     block_mn_range = [16, 32, 64, 128, 256]
     block_k_range = [16, 32, 64, 128, 256]
     if not use_fp16:
@@ -342,8 +344,14 @@ def get_rocm_tuning_space(use_fp16):
     group_m_range = [1, 4, 8, 16, 32]
     num_stage_range = [2]
     waves_per_eu_range = [0, 1, 2, 4]
-    matrix_instr_nonkdim_range = [16, 32] if use_fp16 else []
-    kpack_range = [1, 2] if use_fp16 else []
+
+    # matrix_instr_nonkdim and kpack select MFMA instruction shapes, which exist
+    # only on CDNA. RDNA (gfx11xx/gfx12xx) uses WMMA and has no MFMA, so varying
+    # them there multiplies the search space (4x for fp16) without producing
+    # distinguishable configurations.
+    has_mfma = on_cdna()
+    matrix_instr_nonkdim_range = [16, 32] if (use_fp16 and has_mfma) else []
+    kpack_range = [1, 2] if (use_fp16 and has_mfma) else []
 
     param_ranges = {
         "BLOCK_SIZE_M": block_mn_range,
@@ -354,7 +362,7 @@ def get_rocm_tuning_space(use_fp16):
         "num_stages": num_stage_range,
         "waves_per_eu": waves_per_eu_range,
     }
-    if use_fp16:
+    if use_fp16 and has_mfma:
         param_ranges["matrix_instr_nonkdim"] = matrix_instr_nonkdim_range
         param_ranges["kpack"] = kpack_range
 
@@ -443,8 +451,10 @@ def prune_rocm_configs(M, N, K, configs, is_fp16=True):
         BLOCK_SIZE_K = config.get("BLOCK_SIZE_K")
         num_warps = config.get("num_warps")
 
-        if is_fp16:
-            matrix_instr_nonkdim = config.get("matrix_instr_nonkdim")
+        # matrix_instr_nonkdim is absent on RDNA (see get_rocm_tuning_space), so
+        # checks that depend on it must be skipped rather than compared to None.
+        matrix_instr_nonkdim = config.get("matrix_instr_nonkdim")
+        if is_fp16 and matrix_instr_nonkdim is not None:
             if matrix_instr_nonkdim > mfma:
                 continue
         if mfma == 4 and BLOCK_SIZE_K < 64:
@@ -455,7 +465,7 @@ def prune_rocm_configs(M, N, K, configs, is_fp16=True):
             continue
         SPLIT_K = config.get("SPLIT_K", 1)
         GROUP_M = config.get("GROUP_SIZE_M")
-        if is_fp16:
+        if is_fp16 and matrix_instr_nonkdim is not None:
             if (
                 matrix_instr_nonkdim > BLOCK_SIZE_M
                 or matrix_instr_nonkdim > BLOCK_SIZE_N


### PR DESCRIPTION
## Summary

`benchmarks/kernels/benchmark_moe.py` adds `matrix_instr_nonkdim` and `kpack` to the ROCm
MoE autotune search space unconditionally. Both select **MFMA** instruction shapes. MFMA
exists on CDNA; RDNA (gfx11xx / gfx12xx) uses **WMMA** and has no MFMA at all.

There is no architecture check in the file, so RDNA targets tune over a search space that
is **2.0–3.2× larger than necessary after pruning**, and `prune_rocm_configs` makes four
filtering decisions keyed off a parameter that maps to no instruction on that hardware.

This gates both parameters on the existing `vllm.platforms.rocm.on_cdna()` accessor.
**CDNA behaviour is unchanged.**

## The current behaviour

`get_rocm_tuning_space()` (line ~345 on `41848caa6`):

```python
matrix_instr_nonkdim_range = [16, 32] if use_fp16 else []
kpack_range = [1, 2] if use_fp16 else []
...
if use_fp16:
    param_ranges["matrix_instr_nonkdim"] = matrix_instr_nonkdim_range
    param_ranges["kpack"] = kpack_range
```

Grepping all 1,089 lines for `gfx`, `gcnArch`, `arch_name`, `is_navi`, `has_mfma`, `CDNA`,
`RDNA`, `wmma`, `mfma` returns three hits, all inside `prune_rocm_configs`, and none of them
queries the device:

```python
mfma = 16 if M < 32 or N < 32 else 32   # derived from matrix shape, not from hardware
```

`prune_rocm_configs` then filters on `matrix_instr_nonkdim` in four places:

```python
if matrix_instr_nonkdim > mfma: continue
if matrix_instr_nonkdim > BLOCK_SIZE_M or matrix_instr_nonkdim > BLOCK_SIZE_N: continue
if matrix_instr_nonkdim >= M and matrix_instr_nonkdim != BLOCK_SIZE_M: continue
if matrix_instr_nonkdim >= N and matrix_instr_nonkdim != BLOCK_SIZE_N: continue
```

On RDNA the search is therefore both inflated *and* pruned by a parameter with no hardware
behind it.

## The change

1. **`get_rocm_tuning_space()`** — gate both parameters on `on_cdna()`. That accessor already
   exists in `vllm/platforms/rocm.py` next to `on_rdna()`, `on_rdna4()`, `on_gfx9()` and
   `get_cdna_version()`, so **no new device detection is introduced**.

2. **`prune_rocm_configs()`** — hoist the `config.get("matrix_instr_nonkdim")` read and guard
   the dependent branches with `is not None`. Required, not cosmetic: `.get()` returns `None`
   when the key is absent and `None > int` raises `TypeError`.

16 insertions, 6 deletions, one file.

## Test plan

### Search space size, `on_cdna()` stubbed both ways

| `on_cdna()` | `use_fp16` | enumerated | MFMA keys present |
|---|---|---|---|
| `True` | `True` | **40,000** | `matrix_instr_nonkdim`, `kpack` |
| `True` | `False` | 8,000 | none |
| `False` | `True` | **10,000** | none |
| `False` | `False` | 8,000 | none |

### After running the real `prune_rocm_configs`

This is the number that determines tuning wall-clock time. Shapes are Qwen3-30B-A3B-style
(N=768 per rank, K=4096):

| shape | CDNA (unchanged) | RDNA (this PR) | reduction |
|---|---|---|---|
| M=1 (decode) | 704 | **352** | 2.0× |
| M=64 | 4,992 | **1,712** | 2.9× |
| M=4096 (prefill) | 24,896 | **7,760** | 3.2× |

The effective reduction is 2.0–3.2× rather than the naive 4×, because the existing pruning
already removes some of the redundancy. `prune_rocm_configs` runs without error on the
reduced space, which exercises the `is not None` guard.

### Not covered by this test plan

- **`ruff` / `pre-commit` were not run** — no working Python tooling on the test machine
  (Python 3.14, no wheels for `pre-commit` or `ruff`). Verified manually: file parses, no
  trailing whitespace, no tabs, all added lines ≤ 88 chars, `git diff --check` clean. If CI
  reformats the comment block, that is expected.
- **No end-to-end tune was run**, for the same reason — no vLLM install on this machine.
- **The CDNA path was not executed on hardware.** I have RDNA 4 only.

## What I could not verify

**What AMD's Triton fork does with `matrix_instr_nonkdim` on an RDNA target** — whether it is
silently ignored or raises. No Triton install available.

This does not change the conclusion either way: if it is ignored, those configurations are
duplicates; if it raises, they are failed trials. Neither yields useful tuning data. But if a
maintainer knows the Triton-side behaviour it may permit a tighter fix — for example keeping
a single fixed value rather than dropping the key.

**Whether `on_cdna()` is the right predicate for `gfx1250`.** `vllm/platforms/rocm.py`
classifies it as CDNA despite the gfx12 prefix:

```python
_ON_CDNA = any(arch in _GCN_ARCH for arch in ["gfx9", "gfx1250"])
# RDNA = gfx11/gfx12 minus the CDNA-classified gfx1250.
_ON_RDNA = _ON_GFX1X and not _ON_CDNA
```

So `gfx1250` keeps the MFMA parameters under this patch. That appears to be intended by the
existing taxonomy, but I cannot test it and would appreciate confirmation.

## Hardware facts this rests on

Verified by compilation on an RX 9070 XT (gfx1201, RDNA 4), ROCm 7.1.52801, Ubuntu 26.04:

```
gfx1201  __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12    compiles
gfx1201  __builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12 compiles
gfx1201  MFMA                                                does not exist
```

A related CDNA-only feature, confirming the family split — async global→LDS copy:

| target | `__builtin_amdgcn_global_load_lds` |
|---|---|
| `gfx90a` (CDNA 2) | available |
| `gfx942` (CDNA 3) | available |
| `gfx1100` (RDNA 3) | `needs target feature vmem-to-lds-load-insts` |
| `gfx1201` (RDNA 4) | `needs target feature vmem-to-lds-load-insts` |

## Base

`41848caa63b131f931618055d3ece0b487ce8edb` (2026-09-02)