### PR TITLE
[Bugfix] Support Mamba2 TP group replication

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -447,8 +447,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
         self.disable_tp_for_ba_proj = self.maybe_disable_tp(self.quant_config)
 
-        query_key_settings = (self.key_dim, 0, False)
-        value_settings = (self.value_dim, 0, False)
+        query_key_settings = (self.key_dim, 0, 1)
+        value_settings = (self.value_dim, 0, 1)
 
         self.conv1d.weight.weight_loader = mamba_v2_sharded_weight_loader(
             [

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -189,7 +189,7 @@ class Mixer2RMSNormGated(CustomOp):
 
 
 def mamba_v2_sharded_weight_loader(
-    shard_spec: list[tuple[int, int, float]],
+    shard_spec: list[tuple[int, int, int]],
     tp_size: int,
     tp_rank: int,
 ) -> LoaderFunction:
@@ -204,23 +204,20 @@ def mamba_v2_sharded_weight_loader(
         boundary, loaded_boundary = 0, 0
 
         # - iterate over the shard specs
-        for full_dim, extra, duplicate_groups in shard_spec:
+        for full_dim, extra, replication_factor in shard_spec:
             # - full dim is the model dim (before TP).
             # - extra > 0, means there is expected overall increase
             #   of dimensions. This is so because of replication.
-            # - ratio is used map the tp_rank to the actual shard
-            #   rank. This is useful when there is replication of
-            #   groups to accompany head shards.
+            # - replication_factor maps adjacent TP ranks to the same
+            #   group shard.
 
             # - size of the loaded shard
             shard_size = full_dim // tp_size
 
             # - compute the rank into the loaded shard.
-            # - if there is replication, different TP shards will
-            #   take from the same rank.
-            # NOTE: currently we only support duplication
-            # in the case where num_groups == 1
-            rank = 0 if duplicate_groups else tp_rank
+            # - if there is replication, adjacent TP shards take
+            #   from the same rank.
+            rank = tp_rank // replication_factor
 
             # - leftmost boundary index into loaded weight.
             loaded_skip = rank * shard_size
@@ -297,8 +294,8 @@ class MambaMixer2(MambaBase, PluggableLayer):
         # - HOWEVER IF, world_size DOES NOT divide groups, then we need
         #   to allocate extra space in the shard, such that groups
         #   may be replicated to follow the head shard.
-        # - NOTE: currently for the world size DOES NOT divide groups
-        #   case, we only support the case when n_groups == 1
+        # - If world_size is a multiple of groups, replicate each group
+        #   across the adjacent head shards that consume it.
         self.tp_size = get_tensor_model_parallel_world_size()
         tp_rank = get_tensor_model_parallel_rank()
 
@@ -306,9 +303,8 @@ class MambaMixer2(MambaBase, PluggableLayer):
             "Tensor parallel world size must divide num heads."
         )
 
-        assert (n_groups % self.tp_size) == 0 or n_groups == 1, (
-            "If tensor parallel world size does not divide num_groups, "
-            "then num_groups must equal 1."
+        assert (n_groups % self.tp_size) == 0 or (self.tp_size % n_groups) == 0, (
+            "Tensor parallel world size and num_groups must divide one another."
         )
 
         self.ssm_state_size = ssm_state_size
@@ -359,8 +355,8 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 prefix=f"{prefix}.in_proj",
             )
         else:
-            # This is the n_groups == 1 case,
-            # where we need to duplicate groups if TP>1.
+            # TP is a multiple of n_groups, so each group is replicated
+            # across the adjacent head shards that consume it.
 
             self.conv1d = ColumnParallelLinear(
                 input_size=conv_kernel_size,
@@ -387,10 +383,10 @@ class MambaMixer2(MambaBase, PluggableLayer):
             group_shard_settings = (
                 self.groups_ssm_state_size,  # expected model size
                 (self.n_groups - n_groups) * self.ssm_state_size,  # extra dims assigned
-                n_groups == 1,  # if there was only one group
+                self.tp_size // n_groups,
             )
-            intermediate_settings = (intermediate_size, 0, False)
-            head_settings = (self.num_heads, 0, False)
+            intermediate_settings = (intermediate_size, 0, 1)
+            head_settings = (self.num_heads, 0, 1)
 
             # - the weight already has a "weight_loader" attribute
             #   which set_weight_attrs will raise if we do not


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`MambaMixer2` currently supports tensor parallelism larger than `num_groups` only when `num_groups == 1`. This prevents serving models such as `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16`, which has eight Mamba groups, with TP32:

```text
AssertionError: If tensor parallel world size does not divide num_groups,
then num_groups must equal 1.
```

When tensor parallelism is a multiple of the group count, each group can be replicated across the adjacent TP ranks whose head shards consume it. This patch:

- represents the weight-loader setting as an integer replication factor;
- maps each TP rank to `tp_rank // replication_factor` for replicated group shards;
- accepts either `num_groups % tp_size == 0` or `tp_size % num_groups == 0`; and
- updates the Qwen GDN caller to pass a replication factor of one for ordinary shards.

Related issue [#46407](https://github.com/vllm-project/vllm/issues/46407) reports the same TP limitation in a broader pipeline-disaggregation setup.

## Test Plan

Use four nodes with eight H100 GPUs each. Start the Ray head on the first node:

```bash
ray start --head --port=6379
```

Join each of the other three nodes to it:

```bash
ray start --address="<HEAD_NODE_IP>:6379"
```

On the head node, run the following command first from `origin/main` to reproduce the failure, then from this branch to verify the fix:

```bash
vllm serve nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16 \
  --host 0.0.0.0 \
  --port 8000 \
  --dtype bfloat16 \
  --tensor-parallel-size 32 \
  --distributed-executor-backend ray \
  --trust-remote-code \
  --gpu-memory-utilization 0.9 \
  --max-model-len 34816 \
  --max-num-batched-tokens 16384 \
  --max-num-seqs 64 \
  --block-size 128 \
  --no-enable-prefix-caching \
  --compilation-config '{"cudagraph_capture_sizes":[1,2,4,8,16,32,64]}'
```

After the patched server becomes ready, run the 32K-input, one-output-token workload at concurrency 16:

```bash
vllm bench serve \
  --backend vllm \
  --host "<HEAD_NODE_IP>" \
  --port 8000 \
  --model nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16 \
  --endpoint /v1/completions \
  --dataset-name random \
  --random-input-len 32768 \
  --random-output-len 1 \
  --random-range-ratio 0.8 \
  --num-prompts 48 \
  --max-concurrency 16 \
  --request-rate inf \
  --ignore-eos
```

## Test Result

Before the change, the server failed during model construction before loading weights:

```text
MambaMixer2.__init__
AssertionError: If tensor parallel world size does not divide num_groups,
then num_groups must equal 1.
```

After the change, the same BF16 checkpoint and TP32 topology initialized all 32 ranks, loaded the checkpoint, captured CUDA graphs, became ready, and served all 48 requests successfully. The saved concurrency-16 result was:

```text
completed: 48
total_input_tokens: 1396900
total_output_tokens: 48
generated_texts: 48 non-empty one-token responses ("The")
errors: 48 empty entries
total_token_throughput: 7030.0069 tokens/s
```

The workload requests exactly one output token, and every request returned the expected one-token response without an error.

AI assistance was used to prepare the patch and PR description. The author reviewed every changed line and validated the change with the end-to-end run above.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the failing configuration and related issue.
- [x] The test plan and commands are provided.
- [x] Before-and-after end-to-end results are provided.

</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
(anything written below this line will be removed by GitHub Actions)
