### PR TITLE
[Perf][Mamba] Skip post-step state bookkeeping without speculative decoding

### DIFF
--- a/tests/v1/worker/test_mamba_hybrid_model_state.py
+++ b/tests/v1/worker/test_mamba_hybrid_model_state.py
@@ -22,6 +22,7 @@ def test_postprocess_state_scalar_with_int32_mapping(
     num_sampled: int, expected_value: int
 ) -> None:
     state = object.__new__(MambaHybridModelState)
+    state.vllm_config = SimpleNamespace(num_speculative_tokens=1)
     state.num_accepted_tokens_gpu = torch.full(
         (4,), 9, dtype=torch.int32, device="cuda"
     )
@@ -36,6 +37,28 @@ def test_postprocess_state_scalar_with_int32_mapping(
         [expected_value, 9, expected_value, 9], dtype=torch.int32, device="cuda"
     )
     torch.testing.assert_close(state.num_accepted_tokens_gpu, expected)
+
+
+def test_postprocess_state_skips_without_speculative_decoding() -> None:
+    state = object.__new__(MambaHybridModelState)
+    state.vllm_config = SimpleNamespace(num_speculative_tokens=0)
+    state.num_accepted_tokens_gpu = torch.full((2,), 9, dtype=torch.int32)
+    state._align_mode = True
+    state.recoverssm = Mock()
+    state._mamba_ctx = Mock()
+
+    state.postprocess_state(
+        torch.tensor([0, 1], dtype=torch.int32),
+        torch.tensor([2, 3], dtype=torch.int32),
+        torch.tensor([8, 9], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(
+        state.num_accepted_tokens_gpu,
+        torch.full((2,), 9, dtype=torch.int32),
+    )
+    state.recoverssm.commit_step.assert_not_called()
+    state._mamba_ctx.run_fused_postprocess_align.assert_not_called()
 
 
 def test_recoverssm_commits_accepted_window_after_v2_sampling() -> None:
@@ -67,6 +90,7 @@ def test_recoverssm_commits_accepted_window_after_v2_sampling() -> None:
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
 def test_recoverssm_align_tracks_mixed_batch_state_and_neutralizes_copy_bias() -> None:
     state = object.__new__(MambaHybridModelState)
+    state.vllm_config = SimpleNamespace(num_speculative_tokens=1)
     state._align_mode = True
     state._mamba_ctx = None
     state._mamba_state_idx_gpu = torch.full((5,), -1, dtype=torch.int32, device="cuda")

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -340,6 +340,9 @@ class MambaHybridModelState(DefaultModelState):
         num_sampled: torch.Tensor | int,
         num_computed_tokens: torch.Tensor | None = None,
     ) -> None:
+        if self.vllm_config.num_speculative_tokens == 0:
+            return
+
         # Chunked prefill does not sample a token, so num_sampled can be 0.
         # Mamba treats num_accepted_tokens=1 as the neutral non-spec value.
         num_reqs = idx_mapping.shape[0]


### PR DESCRIPTION
## Purpose

`MambaHybridModelState.postprocess_state` commits accepted-token windows after speculative verification. Without speculative decoding, every request accepts exactly one token — the neutral value the state machinery already assumes — so the call is semantically a no-op, yet it still launched its bookkeeping kernels (accepted-token scatter and the fused align postprocess) on every decode step. Return early when `num_speculative_tokens == 0`; speculative configurations are unchanged.

Not duplicating open work: searched open PRs around hybrid mamba state (#52942, #54637) — both concern speculative-decoding correctness/caching, not the non-spec path.

## Test Plan

- `pytest tests/v1/worker/test_mamba_hybrid_model_state.py` on B300, run on a development tree containing this change, including a new `test_postprocess_state_skips_without_speculative_decoding` asserting the state tensors are untouched and no commit/postprocess calls are made.
- Kimi-K3 TP8 serving A/B (8192-in/1024-out, concurrency 1, fp8 KV cache, no spec decoding) with Nsight Systems traces, measured together with a related metadata change (#55024).

## Test Result

- `5 passed` (ported file), suite green on the development tree.
- Together with #55024: ~24 us/step reduction in step-boundary work (stable-step median 8.821 -> 8.797 ms in that pass). Model outputs unchanged (the skipped work is a no-op without drafts).

AI assistance was used for this PR (Claude Code); every changed line was reviewed and the tests above were run by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected state postprocessing for configurations without speculative decoding.
  * Prevented unnecessary acceptance-count updates and postprocessing operations when speculative decoding is disabled.
  * Preserved existing behavior for speculative decoding configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->