### PR TITLE
[ROCm][CI] Add MiniMax reduce RMS kernel coverage

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1603,6 +1603,24 @@ steps:
   commands:
   - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
+- label: ":amd: (MI300) MiniMax Reduce RMS Kernels" # TBD
+  timeout_in_minutes: 25
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  dind: false
+  agent_pool: mi300_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/model_executor/layers/minimax_rms_norm/
+  - vllm/distributed/
+  - vllm/_aiter_ops.py
+  - vllm/envs.py
+  - vllm/platforms/rocm.py
+  - tests/kernels/core/test_minimax_reduce_rms.py
+  - tests/utils.py
+  commands:
+  - pytest -v -s kernels/core/test_minimax_reduce_rms.py
+
 - label: ":amd: (MI300) KDA Kernels" # TBD
   timeout_in_minutes: 30
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
@@ -3450,6 +3468,24 @@ steps:
   - vllm/platforms/rocm.py
   commands:
   - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+
+- label: ":amd: (MI355) MiniMax Reduce RMS Kernels" # TBD
+  timeout_in_minutes: 25
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
+  dind: false
+  agent_pool: mi355_2
+  num_gpus: 2
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/model_executor/layers/minimax_rms_norm/
+  - vllm/distributed/
+  - vllm/_aiter_ops.py
+  - vllm/envs.py
+  - vllm/platforms/rocm.py
+  - tests/kernels/core/test_minimax_reduce_rms.py
+  - tests/utils.py
+  commands:
+  - pytest -v -s kernels/core/test_minimax_reduce_rms.py
 
 - label: ":amd: (MI355) Kernels" # TBD
   timeout_in_minutes: 25

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1604,7 +1604,7 @@ steps:
   - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
 - label: ":amd: (MI300) MiniMax Reduce RMS Kernels" # TBD
-  timeout_in_minutes: 25
+  timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   dind: false
   agent_pool: mi300_2
@@ -3470,7 +3470,7 @@ steps:
   - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
 - label: ":amd: (MI355) MiniMax Reduce RMS Kernels" # TBD
-  timeout_in_minutes: 25
+  timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
   dind: false
   agent_pool: mi355_2

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -33,13 +33,32 @@ steps:
   num_devices: 2
   device: h100
   source_file_dependencies:
-  - csrc/minimax_reduce_rms_kernel.cu
-  - csrc/minimax_reduce_rms_kernel.h
-  - vllm/model_executor/layers/mamba/linear_attn.py
-  - vllm/model_executor/layers/mamba/lamport_workspace.py
+  - csrc/libtorch_stable/minimax_reduce_rms_kernel.cu
+  - csrc/libtorch_stable/minimax_reduce_rms_kernel.h
+  - csrc/libtorch_stable/ops.h
+  - csrc/libtorch_stable/torch_bindings.cpp
+  - vllm/model_executor/layers/minimax_rms_norm/
+  - vllm/model_executor/layers/mamba/linear/minimax_linear_attn.py
   - tests/kernels/core/test_minimax_reduce_rms.py
   commands:
     - pytest -v -s kernels/core/test_minimax_reduce_rms.py
+  mirror:
+    amd:
+      label: ":amd: (MI300) MiniMax Reduce RMS Kernels"
+      dind: false
+      device: mi300_2
+      timeout_in_minutes: 40
+      working_dir: "/vllm-workspace/tests"
+      depends_on:
+      - image-build-amd
+      source_file_dependencies:
+      - vllm/model_executor/layers/minimax_rms_norm/
+      - vllm/distributed/
+      - vllm/_aiter_ops.py
+      - vllm/envs.py
+      - vllm/platforms/rocm.py
+      - tests/kernels/core/test_minimax_reduce_rms.py
+      - tests/utils.py
 
 - label: ":nvidia: (H100) DeepSeek V4 Kernels"
   key: deepseek-v4-kernel-test-h100

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -44,10 +44,10 @@ steps:
     - pytest -v -s kernels/core/test_minimax_reduce_rms.py
   mirror:
     amd:
-      label: ":amd: (MI300) MiniMax Reduce RMS Kernels"
+      label: ":amd: (MI355) MiniMax Reduce RMS Kernels"
       dind: false
-      device: mi300_2
-      timeout_in_minutes: 40
+      device: mi355_2
+      timeout_in_minutes: 45
       working_dir: "/vllm-workspace/tests"
       depends_on:
       - image-build-amd

--- a/tests/kernels/core/test_minimax_reduce_rms.py
+++ b/tests/kernels/core/test_minimax_reduce_rms.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for MiniMax QK RMS-norm: NCCL reference vs Lamport fused kernel."""
+"""Tests for MiniMax QK RMS-norm fused all-reduce kernels and fallbacks."""
+
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -9,6 +11,7 @@ from torch.multiprocessing import spawn
 
 from tests.kernels.utils import opcheck
 from tests.utils import ensure_current_vllm_config, init_test_distributed_environment
+from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.model_executor.layers.minimax_rms_norm import (
     MiniMaxText01RMSNormTP,
@@ -122,6 +125,116 @@ def _worker_forward_qk(
     torch.testing.assert_close(fused_k, ref_k, atol=3e-2, rtol=3e-2)
 
     cleanup_dist_env_and_memory()
+
+
+@ensure_current_vllm_config()
+def _worker_forward_qk_rocm_aiter(
+    local_rank: int,
+    world_size: int,
+    port: str,
+    hidden_q_full: int,
+    hidden_k_full: int,
+    seed: int,
+    eps: float,
+) -> None:
+    """Compare the ROCm AITER fusion with the eager TP implementation."""
+    device = torch.device(f"cuda:{local_rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(
+        world_size, 1, local_rank, port, local_rank=local_rank
+    )
+
+    try:
+        aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
+        assert aiter_ar is not None, "AITER custom all-reduce was not initialized"
+        assert not aiter_ar.disabled, "AITER custom all-reduce is disabled"
+        assert hasattr(aiter_ar.aiter_ca, "custom_fused_qknorm_ar")
+
+        hq = hidden_q_full // world_size
+        hk = hidden_k_full // world_size
+        test_cases = (
+            (1, torch.bfloat16),
+            (128, torch.bfloat16),
+            (333, torch.bfloat16),
+            (1, torch.float16),
+            (128, torch.float16),
+            (333, torch.float16),
+        )
+
+        for num_tokens, dtype in test_cases:
+            q_norm = MiniMaxText01RMSNormTP(hidden_q_full, eps=eps).cuda()
+            k_norm = MiniMaxText01RMSNormTP(hidden_k_full, eps=eps).cuda()
+
+            set_random_seed(seed)
+            q_weight = torch.randn(hidden_q_full, dtype=dtype, device="cuda")
+            k_weight = torch.randn(hidden_k_full, dtype=dtype, device="cuda")
+            q_norm.weight = nn.Parameter(
+                q_weight[local_rank * hq : (local_rank + 1) * hq]
+            )
+            k_norm.weight = nn.Parameter(
+                k_weight[local_rank * hk : (local_rank + 1) * hk]
+            )
+
+            torch.manual_seed(seed + num_tokens + local_rank)
+            qkv = torch.randn(num_tokens, hq + hk + hk, dtype=dtype, device="cuda")
+
+            ref_q, ref_k = rms_norm_tp._minimax_qk_norm_tp_eager(
+                qkv.clone(),
+                q_norm.weight,
+                k_norm.weight,
+                hq,
+                hk,
+                world_size,
+                eps,
+            )
+
+            with (
+                patch.object(rms_norm_tp, "_MINIMAX_FUSED_AR_RMS_QK", None),
+                patch.object(
+                    rms_norm_tp,
+                    "_minimax_qk_norm_tp_fallback",
+                    side_effect=AssertionError(
+                        "ROCm AITER test unexpectedly used the fallback"
+                    ),
+                ),
+            ):
+                fused_q, fused_k, fused_v = MiniMaxText01RMSNormTP.forward_qkv(
+                    q_norm, k_norm, qkv.clone(), hq, hk
+                )
+
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(fused_q, ref_q, atol=3e-2, rtol=3e-2)
+            torch.testing.assert_close(fused_k, ref_k, atol=3e-2, rtol=3e-2)
+            assert torch.equal(fused_v, qkv[:, hq + hk :])
+    finally:
+        cleanup_dist_env_and_memory()
+
+
+@pytest.mark.distributed(num_gpus=2)
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="ROCm required",
+)
+def test_minimax_reduce_rms_qk_rocm_aiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MiniMax TP QK path dispatches to AITER and matches eager RMSNorm."""
+    assert is_aiter_found_and_supported(), "AITER requires ROCm CDNA3 or newer"
+
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER_CUSTOM_AR", "1")
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION", "NONE")
+
+    world_size = 2
+    if current_platform.device_count() < world_size:
+        pytest.skip("Need at least two GPUs")
+
+    spawn(
+        _worker_forward_qk_rocm_aiter,
+        args=(world_size, str(get_open_port()), 6144, 1024, 42, 1e-6),
+        nprocs=world_size,
+        join=True,
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
- Add a two-GPU ROCm test that forces MiniMax tensor-parallel Q/K RMSNorm through AITER custom all-reduce and compares it with the eager reference.
- Cover BF16 and FP16 across representative token counts while verifying that the V output remains unchanged and the fallback is not silently selected.
- Add dedicated MiniMax kernel jobs for MI300 and MI355, including an AMD mirror that runs the same full-file pytest command as the upstream NVIDIA job.

MiniMax Q/K RMSNorm has distinct fused all-reduce paths on NVIDIA and ROCm, but the ROCm AITER path lacked targeted multi-GPU correctness coverage. The new test exercises production dispatch with AITER custom all-reduce enabled, fails if execution falls back, and checks its results against the eager implementation. Dedicated MI300 and MI355 jobs provide the two-GPU AMD environment required by the test while preserving the upstream full-file test command.
