### PR TITLE
[Examples] Fix ghost demo.py Usage in chat_with_tools_offline

### DIFF
--- a/examples/tool_calling/chat_with_tools_offline.py
+++ b/examples/tool_calling/chat_with_tools_offline.py
@@ -42,8 +42,7 @@ from vllm.sampling_params import SamplingParams
 # ```
 #
 # Usage:
-#     python demo.py simple
-#     python demo.py advanced
+#     python examples/tool_calling/chat_with_tools_offline.py
 
 model_name = "mistralai/Mistral-7B-Instruct-v0.3"
 # or switch to "mistralai/Mistral-Nemo-Instruct-2407"


### PR DESCRIPTION
## Summary
- Fix the Usage comment in `examples/tool_calling/chat_with_tools_offline.py`.
- It previously told readers to run `python demo.py simple` / `python demo.py advanced`, but there is no `demo.py` and this script has no CLI modes (no argparse / argv / simple|advanced branches).
- Point Usage at the actual one-file offline demo instead.

## Repro
On current `main` (`0e14198a63c03f899a10f3e782e88eca7f11265b`):

```bash
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/tool_calling/chat_with_tools_offline.py | sed -n '44,46p'
# Usage:
#     python demo.py simple
#     python demo.py advanced

curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/examples/tool_calling/demo.py | head -1
# HTTP/2 404

# Directory listing has no demo.py; script has no argparse/sys.argv/simple|advanced modes.
```

## Test plan
- [x] Confirm Usage block no longer mentions `demo.py` / `simple` / `advanced`
- [x] Confirm run path matches `examples/tool_calling/chat_with_tools_offline.py`
- [x] Comment-only change; runtime code untouched
