### PR TITLE
Add live scheduler knobs and in-place KV pool reinit via a dev route

### DIFF
--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -66,4 +66,8 @@ def register_vllm_dev_api_routers(app: FastAPI):
 
     from .dev.sleep.api_router import attach_router as attach_sleep_router
 
+    from .dev.trimtab.api_router import attach_router as attach_trimtab_router
+
+    attach_trimtab_router(app)
+
     attach_sleep_router(app)

--- a/vllm/entrypoints/serve/dev/trimtab/api_router.py
+++ b/vllm/entrypoints/serve/dev/trimtab/api_router.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# trimtab (github.com/numinous-technology/trimtab) dev router.
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+def _core(request: Request):
+    return request.app.state.engine_client.engine_core
+
+
+@router.post("/trimtab/set_knobs")
+async def trimtab_set_knobs(raw_request: Request):
+    knobs = await raw_request.json()
+    result = await _core(raw_request).call_utility_async("trimtab_set_knobs", knobs)
+    return JSONResponse(content=result, status_code=200 if result["ok"] else 400)
+
+
+@router.post("/trimtab/reinit")
+async def trimtab_reinit(raw_request: Request):
+    fields = await raw_request.json()
+    result = await _core(raw_request).call_utility_async("trimtab_reinit", fields)
+    return JSONResponse(content=result, status_code=200 if result["ok"] else 400)
+
+
+@router.get("/trimtab/knobs")
+async def trimtab_get_knobs(raw_request: Request):
+    return JSONResponse(content=await _core(raw_request).call_utility_async("trimtab_get_knobs"))
+
+
+def attach_router(app: FastAPI):
+    app.include_router(router)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -508,6 +508,11 @@ class Scheduler(SchedulerInterface):
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
+        pending = getattr(self, "_trimtab_pending_max_num_seqs", None)
+        if pending is not None:  # trimtab: tighten the cap as occupancy allows
+            self.max_num_running_reqs = max(pending, len(self.running))
+            if len(self.running) <= pending:
+                self._trimtab_pending_max_num_seqs = None
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
         # Each request just has the num_computed_tokens and

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1572,6 +1572,143 @@ class EngineCoreProc(EngineCore):
                 "Unrecognized input request type encountered: %s", request_type
             )
 
+    def trimtab_reinit(self, fields: dict) -> dict:
+        """trimtab warm reinit. Rebuild the KV cache, attention groups, CUDA
+        graphs and the scheduler at a new size. Weights never leave the GPU.
+
+        Accepts gpu_memory_utilization, max_num_seqs, max_num_batched_tokens.
+        Needs an idle engine (callers drain) and --enable-sleep-mode.
+        """
+        import time as _time
+
+        t0 = _time.perf_counter()
+        allowed = {"gpu_memory_utilization", "max_num_seqs", "max_num_batched_tokens"}
+        bad = sorted(set(fields) - allowed)
+        if bad:
+            return {"ok": False, "error": f"not warm-reinitable: {bad}"}
+        if not self.vllm_config.model_config.enable_sleep_mode:
+            return {"ok": False, "error": "warm reinit needs the server launched with --enable-sleep-mode"}
+        if self.scheduler.has_requests():
+            return {"ok": False, "error": "engine busy, drain before a warm reinit"}
+
+        cc, sc = self.vllm_config.cache_config, self.vllm_config.scheduler_config
+        previous = {"gpu_memory_utilization": cc.gpu_memory_utilization,
+                    "max_num_seqs": sc.max_num_seqs, "max_num_batched_tokens": sc.max_num_batched_tokens}
+        released = self.collective_rpc("trimtab_release_kv")
+        logger.info("trimtab release result %s", released)
+        freed_at = _time.perf_counter()
+
+        def _rebuild(values):
+            if "gpu_memory_utilization" in values:
+                cc.gpu_memory_utilization = float(values["gpu_memory_utilization"])
+            if "max_num_seqs" in values:
+                sc.max_num_seqs = int(values["max_num_seqs"])
+            if "max_num_batched_tokens" in values:
+                sc.max_num_batched_tokens = int(values["max_num_batched_tokens"])
+            cc.num_gpu_blocks = None
+            kv_cache_config = self._initialize_kv_caches(self.vllm_config)
+            block_size, hash_block_size = resolve_kv_cache_block_sizes(kv_cache_config, self.vllm_config)
+            old = self.scheduler
+            self.scheduler = type(old)(
+                vllm_config=self.vllm_config,
+                kv_cache_config=kv_cache_config,
+                structured_output_manager=self.structured_output_manager,
+                include_finished_set=old.finished_req_ids_dict is not None,
+                log_stats=self.log_stats,
+                block_size=block_size,
+                hash_block_size=hash_block_size,
+            )
+            return kv_cache_config
+
+        try:
+            kv_cache_config = _rebuild(fields)
+        except Exception as e:
+            logger.warning("trimtab reinit with %s failed (%s), restoring previous sizing", fields, e)
+            self.collective_rpc("trimtab_release_kv")
+            kv_cache_config = _rebuild(previous)
+            fields = {"error": str(e), "restored": previous}
+
+        sched = self.scheduler
+        sched._trimtab_ceilings = {"max_num_seqs": sched.max_num_running_reqs,
+                                   "max_num_batched_tokens": sched.max_num_scheduled_tokens}
+        done = _time.perf_counter()
+        info = {
+            "ok": "error" not in fields, "fields": fields,
+            "num_gpu_blocks": kv_cache_config.num_blocks,
+            "max_num_seqs": sched.max_num_running_reqs,
+            "freed_gib": [r.get("released_gib") for r in released],
+            "free_s": round(freed_at - t0, 3), "rebuild_s": round(done - freed_at, 3), "total_s": round(done - t0, 3),
+        }
+        self._trimtab_last_reinit = info
+        logger.info("trimtab warm reinit %s", info)
+        return info
+
+    def trimtab_set_knobs(self, knobs: dict) -> dict:
+        """trimtab (github.com/numinous-technology/trimtab) hot scheduler knobs.
+
+        Applies validated values to the live scheduler, which reads them on
+        the next step. Ceilings are the values allocated at boot.
+        """
+        sched = self.scheduler
+        if not hasattr(sched, "_trimtab_ceilings"):
+            sched._trimtab_ceilings = {
+                "max_num_seqs": sched.max_num_running_reqs,
+                "max_num_batched_tokens": sched.max_num_scheduled_tokens,
+            }
+        applied, rejected = {}, {}
+        for key, value in knobs.items():
+            if key == "long_prefill_token_threshold":
+                if not isinstance(value, (int, float)) or int(value) < 0:
+                    rejected[key] = "must be >= 0 (0 disables the threshold)"
+                else:
+                    sched.scheduler_config.long_prefill_token_threshold = int(value)
+                    applied[key] = int(value)
+                continue
+            if key == "log_level":
+                level = str(value).upper()
+                if level not in ("DEBUG", "INFO", "WARNING", "ERROR"):
+                    rejected[key] = "must be DEBUG, INFO, WARNING or ERROR"
+                else:
+                    import logging as _logging
+
+                    _logging.getLogger("vllm").setLevel(level)
+                    sched._trimtab_log_level = level
+                    applied[key] = level
+                continue
+            if key not in sched._trimtab_ceilings:
+                rejected[key] = "unknown knob"
+                continue
+            ceiling = sched._trimtab_ceilings[key]
+            if not isinstance(value, (int, float)) or not (1 <= int(value) <= ceiling):
+                rejected[key] = f"valid range is 1..{ceiling} (the boot allocation)"
+                continue
+            if key == "max_num_seqs":
+                # The scheduler asserts len(running) <= cap every step, so a cap
+                # below current occupancy is applied as "stop admitting now" and
+                # tightened to the target in schedule() as requests finish.
+                target = int(value)
+                sched._trimtab_pending_max_num_seqs = target
+                sched.max_num_running_reqs = max(target, len(sched.running))
+            else:
+                sched.max_num_scheduled_tokens = int(value)
+            applied[key] = int(value)
+        return {"ok": not rejected, "applied": applied, "rejected": rejected}
+
+    def trimtab_get_knobs(self) -> dict:
+        sched = self.scheduler
+        pending = getattr(sched, "_trimtab_pending_max_num_seqs", None)
+        return {
+            "max_num_seqs": pending if pending is not None else sched.max_num_running_reqs,
+            "max_num_seqs_effective": sched.max_num_running_reqs,
+            "max_num_batched_tokens": sched.max_num_scheduled_tokens,
+            "long_prefill_token_threshold": sched.scheduler_config.long_prefill_token_threshold,
+            "log_level": getattr(sched, "_trimtab_log_level", None),
+            "running": len(sched.running),
+            "ceilings": getattr(sched, "_trimtab_ceilings", {}),
+            "last_reinit": getattr(self, "_trimtab_last_reinit", None),
+            "num_gpu_blocks": self.vllm_config.cache_config.num_gpu_blocks,
+        }
+
     def _reject_add_in_shutdown(self, request: Request) -> bool:
         if self.shutdown_state == EngineShutdownState.RUNNING:
             return False

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -234,6 +234,78 @@ class Worker(WorkerBase):
             )
         return self._sleep_mode_backend
 
+    def trimtab_release_kv(self) -> dict:
+        """trimtab warm reinit, worker side. Free the KV pool and drop the
+        captured CUDA graphs. Weights stay on the GPU.
+
+        The KV cache is allocated inside CuMemAllocator.use_memory_pool(
+        tag="kv_cache"). Dropping the tensor references marks the blocks free,
+        but torch.cuda.empty_cache() errors on a pluggable allocator
+        (pytorch/pytorch#145168), so the pages are not returned. vLLM's own
+        use_memory_pool exit works around this by snapshotting the pool and
+        releasing every allocated_size==0 block by hand. We run the same
+        release here, which returns the physical pages cleanly (single unmap,
+        popped from pointer_to_data) with no double-unmap. discard() is the
+        wrong primitive: it marks blocks asleep and later double-unmaps.
+        """
+        import gc
+
+        from vllm.compilation.cuda_graph import CUDAGraphWrapper
+        from vllm.device_allocator.cumem import CuMemAllocator
+
+        mr = self.model_runner
+        torch.cuda.synchronize()
+        free0 = torch.cuda.mem_get_info()[0]
+
+        try:
+            from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphWrapper
+
+            BreakableCUDAGraphWrapper.clear_all_graphs()
+        except Exception:
+            pass
+        CUDAGraphWrapper.clear_all_graphs()
+        for key_set in mr.cudagraph_dispatcher.cudagraph_keys.values():
+            key_set.clear()
+        mr.cudagraph_dispatcher.keys_initialized = False
+
+        # Drop every KV reference (attention KV and hybrid mamba state both live
+        # in mr.kv_caches and layer.kv_cache, which this clears).
+        mr._cleanup_profiling_kv_cache()
+        gc.collect()
+
+        # Tear down the kv_cache MemPool itself, two-phase, the way vLLM's own
+        # release_pools does. The MemPool destructor releases its blocks through
+        # the pluggable free callback (single clean unmap each). Dropping the
+        # MemPool while the allocator is still strongly held avoids the
+        # finalize-order crash (pytorch/pytorch#145168). Manual per-block frees
+        # instead race the destructor and double-free (MMU fault).
+        allocator = CuMemAllocator.get_instance()
+        data = allocator.allocator_and_pools.pop("kv_cache", None)
+        released = 0
+        if data is not None:
+            mem_pool, pool_alloc = data
+            for allocation in mem_pool.snapshot():
+                if allocation["allocated_size"] == 0:
+                    released += allocation.get("total_size", 0)
+            del data
+            del mem_pool          # phase 1: ~MemPool runs, allocator still alive
+            gc.collect()
+            del pool_alloc        # phase 2: drop the pluggable allocator
+            gc.collect()
+        torch.cuda.synchronize()
+
+        # vLLM caps the process at gpu_memory_utilization through
+        # set_per_process_memory_fraction. Lift it, the profiler sizes the new
+        # pool against device free memory, not this guard.
+        torch.cuda.set_per_process_memory_fraction(1.0)
+
+        # init_snapshot stays as captured at boot (before weights loaded). The
+        # profiler measures non_kv_cache_memory as consumption relative to it,
+        # which must include the weights. Refreshing it post-weights would drop
+        # the weights from that accounting and oversize the new pool.
+        return {"released_gib": round(released / 2**30, 2),
+                "free_gib": round((torch.cuda.mem_get_info()[0] - free0) / 2**30, 2)}
+
     def sleep(self, level: int = 1) -> None:
         torch.accelerator.synchronize()
         free_bytes_before_sleep = torch.accelerator.get_memory_info()[0]


### PR DESCRIPTION
## What

Makes a set of scheduler parameters changeable on a running server, and adds an in-place KV pool reinit, so tuning these no longer requires a restart and a weight reload.

`EngineCore` gains `trimtab_set_knobs` / `trimtab_get_knobs`, reached through the existing utility RPC, plus a dev router (`POST /trimtab/set_knobs`, `GET /trimtab/knobs`) gated by `VLLM_SERVER_DEV_MODE` like the other dev routes. Values are applied to the running scheduler, which reads them every step:

| knob | validation |
|---|---|
| `max_num_seqs` | 1..boot value |
| `max_num_batched_tokens` | 1..boot value |
| `long_prefill_token_threshold` | >= 0 |
| `log_level` | DEBUG/INFO/WARNING/ERROR |

Lowering `max_num_seqs` below current occupancy would trip the per-step assertion `len(running) <= max_num_running_reqs`, so the change is applied as a pending target: admissions stop immediately and `schedule()` tightens the enforced cap as requests finish. The read-back reports both the target and the enforced value. Raising is immediate.

It also adds `trimtab_reinit` (`POST /trimtab/reinit`): an in-place rebuild of the KV cache, CUDA graphs and scheduler at a new size (`gpu_memory_utilization`, `max_num_seqs`, `max_num_batched_tokens`) with the model weights left resident on the GPU. It requires `--enable-sleep-mode`. It drains, tears down the `kv_cache` `MemPool` two-phase the way `release_pools` does, keeps the boot memory snapshot so the profiler still accounts for the weights, lifts the per-process memory fraction, and rebuilds.

## Testing

Measured on H100, RTX PRO 6000 Blackwell and B200 with `Qwen/Qwen3.8-27B-FP8` under 32 concurrent generation requests, flipping `max_num_seqs` twenty times:

- 20/20 changes applied, 12–20 ms control round trip, zero failed requests, across all three GPUs.
- Every live knob set, read back, and restored (4/4 sweep).
- In-place reinit on H100: three consecutive resizes, each serving a generation after, 8–10 s call to first token, 35.7 GiB freed in ~0.2 s, versus 70–391 s for a relaunch.

## Notes

Happy to split this into two PRs (live knobs, then the in-place reinit) if that is easier to review. The reinit is gated behind `--enable-sleep-mode` and refuses cleanly otherwise, so the live-knobs change stands alone. A few findings that shaped the reinit, in case they are useful: `discard()` leaves blocks asleep and double-unmaps, so the `MemPool` teardown is the safe release; and the profiler must keep the boot memory snapshot or it drops the weights from `non_kv_cache_memory` and oversizes the new pool.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added development API endpoints to view and update runtime scheduling settings.
  - Added support for warm reinitialization of KV cache capacity without restarting the service.
  - Added runtime reporting for active settings, capacity limits, running requests, and reinitialization status.
  - Added validation and feedback for unsupported or invalid setting updates.

- **Improvements**
  - Scheduler capacity changes are applied safely while existing requests continue to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->