### PR TITLE
[Bugfix] Reject invalid GLM kpool indices

### DIFF
--- a/tests/kernels/test_kpool_decode_update_batched.py
+++ b/tests/kernels/test_kpool_decode_update_batched.py
@@ -32,12 +32,14 @@ from vllm.platforms import current_platform
 
 if current_platform.is_rocm():
     from vllm.models.glm5next.amd.ops.kpool_compress import (
+        expand_pools_and_append_tail,
         kpool_compress_and_write_cache,
         kpool_decode_update_and_maybe_write_cache_batched,
         kpool_seed_tail_cache,
     )
 else:
     from vllm.models.glm5next.nvidia.ops.kpool_compress import (
+        expand_pools_and_append_tail,
         kpool_compress_and_write_cache,
         kpool_decode_update_and_maybe_write_cache_batched,
         kpool_seed_tail_cache,
@@ -50,6 +52,20 @@ NUM_BLOCKS = 32
 ROUND_SCALE = True
 FP8_DTYPE = current_platform.fp8_dtype()
 FP8_MAX = torch.finfo(FP8_DTYPE).max
+
+
+def test_expand_pools_rejects_ids_outside_completed_pool_count():
+    pool_ids = torch.tensor([[0, 1, -1, -2, 2, 9]], dtype=torch.int64, device="cuda")
+    seq_lens = torch.tensor([10], dtype=torch.int32, device="cuda")
+
+    out = expand_pools_and_append_tail(pool_ids, seq_lens, pool_size=4)
+
+    expected = torch.tensor(
+        [[*range(8), *([-1] * 16), 8, 9, -1]],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    torch.testing.assert_close(out, expected)
 
 
 def _make_caches():

--- a/vllm/model_executor/layers/sparse_attn_indexer_kpool.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer_kpool.py
@@ -535,8 +535,13 @@ def sparse_attn_indexer_kpool(
             # expand each pool back to its kpool constituent tokens.
             select_k = topk_tokens // index_kpool if index_kpool > 1 else topk_tokens
             if index_kpool > 1:
-                pool_topk = torch.empty(
-                    (num_rows, select_k), dtype=torch.int32, device=logits.device
+                # Top-k kernels may leave slots unwritten when a row has fewer
+                # than select_k pools.
+                pool_topk = torch.full(
+                    (num_rows, select_k),
+                    -1,
+                    dtype=torch.int32,
+                    device=logits.device,
                 )
                 topk_dst = pool_topk
             else:
@@ -581,7 +586,8 @@ def sparse_attn_indexer_kpool(
                         pool_ids, q_seq, index_kpool
                     )
                 else:
-                    valid = pool_ids >= 0
+                    pool_lens = chunk.cu_seqlen_ke - chunk.cu_seqlen_ks
+                    valid = (pool_ids >= 0) & (pool_ids < pool_lens[:, None])
                     expanded = kpool_ops.expand_pools_to_tokens(
                         pool_ids, valid, topk_tokens, index_kpool
                     )
@@ -798,8 +804,11 @@ def sparse_attn_indexer_kpool(
         # then expand each pool back to its kpool tokens.
         select_k = topk_tokens // index_kpool if index_kpool > 1 else topk_tokens
         if index_kpool > 1:
-            pool_topk = torch.empty(
-                (num_rows, select_k), dtype=torch.int32, device=logits.device
+            pool_topk = torch.full(
+                (num_rows, select_k),
+                -1,
+                dtype=torch.int32,
+                device=logits.device,
             )
             topk_dst = pool_topk
         else:

--- a/vllm/models/glm5next/amd/ops/kpool_compress.py
+++ b/vllm/models/glm5next/amd/ops/kpool_compress.py
@@ -844,7 +844,7 @@ def _expand_pools_and_append_tail_kernel(
     o = cols % POOL_SIZE
     pid = tl.load(pool_ids_ptr + row * pid_s0 + g, mask=mask & is_history, other=-1)
     hist_val = (pid * POOL_SIZE + o).to(tl.int32)
-    hist_out = tl.where(pid >= 0, hist_val, -1)
+    hist_out = tl.where((pid >= 0) & (pid < pool_len), hist_val, -1)
 
     # Tail region [topk, out_cols): the request's trailing incomplete pool.
     tail_off = cols - topk

--- a/vllm/models/glm5next/nvidia/ops/kpool_compress.py
+++ b/vllm/models/glm5next/nvidia/ops/kpool_compress.py
@@ -845,7 +845,7 @@ def _expand_pools_and_append_tail_kernel(
     o = cols % POOL_SIZE
     pid = tl.load(pool_ids_ptr + row * pid_s0 + g, mask=mask & is_history, other=-1)
     hist_val = (pid * POOL_SIZE + o).to(tl.int32)
-    hist_out = tl.where(pid >= 0, hist_val, -1)
+    hist_out = tl.where((pid >= 0) & (pid < pool_len), hist_val, -1)
 
     # Tail region [topk, out_cols): the request's trailing incomplete pool.
     tail_off = cols - topk


### PR DESCRIPTION
## Purpose

GLM-5.3 kpool top-k can produce fewer valid entries than the allocated `select_k` width for short rows. The kernels do not promise to write the remaining slots, so allocating `pool_topk` with `torch.empty` can leave arbitrary positive values that are later treated as pool IDs and expanded into out-of-range sparse-attention token indices.

This change adds two defensive layers:

1. Initialize the prefill and decode pool-topk destinations with the `-1` sentinel.
2. Reject pool IDs outside the completed-pool count in the NVIDIA and AMD fused expansion kernels and in the current prefill fallback.

The regression covers valid pool IDs, negative sentinels, positive out-of-range IDs, and an incomplete tail. Only tokens from valid completed pools and the legitimate tail survive.

This was originally developed in https://github.com/ZJY0516/vllm/pull/8 while https://github.com/vllm-project/vllm/pull/53906 was still pending. Now that #53906 is merged, this is the upstream-main version.

## Why this is not duplicating existing work

Before opening this PR, I searched open PRs for references to #53906, `GLM kpool invalid indices`, `pool_topk expand_pools`, and the broader `kpool` term. No open PR carries this exact sentinel initialization plus completed-pool bounds check.

The closest active changes are orthogonal: #54951 changes kpool row sharding but does not initialize unwritten top-k slots or validate expanded pool IDs, while #53969 concerns SM120 NoPE/effective-width behavior.

## Test plan and results

Commands run from an isolated Python 3.12 venv:

```text
git diff --check
.venv/bin/python -m compileall -q tests/kernels/test_kpool_decode_update_batched.py vllm/model_executor/layers/sparse_attn_indexer_kpool.py vllm/models/glm5next/amd/ops/kpool_compress.py vllm/models/glm5next/nvidia/ops/kpool_compress.py
PRE_COMMIT_HOME=/private/tmp/vllm-precommit-cache .venv/bin/pre-commit run --files tests/kernels/test_kpool_decode_update_batched.py vllm/model_executor/layers/sparse_attn_indexer_kpool.py vllm/models/glm5next/amd/ops/kpool_compress.py vllm/models/glm5next/nvidia/ops/kpool_compress.py
.venv/bin/python -m pytest tests/v1/attention/test_sparse_indexer_decode_seq_lens.py -q --noconftest
.venv/bin/python -m pytest tests/kernels/test_kpool_decode_update_batched.py -q --collect-only --noconftest -k expand_pools_rejects_ids_outside_completed_pool_count
```

Results:

- `git diff --check`: passed.
- Compile check: passed.
- All applicable pre-commit hooks: passed, including Ruff, mypy, typos, SPDX, lazy-import, and forbidden-import checks.
- Nearby CPU test: 7 passed.
- New platform-dispatched GPU regression: collected successfully as 1 focused test.

The current machine is an Apple M4 Mac without NVIDIA CUDA or AMD ROCm hardware, so the new regression was not executed on GPU and no model evaluation was run for this current-main adaptation. CUDA and ROCm CI should exercise the same test against their respective backend implementations.

## Provenance and AI disclosure

The fix was authored by Luca Motz and adapted from ZJY0516/vllm#8 after #53906 landed. OpenAI Codex assisted with the upstream adaptation, validation, duplicate search, and PR description. I reviewed the changed lines and am responsible for the implementation and evidence reported here.
