### PR TITLE
[Skills] Add kernel benchmark sanity references

### DIFF
--- a/.agents/skills/kernel-microbenchmark/SKILL.md
+++ b/.agents/skills/kernel-microbenchmark/SKILL.md
@@ -42,6 +42,25 @@ description: Build, debug, and interpret vLLM GPU kernel microbenchmarks for CUD
 - Keep metadata setup, plan construction, allocation, random input generation,
   and logging outside the timed region unless that overhead is the experiment.
 
+## Sanity-Check Reference Numbers
+
+Use these as rough reference points for large, well-shaped workloads, not as
+gold standards, guaranteed peaks, or hard limits. Hardware SKU, clocks, shape,
+precision conventions, and the FLOP/byte accounting can move the result. A
+large gap is a prompt to investigate, not proof that a kernel is poor.
+
+| Kernel regime | Hardware | Rough reference |
+| --- | --- | ---: |
+| Memory-bound, large batch | Blackwell | 6 TB/s |
+| BF16 GEMM | Blackwell | 2 PFLOP/s |
+| BF16 attention | B200 | 1.6 PFLOP/s |
+| FP8 GEMM | Blackwell | 4 PFLOP/s |
+| FP8 attention | B300 | 2.8 PFLOP/s |
+
+The BF16 attention reference is approximately the 1613 TFLOP/s result reported
+by the FlashAttention-4 paper. Compare kernels only with matching workload and
+throughput conventions.
+
 ## Multi-GPU Benchmarks
 
 - State whether the run is local or multi-node and report the GPU topology,


### PR DESCRIPTION
## Summary

- add rough Blackwell sanity-check references for memory-bound, GEMM, and
  attention kernel benchmarks
- clarify that the figures are diagnostic reference points rather than gold
  standards, guaranteed peaks, or hard limits
- note the FlashAttention-4 source for the B200 BF16 attention result

## Duplicate-work check

Searched open PRs for `kernel-microbenchmark`, `PFLOP/s`, and
`FlashAttention-4 skill`; no matching PR was found. This change is not linked
to an issue.

## Tests

- `.venv/bin/python /home/woosuk/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/kernel-microbenchmark` — passed (`Skill is valid!`)
- `git diff --check` — passed
- `.venv/bin/pre-commit run --files .agents/skills/kernel-microbenchmark/SKILL.md` — passed (applicable hooks, including markdownlint and typos)

Model evaluation is not applicable because this changes contributor skill
guidance only and does not affect model output, accuracy, or serving behavior.

## AI assistance

OpenAI Codex assisted with editing, duplicate-work checks, validation, the
commit, and drafting this PR description. The human submitter reviewed every
changed line and is responsible for the change.
