### PR TITLE
[Bugfix][KV Offload] Keep direct caches topology-specific

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for translating vLLM cache metadata to native offloading config."""
 
+from dataclasses import replace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -48,8 +49,7 @@ def _make_vllm_config(
     config.cache_config.cache_dtype = torch.float16
     config.model_config.model = "test-model"
     config.model_config.use_mla = False
-    # _full_attention_spec's heads at tp=1: the parallelism-agnostic gate
-    # requires the head shard to cover the model's KV heads exactly
+    # Matches _full_attention_spec's heads at tp=1.
     config.model_config.get_total_num_kv_heads.return_value = 4
     world_size = (
         tensor_parallel_size * pipeline_parallel_size * prefill_context_parallel_size
@@ -275,9 +275,11 @@ def _parallelism_agnostic(
     *,
     canonical: bool = False,
     v2: bool = False,
+    tensor_parallel_size: int = 1,
 ) -> bool:
     config = _make_vllm_config(
-        extra_config={"canonical_layout": True} if canonical else None
+        extra_config={"canonical_layout": True} if canonical else None,
+        tensor_parallel_size=tensor_parallel_size,
     )
     config.use_v2_model_runner = v2
     kv_cache_config = KVCacheConfig(
@@ -723,8 +725,20 @@ def test_replicated_layout_parallel_gate(kwargs: dict[str, Any], case: str):
     assert not _replicated_layout(_make_mla_kv_cache_config(), **kwargs), case
 
 
-def test_parallelism_agnostic_for_single_full_attention_group():
-    assert _parallelism_agnostic([KVCacheGroupSpec(["l0"], _full_attention_spec())])
+@pytest.mark.parametrize("tensor_parallel_size", [1, 2])
+@pytest.mark.parametrize("canonical", [False, True])
+def test_head_sharded_attention_requires_canonical_layout_for_portability(
+    tensor_parallel_size: int, canonical: bool
+):
+    spec = replace(_full_attention_spec(), num_kv_heads=4 // tensor_parallel_size)
+    assert (
+        _parallelism_agnostic(
+            [KVCacheGroupSpec(["l0", "l1"], spec)],
+            canonical=canonical,
+            tensor_parallel_size=tensor_parallel_size,
+        )
+        is canonical
+    )
 
 
 _SWA_SPEC = SlidingWindowSpec(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -127,25 +127,11 @@ def build_offloading_config(
 
     canonical_layout = bool(extra_config.get("canonical_layout", False))
 
-    # Only a single non-MLA full-attention group with genuinely head-sharded
-    # pages is parallelism-invariant: replicated latent or GQA heads,
-    # per-token-head scales, CP token sharding, and the V2 model runner's
-    # layout are all excluded.
-    is_parallelism_agnostic = (
-        not vllm_config.use_v2_model_runner
-        and single_group_spec is not None
-        and isinstance(single_group_spec, FullAttentionSpec)
-        and not isinstance(single_group_spec, MLAAttentionSpec)
-        and single_group_spec.num_kv_heads * parallel_config.tensor_parallel_size
-        == vllm_config.model_config.get_total_num_kv_heads()
-        and not single_group_spec.kv_quant_mode.is_per_token_head
-        and parallel_config.decode_context_parallel_size == 1
-        and parallel_config.prefill_context_parallel_size == 1
-    )
-    # Canonical pages are topology-free, so the gate widens to every config
-    # whose mappings derive portable, group by group; certification happens
-    # per layer at registration and create_worker fails closed on this flag.
-    if canonical_layout and not is_parallelism_agnostic:
+    # Direct pages concatenate each worker's layers before the next worker,
+    # so changing TP changes the byte layout even with head-sharded attention.
+    is_parallelism_agnostic = False
+    # Canonical mappings are also certified per layer at worker registration.
+    if canonical_layout:
         tp_size = parallel_config.tensor_parallel_size
         total_kv_heads = vllm_config.model_config.get_total_num_kv_heads()
 


### PR DESCRIPTION
## Purpose

Prevent silent KV corruption when the native filesystem offload cache is reused after changing tensor-parallel size.

With model runner V1, multiple full-attention layers, KV heads partitioned across workers, and default `canonical_layout=False`, direct storage concatenates each worker's local layers. Changing TP changes those byte offsets, but `is_parallelism_agnostic` currently causes both runs to use the same filenames. Equal-sized reads succeed while returning another layer's/head's values.

Only certified canonical layouts now set `is_parallelism_agnostic`. Direct storage keeps topology-specific filenames; the separate replicated-MLA exception remains intact. The regression covers TP1/TP2 with canonical layout disabled and enabled.

### Duplicate checks

Checked against upstream `b7624069ff023043b39ba4ea67ae5f6045556819` on 2026-09-03. Open-PR searches covered `offload canonical`, `offload parallelism`, and `48414 in:body`, in addition to earlier issue/PR searches for the specific failure.

Inspected #53544 (packed mapping optimization), #51691 (canonical quantization support), and #50653 (PP capacity); none fixes this default-direct-layout predicate. Merged #48414 provides opt-in canonical storage, and #49440 separates model runners, leaving this case unchanged.

## Test Plan

```sh
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_config.py tests/v1/kv_offload/test_file_mapper.py -q
```

For model validation, populate a filesystem secondary tier using `TieringOffloadingSpec`, V1, and direct layout at TP1; request the same prompts at TP2 using the same root, then repeat in reverse. Compare with offload disabled. Include same-TP and canonical-layout controls.

## Test Result

- The native configuration and FileMapper suites passed all 67 tests on CPU after rebasing onto `2a336d8239`.
- The CPU reproduction uses actual KV views, offload registration, copy descriptors, filenames, and filesystem I/O. Before the fix, both cross-TP directions loaded successfully but produced **16,384 wrong FP16 elements**; same-TP controls had zero mismatches. With the fix, cross-TP filenames differ and same-TP controls remain correct. CPU memory copying substitutes for CUDA DMA in this reproduction.
- All applicable changed-file pre-commit hooks passed with `--hook-stage manual`, including mypy for Python 3.10, 3.11, 3.12, and 3.13. `git diff --check` passed.
- The earlier dependency and hook-bootstrap failures are resolved. Upstream CI is still stopped at its contributor authorization check, before pre-commit executes.
- GPU/model evaluation remains pending because this host has no GPU. Native CPU tests and the copy reproduction do not replace model-level validation.

## Downsides

Existing direct-layout persistent caches become cold because their namespace changes. This prevents reads from old files whose producer topology is ambiguous. Canonical and replicated namespaces retain their existing behavior; no cache files are deleted.

## Risk and rollback

Watch cache hit rate, recomputation, and latency. Disable the filesystem tier or use a separate root for each topology as an operational fallback. Reverting restores the ambiguous namespace, so isolate or clear the relevant cache before reverting.

## AI assistance

AI assistance was used for investigation, implementation, tests, and review, including vega-alpha subagents. Native regressions pass; GPU/model evaluations remain pending as listed above.
