### PR TITLE
[ROCm][Perf] Pad fp16/bf16 GEMM weight row stride for L2 cache

### DIFF
--- a/tests/model_executor/layers/test_rocm_unquantized_gemm.py
+++ b/tests/model_executor/layers/test_rocm_unquantized_gemm.py
@@ -17,6 +17,15 @@ if current_platform.is_cuda():
 from vllm.model_executor.layers import utils
 
 
+def _on_gfx11() -> bool:
+    """gfx11 check that is safe to evaluate at collection time on any platform."""
+    if not current_platform.is_rocm():
+        return False
+    from vllm.platforms.rocm import on_gfx11
+
+    return on_gfx11()
+
+
 def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
     x = torch.randn(1, 64, dtype=torch.float16)
     weight = torch.randn(128, 64, dtype=torch.float16)
@@ -130,12 +139,139 @@ def test_rocm_unquantized_gemm_rejects_unsupported_skinny_layouts(
     assert torch.allclose(out, ref, atol=1e-3, rtol=1e-3)
 
 
+def _row_stride_padded(weight: torch.Tensor, pad: int) -> torch.Tensor:
+    """A weight whose row stride is offset by ``pad`` elements, as produced by
+    ``maybe_pad_weight_avoid_cache_aliasing``."""
+    padded = torch.nn.functional.pad(weight, (0, pad))[..., :-pad]
+    assert padded.shape == weight.shape
+    assert padded.stride() == (weight.shape[1] + pad, 1)
+    return padded
+
+
+def test_rocm_unquantized_gemm_wvsplitk_accepts_row_stride_padded_weight(monkeypatch):
+    # wvSplitK reads the weight row stride, so a row-stride-padded weight must
+    # still reach it instead of falling back to torch.nn.functional.linear.
+    x = torch.randn(4, 1024, dtype=torch.float16)
+    weight = _row_stride_padded(torch.randn(128, 1024, dtype=torch.float16), 64)
+
+    monkeypatch.setattr(utils, "use_aiter_triton_gemm", lambda *args: False)
+    monkeypatch.setattr(utils.rocm_aiter_ops, "is_tgemm_enabled", lambda: False)
+    monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx11", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx9", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx950", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1250", lambda: False)
+    monkeypatch.setattr(utils, "num_compute_units", lambda: 120)
+
+    wvsplitk_mock = MagicMock(side_effect=lambda w, x_view, _, __: x_view @ w.t())
+    monkeypatch.setattr(utils.ops, "wvSplitK", wvsplitk_mock)
+
+    out = utils.rocm_unquantized_gemm_impl(x, weight, None)
+    ref = torch.nn.functional.linear(x, weight, None)
+
+    wvsplitk_mock.assert_called_once()
+    assert wvsplitk_mock.call_args.args[0].stride() == weight.stride()
+    assert torch.allclose(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "k,element_size,expected",
+    [
+        (4096, 2, 64),  # 8192 B row stride, aliases
+        (12288, 2, 64),  # 24576 B row stride, aliases
+        (1024, 2, 64),  # smallest aliasing bf16/fp16 K
+        (2560, 2, 0),  # 5120 B, no aliasing
+        (11008, 2, 0),  # 22016 B, no aliasing
+        (2048, 1, 128),  # fp8: 2048 B, aliases, twice the pad
+        (512, 4, 32),  # fp32: 2048 B, aliases, half the pad
+    ],
+)
+def test_cache_aliasing_pad_elems(k, element_size, expected):
+    assert utils.cache_aliasing_pad_elems(k, element_size, "gfx1151") == expected
+
+
+@pytest.mark.parametrize("gcn_arch", ["gfx942", "gfx1201", "gfx1250"])
+def test_cache_aliasing_pad_elems_skips_unlisted_arch(gcn_arch):
+    # Only architectures in CACHE_ALIASING_GEOMETRY are padded, even for a K whose
+    # row stride would alias on gfx11.
+    assert utils.cache_aliasing_pad_elems(4096, 2, gcn_arch) == 0
+
+
+def test_maybe_pad_weight_avoid_cache_aliasing(monkeypatch):
+    monkeypatch.setattr(utils.current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.get_gcn_arch", lambda: "gfx1151")
+    monkeypatch.setattr(utils.envs, "VLLM_ROCM_LINEAR_PADDING", True)
+
+    weight = torch.randn(128, 4096, dtype=torch.bfloat16)
+    padded = utils.maybe_pad_weight_avoid_cache_aliasing(weight)
+
+    assert padded.shape == weight.shape
+    assert padded.stride() == (4096 + 64, 1)
+    assert torch.equal(padded, weight)
+    # Idempotent: the padded stride no longer aliases, so a second call is a no-op
+    # and preserves the pointer captured by any graph.
+    repadded = utils.maybe_pad_weight_avoid_cache_aliasing(padded)
+    assert repadded.data_ptr() == padded.data_ptr()
+
+
+@pytest.mark.parametrize(
+    "weight",
+    [
+        torch.randn(128, 2560, dtype=torch.bfloat16),  # no aliasing
+        torch.randn(2560, 128, dtype=torch.bfloat16).t(),  # not contiguous
+        torch.randn(2, 128, 4096, dtype=torch.bfloat16),  # not 2D
+    ],
+)
+def test_maybe_pad_weight_avoid_cache_aliasing_skips(monkeypatch, weight):
+    monkeypatch.setattr(utils.current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.get_gcn_arch", lambda: "gfx1151")
+    monkeypatch.setattr(utils.envs, "VLLM_ROCM_LINEAR_PADDING", True)
+
+    assert (
+        utils.maybe_pad_weight_avoid_cache_aliasing(weight).data_ptr()
+        == weight.data_ptr()
+    )
+
+
+def test_maybe_pad_weight_avoid_cache_aliasing_respects_env(monkeypatch):
+    monkeypatch.setattr(utils.current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.get_gcn_arch", lambda: "gfx1151")
+    monkeypatch.setattr(utils.envs, "VLLM_ROCM_LINEAR_PADDING", False)
+
+    weight = torch.randn(128, 4096, dtype=torch.bfloat16)
+    assert (
+        utils.maybe_pad_weight_avoid_cache_aliasing(weight).data_ptr()
+        == weight.data_ptr()
+    )
+
+
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-only kernel test")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_rocm_unquantized_gemm_noncontiguous_activation_real_kernel(monkeypatch, dtype):
     x = torch.randn(64, 4, device="cuda", dtype=dtype).t()
     weight = torch.randn(128, 64, device="cuda", dtype=dtype)
     assert x.stride() == (1, 4)
+
+    monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
+    original_wvsplitk = utils.ops.wvSplitK
+    wvsplitk_mock = MagicMock(side_effect=original_wvsplitk)
+    monkeypatch.setattr(utils.ops, "wvSplitK", wvsplitk_mock)
+
+    out = utils.rocm_unquantized_gemm_impl(x, weight, None)
+    ref = torch.nn.functional.linear(x, weight, None)
+
+    wvsplitk_mock.assert_called_once()
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(
+    not _on_gfx11(), reason="cache-aliasing padding only applies on gfx11"
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_rocm_unquantized_gemm_padded_weight_real_kernel(monkeypatch, dtype):
+    x = torch.randn(4, 4096, device="cuda", dtype=dtype)
+    weight = _row_stride_padded(torch.randn(128, 4096, device="cuda", dtype=dtype), 64)
 
     monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
     original_wvsplitk = utils.ops.wvSplitK

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -152,6 +152,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
+    VLLM_ROCM_LINEAR_PADDING: bool = True
     VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: bool = False
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
@@ -1365,6 +1366,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_FP8_PADDING": lambda: bool(int(os.getenv("VLLM_ROCM_FP8_PADDING", "1"))),
     # Pad the weights for the moe kernel
     "VLLM_ROCM_MOE_PADDING": lambda: bool(int(os.getenv("VLLM_ROCM_MOE_PADDING", "1"))),
+    # Pad unquantized linear weights to avoid cache aliasing
+    "VLLM_ROCM_LINEAR_PADDING": lambda: bool(
+        int(os.getenv("VLLM_ROCM_LINEAR_PADDING", "1"))
+    ),
     # Whether to use the shuffled kv cache layout
     "VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT": lambda: (
         os.getenv("VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT", "False").lower() in ("true", "1")

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 )
 from vllm.model_executor.layers.utils import (
     dispatch_unquantized_gemm,
+    maybe_pad_weight_avoid_cache_aliasing,
 )
 from vllm.model_executor.parameter import (
     BasevLLMParameter,
@@ -224,6 +225,8 @@ class UnquantizedLinearMethod(LinearMethodBase):
                 and weight.stride(0) != 1
             ):
                 layer.weight.data = weight.t().contiguous().t()
+        elif current_platform.is_rocm():
+            layer.weight.data = maybe_pad_weight_avoid_cache_aliasing(layer.weight.data)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -288,10 +288,60 @@ def wvsplitkrc_dispatch(n: int, k: int, m: int, cu_count: int) -> tuple[int, boo
     return chunkk, fits
 
 
+# A weight row stride that is a multiple of the aliasing period makes the multi-row
+# global loads of a GEMM collide on the L2/MALL channel hash. Offsetting the stride by
+# one cache line dodges the collision and keeps each row aligned. Maps a GPU arch to
+# its (aliasing period, cache line) in bytes; an arch absent from this table is not
+# known to alias and is left alone.
+CACHE_ALIASING_GEOMETRY: dict[str, tuple[int, int]] = {
+    "gfx11": (2048, 128),
+}
+
+
+def cache_aliasing_pad_elems(k: int, element_size: int, gcn_arch: str) -> int:
+    """Row-stride pad, in elements, that stops an ``[n, k]`` weight aliasing, or 0
+    when the stride does not alias or the arch is not known to alias.
+
+    Args:
+        k: Number of elements per weight row.
+        element_size: Size of one element in bytes.
+        gcn_arch: GCN arch of the target GPU, e.g. ``"gfx1151"``.
+
+    Returns:
+        The number of elements to add to the row stride.
+    """
+    for arch, (period, cache_line) in CACHE_ALIASING_GEOMETRY.items():
+        if gcn_arch.startswith(arch):
+            if (k * element_size) % period != 0:
+                return 0
+            return cache_line // element_size
+    return 0
+
+
+def maybe_pad_weight_avoid_cache_aliasing(weight: torch.Tensor) -> torch.Tensor:
+    """Offset a dense weight's row stride so it stops aliasing.
+
+    Returns a view with the original shape whose row stride is one cache line
+    wider, or ``weight`` unchanged when the pad does not apply.
+    """
+    from vllm.platforms.rocm import get_gcn_arch
+
+    if not (envs.VLLM_ROCM_LINEAR_PADDING and current_platform.is_rocm()):
+        return weight
+    if weight.dim() != 2 or not weight.is_contiguous():
+        return weight
+    pad = cache_aliasing_pad_elems(
+        weight.shape[1], weight.element_size(), get_gcn_arch()
+    )
+    if pad == 0:
+        return weight
+    return torch.nn.functional.pad(weight, (0, pad))[..., :-pad]
+
+
 def rocm_unquantized_gemm_impl(
     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
 ) -> torch.Tensor:
-    from vllm.platforms.rocm import on_gfx1x, on_gfx9, on_gfx950, on_gfx1250
+    from vllm.platforms.rocm import on_gfx1x, on_gfx9, on_gfx11, on_gfx950, on_gfx1250
 
     n = x.numel() // x.size(-1)
     m = weight.shape[0]
@@ -333,27 +383,46 @@ def rocm_unquantized_gemm_impl(
 
         return gemm_a16w16(x, weight, bias)
 
-    use_skinny = (
+    skinny_gemm_enabled = (
         envs.VLLM_ROCM_USE_SKINNY_GEMM
         and (on_gfx9() or on_gfx1x())
         # build (gfx9/gfx11 ISA); fall back to torch GEMM there.
         # TODO GFX1250: Include once skinny GEMM is supported on gfx1250
         and x.dtype in [torch.float16, torch.bfloat16]
         and k % 8 == 0
-        and skinny_operands_compatible
     )
 
-    if use_skinny:
+    # wvSplitK allows row strides. Perf impact is only validated on gfx11.
+    weight_ok_for_wvsplitk = weight.is_contiguous() or (
+        on_gfx11() and weight.stride(1) == 1
+    )
+
+    use_wvsplitk = (
+        skinny_gemm_enabled
+        and weight_ok_for_wvsplitk
+        and (bias is None or bias.is_contiguous())
+        and m > 8
+        and 0 < n <= 5
+    )
+
+    use_llmm1 = (
+        skinny_gemm_enabled
+        and weight.is_contiguous()
+        and bias is None
+        and m % 4 == 0
+        and n == 1
+        and k <= 8192
+    )
+
+    if use_wvsplitk or use_llmm1:
         # The skinny kernels assume contiguous K elements. A shape-preserving
         # reshape can retain a transposed activation's non-contiguous strides.
         x_view = x.reshape(-1, x.size(-1)).contiguous()
-        if m > 8 and 0 < n <= 5:
-            cu_count = num_compute_units()
+        if use_wvsplitk:
             out = ops.wvSplitK(weight, x_view, cu_count, bias)
-            return out.reshape(*x.shape[:-1], weight.shape[0])
-        elif m % 4 == 0 and n == 1 and k <= 8192 and bias is None:
+        else:
             out = ops.LLMM1(weight, x_view, 4)
-            return out.reshape(*x.shape[:-1], weight.shape[0])
+        return out.reshape(*x.shape[:-1], weight.shape[0])
 
     if rocm_aiter_ops.is_tgemm_enabled():
         from aiter.tuned_gemm import tgemm

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -303,6 +303,10 @@ def _capability_from_gcn_arch(gcn_arch: str) -> tuple[int, int] | None:
     return (major, minor)
 
 
+def get_gcn_arch() -> str:
+    return _GCN_ARCH
+
+
 def on_gfx1x() -> bool:
     return _ON_GFX1X and not _ON_CDNA
 


### PR DESCRIPTION
On gfx11 (RDNA3/3.5) a dense GEMM whose weight row stride is a multiple of 2048 bytes collide on the L2/MALL hashes, costing a large share of achievable bandwidth. Offsetting the row stride by one 128 B cache line dodges the collision.
This PR improves TTFT by up to 13% and TPOT by up to 3%.

We pad the row stride once in `UnquantizedLinearMethod.process_weights_after_loading`.
It has a minimal impact on memory consumption on affected layers only (1.29 % of weight memory for Qwen3-8B: 171 MiB on 12.94 GiB).

The predicate is `(K * element_size) % 2048 == 0`, so for bf16/fp16 it fires on any layer
with `K % 1024 == 0`. That covers most of the Llama/Qwen dense family: for Qwen3-8B all
four linears qualify (`qkv`/`o`/`gate_up` `K=4096` → 8192 B, `down` `K=12288` → 24576 B).

Gated on gfx11. This might also apply to gfx12, but we will need to measure and can enable as a follow up.

## Benchmark

On AMD Strix Halo (gfx1151),
`--num-prompts 5`, 2 interleaved reps per cell. Both arms only differ in `VLLM_ROCM_LINEAR_PADDING`.

| Model (in/out len) | Qualifying | Median TTFT | Median TPOT | Weight memory |
|---|---|---|---|---|
| `Qwen3-8B` 1920/128 | 100 % | 918.02 → 852.39 ms (**−7.15 %**) | 72.15 → 69.83 ms (**−3.21 %**) | 15.27 → 15.47 GiB |
| `Qwen3-8B` 128/128 | 100 % | 119.35 → 103.59 ms (**−13.20 %**) | 70.50 → 68.11 ms (**−3.39 %**) | 15.27 → 15.47 GiB |
| `Qwen2.5-VL-3B-Instruct` 1920/128 | 70.7 % | 969.01 → 932.10 ms (**−3.81 %**) | 30.37 → 29.36 ms (**−3.33 %**) | 7.16 → 7.27 GiB |
| `Qwen3-4B` 1920/128 | 10.4 % | 512.12 → 510.49 ms (not resolvable) | 38.85 → 38.03 ms (**−2.11 %**) | 7.56 → 7.57 GiB |
| `Qwen2-1.5B-Instruct` 1920/128 | 0 % | 198.34 → 201.03 ms (no effect) | 14.64 → 14.74 ms (no effect) | 2.89 → 2.89 GiB |

## Accuracy

`tests/evals/gsm8k/gsm8k_eval.py`, full 1319-question test set, 5-shot, greedy
(temperature 0.0, seed 42), `Qwen/Qwen3-8B` on gfx1151:

| | Accuracy | Correct | Invalid |
|---|---|---|---|
| padding off | 88.931 % | 1173 / 1319 | 0.0 |
| padding on | 89.159 % | 1176 / 1319 | 0.0 |

## AI assistance

AI assistance was used for this PR. Every changed line was reviewed by the submitter, and
all tests, benchmarks and evals listed above were run on the hardware named.