### PR TITLE
[ROCm][Perf][DSv4][Kernel] Add opt-in gfx942 HIP CSA/HCA compressor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1521,6 +1521,15 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
       "csrc/rocm/moe_q_gemm_rdna3.cu")
   endif()
 
+  set(VLLM_ROCM_HAS_GFX942_DSV4_COMPRESSOR OFF)
+  if(VLLM_GPU_ARCHES MATCHES "gfx942")
+    set(VLLM_ROCM_HAS_GFX942_DSV4_COMPRESSOR ON)
+    list(APPEND VLLM_ROCM_EXT_SRC
+      "vllm/models/deepseek_v4/amd/ops/dsv4_csa_compress.hip"
+      "vllm/models/deepseek_v4/amd/ops/dsv4_hca_compress.hip"
+      "vllm/models/deepseek_v4/amd/ops/dsv4_compress_ops.hip")
+  endif()
+
   define_extension_target(
     _rocm_C
     DESTINATION vllm
@@ -1539,6 +1548,11 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
 
   if(VLLM_ROCM_HAS_GFX1100)
     target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX1100)
+  endif()
+  if(VLLM_ROCM_HAS_GFX942_DSV4_COMPRESSOR)
+    target_compile_definitions(_rocm_C PRIVATE VLLM_ROCM_GFX942)
+    target_include_directories(_rocm_C PRIVATE
+      "${CMAKE_CURRENT_SOURCE_DIR}/vllm/models/deepseek_v4/amd/ops")
   endif()
 endif()
 

--- a/benchmarks/kernels/benchmark_dsv4_compress.py
+++ b/benchmarks/kernels/benchmark_dsv4_compress.py
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark DeepSeek-V4 ROCm gfx942 compressor kernels."""
+
+from dataclasses import dataclass
+
+import torch
+from tabulate import tabulate
+
+from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+    compress_norm_rope_store_triton,
+    compress_norm_rope_store_two_stage_triton,
+)
+from vllm.models.deepseek_v4.common.ops.save_partial_states import (
+    save_partial_states,
+)
+from vllm.triton_utils import triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+KV_BLOCK_SIZE = 16
+RMS_EPS = 1e-6
+SEED = 2026
+
+
+@dataclass(frozen=True)
+class ShapeConfig:
+    name: str
+    head_dim: int
+    rope_head_dim: int
+    ratio: int
+    overlap: bool
+    state_block_size: int
+    quant_format: str
+
+    @property
+    def state_width(self) -> int:
+        return (2 if self.overlap else 1) * self.head_dim
+
+    @property
+    def coff(self) -> int:
+        return 2 if self.overlap else 1
+
+    @property
+    def token_stride(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 2
+        return self.head_dim + self.rope_head_dim
+
+    @property
+    def scale_dim(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return 4
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 32
+        return (self.head_dim - self.rope_head_dim) // 64 + 1
+
+    @property
+    def quant_block(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim
+        if self.quant_format == "indexer_mxfp4":
+            return 32
+        return 64
+
+
+SHAPES = (
+    ShapeConfig("csa_main", 512, 64, 4, True, 4, "csa"),
+    ShapeConfig("hca_main", 512, 64, 128, False, 8, "hca"),
+)
+SCENARIOS = (
+    "decode_boundary",
+    "prefill_256",
+    "prefill_1024",
+    "prefill_4096",
+    "prefill_32768",
+    "prefill_65536",
+    "prefill_102400",
+)
+
+
+class KVCacheMetadata:
+    def __init__(self, slot_mapping: torch.Tensor):
+        self.slot_mapping = slot_mapping
+
+
+@dataclass
+class BenchmarkInput:
+    name: str
+    shape: ShapeConfig
+    positions: torch.Tensor
+    token_to_req_indices: torch.Tensor
+    slot_mapping: torch.Tensor
+    block_table: torch.Tensor
+    kv_slot_mapping: torch.Tensor
+    state_cache_fp32: torch.Tensor
+    state_cache_bf16: torch.Tensor
+    ape: torch.Tensor
+    cos_sin_cache: torch.Tensor
+    rms_weight: torch.Tensor
+    num_tokens: int
+    num_kv_blocks: int
+    kv_block_bytes: int
+
+    def new_kv_cache(self) -> torch.Tensor:
+        return torch.zeros(
+            self.num_kv_blocks,
+            KV_BLOCK_SIZE,
+            self.kv_block_bytes,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+
+    def common_kwargs(self, kv_cache: torch.Tensor) -> dict:
+        shape = self.shape
+        return dict(
+            num_actual=self.num_tokens,
+            token_to_req_indices=self.token_to_req_indices,
+            positions=self.positions,
+            slot_mapping=self.slot_mapping,
+            block_table=self.block_table,
+            block_size=shape.state_block_size,
+            state_width=shape.state_width,
+            cos_sin_cache=self.cos_sin_cache,
+            kv_cache=kv_cache,
+            k_cache_metadata=KVCacheMetadata(self.kv_slot_mapping),
+            pdl_kwargs={},
+            head_dim=shape.head_dim,
+            rope_head_dim=shape.rope_head_dim,
+            compress_ratio=shape.ratio,
+            overlap=shape.overlap,
+            use_fp4_cache=shape.quant_format == "indexer_mxfp4",
+            rms_norm_weight=self.rms_weight,
+            rms_norm_eps=RMS_EPS,
+            quant_block=shape.quant_block,
+            token_stride=shape.token_stride,
+            scale_dim=shape.scale_dim,
+        )
+
+
+def _scenario(
+    shape: ShapeConfig,
+    name: str,
+) -> tuple[list[int], list[int], list[int]]:
+    if name == "decode_boundary":
+        positions, req_indices, slots = [], [], []
+        context_len = 4096
+        for req_idx, max_position in enumerate([127, 255, 383, 511]):
+            for position in range(max_position + 1):
+                positions.append(position)
+                req_indices.append(req_idx)
+                slots.append(req_idx * context_len + position)
+        return positions, req_indices, slots
+
+    seq_len = int(name.removeprefix("prefill_"))
+    positions = list(range(seq_len))
+    return positions, [0] * seq_len, positions
+
+
+def _kv_slot_mapping(positions: list[int], ratio: int) -> list[int]:
+    kv_slots = []
+    next_slot = 0
+    for position in positions:
+        if (position + 1) % ratio == 0:
+            kv_slots.append(next_slot)
+            next_slot += 1
+        else:
+            kv_slots.append(-1)
+    return kv_slots
+
+
+def _block_table(
+    positions: list[int],
+    token_to_req: list[int],
+    slot_mapping: list[int],
+    block_size: int,
+) -> torch.Tensor:
+    num_reqs = max(token_to_req) + 1
+    num_blocks = max(positions) // block_size + 2
+    table = torch.zeros(num_reqs, num_blocks, dtype=torch.int32, device="cuda")
+    for req_idx, position, slot in zip(token_to_req, positions, slot_mapping):
+        table[req_idx, position // block_size] = slot // block_size
+    return table
+
+
+def _cos_sin_cache(max_position: int, rope_head_dim: int) -> torch.Tensor:
+    inv_freq = 1.0 / (
+        10000
+        ** (
+            torch.arange(0, rope_head_dim, 2, dtype=torch.float32, device="cuda")
+            / rope_head_dim
+        )
+    )
+    freqs = torch.outer(
+        torch.arange(max_position + 1, dtype=torch.float32, device="cuda"),
+        inv_freq,
+    )
+    return torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+
+
+def build_input(shape: ShapeConfig, scenario: str) -> BenchmarkInput:
+    positions, token_to_req, slot_mapping = _scenario(shape, scenario)
+    num_tokens = len(positions)
+    kv_slot_mapping = _kv_slot_mapping(positions, shape.ratio)
+
+    generator = torch.Generator(device="cuda").manual_seed(SEED + num_tokens)
+    kv = torch.randn(
+        num_tokens,
+        shape.coff * shape.head_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    score = torch.randn_like(kv)
+    ape = torch.randn(
+        shape.ratio,
+        shape.coff * shape.head_dim,
+        dtype=torch.float32,
+        device="cuda",
+        generator=generator,
+    )
+    rms_weight = torch.rand(
+        shape.head_dim,
+        dtype=torch.float32,
+        device="cuda",
+        generator=generator,
+    ).to(torch.bfloat16)
+
+    positions_t = torch.tensor(positions, dtype=torch.int64, device="cuda")
+    token_to_req_t = torch.tensor(token_to_req, dtype=torch.int32, device="cuda")
+    slot_mapping_t = torch.tensor(slot_mapping, dtype=torch.int64, device="cuda")
+    kv_slot_mapping_t = torch.tensor(kv_slot_mapping, dtype=torch.int64, device="cuda")
+
+    max_slot = max(slot_mapping)
+    state_shape = (
+        max_slot // shape.state_block_size + 4,
+        shape.state_block_size,
+        2 * shape.state_width,
+    )
+    state_cache_fp32 = torch.zeros(state_shape, dtype=torch.float32, device="cuda")
+    state_cache_bf16 = torch.zeros(state_shape, dtype=torch.bfloat16, device="cuda")
+    save_partial_states(
+        kv=kv,
+        score=score,
+        ape=ape,
+        positions=positions_t,
+        state_cache=state_cache_fp32,
+        slot_mapping=slot_mapping_t,
+        block_size=shape.state_block_size,
+        state_width=shape.state_width,
+        compress_ratio=shape.ratio,
+    )
+    save_partial_states(
+        kv=kv,
+        score=score,
+        ape=None,
+        positions=positions_t,
+        state_cache=state_cache_bf16,
+        slot_mapping=slot_mapping_t,
+        block_size=shape.state_block_size,
+        state_width=shape.state_width,
+        compress_ratio=shape.ratio,
+    )
+
+    num_compressed_tokens = sum(slot >= 0 for slot in kv_slot_mapping)
+    return BenchmarkInput(
+        name=scenario,
+        shape=shape,
+        positions=positions_t,
+        token_to_req_indices=token_to_req_t,
+        slot_mapping=slot_mapping_t,
+        block_table=_block_table(
+            positions, token_to_req, slot_mapping, shape.state_block_size
+        ),
+        kv_slot_mapping=kv_slot_mapping_t,
+        state_cache_fp32=state_cache_fp32,
+        state_cache_bf16=state_cache_bf16,
+        ape=ape,
+        cos_sin_cache=_cos_sin_cache(max(positions), shape.rope_head_dim),
+        rms_weight=rms_weight,
+        num_tokens=num_tokens,
+        num_kv_blocks=num_compressed_tokens // KV_BLOCK_SIZE + 4,
+        kv_block_bytes=shape.token_stride + shape.scale_dim,
+    )
+
+
+def hip_available() -> bool:
+    try:
+        import vllm._rocm_C  # noqa: F401
+
+        return hasattr(torch.ops._rocm_C, "dsv4_csa_compress")
+    except Exception:
+        return False
+
+
+def run_triton(
+    inputs: BenchmarkInput,
+    kv_cache: torch.Tensor,
+    compress_scratch: torch.Tensor | None,
+) -> None:
+    kwargs = inputs.common_kwargs(kv_cache)
+    if inputs.shape.ratio == 128:
+        compress_norm_rope_store_two_stage_triton(
+            state_cache=inputs.state_cache_fp32,
+            **kwargs,
+            num_decode_tokens=(
+                inputs.num_tokens if inputs.name == "decode_boundary" else 0
+            ),
+            compress_scratch=compress_scratch,
+        )
+    else:
+        compress_norm_rope_store_triton(
+            state_cache=inputs.state_cache_fp32,
+            **kwargs,
+        )
+
+
+def run_hip(
+    inputs: BenchmarkInput,
+    kv_cache: torch.Tensor,
+    plan_scratch: torch.Tensor | None,
+    counter_scratch: torch.Tensor | None,
+) -> None:
+    shape = inputs.shape
+    common = (
+        inputs.state_cache_bf16,
+        inputs.num_tokens,
+        inputs.ape,
+        inputs.token_to_req_indices,
+        inputs.positions,
+        inputs.slot_mapping,
+        inputs.block_table,
+        shape.state_block_size,
+        inputs.rms_weight.to(torch.float32),
+        RMS_EPS,
+        inputs.cos_sin_cache,
+        kv_cache,
+        inputs.kv_slot_mapping,
+        kv_cache.shape[1],
+        shape.scale_dim,
+    )
+    if shape.ratio == 128:
+        assert plan_scratch is not None and counter_scratch is not None
+        torch.ops._rocm_C.dsv4_hca_compress(
+            *common,
+            plan_scratch,
+            counter_scratch,
+        )
+    else:
+        torch.ops._rocm_C.dsv4_csa_compress(*common)
+
+
+def do_bench_us(fn) -> tuple[float, float, float]:
+    ms, min_ms, max_ms = triton.testing.do_bench(
+        fn,
+        quantiles=[0.5, 0.2, 0.8],
+    )
+    return 1000 * ms, 1000 * min_ms, 1000 * max_ms
+
+
+def benchmark_one(inputs: BenchmarkInput) -> tuple[str, str, str, str, str]:
+    hip_cache = inputs.new_kv_cache()
+    is_hca = inputs.shape.ratio == 128
+    plan_scratch = (
+        torch.empty(
+            inputs.num_tokens // inputs.shape.ratio + inputs.block_table.shape[0] + 2,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        if is_hca
+        else None
+    )
+    counter_scratch = (
+        torch.empty(1, dtype=torch.int32, device="cuda") if is_hca else None
+    )
+    hip_us, _, _ = do_bench_us(
+        lambda: run_hip(inputs, hip_cache, plan_scratch, counter_scratch)
+    )
+
+    triton_cache = inputs.new_kv_cache()
+    compress_scratch = (
+        torch.empty(
+            inputs.num_tokens,
+            inputs.shape.head_dim,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        if is_hca
+        else None
+    )
+    triton_us, _, _ = do_bench_us(
+        lambda: run_triton(inputs, triton_cache, compress_scratch)
+    )
+    return (
+        inputs.shape.name,
+        inputs.name,
+        f"{triton_us:.1f}",
+        f"{hip_us:.1f}",
+        f"{hip_us / triton_us:.3f}",
+    )
+
+
+def parse_args():
+    parser = FlexibleArgumentParser(
+        description="Benchmark DeepSeek-V4 ROCm gfx942 compressor kernels."
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    parse_args()
+    torch.set_default_device("cuda")
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA/HIP device is not available")
+    if not hip_available():
+        raise SystemExit("dsv4 compressor ops are not registered in _rocm_C")
+
+    rows = []
+    for shape in SHAPES:
+        for scenario in SCENARIOS:
+            row = benchmark_one(build_input(shape, scenario))
+            rows.append(row)
+
+    print(
+        tabulate(
+            rows,
+            headers=["shape", "scenario", "triton (us)", "hip (us)", "hip/triton"],
+            tablefmt="github",
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -42,6 +42,28 @@ void moe_gptq_gemm_rdna3(torch::Tensor a, torch::Tensor c,
                          int64_t block_size_m, bool mul_topk_weight,
                          int64_t output_topk);
 
+// DeepSeek-V4 gfx942 compressors. Implementations live with the model under
+// vllm/models/deepseek_v4/amd/ops.
+void dsv4_csa_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim);
+
+void dsv4_hca_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim,
+                       torch::Tensor plan_scratch,
+                       torch::Tensor counter_scratch);
+
 void paged_attention(
     torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
     torch::Tensor& tmp_out, torch::Tensor& query, torch::Tensor& key_cache,

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -74,6 +74,25 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
   rocm_ops.impl("moe_gptq_gemm_rdna3", torch::kCUDA, &moe_gptq_gemm_rdna3);
 #endif
 
+#ifdef VLLM_ROCM_GFX942
+  rocm_ops.def(
+      "dsv4_csa_compress(Tensor state_cache, int num_actual, Tensor ape, "
+      "Tensor token_to_req_indices, Tensor positions, Tensor slot_mapping, "
+      "Tensor block_table, int block_size, Tensor rms_norm_weight, "
+      "float rms_norm_eps, Tensor cos_sin_cache, Tensor! kv_cache, "
+      "Tensor kv_slot_mapping, int kv_cache_block_size, int scale_dim) -> ()");
+  rocm_ops.impl("dsv4_csa_compress", torch::kCUDA, &dsv4_csa_compress);
+
+  rocm_ops.def(
+      "dsv4_hca_compress(Tensor state_cache, int num_actual, Tensor ape, "
+      "Tensor token_to_req_indices, Tensor positions, Tensor slot_mapping, "
+      "Tensor block_table, int block_size, Tensor rms_norm_weight, "
+      "float rms_norm_eps, Tensor cos_sin_cache, Tensor! kv_cache, "
+      "Tensor kv_slot_mapping, int kv_cache_block_size, int scale_dim, "
+      "Tensor! plan_scratch, Tensor! counter_scratch) -> ()");
+  rocm_ops.impl("dsv4_hca_compress", torch::kCUDA, &dsv4_hca_compress);
+#endif
+
   // Custom attention op
   // Compute the attention between an input query and the cached
   // keys/values using PagedAttention.

--- a/tests/kernels/attention/dsv4_compress_utils.py
+++ b/tests/kernels/attention/dsv4_compress_utils.py
@@ -1,0 +1,670 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared DeepSeek-V4 compressor test fixtures."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import torch
+
+KV_BLOCK_SIZE = 16
+RMS_EPS = 1e-6
+FP8_MAX = 448.0
+SEED = 2026
+
+H512_TOKEN_STRIDE = 576
+H512_NOPE = 448
+H512_SCALE_DIM = 8
+H512_N_NOPE_BLOCKS = 7
+H512_QUANT_BLOCK = 64
+
+E2M1_LUT = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def detect_gfx942() -> bool:
+    try:
+        from vllm.models.deepseek_v4.amd.ops.hip_compress_dispatch import (
+            hip_compressor_runtime_available,
+        )
+
+        return hip_compressor_runtime_available()
+    except Exception:
+        return False
+
+
+@dataclass
+class ShapeConfig:
+    label: str
+    head_dim: int
+    rope_head_dim: int
+    ratio: int
+    overlap: bool
+    state_block_size: int = 4
+    quant_format: str = "csa"
+
+    @property
+    def nope_dim(self) -> int:
+        return self.head_dim - self.rope_head_dim
+
+    @property
+    def token_stride(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 2
+        return self.nope_dim + self.rope_head_dim * 2
+
+    @property
+    def scale_dim(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return 4
+        if self.quant_format == "indexer_mxfp4":
+            return self.head_dim // 32
+        return self.nope_dim // 64 + 1
+
+    @property
+    def quant_block(self) -> int:
+        if self.quant_format == "indexer_fp8":
+            return self.head_dim
+        if self.quant_format == "indexer_mxfp4":
+            return 32
+        return 64
+
+    @property
+    def state_width(self) -> int:
+        return (2 if self.overlap else 1) * self.head_dim
+
+    @property
+    def k_pool(self) -> int:
+        return (2 if self.overlap else 1) * self.ratio
+
+    @property
+    def coff(self) -> int:
+        return 2 if self.overlap else 1
+
+
+CSA_MAIN = ShapeConfig("csa_main", 512, 64, 4, True)
+HCA_MAIN = ShapeConfig("hca_main", 512, 64, 128, False, state_block_size=8)
+INDEXER_FP8 = ShapeConfig("indexer_fp8", 128, 64, 4, True, quant_format="indexer_fp8")
+INDEXER_MXFP4 = ShapeConfig(
+    "indexer_mxfp4", 128, 64, 4, True, quant_format="indexer_mxfp4"
+)
+
+BYTE_EXACT_SHAPES = [CSA_MAIN, HCA_MAIN]
+
+
+class MockMetadata:
+    def __init__(self, slot_mapping: torch.Tensor):
+        self.slot_mapping = slot_mapping
+
+
+@dataclass
+class CompressorContext:
+    name: str
+    desc: str
+    shape: ShapeConfig
+    positions: list[int]
+    token_to_req: list[int]
+    slot_mapping: list[int]
+    kv_slot_mapping: list[int]
+    max_position: int
+
+    num_tokens: int = 0
+    num_compress: int = 0
+    ape: torch.Tensor = None
+    cos_sin_cache: torch.Tensor = None
+    rms_weight: torch.Tensor = None
+    block_table: torch.Tensor = None
+    max_state_blocks: int = 0
+    total_kv_blocks: int = 0
+    bytes_per_block: int = 0
+    _raw: dict = field(default_factory=dict)
+    state_cache_fp32: torch.Tensor = None
+    state_cache_bf16: torch.Tensor = None
+    positions_t: torch.Tensor = None
+    token_to_req_t: torch.Tensor = None
+    slot_mapping_t: torch.Tensor = None
+    kv_slot_mapping_t: torch.Tensor = None
+
+    def build(self) -> CompressorContext:
+        shape = self.shape
+        self.num_tokens = len(self.positions)
+        self.num_compress = sum(1 for k in self.kv_slot_mapping if k >= 0)
+        bs = max(self.token_to_req) + 1 if self.token_to_req else 1
+
+        g = torch.Generator(device="cuda").manual_seed(SEED + self.num_tokens)
+        kv_raw = (
+            torch.randn(
+                self.num_tokens,
+                shape.coff * shape.head_dim,
+                dtype=torch.bfloat16,
+                generator=g,
+            )
+            * 0.5
+        )
+        score_raw = (
+            torch.randn(
+                self.num_tokens,
+                shape.coff * shape.head_dim,
+                dtype=torch.bfloat16,
+                generator=g,
+            )
+            * 0.5
+        )
+        self.ape = (
+            torch.randn(
+                shape.ratio,
+                shape.coff * shape.head_dim,
+                dtype=torch.float32,
+                generator=g,
+            )
+            * 0.1
+        )
+        self._raw = {"kv": kv_raw, "score": score_raw}
+
+        self.positions_t = torch.tensor(self.positions, dtype=torch.int64)
+        self.token_to_req_t = torch.tensor(self.token_to_req, dtype=torch.int32)
+        self.slot_mapping_t = torch.tensor(self.slot_mapping, dtype=torch.int64)
+        self.kv_slot_mapping_t = torch.tensor(self.kv_slot_mapping, dtype=torch.int64)
+
+        # Map logical state pages to slot-derived physical pages.
+        sbs = shape.state_block_size
+        max_slot = max((s for s in self.slot_mapping if s >= 0), default=0)
+        max_state_blocks = (max_slot // sbs) + 4
+        max_lblk = 0
+        for pos, slot in zip(self.positions, self.slot_mapping):
+            if slot >= 0:
+                max_lblk = max(max_lblk, pos // sbs)
+        max_blocks_per_seq = max_lblk + 2
+        block_table = torch.zeros(bs, max_blocks_per_seq, dtype=torch.int32)
+        for req, pos, slot in zip(self.token_to_req, self.positions, self.slot_mapping):
+            if slot < 0:
+                continue
+            block_table[req, pos // sbs] = slot // sbs
+        self.block_table = block_table
+        self.max_state_blocks = max_state_blocks
+
+        self.rms_weight = (
+            torch.rand(shape.head_dim, dtype=torch.float32, generator=g) * 0.5 + 0.5
+        ).to(torch.bfloat16)
+
+        max_cos_pos = self.max_position + 1
+        inv_freq = 1.0 / (
+            10000
+            ** (
+                torch.arange(0, shape.rope_head_dim, 2, dtype=torch.float32)
+                / shape.rope_head_dim
+            )
+        )
+        freqs = torch.outer(torch.arange(max_cos_pos, dtype=torch.float32), inv_freq)
+        self.cos_sin_cache = torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+
+        self.total_kv_blocks = (self.num_compress // KV_BLOCK_SIZE) + 4
+        self.bytes_per_block = (
+            KV_BLOCK_SIZE * shape.token_stride + KV_BLOCK_SIZE * shape.scale_dim
+        )
+
+        self._populate_state_caches()
+        return self
+
+    def _populate_state_caches(self):
+        from vllm.models.deepseek_v4.common.ops.save_partial_states import (
+            save_partial_states,
+        )
+
+        shape = self.shape
+        sbs = shape.state_block_size
+        self.state_cache_fp32 = torch.zeros(
+            self.max_state_blocks, sbs, 2 * shape.state_width, dtype=torch.float32
+        )
+        save_partial_states(
+            kv=self._raw["kv"],
+            score=self._raw["score"],
+            ape=self.ape,
+            positions=self.positions_t,
+            state_cache=self.state_cache_fp32,
+            slot_mapping=self.slot_mapping_t,
+            block_size=sbs,
+            state_width=shape.state_width,
+            compress_ratio=shape.ratio,
+        )
+        self.state_cache_bf16 = torch.zeros(
+            self.max_state_blocks, sbs, 2 * shape.state_width, dtype=torch.bfloat16
+        )
+        save_partial_states(
+            kv=self._raw["kv"],
+            score=self._raw["score"],
+            ape=None,
+            positions=self.positions_t,
+            state_cache=self.state_cache_bf16,
+            slot_mapping=self.slot_mapping_t,
+            block_size=sbs,
+            state_width=shape.state_width,
+            compress_ratio=shape.ratio,
+        )
+
+    def new_kv_cache(self) -> tuple[torch.Tensor, torch.Tensor]:
+        kv = torch.zeros(self.total_kv_blocks, self.bytes_per_block, dtype=torch.uint8)
+        return kv, kv.view(self.total_kv_blocks, KV_BLOCK_SIZE, -1)
+
+    def generic_kwargs(self) -> dict:
+        return dict(
+            num_actual=self.num_tokens,
+            token_to_req_indices=self.token_to_req_t,
+            positions=self.positions_t,
+            slot_mapping=self.slot_mapping_t,
+            block_table=self.block_table,
+            block_size=self.shape.state_block_size,
+            state_width=self.shape.state_width,
+            cos_sin_cache=self.cos_sin_cache,
+            k_cache_metadata=MockMetadata(self.kv_slot_mapping_t),
+            pdl_kwargs={},
+            head_dim=self.shape.head_dim,
+            rope_head_dim=self.shape.rope_head_dim,
+            compress_ratio=self.shape.ratio,
+            overlap=self.shape.overlap,
+            use_fp4_cache=(self.shape.quant_format == "indexer_mxfp4"),
+            rms_norm_weight=self.rms_weight,
+            rms_norm_eps=RMS_EPS,
+            quant_block=self.shape.quant_block,
+            token_stride=self.shape.token_stride,
+            scale_dim=self.shape.scale_dim,
+        )
+
+
+def _mk(shape, name, pos, t2r, slot, max_pos) -> CompressorContext:
+    kvs, b = [], 0
+    for p in pos:
+        if (p + 1) % shape.ratio == 0:
+            kvs.append(b)
+            b += 1
+        else:
+            kvs.append(-1)
+    return CompressorContext(name, name, shape, pos, t2r, slot, kvs, max_pos)
+
+
+def _prefill(shape, name, seqlen):
+    return _mk(
+        shape, name, list(range(seqlen)), [0] * seqlen, list(range(seqlen)), seqlen
+    )
+
+
+def _chunked(shape, name, offset, length):
+    pos = list(range(offset, offset + length))
+    return _mk(shape, name, pos, [0] * length, list(pos), offset + length)
+
+
+def _multi(shape, name, lengths):
+    P, T, S = [], [], []
+    ml = max(lengths)
+    for bi, L in enumerate(lengths):
+        for p in range(L):
+            P.append(p)
+            T.append(bi)
+            S.append(bi * ml + p)
+    return _mk(shape, name, P, T, S, ml)
+
+
+def _decode(shape, name, positions, ctx_len=4096):
+    P, T, S = [], [], []
+    for bi, mp in enumerate(positions):
+        for p in range(mp + 1):
+            P.append(p)
+            T.append(bi)
+            S.append(bi * ctx_len + p)
+    return _mk(shape, name, P, T, S, ctx_len)
+
+
+def _padded(shape, name, seqlen, num_pad):
+    pos = list(range(seqlen)) + [0] * num_pad
+    t2r = [0] * (seqlen + num_pad)
+    slot = list(range(seqlen)) + [-1] * num_pad
+    return _mk(shape, name, pos, t2r, slot, seqlen)
+
+
+def all_scenarios(shape) -> list[CompressorContext]:
+    s = []
+    s.append(_decode(shape, "decode_boundary", [127, 255, 383, 511]))
+    s.append(_decode(shape, "decode_mixed", [127, 255, 200, 383]))
+    for seqlen in [128, 256, 512, 1024, 4096, 16384, 32768]:
+        s.append(_prefill(shape, f"prefill_{seqlen}", seqlen))
+    for seqlen in [257, 1025, 4097]:
+        s.append(_prefill(shape, f"prefill_tail_{seqlen}", seqlen))
+    s.append(_chunked(shape, "chunked_100", 100, 1024))
+    s.append(_chunked(shape, "chunked_4096", 4096, 4096))
+    s.append(_multi(shape, "multi_2", [256, 512]))
+    s.append(_multi(shape, "multi_3", [257, 1024, 384]))
+    s.append(_padded(shape, "padded", 256, 4))
+    return s
+
+
+SCENARIO_NAMES = [c.name for c in all_scenarios(CSA_MAIN)]
+
+
+def build_scenario(shape, name) -> CompressorContext:
+    for c in all_scenarios(shape):
+        if c.name == name:
+            return c
+    raise KeyError(f"unknown scenario {name!r}; available: {SCENARIO_NAMES}")
+
+
+def build_shared_input(ctx: CompressorContext) -> None:
+    """Build equivalent BF16 HIP and APE-expanded FP32 Triton inputs."""
+    from vllm.models.deepseek_v4.common.ops.save_partial_states import (
+        save_partial_states,
+    )
+
+    shape = ctx.shape
+    sw = shape.state_width
+    ratio = shape.ratio
+    sbs = shape.state_block_size
+
+    window_depth = (2 if shape.overlap else 1) * ratio - 1
+    req_min: dict[int, int] = {}
+    present: set[tuple[int, int]] = set()
+    for r, p, sl in zip(ctx.token_to_req, ctx.positions, ctx.slot_mapping):
+        if sl < 0:
+            continue
+        present.add((r, p))
+        req_min[r] = min(req_min.get(r, p), p)
+    lb_pos, lb_slot, lb_req = [], [], []
+    for r, mn in req_min.items():
+        for p in range(max(0, mn - window_depth), mn):
+            if (r, p) in present:
+                continue
+            lb_pos.append(p)
+            lb_slot.append(p)
+            lb_req.append(r)
+
+    bf16 = torch.zeros(ctx.max_state_blocks, sbs, 2 * sw, dtype=torch.bfloat16)
+    save_partial_states(
+        kv=ctx._raw["kv"],
+        score=ctx._raw["score"],
+        ape=None,
+        positions=ctx.positions_t,
+        state_cache=bf16,
+        slot_mapping=ctx.slot_mapping_t,
+        block_size=sbs,
+        state_width=sw,
+        compress_ratio=ratio,
+    )
+    if lb_pos:
+        g = torch.Generator(device="cuda").manual_seed(20240611 + ctx.num_tokens)
+        n_lb = len(lb_pos)
+        lb_kv = (
+            torch.randn(
+                n_lb, shape.coff * shape.head_dim, dtype=torch.bfloat16, generator=g
+            )
+            * 0.5
+        )
+        lb_score = (
+            torch.randn(
+                n_lb, shape.coff * shape.head_dim, dtype=torch.bfloat16, generator=g
+            )
+            * 0.5
+        )
+        save_partial_states(
+            kv=lb_kv,
+            score=lb_score,
+            ape=None,
+            positions=torch.tensor(lb_pos, dtype=torch.int64),
+            state_cache=bf16,
+            slot_mapping=torch.tensor(lb_slot, dtype=torch.int64),
+            block_size=sbs,
+            state_width=sw,
+            compress_ratio=ratio,
+        )
+        for r, p, sl in zip(lb_req, lb_pos, lb_slot):
+            ctx.block_table[r, p // sbs] = sl // sbs
+    ctx.state_cache_bf16 = bf16
+
+    fp32 = bf16.float()
+    ape = ctx.ape  # [ratio, 2*head_dim] fp32 (== sw)
+    for p, sl in list(zip(ctx.positions, ctx.slot_mapping)) + list(
+        zip(lb_pos, lb_slot)
+    ):
+        if sl < 0:
+            continue
+        blk, off = sl // sbs, sl % sbs
+        fp32[blk, off, sw : 2 * sw] += ape[p % ratio]
+    ctx.state_cache_fp32 = fp32
+
+
+def hip_available() -> bool:
+    try:
+        import vllm._rocm_C  # noqa: F401
+
+        return hasattr(torch.ops._rocm_C, "dsv4_csa_compress")
+    except Exception:
+        return False
+
+
+def run_triton(ctx, kv_3d) -> None:
+    from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+        compress_norm_rope_store_triton,
+    )
+
+    compress_norm_rope_store_triton(
+        state_cache=ctx.state_cache_fp32, kv_cache=kv_3d, **ctx.generic_kwargs()
+    )
+
+
+def run_hip(ctx, kv_3d) -> None:
+    s = ctx.shape
+    common = (
+        ctx.state_cache_bf16,
+        ctx.num_tokens,
+        ctx.ape,
+        ctx.token_to_req_t,
+        ctx.positions_t,
+        ctx.slot_mapping_t,
+        ctx.block_table,
+        s.state_block_size,
+        ctx.rms_weight.to(torch.float32),
+        RMS_EPS,
+        ctx.cos_sin_cache,
+        kv_3d,
+        ctx.kv_slot_mapping_t,
+        kv_3d.shape[1],
+        s.scale_dim,
+    )
+    if s.head_dim == 128:
+        torch.ops._rocm_C.dsv4_indexer_compress(
+            *common, s.quant_format == "indexer_mxfp4"
+        )
+    elif s.ratio == 128:
+        plan_capacity = ctx.num_tokens // s.ratio + ctx.block_table.shape[0] + 2
+        plan_scratch = torch.empty(
+            plan_capacity, dtype=torch.int32, device=ctx.state_cache_bf16.device
+        )
+        counter_scratch = torch.empty(
+            1, dtype=torch.int32, device=ctx.state_cache_bf16.device
+        )
+        torch.ops._rocm_C.dsv4_hca_compress(*common, plan_scratch, counter_scratch)
+    else:
+        torch.ops._rocm_C.dsv4_csa_compress(*common)
+
+
+def _dequant_h512(buf, ci):
+    soff = KV_BLOCK_SIZE * H512_TOKEN_STRIDE
+    blk, p = ci // KV_BLOCK_SIZE, ci % KV_BLOCK_SIZE
+    base = p * H512_TOKEN_STRIDE
+    fp8 = buf[blk][base : base + H512_NOPE].view(torch.float8_e4m3fn).float()
+    sc = buf[blk][
+        soff + p * H512_SCALE_DIM : soff + p * H512_SCALE_DIM + H512_N_NOPE_BLOCKS
+    ]
+    out = torch.zeros(512)
+    for nb in range(H512_N_NOPE_BLOCKS):
+        e = sc[nb].int().item() - 127
+        out[nb * H512_QUANT_BLOCK : (nb + 1) * H512_QUANT_BLOCK] = fp8[
+            nb * H512_QUANT_BLOCK : (nb + 1) * H512_QUANT_BLOCK
+        ] * (2.0**e)
+    out[H512_NOPE:] = (
+        buf[blk][base + H512_NOPE : base + H512_TOKEN_STRIDE]
+        .view(torch.bfloat16)
+        .float()
+    )
+    return out
+
+
+def _dequant_indexer_fp8(buf, ci):
+    ts, sd = 128, 4
+    soff = KV_BLOCK_SIZE * ts
+    blk, p = ci // KV_BLOCK_SIZE, ci % KV_BLOCK_SIZE
+    base = p * ts
+    fp8 = buf[blk][base : base + 128].view(torch.float8_e4m3fn).float()
+    scale = buf[blk][soff + p * sd : soff + p * sd + 4].view(torch.float32)
+    return fp8 * scale
+
+
+def _dequant_indexer_mxfp4(buf, ci):
+    ts, sd = 64, 4
+    soff = KV_BLOCK_SIZE * ts
+    blk, p = ci // KV_BLOCK_SIZE, ci % KV_BLOCK_SIZE
+    base = p * ts
+    packed = buf[blk][base : base + ts].long()
+    sc = buf[blk][soff + p * sd : soff + p * sd + sd].long()
+    low = packed & 0xF
+    high = (packed >> 4) & 0xF
+    scale = (2.0 ** (sc.float() - 127.0)).repeat_interleave(ts // sd)
+    lut = E2M1_LUT.to(packed.device)
+    even = lut[low] * scale
+    odd = lut[high] * scale
+    return torch.stack([even, odd], dim=1).reshape(128)
+
+
+def _dequant_row(buf, ci, shape):
+    if shape.quant_format == "indexer_fp8":
+        return _dequant_indexer_fp8(buf, ci)
+    if shape.quant_format == "indexer_mxfp4":
+        return _dequant_indexer_mxfp4(buf, ci)
+    return _dequant_h512(buf, ci)
+
+
+def compare_to_triton(ref, hip, ctx) -> tuple:
+    shape = ctx.shape
+    nc = ctx.num_compress
+    byte_pct = (
+        ref.view(torch.uint8).int() == hip.view(torch.uint8).int()
+    ).float().mean().item() * 100
+    if shape.head_dim == 512:
+        nope_mean, rope_max = 0.0, 0.0
+        for ci in range(nc):
+            d = (_dequant_h512(ref, ci) - _dequant_h512(hip, ci)).abs()
+            nope_mean = max(nope_mean, d[:H512_NOPE].mean().item())
+            rope_max = max(rope_max, d[H512_NOPE:].max().item())
+        aligned = nope_mean < 5e-2 and rope_max < 5e-2
+        detail = (
+            f"byte%={byte_pct:.2f} nope_mean={nope_mean:.5f} rope_max={rope_max:.4f}"
+        )
+    else:
+        dmean = 0.0
+        for ci in range(nc):
+            d = (_dequant_row(ref, ci, shape) - _dequant_row(hip, ci, shape)).abs()
+            dmean = max(dmean, d.mean().item())
+        aligned = dmean < 1e-2
+        detail = f"byte%={byte_pct:.2f} dmean={dmean:.5f}"
+    return aligned, detail
+
+
+def _torch_indexer_row(ctx, P, r) -> torch.Tensor:
+    sbs = ctx.shape.state_block_size
+    state = ctx.state_cache_bf16.float()
+    HEAD, SW = 128, 256
+    ape = ctx.ape
+    kv_l, sc_l, valid = [], [], []
+    for k in range(8):
+        pk = P - 7 + k
+        ho = 128 if k >= 4 else 0
+        if pk < 0:
+            valid.append(False)
+            kv_l.append(torch.zeros(HEAD))
+            sc_l.append(torch.zeros(HEAD))
+            continue
+        valid.append(True)
+        blk = int(ctx.block_table[r, pk // sbs].item())
+        off = pk % sbs
+        kv_l.append(state[blk, off, ho : ho + HEAD])
+        sc_l.append(
+            state[blk, off, SW + ho : SW + ho + HEAD] + ape[k % 4, ho : ho + HEAD]
+        )
+    KV = torch.stack(kv_l)
+    SC = torch.stack(sc_l)
+    mask = torch.tensor(valid, device=KV.device).view(8, 1)
+    SC = torch.where(mask, SC, torch.full_like(SC, -float("inf")))
+    w = torch.softmax(SC, dim=0)
+    comp = (w * KV).sum(0)
+    var = (comp * comp).mean()
+    normed = comp * torch.rsqrt(var + RMS_EPS) * ctx.rms_weight.float()
+    cs = ctx.cos_sin_cache[(P // 4) * 4]
+    out = normed.clone()
+    idx = torch.arange(32, device=out.device)
+    e = normed[64::2]
+    o = normed[65::2]
+    cos_v = cs[idx]
+    sin_v = cs[32 + idx]
+    out[64::2] = e * cos_v - o * sin_v
+    out[65::2] = o * cos_v + e * sin_v
+    return out
+
+
+def _torch_mxfp4_dequant(row: torch.Tensor) -> torch.Tensor:
+    HEAD = 128
+    mag = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], device=row.device)
+    odd_pen = torch.tensor([0.0, 1, 0, 1, 0, 1, 0, 1], device=row.device) * 1e-6
+    even = row[0::2].bfloat16().float()
+    odd = row[1::2].bfloat16().float()
+    out = torch.zeros(HEAD, device=row.device)
+
+    def _q(x, log2r):
+        s = x.sign()
+        xs = (x.abs() * (2.0**-log2r)).unsqueeze(-1)
+        idx = ((xs - mag).abs() + odd_pen).argmin(-1)
+        return s * mag[idx] * (2.0**log2r)
+
+    for b in range(4):
+        e = even[b * 16 : (b + 1) * 16]
+        o = odd[b * 16 : (b + 1) * 16]
+        amax = max(e.abs().max().item(), o.abs().max().item(), 6.0 * 2**-126)
+        log2r = min(max(math.ceil(math.log2(amax / 6.0)), -127), 127)
+        out[b * 32 : b * 32 + 32 : 2] = _q(e, log2r)
+        out[b * 32 + 1 : b * 32 + 32 : 2] = _q(o, log2r)
+    return out
+
+
+def mxfp4_oracle_diff(ctx, hip_cpu, max_check=512) -> float:
+    nc = ctx.num_compress
+    bnd = [
+        (p, r)
+        for p, r, ks in zip(ctx.positions, ctx.token_to_req, ctx.kv_slot_mapping)
+        if ks >= 0
+    ]
+    dmean = 0.0
+    for ci in range(min(nc, max_check)):
+        P, r = bnd[ci]
+        exp = _torch_mxfp4_dequant(_torch_indexer_row(ctx, P, r))
+        act = _dequant_indexer_mxfp4(hip_cpu, ci).cuda()
+        dmean = max(dmean, (exp - act).abs().mean().item())
+    return dmean

--- a/tests/kernels/attention/test_dsv4_compress.py
+++ b/tests/kernels/attention/test_dsv4_compress.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek-V4 fused HIP compressor tests."""
+
+import pytest
+import torch
+
+from tests.kernels.attention.dsv4_compress_utils import (
+    BYTE_EXACT_SHAPES,
+    H512_NOPE,
+    H512_TOKEN_STRIDE,
+    KV_BLOCK_SIZE,
+    SCENARIO_NAMES,
+    build_scenario,
+    build_shared_input,
+    compare_to_triton,
+    detect_gfx942,
+    hip_available,
+    run_hip,
+    run_triton,
+)
+
+pytestmark = pytest.mark.skipif(
+    not detect_gfx942(), reason="DSV4 fused compressor requires gfx942"
+)
+
+
+@pytest.fixture(autouse=True)
+def _default_cuda_device():
+    torch.set_default_device("cuda")
+    yield
+    torch.set_default_device("cpu")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_ops():
+    assert hip_available(), "dsv4 compressor ops not registered in _rocm_C on gfx942"
+
+
+def _native_op_and_args(ctx, kv_3d):
+    shape = ctx.shape
+    args = [
+        ctx.state_cache_bf16,
+        ctx.num_tokens,
+        ctx.ape,
+        ctx.token_to_req_t,
+        ctx.positions_t,
+        ctx.slot_mapping_t,
+        ctx.block_table,
+        shape.state_block_size,
+        ctx.rms_weight.to(torch.float32),
+        1e-6,
+        ctx.cos_sin_cache,
+        kv_3d,
+        ctx.kv_slot_mapping_t,
+        kv_3d.shape[1],
+        shape.scale_dim,
+    ]
+    if shape.ratio == 128:
+        plan_capacity = ctx.num_tokens // shape.ratio + ctx.block_table.shape[0] + 2
+        args.extend(
+            [
+                torch.empty(plan_capacity, dtype=torch.int32),
+                torch.empty(1, dtype=torch.int32),
+            ]
+        )
+        return torch.ops._rocm_C.dsv4_hca_compress, args
+    return torch.ops._rocm_C.dsv4_csa_compress, args
+
+
+@pytest.mark.parametrize("shape", BYTE_EXACT_SHAPES, ids=lambda s: s.label)
+@pytest.mark.parametrize("scenario", SCENARIO_NAMES)
+def test_compress_matches_triton(shape, scenario):
+    ctx = build_scenario(shape, scenario)
+    ctx.build()
+    build_shared_input(ctx)
+
+    ref_flat, ref_3d = ctx.new_kv_cache()
+    run_triton(ctx, ref_3d)
+    torch.accelerator.synchronize()
+
+    hip_flat, hip_3d = ctx.new_kv_cache()
+    run_hip(ctx, hip_3d)
+    torch.accelerator.synchronize()
+
+    aligned, detail = compare_to_triton(ref_flat.cpu(), hip_flat.cpu(), ctx)
+    assert aligned, (
+        f"{shape.label}/{scenario}: {detail} (expected reference-equivalent)"
+    )
+
+
+@pytest.mark.parametrize("shape", BYTE_EXACT_SHAPES, ids=lambda s: s.label)
+@pytest.mark.parametrize(
+    "weight",
+    [0.0, -0.0, float("nan"), -float("nan")],
+    ids=["positive_zero", "negative_zero", "positive_nan", "negative_nan"],
+)
+def test_native_ocp_transform_edge_values(shape, weight):
+    ctx = build_scenario(shape, "prefill_256")
+    ctx.build()
+    build_shared_input(ctx)
+    ctx.rms_weight.fill_(weight)
+
+    ref_flat, ref_3d = ctx.new_kv_cache()
+    run_triton(ctx, ref_3d)
+    hip_flat, hip_3d = ctx.new_kv_cache()
+    run_hip(ctx, hip_3d)
+    torch.accelerator.synchronize()
+
+    aligned, detail = compare_to_triton(ref_flat.cpu(), hip_flat.cpu(), ctx)
+    for ci in range(ctx.num_compress):
+        block, offset = divmod(ci, KV_BLOCK_SIZE)
+        base = offset * H512_TOKEN_STRIDE
+        encoded = hip_flat[block, base : base + H512_NOPE]
+        if weight == weight:
+            expected = ref_flat[block, base : base + H512_NOPE]
+            assert torch.equal(encoded, expected), (
+                f"{shape.label}/{weight}: OCP zero bytes differ: {detail}"
+            )
+        else:
+            assert set(encoded.cpu().tolist()) == {0x7F}
+    assert aligned or weight != 0.0, f"{shape.label}/{weight}: {detail}"
+
+
+@pytest.mark.parametrize("shape", BYTE_EXACT_SHAPES, ids=lambda s: s.label)
+@pytest.mark.parametrize(
+    "invalid",
+    ["negative_count", "short_metadata", "cpu_input", "block_table", "kv_layout"],
+)
+def test_native_wrapper_rejects_invalid_inputs(shape, invalid):
+    ctx = build_scenario(shape, "prefill_256")
+    ctx.build()
+    build_shared_input(ctx)
+    _, kv_3d = ctx.new_kv_cache()
+    op, args = _native_op_and_args(ctx, kv_3d)
+    if invalid == "negative_count":
+        args[1] = -1
+    elif invalid == "short_metadata":
+        args[4] = ctx.positions_t[:-1]
+    elif invalid == "cpu_input":
+        args[2] = ctx.ape.cpu()
+    elif invalid == "block_table":
+        args[6] = ctx.block_table.T
+    else:
+        args[11] = kv_3d[:, :, :H512_TOKEN_STRIDE]
+
+    with pytest.raises(RuntimeError):
+        op(*args)
+
+
+@pytest.mark.parametrize("shape", BYTE_EXACT_SHAPES, ids=lambda s: s.label)
+def test_native_compressor_graph_replay(shape):
+    ctx = build_scenario(shape, "prefill_256")
+    ctx.build()
+    build_shared_input(ctx)
+    _, kv_3d = ctx.new_kv_cache()
+    op, args = _native_op_and_args(ctx, kv_3d)
+
+    op(*args)
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        op(*args)
+    torch.accelerator.synchronize()
+    expected = kv_3d.clone()
+
+    kv_3d.zero_()
+    graph.replay()
+    torch.accelerator.synchronize()
+    assert torch.equal(kv_3d, expected)

--- a/tests/kernels/attention/test_dsv4_compress_arch_guard.py
+++ b/tests/kernels/attention/test_dsv4_compress_arch_guard.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Architecture and opt-in gating for the gfx942 compressor ops."""
+
+import torch
+
+from tests.kernels.attention.dsv4_compress_utils import detect_gfx942
+from vllm.models.deepseek_v4.amd.ops import hip_compress_dispatch as dispatch
+from vllm.models.deepseek_v4.amd.ops.hip_compress_dispatch import (
+    SUPPORTED_SHAPES,
+    hip_compressor_enabled,
+    hip_compressor_selected,
+    hip_compressor_supported,
+)
+
+
+def test_compressor_opt_in(monkeypatch):
+    monkeypatch.setenv("VLLM_ROCM_DSV4_HIP_COMPRESSOR", "0")
+    assert not hip_compressor_selected(512, 4)
+    monkeypatch.setenv("VLLM_ROCM_DSV4_HIP_COMPRESSOR", "1")
+    assert hip_compressor_selected(512, 4)
+    assert hip_compressor_selected(512, 128)
+    assert not hip_compressor_selected(128, 4)
+
+
+def test_compressor_construction_gates(monkeypatch):
+    monkeypatch.setenv("VLLM_ROCM_DSV4_HIP_COMPRESSOR", "1")
+    monkeypatch.setattr(dispatch, "hip_compressor_available", lambda *_: True)
+
+    assert hip_compressor_enabled(512, 64, 4, "fp8_ds_mla")
+    assert not hip_compressor_enabled(512, 32, 4, "fp8_ds_mla")
+    assert not hip_compressor_enabled(512, 64, 4, "fp8")
+
+    monkeypatch.setattr(dispatch, "hip_compressor_available", lambda *_: False)
+    assert not hip_compressor_enabled(512, 64, 4, "fp8_ds_mla")
+
+
+def test_compressor_gated_on_gfx942():
+    on = detect_gfx942()
+    if on:
+        import vllm._rocm_C  # noqa: F401  (ensure the ops are registered)
+
+    u8 = torch.empty(1, 16, dtype=torch.uint8)
+
+    for head_dim, ratio in SUPPORTED_SHAPES:
+        assert hip_compressor_supported(head_dim, ratio, u8) == on
+
+    assert not hip_compressor_supported(128, 4, u8)
+    assert not hip_compressor_supported(256, 4, u8)
+    bf16 = torch.empty(1, 16, dtype=torch.bfloat16)
+    assert not hip_compressor_supported(512, 4, bf16)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -133,6 +133,7 @@ if TYPE_CHECKING:
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
     VLLM_ROCM_USE_AITER: bool = False
+    VLLM_ROCM_DSV4_HIP_COMPRESSOR: bool = False
     VLLM_ROCM_USE_AITER_CUSTOM_AR: bool = True
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
     VLLM_ROCM_USE_AITER_LINEAR_HIPBMM: bool = False
@@ -1256,6 +1257,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_ROCM_USE_AITER": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER", "False").lower() in ("true", "1")
+    ),
+    # Opt in to the gfx942 DeepSeek-V4 CSA/HCA HIP compressor.
+    "VLLM_ROCM_DSV4_HIP_COMPRESSOR": lambda: (
+        os.getenv("VLLM_ROCM_DSV4_HIP_COMPRESSOR", "False").lower() in ("true", "1")
     ),
     # Use AITER's CustomAllreduce as the custom-allreduce backend inside vLLM's
     # CudaCommunicator on ROCm.

--- a/vllm/models/deepseek_v4/amd/ops/dsv4_compress_common.cuh
+++ b/vllm/models/deepseek_v4/amd/ops/dsv4_compress_common.cuh
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cmath>
+#include <cstdint>
+
+// Scaling by 1/2 shifts gfx942's FNUZ encoding to the OCP cache format.
+#if defined(__HIPCC__) && defined(__gfx942__)
+  #define DSV4_GFX942
+#endif
+
+#if defined(DSV4_GFX942) || !defined(__HIP_DEVICE_COMPILE__)
+  #define DSV4_COMPILE_GFX942_BODY 1
+#endif
+
+namespace dsv4 {
+
+template <typename... Args>
+__host__ __device__ __forceinline__ void ignore_unused(const Args&...) {}
+
+constexpr int WARP_SIZE = 64;
+constexpr int HEAD_SIZE = 512;
+constexpr int ROPE_HEAD_DIM = 64;
+constexpr int NOPE_HEAD_DIM = HEAD_SIZE - ROPE_HEAD_DIM;
+constexpr int QUANT_BLOCK = 64;
+constexpr int N_NOPE_BLOCKS = NOPE_HEAD_DIM / QUANT_BLOCK;
+constexpr int TOKEN_STRIDE = NOPE_HEAD_DIM + ROPE_HEAD_DIM * 2;
+constexpr int DIMS_PER_LANE = HEAD_SIZE / WARP_SIZE;
+constexpr float FP8_MAX = 448.0f;
+constexpr float INV_FP8_MAX = 1.0f / FP8_MAX;
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+#pragma unroll
+  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+    val += __shfl_xor(val, offset);
+  }
+  return val;
+}
+
+__device__ __forceinline__ float load_rms_norm_weight(
+    const float* __restrict__ rms_norm_weight, int idx) {
+  return rms_norm_weight[idx];
+}
+
+__device__ __forceinline__ float load_rms_norm_weight(
+    const __hip_bfloat16* __restrict__ rms_norm_weight, int idx) {
+  return __bfloat162float(rms_norm_weight[idx]);
+}
+
+// Must be called by all 64 lanes of one wave.
+template <typename WeightT>
+__device__ __forceinline__ void write_output_512(
+    float comp[DIMS_PER_LANE], int lane_id, int dim_base, int64_t position,
+    int64_t kv_slot_idx, int ratio, const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps, const float* __restrict__ cos_sin_cache,
+    int64_t cos_sin_stride, uint8_t* __restrict__ kv_cache,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+  float sq = 0.0f;
+  #pragma unroll
+  for (int d = 0; d < DIMS_PER_LANE; d++) sq += comp[d] * comp[d];
+  float variance = warp_reduce_sum(sq) / HEAD_SIZE;
+  float rrms = rsqrtf(variance + rms_norm_eps);
+
+  float normed[DIMS_PER_LANE];
+  #pragma unroll
+  for (int d = 0; d < DIMS_PER_LANE; d++) {
+    float w = load_rms_norm_weight(rms_norm_weight, dim_base + d);
+    normed[d] = comp[d] * rrms * w;
+  }
+
+  int64_t kv_blk_idx = kv_slot_idx / kv_cache_block_size;
+  int64_t kv_pos = kv_slot_idx % kv_cache_block_size;
+  uint8_t* cache_block = kv_cache + kv_blk_idx * kv_block_stride;
+  uint8_t* fp8_ptr = cache_block + kv_pos * TOKEN_STRIDE;
+  uint8_t* scale_ptr =
+      cache_block + kv_cache_block_size * TOKEN_STRIDE + kv_pos * scale_dim;
+
+  // BF16 roundtrip for parity with the fused Triton path.
+  float quant[DIMS_PER_LANE];
+  #pragma unroll
+  for (int d = 0; d < DIMS_PER_LANE; d++) {
+    quant[d] = __bfloat162float(__float2bfloat16(normed[d]));
+  }
+
+  if (dim_base < NOPE_HEAD_DIM) {
+    float local_max = 0.0f;
+  #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+      local_max = fmaxf(local_max, fabsf(quant[d]));
+    }
+    float rmax = local_max;
+    rmax = fmaxf(rmax, __shfl_xor(rmax, 4));
+    rmax = fmaxf(rmax, __shfl_xor(rmax, 2));
+    rmax = fmaxf(rmax, __shfl_xor(rmax, 1));
+    float blk_max = fmaxf(rmax, 1e-4f);
+
+    float raw_scale = blk_max * INV_FP8_MAX;
+    float exponent = ceilf(log2f(raw_scale));
+    float inv_scale = exp2f(-exponent);
+    int enc_scale = (int)(exponent + 127.0f);
+    enc_scale = max(0, min(255, enc_scale));
+
+    uint32_t words[2];
+  #pragma unroll
+    for (int p = 0; p < 2; p++) {
+      int b = p * 4;
+      float values[4];
+  #pragma unroll
+      for (int i = 0; i < 4; i++) {
+        values[i] = quant[b + i] * inv_scale;
+      }
+      int w = 0;
+      constexpr float OCP_TO_FNUZ = 0.5f;
+      w = __builtin_amdgcn_cvt_pk_fp8_f32(values[0] * OCP_TO_FNUZ,
+                                          values[1] * OCP_TO_FNUZ, w, false);
+      w = __builtin_amdgcn_cvt_pk_fp8_f32(values[2] * OCP_TO_FNUZ,
+                                          values[3] * OCP_TO_FNUZ, w, true);
+      // FNUZ reserves 0x80 for NaN and lacks signed zero.
+      uint32_t magnitude_bytes = static_cast<uint32_t>(w) & 0x7f7f7f7fu;
+      uint32_t zero_bytes =
+          (magnitude_bytes - 0x01010101u) & ~magnitude_bytes & 0x80808080u;
+      if (__builtin_expect(zero_bytes != 0, 0)) {
+  #pragma unroll
+        for (int i = 0; i < 4; i++) {
+          uint32_t shift = static_cast<uint32_t>(i * 8);
+          uint32_t encoded = (static_cast<uint32_t>(w) >> shift) & 0xffu;
+          if ((encoded & 0x7fu) != 0) continue;
+          uint32_t bits = __float_as_uint(values[i]);
+          uint32_t abs_bits = bits & 0x7fffffffu;
+          uint32_t byte;
+          if (abs_bits == 0 || encoded == 0) {
+            byte = bits >> 31 ? 0x80 : 0x00;  // signed zero or underflow
+          } else if (abs_bits > 0x7f800000u) {
+            byte = 0x7f;  // canonical OCP E4M3 NaN
+          } else {
+            byte = (bits >> 31) ? 0xfe : 0x7e;  // saturated finite
+          }
+          w = (w & ~(0xffu << shift)) | (byte << shift);
+        }
+      }
+      words[p] = static_cast<uint32_t>(w);
+    }
+    *reinterpret_cast<uint64_t*>(fp8_ptr + dim_base) =
+        static_cast<uint64_t>(words[0]) |
+        (static_cast<uint64_t>(words[1]) << 32);
+
+    int qb = dim_base / QUANT_BLOCK;
+    if ((lane_id % 8) == 0 && qb < N_NOPE_BLOCKS) {
+      scale_ptr[qb] = (uint8_t)enc_scale;
+    }
+  }
+
+  if (lane_id == 0) {
+    scale_ptr[N_NOPE_BLOCKS] = 0;  // padding scale
+  }
+
+  if (dim_base >= NOPE_HEAD_DIM) {
+    __hip_bfloat16* bf16_out =
+        reinterpret_cast<__hip_bfloat16*>(fp8_ptr + NOPE_HEAD_DIM);
+    int64_t comp_pos = position & (~(int64_t)(ratio - 1));
+    const float* cs = cos_sin_cache + comp_pos * cos_sin_stride;
+  #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d += 2) {
+      int rope_local = (dim_base - NOPE_HEAD_DIM) + d;
+      int cs_idx = rope_local / 2;
+      float cos_v = cs[cs_idx];
+      float sin_v = cs[ROPE_HEAD_DIM / 2 + cs_idx];
+      float e = normed[d], o = normed[d + 1];
+      bf16_out[rope_local] = __float2bfloat16(e * cos_v - o * sin_v);
+      bf16_out[rope_local + 1] = __float2bfloat16(o * cos_v + e * sin_v);
+    }
+  }
+#else
+  ignore_unused(comp, lane_id, dim_base, position, kv_slot_idx, ratio,
+                rms_norm_weight, rms_norm_eps, cos_sin_cache, cos_sin_stride,
+                kv_cache, kv_cache_block_size, kv_block_stride, scale_dim);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+}  // namespace dsv4

--- a/vllm/models/deepseek_v4/amd/ops/dsv4_compress_ops.hip
+++ b/vllm/models/deepseek_v4/amd/ops/dsv4_compress_ops.hip
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <torch/all.h>
+#include <ATen/hip/HIPContext.h>
+#include <c10/hip/HIPGuard.h>
+#include <limits>
+
+#include "rocm/ops.h"
+
+#ifdef VLLM_ROCM_GFX942
+
+extern "C" void launch_csa_compress(
+    int num_tokens,
+    const void* state_cache, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream);
+
+extern "C" void launch_hca_compress_plan(
+    int num_tokens, int nw_select,
+    const void* state_cache, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    int32_t* plan, int32_t* counter, int plan_capacity, void* stream);
+
+extern "C" void launch_hca_compress_nw(
+    int num_tokens, int nw_select,
+    const void* state_cache, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream);
+
+namespace {
+bool is_supported_rms_weight_dtype(const torch::Tensor& w) {
+  return w.dtype() == torch::kBFloat16 || w.dtype() == torch::kFloat32;
+}
+}  // namespace
+
+void dsv4_csa_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim) {
+  TORCH_CHECK(num_actual >= 0 &&
+                  num_actual <= std::numeric_limits<int32_t>::max(),
+              "num_actual must fit in a non-negative int32");
+  TORCH_CHECK(state_cache.dtype() == torch::kBFloat16, "state_cache must be bf16");
+  TORCH_CHECK(ape.dtype() == torch::kFloat32, "ape must be fp32");
+  TORCH_CHECK(is_supported_rms_weight_dtype(rms_norm_weight),
+              "rms_norm_weight must be bf16 or fp32");
+  TORCH_CHECK(ape.dim() == 2 && ape.size(0) == 4 && ape.size(1) == 1024,
+              "CSA expects contiguous RAW ape [4, 1024]");
+  TORCH_CHECK(ape.stride(1) == 1, "CSA ape innermost dimension must be contiguous");
+  TORCH_CHECK(block_size == 4, "CSA state-cache block size must be 4");
+  TORCH_CHECK(scale_dim == 8, "CSA packed-cache scale dimension must be 8");
+  TORCH_CHECK(state_cache.dim() == 3 && state_cache.size(2) == 2048 &&
+                  state_cache.stride(2) == 1,
+              "CSA state_cache must have contiguous rows of width 2048");
+  TORCH_CHECK(rms_norm_weight.numel() == 512,
+              "CSA rms_norm_weight must contain 512 elements");
+  TORCH_CHECK(cos_sin_cache.dtype() == torch::kFloat32 &&
+                  cos_sin_cache.dim() == 2 && cos_sin_cache.size(1) == 64,
+              "CSA cos_sin_cache must be fp32 [max_position, 64]");
+  TORCH_CHECK(kv_cache.dtype() == torch::kUInt8 && kv_cache.dim() == 3,
+              "CSA kv_cache must use the 3D uint8 fp8_ds_mla layout");
+  TORCH_CHECK(token_to_req_indices.dtype() == torch::kInt32 &&
+                  positions.dtype() == torch::kInt64 &&
+                  slot_mapping.dtype() == torch::kInt64 &&
+                  block_table.dtype() == torch::kInt32 &&
+                  kv_slot_mapping.dtype() == torch::kInt64,
+              "CSA metadata tensors have unexpected dtypes");
+  TORCH_CHECK(token_to_req_indices.numel() >= num_actual &&
+                  positions.numel() >= num_actual &&
+                  slot_mapping.numel() >= num_actual &&
+                  kv_slot_mapping.numel() >= num_actual,
+              "CSA per-token metadata is shorter than num_actual");
+  TORCH_CHECK(block_table.dim() == 2 && block_table.stride(1) == 1,
+              "CSA block_table must be a row-contiguous 2D tensor");
+  TORCH_CHECK(rms_norm_weight.is_contiguous(),
+              "CSA rms_norm_weight must be contiguous");
+  TORCH_CHECK(cos_sin_cache.stride(1) == 1,
+              "CSA cos_sin_cache rows must be contiguous");
+  TORCH_CHECK(kv_cache.size(1) == kv_cache_block_size &&
+                  kv_cache.size(2) >= 584 && kv_cache.stride(2) == 1,
+              "CSA kv_cache has an invalid block size or packed-row layout");
+  for (const torch::Tensor* tensor :
+       {&ape, &token_to_req_indices, &positions, &slot_mapping, &block_table,
+        &rms_norm_weight, &cos_sin_cache, &kv_cache, &kv_slot_mapping}) {
+    TORCH_CHECK(tensor->device() == state_cache.device(),
+                "CSA inputs must be on the state_cache device");
+  }
+  if (num_actual == 0) return;
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(state_cache));
+  bool rms_norm_weight_is_bf16 = rms_norm_weight.dtype() == torch::kBFloat16;
+  launch_csa_compress(
+      static_cast<int>(num_actual), state_cache.data_ptr(),
+      state_cache.stride(0), state_cache.stride(1), ape.data_ptr<float>(),
+      ape.stride(0), token_to_req_indices.data_ptr<int32_t>(),
+      positions.data_ptr<int64_t>(), slot_mapping.data_ptr<int64_t>(),
+      block_table.data_ptr<int32_t>(), block_table.stride(0),
+      static_cast<int32_t>(block_size), rms_norm_weight.data_ptr(),
+      rms_norm_weight_is_bf16, static_cast<float>(rms_norm_eps),
+      cos_sin_cache.data_ptr<float>(),
+      cos_sin_cache.stride(0), kv_cache.data_ptr<uint8_t>(),
+      kv_slot_mapping.data_ptr<int64_t>(),
+      static_cast<int32_t>(kv_cache_block_size), kv_cache.stride(0),
+      static_cast<int32_t>(scale_dim),
+      at::cuda::getCurrentCUDAStream().stream());
+}
+
+void dsv4_hca_compress(torch::Tensor state_cache, int64_t num_actual,
+                       torch::Tensor ape, torch::Tensor token_to_req_indices,
+                       torch::Tensor positions, torch::Tensor slot_mapping,
+                       torch::Tensor block_table, int64_t block_size,
+                       torch::Tensor rms_norm_weight, double rms_norm_eps,
+                       torch::Tensor cos_sin_cache, torch::Tensor kv_cache,
+                       torch::Tensor kv_slot_mapping,
+                       int64_t kv_cache_block_size, int64_t scale_dim,
+                       torch::Tensor plan_scratch,
+                       torch::Tensor counter_scratch) {
+  TORCH_CHECK(num_actual >= 0 &&
+                  num_actual <= std::numeric_limits<int32_t>::max(),
+              "num_actual must fit in a non-negative int32");
+  TORCH_CHECK(state_cache.dtype() == torch::kBFloat16, "state_cache must be bf16");
+  TORCH_CHECK(ape.dtype() == torch::kFloat32, "ape must be fp32");
+  TORCH_CHECK(is_supported_rms_weight_dtype(rms_norm_weight),
+              "rms_norm_weight must be bf16 or fp32");
+  TORCH_CHECK(plan_scratch.dtype() == torch::kInt32,
+              "plan_scratch must be int32");
+  TORCH_CHECK(counter_scratch.dtype() == torch::kInt32,
+              "counter_scratch must be int32");
+  TORCH_CHECK(ape.dim() == 2 && ape.size(0) == 128 && ape.size(1) == 512,
+              "HCA expects contiguous RAW ape [128, 512]");
+  TORCH_CHECK(ape.stride(1) == 1, "HCA ape innermost dimension must be contiguous");
+  TORCH_CHECK(block_size == 8, "HCA state-cache block size must be 8");
+  TORCH_CHECK(scale_dim == 8, "HCA packed-cache scale dimension must be 8");
+  TORCH_CHECK(state_cache.dim() == 3 && state_cache.size(2) == 1024 &&
+                  state_cache.stride(2) == 1,
+              "HCA state_cache must have contiguous rows of width 1024");
+  TORCH_CHECK(rms_norm_weight.numel() == 512,
+              "HCA rms_norm_weight must contain 512 elements");
+  TORCH_CHECK(cos_sin_cache.dtype() == torch::kFloat32 &&
+                  cos_sin_cache.dim() == 2 && cos_sin_cache.size(1) == 64,
+              "HCA cos_sin_cache must be fp32 [max_position, 64]");
+  TORCH_CHECK(kv_cache.dtype() == torch::kUInt8 && kv_cache.dim() == 3,
+              "HCA kv_cache must use the 3D uint8 fp8_ds_mla layout");
+  TORCH_CHECK(token_to_req_indices.dtype() == torch::kInt32 &&
+                  positions.dtype() == torch::kInt64 &&
+                  slot_mapping.dtype() == torch::kInt64 &&
+                  block_table.dtype() == torch::kInt32 &&
+                  kv_slot_mapping.dtype() == torch::kInt64,
+              "HCA metadata tensors have unexpected dtypes");
+  TORCH_CHECK(token_to_req_indices.numel() >= num_actual &&
+                  positions.numel() >= num_actual &&
+                  slot_mapping.numel() >= num_actual &&
+                  kv_slot_mapping.numel() >= num_actual,
+              "HCA per-token metadata is shorter than num_actual");
+  TORCH_CHECK(block_table.dim() == 2 && block_table.stride(1) == 1,
+              "HCA block_table must be a row-contiguous 2D tensor");
+  TORCH_CHECK(rms_norm_weight.is_contiguous(),
+              "HCA rms_norm_weight must be contiguous");
+  TORCH_CHECK(cos_sin_cache.stride(1) == 1,
+              "HCA cos_sin_cache rows must be contiguous");
+  TORCH_CHECK(kv_cache.size(1) == kv_cache_block_size &&
+                  kv_cache.size(2) >= 584 && kv_cache.stride(2) == 1,
+              "HCA kv_cache has an invalid block size or packed-row layout");
+  for (const torch::Tensor* tensor :
+       {&ape, &token_to_req_indices, &positions, &slot_mapping, &block_table,
+        &rms_norm_weight, &cos_sin_cache, &kv_cache, &kv_slot_mapping,
+        &plan_scratch, &counter_scratch}) {
+    TORCH_CHECK(tensor->device() == state_cache.device(),
+                "HCA inputs must be on the state_cache device");
+  }
+  if (num_actual == 0) return;
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(state_cache));
+  bool rms_norm_weight_is_bf16 = rms_norm_weight.dtype() == torch::kBFloat16;
+
+  int64_t num_reqs = block_table.size(0);
+  int plan_capacity = static_cast<int>(num_actual / 128 + num_reqs + 2);
+  TORCH_CHECK(plan_scratch.device() == state_cache.device(),
+              "plan_scratch must be on the same device as state_cache");
+  TORCH_CHECK(counter_scratch.device() == state_cache.device(),
+              "counter_scratch must be on the same device as state_cache");
+  TORCH_CHECK(plan_scratch.numel() >= plan_capacity,
+              "plan_scratch is too small for HCA compact plan");
+  TORCH_CHECK(counter_scratch.numel() >= 1,
+              "counter_scratch must have at least one element");
+
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  if (num_actual <= 2048) {
+    launch_hca_compress_nw(
+        static_cast<int>(num_actual), /*nw_select=*/8, state_cache.data_ptr(),
+        state_cache.stride(0), state_cache.stride(1), ape.data_ptr<float>(),
+        ape.stride(0), token_to_req_indices.data_ptr<int32_t>(),
+        positions.data_ptr<int64_t>(), slot_mapping.data_ptr<int64_t>(),
+        block_table.data_ptr<int32_t>(), block_table.stride(0),
+        static_cast<int32_t>(block_size), rms_norm_weight.data_ptr(),
+        rms_norm_weight_is_bf16, static_cast<float>(rms_norm_eps),
+        cos_sin_cache.data_ptr<float>(), cos_sin_cache.stride(0),
+        kv_cache.data_ptr<uint8_t>(), kv_slot_mapping.data_ptr<int64_t>(),
+        static_cast<int32_t>(kv_cache_block_size), kv_cache.stride(0),
+        static_cast<int32_t>(scale_dim), stream);
+    return;
+  }
+
+  launch_hca_compress_plan(
+      static_cast<int>(num_actual), /*nw_select=*/0, state_cache.data_ptr(),
+      state_cache.stride(0), state_cache.stride(1), ape.data_ptr<float>(),
+      ape.stride(0), token_to_req_indices.data_ptr<int32_t>(),
+      positions.data_ptr<int64_t>(), slot_mapping.data_ptr<int64_t>(),
+      block_table.data_ptr<int32_t>(), block_table.stride(0),
+      static_cast<int32_t>(block_size), rms_norm_weight.data_ptr(),
+      rms_norm_weight_is_bf16, static_cast<float>(rms_norm_eps),
+      cos_sin_cache.data_ptr<float>(),
+      cos_sin_cache.stride(0), kv_cache.data_ptr<uint8_t>(),
+      kv_slot_mapping.data_ptr<int64_t>(),
+      static_cast<int32_t>(kv_cache_block_size), kv_cache.stride(0),
+      static_cast<int32_t>(scale_dim), plan_scratch.data_ptr<int32_t>(),
+      counter_scratch.data_ptr<int32_t>(), plan_capacity,
+      stream);
+}
+
+#endif  // VLLM_ROCM_GFX942

--- a/vllm/models/deepseek_v4/amd/ops/dsv4_csa_compress.hip
+++ b/vllm/models/deepseek_v4/amd/ops/dsv4_csa_compress.hip
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cmath>
+#include <cstdint>
+
+#include "dsv4_compress_common.cuh"
+using namespace dsv4;
+
+[[maybe_unused]] constexpr int K_POOL = 8;
+[[maybe_unused]] constexpr int STATE_WIDTH = 1024;
+[[maybe_unused]] constexpr int BLOCK_SIZE = 256;
+
+template <typename WeightT>
+__global__ void csa_compress_kernel(
+    int num_tokens,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0,
+    int64_t state_stride1,
+    const float* __restrict__ ape,
+    int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int32_t* __restrict__ block_table,
+    int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache,
+    int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache,
+    const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size,
+    int64_t kv_block_stride,
+    int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+    int wave_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int token_idx = blockIdx.x * (BLOCK_SIZE / WARP_SIZE) + wave_id;
+    if (token_idx >= num_tokens) return;
+
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    int64_t position = positions[token_idx];
+    if (((position + 1) & 3) != 0 || kv_slot_idx < 0) return;
+    int64_t slot_id = slot_mapping[token_idx];
+    if (slot_id < 0) return;
+
+    int32_t req_idx = token_to_req_indices[token_idx];
+    int64_t start_pos = position - (K_POOL - 1);
+    int dim_base = lane_id * DIMS_PER_LANE;
+
+    const __hip_bfloat16* row_ptrs[K_POOL];
+    bool valid_k[K_POOL];
+    #pragma unroll
+    for (int k = 0; k < K_POOL; k++) {
+        int64_t pos_k = start_pos + k;
+        if (pos_k < 0) {
+            valid_k[k] = false;
+            row_ptrs[k] = nullptr;
+            continue;
+        }
+        valid_k[k] = true;
+        int64_t blk_idx = pos_k / block_size;
+        int64_t blk_off = pos_k % block_size;
+        int32_t blk_num = block_table[req_idx * block_table_stride + blk_idx];
+        int head_offset = (k >= 4) ? HEAD_SIZE : 0;
+        row_ptrs[k] = state_cache + blk_num * state_stride0
+                    + blk_off * state_stride1 + head_offset;
+    }
+
+    float m[DIMS_PER_LANE], l[DIMS_PER_LANE], acc[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        m[d] = -INFINITY; l[d] = 0.0f; acc[d] = 0.0f;
+    }
+    #pragma unroll
+    for (int k = 0; k < K_POOL; k++) {
+        if (!valid_k[k]) continue;
+        union { float4 v; __hip_bfloat16 h[8]; } us, uk;
+        us.v = *reinterpret_cast<const float4*>(row_ptrs[k] + STATE_WIDTH + dim_base);
+        uk.v = *reinterpret_cast<const float4*>(row_ptrs[k] + dim_base);
+        const float* ape_ptr = ape + (int64_t)(k & 3) * ape_stride
+                             + ((k >= 4) ? HEAD_SIZE : 0) + dim_base;
+        #pragma unroll
+        for (int d = 0; d < DIMS_PER_LANE; d++) {
+            float s = __bfloat162float(us.h[d]) + ape_ptr[d];
+            float kvv = __bfloat162float(uk.h[d]);
+            float new_m = fmaxf(m[d], s);
+            float corr = __expf(m[d] - new_m);
+            float p = __expf(s - new_m);
+            l[d] = l[d] * corr + p;
+            acc[d] = acc[d] * corr + p * kvv;
+            m[d] = new_m;
+        }
+    }
+    float comp[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) comp[d] = acc[d] / l[d];
+
+    write_output_512(comp, lane_id, dim_base, position, kv_slot_idx, /*ratio=*/4,
+                     rms_norm_weight, rms_norm_eps,
+                     cos_sin_cache, cos_sin_stride, kv_cache, kv_cache_block_size,
+                     kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(num_tokens, state_cache, state_stride0, state_stride1,
+                        ape, ape_stride, token_to_req_indices, positions,
+                        slot_mapping, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_slot_mapping, kv_cache_block_size, kv_block_stride,
+                        scale_dim);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+extern "C" void launch_csa_compress(
+    int num_tokens,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices,
+    const int64_t* positions,
+    const int64_t* slot_mapping,
+    const int32_t* block_table, int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream_ptr
+) {
+    if (num_tokens == 0) return;
+
+    const __hip_bfloat16* state_cache = reinterpret_cast<const __hip_bfloat16*>(state_cache_ptr);
+    hipStream_t stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    constexpr int WAVES_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;
+    int num_blocks = (num_tokens + WAVES_PER_BLOCK - 1) / WAVES_PER_BLOCK;
+    dim3 grid(num_blocks);
+    dim3 block(BLOCK_SIZE);
+
+    #define CSA_FWD_ARGS \
+        num_tokens, state_cache, state_stride0, state_stride1, \
+        ape_raw, ape_stride, token_to_req_indices, positions, slot_mapping, \
+        block_table, block_table_stride, block_size, rms_norm_weight_t, \
+        rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache, kv_slot_mapping, \
+        kv_cache_block_size, kv_block_stride, scale_dim
+
+    if (rms_norm_weight_is_bf16) {
+        const __hip_bfloat16* rms_norm_weight_t =
+            reinterpret_cast<const __hip_bfloat16*>(rms_norm_weight);
+        hipLaunchKernelGGL((csa_compress_kernel<__hip_bfloat16>),
+                           grid, block, 0, stream, CSA_FWD_ARGS);
+    } else {
+        const float* rms_norm_weight_t =
+            reinterpret_cast<const float*>(rms_norm_weight);
+        hipLaunchKernelGGL((csa_compress_kernel<float>),
+                           grid, block, 0, stream, CSA_FWD_ARGS);
+    }
+    #undef CSA_FWD_ARGS
+}

--- a/vllm/models/deepseek_v4/amd/ops/dsv4_hca_compress.hip
+++ b/vllm/models/deepseek_v4/amd/ops/dsv4_hca_compress.hip
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cmath>
+#include <cstdint>
+
+#include "dsv4_compress_common.cuh"
+using namespace dsv4;
+
+[[maybe_unused]] constexpr int RATIO = 128;
+[[maybe_unused]] constexpr int K_POOL = RATIO;
+[[maybe_unused]] constexpr int STATE_WIDTH = HEAD_SIZE;
+[[maybe_unused]] constexpr int V0_BLOCK_SIZE = 256;
+
+__device__ __forceinline__ void hca_softmax_step(
+    int k, int64_t start_pos, int32_t req_idx,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size, const float* __restrict__ ape, int64_t ape_stride,
+    int dim_base, float m[DIMS_PER_LANE], float l[DIMS_PER_LANE],
+    float acc[DIMS_PER_LANE]
+) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+    int64_t pos_k = start_pos + k;
+    if (pos_k < 0) return;
+    int64_t blk_idx = pos_k / block_size;
+    int64_t blk_off = pos_k % block_size;
+    int32_t blk_num = block_table[req_idx * block_table_stride + blk_idx];
+    const __hip_bfloat16* row = state_cache + blk_num * state_stride0
+                              + blk_off * state_stride1;
+    union { float4 v; __hip_bfloat16 h[8]; } us, uk;
+    us.v = *reinterpret_cast<const float4*>(row + STATE_WIDTH + dim_base);
+    uk.v = *reinterpret_cast<const float4*>(row + dim_base);
+    const float* ape_ptr = ape + (int64_t)k * ape_stride + dim_base;
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        float s = __bfloat162float(us.h[d]) + ape_ptr[d];
+        float kvv = __bfloat162float(uk.h[d]);
+        float new_m = fmaxf(m[d], s);
+        float corr = __expf(m[d] - new_m);
+        float p = __expf(s - new_m);
+        l[d] = l[d] * corr + p;
+        acc[d] = acc[d] * corr + p * kvv;
+        m[d] = new_m;
+    }
+#else
+    dsv4::ignore_unused(k, start_pos, req_idx, state_cache, state_stride0,
+                        state_stride1, block_table, block_table_stride,
+                        block_size, ape, ape_stride, dim_base, m, l, acc);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+template <typename WeightT>
+__global__ void hca_compress_kernel(
+    int num_tokens,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+    int wave_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int token_idx = blockIdx.x * (V0_BLOCK_SIZE / WARP_SIZE) + wave_id;
+    if (token_idx >= num_tokens) return;
+
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    int64_t position = positions[token_idx];
+    if (((position + 1) & (RATIO - 1)) != 0 || kv_slot_idx < 0) return;
+    if (slot_mapping[token_idx] < 0) return;
+
+    int32_t req_idx = token_to_req_indices[token_idx];
+    int64_t start_pos = position - (K_POOL - 1);
+    int dim_base = lane_id * DIMS_PER_LANE;
+
+    float m[DIMS_PER_LANE], l[DIMS_PER_LANE], acc[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) { m[d] = -INFINITY; l[d] = 0.0f; acc[d] = 0.0f; }
+    for (int k = 0; k < K_POOL; k++) {
+        hca_softmax_step(k, start_pos, req_idx, state_cache, state_stride0,
+                         state_stride1, block_table, block_table_stride,
+                         block_size, ape, ape_stride, dim_base, m, l, acc);
+    }
+    float comp[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) comp[d] = acc[d] / l[d];
+
+    write_output_512(comp, lane_id, dim_base, position, kv_slot_idx, RATIO,
+                     rms_norm_weight, rms_norm_eps,
+                     cos_sin_cache, cos_sin_stride, kv_cache,
+                     kv_cache_block_size, kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(num_tokens, state_cache, state_stride0, state_stride1,
+                        ape, ape_stride, token_to_req_indices, positions,
+                        slot_mapping, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_slot_mapping, kv_cache_block_size, kv_block_stride,
+                        scale_dim);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+template <int NW, typename WeightT>
+__device__ __forceinline__ void hca_ksplit_body(
+    int token_idx, int64_t position, int64_t kv_slot_idx,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+    constexpr int K_PER_WAVE = K_POOL / NW;
+    int wid = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int dim_base = lane_id * DIMS_PER_LANE;
+    int32_t req_idx = token_to_req_indices[token_idx];
+    int64_t start_pos = position - (K_POOL - 1);
+
+    float m[DIMS_PER_LANE], l[DIMS_PER_LANE], acc[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) { m[d] = -INFINITY; l[d] = 0.0f; acc[d] = 0.0f; }
+    int k0 = wid * K_PER_WAVE;
+    #pragma unroll
+    for (int kk = 0; kk < K_PER_WAVE; kk++) {
+        hca_softmax_step(k0 + kk, start_pos, req_idx, state_cache, state_stride0,
+                         state_stride1, block_table, block_table_stride,
+                         block_size, ape, ape_stride, dim_base, m, l, acc);
+    }
+
+    __shared__ float sm[NW * HEAD_SIZE];
+    __shared__ float sl[NW * HEAD_SIZE];
+    __shared__ float sa[NW * HEAD_SIZE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        int idx = wid * HEAD_SIZE + dim_base + d;
+        sm[idx] = m[d]; sl[idx] = l[d]; sa[idx] = acc[d];
+    }
+    __syncthreads();
+    if (wid != 0) return;
+
+    float comp[DIMS_PER_LANE];
+    #pragma unroll
+    for (int d = 0; d < DIMS_PER_LANE; d++) {
+        int dd = dim_base + d;
+        float mg = -INFINITY;
+        #pragma unroll
+        for (int w = 0; w < NW; w++) mg = fmaxf(mg, sm[w * HEAD_SIZE + dd]);
+        float ls = 0.0f, as = 0.0f;
+        #pragma unroll
+        for (int w = 0; w < NW; w++) {
+            float sc = __expf(sm[w * HEAD_SIZE + dd] - mg);
+            ls += sl[w * HEAD_SIZE + dd] * sc;
+            as += sa[w * HEAD_SIZE + dd] * sc;
+        }
+        comp[d] = as / ls;
+    }
+    write_output_512(comp, lane_id, dim_base, position, kv_slot_idx, RATIO,
+                     rms_norm_weight, rms_norm_eps,
+                     cos_sin_cache, cos_sin_stride, kv_cache,
+                     kv_cache_block_size, kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(token_idx, position, kv_slot_idx, state_cache,
+                        state_stride0, state_stride1, ape, ape_stride,
+                        token_to_req_indices, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_cache_block_size, kv_block_stride, scale_dim);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+template <int NW, typename WeightT>
+__global__ void __launch_bounds__(WARP_SIZE * NW)
+hca_compress_ksplit_kernel(
+    int num_tokens,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+    int token_idx = blockIdx.x;
+    if (token_idx >= num_tokens) return;
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    int64_t position = positions[token_idx];
+    if (((position + 1) & (RATIO - 1)) != 0 || kv_slot_idx < 0) return;
+    if (slot_mapping[token_idx] < 0) return;
+    hca_ksplit_body<NW, WeightT>(token_idx, position, kv_slot_idx, state_cache,
+        state_stride0, state_stride1, ape, ape_stride, token_to_req_indices,
+        block_table, block_table_stride, block_size, rms_norm_weight,
+        rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache, kv_cache_block_size,
+        kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(num_tokens, state_cache, state_stride0, state_stride1,
+                        ape, ape_stride, token_to_req_indices, positions,
+                        slot_mapping, block_table, block_table_stride,
+                        block_size, rms_norm_weight, rms_norm_eps,
+                        cos_sin_cache, cos_sin_stride, kv_cache,
+                        kv_slot_mapping, kv_cache_block_size, kv_block_stride,
+                        scale_dim);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+extern "C" __global__ void hca_build_plan_kernel(
+    int num_tokens,
+    const int64_t* __restrict__ positions,
+    const int64_t* __restrict__ slot_mapping,
+    const int64_t* __restrict__ kv_slot_mapping,
+    int32_t* __restrict__ plan,
+    int32_t* __restrict__ counter
+) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= num_tokens) return;
+    int64_t kv_slot = kv_slot_mapping[t];
+    int64_t pos = positions[t];
+    if (((pos + 1) & (RATIO - 1)) != 0 || kv_slot < 0) return;
+    if (slot_mapping[t] < 0) return;
+    int slot = atomicAdd(counter, 1);
+    plan[slot] = t;
+#else
+    dsv4::ignore_unused(num_tokens, positions, slot_mapping, kv_slot_mapping,
+                        plan, counter);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+template <int NW, typename WeightT>
+__global__ void __launch_bounds__(WARP_SIZE * NW)
+hca_compress_plan_ksplit_kernel(
+    const int32_t* __restrict__ plan,
+    const __hip_bfloat16* __restrict__ state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* __restrict__ ape, int64_t ape_stride,
+    const int32_t* __restrict__ token_to_req_indices,
+    const int64_t* __restrict__ positions,
+    const int32_t* __restrict__ block_table, int64_t block_table_stride,
+    int32_t block_size,
+    const WeightT* __restrict__ rms_norm_weight,
+    float rms_norm_eps,
+    const float* __restrict__ cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* __restrict__ kv_cache, const int64_t* __restrict__ kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim
+) {
+#if defined(DSV4_COMPILE_GFX942_BODY)
+    int token_idx = plan[blockIdx.x];
+    if (token_idx < 0) return;
+    int64_t position = positions[token_idx];
+    int64_t kv_slot_idx = kv_slot_mapping[token_idx];
+    hca_ksplit_body<NW, WeightT>(token_idx, position, kv_slot_idx, state_cache,
+        state_stride0, state_stride1, ape, ape_stride, token_to_req_indices,
+        block_table, block_table_stride, block_size, rms_norm_weight,
+        rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache,
+        kv_cache_block_size, kv_block_stride, scale_dim);
+#else
+    dsv4::ignore_unused(plan, state_cache, state_stride0, state_stride1, ape,
+                        ape_stride, token_to_req_indices, positions,
+                        block_table, block_table_stride, block_size,
+                        rms_norm_weight, rms_norm_eps, cos_sin_cache,
+                        cos_sin_stride, kv_cache, kv_slot_mapping,
+                        kv_cache_block_size, kv_block_stride, scale_dim);
+#endif  // DSV4_COMPILE_GFX942_BODY
+}
+
+template <int NW, typename WeightT>
+static void ksplit_launch(
+    int num_tokens, const __hip_bfloat16* state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* ape, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const WeightT* rms_norm_weight,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    hipStream_t stream
+) {
+    dim3 grid(num_tokens);
+    dim3 block(WARP_SIZE * NW);
+    hipLaunchKernelGGL(
+        (hca_compress_ksplit_kernel<NW, WeightT>), grid, block, 0, stream,
+        num_tokens, state_cache, state_stride0, state_stride1,
+        ape, ape_stride, token_to_req_indices, positions, slot_mapping,
+        block_table, block_table_stride, block_size,
+        rms_norm_weight, rms_norm_eps,
+        cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim);
+}
+
+template <typename WeightT>
+static void v0_launch(
+    int num_tokens, const __hip_bfloat16* state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* ape, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const WeightT* rms_norm_weight,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    hipStream_t stream
+) {
+    int num_blocks = (num_tokens + (V0_BLOCK_SIZE / WARP_SIZE) - 1) / (V0_BLOCK_SIZE / WARP_SIZE);
+    hipLaunchKernelGGL(
+        (hca_compress_kernel<WeightT>), dim3(num_blocks), dim3(V0_BLOCK_SIZE), 0, stream,
+        num_tokens, state_cache, state_stride0, state_stride1,
+        ape, ape_stride, token_to_req_indices, positions, slot_mapping,
+        block_table, block_table_stride, block_size,
+        rms_norm_weight, rms_norm_eps,
+        cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim);
+}
+
+template <int NW, typename WeightT>
+static void plan_ksplit_launch(
+    int plan_capacity, const int32_t* plan, const __hip_bfloat16* state_cache,
+    int64_t state_stride0, int64_t state_stride1,
+    const float* ape, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int32_t* block_table, int64_t block_table_stride, int32_t block_size,
+    const WeightT* rms_norm_weight,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    hipStream_t stream
+) {
+    hipLaunchKernelGGL(
+        (hca_compress_plan_ksplit_kernel<NW, WeightT>),
+        dim3(plan_capacity), dim3(WARP_SIZE * NW),
+        0, stream, plan, state_cache, state_stride0, state_stride1,
+        ape, ape_stride, token_to_req_indices, positions,
+        block_table, block_table_stride, block_size,
+        rms_norm_weight, rms_norm_eps,
+        cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim);
+}
+
+#define HCA_FWD_ARGS \
+    state_cache, state_stride0, state_stride1, ape_raw, ape_stride, \
+    token_to_req_indices, positions, slot_mapping, block_table, \
+    block_table_stride, block_size, rms_norm_weight_t, rms_norm_eps, \
+    cos_sin_cache, cos_sin_stride, kv_cache, kv_slot_mapping, \
+    kv_cache_block_size, kv_block_stride, scale_dim, stream
+
+#define HCA_PLAN_ARGS \
+    state_cache, state_stride0, state_stride1, ape_raw, ape_stride, \
+    token_to_req_indices, positions, block_table, block_table_stride, block_size, \
+    rms_norm_weight_t, rms_norm_eps, cos_sin_cache, cos_sin_stride, kv_cache, \
+    kv_slot_mapping, kv_cache_block_size, kv_block_stride, scale_dim, stream
+
+extern "C" void launch_hca_compress_nw(
+    int num_tokens, int nw_select,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream_ptr
+) {
+    if (num_tokens == 0) return;
+    const __hip_bfloat16* state_cache =
+        reinterpret_cast<const __hip_bfloat16*>(state_cache_ptr);
+    hipStream_t stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    int nw = nw_select;
+    if (nw == 0) {
+        int est = num_tokens / RATIO;
+        nw = (est <= 64) ? 8 : 4;
+    }
+    if (rms_norm_weight_is_bf16) {
+        const __hip_bfloat16* rms_norm_weight_t =
+            reinterpret_cast<const __hip_bfloat16*>(rms_norm_weight);
+        switch (nw) {
+            case 8: ksplit_launch<8>(num_tokens, HCA_FWD_ARGS); break;
+            case 4: ksplit_launch<4>(num_tokens, HCA_FWD_ARGS); break;
+            case 2: ksplit_launch<2>(num_tokens, HCA_FWD_ARGS); break;
+            default: v0_launch(num_tokens, HCA_FWD_ARGS); break;
+        }
+    } else {
+        const float* rms_norm_weight_t =
+            reinterpret_cast<const float*>(rms_norm_weight);
+        switch (nw) {
+            case 8: ksplit_launch<8>(num_tokens, HCA_FWD_ARGS); break;
+            case 4: ksplit_launch<4>(num_tokens, HCA_FWD_ARGS); break;
+            case 2: ksplit_launch<2>(num_tokens, HCA_FWD_ARGS); break;
+            default: v0_launch(num_tokens, HCA_FWD_ARGS); break;
+        }
+    }
+}
+
+extern "C" void launch_hca_compress(
+    int num_tokens,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    void* stream_ptr
+) {
+    launch_hca_compress_nw(
+        num_tokens, 0, state_cache_ptr, state_stride0, state_stride1,
+        ape_raw, ape_stride, token_to_req_indices, positions, slot_mapping,
+        block_table, block_table_stride, block_size, rms_norm_weight,
+        rms_norm_weight_is_bf16, rms_norm_eps, cos_sin_cache, cos_sin_stride,
+        kv_cache, kv_slot_mapping,
+        kv_cache_block_size, kv_block_stride, scale_dim, stream_ptr);
+}
+
+extern "C" void launch_hca_compress_plan(
+    int num_tokens, int nw_select,
+    const void* state_cache_ptr, int64_t state_stride0, int64_t state_stride1,
+    const float* ape_raw, int64_t ape_stride,
+    const int32_t* token_to_req_indices, const int64_t* positions,
+    const int64_t* slot_mapping, const int32_t* block_table,
+    int64_t block_table_stride, int32_t block_size,
+    const void* rms_norm_weight, bool rms_norm_weight_is_bf16,
+    float rms_norm_eps,
+    const float* cos_sin_cache, int64_t cos_sin_stride,
+    uint8_t* kv_cache, const int64_t* kv_slot_mapping,
+    int32_t kv_cache_block_size, int64_t kv_block_stride, int32_t scale_dim,
+    int32_t* plan, int32_t* counter, int plan_capacity,
+    void* stream_ptr
+) {
+    if (num_tokens == 0) return;
+    const __hip_bfloat16* state_cache =
+        reinterpret_cast<const __hip_bfloat16*>(state_cache_ptr);
+    hipStream_t stream = reinterpret_cast<hipStream_t>(stream_ptr);
+
+    (void)hipMemsetAsync(counter, 0, sizeof(int32_t), stream);
+    (void)hipMemsetAsync(plan, 0xFF, (size_t)plan_capacity * sizeof(int32_t), stream);
+    int prep_blocks = (num_tokens + 255) / 256;
+    hipLaunchKernelGGL(hca_build_plan_kernel, dim3(prep_blocks), dim3(256), 0, stream,
+                       num_tokens, positions, slot_mapping, kv_slot_mapping, plan, counter);
+
+    // The non-monotonic crossover comes from 24 versus 48 KiB LDS occupancy.
+    int nw = nw_select;
+    if (nw == 0) {
+        int est = num_tokens / RATIO;
+        nw = (est < 320 || (est >= 576 && est < 960)) ? 8 : 4;
+    }
+    if (rms_norm_weight_is_bf16) {
+        const __hip_bfloat16* rms_norm_weight_t =
+            reinterpret_cast<const __hip_bfloat16*>(rms_norm_weight);
+        switch (nw) {
+            case 8: plan_ksplit_launch<8>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 4: plan_ksplit_launch<4>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 2: plan_ksplit_launch<2>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            default: plan_ksplit_launch<1>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+        }
+    } else {
+        const float* rms_norm_weight_t =
+            reinterpret_cast<const float*>(rms_norm_weight);
+        switch (nw) {
+            case 8: plan_ksplit_launch<8>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 4: plan_ksplit_launch<4>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            case 2: plan_ksplit_launch<2>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+            default: plan_ksplit_launch<1>(plan_capacity, plan, HCA_PLAN_ARGS); break;
+        }
+    }
+}

--- a/vllm/models/deepseek_v4/amd/ops/hip_compress_dispatch.py
+++ b/vllm/models/deepseek_v4/amd/ops/hip_compress_dispatch.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""gfx942 DeepSeek-V4 HIP compressor dispatch."""
+
+from typing import Any
+
+import torch
+
+from vllm import envs
+
+SUPPORTED_SHAPES = frozenset({(512, 4), (512, 128)})
+
+
+def hip_compressor_selected(head_dim: int, compress_ratio: int) -> bool:
+    return (
+        envs.VLLM_ROCM_DSV4_HIP_COMPRESSOR
+        and (
+            head_dim,
+            compress_ratio,
+        )
+        in SUPPORTED_SHAPES
+    )
+
+
+def hip_compressor_runtime_available() -> bool:
+    try:
+        from vllm.platforms.rocm import on_gfx942
+
+        return on_gfx942()
+    except Exception:
+        return False
+
+
+def _aot_op(head_dim: int, compress_ratio: int):
+    rocm_C = getattr(torch.ops, "_rocm_C", None)
+    if rocm_C is None:
+        return None
+    if head_dim == 512 and compress_ratio == 4:
+        return getattr(rocm_C, "dsv4_csa_compress", None)
+    if head_dim == 512 and compress_ratio == 128:
+        return getattr(rocm_C, "dsv4_hca_compress", None)
+    return None
+
+
+def hip_compressor_available(head_dim: int, compress_ratio: int) -> bool:
+    return (
+        hip_compressor_runtime_available()
+        and _aot_op(head_dim, compress_ratio) is not None
+    )
+
+
+def hip_compressor_enabled(
+    head_dim: int,
+    rope_head_dim: int,
+    compress_ratio: int,
+    cache_dtype: str,
+) -> bool:
+    return (
+        hip_compressor_selected(head_dim, compress_ratio)
+        and hip_compressor_available(head_dim, compress_ratio)
+        and rope_head_dim == 64
+        and cache_dtype == "fp8_ds_mla"
+    )
+
+
+def hip_compressor_supported(
+    head_dim: int,
+    compress_ratio: int,
+    kv_cache: torch.Tensor,
+    allowed_shapes: frozenset[tuple[int, int]] | None = None,
+) -> bool:
+    if allowed_shapes is None:
+        allowed_shapes = SUPPORTED_SHAPES
+    if (head_dim, compress_ratio) not in allowed_shapes:
+        return False
+    if kv_cache.dtype != torch.uint8:
+        return False
+    return hip_compressor_available(head_dim, compress_ratio)
+
+
+def compress_norm_rope_store_hip(
+    *,
+    state_cache: torch.Tensor,
+    num_actual: int,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    state_width: int,
+    cos_sin_cache: torch.Tensor,
+    kv_cache: torch.Tensor,
+    k_cache_metadata: Any,
+    pdl_kwargs: dict,
+    head_dim: int,
+    rope_head_dim: int,
+    compress_ratio: int,
+    overlap: bool,
+    use_fp4_cache: bool,
+    rms_norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+    ape: torch.Tensor,
+    use_bf16_state_cache: bool = True,
+    hca_plan_scratch: torch.Tensor | None = None,
+    hca_counter_scratch: torch.Tensor | None = None,
+    **_ignored: Any,
+) -> None:
+    if num_actual == 0:
+        return
+
+    op = _aot_op(head_dim, compress_ratio)
+    if op is None:
+        raise RuntimeError(
+            f"HIP compressor op unavailable for (head_dim={head_dim}, "
+            f"compress_ratio={compress_ratio}); was _rocm_C built with "
+            f"VLLM_ROCM_GFX942?"
+        )
+
+    args = [
+        state_cache,
+        num_actual,
+        ape,
+        token_to_req_indices,
+        positions,
+        slot_mapping,
+        block_table,
+        block_size,
+        rms_norm_weight,
+        rms_norm_eps,
+        cos_sin_cache,
+        kv_cache,
+        k_cache_metadata.slot_mapping,
+        kv_cache.shape[1],
+        scale_dim,
+    ]
+    if head_dim == 512 and compress_ratio == 128:
+        if hca_plan_scratch is None or hca_counter_scratch is None:
+            raise RuntimeError(
+                "HCA HIP compressor requires reusable plan/counter scratch buffers."
+            )
+        args.extend([hca_plan_scratch, hca_counter_scratch])
+    op(*args)

--- a/vllm/models/deepseek_v4/common/ops/save_partial_states.py
+++ b/vllm/models/deepseek_v4/common/ops/save_partial_states.py
@@ -5,11 +5,13 @@ import torch
 
 from vllm.triton_utils import tl, triton
 
+_DUMMY_APE_CACHE: dict[torch.device, torch.Tensor] = {}
+
 
 def save_partial_states(
     kv: torch.Tensor,
     score: torch.Tensor,
-    ape: torch.Tensor,
+    ape: torch.Tensor | None,
     positions: torch.Tensor,
     state_cache: torch.Tensor,
     slot_mapping: torch.Tensor,
@@ -18,12 +20,20 @@ def save_partial_states(
     compress_ratio: int,
     pdl_kwargs: dict | None = None,
 ) -> None:
-    """Write packed [kv, score+ape] partial states into the compressor cache.
+    """Write packed [kv, score(+ape)] partial states into the compressor cache.
 
     One program per token; pads (slot_id == -1) are skipped.
     """
     num_actual = slot_mapping.shape[0]
     head_size = kv.shape[-1]
+    skip_ape = ape is None
+    if skip_ape:
+        ape = _DUMMY_APE_CACHE.get(kv.device)
+        if ape is None:
+            ape = torch.empty(1, 1, dtype=torch.float32, device=kv.device)
+            _DUMMY_APE_CACHE[kv.device] = ape
+    assert ape is not None
+
     _save_partial_states_kernel[(num_actual,)](
         kv,
         kv.stride(0),
@@ -41,6 +51,7 @@ def save_partial_states(
         TRITON_BLOCK_SIZE=triton.next_power_of_2(head_size),
         STATE_WIDTH=state_width,
         COMPRESS_RATIO=compress_ratio,
+        SKIP_APE=skip_ape,
         **(pdl_kwargs or {}),
     )
 
@@ -64,6 +75,7 @@ def _save_partial_states_kernel(
     # state_cache last dim packs [kv_state, score_state], each STATE_WIDTH wide.
     STATE_WIDTH: tl.constexpr,
     COMPRESS_RATIO: tl.constexpr,
+    SKIP_APE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
     slot_id = tl.load(slot_mapping_ptr + token_idx)
@@ -89,13 +101,11 @@ def _save_partial_states_kernel(
     kv = tl.load(kv_ptr + token_idx * kv_stride + block, mask=mask)
     tl.store(base_ptr + block, kv, mask=mask)
 
-    # Fused: score += ape[position % compress_ratio]
-    position = tl.load(positions_ptr + token_idx)
-    ape_row = position % COMPRESS_RATIO
-    ape = tl.load(ape_ptr + ape_row * ape_stride + block, mask=mask)
     score = tl.load(score_ptr + token_idx * score_stride + block, mask=mask)
-    tl.store(
-        base_ptr + STATE_WIDTH + block,
-        score + ape,
-        mask=mask,
-    )
+    if SKIP_APE:
+        tl.store(base_ptr + STATE_WIDTH + block, score, mask=mask)
+    else:
+        position = tl.load(positions_ptr + token_idx)
+        ape_row = position % COMPRESS_RATIO
+        ape = tl.load(ape_ptr + ape_row * ape_stride + block, mask=mask)
+        tl.store(base_ptr + STATE_WIDTH + block, score + ape, mask=mask)

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import MergedColumnParallelLinear
@@ -34,6 +35,8 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+
+logger = init_logger(__name__)
 
 
 def _prefer_two_stage_compressor() -> bool:
@@ -148,7 +151,7 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
 
-        assert self.dtype == torch.float32
+        assert self.dtype in (torch.float32, torch.bfloat16)
         assert compress_ratio in [4, 128]
         coff = 1 + (compress_ratio == 4)
         self.sliding_window = coff * compress_ratio
@@ -231,13 +234,31 @@ class DeepseekCompressor(nn.Module):
 
         self.overlap = compress_ratio == 4
         self.coff = 1 + self.overlap
+        self.use_hip_compressor = False
+        if current_platform.is_rocm():
+            from .amd.ops.hip_compress_dispatch import hip_compressor_enabled
+
+            self.use_hip_compressor = hip_compressor_enabled(
+                head_dim,
+                self.rope_head_dim,
+                compress_ratio,
+                vllm_config.cache_config.cache_dtype,
+            )
+            if self.use_hip_compressor:
+                logger.info_once(
+                    "Using gfx942 HIP DeepSeek-V4 compressor for head_dim=%d.",
+                    head_dim,
+                )
 
         # The head=512 cr>=128 no-overlap deep gather uses the two-stage
         # compressor, which needs an fp32 scratch [max_batched, 512] for
         # the intermediate compressed_kv.
         # Currently only tested on ROCm
         self._use_two_stage_fused_compressor = (
-            _prefer_two_stage_compressor() and head_dim == 512 and not self.overlap
+            not self.use_hip_compressor
+            and _prefer_two_stage_compressor()
+            and head_dim == 512
+            and not self.overlap
         )
         self.max_num_batched_tokens = (
             vllm_config.scheduler_config.max_num_batched_tokens
@@ -251,15 +272,29 @@ class DeepseekCompressor(nn.Module):
                 device=self.device,
             )
 
-        state_dtype = torch.float32
+        state_dtype = torch.bfloat16 if self.use_hip_compressor else torch.float32
         self.ape = nn.Parameter(
             torch.empty(
                 (compress_ratio, self.coff * self.head_dim),
-                dtype=state_dtype,
+                dtype=torch.float32,
                 device=self.device,
             ),
             requires_grad=False,
         )
+        if self.use_hip_compressor and compress_ratio == 128:
+            plan_capacity = (
+                self.max_num_batched_tokens // compress_ratio + self.max_num_reqs + 2
+            )
+            self.register_buffer(
+                "_hca_plan_scratch",
+                torch.empty(plan_capacity, dtype=torch.int32, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_hca_counter_scratch",
+                torch.empty(1, dtype=torch.int32, device=self.device),
+                persistent=False,
+            )
 
         self.fused_wkv_wgate = MergedColumnParallelLinear(
             self.hidden_size,
@@ -345,7 +380,7 @@ class DeepseekCompressor(nn.Module):
             else {"launch_pdl": False}
         )
 
-        # Store the KV and score (with fused APE addition) in the state.
+        # The HIP path adds APE during compression.
         # NOTE: PDL is disabled — both this kernel and the compress kernels
         # below depend on preceding kernel outputs (kv/score from the cublas
         # GEMM; state_cache from this kernel) but neither emits/waits on PDL
@@ -354,7 +389,7 @@ class DeepseekCompressor(nn.Module):
         save_partial_states(
             kv=kv,
             score=score,
-            ape=self.ape,
+            ape=None if self.use_hip_compressor else self.ape,
             positions=positions,
             state_cache=state_cache,
             slot_mapping=slot_mapping,
@@ -413,6 +448,31 @@ class DeepseekCompressor(nn.Module):
                 store_full_fp8=store_full_fp8,
                 fp8_scale=fp8_scale,
             )
+        elif current_platform.is_rocm() and self.use_hip_compressor:
+            from .amd.ops.hip_compress_dispatch import (
+                compress_norm_rope_store_hip,
+                hip_compressor_supported,
+            )
+
+            if not hip_compressor_supported(
+                self.head_dim,
+                self.compress_ratio,
+                kv_cache,
+            ):
+                raise RuntimeError(
+                    "The gfx942 DSV4 HIP compressor was selected but its "
+                    "_rocm_C op or paged uint8 cache layout is unavailable."
+                )
+            compress_norm_rope_store_fn = compress_norm_rope_store_hip
+            extra_kwargs = {
+                "ape": self.ape,
+                "use_bf16_state_cache": True,
+            }
+            if self.compress_ratio == 128:
+                extra_kwargs.update(
+                    hca_plan_scratch=self._hca_plan_scratch,
+                    hca_counter_scratch=self._hca_counter_scratch,
+                )
         elif self._use_two_stage_fused_compressor:
             # head=512 cr>=128 (no overlap): two-pass split compressor on the
             # prefill suffix, single-pass on the decode prefix.


### PR DESCRIPTION
## Motivation

DeepSeek-V4 compression is expensive during large long-context batches on gfx942. This adds opt-in HIP kernels for the main CSA and HCA shapes while preserving the existing cache format and fallback path.

## Changes

- Add fused gfx942 CSA and HCA compressors.
- Keep the feature disabled by default.
- Preserve OCP FP8 behavior, including edge values.
- Add runtime validation, graph replay coverage, and 57 correctness tests.

## Kernel results

Median of five runs on gfx942.

| Kernel | Tokens | Triton | HIP | Speedup |
|---|---:|---:|---:|---:|
| CSA | Decode | 56.5 µs | 23.8 µs | 2.37x |
| CSA | 32K | 201.3 µs | 90.3 µs | 2.23x |
| CSA | 102K | 564.3 µs | 201.3 µs | 2.80x |
| HCA | Decode | 60.1 µs | 35.0 µs | 1.72x |
| HCA | 32K | 360.4 µs | 58.9 µs | 6.12x |
| HCA | 102K | 2228.8 µs | 136.8 µs | 16.29x |

## Serving result

Dummy weights, TP=4, 32K batched tokens, 128K input, 1K output, concurrency 8.

| Metric | Triton | HIP | Change |
|---|---:|---:|---:|
| Duration | 140.20 s | 110.81 s | 21.0% lower |
| Mean TTFT | 53,891.97 ms | 52,793.26 ms | 2.0% lower |
| Mean TPOT | 84.35 ms | 56.36 ms | 33.2% lower |
| Output throughput | 58.43 tok/s | 73.93 tok/s | 26.5% higher |

The E2E gain depends on the prefill workload and scheduler batch size. At TP=8 with 8K batched tokens, the uplift was about 1% because compression was a small part of total runtime. The larger result below uses TP=4 with 32K batched tokens and long-context prefill, where compressor cost is more visible.

## Follow-up work

- Run wider A/B performance testing across batch sizes, context lengths, concurrency levels, and TP configurations.
- Run GSM8K with real weights to check model-level quality.
- Repeat serving benchmarks with real weight loading and representative production traffic.
- Complete human review of the kernel, dispatch logic, fallback behavior, and test coverage.

<details>
<summary>Reproduction commands</summary>

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_DSV4_HIP_COMPRESSOR=1

vllm serve deepseek-ai/DeepSeek-V4-Flash-0731 \
  --load-format dummy \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --enable-expert-parallel \
  --tensor-parallel-size 4 \
  --distributed-executor-backend mp \
  --max-num-seqs 512 \
  --max-num-batched-tokens 32768 \
  --compilation-config '{"mode":3,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
  --gpu-memory-utilization 0.85 \
  --tokenizer-mode deepseek_v4
```

```bash
vllm bench serve \
  --backend openai \
  --model deepseek-ai/DeepSeek-V4-Flash-0731 \
  --dataset-name random \
  --random-input-len 131072 \
  --random-output-len 1024 \
  --random-range-ratio 0 \
  --num-prompts 8 \
  --max-concurrency 8 \
  --ignore-eos \
  --trust-remote-code
```

</details>