### PR TITLE
[BugFix][Model Runner V2][Spec Decode] Fix decode instance's multi-layer MTP kv caches during P/D

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -130,7 +130,7 @@ class TestPushScheduler:
 
         with patch.object(
             sched,
-            "_truncate_mamba_request_for_prefill",
+            "_truncate_request_for_prefill",
             side_effect=AssertionError("must not truncate after cache lookup"),
         ):
             assert sched.get_num_new_matched_tokens(request, 0) == (0, False)

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -519,6 +519,8 @@ def make_nixl_scheduler(
     Only sets the flags needed by the tests.  When *heartbeat=True* the
     scheduler-side heartbeat bookkeeping fields are also initialised.
     """
+    from types import SimpleNamespace
+
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler import (
         NixlConnectorScheduler,
     )
@@ -530,6 +532,7 @@ def make_nixl_scheduler(
         block_size=16,
         mamba_enabled=has_mamba,
     )
+    sched.vllm_config = SimpleNamespace(num_prefill_lookahead_tokens=0)
 
     if heartbeat:
         sched._heartbeat_by_engine = {}
@@ -593,9 +596,11 @@ def make_nixl_push_scheduler(
         mamba_enabled=has_mamba,
     )
 
-    # vllm_config is consulted for parallel_config.tensor_parallel_size.
+    # vllm_config is consulted for parallel_config.tensor_parallel_size, and by
+    # `_prefill_backoff` on both the P and D prefill paths.
     vllm_config = MagicMock()
     vllm_config.parallel_config.tensor_parallel_size = 1
+    vllm_config.num_prefill_lookahead_tokens = 0
     sched.vllm_config = vllm_config
 
     # Push-specific state.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -644,6 +644,29 @@ class VllmConfig:
         return 0
 
     @property
+    def num_prefill_lookahead_tokens(self) -> int:
+        """Prefill tokens past the computed range that the drafter reads.
+
+        Mid-prefill the drafter consumes tokens the target model has not been
+        scheduled for yet, so every component that has to keep them available
+        must apply this margin: the scheduler, which never ends a chunk within
+        it and shifts encoder scheduling by it, and the KV cache manager, which
+        treats the trailing `this - 1` tokens as re-prefillable rather than
+        finalized. Consumers must read this property rather than re-deriving
+        their own per-method lookahead, so those components cannot drift apart.
+        """
+        speculative_config = self.speculative_config
+        if speculative_config is None or not speculative_config.use_eagle():
+            return 0
+        if speculative_config.use_multi_module_mtp():
+            # Each MTP module reads one token further ahead than the one before
+            # it, so the chain needs num_speculative_tokens of runway at a
+            # chunked-prefill boundary.
+            return self.num_speculative_tokens
+        # Eagle-family drafters read only the immediate next token.
+        return 1
+
+    @property
     def uniform_decode_query_len(self) -> int:
         """Query length of every request in a uniform decode batch.
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -196,8 +196,8 @@ class NixlBaseConnectorScheduler:
     def on_new_request(self, request: "Request") -> None:
         """Track a request that may need heartbeats."""
         params = request.kv_transfer_params
-        if params is not None and params.get("do_remote_decode") and self._has_mamba:
-            self._truncate_mamba_request_for_prefill(request)
+        if params is not None and params.get("do_remote_decode"):
+            self._truncate_request_for_prefill(request)
 
         # NOTE (NickLucche) This excludes request meant for P, ie heartbeats are
         # effectively disabled for Bidirectional KV transfer.
@@ -379,36 +379,56 @@ class NixlBaseConnectorScheduler:
                     (identity, b"", encoded_data[(target_pp_rank, target_tp_rank)], ts)
                 )
 
+    def _prefill_backoff(self) -> int:
+        """Trailing prompt tokens the prefiller must not compute; the decoder
+        recomputes them locally.
+
+        Mamba needs h(N-1) so the decoder can derive h(N) itself. Multi-module
+        MTP needs to keep its whole lookahead window off of the prefiller, which
+        would otherwise embed the unverified drafts in the MTP layer's KV cache. The
+        decoder would never rebuild them, because the update is sized by the rejection
+        count, which is zero for the first decode.
+        """
+        return max(
+            1 if self._has_mamba else 0,
+            self.vllm_config.num_prefill_lookahead_tokens - 1,
+        )
+
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
-        """D-side only. Returns N-1 for Mamba models since the decoder
-        always recomputes the last token and must start from h(N-1)."""
-        if self._has_mamba and num_prompt_tokens > 1:
-            return num_prompt_tokens - 1
+        """D-side only. The number of prompt tokens to load from the prefiller.
+        Stops short of the trailing ``_prefill_backoff()`` tokens that the decoder
+        will recompute locally."""
+        backoff = self._prefill_backoff()
+        if backoff and num_prompt_tokens > backoff:
+            return num_prompt_tokens - backoff
         return num_prompt_tokens
 
-    def _truncate_mamba_request_for_prefill(self, request: "Request") -> None:
-        """P-side only: drop the last prompt token so the prefiller computes
-        h(N-1) instead of h(N). The decoder recomputes the last token to
-        derive h(N) correctly.
+    def _truncate_request_for_prefill(self, request: "Request") -> None:
+        """P-side only: drop the trailing ``_prefill_backoff()`` prompt tokens
+        so the prefiller stops short of what the decoder recomputes locally.
+        For Mamba that is the single token needed to yield h(N-1); for
+        multi-module MTP it is the drafter's whole lookahead window.
 
         Guarded by ``_p_side_truncated`` to avoid repeated truncation if the
         request is preempted and rescheduled."""
+        backoff = self._prefill_backoff()
         params = request.kv_transfer_params
         if (
-            params is not None
+            backoff
+            and params is not None
             # Guard against repeated truncation after preemption/reschedule.
             and not params.get("_p_side_truncated")
-            and request.num_prompt_tokens > 1
+            and request.num_prompt_tokens > backoff
         ):
             if request.prompt_token_ids is not None:
-                request.prompt_token_ids.pop()
+                del request.prompt_token_ids[-backoff:]
             elif request.prompt_embeds is not None:
-                request.prompt_embeds = request.prompt_embeds[:-1]
+                request.prompt_embeds = request.prompt_embeds[:-backoff]
             else:
                 return
 
-            request._all_token_ids.pop()
-            request.num_prompt_tokens -= 1
+            del request._all_token_ids[-backoff:]
+            request.num_prompt_tokens -= backoff
             request.max_tokens = 1
             params["_p_side_truncated"] = True
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2582,12 +2582,7 @@ def get_kv_cache_configs(
 
     # When speculating with more than 1 speculative module (e.g. multi-layered MTP)
     # tag every SlidingWindowSpec with how many extra tokens to retain in the window.
-    extra_retained_tokens = (
-        vllm_config.speculative_config.num_speculative_tokens - 1
-        if vllm_config.speculative_config is not None
-        and vllm_config.speculative_config.use_multi_module_mtp()
-        else 0
-    )
+    extra_retained_tokens = max(0, vllm_config.num_prefill_lookahead_tokens - 1)
     for layer_name, layer_spec in merged_kv_cache_specs.items():
         if isinstance(layer_spec, SlidingWindowSpec):
             merged_kv_cache_specs[layer_name] = replace(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -263,13 +263,7 @@ class Scheduler(SchedulerInterface):
         self.use_eagle_block_drop = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
         self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
-        # Positions past the computed tokens that the drafter reads mid-prefill.
-        # Eagle-family drafters read 1 ahead, but multi-module MTP reads
-        # num_spec_tokens ahead at chunked-prefill boundaries. Determines the
-        # encoder scheduling shift, the deferred encoder free, the KV cache
-        # manager's re-prefillable window (this minus 1), and how many tokens to
-        # reserve between a chunk boundary and the prefill end.
-        self.num_prefill_lookahead = 0
+        self.num_prefill_lookahead = vllm_config.num_prefill_lookahead_tokens
         self.dynamic_sd_lookup: list[int] | None = None
         if speculative_config is not None:
             if speculative_config.num_speculative_tokens_per_batch_size:
@@ -279,12 +273,6 @@ class Scheduler(SchedulerInterface):
                     vllm_num_speculative_tokens=self.num_spec_tokens,
                 )
             self.use_eagle = speculative_config.use_eagle()
-            if self.use_eagle:
-                self.num_prefill_lookahead = (
-                    self.num_spec_tokens
-                    if speculative_config.use_multi_module_mtp()
-                    else 1
-                )
             self.use_eagle_block_drop = speculative_config.use_eagle_block_drop()
             if self.use_eagle and not self.use_eagle_block_drop:
                 logger.warning(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -296,15 +296,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.is_pooling_model = self.model_config.runner_type == "pooling"
         self.pooling_runner: PoolingRunner | None = None
 
-        # Multi-module MTP feeds its modules the next num_speculative_steps prefill
-        # tokens during chunked prefill. Other speculators only read the immediate
-        # next one.
-        num_prefill_lookahead = (
-            self.num_speculative_steps
-            if self.speculative_config is not None
-            and self.speculative_config.use_multi_module_mtp()
-            else 1
-        )
+        num_prefill_lookahead = max(1, vllm_config.num_prefill_lookahead_tokens)
 
         self.step_timing = StepTimingCollector()
 


### PR DESCRIPTION
## Context
During multi-module MTP with P/D, the prefill instance runs prefill on the full prompt and the last N MTP layers each generate a draft token. This is problematic on the last prefill chunk, because MTP layer i will embed its draft token into MTP layer i + 1. Those draft tokens are unverified, and remain in the KV cache for those last N-1 MTP layers. See the visualization below:
<img width="1066" height="324" alt="image" src="https://github.com/user-attachments/assets/c0ea7afb-8095-47ff-815f-085f0ab3612c" />

During standalone serving, the next decode step would receive the number of rejections, and would re-prefill those stale cache slots accordingly. During P/D, the decode instance doesn't receive this information, and thus the unverified draft tokens remain in the KV cache, hurting acceptance rates.

## This PR
Generalizes the 1-token backoff used by Mamba to skip prefilling the last token on the prefill instance, and recompute that token on the decode instance, for multi-module MTP. Now, the prefill instance no longer pollutes the last N-1 MTP modules with unverified draft tokens, and the decode instance completes prefill for the last N-1 prompt tokens.

I created a helper method in `VllmConfig` called `num_prefill_lookahead_tokens` that is used to get the number of MTP modules, and use them for this prefill backoff. It is now called by several other callsites to reduce code duplication.

## Benchmarks
Inkling-Small-NVFP4, 1P1D on one 4×GB200 node (prefill GPUs 0,1 / decode GPUs 2,3, TP=2 each),
`{"method":"mtp","num_speculative_tokens":8}`, SPEED-Bench `throughput_16k`/`low_entropy`,
2048 in / 2048 out, concurrency 64, 512 prompts. Acceptance read from the decode instance's `/metrics`.

| Metric | Before (`ae71862c51`) | After (`5ee6a77da2`) | Delta |
|---|---:|---:|---:|
| **acceptance_length** | **1.0891** | **3.5207** | **+2.4316** |
| **acceptance_rate** | **1.11%** | **31.51%** | **+30.40** |
| Total token throughput | 3,520 tok/s | 12,156 tok/s | +245% |
| Mean TPOT | 35.67 ms | 9.99 ms | −72% |
| Mean E2EL | 73.6 s | 20.5 s | −72% |
| Benchmark wall time | 634.8 s | 204.4 s | −68% |

| Position | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Before | .0259 | .0179 | .0132 | .0095 | .0074 | .0060 | .0050 | .0042 |
| After | .6745 | .4802 | .3575 | .2806 | .2282 | .1917 | .1644 | .1436 |

Both arms completed 512/512 requests with 0 failures on identical input (1,048,576 tokens).
Output token counts differ by 2.3%. An acceptance length of 1.089 means ~99% of drafts were
rejected. Speculative decoding was effectively inert under P/D before the fix.
