### PR TITLE
[Bugfix][Reasoning] Handle multi-token streaming boundaries

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -333,6 +333,25 @@ class TestBaseThinkingReasoningParserStreaming:
         assert reasoning == "Some reasoning"
         assert content == "Answer"
 
+    def test_streaming_multi_token_delta_strips_start_token(self, test_tokenizer):
+        """A delta containing the start token and reasoning must strip it."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        delta_text = "<test:think>step one"
+        delta_token_ids = [parser.start_token_id, 1234]
+
+        delta_message = parser.extract_reasoning_streaming(
+            previous_text="",
+            current_text=delta_text,
+            delta_text=delta_text,
+            previous_token_ids=[],
+            current_token_ids=delta_token_ids,
+            delta_token_ids=delta_token_ids,
+        )
+
+        assert delta_message is not None
+        assert delta_message.reasoning == "step one"
+        assert delta_message.content is None
+
     def test_streaming_no_end_token(self, test_tokenizer):
         """Test streaming when no end token is encountered."""
         parser = TestThinkingReasoningParser(test_tokenizer)

--- a/tests/reasoning/test_olmo3_reasoning_parser.py
+++ b/tests/reasoning/test_olmo3_reasoning_parser.py
@@ -161,3 +161,23 @@ def test_reasoning(
 
     assert reasoning == param_dict["reasoning"]
     assert content == param_dict["content"]
+
+
+def test_streaming_single_delta_preserves_content_after_reasoning():
+    """A combined delta must not leave post-thinking content buffered."""
+    output = f"{START_REASONING}Think first{END_REASONING}Final answer"
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser: ReasoningParser = parser_cls(tokenizer)
+
+    delta_message = parser.extract_reasoning_streaming(
+        previous_text="",
+        current_text=output,
+        delta_text=output,
+        previous_token_ids=[],
+        current_token_ids=[],
+        delta_token_ids=[],
+    )
+
+    assert delta_message is not None
+    assert delta_message.reasoning == "Think first"
+    assert delta_message.content == "Final answer"

--- a/tests/reasoning/utils.py
+++ b/tests/reasoning/utils.py
@@ -13,6 +13,7 @@ class StreamingReasoningReconstructor:
         self.other_content = None
 
     def append_delta(self, delta: DeltaMessage):
+        """Accumulate reasoning and response text from a parser delta."""
         # A single delta can cross the reasoning/content boundary, so preserve
         # both fields when the parser returns a compound DeltaMessage.
         if delta.reasoning is not None:

--- a/tests/reasoning/utils.py
+++ b/tests/reasoning/utils.py
@@ -13,21 +13,18 @@ class StreamingReasoningReconstructor:
         self.other_content = None
 
     def append_delta(self, delta: DeltaMessage):
-        # content and the reasoning content should not be present
-        # at the same time
-        assert delta.content is None or delta.reasoning is None, (
-            "Both content and reasoning content are present in the delta message"
-        )
+        # A single delta can cross the reasoning/content boundary, so preserve
+        # both fields when the parser returns a compound DeltaMessage.
+        if delta.reasoning is not None:
+            if self.reasoning is None:
+                self.reasoning = delta.reasoning
+            else:
+                self.reasoning += delta.reasoning
         if delta.content is not None:
             if self.other_content is None:
                 self.other_content = delta.content
             else:
                 self.other_content += delta.content
-        else:
-            if self.reasoning is None:
-                self.reasoning = delta.reasoning
-            else:
-                self.reasoning += delta.reasoning
 
 
 def run_reasoning_extraction(

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -149,7 +149,13 @@ class BaseThinkingReasoningParser(ReasoningParser):
             else:
                 # start token in delta, no end token in delta,
                 # reasoning content continues
-                return DeltaMessage(reasoning=delta_text)
+                start_index = delta_text.find(self.start_token)
+                reasoning = (
+                    delta_text[start_index + len(self.start_token) :]
+                    if start_index >= 0
+                    else delta_text
+                )
+                return DeltaMessage(reasoning=reasoning)
         else:
             # not find thinking start token
             return DeltaMessage(content=delta_text)

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -86,6 +86,7 @@ class Olmo3ReasoningBuffer:
     state: Olmo3ReasoningState = Olmo3ReasoningState.REASONING
 
     def process_buffer(self) -> DeltaMessage | None:
+        """Convert buffered text into the next reasoning/content delta."""
         start_think_idx = self.buffer.find(self.think_start)
 
         if start_think_idx >= 0:

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -110,7 +110,9 @@ class Olmo3ReasoningBuffer:
             if end_think_idx > 0:
                 # this covers the case there's content before
                 # the end of the reasoning block
-                return DeltaMessage(reasoning=pretext)
+                content = self.buffer or None
+                self.buffer = ""
+                return DeltaMessage(reasoning=pretext, content=content)
 
         if self.state == Olmo3ReasoningState.REASONING:
             # we are inside reasoning block, return and empty

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -141,6 +141,7 @@ class Olmo3ReasoningBuffer:
         return len(self.buffer)
 
     def add_text(self, delta_text: str) -> DeltaMessage | None:
+        """Append streamed text and return any newly complete delta."""
         # we start by adding the delta text to the buffer
         self.buffer += delta_text
 


### PR DESCRIPTION
## Summary

- Strip a reasoning start marker when it arrives together with reasoning text in one streaming delta.
- Preserve content that follows `</think>` when an Olmo3 response crosses the reasoning/content boundary inside one delta.
- Update the reasoning test helper to reconstruct compound `DeltaMessage` values.

Fixes #55195.

## Root cause

`BaseThinkingReasoningParser.extract_reasoning_streaming` detected the start-token ID but returned the full delta text, leaking `<think>` into `reasoning_content` when the marker and the first reasoning tokens were grouped together.

`Olmo3ReasoningBuffer.process_buffer` returned as soon as it extracted the reasoning prefix, leaving post-`</think>` content in its buffer. If that was the final delta, the content was never emitted.

## Validation

- `pytest --noconftest tests/reasoning/test_base_thinking_reasoning_parser.py tests/reasoning/test_olmo3_reasoning_parser.py -q` → **41 passed**
- `ruff check` on all changed Python files → passed
- `ruff format --check` on all changed Python files → passed
- `git diff --check` → passed

The regression tests cover a multi-token start delta and a single delta containing reasoning followed by final content. No GPU or model-serving setup is required for these parser-level tests.
