### PR TITLE
[Perf][Kimi-K3] Alias precomputed aligned state indices in decode metadata

### DIFF
--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -795,3 +795,35 @@ def test_aligned_block_table_matches_shared_gdn():
     )
 
     torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_non_spec_cudagraph_aliases_precomputed_aligned_state_indices():
+    device = torch.device("cuda")
+    batch = BatchSpec(seq_lens=[40, 30], query_lens=[1, 1])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, device
+    ).replace(is_prefilling=torch.tensor([False, False]))
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=True,
+        mamba_cache_mode="align",
+        device=device,
+    )
+    assert isinstance(builder, KimiK3KDAMetadataBuilder)
+    precomputed_indices = torch.tensor(
+        [[101], [201], [301]], dtype=torch.int32, device=device
+    )
+    builder.mamba_aligned_state_indices = precomputed_indices
+
+    metadata = builder.build(0, common_attn_metadata)
+
+    state_indices = metadata.non_spec_state_indices_tensor
+    assert state_indices is not None
+    assert state_indices.is_contiguous()
+    assert state_indices.data_ptr() == precomputed_indices.data_ptr()
+    torch.testing.assert_close(
+        state_indices,
+        precomputed_indices[: batch.batch_size, 0],
+    )

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -673,15 +673,21 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             and num_spec_decodes == 0
             and num_decodes <= self.decode_cudagraph_max_bs
         ):
-            self.non_spec_state_indices_tensor[:num_decodes].copy_(
-                non_spec_state_indices_tensor, non_blocking=True
+            can_alias_aligned_state_indices = (
+                not self.use_spec_decode
+                and self.mamba_aligned_state_indices is not None
+                and num_decodes == batch_size
             )
-            self.non_spec_state_indices_tensor[num_decodes:batch_size].fill_(
-                NULL_BLOCK_ID
-            )
-            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
-                :batch_size
-            ]
+            if not can_alias_aligned_state_indices:
+                self.non_spec_state_indices_tensor[:num_decodes].copy_(
+                    non_spec_state_indices_tensor, non_blocking=True
+                )
+                self.non_spec_state_indices_tensor[num_decodes:batch_size].fill_(
+                    NULL_BLOCK_ID
+                )
+                non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
+                    :batch_size
+                ]
 
         recoverssm_commit = None
         if self.use_recoverssm and num_spec_decodes > 0:


### PR DESCRIPTION
## Purpose

In the full-cudagraph decode-only branch of the Kimi-K3 KDA metadata builder, the non-spec state indices were copied into the builder's persistent buffer and the padding tail filled with `NULL_BLOCK_ID` on every step. When speculative decoding is disabled, the mamba-aligned state indices are precomputed, and the decode count covers the whole batch, the incoming tensor already *is* the graph-stable aligned buffer — so it can be aliased directly. This skips one device-to-device copy and one fill launch per decode step; every other shape keeps the copy path.

Not duplicating open work: searched open PRs around K3 metadata (#53301, #53774, #51483) — none touch this copy.

## Test Plan

- `pytest tests/models/kimi_k3/test_kda_metadata.py` on B300, run on a development tree containing this change (25 passed there), plus a new `test_non_spec_cudagraph_aliases_precomputed_aligned_state_indices` asserting the returned indices alias the precomputed buffer (`data_ptr` equality) with the correct values.
- Kimi-K3 TP8 serving A/B (8192-in/1024-out, concurrency 1, fp8 KV cache) with Nsight Systems traces, measured together with a related per-step bookkeeping change (submitted separately).

## Test Result

- New test passes; suite green on the development tree.
- Together with the related bookkeeping change: ~24 us/step reduction in step-boundary work (stable-step median 8.821 -> 8.797 ms in that pass). Metadata contents are identical (the new test asserts values and aliasing).

AI assistance was used for this PR (Claude Code); every changed line was reviewed and the tests above were run by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved CUDA-graph decode handling by reusing precomputed state indices in eligible non-speculative decode scenarios.
  * Retained existing state-index staging and padding behavior for other request types.
* **Tests**
  * Added coverage verifying that precomputed state indices are reused without copying and remain contiguous.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->