### PR TITLE
[Core] Deprecate "all" mamba cache mode

### DIFF
--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -459,7 +459,10 @@ def test_v2_model_runner_accepts_routed_experts(monkeypatch):
             mode=CompilationMode.NONE,
             pass_config=SimpleNamespace(enable_sp=False),
         ),
-        cache_config=SimpleNamespace(kv_sharing_fast_prefill=False),
+        cache_config=SimpleNamespace(
+            kv_sharing_fast_prefill=False,
+            mamba_cache_mode="none",
+        ),
         ec_transfer_config=None,
     )
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -323,6 +323,17 @@ class CacheConfig:
             self.user_specified_mamba_block_size = True
         return self
 
+    @field_validator("mamba_cache_mode", mode="after")
+    @classmethod
+    def _validate_mamba_cache_mode(cls, mode: MambaCacheMode) -> MambaCacheMode:
+        if mode == "all":
+            logger.warning_once(
+                "Mamba cache mode 'all' is deprecated and will be removed in an "
+                "upcoming release. If this is a problem, please open an issue "
+                "at https://github.com/vllm-project/vllm/issues."
+            )
+        return mode
+
     @field_validator("cache_dtype", mode="after")
     @classmethod
     def _validate_cache_dtype(cls, cache_dtype: CacheDType) -> CacheDType:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2614,6 +2614,9 @@ class VllmConfig:
             # Will be added by https://github.com/vllm-project/vllm/pull/35045
             unsupported.append("KV sharing fast prefill")
 
+        if self.cache_config.mamba_cache_mode == "all":
+            unsupported.append("mamba cache mode 'all'")
+
         return unsupported
 
     def _get_v1_model_runner_unsupported_features(self) -> list[str]:


### PR DESCRIPTION
And fall back to MRV1 if configured since it's not implemented in MRV2.