### PR TITLE
[ROCm] Add V1 streamed FP8 pipeline transport

### DIFF
--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -27,7 +27,7 @@ from vllm.distributed.parallel_state import GroupCoordinator, TensorMetadata
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils.import_utils import has_aiter
-from vllm.v1.worker.gpu.pp_transport import PPTransport
+from vllm.v1.worker.gpu.pp_transport import PPTransport, PPTransportMode
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 
 from ..utils import (
@@ -670,6 +670,7 @@ def _pp_transport_test_worker(
     pp_size: int,
     rank: int,
     distributed_init_port: str,
+    mode: PPTransportMode,
 ):
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     device = torch.device(f"cuda:{rank}")
@@ -681,6 +682,7 @@ def _pp_transport_test_worker(
         {"hidden_states": torch.empty(shape, dtype=torch.bfloat16, device=device)}
     )
     transport = PPTransport(
+        mode,
         schema,
         chunk_tokens=shape[0],
         ring_size=2,
@@ -708,7 +710,12 @@ def _pp_transport_test_worker(
                 handle.wait()
             for fn in postprocess:
                 fn()
-            torch.testing.assert_close(tensors["hidden_states"], value)
+            torch.testing.assert_close(
+                tensors["hidden_states"],
+                value,
+                rtol=0.15 if mode == "fp8" else 0,
+                atol=0.15 if mode == "fp8" else 0,
+            )
         tail = get_pp_group().recv_tensor_dict()
         assert tail is not None
         torch.testing.assert_close(
@@ -719,7 +726,12 @@ def _pp_transport_test_worker(
 
 @ray.remote(num_gpus=1, max_calls=1)
 def pp_stream_transport_test_worker(*args):
-    _pp_transport_test_worker(*args)
+    _pp_transport_test_worker(*args, mode="stream")
+
+
+@ray.remote(num_gpus=1, max_calls=1)
+def pp_fp8_transport_test_worker(*args):
+    _pp_transport_test_worker(*args, mode="fp8")
 
 
 @multi_gpu_test(num_gpus=2)
@@ -759,7 +771,10 @@ def test_multi_process_pipeline_parallel(
     not current_platform.is_rocm() or not has_aiter(),
     reason="requires ROCm and AITER",
 )
-@pytest.mark.parametrize("test_target", [pp_stream_transport_test_worker])
+@pytest.mark.parametrize(
+    "test_target",
+    [pp_stream_transport_test_worker, pp_fp8_transport_test_worker],
+)
 def test_multi_process_pp_transport(
     monkeypatch: pytest.MonkeyPatch,
     test_target: Callable[..., Any],

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -24,6 +24,10 @@ from vllm.distributed import (
 from vllm.distributed.device_communicators import flashinfer_all_reduce
 from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
 from vllm.distributed.parallel_state import GroupCoordinator, TensorMetadata
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+from vllm.utils.import_utils import has_aiter
+from vllm.v1.worker.gpu.pp_transport import PPTransport
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 
 from ..utils import (
@@ -660,6 +664,64 @@ def async_send_recv_tensor_test_worker(
         torch.testing.assert_close(received, expected)
 
 
+def _pp_transport_test_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+    shape = (8, 256)
+    schema = IntermediateTensors(
+        {"hidden_states": torch.empty(shape, dtype=torch.bfloat16, device=device)}
+    )
+    transport = PPTransport(
+        schema,
+        chunk_tokens=shape[0],
+        ring_size=2,
+        device=device,
+    )
+
+    expected = [
+        torch.full(shape, value, dtype=torch.bfloat16, device=device)
+        for value in (1.0, 2.0)
+    ]
+    if get_pp_group().is_first_rank:
+        for value in expected:
+            transport.send(value)
+        tail = torch.full((4, 256), 3.0, dtype=torch.bfloat16, device=device)
+        transport.send_generic(
+            {"hidden_states": tail},
+            all_gather_group=None,
+            all_gather_tensors={},
+        )
+        transport.drain()
+    else:
+        for value in expected:
+            tensors, handles, postprocess = transport.receive()
+            for handle in handles:
+                handle.wait()
+            for fn in postprocess:
+                fn()
+            torch.testing.assert_close(tensors["hidden_states"], value)
+        tail = get_pp_group().recv_tensor_dict()
+        assert tail is not None
+        torch.testing.assert_close(
+            tail["hidden_states"],
+            torch.full((4, 256), 3.0, dtype=torch.bfloat16, device=device),
+        )
+
+
+@ray.remote(num_gpus=1, max_calls=1)
+def pp_stream_transport_test_worker(*args):
+    _pp_transport_test_worker(*args)
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize(
@@ -690,6 +752,19 @@ def test_multi_process_pipeline_parallel(
     test_target: Callable[..., Any],
 ):
     multi_process_parallel(monkeypatch, 1, pp_size, test_target)
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.skipif(
+    not current_platform.is_rocm() or not has_aiter(),
+    reason="requires ROCm and AITER",
+)
+@pytest.mark.parametrize("test_target", [pp_stream_transport_test_worker])
+def test_multi_process_pp_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    test_target: Callable[..., Any],
+):
+    multi_process_parallel(monkeypatch, 1, 2, test_target)
 
 
 @multi_gpu_test(num_gpus=4)

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -245,6 +245,47 @@ def _make_group_for_unit_test(
     return g
 
 
+def test_async_single_tensor_uses_default_neighbors_and_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int, object]] = []
+    work = _DummyWork()
+
+    def fake_isend(tensor, dst, group):
+        calls.append(("send", dst, group))
+        return work
+
+    def fake_irecv(tensor, src, group):
+        calls.append(("recv", src, group))
+        return work
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "isend", fake_isend)
+    monkeypatch.setattr(torch.distributed, "irecv", fake_irecv)
+
+    group = _make_group_for_unit_test(rank_in_group=1, world_size=3)
+    group.cpu_group = object()
+    group.device_group = object()
+
+    assert group.isend_tensor(torch.empty(1)) is work
+    assert group.irecv_tensor(torch.empty(1)) is work
+    assert calls == [
+        ("send", 2, group.cpu_group),
+        ("recv", 0, group.cpu_group),
+    ]
+
+
+def test_async_single_tensor_requires_initialized_multi_rank_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = _make_group_for_unit_test(world_size=2)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    with pytest.raises(RuntimeError, match="initialized multi-rank"):
+        group.isend_tensor(torch.empty(1))
+    with pytest.raises(RuntimeError, match="initialized multi-rank"):
+        group.irecv_tensor(torch.empty(1))
+
+
 def test_irecv_tensor_dict_send_allgather_postprocess_binds_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -594,6 +635,31 @@ def send_recv_test_worker(
         torch.testing.assert_close(test_tensor, recv_tensor)
 
 
+@ray.remote(num_gpus=1, max_calls=1)
+def async_send_recv_tensor_test_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+    expected = torch.arange(64, dtype=torch.float32, device="cuda")
+    if get_pp_group().is_first_rank:
+        work = get_pp_group().isend_tensor(expected)
+    else:
+        received = torch.empty_like(expected)
+        work = get_pp_group().irecv_tensor(received)
+    work.wait()
+
+    if not get_pp_group().is_first_rank:
+        torch.testing.assert_close(received, expected)
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize(
@@ -611,7 +677,12 @@ def test_multi_process_tensor_parallel(
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("pp_size", [2])
 @pytest.mark.parametrize(
-    "test_target", [send_recv_test_worker, send_recv_tensor_dict_test_worker]
+    "test_target",
+    [
+        send_recv_test_worker,
+        send_recv_tensor_dict_test_worker,
+        async_send_recv_tensor_test_worker,
+    ],
 )
 def test_multi_process_pipeline_parallel(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -29,6 +29,23 @@ def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):
     assert not hasattr(envs.__getattr__, "cache_info")
 
 
+@pytest.mark.parametrize("value", ["disabled", "stream"])
+def test_rocm_pp_transport_modes(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("VLLM_ROCM_PP_TRANSPORT", value)
+    assert value == envs.VLLM_ROCM_PP_TRANSPORT
+
+
+def test_rocm_pp_transport_rejects_invalid_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_ROCM_PP_TRANSPORT", "invalid")
+    with pytest.raises(ValueError, match="VLLM_ROCM_PP_TRANSPORT"):
+        _ = envs.VLLM_ROCM_PP_TRANSPORT
+
+
 def test_nixl_side_channel_host_is_not_compile_factor(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -29,7 +29,7 @@ def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):
     assert not hasattr(envs.__getattr__, "cache_info")
 
 
-@pytest.mark.parametrize("value", ["disabled", "stream"])
+@pytest.mark.parametrize("value", ["disabled", "stream", "fp8"])
 def test_rocm_pp_transport_modes(
     monkeypatch: pytest.MonkeyPatch,
     value: str,

--- a/tests/v1/worker/test_pp_transport.py
+++ b/tests/v1/worker/test_pp_transport.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.sequence import IntermediateTensors
+from vllm.v1.worker.gpu.pp_transport import PPTransport
+
+
+def test_transport_rejects_unsupported_schema() -> None:
+    schema = IntermediateTensors(
+        {
+            "hidden_states": torch.empty(8, 32, dtype=torch.bfloat16),
+            "residual": torch.empty(8, 32, dtype=torch.bfloat16),
+        }
+    )
+    with pytest.raises(ValueError, match="single hidden_states"):
+        PPTransport(schema, 8, 2, torch.device("cpu"))
+
+
+def test_transport_drain_waits_every_ring_slot() -> None:
+    transport = PPTransport.__new__(PPTransport)
+    work = [[Mock(), Mock()], None, [Mock()]]
+    generic_work = Mock()
+    transport._send_work = work
+    transport._generic_send_work = [[generic_work]]
+
+    transport.drain()
+
+    for slot in work:
+        if slot is not None:
+            for handle in slot:
+                handle.wait.assert_called_once_with()
+    generic_work.wait.assert_called_once_with()
+    assert transport._send_work == [None, None, None]
+    assert transport._generic_send_work == []
+
+
+def test_transport_reaps_completed_generic_sends() -> None:
+    transport = PPTransport.__new__(PPTransport)
+    metadata = Mock()
+    tensor = Mock()
+    tensor.is_completed.return_value = True
+    transport._generic_send_work = [[metadata, tensor]]
+
+    transport._reap_generic_send_work()
+
+    metadata.wait.assert_called_once_with()
+    tensor.wait.assert_called_once_with()
+    assert transport._generic_send_work == []

--- a/tests/v1/worker/test_pp_transport.py
+++ b/tests/v1/worker/test_pp_transport.py
@@ -6,8 +6,13 @@ from unittest.mock import Mock
 import pytest
 import torch
 
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
-from vllm.v1.worker.gpu.pp_transport import PPTransport
+from vllm.utils.import_utils import has_aiter
+from vllm.v1.worker.gpu.pp_transport import (
+    PPTransport,
+    dequant_fp8_per_token,
+)
 
 
 def test_transport_rejects_unsupported_schema() -> None:
@@ -18,7 +23,15 @@ def test_transport_rejects_unsupported_schema() -> None:
         }
     )
     with pytest.raises(ValueError, match="single hidden_states"):
-        PPTransport(schema, 8, 2, torch.device("cpu"))
+        PPTransport("stream", schema, 8, 2, torch.device("cpu"))
+
+
+def test_dequant_rejects_noncanonical_scale_shape() -> None:
+    src = torch.empty(4, 32, dtype=current_platform.fp8_dtype())
+    scales = torch.empty(4, dtype=torch.float32)
+    dst = torch.empty_like(src, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="scale shape"):
+        dequant_fp8_per_token(src, scales, dst)
 
 
 def test_transport_drain_waits_every_ring_slot() -> None:
@@ -51,3 +64,22 @@ def test_transport_reaps_completed_generic_sends() -> None:
     metadata.wait.assert_called_once_with()
     tensor.wait.assert_called_once_with()
     assert transport._generic_send_work == []
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm() or not has_aiter(),
+    reason="requires ROCm and AITER",
+)
+def test_fp8_quant_dequant_matches_bf16() -> None:
+    from aiter import dynamic_per_token_scaled_quant
+
+    torch.manual_seed(0)
+    src = torch.randn(8, 256, device="cuda", dtype=torch.bfloat16)
+    quant = torch.empty_like(src, dtype=current_platform.fp8_dtype())
+    scales = torch.empty(8, 1, device="cuda", dtype=torch.float32)
+    restored = torch.empty_like(src)
+
+    dynamic_per_token_scaled_quant(quant, src, scales)
+    dequant_fp8_per_token(quant, scales, restored)
+
+    torch.testing.assert_close(restored, src, rtol=0.15, atol=0.15)

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1230,6 +1230,45 @@ class GroupCoordinator:
 
         return handles
 
+    def isend_tensor(self, tensor: torch.Tensor, dst: int | None = None) -> Handle:
+        """Asynchronously send a tensor without exchanging metadata."""
+        if not torch.distributed.is_initialized() or self.world_size <= 1:
+            raise RuntimeError("isend_tensor requires an initialized multi-rank group")
+        if self.use_cpu_custom_send_recv:
+            raise RuntimeError("isend_tensor does not support custom CPU transport")
+        if dst is None:
+            dst = (self.rank_in_group + 1) % self.world_size
+        if not 0 <= dst < self.world_size:
+            raise ValueError(f"Invalid destination rank {dst}")
+
+        comm_group = self.cpu_group if tensor.is_cpu else self.device_group
+        handle = torch.distributed.isend(
+            tensor,
+            dst=self.ranks[dst],
+            group=comm_group,
+        )
+        if tensor.is_cuda:
+            tensor.record_stream(torch.cuda.current_stream(tensor.device))
+        return handle
+
+    def irecv_tensor(self, tensor: torch.Tensor, src: int | None = None) -> Handle:
+        """Asynchronously receive a tensor with an already-known schema."""
+        if not torch.distributed.is_initialized() or self.world_size <= 1:
+            raise RuntimeError("irecv_tensor requires an initialized multi-rank group")
+        if self.use_cpu_custom_send_recv:
+            raise RuntimeError("irecv_tensor does not support custom CPU transport")
+        if src is None:
+            src = (self.rank_in_group - 1) % self.world_size
+        if not 0 <= src < self.world_size:
+            raise ValueError(f"Invalid source rank {src}")
+
+        comm_group = self.cpu_group if tensor.is_cpu else self.device_group
+        return torch.distributed.irecv(
+            tensor,
+            src=self.ranks[src],
+            group=comm_group,
+        )
+
     def recv_tensor_dict(
         self,
         src: int | None = None,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -149,6 +149,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
+    VLLM_ROCM_PP_TRANSPORT: Literal["disabled", "stream"] = "disabled"
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -1353,6 +1354,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_TRITON_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_GEMM", "True").lower() in ("true", "1")
+    ),
+    # Optional fixed-schema BF16 PP transport for ROCm on the V1 worker path.
+    "VLLM_ROCM_PP_TRANSPORT": env_with_choices(
+        "VLLM_ROCM_PP_TRANSPORT",
+        "disabled",
+        ["disabled", "stream"],
     ),
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM": lambda: (

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -149,7 +149,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
-    VLLM_ROCM_PP_TRANSPORT: Literal["disabled", "stream"] = "disabled"
+    VLLM_ROCM_PP_TRANSPORT: Literal["disabled", "stream", "fp8"] = "disabled"
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -1355,11 +1355,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER_TRITON_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_GEMM", "True").lower() in ("true", "1")
     ),
-    # Optional fixed-schema BF16 PP transport for ROCm on the V1 worker path.
+    # Optional fixed-schema PP transport for ROCm. "stream" uses preallocated
+    # BF16 buffers on a dedicated stream; "fp8" additionally compresses the
+    # activation payload with per-token scales.
     "VLLM_ROCM_PP_TRANSPORT": env_with_choices(
         "VLLM_ROCM_PP_TRANSPORT",
         "disabled",
-        ["disabled", "stream"],
+        ["disabled", "stream", "fp8"],
     ),
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM": lambda: (

--- a/vllm/v1/worker/gpu/pp_transport.py
+++ b/vllm/v1/worker/gpu/pp_transport.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+
+import torch
+
+from vllm.distributed.parallel_state import Handle, get_pp_group
+from vllm.sequence import IntermediateTensors
+
+
+class PPTransport:
+    """Fixed-schema V1 PP transport backed by a bounded BF16 send-buffer ring."""
+
+    def __init__(
+        self,
+        schema: IntermediateTensors,
+        chunk_tokens: int,
+        ring_size: int,
+        device: torch.device,
+    ) -> None:
+        if set(schema.tensors) != {"hidden_states"}:
+            raise ValueError(
+                "ROCm PP transport currently requires a single hidden_states tensor"
+            )
+        hidden_states = schema.tensors["hidden_states"]
+        if hidden_states.shape[0] != chunk_tokens:
+            raise ValueError(
+                f"Expected {chunk_tokens} schema tokens, got {hidden_states.shape[0]}"
+            )
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError(
+                "ROCm PP transport requires BF16 hidden states, "
+                f"got {hidden_states.dtype}"
+            )
+        if not hidden_states.is_contiguous():
+            raise ValueError("ROCm PP transport requires contiguous hidden states")
+        if ring_size < 1:
+            raise ValueError(f"ring_size must be positive, got {ring_size}")
+
+        self.chunk_tokens = chunk_tokens
+        self.hidden_shape = hidden_states.shape
+        self.device = device
+        self._group = get_pp_group()
+        self._send_stream = torch.cuda.Stream(device=device)
+        self._send_index = 0
+        self._send_work: list[list[Handle] | None] = [None] * ring_size
+        self._generic_send_work: list[list[Handle]] = []
+        self._ready_events = [torch.cuda.Event() for _ in range(ring_size)]
+
+        self._recv_buffer = (
+            None if self._group.is_first_rank else hidden_states
+        )
+        self._send_ring = (
+            []
+            if self._group.is_last_rank
+            else [
+                torch.empty(
+                    self.hidden_shape,
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                for _ in range(ring_size)
+            ]
+        )
+
+    def can_transfer(self, num_scheduled_tokens: int) -> bool:
+        return num_scheduled_tokens == self.chunk_tokens
+
+    def receive(
+        self,
+    ) -> tuple[
+        dict[str, torch.Tensor],
+        list[Handle],
+        list[Callable[[], None]],
+    ]:
+        if self._recv_buffer is None:
+            raise RuntimeError("The first PP rank cannot receive activations")
+        return (
+            {"hidden_states": self._recv_buffer},
+            [self._group.irecv_tensor(self._recv_buffer)],
+            [],
+        )
+
+    def send(self, hidden_states: torch.Tensor) -> None:
+        if not self._send_ring:
+            raise RuntimeError("The last PP rank cannot send activations")
+        if hidden_states.shape != self.hidden_shape:
+            raise ValueError(
+                f"Expected hidden state shape {self.hidden_shape}, "
+                f"got {hidden_states.shape}"
+            )
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError(f"Expected BF16 hidden states, got {hidden_states.dtype}")
+
+        ring_index = self._send_index
+        prior_work = self._send_work[ring_index]
+        if prior_work is not None:
+            for handle in prior_work:
+                handle.wait()
+
+        send_buffer = self._send_ring[ring_index]
+        send_buffer.copy_(hidden_states)
+
+        ready_event = self._ready_events[ring_index]
+        ready_event.record(torch.cuda.current_stream(self.device))
+        with torch.cuda.stream(self._send_stream):
+            self._send_stream.wait_event(ready_event)
+            self._send_work[ring_index] = [
+                self._group.isend_tensor(send_buffer),
+            ]
+
+        self._send_index = (ring_index + 1) % len(self._send_ring)
+
+    def send_generic(
+        self,
+        tensor_dict: dict[str, torch.Tensor],
+        all_gather_group,
+        all_gather_tensors: dict[str, bool],
+    ) -> None:
+        """Order a generic tail send after fixed sends on the send stream."""
+        self._reap_generic_send_work()
+        ready_event = torch.cuda.Event()
+        ready_event.record(torch.cuda.current_stream(self.device))
+        with torch.cuda.stream(self._send_stream):
+            self._send_stream.wait_event(ready_event)
+            self._generic_send_work.append(
+                self._group.isend_tensor_dict(
+                    tensor_dict,
+                    all_gather_group=all_gather_group,
+                    all_gather_tensors=all_gather_tensors,
+                )
+            )
+
+    def _reap_generic_send_work(self) -> None:
+        while self._generic_send_work:
+            handles = self._generic_send_work[0]
+            tensor_handles = handles[1:]
+            if not tensor_handles or not all(
+                handle.is_completed() for handle in tensor_handles
+            ):
+                break
+            for handle in handles:
+                handle.wait()
+            self._generic_send_work.pop(0)
+
+    def drain(self) -> None:
+        for work in self._send_work:
+            if work is not None:
+                for handle in work:
+                    handle.wait()
+        self._send_work = [None] * len(self._send_work)
+        for handles in self._generic_send_work:
+            for handle in handles:
+                handle.wait()
+        self._generic_send_work.clear()

--- a/vllm/v1/worker/gpu/pp_transport.py
+++ b/vllm/v1/worker/gpu/pp_transport.py
@@ -2,18 +2,74 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
+from typing import Literal
 
 import torch
 
 from vllm.distributed.parallel_state import Handle, get_pp_group
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.triton_utils import tl, triton
+
+PPTransportMode = Literal["stream", "fp8"]
+
+
+@triton.jit
+def _dequant_fp8_per_token_kernel(
+    src_ptr,
+    scale_ptr,
+    dst_ptr,
+    numel,
+    row_width: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < numel
+    values = tl.load(src_ptr + offsets, mask=mask).to(tl.float32)
+    scales = tl.load(scale_ptr + offsets // row_width, mask=mask)
+    tl.store(dst_ptr + offsets, values * scales, mask=mask)
+
+
+def dequant_fp8_per_token(
+    src: torch.Tensor,
+    scales: torch.Tensor,
+    dst: torch.Tensor,
+) -> None:
+    """Dequantize contiguous per-token FP8 into caller-owned BF16 storage."""
+    if src.shape != dst.shape:
+        raise ValueError(f"Shape mismatch: source {src.shape}, destination {dst.shape}")
+    if src.dtype != current_platform.fp8_dtype():
+        raise ValueError(f"Expected FP8 source, got {src.dtype}")
+    if dst.dtype != torch.bfloat16:
+        raise ValueError(f"Expected BF16 destination, got {dst.dtype}")
+    if not (src.is_contiguous() and scales.is_contiguous() and dst.is_contiguous()):
+        raise ValueError("PP transport tensors must be contiguous")
+
+    row_width = src.shape[-1]
+    expected_scale_shape = (*src.shape[:-1], 1)
+    if scales.shape != expected_scale_shape:
+        raise ValueError(
+            f"Expected scale shape {expected_scale_shape}, got {scales.shape}"
+        )
+
+    block = 256
+    _dequant_fp8_per_token_kernel[(triton.cdiv(src.numel(), block),)](
+        src,
+        scales,
+        dst,
+        src.numel(),
+        row_width=row_width,
+        BLOCK=block,
+        num_warps=4,
+    )
 
 
 class PPTransport:
-    """Fixed-schema V1 PP transport backed by a bounded BF16 send-buffer ring."""
+    """Fixed-schema PP transport backed by a bounded send-buffer ring."""
 
     def __init__(
         self,
+        mode: PPTransportMode,
         schema: IntermediateTensors,
         chunk_tokens: int,
         ring_size: int,
@@ -38,6 +94,7 @@ class PPTransport:
         if ring_size < 1:
             raise ValueError(f"ring_size must be positive, got {ring_size}")
 
+        self.mode = mode
         self.chunk_tokens = chunk_tokens
         self.hidden_shape = hidden_states.shape
         self.device = device
@@ -51,18 +108,44 @@ class PPTransport:
         self._recv_buffer = (
             None if self._group.is_first_rank else hidden_states
         )
+        self._recv_quant: torch.Tensor | None = None
+        self._recv_scale: torch.Tensor | None = None
+        self._send_scale_ring: list[torch.Tensor] = []
+
+        send_dtype = torch.bfloat16
+        if mode == "fp8":
+            send_dtype = current_platform.fp8_dtype()
         self._send_ring = (
             []
             if self._group.is_last_rank
             else [
                 torch.empty(
                     self.hidden_shape,
-                    dtype=torch.bfloat16,
+                    dtype=send_dtype,
                     device=device,
                 )
                 for _ in range(ring_size)
             ]
         )
+
+        scale_shape = (*self.hidden_shape[:-1], 1)
+        if mode == "fp8":
+            if not self._group.is_last_rank:
+                self._send_scale_ring = [
+                    torch.empty(scale_shape, dtype=torch.float32, device=device)
+                    for _ in range(ring_size)
+                ]
+            if not self._group.is_first_rank:
+                self._recv_quant = torch.empty(
+                    self.hidden_shape,
+                    dtype=current_platform.fp8_dtype(),
+                    device=device,
+                )
+                self._recv_scale = torch.empty(
+                    scale_shape,
+                    dtype=torch.float32,
+                    device=device,
+                )
 
     def can_transfer(self, num_scheduled_tokens: int) -> bool:
         return num_scheduled_tokens == self.chunk_tokens
@@ -76,11 +159,32 @@ class PPTransport:
     ]:
         if self._recv_buffer is None:
             raise RuntimeError("The first PP rank cannot receive activations")
-        return (
-            {"hidden_states": self._recv_buffer},
-            [self._group.irecv_tensor(self._recv_buffer)],
-            [],
-        )
+
+        if self.mode == "stream":
+            return (
+                {"hidden_states": self._recv_buffer},
+                [self._group.irecv_tensor(self._recv_buffer)],
+                [],
+            )
+
+        assert self._recv_quant is not None
+        assert self._recv_scale is not None
+        handles = [
+            self._group.irecv_tensor(self._recv_quant),
+            self._group.irecv_tensor(self._recv_scale),
+        ]
+
+        def dequantize() -> None:
+            assert self._recv_quant is not None
+            assert self._recv_scale is not None
+            assert self._recv_buffer is not None
+            dequant_fp8_per_token(
+                self._recv_quant,
+                self._recv_scale,
+                self._recv_buffer,
+            )
+
+        return {"hidden_states": self._recv_buffer}, handles, [dequantize]
 
     def send(self, hidden_states: torch.Tensor) -> None:
         if not self._send_ring:
@@ -100,15 +204,27 @@ class PPTransport:
                 handle.wait()
 
         send_buffer = self._send_ring[ring_index]
-        send_buffer.copy_(hidden_states)
+        if self.mode == "fp8":
+            from aiter import dynamic_per_token_scaled_quant
+
+            send_scale = self._send_scale_ring[ring_index]
+            dynamic_per_token_scaled_quant(
+                send_buffer,
+                hidden_states,
+                send_scale,
+            )
+        else:
+            send_scale = None
+            send_buffer.copy_(hidden_states)
 
         ready_event = self._ready_events[ring_index]
         ready_event.record(torch.cuda.current_stream(self.device))
         with torch.cuda.stream(self._send_stream):
             self._send_stream.wait_event(ready_event)
-            self._send_work[ring_index] = [
-                self._group.isend_tensor(send_buffer),
-            ]
+            handles = [self._group.isend_tensor(send_buffer)]
+            if send_scale is not None:
+                handles.append(self._group.isend_tensor(send_scale))
+            self._send_work[ring_index] = handles
 
         self._send_index = (ring_index + 1) % len(self._send_ring)
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import timedelta
 from types import NoneType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import regex as re
@@ -139,7 +139,7 @@ def maybe_rocm_profiling_fallback(profile_result: MemoryProfilingResult) -> int 
 if TYPE_CHECKING:
     from vllm.device_allocator.sleep_mode_backend import SleepModeBackend
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
-    from vllm.v1.worker.gpu.pp_transport import PPTransport
+    from vllm.v1.worker.gpu.pp_transport import PPTransport, PPTransportMode
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
@@ -516,11 +516,6 @@ class Worker(WorkerBase):
         mode = envs.VLLM_ROCM_PP_TRANSPORT
         if mode == "disabled":
             return
-        if mode != "stream":
-            raise ValueError(
-                f"Unsupported VLLM_ROCM_PP_TRANSPORT mode {mode!r}; "
-                "only 'disabled' and 'stream' are supported"
-            )
         if not current_platform.is_rocm():
             raise ValueError("VLLM_ROCM_PP_TRANSPORT is only supported on ROCm")
         if self.parallel_config.pipeline_parallel_size <= 1:
@@ -529,6 +524,15 @@ class Worker(WorkerBase):
             raise ValueError("VLLM_ROCM_PP_TRANSPORT currently requires TP=1")
         if self.model_config.dtype != torch.bfloat16:
             raise ValueError("VLLM_ROCM_PP_TRANSPORT requires BF16 hidden states")
+        if mode == "fp8":
+            from vllm.utils.import_utils import has_aiter
+
+            if not current_platform.supports_fp8():
+                raise ValueError("FP8 PP transport requires FP8-capable hardware")
+            if not envs.VLLM_ROCM_USE_AITER or not has_aiter():
+                raise ValueError(
+                    "FP8 PP transport requires VLLM_ROCM_USE_AITER and AITER"
+                )
 
         from vllm.v1.worker.gpu.pp_transport import PPTransport
 
@@ -540,13 +544,15 @@ class Worker(WorkerBase):
             device=self.device,
         )
         self._pp_transport = PPTransport(
+            mode=cast("PPTransportMode", mode),
             schema=schema,
             chunk_tokens=chunk_tokens,
             ring_size=self.parallel_config.pipeline_parallel_size,
             device=self.device,
         )
         logger.info(
-            "Enabled ROCm streamed BF16 PP transport with %d-token chunks",
+            "Enabled ROCm %s PP transport with %d-token chunks",
+            mode,
             chunk_tokens,
         )
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -139,6 +139,7 @@ def maybe_rocm_profiling_fallback(profile_result: MemoryProfilingResult) -> int 
 if TYPE_CHECKING:
     from vllm.device_allocator.sleep_mode_backend import SleepModeBackend
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+    from vllm.v1.worker.gpu.pp_transport import PPTransport
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
@@ -218,6 +219,7 @@ class Worker(WorkerBase):
         self.profiler_config = vllm_config.profiler_config
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
+        self._pp_transport: PPTransport | None = None
 
         # Resolved lazily on first sleep/wake; persists worker-process state.
         self._sleep_mode_backend: SleepModeBackend | None = None
@@ -235,6 +237,8 @@ class Worker(WorkerBase):
         return self._sleep_mode_backend
 
     def sleep(self, level: int = 1) -> None:
+        if self._pp_transport is not None:
+            self._pp_transport.drain()
         torch.accelerator.synchronize()
         free_bytes_before_sleep = torch.accelerator.get_memory_info()[0]
 
@@ -498,6 +502,8 @@ class Worker(WorkerBase):
         ):
             self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
 
+        self._init_pp_transport()
+
         if self.vllm_config.weight_transfer_config is not None:
             self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
                 self.vllm_config.weight_transfer_config,
@@ -505,6 +511,44 @@ class Worker(WorkerBase):
                 self.device,
                 self.model_runner.get_model(),
             )
+
+    def _init_pp_transport(self) -> None:
+        mode = envs.VLLM_ROCM_PP_TRANSPORT
+        if mode == "disabled":
+            return
+        if mode != "stream":
+            raise ValueError(
+                f"Unsupported VLLM_ROCM_PP_TRANSPORT mode {mode!r}; "
+                "only 'disabled' and 'stream' are supported"
+            )
+        if not current_platform.is_rocm():
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT is only supported on ROCm")
+        if self.parallel_config.pipeline_parallel_size <= 1:
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT requires pipeline parallelism")
+        if self.parallel_config.tensor_parallel_size != 1:
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT currently requires TP=1")
+        if self.model_config.dtype != torch.bfloat16:
+            raise ValueError("VLLM_ROCM_PP_TRANSPORT requires BF16 hidden states")
+
+        from vllm.v1.worker.gpu.pp_transport import PPTransport
+
+        chunk_tokens = self.scheduler_config.max_num_batched_tokens
+        model = self.model_runner.get_model()
+        schema = model.make_empty_intermediate_tensors(
+            batch_size=chunk_tokens,
+            dtype=self.model_config.dtype,
+            device=self.device,
+        )
+        self._pp_transport = PPTransport(
+            schema=schema,
+            chunk_tokens=chunk_tokens,
+            ring_size=self.parallel_config.pipeline_parallel_size,
+            device=self.device,
+        )
+        logger.info(
+            "Enabled ROCm streamed BF16 PP transport with %d-token chunks",
+            chunk_tokens,
+        )
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)
@@ -1116,6 +1160,11 @@ class Worker(WorkerBase):
         intermediate_tensors = None
         forward_pass = scheduler_output.total_num_scheduled_tokens > 0
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+        use_fixed_pp_transport = (
+            forward_pass
+            and self._pp_transport is not None
+            and self._pp_transport.can_transfer(num_scheduled_tokens)
+        )
         all_gather_tensors = {}
         compilation_config = self.vllm_config.compilation_config
         parallel_config = self.vllm_config.parallel_config
@@ -1150,12 +1199,18 @@ class Worker(WorkerBase):
             }
 
         if forward_pass and not get_pp_group().is_first_rank:
-            tensor_dict, comm_handles, comm_postprocess = (
-                get_pp_group().irecv_tensor_dict(
-                    all_gather_group=get_tp_group(),
-                    all_gather_tensors=all_gather_tensors,
+            if use_fixed_pp_transport:
+                assert self._pp_transport is not None
+                tensor_dict, comm_handles, comm_postprocess = (
+                    self._pp_transport.receive()
                 )
-            )
+            else:
+                tensor_dict, comm_handles, comm_postprocess = (
+                    get_pp_group().irecv_tensor_dict(
+                        all_gather_group=get_tp_group(),
+                        all_gather_tensors=all_gather_tensors,
+                    )
+                )
             assert tensor_dict is not None
             intermediate_tensors = AsyncIntermediateTensors(
                 tensor_dict,
@@ -1185,16 +1240,27 @@ class Worker(WorkerBase):
             and not get_pp_group().is_last_rank
         )
 
-        # launch non-blocking send of intermediate tensors; the
-        # GroupCoordinator self-retains the source tensors and the
-        # metadata handle in ``_pending_isends`` and reaps them lazily on
-        # the next ``isend_tensor_dict(is_async=True)`` call, so this
-        # step returns without waiting for the receiver to drain.
-        get_pp_group().isend_tensor_dict(
-            output.tensors,
-            all_gather_group=get_tp_group(),
-            all_gather_tensors=all_gather_tensors,
-        )
+        if use_fixed_pp_transport:
+            assert self._pp_transport is not None
+            if set(output.tensors) != {"hidden_states"}:
+                raise ValueError(
+                    "Fixed PP transport requires a single hidden_states tensor"
+                )
+            self._pp_transport.send(output.tensors["hidden_states"])
+        elif self._pp_transport is not None:
+            self._pp_transport.send_generic(
+                output.tensors,
+                all_gather_group=get_tp_group(),
+                all_gather_tensors=all_gather_tensors,
+            )
+        else:
+            # The GroupCoordinator self-retains source tensors and handles,
+            # allowing this call to return without waiting for the receiver.
+            get_pp_group().isend_tensor_dict(
+                output.tensors,
+                all_gather_group=get_tp_group(),
+                all_gather_tensors=all_gather_tensors,
+            )
 
         return None
 
@@ -1431,6 +1497,9 @@ class Worker(WorkerBase):
 
     def shutdown(self) -> None:
         gc.unfreeze()
+
+        if self._pp_transport is not None:
+            self._pp_transport.drain()
 
         # has_kv_transfer_group can be None during interpreter shutdown.
         if ensure_kv_transfer_shutdown is not None:


### PR DESCRIPTION
## Summary

Add an opt-in FP8 payload mode to the V1 fixed-schema PP transport:

- extend `VLLM_ROCM_PP_TRANSPORT` with `fp8` alongside `disabled` and `stream`
- quantize outgoing `hidden_states` with AITER per-token scales on the dedicated send stream
- receive FP8 payload + scales into fixed buffers, then dequantize into the persistent BF16 receive buffer
- keep the existing BF16 `stream` path and generic tensor-dict fallback unchanged

**Dependency:** this PR builds on #55032 (BF16 stream transport + async P2P infra). The FP8 delta is the top commit only; please review/merge after #55032 lands, or review the stacked diff here.

## Tests

- unit tests for FP8 dequant scale-shape validation and quant/dequant round-trip (ROCm + AITER)
- environment tests for `VLLM_ROCM_PP_TRANSPORT=fp8`
- 2-rank integration test covering FP8 ring transport with relaxed FP8 tolerance

## Performance

Validated on the tuned DeepSeek-V4-Pro TP1/PP8 100K-token stack:

| Stack | Stream BF16 | Stream FP8 | Delta |
|---|---:|---:|---:|
| V1 tuned experiment | 2187.8 ms | 2107.2 ms | -80.6 ms |

## Usage

```bash
export VLLM_ROCM_PP_TRANSPORT=fp8
```

Requires ROCm, AITER (`VLLM_ROCM_USE_AITER=1`), PP > 1, TP=1, and BF16 model weights.


Made with [Cursor](https://cursor.com)