### PR TITLE
Optimize PLE MTP metadata transfers

### DIFF
--- a/vllm/v1/attention/backends/short_conv_attn.py
+++ b/vllm/v1/attention/backends/short_conv_attn.py
@@ -324,8 +324,8 @@ class PleShortConvAttentionMetadataBuilder(ShortConvAttentionMetadataBuilder):
         decode_req_idx_cpu = decode_mask_cpu.nonzero(as_tuple=True)[0]
         prefill_req_idx_cpu = prefill_mask_cpu.nonzero(as_tuple=True)[0]
         non_spec_req_idx_cpu = torch.cat((decode_req_idx_cpu, prefill_req_idx_cpu))
-        spec_req_idx = spec_req_idx_cpu.to(query_start_loc.device)
-        non_spec_req_idx = non_spec_req_idx_cpu.to(query_start_loc.device)
+        spec_req_idx = async_tensor_h2d(spec_req_idx_cpu, device=query_start_loc.device)
+        non_spec_req_idx: torch.Tensor | None = None
 
         if num_decodes == 0 and num_prefills == 0:
             # Pure speculative-decode batch: all real tokens are spec tokens.
@@ -348,6 +348,12 @@ class PleShortConvAttentionMetadataBuilder(ShortConvAttentionMetadataBuilder):
             # stable sort, so tokens of each request stay contiguous and in
             # request order. This yields spec tokens first, then the non-spec
             # [decode, prefill] tokens.
+            non_spec_req_idx = async_tensor_h2d(
+                non_spec_req_idx_cpu, device=query_start_loc.device
+            )
+            decode_req_idx = async_tensor_h2d(
+                decode_req_idx_cpu, device=query_start_loc.device
+            )
             req_group = torch.full(
                 (m.num_reqs,),
                 2,
@@ -355,7 +361,7 @@ class PleShortConvAttentionMetadataBuilder(ShortConvAttentionMetadataBuilder):
                 device=query_start_loc.device,
             )
             req_group[spec_req_idx] = 0
-            req_group[decode_req_idx_cpu.to(query_start_loc.device)] = 1
+            req_group[decode_req_idx] = 1
             token_group = torch.repeat_interleave(req_group, query_lens)
             token_perm = torch.argsort(token_group, stable=True)
             spec_token_indx = token_perm[:num_spec_decode_tokens]
@@ -391,9 +397,7 @@ class PleShortConvAttentionMetadataBuilder(ShortConvAttentionMetadataBuilder):
         assert num_accepted_tokens is not None
         # Accepted-token counts must follow the same request order as the
         # speculative state indices.
-        num_accepted_tokens = num_accepted_tokens[
-            spec_req_idx_cpu.to(num_accepted_tokens.device)
-        ]
+        num_accepted_tokens = num_accepted_tokens[spec_req_idx]
 
         # Compute the conv-state slots for the non-spec decode/prefill split,
         # plus the initial-state masks and Triton causal_conv1d metadata.
@@ -410,9 +414,8 @@ class PleShortConvAttentionMetadataBuilder(ShortConvAttentionMetadataBuilder):
         state_indices_tensor_d = None
         if num_decodes > 0 or num_prefills > 0:
             num_computed_tokens = m.compute_num_computed_tokens()
-            if non_spec_req_idx_cpu is not None:
-                non_spec_req_idx = non_spec_req_idx_cpu.to(num_computed_tokens.device)
-                num_computed_tokens = num_computed_tokens[non_spec_req_idx]
+            assert non_spec_req_idx is not None
+            num_computed_tokens = num_computed_tokens[non_spec_req_idx]
 
             state_indices_tensor_d = state_indices_tensor[:num_decodes]
             state_indices_tensor_p = state_indices_tensor[


### PR DESCRIPTION
## Purpose

The Qwen4Exp PLE speculative-decode metadata builder performs several small host-to-device request-index transfers every decode step. Using synchronous `.to(device)` calls on this path introduces stream synchronization and leaves gaps between otherwise unchanged GPU kernels.

This PR uses `async_tensor_h2d` for the speculative, non-speculative, and decode request indices, then reuses those device tensors for the accepted-token and computed-token gathers. It removes the synchronization points without changing request ordering or model math.

Open-PR searches for `short_conv_attn async_tensor_h2d`, `spec_req_idx`, and `PleShortConvAttentionMetadataBuilder` found no existing PR that implements this optimization.

## Performance Impact

Nsight Systems validation used GB300, FP8, TP1, MTP3, `FULL_DECODE_ONLY` CUDA graphs, 8K input, 1K output, C1, and 20 profiled decode steps on the same node:

| Metric | Base | Optimized | Change |
| --- | ---: | ---: | ---: |
| GPU activity span / step | 11.185 ms | 9.272 ms | -17.102% |
| `cudaStreamSynchronize` / step | 2 | 0 | -100% |
| Summed kernel time / step | 10.810 ms | 10.813 ms | +0.003 ms |

The unchanged kernel time and shorter activity span confirm that the gain comes from removing metadata-transfer synchronization rather than changing GPU kernels.

Five same-node alternating Base/Optimized pairs with the same FP8 TP1 MTP3 8K/1K configuration measured output-throughput changes of:

| Concurrency | Output throughput change |
| ---: | ---: |
| C1 | +9.877% |
| C2 | +4.740% |
| C4 | +7.287% |
| C8 | +0.409% |

These measurements were collected with the identical code delta before its final rebase onto current `main`; latest-main CI validation is still pending.

## Test Plan

- Run Ruff lint and formatting checks on the changed file.
- Run `git diff --check`.
- Run the Qwen4Exp PLE tests in a complete CUDA development environment.
- Let upstream CI exercise the latest-main dependency matrix.

## Test Result

- `ruff check vllm/v1/attention/backends/short_conv_attn.py`: passed.
- `ruff format --check vllm/v1/attention/backends/short_conv_attn.py`: passed.
- `git diff --check`: passed.
- AIME 2026 correctness evaluation of the identical code delta: 239/240 samples correct, with no request errors or truncations.
- `pytest tests/models/qwen4_exp/test_ple.py -q`: not started on the host because the available development environment lacks `numpy` and `torch`; this PR remains a draft pending CUDA test and CI completion.

AI assistance was used to prepare this draft. Before marking it ready for review, the human submitter must understand and review every changed line and confirm the relevant tests and evaluation results.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] The test plan is described.
- [x] Available correctness and performance results are included.
- [x] No documentation update is required for this internal metadata-path optimization.
</details>
