### PR TITLE
[Bugfix] Account for PCP in multi-node world size validation

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -464,6 +464,25 @@ def test_attention_config():
         engine_args.create_engine_config()
 
 
+def test_multi_node_world_size_includes_pcp(monkeypatch):
+    """PCP expands the process world size, so the --nnodes divisibility check
+    must include it. Without this, TP=1/PCP=2 over 2 nodes computes a world
+    size of 1 and the launch is rejected before the engine starts."""
+    import vllm.config.vllm
+
+    # PCP requires the V2 model runner, which is gated on Triton.
+    monkeypatch.setattr(vllm.config.vllm, "HAS_TRITON", True)
+
+    engine_args = EngineArgs(
+        model="facebook/opt-125m",
+        tensor_parallel_size=1,
+        prefill_context_parallel_size=2,
+        nnodes=2,
+    )
+    vllm_config = engine_args.create_engine_config()
+    assert vllm_config.parallel_config.world_size == 2
+
+
 def test_prefix_cache_default():
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
     args = parser.parse_args([])

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2125,17 +2125,21 @@ class EngineArgs:
                 self.data_parallel_size
                 * self.pipeline_parallel_size
                 * self.tensor_parallel_size
+                * self.prefill_context_parallel_size
             )
             world_size_within_dp = (
-                self.pipeline_parallel_size * self.tensor_parallel_size
+                self.pipeline_parallel_size
+                * self.tensor_parallel_size
+                * self.prefill_context_parallel_size
             )
             if world_size % self.nnodes != 0:
                 raise ValueError(
                     "Invalid data-parallel launch options: "
                     f"`--nnodes {self.nnodes}` must evenly divide the total "
                     f"world size ({world_size}). Adjust `--nnodes`, "
-                    "`--data-parallel-size`, `--pipeline-parallel-size`, or "
-                    "`--tensor-parallel-size`."
+                    "`--data-parallel-size`, `--pipeline-parallel-size`, "
+                    "`--tensor-parallel-size`, or "
+                    "`--prefill-context-parallel-size`."
                 )
             if not 0 <= self.node_rank < self.nnodes:
                 raise ValueError(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2121,25 +2121,19 @@ class EngineArgs:
             )
         inferred_data_parallel_rank = 0
         if self.nnodes > 1:
-            world_size = (
-                self.data_parallel_size
-                * self.pipeline_parallel_size
-                * self.tensor_parallel_size
-                * self.prefill_context_parallel_size
-            )
             world_size_within_dp = (
                 self.pipeline_parallel_size
                 * self.tensor_parallel_size
                 * self.prefill_context_parallel_size
             )
+            world_size = self.data_parallel_size * world_size_within_dp
             if world_size % self.nnodes != 0:
                 raise ValueError(
                     "Invalid data-parallel launch options: "
                     f"`--nnodes {self.nnodes}` must evenly divide the total "
                     f"world size ({world_size}). Adjust `--nnodes`, "
                     "`--data-parallel-size`, `--pipeline-parallel-size`, "
-                    "`--tensor-parallel-size`, or "
-                    "`--prefill-context-parallel-size`."
+                    "`--tensor-parallel-size`, or `--prefill-context-parallel-size`."
                 )
             if not 0 <= self.node_rank < self.nnodes:
                 raise ValueError(


### PR DESCRIPTION
## Purpose

`EngineArgs.create_engine_config` recomputes the world size for the `--nnodes` divisibility check, but omits `prefill_context_parallel_size`:

```python
world_size = (
    self.data_parallel_size
    * self.pipeline_parallel_size
    * self.tensor_parallel_size
)
```

`ParallelConfig.world_size` already multiplies in PCP, so this local recomputation disagrees with the authoritative value.

With `TP=1 / PP=1 / PCP=2` across 2 nodes, the check computes `world_size = 1`, and `1 % 2 != 0` aborts the launch before the engine starts:

```
ValueError: Invalid data-parallel launch options: `--nnodes 2` must evenly
divide the total world size (1). Adjust `--nnodes`, `--data-parallel-size`,
`--pipeline-parallel-size`, or `--tensor-parallel-size`.
```

There is no way to work around this from the CLI: raising TP or PP to satisfy the check would change the parallelism layout that was actually requested.

This PR multiplies PCP into both `world_size` and `world_size_within_dp`, and adds `--prefill-context-parallel-size` to the error message since it now contributes to the total.

## Not a duplicate

Searched open and closed PRs for overlapping work:

- #51490 — *Fix DCP max-size check to account for PCP-induced KV duplication*: also a PCP validation fix, but targets the DCP max-size check in the KV cache path, not the `--nnodes` world size computation.
- #33207 — *[WIP] PCP simplification*: draft, no activity on this code path.
- #53743 — *Fix ZeroDivisionError with external LB when DP size exceeds node count*: touches the same `nnodes` block but fixes a DP/external-LB division issue; orthogonal to the missing PCP factor.

No open PR or issue covers the PCP factor missing from the multi-node world size check.

## Test Plan

```bash
pytest tests/engine/test_arg_utils.py -k multi_node_world_size -v
pytest tests/engine/test_arg_utils.py
```

The new test constructs the failing configuration (`TP=1`, `PCP=2`, `nnodes=2`) and asserts the resulting `parallel_config.world_size == 2`. It monkeypatches `HAS_TRITON` because PCP requires the V2 model runner, which is gated on Triton availability.

To confirm the test actually guards the bug, revert the `arg_utils.py` hunk and re-run — it fails with the exact `world size (1)` error above.

## Test Result

```
$ pytest tests/engine/test_arg_utils.py -k multi_node_world_size -v
platform darwin -- Python 3.10.11, pytest-9.1.1, pluggy-1.6.0
configfile: pyproject.toml
tests/engine/test_arg_utils.py::test_multi_node_world_size_includes_pcp PASSED [100%]
================ 1 passed, 97 deselected, 14 warnings in 3.19s =================

$ pytest tests/engine/test_arg_utils.py
======================= 98 passed, 14 warnings in 20.45s =======================
```

Reverting the `arg_utils.py` hunk and re-running the new test reproduces the
reported failure, confirming the test guards the fix:

```
E  ValueError: Invalid data-parallel launch options: `--nnodes 2` must evenly
   divide the total world size (1). Adjust `--nnodes`, `--data-parallel-size`,
   `--pipeline-parallel-size`, or `--tensor-parallel-size`.
```

Lint (`ruff==0.14.0`, matching `.pre-commit-config.yaml`):

```
$ ruff check vllm/engine/arg_utils.py tests/engine/test_arg_utils.py
All checks passed!
$ ruff format --diff vllm/engine/arg_utils.py tests/engine/test_arg_utils.py
2 files already formatted
```

## Model evaluation

Not applicable. This change only affects launch-time argument validation in `EngineArgs.create_engine_config`. It does not touch model execution, sampling, or KV cache behaviour, and cannot alter model output for any configuration that already starts successfully. Configurations that previously started are unaffected: with `PCP=1` (the default) both expressions are numerically unchanged.

## Real-world validation

The equivalent change was verified on a multi-node prefill/decode-disaggregated deployment whose prefill role runs with `TP=1` and `PCP=2` across 2 nodes. The role fails to start without the fix and comes up cleanly with it.

## AI assistance disclosure

This change was developed with AI assistance (Claude Code). The submitter reviewed every changed line, ran the tests listed above locally, and can defend the change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
