### PR TITLE
[Bugfix][Frontend] Preserve model text when tool calling is off

### DIFF
--- a/tests/parser/engine/test_delegating_replay.py
+++ b/tests/parser/engine/test_delegating_replay.py
@@ -151,7 +151,10 @@ def test_delegating_replay(parser_cls, sample, chunk_size):
         sample.tokens,
         chunk_size=chunk_size,
         finished_on_last=True,
-        tools=sample.tools,
+        # Samples without tool defs would otherwise default to
+        # tool_choice="none", which skips tool extraction. Dummy tools
+        # keep this replay on the auto path (tools enabled).
+        tools=sample.tools or DUMMY_TOOLS,
         prompt_token_ids=sample.prompt_token_ids,
     )
     output = collect_output(deltas)

--- a/tests/parser/engine/test_delegating_replay.py
+++ b/tests/parser/engine/test_delegating_replay.py
@@ -23,7 +23,6 @@ from tests.parser.engine.replay_harness import (
     DUMMY_TOOLS,
     MockTokenizer,
     _test_request,
-    assert_no_terminal_leakage,
     assert_parse_output,
     collect_output,
     make_mock_tokenizer,
@@ -173,8 +172,11 @@ _TOOL_CALL_SAMPLES = [
     ids=lambda v: v.id if hasattr(v, "id") else "",
 )
 def test_delegating_parse_tool_choice_none(parser_cls, parser_name, sample):
-    """Non-streaming parse() with tool_choice='none' via DelegatingParser
-    must not leak special tokens into content."""
+    """Non-streaming parse() with tool_choice='none' skips tool extraction.
+
+    Remaining text after reasoning is returned as content, including
+    tool-call markup. Reasoning must still not contain parser terminals.
+    """
     tokenizer = make_mock_tokenizer(sample)
     validated_tools = (
         _TOOLS_VALIDATOR.validate_python(sample.tools) if sample.tools else None
@@ -200,8 +202,13 @@ def test_delegating_parse_tool_choice_none(parser_cls, parser_name, sample):
         for v in set(cfg.terminals.values()) | set(cfg.token_id_terminals.values())
         if len(v) > 1
     )
-    assert_no_terminal_leakage(
-        output,
-        terminals,
-        context=f"parser={parser_name}",
-    )
+    for terminal in terminals:
+        assert terminal not in output.reasoning, (
+            f"{terminal!r} leaked into reasoning (parser={parser_name})"
+        )
+    tool_start = cfg.terminals.get("TOOL_START")
+    if tool_start:
+        assert tool_start in output.content, (
+            f"tool_choice=none should preserve tool markup in content "
+            f"(parser={parser_name})"
+        )

--- a/tests/parser/test_tool_choice_none_preserves_content.py
+++ b/tests/parser/test_tool_choice_none_preserves_content.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""tool_choice='none' must skip tool extraction and keep original model text.
+
+Regression for https://github.com/vllm-project/vllm/issues/55080
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.parser.engine.replay_harness import MockTokenizer
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.parser_manager import ParserManager
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+TEXT = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "SF"}}\n</tool_call>'
+
+ENGINE_PARSERS = ("glm45", "qwen3_xml")
+
+_GLM_VOCAB = {
+    "<think>": 50,
+    "</think>": 51,
+    "<tool_call>": 60,
+    "</tool_call>": 61,
+    "<arg_key>": 62,
+    "</arg_key>": 63,
+    "<arg_value>": 64,
+    "</arg_value>": 65,
+}
+
+_QWEN3_VOCAB = {
+    "<tool_call>": 100,
+    "</tool_call>": 101,
+}
+
+GLM45_AUTO_TEXT = """I'll check it. <tool_call>get_current_weather
+<arg_key>city</arg_key>
+<arg_value>Dallas</arg_value>
+</tool_call>"""
+
+QWEN3_XML_AUTO_TEXT = (
+    "<tool_call>\n"
+    "<function=get_weather>\n"
+    "<parameter=city>Tokyo</parameter>\n"
+    "</function>\n"
+    "</tool_call>"
+)
+
+
+class _TokenizerStub:
+    """Tokenizer stub: the defect is in parser dispatch, not tokenization."""
+
+    def get_vocab(self) -> dict[str, int]:
+        return {}
+
+    @property
+    def vocab(self) -> dict[str, int]:
+        return {}
+
+    def encode(self, text: str, **kwargs) -> list[int]:
+        return [ord(c) % 1000 for c in text]
+
+    def decode(self, ids: list[int], **kwargs) -> str:
+        return "".join(chr(i) for i in ids)
+
+    def convert_tokens_to_ids(self, tokens) -> int:
+        return 90000
+
+    def convert_ids_to_tokens(self, ids: list[int]) -> list[str]:
+        return [str(i) for i in ids]
+
+    @property
+    def all_special_tokens(self) -> list[str]:
+        return []
+
+    def __len__(self) -> int:
+        return 100000
+
+
+def _none_request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        tool_choice="none",
+    )
+
+
+def _auto_request(tool_name: str) -> ChatCompletionRequest:
+    return ChatCompletionRequest.model_validate(
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+        }
+    )
+
+
+def _make_parser(parser_name: str, tokenizer=None):
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name=parser_name,
+        enable_auto_tools=True,
+    )
+    assert parser_cls is not None
+    return parser_cls(tokenizer if tokenizer is not None else _TokenizerStub())
+
+
+@pytest.mark.parametrize("parser_name", ENGINE_PARSERS)
+def test_extract_tool_calls_preserves_content_when_tool_choice_none(parser_name):
+    parser = _make_parser(parser_name)
+    request = _none_request()
+
+    calls, content = parser._extract_tool_calls(TEXT, request)
+
+    assert calls == []
+    assert content == TEXT
+
+
+@pytest.mark.parametrize("parser_name", ENGINE_PARSERS)
+def test_parse_preserves_content_when_tool_choice_none(parser_name):
+    parser = _make_parser(parser_name)
+    request = _none_request()
+
+    reasoning, content, calls = parser.parse(TEXT, request, enable_auto_tools=True)
+
+    assert reasoning is None
+    assert calls == []
+    assert content == TEXT
+
+
+@pytest.mark.parametrize("parser_name", ENGINE_PARSERS)
+def test_streaming_preserves_delta_when_tool_choice_none(parser_name):
+    parser = _make_parser(parser_name)
+    request = _none_request()
+    token_ids = parser.model_tokenizer.encode(TEXT)
+
+    delta, function_name_returned = parser._extract_tool_calls_streaming(
+        previous_text="",
+        current_text=TEXT,
+        delta_text=TEXT,
+        previous_token_ids=[],
+        current_token_ids=token_ids,
+        delta_token_ids=token_ids,
+        request=request,
+    )
+
+    assert function_name_returned is False
+    assert delta is not None
+    assert delta.content == TEXT
+    assert not delta.tool_calls
+
+
+@pytest.mark.parametrize("parser_name", ENGINE_PARSERS)
+def test_streaming_empty_delta_is_none_when_tool_choice_none(parser_name):
+    parser = _make_parser(parser_name)
+    request = _none_request()
+
+    delta, _ = parser._extract_tool_calls_streaming(
+        previous_text="",
+        current_text="",
+        delta_text="",
+        previous_token_ids=[],
+        current_token_ids=[],
+        delta_token_ids=[],
+        request=request,
+    )
+
+    assert delta is None
+
+
+def test_glm45_auto_still_extracts_tool_calls():
+    parser = _make_parser("glm45", MockTokenizer(vocab=_GLM_VOCAB, tokens=[]))
+    request = _auto_request("get_current_weather")
+
+    calls, content = parser._extract_tool_calls(
+        GLM45_AUTO_TEXT, request, enable_auto_tools=True
+    )
+
+    assert calls
+    assert calls[0].name == "get_current_weather"
+    assert json.loads(calls[0].arguments) == {"city": "Dallas"}
+    assert content == "I'll check it."
+
+
+def test_qwen3_xml_auto_still_extracts_tool_calls():
+    parser = _make_parser("qwen3_xml", MockTokenizer(vocab=_QWEN3_VOCAB, tokens=[]))
+    request = _auto_request("get_weather")
+
+    calls, content = parser._extract_tool_calls(
+        QWEN3_XML_AUTO_TEXT, request, enable_auto_tools=True
+    )
+
+    assert calls
+    assert calls[0].name == "get_weather"
+    assert json.loads(calls[0].arguments) == {"city": "Tokyo"}
+    assert not content or content.strip() == ""

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -440,9 +440,6 @@ class DelegatingParser(Parser):
             return [], content
 
         if request.tool_choice == "none":
-            if self._engine_based:
-                result = self.extract_tool_calls(content or "", request=request)
-                return [], result.content
             return [], content
 
         supports_required_and_named = tool_parser.supports_required_and_named
@@ -683,22 +680,6 @@ class DelegatingParser(Parser):
         supports_required_and_named = self._tool_parser.supports_required_and_named
 
         if request.tool_choice == "none":
-            if self._engine_based:
-                # Engine-backed parsers route content extraction through
-                # extract_tool_calls_streaming, so run the full pipeline
-                # and strip tool_calls after.
-                delta_message = self.extract_tool_calls_streaming(
-                    previous_text,
-                    current_text,
-                    delta_text,
-                    previous_token_ids,
-                    current_token_ids,
-                    delta_token_ids,
-                    request,  # type: ignore[arg-type]
-                )
-                if delta_message:
-                    delta_message.tool_calls = []
-                return delta_message, False
             return (DeltaMessage(content=delta_text) if delta_text else None), False
 
         if (


### PR DESCRIPTION
## Purpose

Fixes #55080

When tool calling is off — `tool_choice="none"` **or** the request has **no tools** — `DelegatingParser` should skip tool extraction and return the original model text as content.

The engine-based branch of `_extract_tool_calls` still ran `extract_tool_calls` and returned `result.content`. For glm45, qwen3_xml, and other engine-based parsers, tool-call-shaped text was consumed and content became `None`. With `--enable-auto-tool-choice`, `tool_choice is None` is also treated as auto, so a no-tools request could still run extraction and swallow markup (ammo-man measurement on v0.29.0, arms B and C).

This change skips the tool parser when `tool_choice == "none"` **or** `not request.tools`, for both non-streaming and streaming dispatch, and keeps the original text. Tool extraction for `auto` / named / required with tools present is unchanged.

This is not a duplicate of #42868, which changes the serving-layer streaming path in `serving.py`. That path is out of scope here.

## Test Plan

```bash
pytest \
  tests/parser/test_tool_choice_none_preserves_content.py \
  tests/entrypoints/openai/test_tool_choice_content_none.py \
  tests/parser/engine/test_delegating_replay.py \
  tests/parser/engine/test_replay.py::TestToolCallFilteringNonStreaming \
  tests/parser/engine/test_replay.py::TestToolCallFilteringReplay \
  -v
```

## Test Result

- `tests/parser/test_tool_choice_none_preserves_content.py`: **26 passed** (tool_choice=none + no-tools/omitted + no-tools/tool_choice=None for glm45 and qwen3_xml; auto-with-tools still extracts)
- Issue CPU repro (`glm45`/`qwen3_xml`, tool-call-shaped TEXT): original text preserved for both `tool_choice="none"` and no-tools requests
