### PR TITLE
[Perf][Quant][NVFP4] Prefer W4A4 linear kernels over weight-only ones on SM120/121

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_kernel_selection.py
+++ b/tests/kernels/quantization/test_nvfp4_kernel_selection.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for NVFP4 linear kernel selection order (CPU-only).
-
-Run `pytest tests/kernels/quantization/test_nvfp4_kernel_selection.py`.
-"""
+"""Tests for NVFP4 linear kernel selection order (CPU-only)."""
 
 import pytest
 
@@ -16,8 +13,8 @@ from vllm.model_executor.kernels.linear import (
 )
 from vllm.platforms.interface import PlatformEnum
 
-# W4A4 kernels that run on SM120/121, where the CuTe-DSL W4A4 kernel at the head
-# of the list is gated off (it requires sm_10x).
+# W4A4 kernels that run on SM120/121, where the head of the list is gated to
+# sm_10x and selection falls through to whatever follows.
 W4A4_KERNELS_ON_SM12X = (
     FlashInferCutlassNvFp4LinearKernel,
     FlashInferB12xNvFp4LinearKernel,
@@ -27,13 +24,6 @@ W4A4_KERNELS_ON_SM12X = (
 
 @pytest.mark.parametrize("w4a4_kernel", W4A4_KERNELS_ON_SM12X)
 def test_w4a16_kernel_does_not_precede_w4a4_kernels(w4a4_kernel):
-    """A weight-only kernel must not outrank a W4A4 one.
-
-    Selection walks this list and takes the first kernel reporting support on
-    the current device. On SM120/121 the head entry is gated off, so a
-    weight-only kernel placed above the W4A4 entries is chosen even though the
-    checkpoint can feed FP4 activations.
-    """
     candidates = _POSSIBLE_NVFP4_KERNELS[PlatformEnum.CUDA]
     w4a16_index = candidates.index(FlashInferCuteDslNvFp4W4A16LinearKernel)
     assert candidates.index(w4a4_kernel) < w4a16_index, (

--- a/tests/kernels/quantization/test_nvfp4_kernel_selection.py
+++ b/tests/kernels/quantization/test_nvfp4_kernel_selection.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for NVFP4 linear kernel selection order (CPU-only).
+
+Run `pytest tests/kernels/quantization/test_nvfp4_kernel_selection.py`.
+"""
+
+from vllm.model_executor.kernels.linear import (
+    _POSSIBLE_NVFP4_KERNELS,
+    FlashInferCuteDslNvFp4W4A16LinearKernel,
+    MarlinNvFp4LinearKernel,
+)
+from vllm.platforms.interface import PlatformEnum
+
+# Kernels that consume BF16 activations. They are correct for weight-only
+# checkpoints but leave the FP4 tensor cores idle on a W4A4-capable one.
+WEIGHT_ONLY_KERNELS = (
+    FlashInferCuteDslNvFp4W4A16LinearKernel,
+    MarlinNvFp4LinearKernel,
+)
+
+
+def test_weight_only_kernels_are_not_preferred_over_w4a4():
+    """A weight-only kernel must never outrank a W4A4 kernel.
+
+    Selection walks this list and takes the first kernel that reports support
+    on the current device. A weight-only kernel placed above a W4A4 one is
+    therefore picked on any platform where the kernels above it are gated off,
+    even though the checkpoint can feed FP4 activations.
+    """
+    candidates = _POSSIBLE_NVFP4_KERNELS[PlatformEnum.CUDA]
+    first_weight_only = min(
+        candidates.index(kernel)
+        for kernel in WEIGHT_ONLY_KERNELS
+        if kernel in candidates
+    )
+    trailing = candidates[first_weight_only:]
+    offenders = [k.__name__ for k in trailing if k not in WEIGHT_ONLY_KERNELS]
+    assert not offenders, (
+        "W4A4 kernels must precede weight-only kernels, but these follow the "
+        f"first weight-only entry: {offenders}"
+    )

--- a/tests/kernels/quantization/test_nvfp4_kernel_selection.py
+++ b/tests/kernels/quantization/test_nvfp4_kernel_selection.py
@@ -5,38 +5,38 @@
 Run `pytest tests/kernels/quantization/test_nvfp4_kernel_selection.py`.
 """
 
+import pytest
+
 from vllm.model_executor.kernels.linear import (
     _POSSIBLE_NVFP4_KERNELS,
+    CutlassNvFp4LinearKernel,
+    FlashInferB12xNvFp4LinearKernel,
     FlashInferCuteDslNvFp4W4A16LinearKernel,
-    MarlinNvFp4LinearKernel,
+    FlashInferCutlassNvFp4LinearKernel,
 )
 from vllm.platforms.interface import PlatformEnum
 
-# Kernels that consume BF16 activations. They are correct for weight-only
-# checkpoints but leave the FP4 tensor cores idle on a W4A4-capable one.
-WEIGHT_ONLY_KERNELS = (
-    FlashInferCuteDslNvFp4W4A16LinearKernel,
-    MarlinNvFp4LinearKernel,
+# W4A4 kernels that run on SM120/121, where the CuTe-DSL W4A4 kernel at the head
+# of the list is gated off (it requires sm_10x).
+W4A4_KERNELS_ON_SM12X = (
+    FlashInferCutlassNvFp4LinearKernel,
+    FlashInferB12xNvFp4LinearKernel,
+    CutlassNvFp4LinearKernel,
 )
 
 
-def test_weight_only_kernels_are_not_preferred_over_w4a4():
-    """A weight-only kernel must never outrank a W4A4 kernel.
+@pytest.mark.parametrize("w4a4_kernel", W4A4_KERNELS_ON_SM12X)
+def test_w4a16_kernel_does_not_precede_w4a4_kernels(w4a4_kernel):
+    """A weight-only kernel must not outrank a W4A4 one.
 
-    Selection walks this list and takes the first kernel that reports support
-    on the current device. A weight-only kernel placed above a W4A4 one is
-    therefore picked on any platform where the kernels above it are gated off,
-    even though the checkpoint can feed FP4 activations.
+    Selection walks this list and takes the first kernel reporting support on
+    the current device. On SM120/121 the head entry is gated off, so a
+    weight-only kernel placed above the W4A4 entries is chosen even though the
+    checkpoint can feed FP4 activations.
     """
     candidates = _POSSIBLE_NVFP4_KERNELS[PlatformEnum.CUDA]
-    first_weight_only = min(
-        candidates.index(kernel)
-        for kernel in WEIGHT_ONLY_KERNELS
-        if kernel in candidates
-    )
-    trailing = candidates[first_weight_only:]
-    offenders = [k.__name__ for k in trailing if k not in WEIGHT_ONLY_KERNELS]
-    assert not offenders, (
-        "W4A4 kernels must precede weight-only kernels, but these follow the "
-        f"first weight-only entry: {offenders}"
+    w4a16_index = candidates.index(FlashInferCuteDslNvFp4W4A16LinearKernel)
+    assert candidates.index(w4a4_kernel) < w4a16_index, (
+        f"{w4a4_kernel.__name__} must be preferred over "
+        f"{FlashInferCuteDslNvFp4W4A16LinearKernel.__name__}"
     )

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -536,8 +536,7 @@ _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
         FlashInferCutlassNvFp4LinearKernel,
         FlashInferB12xNvFp4LinearKernel,
         CutlassNvFp4LinearKernel,
-        # Weight-only kernels go last: on a W4A4-capable checkpoint they are a
-        # fallback, not a preference.
+        # Weight-only: a fallback on a W4A4-capable checkpoint, not a preference.
         FlashInferCuteDslNvFp4W4A16LinearKernel,
         MarlinNvFp4LinearKernel,
         FlashInferTrtllmNvFp4LinearKernel,

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -533,10 +533,12 @@ _POSSIBLE_MXFP8_KERNELS: dict[PlatformEnum, list[type[Mxfp8LinearKernel]]] = {
 _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
     PlatformEnum.CUDA: [
         FlashInferCuteDslNvFp4LinearKernel,
-        FlashInferCuteDslNvFp4W4A16LinearKernel,
         FlashInferCutlassNvFp4LinearKernel,
         FlashInferB12xNvFp4LinearKernel,
         CutlassNvFp4LinearKernel,
+        # Weight-only kernels go last: on a W4A4-capable checkpoint they are a
+        # fallback, not a preference.
+        FlashInferCuteDslNvFp4W4A16LinearKernel,
         MarlinNvFp4LinearKernel,
         FlashInferTrtllmNvFp4LinearKernel,
         FlashInferCudnnNvFp4LinearKernel,


### PR DESCRIPTION
## Purpose

On SM120/121, NVFP4 linear layers run a **weight-only (W4A16)** kernel even when the checkpoint can feed FP4 activations, so the FP4 tensor cores sit idle.

Measured on Qwen3.8-27B-NVFP4, RTX PRO 6000 Blackwell Max-Q, BS1, 32K cached prefix + 2K ISL + 256 OSL, same node, same checkpoint, `v0.28.1rc1.dev337+g27a94d1ce` with the V2 model runner:

| `--linear-backend` | selected kernel | TTFT | output tok/s |
|---|---|---|---|
| `auto` (today) | `FlashInferCuteDslNvFp4W4A16LinearKernel` | 1455.2 ms | 74.81 |
| `flashinfer_cutlass` | `FlashInferCutlassNvFp4LinearKernel` | **926.1 ms** | **92.63** |

**+23.8% output throughput and 36% lower TTFT** from selecting a W4A4 kernel instead.

The same comparison on the V1 runner gives +18.7%, and there `marlin` measures 74.60 against 73.08 for the weight-only CuTe-DSL kernel. The gap is concentrated in prefill, which is where losing the FP4 tensor cores costs most.

So on SM120/121 the weight-only CuTe-DSL kernel is not the best choice even among weight-only kernels.

Scope: kernel selection is static per layer, so this picks the better default for a mixed prefill and decode workload. W4A4 wins prefill decisively and loses BS1 decode by a few percent, so a decode-only workload would prefer the weight-only kernel. Choosing per forward instead of per server needs the two kernels to share a weight layout, which is #54614.

## Cause

`_POSSIBLE_NVFP4_KERNELS[CUDA]` is walked in order and the first kernel reporting support wins:

```
FlashInferCuteDslNvFp4LinearKernel          # W4A4, gated to sm_10x
FlashInferCuteDslNvFp4W4A16LinearKernel     # weight-only
FlashInferCutlassNvFp4LinearKernel          # W4A4
FlashInferB12xNvFp4LinearKernel             # W4A4
CutlassNvFp4LinearKernel                    # W4A4
```

The first entry returns `"FlashInfer cutedsl requires sm_10x"`, because FlashInfer's CuTe-DSL FP4 GEMM only ships `dense_blockscaled_gemm_sm100` / `sm103` kernels with sm100/sm107 tactic selectors. On SM120 it is skipped and selection lands on the weight-only kernel at position 2, ahead of three W4A4 kernels that do run there.

`use_a16` only ever narrows the list *to* the weight-only kernels, so on a W4A4-capable checkpoint nothing prevents a weight-only kernel from being preferred.

This ordering came in with #53014, which added the kernel. That PR gated the *forced* weight-only path to SM100/103, but the priority list entry is ungated, so it also applies on SM120/121.

## Fix

Move `FlashInferCuteDslNvFp4W4A16LinearKernel` after the W4A4 entries, next to `MarlinNvFp4LinearKernel`.

Weight-only checkpoints are unaffected: `use_a16` filters to the a16 kernels and preserves their relative order, and the forced weight-only path already selects explicitly by compute capability.

## Testing

```
pytest tests/kernels/quantization/test_nvfp4_kernel_selection.py
```

Added `test_w4a16_kernel_does_not_precede_w4a4_kernels`, which asserts the CuTe-DSL W4A16 kernel does not precede the three W4A4 kernels that run on SM120/121. It fails on `main` for all three and passes with this change. CPU-only, no GPU required.

The throughput numbers are a same-node A/B. Kernel selection happens in `init_nvfp4_linear_kernel` and is runner-independent, so the runner affects the size of the delta, not which kernel is chosen.

Verified inert on SM103 (GB300, same harness and checkpoint): `auto` already selects `FlashInferCuteDslNvFp4LinearKernel` at position 1 there, so the entry being moved is never reached. A weight-only checkpoint on SM103 still selects `FlashInferCuteDslNvFp4W4A16LinearKernel` as before.

## Why this is not a duplicate

I ran the checks in AGENTS.md. No open PR or issue touches NVFP4 linear kernel selection. The nearest work is #55103 (Marlin scale-factor memory) and #55073 (MoE w13 global scales), both different surfaces.


## AI assistance

AI assistance was used to author this change. I have reviewed every changed line, ran the test and the benchmark above myself, and can defend the design.
