### PR TITLE
[ROCm][MXFP4] Align the AITER W4A4 MoE intermediate size to 128

### DIFF
--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -2011,3 +2011,79 @@ def test_emulation_a_mxfp6_moe_forward_quantizes_activations():
         "w_mxfp4_a_mxfp6_e3m2 output is bit-identical to weight-only w_mxfp4:"
         " the emulation never fake-quantized the activations"
     )
+
+
+# (backend, activation, hidden_in, inter_in, hidden_out, inter_out)
+#
+# The AITER_MXFP4_MXFP4 (W4A4) rows are the ones this table exists for: the
+# per-partition intermediate is aligned to 128, not 256, so a model whose native
+# shard is already 128-aligned is allocated at its real width instead of being
+# padded up. `hidden_size` deliberately stays on 256 -- the gfx950 stage-1 mxfp4
+# kernels are generated with tile_k 256 only, and stage-1 reduces over model_dim.
+#
+# The remaining rows pin the neighbouring branches so a future edit to this
+# function cannot silently move a backend between them.
+ROCM_MXFP4_ROUNDUP_CASES = [
+    # W4A4: 3072 / TP8 = 384 stays 384. This is the case the alignment change is
+    # for; the generic 256 round-up would allocate 512.
+    ("AITER_MXFP4_MXFP4", "SILU", 6144, 384, 6144, 384),
+    # W4A4, already 256-aligned (e.g. moe_intermediate 2048 at TP8): identity in
+    # both the old and the new form, so such models are provably untouched.
+    ("AITER_MXFP4_MXFP4", "SILU", 6144, 256, 6144, 256),
+    # W4A4, 1024 / TP8 = 128: the most aggressive case, halved rather than trimmed.
+    ("AITER_MXFP4_MXFP4", "SILU", 4096, 128, 4096, 128),
+    # W4A4 ignores the activation -- the branch does not read it.
+    ("AITER_MXFP4_MXFP4", None, 6144, 384, 6144, 384),
+    ("AITER_MXFP4_MXFP4", "SWIGLUOAI", 6144, 384, 6144, 384),
+    # W4A4 hidden_size is still rounded to 256, unlike the intermediate.
+    ("AITER_MXFP4_MXFP4", "SILU", 384, 384, 512, 384),
+    # W4A16 CK + SiTU/SILU keeps its own 128/128 carve-out.
+    ("AITER_MXFP4_BF16", "SITU", 384, 384, 384, 384),
+    ("AITER_MXFP4_BF16", "SILU", 384, 384, 384, 384),
+    # ... but only for those activations; anything else takes the generic ROCm arm.
+    ("AITER_MXFP4_BF16", "SWIGLUOAI", 384, 384, 512, 512),
+    # Backends that stay on the generic ROCm 256/256 round-up.
+    ("AITER_MXFP4_FP8", "SILU", 384, 384, 512, 512),
+    ("AITER_TRITON_MXFP4_BF16", "SILU", 384, 384, 512, 512),
+    ("TRITON", "SWIGLUOAI", 384, 384, 512, 512),
+]
+
+
+@pytest.mark.parametrize(
+    "backend_name,activation_name,hidden_in,inter_in,hidden_out,inter_out",
+    ROCM_MXFP4_ROUNDUP_CASES,
+)
+@pytest.mark.skipif(not ROCM_AVAILABLE, reason="ROCm is required for this test")
+def test_rocm_mxfp4_round_up_hidden_and_intermediate(
+    backend_name: str,
+    activation_name: str | None,
+    hidden_in: int,
+    inter_in: int,
+    hidden_out: int,
+    inter_out: int,
+):
+    """Pin the ROCm arm of mxfp4_round_up_hidden_size_and_intermediate_size.
+
+    The allocation this function returns is what every MXFP4 MoE weight buffer,
+    scale buffer and aiter tuned-config lookup is sized from, so a change here is
+    invisible locally and expensive everywhere else. Asserting the table keeps
+    each backend on the alignment its kernels actually require.
+    """
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+        Mxfp4MoeBackend,
+        mxfp4_round_up_hidden_size_and_intermediate_size,
+    )
+
+    backend = Mxfp4MoeBackend[backend_name]
+    activation = MoEActivation[activation_name] if activation_name else None
+
+    hidden, intermediate = mxfp4_round_up_hidden_size_and_intermediate_size(
+        backend, hidden_in, inter_in, activation
+    )
+
+    assert (hidden, intermediate) == (hidden_out, inter_out), (
+        f"{backend_name} / {activation_name}: "
+        f"hidden {hidden_in}->{hidden} (expected {hidden_out}), "
+        f"intermediate {inter_in}->{intermediate} (expected {inter_out})"
+    )

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -768,6 +768,19 @@ def mxfp4_round_up_hidden_size_and_intermediate_size(
             # which would inflate weights and OOM.
             intermediate_size = round_up(intermediate_size, 128)
             hidden_size = round_up(hidden_size, 128)
+        elif backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
+            # Same situation as the K3 carve-out above, for the W4A4 backend. The generic
+            # 256 round-up turns a 384/partition intermediate (moe_intermediate 3072 at TP8)
+            # into 512, which allocates 33% oversized expert weights AND makes aiter's tuned
+            # config key inter_dim=512 -- a value that matches nothing, while aiter ships 16
+            # validated rows for exactly (gfx950, cu_num=256, model_dim=6144, inter_dim=384,
+            # expert=129, topk=5, fp4x2/fp4x2, per_1x32). 384 = 3 x 128 tiles cleanly in both
+            # FlyDSL stages (stage-1 tile_n 128, stage-2 tile_k 128).
+            # hidden_size deliberately stays on 256: gfx950 stage-1 mxfp4 kernels are generated
+            # with tile_ks=[256] only and stage-1 K is model_dim, so relaxing hidden to 128
+            # could leave some models with no legal stage-1 tile.
+            intermediate_size = round_up(intermediate_size, 128)
+            hidden_size = round_up(hidden_size, 256)
         else:
             intermediate_size = round_up(intermediate_size, 256)
             hidden_size = round_up(hidden_size, 256)


### PR DESCRIPTION
> **Blocked: do not merge before ROCm/aiter#5232 lands.** Without that fix this change silently
> corrupts decode output on the affected shapes. Kept as a draft until the dependency is released.

## Purpose

On ROCm, `mxfp4_round_up_hidden_size_and_intermediate_size` rounds the MoE per-partition
intermediate size up to a multiple of 256 for the `AITER_MXFP4_MXFP4` (W4A4) backend, but the
aiter kernels on that path only require 128. For MiniMax-M3-MXFP4 at TP8 the native
per-partition size is `3072 / 8 = 384`, so rounding to 256 allocates 512 and a third of every
expert's intermediate dimension is zero padding that is still loaded, still multiplied and still
reduced over. Rounding to 128 allocates the exact 384: 25 % smaller expert weights and +4.26 %
output throughput.

The change is one `elif` branch in `vllm/model_executor/layers/fused_moe/oracle/mxfp4.py` that
relaxes `intermediate_size` to `round_up(..., 128)` for that backend. `hidden_size` stays on 256,
because the gfx950 stage-1 mxfp4 kernels are generated with `tile_k = 256` only. Everything
downstream of the allocation — `intermediate_pad`, the scale buffer sizing in
`quark_moe.py::create_weights`, `routed_experts.py`'s `maybe_roundup_sizes` — already follows it
correctly at 384.

**Dependency.** aiter's CK-Tile 2-stage MXFP4 stage-2 kernel mis-indexes its E8M0 weight scales
when `inter_dim % 256 != 0`: the host pads the scale group dimension up to a multiple of 8 groups
(8 x 32 = 256 elements) and the kernel's indexing does not account for it. That is the
decode-sized dispatch, so a 384-wide intermediate prefills correctly and decodes garbage.
ROCm/aiter#5232 routes those shapes to the FlyDSL a16w4 kernels, which are correct at any
128-aligned intermediate size. Defect report: ROCm/aiter#5233.

## Test Plan

* `tests/kernels/moe/test_ocp_mx_moe.py::test_rocm_mxfp4_round_up_hidden_and_intermediate` — a
  12-row table over the ROCm arm of the function, pinning both the W4A4 rows this change is for
  and the neighbouring branches. Needs no GPU and no aiter.
* End to end on MiniMax-M3-MXFP4, TP8, MI355X, `--moe-backend aiter --attention-backend
  TRITON_ATTN`, fp8 KV cache: throughput via `vllm bench serve` (random, ISL 8192 / OSL 1024,
  concurrency 64), quality via teacher-forced perplexity over 48 texts paired per text, with a
  second control session for the restart-drift baseline. Both arms run from one build behind an
  env switch, with a log line reporting the shape the oracle actually allocated.
* GLM-5.2-MXFP4 (256 per partition at TP8, already aligned) as a control, where the change should
  be a no-op.

## Test Result

All 12 unit cases pass. Reverting the oracle hunk fails exactly the rows whose expected value it
produces, and the already-aligned rows pass in both arms.

MiniMax-M3, 2x2 paired runs: **+4.26 %** output throughput (2754.25 -> 2871.67 tok/s), entirely
decode-side (TPOT 21.10 -> 20.15 ms, TTFT unchanged), against a within-arm spread of 0.81 %.
Clean-corpus perplexity moves -0.11 % where a control-vs-control restart drifts -0.08 %
(n = 48, paired, |t| < 0.5), so it is indistinguishable from a restart.

GLM-5.2 is a no-op as predicted: both arms allocate `intermediate 256->256`, the aiter
heuristic-fallback count is 112 in all six runs, and the -0.63 % throughput delta sits inside a
1.35 % within-arm spread.

Without ROCm/aiter#5232 the same A/B gives clean-corpus perplexity 10.936 -> 41.325 (t = +43.8,
0 of 48 texts better) and degenerate greedy completions.

Measured on a vLLM 0.28.0 install with the patch applied rather than a `main` checkout, against
aiter 0.1.19. gfx950 only; no EP or interleaved-layout configuration was tested.
