### PR TITLE
[Perf][Kimi-K3] Use the one-shot custom all-gather for TP logits

### DIFF
--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -15,6 +15,7 @@ from vllm.distributed import (
     get_ep_group,
     get_pp_group,
     get_tensor_model_parallel_world_size,
+    get_tp_group,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
@@ -1596,6 +1597,35 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                 module.experts.finalize_weights()
 
 
+class KimiK3LogitsProcessor(LogitsProcessor):
+    """LogitsProcessor with a one-shot custom all-gather for the TP logits.
+
+    The NCCL ring all-gather costs ~21us per decode step for K3's
+    vocab-sharded logits on an NVLink mesh; the one-shot custom (or MNNVL
+    Lamport) all-gather does the same rank-order concat in a few
+    microseconds. Falls back to the base collective whenever the custom
+    kernel is unavailable or declines the input.
+    """
+
+    def _gather_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        if logits.dim() == 2:
+            comm = getattr(get_tp_group(), "device_communicator", None)
+            custom_all_gather = getattr(comm, "custom_all_gather", None)
+            if custom_all_gather is not None:
+                gathered = custom_all_gather(logits)
+                if gathered is not None:
+                    num_tokens = logits.shape[0]
+                    if num_tokens == 1:
+                        return gathered.view(1, -1)
+                    world_size = gathered.shape[0] // num_tokens
+                    return (
+                        gathered.view(world_size, num_tokens, -1)
+                        .movedim(0, 1)
+                        .reshape(num_tokens, -1)
+                    )
+        return super()._gather_logits(logits)
+
+
 class KimiLinearForCausalLM(
     nn.Module,
     HasInnerState,
@@ -1626,7 +1656,7 @@ class KimiLinearForCausalLM(
             self.lm_head = PPMissingLayer()
         enable_kimi_k3_low_latency_gemm(self, self.model_config.dtype)
         logit_scale = getattr(self.config, "logit_scale", 1.0)
-        self.logits_processor = LogitsProcessor(
+        self.logits_processor = KimiK3LogitsProcessor(
             self.config.vocab_size, scale=logit_scale
         )
 


### PR DESCRIPTION
## Purpose

Kimi-K3's vocab-parallel logits all-gather went through the NCCL ring collective, which costs ~21us per decode step on an NVLink-connected TP8 group (latency-bound: 7 hops for a ~40KB-per-rank shard). This adds a `KimiK3LogitsProcessor` that routes the gather through the one-shot custom all-gather (MNNVL Lamport when available), which does the same rank-order concat in a single exchange, with a transparent fallback to the base collective whenever the custom kernel is unavailable or declines the input (size, dtype, registration). Gather semantics are identical, including the padded-vocab slice afterwards.

Not duplicating open work: searched open PRs; #48572 warms the spec-sized logits all-gather at init and #54433 changes DSpark top-k — neither changes the collective used here.

## Test Plan

- `pytest tests/models/kimi_k3/` unit suites on B300, run on a development tree containing this change.
- A/B Kimi-K3 TP8 serving (single 8x B300 node, 8192-in/1024-out, concurrency 1, fp8 KV cache) with Nsight Systems traces; combined with the pure-decode gather skip (submitted separately), since the two were measured in one run.

## Test Result

- Logits all-gather: **20.2 -> 10.8 us per decode step** (trace mean); the `mnnvl_lamport_all_gather` kernel launches early enough to overlap the LM-head GEMM tail.
- Combined with the separate decode-gather skip: stable-step median 8.7972 -> 8.7747 ms, bench median ITL 8.791 -> 8.770 ms (-0.25%).
- Greedy output spot checks unchanged (the collective is bitwise-equivalent).

AI assistance was used for this PR (Claude Code); every changed line was reviewed and the tests above were run by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Summary by CodeRabbit

* **Improvements**
  * Improved logits gathering for Kimi K3 models across tensor-parallel configurations.
  * Added fallback handling when the optimized gathering path is unavailable, preserving standard logits processing behavior.

