### PR TITLE
[Bugfix] Skip non-prefix-cacheable KV groups in the offloading divisibility assert

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_build_offloading_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_build_offloading_config.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the hash-divisibility assert in build_offloading_config().
+
+Hybrid models can carry a KV cache group that opts out of prefix caching
+(e.g. CircularBufferSpec, a one-block-per-request ring whose block size is
+unrelated to the hash granularity). Such a group is never addressed by
+block hashes, so constraining its block size by tokens_per_hash makes
+native offloading unbootable on those models.
+"""
+
+import pytest
+import torch
+
+from tests.v1.kv_connector.unit.offloading_connector.test_config import (
+    _full_attention_spec,
+    _make_vllm_config,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.config import (
+    build_offloading_config,
+)
+from vllm.v1.kv_cache_interface import (
+    CircularBufferSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+# The attention group sets the hash granularity; the ring group's block is
+# far smaller and unrelated to it.
+ATTENTION_BLOCK_SIZE = 1152
+RING_BLOCK_SIZE = 4
+
+
+def _ring_spec(block_size: int = RING_BLOCK_SIZE) -> CircularBufferSpec:
+    return CircularBufferSpec(
+        block_size=block_size,
+        num_kv_heads=4,
+        head_size=128,
+        dtype=torch.float32,
+    )
+
+
+def _kv_cache_config(*specs) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=4,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec([f"layer_{i}"], spec) for i, spec in enumerate(specs)
+        ],
+    )
+
+
+def test_non_prefix_cacheable_group_is_exempt():
+    """A ring group whose block size does not divide the hash unit boots.
+
+    Without the exemption this raises AssertionError, and no hybrid model
+    carrying such a group can start with native offloading at all.
+    """
+    config = build_offloading_config(
+        _make_vllm_config(),
+        _kv_cache_config(
+            _full_attention_spec(block_size=ATTENTION_BLOCK_SIZE), _ring_spec()
+        ),
+    )
+
+    # The hash unit comes from the prefix-cacheable group alone, so the ring
+    # block size (4) never has to divide it.
+    assert config.cache.tokens_per_hash == ATTENTION_BLOCK_SIZE
+    assert [group.tokens_per_block for group in config.groups] == [
+        ATTENTION_BLOCK_SIZE,
+        RING_BLOCK_SIZE,
+    ]
+
+
+def test_divisibility_still_enforced_for_prefix_cacheable_groups():
+    """Prefix-cacheable groups keep the assert.
+
+    A mamba group outside "align" mode pins the hash unit to the LCM of the
+    group block sizes (48), which the prefix-cacheable attention group's own
+    block size (16) does not divide.
+    """
+    kv_cache_config = _kv_cache_config(
+        _full_attention_spec(block_size=16),
+        MambaSpec(
+            block_size=24,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="none",
+        ),
+    )
+
+    with pytest.raises(AssertionError, match="not divisible"):
+        build_offloading_config(_make_vllm_config(), kv_cache_config)
+
+
+def test_all_non_prefix_cacheable_falls_back_to_every_group():
+    """With nothing prefix-cacheable, every group is asserted again.
+
+    Mirrors the ``or group_block_sizes`` fallback that
+    resolve_kv_cache_block_sizes() uses when deriving the hash unit, so the
+    assert degenerates into checking every group rather than checking none.
+    """
+    config = build_offloading_config(
+        _make_vllm_config(),
+        _kv_cache_config(_ring_spec(4), _ring_spec(8)),
+    )
+
+    # GCD of the ring block sizes, since no group participates in hashing.
+    assert config.cache.tokens_per_hash == 4

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -54,7 +54,20 @@ def build_offloading_config(
     )
 
     _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
-    for group in groups:
+    # Only prefix-cacheable groups are addressed by block hashes, so only they
+    # are constrained by the hash granularity. A group that opts out (e.g.
+    # CircularBufferSpec, a one-block-per-request ring whose block size is
+    # unrelated to the hash unit) never has block hashes computed over it;
+    # asserting divisibility on it makes native offloading unbootable on any
+    # hybrid model carrying such a group. Mirrors the prefix_cacheable filter
+    # resolve_kv_cache_block_sizes() applies when deriving tokens_per_hash,
+    # fallback included.
+    hashable_groups = [
+        offload_group
+        for cache_group, offload_group in zip(kv_cache_config.kv_cache_groups, groups)
+        if cache_group.kv_cache_spec.prefix_cacheable
+    ] or groups
+    for group in hashable_groups:
         assert group.tokens_per_block % tokens_per_hash == 0, (
             f"tokens_per_block={group.tokens_per_block} not divisible by "
             f"tokens_per_hash={tokens_per_hash}. "


### PR DESCRIPTION
## Summary

Native KV offloading (`OffloadingConnector`) cannot boot on a hybrid model that carries a KV cache group opting out of prefix caching — e.g. a `CircularBufferSpec` scratch group, a small per-request ring buffer whose block size (4 tokens) is unrelated to the hash granularity. `build_offloading_config()` asserts divisibility over *every* group:

```
AssertionError: tokens_per_block=4 not divisible by tokens_per_hash=1152.
Hybrid models (e.g. Mamba+Attention) need --enable-prefix-caching to align block sizes.
```

Such a group is exempt by construction: `CircularBufferSpec.prefix_cacheable` is `False`, so its blocks are never addressed by block hashes and constraining them by `tokens_per_hash` is meaningless. The assert fires anyway and the engine dies at init.

`resolve_kv_cache_block_sizes()` in `vllm/v1/core/kv_cache_utils.py` — the very function that produces `tokens_per_hash` — already filters on exactly this attribute, with an `or`-fallback for when no group participates:

```python
hashing_sizes = [
    block_size
    for group, block_size in zip(groups, group_block_sizes)
    if group.kv_cache_spec.prefix_cacheable
] or group_block_sizes
```

This patch applies the same idiom in the consumer of that value, so the assert is checked against the same set of groups the hash unit was derived from.

**Who this affects upstream.** The only producer of `CircularBufferSpec` in the tree is Qwen4-exp's QSA cache (`vllm/models/qwen4_exp/common/qsa_cache.py`), which pairs the ring with an `MLAAttentionSpec` group — exactly the hybrid shape the tests below model. QSA deliberately sizes the ring so it *divides* the attention block size:

```python
assert self.cache_config.block_size % capacity == 0, (
    f"QSA ring capacity {capacity} must divide the attention block "
    f"size {self.cache_config.block_size}"
)
```

That keeps the scheduler's LCM well-formed, but it says nothing about the hash unit: `tokens_per_hash` is the GCD over *prefix-cacheable* groups, i.e. the attention block size, which the strictly smaller ring never divides. So the assert fires and native offloading cannot start. Any future model carrying a compression or scratch ring lands in the same place.

## Changes

- `build_offloading_config()`: restrict the divisibility assert to groups whose spec reports `prefix_cacheable`, falling back to all groups when none do (mirroring the upstream idiom above).
- New tests, `tests/v1/kv_connector/unit/offloading_connector/test_build_offloading_config.py`:
  - a `FullAttentionSpec` (block 1152) + `CircularBufferSpec` (block 4) group set now builds an offloading config, where stock code raises the assert above;
  - divisibility is still enforced for prefix-cacheable groups — a mamba group outside `align` mode pins the hash unit to the LCM (48) of the group block sizes, which the attention group's own block size (16) does not divide, and the assert still fires;
  - the all-non-cacheable fallback, where the hash unit falls back to the GCD of every group.

The tests reuse `_make_vllm_config()` and `_full_attention_spec()` from the neighbouring `test_config.py` rather than hand-rolling fixtures.

## Test plan

- [x] New unit tests under `tests/v1/kv_connector/unit/offloading_connector/`, alongside the existing `test_config.py`
- [x] Verified on a live hybrid deployment (GLM-5.3-Flash, KDA+MLA, single node 8xH200) whose scratch group has the same shape as `CircularBufferSpec` — 4-token blocks against a 1152-token hash unit: the engine boots with KV offloading enabled where stock code crashes at init (3/3 attempts).

Follow-up: #55038 fixes three later crashes in the offloading scheduler that only surface once this lands and such a group is actually scheduled. That branch is this one plus exactly one commit.
