### PR TITLE
[Examples] Fix ghost demo.py Usage in mistral-small_offline

### DIFF
--- a/examples/generate/multimodal/mistral-small_offline.py
+++ b/examples/generate/multimodal/mistral-small_offline.py
@@ -49,8 +49,8 @@ from vllm.multimodal.utils import encode_image_url
 # ```
 #
 # Usage:
-#     python demo.py simple
-#     python demo.py advanced
+#     python examples/generate/multimodal/mistral-small_offline.py simple
+#     python examples/generate/multimodal/mistral-small_offline.py advanced
 
 # Lower max_model_len and/or max_num_seqs on low-VRAM GPUs.
 # These scripts have been tested on 2x L40 GPUs


### PR DESCRIPTION
## Summary
- Fix Usage comment in `examples/generate/multimodal/mistral-small_offline.py`: ghost `python demo.py simple|advanced` → real path `python examples/generate/multimodal/mistral-small_offline.py simple|advanced`.

## Repro
1. On `main`:
   ```bash
   curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/generate/multimodal/mistral-small_offline.py | sed -n '48,55p'
   ```
   Usage cites `python demo.py simple` / `python demo.py advanced`.
2. Confirm ghost path:
   ```bash
   gh api repos/vllm-project/vllm/contents/examples/generate/multimodal/demo.py
   ```
   → HTTP 404 (no `demo.py` under that directory; tree has no `demo.py` example).
3. The file itself is `mistral-small_offline.py` and accepts `simple|advanced` modes via argparse.

## Test plan
- [x] Comment-only change; Usage matches filename + modes
- [x] No runtime / argparse / other files changed
- [ ] CI / pre-run-check as applicable
