### PR TITLE
[PP][XPU]Add the flag to control microbatch feature on MRV2+PP

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
+    VLLM_PP_DECODE_MICROBATCH: bool = True
     VLLM_USE_RAY_V2_EXECUTOR_BACKEND: bool = False
     VLLM_DISTRIBUTED_USE_SPLIT_GROUP: bool = False
     VLLM_XLA_USE_SPMD: bool = False
@@ -922,6 +923,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Compiled Graph. Otherwise, it uses Ray's NCCL communicator.
     "VLLM_USE_RAY_WRAPPED_PP_COMM": lambda: bool(
         int(os.getenv("VLLM_USE_RAY_WRAPPED_PP_COMM", "1"))
+    ),
+    # Enable PP decode microbatching (V2 Model Runner). Default on: decodes are
+    # staggered across pp_size microbatches. Set to 0 to decode at full batch.
+    "VLLM_PP_DECODE_MICROBATCH": lambda: bool(
+        int(os.getenv("VLLM_PP_DECODE_MICROBATCH", "1"))
     ),
     # When True and distributed_executor_backend="ray", use RayExecutorV2
     # (MQ-based) instead of RayDistributedExecutor (compiled-graph backend).

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -15,6 +16,9 @@ class AsyncScheduler(Scheduler):
         # reusable read-only placeholder list for speculative decoding.
         self._spec_token_placeholders: list[int] = [-1] * self.num_spec_tokens
         self.pp_size = self.parallel_config.pipeline_parallel_size
+        # Decode stagger; must match PPHandler's ring depth. pp_size spreads
+        # decodes across microbatches; 1 runs decode at full batch per step.
+        self.decode_stagger = self.pp_size if envs.VLLM_PP_DECODE_MICROBATCH else 1
 
     def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
         super()._update_after_schedule(scheduler_output)
@@ -46,7 +50,9 @@ class AsyncScheduler(Scheduler):
             if self.use_v2_model_runner:
                 # Set the next step index in which this request is eligible to be
                 # scheduled for decode (for PP microbatching).
-                request.next_decode_eligible_step = self.current_step + self.pp_size
+                request.next_decode_eligible_step = (
+                    self.current_step + self.decode_stagger
+                )
 
     def _update_request_with_output(
         self, request: Request, new_token_ids: list[int], is_stale: bool = False

--- a/vllm/v1/worker/gpu/pp_utils.py
+++ b/vllm/v1/worker/gpu/pp_utils.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
@@ -65,12 +66,13 @@ class PPHandler:
         self.main_stream = torch.cuda.current_stream(device)
         self.broadcast_stream = torch.cuda.Stream(device)
 
-        # On non-last ranks, a FIFO with one entry per in-flight step: the entry
-        # pushed by step T's `receive` is consumed pp_size steps later. Pre-seeded
-        # with pp_size None placeholders so the first pp_size consumes are no-ops.
-        # None means no postprocess is pending for that step (broadcast skipped).
+        # FIFO on non-last ranks: entry pushed at step T is consumed
+        # `ring_depth` steps later. Depth must match AsyncScheduler.decode_stagger
+        # (pp_size, or 1 when microbatching is off). Pre-seeded with None
+        # placeholders so early consumes are no-ops.
+        ring_depth = get_pp_group().world_size if envs.VLLM_PP_DECODE_MICROBATCH else 1
         self.queue: deque[PendingRecv | None] = (
-            deque() if self.is_last_rank else deque([None] * get_pp_group().world_size)
+            deque() if self.is_last_rank else deque([None] * ring_depth)
         )
 
         # Per req-index generation counter, incremented every time a request
@@ -87,8 +89,8 @@ class PPHandler:
         self.req_idx_gen_np[req_idx] += 1
 
     def get_prev_sampled_outputs(self) -> dict[str, torch.Tensor] | None:
-        """Consume the entry from pp_size steps ago and wait for its recv event,
-        then filter out entries whose request was freed since `receive`.
+        """Consume the entry from `ring_depth` steps ago, wait for its recv
+        event, then drop entries whose request was freed since `receive`.
         """
         if not self.queue:
             return None


### PR DESCRIPTION
Model Runner V2 uses micro-batching for pipeline parallelism (PP) to reduce pipeline bubbles. However, on current XPU devices such as BMG, the available device memory per card is relatively limited. When running models across multiple cards, communication can account for a significant portion of the overall execution time. In this scenario, the micro-batching optimization may not improve the throughput. Add a flag to control whether this optimization is enabled on XPU devices, allowing users to disable it.
