### PR TITLE
[Bugfix][V1] Honor enable_jit_warmup for V2 kernel warmup

### DIFF
--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -3,7 +3,7 @@
 
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -221,3 +221,51 @@ def test_execute_model_waits_previous_pp_send_before_forward(
 
     assert log == ["wait:prev-tensor", "forward", "isend"]
     assert worker._pp_send_work == [tensor_handle]
+
+
+def _v2_warmup_worker(monkeypatch: pytest.MonkeyPatch, enabled: bool):
+    compilation_config = SimpleNamespace(
+        mode=gpu_worker.CompilationMode.NONE,
+        backend=None,
+        compilation_time=0.0,
+        encoder_compilation_time=0.0,
+    )
+    for name in (
+        "kernel_warmup",
+        "set_random_seed",
+        "freeze_gc_heap",
+        "maybe_attach_gc_debug_callback",
+        "enable_gpu_sync_check",
+        "set_torch_threads_for_runtime",
+    ):
+        monkeypatch.setattr(gpu_worker, name, Mock())
+    monkeypatch.setattr("vllm.utils.jit_monitor.activate", Mock())
+    return SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            compilation_config=compilation_config,
+            kernel_config=SimpleNamespace(enable_jit_warmup=enabled),
+        ),
+        compilation_config=compilation_config,
+        model_runner=Mock(lora_config=None),
+        model_config=SimpleNamespace(enforce_eager=True, seed=0),
+        cache_config=SimpleNamespace(kv_cache_memory_bytes=1),
+        observability_config=Mock(),
+        use_v2_model_runner=True,
+        execute_model=Mock(),
+        sample_tokens=Mock(),
+    )
+
+
+@pytest.mark.parametrize(("enabled", "expected_calls"), [(False, 0), (True, 1)])
+def test_v2_scheduler_warmup_honors_jit_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    enabled,
+    expected_calls,
+):
+    worker = _v2_warmup_worker(monkeypatch, enabled)
+    warmup_kernels = Mock()
+    monkeypatch.setattr(gpu_worker, "warmup_kernels", warmup_kernels)
+
+    gpu_worker.Worker.compile_or_warm_up_model(worker)
+
+    assert warmup_kernels.call_count == expected_calls

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -790,9 +790,12 @@ class Worker(WorkerBase):
         # cuda graph capture.
         kernel_warmup(self)
 
-        if self.use_v2_model_runner:
-            # A workspace resize after capture frees what the graphs point at.
-            warmup_kernels(self.model_runner, self.execute_model, self.sample_tokens)
+        if self.use_v2_model_runner:  # noqa: SIM102
+            if self.vllm_config.kernel_config.enable_jit_warmup:
+                # A workspace resize after capture frees what the graphs point at.
+                warmup_kernels(
+                    self.model_runner, self.execute_model, self.sample_tokens
+                )
 
         cuda_graph_memory_bytes = 0
         if not self.model_config.enforce_eager:


### PR DESCRIPTION
## Purpose

Honor `kernel_config.enable_jit_warmup` for the V2 scheduler-level kernel warmup.

Currently, `Worker.compile_or_warm_up_model()` calls `warmup_kernels()` unconditionally when the V2 model runner is enabled. As a result, setting `enable_jit_warmup=False` does not actually skip this JIT warmup path.

This PR gates the V2 `warmup_kernels()` call on the existing `enable_jit_warmup` configuration flag while preserving the current behavior when the flag is enabled.

This addresses the `enable_jit_warmup=False` behavior reported in #54866.

On an A100 40GB reproduction with a locally cached tiny Llama model, disabling JIT warmup reduced cold engine startup from:

* Before: 125.865 s
* After: 36.089 s
* Reduction: 71.3%

As expected for lazy JIT, the first request became slower because compilation moved to first use:

* First request: 68.1 ms -> 605.0 ms
* Second request: 49.7 ms -> 47.7 ms

Greedy output token IDs were identical before and after the change.

## Test Plan

Added a focused regression test for the V2 worker initialization path:

* `enable_jit_warmup=False` -> `warmup_kernels()` is not called
* `enable_jit_warmup=True` -> `warmup_kernels()` is called exactly once

Also ran the complete nearest worker test file and an A100 runtime smoke test with V2 enabled.

Commands:

```bash
pytest tests/v1/worker/test_gpu_worker.py -q
git diff --check
```

## Test Result

```text
10 passed
```

Pre-commit checks for the modified files passed.

Runtime smoke test on NVIDIA A100 40GB:

* V2 engine initialized successfully with `enable_jit_warmup=False`
* Two consecutive greedy generations completed successfully
* Output token IDs were identical
* First request: 76.875 ms
* Second request: 45.129 ms
