### PR TITLE
[Bugfix] Detect content-format incompatibility even when explicitly specified

### DIFF
--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -570,15 +570,20 @@ def resolve_chat_template_content_format(
     *,
     model_config: ModelConfig,
 ) -> ChatTemplateContentFormat:
-    if given_format != "auto":
-        return given_format
-
     detected_format = _resolve_chat_template_content_format(
         chat_template,
         tools,
         tokenizer,
         model_config=model_config,
     )
+
+    if given_format != "auto":
+        _log_chat_template_content_format(
+            chat_template,
+            given_format=given_format,
+            detected_format=detected_format,
+        )
+        return given_format
 
     _log_chat_template_content_format(
         chat_template,
@@ -789,6 +794,14 @@ def safe_apply_chat_template(
             tokenize=tokenize,
             **resolved_kwargs,
         )
+    except TypeError as e:
+        logger.exception(
+            "A TypeError occurred while applying the chat template. "
+            "This often means the chat template is incompatible with "
+            "the chosen --chat-template-content-format (e.g. 'openai' "
+            "passes list content but the template expects strings)."
+        )
+        raise ValueError(str(e)) from e
     except Exception as e:
         logger.exception(
             "An error occurred in `transformers` while applying chat template"


### PR DESCRIPTION
## Summary
- When --chat-template-content-format openai is explicitly specified, resolve_chat_template_content_format now still runs the auto-detection probe and logs a warning if the template is incompatible with the chosen format.
- Previously, explicit format selection short-circuited detection entirely, causing a confusing ValueError deep inside transformers.apply_chat_template.

## Motivation
Fixes #54491 / #54486. Users explicitly setting --chat-template-content-format openai with templates that expect plain strings (e.g. Qwen) get an opaque error instead of an actionable warning.

## Not duplicating an existing PR
No open PR addresses this issue (verified via gh pr list --search 54491).

## Test plan
- [x] Code review: the early-return path now runs detection + warning before returning
- [x] Error message now suggests checking content format compatibility

## AI assistance disclosure
This PR was developed with AI assistance (Trae AI). All changes have been reviewed by the human submitter.