### PR TITLE
[Frontend] Add per-request metrics to Responses API

### DIFF
--- a/docs/features/per_request_metrics.md
+++ b/docs/features/per_request_metrics.md
@@ -120,6 +120,16 @@ the same `metrics` response field. As with `n > 1`, metrics are omitted for
 requests with multiple prompts, because the timing data cannot be attributed to
 a single prompt's generation.
 
+## Responses API
+
+Per-request metrics are available on the `/v1/responses` endpoint using the
+common `metrics` object described above. Non-streaming responses include it at
+the top level. Streaming responses include it in the final response carried by
+the `response.completed` event; intermediate events do not include metrics.
+
+Metrics are omitted for Responses requests that perform multiple
+model-generation turns, such as built-in tool-call workflows.
+
 ## Relationship to Prometheus Metrics
 
 The `metrics` response field provides per-request values for a single request.

--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -4,10 +4,14 @@ from openai_harmony import (
     Message,
 )
 
+from vllm.entrypoints.generate.base.protocol import PerRequestMetrics
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
+    ResponsesResponse,
     serialize_message,
     serialize_messages,
 )
+from vllm.sampling_params import SamplingParams
 
 
 def test_serialize_message() -> None:
@@ -37,3 +41,44 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
+
+
+def test_response_serializes_per_request_metrics() -> None:
+    metrics = PerRequestMetrics(
+        time_to_first_token_ms=200.0,
+        generation_time_ms=1000.0,
+        queue_time_ms=100.0,
+        mean_itl_ms=250.0,
+        tokens_per_second=4.166666666666667,
+    )
+    response = ResponsesResponse.from_request(
+        request=ResponsesRequest(model="test-model", input="hello"),
+        sampling_params=SamplingParams(max_tokens=8),
+        model_name="test-model",
+        created_time=0,
+        output=[],
+        status="completed",
+        metrics=metrics,
+    )
+
+    assert response.model_dump(mode="json", by_alias=True)["metrics"] == {
+        "time_to_first_token_ms": 200.0,
+        "generation_time_ms": 1000.0,
+        "queue_time_ms": 100.0,
+        "mean_itl_ms": 250.0,
+        "tokens_per_second": 4.166666666666667,
+        "speculative_decoding": None,
+    }
+
+
+def test_response_omits_absent_per_request_metrics() -> None:
+    response = ResponsesResponse.from_request(
+        request=ResponsesRequest(model="test-model", input="hello"),
+        sampling_params=SamplingParams(max_tokens=8),
+        model_name="test-model",
+        created_time=0,
+        output=[],
+        status="completed",
+    )
+
+    assert "metrics" not in response.model_dump(mode="json", by_alias=True)

--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -4,14 +4,10 @@ from openai_harmony import (
     Message,
 )
 
-from vllm.entrypoints.generate.base.protocol import PerRequestMetrics
 from vllm.entrypoints.openai.responses.protocol import (
-    ResponsesRequest,
-    ResponsesResponse,
     serialize_message,
     serialize_messages,
 )
-from vllm.sampling_params import SamplingParams
 
 
 def test_serialize_message() -> None:
@@ -41,44 +37,3 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
-
-
-def test_response_serializes_per_request_metrics() -> None:
-    metrics = PerRequestMetrics(
-        time_to_first_token_ms=200.0,
-        generation_time_ms=1000.0,
-        queue_time_ms=100.0,
-        mean_itl_ms=250.0,
-        tokens_per_second=4.166666666666667,
-    )
-    response = ResponsesResponse.from_request(
-        request=ResponsesRequest(model="test-model", input="hello"),
-        sampling_params=SamplingParams(max_tokens=8),
-        model_name="test-model",
-        created_time=0,
-        output=[],
-        status="completed",
-        metrics=metrics,
-    )
-
-    assert response.model_dump(mode="json", by_alias=True)["metrics"] == {
-        "time_to_first_token_ms": 200.0,
-        "generation_time_ms": 1000.0,
-        "queue_time_ms": 100.0,
-        "mean_itl_ms": 250.0,
-        "tokens_per_second": 4.166666666666667,
-        "speculative_decoding": None,
-    }
-
-
-def test_response_omits_absent_per_request_metrics() -> None:
-    response = ResponsesResponse.from_request(
-        request=ResponsesRequest(model="test-model", input="hello"),
-        sampling_params=SamplingParams(max_tokens=8),
-        model_name="test-model",
-        created_time=0,
-        output=[],
-        status="completed",
-    )
-
-    assert "metrics" not in response.model_dump(mode="json", by_alias=True)

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1167,7 +1167,6 @@ _PER_REQUEST_STATS = RequestStateStats(
     scheduled_ts=1.5,
     first_token_ts=2.0,
     last_token_ts=3.0,
-    num_generation_tokens=2,
 )
 
 
@@ -1195,7 +1194,6 @@ def _make_simple_context_with_output(
         prompt_logprobs=None,
         outputs=[completion],
         finished=False,
-        metrics=metrics,
         num_cached_tokens=0,
     )
     ctx.append_output(req_output)
@@ -1237,13 +1235,14 @@ async def _empty_context_generator():
 
 async def _make_full_metrics_response(
     enable_per_request_metrics: bool,
-    metrics: RequestStateStats | None = _PER_REQUEST_STATS,
 ):
     serving = _make_serving_instance(
         enable_per_request_metrics=enable_per_request_metrics
     )
     request = ResponsesRequest(input="hi", tools=[], stream=False, store=False)
-    context = _make_simple_context_with_output("hello", [10, 20], metrics=metrics)
+    context = _make_simple_context_with_output(
+        "hello", [10, 20], metrics=_PER_REQUEST_STATS
+    )
     response = await serving.responses_full_generator(
         request=request,
         sampling_params=SamplingParams(max_tokens=16),
@@ -1266,22 +1265,6 @@ async def test_responses_per_request_metrics_follow_server_flag():
     enabled_response = await _make_full_metrics_response(True)
     assert enabled_response.metrics is not None
     assert enabled_response.metrics.time_to_first_token_ms == pytest.approx(500.0)
-    assert enabled_response.metrics.generation_time_ms == pytest.approx(1000.0)
-    assert enabled_response.metrics.queue_time_ms == pytest.approx(500.0)
-    assert enabled_response.metrics.mean_itl_ms == pytest.approx(1000.0)
-    assert enabled_response.metrics.tokens_per_second == pytest.approx(4.0 / 3.0)
-
-
-@pytest.mark.asyncio
-async def test_responses_per_request_metrics_without_engine_stats():
-    response = await _make_full_metrics_response(True, metrics=None)
-
-    assert response.metrics is not None
-    assert response.metrics.time_to_first_token_ms is None
-    assert response.metrics.generation_time_ms is None
-    assert response.metrics.queue_time_ms is None
-    assert response.metrics.mean_itl_ms is None
-    assert response.metrics.tokens_per_second is None
 
 
 @pytest.mark.asyncio
@@ -1305,8 +1288,8 @@ async def test_responses_streaming_metrics_only_on_completed_event():
         )
     ]
 
-    assert "metrics" not in events[0].response.model_dump(mode="json")
-    assert "metrics" not in events[1].response.model_dump(mode="json")
+    for event in events[:-1]:
+        assert "metrics" not in event.response.model_dump(mode="json")
     assert isinstance(events[-1], ResponseCompletedEvent)
     assert events[-1].response.metrics is not None
     assert events[-1].response.metrics.time_to_first_token_ms == pytest.approx(500.0)

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -44,6 +44,7 @@ from vllm.entrypoints.openai.responses.context import (
     SimpleContext,
 )
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponseCompletedEvent,
     ResponseCreatedEvent,
     ResponseRawMessageAndToken,
     ResponsesRequest,
@@ -67,6 +68,7 @@ from vllm.renderers.online_renderer import (
     _extract_allowed_tools_from_mcp_requests,
 )
 from vllm.sampling_params import SamplingParams
+from vllm.v1.metrics.stats import RequestStateStats
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -1160,7 +1162,21 @@ class TestHarmonyPreambleStreaming:
             assert "response.output_item.done" in type_names
 
 
-def _make_simple_context_with_output(text, token_ids, response_parser=None):
+_PER_REQUEST_STATS = RequestStateStats(
+    queued_ts=1.0,
+    scheduled_ts=1.5,
+    first_token_ts=2.0,
+    last_token_ts=3.0,
+    num_generation_tokens=2,
+)
+
+
+def _make_simple_context_with_output(
+    text,
+    token_ids,
+    response_parser=None,
+    metrics: RequestStateStats | None = None,
+):
     """Create a SimpleContext with a RequestOutput containing the given text."""
     ctx = SimpleContext(response_parser=response_parser)
     completion = CompletionOutput(
@@ -1179,14 +1195,19 @@ def _make_simple_context_with_output(text, token_ids, response_parser=None):
         prompt_logprobs=None,
         outputs=[completion],
         finished=False,
+        metrics=metrics,
         num_cached_tokens=0,
     )
     ctx.append_output(req_output)
+    ctx.request_metrics = metrics
     return ctx
 
 
-def _make_serving_instance_with_reasoning():
-    """Create an OpenAIServingResponses with a mocked reasoning parser."""
+def _make_serving_instance(
+    *,
+    reasoning_parser: str = "",
+    enable_per_request_metrics: bool = False,
+) -> OpenAIServingResponses:
     engine_client = MagicMock()
     model_config = MagicMock()
     model_config.max_model_len = 100
@@ -1197,18 +1218,140 @@ def _make_serving_instance_with_reasoning():
     engine_client.input_processor = MagicMock()
     engine_client.renderer = MagicMock()
 
-    models = MagicMock()
-
-    serving = OpenAIServingResponses(
+    return OpenAIServingResponses(
         engine_client=engine_client,
-        models=models,
+        models=MagicMock(),
         online_renderer=MagicMock(),
         request_logger=None,
         chat_template=None,
         chat_template_content_format="auto",
-        reasoning_parser="qwen3",
+        reasoning_parser=reasoning_parser,
+        enable_per_request_metrics=enable_per_request_metrics,
     )
-    return serving
+
+
+async def _empty_context_generator():
+    if False:
+        yield
+
+
+async def _make_full_metrics_response(
+    enable_per_request_metrics: bool,
+    metrics: RequestStateStats | None = _PER_REQUEST_STATS,
+):
+    serving = _make_serving_instance(
+        enable_per_request_metrics=enable_per_request_metrics
+    )
+    request = ResponsesRequest(input="hi", tools=[], stream=False, store=False)
+    context = _make_simple_context_with_output("hello", [10, 20], metrics=metrics)
+    response = await serving.responses_full_generator(
+        request=request,
+        sampling_params=SamplingParams(max_tokens=16),
+        result_generator=_empty_context_generator(),
+        context=context,
+        model_name="test-model",
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="req"),
+    )
+    assert isinstance(response, ResponsesResponse)
+    return response
+
+
+@pytest.mark.asyncio
+async def test_responses_per_request_metrics_follow_server_flag():
+    disabled_response = await _make_full_metrics_response(False)
+    assert disabled_response.metrics is None
+    assert "metrics" not in disabled_response.model_dump(mode="json")
+
+    enabled_response = await _make_full_metrics_response(True)
+    assert enabled_response.metrics is not None
+    assert enabled_response.metrics.time_to_first_token_ms == pytest.approx(500.0)
+    assert enabled_response.metrics.generation_time_ms == pytest.approx(1000.0)
+    assert enabled_response.metrics.queue_time_ms == pytest.approx(500.0)
+    assert enabled_response.metrics.mean_itl_ms == pytest.approx(1000.0)
+    assert enabled_response.metrics.tokens_per_second == pytest.approx(4.0 / 3.0)
+
+
+@pytest.mark.asyncio
+async def test_responses_per_request_metrics_without_engine_stats():
+    response = await _make_full_metrics_response(True, metrics=None)
+
+    assert response.metrics is not None
+    assert response.metrics.time_to_first_token_ms is None
+    assert response.metrics.generation_time_ms is None
+    assert response.metrics.queue_time_ms is None
+    assert response.metrics.mean_itl_ms is None
+    assert response.metrics.tokens_per_second is None
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_metrics_only_on_completed_event():
+    serving = _make_serving_instance(enable_per_request_metrics=True)
+    request = ResponsesRequest(input="hi", tools=[], stream=True, store=False)
+    context = _make_simple_context_with_output(
+        "hello", [10, 20], metrics=_PER_REQUEST_STATS
+    )
+
+    events = [
+        event
+        async for event in serving.responses_stream_generator(
+            request=request,
+            sampling_params=SamplingParams(max_tokens=16),
+            result_generator=_empty_context_generator(),
+            context=context,
+            model_name="test-model",
+            tokenizer=MagicMock(),
+            request_metadata=RequestResponseMetadata(request_id="req"),
+        )
+    ]
+
+    assert "metrics" not in events[0].response.model_dump(mode="json")
+    assert "metrics" not in events[1].response.model_dump(mode="json")
+    assert isinstance(events[-1], ResponseCompletedEvent)
+    assert events[-1].response.metrics is not None
+    assert events[-1].response.metrics.time_to_first_token_ms == pytest.approx(500.0)
+
+
+@pytest.mark.asyncio
+async def test_responses_metrics_suppressed_for_multiple_generation_streams(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    serving = _make_serving_instance(enable_per_request_metrics=True)
+    context = MockConversationContext()
+    monkeypatch.setattr(
+        context, "need_builtin_tool_call", MagicMock(side_effect=[True, False])
+    )
+
+    async def generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="req",
+            prompt=None,
+            prompt_token_ids=[],
+            prompt_logprobs=None,
+            outputs=[],
+            finished=True,
+            metrics=_PER_REQUEST_STATS,
+        )
+
+    monkeypatch.setattr(serving.engine_client, "generate", generate)
+
+    results = [
+        result
+        async for result in serving._generate_with_builtin_tools(
+            request_id="req",
+            engine_input=tokens_input([1]),
+            sampling_params=SamplingParams(max_tokens=8),
+            context=context,
+        )
+    ]
+
+    assert len(results) == 2
+    assert context.request_metrics_attributable is False
+
+
+def _make_serving_instance_with_reasoning():
+    """Create an OpenAIServingResponses with a mocked reasoning parser."""
+    return _make_serving_instance(reasoning_parser="qwen3")
 
 
 def _identity_increment(event):

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -712,6 +712,7 @@ class TestInitializeToolSessions:
             pass
 
         assert serving_responses_instance.engine_client.generate.call_count == 2
+        assert context.request_metrics_cover_all_generation_turns is False
         followup_engine_input = (
             serving_responses_instance.engine_client.generate.call_args_list[1].args[0]
         )

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1235,6 +1235,7 @@ async def _empty_context_generator():
 
 async def _make_full_metrics_response(
     enable_per_request_metrics: bool,
+    request_metrics_cover_all_generation_turns: bool = True,
 ):
     serving = _make_serving_instance(
         enable_per_request_metrics=enable_per_request_metrics
@@ -1242,6 +1243,9 @@ async def _make_full_metrics_response(
     request = ResponsesRequest(input="hi", tools=[], stream=False, store=False)
     context = _make_simple_context_with_output(
         "hello", [10, 20], metrics=_PER_REQUEST_STATS
+    )
+    context.request_metrics_cover_all_generation_turns = (
+        request_metrics_cover_all_generation_turns
     )
     response = await serving.responses_full_generator(
         request=request,
@@ -1296,40 +1300,13 @@ async def test_responses_streaming_metrics_only_on_completed_event():
 
 
 @pytest.mark.asyncio
-async def test_responses_metrics_suppressed_for_multiple_generation_streams(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    serving = _make_serving_instance(enable_per_request_metrics=True)
-    context = MockConversationContext()
-    monkeypatch.setattr(
-        context, "need_builtin_tool_call", MagicMock(side_effect=[True, False])
+async def test_responses_metrics_suppressed_for_multiple_generation_turns():
+    response = await _make_full_metrics_response(
+        True, request_metrics_cover_all_generation_turns=False
     )
 
-    async def generate(*args, **kwargs):
-        yield RequestOutput(
-            request_id="req",
-            prompt=None,
-            prompt_token_ids=[],
-            prompt_logprobs=None,
-            outputs=[],
-            finished=True,
-            metrics=_PER_REQUEST_STATS,
-        )
-
-    monkeypatch.setattr(serving.engine_client, "generate", generate)
-
-    results = [
-        result
-        async for result in serving._generate_with_builtin_tools(
-            request_id="req",
-            engine_input=tokens_input([1]),
-            sampling_params=SamplingParams(max_tokens=8),
-            context=context,
-        )
-    ]
-
-    assert len(results) == 2
-    assert context.request_metrics_attributable is False
+    assert response.metrics is None
+    assert "metrics" not in response.model_dump(mode="json")
 
 
 def _make_serving_instance_with_reasoning():

--- a/vllm/entrypoints/generate/api_router.py
+++ b/vllm/entrypoints/generate/api_router.py
@@ -116,6 +116,7 @@ async def init_generate_state(
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
+            enable_per_request_metrics=args.enable_per_request_metrics,
             enable_log_outputs=args.enable_log_outputs,
             default_chat_template_kwargs=default_chat_template_kwargs,
         )

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -45,6 +45,8 @@ from vllm.utils import random_uuid
 if TYPE_CHECKING:
     from mcp.client import ClientSession
 
+    from vllm.v1.metrics.stats import RequestStateStats
+
 logger = logging.getLogger(__name__)
 
 # This is currently needed as the tool type doesn't 1:1 match the
@@ -102,6 +104,8 @@ class TurnMetrics:
 
 class ConversationContext(ABC):
     response_parser: Parser | None = None
+    request_metrics: "RequestStateStats | None" = None
+    request_metrics_attributable: bool = True
 
     @abstractmethod
     def append_output(self, output: RequestOutput) -> None:

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -105,7 +105,10 @@ class TurnMetrics:
 class ConversationContext(ABC):
     response_parser: Parser | None = None
     request_metrics: "RequestStateStats | None" = None
-    request_metrics_attributable: bool = True
+    # Built-in tools can trigger additional model generations. In that case,
+    # the stored engine timestamps cover only one turn, while token usage is
+    # accumulated across all turns.
+    request_metrics_cover_all_generation_turns: bool = True
 
     @abstractmethod
     def append_output(self, output: RequestOutput) -> None:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -60,7 +60,11 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
 )
-from vllm.entrypoints.generate.base.protocol import StopParam, validate_cache_salt
+from vllm.entrypoints.generate.base.protocol import (
+    PerRequestMetrics,
+    StopParam,
+    validate_cache_salt,
+)
 from vllm.entrypoints.serve.engine.protocol import OpenAIBaseModel
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
@@ -687,6 +691,11 @@ class ResponsesResponse(OpenAIBaseModel):
     usage: ResponseUsage | None = None
     user: str | None = None
 
+    # vLLM-specific per-request metrics. Omitted unless enabled server-side.
+    metrics: PerRequestMetrics | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+
     presence_penalty: float | None = Field(
         default=None,
         ge=-2.0,
@@ -755,6 +764,7 @@ class ResponsesResponse(OpenAIBaseModel):
         output: list[ResponseOutputItem],
         status: ResponseStatus,
         usage: ResponseUsage | None = None,
+        metrics: PerRequestMetrics | None = None,
         input_messages: ResponseInputOutputMessage | None = None,
         output_messages: ResponseInputOutputMessage | None = None,
         kv_transfer_params: dict[str, Any] | None = None,
@@ -798,6 +808,7 @@ class ResponsesResponse(OpenAIBaseModel):
             truncation=request.truncation,
             user=request.user,
             usage=usage,
+            metrics=metrics,
             kv_transfer_params=kv_transfer_params,
             ec_transfer_params=ec_transfer_params,
         )

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -660,7 +660,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 break
 
             # Call the tool and update the context with the result.
-            context.request_metrics_attributable = False
+            context.request_metrics_cover_all_generation_turns = False
             tool_output = await context.call_tool()
             context.append_tool_output(tool_output)
 
@@ -864,7 +864,10 @@ class OpenAIServingResponses(GenerateBaseServing):
             ),
         )
         per_request_metrics = None
-        if self.enable_per_request_metrics and context.request_metrics_attributable:
+        if (
+            self.enable_per_request_metrics
+            and context.request_metrics_cover_all_generation_turns
+        ):
             per_request_metrics = build_per_request_timing_metrics(
                 context.request_metrics, num_generated_tokens
             )

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -30,7 +30,10 @@ from vllm.entrypoints.generate.base.protocol import (
     DeltaMessage,
     RequestResponseMetadata,
 )
-from vllm.entrypoints.generate.base.serving import GenerateBaseServing
+from vllm.entrypoints.generate.base.serving import (
+    GenerateBaseServing,
+    build_per_request_timing_metrics,
+)
 from vllm.entrypoints.mcp.tool_server import ToolServer
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.responses.context import (
@@ -109,6 +112,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         tool_server: ToolServer | None = None,
         enable_prompt_tokens_details: bool = False,
         enable_force_include_usage: bool = False,
+        enable_per_request_metrics: bool = False,
         enable_log_outputs: bool = False,
         default_chat_template_kwargs: dict[str, Any] | None = None,
     ) -> None:
@@ -136,6 +140,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         )
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
+        self.enable_per_request_metrics = enable_per_request_metrics
 
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config
@@ -645,6 +650,7 @@ class OpenAIServingResponses(GenerateBaseServing):
             )
 
             async for res in generator:
+                context.request_metrics = res.metrics
                 context.append_output(res)
                 # NOTE(woosuk): The stop condition is handled by the engine.
                 yield context
@@ -654,6 +660,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 break
 
             # Call the tool and update the context with the result.
+            context.request_metrics_attributable = False
             tool_output = await context.call_tool()
             context.append_tool_output(tool_output)
 
@@ -856,6 +863,11 @@ class OpenAIServingResponses(GenerateBaseServing):
                 ],
             ),
         )
+        per_request_metrics = None
+        if self.enable_per_request_metrics and context.request_metrics_attributable:
+            per_request_metrics = build_per_request_timing_metrics(
+                context.request_metrics, num_generated_tokens
+            )
         response = ResponsesResponse.from_request(
             request,
             sampling_params,
@@ -866,6 +878,7 @@ class OpenAIServingResponses(GenerateBaseServing):
             output=output,
             status=status,
             usage=usage,
+            metrics=per_request_metrics,
             kv_transfer_params=context.kv_transfer_params,
             ec_transfer_params=context.ec_transfer_params,
         )


### PR DESCRIPTION
## Purpose

Closes #54828.

Extend the existing response-body per-request timing metrics to `/v1/responses`.

- Reuse `PerRequestMetrics` and `build_per_request_timing_metrics`.
- Include metrics in non-streaming responses when `--enable-per-request-metrics` is set.
- Include metrics only in the terminal `response.completed` event for streaming responses.
- Omit the field when metrics are disabled to preserve the existing response shape.
- Suppress metrics for built-in-tool flows with multiple model-generation streams because their independent engine timestamps cannot be accurately represented as one timing object.
- Document the Responses API behavior.

This does not duplicate an existing PR. I searched open PRs for #54828 and for Responses API per-request metrics. #46768 added this support only to Chat Completions and Completions; #54829 separately tracks reasoning/content phase metrics.

AI assistance was used to help draft the implementation, tests, and documentation. I reviewed every changed line and understand and can defend the change end-to-end.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/responses/test_protocol.py \
  tests/entrypoints/openai/responses/test_serving_responses.py -q

PRE_COMMIT_HOME=/tmp/vllm-pre-commit \
  .venv/bin/pre-commit run --from-ref origin/main --to-ref HEAD
```

A100 end-to-end validation used `HuggingFaceTB/SmolLM2-135M-Instruct` against a locally served `/v1/responses` endpoint.

Model evaluation was not run because this changes only API response serialization and does not affect model execution, generated output, or accuracy.

## Test Results

- Responses protocol and serving tests: 40 passed, 1 pre-existing expected xfail.
- All configured pre-commit hooks passed, including Ruff, markdownlint, mypy, forbidden-import checks, and configuration validation.
- A100 non-streaming E2E: populated metrics were returned in the completed response.
- A100 streaming E2E: intermediate events omitted metrics and `response.completed` included populated metrics.
- A100 compatibility E2E with the feature disabled: the metrics field was omitted.
