### PR TITLE
[Bugfix] Gate sm_100-only MLA backend tests on the capability family

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -139,8 +139,11 @@ def test_dcp_chunked_context_accepts_non_virtual_block_aligned_prefix():
     assert [chunk.num_local_context_tokens for chunk in metadata.chunks] == [17, 24]
 
 
-# Remove sm100 backends from the list if not using sm100
-if not torch.cuda.is_available() or torch.cuda.get_device_properties(0).major < 10:
+# Remove sm100 backends from the list if not using sm100. These backends
+# declare supports_compute_capability as major == 10, so gate on the
+# capability family rather than ">= 10": consumer Blackwell (sm_120/sm_121)
+# is major 12 but has no trtllm-gen / CUTLASS MLA runner.
+if not torch.cuda.is_available() or not current_platform.is_device_capability_family(100):
     BACKENDS_TO_TEST.remove(AttentionBackendEnum.CUTLASS_MLA)
     BACKENDS_TO_TEST.remove(AttentionBackendEnum.FLASHINFER_MLA)
     BACKENDS_TO_TEST.remove(AttentionBackendEnum.TOKENSPEED_MLA)


### PR DESCRIPTION
## Purpose

`tests/v1/attention/test_mla_backends.py` removes `CUTLASS_MLA`, `FLASHINFER_MLA` and `TOKENSPEED_MLA` from `BACKENDS_TO_TEST` when the device's major capability is below 10. All three backends declare `supports_compute_capability` as `major == 10`, so on consumer Blackwell (sm_120 / sm_121, major 12) the test keeps backends the selector would never pick, and every parametrization fails on paths only a trtllm-gen or CUTLASS sm_100 runner can execute.

On a GB10 (sm_121) the full file reports 109 passed / 514 failed, identical across three runs. 240 failures are `FLASHINFER_MLA`: flashinfer resolves `backend="auto"` to `"xqa"` whenever major != 10, and xqa rejects the `multi_ctas_kv_counter_buffer` the vLLM backend passes for page sizes 32/64. 288 are `CUTLASS_MLA` hitting `_C::sm100_cutlass_mla_get_workspace_size`, which has no kernel for this arch. Neither is a defect in the backends, which correctly refuse sm_12x via `supports_compute_capability`; the test bypasses that check.

Gate on `current_platform.is_device_capability_family(100)` instead, matching the backends' own declaration and the fix applied to the kernel tests in #54306.

## Test Plan

Same file, `R1 and single_decode` subset of `test_backend_correctness` (48 tests), on the GB10.

## Test Result

```
main:                 48 failed  (24 ValueError, 24 NotImplementedError)
this change:          32 failed / 16 passed. All 32 remaining are
                      "OutOfResources: shared memory, Required: 102400,
                      Hardware limit: 101376" from TRITON_MLA
this change + #54013: 48 passed
```

The remaining failures are the fp8 KV cache shared memory overflow that #54013 fixes, so the two together make this file pass on sm_121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Summary by CodeRabbit

- **Tests**
  - Updated backend compatibility coverage to exclude SM100-specific backends on unsupported devices.
  - Consumer Blackwell devices are no longer treated as compatible with these backends.

