### PR TITLE
[Perf][Rust Frontend] Coalesce decoded chunks per engine update

### DIFF
--- a/rust/src/text/src/output/decoded.rs
+++ b/rust/src/text/src/output/decoded.rs
@@ -201,11 +201,14 @@ pub async fn decoded_text_event_stream(
 
                 break;
             }
+        }
 
-            // TODO: avoid generating a chunk every time a token is pushed
-            if intermediate && let Some(chunk) = decoder.next_chunk() {
-                decoded.append(chunk);
-            }
+        // Coalesce output per nonterminal engine update; terminal updates flush below.
+        if intermediate
+            && finish_reason.is_none()
+            && let Some(chunk) = decoder.next_chunk()
+        {
+            decoded.append(chunk);
         }
 
         let mut new_token_ids = output.token_ids;


### PR DESCRIPTION
## Purpose

Streaming engine updates can carry multiple generated tokens with MTP or speculative decoding. The Rust frontend currently extracts and appends a decoded chunk after every token, then yields one `TextDelta` for the whole engine update.

This change extracts at most one decoded chunk after each nonterminal engine update. Per-token decoding and stop-string checks remain in place, while terminal updates continue through the existing `flush()` path.

Local release microbenchmark results for the full incremental decode loop (`push_token` + decode + `next_chunk` + append), using the Qwen3.5-0.8B tokenizer, 1,000 requests with 256 output tokens each, CPU 69 affinity, and the median of 7 samples:

| MTP batch | CPU time | Loop throughput | Allocations |
|---:|---:|---:|---:|
| 1 | Flat | Flat | Flat |
| 2 | -10.7% | +12.0% | -14.2% |
| 4 | -16.9% | +20.4% | -18.3% |
| 8 | -19.9% | +24.9% | -18.2% |
| 16 | -20.9% | +26.4% | -18.3% |

The benchmark harness was temporary and is excluded from this PR. End-to-end gains depend on the share of frontend CPU spent in incremental detokenization.

## Test Plan

- `cargo nextest run -p vllm-text`
- `cargo clippy -p vllm-text --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`

## Test Result

- `vllm-text`: 90 passed, 1 skipped.
- Clippy passed with warnings denied.
- Diff check passed.
- Model evaluation is not applicable because decoded text, token IDs, logprobs, stop handling, and streaming event boundaries remain unchanged.

AI assistance was used for code changes, validation, benchmarking, and PR preparation. Every changed line and the reported benchmark scope were reviewed by the submitter.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

