### PR TITLE
[Test][Tool Parser] Add streaming split-invariance test to the common suite

### DIFF
--- a/tests/tool_parsers/common_tests.py
+++ b/tests/tool_parsers/common_tests.py
@@ -8,9 +8,18 @@ from typing import Any
 
 import pytest
 
-from tests.tool_parsers.utils import run_tool_extraction
+from tests.tool_parsers.utils import (
+    random_groupings,
+    run_tool_extraction,
+    run_tool_extraction_streaming_batched,
+    split_string_into_token_stream,
+    two_chunk_groupings,
+)
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParserManager
+
+RANDOM_GROUPING_COUNT = 100
+RANDOM_GROUPING_SEED = 20260902
 
 
 @dataclass
@@ -366,6 +375,99 @@ class ToolParserTests:
         if len(tools_non) > 0:
             assert tools_non[0].function.name == tools_stream[0].function.name
             assert tools_non[0].function.arguments == tools_stream[0].function.arguments
+
+    def test_streaming_split_invariance(
+        self,
+        request: pytest.FixtureRequest,
+        tool_parser: Any,
+        test_config: ToolParserTestConfig,
+    ):
+        """Verify the streamed result does not depend on token batching.
+
+        ``test_streaming_reconstruction`` streams one token at a time,
+        which is a single partition of the token stream.  A server
+        batches a variable number of tokens per delta, so a tool-call
+        tag that is only mishandled when it straddles one particular
+        delta boundary never shows up.
+
+        The baseline here is the one-token-per-delta stream rather than
+        the non-streaming parse, so the check stays meaningful for
+        parsers whose non-streaming path is separately known to be
+        broken (see ``xfail_nonstreaming``).
+        """
+        test_name = "test_streaming_split_invariance"
+        self.apply_xfail_mark(request, test_config, test_name, True)
+
+        for label, output in (
+            ("single", test_config.single_tool_call_output),
+            ("parallel", test_config.parallel_tool_calls_output),
+        ):
+            token_texts, token_ids = split_string_into_token_stream(
+                tool_parser.model_tokenizer, output
+            )
+            baseline = self.stream_with_batching(
+                test_config,
+                tool_parser.model_tokenizer,
+                token_texts,
+                token_ids,
+                [1] * len(token_texts),
+            )
+            batchings = two_chunk_groupings(len(token_texts)) + random_groupings(
+                len(token_texts),
+                count=RANDOM_GROUPING_COUNT,
+                seed=RANDOM_GROUPING_SEED,
+            )
+            failures: list[tuple[list[int], str]] = []
+            for lengths in batchings:
+                try:
+                    actual = self.stream_with_batching(
+                        test_config,
+                        tool_parser.model_tokenizer,
+                        token_texts,
+                        token_ids,
+                        lengths,
+                    )
+                    assert actual == baseline, f"expected {baseline}, got {actual}"
+                except AssertionError as exc:
+                    failures.append((lengths, str(exc)))
+
+            if failures:
+                lengths, err = min(failures, key=lambda item: len(item[0]))
+                raise AssertionError(
+                    f"{len(failures)}/{len(batchings)} token batchings changed "
+                    f"the {label} tool-call parse for "
+                    f"{test_config.parser_name!r}. Minimal failing batching "
+                    f"(tokens per delta) {lengths}:\n{err}"
+                )
+
+    @staticmethod
+    def stream_with_batching(
+        test_config: ToolParserTestConfig,
+        tokenizer: TokenizerLike,
+        token_texts: list[str],
+        token_ids: list[int],
+        lengths: list[int],
+    ) -> tuple[str | None, tuple[tuple[str, str], ...]]:
+        """Stream the token sequence batched by *lengths* into a result.
+
+        A fresh parser is built per batching because parsers carry
+        streaming state across deltas.
+        """
+        parser = ToolParserManager.get_tool_parser(test_config.parser_name)(tokenizer)
+        reconstructor = run_tool_extraction_streaming_batched(
+            parser,
+            token_texts,
+            token_ids,
+            lengths,
+            assert_one_tool_per_delta=False,
+        )
+        return (
+            reconstructor.other_content or None,
+            tuple(
+                (tc.function.name, tc.function.arguments or "")
+                for tc in reconstructor.tool_calls
+            ),
+        )
 
     def apply_xfail_mark(self, request, test_config, test_name, streaming):
         reason = None

--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -82,7 +82,14 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
             parallel_tool_calls_count=2,
             parallel_tool_calls_names=["get_weather", "search_hotels"],
             # xfail markers
-            xfail_streaming={},
+            xfail_streaming={
+                "test_streaming_split_invariance": (
+                    "Streamed result depends on delta boundaries: the call is dropped "
+                    "when a delta carries it whole (#48020, PR #48636) and "
+                    "arguments are lost when the end token shares a delta "
+                    "(#48342, PR #48343)"
+                ),
+            },
             xfail_nonstreaming={
                 "test_malformed_input": (
                     "Parser sets tools_called=True even when tool_calls is "

--- a/tests/tool_parsers/test_granite_20b_fc_tool_parser.py
+++ b/tests/tool_parsers/test_granite_20b_fc_tool_parser.py
@@ -68,6 +68,10 @@ class TestGranite20bFcToolParser(ToolParserTests):
             parallel_tool_calls_names=["get_weather", "get_time"],
             # xfail markers
             xfail_streaming={
+                "test_streaming_split_invariance": (
+                    "Streamed result depends on delta boundaries; the tool call is "
+                    "lost when a delta carries it whole (#47907)"
+                ),
                 "test_surrounding_text": (
                     "Granite 20B FC streaming requires <function_call> at start"
                 ),

--- a/tests/tool_parsers/test_granite_tool_parser.py
+++ b/tests/tool_parsers/test_granite_tool_parser.py
@@ -78,6 +78,10 @@ I'll get that information.""",
             parallel_tool_calls_names=["get_weather", "get_time"],
             # xfail markers
             xfail_streaming={
+                "test_streaming_split_invariance": (
+                    "Streamed result depends on delta boundaries; the tool call is "
+                    "lost when a delta carries it whole (#47907)"
+                ),
                 "test_malformed_input": (
                     "Streaming mode incorrectly creates tool call from malformed JSON"
                 ),

--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -98,6 +98,11 @@ class TestInternLM2ToolParser(ToolParserTests):
             allow_empty_or_json_empty_args=True,
             # xfail markers
             xfail_streaming={
+                "test_streaming_split_invariance": (
+                    "Streamed result depends on delta boundaries; arguments or the "
+                    "whole call are lost when a delta carries the call "
+                    "whole (#48347, PR #50461)"
+                ),
                 "test_single_tool_call_simple_args": (
                     "InternLM2 streaming not fully implemented"
                 ),

--- a/tests/tool_parsers/test_step3_tool_parser.py
+++ b/tests/tool_parsers/test_step3_tool_parser.py
@@ -99,6 +99,10 @@ class TestStep3ToolParser(ToolParserTests):
                 "test_escaped_strings": "Step3 parser non-streaming has bugs",
             },
             xfail_streaming={
+                "test_streaming_split_invariance": (
+                    "Streamed tool arguments are empty unless each token arrives in "
+                    "its own delta"
+                ),
                 "test_parallel_tool_calls": (
                     "Step3 parser has significant bugs in both streaming "
                     "and non-streaming"

--- a/tests/tool_parsers/utils.py
+++ b/tests/tool_parsers/utils.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable
+import random
+from collections.abc import Iterable, Sequence
 
 from vllm.entrypoints.generate.base.protocol import (
     DeltaMessage,
@@ -124,6 +125,140 @@ def split_string_into_token_deltas(tokenizer: TokenizerLike, text: str) -> list[
         previously_decoded_text = current_text
         deltas.append(new_text)
     return deltas
+
+
+def group_token_deltas(deltas: Sequence[str], lengths: Sequence[int]) -> list[str]:
+    """Batch per-token *deltas* into chunks of the given *lengths*.
+
+    A server batches several tokens into one streamed delta, so the text
+    a parser sees is an arbitrary grouping of the token stream rather
+    than one token at a time.  Any leftover tokens form a final chunk.
+    """
+    chunks: list[str] = []
+    start = 0
+    for length in lengths:
+        if start >= len(deltas):
+            break
+        end = min(start + length, len(deltas))
+        chunks.append("".join(deltas[start:end]))
+        start = end
+    if start < len(deltas):
+        chunks.append("".join(deltas[start:]))
+    return chunks
+
+
+def two_chunk_groupings(n_deltas: int) -> list[list[int]]:
+    """Every way to batch *n_deltas* tokens into exactly two deltas.
+
+    Exhaustive and cheap (``n_deltas - 1`` groupings).  A tool-call tag
+    that is only mishandled when it straddles one particular delta
+    boundary is invisible to single-token streaming but is always caught
+    here.
+    """
+    return [[i, n_deltas - i] for i in range(1, n_deltas)]
+
+
+def random_groupings(
+    n_deltas: int,
+    *,
+    count: int,
+    seed: int,
+    max_chunk: int = 4,
+) -> list[list[int]]:
+    """Sample *count* random batchings of *n_deltas* tokens.
+
+    Chunk lengths are drawn uniformly from ``1..max_chunk``.  ``seed``
+    makes the set reproducible so a failure can be replayed exactly.
+    """
+    rng = random.Random(seed)
+    groupings: list[list[int]] = []
+    for _ in range(count):
+        lengths: list[int] = []
+        remaining = n_deltas
+        while remaining > 0:
+            length = min(rng.randint(1, max_chunk), remaining)
+            lengths.append(length)
+            remaining -= length
+        groupings.append(lengths)
+    return groupings
+
+
+def split_string_into_token_stream(
+    tokenizer: TokenizerLike, text: str
+) -> tuple[list[str], list[int]]:
+    """Split *text* into per-token texts alongside their token ids.
+
+    ``split_string_into_token_deltas`` returns only the texts, so a
+    caller that batches tokens has to re-tokenize the joined text to
+    recover ids.  Re-tokenization does not round-trip (``"<|a|>"`` as one
+    string may tokenize differently than its pieces), which would make a
+    batched replay feed the parser ids the model never generated.
+    """
+    token_ids = tokenizer.encode(text, add_special_tokens=False)
+    texts: list[str] = []
+    previously_decoded_text = ""
+    for i in range(1, len(token_ids) + 1):
+        current_text = tokenizer.decode(token_ids[:i])
+        texts.append(current_text[len(previously_decoded_text) :])
+        previously_decoded_text = current_text
+    return texts, token_ids
+
+
+def run_tool_extraction_streaming_batched(
+    tool_parser: ToolParser,
+    token_texts: Sequence[str],
+    token_ids: Sequence[int],
+    lengths: Sequence[int],
+    request: ChatCompletionRequest | None = None,
+    assert_one_tool_per_delta: bool = True,
+) -> StreamingToolReconstructor:
+    """Stream a token sequence batched into deltas of *lengths* tokens.
+
+    Unlike :func:`run_tool_extraction_streaming`, the real token ids are
+    carried through the batching instead of being recovered by
+    re-tokenizing each delta, which matches what the server passes to
+    ``extract_tool_calls_streaming``.
+    """
+    request = request or ChatCompletionRequest(messages=[], model="test-model")
+    reconstructor = StreamingToolReconstructor(
+        assert_one_tool_per_delta=assert_one_tool_per_delta
+    )
+    previous_text = ""
+    previous_tokens: list[int] = []
+    for start, end in _batch_bounds(len(token_texts), lengths):
+        delta = "".join(token_texts[start:end])
+        token_delta = list(token_ids[start:end])
+        current_text = previous_text + delta
+        current_tokens = previous_tokens + token_delta
+        delta_message = tool_parser.extract_tool_calls_streaming(
+            previous_text,
+            current_text,
+            delta,
+            previous_tokens,
+            current_tokens,
+            token_delta,
+            request,
+        )
+        if delta_message is not None:
+            reconstructor.append_delta(delta_message)
+        previous_text = current_text
+        previous_tokens = current_tokens
+    return reconstructor
+
+
+def _batch_bounds(n_tokens: int, lengths: Sequence[int]) -> list[tuple[int, int]]:
+    """Turn per-delta *lengths* into ``(start, end)`` pairs over the stream."""
+    bounds: list[tuple[int, int]] = []
+    start = 0
+    for length in lengths:
+        if start >= n_tokens:
+            break
+        end = min(start + length, n_tokens)
+        bounds.append((start, end))
+        start = end
+    if start < n_tokens:
+        bounds.append((start, n_tokens))
+    return bounds
 
 
 def run_tool_extraction_streaming(


### PR DESCRIPTION
## Purpose

A streaming tool parser is a state machine over an arbitrary partition of its
token stream. Which tokens land in which delta is decided by the scheduler,
`--stream-interval`, and speculative decoding, so the parsed result must not
depend on it. The common suite streams **one token per delta**, which is a
single partition, so a tag mishandled only when it straddles one particular
delta boundary is never exercised.

Issue #48342 names this gap directly:

> The existing tests stream strictly one token per delta, so this
> multi-token-delta path is untested.

The same failure class has since been filed parser by parser:

| Issue | Parsers | Fix PR |
|---|---|---|
| #48020 | deepseek_v3, deepseek_v31 | #48636 (open) |
| #48342 | deepseek_v3 (arguments truncated) | #48343 (open) |
| #47907 | gigachat3, granite, granite-20b-fc | - |
| #48294 | llama3_json, jamba, ernie45 | #48295 (open) |
| #48347 | internlm | #50461 (open) |

That is five issues and nine parsers for one property. This PR adds the
property test so the class is covered once, for every parser using the common
suite, rather than one issue per parser.

## What it does

`ToolParserTests.test_streaming_split_invariance` replays each config's
single and parallel tool-call outputs (as separate parametrized cases) as:

- the **whole stream in one delta**,
- every **two-delta split** (exhaustive, `n-1` of them), and
- **100 seeded random batchings** of 1-4 tokens per delta,

and compares each against the one-token-per-delta baseline.

Two deliberate choices:

- **The baseline is the streamed result, not the non-streamed parse.** Several
  parsers have separately known non-streaming bugs (see `xfail_nonstreaming`),
  and using them as the oracle would report those instead of the property
  under test.
- **Failures report the shortest failing batching**, so the repro names the
  exact boundary rather than a random 30-chunk split.

`run_tool_extraction_streaming` recovers token ids by re-tokenizing each
delta. That does not round-trip once a delta holds several tokens (`"<|a|>"`
as one string does not tokenize like its pieces), so a batched replay would
feed parsers ids the model never generated. `run_tool_extraction_streaming_batched`
carries the real ids through the batching instead, and after the last delta
appends `get_remaining_unstreamed_args()` to the last tool call, as
`finalize_generation` does in the serving layer, so only client-visible loss
counts. Existing behaviour is untouched.

## Result

Parsers currently failing the property are marked `xfail(strict=True)` against
the issues above, so this lands green and flips to a failure the moment each
fix merges.

| Parser | 2-delta splits differing from baseline | Symptom at the minimal split |
|---|---|---|
| deepseek_v3 | 26/26 | call dropped, or name with empty arguments |
| granite | 28/28 | call dropped, content truncated to `<` |
| granite-20b-fc | 5/24 | call dropped |
| internlm | 36/37 | call dropped, content truncated to `<` |
| step3 | 27/64 | name emitted with empty arguments |
| longcat | 0/35 | passes |
| phi4_mini_json | 0/24 | passes |

step3 is the one row with no issue filed; the others match the table above.

Counts include the end-of-stream flush. Without it granite-20b-fc differed on
24/24 splits, but 19 of those were missing only argument text the serving layer
restores (see the review thread); every other row is the same either way.

## Not a duplicate

Checked per AGENTS.md. The open PRs listed above are **bugfixes** to individual
parsers; this is the missing **test coverage** whose absence #48342 identifies
as the reason the class kept recurring. It deliberately does not change any
parser, so it does not collide with #48636, #48343, #48295, #50461 or #49648.
When those merge, their `xfail` entries are removed in the same PR.

## Test plan

```bash
.venv/bin/python -m pytest tests/tool_parsers tests/parser -q \
    --ignore=tests/tool_parsers/test_cohere_command_tool_parser.py
```

- `tests/tool_parsers` + `tests/parser`: 5083 passed, 1 skipped, 44 xfailed
- `tests/tool_parsers/test_cohere_command_tool_parser.py` was excluded: it
  needs the `cohere_melody` package, which is not installed here.
- 15 errors in `tests/tool_parsers/test_llama3_json_tool_parser.py` are
  pre-existing on this machine (gated `meta-llama/Llama-3.2-1B-Instruct`,
  HTTP 401) and reproduce without this change.
- `ruff check` and `ruff format --check` clean.

The findings above were also reproduced with a standalone script that calls
only `extract_tool_calls_streaming`, with no test helpers, to rule out the
harness as the cause.

No model evaluation: tests only, no serving or output path is modified.

AI assistance was used to write this change.

---

cc @bbrowning @chaunceyjiang, who own `tests/parser/engine` and the streaming
parser engine work this sits next to. Happy to split the `xfail` markers into a
follow-up, or to narrow the sampled batchings, if either would make review easier.

