### PR TITLE
[Guard] Assert no prefill in FULL decode-cudagraph replay (#53051)

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1823,3 +1823,33 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+def _all_decoding_runner(
+    num_computed_tokens: list[int], num_prompt_tokens: list[int]
+) -> SimpleNamespace:
+    """Minimal stand-in for the ``self`` used by _is_all_decoding."""
+    return SimpleNamespace(
+        input_batch=SimpleNamespace(
+            num_computed_tokens_cpu=np.array(num_computed_tokens),
+            num_prompt_tokens=np.array(num_prompt_tokens),
+        )
+    )
+
+
+def test_is_all_decoding():
+    # All requests past their prompt: genuinely decoding.
+    decode = _all_decoding_runner([10, 12, 8], [8, 8, 8])
+    assert GPUModelRunner._is_all_decoding(decode, 3)
+    # computed == prompt is the boundary of "finished the prompt"; the next
+    # scheduled token is a generated one, so the request is decoding.
+    edge = _all_decoding_runner([8, 8], [8, 8])
+    assert GPUModelRunner._is_all_decoding(edge, 2)
+    # A fresh request that has computed no prompt token is a prefill.
+    prefill = _all_decoding_runner([0, 8], [8, 8])
+    assert not GPUModelRunner._is_all_decoding(prefill, 2)
+    # A shape-aliased prefill (computed < prompt) must not count as decoding;
+    # this is the case that previously slipped into a FULL decode replay
+    # (vllm-project/vllm#53051).
+    aliased = _all_decoding_runner([2, 2], [4, 4])
+    assert not GPUModelRunner._is_all_decoding(aliased, 2)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3989,6 +3989,23 @@ class GPUModelRunner(
             else force_uniform_decode
         )
 
+    def _is_all_decoding(self, num_reqs: int) -> bool:
+        """Whether every scheduled request has finished its prompt.
+
+        A request is decoding once ``num_computed_tokens >= num_prompt_tokens``
+        (it has computed all prompt tokens). This is the same predicate the
+        dispatch side uses to keep shape-aliased prefills out of uniform-decode
+        batches (vllm-project/vllm#53051); it is factored out so the replay-side
+        guard in ``execute_model`` can reuse it for the FULL cudagraph check.
+        """
+        input_batch = self.input_batch
+        return bool(
+            (
+                input_batch.num_computed_tokens_cpu[:num_reqs]
+                >= input_batch.num_prompt_tokens[:num_reqs]
+            ).all()
+        )
+
     def _allow_microbatching(
         self, num_reqs: int, num_scheduled_tokens_np: np.ndarray
     ) -> bool:
@@ -4420,6 +4437,27 @@ class GPUModelRunner(
                 if not isinstance(spec.kv_cache_spec, EncoderOnlyAttentionSpec)
             )
             pad_attn = cudagraph_mode == CUDAGraphMode.FULL
+
+            if pad_attn:
+                # Defense in depth for vllm-project/vllm#53051: a FULL decode
+                # cudagraph replay must never contain a prefill. Backends with
+                # persistent capture-time buffers (e.g. GDN) only refresh them
+                # in their num_prefills == 0 metadata branch, so a prefill that
+                # reaches a FULL replay would reuse stale indices and the
+                # null-block guards would silently drop the state writes. The
+                # dispatch-side fix rejects shape-aliased prefills; assert it
+                # still holds here so any regression fails loudly instead of
+                # corrupting output. This path is real forwards only (capture
+                # and warmup run through _dummy_run), so legitimate PIECEWISE
+                # prefill batches never reach this check.
+                assert self._is_all_decoding(num_reqs), (
+                    "A FULL cudagraph replay was dispatched for a batch that "
+                    "still contains prefill(s) "
+                    "(vllm-project/vllm#53051). This would silently reuse "
+                    "stale capture-time GDN state indices and drop prefill "
+                    "state writes. See the dispatch-side fix in "
+                    "_is_uniform_decode."
+                )
 
             if self.cache_config.mamba_cache_mode == "align":
                 # preprocess_mamba reads req_state.num_computed_tokens (CPU)


### PR DESCRIPTION
## What

Defense-in-depth guard for #53051 (the "second latent half" from @allenzz-dev's addendum): assert that a FULL decode-cudagraph replay never contains a prefill.

A FULL graph is only dispatched for uniform-decode batches (`CudagraphDispatcher` builds FULL keys exclusively with `uniform=True` descriptors). For backends with persistent capture-time buffers (e.g. GDN), `GDNAttentionMetadataBuilder.build()` refreshes those buffers only in the `num_prefills == 0` branch, so a prefill reaching a FULL replay would reuse stale capture-time state indices and the null-block guards would silently drop the prefill state writes, producing garbage output. This guard turns that into an immediate, debuggable assertion on the real replay path (`execute_model`, where the dispatch has already chosen FULL).

The check is a no-op on the correct path: FULL ⇒ uniform decode ⇒ every request is past its prompt. It complements the dispatch-side fix in `_is_uniform_decode` (#53059) and holds regardless of whether that lands.

## Why this is not a duplicate

- #53059 fixes the **dispatch side** (shape-aliased prefills no longer classified as uniform decode). This adds the **replay-side** assertion it does not include — the one explicitly requested in the issue's addendum ("add a builder- or replay-side guard").
- #51508 fixes a different mechanism (stale `num_accepted_tokens=0` → index -1 under async scheduling), not the prefill-into-FULL path.
- #54361 covers the breakable-cudagraph path, not standard FULL_AND_PIECEWISE dispatch.

## Tests

- `ruff check` + `ruff format --check` on the changed files: pass.
- New unit test `tests/v1/worker/test_gpu_model_runner.py::test_is_all_decoding` (all-decode / boundary `computed == prompt` / fresh prefill / shape-aliased prefill cases), following the existing stub-based pattern in that file.
- Verified the guard's placement structurally: `cudagraph_keys[FULL]` is only populated with `uniform=True` batch descriptors, so `cudagraph_mode == FULL` in `execute_model` is reachable only for uniform-decode batches; capture/warmup run through `_dummy_run` and never reach this code.
- Not run locally: full pytest / GPU e2e (no GPU and no compiled `vllm._C` on the dev box) — left to CI.

## Model eval

No model-eval results included: this change adds an invariant guard on the replay path and does not alter model output, accuracy, or serving behavior when the batch is a legitimate uniform decode.

## AI assistance

AI assistance was used for source tracing and drafting.
