### PR TITLE
[Bugfix][ROCm] Allocate topk_ids at the width AITER's topk kernels write

### DIFF
--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -89,39 +89,41 @@ def fused_topk(
 
     M, _ = hidden_states.size()
 
+    # AITER's topk_softmax / topk_sigmoid write 32-bit expert ids regardless of
+    # the dtype of the buffer they are handed. Allocating `indices_type` here
+    # would leave the upper half of every 64-bit slot holding whatever
+    # torch.empty returned, so allocate what the kernel writes and widen after
+    # it has filled the buffer. Callers that ask for int64 (e.g.
+    # DeepEPV2PrepareAndFinalize.topk_indices_dtype) index with these ids, and
+    # the uninitialised halves show up there as out-of-range experts.
+    use_rocm_aiter = rocm_aiter_ops.is_fused_moe_enabled()
+    ids_dtype = (
+        torch.int32 if (use_rocm_aiter or indices_type is None) else indices_type
+    )
+
     topk_weights = torch.empty(
         M, topk, dtype=torch.float32, device=hidden_states.device
     )
-    topk_ids = torch.empty(
-        M,
-        topk,
-        dtype=torch.int32 if indices_type is None else indices_type,
-        device=hidden_states.device,
-    )
+    topk_ids = torch.empty(M, topk, dtype=ids_dtype, device=hidden_states.device)
     token_expert_indices = torch.empty(
         M, topk, dtype=torch.int32, device=hidden_states.device
     )
 
     if scoring_func == "softmax":
-        topk_func = dispatch_topk_softmax_func(
-            use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
-        )
-        topk_weights, topk_ids = topk_func(
-            topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
-        )
-
-        return topk_weights, topk_ids, token_expert_indices
+        topk_func = dispatch_topk_softmax_func(use_rocm_aiter=use_rocm_aiter)
     elif scoring_func == "sigmoid":
-        topk_func = dispatch_topk_sigmoid_func(
-            use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
-        )
-        topk_weights, topk_ids = topk_func(
-            topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
-        )
-
-        return topk_weights, topk_ids, token_expert_indices
+        topk_func = dispatch_topk_sigmoid_func(use_rocm_aiter=use_rocm_aiter)
     else:
         raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    topk_weights, topk_ids = topk_func(
+        topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
+    )
+
+    if indices_type is not None and topk_ids.dtype != indices_type:
+        topk_ids = topk_ids.to(dtype=indices_type)
+
+    return topk_weights, topk_ids, token_expert_indices
 
 
 class FusedTopKRouter(BaseRouter):


### PR DESCRIPTION
## The bug

`fused_topk` allocates the routing output at the width the *caller* asked for and hands that buffer to the topk kernel to fill:

```python
topk_ids = torch.empty(..., dtype=torch.int32 if indices_type is None else indices_type)
topk_weights, topk_ids = topk_func(topk_weights, topk_ids, ...)
```

AITER's `topk_softmax` / `topk_sigmoid` write **32-bit** expert ids regardless of the buffer's dtype. When a caller asks for `int64` the upper half of every 64-bit slot keeps whatever `torch.empty` returned, and the consumer then indexes with those values.

## Reproduction

Standalone on gfx950 (MI350X), AITER `d9e5ef7c`: one direct `aiter.topk_softmax` call, no vLLM modular kernel and no distributed init. The buffer is pre-filled with `-999999` so an untouched slot is unmistakable. 256 tokens, topk 6, 64 experts.

| buffer dtype | ids landing in `[0, 64)` | min / max |
| --- | --- | --- |
| `torch.int32` | **1536 / 1536 (100%)** | 0 / 63 |
| `torch.int64` | **14 / 1536 (0.9%)** | **-999999** / 270582939709 |

The surviving poison is the proof: the kernel never wrote those slots.

<details><summary>repro script</summary>

```python
import torch
from aiter import topk_softmax

M, E, TOPK = 256, 64, 6
gating = torch.randn(M, E, device="cuda", dtype=torch.float32)

for dt in (torch.int32, torch.int64):
    w = torch.empty(M, TOPK, device="cuda", dtype=torch.float32)
    ids = torch.empty(M, TOPK, device="cuda", dtype=dt).fill_(-999999)
    tei = torch.empty(M, TOPK, device="cuda", dtype=torch.int32)
    topk_softmax(w, ids, tei, gating, False, 0, "")
    torch.cuda.synchronize()
    ok = int(((ids >= 0) & (ids < E)).sum())
    print(f"dtype={dt} in_range={ok}/{ids.numel()} min={int(ids.min())} max={int(ids.max())}")
```
</details>

## Downstream impact on ROCm

Two crash signatures, one cause. DeepEP indexes with the ids and writes out of bounds (`Memory access fault ... Write access to a read-only page`); and once the obviously invalid ids are clamped, the remaining corrupted entries produce duplicate expert ids for a token, which trips DeepEP's own device assert in `dispatch_copy_epilogue` (`EP_DEVICE_ASSERT(ptx::deduplicate(...) or dst_expert_idx == -1)`) and aborts with `HSA_STATUS_ERROR_EXCEPTION`.

MoRI never hit this because `MoriPrepareAndFinalize.topk_indices_dtype()` returns `int32` — it happens to request the width AITER actually writes.

## The fix

When the AITER kernels are in use, allocate `int32` and widen with `.to()` after they have filled the buffer. Non-AITER paths keep allocating `indices_type` directly, so their behaviour is unchanged. Also hoists the duplicated `topk_func` call out of the two scoring branches, which were identical.

Arguably AITER should also honour the buffer dtype or assert on it; this PR fixes the caller side, which is where the contract is currently violated.

## Test plan

Verified on MI350X (gfx950): with this change DeepSeek-V2-Lite BF16 serves with AITER fused MoE at `TP=1/DP=8/EP=8` — 8/8 ranks up, coherent output, benchmarks stable across 8 runs. Before it faulted during startup on every attempt.