### PR TITLE
[Bugfix][MooncakeStore] Zero the unwritten tail pages of async-loaded blocks

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -4503,28 +4503,33 @@ def test_blob_block_hashes_empty():
     assert list(view) == []
 
 
-def test_zero_unloaded_tails_zeroes_only_never_written_pages():
+def test_zero_unloaded_tails_zeroes_only_never_written_slots():
     """An async Store load fills ``token_len`` tokens of its last logical block;
-    the scheduler skips zeroing for the whole block, so the kernel pages after
-    the loaded prefix keep their previous owner's bytes. Once the load lands the
-    worker must zero exactly those pages in every attention layer and leave the
-    loaded pages, other blocks and Mamba groups untouched."""
+    the scheduler skips zeroing for the whole block, so everything after the
+    loaded prefix keeps its previous owner's bytes. Once the load lands the
+    worker must zero exactly that remainder in every attention layer -- the
+    untouched kernel pages and the stale slots of the partially written page
+    (hits need not be page aligned: ``prefix_match_unit`` only has to divide the
+    block) -- and leave loaded slots, other blocks and Mamba groups alone."""
     from vllm.v1.kv_cache_interface import MambaSpec
 
     w = worker.MooncakeStoreWorker.__new__(worker.MooncakeStoreWorker)
     w.num_blocks = 4
     pages_per_block = 8  # 512-token logical blocks, 64-token kernel pages
     attn = FullAttentionSpec(
-        block_size=512, num_kv_heads=1, head_size=8, dtype=torch.bfloat16
+        block_size=512, num_kv_heads=2, head_size=8, dtype=torch.bfloat16
     )
     mamba = MambaSpec(block_size=512, shapes=((4,),), dtypes=(torch.float32,))
     w._kv_cache_groups = [
         SimpleNamespace(kv_cache_spec=mamba, layer_names=["m0"]),
         SimpleNamespace(kv_cache_spec=attn, layer_names=["a0", "a1"]),
     ]
+    # Standardized [B, H, N, C] view and a raw MLA-style [B, N, C] view.
     raw = [
-        torch.full((w.num_blocks * pages_per_block, 64, 8), 7.0, dtype=torch.bfloat16)
-        for _ in range(2)
+        torch.full(
+            (w.num_blocks * pages_per_block, 2, 64, 8), 7.0, dtype=torch.bfloat16
+        ),
+        torch.full((w.num_blocks * pages_per_block, 64, 8), 7.0, dtype=torch.bfloat16),
     ]
     mamba_cache = torch.full((w.num_blocks, 4), 7.0)
     w._load_tail_caches = {}
@@ -4534,7 +4539,8 @@ def test_zero_unloaded_tails_zeroes_only_never_written_pages():
     w._track_load_tail_cache("m0", mamba_cache, groups)
     assert set(w._load_tail_caches) == {1}
     w._pending_load_tails = {
-        # 200 tokens into block 2: pages 0..3 hold data, pages 4..7 are stale.
+        # 200 tokens into block 2: pages 0..2 full, page 3 holds 8 valid slots,
+        # pages 4..7 untouched.
         "partial": (([1], [2]), 200),
         # One full block plus 64 tokens: block 3 full, block 0 keeps page 0 only.
         "spans": (([1], [3, 0]), 512 + 64),
@@ -4548,7 +4554,10 @@ def test_zero_unloaded_tails_zeroes_only_never_written_pages():
 
     for cache in raw:
         g = cache.unflatten(0, (w.num_blocks, pages_per_block))
-        assert (g[2, :4] == 7).all() and (g[2, 4:] == 0).all()
+        assert (g[2, :3] == 7).all()
+        assert (g[2, 3].narrow(-2, 0, 8) == 7).all()
+        assert (g[2, 3].narrow(-2, 8, 56) == 0).all()
+        assert (g[2, 4:] == 0).all()
         assert (g[0, :1] == 7).all() and (g[0, 1:] == 0).all()
         assert (g[3] == 7).all() and (g[1] == 7).all()
     assert (mamba_cache == 7).all()

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -3283,6 +3283,8 @@ def _make_bare_worker(
     worker.tp_rank = 0
     worker.enable_kv_events = False
     worker.load_async = True
+    worker._pending_load_tails = {}
+    worker._load_tail_caches = {}
     worker.kv_send_thread = None
     worker.kv_recv_threads = []
     worker.num_recv_threads = 1
@@ -4499,3 +4501,55 @@ def test_blob_block_hashes_empty():
     view = BlobBlockHashes(memoryview(b""), 0)
     assert len(view) == 0
     assert list(view) == []
+
+
+def test_zero_unloaded_tails_zeroes_only_never_written_pages():
+    """An async Store load fills ``token_len`` tokens of its last logical block;
+    the scheduler skips zeroing for the whole block, so the kernel pages after
+    the loaded prefix keep their previous owner's bytes. Once the load lands the
+    worker must zero exactly those pages in every attention layer and leave the
+    loaded pages, other blocks and Mamba groups untouched."""
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    w = worker.MooncakeStoreWorker.__new__(worker.MooncakeStoreWorker)
+    w.num_blocks = 4
+    pages_per_block = 8  # 512-token logical blocks, 64-token kernel pages
+    attn = FullAttentionSpec(
+        block_size=512, num_kv_heads=1, head_size=8, dtype=torch.bfloat16
+    )
+    mamba = MambaSpec(block_size=512, shapes=((4,),), dtypes=(torch.float32,))
+    w._kv_cache_groups = [
+        SimpleNamespace(kv_cache_spec=mamba, layer_names=["m0"]),
+        SimpleNamespace(kv_cache_spec=attn, layer_names=["a0", "a1"]),
+    ]
+    raw = [
+        torch.full((w.num_blocks * pages_per_block, 64, 8), 7.0, dtype=torch.bfloat16)
+        for _ in range(2)
+    ]
+    mamba_cache = torch.full((w.num_blocks, 4), 7.0)
+    w._load_tail_caches = {}
+    groups = {"a0": 1, "a1": 1}
+    for name, cache in zip(["a0", "a1"], raw):
+        w._track_load_tail_cache(name, cache, groups)
+    w._track_load_tail_cache("m0", mamba_cache, groups)
+    assert set(w._load_tail_caches) == {1}
+    w._pending_load_tails = {
+        # 200 tokens into block 2: pages 0..3 hold data, pages 4..7 are stale.
+        "partial": (([1], [2]), 200),
+        # One full block plus 64 tokens: block 3 full, block 0 keeps page 0 only.
+        "spans": (([1], [3, 0]), 512 + 64),
+        # Aborted before its load landed: dropped without touching memory.
+        "aborted": (([1], [1]), 100),
+    }
+
+    w._zero_unloaded_tails(
+        done_recving={"partial", "spans"}, finished_req_ids={"aborted"}
+    )
+
+    for cache in raw:
+        g = cache.unflatten(0, (w.num_blocks, pages_per_block))
+        assert (g[2, :4] == 7).all() and (g[2, 4:] == 0).all()
+        assert (g[0, :1] == 7).all() and (g[0, 1:] == 0).all()
+        assert (g[3] == 7).all() and (g[1] == 7).all()
+    assert (mamba_cache == 7).all()
+    assert w._pending_load_tails == {}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -75,6 +75,7 @@ from vllm.v1.core.kv_cache_utils import (
     resolve_kv_cache_block_sizes,
 )
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
@@ -1525,6 +1526,10 @@ class MooncakeStoreWorker:
             extra_config.get("save_decode_cache", False)
         )
         self.load_async = extra_config.get("load_async", True)
+        # An async load may fill only part of its last logical block; the kernel
+        # pages it never writes are zeroed once it lands (_zero_unloaded_tails).
+        self._pending_load_tails: dict[str, tuple[tuple[list[int], ...], int]] = {}
+        self._load_tail_caches: dict[int, tuple[int, list[torch.Tensor]]] = {}
         # Mirrors MooncakeStoreConnector._capacity_only.
         self._capacity_only = (
             self.kv_role == "kv_consumer"
@@ -1891,8 +1896,16 @@ class MooncakeStoreWorker:
 
         seen_storage_ptrs: set[int] = set()
         cache_tensors: list[torch.Tensor] = []
+        attention_group_of_layer = {
+            layer_name: g_idx
+            for g_idx, group in enumerate(self._kv_cache_groups)
+            if isinstance(group.kv_cache_spec, AttentionSpec)
+            for layer_name in group.layer_names
+        }
+        self._load_tail_caches = {}
 
-        for cache in kv_caches.values():
+        for layer_name, cache in kv_caches.items():
+            self._track_load_tail_cache(layer_name, cache, attention_group_of_layer)
             cache = group_kernel_blocks(cache, self.num_blocks)
             cache_tensors.append(cache)
             cache_storage = cache.untyped_storage()
@@ -1981,6 +1994,10 @@ class MooncakeStoreWorker:
                 continue
 
             load_spec.token_len = load_spec.kvpool_cached_tokens
+            self._pending_load_tails[request.req_id] = (
+                request.block_ids,
+                load_spec.token_len,
+            )
             self.recv_request_queue.put(request)
 
         assert self.load_async, "load_async must be True for better performance."
@@ -2028,6 +2045,7 @@ class MooncakeStoreWorker:
         if self.load_async:
             for recv_thread in self.kv_recv_threads:
                 done_recving |= recv_thread.get_and_clear_finished_requests()
+        self._zero_unloaded_tails(done_recving, finished_req_ids)
 
         logger.debug(
             "Completed send: %d, recv: %d, tp_rank: %d",
@@ -2036,6 +2054,66 @@ class MooncakeStoreWorker:
             self.tp_rank,
         )
         return done_sending, done_recving
+
+    def _track_load_tail_cache(
+        self,
+        layer_name: str,
+        cache: torch.Tensor,
+        attention_group_of_layer: dict[str, int],
+    ) -> None:
+        """Keep a ``[num_blocks, pages_per_block, ...]`` view of an attention
+        layer cache whose logical block spans several kernel pages."""
+        g_idx = attention_group_of_layer.get(layer_name)
+        if g_idx is None or cache.shape[0] % self.num_blocks != 0:
+            return
+        pages_per_block = cache.shape[0] // self.num_blocks
+        if pages_per_block <= 1:
+            # Block == kernel page: loads are block granular, nothing to zero.
+            return
+        ratio, caches = self._load_tail_caches.setdefault(g_idx, (pages_per_block, []))
+        assert ratio == pages_per_block, (
+            f"group {g_idx}: inconsistent kernel pages per block "
+            f"({ratio} vs {pages_per_block} for {layer_name})"
+        )
+        caches.append(cache.unflatten(0, (self.num_blocks, pages_per_block)))
+
+    def _zero_unloaded_tails(
+        self, done_recving: set[str], finished_req_ids: set[str]
+    ) -> None:
+        """Zero the kernel pages an async load left unwritten.
+
+        The scheduler skips its zeroing of every block an async load will
+        write (the zeroing could race the transfer), but a Store hit only
+        fills ``token_len`` tokens of its last logical block. The remaining
+        kernel pages keep their previous owner's bytes; with overlaid hybrid
+        cache groups those can be another group's state (e.g. fp32 Mamba
+        state read back as bf16 latents -> NaN/Inf), and attention decode
+        kernels read the whole page holding the current position. Runs on
+        the caller's stream after the load completed, so it races neither
+        the transfer nor the next forward. A page the load partially wrote
+        (``token_len`` not page aligned) is left untouched.
+        """
+        for req_id in finished_req_ids:
+            self._pending_load_tails.pop(req_id, None)
+        for req_id in done_recving:
+            entry = self._pending_load_tails.pop(req_id, None)
+            if entry is None or not self._load_tail_caches:
+                continue
+            block_ids, token_len = entry
+            if token_len <= 0:
+                continue
+            for g_idx, (pages_per_block, caches) in self._load_tail_caches.items():
+                block_size = self._kv_cache_groups[g_idx].kv_cache_spec.block_size
+                last_block = (token_len - 1) // block_size
+                if g_idx >= len(block_ids) or last_block >= len(block_ids[g_idx]):
+                    continue
+                tokens_in_last = token_len - last_block * block_size
+                first_unwritten = cdiv(tokens_in_last, block_size // pages_per_block)
+                if first_unwritten >= pages_per_block:
+                    continue
+                block_id = block_ids[g_idx][last_block]
+                for cache in caches:
+                    cache[block_id, first_unwritten:].zero_()
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         block_ids: set[int] = set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -2070,6 +2070,13 @@ class MooncakeStoreWorker:
         if pages_per_block <= 1:
             # Block == kernel page: loads are block granular, nothing to zero.
             return
+        block_size = self._kv_cache_groups[g_idx].kv_cache_spec.block_size
+        # Runner views are standardized [B, H, N, C] (or [B, N, C] for a raw
+        # MLA latent cache): the token axis is second to last either way.
+        assert cache.ndim >= 3 and cache.shape[-2] == block_size // pages_per_block, (
+            f"{layer_name}: cache shape {tuple(cache.shape)} does not expose "
+            f"{block_size // pages_per_block} tokens per kernel page"
+        )
         ratio, caches = self._load_tail_caches.setdefault(g_idx, (pages_per_block, []))
         assert ratio == pages_per_block, (
             f"group {g_idx}: inconsistent kernel pages per block "
@@ -2090,8 +2097,9 @@ class MooncakeStoreWorker:
         state read back as bf16 latents -> NaN/Inf), and attention decode
         kernels read the whole page holding the current position. Runs on
         the caller's stream after the load completed, so it races neither
-        the transfer nor the next forward. A page the load partially wrote
-        (``token_len`` not page aligned) is left untouched.
+        the transfer nor the next forward. Within the page holding the last
+        loaded token, only the slots after it are zeroed, along the token axis
+        of the standardized ``[B, H, N, C]`` view (layout agnostic).
         """
         for req_id in finished_req_ids:
             self._pending_load_tails.pop(req_id, None)
@@ -2108,12 +2116,17 @@ class MooncakeStoreWorker:
                 if g_idx >= len(block_ids) or last_block >= len(block_ids[g_idx]):
                     continue
                 tokens_in_last = token_len - last_block * block_size
-                first_unwritten = cdiv(tokens_in_last, block_size // pages_per_block)
-                if first_unwritten >= pages_per_block:
-                    continue
+                page_tokens = block_size // pages_per_block
+                last_page, valid_in_page = divmod(tokens_in_last - 1, page_tokens)
+                valid_in_page += 1
                 block_id = block_ids[g_idx][last_block]
                 for cache in caches:
-                    cache[block_id, first_unwritten:].zero_()
+                    if last_page + 1 < pages_per_block:
+                        cache[block_id, last_page + 1 :].zero_()
+                    if valid_in_page < page_tokens:
+                        cache[block_id, last_page].narrow(
+                            -2, valid_in_page, page_tokens - valid_in_page
+                        ).zero_()
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         block_ids: set[int] = set()


### PR DESCRIPTION
## Purpose

Fix silent accuracy corruption (NaN -> degenerate `@ @ @ ...` outputs) for requests whose prefix is partially restored from the Mooncake Store on a hybrid (Mamba + attention) model with kernel-block splitting.

**Root cause.** `Scheduler._skip_zero_block_ids` exempts every block an async KV load will write from the worker-side zeroing (`needs_kv_cache_zeroing`), because zeroing could race the transfer. A Mooncake Store hit, however, only fills the hit length (a multiple of `prefix_match_unit`) of its last logical block; the remaining kernel pages of that block keep their previous owner's bytes. On hybrid models all cache groups overlay one block pool, so a block that last held a Mamba group's fp32 recurrent state is read back as bf16 attention latents, which decode to NaN/Inf with ~1/256 density. The prefill path never reads past the written tokens, but attention decode kernels (trtllm-gen MLA here) read the whole kernel page holding the current position, so the request's **first decode step** produces NaN in the first attention layer; the NaN then propagates into every later Mamba state and cache slot of that request.

**Fix.** `MooncakeStoreWorker` remembers the block ids and loaded token count of each async load and, in `get_finished()` (runner main thread, compute stream, after the load has landed), zeroes the never-written kernel pages of the last loaded logical block for every attention group. This races neither the transfer nor the next forward, leaves Mamba groups alone (their state is initialized by the kernels), and costs one small `zero_()` per attention layer per completed load. Within the page holding the last loaded token, the slots after it are zeroed along the token axis of the standardized `[B, H, N, C]` view (second to last dim, also for a raw `[B, N, C]` MLA latent cache), so hits that are not kernel-page aligned (`prefix_match_unit` only has to divide the block, e.g. 32 vs 64) are handled too. Blocks whose logical size equals the kernel page are untouched (loads are block granular there).

Not a duplicate: #37530 makes MLA blocks participate in zeroing on *reuse*, #54421 adds range loads; neither addresses the tail of a partially loaded block being exempt from zeroing. No open issue tracks this.

## Test Plan

- `pytest tests/v1/kv_connector/unit/test_mooncake_store_worker.py` (new `test_zero_unloaded_tails_zeroes_only_never_written_slots` covers: a 200-token hit on 64-token pages, i.e. whole stale pages plus the stale slots of the partially written page, on a 4-D `[B,H,N,C]` and a 3-D `[B,N,C]` view; a load spanning two blocks; an aborted request; Mamba group untouched).
- `ruff check` / `ruff format --check` on the touched files.
- End-to-end on Kimi-K3 (KDA + MLA hybrid, FLASHINFER_MLA, kernel page 64, logical block 5760 tokens, `--prefix-match-unit 128`), P/D disaggregation (prefill TP8 x2 nodes, decode DP16 on 4 GB300 nodes), NixlConnector for P/D + MooncakeStoreConnector (TP-shared store layout from #54307/#53129 applied on top; the fix itself does not depend on them), gsm8k 5-shot greedy, two identical 1319-sample passes so pass 2 (and part of pass 1) hits the Store. Instrumented builds logged per-layer finiteness and the stale content of each decode row's last page.

## Test Result

- Unit: 167 passed.
- Without the fix (job 11833): gsm8k **0.9538 / 0.9484**. 20 requests went non-finite; all 20 were Store-hit requests and all at their first decode step, with the last cache page's unwritten tail non-finite in 23/24 MLA layers; 0 of 166 NIXL-loaded requests were affected. 21 degenerate outputs in pass 2.
- With the fix (job 11834, same nodes/recipe): gsm8k **0.9591 / 0.9651**, 0 non-finite events, 0 pages with non-finite tails (384 decode rows checked, 9216 full-sequence page scans), 0 degenerate outputs. Healthy baseline for this setup is 0.963-0.967.

AI assistance was used (Claude Code) for the investigation, the patch and this description; the author has reviewed every line and ran the tests and evaluations above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hMcjaJa8vC9zEZeipxDfd
