### PR TITLE
[Perf][Model Runner] Skip the identity logits gather on pure decode

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1433,7 +1433,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             logits = all_to_all_logits(local_logits, shard_metadata)
             logits = logits[:, : self.vocab_size]
         else:
-            sample_hidden_states = hidden_states[input_batch.logits_indices]
+            if (
+                input_batch.num_draft_tokens == 0
+                and not input_batch.has_prefill
+                and input_batch.num_tokens == input_batch.num_reqs
+                and input_batch.logits_indices.shape[0] == input_batch.num_reqs
+            ):
+                # Pure decode: each request's single scheduled token is its
+                # sampling position, so logits_indices is arange(num_reqs) and
+                # the gather kernel can be skipped.
+                sample_hidden_states = hidden_states[: input_batch.num_reqs]
+            else:
+                sample_hidden_states = hidden_states[input_batch.logits_indices]
             logits = self.model.compute_logits(sample_hidden_states)
 
         if grammar_output is not None:


### PR DESCRIPTION
## Purpose

In `GPUModelRunner.sample`, the hidden states are gathered at `logits_indices` before `compute_logits`. At pure decode without speculative drafts, each request's single scheduled token is its sampling position, so `logits_indices` is `arange(num_reqs)` and the gather is an identity over the first `num_reqs` rows — but it still launches an eager index kernel and allocates its output every step. This replaces it with a slice when `num_draft_tokens == 0`, there is no prefill in the batch, `num_tokens == num_reqs`, and the logits count matches `num_reqs`; every other batch shape (spec decode, prefill, prompt logprobs) keeps the gather.

Not duplicating open work: searched open PRs for this gather; none touch it.

## Test Plan

- `pytest tests/v1/worker/test_gpu_model_runner_v2.py tests/v1/worker/test_gpu_input_batch_v2.py` on B300, run on a development tree containing this change.
- A/B Kimi-K3 TP8 serving (8192-in/1024-out, concurrency 1, fp8 KV cache) with Nsight Systems traces; measured in one run together with a separate Kimi-K3 logits all-gather change (#55021).

## Test Result

- `8 passed`.
- Removes one ~6.7 us eager `index_elementwise` launch per decode step (3 -> 2 such kernels in the step tail).
- Combined with #55021: stable-step median 8.7972 -> 8.7747 ms, bench median ITL 8.791 -> 8.770 ms (-0.25%). Outputs unchanged (identity gather).

AI assistance was used for this PR (Claude Code); every changed line was reviewed and the tests above were run by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Summary by CodeRabbit

- **Performance**
  - Improved generation efficiency for standard decode-only requests by streamlining hidden-state processing.
  - Reduced unnecessary processing in cases where each request produces one token, potentially lowering latency and improving throughput.
- **Compatibility**
  - Other generation scenarios continue to use their existing processing path, preserving current behavior.

