### PR TITLE
[Bugfix] Reconcile mismatched NVFP4 MoE w13 global scales

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -34,6 +34,9 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
 )
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    reconcile_nvfp4_moe_w13_scales,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
     kMxfp8Dynamic,
@@ -52,6 +55,77 @@ from vllm.platforms import current_platform
 def enable_pickle(monkeypatch):
     """`LLM.apply_model` requires pickling a function."""
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+
+def test_nvfp4_moe_matching_w13_global_scales_are_unchanged():
+    block_scales = torch.tensor(
+        [[[0.5], [1.0], [1.5], [2.0]]], dtype=torch.float8_e4m3fn
+    )
+    global_scales = torch.tensor([[2.0, 2.0]])
+
+    reconciled_block_scales, reconciled_global_scales = reconcile_nvfp4_moe_w13_scales(
+        block_scales, global_scales
+    )
+
+    assert reconciled_block_scales is block_scales
+    torch.testing.assert_close(reconciled_global_scales, global_scales[:, 0])
+
+
+@pytest.mark.parametrize(
+    ("global_scales", "expected_block_scales", "expected_global_scale"),
+    [
+        ([[1.0, 2.0]], [0.5, 0.5, 1.0, 1.0], [2.0]),
+        ([[4.0, 1.0]], [1.0, 1.0, 0.25, 0.25], [4.0]),
+    ],
+)
+def test_nvfp4_moe_reconciles_each_w13_half(
+    global_scales, expected_block_scales, expected_global_scale
+):
+    block_scales = torch.ones((1, 4, 1), dtype=torch.float8_e4m3fn)
+
+    reconciled_block_scales, reconciled_global_scales = reconcile_nvfp4_moe_w13_scales(
+        block_scales, torch.tensor(global_scales)
+    )
+
+    torch.testing.assert_close(
+        reconciled_block_scales.float().flatten(),
+        torch.tensor(expected_block_scales),
+    )
+    torch.testing.assert_close(
+        reconciled_global_scales, torch.tensor(expected_global_scale)
+    )
+
+
+def test_nvfp4_moe_reconciles_mismatched_w13_global_scales_per_expert():
+    block_scales = torch.tensor(
+        [
+            [[0.5], [1.0], [1.5], [2.0]],
+            [[1.0], [1.5], [2.0], [2.5]],
+            [[0.5], [1.5], [2.5], [3.5]],
+        ],
+        dtype=torch.float8_e4m3fn,
+    )
+    global_scales = torch.tensor([[2.0, 2.0], [4.0, 1.0], [1.0, 3.0]])
+    shard_scales = global_scales[:, :, None, None]
+    effective_scales_before = block_scales.reshape(3, 2, 2, 1).float() * shard_scales
+
+    reconciled_block_scales, reconciled_global_scales = reconcile_nvfp4_moe_w13_scales(
+        block_scales, global_scales
+    )
+    effective_scales_after = reconciled_block_scales.reshape(3, 2, 2, 1).float()
+    effective_scales_after *= reconciled_global_scales[:, None, None, None]
+
+    torch.testing.assert_close(reconciled_global_scales, torch.tensor([2.0, 4.0, 3.0]))
+    assert not torch.allclose(
+        effective_scales_before[2, 1],
+        block_scales.reshape(3, 2, 2, 1)[2, 1].float() * global_scales[2, 0],
+    )
+    torch.testing.assert_close(
+        effective_scales_after,
+        effective_scales_before,
+        rtol=2**-4,
+        atol=0,
+    )
 
 
 def _skip(msg: str) -> NoReturn:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -26,6 +26,9 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
 )
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    reconcile_nvfp4_moe_w13_scales,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
@@ -201,15 +204,16 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         )
         delattr(layer, "w2_weight_packed")
 
-        # Use a single gscale for w13.
-        if self.moe.is_act_and_mul and not torch.allclose(
-            layer.w13_weight_global_scale[:, 0], layer.w13_weight_global_scale[:, 1]
-        ):
-            logger.warning_once(
-                "w1_weight_global_scale must match w3_weight_global_scale. "
-                "Accuracy may be affected.",
+        w13_weight_scale = layer.w13_weight_scale
+        # CT stores global scales as divisors; use the kernel multiplier form.
+        w13_weight_scale_2 = 1.0 / layer.w13_weight_global_scale
+        if self.moe.is_act_and_mul and self.nvfp4_backend != NvFp4MoeBackend.HUMMING:
+            w13_weight_scale, w13_weight_scale_2 = reconcile_nvfp4_moe_w13_scales(
+                w13_weight_scale,
+                w13_weight_scale_2,
             )
-        w13_weight_global_scale = layer.w13_weight_global_scale[:, 0].contiguous()
+        else:
+            w13_weight_scale_2 = w13_weight_scale_2[:, 0].contiguous()
 
         # Shuffle weights into the NvFp4 kernel format.
         (
@@ -225,8 +229,8 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             nvfp4_backend=self.nvfp4_backend,
             layer=layer,
             w13=layer.w13_weight,
-            w13_scale=layer.w13_weight_scale,
-            w13_scale_2=(1.0 / w13_weight_global_scale),
+            w13_scale=w13_weight_scale,
+            w13_scale_2=w13_weight_scale_2,
             a13_scale=(1.0 / layer.w13_input_global_scale),
             w2=layer.w2_weight,
             w2_scale=layer.w2_weight_scale,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -40,6 +40,7 @@ from vllm.model_executor.layers.fused_moe.oracle.mxfp8 import (
     select_mxfp8_moe_backend,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
     convert_to_nvfp4_moe_kernel_format,
     is_global_sf_supported_for_nvfp4_backend,
     make_nvfp4_moe_kernel,
@@ -74,6 +75,9 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_BLOCK_SIZE,
     MXFP8_SCALE_DTYPE,
     MXFP8_VALUE_DTYPE,
+)
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    reconcile_nvfp4_moe_w13_scales,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     FP4_DTYPE,
@@ -964,15 +968,14 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         Convert NVFP4 MoE weights into kernel format and setup the kernel.
         """
 
-        # Use a single gscale for w13.
-        if self.moe.is_act_and_mul and not torch.allclose(
-            layer.w13_weight_scale_2[:, 0], layer.w13_weight_scale_2[:, 1]
-        ):
-            logger.warning_once(
-                "w1_weight_scale_2 must match w3_weight_scale_2. "
-                "Accuracy may be affected."
+        w13_weight_scale = layer.w13_weight_scale
+        if self.moe.is_act_and_mul and self.nvfp4_backend != NvFp4MoeBackend.HUMMING:
+            w13_weight_scale, w13_weight_scale_2 = reconcile_nvfp4_moe_w13_scales(
+                w13_weight_scale,
+                layer.w13_weight_scale_2,
             )
-        w13_weight_scale_2 = layer.w13_weight_scale_2[:, 0].contiguous()
+        else:
+            w13_weight_scale_2 = layer.w13_weight_scale_2[:, 0].contiguous()
 
         (
             w13,
@@ -987,7 +990,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             nvfp4_backend=self.nvfp4_backend,
             layer=layer,
             w13=layer.w13_weight,
-            w13_scale=layer.w13_weight_scale,
+            w13_scale=w13_weight_scale,
             w13_scale_2=w13_weight_scale_2,
             a13_scale=layer.w13_input_scale,
             w2=layer.w2_weight,

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -51,6 +51,7 @@ from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     select_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
     convert_to_nvfp4_moe_kernel_format,
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
@@ -59,6 +60,9 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
 from vllm.model_executor.layers.quantization.quark.utils import QuarkQTensorHint
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     validate_fp8_block_shape_moe,
+)
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    reconcile_nvfp4_moe_w13_scales,
 )
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     _ACTIVATION_QUANT_KEY_MAP,
@@ -1752,16 +1756,14 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
         Convert NVFP4 MoE weights into kernel format and setup the kernel.
         """
 
-        # Match existing NVFP4 MoE paths: fused w13 uses the w1 global scale.
-        if self.moe.is_act_and_mul and not torch.allclose(
-            layer.w13_weight_scale_2[:, 0], layer.w13_weight_scale_2[:, 1]
-        ):
-            logger.warning_once(
-                "w1_weight_scale_2 must match w3_weight_scale_2. "
-                "Accuracy may be affected."
+        w13_weight_scale = layer.w13_weight_scale
+        if self.moe.is_act_and_mul and self.nvfp4_backend != NvFp4MoeBackend.HUMMING:
+            w13_weight_scale, w13_weight_scale_2 = reconcile_nvfp4_moe_w13_scales(
+                w13_weight_scale,
+                layer.w13_weight_scale_2,
             )
-
-        w13_weight_scale_2 = layer.w13_weight_scale_2[:, 0].contiguous()
+        else:
+            w13_weight_scale_2 = layer.w13_weight_scale_2[:, 0].contiguous()
 
         w2_weight_scale_2 = layer.w2_weight_scale_2
 
@@ -1778,7 +1780,7 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
             nvfp4_backend=self.nvfp4_backend,
             layer=layer,
             w13=layer.w13_weight,
-            w13_scale=layer.w13_weight_scale,
+            w13_scale=w13_weight_scale,
             w13_scale_2=w13_weight_scale_2,
             a13_scale=layer.w13_input_scale_2,
             w2=layer.w2_weight,

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_utils.py
@@ -6,8 +6,43 @@ import torch
 from vllm._custom_ops import (
     cutlass_scaled_mm_supports_fp4,
 )
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import round_up
+
+logger = init_logger(__name__)
+
+
+def reconcile_nvfp4_moe_w13_scales(
+    w13_scale: torch.Tensor,
+    w13_scale_2: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reconcile fused MoE gate/up weights to one scale per expert.
+
+    The block scales are adjusted so that ``block_scale * scale_2`` is
+    preserved, within E4M3 rounding error.
+    """
+    gate_scale_2 = w13_scale_2[:, 0]
+    up_scale_2 = w13_scale_2[:, 1]
+    if torch.allclose(gate_scale_2, up_scale_2):
+        return w13_scale, gate_scale_2.contiguous()
+
+    logger.warning_once(
+        "Detected mismatched w1/w3 NVFP4 global scales for fused MoE "
+        "weights; reconciling them to a shared per-expert scale."
+    )
+
+    common_scale_2 = torch.maximum(gate_scale_2, up_scale_2)
+    scale_factors = w13_scale_2 / common_scale_2.unsqueeze(1)
+    num_experts, fused_size, block_count = w13_scale.shape
+    assert fused_size % 2 == 0
+    reconciled_scale = w13_scale.reshape(
+        num_experts, 2, fused_size // 2, block_count
+    ).float()
+    reconciled_scale *= scale_factors[:, :, None, None]
+    reconciled_scale = reconciled_scale.to(w13_scale.dtype).reshape(w13_scale.shape)
+
+    return reconciled_scale.contiguous(), common_scale_2.contiguous()
 
 
 def swizzle_blockscale(scale: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

NVFP4 fused MoE checkpoints may contain different per-expert global
scales for the gate and up projections.

The previous loading path detected this mismatch but retained only the
gate scale for fused w13, causing the up half to use the wrong effective
dequantization scale.

## Fix

- Reconcile gate/up `scale_2` per expert using their shared maximum.
- Rescale each half's E4M3 block scales to preserve its original
  effective dequantization scale.
- Leave the FP4 payload unchanged.
- Keep matching-scale checkpoints on a no-op path.
- Reuse the logic across ModelOpt, Quark, and compressed-tensors.
- Skip HUMMING because its converter already folds each half's
  `scale_2` into its block scales.

This follows the same max-scale policy used by vLLM's fused FP8 paths.

## Tests

Coverage includes:

- Matching-scale no-op.
- gate < up.
- gate > up.
- Multiple experts with independent reconciliation.
- Effective dequantization-scale invariant within E4M3 rounding.
- Regression coverage for the previous gate-only behavior.

Validation:

- Targeted reconciliation tests: 4 passed.
- Quark NVFP4 tests: 2 passed.
- Runnable compressed-tensors NVFP4 targets: 2 passed.
- Changed-files pre-commit hooks, including Ruff and mypy: passed.
- `git diff --check`: passed.

Full `tests/quantization/test_modelopt.py`:

- 38 passed.
- 2 skipped.
- 1 unrelated existing FP8/Marlin failure:
  `QKVParallelLinear` has no `orig_dtype` attribute in
  `test_modelopt_fp8_pb_wo_checkpoint_setup`.

Model evaluation:

- NOT RUN locally.
- The available RTX 4060 Laptop is SM89 and cannot execute the affected
  Blackwell NVFP4 MoE path; the affected checkpoint also exceeds the
  available 8 GiB VRAM.
- Numerical unit coverage validates preservation of the effective
  dequantization scale. End-to-end Blackwell evaluation remains
  hardware-blocked locally.

## Duplicate work

GitHub open-PR searches for #54974 and the relevant NVFP4 MoE w1/w3
scale-reconciliation terms found no PR addressing this issue.

## AI assistance

OpenAI Codex was used to inspect the implementation, prepare the patch,
and run the checks above. I reviewed the changes and am responsible for
the submitted code and validation.

## Issue

Fixes #54974
