### PR TITLE
[ROCm][Perf] Fuse MiniMax-M3 BF16 index-cache insertion

### DIFF
--- a/csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu
+++ b/csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu
@@ -49,6 +49,7 @@
  */
 
 #include <cmath>
+#include <cstdint>
 #include <cuda_runtime.h>
 #include <type_traits>
 
@@ -291,10 +292,10 @@ __device__ __forceinline__ void storeScaledQElemsFp8(
 // Grid: 1D, ceil(num_tokens * slots_per_token / warps_per_block).
 // Each warp = one (token, slot).
 //
-// `kHasIndex`, `kProcessIndex`, and `kInsertKV` are compile-time template
-// bools, so branch decisions that distinguish the dense layer from the sparse
-// layer (index slots, KV/index inserts, V slots) fold away per instantiation.
-// Slots per token:
+// `kHasIndex`, `kProcessIndex`, `kInsertKV`, and `kInsertIndex` are
+// compile-time template bools, so branch decisions that distinguish the dense
+// layer from the sparse layer (index slots, cache inserts, V slots) fold away
+// per instantiation. Slots per token:
 //     Q : nq                            (always — norm+RoPE)
 //     K : nkv                           (always — norm+RoPE; +K-cache insert)
 //     V : nkv  only if kInsertKV        (V-cache insert; no warps in dense)
@@ -307,9 +308,8 @@ __device__ __forceinline__ void storeScaledQElemsFp8(
 // branch and writes index_q/index_k outputs. Skip-index-topk reuse layers keep
 // kHasIndex=true but set kProcessIndex=false.
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt,
-          typename out_idx_t, bool kHasIndex, bool kInsertKV,
-          bool kProcessIndex,
-          bool kFp8Idx>
+          typename out_idx_t, bool kHasIndex, bool kInsertKV, bool kInsertIndex,
+          bool kProcessIndex, bool kFp8Idx>
 __global__ void fusedMiniMaxM3QNormRopeKVInsertKernel(
     scalar_t* __restrict__ qkv,  // [N, qkv_row] in/out (packs index if sparse)
     scalar_t* __restrict__ q_out,         // [N, nq*128] contiguous, or nullptr
@@ -346,6 +346,8 @@ __global__ void fusedMiniMaxM3QNormRopeKVInsertKernel(
 
     static_assert(!kProcessIndex || kHasIndex,
                   "index processing requires sparse row layout");
+    static_assert(!kInsertIndex || kProcessIndex,
+                  "index insertion requires index processing");
 
     // Slot layout (compile-time gated: dense has neither V nor index slots).
     int const v_slots = kInsertKV ? nkv : 0;
@@ -474,20 +476,9 @@ __global__ void fusedMiniMaxM3QNormRopeKVInsertKernel(
     // ── Cache inserts (sparse serving only). ───────────────────────────────
     if constexpr (kInsertKV) {
       // Guard (not early-return) so every thread reaches the PDL trigger below.
-      int64_t sm = -1;
       if (isK || isV) {
-        sm = slot_mapping[tokenIdx];
-      } else if constexpr (kProcessIndex) {
-        if (isIK) sm = index_slot_mapping[tokenIdx];
-      }
-      if (sm >= 0) {  // skip padded / unscheduled tokens
-        if (isIK) {
-          if constexpr (kFp8Idx) {
-            storeElemsFp8(index_cache + sm * kHeadDim + dim_base, elems);
-          } else {
-            storeElems<scalar_t>(index_cache + sm * kHeadDim + dim_base, elems);
-          }
-        } else if (isK || isV) {
+        int64_t const sm = slot_mapping[tokenIdx];
+        if (sm >= 0) {  // skip padded / unscheduled tokens
           // kv_cache logical shape [num_blocks, nkv, block_size, 2*head_dim].
           // Paging is logical (block = sm/block_size, token = sm%block_size);
           // the physical NHD/HND layout is honoured via the passed strides.
@@ -498,6 +489,19 @@ __global__ void fusedMiniMaxM3QNormRopeKVInsertKernel(
                               t * kv_s_token +
                               (kv * kHeadDim + dim_base) * kv_s_dim;
           storeCacheElems<scalar_t, cache_t, kv_dt>(kv_cache + off, elems);
+        }
+      }
+    }
+
+    if constexpr (kInsertIndex) {
+      if (isIK) {
+        int64_t const sm = index_slot_mapping[tokenIdx];
+        if (sm >= 0) {  // skip padded / unscheduled tokens
+          if constexpr (kFp8Idx) {
+            storeElemsFp8(index_cache + sm * kHeadDim + dim_base, elems);
+          } else {
+            storeElems<scalar_t>(index_cache + sm * kHeadDim + dim_base, elems);
+          }
         }
       }
     }
@@ -526,12 +530,13 @@ void launchFusedMiniMaxM3(
     float const q_fp8_inv_scale, int const rotary_dim, int const num_tokens,
     int const nq, int const nkv, int const niq, int const block_size,
     int64_t const kv_s_block, int64_t const kv_s_head, int64_t const kv_s_token,
-    int64_t const kv_s_dim, bool const has_index, bool const insert_kv,
-    bool const process_index, bool const fp8_idx, cudaStream_t stream) {
+    int64_t const kv_s_dim, bool const has_index, bool const insert_main_kv,
+    bool const insert_index, bool const process_index, bool const fp8_idx,
+    cudaStream_t stream) {
   // Index outputs are scalar_t (bf16) or e4m3 bytes (uint8_t); reinterpret the
   // void* pointers per instantiation in the LAUNCH macro.
   // Slot count must match the kernel's compile-time gating.
-  int const v_slots = insert_kv ? nkv : 0;
+  int const v_slots = insert_main_kv ? nkv : 0;
   int const idx_slots = process_index ? niq + 1 : 0;
   int const slots_per_token = nq + nkv + v_slots + idx_slots;
 
@@ -559,25 +564,27 @@ void launchFusedMiniMaxM3(
   config.attrs = attrs;
   config.numAttrs = (sm_version >= 90) ? 1 : 0;
 
-  #define LAUNCH(HAS_INDEX, INSERT, PROCESS_INDEX, FP8, OUT_T)                 \
-    cudaLaunchKernelEx(                                                        \
-        &config,                                                               \
-        fusedMiniMaxM3QNormRopeKVInsertKernel<scalar_t, cache_t, kv_dt, OUT_T, \
-                                              HAS_INDEX, INSERT,               \
-                                              PROCESS_INDEX, FP8>,             \
-        qkv, q_out, q_fp8_out, reinterpret_cast<OUT_T*>(index_q_out),          \
-        q_norm_w, k_norm_w, iq_norm_w, ik_norm_w, cos_sin_cache, positions,    \
-        slot_mapping, index_slot_mapping, kv_cache,                            \
-        reinterpret_cast<OUT_T*>(index_cache), eps, q_fp8_inv_scale,           \
-        rotary_dim, num_tokens, nq, nkv, niq, block_size, kv_s_block,          \
+  #define LAUNCH(HAS_INDEX, INSERT_KV, INSERT_INDEX, PROCESS_INDEX, FP8,    \
+                 OUT_T)                                                     \
+    cudaLaunchKernelEx(                                                     \
+        &config,                                                            \
+        fusedMiniMaxM3QNormRopeKVInsertKernel<                              \
+            scalar_t, cache_t, kv_dt, OUT_T, HAS_INDEX, INSERT_KV,          \
+            INSERT_INDEX, PROCESS_INDEX, FP8>,                              \
+        qkv, q_out, q_fp8_out, reinterpret_cast<OUT_T*>(index_q_out),       \
+        q_norm_w, k_norm_w, iq_norm_w, ik_norm_w, cos_sin_cache, positions, \
+        slot_mapping, index_slot_mapping, kv_cache,                         \
+        reinterpret_cast<OUT_T*>(index_cache), eps, q_fp8_inv_scale,        \
+        rotary_dim, num_tokens, nq, nkv, niq, block_size, kv_s_block,       \
         kv_s_head, kv_s_token, kv_s_dim)
 #else
   // ROCm: standard kernel launch syntax (no PDL/stream serialization).
   // clang-format off
-  #define LAUNCH(HAS_INDEX, INSERT, PROCESS_INDEX, FP8, OUT_T)              \
+  #define LAUNCH(HAS_INDEX, INSERT_KV, INSERT_INDEX, PROCESS_INDEX, FP8,     \
+                 OUT_T)                                                     \
     fusedMiniMaxM3QNormRopeKVInsertKernel<                                  \
-        scalar_t, cache_t, kv_dt, OUT_T, HAS_INDEX, INSERT, PROCESS_INDEX,  \
-        FP8><<<grid, kBlockSize, 0, stream>>>(                              \
+        scalar_t, cache_t, kv_dt, OUT_T, HAS_INDEX, INSERT_KV, INSERT_INDEX,\
+        PROCESS_INDEX, FP8><<<grid, kBlockSize, 0, stream>>>(                \
         qkv, q_out, q_fp8_out, reinterpret_cast<OUT_T*>(index_q_out),       \
         q_norm_w, k_norm_w, iq_norm_w, ik_norm_w, cos_sin_cache, positions, \
         slot_mapping, index_slot_mapping, kv_cache,                         \
@@ -589,30 +596,35 @@ void launchFusedMiniMaxM3(
 
   if (has_index) {
     if (!process_index) {
-      if (insert_kv) {
-        LAUNCH(true, true, false, false, scalar_t);
+      if (insert_main_kv) {
+        LAUNCH(true, true, false, false, false, scalar_t);
       } else {
-        LAUNCH(true, false, false, false, scalar_t);
+        LAUNCH(true, false, false, false, false, scalar_t);
       }
-    } else if (insert_kv) {
+    } else if (insert_main_kv) {
       if (fp8_idx) {
-        LAUNCH(true, true, true, true,
+        LAUNCH(true, true, true, true, true,
                uint8_t);  // sparse serving, fp8 index outputs
       } else {
-        LAUNCH(true, true, true, false, scalar_t);  // sparse serving, bf16
+        LAUNCH(true, true, true, true, false,
+               scalar_t);  // sparse serving, bf16
       }
+    } else if (insert_index) {
+      LAUNCH(true, false, true, true, false,
+             scalar_t);  // sparse serving, bf16 index only
     } else {
       if (fp8_idx) {
-        LAUNCH(true, false, true, true,
+        LAUNCH(true, false, false, true, true,
                uint8_t);  // sparse profiling, fp8 index_q
       } else {
-        LAUNCH(true, false, true, false, scalar_t);  // sparse profiling, bf16
+        LAUNCH(true, false, false, true, false,
+               scalar_t);  // sparse profiling, bf16
       }
     }
   } else {
     // Dense layer: never has an index branch and never inserts here (the
     // generic Attention layer owns the KV insert).
-    LAUNCH(false, false, false, false, scalar_t);
+    LAUNCH(false, false, false, false, false, scalar_t);
   }
 #undef LAUNCH
 }
@@ -641,20 +653,23 @@ void launchFusedMiniMaxM3(
           : nullptr,                                                           \
       reinterpret_cast<st const*>(cos_sin_cache.data_ptr()),                   \
       reinterpret_cast<int64_t const*>(positions.data_ptr()),                  \
-      insert_kv ? reinterpret_cast<int64_t const*>(slot_mapping->data_ptr())   \
-                : nullptr,                                                     \
-      (insert_kv && process_index)                                             \
+      insert_main_kv                                                           \
+          ? reinterpret_cast<int64_t const*>(slot_mapping->data_ptr())         \
+          : nullptr,                                                           \
+      insert_index                                                             \
           ? reinterpret_cast<int64_t const*>(                                  \
                 effective_index_slot_mapping->data_ptr())                      \
           : nullptr,                                                           \
-      insert_kv ? reinterpret_cast<CACHE_T*>(kv_cache->data_ptr()) : nullptr,  \
-      (insert_kv && process_index)                                             \
+      insert_main_kv ? reinterpret_cast<CACHE_T*>(kv_cache->data_ptr())        \
+                     : nullptr,                                                \
+      insert_index                                                             \
           ? reinterpret_cast<void*>(index_cache->data_ptr())                   \
           : nullptr,                                                           \
       static_cast<float>(eps), 1.0f / static_cast<float>(q_fp8_scale),          \
       static_cast<int>(rotary_dim), num_tokens, nq, nkv, niq,                  \
       static_cast<int>(block_size), kv_s_block, kv_s_head, kv_s_token,         \
-      kv_s_dim, has_index, insert_kv, process_index, fp8_idx, stream)
+      kv_s_dim, has_index, insert_main_kv, insert_index, process_index,         \
+      fp8_idx, stream)
 // clang-format on
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -719,8 +734,9 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
   // The sparse layer packs the index branch ([index_q (niq heads) | index_k
   // (1 head)]) right after [q|k|v] in the same row; the dense layer does not.
   bool const has_index = niq > 0;
-  bool const insert_kv = kv_cache.has_value();
+  bool const insert_main_kv = kv_cache.has_value();
   bool const process_index = has_index && !skip_index_branch;
+  bool const insert_index = process_index && index_cache.has_value();
   vllm::Fp8KVCacheDataType const kv_dt =
       vllm::get_fp8_kv_cache_data_type(kv_cache_dtype);
   int const kHeadDim = vllm::minimax_m3_fused_ops::kHeadDim;
@@ -734,7 +750,7 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
   // Only the sparse layer inserts here (dense lets the generic Attention layer
   // own the KV write); there is no dense+insert kernel instantiation.
   STD_TORCH_CHECK(
-      !insert_kv || has_index,
+      !insert_main_kv || has_index,
       "insert mode (kv_cache) requires the index branch (sparse layer)");
   STD_TORCH_CHECK(has_index || !skip_index_branch,
                   "skip_index_branch requires sparse qkv rows");
@@ -755,19 +771,15 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
   // op argument is needed -- the strides ride along with the tensor itself.
   int64_t kv_s_block = 0, kv_s_head = 0, kv_s_token = 0, kv_s_dim = 0;
   torch::stable::Tensor const* effective_index_slot_mapping = nullptr;
-  if (insert_kv) {
+  if (insert_main_kv) {
     STD_TORCH_CHECK(
         slot_mapping.has_value() && slot_mapping->is_cuda() &&
             slot_mapping->scalar_type() == torch::headeronly::ScalarType::Long,
         "insert mode requires int64 CUDA slot_mapping");
     if (process_index) {
       STD_TORCH_CHECK(
-          !index_slot_mapping.has_value() ||
-              (index_slot_mapping->is_cuda() &&
-               index_slot_mapping->scalar_type() ==
-                   torch::headeronly::ScalarType::Long &&
-               index_slot_mapping->numel() == slot_mapping->numel()),
-          "index_slot_mapping must be int64 CUDA with slot_mapping length");
+          index_cache.has_value(),
+          "main KV insertion with index processing requires index_cache");
     }
     // Main attention KV cache: auto matches qkv, fp8 uses uint8 storage.
     if (kv_dt == vllm::Fp8KVCacheDataType::kAuto) {
@@ -778,15 +790,6 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
           kv_cache->scalar_type() == torch::headeronly::ScalarType::Byte,
           "fp8 kv_cache must use uint8 storage");
     }
-    // Indexer index-K cache: independent dtype -- qkv dtype or fp8 e4m3.
-    if (process_index) {
-      STD_TORCH_CHECK(
-          index_cache.has_value() &&
-              (index_cache->scalar_type() == qkv.scalar_type() ||
-               index_cache->scalar_type() ==
-                   torch::headeronly::ScalarType::Float8_e4m3fn),
-          "insert mode requires index_cache matching qkv dtype or fp8 e4m3");
-    }
     STD_TORCH_CHECK(kv_cache->dim() == 4 && kv_cache->stride(3) == 1,
                     "kv_cache must be [nb,nkv,bs,2*head_dim] with contiguous "
                     "content dim (stride(3)==1)");
@@ -794,11 +797,56 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     kv_s_head = kv_cache->stride(1);
     kv_s_token = kv_cache->stride(2);
     kv_s_dim = kv_cache->stride(3);
-    if (process_index) {
-      effective_index_slot_mapping = index_slot_mapping.has_value()
-                                         ? &index_slot_mapping.value()
-                                         : &slot_mapping.value();
+  }
+  if (insert_index) {
+    if (insert_main_kv) {
+      STD_TORCH_CHECK(index_cache->scalar_type() == qkv.scalar_type() ||
+                          index_cache->scalar_type() ==
+                              torch::headeronly::ScalarType::Float8_e4m3fn,
+                      "index_cache must match qkv dtype or be fp8 e4m3");
+    } else {
+      STD_TORCH_CHECK(
+          qkv.scalar_type() == torch::headeronly::ScalarType::BFloat16 &&
+              index_cache->scalar_type() ==
+                  torch::headeronly::ScalarType::BFloat16,
+          "index-only insertion requires bfloat16 qkv and index_cache");
     }
+    STD_TORCH_CHECK(index_cache->is_cuda() && index_cache->get_device_index() ==
+                                                  qkv.get_device_index(),
+                    "index_cache must be on the same CUDA device as qkv");
+    STD_TORCH_CHECK(
+        index_cache->dim() == 3 && index_cache->size(2) == kHeadDim &&
+            index_cache->is_contiguous(),
+        "index_cache must be contiguous [num_blocks, block_size, 128]");
+    STD_TORCH_CHECK(num_tokens == 0 || index_cache->numel() > 0,
+                    "index_cache must be nonempty when qkv has tokens");
+    STD_TORCH_CHECK(
+        reinterpret_cast<std::uintptr_t>(index_cache->data_ptr()) % 8 == 0,
+        "index_cache must be 8-byte aligned");
+
+    if (index_slot_mapping.has_value()) {
+      effective_index_slot_mapping = &index_slot_mapping.value();
+    } else {
+      STD_TORCH_CHECK(insert_main_kv,
+                      "index-only insertion requires index_slot_mapping");
+      effective_index_slot_mapping = &slot_mapping.value();
+    }
+    STD_TORCH_CHECK(
+        effective_index_slot_mapping->is_cuda() &&
+            effective_index_slot_mapping->get_device_index() ==
+                qkv.get_device_index() &&
+            effective_index_slot_mapping->scalar_type() ==
+                torch::headeronly::ScalarType::Long &&
+            effective_index_slot_mapping->dim() == 1 &&
+            effective_index_slot_mapping->is_contiguous() &&
+            effective_index_slot_mapping->numel() == num_tokens,
+        "index_slot_mapping must be a contiguous int64 CUDA vector with "
+        "num_tokens elements on the qkv device");
+    STD_TORCH_CHECK(reinterpret_cast<std::uintptr_t>(
+                        effective_index_slot_mapping->data_ptr()) %
+                            8 ==
+                        0,
+                    "index_slot_mapping must be 8-byte aligned");
   }
   // Optional contiguous gather targets: when given, the normed/roped q (and
   // index_q) are written here instead of in place, so callers avoid a separate

--- a/tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py
+++ b/tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 import vllm._custom_ops as ops
+from vllm.platforms import current_platform
 
 HEAD_DIM = 128
 ROTARY_DIM = 64
@@ -100,7 +101,60 @@ def assert_fp8_cache_close(kv_cache, expected_kv_cache):
     )
 
 
-# ── Test 1: dense mode (norm+rope only, no index, no insert) ─────────────────
+def assert_storage_equal(actual, expected):
+    """Compare tensor storage bit-for-bit, including signed zero."""
+    assert actual.dtype == expected.dtype
+    assert actual.shape == expected.shape
+    torch.testing.assert_close(
+        actual.view(torch.uint8), expected.view(torch.uint8), rtol=0, atol=0
+    )
+
+
+# Model dispatch eligibility
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm(), reason="AITER dispatch is ROCm-only"
+)
+@pytest.mark.parametrize(
+    "layout,expected",
+    [
+        pytest.param("bf16", True, id="bf16-eligible"),
+        pytest.param("fp8", False, id="fp8-fallback"),
+        pytest.param("strided_cache", False, id="strided-cache-fallback"),
+        pytest.param("strided_mapping", False, id="strided-mapping-fallback"),
+        pytest.param("misaligned_cache", False, id="misaligned-cache-fallback"),
+    ],
+)
+def test_aiter_index_cache_insert_fusion_eligibility(layout, expected):
+    from vllm.models.minimax_m3.amd.model import (
+        _can_fuse_aiter_index_cache_insert,
+    )
+
+    num_tokens = 4
+    cache_shape = (2, 128, HEAD_DIM)
+    qkv = torch.empty(num_tokens, 1, dtype=torch.bfloat16)
+    index_cache = torch.empty(cache_shape, dtype=torch.bfloat16)
+    index_slot_mapping = torch.arange(num_tokens, dtype=torch.int64)
+
+    if layout == "fp8":
+        index_cache = torch.empty(cache_shape, dtype=torch.float8_e4m3fn)
+    elif layout == "strided_cache":
+        index_cache = torch.empty(2, 256, HEAD_DIM, dtype=torch.bfloat16)[:, ::2]
+    elif layout == "strided_mapping":
+        index_slot_mapping = torch.arange(num_tokens * 2, dtype=torch.int64)[::2]
+    elif layout == "misaligned_cache":
+        storage = torch.empty(index_cache.numel() + 1, dtype=torch.bfloat16)
+        index_cache = storage[1:].view(cache_shape)
+        assert index_cache.data_ptr() % 8 != 0
+
+    assert (
+        _can_fuse_aiter_index_cache_insert(qkv, index_cache, index_slot_mapping)
+        is expected
+    )
+
+
+# Test 1: dense mode (norm+rope only, no index, no insert)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 64, 513])
@@ -318,6 +372,161 @@ def test_sparse_full(num_tokens, block_size, kv_cache_dtype):
     expected_index_cache[index_slot_mapping] = index_k
     torch.testing.assert_close(
         index_cache.view(-1, HEAD_DIM), expected_index_cache, rtol=0, atol=0
+    )
+
+
+@pytest.mark.parametrize(
+    "num_tokens,slot_case,use_graph",
+    [
+        pytest.param(0, "active", False, id="zero"),
+        pytest.param(1, "active", False, id="one"),
+        pytest.param(4, "boundary", True, id="four-graph-boundary"),
+        pytest.param(12, "interspersed", False, id="twelve-padded"),
+        pytest.param(16, "all_padding", False, id="sixteen-all-padding"),
+        pytest.param(24, "boundary", True, id="twenty-four-graph-boundary"),
+        pytest.param(64, "active", False, id="sixty-four"),
+    ],
+)
+@pytest.mark.parametrize("kv_cache_dtype", ["auto", "fp8"])
+def test_sparse_index_only_insert_matches_triton(
+    num_tokens, slot_case, use_graph, kv_cache_dtype
+):
+    from vllm.models.minimax_m3.amd.ops.sparse_pa import (
+        minimax_m3_insert_index_cache,
+    )
+
+    torch.manual_seed(3)
+    device, dtype, eps = "cuda", torch.bfloat16, 1e-6
+    base, max_pos = 5_000_000.0, 131_072
+    num_heads, num_kv_heads, num_idx_heads = 16, 1, 1
+    block_size, num_blocks = 128, 3
+
+    q_w = torch.randn(HEAD_DIM, dtype=dtype, device=device) * 0.1
+    k_w = torch.randn(HEAD_DIM, dtype=dtype, device=device) * 0.1
+    iq_w = torch.randn(HEAD_DIM, dtype=dtype, device=device) * 0.1
+    ik_w = torch.randn(HEAD_DIM, dtype=dtype, device=device) * 0.1
+    cos_sin = make_cos_sin_cache(max_pos, ROTARY_DIM, base, dtype, device)
+    positions = torch.arange(num_tokens, dtype=torch.int64, device=device) * 997
+    if num_tokens:
+        positions[-1] = max_pos - 1
+
+    qsz, kvsz = num_heads * HEAD_DIM, num_kv_heads * HEAD_DIM
+    iqsz = num_idx_heads * HEAD_DIM
+    row_size = qsz + 2 * kvsz + iqsz + HEAD_DIM
+    qkv_source = torch.randn(num_tokens, row_size, dtype=dtype, device=device)
+    if qkv_source.numel():
+        qkv_source.view(-1)[0] = 0.0
+        qkv_source.view(-1)[1] = -0.0
+        index_k_source = qkv_source[:, -HEAD_DIM:]
+        index_k_source[0].zero_()
+        index_k_source[0, 1] = -0.0
+
+    live_prefix = [0, 1, 126, 127, 128, 255, 256]
+    live_slots = live_prefix + [
+        slot for slot in range(num_blocks * block_size) if slot not in live_prefix
+    ]
+    if slot_case == "all_padding":
+        slots = [-1] * num_tokens
+    elif slot_case == "interspersed":
+        slots = [
+            -1 if token % 3 == 1 else live_slots[token] for token in range(num_tokens)
+        ]
+    elif slot_case == "boundary":
+        boundary_slots = [127, 128, 255, -1, 256]
+        remaining_slots = [
+            slot for slot in live_slots if slot not in {127, 128, 255, 256}
+        ]
+        slots = (boundary_slots + remaining_slots)[:num_tokens]
+    else:
+        slots = live_slots[:num_tokens]
+    index_slot_mapping = torch.tensor(slots, dtype=torch.int64, device=device)
+
+    poison = torch.full(
+        (num_blocks, block_size, HEAD_DIM),
+        -31.5,
+        dtype=dtype,
+        device=device,
+    )
+
+    def make_provider():
+        return (
+            qkv_source.clone(),
+            torch.empty(num_tokens, qsz, dtype=dtype, device=device),
+            torch.empty(num_tokens, iqsz, dtype=dtype, device=device),
+            poison.clone(),
+        )
+
+    def run_fused(qkv, q_out, index_q_out, index_cache=None):
+        ops.fused_minimax_m3_qknorm_rope_kv_insert(
+            qkv,
+            q_w,
+            k_w,
+            cos_sin,
+            positions,
+            num_heads,
+            num_kv_heads,
+            ROTARY_DIM,
+            eps,
+            iq_w,
+            ik_w,
+            num_idx_heads,
+            index_slot_mapping=(
+                index_slot_mapping if index_cache is not None else None
+            ),
+            index_cache=index_cache,
+            q_out=q_out,
+            index_q_out=index_q_out,
+            kv_cache_dtype=kv_cache_dtype,
+        )
+
+    def run_baseline(qkv, q_out, index_q_out, index_cache):
+        run_fused(qkv, q_out, index_q_out)
+        minimax_m3_insert_index_cache(
+            qkv[:, -HEAD_DIM:], index_cache, index_slot_mapping
+        )
+
+    baseline = make_provider()
+    candidate = make_provider()
+    if use_graph:
+        warm_baseline = make_provider()
+        warm_candidate = make_provider()
+        run_baseline(*warm_baseline)
+        run_fused(
+            warm_candidate[0],
+            warm_candidate[1],
+            warm_candidate[2],
+            warm_candidate[3],
+        )
+        torch.accelerator.synchronize()
+
+        baseline_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(baseline_graph):
+            run_baseline(*baseline)
+        candidate_graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(candidate_graph):
+            run_fused(candidate[0], candidate[1], candidate[2], candidate[3])
+
+        baseline[0].copy_(qkv_source)
+        candidate[0].copy_(qkv_source)
+        baseline[3].copy_(poison)
+        candidate[3].copy_(poison)
+        index_slot_mapping.copy_(index_slot_mapping.roll(1))
+        baseline_graph.replay()
+        candidate_graph.replay()
+        torch.accelerator.synchronize()
+    else:
+        run_baseline(*baseline)
+        run_fused(candidate[0], candidate[1], candidate[2], candidate[3])
+
+    for baseline_tensor, candidate_tensor in zip(baseline, candidate):
+        assert_storage_equal(candidate_tensor, baseline_tensor)
+
+    live = index_slot_mapping[index_slot_mapping >= 0]
+    untouched = torch.ones(num_blocks * block_size, dtype=torch.bool, device=device)
+    untouched[live] = False
+    assert_storage_equal(
+        candidate[3].view(-1, HEAD_DIM)[untouched],
+        poison.view(-1, HEAD_DIM)[untouched],
     )
 
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2738,10 +2738,12 @@ def fused_minimax_m3_qknorm_rope_kv_insert(
       index_k]`` — the index branch is read straight out of ``qkv``.
 
     When ``kv_cache`` is given (sparse serving), also scatter-inserts the
-    normed/roped k & v into the paged KV cache by ``slot_mapping`` and the
-    index key into ``index_cache`` by ``index_slot_mapping``. ``kv_cache_dtype``
-    selects the cache storage/conversion path. If
-    ``index_slot_mapping`` is omitted, ``slot_mapping`` is used for both caches.
+    normed/roped k & v into the paged KV cache by ``slot_mapping``. A BF16
+    ``index_cache`` may be supplied independently with an explicit
+    ``index_slot_mapping`` to insert only the index key, without main K/V
+    insertion. When both caches are supplied, an omitted
+    ``index_slot_mapping`` falls back to ``slot_mapping``. ``kv_cache_dtype``
+    selects the main-cache storage/conversion path.
 
     If ``q_out`` / ``index_q_out`` (contiguous ``[N, nq*128]`` / ``[N,
     niq*128]``) are given, the normed/roped q / index_q are written there

--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -120,6 +120,27 @@ from vllm.v1.kv_cache_interface import (
 logger = init_logger(__name__)
 
 
+def _can_fuse_aiter_index_cache_insert(
+    qkv: torch.Tensor,
+    index_cache: torch.Tensor,
+    index_slot_mapping: torch.Tensor,
+) -> bool:
+    """Whether the AITER path can fuse its BF16 index-cache insert."""
+    if not (
+        index_cache.numel() > 0
+        and qkv.dtype == torch.bfloat16
+        and index_cache.dtype == qkv.dtype
+        and index_cache.is_contiguous()
+        and index_slot_mapping.is_contiguous()
+    ):
+        return False
+    if torch.compiler.is_compiling():
+        # Cache-manager allocations are aligned; avoid unsupported pointer
+        # introspection while Dynamo traces the bound buffers.
+        return True
+    return index_cache.data_ptr() % 8 == 0 and index_slot_mapping.data_ptr() % 8 == 0
+
+
 def _sparse_attention_layer_ids(config: PretrainedConfig) -> set[int]:
     """Layer ids whose attention runs the extra sparse "index" branch."""
     cfg = getattr(config, "sparse_attention_config", None)
@@ -943,6 +964,37 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             index_slot_mapping = fwd_slot_mapping[self.indexer.index_cache.prefix]
             index_q = qkv.new_empty((num_tokens, self.index_q_size))
             if self.use_aiter_sparse_pa:
+                index_cache = self.indexer.index_cache.kv_cache
+                if index_cache.numel() > 0:
+                    if index_cache.device != qkv.device:
+                        raise RuntimeError(
+                            "MiniMax-M3 index cache must be on the qkv device"
+                        )
+                    if (
+                        index_cache.dim() != 3
+                        or index_cache.shape[2] != self.idx_head_dim
+                        or index_cache.stride(2) != 1
+                    ):
+                        raise RuntimeError(
+                            "MiniMax-M3 index cache must have shape [B,T,128] "
+                            "with a contiguous head dimension"
+                        )
+                    if index_slot_mapping.device != qkv.device:
+                        raise RuntimeError(
+                            "MiniMax-M3 index slot mapping must be on the qkv device"
+                        )
+                    if (
+                        index_slot_mapping.dtype != torch.int64
+                        or index_slot_mapping.dim() != 1
+                        or index_slot_mapping.numel() != num_tokens
+                    ):
+                        raise RuntimeError(
+                            "MiniMax-M3 index slot mapping must be a length-N "
+                            "int64 vector"
+                        )
+                fuse_index_insert = _can_fuse_aiter_index_cache_insert(
+                    qkv, index_cache, index_slot_mapping
+                )
                 ops.fused_minimax_m3_qknorm_rope_kv_insert(
                     qkv,
                     self.q_norm.weight,
@@ -958,6 +1010,10 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
                     self.num_idx_heads,
                     q_out=q,
                     index_q_out=index_q,
+                    index_slot_mapping=(
+                        index_slot_mapping if fuse_index_insert else None
+                    ),
+                    index_cache=index_cache if fuse_index_insert else None,
                     kv_cache_dtype=self.kv_cache_dtype,
                 )
                 k_start = self.q_size
@@ -969,9 +1025,11 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
                 v = qkv[:, v_start : v_start + self.kv_size].view(
                     num_tokens, self.num_kv_heads, self.head_dim
                 )
-                index_k = qkv[
-                    :, index_k_start : index_k_start + self.idx_head_dim
-                ].view(num_tokens, self.idx_head_dim)
+                index_k = None
+                if not fuse_index_insert:
+                    index_k = qkv[
+                        :, index_k_start : index_k_start + self.idx_head_dim
+                    ].view(num_tokens, self.idx_head_dim)
                 self._insert_aiter_sparse_pa_kv(
                     k,
                     v,


### PR DESCRIPTION
## Summary

- let the existing vLLM MiniMax-M3 fused QK-norm/RoPE kernel insert the
  normalized BF16 index key directly into the index cache
- remove the separate Triton index-cache scatter from the ROCm AITER sparse-PA
  path when the BF16 cache/layout contract is satisfied
- retain the existing path unchanged for FP8, non-contiguous, misaligned, or
  otherwise unsupported index-cache inputs

The main K/V cache writer remains AITER `reshape_and_cache`; this PR changes
only the BF16 index-cache insertion boundary.

## Motivation

MiniMax-M3 computes a fresh index key in every sparse layer. On the current
ROCm AITER sparse-attention path, vLLM's fused QK-norm/RoPE producer writes that
index key to `qkv`, then a separate Triton kernel reads and scatters it into the
index cache. The producer already owns the normalized index-key values and the
existing vLLM kernel already supports cache insertion for the non-AITER layout,
so accepting an independent index cache/mapping removes one hot-path launch and
one round trip through the materialized index-key slice.

The dispatch is fail-closed. It selects the fused store only for a contiguous,
aligned BF16 index cache and contiguous index slot mapping on the same device;
all other cases retain the existing scatter.

## Existing work and non-duplication

This was checked against the open MiniMax-M3 cache-fusion work before opening:

- [#53833](https://github.com/vllm-project/vllm/pull/53833), backed by
  [ROCm/AITER#4813](https://github.com/ROCm/aiter/pull/4813), proposes a broader
  one-kernel AITER path
  that fuses QK normalization, RoPE, main K/V insertion, and index-cache
  insertion. It can remove two launches and is expected to have a larger
  ceiling than this PR, but currently depends on a new AITER operation and a
  stable supported-architecture capability contract.
- [#54535](https://github.com/vllm-project/vllm/pull/54535), backed by
  [ROCm/AITER#5143](https://github.com/ROCm/aiter/pull/5143) and
  [#52664](https://github.com/vllm-project/vllm/pull/52664), integrates the
  consolidated AITER operation and adds FP8 index-query/cache support. It is
  likewise broader and has an external dependency chain.

This PR is the smaller, vLLM-only alternative/fallback: it extends the existing
vLLM kernel, introduces no AITER source or API dependency, leaves the AITER main
K/V writer untouched, and deliberately supports only the current BF16 index
cache. It is therefore not the same implementation, although the optimized
operation overlaps with the broader drafts.

This is opened as a draft to coordinate that overlap. If #53833's AITER
dependency lands with a supported-architecture capability contract and
current-`main` correctness/performance evidence, I am happy to converge this
fallback into that PR or close this one if maintainers do not want an
independent vLLM fallback.

Duplicate searches run:

```text
gh pr list --repo vllm-project/vllm --state open \
  --search "MiniMax M3 index cache insertion"
gh pr list --repo vllm-project/vllm --state open \
  --search "MiniMax M3 KV cache fusion ROCm"
gh pr list --repo vllm-project/vllm --state open \
  --search "qknorm rope kv insert gfx950"
```

## Performance

MI355X (`gfx950`), TP4. The isolated boundary compares the same loaded vLLM
extension in both variants: fused QK-norm/RoPE plus a separate Triton BF16
scatter versus the same producer with its index-cache store enabled. Main K/V
insertion and top-k are outside the measured boundary. Each value is the median
of 96 paired AB/BA samples; each sample uses 200 graph replays and reports the
maximum rank latency. Each provider/case received 768 warmup replays.

| AgentX case | Scheduled tokens | Baseline (us) | Fused store (us) | Saving (us) | Improvement |
| --- | ---: | ---: | ---: | ---: | ---: |
| c1 | 4 | 17.6496 | 16.3851 | 1.2645 | 7.166% |
| c5 | 12 | 18.1890 | 16.7647 | 1.4237 | 7.828% |
| c10 | 16 | 18.3047 | 16.9056 | 1.3997 | 7.649% |
| c15 | 24 | 18.1999 | 16.8219 | 1.3786 | 7.575% |

The controlled, counterbalanced AgentX c10 server A/B measured:

- full ITL/TPOT improvement: **0.872%**
- paired-bootstrap 95% CI: **[0.363%, 1.441%]**
- exact-matched-span output-throughput improvement: **0.557%**
- four fully warmed runs, 207 common measured requests, zero request errors,
  and no late JIT events

The end-to-end effect is intentionally smaller than the broader AITER fusion
reported in #53833; this PR removes only the index-scatter launch.

## Correctness and evaluation

The focused kernel suite compares the fused insertion against the existing
Triton scatter bit-for-bit, including zero tokens, active/padded mappings, page
boundaries, graph replay with a changed mapping, untouched poison rows, BF16
index-cache ownership, FP8-main-KV dispatch, and fallback eligibility. The full
suite also covers the existing dense, sparse main-cache, skip-index, and FP8
index modes.

```text
HIP_VISIBLE_DEVICES=0 VLLM_SOURCE_ROOT=/home/amd/vllm-bf16-insert-pr \
  /home/amd/vllm/mm3_rocm_bench/rocm_source_python.sh -m pytest \
  tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py -v
67 passed, 14 warnings in 30.26s

/home/amd/vllm/.venv/bin/pre-commit run --files \
  csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu \
  tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py \
  vllm/_custom_ops.py vllm/models/minimax_m3/amd/model.py
PASS

/home/amd/vllm/.venv/bin/python -m py_compile \
  vllm/_custom_ops.py vllm/models/minimax_m3/amd/model.py \
  tests/kernels/test_fused_minimax_m3_qknorm_rope_kv_insert.py
PASS

git diff --check upstream/main...HEAD
PASS
```

Model-level validation on the real MiniMax-M3-MXFP4 target completed all
1,319 GSM8K requests at c64 with zero request errors and strict exact match
`0.9454131918119788`. That run used the branch containing this change plus the
separately submitted decode top-k work, so it is a serving/accuracy guard rather
than attribution evidence for this PR. The bitwise kernel comparison above
isolates this change.

## AI assistance and submitter responsibility

OpenAI Codex assisted with implementation analysis, test construction,
performance analysis, rebasing, duplicate-work review, and drafting this
description. The human submitter must review and understand every changed line,
reproduce the relevant ROCm tests/evaluation, and be able to defend the change
end-to-end before marking this draft ready for review.
