### PR TITLE
[CI] Exclude nightly-dev tags from nightly DockerHub cleanup

### DIFF
--- a/.buildkite/scripts/cleanup-nightly-builds.sh
+++ b/.buildkite/scripts/cleanup-nightly-builds.sh
@@ -4,6 +4,7 @@ set -ex
 
 # Clean up old nightly builds from DockerHub, keeping only the last 14 builds
 # This script uses DockerHub API to list and delete old tags with specified prefix
+# Tags starting with "nightly-dev" are always excluded from deletion
 # Usage: cleanup-nightly-builds.sh [TAG_PREFIX] [REPO]
 # Example: cleanup-nightly-builds.sh "nightly-"
 # Example: cleanup-nightly-builds.sh "cu130-nightly-"
@@ -55,7 +56,8 @@ get_all_tags() {
         set -x
         
         # Get both last_updated timestamp and tag name, separated by |
-        local tags=$(echo "$response" | jq -r --arg prefix "$TAG_PREFIX" '.results[] | select(.name | startswith($prefix)) | "\(.last_updated)|\(.name)"')
+        # Exclude nightly-dev tags from cleanup
+        local tags=$(echo "$response" | jq -r --arg prefix "$TAG_PREFIX" '.results[] | select(.name | startswith($prefix)) | select(.name | startswith("nightly-dev") | not) | "\(.last_updated)|\(.name)"')
         
         if [ -z "$tags" ]; then
             break


### PR DESCRIPTION
## Purpose

The nightly cleanup script (`.buildkite/scripts/cleanup-nightly-builds.sh`) runs after every nightly release build and deletes all but the newest 14 DockerHub tags matching the `nightly-` prefix. Since `nightly-dev` tags also start with `nightly-`, they are matched by the prefix filter, counted toward the keep-14 window, and can be deleted.

This PR excludes any tag starting with `nightly-dev` from the jq selection so those tags are never deleted and no longer count toward the keep window.

## Test plan

Verified the jq filter locally:

```bash
echo '{"results":[{"name":"nightly-abc123","last_updated":"2026-09-01"},{"name":"nightly-dev","last_updated":"2026-08-01"},{"name":"nightly-dev-foo","last_updated":"2026-08-02"},{"name":"nightly-def456","last_updated":"2026-08-03"}]}' | jq -r --arg prefix "nightly-" '.results[] | select(.name | startswith($prefix)) | select(.name | startswith("nightly-dev") | not) | "\(.last_updated)|\(.name)"'
# Output:
# 2026-09-01|nightly-abc123
# 2026-08-03|nightly-def456
```

`nightly-dev` and `nightly-dev-foo` are excluded; regular `nightly-*` tags pass through. `shellcheck` on the modified script passes with no warnings.

## Duplicate check

Searched open PRs for "nightly-dev cleanup", "cleanup-nightly-builds", and "nightly tag delete" — no existing PR addresses this.

---
This change was made with AI assistance (Kimi Code). All changed lines have been reviewed by the human submitter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Nightly cleanup now excludes DockerHub tags beginning with `nightly-dev`, preventing them from being selected for deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->