### PR TITLE
[Feat] Add EPLB support for GLM-5.3-Flash

### DIFF
--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -725,12 +725,24 @@ class Glm5NextModel(nn.Module):
         if self.config.is_moe:
             # Params for weights, fp8 weight scales, fp8 activation scales
             # (param_name, weight_name, expert_id, shard_id)
+            # EPLB: the mapping enumerates physical experts, so it must cover
+            # the redundant replicas or their slots are never loaded.
+            num_redundant_experts = next(
+                (
+                    layer.mlp.n_redundant_experts
+                    for layer in self.layers
+                    if isinstance(layer, Glm5NextDecoderLayer)
+                    and isinstance(layer.mlp, Glm5NextMoE)
+                ),
+                0,
+            )
             expert_params_mapping = fused_moe_make_expert_params_mapping(
                 self,
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
                 ckpt_up_proj_name="up_proj",
                 num_experts=self.config.n_routed_experts,
+                num_redundant_experts=num_redundant_experts,
             )
         else:
             expert_params_mapping = []
@@ -818,28 +830,38 @@ class Glm5NextModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                for idx, (
+                is_expert_weight = False
+                for (
                     param_name,
                     weight_name,
                     expert_id,
                     expert_shard_id,
-                ) in enumerate(expert_params_mapping):
+                ) in expert_params_mapping:
                     if weight_name not in name:
                         continue
-                    name = name.replace(weight_name, param_name)
-                    if is_pp_missing_parameter(name, self):
+                    # A checkpoint expert may map to several physical replicas
+                    # under EPLB; keep `name` intact and try the next entry
+                    # when this physical expert is not local to the rank.
+                    is_expert_weight = True
+                    name_mapped = name.replace(weight_name, param_name)
+                    if is_pp_missing_parameter(name_mapped, self):
                         continue
-                    param = params_dict[name]
+                    param = params_dict[name_mapped]
                     weight_loader = param.weight_loader
-                    weight_loader(
+                    success = weight_loader(
                         param,
                         loaded_weight,
-                        name,
+                        name_mapped,
                         expert_id=expert_id,
                         shard_id=expert_shard_id,
+                        return_success=True,
                     )
-                    break
+                    if success:
+                        name = name_mapped
+                        break
                 else:
+                    if is_expert_weight:
+                        continue
                     # Skip loading extra bias for GPTQ models.
                     if (
                         name.endswith(".bias")

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -877,6 +877,24 @@ class Glm5NextForCausalLM(
         self.model = Glm5NextModel(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        self.moe_mlp_layers = [
+            layer.mlp
+            for layer in self.model.layers
+            if isinstance(layer, Glm5NextDecoderLayer)
+            and isinstance(layer.mlp, Glm5NextMoE)
+        ]
+        self.moe_layers = [mlp.experts for mlp in self.moe_mlp_layers]
+        self.num_moe_layers = len(self.moe_layers)
+        self.num_expert_groups = self.config.n_group
+        if not self.moe_mlp_layers:
+            raise RuntimeError("No Glm5NextMoE layer found in model.layers.")
+        example_moe = self.moe_mlp_layers[0]
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
         if get_pp_group().is_last_rank:
             self.lm_head = ParallelLMHead(
                 self.config.vocab_size,
@@ -889,6 +907,19 @@ class Glm5NextForCausalLM(
         self.logits_processor = LogitsProcessor(
             self.config.vocab_size, scale=self.config.logit_scale
         )
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_physical_experts = num_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -961,7 +992,7 @@ class Glm5NextForCausalLM(
     dummy_inputs=Glm4vDummyInputsBuilder,
 )
 class Glm5NextForConditionalGeneration(
-    Glm4vForConditionalGeneration, HasInnerState, IsHybrid
+    Glm4vForConditionalGeneration, HasInnerState, IsHybrid, MixtureOfExperts
 ):
     # The text model (KDA + dense-MLA + MoE) is a hybrid mamba model. The
     # multimodal wrapper must declare the same interfaces so vLLM treats it as
@@ -1036,9 +1067,31 @@ class Glm5NextForConditionalGeneration(
                 architectures=["Glm5NextForCausalLM"],
             )
 
+        self.moe_layers = self.language_model.moe_layers
+        self.num_moe_layers = self.language_model.num_moe_layers
+        self.num_expert_groups = self.language_model.num_expert_groups
+        self.num_logical_experts = self.language_model.num_logical_experts
+        self.num_physical_experts = self.language_model.num_physical_experts
+        self.num_local_physical_experts = self.language_model.num_local_physical_experts
+        self.num_routed_experts = self.language_model.num_routed_experts
+        self.num_shared_experts = self.language_model.num_shared_experts
+        self.num_redundant_experts = self.language_model.num_redundant_experts
+
         # Glm5NextForCausalLM does not implement make_empty_intermediate_tensors,
         # so pipeline parallelism is gated off (consistent with the text-only
         # model) and we intentionally do not alias it here.
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        self.language_model.update_physical_experts_metadata(
+            num_physical_experts, num_local_physical_experts
+        )
+        self.num_physical_experts = self.language_model.num_physical_experts
+        self.num_local_physical_experts = self.language_model.num_local_physical_experts
+        self.num_redundant_experts = self.language_model.num_redundant_experts
 
     def get_encoder_cudagraph_config(self):
         # This vision tower does not produce the absolute position embedding

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -899,24 +899,6 @@ class Glm5NextForCausalLM(
         self.model = Glm5NextModel(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
-        self.moe_mlp_layers = [
-            layer.mlp
-            for layer in self.model.layers
-            if isinstance(layer, Glm5NextDecoderLayer)
-            and isinstance(layer.mlp, Glm5NextMoE)
-        ]
-        self.moe_layers = [mlp.experts for mlp in self.moe_mlp_layers]
-        self.num_moe_layers = len(self.moe_layers)
-        self.num_expert_groups = self.config.n_group
-        if not self.moe_mlp_layers:
-            raise RuntimeError("No Glm5NextMoE layer found in model.layers.")
-        example_moe = self.moe_mlp_layers[0]
-        self.num_logical_experts = example_moe.n_logical_experts
-        self.num_physical_experts = example_moe.n_physical_experts
-        self.num_local_physical_experts = example_moe.n_local_physical_experts
-        self.num_routed_experts = example_moe.n_routed_experts
-        self.num_shared_experts = example_moe.n_shared_experts
-        self.num_redundant_experts = example_moe.n_redundant_experts
         if get_pp_group().is_last_rank:
             self.lm_head = ParallelLMHead(
                 self.config.vocab_size,
@@ -929,19 +911,6 @@ class Glm5NextForCausalLM(
         self.logits_processor = LogitsProcessor(
             self.config.vocab_size, scale=self.config.logit_scale
         )
-
-    def update_physical_experts_metadata(
-        self,
-        num_physical_experts: int,
-        num_local_physical_experts: int,
-    ) -> None:
-        assert self.num_local_physical_experts == num_local_physical_experts
-        self.num_physical_experts = num_physical_experts
-        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
-        for moe in self.moe_mlp_layers:
-            moe.n_physical_experts = num_physical_experts
-            moe.n_redundant_experts = self.num_redundant_experts
-            moe.experts.update_expert_map()
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -1089,31 +1058,46 @@ class Glm5NextForConditionalGeneration(
                 architectures=["Glm5NextForCausalLM"],
             )
 
-        self.moe_layers = self.language_model.moe_layers
-        self.num_moe_layers = self.language_model.num_moe_layers
-        self.num_expert_groups = self.language_model.num_expert_groups
-        self.num_logical_experts = self.language_model.num_logical_experts
-        self.num_physical_experts = self.language_model.num_physical_experts
-        self.num_local_physical_experts = self.language_model.num_local_physical_experts
-        self.num_routed_experts = self.language_model.num_routed_experts
-        self.num_shared_experts = self.language_model.num_shared_experts
-        self.num_redundant_experts = self.language_model.num_redundant_experts
+        self.set_moe_parameters()
 
         # Glm5NextForCausalLM does not implement make_empty_intermediate_tensors,
         # so pipeline parallelism is gated off (consistent with the text-only
         # model) and we intentionally do not alias it here.
+
+    def set_moe_parameters(self) -> None:
+        self.moe_mlp_layers = [
+            layer.mlp
+            for layer in self.language_model.model.layers
+            if isinstance(layer, Glm5NextDecoderLayer)
+            and isinstance(layer.mlp, Glm5NextMoE)
+        ]
+        self.moe_layers = [moe.experts for moe in self.moe_mlp_layers]
+        self.num_moe_layers = len(self.moe_layers)
+        if not self.num_moe_layers:
+            return
+        example_moe = self.moe_mlp_layers[0]
+        self.num_expert_groups = self.config.text_config.n_group
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
 
     def update_physical_experts_metadata(
         self,
         num_physical_experts: int,
         num_local_physical_experts: int,
     ) -> None:
-        self.language_model.update_physical_experts_metadata(
-            num_physical_experts, num_local_physical_experts
-        )
-        self.num_physical_experts = self.language_model.num_physical_experts
-        self.num_local_physical_experts = self.language_model.num_local_physical_experts
-        self.num_redundant_experts = self.language_model.num_redundant_experts
+        if not self.num_moe_layers:
+            return
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_physical_experts = num_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()
 
     def get_encoder_cudagraph_config(self):
         # This vision tower does not produce the absolute position embedding

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -303,6 +303,7 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.n_routed_experts,
+            num_redundant_experts=self.num_redundant_experts,
         )
 
         params_dict = dict(self.named_parameters())


### PR DESCRIPTION



## Purpose

## Test Plan
```
VLLM_ENGINE_READY_TIMEOUT_S=3600 vllm serve  /mnt/nvme/shared/models/ZhipuAI/GLM-5.3-Flash --tensor-parallel-size 4 --tool-call-parser glm47 --enable-auto-tool-choice --reasoning-parser glm45 --load-format instanttensor  -ep --no-enable-flashinfer-autotune --enable-eplb --eplb-config '{"window_size":100,"step_interval":100,"num_redundant_experts":8,"use_async":true}

```
## Test Result
before
```
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385] EngineCore failed to start.
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385] Traceback (most recent call last):
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/engine/core.py", line 1347, in run_engine_core
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     return func(*args, **kwargs)
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/engine/core.py", line 1104, in __init__
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     super().__init__(
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/engine/core.py", line 145, in __init__
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     kv_cache_config = self._initialize_kv_caches(vllm_config)
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     return func(*args, **kwargs)
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/engine/core.py", line 308, in _initialize_kv_caches
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     available_gpu_memory = self.model_executor.determine_available_memory()
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/executor/abstract.py", line 149, in determine_available_memory
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     return self.collective_rpc("determine_available_memory")
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/executor/multiproc_executor.py", line 448, in collective_rpc
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     return future if non_block else future.result()
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]                                     ^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/executor/multiproc_executor.py", line 99, in result
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     return super().result()
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]            ^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     return self.__get_result()
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     raise self._exception
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/executor/multiproc_executor.py", line 103, in _wait_for_response
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     response = self.aggregate(self.get_response())
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]                               ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]   File "/home/chauncey/vllm/vllm/v1/executor/multiproc_executor.py", line 437, in get_response
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385]     raise RuntimeError(
(EngineCore pid=174936) ERROR 09-03 17:06:47 [core.py:1385] RuntimeError: Worker failed with error 'EPLB requires expert_load_view != None', please check the stack trace above for the root cause

```
this pr
```
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /version, Methods: GET
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /health, Methods: GET
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /metrics, Methods: GET
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /tokenize, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /detokenize, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/models, Methods: GET
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /ping, Methods: GET
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /ping, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /invocations, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/chat/completions, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/responses, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/completions, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/messages, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /generative_scoring, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=702477) INFO 09-03 17:37:35 [launcher.py:70] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=702477) INFO:     Started server process [702477]
(APIServer pid=702477) INFO:     Waiting for application startup.
(APIServer pid=702477) INFO:     Application startup complete.
```

```
lm_eval run \ 
  --model local-completions \
  --model_args model=/mnt/nvme/shared/models/ZhipuAI/GLM-5.3-Flash,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=64,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size 1 \
  --gen_kwargs temperature=0 \
  --output_path /home/chauncey/vllm/downloads/glm5.3_flash_profile/gsm8k_lm_eval \
  --log_samples \
  --seed 12345

```

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9234|±  |0.0073|
|     |       |strict-match    |     5|exact_match|↑  |0.9234|±  |0.0073|

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

