### PR TITLE
[Bugfix] Reject unsupported prefix caching for pooling models

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -4,7 +4,8 @@
 import json
 from argparse import ArgumentError
 from contextlib import AbstractContextManager, nullcontext
-from typing import Annotated, Literal
+from types import SimpleNamespace
+from typing import Annotated, Literal, cast
 
 import pytest
 from pydantic import Field
@@ -505,6 +506,27 @@ def test_prefix_cache_default():
     args = parser.parse_args(["--prefix-cache-retention-interval", "64"])
     engine_args = EngineArgs.from_cli_args(args=args)
     assert engine_args.prefix_cache_retention_interval == 64
+
+
+def test_unsupported_pooling_prefix_caching():
+    model_config = cast(
+        ModelConfig,
+        SimpleNamespace(
+            is_chunked_prefill_supported=False,
+            is_prefix_caching_supported=False,
+            runner_type="pooling",
+        ),
+    )
+
+    engine_args = EngineArgs()
+    engine_args._set_default_chunked_prefill_and_prefix_caching_args(model_config)
+    assert engine_args.enable_prefix_caching is False
+
+    engine_args = EngineArgs(enable_prefix_caching=True)
+    with pytest.raises(
+        ValueError, match="Prefix caching is not supported for this pooling model"
+    ):
+        engine_args._set_default_chunked_prefill_and_prefix_caching_args(model_config)
 
 
 def test_prefix_cache_retention_interval_from_deprecated_env(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2753,10 +2753,9 @@ class EngineArgs:
             and self.enable_prefix_caching
             and not default_prefix_caching
         ):
-            logger.warning_once(
-                "This model does not officially support prefix caching. "
-                "Enabling this manually may cause the engine to crash "
-                "or produce incorrect outputs.",
+            raise ValueError(
+                "Prefix caching is not supported for this pooling model. "
+                "Please disable prefix caching."
             )
 
         # Disable chunked prefill and prefix caching for:


### PR DESCRIPTION
## Summary

- fail early when prefix caching is explicitly enabled for an unsupported pooling model
- preserve the existing model-dependent default behavior
- add a regression test covering both the default and explicit-enable paths

Fixes #55049

## Duplicate check

This does not duplicate an existing PR. I searched open PRs for `55049 in:body`, `encoder-only prefix caching`, and unsupported pooling prefix caching; no PR addressing this validation was found. The `--calculate-kv-scales` part of the original report is already removed on current main; this fixes the remaining prefix-caching failure.

## Testing

- `HF_HOME=/tmp/vllm-hf-cache .venv/bin/python -m pytest tests/engine/test_arg_utils.py -v`
  - 99 passed
- pre-commit hooks on `vllm/engine/arg_utils.py` and `tests/engine/test_arg_utils.py`
  - all applicable hooks passed (`actionlint` skipped because no workflow files changed)
- manual `BAAI/bge-large-en-v1.5` config validation
  - explicit prefix caching raises the new `ValueError`
  - default prefix caching resolves to `False`

## Model evaluation

Not applicable. This only changes configuration validation and does not affect model outputs, serving accuracy, or performance.

## AI assistance

OpenAI Codex assisted with issue investigation, implementation, testing, and PR drafting. The human submitter reviewed every changed line, understood the change, and approved submission.
