### PR TITLE
Fix/dsv4 sparse mla portability

### DIFF
--- a/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu
+++ b/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu
@@ -173,3 +173,37 @@ void silu_and_mul_scaled_fp4_experts_quant(
   STD_TORCH_CHECK_NOT_IMPLEMENTED(
       false, "No compiled silu_and_mul nvfp4 experts quantization kernel");
 }
+
+// MXFP4 link stubs for archs without a compiled MXFP4 kernel. On SM10.x the
+// real impls in `mxfp4_experts_quant.cu` are compiled (same CMake block that
+// defines `ENABLE_NVFP4_SM100`); on SM 8.x the real file is skipped, leaving
+// `torch_bindings.cpp`'s unconditional `&mxfp4_experts_quant` reference with
+// no symbol to bind to, so the `.so` fails to load. These stubs satisfy the
+// linker on unsupported archs and raise NOT_IMPLEMENTED if anyone actually
+// calls them.
+#if !(defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)
+void mxfp4_experts_quant(
+    torch::stable::Tensor& output, torch::stable::Tensor& output_scale,
+    torch::stable::Tensor const& input,
+    torch::stable::Tensor const& input_offset_by_experts,
+    torch::stable::Tensor const& output_scale_offset_by_experts,
+    int64_t n_experts) {
+  STD_TORCH_CHECK_NOT_IMPLEMENTED(
+      false, "No compiled mxfp4 experts quantization kernel for SM ",
+      get_sm_version_num(),
+      ". Recompile with SM 10.x (Blackwell) for MXFP4 support.");
+}
+
+void silu_and_mul_mxfp4_experts_quant(
+    torch::stable::Tensor& output, torch::stable::Tensor& output_scale,
+    torch::stable::Tensor const& input,
+    torch::stable::Tensor const& input_offset_by_experts,
+    torch::stable::Tensor const& output_scale_offset_by_experts,
+    int64_t n_experts) {
+  STD_TORCH_CHECK_NOT_IMPLEMENTED(
+      false,
+      "No compiled silu_and_mul mxfp4 experts quantization kernel for SM ",
+      get_sm_version_num(),
+      ". Recompile with SM 10.x (Blackwell) for MXFP4 support.");
+}
+#endif  // !ENABLE_NVFP4_SM100

--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -98,6 +98,18 @@ Priority is **1 = highest** (tried first).
 
 --8<-- "gen:priority-mla"
 
+**Ampere/Hopper (SM 8.x-9.x):**
+
+| Priority | Backend |
+| -------- | ------- |
+| 1 | `FLASH_ATTN_MLA` |
+| 2 | `FLASHMLA` |
+| 3 | `FLASHINFER_MLA` |
+| 4 | `TRITON_MLA` |
+| 5 | `FLASH_ATTN_MLA_SPARSE` |
+| 6 | `FLASHMLA_SPARSE` |
+| 7 | `TRITON_MLA_SPARSE` |
+
 > **\*** For sparse MLA, FP8 KV cache always prefers `FLASHINFER_MLA_SPARSE`. With BF16 KV cache, `FLASHINFER_MLA_SPARSE` is preferred for low query-head counts (<= 16), while `FLASHMLA_SPARSE` is preferred otherwise.
 >
 > **Note:** ROCm and CPU platforms have their own selection logic. See the platform-specific documentation for details.

--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -14,6 +14,15 @@ def test_deepseek_v4_sparse_mla_supports_cuda_architectures(major: int, minor: i
     )
 
 
+def test_deepseek_v4_sparse_mla_rejects_sm75():
+    from vllm.models.deepseek_v4.sparse_mla import DeepseekV4SparseMLABackend
+    from vllm.platforms.interface import DeviceCapability
+
+    assert not DeepseekV4SparseMLABackend.supports_compute_capability(
+        DeviceCapability(7, 5)
+    )
+
+
 @pytest.mark.parametrize("major,expected", [(7, False), (8, True), (12, True)])
 def test_triton_sparse_mla_requires_sm80(major: int, expected: bool):
     from vllm.platforms.interface import DeviceCapability

--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -4,6 +4,16 @@ import pytest
 import torch
 
 
+@pytest.mark.parametrize("major,minor", [(8, 0), (8, 6), (8, 9), (9, 0), (10, 0)])
+def test_deepseek_v4_sparse_mla_supports_cuda_architectures(major: int, minor: int):
+    from vllm.models.deepseek_v4.sparse_mla import DeepseekV4SparseMLABackend
+    from vllm.platforms.interface import DeviceCapability
+
+    assert DeepseekV4SparseMLABackend.supports_compute_capability(
+        DeviceCapability(major, minor)
+    )
+
+
 @pytest.mark.parametrize("sm120", [False, True])
 def test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride(
     monkeypatch: pytest.MonkeyPatch,
@@ -24,6 +34,7 @@ def test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride(
         (2, capacity_width), dtype=torch.int32, device=device
     )
     prefill_buffer = torch.empty_like(global_decode_buffer)
+    decode_lens_buffer = torch.empty(2, dtype=torch.int32, device=device)
     kwargs = dict(
         positions=torch.tensor([255, 511, 383, 639], device=device),
         compress_ratio=128,
@@ -33,9 +44,9 @@ def test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride(
         ),
         block_table=torch.tensor([[3], [5]], dtype=torch.int32, device=device),
         block_size=capacity_width,
-        slot_mapping=torch.arange(4, dtype=torch.int64, device=device),
+        slot_mapping=torch.tensor([0, -1, 2, 3], dtype=torch.int64, device=device),
         global_decode_buffer=global_decode_buffer,
-        decode_lens_buffer=torch.empty(2, dtype=torch.int32, device=device),
+        decode_lens_buffer=decode_lens_buffer,
         prefill_buffer=prefill_buffer,
     )
     captured_decode, _, captured_prefill = sparse_mla.build_c128a_topk_metadata(
@@ -70,10 +81,11 @@ def test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride(
 
     assert captured_rows.cpu().tolist() == [
         [1536, 1537, -1, -1],
-        [2560, 2561, 2562, 2563],
+        [-1, -1, -1, -1],
         [0, 1, 2, -1],
         [0, 1, 2, 3],
     ]
+    assert decode_lens_buffer.cpu().tolist() == [2, 0]
     assert torch.all(global_decode_buffer[:, 128:] == -99)
     assert torch.all(prefill_buffer[:, 128:] == -99)
 

--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -14,6 +14,19 @@ def test_deepseek_v4_sparse_mla_supports_cuda_architectures(major: int, minor: i
     )
 
 
+@pytest.mark.parametrize("major,expected", [(7, False), (8, True), (12, True)])
+def test_triton_sparse_mla_requires_sm80(major: int, expected: bool):
+    from vllm.platforms.interface import DeviceCapability
+    from vllm.v1.attention.backends.mla.triton_mla_sparse import (
+        TritonMLASparseBackend,
+    )
+
+    assert (
+        TritonMLASparseBackend.supports_compute_capability(DeviceCapability(major, 0))
+        is expected
+    )
+
+
 @pytest.mark.parametrize("sm120", [False, True])
 def test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -27,6 +27,55 @@ def test_triton_sparse_mla_requires_sm80(major: int, expected: bool):
     )
 
 
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "model_dtype,cache_dtype,expected_kv_dtype",
+    [
+        (torch.float16, "auto", torch.float16),
+        (torch.bfloat16, "auto", torch.bfloat16),
+        (torch.float16, "bfloat16", torch.bfloat16),
+        (torch.bfloat16, "float16", torch.float16),
+    ],
+)
+def test_triton_sparse_mla_warmup_uses_configured_dtypes(
+    monkeypatch, model_dtype, cache_dtype, expected_kv_dtype
+):
+    from types import SimpleNamespace
+
+    from vllm.v1.attention.backends.mla import triton_mla_sparse
+
+    calls = set()
+    monkeypatch.setattr(
+        triton_mla_sparse,
+        "get_current_vllm_config_or_none",
+        lambda: SimpleNamespace(
+            model_config=SimpleNamespace(dtype=model_dtype),
+            cache_config=SimpleNamespace(block_size=64),
+        ),
+    )
+    monkeypatch.setattr(
+        triton_mla_sparse,
+        "triton_mla_sparse_attention",
+        lambda q, kv, *args, **kwargs: calls.add((q.dtype, kv.dtype)),
+    )
+    for name in (
+        "warmup_fp8_mqa_logits_triton",
+        "warmup_fp8_paged_mqa_logits_triton",
+    ):
+        monkeypatch.setattr(triton_mla_sparse, name, lambda **kwargs: None)
+    impl = SimpleNamespace(
+        topk_indices_buffer=torch.empty(1, 1, 16),
+        num_heads=16,
+        softmax_scale=1.0,
+        _sm_count=1,
+        kv_cache_dtype=cache_dtype,
+    )
+
+    triton_mla_sparse.TritonMLASparseImpl._warmup_autotune(impl, SimpleNamespace())
+
+    assert calls == {(model_dtype, expected_kv_dtype)}
+
+
 @pytest.mark.parametrize("sm120", [False, True])
 def test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/kernels/attention/test_mqa_logits_triton.py
+++ b/tests/kernels/attention/test_mqa_logits_triton.py
@@ -121,10 +121,17 @@ def _fp8_paged_mqa_logits_ref(
                 float("-inf"),
             )
             s = (torch.relu(s) * weight_slice[..., None]).sum(dim=0)
+            block_start = block_rk * block_size
+            block_end = min((block_rk + 1) * block_size, max_model_len)
+            block_width = block_end - block_start
             logits[
                 i * next_n : (i + 1) * next_n,
-                block_rk * block_size : (block_rk + 1) * block_size,
-            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
+                block_start:block_end,
+            ] = torch.where(
+                k_offsets[None, :block_width] <= q_offsets[:, None],
+                s[:, :block_width],
+                float("-inf"),
+            )
     return logits
 
 
@@ -242,6 +249,7 @@ def test_fp8_mqa_logits_triton_clean_logits_false_overwrites_masked():
         (1, 1, 512),
         (2, 1, 256),
         (1, 4, 512),  # speculative decoding with next_n=4
+        (2, 4, 130),  # active max length is not block-aligned
     ],
 )
 @pytest.mark.parametrize("num_heads", [16, 32])
@@ -289,7 +297,7 @@ def test_fp8_paged_mqa_logits_triton_matches_torch(
         device=device,
     )
 
-    max_model_len = max_blocks * block_size
+    max_model_len = context_len
 
     out_torch = _fp8_paged_mqa_logits_ref(
         q_fp8, kv_packed, weights, context_lens, block_tables, max_model_len

--- a/tests/kernels/attention/test_mqa_logits_triton.py
+++ b/tests/kernels/attention/test_mqa_logits_triton.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the Triton MQA logits kernels."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.ops.mqa_logits_triton import (
+    fp8_mqa_logits_triton,
+    fp8_paged_mqa_logits_triton,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Triton MQA logits kernels require CUDA/ROCm",
+)
+
+
+def _quantize_k_per_row(
+    k_bf16: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    amax = k_bf16.abs().float().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+    sf = amax / 448.0
+    k_fp8 = (k_bf16.float() / sf).to(torch.float8_e4m3fn)
+    return k_fp8, sf.squeeze(-1)
+
+
+def _pack_paged_kv(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Pack BF16 KV into the layout produced by `indexer_k_quant_and_cache`.
+
+    Physical bytes per block are segregated: all `block_size * head_dim` fp8 K
+    bytes first, then `block_size * 4` fp32 scale bytes. The outer
+    `[NB, BS, 1, D+4]` shape matches the production cache allocation.
+    """
+    num_blocks, block_size, head_dim = kv_bf16.shape
+    amax = kv_bf16.abs().float().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+    sf = (amax / 448.0).to(torch.float32)
+    k_fp8 = (kv_bf16.float() / sf).to(torch.float8_e4m3fn)
+    packed = torch.empty(
+        (num_blocks, block_size, 1, head_dim + 4),
+        dtype=torch.uint8,
+        device=kv_bf16.device,
+    )
+    flat = packed.view(num_blocks, -1)
+    k_end = block_size * head_dim
+    flat[:, :k_end] = k_fp8.reshape(num_blocks, -1).view(torch.uint8)
+    flat[:, k_end:] = sf.reshape(num_blocks, -1).view(torch.uint8)
+    return packed
+
+
+# References adapted from DeepGEMM (test_attention.py) — used as the spec
+# the Triton kernels must agree with.
+def _fp8_mqa_logits_ref(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    k_fp8, scale = kv
+    seq_len_kv = k_fp8.shape[0]
+    k = k_fp8.to(torch.bfloat16)
+    q = q.to(torch.bfloat16)
+    arange = torch.arange(0, seq_len_kv, device=q.device)[None, :]
+    mask = (arange >= cu_seqlen_ks[:, None]) & (arange < cu_seqlen_ke[:, None])
+    score = torch.einsum("mhd,nd->hmn", q, k).float() * scale
+    logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
+    return logits.masked_fill(~mask, float("-inf"))
+
+
+def _fp8_paged_mqa_logits_ref(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    fp8_dtype = torch.float8_e4m3fn
+    batch_size, next_n, _, dim = q.size()
+    num_blocks, block_size = kv_cache.shape[0], kv_cache.shape[1]
+    flat = kv_cache.view(num_blocks, -1)
+    k_end = block_size * dim
+    kv_data = (
+        flat[:, :k_end].reshape(num_blocks, block_size, 1, dim).view(fp8_dtype).float()
+    )
+    scale = flat[:, k_end:].view(torch.float32).reshape(num_blocks, block_size, 1, 1)
+    q = q.float()
+    kv_data = kv_data * scale
+    logits = torch.full(
+        [batch_size * next_n, max_model_len],
+        float("-inf"),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    context_lens_list = context_lens.tolist()
+    for i in range(batch_size):
+        context_len = context_lens_list[i]
+        q_offsets = torch.arange(context_len - next_n, context_len, device=q.device)
+        weight_slice = (
+            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
+        )
+        for block_rk in range(cdiv(context_len, block_size)):
+            block_idx = block_tables[i][block_rk]
+            qx, kx = q[i], kv_data[block_idx]
+            k_offsets = torch.arange(
+                block_rk * block_size,
+                (block_rk + 1) * block_size,
+                device=q.device,
+            )
+            mask = (k_offsets[None, :] < context_len) & (
+                k_offsets[None, :] <= q_offsets[:, None]
+            )
+            s = torch.where(
+                mask[None, :, :],
+                (qx.transpose(0, 1) @ kx.transpose(0, 1).transpose(1, 2)).to(
+                    logits.dtype
+                ),
+                float("-inf"),
+            )
+            s = (torch.relu(s) * weight_slice[..., None]).sum(dim=0)
+            logits[
+                i * next_n : (i + 1) * next_n,
+                block_rk * block_size : (block_rk + 1) * block_size,
+            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
+    return logits
+
+
+# Looser tolerance to accommodate FP8 rounding and the paged torch
+# reference using fp32 matmul while the triton kernel uses bf16 matmul
+# (with an fp32 accumulator, matching the DeepGEMM path).
+_ATOL = 1.0
+_RTOL = 0.2
+
+
+@pytest.mark.parametrize("M,N", [(64, 64), (128, 256), (256, 512)])
+@pytest.mark.parametrize("num_heads", [16, 32])
+@pytest.mark.parametrize("partial_mask", [False, True])
+@pytest.mark.parametrize("clean_logits", [True, False])
+def test_fp8_mqa_logits_triton_matches_torch(
+    M, N, num_heads, partial_mask, clean_logits
+):
+    """`clean_logits=True` requires full-tensor agreement with the reference;
+    `clean_logits=False` is only contractually correct on the in-range
+    `[ks, ke)` slots, which is what `finite` already masks here (the reference
+    writes -inf outside that range)."""
+    torch.manual_seed(0)
+    head_dim = 128
+    device = "cuda"
+
+    q_bf16 = torch.randn(M, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    k_bf16 = torch.randn(N, head_dim, dtype=torch.bfloat16, device=device)
+    weights = torch.randn(M, num_heads, dtype=torch.float32, device=device)
+    q_fp8 = q_bf16.to(torch.float8_e4m3fn)
+    k_fp8, k_scales = _quantize_k_per_row(k_bf16)
+
+    if partial_mask:
+        # Exercise the non-trivial ks/ke masking branch (chunked prefill).
+        ks = torch.arange(M, dtype=torch.int32, device=device) % (N // 4)
+        ke = ks + torch.randint(1, N // 2, (M,), dtype=torch.int32, device=device)
+        ke = torch.minimum(ke, torch.tensor(N, dtype=torch.int32, device=device))
+    else:
+        ks = torch.zeros(M, dtype=torch.int32, device=device)
+        ke = torch.full((M,), N, dtype=torch.int32, device=device)
+
+    out_torch = _fp8_mqa_logits_ref(q_fp8, (k_fp8, k_scales), weights, ks, ke)
+    out_triton = fp8_mqa_logits_triton(
+        q_fp8, (k_fp8, k_scales), weights, ks, ke, clean_logits=clean_logits
+    )
+
+    if clean_logits:
+        assert torch.equal(
+            torch.isinf(out_torch) & (out_torch < 0),
+            torch.isinf(out_triton) & (out_triton < 0),
+        )
+    finite = ~torch.isinf(out_torch)
+    if finite.any():
+        torch.testing.assert_close(
+            out_triton[finite], out_torch[finite], atol=_ATOL, rtol=_RTOL
+        )
+
+
+def test_fp8_mqa_logits_triton_clean_logits_false_overwrites_masked():
+    """Regression test for PR #38476 comment 4398225404: when `clean_logits=False`
+    skips the `-inf` pre-fill, the kernel itself must still write `-inf` to
+    masked positions. Otherwise the K-tile early-exit branch leaves
+    uninitialized memory in the output, downstream top-k reads garbage, and the
+    model collapses to repeating a single token.
+
+    Trigger: a narrow per-row `[ks, ke)` so that BLOCK_N tiles past every row's
+    `ke` hit the early-exit path. We assert that `clean_logits=False` produces
+    bit-identical output to `clean_logits=True` on every position (the flag is
+    a perf opt, not a behavior change)."""
+    torch.manual_seed(0)
+    M, N, num_heads, head_dim = 256, 1024, 32, 128
+    device = "cuda"
+
+    q_fp8 = torch.randn(M, num_heads, head_dim, dtype=torch.bfloat16, device=device).to(
+        torch.float8_e4m3fn
+    )
+    k_bf16 = torch.randn(N, head_dim, dtype=torch.bfloat16, device=device)
+    weights = torch.randn(M, num_heads, dtype=torch.float32, device=device)
+    k_fp8, k_scales = _quantize_k_per_row(k_bf16)
+
+    # Narrow per-row range: most rows' `[ks, ke)` cover ~1/16 of N, so most
+    # K-tiles past `ke` hit the kernel's early-exit branch.
+    ks = torch.arange(M, dtype=torch.int32, device=device) % (N // 8)
+    ke = ks + N // 16
+    ke = torch.minimum(ke, torch.full_like(ke, N))
+
+    out_clean = fp8_mqa_logits_triton(
+        q_fp8, (k_fp8, k_scales), weights, ks, ke, clean_logits=True
+    )
+    out_dirty = fp8_mqa_logits_triton(
+        q_fp8, (k_fp8, k_scales), weights, ks, ke, clean_logits=False
+    )
+
+    # Every position the clean run wrote `-inf` to (i.e. outside `[ks, ke)`)
+    # must also be `-inf` in the dirty run — otherwise the early-exit left
+    # uninitialized memory and downstream top-k will pick from garbage.
+    inf_mask = torch.isinf(out_clean) & (out_clean < 0)
+    bad = inf_mask & ~(torch.isinf(out_dirty) & (out_dirty < 0))
+    if bad.any():
+        # Surface a useful error: how many positions, and a sample of the
+        # leaked values so it's obvious they're not `-inf`.
+        leaked_count = int(bad.sum().item())
+        sample = out_dirty[bad].flatten()[:8].tolist()
+        raise AssertionError(
+            f"clean_logits=False left {leaked_count} positions un-initialised "
+            f"(should be -inf). Sample leaked values: {sample}. "
+            "Likely cause: the kernel's K-tile early-exit branch returns "
+            "without writing -inf, so downstream top-k reads garbage."
+        )
+
+
+@pytest.mark.parametrize(
+    "batch_size,next_n,context_len",
+    [
+        (1, 1, 128),
+        (1, 1, 512),
+        (2, 1, 256),
+        (1, 4, 512),  # speculative decoding with next_n=4
+    ],
+)
+@pytest.mark.parametrize("num_heads", [16, 32])
+@pytest.mark.parametrize("clean_logits", [True, False])
+def test_fp8_paged_mqa_logits_triton_matches_torch(
+    batch_size, next_n, context_len, num_heads, clean_logits
+):
+    """`clean_logits=True` requires whole-tensor agreement; `clean_logits=False`
+    is only correct on `[:, :context_len]` (downstream topk reads only that
+    range), so all comparisons below are sliced accordingly."""
+    torch.manual_seed(0)
+    head_dim = 128
+    block_size = 64
+    device = "cuda"
+
+    total_blocks = 64
+    max_blocks = (context_len + block_size - 1) // block_size + 4
+
+    kv_bf16 = torch.randn(
+        total_blocks, block_size, head_dim, dtype=torch.bfloat16, device=device
+    )
+    kv_packed = _pack_paged_kv(kv_bf16)
+
+    q_fp8 = torch.randn(
+        batch_size,
+        next_n,
+        num_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(torch.float8_e4m3fn)
+
+    weights = torch.randn(
+        batch_size * next_n, num_heads, dtype=torch.float32, device=device
+    )
+
+    context_lens = torch.full(
+        (batch_size,), context_len, dtype=torch.int32, device=device
+    )
+    block_tables = torch.randint(
+        0,
+        total_blocks,
+        (batch_size, max_blocks),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    max_model_len = max_blocks * block_size
+
+    out_torch = _fp8_paged_mqa_logits_ref(
+        q_fp8, kv_packed, weights, context_lens, block_tables, max_model_len
+    )
+    out_triton = fp8_paged_mqa_logits_triton(
+        q_fp8,
+        kv_packed,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+        clean_logits=clean_logits,
+    )
+
+    inf_torch = (torch.isinf(out_torch) & (out_torch < 0))[:, :context_len]
+    inf_triton = (torch.isinf(out_triton) & (out_triton < 0))[:, :context_len]
+    assert torch.equal(inf_torch, inf_triton)
+    finite = ~inf_torch
+    if finite.any():
+        torch.testing.assert_close(
+            out_triton[:, :context_len][finite],
+            out_torch[:, :context_len][finite],
+            atol=_ATOL,
+            rtol=_RTOL,
+        )

--- a/tests/kernels/attention/test_mqa_logits_triton.py
+++ b/tests/kernels/attention/test_mqa_logits_triton.py
@@ -323,3 +323,77 @@ def test_fp8_paged_mqa_logits_triton_matches_torch(
             atol=_ATOL,
             rtol=_RTOL,
         )
+
+
+def test_fp8_paged_mqa_logits_triton_strided_pool_no_int32_overflow():
+    """Unified-KV-pool layer views have a large block stride; with enough
+    blocks, int32 `block_idx * stride` exceeds 2**31 and wraps to a negative
+    offset (IMA, or silent corruption when the wrapped address is mapped).
+    Uses a padded pool whose stride puts the referenced blocks past the
+    overflow threshold and checks parity against the torch reference."""
+    torch.manual_seed(0)
+    head_dim = 128
+    block_size = 64
+    batch_size, next_n, num_heads = 2, 1, 16
+    context_len = 256
+    device = "cuda"
+
+    # Row payload is block_size * (head_dim + 4) = 8448 B; pad the pool block
+    # stride to 2 MiB so int32 wraps at block_idx >= 2**31 / 2**21 = 1024.
+    pool_stride = 2**21
+    total_blocks = 1040
+
+    row_elems = block_size * (head_dim + 4)
+    kv_bf16 = torch.randn(
+        total_blocks, block_size, head_dim, dtype=torch.bfloat16, device=device
+    )
+    kv_contig = _pack_paged_kv(kv_bf16)
+
+    backing = torch.zeros(total_blocks * pool_stride, dtype=torch.uint8, device=device)
+    kv_strided = backing.as_strided(
+        (total_blocks, block_size, 1, head_dim + 4),
+        (pool_stride, head_dim + 4, head_dim + 4, 1),
+    )
+    kv_strided.copy_(kv_contig.view(total_blocks, block_size, 1, head_dim + 4))
+    assert kv_strided.view(total_blocks, -1).stride(0) == pool_stride
+    assert kv_strided.view(total_blocks, -1).shape[1] == row_elems
+
+    q_fp8 = torch.randn(
+        batch_size, next_n, num_heads, head_dim, dtype=torch.bfloat16, device=device
+    ).to(torch.float8_e4m3fn)
+    weights = torch.randn(
+        batch_size * next_n, num_heads, dtype=torch.float32, device=device
+    )
+    context_lens = torch.full(
+        (batch_size,), context_len, dtype=torch.int32, device=device
+    )
+    # Every referenced block sits past the int32 overflow threshold.
+    max_blocks = (context_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        1024,
+        total_blocks,
+        (batch_size, max_blocks),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    out_torch = _fp8_paged_mqa_logits_ref(
+        q_fp8, kv_strided, weights, context_lens, block_tables, context_len
+    )
+    out_triton = fp8_paged_mqa_logits_triton(
+        q_fp8,
+        kv_strided,
+        weights,
+        context_lens,
+        block_tables,
+        context_len,
+        clean_logits=True,
+    )
+
+    inf_torch = torch.isinf(out_torch) & (out_torch < 0)
+    inf_triton = torch.isinf(out_triton) & (out_triton < 0)
+    assert torch.equal(inf_torch, inf_triton)
+    finite = ~inf_torch
+    torch.testing.assert_close(
+        out_triton[finite], out_torch[finite], atol=_ATOL, rtol=_RTOL
+    )

--- a/tests/kernels/attention/test_mqa_logits_triton.py
+++ b/tests/kernels/attention/test_mqa_logits_triton.py
@@ -95,10 +95,14 @@ def _fp8_paged_mqa_logits_ref(
         device=q.device,
         dtype=torch.float32,
     )
+    if context_lens.ndim == 1:
+        token_offsets = torch.arange(next_n - 1, -1, -1, device=q.device)
+        context_lens = context_lens[:, None] - token_offsets[None, :]
     context_lens_list = context_lens.tolist()
     for i in range(batch_size):
-        context_len = context_lens_list[i]
-        q_offsets = torch.arange(context_len - next_n, context_len, device=q.device)
+        token_context_lens = context_lens_list[i]
+        context_len = max(token_context_lens)
+        q_offsets = torch.tensor(token_context_lens, device=q.device) - 1
         weight_slice = (
             weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
         )
@@ -110,7 +114,7 @@ def _fp8_paged_mqa_logits_ref(
                 (block_rk + 1) * block_size,
                 device=q.device,
             )
-            mask = (k_offsets[None, :] < context_len) & (
+            mask = (k_offsets[None, :] < context_lens[i, :, None]) & (
                 k_offsets[None, :] <= q_offsets[:, None]
             )
             s = torch.where(
@@ -286,9 +290,14 @@ def test_fp8_paged_mqa_logits_triton_matches_torch(
         batch_size * next_n, num_heads, dtype=torch.float32, device=device
     )
 
-    context_lens = torch.full(
-        (batch_size,), context_len, dtype=torch.int32, device=device
-    )
+    if next_n > 1 and context_len == 130:
+        context_lens = torch.tensor(
+            [128, 129, 129, 130], dtype=torch.int32, device=device
+        ).expand(batch_size, -1)
+    else:
+        context_lens = torch.full(
+            (batch_size,), context_len, dtype=torch.int32, device=device
+        )
     block_tables = torch.randint(
         0,
         total_blocks,
@@ -312,10 +321,17 @@ def test_fp8_paged_mqa_logits_triton_matches_torch(
         clean_logits=clean_logits,
     )
 
+    if context_lens.ndim == 1:
+        token_offsets = torch.arange(next_n - 1, -1, -1, device=device)
+        readable_lens = context_lens[:, None] - token_offsets[None, :]
+    else:
+        readable_lens = context_lens
+    positions = torch.arange(context_len, device=device)
+    readable = positions[None, :] < readable_lens.reshape(-1, 1)
     inf_torch = (torch.isinf(out_torch) & (out_torch < 0))[:, :context_len]
     inf_triton = (torch.isinf(out_triton) & (out_triton < 0))[:, :context_len]
-    assert torch.equal(inf_torch, inf_triton)
-    finite = ~inf_torch
+    assert torch.equal(inf_torch[readable], inf_triton[readable])
+    finite = readable & ~inf_torch
     if finite.any():
         torch.testing.assert_close(
             out_triton[:, :context_len][finite],

--- a/tests/kernels/attention/test_triton_mla_sparse_kernel.py
+++ b/tests/kernels/attention/test_triton_mla_sparse_kernel.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the Triton sparse MLA kernel.
+
+Compares split-KV against the single-pass (`num_kv_splits=1`) path
+produced by the same kernel — both paths must agree to within bf16 ULPs.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.ops.triton_mla_sparse_kernel import (
+    _DIM_QK,
+    triton_mla_sparse_attention,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Triton sparse MLA kernel requires CUDA/ROCm",
+)
+
+
+@pytest.fixture(scope="module")
+def kv_cache():
+    torch.manual_seed(0)
+    return torch.randn(32768, 1, _DIM_QK, dtype=torch.bfloat16, device="cuda")
+
+
+def _assert_split_matches_single_pass(
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    num_kv_splits: int | None,
+    kv_cache: torch.Tensor,
+) -> None:
+    torch.manual_seed(0)
+    q = torch.randn(num_tokens, num_heads, _DIM_QK, dtype=torch.bfloat16, device="cuda")
+    indices = torch.randint(
+        0, kv_cache.shape[0], (num_tokens, 1, topk), dtype=torch.int32, device="cuda"
+    )
+    out_ref = triton_mla_sparse_attention(
+        q,
+        kv_cache,
+        indices,
+        sm_scale=0.1,
+        num_kv_splits=1,
+    )
+    out = triton_mla_sparse_attention(
+        q,
+        kv_cache,
+        indices,
+        sm_scale=0.1,
+        num_kv_splits=num_kv_splits,
+    )
+    torch.testing.assert_close(
+        out.float(),
+        out_ref.float(),
+        atol=5e-2,
+        rtol=5e-3,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_tokens,num_heads",
+    [(1, 16), (1, 128), (8, 32), (32, 128), (128, 16)],
+)
+@pytest.mark.parametrize("topk", [1024, 2048, 4096])
+@pytest.mark.parametrize("num_kv_splits", [2, 4, 8])
+def test_split_kv_matches_single_pass(
+    num_tokens, num_heads, topk, num_kv_splits, kv_cache
+):
+    _assert_split_matches_single_pass(
+        num_tokens,
+        num_heads,
+        topk,
+        num_kv_splits,
+        kv_cache,
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 32, 128])
+def test_auto_split_matches_single_pass(num_tokens, kv_cache):
+    _assert_split_matches_single_pass(
+        num_tokens,
+        num_heads=128,
+        topk=2048,
+        num_kv_splits=None,
+        kv_cache=kv_cache,
+    )
+
+
+@pytest.mark.parametrize("num_kv_splits", [1, 2, 4, 8])
+def test_short_prefill_no_nan(num_kv_splits, kv_cache):
+    """Regression: short prefill where most topk slots are -1 sentinels.
+
+    The indexer fills 2048 topk positions with only a handful of valid
+    indices; the rest are -1. Before the NEG_LARGE sentinel fix, the online
+    softmax produced NaN via `max(-inf, -inf) = -inf` and
+    `exp2(-inf − -inf) = NaN`, poisoning every split.
+    """
+    torch.manual_seed(0)
+    num_tokens, num_heads, topk = 5, 16, 2048
+    q = torch.randn(num_tokens, num_heads, _DIM_QK, dtype=torch.bfloat16, device="cuda")
+    indices = torch.full((num_tokens, 1, topk), -1, dtype=torch.int32, device="cuda")
+    # Only the first `t+1` slots of each query hold valid indices; the
+    # remaining ~2045 slots are -1, producing many all-invalid BLOCK_N tiles.
+    for t in range(num_tokens):
+        indices[t, 0, : t + 1] = torch.arange(
+            64, 64 + t + 1, dtype=torch.int32, device="cuda"
+        )
+    out = triton_mla_sparse_attention(
+        q, kv_cache, indices, sm_scale=0.0417, num_kv_splits=num_kv_splits
+    )
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -28,7 +28,7 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
     fp8_fp4_mqa_logits,
     fp8_fp4_paged_mqa_logits,
-    has_deep_gemm,
+    is_deep_gemm_supported,
 )
 from vllm.utils.import_utils import has_cutedsl
 from vllm.utils.torch_utils import (
@@ -41,6 +41,10 @@ from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerMetadata,
 )
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
+from vllm.v1.attention.ops.mqa_logits_triton import (
+    fp8_mqa_logits_triton,
+    fp8_paged_mqa_logits_triton,
+)
 from vllm.v1.attention.ops.pcp import maybe_gather_indexer_k
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -476,6 +480,12 @@ def sparse_attn_indexer(
     # fill.
     if not skip_topk_buffer_clear:
         topk_indices_buffer[: hidden_states.shape[0]] = -1
+    # DeepGEMM availability is constant per process; check once for both branches.
+    use_deep_gemm = is_deep_gemm_supported()
+    if not use_deep_gemm:
+        assert not use_fp4_cache, (
+            "Triton sparse-MLA fallback does not support FP4 KV cache"
+        )
     if has_prefill:
         prefill_metadata = attn_metadata_narrowed.prefill
         assert prefill_metadata is not None
@@ -577,9 +587,19 @@ def sparse_attn_indexer(
                         cu_seqlen_ks,
                         cu_seqlen_ke,
                     )
-                else:
+                elif use_deep_gemm:
                     logits = fp8_fp4_mqa_logits(
                         (q_slice_cast, q_scale_slice),
+                        (k_quant_cast, k_scale_cast),
+                        weights[chunk.token_start : chunk.token_end],
+                        cu_seqlen_ks,
+                        cu_seqlen_ke,
+                        clean_logits=False,
+                    )
+                else:
+                    # SM80/SM121 Triton fallback (DeepGEMM unavailable).
+                    logits = fp8_mqa_logits_triton(
+                        q_slice_cast,
                         (k_quant_cast, k_scale_cast),
                         weights[chunk.token_start : chunk.token_end],
                         cu_seqlen_ks,
@@ -707,7 +727,7 @@ def sparse_attn_indexer(
                 decode_metadata.schedule_metadata,
                 max_model_len,
             )
-        else:
+        elif use_deep_gemm:
             logits = fp8_fp4_paged_mqa_logits(
                 (padded_q_quant_cast, padded_q_scale),
                 kv_cache,
@@ -718,6 +738,20 @@ def sparse_attn_indexer(
                 max_model_len=max_model_len,
                 clean_logits=False,
                 indices=decode_metadata.indices,
+            )
+        else:
+            # SM80/SM121 Triton fallback. Downstream topk reads only up to
+            # `seq_lens`, so size the buffer to the active batch max rather
+            # than the configured model max.
+            active_max_model_len = attn_metadata_narrowed.max_seq_len
+            logits = fp8_paged_mqa_logits_triton(
+                padded_q_quant_cast,
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
+                max_model_len=active_max_model_len,
+                clean_logits=False,
             )
         num_rows = logits.shape[0]
         if candidate_blocks is not None:
@@ -922,10 +956,10 @@ class SparseAttnIndexer(CustomOp):
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.use_pcp = parallel_config.prefill_context_parallel_size > 1
         self._cp_kv_cache_interleave_size: int | None = None
-        if current_platform.is_cuda() and not has_deep_gemm():
-            raise RuntimeError(
-                "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
-                "the current vLLM environment."
+        if current_platform.is_cuda() and not is_deep_gemm_supported():
+            logger.warning_once(
+                "DeepGEMM attention kernels are unavailable on this CUDA "
+                "architecture; using the Triton sparse-indexer fallback."
             )
 
         if vllm_config.kernel_config.enable_jit_warmup:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -747,6 +747,10 @@ class Indexer(nn.Module):
         self.n_head_scale = self.n_head**-0.5
         self.use_fused_indexer_q = (
             current_platform.is_cuda()
+            # The fused Triton kernel stores fp8e4nv, which Triton only
+            # supports on SM89+; older archs (e.g. SM80) take the unfused
+            # rope + per_token_group_quant_fp8 path below.
+            and current_platform.has_device_capability(89)
             and self.quant_block_size == self.head_dim
             and self.head_dim == 128
             and self.rope_dim == 64

--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -38,6 +38,20 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.import_utils import has_cutedsl
 from vllm.utils.math_utils import next_power_of_2
+from vllm.v1.attention.ops.fp8e4nv import (
+    FP8E4NV_EXTERN_LIBS,
+    convert_from_fp8e4m3,
+)
+
+
+def _can_use_cutedsl() -> bool:
+    capability = current_platform.get_device_capability()
+    return (
+        current_platform.is_cuda()
+        and has_cutedsl()
+        and capability is not None
+        and capability.major >= 9
+    )
 
 
 @triton.jit
@@ -242,6 +256,7 @@ class DequantizeAndGatherKCacheKernel(
         max_blocks_per_seq: int
         cache_block_size: int
         block_stride: int
+        fp8_software_conv: bool
         use_fnuz: bool
         has_gather_lens: bool
         offset: int
@@ -269,6 +284,7 @@ class DequantizeAndGatherKCacheKernel(
         output_dim: tl.constexpr,  # 512
         fp8_max: tl.constexpr,
         n_quant_blocks: tl.constexpr,  # 7 real blocks
+        fp8_software_conv: tl.constexpr = False,
         use_fnuz: tl.constexpr = False,
     ):
         batch_idx = tl.program_id(0)
@@ -334,11 +350,12 @@ class DequantizeAndGatherKCacheKernel(
                     # Bitcast uint8 back to fp8 (FNUZ on gfx942, OCP elsewhere).
                     if use_fnuz:
                         x_fp8 = x_uint8.to(tl.float8e4b8, bitcast=True)
+                        x_float = x_fp8.to(tl.float32)
+                    elif fp8_software_conv:
+                        x_float = convert_from_fp8e4m3(x_uint8, tl.float32)
                     else:
                         x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
-
-                    # Convert fp8 to float32 for computation
-                    x_float = x_fp8.to(tl.float32)
+                        x_float = x_fp8.to(tl.float32)
 
                     # Load and decode UE8M0 scale
                     # UE8M0: scale = 2^(stored_value - 127)
@@ -398,11 +415,17 @@ class DequantizeAndGatherKCacheKernel(
             max(1, int(compress_ratio))
             for compress_ratio in vllm_config.model_config.hf_config.compress_ratios
         )
+        fp8_software_conv = (
+            current_platform.is_cuda()
+            and current_platform.has_device_capability(75)
+            and not current_platform.has_device_capability(89)
+        )
         return self._trace_dispatch(self.dispatch)(
             zip_inputs(
                 dict(
                     cache_block_size=block_size,
                     has_gather_lens=True,
+                    fp8_software_conv=fp8_software_conv,
                     use_fnuz=current_platform.is_fp8_fnuz(),
                     offset=1,
                     enabled=True,
@@ -410,6 +433,7 @@ class DequantizeAndGatherKCacheKernel(
                 dict(
                     cache_block_size=block_size,
                     has_gather_lens=True,
+                    fp8_software_conv=fp8_software_conv,
                     use_fnuz=current_platform.is_fp8_fnuz(),
                     offset=2,
                     enabled=True,
@@ -417,6 +441,7 @@ class DequantizeAndGatherKCacheKernel(
                 dict(
                     cache_block_size=block_size,
                     has_gather_lens=True,
+                    fp8_software_conv=fp8_software_conv,
                     use_fnuz=current_platform.is_fp8_fnuz(),
                     offset=16,
                     enabled=True,
@@ -424,6 +449,7 @@ class DequantizeAndGatherKCacheKernel(
                 dict(
                     cache_block_size=max(block_size // 4, 1),
                     has_gather_lens=False,
+                    fp8_software_conv=fp8_software_conv,
                     use_fnuz=False,
                     offset=16,
                     enabled=4 in compress_ratios,
@@ -431,6 +457,7 @@ class DequantizeAndGatherKCacheKernel(
                 dict(
                     cache_block_size=max(block_size // 128, 1),
                     has_gather_lens=False,
+                    fp8_software_conv=fp8_software_conv,
                     use_fnuz=False,
                     offset=16,
                     enabled=128 in compress_ratios,
@@ -479,6 +506,11 @@ class DequantizeAndGatherKCacheKernel(
         use_fnuz: bool = False,
     ) -> LaunchSpec:
         num_reqs = seq_lens.shape[0]
+        fp8_software_conv = (
+            current_platform.is_cuda()
+            and current_platform.has_device_capability(75)
+            and not current_platform.has_device_capability(89)
+        )
         return (num_reqs, self.NUM_WORKERS), dict(
             out_stride0=out.stride(0),
             out_stride1=out.stride(1),
@@ -493,6 +525,8 @@ class DequantizeAndGatherKCacheKernel(
             output_dim=512,
             fp8_max=448.0,
             n_quant_blocks=7,
+            fp8_software_conv=fp8_software_conv,
+            **({"extern_libs": FP8E4NV_EXTERN_LIBS} if fp8_software_conv else {}),
         )
 
 
@@ -518,7 +552,7 @@ def dequantize_and_gather_k_cache(
     ``current_platform.is_fp8_fnuz()`` for ``swa_k_cache`` (C++ encoder
     writes FNUZ on gfx942 and OCP on gfx950).
     """
-    if has_cutedsl():
+    if _can_use_cutedsl():
         # lazily import, otherwise some tests fail due to CUDA driver init failure.
         from vllm.models.deepseek_v4.nvidia.ops.dequant_gather_k_cutedsl import (
             _DEQUANT_GATHER_K_CACHE_CUTEDSL_KERNEL,

--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
@@ -35,6 +35,10 @@ from vllm.model_executor.warmup.jit_warmup_triton_helper import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import round_up
+from vllm.v1.attention.ops.fp8e4nv import (
+    FP8E4NV_EXTERN_LIBS,
+    convert_to_fp8e4m3,
+)
 
 if current_platform.is_rocm():
     from vllm.platforms.rocm import _ON_GFX950
@@ -73,10 +77,21 @@ def compress_norm_rope_store_triton(
     Picks one of the three kernels in this module based on ``head_dim`` and
     ``use_fp4_cache``. Identical launch signature for all three.
     """
+    fp8_software_conv = (
+        current_platform.is_cuda()
+        and current_platform.has_device_capability(75)
+        and not current_platform.has_device_capability(89)
+    )
     if head_dim == 512:
         kernel = _fused_kv_compress_norm_rope_insert_sparse_attn
         num_warps = 4
-        kernel_kwargs = {"SANITIZE_CACHE_NANS": _ON_GFX950}
+        kernel_kwargs = {
+            "SANITIZE_CACHE_NANS": _ON_GFX950,
+            "FP8_SOFTWARE_CONV": fp8_software_conv,
+        }
+        launch_kwargs = (
+            {"extern_libs": FP8E4NV_EXTERN_LIBS} if fp8_software_conv else {}
+        )
     else:
         _FUSED_KV_COMPRESS_NORM_ROPE_INSERT_INDEXER_TRITON_KERNEL(
             state_cache=state_cache,
@@ -141,6 +156,7 @@ def compress_norm_rope_store_triton(
         num_warps=num_warps,
         **kernel_kwargs,
         **pdl_kwargs,
+        **launch_kwargs,
     )
 
 
@@ -183,6 +199,7 @@ def _fused_kv_compress_norm_rope_insert_sparse_attn(
     SCALE_DIM: tl.constexpr,  # 8 for DeepseekV4 (7 real + 1 pad)
     KV_BLOCK_STRIDE: tl.constexpr,
     SANITIZE_CACHE_NANS: tl.constexpr,
+    FP8_SOFTWARE_CONV: tl.constexpr = False,
 ):
     """Fused compress → RMSNorm → FP8 quant (nope) → RoPE → bf16 store (rope).
 
@@ -290,8 +307,11 @@ def _fused_kv_compress_norm_rope_insert_sparse_attn(
     inv_scales_col = tl.reshape(inv_scales, (N_QUANT_BLOCKS, 1))
     x_scaled = quant_2d * inv_scales_col
     x_clamped = tl.clamp(x_scaled, -FP8_MAX, FP8_MAX)
-    x_fp8 = x_clamped.to(tl.float8e4nv)
-    x_uint8 = x_fp8.to(tl.uint8, bitcast=True)
+    if FP8_SOFTWARE_CONV:
+        x_uint8 = convert_to_fp8e4m3(x_clamped)
+    else:
+        x_fp8 = x_clamped.to(tl.float8e4nv)
+        x_uint8 = x_fp8.to(tl.uint8, bitcast=True)
     x_uint8_flat = tl.reshape(x_uint8, (TRITON_BLOCK_SIZE,))
 
     nope_mask = block < NOPE_HEAD_DIM
@@ -459,6 +479,7 @@ def _finalize_norm_rope_quant_store_sparse_attn(
     SCALE_DIM: tl.constexpr,
     KV_BLOCK_STRIDE: tl.constexpr,
     SANITIZE_CACHE_NANS: tl.constexpr,
+    FP8_SOFTWARE_CONV: tl.constexpr = False,
 ):
     """Stage 2: read compressed_kv[512] from scratch buffer, then
     RMSNorm + FP8 quant (nope) + RoPE + bf16 store
@@ -509,10 +530,11 @@ def _finalize_norm_rope_quant_store_sparse_attn(
     inv_scales = tl.exp2(-exponents)
     x_scaled = quant_2d * tl.reshape(inv_scales, (N_QUANT_BLOCKS, 1))
     x_clamped = tl.clamp(x_scaled, -FP8_MAX, FP8_MAX)
-    x_uint8 = tl.reshape(
-        x_clamped.to(tl.float8e4nv).to(tl.uint8, bitcast=True),
-        (TRITON_BLOCK_SIZE,),
-    )
+    if FP8_SOFTWARE_CONV:
+        x_uint8 = convert_to_fp8e4m3(x_clamped)
+    else:
+        x_uint8 = x_clamped.to(tl.float8e4nv).to(tl.uint8, bitcast=True)
+    x_uint8 = tl.reshape(x_uint8, (TRITON_BLOCK_SIZE,))
     tl.store(fp8_ptr + block, x_uint8, mask=block < NOPE_HEAD_DIM)
 
     scale_idx = tl.arange(0, N_QUANT_BLOCKS)
@@ -567,6 +589,11 @@ def _launch_two_stage_sparse_attn_compressor(
     num_actual: int,
     compress_scratch: torch.Tensor,
 ) -> None:
+    fp8_software_conv = (
+        current_platform.is_cuda()
+        and current_platform.has_device_capability(75)
+        and not current_platform.has_device_capability(89)
+    )
     num_splits = _pick_compress_num_splits(num_actual, compress_ratio, head_dim)
     head_tile = head_dim // num_splits
     scratch = compress_scratch[:num_actual]
@@ -610,6 +637,8 @@ def _launch_two_stage_sparse_attn_compressor(
         SCALE_DIM=scale_dim,
         KV_BLOCK_STRIDE=kv_cache.stride(0),
         SANITIZE_CACHE_NANS=_ON_GFX950,
+        FP8_SOFTWARE_CONV=fp8_software_conv,
+        **({"extern_libs": FP8E4NV_EXTERN_LIBS} if fp8_software_conv else {}),
     )
 
 
@@ -743,6 +772,7 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     TOKEN_STRIDE: tl.constexpr,  # 128 for indexer
     SCALE_DIM: tl.constexpr,  # 4 for indexer (1 float32)
     KV_BLOCK_STRIDE: tl.constexpr,
+    FP8_SOFTWARE_CONV: tl.constexpr = False,
 ):
     """Fused compress → RMSNorm → RoPE → FP8 quant → store.
 
@@ -872,8 +902,10 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
 
     x_scaled = result_bf16 * inv_scale
     x_clamped = tl.clamp(x_scaled, -FP8_MAX, FP8_MAX)
-    x_fp8 = x_clamped.to(tl.float8e4nv)
-    x_uint8 = x_fp8.to(tl.uint8, bitcast=True)
+    if FP8_SOFTWARE_CONV:
+        x_uint8 = convert_to_fp8e4m3(x_clamped)
+    else:
+        x_uint8 = x_clamped.to(tl.float8e4nv).to(tl.uint8, bitcast=True)
 
     tl.store(fp8_ptr + block, x_uint8, mask=mask)
 
@@ -1103,6 +1135,7 @@ class FusedKVCompressNormRopeInsertIndexerTritonKernel(
         block_size: int
         kv_cache_block_size: int
         kv_block_stride: int
+        fp8_software_conv: bool
 
     # Canonical kernel for the launcher's arg_names mapping; the launched
     # variant (fp8/mxfp4, same arg_names) is picked per call in __call__.
@@ -1166,6 +1199,12 @@ class FusedKVCompressNormRopeInsertIndexerTritonKernel(
             if runtime_state_width is not None
             else head_dim * (1 + overlap)
         )
+        fp8_software_conv = (
+            not use_fp4_cache
+            and current_platform.is_cuda()
+            and current_platform.has_device_capability(75)
+            and not current_platform.has_device_capability(89)
+        )
         return self.CompileKey(
             dtype=dtype,
             use_fp4_cache=use_fp4_cache,
@@ -1182,6 +1221,7 @@ class FusedKVCompressNormRopeInsertIndexerTritonKernel(
             block_size=state_block_size,
             kv_cache_block_size=kv_cache_block_size,
             kv_block_stride=kv_block_stride,
+            fp8_software_conv=fp8_software_conv,
         )
 
     def get_warmup_keys(self, vllm_config: Any) -> list[CompileKey]:
@@ -1278,6 +1318,20 @@ class FusedKVCompressNormRopeInsertIndexerTritonKernel(
         token_stride: int,
         scale_dim: int,
     ) -> LaunchSpec:
+        fp8_software_conv = (
+            not use_fp4_cache
+            and current_platform.is_cuda()
+            and current_platform.has_device_capability(75)
+            and not current_platform.has_device_capability(89)
+        )
+        kernel_kwargs = (
+            {
+                "FP8_SOFTWARE_CONV": True,
+                "extern_libs": FP8E4NV_EXTERN_LIBS,
+            }
+            if fp8_software_conv
+            else ({"FP8_SOFTWARE_CONV": False} if not use_fp4_cache else {})
+        )
         return (num_actual,), dict(
             kernel=(
                 _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn
@@ -1304,6 +1358,7 @@ class FusedKVCompressNormRopeInsertIndexerTritonKernel(
             KV_BLOCK_STRIDE=kv_cache.stride(0),
             num_warps=1,
             **pdl_kwargs,
+            **kernel_kwargs,
         )
 
 

--- a/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
@@ -15,9 +15,23 @@ from vllm.model_executor.warmup.jit_warmup_triton_helper import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.import_utils import has_cutedsl
+from vllm.v1.attention.ops.fp8e4nv import (
+    FP8E4NV_EXTERN_LIBS,
+    convert_to_fp8e4m3,
+)
 
 # MXFP4: 32 elements per block, packed 2 nibbles per byte, ue8m0 block scale.
 MXFP4_BLOCK_SIZE = 32
+
+
+def _can_use_cutedsl() -> bool:
+    capability = current_platform.get_device_capability()
+    return (
+        current_platform.is_cuda()
+        and has_cutedsl()
+        and capability is not None
+        and capability.major >= 9
+    )
 
 
 @triton.jit
@@ -87,6 +101,7 @@ class FusedIndexerQRopeQuantTritonKernel(
         index_q_head_dim: int
         fp8_max: float
         use_fnuz: bool
+        fp8_software_conv: bool
         use_explicit_fma: bool
 
     @staticmethod
@@ -114,6 +129,7 @@ class FusedIndexerQRopeQuantTritonKernel(
         index_weights_out_stride,
         FP8_MAX: tl.constexpr = 448.0,
         USE_FNUZ: tl.constexpr = False,
+        FP8_SOFTWARE_CONV: tl.constexpr = False,
         USE_EXPLICIT_FMA: tl.constexpr = False,
     ):
         # Layout matches the unfused reference (DeepseekV4ScalingRotaryEmbedding
@@ -165,26 +181,31 @@ class FusedIndexerQRopeQuantTritonKernel(
 
         # Store quantized values to index_q_fp8. FNUZ (e4m3fnuz) on gfx942, OCP
         # (e4m3fn) elsewhere -- matches the K cache.
-        fp8_dtype = tl.float8e4b8 if USE_FNUZ else tl.float8e4nv
         fp8_base_ptr = (
             index_q_fp8_ptr
             + tok_idx * index_q_fp8_stride0
             + head_idx * index_q_fp8_stride1
         )
+        if USE_FNUZ:
+            q_even = tl.div_rn(r_even, index_q_scale).to(tl.float8e4b8)
+            q_odd = tl.div_rn(r_odd, index_q_scale).to(tl.float8e4b8)
+        elif FP8_SOFTWARE_CONV:
+            q_even = convert_to_fp8e4m3(tl.div_rn(r_even, index_q_scale))
+            q_odd = convert_to_fp8e4m3(tl.div_rn(r_odd, index_q_scale))
+        else:
+            q_even = tl.div_rn(r_even, index_q_scale).to(tl.float8e4nv)
+            q_odd = tl.div_rn(r_odd, index_q_scale).to(tl.float8e4nv)
         if INDEX_Q_NOPE_DIM > 0:
-            tl.store(
-                fp8_base_ptr + nope_offset,
-                tl.div_rn(x_nope, index_q_scale).to(fp8_dtype),
-            )
+            if USE_FNUZ:
+                q_nope = tl.div_rn(x_nope, index_q_scale).to(tl.float8e4b8)
+            elif FP8_SOFTWARE_CONV:
+                q_nope = convert_to_fp8e4m3(tl.div_rn(x_nope, index_q_scale))
+            else:
+                q_nope = tl.div_rn(x_nope, index_q_scale).to(tl.float8e4nv)
+            tl.store(fp8_base_ptr + nope_offset, q_nope)
         fp8_rot_base = fp8_base_ptr + INDEX_Q_NOPE_DIM
-        tl.store(
-            fp8_rot_base + half_offset * 2,
-            tl.div_rn(r_even, index_q_scale).to(fp8_dtype),
-        )
-        tl.store(
-            fp8_rot_base + half_offset * 2 + 1,
-            tl.div_rn(r_odd, index_q_scale).to(fp8_dtype),
-        )
+        tl.store(fp8_rot_base + half_offset * 2, q_even)
+        tl.store(fp8_rot_base + half_offset * 2 + 1, q_odd)
 
         # FP8 weight-fold contract:
         #   index_weights_out = index_weights * q_scale * softmax_scale * head_scale
@@ -215,6 +236,11 @@ class FusedIndexerQRopeQuantTritonKernel(
         rope_dim: int,
         use_fnuz: bool,
     ) -> CompileKey:
+        fp8_software_conv = (
+            current_platform.is_cuda()
+            and current_platform.has_device_capability(75)
+            and not current_platform.has_device_capability(89)
+        )
         return self.CompileKey(
             dtype=dtype,
             num_heads=num_heads,
@@ -222,6 +248,7 @@ class FusedIndexerQRopeQuantTritonKernel(
             index_q_head_dim=head_dim,
             fp8_max=224.0 if use_fnuz else 448.0,
             use_fnuz=use_fnuz,
+            fp8_software_conv=fp8_software_conv,
             use_explicit_fma=current_platform.is_rocm(),
         )
 
@@ -261,7 +288,11 @@ class FusedIndexerQRopeQuantTritonKernel(
             index_weights_softmax_scale=1.0,
             index_weights_head_scale=1.0,
             index_q_fp8=TritonWarmupTensor(
-                current_platform.fp8_dtype(),
+                (
+                    torch.uint8
+                    if compile_key.fp8_software_conv
+                    else current_platform.fp8_dtype()
+                ),
                 shape=(1, compile_key.num_heads, compile_key.index_q_head_dim),
                 strides=(q_stride0, compile_key.index_q_head_dim, 1),
             ),
@@ -290,6 +321,16 @@ class FusedIndexerQRopeQuantTritonKernel(
     ) -> LaunchSpec:
         num_tokens = positions.shape[0]
         num_index_q_heads = index_q.shape[1]
+        fp8_software_conv = (
+            current_platform.is_cuda()
+            and current_platform.has_device_capability(75)
+            and not current_platform.has_device_capability(89)
+        )
+        index_q_out = (
+            index_q_fp8.view(torch.uint8)
+            if fp8_software_conv and isinstance(index_q_fp8, torch.Tensor)
+            else index_q_fp8
+        )
         return (num_tokens, num_index_q_heads), dict(
             pos_ptr=positions,
             index_q_stride0=index_q.stride(0),
@@ -297,15 +338,18 @@ class FusedIndexerQRopeQuantTritonKernel(
             index_q_cos_sin_ptr=index_q_cos_sin_cache,
             index_q_cos_sin_stride=index_q_cos_sin_cache.stride(0),
             INDEX_Q_HALF_ROT_DIM=index_q_cos_sin_cache.shape[-1] // 2,
-            index_q_fp8_stride0=index_q_fp8.stride(0),
-            index_q_fp8_stride1=index_q_fp8.stride(1),
+            index_q_fp8_ptr=index_q_out,
+            index_q_fp8_stride0=index_q_out.stride(0),
+            index_q_fp8_stride1=index_q_out.stride(1),
             INDEX_Q_HEAD_DIM=index_q.shape[2],
             index_weights_stride=index_weights.stride(0),
             index_weights_out_stride=index_weights_out.stride(0),
             FP8_MAX=fp8_max,
             USE_FNUZ=use_fnuz,
+            FP8_SOFTWARE_CONV=fp8_software_conv,
             USE_EXPLICIT_FMA=current_platform.is_rocm(),
             num_warps=1,
+            **({"extern_libs": FP8E4NV_EXTERN_LIBS} if fp8_software_conv else {}),
         )
 
 
@@ -595,7 +639,7 @@ def fused_indexer_q_rope_quant(
             dtype=torch.uint8,
             device=index_q.device,
         )
-        if has_cutedsl():
+        if _can_use_cutedsl():
             # lazily import, otherwise some tests fail due to CUDA driver init failure.
             from vllm.models.deepseek_v4.nvidia.ops.fused_indexer_q_cutedsl import (
                 _INDEXER_Q_MXFP4_KERNEL,
@@ -651,7 +695,7 @@ def fused_indexer_q_rope_quant(
     use_fnuz = fp8_dtype == torch.float8_e4m3fnuz
     fp8_max = 224.0 if use_fnuz else 448.0
     index_q_fp8 = torch.empty_like(index_q, dtype=fp8_dtype)
-    if has_cutedsl():
+    if _can_use_cutedsl():
         # lazily import, otherwise some tests fail due to CUDA driver init failure.
         from vllm.models.deepseek_v4.nvidia.ops.fused_indexer_q_cutedsl import (
             _INDEXER_Q_FP8_KERNEL,

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -443,14 +443,17 @@ class DeepseekCompressor(nn.Module):
         # cutedsl (head=512) accepts the full-cache flags; triton (indexer/AMD)
         # does not, so the two callables have different signatures.
         compress_norm_rope_store_fn: Any
-        if current_platform.is_cuda() and self.head_dim == 512:
+        if (
+            current_platform.is_cuda()
+            and current_platform.has_device_capability(90)
+            and self.head_dim == 512
+        ):
             from .nvidia.ops.sparse_attn_compress_cutedsl import (
                 _SPARSE_ATTN_COMPRESSOR_CUTEDSL_KERNEL,
             )
 
-            # head=512 on CUDA always uses cutedsl, for both the fp8_ds_mla
-            # layout and the plain full-cache layout. The full-cache flags
-            # are consumed only here.
+            # CuTeDSL's sparse compressor requires SM90+. It handles both
+            # the fp8_ds_mla layout and the plain full-cache layout.
             compress_norm_rope_store_fn = _SPARSE_ATTN_COMPRESSOR_CUTEDSL_KERNEL
             extra_kwargs: dict[str, Any] = dict(
                 store_full_kv=store_full_kv,

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -21,6 +21,7 @@ from vllm.models.deepseek_v4.common.ops.save_partial_states import (
     _SAVE_PARTIAL_STATES_KERNEL,
 )
 from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_cutedsl
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -447,6 +448,7 @@ class DeepseekCompressor(nn.Module):
             current_platform.is_cuda()
             and current_platform.has_device_capability(90)
             and self.head_dim == 512
+            and has_cutedsl()
         ):
             from .nvidia.ops.sparse_attn_compress_cutedsl import (
                 _SPARSE_ATTN_COMPRESSOR_CUTEDSL_KERNEL,
@@ -470,7 +472,13 @@ class DeepseekCompressor(nn.Module):
                 "compress_scratch": self._compress_scratch,
             }
         else:
-            # Indexer path (head_dim == 128) or non-CUDA GPUs (AMD, XPU, etc.).
+            # Indexer path, non-CUDA GPUs, or pre-SM90 CUDA. The latter uses
+            # the portable Triton sparse compressor for fp8_ds_mla.
+            if current_platform.is_cuda() and self.head_dim == 512 and store_full_kv:
+                raise NotImplementedError(
+                    "DeepSeek V4 full-row KV cache on CUDA requires the CuTeDSL "
+                    "sparse compressor; install cutlass or use fp8_ds_mla KV cache"
+                )
             compress_norm_rope_store_fn = compress_norm_rope_store_triton
             extra_kwargs = {}
 

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -30,6 +30,10 @@ from vllm.v1.attention.ops.flashmla import (
     flash_mla_sparse_fwd,
     flash_mla_with_kvcache,
 )
+from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+    rocm_sparse_attn_decode,
+    rocm_sparse_attn_prefill,
+)
 from vllm.v1.worker.workspace import current_workspace_manager
 
 if TYPE_CHECKING:
@@ -53,6 +57,7 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
 
     backend_cls = DeepseekV4FlashMLABackend
     swa_backend_cls = DeepseekSparseSWAFlashMLABackend
+    use_triton_sparse_attn = False
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -208,6 +213,29 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
 
         swa_indices = swa_metadata.decode_swa_indices
         swa_lens = swa_metadata.decode_swa_lens
+
+        if self.use_triton_sparse_attn:
+            rocm_sparse_attn_decode(
+                q=q,
+                kv_cache=kv_cache,
+                swa_k_cache=self.swa_cache_layer.kv_cache,
+                swa_only=swa_only,
+                topk_indices=topk_indices,
+                topk_lens=topk_lens,
+                swa_indices=swa_indices,
+                swa_lens=swa_lens,
+                swa_ragged_indices=None,
+                swa_ragged_indptr=None,
+                topk_ragged_indices=None,
+                topk_ragged_indptr=None,
+                attn_sink=self.attn_sink,
+                scale=self.scale,
+                head_dim=self.head_dim,
+                nope_head_dim=self.nope_head_dim,
+                rope_head_dim=self.rope_head_dim,
+                output=output,
+            )
+            return
 
         # We treat queries in the same seq as different queries
         # and later we only attend by generated indices.
@@ -387,12 +415,32 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 ),
                 max_image_tokens=self.max_image_tokens,
             )
-            flash_mla_sparse_fwd(
-                q=q[query_start:query_end],
-                kv=kv.view(-1, 1, q.shape[-1]),
-                indices=combined_indices.unsqueeze(1),
-                sm_scale=self.scale,
-                attn_sink=self.attn_sink,
-                topk_length=combined_lens,
-                out=output[query_start:query_end],
-            )
+            if self.use_triton_sparse_attn:
+                rocm_sparse_attn_prefill(
+                    q=q[query_start:query_end],
+                    kv=kv.view(-1, 1, q.shape[-1]),
+                    indices=combined_indices.unsqueeze(1),
+                    topk_length=combined_lens,
+                    scale=self.scale,
+                    head_dim=self.head_dim,
+                    nope_head_dim=self.nope_head_dim,
+                    rope_head_dim=self.rope_head_dim,
+                    attn_sink=self.attn_sink,
+                    output=output[query_start:query_end],
+                )
+            else:
+                flash_mla_sparse_fwd(
+                    q=q[query_start:query_end],
+                    kv=kv.view(-1, 1, q.shape[-1]),
+                    indices=combined_indices.unsqueeze(1),
+                    sm_scale=self.scale,
+                    attn_sink=self.attn_sink,
+                    topk_length=combined_lens,
+                    out=output[query_start:query_end],
+                )
+
+
+class DeepseekV4TritonMLAAttention(DeepseekV4FlashMLAAttention):
+    """Portable sparse-MLA attention for CUDA architectures below SM90."""
+
+    use_triton_sparse_attn = True

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -81,7 +81,10 @@ from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
     DeepseekV4FlashInferMLAAttention,
     DeepseekV4FlashInferSM120Attention,
 )
-from vllm.models.deepseek_v4.nvidia.flashmla import DeepseekV4FlashMLAAttention
+from vllm.models.deepseek_v4.nvidia.flashmla import (
+    DeepseekV4FlashMLAAttention,
+    DeepseekV4TritonMLAAttention,
+)
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
@@ -1110,10 +1113,14 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
         AttentionBackendEnum.FLASHMLA_SPARSE,
         AttentionBackendEnum.FLASHMLA_SPARSE_DSV4,
     ):
+        if device_capability is not None and device_capability.major < 9:
+            return DeepseekV4TritonMLAAttention
         return DeepseekV4FlashMLAAttention
 
     if device_capability is not None and device_capability.major == 12:
         return DeepseekV4FlashInferSM120Attention
+    if device_capability is not None and device_capability.major < 9:
+        return DeepseekV4TritonMLAAttention
     return DeepseekV4FlashMLAAttention
 
 

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -408,6 +408,7 @@ class BuildC128ATopkMetadataKernel(
         if is_decode:
             # --- Decode: block-table lookup → global slot ids + count ---
             is_valid_token = tl.load(slot_mapping_ptr + token_idx) >= 0
+            num_compressed = tl.where(is_valid_token, num_compressed, 0)
             req_idx = tl.load(token_to_req_indices_ptr + token_idx)
             count = tl.zeros((), dtype=tl.int32)
             for i in range(0, max_compressed_tokens, BLOCK_SIZE):

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -149,6 +149,7 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLASHINFER_MLA,
                 AttentionBackendEnum.TRITON_MLA,
                 *sparse_tail,
+                AttentionBackendEnum.TRITON_MLA_SPARSE,
             ]
     else:
         # SM100f defaults to FlashInfer for TRTLLM causal attention, but its non-causal

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -131,7 +131,11 @@ def _get_backend_priorities(
         elif device_capability.major == 12:
             return [
                 AttentionBackendEnum.TRITON_MLA,
+                # FP8 KV cache only; with BF16 KV it is rejected by
+                # supports_combination and selection falls through to the
+                # Triton sparse backend below.
                 AttentionBackendEnum.FLASHINFER_MLA_SPARSE_SM120,
+                AttentionBackendEnum.TRITON_MLA_SPARSE,
             ]
         else:
             sparse_tail = [

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -22,7 +22,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
     get_paged_mqa_logits_metadata,
-    has_deep_gemm,
+    is_deep_gemm_supported,
     native_next_n_supported,
 )
 from vllm.utils.platform_utils import num_compute_units
@@ -705,7 +705,7 @@ def _supports_varlen_paged_mqa_logits() -> bool:
     return (
         current_platform.is_cuda()
         and current_platform.is_device_capability_family(100)
-        and has_deep_gemm()
+        and is_deep_gemm_supported()
     )
 
 
@@ -713,7 +713,7 @@ def _supports_flattened_device_query_lens() -> bool:
     return (
         current_platform.is_cuda()
         and current_platform.is_device_capability_family(90)
-        and has_deep_gemm()
+        and is_deep_gemm_supported()
     )
 
 
@@ -722,7 +722,7 @@ def _supports_native_decode(next_n: int) -> bool:
     instead of flattening to one single-token row per query, which re-reads
     the KV tile once per row.
     """
-    if not (current_platform.is_cuda() and has_deep_gemm()):
+    if not (current_platform.is_cuda() and is_deep_gemm_supported()):
         return next_n in (1, 2)
     if current_platform.is_device_capability_family(100):
         return True
@@ -1464,9 +1464,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if seq_lens.dim() == 1:
                 seq_lens = seq_lens.unsqueeze(-1)
 
-            # DeepGEMM is required for the paged MQA logits on CUDA devices
+            # Only the DeepGEMM paged-MQA path consumes scheduler metadata.
             schedule_metadata = self.scheduler_metadata_buffer
-            if current_platform.is_cuda() and has_deep_gemm():
+            if current_platform.is_cuda() and is_deep_gemm_supported():
                 metadata = get_paged_mqa_logits_metadata(
                     seq_lens,
                     self.kv_cache_spec.num_states,

--- a/vllm/v1/attention/backends/mla/triton_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_sparse.py
@@ -10,7 +10,11 @@ from vllm.config import get_current_vllm_config_or_none
 from vllm.config.cache import CacheDType
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.platform_utils import num_compute_units
-from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    MultipleOf,
+)
 from vllm.v1.attention.backends.mla.xpu_mla_sparse import (
     XPUMLASparseImpl,
     XPUMLASparseMetadata,
@@ -119,6 +123,17 @@ class TritonMLASparseBackend(AttentionBackend):
     @staticmethod
     def get_name() -> str:
         return "TRITON_MLA_SPARSE"
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        # The DSA indexer backend requires block size 64 on CUDA and shares
+        # the KV cache group with this backend; the base-class MultipleOf(1)
+        # default lets auto-selection settle on 16, which then fails
+        # select_common_block_size ("No common block size for 16").
+        # MultipleOf(64) (rather than [64]) keeps larger user-specified
+        # sizes like 128 usable, which measurably lowers profile-time peak
+        # memory for very long contexts.
+        return [MultipleOf(64)]
 
     @staticmethod
     def get_metadata_cls() -> type[XPUMLASparseMetadata]:

--- a/vllm/v1/attention/backends/mla/triton_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_sparse.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-Triton sparse MLA backend for SM80 (A100) / SM121 (GB10)."""
+
+from typing import ClassVar
+
+import torch
+
+from vllm.config import get_current_vllm_config_or_none
+from vllm.config.cache import CacheDType
+from vllm.platforms.interface import DeviceCapability
+from vllm.utils.platform_utils import num_compute_units
+from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport
+from vllm.v1.attention.backends.mla.xpu_mla_sparse import (
+    XPUMLASparseImpl,
+    XPUMLASparseMetadata,
+    XPUMLASparseMetadataBuilder,
+)
+from vllm.v1.attention.ops.mqa_logits_triton import (
+    warmup_fp8_mqa_logits_triton,
+    warmup_fp8_paged_mqa_logits_triton,
+)
+from vllm.v1.attention.ops.triton_mla_sparse_kernel import (
+    _DIM_QK,
+    KV_SPLITS_CANDIDATES,
+    triton_mla_sparse_attention,
+)
+
+# V3.2 indexers don't expose `n_head`; GLM-5.1-NVFP4 sets index_n_heads=32.
+# Autotune key includes (num_heads, head_dim), so a wrong warmup shape forces
+# a re-tune on first real request.
+_INDEXER_NUM_HEADS = 64
+_INDEXER_HEAD_DIM = 128
+
+
+class TritonMLASparseMetadataBuilder(XPUMLASparseMetadataBuilder):
+    # XPU base keeps NEVER (not validated under cudagraph); this subclass
+    # claims UNIFORM_BATCH for the CUDA/Triton path.
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class TritonMLASparseImpl(XPUMLASparseImpl):
+    """Triton sparse-MLA impl with split-KV decode (3-7× faster than the
+    single-pass XPU base for single-query decode on SM80 / SM121)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._sm_count: int | None = None
+        if self.topk_indices_buffer is not None:
+            self._sm_count = num_compute_units(self.topk_indices_buffer.device.index)
+        self._warmup_autotune(kwargs["indexer"])
+
+    def _warmup_autotune(self, indexer) -> None:
+        """Prime `@triton.autotune` caches at init so the first request
+        doesn't pay the inline config-sweep cost."""
+        if self.topk_indices_buffer is None:
+            return
+        device = self.topk_indices_buffer.device
+        topk = self.topk_indices_buffer.shape[-1]
+        q = torch.empty(1, self.num_heads, _DIM_QK, dtype=torch.bfloat16, device=device)
+        kv = torch.empty(64, 1, _DIM_QK, dtype=torch.bfloat16, device=device)
+        indices = torch.zeros(1, 1, topk, dtype=torch.int32, device=device)
+        for splits in KV_SPLITS_CANDIDATES:
+            triton_mla_sparse_attention(
+                q,
+                kv,
+                indices,
+                sm_scale=self.softmax_scale,
+                num_kv_splits=splits,
+                sm_count=self._sm_count,
+            )
+        indexer_num_heads = getattr(indexer, "n_head", _INDEXER_NUM_HEADS)
+        indexer_head_dim = getattr(indexer, "head_dim", _INDEXER_HEAD_DIM)
+        warmup_fp8_mqa_logits_triton(
+            num_heads=indexer_num_heads, head_dim=indexer_head_dim, device=device
+        )
+        cfg = get_current_vllm_config_or_none()
+        if cfg is not None:
+            warmup_fp8_paged_mqa_logits_triton(
+                num_heads=indexer_num_heads,
+                head_dim=indexer_head_dim,
+                block_size=cfg.cache_config.block_size,
+                device=device,
+            )
+
+    def _forward_bf16_kv(
+        self,
+        q: torch.Tensor,  # [sq, heads, d_qk]
+        kv_c_and_k_pe_cache: torch.Tensor,  # [blocks, heads, d_qk]
+        topk_indices: torch.Tensor,  # [sq, topk]
+        attn_metadata: XPUMLASparseMetadata,
+    ) -> torch.Tensor:
+        num_tokens = q.shape[0]
+        kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(
+            -1, 1, kv_c_and_k_pe_cache.shape[-1]
+        )
+        topk_indices = topk_indices.view(num_tokens, 1, -1)
+        output = triton_mla_sparse_attention(
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            sm_scale=self.softmax_scale,
+            sm_count=self._sm_count,
+        )
+        return output[:, : self.num_heads, :]
+
+
+class TritonMLASparseBackend(AttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [
+        torch.float16,
+        torch.bfloat16,
+    ]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "float16",
+        "bfloat16",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "TRITON_MLA_SPARSE"
+
+    @staticmethod
+    def get_metadata_cls() -> type[XPUMLASparseMetadata]:
+        return XPUMLASparseMetadata
+
+    @staticmethod
+    def get_builder_cls() -> type["TritonMLASparseMetadataBuilder"]:
+        return TritonMLASparseMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> type["TritonMLASparseImpl"]:
+        return TritonMLASparseImpl
+
+    @classmethod
+    def is_mla(cls) -> bool:
+        return True
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (num_blocks, block_size, head_size)
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [_DIM_QK]
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        return True

--- a/vllm/v1/attention/backends/mla/triton_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_sparse.py
@@ -174,7 +174,7 @@ class TritonMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        # This implementation still hard-codes BF16 output. Supporting FP16
-        # inputs alone is not enough to claim SM75 support; make the output
-        # dtype-aware before relaxing this guard.
+        # This particular Triton sparse-MLA implementation still hard-codes
+        # BF16 output, so its advertised FP16 path is not yet enough to claim
+        # SM75 support. Make the output dtype-aware before relaxing this guard.
         return capability.major >= 8

--- a/vllm/v1/attention/backends/mla/triton_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_sparse.py
@@ -171,4 +171,4 @@ class TritonMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        return True
+        return capability.major >= 8

--- a/vllm/v1/attention/backends/mla/triton_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_sparse.py
@@ -174,4 +174,7 @@ class TritonMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        # This implementation still hard-codes BF16 output. Supporting FP16
+        # inputs alone is not enough to claim SM75 support; make the output
+        # dtype-aware before relaxing this guard.
         return capability.major >= 8

--- a/vllm/v1/attention/backends/mla/triton_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_sparse.py
@@ -10,6 +10,7 @@ from vllm.config import get_current_vllm_config_or_none
 from vllm.config.cache import CacheDType
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.platform_utils import num_compute_units
+from vllm.utils.torch_utils import get_kv_cache_torch_dtype
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -61,8 +62,11 @@ class TritonMLASparseImpl(XPUMLASparseImpl):
             return
         device = self.topk_indices_buffer.device
         topk = self.topk_indices_buffer.shape[-1]
-        q = torch.empty(1, self.num_heads, _DIM_QK, dtype=torch.bfloat16, device=device)
-        kv = torch.empty(64, 1, _DIM_QK, dtype=torch.bfloat16, device=device)
+        cfg = get_current_vllm_config_or_none()
+        model_dtype = cfg.model_config.dtype if cfg is not None else torch.bfloat16
+        kv_dtype = get_kv_cache_torch_dtype(self.kv_cache_dtype, model_dtype)
+        q = torch.empty(1, self.num_heads, _DIM_QK, dtype=model_dtype, device=device)
+        kv = torch.empty(64, 1, _DIM_QK, dtype=kv_dtype, device=device)
         indices = torch.zeros(1, 1, topk, dtype=torch.int32, device=device)
         for splits in KV_SPLITS_CANDIDATES:
             triton_mla_sparse_attention(
@@ -78,7 +82,6 @@ class TritonMLASparseImpl(XPUMLASparseImpl):
         warmup_fp8_mqa_logits_triton(
             num_heads=indexer_num_heads, head_dim=indexer_head_dim, device=device
         )
-        cfg = get_current_vllm_config_or_none()
         if cfg is not None:
             warmup_fp8_paged_mqa_logits_triton(
                 num_heads=indexer_num_heads,

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -82,6 +82,9 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         "FlashInferMLASparseSM90Backend"
     )
     TRITON_MLA = "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend"
+    TRITON_MLA_SPARSE = (
+        "vllm.v1.attention.backends.mla.triton_mla_sparse.TritonMLASparseBackend"
+    )
     CUTLASS_MLA = "vllm.v1.attention.backends.mla.cutlass_mla.CutlassMLABackend"
     FLASHMLA = "vllm.v1.attention.backends.mla.flashmla.FlashMLABackend"
     FLASHMLA_SPARSE = (

--- a/vllm/v1/attention/ops/mqa_logits_triton.py
+++ b/vllm/v1/attention/ops/mqa_logits_triton.py
@@ -1,0 +1,455 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton fallback for DeepGEMM's fp8_mqa_logits / fp8_paged_mqa_logits."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+# Paged decode: num_warps=4 dominated on A100/SM80 across {2,4,8}; the others
+# were 1.5–1.7× slower at (num_heads=32, head_dim=128, block_size=64), so
+# narrow the sweep to keep autotune from latching onto a bad pick under noise.
+_PAGED_AUTOTUNE_CONFIGS = [
+    triton.Config({}, num_warps=4, num_stages=ns) for ns in (2, 4)
+]
+
+# Prefill kernel adds BLOCK_N as a free tile axis. num_warps=8 was 1.5–3×
+# worse than {2,4} across the sweep; keep BLOCK_N ∈ {32, 64, 128} so autotune
+# can pick per shape (BN=128 wins for GLM-5.1 long chunks).
+_PREFILL_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": bn}, num_warps=nw, num_stages=ns)
+    for bn in (32, 64, 128)
+    for nw in (2, 4)
+    for ns in (2, 4)
+]
+
+# Warmup shape mirrors the chunked-prefill regime (small M, long N) so
+# autotune picks a tile sized for real serving rather than a launch-overhead-
+# dominated dummy grid.
+_PREFILL_WARMUP_M = 8
+_PREFILL_WARMUP_N = 8192
+
+
+_E4M3FN_BF16_LUT_CACHE: dict[torch.device, torch.Tensor] = {}
+
+
+def _get_e4m3fn_bf16_lut(device: torch.device) -> torch.Tensor:
+    lut = _E4M3FN_BF16_LUT_CACHE.get(device)
+    if lut is not None:
+        return lut
+    lut = (
+        torch.arange(256, dtype=torch.uint8, device=device)
+        .view(torch.float8_e4m3fn)
+        .to(torch.bfloat16)
+    )
+    lut[0x7F] = 480.0
+    lut[0xFF] = -480.0
+    _E4M3FN_BF16_LUT_CACHE[device] = lut
+    return lut
+
+
+@triton.jit
+def _decode_e4m3fn_bf16_lut(u, lut_ptr):
+    return tl.load(lut_ptr + u.to(tl.uint32))
+
+
+@triton.autotune(
+    configs=_PAGED_AUTOTUNE_CONFIGS,
+    key=["num_heads", "head_dim", "block_size"],
+)
+@triton.jit
+def _fp8_paged_mqa_logits_kernel(
+    q_ptr,
+    kv_fp8_ptr,
+    kv_scale_ptr,
+    weights_ptr,
+    fp8_lut_ptr,
+    context_lens_ptr,
+    block_tables_ptr,
+    logits_ptr,
+    stride_q_b,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_kvf_block,
+    stride_kvf_s,
+    stride_kvf_d,
+    stride_kvs_block,
+    stride_kvs_s,
+    stride_w_t,
+    stride_w_h,
+    stride_bt_b,
+    stride_bt_k,
+    stride_l_t,
+    stride_l_n,
+    next_n: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    block_rk = tl.program_id(1)
+
+    batch_id = token_id // next_n
+    next_n_id = token_id % next_n
+
+    context_len = tl.load(context_lens_ptr + batch_id)
+    if block_rk * block_size >= context_len:
+        return
+
+    q_offset = context_len - next_n + next_n_id
+
+    block_idx = tl.load(
+        block_tables_ptr + batch_id * stride_bt_b + block_rk * stride_bt_k
+    )
+
+    offs_h = tl.arange(0, BLOCK_H)
+    offs_d = tl.arange(0, BLOCK_D)
+    offs_n = tl.arange(0, BLOCK_N)
+    mask_h = offs_h < num_heads
+    mask_d = offs_d < head_dim
+    mask_n = offs_n < block_size
+
+    q_base = q_ptr + batch_id * stride_q_b + next_n_id * stride_q_n
+    q_byte = tl.load(
+        q_base + offs_h[:, None] * stride_q_h + offs_d[None, :] * stride_q_d,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0,
+    )
+    q = _decode_e4m3fn_bf16_lut(q_byte, fp8_lut_ptr)
+
+    kvf_base = kv_fp8_ptr + block_idx * stride_kvf_block
+    k_byte = tl.load(
+        kvf_base + offs_n[:, None] * stride_kvf_s + offs_d[None, :] * stride_kvf_d,
+        mask=mask_n[:, None] & mask_d[None, :],
+        other=0,
+    )
+    kvs_base = kv_scale_ptr + block_idx * stride_kvs_block
+    k_scale = tl.load(
+        kvs_base + offs_n * stride_kvs_s,
+        mask=mask_n,
+        other=0.0,
+    )
+    k = _decode_e4m3fn_bf16_lut(k_byte, fp8_lut_ptr)
+    # Scale in fp32 after the dot to avoid an extra bf16 round-trip on K.
+    s = tl.dot(q, tl.trans(k)) * k_scale[None, :]
+
+    w = tl.load(
+        weights_ptr + token_id * stride_w_t + offs_h * stride_w_h,
+        mask=mask_h,
+        other=0.0,
+    )
+    s = tl.where(s > 0, s, 0.0) * w[:, None]
+    out = tl.sum(s, axis=0)
+
+    k_offset = block_rk * block_size + offs_n
+    valid = mask_n & (k_offset < context_len) & (k_offset <= q_offset)
+    out = tl.where(valid, out, float("-inf"))
+
+    tl.store(
+        logits_ptr + token_id * stride_l_t + k_offset * stride_l_n,
+        out,
+        mask=mask_n,
+    )
+
+
+def fp8_paged_mqa_logits_triton(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    """Triton implementation of DeepGEMM's fp8_paged_mqa_logits.
+
+    Args:
+        q:             [B, next_n, H, D] fp8_e4m3fn
+        kv_cache:      [num_blocks, block_size, 1, D+4] uint8 (FP8 + fp32 scale)
+        weights:       [B*next_n, H] float32
+        context_lens:  [B] int32
+        block_tables:  [B, max_blocks] int32
+        max_model_len: output width. Caller passes the active batch max so
+            the logits buffer and grid stay tight.
+        clean_logits: when False, skip the -inf pre-fill of the output
+            (indexer top-k reads only `[:context_len]` per row).
+    Returns:
+        logits:        [B*next_n, max_model_len] float32
+    """
+    B, next_n, num_heads, head_dim = q.shape
+    _, block_size, one, d_plus_4 = kv_cache.shape
+    assert one == 1
+    assert d_plus_4 == head_dim + 4
+
+    # Cache layout from `indexer_k_quant_and_cache`: per block, FP8 K bytes
+    # (block_size * head_dim) followed by fp32 scales (block_size * 4). The
+    # `[NB, block_size, 1, head_dim+4]` shape is a stride trick; re-slice flat.
+    # Kernel decodes FP8 from uint8 via LUT (SM80 Triton can't load fp8e4nv).
+    num_blocks = kv_cache.shape[0]
+    kv_flat = kv_cache.view(num_blocks, -1)
+    k_end = block_size * head_dim
+    kv_byte = kv_flat[:, :k_end].as_strided(
+        (num_blocks, block_size, head_dim),
+        (kv_flat.stride(0), head_dim, 1),
+    )
+    kv_scale = kv_flat[:, k_end:].view(torch.float32)
+    q_byte = q.view(torch.uint8)
+
+    if clean_logits:
+        logits = torch.full(
+            (B * next_n, max_model_len),
+            float("-inf"),
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        logits = torch.empty(
+            (B * next_n, max_model_len), dtype=torch.float32, device=q.device
+        )
+
+    BLOCK_H = max(16, triton.next_power_of_2(num_heads))
+    BLOCK_D = triton.next_power_of_2(head_dim)
+    BLOCK_N = triton.next_power_of_2(block_size)
+
+    fp8_lut = _get_e4m3fn_bf16_lut(q.device)
+    grid = (B * next_n, block_tables.shape[1])
+    _fp8_paged_mqa_logits_kernel[grid](
+        q_byte,
+        kv_byte,
+        kv_scale,
+        weights,
+        fp8_lut,
+        context_lens,
+        block_tables,
+        logits,
+        q_byte.stride(0),
+        q_byte.stride(1),
+        q_byte.stride(2),
+        q_byte.stride(3),
+        kv_byte.stride(0),
+        kv_byte.stride(1),
+        kv_byte.stride(2),
+        kv_scale.stride(0),
+        kv_scale.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        next_n=next_n,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        BLOCK_H=BLOCK_H,
+        BLOCK_D=BLOCK_D,
+        BLOCK_N=BLOCK_N,
+    )
+    return logits
+
+
+@triton.autotune(
+    configs=_PREFILL_AUTOTUNE_CONFIGS,
+    # Per-program work is N-independent; key on (heads, dim) only so chunked
+    # prefill with varying N doesn't re-tune on every new chunk size.
+    key=["num_heads", "head_dim"],
+)
+@triton.jit
+def _fp8_mqa_logits_kernel(
+    q_ptr,
+    k_ptr,
+    k_scale_ptr,
+    weights_ptr,
+    ks_ptr,
+    ke_ptr,
+    logits_ptr,
+    stride_q_m,
+    stride_q_h,
+    stride_q_d,
+    stride_k_n,
+    stride_k_d,
+    stride_w_m,
+    stride_w_h,
+    stride_l_m,
+    stride_l_n,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    N,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    # bf16 q/k inputs: the wrapper pre-decodes FP8 → bf16. At compute-bound
+    # prefill this is ~2× the in-kernel LUT (LUT lookups contend with the
+    # matmul for ALU/regs). Paged-decode keeps the LUT path.
+    m = tl.program_id(0)
+    n_block = tl.program_id(1)
+
+    n_start = n_block * BLOCK_N
+    offs_n = n_start + tl.arange(0, BLOCK_N)
+    mask_n = offs_n < N
+    # Early-exit when this row's `[ks, ke)` range doesn't overlap the tile.
+    # Chunked prefill produces many such all-masked tiles per row.
+    ks = tl.load(ks_ptr + m)
+    ke = tl.load(ke_ptr + m)
+    if (n_start >= ke) | (n_start + BLOCK_N <= ks):
+        # When `clean_logits=False` the caller skipped the -inf pre-fill, so
+        # write -inf here for the early-exit tile.
+        tl.store(
+            logits_ptr + m * stride_l_m + offs_n * stride_l_n,
+            tl.full([BLOCK_N], float("-inf"), dtype=tl.float32),
+            mask=mask_n,
+        )
+        return
+
+    offs_h = tl.arange(0, BLOCK_H)
+    offs_d = tl.arange(0, BLOCK_D)
+    mask_h = offs_h < num_heads
+    mask_d = offs_d < head_dim
+
+    q = tl.load(
+        q_ptr
+        + m * stride_q_m
+        + offs_h[:, None] * stride_q_h
+        + offs_d[None, :] * stride_q_d,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0.0,
+    )
+
+    k = tl.load(
+        k_ptr + offs_n[:, None] * stride_k_n + offs_d[None, :] * stride_k_d,
+        mask=mask_n[:, None] & mask_d[None, :],
+        other=0.0,
+    )
+    k_scale = tl.load(k_scale_ptr + offs_n, mask=mask_n, other=0.0)
+    s = tl.dot(q, tl.trans(k)) * k_scale[None, :]
+
+    w = tl.load(
+        weights_ptr + m * stride_w_m + offs_h * stride_w_h,
+        mask=mask_h,
+        other=0.0,
+    )
+    s = tl.where(s > 0, s, 0.0) * w[:, None]
+    out = tl.sum(s, axis=0)
+
+    valid = mask_n & (offs_n >= ks) & (offs_n < ke)
+    out = tl.where(valid, out, float("-inf"))
+
+    tl.store(
+        logits_ptr + m * stride_l_m + offs_n * stride_l_n,
+        out,
+        mask=mask_n,
+    )
+
+
+def fp8_mqa_logits_triton(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    """Triton implementation of DeepGEMM's fp8_mqa_logits.
+
+    Args:
+        q:            [M, H, D] fp8_e4m3fn
+        kv:           (k_fp8 [N, D], k_scales [N]) — fp8_e4m3fn, float32
+        weights:      [M, H] float32
+        cu_seqlen_ks: [M] int32
+        cu_seqlen_ke: [M] int32
+        clean_logits: when False, skip the -inf pre-fill of the output
+            (indexer top-k reads only `[ks, ke)` per row). Matches DeepGEMM.
+    Returns:
+        logits:       [M, N] float32
+    """
+    k_fp8, k_scales = kv
+    k_scales = k_scales.reshape(-1)
+
+    M, num_heads, head_dim = q.shape
+    N = k_fp8.shape[0]
+
+    if clean_logits:
+        logits = torch.full((M, N), float("-inf"), dtype=torch.float32, device=q.device)
+    else:
+        logits = torch.empty((M, N), dtype=torch.float32, device=q.device)
+
+    BLOCK_H = max(16, triton.next_power_of_2(num_heads))
+    BLOCK_D = triton.next_power_of_2(head_dim)
+
+    # Pre-decode FP8 → bf16; the kernel runs a straight `tl.dot`.
+    q_bf16 = q.to(torch.bfloat16)
+    k_bf16 = k_fp8.to(torch.bfloat16)
+
+    # Grid depends on the autotuned BLOCK_N.
+    grid = lambda meta: (M, triton.cdiv(N, meta["BLOCK_N"]))  # noqa: E731
+    _fp8_mqa_logits_kernel[grid](
+        q_bf16,
+        k_bf16,
+        k_scales,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        logits,
+        q_bf16.stride(0),
+        q_bf16.stride(1),
+        q_bf16.stride(2),
+        k_bf16.stride(0),
+        k_bf16.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        num_heads=num_heads,
+        head_dim=head_dim,
+        N=N,
+        BLOCK_H=BLOCK_H,
+        BLOCK_D=BLOCK_D,
+    )
+    return logits
+
+
+def warmup_fp8_mqa_logits_triton(
+    num_heads: int,
+    head_dim: int,
+    device: torch.device,
+) -> None:
+    """Prime the prefill `@triton.autotune` cache so first-call doesn't pay
+    the inline sweep (~5–8 s on A100 SM80). N is a runtime scalar, so one
+    small-M / long-N shape covers all chunk lengths."""
+    max_block_n = max(c.kwargs["BLOCK_N"] for c in _PREFILL_AUTOTUNE_CONFIGS)
+    m = _PREFILL_WARMUP_M
+    n = max(_PREFILL_WARMUP_N, max_block_n)
+    q = torch.empty(m, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    k = torch.empty(n, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    scales = torch.zeros(n, dtype=torch.float32, device=device)
+    weights = torch.zeros(m, num_heads, dtype=torch.float32, device=device)
+    ks = torch.zeros(m, dtype=torch.int32, device=device)
+    ke = torch.full((m,), n, dtype=torch.int32, device=device)
+    fp8_mqa_logits_triton(q, (k, scales), weights, ks, ke)
+
+
+def warmup_fp8_paged_mqa_logits_triton(
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    device: torch.device,
+) -> None:
+    """Prime the paged-decode `@triton.autotune` cache for the indexer's
+    logits kernel (see `warmup_fp8_mqa_logits_triton` for rationale).
+    """
+    num_blocks = 2
+    q = torch.empty(1, 1, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    kv_cache = torch.zeros(
+        num_blocks, block_size, 1, head_dim + 4, dtype=torch.uint8, device=device
+    )
+    weights = torch.zeros(1, num_heads, dtype=torch.float32, device=device)
+    context_lens = torch.tensor([block_size], dtype=torch.int32, device=device)
+    block_tables = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    fp8_paged_mqa_logits_triton(
+        q, kv_cache, weights, context_lens, block_tables, max_model_len=block_size
+    )

--- a/vllm/v1/attention/ops/mqa_logits_triton.py
+++ b/vllm/v1/attention/ops/mqa_logits_triton.py
@@ -152,7 +152,7 @@ def _fp8_paged_mqa_logits_kernel(
     tl.store(
         logits_ptr + token_id * stride_l_t + k_offset * stride_l_n,
         out,
-        mask=mask_n,
+        mask=mask_n & (k_offset < context_len),
     )
 
 

--- a/vllm/v1/attention/ops/mqa_logits_triton.py
+++ b/vllm/v1/attention/ops/mqa_logits_triton.py
@@ -102,9 +102,12 @@ def _fp8_paged_mqa_logits_kernel(
 
     q_offset = context_len - next_n + next_n_id
 
+    # int64: unified-KV-pool layer views carry a large block stride (~1e6
+    # elements), so int32 `block_idx * stride` wraps once a batch touches
+    # roughly >2k pool blocks (long context or concurrent sequences).
     block_idx = tl.load(
         block_tables_ptr + batch_id * stride_bt_b + block_rk * stride_bt_k
-    )
+    ).to(tl.int64)
 
     offs_h = tl.arange(0, BLOCK_H)
     offs_d = tl.arange(0, BLOCK_D)

--- a/vllm/v1/attention/ops/mqa_logits_triton.py
+++ b/vllm/v1/attention/ops/mqa_logits_triton.py
@@ -80,8 +80,11 @@ def _fp8_paged_mqa_logits_kernel(
     stride_w_h,
     stride_bt_b,
     stride_bt_k,
+    stride_ctx_b,
+    stride_ctx_n,
     stride_l_t,
     stride_l_n,
+    per_token_context: tl.constexpr,
     next_n: tl.constexpr,
     num_heads: tl.constexpr,
     head_dim: tl.constexpr,
@@ -96,11 +99,15 @@ def _fp8_paged_mqa_logits_kernel(
     batch_id = token_id // next_n
     next_n_id = token_id % next_n
 
-    context_len = tl.load(context_lens_ptr + batch_id)
+    context_len = tl.load(
+        context_lens_ptr + batch_id * stride_ctx_b + next_n_id * stride_ctx_n
+    )
     if block_rk * block_size >= context_len:
         return
 
-    q_offset = context_len - next_n + next_n_id
+    q_offset = (
+        context_len - 1 if per_token_context else context_len - next_n + next_n_id
+    )
 
     # int64: unified-KV-pool layer views carry a large block stride (~1e6
     # elements), so int32 `block_idx * stride` wraps once a batch touches
@@ -174,7 +181,7 @@ def fp8_paged_mqa_logits_triton(
         q:             [B, next_n, H, D] fp8_e4m3fn
         kv_cache:      [num_blocks, block_size, 1, D+4] uint8 (FP8 + fp32 scale)
         weights:       [B*next_n, H] float32
-        context_lens:  [B] int32
+        context_lens:  [B] final lengths, or [B, next_n] per-token lengths
         block_tables:  [B, max_blocks] int32
         max_model_len: output width. Caller passes the active batch max so
             the logits buffer and grid stay tight.
@@ -184,6 +191,14 @@ def fp8_paged_mqa_logits_triton(
         logits:        [B*next_n, max_model_len] float32
     """
     B, next_n, num_heads, head_dim = q.shape
+    per_token_context = context_lens.ndim == 2
+    if per_token_context:
+        assert context_lens.shape[0] == B
+        assert context_lens.shape[1] >= next_n
+        stride_ctx_b, stride_ctx_n = context_lens.stride()[:2]
+    else:
+        assert context_lens.shape == (B,)
+        stride_ctx_b, stride_ctx_n = context_lens.stride(0), 0
     _, block_size, one, d_plus_4 = kv_cache.shape
     assert one == 1
     assert d_plus_4 == head_dim + 4
@@ -242,8 +257,11 @@ def fp8_paged_mqa_logits_triton(
         weights.stride(1),
         block_tables.stride(0),
         block_tables.stride(1),
+        stride_ctx_b,
+        stride_ctx_n,
         logits.stride(0),
         logits.stride(1),
+        per_token_context=per_token_context,
         next_n=next_n,
         num_heads=num_heads,
         head_dim=head_dim,

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -19,6 +19,10 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import LayerNameType
 from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
+from vllm.v1.attention.ops.fp8e4nv import (
+    FP8E4NV_EXTERN_LIBS,
+    convert_from_fp8e4m3,
+)
 from vllm.v1.worker.workspace import current_workspace_manager
 
 if current_platform.is_rocm():
@@ -1729,6 +1733,7 @@ def _sparse_attn_decode_ragged_kernel(
     # Compressed K-cache (extra): Triton encoder writes OCP everywhere.
     IS_FNUZ_MAIN: tl.constexpr,
     IS_FNUZ_EXTRA: tl.constexpr,
+    FP8_SOFTWARE_CONV: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
@@ -1787,6 +1792,8 @@ def _sparse_attn_decode_ragged_kernel(
         )
         if IS_FNUZ_MAIN:
             x_fp8 = x_uint8.to(tl.float8e4b8, bitcast=True)
+        elif FP8_SOFTWARE_CONV:
+            x_fp8 = convert_from_fp8e4m3(x_uint8, tl.bfloat16)
         else:
             x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
         encoded_scales = tl.load(
@@ -1855,6 +1862,8 @@ def _sparse_attn_decode_ragged_kernel(
             )
             if IS_FNUZ_EXTRA:
                 x_fp8 = x_uint8.to(tl.float8e4b8, bitcast=True)
+            elif FP8_SOFTWARE_CONV:
+                x_fp8 = convert_from_fp8e4m3(x_uint8, tl.bfloat16)
             else:
                 x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
             encoded_scales = tl.load(
@@ -3084,6 +3093,14 @@ def _rocm_sparse_attn_decode_ragged_triton(
 
     if not (_ON_GFX942 or _ON_GFX950):  # Fallback path for un-tuned architectures.
         block_k = 16 if head_dim >= 256 else 32
+        fp8_software_conv = (
+            current_platform.is_cuda()
+            and current_platform.has_device_capability(75)
+            and not current_platform.has_device_capability(89)
+        )
+        launch_kwargs = (
+            {"extern_libs": FP8E4NV_EXTERN_LIBS} if fp8_software_conv else {}
+        )
         _sparse_attn_decode_ragged_kernel[(num_queries, heads_blocks)](
             q,
             main_cache,
@@ -3113,9 +3130,11 @@ def _rocm_sparse_attn_decode_ragged_triton(
             ROPE_DIM=rope_head_dim,
             IS_FNUZ_MAIN=is_fnuz,
             IS_FNUZ_EXTRA=False,
+            FP8_SOFTWARE_CONV=fp8_software_conv,
             BLOCK_H=block_h,
             BLOCK_K=block_k,
             num_warps=8,
+            **launch_kwargs,
         )
         return out
 

--- a/vllm/v1/attention/ops/triton_mla_sparse_kernel.py
+++ b/vllm/v1/attention/ops/triton_mla_sparse_kernel.py
@@ -1,0 +1,550 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton sparse MLA attention with split-KV for low-batch decode."""
+
+import functools
+
+import torch
+
+from vllm.triton_utils import LOG2E, LOGE2, tl, triton
+from vllm.utils.platform_utils import num_compute_units
+
+# DeepSeek-V3.2 / GLM-5 sparse MLA shape constants.
+_BLOCK_DMODEL = 512
+_BLOCK_DPE = 64
+_BLOCK_DV = 512
+_DIM_QK = _BLOCK_DMODEL + _BLOCK_DPE  # 576
+
+_BLOCK_H = 16
+# Smallest BLOCK_N the autotune sweep offers; only used for the topk-divisibility
+# check at dispatch time.
+_MIN_BLOCK_N = 16
+
+# Merge kernel grid is spread across heads and DV tiles to avoid a (1,1)
+# launch starving the SMs (pattern from FlashMLA's combine kernel).
+_MERGE_BLOCK_H = 1
+_MERGE_BLOCK_DV_TILE = 128
+assert _BLOCK_DV % _MERGE_BLOCK_DV_TILE == 0
+_NUM_MERGE_DV_TILES = _BLOCK_DV // _MERGE_BLOCK_DV_TILE
+
+# Final (prefill) and split (decode) kernels each tune to their own regime.
+_FINAL_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": 16}, num_warps=nw, num_stages=ns)
+    for nw in (2, 4)
+    for ns in (2, 4)
+]
+_SPLIT_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=ns) for ns in (2, 4)
+]
+
+# Split-count candidates for `_choose_num_kv_splits`; also the set pre-compiled
+# by `_warmup_autotune`.
+KV_SPLITS_CANDIDATES = (1, 2, 4, 8, 16)
+
+_MIN_TOPK_PER_SPLIT = 128  # below this, per-split work is too small to amortize
+_SPLIT_MAX_OCCUPANCY = 4  # skip split when baseline grid fills >=1/4 of SMs
+
+
+@triton.jit
+def _sparse_mla_compute_tile(
+    q_buffer,
+    k_buffer,  # V is the first BLOCK_DV lanes of each row of k_buffer.
+    indices_ptr,
+    cur_q,
+    cur_head,
+    cur_kv_head_id,
+    mask_h,
+    split_start,
+    split_end,
+    seq_kv,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+):
+    """Shared stage-1 body: load Q, run the sparse online-softmax loop over
+    `[split_start, split_end)` of the topk axis, return accumulators."""
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mask_dpe = offs_dpe < BLOCK_DMODEL + BLOCK_DPE
+
+    q = tl.load(
+        q_buffer
+        + cur_q * stride_q_token
+        + cur_head[:, None] * stride_q_head
+        + offs_d[None, :],
+        mask=mask_h[:, None],
+        other=0.0,
+    )
+    qpe = tl.load(
+        q_buffer
+        + cur_q * stride_q_token
+        + cur_head[:, None] * stride_q_head
+        + offs_dpe[None, :],
+        mask=(mask_h[:, None]) & (mask_dpe[None, :]),
+        other=0.0,
+    )
+
+    # Finite sentinel (not -inf) — when an entire BLOCK_N tile is masked,
+    # `-inf - -inf = NaN` poisons the softmax; `sentinel - sentinel = 0`
+    # gives `exp2(0) = 1` and the matching V rows are already 0.
+    NEG_LARGE = -1.0e30
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) + NEG_LARGE
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    for start_indice in range(split_start, split_end, BLOCK_N):
+        offs_indice = start_indice + tl.arange(0, BLOCK_N)
+        mask_indice = offs_indice < split_end
+        indices = tl.load(
+            indices_ptr
+            + cur_q * stride_indices_token
+            + cur_kv_head_id * stride_indices_head
+            + offs_indice,
+            mask=mask_indice,
+            other=-1,
+        )
+        mask_kv = (indices >= 0) & (indices < seq_kv)
+
+        offs_k = (
+            indices[None, :] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_d[:, None]
+        )
+        k = tl.load(k_buffer + offs_k, mask=mask_kv[None, :], other=0.0)
+        qk = tl.dot(q, k.to(q.dtype))
+
+        offs_kpe = (
+            indices[None, :] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_dpe[:, None]
+        )
+        kpe = tl.load(
+            k_buffer + offs_kpe,
+            mask=(mask_kv[None, :]) & (mask_dpe[:, None]),
+            other=0.0,
+        )
+        qk += tl.dot(qpe, kpe.to(q.dtype))
+
+        qk *= sm_scale
+        qk = tl.where((mask_h[:, None]) & (mask_kv[None, :]), qk, NEG_LARGE)
+
+        offs_v = (
+            indices[:, None] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_dv[None, :]
+        )
+        v = tl.load(k_buffer + offs_v, mask=mask_kv[:, None], other=0.0)
+
+        n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+        re_scale = tl.exp2(e_max - n_e_max)
+        p = tl.exp2(qk - n_e_max[:, None])
+        acc *= re_scale[:, None]
+        acc += tl.dot(p.to(v.dtype), v)
+        e_sum = e_sum * re_scale + tl.sum(p, 1)
+        e_max = n_e_max
+
+    return acc, e_max, e_sum
+
+
+@triton.autotune(configs=_FINAL_AUTOTUNE_CONFIGS, key=["index_topk", "kv_group_num"])
+@triton.jit
+def _sparse_mla_kernel_final(
+    q_buffer,
+    k_buffer,
+    indices_ptr,
+    out_ptr,
+    seq_kv,
+    h_q,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_out_token,
+    stride_out_head,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    index_topk: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+):
+    """Single-pass fast path: full topk, write final bf16 output directly."""
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_kv_head_id = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    acc, e_max, e_sum = _sparse_mla_compute_tile(
+        q_buffer,
+        k_buffer,
+        indices_ptr,
+        cur_q,
+        cur_head,
+        cur_kv_head_id,
+        mask_h,
+        0,
+        index_topk,
+        seq_kv,
+        stride_q_token,
+        stride_q_head,
+        stride_kv_token,
+        stride_kv_head,
+        stride_indices_token,
+        stride_indices_head,
+        sm_scale,
+        BLOCK_H,
+        BLOCK_N,
+        BLOCK_DV,
+        BLOCK_DMODEL,
+        BLOCK_DPE,
+    )
+
+    # Guard against queries with zero valid KV (e_sum == 0 → NaN from 0/0).
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    tl.store(
+        out_ptr
+        + cur_q * stride_out_token
+        + cur_head[:, None] * stride_out_head
+        + offs_dv[None, :],
+        (acc / e_sum_safe[:, None]).to(tl.bfloat16),
+        mask=mask_h[:, None],
+    )
+
+
+@triton.autotune(
+    configs=_SPLIT_AUTOTUNE_CONFIGS,
+    key=["index_topk", "NUM_KV_SPLITS", "kv_group_num"],
+)
+@triton.jit
+def _sparse_mla_kernel_split(
+    q_buffer,
+    k_buffer,
+    indices_ptr,
+    mid_out_ptr,
+    seq_kv,
+    h_q,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_mid_token,
+    stride_mid_head,
+    stride_mid_split,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    index_topk: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    LOGE2: tl.constexpr,
+):
+    """Stage 1 of split-KV: process one slice of the topk axis and write
+    its `(out_partial, lse_partial)` into the mid buffer."""
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+    cur_kv_head_id = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    split_topk: tl.constexpr = tl.cdiv(index_topk, NUM_KV_SPLITS)
+    split_start = split_kv_id * split_topk
+    split_end = tl.minimum(split_start + split_topk, index_topk)
+
+    acc, e_max, e_sum = _sparse_mla_compute_tile(
+        q_buffer,
+        k_buffer,
+        indices_ptr,
+        cur_q,
+        cur_head,
+        cur_kv_head_id,
+        mask_h,
+        split_start,
+        split_end,
+        seq_kv,
+        stride_q_token,
+        stride_q_head,
+        stride_kv_token,
+        stride_kv_head,
+        stride_indices_token,
+        stride_indices_head,
+        sm_scale,
+        BLOCK_H,
+        BLOCK_N,
+        BLOCK_DV,
+        BLOCK_DMODEL,
+        BLOCK_DPE,
+    )
+
+    # Partial output and natural-log LSE for stage-2 merge.
+    # When a split has no valid KV (`e_sum == 0`), guard the divide so the
+    # mid buffer holds 0 instead of NaN; otherwise the `0 * NaN = NaN` term
+    # in stage 2 would poison every other split.
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mid_base_2d = (
+        mid_out_ptr
+        + cur_q * stride_mid_token
+        + cur_head[:, None] * stride_mid_head
+        + split_kv_id * stride_mid_split
+    )
+    tl.store(
+        mid_base_2d + offs_dv[None, :],
+        acc / e_sum_safe[:, None],
+        mask=mask_h[:, None],
+    )
+    mid_lse_ptr = (
+        mid_out_ptr
+        + cur_q * stride_mid_token
+        + cur_head * stride_mid_head
+        + split_kv_id * stride_mid_split
+        + BLOCK_DV
+    )
+    tl.store(mid_lse_ptr, (e_max + tl.log2(e_sum)) * LOGE2, mask=mask_h)
+
+
+@triton.jit
+def _sparse_mla_merge_kernel(
+    mid_out_ptr,
+    out_ptr,
+    h_q,
+    stride_mid_token,
+    stride_mid_head,
+    stride_mid_split,
+    stride_out_token,
+    stride_out_head,
+    NUM_KV_SPLITS: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DV_TILE: tl.constexpr,
+):
+    """Stage 2: N-way online-softmax merge of per-split `(out, lse)` tiles.
+
+    Grid is `(num_tokens, num_head_groups, num_dv_tiles)`. Each program handles
+    `BLOCK_H` heads × `BLOCK_DV_TILE` output-dim lanes. The LSE reduction is
+    identical across DV tiles for the same (token, head) — each program
+    recomputes it locally, which is cheap (O(NUM_KV_SPLITS) scalars) and
+    avoids inter-CTA synchronization.
+    """
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_dv_tile = tl.program_id(2)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    offs_dv = cur_dv_tile * BLOCK_DV_TILE + tl.arange(0, BLOCK_DV_TILE)
+    mask_dv = offs_dv < BLOCK_DV
+    # Finite sentinel — same NaN guard as the split kernel for empty splits.
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - 1.0e30
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV_TILE], dtype=tl.float32)
+
+    mid_base_2d = (
+        mid_out_ptr + cur_q * stride_mid_token + cur_head[:, None] * stride_mid_head
+    )
+    mid_lse_1d = (
+        mid_out_ptr + cur_q * stride_mid_token + cur_head * stride_mid_head + BLOCK_DV
+    )
+
+    for split_kv_id in range(NUM_KV_SPLITS):
+        tv = tl.load(
+            mid_base_2d + split_kv_id * stride_mid_split + offs_dv[None, :],
+            mask=mask_h[:, None] & mask_dv[None, :],
+            other=0.0,
+        )
+        tlogic = tl.load(
+            mid_lse_1d + split_kv_id * stride_mid_split,
+            mask=mask_h,
+            other=-float("inf"),
+        )
+        n_e_max = tl.maximum(tlogic, e_max)
+        old_scale = tl.exp(e_max - n_e_max)
+        exp_logic = tl.exp(tlogic - n_e_max)
+        acc = acc * old_scale[:, None] + exp_logic[:, None] * tv
+        e_sum = e_sum * old_scale + exp_logic
+        e_max = n_e_max
+
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    tl.store(
+        out_ptr
+        + cur_q * stride_out_token
+        + cur_head[:, None] * stride_out_head
+        + offs_dv[None, :],
+        (acc / e_sum_safe[:, None]).to(tl.bfloat16),
+        mask=mask_h[:, None] & mask_dv[None, :],
+    )
+
+
+@functools.lru_cache(maxsize=256)
+def _choose_num_kv_splits(
+    num_tokens: int, num_head_groups: int, index_topk: int, sm_count: int
+) -> int:
+    """Pick a power-of-2 split count that fills the device without dropping
+    per-split work below _MIN_TOPK_PER_SPLIT. Returns 1 when the single-pass
+    grid already reaches ~1/_SPLIT_MAX_OCCUPANCY utilization.
+    """
+    baseline = num_tokens * num_head_groups
+    if baseline == 0 or baseline * _SPLIT_MAX_OCCUPANCY >= sm_count:
+        return 1
+    ideal = triton.next_power_of_2(max(1, index_topk // _MIN_TOPK_PER_SPLIT))
+    max_splits = max(1, sm_count // baseline)
+    max_splits = 1 << (max_splits.bit_length() - 1)  # floor to power of 2
+    num_kv_splits = min(ideal, max_splits)
+    while num_kv_splits > 1 and index_topk % num_kv_splits != 0:
+        num_kv_splits //= 2
+    return max(1, num_kv_splits)
+
+
+def triton_mla_sparse_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    num_kv_splits: int | None = None,
+    sm_count: int | None = None,
+) -> torch.Tensor:
+    """Sparse MLA attention over topk indices.
+
+    Args:
+        q:         [num_tokens, num_heads_q, dim_qk] bf16
+        kv:        [seq_kv, num_heads_kv=1, dim_qk] bf16
+        indices:   [num_tokens, num_heads_kv=1, topk] int32
+        sm_scale:  softmax scale
+        num_kv_splits: override auto-heuristic; None/0 = auto, 1 = force single-pass.
+        sm_count:  cached device SM count for the split heuristic.
+
+    Returns:
+        out:   [num_tokens, num_heads_q, _BLOCK_DV] bf16
+    """
+    num_tokens, num_heads_q, dim_qk = q.shape
+    assert dim_qk == _DIM_QK, (
+        f"sparse MLA kernel requires dim_qk={_DIM_QK} (DeepSeek-V3.2 / GLM-5), "
+        f"got {dim_qk}"
+    )
+    assert kv.shape[1] == 1 and kv.shape[2] == _DIM_QK
+    index_topk = indices.shape[2]
+    assert index_topk % _MIN_BLOCK_N == 0, (
+        f"topk ({index_topk}) must be a multiple of the smallest autotune "
+        f"BLOCK_N ({_MIN_BLOCK_N})"
+    )
+
+    kv_group_num = num_heads_q
+    num_head_groups = triton.cdiv(num_heads_q, min(_BLOCK_H, kv_group_num))
+
+    if num_kv_splits is None or num_kv_splits == 0:
+        if sm_count is None:
+            sm_count = num_compute_units(q.device.index)
+        num_kv_splits = _choose_num_kv_splits(
+            num_tokens, num_head_groups, index_topk, sm_count
+        )
+
+    out = torch.empty(
+        (num_tokens, num_heads_q, _BLOCK_DV),
+        dtype=torch.bfloat16,
+        device=q.device,
+    )
+
+    if num_kv_splits == 1:
+        _sparse_mla_kernel_final[(num_tokens, num_head_groups)](
+            q_buffer=q,
+            k_buffer=kv,
+            indices_ptr=indices,
+            out_ptr=out,
+            seq_kv=kv.shape[0],
+            h_q=num_heads_q,
+            stride_q_token=q.stride(0),
+            stride_q_head=q.stride(1),
+            stride_kv_token=kv.stride(0),
+            stride_kv_head=kv.stride(1),
+            stride_out_token=out.stride(0),
+            stride_out_head=out.stride(1),
+            stride_indices_token=indices.stride(0),
+            stride_indices_head=indices.stride(1),
+            sm_scale=sm_scale * LOG2E,
+            index_topk=index_topk,
+            kv_group_num=kv_group_num,
+            BLOCK_H=_BLOCK_H,
+            BLOCK_DV=_BLOCK_DV,
+            BLOCK_DMODEL=_BLOCK_DMODEL,
+            BLOCK_DPE=_BLOCK_DPE,
+        )
+        return out
+
+    # Split-KV: partial fp32 output + LSE per (token, head, split).
+    mid_out = torch.empty(
+        (num_tokens, num_heads_q, num_kv_splits, _BLOCK_DV + 1),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    _sparse_mla_kernel_split[(num_tokens, num_head_groups, num_kv_splits)](
+        q_buffer=q,
+        k_buffer=kv,
+        indices_ptr=indices,
+        mid_out_ptr=mid_out,
+        seq_kv=kv.shape[0],
+        h_q=num_heads_q,
+        stride_q_token=q.stride(0),
+        stride_q_head=q.stride(1),
+        stride_kv_token=kv.stride(0),
+        stride_kv_head=kv.stride(1),
+        stride_mid_token=mid_out.stride(0),
+        stride_mid_head=mid_out.stride(1),
+        stride_mid_split=mid_out.stride(2),
+        stride_indices_token=indices.stride(0),
+        stride_indices_head=indices.stride(1),
+        sm_scale=sm_scale * LOG2E,
+        index_topk=index_topk,
+        NUM_KV_SPLITS=num_kv_splits,
+        kv_group_num=kv_group_num,
+        BLOCK_H=_BLOCK_H,
+        BLOCK_DV=_BLOCK_DV,
+        BLOCK_DMODEL=_BLOCK_DMODEL,
+        BLOCK_DPE=_BLOCK_DPE,
+        LOGE2=LOGE2,
+    )
+
+    _sparse_mla_merge_kernel[(num_tokens, num_heads_q, _NUM_MERGE_DV_TILES)](
+        mid_out_ptr=mid_out,
+        out_ptr=out,
+        h_q=num_heads_q,
+        stride_mid_token=mid_out.stride(0),
+        stride_mid_head=mid_out.stride(1),
+        stride_mid_split=mid_out.stride(2),
+        stride_out_token=out.stride(0),
+        stride_out_head=out.stride(1),
+        NUM_KV_SPLITS=num_kv_splits,
+        kv_group_num=kv_group_num,
+        BLOCK_H=_MERGE_BLOCK_H,
+        BLOCK_DV=_BLOCK_DV,
+        BLOCK_DV_TILE=_MERGE_BLOCK_DV_TILE,
+        num_warps=2,
+    )
+    return out


### PR DESCRIPTION


## Purpose

DeepSeek V4’s CUDA sparse-MLA path currently selects implementations that require DeepGEMM, CuTeDSL SM90 code generation, or native Triton `fp8e4nv` conversion. On A100/SM80 the model fails during sparse-indexer or cache execution instead of reaching generation. The same selection assumptions exclude SM86 and SM89. Observed A100 failures include:

```text
ValueError: type fp8e4nv not supported in this architecture
NVVM backend compilation failed
```

This PR routes DeepSeek V4 to the Triton sparse-MLA backend when DeepGEMM is unavailable, restricts CuTeDSL selection to SM90 and newer GPUs, uses the shared FP8 E4M3 helpers at the DeepSeek V4 compressor, indexer-query, cache-gather, and sparse-decode call sites, and masks invalid CUDA-graph padding rows before they can publish physical cache indices. SM89 uses its native FP8 conversion while SM80 and SM86 use the shared software conversion; all three use the Triton sparse-MLA path because DeepGEMM is unavailable on SM8x.

The generic Triton sparse-MLA capability guard remains backend-specific: it rejects pre-SM80 without blocking other FP16 Turing paths. The adjacent comment records that SM75 support requires making the currently hard-coded BF16 output dtype-aware. The autotune warmup now uses the configured model-activation and resolved KV-cache dtype pair so FP16 and mixed FP16/BF16 specializations are compiled before CUDA-graph capture.

This PR is intentionally stacked on [#47629](https://github.com/vllm-project/vllm/pull/47629). That PR owns the generic Triton sparse-MLA backend, MQA kernels, bounded tail stores, 64-bit physical-block addressing, and their generic tests. This PR contains only the DeepSeek V4 FP8 compressed-cache integration, the two-dimensional per-token context adaptation required by DeepSeek V4 compression, and its model-specific invalid-padding regression. It will be rebased onto `main` after #47629 lands.

The shared FP8 conversion helper is a separate prerequisite because several DeepSeek V4 kernels need the same conversion contract. The output-projection fallback is also separate because it is an independent kernel and failure mode.

## Test Plan

Extend the existing FlashMLA sparse tests with a poisoned invalid CUDA-graph row and verify that the row contributes zero decode length and only `-1` indices. The CPU-only capability cases check DeepSeek V4 acceptance on SM80, SM86, SM89, SM90, and SM100, explicit SM75 rejection, and generic Triton sparse-MLA rejection on SM75 with SM80 and SM120 acceptance. The dtype-aware warmup regression covers all four FP16/BF16 model-cache combinations. The CUDA graph-padding regression runs on a physical RTX 4090 with native SM89 execution.

```bash
.venv/bin/python -m pytest \
  tests/kernels/attention/test_flashmla_sparse.py::test_deepseek_v4_sparse_mla_supports_cuda_architectures \
  tests/kernels/attention/test_flashmla_sparse.py::test_deepseek_v4_sparse_mla_rejects_sm75 \
  tests/kernels/attention/test_flashmla_sparse.py::test_triton_sparse_mla_requires_sm80 \
  tests/kernels/attention/test_flashmla_sparse.py::test_triton_sparse_mla_warmup_uses_configured_dtypes \
  tests/kernels/attention/test_flashmla_sparse.py::test_deepseek_v4_c128a_adaptive_width_has_capture_stable_stride \
  -v
```

Extend #47629’s existing paged-MQA parameterization with `next_n > 1` and nonuniform per-token compressed context lengths to verify the DeepSeek V4 two-dimensional context contract. Run it on a physical RTX 4090 with native SM89 code generation and with Triton targeting SM80 and SM86:

```bash
TRITON_OVERRIDE_ARCH=sm80 \
  .venv/bin/python -m pytest \
  tests/kernels/attention/test_mqa_logits_triton.py::test_fp8_paged_mqa_logits_triton_matches_torch \
  -v

TRITON_OVERRIDE_ARCH=sm86 \
  .venv/bin/python -m pytest \
  tests/kernels/attention/test_mqa_logits_triton.py::test_fp8_paged_mqa_logits_triton_matches_torch \
  -v

.venv/bin/python -m pytest \
  tests/kernels/attention/test_mqa_logits_triton.py::test_fp8_paged_mqa_logits_triton_matches_torch \
  -v
```

Exercise the complete DeepSeek V4 path with this PR, #47629, the FP8-conversion-helper prerequisite, and the output-projection companion on four eight-GPU A100/SM80 nodes. Run the prerequisite and companion validation stack without this PR to reproduce its sparse-MLA failure, then add this PR and repeat the same Slurm job:

```bash
#!/bin/bash
#SBATCH --nodes=4
#SBATCH --ntasks=4
#SBATCH --ntasks-per-node=1
#SBATCH --gpus-per-node=8
#SBATCH --time=02:00:00

set -euo pipefail

export MODEL=nvidia/DeepSeek-V4-Pro-0813-NVFP4
export REVISION=2ff4ec53ee664e54571f670276d2c89d0fcc7b82
export MASTER_ADDR
MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
export MASTER_PORT=29501
export COMPILATION_CONFIG='{"cudagraph_capture_sizes":[1,2,4,8,16,32,64],"inductor_compile_config":{"enable_auto_functionalized_v2":true}}'

srun --nodes=4 --ntasks=4 --ntasks-per-node=1 bash -lc '
  headless=()
  if (( SLURM_NODEID > 0 )); then
    headless=(--headless)
  fi

  exec vllm serve "$MODEL" \
    --revision "$REVISION" \
    --served-model-name deepseek-v4-pro \
    --host 0.0.0.0 \
    --port 8000 \
    --trust-remote-code \
    --tokenizer-mode deepseek_v4 \
    --load-format fastsafetensors \
    --safetensors-load-strategy lazy \
    --distributed-executor-backend mp \
    --master-addr "$MASTER_ADDR" \
    --master-port "$MASTER_PORT" \
    --nnodes "$SLURM_NNODES" \
    --node-rank "$SLURM_NODEID" \
    --tensor-parallel-size 16 \
    --pipeline-parallel-size 2 \
    --enable-expert-parallel \
    --kv-cache-dtype fp8 \
    --block-size 256 \
    --max-model-len 10240 \
    --max-num-seqs 64 \
    --max-num-batched-tokens 16384 \
    --gpu-memory-utilization 0.9 \
    --linear-backend auto \
    --moe-backend auto \
    --no-enable-prefix-caching \
    --distributed-timeout-seconds 7200 \
    --cpu-distributed-timeout-seconds 7200 \
    --compilation-config "$COMPILATION_CONFIG" \
    "${headless[@]}"
'
```

After the A100 head process becomes ready, run a 16-question concurrency smoke and then the full GSM8K evaluation:

```bash
.venv/bin/python tests/evals/gsm8k/gsm8k_eval.py \
  --host http://127.0.0.1 \
  --port 8000 \
  --num-questions 16 \
  --num-shots 5 \
  --max-tokens 1024 \
  --temperature 0 \
  --seed 42 \
  --max-concurrency 16 \
  --save-results gsm8k-c16.json

.venv/bin/python tests/evals/gsm8k/gsm8k_eval.py \
  --host http://127.0.0.1 \
  --port 8000 \
  --num-questions 1319 \
  --num-shots 5 \
  --max-tokens 1024 \
  --temperature 0 \
  --seed 42 \
  --max-concurrency 64 \
  --save-results gsm8k-full.json
```

Run the repository checks on every changed file:

```bash
pre-commit run --files \
  tests/kernels/attention/test_flashmla_sparse.py \
  tests/kernels/attention/test_mqa_logits_triton.py \
  vllm/models/deepseek_v4/common/ops/cache_utils.py \
  vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py \
  vllm/models/deepseek_v4/common/ops/fused_indexer_q.py \
  vllm/models/deepseek_v4/compressor.py \
  vllm/models/deepseek_v4/nvidia/flashmla.py \
  vllm/models/deepseek_v4/nvidia/model.py \
  vllm/models/deepseek_v4/sparse_mla.py \
  vllm/v1/attention/ops/mqa_logits_triton.py \
  vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
```

## Test Result

Before the fixes, the physical A100/SM80 model path failed at the native FP8 or CuTeDSL gates shown above. On the physical RTX 4090, the native-SM89 invalid-padding regression also showed a padded decode row publishing physical cache indices instead of `-1`, and the SM80, SM86, and native-SM89 paged-MQA runs exposed the incorrect two-dimensional context handling.

After the fixes, the invalid row has decode length zero and contains only `-1` indices; the original two focused FlashMLA tests pass 7/7. The added capability and dtype-aware warmup regressions pass 8/8; the four dtype pairs also complete real Triton warmup on a physical A100/SM80, launching all five split candidates for each pair. #47629's paged-MQA parameterization, extended with the DeepSeek V4 two-dimensional context case, passes 20/20 on the physical RTX 4090 with Triton targeting SM80, targeting SM86, and using native SM89 code generation.

Together with #47629 and the co-pending FP8-conversion-helper and SM8x output-projection PRs, this PR lets the compiled A100 server capture CUDA graphs and produces the following successful end-to-end results:

```text
DeepSeek V4 Pro c16: 16/16 requests completed, 0 invalid responses
DeepSeek V4 Pro full GSM8K: 1319/1319 requests completed
flexible accuracy: 0.965125
strict accuracy: 0.953753
invalid responses: 0
output tokens: 121802
evaluation time: 429.349 seconds

DeepSeek V4 Flash c16: 16/16 requests completed, 0 invalid responses
DeepSeek V4 Flash full GSM8K: 1319/1319 requests completed
flexible accuracy: 0.962
CUDA illegal-memory-access errors: 0
```

All applicable pre-commit hooks passed.

AI assistance was used to prepare the patch and PR description. The author reviewed every changed line and validated the focused and end-to-end results above.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose, failure modes, prerequisites, and relationship to #47629 are described.
- [x] The focused tests, complete Slurm-native launch, and benchmark commands are provided.
- [x] The architecture-specific before/after comparison and A100 end-to-end results are provided.
- [x] No documentation update is required because this extends an existing model backend without changing its public interface.

</details>