### PR TITLE
[WIP][Qwen3.8-Flash-Next] Enable breakable CUDA graphs without torch.compile

### DIFF
--- a/tests/models/qwen4_exp/test_hc_ops.py
+++ b/tests/models/qwen4_exp/test_hc_ops.py
@@ -4,11 +4,15 @@
 import pytest
 import torch
 
+from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
 from vllm.models.qwen4_exp.nvidia.ops.hc import (
     grouped_gemma_rmsnorm,
     hc_combine,
     hc_combine_norm,
     hc_gate_mix,
+)
+from vllm.models.qwen4_exp.nvidia.ops.moe import (
+    finalize_moe_with_shared,
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
@@ -92,3 +96,57 @@ def test_hc_combine_norm() -> None:
 
     torch.testing.assert_close(actual, expected)
     torch.testing.assert_close(actual_norm, expected_norm.to(torch.bfloat16))
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 16])
+@pytest.mark.parametrize("defer_shared_gate", [False, True])
+def test_finalize_moe_with_shared(
+    num_tokens: int,
+    defer_shared_gate: bool,
+) -> None:
+    torch.manual_seed(0)
+    top_k = 10
+    num_permuted = num_tokens * top_k + 7
+    gemm2 = torch.randn(
+        num_permuted,
+        HIDDEN_SIZE,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    weights = torch.rand(
+        num_tokens,
+        top_k,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    indices = torch.randperm(num_permuted, device="cuda")[: num_tokens * top_k]
+    indices = indices.to(torch.int32).view(num_tokens, top_k)
+    indices[:, -1] = -1
+    shared = torch.randn(
+        num_tokens,
+        HIDDEN_SIZE,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    shared_gate_logits = (
+        torch.randn(num_tokens, 1, dtype=torch.bfloat16, device="cuda")
+        if defer_shared_gate
+        else None
+    )
+    routed = UnfinalizedMoEOutput(gemm2, weights, indices)
+
+    actual = finalize_moe_with_shared(routed, shared, shared_gate_logits)
+
+    expected_routed = torch.zeros_like(shared, dtype=torch.float32)
+    for slot in range(top_k):
+        valid = indices[:, slot] >= 0
+        expected_routed[valid] += (
+            gemm2[indices[valid, slot].long()].float()
+            * weights[valid, slot, None].float()
+        )
+    expected_routed = expected_routed.to(torch.bfloat16)
+    expected_shared = shared
+    if shared_gate_logits is not None:
+        expected_shared = torch.sigmoid(shared_gate_logits) * expected_shared
+    expected = (expected_routed.float() + expected_shared.float()).to(torch.bfloat16)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -1236,6 +1236,12 @@ def test_fused_conv_correctness(
         dtype=torch.bfloat16,
         generator=rng,
     )
+    outer_residual = torch.randn(
+        inputs.shape,
+        device=device,
+        dtype=torch.bfloat16,
+        generator=rng,
+    )
     null_state = conv_state[NULL_BLOCK_ID].clone()
     residual_kernel = residual.clone()
     residual_reference = residual.clone()
@@ -1243,6 +1249,7 @@ def test_fused_conv_correctness(
     module._short_conv_dilated_dispatch(
         inputs=inputs,
         residual=residual_kernel,
+        outer_residual=outer_residual,
         metadata=metadata,
         conv_state=conv_state,
         conv_weights=weights,
@@ -1256,6 +1263,7 @@ def test_fused_conv_correctness(
         conv_state_len=module.conv_state_len,
         dilation=module.short_conv_dilation,
     )
+    residual_reference = outer_residual + residual_reference
 
     torch.testing.assert_close(
         residual_kernel.float(), residual_reference.float(), atol=3e-2, rtol=3e-2
@@ -1264,7 +1272,8 @@ def test_fused_conv_correctness(
     assert torch.equal(conv_state[NULL_BLOCK_ID], null_state)
     if case.graph_padding:
         assert torch.equal(
-            residual_kernel[num_real_tokens:], residual[num_real_tokens:]
+            residual_kernel[num_real_tokens:],
+            (outer_residual + residual)[num_real_tokens:],
         )
 
 

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -790,6 +790,7 @@ def test_qsa_sparse_paged_attention_correctness(
     q = torch.randn(
         num_rows, num_query_heads, head_dim, device="cuda", dtype=torch.bfloat16
     )
+    output_gate = torch.randn_like(q)
     kv_cache = torch.randn(
         num_cache_blocks,
         page_size,
@@ -857,6 +858,7 @@ def test_qsa_sparse_paged_attention_correctness(
         logical_indices,
         block_table,
         token_to_req,
+        output_gate=output_gate,
     )
     expected = _qsa_sparse_paged_attention_reference(
         q,
@@ -867,6 +869,7 @@ def test_qsa_sparse_paged_attention_correctness(
         token_to_req,
         scale,
     )
+    expected = expected * torch.sigmoid(output_gate)
 
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+    triton_scalar_specialization_rep,
+)
 from vllm.models.qwen4_exp.common import qsa_cache
 from vllm.models.qwen4_exp.common.qsa_cache import QSAMetadataBuilder
 from vllm.models.qwen4_exp.nvidia import indexer_qsa
@@ -22,6 +25,44 @@ requires_qsa_kernels = pytest.mark.skipif(
     not current_platform.is_cuda() or not HAS_TRITON,
     reason="QSA kernels require CUDA and Triton",
 )
+
+
+def test_qsa_sparse_attention_warmup_profiles_cover_dispatches() -> None:
+    max_num_rows = 1024
+    num_kv_heads = 2
+    group_size = 4
+    selection_width = 2048
+    profiles = qsa_ops._qsa_sparse_attention_warmup_profiles(
+        max_num_rows,
+        num_kv_heads,
+        group_size,
+        selection_width,
+    )
+    profile_keys = {
+        (
+            *qsa_ops._qsa_sparse_attention_launch_config(
+                num_rows,
+                num_kv_heads,
+                group_size,
+                selection_width,
+            ),
+            triton_scalar_specialization_rep(num_rows),
+        )
+        for num_rows in profiles
+    }
+
+    for num_rows in range(1, max_num_rows + 1):
+        key = (
+            *qsa_ops._qsa_sparse_attention_launch_config(
+                num_rows,
+                num_kv_heads,
+                group_size,
+                selection_width,
+            ),
+            triton_scalar_specialization_rep(num_rows),
+        )
+        assert key in profile_keys
+    assert len(profiles) < 16
 
 
 def test_qsa_mtp_index_share_updates_cache_but_skips_selection(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -338,9 +338,15 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
         ("DeepseekV32MTPModel", True, False),
         ("GlmMoeDsaForCausalLM", False, True),
         ("GlmMoeDsaForCausalLM", True, False),
+        ("Qwen4ExpForCausalLM", False, True),
+        ("Qwen4ExpForCausalLM", True, False),
+        ("Qwen4ExpForConditionalGeneration", False, True),
+        ("Qwen4ExpForConditionalGeneration", True, False),
+        ("Qwen4ExpMTP", False, True),
+        ("Qwen4ExpMTP", True, False),
     ],
 )
-def test_dsa_breakable_cudagraph_platform_default(
+def test_breakable_cudagraph_platform_default(
     monkeypatch, architecture, is_rocm, expected
 ):
     from vllm.config.vllm import default_breakable_cudagraph_architectures

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -91,6 +91,9 @@ DEFAULT_BREAKABLE_CUDAGRAPH_ARCHITECTURES = frozenset(
         "KimiLinearForCausalLM",
         "MiniMaxM3SparseForCausalLM",
         "MiniMaxM3SparseForConditionalGeneration",
+        "Qwen4ExpForCausalLM",
+        "Qwen4ExpForConditionalGeneration",
+        "Qwen4ExpMTP",
     }
 )
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1323,6 +1323,9 @@ class FusedMoEConfig:
     defer_moe_finalize: bool = False
     # Optional consumer capacity for deferred finalize. Negative means unbounded.
     defer_moe_finalize_max_num_tokens: int = -1
+    # Expert-parallel consumers must explicitly opt in after handling the local
+    # top-k finalize before the cross-rank reduction.
+    defer_moe_finalize_allow_ep: bool = False
 
     # SwiGLU clamp limit. When set, backends that do not implement the clamp
     # are filtered out by `FusedMoEExperts.is_supported_config` so the oracle
@@ -1453,9 +1456,9 @@ class FusedMoEConfig:
         # combine or reduce-scatter after the experts and cannot defer it.
         return (
             self.defer_moe_finalize
-            and self.tp_size > 1
+            and (self.tp_size > 1 or self.ep_size > 1)
             and self.dp_size == 1
-            and self.ep_size == 1
+            and (self.ep_size == 1 or self.defer_moe_finalize_allow_ep)
             and self.pcp_size == 1
             and not self.is_sequence_parallel
         )

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -12,6 +12,7 @@ from torch import nn
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
@@ -1909,6 +1910,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
 
 
+@eager_break_during_capture
 def qwen_gdn_attention_core(
     qkv_or_qkvz: torch.Tensor,
     b_or_ba: torch.Tensor,
@@ -1969,6 +1971,7 @@ direct_register_custom_op(
 )
 
 
+@eager_break_during_capture
 def qwen_gdn_attention_core_fused_norm_packed(
     mixed_qkvz: torch.Tensor,
     ba: torch.Tensor,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -126,7 +126,13 @@ def _should_replicate_misaligned_shared_expert(
 
 
 class Qwen3NextSparseMoeBlock(nn.Module):
-    def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        runner_cls=None,
+        shared_expert_cls=Qwen3NextMLP,
+    ):
         super().__init__()
 
         config = vllm_config.model_config.hf_text_config
@@ -200,7 +206,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         ):
             self.shared_expert = None
         else:
-            self.shared_expert = Qwen3NextMLP(
+            self.shared_expert = shared_expert_cls(
                 hidden_size=config.hidden_size,
                 intermediate_size=config.shared_expert_intermediate_size,
                 hidden_act=config.hidden_act,
@@ -232,6 +238,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             shared_expert_gate=self.shared_expert_gate
             if self.shared_expert is None
             else None,
+            runner_cls=runner_cls,
         )
 
     def forward(

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -272,13 +272,31 @@ _FLASHINFER_BF16_AUTOTUNE_MAX_TOKENS = 32
 
 def _flashinfer_autotune_token_counts(runner: "GPUModelRunner") -> tuple[int, ...]:
     max_tokens = runner.scheduler_config.max_num_batched_tokens
+    token_counts = [max_tokens]
     linear_backend = runner.vllm_config.kernel_config.linear_backend
     if (
         linear_backend == "flashinfer_cutedsl"
         and max_tokens > _FLASHINFER_BF16_AUTOTUNE_MAX_TOKENS
     ):
-        return max_tokens, _FLASHINFER_BF16_AUTOTUNE_MAX_TOKENS
-    return (max_tokens,)
+        token_counts.append(_FLASHINFER_BF16_AUTOTUNE_MAX_TOKENS)
+
+    deferred_moe_max_tokens = max(
+        (
+            module.moe_config.defer_moe_finalize_max_num_tokens
+            for module in runner.get_model().modules()
+            if getattr(getattr(module, "moe_config", None), "defer_moe_finalize", False)
+        ),
+        default=-1,
+    )
+    if deferred_moe_max_tokens > 0:
+        capture_sizes = (
+            runner.vllm_config.compilation_config.cudagraph_capture_sizes or []
+        )
+        token_counts.extend(
+            size for size in capture_sizes if 0 < size <= deferred_moe_max_tokens
+        )
+
+    return tuple(dict.fromkeys(token_counts))
 
 
 def _run_flashinfer_autotune_dummy_runs(runner: "GPUModelRunner") -> None:

--- a/vllm/model_executor/warmup/qwen4_exp_qsa_warmup.py
+++ b/vllm/model_executor/warmup/qwen4_exp_qsa_warmup.py
@@ -5,6 +5,8 @@
 import sys
 from typing import TYPE_CHECKING, cast
 
+import torch
+
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -14,8 +16,67 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _warmup_qwen4_exp_ple(worker: "Worker") -> None:
+    ple_module = sys.modules.get("vllm.models.qwen4_exp.nvidia.ple_layer")
+    if ple_module is None:
+        return
+    ple = next(
+        (
+            layer
+            for layer in worker.get_model().modules()
+            if isinstance(layer, ple_module.Qwen4ExpPLELayer)
+        ),
+        None,
+    )
+    if ple is None:
+        return
+
+    from vllm.model_executor.layers.mamba.mamba_utils import (
+        is_conv_state_dim_first,
+    )
+    from vllm.models.qwen4_exp.nvidia.ops.ple import ple_conv
+
+    conv_state = ple.kv_cache[0]
+    if not is_conv_state_dim_first():
+        conv_state = conv_state.transpose(-1, -2)
+    state_width = ple.conv_state_len + ple.num_spec_tokens
+    conv_state = torch.empty_strided(
+        (1, ple.hc_hidden_size, state_width),
+        conv_state.stride(),
+        dtype=conv_state.dtype,
+        device=conv_state.device,
+    )
+    inputs = torch.empty(
+        (2, ple.hc_hidden_size),
+        dtype=ple.model_config.dtype,
+        device=conv_state.device,
+    )
+    residual = torch.empty_like(inputs)
+    outer_residual = torch.empty_like(inputs)
+    # Runtime state indices are a tail slice, while the query-start tensor is
+    # aligned for a pure-prefill batch. Reproduce both pointer cache-key classes.
+    state_indices_storage = torch.zeros(2, dtype=torch.int32, device=conv_state.device)
+    state_indices = state_indices_storage[1:]
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=conv_state.device)
+    has_initial_states = torch.ones(1, dtype=torch.bool, device=conv_state.device)
+    ple_conv(
+        inputs,
+        residual,
+        conv_state,
+        ple.conv1d.weight.squeeze(1).to(dtype=inputs.dtype),
+        state_indices,
+        outer_residual,
+        mode="prefill",
+        dilation=ple.short_conv_dilation,
+        query_start_loc=query_start_loc,
+        has_initial_states=has_initial_states,
+    )
+    logger.info("Warmed up Qwen4Exp PLE prefill short-convolution kernels.")
+
+
+@torch.inference_mode()
 def qwen4_exp_qsa_triton_warmup(worker: "Worker") -> None:
-    """Warm every reachable QSA decode-query-length specialization."""
+    """Warm every reachable QSA indexer and sparse-attention specialization."""
 
     qsa_module = sys.modules.get("vllm.models.qwen4_exp.nvidia.indexer_qsa")
     if qsa_module is None:
@@ -50,6 +111,7 @@ def qwen4_exp_qsa_triton_warmup(worker: "Worker") -> None:
 
     from vllm.models.qwen4_exp.nvidia.ops.qsa_indexer import (
         warmup_qsa_mqa_paged_decode,
+        warmup_qsa_mqa_paged_prefill,
     )
 
     k_cache = indexer.compressed_key_cache.kv_cache
@@ -64,3 +126,61 @@ def qwen4_exp_qsa_triton_warmup(worker: "Worker") -> None:
         max_num_batched_tokens=runner.max_num_tokens,
     )
     logger.info("Warmed up Qwen4Exp QSA decode kernels: %s.", profiles)
+    warmup_qsa_mqa_paged_prefill(
+        k_cache,
+        block_table,
+        num_heads=indexer.index_n_heads,
+        head_dim=indexer.index_head_dim,
+    )
+    logger.info("Warmed up Qwen4Exp QSA prefill scorer.")
+
+    qsa_attention_module = sys.modules.get("vllm.models.qwen4_exp.nvidia.qsa")
+    if qsa_attention_module is None:
+        return
+    attention = next(
+        (
+            layer
+            for layer in worker.get_model().modules()
+            if isinstance(layer, qsa_attention_module.Qwen4ExpQSAAttention)
+        ),
+        None,
+    )
+    if attention is None:
+        return
+
+    attention_group_id = next(
+        i
+        for i, group in enumerate(runner.kv_cache_config.kv_cache_groups)
+        if attention.layer_name in group.layer_names
+    )
+    if worker.use_v2_model_runner:
+        attention_block_table = runner_v2.block_tables.input_block_tables[
+            attention_group_id
+        ]
+    else:
+        attention_block_table = runner.input_batch.block_table[
+            attention_group_id
+        ].get_device_tensor(runner.max_num_reqs)
+
+    from vllm.models.qwen4_exp.nvidia.ops.qsa import (
+        warmup_qsa_sparse_paged_attention,
+    )
+
+    key_cache, value_cache = attention.kv_cache.transpose(1, 2).split(
+        attention.head_dim, dim=-1
+    )
+    attention_profiles = warmup_qsa_sparse_paged_attention(
+        key_cache,
+        value_cache,
+        attention_block_table,
+        num_query_heads=attention.num_heads,
+        head_dim=attention.head_dim,
+        selection_width=attention.indexer.output_width,
+        max_num_batched_tokens=runner.max_num_tokens,
+        has_output_gate=attention.attn_output_gate,
+    )
+    logger.info(
+        "Warmed up Qwen4Exp QSA sparse-attention kernels for row counts: %s.",
+        attention_profiles,
+    )
+    _warmup_qwen4_exp_ple(worker)

--- a/vllm/model_executor/warmup/qwen_triton_warmup.py
+++ b/vllm/model_executor/warmup/qwen_triton_warmup.py
@@ -22,6 +22,7 @@ _QWEN_MODEL_TYPES = frozenset(
         "qwen3_5_text",
         "qwen3_5_moe",
         "qwen3_5_moe_text",
+        "qwen4_exp_text",
     }
 )
 
@@ -215,21 +216,30 @@ def _warm_fused_post_conv_kernel(
         conv_output = torch.empty(
             (length, qkv_dim), dtype=config.conv_dtype, device=device
         )
-        a = torch.empty((length, config.hv), dtype=config.conv_dtype, device=device)
-        b = torch.empty_like(a)
-
-        fused_post_conv_prep(
-            conv_output,
-            a,
-            b,
-            config.a_log,
-            config.dt_bias,
-            config.h,
-            config.k,
-            config.v,
-            apply_l2norm=True,
-            output_g_exp=False,
+        aligned_a = torch.empty(
+            (length, config.hv), dtype=config.conv_dtype, device=device
         )
+        aligned_b = torch.empty_like(aligned_a)
+        a_storage = torch.empty(
+            length * config.hv + 1, dtype=config.conv_dtype, device=device
+        )
+        b_storage = torch.empty_like(a_storage)
+        unaligned_a = a_storage[1:].view(length, config.hv)
+        unaligned_b = b_storage[1:].view(length, config.hv)
+
+        for a, b in ((aligned_a, aligned_b), (unaligned_a, unaligned_b)):
+            fused_post_conv_prep(
+                conv_output,
+                a,
+                b,
+                config.a_log,
+                config.dt_bias,
+                config.h,
+                config.k,
+                config.v,
+                apply_l2norm=True,
+                output_g_exp=False,
+            )
 
 
 def _warm_fused_sigmoid_gating_delta_rule_update_kernel(

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -8,7 +8,6 @@ from itertools import islice
 import torch
 from torch import nn
 
-from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
 from vllm.model_executor.layers.fused_moe.utils import (
@@ -296,7 +295,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
 
             if input_ids is None or query_start_loc is None or ngram_context is None:
                 raise RuntimeError("PLE inputs were not prepared")
-            hidden_states = hidden_states + self.ple(
+            hidden_states = self.ple(
                 hidden_states,
                 input_ids,
                 query_start_loc,
@@ -379,17 +378,6 @@ class Qwen4ExpMixtureOfExperts(MixtureOfExperts):
             moe.experts.update_expert_map()
 
 
-@support_torch_compile(
-    dynamic_arg_dims={
-        "input_ids": 0,
-        "positions": -1,
-        "intermediate_tensors": 0,
-        "inputs_embeds": 0,
-        "query_start_loc": 0,
-        "ngram_context": 0,
-        "deepstack_input_embeds": 0,
-    }
-)
 class Qwen4ExpModel(nn.Module):
     hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _EXTRA_WEIGHTS_MAPPER
 

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -78,6 +78,7 @@ from vllm.v1.kv_cache_interface import MambaSpec
 from ..config import Qwen4ExpConfig
 from .hyperconnection import GatedResidual, HyperConnectionConfig
 from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .moe import Qwen4ExpMoERunner
 from .ple_layer import Qwen4ExpPLELayer
 from .qsa import Qwen4ExpQSAAttention
 
@@ -140,6 +141,7 @@ _QWEN4_EXP_IGNORED_MISSING_SUFFIXES = [
     "_input_scale",
 ]
 
+
 # The checkpoint stores these projections separately; runtime packs each group
 # into adjacent logical shards of a MergedColumnParallelLinear.
 _EXTRA_WEIGHTS_MAPPER = WeightsMapper(
@@ -158,6 +160,39 @@ _EXTRA_WEIGHTS_MAPPER = WeightsMapper(
 )
 
 
+class Qwen4ExpSharedMLP(Qwen3NextMLP):
+    """Shared MLP that can defer its scalar gate to the MoE tail."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._defer_gate_max_num_tokens = 0
+        self._deferred_gate_logits: torch.Tensor | None = None
+
+    def enable_deferred_gate(self, max_num_tokens: int) -> None:
+        self._defer_gate_max_num_tokens = max_num_tokens
+
+    @property
+    def deferred_gate_logits(self) -> torch.Tensor | None:
+        return self._deferred_gate_logits
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(x)
+        out = self.act_fn(gate_up)
+        out, _ = self.down_proj(out)
+
+        if self.expert_gate is None:
+            self._deferred_gate_logits = None
+            return out
+
+        gate_logits, _ = self.expert_gate(x)
+        if x.shape[0] <= self._defer_gate_max_num_tokens:
+            self._deferred_gate_logits = gate_logits
+            return out
+
+        self._deferred_gate_logits = None
+        return torch.sigmoid(gate_logits) * out
+
+
 class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
     """Qwen3Next MoE with Qwen4Exp HC validation."""
 
@@ -167,7 +202,12 @@ class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
             raise NotImplementedError(
                 "Qwen4Exp HC does not support sequence-parallel MoE"
             )
-        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        super().__init__(
+            vllm_config=vllm_config,
+            prefix=prefix,
+            runner_cls=Qwen4ExpMoERunner,
+            shared_expert_cls=Qwen4ExpSharedMLP,
+        )
         config = vllm_config.model_config.hf_text_config
         self.n_shared_experts = int(config.shared_expert_intermediate_size > 0)
 
@@ -295,7 +335,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
 
             if input_ids is None or query_start_loc is None or ngram_context is None:
                 raise RuntimeError("PLE inputs were not prepared")
-            hidden_states = self.ple(
+            hidden_states = hidden_states + self.ple(
                 hidden_states,
                 input_ids,
                 query_start_loc,

--- a/vllm/models/qwen4_exp/nvidia/moe.py
+++ b/vllm/models/qwen4_exp/nvidia/moe.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp-specific MoE execution."""
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.experts.trtllm_bf16_moe import (
+    TrtLlmBf16ExpertsMonolithic,
+)
+from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import (
+    MoERunner,
+    _unpack,
+)
+from vllm.platforms import current_platform
+
+from .ops.moe import finalize_moe_with_shared
+
+_MAX_DEFERRED_TOKENS = 128
+logger = init_logger(__name__)
+
+
+class Qwen4ExpMoERunner(MoERunner):
+    """Fuse the BF16 MoE local finalize with the shared-expert add."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        experts_cls = getattr(self._quant_method, "experts_cls", None)
+        self._defer_finalize = (
+            current_platform.is_cuda()
+            and current_platform.is_device_capability_family(100)
+            and experts_cls is TrtLlmBf16ExpertsMonolithic
+            and self._shared_experts is not None
+            and not self._fused_output_is_reduced
+            and self.moe_config.dp_size == 1
+            and self.moe_config.pcp_size == 1
+            and not self.moe_config.is_sequence_parallel
+        )
+        logger.info_once(
+            "Qwen4Exp BF16 deferred MoE tail: enabled=%s experts=%s "
+            "shared=%s reduced=%s dp=%d ep=%d tp=%d pcp=%d sp=%s",
+            self._defer_finalize,
+            getattr(experts_cls, "__name__", experts_cls),
+            self._shared_experts is not None,
+            self._fused_output_is_reduced,
+            self.moe_config.dp_size,
+            self.moe_config.ep_size,
+            self.moe_config.tp_size,
+            self.moe_config.pcp_size,
+            self.moe_config.is_sequence_parallel,
+        )
+        if self._defer_finalize:
+            self.moe_config.defer_moe_finalize = True
+            self.moe_config.defer_moe_finalize_allow_ep = True
+            self.moe_config.defer_moe_finalize_max_num_tokens = _MAX_DEFERRED_TOKENS
+
+        shared_layer = (
+            self._shared_experts._layer if self._shared_experts is not None else None
+        )
+        self._defer_shared_gate = (
+            self._defer_finalize
+            and not self._shared_experts.enable_dbo
+            and hasattr(shared_layer, "enable_deferred_gate")
+        )
+        if self._defer_shared_gate:
+            shared_layer.enable_deferred_gate(_MAX_DEFERRED_TOKENS)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+        shared_experts_input: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not (
+            self._defer_finalize
+            and self.moe_config.should_defer_moe_finalize(hidden_states.shape[0])
+        ):
+            return super().forward(
+                hidden_states,
+                router_logits,
+                input_ids,
+                shared_experts_input,
+            )
+
+        if shared_experts_input is None:
+            hidden_states, shared_experts_input = self.apply_routed_input_transform(
+                hidden_states
+            )
+        hidden_states, pre_trunc, post_trunc = self._maybe_pad_hidden_states(
+            shared_experts_input,
+            hidden_states,
+        )
+        if pre_trunc is not None or post_trunc is not None:
+            return super().forward(
+                hidden_states,
+                router_logits,
+                input_ids,
+                shared_experts_input,
+            )
+
+        result = self._forward_impl(
+            hidden_states,
+            router_logits,
+            shared_experts_input,
+            input_ids,
+        )
+        shared_output, routed_output = _unpack(result)
+        assert shared_output is not None
+        assert isinstance(routed_output, UnfinalizedMoEOutput)
+        shared_gate_logits = None
+        if self._defer_shared_gate:
+            shared_gate_logits = self._shared_experts._layer.deferred_gate_logits
+            assert shared_gate_logits is not None
+        result = finalize_moe_with_shared(
+            routed_output,
+            shared_output,
+            shared_gate_logits,
+        )
+        result = self._maybe_reduce_final_output(
+            result,
+            trunc_size=None,
+            output_is_reduced=False,
+        )
+        return self._maybe_add_zero_expert_output(result)
+
+
+__all__ = ["Qwen4ExpMoERunner"]

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -19,7 +19,6 @@ import regex as re
 import torch
 from torch import nn
 
-from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig, replace, set_current_vllm_config
 from vllm.distributed import get_pp_group
 from vllm.model_executor.layers.fused_moe.utils import (
@@ -147,15 +146,6 @@ def _make_draft_vllm_config(
     return draft_vllm_config
 
 
-@support_torch_compile(
-    dynamic_arg_dims={
-        "input_ids": 0,
-        "positions": -1,
-        "intermediate_tensors": 0,
-        "inputs_embeds": 0,
-        "hidden_states": 0,
-    }
-)
 class Qwen4ExpMultiTokenPredictor(nn.Module):
     hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _EXTRA_WEIGHTS_MAPPER
 
@@ -356,15 +346,6 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
         return loader.load_weights(weights, mapper=mapper)
 
 
-@support_torch_compile(
-    dynamic_arg_dims={
-        "input_ids": 0,
-        "positions": -1,
-        "intermediate_tensors": 0,
-        "inputs_embeds": 0,
-        "hidden_states": 0,
-    }
-)
 class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],

--- a/vllm/models/qwen4_exp/nvidia/ops/moe.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/moe.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp MoE tail kernels."""
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+@triton.jit
+def _finalize_moe_with_shared_kernel(
+    gemm2_ptr,
+    expert_weights_ptr,
+    expanded_idx_ptr,
+    shared_ptr,
+    shared_gate_ptr,
+    output_ptr,
+    stride_gemm2,
+    stride_weights,
+    stride_indices,
+    stride_shared,
+    stride_shared_gate,
+    stride_output,
+    HIDDEN_SIZE: tl.constexpr,
+    TOP_K: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    token = tl.program_id(0)
+    tile = tl.program_id(1)
+    offsets = tile * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    hidden_mask = offsets < HIDDEN_SIZE
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    routed = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for slot in tl.static_range(TOP_K):
+        permuted_idx = tl.load(expanded_idx_ptr + token * stride_indices + slot)
+        route_mask = hidden_mask & (permuted_idx >= 0)
+        values = tl.load(
+            gemm2_ptr + permuted_idx * stride_gemm2 + offsets,
+            mask=route_mask,
+            other=0.0,
+        )
+        weight = tl.load(expert_weights_ptr + token * stride_weights + slot)
+        routed += values.to(tl.float32) * weight.to(tl.float32)
+
+    # Preserve the original FlashInfer finalize -> BF16 add boundary.
+    routed = routed.to(output_ptr.dtype.element_ty)
+    shared = tl.load(
+        shared_ptr + token * stride_shared + offsets,
+        mask=hidden_mask,
+        other=0.0,
+    )
+    if shared_gate_ptr is not None:
+        shared_gate = tl.load(shared_gate_ptr + token * stride_shared_gate)
+        shared_gate = tl.sigmoid(shared_gate.to(tl.float32)).to(
+            shared_ptr.dtype.element_ty
+        )
+        shared = (shared.to(tl.float32) * shared_gate.to(tl.float32)).to(
+            shared_ptr.dtype.element_ty
+        )
+    output = routed.to(tl.float32) + shared.to(tl.float32)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(
+        output_ptr + token * stride_output + offsets,
+        output,
+        mask=hidden_mask,
+    )
+
+
+def _finalize_moe_with_shared(
+    gemm2_permuted: torch.Tensor,
+    expert_weights: torch.Tensor,
+    expanded_idx: torch.Tensor,
+    shared_output: torch.Tensor,
+    shared_gate_logits: torch.Tensor | None,
+    top_k: int,
+) -> torch.Tensor:
+    num_tokens, hidden_size = shared_output.shape
+    assert gemm2_permuted.shape[1] == hidden_size
+    assert expert_weights.shape == (num_tokens, top_k)
+    assert expanded_idx.shape == (num_tokens, top_k)
+    assert gemm2_permuted.dtype == shared_output.dtype == torch.bfloat16
+    assert expert_weights.dtype == torch.bfloat16
+    assert expanded_idx.dtype == torch.int32
+    if shared_gate_logits is not None:
+        assert shared_gate_logits.shape == (num_tokens, 1)
+        assert shared_gate_logits.dtype == shared_output.dtype
+        assert shared_gate_logits.is_contiguous()
+    assert all(
+        tensor.is_contiguous()
+        for tensor in (
+            gemm2_permuted,
+            expert_weights,
+            expanded_idx,
+            shared_output,
+        )
+    )
+
+    output = torch.empty_like(shared_output)
+    block_size = 512
+    _finalize_moe_with_shared_kernel[
+        (num_tokens, triton.cdiv(hidden_size, block_size))
+    ](
+        gemm2_permuted,
+        expert_weights,
+        expanded_idx,
+        shared_output,
+        shared_gate_logits,
+        output,
+        gemm2_permuted.stride(0),
+        expert_weights.stride(0),
+        expanded_idx.stride(0),
+        shared_output.stride(0),
+        shared_gate_logits.stride(0) if shared_gate_logits is not None else 0,
+        output.stride(0),
+        HIDDEN_SIZE=hidden_size,
+        TOP_K=top_k,
+        BLOCK_SIZE=block_size,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return output
+
+
+def _finalize_moe_with_shared_fake(
+    gemm2_permuted: torch.Tensor,
+    expert_weights: torch.Tensor,
+    expanded_idx: torch.Tensor,
+    shared_output: torch.Tensor,
+    shared_gate_logits: torch.Tensor | None,
+    top_k: int,
+) -> torch.Tensor:
+    del gemm2_permuted, expert_weights, expanded_idx, shared_gate_logits, top_k
+    return torch.empty_like(shared_output)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_finalize_moe_with_shared",
+    op_func=_finalize_moe_with_shared,
+    fake_impl=_finalize_moe_with_shared_fake,
+)
+
+
+def finalize_moe_with_shared(
+    routed_output: UnfinalizedMoEOutput,
+    shared_output: torch.Tensor,
+    shared_gate_logits: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_finalize_moe_with_shared(
+        routed_output.gemm2_permuted,
+        routed_output.expert_weights,
+        routed_output.expanded_idx_to_permuted_idx,
+        shared_output,
+        shared_gate_logits,
+        routed_output.expert_weights.shape[1],
+    )
+
+
+__all__ = ["finalize_moe_with_shared"]

--- a/vllm/models/qwen4_exp/nvidia/ops/ple.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/ple.py
@@ -322,6 +322,7 @@ def _ple_conv_kernel(
     state_ptr,
     w_ptr,
     residual_ptr,
+    outer_residual_ptr,
     state_idx_ptr,
     qsl_ptr,
     num_acc_ptr,
@@ -441,11 +442,21 @@ def _ple_conv_kernel(
         mask=c_mask,
         other=0.0,
     )
+    # Preserve the original eager operation boundaries: short convolution is
+    # first accumulated into the BF16/FP16 PLE output, then the outer residual
+    # is added to that rounded value.
+    ple_output = (residual + conv_output).to(residual_ptr.dtype.element_ty)
+    outer_residual = tl.load(
+        outer_residual_ptr + output_t * C + c_offs,
+        mask=c_mask,
+        other=0.0,
+    )
+    ple_output = outer_residual + ple_output
     if launch_pdl:
         tl.extra.cuda.gdc_launch_dependents()
     tl.store(
         residual_ptr + output_t * C + c_offs,
-        residual + conv_output,
+        ple_output,
         mask=c_mask,
     )
 
@@ -562,6 +573,7 @@ def ple_conv(
     conv_state: torch.Tensor,
     conv_weights: torch.Tensor,
     state_indices: torch.Tensor,
+    outer_residual: torch.Tensor,
     *,
     mode: Literal["decode", "spec", "prefill"],
     dilation: int,
@@ -571,7 +583,7 @@ def ple_conv(
     spec_query_len: int = 1,
     token_indices: torch.Tensor | None = None,
 ) -> None:
-    """Add short-convolution output to ``residual`` and update its state."""
+    """Add short convolution and the outer residual; update state."""
     BLOCK_C = 512
     kernel_spec_query_len = spec_query_len if mode == "spec" else 1
     T, C = inputs.shape
@@ -620,6 +632,7 @@ def ple_conv(
         conv_state,
         conv_weights,
         residual,
+        outer_residual,
         state_indices,
         query_start_loc,
         num_accepted_tokens,

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -20,6 +20,7 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     partial_output_ptr,
     partial_lse_ptr,
     output_ptr,
+    output_gate_ptr,
     stride_q_row,
     stride_q_head,
     stride_k_block,
@@ -32,6 +33,8 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     stride_table_req,
     stride_output_row,
     stride_output_head,
+    stride_output_gate_row,
+    stride_output_gate_head,
     num_rows,
     num_cache_blocks,
     num_requests,
@@ -142,6 +145,21 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     )
     output_mask = head_offsets[:, None] < GROUP_SIZE
     if NUM_SPLITS == 1:
+        if output_gate_ptr is not None:
+            # Preserve the unfused path's BF16 attention-output rounding before
+            # applying the gate in FP32.
+            normalized_output = normalized_output.to(output_ptr.dtype.element_ty)
+            output_gate = tl.load(
+                output_gate_ptr
+                + row * stride_output_gate_row
+                + (first_head + head_offsets[:, None]) * stride_output_gate_head
+                + dim_offsets[None, :],
+                mask=output_mask,
+                other=0.0,
+            ).to(tl.float32)
+            normalized_output = normalized_output.to(tl.float32) * tl.sigmoid(
+                output_gate
+            )
         tl.store(
             output_ptr
             + row * stride_output_row
@@ -183,8 +201,11 @@ def _qsa_merge_splitk_kernel(
     partial_output_ptr,
     partial_lse_ptr,
     output_ptr,
+    output_gate_ptr,
     stride_output_row,
     stride_output_head,
+    stride_output_gate_row,
+    stride_output_gate_head,
     num_rows,
     HEAD_DIM: tl.constexpr,
     NUM_QUERY_HEADS: tl.constexpr,
@@ -216,6 +237,17 @@ def _qsa_merge_splitk_kernel(
     )
     merged = tl.sum(partial_output * weights[:, None], axis=0)
     merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    if output_gate_ptr is not None:
+        # Preserve the unfused path's BF16 attention-output rounding before
+        # applying the gate in FP32.
+        merged = merged.to(output_ptr.dtype.element_ty)
+        output_gate = tl.load(
+            output_gate_ptr
+            + row * stride_output_gate_row
+            + head * stride_output_gate_head
+            + dim_offsets
+        ).to(tl.float32)
+        merged = merged.to(tl.float32) * tl.sigmoid(output_gate)
     tl.store(
         output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
         merged,
@@ -416,6 +448,7 @@ def qsa_sparse_paged_attention(
     block_table: torch.Tensor,
     token_to_req: torch.Tensor,
     out: torch.Tensor | None = None,
+    output_gate: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run sparse GQA directly over paged BF16 K/V caches."""
 
@@ -450,6 +483,7 @@ def qsa_sparse_paged_attention(
         raise ValueError("QSA sparse output must match its query")
     assert out.dtype == q.dtype and out.device == q.device
     assert out.stride(2) == 1
+    output_gate_view = output_gate.view_as(q) if output_gate is not None else None
     if not q.shape[0]:
         return out
 
@@ -503,6 +537,7 @@ def qsa_sparse_paged_attention(
         partial_output,
         partial_lse,
         out,
+        output_gate_view,
         q.stride(0),
         q.stride(1),
         k_cache.stride(0),
@@ -515,6 +550,8 @@ def qsa_sparse_paged_attention(
         block_table.stride(0),
         out.stride(0),
         out.stride(1),
+        output_gate_view.stride(0) if output_gate_view is not None else 0,
+        output_gate_view.stride(1) if output_gate_view is not None else 0,
         q.shape[0],
         k_cache.shape[0],
         block_table.shape[0],
@@ -538,8 +575,11 @@ def qsa_sparse_paged_attention(
         partial_output,
         partial_lse,
         out,
+        output_gate_view,
         out.stride(0),
         out.stride(1),
+        output_gate_view.stride(0) if output_gate_view is not None else 0,
+        output_gate_view.stride(1) if output_gate_view is not None else 0,
         q.shape[0],
         HEAD_DIM=q.shape[2],
         NUM_QUERY_HEADS=q.shape[1],

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 import torch
 
+from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+    TritonWarmupTensor,
+    triton_scalar_specialization_rep,
+)
 from vllm.triton_utils import HAS_TRITON, tl, triton
 
 
@@ -440,6 +444,202 @@ def _compress_qsa_groups_kernel(
     )
 
 
+def _qsa_sparse_attention_launch_config(
+    num_rows: int,
+    num_kv_heads: int,
+    group_size: int,
+    selection_width: int,
+) -> tuple[int, int, int, int, int]:
+    block_m = triton.next_power_of_2(group_size)
+    base_programs = num_rows * num_kv_heads
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+
+    num_tiles = triton.cdiv(selection_width, block_n)
+    # Avoid empty splits when the selection width is smaller than the profile.
+    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
+    num_splits = min(max_useful_splits, target_splits)
+    return block_m, block_n, num_splits, num_tiles, partial_warps
+
+
+def _qsa_sparse_attention_warmup_profiles(
+    max_num_rows: int,
+    num_kv_heads: int,
+    group_size: int,
+    selection_width: int,
+) -> tuple[int, ...]:
+    """Pick one row count for every reachable Triton cache-key class."""
+
+    profiles: dict[tuple[int, ...], int] = {}
+    for num_rows in range(1, max_num_rows + 1):
+        launch_config = _qsa_sparse_attention_launch_config(
+            num_rows,
+            num_kv_heads,
+            group_size,
+            selection_width,
+        )
+        key = (*launch_config, triton_scalar_specialization_rep(num_rows))
+        profiles.setdefault(key, num_rows)
+    return tuple(profiles.values())
+
+
+def warmup_qsa_sparse_paged_attention(
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    *,
+    num_query_heads: int,
+    head_dim: int,
+    selection_width: int,
+    max_num_batched_tokens: int,
+    has_output_gate: bool,
+) -> tuple[tuple[int, int], ...]:
+    """Compile every reachable sparse-attention specialization without launch."""
+
+    num_kv_heads = k_cache.shape[2]
+    group_size = num_query_heads // num_kv_heads
+    profiles = _qsa_sparse_attention_warmup_profiles(
+        max_num_batched_tokens,
+        num_kv_heads,
+        group_size,
+        selection_width,
+    )
+    k_cache_ptr = TritonWarmupTensor(
+        k_cache.dtype,
+        shape=tuple(k_cache.shape),
+        strides=tuple(k_cache.stride()),
+    )
+    v_cache_ptr = TritonWarmupTensor(
+        v_cache.dtype,
+        shape=tuple(v_cache.shape),
+        strides=tuple(v_cache.stride()),
+    )
+    num_request_profiles: dict[int, int] = {}
+    for num_requests in range(1, block_table.shape[0] + 1):
+        key = triton_scalar_specialization_rep(num_requests)
+        num_request_profiles.setdefault(key, num_requests)
+
+    compiled_profiles: list[tuple[int, int]] = []
+    for num_rows in profiles:
+        block_m, block_n, num_splits, num_tiles, partial_warps = (
+            _qsa_sparse_attention_launch_config(
+                num_rows,
+                num_kv_heads,
+                group_size,
+                selection_width,
+            )
+        )
+        q_ptr = TritonWarmupTensor(
+            torch.bfloat16,
+            shape=(num_rows, num_query_heads, head_dim),
+        )
+        indices_ptr = TritonWarmupTensor(
+            torch.int32,
+            shape=(num_rows, selection_width),
+        )
+        token_to_req_ptr = TritonWarmupTensor(torch.int32, shape=(num_rows,))
+        output_ptr = TritonWarmupTensor(
+            torch.bfloat16,
+            shape=(num_rows, num_query_heads, head_dim),
+        )
+        output_gate_ptr = output_ptr if has_output_gate else None
+        if num_splits == 1:
+            partial_output_ptr = output_ptr
+            partial_lse_ptr = output_ptr
+        else:
+            partial_output_ptr = TritonWarmupTensor(
+                torch.float32,
+                shape=(num_splits, num_rows, num_query_heads, head_dim),
+            )
+            partial_lse_ptr = TritonWarmupTensor(
+                torch.float32,
+                shape=(num_splits, num_rows, num_query_heads),
+            )
+
+        for num_requests in num_request_profiles.values():
+            block_table_ptr = TritonWarmupTensor(
+                block_table.dtype,
+                shape=(num_requests, block_table.shape[1]),
+                strides=tuple(block_table.stride()),
+            )
+            _qsa_sparse_paged_gqa_splitk_kernel.warmup(
+                q_ptr,
+                k_cache_ptr,
+                v_cache_ptr,
+                indices_ptr,
+                block_table_ptr,
+                token_to_req_ptr,
+                partial_output_ptr,
+                partial_lse_ptr,
+                output_ptr,
+                output_gate_ptr,
+                q_ptr.stride(0),
+                q_ptr.stride(1),
+                k_cache.stride(0),
+                k_cache.stride(1),
+                k_cache.stride(2),
+                v_cache.stride(0),
+                v_cache.stride(1),
+                v_cache.stride(2),
+                indices_ptr.stride(0),
+                block_table.stride(0),
+                output_ptr.stride(0),
+                output_ptr.stride(1),
+                output_ptr.stride(0) if has_output_gate else 0,
+                output_ptr.stride(1) if has_output_gate else 0,
+                num_rows,
+                k_cache.shape[0],
+                num_requests,
+                TOPK=selection_width,
+                PAGE_SIZE=k_cache.shape[1],
+                PAGE_TABLE_WIDTH=block_table.shape[1],
+                GROUP_SIZE=group_size,
+                HEAD_DIM=head_dim,
+                NUM_QUERY_HEADS=num_query_heads,
+                NUM_SPLITS=num_splits,
+                NUM_TILES=num_tiles,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+                num_warps=partial_warps,
+                num_stages=2,
+                grid=(1,),
+            )
+            compiled_profiles.append((num_rows, num_requests))
+        if num_splits == 1:
+            continue
+        _qsa_merge_splitk_kernel.warmup(
+            partial_output_ptr,
+            partial_lse_ptr,
+            output_ptr,
+            output_gate_ptr,
+            output_ptr.stride(0),
+            output_ptr.stride(1),
+            output_ptr.stride(0) if has_output_gate else 0,
+            output_ptr.stride(1) if has_output_gate else 0,
+            num_rows,
+            HEAD_DIM=head_dim,
+            NUM_QUERY_HEADS=num_query_heads,
+            NUM_SPLITS=num_splits,
+            BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+            num_warps=2,
+            num_stages=1,
+            grid=(1,),
+        )
+    return tuple(compiled_profiles)
+
+
 def qsa_sparse_paged_attention(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -488,27 +688,14 @@ def qsa_sparse_paged_attention(
         return out
 
     group_size = q.shape[1] // k_cache.shape[2]
-    block_m = triton.next_power_of_2(group_size)
-    base_programs = q.shape[0] * k_cache.shape[2]
-    small_profile_limit = 8 if block_m <= 8 else 4
-
-    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
-    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
-    if base_programs <= small_profile_limit:
-        block_n, target_splits, partial_warps = 16, 64, 4
-    elif base_programs < 32:
-        block_n, target_splits, partial_warps = 16, 32, 4
-    elif base_programs <= 256:
-        block_n, target_splits, partial_warps = 64, 8, 2
-    elif base_programs <= 512:
-        block_n, target_splits, partial_warps = 64, 4, 2
-    else:
-        block_n, target_splits, partial_warps = 64, 1, 2
-
-    num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
-    # Avoid empty splits when the selection width is smaller than the profile.
-    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
-    num_splits = min(max_useful_splits, target_splits)
+    block_m, block_n, num_splits, num_tiles, partial_warps = (
+        _qsa_sparse_attention_launch_config(
+            q.shape[0],
+            k_cache.shape[2],
+            group_size,
+            logical_indices.shape[1],
+        )
+    )
 
     # Split=1 writes output directly and compiles out all workspace accesses.
     if num_splits == 1:

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -365,6 +365,68 @@ def warmup_qsa_mqa_paged_decode(
     return profiles
 
 
+def warmup_qsa_mqa_paged_prefill(
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    *,
+    num_heads: int,
+    head_dim: int,
+) -> None:
+    """Compile the shape-polymorphic QSA prefill scorer without launching it."""
+
+    num_rows = 2
+    columns = page_table.shape[1] * k_cache.shape[1]
+    q_ptr = TritonWarmupTensor(
+        torch.bfloat16,
+        shape=(num_rows, num_heads, head_dim),
+    )
+    k_cache_ptr = TritonWarmupTensor(
+        k_cache.dtype,
+        shape=tuple(k_cache.shape),
+        strides=tuple(k_cache.stride()),
+    )
+    page_table_ptr = TritonWarmupTensor(
+        page_table.dtype,
+        shape=(1, page_table.shape[1]),
+        strides=tuple(page_table.stride()),
+    )
+    # Packed prefill metadata is commonly a slice of a larger backing tensor.
+    query_start_loc_ptr = TritonWarmupTensor(torch.int32, aligned=False, shape=(2,))
+    visible_blocks_ptr = TritonWarmupTensor(
+        torch.int32, aligned=False, shape=(num_rows,)
+    )
+    logits_ptr = TritonWarmupTensor(
+        torch.float32,
+        shape=(num_rows, columns),
+    )
+    _qsa_mqa_paged_prefill_kernel.warmup(
+        q_ptr,
+        k_cache_ptr,
+        page_table_ptr,
+        query_start_loc_ptr,
+        visible_blocks_ptr,
+        logits_ptr,
+        q_ptr.stride(0),
+        q_ptr.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        page_table.stride(0),
+        logits_ptr.stride(0),
+        num_rows,
+        0,
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=num_heads,
+        HEAD_DIM=head_dim,
+        TILE_R=64,
+        BLOCK_N=64,
+        K_TILES=16,
+        STAGES=2,
+        num_warps=4,
+        grid=(1,),
+    )
+
+
 def _prefill_logits(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -614,4 +676,5 @@ __all__ = [
     "qsa_select_paged_decode",
     "qsa_select_paged_prefill",
     "warmup_qsa_mqa_paged_decode",
+    "warmup_qsa_mqa_paged_prefill",
 ]

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -644,6 +644,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         self,
         inputs: torch.Tensor,
         residual: torch.Tensor,
+        outer_residual: torch.Tensor,
         metadata: PleShortConvAttentionMetadata,
         conv_state: torch.Tensor,
         conv_weights: torch.Tensor,
@@ -658,6 +659,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         has_non_spec = has_prefill or has_decode
         inputs = inputs[: metadata.num_actual_tokens]
         residual = residual[: metadata.num_actual_tokens]
+        outer_residual = outer_residual[: metadata.num_actual_tokens]
 
         spec_token_indices = None
         non_spec_token_indices = None
@@ -684,6 +686,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 conv_state=conv_state,
                 conv_weights=conv_weights,
                 state_indices=spec_state_indices,
+                outer_residual=outer_residual,
                 mode="spec",
                 dilation=self.short_conv_dilation,
                 query_start_loc=query_start_loc,
@@ -708,11 +711,17 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 residual_d, residual_p = torch.split(
                     residual, [num_decode_tokens, num_prefill_tokens], dim=0
                 )
+                outer_residual_d, outer_residual_p = torch.split(
+                    outer_residual,
+                    [num_decode_tokens, num_prefill_tokens],
+                    dim=0,
+                )
                 token_indices_d = None
                 token_indices_p = None
             else:
                 inputs_d = inputs_p = inputs
                 residual_d = residual_p = residual
+                outer_residual_d = outer_residual_p = outer_residual
                 token_indices_d, token_indices_p = torch.split(
                     non_spec_token_indices,
                     [num_decode_tokens, num_prefill_tokens],
@@ -726,6 +735,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                     conv_state=conv_state,
                     conv_weights=conv_weights,
                     state_indices=state_indices_d,
+                    outer_residual=outer_residual_d,
                     mode="decode",
                     dilation=self.short_conv_dilation,
                     has_initial_states=metadata.has_initial_states_d,
@@ -747,6 +757,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 conv_state=conv_state,
                 conv_weights=conv_weights,
                 state_indices=state_indices_p,
+                outer_residual=outer_residual_p,
                 mode="prefill",
                 dilation=self.short_conv_dilation,
                 query_start_loc=query_start_loc,
@@ -765,18 +776,25 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 conv_state=conv_state,
                 conv_weights=conv_weights,
                 state_indices=state_indices[:num_decode_rows],
+                outer_residual=outer_residual,
                 mode="decode",
                 dilation=self.short_conv_dilation,
                 has_initial_states=metadata.has_initial_states_d,
                 token_indices=non_spec_token_indices,
             )
 
-    def _short_conv(self, inputs: torch.Tensor, residual: torch.Tensor) -> None:
+    def _short_conv(
+        self,
+        inputs: torch.Tensor,
+        residual: torch.Tensor,
+        outer_residual: torch.Tensor,
+    ) -> None:
         forward_context = get_forward_context()
         attn_metadata = forward_context.attn_metadata
-        # Profiling omits all metadata or this Mamba entry. The residual
-        # already contains the gated output, so short convolution is a no-op.
+        # Profiling omits all metadata or this Mamba entry. Short convolution
+        # is a no-op there, but preserve the outer residual addition.
         if attn_metadata is None:
+            residual.add_(outer_residual)
             return
 
         if not isinstance(attn_metadata, dict):
@@ -787,6 +805,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
 
         layer_attn_metadata = attn_metadata.get(self.prefix)
         if layer_attn_metadata is None:
+            residual.add_(outer_residual)
             return
         if not isinstance(layer_attn_metadata, PleShortConvAttentionMetadata):
             raise TypeError(
@@ -814,6 +833,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         self._short_conv_dilated_dispatch(
             inputs=inputs,
             residual=residual,
+            outer_residual=outer_residual,
             metadata=layer_attn_metadata,
             conv_state=conv_state,
             conv_weights=conv_weights.to(dtype=inputs.dtype),
@@ -848,7 +868,9 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         )
         # State routing depends on runtime request metadata and remains outside
         # the piecewise graph; short convolution accumulates into gated_output.
-        torch.ops.vllm.qwen4_exp_ple_short_conv(conv_input, gated_output, self.prefix)
+        torch.ops.vllm.qwen4_exp_ple_short_conv(
+            conv_input, gated_output, hidden_states, self.prefix
+        )
         return gated_output
 
 
@@ -882,15 +904,17 @@ def qwen4_exp_compute_ple_ngram_ids_fake(
 def qwen4_exp_ple_short_conv(
     inputs: torch.Tensor,
     residual_output: torch.Tensor,
+    outer_residual: torch.Tensor,
     layer_name: str,
 ) -> None:
     layer = get_forward_context().no_compile_layers[layer_name]
-    layer._short_conv(inputs, residual_output)
+    layer._short_conv(inputs, residual_output, outer_residual)
 
 
 def qwen4_exp_ple_short_conv_fake(
     inputs: torch.Tensor,
     residual_output: torch.Tensor,
+    outer_residual: torch.Tensor,
     layer_name: str,
 ) -> None:
     return

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.linear import MergedColumnParallelLinear
@@ -874,6 +875,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         return gated_output
 
 
+@eager_break_during_capture
 def qwen4_exp_compute_ple_ngram_ids(
     input_ids: torch.Tensor,
     query_start_loc: torch.Tensor,
@@ -901,6 +903,7 @@ def qwen4_exp_compute_ple_ngram_ids_fake(
     return
 
 
+@eager_break_during_capture
 def qwen4_exp_ple_short_conv(
     inputs: torch.Tensor,
     residual_output: torch.Tensor,

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -124,6 +124,7 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
         attn_metadata: FlashAttentionMetadata,
         output: torch.Tensor,
         token_to_req: torch.Tensor,
+        output_gate: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
@@ -161,6 +162,7 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
             attn_metadata.block_table,
             token_to_req,
             output[:num_tokens],
+            output_gate=None if output_gate is None else output_gate[:num_tokens],
         )
         return output
 
@@ -346,6 +348,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         key: torch.Tensor,
         value: torch.Tensor,
         output: torch.Tensor,
+        output_gate: torch.Tensor | None,
     ) -> None:
         metadata = get_forward_context().attn_metadata
         if isinstance(metadata, list):
@@ -391,6 +394,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             main_metadata,
             output,
             token_to_req=side_metadata.token_to_req,
+            output_gate=output_gate,
         )
 
     def forward(
@@ -414,6 +418,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
                 key,
                 value,
                 attn_output,
+                gate,
                 encoded_layer_name,
             )
         else:
@@ -424,11 +429,10 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
                 key,
                 value,
                 attn_output,
+                gate,
                 encoded_layer_name,
             )
         flat_output = attn_output.view(num_tokens, -1)
-        if gate is not None:
-            flat_output = flat_output * torch.sigmoid(gate)
         output, _ = self.o_proj(flat_output)
         return output
 
@@ -440,6 +444,7 @@ def qwen4_exp_qsa_with_output(
     key: torch.Tensor,
     value: torch.Tensor,
     output: torch.Tensor,
+    output_gate: torch.Tensor | None,
     layer_name: LayerNameType,
 ) -> None:
     """Run the complete QSA state/update/attend transaction."""
@@ -455,6 +460,7 @@ def qwen4_exp_qsa_with_output(
         key,
         value,
         output,
+        output_gate,
     )
 
 
@@ -465,9 +471,10 @@ def qwen4_exp_qsa_with_output_fake(
     key: torch.Tensor,
     value: torch.Tensor,
     output: torch.Tensor,
+    output_gate: torch.Tensor | None,
     layer_name: LayerNameType,
 ) -> None:
-    del hidden_states, positions, query, key, value, output, layer_name
+    del hidden_states, positions, query, key, value, output, output_gate, layer_name
 
 
 direct_register_custom_op(

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -9,6 +9,7 @@ from typing import ClassVar, cast
 import torch
 from torch import nn
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.distributed import get_tensor_model_parallel_world_size
@@ -340,6 +341,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
         )
 
+    @eager_break_during_capture
     def _run_qsa(
         self,
         hidden_states: torch.Tensor,


### PR DESCRIPTION
## Purpose

Related to #54688.

This draft removes the NVIDIA Qwen3.8-Flash-Next (`Qwen4Exp`) model-level `torch.compile` dependency and runs the model-specific operations through breakable CUDA graphs:

- remove `support_torch_compile` from the main model and MTP paths;
- opt Qwen4Exp into breakable CUDA graphs and mark the metadata-dependent QSA, PLE, and GDN transactions as eager capture boundaries;
- warm the reachable QSA, PLE, GDN, and FlashInfer BF16 MoE specializations before serving;
- fuse the PLE outer residual add and QSA sigmoid output gate into their existing kernels; and
- defer small-batch FlashInfer BF16 MoE finalization and the shared-expert gate, then fuse routed top-k reduction, the shared gate, and the shared/routed add into one Triton tail kernel.

DeepGEMM/Mega-MoE work is intentionally not included in this PR.

## Why this is not duplicate work

The existing Qwen4Exp PRs listed in #54688 provide the underlying HC, QSA, and PLE kernels. This PR implements the remaining model integration needed to run the NVIDIA path without model-level Inductor compilation, plus the PLE/QSA epilogue fusions and BF16 MoE tail fusion. No other open PR found during the duplicate-work check covers this integration.

## Performance

Initial end-to-end results on 4 x B200, BF16, TP=4, EP=4, using `Qwen3.8-Flash-Next`. The POC uses `VLLM_USE_BREAKABLE_CUDAGRAPH=1`; no FP8 or DeepGEMM path is involved.

### Sustained 8K/1K serving

200 prompts, 8192 input tokens, 1024 output tokens, max concurrency 16, seed 17, with prefix caching disabled. Both variants used the same container, model, GPUs, server arguments, and per-variant warmup. The baseline was `main` at `848ab131bcdb5264bcff0d802f47f7d4adb0f548` with the default compiled path; the POC was `6c9fcc3fa78c727cdf2fa2a67eee46892eab4410` with breakable CUDA graphs. Both runs completed 200/200 requests successfully.

| Metric | Compiled baseline | Breakable/custom-op POC | Change |
| --- | ---: | ---: | ---: |
| Benchmark duration | 131.53 s | 129.80 s | -1.3% |
| Request throughput | 1.521 req/s | 1.541 req/s | +1.3% |
| Output token throughput | 1,557.04 tok/s | 1,577.78 tok/s | +1.3% |
| Total token throughput | 14,013.38 tok/s | 14,199.98 tok/s | +1.3% |
| Mean TTFT | 1,067.44 ms | 1,042.13 ms | -2.4% |
| Median TTFT | 1,215.99 ms | 1,041.77 ms | -14.3% |
| P99 TTFT | 1,820.79 ms | 1,701.86 ms | -6.5% |
| Mean TPOT | 8.934 ms | 8.836 ms | -1.1% |
| P99 TPOT | 9.847 ms | 9.811 ms | -0.4% |

For this longer, sustained workload, the end-to-end improvement is much smaller than in the short preliminary workloads below: output throughput improves by 1.3%, mean TTFT by 2.4%, and mean TPOT by 1.1%. The median TTFT result should be confirmed with alternating repeated runs before being treated as stable.

### Heavy prefill

16 prompts, 8192 input tokens, 32 output tokens, max concurrency 4:

| Metric | Compiled baseline | Breakable/custom-op POC | Change |
| --- | ---: | ---: | ---: |
| Total token throughput | 34,580 tok/s | 46,470 tok/s | +34.4% |
| Mean TTFT | 621.00 ms | 402.55 ms | -35.2% |
| Mean TPOT | 10.59 ms | 9.79 ms | -7.6% |

### Heavy decode

16 prompts, 128 input tokens, 512 output tokens, max concurrency 16, seed 11:

| Metric | Compiled baseline | Breakable/custom-op POC | Change |
| --- | ---: | ---: | ---: |
| Output token throughput | 1,619.00 tok/s | 1,913.76 tok/s | +18.2% |
| Mean TTFT | 925.00 ms | 189.18 ms | -79.5% |
| Mean TPOT | 8.08 ms | 8.00 ms | -1.0% |

Across decode seeds 11-13, output throughput was 1,913.76-1,997.19 tok/s and mean TPOT was 7.69-8.02 ms.

These are preliminary POC measurements. More repetitions, accuracy evaluation, mixed-batch coverage, and per-change ablations are required before the PR is ready for review.

## Test plan and results

- `pytest -q tests/models/qwen4_exp/test_qsa_reference.py`: 50 passed on the initial fusion slice.
- `pytest -q tests/models/qwen4_exp/test_ple.py`: 32 passed on the initial fusion slice.
- `pre-commit run`: passed on the initial fusion slice.
- `pytest tests/models/qwen4_exp/test_hc_ops.py -k finalize_moe_with_shared`: 6 passed, 4 deselected.
- `git diff --check`: passed for the current branch.
- Deterministic completion check: `The capital of France is` produced ` Paris. The capital of Germany is Berlin. The capital of`.
- End-to-end `vllm bench serve` completed for all workloads reported above; the sustained 8K/1K comparison completed 200/200 requests for both variants.

Before marking ready, rerun the complete Qwen4Exp tests and pre-commit on the expanded branch, then add accuracy and mixed-batch results.

## AI assistance

AI assistance was used for implementation, profiling orchestration, benchmark analysis, and drafting this PR. The human submitter will review every changed line and rerun the required checks before marking the PR ready for review.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR and related issue.
- [x] The test plan and commands.
- [x] Initial end-to-end performance results.
- [ ] Complete test/evaluation refresh before ready-for-review.
- [ ] Optional documentation update, if required.

</details>
