### PR TITLE
[Bugfix] Reject quantized KV cache for encoder-only attention

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ import pydantic
 import pytest
 from huggingface_hub import ResolvedRevision
 from pydantic import ValidationError
+from transformers import BertConfig
 
 import vllm.config.vllm as vllm_config_module
 import vllm.envs as envs
@@ -53,6 +54,45 @@ DEVICE_TYPE = current_platform.device_type
 def _write_json(path: Path, value: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value), encoding="utf-8")
+
+
+@pytest.mark.parametrize("cache_dtype", ["fp8_e4m3", "turboquant_k8v4"])
+def test_encoder_only_rejects_quantized_kv_cache(tmp_path: Path, cache_dtype: str):
+    model_path = tmp_path / "bert"
+    BertConfig(architectures=["BertModel"]).save_pretrained(model_path)
+    model_config = ModelConfig(str(model_path), runner="pooling", max_model_len=128)
+
+    with pytest.raises(ValueError) as exc_info:
+        VllmConfig(
+            model_config=model_config,
+            cache_config=CacheConfig(cache_dtype=cache_dtype),
+            device_config=DeviceConfig(device="cpu"),
+        )
+
+    error = str(exc_info.value)
+    assert cache_dtype in error
+    assert "encoder-only attention" in error
+    assert "--kv-cache-dtype auto" in error
+
+
+@pytest.mark.parametrize(
+    ("attn_type", "cache_dtype"),
+    [
+        ("encoder_only", "auto"),
+        ("encoder_only", "bfloat16"),
+        ("decoder", "fp8_e4m3"),
+        ("decoder", "turboquant_k8v4"),
+    ],
+)
+def test_encoder_only_kv_cache_validation_allows_compatible_configs(
+    attn_type: str, cache_dtype: str
+):
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(attn_type=attn_type),
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype),
+    )
+
+    VllmConfig._verify_encoder_only_kv_cache_dtype(config)
 
 
 def test_kda_recoverssm_derivation_is_revalidated():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -26,6 +26,7 @@ from vllm.transformers_utils.runai_utils import is_runai_obj_uri
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils import random_uuid
 from vllm.utils.hashing import safe_hash
+from vllm.v1.kv_cache_interface import is_quantized_kv_cache
 
 from .attention import AttentionConfig
 from .cache import CacheConfig
@@ -1077,6 +1078,20 @@ class VllmConfig:
         if not self.use_v2_model_runner:
             raise ValueError("trace replay requires Model Runner V2")
 
+    def _verify_encoder_only_kv_cache_dtype(self) -> None:
+        model_config = self.model_config
+        cache_dtype = self.cache_config.cache_dtype
+        if (
+            model_config is not None
+            and model_config.attn_type == "encoder_only"
+            and is_quantized_kv_cache(cache_dtype)
+        ):
+            raise ValueError(
+                f"Quantized KV cache dtype {cache_dtype!r} is not supported for "
+                "encoder-only attention. Use --kv-cache-dtype auto or a "
+                "non-quantized dtype."
+            )
+
     def __post_init__(self):
         """Verify configs are valid & consistent with each other."""
 
@@ -1084,6 +1099,7 @@ class VllmConfig:
         self.instance_id = f"{time.time_ns()}"
 
         self._resolve_mm_encoder_only()
+        self._verify_encoder_only_kv_cache_dtype()
 
         if self.performance_mode != "balanced":
             logger.info_once("Performance mode set to '%s'.", self.performance_mode)


### PR DESCRIPTION
## Summary

Fixes #55048.

This PR rejects quantized KV cache dtypes for encoder-only attention during `VllmConfig` construction, before EngineCore, workers, or attention backends are initialized.

Previously, encoder-only models and quantized KV cache dtypes were each accepted independently, but their unsupported combination was not validated. As a result, encoder models such as `BAAI/bge-large-en-v1.5` could enter EngineCore and fail later during attention backend initialization or execution.

## Changes

- Add a combined validation for encoder-only attention and quantized KV cache dtypes.
- Use the canonical V1 KV-cache quantization classifier, covering FP8, per-token-head, NVFP4, and TurboQuant formats.
- Raise a clear `ValueError` with the invalid dtype and a recommendation to use `--kv-cache-dtype auto` or another non-quantized dtype.
- Preserve quantized KV cache support for decoder models.
- Keep existing backend runtime checks as defensive validation.

## Tests

Added regression coverage for:

- rejecting `encoder_only + fp8_e4m3`;
- rejecting `encoder_only + turboquant_k8v4`;
- clear error text containing the dtype and suggested alternative;
- allowing `encoder_only + auto` and `encoder_only + bfloat16`;
- allowing `decoder + fp8_e4m3` and `decoder + turboquant_k8v4`.

Commands and results:

- `python -m pytest tests/test_config.py -k "encoder_only_rejects_quantized_kv_cache or encoder_only_kv_cache_validation_allows_compatible_configs" -q`
  - `6 passed`
- `python -m pytest tests/utils_/test_torch_utils.py -v`
  - `34 passed`
- `python -m pytest tests/test_config.py -v --timeout=90`
  - `245 passed, 3 failed`
  - The three failures require authenticated access to gated Meta Llama repositories and failed with HTTP 401. They do not exercise this change.
- `pre-commit run --files vllm/config/vllm.py tests/test_config.py`
  - Passed
- `pre-commit run mypy-3.12 --hook-stage manual --files vllm/config/vllm.py tests/test_config.py`
  - Passed
- `git diff --check`
  - Passed

## E2E validation

Validated on a single NVIDIA RTX 4090 with `BAAI/bge-large-en-v1.5`.

Before the fix:

- `fp8_e4m3` passed configuration validation;
- EngineCore and the CUDA worker were started;
- execution later failed with `NotImplementedError: quantized KV cache is not supported for encoder attention`.

After the fix:

- `fp8_e4m3` fails during `VllmConfig` construction;
- `turboquant_k8v4` also fails during `VllmConfig` construction;
- neither invalid configuration starts EngineCore;
- the error identifies the invalid dtype and recommends a non-quantized configuration.

As a legal control, the same encoder model successfully started with `--kv-cache-dtype auto`, passed its health check, and returned HTTP 200 from `/v1/embeddings` with a 1024-dimensional embedding.

## Scope and duplicate check

This change only moves validation of an already unsupported configuration to the earliest layer that has both the model attention type and KV cache dtype. It does not change model outputs, accuracy, kernels, or valid decoder KV cache configurations, so no model quality evaluation is required.

I checked Issue #55048 and searched open pull requests by issue number and relevant keywords before submission. No existing PR implementing the same fix was found.

## AI assistance

This PR was developed with assistance from OpenAI Codex. I reviewed and understood every changed line and verified the test and E2E results reported above.