### PR TITLE
[CI] Fix DeepSeek-V4 registry platform guard

### DIFF
--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -64,7 +64,7 @@ def test_registry_imports(model_arch):
     ):
         pytest.skip("HY V4 is only supported on CUDA")
 
-    if model_arch == "DeepseekV4ForConditionalGeneration" and (
+    if model_arch == "DeepseekV4ForConditionalGeneration" and not (
         current_platform.is_cuda()
     ):
         pytest.skip("Deepseek V4 is only supported on CUDA")


### PR DESCRIPTION
## Purpose

#54566 added an NVIDIA-only DeepSeek-V4 vision implementation with a stub for unsupported platforms. Its registry-test guard was inverted: it skipped CUDA while allowing ROCm to validate the unsupported stub as a real generation model. This caused the AMD MI300 `basic-models-other` job in #54177 to fail because the stub intentionally lacks `embed_input_ids`.

This change corrects the guard so unsupported non-CUDA platforms skip the registry interface checks while CUDA continues validating the real implementation.

- Originating PR: https://github.com/vllm-project/vllm/pull/54566
- CI failures: 
- [Build 86967](https://buildkite.com/vllm/ci/builds/86967#01a06488-581a-491d-bc18-e3712e2e2e4b)
- [Build 86965 / PR #54962](https://buildkite.com/vllm/ci/builds/86965) 
- [Build 86966 / PR #54651](https://buildkite.com/vllm/ci/builds/86966) 
- [Build 86967 / PR #54177](https://buildkite.com/vllm/ci/builds/86967)



## AI assistance disclosure
OpenAI Codex (GPT-5) assisted in root cause analysis of this CI issue