### PR TITLE
[Bugfix] Validate token budget after disabling chunked prefill

### DIFF
--- a/tests/v1/engine/test_engine_core_init.py
+++ b/tests/v1/engine/test_engine_core_init.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.config import SchedulerConfig
+from vllm.v1.engine.core import EngineCore
+
+
+def test_non_causal_attention_revalidates_scheduler_token_budget():
+    max_model_len = 4096
+    vllm_config = MagicMock()
+    vllm_config.model_config.max_model_len = max_model_len
+    vllm_config.scheduler_config = SchedulerConfig(
+        max_num_seqs=16,
+        max_num_batched_tokens=2048,
+        max_model_len=max_model_len,
+        enable_chunked_prefill=True,
+        is_encoder_decoder=False,
+    )
+    vllm_config.cache_config.enable_prefix_caching = True
+
+    engine_core = object.__new__(EngineCore)
+    engine_core.model_executor = MagicMock()
+    engine_core.model_executor.get_kv_cache_specs.return_value = [
+        {"non_causal_layer": SimpleNamespace(non_causal=True)}
+    ]
+
+    with (
+        patch("vllm.v1.engine.core.register_all_kvcache_specs"),
+        pytest.raises(
+            ValueError,
+            match=r"max_num_batched_tokens \(2048\).*max_model_len \(4096\)",
+        ),
+    ):
+        engine_core._initialize_kv_caches(vllm_config)
+
+    assert not vllm_config.scheduler_config.enable_chunked_prefill
+    assert not vllm_config.cache_config.enable_prefix_caching

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -282,6 +282,14 @@ class EngineCore:
                 )
                 vllm_config.cache_config.enable_prefix_caching = False
 
+            # SchedulerConfig validates this constraint while chunked prefill is
+            # still enabled. Revalidate after disabling it so prompts larger
+            # than the scheduling budget are rejected at startup instead of
+            # waiting indefinitely in the scheduler.
+            vllm_config.scheduler_config.verify_max_model_len(
+                vllm_config.model_config.max_model_len
+            )
+
         # Resolve the KV cache layout before memory profiling: workers that
         # capture full cudagraphs initialize a minimal KV cache during it.
         # Attention-free models resolve the default so layout reads never precede


### PR DESCRIPTION
## Purpose

Models with non-causal attention disable chunked prefill only after KV-cache specifications are collected in EngineCore. At that point, SchedulerConfig has already validated max_num_batched_tokens while chunked prefill was still enabled.

If max_num_batched_tokens is smaller than max_model_len, a prompt larger than the scheduling budget can therefore remain in the waiting queue indefinitely. This was reproduced with HRM-Text-1B using max_model_len=4096 and the default max_num_batched_tokens=2048: 2048-token prompts completed, while 2049-token prompts never became schedulable.

Re-run SchedulerConfig.verify_max_model_len after disabling chunked prefill for non-causal attention. Invalid configurations now fail during engine startup with the existing actionable error instead of accepting requests that cannot be scheduled.

## Test Plan

- Add a CPU-only regression test with a non-causal KV-cache specification and an initially enabled chunked-prefill configuration.
- Verify that late disabling of chunked prefill revalidates the scheduling token budget.
- Run Ruff lint and format checks on both changed files.

## Test Result

```text
python -m pytest -q --confcutdir=tests/v1/engine tests/v1/engine/test_engine_core_init.py
1 passed in 1.11s

ruff check vllm/v1/engine/core.py tests/v1/engine/test_engine_core_init.py
All checks passed!

ruff format --check vllm/v1/engine/core.py tests/v1/engine/test_engine_core_init.py
2 files already formatted
```

Manual Ascend reproduction before this patch:

- max_model_len=4096, max_num_batched_tokens=2048
- 2048-token prompt: completed
- 2049-token prompt: remained waiting for more than 120 seconds
- Explicitly setting max_num_batched_tokens=4096 allowed 2049, 3000, 4000, and 4095-token prompts to complete

This validation is platform-independent; Ascend was used only to discover and reproduce the scheduler state.