### PR TITLE
[ROCm][CI] Extend Multimodal Processor Shard timeout on AMD CI

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -128,7 +128,7 @@ steps:
   - pytest -v -s models/test_utils.py models/test_vision.py models/test_adapters.py models/transformers/fusers/
 
 - label: ":computer: (CPU) Multimodal Processor Shard %N" # TBD
-  timeout_in_minutes: 60
+  timeout_in_minutes: 90
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
   agent_pool: mi250_1
   no_gpu: true


### PR DESCRIPTION

As seen in https://buildkite.com/vllm/amd-ci/builds/12553/list?jid=01a0615a-0215-4914-8a00-d7b55431dbee&tab=output, the timeout for `(CPU) Multimodal Processor Shard %N` in AMD CI is sometimes hit. Here we extend the timeout to allow it to finish.



## Summary by CodeRabbit

* **Chores**
  * Increased the timeout for AMD CPU multimodal processor shard tests from 60 to 90 minutes.

