### PR TITLE
[Kernel][HY-V4] iHC: head op, custom-op registration, tensor-core path for large batches, warmup and tests

### DIFF
--- a/benchmarks/kernels/benchmark_hy_v4_ihc.py
+++ b/benchmarks/kernels/benchmark_hy_v4_ihc.py
@@ -5,7 +5,6 @@ and torch.compile of the eager code."""
 
 import os
 import subprocess
-from functools import partial
 from importlib.metadata import version
 from statistics import median
 
@@ -71,18 +70,30 @@ def eager_post(
 
 
 def _timer(method: str):
+    """Return ``timer(fn, args)`` measuring ``fn(*args)`` with cold L2.
+
+    The inputs are passed as ``input_args`` (not baked into a ``partial``):
+    flashinfer only flushes L2 for tensors it can see in the arguments.
+    """
     if method == "cupti":
+        try:
+            from cupti import cupti  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "cupti-python is required for --method cupti "
+                "(pip install cupti-python); or use --method cudagraph"
+            ) from e
         from flashinfer.testing import bench_gpu_time_with_cupti
 
-        return partial(
-            bench_gpu_time_with_cupti,
-            use_cuda_graph=True,
-            cold_l2_cache=True,
+        return lambda fn, args: bench_gpu_time_with_cupti(
+            fn, input_args=args, use_cuda_graph=True, cold_l2_cache=True
         )
     if method == "cudagraph":
         from flashinfer.testing import bench_gpu_time_with_cudagraph
 
-        return partial(bench_gpu_time_with_cudagraph, cold_l2_cache=True)
+        return lambda fn, args: bench_gpu_time_with_cudagraph(
+            fn, input_args=args, cold_l2_cache=True
+        )
     raise ValueError(f"unknown timing method: {method}")
 
 
@@ -177,12 +188,13 @@ def run_benchmark(
             rtol=1e-2,
         )
 
+        pre_args = (x, weight, scale, base, 2.0, 1e-6, 1e-5)
+        post_args = (block_output, residual, post)
         benchmarks = (
             (
                 "pre",
-                partial(eager_pre, x, weight, scale, base, 2.0, 1e-6, 1e-5),
-                partial(compiled_pre, x, weight, scale, base, 2.0, 1e-6, 1e-5),
-                partial(triton_ihc_pre, x, weight, scale, base, 2.0, 1e-6, 1e-5),
+                (eager_pre, compiled_pre, triton_ihc_pre),
+                pre_args,
                 x.nbytes
                 + weight.nbytes
                 + scale.nbytes
@@ -192,16 +204,14 @@ def run_benchmark(
             ),
             (
                 "post",
-                partial(eager_post, block_output, residual, post),
-                partial(compiled_post, block_output, residual, post),
-                partial(triton_ihc_post, block_output, residual, post),
+                (eager_post, compiled_post, triton_ihc_post),
+                post_args,
                 block_output.nbytes + residual.nbytes + post.nbytes + residual.nbytes,
             ),
             (
                 "head",
-                partial(eager_head, *head_args),
-                partial(compiled_head, *head_args),
-                partial(triton_ihc_head, *head_args),
+                (eager_head, compiled_head, triton_ihc_head),
+                head_args,
                 x.nbytes
                 + head_weight.nbytes
                 + head_scale.nbytes
@@ -209,10 +219,11 @@ def run_benchmark(
                 + eager_output.nbytes,
             ),
         )
-        for op_name, eager_fn, compiled_fn, triton_fn, logical_bytes in benchmarks:
-            eager_us = median(timer(eager_fn)) * 1e3
-            compile_us = median(timer(compiled_fn)) * 1e3
-            triton_us = median(timer(triton_fn)) * 1e3
+        for op_name, fns, fn_args, logical_bytes in benchmarks:
+            eager_fn, compiled_fn, triton_fn = fns
+            eager_us = median(timer(eager_fn, fn_args)) * 1e3
+            compile_us = median(timer(compiled_fn, fn_args)) * 1e3
+            triton_us = median(timer(triton_fn, fn_args)) * 1e3
             logical_gib = logical_bytes / 2**30
             triton_gbps = logical_bytes / triton_us / 1e3
             print(

--- a/benchmarks/kernels/benchmark_hy_v4_ihc.py
+++ b/benchmarks/kernels/benchmark_hy_v4_ihc.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Benchmark the HY V4 Triton iHC pre/post kernels against eager PyTorch."""
+"""Benchmark the HY V4 Triton iHC pre/post/head kernels against eager PyTorch
+and torch.compile of the eager code."""
 
 import os
 import subprocess
@@ -13,6 +14,7 @@ import torch.nn.functional as F
 
 import vllm
 from vllm.models.hy_v4.nvidia.triton_ihc import (
+    triton_ihc_head,
     triton_ihc_post,
     triton_ihc_pre,
 )
@@ -39,6 +41,23 @@ def eager_pre(
     post = magnitude * post + hc_eps
     output = torch.sum(pre.unsqueeze(-1) * x.float(), dim=1)
     return output.to(x.dtype).reshape(num_tokens, hidden_size), post
+
+
+def eager_head(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    hc_eps: float,
+    norm_eps: float,
+) -> torch.Tensor:
+    num_tokens, hc_mult, hidden_size = x.shape
+    x_flat = x.flatten(1).float()
+    reciprocal_rms = torch.rsqrt(x_flat.square().mean(-1, keepdim=True) + norm_eps)
+    mixes = F.linear(x_flat, weight) * reciprocal_rms
+    pre = torch.sigmoid(mixes * scale + base) + hc_eps
+    output = torch.sum(pre.unsqueeze(-1) * x.float(), dim=1)
+    return output.to(x.dtype).reshape(num_tokens, hidden_size)
 
 
 def eager_post(
@@ -85,7 +104,12 @@ def run_benchmark(
     )
     scale = torch.randn(2, device=device, dtype=torch.float32) * 0.01
     base = torch.randn(2 * hc_mult, device=device, dtype=torch.float32)
+    head_weight = weight[:hc_mult].contiguous()
+    head_scale, head_base = scale[:1].contiguous(), base[:hc_mult].contiguous()
     timer = _timer(method)
+    compiled_pre = torch.compile(eager_pre)
+    compiled_post = torch.compile(eager_post)
+    compiled_head = torch.compile(eager_head)
 
     properties = torch.cuda.get_device_properties(device)
     git_branch = subprocess.run(
@@ -118,9 +142,9 @@ def run_benchmark(
     )
     print(f"hidden_size: {hidden_size}; hc_mult: {hc_mult}")
     print(
-        f"{'tokens':>8} {'op':>6} {'eager (us)':>12} "
-        f"{'triton (us)':>12} {'speedup':>9} {'GiB':>8} "
-        f"{'eager GB/s':>12} {'triton GB/s':>13}"
+        f"{'tokens':>8} {'op':>6} {'eager (us)':>12} {'compile (us)':>13} "
+        f"{'triton (us)':>12} {'x eager':>9} {'x compile':>10} {'GiB':>8} "
+        f"{'triton GB/s':>13}"
     )
 
     for num_tokens in token_counts:
@@ -145,11 +169,19 @@ def run_benchmark(
             atol=0,
             rtol=0,
         )
+        head_args = (x, head_weight, head_scale, head_base, 1e-6, 1e-5)
+        torch.testing.assert_close(
+            triton_ihc_head(*head_args),
+            eager_head(*head_args),
+            atol=2e-2,
+            rtol=1e-2,
+        )
 
         benchmarks = (
             (
                 "pre",
                 partial(eager_pre, x, weight, scale, base, 2.0, 1e-6, 1e-5),
+                partial(compiled_pre, x, weight, scale, base, 2.0, 1e-6, 1e-5),
                 partial(triton_ihc_pre, x, weight, scale, base, 2.0, 1e-6, 1e-5),
                 x.nbytes
                 + weight.nbytes
@@ -161,21 +193,33 @@ def run_benchmark(
             (
                 "post",
                 partial(eager_post, block_output, residual, post),
+                partial(compiled_post, block_output, residual, post),
                 partial(triton_ihc_post, block_output, residual, post),
                 block_output.nbytes + residual.nbytes + post.nbytes + residual.nbytes,
             ),
+            (
+                "head",
+                partial(eager_head, *head_args),
+                partial(compiled_head, *head_args),
+                partial(triton_ihc_head, *head_args),
+                x.nbytes
+                + head_weight.nbytes
+                + head_scale.nbytes
+                + head_base.nbytes
+                + eager_output.nbytes,
+            ),
         )
-        for op_name, eager_fn, triton_fn, logical_bytes in benchmarks:
+        for op_name, eager_fn, compiled_fn, triton_fn, logical_bytes in benchmarks:
             eager_us = median(timer(eager_fn)) * 1e3
+            compile_us = median(timer(compiled_fn)) * 1e3
             triton_us = median(timer(triton_fn)) * 1e3
-            speedup = eager_us / triton_us
             logical_gib = logical_bytes / 2**30
-            eager_gbps = logical_bytes / eager_us / 1e3
             triton_gbps = logical_bytes / triton_us / 1e3
             print(
-                f"{num_tokens:>8} {op_name:>6} {eager_us:>12.1f} "
-                f"{triton_us:>12.1f} {speedup:>8.2f}x {logical_gib:>8.3f} "
-                f"{eager_gbps:>12.1f} {triton_gbps:>13.1f}"
+                f"{num_tokens:>8} {op_name:>6} {eager_us:>12.1f} {compile_us:>13.1f} "
+                f"{triton_us:>12.1f} {eager_us / triton_us:>8.2f}x "
+                f"{compile_us / triton_us:>9.2f}x {logical_gib:>8.3f} "
+                f"{triton_gbps:>13.1f}"
             )
 
 

--- a/tests/models/hy_v4/__init__.py
+++ b/tests/models/hy_v4/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/models/hy_v4/test_ihc_e2e.py
+++ b/tests/models/hy_v4/test_ihc_e2e.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end check of the Triton iHC ops inside the HY V4 model.
+
+The public checkpoint is ~800B parameters, so this runs a one-layer dummy-weight
+model (same hidden size / hc_mult as ``tencent/Hy4-preview``) through the full
+engine, CUDA graphs included, and compares greedy logprobs of the Triton path
+against the eager path.
+"""
+
+from functools import partial
+
+import pytest
+
+from vllm.models.hy_v4.nvidia import hc as hc_mod
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
+
+from ..utils import check_logprobs_close, dummy_hf_overrides
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda() or not HAS_TRITON,
+    reason="iHC Triton kernels require CUDA and Triton",
+)
+
+MODEL = "tencent/Hy4-preview"
+PROMPTS = [
+    "The capital of France is",
+    "def fibonacci(n):",
+    "Hyper-connections replace the residual stream with",
+    "In 2026, the most popular inference engine",
+]
+
+
+def _greedy_logprobs(vllm_runner, monkeypatch: pytest.MonkeyPatch, fused: bool):
+    calls = 0
+    real_pre = hc_mod.triton_ihc_pre
+
+    def counting_pre(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real_pre(*args, **kwargs)
+
+    with monkeypatch.context() as m:
+        # Run the engine in-process so the patches below reach the model.
+        m.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+        if fused:
+            m.setattr(hc_mod, "triton_ihc_pre", counting_pre)
+        else:
+            m.setattr(hc_mod, "triton_ihc_supported", lambda x: False)
+        with vllm_runner(
+            MODEL,
+            trust_remote_code=True,
+            load_format="dummy",
+            hf_overrides=partial(dummy_hf_overrides, model_arch="HYV4ForCausalLM"),
+            max_model_len=256,
+            max_num_seqs=4,
+            block_size=64,  # sparse MLA (FlashMLA) kernel block size
+            gpu_memory_utilization=0.6,
+            enforce_eager=False,
+        ) as vllm_model:
+            outputs = vllm_model.generate_greedy_logprobs(
+                PROMPTS, max_tokens=8, num_logprobs=5
+            )
+    if fused:
+        assert calls > 0, "Triton iHC op was not dispatched"
+    return outputs
+
+
+def test_ihc_triton_matches_eager_e2e(vllm_runner, monkeypatch: pytest.MonkeyPatch):
+    eager = _greedy_logprobs(vllm_runner, monkeypatch, fused=False)
+    fused = _greedy_logprobs(vllm_runner, monkeypatch, fused=True)
+    check_logprobs_close(
+        outputs_0_lst=eager,
+        outputs_1_lst=fused,
+        name_0="eager",
+        name_1="triton",
+    )

--- a/tests/models/hy_v4/test_ihc_ops.py
+++ b/tests/models/hy_v4/test_ihc_ops.py
@@ -42,7 +42,7 @@ HC_EPS = 1e-6
 MAGNITUDE = 2.0
 DEVICE = "cuda"
 
-TOKENS = [1, 2, 7, 16, 65, 300, 1024]
+TOKENS = [1, 2, 7, 16, 127, 128, 129, 300, 1024]
 HIDDEN = [512, 4096, 6144]
 DTYPES = [torch.bfloat16, torch.float16]
 
@@ -198,7 +198,7 @@ def test_ihc_gate_math_sanity() -> None:
     torch.testing.assert_close(post, expected_post, atol=1e-6, rtol=1e-6)
 
 
-@pytest.mark.parametrize("tokens", [1, 5, 64])
+@pytest.mark.parametrize("tokens", [1, 5, 128])
 def test_ihc_opcheck(tokens: int) -> None:
     hidden = 512
     x = torch.randn(tokens, HC, hidden, dtype=torch.bfloat16, device=DEVICE)
@@ -228,15 +228,16 @@ def _run_all_ops(tokens: int, hidden: int) -> None:
     triton_ihc_post(y, x, post)
 
 
-def test_ihc_warmup_covers_compile_keys() -> None:
-    """One launch per op at startup compiles every Triton variant the model
-    will use: the token count is not part of the compile key (what
-    ``hy_v4_ihc_warmup`` relies on)."""
-    hidden = 512
+def test_ihc_warmup_token_sizes_cover_compile_keys() -> None:
+    """Running the ops at ``warmup_token_sizes`` compiles every Triton variant
+    reachable below ``max_tokens`` (what ``hy_v4_ihc_warmup`` relies on)."""
+    hidden, max_tokens = 512, 2048
     device_index = torch.accelerator.current_device_index()
     kernels = (
         triton_ihc._ihc_pre_stage1,
         triton_ihc._ihc_pre_stage2,
+        triton_ihc._ihc_stats_kernel,
+        triton_ihc._ihc_apply_kernel,
         triton_ihc._ihc_post_kernel,
     )
     if not all(hasattr(k, "device_caches") for k in kernels):
@@ -249,11 +250,14 @@ def test_ihc_warmup_covers_compile_keys() -> None:
             if device_index in k.device_caches
         )
 
-    _run_all_ops(1, hidden)
+    sizes = triton_ihc.warmup_token_sizes(hidden, HC, max_tokens, device_index)
+    assert len(sizes) < 64, sizes
+    for tokens in sizes:
+        _run_all_ops(tokens, hidden)
     torch.accelerator.synchronize()
     warmed = compiled_variants()
     assert warmed > 0
-    for tokens in (2, 3, 16, 17, 64, 300, 1024, 2048):
+    for tokens in [*range(1, max_tokens + 1, 13), 127, 128, 129, max_tokens]:
         _run_all_ops(tokens, hidden)
     torch.accelerator.synchronize()
     assert compiled_variants() == warmed

--- a/tests/models/hy_v4/test_ihc_ops.py
+++ b/tests/models/hy_v4/test_ihc_ops.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Parity of the Triton iHC ops (pre / post / head) against the eager HY V4
+layers, plus custom-op and warmup checks."""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.hy_v4.nvidia import hc as hc_mod
+from vllm.models.hy_v4.nvidia import triton_ihc
+from vllm.models.hy_v4.nvidia.hc import (
+    HYV4HCHeadLayer,
+    HYV4HCPostLayer,
+    HYV4HCPreLayer,
+)
+from vllm.models.hy_v4.nvidia.triton_ihc import (
+    triton_ihc_head,
+    triton_ihc_post,
+    triton_ihc_pre,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda() or not HAS_TRITON,
+    reason="iHC Triton kernels require CUDA and Triton",
+)
+
+
+@pytest.fixture(autouse=True)
+def _vllm_env(dist_init, default_vllm_config):
+    """ReplicatedLinear needs a TP group and a current VllmConfig."""
+    yield
+
+
+HC = 4
+NORM_EPS = 1e-5
+HC_EPS = 1e-6
+MAGNITUDE = 2.0
+DEVICE = "cuda"
+
+TOKENS = [1, 2, 7, 16, 65, 300, 1024]
+HIDDEN = [512, 4096, 6144]
+DTYPES = [torch.bfloat16, torch.float16]
+
+
+def _config(hidden_size: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        hidden_size=hidden_size,
+        hc_mult=HC,
+        hc_magnitude=MAGNITUDE,
+        hc_eps=HC_EPS,
+        rms_norm_eps=NORM_EPS,
+        enable_ihc=True,
+    )
+
+
+def _randomize_gates(scale: torch.Tensor, base: torch.Tensor) -> None:
+    # Init values (0.01 scale) leave every gate near its bias; perturb so the
+    # normalization + projection path actually affects the output.
+    with torch.no_grad():
+        scale.fill_(0.5)
+        base.add_(torch.randn_like(base) * 0.3)
+
+
+def _make_pre(hidden: int) -> HYV4HCPreLayer:
+    layer = HYV4HCPreLayer(
+        _config(hidden), hidden, HC, MAGNITUDE, 6e-3, 0.0, HC_EPS, NORM_EPS
+    ).to(DEVICE)
+    layer.hpc_op = None
+    with torch.no_grad():
+        layer.hc_fn.weight.normal_(std=6e-3)
+    _randomize_gates(layer.hc_scale, layer.hc_base)
+    return layer
+
+
+def _make_head(hidden: int) -> HYV4HCHeadLayer:
+    layer = HYV4HCHeadLayer(_config(hidden), hidden, HC, HC_EPS).to(DEVICE)
+    layer.hpc_op = None
+    with torch.no_grad():
+        layer.hc_head_fn.weight.normal_(std=6e-3)
+    _randomize_gates(layer.hc_head_scale, layer.hc_head_base)
+    return layer
+
+
+def _eager(monkeypatch: pytest.MonkeyPatch, layer, *args):
+    """Run the layer on its eager path (Triton dispatch disabled)."""
+    with monkeypatch.context() as m:
+        m.setattr(hc_mod, "triton_ihc_supported", lambda x: False)
+        return layer(*args)
+
+
+@pytest.mark.parametrize("tokens", TOKENS)
+@pytest.mark.parametrize("hidden", HIDDEN)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_ihc_pre_matches_eager(
+    tokens: int, hidden: int, dtype: torch.dtype, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    torch.manual_seed(0)
+    layer = _make_pre(hidden)
+    x = torch.randn(tokens, HC, hidden, dtype=dtype, device=DEVICE)
+
+    ref_y, ref_post = _eager(monkeypatch, layer, x)
+    y, post = triton_ihc_pre(
+        x,
+        layer.hc_fn.weight,
+        layer.hc_scale,
+        layer.hc_base,
+        MAGNITUDE,
+        HC_EPS,
+        NORM_EPS,
+    )
+    torch.testing.assert_close(post, ref_post, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(y, ref_y, atol=2e-2, rtol=2e-2)
+    # The layer itself dispatches to the Triton op on this platform.
+    y2, post2 = layer(x)
+    torch.testing.assert_close(y2, y)
+    torch.testing.assert_close(post2, post)
+
+
+@pytest.mark.parametrize("tokens", TOKENS)
+@pytest.mark.parametrize("hidden", HIDDEN)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_ihc_head_matches_eager(
+    tokens: int, hidden: int, dtype: torch.dtype, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    torch.manual_seed(0)
+    layer = _make_head(hidden)
+    x = torch.randn(tokens, HC, hidden, dtype=dtype, device=DEVICE)
+
+    ref = _eager(monkeypatch, layer, x)
+    y = triton_ihc_head(
+        x,
+        layer.hc_head_fn.weight,
+        layer.hc_head_scale,
+        layer.hc_head_base,
+        HC_EPS,
+        NORM_EPS,
+    )
+    torch.testing.assert_close(y, ref, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(layer(x), y)
+
+
+@pytest.mark.parametrize("tokens", TOKENS)
+@pytest.mark.parametrize("hidden", HIDDEN)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_ihc_post_matches_eager(
+    tokens: int, hidden: int, dtype: torch.dtype, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    torch.manual_seed(0)
+    layer = HYV4HCPostLayer(_config(hidden))
+    layer.hpc_op = None
+    x = torch.randn(tokens, hidden, dtype=dtype, device=DEVICE)
+    residual = torch.randn(tokens, HC, hidden, dtype=dtype, device=DEVICE)
+    post = (
+        torch.rand(tokens, HC, dtype=torch.float32, device=DEVICE) * MAGNITUDE + HC_EPS
+    )
+
+    ref = _eager(monkeypatch, layer, x, residual, post)
+    y = triton_ihc_post(x, residual, post)
+    torch.testing.assert_close(y, ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(layer(x, residual, post), y)
+
+
+def test_ihc_pre_strided_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A channel-strided view (e.g. a slice of a wider buffer) is handled."""
+    torch.manual_seed(0)
+    hidden = 1024
+    layer = _make_pre(hidden)
+    wide = torch.randn(9, HC, 2 * hidden, dtype=torch.bfloat16, device=DEVICE)
+    x = wide[:, :, :hidden]
+    ref_y, ref_post = _eager(monkeypatch, layer, x)
+    y, post = layer(x)
+    torch.testing.assert_close(post, ref_post, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(y, ref_y, atol=2e-2, rtol=2e-2)
+
+
+def test_ihc_gate_math_sanity() -> None:
+    """With zero projection weight the gates reduce to sigmoid(base) + eps."""
+    hidden = 256
+    x = torch.randn(3, HC, hidden, dtype=torch.bfloat16, device=DEVICE)
+    weight = torch.zeros(2 * HC, HC * hidden, dtype=torch.float32, device=DEVICE)
+    scale = torch.full((2,), 0.5, dtype=torch.float32, device=DEVICE)
+    base = torch.cat(
+        [
+            torch.full((HC,), -math.log(HC - 1.0), device=DEVICE),
+            torch.zeros(HC, device=DEVICE),
+        ]
+    )
+    y, post = triton_ihc_pre(x, weight, scale, base, MAGNITUDE, HC_EPS, NORM_EPS)
+    pre_gate = torch.sigmoid(base[:HC]) + HC_EPS
+    expected_y = (pre_gate[None, :, None] * x.float()).sum(1).to(x.dtype)
+    torch.testing.assert_close(y, expected_y, atol=2e-2, rtol=2e-2)
+    expected_post = (MAGNITUDE * torch.sigmoid(base[HC:]) + HC_EPS).expand(3, HC)
+    torch.testing.assert_close(post, expected_post, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.parametrize("tokens", [1, 5, 64])
+def test_ihc_opcheck(tokens: int) -> None:
+    hidden = 512
+    x = torch.randn(tokens, HC, hidden, dtype=torch.bfloat16, device=DEVICE)
+    w = torch.randn(2 * HC, HC * hidden, dtype=torch.float32, device=DEVICE) * 6e-3
+    scale = torch.full((2,), 0.5, dtype=torch.float32, device=DEVICE)
+    base = torch.randn(2 * HC, dtype=torch.float32, device=DEVICE)
+    torch.library.opcheck(
+        torch.ops.vllm.hy_v4_ihc_pre, (x, w, scale, base, MAGNITUDE, HC_EPS, NORM_EPS)
+    )
+    torch.library.opcheck(
+        torch.ops.vllm.hy_v4_ihc_head,
+        (x, w[:HC].contiguous(), scale[:1], base[:HC].contiguous(), HC_EPS, NORM_EPS),
+    )
+    residual = torch.randn(tokens, HC, hidden, dtype=torch.bfloat16, device=DEVICE)
+    post = torch.rand(tokens, HC, dtype=torch.float32, device=DEVICE)
+    torch.library.opcheck(torch.ops.vllm.hy_v4_ihc_post, (x[:, 0], residual, post))
+
+
+def _run_all_ops(tokens: int, hidden: int) -> None:
+    x = torch.randn(tokens, HC, hidden, dtype=torch.bfloat16, device=DEVICE)
+    w = torch.randn(2 * HC, HC * hidden, dtype=torch.float32, device=DEVICE) * 6e-3
+    scale = torch.full((2,), 0.5, dtype=torch.float32, device=DEVICE)
+    base = torch.zeros(2 * HC, dtype=torch.float32, device=DEVICE)
+    y, post = triton_ihc_pre(x, w, scale, base, MAGNITUDE, HC_EPS, NORM_EPS)
+    w_head, base_head = w[:HC].contiguous(), base[:HC].contiguous()
+    triton_ihc_head(x, w_head, scale[:1], base_head, HC_EPS, NORM_EPS)
+    triton_ihc_post(y, x, post)
+
+
+def test_ihc_warmup_covers_compile_keys() -> None:
+    """One launch per op at startup compiles every Triton variant the model
+    will use: the token count is not part of the compile key (what
+    ``hy_v4_ihc_warmup`` relies on)."""
+    hidden = 512
+    device_index = torch.accelerator.current_device_index()
+    kernels = (
+        triton_ihc._ihc_pre_stage1,
+        triton_ihc._ihc_pre_stage2,
+        triton_ihc._ihc_post_kernel,
+    )
+    if not all(hasattr(k, "device_caches") for k in kernels):
+        pytest.skip("triton JITFunction.device_caches not available")
+
+    def compiled_variants() -> int:
+        return sum(
+            len(k.device_caches[device_index][0])
+            for k in kernels
+            if device_index in k.device_caches
+        )
+
+    _run_all_ops(1, hidden)
+    torch.accelerator.synchronize()
+    warmed = compiled_variants()
+    assert warmed > 0
+    for tokens in (2, 3, 16, 17, 64, 300, 1024, 2048):
+        _run_all_ops(tokens, hidden)
+    torch.accelerator.synchronize()
+    assert compiled_variants() == warmed

--- a/vllm/model_executor/warmup/hy_v4_ihc_warmup.py
+++ b/vllm/model_executor/warmup/hy_v4_ihc_warmup.py
@@ -2,10 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Warm up the HY V4 Triton iHC kernels before serving requests.
 
-``triton_ihc_pre`` / ``post`` / ``head`` run in every decoder layer. Their
-compile keys depend only on the model shape (hidden size, ``hc_mult``, eps and
-magnitude constants), so one launch per op compiles everything the model will
-ever use. No-op for other models and for the HPC / eager paths.
+``triton_ihc_pre`` / ``post`` / ``head`` run in every decoder layer, and the
+large-batch (tensor-core) path's compile keys depend on the token count, so
+``warmup_token_sizes`` enumerates one representative batch size per key and
+each is launched once here instead of on the first request that hits it.
+No-op for other models and for the HPC / eager paths.
 """
 
 import time
@@ -17,17 +18,26 @@ from vllm.tracing import instrument
 
 logger = init_logger(__name__)
 
-_WARMUP_TOKENS = (1, 16)
+_WARMUP_MAX_TOKENS = 16_384
 
 
 @instrument(span_name="HY V4 iHC warmup")
-def hy_v4_ihc_warmup(model: torch.nn.Module, *, dtype: torch.dtype) -> None:
+def hy_v4_ihc_warmup(
+    model: torch.nn.Module,
+    *,
+    dtype: torch.dtype,
+    max_tokens: int,
+    cudagraph_capture_sizes: list[int] | None = None,
+) -> None:
     config = getattr(model, "config", None)
     if config is None or getattr(config, "model_type", None) != "hy_v4":
         return
 
     from vllm.models.hy_v4.nvidia.hc import HYV4HCHeadLayer, HYV4HCLayer
-    from vllm.models.hy_v4.nvidia.triton_ihc import triton_ihc_supported
+    from vllm.models.hy_v4.nvidia.triton_ihc import (
+        triton_ihc_supported,
+        warmup_token_sizes,
+    )
 
     hc_layer = next(
         (m for m in model.modules() if isinstance(m, HYV4HCLayer) and m.enable_ihc),
@@ -38,21 +48,26 @@ def hy_v4_ihc_warmup(model: torch.nn.Module, *, dtype: torch.dtype) -> None:
     device = hc_layer.hc_pre.hc_fn.weight.device
     hidden_size = int(config.hidden_size)
     hc_mult = int(config.hc_mult)
-    x = torch.zeros(
-        max(_WARMUP_TOKENS), hc_mult, hidden_size, dtype=dtype, device=device
-    )
+    max_tokens = min(max_tokens, _WARMUP_MAX_TOKENS)
+    sizes = set(warmup_token_sizes(hidden_size, hc_mult, max_tokens, device.index or 0))
+    sizes.update(s for s in (cudagraph_capture_sizes or []) if 1 <= s <= max_tokens)
+    if not sizes:
+        return
+    x = torch.zeros(max(sizes), hc_mult, hidden_size, dtype=dtype, device=device)
     if not triton_ihc_supported(x):
         return
     head = next((m for m in model.modules() if isinstance(m, HYV4HCHeadLayer)), None)
 
     started = time.perf_counter()
     with torch.inference_mode():
-        for size in _WARMUP_TOKENS:
+        for size in sorted(sizes):
             reduced, post_gates, residual = hc_layer.pre(x[:size])
             hc_layer.post(reduced, residual, post_gates)
             if head is not None and head.hpc_op is None:
                 head(x[:size])
         torch.accelerator.synchronize()
     logger.info(
-        "HY V4 iHC Triton warmup finished in %.2f s", time.perf_counter() - started
+        "HY V4 iHC Triton warmup: %d token sizes in %.2f s",
+        len(sizes),
+        time.perf_counter() - started,
     )

--- a/vllm/model_executor/warmup/hy_v4_ihc_warmup.py
+++ b/vllm/model_executor/warmup/hy_v4_ihc_warmup.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Warm up the HY V4 Triton iHC kernels before serving requests.
+
+``triton_ihc_pre`` / ``post`` / ``head`` run in every decoder layer. Their
+compile keys depend only on the model shape (hidden size, ``hc_mult``, eps and
+magnitude constants), so one launch per op compiles everything the model will
+ever use. No-op for other models and for the HPC / eager paths.
+"""
+
+import time
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.tracing import instrument
+
+logger = init_logger(__name__)
+
+_WARMUP_TOKENS = (1, 16)
+
+
+@instrument(span_name="HY V4 iHC warmup")
+def hy_v4_ihc_warmup(model: torch.nn.Module, *, dtype: torch.dtype) -> None:
+    config = getattr(model, "config", None)
+    if config is None or getattr(config, "model_type", None) != "hy_v4":
+        return
+
+    from vllm.models.hy_v4.nvidia.hc import HYV4HCHeadLayer, HYV4HCLayer
+    from vllm.models.hy_v4.nvidia.triton_ihc import triton_ihc_supported
+
+    hc_layer = next(
+        (m for m in model.modules() if isinstance(m, HYV4HCLayer) and m.enable_ihc),
+        None,
+    )
+    if hc_layer is None or hc_layer.hc_pre.hpc_op is not None:
+        return
+    device = hc_layer.hc_pre.hc_fn.weight.device
+    hidden_size = int(config.hidden_size)
+    hc_mult = int(config.hc_mult)
+    x = torch.zeros(
+        max(_WARMUP_TOKENS), hc_mult, hidden_size, dtype=dtype, device=device
+    )
+    if not triton_ihc_supported(x):
+        return
+    head = next((m for m in model.modules() if isinstance(m, HYV4HCHeadLayer)), None)
+
+    started = time.perf_counter()
+    with torch.inference_mode():
+        for size in _WARMUP_TOKENS:
+            reduced, post_gates, residual = hc_layer.pre(x[:size])
+            hc_layer.post(reduced, residual, post_gates)
+            if head is not None and head.hpc_op is None:
+                head(x[:size])
+        torch.accelerator.synchronize()
+    logger.info(
+        "HY V4 iHC Triton warmup finished in %.2f s", time.perf_counter() - started
+    )

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -163,7 +163,12 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
         max_tokens=worker.scheduler_config.max_num_batched_tokens,
         cudagraph_capture_sizes=cudagraph_capture_sizes,
     )
-    hy_v4_ihc_warmup(worker.get_model(), dtype=worker.model_config.dtype)
+    hy_v4_ihc_warmup(
+        worker.get_model(),
+        dtype=worker.model_config.dtype,
+        max_tokens=worker.scheduler_config.max_num_batched_tokens,
+        cudagraph_capture_sizes=cudagraph_capture_sizes,
+    )
 
     # Run next so input-prep kernels JIT against pristine runner state.
     if worker.vllm_config.kernel_config.enable_jit_warmup:

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -28,6 +28,7 @@ from vllm.model_executor.warmup.flashinfer_sparse_mla_warmup import (
     deepseek_v4_sparse_mla_attention_warmup,
     flashinfer_sparse_mla_decode_autotune_warmup,
 )
+from vllm.model_executor.warmup.hy_v4_ihc_warmup import hy_v4_ihc_warmup
 from vllm.model_executor.warmup.kimi_k3_triton_warmup import (
     kimi_k3_triton_warmup,
 )
@@ -162,6 +163,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
         max_tokens=worker.scheduler_config.max_num_batched_tokens,
         cudagraph_capture_sizes=cudagraph_capture_sizes,
     )
+    hy_v4_ihc_warmup(worker.get_model(), dtype=worker.model_config.dtype)
 
     # Run next so input-prep kernels JIT against pristine runner state.
     if worker.vllm_config.kernel_config.enable_jit_warmup:

--- a/vllm/models/hy_v4/nvidia/hc.py
+++ b/vllm/models/hy_v4/nvidia/hc.py
@@ -9,8 +9,8 @@ scatters the result back over the channels (``HYV4HCPostLayer``). The final
 ``HYV4HCHeadLayer`` merges the channels before the model's output norm.
 
 NOTE: Each of the three steps has an optional single-kernel HPC replacement
-(``HpcIHCPre`` / ``HpcIHCPost`` / ``HpcIHCHead``). Pre and post fall back to
-in-tree Triton kernels on CUDA when HPC is unavailable, then to the eager path.
+(``HpcIHCPre`` / ``HpcIHCPost`` / ``HpcIHCHead``). Pre, post and head fall back
+to in-tree Triton kernels on CUDA when HPC is unavailable, then to the eager path.
 TODO: port the cross-layer post+pre fusion (``HpcIHCPostPre``) as well; it
 requires restructuring the decoder-layer forward scheduling.
 """
@@ -22,6 +22,7 @@ from transformers import PretrainedConfig
 from vllm.model_executor.layers.hpc import HpcIHCHead, HpcIHCPost, HpcIHCPre
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.models.hy_v4.nvidia.triton_ihc import (
+    triton_ihc_head,
     triton_ihc_post,
     triton_ihc_pre,
     triton_ihc_supported,
@@ -275,6 +276,15 @@ class HYV4HCHeadLayer(nn.Module):
         """
         if self.hpc_op is not None:
             return self.hpc_op(x)
+        if triton_ihc_supported(x):
+            return triton_ihc_head(
+                x,
+                self.hc_head_fn.weight,
+                self.hc_head_scale,
+                self.hc_head_base,
+                self.hc_eps,
+                self.config.rms_norm_eps,
+            )
 
         shape, x_dtype = x.size(), x.dtype
 

--- a/vllm/models/hy_v4/nvidia/triton_ihc.py
+++ b/vllm/models/hy_v4/nvidia/triton_ihc.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Triton iHC pre/post kernels for HY V4.
+"""Triton iHC pre / post / head kernels for HY V4.
 
 Adapted from the SGLang HY V4 implementation:
 https://github.com/sgl-project/sglang/pull/36805
+
+The ops are registered as custom ops with fake impls
+(torch.ops.vllm.hy_v4_ihc_pre / post / head) so they stay opaque to
+torch.compile and are safe inside CUDA graphs. head is pre without the post
+gates (HAS_POST=False) and shares its two kernels.
 """
 
 import torch
@@ -11,6 +16,7 @@ import torch
 from vllm import envs
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
 
 _BLOCK_K = 1024
 _BLOCK_D = 1024
@@ -38,6 +44,7 @@ def _ihc_pre_stage1(
     NUM_SPLITS: tl.constexpr,
     BLOCK_K: tl.constexpr,
     PARTIAL_STRIDE: tl.constexpr,
+    HAS_POST: tl.constexpr,
 ):
     token_idx = tl.program_id(0).to(tl.int64)
     split_idx = tl.program_id(1)
@@ -59,20 +66,20 @@ def _ihc_pre_stage1(
         tl.load(weight_ptr + weight_offsets, mask=weight_mask, other=0.0) * x[None, :],
         axis=1,
     )
-    post_mix = tl.sum(
-        tl.load(
-            weight_ptr + HC_MULT * K_TOTAL + weight_offsets,
-            mask=weight_mask,
-            other=0.0,
-        )
-        * x[None, :],
-        axis=1,
-    )
-
     partial = partial_ptr + (token_idx * NUM_SPLITS + split_idx) * PARTIAL_STRIDE
     tl.store(partial, sum_squares)
     tl.store(partial + 1 + hc_idx, pre_mix, mask=hc_mask)
-    tl.store(partial + 1 + HC_POW2 + hc_idx, post_mix, mask=hc_mask)
+    if HAS_POST:
+        post_mix = tl.sum(
+            tl.load(
+                weight_ptr + HC_MULT * K_TOTAL + weight_offsets,
+                mask=weight_mask,
+                other=0.0,
+            )
+            * x[None, :],
+            axis=1,
+        )
+        tl.store(partial + 1 + HC_POW2 + hc_idx, post_mix, mask=hc_mask)
 
 
 @triton.jit
@@ -93,6 +100,7 @@ def _ihc_pre_stage2(
     MAGNITUDE: tl.constexpr,
     NORM_EPS: tl.constexpr,
     HC_EPS: tl.constexpr,
+    HAS_POST: tl.constexpr,
 ):
     token_idx = tl.program_id(0).to(tl.int64)
     hidden_block_idx = tl.program_id(1)
@@ -107,29 +115,32 @@ def _ihc_pre_stage2(
         partial = partial_row + split_idx * PARTIAL_STRIDE
         sum_squares += tl.load(partial)
         pre_mix += tl.load(partial + 1 + hc_idx, mask=hc_mask, other=0.0)
-        post_mix += tl.load(
-            partial + 1 + HC_POW2 + hc_idx,
-            mask=hc_mask,
-            other=0.0,
-        )
+        if HAS_POST:
+            post_mix += tl.load(
+                partial + 1 + HC_POW2 + hc_idx,
+                mask=hc_mask,
+                other=0.0,
+            )
 
     reciprocal_rms = tl.rsqrt(sum_squares / K_TOTAL + NORM_EPS)
     pre_scale = tl.load(scale_ptr)
-    post_scale = tl.load(scale_ptr + 1)
     pre_base = tl.load(base_ptr + hc_idx, mask=hc_mask, other=0.0)
-    post_base = tl.load(base_ptr + HC_MULT + hc_idx, mask=hc_mask, other=0.0)
     pre = tl.sigmoid(pre_mix * reciprocal_rms * pre_scale + pre_base) + HC_EPS
 
-    if hidden_block_idx == 0:
-        post = (
-            MAGNITUDE * tl.sigmoid(post_mix * reciprocal_rms * post_scale + post_base)
-            + HC_EPS
-        )
-        tl.store(
-            post_ptr + token_idx * HC_MULT + hc_idx,
-            post,
-            mask=hc_mask,
-        )
+    if HAS_POST:  # noqa: SIM102 - constexpr branch, keep apart from the runtime one
+        if hidden_block_idx == 0:
+            post_scale = tl.load(scale_ptr + 1)
+            post_base = tl.load(base_ptr + HC_MULT + hc_idx, mask=hc_mask, other=0.0)
+            post = (
+                MAGNITUDE
+                * tl.sigmoid(post_mix * reciprocal_rms * post_scale + post_base)
+                + HC_EPS
+            )
+            tl.store(
+                post_ptr + token_idx * HC_MULT + hc_idx,
+                post,
+                mask=hc_mask,
+            )
 
     hidden_offsets = hidden_block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
     hidden_mask = hidden_offsets < HIDDEN_SIZE
@@ -196,7 +207,7 @@ def _ihc_post_kernel(
         )
 
 
-def triton_ihc_pre(
+def _ihc_reduce(
     x: torch.Tensor,
     weight: torch.Tensor,
     scale: torch.Tensor,
@@ -204,8 +215,9 @@ def triton_ihc_pre(
     magnitude: float,
     hc_eps: float,
     norm_eps: float,
+    has_post: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Reduce iHC channels and produce the post gates."""
+    """Shared launch for pre (with post gates) and head (without)."""
     assert x.dim() == 3
     assert x.is_cuda and weight.is_cuda and scale.is_cuda and base.is_cuda
     assert weight.dtype == torch.float32
@@ -217,21 +229,23 @@ def triton_ihc_pre(
     base = base.contiguous()
     num_tokens, hc_mult, hidden_size = x.shape
     k_total = hc_mult * hidden_size
-    assert weight.shape == (2 * hc_mult, k_total)
-    assert scale.shape == (2,)
-    assert base.shape == (2 * hc_mult,)
+    n_out = 2 * hc_mult if has_post else hc_mult
+    assert weight.shape == (n_out, k_total)
+    assert scale.shape == (2 if has_post else 1,)
+    assert base.shape == (n_out,)
 
+    post_rows = hc_mult if has_post else 0
     if num_tokens == 0:
         return (
             torch.empty((0, hidden_size), dtype=x.dtype, device=x.device),
-            torch.empty((0, hc_mult), dtype=torch.float32, device=x.device),
+            torch.empty((0, post_rows), dtype=torch.float32, device=x.device),
         )
 
     output = torch.empty((num_tokens, hidden_size), dtype=x.dtype, device=x.device)
-    post = torch.empty((num_tokens, hc_mult), dtype=torch.float32, device=x.device)
+    post = torch.empty((num_tokens, post_rows), dtype=torch.float32, device=x.device)
     hc_pow2 = triton.next_power_of_2(hc_mult)
     num_splits = triton.cdiv(k_total, _BLOCK_K)
-    partial_stride = 1 + 2 * hc_pow2
+    partial_stride = 1 + (2 if has_post else 1) * hc_pow2
     partial = torch.empty(
         (num_tokens, num_splits, partial_stride),
         dtype=torch.float32,
@@ -248,6 +262,7 @@ def triton_ihc_pre(
         NUM_SPLITS=num_splits,
         BLOCK_K=_BLOCK_K,
         PARTIAL_STRIDE=partial_stride,
+        HAS_POST=has_post,
         num_warps=8,
         enable_fp_fusion=False,
     )
@@ -268,18 +283,96 @@ def triton_ihc_pre(
         MAGNITUDE=magnitude,
         NORM_EPS=norm_eps,
         HC_EPS=hc_eps,
+        HAS_POST=has_post,
         num_warps=4,
         enable_fp_fusion=False,
     )
     return output, post
 
 
-def triton_ihc_post(
+def _triton_ihc_pre(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    magnitude: float,
+    hc_eps: float,
+    norm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _ihc_reduce(x, weight, scale, base, magnitude, hc_eps, norm_eps, True)
+
+
+def _triton_ihc_pre_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    magnitude: float,
+    hc_eps: float,
+    norm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, hc_mult, hidden_size = x.shape
+    return (
+        x.new_empty((num_tokens, hidden_size)),
+        x.new_empty((num_tokens, hc_mult), dtype=torch.float32),
+    )
+
+
+def _triton_ihc_head(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    hc_eps: float,
+    norm_eps: float,
+) -> torch.Tensor:
+    return _ihc_reduce(x, weight, scale, base, 1.0, hc_eps, norm_eps, False)[0]
+
+
+def _triton_ihc_head_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    hc_eps: float,
+    norm_eps: float,
+) -> torch.Tensor:
+    num_tokens, _, hidden_size = x.shape
+    return x.new_empty((num_tokens, hidden_size))
+
+
+def triton_ihc_pre(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    magnitude: float,
+    hc_eps: float,
+    norm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reduce iHC channels and produce the post gates."""
+    return torch.ops.vllm.hy_v4_ihc_pre(
+        x, weight, scale, base, magnitude, hc_eps, norm_eps
+    )
+
+
+def triton_ihc_head(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    hc_eps: float,
+    norm_eps: float,
+) -> torch.Tensor:
+    """Reduce iHC channels for the head layer (no post gates)."""
+    return torch.ops.vllm.hy_v4_ihc_head(x, weight, scale, base, hc_eps, norm_eps)
+
+
+def _triton_ihc_post(
     x: torch.Tensor,
     residual: torch.Tensor,
     post: torch.Tensor,
 ) -> torch.Tensor:
-    """Scatter a sub-block output back over the iHC residual channels."""
     assert x.dim() == 2
     assert x.is_cuda and residual.is_cuda and post.is_cuda
     assert post.dtype == torch.float32
@@ -311,3 +404,37 @@ def triton_ihc_post(
         enable_fp_fusion=False,
     )
     return output
+
+
+def _triton_ihc_post_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post: torch.Tensor,
+) -> torch.Tensor:
+    return residual.new_empty(residual.shape)
+
+
+def triton_ihc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post: torch.Tensor,
+) -> torch.Tensor:
+    """Scatter a sub-block output back over the iHC residual channels."""
+    return torch.ops.vllm.hy_v4_ihc_post(x, residual, post)
+
+
+direct_register_custom_op(
+    op_name="hy_v4_ihc_pre",
+    op_func=_triton_ihc_pre,
+    fake_impl=_triton_ihc_pre_fake,
+)
+direct_register_custom_op(
+    op_name="hy_v4_ihc_head",
+    op_func=_triton_ihc_head,
+    fake_impl=_triton_ihc_head_fake,
+)
+direct_register_custom_op(
+    op_name="hy_v4_ihc_post",
+    op_func=_triton_ihc_post,
+    fake_impl=_triton_ihc_post_fake,
+)

--- a/vllm/models/hy_v4/nvidia/triton_ihc.py
+++ b/vllm/models/hy_v4/nvidia/triton_ihc.py
@@ -11,6 +11,8 @@ torch.compile and are safe inside CUDA graphs. head is pre without the post
 gates (HAS_POST=False) and shares its two kernels.
 """
 
+import functools
+
 import torch
 
 from vllm import envs
@@ -170,41 +172,334 @@ def _ihc_post_kernel(
     output_ptr,
     HIDDEN_SIZE: tl.constexpr,
     HC_MULT: tl.constexpr,
-    HC_POW2: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    launch_pdl: tl.constexpr,
 ):
-    token_idx = tl.program_id(0).to(tl.int64)
-    hidden_block_idx = tl.program_id(1)
-    hc_idx = tl.arange(0, HC_POW2)
-    hc_mask = hc_idx < HC_MULT
-    post = tl.load(
-        post_ptr + token_idx * HC_MULT + hc_idx,
-        mask=hc_mask,
-        other=0.0,
-    )
+    """output[t, c, :] = post[t, c] * x[t, :] + residual[t, c, :].
 
-    hidden_offsets = hidden_block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
+    One program per (token, channel, hidden-dim tile), tile fastest, so
+    consecutive programs stream consecutive memory of the ``[T, HC, D]``
+    residual / output (the op is bandwidth-bound; x is re-read from L2).
+    """
+    pid = tl.program_id(0).to(tl.int64)
+    n_tiles: tl.constexpr = (HIDDEN_SIZE + BLOCK_D - 1) // BLOCK_D
+    tile = pid % n_tiles
+    channel_idx = (pid // n_tiles) % HC_MULT
+    token_idx = pid // (n_tiles * HC_MULT)
+
+    hidden_offsets = tile * BLOCK_D + tl.arange(0, BLOCK_D)
     hidden_mask = hidden_offsets < HIDDEN_SIZE
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
     x = tl.load(
         x_ptr + token_idx * HIDDEN_SIZE + hidden_offsets,
         mask=hidden_mask,
         other=0.0,
     ).to(tl.float32)
-    residual_row = residual_ptr + token_idx * HC_MULT * HIDDEN_SIZE
-    output_row = output_ptr + token_idx * HC_MULT * HIDDEN_SIZE
-    for channel_idx in tl.static_range(HC_MULT):
-        residual = tl.load(
-            residual_row + channel_idx * HIDDEN_SIZE + hidden_offsets,
-            mask=hidden_mask,
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    channel_gate = tl.load(post_ptr + token_idx * HC_MULT + channel_idx)
+    row = (token_idx * HC_MULT + channel_idx) * HIDDEN_SIZE
+    residual = tl.load(
+        residual_ptr + row + hidden_offsets, mask=hidden_mask, other=0.0
+    ).to(tl.float32)
+    output = channel_gate * x + residual
+    tl.store(
+        output_ptr + row + hidden_offsets,
+        output.to(output_ptr.dtype.element_ty),
+        mask=hidden_mask,
+    )
+
+
+@functools.cache
+def _sm_count(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+# Tensor-core path for large batches (prefill, high-concurrency decode): a
+# *stats* launch (row sum-of-squares + the hc_fn projection with tl.dot, the
+# fp32 weight split into a bf16 hi+lo pair, hidden dim split across programs)
+# and an *apply* launch (gates + channel reduction). Below _LARGE_T_MIN tokens
+# the two-stage kernels above are faster (crossover between 96 and 128 tokens
+# under a cold L2 on RTX 5090 and RTX PRO 6000).
+_LARGE_T_MIN = 128
+_LARGE_CFG = {
+    # tl.dot needs M >= 16; rows beyond T are masked. Larger row blocks
+    # amortize the weight slice each program streams from L2.
+    "block_t_small": 16,  # T < 128
+    "block_t_mid": 32,  # 128 <= T < 1024
+    "block_t_large": 64,  # T >= 1024
+    "block_d": 64,
+    "programs_per_sm": 4,
+    "max_split": 32,  # bounds the partials each apply program reduces
+    "warps": 4,
+    "stages": 1,
+}
+
+
+@triton.jit
+def _ihc_stats_kernel(
+    x_ptr,
+    w_ptr,
+    ws_ptr,
+    T,
+    stride_xt,
+    stride_xc,
+    stride_ws_t,
+    stride_ws_s,
+    D_PER_SPLIT,
+    D: tl.constexpr,
+    HC: tl.constexpr,
+    N_OUT: tl.constexpr,
+    N_PAD: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    """Partial sum(x^2) and partial x_flat @ w.T for a block of rows and a
+    slice of the hidden dim (same slice in every hc channel).
+
+    The dot runs on tensor cores with the fp32 weight split into a bf16
+    hi + lo pair (x itself is bf16, so this keeps ~fp32 accuracy while the
+    kernel stays purely memory bound).
+    """
+    pid_t = tl.program_id(0)
+    split = tl.program_id(1)
+    rows = pid_t * BLOCK_T + tl.arange(0, BLOCK_T)
+    row_mask = rows < T
+    outs = tl.arange(0, N_PAD)
+    out_mask = outs < N_OUT
+
+    d_start = split * D_PER_SPLIT
+    d_end = tl.minimum(d_start + D_PER_SPLIT, D)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    sq = tl.zeros([BLOCK_T, BLOCK_D], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_T, N_PAD], dtype=tl.float32)
+    for d0 in range(d_start, d_end, BLOCK_D):
+        offs_d = d0 + tl.arange(0, BLOCK_D)
+        d_mask = offs_d < d_end
+        for c in tl.static_range(HC):
+            x = tl.load(
+                x_ptr + rows[:, None] * stride_xt + c * stride_xc + offs_d[None, :],
+                mask=row_mask[:, None] & d_mask[None, :],
+                other=0.0,
+            )
+            xf = x.to(tl.float32)
+            sq += xf * xf
+            w = tl.load(
+                w_ptr + outs[:, None] * (HC * D) + c * D + offs_d[None, :],
+                mask=out_mask[:, None] & d_mask[None, :],
+                other=0.0,
+            )
+            w_hi = w.to(x.dtype)
+            w_lo = (w - w_hi.to(tl.float32)).to(x.dtype)
+            acc += tl.dot(x, tl.trans(w_hi)) + tl.dot(x, tl.trans(w_lo))
+
+    sumsq = tl.sum(sq, axis=1)
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    ws_base = ws_ptr + rows * stride_ws_t + split * stride_ws_s
+    tl.store(
+        ws_base[:, None] + outs[None, :],
+        acc,
+        mask=row_mask[:, None] & out_mask[None, :],
+    )
+    tl.store(ws_base + N_OUT, sumsq, mask=row_mask)
+
+
+@triton.jit
+def _ihc_apply_kernel(
+    x_ptr,
+    ws_ptr,
+    scale_ptr,
+    base_ptr,
+    y_ptr,
+    post_ptr,
+    T,
+    stride_xt,
+    stride_xc,
+    stride_ws_t,
+    stride_ws_s,
+    stride_yt,
+    stride_pt,
+    D_PER_SPLIT,
+    SPLIT,
+    norm_eps,
+    hc_eps,
+    magnitude,
+    D: tl.constexpr,
+    HC: tl.constexpr,
+    N_OUT: tl.constexpr,
+    HAS_POST: tl.constexpr,
+    SPLIT_PAD: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    """Finalize gates from the workspace partials and reduce the channels for
+    this program's slice of the hidden dim."""
+    pid_t = tl.program_id(0)
+    split = tl.program_id(1)
+    rows = pid_t * BLOCK_T + tl.arange(0, BLOCK_T)
+    row_mask = rows < T
+    outs = tl.arange(0, N_OUT)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    # Reduce the split partials with one vectorized load per row block.
+    s_offs = tl.arange(0, SPLIT_PAD)
+    s_mask = s_offs < SPLIT
+    ws_rows = ws_ptr + rows[:, None] * stride_ws_t + s_offs[None, :] * stride_ws_s
+    rs_mask = row_mask[:, None] & s_mask[None, :]
+    acc = tl.sum(
+        tl.load(
+            ws_rows[:, :, None] + outs[None, None, :],
+            mask=rs_mask[:, :, None],
             other=0.0,
-        ).to(tl.float32)
-        channel_gate = tl.sum(tl.where(hc_idx == channel_idx, post, 0.0), axis=0)
-        output = channel_gate * x + residual
+        ),
+        axis=1,
+    )
+    sumsq = tl.sum(tl.load(ws_rows + N_OUT, mask=rs_mask, other=0.0), axis=1)
+
+    rstd = tl.rsqrt(sumsq / (HC * D) + norm_eps)
+    mixes = acc * rstd[:, None]
+    base = tl.load(base_ptr + outs)
+    if HAS_POST:
+        s0 = tl.load(scale_ptr)
+        s1 = tl.load(scale_ptr + 1)
+        is_pre = outs < HC
+        scale = tl.where(is_pre, s0, s1)
+        mag = tl.where(is_pre, 1.0, magnitude)
+    else:
+        scale = tl.load(scale_ptr) + tl.zeros([N_OUT], dtype=tl.float32)
+        mag = 1.0 + tl.zeros([N_OUT], dtype=tl.float32)
+    gates = mag[None, :] * tl.sigmoid(mixes * scale[None, :] + base[None, :]) + hc_eps
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    if HAS_POST:  # noqa: SIM102 - constexpr branch, keep it separate from the runtime one
+        if split == 0:
+            post_mask = row_mask[:, None] & (outs[None, :] >= HC)
+            tl.store(
+                post_ptr + rows[:, None] * stride_pt + (outs[None, :] - HC),
+                gates,
+                mask=post_mask,
+            )
+
+    d_start = split * D_PER_SPLIT
+    d_end = tl.minimum(d_start + D_PER_SPLIT, D)
+    for d0 in range(d_start, d_end, BLOCK_D):
+        offs_d = d0 + tl.arange(0, BLOCK_D)
+        d_mask = offs_d < d_end
+        y = tl.zeros([BLOCK_T, BLOCK_D], dtype=tl.float32)
+        for c in tl.static_range(HC):
+            g = tl.sum(tl.where(outs[None, :] == c, gates, 0.0), axis=1)
+            x = tl.load(
+                x_ptr + rows[:, None] * stride_xt + c * stride_xc + offs_d[None, :],
+                mask=row_mask[:, None] & d_mask[None, :],
+                other=0.0,
+            ).to(tl.float32)
+            y += g[:, None] * x
         tl.store(
-            output_row + channel_idx * HIDDEN_SIZE + hidden_offsets,
-            output.to(output_ptr.dtype.element_ty),
-            mask=hidden_mask,
+            y_ptr + rows[:, None] * stride_yt + offs_d[None, :],
+            y.to(y_ptr.dtype.element_ty),
+            mask=row_mask[:, None] & d_mask[None, :],
         )
+
+
+def _pick_large_launch(T: int, D: int, device_index: int) -> tuple[int, int, int, int]:
+    """Return (BLOCK_T, BLOCK_D, SPLIT, D_PER_SPLIT) for the tensor-core path."""
+    cfg = _LARGE_CFG
+    if T < 128:
+        BLOCK_T = cfg["block_t_small"]
+    elif T < 1024:
+        BLOCK_T = cfg["block_t_mid"]
+    else:
+        BLOCK_T = cfg["block_t_large"]
+    BLOCK_D = cfg["block_d"]
+    n_row_blocks = triton.cdiv(T, BLOCK_T)
+    want = max(1, (cfg["programs_per_sm"] * _sm_count(device_index)) // n_row_blocks)
+    max_split = min(triton.cdiv(D, BLOCK_D), cfg["max_split"])
+    SPLIT = max(1, min(want, max_split))
+    D_PER_SPLIT = triton.cdiv(triton.cdiv(D, SPLIT), BLOCK_D) * BLOCK_D
+    SPLIT = triton.cdiv(D, D_PER_SPLIT)
+    return BLOCK_T, BLOCK_D, SPLIT, D_PER_SPLIT
+
+
+def _ihc_reduce_large(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    magnitude: float,
+    hc_eps: float,
+    norm_eps: float,
+    has_post: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    T, HC, D = x.shape
+    n_out = weight.shape[0]
+    device_index = x.device.index or 0
+    BLOCK_T, BLOCK_D, SPLIT, D_PER_SPLIT = _pick_large_launch(T, D, device_index)
+    ws = torch.empty((T, SPLIT, n_out + 1), dtype=torch.float32, device=x.device)
+    y = torch.empty((T, D), dtype=x.dtype, device=x.device)
+    post = torch.empty((T, HC if has_post else 0), dtype=torch.float32, device=x.device)
+
+    grid = (triton.cdiv(T, BLOCK_T), SPLIT)
+    pdl = current_platform.is_arch_support_pdl()
+    _ihc_stats_kernel[grid](
+        x,
+        weight,
+        ws,
+        T,
+        x.stride(0),
+        x.stride(1),
+        ws.stride(0),
+        ws.stride(1),
+        D_PER_SPLIT,
+        D=D,
+        HC=HC,
+        N_OUT=n_out,
+        N_PAD=max(16, n_out),
+        BLOCK_T=BLOCK_T,
+        BLOCK_D=BLOCK_D,
+        launch_pdl=pdl,
+        num_warps=_LARGE_CFG["warps"],
+        num_stages=_LARGE_CFG["stages"],
+    )
+    _ihc_apply_kernel[grid](
+        x,
+        ws,
+        scale,
+        base,
+        y,
+        post,
+        T,
+        x.stride(0),
+        x.stride(1),
+        ws.stride(0),
+        ws.stride(1),
+        y.stride(0),
+        post.stride(0),
+        D_PER_SPLIT,
+        SPLIT,
+        norm_eps,
+        hc_eps,
+        magnitude,
+        D=D,
+        HC=HC,
+        N_OUT=n_out,
+        HAS_POST=has_post,
+        SPLIT_PAD=triton.next_power_of_2(SPLIT),
+        BLOCK_T=BLOCK_T,
+        BLOCK_D=BLOCK_D,
+        launch_pdl=pdl,
+        num_warps=_LARGE_CFG["warps"],
+    )
+    return y, post
 
 
 def _ihc_reduce(
@@ -239,6 +534,10 @@ def _ihc_reduce(
         return (
             torch.empty((0, hidden_size), dtype=x.dtype, device=x.device),
             torch.empty((0, post_rows), dtype=torch.float32, device=x.device),
+        )
+    if num_tokens >= _LARGE_T_MIN and (hc_mult & (hc_mult - 1)) == 0:
+        return _ihc_reduce_large(
+            x, weight, scale, base, magnitude, hc_eps, norm_eps, has_post
         )
 
     output = torch.empty((num_tokens, hidden_size), dtype=x.dtype, device=x.device)
@@ -391,15 +690,16 @@ def _triton_ihc_post(
     output = torch.empty(
         (num_tokens, hc_mult, hidden_size), dtype=x.dtype, device=x.device
     )
-    _ihc_post_kernel[(num_tokens, triton.cdiv(hidden_size, _BLOCK_D))](
+    n_tiles = triton.cdiv(hidden_size, _BLOCK_D)
+    _ihc_post_kernel[(num_tokens * hc_mult * n_tiles,)](
         x,
         residual,
         post,
         output,
         HIDDEN_SIZE=hidden_size,
         HC_MULT=hc_mult,
-        HC_POW2=triton.next_power_of_2(hc_mult),
         BLOCK_D=_BLOCK_D,
+        launch_pdl=current_platform.is_arch_support_pdl(),
         num_warps=4,
         enable_fp_fusion=False,
     )
@@ -421,6 +721,43 @@ def triton_ihc_post(
 ) -> torch.Tensor:
     """Scatter a sub-block output back over the iHC residual channels."""
     return torch.ops.vllm.hy_v4_ihc_post(x, residual, post)
+
+
+def _spec_class(v: int) -> int:
+    """Triton's default integer specialization class: 1, multiple of 16, other."""
+    return 1 if v == 1 else (16 if v % 16 == 0 else 0)
+
+
+def _launch_key(T: int, D: int, HC: int, device_index: int) -> tuple:
+    if T < _LARGE_T_MIN:
+        return ("small",)
+    BLOCK_T, _, SPLIT, D_PER_SPLIT = _pick_large_launch(T, D, device_index)
+    return (
+        "large",
+        BLOCK_T,
+        _spec_class(T),
+        _spec_class(SPLIT),
+        triton.next_power_of_2(SPLIT),
+        _spec_class(D_PER_SPLIT),
+    )
+
+
+def warmup_token_sizes(
+    D: int, HC: int, max_tokens: int, device_index: int
+) -> list[int]:
+    """One token count per distinct Triton compile key of the three ops.
+
+    Calling pre / head / post for each returned size JIT-compiles every kernel
+    variant reachable for ``T <= max_tokens`` (see hy_v4_ihc_warmup).
+    """
+    seen: set[tuple] = set()
+    sizes: list[int] = []
+    for T in range(1, max_tokens + 1):
+        key = _launch_key(T, D, HC, device_index)
+        if key not in seen:
+            seen.add(key)
+            sizes.append(T)
+    return sizes
 
 
 direct_register_custom_op(


### PR DESCRIPTION
# [Kernel][HY-V4] iHC: head op, custom-op registration, tensor-core path for large batches, warmup and tests

## Purpose

Follow-up to #55059, which added Triton kernels for the HY V4 iHC `pre` and `post` ops
(the 4-channel residual mixing that runs twice per decoder layer, 156 times per token).
This PR keeps those kernels as the decode path and completes the iHC Triton path:

* **`head` is covered.** The final channel merge before the output norm was still on the
  15-launch torch path; it is `pre` without the post gates, so the #55059 kernels gain a
  `HAS_POST` constexpr and serve it (`triton_ihc_head`).
* **Custom ops with fake impls.** `pre` / `post` / `head` are registered as
  `torch.ops.vllm.hy_v4_ihc_*` (`direct_register_custom_op`), so the launches stay opaque to
  torch.compile and are safe inside piecewise CUDA graphs; checked with `torch.library.opcheck`.
* **Tensor-core path for large batches.** From 128 tokens per step (prefill, or 128+
  concurrent requests in decode) `pre` / `head` switch to a two-launch *stats* + *apply*
  pair: the `[T, 4d] @ [4d, 8]` projection runs on tensor cores with the fp32 weight split
  into a bf16 hi+lo pair (fp32-level accuracy), the hidden dim split across programs.
  Against the #55059 kernels (CUPTI, cold L2): 1.2-1.5x on `pre` at 256-4096 tokens on
  RTX 5090 and RTX PRO 6000; the crossover is between 96 and 128 tokens on both, so below
  128 the #55059 two-stage kernels stay in use unchanged.
* **`post` re-gridded.** One program per (token, channel, hidden tile) with the tile index
  fastest, so consecutive programs stream consecutive memory of the `[T, 4, D]` residual and
  output, plus PDL. The #55059 `post` (one program per (token, tile), all channels inside)
  is 0.6-0.8x of `torch.compile` at 64-128 tokens and 1.5-1.9x slower than this one at
  1-8 tokens; the new one is within 0.93-1.05x of `torch.compile` at every size measured
  (bandwidth-bound: 1.5 TB/s on both GPUs at large T).
* **Startup warmup.** `warmup_token_sizes()` enumerates the Triton compile keys reachable for
  `T <= max_num_batched_tokens` (the large-batch path's keys depend on the batch size) and
  `hy_v4_ihc_warmup` launches each once, hooked into `kernel_warmup` next to the DeepSeek-V4
  mHC warmup, so nothing JITs on the first request.
* **Tests.** Parity of all three ops against the eager layers (both paths and the 128-token
  boundary), opcheck, warmup coverage, and a model-level test through the engine.

`T` below is the number of tokens in the batch (all requests of a step together). The model
is not `@support_torch_compile`-wrapped, so vLLM runs it with `CompilationMode.NONE` and the
"eager" numbers are what the torch path costs in production.

Benchmark note: the #55059 script passed the inputs to flashinfer's timer inside a `partial`,
which silently disables its cold-L2 rotation, and fell back to CUDA events when
`cupti-python` is missing while still printing "cupti". The script now passes `input_args`
and fails loudly without CUPTI; all numbers below are with CUPTI and a cold L2, which is
20-40% slower than warm-L2 numbers for these bandwidth-bound ops.

Relation to other PRs: #55059 (merged) is the base this PR builds on; its kernels are kept
and extended, not replaced. #54432 / #54594 are the AMD side (`vllm/models/hy_v4/amd/`) and
do not touch this path. The threshold and the head-to-head numbers were measured on RTX
5090 and RTX PRO 6000 Blackwell (no H100 at hand at the moment); `_LARGE_T_MIN` is a
one-line constant if the crossover differs on Hopper.

## Test Plan

* `pytest tests/models/hy_v4/test_ihc_ops.py` — parity of `pre` / `head` / `post` against the
  eager layers (Triton dispatch disabled) over T in {1, 2, 7, 16, 127, 128, 129, 300, 1024},
  hidden in {512, 4096, 6144}, bf16/fp16; channel-strided input; gate math with zero weights;
  `torch.library.opcheck` for the three ops; `warmup_token_sizes` covers every compile key
  (checked against the Triton JIT cache after running T = 1..2048).
* `pytest tests/models/hy_v4/test_ihc_e2e.py` — one-layer dummy-weight `Hy4-preview`
  (real hidden size, `hc_mult`, sparse MLA) through the engine with CUDA graphs, greedy
  logprobs of the Triton path vs the eager path (`check_logprobs_close`), fused op asserted
  to be dispatched. Needs a GPU with a sparse-MLA backend.
* `tests/models/test_initialization.py -k HYV4ForCausalLM`.
* `benchmarks/kernels/benchmark_hy_v4_ihc.py` (the #55059 script, extended with `head` and a
  `torch.compile` column, inputs passed via `input_args`); CUPTI, CUDA graph replay, cold L2.
* `pre-commit run --files ...`.

GSM8K on the real checkpoint (~800B parameters) needs an 8-GPU node I do not have; the
model-level test plus the op-level parity tests are what I could run.

## Test Result

`tests/models/hy_v4/test_ihc_ops.py`: **168 passed**; `tests/models/hy_v4/test_ihc_e2e.py`:
**passed** (eager vs Triton logprobs match through the engine, CUDA graphs on);
`test_initialization -k HYV4ForCausalLM`: passed; `pre-commit` clean. Run on RTX 5090 and on
RTX PRO 6000 Blackwell, both on top of 7fa2c637 (main with #55059).

### Against the #55059 kernels

Same inputs, bf16, hidden 6144 (the model's size), median us per call, CUPTI, CUDA graph
replay, cold L2; `x` = #55059 time / this PR time. Below 128 tokens `pre` runs the unchanged
#55059 kernel on both sides (differences there are timer noise). `head` has no #55059
counterpart (it ran on the torch path: 24 us at 1 token).

RTX 5090:

| tokens | pre #55059 | pre this PR | x | post #55059 | post this PR | x | head this PR |
|---|---|---|---|---|---|---|---|
| 1 | 5.34 | 5.31 | 1.01 | 2.56 | 1.38 | 1.86 | 4.19 |
| 4 | 5.73 | 5.73 | 1.00 | 2.75 | 1.63 | 1.69 | 4.48 |
| 8 | 6.08 | 6.05 | 1.01 | 3.07 | 1.92 | 1.60 | 4.29 |
| 16 | 7.07 | 7.01 | 1.01 | 3.39 | 2.56 | 1.32 | 5.60 |
| 32 | 9.54 | 9.31 | 1.02 | 4.70 | 3.14 | 1.50 | 6.88 |
| 64 | 14.46 | 14.18 | 1.02 | 5.60 | 4.64 | 1.21 | 9.73 |
| 256 | 33.41 | 25.60 | 1.30 | 21.66 | 17.76 | 1.22 | 23.94 |
| 1024 | 103.94 | 71.26 | 1.46 | 84.93 | 74.53 | 1.14 | 65.89 |
| 4096 | 459.23 | 303.81 | 1.51 | 310.54 | 294.53 | 1.05 | 296.27 |

RTX PRO 6000 Blackwell (188 SMs, 96 GB):

| tokens | pre #55059 | pre this PR | x | post #55059 | post this PR | x | head this PR |
|---|---|---|---|---|---|---|---|
| 1 | 5.38 | 5.38 | 1.00 | 2.46 | 1.34 | 1.83 | 4.19 |
| 4 | 5.76 | 5.76 | 1.00 | 2.78 | 1.63 | 1.71 | 4.48 |
| 8 | 5.89 | 5.82 | 1.01 | 3.01 | 1.98 | 1.52 | 4.50 |
| 16 | 6.75 | 6.62 | 1.02 | 3.46 | 2.40 | 1.44 | 4.80 |
| 32 | 8.80 | 8.54 | 1.03 | 4.80 | 3.17 | 1.52 | 6.54 |
| 64 | 12.83 | 12.64 | 1.02 | 5.60 | 4.80 | 1.17 | 9.34 |
| 256 | 31.49 | 25.79 | 1.22 | 17.12 | 17.79 | 0.96 | 24.07 |
| 1024 | 95.39 | 64.61 | 1.48 | 84.22 | 75.27 | 1.12 | 58.85 |
| 4096 | 438.28 | 319.03 | 1.37 | 313.93 | 304.64 | 1.03 | 308.84 |

<details>
<summary>Same, hidden 4096</summary>

RTX 5090:

| tokens | pre #55059 | pre this PR | x | post #55059 | post this PR | x | head this PR |
|---|---|---|---|---|---|---|---|
| 1 | 4.74 | 5.09 | 0.93 | 2.46 | 1.73 | 1.43 | 4.16 |
| 4 | 5.38 | 5.44 | 0.99 | 2.78 | 1.86 | 1.50 | 4.32 |
| 8 | 5.60 | 5.60 | 1.00 | 2.75 | 1.95 | 1.41 | 4.42 |
| 16 | 6.14 | 6.11 | 1.01 | 3.07 | 2.30 | 1.33 | 4.90 |
| 32 | 7.62 | 7.49 | 1.02 | 3.65 | 2.91 | 1.25 | 6.14 |
| 64 | 10.88 | 10.69 | 1.02 | 4.96 | 4.22 | 1.17 | 8.38 |
| 256 | 24.10 | 19.58 | 1.23 | 11.49 | 10.91 | 1.05 | 17.34 |
| 1024 | 71.62 | 50.50 | 1.42 | 57.76 | 49.73 | 1.16 | 42.43 |
| 4096 | 294.21 | 205.18 | 1.43 | 209.44 | 197.41 | 1.06 | 198.32 |

RTX PRO 6000 Blackwell:

| tokens | pre #55059 | pre this PR | x | post #55059 | post this PR | x | head this PR |
|---|---|---|---|---|---|---|---|
| 1 | 4.70 | 5.09 | 0.92 | 2.50 | 1.70 | 1.47 | 4.19 |
| 4 | 5.41 | 5.38 | 1.01 | 2.66 | 1.79 | 1.48 | 4.26 |
| 8 | 5.44 | 5.47 | 0.99 | 2.75 | 1.86 | 1.48 | 4.29 |
| 16 | 6.05 | 6.05 | 1.00 | 3.10 | 2.29 | 1.36 | 4.78 |
| 32 | 7.04 | 6.98 | 1.01 | 3.65 | 2.98 | 1.23 | 5.76 |
| 64 | 10.24 | 10.02 | 1.02 | 5.18 | 4.00 | 1.30 | 8.00 |
| 256 | 22.53 | 18.62 | 1.21 | 9.66 | 10.88 | 0.89 | 17.25 |
| 1024 | 65.03 | 49.18 | 1.32 | 52.58 | 53.34 | 0.99 | 41.73 |
| 4096 | 275.43 | 209.06 | 1.32 | 207.78 | 204.71 | 1.02 | 202.47 |

</details>

Reading: the tensor-core path takes over at 128 tokens and reaches 1.2-1.5x at 256-4096
tokens, i.e. prefill and high-concurrency decode; at 1-64 tokens `pre` is unchanged. `post`
is 1.3-1.9x at <= 32 tokens, 1.2x at 64 and within noise of the #55059 kernel from 256 on
(0.96-1.22x; both bandwidth-bound there). The crossover sweep (32-256 tokens) is below;
`_LARGE_T_MIN = 128` is above the crossover on both GPUs.

<details>
<summary>Crossover sweep (CUPTI, cold L2)</summary>

RTX 5090:

hidden 4096 (us):

| tokens | #55059 pre | tensor-core pre | #55059 post | this post |
|---|---|---|---|---|
| 32 | 7.33 | 11.65 | 3.62 | 2.98 |
| 64 | 11.23 | 12.61 | 4.99 | 3.71 |
| 96 | 14.18 | 13.92 | 5.47 | 4.99 |
| 112 | 15.36 | 13.89 | 5.54 | 5.28 |
| 128 | 16.77 | 14.40 | 5.79 | 5.57 |
| 160 | 19.14 | 15.58 | 6.27 | 6.98 |
| 256 | 24.16 | 19.58 | 11.39 | 10.46 |

hidden 6144 (us):

| tokens | #55059 pre | tensor-core pre | #55059 post | this post |
|---|---|---|---|---|
| 32 | 9.02 | 15.20 | 4.67 | 3.14 |
| 64 | 14.95 | 16.51 | 5.57 | 4.54 |
| 96 | 19.20 | 17.89 | 6.50 | 5.73 |
| 112 | 20.67 | 18.11 | 6.98 | 6.82 |
| 128 | 22.82 | 18.62 | 7.55 | 7.26 |
| 160 | 25.50 | 20.22 | 10.72 | 9.70 |
| 256 | 33.60 | 26.50 | 17.63 | 15.46 |

RTX PRO 6000:

hidden 4096 (us):

| tokens | #55059 pre | tensor-core pre | #55059 post | this post |
|---|---|---|---|---|
| 32 | 6.85 | 11.62 | 3.87 | 3.07 |
| 64 | 10.14 | 12.10 | 5.25 | 3.78 |
| 96 | 12.74 | 13.47 | 5.63 | 5.30 |
| 112 | 13.89 | 13.79 | 5.57 | 5.25 |
| 128 | 15.14 | 14.21 | 5.98 | 5.63 |
| 160 | 16.74 | 15.52 | 6.53 | 7.10 |
| 256 | 22.11 | 19.39 | 10.43 | 10.91 |

hidden 6144 (us):

| tokens | #55059 pre | tensor-core pre | #55059 post | this post |
|---|---|---|---|---|
| 32 | 9.02 | 15.20 | 4.77 | 3.17 |
| 64 | 13.28 | 16.06 | 5.47 | 4.34 |
| 96 | 17.06 | 17.63 | 6.46 | 6.18 |
| 112 | 19.33 | 18.46 | 7.10 | 7.17 |
| 128 | 19.71 | 18.62 | 7.49 | 7.55 |
| 160 | 24.22 | 21.25 | 9.63 | 9.38 |
| 256 | 32.35 | 26.85 | 17.76 | 16.03 |

</details>

### Eager vs torch.compile vs Triton (RTX 5090, hidden 6144, bf16, CUPTI, CUDA graph, cold L2)

`eager` = the torch path the model runs today; `compile` = `torch.compile` of that path;
`x` = time / Triton time. The >20x `x compile` cells at 2-16 tokens on the 5090 come from
cuBLAS picking a poor split-K algorithm for the tiny-M fp32 projection in the compiled
baseline (not seen on the PRO 6000 or on H100/A100).

| tokens | op | eager us | compile us | triton us | x eager | x compile |
|---|---|---|---|---|---|---|
| 1 | pre | 29.6 | 15.4 | 5.0 | 5.92x | 3.08x |
| 1 | post | 8.3 | 1.3 | 1.3 | 6.29x | 1.00x |
| 1 | head | 28.4 | 14.9 | 4.3 | 6.68x | 3.51x |
| 2 | pre | 171.1 | 152.2 | 5.5 | 31.26x | 27.81x |
| 2 | post | 9.7 | 1.4 | 1.4 | 7.02x | 1.02x |
| 2 | head | 162.0 | 147.8 | 4.3 | 37.49x | 34.21x |
| 4 | pre | 172.1 | 153.2 | 5.7 | 30.04x | 26.74x |
| 4 | post | 10.0 | 1.5 | 1.5 | 6.68x | 1.00x |
| 4 | head | 162.7 | 148.7 | 4.5 | 36.06x | 32.96x |
| 8 | pre | 216.6 | 197.5 | 6.0 | 36.01x | 32.84x |
| 8 | post | 11.2 | 1.8 | 1.8 | 6.23x | 1.00x |
| 8 | head | 201.8 | 191.4 | 4.4 | 46.37x | 43.99x |
| 16 | pre | 210.1 | 195.3 | 6.7 | 31.42x | 29.20x |
| 16 | post | 11.6 | 2.2 | 2.2 | 5.28x | 0.99x |
| 16 | head | 202.6 | 191.1 | 5.2 | 38.60x | 36.42x |
| 64 | pre | 54.2 | 29.8 | 14.2 | 3.82x | 2.10x |
| 64 | post | 23.7 | 3.6 | 3.6 | 6.49x | 0.98x |
| 64 | head | 48.8 | 28.5 | 10.0 | 4.87x | 2.84x |
| 256 | pre | 114.1 | 62.8 | 25.8 | 4.42x | 2.43x |
| 256 | post | 71.9 | 14.9 | 14.8 | 4.84x | 1.01x |
| 256 | head | 108.7 | 61.5 | 24.0 | 4.53x | 2.56x |
| 1024 | pre | 652.8 | 225.9 | 70.2 | 9.30x | 3.22x |
| 1024 | post | 462.4 | 64.8 | 64.4 | 7.19x | 1.01x |
| 1024 | head | 647.9 | 229.6 | 65.0 | 9.97x | 3.53x |
| 4096 | pre | 2793.2 | 880.1 | 303.3 | 9.21x | 2.90x |
| 4096 | post | 2036.8 | 294.8 | 283.0 | 7.20x | 1.04x |
| 4096 | head | 2785.0 | 873.9 | 295.5 | 9.43x | 2.96x |
| 8192 | pre | 5670.5 | 1774.0 | 591.1 | 9.59x | 3.00x |
| 8192 | post | 4091.3 | 588.5 | 578.2 | 7.08x | 1.02x |
| 8192 | head | 5664.0 | 1765.1 | 589.3 | 9.61x | 3.00x |

<details>
<summary>RTX 5090, hidden 4096</summary>

| tokens | op | eager us | compile us | triton us | x eager | x compile |
|---|---|---|---|---|---|---|
| 1 | pre | 28.4 | 12.1 | 4.8 | 5.92x | 2.51x |
| 1 | post | 8.3 | 1.2 | 1.4 | 5.86x | 0.89x |
| 1 | head | 27.5 | 11.9 | 4.2 | 6.61x | 2.85x |
| 2 | pre | 124.8 | 103.5 | 5.2 | 24.07x | 19.96x |
| 2 | post | 9.6 | 1.3 | 1.4 | 6.69x | 0.93x |
| 2 | head | 116.9 | 100.4 | 4.2 | 28.09x | 24.14x |
| 4 | pre | 125.1 | 103.8 | 5.2 | 23.84x | 19.78x |
| 4 | post | 9.8 | 1.5 | 1.6 | 6.27x | 0.96x |
| 4 | head | 116.4 | 100.0 | 4.3 | 27.14x | 23.31x |
| 8 | pre | 155.9 | 134.8 | 5.4 | 28.83x | 24.92x |
| 8 | post | 10.4 | 1.6 | 1.6 | 6.52x | 0.98x |
| 8 | head | 142.2 | 129.4 | 4.0 | 35.54x | 32.35x |
| 16 | pre | 148.7 | 131.6 | 5.6 | 26.40x | 23.38x |
| 16 | post | 10.4 | 2.0 | 2.0 | 5.14x | 0.98x |
| 16 | head | 142.6 | 128.9 | 4.5 | 31.60x | 28.57x |
| 64 | pre | 45.9 | 21.2 | 10.7 | 4.30x | 1.99x |
| 64 | post | 18.7 | 3.1 | 3.2 | 5.91x | 0.98x |
| 64 | head | 45.0 | 20.9 | 8.3 | 5.40x | 2.51x |
| 256 | pre | 88.9 | 44.0 | 19.6 | 4.53x | 2.24x |
| 256 | post | 53.2 | 8.0 | 9.0 | 5.90x | 0.89x |
| 256 | head | 81.9 | 42.5 | 17.5 | 4.68x | 2.43x |
| 1024 | pre | 361.4 | 137.5 | 49.9 | 7.25x | 2.76x |
| 1024 | post | 266.2 | 44.2 | 44.9 | 5.92x | 0.98x |
| 1024 | head | 352.0 | 136.0 | 42.6 | 8.26x | 3.19x |
| 4096 | pre | 1803.8 | 553.9 | 203.9 | 8.85x | 2.72x |
| 4096 | post | 1345.2 | 197.2 | 186.1 | 7.23x | 1.06x |
| 4096 | head | 1800.5 | 551.1 | 197.8 | 9.10x | 2.79x |
| 8192 | pre | 3694.4 | 1097.2 | 387.8 | 9.53x | 2.83x |
| 8192 | post | 2712.0 | 392.1 | 382.7 | 7.09x | 1.02x |
| 8192 | head | 3697.0 | 1091.7 | 387.0 | 9.55x | 2.82x |

</details>

<details>
<summary>RTX PRO 6000 Blackwell, hidden 6144</summary>

| tokens | op | eager us | compile us | triton us | x eager | x compile |
|---|---|---|---|---|---|---|
| 1 | pre | 30.1 | 15.8 | 5.0 | 5.99x | 3.14x |
| 1 | post | 8.4 | 1.2 | 1.2 | 6.69x | 1.00x |
| 1 | head | 29.9 | 15.8 | 4.3 | 7.03x | 3.71x |
| 2 | pre | 42.0 | 22.1 | 5.5 | 7.58x | 3.99x |
| 2 | post | 9.8 | 1.4 | 1.4 | 6.98x | 0.98x |
| 2 | head | 35.5 | 20.6 | 4.4 | 8.10x | 4.70x |
| 4 | pre | 42.1 | 22.2 | 5.8 | 7.32x | 3.86x |
| 4 | post | 10.3 | 1.5 | 1.4 | 7.13x | 1.04x |
| 4 | head | 35.8 | 20.7 | 4.6 | 7.83x | 4.53x |
| 8 | pre | 42.5 | 23.0 | 5.8 | 7.34x | 3.97x |
| 8 | post | 11.3 | 1.9 | 1.9 | 5.97x | 0.98x |
| 8 | head | 31.6 | 20.4 | 4.2 | 7.58x | 4.92x |
| 16 | pre | 38.9 | 23.5 | 6.5 | 6.02x | 3.63x |
| 16 | post | 11.9 | 2.2 | 2.2 | 5.48x | 1.01x |
| 16 | head | 34.2 | 22.2 | 5.0 | 6.85x | 4.46x |
| 64 | pre | 58.8 | 34.5 | 12.9 | 4.55x | 2.67x |
| 64 | post | 23.4 | 3.6 | 3.7 | 6.37x | 0.99x |
| 64 | head | 53.2 | 33.3 | 9.5 | 5.60x | 3.50x |
| 256 | pre | 114.3 | 65.8 | 26.0 | 4.40x | 2.53x |
| 256 | post | 72.5 | 13.8 | 14.8 | 4.89x | 0.93x |
| 256 | head | 108.5 | 64.3 | 24.2 | 4.49x | 2.66x |
| 1024 | pre | 623.4 | 235.2 | 64.4 | 9.68x | 3.65x |
| 1024 | post | 438.9 | 66.1 | 65.3 | 6.72x | 1.01x |
| 1024 | head | 615.9 | 232.8 | 58.7 | 10.50x | 3.97x |
| 4096 | pre | 2842.3 | 895.0 | 316.6 | 8.98x | 2.83x |
| 4096 | post | 2091.8 | 302.6 | 287.9 | 7.27x | 1.05x |
| 4096 | head | 2830.3 | 888.8 | 309.4 | 9.15x | 2.87x |
| 8192 | pre | 5795.3 | 1736.6 | 615.2 | 9.42x | 2.82x |
| 8192 | post | 4208.1 | 606.4 | 594.6 | 7.08x | 1.02x |
| 8192 | head | 5780.4 | 1729.3 | 613.2 | 9.43x | 2.82x |

</details>

<details>
<summary>H100 SXM / A100 PCIe: tensor-core pre/head path, measured on an earlier revision</summary>

The tensor-core `pre`/`head` path is unchanged from an earlier revision of this branch that
was measured on H100 (driver 550, torch cu129) and A100 40GB (driver 595, cu130), warm L2
(the timer issue above), so these rows are indicative only; `post` rows are omitted (the
kernel changed since). Rows for the #55059 kernels are omitted too.

H100 SXM 80GB:

| tokens | op | eager us | compile us | triton us | x eager | x compile |
|---|---|---|---|---|---|---|
| 256 | pre | 154.52 | 75.32 | 18.44 | 8.38 | 4.08 |
| 1024 | pre | 439.48 | 200.05 | 68.26 | 6.44 | 2.93 |
| 4096 | pre | 1562.27 | 739.70 | 199.57 | 7.83 | 3.71 |
| 256 | head | 139.25 | 72.50 | 15.99 | 8.71 | 4.53 |
| 1024 | head | 408.97 | 196.48 | 58.88 | 6.95 | 3.34 |
| 4096 | head | 1483.50 | 731.32 | 200.21 | 7.41 | 3.65 |

A100 PCIe 40GB:

| tokens | op | eager us | compile us | triton us | x eager | x compile |
|---|---|---|---|---|---|---|
| 256 | pre | 223.74 | 99.94 | 33.18 | 6.74 | 3.01 |
| 1024 | pre | 825.34 | 399.46 | 115.81 | 7.13 | 3.45 |
| 4096 | pre | 3051.83 | 1512.09 | 385.64 | 7.91 | 3.92 |
| 256 | head | 206.03 | 99.74 | 28.98 | 7.11 | 3.44 |
| 1024 | head | 793.96 | 397.11 | 113.87 | 6.97 | 3.49 |
| 4096 | head | 2946.46 | 1534.11 | 387.17 | 7.61 | 3.96 |

</details>


## AI assistance

Written with Claude (Anthropic) as an assistant; I reviewed every line, ran the tests and
benchmarks listed above and am responsible for the change. Commits carry a
`Co-authored-by:` trailer.
