### PR TITLE
[Perf][Structured Output] Track parser-engine reasoning boundaries incrementally

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -42,6 +42,7 @@ from vllm.parser.engine.registered_adapters import (
 
 _THINK_START_ID = 50
 _THINK_END_ID = 51
+_TOOL_START_ID = 52
 
 _PARAM_OPEN = '｜DSML｜parameter name="{name}" string="{is_str}">'
 _PARAM_CLOSE = "</｜DSML｜parameter>"
@@ -57,6 +58,7 @@ def mock_tokenizer():
         {
             DSML_THINK_START: _THINK_START_ID,
             DSML_THINK_END: _THINK_END_ID,
+            DSML_TOOL_START: _TOOL_START_ID,
         }
     )
 
@@ -426,6 +428,12 @@ class TestImplicitReasoningEnd:
         assert reasoning == "Let me look up the weather."
         assert DSML_TOOL_START not in reasoning
         assert DSML_INVOKE_PREFIX not in reasoning
+
+    def test_boundary_tracker_uses_implicit_end_transition(self, thinking_parser):
+        tracker = thinking_parser.create_reasoning_end_tracker([], False)
+
+        assert tracker is not None
+        assert tracker.preview([7, _TOOL_START_ID, 8]) == 1
 
     def test_streaming_tool_extraction_implicit_end(
         self, thinking_parser, mock_request

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -33,6 +33,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.parser.engine.reasoning_end_tracker import ReasoningEndTracker
 from vllm.parser.parser_manager import ParserManager
 
 # ── Shared test configs ──────────────────────────────────────────────
@@ -130,6 +131,151 @@ def _make_engine(
         tools=tools,
         parser_engine_config=cfg,
     )
+
+
+class TestReasoningEndTracker:
+    def test_preview_does_not_mutate_and_commit_does(self):
+        tracker = _make_engine().create_reasoning_end_tracker([], False)
+
+        assert tracker is not None
+        assert tracker.preview([10, 201, 11]) == 1
+        assert tracker.reasoning_ended is False
+        assert tracker.preview([10, 201, 11]) == 1
+
+        assert tracker.commit([10, 201, 11]) == 1
+        assert tracker.reasoning_ended is True
+        assert tracker.preview([201]) is None
+
+    def test_multi_token_boundary_spans_commits(self):
+        tracker = ReasoningEndTracker(((41, 42, 43),), False)
+
+        assert tracker.commit([7, 41]) is None
+        assert tracker.preview([42, 43, 9]) == 1
+        assert tracker.reasoning_ended is False
+        assert tracker.commit([42]) is None
+        assert tracker.commit([43, 9]) == 0
+        assert tracker.reasoning_ended is True
+
+    def test_input_suffix_primes_split_boundary(self):
+        tracker = ReasoningEndTracker(((41, 42, 43),), False, [7, 41, 42])
+
+        assert tracker.commit([43, 9]) == 0
+
+    def test_text_only_end_terminal_uses_parser_fallback(self):
+        config = ParserEngineConfig(
+            name="text_only_reasoning_end",
+            terminals={"THINK_END": "xy"},
+            transitions={
+                (ParserState.REASONING, "THINK_END"): Transition(
+                    ParserState.CONTENT,
+                    (EventType.REASONING_END,),
+                )
+            },
+            initial_state=ParserState.REASONING,
+        )
+        tokenizer = make_mock_tokenizer({})
+        tokenizer.encode.return_value = [41, 42, 43]
+        tracker = ParserEngine(
+            tokenizer, parser_engine_config=config
+        ).create_reasoning_end_tracker([], False)
+
+        assert tracker is None
+        tokenizer.encode.assert_not_called()
+
+    def test_unresolved_end_terminal_disables_whole_tracker(self):
+        config = ParserEngineConfig(
+            name="partially_resolved_reasoning_end",
+            token_id_terminals={
+                "THINK_END": "</think>",
+                "TOOL_START": "<tool_call>",
+            },
+            transitions={
+                (ParserState.REASONING, "THINK_END"): Transition(
+                    ParserState.CONTENT,
+                    (EventType.REASONING_END,),
+                ),
+                (ParserState.REASONING, "TOOL_START"): Transition(
+                    ParserState.TOOL_ARGS,
+                    (EventType.REASONING_END,),
+                ),
+            },
+            initial_state=ParserState.REASONING,
+        )
+
+        engine = _make_engine(config, vocab={"</think>": 201})
+        tracker = engine.create_reasoning_end_tracker(
+            [],
+            False,
+        )
+
+        assert tracker is None
+
+    def test_end_transition_outside_reasoning_uses_parser_fallback(self):
+        config = ParserEngineConfig(
+            name="content_reasoning_end",
+            token_id_terminals={"TOOL_START": "<tool_call>"},
+            transitions={
+                (ParserState.CONTENT, "TOOL_START"): Transition(
+                    ParserState.TOOL_ARGS,
+                    (EventType.REASONING_END,),
+                )
+            },
+        )
+
+        tracker = _make_engine(config).create_reasoning_end_tracker([], False)
+
+        assert tracker is None
+
+    def test_non_reasoning_end_transition_does_not_disable_tracker(self):
+        config = _combined_config()
+        config.transitions[(ParserState.REASONING, "TOOL_START")] = Transition(
+            ParserState.TOOL_ARGS,
+            (EventType.REASONING_END, EventType.TOOL_CALL_START),
+        )
+        config.transitions[(ParserState.CONTENT, "TOOL_START")] = Transition(
+            ParserState.TOOL_ARGS,
+            (EventType.REASONING_END, EventType.TOOL_CALL_START),
+        )
+
+        tracker = _make_engine(config).create_reasoning_end_tracker([], False)
+
+        assert tracker is not None
+        assert tracker.preview([8, 202, 9]) == 1
+
+    def test_unreported_reasoning_exit_uses_parser_fallback(self):
+        config = ParserEngineConfig(
+            name="unreported_reasoning_exit",
+            token_id_terminals={
+                "THINK_END": "</think>",
+                "TOOL_START": "<tool_call>",
+            },
+            transitions={
+                (ParserState.REASONING, "THINK_END"): Transition(
+                    ParserState.CONTENT,
+                    (EventType.REASONING_END,),
+                ),
+                (ParserState.REASONING, "TOOL_START"): Transition(
+                    ParserState.TOOL_ARGS,
+                    (EventType.TOOL_CALL_START,),
+                ),
+            },
+            initial_state=ParserState.REASONING,
+        )
+
+        tracker = _make_engine(config).create_reasoning_end_tracker([], False)
+
+        assert tracker is None
+
+    def test_configured_tool_opener_can_end_reasoning(self):
+        config = _combined_config()
+        config.transitions[(ParserState.REASONING, "TOOL_START")] = Transition(
+            ParserState.TOOL_ARGS,
+            (EventType.REASONING_END, EventType.TOOL_CALL_START),
+        )
+        tracker = _make_engine(config).create_reasoning_end_tracker([], False)
+
+        assert tracker is not None
+        assert tracker.preview([8, 202, 9]) == 1
 
 
 # ── TestEventsToDelta ────────────────────────────────────────────────
@@ -918,6 +1064,9 @@ def test_parser_manager_preserves_shared_engine_adapters(monkeypatch):
     assert parser.tool_parser is not None
     assert parser.reasoning_parser._parser_engine_cls is _CombinedTestEngine
     assert parser.tool_parser._parser_engine_cls is _CombinedTestEngine
+    tracker = parser.create_reasoning_end_tracker([], False)
+    assert tracker is not None
+    assert tracker.preview([10, 201, 11]) == 1
     request = _make_delegating_request()
     token_ids = [ord("a"), ord("b"), 201, ord("c")]
     reasoning, content, _ = parser.parse(

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -155,6 +155,15 @@ def test_bitmask_constrained_when_reasoning_ends_midwindow(backend):
 
     marker = tokenizer.encode("\n")[0]
 
+    class Tracker:
+        reasoning_ended = False
+
+        def preview(self, token_ids):
+            return list(token_ids).index(marker)
+
+        def commit(self, token_ids):
+            raise AssertionError("speculative bitmask preview must not commit")
+
     class StubReasoner:
         def __init__(self, *_, **__):
             self.end_token_id = marker
@@ -163,7 +172,10 @@ def test_bitmask_constrained_when_reasoning_ends_midwindow(backend):
             return marker in list(input_ids)
 
         def is_reasoning_end_streaming(self, input_ids, delta_ids):
-            return marker in list(delta_ids)
+            raise AssertionError("tracker path must not rescan draft prefixes")
+
+        def create_reasoning_end_tracker(self, input_ids, reasoning_ended):
+            return Tracker()
 
     manager.reasoner_cls = StubReasoner
     request.structured_output_request.reasoner = StubReasoner()

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -65,6 +65,8 @@ class TestReasoningStructuredOutput:
         request.structured_output_request.grammar = Mock()
         request.structured_output_request.reasoning_parser_kwargs = None
         request.structured_output_request.reasoner = None
+        request.structured_output_request.reasoning_end_tracker = None
+        request.structured_output_request.reasoning_end_tracker_initialized = False
         request.structured_output_request.grammar.is_terminated = Mock(
             return_value=False
         )
@@ -403,3 +405,133 @@ class TestReasoningStructuredOutput:
         assert manager_with_reasoner.trim_reasoning_for_advance(
             mock_request_with_structured_output, new_token_ids
         ) == [271, 5005]
+
+    def test_should_advance_uses_tracker_boundary_offset(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """An engine tracker supplies the boundary without prefix rescans."""
+
+        class Tracker:
+            reasoning_ended = False
+
+            def preview(self, token_ids):
+                raise AssertionError("should_advance must commit accepted tokens")
+
+            def commit(self, token_ids):
+                assert token_ids == [9, 198, 248069, 271]
+                self.reasoning_ended = True
+                return 2
+
+        class TrackerReasoner:
+            def create_reasoning_end_tracker(self, input_ids, reasoning_ended):
+                assert input_ids == [1, 2, 3]
+                assert reasoning_ended is False
+                return Tracker()
+
+            def is_reasoning_end_streaming(self, input_ids, delta_ids):
+                raise AssertionError("tracker path must not rescan token prefixes")
+
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.reasoner = TrackerReasoner()
+        new_token_ids = [9, 198, 248069, 271]
+        mock_request_with_structured_output.all_token_ids = [1, 2, 3] + new_token_ids
+
+        assert manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=new_token_ids,
+        )
+        assert structured_req.reasoning_end_token_index == 5
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            mock_request_with_structured_output, new_token_ids
+        ) == [271]
+
+    def test_should_advance_without_new_tokens_only_previews_tracker(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Speculative queries must not consume the request tracker."""
+        tracker = Mock()
+        tracker.preview.return_value = 0
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.reasoning_end_token_index = None
+        structured_req.reasoning_end_tracker = tracker
+        structured_req.reasoning_end_tracker_initialized = True
+        mock_request_with_structured_output.num_computed_tokens = 7
+        mock_request_with_structured_output.num_output_placeholders = 0
+
+        assert manager_with_reasoner.should_advance(mock_request_with_structured_output)
+        assert manager_with_reasoner.should_advance(mock_request_with_structured_output)
+
+        assert tracker.preview.call_count == 2
+        tracker.commit.assert_not_called()
+        assert structured_req.reasoning_ended is False
+        assert structured_req.reasoning_end_token_index is None
+
+    def test_cached_tracker_avoids_copying_token_history(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Tracker lookup must not slice the accumulated token prefix."""
+
+        class SliceCountingList(list):
+            slice_count = 0
+
+            def __getitem__(self, index):
+                if isinstance(index, slice):
+                    self.slice_count += 1
+                return super().__getitem__(index)
+
+        tracker = Mock()
+        tracker.preview.return_value = None
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.reasoning_end_tracker = tracker
+        structured_req.reasoning_end_tracker_initialized = True
+        token_ids = SliceCountingList([1, 2, 3, 4, 5, 6, 7, 8])
+        mock_request_with_structured_output.all_token_ids = token_ids
+
+        assert not manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+
+        assert token_ids.slice_count == 0
+
+    def test_unavailable_tracker_factory_is_attempted_once(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """A failed tracker capability check is cached per request."""
+
+        class SliceCountingList(list):
+            slice_count = 0
+
+            def __getitem__(self, index):
+                if isinstance(index, slice):
+                    self.slice_count += 1
+                return super().__getitem__(index)
+
+        reasoner = Mock()
+        reasoner.create_reasoning_end_tracker.return_value = None
+        reasoner.is_reasoning_end_streaming.return_value = False
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.reasoner = reasoner
+        token_ids = SliceCountingList([1, 2, 3, 4, 5, 6, 7, 8])
+        mock_request_with_structured_output.all_token_ids = token_ids
+
+        assert not manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+        assert not manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+
+        reasoner.create_reasoning_end_tracker.assert_called_once()
+        assert token_ids.slice_count == 1

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 from openai.types.responses import ToolChoiceFunction
 from pydantic import TypeAdapter, ValidationError
@@ -39,6 +40,9 @@ from vllm.tool_parsers.streaming import (
 )
 
 logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from vllm.parser.engine.reasoning_end_tracker import ReasoningEndTracker
 
 
 @dataclass
@@ -188,6 +192,14 @@ class Parser:
         state.history_tool_call_cnt_initialized = True
 
     # ========== Reasoning Parser Methods ==========
+
+    def create_reasoning_end_tracker(
+        self,
+        input_ids: Sequence[int],
+        reasoning_ended: bool | None = None,
+    ) -> "ReasoningEndTracker | None":
+        """Create request-local reasoning-end state when supported."""
+        return None
 
     @abstractmethod
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
@@ -405,6 +417,16 @@ class DelegatingParser(Parser):
         if self._reasoning_parser is None:
             return None, model_output
         return self._reasoning_parser.extract_reasoning(model_output, request)
+
+    def create_reasoning_end_tracker(
+        self,
+        input_ids: Sequence[int],
+        reasoning_ended: bool | None = None,
+    ) -> "ReasoningEndTracker | None":
+        factory = getattr(self._reasoning_parser, "create_reasoning_end_tracker", None)
+        if factory is None:
+            return None
+        return factory(input_ids, reasoning_ended)
 
     def _get_function_name(
         self, request: ChatCompletionRequest | ResponsesRequest

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     )
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
     from vllm.parser.engine.parser_engine import ParserEngine
+    from vllm.parser.engine.reasoning_end_tracker import ReasoningEndTracker
     from vllm.tokenizers import TokenizerLike
     from vllm.tool_parsers.utils import Tool
 
@@ -64,6 +65,15 @@ class ParserEngineReasoningAdapter(ReasoningParser):
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         return self._parser_engine.is_reasoning_end(list(input_ids))
+
+    def create_reasoning_end_tracker(
+        self,
+        input_ids: Sequence[int],
+        reasoning_ended: bool | None = None,
+    ) -> ReasoningEndTracker | None:
+        return self._parser_engine.create_reasoning_end_tracker(
+            input_ids, reasoning_ended
+        )
 
     def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
         self._parser_engine.adjust_initial_state_from_prompt(prompt_token_ids)

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -26,6 +26,7 @@ from vllm.logger import init_logger
 from vllm.parser.abstract_parser import Parser, StreamState
 from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
+from vllm.parser.engine.reasoning_end_tracker import ReasoningEndTracker
 from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
 from vllm.tool_parsers.utils import (
     coerce_to_schema_type,
@@ -152,6 +153,39 @@ class ParserEngine(Parser):
             for token in parser_engine_config.turn_boundary_tokens
             if (token_id := vocab.get(token)) is not None
         )
+
+    def create_reasoning_end_tracker(
+        self,
+        input_ids: Sequence[int],
+        reasoning_ended: bool | None = None,
+    ) -> ReasoningEndTracker | None:
+        """Create a tracker when token-only matching is state-safe."""
+        config = self.parser_engine_config
+        end_terminals: list[str] = []
+        for (state, terminal), transition in config.transitions.items():
+            if state != ParserState.REASONING:
+                continue
+            ends_reasoning = EventType.REASONING_END in transition.events
+            if ends_reasoning:
+                end_terminals.append(terminal)
+            elif transition.next_state != ParserState.REASONING:
+                return None
+
+        boundaries = []
+        for terminal in dict.fromkeys(end_terminals):
+            text = config.token_id_terminals.get(terminal)
+            if text is None or (token_id := self.vocab.get(text)) is None:
+                return None
+            boundaries.append((token_id,))
+        if not boundaries:
+            return None
+
+        ended = (
+            self.is_reasoning_end(list(input_ids))
+            if reasoning_ended is None
+            else reasoning_ended
+        )
+        return ReasoningEndTracker(tuple(boundaries), ended, input_ids)
 
     @property
     def reasoning_start_str(self) -> str | None:

--- a/vllm/parser/engine/reasoning_end_tracker.py
+++ b/vllm/parser/engine/reasoning_end_tracker.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request-scoped reasoning-end tracking for parser engines."""
+
+from collections.abc import Sequence
+
+
+class ReasoningEndTracker:
+    """Incrementally match token sequences that end reasoning."""
+
+    def __init__(
+        self,
+        boundaries: tuple[tuple[int, ...], ...],
+        reasoning_ended: bool,
+        prefix_token_ids: Sequence[int] = (),
+    ) -> None:
+        self._boundaries = boundaries
+        self._reasoning_ended = reasoning_ended
+        self._matched_prefixes = self._suffix_prefix_lengths(prefix_token_ids)
+
+    @property
+    def reasoning_ended(self) -> bool:
+        return self._reasoning_ended
+
+    def _suffix_prefix_lengths(self, token_ids: Sequence[int]) -> tuple[int, ...]:
+        prefixes = []
+        for boundary in self._boundaries:
+            max_length = min(len(token_ids), len(boundary) - 1)
+            for length in range(max_length, 0, -1):
+                if tuple(token_ids[-length:]) == boundary[:length]:
+                    prefixes.append(length)
+                    break
+            else:
+                prefixes.append(0)
+        return tuple(prefixes)
+
+    def _scan(
+        self,
+        token_ids: Sequence[int],
+        matched_prefixes: tuple[int, ...],
+    ) -> tuple[int | None, tuple[int, ...]]:
+        prefixes = list(matched_prefixes)
+        for offset, token_id in enumerate(token_ids):
+            for index, boundary in enumerate(self._boundaries):
+                matched = prefixes[index]
+                candidate = (*boundary[:matched], token_id)
+                if candidate == boundary:
+                    return offset, tuple(prefixes)
+
+                next_matched = min(len(candidate), len(boundary) - 1)
+                while (
+                    next_matched
+                    and candidate[-next_matched:] != boundary[:next_matched]
+                ):
+                    next_matched -= 1
+                prefixes[index] = next_matched
+        return None, tuple(prefixes)
+
+    def preview(self, token_ids: Sequence[int]) -> int | None:
+        if self._reasoning_ended:
+            return None
+        offset, _ = self._scan(token_ids, self._matched_prefixes)
+        return offset
+
+    def commit(self, token_ids: Sequence[int]) -> int | None:
+        if self._reasoning_ended:
+            return None
+        offset, prefixes = self._scan(token_ids, self._matched_prefixes)
+        if offset is not None:
+            self._reasoning_ended = True
+        else:
+            self._matched_prefixes = prefixes
+        return offset

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     import torch
 
+    from vllm.parser.engine.reasoning_end_tracker import ReasoningEndTracker
     from vllm.reasoning import ReasoningParser
     from vllm.v1.request import Request
 else:
@@ -111,6 +112,23 @@ class StructuredOutputManager:
                 **parser_kwargs,
             )
         return structured_req.reasoner
+
+    def _get_reasoning_end_tracker(
+        self,
+        request: "Request",
+        reasoner: "ReasoningParser",
+        input_ids: Sequence[int],
+    ) -> "ReasoningEndTracker | None":
+        structured_req = request.structured_output_request
+        assert structured_req is not None
+        tracker = structured_req.reasoning_end_tracker
+        if not structured_req.reasoning_end_tracker_initialized:
+            factory = getattr(reasoner, "create_reasoning_end_tracker", None)
+            if factory is not None:
+                tracker = factory(input_ids, structured_req.reasoning_ended)
+            structured_req.reasoning_end_tracker = tracker
+            structured_req.reasoning_end_tracker_initialized = True
+        return tracker
 
     def grammar_init(self, request: "Request") -> None:
         if request.structured_output_request is None:
@@ -292,12 +310,22 @@ class StructuredOutputManager:
 
                 reasoner = None if apply_bitmask else self._get_reasoner(request)
                 detect_reasoning_end = reasoner is not None
+                tracker = (
+                    self._get_reasoning_end_tracker(
+                        request, reasoner, request.all_token_ids
+                    )
+                    if reasoner is not None
+                    else None
+                )
                 simulated_buf: list[int] | None = None
                 history_len = 0
 
                 state_advancements = 0
                 post_reasoning_end_in_window = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
+                previewed_end = (
+                    tracker.preview(req_tokens) if tracker is not None else None
+                )
                 for i, token in enumerate(req_tokens):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
                     advance_grammar = apply_bitmask
@@ -309,12 +337,18 @@ class StructuredOutputManager:
                         and reasoner is not None
                         and not apply_bitmask
                     ):
-                        if simulated_buf is None:
-                            history = list(request.all_token_ids)
-                            history_len = len(history)
-                            simulated_buf = history + list(req_tokens)
-                        simulated = simulated_buf[: history_len + i + 1]
-                        if reasoner.is_reasoning_end_streaming(simulated, [token]):
+                        if tracker is not None:
+                            reasoning_ends_here = i == previewed_end
+                        else:
+                            if simulated_buf is None:
+                                history = list(request.all_token_ids)
+                                history_len = len(history)
+                                simulated_buf = history + list(req_tokens)
+                            simulated = simulated_buf[: history_len + i + 1]
+                            reasoning_ends_here = reasoner.is_reasoning_end_streaming(
+                                simulated, [token]
+                            )
+                        if reasoning_ends_here:
                             # Reasoning ended mid-window. Constrain the rest
                             # of the window via bitmask. Skip grammar advance
                             # through the marker (it is reasoning content);
@@ -388,6 +422,9 @@ class StructuredOutputManager:
                 structured_req.reasoning_ended = reasoner.is_reasoning_end(
                     request.prompt_token_ids or []
                 )
+                self._get_reasoning_end_tracker(
+                    request, reasoner, request.all_token_ids
+                )
             return structured_req.reasoning_ended
         return True
 
@@ -427,7 +464,7 @@ class StructuredOutputManager:
         # count remains > 0 after the step and the computed delta window
         # starts past the reasoning-end marker.
         all_token_ids = request.all_token_ids
-        if new_token_ids:
+        if new_token_ids is not None:
             # The tokens were already appended this step, so the step window
             # starts exactly len(new_token_ids) from the end.
             start = len(all_token_ids) - len(new_token_ids)
@@ -440,11 +477,35 @@ class StructuredOutputManager:
                 else max(len(all_token_ids) + delta_from, 0)
             )
             delta_ids = itertools.islice(all_token_ids, start, None)
-        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
+        tracker = structured_req.reasoning_end_tracker
+        if not structured_req.reasoning_end_tracker_initialized:
+            tracker = self._get_reasoning_end_tracker(
+                request, reasoner, all_token_ids[:start]
+            )
+        if tracker is not None:
+            delta_ids = list(delta_ids)
+            end_offset = (
+                tracker.commit(delta_ids)
+                if new_token_ids is not None
+                else tracker.preview(delta_ids)
+            )
+            reasoning_ended = end_offset is not None
+        else:
+            reasoning_ended = reasoner.is_reasoning_end_streaming(
+                all_token_ids, delta_ids
+            )
+            end_offset = None
+        if reasoning_ended:
+            if tracker is not None and new_token_ids is None:
+                return True
             structured_req.reasoning_ended = True
 
             # Record the boundary so the scheduler can exclude reasoning tokens.
-            end_index = self._find_reasoning_end_index(reasoner, all_token_ids, start)
+            end_index = (
+                start + end_offset
+                if end_offset is not None
+                else self._find_reasoning_end_index(reasoner, all_token_ids, start)
+            )
 
             structured_req.reasoning_end_token_index = end_index
             return True

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -15,6 +15,7 @@ from vllm.v1.structured_output.backend_types import (
 )
 
 if TYPE_CHECKING:
+    from vllm.parser.engine.reasoning_end_tracker import ReasoningEndTracker
     from vllm.reasoning import ReasoningParser
 
 
@@ -35,6 +36,8 @@ class StructuredOutputRequest:
     # Cached per request; do not share reasoning parsers across requests because
     # their behavior can depend on reasoning_parser_kwargs.
     reasoner: "ReasoningParser | None" = None
+    reasoning_end_tracker: "ReasoningEndTracker | None" = None
+    reasoning_end_tracker_initialized: bool = False
 
     @staticmethod
     def from_sampling_params(


### PR DESCRIPTION
## Summary

- derive reasoning-end token sequences from ParserEngineConfig transitions that emit REASONING_END
- track boundary prefixes per request with non-mutating speculative preview and accepted-token commit operations
- use exact boundary offsets when structured-output reasoning ends within a scheduled token batch
- retain the existing reasoning-parser scan as a compatibility fallback

## Tests

- .venv/bin/python -m pytest tests/parser/engine/test_parser_engine.py tests/parser/engine/test_deepseek_v4.py tests/v1/structured_output/test_reasoning_structured_output.py tests/v1/spec_decode/test_mtp_structured_output.py -q — 222 passed
- ruff check and ruff format hooks on all changed Python files — passed
- installed commit-time pre-commit hook suite, including mypy — passed

Model evaluation was not run because this changes parser/scheduler boundary bookkeeping, not model execution or output quality; focused behavioral tests cover the affected paths.
