### PR TITLE
[Bugfix][Core] Bound registered NCCL symmetric scratch growth

### DIFF
--- a/tests/distributed/test_nccl_symm_mem.py
+++ b/tests/distributed/test_nccl_symm_mem.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import contextlib
+import logging
 import random
 import typing
 
@@ -157,6 +159,104 @@ def test_nccl_symm_mem_allgather(monkeypatch: pytest.MonkeyPatch, world_size):
 
     mp.spawn(nccl_symm_mem_allgather_worker, args=(world_size,), nprocs=world_size)
     cleanup_dist_env_and_memory()
+
+
+def test_bounded_symm_scratch_reuses_capacity(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    import vllm.distributed.device_communicators.pynccl_allocator as allocator
+
+    monkeypatch.setenv("VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH", "1")
+    monkeypatch.setenv("VLLM_NCCL_SYMM_MEM_ALIAS_DIAGNOSTICS", "1")
+    monkeypatch.setattr(
+        allocator,
+        "nccl_symm_mem_context",
+        lambda _communicator: contextlib.nullcontext(),
+    )
+
+    communicator = object.__new__(CudaCommunicator)
+    communicator.pynccl_comm = object()
+    communicator.unique_name = "test"
+    device = torch.device("cpu")
+    caplog.set_level(logging.WARNING)
+
+    first = communicator._get_symm_scratch("ag_out", (3, 4), torch.float32, device)
+    second = communicator._get_symm_scratch("ag_out", (2, 6), torch.float32, device)
+    assert first.shape == (3, 4)
+    assert second.shape == (2, 6)
+    assert first.untyped_storage().data_ptr() == second.untyped_storage().data_ptr()
+    assert second.untyped_storage().nbytes() == 16 * second.element_size()
+    assert "NCCL bounded symmetric scratch live alias before reuse" in caplog.text
+
+    different_role = communicator._get_symm_scratch(
+        "rs_in", (3, 4), torch.float32, device
+    )
+    assert different_role.untyped_storage().data_ptr() != (
+        second.untyped_storage().data_ptr()
+    )
+
+    first_storage_ptr = first.untyped_storage().data_ptr()
+    communicator.seal_bounded_symm_scratch("unit_test")
+    grown = communicator._get_symm_scratch("ag_out", (5, 4), torch.float32, device)
+    assert grown.shape == (5, 4)
+    assert grown.untyped_storage().nbytes() == 32 * grown.element_size()
+    assert len(communicator._symm_scratch_bufs) == 2
+    assert len(communicator._symm_scratch_retired) == 1
+    assert (
+        communicator._symm_scratch_retired[0].untyped_storage().data_ptr()
+        == first_storage_ptr
+    )
+    assert "NCCL bounded symmetric scratch late grow after seal" in caplog.text
+
+
+def test_bounded_symm_scratch_covers_symmetric_allreduce(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import vllm.distributed.device_communicators.cuda_communicator as cuda_module
+    import vllm.distributed.device_communicators.pynccl_allocator as allocator
+
+    class FakePyNcclCommunicator:
+        world_size = 8
+
+        @staticmethod
+        def all_reduce(input_: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+            output.copy_(input_)
+            return output
+
+    monkeypatch.setenv("VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH", "1")
+    monkeypatch.setattr(
+        allocator,
+        "nccl_symm_mem_context",
+        lambda _communicator: contextlib.nullcontext(),
+    )
+    monkeypatch.setattr(
+        cuda_module, "should_nccl_symm_mem_allreduce", lambda *_args: True
+    )
+
+    communicator = object.__new__(CudaCommunicator)
+    communicator.pynccl_comm = FakePyNcclCommunicator()
+    communicator.fi_ar_comm = None
+    communicator.unique_name = "test"
+    communicator._bounded_symm_scratch_enabled = True
+    communicator._symm_scratch_sealed = False
+    input_ = torch.arange(12, dtype=torch.float32).view(3, 4)
+
+    output = communicator.all_reduce(input_)
+    assert torch.equal(output, input_)
+    cache = communicator._symm_scratch_bufs
+    assert ("flat_capacity", "ar_in", input_.dtype, input_.device) in cache
+    assert ("flat_capacity", "ar_out", input_.dtype, input_.device) in cache
+    ar_out = cache[("flat_capacity", "ar_out", input_.dtype, input_.device)]
+    assert output.untyped_storage().data_ptr() != (ar_out.untyped_storage().data_ptr())
+
+    first_result = output.clone()
+    second_input = input_ + 100
+    second_output = communicator.all_reduce(second_input)
+    assert torch.equal(output, first_result)
+    assert torch.equal(second_output, second_input)
+    assert second_output.untyped_storage().data_ptr() != (
+        ar_out.untyped_storage().data_ptr()
+    )
 
 
 def nccl_symm_mem_reduce_scatter_worker(local_rank: int, world_size: int):

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
+import weakref
 
 import torch
 from torch.distributed import ProcessGroup
@@ -146,6 +148,15 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 symm_mem_enabled=(
                     self.symm_mem_comm is not None and not self.symm_mem_comm.disabled
                 ),
+            )
+
+        self._bounded_symm_scratch_enabled = envs.VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH
+        self._symm_scratch_sealed = False
+        if self._bounded_symm_scratch_enabled and "tp" in self.unique_name:
+            logger.info(
+                "NCCL bounded symmetric scratch enabled: group=%s "
+                "growth=power_of_two retired_generations=retained",
+                self.unique_name,
             )
 
         if use_custom_allreduce and self.world_size > 1 and current_platform.is_rocm():
@@ -317,7 +328,21 @@ class CudaCommunicator(DeviceCommunicatorBase):
             and not use_fi_ar
             and should_nccl_symm_mem_allreduce(self.pynccl_comm.world_size, input_)
         ):
-            out = torch.ops.vllm.all_reduce_symmetric_with_copy(input_)
+            if self._bounded_symm_scratch_enabled:
+                symm_input = self._get_symm_scratch(
+                    "ar_in", tuple(input_.shape), input_.dtype, input_.device
+                )
+                symm_output = self._get_symm_scratch(
+                    "ar_out", tuple(input_.shape), input_.dtype, input_.device
+                )
+                symm_input.copy_(input_)
+                out = self.pynccl_comm.all_reduce(symm_input, symm_output)
+                if out is not None:
+                    # A reusable registered output must not escape to callers
+                    # that retain consecutive all-reduce results.
+                    out = out.clone()
+            else:
+                out = torch.ops.vllm.all_reduce_symmetric_with_copy(input_)
             if out is not None:
                 return out
         qr_comm = self.qr_comm
@@ -511,7 +536,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
         Allocating a fresh symm tensor per collective pays the
         ``nccl_symm_mem_context`` snapshot + window-registration scan on every
         call (~0.5 ms/RS+AG pair, dwarfing the NVLS transfer itself). Instead we
-        allocate once per ``(role, shape, dtype)``, register once, and reuse.
+        allocate once per ``(role, shape, dtype)``, register once, and reuse in
+        the default mode. The bounded mode instead maintains a power-of-two
+        flat capacity per ``(role, dtype, device)``.
 
         Safe for serial (eager) sequence parallelism: each collective's result
         is consumed on the same stream before the next same-role collective
@@ -526,6 +553,86 @@ class CudaCommunicator(DeviceCommunicatorBase):
         pynccl_comm = self.pynccl_comm
         assert pynccl_comm is not None
         cache = self.__dict__.setdefault("_symm_scratch_bufs", {})
+        bounded = self.__dict__.get("_bounded_symm_scratch_enabled")
+        if bounded is None:
+            bounded = envs.VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH
+            self._bounded_symm_scratch_enabled = bounded
+        if bounded:
+            # Long prefills visit many nearby token counts. NCCL retains every
+            # registered segment, so exact-shape caching grows without bound.
+            requested_elements = math.prod(shape)
+            capacity_elements = max(1, 1 << (requested_elements - 1).bit_length())
+            key = ("flat_capacity", role, dtype, device)
+            buf = cache.get(key)
+            if buf is None or buf.numel() < requested_elements:
+                previous_elements = 0 if buf is None else buf.numel()
+                if buf is not None:
+                    # CUDA graphs and NCCL registration can retain the old
+                    # address. Power-of-two growth bounds all retired storage
+                    # to less than the final live capacity.
+                    self.__dict__.setdefault("_symm_scratch_retired", []).append(buf)
+                with nccl_symm_mem_context(pynccl_comm):
+                    buf = torch.empty((capacity_elements,), dtype=dtype, device=device)
+                cache[key] = buf
+                sealed = bool(self.__dict__.get("_symm_scratch_sealed", False))
+                log_args = (
+                    self.unique_name,
+                    role,
+                    dtype,
+                    shape,
+                    requested_elements,
+                    previous_elements,
+                    capacity_elements,
+                    capacity_elements * buf.element_size() / 2**20,
+                )
+                if sealed:
+                    logger.warning(
+                        "NCCL bounded symmetric scratch late grow after seal: "
+                        "group=%s role=%s dtype=%s requested_shape=%s "
+                        "requested_elements=%d previous_elements=%d "
+                        "capacity_elements=%d mib=%.2f",
+                        *log_args,
+                    )
+                else:
+                    logger.info(
+                        "NCCL bounded symmetric scratch grow: group=%s role=%s "
+                        "dtype=%s requested_shape=%s requested_elements=%d "
+                        "previous_elements=%d capacity_elements=%d mib=%.2f",
+                        *log_args,
+                    )
+
+            view = buf[:requested_elements].view(shape)
+            if envs.VLLM_NCCL_SYMM_MEM_ALIAS_DIAGNOSTICS:
+                aliases = self.__dict__.setdefault("_symm_scratch_last_views", {})
+                previous = aliases.get(key)
+                if previous is not None:
+                    previous_ref, previous_shape, previous_ptr = previous
+                    previous_view = previous_ref()
+                    if (
+                        previous_view is not None
+                        and previous_ptr == view.untyped_storage().data_ptr()
+                    ):
+                        warned = self.__dict__.setdefault(
+                            "_symm_scratch_alias_warned", set()
+                        )
+                        if key not in warned:
+                            warned.add(key)
+                            logger.warning(
+                                "NCCL bounded symmetric scratch live alias before "
+                                "reuse: group=%s role=%s previous_shape=%s "
+                                "requested_shape=%s",
+                                self.unique_name,
+                                role,
+                                previous_shape,
+                                shape,
+                            )
+                aliases[key] = (
+                    weakref.ref(view),
+                    tuple(shape),
+                    view.untyped_storage().data_ptr(),
+                )
+            return view
+
         key = (role, tuple(shape), dtype)
         buf = cache.get(key)
         if buf is None:
@@ -533,6 +640,33 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 buf = torch.empty(shape, dtype=dtype, device=device)
             cache[key] = buf
         return buf
+
+    def seal_bounded_symm_scratch(self, reason: str) -> None:
+        """Mark startup profiling complete and diagnose later growth."""
+        if not self.__dict__.get("_bounded_symm_scratch_enabled", False):
+            return
+        self._symm_scratch_sealed = True
+        cache = self.__dict__.get("_symm_scratch_bufs", {})
+        retired = self.__dict__.get("_symm_scratch_retired", [])
+        capacities = sorted(
+            (
+                str(key[1]),
+                int(buf.numel()),
+                str(key[2]),
+                str(key[3]),
+            )
+            for key, buf in cache.items()
+            if isinstance(key, tuple) and key and key[0] == "flat_capacity"
+        )
+        logger.info(
+            "NCCL bounded symmetric scratch sealed: group=%s reason=%s "
+            "live_buffers=%d retired_generations=%d capacities=%s",
+            self.unique_name,
+            reason,
+            len(capacities),
+            len(retired),
+            capacities,
+        )
 
     def _reduce_scatter_symm_mem(
         self,
@@ -747,12 +881,21 @@ class CudaCommunicator(DeviceCommunicatorBase):
         world_size = self.world_size
 
         symm_outputs = []
-        with nccl_symm_mem_context(pynccl_comm):
-            for inp in inputs:
+        if self._bounded_symm_scratch_enabled:
+            for index, inp in enumerate(inputs):
                 out_size = (inp.size(0) * world_size,) + inp.size()[1:]
                 symm_outputs.append(
-                    torch.empty(out_size, dtype=inp.dtype, device=inp.device)
+                    self._get_symm_scratch(
+                        f"ag_batched_out_{index}", out_size, inp.dtype, inp.device
+                    )
                 )
+        else:
+            with nccl_symm_mem_context(pynccl_comm):
+                for inp in inputs:
+                    out_size = (inp.size(0) * world_size,) + inp.size()[1:]
+                    symm_outputs.append(
+                        torch.empty(out_size, dtype=inp.dtype, device=inp.device)
+                    )
 
         pynccl_comm.group_start()
         for symm_out, inp in zip(symm_outputs, inputs):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -290,6 +290,8 @@ if TYPE_CHECKING:
     VLLM_ENABLE_INDUCTOR_MAX_AUTOTUNE: bool = True
     VLLM_ENABLE_INDUCTOR_COORDINATE_DESCENT_TUNING: bool = True
     VLLM_USE_NCCL_SYMM_MEM: bool = False
+    VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH: bool = False
+    VLLM_NCCL_SYMM_MEM_ALIAS_DIAGNOSTICS: bool = False
     VLLM_NCCL_INCLUDE_PATH: str | None = None
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
@@ -2016,6 +2018,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Flag to enable NCCL symmetric memory allocation and registration
     "VLLM_USE_NCCL_SYMM_MEM": lambda: bool(
         int(os.getenv("VLLM_USE_NCCL_SYMM_MEM", "0"))
+    ),
+    # Reuse power-of-two symmetric-memory scratch buffers instead of retaining
+    # one registered allocation for every collective shape.
+    "VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH": lambda: bool(
+        int(os.getenv("VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH", "0"))
+    ),
+    # Warn when a bounded scratch view remains live when the slot is reused.
+    "VLLM_NCCL_SYMM_MEM_ALIAS_DIAGNOSTICS": lambda: bool(
+        int(os.getenv("VLLM_NCCL_SYMM_MEM_ALIAS_DIAGNOSTICS", "0"))
     ),
     # NCCL header path
     "VLLM_NCCL_INCLUDE_PATH": lambda: os.environ.get("VLLM_NCCL_INCLUDE_PATH", None),

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -753,6 +753,16 @@ class Worker(WorkerBase):
         ):
             self.model_runner._init_kv_zero_meta()
 
+        # The max-token profile run precedes KV allocation and should size all
+        # persistent symmetric scratch roles. Seal after allocation so any
+        # serving-time growth is visible in logs.
+        tp_device_communicator = get_tp_group().device_communicator
+        seal_symm_scratch = getattr(
+            tp_device_communicator, "seal_bounded_symm_scratch", None
+        )
+        if seal_symm_scratch is not None:
+            seal_symm_scratch("kv_cache_initialized")
+
     @instrument(span_name="Warmup (GPU)")
     def compile_or_warm_up_model(self) -> CompilationTimes:
         warmup_sizes: list[int] = []


### PR DESCRIPTION
## TL;DR

Adds an opt-in bounded allocator for NCCL symmetric-memory scratch, keyed by role, dtype, and device with power-of-two capacity growth. It prevents long chunked-prefill runs from registering one permanent buffer per token shape while retaining old generations for CUDA Graph and NCCL address safety.

## Purpose

Add an opt-in bounded allocator for persistent NCCL symmetric-memory scratch.

The existing cache is keyed by exact `(role, shape, dtype)`. Long chunked-prefill workloads can visit many nearby token shapes, permanently retaining and registering one symmetric buffer per shape. On B200 TP8 sequence-parallel runs this caused PP1 memory to grow from about 129 GiB to 182.4 GiB and eventually failed at `ncclCommWindowRegister` with `NCCL error: unhandled cuda error`.

When `VLLM_NCCL_SYMM_MEM_BOUNDED_SCRATCH=1`, this PR:

- reuses one power-of-two flat capacity per role, dtype, and device;
- keeps retired generations alive for CUDA graph and NCCL registration safety;
- covers reduce-scatter, all-gather, batched all-gather, and symmetric all-reduce;
- clones reusable all-reduce output before returning it;
- seals capacity after KV-cache initialization and warns on serving-time growth;
- optionally reports live aliases with `VLLM_NCCL_SYMM_MEM_ALIAS_DIAGNOSTICS=1`.

Related to #54626 and #28901.

## Test Plan

- CPU unit test for same-role reuse across shapes.
- Verify separate roles never share storage.
- Verify power-of-two growth and retired-generation retention.
- Verify growth after seal is diagnosed.
- Verify symmetric all-reduce uses bounded input/output scratch and does not return reusable storage.
- Existing multi-GPU NCCL symmetric-memory tests remain unchanged.

## Test Result

- Production validation on TP8 B200: rank0 memory grew about 2 MiB after profile, rank1 about 0 MiB; no late growth, alias warning, or NCCL window registration error.
- `git diff --check`: passed.
- Ruff format check: passed.
- Python AST parsing: passed.
- GPU unit tests were not run on this macOS checkout; CI/GPU maintainer validation is requested on this Draft PR.

---

<details>
<summary>PR Checklist</summary>

- [x] The implementation is opt-in for safe review and rollout.
- [x] Tests cover capacity, lifetime, alias diagnostics, and all-reduce ownership.
- [x] Every commit includes a DCO sign-off.
- [ ] Full CI and upstream GPU validation have passed.

</details>