### PR TITLE
[Bugfix] Fix chat_template_content_format=openai crashing text-only models

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -18,6 +18,7 @@ from vllm.entrypoints.chat_utils import (
     MEDIA_CONNECTOR_REGISTRY,
     AsyncMultiModalItemTracker,
     ConversationMessage,
+    _collapse_text_only_content,
     _postprocess_messages,
     parse_chat_messages,
     parse_chat_messages_async,
@@ -47,6 +48,14 @@ def kimi_k2_5_model_config():
         limit_mm_per_prompt={
             "image": 2,
         },
+    )
+
+
+@pytest.fixture(scope="function")
+def qwen25_model_config():
+    return ModelConfig(
+        "Qwen/Qwen2.5-0.5B-Instruct",
+        runner="generate",
     )
 
 
@@ -3138,3 +3147,90 @@ def test_tool_call_arguments_multiple_independent(caplog):
 
     assert len(caplog.records) == 1
     assert "bad" in caplog.records[0].message
+
+
+def test_collapse_text_only_content_helper():
+    # Plain string is passed through unchanged.
+    assert _collapse_text_only_content("hello") == "hello"
+
+    # A single text part collapses to its string.
+    assert _collapse_text_only_content([{"type": "text", "text": "hello"}]) == "hello"
+
+    # Multiple text parts are joined with newlines, matching the plain
+    # `content_format="string"` behavior.
+    assert (
+        _collapse_text_only_content(
+            [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b"},
+            ]
+        )
+        == "a\nb"
+    )
+
+    # An empty list of parts collapses to an empty string.
+    assert _collapse_text_only_content([]) == ""
+
+    # Structured (non-text) parts are left untouched so a template can
+    # still expand them, e.g. images or `tool_reference` entries.
+    mixed = [{"type": "text", "text": "a"}, {"type": "image"}]
+    assert _collapse_text_only_content(mixed) is mixed
+
+    tool_ref = [{"type": "tool_reference", "name": "x"}]
+    assert _collapse_text_only_content(tool_ref) is tool_ref
+
+
+def test_parse_chat_messages_openai_format_text_only_model(
+    qwen25_model_config,
+):
+    # https://github.com/vllm-project/vllm/issues/54491
+    # `--chat-template-content-format openai` used to wrap every message's
+    # content in `[{"type": "text", "text": ...}]` even for a plain
+    # text-only model, which broke chat templates (like Qwen2.5's) that
+    # only know how to handle a string `content` field -- see the
+    # `TypeError` this reproduces without the fix in `_collapse_text_only_content`.
+    conversation, mm_data, mm_uuids = parse_chat_messages(
+        [{"role": "user", "content": "Reply with exactly OK."}],
+        qwen25_model_config,
+        content_format="openai",
+    )
+
+    assert conversation == [
+        {"role": "user", "content": "Reply with exactly OK."},
+    ]
+    assert mm_data is None
+    assert mm_uuids is None
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(qwen25_model_config.model)
+    # This must not raise `TypeError: can only concatenate str (not "list")
+    # to str`, which is what a plain-string chat template raises when given
+    # list-shaped content.
+    rendered = tokenizer.apply_chat_template(
+        conversation, tokenize=False, add_generation_prompt=True
+    )
+    assert "Reply with exactly OK." in rendered
+
+
+def test_parse_chat_messages_openai_format_multimodal_model_keeps_array(
+    phi3v_model_config,
+):
+    # A multimodal model's chat template is written for (and tested
+    # against) the array shape, so text-only content stays wrapped when the
+    # model actually supports multimodal input -- only text-only models get
+    # the plain-string fallback above.
+    conversation, mm_data, mm_uuids = parse_chat_messages(
+        [{"role": "user", "content": "What about this one?"}],
+        phi3v_model_config,
+        content_format="openai",
+    )
+
+    assert conversation == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "What about this one?"}],
+        },
+    ]
+    assert mm_data is None
+    assert mm_uuids is None

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1963,6 +1963,37 @@ _AssistantParser = partial(cast, ChatCompletionAssistantMessageParam)
 _ToolParser = partial(cast, ChatCompletionToolMessageParam)
 
 
+def _collapse_text_only_content(
+    content: str | None | list[dict[str, str]],
+) -> str | None | list[dict[str, str]]:
+    """Collapse OpenAI-style array content back to a plain string when it
+    contains only text parts.
+
+    ``content_format="openai"`` wraps every message's content in
+    ``[{"type": "text", "text": ...}, ...]`` regardless of role, but most
+    community chat templates (including many single-string Jinja templates)
+    only know how to handle a plain string content field and will raise a
+    ``TypeError`` trying to concatenate it. Structured parts that a template
+    needs to expand (images, audio, ``tool_reference``, etc.) are left
+    untouched.
+    """
+    if not isinstance(content, list):
+        return content
+
+    has_non_text = any(
+        isinstance(item, dict) and item.get("type") != "text" for item in content
+    )
+    if has_non_text:
+        return content
+
+    texts = [
+        item.get("text", "")
+        for item in content
+        if isinstance(item, dict) and item.get("type") == "text"
+    ]
+    return "\n".join(texts) if texts else ""
+
+
 def _parse_chat_message_content(
     message: ChatCompletionMessageParam,
     mm_tracker: BaseMultiModalItemTracker,
@@ -1987,7 +2018,23 @@ def _parse_chat_message_content(
         mm_processor_kwargs=mm_processor_kwargs,
     )
 
+    # `content_format="openai"` wraps every message's content in
+    # `[{"type": "text", "text": ...}, ...]` regardless of role. Multimodal
+    # chat templates generally expect (and are tested against) that
+    # consistent shape, but plain single-string Jinja templates used by
+    # most text-only models only know how to handle a plain string and
+    # raise a TypeError trying to concatenate it. For a model with no
+    # multimodal config there is no benefit to the array shape, so collapse
+    # text-only array content back to a string; structured parts a template
+    # still needs to expand (images, audio, `tool_reference`, etc.) are
+    # left untouched either way.
+    is_multimodal_model = mm_tracker.model_config.multimodal_config is not None
+
     for result_msg in result:
+        if role == "tool" or not is_multimodal_model:
+            result_msg["content"] = _collapse_text_only_content(
+                result_msg.get("content")
+            )
         if role == "assistant":
             parsed_msg = _AssistantParser(message)
 
@@ -2006,28 +2053,6 @@ def _parse_chat_message_content(
             parsed_msg = _ToolParser(message)
             if "tool_call_id" in parsed_msg:
                 result_msg["tool_call_id"] = parsed_msg["tool_call_id"]
-            # Normalize tool message content from OpenAI array format to plain
-            # string. Clients like Claude Code / Cursor send tool results as
-            # [{"type": "text", "text": "..."}], but most chat templates only
-            # handle string content for tool messages.
-            # However, tool_reference items must be preserved as structured
-            # dicts for the chat template to expand them.
-            msg_content = result_msg.get("content")
-            if isinstance(msg_content, list):
-                has_non_text = any(
-                    isinstance(item, dict) and item.get("type") != "text"
-                    for item in msg_content
-                )
-                if has_non_text:
-                    # Keep structured content (e.g., tool_reference)
-                    result_msg["content"] = msg_content
-                else:
-                    texts = [
-                        item.get("text", "")
-                        for item in msg_content
-                        if isinstance(item, dict) and item.get("type") == "text"
-                    ]
-                    result_msg["content"] = "\n".join(texts) if texts else ""
 
         if "name" in message and isinstance(message["name"], str):
             result_msg["name"] = message["name"]


### PR DESCRIPTION
## Summary

`--chat-template-content-format openai` wraps every message's `content` in
`[{"type": "text", "text": ...}, ...]` regardless of role or whether the model
is multimodal. Many text-only models' chat templates (Qwen2.5 included) only
know how to handle a plain string `content` field, so this raises
`TypeError: can only concatenate str (not "list") to str` deep inside the
Jinja render — chat, streaming, multi-turn, and JSON-schema requests all fail
with HTTP 400.

Repro (no GPU needed):
```python
from transformers import AutoTokenizer
tok = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
tok.apply_chat_template(
    [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
    tokenize=False, add_generation_prompt=True,
)
# TypeError: can only concatenate str (not "list") to str
```

## Fix

Adds `_collapse_text_only_content`, which collapses list content back to a
plain string when every part is plain text, and applies it whenever the
model has no multimodal config (`model_config.multimodal_config is None`).
This generalizes the existing tool-role-only normalization added for a
similar reason (tool results / Claude Code & Cursor clients) to also cover
`user`/`system`/`assistant` messages on text-only models.

Structured parts a template still needs to expand (images, audio,
`tool_reference`, etc.) are left untouched, and a genuinely multimodal
model's chat template keeps the array shape it's written for — the existing
`test_parse_chat_messages_context_text_format` (phi3v) test still passes
unchanged, and a new test
(`test_parse_chat_messages_openai_format_multimodal_model_keeps_array`)
pins that behavior down explicitly.

## Test plan

- `test_collapse_text_only_content_helper`: unit-tests the new helper directly
  (plain string passthrough, single/multiple text parts, empty list, mixed
  content and `tool_reference` left untouched).
- `test_parse_chat_messages_openai_format_text_only_model`: reproduces the
  exact reported failure with `Qwen/Qwen2.5-0.5B-Instruct` and asserts the
  chat template now renders successfully.
- `test_parse_chat_messages_openai_format_multimodal_model_keeps_array`:
  confirms a multimodal model (phi3v) keeps the array shape, so this fix
  doesn't regress multimodal chat templates.
- Ran the full `tests/entrypoints/unit_tests/test_chat_utils.py` suite
  locally: 75 passed, 7 pre-existing failures unrelated to this change
  (a `caplog` propagation issue in `test_tool_call_arguments_*`, reproduced
  identically on a clean `main` checkout without this diff).
- `ruff check`, `ruff format --check`, and `mypy` all pass via
  `pre-commit run --files vllm/entrypoints/chat_utils.py tests/entrypoints/unit_tests/test_chat_utils.py`.

Fixes #54491

🤖 Generated with [Claude Code](https://claude.com/claude-code)