### PR TITLE
[Agents] Expose Triton kernel-writing skill to Claude

### DIFF
--- a/.claude/skills/triton-kernel-writing
+++ b/.claude/skills/triton-kernel-writing
@@ -1,0 +1,1 @@
+../../.agents/skills/triton-kernel-writing


### PR DESCRIPTION
## Summary

- Expose the Triton kernel-writing skill added by #55019 under `.claude/skills`.
- Follow the existing repository convention by symlinking to the canonical `.agents/skills` copy, avoiding duplicated guidance.

## Duplicate-work check

Open PR searches for `triton-kernel-writing Claude`, `Expose Triton skill to Claude`, and `.claude/skills/triton-kernel-writing` found no overlapping change. There is no linked issue.

This is a focused follow-up to merged PR #55019. That PR added the canonical skill under `.agents/skills`; this PR makes the same skill discoverable from `.claude/skills` without copying it.

## Testing

- `.venv/bin/python /home/woosuk/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/triton-kernel-writing` — passed.
- `.venv/bin/pre-commit run --files .claude/skills/triton-kernel-writing` — all applicable hooks passed or skipped.
- Verified that the symlink resolves to `../../.agents/skills/triton-kernel-writing` and its `SKILL.md` is readable.

## Model evaluation

Not applicable. This changes skill discovery only and does not affect model output, accuracy, or serving behavior.

## AI assistance and accountability

OpenAI Codex assisted with implementing and validating this change. The human submitter must review the changed line and understand and defend the contribution end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a link to the Triton kernel-writing guidance for improved access to development resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->