### PR TITLE
[Bugfix][Core] Validate sampling param size limits before reaching EngineCore

### DIFF
--- a/tests/v1/sample/test_sampling_params_e2e.py
+++ b/tests/v1/sample/test_sampling_params_e2e.py
@@ -201,6 +201,19 @@ def test_stop_token_ids_size_limit(llm):
             SamplingParams(stop_token_ids=list(range(200))),
         )
 
+    # Boundary: 128 user-supplied stop IDs that exclude the model EOS (id=2
+    # for hmellor/tiny-random-LlamaForCausalLM). After EOS merge the set
+    # becomes 129 > MAX_NUM_STOP_TOKEN_IDS. min_tokens=1 activates the
+    # engine path that indexes by stop IDs.
+    with pytest.raises(VLLMValidationError):
+        _ = llm.generate(
+            PROMPT,
+            SamplingParams(
+                stop_token_ids=list(range(3, 131)),
+                min_tokens=1,
+            ),
+        )
+
 
 def test_seed(llm):
     """Check that seed impacts randomness."""

--- a/tests/v1/sample/test_sampling_params_e2e.py
+++ b/tests/v1/sample/test_sampling_params_e2e.py
@@ -173,6 +173,34 @@ def test_allowed_token_ids(llm):
     with pytest.raises(VLLMValidationError):
         _ = llm.generate(PROMPT, SamplingParams(allowed_token_ids=[10000000]))
 
+    # Reject exceeding max size (MAX_NUM_ALLOWED_TOKEN_IDS = 1024).
+    with pytest.raises(VLLMValidationError):
+        _ = llm.generate(PROMPT, SamplingParams(allowed_token_ids=list(range(2000))))
+
+
+def test_logit_bias_size_limit(llm):
+    """Check that exceeding logit_bias size limit raises an error
+    instead of crashing the engine."""
+
+    # Reject exceeding max size (MAX_NUM_LOGIT_BIAS_TOKENS = 1024).
+    with pytest.raises(VLLMValidationError):
+        _ = llm.generate(
+            PROMPT,
+            SamplingParams(logit_bias={i: 1.0 for i in range(2000)}),
+        )
+
+
+def test_stop_token_ids_size_limit(llm):
+    """Check that exceeding stop_token_ids size limit raises an error
+    instead of crashing the engine."""
+
+    # Reject exceeding max size (MAX_NUM_STOP_TOKEN_IDS = 128).
+    with pytest.raises(VLLMValidationError):
+        _ = llm.generate(
+            PROMPT,
+            SamplingParams(stop_token_ids=list(range(200))),
+        )
+
 
 def test_seed(llm):
     """Check that seed impacts randomness."""

--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -13,6 +13,7 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import (
+    MAX_NUM_ALLOWED_TOKEN_IDS,
     BeamSearchParams,
     SamplingParams,
     StructuredOutputsParams,
@@ -29,10 +30,6 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
-
-# Engine-side cap on `SamplingParams.allowed_token_ids`; keep in sync with
-# MAX_NUM_ALLOWED_TOKEN_IDS in vllm/v1/worker/gpu/sample/logit_bias.py.
-_MAX_NUM_ALLOWED_TOKEN_IDS = 1024
 
 
 _bitmask_cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
@@ -447,7 +444,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
                 detokenize=False,
                 allowed_token_ids=(
                     allowed_ids
-                    if len(allowed_ids) <= _MAX_NUM_ALLOWED_TOKEN_IDS
+                    if len(allowed_ids) <= MAX_NUM_ALLOWED_TOKEN_IDS
                     else None
                 ),
                 skip_clone=True,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -31,6 +31,18 @@ MAX_LOGPROB_TOKEN_IDS = 128
 """Upper bound on `SamplingParams.logprob_token_ids` list length. Must match
 the per-request row width allocated by the sampler's `LogprobTokenIdsState`."""
 
+MAX_NUM_ALLOWED_TOKEN_IDS = 1024
+"""Upper bound on `SamplingParams.allowed_token_ids` list length. Must match
+the per-request row width allocated by `LogitBiasState`."""
+
+MAX_NUM_LOGIT_BIAS_TOKENS = 1024
+"""Upper bound on `SamplingParams.logit_bias` dict length. Must match
+the per-request row width allocated by `LogitBiasState`."""
+
+MAX_NUM_STOP_TOKEN_IDS = 128
+"""Upper bound on stop token IDs set size. Must match the per-request
+row width allocated by `LogitBiasState`."""
+
 
 def _verify_num_sequences(value: int, parameter_name: str) -> None:
     if not isinstance(value, int):
@@ -876,6 +888,14 @@ class SamplingParams(
         if not self.stop_token_ids:
             return
 
+        if len(self.stop_token_ids) > MAX_NUM_STOP_TOKEN_IDS:
+            raise VLLMValidationError(
+                f"Too many stop token IDs: {len(self.stop_token_ids)}. "
+                f"The max size is {MAX_NUM_STOP_TOKEN_IDS}.",
+                parameter="stop_token_ids",
+                value=len(self.stop_token_ids),
+            )
+
         # stop_token_ids are used as column indices into the logits tensor,
         # whose width is the model's vocab size (LogitsProcessor is built from
         # config.vocab_size, InputBatch.vocab_size comes from
@@ -900,6 +920,14 @@ class SamplingParams(
         """Validate logit_bias token IDs are within vocabulary range."""
         if not self.logit_bias:
             return
+
+        if len(self.logit_bias) > MAX_NUM_LOGIT_BIAS_TOKENS:
+            raise VLLMValidationError(
+                f"Too many logit bias tokens: {len(self.logit_bias)}. "
+                f"The max size is {MAX_NUM_LOGIT_BIAS_TOKENS}.",
+                parameter="logit_bias",
+                value=len(self.logit_bias),
+            )
 
         vocab_size = model_config.get_vocab_size()
         invalid_token_ids = [
@@ -988,6 +1016,14 @@ class SamplingParams(
                 "allowed_token_ids is not None and empty!",
                 parameter="allowed_token_ids",
                 value=allowed_token_ids,
+            )
+
+        if len(allowed_token_ids) > MAX_NUM_ALLOWED_TOKEN_IDS:
+            raise VLLMValidationError(
+                f"Too many allowed token IDs: {len(allowed_token_ids)}. "
+                f"The max size is {MAX_NUM_ALLOWED_TOKEN_IDS}.",
+                parameter="allowed_token_ids",
+                value=len(allowed_token_ids),
             )
 
         # allowed_token_ids are client-supplied ids used as column indices

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -24,7 +24,7 @@ from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import BaseRenderer, renderer_from_config
 from vllm.renderers.inputs.preprocess import parse_model_prompt
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import MAX_NUM_STOP_TOKEN_IDS, SamplingParams
 from vllm.tasks import GENERATION_TASKS, POOLING_TASKS, SupportedTask
 from vllm.tokenizers import TokenizerLike
 from vllm.utils import length_from_prompt_token_ids_or_embeds, random_uuid
@@ -367,6 +367,17 @@ class InputProcessor:
             )
             if self.tokenizer is not None:
                 sampling_params.update_from_tokenizer(self.tokenizer)
+
+            num_all_stop = len(sampling_params.all_stop_token_ids)
+            if num_all_stop > MAX_NUM_STOP_TOKEN_IDS:
+                raise VLLMValidationError(
+                    f"Too many stop token IDs after merging EOS: "
+                    f"{num_all_stop}. "
+                    f"The max size is {MAX_NUM_STOP_TOKEN_IDS}.",
+                    parameter="stop_token_ids",
+                    value=num_all_stop,
+                )
+
             if sampling_params.trace_decode_token_ids:
                 self._normalize_trace_replay_params(
                     sampling_params,

--- a/vllm/v1/worker/gpu/sample/logit_bias.py
+++ b/vllm/v1/worker/gpu/sample/logit_bias.py
@@ -3,13 +3,14 @@
 import numpy as np
 import torch
 
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import (
+    MAX_NUM_ALLOWED_TOKEN_IDS,
+    MAX_NUM_LOGIT_BIAS_TOKENS,
+    MAX_NUM_STOP_TOKEN_IDS,
+    SamplingParams,
+)
 from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
-
-MAX_NUM_ALLOWED_TOKEN_IDS = 1024
-MAX_NUM_LOGIT_BIAS_TOKENS = 1024
-MAX_NUM_STOP_TOKEN_IDS = 128
 
 
 class LogitBiasState:


### PR DESCRIPTION
## Purpose

`allowed_token_ids`, `logit_bias`, and `stop_token_ids` have internal size limits (1024, 1024, 128) set by the pre-allocated GPU tensor row widths in `LogitBiasState`. Exceeding these limits raises a bare `ValueError` inside `EngineCore`'s execution loop, which is treated as a fatal error: the entire server shuts down with HTTP 500.

This is the same class of bug as #16529 (out-of-vocab `logit_bias`) and #54195 (out-of-vocab `stop_token_ids`), but for **size-limit violations** rather than vocab-range violations. Neither #16529 nor #54196 added size-limit checks.

## Reproducer

```bash
vllm serve hmellor/tiny-random-LlamaForCausalLM --enforce-eager
```

```python
import json, requests

resp = requests.post("http://localhost:8000/v1/chat/completions", json={
    "model": "hmellor/tiny-random-LlamaForCausalLM",
    "messages": [{"role": "user", "content": "hello"}],
    "max_tokens": 5,
    "allowed_token_ids": list(range(2000)),
})
print(resp.status_code, resp.json())
```

**Before (server crashes):**

```
(EngineCore) ERROR: EngineCore encountered a fatal error.
  File ".../vllm/v1/worker/gpu/sample/logit_bias.py", line 63, in add_request
    raise ValueError(
ValueError: Too many allowed token IDs: 2000. The max size is 1024.

(APIServer) ERROR: vllm.v1.engine.exceptions.EngineDeadError
(APIServer) INFO: "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
(APIServer) INFO: Shutting down
```

All subsequent requests fail. The engine is dead.

**After (400 + engine survives):**

```json
{
    "error": {
        "message": "Too many allowed token IDs: 2000. The max size is 1024. (parameter=allowed_token_ids, value=2000)",
        "type": "BadRequestError",
        "param": "allowed_token_ids",
        "code": 400
    }
}
```

Subsequent requests continue normally.

## Fix

Move `MAX_NUM_ALLOWED_TOKEN_IDS`, `MAX_NUM_LOGIT_BIAS_TOKENS`, and `MAX_NUM_STOP_TOKEN_IDS` from `logit_bias.py` to `sampling_params.py` (following the `MAX_LOGPROB_TOKEN_IDS` pattern from #40559), and add early size-limit validation in `_validate_allowed_token_ids`, `_validate_logit_bias`, and `_validate_stop_token_ids`. Oversized requests now receive `VLLMValidationError` (HTTP 400) before reaching the engine.

Also remove the duplicate `_MAX_NUM_ALLOWED_TOKEN_IDS` in `beam_search/offline.py` in favor of the shared constant.

The defensive `ValueError` in `logit_bias.py` is kept as a belt-and-suspenders guard.

## Test Plan

```bash
pytest tests/v1/sample/test_sampling_params_e2e.py::test_allowed_token_ids -v
pytest tests/v1/sample/test_sampling_params_e2e.py::test_logit_bias_size_limit -v
pytest tests/v1/sample/test_sampling_params_e2e.py::test_stop_token_ids_size_limit -v
```

## Test Result

Tested via the OpenAI-compatible HTTP API (`/v1/chat/completions`).

**Before fix:**

| Test | Result |
|---|---|
| Normal request | OK |
| `allowed_token_ids` = 2000 | **500 + EngineCore dies + server shuts down** |
| Subsequent request | **Engine DEAD** |

**After fix:**

| Test | Result |
|---|---|
| Normal request | OK |
| `allowed_token_ids` = 2000 | **400 BadRequestError** |
| `logit_bias` = 2000 keys | **400 BadRequestError** |
| Subsequent request | **Health 200 + normal response** |

---

## AI assistance disclosure

This change was developed with AI assistance (Claude Code). The submitter reviewed every changed line, ran the tests listed above locally, and can defend the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
