### PR TITLE
[Bugfix] Retain vocab embeddings during replacement

### DIFF
--- a/tests/models/transformers/test_backend.py
+++ b/tests/models/transformers/test_backend.py
@@ -479,11 +479,11 @@ def replace_vocab_embeddings(model, **config_kwargs):
     stub.config = PretrainedConfig(
         vocab_size=VOCAB_SIZE, num_positions=NUM_POSITIONS, **config_kwargs
     )
-    ids = Base._vocab_embedding_ids(stub)
+    embeddings = Base._vocab_embeddings(stub)
 
     replaced = []
     for name, module in list(model.named_modules()):
-        if id(module) in ids:
+        if module in embeddings:
             replaced.append(replace(module))
             attrsetter(name)(model, replaced[-1])
     return replaced

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -416,8 +416,8 @@ class Base(
                 # attrsetter in case the module is nested (e.g. "text_model.norm")
                 attrsetter(name)(module, PPMissingLayer())
 
-    def _vocab_embedding_ids(self) -> set[int]:
-        """ids of the `nn.Embedding`s in `self.model` which hold a vocab table."""
+    def _vocab_embeddings(self) -> set[nn.Embedding]:
+        """The `nn.Embedding`s in `self.model` which hold a vocab table."""
 
         def vocab_sizes(config: PretrainedConfig):
             for key, value in vars(config).items():
@@ -429,17 +429,17 @@ class Base(
         sizes = set(vocab_sizes(self.config))
         # `get_input_embeddings` may return a module which composes the `nn.Embedding`,
         # or a `PPMissingLayer` if the embeddings are not on this pipeline stage
-        ids = {
-            id(module)
+        embeddings = {
+            module
             for module in self.model.get_input_embeddings().modules()
             if isinstance(module, nn.Embedding)
         }
-        ids.update(
-            id(module)
+        embeddings.update(
+            module
             for module in self.model.modules()
             if isinstance(module, nn.Embedding) and module.num_embeddings in sizes
         )
-        return ids
+        return embeddings
 
     def recursive_replace(self):
         """Recursively replace modules in the model as needed.
@@ -473,7 +473,7 @@ class Base(
         # Detect fusable patterns once per module class (cached, so this is cheap)
         fusers = Fusers(self.model, self.vllm_config)
 
-        vocab_embedding_ids = self._vocab_embedding_ids()
+        vocab_embeddings = self._vocab_embeddings()
 
         def register_fusion(fuser: BaseFuser, prefix: str):
             """Register a fused layer's mappings just before it is built."""
@@ -524,7 +524,7 @@ class Base(
                     )
                 elif isinstance(child_module, (nn.Conv2d, nn.Conv3d)):
                     new_module = replace_conv_class(child_module)
-                elif id(child_module) in vocab_embedding_ids:
+                elif child_module in vocab_embeddings:
                     new_module = replace_embedding_class(
                         child_module, self.quant_config, prefix=qual_name
                     )


### PR DESCRIPTION
## Purpose

PR #54760 tracked vocabulary embeddings using only their Python object IDs. During recursive replacement, an embedding can be released and its object ID reused by a subsequently created module such as `QKVParallelLinear`. This causes the new module to be misclassified as an embedding and crashes while accessing `num_embeddings`.

## Reproducer

```bash
.venv/bin/python -m pytest \
  'tests/models/transformers/test_backend.py::test_pooling[v2-TransformersForSequenceClassification]' \
  -q
```

### Main output:

```text
AttributeError: 'QKVParallelLinear' object has no attribute 'num_embeddings'
FAILED tests/models/transformers/test_backend.py::test_pooling[v2-TransformersForSequenceClassification]
```

### Branch  Output:

The deterministic strong-reference probe reports:

```text
strong-reference lifetime probe: PASS
```

The focused existing replacement tests report:


```text
8 passed, 17 deselected, 14 warnings in 11.88s
```

Test Plan and Results:

```bash
VLLM_TARGET_DEVICE=cpu CUDA_VISIBLE_DEVICES='' \
.venv/bin/python -m pytest tests/models/transformers/test_backend.py \
  -k 'replace_plain_embedding or replace_infers_shape_and_dtype or replace_inherited_embedding or replace_is_idempotent or only_vocab_tables_are_replaced or per_layer_vocab_table_is_replaced or composed_input_embeddings_are_replaced or missing_input_embeddings_are_skipped' \
  -q
```

```text
8 passed, 17 deselected, 14 warnings in 11.88s
```

## AI assistance disclosure

OpenAI Codex (GPT-5) assisted with root-cause analysis and drafting the code.