### PR TITLE
[Bugfix][Core] Copy every overlaid KV view in copy_kv_cache_blocks_inplace

### DIFF
--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -318,3 +318,47 @@ def test_copy_kv_cache_blocks_with_virtual_block_splitting(
             torch.testing.assert_close(
                 cache[dst_start + physical_idx], expected[layer_idx][physical_idx]
             )
+
+
+def test_copy_kv_cache_blocks_overlaid_views_copy_whole_block():
+    """Hybrid overlays: a Mamba state view and an attention view of one tensor
+    share a base address but span different bytes per block, and several such
+    tensors live in one allocation (so the whole-storage fast path is off).
+    The copy must cover the attention span even though the narrow Mamba view
+    is encountered first; otherwise the pages past the Mamba state size in
+    the destination block keep whatever they held before."""
+    num_blocks = 4
+    num_tensors = 2
+    block_stride = 64  # bytes per scheduler block in every tensor
+    state_bytes = 24  # Mamba state occupies only the leading bytes of a block
+    tensor_bytes = num_blocks * block_stride
+    raw = torch.arange(num_tensors * tensor_bytes, dtype=torch.int32).to(torch.uint8)
+    storage = raw.untyped_storage()
+
+    caches: list[torch.Tensor] = []
+    for tensor_idx in range(num_tensors):
+        base = tensor_idx * tensor_bytes
+        mamba = torch.empty(0, dtype=torch.int8)
+        mamba.set_(storage)
+        mamba = mamba.as_strided(
+            (num_blocks, 1, 1, state_bytes), (block_stride, 1, 1, 1), base
+        )
+        # 2 kernel pages of 8 int16 per scheduler block cover the whole block.
+        attn = torch.empty(0, dtype=torch.int16)
+        attn.set_(storage)
+        attn = attn.as_strided((num_blocks * 2, 1, 8, 2), (16, 16, 2, 1), base // 2)
+        assert mamba.data_ptr() == attn.data_ptr()
+        caches += [mamba, attn]
+
+    expected = raw.view(num_tensors, num_blocks, block_stride).clone()
+    expected[:, 2] = expected[:, 0]
+
+    copy_kv_cache_blocks_inplace(
+        caches,
+        num_blocks,
+        [KVCacheBlockCopy(src_block_id=0, dst_block_id=2)],
+    )
+
+    torch.testing.assert_close(
+        raw.view(num_tensors, num_blocks, block_stride), expected
+    )

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -659,12 +659,22 @@ def copy_kv_cache_blocks_inplace(
 
     indices_np = np.array(kv_cache_block_copies, dtype=np.int64)
     indices: torch.Tensor | None = None
-    seen: set[tuple[torch.device, int]] = set()
+    seen: set[tuple[Any, ...]] = set()
     copied_storages: set[tuple[torch.device, int]] = set()
     for cache in kv_caches:
         # Layers sharing KV (cross-layer sharing) alias the same view; copy it
-        # once. data_ptr distinguishes per-layer views of a shared allocation.
-        key = (cache.device, cache.data_ptr())
+        # once. Hybrid models overlay layers of different kinds on one tensor,
+        # so views at the same address can differ in geometry (a Mamba state
+        # view spans only the leading bytes of a block that an attention view
+        # spans in full); each geometry must be copied, so the key covers the
+        # view's shape and strides and not just its address.
+        key = (
+            cache.device,
+            cache.data_ptr(),
+            tuple(cache.shape),
+            tuple(cache.stride()),
+            cache.element_size(),
+        )
         if key in seen:
             continue
         seen.add(key)


### PR DESCRIPTION
## Purpose

`copy_kv_cache_blocks_inplace` (the CoW copy for partial prefix-cache hits) skips a KV cache view when another view with the same `data_ptr` has already been copied. That is right for cross-layer KV sharing (identical aliased views) but wrong for hybrid models: the KV cache config puts one layer of each KV cache group on the same tensor, so a Mamba state view and an attention view share a base address while spanning different bytes per block, and whichever view comes first in layer order decides how many bytes of a block get copied.

For Kimi-K3 (3 KDA groups + 1 MLA group, block_size 5760, kernel page 64) the KDA view `(num_blocks, 1, 1, 814080)` int8 comes first, so the MLA view `(num_blocks*90, 1, 64, 576)` bf16 of the same tensor is skipped and an MLA block copy moves only 814080 of its 6635520 bytes, i.e. the first 706 of 5760 token slots. The whole-storage fast path would hide this, but it is not taken when several tensors live in one allocation.

Observed effect (het-TP PD, TP8 prefill -> TP1 decode, `--prefix-match-unit 128`, GSM8K 5-shot): every prompt's prefill stops at its last 128-token boundary `B` (Mamba align mode caches the state there); on the small-KV prefill engine the request is then preempted and resumes with a local partial prefix-cache hit on its own boundary entry, which redirects every group's block through this CoW copy (any new request with a partial hit takes the same path). The block the request continues in and ships to decode reads `slots [0,707) valid | [707,B) zero | [B,N-1) valid`. Accuracy dropped to 0.72 with a 128-token sawtooth (about 0.2 right after a boundary, 0.95 late in a chunk), only for `B >= 768`, deterministic per prompt and independent of the KDA kernel. Decode-local prefill on TP1 was unaffected because its per-block Mamba state is 8x larger (5653 slots), which is why the problem only showed up with a high-TP prefill engine.

## Fix

Key the dedup on `(device, data_ptr, shape, stride, element_size)`, so only identical aliased views are skipped and every overlaid geometry is copied. Overlaid views copy the same source block, so the extra narrow copy is redundant but harmless.

## Test Plan

- New `tests/v1/worker/test_attn_utils.py::test_copy_kv_cache_blocks_overlaid_views_copy_whole_block`: two tensors in one storage, each with a narrow Mamba view listed before a wide attention view at the same address. Fails before the fix (only the first 24 of 64 bytes of the block are copied), passes after.
- `pytest tests/v1/worker/test_attn_utils.py`: 16 passed.
- E2E: Kimi-K3 het-TP PD (TP8 prefill, TP1/DP16 decode, NIXL + Mooncake Store), GSM8K 5-shot, 1319 prompts:

  | | before fix | with fix |
  |---|---|---|
  | exact_match (strict) | 0.7218 / 0.7286 (two runs) | **0.9682** |
  | decode-side MLA page scans with interior all-zero pages | 344 of 347 requests with B >= 768 | 0 of 31656 scans |

  (Second pass of the same run pending; decode-only baseline for this model is ~0.964.)

## Notes

- No open PR touches `copy_kv_cache_blocks_inplace` (searched `copy_kv_cache_blocks_inplace`, `kv_cache_block_copies`, `CoW block copy hybrid`).
- AI-assisted (Claude Code); the analysis, fix and test were reviewed line by line and the tests above were run by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hMcjaJa8vC9zEZeipxDfd
