### PR TITLE
[Bugfix][KV Connector] Keep unselected MooncakeStore jobs idle

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -151,6 +151,9 @@ def test_scheduler_only_tracks_token_ids_for_kv_events():
             assert tracker.token_ids is None
             assert req_meta.token_ids is None
 
+        tracker.allocated_block_ids[0].append(99)
+        assert req_meta.block_ids == ([0, 1],)
+
 
 def _make_preemption_scheduler_output():
     return SimpleNamespace(
@@ -474,6 +477,28 @@ def test_pending_load_does_not_co_queue_save():
     # And the save watermark does not advance for a save that was never queued.
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
+
+
+def test_pending_rejected_child_load_does_not_emit_empty_save():
+    """An unselected MultiConnector child must remain idle."""
+    scheduler = _make_bare_scheduler()
+    _make_pending_load_unfinished_request(
+        scheduler,
+        num_tokens=48,
+        block_hashes=[b"h0", b"h1", b"h2"],
+        block_ids=(),
+    )
+    scheduler.load_specs["req-0"] = LoadSpec(
+        vllm_cached_tokens=0,
+        kvpool_cached_tokens=48,
+        can_load=False,
+    )
+
+    meta = scheduler.build_connector_meta(_make_pending_load_scheduler_output())
+
+    assert meta.requests == []
+    assert "req-0" not in scheduler.load_specs
+    assert "req-0" not in scheduler._request_trackers
 
 
 def _make_resumed_unfinished_request(

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -256,6 +256,34 @@ def _make_multi_group_store_req(req_id: str, block_hashes: list[bytes]) -> ReqMe
     )
 
 
+def test_store_send_group_mismatch_fails_closed(caplog_vllm):
+    caplog_vllm.set_level(logging.ERROR, logger=worker.logger.name)
+    store = MagicMock()
+    databases = []
+    for group_id in range(2):
+        db = ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=16,
+        )
+        db.set_kv_caches_base_addr([0x1000 + group_id * 0x1000])
+        db.set_block_len([256])
+        databases.append(db)
+    thread = _make_store_sending_thread(store, token_databases=databases)
+    req = _make_store_req("req-missing-group", [b"a0", b"a1"])
+
+    _run_store_req(thread, req)
+
+    store.batch_is_exist.assert_not_called()
+    store.batch_put_from_multi_buffers.assert_not_called()
+    assert thread.take_completed_saves() == {req.store_job_id: 1}
+    assert any(
+        "Rejecting Mooncake store job with cache-group mismatch" in record.getMessage()
+        and "metadata_groups=1" in record.getMessage()
+        and "worker_groups=2" in record.getMessage()
+        for record in caplog_vllm.records
+    )
+
+
 _DISK_OFFLOAD_SINGLE_KEY_BYTES = worker._estimate_disk_offload_staging_bytes([256])
 _DISK_OFFLOAD_USABLE_BUDGET_RATIO = 0.9
 _DISK_OFFLOAD_BUDGET_FOR_THREE_KEYS = 4 * _DISK_OFFLOAD_SINGLE_KEY_BYTES

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -774,6 +774,11 @@ class ReqMeta:
         """Create ReqMeta from a RequestTracker."""
         if block_hashes is None:
             block_hashes = []
+        # MultiConnector probes all children and marks unselected loads as
+        # rejected. A rejected lookup is not a worker operation and must not
+        # be reinterpreted as a save.
+        if load_spec is not None and not load_spec.can_load:
+            return None
         input_token_len = tracker.token_len
 
         token_ids_start = tracker.num_saved_tokens
@@ -817,7 +822,10 @@ class ReqMeta:
         return ReqMeta(
             req_id=tracker.req_id,
             token_len_chunk=num_tokens_to_save,
-            block_ids=tracker.allocated_block_ids,
+            # The scheduler keeps extending the tracker while the worker
+            # handles this metadata asynchronously. Own the block table used
+            # by this job instead of observing future allocations.
+            block_ids=tuple(group.copy() for group in tracker.allocated_block_ids),
             can_save=not skip_save,
             load_spec=load_spec,
             block_hashes=block_hashes,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -372,7 +372,12 @@ class MooncakeStoreScheduler:
         ) in self._unfinished_requests.items():
             if request_id not in request_ids and request_id not in cached_reqs.req_ids:
                 load_spec = self.load_specs.pop(request_id, None)
-                if not load_spec:
+                # MultiConnector queries every child before selecting a load
+                # source. Unselected children are notified with zero external
+                # tokens, leaving a rejected LoadSpec behind. The request is
+                # parked for another child and has not run a forward pass, so
+                # it must not be converted into a Store save job.
+                if load_spec is None or not load_spec.can_load:
                     continue
                 num_tokens_to_compute = load_spec.kvpool_cached_tokens
                 request_tracker = RequestTracker(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -937,6 +937,21 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if not self.is_live_store_job(req_meta):
                 return
 
+            # Scheduler and worker cache groups form a wire contract. Refuse
+            # incomplete metadata before indexing it or publishing a partial
+            # logical cache entry.
+            if len(block_ids_per_group) != len(self.token_databases):
+                logger.error(
+                    "Rejecting Mooncake store job with cache-group mismatch "
+                    "(req=%s, store_job_id=%s, metadata_groups=%d, "
+                    "worker_groups=%d)",
+                    req_id,
+                    req_meta.store_job_id,
+                    len(block_ids_per_group),
+                    len(self.token_databases),
+                )
+                return
+
             if self.enable_kv_event:
                 retry_token_ids = self._get_retry_token_ids(req_meta)
                 if retry_token_ids is not None and event_token_ids is not None:


### PR DESCRIPTION
## TL;DR

Fixes a MultiConnector lifecycle bug where an unselected MooncakeStore child could turn `LoadSpec(can_load=False)` into an empty asynchronous save job and crash on a cache-group mismatch. Rejected loads now become true no-ops, save jobs retain the correct block-table snapshot, and unexpected group shapes fail closed instead of terminating the worker.

## Purpose

Fix MooncakeStore behavior when it is used as a child of `MultiConnector` and another child is selected for an asynchronous load.

`MultiConnector` notifies unselected children with zero external tokens. MooncakeStore previously kept the rejected lookup pending and later converted it into a save job with an empty endpoint-local block table. The background sending thread then indexed a missing cache group and terminated.

This change:

- drops rejected child load specs instead of turning them into saves;
- snapshots each asynchronous job block table;
- validates the scheduler/worker cache-group contract before accessing or publishing data.

Related to #51805 and #52360.

## Test Plan

- Regression test for an unselected MooncakeStore child with an empty local block table.
- Regression test that asynchronous metadata owns its block-table snapshot.
- Regression test that a scheduler/worker cache-group mismatch fails closed and completes block release.

## Test Result

- `git diff --check`: passed.
- Ruff on changed production files: passed.
- Ruff format check on all changed files: passed.
- Python AST parsing on all changed files: passed.
- Unit tests were not run locally because this macOS checkout has no vLLM test environment; CI is requested on this Draft PR.

---

<details>
<summary>PR Checklist</summary>

- [x] The code follows the vLLM contribution style.
- [x] Tests cover the reported regression and failure behavior.
- [x] Every commit includes a DCO sign-off.
- [ ] Full CI has passed.

</details>