### PR TITLE
[Bugfix][Tool Parser] Make step3 streaming independent of delta boundaries

### DIFF
--- a/tests/tool_parsers/test_step3_tool_parser.py
+++ b/tests/tool_parsers/test_step3_tool_parser.py
@@ -2,13 +2,65 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.tokenizers import TokenizerLike, get_tokenizer
+from vllm.tool_parsers import ToolParserManager
+
+
+def _stream_in_deltas(
+    tokenizer: TokenizerLike, output: str, boundaries: list[tuple[int, int]]
+) -> tuple[str, list[tuple[str, str]]]:
+    """Stream `output` through a fresh parser, batching tokens as given.
+
+    Returns the reconstructed content and (name, arguments) of each tool call.
+    """
+    parser = ToolParserManager.get_tool_parser("step3")(tokenizer)
+    request = ChatCompletionRequest(messages=[], model="test")
+
+    token_ids = tokenizer.encode(output, add_special_tokens=False)
+    token_texts, decoded = [], ""
+    for i in range(1, len(token_ids) + 1):
+        current = tokenizer.decode(token_ids[:i])
+        token_texts.append(current[len(decoded) :])
+        decoded = current
+
+    previous_text = ""
+    previous_ids: list[int] = []
+    content = ""
+    calls: dict[int, dict[str, str]] = {}
+    for start, end in boundaries:
+        delta_text = "".join(token_texts[start:end])
+        delta_ids = token_ids[start:end]
+        current_text = previous_text + delta_text
+        current_ids = previous_ids + delta_ids
+
+        message = parser.extract_tool_calls_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_ids,
+            current_ids,
+            delta_ids,
+            request,
+        )
+        if message is not None:
+            content += message.content or ""
+            for tool_call in message.tool_calls or []:
+                call = calls.setdefault(tool_call.index, {"name": "", "arguments": ""})
+                call["name"] += tool_call.function.name or ""
+                call["arguments"] += tool_call.function.arguments or ""
+
+        previous_text, previous_ids = current_text, current_ids
+
+    return content, [(c["name"], c["arguments"]) for c in calls.values()]
 
 
 class TestStep3ToolParser(ToolParserTests):
@@ -110,3 +162,41 @@ class TestStep3ToolParser(ToolParserTests):
             },
             supports_typed_arguments=False,
         )
+
+    @pytest.mark.parametrize(
+        "output_attr", ["single_tool_call_output", "surrounding_text_output"]
+    )
+    def test_streaming_is_independent_of_delta_boundaries(
+        self,
+        test_config: ToolParserTestConfig,
+        tokenizer: TokenizerLike,
+        output_attr: str,
+    ):
+        """Streaming must not depend on how tokens are batched into deltas.
+
+        The name and the arguments used to be emitted from separate calls, so
+        a delta carrying a whole tool call yielded empty arguments, and a delta
+        carrying both leading text and a tool call yielded no tool call at all.
+        Multi-token deltas are normal in production (``--stream-interval``,
+        speculative decoding, scheduler batching).
+        """
+        output = getattr(test_config, output_attr)
+        num_tokens = len(tokenizer.encode(output, add_special_tokens=False))
+
+        baseline = _stream_in_deltas(
+            tokenizer, output, [(i, i + 1) for i in range(num_tokens)]
+        )
+        assert baseline[1] == [
+            (
+                test_config.single_tool_call_expected_name,
+                json.dumps(test_config.single_tool_call_expected_args),
+            )
+        ]
+
+        for split in range(1, num_tokens):
+            batched = _stream_in_deltas(
+                tokenizer, output, [(0, split), (split, num_tokens)]
+            )
+            assert batched == baseline, f"differs when split after token {split}"
+
+        assert _stream_in_deltas(tokenizer, output, [(0, num_tokens)]) == baseline

--- a/vllm/tool_parsers/step3_tool_parser.py
+++ b/vllm/tool_parsers/step3_tool_parser.py
@@ -78,6 +78,14 @@ class Step3ToolParser(ToolParser):
             params[name] = value.strip()
         return func_name, params
 
+    @staticmethod
+    def _partial_token_suffix_len(text: str, token: str) -> int:
+        """Length of the longest suffix of ``text`` that is a prefix of ``token``."""
+        for size in range(min(len(text), len(token) - 1), 0, -1):
+            if token.startswith(text[-size:]):
+                return size
+        return 0
+
     def _cast_arguments(
         self,
         func_name: str,
@@ -122,17 +130,25 @@ class Step3ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
+        # Everything found in this delta is accumulated instead of returned as
+        # soon as it is parsed: a delta may carry content and a whole tool call
+        # at once, and there is no guarantee another call will follow to emit
+        # the rest in.
+        pending_content = ""
+        delta_tool_calls: list[DeltaToolCall] = []
+
         # The main loop processes the stream from the last known position.
         while True:
             if self.position >= len(current_text):
-                return None  # We've processed the entire stream.
+                break  # We've processed the entire stream.
 
             unprocessed_text = current_text[self.position :]
 
             # STATE: After all tools are done, all subsequent text is content.
             if self.tool_block_finished:
                 self.position = len(current_text)
-                return DeltaMessage(content=unprocessed_text)
+                pending_content += unprocessed_text
+                continue
 
             # STATE: Before the tool block has started.
             if not self.tool_block_started:
@@ -143,17 +159,20 @@ class Step3ToolParser(ToolParser):
 
                 start_pos = unprocessed_text.find(self.TOOL_CALLS_BEGIN)
                 if start_pos == -1:
-                    if (
-                        self.TOOL_CALLS_BEGIN.startswith(unprocessed_text.strip())
-                        and unprocessed_text
-                    ):
-                        return None  # It's a prefix, wait.
-                    self.position = len(current_text)
-                    return DeltaMessage(content=unprocessed_text)
+                    # A trailing partial begin token must not be emitted as
+                    # content: hold it back until the rest of it arrives.
+                    partial = self._partial_token_suffix_len(
+                        unprocessed_text, self.TOOL_CALLS_BEGIN
+                    )
+                    content = unprocessed_text[: len(unprocessed_text) - partial]
+                    self.position += len(content)
+                    pending_content += content
+                    break
                 else:
                     content = unprocessed_text[:start_pos]
                     self.position += len(content)
-                    return DeltaMessage(content=content)
+                    pending_content += content
+                    continue
 
             # STATE: Inside the main tool block.
             offset = len(unprocessed_text) - len(unprocessed_text.lstrip())
@@ -184,7 +203,7 @@ class Step3ToolParser(ToolParser):
                     continue
 
                 if self.TOOL_CALL_BEGIN.startswith(unprocessed_text):
-                    return None
+                    break
 
             # STATE: Parsing an active tool call.
             if self.current_tool_id != -1 and not self.prev_tool_call_arr[
@@ -197,35 +216,25 @@ class Step3ToolParser(ToolParser):
                     tool_body = unprocessed_text[:end_tool_pos]
 
                 if end_tool_pos == -1 and self.TOOL_CALL_END.startswith(tool_body):
-                    return None
+                    break
 
                 function_name, arguments = self._parse_steptml_invoke(tool_body)
                 if not function_name:
-                    return None
+                    break
 
                 tool_call_arr = {"name": function_name, "parameters": arguments or {}}
-
-                # Send the function name as soon as it's parsed.
-                if not self.current_tool_name_sent:
-                    self.current_tool_name_sent = True
-                    self.prev_tool_call_arr[self.current_tool_id].update(tool_call_arr)
-                    return DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                type="function",
-                                id=f"chatcmpl-tool-{random_uuid()}",
-                                function=DeltaFunctionCall(name=function_name),
-                            )
-                        ]
-                    )
 
                 # Update our internal state with the latest parsed arguments.
                 self.prev_tool_call_arr[self.current_tool_id].update(  # noqa: E501
                     tool_call_arr
                 )
 
-                # Only send arguments when the tool call is complete.
+                send_name = not self.current_tool_name_sent
+
+                # Arguments are only sent once the tool call is complete, so
+                # they have to be able to go out with the name: a delta may
+                # carry the whole call and be the last one.
+                final_args_json = None
                 if end_tool_pos != -1:
                     self.position += end_tool_pos + len(self.TOOL_CALL_END)
                     self.prev_tool_call_arr[self.current_tool_id]["finished"] = True
@@ -236,21 +245,38 @@ class Step3ToolParser(ToolParser):
                     )
                     if final_args:
                         final_args_json = json.dumps(final_args, ensure_ascii=False)
-                        return DeltaMessage(
-                            tool_calls=[
-                                DeltaToolCall(
-                                    index=self.current_tool_id,
-                                    function=DeltaFunctionCall(
-                                        arguments=final_args_json
-                                    ),
-                                )
-                            ]
+
+                if send_name:
+                    self.current_tool_name_sent = True
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=self.current_tool_id,
+                            type="function",
+                            id=f"chatcmpl-tool-{random_uuid()}",
+                            function=DeltaFunctionCall(
+                                name=function_name, arguments=final_args_json
+                            ),
                         )
+                    )
+                elif final_args_json is not None:
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=self.current_tool_id,
+                            function=DeltaFunctionCall(arguments=final_args_json),
+                        )
+                    )
 
-                # If tool is not finished, return None to wait for more tokens.
-                return None
+                if end_tool_pos == -1:
+                    break  # Wait for the rest of the tool call.
+                continue
 
+            break
+
+        if not pending_content and not delta_tool_calls:
             return None
+        return DeltaMessage(
+            content=pending_content or None, tool_calls=delta_tool_calls
+        )
 
     def extract_tool_calls(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fixes #55082.

`extract_tool_calls_streaming` returns at most one `DeltaMessage` per call, but it returned as soon as it parsed anything. The branch that first sends the function name returned **without advancing `self.position`**, so the arguments were only emitted by a later call:

```python
# Send the function name as soon as it's parsed.
if not self.current_tool_name_sent:
    self.current_tool_name_sent = True
    self.prev_tool_call_arr[self.current_tool_id].update(tool_call_arr)
    return DeltaMessage(tool_calls=[...])   # position not advanced
```

When a single delta carried the invoke tag, the parameters and `<|tool_call_end|>`, there was no later call, so the client received a syntactically valid tool call with **empty arguments**, HTTP 200 and no error. A delta carrying leading text plus a tool call lost the tool call entirely.

Multi-token deltas are the normal case in production: `--stream-interval > 1`, speculative decoding and ordinary scheduler batching all produce them.

This PR:

1. Accumulates content and tool calls across the parse loop and emits them in a single message, so the name and the arguments can go out together.
2. Holds back a trailing partial `<|tool_calls_begin|>` token instead of flushing it as content. Consuming it desynced the parser, which then streamed the whole tool call as plain text. The previous `.strip()` prefix check only caught the case where the *entire* chunk was a prefix, which is why this only showed up with multi-token deltas.

**Not a duplicate.** No open PR references #55082. #49567 touches this file (whitespace in parameter values); the issue reporter applied it and re-ran the scan with an unchanged 27/64 result, so it does not address this.

**Out of scope:** step3's non-streaming path and parallel tool calls are separately broken (`<|tool_sep|>` is required by `extract_tool_calls` but absent from the fixtures, and is not consumed between calls when streaming). Those are the existing `xfail` markers in `tests/tool_parsers/test_step3_tool_parser.py`; this PR leaves them untouched and no marker changes status.

## Test Plan

Regression tests added to the existing suite, parametrized over both the single-tool-call and surrounding-text fixtures. Each asserts that streaming the output is identical for every two-delta split and for the whole-stream-in-one-delta case, compared against the one-token-per-delta baseline.

```bash
# New + existing step3 tests
pytest tests/tool_parsers/test_step3_tool_parser.py -q -rxX

# Regression sweep over every tool parser
pytest tests/tool_parsers/ -q

# Linting
pre-commit run --files vllm/tool_parsers/step3_tool_parser.py tests/tool_parsers/test_step3_tool_parser.py
pre-commit run --hook-stage manual mypy-3.12 --files vllm/tool_parsers/step3_tool_parser.py tests/tool_parsers/test_step3_tool_parser.py
```

## Test Result

Replaying the parser's own 65-token test sample and cutting it into two deltas at each of the 64 possible boundaries, using only the public parser API:

**Before**

```
1 token per delta      : [('get_weather', '{"city": "Tokyo"}')]
2 deltas, split after 1: [('get_weather', '')]
whole stream, 1 delta  : [('get_weather', '')]
27/64 two-delta splits differ: [1..27]
```

**After**

```
1 token per delta      : [('get_weather', '{"city": "Tokyo"}')]
2 deltas, split after 1: [('get_weather', '{"city": "Tokyo"}')]
whole stream, 1 delta  : [('get_weather', '{"city": "Tokyo"}')]
0/64 two-delta splits differ: []
```

Extending the scan to every 2-delta and 3-delta split across five fixtures (single call, parallel, empty arguments, surrounding text, no tool calls): **0 deviations from the per-token baseline**, down from 27 / 78 / 2275 respectively on the affected fixtures.

Both new tests fail on unmodified code (`differs when split after token 1`).

| Suite | Result |
| --- | --- |
| `test_step3_tool_parser.py` | 11 passed, 16 xfailed, **0 failed, 0 xpassed** |
| `tests/tool_parsers/` | 671 passed, 3 skipped, 68 xfailed, **0 failed** |

Linting: `ruff check`, `ruff format`, `typos`, `mypy-3.10`, `mypy-3.12`, SPDX, lazy-import, forbidden-import and config-validation hooks all pass.

**Environment caveat:** tests were run on Windows with a CPU-only PyTorch build. The suite reports additional teardown errors from `torch.accelerator.empty_cache()` (no accelerator available) and setup errors for gated HuggingFace repos; these are environmental, identical before and after this change, and none are assertion failures. Model evals were not run — step3 does not fit in the available VRAM. Relying on CI for GPU-backed validation, per the contributing guide.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>