### PR TITLE
[Bugfix][Docs] Package glm5next nvidia subtree and fix its docstrings

### DIFF
--- a/vllm/models/glm5next/amd/ops/kpool_compress.py
+++ b/vllm/models/glm5next/amd/ops/kpool_compress.py
@@ -631,9 +631,11 @@ def kpool_decode_update_and_maybe_write_cache_batched(
         tail_kv_cache: paged tail cache ``[num_blocks, 2, pool_size, head_dim]``
             bf16 (K at half 0, gate score at half 1).
         tail_slot_mapping: ``[num_requests, next_n]`` int32.
-        key / slot_score: ``[num_requests, next_n, head_dim]`` bf16.
+        key: ``[num_requests, next_n, head_dim]`` bf16.
+        slot_score: ``[num_requests, next_n, head_dim]`` bf16.
         ape: ``[pool_size, head_dim]`` fp32.
-        slot_mapping / positions: ``[num_requests, next_n]`` int32.
+        slot_mapping: ``[num_requests, next_n]`` int32.
+        positions: ``[num_requests, next_n]`` int32.
     """
     num_requests, next_n = key.shape[0], key.shape[1]
     if num_requests == 0 or next_n == 0:

--- a/vllm/models/glm5next/nvidia/__init__.py
+++ b/vllm/models/glm5next/nvidia/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/glm5next/nvidia/ops/__init__.py
+++ b/vllm/models/glm5next/nvidia/ops/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/glm5next/nvidia/ops/kpool_compress.py
+++ b/vllm/models/glm5next/nvidia/ops/kpool_compress.py
@@ -637,9 +637,11 @@ def kpool_decode_update_and_maybe_write_cache_batched(
         tail_kv_cache: paged tail cache ``[num_blocks, 2, pool_size, head_dim]``
             bf16 (K at half 0, gate score at half 1).
         tail_slot_mapping: ``[num_requests, next_n]`` int32.
-        key / slot_score: ``[num_requests, next_n, head_dim]`` bf16.
+        key: ``[num_requests, next_n, head_dim]`` bf16.
+        slot_score: ``[num_requests, next_n, head_dim]`` bf16.
         ape: ``[pool_size, head_dim]`` fp32.
-        slot_mapping / positions: ``[num_requests, next_n]`` int32.
+        slot_mapping: ``[num_requests, next_n]`` int32.
+        positions: ``[num_requests, next_n]`` int32.
     """
     num_requests, next_n = key.shape[0], key.shape[1]
     if num_requests == 0 or next_n == 0:


### PR DESCRIPTION
## Purpose

The docs build emits these warnings on `main`:

```
WARNING - api-autonav: Skipping implicit namespace package (without an __init__.py file) at .../vllm/models/glm5next/nvidia
WARNING - griffe: vllm/models/glm5next/amd/ops/kpool_compress.py:634: No type or annotation for parameter 'key / slot_score'
WARNING - griffe: vllm/models/glm5next/amd/ops/kpool_compress.py:634: Parameter 'key / slot_score' does not appear in the function signature
WARNING - griffe: vllm/models/glm5next/amd/ops/kpool_compress.py:636: No type or annotation for parameter 'slot_mapping / positions'
WARNING - griffe: vllm/models/glm5next/amd/ops/kpool_compress.py:636: Parameter 'slot_mapping / positions' does not appear in the function signature
```

The first one is more than a docs nit. `vllm/models/glm5next/nvidia/` and `vllm/models/glm5next/nvidia/ops/` have no `__init__.py`, and `pyproject.toml` uses `[tool.setuptools.packages.find]` (regular packages, not namespace packages), so **the entire nvidia subtree is silently dropped from built wheels**:

```python
>>> from setuptools import find_packages
>>> sorted(p for p in find_packages(include=["vllm*"]) if "glm5next" in p)
['vllm.models.glm5next',
 'vllm.models.glm5next.amd',
 'vllm.models.glm5next.amd.ops',
 'vllm.models.glm5next.amd.ops.third_party',
 'vllm.models.glm5next.amd.ops.third_party.kda']
```

Note the missing `vllm.models.glm5next.nvidia*` entries, including `nvidia/ops/third_party/kda` (which does have its own `__init__.py`, but is unreachable because its parents do not). Editable installs work by path so this is invisible locally.

## Changes

- Add `__init__.py` (SPDX header only, matching the sibling `amd` packages) to `vllm/models/glm5next/nvidia/` and `vllm/models/glm5next/nvidia/ops/`.
- Split the combined `key / slot_score:` and `slot_mapping / positions:` Google-style docstring entries into one entry per parameter in both `amd/ops/kpool_compress.py` and `nvidia/ops/kpool_compress.py`. griffe treats the combined text as a single parameter name that does not exist in the signature. (The nvidia copy had the same defect but was never reported, because the missing `__init__.py` meant griffe never loaded it.)

No behaviour change.

## Test Result

Packaging fix verified:

```python
>>> sorted(p for p in find_packages(include=["vllm*"]) if "glm5next" in p)
[... 'vllm.models.glm5next.nvidia',
     'vllm.models.glm5next.nvidia.ops',
     'vllm.models.glm5next.nvidia.ops.third_party',
     'vllm.models.glm5next.nvidia.ops.third_party.kda']
```

Docstring fix verified by loading the package with griffe and forcing every docstring to parse; no warnings are emitted, and `nvidia` is now discovered as a package with submodules `attention, kda, model, mtp, multimodal, ops`.

Linters:

```
pre-commit run                                     # all hooks Passed
pre-commit run mypy-3.12 --all-files --hook-stage manual   # Passed
```

The GPU tests that touch these modules (`tests/kernels/test_kpool_decode_update_batched.py`, `tests/v1/attention/test_sparse_indexer_decode_seq_lens.py`) were not run locally: no GPU available. The change is docstring text plus two SPDX-only `__init__.py` files, so it cannot affect model output, accuracy, or serving, and no evals are applicable.

## Duplicate check

`gh pr list --repo vllm-project/vllm --state open --search "glm5next"` and `--search "docs warnings griffe"` return no PR touching these files or warnings.

## AI assistance

AI assistance (Claude Code) was used to prepare this change. I have reviewed every changed line and verified the packaging and docs results quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CLGRdkJaWFMjm7Xtmd8bS