### PR TITLE
[Bugfix][Parser] Preserve prose after tool calls

### DIFF
--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -24,6 +24,7 @@ from vllm.parser.qwen3 import (
     TOOL_CALL_START,
     qwen3_config,
 )
+from vllm.tool_parsers.qwen3_engine_tool_parser import Qwen3EngineToolParser
 
 
 @pytest.fixture
@@ -142,6 +143,36 @@ class TestNonStreaming:
         assert result.content is not None
         assert "Let me check the weather" in result.content
         assert result.tool_calls[0].function.name == "get_weather"
+
+    @pytest.mark.parametrize(
+        "before,between,after",
+        [("", "", "Final answer."), ("  Before. ", " Between. ", " After.  ")],
+    )
+    def test_tool_adapter_preserves_text_after_tool_calls(
+        self, mock_tokenizer, mock_request, before, between, after
+    ):
+        """The serving adapter must retain all prose around ordered tool calls."""
+        parser = Qwen3EngineToolParser(mock_tokenizer)
+        text = (
+            f"{before}<tool_call><function=get_weather>"
+            "<parameter=city>Tokyo</parameter></function></tool_call>"
+            f"{between}<tool_call><function=get_time>"
+            "<parameter=timezone>Asia/Tokyo</parameter></function></tool_call>"
+            f"{after}"
+        )
+
+        result = parser.extract_tool_calls(text, mock_request)
+
+        assert result.content == (before + between + after).strip()
+        assert result.tools_called
+        assert [tc.function.name for tc in result.tool_calls] == [
+            "get_weather",
+            "get_time",
+        ]
+        assert [json.loads(tc.function.arguments) for tc in result.tool_calls] == [
+            {"city": "Tokyo"},
+            {"timezone": "Asia/Tokyo"},
+        ]
 
     def test_escaped_strings(self, parser, mock_request):
         text = (

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -672,6 +672,11 @@ class ParserEngine(Parser):
             reasoning = reasoning.rstrip() or None
 
         content = delta.content if delta else None
+        # A complete parse must include text deferred for streaming ordering.
+        if self._deferred_content:
+            deferred_delta = self._events_to_delta([], finished=True)
+            if deferred_delta and deferred_delta.content:
+                content = (content or "") + deferred_delta.content
         if content:
             content = self._strip_content_whitespace(
                 content, tool_call_info.tools_called


### PR DESCRIPTION
## Purpose

Preserve assistant prose after tool calls in non-streaming engine-parser responses. With `qwen3_coder`, a valid tool call followed by `Final answer.` currently returns the tool call with `content=None`. If prose precedes the call, only that earlier prose survives.

The event converter defers post-tool text to preserve streaming order. Complete parses invoke it once and never drain that content. Drain it through the existing converter before final whitespace normalization. Streaming behavior and ordered tool arguments remain unchanged.

### Duplicate checks

Checked current upstream and targeted issue/open-PR searches on 2026-09-03. Read #49412 and inspected #49426, which addresses whitespace at streaming boundaries rather than missing non-streaming text. Also inspected #52279 (no-tool normalization), #42415 (stop interruption), and #52418 (Responses ordering). No matching open fix was found.

## Test Plan

```sh
.venv/bin/python -m pytest tests/parser/engine/test_qwen3.py -q
pre-commit run --files vllm/parser/engine/parser_engine.py tests/parser/engine/test_qwen3.py
```

The added production-adapter regression checks tail-only prose and prose before/between/after two tool calls, including exact content, tool order, and arguments. The existing Qwen3-Coder parser suite also runs with the real `Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8` tokenizer:

```sh
.venv/bin/python -m pytest tests/tool_parsers/test_qwen3coder_tool_parser.py -q
```

## Test Result

- Native Qwen3 parser suite: **53 passed**.
- Full local pre-commit hooks on changed files: passed, including Ruff, formatting, typos, mypy-3.10, and repository checks.
- Source reproduction fails the fixed-output expectation on the original code and passes with the patch. Additional controls preserve reasoning, whitespace policies, whitespace-only suppression, and streaming finalization.
- Real-tokenizer integration: **60 passed** in `tests/tool_parsers/test_qwen3coder_tool_parser.py` with the `Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8` tokenizer.
- Model/HTTP generation evaluation was not run. The affected logic deterministically parses completed model text; the native adapter regression covers the failing output and the real-tokenizer parser suite covers the serving parser integration.

## Risk and rollback

Non-streaming responses may now contain prose previously discarded after tools. Clients should already handle content alongside tool calls. Reverting restores the content loss; streaming response ordering is unchanged.

## AI assistance

AI assistance was used for investigation, implementation, regression tests, and independent review. This is ready for human review.
