### PR TITLE
[Bugfix][KVConnector] Fix Mooncake bootstrap registration hang on timeout

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import contextlib
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,6 +15,9 @@ import zmq.asyncio
 from tests.v1.attention.utils import dense_kv_cache_views
 from vllm import envs
 from vllm.config import set_current_vllm_config
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
+    mooncake_connector,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
     KVConnectorRole,
     MooncakeConnector,
@@ -31,6 +35,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
     MooncakeBootstrapServer,
+    RegisterWorkerPayload,
 )
 from vllm.utils.network_utils import get_open_port
 from vllm.v1.kv_cache_interface import (
@@ -504,9 +509,23 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         assert data["0"]["worker_addr"]["0"]["0"] == "tcp://1.1.1.1:1111"
         assert data["0"]["worker_addr"]["0"]["1"] == "tcp://2.2.2.2:2222"
 
-    # Test failure: re-registering the same worker
+    # Re-registering the same rank at the same address is idempotent, so a
+    # client that timed out waiting for a response it never saw can safely
+    # retry a request that was already committed server-side.
     async with httpx.AsyncClient() as client:
         response = await client.post(f"{base_url}/register", json=payload1)
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{base_url}/query")
+        assert response.json()["0"]["worker_addr"]["0"]["0"] == "tcp://1.1.1.1:1111"
+
+    # Test failure: re-registering the same rank at a *different* address
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{base_url}/register", json={**payload1, "addr": "tcp://9.9.9.9:9999"}
+        )
         assert response.status_code == 400
         assert "is already registered" in response.text
 
@@ -1402,3 +1421,113 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
 
         prefill_worker.sender_loop = origin_sender_loop
         prefill_worker.shutdown()
+
+
+class _SlowFirstRegisterServer(MooncakeBootstrapServer):
+    """Bootstrap server that commits the first registration but answers it
+    too late for the client to see the response."""
+
+    def __init__(self, host: str, port: int, delay: float):
+        self._delay = delay
+        self._calls = 0
+        super().__init__(host, port)
+
+    async def register_worker(self, payload: RegisterWorkerPayload):
+        result = await super().register_worker(payload)
+        self._calls += 1
+        if self._calls == 1:
+            await asyncio.sleep(self._delay)
+        return result
+
+
+def _register_stub() -> SimpleNamespace:
+    return SimpleNamespace(
+        vllm_config=None,
+        hostname="127.0.0.1",
+        side_channel_port=5555,
+        engine_id="eng-timeout",
+        dp_rank=0,
+        tp_rank=0,
+        pp_rank=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_with_bootstrap_retries_timeout_idempotently(monkeypatch):
+    """A registration that is committed server-side but times out client-side
+    must be retried and must succeed, rather than failing startup."""
+
+    port = get_open_port()
+    server = _SlowFirstRegisterServer("127.0.0.1", port, delay=2.0)
+    server.start()
+
+    monkeypatch.setattr(mooncake_connector, "_BOOTSTRAP_REGISTER_HTTP_TIMEOUT", 0.5)
+    monkeypatch.setattr(mooncake_connector, "_BOOTSTRAP_REGISTER_RETRY_INTERVAL", 0.1)
+    monkeypatch.setattr(
+        mooncake_connector, "get_mooncake_bootstrap_addr", lambda _: ("127.0.0.1", port)
+    )
+
+    try:
+        await MooncakeConnectorWorker.register_worker_with_bootstrap(_register_stub())
+
+        assert server._calls >= 2, "client should have retried after the timeout"
+
+        import httpx
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{port}/query")
+            assert (
+                response.json()["0"]["worker_addr"]["0"]["0"] == "tcp://127.0.0.1:5555"
+            )
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_register_with_bootstrap_gives_up_at_deadline(monkeypatch):
+    """An unreachable bootstrap server must fail the coroutine at the
+    deadline instead of retrying forever."""
+
+    import httpx
+
+    port = get_open_port()
+    monkeypatch.setattr(mooncake_connector, "_BOOTSTRAP_REGISTER_RETRY_INTERVAL", 0.05)
+    monkeypatch.setattr(mooncake_connector, "_BOOTSTRAP_REGISTER_DEADLINE", 0.3)
+    monkeypatch.setattr(
+        mooncake_connector, "get_mooncake_bootstrap_addr", lambda _: ("127.0.0.1", port)
+    )
+
+    with pytest.raises((httpx.ConnectError, httpx.TimeoutException)):
+        await asyncio.wait_for(
+            MooncakeConnectorWorker.register_worker_with_bootstrap(_register_stub()),
+            timeout=30,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sender_listener_reports_registration_failure():
+    """A registration failure must unblock register_kv_caches() and hand it
+    the exception, instead of leaving it waiting on the ready event."""
+
+    err = RuntimeError("bootstrap unreachable")
+
+    async def _failing_register():
+        raise err
+
+    stub = SimpleNamespace(
+        async_zmq_ctx=zmq.asyncio.Context(),
+        hostname="127.0.0.1",
+        num_sender_tasks=1,
+        side_channel_port=0,
+        register_worker_with_bootstrap=_failing_register,
+        _sender_listener_startup_exc=None,
+    )
+
+    ready_event = threading.Event()
+    try:
+        await MooncakeConnectorWorker._mooncake_sender_listener(stub, ready_event)
+
+        assert ready_event.is_set(), "waiter must not be left blocked"
+        assert stub._sender_listener_startup_exc is err
+    finally:
+        stub.async_zmq_ctx.destroy(linger=0)

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -1491,8 +1491,12 @@ async def test_register_with_bootstrap_gives_up_at_deadline(monkeypatch):
     import httpx
 
     port = get_open_port()
+    monkeypatch.setenv("VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT", "1")
     monkeypatch.setattr(mooncake_connector, "_BOOTSTRAP_REGISTER_RETRY_INTERVAL", 0.05)
-    monkeypatch.setattr(mooncake_connector, "_BOOTSTRAP_REGISTER_DEADLINE", 0.3)
+    # A refused connection fails fast, but on a host where the port is
+    # filtered rather than refused a single attempt would otherwise run to
+    # the full default before the deadline is noticed.
+    monkeypatch.setattr(mooncake_connector, "_BOOTSTRAP_REGISTER_HTTP_TIMEOUT", 0.2)
     monkeypatch.setattr(
         mooncake_connector, "get_mooncake_bootstrap_addr", lambda _: ("127.0.0.1", port)
     )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -66,6 +66,12 @@ from vllm.v1.worker.utils import select_common_block_size
 
 logger = init_logger(__name__)
 
+# Bootstrap registration runs while every prefiller worker is initializing, so
+# the server (a thread of the global rank 0 worker) may be slow to respond.
+_BOOTSTRAP_REGISTER_HTTP_TIMEOUT = 30.0
+_BOOTSTRAP_REGISTER_RETRY_INTERVAL = 1.0
+_BOOTSTRAP_REGISTER_DEADLINE = 300.0
+
 try:
     from mooncake.engine import TransferEngine
 except ImportError:
@@ -973,6 +979,9 @@ class MooncakeConnectorWorker:
             # An asyncio queue to buffer incoming requests for the sender
             self.sender_worker_queue = asyncio.Queue[tuple[bytes, bytes]]()
             self.sender_loop = asyncio.new_event_loop()
+            # Set by the listener when it fails before signalling readiness,
+            # then re-raised by register_kv_caches().
+            self._sender_listener_startup_exc: Exception | None = None
             # Background thread for processing new sending requests.
             self._sender_listener_t = threading.Thread(
                 target=_async_loop, args=(self.sender_loop,), daemon=True
@@ -1092,22 +1101,44 @@ class MooncakeConnectorWorker:
             pp_rank=self.pp_rank,
             addr=worker_addr,
         )
+        deadline = time.perf_counter() + _BOOTSTRAP_REGISTER_DEADLINE
         while True:
             try:
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(
+                    timeout=_BOOTSTRAP_REGISTER_HTTP_TIMEOUT
+                ) as client:
                     response = await client.post(url, json=payload.model_dump())
                     response.raise_for_status()
                 logger.debug("Successfully registered with bootstrap server at %s", url)
                 break
-            except httpx.ConnectError:
-                # Bootstrap server not ready, wait for a while and retry.
-                await asyncio.sleep(1)
+            except (httpx.ConnectError, httpx.TimeoutException) as e:
+                # The bootstrap server runs in a thread of the global rank 0
+                # prefiller worker, so it can be slow to start or slow to
+                # answer while that worker is busy initializing. Both cases
+                # are transient: retry until the deadline. Registration is
+                # idempotent for an unchanged address, so a request that
+                # timed out after being committed server-side is safe to
+                # repeat.
+                if time.perf_counter() >= deadline:
+                    logger.error(
+                        "Timed out after %.1fs registering %s with bootstrap "
+                        "server at %s: %r",
+                        _BOOTSTRAP_REGISTER_DEADLINE,
+                        payload,
+                        url,
+                        e,
+                    )
+                    raise
+                await asyncio.sleep(_BOOTSTRAP_REGISTER_RETRY_INTERVAL)
             except Exception as e:
                 err_msg = (
-                    e.response.text if isinstance(e, httpx.HTTPStatusError) else str(e)
+                    e.response.text if isinstance(e, httpx.HTTPStatusError) else repr(e)
                 )
                 logger.error(
-                    "Error registering %s with bootstrap server: %s", payload, err_msg
+                    "Error registering %s with bootstrap server at %s: %s",
+                    payload,
+                    url,
+                    err_msg,
                 )
                 raise e
 
@@ -1125,15 +1156,23 @@ class MooncakeConnectorWorker:
             self.side_channel_port,
         )
 
-        await self.register_worker_with_bootstrap()
+        try:
+            await self.register_worker_with_bootstrap()
 
-        # Create async worker tasks that process items from the queue
-        sender_tasks = [
-            asyncio.create_task(self._sender_worker(sock))
-            for _ in range(self.num_sender_tasks)
-        ]
-
-        ready_event.set()
+            # Create async worker tasks that process items from the queue
+            sender_tasks = [
+                asyncio.create_task(self._sender_worker(sock))
+                for _ in range(self.num_sender_tasks)
+            ]
+        except Exception as e:
+            # Hand the failure to the thread blocked in register_kv_caches()
+            # before unblocking it, so startup fails loudly instead of
+            # waiting on a ready event that would never be set.
+            self._sender_listener_startup_exc = e
+            sock.close()
+            return
+        finally:
+            ready_event.set()
 
         try:
             while True:
@@ -1733,6 +1772,8 @@ class MooncakeConnectorWorker:
             self._mooncake_sender_listener(ready_event), self.sender_loop
         )
         ready_event.wait()  # Wait for listener ZMQ socket to be ready.
+        if self._sender_listener_startup_exc is not None:
+            raise self._sender_listener_startup_exc
 
     async def fetch_finished_recving_reqs(self) -> set[ReqId]:
         finished_recving_reqs = self.finished_recving_reqs

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -68,9 +68,9 @@ logger = init_logger(__name__)
 
 # Bootstrap registration runs while every prefiller worker is initializing, so
 # the server (a thread of the global rank 0 worker) may be slow to respond.
+# The overall deadline is VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT.
 _BOOTSTRAP_REGISTER_HTTP_TIMEOUT = 30.0
 _BOOTSTRAP_REGISTER_RETRY_INTERVAL = 1.0
-_BOOTSTRAP_REGISTER_DEADLINE = 300.0
 
 try:
     from mooncake.engine import TransferEngine
@@ -1101,12 +1101,17 @@ class MooncakeConnectorWorker:
             pp_rank=self.pp_rank,
             addr=worker_addr,
         )
-        deadline = time.perf_counter() + _BOOTSTRAP_REGISTER_DEADLINE
+        start = time.perf_counter()
+        deadline = start + envs.VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT
         while True:
+            # Never let a single attempt outlive the deadline, so a server
+            # that silently drops packets is not waited on for a further
+            # _BOOTSTRAP_REGISTER_HTTP_TIMEOUT past it.
+            attempt_timeout = min(
+                _BOOTSTRAP_REGISTER_HTTP_TIMEOUT, deadline - time.perf_counter()
+            )
             try:
-                async with httpx.AsyncClient(
-                    timeout=_BOOTSTRAP_REGISTER_HTTP_TIMEOUT
-                ) as client:
+                async with httpx.AsyncClient(timeout=attempt_timeout) as client:
                     response = await client.post(url, json=payload.model_dump())
                     response.raise_for_status()
                 logger.debug("Successfully registered with bootstrap server at %s", url)
@@ -1121,15 +1126,23 @@ class MooncakeConnectorWorker:
                 # repeat.
                 if time.perf_counter() >= deadline:
                     logger.error(
-                        "Timed out after %.1fs registering %s with bootstrap "
-                        "server at %s: %r",
-                        _BOOTSTRAP_REGISTER_DEADLINE,
+                        "Gave up after %.1fs registering %s with bootstrap "
+                        "server at %s: %r. Raise "
+                        "VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT (currently "
+                        "%ds) if startup is legitimately slower than this.",
+                        time.perf_counter() - start,
                         payload,
                         url,
                         e,
+                        envs.VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT,
                     )
                     raise
-                await asyncio.sleep(_BOOTSTRAP_REGISTER_RETRY_INTERVAL)
+                await asyncio.sleep(
+                    min(
+                        _BOOTSTRAP_REGISTER_RETRY_INTERVAL,
+                        max(0.0, deadline - time.perf_counter()),
+                    )
+                )
             except Exception as e:
                 err_msg = (
                     e.response.text if isinstance(e, httpx.HTTPStatusError) else repr(e)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
@@ -98,14 +98,15 @@ class MooncakeBootstrapServer:
             dp_entry.worker_addr[payload.tp_rank] = {}
 
         tp_entry = dp_entry.worker_addr[payload.tp_rank]
-        if payload.pp_rank in tp_entry:
+        registered_addr = tp_entry.get(payload.pp_rank)
+        if registered_addr is not None and registered_addr != payload.addr:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     f"Worker with dp_rank={payload.dp_rank}, "
                     f"tp_rank={payload.tp_rank}, pp_rank={payload.pp_rank} "
                     f"is already registered at "
-                    f"{tp_entry[payload.pp_rank]}, "
+                    f"{registered_addr}, "
                     f"but still want to register at {payload.addr}"
                 ),
             )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -256,6 +256,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB: int | None = None
     VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB: int | None = None
     VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT: int = 480
+    VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT: int = 300
     VLLM_ENABLE_CUDAGRAPH_GC: bool = False
     VLLM_LOOPBACK_IP: str = ""
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = True
@@ -1828,6 +1829,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Timeout (in seconds) for MooncakeConnector in PD disaggregated setup.
     "VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT": lambda: int(
         os.getenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "480")
+    ),
+    # Deadline (in seconds) for a Mooncake prefiller worker to register with
+    # the bootstrap server at startup. The server runs in a thread of the
+    # global rank 0 worker, so it can be slow to answer while that worker is
+    # still initializing; registration is retried until this deadline before
+    # failing startup.
+    "VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT": lambda: int(
+        os.getenv("VLLM_MOONCAKE_BOOTSTRAP_REGISTER_TIMEOUT", "300")
     ),
     # If set, it means we pre-downloaded cubin files and flashinfer will
     # read the cubin files directly.


### PR DESCRIPTION


## Purpose

Fixes #55114.

Mooncake producer startup can hang indefinitely when a worker's `POST /register` is accepted by the bootstrap server but the response does not arrive within httpx's 5s default timeout.

`httpx.ConnectTimeout` and `httpx.ReadTimeout` derive from `TimeoutException`, not `ConnectError`, so the only retryable branch in `register_worker_with_bootstrap()` did not cover them and a timeout went straight to the fatal branch. That exception
was then lost: `register_kv_caches()` discards the future returned by `run_coroutine_threadsafe()` and blocks on a `ready_event` that `_mooncake_sender_listener()` sets only *after* registration succeeds. Nothing observes the failure and nothing unblocks the waiter, so the engine never finishes startup.

This is reachable whenever the bootstrap-hosting worker (a thread of the global rank 0 prefiller) is a startup straggler — the reporter saw registrations spread over ~14s with every worker failing at ~5.02s, while a later `GET /query` showed all eight rank tuples present, proving the requests were committed server-side.

Changes:

- **Retry timeouts.** `httpx.TimeoutException` joins `ConnectError` in the retry branch, bounded by a deadline so an unreachable server fails explicitly instead of looping forever. The client also gets an explicit timeout rather than the 5s
  default.
- **Idempotent registration.** `/register` returns 200 when the same rank tuple re-registers the *same* address, so a request that timed out after being committed can be safely retried; a differing address still returns 400. Without this, retrying would just turn the hang into a hard 400.
- **Propagate startup failure.** The listener records the exception, closes the socket, and always sets `ready_event`, and `register_kv_caches()` re-raises it. An explicit attribute is used rather than inspecting the future, because `fut.done()` races with `ready_event.set()`.
- **Diagnosable logs.** `repr(exception)` plus the URL — `str()` is empty for a bare timeout, which is why the reported error lines ended at the colon.


## Test Plan

```bash
pytest tests/v1/kv_connector/unit/test_mooncake_connector.py -v
pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py
```

Three new regression tests, each of which fails on `main` and passes here:

- `test_register_with_bootstrap_retries_timeout_idempotently` — a server that commits the first registration then answers past the client timeout; the client must retry and succeed.
- `test_register_with_bootstrap_gives_up_at_deadline` — an unreachable server must raise at the deadline instead of retrying forever.
- `test_sender_listener_reports_registration_failure` — a registration failure must set `ready_event` and hand the exception to the waiter.

`test_bootstrap_server` was updated: it previously re-registered the same rank at the *same* address and asserted 400, which encoded the bug. It now asserts the idempotent 200 and adds a separate differing-address conflict case.

## Test Result

```
test_bootstrap_server                                     PASSED
test_register_with_bootstrap_retries_timeout_idempotently PASSED
test_register_with_bootstrap_gives_up_at_deadline         PASSED
test_sender_listener_reports_registration_failure         PASSED

19 passed, 14 failed
```

Before/after comparison of the four targeted behaviours:

| Check | `main` | This PR |
|---|---|---|
| Idempotent retry at same address | FAIL (400) | PASS |
| Registration failure reaches waiter | FAIL (raised into discarded future) | PASS |
| Bounded deadline on unreachable server | FAIL (retried forever) | PASS |
| Retry after committed-but-timed-out POST | FAIL (no retry, calls=1) | PASS |

The 14 failures are environmental, not from this change: my machine is Windows, so vLLM cannot be built (`VLLM_USE_PRECOMPILED` has no wheel for this commit, and source builds need MSVC + CUDA toolkit). Without an installed distribution, `importlib.metadata.version("vllm")` raises, CUDA platform detection silently falls back to `UnspecifiedPlatform`, and those tests die in `current_platform.set_device()`. **The identical 14 fail on unmodified `main`** — diffing the two failure sets returns empty in both directions. They need a CI run on Linux to be meaningful; `test_register_kv_caches` in particular touches a function I modified and is the one case I could not verify locally.

`pre-commit` passes on all changed files, including `ruff-check`, `ruff-format`, and `mypy`.

No model evaluation is included: this change is confined to the P/D bootstrap registration handshake at worker startup and does not touch sampling, kernels, or any path affecting model output or accuracy.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>