### PR TITLE
Fix/dsv4 sm8x o proj

### DIFF
--- a/tests/models/deepseek_v4/test_nvidia_o_proj.py
+++ b/tests/models/deepseek_v4/test_nvidia_o_proj.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+
+def load_o_proj_module():
+    root = Path(__file__).parents[3]
+    module_path = (
+        root / "vllm" / "models" / "deepseek_v4" / "nvidia" / "ops" / "o_proj.py"
+    )
+
+    stub_names = (
+        "vllm.models.deepseek_v4.common.ops",
+        "vllm.platforms",
+        "vllm.utils.deep_gemm",
+    )
+    original_modules = {
+        name: sys.modules.get(name) for name in stub_names if name in sys.modules
+    }
+    missing_modules = {name for name in stub_names if name not in sys.modules}
+    try:
+        common_ops = types.ModuleType("vllm.models.deepseek_v4.common.ops")
+        common_ops.fused_inv_rope_fp8_quant = None
+        sys.modules["vllm.models.deepseek_v4.common.ops"] = common_ops
+
+        platforms = types.ModuleType("vllm.platforms")
+        platforms.current_platform = None
+        sys.modules["vllm.platforms"] = platforms
+
+        deep_gemm = types.ModuleType("vllm.utils.deep_gemm")
+        deep_gemm.fp8_einsum = None
+        sys.modules["vllm.utils.deep_gemm"] = deep_gemm
+
+        spec = importlib.util.spec_from_file_location("test_o_proj", module_path)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, module in original_modules.items():
+            sys.modules[name] = module
+        for name in missing_modules:
+            sys.modules.pop(name, None)
+
+
+o_proj = load_o_proj_module()
+get_fp8_weight_scale = o_proj.get_fp8_weight_scale
+inv_rope_bf16_o_proj = o_proj.inv_rope_bf16_o_proj
+deep_gemm_fp8_o_proj = o_proj.deep_gemm_fp8_o_proj
+
+
+def test_get_fp8_weight_scale_prefers_weight_scale_inv():
+    layer = nn.Module()
+    layer.weight_scale = nn.Parameter(torch.tensor([1.0]), requires_grad=False)
+    layer.weight_scale_inv = nn.Parameter(torch.tensor([2.0]), requires_grad=False)
+
+    assert get_fp8_weight_scale(layer) is layer.weight_scale_inv
+
+
+def test_get_fp8_weight_scale_accepts_weight_scale():
+    layer = nn.Module()
+    layer.weight_scale = nn.Parameter(torch.tensor([1.0]), requires_grad=False)
+
+    assert get_fp8_weight_scale(layer) is layer.weight_scale
+
+
+def test_get_fp8_weight_scale_returns_none_without_scale():
+    assert get_fp8_weight_scale(nn.Module()) is None
+
+
+class FakeWoA(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input = None
+
+    def forward(self, x):
+        self.input = x
+        return x[..., :1]
+
+
+def test_inv_rope_bf16_o_proj_uses_unquantized_linear_path():
+    wo_a = FakeWoA()
+    o = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]], dtype=torch.bfloat16)
+    cos_sin_cache = torch.tensor([[0.0, 1.0]], dtype=torch.float32)
+    out = inv_rope_bf16_o_proj(
+        o,
+        torch.tensor([0], dtype=torch.long),
+        cos_sin_cache,
+        wo_a,
+        n_groups=1,
+        heads_per_group=1,
+        nope_dim=2,
+        rope_dim=2,
+        o_lora_rank=1,
+    )
+
+    assert out.shape == (1, 1, 1)
+    assert wo_a.input is not None
+    expected = torch.tensor([[[1.0, 2.0, 4.0, -3.0]]], dtype=torch.bfloat16)
+    torch.testing.assert_close(wo_a.input, expected)
+
+
+class FakeGroupedWoA(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0, 0.0],
+                    [0.0, 2.0, 0.0, 0.0],
+                ],
+                dtype=torch.bfloat16,
+            ),
+            requires_grad=False,
+        )
+
+
+class FakeSingleGroupWoA(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                ],
+                dtype=torch.bfloat16,
+            ),
+            requires_grad=False,
+        )
+
+
+def test_inv_rope_bf16_o_proj_reshapes_flat_grouped_weight():
+    o = torch.tensor(
+        [[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]], dtype=torch.bfloat16
+    )
+    out = inv_rope_bf16_o_proj(
+        o,
+        torch.tensor([0], dtype=torch.long),
+        torch.tensor([[1.0, 0.0]], dtype=torch.float32),
+        FakeGroupedWoA(),
+        n_groups=2,
+        heads_per_group=1,
+        nope_dim=2,
+        rope_dim=2,
+        o_lora_rank=2,
+    )
+
+    expected = torch.tensor([[[1.0, 2.0], [10.0, 12.0]]], dtype=torch.bfloat16)
+    torch.testing.assert_close(out, expected)
+
+
+class FakeWoB(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input = None
+
+    def forward(self, x):
+        self.input = x
+        return x + 1
+
+
+def test_deep_gemm_fp8_o_proj_uses_bf16_fallback_without_scale():
+    wo_b = FakeWoB()
+    out = deep_gemm_fp8_o_proj(
+        torch.tensor([[[1.0, 2.0, 3.0, 4.0]]], dtype=torch.bfloat16),
+        torch.tensor([0], dtype=torch.long),
+        torch.tensor([[1.0, 0.0]], dtype=torch.float32),
+        FakeSingleGroupWoA(),
+        wo_b,
+        n_groups=1,
+        heads_per_group=1,
+        nope_dim=2,
+        rope_dim=2,
+        o_lora_rank=2,
+        einsum_recipe=(1, 128, 128),
+        tma_aligned_scales=False,
+    )
+
+    assert wo_b.input is not None
+    torch.testing.assert_close(
+        wo_b.input, torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16)
+    )
+    torch.testing.assert_close(out, torch.tensor([[2.0, 3.0]], dtype=torch.bfloat16))

--- a/tests/models/deepseek_v4/test_nvidia_o_proj.py
+++ b/tests/models/deepseek_v4/test_nvidia_o_proj.py
@@ -1,57 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import importlib.util
-import sys
 import types
-from pathlib import Path
 
+import pytest
 import torch
 import torch.nn as nn
 
+from vllm.models.deepseek_v4.nvidia.ops import o_proj
 
-def load_o_proj_module():
-    root = Path(__file__).parents[3]
-    module_path = (
-        root / "vllm" / "models" / "deepseek_v4" / "nvidia" / "ops" / "o_proj.py"
-    )
-
-    stub_names = (
-        "vllm.models.deepseek_v4.common.ops",
-        "vllm.platforms",
-        "vllm.utils.deep_gemm",
-    )
-    original_modules = {
-        name: sys.modules.get(name) for name in stub_names if name in sys.modules
-    }
-    missing_modules = {name for name in stub_names if name not in sys.modules}
-    try:
-        common_ops = types.ModuleType("vllm.models.deepseek_v4.common.ops")
-        common_ops.fused_inv_rope_fp8_quant = None
-        sys.modules["vllm.models.deepseek_v4.common.ops"] = common_ops
-
-        platforms = types.ModuleType("vllm.platforms")
-        platforms.current_platform = None
-        sys.modules["vllm.platforms"] = platforms
-
-        deep_gemm = types.ModuleType("vllm.utils.deep_gemm")
-        deep_gemm.fp8_einsum = None
-        sys.modules["vllm.utils.deep_gemm"] = deep_gemm
-
-        spec = importlib.util.spec_from_file_location("test_o_proj", module_path)
-        assert spec is not None
-        assert spec.loader is not None
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
-    finally:
-        for name, module in original_modules.items():
-            sys.modules[name] = module
-        for name in missing_modules:
-            sys.modules.pop(name, None)
-
-
-o_proj = load_o_proj_module()
 get_fp8_weight_scale = o_proj.get_fp8_weight_scale
 inv_rope_bf16_o_proj = o_proj.inv_rope_bf16_o_proj
 deep_gemm_fp8_o_proj = o_proj.deep_gemm_fp8_o_proj
@@ -128,6 +85,7 @@ class FakeGroupedWoA(nn.Module):
 class FakeSingleGroupWoA(nn.Module):
     def __init__(self):
         super().__init__()
+        self.input = None
         self.weight = nn.Parameter(
             torch.tensor(
                 [
@@ -138,6 +96,13 @@ class FakeSingleGroupWoA(nn.Module):
             ),
             requires_grad=False,
         )
+
+    def forward(self, x):
+        self.input = x
+        scale = getattr(self, "weight_scale", 1)
+        if isinstance(scale, torch.Tensor):
+            scale = scale.to(x.dtype)
+        return torch.einsum("bgi,ri->bgr", x, self.weight) * scale
 
 
 def test_inv_rope_bf16_o_proj_reshapes_flat_grouped_weight():
@@ -170,13 +135,24 @@ class FakeWoB(nn.Module):
         return x + 1
 
 
-def test_deep_gemm_fp8_o_proj_uses_bf16_fallback_without_scale():
+@pytest.mark.parametrize("with_weight_scale", [False, True])
+def test_deep_gemm_fp8_o_proj_uses_bf16_fallback(monkeypatch, with_weight_scale):
+    monkeypatch.setattr(
+        o_proj,
+        "current_platform",
+        types.SimpleNamespace(support_deep_gemm=lambda: False),
+    )
+    wo_a = FakeSingleGroupWoA()
+    factor = 2.0 if with_weight_scale else 1.0
+    if with_weight_scale:
+        wo_a.weight_scale = nn.Parameter(torch.tensor([factor]), requires_grad=False)
     wo_b = FakeWoB()
+
     out = deep_gemm_fp8_o_proj(
         torch.tensor([[[1.0, 2.0, 3.0, 4.0]]], dtype=torch.bfloat16),
         torch.tensor([0], dtype=torch.long),
         torch.tensor([[1.0, 0.0]], dtype=torch.float32),
-        FakeSingleGroupWoA(),
+        wo_a,
         wo_b,
         n_groups=1,
         heads_per_group=1,
@@ -187,8 +163,10 @@ def test_deep_gemm_fp8_o_proj_uses_bf16_fallback_without_scale():
         tma_aligned_scales=False,
     )
 
+    if with_weight_scale:
+        assert wo_a.input is not None
     assert wo_b.input is not None
-    torch.testing.assert_close(
-        wo_b.input, torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16)
-    )
-    torch.testing.assert_close(out, torch.tensor([[2.0, 3.0]], dtype=torch.bfloat16))
+    expected = torch.tensor([[factor, 2 * factor]], dtype=torch.bfloat16)
+    expected_out = expected + 1
+    torch.testing.assert_close(wo_b.input, expected)
+    torch.testing.assert_close(out, expected_out)

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -10,6 +10,88 @@ from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import fp8_einsum
 
 
+def get_fp8_weight_scale(layer: nn.Module) -> torch.Tensor | None:
+    if hasattr(layer, "weight_scale_inv"):
+        return layer.weight_scale_inv
+    if hasattr(layer, "weight_scale"):
+        return layer.weight_scale
+    return None
+
+
+def maybe_unpack_linear_output(
+    output: torch.Tensor | tuple[torch.Tensor, torch.Tensor | None],
+) -> torch.Tensor:
+    if isinstance(output, tuple):
+        return output[0]
+    return output
+
+
+def inv_rope_bf16_o_proj(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    wo_a: nn.Module,
+    *,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    o_lora_rank: int,
+) -> torch.Tensor:
+    num_tokens, num_heads, head_dim = o.shape
+    expected_heads = n_groups * heads_per_group
+    expected_head_dim = nope_dim + rope_dim
+    if num_heads != expected_heads:
+        raise ValueError(f"Expected {expected_heads} heads, got {num_heads}.")
+    if head_dim != expected_head_dim:
+        raise ValueError(
+            f"Expected head dimension {expected_head_dim}, got {head_dim}."
+        )
+    if rope_dim % 2 != 0:
+        raise ValueError(f"rope_dim must be even, got {rope_dim}.")
+
+    grouped = o.reshape(num_tokens, n_groups, heads_per_group, head_dim)
+    projected = grouped.clone()
+
+    rope = projected[..., nope_dim:]
+    rope_pairs = rope.reshape(*rope.shape[:-1], rope_dim // 2, 2)
+    cos_sin = cos_sin_cache.index_select(0, positions)
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    cos = cos[:, None, None, :, None].to(dtype=rope.dtype)
+    sin = sin[:, None, None, :, None].to(dtype=rope.dtype)
+
+    x0 = rope_pairs[..., 0:1]
+    x1 = rope_pairs[..., 1:2]
+    rope_pairs.copy_(torch.cat((x0 * cos + x1 * sin, x1 * cos - x0 * sin), dim=-1))
+
+    wo_a_weight = getattr(wo_a, "weight", None)
+    wo_a_input_size = (
+        wo_a_weight.shape[-1]
+        if wo_a_weight is not None and wo_a_weight.ndim >= 2
+        else getattr(wo_a, "input_size", heads_per_group * head_dim)
+    )
+    flattened_size = num_heads * head_dim
+    if flattened_size % wo_a_input_size != 0:
+        raise ValueError(
+            "Cannot reshape O-proj input of size "
+            f"{flattened_size} into groups of size {wo_a_input_size}."
+        )
+
+    wo_a_groups = flattened_size // wo_a_input_size
+    wo_a_input = projected.reshape(num_tokens, wo_a_groups, wo_a_input_size)
+
+    if (
+        wo_a_weight is not None
+        and wo_a_weight.ndim == 2
+        and wo_a_weight.shape[0] % o_lora_rank == 0
+        and wo_a_weight.shape[0] // o_lora_rank == wo_a_groups
+    ):
+        grouped_weight = wo_a_weight.reshape(wo_a_groups, o_lora_rank, wo_a_input_size)
+        return torch.einsum("bgi,gri->bgr", wo_a_input, grouped_weight)
+
+    return maybe_unpack_linear_output(wo_a(wo_a_input))
+
+
 def compute_fp8_einsum_recipe() -> tuple[tuple[int, int, int], bool]:
     """fp8_einsum recipe + scale layout for the current GPU arch.
 
@@ -45,6 +127,21 @@ def deep_gemm_fp8_o_proj(
     Shared by the FlashMLA and FlashInfer CUDA backends. ``einsum_recipe`` /
     ``tma_aligned_scales`` come from ``compute_fp8_einsum_recipe``.
     """
+    weight_scale = get_fp8_weight_scale(wo_a)
+    if weight_scale is None:
+        z = inv_rope_bf16_o_proj(
+            o,
+            positions,
+            cos_sin_cache,
+            wo_a,
+            n_groups=n_groups,
+            heads_per_group=heads_per_group,
+            nope_dim=nope_dim,
+            rope_dim=rope_dim,
+            o_lora_rank=o_lora_rank,
+        )
+        return wo_b(z.flatten(1))
+
     o_fp8, o_scale = fused_inv_rope_fp8_quant(
         o,
         positions,

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -80,6 +80,13 @@ def inv_rope_bf16_o_proj(
     wo_a_groups = flattened_size // wo_a_input_size
     wo_a_input = projected.reshape(num_tokens, wo_a_groups, wo_a_input_size)
 
+    if get_fp8_weight_scale(wo_a) is not None:
+        z_all = maybe_unpack_linear_output(wo_a(wo_a_input)).reshape(
+            num_tokens, wo_a_groups, wo_a_groups, o_lora_rank
+        )
+        group = torch.arange(wo_a_groups, device=o.device)
+        return z_all[:, group, group]
+
     if (
         wo_a_weight is not None
         and wo_a_weight.ndim == 2
@@ -128,7 +135,7 @@ def deep_gemm_fp8_o_proj(
     ``tma_aligned_scales`` come from ``compute_fp8_einsum_recipe``.
     """
     weight_scale = get_fp8_weight_scale(wo_a)
-    if weight_scale is None:
+    if weight_scale is None or not current_platform.support_deep_gemm():
         z = inv_rope_bf16_o_proj(
             o,
             positions,


### PR DESCRIPTION


## Purpose

DeepSeek V4 sends scaled NVIDIA output-projection weights through the fused FP8 DeepGEMM path. On A100 the first projection fails before generation while converting the inverse-RoPE output:

```text
ValueError: type fp8e4nv not supported in this architecture
```

DeepGEMM is unavailable throughout SM8x, so replacing only that conversion would move the failure into `fp8_einsum`. [#44847](https://github.com/vllm-project/vllm/pull/44847) already provides a BF16 grouped output-projection helper when scale metadata is absent. This PR is stacked on #44847 and selects that helper whenever the platform does not support DeepGEMM, including when the weights carry scale metadata.

Scaled weights must still pass through `wo_a` so its quantization backend applies their scales. The helper therefore calls `wo_a` for scaled weights, reshapes its output by group, and selects the per-group diagonal. It retains #44847’s direct einsum for unscaled BF16 weights and retains the fused FP8 path on DeepGEMM-capable GPUs.

The alternatives were to duplicate the BF16 inverse-RoPE projection or extend only the FP8 conversion. Reusing #44847 avoids a second implementation, while extending only the conversion would still fail at DeepGEMM. Calling the existing linear module for scaled weights preserves its quantization contract instead of reading raw FP8 weights without their scales.

## Test Plan

Use a direct import of the production output-projection module, extend #44847’s existing test with a scaled-weight case, and run the complete module. This focused test is CPU-only: it reproduces the A100/SM8x dispatch condition by forcing `support_deep_gemm()` to false and verifies both the scaled and unscaled projection contracts without claiming GPU kernel coverage.

```bash
.venv/bin/python -m pytest \
  tests/models/deepseek_v4/test_nvidia_o_proj.py \
  -v
```

Exercise the model path with #44847, the FP8-conversion-helper prerequisite, and the sparse-MLA companion on four eight-GPU A100 nodes. Run the prerequisite stack without this branch to reproduce the output-projection failure, then add this branch and repeat the same job:

```bash
#!/bin/bash
#SBATCH --nodes=4
#SBATCH --ntasks=4
#SBATCH --ntasks-per-node=1
#SBATCH --gpus-per-node=8
#SBATCH --time=02:00:00

set -euo pipefail

export MODEL=nvidia/DeepSeek-V4-Pro-0813-NVFP4
export REVISION=2ff4ec53ee664e54571f670276d2c89d0fcc7b82
export MASTER_ADDR
MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
export MASTER_PORT=29501
export COMPILATION_CONFIG='{"cudagraph_capture_sizes":[1,2,4,8,16,32,64],"inductor_compile_config":{"enable_auto_functionalized_v2":true}}'

srun --nodes=4 --ntasks=4 --ntasks-per-node=1 bash -lc '
  headless=()
  if (( SLURM_NODEID > 0 )); then
    headless=(--headless)
  fi

  exec vllm serve "$MODEL" \
    --revision "$REVISION" \
    --served-model-name deepseek-v4-pro \
    --host 0.0.0.0 \
    --port 8000 \
    --trust-remote-code \
    --tokenizer-mode deepseek_v4 \
    --load-format fastsafetensors \
    --safetensors-load-strategy lazy \
    --distributed-executor-backend mp \
    --master-addr "$MASTER_ADDR" \
    --master-port "$MASTER_PORT" \
    --nnodes "$SLURM_NNODES" \
    --node-rank "$SLURM_NODEID" \
    --tensor-parallel-size 16 \
    --pipeline-parallel-size 2 \
    --enable-expert-parallel \
    --kv-cache-dtype fp8 \
    --block-size 256 \
    --max-model-len 10240 \
    --max-num-seqs 64 \
    --max-num-batched-tokens 16384 \
    --gpu-memory-utilization 0.9 \
    --linear-backend auto \
    --moe-backend auto \
    --no-enable-prefix-caching \
    --distributed-timeout-seconds 7200 \
    --cpu-distributed-timeout-seconds 7200 \
    --compilation-config "$COMPILATION_CONFIG" \
    "${headless[@]}"
'
```

After the A100 head process becomes ready, run a concurrency-16 smoke test and then the full GSM8K evaluation:

```bash
.venv/bin/python tests/evals/gsm8k/gsm8k_eval.py \
  --host http://127.0.0.1 \
  --port 8000 \
  --num-questions 16 \
  --num-shots 5 \
  --max-tokens 1024 \
  --temperature 0 \
  --seed 42 \
  --max-concurrency 16 \
  --save-results gsm8k-c16.json

.venv/bin/python tests/evals/gsm8k/gsm8k_eval.py \
  --host http://127.0.0.1 \
  --port 8000 \
  --num-questions 1319 \
  --num-shots 5 \
  --max-tokens 1024 \
  --temperature 0 \
  --seed 42 \
  --max-concurrency 64 \
  --save-results gsm8k-full.json
```

Run the repository checks on both changed files:

```bash
pre-commit run --files \
  tests/models/deepseek_v4/test_nvidia_o_proj.py \
  vllm/models/deepseek_v4/nvidia/ops/o_proj.py
```

## Test Result

On #44847 alone, the CPU-only focused module passed six cases, but the scaled-weight case entered `fused_inv_rope_fp8_quant` instead of the BF16 fallback and failed. With this PR, the same module passes 7/7 cases. The scaled case verifies that `wo_a` receives the BF16 inverse-RoPE activations and applies its non-unit scale before `wo_b`; the unscaled case continues to use #44847's direct BF16 einsum.

Before this PR, the compiled four-node A100/SM80 model run failed in `deep_gemm_fp8_o_proj` before producing a response:

```text
ValueError: type fp8e4nv not supported in this architecture
```

Together with #44847 and the co-pending FP8-conversion-helper and sparse-MLA PRs, this PR lets the compiled A100 server capture CUDA graphs and produces the following successful end-to-end results:

```text
c16: 16/16 requests completed, 0 invalid responses
full GSM8K: 1319/1319 requests completed
flexible accuracy: 0.965125
strict accuracy: 0.953753
invalid responses: 0
output tokens: 121802
evaluation time: 429.349 seconds
```

All applicable pre-commit hooks passed.

AI assistance was used to prepare the patch and PR description. The author reviewed every changed line and validated the focused and end-to-end results above.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the failure and dependency on #44847, is described.
- [x] The focused test and complete Slurm-native test commands are provided.
- [x] The focused before/after comparison and A100 end-to-end results are provided.
- [x] No documentation update is required because this changes backend dispatch without changing the public model interface.

</details>

