### PR TITLE
[ROCm][CI] Fix false multi-node detection on native CI

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -645,7 +645,7 @@ is_multi_node() {
   fi
   # Fallback: detect the bracket syntax structurally
   # Pattern: [...] && [...] (per-node command arrays)
-  if [[ "$cmds" =~ \[.*\].*\&\&.*\[.*\] ]]; then
+  if [[ "$cmds" == *'] && ['* ]]; then
     return 0
   fi
   return 1


### PR DESCRIPTION
Native AMD CI on [build 86848](https://buildkite.com/vllm/ci/builds/86848/canvas?jid=01a0624a-61b6-471a-97f6-c1cb2ca6a3e0&tab=output) (`amd-entrypoints-integration-api-server`) exited immediately with `Native CI does not support multi-node jobs yet.` after [#52344](https://github.com/vllm-project/vllm/pull/52344) added an `if [ "$BUILDKITE_PARALLEL_JOB" = "1" ]` guard. `is_multi_node()` treated that bash `[ ... ]` test as the `[node0] && [node1]` multi-node syntax. This tightens the fallback to the real `] && [` delimiter so sharded single-node jobs still run.