### PR TITLE
[Bugfix][KV Offload] Don't pop a verified full-attn eagle prefix chunk

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -2761,8 +2761,8 @@ class TestEagle:
     # Lookup unit tests: call _lookup() directly via request_runner
     # -------------------------------------------------------------------
 
-    def test_full_attn_lookup_pops_one_block(self, request_runner):
-        """Full-attn eagle group with 3 blocks all hit → pop to 2 blocks."""
+    def test_full_attn_lookup_keeps_all_hits(self, request_runner):
+        """Full-attn eagle keeps every prefix hit (no SWA-style pop)."""
         block_size = 4
         groups = [
             KVCacheGroupSpec(
@@ -2791,11 +2791,11 @@ class TestEagle:
         req_status = self._make_req_status(
             sched, num_tokens=12, offload_keys_per_group=[[1, 2, 3]]
         )
-        # 3 hits, pop to 2 → 2 * block_size = 8 tokens loadable
-        assert sched._lookup(req_status) == 8
+        # 3 hits, no pop → 3 * block_size = 12 tokens loadable
+        assert sched._lookup(req_status) == 12
 
-    def test_full_attn_lookup_single_block_returns_zero(self, request_runner):
-        """Full-attn eagle group with 1 block hit → pop to 0 → returns 0."""
+    def test_full_attn_lookup_single_block_keeps_hit(self, request_runner):
+        """Full-attn eagle 1-chunk prefix stays a hit (the DRAM-read veto)."""
         block_size = 4
         groups = [
             KVCacheGroupSpec(
@@ -2824,8 +2824,9 @@ class TestEagle:
         req_status = self._make_req_status(
             sched, num_tokens=4, offload_keys_per_group=[[1]]
         )
-        # 1 hit, pop to 0 → new_num_hit_tokens < block_size → return 0
-        assert sched._lookup(req_status) == 0
+        # 1 verified prompt chunk must remain loadable. The old unconditional
+        # pop turned this into 0 and aborted the whole lookup.
+        assert sched._lookup(req_status) == 4
 
     def test_full_attn_lookup_no_hits_returns_zero(self, request_runner):
         """Full-attn eagle group with 0 hits returns 0 before pop."""
@@ -2995,12 +2996,11 @@ class TestEagle:
         assert sched._lookup(req_status) == 8
 
     def test_eagle_verified_prevents_double_pop(self, request_runner):
-        """Once an eagle group has popped, it doesn't pop again on re-iteration.
+        """Full-attn eagle does not pop, so mixed FA groups keep the prefix.
 
         Setup: group 0 = non-eagle full-attn (3 blocks), group 1 = eagle
-        full-attn (3 blocks). Both see all hits. Eagle pops to 2 and tightens
-        max_hit to 8. Group 0 re-runs (convergence) but since eagle_verified
-        contains group 1, it won't pop again — result stays at 8 tokens.
+        full-attn (3 blocks). Both see all hits. Without a SWA pop there is
+        nothing to tighten; result stays at 12 tokens.
         """
         block_size = 4
         groups = [
@@ -3043,19 +3043,16 @@ class TestEagle:
             offload_keys_per_group=[[1, 2, 3], [1, 2, 3]],
         )
         # Group 0: prefix finds 3 → max_hit=12, num_hit=12
-        # Group 1 (eagle): prefix finds 3, pop to 2 → max_hit=8, num_hit=8
-        # num_hit(8) < prev num_hit(12) AND group IS eagle → no clear
-        # No re-iteration triggered (eagle shrink doesn't trigger re-loop)
-        # Final: 8 tokens
-        assert sched._lookup(req_status) == 8
+        # Group 1 (eagle FA): prefix finds 3, no pop → 12
+        assert sched._lookup(req_status) == 12
 
     def test_non_eagle_tighten_clears_eagle_verified(self, request_runner):
-        """Non-eagle group tightening clears eagle_verified → eagle re-pops.
+        """Non-eagle tighten to 1 chunk; full-attn eagle keeps that chunk.
 
         Groups: 0=non-eagle full-attn, 1=eagle full-attn.
         Group 0 has only 1 hit (out of 3 keys) → max_hit tightens to 4.
         This clears eagle_verified. Group 1 runs with max_hit=4 → only 1
-        key queried, 1 hit, pop to 0 → returns 0.
+        key queried, 1 hit, kept (no SWA pop) → 4 tokens.
         """
         block_size = 4
         groups = [
@@ -3101,16 +3098,14 @@ class TestEagle:
         )
         # Group 0 (non-eagle FA): prefix finds 1 hit → max_hit=4, num_hit=4
         # Group 1 (eagle FA): max_hit=4 → num_blocks=1, keys=[1].
-        #   Finds 1 hit, pop to 0 → new_num_hit = 0 < block_size → return 0
-        assert sched._lookup(req_status) == 0
+        #   Finds 1 hit, no pop → 4 tokens (old pop vetoed the whole lookup)
+        assert sched._lookup(req_status) == 4
 
     def test_eagle_verified_survives_eagle_tighten(self, request_runner):
-        """Eagle group tightening does NOT clear eagle_verified.
+        """Full-attn eagle does not pop, so it does not tighten max_hit.
 
         Groups: 0=non-eagle full-attn, 1=eagle full-attn.
-        Group 0 finds 3 hits (max_hit=12). Group 1 finds 3 hits, pops to 2
-        (max_hit=8). Since group 1 IS eagle, eagle_verified is NOT cleared.
-        Result: 8 tokens (eagle only pops once).
+        Both find 3 hits. Without a SWA pop, max_hit stays 12.
         """
         block_size = 4
         groups = [
@@ -3153,9 +3148,8 @@ class TestEagle:
             offload_keys_per_group=[[1, 2, 3], [1, 2, 3]],
         )
         # Group 0: 3 hits → max_hit=12, num_hit=12
-        # Group 1 (eagle): 3 hits, pop to 2 → max_hit=8, num_hit=8
-        # Tightened but IS eagle → no clear. No re-iteration.
-        assert sched._lookup(req_status) == 8
+        # Group 1 (eagle FA): 3 hits, no pop → 12
+        assert sched._lookup(req_status) == 12
 
     # -------------------------------------------------------------------
     # Integration tests: store and load via request_runner

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -757,8 +757,8 @@ class OffloadingConnectorScheduler:
                     group_config.sliding_window_size_in_chunks
                 )
 
-                # For eagle groups, query one extra chunk that will be popped.
-                # We only need to increase the query size for sliding window groups.
+                # SWA eagle over-queries one extra chunk (popped below). Full-
+                # attention eagle is a PREFIX scan and must not over-query.
                 query_max = max_hit_size_tokens
                 if is_eagle_unverified and sliding_window_size_in_chunks is not None:
                     query_max = min(
@@ -797,7 +797,13 @@ class OffloadingConnectorScheduler:
                     defer_lookup = True
                 else:
                     if is_eagle_unverified:
-                        num_hit_chunks -= 1
+                        # Pair with the SWA-only over-query above. Full-attn
+                        # eagle never over-queries, and with offload_prompt_only
+                        # / store-side decode drop it never stores a volatile
+                        # tail — decrementing would drop a verified prompt
+                        # chunk and veto <=1-chunk prefixes (CPU→GPU stays 0).
+                        if sliding_window_size_in_chunks is not None:
+                            num_hit_chunks -= 1
                         eagle_verified.add(group_idx)
 
                     max_hit_size_tokens = min(


### PR DESCRIPTION
## Purpose

Fixes `OffloadingConnector` storing CPU KV but serving **0** hits when the eagle group is **full-attention** (prefix scan). The lookup pops one chunk from every unverified eagle group:

```python
if is_eagle_unverified:
    num_hit_chunks -= 1
```

The compensating over-query (`query_max += tokens_per_chunk`) is **SWA-only**. Full-attn eagle never over-queries, so the pop removes a *matched* prompt chunk. With a stored prefix of ≤ 1 chunk, `new_num_hit_tokens < tokens_per_chunk` then `return 0` aborts the **whole** request. `GPU_to_CPU` grows; `CPU_to_GPU` stays 0.

`offload_prompt_only` (default True) plus the store-side decode drop already omit the volatile full-attn tail. There is no extra chunk on the prefix path for the pop to eat.

## Fix

Gate the decrement on the same condition as the over-query:

```python
if is_eagle_unverified:
    if sliding_window_size_in_chunks is not None:
        num_hit_chunks -= 1
    eagle_verified.add(group_idx)
```

SWA eagle is unchanged (over-query + pop). Full-attn eagle keeps the verified prefix.

## Not a duplicate of #52771

[#52771](https://github.com/vllm-project/vllm/pull/52771) is the right fix for **unannotated shared-group MTP** (Qwen3.5/3.8: mark-every-group fallback + finish-time store hole). Its lookup hunk **widens every eagle group and keeps the pop**.

That does not cover this bug:

1. Widen is capped by `len(offload_keys)`. A 1-chunk stored FA prefix has no second key, so the extra query is a no-op and the pop still goes 1 → 0.
2. [#52669](https://github.com/vllm-project/vllm/pull/52669) / [#52674](https://github.com/vllm-project/vllm/pull/52674) already tried widen-only on this path and were closed; they did not restore reads.
3. #52771 explicitly treats DSpark draft-group AND-poison ([#47891](https://github.com/vllm-project/vllm/pull/47891) / [#48459](https://github.com/vllm-project/vllm/pull/48459)) as a different mechanism. This PR is the **annotated full-attn eagle pop** on that DSpark path, not the shared-group MTP fallback.

[#52807](https://github.com/vllm-project/vllm/pull/52807) originally dropped this pop (same polarity), then deferred the eagle half to #52771. This PR restores the SWA-only pop for the 1-chunk FA case widen cannot save.

If #52771 lands first, this rebases to: **only pop when the query was actually widened**. Composing the other way (widen FA *and* skip the pop) would keep a volatile extra chunk; we are not proposing that.

[#52047](https://github.com/vllm-project/vllm/pull/52047) (draft-group annotation) is already on `main` and is not this pop.

## Test Plan

`tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py`:

- full-attn eagle 3 hits stay 12 (no pop)
- full-attn eagle 1 hit stays 4 (the veto case; this is the 1-chunk prefix #52771's widen cannot save)
- existing SWA pop tests unchanged

`VLLM_TARGET_DEVICE=cpu pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py`

Production: Kimi-K3 DSpark + `SimpleCPUOffloadConnector`. Before: CPU→GPU = 0. After: c16 CPU hit ~60% under the same recipe.

*AI-assistance disclosure: developed with Cursor; every changed line reviewed by the submitter.*

Made with [Cursor](https://cursor.com)