### PR TITLE
[ROCm] Route AWQ linear through choose_mp_linear_kernel

### DIFF
--- a/tests/quantization/test_auto_awq.py
+++ b/tests/quantization/test_auto_awq.py
@@ -237,3 +237,66 @@ def test_auto_awq_config_get_name():
     from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 
     assert AutoAWQConfig.get_name() == "auto_awq"
+
+
+def _rocm_linear_quant_method(monkeypatch, group_size: int, zero_point: bool):
+    """Resolve the AWQ linear method ROCm would pick for a given config."""
+    from vllm.model_executor.layers.linear import LinearBase
+    from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
+    from vllm.platforms.interface import PlatformEnum
+
+    # Platform predicates all derive from _enum, so this flips is_rocm() on and
+    # is_cuda()/is_cpu()/is_xpu() off consistently for every module that holds a
+    # reference to the singleton.
+    monkeypatch.setattr(current_platform, "_enum", PlatformEnum.ROCM)
+
+    quant_config = AutoAWQConfig(
+        weight_bits=4,
+        group_size=group_size,
+        zero_point=zero_point,
+        lm_head_quantized=False,
+    )
+    # get_quant_method only type-checks the layer on this path.
+    layer = object.__new__(LinearBase)
+    return quant_config.get_quant_method(layer, prefix="model.layers.0.q_proj")
+
+
+@pytest.mark.parametrize("group_size", [-1, 32, 64, 128])
+def test_rocm_asymmetric_linear_routed_through_mp_linear_kernel(
+    group_size: int, monkeypatch
+):
+    """On ROCm, zero-point AWQ linear layers must reach choose_mp_linear_kernel.
+
+    ROCm has no Marlin kernel, but AutoAWQMarlinLinearMethod is the method that
+    dispatches through choose_mp_linear_kernel, which is where the W4A16 kernels
+    registered for PlatformEnum.ROCM live. AutoAWQLinearMethod bypasses them.
+    """
+    from vllm.model_executor.layers.quantization.auto_awq import (
+        AutoAWQMarlinLinearMethod,
+    )
+
+    quant_method = _rocm_linear_quant_method(monkeypatch, group_size, zero_point=True)
+
+    assert isinstance(quant_method, AutoAWQMarlinLinearMethod), (
+        f"Expected AutoAWQMarlinLinearMethod on ROCm for group_size={group_size}, "
+        f"got {type(quant_method)}"
+    )
+
+
+@pytest.mark.parametrize("group_size", [-1, 32, 64, 128])
+def test_rocm_symmetric_linear_falls_back(group_size: int, monkeypatch):
+    """Symmetric AWQ must keep falling back instead of failing to load.
+
+    AutoAWQMarlinLinearMethod asserts verify_marlin_supported(), which rejects
+    the AWQ uint4 type when there are no zero points. ROCm must therefore screen
+    the same condition the CUDA path screens, or symmetric checkpoints raise
+    ValueError at load time instead of using AutoAWQLinearMethod.
+    """
+    from vllm.model_executor.layers.quantization.auto_awq import AutoAWQLinearMethod
+
+    quant_method = _rocm_linear_quant_method(monkeypatch, group_size, zero_point=False)
+
+    assert isinstance(quant_method, AutoAWQLinearMethod), (
+        f"Expected AutoAWQLinearMethod fallback on ROCm for group_size="
+        f"{group_size} without zero points, got {type(quant_method)}"
+    )

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -296,12 +296,22 @@ class AutoAWQConfig(QuantizationConfig):
             ):
                 return UnquantizedLinearMethod()
 
-            # On CPU and XPU, use the Marlin linear method which uses
+            # On CPU, XPU and ROCm, use the Marlin linear method which uses
             # choose_mp_linear_kernel to select the best available kernel
-            # (CPUWNA16LinearKernel on CPU, XPUwNa16LinearKernel on XPU).
-            # The AWQ checkpoint is converted to the standard GPTQ-like format
-            # in process_weights_after_loading before being handed to the kernel.
-            if current_platform.is_cpu() or current_platform.is_xpu():
+            # (CPUWNA16LinearKernel on CPU, XPUwNa16LinearKernel on XPU, and
+            # the RDNA/Triton W4A16 kernels on ROCm). The AWQ checkpoint is
+            # converted to the standard GPTQ-like format in
+            # process_weights_after_loading before being handed to the kernel.
+            if (
+                current_platform.is_cpu()
+                or current_platform.is_xpu()
+                or (
+                    current_platform.is_rocm()
+                    and check_marlin_supported(
+                        self.quant_type, self.group_size, self.zero_point
+                    )
+                )
+            ):
                 return AutoAWQMarlinLinearMethod(self)
 
             # Check if Marlin is supported and not using batch invariant mode


### PR DESCRIPTION
Make `AutoAWQConfig.get_quant_method` route to `AutoAWQMarlinLinearMethod` (which dispatches through `choose_mp_linear_kernel`).

This makes `AutoAWQConfig.get_quant_method` match `AutoGPTQConfig.get_quant_method`, where ROCm already goes through `choose_mp_linear_kernel`.


### Benchmarks
Benchmarked on Strix Halo (gfx1151).

**in=128, out=128:**

| Model | group_size | TTFT before → after | Δ TTFT | TPOT before → after | TPOT speedup |
|---|---|---|---|---|---|
| TheBloke/Llama-2-7B-AWQ | 128 | 198.4 → 147.2 ms | −25.8% | 151.7 → 18.6 ms | **8.14×** |
| Qwen/Qwen2.5-7B-Instruct-AWQ | 128 | 170.9 → 97.4 ms | −43.0% | 150.8 → 21.1 ms | **7.16×** |
| Qwen/Qwen3-8B-AWQ | 128 | 223.9 → 122.7 ms | −45.2% | 169.7 → 24.4 ms | **6.96×** |
| Qwen/Qwen3-4B-AWQ | 128 | 108.9 → 64.2 ms | −41.0% | 81.8 → 13.8 ms | **5.92×** |
| Qwen/Qwen2.5-3B-Instruct-AWQ | 128 | 86.6 → 52.7 ms | −39.1% | 65.4 → 11.3 ms | **5.77×** |
| trymirai/SmolLM2-1.7B-Instruct-AWQ | 32 | 56.8 → 38.7 ms | −31.8% | 37.2 → 7.1 ms | **5.27×** |

**in=1920, out=128:**

| Model | TTFT before → after | Δ TTFT | TPOT speedup |
|---|---|---|---|
| TheBloke/Llama-2-7B-AWQ | 906 → 1153 ms | **+27.3% (slower)** | 6.60× |
| Qwen/Qwen3-8B-AWQ | 988 → 1327 ms | **+34.3% (slower)** | 6.66× |
| Qwen/Qwen2.5-7B-Instruct-AWQ | 808 → 1086 ms | **+34.5% (slower)** | 7.01× |

### Model evaluation

`lm_eval`, 200 samples per task, `max_num_seqs=1`, `dtype=float16`:

| Model | Task | Metric | Before | After | Delta |
|---|---|---|---|---|---|
| Qwen2.5-3B-Instruct-AWQ | gsm8k | flexible-extract | 0.625 | 0.615 | −1.0 pp |
| Qwen2.5-3B-Instruct-AWQ | gsm8k | strict-match | 0.205 | 0.195 | −1.0 pp |
| Qwen2.5-3B-Instruct-AWQ | arc_easy | acc | 0.755 | 0.755 | 0.0 |
| Qwen2.5-3B-Instruct-AWQ | arc_easy | acc_norm | 0.720 | 0.720 | 0.0 |
| SmolLM2-1.7B-Instruct-AWQ | arc_easy | acc | 0.660 | 0.665 | +0.5 pp |

## AI assistance

AI assistance (Claude Code) was used to prepare this change.
