### PR TITLE
[Kernel][Quantization] Cut transient memory in NVFP4 Marlin scale-factor computation

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_marlin_scale_factor.py
+++ b/tests/kernels/quantization/test_nvfp4_marlin_scale_factor.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the NVFP4 Marlin power-of-2 scale factor helper.
+
+The helper must return the same factor as the previous mask-and-gather
+implementation while allocating no tensor-sized temporaries.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    _nvfp4_compute_scale_factor,
+)
+
+DTYPES = [torch.float16, torch.bfloat16]
+SHAPES = [(64,), (128, 256), (8, 64, 128)]
+UPPER = 448 * (2**7)
+
+
+def _reference_scale_factor(
+    marlin_scales: torch.Tensor, a_dtype: torch.dtype | None = None
+) -> float:
+    """The previous implementation, kept verbatim as the oracle."""
+    if a_dtype is not None and a_dtype == torch.half:
+        return 1.0
+    ws_float = marlin_scales.float() * (2**7)
+    nonzero_mask = ws_float > 0
+    if nonzero_mask.any():
+        max_val = ws_float[nonzero_mask].max()
+        if max_val < UPPER:
+            sf = (UPPER / max_val).log2().floor().exp2()
+            return sf.item()
+    return 1.0
+
+
+def _cases(shape: tuple[int, ...], dtype: torch.dtype) -> dict[str, torch.Tensor]:
+    gen = torch.Generator().manual_seed(0)
+    small = torch.rand(shape, generator=gen) * 0.01
+    with_zeros = small.clone()
+    with_zeros.flatten()[::3] = 0.0
+    with_negatives = small.clone()
+    with_negatives.flatten()[::5] *= -1.0
+    normalized = torch.rand(shape, generator=gen) * 400.0 + 48.0
+    return {
+        "small": small.to(dtype),
+        "with_zeros": with_zeros.to(dtype),
+        "with_negatives": with_negatives.to(dtype),
+        "all_zeros": torch.zeros(shape, dtype=dtype),
+        "all_negative": (-small - 0.001).to(dtype),
+        "already_normalized": normalized.to(dtype),
+        "single_large": torch.full(shape, 0.5, dtype=dtype),
+    }
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("a_dtype", [None, torch.float16, torch.bfloat16])
+def test_scale_factor_matches_reference(
+    dtype: torch.dtype, shape: tuple[int, ...], a_dtype: torch.dtype | None
+):
+    for name, scales in _cases(shape, dtype).items():
+        expected = _reference_scale_factor(scales, a_dtype)
+        actual = _nvfp4_compute_scale_factor(scales, a_dtype)
+        assert actual == expected, name
+        assert actual >= 1.0
+        assert actual == 2.0 ** round(torch.tensor(actual).log2().item())
+
+
+def test_scale_factor_rescales_into_range():
+    scales = torch.full((32, 64), 2**-10, dtype=torch.bfloat16)
+    sf = _nvfp4_compute_scale_factor(scales)
+    rescaled = scales.float().max() * (2**7) * sf
+    assert 2.0 <= rescaled < UPPER
+
+
+def test_scale_factor_empty_tensor():
+    assert _nvfp4_compute_scale_factor(torch.empty(0, dtype=torch.bfloat16)) == 1.0
+
+
+def test_scale_factor_rejects_nan():
+    scales = torch.rand(16, 16, dtype=torch.bfloat16)
+    scales[3, 3] = float("nan")
+    with pytest.raises(ValueError, match="NaN"):
+        _nvfp4_compute_scale_factor(scales)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_scale_factor_allocates_no_tensor_temporaries():
+    device = torch.device("cuda")
+    scales = torch.rand((288, 512, 256), dtype=torch.bfloat16, device=device) * 0.01
+    torch.cuda.synchronize(device)
+    torch.cuda.reset_peak_memory_stats(device)
+    baseline = torch.cuda.memory_allocated(device)
+    sf = _nvfp4_compute_scale_factor(scales)
+    torch.cuda.synchronize(device)
+    transient = torch.cuda.max_memory_allocated(device) - baseline
+    assert sf > 1.0
+    # The previous implementation needed ~4.5x the tensor size here.
+    assert transient < scales.numel() * scales.element_size() // 64

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -50,11 +50,8 @@ def _nvfp4_compute_scale_factor(
     if marlin_scales.numel() == 0:
         return 1.0
 
-    # The factor depends only on the largest scale, so reduce the input
-    # directly. Materializing an FP32 copy, a boolean mask, and a gathered
-    # copy of every scale costs up to 9x the tensor size in transient device
-    # memory; for fused MoE parameters (all experts at once) that is several
-    # GiB during weight loading.
+    # Reduce the input directly: the FP32 copy, mask, and gathered copy of the
+    # old path cost several times the tensor size in transient memory.
     max_val = marlin_scales.max().float() * (2**7)
     if torch.isnan(max_val):
         raise ValueError("NVFP4 Marlin scales contain NaN")

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -47,14 +47,20 @@ def _nvfp4_compute_scale_factor(
     # no rescaling is applied here if active dtype is half.
     if a_dtype is not None and a_dtype == torch.half:
         return 1.0
+    if marlin_scales.numel() == 0:
+        return 1.0
 
-    ws_float = marlin_scales.float() * (2**7)
-    nonzero_mask = ws_float > 0
-    if nonzero_mask.any():
-        max_val = ws_float[nonzero_mask].max()
-        if max_val < 448 * (2**7):
-            sf = (448 * (2**7) / max_val).log2().floor().exp2()
-            return sf.item()
+    # The factor depends only on the largest scale, so reduce the input
+    # directly. Materializing an FP32 copy, a boolean mask, and a gathered
+    # copy of every scale costs up to 9x the tensor size in transient device
+    # memory; for fused MoE parameters (all experts at once) that is several
+    # GiB during weight loading.
+    max_val = marlin_scales.max().float() * (2**7)
+    if torch.isnan(max_val):
+        raise ValueError("NVFP4 Marlin scales contain NaN")
+    if 0 < max_val < 448 * (2**7):
+        sf = (448 * (2**7) / max_val).log2().floor().exp2()
+        return sf.item()
     return 1.0
 
 


### PR DESCRIPTION
## Purpose

`_nvfp4_compute_scale_factor` in `marlin_utils_fp4.py` finds the largest NVFP4 weight scale by materializing an FP32 copy of the whole scale tensor, a boolean mask, and a gathered copy of the positive entries. The MoE paths (`prepare_nvfp4_moe_layer_for_marlin`, `prepare_moe_fp4_layer_for_marlin`) call it on the scales of **all experts at once**, so for a 288-expert model such as GLM-5.3-Flash NVFP4 one call touches about 300M elements and allocates several GiB of transient device memory during weight loading. On unified-memory machines with little headroom at load time (DGX Spark GB10, #50925) that spike can fail the load or push the driver into the memory-pressure spiral reported by the community.

This PR reduces the input tensor directly. The returned factor is unchanged:

- a max commutes with the exact multiplication by `2**7`;
- non-positive scales never win the max when a positive scale exists, and an all-non-positive tensor still returns `1.0`;
- an empty tensor returns `1.0` as before.

One deliberate behavior change: a NaN scale now raises `ValueError` instead of being silently excluded from the max. Happy to drop that if maintainers prefer the old silent behavior.

## Test Plan

- New `tests/kernels/quantization/test_nvfp4_marlin_scale_factor.py`: the previous implementation is kept verbatim as the oracle and compared against the new one for fp16/bf16 inputs, 1-D/2-D/3-D shapes, and inputs with zeros, negatives, all zeros, all negative, already-normalized values, and the `a_dtype=half` early return; plus range, empty-tensor, and NaN tests. A CUDA-only test asserts the call allocates no tensor-sized temporaries on a `(288, 512, 256)` bf16 input.
- `pre-commit` (ruff check / ruff format) on the two files.

```
pytest tests/kernels/quantization/test_nvfp4_marlin_scale_factor.py -q
```

## Test Result

CPU run (torch 2.13, the CUDA test skipped): `21 passed, 1 skipped`.

Peak RSS growth of one call on a bf16 tensor of shape `(288, 512, 256)` (37.7M elements, one eighth of the production fused w13 scales), each variant in its own process:

| variant | scale factor | RSS growth |
|---|---|---|
| before | 32768.0 | 1011 MiB |
| after | 32768.0 | 3 MiB |

The full-size production call (GLM-5.3-Flash NVFP4, 288 experts, fused w13 scales of 302M elements) is eight times larger.


## Duplicate-work check

Searches run on 2026-09-03 before this PR was filed and again before this update:

```
gh issue view 50925 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "50925 in:body"
gh pr list --repo vllm-project/vllm --state open --search "nvfp4 marlin scale factor"
gh pr list --repo vllm-project/vllm --state open --search "_nvfp4_compute_scale_factor"
gh pr list --repo vllm-project/vllm --state open --search "marlin_utils_fp4"
```

No open PR touches `_nvfp4_compute_scale_factor` or the transient memory of the NVFP4 Marlin weight preparation. The hits are unrelated: #54669 (B12X MoE selection), #45192 and #48199 (warning text), #47673 (custom-op reporting). Issue #50925 has no fix attached; its two comments discuss the sm_121 Marlin fallback itself, which this PR does not change.

## Model evaluation

The returned scale factor is identical by construction (the maximum of the same values), and the oracle test in the new test file compares the new implementation against the previous one, so model outputs do not change. As serving evidence, the patched helper runs GLM-5.3-Flash NVFP4 (288 experts, `--moe-backend marlin`, TP=2) on two DGX Spark GB10 nodes; the qualification run of 2026-09-03 passed its accuracy gate at 262,144-token context with this helper in the image.

## AI assistance

AI assistance was used: Claude Code (Anthropic) drafted the change, the unit test, the memory measurement, and this description under the author's direction. The author is accountable for the change.
