### PR TITLE
[Bugfix] Guard zero-hash KV groups in the offloading scheduler

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_build_offloading_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_build_offloading_config.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the hash-divisibility assert in build_offloading_config().
+
+Hybrid models can carry a KV cache group that opts out of prefix caching
+(e.g. CircularBufferSpec, a one-block-per-request ring whose block size is
+unrelated to the hash granularity). Such a group is never addressed by
+block hashes, so constraining its block size by tokens_per_hash makes
+native offloading unbootable on those models.
+"""
+
+import pytest
+import torch
+
+from tests.v1.kv_connector.unit.offloading_connector.test_config import (
+    _full_attention_spec,
+    _make_vllm_config,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.config import (
+    build_offloading_config,
+)
+from vllm.v1.kv_cache_interface import (
+    CircularBufferSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+# The attention group sets the hash granularity; the ring group's block is
+# far smaller and unrelated to it.
+ATTENTION_BLOCK_SIZE = 1152
+RING_BLOCK_SIZE = 4
+
+
+def _ring_spec(block_size: int = RING_BLOCK_SIZE) -> CircularBufferSpec:
+    return CircularBufferSpec(
+        block_size=block_size,
+        num_kv_heads=4,
+        head_size=128,
+        dtype=torch.float32,
+    )
+
+
+def _kv_cache_config(*specs) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=4,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec([f"layer_{i}"], spec) for i, spec in enumerate(specs)
+        ],
+    )
+
+
+def test_non_prefix_cacheable_group_is_exempt():
+    """A ring group whose block size does not divide the hash unit boots.
+
+    Without the exemption this raises AssertionError, and no hybrid model
+    carrying such a group can start with native offloading at all.
+    """
+    config = build_offloading_config(
+        _make_vllm_config(),
+        _kv_cache_config(
+            _full_attention_spec(block_size=ATTENTION_BLOCK_SIZE), _ring_spec()
+        ),
+    )
+
+    # The hash unit comes from the prefix-cacheable group alone, so the ring
+    # block size (4) never has to divide it.
+    assert config.cache.tokens_per_hash == ATTENTION_BLOCK_SIZE
+    assert [group.tokens_per_block for group in config.groups] == [
+        ATTENTION_BLOCK_SIZE,
+        RING_BLOCK_SIZE,
+    ]
+
+
+def test_divisibility_still_enforced_for_prefix_cacheable_groups():
+    """Prefix-cacheable groups keep the assert.
+
+    A mamba group outside "align" mode pins the hash unit to the LCM of the
+    group block sizes (48), which the prefix-cacheable attention group's own
+    block size (16) does not divide.
+    """
+    kv_cache_config = _kv_cache_config(
+        _full_attention_spec(block_size=16),
+        MambaSpec(
+            block_size=24,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="none",
+        ),
+    )
+
+    with pytest.raises(AssertionError, match="not divisible"):
+        build_offloading_config(_make_vllm_config(), kv_cache_config)
+
+
+def test_all_non_prefix_cacheable_falls_back_to_every_group():
+    """With nothing prefix-cacheable, every group is asserted again.
+
+    Mirrors the ``or group_block_sizes`` fallback that
+    resolve_kv_cache_block_sizes() uses when deriving the hash unit, so the
+    assert degenerates into checking every group rather than checking none.
+    """
+    config = build_offloading_config(
+        _make_vllm_config(),
+        _kv_cache_config(_ring_spec(4), _ring_spec(8)),
+    )
+
+    # GCD of the ring block sizes, since no group participates in hashing.
+    assert config.cache.tokens_per_hash == 4

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -19,6 +19,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
 )
 from vllm.platforms import current_platform
 from vllm.v1.kv_cache_interface import (
+    CircularBufferSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
     KVCacheConfig,
@@ -264,6 +265,32 @@ def _make_mamba_hybrid_kv_cache_config() -> KVCacheConfig:
                     shapes=((1, 1),),
                     dtypes=(torch.float32,),
                     mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def _make_non_cacheable_tail_kv_cache_config() -> KVCacheConfig:
+    """Full attention plus a non-prefix-cacheable circular-buffer tail group.
+
+    Shapes a hybrid model that carries a small ring scratch group: the
+    attention group sets the hash granularity (1152 tokens) while the ring
+    group's block holds 4 tokens and opts out of prefix caching, so the ring
+    resolves to hashes_per_chunk == 0 and owns no hash-addressable chunk.
+    """
+    return KVCacheConfig(
+        num_blocks=4,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full_layer"], _full_attention_spec(block_size=1152)),
+            KVCacheGroupSpec(
+                ["ring_layer"],
+                CircularBufferSpec(
+                    block_size=4,
+                    num_kv_heads=4,
+                    head_size=128,
+                    dtype=torch.float32,
                 ),
             ),
         ],

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -8,6 +8,7 @@ import torch
 
 from tests.v1.kv_connector.unit.offloading_connector.test_config import (
     _make_mamba_hybrid_kv_cache_config,
+    _make_non_cacheable_tail_kv_cache_config,
     _make_vllm_config,
 )
 from tests.v1.kv_connector.unit.offloading_connector.utils import (
@@ -3680,3 +3681,89 @@ def test_chunked_local_attention_reports_its_chunk_window():
     assert get_sliding_window_size_in_chunks(spec, tokens_per_chunk=1024) == 8
     # Partial chunks round up, so the reachable tail is never understated.
     assert get_sliding_window_size_in_chunks(spec, tokens_per_chunk=3000) == 3
+
+
+def _make_non_cacheable_tail_scheduler() -> OffloadingConnectorScheduler:
+    """Scheduler over an MLA + CircularBufferSpec ring group set.
+
+    The ring group's chunk (4 tokens) is smaller than the hash granularity
+    derived from the prefix-cacheable MLA group (1152), so its
+    hashes_per_chunk resolves to 0.
+    """
+    vllm_config = _make_vllm_config()
+    vllm_config.speculative_config = None
+    kv_cache_config = _make_non_cacheable_tail_kv_cache_config()
+    spec = MockOffloadingSpec(build_offloading_config(vllm_config, kv_cache_config))
+    return OffloadingConnectorScheduler(spec, vllm_config, kv_cache_config)
+
+
+def _make_non_cacheable_tail_request(num_block_hashes: int = 4) -> MagicMock:
+    request = MagicMock()
+    request.request_id = "req"
+    request.kv_transfer_params = None
+    request.num_prompt_tokens = 1152 * num_block_hashes
+    request.num_tokens = request.num_prompt_tokens
+    request.block_hashes = [
+        BlockHash(f"h{i}".encode()) for i in range(num_block_hashes)
+    ]
+    request.lora_request = None
+    request.is_finished.return_value = False
+    return request
+
+
+def test_non_cacheable_tail_group_has_zero_hashes_per_chunk():
+    """The ring group owns no hash-addressable chunk.
+
+    Pins the quantity the guards key on: tokens_per_chunk stays positive
+    (4), so a guard written against it would never fire; hashes_per_chunk is
+    what collapses to 0.
+    """
+    scheduler = _make_non_cacheable_tail_scheduler()
+    mla_config, ring_config = scheduler.config.kv_group_configs
+
+    assert mla_config.hashes_per_chunk == 1
+    assert ring_config.tokens_per_chunk == 4
+    assert ring_config.hashes_per_chunk == 0
+
+
+def test_update_offload_keys_skips_zero_hash_group():
+    """islice() rejects a zero step, so the ring group must be skipped.
+
+    Without the guard this raises, on the first scheduled request:
+        ValueError: Indices for islice() must be None or an integer:
+        0 <= x <= sys.maxsize.
+    """
+    scheduler = _make_non_cacheable_tail_scheduler()
+    state = RequestOffloadState(
+        config=scheduler.config,
+        req=_make_non_cacheable_tail_request(),
+        req_context=ReqContext(req_id="req"),
+        offloading_context=RequestOffloadingContext(policy=OffloadPolicy.BLOCK_LEVEL),
+    )
+
+    state.update_offload_keys()
+
+    mla_state, ring_state = state.group_states
+    # The prefix-cacheable group still accumulates keys at its granularity.
+    assert len(mla_state.offload_keys) == 4
+    # The ring group accumulates none, by construction.
+    assert not ring_state.offload_keys
+
+
+def test_update_offload_keys_is_idempotent_for_zero_hash_group():
+    """Repeated scheduling steps must keep the skipped group empty rather
+    than drift the other group's key list."""
+    scheduler = _make_non_cacheable_tail_scheduler()
+    state = RequestOffloadState(
+        config=scheduler.config,
+        req=_make_non_cacheable_tail_request(),
+        req_context=ReqContext(req_id="req"),
+        offloading_context=RequestOffloadingContext(policy=OffloadPolicy.BLOCK_LEVEL),
+    )
+
+    state.update_offload_keys()
+    state.update_offload_keys()
+
+    mla_state, ring_state = state.group_states
+    assert len(mla_state.offload_keys) == 4
+    assert not ring_state.offload_keys

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -54,7 +54,20 @@ def build_offloading_config(
     )
 
     _, tokens_per_hash = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
-    for group in groups:
+    # Only prefix-cacheable groups are addressed by block hashes, so only they
+    # are constrained by the hash granularity. A group that opts out (e.g.
+    # CircularBufferSpec, a one-block-per-request ring whose block size is
+    # unrelated to the hash unit) never has block hashes computed over it;
+    # asserting divisibility on it makes native offloading unbootable on any
+    # hybrid model carrying such a group. Mirrors the prefix_cacheable filter
+    # resolve_kv_cache_block_sizes() applies when deriving tokens_per_hash,
+    # fallback included.
+    hashable_groups = [
+        offload_group
+        for cache_group, offload_group in zip(kv_cache_config.kv_cache_groups, groups)
+        if cache_group.kv_cache_spec.prefix_cacheable
+    ] or groups
+    for group in hashable_groups:
         assert group.tokens_per_block % tokens_per_hash == 0, (
             f"tokens_per_block={group.tokens_per_block} not divisible by "
             f"tokens_per_hash={tokens_per_hash}. "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -32,6 +32,7 @@ from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    CircularBufferSpec,
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
@@ -120,6 +121,11 @@ def get_sliding_window_size_in_chunks(
 
     if isinstance(kv_cache_spec, MambaSpec):
         # Mamba depends on a single state
+        return 1
+
+    if isinstance(kv_cache_spec, CircularBufferSpec):
+        # A one-block-per-request ring holding the group still being
+        # compressed; it never reaches back beyond its own block.
         return 1
 
     assert isinstance(kv_cache_spec, FullAttentionSpec)
@@ -354,9 +360,16 @@ class RequestOffloadState:
             )
 
     def update_offload_keys(self) -> None:
+        # Groups whose tokens_per_chunk < tokens_per_hash resolve to
+        # hashes_per_chunk == 0 (e.g. CircularBufferSpec: 4 tokens/block vs
+        # a 1152-token hash granularity). islice(step=0) raises ValueError;
+        # such groups carry no hash-addressable offload blocks by
+        # construction, so skip them entirely.
         for group_config, group_state in zip(
             self.config.kv_group_configs, self.group_states
         ):
+            if group_config.hashes_per_chunk <= 0:
+                continue
             for req_block_hash in islice(
                 self.req.block_hashes,
                 group_config.hashes_per_chunk * len(group_state.offload_keys)
@@ -1357,6 +1370,12 @@ class OffloadingConnectorScheduler:
                 )
 
                 if group_config.requires_cow_source:
+                    continue
+
+                # Zero-hash groups (hashes_per_chunk == 0) accumulate no
+                # offload keys; skip them to keep offload_keys and
+                # offload_block_ids length-consistent.
+                if group_config.hashes_per_chunk <= 0:
                     continue
 
                 start_chunk_idx = group_state.next_stored_chunk_idx


### PR DESCRIPTION
## Summary

Stacked on #55037, which is required: without the divisibility fix the engine never boots far enough to reach these paths. Once a hybrid model carrying a non-prefix-cacheable group does boot with native offloading, the offloading scheduler crashes at three further points, all from one root cause — a group whose `tokens_per_chunk` (4) is smaller than `tokens_per_hash` (1152) resolves to `hashes_per_chunk == 0`, i.e. it owns no hash-addressable offload block at all.

1. `get_sliding_window_size_in_chunks()` ends in `assert isinstance(kv_cache_spec, FullAttentionSpec)`. A `CircularBufferSpec` ring is an `AttentionSpec` but not a `FullAttentionSpec`, so the scheduler dies in `SchedulerOffloadConfig.from_spec()` — before either path below is reached.
2. `update_offload_keys()`: `hashes_per_chunk` is passed as the `islice()` step, so a zero raises `ValueError: Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize` on the first scheduled request.
3. `_build_store_jobs()`: the zero-hash group appends no `offload_keys`, while `offload_block_ids` positions still advance through the shared hybrid allocator — tripping `assert len(offload_keys) == len(offload_block_ids)`.

## Changes

- Report a single-chunk reach for `CircularBufferSpec` in `get_sliding_window_size_in_chunks()`, exactly as already done for `MambaSpec` — a one-block-per-request ring never reaches back beyond its own block.
- Skip groups with `hashes_per_chunk <= 0` in `update_offload_keys()`.
- Skip them in `_build_store_jobs()` as well, **before** any block ids are derived for them.
- Regression tests in `tests/v1/kv_connector/unit/offloading_connector/`, with the shared `_make_non_cacheable_tail_kv_cache_config()` fixture added to `test_config.py` alongside the existing `_make_mamba_hybrid_kv_cache_config()`.

**On the predicate.** The quantity that reaches zero is `hashes_per_chunk`, not `tokens_per_chunk`: the ring group's `tokens_per_chunk` stays positive (4); it is the integer division against the 1152-token hash unit that collapses. `test_non_cacheable_tail_group_has_zero_hashes_per_chunk` pins exactly that, so a guard written against the wrong quantity is caught by the tests.

**On the assert.** `assert len(offload_keys) == len(offload_block_ids)` is deliberately **kept** for participating groups. Zero-hash groups are skipped before they can reach it and never accumulate keys, so the invariant now holds by construction instead of being relaxed — an over-supply of block ids for a real group still fails loudly rather than being silently truncated into a mispairing.

**Who this affects upstream.** The only producer of `CircularBufferSpec` is Qwen4-exp's QSA cache (`vllm/models/qwen4_exp/common/qsa_cache.py`), which pairs the ring with an `MLAAttentionSpec` group. Its ring capacity is strictly smaller than the attention block size that sets `tokens_per_hash`, so `hashes_per_chunk` floors to 0 and all three paths above are reachable there.

**Verified on vanilla main.** On a clean checkout of the merge base, the three scheduler tests added here cannot even reach their own bug — `build_offloading_config()` raises first, which is precisely why these are two stacked PRs:

| `vllm/` code under test | Result |
| --- | --- |
| pristine `main` | `AssertionError: tokens_per_block=4 not divisible by tokens_per_hash=1152` |
| + #55037 `config.py` only | boot succeeds; bare `AssertionError` from `assert isinstance(kv_cache_spec, FullAttentionSpec)` |
| + this PR's `scheduler.py` | all green |

Same test files throughout; only library code changes between rows.

## Evidence

GLM-5.3-Flash (KDA+MLA hybrid with a non-prefix-cacheable tail group), single node 8xH200, 28 GiB CPU offload buffer:

- Stock code: boot crash at init — the assert fixed by #55037.
- #55037 alone: boots, then crashes in the scheduler as above.
- With all three guards: engine boots, `OffloadingConnector` is created, and an A/B benchmark completes end to end (667 tok/s with offloading on vs 998 baseline on this workload — we are not enabling offloading on this hardware, but the crash fixes stand on their own: as it is, no hybrid model with a non-prefix-cacheable group can run native offloading at all).

## Test plan

- [x] `pytest tests/v1/kv_connector/unit/offloading_connector/` — 243 passed. The three new scheduler tests (zero-hash skip in `update_offload_keys()`, idempotency across repeated scheduling steps, and the `hashes_per_chunk == 0` derivation from real spec construction) each fail without the corresponding guard.
- [x] The new `test_build_offloading_config.py` case in #55037 fails on unpatched code with the exact boot assert, and passes with it.
- [x] Full A/B on the hybrid deployment above: boot plus end-to-end benchmark with offloading enabled.

## Why this is separate from #55037

#55037 is the smallest independently reviewable bug and is worth landing on its own. These scheduler guards only matter once such a group is actually scheduled with offloading enabled. This branch is #55037 plus exactly one commit.
