### PR TITLE
[Attention] Add FlashInfer SM120 FP8 PRIMS prefill

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for v1 attention backends without GPUModelRunner dependency."""
 
+from dataclasses import replace
 from functools import partial
 from types import SimpleNamespace
 
@@ -32,7 +33,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheLayout
+from vllm.v1.kv_cache_interface import AttentionSpec, FullAttentionSpec, KVCacheLayout
 
 BACKENDS_TO_TEST = [
     AttentionBackendEnum.FLASH_ATTN,
@@ -270,7 +271,7 @@ def _clone_kv_cache_in_layout(
 
 def run_attention_backend(
     backend: AttentionBackendEnum | str,
-    kv_cache_spec: FullAttentionSpec,
+    kv_cache_spec: AttentionSpec,
     layer_names: list[str],
     vllm_config,
     device: torch.device,
@@ -284,6 +285,7 @@ def run_attention_backend(
     kv_cache_dtype: str = "auto",
     sinks: torch.Tensor | None = None,
     use_cuda_graph: bool = False,
+    common_prefix_len: int = 0,
 ) -> torch.Tensor:
     """Run attention computation using the specified backend's AttentionImpl."""
 
@@ -319,7 +321,7 @@ def run_attention_backend(
         ):
             builder = builder_cls(kv_cache_spec, layer_names, vllm_config, device)
             attn_metadata = builder.build(
-                common_prefix_len=0,
+                common_prefix_len=common_prefix_len,
                 common_attn_metadata=common_attn_metadata,
             )
     else:
@@ -328,7 +330,7 @@ def run_attention_backend(
         if backend == AttentionBackendEnum.FLEX_ATTENTION:
             builder.direct_build = use_direct_block_mask
         attn_metadata = builder.build(
-            common_prefix_len=0,
+            common_prefix_len=common_prefix_len,
             common_attn_metadata=common_attn_metadata,
         )
 
@@ -413,6 +415,8 @@ def _test_backend_correctness(
     model_dtype: torch.dtype | None = None,
     max_num_seqs: int | None = None,
     max_num_batched_tokens: int | None = None,
+    fp8_prefill_query_only: bool = False,
+    common_prefix_len: int = 0,
 ):
     """
     Test that all backends produce similar outputs to a reference implementation
@@ -519,7 +523,8 @@ def _test_backend_correctness(
         v_full = torch.randn(s_len, num_kv_heads, head_size, dtype=dtype, device=device)
 
         if fp8_kv_cache:
-            q_ref = q.to(query_fp8_dtype).to(dtype)
+            quantize_q = not fp8_prefill_query_only or q_len > 1
+            q_ref = q.to(query_fp8_dtype).to(dtype) if quantize_q else q
             k_ref = k_full.to(kv_fp8_dtype).to(dtype)
             v_ref = v_full.to(kv_fp8_dtype).to(dtype)
         else:
@@ -635,6 +640,14 @@ def _test_backend_correctness(
     # with test infrastructures
     for backend_name in backend_to_test:
         backend_cls = _actual_backend(backend_name).get_class()
+        backend_kv_cache_spec = kv_cache_spec
+        if backend_name == AttentionBackendEnum.FLASHINFER:
+            if kv_cache_dtype in FP8_KV_CACHE_DTYPES:
+                backend_kv_cache_spec = replace(
+                    backend_kv_cache_spec,
+                    dtype=FP8_KV_CACHE_DTYPES[kv_cache_dtype],
+                )
+            backend_kv_cache_spec = backend_cls.customize_spec(backend_kv_cache_spec)
 
         if is_quantized_kv_cache(kv_cache_dtype) and (
             not backend_cls.supports_kv_cache_dtype(kv_cache_dtype)
@@ -668,13 +681,30 @@ def _test_backend_correctness(
                 packed_cache, backend_layout
             )
 
+        if (
+            backend_name == AttentionBackendEnum.FLASHINFER
+            and kv_cache_dtype in FP8_KV_CACHE_DTYPES
+            and backend_kv_cache_spec.num_head_slots == 2 * num_kv_heads
+        ):
+            typed_cache = kv_cache.view(FP8_KV_CACHE_DTYPES[kv_cache_dtype])
+            separate_cache = torch.cat(
+                (
+                    typed_cache[..., :head_size],
+                    typed_cache[..., head_size:],
+                ),
+                dim=1,
+            ).view(torch.uint8)
+            kv_cache_for_backend = _clone_kv_cache_in_layout(
+                separate_cache, backend_layout
+            )
+
         # FlashInfer reads the layout at plan time; set it to match
         # the physical order of the test cache.
         vllm_config.cache_config.kv_cache_layout = backend_layout.name
 
         backend_output = run_attention_backend(
             backend_name,
-            kv_cache_spec,
+            backend_kv_cache_spec,
             ["placeholder"],
             vllm_config,
             device,
@@ -688,6 +718,7 @@ def _test_backend_correctness(
             kv_cache_dtype=kv_cache_dtype,
             sinks=sinks,
             use_cuda_graph=use_cuda_graph,
+            common_prefix_len=common_prefix_len,
         )
 
         # Check shape and dtype consistency
@@ -847,6 +878,187 @@ def test_flashinfer_xqa_bmm1_scale_matches_decode_q_dtype():
 
     assert impl.get_xqa_bmm1_scale(MockLayer, torch.bfloat16) == 1.5
     assert impl.get_xqa_bmm1_scale(MockLayer, torch.float8_e4m3fn) == 3.0
+
+
+def _make_flashinfer_prims_builder(flashinfer_backend):
+    builder = object.__new__(flashinfer_backend.FlashInferMetadataBuilder)
+    builder.flashinfer_prefill_backend = "cute-dsl-prims"
+    builder.cache_dtype = "fp8"
+    builder.attention_config = SimpleNamespace(disable_flashinfer_q_quantization=False)
+    builder.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    builder.head_dim = 128
+    builder.num_qo_heads = 32
+    builder.num_kv_heads = 8
+    builder.use_dcp = False
+    builder.has_sinks = False
+    builder.window_left = -1
+    builder.logits_soft_cap = 0.0
+    return builder
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+def test_flashinfer_prims_uses_compact_hnd_kv_planes(monkeypatch):
+    from vllm.platforms.interface import DeviceCapability
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+    from vllm.v1.kv_cache_interface import KVQuantMode
+
+    monkeypatch.setattr(
+        flashinfer_backend.envs,
+        "VLLM_FLASHINFER_PREFILL_BACKEND",
+        "cute-dsl-prims",
+    )
+    monkeypatch.setattr(
+        flashinfer_backend.current_platform,
+        "get_device_capability",
+        lambda: DeviceCapability(12, 0),
+    )
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float8_e4m3fn,
+        kv_quant_mode=KVQuantMode.FP8_PER_TENSOR,
+    )
+
+    customized = flashinfer_backend.FlashInferBackend.customize_spec(spec)
+
+    assert customized.num_head_slots == 16
+    assert customized.state_content_bytes == 128
+    assert customized.page_size_bytes == spec.page_size_bytes
+    assert flashinfer_backend.FlashInferBackend.customize_spec(customized) is customized
+    assert flashinfer_backend.FlashInferBackend.supported_kv_cache_layouts() == (
+        KVCacheLayout.LBHNC,
+        KVCacheLayout.BLHNC,
+    )
+
+    monkeypatch.setattr(
+        flashinfer_backend.envs,
+        "VLLM_FLASHINFER_PREFILL_BACKEND",
+        "auto",
+    )
+    assert flashinfer_backend.FlashInferBackend.customize_spec(spec) is spec
+    assert flashinfer_backend.FlashInferBackend.supported_kv_cache_layouts() is None
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+def test_flashinfer_prims_quantizes_prefill_q_only(monkeypatch):
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    monkeypatch.setattr(
+        flashinfer_backend.current_platform,
+        "is_device_capability",
+        lambda capability: capability == 120,
+    )
+    monkeypatch.setattr(
+        flashinfer_backend.current_platform,
+        "is_device_capability_family",
+        lambda capability: capability == 120,
+    )
+    monkeypatch.setattr(flashinfer_backend, "force_use_trtllm_attention", lambda: True)
+    builder = _make_flashinfer_prims_builder(flashinfer_backend)
+    builder.vllm_config = SimpleNamespace(attention_config=builder.attention_config)
+    builder.kv_cache_spec = SimpleNamespace(dtype=torch.float8_e4m3fn)
+
+    assert builder.get_q_data_type(is_prefill=True) == torch.float8_e4m3fn
+    assert builder.get_q_data_type(is_prefill=False) == torch.bfloat16
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+@pytest.mark.parametrize(
+    ("attribute", "value", "match"),
+    [
+        ("cache_dtype", "fp8_e5m2", "E4M3"),
+        (
+            "attention_config",
+            SimpleNamespace(disable_flashinfer_q_quantization=True),
+            "query quantization",
+        ),
+        ("head_dim", 512, "head size"),
+        ("use_dcp", True, "decode-context parallel"),
+        ("has_sinks", True, "attention sinks"),
+        ("window_left", 127, "sliding-window"),
+        ("logits_soft_cap", 30.0, "logits soft cap"),
+    ],
+)
+def test_flashinfer_prims_rejects_unsupported_configuration(
+    monkeypatch, attribute, value, match
+):
+    from vllm.platforms.interface import DeviceCapability
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    monkeypatch.setattr(
+        flashinfer_backend.current_platform,
+        "get_device_capability",
+        lambda: DeviceCapability(12, 0),
+    )
+    monkeypatch.setattr(flashinfer_backend.envs, "VLLM_BATCH_INVARIANT", False)
+    builder = _make_flashinfer_prims_builder(flashinfer_backend)
+    setattr(builder, attribute, value)
+
+    with pytest.raises((ValueError, NotImplementedError), match=match):
+        builder._validate_flashinfer_prefill_backend()
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+@pytest.mark.parametrize(
+    (
+        "batch_spec_name",
+        "tensor_parallel_size",
+        "use_cuda_graph",
+        "common_prefix_len",
+    ),
+    [
+        ("small_prefill", 1, False, 16),
+        ("mixed_small", 8, True, 0),
+    ],
+)
+def test_flashinfer_prims_prefill_correctness(
+    batch_spec_name, tensor_parallel_size, use_cuda_graph, common_prefix_len
+):
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    if flashinfer_backend.envs.VLLM_FLASHINFER_PREFILL_BACKEND != "cute-dsl-prims":
+        pytest.skip(
+            "Run with VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims and a "
+            "FlashInfer build containing the SM120 PRIMS backend."
+        )
+    if not (current_platform.is_cuda() and current_platform.is_device_capability(120)):
+        pytest.skip("FlashInfer cute-dsl-prims requires SM120.")
+
+    def causal_mask_mod(
+        b: torch.Tensor,
+        h: torch.Tensor,
+        q_idx: torch.Tensor,
+        kv_idx: torch.Tensor,
+        *,
+        context_len: int,
+    ):
+        return (q_idx + context_len) >= kv_idx
+
+    _test_backend_correctness(
+        BATCH_SPECS[batch_spec_name],
+        "meta-llama/Meta-Llama-3-8B",
+        [AttentionBackendEnum.FLASHINFER],
+        causal_mask_mod,
+        tensor_parallel_size=tensor_parallel_size,
+        kv_cache_dtype="fp8",
+        layout=KVCacheLayout.LBHNC,
+        use_cuda_graph=use_cuda_graph,
+        fp8_prefill_query_only=True,
+        common_prefix_len=common_prefix_len,
+    )
 
 
 @pytest.mark.skipif(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -216,6 +216,7 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
+    VLLM_FLASHINFER_PREFILL_BACKEND: Literal["auto", "cute-dsl-prims"] = "auto"
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
@@ -1742,6 +1743,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
             for v in os.environ["VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS"].split(",")
             if v.strip()
         ]
+    ),
+    # Select the implementation used by FlashInfer's native paged prefill
+    # wrapper. The CuTe DSL primitives backend is an opt-in SM120 FP8 path.
+    "VLLM_FLASHINFER_PREFILL_BACKEND": env_with_choices(
+        "VLLM_FLASHINFER_PREFILL_BACKEND",
+        "auto",
+        ["auto", "cute-dsl-prims"],
     ),
     # Flashinfer fused allreduce backend.
     "VLLM_FLASHINFER_ALLREDUCE_BACKEND": env_with_choices(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -100,6 +100,10 @@ logger = init_logger(__name__)
 trtllm_workspace_buffer = None
 
 
+def _use_cute_dsl_prims_prefill() -> bool:
+    return envs.VLLM_FLASHINFER_PREFILL_BACKEND == "cute-dsl-prims"
+
+
 def _get_trtllm_workspace_buffer():
     global trtllm_workspace_buffer
     if trtllm_workspace_buffer is None:
@@ -393,8 +397,29 @@ class BatchDCPPrefillWrapper:
 class FlashInferBackend(AttentionBackend):
     @classmethod
     def customize_spec(cls, spec: "AttentionSpec") -> "AttentionSpec":
-        """NVFP4 stores K and V as separate per-head slots of packed fp4 data
-        plus fp8 block scales."""
+        """Customize separate K/V planes used by PRIMS and NVFP4."""
+        if _use_cute_dsl_prims_prefill():
+            if spec.head_size != spec.head_size_v:
+                raise ValueError(
+                    "FlashInfer cute-dsl-prims requires equal K/V head dimensions."
+                )
+            num_head_slots = 2 * spec.num_kv_heads
+            state_content_bytes = spec.head_size * get_dtype_size(spec.dtype)
+            if spec.state_content_bytes is not None:
+                if (
+                    spec.num_head_slots == num_head_slots
+                    and spec.state_content_bytes == state_content_bytes
+                ):
+                    return spec
+                raise ValueError(
+                    "FlashInfer cute-dsl-prims requires compact, separate K/V planes."
+                )
+            return replace(
+                spec,
+                num_head_slots=num_head_slots,
+                state_content_bytes=state_content_bytes,
+            )
+
         if spec.state_content_bytes is not None or not spec.kv_quant_mode.is_nvfp4:
             return spec
         hs_k = nvfp4_kv_cache_full_dim(spec.head_size)
@@ -536,9 +561,16 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...] | None:
         capability = current_platform.get_device_capability()
-        if capability is not None and capability.major == 10:
+        if capability is not None and (
+            capability.major == 10
+            or (
+                (capability.major, capability.minor) == (12, 0)
+                and _use_cute_dsl_prims_prefill()
+            )
+        ):
             # The trtllm-gen kernels consume head-major block interiors; the L/B
-            # nesting outside the block is immaterial to them.
+            # nesting outside the block is immaterial to them. SM120 PRIMS also
+            # requires compact head-major K/V planes.
             return (KVCacheLayout.LBHNC, KVCacheLayout.BLHNC)
         return super().supported_kv_cache_layouts()
 
@@ -757,6 +789,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size
         self.page_size = self.kv_cache_spec.block_size
+        self.flashinfer_prefill_backend = envs.VLLM_FLASHINFER_PREFILL_BACKEND
 
         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
             self.cache_dtype = self.cache_config.cache_dtype
@@ -894,6 +927,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.window_left = self.global_hyperparameters.window_left
         self.logits_soft_cap = self.global_hyperparameters.logits_soft_cap
         self.has_sinks = self.global_hyperparameters.has_sinks
+        self._validate_flashinfer_prefill_backend()
         if self.has_sinks and not FlashInferBackend.supports_sink():
             raise NotImplementedError(
                 "FlashInfer backend currently does not support attention "
@@ -909,9 +943,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
         logger.info_once(
             "FlashInfer resolved query dtypes: prefill=%s, decode=%s, "
-            "decode_backend=%s, kv_cache_dtype=%s, arch=%s",
+            "prefill_backend=%s, decode_backend=%s, kv_cache_dtype=%s, arch=%s",
             self.q_data_type_prefill,
             self.q_data_type_decode,
+            self.flashinfer_prefill_backend,
             decode_backend,
             self.kv_cache_dtype,
             arch,
@@ -926,6 +961,70 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.paged_kv_last_page_len = CpuGpuBuffer(
             max_num_reqs, dtype=torch.int32, device=self.device, pin_memory=False
         )
+
+    def _validate_flashinfer_prefill_backend(self) -> None:
+        if self.flashinfer_prefill_backend == "auto":
+            return
+
+        assert self.flashinfer_prefill_backend == "cute-dsl-prims"
+        capability = current_platform.get_device_capability()
+        if capability is None or (capability.major, capability.minor) != (12, 0):
+            raise ValueError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims requires an "
+                "SM120 GPU (compute capability 12.0)."
+            )
+        if self.cache_dtype not in ("fp8", "fp8_e4m3"):
+            raise ValueError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims requires "
+                "--kv-cache-dtype fp8 (E4M3)."
+            )
+        if self.attention_config.disable_flashinfer_q_quantization:
+            raise ValueError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims requires FP8 "
+                "query quantization; remove "
+                "--attention-config.disable_flashinfer_q_quantization."
+            )
+        if self.model_config.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims requires "
+                f"float16 or bfloat16 output; got {self.model_config.dtype}."
+            )
+        if self.head_dim not in (64, 128, 256):
+            raise ValueError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims requires "
+                f"head size in {{64, 128, 256}}; got {self.head_dim}."
+            )
+        if self.num_kv_heads <= 0 or self.num_qo_heads % self.num_kv_heads != 0:
+            raise ValueError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims requires the "
+                "number of query heads to be divisible by the number of KV "
+                f"heads; got {self.num_qo_heads}/{self.num_kv_heads}."
+            )
+        if self.use_dcp:
+            raise NotImplementedError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims is not yet "
+                "wired for decode-context parallel prefill in vLLM."
+            )
+        if envs.VLLM_BATCH_INVARIANT:
+            raise NotImplementedError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims does not "
+                "support VLLM_BATCH_INVARIANT."
+            )
+        if self.has_sinks:
+            raise NotImplementedError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims does not "
+                "support attention sinks."
+            )
+        if self.window_left != -1:
+            raise NotImplementedError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims does not "
+                "support sliding-window attention."
+            )
+        if self.logits_soft_cap not in (None, 0.0):
+            raise NotImplementedError(
+                "VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims does not "
+                "support logits soft cap."
+            )
 
     @property
     def kv_cache_layout(self) -> KVCacheLayout:
@@ -958,11 +1057,18 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # Otherwise, match Q dtype to the KV cache dtype.
         if cache_dtype.startswith("fp8"):
             # FP8-Q requires an fp8 tensor-core attention path.
-            # Architectures with only fa2 (e.g. SM89, SM120) cannot
-            # consume FP8 queries, so keep the model dtype for Q there.
-            if current_platform.is_device_capability(
-                90
-            ) or current_platform.is_device_capability_family(100):
+            # Architectures with only fa2 (e.g. SM89 and stock SM120) cannot
+            # consume FP8 queries. The PRIMS backend is the SM120 prefill
+            # exception; XQA decode continues to use the model dtype.
+            if (
+                current_platform.is_device_capability(90)
+                or current_platform.is_device_capability_family(100)
+                or (
+                    is_prefill
+                    and self.flashinfer_prefill_backend == "cute-dsl-prims"
+                    and current_platform.is_device_capability(120)
+                )
+            ):
                 return FlashInferBackend.get_dtype_for_flashinfer(cache_dtype)
             return self.model_config.dtype
         if cache_dtype.startswith("nvfp4"):
@@ -1139,7 +1245,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         BatchPrefillWithPagedKVCacheWrapper(
                             self._get_workspace_buffer(),
                             get_flashinfer_layout_string(self.kv_cache_layout),
-                            backend="auto",
+                            backend=self.flashinfer_prefill_backend,
                         )
                     )
             return self._noncausal_prefill_wrapper
@@ -1171,7 +1277,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
                         self._get_workspace_buffer(),
                         get_flashinfer_layout_string(self.kv_cache_layout),
-                        backend=backend,
+                        backend=(
+                            backend
+                            if self.is_kvcache_nvfp4
+                            else self.flashinfer_prefill_backend
+                        ),
                     )
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
@@ -1315,7 +1425,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # - Cascade attention (distinct mode)
         # - Prefill (FI native or TRTLLM)
         # - Decode (FI native, XQA, or trtllm-gen)
-        use_cascade = common_prefix_len > 0
+        # Cascade uses the generic FlashInfer wrappers and requires one query
+        # dtype for both phases. PRIMS uses FP8 prefill Q with model-dtype XQA
+        # decode Q, so keep prefix caching but skip the cascade optimization.
+        use_cascade = common_prefix_len > 0 and not _use_cute_dsl_prims_prefill()
         uses_spec_reorder = self.reorder_batch_threshold > 1
         # Page sizes >= 128 must use trtllm-gen; force it for prefill too.
         prefill_force_trtllm = (
@@ -1611,6 +1724,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     o_dtype = (
                         FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
                     )
+                    prims_plan_kwargs = (
+                        {"block_tables": block_table_tensor[prefill_start:]}
+                        if self.flashinfer_prefill_backend == "cute-dsl-prims"
+                        else {}
+                    )
                     prefill_wrapper.plan(
                         qo_indptr=qo_indptr_prefill_cpu,
                         paged_kv_indptr=paged_kv_indptr_prefill_cpu,
@@ -1629,6 +1747,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         o_data_type=o_dtype,
                         fixed_split_size=self.prefill_fixed_split_size,
                         disable_split_kv=self.disable_split_kv,
+                        **prims_plan_kwargs,
                     )
                 attn_metadata.prefill = FIPrefill(wrapper=prefill_wrapper)
 
@@ -1783,6 +1902,9 @@ class FlashInferImpl(AttentionImpl):
         self.cache_dtype = kv_cache_dtype
         self.is_kvcache_nvfp4 = kv_cache_dtype.startswith("nvfp4")
         self.kv_cache_dtype = "nvfp4" if self.is_kvcache_nvfp4 else kv_cache_dtype
+        self.uses_separate_kv_planes = (
+            self.is_kvcache_nvfp4 or _use_cute_dsl_prims_prefill()
+        )
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
@@ -1926,7 +2048,8 @@ class FlashInferImpl(AttentionImpl):
             query: shape = [num_tokens, num_heads, head_size]
             key: shape = [num_tokens, num_kv_heads, head_size]
             value: shape = [num_tokens, num_kv_heads, head_size]
-            kv_cache: [num_blocks, num_kv_heads, block_size, 2*head_size]
+            kv_cache: packed K/V in the content dimension, or separate K/V head
+                planes when using NVFP4 or cute-dsl-prims.
             attn_metadata: Metadata for attention.
         Returns:
             shape = [num_tokens, num_heads * head_size]
@@ -2025,7 +2148,7 @@ class FlashInferImpl(AttentionImpl):
             # Cascade attention (rare case).
             assert attn_metadata.cascade_wrapper is not None
             stride_order = self.kv_cache_layout.layer_view_order
-            if self.is_kvcache_nvfp4:
+            if self.uses_separate_kv_planes:
                 kv_cache_views = tuple(
                     cache.permute(*stride_order)
                     for cache in kv_cache.split(self.num_kv_heads, dim=1)
@@ -2062,21 +2185,22 @@ class FlashInferImpl(AttentionImpl):
             )
         kv_cache_permute = fixed
 
-        # Split K/V — zero-copy views. NVFP4 stores K/V as separate head
-        # groups; other dtypes pack K/V in the content dim.
+        # Split K/V into zero-copy views. NVFP4 and PRIMS store K/V as separate
+        # head groups; other dtypes pack K/V in the content dim.
         hs = self.head_size
         nvfp4_kv_data = None
         nvfp4_kv_block_scales = None
-        if self.is_kvcache_nvfp4:
+        if self.uses_separate_kv_planes:
             k_cache, v_cache = kv_cache.split(self.num_kv_heads, dim=1)
             kv_cache_tuple = (
                 canonicalize_singleton_dim_strides(k_cache.permute(*stride_order)),
                 canonicalize_singleton_dim_strides(v_cache.permute(*stride_order)),
             )
-            k_data, k_sf = nvfp4_split_data_scale(kv_cache_tuple[0])
-            v_data, v_sf = nvfp4_split_data_scale(kv_cache_tuple[1])
-            nvfp4_kv_data = (k_data, v_data)
-            nvfp4_kv_block_scales = (k_sf, v_sf)
+            if self.is_kvcache_nvfp4:
+                k_data, k_sf = nvfp4_split_data_scale(kv_cache_tuple[0])
+                v_data, v_sf = nvfp4_split_data_scale(kv_cache_tuple[1])
+                nvfp4_kv_data = (k_data, v_data)
+                nvfp4_kv_block_scales = (k_sf, v_sf)
         else:
             kv_cache_tuple = kv_cache_permute.split(hs, dim=-1)
 
@@ -2550,9 +2674,9 @@ class FlashInferImpl(AttentionImpl):
             # and value[:num_actual_tokens] because the reshape_and_cache_flash
             # op uses the slot_mapping's shape to determine the number of
             # actual tokens.
-            if self.is_kvcache_nvfp4:
-                # (B, 2*H, N, full_dim) -> ((B, N, H, full_dim),
-                #                            (B, N, H, full_dim));
+            if self.uses_separate_kv_planes:
+                # (B, 2*H, N, plane_dim) -> ((B, N, H, plane_dim),
+                #                             (B, N, H, plane_dim));
                 # K heads first, then V heads.
                 k_cache, v_cache = kv_cache.transpose(1, 2).split(
                     self.num_kv_heads, dim=-2


### PR DESCRIPTION
## Purpose

Add an opt-in vLLM integration for FlashInfer's SM120 FP8 paged prefill
backend introduced by
[flashinfer-ai/flashinfer#4714](https://github.com/flashinfer-ai/flashinfer/pull/4714).

This change:

- adds `VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims`, while keeping `auto`
  as the default;
- allows FP8 E4M3 prefill queries on SM120 while retaining model-dtype XQA
  queries for decode;
- publishes compact, separate HND K/V cache planes and forwards vLLM's block
  tables to the PRIMS planner;
- rejects unsupported devices, dtypes, head sizes, DCP, sinks, sliding-window
  attention, logits soft cap, and batch-invariant mode at initialization; and
- skips the incompatible cascade optimization without disabling prefix caching.

This PR intentionally does not update `requirements/cuda.txt`. vLLM currently
pins FlashInfer 0.6.18; early users must install FlashInfer at or after merged
commit
[`af78f8f`](https://github.com/flashinfer-ai/flashinfer/commit/af78f8fc17a9654563a619974de56e79257aaea6)
and a compatible `nvidia-cutlass-dsl>=4.7.0a0`. A future dependency-bump PR can
switch the pin to a release containing #4714.

Duplicate check: open vLLM PRs were searched for `cute-dsl-prims` and
`SM120 FlashInfer FP8 prefill`. No PR was found that integrates #4714's paged
prefill backend; the related results cover different NVFP4 KV-cache, MLA, or
GDN paths.

AI assistance disclosure: OpenAI Codex assisted with porting the integration,
drafting tests, and reviewing the change. The human submitter reviewed the
resulting diff and is responsible for the contribution.

## Test Plan

Static checks on the rebased vLLM `main` change:

```bash
SKIP=actionlint .venv/bin/pre-commit run --files \
  vllm/envs.py \
  vllm/v1/attention/backends/flashinfer.py \
  tests/v1/attention/test_attention_backends.py

SKIP=actionlint .venv/bin/pre-commit run --hook-stage manual mypy-3.12 \
  --files vllm/envs.py \
  vllm/v1/attention/backends/flashinfer.py \
  tests/v1/attention/test_attention_backends.py
```

The added SM120 test can be run with a compatible source build of FlashInfer:

```bash
VLLM_FLASHINFER_PREFILL_BACKEND=cute-dsl-prims \
  .venv/bin/python -m pytest \
  tests/v1/attention/test_attention_backends.py \
  -k flashinfer_prims -vv
```

The serving A/B used the same model, image, and command-line configuration,
changing only `VLLM_FLASHINFER_PREFILL_BACKEND` between `auto` and
`cute-dsl-prims`. The client command was:

```bash
vllm bench serve \
  --backend openai \
  --endpoint /v1/completions \
  --model Qwen3.6-35B-A3B-NVFP4 \
  --base-url "$VLLM_BASE_URL" \
  --num-prompts 32 \
  --max-concurrency 32 \
  --percentile-metrics ttft,tpot,itl,e2el \
  --metric-percentiles 50,90,95,99 \
  --ignore-eos \
  --dataset-name prefix_repetition \
  --prefix-repetition-prefix-len 1 \
  --prefix-repetition-suffix-len 65535 \
  --prefix-repetition-num-prefixes 32 \
  --prefix-repetition-output-len 1 \
  --disable-shuffle \
  --num-warmups 0 \
  --temperature 0 \
  --tokenizer nvidia/Qwen3.6-35B-A3B-NVFP4
```

## Test Result

- Applicable pre-commit hooks, including ruff, typos, repository policy
  checks, and Python 3.10 mypy: passed.
- Python 3.12 mypy: passed.
- `py_compile` and `git diff --check`: passed.
- The added SM120 pytest was not run on the rebased commit because the local
  development host is macOS/arm64 without CUDA or FlashInfer. The test is
  opt-in for the same reason that the backend is opt-in while vLLM pins an
  earlier FlashInfer release.

Prior end-to-end validation used an RTX PRO 6000 (SM120), vLLM v0.28.0 with
the equivalent adapter, FlashInfer #4714 at `73c0663`, FP8 E4M3 KV cache,
TP=1, and `nvidia/Qwen3.6-35B-A3B-NVFP4`. Both variants completed 32 concurrent
requests with 65,536 input tokens and one output token per request:

| Prefill backend | Reported throughput (tokens/s) | Relative |
| --- | ---: | ---: |
| `auto` | 20,140 | 1.00x |
| `cute-dsl-prims` | 31,851 | 1.58x (+58.1%) |

The benchmark used `--num-warmups 0`; these numbers are reported as an
end-to-end serving A/B rather than a multi-run statistical benchmark. No
separate model-accuracy evaluation was recorded; output length was one token,
so this result is treated as functional/performance evidence rather than an
accuracy result.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described above.
- [x] The test commands are included above.
- [x] Test results and limitations are included above.
- [x] No documentation update is required because the backend is an opt-in
  integration for a FlashInfer version not yet pinned by vLLM.
</details>

