### PR TITLE
[Bugfix][Model] Fix padding isolation in FunASR adaptor attention

### DIFF
--- a/tests/model_executor/test_funasr_adaptor.py
+++ b/tests/model_executor/test_funasr_adaptor.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for FunASR adaptor padding isolation."""
+
+import pytest
+import torch
+
+from vllm.model_executor.models.funasr import Transformer
+from vllm.platforms import current_platform
+
+
+def _seed_weights(module: torch.nn.Module) -> None:
+    """Initialize weights for a forward pass without a checkpoint."""
+    for name, param in module.named_parameters():
+        if "norm" in name:
+            continue
+        if param.dim() >= 2:
+            torch.nn.init.xavier_uniform_(param)
+        else:
+            torch.nn.init.zeros_(param)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="MMEncoderAttention requires a CUDA-like device",
+)
+@pytest.mark.parametrize("seed", range(100, 105))
+def test_adaptor_batch_invariant(dist_init, seed: int) -> None:
+    """A short sample's output must not depend on its batch mates."""
+    torch.manual_seed(seed)
+    short_len, long_len, dim = 5, 40, 32
+    device = current_platform.device_type
+
+    adaptor = Transformer(
+        downsample_rate=1,
+        encoder_dim=dim,
+        llm_dim=dim,
+        ffn_dim=64,
+        n_layer=2,
+        attention_heads=4,
+    ).eval()
+    adaptor = adaptor.to(device)
+    _seed_weights(adaptor)
+
+    short_features = torch.randn(short_len, dim, device=device)
+    padding = torch.randn(long_len - short_len, dim, device=device) * 7 + 3
+    padded_short = torch.cat([short_features, padding])
+    batched = torch.stack([padded_short, torch.randn(long_len, dim, device=device)])
+    ilens_batched = torch.tensor(
+        [short_len, long_len], dtype=torch.int32, device=device
+    )
+
+    alone = short_features.unsqueeze(0)
+    ilens_alone = torch.tensor([short_len], dtype=torch.int32, device=device)
+
+    with torch.no_grad():
+        out_batched, olens_batched = adaptor(batched, ilens_batched)
+        out_alone, olens_alone = adaptor(alone, ilens_alone)
+
+    assert olens_batched[0].item() == short_len
+    assert olens_alone[0].item() == short_len
+    torch.testing.assert_close(
+        out_batched[0, :short_len],
+        out_alone[0, :short_len],
+        atol=1e-3,
+        rtol=1e-3,
+    )

--- a/vllm/model_executor/models/funasr.py
+++ b/vllm/model_executor/models/funasr.py
@@ -5,6 +5,7 @@ import math
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Annotated, cast
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -446,15 +447,62 @@ class EncoderLayer(nn.Module):
         self.norm1 = LayerNorm(size)
         self.norm2 = LayerNorm(size)
 
-    def forward(self, hidden_states: torch.Tensor):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+        sequence_lengths: torch.Tensor | None = None,
+    ):
         residual = hidden_states
         hidden_states = self.norm1(hidden_states)
-        hidden_states = residual + self.self_attn(hidden_states, None, None)
+        hidden_states = residual + self.self_attn(
+            hidden_states, cu_seqlens, max_seqlen, sequence_lengths
+        )
         residual = hidden_states
         hidden_states = self.norm2(hidden_states)
         hidden_states = residual + self.feed_forward(hidden_states)
 
         return hidden_states
+
+
+class FunASREncoderAttention(MMEncoderAttention):
+    """MMEncoderAttention with 2D (seq_len, hidden_size) tensor support.
+
+    Mirrors `vllm.model_executor.models.whisper.WhisperEncoderAttention`:
+    the adaptor flattens its batch dim into the sequence dim so that
+    segmented `cu_seqlens` can confine attention to each row's valid
+    prefix without crossing into another row's padding.
+    """
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+        sequence_lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        is_2d = query.dim() == 2
+        if is_2d:
+            query = query.unsqueeze(0)
+            key = key.unsqueeze(0)
+            value = value.unsqueeze(0)
+
+        out = super().forward(
+            query,
+            key,
+            value,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
+        )
+
+        if is_2d:
+            out = out.squeeze(0)
+
+        return out
 
 
 class FunASRAudioAttention(nn.Module):
@@ -495,7 +543,7 @@ class FunASRAudioAttention(nn.Module):
             prefix=f"{prefix}.out_proj",
         )
 
-        self.attn = MMEncoderAttention(
+        self.attn = FunASREncoderAttention(
             num_heads=self.num_local_heads,
             head_size=self.head_dim,
             scale=self.scaling,
@@ -504,15 +552,12 @@ class FunASRAudioAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        cu_seqlens: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
         max_seqlen: torch.Tensor | None,
+        sequence_lengths: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        bs, seq_length, _ = hidden_states.size()
         qkv, _ = self.qkv(hidden_states)
         q, k, v = qkv.chunk(3, dim=-1)
-        q = q.view(bs, seq_length, -1, self.head_dim)
-        k = k.view(bs, seq_length, -1, self.head_dim)
-        v = v.view(bs, seq_length, -1, self.head_dim)
 
         attn_output = self.attn(
             query=q,
@@ -520,11 +565,55 @@ class FunASRAudioAttention(nn.Module):
             value=v,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
         )
 
-        attn_output = attn_output.view(bs, seq_length, -1)
         output, _ = self.out_proj(attn_output)
         return output
+
+
+def _build_adaptor_attn_metadata(
+    attn: MMEncoderAttention,
+    feature_lens: torch.Tensor,
+    seq_len: int,
+    hidden_size: int,
+    device: torch.device,
+) -> dict[str, torch.Tensor | None]:
+    """Segmented varlen attention metadata for the padded adaptor batch.
+
+    Each padded row contributes up to two sequences to `cu_seqlens`: its
+    valid prefix and its padding tail, so attention never crosses a
+    valid/padding boundary while every row keeps a fixed token count.
+    Mirrors `vllm.model_executor.models.ultravox._build_chunk_attn_metadata`.
+    """
+    batch_size = feature_lens.shape[0]
+    starts = np.arange(batch_size, dtype=np.int64) * seq_len
+    lens_np = feature_lens.cpu().numpy().astype(np.int64)
+    bounds = np.stack([starts + lens_np, starts + seq_len], axis=1).reshape(-1)
+    cu_seqlens_np = np.concatenate(([0], bounds))
+    # Fully-valid rows produce empty padding segments; drop the duplicates.
+    cu_seqlens_np = np.unique(cu_seqlens_np).astype(np.int32)
+
+    attn_backend = attn.attn_backend
+    sequence_lengths = MMEncoderAttention.maybe_compute_seq_lens(
+        attn_backend, cu_seqlens_np, device
+    )
+    max_seqlen = torch.tensor(
+        MMEncoderAttention.compute_max_seqlen(attn_backend, cu_seqlens_np),
+        dtype=torch.int32,
+    )
+    cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+        attn_backend,
+        cu_seqlens_np,
+        hidden_size,
+        get_tensor_model_parallel_world_size(),
+        device,
+    )
+    return {
+        "cu_seqlens": cu_seqlens,
+        "max_seqlen": max_seqlen,
+        "sequence_lengths": sequence_lengths,
+    }
 
 
 class Transformer(nn.Module):
@@ -592,8 +681,19 @@ class Transformer(nn.Module):
         olens = (ilens - 1) // self.k + 1
 
         if self.blocks is not None:
+            attn_metadata = _build_adaptor_attn_metadata(
+                self.blocks[0].self_attn.attn,
+                feature_lens=olens,
+                seq_len=chunk_num,
+                hidden_size=self.llm_dim,
+                device=hidden_states.device,
+            )
+            # Flatten batch into the sequence dim so segmented cu_seqlens
+            # can confine each row's attention to its own valid prefix.
+            hidden_states = hidden_states.reshape(batch_size * chunk_num, self.llm_dim)
             for layer, block in enumerate(self.blocks):
-                hidden_states = block(hidden_states)
+                hidden_states = block(hidden_states, **attn_metadata)
+            hidden_states = hidden_states.reshape(batch_size, chunk_num, self.llm_dim)
         return hidden_states, olens
 
 


### PR DESCRIPTION


## Purpose

`FunASRForConditionalGeneration` uses an audio adaptor to downsample and project audio-encoder features before the LLM consumes them. The adaptor pads each row to the longest feature sequence in the scheduled batch. However, `EncoderLayer.forward` currently calls adaptor self-attention without length metadata:

```python
self.self_attn(hidden_states, None, None)
```

A short request's valid frames can therefore attend to its right-padding positions introduced by longer batch-mates. Its transcription can change depending on the other requests in the batch. The reference FunASR adaptor (`funasr/models/llm_asr/adaptor.py`) does not have this issue because it builds a padding mask from the real feature lengths and passes it through every block.

This PR derives the length metadata from the adaptor's post-downsampling output lengths and routes the three representations expected by `MMEncoderAttention` through every adaptor block: `cu_seqlens` stores the cumulative boundaries of the packed segments, `max_seqlen` stores the longest segment length for kernels that need it, and `sequence_lengths` stores each individual segment length for backends that consume explicit lengths. Carrying all three lets `MMEncoderAttention` select the representation required by its active backend without reconstructing or losing the padding boundaries.

- Each padded row contributes a valid-prefix segment and, when present, a padding-tail segment. For example, two rows with valid lengths 5 and 40, both physically padded to 40, produce boundaries `[0, 5, 40, 80]`: short valid frames, short padding, then long valid frames. `MMEncoderAttention` passes these boundaries to its supported backends, which restrict attention to each segment while all rows retain their fixed physical length.
- The adaptor batch is flattened into one continuous token axis, which is the axis indexed by `cu_seqlens`, before its attention blocks and restored afterward.
- A thin `FunASREncoderAttention` wrapper supports this 2D calling convention, following the existing `WhisperEncoderAttention` pattern.
- A deterministic regression test compares the short sample's adaptor hidden states when encoded alone and when encoded beside a longer sample; it does not run full transcription.

The implementation change is isolated to `vllm/model_executor/models/funasr.py`; regression coverage is added in `tests/model_executor/test_funasr_adaptor.py`. No processor, registry, multimodal-framework, or attention-backend files are changed.

Not duplicate work: #36633 changed preprocessing padding, whereas this patch isolates padding inside adaptor self-attention. #54620 addresses unrelated fp16 positional-encoding precision. No open PR for this specific fix was found as of 2026-09-03.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/model_executor/test_funasr_adaptor.py
.venv/bin/ruff check \
  vllm/model_executor/models/funasr.py \
  tests/model_executor/test_funasr_adaptor.py
.venv/bin/ruff format --check \
  vllm/model_executor/models/funasr.py \
  tests/model_executor/test_funasr_adaptor.py
.venv/bin/python -m py_compile \
  vllm/model_executor/models/funasr.py \
  tests/model_executor/test_funasr_adaptor.py
```

End-to-end transcription evaluation configuration:

- Checkpoint: a vLLM-compatible safetensors artifact derived from the official ModelScope [`FunAudioLLM/Fun-ASR-Nano-2512`](https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512) checkpoint. The audio encoder, adaptor, and LLM tensor values were copied unchanged. Tensors used only by the auxiliary connectionist temporal classification (CTC) head were omitted because the current vLLM FunASR implementation has no CTC modules.
- Runtime: vLLM 0.28.0
- Dataset: `D4nt3/esb-datasets-earnings22-validation-tiny-filtered`, the public dataset used by vLLM's ASR correctness tests
- Dataset size: 511 clips, 3379.833 audio-seconds, and 8317 normalized reference words
- GPU: one NVIDIA GeForce RTX 5090 (32 GiB) per run; each before/after pair ran on the same physical GPU
- Container CUDA version: 13.0.2
- Data type: `bfloat16`
- Decoding: `temperature=0`, `max_tokens=500` (deterministic greedy decoding with no sampling)
- Tensor parallel size: 1
- Maximum model length: 4096
- GPU memory utilization: 0.85
- `max_num_seqs` (the scheduler's maximum number of concurrent sequences): 1, 8, 32, 64, and 128; 128 is the vLLM 0.28.0 default
- Audio adaptor attention backend: FlashAttention
- Execution mode: `torch.compile` and CUDA graphs enabled (`enforce_eager=False`)
- Timing: one warmup call first; model initialization, audio loading, and warmup excluded; the full subsequent `llm.generate()` call timed
- WER (word error rate; lower is better): the same method used by current vLLM ASR correctness tests—normalize references and predictions with `EnglishTextNormalizer` and the `openai/whisper-large-v3` English spelling map, then call `jiwer.wer`

For this comparison, “before fix” is the unpatched vLLM 0.28.0 FunASR implementation and “after fix” is the same implementation with this diff applied. The checkpoint, dataset, decoding parameters, hardware, and scheduler settings were held constant. Inference ran on vLLM 0.28.0; the saved outputs were then rescored offline with the current-main scoring logic described above.

The local evaluation driver preloaded the same 511 waveforms and ran the following core calls for each `max_num_seqs` value:

```python
llm = LLM(
    model=checkpoint,
    dtype="bfloat16",
    gpu_memory_utilization=0.85,
    max_model_len=4096,
    max_num_seqs=max_num_seqs,
    limit_mm_per_prompt={"audio": 1},
    tensor_parallel_size=1,
)
sampling_params = SamplingParams(temperature=0, max_tokens=500)
llm.generate(inputs[:8], sampling_params, use_tqdm=False)  # Warmup.
outputs = llm.generate(inputs, sampling_params, use_tqdm=False)
```

## Test Result

The regression test was run against both implementations in the frozen vLLM 0.28.0 runtime.

```text
before fix: 5 failed in 9.58s
after fix:  5 passed in 8.96s
```

All five cases before the fix fail at the intended isolated-vs-batched `assert_close`; all five cases after the fix pass. The test uses fixed seeds, synthetic adaptor feature tensors, and no checkpoint or network access.

Local runtime validation was performed on vLLM 0.28.0. The submitted branch targets current main; execution in a matching current-main build remains for upstream CI.

Lint and formatting results for the two final files:

```text
ruff check:        All checks passed!
ruff format check: 2 files already formatted
py_compile:        passed
```

End-to-end transcription results (`temperature=0`, no sampling):

| `max_num_seqs` | WER before fix | WER after fix | WER reduction (percentage points) | Total word errors before / after | Audio throughput before / after (audio seconds/s) |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 12.9855% | 12.9855% | 0.0000 | 1080 / 1080 | 86.42 / 82.87 |
| 8 | 13.2379% | 13.0095% | 0.2284 | 1101 / 1082 | 165.40 / 155.68 |
| 32 | 13.7309% | 13.0095% | 0.7214 | 1142 / 1082 | 284.02 / 284.48 |
| 64 | 14.2239% | 13.0215% | 1.2024 | 1183 / 1083 | 421.29 / 410.78 |
| 128 (default) | 14.8010% | 13.0696% | **1.7314** | 1231 / 1087 | 513.53 / 510.32 |

“Total word errors” is the sum of substitutions, deletions, and insertions reported by `jiwer`.

When `max_num_seqs=1`, different requests cannot be batched together; the code before and after the fix produces identical transcripts and WER. Compared with this single-request result, the code before the fix produces 21, 62, 103, and 151 additional word errors as `max_num_seqs` increases. After the fix, it produces only 2, 2, 3, and 7 additional errors. At the default `max_num_seqs=128`, the fix removes 144 of the 151 additional errors (95.4%). WER after the fix varies by only 0.0841 percentage points across all five settings.

The saved references and predictions were scored with the metric and normalization code used by `tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py` at upstream commit `bb363db9`. vLLM currently applies this method to Whisper and CohereASR; this PR applies the same method to a FunASR-specific batching sweep.

Throughput is included only as directional context. Each value comes from one post-warmup `llm.generate()` measurement (6.6–40.8 seconds), with no repeated trials or uncertainty estimate. The deltas are not monotonic, so this evaluation does not claim a precise performance change. At the vLLM 0.28.0 default setting, throughput changes by −0.63%.

Local validation covered FlashAttention on one NVIDIA GeForce RTX 5090 with tensor parallelism 1 in vLLM 0.28.0. Other `MMEncoderAttention` backends, tensor-parallel configurations greater than 1, and non-CUDA platforms were not exercised by these results.

## AI assistance

AI assistance (Claude Code) was used for the root-cause investigation, implementation, tests, and evaluation. The human submitter has reviewed every changed line and takes responsibility for the change and the reported validation.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan and commands.
- [x] The test results, including before/after and model evaluation.
- [x] No documentation update is required because this fixes existing model behavior without changing the public API.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
