### PR TITLE
[Bugfix][Spec Decode] Implement SupportsPP on remaining MTP drafters (14 classes)

### DIFF
--- a/vllm/model_executor/models/ernie_mtp.py
+++ b/vllm/model_executor/models/ernie_mtp.py
@@ -37,8 +37,14 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.sequence import IntermediateTensors
 
+from .interfaces import SupportsPP
 from .llama import LlamaDecoderLayer
-from .utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
+from .utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 
 
 class ErnieMultiTokenPredictorLayer(nn.Module):
@@ -140,11 +146,16 @@ class ErnieMultiTokenPredictor(nn.Module):
         return logits
 
 
-class ErnieMTP(nn.Module):
+class ErnieMTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
         self.config = vllm_config.model_config.hf_config
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
         # MTP weights are stored under a flat `mtp_*.0.` block in the
         # checkpoint; rewrite them into `model.layers.{spec_layer}.*`.
         spec_layer = self.config.num_hidden_layers
@@ -182,7 +193,7 @@ class ErnieMTP(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/exaone_moe_mtp.py
+++ b/vllm/model_executor/models/exaone_moe_mtp.py
@@ -21,7 +21,13 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.models.exaone_moe import ExaoneMoeDecoderLayer
 from vllm.sequence import IntermediateTensors
 
-from .utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
+from .interfaces import SupportsPP
+from .utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 
 logger = init_logger(__name__)
 
@@ -132,7 +138,7 @@ class ExaoneMoeMultiTokenPredictor(nn.Module):
 
 
 @support_torch_compile
-class ExaoneMoeMTP(nn.Module):
+class ExaoneMoeMTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         config = vllm_config.model_config.hf_config
         self.vllm_config = vllm_config
@@ -140,6 +146,11 @@ class ExaoneMoeMTP(nn.Module):
 
         super().__init__()
         self.config = config
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
         self.model = ExaoneMoeMultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
         )
@@ -160,7 +171,7 @@ class ExaoneMoeMTP(nn.Module):
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -48,11 +48,13 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.gemma4 import gemma4_layer_config
 
 from .gemma4 import Gemma4MLP, _get_text_config
+from .interfaces import SupportsPP
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
     extract_layer_index,
     get_draft_quant_config,
+    make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
 
@@ -437,7 +439,7 @@ class Gemma4MultiTokenPredictor(nn.Module):
 
 
 @support_torch_compile
-class Gemma4MTP(nn.Module):
+class Gemma4MTP(nn.Module, SupportsPP):
     """Gemma4 Multi-Token Prediction model for speculative decoding.
 
     forward() returns (draft_hidden_states, backbone_hidden_states).
@@ -491,6 +493,11 @@ class Gemma4MTP(nn.Module):
             text_config.vocab_size,
             soft_cap=getattr(text_config, "final_logit_softcapping", None),
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], text_config.hidden_size
+        )
 
         self.masked_embedding: Gemma4MTPMaskedEmbedder | None
         if getattr(config, "use_ordered_embeddings", False):
@@ -524,7 +531,7 @@ class Gemma4MTP(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -52,9 +52,11 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from .hy_v3 import HYV3DecoderLayer
+from .interfaces import SupportsPP
 from .utils import (
     get_spec_layer_idx_from_weight_name,
     is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
 
@@ -205,7 +207,7 @@ class HYV3MultiTokenPredictor(nn.Module):
         return logits
 
 
-class HYV3MTP(nn.Module):
+class HYV3MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
@@ -213,10 +215,15 @@ class HYV3MTP(nn.Module):
         self.model = HYV3MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
         self.sampler = Sampler()
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/longcat_flash_mtp.py
+++ b/vllm/model_executor/models/longcat_flash_mtp.py
@@ -24,7 +24,8 @@ from vllm.model_executor.models.longcat_flash import FlashConfig
 from vllm.sequence import IntermediateTensors
 
 from .deepseek_v2 import DeepseekV2DecoderLayer
-from .utils import maybe_prefix
+from .interfaces import SupportsPP
+from .utils import make_empty_intermediate_tensors_factory, maybe_prefix
 
 
 class LongCatMultiTokenPredictorLayer(nn.Module):
@@ -123,7 +124,7 @@ class LongCatMultiTokenPredictor(nn.Module):
         )
 
 
-class LongCatFlashMTP(nn.Module):
+class LongCatFlashMTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         # LongCat MTP has no MoE layers: clear n_routed_experts so the predictor
@@ -149,8 +150,13 @@ class LongCatFlashMTP(nn.Module):
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/mimo_mtp.py
+++ b/vllm/model_executor/models/mimo_mtp.py
@@ -37,7 +37,13 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.models.qwen2 import Qwen2DecoderLayer
 from vllm.sequence import IntermediateTensors
 
-from .utils import AutoWeightsLoader, WeightsMapper, maybe_prefix
+from .interfaces import SupportsPP
+from .utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 
 
 class MiMoMultiTokenPredictorLayer(nn.Module):
@@ -150,7 +156,7 @@ class MiMoMultiTokenPredictor(nn.Module):
         return logits
 
 
-class MiMoMTP(nn.Module):
+class MiMoMTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
@@ -161,6 +167,11 @@ class MiMoMTP(nn.Module):
             self.config.vocab_size,
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
         )
         # Checkpoint stores MTP layers 0-indexed and without the `mtp_block`
         # wrapper around the transformer block; remap onto the offset index.
@@ -188,7 +199,7 @@ class MiMoMTP(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/mimo_v2_mtp.py
+++ b/vllm/model_executor/models/mimo_v2_mtp.py
@@ -43,10 +43,15 @@ from vllm.sequence import IntermediateTensors
 from .interfaces import (
     MultiModalEmbeddings,
     SupportsMultiModal,
+    SupportsPP,
     _require_is_multimodal,
 )
 from .mimo_v2 import MiMoV2Attention, MiMoV2MLP
-from .utils import _merge_multimodal_embeddings, maybe_prefix
+from .utils import (
+    _merge_multimodal_embeddings,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 
 # MiMo-V2 checkpoints contain multiple MTP layers, but vLLM currently supports
 # only the first layer
@@ -215,7 +220,7 @@ class MiMoV2MultiTokenPredictor(nn.Module):
         return self.logits_processor(lm_head, hidden_states)
 
 
-class MiMoV2MTP(nn.Module):
+class MiMoV2MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         self.config = vllm_config.model_config.hf_config
@@ -227,11 +232,16 @@ class MiMoV2MTP(nn.Module):
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/openpangu_mtp.py
+++ b/vllm/model_executor/models/openpangu_mtp.py
@@ -42,7 +42,11 @@ from vllm.model_executor.models.deepseek_mtp import (
     DeepSeekMultiTokenPredictorLayer,
     SharedHead,
 )
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.sequence import IntermediateTensors
 
 from .openpangu import OpenPanguDecoderLayer
@@ -93,18 +97,23 @@ class OpenPanguMultiTokenPredictor(DeepSeekMultiTokenPredictor):
 
 
 @support_torch_compile
-class OpenPanguMTP(nn.Module):
+class OpenPanguMTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
         self.model = OpenPanguMultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/model_executor/models/step3p5_mtp.py
+++ b/vllm/model_executor/models/step3p5_mtp.py
@@ -21,8 +21,13 @@ from vllm.model_executor.model_loader.mtp_validation import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
 
+from .interfaces import SupportsPP
 from .step3p5 import Step3p5DecoderLayer
-from .utils import get_spec_layer_idx_from_weight_name, maybe_prefix
+from .utils import (
+    get_spec_layer_idx_from_weight_name,
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 
 logger = init_logger(__name__)
 
@@ -151,7 +156,7 @@ class Step3p5AMultiTokenPredictor(nn.Module):
         return self.embed_tokens(input_ids)
 
 
-class Step3p5MTP(nn.Module):
+class Step3p5MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
@@ -159,11 +164,16 @@ class Step3p5MTP(nn.Module):
         self.model = Step3p5AMultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,

--- a/vllm/models/deepseek_v32/amd/mtp.py
+++ b/vllm/models/deepseek_v32/amd/mtp.py
@@ -170,6 +170,11 @@ class DeepseekV32MTP(nn.Module, DeepseekV2MixtureOfExperts, SupportsPP):
         self.model = DeepseekV32MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
         self.set_moe_parameters()
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], self.config.hidden_size

--- a/vllm/models/deepseek_v32/nvidia/mtp.py
+++ b/vllm/models/deepseek_v32/nvidia/mtp.py
@@ -272,6 +272,11 @@ class DeepseekV32MTP(nn.Module, DeepseekV2MixtureOfExperts, SupportsPP):
         )
         if self.config.model_type == "glm_moe_dsa":
             enable_glm52_low_latency_gemm(self, vllm_config.model_config.dtype)
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
         self.set_moe_parameters()
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], self.config.hidden_size

--- a/vllm/models/hy_v4/nvidia/mtp.py
+++ b/vllm/models/hy_v4/nvidia/mtp.py
@@ -29,9 +29,11 @@ from vllm.model_executor.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from vllm.model_executor.models.deepseek_v2 import _try_load_fp8_indexer_wk
+from vllm.model_executor.models.interfaces import SupportsPP
 from vllm.model_executor.models.utils import (
     get_pp_missing_layer_names,
     is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
 from vllm.sequence import IntermediateTensors
@@ -518,11 +520,13 @@ class HYV4MultiTokenPredictor(nn.Module):
         return self.logits_processor(lm_head, proj_input)
 
 
-class HYV4MTP(nn.Module):
+class HYV4MTP(nn.Module, SupportsPP):
     """HY V4 MTP draft head.
 
     Not a pipeline-parallel stage: the draft head always runs on a single rank,
-    matching `DeepseekV32MTP` / `KimiK3MTP` / `HYV3MTP`.
+    matching `DeepseekV32MTP` / `KimiK3MTP` / `HYV3MTP`. SupportsPP + the empty
+    intermediate-tensors factory only satisfy the config verification path that
+    copies pipeline_parallel_size from the target into draft_parallel_config.
     """
 
     packed_modules_mapping = {
@@ -541,6 +545,9 @@ class HYV4MTP(nn.Module):
         )
         self.quant_config = self.model.quant_config
         self.sampler = Sampler()
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def set_topk_indices_buffer(self, topk_indices_buffer: torch.Tensor) -> None:
         """Share the target sparse-index buffer with every draft consumer.
@@ -565,7 +572,7 @@ class HYV4MTP(nn.Module):
             )
             attn_impl.topk_indices_buffer = topk_indices_buffer
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,

--- a/vllm/models/inkling/amd/mtp.py
+++ b/vllm/models/inkling/amd/mtp.py
@@ -33,8 +33,14 @@ from vllm.model_executor.model_loader.mtp_validation import (
     is_mtp_completeness_check_enabled,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm.model_executor.models.interfaces import SupportsMultiModalEmbeddings
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models.interfaces import (
+    SupportsMultiModalEmbeddings,
+    SupportsPP,
+)
+from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.sequence import IntermediateTensors
 
 from ..configs import InklingModelConfig
@@ -243,7 +249,7 @@ class InklingMultiTokenPredictor(nn.Module):
         return hidden
 
 
-class InklingMTP(nn.Module, SupportsMultiModalEmbeddings):
+class InklingMTP(nn.Module, SupportsPP, SupportsMultiModalEmbeddings):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         assert vllm_config.speculative_config is not None
@@ -262,6 +268,11 @@ class InklingMTP(nn.Module, SupportsMultiModalEmbeddings):
             org_vocab_size=config.vocab_size,
             soft_cap=config.final_logit_softcapping,
         )
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
         self._logits_zero: torch.Tensor | None = None
 
     def embed_input_ids(
@@ -275,7 +286,7 @@ class InklingMTP(nn.Module, SupportsMultiModalEmbeddings):
             input_ids, multimodal_embeddings, is_multimodal=is_multimodal
         )
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,

--- a/vllm/models/inkling/nvidia/mtp.py
+++ b/vllm/models/inkling/nvidia/mtp.py
@@ -33,8 +33,14 @@ from vllm.model_executor.model_loader.mtp_validation import (
     is_mtp_completeness_check_enabled,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm.model_executor.models.interfaces import SupportsMultiModalEmbeddings
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models.interfaces import (
+    SupportsMultiModalEmbeddings,
+    SupportsPP,
+)
+from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.sequence import IntermediateTensors
 
 from ..configs import InklingModelConfig
@@ -243,7 +249,7 @@ class InklingMultiTokenPredictor(nn.Module):
         return hidden
 
 
-class InklingMTP(nn.Module, SupportsMultiModalEmbeddings):
+class InklingMTP(nn.Module, SupportsPP, SupportsMultiModalEmbeddings):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         assert vllm_config.speculative_config is not None
@@ -263,6 +269,11 @@ class InklingMTP(nn.Module, SupportsMultiModalEmbeddings):
             soft_cap=config.final_logit_softcapping,
         )
         self._logits_zero: torch.Tensor | None = None
+        # The drafter is only built on the last PP rank so the SupportsPP-shaped
+        # forward is never called; the factory is here to satisfy the interface.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
 
     def embed_input_ids(
         self,
@@ -275,7 +286,7 @@ class InklingMTP(nn.Module, SupportsMultiModalEmbeddings):
             input_ids, multimodal_embeddings, is_multimodal=is_multimodal
         )
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,


### PR DESCRIPTION
## Summary

Completes the SupportsPP sweep started in #46994 (DeepSeek + Qwen3.5), #53408 (DSv4), and #54635 (Kimi-K3, MiniMax-M3, Glm4-MoE) by adding the mixin + `make_empty_intermediate_tensors_factory` wire-up to the 14 remaining outer MTP draft classes.

## Files (12)

| file | class |
|---|---|
| `vllm/model_executor/models/ernie_mtp.py` | `ErnieMTP` |
| `vllm/model_executor/models/exaone_moe_mtp.py` | `ExaoneMoeMTP` (`Exaone4_5_MTP` inherits) |
| `vllm/model_executor/models/gemma4_mtp.py` | `Gemma4MTP` |
| `vllm/model_executor/models/hy_v3_mtp.py` | `HYV3MTP` |
| `vllm/model_executor/models/longcat_flash_mtp.py` | `LongCatFlashMTP` |
| `vllm/model_executor/models/mimo_mtp.py` | `MiMoMTP` |
| `vllm/model_executor/models/mimo_v2_mtp.py` | `MiMoV2MTP` (`MiMoV2OmniMTP` inherits) |
| `vllm/model_executor/models/openpangu_mtp.py` | `OpenPanguMTP` |
| `vllm/model_executor/models/step3p5_mtp.py` | `Step3p5MTP` |
| `vllm/models/deepseek_v32/amd/mtp.py` | `DeepseekV32MTP` |
| `vllm/models/deepseek_v32/nvidia/mtp.py` | `DeepseekV32MTP` (`Dots3NoteMTP` inherits) |
| `vllm/models/hy_v4/nvidia/mtp.py` | `HYV4MTP` (docstring already noted "always runs on a single rank") |
| `vllm/models/inkling/amd/mtp.py` | `InklingMTP` (already has `SupportsMultiModalEmbeddings`) |
| `vllm/models/inkling/nvidia/mtp.py` | `InklingMTP` (same) |

## Rationale

Same as prior PRs: the drafter is only ever built on the last PP stage (`is_last_pp_rank` guard in `model_runner.py`), so the SupportsPP-shaped `forward` is never called. The mixin + factory just satisfy the config verification path that copies `pipeline_parallel_size` from the target into `draft_parallel_config`, so `vllm serve <model> --pipeline-parallel-size N --speculative-config method:mtp` does not fail during `create_engine_config` with `NotImplementedError: Pipeline parallelism is not supported for this model. Supported models implement the SupportsPP interface.`

## Duplicate-work check

Searched open PRs for each target file, for `MTP SupportsPP`, and for `#52069 in:body`. Only #46994, #53408, and #54635 are in flight; the file sets are disjoint.

## Testing

- `.venv/bin/python -m pre_commit run --files <the 14 files>` — passed (ruff, mypy, typos, SPDX, etc.)

Mechanical, per-class mixin add; no behavior change on the per-request path (draft forward call site is untouched).

AI assistance was used for code search and drafting; every line was reviewed by the submitter.
