### PR TITLE
[Bugfix][Rust Frontend][Parser] Preserve DeepSeek DSML JSON types without parameter schemas

### DIFF
--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v4.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v4.rs
@@ -75,12 +75,12 @@ mod tests {
     use crate::tool::test_utils::{collect_stream, test_tools};
     use crate::tool::{ToolParser, ToolParserTestExt as _};
 
-    fn build_tool_call(function_name: &str, params: &[(&str, &str)]) -> String {
+    fn build_tool_call(function_name: &str, params: &[(&str, &str)], is_string: bool) -> String {
         let params = params
             .iter()
             .map(|(name, value)| {
                 format!(
-                    r#"<｜DSML｜parameter name="{name}" string="true">{value}</｜DSML｜parameter>"#
+                    r#"<｜DSML｜parameter name="{name}" string="{is_string}">{value}</｜DSML｜parameter>"#
                 )
             })
             .collect::<Vec<_>>()
@@ -88,6 +88,14 @@ mod tests {
         format!(
             "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"{function_name}\">\n{params}\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>"
         )
+    }
+
+    fn parse_arguments(function_name: &str, params: &[(&str, &str)], is_string: bool) -> Value {
+        let mut parser = DeepSeekV4ToolParser::new(&test_tools());
+        let output = parser
+            .parse_complete(&build_tool_call(function_name, params, is_string))
+            .unwrap();
+        serde_json::from_str(&output.calls()[0].arguments).unwrap()
     }
 
     #[test]
@@ -104,6 +112,7 @@ mod tests {
             .parse_complete(&build_tool_call(
                 "get_weather",
                 &[("location", "SF"), ("date", "2024-01-16")],
+                true,
             ))
             .unwrap();
 
@@ -116,6 +125,44 @@ mod tests {
                 "location": "SF",
                 "date": "2024-01-16"
             })
+        );
+    }
+
+    #[test]
+    fn deepseek_v4_parse_complete_uses_json_types_for_unknown_tool_params() {
+        assert_eq!(
+            parse_arguments(
+                "unknown",
+                &[
+                    ("count", "5"),
+                    ("enabled", "false"),
+                    ("config", r#"{"a":1}"#),
+                    ("flags", "[true,false]"),
+                ],
+                false,
+            ),
+            json!({
+                "count": 5,
+                "enabled": false,
+                "config": { "a": 1 },
+                "flags": [true, false],
+            })
+        );
+    }
+
+    #[test]
+    fn deepseek_v4_parse_complete_uses_json_types_without_property_schema() {
+        assert_eq!(
+            parse_arguments("get_weather", &[("extra_opts", r#"{"b":2}"#)], false),
+            json!({ "extra_opts": { "b": 2 } })
+        );
+    }
+
+    #[test]
+    fn deepseek_v4_parse_complete_preserves_invalid_json_without_schema() {
+        assert_eq!(
+            parse_arguments("unknown", &[("data", "[broken")], false),
+            json!({ "data": "[broken" })
         );
     }
 

--- a/rust/src/parser/src/tool/deepseek_dsml/mod.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/mod.rs
@@ -107,12 +107,15 @@ impl DeepSeekDsmlToolParser {
                 for param in raw_params {
                     let value = if param.is_string {
                         serde_json::Value::String(param.value)
-                    } else {
+                    } else if self.tool_parameters.has_param_schema(&name, &param.name) {
                         self.tool_parameters.convert_param_with_schema(
                             &name,
                             &param.name,
                             param.value,
                         )
+                    } else {
+                        serde_json::from_str(&param.value)
+                            .unwrap_or_else(|_| serde_json::Value::String(param.value))
                     };
                     arguments.insert(param.name, value);
                 }

--- a/rust/src/parser/src/tool/parameters.rs
+++ b/rust/src/parser/src/tool/parameters.rs
@@ -76,6 +76,13 @@ impl ToolSchemas {
         Self { tools }
     }
 
+    /// Return whether one named parameter has a normalized schema.
+    pub(super) fn has_param_schema(&self, function_name: &str, name: &str) -> bool {
+        self.tools
+            .get(function_name)
+            .is_some_and(|tool_schema| tool_schema.params.contains_key(name))
+    }
+
     /// Convert parameter values for one named tool.
     ///
     /// Unknown tool names use an empty schema, so all parameters fall back to


### PR DESCRIPTION



## Purpose

DeepSeek DSML uses `string="false"` to identify parameter bodies containing
  JSON values such as numbers, booleans, arrays, and objects.

  The Rust parser previously sent these values through schema-based conversion.
  When the tool was unknown or the parameter was absent from the tool's
  `properties`, no schema type was available and the converter fell back to a
  JSON string. For example:

  ```
  <｜DSML｜parameter name="count" string="false">5</｜DSML｜parameter>
  <｜DSML｜parameter name="config" string="false">{"a":1}</｜DSML｜parameter>
```

  Previously produced:
```
  {"count":"5","config":"{\"a\":1}"}
```
  The corrected output is:
```
  {"count":5,"config":{"a":1}}
```
  Parameters with a normalized schema continue to use the existing schema-based
  conversion. Parameters without one are parsed directly as JSON, with invalid
  JSON preserved as a string.

  This keeps tool argument types intact for unknown tools, incomplete schemas,
  and schema-external parameters, preventing downstream validation and tool
  execution from receiving strings in place of structured JSON values.

## Test Plan

```
  cargo nextest run -p vllm-parser deepseek_v4_parse_complete_
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

