### PR TITLE
Update CuteDSL fused MoE API for 16-row interleave and low latency kernel support

### DIFF
--- a/tests/kernels/moe/test_flashinfer_cutedsl_layout.py
+++ b/tests/kernels/moe/test_flashinfer_cutedsl_layout.py
@@ -113,7 +113,7 @@ def test_modular_and_monolithic_select_routing_mode(monkeypatch):
         apply_router_weight_on_input=False,
         **common,
     )
-    assert "router_logits" not in captured
+    assert captured["router_logits"] is None
     # dtypes the kernel requires, normalized by apply()
     assert captured["token_selected_experts"].dtype == torch.int32
     assert captured["token_final_scales"].dtype == torch.float32
@@ -126,9 +126,9 @@ def test_modular_and_monolithic_select_routing_mode(monkeypatch):
         apply_router_weight_on_input=False,
         **common,
     )
-    assert "token_selected_experts" not in captured
-    assert "token_final_scales" not in captured
-    assert captured["router_logits"].shape == (2, 4)
+    assert captured["token_selected_experts"] is None
+    assert captured["token_final_scales"] is None
+    assert captured.pop("router_logits").shape == (2, 4)
 
 
 def test_monolithic_opts_out_when_fused_routing_cannot_be_used():

--- a/tests/kernels/moe/test_flashinfer_cutedsl_layout.py
+++ b/tests/kernels/moe/test_flashinfer_cutedsl_layout.py
@@ -1,11 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Weight-layout normalization for the FlashInfer CuTeDSL NVFP4 MoE backend."""
+"""Weight layout and routing dispatch for the FlashInfer CuTeDSL MoE backend."""
+
+import dataclasses
+from types import SimpleNamespace
 
 import pytest
 import torch
 
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.fused_moe.experts import flashinfer_cutedsl_moe
+from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutedsl_moe import (
+    FlashInferCuteDSLExperts,
+    FlashInferCuteDSLExpertsMonolithic,
+)
 from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
     reorder_w13_to_w31_for_flashinfer_cutedsl,
 )
@@ -41,3 +53,98 @@ def test_reorder_w13_packed_layouts(activation: MoEActivation):
 
     torch.testing.assert_close(out, _EXPECTED)
     torch.testing.assert_close(out_scale, _EXPECTED + 100)
+
+
+def _stub_experts(cls):
+    """Build an experts instance with only the fields ``_fused_moe`` reads."""
+    obj = object.__new__(cls)
+    # quant_dtype/w*_scale/g*_alphas/a2_gscale are properties over quant_config.
+    obj.quant_config = SimpleNamespace(
+        quant_dtype="mxfp4",
+        w1_scale=torch.empty(0),
+        w2_scale=torch.empty(0),
+        g1_alphas=None,
+        g2_alphas=None,
+        a2_gscale=None,
+    )
+    obj.out_dtype = torch.bfloat16
+    obj.hidden_dim = 8
+    obj.topk = 2
+    obj.global_num_experts = 4
+    obj.local_num_experts = 4
+    obj.local_expert_offset = 0
+    obj._bias_up = obj._bias_gate = obj._down_bias = None
+    obj.gemm1_alpha = obj.gemm1_beta = obj.gemm1_clamp_limit = None
+    return obj
+
+
+def test_modular_and_monolithic_select_routing_mode(monkeypatch):
+    """Modular passes precomputed topk; monolithic passes router logits.
+
+    The CuTeDSL kernel picks its routing path from these mutually exclusive
+    kwargs, so sending the wrong pair silently changes which routing kernel
+    runs, or trips the library's validation.
+    """
+    captured: dict = {}
+    monkeypatch.setattr(
+        flashinfer_cutedsl_moe, "flashinfer_cute_dsl_fused_moe", captured.update
+    )
+
+    x = torch.zeros(2, 8, dtype=torch.bfloat16)
+    common = dict(
+        hidden_states=x,
+        w1=torch.empty(0),
+        # [experts, hidden_dim, N]: monolithic sizes its output from w2.size(1).
+        w2=torch.empty(4, 8, 8),
+        activation=MoEActivation.SILU,
+        a1q_scale=torch.empty(0),
+    )
+
+    _stub_experts(FlashInferCuteDSLExperts).apply(
+        output=torch.zeros_like(x),
+        topk_weights=torch.zeros(2, 2, dtype=torch.bfloat16),
+        topk_ids=torch.zeros(2, 2, dtype=torch.int64),
+        global_num_experts=4,
+        expert_map=None,
+        a2_scale=None,
+        workspace13=None,
+        workspace2=None,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+        **common,
+    )
+    assert "router_logits" not in captured
+    # dtypes the kernel requires, normalized by apply()
+    assert captured["token_selected_experts"].dtype == torch.int32
+    assert captured["token_final_scales"].dtype == torch.float32
+
+    captured.clear()
+    _stub_experts(FlashInferCuteDSLExpertsMonolithic).apply(
+        router_logits=torch.zeros(2, 4, dtype=torch.bfloat16),
+        global_num_experts=4,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        **common,
+    )
+    assert "token_selected_experts" not in captured
+    assert "token_final_scales" not in captured
+    assert captured["router_logits"].shape == (2, 4)
+
+
+def test_monolithic_opts_out_when_fused_routing_cannot_be_used():
+    """Fused routing needs every expert local (EP=1) and TopK->softmax routing;
+    anything else must fall back to the modular variant."""
+    cls = FlashInferCuteDSLExpertsMonolithic
+
+    assert cls._supports_parallel_config(FusedMoEParallelConfig.make_no_parallel())
+    ep = dataclasses.replace(
+        FusedMoEParallelConfig.make_no_parallel(), ep_size=2, use_ep=True
+    )
+    assert not cls._supports_parallel_config(ep)
+
+    assert cls._supports_routing_method(RoutingMethodType.Renormalize, None, None)
+    # What get_routing_method_type actually returns for softmax models (gpt-oss);
+    # same function as Renormalize. Default omits the renormalize, so weights differ.
+    assert cls._supports_routing_method(RoutingMethodType.RenormalizeNaive, None, None)
+    assert not cls._supports_routing_method(RoutingMethodType.Default, None, None)
+    assert not cls._supports_routing_method(RoutingMethodType.DeepSeekV3, None, None)

--- a/tests/kernels/moe/test_flashinfer_cutedsl_layout.py
+++ b/tests/kernels/moe/test_flashinfer_cutedsl_layout.py
@@ -73,7 +73,8 @@ def _stub_experts(cls):
     obj.global_num_experts = 4
     obj.local_num_experts = 4
     obj.local_expert_offset = 0
-    obj._bias_up = obj._bias_gate = obj._down_bias = None
+    obj._w1_bias = obj._w2_bias = None
+    obj._weight_interleave = 16
     obj.gemm1_alpha = obj.gemm1_beta = obj.gemm1_clamp_limit = None
     return obj
 

--- a/tests/kernels/moe/test_flashinfer_cutedsl_moe.py
+++ b/tests/kernels/moe/test_flashinfer_cutedsl_moe.py
@@ -38,11 +38,11 @@ from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
     prepare_nvfp4_moe_layer_for_flashinfer_cutedsl,
 )
 from vllm.platforms import current_platform
-from vllm.utils.flashinfer import has_flashinfer_cutedsl_moe_nvfp4
+from vllm.utils.flashinfer import has_flashinfer_cutedsl_moe
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
 
-if not has_flashinfer_cutedsl_moe_nvfp4() or not (
+if not has_flashinfer_cutedsl_moe() or not (
     current_platform.is_device_capability_family(100)
 ):
     pytest.skip(
@@ -193,7 +193,6 @@ def test_flashinfer_cutedsl_fp4_moe(
             hidden_states, score, topk, renormalize=False
         )
 
-        activation = MoEActivation.RELU2_NO_MUL
         moe_config = FusedMoEConfig(
             num_experts=e,
             experts_per_token=topk,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
@@ -9,6 +9,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
+    RoutingMethodType,
 )
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
@@ -18,17 +19,19 @@ from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
+    kMxfp4Static,
+    kMxfp8Dynamic,
     kNvfp4Dynamic,
     kNvfp4Static,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
-    flashinfer_cute_dsl_fused_moe_nvfp4,
-    has_flashinfer_cutedsl_moe_nvfp4,
+    flashinfer_cute_dsl_fused_moe,
+    has_flashinfer_cutedsl_moe,
 )
 
 
-class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
+class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
     """
     CuteDSL NvFP4 MoE experts using the FlashInfer functional API.
 
@@ -46,8 +49,8 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
             moe_config=moe_config,
             quant_config=quant_config,
         )
-        assert quant_config.quant_dtype == "nvfp4", (
-            "Only nvfp4 quantization is currently supported."
+        assert quant_config.quant_dtype in ("nvfp4", "mxfp4", "mxfp8"), (
+            "Only nvfp4, mxfp4, and mxfp8 quantization are currently supported."
         )
         self.out_dtype = moe_config.in_dtype
         self.hidden_dim = moe_config.hidden_dim
@@ -64,10 +67,25 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
         self.gemm1_clamp_limit = quant_config.gemm1_clamp_limit
         self.situ_beta = moe_config.activation_situ_beta
         self.situ_linear_beta = moe_config.activation_situ_linear_beta
+        half_layout = quant_config.quant_dtype in ("mxfp4", "mxfp8")
+        self._bias_gate, self._bias_up, self._down_bias = self._prepare_biases(
+            quant_config.w1_bias,
+            quant_config.w2_bias,
+            half_layout=half_layout,
+            activation=moe_config.activation,
+        )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
-        layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        if self.quant_dtype == "nvfp4":
+            layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
+            layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        half_layout = self.quant_dtype in ("mxfp4", "mxfp8")
+        self._bias_gate, self._bias_up, self._down_bias = self._prepare_biases(
+            self.w1_bias,
+            self.w2_bias,
+            half_layout=half_layout,
+            activation=self.moe_config.activation,
+        )
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -79,7 +97,7 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
         return (
             p.is_cuda()
             and p.is_device_capability_family(100)
-            and has_flashinfer_cutedsl_moe_nvfp4()
+            and has_flashinfer_cutedsl_moe()
         )
 
     @staticmethod
@@ -93,6 +111,7 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
     ) -> bool:
         SUPPORTED_W_A = [
             (kNvfp4Static, kNvfp4Dynamic),
+            (kMxfp4Static, kMxfp8Dynamic),
         ]
         return (weight_key, activation_key) in SUPPORTED_W_A
 
@@ -128,11 +147,136 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
         workspace1 = (0,)
         workspace2 = (0,)
-        # K is packed (K//2 for uint8), so output uses hidden_dim.
-        assert self.hidden_dim == K * 2
+        if self.quant_dtype == "nvfp4":
+            # K is packed (K//2 for uint8), so output uses hidden_dim in nvfp4.
+            assert self.hidden_dim == K * 2
         output = (M, self.hidden_dim)
         return (workspace1, workspace2, output)
 
+    @staticmethod
+    def _prepare_biases(
+        w1_bias: torch.Tensor | None,
+        w2_bias: torch.Tensor | None,
+        *,
+        half_layout: bool,
+        activation: MoEActivation,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+        """MXFP4 convert already emits [up | gate] halves; else normalize."""
+        from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+            reorder_w13_to_w31_for_flashinfer_cutedsl,
+        )
+
+        if w1_bias is None:
+            bias_gate, bias_up = None, None
+        else:
+            bias = (
+                w1_bias if w1_bias.dtype == torch.float32 else w1_bias.to(torch.float32)
+            )
+            if not half_layout:
+                bias = reorder_w13_to_w31_for_flashinfer_cutedsl(
+                    activation, bias, bias
+                )[0]
+            half = bias.shape[1] // 2
+            bias_up = bias[:, :half].contiguous()
+            bias_gate = bias[:, half:].contiguous()
+        if w2_bias is None:
+            down_bias = None
+        elif w2_bias.dtype == torch.float32 and w2_bias.is_contiguous():
+            down_bias = w2_bias
+        else:
+            down_bias = w2_bias.to(torch.float32).contiguous()
+        return bias_gate, bias_up, down_bias
+
+    def _fused_moe(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        activation: MoEActivation,
+        a1q_scale: torch.Tensor | None,
+        **routing_kwargs: torch.Tensor,
+    ) -> torch.Tensor:
+        assert self.quant_dtype in ("nvfp4", "mxfp4", "mxfp8")
+        assert a1q_scale is not None
+        assert self.w1_scale is not None
+        assert self.w2_scale is not None
+
+        # a1q_scale is (M, K//16) float8_e4m3fn from fp4_quantize.
+        # The functional API expects x_sf with trailing dim: (M, K//16, 1).
+        # fp8 has no trailing dim, so we don't need to unsqueeze.
+        x_sf = a1q_scale.unsqueeze(-1) if self.quant_dtype == "nvfp4" else a1q_scale
+
+        # The kernel defaults swiglu_{alpha,beta,limit} to the plain-SwiGLU
+        # values, so only forward the ones the model actually sets.
+        swiglu_params: dict[str, float | None] = {}
+        if activation == MoEActivation.SILU:
+            swiglu_params = {"swiglu_limit": self.gemm1_clamp_limit}
+        elif activation in (
+            MoEActivation.SWIGLUOAI,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        ):
+            swiglu_params = {
+                "swiglu_alpha": self.gemm1_alpha,
+                "swiglu_beta": self.gemm1_beta,
+                "swiglu_limit": self.gemm1_clamp_limit,
+            }
+        elif activation == MoEActivation.SITU:
+            if self.situ_beta is None:
+                raise ValueError(
+                    "SITU activation requires moe_config.activation_situ_beta"
+                )
+            swiglu_params = {
+                "situ_beta": self.situ_beta,
+                "situ_linear_beta": self.situ_linear_beta,
+            }
+        swiglu_kwargs = {k: v for k, v in swiglu_params.items() if v is not None}
+
+        # w2's hidden dim may be mx-alignment padded wider than output.
+        kernel_dim = w2.size(1)
+        if output.shape[-1] == kernel_dim:
+            kernel_output = output
+        else:
+            kernel_output = torch.empty(
+                *output.shape[:-1],
+                kernel_dim,
+                dtype=output.dtype,
+                device=output.device,
+            )
+
+        flashinfer_cute_dsl_fused_moe(
+            x=hidden_states,
+            x_sf=x_sf,
+            **routing_kwargs,
+            w1_weight=w1,
+            w1_weight_sf=self.w1_scale,
+            w1_alpha=self.g1_alphas,
+            fc2_input_scale=self.a2_gscale,
+            w2_weight=w2,
+            w2_weight_sf=self.w2_scale,
+            w2_alpha=self.g2_alphas,
+            num_experts=self.global_num_experts,
+            top_k=self.topk,
+            num_local_experts=self.local_num_experts,
+            local_expert_offset=self.local_expert_offset,
+            output_dtype=self.out_dtype,
+            moe_output=kernel_output,
+            activation_type=activation_to_flashinfer_int(
+                MoEActivation.SILU if activation == MoEActivation.SITU else activation
+            ),
+            bias_up=self._bias_up,
+            bias_gate=self._bias_gate,
+            down_bias=self._down_bias,
+            quant_mode="w4a4" if self.quant_dtype == "nvfp4" else "w4a8",
+            weight_interleave=16,
+            **swiglu_kwargs,
+        )
+        if kernel_output is not output:
+            output.copy_(kernel_output[..., : output.shape[-1]])
+        return output
+
+
+class FlashInferCuteDSLExperts(FlashInferCuteDSLExpertsBase, mk.FusedMoEExpertsModular):
     def apply(
         self,
         output: torch.Tensor,
@@ -151,63 +295,82 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool | None,
     ):
-        assert self.quant_dtype == "nvfp4"
-        assert a1q_scale is not None
-        assert self.w1_scale is not None
-        assert self.w2_scale is not None
+        if topk_ids.dtype != torch.int32:
+            topk_ids = topk_ids.to(torch.int32)
+        if topk_weights.dtype != torch.float32:
+            topk_weights = topk_weights.float()
+        self._fused_moe(
+            output=output,
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            activation=activation,
+            a1q_scale=a1q_scale,
+            token_selected_experts=topk_ids,
+            token_final_scales=topk_weights,
+        )
 
-        # a1q_scale is (M, K//16) float8_e4m3fn from fp4_quantize.
-        # The functional API expects x_sf with trailing dim: (M, K//16, 1).
-        x_sf = a1q_scale.unsqueeze(-1)
 
-        # The kernel defaults swiglu_{alpha,beta,limit} to the plain-SwiGLU
-        # values, so only forward the ones the model actually sets.
-        swiglu_params: dict[str, float | None] = {}
-        if activation == MoEActivation.SILU:
-            swiglu_params = {"swiglu_limit": self.gemm1_clamp_limit}
-        elif activation in (
-            MoEActivation.SWIGLUOAI,
-            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
-        ):
-            swiglu_params = {
-                "swiglu_alpha": self.gemm1_alpha,
-                "swiglu_beta": self.gemm1_beta,
-                "swiglu_limit": self.gemm1_clamp_limit,
-            }
-        elif activation == MoEActivation.SITU:
-            # The cute_dsl kernel keys SiTU on situ_beta and requires
-            # activation_type to stay a base type (ActivationType.Situ is
-            # rejected by normalize_cute_dsl_moe_activation_type), so the
-            # Swiglu base type is passed below and SiTU rides the betas.
-            if self.situ_beta is None:
-                raise ValueError(
-                    "SITU activation requires moe_config.activation_situ_beta"
-                )
-            swiglu_params = {
-                "situ_beta": self.situ_beta,
-                "situ_linear_beta": self.situ_linear_beta,
-            }
-        swiglu_kwargs = {k: v for k, v in swiglu_params.items() if v is not None}
+class FlashInferCuteDSLExpertsMonolithic(
+    FlashInferCuteDSLExpertsBase, mk.FusedMoEExpertsMonolithic
+):
+    @staticmethod
+    def _supports_parallel_config(
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> bool:
+        return not moe_parallel_config.use_ep
 
-        flashinfer_cute_dsl_fused_moe_nvfp4(
-            x=hidden_states,
-            x_sf=x_sf,
-            token_selected_experts=topk_ids.to(torch.int32),
-            token_final_scales=topk_weights.float(),
-            w1_weight=w1,
-            w1_weight_sf=self.w1_scale,
-            w1_alpha=self.g1_alphas,
-            fc2_input_scale=self.a2_gscale,
-            w2_weight=w2,
-            w2_weight_sf=self.w2_scale,
-            w2_alpha=self.g2_alphas,
-            num_experts=self.global_num_experts,
-            top_k=self.topk,
-            num_local_experts=self.local_num_experts,
-            local_expert_offset=self.local_expert_offset,
-            moe_output=output,
-            activation_type=activation_to_flashinfer_int(
-                MoEActivation.SILU if activation == MoEActivation.SITU else activation
-            ),
-            **swiglu_kwargs,
+    @staticmethod
+    def _supports_routing_method(
+        routing_method: RoutingMethodType,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        # Fused kernel does TopK -> softmax over selected; RenormalizeNaive matches.
+        return routing_method in (
+            RoutingMethodType.Renormalize,
+            RoutingMethodType.RenormalizeNaive,
+        )
+
+    @staticmethod
+    def _supports_router_logits_dtype(
+        router_logits_dtype: torch.dtype | None,
+        routing_method: RoutingMethodType,
+    ) -> bool:
+        return router_logits_dtype in (
+            torch.bfloat16,
+            torch.float16,
+            torch.float32,
+        )
+
+    def apply(
+        self,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        router_logits: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        num_expert_group: int | None = None,
+        e_score_correction_bias: torch.Tensor | None = None,
+        routed_scaling_factor: float | None = None,
+        topk_group: int | None = None,
+    ) -> torch.Tensor:
+        output = torch.empty(
+            *hidden_states.shape[:-1],
+            self.hidden_dim,
+            dtype=self.out_dtype,
+            device=hidden_states.device,
+        )
+        return self._fused_moe(
+            output=output,
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            activation=activation,
+            a1q_scale=a1q_scale,
+            router_logits=router_logits.contiguous(),
         )

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
@@ -195,7 +195,9 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
         w2: torch.Tensor,
         activation: MoEActivation,
         a1q_scale: torch.Tensor | None,
-        **routing_kwargs: torch.Tensor,
+        token_selected_experts: torch.Tensor | None = None,
+        token_final_scales: torch.Tensor | None = None,
+        router_logits: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert self.quant_dtype in ("nvfp4", "mxfp4", "mxfp8")
         assert a1q_scale is not None
@@ -247,7 +249,8 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
         flashinfer_cute_dsl_fused_moe(
             x=hidden_states,
             x_sf=x_sf,
-            **routing_kwargs,
+            token_selected_experts=token_selected_experts,
+            token_final_scales=token_final_scales,
             w1_weight=w1,
             w1_weight_sf=self.w1_scale,
             w1_alpha=self.g1_alphas,
@@ -269,6 +272,7 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
             down_bias=self._down_bias,
             quant_mode="w4a4" if self.quant_dtype == "nvfp4" else "w4a8",
             weight_interleave=16,
+            router_logits=router_logits,
             **swiglu_kwargs,
         )
         if kernel_output is not output:

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
@@ -14,6 +14,9 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
+from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+    flashinfer_cutedsl_weight_interleave,
+)
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     activation_to_flashinfer_int,
 )
@@ -67,8 +70,9 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
         self.gemm1_clamp_limit = quant_config.gemm1_clamp_limit
         self.situ_beta = moe_config.activation_situ_beta
         self.situ_linear_beta = moe_config.activation_situ_linear_beta
+        self._weight_interleave = flashinfer_cutedsl_weight_interleave()
         half_layout = quant_config.quant_dtype in ("mxfp4", "mxfp8")
-        self._bias_gate, self._bias_up, self._down_bias = self._prepare_biases(
+        self._w1_bias, self._w2_bias = self._prepare_biases(
             quant_config.w1_bias,
             quant_config.w2_bias,
             half_layout=half_layout,
@@ -80,7 +84,7 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
             layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
             layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
         half_layout = self.quant_dtype in ("mxfp4", "mxfp8")
-        self._bias_gate, self._bias_up, self._down_bias = self._prepare_biases(
+        self._w1_bias, self._w2_bias = self._prepare_biases(
             self.w1_bias,
             self.w2_bias,
             half_layout=half_layout,
@@ -113,6 +117,10 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
             (kNvfp4Static, kNvfp4Dynamic),
             (kMxfp4Static, kMxfp8Dynamic),
         ]
+        cap = current_platform.get_device_capability()
+        if cap is not None and cap.to_int() == 107:
+            # SM107 only has the W4A4 kernel.
+            SUPPORTED_W_A = SUPPORTED_W_A[:1]
         return (weight_key, activation_key) in SUPPORTED_W_A
 
     @staticmethod
@@ -160,32 +168,23 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
         *,
         half_layout: bool,
         activation: MoEActivation,
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
-        """MXFP4 convert already emits [up | gate] halves; else normalize."""
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """The kernel splits w1_bias into [up | gate]; MXFP4 convert already
+        emits that layout, else reorder into it."""
         from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
             reorder_w13_to_w31_for_flashinfer_cutedsl,
         )
 
-        if w1_bias is None:
-            bias_gate, bias_up = None, None
-        else:
-            bias = (
-                w1_bias if w1_bias.dtype == torch.float32 else w1_bias.to(torch.float32)
-            )
+        if w1_bias is not None:
+            w1_bias = w1_bias.to(torch.float32)
             if not half_layout:
-                bias = reorder_w13_to_w31_for_flashinfer_cutedsl(
-                    activation, bias, bias
+                w1_bias = reorder_w13_to_w31_for_flashinfer_cutedsl(
+                    activation, w1_bias, w1_bias
                 )[0]
-            half = bias.shape[1] // 2
-            bias_up = bias[:, :half].contiguous()
-            bias_gate = bias[:, half:].contiguous()
-        if w2_bias is None:
-            down_bias = None
-        elif w2_bias.dtype == torch.float32 and w2_bias.is_contiguous():
-            down_bias = w2_bias
-        else:
-            down_bias = w2_bias.to(torch.float32).contiguous()
-        return bias_gate, bias_up, down_bias
+            w1_bias = w1_bias.contiguous()
+        if w2_bias is not None:
+            w2_bias = w2_bias.to(torch.float32).contiguous()
+        return w1_bias, w2_bias
 
     def _fused_moe(
         self,
@@ -267,11 +266,10 @@ class FlashInferCuteDSLExpertsBase(mk.FusedMoEExperts):
             activation_type=activation_to_flashinfer_int(
                 MoEActivation.SILU if activation == MoEActivation.SITU else activation
             ),
-            bias_up=self._bias_up,
-            bias_gate=self._bias_gate,
-            down_bias=self._down_bias,
+            w1_bias=self._w1_bias,
+            w2_bias=self._w2_bias,
             quant_mode="w4a4" if self.quant_dtype == "nvfp4" else "w4a8",
-            weight_interleave=16,
+            weight_interleave=self._weight_interleave,
             router_logits=router_logits,
             **swiglu_kwargs,
         )

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -112,6 +112,8 @@ class Mxfp4MoeBackend(Enum):
     # FlashInfer CUTLASS backends
     FLASHINFER_CUTLASS_MXFP4_MXFP8 = "FLASHINFER_CUTLASS_MXFP4_MXFP8"
     FLASHINFER_CUTLASS_MXFP4_BF16 = "FLASHINFER_CUTLASS_MXFP4_BF16"
+    # FlashInfer CuteDSL backends
+    FLASHINFER_CUTEDSL_MXFP4_MXFP8 = "FLASHINFER_CUTEDSL_MXFP4_MXFP8"
     # Marlin
     BATCHED_MARLIN = "BATCHED_MARLIN"
     MARLIN = "MARLIN"
@@ -192,6 +194,15 @@ def backend_to_kernel_cls(
         )
 
         return [FlashInferExperts]
+
+    elif backend == Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8:
+        from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutedsl_moe import (  # noqa: E501
+            FlashInferCuteDSLExperts,
+            FlashInferCuteDSLExpertsMonolithic,
+        )
+
+        # NOTE: prefer Monolithic > Modular, so return Monolithic first.
+        return [FlashInferCuteDSLExpertsMonolithic, FlashInferCuteDSLExperts]
 
     elif backend == Mxfp4MoeBackend.TRITON:
         from vllm.model_executor.layers.fused_moe.experts.gpt_oss_triton_kernels_moe import (  # noqa: E501
@@ -304,6 +315,10 @@ def map_mxfp4_backend(runner_backend: MoEBackend) -> list[Mxfp4MoeBackend]:
             Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
         ],
         "flashinfer_cutlass_afp8": [Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8],
+        "flashinfer_cutedsl": [
+            Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8,
+        ],
+        "flashinfer_cutedsl_afp8": [Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8],
         "triton": [Mxfp4MoeBackend.TRITON],
         "triton_unfused": [Mxfp4MoeBackend.TRITON_UNFUSED],
         "humming": [Mxfp4MoeBackend.HUMMING],
@@ -342,6 +357,7 @@ def _get_priority_backends_for_gpt_oss() -> list[Mxfp4MoeBackend]:
         Mxfp4MoeBackend.TRITON,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8,
         # TRITON_UNFUSED has bug with MTP support
         # TODO re-enable after kernel is fixed
         # TRITON_UNFUSED
@@ -387,6 +403,7 @@ def _backend_activation_key(backend: Mxfp4MoeBackend) -> QuantKey | None:
     if backend in (
         Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8,
     ):
         return kMxfp8Dynamic
     if backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
@@ -1076,6 +1093,96 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
                 w13_bias_swapped,
                 w2_bias,
             )
+
+    elif mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8:
+        from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+            interleave_linear_and_gate,
+            reorder_w13_to_w31_for_flashinfer_cutedsl,
+        )
+        from vllm.utils.flashinfer import flashinfer_convert_sf_to_mma_layout
+
+        w13_weight = w13_weight.data
+        w2_weight = w2_weight.data
+        w13_weight_scale = w13_weight_scale.data
+        w2_weight_scale = w2_weight_scale.data
+
+        sf_vec_size = 32
+        # Normalize w13 rows to the [up | gate] halves CuteDSL expects.
+        half = w13_weight.shape[1] // 2
+        w13_weight, w13_weight_scale = reorder_w13_to_w31_for_flashinfer_cutedsl(
+            layer.activation, w13_weight, w13_weight_scale
+        )
+        if w13_bias is not None:
+            b = w13_bias.data.to(torch.float32)
+            w13_bias = reorder_w13_to_w31_for_flashinfer_cutedsl(
+                layer.activation, b, b
+            )[0]
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32).contiguous()
+
+        # dims need to be 128 aligned for kernel and SF swizzle. gate/up halves
+        # are padded separately so the padding lands in the last interleave group.
+        def _pad128(x: int) -> int:
+            return -(-x // 128) * 128
+
+        num_experts = w13_weight.shape[0]
+        i_pad = _pad128(half) - half
+        kb = w13_weight.shape[2]  # fp4-packed: bytes = elems/2
+        kb_pad = _pad128(kb * 2) // 2 - kb
+        if i_pad or kb_pad:
+            w13_weight = torch.nn.functional.pad(
+                w13_weight.view(num_experts, 2, half, kb), (0, kb_pad, 0, i_pad)
+            ).reshape(num_experts, 2 * (half + i_pad), kb + kb_pad)
+            w13_weight_scale = torch.nn.functional.pad(
+                w13_weight_scale.view(num_experts, 2, half, -1), (0, 0, 0, i_pad)
+            ).reshape(num_experts, 2 * (half + i_pad), -1)
+            h_pad = _pad128(w2_weight.shape[1]) - w2_weight.shape[1]
+            kb2 = w2_weight.shape[2]
+            kb2_pad = _pad128(kb2 * 2) // 2 - kb2
+            w2_weight = torch.nn.functional.pad(w2_weight, (0, kb2_pad, 0, h_pad))
+
+            if w13_bias is not None:
+                up_b = torch.nn.functional.pad(w13_bias[:, :half], (0, i_pad))
+                gate_b = torch.nn.functional.pad(w13_bias[:, half:], (0, i_pad))
+                w13_bias = torch.cat([up_b, gate_b], dim=1).contiguous()
+            if w2_bias is not None:
+                w2_bias = torch.nn.functional.pad(w2_bias, (0, h_pad))
+
+        w13_weight = interleave_linear_and_gate(w13_weight, group_size=16, dim=1)
+        w13_weight_scale = interleave_linear_and_gate(
+            w13_weight_scale, group_size=16, dim=1
+        )
+
+        # Swizzle scales for CuteDSL kernel (swizzle_blockscale asserts e4m3, hence the
+        # dtype views)
+        from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+            swizzle_blockscale,
+        )
+
+        def _to_mma_layout(scale: torch.Tensor) -> torch.Tensor:
+            scale = swizzle_blockscale(scale.view(torch.float8_e4m3fn)).view(
+                scale.dtype
+            )
+            num_experts, m_padded, k_sf_padded = scale.shape
+            return flashinfer_convert_sf_to_mma_layout(
+                scale.reshape(num_experts * m_padded, k_sf_padded),
+                m=m_padded,
+                k=k_sf_padded * sf_vec_size,
+                num_groups=num_experts,
+                sf_vec_size=sf_vec_size,
+            )
+
+        w13_weight_scale = _to_mma_layout(w13_weight_scale)
+        w2_weight_scale = _to_mma_layout(w2_weight_scale)
+
+        return (
+            w13_weight,
+            w2_weight,
+            w13_weight_scale,
+            w2_weight_scale,
+            w13_bias,
+            w2_bias,
+        )
 
     elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
         from vllm._aiter_ops import rocm_aiter_ops
@@ -1881,6 +1988,18 @@ def make_mxfp4_moe_quant_config(
             gemm1_beta=gemm1_beta,
             gemm1_clamp_limit=swiglu_limit,
             is_scale_swizzled=True,
+        )
+    elif mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8:
+        return mxfp4_mxfp8_moe_quant_config(
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            gemm1_alpha=gemm1_alpha,
+            gemm1_beta=gemm1_beta,
+            gemm1_clamp_limit=swiglu_limit,
+            mx_alignment=128,
+            is_scale_swizzled=False,
         )
     elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
         # W4A8: MXFP4 weights + static FP8 activations

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1096,6 +1096,7 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
 
     elif mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTEDSL_MXFP4_MXFP8:
         from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+            flashinfer_cutedsl_weight_interleave,
             interleave_linear_and_gate,
             reorder_w13_to_w31_for_flashinfer_cutedsl,
         )
@@ -1148,9 +1149,12 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             if w2_bias is not None:
                 w2_bias = torch.nn.functional.pad(w2_bias, (0, h_pad))
 
-        w13_weight = interleave_linear_and_gate(w13_weight, group_size=16, dim=1)
+        interleave = flashinfer_cutedsl_weight_interleave()
+        w13_weight = interleave_linear_and_gate(
+            w13_weight, group_size=interleave, dim=1
+        )
         w13_weight_scale = interleave_linear_and_gate(
-            w13_weight_scale, group_size=16, dim=1
+            w13_weight_scale, group_size=interleave, dim=1
         )
 
         # Swizzle scales for CuteDSL kernel (swizzle_blockscale asserts e4m3, hence the

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -99,9 +99,11 @@ def backend_to_kernel_cls(
     elif backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
         from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutedsl_moe import (  # noqa: E501
             FlashInferCuteDSLExperts,
+            FlashInferCuteDSLExpertsMonolithic,
         )
 
-        return [FlashInferCuteDSLExperts]
+        # NOTE: prefer Monolithic > Modular, so return Monolithic first.
+        return [FlashInferCuteDSLExpertsMonolithic, FlashInferCuteDSLExperts]
 
     elif backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED:
         from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutedsl_batched_moe import (  # noqa: E501

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -68,7 +68,7 @@ def reorder_w1w3_to_w3w1(
 
 def interleave_linear_and_gate(
     x: torch.Tensor,
-    group_size: int = 64,
+    group_size: int = 16,
     dim: int = -1,
 ) -> torch.Tensor:
     """Interleave gate and linear weight rows for CuteDSL wrapper."""
@@ -146,8 +146,8 @@ def prepare_nvfp4_moe_layer_for_flashinfer_cutedsl(
         )
 
         # Interleave up/gate rows for w13 weights and scales.
-        w13 = interleave_linear_and_gate(w13, group_size=64, dim=1)
-        w13_scale = interleave_linear_and_gate(w13_scale, group_size=64, dim=1)
+        w13 = interleave_linear_and_gate(w13, group_size=16, dim=1)
+        w13_scale = interleave_linear_and_gate(w13_scale, group_size=16, dim=1)
 
     w13_scale = swizzle_blockscale(w13_scale)
     w2_scale = swizzle_blockscale(w2_scale)

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     amax_for_moe_activation_quant,
 )
+from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe import RoutedExperts
@@ -64,6 +65,16 @@ def reorder_w1w3_to_w3w1(
             t[a] = tmp
 
     return weight, scale
+
+
+def flashinfer_cutedsl_weight_interleave() -> int:
+    """Physical w13 up/gate interleave the CuteDSL kernel expects.
+
+    SM100/SM103 take the swap-AB kernels, which need 16; SM107 has no swap-AB
+    variant and only accepts 64.
+    """
+    cap = current_platform.get_device_capability()
+    return 64 if cap is not None and cap.to_int() == 107 else 16
 
 
 def interleave_linear_and_gate(
@@ -146,8 +157,9 @@ def prepare_nvfp4_moe_layer_for_flashinfer_cutedsl(
         )
 
         # Interleave up/gate rows for w13 weights and scales.
-        w13 = interleave_linear_and_gate(w13, group_size=16, dim=1)
-        w13_scale = interleave_linear_and_gate(w13_scale, group_size=16, dim=1)
+        interleave = flashinfer_cutedsl_weight_interleave()
+        w13 = interleave_linear_and_gate(w13, group_size=interleave, dim=1)
+        w13_scale = interleave_linear_and_gate(w13_scale, group_size=interleave, dim=1)
 
     w13_scale = swizzle_blockscale(w13_scale)
     w2_scale = swizzle_blockscale(w2_scale)

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -212,9 +212,7 @@ scaled_fp4_grouped_quantize = _lazy_import_wrapper(
 nvfp4_block_scale_interleave = _lazy_import_wrapper(
     "flashinfer.fp4_quantization", "block_scale_interleave"
 )
-flashinfer_cute_dsl_fused_moe_nvfp4 = _lazy_import_wrapper(
-    "flashinfer", "cute_dsl_fused_moe_nvfp4"
-)
+flashinfer_cute_dsl_fused_moe = _lazy_import_wrapper("flashinfer", "cute_dsl_fused_moe")
 flashinfer_convert_sf_to_mma_layout = _lazy_import_wrapper(
     "flashinfer.cute_dsl.utils", "convert_sf_to_mma_layout"
 )
@@ -434,12 +432,12 @@ def has_flashinfer_cutedsl_grouped_gemm_nt_masked() -> bool:
 
 
 @functools.cache
-def has_flashinfer_cutedsl_moe_nvfp4() -> bool:
-    """Return ``True`` if FlashInfer cute_dsl_fused_moe_nvfp4 is available."""
+def has_flashinfer_cutedsl_moe() -> bool:
+    """Return ``True`` if FlashInfer cute_dsl_fused_moe is available."""
     if not has_flashinfer_cutedsl():
         return False
     mod = _get_submodule("flashinfer")
-    return mod is not None and hasattr(mod, "cute_dsl_fused_moe_nvfp4")
+    return mod is not None and hasattr(mod, "cute_dsl_fused_moe")
 
 
 @functools.cache
@@ -1236,7 +1234,7 @@ __all__ = [
     "silu_and_mul_scaled_nvfp4_experts_quantize",
     "scaled_fp4_grouped_quantize",
     "nvfp4_block_scale_interleave",
-    "flashinfer_cute_dsl_fused_moe_nvfp4",
+    "flashinfer_cute_dsl_fused_moe",
     "flashinfer_b12x_fused_moe",
     "flashinfer_convert_sf_to_mma_layout",
     "trtllm_fp4_block_scale_moe",
@@ -1250,7 +1248,7 @@ __all__ = [
     "has_flashinfer_nvlink_one_sided",
     "has_flashinfer_cutlass_fused_moe",
     "has_flashinfer_cutedsl_grouped_gemm_nt_masked",
-    "has_flashinfer_cutedsl_moe_nvfp4",
+    "has_flashinfer_cutedsl_moe",
     "has_flashinfer_bf16_fp4",
     "has_flashinfer_b12x_moe",
     "has_flashinfer_b12x_gemm",


### PR DESCRIPTION


## Purpose

- Use new FlashInfer CuteDSL MoE api which support mxfp8 x mxfp4 dtypes and improves low latency decode performance
- Adds GPT-OSS-120B support on the CuteDSL backend
- Migrate the FlashInfer CuteDSL MoE integration from `cute_dsl_fused_moe_nvfp4` to `cute_dsl_fused_moe`.
- Pass weight_interleave=16 to the new API.
- Prepare W13 weights and scales using the matching 16-row interleave.
- Update FlashInfer API availability detection and exports.

## Test Plan

- pytest tests/kernels/moe/test_flashinfer_cutedsl_layout.py
- pytest tests/kernels/moe/flashinfer_cutedsl_moe.py

## Test Result
PASS

