### PR TITLE
[Bugfix][KV Connector] Cap MooncakeStore lookup at num_tokens - 1

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -1393,3 +1393,94 @@ def test_worker_metadata_aggregates_completions_across_ranks():
         MooncakeStoreWorkerMetadata(completed_saves={1: 1, 2: 1})
     )
     assert merged.completed_saves == {1: 2, 2: 1}
+
+
+def test_full_prompt_lookup_capped_at_num_tokens_minus_one():
+    # The last prompt token must be recomputed locally to obtain logits,
+    # so a lookup reporting the full prompt length must be capped at
+    # num_tokens - 1 (the same idiom applied by example, hf3fs, lmcache v1
+    # adapter, moriio-READ, decode_bench). Without this cap a sync load
+    # (`load_async=False`) forces num_new_tokens == 0 in the scheduler
+    # and trips `assert num_new_tokens > 0` at scheduler.py:923.
+    scheduler = _make_bare_scheduler()
+    scheduler.load_async = False
+    scheduler.client = _StubLookupClient(hit_tokens=32)
+
+    request = SimpleNamespace(
+        request_id="req-0",
+        num_tokens=32,
+        block_hashes=[b"h0", b"h1"],
+    )
+
+    need_to_allocate, load_async = scheduler.get_num_new_matched_tokens(
+        request, num_computed_tokens=0
+    )
+
+    assert need_to_allocate == 31, (
+        f"expected 31 after num_tokens-1 cap, got {need_to_allocate}"
+    )
+    assert load_async is False
+    load_spec = scheduler.load_specs["req-0"]
+    # Round-trip consistent: the connector cached the same capped value
+    # it returned. update_state_after_alloc validates the scheduler
+    # passes num_external_tokens == kvpool_cached_tokens - vllm_cached
+    # unchanged; when the connector itself applies the cap, this holds.
+    assert load_spec.vllm_cached_tokens == 0
+    assert load_spec.kvpool_cached_tokens == 31
+
+
+def test_full_prompt_lookup_does_not_crash_scheduler(monkeypatch):
+    # Reproduces the assert num_new_tokens > 0 crash at scheduler.py:923
+    # driven end-to-end through the real Scheduler via the real
+    # MooncakeStoreConnector scheduler side (no mocks of the CUT; only
+    # the ZMQ boundary is mocked, per AGENTS.md allowed mocks). Verifies
+    # the connector-side cap from get_num_new_matched_tokens flows
+    # through update_state_after_alloc round-trip-consistent.
+    # Patch at the boundary only: the ZMQ context open so the client is
+    # buildable without a server, and the lookup call returns the full
+    # prompt length to drive the overshoot path. monkeypatch auto-stops.
+    from unittest.mock import MagicMock
+
+    from tests.v1.core.utils import create_requests, create_scheduler
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
+        worker as store_worker,
+    )
+
+    monkeypatch.setattr(store_worker.zmq, "Context", MagicMock)
+
+    def fake_lookup(self, req_id, num_tokens, block_hashes, non_block=False):
+        # Lookup claims the entire prompt is in the remote store.
+        return MooncakeLookupResult(num_tokens)
+
+    monkeypatch.setattr(store_worker.LookupKeyClient, "lookup", fake_lookup)
+
+    scheduler = create_scheduler(
+        use_kv_connector="MooncakeStoreConnector",
+        kv_role="kv_consumer",
+        enable_prefix_caching=True,
+        block_size=16,
+    )
+    # Force the production-reachable sync config: load_async=False.
+    scheduler.connector.connector_scheduler.load_async = False
+
+    request = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        max_tokens=16,
+        same_prompt=False,
+        req_ids=["r1"],
+    )[0]
+    scheduler.add_request(request)
+
+    out = scheduler.schedule()
+    # Exactly one local token is scheduled: the last prompt token that
+    # must be recomputed for logits; the other 31 are covered by the
+    # connector-supplied external hit (capped from the raw 32).
+    assert out.num_scheduled_tokens[request.request_id] == 1, (
+        f"expected 1 local scheduled token, got "
+        f"{out.num_scheduled_tokens.get(request.request_id)}"
+    )
+    assert request.num_computed_tokens == 32, (
+        f"expected full prompt counted as computed (31 external + 1 local), "
+        f"got {request.num_computed_tokens}"
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -139,6 +139,16 @@ class MooncakeStoreScheduler:
             return None, False
         num_external_hit_tokens = lookup_result.hit_length
 
+        # Cap at num_tokens - 1: the last prompt token must be recomputed
+        # locally for logits, matching the idiom applied by example, hf3fs,
+        # lmcache v1, moriio-READ and the local get_computed_blocks. Without
+        # this, a sync (`load_async=False`) lookup covering the full prompt
+        # drives num_new_tokens==0 in the scheduler and trips
+        # assert num_new_tokens > 0 (scheduler.py:923).
+        num_external_hit_tokens = min(
+            num_external_hit_tokens, max(request.num_tokens - 1, 0)
+        )
+
         if num_external_hit_tokens < num_computed_tokens:
             need_to_allocate = 0
         else:


### PR DESCRIPTION
---
## Summary

Caps the MooncakeStore lookup result at `num_tokens - 1` inside `MooncakeStoreScheduler.get_num_new_matched_tokens`, so a lookup that reports the full prompt can no longer drive `num_new_tokens` to zero in `Scheduler.schedule()` and trip `assert num_new_tokens > 0` (`vllm/v1/core/sched/scheduler.py:923`) on the sync (`load_async=False`) path.

The cap is applied before both uses of the value, the returned `need_to_allocate` and the cached `load_specs.kvpool_cached_tokens`, so the round trip through the scheduler back into `update_state_after_alloc` (which asserts `num_external_tokens == kvpool_cached_tokens - vllm_cached_tokens`) stays consistent. No scheduler code is touched.

## Background

The last prompt token must always be recomputed locally to obtain logits. That rule is already enforced in three places: the local prefix cache lookup (`get_computed_blocks`), five in tree connectors (example, HF3FS, LMCache v1 adapter, MoRIIO READ, decode bench), and the MooncakeStore worker itself, which rederives a full hit below the request end (`worker.py:1854`). The MooncakeStore scheduler side component was the one place that passed the raw lookup count through uncapped.

One precision note for reviewers: through a matched pair of in tree server and scheduler components, the worker side rederivation keeps the lookup below N today. This change caps the scheduler side component itself, so the assert gated sync path no longer depends on server side behavior. The scheduler side receives its number over ZMQ from a server the base connector contract does not bound, and any server returning N (a third party implementation, a custom `LookupKeyServer`, or a future refactor) would crash `schedule()` without this guard.

## The fix

`vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py` (+10 lines): `min(num_external_hit_tokens, max(request.num_tokens - 1, 0))` immediately after the lookup resolves and before `need_to_allocate` and `load_specs` are derived. The cap is idempotent against values the worker already truncated, preserves the async flag, and leaves every below cap result byte for byte unchanged.

## Why this is not duplicating an existing PR

| Search | Result |
|---|---|
| Open PRs: "mooncake store cap", "MooncakeStore load_async=False" | Only #51358 (Mamba boundary state saves, unrelated) |
| Open PRs: "connector num_tokens - 1 cap" | None touching this method |
| #50864 (mine, scheduler side clamp for the same assert) | Closed in favor of this PR, per the review there that the fix belongs in the connector |

## Regression tests

Both tests fail with the fix stashed and pass with it applied.

| Test | What it proves |
|---|---|
| `test_full_prompt_lookup_capped_at_num_tokens_minus_one` | Connector side, existing `_StubLookupClient` pattern: lookup 32, computed 0, `num_tokens` 32 returns 31, async flag preserved, `load_specs` caches 31 |
| `test_full_prompt_lookup_does_not_crash_scheduler` | End to end through the real `Scheduler` and the real `MooncakeStoreConnector` scheduler side with only the ZMQ boundary stubbed and `load_async=False`: 32 token prompt schedules exactly 1 local token, `num_computed_tokens` reaches 32 (31 external + 1 local) |

## Test results (CPU only box, AMD 2 core)

```
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py -q -p no:cacheprovider
# 24 passed (22 pre-existing + 2 new)

.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py \
  tests/v1/kv_connector/unit/test_mooncake_store_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py \
  tests/v1/kv_connector/unit/test_mooncake_store_prepare_values.py -q -p no:cacheprovider
# 91 passed

.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake*.py -q -p no:cacheprovider
# 247 passed, 18 failed. The 18 are byte identical with and without this change (verified by stash flip on test names): pre-existing environment gaps (missing pytest-asyncio plugin, RDMA dependent worker paths).

.venv/bin/python -m ruff check <both touched files>   # All checks passed
.venv/bin/python -m ruff format --check <both files>  # already formatted
```

Additionally verified by direct calls: overshoot capped (32/32 to 31), sub cap values unchanged, `num_tokens=1` yields no phantom load, already truncated inputs pass through untouched (idempotent), and the async default path (`load_async=True`) still routes to `WAITING_FOR_REMOTE_KVS` as designed with consistent cached accounting.

## Limitations and what CI should cover

No GPU on this box, so no serving or accuracy evals were possible. The change is CPU pure accounting (`min` on a token count) and only alters behavior where the scheduler previously asserted, but GPU validation of the disaggregated prefill path is requested. mypy was skipped (times out past 120s on this machine; no new typing surface was added).

## AI assistance disclosure

Per repo policy this PR is AI assisted. A human submitter reviewed every changed line, ran the tests above locally, and takes responsibility for the change end to end.

Co-authored-by: Cline
