### PR TITLE
[Bugfix][Pooling] Clear V1 pooling state after preemption

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -29,8 +29,10 @@ from vllm.lora.layers import LoRAMappingType
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+from vllm.model_executor.layers.pooler.tokwise.methods import AllPool
 from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
 from vllm.platforms import current_platform
+from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.system_utils import update_environment_variables
@@ -586,6 +588,52 @@ def test_update_states_request_resumed(model_runner, dist_init):
     assert _is_req_added(model_runner, req_id)
     assert _is_req_scheduled(model_runner, req_id)
     assert _is_req_state_block_table_match(model_runner, req_id)
+
+
+@pytest.mark.parametrize("preempted", [False, True])
+def test_token_pooling_after_request_resumes(model_runner, dist_init, preempted):
+    """Preserve paused chunks, but discard chunks that preemption recomputes."""
+    req_id = "req_0"
+    pooler = AllPool()
+    model_runner.model = SimpleNamespace(pooler=pooler)
+    model_runner.is_pooling_model = True
+    model_runner.input_batch.is_pooling_model = True
+    hidden_states = torch.tensor([[1.0], [2.0], [3.0]], device=model_runner.device)
+
+    def pool_chunk(hidden_chunk, seq_len):
+        metadata = model_runner.input_batch.get_pooling_metadata()
+        metadata.build_pooling_cursor(
+            np.array([len(hidden_chunk)], dtype=np.int32),
+            torch.tensor([seq_len], dtype=torch.int32),
+            device=hidden_chunk.device,
+        )
+        return pooler(hidden_chunk, metadata)[0]
+
+    scheduler_output = _schedule_new_request(req_id)
+    new_req = scheduler_output.scheduled_new_reqs[0]
+    new_req.sampling_params = None
+    new_req.pooling_params = PoolingParams(task="token_embed")
+    scheduler_output.num_scheduled_tokens[req_id] = 2
+    scheduler_output.total_num_scheduled_tokens = 2
+    model_runner._update_states(scheduler_output)
+    assert pool_chunk(hidden_states[:2], seq_len=2) is None
+
+    model_runner._update_states(_schedule_new_request())
+    start = 0 if preempted else 2
+    scheduler_output = _schedule_cached_requests(
+        [req_id],
+        num_scheduled_tokens={req_id: len(hidden_states) - start},
+        new_token_ids=[[]],
+        num_computed_tokens=[start],
+        num_output_tokens=[0],
+    )
+    if preempted:
+        scheduler_output.scheduled_cached_reqs.resumed_req_ids = {req_id}
+        scheduler_output.scheduled_cached_reqs.new_block_ids = [([1],)]
+    model_runner._update_states(scheduler_output)
+
+    output = pool_chunk(hidden_states[start:], seq_len=len(hidden_states))
+    torch.testing.assert_close(output, hidden_states)
 
 
 def test_get_nans_in_logits(model_runner, dist_init, monkeypatch):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1462,6 +1462,8 @@ class GPUModelRunner(
                 # The request is resumed from preemption.
                 # Replace the existing block IDs with the new ones.
                 req_state.block_ids = new_block_ids
+                if req_state.pooling_states is not None:
+                    req_state.pooling_states.clean()
 
             if req_index is None:
                 # The request is not in the persistent batch.


### PR DESCRIPTION
## Purpose

Fix duplicated token embeddings/classifications when a chunked pooling request is preempted in model runner V1.

Preemption resets the scheduler's computed-token count and recomputes the prompt, but the worker retains partial `PoolingStates`. `AllPool` then concatenates old chunks with recomputed tokens. Clear that state on the existing preemption-resume branch, while preserving chunks across ordinary scheduling pauses.

The regression uses the existing worker/scheduler fixtures and checks exact ordered token outputs in both cases. V2 already clears this state on removal.

### Duplicate checks

Checked against upstream `b7624069ff023043b39ba4ea67ae5f6045556819` on 2026-09-03. Read #26839 and its comments, and searched open PRs for `26839 in:body`, `pooling preemption`, and `pooling states`, in addition to earlier specific issue/PR searches.

#26839 concerns cross-request hidden-state caching. Inspected open #49107 (token-ID flags during reordering) and #48214 (input-buffer synchronization); neither resets partial pooling output after preemption. No matching open fix was found.

## Test Plan

```sh
.venv/bin/python -m pytest tests/v1/worker/test_gpu_model_runner.py -k test_token_pooling_after_request_resumes -q
```

For model validation, run a causal token embedding model with V1 and chunked prefill, then submit concurrent long prompts under a KV budget that causes preemption after a partial chunk. Compare output lengths, embeddings, and query-side MaxSim with an unconstrained baseline. Example setup to adapt to the evaluation GPU:

```sh
VLLM_USE_V2_MODEL_RUNNER=0 vllm serve Qwen/Qwen3-Embedding-0.6B \
  --runner pooling --pooler-config.task token_embed \
  --enable-chunked-prefill --max-num-batched-tokens 256 \
  --max-model-len 4096 --enforce-eager
```

## Test Result

- Both native regression cases passed after rebasing onto `2a336d8239`: preemption recomputes the correct token rows, and an ordinary scheduling pause preserves existing chunks. The tests used the existing model-runner fixture with `VLLM_TARGET_DEVICE=cpu`, a cached public OPT configuration, and local Gloo communication. No model weights were downloaded.
- The CPU source reproduction also passed. Before the fix, preemption returned `[1,2,1,2,3,4]` instead of `[1,2,3,4]`, with a query-side MaxSim score of **13 instead of 10**. With the fix, it returns four rows and score 10. The ordinary-pause control remains correct.
- All applicable changed-file pre-commit hooks passed with `--hook-stage manual`, including mypy for Python 3.10, 3.11, 3.12, and 3.13. `git diff --check` passed.
- The earlier dependency and hook-bootstrap failures are resolved. Upstream CI is still stopped at its contributor authorization check, before pre-commit executes.
- GPU/model evaluation remains pending because this host has no GPU. The CPU regression is not a model inference evaluation.

## Risk and rollback

The reset only applies to requests explicitly marked as resumed from preemption. Monitor token-output lengths and embedding equality under preemption. Reverting restores the duplication bug; V2, which already clears this state, provides an operational alternative where supported.

## AI assistance

AI assistance was used for investigation, implementation, tests, and review, including vega-alpha subagents. Native regressions pass; GPU/model evaluations remain pending as listed above.
