### PR TITLE
[Bugfix][CPU][Spec Decode] Write expand_kernel output at caller dtype in CPU shim

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -1183,3 +1183,38 @@ def test_placeholder_draft_token_rejected_random(rejection_sampler):
     assert sampled[0, 1].item() == vocab_size - 1
     recovered = sampled[0, 2].item()
     assert 0 <= recovered < vocab_size
+
+
+@pytest.mark.parametrize(
+    ("x", "replace_from", "replace_to"),
+    [
+        # Production dtypes from apply_sampling_constraints: fp32 temperature
+        # (with the GREEDY_TEMPERATURE=0 -> 1 rewrite), fp32 top_p, int32
+        # top_k. The CPU shim used to route these through an int64 copy,
+        # discarding the kernel's writes (output stayed uninitialized) and
+        # truncating the float values (0.7 -> 0 -> "replaced" with 1).
+        (torch.tensor([0.7, 0.5, 0.9], dtype=torch.float32), 0, 1),
+        (torch.tensor([0.9, 0.0, 0.3], dtype=torch.float32), 0, 0),
+        (torch.tensor([5, 40, 1], dtype=torch.int32), 0, 0),
+        (torch.tensor([10, 20, 30], dtype=torch.int64), 0, 0),
+    ],
+)
+def test_expand_kernel_cpu_shim_writes_output_at_caller_dtype(
+    x: torch.Tensor, replace_from: int, replace_to: int
+):
+    """The CPU expand shim must fill the caller's buffer in-place at the
+    caller's dtype, honoring the replace_from -> replace_to rewrite without
+    integer truncation of float inputs."""
+    from vllm.utils import cpu_triton_utils as cpu_tl
+
+    cu_num_tokens = torch.tensor([2, 5, 6], dtype=torch.int64)
+    counts = torch.tensor([2, 3, 1], dtype=torch.int64)
+
+    # Sentinel-filled output: proves the shim writes through, not into a
+    # discarded int64 temporary.
+    output = torch.full((6,), -777, dtype=x.dtype)
+    cpu_tl._expand_kernel_impl(output, x, cu_num_tokens, replace_from, replace_to)
+
+    expected_vals = torch.where(x == replace_from, torch.full_like(x, replace_to), x)
+    expected = torch.repeat_interleave(expected_vals, counts)
+    assert torch.equal(output, expected)

--- a/vllm/utils/cpu_triton_utils.py
+++ b/vllm/utils/cpu_triton_utils.py
@@ -413,13 +413,20 @@ def _expand_kernel_impl(
     replace_to,
     MAX_NUM_TOKENS=None,
 ):
-    torch.ops._C.expand_kernel_impl(
-        _ensure_int64(output),
-        _ensure_int64(input_val),
-        _ensure_int64(cu_num_tokens),
-        replace_from,
-        replace_to,
+    # The C++ expand kernel is int64-only, but the production callers
+    # (expand_batch_to_tokens) pass float32 temperature/top_p and int32
+    # top_k with `output` allocated in the same dtype. Routing through
+    # _ensure_int64 would discard the kernel's writes (the converted
+    # output is a copy that is never copied back) and truncate float
+    # inputs, so expand natively at the caller's dtype instead.
+    counts = torch.diff(cu_num_tokens, prepend=cu_num_tokens.new_zeros(1))
+    vals = torch.where(
+        input_val == replace_from,
+        torch.full_like(input_val, replace_to),
+        input_val,
     )
+    expanded = torch.repeat_interleave(vals, counts)
+    output[: expanded.shape[0]] = expanded
 
 
 def _sample_recovered_tokens_kernel_impl(


### PR DESCRIPTION
## Purpose

Fixes #55005.

The CPU monkey-patch for `expand_kernel` (`vllm/utils/cpu_triton_utils.py`) routed all tensors through `_ensure_int64`, which returns a *new* tensor for non-int64 inputs. The C++ kernel filled that temporary; the caller's buffer — allocated by `expand_batch_to_tokens` as `x.new_empty(num_tokens)` in x's dtype — was never written. Production passes float32 temperature/top_p and int32 top_k, so every CPU spec-decode step with a non-greedy request divided logits by uninitialized memory (zero pages → inf logits; arbitrary garbage → the OOB crash reported in #42638). Float inputs were additionally truncated (temperature 0.7 → 0 → rewritten to 1 by the `replace_from=0` logic).

## Fix

Expand natively at the caller's dtype in the shim: `torch.repeat_interleave` over `diff(cu_num_tokens)` with the `replace_from → replace_to` rewrite applied at input dtype before the store — matching the Triton kernel's compare-before-store-cast ordering. This is the semantics #42638 proposed in `expand_batch_to_tokens`, relocated to the CPU shim layer per the maintainer guidance on that PR (keep hardware-specific handling out of the common code path).

**Not a duplicate:** #42638 (closed unmerged) targeted the no-Triton-driver kernel no-op inside `expand_batch_to_tokens` and was closed after #44991 covered the Triton-CPU path, on the premise that the C++ monkey-patch fallbacks handle non-Triton environments. This PR fixes the fallback itself, which never produced correct output for the production dtypes. No open PR touches `cpu_triton_utils.py` or this path (searched `expand_kernel`, `expand_batch_to_tokens`, `cpu_triton_utils` in open PRs, 2026-09-02).

## Test Plan

New regression test `test_expand_kernel_cpu_shim_writes_output_at_caller_dtype` in `tests/v1/sample/test_rejection_sampler.py`: sentinel-filled output buffers across the three production dtypes plus the int64 control, asserting in-place writes with correct replace semantics and no truncation. Pure-torch shim, so the test runs on any platform.

```
# Before fix (main @ 605c3ddc):
3 failed, 1 passed   # int64 control passes via the dtype-identity path — the exact bug shape
# After fix:
4 passed
```

Baseline attribution: the rest of `tests/v1/sample/test_rejection_sampler.py` fails identically (75) on unmodified main in this no-GPU environment (the file targets the Triton path and is not in CPU CI); this PR changes none of those results.

Direct-shim repro (also in the linked issue) measured before/after on a from-source CPU build at `605c3ddc`: sentinel buffer untouched before, correct expansion after; fp32 temperature `[0,0,0,0,0,0]` → `[0.7, 0.7, 0.5, 0.5, 0.5, 0.9]`; int32 top_k `[0,...]` → `[5, 5, 40, 40, 40, 1]`.

Lint: `pre-commit run --files vllm/utils/cpu_triton_utils.py tests/v1/sample/test_rejection_sampler.py` — all hooks pass (ruff check/format, mypy-3.10, SPDX).

Model evals: not run — no GPU available to this contributor; the change affects only the CPU fallback path and restores the documented expand semantics verified by the unit test above.

## Disclosure

AI assistance (Claude Code) was used for the audit, repro, and patch; every changed line was reviewed and all commands above were run by the submitter. Commit carries a `Co-authored-by` trailer per AGENTS.md.




## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU sampling expansion to preserve the caller’s original data types.
  * Prevented truncation of floating-point values during replacement and expansion operations.
  * Ensured results are written directly to the provided output, improving correctness for CPU execution.

* **Tests**
  * Added coverage for floating-point and integer sampling inputs, including in-place output behavior.

