### PR TITLE
[CI] Force HTTP/1.1 for runtime Git installs

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -44,6 +44,12 @@ steps:
   device: h200_35gb
   key: v1-core-kv-metrics
   timeout_in_minutes: 80
+  env:
+    # GitHub intermittently rejects HTTP/2 upload-pack requests from the H200
+    # CI image. Force Git's smart protocol to use HTTP/1.1 for source installs.
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: http.version
+    GIT_CONFIG_VALUE_0: HTTP/1.1
   source_file_dependencies:
     - vllm/config/
     - vllm/distributed/

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -61,6 +61,12 @@ steps:
   device: h200_35gb
   key: language-models-tests-hybrid
   timeout_in_minutes: 65
+  env:
+    # GitHub intermittently rejects HTTP/2 upload-pack requests from the H200
+    # CI image. Force Git's smart protocol to use HTTP/1.1 for source installs.
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: http.version
+    GIT_CONFIG_VALUE_0: HTTP/1.1
   source_file_dependencies:
   - vllm/
   - "!vllm/distributed/kv_transfer/"


### PR DESCRIPTION
## Summary

- force Git's smart protocol to use HTTP/1.1 in the H200 Hybrid and V1 Core/KV/Metrics steps
- keep the workaround scoped to the jobs that install source dependencies from GitHub at runtime
- prevent HTTP/2 upload-pack 401 responses from turning into interactive username-prompt timeouts

## Root cause

The failing H200 jobs can fetch public GitHub refs, but Git 2.43/libcurl 8.5 in the CI image sends the upload-pack POST over HTTP/2 and receives HTTP 401. Git then prompts for a username and the job hangs until its 65/80-minute timeout. Host-side Git on the same machines succeeds, so checkout and host egress are not the failing boundary.

The same CI image reproduces the protocol split exactly:

- forced `HTTP/2`: exit 128, `fatal: expected flush after ref listing`
- `GIT_CONFIG_COUNT=1`, `GIT_CONFIG_KEY_0=http.version`, `GIT_CONFIG_VALUE_0=HTTP/1.1`: public tag lookup succeeds

Representative failures:

- Hybrid shard 1: https://buildkite.com/vllm/ci/builds/86957#01a06435-5c3a-4e5f-97b7-3ba97e89b532
- Hybrid shard 2: https://buildkite.com/vllm/ci/builds/86957#01a06435-5c3a-4a73-b38c-04d7bb702d3e
- V1 Core/KV/Metrics: https://buildkite.com/vllm/ci/builds/86957#01a06435-5c39-42aa-ae00-07e4657ef9fc

## Duplicate work

I searched open vLLM PRs and issues for `http.version`, `HTTP/1.1`, `expected flush after ref listing`, `could not read Username`, and the Mamba/causal-conv1d install path. I found no open PR addressing this CI transport failure.

## Validation

- Reproduced forced HTTP/2 failure and HTTP/1.1 success in the same current vLLM CI image on `h200-ci-4`
- Parsed both modified YAML files through the ci-infra `Step` schema and asserted the exact environment mapping
- `pre-commit run --hook-stage pre-commit --files .buildkite/test_areas/models_language.yaml .buildkite/test_areas/misc.yaml` passed
- `git diff --check` passed
- Model evaluation: not applicable; this changes CI transport configuration only

This contribution was prepared with AI assistance and reviewed line by line by the human submitter.
