### PR TITLE
[Docs] Point structured-outputs Usage/entry at structured_outputs_client

### DIFF
--- a/examples/features/structured_outputs/README.md
+++ b/examples/features/structured_outputs/README.md
@@ -34,19 +34,19 @@ See [feature docs](https://docs.vllm.ai/en/latest/features/structured_outputs.ht
 Run all constraints, non-streaming:
 
 ```bash
-uv run structured_outputs_offline.py
+uv run structured_outputs_client.py
 ```
 
 Run all constraints, streaming:
 
 ```bash
-uv run structured_outputs_offline.py --stream
+uv run structured_outputs_client.py --stream
 ```
 
 Run certain constraints, for example `structural_tag` and `regex`, streaming:
 
 ```bash
-uv run structured_outputs_offline.py \
+uv run structured_outputs_client.py \
     --constraint structural_tag regex \
     --stream
 ```
@@ -54,5 +54,5 @@ uv run structured_outputs_offline.py \
 Run all constraints, with reasoning models and streaming:
 
 ```bash
-uv run structured_outputs_offline.py --reasoning --stream
+uv run structured_outputs_client.py --reasoning --stream
 ```

--- a/examples/features/structured_outputs/pyproject.toml
+++ b/examples/features/structured_outputs/pyproject.toml
@@ -5,4 +5,4 @@ dependencies = ["openai==1.78.1", "pydantic==2.11.4"]
 version = "0.0.0"
 
 [project.scripts]
-structured-outputs = "structured_outputs:main"
+structured-outputs = "structured_outputs_client:main"


### PR DESCRIPTION
## Summary
- `examples/features/structured_outputs/README.md` Usage examples invoked `structured_outputs_offline.py` with `--stream` / `--constraint` / `--reasoning`, but those CLI flags exist only on `structured_outputs_client.py` (offline has no argparse).
- `pyproject.toml` entry point `structured-outputs = "structured_outputs:main"` pointed at a missing `structured_outputs.py` (404). Point it at `structured_outputs_client:main` so `uvx ... structured-outputs` works.

## Local repro
```bash
# On main: Usage flags do not exist on offline script
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/structured_outputs/structured_outputs_offline.py | rg 'ArgumentParser|add_argument' || echo 'no argparse'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/structured_outputs/structured_outputs_client.py | rg 'add_argument|--stream|--constraint|--reasoning'
# Ghost module for entry point
curl -sL -o /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/structured_outputs/structured_outputs.py
# README still names offline + flags
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/structured_outputs/README.md | rg 'uv run'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/structured_outputs/pyproject.toml
```

## Test plan
- [ ] Confirm README Usage commands match `structured_outputs_client.py` argparse
- [ ] Confirm `structured-outputs` script entry resolves to `structured_outputs_client:main`
- [ ] Docs/examples-only change; no runtime code touched