### PR TITLE
[Docs] Point Completions client example at openai_completion_client.py

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -264,7 +264,7 @@ Since this server is compatible with OpenAI API, you can use it as a drop-in rep
     print("Completion result:", completion)
     ```
 
-A more detailed client example can be found here: [examples/basic/offline_inference/basic.py](../../examples/basic/offline_inference/basic.py)
+A more detailed client example can be found here: [examples/basic/online_serving/openai_completion_client.py](../../examples/basic/online_serving/openai_completion_client.py)
 
 ### OpenAI Chat Completions API with vLLM
 


### PR DESCRIPTION
## Summary

Under **OpenAI Completions API with vLLM**, the quickstart linked to `examples/basic/offline_inference/basic.py` (offline `LLM.generate`) as the “more detailed client example”. That file is not an OpenAI Completions client.

Point the link at `examples/basic/online_serving/openai_completion_client.py`, which uses `client.completions.create` against a running vLLM server.

(The earlier offline-inference link to `basic.py` in the same doc is left unchanged.)

## Repro

1. Open `docs/getting_started/quickstart.md` on `main`, section **OpenAI Completions API with vLLM**.
2. Note the sentence: “A more detailed client example can be found here” → `examples/basic/offline_inference/basic.py`.
3. Open that file: it imports `from vllm import LLM, SamplingParams` and calls `llm.generate` (offline), not the OpenAI Completions client.
4. Confirm `examples/basic/online_serving/openai_completion_client.py` exists and calls `client.completions.create`.

```bash
# Verify wrong link target (offline LLM API)
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/basic/offline_inference/basic.py | head -20

# Verify correct Completions client
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/basic/online_serving/openai_completion_client.py | head -40
```

## Test plan

- [x] Diff is a single link change in `docs/getting_started/quickstart.md`
- [x] Target path returns HTTP 200 on `main`
- [x] Offline `basic.py` link earlier in the doc remains intact