### PR TITLE
[ROCm] Add V1 streamed BF16 pipeline transport

### DIFF
--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -24,6 +24,10 @@ from vllm.distributed import (
 from vllm.distributed.device_communicators import flashinfer_all_reduce
 from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
 from vllm.distributed.parallel_state import GroupCoordinator, TensorMetadata
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+from vllm.utils.import_utils import has_aiter
+from vllm.v1.worker.gpu.pp_transport import PPTransport
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 
 from ..utils import (
@@ -660,6 +664,64 @@ def async_send_recv_tensor_test_worker(
         torch.testing.assert_close(received, expected)
 
 
+def _pp_transport_test_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+    shape = (8, 256)
+    schema = IntermediateTensors(
+        {"hidden_states": torch.empty(shape, dtype=torch.bfloat16, device=device)}
+    )
+    transport = PPTransport(
+        schema,
+        chunk_tokens=shape[0],
+        ring_size=2,
+        device=device,
+    )
+
+    expected = [
+        torch.full(shape, value, dtype=torch.bfloat16, device=device)
+        for value in (1.0, 2.0)
+    ]
+    if get_pp_group().is_first_rank:
+        for value in expected:
+            transport.send(value)
+        tail = torch.full((4, 256), 3.0, dtype=torch.bfloat16, device=device)
+        transport.send_generic(
+            {"hidden_states": tail},
+            all_gather_group=None,
+            all_gather_tensors={},
+        )
+        transport.drain()
+    else:
+        for value in expected:
+            tensors, handles, postprocess = transport.receive()
+            for handle in handles:
+                handle.wait()
+            for fn in postprocess:
+                fn()
+            torch.testing.assert_close(tensors["hidden_states"], value)
+        tail = get_pp_group().recv_tensor_dict()
+        assert tail is not None
+        torch.testing.assert_close(
+            tail["hidden_states"],
+            torch.full((4, 256), 3.0, dtype=torch.bfloat16, device=device),
+        )
+
+
+@ray.remote(num_gpus=1, max_calls=1)
+def pp_stream_transport_test_worker(*args):
+    _pp_transport_test_worker(*args)
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize(
@@ -690,6 +752,19 @@ def test_multi_process_pipeline_parallel(
     test_target: Callable[..., Any],
 ):
     multi_process_parallel(monkeypatch, 1, pp_size, test_target)
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.skipif(
+    not current_platform.is_rocm() or not has_aiter(),
+    reason="requires ROCm and AITER",
+)
+@pytest.mark.parametrize("test_target", [pp_stream_transport_test_worker])
+def test_multi_process_pp_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    test_target: Callable[..., Any],
+):
+    multi_process_parallel(monkeypatch, 1, 2, test_target)
 
 
 @multi_gpu_test(num_gpus=4)

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -245,6 +245,47 @@ def _make_group_for_unit_test(
     return g
 
 
+def test_async_single_tensor_uses_default_neighbors_and_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int, object]] = []
+    work = _DummyWork()
+
+    def fake_isend(tensor, dst, group):
+        calls.append(("send", dst, group))
+        return work
+
+    def fake_irecv(tensor, src, group):
+        calls.append(("recv", src, group))
+        return work
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "isend", fake_isend)
+    monkeypatch.setattr(torch.distributed, "irecv", fake_irecv)
+
+    group = _make_group_for_unit_test(rank_in_group=1, world_size=3)
+    group.cpu_group = object()
+    group.device_group = object()
+
+    assert group.isend_tensor(torch.empty(1)) is work
+    assert group.irecv_tensor(torch.empty(1)) is work
+    assert calls == [
+        ("send", 2, group.cpu_group),
+        ("recv", 0, group.cpu_group),
+    ]
+
+
+def test_async_single_tensor_requires_initialized_multi_rank_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = _make_group_for_unit_test(world_size=2)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    with pytest.raises(RuntimeError, match="initialized multi-rank"):
+        group.isend_tensor(torch.empty(1))
+    with pytest.raises(RuntimeError, match="initialized multi-rank"):
+        group.irecv_tensor(torch.empty(1))
+
+
 def test_irecv_tensor_dict_send_allgather_postprocess_binds_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -594,6 +635,31 @@ def send_recv_test_worker(
         torch.testing.assert_close(test_tensor, recv_tensor)
 
 
+@ray.remote(num_gpus=1, max_calls=1)
+def async_send_recv_tensor_test_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+    expected = torch.arange(64, dtype=torch.float32, device="cuda")
+    if get_pp_group().is_first_rank:
+        work = get_pp_group().isend_tensor(expected)
+    else:
+        received = torch.empty_like(expected)
+        work = get_pp_group().irecv_tensor(received)
+    work.wait()
+
+    if not get_pp_group().is_first_rank:
+        torch.testing.assert_close(received, expected)
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize(
@@ -611,7 +677,12 @@ def test_multi_process_tensor_parallel(
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("pp_size", [2])
 @pytest.mark.parametrize(
-    "test_target", [send_recv_test_worker, send_recv_tensor_dict_test_worker]
+    "test_target",
+    [
+        send_recv_test_worker,
+        send_recv_tensor_dict_test_worker,
+        async_send_recv_tensor_test_worker,
+    ],
 )
 def test_multi_process_pipeline_parallel(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -29,6 +29,23 @@ def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):
     assert not hasattr(envs.__getattr__, "cache_info")
 
 
+@pytest.mark.parametrize("value", ["disabled", "stream"])
+def test_rocm_pp_transport_modes(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("VLLM_ROCM_PP_TRANSPORT", value)
+    assert value == envs.VLLM_ROCM_PP_TRANSPORT
+
+
+def test_rocm_pp_transport_rejects_invalid_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_ROCM_PP_TRANSPORT", "invalid")
+    with pytest.raises(ValueError, match="VLLM_ROCM_PP_TRANSPORT"):
+        _ = envs.VLLM_ROCM_PP_TRANSPORT
+
+
 def test_nixl_side_channel_host_is_not_compile_factor(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/v1/worker/test_pp_transport.py
+++ b/tests/v1/worker/test_pp_transport.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.sequence import IntermediateTensors
+from vllm.v1.worker.gpu.pp_transport import PPTransport
+
+
+def test_transport_rejects_unsupported_schema() -> None:
+    schema = IntermediateTensors(
+        {
+            "hidden_states": torch.empty(8, 32, dtype=torch.bfloat16),
+            "residual": torch.empty(8, 32, dtype=torch.bfloat16),
+        }
+    )
+    with pytest.raises(ValueError, match="single hidden_states"):
+        PPTransport(schema, 8, 2, torch.device("cpu"))
+
+
+def test_transport_drain_waits_every_ring_slot() -> None:
+    transport = PPTransport.__new__(PPTransport)
+    work = [[Mock(), Mock()], None, [Mock()]]
+    generic_work = Mock()
+    transport._send_work = work
+    transport._generic_send_work = [[generic_work]]
+
+    transport.drain()
+
+    for slot in work:
+        if slot is not None:
+            for handle in slot:
+                handle.wait.assert_called_once_with()
+    generic_work.wait.assert_called_once_with()
+    assert transport._send_work == [None, None, None]
+    assert transport._generic_send_work == []
+
+
+def test_transport_reaps_completed_generic_sends() -> None:
+    transport = PPTransport.__new__(PPTransport)
+    metadata = Mock()
+    tensor = Mock()
+    tensor.is_completed.return_value = True
+    transport._generic_send_work = [[metadata, tensor]]
+
+    transport._reap_generic_send_work()
+
+    metadata.wait.assert_called_once_with()
+    tensor.wait.assert_called_once_with()
+    assert transport._generic_send_work == []

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1230,6 +1230,45 @@ class GroupCoordinator:
 
         return handles
 
+    def isend_tensor(self, tensor: torch.Tensor, dst: int | None = None) -> Handle:
+        """Asynchronously send a tensor without exchanging metadata."""
+        if not torch.distributed.is_initialized() or self.world_size <= 1:
+            raise RuntimeError("isend_tensor requires an initialized multi-rank group")
+        if self.use_cpu_custom_send_recv:
+            raise RuntimeError("isend_tensor does not support custom CPU transport")
+        if dst is None:
+            dst = (self.rank_in_group + 1) % self.world_size
+        if not 0 <= dst < self.world_size:
+            raise ValueError(f"Invalid destination rank {dst}")
+
+        comm_group = self.cpu_group if tensor.is_cpu else self.device_group
+        handle = torch.distributed.isend(
+            tensor,
+            dst=self.ranks[dst],
+            group=comm_group,
+        )
+        if tensor.is_cuda:
+            tensor.record_stream(torch.cuda.current_stream(tensor.device))
+        return handle
+
+    def irecv_tensor(self, tensor: torch.Tensor, src: int | None = None) -> Handle:
+        """Asynchronously receive a tensor with an already-known schema."""
+        if not torch.distributed.is_initialized() or self.world_size <= 1:
+            raise RuntimeError("irecv_tensor requires an initialized multi-rank group")
+        if self.use_cpu_custom_send_recv:
+            raise RuntimeError("irecv_tensor does not support custom CPU transport")
+        if src is None:
+            src = (self.rank_in_group - 1) % self.world_size
+        if not 0 <= src < self.world_size:
+            raise ValueError(f"Invalid source rank {src}")
+
+        comm_group = self.cpu_group if tensor.is_cpu else self.device_group
+        return torch.distributed.irecv(
+            tensor,
+            src=self.ranks[src],
+            group=comm_group,
+        )
+
     def recv_tensor_dict(
         self,
         src: int | None = None,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -149,6 +149,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
+    VLLM_ROCM_PP_TRANSPORT: Literal["disabled", "stream"] = "disabled"
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -1353,6 +1354,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_TRITON_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_GEMM", "True").lower() in ("true", "1")
+    ),
+    # Optional fixed-schema BF16 PP transport for ROCm on the V1 worker path.
+    "VLLM_ROCM_PP_TRANSPORT": env_with_choices(
+        "VLLM_ROCM_PP_TRANSPORT",
+        "disabled",
+        ["disabled", "stream"],
     ),
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM": lambda: (

--- a/vllm/v1/worker/gpu/pp_transport.py
+++ b/vllm/v1/worker/gpu/pp_transport.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+
+import torch
+
+from vllm.distributed.parallel_state import Handle, get_pp_group
+from vllm.sequence import IntermediateTensors
+
+
+class PPTransport:
+    """Fixed-schema V1 PP transport backed by a bounded BF16 send-buffer ring."""
+
+    def __init__(
+        self,
+        schema: IntermediateTensors,
+        chunk_tokens: int,
+        ring_size: int,
+        device: torch.device,
+    ) -> None:
+        if set(schema.tensors) != {"hidden_states"}:
+            raise ValueError(
+                "ROCm PP transport currently requires a single hidden_states tensor"
+            )
+        hidden_states = schema.tensors["hidden_states"]
+        if hidden_states.shape[0] != chunk_tokens:
+            raise ValueError(
+                f"Expected {chunk_tokens} schema tokens, got {hidden_states.shape[0]}"
+            )
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError(
+                "ROCm PP transport requires BF16 hidden states, "
+                f"got {hidden_states.dtype}"
+            )
+        if not hidden_states.is_contiguous():
+            raise ValueError("ROCm PP transport requires contiguous hidden states")
+        if ring_size < 1:
+            raise ValueError(f"ring_size must be positive, got {ring_size}")
+
+        self.chunk_tokens = chunk_tokens
+        self.hidden_shape = hidden_states.shape
+        self.device = device
+        self._group = get_pp_group()
+        self._send_stream = torch.cuda.Stream(device=device)
+        self._send_index = 0
+        self._send_work: list[list[Handle] | None] = [None] * ring_size
+        self._generic_send_work: list[list[Handle]] = []
+        self._ready_events = [torch.cuda.Event() for _ in range(ring_size)]
+
+        self._recv_buffer = (
+            None if self._group.is_first_rank else hidden_states
+        )
+        self._send_ring = (
+            []
+            if self._group.is_last_rank
+            else [
+                torch.empty(
+                    self.hidden_shape,
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                for _ in range(ring_size)
+            ]
+        )
+
+    def can_transfer(self, num_scheduled_tokens: int) -> bool:
+        return num_scheduled_tokens == self.chunk_tokens
+
+    def receive(
+        self,
+    ) -> tuple[
+        dict[str, torch.Tensor],
+        list[Handle],
+        list[Callable[[], None]],
+    ]:
+        if self._recv_buffer is None:
+            raise RuntimeError("The first PP rank cannot receive activations")
+        return (
+            {"hidden_states": self._recv_buffer},
+            [self._group.irecv_tensor(self._recv_buffer)],
+            [],
+        )
+
+    def send(self, hidden_states: torch.Tensor) -> None:
+        if not self._send_ring:
+            raise RuntimeError("The last PP rank cannot send activations")
+        if hidden_states.shape != self.hidden_shape:
+            raise ValueError(
+                f"Expected hidden state shape {self.hidden_shape}, "
+                f"got {hidden_states.shape}"
+            )
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError(f"Expected BF16 hidden states, got {hidden_states.dtype}")
+
+        ring_index = self._send_index
+        prior_work = self._send_work[ring_index]
+        if prior_work is not None:
+            for handle in prior_work:
+                handle.wait()
+
+        send_buffer = self._send_ring[ring_index]
+        send_buffer.copy_(hidden_states)
+
+        ready_event = self._ready_events[ring_index]
+        ready_event.record(torch.cuda.current_stream(self.device))
+        with torch.cuda.stream(self._send_stream):
+            self._send_stream.wait_event(ready_event)
+            self._send_work[ring_index] = [
+                self._group.isend_tensor(send_buffer),
+            ]
+
+        self._send_index = (ring_index + 1) % len(self._send_ring)
+
+    def send_generic(
+        self,
+        tensor_dict: dict[str, torch.Tensor],
+        all_gather_group,
+        all_gather_tensors: dict[str, bool],
+    ) -> None:
+        """Order a generic tail send after fixed sends on the send stream."""
+        self._reap_generic_send_work()
+        ready_event = torch.cuda.Event()
+        ready_event.record(torch.cuda.current_stream(self.device))
+        with torch.cuda.stream(self._send_stream):
+            self._send_stream.wait_event(ready_event)
+            self._generic_send_work.append(
+                self._group.isend_tensor_dict(
+                    tensor_dict,
+                    all_gather_group=all_gather_group,
+                    all_gather_tensors=all_gather_tensors,
+                )
+            )
+
+    def _reap_generic_send_work(self) -> None:
+        while self._generic_send_work:
+            handles = self._generic_send_work[0]
+            tensor_handles = handles[1:]
+            if not tensor_handles or not all(
+                handle.is_completed() for handle in tensor_handles
+            ):
+                break
+            for handle in handles:
+                handle.wait()
+            self._generic_send_work.pop(0)
+
+    def drain(self) -> None:
+        for work in self._send_work:
+            if work is not None:
+                for handle in work:
+                    handle.wait()
+        self._send_work = [None] * len(self._send_work)
+        for handles in self._generic_send_work:
+            for handle in handles:
+                handle.wait()
+        self._generic_send_work.clear()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -139,6 +139,7 @@ def maybe_rocm_profiling_fallback(profile_result: MemoryProfilingResult) -> int 
 if TYPE_CHECKING:
     from vllm.device_allocator.sleep_mode_backend import SleepModeBackend
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+    from vllm.v1.worker.gpu.pp_transport import PPTransport
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
@@ -218,6 +219,7 @@ class Worker(WorkerBase):
         self.profiler_config = vllm_config.profiler_config
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
+        self._pp_transport: PPTransport | None = None
 
         # Device handles of the previous step's PP intermediate-tensor send.
         self._pp_send_work: list[Handle] = []
@@ -238,6 +240,8 @@ class Worker(WorkerBase):
         return self._sleep_mode_backend
 
     def sleep(self, level: int = 1) -> None:
+        if self._pp_transport is not None:
+            self._pp_transport.drain()
         torch.accelerator.synchronize()
         free_bytes_before_sleep = torch.accelerator.get_memory_info()[0]
 
@@ -501,6 +505,8 @@ class Worker(WorkerBase):
         ):
             self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
 
+        self._init_pp_transport()
+
         if self.vllm_config.weight_transfer_config is not None:
             self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
                 self.vllm_config.weight_transfer_config,
@@ -508,6 +514,44 @@ class Worker(WorkerBase):
                 self.device,
                 self.model_runner.get_model(),
             )
+
+    def _init_pp_transport(self) -> None:
+        mode = envs.VLLM_ROCM_PP_TRANSPORT
+        if mode == "disabled":
+            return
+        if mode != "stream":
+            raise ValueError(
+                f"Unsupported VLLM_ROCM_PP_TRANSPORT mode {mode!r}; "
+                "only 'disabled' and 'stream' are supported"
+            )
+        if not current_platform.is_rocm():
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT is only supported on ROCm")
+        if self.parallel_config.pipeline_parallel_size <= 1:
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT requires pipeline parallelism")
+        if self.parallel_config.tensor_parallel_size != 1:
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT currently requires TP=1")
+        if self.model_config.dtype != torch.bfloat16:
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT requires BF16 hidden states")
+
+        from vllm.v1.worker.gpu.pp_transport import PPTransport
+
+        chunk_tokens = self.scheduler_config.max_num_batched_tokens
+        model = self.model_runner.get_model()
+        schema = model.make_empty_intermediate_tensors(
+            batch_size=chunk_tokens,
+            dtype=self.model_config.dtype,
+            device=self.device,
+        )
+        self._pp_transport = PPTransport(
+            schema=schema,
+            chunk_tokens=chunk_tokens,
+            ring_size=self.parallel_config.pipeline_parallel_size,
+            device=self.device,
+        )
+        logger.info(
+            "Enabled ROCm streamed BF16 PP transport with %d-token chunks",
+            chunk_tokens,
+        )
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)
@@ -1126,6 +1170,11 @@ class Worker(WorkerBase):
         intermediate_tensors = None
         forward_pass = scheduler_output.total_num_scheduled_tokens > 0
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+        use_fixed_pp_transport = (
+            forward_pass
+            and self._pp_transport is not None
+            and self._pp_transport.can_transfer(num_scheduled_tokens)
+        )
         all_gather_tensors = {}
         compilation_config = self.vllm_config.compilation_config
         parallel_config = self.vllm_config.parallel_config
@@ -1160,12 +1209,18 @@ class Worker(WorkerBase):
             }
 
         if forward_pass and not get_pp_group().is_first_rank:
-            tensor_dict, comm_handles, comm_postprocess = (
-                get_pp_group().irecv_tensor_dict(
-                    all_gather_group=get_tp_group(),
-                    all_gather_tensors=all_gather_tensors,
+            if use_fixed_pp_transport:
+                assert self._pp_transport is not None
+                tensor_dict, comm_handles, comm_postprocess = (
+                    self._pp_transport.receive()
                 )
-            )
+            else:
+                tensor_dict, comm_handles, comm_postprocess = (
+                    get_pp_group().irecv_tensor_dict(
+                        all_gather_group=get_tp_group(),
+                        all_gather_tensors=all_gather_tensors,
+                    )
+                )
             assert tensor_dict is not None
             intermediate_tensors = AsyncIntermediateTensors(
                 tensor_dict,
@@ -1195,15 +1250,29 @@ class Worker(WorkerBase):
             and not get_pp_group().is_last_rank
         )
 
-        # Non-blocking send of the intermediate tensors. The metadata handle
-        # is reaped lazily by the GroupCoordinator; the device handles are
-        # waited at the top of the next step.
-        handles = get_pp_group().isend_tensor_dict(
-            output.tensors,
-            all_gather_group=get_tp_group(),
-            all_gather_tensors=all_gather_tensors,
-        )
-        self._pp_send_work = handles[1:]
+        if use_fixed_pp_transport:
+            assert self._pp_transport is not None
+            if set(output.tensors) != {"hidden_states"}:
+                raise ValueError(
+                    "Fixed PP transport requires a single hidden_states tensor"
+                )
+            self._pp_transport.send(output.tensors["hidden_states"])
+        elif self._pp_transport is not None:
+            self._pp_transport.send_generic(
+                output.tensors,
+                all_gather_group=get_tp_group(),
+                all_gather_tensors=all_gather_tensors,
+            )
+        else:
+            # Non-blocking send of the intermediate tensors. The metadata handle
+            # is reaped lazily by the GroupCoordinator; the device handles are
+            # waited at the top of the next step.
+            handles = get_pp_group().isend_tensor_dict(
+                output.tensors,
+                all_gather_group=get_tp_group(),
+                all_gather_tensors=all_gather_tensors,
+            )
+            self._pp_send_work = handles[1:]
 
         return None
 
@@ -1440,6 +1509,9 @@ class Worker(WorkerBase):
 
     def shutdown(self) -> None:
         gc.unfreeze()
+
+        if self._pp_transport is not None:
+            self._pp_transport.drain()
 
         # has_kv_transfer_group can be None during interpreter shutdown.
         if ensure_kv_transfer_shutdown is not None:


### PR DESCRIPTION
## Summary

Add an opt-in V1 fixed-schema BF16 pipeline transport for ROCm:

- preallocate a bounded sender ring and order P2P sends on a dedicated stream
- receive full-size chunks directly into a fixed receive buffer
- bypass per-step metadata exchange for full `max_num_batched_tokens` chunks
- preserve the existing tensor-dict path for partial tails and unsupported schemas

The feature is disabled by default and selected with `VLLM_ROCM_PP_TRANSPORT=stream`. Its initial support envelope is V1, ROCm, **TP=1, PP>1**, contiguous BF16 `hidden_states`, and full `max_num_batched_tokens` chunks. Partial tails, non-BF16 tensors, and unsupported schemas use the existing path or fail configuration validation before model loading.

This PR intentionally keeps the scope to BF16 streaming only. FP8 transport and the V2 `PPHandler` integration are tracked separately on `rocm-pp-v2-transport` (#55100).

## Tests

- V1 `PPTransport` unit tests: schema validation, ring drain, and generic-send reap
- environment tests for `VLLM_ROCM_PP_TRANSPORT=disabled|stream`
- 2-rank BF16 integration test covering two ring slots, fixed-to-generic tail ordering, exact BF16 equality, and drain
- Worker startup guards in `gpu_worker.py` reject unsupported topologies (`PP <= 1` or `TP != 1`) before model load

## Performance

Measured on 8 x MI355X, DeepSeek-V4-Pro tuned stack (OPUS sparse + FP8 WO_A, `main-tuned-v1` images on commit `64e8edc2d8`), **TP1/PP8 only**, prefix caching disabled.

### C1 100K TTFT (primary transport evidence)

Single-request prefill (ISL=100K, OSL=1, BS=1). This workload keeps PP stage-to-stage activation transfer on the critical path.

| Arm | TTFT runs (ms) | Median TTFT | Delta |
|---|---:|---:|---:|
| generic (`PP_TRANSPORT=disabled`) | 2285.4 / 2277.1 / 2274.9 | **2277.1** | — |
| stream (`PP_TRANSPORT=stream`) | 2204.2 / 2191.9 / 2189.4 | **2191.9** | **-85.2 ms (-3.7%)** |

Transport benefit is metadata bypass plus removal of the receive copy on full 8192-token chunks.

### Concurrency sweep (regression check only)

8K input / 1 output, random prompts, `max-concurrency` 1–48. **Not used as transport speedup evidence**: on the V1 runner both arms plateau at ~9350 total tok/s from C=2 upward because the engine caps active requests (~7) and prompt throughput (~9K tok/s), independent of client concurrency. Generic vs stream differ by only ±0.3% (noise).

| Max concurrency | Generic total tok/s | Stream total tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 5112.68 | 5118.95 | +0.12% |
| 2 | 9324.84 | 9301.61 | -0.25% |
| 4 | 9367.90 | 9334.17 | -0.36% |
| 8 | 9359.25 | 9330.41 | -0.31% |
| 16 | 9358.74 | 9329.58 | -0.31% |
| 32 | 9359.01 | 9330.41 | -0.31% |
| 48 | 9357.53 | 9329.08 | -0.30% |


### Concurrency sweep — median TTFT

Same workload as above (8K input / 1 output, 10 prompts per concurrency slot).

| Max concurrency | Generic median TTFT (ms) | Stream median TTFT (ms) | Δ |
|---:|---:|---:|---:|
| 1 | 901.2 | 903.7 | +0.3% |
| 2 | 1754.9 | 1759.2 | +0.2% |
| 4 | 3495.8 | 3507.9 | +0.3% |
| 8 | 7000.1 | 7020.9 | +0.3% |
| 16 | 14004.2 | 14047.3 | +0.3% |
| 32 | 28009.2 | 28094.5 | +0.3% |
| 48 | 42018.6 | 42142.9 | +0.3% |

At C=1 the first request (long prefill) is **7918 ms** (generic) vs **7878 ms** (stream), -40 ms. From C≥2, median TTFT scales roughly linearly with concurrency, reflecting V1 runner queueing and the ~7 active-request cap—not transport regression. Transport evidence remains the 100K C1 TTFT (-85.2 ms) above.

High-concurrency transport scaling on the V2 runner is benchmarked separately in #55100.

### GSM8K 1319 (5-shot greedy, temperature=0, max-concurrency=32)

| Arm | Accuracy | Correct | Invalid |
|---|---:|---:|---:|
| generic (`PP_TRANSPORT=disabled`) | 95.60% | 1261/1319 | 0 |
| stream (`PP_TRANSPORT=stream`) | 95.00% | 1253/1319 | 0 |

Generic/stream drift is 0.61pp with zero invalid responses on both arms.

