### PR TITLE
[Frontend] Attach resolved logprobs to streaming derender chunks

### DIFF
--- a/docs/serving/online_serving/derenderer.md
+++ b/docs/serving/online_serving/derenderer.md
@@ -6,7 +6,8 @@ This closes the loop for a token-in / token-out engine in disaggregated serving:
 
 - **GPU less post processing**: Detokenization, reasoning parsing, and tool call parsing run on the same GPU less frontend that hosts `/render`
 - **Parser parity**: The derenderer reuses vLLM's tool and reasoning parsers, so a disaggregated deployment produces the same `content`/`reasoning`/ `tool_calls` split as a standard `vllm serve` server
-- **Non-streaming**: The endpoints expect a complete `GenerateResponse` with all token IDs present and perform one-shot parsing. Streaming derender would require a separate endpoint design and is not currently supported but is in the pipeline
+- **Non-streaming**: The endpoints accept a complete `GenerateResponse` with all token IDs present and perform one-shot parsing
+- **Streaming**: The same endpoints accept `stream: true` bodies, processing one generate chunk per call with a client-carried `stream_state` (plain detokenization; parser-aware streaming is in progress)
 
 Both endpoints are hosted by the GPU less rendering server started with [`vllm launch render`](../../cli/launch/render.md), alongside the `/render`
 endpoints.
@@ -51,6 +52,15 @@ Each request wraps the engine's `GenerateResponse`(s) together with the caller m
     ```
 
 Oversized payloads are rejected with a `400` before any `tokenizer.decode()` or parser runs.
+
+## Streaming state and logprobs
+
+Streaming derender is stateless server side: all mutable state lives in the client-carried `stream_state` (`DerenderStreamState`), passed back on every per-chunk call. Besides the bounded incremental detokenization window (`prev_tokens`, `prefix_offset`, `read_offset`) and `role_sent`, the state carries two fields for logprob handling:
+
+- `logprob_context_token_ids`: the trailing sampled token IDs (at most 4) from previous chunks, used to seed byte-fallback (U+FFFD) correction so multi-byte characters whose tokens split across chunk boundaries still resolve to real strings
+- `logprob_text_offset`: the cumulative emitted text length, so `text_offset` in completion streaming logprobs stays absolute across chunks instead of restarting at 0
+
+When a streamed `GenerateResponseStreamChoice` carries `logprobs`, the `token_id:N` placeholders are resolved per chunk and the resolved logprobs are attached to the corresponding streamed choice — for chat as `ChatCompletionLogProbs`, for completions converted to the flat `CompletionLogProbs` lists. Chunks without `logprobs` produce choices with `logprobs: null`.
 
 ## Example
 

--- a/docs/serving/online_serving/derenderer.md
+++ b/docs/serving/online_serving/derenderer.md
@@ -55,7 +55,7 @@ Oversized payloads are rejected with a `400` before any `tokenizer.decode()` or 
 
 ## Streaming state and logprobs
 
-Streaming derender is stateless server side: all mutable state lives in the client-carried `stream_state` (`DerenderStreamState`), passed back on every per-chunk call. Besides the bounded incremental detokenization window (`prev_tokens`, `prefix_offset`, `read_offset`) and `role_sent`, the state carries two fields for logprob handling:
+Streaming derender is stateless on the server side: all mutable state lives in the client-carried `stream_state` (`DerenderStreamState`), passed back on every per-chunk call. Besides the bounded incremental detokenization window (`prev_tokens`, `prefix_offset`, `read_offset`) and `role_sent`, the state carries two fields for logprob handling:
 
 - `logprob_context_token_ids`: the trailing sampled token IDs (at most 4) from previous chunks, used to seed byte-fallback (U+FFFD) correction so multi-byte characters whose tokens split across chunk boundaries still resolve to real strings
 - `logprob_text_offset`: the cumulative emitted text length, so `text_offset` in completion streaming logprobs stays absolute across chunks instead of restarting at 0

--- a/tests/entrypoints/scale_out/derender/test_derender_stream.py
+++ b/tests/entrypoints/scale_out/derender/test_derender_stream.py
@@ -39,6 +39,7 @@ def _make_stream_chunk(
     finish_reason: str | None = None,
     request_id: str = "test-req",
     usage: dict | None = None,
+    logprobs: dict | None = None,
 ) -> GenerateStreamResponse:
     """Build a GenerateStreamResponse SSE chunk."""
 
@@ -49,10 +50,27 @@ def _make_stream_chunk(
                 index=index,
                 token_ids=token_ids,
                 finish_reason=finish_reason,
+                logprobs=logprobs,
             )
         ],
         usage=UsageInfo(**usage) if usage else None,
     )
+
+
+def _placeholder_logprobs(token_ids: list[int]) -> dict:
+    """Per-token logprob entries using token_id:N placeholders, as sent by
+    the generate worker."""
+    return {
+        "content": [
+            {
+                "token": f"token_id:{tid}",
+                "logprob": -0.5,
+                "bytes": None,
+                "top_logprobs": [],
+            }
+            for tid in token_ids
+        ]
+    }
 
 
 def _make_usage_chunk(
@@ -329,6 +347,115 @@ class TestDerenderCompletionStream:
             generate_chunk=_make_stream_chunk(token_ids, finish_reason="length"),
         )
         assert chunk.choices[0].finish_reason == "length"
+
+
+class TestStreamLogprobs:
+    """Streaming derender must carry per-chunk logprobs with placeholders
+    resolved, matching what the generate streaming path emits."""
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_logprobs_resolved_per_chunk(self, derenderer, tokenizer):
+        """Each streamed chunk carries logprobs with token_id:N resolved."""
+        token_ids = tokenizer.encode("hello world")[:6]
+        mid = len(token_ids) // 2
+
+        state = None
+        for part in (token_ids[:mid], token_ids[mid:]):
+            chunk, state = await derenderer.derender_chat_stream(
+                model=MODEL_NAME,
+                generate_chunk=_make_stream_chunk(
+                    part, logprobs=_placeholder_logprobs(part)
+                ),
+                state=state,
+            )
+            logprobs = chunk.choices[0].logprobs
+            assert logprobs is not None and logprobs.content is not None
+            assert len(logprobs.content) == len(part)
+            for entry in logprobs.content:
+                assert not entry.token.startswith("token_id:"), (
+                    f"placeholder not resolved: {entry.token!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_logprobs_multibyte_across_chunks(
+        self, derenderer, tokenizer
+    ):
+        """Byte-fallback correction works when a multi-byte character's
+        tokens are split across chunks (context carried in stream_state)."""
+        token_ids = tokenizer.encode("👍", add_special_tokens=False)
+        if len(token_ids) < 2 or "�" not in tokenizer.decode([token_ids[-1]]):
+            pytest.skip("Tokenizer does not byte-split this character")
+
+        state = None
+        last_chunk = None
+        # One token per chunk: every entry after the first needs cross-chunk
+        # context to resolve without U+FFFD.
+        for i, tid in enumerate(token_ids):
+            last_chunk, state = await derenderer.derender_chat_stream(
+                model=MODEL_NAME,
+                generate_chunk=_make_stream_chunk(
+                    [tid], logprobs=_placeholder_logprobs([tid])
+                ),
+                state=state,
+            )
+
+        assert last_chunk is not None
+        final_entry = last_chunk.choices[0].logprobs.content[0]
+        assert not final_entry.token.endswith("�"), (
+            "byte-fallback correction failed across chunk boundary: "
+            f"{final_entry.token!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_completion_stream_logprobs_text_offset_absolute(
+        self, derenderer, tokenizer
+    ):
+        """text_offset continues across chunks instead of restarting at 0."""
+        token_ids = tokenizer.encode("hello world")[:6]
+        mid = len(token_ids) // 2
+
+        chunk1, state = await derenderer.derender_completion_stream(
+            model=MODEL_NAME,
+            generate_chunk=_make_stream_chunk(
+                token_ids[:mid], logprobs=_placeholder_logprobs(token_ids[:mid])
+            ),
+        )
+        chunk2, _ = await derenderer.derender_completion_stream(
+            model=MODEL_NAME,
+            generate_chunk=_make_stream_chunk(
+                token_ids[mid:], logprobs=_placeholder_logprobs(token_ids[mid:])
+            ),
+            state=state,
+        )
+
+        assert chunk1.choices[0].logprobs.text_offset[0] == 0
+        assert chunk2.choices[0].logprobs.text_offset[0] == len(chunk1.choices[0].text)
+
+    @pytest.mark.asyncio
+    async def test_stream_logprob_state_stays_bounded(self, derenderer, tokenizer):
+        """Carried logprob context never exceeds the 4-token window."""
+        token_ids = tokenizer.encode("the quick brown fox jumps over the lazy dog")
+        state = None
+        for tid in token_ids:
+            _, state = await derenderer.derender_chat_stream(
+                model=MODEL_NAME,
+                generate_chunk=_make_stream_chunk(
+                    [tid], logprobs=_placeholder_logprobs([tid])
+                ),
+                state=state,
+            )
+        assert state is not None
+        assert len(state.logprob_context_token_ids) <= 4
+
+    @pytest.mark.asyncio
+    async def test_stream_without_logprobs_unchanged(self, derenderer, tokenizer):
+        """Chunks without logprobs keep logprobs=None on the output choice."""
+        token_ids = tokenizer.encode("hello")[:3]
+        chunk, _ = await derenderer.derender_chat_stream(
+            model=MODEL_NAME,
+            generate_chunk=_make_stream_chunk(token_ids),
+        )
+        assert chunk.choices[0].logprobs is None
 
 
 class TestDerenderChatStream:

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -403,6 +403,17 @@ class DerenderStreamState(BaseModel):
     window is transiently empty (e.g. usage only final chunk).
     """
 
+    logprob_context_token_ids: list[int] = Field(default_factory=list, max_length=4)
+    """Trailing sampled token IDs carried across chunks so byte-fallback
+    (U+FFFD) correction during logprob placeholder resolution has context
+    at chunk boundaries. Bounded to the 4-token window that
+    ``_correct_decoded_token`` reads."""
+
+    logprob_text_offset: int = Field(default=0, ge=0)
+    """Cumulative emitted text length. Seeds ``text_offset`` for completion
+    streaming logprobs so offsets stay absolute across chunks, mirroring
+    ``initial_text_offset`` in the generate streaming path."""
+
     # TODO: Properties used in follow on PR for tool call parsing
     last_content: str | None = None
     """Last emitted cumulative assistant content text."""

--- a/vllm/renderers/online_derenderer.py
+++ b/vllm/renderers/online_derenderer.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Sequence
 from typing import Any
 
 from vllm.config import ModelConfig
@@ -335,9 +336,23 @@ class OnlineDerenderer:
                 tokenizer, delta_tids, updated_state, skip_special_tokens=skip_special
             )
 
+            resolved_logprobs = None
+            if choice.logprobs is not None:
+                resolved_logprobs = _resolve_logprobs(
+                    choice.logprobs,
+                    tokenizer,
+                    initial_context_token_ids=state.logprob_context_token_ids,
+                )
+
             include_role = not updated_state.role_sent
-            if include_role:
-                updated_state = updated_state.model_copy(update={"role_sent": True})
+            updated_state = updated_state.model_copy(
+                update={
+                    "role_sent": True,
+                    "logprob_context_token_ids": _logprob_context_tail(
+                        state.logprob_context_token_ids, delta_tids
+                    ),
+                }
+            )
 
             delta = DeltaMessage(
                 role="assistant" if include_role else None,
@@ -347,6 +362,7 @@ class OnlineDerenderer:
                 ChatCompletionResponseStreamChoice(
                     index=choice.index,
                     delta=delta,
+                    logprobs=resolved_logprobs,
                     finish_reason=choice.finish_reason,
                 )
             )
@@ -488,10 +504,32 @@ class OnlineDerenderer:
             new_text, updated_state = self._detokenize_delta(
                 tokenizer, delta_tids, updated_state, skip_special_tokens=skip_special
             )
+
+            completion_logprobs = None
+            if choice.logprobs is not None:
+                resolved = _resolve_logprobs(
+                    choice.logprobs,
+                    tokenizer,
+                    initial_context_token_ids=state.logprob_context_token_ids,
+                )
+                completion_logprobs = _convert_chat_logprobs_to_completion_logprobs(
+                    resolved, initial_text_offset=state.logprob_text_offset
+                )
+
+            updated_state = updated_state.model_copy(
+                update={
+                    "logprob_context_token_ids": _logprob_context_tail(
+                        state.logprob_context_token_ids, delta_tids
+                    ),
+                    "logprob_text_offset": state.logprob_text_offset + len(new_text),
+                }
+            )
+
             stream_choices.append(
                 CompletionResponseStreamChoice(
                     index=choice.index,
                     text=new_text,
+                    logprobs=completion_logprobs,
                     finish_reason=choice.finish_reason,
                 )
             )
@@ -514,6 +552,18 @@ class OnlineDerenderer:
             usage=usage,
         )
         return chunk, updated_state
+
+
+# Number of preceding sampled token IDs `_correct_decoded_token` reads to
+# repair U+FFFD from byte-fallback tokenization.
+_LOGPROB_CONTEXT_WINDOW = 4
+
+
+def _logprob_context_tail(
+    context_token_ids: list[int], delta_token_ids: list[int]
+) -> list[int]:
+    """Advance the carried logprob context by this chunk's sampled tokens."""
+    return (list(context_token_ids) + list(delta_token_ids))[-_LOGPROB_CONTEXT_WINDOW:]
 
 
 def _parse_token_id_placeholder(token: str) -> int | None:
@@ -565,13 +615,20 @@ def _correct_decoded_token(
 
 
 def _resolve_logprobs(
-    logprobs: ChatCompletionLogProbs, tokenizer: TokenizerLike
+    logprobs: ChatCompletionLogProbs,
+    tokenizer: TokenizerLike,
+    initial_context_token_ids: Sequence[int] = (),
 ) -> ChatCompletionLogProbs:
-    """Resolve token_id:N placeholders in a ChatCompletionLogProbs object."""
+    """Resolve token_id:N placeholders in a ChatCompletionLogProbs object.
+
+    ``initial_context_token_ids`` seeds the byte-fallback correction context
+    with sampled IDs from preceding chunks (streaming), so multi-byte
+    characters split across chunk boundaries still resolve.
+    """
     if logprobs.content is None:
         return logprobs
 
-    context_token_ids: list[int] = []
+    context_token_ids: list[int] = list(initial_context_token_ids)
     resolved_content = []
 
     for entry in logprobs.content:
@@ -611,9 +668,14 @@ def _resolve_logprobs(
 
 def _convert_chat_logprobs_to_completion_logprobs(
     logprobs: ChatCompletionLogProbs,
+    initial_text_offset: int = 0,
 ) -> CompletionLogProbs:
     """Convert ChatCompletionLogProbs (per-token objects) to CompletionLogProbs
-    (parallel flat lists) as required by the /v1/completions response schema."""
+    (parallel flat lists) as required by the /v1/completions response schema.
+
+    ``initial_text_offset`` keeps ``text_offset`` absolute across streaming
+    chunks, mirroring the generate streaming path.
+    """
     if logprobs.content is None:
         return CompletionLogProbs()
 
@@ -622,7 +684,7 @@ def _convert_chat_logprobs_to_completion_logprobs(
     top_logprobs_list: list[dict[str, float] | None] = []
     text_offset: list[int] = []
 
-    offset = 0
+    offset = initial_text_offset
     for entry in logprobs.content:
         text_offset.append(offset)
         tokens.append(entry.token)

--- a/vllm/renderers/online_derenderer.py
+++ b/vllm/renderers/online_derenderer.py
@@ -336,6 +336,12 @@ class OnlineDerenderer:
                 tokenizer, delta_tids, updated_state, skip_special_tokens=skip_special
             )
 
+            # NOTE for the parser-aware streaming path: the generate chat
+            # streaming path suppresses logprobs entirely when a parser is
+            # configured and reasoning is hidden, because decoded logprob
+            # token text would leak hidden reasoning. Unreachable here (the
+            # parser path fails closed above); mirror that suppression when
+            # it lands.
             resolved_logprobs = None
             if choice.logprobs is not None:
                 resolved_logprobs = _resolve_logprobs(


### PR DESCRIPTION
## Purpose

Complete the streaming-logprobs limitation deferred in RFC #47161's PR-1 ("logprobs are dropped on the streaming path as a known limitation"): the streaming derender endpoints accepted `GenerateResponseStreamChoice.logprobs` from the generate worker but never resolved or attached them — only non-streaming derender resolved the `token_id:N` placeholders. An OpenAI client streaming with `logprobs: true` through a token-in/token-out router received no logprobs. This PR attaches the existing resolution to the streaming paths; the broader `GenerateLogProbs` shape redesign from the RFC remains deferred.

The fix resolves placeholders per chunk on both streaming paths and attaches them to the output choices (both `ChatCompletionResponseStreamChoice` and `CompletionResponseStreamChoice` already had the fields). Two small, bounded additions to the client-carried `DerenderStreamState` keep resolution correct across chunk boundaries without breaking the stateless protocol:

- `logprob_context_token_ids` (max 4 entries — exactly the window `_correct_decoded_token` reads): seeds byte-fallback (U+FFFD) correction so multi-byte characters whose tokens split across chunks still resolve to real strings.
- `logprob_text_offset`: keeps completion-logprobs `text_offset` absolute across chunks, mirroring `initial_text_offset` in the generate streaming path (`vllm/entrypoints/openai/completion/serving.py`).

Docs: `derenderer.md` gains a "Streaming state and logprobs" section covering the new fields and behavior (the limitation was previously undocumented there), and the stale bullet describing streaming derender as unsupported is refreshed.

**Not a duplicate:** searched open/closed PRs and issues for derender + logprobs / streaming logprobs; nothing addresses this. #50550 (parser-aware streaming derender, in review) does not touch logprobs — its parsed path constructs stream choices without them and will need the same treatment as a follow-up once it lands (a code comment now flags the parser-path logprobs/hidden-reasoning suppression for that work).

No model-output changes: this affects only frontend response-processing parity, so no model evals are applicable.

## Test Plan

New unit tests (real tokenizer on a tiny model, stub renderer — no server, matching the existing pattern in the file):

```bash
pytest tests/entrypoints/scale_out/derender/test_derender_stream.py -q
pytest tests/entrypoints/scale_out/derender/test_derender.py -q
```

Covered behaviors: per-chunk placeholder resolution (chat), byte-fallback correction across chunk boundaries (one token per chunk of a byte-split emoji), absolute `text_offset` continuation (completions), state boundedness (context tail never exceeds 4), and a control test that chunks without logprobs keep `logprobs: null`.

Lint:

```bash
pre-commit run --files vllm/renderers/online_derenderer.py vllm/entrypoints/scale_out/token_in_token_out/protocol.py tests/entrypoints/scale_out/derender/test_derender_stream.py docs/serving/online_serving/derenderer.md
pre-commit run mypy-3.12 --files vllm/renderers/online_derenderer.py vllm/entrypoints/scale_out/token_in_token_out/protocol.py --hook-stage manual
```

## Test Result

- New tests: 5/5 pass with the change; **4/5 fail without it** (missing logprobs on streamed choices), with the no-logprobs control correctly passing on both.
- Full derender suites: **71 passed** (36 streaming + 35 endpoint tests).
- All pre-commit hooks passed, including CI-style `mypy-3.12` (manual stage).

## AI-assisted contribution

This change was developed with AI assistance (Claude Code). Every changed line was reviewed by the submitter, who ran the tests above.
