### PR TITLE
[Bugfix][Spec Decode] EAGLE replay boundary in the offload store; one definition of the Mamba P/D handoff

### DIFF
--- a/tests/v1/core/prefix_cache/test_mamba_eagle_resume_checkpoint.py
+++ b/tests/v1/core/prefix_cache/test_mamba_eagle_resume_checkpoint.py
@@ -338,6 +338,26 @@ def test_enabling_never_reduces_reuse(eagle_group, num_prefill_lookahead):
     assert on >= off, f"enabling the flag cut the sibling's hit from {off} to {on}"
 
 
+@pytest.mark.parametrize("prompt_len", [2048, 4096])
+def test_a_block_aligned_prompt_is_still_reusable(prompt_len):
+    """A prompt ending exactly on a block boundary must still be reusable.
+
+    A replay is capped at ``num_tokens - 1``, so it can never reach a
+    check-point at the prompt's own end. Flooring the Mamba grid stop from
+    ``num_tokens`` put the only reachable state there, and an identical replay
+    got nothing at all -- not a shorter hit, zero.
+    """
+    block_size, hash_block_size = 512, 32
+    manager = _manager(block_size, hash_block_size, fine_grained=False)
+    stub = _stub(manager, block_size, hash_block_size)
+    assert prompt_len % block_size == 0, "the regression needs a block-aligned prompt"
+
+    producer = make_request("p", PREFIX[:prompt_len], hash_block_size, sha256)
+    _prefill(manager, stub, producer)
+    replay = make_request("r", PREFIX[:prompt_len], hash_block_size, sha256)
+    assert manager.get_computed_blocks(replay)[1] >= prompt_len - 2 * block_size
+
+
 def test_disabled_by_default():
     """Off, the junction is block-floored and no resume point is registered."""
     block_size, hash_block_size = 512, 32

--- a/tests/v1/core/prefix_cache/test_mamba_eagle_resume_checkpoint.py
+++ b/tests/v1/core/prefix_cache/test_mamba_eagle_resume_checkpoint.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mamba "align" check-points at the position an EAGLE sibling resumes from.
+
+Full attention hits where it holds a key; EAGLE prunes one hash unit off that
+candidate and drops it. Mamba materializes state only on its own block grid, so
+the pruned position holds nothing and the hit floors back a whole Mamba block.
+
+Gated by ``CacheConfig.enable_mamba_fine_grained_prefix_cache``. Every test here
+drives the real ``Scheduler._mamba_block_aligned_split`` and the real
+``KVCacheManager``; no chunk boundary is hard-coded.
+"""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from tests.v1.core.test_prefix_caching import (
+    _make_hybrid_kv_cache_config,
+    make_kv_cache_manager,
+    make_request,
+)
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.core.sched.scheduler import Scheduler
+
+PREFIX = list(range(1, 20_001))
+
+
+def _manager(
+    block_size,
+    hash_block_size,
+    *,
+    fine_grained=True,
+    num_blocks=8192,
+    eagle_group=None,
+    num_prefill_lookahead=0,
+):
+    init_none_hash(sha256)
+    config = _make_hybrid_kv_cache_config(
+        block_size, num_blocks, ["full", "mamba_align"]
+    )
+    if eagle_group is not None:
+        groups = list(config.kv_cache_groups)
+        groups[eagle_group] = replace(groups[eagle_group], is_eagle_group=True)
+        config = replace(config, kv_cache_groups=groups)
+    return make_kv_cache_manager(
+        kv_cache_config=config,
+        max_model_len=1 << 20,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+        num_prefill_lookahead=num_prefill_lookahead,
+        enable_mamba_fine_grained_prefix_cache=fine_grained,
+    )
+
+
+def _stub(manager, block_size, hash_block_size, *, block_drop=True):
+    """``self`` for the real ``Scheduler._mamba_block_aligned_split``.
+
+    Derives both gates exactly as ``Scheduler.__init__`` does, so a manager that
+    cannot honour the junction stop also stops the split from making one.
+    """
+    partial_hit = (
+        hash_block_size < block_size and manager.coordinator.enable_partial_hash_hits
+    )
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        max_num_scheduled_tokens=1 << 20,
+        use_eagle=True,
+        # The EAGLE adjustments key on the block-drop bit, not plain use_eagle:
+        # they exist only to compensate for the drop.
+        use_eagle_block_drop=block_drop,
+        hash_block_size=hash_block_size,
+        mamba_has_prefill_checkpoint_blocks=False,  # forced False under eagle
+        mamba_partial_cache_hit=partial_hit,
+        mamba_fine_grained_prefix_cache=(
+            partial_hit and manager.mamba_fine_grained_prefix_cache
+        ),
+    )
+
+
+def _prefill(manager, stub, request, *, external=0) -> list[int]:
+    """Schedule ``request`` to completion the way ``Scheduler.schedule()`` does.
+
+    Returns the chunk ends. Every boundary comes from the real splitter, so no
+    test in this file hard-codes one.
+    """
+    blocks, local, junction = manager.get_computed_blocks(request)
+    request.shared_prefix_boundary = junction
+    ends = []
+    first = True
+    while request.num_computed_tokens < request.num_tokens:
+        new_local, ext = (local, external) if first else (0, 0)
+        start = request.num_computed_tokens + new_local + ext
+        if start >= request.num_tokens:
+            break
+        num_new = Scheduler._mamba_block_aligned_split(
+            stub, request, request.num_tokens - start, new_local, ext
+        )
+        if num_new <= 0:
+            break
+        assert (
+            manager.allocate_slots(
+                request,
+                num_new,
+                num_new_computed_tokens=new_local,
+                new_computed_blocks=blocks if first else None,
+                num_external_computed_tokens=ext,
+                has_scheduled_reqs=False,
+            )
+            is not None
+        )
+        request.num_computed_tokens = start + num_new
+        ends.append(request.num_computed_tokens)
+        _, retained = manager.take_kv_cache_block_copies()
+        if retained:
+            manager.block_pool.free_blocks(retained)
+        manager.new_step_starts()
+        first = False
+    return ends
+
+
+def _orphaned_full_attention_tail(manager, stub, prompt_len):
+    """Produce the state a KV connector leaves behind, which creates a junction.
+
+    NIXL reports ``num_prompt_tokens - 1`` external computed tokens for Mamba
+    models (``nixl/base_scheduler.py::_get_remote_prefill_token_count``), so the
+    producer starts past its own tail stop: full attention still registers a
+    partial tail the Mamba group has no state for.
+    """
+    producer = make_request(
+        "producer", PREFIX[:prompt_len], stub.hash_block_size, sha256
+    )
+    _prefill(manager, stub, producer, external=prompt_len - 1)
+
+
+def _sibling_hit(manager, shared, suffix, hash_block_size):
+    request = make_request("sibling", PREFIX[:shared] + suffix, hash_block_size, sha256)
+    return manager.get_computed_blocks(request)[1]
+
+
+# --------------------------------------------------------------------------
+# The two positions a sibling resumes at
+
+
+def test_sibling_resumes_from_the_observed_junction():
+    """The scheduler splits at the junction; the manager must cache there."""
+    block_size, hash_block_size = 512, 32
+    manager = _manager(block_size, hash_block_size)
+    stub = _stub(manager, block_size, hash_block_size)
+    assert stub.mamba_fine_grained_prefix_cache, "the feature must be armed"
+    _orphaned_full_attention_tail(manager, stub, 2020)
+
+    consumer = make_request(
+        "consumer", PREFIX[:2016] + [-1] * 584, hash_block_size, sha256
+    )
+    junction = manager.get_computed_blocks(consumer)[2]
+    assert junction, "expected a junction against the orphaned full-attention tail"
+    _prefill(manager, stub, consumer)
+
+    hit = _sibling_hit(manager, 2016, [-2] * 584, hash_block_size)
+    assert hit == junction, (
+        f"the chunk stopped at {junction} but nothing was cached there: "
+        f"sibling resumes at {hit}"
+    )
+
+
+def test_sibling_resumes_below_the_block_grid_when_the_prefix_ends_early():
+    """A system prompt followed by a per-request suffix -- the deployed shape.
+
+    The owner's prompt tail sits over its own suffix, which no sibling shares, so
+    a check-point there is unreachable. The next request's full-attention match
+    stops at the last shared block boundary and EAGLE drops one hash unit below
+    it, so state has to exist just under the block grid too.
+    """
+    block_size, hash_block_size = 16, 4
+    manager = _manager(block_size, hash_block_size)
+    stub = _stub(manager, block_size, hash_block_size)
+
+    shared = 24
+    owner = make_request("owner", PREFIX[:shared] + [-1] * 16, hash_block_size, sha256)
+    _prefill(manager, stub, owner)
+
+    # The first follower observes the junction (16 shared, dropped to 12) and
+    # registers state there; the second one gets to resume from it.
+    follower = make_request(
+        "follower", PREFIX[:shared] + [-2] * 16, hash_block_size, sha256
+    )
+    _prefill(manager, stub, follower)
+
+    resume = shared // block_size * block_size - hash_block_size
+    hit = _sibling_hit(manager, shared, [-3] * 16, hash_block_size)
+    assert hit == resume, f"expected the resume point at {resume}, got {hit}"
+
+
+# --------------------------------------------------------------------------
+# Invariants the two clauses have to keep
+
+
+def _armed_configs():
+    """``(block_size, hash_block_size)`` pairs the junction path can arm on.
+
+    The prefix match unit must divide every group's block size and be strictly
+    smaller, or ``enable_partial_hash_hits`` is False and the path is inert.
+    """
+    for block_size in (16, 128, 512):
+        for hash_block_size in (4, 32):
+            if hash_block_size < block_size and block_size % hash_block_size == 0:
+                yield block_size, hash_block_size
+
+
+def test_scheduler_never_stops_where_the_manager_refuses():
+    """A junction stop must always be a position the manager caches.
+
+    "The scheduler schedules a number of tokens it thinks can be cached, but the
+    cache manager won't agree" is a property of the pair, not of one
+    configuration, so sweep the armed parameter space.
+    """
+    evaluated, refused, skipped = 0, [], []
+    for block_size, hash_block_size in _armed_configs():
+        for prompt_len in (
+            2 * block_size - hash_block_size,
+            3 * block_size + hash_block_size + 1,
+            4 * block_size - 1,
+        ):
+            manager = _manager(block_size, hash_block_size)
+            stub = _stub(manager, block_size, hash_block_size)
+            _orphaned_full_attention_tail(manager, stub, prompt_len)
+
+            shared = prompt_len // hash_block_size * hash_block_size
+            suffix = [-1] * (block_size + 3)
+            consumer = make_request(
+                "consumer", PREFIX[:shared] + suffix, hash_block_size, sha256
+            )
+            junction = manager.get_computed_blocks(consumer)[2]
+            if not junction:
+                continue
+            case = (block_size, hash_block_size, prompt_len, junction)
+            # The stop and the check-point are both keyed on the junction, so it
+            # has to be on the hash grid -- nothing else keeps them together.
+            assert junction % hash_block_size == 0, case
+            if junction not in _prefill(manager, stub, consumer):
+                skipped.append(case)
+                continue
+            evaluated += 1
+            hit = _sibling_hit(
+                manager, shared, [-2] * (block_size + 3), hash_block_size
+            )
+            if hit < junction:
+                refused.append(case + (hit,))
+
+    assert not skipped, (
+        f"the scheduler declined to stop at {len(skipped)}: {skipped[:3]}"
+    )
+    assert evaluated >= 10, f"sweep did not exercise the junction: {evaluated} cases"
+    assert not refused, (
+        f"{len(refused)} of {evaluated} configs split at a junction the manager then "
+        f"refused (block, hash, prompt_len, junction, sibling_hit): {refused[:3]}"
+    )
+
+
+def test_a_junction_past_the_prompt_falls_back_and_registers_nothing():
+    """A resumed request's junction can land in its output tokens.
+
+    The manager writes nothing there -- during decode the target is the running
+    state block, mutated in place, which equals what its key promises only after
+    that step's forward. So the scheduler must not stop AT it, but it must still
+    take the block-floored stop stock vLLM would have made: dropping the stop
+    entirely loses a check-point a sibling could have resumed from.
+    """
+    block_size, hash_block_size = 512, 32
+    manager = _manager(block_size, hash_block_size)
+    stub = _stub(manager, block_size, hash_block_size)
+
+    request = make_request("r", PREFIX[:2000], hash_block_size, sha256)
+    for _ in range(2000):
+        request.append_output_token_ids(1)
+    assert request.num_prompt_tokens == 2000 and request.num_tokens == 4000
+
+    # 2208 is past the prompt: not used verbatim, but the block-floored stop
+    # (2048) still applies -- not the last cacheable boundary (3072), which is
+    # what dropping the stop would give.
+    request.shared_prefix_boundary = 2208
+    assert Scheduler._mamba_block_aligned_split(stub, request, 8192) == 2048
+    # Inside the prompt it still stops, at the junction itself.
+    request.shared_prefix_boundary = 992
+    assert Scheduler._mamba_block_aligned_split(stub, request, 8192) == 992
+
+    # And the manager refuses on its own at the position that matters: the
+    # RUNNING state block mid-decode. Interior blocks are nulled in align mode,
+    # so every other decode-side position is already refused for that reason --
+    # here the block is live and holds exactly what a key would claim, and only
+    # the prompt bound stops it being published a forward before it changes.
+    _prefill(manager, stub, request)
+    mamba = manager.coordinator.single_type_managers[1]
+    running = request.num_computed_tokens
+    assert not mamba.req_to_blocks["r"][running // block_size].is_null
+    request.shared_prefix_boundary = running
+    assert mamba._cache_partial_tail_block(request, running) is None
+
+
+@pytest.mark.parametrize("eagle_group", [None, 0])
+@pytest.mark.parametrize("num_prefill_lookahead", [0, 2, 33])
+def test_enabling_never_reduces_reuse(eagle_group, num_prefill_lookahead):
+    """Turning the flag on may add check-points; it must never move one away.
+
+    Two axes decide whether the manager can honour the junction stop the
+    scheduler makes for it, and both fail silently -- as lost reuse, not as an
+    error. ``is_eagle_group`` annotation: the manager takes the EAGLE drop per
+    group while the scheduler flag is model-wide, so on an annotated model the
+    Mamba group can be outside ``eagle_group_ids``. Multi-module MTP: the
+    coordinator hands the manager ``num_computed - num_reprefillable``, not the
+    chunk end. In either case the junction stop displaces the block-boundary
+    stop and the check-point it replaced is never written.
+    """
+    block_size, hash_block_size = 512, 32
+
+    def sibling_hit(fine_grained):
+        manager = _manager(
+            block_size,
+            hash_block_size,
+            fine_grained=fine_grained,
+            eagle_group=eagle_group,
+            num_prefill_lookahead=num_prefill_lookahead,
+        )
+        stub = _stub(manager, block_size, hash_block_size)
+        _orphaned_full_attention_tail(manager, stub, 2020)
+        consumer = make_request(
+            "consumer", PREFIX[:2016] + [-1] * 584, hash_block_size, sha256
+        )
+        _prefill(manager, stub, consumer)
+        return _sibling_hit(manager, 2016, [-2] * 584, hash_block_size)
+
+    on, off = sibling_hit(True), sibling_hit(False)
+    assert on >= off, f"enabling the flag cut the sibling's hit from {off} to {on}"
+
+
+def test_disabled_by_default():
+    """Off, the junction is block-floored and no resume point is registered."""
+    block_size, hash_block_size = 512, 32
+    manager = _manager(block_size, hash_block_size, fine_grained=False)
+    stub = _stub(manager, block_size, hash_block_size)
+    _orphaned_full_attention_tail(manager, stub, 2020)
+
+    consumer = make_request(
+        "consumer", PREFIX[:2016] + [-1] * 584, hash_block_size, sha256
+    )
+    junction = manager.get_computed_blocks(consumer)[2]
+    assert junction, "expected a junction"
+    _prefill(manager, stub, consumer)
+
+    assert _sibling_hit(manager, 2016, [-2] * 584, hash_block_size) < junction
+
+    request = make_request("r", PREFIX[:10000], hash_block_size, sha256)
+    request.shared_prefix_boundary = 2000
+    assert Scheduler._mamba_block_aligned_split(stub, request, 8192) == 1536

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -175,6 +175,7 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
         dcp_world_size=dcp_world_size,
         scheduler_block_size=scheduler_block_size,
         mamba_partial_cache_hit=True,
+        mamba_fine_grained_prefix_cache=False,
         mamba_has_prefill_checkpoint_blocks=False,
     )
     split = Scheduler._mamba_block_aligned_split
@@ -221,6 +222,7 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
         use_eagle_block_drop=False,
         hash_block_size=32,
         mamba_partial_cache_hit=False,
+        mamba_fine_grained_prefix_cache=False,
         mamba_has_prefill_checkpoint_blocks=False,
     )
     req = make_request("0", [0] * prompt_length, 32, sha256)
@@ -260,6 +262,7 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
         use_eagle_block_drop=False,
         hash_block_size=32,
         mamba_partial_cache_hit=False,
+        mamba_fine_grained_prefix_cache=False,
         mamba_has_prefill_checkpoint_blocks=False,
     )
     req = make_request("0", [0] * prompt_length, 32, sha256)
@@ -1634,6 +1637,7 @@ def test_mamba_align_split_stops_below_eagle_proof_boundary():
         use_eagle_block_drop=True,
         hash_block_size=hash_block_size,
         mamba_partial_cache_hit=True,
+        mamba_fine_grained_prefix_cache=False,
         mamba_has_prefill_checkpoint_blocks=False,
     )
     split = Scheduler._mamba_block_aligned_split

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1619,6 +1619,177 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
 
 
+def test_mamba_align_split_stops_below_eagle_proof_boundary():
+    """The chunk that registers the partial tail must end one hash unit below
+    the prompt's last hash boundary under Eagle, which drops one unit past the
+    candidate.
+    """
+    block_size = 1536
+    hash_block_size = 128
+    mock = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        max_num_scheduled_tokens=8192,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        use_eagle=True,
+        use_eagle_block_drop=True,
+        hash_block_size=hash_block_size,
+        mamba_partial_cache_hit=True,
+        mamba_has_prefill_checkpoint_blocks=False,
+    )
+    split = Scheduler._mamba_block_aligned_split
+
+    for prompt_len in (24576, 24577):
+        req = make_request("0", [0] * prompt_len, hash_block_size, sha256)
+        req.num_computed_tokens = 23040
+        assert (
+            split(self=mock, request=req, num_new_tokens=prompt_len - 23040)
+            == 24448 - 23040
+        )
+
+    # Without the eagle block drop the tail stays at the prompt's own last hash
+    # boundary -- the shift exists only to compensate for the drop, so it keys
+    # on use_eagle_block_drop rather than plain use_eagle.
+    mock.use_eagle_block_drop = False
+    req = make_request("1", [0] * 24577, hash_block_size, sha256)
+    req.num_computed_tokens = 23040
+    assert split(self=mock, request=req, num_new_tokens=1537) == 24576 - 23040
+
+
+def test_mamba_partial_tail_hits_below_eagle_proof_boundary():
+    """Regression: a prompt whose last hash boundary coincides with its last
+    mamba block boundary registered its only fine-grained checkpoint at a
+    position Eagle can never resume from, collapsing the next turn to the
+    coarse block boundary (or, under sparse retention, to a full miss).
+    """
+    hash_block_size = 2
+    mamba_block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        use_eagle=True,
+    )
+
+    # 9 tokens: the last hash boundary (8) is also a mamba block boundary, so
+    # the prompt's two checkpoints collapse. The reachable tail is 6.
+    req0 = make_request("0", [7] * 9, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
+    req0.num_computed_tokens = 6
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 3) is not None
+    req0.num_computed_tokens = 9
+    manager.new_step_starts()
+
+    partial_hash = req0.block_hashes[6 // hash_block_size - 1]
+    partial_block = manager.block_pool.get_cached_block(
+        partial_hash, kv_cache_group_ids=[1]
+    )
+    assert partial_block is not None
+    assert partial_block[0].block_hash_num_tokens == 6
+
+    # Full attention matches to 8 and drops one hash unit to 6, where the
+    # mamba tail now exists -- instead of falling back to the block boundary 4.
+    req1 = make_request("1", [7] * 9 + [9] * 4, hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+
+
+def test_mamba_coarse_checkpoint_retained_below_eagle_proof_boundary():
+    """Without a prefix-match unit there is no partial tail, so the only
+    checkpoint comes from the retention mask. A prompt ending just past its
+    last block boundary pinned that checkpoint where eagle can never resume,
+    so under ``retention_interval=0`` the reachable block was masked out and
+    the next turn missed entirely.
+    """
+    block_size = 4
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+        prefix_cache_retention_interval=0,
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+    # 9 tokens: the last aligned boundary is 8, which eagle cannot resume
+    # from, so block 0 (ending at 4) must stay retained. Prefill in
+    # scheduler-split style -- Mamba keeps one rolling state, so a boundary is
+    # only materialized by a chunk that ends exactly on it.
+    req0 = make_request("0", [7] * 9, block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 4, num_computed, computed_blocks) is not None
+    req0.num_computed_tokens = 4
+    manager.new_step_starts()
+    assert manager.allocate_slots(req0, 5) is not None
+    req0.num_computed_tokens = 9
+    manager.free(req0)
+    manager.new_step_starts()
+
+    # The reachable state (4) is retained; the unreachable one (8) is not.
+    assert (
+        manager.block_pool.get_cached_block(
+            req0.block_hashes[0], kv_cache_group_ids=[1]
+        )
+        is not None
+    )
+
+    req1 = make_request("1", [7] * 9 + [9] * 4, block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 4
+
+
 def test_hybrid_sliding_window_group_disables_partial_hash_hits():
     hash_block_size = 2
     sliding_window_block_size = 2 * hash_block_size

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -94,6 +94,7 @@ def _split(
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         # `prefix_match_unit` finer than the block size (#46384).
         mamba_partial_cache_hit=partial_hit,
+        mamba_fine_grained_prefix_cache=False,
         hash_block_size=ATTN_BLOCK_SIZE,
         mamba_has_prefill_checkpoint_blocks=(
             num_prefill_checkpoint_blocks > 0 and not use_eagle

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -278,7 +278,12 @@ def test_unaligned_resume_never_runs_past_its_block(
     """
     prompt_len = 3602
     (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
-    tail_boundary = prompt_len // ATTN_BLOCK_SIZE * ATTN_BLOCK_SIZE
+    # Under eagle the partial-tail stop sits one hash unit below the prompt's
+    # last hash boundary: eagle matches a unit past its candidate and drops it,
+    # so nothing proves that last boundary.
+    tail_stop = prompt_len // ATTN_BLOCK_SIZE * ATTN_BLOCK_SIZE
+    if use_eagle:
+        tail_stop -= ATTN_BLOCK_SIZE
 
     pos, ends = resume_at, []
     while pos < prompt_len:
@@ -303,7 +308,7 @@ def test_unaligned_resume_never_runs_past_its_block(
 
     for end in ends[:-1]:
         aligned = end % MAMBA_BLOCK_SIZE == 0
-        assert aligned or (partial_hit and end == tail_boundary), (
+        assert aligned or (partial_hit and end == tail_stop), (
             f"intermediate chunk end {end} is neither block-aligned nor the "
-            f"partial-tail boundary"
+            f"partial-tail stop ({tail_stop})"
         )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3537,9 +3537,10 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
         use_eagle=True,
     )
 
-    # 127 tokens: latest replay boundary is floor((127 - 1) / 32) * 32 = 96.
-    # The EAGLE/MTP SWA lookup group must cache the local tail ending at
-    # 104 tokens, and that tail is two 8-token blocks wide: hashes 11 and 12.
+    # 127 tokens: eagle proves a boundary only if an aligned unit exists past
+    # it, so the replay boundary rewinds one unit to
+    # floor(127 / 32) * 32 - 32 = 64. The SWA tail plus its proof block then
+    # ends at 72, two 8-token blocks wide: hashes 7 and 8.
     token_ids = [i for i in range(15) for _ in range(block_size)] + [15] * 7
     req0 = make_request("0", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
@@ -3553,7 +3554,7 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11, 12}
+    expected_swa_cached = {7, 8}
     for i in range(15):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:
@@ -3565,8 +3566,8 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
 
     req1 = make_request("1", token_ids, block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
-    assert num_computed_tokens == 12 * block_size
-    assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 12]
+    assert num_computed_tokens == 8 * block_size
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [2, 8]
 
 
 def test_block_lookup_cache_single_block_per_key():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1166,6 +1166,7 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
         use_eagle_block_drop=False,
         hash_block_size=block_size,
         mamba_partial_cache_hit=False,
+        mamba_fine_grained_prefix_cache=False,
         mamba_has_prefill_checkpoint_blocks=False,
     )
     req_2.shared_prefix_boundary = shared_prefix_boundary

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -5,6 +5,11 @@ from math import lcm
 
 import torch
 
+from tests.v1.core.test_prefix_caching import (
+    _make_hybrid_kv_cache_config,
+    make_kv_cache_manager,
+    make_request,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
     ExternalCachedBlockPool,
     MooncakeStoreCoordinator,
@@ -12,7 +17,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator imp
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     chunk_hashes_for_block_size,
 )
-from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import BlockHash, init_none_hash
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -414,6 +421,49 @@ def test_store_mask_retention_interval_zero_keeps_only_replay_boundary():
     # num_prompt=100 -> latest hit boundary = (100-1)//32*32 = 96 -> chunk 11.
     masks = coord.store_mask(128, num_prompt_tokens=100)
     assert masks[1] == [i == 11 for i in range(16)]
+
+
+def test_store_retention_matches_the_engine_for_the_same_request():
+    """The store is a peer of the engine, so it must retain exactly what the
+    engine retains -- no hard-coded chunk numbers, both sides asked directly.
+
+    Before this was true the store seeded `num_prompt_tokens - 1` while the
+    engine, under EAGLE, resumes a block lower: it kept state nothing reaches.
+    """
+    block, hash_block = 32, 8
+    init_none_hash(sha256)
+    config = _make_hybrid_kv_cache_config(block, 4096, ["full", "sliding_window"])
+    engine = make_kv_cache_manager(
+        kv_cache_config=config,
+        max_model_len=1 << 20,
+        enable_caching=True,
+        hash_block_size=hash_block,
+        use_eagle=True,
+    )
+    store = _make_coord(
+        list(config.kv_cache_groups),
+        hash_block_size=hash_block,
+        use_eagle=True,
+        retention_interval=0,
+    )
+    swa_spec = config.kv_cache_groups[1].kv_cache_spec
+
+    for num_prompt in range(64, 160, 4):
+        request = make_request(
+            f"r{num_prompt}", list(range(num_prompt)), hash_block, sha256
+        )
+        expected = SlidingWindowManager.reachable_block_mask(
+            start_block=0,
+            end_block=128 // swa_spec.block_size,
+            alignment_tokens=block,
+            kv_cache_spec=swa_spec,
+            use_eagle=True,
+            retention_interval=0,
+            reachable_boundaries=(engine.coordinator.get_replay_boundary(request),),
+        )
+        assert store.store_mask(128, num_prompt_tokens=num_prompt)[1] == expected, (
+            f"store and engine disagree at num_prompt={num_prompt}"
+        )
 
 
 def test_store_mask_retention_interval_keeps_segment_and_replay_tails():

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -195,6 +195,12 @@ class CacheConfig:
       when the token is at position i * block_size. This is the default when prefix
       caching is enabled.
     """
+    enable_mamba_fine_grained_prefix_cache: bool = False
+    """Also register a Mamba "align" checkpoint at the shared-prefix junction --
+    where an EAGLE/MTP sibling was observed to resume -- instead of only at the
+    prompt tail. Off by default; only takes effect with `mamba_cache_mode`
+    "align", EAGLE on the Mamba group, and a prefix match unit smaller than the
+    Mamba block size."""
     replayssm_buffer_len: int = Field(default=16, gt=0)
     """ReplaySSM logical history length B for Mamba2. Triton uses B physical
     rows and FlashInfer uses B+1. Kimi-K3 speculative decode does not use B.
@@ -274,6 +280,7 @@ class CacheConfig:
             "prefix_cache_retention_interval",
             # Prefix-caching implementation detail (doesn't affect compiled graph).
             "prefix_match_unit",
+            "enable_mamba_fine_grained_prefix_cache",
             "mamba_page_size_padded",
             "skip_page_size_padded",
             "user_specified_block_size",

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -26,6 +26,7 @@ from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
 
 if TYPE_CHECKING:
     from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
+    from vllm.v1.request import Request
 
 logger = init_logger(__name__)
 
@@ -33,6 +34,50 @@ EngineId = str
 # block ids as returned by the hybrid KV cache manager. list[list[int]] are allow
 # mutability and are for connector internal use only.
 BlockIds = tuple[list[int], ...] | list[list[int]]
+
+
+def remote_prefill_token_count(num_prompt_tokens: int, has_mamba: bool) -> int:
+    """D-side half of the Mamba P/D handoff: how many tokens P computed.
+
+    Returns N-1 for Mamba models because the decoder always recomputes the last
+    token and must start from h(N-1); see ``truncate_mamba_request_for_prefill``
+    for the P-side half that makes it so.
+
+    This offset is a protocol constant, not a cache position, and in particular
+    it is *not* ``KVCacheCoordinator.get_replay_boundary``. It is hard-coded on
+    both nodes and never sent on the wire, so P and D must move together or not
+    at all -- moving one desynchronises the handoff.
+    """
+    if has_mamba and num_prompt_tokens > 1:
+        return num_prompt_tokens - 1
+    return num_prompt_tokens
+
+
+def truncate_mamba_request_for_prefill(request: "Request") -> None:
+    """P-side half: drop the last prompt token so the prefiller computes
+    h(N-1) instead of h(N). The decoder recomputes the last token to derive
+    h(N) correctly.
+
+    Guarded by ``_p_side_truncated`` to avoid repeated truncation if the
+    request is preempted and rescheduled.
+    """
+    params = request.kv_transfer_params
+    if (
+        params is not None
+        and not params.get("_p_side_truncated")
+        and request.num_prompt_tokens > 1
+    ):
+        if request.prompt_token_ids is not None:
+            request.prompt_token_ids.pop()
+        elif request.prompt_embeds is not None:
+            request.prompt_embeds = request.prompt_embeds[:-1]
+        else:
+            return
+
+        request._all_token_ids.pop()
+        request.num_prompt_tokens -= 1
+        request.max_tokens = 1
+        params["_p_side_truncated"] = True
 
 
 def get_kv_connector_cache_layout(vllm_config: VllmConfig | None = None):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -23,6 +23,8 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
     EngineId,
     TransferTopology,
     get_current_attn_backends,
+    remote_prefill_token_count,
+    truncate_mamba_request_for_prefill,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
@@ -660,36 +662,10 @@ class MooncakeConnectorScheduler:
         ]
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
-        """D-side only. Returns N-1 for Mamba models since the decoder
-        always recomputes the last token and must start from h(N-1)."""
-        if self._has_mamba and num_prompt_tokens > 1:
-            return num_prompt_tokens - 1
-        return num_prompt_tokens
+        return remote_prefill_token_count(num_prompt_tokens, self._has_mamba)
 
     def _truncate_mamba_request_for_prefill(self, request: "Request") -> None:
-        """P-side only: drop the last prompt token so the prefiller computes
-        h(N-1) instead of h(N). The decoder recomputes the last token to
-        derive h(N) correctly.
-
-        Guarded by ``_p_side_truncated`` to avoid repeated truncation if the
-        request is preempted and rescheduled."""
-        params = request.kv_transfer_params
-        if (
-            params is not None
-            and not params.get("_p_side_truncated")
-            and request.num_prompt_tokens > 1
-        ):
-            if request.prompt_token_ids is not None:
-                request.prompt_token_ids.pop()
-            elif request.prompt_embeds is not None:
-                request.prompt_embeds = request.prompt_embeds[:-1]
-            else:
-                return
-
-            request._all_token_ids.pop()
-            request.num_prompt_tokens -= 1
-            request.max_tokens = 1
-            params["_p_side_truncated"] = True
+        truncate_mamba_request_for_prefill(request)
 
     def on_new_request(self, request: "Request") -> None:
         params = request.kv_transfer_params

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -14,6 +14,7 @@ from vllm.v1.core.kv_cache_coordinator import SpecGroup
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    replay_boundary,
 )
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -264,6 +265,17 @@ class MooncakeStoreCoordinator:
             f"aligned_token_len ({aligned_token_len}) must be a multiple of "
             f"{mask_alignment}"
         )
+        # Model-level, so it is computed once and shared by every group; the
+        # store's retention must name the position the engine resumes at.
+        reachable_boundaries = (
+            ()
+            if num_prompt_tokens is None
+            else (
+                replay_boundary(
+                    num_prompt_tokens, self.lcm_block_size, bool(self.eagle_group_ids)
+                ),
+            )
+        )
         masks: list[list[bool] | None] = []
         for g_idx, g in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(g.kv_cache_spec)
@@ -275,9 +287,6 @@ class MooncakeStoreCoordinator:
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids
-            reachable_boundaries = (
-                () if num_prompt_tokens is None else (num_prompt_tokens - 1,)
-            )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,
                 end_block=end_chunk,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -110,19 +110,6 @@ class MooncakeStoreCoordinator:
         )
         return length // alignment * alignment
 
-    def get_replay_boundary(self, num_prompt_tokens: int) -> int:
-        """Mirror of ``KVCacheCoordinator.get_replay_boundary``.
-
-        The store's retention must name the same position the engine resumes
-        at; if the two disagree the store keeps state where nothing can reach
-        it. Model-level for the same reason: a hit is the shortest hit across
-        groups, so an EAGLE group's drop caps every group.
-        """
-        if not self.eagle_group_ids:
-            return num_prompt_tokens - 1
-        aligned = num_prompt_tokens // self.lcm_block_size * self.lcm_block_size
-        return max(aligned - self.lcm_block_size, 0)
-
     def _verify_and_split_kv_cache_groups(self) -> None:
         """Mirrors KVCacheCoordinator.verify_and_split_kv_cache_groups but
         dispatches via spec_manager_map (we don't allocate managers).
@@ -277,13 +264,6 @@ class MooncakeStoreCoordinator:
             f"aligned_token_len ({aligned_token_len}) must be a multiple of "
             f"{mask_alignment}"
         )
-        # Model-level, so it is computed once and shared by every group (see
-        # KVCacheCoordinator.get_replay_boundary).
-        reachable_boundaries = (
-            ()
-            if num_prompt_tokens is None
-            else (self.get_replay_boundary(num_prompt_tokens),)
-        )
         masks: list[list[bool] | None] = []
         for g_idx, g in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(g.kv_cache_spec)
@@ -295,6 +275,9 @@ class MooncakeStoreCoordinator:
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids
+            reachable_boundaries = (
+                () if num_prompt_tokens is None else (num_prompt_tokens - 1,)
+            )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,
                 end_block=end_chunk,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -110,6 +110,19 @@ class MooncakeStoreCoordinator:
         )
         return length // alignment * alignment
 
+    def get_replay_boundary(self, num_prompt_tokens: int) -> int:
+        """Mirror of ``KVCacheCoordinator.get_replay_boundary``.
+
+        The store's retention must name the same position the engine resumes
+        at; if the two disagree the store keeps state where nothing can reach
+        it. Model-level for the same reason: a hit is the shortest hit across
+        groups, so an EAGLE group's drop caps every group.
+        """
+        if not self.eagle_group_ids:
+            return num_prompt_tokens - 1
+        aligned = num_prompt_tokens // self.lcm_block_size * self.lcm_block_size
+        return max(aligned - self.lcm_block_size, 0)
+
     def _verify_and_split_kv_cache_groups(self) -> None:
         """Mirrors KVCacheCoordinator.verify_and_split_kv_cache_groups but
         dispatches via spec_manager_map (we don't allocate managers).
@@ -264,6 +277,13 @@ class MooncakeStoreCoordinator:
             f"aligned_token_len ({aligned_token_len}) must be a multiple of "
             f"{mask_alignment}"
         )
+        # Model-level, so it is computed once and shared by every group (see
+        # KVCacheCoordinator.get_replay_boundary).
+        reachable_boundaries = (
+            ()
+            if num_prompt_tokens is None
+            else (self.get_replay_boundary(num_prompt_tokens),)
+        )
         masks: list[list[bool] | None] = []
         for g_idx, g in enumerate(self.kv_cache_groups):
             spec = _unwrap_spec(g.kv_cache_spec)
@@ -275,9 +295,6 @@ class MooncakeStoreCoordinator:
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None
             use_eagle = g_idx in self.eagle_group_ids
-            reachable_boundaries = (
-                () if num_prompt_tokens is None else (num_prompt_tokens - 1,)
-            )
             mask = manager_cls.reachable_block_mask(
                 start_block=start_chunk,
                 end_block=end_chunk,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -13,6 +13,8 @@ from vllm import envs
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     BlockIds,
     EngineId,
+    remote_prefill_token_count,
+    truncate_mamba_request_for_prefill,
     yield_req_data,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -380,37 +382,10 @@ class NixlBaseConnectorScheduler:
                 )
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
-        """D-side only. Returns N-1 for Mamba models since the decoder
-        always recomputes the last token and must start from h(N-1)."""
-        if self._has_mamba and num_prompt_tokens > 1:
-            return num_prompt_tokens - 1
-        return num_prompt_tokens
+        return remote_prefill_token_count(num_prompt_tokens, self._has_mamba)
 
     def _truncate_mamba_request_for_prefill(self, request: "Request") -> None:
-        """P-side only: drop the last prompt token so the prefiller computes
-        h(N-1) instead of h(N). The decoder recomputes the last token to
-        derive h(N) correctly.
-
-        Guarded by ``_p_side_truncated`` to avoid repeated truncation if the
-        request is preempted and rescheduled."""
-        params = request.kv_transfer_params
-        if (
-            params is not None
-            # Guard against repeated truncation after preemption/reschedule.
-            and not params.get("_p_side_truncated")
-            and request.num_prompt_tokens > 1
-        ):
-            if request.prompt_token_ids is not None:
-                request.prompt_token_ids.pop()
-            elif request.prompt_embeds is not None:
-                request.prompt_embeds = request.prompt_embeds[:-1]
-            else:
-                return
-
-            request._all_token_ids.pop()
-            request.num_prompt_tokens -= 1
-            request.max_tokens = 1
-            params["_p_side_truncated"] = True
+        truncate_mamba_request_for_prefill(request)
 
     def _build_save_meta(
         self,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -725,6 +725,9 @@ class EngineArgs:
     mamba_block_size: int | None = get_field(CacheConfig, "mamba_block_size")
     prefix_match_unit: int | None = get_field(CacheConfig, "prefix_match_unit")
     mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
+    enable_mamba_fine_grained_prefix_cache: bool = (
+        CacheConfig.enable_mamba_fine_grained_prefix_cache
+    )
     replayssm_buffer_len: int = CacheConfig.replayssm_buffer_len
     use_replayssm: bool = CacheConfig.use_replayssm
 
@@ -1278,6 +1281,10 @@ class EngineArgs:
         )
         cache_group.add_argument(
             "--mamba-cache-mode", **cache_kwargs["mamba_cache_mode"]
+        )
+        cache_group.add_argument(
+            "--enable-mamba-fine-grained-prefix-cache",
+            **cache_kwargs["enable_mamba_fine_grained_prefix_cache"],
         )
         cache_group.add_argument(
             "--replayssm-buffer-len", **cache_kwargs["replayssm_buffer_len"]
@@ -2057,6 +2064,9 @@ class EngineArgs:
             mamba_block_size=self.mamba_block_size,
             prefix_match_unit=self.prefix_match_unit,
             mamba_cache_mode=self.mamba_cache_mode,
+            enable_mamba_fine_grained_prefix_cache=(
+                self.enable_mamba_fine_grained_prefix_cache
+            ),
             replayssm_buffer_len=self.replayssm_buffer_len,
             use_replayssm=self.use_replayssm,
             kv_offloading_size=self.kv_offloading_size,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -12,6 +12,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
     dcp_world_size_for_kv_cache_spec,
+    replay_boundary,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -304,26 +305,12 @@ class KVCacheCoordinator(ABC):
         )
 
     def get_replay_boundary(self, request: Request) -> int:
-        """Return the position a later request replaying this prompt resumes at.
-
-        A cache hit is the shortest hit across all groups, so this is a
-        model-level position: every group has to retain state here, whether or
-        not it is the group that drops. Groups differ only in how much they
-        keep around it -- EAGLE groups also keep the block above, which they
-        match and drop back from (see ``reachable_block_mask``).
-
-        Under EAGLE that block must exist, so the boundary sits one alignment
-        unit below the prompt's last aligned position; every group's block size
-        divides the alignment, so the block above always fits in the prompt.
-        """
-        if not self.eagle_group_ids:
-            return request.num_prompt_tokens - 1
-        aligned = (
-            request.num_prompt_tokens
-            // self.scheduler_block_size
-            * self.scheduler_block_size
+        """Bind ``replay_boundary`` to this coordinator's geometry."""
+        return replay_boundary(
+            request.num_prompt_tokens,
+            self.scheduler_block_size,
+            bool(self.eagle_group_ids),
         )
-        return max(aligned - self.scheduler_block_size, 0)
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -303,6 +303,28 @@ class KVCacheCoordinator(ABC):
             for manager in self.single_type_managers
         )
 
+    def get_replay_boundary(self, request: Request) -> int:
+        """Return the position a later request replaying this prompt resumes at.
+
+        A cache hit is the shortest hit across all groups, so this is a
+        model-level position: every group has to retain state here, whether or
+        not it is the group that drops. Groups differ only in how much they
+        keep around it -- EAGLE groups also keep the block above, which they
+        match and drop back from (see ``reachable_block_mask``).
+
+        Under EAGLE that block must exist, so the boundary sits one alignment
+        unit below the prompt's last aligned position; every group's block size
+        divides the alignment, so the block above always fits in the prompt.
+        """
+        if not self.eagle_group_ids:
+            return request.num_prompt_tokens - 1
+        aligned = (
+            request.num_prompt_tokens
+            // self.scheduler_block_size
+            * self.scheduler_block_size
+        )
+        return max(aligned - self.scheduler_block_size, 0)
+
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """
         Cache the blocks for the request.
@@ -313,6 +335,7 @@ class KVCacheCoordinator(ABC):
                 that need to be cached
                 (including tokens that are already cached).
         """
+        replay_boundary = self.get_replay_boundary(request)
         for manager in self.single_type_managers:
             # Only cache tokens with finalized KV. The last num_reprefillable_tokens
             # tokens can be re-prefilled during multi-module MTP.
@@ -323,6 +346,7 @@ class KVCacheCoordinator(ABC):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                replay_boundary=replay_boundary,
             )
 
     def free(self, request_id: str) -> None:
@@ -739,6 +763,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         cached_num_computed_tokens = self._align_cacheable(num_computed_tokens)
+        replay_boundary = self.get_replay_boundary(request)
         for manager in self.single_type_managers:
             num_tokens_to_cache = cached_num_computed_tokens
             # EAGLE groups match one block past each aligned boundary and drop
@@ -765,6 +790,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                replay_boundary=replay_boundary,
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -15,6 +15,7 @@ from vllm.v1.core.kv_cache_coordinator import (
 )
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.single_type_kv_cache_manager import MambaManager
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     CrossAttentionSpec,
@@ -132,6 +133,7 @@ class KVCacheManager:
         pcp_world_size: int = 1,
         metrics_collector: KVCacheMetricsCollector | None = None,
         watermark: float = 0.0,
+        enable_mamba_fine_grained_prefix_cache: bool = False,
     ) -> None:
         self.max_model_len = max_model_len
         # When unset, fall back to `max_model_len` so the recycling-aware cap
@@ -164,6 +166,21 @@ class KVCacheManager:
             metrics_collector=self.metrics_collector,
             num_prefill_lookahead=num_prefill_lookahead,
         )
+        # One predicate, read by both sides of the feature, so the scheduler
+        # cannot end a chunk at a junction the manager would refuse -- a refused
+        # junction costs a forward pass and displaces the block-boundary stop.
+        # Multi-module MTP is excluded because ``cache_blocks`` then hands the
+        # manager ``num_computed - num_reprefillable`` rather than the chunk end.
+        self.mamba_fine_grained_prefix_cache = (
+            enable_mamba_fine_grained_prefix_cache
+            and bool(self.coordinator.eagle_group_ids)
+            and self.coordinator.enable_partial_hash_hits
+            and self.coordinator.num_reprefillable_tokens == 0
+        )
+        if self.mamba_fine_grained_prefix_cache:
+            for manager in self.coordinator.single_type_managers:
+                if isinstance(manager, MambaManager):
+                    manager.fine_grained_prefix_cache = True
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool
         self.kv_cache_config = kv_cache_config

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -697,6 +697,30 @@ def dcp_world_size_for_kv_cache_spec(spec: KVCacheSpec, dcp_world_size: int) -> 
     return 1
 
 
+def replay_boundary(num_prompt_tokens: int, alignment: int, use_eagle: bool) -> int:
+    """Return the position a later request replaying this prompt resumes at.
+
+    Model-level, not per-group: a hit is the shortest hit across all groups, so
+    an EAGLE group's drop caps every group and all of them must retain state
+    here. Groups differ only in how much they keep around it -- EAGLE groups
+    also keep the block above, which they match and drop back from (see
+    ``SingleTypeKVCacheManager.reachable_block_mask``).
+
+    Under EAGLE that block must exist, so the boundary sits one alignment unit
+    below the prompt's last aligned position; every group's block size divides
+    the alignment, so the block above always fits in the prompt.
+
+    Args:
+        num_prompt_tokens: Length of the prompt being replayed.
+        alignment: Scheduler block size.
+        use_eagle: Whether any group takes the EAGLE drop.
+    """
+    if not use_eagle:
+        return num_prompt_tokens - 1
+    aligned = num_prompt_tokens // alignment * alignment
+    return max(aligned - alignment, 0)
+
+
 def resolve_kv_cache_block_sizes(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -432,7 +432,12 @@ class Scheduler(SchedulerInterface):
         # The last block-aligned position whose state can be cached. With
         # Eagle, FullAttn prunes the last matching block, so back off one
         # block to avoid a Mamba cache miss.
-        last_cache_position = request.num_tokens - request.num_tokens % block_size
+        # Floor from num_tokens - 1: a request always recomputes its last
+        # token, so that is the highest position any replay can match. A
+        # block-aligned prompt floored from num_tokens lands on the prompt's
+        # own end, one block above what a replay can reach.
+        ceiling = request.num_tokens - 1
+        last_cache_position = ceiling - ceiling % block_size
         if self.use_eagle_block_drop:
             last_cache_position = max(last_cache_position - block_size, 0)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -451,6 +451,14 @@ class Scheduler(SchedulerInterface):
             if self.mamba_partial_cache_hit
             else 0
         )
+        if tail_boundary and self.use_eagle_block_drop:
+            # Eagle matches one hash unit past the candidate and drops it, so
+            # nothing proves the prompt's own last hash boundary. Materialize
+            # the state one unit lower, where the hit can actually land. Keyed on
+            # the block-drop bit, not plain use_eagle: this shift exists only to
+            # compensate for the drop, and the Mamba manager's matching gate
+            # reads the same bit (the coordinator is handed use_eagle_block_drop).
+            tail_boundary = max(tail_boundary - self.hash_block_size, 0)
         stops = (
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -307,6 +307,9 @@ class Scheduler(SchedulerInterface):
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
             watermark=self.scheduler_config.watermark,
+            enable_mamba_fine_grained_prefix_cache=(
+                self.cache_config.enable_mamba_fine_grained_prefix_cache
+            ),
         )
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
@@ -351,6 +354,14 @@ class Scheduler(SchedulerInterface):
             self.need_mamba_block_aligned_split
             and self.hash_block_size < self.block_size
             and self.kv_cache_manager.coordinator.enable_partial_hash_hits
+        )
+        # Opt-in: also stop at the junction, where an eagle sibling resumes. The
+        # manager decides whether it can check-point there (per-group eagle bit,
+        # no MTP re-prefill tail); splitting for a stop it would refuse costs a
+        # forward pass and displaces the block-boundary stop.
+        self.mamba_fine_grained_prefix_cache = (
+            self.mamba_partial_cache_hit
+            and self.kv_cache_manager.mamba_fine_grained_prefix_cache
         )
 
         # Counts of non-empty steps scheduled / processed. update_from_output
@@ -459,6 +470,21 @@ class Scheduler(SchedulerInterface):
             # compensate for the drop, and the Mamba manager's matching gate
             # reads the same bit (the coordinator is handed use_eagle_block_drop).
             tail_boundary = max(tail_boundary - self.hash_block_size, 0)
+        junction = request.shared_prefix_boundary
+        # Block-floored: a sub-block junction's state is not separately cacheable.
+        block_floored = start + (junction - start) // block_size * block_size
+        if self.mamba_fine_grained_prefix_cache:
+            # Stop at the junction as observed. It is already on the hash grid,
+            # which is where eagle resumes; block-flooring rounds that position
+            # away. Past the prompt the manager writes nothing, so fall back to
+            # the block-floored stop rather than dropping it -- a resumed request
+            # replaying output tokens can observe a junction there, and the
+            # block-boundary check-point is still worth taking.
+            junction_stop = (
+                junction if junction <= request.num_prompt_tokens else block_floored
+            )
+        else:
+            junction_stop = block_floored
         stops = (
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.
@@ -470,12 +496,9 @@ class Scheduler(SchedulerInterface):
             tail_boundary
             if last_cache_position < tail_boundary < request.num_prompt_tokens
             else 0,
-            # Marconi shared-prefix junction, block-floored (a sub-block
-            # junction's state is not separately cacheable): cache its state
-            # so sibling requests sharing the prefix can reuse it.
-            start + (request.shared_prefix_boundary - start) // block_size * block_size
-            if start < request.shared_prefix_boundary < end
-            else 0,
+            # Marconi shared-prefix junction: cache its state so sibling
+            # requests sharing the prefix can reuse it.
+            junction_stop if start < junction < end else 0,
         )
         # Stop at the earliest mandatory position strictly inside the chunk.
         end = min((s for s in stops if start < s < end), default=end)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -113,6 +113,9 @@ class SingleTypeKVCacheManager(ABC):
         # aligned segment (SWA). Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+        # ``CacheConfig.enable_mamba_fine_grained_prefix_cache``, narrowed and set
+        # by ``KVCacheManager``; only an EAGLE Mamba "align" group ever gets it.
+        self.fine_grained_prefix_cache = False
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
@@ -1890,7 +1893,16 @@ class MambaManager(SingleTypeKVCacheManager):
             latest_prompt_hash_boundary = max(
                 latest_prompt_hash_boundary - hash_block_size, 0
             )
-        if num_tokens != latest_prompt_hash_boundary:
+        # The junction is the other position a sibling resumes at: where one was
+        # observed to stop, and where the scheduler already ends a chunk. Bounded
+        # to the prompt chunk being computed -- during decode the target is the
+        # running state block, mutated in place, which equals what its key
+        # promises only after that step's forward.
+        if num_tokens != latest_prompt_hash_boundary and not (
+            self.fine_grained_prefix_cache
+            and num_tokens == request.shared_prefix_boundary
+            and request.num_computed_tokens < num_tokens <= request.num_prompt_tokens
+        ):
             return None
 
         block_idx = num_tokens // self.block_size

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -113,7 +113,6 @@ class SingleTypeKVCacheManager(ABC):
         # aligned segment (SWA). Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
-
         # Partial-hit copy-on-write bookkeeping. Populated only by fine-grained
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
@@ -434,6 +433,8 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -456,7 +457,7 @@ class SingleTypeKVCacheManager(ABC):
         # Token boundaries whose reachable tail must be retained under sparse
         # retention: the replay boundary (``num_prompt - 1``, capped by
         # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
+        reachable_boundaries = [replay_boundary]
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
 
@@ -791,8 +792,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            replay_boundary=replay_boundary,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1819,9 +1827,16 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            replay_boundary=replay_boundary,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1869,6 +1884,12 @@ class MambaManager(SingleTypeKVCacheManager):
         latest_prompt_hash_boundary = (
             request.num_prompt_tokens // hash_block_size
         ) * hash_block_size
+        if self.use_eagle:
+            # Eagle groups match one hash unit past the candidate and drop it,
+            # so register the tail one unit lower.
+            latest_prompt_hash_boundary = max(
+                latest_prompt_hash_boundary - hash_block_size, 0
+            )
         if num_tokens != latest_prompt_hash_boundary:
             return None
 
@@ -1926,6 +1947,8 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        *,
+        replay_boundary: int,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.


### PR DESCRIPTION
Follow-up to [#53945](https://github.com/vllm-project/vllm/pull/53945), which deferred the disagg half.

## Commits

**1. `37ca89be` — Point the Mooncake store at the engine's replay boundary** The store retained at `num_prompt_tokens - 1` while the engine, under EAGLE, resumes a block lower. One shared `kv_cache_utils.replay_boundary` now defines that position for both.

**2. `1b6dda42` — One definition of the Mamba P/D prefill handoff** The two handoff helpers were byte-identical in NIXL and Mooncake, 63 duplicated lines. Both now delegate to one definition in `kv_connector/utils.py`.

**3. `d0d5101d` — Keep a block-aligned prompt reusable under EAGLE + mamba align**

## Defects corrected

| \# | defect | commit | how |
|----|--------|--------|-----|
| 1 | Under EAGLE the store retained state at a position no replaying request can reach, and dropped the one it needs (prompt 100, lcm 32: kept 96, engine resumes at 64). | 1 | Seed `reachable_boundaries` from the shared `replay_boundary` instead of `num_prompt_tokens - 1`. |
| 2 | The boundary was recomputed per group inside a loop, though it is model-level — a hit is the shortest hit across groups. | 1 | Hoisted out of the per-group loop, computed once. |
| 3 | `_get_remote_prefill_token_count` and `_truncate_mamba_request_for_prefill` existed twice, in two connector families sharing no base class. Either copy could drift. | 2 | Moved to `kv_connector/utils.py`; each connector keeps a one-line binding. |
| 4 | Nothing recorded that the P/D `N-1` is a protocol constant, not a cache position. That confusion produced !20's review question. | 2 | Stated in the shared docstring, at the single definition. |
| 5 | A block-aligned prompt put the only reachable Mamba state at the prompt's own end. A replay is capped at `num_tokens - 1` and can never reach it, so an identical replay got **0** — not a shorter hit. | 3 | Floor the grid stop from `num_tokens - 1`; block-aligned prompts are the only lengths that move. |

Not fixed, deliberately: the P/D handoff offset stays at `N-1`. Commit 2 gives it one definition, but each node still applies it locally and it is never sent on the wire, so P and D agree only by running the same build — any change to it has to land on both at once.

## Notes for the reviewer

**Merge order.** Upstream `main` has no `get_replay_boundary` in either the engine or the store, so there is no defect 1 in `main` today. It exists only where #51295's engine half lands without its store half — the state #53945 creates by deferring it. If that deferral never lands, **commit 1 is redundant and should be dropped**.

## AI assistance

AI assistance was used (Claude Code), including the mutation checks and sweeps above. Every changed line was reviewed by me and the commands were run locally.