### PR TITLE
[Bugfix][Model] DeepseekV4: resolve kv_cache_dtype="auto" to fp8_ds_mla

### DIFF
--- a/tests/models/test_deepseek_v4_kv_cache_dtype.py
+++ b/tests/models/test_deepseek_v4_kv_cache_dtype.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.attention import _resolve_dsv4_kv_cache_dtype
+
+
+@pytest.mark.parametrize("kv_cache_dtype", ["auto", "fp8", "fp8_e4m3", "fp8_ds_mla"])
+def test_fp8_ds_mla_layout_resolves_to_fp8_ds_mla(kv_cache_dtype: str):
+    # The fp8_ds_mla layout architecturally requires fp8 storage; "auto" and
+    # fp8 aliases resolve to the canonical string and are written back to the
+    # cache config so page-size specs pick the 576B per-token slot.
+    cache_config = SimpleNamespace(cache_dtype=kv_cache_dtype)
+    resolved, torch_dtype = _resolve_dsv4_kv_cache_dtype(
+        True, kv_cache_dtype, cache_config
+    )
+    assert resolved == "fp8_ds_mla"
+    assert torch_dtype is torch.uint8
+    assert cache_config.cache_dtype == "fp8_ds_mla"
+
+
+def test_fp8_ds_mla_layout_rejects_explicit_non_fp8():
+    with pytest.raises(AssertionError, match="only supports fp8"):
+        _resolve_dsv4_kv_cache_dtype(True, "bfloat16", None)
+
+
+def test_plain_layout_keeps_auto_as_bf16():
+    assert _resolve_dsv4_kv_cache_dtype(False, "auto", None) == (
+        "auto",
+        torch.bfloat16,
+    )
+    assert _resolve_dsv4_kv_cache_dtype(False, "fp8", None) == (
+        "fp8",
+        torch.float8_e4m3fn,
+    )

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -102,7 +102,10 @@ def _resolve_dsv4_kv_cache_dtype(
     """
     if use_fp8_ds_mla_layout:
         # fp8_ds_mla block format: UE8M0 block-scaled fp8 packed as uint8.
-        assert kv_cache_dtype.startswith("fp8"), (
+        # The layout requires fp8 storage, so "auto" also resolves to
+        # fp8_ds_mla, like _canonicalize_sparse_mla_kv_cache_dtype does for
+        # FLASHMLA_SPARSE / FLASHINFER_MLA_SPARSE_SM120.
+        assert kv_cache_dtype == "auto" or kv_cache_dtype.startswith("fp8"), (
             f"DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, "
             f"got {kv_cache_dtype}"
         )

--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -157,7 +157,9 @@ class DeepseekV4FlashInferMLASparseBackend(DeepseekV4SparseMLABackend):
                 return "kv_cache_dtype not supported"
             return None
         if device_capability.major == 12:
-            if kv_cache_dtype not in ("fp8", "fp8_e4m3", "fp8_ds_mla"):
+            # "auto" is accepted and resolved to fp8_ds_mla at layer
+            # construction (see _resolve_dsv4_kv_cache_dtype).
+            if kv_cache_dtype not in ("auto", "fp8", "fp8_e4m3", "fp8_ds_mla"):
                 return "kv_cache_dtype not supported"
             from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
 


### PR DESCRIPTION
## Purpose

Fixes #47174.

Starting DeepseekV4 (e.g. `deepseek-ai/DeepSeek-V4-Flash`) with default options crashes at layer construction on platforms using the `fp8_ds_mla` KV layout (FlashMLA on SM90, FlashInfer sparse on SM120):

```
AssertionError: DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, got auto
```

The DSv4 backends declare `"auto"` in `supported_kv_cache_dtypes`, but nothing resolves it before `DeepseekV4Attention.__init__` asserts on it. The layout architecturally requires fp8 storage (the FlashMLA decode kernel hardcodes `is_fp8_kvcache=True`), so there is no bf16 fallback for "auto" to resolve to — the only sensible resolution is `fp8_ds_mla`, which is also DeepSeek's native serving format for this model (the checkpoints are fp8 and all reference configs pass `--kv-cache-dtype fp8`).

This currently breaks `test_can_initialize_large_subset[DeepseekV4ForConditionalGeneration]` on the (H200 MIG 35GB) Basic Models (Extra Initialization) shard — reproducible on main, e.g. build 87059.

Changes:

- `_resolve_dsv4_kv_cache_dtype`: accept `"auto"` and resolve it to `fp8_ds_mla`, writing it back to `cache_config` so page-size specs pick the 576B per-token slot (same path as the existing `"fp8"` alias).
- SM120 `supports_combination` validator: accept `"auto"` (resolved to `fp8_ds_mla` at layer construction).
- Explicit non-fp8 dtypes (e.g. `bfloat16`) are still rejected, since the kernel has no such implementation.

This mirrors `_canonicalize_sparse_mla_kv_cache_dtype`, which already resolves `"auto"` → `fp8_ds_mla` for `FLASHINFER_MLA_SPARSE_SM120` (V3.2 family).

## Test Plan

New `tests/models/test_deepseek_v4_kv_cache_dtype.py`: resolution of `auto`/fp8 aliases to `fp8_ds_mla`, `cache_config` write-back, rejection of explicit non-fp8 dtypes, and plain-layout passthrough.

## Test Result

```
.venv/bin/python -m pytest tests/models/test_deepseek_v4_kv_cache_dtype.py -v
6 passed
```

No model-eval impact: behavior only changes for `kv_cache_dtype="auto"`, which previously crashed; explicit `fp8*` settings resolve exactly as before.

## Duplicate-work check

Searched open PRs/issues for `fp8_ds_mla auto` / `_resolve_dsv4_kv_cache_dtype`: only issues (#47174, #52938, #47266), no open fix PR found at the time of writing.

## AI assistance

Prepared with AI assistance (Kimi Code); the human submitter has reviewed every changed line.
