### PR TITLE
[Docs] max_num_seqs is bounded by the Mamba cache pool on hybrid models

### DIFF
--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -45,6 +45,14 @@ from vllm import LLM
 llm = LLM(model="Qwen/Qwen2.5-VL-3B-Instruct", max_model_len=2048, max_num_seqs=2)
 ```
 
+On hybrid Mamba/attention models (Qwen3-Next, Qwen3.5/3.6/3.8, Granite 4, Jamba, ...) `max_num_seqs` is also bounded by the Mamba cache: each decode sequence needs one block, and the pool is sized from what is left after the weights and the KV cache. At a long `max_model_len` on a card with little headroom the pool can hold fewer blocks than the default `max_num_seqs` (256, or 1024 on cards with 70 GiB or more), and the engine stops rather than lowering the concurrency ceiling on its own:
+
+```text
+ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (969). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 969 or increase gpu_memory_utilization.
+```
+
+Set `max_num_seqs` to the number in the message, raise `gpu_memory_utilization`, or shorten `max_model_len`. The block count is known only after the weights are loaded and the KV cache is profiled.
+
 ## Reduce CUDA Graphs
 
 By default, we optimize model inference using CUDA graphs which take up extra memory in the GPU.

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -22,6 +22,10 @@ It'd be better to store the model in a local disk. Additionally, have a look at 
 
 If the model is too large to fit in a single GPU, you will get an out-of-memory (OOM) error. Consider adopting [these options](../configuration/conserving_memory.md) to reduce the memory consumption.
 
+## `max_num_seqs (N) exceeds available Mamba cache blocks (M)`
+
+A hybrid Mamba/attention model needs one Mamba cache block per decode sequence, and the pool is sized after the KV cache, so at a long `max_model_len` it can be smaller than the default `max_num_seqs`. Pass `--max-num-seqs M` with the number from the message, raise `gpu_memory_utilization`, or reduce `max_model_len`. See [Conserving Memory](../configuration/conserving_memory.md#context-length-and-batch-size); the behaviour is deliberate ([#49064](https://github.com/vllm-project/vllm/issues/49064)).
+
 ## Generation quality changed
 
 In v0.8.0, the source of default sampling parameters was changed in <https://github.com/vllm-project/vllm/pull/12622>. Prior to v0.8.0, the default sampling parameters came from vLLM's set of neutral defaults. From v0.8.0 onwards, the default sampling parameters come from the `generation_config.json` provided by the model creator.


### PR DESCRIPTION
Hybrid Mamba/attention models need one Mamba cache block per decode sequence, and since #38270 the engine refuses to start when `max_num_seqs` exceeds the pool rather than capping silently (#49064 kept that). The docs never mention the bound, and the default `max_num_seqs` is above the pool whenever `max_model_len` is long: 1024 against 969 blocks on an H100 at 132 000 (#49064), 256 against 161 on a 20 GiB gfx1100 pair at 122 633.

One paragraph in *Conserving Memory* next to `max_model_len`/`max_num_seqs`, one entry in *Troubleshooting* under the error text so a search for the message lands on the fix. No code change.

## AI assistance

The investigation and this description were produced with an AI agent; I reviewed the change, the two reproductions ran on hardware I own and on a rented H100, and the commit carries a `Co-authored-by:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
