### PR TITLE
[Bugfix][Core] Hand off a producer's partial-tail boundary state on preemption

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -585,9 +585,12 @@ def test_internal_checkpoint_requires_block_aligned_start():
     assert manager.block_pool.get_cached_block(checkpoint_hash, [1]) is None
 
 
-def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
-    """An external mid-block hit must become a running request even when its
-    first continuation does not need another Mamba block."""
+def test_external_mamba_hit_continues_in_place_without_cow():
+    """A boundary state a connector loaded into the request's private block is
+    not re-registered as a local partial-tail entry: the store already has it,
+    and registering it would make the first continuation need a CoW block that
+    admission never reserved (with every block holder waiting on a load nothing
+    is preemptible and the scheduler deadlocks). The request continues in place."""
     hash_block_size = 2
     mamba_block_size = 4 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -625,36 +628,48 @@ def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
     loaded_blocks = manager.allocate_slots(
         request,
         num_new_tokens=0,
-        num_external_computed_tokens=10,
+        num_external_computed_tokens=14,
         delay_cache_blocks=True,
     )
     assert loaded_blocks is not None
+    assert request.num_externally_loaded_tokens == 14
 
-    request.num_computed_tokens = 10
-    first_step_blocks = manager.allocate_slots(request, num_new_tokens=4)
-    assert first_step_blocks is not None
-
-    source_block_id = manager.get_blocks("0").get_block_ids()[1][1]
-    partial_hash = request.block_hashes[14 // hash_block_size - 1]
-    partial_block = manager.block_pool.get_cached_block(
-        partial_hash, kv_cache_group_ids=[1]
-    )
-    assert partial_block is not None
-    assert partial_block[0].block_id == source_block_id
-
+    # The load landed: the scheduler caches the loaded prefix, whose end is the
+    # prompt's last hash boundary (14 of 15 tokens).
     request.num_computed_tokens = 14
+    manager.cache_blocks(request, 14)
+    partial_hash = request.block_hashes[14 // hash_block_size - 1]
+    assert (
+        manager.block_pool.get_cached_block(partial_hash, kv_cache_group_ids=[1])
+        is None
+    )
+    assert (
+        manager.block_pool.get_cached_block(partial_hash, kv_cache_group_ids=[0])
+        is not None
+    )
+    source_block_id = manager.get_blocks("0").get_block_ids()[1][1]
+
     continuation_blocks = manager.allocate_slots(request, num_new_tokens=1)
     assert continuation_blocks is not None
-
     assert continuation_blocks.get_block_ids()[1] == []
     assert manager.get_blocks("0").get_block_ids()[1][1] == source_block_id
     copies, _ = manager.take_kv_cache_block_copies()
-    cow_copy = next(c for c in copies if c.src_block_id == source_block_id)
-    assert cow_copy.dst_block_id != source_block_id
+    assert copies == []
+    assert manager.finalize_partial_tail_offloads(request) == []
 
-    moved = manager.block_pool.get_cached_block(partial_hash, kv_cache_group_ids=[1])
-    assert moved is not None
-    assert moved[0].block_id == cow_copy.dst_block_id
+    # A prefix computed locally still registers its boundary and CoWs on continue.
+    local = make_request("1", [1] * 15, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(local)
+    assert manager.allocate_slots(local, 14, num_computed, computed_blocks) is not None
+    local.num_computed_tokens = 14
+    local_hash = local.block_hashes[14 // hash_block_size - 1]
+    assert (
+        manager.block_pool.get_cached_block(local_hash, kv_cache_group_ids=[1])
+        is not None
+    )
+    assert manager.allocate_slots(local, num_new_tokens=1) is not None
+    copies, _ = manager.take_kv_cache_block_copies()
+    assert copies
 
 
 def test_boundary_state_offloads_returns_cow_target():
@@ -2157,3 +2172,135 @@ def test_boundary_states_offered_past_prompt_for_resumed_prefill():
     offered = [b for _, _, b in drain_boundary_state_offloads(manager).get("0", [])]
     assert 2 * block_size in offered
     assert req0.num_prompt_tokens < 2 * block_size
+
+
+def test_connector_preempt_registers_partial_tail_before_cleanup():
+    """A preempted producer loses its blocks like a finished one, so a
+    completed partial-tail boundary state must be handed off before the free;
+    otherwise the request resumes from the local entry and the boundary is
+    never offloaded."""
+    from vllm.v1.request import RequestStatus
+
+    calls: list[str] = []
+
+    class _Connector(SupportsHMA):
+        def register_finished_partial_tail(self, request, block_ids, offloads):
+            calls.append("register")
+            self.registered = (request, block_ids, offloads)
+            return True
+
+        def request_finished_all_groups(self, request, block_ids):
+            return False, None
+
+    scheduler = object.__new__(Scheduler)
+    scheduler.connector = _Connector()
+    scheduler.vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(is_kv_producer=True)
+    )
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.kv_cache_manager.finalize_partial_tail_offloads.return_value = [
+        (1, 9, 12)
+    ]
+    scheduler.kv_cache_manager.get_block_ids_for_computed_tokens.return_value = (
+        [3],
+        [9],
+    )
+    scheduler._free_request_blocks = MagicMock(
+        side_effect=lambda request: calls.append("free")
+    )
+    scheduler.encoder_cache_manager = MagicMock()
+    scheduler._inflight_prefills = MagicMock()
+    scheduler.log_stats = False
+    scheduler.waiting = MagicMock()
+    scheduler.reset_preempted_req_ids = set()
+    request = SimpleNamespace(
+        request_id="0",
+        status=RequestStatus.RUNNING,
+        num_computed_tokens=12,
+        num_in_flight_tokens=0,
+        num_prompt_tokens=20,
+        spec_token_ids=[],
+        drop_stale_output=False,
+        num_stale_output_tokens=0,
+        num_output_placeholders=0,
+        num_preemptions=0,
+    )
+
+    scheduler._preempt_request(request, timestamp=0.0)
+
+    assert calls == ["register", "free"]
+    assert scheduler.connector.registered == (request, ([3], [9]), [(1, 9, 12)])
+    # The boundary chunk may still be executing at preemption time; the hand-off
+    # must not be refused for that (the store job fences on the next step).
+    scheduler.kv_cache_manager.finalize_partial_tail_offloads.assert_called_once_with(
+        request, allow_in_flight=True
+    )
+    scheduler.kv_cache_manager.get_block_ids_for_computed_tokens.assert_called_once_with(
+        request_id="0", num_computed_tokens=12
+    )
+    assert request.status == RequestStatus.PREEMPTED
+    assert request.num_computed_tokens == 0
+    assert "0" in scheduler.reset_preempted_req_ids
+
+
+def test_finalize_partial_tail_allows_in_flight_boundary_chunk_on_preemption():
+    """At preemption the chunk that ends at the boundary can still be in
+    flight; the finish-time rule refuses that, the preemption rule accepts it
+    (the store job fences on a later event), and either way the producer tail
+    is consumed exactly once."""
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=24,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=hash_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+    def make_in_flight_request(manager, request_id):
+        req = make_request(request_id, [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
+        computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+        assert manager.allocate_slots(req, 6, num_computed, computed_blocks) is not None
+        req.num_computed_tokens = 6
+        req.num_in_flight_tokens = 6
+        return req
+
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    req0 = make_in_flight_request(manager, "0")
+    source_block_id = manager.get_blocks("0").get_block_ids()[1][1]
+    assert manager.finalize_partial_tail_offloads(req0, allow_in_flight=True) == [
+        (1, source_block_id, 6)
+    ]
+    assert manager.finalize_partial_tail_offloads(req0, allow_in_flight=True) == []
+
+    strict_manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    req1 = make_in_flight_request(strict_manager, "1")
+    assert strict_manager.finalize_partial_tail_offloads(req1) == []

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -994,11 +994,12 @@ def test_finished_partial_tail_is_pre_pinned_as_store_job():
         [(1, 9, 12)],
     )
 
-    # The exact source is pinned immediately, so the request can be freed
+    # The exact source and the other groups' blocks the tail put reads are
+    # pinned immediately, so the request can be freed (finish or preemption)
     # before the next connector metadata build.
     assert delay_free is False
     assert scheduler._gpu_block_pool.blocks[9].ref_cnt == 1
-    assert scheduler._gpu_block_pool.blocks[3].ref_cnt == 0
+    assert scheduler._gpu_block_pool.blocks[3].ref_cnt == 1
 
     out = SimpleNamespace(
         finished_req_ids={"req-0"},
@@ -1023,12 +1024,13 @@ def test_finished_partial_tail_is_pre_pinned_as_store_job():
     assert req_meta.block_ids == block_ids
     assert req_meta.block_hashes == request.block_hashes
     assert req_meta.boundary_state_offloads == [(1, 9, 12)]
-    assert scheduler._pinned_saves[req_meta.store_job_id][0] == [9]
+    assert scheduler._pinned_saves[req_meta.store_job_id][0] == [9, 3]
     assert scheduler._gpu_block_pool.blocks[9].ref_cnt == 1
     assert scheduler._finished_partial_tail_metas == {}
 
     scheduler.update_connector_output(_make_worker_output({req_meta.store_job_id: 1}))
     assert scheduler._gpu_block_pool.blocks[9].ref_cnt == 0
+    assert scheduler._gpu_block_pool.blocks[3].ref_cnt == 0
 
 
 def test_decode_boundary_state_offload_dropped_unclaimed():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -48,6 +48,7 @@ from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
+    MambaSpec,
     RSWASpec,
 )
 from vllm.v1.kv_cache_layout import KVCacheLayout
@@ -3288,6 +3289,7 @@ def _make_bare_worker(
     worker.num_recv_threads = 1
     worker.recv_request_queue = queue.Queue()
     worker.finished_store_req = set()
+    worker._issued_store_metadata = None
     worker.tp_size = 1
     worker.store_tp_size = None
     worker.num_kv_head = 1
@@ -4499,3 +4501,79 @@ def test_blob_block_hashes_empty():
     view = BlobBlockHashes(memoryview(b""), 0)
     assert len(view) == 0
     assert list(view) == []
+
+
+def test_pinned_handoff_job_runs_after_request_ledger_retired():
+    """A preemption retires the request's ledger in the same step its boundary
+    hand-off job is issued; the job owns pinned blocks and no resume offset, so
+    it must still upload and then report completion so the pins are released."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_partial_tail_send_thread(store)
+    # The positional save path that follows the hand-off consults the specs.
+    thread.coord.kv_cache_groups = [
+        SimpleNamespace(
+            kv_cache_spec=FullAttentionSpec(
+                block_size=4, num_kv_heads=1, head_size=1, dtype=torch.float32
+            )
+        ),
+        SimpleNamespace(
+            kv_cache_spec=MambaSpec(
+                block_size=16,
+                shapes=(1, 1),
+                dtypes=(torch.float32,),
+                mamba_cache_mode="align",
+            )
+        ),
+    ]
+    req = _make_partial_tail_req([0, 2, 3])
+    req.store_job_id = 5
+    thread.add_request(req)
+    thread.delete_finished_stored_request(req.req_id)
+    assert not thread.is_live_store_job(req)
+
+    thread._handle_request(req)
+
+    assert store.batch_put_from_multi_buffers.called
+    assert thread.take_completed_saves() == {5: 1}
+
+    # A normal (positional) save of a retired request is still skipped.
+    store.reset_mock()
+    normal = _make_store_req("req-b", [b"b0", b"b1", b"b2", b"b3"])
+    normal.store_job_id = 6
+    thread.add_request(normal)
+    thread.delete_finished_stored_request("req-b")
+    thread._handle_request(normal)
+    assert not store.batch_put_from_multi_buffers.called
+    assert thread.take_completed_saves() == {6: 1}
+
+
+def test_get_finished_issues_store_jobs_when_no_forward_ran(monkeypatch):
+    """A step without a forward skips wait_for_save; get_finished must still
+    issue the step's store jobs (pinned hand-offs read blocks written by
+    earlier steps), exactly once per metadata."""
+    worker = _make_bare_worker()
+    worker.kv_send_thread = MagicMock()
+    worker.load_async = False
+    worker._zero_load_tail = False
+    monkeypatch.setattr(mooncake_store_worker.torch.cuda, "Event", MagicMock)
+    meta = mooncake_store_worker.MooncakeStoreConnectorMetadata(set(), set())
+    req = _make_partial_tail_req([0, 2, 3])
+    req.store_job_id = 5
+    meta.add_request(req)
+
+    worker.get_finished(set(), meta)
+    worker.kv_send_thread.add_request.assert_called_once_with(req)
+
+    # The same metadata is not issued twice (wait_for_save after get_finished
+    # or the other way round).
+    worker.wait_for_save(meta)
+    worker.kv_send_thread.add_request.assert_called_once()
+
+    other = mooncake_store_worker.MooncakeStoreConnectorMetadata(set(), set())
+    other.add_request(req)
+    worker.wait_for_save(other)
+    assert worker.kv_send_thread.add_request.call_count == 2
+    worker.get_finished(set(), other)
+    assert worker.kv_send_thread.add_request.call_count == 2

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -510,6 +510,16 @@ class MooncakeStoreScheduler:
             if block_id == NULL_BLOCK_ID:
                 return False
             pinned_block_ids.append(block_id)
+        # The sub-block tail put also reads the other groups' blocks for the
+        # boundary chunk, and a preempted request frees its table in the same
+        # scheduling pass, so pin those too until every rank reports the job.
+        pinned_block_ids.extend(
+            block_id
+            for group_id, group in enumerate(block_ids)
+            if group_id not in self._boundary_state_group_ids
+            for block_id in group
+            if block_id != NULL_BLOCK_ID
+        )
         pinned_block_ids = list(dict.fromkeys(pinned_block_ids))
 
         pool = self._gpu_block_pool

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -934,7 +934,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
             block_ids_per_group = req_meta.block_ids
             current_event = req_meta.current_event
 
-            if not self.is_live_store_job(req_meta):
+            # A pinned hand-off (finish or preemption) owns exact block refs and
+            # carries no resume offset, so it stays valid after the request's
+            # ledger entry was retired (preemption retires it in the same
+            # step the job is issued).
+            is_pinned_handoff = req_meta.token_len_chunk == 0 and bool(
+                req_meta.boundary_state_offloads
+            )
+            if not is_pinned_handoff and not self.is_live_store_job(req_meta):
                 return
 
             if self.enable_kv_event:
@@ -1634,6 +1641,7 @@ class MooncakeStoreWorker:
         self.num_recv_threads = max(1, envs.VLLM_MOONCAKE_LOAD_RECV_THREADS)
         self.recv_request_queue: queue.Queue[ReqMeta] = queue.Queue()
         self.finished_store_req: set[str] = set()
+        self._issued_store_metadata: MooncakeStoreConnectorMetadata | None = None
         self._kv_connector_stats_lock = threading.Lock()
         self.kv_connector_stats = MooncakeStoreConnectorStats()
 
@@ -1992,6 +2000,13 @@ class MooncakeStoreWorker:
         """
         if self._capacity_only or not self.can_put:
             return
+        self._issue_store_jobs(metadata)
+
+    def _issue_store_jobs(self, metadata: MooncakeStoreConnectorMetadata) -> None:
+        """Queue this step's store jobs once, whether or not a forward ran."""
+        if metadata is self._issued_store_metadata:
+            return
+        self._issued_store_metadata = metadata
 
         current_event = None
         for request in metadata.requests:
@@ -2018,6 +2033,10 @@ class MooncakeStoreWorker:
             return set(), set()
 
         if self.can_put:
+            # A step without a forward skips wait_for_save. Jobs whose blocks
+            # were written by earlier steps (pinned boundary hand-offs) must
+            # still be issued, otherwise their block references never drop.
+            self._issue_store_jobs(meta)
             self._close_ended_store_requests(finished_req_ids, meta)
 
         # Blocks read by a store job are released by the scheduler when the job

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -545,6 +545,14 @@ class KVCacheManager:
             num_encoder_tokens,
         )
 
+        if num_external_computed_tokens > 0:
+            # A Mamba "align" boundary inside the loaded prefix is not
+            # re-registered as a local partial-tail entry (see
+            # MambaManager._cache_partial_tail_block).
+            request.num_externally_loaded_tokens = (
+                num_local_computed_tokens + num_external_computed_tokens
+            )
+
         # P/D: delay caching blocks if we have to recv from
         # remote. Update state for locally cached blocks.
         if not self.enable_caching or delay_cache_blocks:
@@ -875,7 +883,7 @@ class KVCacheManager:
         return offloads
 
     def finalize_partial_tail_offloads(
-        self, request: Request
+        self, request: Request, allow_in_flight: bool = False
     ) -> list[tuple[int, int, int]]:
         """Consume safe producer partial tails when a request finishes.
 
@@ -883,13 +891,17 @@ class KVCacheManager:
         token was forwarded. The connector pins and queues the exact table
         block before request cleanup, then releases the pin when every worker
         reports the store job complete.
+
+        ``allow_in_flight`` is for preemption: the chunk ending at the boundary
+        may still be executing, but the connector fences its read on an event
+        recorded after the next forward, so the state is complete by then.
         """
         offloads: list[tuple[int, int, int]] = []
         for mgr in self.coordinator.single_type_managers:
             finalized = mgr.finalize_partial_tail_offload(
                 request.request_id,
                 request.num_computed_tokens,
-                request.num_in_flight_tokens,
+                0 if allow_in_flight else request.num_in_flight_tokens,
             )
             if finalized is None:
                 continue

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1426,11 +1426,34 @@ class Scheduler(SchedulerInterface):
         assert request.status == RequestStatus.RUNNING, (
             "Only running requests can be preempted"
         )
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if (
+            self.connector is not None
+            and kv_transfer_config is not None
+            and kv_transfer_config.is_kv_producer
+        ):
+            # A preempted producer gives its blocks back like a finished one,
+            # so a completed partial-tail boundary state has to be handed off
+            # now. Otherwise it is dropped with the blocks, and the request,
+            # which resumes from the local cache entry, never owns that
+            # boundary block again.
+            partial_tails = self.kv_cache_manager.finalize_partial_tail_offloads(
+                request, allow_in_flight=True
+            )
+            if partial_tails:
+                block_ids = self.kv_cache_manager.get_block_ids_for_computed_tokens(
+                    request_id=request.request_id,
+                    num_computed_tokens=request.num_computed_tokens,
+                )
+                self.connector.register_finished_partial_tail(
+                    request, block_ids, partial_tails
+                )
         self._free_request_blocks(request)
         self.encoder_cache_manager.free(request)
         self._inflight_prefills.discard(request)
         request.status = RequestStatus.PREEMPTED
         request.num_computed_tokens = 0
+        request.num_externally_loaded_tokens = 0
         if request.spec_token_ids:
             request.spec_token_ids = []
         # Async scheduling: mark all in-flight output as stale. Its tokens are

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1896,6 +1896,13 @@ class MambaManager(SingleTypeKVCacheManager):
         latest_prompt_hash_boundary = (
             request.num_prompt_tokens // hash_block_size
         ) * hash_block_size
+        if num_tokens <= getattr(request, "num_externally_loaded_tokens", 0):
+            # The boundary state was loaded by a connector into this request's
+            # private block. Registering it as a partial-tail entry would make
+            # the next chunk need a CoW block that admission never reserved;
+            # with every block holder waiting on a load nothing is preemptible
+            # and the scheduler deadlocks. The store already has this state.
+            return None
         if num_tokens != latest_prompt_hash_boundary:
             return None
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -180,6 +180,12 @@ class Request:
 
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
+        # Prefix length filled by a KV connector load (local prefix-cache hits
+        # included); reset on preemption. A Mamba "align" boundary inside it
+        # is not re-registered as a local partial-tail entry: the state came
+        # from the store and the request must be able to continue without
+        # a CoW block.
+        self.num_externally_loaded_tokens = 0
         self.cache_salt: str | None = cache_salt
 
         # Multi-modal related


### PR DESCRIPTION
## Purpose

A KV-producer request whose prefill stops at its last hash boundary (Mamba "align" mode with `--prefix-match-unit`) keeps that boundary's SSM state as a partial-tail cache entry and hands the block to the KV connector so a later prompt can complete a hybrid (attention + Mamba) prefix hit from the store. Today the hand-off happens either when the next chunk's CoW runs or, if the request finishes first, in `_connector_finished`. Preemption takes neither path: `_preempt_request` frees the blocks, `pop_blocks_for_free` drops the pending producer tail, and the request resumes from its local partial entry without ever owning the boundary block again.

On a disaggregated prefill engine with a small KV pool this is the common case: every request is preempted right after its first chunk (it needs more blocks for the CoWs than are free), so the store never receives a boundary state and a second pass over identical prompts gets ~0% external hits (Kimi-K3, TP8 prefill, 64 blocks: 24/1319 prompts had a boundary state saved, all of them prompts that never split).

## Changes

- `Scheduler._preempt_request` finalizes the partial tail and calls `connector.register_finished_partial_tail` before the blocks are freed, exactly like the finish path. Because the scheduler runs ahead of execution, the chunk that ends at the boundary may still be in flight at preemption time; the preemption path passes `allow_in_flight=True` (`KVCacheManager.finalize_partial_tail_offloads`), which is safe because the store job fences its read on an event recorded after a later forward.
- `MooncakeStoreScheduler.register_finished_partial_tail` pins, at registration, the other groups' blocks the sub-block tail put reads as well as the boundary blocks: a preempted request's table goes back to the pool in the same scheduling pass.
- `KVCacheStoreSendingThread._handle_request`: a pinned hand-off job (`token_len_chunk == 0` with boundary offloads) owns exact block references and no resume offset, so it is executed even after the request's ledger entry was retired (preemption retires it in the same step the job is issued; without this the job was skipped and the boundary state was still never uploaded).
- `MooncakeStoreWorker.get_finished` issues the step's store jobs when `wait_for_save` was skipped. A step with no forward goes through `kv_connector_no_forward`, which does not call `wait_for_save`; store jobs emitted in such a step (pinned hand-offs after a preemption that left nothing to schedule) were never queued, so their block pins never dropped. On the 64-block engine this exhausted the pool within a minute and deadlocked the scheduler (running 0, waiting 512, KV 95%, every later step no-forward). The same leak exists for finish-time hand-offs flushed into a no-forward step.

- `Request.num_externally_loaded_tokens` / `MambaManager._cache_partial_tail_block`: a boundary state that a connector loaded into the request's private block is not re-registered as a local partial-tail entry. With the store now serving those states, every second-pass prompt on the same engine loaded `[0, B)`; the loaded request then needed 3-4 CoW blocks to run its tail (the registered entry must be preserved), 15 admitted loads held 60 of 64 blocks, and requests waiting on or just finished with a load are not preemptible, so the scheduler deadlocked (running 0, waiting 512). The request now continues in place; the store already holds that state, so nothing is lost for later prompts.

## Test Plan

- `tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py`: `test_connector_preempt_registers_partial_tail_before_cleanup` (registration happens before the free, with `allow_in_flight=True`), `test_finalize_partial_tail_allows_in_flight_boundary_chunk_on_preemption`, and `test_external_mamba_hit_continues_in_place_without_cow` (replaces `test_external_mamba_hit_same_block_uses_running_cow_on_continue`, whose contract caused the deadlock). The first two fail without the fix; file: 44 passed.
- `tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py`: pinning now covers the other groups' blocks (40 passed).
- `tests/v1/kv_connector/unit/test_mooncake_store_worker.py`: `test_pinned_handoff_job_runs_after_request_ledger_retired`, `test_get_finished_issues_store_jobs_when_no_forward_ran` (168 passed).
- E2E (Kimi-K3 het-TP PD, TP8 prefill with a 64-block KV pool / TP1 decode, NIXL + Mooncake Store, GSM8K 5-shot, two passes over the same 1319 prompts with the GPU prefix cache reset in between):

  | | before | after |
  |---|---|---|
  | prompts whose Mamba boundary state reached the store (pass 1) | 24 / 1319 | 1329 / 1319 (a few twice) |
  | prefill external prefix-cache hit rate, cumulative over both passes | 0.6% | 91.9% (pass 2: 1309 / 1319 prompts loaded `[0, B)` from the store) |
  | GSM8K strict-match, pass 1 / pass 2 | 0.9682 / 0.9689 | 0.9712 / 0.9742 |
  | preemptions on the prefill engine (pass 1) | 1310, all hand-offs dropped | 1303, all handed off |
  | scheduler deadlocks | pass 2 deadlocked after 15 loads | none; 0 load failures, 0 NaN |

## Notes

- No open PR touches this path (searched `finalize_partial_tail_offloads`, `register_finished_partial_tail`, `preempt partial tail`).
- AI-assisted (Claude Code); the analysis, fix and tests were reviewed line by line and the tests above were run by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hMcjaJa8vC9zEZeipxDfd
