### PR TITLE
[Bugfix][Pooling] Validate truncated Jina ranking prompts

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
+++ b/tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for JinaRankingIOProcessor request building."""
+"""Unit tests for JinaRankingIOProcessor request building and rendering."""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -9,12 +9,17 @@ import pytest
 from tokenizers import Tokenizer, models, pre_tokenizers
 from transformers import PreTrainedTokenizerFast
 
-from vllm import PoolingParams
+from vllm import PoolingParams, TextPrompt, TokensPrompt
 from vllm.entrypoints.pooling.base.io_processor import PoolingIOProcessor
 from vllm.entrypoints.pooling.scoring.io_processor import JinaRankingIOProcessor
 from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
 from vllm.entrypoints.pooling.scoring.typing import ScoringData
-from vllm.entrypoints.pooling.typing import OfflineScoringInputsContext
+from vllm.entrypoints.pooling.typing import (
+    EncodeCMPLRenderParams,
+    OfflineScoringInputsContext,
+)
+from vllm.exceptions import VLLMValidationError
+from vllm.inputs import tokens_input
 from vllm.renderers import TokenizeParams
 
 pytestmark = pytest.mark.skip_global_cleanup
@@ -142,3 +147,52 @@ def test_offline_rejects_invalid_token_limits(
     ctx.pooling_params.extra_kwargs[name] = limit
     with pytest.raises(ValueError, match=name):
         proc.get_request_factory_offline(ctx)
+
+
+@pytest.mark.parametrize("truncation_side", ["left", "right"])
+@pytest.mark.parametrize("truncate_prompt_tokens", [5, 6, None])
+def test_render_rejects_truncation_only_when_ranking_markers_are_lost(
+    truncation_side, truncate_prompt_tokens
+):
+    """Dropping a document/query marker must not produce mislabeled scores."""
+    proc = JinaRankingIOProcessor.__new__(JinaRankingIOProcessor)
+    proc.model_config = SimpleNamespace(is_encoder_decoder=False)
+    markers = {"<|embed_token|>": 151670, "<|rerank_token|>": 151671}
+    proc.tokenizer = MagicMock()
+    proc.tokenizer.convert_tokens_to_ids.side_effect = markers.__getitem__
+    token_ids = [7, 151670, 8, 151670, 9, 151671, 10]
+
+    def render_cmpl(*, tok_params, **kwargs):
+        prompt = TokensPrompt(prompt_token_ids=token_ids.copy())
+        tok_params.apply_post_tokenization(None, prompt)
+        return [tokens_input(prompt_token_ids=prompt["prompt_token_ids"])]
+
+    proc.renderer = MagicMock()
+    proc.renderer.render_cmpl.side_effect = render_cmpl
+    prompt = proc.format_docs_prompts_func(
+        query="query <|rerank_token|>",
+        docs=["first <|embed_token|>", "second"],
+    )
+    render_params = EncodeCMPLRenderParams(
+        prompts=TextPrompt(prompt=prompt),
+        tok_params=TokenizeParams(
+            max_total_tokens=100,
+            truncate_prompt_tokens=truncate_prompt_tokens,
+            truncation_side=truncation_side,
+        ),
+        prompt_extras=None,
+        skip_mm_cache=False,
+        params=PoolingParams(task="token_embed"),
+        lora_requests=None,
+        priorities=0,
+    )
+
+    if truncate_prompt_tokens == 5:
+        with pytest.raises(VLLMValidationError, match="removed query or document"):
+            proc.render(render_params)
+    else:
+        result = proc.render(render_params)
+        expected = token_ids
+        if truncate_prompt_tokens is not None:
+            expected = token_ids[-6:] if truncation_side == "left" else token_ids[:6]
+        assert result["prompts"]["prompt_token_ids"] == expected

--- a/vllm/entrypoints/pooling/scoring/io_processor.py
+++ b/vllm/entrypoints/pooling/scoring/io_processor.py
@@ -7,6 +7,7 @@ from typing import Any, TypeAlias, cast
 import torch.nn.functional as F
 
 from vllm import PoolingParams, PoolingRequestOutput, TokensPrompt
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.renderers import TokenizeParams
 from vllm.renderers.hf import safe_apply_chat_template
@@ -804,6 +805,39 @@ class JinaRankingIOProcessorMixin:
 class JinaRankingIOProcessor(LateInteractionIOProcessor, JinaRankingIOProcessorMixin):
     name = "jina-reranking-scoring"
     pooling_task: PoolingTask = "token_embed"
+
+    def render(
+        self,
+        render_params: EncodeCMPLRenderParams
+        | EncodeChatRenderParams
+        | ScoringRenderParams,
+    ) -> PoolingEngineInput:
+        render_params = cast(EncodeCMPLRenderParams, render_params)
+        prompt = render_params["prompts"].get("prompt")
+        assert isinstance(prompt, str)
+        # Count before rendering, which can also truncate the prompt text in place.
+        num_docs = prompt.count("<|embed_token|>")
+        engine_input = super().render(render_params)
+        target_prompt = extract_target_prompt(
+            self.model_config, engine_input["prompts"]
+        )
+        token_ids = target_prompt.get("prompt_token_ids")
+        assert token_ids is not None
+
+        doc_token_id = self.tokenizer.convert_tokens_to_ids("<|embed_token|>")
+        query_token_id = self.tokenizer.convert_tokens_to_ids("<|rerank_token|>")
+        if (
+            token_ids.count(doc_token_id) != num_docs
+            or token_ids.count(query_token_id) != 1
+        ):
+            raise VLLMValidationError(
+                "Truncation removed query or document markers required for Jina "
+                "ranking. Increase truncate_prompt_tokens or shorten the query "
+                "and documents before scoring.",
+                parameter="truncate_prompt_tokens",
+            )
+
+        return engine_input
 
     def get_request_factory_online(
         self, ctx: PoolingServeContext


### PR DESCRIPTION
## Purpose

Reject Jina score/rerank prompts when truncation removes the markers required to associate embeddings with the original documents and query.

Jina formats document markers before its query marker. Left truncation can drop an earlier document while the response still labels surviving scores from index zero. Right truncation can remove the query marker, causing the last document embedding to be used as the query. Both paths can return plausible but incorrect scores without an error.

Count expected document markers in the sanitized formatted prompt before rendering, then validate the rendered token IDs before engine dispatch. Truncation that retains all ranking markers remains supported. The shared render path covers online scoring/reranking and offline `LLM.score()`.

### Duplicate checks

Targeted issue and PR searches on 2026-09-03 included `Jina truncation`, `Jina in:title`, `JinaForRanking`, and `jina-reranker-v3`. No matching public report or open fix was found; the latter search returned unrelated CI work #42222.

## Test Plan

```sh
.venv/bin/python -m pytest tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py -q
pre-commit run --files vllm/entrypoints/pooling/scoring/io_processor.py tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
```

The regression exercises the actual render/truncation boundary for left/right marker loss, marker-preserving truncation, and no truncation. User-supplied marker text is sanitized by the formatter.

## Test Result

- Native Jina IO-processor suite: **7 passed**.
- Six isolated regression cases: **6 passed** with the fix; restoring the original render path gives **2 failed, 4 passed**, with both destructive-truncation cases failing to raise.
- Full local pre-commit hooks on changed files: passed, including Ruff, formatting, typos, mypy-3.10, and repository checks.
- CPU source reproduction showed left truncation returning surviving doc1/doc2 scores under doc0/doc1 labels, and right truncation scoring against a document instead of the query. This uses synthetic hidden states and actual truncation/pooling/scoring/response code, not model-quality evaluation.
- GPU/model evaluation: not run; the host has no GPU. This remains a draft pending model-level validation.

## Downsides

Requests whose truncation previously returned misleading scores now fail validation. Increase the truncation limit or shorten query/document text before scoring. Marker-preserving truncation remains accepted.

## Risk and rollback

The guard runs before engine dispatch and changes no model arithmetic. Monitor validation errors for truncated Jina requests. Reverting restores silent document misattribution; callers should avoid marker-removing truncation if reverting.

## AI assistance

AI assistance was used for investigation, implementation, regression tests, and independent review, including vega-alpha subagents.
