### PR TITLE
[Bugfix][Multimodal] Fix per-video cache option reuse

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl.py
@@ -13,6 +13,7 @@ import pytest
 
 from vllm.config import ModelConfig
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.cache import MultiModalProcessorOnlyCache
 
 from ...registry import HF_EXAMPLE_MODELS
 from ...utils import build_model_context
@@ -191,45 +192,59 @@ def test_processor_kwargs_videos_kwargs_does_not_leak_into_image_budget(
     "hf_mm_kwargs",
     [{"num_frames": [8, 16]}, {"fps": [2.0, 4.0]}],
 )
+@pytest.mark.parametrize("model_kwargs", [False, True])
+@pytest.mark.parametrize("use_uuids", [False, True])
+@pytest.mark.skip_global_cleanup
 def test_processor_multi_video_list_kwargs(
     model_id: str,
     hf_mm_kwargs: dict[str, Any],
+    model_kwargs: bool,
+    use_uuids: bool,
 ) -> None:
-    """Regression test: a multi-video request with list-valued per-video
-    ``mm_processor_kwargs`` (one ``fps``/``num_frames`` per video) must not
-    crash.
-
-    Before the fix, ``_apply_hf_processor_main`` copied the whole kwargs to every
-    video without slicing, so ``_get_video_second_idx`` received the list
-    where a scalar was expected and raised ``TypeError``.
-    """
+    """Per-video options must survive duplicate items and partial cache hits."""
     ctx = build_model_context(
         model_id,
         limit_mm_per_prompt={"image": 0, "video": 2},
+        mm_processor_kwargs=hf_mm_kwargs if model_kwargs else None,
+        mm_processor_cache_gb=1,
     )
-    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+    baseline = MULTIMODAL_REGISTRY.create_processor(ctx.model_config, cache=None)
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config, cache=MultiModalProcessorOnlyCache(ctx.model_config)
+    )
+    prompt = "<|vision_start|><|video_pad|><|vision_end|>" * 2
+    videos = [
+        _build_video_mm_data(num_frames=32, original_fps=8.0)["video"][0]
+        for _ in range(3)
+    ]
+    for i, (frames, _) in enumerate(videos):
+        frames.fill(i)
 
-    prompt = (
-        "<|vision_start|><|video_pad|><|vision_end|>"
-        "<|vision_start|><|video_pad|><|vision_end|>"
-    )
-    mm_data = {
-        "video": [
-            _build_video_mm_data(num_frames=16)["video"][0],
-            _build_video_mm_data(num_frames=32)["video"][0],
-        ]
-    }
+    def run(proc, indices, *, cached_only=False):
+        return proc(
+            prompt,
+            mm_items=proc.info.parse_mm_data(
+                {"video": [None if cached_only else videos[i] for i in indices]}
+            ),
+            mm_uuid_items=(
+                {"video": [f"video-{i}" for i in indices]} if use_uuids else None
+            ),
+            hf_processor_mm_kwargs={} if model_kwargs else hf_mm_kwargs,
+        )
 
-    processed = processor(
-        prompt,
-        mm_items=processor.info.parse_mm_data(mm_data),
-        hf_processor_mm_kwargs=hf_mm_kwargs,
-    )
+    for indices in ([0, 0], [0, 1], [0, 2], [2, 0]):
+        expected = run(baseline, indices)
+        actual = run(processor, indices)
+        assert actual["prompt_token_ids"] == expected["prompt_token_ids"]
+        assert actual["mm_placeholders"] == expected["mm_placeholders"]
+        assert actual["mm_kwargs"] == expected["mm_kwargs"]
+        assert actual["mm_hashes"] == expected["mm_hashes"]
+        assert len(set(actual["mm_hashes"]["video"])) == 2
 
-    video_phs = processed["mm_placeholders"].get("video", [])
-    assert len(video_phs) == 2, (
-        f"Expected exactly 2 video placeholders, got {len(video_phs)}"
-    )
+    if use_uuids:
+        cached_only = run(processor, [2, 0], cached_only=True)
+        assert cached_only["prompt_token_ids"] == actual["prompt_token_ids"]
+        assert cached_only["mm_kwargs"] == actual["mm_kwargs"]
 
 
 def _build_video_embeds_mm_data(

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -60,7 +60,7 @@ from vllm.config.multimodal import (
     VideoPruningMethod,
 )
 from vllm.distributed import get_pp_group, parallel_state
-from vllm.inputs import MultiModalDataDict
+from vllm.inputs import MultiModalDataDict, MultiModalHashes
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import _ACTIVATION_REGISTRY
 from vllm.model_executor.layers.attention.mm_encoder_attention import (
@@ -77,6 +77,7 @@ from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.hasher import MultiModalHasher
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
     MultiModalFieldConfig,
@@ -90,6 +91,7 @@ from vllm.multimodal.parse import ImageSize, MultiModalDataItems
 from vllm.multimodal.processing import (
     BaseDummyInputsBuilder,
     BaseMultiModalProcessor,
+    ProcessorInputs,
     PromptReplacement,
     PromptUpdate,
     PromptUpdateDetails,
@@ -1315,6 +1317,51 @@ def _replace_video_token_placeholders(
 
 
 class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo]):
+    def _get_per_video_kwargs(
+        self, kwargs: Mapping[str, object]
+    ) -> dict[str, list[Any]]:
+        merged = self.info.ctx.get_merged_mm_kwargs(kwargs)
+        return {
+            key: value
+            for key, value in merged.items()
+            if key in ("fps", "num_frames") and isinstance(value, list)
+        }
+
+    def _get_mm_hashes(self, inputs: ProcessorInputs) -> MultiModalHashes:
+        hashes = super()._get_mm_hashes(inputs)
+        per_video_kwargs = self._get_per_video_kwargs(inputs.hf_processor_mm_kwargs)
+        if per_video_kwargs and "video" in hashes:
+            algorithm = self.info.ctx.get_mm_config().mm_hasher_algorithm
+            hashes["video"] = [
+                MultiModalHasher.hash_kwargs(
+                    algorithm,
+                    mm_hash=mm_hash,
+                    **{key: values[i] for key, values in per_video_kwargs.items()},
+                )
+                for i, mm_hash in enumerate(hashes["video"])
+            ]
+        return hashes
+
+    def _get_cache_missing_processor_kwargs(
+        self,
+        inputs: ProcessorInputs,
+        mm_is_cached: Mapping[str, list[bool]],
+    ) -> Mapping[str, object]:
+        per_video_kwargs = self._get_per_video_kwargs(inputs.hf_processor_mm_kwargs)
+        if not per_video_kwargs or "video" not in mm_is_cached:
+            return inputs.hf_processor_mm_kwargs
+        return {
+            **inputs.hf_processor_mm_kwargs,
+            **{
+                key: [
+                    value
+                    for value, hit in zip(values, mm_is_cached["video"])
+                    if not hit
+                ]
+                for key, values in per_video_kwargs.items()
+            },
+        }
+
     @staticmethod
     def _expands_only_video_token(hf_processor: ProcessorMixin) -> bool:
         """Transformers>=5.10 processors override `replace_video_token`
@@ -1329,6 +1376,9 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
         mm_items: MultiModalDataItems,
         hf_processor_mm_kwargs: Mapping[str, object],
     ) -> BatchFeature:
+        per_video_kwargs = self._get_per_video_kwargs(hf_processor_mm_kwargs)
+        if per_video_kwargs:
+            hf_processor_mm_kwargs = {**hf_processor_mm_kwargs, **per_video_kwargs}
         valid_mm_items = mm_items.select(
             {k for k, c in mm_items.get_all_counts().items() if c > 0}
         )
@@ -1486,6 +1536,9 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
             for k, v in hf_processor_mm_kwargs.items()
             if k not in ("fps", "num_frames")
         }
+        # The context merges model defaults again when calling HF.
+        for key in self._get_per_video_kwargs({}):
+            non_video_mm_kwargs[key] = None
         processed_data = self.info.ctx.call_hf_processor(
             self.info.get_hf_processor(**non_video_mm_kwargs),
             dict(text=prompt_text, **mm_data),

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1299,6 +1299,21 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         """
         return replace(cached_update, item_idx=new_item_idx)
 
+    def _get_mm_hashes(self, inputs: ProcessorInputs) -> MultiModalHashes:
+        """Get each item's processor and encoder cache identity."""
+        return inputs.get_mm_hashes(
+            self.info.model_id,
+            self.info.ctx.get_mm_config().mm_hasher_algorithm,
+        )
+
+    def _get_cache_missing_processor_kwargs(
+        self,
+        inputs: ProcessorInputs,
+        mm_is_cached: MultiModalIsCached,
+    ) -> Mapping[str, object]:
+        """Select processor options for the items missing from the cache."""
+        return inputs.hf_processor_mm_kwargs
+
     def _merge_mm_kwargs(
         self,
         cache: BaseMultiModalProcessorCache,
@@ -1370,10 +1385,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
 
         # Use overrides if provided; fallback to data-dependent hashing.
         with timing_ctx.record("get_mm_hashes"):
-            mm_hashes = inputs.get_mm_hashes(
-                self.info.model_id,
-                self.info.ctx.get_mm_config().mm_hasher_algorithm,
-            )
+            mm_hashes = self._get_mm_hashes(inputs)
 
         mm_prompt_updates = self._get_mm_prompt_updates(
             inputs.mm_data_items,
@@ -1405,10 +1417,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             return self._apply_hf_processor(inputs, timing_ctx)
 
         with timing_ctx.record("get_mm_hashes"):
-            mm_hashes = inputs.get_mm_hashes(
-                self.info.model_id,
-                self.info.ctx.get_mm_config().mm_hasher_algorithm,
-            )
+            mm_hashes = self._get_mm_hashes(inputs)
 
         with timing_ctx.record("get_cache_missing_items"):
             mm_is_cached, mm_missing_data_items = self._get_cache_missing_items(
@@ -1417,25 +1426,29 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                 mm_hashes=mm_hashes,
             )
 
+        missing_processor_kwargs = self._get_cache_missing_processor_kwargs(
+            inputs, mm_is_cached
+        )
+
         # NOTE: The prompt does not correspond to `mm_missing_data_items`,
         # so we can't apply prompt updates until the new multimodal
         # items are combined with the cached multimodal items
         with timing_ctx.record("apply_hf_processor"):
             mm_missing_processed_data = self._apply_hf_processor_main(
                 mm_items=mm_missing_data_items,
-                hf_processor_mm_kwargs=inputs.hf_processor_mm_kwargs,
+                hf_processor_mm_kwargs=missing_processor_kwargs,
             )
 
         mm_missing_kwargs = MultiModalKwargsItems.from_hf_inputs(
             mm_missing_processed_data,
             self._get_mm_fields_config(
-                mm_missing_processed_data, inputs.hf_processor_mm_kwargs
+                mm_missing_processed_data, missing_processor_kwargs
             ),
         )
 
         mm_missing_prompt_updates = self._get_mm_prompt_updates(
             mm_missing_data_items,
-            inputs.hf_processor_mm_kwargs,
+            missing_processor_kwargs,
             mm_missing_kwargs,
         )
 


### PR DESCRIPTION
## Purpose

Preserve Qwen3-VL per-video `fps`/`num_frames` options across processor-cache reuse.

Two identical videos with `num_frames=[8,16]` currently receive the same cache identity, so merging their processed results can replace the second video's 16-frame result with the first video's 8-frame result. For distinct videos, a partial cache hit removes earlier inputs without removing their option-list entries: the remaining video is processed with the wrong frame count. The incorrect identity also reaches downstream multimodal caches.

Include each video's effective sampling options in its hash and filter option lists together with uncached videos. Two base hooks preserve existing behavior for other processors. Resolve configured defaults before video processing, and prevent configured video lists from being reintroduced into the final text/image HF call. Preserve custom UUIDs, UUID-only warm requests, and scalar request overrides.

Scope is the already supported top-level `fps` and `num_frames` lists. This does not add nested `videos_kwargs` list support.

### Duplicate checks

Checked current upstream and targeted issue/PR searches on 2026-09-03, including `video num_frames cache` and Qwen per-video option/cache terms. Inspected #54527 (nested modality kwargs for other models) and #53610 (HF processing refactor); neither fixes per-item cache identity or partial-hit option indexing. No matching open fix was found.

## Test Plan

```sh
.venv/bin/python -m pytest tests/models/multimodal/processing/test_qwen3_vl.py -k test_processor_multi_video_list_kwargs -q
pre-commit run --files vllm/multimodal/processing/processor.py vllm/model_executor/models/qwen3_vl.py tests/models/multimodal/processing/test_qwen3_vl.py
```

The extended existing test compares cached and uncached processing for repeated videos, partial hits, reordering, request/configured options, and UUID-only reuse. It uses a positive cache capacity and real HF preprocessing of synthetic video arrays.

## Test Result

- Native processor regression: **8 passed, 8 deselected** on CPU with `Qwen/Qwen3-VL-4B-Instruct` tokenizer/processor assets.
- Full local pre-commit hooks on changed files passed, including Ruff, formatting, typos, mypy-3.10, and repository checks.
- Source reproduction: original repeated-video and partial-hit cases produce `[8,8]` instead of `[8,16]`. Fixed cases preserve `[8,16]`, use distinct effective identities, and select 16 frames for the second uncached video. Configured defaults, identical custom UUIDs, UUID-only warm hits, and scalar overrides also pass.
- GPU/model-output evaluation: not run; the host has no GPU. These results validate preprocessing/cache equivalence, not generated-answer quality. This remains a draft pending model-level evaluation.

## Downsides

List-valued video options now produce different hashes, so affected caches warm again. Hashes retain the original full option list as well as each item's effective values; rearranging otherwise equivalent option lists can cause additional misses. Scalar paths keep their existing hashes.

## Risk and rollback

The change affects Qwen3-VL video cache identity and option selection. Watch cache-hit rates and video placeholder/tensor consistency. Reverting restores the option-mixing bug; use separate scalar-option requests as an operational fallback.

## AI assistance

AI assistance was used for investigation, implementation, regression tests, and independent review, including vega-alpha subagents.
