### PR TITLE
[Bugfix] Cover uniform decode sizes under an explicit max_cudagraph_capture_size

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -1298,3 +1298,69 @@ def test_inductor_asserts_user_override(monkeypatch):
     assert config.inductor_compile_config.get("size_asserts") is True
     if not _is_torch_equal_or_newer(torch.__version__, "2.12.0.dev"):
         assert config.inductor_compile_config.get("alignment_asserts") is False
+
+
+@pytest.mark.parametrize(
+    ("max_cudagraph_capture_size", "expected_max", "widest_is_captured"),
+    [
+        # The widest uniform decode batch (6 requests * 7 tokens) fits the
+        # explicit bound exactly, but sits off the 8-token grid. It must be
+        # captured, and the explicit maximum must survive instead of being
+        # truncated to the last grid entry (40).
+        (42, 42, True),
+        # Room above the widest batch: still captured, maximum unchanged.
+        (48, 48, True),
+        # Explicit bound below the widest batch: it is correctly left out and
+        # the maximum still snaps to the largest captured size.
+        (40, 40, False),
+    ],
+)
+def test_explicit_max_cudagraph_capture_size_covers_uniform_decode(
+    max_cudagraph_capture_size, expected_max, widest_is_captured
+):
+    """An explicit scalar maximum with an inferred capture list must still
+    cover schedulable uniform decode shapes within that bound. Previously the
+    uniform decode sizes were only appended when the maximum was derived here,
+    so `max_cudagraph_capture_size=42` produced a list ending at 40, the
+    maximum was truncated to 40, and the 42-token decode step ran eager.
+    """
+    compilation_config = CompilationConfig(
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        max_cudagraph_capture_size=max_cudagraph_capture_size,
+    )
+    config = _mock_config_for_cudagraph_sizes(
+        max_num_seqs=6,
+        num_speculative_tokens=6,
+        max_num_batched_tokens=8192,
+        compilation_config=compilation_config,
+    )
+
+    VllmConfig._set_cudagraph_sizes(config)
+
+    widest_uniform_decode = 6 * 7
+    sizes = compilation_config.cudagraph_capture_sizes
+    assert compilation_config.max_cudagraph_capture_size == expected_max
+    assert sizes[-1] == expected_max
+    assert (widest_uniform_decode in sizes) is widest_is_captured
+    assert all(size <= max_cudagraph_capture_size for size in sizes)
+
+
+def test_explicit_cudagraph_capture_sizes_are_left_as_configured():
+    """An explicit capture list is never extended with uniform decode sizes,
+    even when speculation makes a wider uniform batch schedulable.
+    """
+    compilation_config = CompilationConfig(
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        cudagraph_capture_sizes=[8, 16],
+    )
+    config = _mock_config_for_cudagraph_sizes(
+        max_num_seqs=6,
+        num_speculative_tokens=6,
+        max_num_batched_tokens=8192,
+        compilation_config=compilation_config,
+    )
+
+    VllmConfig._set_cudagraph_sizes(config)
+
+    assert compilation_config.cudagraph_capture_sizes == [8, 16]
+    assert compilation_config.max_cudagraph_capture_size == 16

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2004,95 +2004,102 @@ class VllmConfig:
             # is more than one token wide and only when the default is computed
             # here, so an explicit capture range is left exactly as configured.
             uniform_decode_sizes: list[int] = []
-            if max_cudagraph_capture_size is None:
-                from vllm.platforms import current_platform
+            from vllm.platforms import current_platform
 
-                default_max_graph_size = (
-                    1024 if current_platform.is_device_capability_family(100) else 512
-                )
-                decode_query_len = self.uniform_decode_query_len
-                max_num_seqs = self.scheduler_config.max_num_seqs
+            default_max_graph_size = (
+                1024 if current_platform.is_device_capability_family(100) else 512
+            )
+            decode_query_len = self.uniform_decode_query_len
+            max_num_seqs = self.scheduler_config.max_num_seqs
+            if max_cudagraph_capture_size is None:
                 max_cudagraph_capture_size = min(
                     max_num_seqs * decode_query_len * 2, default_max_graph_size
                 )
-                if decode_query_len > 1:
-                    # A uniform decode batch is decode_query_len tokens per
-                    # request, so the widest one is far outside this ceiling.
-                    # Coverage comes from appending the decode sizes rather than
-                    # extending the token-strided grid. Extending that grid to
-                    # the widest decode size produces 581 sizes at
-                    # max_num_seqs=512 and 16 draft tokens, versus 100 with the
-                    # request-count grid.
-                    #
-                    # The grid would not buy decode coverage anyway. Dispatch
-                    # requires an exact multiple of decode_query_len, so a
-                    # token-strided entry is only usable when it happens to be
-                    # one; at query length 17 a captured 560 rounds to 561 and
-                    # is rejected. Scaling a request-count grid keeps every
-                    # entry usable and the count comparable to the non-
-                    # speculative case.
-                    def request_counts(max_reqs: int) -> list[int]:
-                        # At most the platform default number of requests,
-                        # mirroring the one-token-per-request decode ceiling.
-                        max_reqs = min(max_reqs, default_max_graph_size)
-                        counts = [n for n in (1, 2, 4) if n <= max_reqs]
-                        counts += list(range(8, min(max_reqs + 1, 256), 8))
-                        counts += list(range(256, max_reqs + 1, 16))
-                        return sorted(set(counts + [max_reqs]))
+            # Cover uniform decode shapes whenever the capture list is inferred
+            # here, including under an explicit scalar maximum. A schedulable
+            # decode batch that fits the bound must not be dropped just because
+            # it is off the 8/16-token stride; otherwise the maximum is
+            # truncated to the last grid entry and that batch runs eager. An
+            # explicit cudagraph_capture_sizes list is still left as configured.
+            if (
+                self.compilation_config.cudagraph_capture_sizes is None
+                and decode_query_len > 1
+            ):
+                # A uniform decode batch is decode_query_len tokens per
+                # request, so the widest one is far outside this ceiling.
+                # Coverage comes from appending the decode sizes rather than
+                # extending the token-strided grid. Extending that grid to
+                # the widest decode size produces 581 sizes at
+                # max_num_seqs=512 and 16 draft tokens, versus 100 with the
+                # request-count grid.
+                #
+                # The grid would not buy decode coverage anyway. Dispatch
+                # requires an exact multiple of decode_query_len, so a
+                # token-strided entry is only usable when it happens to be
+                # one; at query length 17 a captured 560 rounds to 561 and
+                # is rejected. Scaling a request-count grid keeps every
+                # entry usable and the count comparable to the non-
+                # speculative case.
+                def request_counts(max_reqs: int) -> list[int]:
+                    # At most the platform default number of requests,
+                    # mirroring the one-token-per-request decode ceiling.
+                    max_reqs = min(max_reqs, default_max_graph_size)
+                    counts = [n for n in (1, 2, 4) if n <= max_reqs]
+                    counts += list(range(8, min(max_reqs + 1, 256), 8))
+                    counts += list(range(256, max_reqs + 1, 16))
+                    return sorted(set(counts + [max_reqs]))
 
-                    # Dynamic speculative decoding picks the draft width from
-                    # the batch size, so a decode step is only uniform within a
-                    # tier and each tier needs its own sizes. Scaling by the
-                    # widest one alone leaves the narrower tiers short: the
-                    # manager rounds a capture size up to a multiple of the
-                    # tier's query length and drops it once the implied request
-                    # count exceeds max_num_seqs, so at query length 3 sizes
-                    # built from 17 stop covering at 227 of 256 requests.
-                    decode_tiers = [(decode_query_len, max_num_seqs)]
-                    speculative_config = self.speculative_config
-                    if (
-                        speculative_config is not None
-                        and speculative_config.uses_dynamic_speculative_decoding()
-                    ):
-                        from vllm.v1.spec_decode.dynamic.utils import (
-                            build_dynamic_sd_schedule_lookup,
-                        )
-
-                        schedule = (
-                            speculative_config.num_speculative_tokens_per_batch_size
-                        )
-                        assert schedule is not None
-                        # Read the tiers off the dense lookup the scheduler
-                        # runs on, so the clamp against num_speculative_tokens
-                        # and the carry-forward through gaps and the tail
-                        # cannot drift from it. Validation lives elsewhere; an
-                        # invalid schedule keeps the single-tier default.
-                        try:
-                            dense_schedule = build_dynamic_sd_schedule_lookup(
-                                schedule,
-                                vllm_max_batch_size=max_num_seqs,
-                                vllm_num_speculative_tokens=self.num_speculative_tokens,
-                            )
-                        except ValueError:
-                            pass
-                        else:
-                            # Ascending batch size, so the last write per
-                            # query length is the widest batch running at it.
-                            widest_batch: dict[int, int] = {}
-                            for batch_size, num_spec in enumerate(
-                                dense_schedule[1:], start=1
-                            ):
-                                widest_batch[num_spec + 1] = batch_size
-                            decode_tiers = list(widest_batch.items())
-
-                    uniform_decode_sizes = sorted(
-                        {
-                            n * query_len
-                            for query_len, tier_max_reqs in decode_tiers
-                            for n in request_counts(tier_max_reqs)
-                            if n * query_len <= max_cudagraph_capture_size
-                        }
+                # Dynamic speculative decoding picks the draft width from
+                # the batch size, so a decode step is only uniform within a
+                # tier and each tier needs its own sizes. Scaling by the
+                # widest one alone leaves the narrower tiers short: the
+                # manager rounds a capture size up to a multiple of the
+                # tier's query length and drops it once the implied request
+                # count exceeds max_num_seqs, so at query length 3 sizes
+                # built from 17 stop covering at 227 of 256 requests.
+                decode_tiers = [(decode_query_len, max_num_seqs)]
+                speculative_config = self.speculative_config
+                if (
+                    speculative_config is not None
+                    and speculative_config.uses_dynamic_speculative_decoding()
+                ):
+                    from vllm.v1.spec_decode.dynamic.utils import (
+                        build_dynamic_sd_schedule_lookup,
                     )
+
+                    schedule = speculative_config.num_speculative_tokens_per_batch_size
+                    assert schedule is not None
+                    # Read the tiers off the dense lookup the scheduler
+                    # runs on, so the clamp against num_speculative_tokens
+                    # and the carry-forward through gaps and the tail
+                    # cannot drift from it. Validation lives elsewhere; an
+                    # invalid schedule keeps the single-tier default.
+                    try:
+                        dense_schedule = build_dynamic_sd_schedule_lookup(
+                            schedule,
+                            vllm_max_batch_size=max_num_seqs,
+                            vllm_num_speculative_tokens=self.num_speculative_tokens,
+                        )
+                    except ValueError:
+                        pass
+                    else:
+                        # Ascending batch size, so the last write per
+                        # query length is the widest batch running at it.
+                        widest_batch: dict[int, int] = {}
+                        for batch_size, num_spec in enumerate(
+                            dense_schedule[1:], start=1
+                        ):
+                            widest_batch[num_spec + 1] = batch_size
+                        decode_tiers = list(widest_batch.items())
+
+                uniform_decode_sizes = sorted(
+                    {
+                        n * query_len
+                        for query_len, tier_max_reqs in decode_tiers
+                        for n in request_counts(tier_max_reqs)
+                        if n * query_len <= max_cudagraph_capture_size
+                    }
+                )
             max_num_tokens = self.scheduler_config.max_num_batched_tokens
             max_cudagraph_capture_size = min(max_num_tokens, max_cudagraph_capture_size)
 


### PR DESCRIPTION

## Purpose

Fixes #54933.

When `max_cudagraph_capture_size` is set explicitly and `cudagraph_capture_sizes` is
left unset, `_set_cudagraph_sizes()` only builds the stepped 8/16 token grid. The
uniform decode sizes (request count times decode query length) were computed inside
the `max_cudagraph_capture_size is None` branch, so with speculation on they were never
appended, the list ended at the last grid entry, and the explicit maximum was
truncated down to it.

Concretely, `max_num_seqs=6` with six speculative tokens has a widest uniform decode
batch of 42 tokens. Setting `max_cudagraph_capture_size=42` produced
`[1, 2, 4, 8, 16, 24, 32, 40]`, a warning "Truncating max_cudagraph_capture_size to
40", and the 42 token verification step dispatched eager.

## Changes

Compute the uniform decode sizes whenever the capture list is being inferred here,
bounded by the (possibly explicit) maximum, instead of only when the maximum is also
inferred. An explicit `cudagraph_capture_sizes` list is still left exactly as
configured, and the platform default ceiling still applies when no maximum is given.

The hunk in `vllm/config/vllm.py` looks large because the uniform size block moved
out one nesting level; with whitespace ignored it is a 14 line change.

Reproducer from the issue, before and after, on current main:

```
before: max_cudagraph_capture_size = 40   sizes = [1, 2, 4, 8, 16, 24, 32, 40]
after:  max_cudagraph_capture_size = 42   sizes = [1, 2, 4, 7, 8, 14, 16, 24, 28, 32, 40, 42]
```

The extra 7, 14 and 28 entries are the same request count grid the inferred maximum
path already produces, now also present under an explicit maximum.

## Test Plan

`tests/compile/test_config.py`:
- `test_explicit_max_cudagraph_capture_size_covers_uniform_decode`, parametrized over
  a maximum equal to, above and below the widest uniform batch.
- `test_explicit_cudagraph_capture_sizes_are_left_as_configured`, guarding that an
  explicit list is never extended.

## Test Result

New tests pass together with the existing cudagraph sizing tests in that file
(`respects_platform_ceiling`, `keep_all_sizes_bounded`, `respect_sequence_parallelism`,
`caps_widest_ngram_decode_batch`). Run on a DGX Spark (GB10) against current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA graph capture sizing for workloads using uniform decode batches, ensuring eligible batch shapes are included when they fit within the configured maximum.
  - Preserved explicitly configured capture-size lists without automatically adding additional sizes.
  - Maintained explicitly configured maximum capture limits while improving support for schedulable decode shapes outside the default size increments.

