### PR TITLE
[Bugfix][OpenAI] Aggregate cached tokens for multi-prompt completions

### DIFF
--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -295,8 +295,10 @@ class OpenAIServingCompletion(GenerateBaseServing):
         previous_num_tokens = [0] * num_choices * num_prompts
         has_echoed = [False] * num_choices * num_prompts
         num_prompt_tokens = [0] * num_prompts
-        num_cached_tokens = None
-        first_iteration = True
+        # ``merge_async_iterators`` interleaves outputs from each prompt, so
+        # cache statistics must be tracked per prompt rather than taken from
+        # the first result.
+        num_cached_tokens_by_prompt: list[int | None] = [None] * num_prompts
 
         stream_options = request.stream_options
         include_usage, include_continuous_usage = should_include_usage(
@@ -310,9 +312,8 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 prompt_token_ids = res.prompt_token_ids
                 prompt_logprobs = res.prompt_logprobs
 
-                if first_iteration:
-                    num_cached_tokens = res.num_cached_tokens
-                    first_iteration = False
+                if num_cached_tokens_by_prompt[prompt_idx] is None:
+                    num_cached_tokens_by_prompt[prompt_idx] = res.num_cached_tokens
 
                 prompt_text = res.prompt
                 if prompt_text is None:
@@ -448,9 +449,22 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 total_tokens=total_prompt_tokens + total_completion_tokens,
             )
 
-            if self.enable_prompt_tokens_details and num_cached_tokens is not None:
+            total_cached_tokens = (
+                sum(
+                    cached_tokens
+                    for cached_tokens in num_cached_tokens_by_prompt
+                    if cached_tokens is not None
+                )
+                if num_cached_tokens_by_prompt
+                and all(
+                    cached_tokens is not None
+                    for cached_tokens in num_cached_tokens_by_prompt
+                )
+                else None
+            )
+            if self.enable_prompt_tokens_details and total_cached_tokens is not None:
                 final_usage_info.prompt_tokens_details = PromptTokenUsageInfo(
-                    cached_tokens=num_cached_tokens
+                    cached_tokens=total_cached_tokens
                 )
 
             if include_usage:
@@ -516,6 +530,21 @@ class OpenAIServingCompletion(GenerateBaseServing):
         kv_transfer_params = None
         ec_transfer_params = None
         last_final_res = None
+        # The completion request may contain multiple prompts.  Each engine
+        # result reports cache hits for one prompt, so usage must aggregate all
+        # of them instead of using the last result only.
+        total_cached_tokens = (
+            sum(
+                final_res.num_cached_tokens
+                for final_res in final_res_batch
+                if final_res.num_cached_tokens is not None
+            )
+            if final_res_batch
+            and all(
+                final_res.num_cached_tokens is not None for final_res in final_res_batch
+            )
+            else None
+        )
         for final_res in final_res_batch:
             last_final_res = final_res
             prompt_token_ids = final_res.prompt_token_ids
@@ -603,13 +632,9 @@ class OpenAIServingCompletion(GenerateBaseServing):
             total_tokens=num_prompt_tokens + num_generated_tokens,
         )
 
-        if (
-            self.enable_prompt_tokens_details
-            and last_final_res
-            and last_final_res.num_cached_tokens is not None
-        ):
+        if self.enable_prompt_tokens_details and total_cached_tokens is not None:
             usage.prompt_tokens_details = PromptTokenUsageInfo(
-                cached_tokens=last_final_res.num_cached_tokens
+                cached_tokens=total_cached_tokens
             )
 
         request_metadata.final_usage_info = usage


### PR DESCRIPTION


## Purpose

Fix `usage.prompt_tokens_details.cached_tokens` for Completion API requests whose
`prompt` is a list of multiple prompts.

The production trigger chain is:

```text
Completion request with prompt=[p1, p2]
  -> OpenAIServingCompletion.generate()
  -> one engine_client.generate() per prompt
  -> merge_async_iterators() interleaves RequestOutput results
  -> completion_stream_generator() / request_output_to_completion_response()
  -> prompt_tokens_details.cached_tokens
```

Each prompt has a separate `RequestOutput` and cache-hit count. The existing serving
code reported only one output's count: the last result in non-streaming responses and
the first result yielded by the interleaved streaming generators. Consequently, the
value depended on prompt order and stream scheduling instead of describing the whole
API request.

This is a real, supported online API case. With `--enable-prefix-caching` and
`--enable-prompt-tokens-details`, a warmed multi-prompt request returns an incorrect
usage field while generated text and inference behavior remain correct. For example, in
the A100 experiment below, the two prompt-level cache counts were 176 and 256 (expected
432), while the parent revision returned 176 or 256 depending on order/mode.

This PR aggregates the value once per prompt in both response paths. It deliberately does
not multiply by `n`, because multiple choices share the same prompt. If any prompt has no
cache statistic, the field remains omitted, preserving the existing fail-closed behavior.

### Duplicate-work check

Searches of open vLLM pull requests for `cached_tokens`, Completion cache aggregation,
and prompt token details found no PR addressing this multi-prompt bug.

In particular,
[#52199](https://github.com/vllm-project/vllm/pull/52199) adds local/external hit
breakdowns, while this PR fixes aggregation for multiple Completion prompts. Other
matches concern disaggregated prefill or telemetry and do not change this path.

## Test Plan

### Automated tests

The added unit tests construct prompt-level `RequestOutput` objects and verify that
cache-hit counts of 2 and 5 aggregate to 7 for both non-streaming and streaming usage
chunks. A partial result containing `None` verifies that the request-level detail remains
omitted rather than reporting an incomplete sum.

```bash
.venv/bin/python -m pytest -q \
  tests/entrypoints/openai/completion/test_completion_error.py \
  -k 'prompt_tokens_details_sum_multiple_prompts'

.venv/bin/python -m pytest -q \
  tests/entrypoints/openai/completion/test_completion_error.py

.venv/bin/pre-commit run --files \
  vllm/entrypoints/openai/completion/serving.py \
  tests/entrypoints/openai/completion/test_completion_error.py

git diff --check
```

### Online reproduction

Run the parent revision and this change in separate fresh server processes with the same
model and options, then warm each prompt independently before sending a list-valued
request:

```bash
vllm serve Mistral-7B-Instruct-v0.2 \
  --max-model-len 1024 \
  --gpu-memory-utilization 0.70 \
  --enable-prefix-caching \
  --enable-prompt-tokens-details
```

For `prompt=[p1, p2]` and the reversed order, compare both non-streaming usage and the
final usage event from `stream=true` with `stream_options.include_usage=true`. The oracle
is the sum of the two warm single-prompt values. Also check a cold prompt, `n=2`, token-id
prompts, `echo`, `logprobs`, shared prefixes, and prefix caching disabled.

## Test Result

On an NVIDIA A100 with Mistral-7B-Instruct-v0.2, after warming two prompts:

| Request | Expected | Parent (`ad127d9a0f`) | This change |
| --- | ---: | ---: | ---: |
| Non-streaming `[p1, p2]` | 432 | 256 | 432 |
| Non-streaming `[p2, p1]` | 432 | 176 | 432 |
| Streaming `[p1, p2]` | 432 | 176 | 432 |
| Streaming `[p2, p1]` | 432 | 256 | 432 |

The prompt, completion, and total token counters were unchanged. Additional checks showed
that `n=2` reports the per-prompt sum once (not twice), and disabling prefix caching keeps
`cached_tokens` at 0. Requests with a missing cache statistic continue to omit the detail.

An additional online run on the current fix branch used `alpha` and `beta` prompts with
42 and 52 prompt tokens. Their independent warm cache hits were 32 and 48. The batched
request had 94 prompt tokens and returned `cached_tokens: 80` in both prompt orders and
in the final usage chunk for both streaming requests, matching `32 + 48`.

This is a serving/metadata correction; generated outputs and model quality are not
changed, so model evaluation is not applicable.

## AI-assisted contribution

This contribution was developed with AI assistance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and the distinct bug are stated.
- [x] The test plan includes exact commands and an online reproduction procedure.
- [x] The test results include before/after values and boundary checks.
- [x] No documentation update is required; this corrects an existing usage field.
</details>

