### PR TITLE
[Qwen4Exp][ROCm] Support FP8 PLE n-gram checkpoints on the AMD path

### DIFF
--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -19,6 +19,9 @@ from vllm.models.qwen4_exp.common.ple import (
     compute_ple_shard_overlap,
     copy_ple_embedding_shard_,
 )
+from vllm.models.qwen4_exp.amd.ple_layer import (
+    Qwen4ExpNGramEmbedding as Qwen4ExpNGramEmbeddingAMD,
+)
 from vllm.models.qwen4_exp.nvidia.ple_layer import (
     Qwen4ExpNGramEmbedding,
     Qwen4ExpPLEFp8EmbeddingMethod,
@@ -166,6 +169,82 @@ def test_ngram_embedding_loads_fp8_shards_and_global_scale() -> None:
         module.ngram_embedding.weight_scale,
         weight_scale.float(),
     )
+
+
+def _make_amd_ngram_embedding_for_load_test() -> Qwen4ExpNGramEmbeddingAMD:
+    module = Qwen4ExpNGramEmbeddingAMD.__new__(Qwen4ExpNGramEmbeddingAMD)
+    nn.Module.__init__(module)
+    module.split_ngram_parts = 2
+    module.register_buffer("layer_multipliers", torch.zeros(1, dtype=torch.long))
+    module.register_buffer("ngram_heads_offsets", torch.zeros(1, dtype=torch.long))
+    module.register_buffer("ngram_heads_vocab_sizes", torch.zeros(1, dtype=torch.long))
+    module.ngram_embedding = SimpleNamespace(
+        org_vocab_size=8,
+        embedding_dim=2,
+        weight=nn.Parameter(torch.full((4, 2), -1.0)),
+        shard_indices=SimpleNamespace(
+            org_vocab_start_index=2,
+            org_vocab_end_index=6,
+        ),
+    )
+    _set_test_embedding_weight_loader(module.ngram_embedding)
+    return module
+
+
+def _amd_fp8_shards() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    shard_0 = torch.arange(8, dtype=torch.float32).reshape(4, 2).to(torch.float8_e4m3fn)
+    shard_1 = (
+        torch.arange(8, 16, dtype=torch.float32).reshape(4, 2).to(torch.float8_e4m3fn)
+    )
+    weight_scale = torch.tensor([0.25], dtype=torch.bfloat16)
+    return shard_0, shard_1, weight_scale
+
+
+def test_amd_ngram_embedding_loads_fp8_shards_with_folded_scale() -> None:
+    """FP8 shards are dequantized to bf16 with the global scale folded in."""
+    module = _make_amd_ngram_embedding_for_load_test()
+    shard_0, shard_1, weight_scale = _amd_fp8_shards()
+
+    # a single-pass generator, as delivered by AutoWeightsLoader
+    loaded = module.load_weights(
+        iter(
+            [
+                ("ngram_embedding.shard_0.weight", shard_0),
+                ("ngram_embedding.shard_1.weight", shard_1),
+                ("ngram_embedding.weight_scale", weight_scale),
+            ]
+        )
+    )
+
+    assert loaded == {"ngram_embedding.weight"}
+    expected = torch.cat((shard_0[2:4], shard_1[0:2])).float() * 0.25
+    torch.testing.assert_close(module.ngram_embedding.weight, expected)
+
+
+def test_amd_ngram_embedding_fp8_scale_cached_across_split_calls() -> None:
+    """The PLE weights may be split across several load_weights calls (one per
+    consecutive checkpoint-file group); the scale arrives in only one of them
+    and must be reused, otherwise the later shards load as raw FP8."""
+    module = _make_amd_ngram_embedding_for_load_test()
+    shard_0, shard_1, weight_scale = _amd_fp8_shards()
+
+    loaded_first = module.load_weights(
+        iter(
+            [
+                ("ngram_embedding.shard_0.weight", shard_0),
+                ("ngram_embedding.weight_scale", weight_scale),
+            ]
+        )
+    )
+    assert loaded_first == {"ngram_embedding.weight"}
+
+    loaded_second = module.load_weights(
+        iter([("ngram_embedding.shard_1.weight", shard_1)])
+    )
+    assert loaded_second == {"ngram_embedding.weight"}
+
+    expected = torch.cat((shard_0[2:4], shard_1[0:2])).float() * 0.25
+    torch.testing.assert_close(module.ngram_embedding.weight, expected)
 
 
 def _make_fp8_embedding_layer(

--- a/vllm/models/qwen4_exp/amd/ple_layer.py
+++ b/vllm/models/qwen4_exp/amd/ple_layer.py
@@ -358,6 +358,24 @@ class Qwen4ExpNGramEmbedding(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Load hash buffers and checkpoint-split embedding rows."""
 
+        # FP8 checkpoints store the n-gram table shards as F8_E4M3 with one
+        # global per-tensor scale (`ngram_embedding.weight_scale`). Fold the
+        # scale in at load time and keep the in-memory table in bf16.
+        # `weights` may be a single-pass generator, and the PLE weights may
+        # arrive split across several load_weights calls (one per consecutive
+        # checkpoint-file group), with the scale in only one of them — so
+        # materialize the iterable and cache the scale on the module.
+        weight_scale: torch.Tensor | None = None
+        weights_list = list(weights)
+        for name, loaded_weight in weights_list:
+            if name.endswith("ngram_embedding.weight_scale"):
+                weight_scale = loaded_weight
+                break
+        if weight_scale is not None:
+            self._cached_ngram_weight_scale = weight_scale
+        else:
+            weight_scale = getattr(self, "_cached_ngram_weight_scale", None)
+
         persistent_buffers = {
             "layer_multipliers": self.layer_multipliers,
             "ngram_heads_offsets": self.ngram_heads_offsets,
@@ -367,7 +385,7 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         regular_weights: list[tuple[str, torch.Tensor]] = []
         shard_prefix = "ngram_embedding.shard_"
 
-        for name, loaded_weight in weights:
+        for name, loaded_weight in weights_list:
             leaf_name = name.rsplit(".", 1)[-1]
             if leaf_name.startswith("hashstats_") or leaf_name == "token_lookup":
                 continue
@@ -380,6 +398,9 @@ class Qwen4ExpNGramEmbedding(nn.Module):
                     )
                 buffer.copy_(loaded_weight.to(device=buffer.device, dtype=buffer.dtype))
                 loaded.add(name)
+                continue
+            if name.endswith("ngram_embedding.weight_scale"):
+                # scale already folded into the shards at load time
                 continue
             if name.startswith(shard_prefix) and name.endswith(".weight"):
                 shard_text = name[len(shard_prefix) : -len(".weight")]
@@ -407,6 +428,19 @@ class Qwen4ExpNGramEmbedding(nn.Module):
                         f"Shape mismatch for PLE embedding shard {shard_index}: "
                         f"expected {expected_shape}, got "
                         f"{tuple(loaded_weight.shape)}"
+                    )
+                if weight_scale is not None and loaded_weight.dtype == (
+                    torch.float8_e4m3fn
+                ):
+                    # move to the destination device first so the fp8->bf16
+                    # cast always runs on a device that supports it
+                    loaded_weight = loaded_weight.to(
+                        device=embedding.weight.device
+                    )
+                    loaded_weight = loaded_weight.to(torch.bfloat16) * (
+                        weight_scale.to(
+                            device=embedding.weight.device, dtype=torch.bfloat16
+                        )
                     )
                 embedding.weight.weight_loader(
                     embedding.weight,


### PR DESCRIPTION
## Purpose

FP8 checkpoints of Qwen3.8-Flash-Next store the PLE n-gram table
(320,001,536 rows × 160 dims, 128 shards) as `F8_E4M3` with one global
per-tensor scale (`ngram_embedding.weight_scale`). The NVIDIA path handles
this at runtime (`embeddings × weight_scale`, #54722); the AMD/ROCm path had
no handling for either, so FP8 PLE tables could not load on ROCm.

This adds load-time dequantization on the AMD path: fold the scale into the
shards and keep the in-memory table in bf16 (same convention as
transformers' `FP8Embedding`).

Two `AutoWeightsLoader` subtleties are handled explicitly:

1. **`weights` may be a single-pass generator.** The scale pre-scan
   materializes the iterable; the main loop must iterate the materialized
   list. Re-iterating the parameter silently loads nothing — and the strict
   unloaded-weights check is disabled for quantized models, so the failure
   is completely silent (the table stays at `torch.empty` init).
2. **The PLE weights may be split across several `load_weights` calls.**
   `_groupby_prefix` only groups *consecutive* same-prefix entries; e.g.
   `model-00037` of `Qwen/Qwen3.8-Flash-Next-FP8` interleaves
   `key_proj`/`norm_*` weights between `ple_embedding` weights, producing
   two calls. The scale arrives in only one of them, so it is cached on the
   module — otherwise the later shards load as raw FP8 (~2000× too large),
   which garbles generation at ~1/16 lookup frequency (the table tail is
   the last trigram hash head).

**Not a duplicate:** #54722 (merged) and #54882 (open) cover the NVIDIA path
only; #53899's AMD path has no FP8 handling; #54129/#54070 are disk-backed
table features. No existing issue tracks the AMD-path gap; found while
serving the FP8 checkpoint on MI350X.

## Test Plan

New unit tests in `tests/models/qwen4_exp/test_ple.py`, mirroring the
existing NVIDIA-path tests:

- `test_amd_ngram_embedding_loads_fp8_shards_with_folded_scale` —
  single-pass generator input (the `AutoWeightsLoader` production path),
  scale folded into bf16
- `test_amd_ngram_embedding_fp8_scale_cached_across_split_calls` — split
  `load_weights` calls with the scale only in the first (the
  checkpoint-file-group split)

```
pytest tests/models/qwen4_exp/test_ple.py -k amd
```

## Test Result

- Both new tests pass against this change.
- End-to-end on MI350X (gfx950, ROCm 7.2.3, `Qwen/Qwen3.8-Flash-Next-FP8`,
  MTP speculative decoding + prefix caching + CUDA graphs, TP=1):

- Before this change the FP8 PLE table was silently dropped (PLE effectively
  disabled); with only the generator fix, 126/128 shards loaded correctly
  and the last two loaded as raw FP8, garbling ~1/16 of lookups.
- **GSM8K** (full 1,319 problems, chat API, greedy, thinking off):
  **95.98%** (1266/1319)
- **MMLU-Pro** (thinking mode, 140-question stratified subset, greedy):
  **78.57%** (official card: 73.23; direct/CoT subsets: 69.80% / 66.53%)

AI assistance was used to develop and validate this change (root-cause
analysis, fix, tests, and evaluation). The submitter has reviewed every
changed line and takes full responsibility for the contribution.
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

