### PR TITLE
[Memory][GDN] Bound FLA chunk-scan workspace during KV cache sizing

### DIFF
--- a/tests/model_executor/layers/mamba/test_gdn_chunk_workspace.py
+++ b/tests/model_executor/layers/mamba/test_gdn_chunk_workspace.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for GDN FLA chunk-scan workspace accounting."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.gdn.chunk_workspace import (
+    _format_workspace_bytes,
+    apply_gdn_chunk_workspace_reservation,
+    estimate_gdn_chunk_workspace,
+    max_gdn_chunk_count,
+    resolve_gdn_workspace_spec,
+    uncovered_gdn_workspace_bytes,
+)
+from vllm.third_party.flash_linear_attention.ops.utils import (
+    FLA_CHUNK_SIZE,
+    gdn_workspace_tracker,
+)
+
+# Qwen3.8-27B linear-attn geometry (global heads; divide by TP in tests).
+_QWEN38_V_HEADS = 48
+_HEAD_DIM = 128
+_BF16 = 2
+_MIB = 1024 * 1024
+
+
+def _qwen38_estimate(
+    num_tokens: int,
+    *,
+    tp_size: int = 1,
+    num_seqs: int = 1,
+    worst_case_chunks: bool = False,
+    seq_lens: list[int] | None = None,
+):
+    return estimate_gdn_chunk_workspace(
+        num_tokens=num_tokens,
+        num_value_heads_local=_QWEN38_V_HEADS // tp_size,
+        key_dim=_HEAD_DIM,
+        value_dim=_HEAD_DIM,
+        dtype_itemsize=_BF16,
+        num_seqs=num_seqs,
+        seq_lens=seq_lens,
+        worst_case_chunks=worst_case_chunks,
+    )
+
+
+def test_qwen38_h_plus_v_new_matches_36kib_per_token():
+    est = _qwen38_estimate(8192)
+    assert est.num_chunks == 128
+    assert est.hv_only_bytes == 288 * _MIB
+    assert est.hv_only_bytes / 8192 == 36 * 1024
+
+
+def test_qwen38_extended_live_set_is_72kib_per_token():
+    est = _qwen38_estimate(8192)
+    assert est.peak_live_bytes == 576 * _MIB
+    assert est.peak_live_bytes / 8192 == 72 * 1024
+    assert est.h_bytes == 192 * _MIB
+    assert est.v_new_bytes == est.w_bytes == est.u_bytes == est.a_bytes == 96 * _MIB
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "hv_mib", "peak_mib"),
+    [
+        (8192, 288, 576),
+        (16384, 576, 1152),
+        (32768, 1152, 2304),
+        (65536, 2304, 4608),
+    ],
+)
+def test_qwen38_scales_linearly_with_tokens(
+    num_tokens: int, hv_mib: int, peak_mib: int
+):
+    est = _qwen38_estimate(num_tokens)
+    assert est.hv_only_bytes == hv_mib * _MIB
+    assert est.peak_live_bytes == peak_mib * _MIB
+
+
+def test_tp_shards_value_heads():
+    full = _qwen38_estimate(16384, tp_size=1)
+    sharded = _qwen38_estimate(16384, tp_size=2)
+    assert sharded.num_value_heads_local == 24
+    assert sharded.peak_live_bytes == full.peak_live_bytes // 2
+    assert sharded.hv_only_bytes == full.hv_only_bytes // 2
+
+
+def test_even_split_same_tokens_same_chunks():
+    one = _qwen38_estimate(8192, num_seqs=1)
+    four = _qwen38_estimate(8192, num_seqs=4)
+    assert one.num_chunks == four.num_chunks == 128
+    assert one.peak_live_bytes == four.peak_live_bytes
+
+
+def test_worst_case_chunks_inflates_h_only():
+    typical = _qwen38_estimate(16384, num_seqs=8, worst_case_chunks=False)
+    worst = _qwen38_estimate(16384, num_seqs=8, worst_case_chunks=True)
+    assert worst.num_chunks == max_gdn_chunk_count(16384, 8)
+    assert worst.num_chunks == 263
+    assert typical.num_chunks == 256
+    assert worst.v_new_bytes == typical.v_new_bytes
+    assert worst.h_bytes > typical.h_bytes
+    assert worst.peak_live_bytes - typical.peak_live_bytes == (
+        worst.h_bytes - typical.h_bytes
+    )
+
+
+def test_seq_lens_override_uses_varlen_chunk_sum():
+    # Eight length-1 sequences plus the remainder would be worst-case.
+    rem = 16384 - 7
+    est = _qwen38_estimate(16384, seq_lens=[1] * 7 + [rem])
+    assert est.num_chunks == 7 + math_ceil(rem, FLA_CHUNK_SIZE)
+    assert est.num_chunks == 263
+
+
+def math_ceil(n: int, d: int) -> int:
+    return (n + d - 1) // d
+
+
+def test_format_workspace_bytes_uses_mib_below_one_gib():
+    assert _format_workspace_bytes(2 * _MIB).endswith("MiB")
+    assert _format_workspace_bytes(2 * 1024 * _MIB).endswith("GiB")
+
+
+def test_uncovered_delta_is_fail_closed():
+    assert uncovered_gdn_workspace_bytes(100, 10) == 90
+    assert uncovered_gdn_workspace_bytes(100, 100) == 0
+    assert uncovered_gdn_workspace_bytes(100, 150) == 0
+    assert uncovered_gdn_workspace_bytes(100, -5) == 100
+
+
+def test_tracker_disabled_is_noop():
+    gdn_workspace_tracker.peak_bytes = 0
+    gdn_workspace_tracker.record(1024)
+    with gdn_workspace_tracker.track_call():
+        gdn_workspace_tracker.record(2048)
+    assert gdn_workspace_tracker.peak_bytes == 0
+
+
+def test_tracker_peak_is_per_call_not_sum_across_layers():
+    with gdn_workspace_tracker.collecting():
+        with gdn_workspace_tracker.track_call():
+            gdn_workspace_tracker.record(100)
+            gdn_workspace_tracker.record(50)
+        with gdn_workspace_tracker.track_call():
+            gdn_workspace_tracker.record(80)
+        assert gdn_workspace_tracker.peak_bytes == 150
+
+
+def test_tracker_without_track_call_does_not_commit_peak():
+    with gdn_workspace_tracker.collecting():
+        gdn_workspace_tracker.record(4096)
+        assert gdn_workspace_tracker.peak_bytes == 0
+
+
+def _dummy_vllm_config(
+    *,
+    max_num_batched_tokens: int = 16384,
+    max_num_seqs: int = 8,
+    tp_size: int = 2,
+    dtype=torch.bfloat16,
+    linear_heads: int | None = _QWEN38_V_HEADS,
+):
+    text = SimpleNamespace(
+        linear_num_value_heads=linear_heads,
+        linear_key_head_dim=_HEAD_DIM,
+        linear_value_head_dim=_HEAD_DIM,
+    )
+    return SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=text, dtype=dtype),
+        parallel_config=SimpleNamespace(tensor_parallel_size=tp_size),
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_num_seqs=max_num_seqs,
+        ),
+    )
+
+
+class _GdnLayer:
+    def __init__(self, backend: str = "triton", tp_size: int = 2):
+        self.num_v_heads = _QWEN38_V_HEADS
+        self.tp_size = tp_size
+        self.head_k_dim = _HEAD_DIM
+        self.head_v_dim = _HEAD_DIM
+        self.gdn_prefill_backend = backend
+        self.model_config = SimpleNamespace(dtype=torch.bfloat16)
+
+    def modules(self):
+        yield self
+
+
+def test_resolve_spec_from_layer_applies_tp():
+    spec = resolve_gdn_workspace_spec(_dummy_vllm_config(), _GdnLayer(tp_size=2))
+    assert spec is not None
+    assert spec.num_value_heads_local == 24
+    assert spec.backend == "triton"
+
+
+def test_apply_reservation_subtracts_uncovered_delta():
+    cfg = _dummy_vllm_config()
+    upper = _qwen38_estimate(
+        16384, tp_size=2, num_seqs=8, worst_case_chunks=True
+    ).peak_live_bytes
+    covered = _qwen38_estimate(FLA_CHUNK_SIZE, tp_size=2).peak_live_bytes
+    available = 8 * 1024**3
+    remaining = apply_gdn_chunk_workspace_reservation(
+        available, cfg, _GdnLayer(), covered
+    )
+    assert remaining == available - (upper - covered)
+    assert 0 < (upper - covered) < available
+
+
+def test_apply_reservation_skips_flashinfer():
+    available = 8 * 1024**3
+    remaining = apply_gdn_chunk_workspace_reservation(
+        available,
+        _dummy_vllm_config(),
+        _GdnLayer(backend="flashinfer"),
+        covered_bytes=0,
+    )
+    assert remaining == available
+
+
+def test_apply_reservation_skips_non_gdn_models():
+    cfg = _dummy_vllm_config(linear_heads=None)
+    cfg.model_config.hf_text_config = SimpleNamespace()
+    remaining = apply_gdn_chunk_workspace_reservation(
+        1024, cfg, model=None, covered_bytes=0
+    )
+    assert remaining == 1024
+
+
+def test_apply_reservation_errors_when_kv_cannot_fit():
+    cfg = _dummy_vllm_config()
+    with pytest.raises(RuntimeError, match="GDN chunk-scan workspace"):
+        apply_gdn_chunk_workspace_reservation(1, cfg, _GdnLayer(), covered_bytes=0)
+
+
+def test_manual_kv_path_logs_but_does_not_subtract():
+    available = 4 * 1024**3
+    remaining = apply_gdn_chunk_workspace_reservation(
+        available,
+        _dummy_vllm_config(),
+        _GdnLayer(),
+        covered_bytes=0,
+        apply_reservation=False,
+    )
+    assert remaining == available

--- a/vllm/model_executor/layers/mamba/gdn/chunk_workspace.py
+++ b/vllm/model_executor/layers/mamba/gdn/chunk_workspace.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FLA gated-delta chunk-scan workspace accounting for KV cache sizing.
+
+V1 ``profile_run`` only warms GDN prefill kernels at ``T = FLA_CHUNK_SIZE``
+and never builds ``attn_metadata``, so the large ``h`` / ``v_new`` / ``w`` /
+``u`` / ``A`` tensors used by a full ``max_num_batched_tokens`` prefill are
+invisible to ``memory_profiling``. This module estimates that live-set and
+reserves only the portion not already observed during profile / CUDA-graph
+capture. See #54775.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+from vllm.utils.mem_constants import GiB_bytes
+from vllm.utils.mem_utils import format_gib, format_mib
+
+logger = init_logger(__name__)
+
+# Triton/FLA allocates these tensors together in chunk_gated_delta_rule_fwd.
+# ``o`` is produced later and can reuse freed memory; SSM ``final_state``
+# is GDN cache, not this workspace.
+_FLA_PREFILL_BACKENDS = frozenset({"triton"})
+
+
+@dataclass(frozen=True)
+class GdnWorkspaceSpec:
+    num_value_heads_local: int
+    key_dim: int
+    value_dim: int
+    dtype_itemsize: int
+    chunk_size: int
+    backend: str
+
+
+@dataclass(frozen=True)
+class GdnWorkspaceEstimate:
+    num_tokens: int
+    num_seqs: int
+    num_chunks: int
+    num_value_heads_local: int
+    key_dim: int
+    value_dim: int
+    chunk_size: int
+    elem_size: int
+    h_bytes: int
+    v_new_bytes: int
+    w_bytes: int
+    u_bytes: int
+    a_bytes: int
+    hv_only_bytes: int
+    peak_live_bytes: int
+
+
+def max_gdn_chunk_count(
+    num_tokens: int,
+    max_num_seqs: int,
+    chunk_size: int = FLA_CHUNK_SIZE,
+) -> int:
+    """Worst-case FLA chunk count for a token and sequence budget.
+
+    Varlen ``NT = sum(ceil(seq_i / chunk_size))``. The maximum is
+    ``(S - 1)`` length-1 sequences plus one sequence with the remainder.
+    """
+    if num_tokens <= 0 or chunk_size <= 0:
+        return 0
+    num_seqs = min(max(max_num_seqs, 1), num_tokens)
+    return (num_seqs - 1) + math.ceil((num_tokens - num_seqs + 1) / chunk_size)
+
+
+def estimate_gdn_chunk_workspace(
+    num_tokens: int,
+    num_value_heads_local: int,
+    key_dim: int,
+    value_dim: int,
+    dtype_itemsize: int = 2,
+    chunk_size: int = FLA_CHUNK_SIZE,
+    num_seqs: int = 1,
+    seq_lens: list[int] | None = None,
+    worst_case_chunks: bool = False,
+) -> GdnWorkspaceEstimate:
+    """Estimate the FLA gated-delta prefill live-set.
+
+    Covers ``h + v_new + w + u + A``. ``h`` scales with chunk count, not
+    raw tokens. Packed varlen layout is ``B = 1``.
+
+    Args:
+        num_tokens: Total tokens in the batch (``T``).
+        num_value_heads_local: Value heads on this TP rank.
+        key_dim: Per-head key dim.
+        value_dim: Per-head value dim.
+        dtype_itemsize: Activation element size (bf16/fp16 is 2).
+        chunk_size: FLA chunk size (``BT``, default 64).
+        num_seqs: Sequence count when ``seq_lens`` is omitted.
+        seq_lens: Explicit per-sequence lengths. Must sum to ``num_tokens``.
+        worst_case_chunks: If true and ``seq_lens`` is omitted, use the
+            maximum chunk count for ``(num_tokens, num_seqs)``.
+
+    Returns:
+        Breakdown of each tensor and the concurrent peak live-set.
+
+    Raises:
+        ValueError: If ``seq_lens`` does not sum to ``num_tokens``, or
+            ``num_seqs`` is not positive when needed.
+    """
+    if num_tokens < 0:
+        raise ValueError("num_tokens must be non-negative")
+    if seq_lens is not None:
+        if sum(seq_lens) != num_tokens:
+            raise ValueError("seq_lens must sum to num_tokens")
+        num_chunks = sum(math.ceil(t / chunk_size) for t in seq_lens if t > 0)
+        resolved_seqs = len(seq_lens)
+    elif worst_case_chunks:
+        if num_seqs <= 0:
+            raise ValueError("num_seqs must be positive")
+        num_chunks = max_gdn_chunk_count(num_tokens, num_seqs, chunk_size)
+        resolved_seqs = min(num_seqs, max(num_tokens, 1)) if num_tokens else 0
+    else:
+        if num_seqs <= 0:
+            raise ValueError("num_seqs must be positive")
+        if num_tokens == 0:
+            seq_lens = [0] * num_seqs
+        elif num_tokens % num_seqs != 0:
+            base = num_tokens // num_seqs
+            rem = num_tokens % num_seqs
+            seq_lens = [base + (1 if i < rem else 0) for i in range(num_seqs)]
+        else:
+            seq_lens = [num_tokens // num_seqs] * num_seqs
+        num_chunks = sum(math.ceil(t / chunk_size) for t in seq_lens if t > 0)
+        resolved_seqs = num_seqs
+
+    h = num_value_heads_local
+    k = key_dim
+    v = value_dim
+    e = dtype_itemsize
+    h_bytes = num_chunks * h * v * k * e
+    v_new_bytes = num_tokens * h * v * e
+    w_bytes = num_tokens * h * k * e
+    u_bytes = num_tokens * h * v * e
+    a_bytes = num_tokens * h * chunk_size * 4
+    hv_only = h_bytes + v_new_bytes
+    peak_live = h_bytes + v_new_bytes + w_bytes + u_bytes + a_bytes
+    return GdnWorkspaceEstimate(
+        num_tokens=num_tokens,
+        num_seqs=resolved_seqs,
+        num_chunks=num_chunks,
+        num_value_heads_local=h,
+        key_dim=k,
+        value_dim=v,
+        chunk_size=chunk_size,
+        elem_size=e,
+        h_bytes=h_bytes,
+        v_new_bytes=v_new_bytes,
+        w_bytes=w_bytes,
+        u_bytes=u_bytes,
+        a_bytes=a_bytes,
+        hv_only_bytes=hv_only,
+        peak_live_bytes=peak_live,
+    )
+
+
+def uncovered_gdn_workspace_bytes(upper_bytes: int, covered_bytes: int) -> int:
+    """Bytes to reserve beyond what profile / CUDA-graph already charged."""
+    return max(0, upper_bytes - max(covered_bytes, 0))
+
+
+def _format_workspace_bytes(n: int) -> str:
+    n = max(n, 0)
+    if n >= GiB_bytes:
+        return f"{format_gib(n)} GiB"
+    return f"{format_mib(n)} MiB"
+
+
+def _dtype_itemsize(dtype: Any) -> int:
+    itemsize = getattr(dtype, "itemsize", None)
+    if itemsize in (1, 2, 4, 8):
+        return int(itemsize)
+    return 2
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def _spec_from_module(module: Any) -> GdnWorkspaceSpec | None:
+    num_v = _positive_int(getattr(module, "num_v_heads", None))
+    tp_size = getattr(module, "tp_size", 1)
+    key_dim = _positive_int(getattr(module, "head_k_dim", None))
+    value_dim = _positive_int(getattr(module, "head_v_dim", None))
+    if num_v is None or key_dim is None or value_dim is None:
+        return None
+    cls_name = type(module).__name__
+    if getattr(module, "gdn_prefill_backend", None) is None and (
+        "GatedDeltaNet" not in cls_name and "GatedDelta" not in cls_name
+    ):
+        return None
+    tp_size = max(int(tp_size), 1)
+    backend = str(getattr(module, "gdn_prefill_backend", "triton") or "triton")
+    model_config = getattr(module, "model_config", None)
+    dtype = getattr(model_config, "dtype", torch.bfloat16)
+    return GdnWorkspaceSpec(
+        num_value_heads_local=num_v // tp_size,
+        key_dim=key_dim,
+        value_dim=value_dim,
+        dtype_itemsize=_dtype_itemsize(dtype),
+        chunk_size=FLA_CHUNK_SIZE,
+        backend=backend,
+    )
+
+
+def resolve_gdn_workspace_spec(
+    vllm_config: Any,
+    model: Any | None = None,
+) -> GdnWorkspaceSpec | None:
+    """Read GDN FLA workspace dims from a loaded layer or HF text config."""
+    if model is not None:
+        modules_fn = getattr(model, "modules", None)
+        if callable(modules_fn):
+            for module in modules_fn():
+                spec = _spec_from_module(module)
+                if spec is not None:
+                    return spec
+        spec = _spec_from_module(model)
+        if spec is not None:
+            return spec
+
+    model_config = getattr(vllm_config, "model_config", None)
+    text = getattr(model_config, "hf_text_config", None)
+    if text is None:
+        text = getattr(model_config, "hf_config", None)
+    num_v = _positive_int(getattr(text, "linear_num_value_heads", None))
+    key_dim = _positive_int(getattr(text, "linear_key_head_dim", None))
+    value_dim = _positive_int(getattr(text, "linear_value_head_dim", None))
+    if num_v is None or key_dim is None or value_dim is None:
+        return None
+
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    tp_size = max(int(getattr(parallel_config, "tensor_parallel_size", 1) or 1), 1)
+    dtype = getattr(model_config, "dtype", torch.bfloat16)
+    backend = "triton"
+    if model is not None:
+        for module in getattr(model, "modules", lambda: ())():
+            layer_backend = getattr(module, "gdn_prefill_backend", None)
+            if layer_backend is not None:
+                backend = str(layer_backend)
+                break
+    return GdnWorkspaceSpec(
+        num_value_heads_local=num_v // tp_size,
+        key_dim=key_dim,
+        value_dim=value_dim,
+        dtype_itemsize=_dtype_itemsize(dtype),
+        chunk_size=FLA_CHUNK_SIZE,
+        backend=backend,
+    )
+
+
+def apply_gdn_chunk_workspace_reservation(
+    available_kv_bytes: int,
+    vllm_config: Any,
+    model: Any | None,
+    covered_bytes: int,
+    *,
+    apply_reservation: bool = True,
+) -> int:
+    """Subtract uncovered FLA workspace from the KV-cache budget.
+
+    No-op for non-GDN models and non-Triton/FLA prefill backends. Logs the
+    upper bound, profile coverage, and extra reservation.
+
+    Args:
+        available_kv_bytes: KV bytes after regular memory profiling.
+        vllm_config: Runtime config (scheduler, parallel, model).
+        model: Loaded model, used to read local heads and backend.
+        covered_bytes: Workspace bytes already charged during profile.
+        apply_reservation: If false, log only (manual KV size path).
+
+    Returns:
+        Remaining KV bytes after the uncovered-delta reservation.
+
+    Raises:
+        RuntimeError: If the uncovered workspace exceeds ``available_kv_bytes``.
+    """
+    spec = resolve_gdn_workspace_spec(vllm_config, model)
+    if spec is None:
+        return available_kv_bytes
+    if spec.backend not in _FLA_PREFILL_BACKENDS:
+        logger.debug(
+            "Skipping GDN chunk workspace reservation for backend %s.",
+            spec.backend,
+        )
+        return available_kv_bytes
+
+    scheduler = getattr(vllm_config, "scheduler_config", None)
+    num_tokens = int(getattr(scheduler, "max_num_batched_tokens", 0) or 0)
+    num_seqs = int(getattr(scheduler, "max_num_seqs", 1) or 1)
+    if num_tokens <= 0 or spec.num_value_heads_local <= 0:
+        return available_kv_bytes
+
+    estimate = estimate_gdn_chunk_workspace(
+        num_tokens=num_tokens,
+        num_value_heads_local=spec.num_value_heads_local,
+        key_dim=spec.key_dim,
+        value_dim=spec.value_dim,
+        dtype_itemsize=spec.dtype_itemsize,
+        chunk_size=spec.chunk_size,
+        num_seqs=num_seqs,
+        worst_case_chunks=True,
+    )
+    additional = uncovered_gdn_workspace_bytes(estimate.peak_live_bytes, covered_bytes)
+    logger.info(
+        "GDN chunk workspace upper bound: %s (tokens=%d, chunks=%d, local_v_heads=%d)",
+        _format_workspace_bytes(estimate.peak_live_bytes),
+        estimate.num_tokens,
+        estimate.num_chunks,
+        spec.num_value_heads_local,
+    )
+    logger.info(
+        "Workspace covered by profile:    %s",
+        _format_workspace_bytes(max(covered_bytes, 0)),
+    )
+    logger.info(
+        "Additional safety reservation:   %s",
+        _format_workspace_bytes(additional),
+    )
+    if not apply_reservation:
+        logger.warning(
+            "Skipping GDN chunk workspace reservation because "
+            "kv_cache_memory_bytes is set."
+        )
+        return available_kv_bytes
+
+    remaining = available_kv_bytes - additional
+    if remaining < 0:
+        raise RuntimeError(
+            "GDN chunk-scan workspace requires "
+            f"{_format_workspace_bytes(additional)} beyond profile, but only "
+            f"{_format_workspace_bytes(available_kv_bytes)} is left for the "
+            "KV cache. Lower --max-num-batched-tokens or "
+            "--gpu-memory-utilization."
+        )
+    return remaining

--- a/vllm/third_party/flash_linear_attention/ops/chunk.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk.py
@@ -16,7 +16,12 @@ from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
 from .l2norm import l2norm_fwd
 from .solve_tril import solve_tril
-from .utils import FLA_CHUNK_SIZE, SUPPRESS_LEVEL, input_guard
+from .utils import (
+    FLA_CHUNK_SIZE,
+    SUPPRESS_LEVEL,
+    gdn_workspace_tracker,
+    input_guard,
+)
 from .wy_fast import recompute_w_u_fwd
 
 
@@ -34,55 +39,61 @@ def chunk_gated_delta_rule_fwd(
     chunk_offsets: torch.Tensor | None = None,
     core_attn_out: torch.Tensor | None = None,
 ):
-    g = chunk_local_cumsum(
-        g, chunk_size=FLA_CHUNK_SIZE, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
-    )
-    # obtain WY representation. u is actually the new v.
-    A = chunk_scaled_dot_kkt_fwd(
-        k=k,
-        beta=beta,
-        g=g,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-        output_dtype=torch.float32,
-    )
-    A = solve_tril(
-        A=A, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices, output_dtype=k.dtype
-    )
-    w, u = recompute_w_u_fwd(
-        k=k,
-        v=v,
-        beta=beta,
-        A=A,
-        g_cumsum=g,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-    )
-    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
-        k=k,
-        w=w,
-        u=u,
-        g=g,
-        initial_state=initial_state,
-        output_final_state=output_final_state,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-        chunk_offsets=chunk_offsets,
-    )
-    o = chunk_fwd_o(
-        q=q,
-        k=k,
-        v=v_new,
-        h=h,
-        g=g,
-        scale=scale,
-        cu_seqlens=cu_seqlens,
-        chunk_indices=chunk_indices,
-        core_attn_out=core_attn_out,
-    )
-    if SUPPRESS_LEVEL < 3:
-        return g, o, A, final_state, None, None, None
-    elif SUPPRESS_LEVEL >= 3:
+    with gdn_workspace_tracker.track_call():
+        g = chunk_local_cumsum(
+            g,
+            chunk_size=FLA_CHUNK_SIZE,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+        # obtain WY representation. u is actually the new v.
+        A = chunk_scaled_dot_kkt_fwd(
+            k=k,
+            beta=beta,
+            g=g,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            output_dtype=torch.float32,
+        )
+        A = solve_tril(
+            A=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            output_dtype=k.dtype,
+        )
+        w, u = recompute_w_u_fwd(
+            k=k,
+            v=v,
+            beta=beta,
+            A=A,
+            g_cumsum=g,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+        h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+            k=k,
+            w=w,
+            u=u,
+            g=g,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            chunk_offsets=chunk_offsets,
+        )
+        o = chunk_fwd_o(
+            q=q,
+            k=k,
+            v=v_new,
+            h=h,
+            g=g,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            core_attn_out=core_attn_out,
+        )
+        if SUPPRESS_LEVEL < 3:
+            return g, o, A, final_state, None, None, None
         return g, o, A, final_state, w, h, v_new
 
 

--- a/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
@@ -14,7 +14,7 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices, prepare_chunk_offsets
 from .op import exp, exp2
-from .utils import FLA_CHUNK_SIZE, use_cuda_graph
+from .utils import FLA_CHUNK_SIZE, record_gdn_workspace_tensor, use_cuda_graph
 
 NUM_WARPS = [2, 4, 8, 16]
 # Triton's AMD backend fails to lower this kernel with num_stages=4.
@@ -350,11 +350,13 @@ def chunk_gated_delta_rule_fwd_h(
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
     h = k.new_empty(B, NT, H, V, K)
+    record_gdn_workspace_tensor(h)
     final_state = (
         k.new_empty(N, H, V, K, dtype=torch.float32) if output_final_state else None
     )
 
     v_new = torch.empty_like(u) if save_new_value else None
+    record_gdn_workspace_tensor(v_new)
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), N * H)

--- a/vllm/third_party/flash_linear_attention/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk_scaled_dot_kkt.py
@@ -15,7 +15,7 @@ from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
 from .op import exp
-from .utils import FLA_CHUNK_SIZE
+from .utils import FLA_CHUNK_SIZE, record_gdn_workspace_tensor
 
 # On RDNA (gfx11xx/gfx12xx) WMMA only
 # accepts 16-bit/int inputs, so a widened (e.g. fp32) tl.dot is lowered to a
@@ -159,6 +159,7 @@ def chunk_scaled_dot_kkt_fwd(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
     A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
+    record_gdn_workspace_tensor(A)
     chunk_scaled_dot_kkt_fwd_kernel[(NT, B * H)](
         k=k,
         g=g,

--- a/vllm/third_party/flash_linear_attention/ops/utils.py
+++ b/vllm/third_party/flash_linear_attention/ops/utils.py
@@ -31,6 +31,58 @@ SUPPRESS_LEVEL = int(os.getenv("GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
 FLA_CHUNK_SIZE = 64
 
 
+class GdnWorkspaceTracker:
+    """Record FLA chunk-scan temporaries during memory profiling.
+
+    Peak is the max live-set of one ``chunk_gated_delta_rule`` call, not
+    the sum across layers. Disabled by default so inference is a no-op.
+    """
+
+    def __init__(self) -> None:
+        self._enabled = False
+        self._current_bytes = 0
+        self.peak_bytes = 0
+
+    @contextlib.contextmanager
+    def collecting(self) -> Any:
+        was_enabled = self._enabled
+        self._enabled = True
+        self._current_bytes = 0
+        self.peak_bytes = 0
+        try:
+            yield self
+        finally:
+            self._enabled = was_enabled
+
+    @contextlib.contextmanager
+    def track_call(self) -> Any:
+        if not self._enabled:
+            yield
+            return
+        prev = self._current_bytes
+        self._current_bytes = 0
+        try:
+            yield
+        finally:
+            if self._current_bytes > self.peak_bytes:
+                self.peak_bytes = self._current_bytes
+            self._current_bytes = prev
+
+    def record(self, nbytes: int) -> None:
+        if self._enabled and nbytes > 0:
+            self._current_bytes += nbytes
+
+
+gdn_workspace_tracker = GdnWorkspaceTracker()
+
+
+def record_gdn_workspace_tensor(tensor: torch.Tensor | None) -> None:
+    """Charge one FLA workspace tensor to the profile tracker."""
+    if tensor is None or not gdn_workspace_tracker._enabled:
+        return
+    gdn_workspace_tracker.record(tensor.numel() * tensor.element_size())
+
+
 def tensor_cache(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
     """
     A decorator that caches the most recent results of a function with tensor inputs.

--- a/vllm/third_party/flash_linear_attention/ops/wy_fast.py
+++ b/vllm/third_party/flash_linear_attention/ops/wy_fast.py
@@ -14,6 +14,7 @@ import torch
 from vllm.triton_utils import tl, triton
 
 from .index import prepare_chunk_indices
+from .utils import record_gdn_workspace_tensor
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
@@ -136,6 +137,8 @@ def recompute_w_u_fwd(
     BV = 64
     u = torch.empty_like(v)
     w = k.new_empty(B, T, H, K)
+    record_gdn_workspace_tensor(u)
+    record_gdn_workspace_tensor(w)
     recompute_w_u_fwd_kernel[(NT, B * H)](
         k=k,
         v=v,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -531,10 +531,25 @@ class Worker(WorkerBase):
         """
         maybe_apply_startup_plan(self)
 
+        from vllm.model_executor.layers.mamba.gdn.chunk_workspace import (
+            apply_gdn_chunk_workspace_reservation,
+        )
+        from vllm.third_party.flash_linear_attention.ops.utils import (
+            gdn_workspace_tracker,
+        )
+
         if kv_cache_memory_bytes := self.cache_config.kv_cache_memory_bytes:
             # still need a profile run which compiles the model for
             # max_num_batched_tokens
-            self.model_runner.profile_run()
+            with gdn_workspace_tracker.collecting():
+                self.model_runner.profile_run()
+            apply_gdn_chunk_workspace_reservation(
+                kv_cache_memory_bytes,
+                self.vllm_config,
+                getattr(self.model_runner, "model", None),
+                gdn_workspace_tracker.peak_bytes,
+                apply_reservation=False,
+            )
 
             msg = (
                 f"Initial free memory {format_gib(self.init_snapshot.free_memory)} "
@@ -556,25 +571,28 @@ class Worker(WorkerBase):
             )
 
         # Execute a forward pass with dummy inputs to profile the memory usage
-        # of the model.
-        with memory_profiling(
-            self.init_snapshot,
-            weights_memory=int(self.model_runner.model_memory_usage),
-        ) as profile_result:
-            self.model_runner.profile_run()
+        # of the model. Tracker stays on through CUDA-graph profiling so a
+        # first-capture GDN transient is treated as already covered (#50780).
+        with gdn_workspace_tracker.collecting():
+            with memory_profiling(
+                self.init_snapshot,
+                weights_memory=int(self.model_runner.model_memory_usage),
+            ) as profile_result:
+                self.model_runner.profile_run()
 
-        # Profile CUDA graph memory if graphs will be captured.
-        # ROCm is included: #44825 moved the profiler to
-        # torch.accelerator.get_memory_info (reliable on ROCm, as used by
-        # the AMD-CI mem tests), and graph_pool_handle resolves to the same
-        # torch.cuda handle the live capture path already uses on ROCm.
-        # XPU stays excluded (see #39977).
-        cudagraph_memory_estimate = 0
-        if (
-            current_platform.is_cuda_alike()
-            and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
-        ):
-            cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
+            # Profile CUDA graph memory if graphs will be captured.
+            # ROCm is included: #44825 moved the profiler to
+            # torch.accelerator.get_memory_info (reliable on ROCm, as used by
+            # the AMD-CI mem tests), and graph_pool_handle resolves to the same
+            # torch.cuda handle the live capture path already uses on ROCm.
+            # XPU stays excluded (see #39977).
+            cudagraph_memory_estimate = 0
+            if (
+                current_platform.is_cuda_alike()
+                and self.vllm_config.compilation_config.cudagraph_mode
+                != CUDAGraphMode.NONE
+            ):
+                cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
         # Respect the opt-in flag as originally designed.
         cudagraph_memory_estimate_applied = (
@@ -610,10 +628,13 @@ class Worker(WorkerBase):
         )
         self.cudagraph_memory_estimate = cudagraph_memory_estimate
 
-        self.available_kv_cache_memory_bytes = (
+        self.available_kv_cache_memory_bytes = apply_gdn_chunk_workspace_reservation(
             self.requested_memory
             - profile_result.non_kv_cache_memory
-            - cudagraph_memory_estimate_applied
+            - cudagraph_memory_estimate_applied,
+            self.vllm_config,
+            getattr(self.model_runner, "model", None),
+            gdn_workspace_tracker.peak_bytes,
         )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory


### PR DESCRIPTION
## Purpose

Address the GDN workspace-profiling gap related to #54775. FLA GDN temporaries (`h`, `v_new`, `w`, `u`, `A`) grow with `--max-num-batched-tokens`, while the V1 GDN warmup uses `T=64`. Leaving headroom reduces the risk of a large prefill exhausting memory after KV allocation.

This PR covers Triton/FLA GDN. The original GLM KDA/ROCm case in #54775 is not yet validated; this is not a claim to fully resolve that issue.

Reserve `max(0, analytic_live_set − profile_covered)`. Fail at startup if KV cannot absorb it. Skip FlashInfer/CuteDSL. `--kv-cache-memory` logs only.

Not a duplicate: searches for `54775 in:body` and `GDN workspace` on 2026-09-13 found no other matching reservation PR. This follows issue option 3; the profile-side investigation mentioned in the issue is a different approach.

## Test Plan

- `pytest tests/model_executor/layers/mamba/test_gdn_chunk_workspace.py --noconftest`
- `ruff check` on touched files
- Qwen3.8-27B-FP8, TP2, eager, `mnbt=16384`, `max_num_seqs=8`, `gpu_memory_utilization=0.90`, 2× L40S

## Test results — 2026-09-13 (L40S, initial)

21 unit tests passed. Same-config serve:

| | before | after |
|---|---:|---:|
| Available KV | 23.46 GiB | 22.9 GiB |
| GPU KV tokens | 669,013 | 652,629 |
| Max concurrency @32K | 20.42× | 19.92× |

Additional reservation: 0.57 GiB. Candidate 8K / 4×2K / 16K prefills completed
without OOM. This demonstrates reservation and successful candidate execution,
not a complete controlled baseline-OOM → candidate-pass reproduction.
It trades KV capacity for workspace headroom; no throughput or accuracy gain is claimed.

## Validation update — 2026-09-18 (H20)

- Rebased onto main `9ff08f9493aa` (no drift in the touched files); includes
  docstring formatting required by the current pre-commit config.
- `pytest tests/model_executor/layers/mamba/test_gdn_chunk_workspace.py
  --noconftest` — 21 passed on H20.
- Synthetic live-set check (random varlen tensors through
  `chunk_gated_delta_rule`, T=16384, HV=32, K=V=128, bf16, l2norm in-kernel):
    - The instrumented tensors match the analytic estimate exactly
      (est/tracked = 1.00) — no double-counting against profile.
    - The measured CUDA peak is ~1.43x the five-tensor set: the output tensor
      is allocated while the five are still referenced, solve_tril's bf16 copy
      of the fp32 A coexists during the cast, and the rest is allocator
      fragmentation.
    - The estimate now counts the first two, landing at ~88% of the measured
      peak across T=8192..16384 and 1/8/16-sequence splits. The residual is
      fragmentation that cannot be modeled analytically.

## Validation update — 2026-09-19 (H20, real GDN model)

Qwen3.8-27B-FP8 (48 linear v-heads, head dim 128), TP2 on 2x H20 96GB,
`--enforce-eager --gpu-memory-utilization 0.95 --max-model-len 131072
--max-num-batched-tokens 131072 --additional-config
'{"gdn_prefill_backend":"triton"}'`. The Triton/FLA backend was forced
because H20 defaults to the FlashInfer GDN prefill path, which this PR does
not touch.

Baseline (main `9ff08f9493aa`):

- 4 concurrent ~120K-token prefills: all 4 requests fail with
  `torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.29 GiB`
  (95.08 GiB total, 1.41 GiB free, 84.28 GiB allocated by PyTorch). Both TP
  workers OOM in the same large chunked-prefill batch; the engine dies.
- The OOM surfaces at an ordinary activation allocation (post-attention
  RMSNorm in `qwen3_next.py`): the FLA chunk-scan workspace allocated earlier
  in the GDN layers is not covered by profiling, so the KV cache (59.3 GiB
  here) leaves no room for it.

Candidate (this PR), identical configuration:

- Startup logs the reservation:
  `GDN chunk workspace upper bound: 5.63 GiB (tokens=131072, chunks=2055,
  local_v_heads=24)`, `Workspace covered by profile: 2.25 MiB`,
  `Additional safety reservation: 5.63 GiB`.
- KV cache shrinks by exactly the reservation: 59.3 -> 53.67 GiB.
- Same 4x~120K-token prefill load: all 4 requests return 200, zero OOM.
- Fail-closed check: at `--gpu-memory-utilization 0.35` startup aborts with
  `RuntimeError: GDN chunk-scan workspace requires 5.63 GiB beyond profile,
  but only 2.25 GiB is left for the KV cache. Lower --max-num-batched-tokens
  or --gpu-memory-utilization.`

Non-Triton backends are untouched, verified on the same box with the default
backend (`requested=auto` -> FlashInfer GDN prefill), identical configuration
otherwise: no reservation is logged, and KV cache memory is 59.3 GiB —
bit-identical to unpatched main with the same backend. A real prefill request
completes normally.

Default CUDA-graph mode (no `--enforce-eager`), Triton/FLA forced, same
sizing: reservation applies as in eager (5.62 GiB; the profiling peak is
lower without eager, so slightly more of the bound is already covered), KV
cache is 56.26 GiB, graph capture finishes normally (0.18 GiB in 17 s), and
the same 4x~120K-token prefill load returns 200 with zero OOM.

Runtime headroom during the passing eager 4x~120K run (100 ms nvidia-smi
sampling): device usage peaked at 93.0 GiB of 95.08 GiB, i.e. ~2 GiB slack.
The reservation is tight, not padded.

This closes the baseline-OOM -> candidate-pass reproduction left open in the
09-18 update. The original KDA/ROCm case from #54775 remains unvalidated.

AI assistance was used for code edits and test scripts; all changes were
reviewed and all tests run by the human author.


---

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] Docs (not needed; no user-facing flag)


