### PR TITLE
[Perf] Fuse CohereASR relative attention score accumulation

### DIFF
--- a/tests/models/multimodal/test_cohere_asr.py
+++ b/tests/models/multimodal/test_cohere_asr.py
@@ -4,9 +4,65 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from vllm.config import SpeechToTextConfig
-from vllm.model_executor.models.cohere_asr import CohereAsrForConditionalGeneration
+from vllm.model_executor.models.cohere_asr import (
+    CohereAsrForConditionalGeneration,
+    RelPositionMultiHeadAttention,
+)
+
+
+class _ReferenceRelPositionMultiHeadAttention(RelPositionMultiHeadAttention):
+    """Relative attention implementation before score accumulation is fused."""
+
+    def forward(self, query, key, value, mask, pos_emb=None):
+        q, k, v = self.forward_qkv(query, key, value)
+        q = q.transpose(1, 2)
+
+        assert pos_emb is not None
+        n_batch_pos = pos_emb.size(0)
+        p = self.linear_pos(pos_emb).view(n_batch_pos, -1, self.h, self.d_k)
+        p = p.transpose(1, 2)
+
+        q_with_bias_u = (q + self.pos_bias_u).transpose(1, 2)
+        q_with_bias_v = (q + self.pos_bias_v).transpose(1, 2)
+
+        matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)
+        matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
+        matrix_bd = matrix_bd[:, :, :, : matrix_ac.size(-1)]
+        scores = (matrix_ac + matrix_bd) / self.s_d_k
+        return self.forward_attention(v, scores, mask)
+
+
+@pytest.mark.parametrize(("query_len", "key_len"), [(2, 2), (3, 5)])
+def test_relative_attention_fuses_score_accumulation(monkeypatch, query_len, key_len):
+    torch.manual_seed(7)
+    batch, heads, model_dim = 2, 4, 32
+    optimized = RelPositionMultiHeadAttention(heads, model_dim, None, None)
+    reference = _ReferenceRelPositionMultiHeadAttention(heads, model_dim, None, None)
+    reference.load_state_dict(optimized.state_dict())
+
+    query = torch.randn(batch, query_len, model_dim)
+    key = torch.randn(batch, key_len, model_dim)
+    value = torch.randn(batch, key_len, model_dim)
+    pos_emb = torch.randn(1, query_len + key_len - 1, model_dim)
+    expected = reference(query, key, value, None, pos_emb)
+
+    original_baddbmm = torch.baddbmm
+    calls = 0
+
+    def tracked_baddbmm(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_baddbmm(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "baddbmm", tracked_baddbmm)
+    actual = optimized(query, key, value, None, pos_emb)
+
+    torch.testing.assert_close(actual, expected)
+    assert calls == 1
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/models/cohere_asr.py
+++ b/vllm/model_executor/models/cohere_asr.py
@@ -1186,10 +1186,18 @@ class RelPositionMultiHeadAttention(CohereASRMultiHeadAttention):
         matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))
         matrix_bd = self.rel_shift(matrix_bd)
 
-        # drops extra elements in the matrix_bd to match the matrix_ac's size
-        matrix_ac = torch.matmul(q_with_bias_u, k.transpose(-2, -1))
-        matrix_bd = matrix_bd[:, :, :, : matrix_ac.size(-1)]
-        scores = (matrix_ac + matrix_bd) / self.s_d_k  # (batch, head, time1, time2)
+        # drops extra elements in matrix_bd to match the key sequence length
+        matrix_bd = matrix_bd[:, :, :, : k.size(-2)]
+        batch, heads, query_len, key_len = matrix_bd.shape
+        scale = 1.0 / self.s_d_k
+        scores = torch.baddbmm(
+            matrix_bd.flatten(0, 1),
+            q_with_bias_u.flatten(0, 1),
+            k.transpose(-2, -1).flatten(0, 1),
+            beta=scale,
+            alpha=scale,
+        ).view(batch, heads, query_len, key_len)
+
         return self.forward_attention(v, scores, mask)
 
 


### PR DESCRIPTION
## Purpose

Fuse CohereASR relative-attention content-score accumulation with
`torch.baddbmm`.

`RelPositionMultiHeadAttention` previously computed the content score with a
separate `torch.matmul`, materialized it, added the relative-position score,
and then scaled the sum. This change uses `alpha` and `beta` in
`torch.baddbmm` to accumulate and scale both terms in one operation:

```text
before: {bmm: 2, add: 1, mul: 1}
after:  {bmm: 1, baddbmm: 1}
```

This removes the separate content-score tensor and elementwise add/scale from
the score path. No custom kernel, new dependency, runtime flag, or model gate
is introduced.

The regression test compares the fused implementation with the previous
implementation for both square and non-square query/key sequence lengths and
asserts that the fused path calls `torch.baddbmm` exactly once.

## Test Plan

### Focused unit test and formatting

```bash
.venv/bin/python -m pytest -q tests/models/multimodal/test_cohere_asr.py
uvx ruff check \
  vllm/model_executor/models/cohere_asr.py \
  tests/models/multimodal/test_cohere_asr.py
uvx ruff format --check \
  vllm/model_executor/models/cohere_asr.py \
  tests/models/multimodal/test_cohere_asr.py
git diff --check origin/main...HEAD
```

### RTX 4090 score-accumulation benchmark

Production CohereASR dimensions were used: 8 heads, model dimension 1280, and
head dimension 160. Each timing is the median of five repeats, with 25 warmup
iterations and 200 measured iterations per repeat.

```bash
python bench_cohere_asr_relative_attention.py \
  --mode benchmark \
  --batches 1 4 8 \
  --heads 8 \
  --sequences 128 375 512 1024 \
  --head-dims 160 \
  --dtypes float16 bfloat16 \
  --warmups 25 \
  --iterations 200 \
  --repeats 5 \
  --output benchmark-exact.csv
```

Selected CUDA Graph median results:

| Batch | Sequence | Dtype | Before (us) | After (us) | Speedup |
|---:|---:|:---:|---:|---:|---:|
| 1 | 128 | FP16 | 13.148 | 12.104 | 1.0863x |
| 1 | 375 | FP16 | 41.964 | 40.310 | 1.0410x |
| 1 | 1024 | FP16 | 213.924 | 172.569 | 1.2396x |
| 4 | 375 | FP16 | 201.518 | 186.179 | 1.0824x |
| 4 | 1024 | BF16 | 1257.533 | 1097.492 | 1.1458x |
| 8 | 375 | FP16 | 402.355 | 377.334 | 1.0663x |
| 8 | 1024 | BF16 | 2595.200 | 2274.406 | 1.1410x |

Across all 48 configurations:

- eager geometric-mean speedup: 1.1019x
- CUDA Graph geometric-mean speedup: 1.0957x
- minimum observed speedup: 1.0307x
- `T=1024` geometric-mean speedup: 1.1700x
- estimated temporary peak-memory reduction: 10.61%-21.52%

The benchmark script, raw p10/p50/p90 CSV, correctness CSV, environment, and
checksums are published in this
[benchmark artifact](https://gist.github.com/Levius-Fubuki/ae38032ad564ea866ebdecf2c952f863).

### Full attention layer and real-model evaluation

- Full attention-layer benchmark: 1.016x-1.039x at `T=375`, and
  1.073x-1.089x at `T=1024`.
- Official demo audio: baseline and optimized implementations produced
  identical token IDs in warmup and 15 measured repetitions.
- Earnings-22, 511 samples through `/v1/audio/transcriptions`, eight concurrent
  requests:
  - baseline: 34.826 s, 14.673 requests/s
  - optimized: 32.496 s, 15.725 requests/s
  - measured throughput speedup: 1.0717x
- WER:
  - baseline: 11.8192%
  - optimized: 11.8552%
  - upstream maximum allowed WER: 12.1392%

The WER evaluation used the upstream dataset, English normalizer, `jiwer`,
sampling settings, concurrency, and acceptance threshold. Because the model
repository is gated, the run used a local snapshot pinned to revision
`b1eacc2686a3d08ceaae5f24a88b1d519620bc09`.

## Test Result

- focused tests: 5 passed
- GPU numerical checks: 36/36 FP16/BF16 configurations passed
- both baseline and optimized implementations passed the upstream WER
  threshold
- Ruff check, Ruff format check, and `git diff --check`: passed

## Limitations

- The microbenchmark and real-model evaluation were run on one RTX 4090; CI and
  maintainer testing remain the source of cross-platform coverage.
- The real-model throughput result is a single paired run and is reported as
  supporting evidence, not a universal end-to-end performance claim.
- Single-request end-to-end latency was noisy and is intentionally not used as
  a performance claim.

## Duplicate check

I searched open vLLM PRs for CohereASR relative attention, `baddbmm`,
`RelPositionMultiHeadAttention`, and `matrix_bd`, and did not find an existing
PR implementing this optimization.

## AI assistance

OpenAI Codex was used for implementation drafting, benchmark automation, and
validation. I reviewed the diff and validated the reported results.
