### PR TITLE
[Bugfix][Structured Outputs] Support new-format structural tags in the guidance backend (strict/required/named tool calling)

### DIFF
--- a/tests/v1/structured_output/test_backend_guidance_structural_tag.py
+++ b/tests/v1/structured_output/test_backend_guidance_structural_tag.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Guidance backend support for new-format (xgrammar-style) structural tags.
+
+Tool parsers emit structural tags as ``{"type": "structural_tag", "format":
+{...}}`` (see ``vllm/tool_parsers/structural_tag_registry.py``); with a
+hermes-style parser this is what ``tool_choice="auto"`` + a ``strict: true``
+tool, ``tool_choice="required"`` and named tool choice produce. These tests
+pin the guidance-backend translation of that format, including accepting the
+closing tag both as raw bytes and as the tokenizer's special token (models
+emit ``</tool_call>`` as a special token).
+"""
+
+import json
+
+import pytest
+from transformers import AutoTokenizer
+
+from vllm.config import StructuredOutputsConfig, VllmConfig
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionToolsParam,
+)
+from vllm.exceptions import VLLMValidationError
+from vllm.tool_parsers.structural_tag_registry import get_model_structural_tag
+from vllm.v1.structured_output.backend_guidance import (
+    GuidanceBackend,
+    serialize_guidance_grammar,
+)
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
+
+# Hermes-style chat template with <tool_call>/</tool_call> special tokens.
+TOKENIZER = "Qwen/Qwen3-0.6B"
+
+WEATHER_SCHEMA = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}},
+    "required": ["city"],
+    "additionalProperties": False,
+}
+
+GOOD_CALL = (
+    '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+)
+BAD_ARGS_CALL = (
+    '<tool_call>\n{"name": "get_weather", "arguments": {"city": 5}}\n</tool_call>'
+)
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    return AutoTokenizer.from_pretrained(TOKENIZER)
+
+
+@pytest.fixture(scope="module")
+def backend(tokenizer):
+    vllm_config = VllmConfig(
+        structured_outputs_config=StructuredOutputsConfig(backend="guidance")
+    )
+    return GuidanceBackend(
+        vllm_config,
+        tokenizer=tokenizer,
+        vocab_size=151936,
+    )
+
+
+def _tools(strict: bool = True) -> list[ChatCompletionToolsParam]:
+    return [
+        ChatCompletionToolsParam(
+            **{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "strict": strict,
+                    "parameters": WEATHER_SCHEMA,
+                },
+            }
+        )
+    ]
+
+
+def _structural_tag_spec(tool_choice) -> str:
+    st = get_model_structural_tag("hermes", _tools(), tool_choice, False)
+    assert st is not None
+    return json.dumps(st.model_dump())
+
+
+def _compile(backend, tool_choice):
+    return backend.compile_grammar(
+        StructuredOutputOptions.STRUCTURAL_TAG, _structural_tag_spec(tool_choice)
+    )
+
+
+def _encode(tokenizer, text: str) -> list[int]:
+    return tokenizer.encode(text, add_special_tokens=False)
+
+
+def test_auto_accepts_special_token_close(backend, tokenizer):
+    # The tokenizer encodes the trailing </tool_call> as its special token,
+    # which is how models actually close the block.
+    grammar = _compile(backend, "auto")
+    tokens = _encode(tokenizer, "Checking the weather. " + GOOD_CALL)
+    close_id = tokenizer.convert_tokens_to_ids("</tool_call>")
+    assert tokens[-1] == close_id
+    assert grammar.accept_tokens("", tokens)
+    # Free text is allowed again after the block, and EOS terminates.
+    assert grammar.accept_tokens("", _encode(tokenizer, " done"))
+    assert grammar.accept_tokens("", [tokenizer.eos_token_id])
+    assert grammar.is_terminated()
+
+
+def test_auto_accepts_byte_spelled_close(backend, tokenizer):
+    grammar = _compile(backend, "auto")
+    tokens = _encode(tokenizer, GOOD_CALL[: -len("</tool_call>")])
+    assert grammar.accept_tokens("", tokens)
+    # Spell the closing tag in regular byte tokens instead of the special
+    # token (split so the tokenizer cannot merge it back into the special).
+    for piece in ("</", "tool", "_call", ">"):
+        assert grammar.accept_tokens("", _encode(tokenizer, piece))
+    assert grammar.accept_tokens("", [tokenizer.eos_token_id])
+    assert grammar.is_terminated()
+
+
+def test_auto_enforces_argument_schema(backend, tokenizer):
+    grammar = _compile(backend, "auto")
+    bad = _encode(tokenizer, BAD_ARGS_CALL)
+    # "city" must be a string; the integer must be rejected somewhere before
+    # the end of the call.
+    assert grammar.validate_tokens(bad) != bad
+
+
+def test_required_forbids_free_text(backend, tokenizer):
+    grammar = _compile(backend, "required")
+    prose = _encode(tokenizer, "The weather is nice.")
+    assert grammar.validate_tokens(prose) != prose
+    # EOS is not allowed before at least one call was made.
+    assert grammar.validate_tokens([tokenizer.eos_token_id]) == []
+    assert grammar.accept_tokens("", _encode(tokenizer, GOOD_CALL))
+    assert grammar.accept_tokens("", [tokenizer.eos_token_id])
+    assert grammar.is_terminated()
+
+
+def test_named_stops_after_first_call(backend, tokenizer):
+    tool_choice = ChatCompletionNamedToolChoiceParam(
+        **{"type": "function", "function": {"name": "get_weather"}}
+    )
+    grammar = _compile(backend, tool_choice)
+    call = _encode(tokenizer, GOOD_CALL)
+    assert grammar.accept_tokens("", call)
+    # Exactly one call: a second one is rejected, only EOS may follow.
+    assert grammar.validate_tokens(call) != call
+    assert grammar.accept_tokens("", [tokenizer.eos_token_id])
+    assert grammar.is_terminated()
+
+
+def test_unsupported_shapes_raise_clear_error():
+    for fmt in (
+        {"type": "sequence", "elements": []},
+        {
+            "type": "triggered_tags",
+            "triggers": ["<a>"],
+            "tags": [],
+            "at_least_one": True,
+        },
+        {
+            "type": "tags_with_separator",
+            "tags": [],
+            "separator": "",
+            "at_least_one": False,
+        },
+    ):
+        spec = json.dumps({"type": "structural_tag", "format": fmt})
+        with pytest.raises(VLLMValidationError, match="Invalid grammar"):
+            serialize_guidance_grammar(StructuredOutputOptions.STRUCTURAL_TAG, spec)
+
+
+def test_legacy_format_still_compiles(backend, tokenizer):
+    spec = json.dumps(
+        {
+            "triggers": ["<tool_call>"],
+            "structures": [
+                {
+                    "begin": "<tool_call>",
+                    "schema": WEATHER_SCHEMA,
+                    "end": "</tool_call>",
+                }
+            ],
+        }
+    )
+    grammar = backend.compile_grammar(StructuredOutputOptions.STRUCTURAL_TAG, spec)
+    tokens = _encode(tokenizer, '<tool_call>{"city": "Paris"}')
+    assert grammar.accept_tokens("", tokens)

--- a/tests/v1/structured_output/test_backend_guidance_structural_tag.py
+++ b/tests/v1/structured_output/test_backend_guidance_structural_tag.py
@@ -190,3 +190,26 @@ def test_legacy_format_still_compiles(backend, tokenizer):
     grammar = backend.compile_grammar(StructuredOutputOptions.STRUCTURAL_TAG, spec)
     tokens = _encode(tokenizer, '<tool_call>{"city": "Paris"}')
     assert grammar.accept_tokens("", tokens)
+
+
+def test_legacy_format_enforces_schema(backend, tokenizer):
+    # Legacy structural tags used to hand llguidance the serialized
+    # {"grammars": [...]} envelope instead of the JSON schema itself, which
+    # llguidance silently interprets as an empty schema — leaving the tag
+    # content unconstrained.
+    spec = json.dumps(
+        {
+            "triggers": ["<tool_call>"],
+            "structures": [
+                {
+                    "begin": "<tool_call>",
+                    "schema": WEATHER_SCHEMA,
+                    "end": "</tool_call>",
+                }
+            ],
+        }
+    )
+    grammar = backend.compile_grammar(StructuredOutputOptions.STRUCTURAL_TAG, spec)
+    assert grammar.accept_tokens("", _encode(tokenizer, "<tool_call>"))
+    bad = _encode(tokenizer, '{"city": 5}')
+    assert grammar.validate_tokens(bad) != bad

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -521,7 +521,12 @@ def serialize_guidance_grammar(
                         # _process_schema returns — llguidance silently
                         # treats that envelope as an empty schema, dropping
                         # every constraint on the tag's content.
-                        grammar=_process_schema(s["schema"]),
+                        grammar=_tag_schema(
+                            s["schema"],
+                            s,
+                            disable_any_whitespace,
+                            disable_additional_properties,
+                        ),
                         end=s["end"],
                     )
                 )

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -225,6 +225,236 @@ class GuidanceGrammar(StructuredOutputGrammar):
         self.ll_matcher.reset()
 
 
+def _unsupported_structural_tag(reason: str, node: Any) -> VLLMValidationError:
+    def _shape(n: Any) -> Any:
+        if isinstance(n, dict):
+            return {k: "..." if k == "json_schema" else _shape(v) for k, v in n.items()}
+        return [_shape(x) for x in n] if isinstance(n, list) else n
+
+    try:
+        desc = json.dumps(_shape(node))[:1000]
+    except (TypeError, ValueError):
+        desc = repr(node)[:1000]
+    return VLLMValidationError(
+        f"Invalid grammar specification: structural tag {reason} is not "
+        f"supported by the guidance backend (got: {desc})"
+    )
+
+
+def _tag_schema(
+    schema: Any,
+    node: Any,
+    disable_any_whitespace: bool,
+    disable_additional_properties: bool,
+) -> dict[str, Any]:
+    """Prepare a tag's JSON schema for embedding into a llguidance grammar
+    (``StructTag.grammar`` / ``%json``). These expect an actual JSON schema —
+    not the serialized ``{"grammars": [...]}`` envelope returned by
+    ``LLMatcher.grammar_from_json_schema``, which llguidance would silently
+    read as an empty schema, dropping every constraint."""
+    if schema is True:
+        schema = {}  # boolean schema "true": any JSON value
+    if not isinstance(schema, dict):
+        raise _unsupported_structural_tag("non-object json_schema content", node)
+    if disable_additional_properties:
+        schema = process_for_additional_properties(schema)
+    else:
+        schema = copy.deepcopy(schema)
+    schema.setdefault("x-guidance", {"whitespace_flexible": not disable_any_whitespace})
+    return schema
+
+
+def _tag_parts(
+    t: Any,
+    disable_any_whitespace: bool,
+    disable_additional_properties: bool,
+) -> tuple[str, str, dict[str, Any]]:
+    """Validate one new-format ``tag`` entry -> ``(begin, end, schema)``."""
+    if not isinstance(t, dict) or t.get("type", "tag") != "tag":
+        raise _unsupported_structural_tag("entry that is not a 'tag'", t)
+    begin, end, content = t.get("begin"), t.get("end"), t.get("content")
+    if isinstance(end, list) and len(end) == 1:
+        end = end[0]
+    if not (isinstance(begin, str) and begin and isinstance(end, str)):
+        raise _unsupported_structural_tag(
+            "tag with token-level or non-string begin/end", t
+        )
+    if (
+        not isinstance(content, dict)
+        or content.get("type") != "json_schema"
+        or content.get("style", "json") != "json"
+        or content.get("any_order")
+    ):
+        raise _unsupported_structural_tag(
+            "tag content that is not plain json_schema", t
+        )
+    schema = _tag_schema(
+        content.get("json_schema"),
+        content,
+        disable_any_whitespace,
+        disable_additional_properties,
+    )
+    return begin, end, schema
+
+
+def _gtext(s: str) -> str:
+    """Lark string literal (empty string -> no element), as emitted by
+    ``llguidance.StructTag.to_grammar``."""
+    return json.dumps(s) if s else ""
+
+
+def _split_leading_special_token(begin: str) -> tuple[str, str]:
+    """Split a leading ``<...>`` special-token marker off ``begin``
+    (``StructTag.to_grammar``'s ``assume_special`` heuristic)."""
+    if begin.startswith("<"):
+        gt = begin.find(">")
+        if gt > 0 and "<" not in begin[1:gt]:
+            return begin[: gt + 1], begin[gt + 1 :]
+    return "", begin
+
+
+def _split_trailing_special_token(end: str) -> tuple[str, str]:
+    """Split a trailing ``<...>`` special-token marker off ``end``, e.g.
+    ``"}\\n</tool_call>"`` -> ``("}\\n", "</tool_call>")``."""
+    if end.endswith(">"):
+        lt = end.rfind("<")
+        if lt != -1:
+            marker = end[lt:]
+            if len(marker) > 2 and ">" not in marker[:-1] and "<" not in marker[1:]:
+                return end[:lt], marker
+    return end, ""
+
+
+def _tag_suffix(rest: str, schema: dict[str, Any], end: str) -> str:
+    """Lark elements for a tag after its opener: remaining begin literal,
+    ``%json`` body, and the end. Models emit closers like ``</tool_call>``
+    either spelled in raw bytes or as the special token — a bytes-only end
+    rejects the special token at runtime (llguidance maps unknown-special
+    bytes to 0xFF), surfacing as "grammar rejected tokens" request
+    termination — so when the end carries a ``<...>`` suffix both spellings
+    are accepted, e.g. ``("}\\n</tool_call>" | "}\\n" </tool_call>)``."""
+    elems = [_gtext(rest)] if rest else []
+    elems.append("%json " + json.dumps(schema))
+    prefix, marker = _split_trailing_special_token(end)
+    if marker:
+        both = f"{_gtext(prefix)} {marker}" if prefix else marker
+        elems.append(f"({_gtext(end)} | {both})")
+    elif end:
+        elems.append(_gtext(end))
+    return " ".join(elems)
+
+
+def _triggered_tags_lark(parts: list[tuple[str, str, str, dict[str, Any]]]) -> str:
+    """Free text with trigger-dispatched tags, zero or more times — the same
+    skeleton ``llguidance.StructTag.to_grammar`` generates, except for the
+    two-spelling end handling in ``_tag_suffix``."""
+    tag_options = " | ".join(f"tag_{i}" for i in range(len(parts)))
+    lark = (
+        "%llguidance {}\n"
+        f"start: ({tag_options})* tag_end\n"
+        "tag_end: TAG_TEXT\n"
+        "TAG_TEXT: /(.|\\n)*/\n"
+    )
+    for i, (trig, begin, end, schema) in enumerate(parts):
+        body = _tag_suffix(begin[len(trig) :], schema, end)
+        lark += "\n"
+        if trig.startswith("<") and trig.endswith(">"):
+            # trigger assumed to be a special token, as in to_grammar
+            lark += f"tag_{i}: TAG_TEXT {trig} {body}\n"
+        else:
+            lark += f"tag_{i}_trig[lazy]: TAG_TEXT {_gtext(trig)}\n"
+            lark += f"tag_{i}: tag_{i}_trig {body}\n"
+    return lark
+
+
+def _tags_with_separator_lark(
+    parts: list[tuple[str, str, dict[str, Any]]],
+    separator: str,
+    stop_after_first: bool,
+) -> str:
+    """One or more tags separated by ``separator`` with NO free text
+    (``at_least_one=true``); exactly one tag with ``stop_after_first``."""
+    bodies = []
+    for begin, end, schema in parts:
+        special, rest = _split_leading_special_token(begin)
+        suffix = _tag_suffix(rest, schema, end)
+        bodies.append(f"{special} {suffix}" if special else suffix)
+    alts = " | ".join(f"tag_{i}" for i in range(len(bodies)))
+    if stop_after_first:
+        start = f"start: {alts}"
+    elif separator:
+        start = f"start: ({alts}) ({_gtext(separator)} ({alts}))*"
+    else:
+        start = f"start: ({alts})+"
+    rules = "\n".join(f"tag_{i}: {body}" for i, body in enumerate(bodies))
+    return f"%llguidance {{}}\n{start}\n{rules}\n"
+
+
+def _serialize_structural_tag_new_format(
+    s_tag: Any,
+    disable_any_whitespace: bool,
+    disable_additional_properties: bool,
+) -> str:
+    """Translate a new-format (xgrammar-style) structural tag —
+    ``{"type": "structural_tag", "format": {...}}`` — to a llguidance
+    grammar. Covers the shapes ``vllm/tool_parsers/structural_tag_registry``
+    emits for tool calling: ``triggered_tags`` (``tool_choice="auto"`` with a
+    ``strict: true`` tool), ``tags_with_separator``
+    (``"required"``/named), and ``any_text``. Anything else raises
+    ``VLLMValidationError`` so the server surfaces a 400."""
+    fmt = s_tag.get("format") if isinstance(s_tag, dict) else None
+    if not isinstance(fmt, dict):
+        raise _unsupported_structural_tag("without a 'format' object", s_tag)
+    ftype = fmt.get("type")
+
+    if ftype == "any_text":
+        if fmt.get("excludes"):
+            raise _unsupported_structural_tag("'any_text' with excludes", fmt)
+        return llguidance.grammar_from("regex", "(?s:.*)")
+
+    if ftype == "triggered_tags":
+        triggers, tags = fmt.get("triggers"), fmt.get("tags")
+        if (
+            fmt.get("at_least_one")
+            or fmt.get("stop_after_first")
+            or fmt.get("excludes")
+            or not triggers
+            or not all(isinstance(t, str) for t in triggers)
+            or not tags
+        ):
+            raise _unsupported_structural_tag(
+                "'triggered_tags' with unsupported options", fmt
+            )
+        parts = []
+        for t in tags:
+            begin, end, schema = _tag_parts(
+                t, disable_any_whitespace, disable_additional_properties
+            )
+            trig = next((tr for tr in triggers if begin.startswith(tr)), None)
+            if trig is None:
+                raise _unsupported_structural_tag(
+                    "tag whose begin matches no trigger", fmt
+                )
+            parts.append((trig, begin, end, schema))
+        return _triggered_tags_lark(parts)
+
+    if ftype == "tags_with_separator":
+        separator, tags = fmt.get("separator"), fmt.get("tags")
+        if not fmt.get("at_least_one") or not isinstance(separator, str) or not tags:
+            raise _unsupported_structural_tag(
+                "'tags_with_separator' with unsupported options", fmt
+            )
+        parts = [
+            _tag_parts(t, disable_any_whitespace, disable_additional_properties)
+            for t in tags
+        ]
+        return _tags_with_separator_lark(
+            parts, separator, bool(fmt.get("stop_after_first"))
+        )
+
+    raise _unsupported_structural_tag(f"format type {ftype!r}", fmt)
+
+
 def serialize_guidance_grammar(
     request_type: StructuredOutputOptions,
     grammar_spec: str | dict[str, Any],
@@ -264,6 +494,15 @@ def serialize_guidance_grammar(
                 s_tag = json.loads(grammar_spec)
             else:
                 s_tag = grammar_spec
+            if not (isinstance(s_tag, dict) and "structures" in s_tag):
+                # New (xgrammar-style) structural tag format, e.g. produced by
+                # vllm.tool_parsers.structural_tag_registry for hermes tool
+                # calling (strict:true + tool_choice="auto", "required", or a
+                # named tool). Same detection as backend_xgrammar: the legacy
+                # format is {"triggers": [...], "structures": [...]}.
+                return _serialize_structural_tag_new_format(
+                    s_tag, disable_any_whitespace, disable_additional_properties
+                )
             triggers: list[str] = s_tag["triggers"]
             tags: list[llguidance.StructTag] = []
             for s in s_tag["structures"]:
@@ -277,6 +516,11 @@ def serialize_guidance_grammar(
                     llguidance.StructTag(
                         trigger=trig,
                         begin=s["begin"],
+                        # StructTag.grammar expects a JSON schema (or Lark),
+                        # not the serialized {"grammars": [...]} envelope
+                        # _process_schema returns — llguidance silently
+                        # treats that envelope as an empty schema, dropping
+                        # every constraint on the tag's content.
                         grammar=_process_schema(s["schema"]),
                         end=s["end"],
                     )


### PR DESCRIPTION
FIX #55152

## Summary

With `--structured-outputs-config '{"backend": "guidance"}'`, every tool-calling request that produces a structural tag — `tool_choice="auto"` with a `strict: true` tool, `tool_choice="required"`, or a named tool — fails at validation with `Invalid grammar specification: 'triggers'`: the tool parsers emit the new xgrammar-style format (`{"type": "structural_tag", "format": {...}}`) while the guidance backend only parsed the legacy `{"triggers": [...], "structures": [...]}` shape.

Two commits, deliberately separable:

**Commit 1 — support the new format (the bug fix).** Translates the shapes the tool-parser registry emits into llguidance grammars: `triggered_tags` (auto: free text + trigger-dispatched tags, Lark mirroring `llguidance.StructTag.to_grammar`), `tags_with_separator` (required: one-or-more tags, no free text; named: exactly one), and `any_text`. Tag ends accept the closing marker both spelled in raw bytes and as the tokenizer's special token — models emit `</tool_call>` as a special token, and a bytes-only grammar rejects it at runtime, which under speculative decoding surfaces as `grammar rejected tokens` request termination. Unsupported shapes raise `VLLMValidationError` with a clear message. Legacy path untouched.

**Commit 2 — legacy path: pass real schemas to llguidance.** `StructTag.grammar` expects a JSON schema, but the legacy path passed the serialized `{"grammars": [...]}` envelope from `grammar_from_json_schema`, which llguidance silently treats as an empty schema — legacy structural-tag content was never actually constrained. This is a behavioral fix (previously-unconstrained requests become constrained), hence the separate commit; happy to split it into its own PR if preferred.

## Testing

New `tests/v1/structured_output/test_backend_guidance_structural_tag.py` (CPU-only, Qwen3-0.6B tokenizer): special-token and byte-spelled closings accepted, argument schemas enforced, required forbids free text, named stops after one call, unsupported shapes rejected, legacy compiles and (commit 2) enforces its schema. 8/8 passing on the v0.28.0 image with these files overlaid; the legacy-enforcement test fails without commit 2, as expected.

Commit 1 is additionally validated in production: it has been serving live traffic on one of our deployments (guidance backend + speculative decoding + async scheduling) with zero grammar errors.

## AI assistance disclosure

This PR was developed with AI assistance (Claude); the fix and tests were reviewed, validated and are submitted by a human contributor. Commits carry the corresponding `Co-authored-by` trailer per the contributing guidelines.
