### PR TITLE
[Bugfix][Scheduler] Restore priority order for streaming continuations

### DIFF
--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -48,8 +48,14 @@ class DummyRequest(Request):
         )
 
 
-def create_scheduler() -> Scheduler:
+def create_scheduler(
+    *, policy: str | None = None, max_num_seqs: int | None = None
+) -> Scheduler:
     vllm_config = VllmConfig(device_config=DeviceConfig("cpu"))
+    if policy is not None:
+        vllm_config.scheduler_config.policy = policy
+    if max_num_seqs is not None:
+        vllm_config.scheduler_config.max_num_seqs = max_num_seqs
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.skip_tokenizer_init = True
     vllm_config.model_config.is_multimodal_model = False
@@ -275,6 +281,31 @@ class TestStreamingScheduler(unittest.TestCase):
         _ = scheduler.schedule()
 
         assert session.status == RequestStatus.RUNNING
+
+    def test_priority_order_after_streaming_session_update(self):
+        scheduler = create_scheduler(policy="priority", max_num_seqs=1)
+        session_a = DummyRequest("A", prompt_token_ids=[1])
+        session_b = DummyRequest("B", prompt_token_ids=[2])
+        session_a.arrival_time = 0.0
+        session_b.arrival_time = 1.0
+
+        for session in (session_a, session_b):
+            scheduler.add_request(session)
+            scheduler.waiting.remove_request(session)
+            assert not scheduler._handle_stopped_request(session)
+
+        continuation_b = DummyRequest("B", prompt_token_ids=[20])
+        continuation_a = DummyRequest("A", prompt_token_ids=[10])
+        continuation_b.arrival_time = 2.0
+        continuation_a.arrival_time = 10.0
+        scheduler.add_request(continuation_b)
+        scheduler.add_request(continuation_a)
+
+        queued = list(scheduler.waiting) + list(scheduler.skipped_waiting)
+        assert sum(request is session_a for request in queued) == 1
+        assert sum(request is session_b for request in queued) == 1
+        output = scheduler.schedule()
+        assert [request.req_id for request in output.scheduled_new_reqs] == ["B"]
 
     def test_update_request_as_session_with_output_tokens(self):
         scheduler = create_scheduler()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2404,7 +2404,11 @@ class Scheduler(SchedulerInterface):
                 existing.streaming_queue.append(update)
             elif update is not None:
                 # Commence next input chunk.
+                if self.policy == SchedulingPolicy.PRIORITY:
+                    self.skipped_waiting.remove_request(existing)
                 self._update_request_as_session(existing, update)
+                if self.policy == SchedulingPolicy.PRIORITY:
+                    self.skipped_waiting.add_request(existing)
             else:
                 # Streaming-input session finished.
                 self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)


### PR DESCRIPTION
## Purpose

When a resumable request is parked in `skipped_waiting`, an arriving streaming continuation updates the existing `Request` in place. The update replaces its `arrival_time`, which is part of the priority queue's ordering key.

Python's heap does not restore its invariant when an ordering field on an element is mutated. Consequently, priority scheduling can select an equal-priority session using the stale heap order.

This PR removes the parked request from `skipped_waiting` before applying the continuation update and adds it back afterwards. The requeue is limited to the priority policy, so the FCFS path and queue position remain unchanged.

The regression uses two equal-priority sessions and one sequence slot. Their initial arrival times are A=0 and B=1; continuations then update B to 2 and A to 10. Before the fix, A is incorrectly scheduled first. After the fix, B is scheduled first. The test also verifies that each session object appears exactly once across the waiting queues.

## Test Plan

```bash
export VLLM_TARGET_DEVICE=cpu

pytest -q \
  tests/v1/streaming_input/test_scheduler_streaming.py::TestStreamingScheduler::test_priority_order_after_streaming_session_update

pytest -q tests/v1/streaming_input/test_scheduler_streaming.py

pytest -q \
  tests/v1/core/test_scheduler.py::test_priority_scheduling_basic_ordering \
  tests/v1/core/test_scheduler.py::test_priority_scheduling_arrival_time_tiebreaker \
  tests/v1/core/test_scheduler.py::test_priority_scheduling_waiting_queue_order \
  tests/v1/core/test_scheduler.py::test_priority_scheduling_fcfs_fallback \
  tests/v1/core/test_scheduler.py::test_priority_scheduling_with_limited_slots \
  tests/v1/core/test_scheduler.py::test_priority_scheduling_heap_property

ruff check vllm/v1/core/sched/scheduler.py \
  tests/v1/streaming_input/test_scheduler_streaming.py
git diff HEAD^ --check
python -m py_compile vllm/v1/core/sched/scheduler.py \
  tests/v1/streaming_input/test_scheduler_streaming.py
```

## Test Result

- Base `bb363db9a5ec2edc7b39e99b00af363a89d1fb81`, with only the new regression test applied: `1 failed` as expected (`['A']` was selected instead of `['B']`).
- Head `93c21a709264e3d289113fe19e40b04020a6a6de`, focused regression: `1 passed`.
- Head, complete streaming scheduler test file: `9 passed`.
- Head, six directly related priority scheduler tests: `6 passed`.
- Ruff, `git diff --check`, and `py_compile`: passed.

GPU testing was not run because this is Python scheduler heap-ordering logic. The patch does not touch a CUDA kernel, model forward pass, tensor layout, or device-specific path.

## Duplicate-work check

I searched current open Issues and PRs for paused streaming continuations, `WAITING_FOR_STREAMING_REQ`, `arrival_time`, and mutable priority-heap keys. I did not find an open change addressing this exact stale-key mechanism.

PR #52717 handles an in-flight continuation being present in running and waiting state at the same time. PR #42015 proposes lazy deletion for priority-queue removal performance. Neither repairs the paused-continuation key mutation here. If #42015 lands first, this patch should be rebased and its remove/re-add bookkeeping rechecked against the new queue implementation.

