### PR TITLE
[ROCm] Add V2 BF16 streamed PP transport

### DIFF
--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -17,6 +17,7 @@ import torch
 from vllm.distributed import (
     broadcast_tensor_dict,
     get_pp_group,
+    get_tp_group,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_reduce_scatter,
@@ -24,6 +25,8 @@ from vllm.distributed import (
 from vllm.distributed.device_communicators import flashinfer_all_reduce
 from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
 from vllm.distributed.parallel_state import GroupCoordinator, TensorMetadata
+from vllm.sequence import IntermediateTensors
+from vllm.v1.worker.gpu.pp_utils import PPActivationTransport
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 
 from ..utils import (
@@ -580,6 +583,30 @@ def test_send_tensor_dict_sync_path_does_not_self_retain(
     assert len(g._pending_isends) == 0
 
 
+def test_drain_pending_isends_releases_retained_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    works: list[_DummyWork] = []
+
+    def fake_isend(t: torch.Tensor, *args: Any, **kwargs: Any) -> _DummyWork:
+        work = _DummyWork()
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "isend", fake_isend)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(GroupCoordinator, "send_object", lambda self, obj, dst: None)
+    group = _make_group_for_unit_test(rank_in_group=0, world_size=2)
+
+    group.isend_tensor_dict({"a": torch.arange(4)}, dst=1)
+    assert len(group._pending_isends) == 1
+
+    group.drain_pending_isends()
+
+    assert len(group._pending_isends) == 0
+    assert works[0].wait_calls == 1
+
+
 def test_async_intermediate_tensors_lazy_wait() -> None:
     work = _DummyWork()
     post_calls = {"n": 0}
@@ -660,6 +687,84 @@ def async_send_recv_tensor_test_worker(
         torch.testing.assert_close(received, expected)
 
 
+@ray.remote(num_gpus=1, max_calls=1)
+def pp_activation_transport_test_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+    shape = (8, 256)
+    schema = IntermediateTensors(
+        {
+            key: torch.empty(shape, dtype=torch.bfloat16, device=device)
+            for key in ("hidden_states", "residual")
+        }
+    )
+    transport = PPActivationTransport(
+        schema,
+        chunk_tokens=shape[0],
+        ring_size=2,
+        device=device,
+    )
+
+    expected = [
+        {
+            key: torch.full(
+                shape,
+                value + offset,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            for offset, key in enumerate(("hidden_states", "residual"))
+        }
+        for value in (1.0, 2.0)
+    ]
+    if get_pp_group().is_first_rank:
+        for tensors in expected:
+            transport.send(tensors)
+        tail = {
+            key: torch.full(
+                (4, 256),
+                3.0 + offset,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            for offset, key in enumerate(("hidden_states", "residual"))
+        }
+        transport.send_generic(
+            tail,
+            all_gather_group=get_tp_group(),
+            all_gather_tensors={},
+        )
+        transport.drain()
+    else:
+        for expected_tensors in expected:
+            tensors, handles = transport.receive()
+            for handle in handles:
+                handle.wait()
+            for key in expected_tensors:
+                torch.testing.assert_close(tensors[key], expected_tensors[key])
+        tail = get_pp_group().recv_tensor_dict()
+        assert tail is not None
+        for key, expected_tensor in {
+            key: torch.full(
+                (4, 256),
+                3.0 + offset,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            for offset, key in enumerate(("hidden_states", "residual"))
+        }.items():
+            torch.testing.assert_close(tail[key], expected_tensor)
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize(
@@ -690,6 +795,13 @@ def test_multi_process_pipeline_parallel(
     test_target: Callable[..., Any],
 ):
     multi_process_parallel(monkeypatch, 1, pp_size, test_target)
+
+
+@multi_gpu_test(num_gpus=2)
+def test_multi_process_pp_transport(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    multi_process_parallel(monkeypatch, 1, 2, pp_activation_transport_test_worker)
 
 
 @multi_gpu_test(num_gpus=4)

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -245,6 +245,47 @@ def _make_group_for_unit_test(
     return g
 
 
+def test_async_single_tensor_uses_default_neighbors_and_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int, object]] = []
+    work = _DummyWork()
+
+    def fake_isend(tensor, dst, group):
+        calls.append(("send", dst, group))
+        return work
+
+    def fake_irecv(tensor, src, group):
+        calls.append(("recv", src, group))
+        return work
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "isend", fake_isend)
+    monkeypatch.setattr(torch.distributed, "irecv", fake_irecv)
+
+    group = _make_group_for_unit_test(rank_in_group=1, world_size=3)
+    group.cpu_group = object()
+    group.device_group = object()
+
+    assert group.isend_tensor(torch.empty(1)) is work
+    assert group.irecv_tensor(torch.empty(1)) is work
+    assert calls == [
+        ("send", 2, group.cpu_group),
+        ("recv", 0, group.cpu_group),
+    ]
+
+
+def test_async_single_tensor_requires_initialized_multi_rank_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = _make_group_for_unit_test(world_size=2)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    with pytest.raises(RuntimeError, match="initialized multi-rank"):
+        group.isend_tensor(torch.empty(1))
+    with pytest.raises(RuntimeError, match="initialized multi-rank"):
+        group.irecv_tensor(torch.empty(1))
+
+
 def test_irecv_tensor_dict_send_allgather_postprocess_binds_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -594,6 +635,31 @@ def send_recv_test_worker(
         torch.testing.assert_close(test_tensor, recv_tensor)
 
 
+@ray.remote(num_gpus=1, max_calls=1)
+def async_send_recv_tensor_test_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+    expected = torch.arange(64, dtype=torch.float32, device="cuda")
+    if get_pp_group().is_first_rank:
+        work = get_pp_group().isend_tensor(expected)
+    else:
+        received = torch.empty_like(expected)
+        work = get_pp_group().irecv_tensor(received)
+    work.wait()
+
+    if not get_pp_group().is_first_rank:
+        torch.testing.assert_close(received, expected)
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize(
@@ -611,7 +677,12 @@ def test_multi_process_tensor_parallel(
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize("pp_size", [2])
 @pytest.mark.parametrize(
-    "test_target", [send_recv_test_worker, send_recv_tensor_dict_test_worker]
+    "test_target",
+    [
+        send_recv_test_worker,
+        send_recv_tensor_dict_test_worker,
+        async_send_recv_tensor_test_worker,
+    ],
 )
 def test_multi_process_pipeline_parallel(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -29,6 +29,19 @@ def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):
     assert not hasattr(envs.__getattr__, "cache_info")
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("0", False), ("false", False), ("1", True), ("true", True)],
+)
+def test_rocm_streamed_pp_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setenv("VLLM_ROCM_USE_STREAMED_PP_TRANSPORT", value)
+    assert expected is envs.VLLM_ROCM_USE_STREAMED_PP_TRANSPORT
+
+
 def test_nixl_side_channel_host_is_not_compile_factor(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/v1/worker/test_pp_utils.py
+++ b/tests/v1/worker/test_pp_utils.py
@@ -5,7 +5,10 @@
 from unittest.mock import Mock
 
 import numpy as np
+import pytest
+import torch
 
+from vllm.sequence import IntermediateTensors
 from vllm.v1.worker.gpu import pp_utils
 
 
@@ -16,6 +19,145 @@ def _batch(num_computed, prefill_len, num_scheduled):
         prefill_len_np=np.array(prefill_len, dtype=np.int32),
         num_scheduled_tokens=np.array(num_scheduled, dtype=np.int32),
     )
+
+
+def test_activation_transport_rejects_non_bf16_schema() -> None:
+    schema = IntermediateTensors({"hidden_states": torch.empty(8, 16)})
+    with pytest.raises(ValueError, match="Expected BF16"):
+        pp_utils.PPActivationTransport(
+            schema,
+            chunk_tokens=8,
+            ring_size=2,
+            device=torch.device("cpu"),
+        )
+
+
+def test_activation_transport_full_chunk_and_override_gate() -> None:
+    transport = pp_utils.PPActivationTransport.__new__(pp_utils.PPActivationTransport)
+    transport.chunk_tokens = 8
+    transport.keys = ("hidden_states", "residual")
+
+    assert transport.can_transfer(8, {})
+    assert not transport.can_transfer(7, {})
+    assert not transport.can_transfer(8, {"residual": False})
+
+
+def test_prepare_pp_intermediate_tensors_reuses_receive_target() -> None:
+    hidden = torch.zeros(8, 16, dtype=torch.bfloat16)
+    residual = torch.ones(8, 16, dtype=torch.bfloat16)
+    persistent = IntermediateTensors(
+        {
+            "hidden_states": hidden,
+            "residual": residual,
+        }
+    )
+
+    prepared = pp_utils.prepare_pp_intermediate_tensors(
+        persistent,
+        persistent,
+        num_tokens=4,
+        dummy_run=False,
+    )
+
+    assert prepared["hidden_states"].data_ptr() == hidden.data_ptr()
+    assert prepared["residual"].data_ptr() == residual.data_ptr()
+
+
+def test_prepare_pp_intermediate_tensors_copies_generic_receive() -> None:
+    persistent = IntermediateTensors(
+        {
+            "hidden_states": torch.zeros(8, 16, dtype=torch.bfloat16),
+            "residual": torch.zeros(8, 16, dtype=torch.bfloat16),
+        }
+    )
+    received = IntermediateTensors(
+        {
+            "hidden_states": torch.ones(4, 16, dtype=torch.bfloat16),
+            "residual": torch.full((4, 16), 2, dtype=torch.bfloat16),
+        }
+    )
+
+    prepared = pp_utils.prepare_pp_intermediate_tensors(
+        persistent,
+        received,
+        num_tokens=4,
+        dummy_run=False,
+    )
+
+    torch.testing.assert_close(prepared["hidden_states"], received["hidden_states"])
+    torch.testing.assert_close(prepared["residual"], received["residual"])
+
+
+def test_prepare_pp_intermediate_tensors_accepts_sp_local_rows() -> None:
+    persistent = IntermediateTensors(
+        {
+            "hidden_states": torch.zeros(8, 16, dtype=torch.bfloat16),
+        }
+    )
+    received = IntermediateTensors(
+        {
+            "hidden_states": torch.ones(2, 16, dtype=torch.bfloat16),
+        }
+    )
+
+    prepared = pp_utils.prepare_pp_intermediate_tensors(
+        persistent,
+        received,
+        num_tokens=8,
+        dummy_run=False,
+    )
+
+    assert prepared["hidden_states"].shape == (2, 16)
+    torch.testing.assert_close(prepared["hidden_states"], received["hidden_states"])
+
+
+def test_activation_transport_falls_back_on_cross_rank_schema_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = Mock(world_size=2, cpu_group=object())
+    monkeypatch.setattr(pp_utils, "get_pp_group", lambda: group)
+
+    def all_gather_object(descriptors, descriptor, group):
+        descriptors[:] = [descriptor, (("residual", (8, 16), torch.bfloat16, True),)]
+
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_gather_object",
+        all_gather_object,
+    )
+    handler = pp_utils.PPHandler.__new__(pp_utils.PPHandler)
+    handler.device = torch.device("cpu")
+    handler.activation_transport = None
+    schema = IntermediateTensors(
+        {
+            "hidden_states": torch.empty(8, 16, dtype=torch.bfloat16),
+        }
+    )
+
+    assert not handler.init_activation_transport(schema, chunk_tokens=8)
+    assert handler.activation_transport is None
+
+
+def test_activation_transport_drain_and_reap() -> None:
+    transport = pp_utils.PPActivationTransport.__new__(pp_utils.PPActivationTransport)
+    ring_work = Mock()
+    metadata_work = Mock()
+    generic_work = Mock()
+    generic_work.is_completed.return_value = True
+    transport.send_work = [[ring_work], None]
+    transport.generic_send_work = [[metadata_work, generic_work]]
+    transport.group = Mock()
+
+    transport._reap_generic_send_work()
+    ring_work.wait.assert_not_called()
+    metadata_work.wait.assert_called_once_with()
+    generic_work.wait.assert_called_once_with()
+
+    transport.drain()
+    ring_work.wait.assert_called_once_with()
+    transport.group.drain_pending_isends.assert_called_once_with()
+    assert transport.send_work == [None, None]
+    assert transport.generic_send_work == []
 
 
 def test_excludes_non_final_prefill_chunks():

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1230,6 +1230,45 @@ class GroupCoordinator:
 
         return handles
 
+    def isend_tensor(self, tensor: torch.Tensor, dst: int | None = None) -> Handle:
+        """Asynchronously send a tensor without exchanging metadata."""
+        if not torch.distributed.is_initialized() or self.world_size <= 1:
+            raise RuntimeError("isend_tensor requires an initialized multi-rank group")
+        if self.use_cpu_custom_send_recv:
+            raise RuntimeError("isend_tensor does not support custom CPU transport")
+        if dst is None:
+            dst = (self.rank_in_group + 1) % self.world_size
+        if not 0 <= dst < self.world_size:
+            raise ValueError(f"Invalid destination rank {dst}")
+
+        comm_group = self.cpu_group if tensor.is_cpu else self.device_group
+        handle = torch.distributed.isend(
+            tensor,
+            dst=self.ranks[dst],
+            group=comm_group,
+        )
+        if tensor.is_cuda:
+            tensor.record_stream(torch.cuda.current_stream(tensor.device))
+        return handle
+
+    def irecv_tensor(self, tensor: torch.Tensor, src: int | None = None) -> Handle:
+        """Asynchronously receive a tensor with an already-known schema."""
+        if not torch.distributed.is_initialized() or self.world_size <= 1:
+            raise RuntimeError("irecv_tensor requires an initialized multi-rank group")
+        if self.use_cpu_custom_send_recv:
+            raise RuntimeError("irecv_tensor does not support custom CPU transport")
+        if src is None:
+            src = (self.rank_in_group - 1) % self.world_size
+        if not 0 <= src < self.world_size:
+            raise ValueError(f"Invalid source rank {src}")
+
+        comm_group = self.cpu_group if tensor.is_cpu else self.device_group
+        return torch.distributed.irecv(
+            tensor,
+            src=self.ranks[src],
+            group=comm_group,
+        )
+
     def recv_tensor_dict(
         self,
         src: int | None = None,

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1146,6 +1146,16 @@ class GroupCoordinator:
             handles[0].wait()
             pending.popleft()
 
+    def drain_pending_isends(self) -> None:
+        """Wait for and release all self-retained tensor-dict sends."""
+        pending = getattr(self, "_pending_isends", None)
+        if pending is None:
+            return
+        while pending:
+            handles, _ = pending.popleft()
+            for handle in handles:
+                handle.wait()
+
     def isend_tensor_dict(
         self,
         tensor_dict: dict[str, torch.Tensor | Any],

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -149,6 +149,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
+    VLLM_ROCM_USE_STREAMED_PP_TRANSPORT: bool = False
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
@@ -1353,6 +1354,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_TRITON_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_GEMM", "True").lower() in ("true", "1")
+    ),
+    # Use fixed-schema BF16 buffers and a dedicated stream for V2 PP transport.
+    "VLLM_ROCM_USE_STREAMED_PP_TRANSPORT": lambda: (
+        os.getenv("VLLM_ROCM_USE_STREAMED_PP_TRANSPORT", "False").lower()
+        in ("true", "1")
     ),
     # use rocm skinny gemms
     "VLLM_ROCM_USE_SKINNY_GEMM": lambda: (

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -133,7 +133,7 @@ from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.lora import set_active_mm_loras
 from vllm.v1.worker.gpu.model_states import init_model_state
 from vllm.v1.worker.gpu.pool.pooling_runner import PoolingRunner
-from vllm.v1.worker.gpu.pp_utils import PPHandler
+from vllm.v1.worker.gpu.pp_utils import PPHandler, prepare_pp_intermediate_tensors
 from vllm.v1.worker.gpu.sample.batch_shard import (
     BatchSharder,
     all_to_all_logits,
@@ -491,6 +491,25 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 dtype=self.model_config.dtype,
                 device=self.device,
             )
+
+        if envs.VLLM_ROCM_USE_STREAMED_PP_TRANSPORT:
+            assert self.pp_handler is not None
+            schema = self.intermediate_tensors
+            if schema is None:
+                schema = self.model.make_empty_intermediate_tensors(
+                    batch_size=self.max_num_tokens,
+                    dtype=self.model_config.dtype,
+                    device=torch.device("meta"),
+                )
+            enabled = self.pp_handler.init_activation_transport(
+                schema=schema,
+                chunk_tokens=self.max_num_tokens,
+            )
+            if enabled:
+                logger.info(
+                    "Enabled streamed BF16 PP transport with %d-token chunks",
+                    self.max_num_tokens,
+                )
 
         get_offloader().post_init()
 
@@ -1735,13 +1754,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             assert intermediate_tensors is not None
             assert self.intermediate_tensors is not None
             n = input_batch.num_tokens_after_padding
-            new_tensors = {
-                k: v[:n]
-                if dummy_run
-                else v[:n].copy_(intermediate_tensors.tensors[k][:n])
-                for k, v in self.intermediate_tensors.tensors.items()
-            }
-            model_inputs["intermediate_tensors"] = IntermediateTensors(new_tensors)
+            model_inputs["intermediate_tensors"] = prepare_pp_intermediate_tensors(
+                self.intermediate_tensors,
+                intermediate_tensors,
+                num_tokens=n,
+                dummy_run=dummy_run,
+            )
             del intermediate_tensors
 
         # Update the EPLB meta.
@@ -2050,6 +2068,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def shutdown(self) -> None:
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
+        if self.pp_handler is not None:
+            self.pp_handler.drain_activation_transport()
         torch.accelerator.synchronize()
         self.cudagraph_manager = None
         if hasattr(self, "kv_caches"):

--- a/vllm/v1/worker/gpu/pp_utils.py
+++ b/vllm/v1/worker/gpu/pp_utils.py
@@ -8,10 +8,14 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
-from vllm.distributed.parallel_state import get_pp_group
+from vllm.distributed.parallel_state import GroupCoordinator, Handle, get_pp_group
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -30,6 +34,179 @@ class PendingRecv:
     # Snapshot of slot generation counters at receive time, used to
     # detect requests aborted since then.
     gen_at_receive_np: np.ndarray  # [num_reqs]
+
+
+class PPActivationTransport:
+    """Fixed-schema BF16 activation transport for V2 pipeline parallelism."""
+
+    def __init__(
+        self,
+        schema: IntermediateTensors,
+        chunk_tokens: int,
+        ring_size: int,
+        device: torch.device,
+    ) -> None:
+        if not schema.tensors:
+            raise ValueError("PP activation schema cannot be empty")
+        if ring_size < 1:
+            raise ValueError(f"ring_size must be positive, got {ring_size}")
+
+        self.keys = tuple(sorted(schema.tensors))
+        self.shapes: dict[str, torch.Size] = {}
+        for key in self.keys:
+            tensor = schema.tensors[key]
+            if tensor.shape[0] != chunk_tokens:
+                raise ValueError(
+                    f"Expected {chunk_tokens} rows for {key}, got {tensor.shape[0]}"
+                )
+            if tensor.dtype != torch.bfloat16:
+                raise ValueError(f"Expected BF16 {key}, got {tensor.dtype}")
+            if not tensor.is_contiguous():
+                raise ValueError(f"Expected contiguous {key}")
+            self.shapes[key] = tensor.shape
+
+        self.chunk_tokens = chunk_tokens
+        self.device = device
+        self.group = get_pp_group()
+        self.send_stream = torch.cuda.Stream(device=device)
+        self.send_index = 0
+        self.send_work: list[list[Handle] | None] = [None] * ring_size
+        self.generic_send_work: list[list[Handle]] = []
+        self.ready_events = [torch.cuda.Event() for _ in range(ring_size)]
+        self.recv_tensors = (
+            {}
+            if self.group.is_first_rank
+            else {key: schema.tensors[key] for key in self.keys}
+        )
+        self.send_ring = (
+            []
+            if self.group.is_last_rank
+            else [
+                {
+                    key: torch.empty(
+                        self.shapes[key],
+                        dtype=torch.bfloat16,
+                        device=device,
+                    )
+                    for key in self.keys
+                }
+                for _ in range(ring_size)
+            ]
+        )
+
+    def can_transfer(
+        self,
+        num_scheduled_tokens: int,
+        all_gather_tensors: dict[str, bool],
+    ) -> bool:
+        return num_scheduled_tokens == self.chunk_tokens and all(
+            all_gather_tensors.get(key, True) for key in self.keys
+        )
+
+    def receive(
+        self,
+    ) -> tuple[dict[str, torch.Tensor], list[Handle]]:
+        if not self.recv_tensors:
+            raise RuntimeError("The first PP rank cannot receive activations")
+        handles = [self.group.irecv_tensor(self.recv_tensors[key]) for key in self.keys]
+        return self.recv_tensors, handles
+
+    def send(self, tensors: dict[str, torch.Tensor]) -> None:
+        if not self.send_ring:
+            raise RuntimeError("The last PP rank cannot send activations")
+        if set(tensors) != set(self.keys):
+            raise ValueError(
+                f"Expected activation keys {self.keys}, got {tuple(sorted(tensors))}"
+            )
+
+        ring_index = self.send_index
+        prior_work = self.send_work[ring_index]
+        if prior_work is not None:
+            for handle in prior_work:
+                handle.wait()
+
+        send_tensors = self.send_ring[ring_index]
+        for key in self.keys:
+            tensor = tensors[key]
+            if tensor.shape != self.shapes[key] or tensor.dtype != torch.bfloat16:
+                raise ValueError(
+                    f"Unexpected {key} schema: shape={tensor.shape}, "
+                    f"dtype={tensor.dtype}"
+                )
+            send_tensors[key].copy_(tensor)
+
+        ready_event = self.ready_events[ring_index]
+        ready_event.record(torch.cuda.current_stream(self.device))
+        with torch.cuda.stream(self.send_stream):
+            self.send_stream.wait_event(ready_event)
+            self.send_work[ring_index] = [
+                self.group.isend_tensor(send_tensors[key]) for key in self.keys
+            ]
+        self.send_index = (ring_index + 1) % len(self.send_ring)
+
+    def send_generic(
+        self,
+        tensor_dict: dict[str, torch.Tensor],
+        all_gather_group: GroupCoordinator,
+        all_gather_tensors: dict[str, bool],
+    ) -> None:
+        """Order a generic tail send after fixed sends on the send stream."""
+        self._reap_generic_send_work()
+        ready_event = torch.cuda.Event()
+        ready_event.record(torch.cuda.current_stream(self.device))
+        with torch.cuda.stream(self.send_stream):
+            self.send_stream.wait_event(ready_event)
+            self.generic_send_work.append(
+                self.group.isend_tensor_dict(
+                    tensor_dict,
+                    all_gather_group=all_gather_group,
+                    all_gather_tensors=all_gather_tensors,
+                )
+            )
+
+    def _reap_generic_send_work(self) -> None:
+        while self.generic_send_work:
+            handles = self.generic_send_work[0]
+            tensor_handles = handles[1:]
+            if not tensor_handles or not all(
+                handle.is_completed() for handle in tensor_handles
+            ):
+                break
+            for handle in handles:
+                handle.wait()
+            self.generic_send_work.pop(0)
+
+    def drain(self) -> None:
+        for work in self.send_work:
+            if work is not None:
+                for handle in work:
+                    handle.wait()
+        self.send_work = [None] * len(self.send_work)
+        for handles in self.generic_send_work:
+            for handle in handles:
+                handle.wait()
+        self.generic_send_work.clear()
+        self.group.drain_pending_isends()
+
+
+def prepare_pp_intermediate_tensors(
+    persistent: IntermediateTensors,
+    received: IntermediateTensors,
+    num_tokens: int,
+    dummy_run: bool,
+) -> IntermediateTensors:
+    """Copy into V2 persistent buffers unless receive already targeted them."""
+    tensors: dict[str, torch.Tensor] = {}
+    for key, persistent_tensor in persistent.tensors.items():
+        if dummy_run:
+            dst = persistent_tensor[:num_tokens]
+        else:
+            src = received.tensors[key]
+            dst = persistent_tensor[: src.shape[0]]
+            if src.data_ptr() != dst.data_ptr():
+                dst.copy_(src)
+        tensors[key] = dst
+    return IntermediateTensors(tensors)
 
 
 def compute_need_sampled_mask(input_batch: InputBatch) -> np.ndarray | None:
@@ -82,6 +259,57 @@ class PPHandler:
         self.broadcast_group = get_pp_group().make_sibling_device_group(
             group_desc="pp_broadcast"
         )
+        self.activation_transport: PPActivationTransport | None = None
+
+    def init_activation_transport(
+        self,
+        schema: IntermediateTensors,
+        chunk_tokens: int,
+    ) -> bool:
+        descriptor = tuple(
+            (
+                key,
+                tuple(tensor.shape),
+                tensor.dtype,
+                tensor.is_contiguous(),
+            )
+            for key, tensor in sorted(schema.tensors.items())
+        )
+        pp_group = get_pp_group()
+        descriptors: list[object] = [None] * pp_group.world_size
+        torch.distributed.all_gather_object(
+            descriptors,
+            descriptor,
+            group=pp_group.cpu_group,
+        )
+        if any(peer_descriptor != descriptor for peer_descriptor in descriptors):
+            logger.warning_once(
+                "Disabling streamed PP transport because pipeline stages have "
+                "different activation schemas."
+            )
+            return False
+        if not descriptor or any(
+            shape[0] != chunk_tokens or dtype != torch.bfloat16 or not is_contiguous
+            for _, shape, dtype, is_contiguous in descriptor
+        ):
+            logger.warning_once(
+                "Disabling streamed PP transport because its activation schema "
+                "is not contiguous BF16 with %d rows.",
+                chunk_tokens,
+            )
+            return False
+
+        self.activation_transport = PPActivationTransport(
+            schema=schema,
+            chunk_tokens=chunk_tokens,
+            ring_size=pp_group.world_size,
+            device=self.device,
+        )
+        return True
+
+    def drain_activation_transport(self) -> None:
+        if self.activation_transport is not None:
+            self.activation_transport.drain()
 
     def on_req_idx_freed(self, req_idx: int) -> None:
         self.req_idx_gen_np[req_idx] += 1

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -139,6 +139,7 @@ def maybe_rocm_profiling_fallback(profile_result: MemoryProfilingResult) -> int 
 if TYPE_CHECKING:
     from vllm.device_allocator.sleep_mode_backend import SleepModeBackend
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
+    from vllm.v1.worker.gpu.pp_utils import PPActivationTransport
     from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
@@ -218,6 +219,17 @@ class Worker(WorkerBase):
         self.profiler_config = vllm_config.profiler_config
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
+        if envs.VLLM_ROCM_USE_STREAMED_PP_TRANSPORT:
+            if not self.use_v2_model_runner:
+                raise ValueError("Streamed PP transport requires the V2 model runner")
+            if not current_platform.is_rocm():
+                raise ValueError("Streamed PP transport is only supported on ROCm")
+            if self.parallel_config.pipeline_parallel_size <= 1:
+                raise ValueError("Streamed PP transport requires PP > 1")
+            if self.parallel_config.tensor_parallel_size != 1:
+                raise ValueError("Streamed PP transport currently requires TP=1")
+            if self.model_config.dtype != torch.bfloat16:
+                raise ValueError("Streamed PP transport requires BF16 activations")
 
         # Device handles of the previous step's PP intermediate-tensor send.
         self._pp_send_work: list[Handle] = []
@@ -238,6 +250,7 @@ class Worker(WorkerBase):
         return self._sleep_mode_backend
 
     def sleep(self, level: int = 1) -> None:
+        self._drain_pp_activation_transport()
         torch.accelerator.synchronize()
         free_bytes_before_sleep = torch.accelerator.get_memory_info()[0]
 
@@ -508,6 +521,19 @@ class Worker(WorkerBase):
                 self.device,
                 self.model_runner.get_model(),
             )
+
+    def _get_pp_activation_transport(self) -> "PPActivationTransport | None":
+        if not self.use_v2_model_runner:
+            return None
+        pp_handler = self.model_runner.pp_handler
+        return None if pp_handler is None else pp_handler.activation_transport
+
+    def _drain_pp_activation_transport(self) -> None:
+        if not self.use_v2_model_runner:
+            return
+        pp_handler = getattr(self.model_runner, "pp_handler", None)
+        if pp_handler is not None:
+            pp_handler.drain_activation_transport()
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)
@@ -1126,6 +1152,7 @@ class Worker(WorkerBase):
         intermediate_tensors = None
         forward_pass = scheduler_output.total_num_scheduled_tokens > 0
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+        activation_transport = self._get_pp_activation_transport()
         all_gather_tensors = {}
         compilation_config = self.vllm_config.compilation_config
         parallel_config = self.vllm_config.parallel_config
@@ -1158,14 +1185,27 @@ class Worker(WorkerBase):
                     self.vllm_config, batch_desc.num_tokens
                 )
             }
+        use_fixed_pp_transport = (
+            forward_pass
+            and activation_transport is not None
+            and activation_transport.can_transfer(
+                num_scheduled_tokens,
+                all_gather_tensors,
+            )
+        )
 
         if forward_pass and not get_pp_group().is_first_rank:
-            tensor_dict, comm_handles, comm_postprocess = (
-                get_pp_group().irecv_tensor_dict(
-                    all_gather_group=get_tp_group(),
-                    all_gather_tensors=all_gather_tensors,
+            if use_fixed_pp_transport:
+                assert activation_transport is not None
+                tensor_dict, comm_handles = activation_transport.receive()
+                comm_postprocess = []
+            else:
+                tensor_dict, comm_handles, comm_postprocess = (
+                    get_pp_group().irecv_tensor_dict(
+                        all_gather_group=get_tp_group(),
+                        all_gather_tensors=all_gather_tensors,
+                    )
                 )
-            )
             assert tensor_dict is not None
             intermediate_tensors = AsyncIntermediateTensors(
                 tensor_dict,
@@ -1195,15 +1235,25 @@ class Worker(WorkerBase):
             and not get_pp_group().is_last_rank
         )
 
-        # Non-blocking send of the intermediate tensors. The metadata handle
-        # is reaped lazily by the GroupCoordinator; the device handles are
-        # waited at the top of the next step.
-        handles = get_pp_group().isend_tensor_dict(
-            output.tensors,
-            all_gather_group=get_tp_group(),
-            all_gather_tensors=all_gather_tensors,
-        )
-        self._pp_send_work = handles[1:]
+        if use_fixed_pp_transport:
+            assert activation_transport is not None
+            activation_transport.send(output.tensors)
+        elif activation_transport is not None:
+            activation_transport.send_generic(
+                output.tensors,
+                all_gather_group=get_tp_group(),
+                all_gather_tensors=all_gather_tensors,
+            )
+        else:
+            # Non-blocking send of the intermediate tensors. The metadata handle
+            # is reaped lazily by the GroupCoordinator; the device handles are
+            # waited at the top of the next step.
+            handles = get_pp_group().isend_tensor_dict(
+                output.tensors,
+                all_gather_group=get_tp_group(),
+                all_gather_tensors=all_gather_tensors,
+            )
+            self._pp_send_work = handles[1:]
 
         return None
 
@@ -1440,6 +1490,8 @@ class Worker(WorkerBase):
 
     def shutdown(self) -> None:
         gc.unfreeze()
+
+        self._drain_pp_activation_transport()
 
         # has_kv_transfer_group can be None during interpreter shutdown.
         if ensure_kv_transfer_shutdown is not None:


### PR DESCRIPTION
## Summary

Add an opt-in V2 fixed-schema BF16 pipeline transport for ROCm on the V2 model runner:

- preallocate a bounded sender ring and order P2P sends on a dedicated stream
- receive full-size chunks directly into a fixed receive buffer
- bypass per-step metadata exchange for full `max_num_batched_tokens` chunks
- preserve the existing tensor-dict path for partial tails and unsupported schemas

The feature is disabled by default and selected with `VLLM_ROCM_USE_STREAMED_PP_TRANSPORT=1`. Supported envelope: V2 model runner, ROCm, **TP=1, PP>1**, contiguous BF16 `hidden_states`, and full `max_num_batched_tokens` chunks. Configurations with `PP=1` (for example TP8/PP1) reject the flag at worker startup; benchmarks below are TP1/PP8 only.

This PR is intentionally separate from #55032, which targets the V1 `PPTransport` path. V2 integrates with `PPHandler` and the V2 GPU model runner.

The first commit adds metadata-free async tensor P2P (`isend_tensor`) used by the transport ring.

## Tests

- `tests/v1/worker/test_pp_utils.py`: V2 transport schema validation, ring drain, generic-send reap
- `tests/test_envs.py`: `VLLM_ROCM_USE_STREAMED_PP_TRANSPORT` parsing
- `tests/distributed/test_comm_ops.py`: metadata-free `isend_tensor` coverage
- Worker startup guards in `gpu_worker.py` reject unsupported topologies (`PP <= 1` or `TP != 1`) before model load

## Performance

Measured on 8 x MI355X, DeepSeek-V4-Pro tuned stack (OPUS sparse + FP8 WO_A, nightly pin `73029d4244`), **TP1/PP8 only**, prefix caching disabled. This transport does not apply to `PP=1` layouts such as TP8/PP1.

### C1 100K prefill (TP1/PP8)

| Arm | TTFT runs (ms) | Median TTFT | Input throughput |
|---|---:|---:|---:|
| Generic (`VLLM_ROCM_USE_STREAMED_PP_TRANSPORT=0`) | 2294.5 / 2278.3 / 2279.1 | 2279.1 ms | 43,877 tok/s |
| Stream (`VLLM_ROCM_USE_STREAMED_PP_TRANSPORT=1`) | 2198.9 / 2183.3 / 2183.9 | 2183.9 ms | 45,790 tok/s |

Delta: **median TTFT -95.2 ms (-4.2%)**.

### TP1/PP8 prefill concurrency

Fixed 8,192-token prompts, one output token, 10 requests per concurrency slot, `max-num-seqs=48`.

| Max concurrency | Generic total tok/s | Stream total tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 2817.27 | 2977.25 | +5.68% |
| 2 | 9329.89 | 9316.00 | -0.15% |
| 4 | 22459.09 | 22612.09 | +0.68% |
| 8 | 48709.24 | 49062.22 | +0.72% |
| 16 | 57937.44 | 61954.36 | +6.93% |
| 32 | 59968.76 | 64380.70 | +7.36% |
| 48 | 60701.55 | 65155.02 | +7.34% |

All 1,110 requests in each arm completed without errors.
### TP1/PP8 prefill concurrency — median TTFT

Same workload as above (8K input / 1 output, 10 prompts per concurrency slot).

| Max concurrency | Generic median TTFT (ms) | Stream median TTFT (ms) | Δ |
|---:|---:|---:|---:|
| 1 | 898.6 | 898.8 | +0.0% |
| 2 | 1754.5 | 1756.8 | +0.1% |
| 4 | 1208.4 | 1193.0 | -1.3% |
| 8 | 1182.3 | 1164.0 | -1.5% |
| 16 | 2109.0 | 1959.3 | **-7.1%** |
| 32 | 4214.1 | 3916.0 | **-7.1%** |
| 48 | 6318.1 | 5877.8 | **-7.0%** |

From C≥16, median TTFT tracks the throughput gains (~7%), consistent with transport savings on the V2 runner (no V1 ~9K tok/s ceiling).



## Correctness

Greedy GSM8K 5-shot, 1319 questions, `temperature=0`, `max-concurrency=32`, TP1/PP8 on the tuned `main-tuned-v2` images:

| Arm | Accuracy | Correct | Invalid |
|---|---:|---:|---:|
| Generic | 94.62% | 1248/1319 | 0 |
| Stream | 95.00% | 1253/1319 | 0 |

Both arms produced zero invalid responses. Stream transport does not introduce parse failures; the generic/stream delta (+5 correct) is within normal greedy run variance.

Reference on the earlier `fp8woa` tuned image (without V2 transport overlay): **1256/1319 = 95.22%**, invalid=0.

## AI assistance

Cursor assisted with implementation, testing, benchmark analysis, and drafting. The human submitter reviewed the resulting change and is responsible for it.

