### PR TITLE
[CI][AMD] Avoid expandable segments in LoRA TP tests

### DIFF
--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -70,7 +70,7 @@ steps:
       - tests/lora
       commands:
       - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-      - export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+      # expandable_segments breaks custom all-reduce IPC on ROCm.
       - case "$$BUILDKITE_PARALLEL_JOB" in 0|1|2|3) ;; *) echo "unexpected BUILDKITE_PARALLEL_JOB=$$BUILDKITE_PARALLEL_JOB" && exit 1;; esac
       - test "$$BUILDKITE_PARALLEL_JOB" != "3" || pytest -v -s -x lora/test_chatglm3_tp.py
       - test "$$BUILDKITE_PARALLEL_JOB" != "1" || pytest -v -s -x lora/test_llama_tp.py


### PR DESCRIPTION
- Remove `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` only from the AMD LoRA tensor-parallel mirror.
- Retain the setting for NVIDIA, where memory-constrained L4 tests still need it.
- Root cause: expandable-segment allocations are incompatible with the ROCm custom all-reduce IPC path.
- The setting reached the AMD mirror when [#52350](https://github.com/vllm-project/vllm/pull/52350) (`f5711fa138d06cfff6be8ccb8a4d98eafa8a3b50`) sharded the distributed tests.
- [PR #43923](https://github.com/vllm-project/vllm/pull/43923) addresses the same allocator/custom-all-reduce interaction in CUDA runtime code but does not fix this AMD CI mirror.
- Scope is limited to the allocator export; shard assignments and model behavior are unchanged.

The AMD workers failed before reaching the LoRA assertions because expandable-segment buffers could not be imported or registered through the ROCm IPC path. This change removes only the incompatible AMD export while preserving NVIDIA OOM mitigation. `.venv/bin/pre-commit run --files .buildkite/test_areas/lora.yaml` passed all applicable checks. A model evaluation is not applicable because model execution code is unchanged. AI assistance was used for investigation, implementation, validation, and PR preparation. The human submitter must review every changed line and confirm the evidence before marking this draft ready.