### PR TITLE
build(docker): build Rust frontend (vllm-rs) in Dockerfile.tpu

### DIFF
--- a/docker/Dockerfile.tpu
+++ b/docker/Dockerfile.tpu
@@ -7,7 +7,8 @@ WORKDIR /workspace/vllm
 # Install some basic utilities
 RUN apt-get update && apt-get install -y \
     git \
-    ffmpeg libsm6 libxext6 libgl1 && \
+    ffmpeg libsm6 libxext6 libgl1 \
+    protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
 # Build vLLM.
@@ -27,6 +28,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
     python3 -m pip install \
         -r requirements/tpu.txt
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install -r requirements/build/rust.txt && \
+    bash build_rust.sh
 
 RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install -e .
 


### PR DESCRIPTION
### Summary
This PR adds `protobuf-compiler` and invokes `build_rust.sh` with `requirements/build/rust.txt` prior to installing vLLM in `docker/Dockerfile.tpu`.

This ensures that the `vllm-rs` Rust frontend binary is compiled and included in TPU container builds and CI test images.

### Validation
Verified that `build_rust.sh` builds `vllm-rs` and that the resulting container can serve requests on Google Cloud TPU.


Related: https://github.com/vllm-project/tpu-inference/pull/3523