### PR TITLE
[KV Connector][NIXL] Add hybrid KDA target-state transport

### DIFF
--- a/tests/v1/kv_connector/unit/test_kda_recoverssm_transport.py
+++ b/tests/v1/kv_connector/unit/test_kda_recoverssm_transport.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+
+from vllm.distributed.kv_transfer.kv_connector.v1.kda_recoverssm_transport import (
+    KDA_BASE_RECURRENT_REGION,
+    KDA_TARGET_CONV_REGION,
+    KDATargetStateLayerTransport,
+)
+from vllm.v1.kv_cache_interface import MambaSpec
+
+
+def _page_cache(spec: MambaSpec, num_blocks: int) -> torch.Tensor:
+    return torch.empty(
+        (num_blocks, 1, 1, spec.state_content_size_bytes), dtype=torch.int8
+    )
+
+
+def _prefill_spec() -> MambaSpec:
+    return MambaSpec(
+        block_size=256,
+        shapes=((3, 6), (2, 2, 2)),
+        dtypes=(torch.float16, torch.float32),
+        mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+    )
+
+
+def _recover_spec(num_speculative_tokens: int) -> MambaSpec:
+    query_len = num_speculative_tokens + 1
+    return MambaSpec(
+        block_size=256,
+        shapes=(
+            (6, 3 + num_speculative_tokens),
+            (2, 2, 2),
+            (2, query_len, 2),
+            (2, query_len, 4),
+        ),
+        dtypes=(torch.float16, torch.float32, torch.float32, torch.float16),
+        mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+    )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("num_speculative_tokens", [4, 7])
+@pytest.mark.parametrize("dcp_size", [1, 4])
+def test_no_spec_prefill_to_recoverssm_target_state_transport(
+    num_speculative_tokens: int,
+    dcp_size: int,
+):
+    num_blocks = 4
+    prefill_spec = _prefill_spec()
+    prefill = KDATargetStateLayerTransport(
+        "linear_attn",
+        1,
+        _page_cache(prefill_spec, num_blocks),
+        prefill_spec,
+        conv_state_dim_first=False,
+    )
+    prefill.states[0].copy_(
+        torch.arange(prefill.states[0].numel(), dtype=torch.float16).view_as(
+            prefill.states[0]
+        )
+    )
+    prefill.recurrent_state.copy_(
+        torch.arange(prefill.recurrent_state.numel(), dtype=torch.float32).view_as(
+            prefill.recurrent_state
+        )
+    )
+    prefill.stage_blocks([1, 2])
+
+    assert [region.kind for region in prefill.regions] == [
+        KDA_TARGET_CONV_REGION,
+        KDA_BASE_RECURRENT_REGION,
+    ]
+
+    for _ in range(dcp_size):
+        decode_spec = _recover_spec(num_speculative_tokens)
+        decode = KDATargetStateLayerTransport(
+            "linear_attn",
+            1,
+            _page_cache(decode_spec, num_blocks),
+            decode_spec,
+            conv_state_dim_first=True,
+        )
+        for state in decode.states:
+            state.fill_(99)
+
+        assert [region.content_len_bytes for region in decode.regions] == [
+            region.content_len_bytes for region in prefill.regions
+        ]
+        decode.target_conv[1:3].copy_(prefill.target_conv[1:3])
+        decode.recurrent_state[1:3].copy_(prefill.recurrent_state[1:3])
+        decode.materialize_blocks([1, 2])
+
+        expected_conv = prefill.states[0][1:3].transpose(-1, -2)
+        torch.testing.assert_close(decode.local_conv[1:3, ..., :3], expected_conv)
+        torch.testing.assert_close(
+            decode.recurrent_state[1:3], prefill.recurrent_state[1:3]
+        )
+        assert torch.count_nonzero(decode.local_conv[1:3, ..., 3:]) == 0
+        for record in decode.states[2:]:
+            assert torch.count_nonzero(record[1:3]) == 0
+
+        assert torch.all(decode.local_conv[0] == 99)
+
+
+@pytest.mark.cpu_test
+def test_homogeneous_recoverssm_transport_resets_local_records():
+    spec = _recover_spec(7)
+    producer = KDATargetStateLayerTransport(
+        "linear_attn", 0, _page_cache(spec, 2), spec, conv_state_dim_first=True
+    )
+    consumer = KDATargetStateLayerTransport(
+        "linear_attn", 0, _page_cache(spec, 2), spec, conv_state_dim_first=True
+    )
+    producer.local_conv.fill_(3)
+    producer.recurrent_state.fill_(5)
+    producer.stage_blocks([1])
+    for state in consumer.states:
+        state.fill_(99)
+
+    consumer.target_conv[1].copy_(producer.target_conv[1])
+    consumer.recurrent_state[1].copy_(producer.recurrent_state[1])
+    consumer.materialize_blocks([1])
+
+    assert torch.all(consumer.local_conv[1, ..., :3] == 3)
+    assert torch.count_nonzero(consumer.local_conv[1, ..., 3:]) == 0
+    assert torch.all(consumer.recurrent_state[1] == 5)
+    for record in consumer.states[2:]:
+        assert torch.count_nonzero(record[1]) == 0
+
+
+@pytest.mark.cpu_test
+def test_ordinary_speculative_kda_page_is_rejected():
+    spec = MambaSpec(
+        block_size=256,
+        shapes=((6, 7), (2, 2, 2)),
+        dtypes=(torch.float16, torch.float32),
+        mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+        num_speculative_blocks=4,
+    )
+    with pytest.raises(ValueError, match="ordinary speculative"):
+        KDATargetStateLayerTransport(
+            "linear_attn",
+            1,
+            _page_cache(spec, 2),
+            spec,
+            conv_state_dim_first=True,
+        )

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -31,6 +31,7 @@ from unittest.mock import MagicMock, patch
 
 import msgspec
 import pytest
+from vllm.v1.outputs import KVConnectorOutput
 
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
@@ -44,7 +45,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
     get_base_request_id,
 )
 from vllm.v1.kv_cache_interface import FullAttentionSpec
-from vllm.v1.outputs import KVConnectorOutput
 
 from .utils import create_request, make_nixl_push_scheduler
 
@@ -152,6 +152,7 @@ class TestPushScheduler:
         assert reg["decode_engine_id"] == sched.engine_id
         assert reg["decode_host"] == sched.side_channel_host
         assert reg["decode_port"] == sched.side_channel_port
+        assert reg["decode_pp_size"] == 1
         assert reg["local_block_ids"] == ([10, 11, 12],)
         assert reg["remote_engine_id"] == "prefill-engine"
 
@@ -354,11 +355,14 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         w.tp_rank = 0
         w.pcp_rank = 0
         w.world_size = 1
+        w.pp_size = 1
+        w.pp_rank = 0
         w.engine_id = "test-decode-engine"
         w._remote_agents = {}
         w._physical_blocks_per_logical_kv_block = 1
         # Single non-hybrid attention group, matching the stub block id lists.
         w._has_mamba = False
+        w._is_hma_required = False
         w._is_csa_linear = False
         w._group_spec_types = (FullAttentionSpec,)
         w._engine_ttl = 0.0
@@ -386,6 +390,7 @@ def _registration_data(
     decode_host: str = "10.0.0.2",
     decode_port: int = 5602,
     decode_tp_size: int = 1,
+    decode_pp_size: int = 1,
     local_block_ids=((100, 101, 102),),
     remote_engine_id: str = "prefill-engine",
     remote_host: str = "10.0.0.1",
@@ -398,6 +403,7 @@ def _registration_data(
         "decode_host": decode_host,
         "decode_port": decode_port,
         "decode_tp_size": decode_tp_size,
+        "decode_pp_size": decode_pp_size,
         "local_block_ids": local_block_ids,
         "remote_engine_id": remote_engine_id,
         "remote_host": remote_host,
@@ -573,12 +579,21 @@ def test_do_start_push_kv_defers_then_writes_when_handshake_ready():
     w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
 
     fut: Future = Future()
-    w._ensure_handshake = lambda *a, **k: fut
+    handshake_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
-    rd = _registration_data("req-hs", decode_engine_id="decode-engine")
+    def pending_handshake(*args, **kwargs):
+        handshake_calls.append((args, kwargs))
+        return fut
+
+    w._ensure_handshake = pending_handshake
+
+    rd = _registration_data(
+        "req-hs", decode_engine_id="decode-engine", decode_pp_size=2
+    )
     _real_do_start_push_kv(w, "req-hs", ([1, 2, 3],), rd)
 
     # Handshake pending -> nothing issued, nothing queued, no wake.
+    assert handshake_calls[0][1]["pp_size"] == 2
     assert xfer_calls == []
     assert w._deferred_push_inbox.qsize() == 0
     assert not w._push_writer_wake.is_set()
@@ -1053,6 +1068,59 @@ class TestPushPipelineParallel:
         assert w._get_new_notifs() == set()
         assert request_id in w._recving_transfers
         assert request_id not in w.consumer_notification_counts_by_req
+
+    def test_homogeneous_pp_completion_uses_matching_stage_only(self):
+        """PP2 -> PP2 needs one notification from the matching P stage."""
+        w = _StubWriterWorker.fresh()
+        w.pp_size = 2
+        w.pp_rank = 1
+        w.transfer_topo = MagicMock()
+        request_id = "req-pp-2-matched"
+        w._recving_metadata[request_id] = MagicMock(pp_size=2)
+
+        w._pending_completion_notifs.put(f"{request_id}:1".encode())
+        assert w._get_new_notifs() == set()
+        assert request_id in w._recving_transfers
+        assert request_id not in w.consumer_notification_counts_by_req
+
+    def test_hybrid_dcp_completion_waits_for_all_overlapping_producers(self):
+        w = _StubWriterWorker.fresh()
+        w._has_mamba = True
+        w.use_mla = True
+        w._group_spec_types = (FullAttentionSpec,)
+        w.transfer_topo = MagicMock()
+        request_id = "req-dcp-overlap"
+        w._recving_metadata[request_id] = MagicMock(pp_size=1, tp_size=8, dcp_size=4)
+        notif = f"{request_id}:8".encode()
+
+        mapping = MagicMock(all_source_ranks=(0, 4))
+        with patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker."
+            "compute_tp_mapping",
+            return_value=mapping,
+        ):
+            w._pending_completion_notifs.put(notif)
+            assert w._get_new_notifs() == set()
+            assert request_id not in w._recving_transfers
+
+            w._pending_completion_notifs.put(notif)
+            assert w._get_new_notifs() == set()
+            assert request_id in w._recving_transfers
+
+    def test_homogeneous_pp_handshake_selects_matching_stage(self):
+        w = _StubWriterWorker.fresh()
+        w.pp_size = 2
+        w.pp_rank = 1
+        w._is_hma_required = True
+        assert w._remote_pp_ranks_for_handshake(2) == (1,)
+
+    def test_hma_mismatched_pp_fails_closed(self):
+        w = _StubWriterWorker.fresh()
+        w.pp_size = 2
+        w.pp_rank = 0
+        w._is_hma_required = True
+        with pytest.raises(NotImplementedError, match="homogeneous pipeline"):
+            w._remote_pp_ranks_for_handshake(1)
 
     def test_req_meta_reads_pp_size_from_kv_transfer_params(self):
         """D learns the producer's pp_size from kv_transfer_params (forwarded

--- a/tests/v1/kv_connector/unit/test_tp_mapping.py
+++ b/tests/v1/kv_connector/unit/test_tp_mapping.py
@@ -103,6 +103,55 @@ def test_mla_dcp_source_ranks(
 
 
 @pytest.mark.parametrize(
+    "tp_rank,expected_attention,expected_ssm,expected_all",
+    [
+        (0, (0, 4), (0,), (0, 4)),
+        (4, (0, 4), (4,), (0, 4)),
+        (3, (3, 7), (3,), (3, 7)),
+    ],
+)
+def test_homogeneous_hybrid_dcp_keeps_ssm_tp_sharded(
+    tp_rank, expected_attention, expected_ssm, expected_all
+):
+    mapping = _compute_mapping(
+        tp_rank=tp_rank,
+        tp_size=8,
+        remote_tp_size=8,
+        is_mla=True,
+        num_kv_heads=1,
+        group_spec_types=(FullAttentionSpec, MambaSpec),
+        dcp_size=4,
+        remote_dcp_size=4,
+    )
+
+    assert mapping.source_ranks_per_group == (expected_attention, expected_ssm)
+    assert mapping.all_source_ranks == expected_all
+
+
+def test_kda_staging_regions_use_only_ssm_block_ids():
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = True
+    worker._kda_transport = object()
+    worker._ssm_region_indices = [2, 3]
+    worker._scratch_region_indices = []
+    worker._ple_group_index = None
+    worker.num_regions = 4
+    worker._group_spec_types = (FullAttentionSpec, MambaSpec)
+
+    desc_ids = worker._compute_desc_ids(
+        ([1], [2]),
+        dst_num_blocks=8,
+        block_size_ratio=None,
+        physical_blocks_per_logical=1,
+    )
+
+    # Attention block 1 addresses only regions 0 and 1. SSM block 2
+    # addresses the two KDA target-state descriptors appended after the
+    # four base-region descriptor tables.
+    np.testing.assert_array_equal(desc_ids, np.asarray([1, 9, 34, 42]))
+
+
+@pytest.mark.parametrize(
     "tp_size,remote_tp_size,dcp_size,remote_dcp_size",
     [
         (4, 2, 4, 2),

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -8,6 +8,17 @@ from itertools import chain, count
 from typing import Any, Literal
 
 import torch
+from vllm.distributed.kv_transfer.kv_connector.v1.example_connector import (  # noqa
+    ExampleConnector,
+)
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.scheduler import Scheduler, SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
+from vllm.v1.request import Request
+from vllm.v1.structured_output import StructuredOutputManager
 
 from vllm import SamplingParams
 from vllm.config import (
@@ -26,14 +37,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     KVConnectorWorkerMetadata,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.example_connector import (  # noqa
-    ExampleConnector,
-)
-from vllm.utils.hashing import sha256
-from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
-from vllm.v1.core.sched.async_scheduler import AsyncScheduler
-from vllm.v1.core.sched.scheduler import Scheduler, SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -41,9 +44,6 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     SlidingWindowSpec,
 )
-from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
-from vllm.v1.request import Request
-from vllm.v1.structured_output import StructuredOutputManager
 
 EOS_TOKEN_ID = 50256
 
@@ -596,6 +596,7 @@ def make_nixl_push_scheduler(
     # vllm_config is consulted for parallel_config.tensor_parallel_size.
     vllm_config = MagicMock()
     vllm_config.parallel_config.tensor_parallel_size = 1
+    vllm_config.parallel_config.pipeline_parallel_size = 1
     sched.vllm_config = vllm_config
 
     # Push-specific state.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -18,9 +18,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_args
 
 import torch
-from pydantic import ConfigDict, Field, model_validator
-
 import vllm.envs as envs
+from pydantic import ConfigDict, Field, model_validator
 from vllm.logger import enable_trace_function_call, init_logger
 from vllm.transformers_utils.runai_utils import is_runai_obj_uri
 from vllm.triton_utils import HAS_TRITON
@@ -54,8 +53,8 @@ from .weight_transfer import WeightTransferConfig
 
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
-
     from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
     from vllm.v1.kv_cache_interface import KVCacheConfig
 else:
     PretrainedConfig = Any
@@ -2926,10 +2925,17 @@ class VllmConfig:
             self.kv_transfer_config is not None
             and self.kv_transfer_config.is_kv_transfer_instance
         ):
-            raise ValueError(
-                "--use-replayssm is incompatible with KV connectors "
-                "(P/D disaggregation, KV cache offload)"
+            from vllm.distributed.kv_transfer.kv_connector.factory import (
+                KVConnectorFactory,
             )
+
+            if not KVConnectorFactory.supports_kda_recoverssm_config(
+                self.kv_transfer_config
+            ):
+                raise ValueError(
+                    "--use-replayssm requires a KV connector that explicitly "
+                    "supports KDA target-state transport"
+                )
         return self
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -10,12 +10,13 @@ from vllm.distributed.kv_transfer.kv_connector.base import (
     KVConnectorBase,
     KVConnectorBaseType,
 )
+from vllm.logger import init_logger
+from vllm.utils.func_utils import supports_kw
+
 from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorRole,
     supports_hma,
 )
-from vllm.logger import init_logger
-from vllm.utils.func_utils import supports_kw
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -143,6 +144,22 @@ class KVConnectorFactory:
         )
 
         return MultiConnector.all_children_support_hma(kv_transfer_config)
+
+    @classmethod
+    def supports_kda_recoverssm_config(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        connector_cls = cls.get_connector_class(kv_transfer_config)
+        if kv_transfer_config.kv_connector != "MultiConnector":
+            return connector_cls.supports_kda_recoverssm_transport(
+                kv_transfer_config.kv_connector_extra_config
+            )
+
+        from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
+            MultiConnector,
+        )
+
+        return MultiConnector.all_children_support_kda_recoverssm(kv_transfer_config)
 
 
 # Register various connectors here.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -46,14 +46,12 @@ from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
-
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 
 if TYPE_CHECKING:
-    from vllm.config import VllmConfig
     from vllm.distributed.kv_events import KVCacheEvent, KVConnectorKVEvents
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
         KVConnectorPromMetrics,
@@ -64,8 +62,10 @@ if TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
     from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-    from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
+
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 # s_tensor_list, d_tensor_list, s_indices, d_indices, direction
 CopyBlocksOp = Callable[
@@ -634,6 +634,16 @@ class KVConnectorBase_V1(ABC):
             True if this connector requires PIECEWISE CUDA graph mode,
             False otherwise.
         """
+        return False
+
+    @classmethod
+    def supports_kda_recoverssm_transport(cls, extra_config: dict[str, Any]) -> bool:
+        """Whether this connector explicitly supports KDA target-state transport."""
+        return False
+
+    @classmethod
+    def supports_dspark_context_transport(cls, extra_config: dict[str, Any]) -> bool:
+        """Whether this connector transports DSpark prompt-context KV."""
         return False
 
     def get_finished_count(self) -> int | None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/dspark_context_transport.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/dspark_context_transport.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Capability contract for transporting DSpark prompt-context KV."""
+
+from typing import Any
+
+DSPARK_CONTEXT_KV_TRANSPORT = "dspark_context_kv_v1"
+
+
+def dspark_context_kv_transport_enabled(extra_config: dict[str, Any]) -> bool:
+    """Return whether the connector explicitly enables DSpark context KV."""
+    return (
+        extra_config.get("dspark_context_transport_policy")
+        == DSPARK_CONTEXT_KV_TRANSPORT
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/kda_recoverssm_transport.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/kda_recoverssm_transport.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layout-neutral target-state transport for KDA RecoverSSM."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from math import prod
+
+import torch
+from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
+
+KDA_TARGET_STATE_TRANSPORT = "target_state_v1"
+KDA_TARGET_CONV_REGION = "kda_target_conv_v1"
+KDA_BASE_RECURRENT_REGION = "kda_base_recurrent_v1"
+
+
+@dataclass(frozen=True)
+class KDATransportRegion:
+    kind: str
+    tensor: torch.Tensor
+    block_stride_bytes: int
+    content_len_bytes: int
+
+
+def _split_page_states(
+    cache: torch.Tensor,
+    spec: MambaSpec,
+) -> tuple[torch.Tensor, ...]:
+    if cache.ndim != 4 or tuple(cache.shape[1:3]) != (1, 1):
+        raise ValueError(
+            "KDA target-state transport requires a [blocks, 1, 1, bytes] cache"
+        )
+    if cache.element_size() != 1:
+        raise ValueError("KDA target-state transport requires a byte cache view")
+
+    pages = cache[:, 0, 0]
+    if pages.shape[1] < spec.state_content_size_bytes:
+        raise ValueError("KDA cache page is shorter than its declared state fields")
+    states: list[torch.Tensor] = []
+    offset = 0
+    for shape, dtype in zip(spec.shapes, spec.dtypes, strict=True):
+        num_bytes = prod(shape) * torch.empty((), dtype=dtype).element_size()
+        state = pages[:, offset : offset + num_bytes].view(dtype)
+        states.append(state.view(cache.shape[0], *shape))
+        offset += num_bytes
+    if offset != spec.state_content_size_bytes:
+        raise ValueError("KDA state fields do not cover the declared page content")
+    return tuple(states)
+
+
+class KDATargetStateLayerTransport:
+    """Expose only target state shared by base KDA and RecoverSSM pages."""
+
+    def __init__(
+        self,
+        layer_name: str,
+        group_index: int,
+        cache: torch.Tensor,
+        spec: MambaSpec,
+        *,
+        conv_state_dim_first: bool | None = None,
+    ) -> None:
+        if spec.mamba_type != MambaAttentionBackendEnum.GDN_ATTN:
+            raise ValueError("KDA transport requires a GDN_ATTN MambaSpec")
+        if len(spec.shapes) not in (2, 4):
+            raise ValueError("KDA transport requires base or RecoverSSM state fields")
+        if spec.num_speculative_blocks:
+            raise ValueError(
+                "ordinary speculative KDA pages are not target-state transportable"
+            )
+
+        self.layer_name = layer_name
+        self.group_index = group_index
+        self.cache = cache
+        self.states = _split_page_states(cache, spec)
+        dim_first = (
+            is_conv_state_dim_first()
+            if conv_state_dim_first is None
+            else conv_state_dim_first
+        )
+        conv_state, self.recurrent_state = self.states[:2]
+        self.local_conv = conv_state if dim_first else conv_state.transpose(-1, -2)
+        if len(self.states) == 4:
+            verify_len = spec.shapes[2][1]
+            self.conv_history_len = self.local_conv.shape[-1] - verify_len + 1
+        else:
+            self.conv_history_len = self.local_conv.shape[-1]
+        if self.conv_history_len <= 0:
+            raise ValueError("RecoverSSM conv state has no target history")
+
+        self.target_conv = torch.empty(
+            (
+                cache.shape[0],
+                self.local_conv.shape[-2],
+                self.conv_history_len,
+            ),
+            dtype=conv_state.dtype,
+            device=conv_state.device,
+        )
+
+    @property
+    def regions(self) -> tuple[KDATransportRegion, KDATransportRegion]:
+        return (
+            KDATransportRegion(
+                kind=KDA_TARGET_CONV_REGION,
+                tensor=self.target_conv,
+                block_stride_bytes=(
+                    self.target_conv.stride(0) * self.target_conv.element_size()
+                ),
+                content_len_bytes=(
+                    self.target_conv[0].numel() * self.target_conv.element_size()
+                ),
+            ),
+            KDATransportRegion(
+                kind=KDA_BASE_RECURRENT_REGION,
+                tensor=self.recurrent_state,
+                block_stride_bytes=(
+                    self.recurrent_state.stride(0) * self.recurrent_state.element_size()
+                ),
+                content_len_bytes=(
+                    self.recurrent_state[0].numel()
+                    * self.recurrent_state.element_size()
+                ),
+            ),
+        )
+
+    def stage_blocks(self, block_ids: list[int]) -> None:
+        indices = self._indices(block_ids)
+        if indices is None:
+            return
+        source = self.local_conv.index_select(0, indices)[..., : self.conv_history_len]
+        self.target_conv.index_copy_(0, indices, source)
+
+    def materialize_blocks(self, block_ids: list[int]) -> None:
+        indices = self._indices(block_ids)
+        if indices is None:
+            return
+        conv = torch.zeros(
+            (indices.numel(), *self.local_conv.shape[1:]),
+            dtype=self.local_conv.dtype,
+            device=self.local_conv.device,
+        )
+        conv[..., : self.conv_history_len].copy_(
+            self.target_conv.index_select(0, indices)
+        )
+        self.local_conv.index_copy_(0, indices, conv)
+        for record in self.states[2:]:
+            record.index_fill_(0, indices, 0)
+
+    def _indices(self, block_ids: list[int]) -> torch.Tensor | None:
+        valid = list(
+            dict.fromkeys(
+                block_id
+                for block_id in block_ids
+                if block_id != NULL_BLOCK_ID and block_id >= 0
+            )
+        )
+        if not valid:
+            return None
+        if max(valid) >= self.cache.shape[0]:
+            raise ValueError(
+                f"KDA block id {max(valid)} exceeds {self.cache.shape[0]} blocks"
+            )
+        return torch.tensor(valid, dtype=torch.long, device=self.cache.device)
+
+
+class KDATargetStateTransport:
+    def __init__(self, layers: dict[str, KDATargetStateLayerTransport]) -> None:
+        self.layers = layers
+        self._layers_by_group: dict[int, list[KDATargetStateLayerTransport]] = {}
+        for layer in layers.values():
+            self._layers_by_group.setdefault(layer.group_index, []).append(layer)
+        self._lock = threading.Lock()
+
+    @classmethod
+    def create(
+        cls,
+        kv_caches: dict[str, torch.Tensor],
+        kv_cache_config: KVCacheConfig,
+        *,
+        conv_state_dim_first: bool | None = None,
+    ) -> KDATargetStateTransport:
+        layers: dict[str, KDATargetStateLayerTransport] = {}
+        for group_index, group in enumerate(kv_cache_config.transfer_groups):
+            group_spec = group.kv_cache_spec
+            specs_by_layer = getattr(group_spec, "kv_cache_specs", {})
+            for layer_name in group.layer_names:
+                spec = specs_by_layer.get(layer_name, group_spec)
+                cache = kv_caches.get(layer_name)
+                if cache is not None and isinstance(spec, MambaSpec):
+                    layers[layer_name] = KDATargetStateLayerTransport(
+                        layer_name,
+                        group_index,
+                        cache,
+                        spec,
+                        conv_state_dim_first=conv_state_dim_first,
+                    )
+        return cls(layers)
+
+    def regions_for_layer(self, layer_name: str) -> tuple[KDATransportRegion, ...]:
+        layer = self.layers.get(layer_name)
+        return () if layer is None else layer.regions
+
+    def stage_groups(self, block_ids_by_group: list[list[int]]) -> None:
+        self._apply_groups(block_ids_by_group, materialize=False)
+
+    def materialize_groups(self, block_ids_by_group: list[list[int]]) -> None:
+        self._apply_groups(block_ids_by_group, materialize=True)
+
+    def _apply_groups(
+        self,
+        block_ids_by_group: list[list[int]],
+        *,
+        materialize: bool,
+    ) -> None:
+        if not self.layers:
+            return
+        with self._lock:
+            devices = {layer.cache.device for layer in self.layers.values()}
+            if len(devices) != 1:
+                raise ValueError("KDA transport layers must share one device")
+            device = next(iter(devices))
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+            for group_index, block_ids in enumerate(block_ids_by_group):
+                for layer in self._layers_by_group.get(group_index, ()):
+                    if materialize:
+                        layer.materialize_blocks(block_ids)
+                    else:
+                        layer.stage_blocks(block_ids)
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+
+
+def kda_target_state_transport_enabled(extra_config: dict[str, object]) -> bool:
+    return extra_config.get("kda_transport_policy") == KDA_TARGET_STATE_TRANSPORT

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -6,20 +6,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 import torch
-
-from vllm.config import VllmConfig
 from vllm.config.kv_transfer import KVTransferConfig
 from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBaseType
-from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
-from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    CopyBlocksOp,
-    KVConnectorBase_V1,
-    KVConnectorHandshakeMetadata,
-    KVConnectorMetadata,
-    KVConnectorRole,
-    KVConnectorWorkerMetadata,
-    SupportsHMA,
-)
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     KVConnectorPromMetrics,
     KVConnectorStats,
@@ -31,13 +19,26 @@ from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    CopyBlocksOp,
+    KVConnectorBase_V1,
+    KVConnectorHandshakeMetadata,
+    KVConnectorMetadata,
+    KVConnectorRole,
+    KVConnectorWorkerMetadata,
+    SupportsHMA,
+)
+
 if TYPE_CHECKING:
     from vllm.distributed.kv_events import KVCacheEvent
     from vllm.forward_context import ForwardContext
     from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-    from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
+
+    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
 
@@ -151,6 +152,16 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         return False
 
     @classmethod
+    def supports_kda_recoverssm_transport(cls, extra_config: dict[str, Any]) -> bool:
+        connectors_config = extra_config.get("connectors", [])
+        return bool(connectors_config) and all(
+            KVConnectorFactory.supports_kda_recoverssm_config(
+                KVTransferConfig(**connector_config)
+            )
+            for connector_config in connectors_config
+        )
+
+    @classmethod
     def all_children_support_hma(cls, kv_transfer_config: "KVTransferConfig") -> bool:
         """Return True only if every configured child connector supports HMA."""
         connectors_config = kv_transfer_config.kv_connector_extra_config.get(
@@ -165,6 +176,14 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             if not KVConnectorFactory.supports_hma_config(child_config):
                 return False
         return True
+
+    @classmethod
+    def all_children_support_kda_recoverssm(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        return cls.supports_kda_recoverssm_transport(
+            kv_transfer_config.kv_connector_extra_config
+        )
 
     def __init__(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -19,6 +19,25 @@ import msgspec
 import numpy as np
 import torch
 import zmq
+from vllm.distributed.kv_transfer.kv_connector.v1.kda_recoverssm_transport import (
+    KDATargetStateTransport,
+    kda_target_state_transport_enabled,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
+from vllm.distributed.parallel_state import (
+    get_pcp_group,
+    get_pp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+from vllm.utils.network_utils import make_zmq_path
+from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.v1.worker.block_table import BlockTable
+from vllm.v1.worker.utils import select_common_block_size
 
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     BlockIds,
@@ -31,7 +50,6 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
     kv_postprocess_layout_on_receive,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import CopyBlocksOp
-from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     GET_META_MSG,
     NixlAgentMetadata,
@@ -60,17 +78,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import
     MambaConvSplitInfo,
     derive_mamba_conv_split,
 )
-from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
-from vllm.distributed.parallel_state import (
-    get_pcp_group,
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
-)
-from vllm.logger import init_logger
-from vllm.platforms import current_platform
-from vllm.utils.gpu_sync_debug import gpu_sync_allowed
-from vllm.utils.network_utils import make_zmq_path
-from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.kv_cache_interface import (
     CircularBufferSpec,
     FullAttentionSpec,
@@ -83,8 +90,6 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
     iter_layer_specs,
 )
-from vllm.v1.worker.block_table import BlockTable
-from vllm.v1.worker.utils import select_common_block_size
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -158,16 +163,16 @@ class NixlBaseConnectorWorker:
         """Compute NIXL descriptor IDs for given block IDs."""
         num_ssm_regions = 0
         if self._has_mamba:
-            assert self._conv_decomp is not None
-            # NIXL regions per SSM layer = conv sub-projections + 1 SSM temporal
-            # (Mamba2/GDN: 3+1=4; Mamba1: 1+1=2).
-            ssm_regions_per_layer = len(self._conv_decomp.local_conv_offsets) + 1
-            # Count only the regions that actually hold SSM state; must match
-            # the descriptors emitted by _build_mamba_local.
-            num_ssm_regions = (
-                len(self._ssm_region_indices or self.block_len_per_layer)
-                * ssm_regions_per_layer
-            )
+            if getattr(self, "_kda_transport", None) is not None:
+                num_ssm_regions = len(self._ssm_region_indices)
+            else:
+                assert self._conv_decomp is not None
+                # NIXL regions per SSM layer = conv sub-projections + temporal.
+                ssm_regions_per_layer = len(self._conv_decomp.local_conv_offsets) + 1
+                num_ssm_regions = (
+                    len(self._ssm_region_indices or self.block_len_per_layer)
+                    * ssm_regions_per_layer
+                )
 
         num_blocks = dst_num_blocks
         if block_size_ratio is not None:
@@ -200,11 +205,21 @@ class NixlBaseConnectorWorker:
             spec_type = self._group_spec_types[i]
             if _is_attention_spec(spec_type):
                 # A scratch cache lives only in its own regions; every other
-                # attention group spans all of them.
+                # attention group spans all attention-backed HMA regions.
+                # KDA target-state staging uses independent allocations and
+                # must only be addressed by the SSM group's block table.
                 fa_region_ids = (
                     np.asarray(self._scratch_region_indices, dtype=np.int32)
                     if spec_type is CircularBufferSpec
-                    else np.arange(self.num_regions, dtype=np.int32)
+                    else np.asarray(
+                        [
+                            region_id
+                            for region_id in range(self.num_regions)
+                            if self._kda_transport is None
+                            or region_id not in self._ssm_region_indices
+                        ],
+                        dtype=np.int32,
+                    )
                 )[:, None]
                 all_descs.append(
                     (fa_region_ids * num_blocks + group_arr[None, :]).ravel()
@@ -376,6 +391,10 @@ class NixlBaseConnectorWorker:
         )
 
         self.kv_cache_config = kv_cache_config
+        self._kda_target_state_enabled = kda_target_state_transport_enabled(
+            vllm_config.kv_transfer_config.kv_connector_extra_config
+        )
+        self._kda_transport: KDATargetStateTransport | None = None
         # Per-layer specs, unwrapping UniformTypeKVCacheSpecs group wrappers.
         self._layer_specs: dict[str, KVCacheSpec] = {}
         for group in kv_cache_config.transfer_groups:
@@ -486,7 +505,7 @@ class NixlBaseConnectorWorker:
         # DCP support is scoped to MLA, with dcp_size in (1, tp_size): either fully
         # replicated or fully sharded. A DCP rank is always derivable this way.
         self.dcp_rank = self.tp_rank % self.dcp_size
-        if self._has_mamba and self.dcp_size > 1:
+        if self._has_mamba and self.dcp_size > 1 and not self._kda_target_state_enabled:
             # Prefix-cache-aware DCP slicing isn't implemented for the Mamba group.
             raise ValueError("DCP is not supported for hybrid MLA+Mamba models.")
 
@@ -557,22 +576,12 @@ class NixlBaseConnectorWorker:
         # (so 1 per layer for MLA, otherwise 2 per layer)
         self.num_regions = 0
 
-        # PP>1 (push mode): this worker holds a contiguous layer slice and
-        # transfers into the matching sub-range of a PP=1 remote's regions.
+        # PP>1: each worker holds a contiguous layer slice. Homogeneous P/D
+        # deployments transfer only between matching PP stages; the legacy
+        # PP-sharded producer -> PP1 consumer path keeps using region slicing.
         self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
+        self.pp_rank = get_pp_group().rank_in_group if self.pp_size > 1 else 0
         self._remote_region_offset = 0
-        # PP push slices regions per layer (uniform count); HMA breaks that.
-        if self.pp_size > 1 and self._is_hma_required:
-            raise NotImplementedError(
-                "NixlPushConnector does not support pipeline_parallel_size > 1 "
-                "with hybrid KV cache layouts (HMA) yet."
-            )
-        # Decode-side PP is unsupported (completions counted per consumer rank).
-        if vllm_config.kv_transfer_config.kv_role == "kv_consumer" and self.pp_size > 1:
-            raise NotImplementedError(
-                "NixlPushConnector consumer (decode) does not support "
-                "pipeline_parallel_size > 1."
-            )
         # Keep heartbeat handshakes to a PP-sharded producer notif-only.
         self._hb_handshake_notif_only = False
 
@@ -791,9 +800,10 @@ class NixlBaseConnectorWorker:
         best_rtt = float("inf")
         best_offset: float | None = None
 
+        remote_pp_ranks = self._remote_pp_ranks_for_handshake(remote_pp_size)
         with zmq_ctx(zmq.REQ, path) as sock:
             for remote_pp_rank, remote_rank in itertools.product(
-                range(remote_pp_size), p_remote_ranks
+                remote_pp_ranks, p_remote_ranks
             ):
                 logger.debug(
                     "Querying metadata on path: %s at remote pp rank %s, tp rank %s",
@@ -903,6 +913,26 @@ class NixlBaseConnectorWorker:
 
         assert best_offset is not None
         return remote_rank_to_agent_name, best_offset
+
+    def _remote_pp_ranks_for_handshake(self, remote_pp_size: int) -> tuple[int, ...]:
+        """Return the remote PP stages this worker may exchange KV with.
+
+        Hybrid KDA/MLA state is safe for PP only when both deployments use the
+        same pipeline partition: stage ``i`` then exchanges only with stage
+        ``i``. Mismatched HMA PP layouts remain fail-closed because slicing a
+        heterogeneous layer/state layout by a uniform region offset is unsafe.
+        """
+        if remote_pp_size < 1:
+            raise ValueError(f"remote_pp_size must be positive, got {remote_pp_size}")
+        if self.pp_size == remote_pp_size:
+            return (self.pp_rank,)
+        if self._is_hma_required and (self.pp_size > 1 or remote_pp_size > 1):
+            raise NotImplementedError(
+                "NIXL HMA pipeline transfer requires homogeneous pipeline "
+                "parallelism with matching P/D stage partitions; "
+                f"local PP={self.pp_size}, remote PP={remote_pp_size}."
+            )
+        return tuple(range(remote_pp_size))
 
     def _add_notif_only_remote_agent(
         self, metadata: NixlAgentMetadata, remote_tp_size: int, remote_dcp_size: int = 1
@@ -1129,6 +1159,24 @@ class NixlBaseConnectorWorker:
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""
 
+        if self._kda_target_state_enabled:
+            if self.use_host_buffer:
+                raise NotImplementedError(
+                    "KDA target-state transport does not support host staging"
+                )
+            self._kda_transport = KDATargetStateTransport.create(
+                kv_caches, self.kv_cache_config
+            )
+            if not self._kda_transport.layers:
+                raise ValueError(
+                    "KDA target-state transport was enabled but no KDA layers exist"
+                )
+            sample = next(iter(self._kda_transport.layers.values())).regions
+            self._mamba_ssm_size = (
+                sample[0].content_len_bytes,
+                sample[1].content_len_bytes,
+            )
+
         self.transfer_topo = TransferTopology(
             tp_rank=self.tp_rank,
             tp_size=self.world_size,
@@ -1280,28 +1328,54 @@ class NixlBaseConnectorWorker:
             # Memory registration follows allocations, while transfer regions follow
             # logical layers (or contiguous head segments). This keeps strided
             # cross-layer views inside their registered allocation.
-            if storage_addr not in seen_storage_addresses:
-                seen_storage_addresses.add(storage_addr)
-                self.device_id = max(cache.get_device(), 0)
-                caches_data.append((storage_addr, storage.nbytes(), self.device_id, ""))
+            def register_storage(tensor: torch.Tensor) -> None:
+                storage = tensor.untyped_storage()
+                storage_addr = storage.data_ptr()
+                if storage_addr not in seen_storage_addresses:
+                    seen_storage_addresses.add(storage_addr)
+                    self.device_id = max(tensor.get_device(), 0)
+                    caches_data.append(
+                        (storage_addr, storage.nbytes(), self.device_id, "")
+                    )
 
             is_mla_region = isinstance(
                 layer_spec, (MLAAttentionSpec, SlidingWindowMLASpec)
             )
 
             if isinstance(layer_spec, MambaSpec):
-                physical_ratio = self._physical_blocks_per_logical_kv_block
-                block_len = physical_page_size // physical_ratio
-                block_stride = physical_page_size
-                if self._is_csa_linear and cache.ndim != 1:
-                    # CSA-linear packs multiple cache owners in each block, so
-                    # state views advance by the packed block stride.
-                    block_stride = cache.stride(0) * cache.element_size()
-                assert block_stride % physical_ratio == 0
-                region_specs = [
-                    (cache.data_ptr(), block_len, block_stride // physical_ratio)
-                ]
+                if self._kda_transport is not None:
+                    regions = self._kda_transport.regions_for_layer(layer_name)
+                    if not regions:
+                        raise ValueError(
+                            f"Missing KDA transport regions for {layer_name}"
+                        )
+                    for region in regions:
+                        register_storage(region.tensor)
+                    region_specs = [
+                        (
+                            region.tensor.data_ptr(),
+                            region.content_len_bytes,
+                            region.block_stride_bytes,
+                        )
+                        for region in regions
+                    ]
+                else:
+                    register_storage(cache)
+                    physical_ratio = self._physical_blocks_per_logical_kv_block
+                    block_len = physical_page_size // physical_ratio
+                    block_stride = physical_page_size
+                    if self._is_csa_linear and cache.ndim != 1:
+                        # CSA-linear packs multiple cache owners in each block, so
+                        # state views advance by the packed block stride.
+                        block_stride = cache.stride(0) * cache.element_size()
+                    assert block_stride % physical_ratio == 0
+                    region_specs = [
+                        (cache.data_ptr(), block_len, block_stride // physical_ratio)
+                    ]
             else:
+                register_storage(cache)
+                storage = cache.untyped_storage()
+                storage_addr = storage.data_ptr()
                 if cache.ndim == 1:
                     # Flat byte view: HMA tensors shared between layer types carry
                     # no block dimension, so stride(0) is 1 byte. Blocks abut, so
@@ -1390,7 +1464,8 @@ class NixlBaseConnectorWorker:
             # When there's a mismatch between kbs<>bs, we rely on HMA to ensure
             # caches are either [NB, PS] or [NB*r, PS/r] where r is bs/kbs.
             if (
-                self._physical_blocks_per_logical_kv_block == 1
+                self._kda_transport is None
+                and self._physical_blocks_per_logical_kv_block == 1
                 and cache.shape[0] != num_blocks
             ):
                 raise AssertionError(
@@ -1421,7 +1496,7 @@ class NixlBaseConnectorWorker:
         self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
         self.num_regions = len(seen_base_addresses)
 
-        if self.pp_size > 1:
+        if self.pp_size > 1 and not self._is_hma_required:
             start_layer, end_layer = self.model_config.get_layers_start_end_indices(
                 self.vllm_config.parallel_config
             )
@@ -1429,6 +1504,9 @@ class NixlBaseConnectorWorker:
             assert num_local_layers > 0 and self.num_regions % num_local_layers == 0
             regions_per_layer = self.num_regions // num_local_layers
             self._remote_region_offset = regions_per_layer * start_layer
+        # HMA regions are not uniform per transformer layer. Homogeneous PP
+        # never slices them: stage i handshakes directly with remote stage i,
+        # whose descriptor list already covers the same layer/state partition.
 
         # Total local FA descriptors (boundary between FA and mamba descs).
         self.num_descs = self.num_regions * self.num_blocks
@@ -1524,6 +1602,17 @@ class NixlBaseConnectorWorker:
         ratio-expanded (see _compute_desc_ids).
         """
         assert base_addresses, "Local KV cache base addresses must not be empty."
+        if getattr(self, "_kda_transport", None) is not None:
+            num_blocks = self._logical_num_blocks
+            block_arange = np.arange(num_blocks, dtype=np.uint64)
+            parts = []
+            for region_index in self._ssm_region_indices:
+                block_len = self.block_len_per_layer[region_index]
+                block_stride = self.block_stride_per_layer[region_index]
+                block_addrs = base_addresses[region_index] + block_arange * block_stride
+                parts.append(self._stack_descs(block_addrs, block_len, self.device_id))
+            return np.concatenate(parts)
+
         assert self._conv_decomp is not None
         conv_offsets = self._conv_decomp.local_conv_offsets
         conv_size, ssm_size = self._mamba_ssm_size
@@ -1565,6 +1654,33 @@ class NixlBaseConnectorWorker:
         assert nixl_agent_meta.kv_caches_base_addr, (
             "Remote KV cache base addresses must not be empty."
         )
+        if getattr(self, "_kda_transport", None) is not None:
+            num_blocks = nixl_agent_meta.num_blocks // (
+                transfer_info.remote_physical_blocks_per_logical
+            )
+            block_arange = np.arange(num_blocks, dtype=np.uint64)
+            parts = []
+            for region_index in self._ssm_region_indices:
+                local_len = self.block_len_per_layer[region_index]
+                remote_len = nixl_agent_meta.block_lens[region_index]
+                if local_len != remote_len:
+                    raise ValueError(
+                        "KDA target-state region length mismatch: "
+                        f"local={local_len}, remote={remote_len}, "
+                        f"region={region_index}"
+                    )
+                remote_stride = nixl_agent_meta.block_strides[region_index]
+                block_addrs = (
+                    nixl_agent_meta.kv_caches_base_addr[region_index]
+                    + block_arange * remote_stride
+                )
+                parts.append(
+                    self._stack_descs(
+                        block_addrs, remote_len, nixl_agent_meta.device_id
+                    )
+                )
+            return np.concatenate(parts)
+
         assert self._conv_decomp is not None
         effective_ratio = max(tp_ratio, 1)
         # Mamba conv state is always TP-sharded, even when attention KV
@@ -2363,6 +2479,11 @@ class NixlBaseConnectorWorker:
             assert meta.remote is not None
             if self.use_host_buffer:
                 self.sync_recved_kv_to_device(req_id, meta)
+
+            if self._kda_transport is not None:
+                self._kda_transport.materialize_groups(
+                    [list(group) for group in meta.local_block_ids]
+                )
 
             # Post processing for heteroblocksize/layout, and for blocks the
             # transfer clipped. The latter happens either at remote-block

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -15,6 +15,17 @@ and worker classes; the connector classes here only forward calls.
 from typing import TYPE_CHECKING, Any
 
 import torch
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.forward_context import ForwardContext
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
@@ -28,11 +39,11 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
-    KVConnectorPromMetrics,
-    KVConnectorStats,
-    PromMetric,
-    PromMetricT,
+from vllm.distributed.kv_transfer.kv_connector.v1.dspark_context_transport import (
+    dspark_context_kv_transport_enabled,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.kda_recoverssm_transport import (
+    kda_target_state_transport_enabled,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlConnectorMetadata,
@@ -53,22 +64,18 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats import (
     NixlKVConnectorStats,
     NixlPromMetrics,
 )
-from vllm.forward_context import ForwardContext
-from vllm.logger import init_logger
-from vllm.v1.attention.backend import AttentionMetadata
-from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.outputs import KVConnectorOutput
 
 if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.request import Request
+
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
         NixlBaseConnectorScheduler,
     )
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
         NixlBaseConnectorWorker,
     )
-    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
-    from vllm.v1.request import Request
 
 logger = init_logger(__name__)
 
@@ -362,6 +369,14 @@ class NixlPullConnector(NixlBaseConnector):
 class NixlPushConnector(NixlBaseConnector):
     """Push-based (WRITE) NIXL KV transfer connector."""
 
+    @classmethod
+    def supports_kda_recoverssm_transport(cls, extra_config: dict[str, Any]) -> bool:
+        return kda_target_state_transport_enabled(extra_config)
+
+    @classmethod
+    def supports_dspark_context_transport(cls, extra_config: dict[str, Any]) -> bool:
+        return dspark_context_kv_transport_enabled(extra_config)
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -369,10 +384,6 @@ class NixlPushConnector(NixlBaseConnector):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, role, kv_cache_config)
-        if vllm_config.parallel_config.decode_context_parallel_size > 1:
-            raise ValueError(
-                "NixlPushConnector does not support decode_context_parallel_size > 1."
-            )
         self.connector_scheduler: NixlPushConnectorScheduler | None = None
         self.connector_worker: NixlPushConnectorWorker | None = None
         if role == KVConnectorRole.SCHEDULER:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -5,13 +5,14 @@
 from dataclasses import dataclass
 from typing import Any
 
+from vllm.logger import init_logger
+
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds, EngineId
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
 )
-from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
@@ -46,8 +47,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   8: Add dcp_size and pcp_size to NixlAgentMetadata
 #   9: Add block_strides
 #  10: Add dense virtual transfer pages for compressed MLA caches
+#  11: Add KDA target-state and DSpark context transport policies
 #
-NIXL_CONNECTOR_VERSION: int = 10
+NIXL_CONNECTOR_VERSION: int = 11
 
 
 @dataclass
@@ -162,12 +164,15 @@ def compute_nixl_compatibility_hash(
     Returns:
         SHA-256 hex digest
     """
-    from vllm import __version__ as vllm_version
     from vllm.config.utils import hash_factors
+
+    from vllm import __version__ as vllm_version
 
     model_config = vllm_config.model_config
     cache_config = vllm_config.cache_config
     is_hma_enabled = not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+    assert vllm_config.kv_transfer_config is not None
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
 
     factors = {
         # Version compatibility
@@ -184,6 +189,10 @@ def compute_nixl_compatibility_hash(
         "cache_dtype": str(cache_config.cache_dtype),
         "is_hma_enabled": is_hma_enabled,
         "speculative_config": _get_speculative_compatibility_factors(vllm_config),
+        "kda_transport_policy": extra_config.get("kda_transport_policy"),
+        "dspark_context_transport_policy": extra_config.get(
+            "dspark_context_transport_policy"
+        ),
         # push (WRITE) and pull (READ) connectors are protocol-incompatible
         "transfer_mode": transfer_mode,
     }

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any
 
+from vllm.logger import init_logger
+
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
@@ -38,15 +40,15 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlConnectorMetadata,
     ReqId,
 )
-from vllm.logger import init_logger
 
 if TYPE_CHECKING:
-    from vllm.config import VllmConfig
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.core.sched.output import SchedulerOutput
-    from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.outputs import KVConnectorOutput
     from vllm.v1.request import Request
+
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 logger = init_logger(__name__)
 
@@ -180,11 +182,16 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             "decode_host": self.side_channel_host,
             "decode_port": self.side_channel_port,
             "decode_tp_size": (self.vllm_config.parallel_config.tensor_parallel_size),
+            "decode_dcp_size": (
+                self.vllm_config.parallel_config.decode_context_parallel_size
+            ),
+            "decode_pp_size": (self.vllm_config.parallel_config.pipeline_parallel_size),
             "local_block_ids": local_block_ids,
             "remote_engine_id": params["remote_engine_id"],
             "remote_host": params["remote_host"],
             "remote_port": params["remote_port"],
             "remote_tp_size": params["tp_size"],
+            "remote_dcp_size": params.get("dcp_size", 1),
             "remote_pp_size": params.get("pp_size", 1),
         }
         self._push_registration_deadlines[request.request_id] = (
@@ -287,6 +294,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            dcp_size=self.vllm_config.parallel_config.decode_context_parallel_size,
             pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
             remote_num_tokens=remote_num_tokens,
             transfer_mode=self._TRANSFER_MODE,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -39,6 +39,7 @@ from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any
 
 import msgspec
+from vllm.logger import init_logger
 
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
@@ -55,9 +56,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     ReadSpec,
     _is_attention_spec,
+    compute_tp_mapping,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import get_base_request_id
-from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     import torch
@@ -313,6 +314,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             reg_data["remote_host"],
             reg_data["remote_port"],
             reg_data["remote_tp_size"],
+            dcp_size=reg_data.get("remote_dcp_size", 1),
             pp_size=remote_pp_size,
             # D only ever sends PUSH_REG notifs to P and never reads or writes
             # P's memory in push mode, so it never needs the transfer
@@ -436,6 +438,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             registration_data["decode_host"],
             registration_data["decode_port"],
             registration_data["decode_tp_size"],
+            dcp_size=registration_data.get("decode_dcp_size", 1),
+            pp_size=registration_data.get("decode_pp_size", 1),
         )
         if fut is not None:
 
@@ -462,6 +466,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
 
         logical_local = self._as_grouped_block_ids(local_block_ids)
         logical_remote = self._as_grouped_block_ids(remote_block_ids)
+        if self._kda_transport is not None:
+            self._kda_transport.stage_groups([list(group) for group in logical_local])
         physical_local = self._logical_to_kernel_block_ids(
             logical_local, self._physical_blocks_per_logical_kv_block
         )
@@ -730,11 +736,24 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             # Not tracked as a P-side send/process for this notif.
             if req_id not in self._reqs_to_send and req_id not in self._reqs_to_process:
                 if (meta := self._recving_metadata.get(req_id)) is not None:
-                    # Consumer waits for one notif per producer rank writing
-                    # here: pp_size stages * producers-per-consumer (>1 when
-                    # producer TP > consumer TP; tp_size is the producer TP).
-                    producers_per_consumer = max(1, int(tp_size) // self.world_size)
-                    expected_notifs = meta.pp_size * producers_per_consumer
+                    # Consumer waits for one notification from every producer
+                    # rank whose group mapping writes into this rank. DCP can
+                    # make multiple homogeneous-TP producers overlap for MLA,
+                    # while KDA target state remains rank-sharded.
+                    producer_plan = compute_tp_mapping(
+                        transfer_topology=self.transfer_topo,
+                        remote_tp_size=int(tp_size),
+                        group_spec_types=self._group_spec_types,
+                        remote_dcp_size=meta.dcp_size,
+                    )
+                    producers_per_consumer = len(producer_plan.all_source_ranks)
+                    # Homogeneous PP pairs stage i with stage i. The legacy
+                    # PP-sharded producer -> PP1 consumer path still receives
+                    # one notification from every producer stage.
+                    stage_matched_pp = self.pp_size > 1 and self.pp_size == meta.pp_size
+                    expected_notifs = producers_per_consumer * (
+                        1 if stage_matched_pp else meta.pp_size
+                    )
                     self.consumer_notification_counts_by_req[req_id] += 1
                     notifs = self.consumer_notification_counts_by_req[req_id]
                     if notifs < expected_notifs:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/tp_mapping.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/tp_mapping.py
@@ -110,7 +110,11 @@ def compute_tp_mapping(
     # --- SSM source ranks ---
     has_ssm = any(_is_ssm_spec(t) for t in group_spec_types)
     if has_ssm:
-        if tp_size < remote_tp_size:
+        if tp_size == remote_tp_size:
+            # Unlike replicated MLA pages, SSM target state remains TP
+            # sharded even when DCP makes multiple attention ranks overlap.
+            ssm_ranks = [tp_rank]
+        elif tp_size < remote_tp_size:
             abs_tp = remote_tp_size // tp_size
             ssm_ranks = list(range(tp_rank * abs_tp, (tp_rank + 1) * abs_tp))
         else:


### PR DESCRIPTION
## TL;DR

Adds fail-closed NIXL Push transport for hybrid MLA + KDA by transferring only target convolution history and base recurrent state, then initializing RecoverSSM-only records locally. It also adds homogeneous PP-stage pairing and DCP-aware rank/completion mapping so replicated MLA and TP-sharded KDA state cannot be confused.

## Purpose

Add an explicit, fail-closed NIXL Push transport contract for hybrid MLA + KDA deployments where the producer and RecoverSSM consumer use different physical KDA page layouts.

The connector now:

- transfers only the target convolution history and base recurrent state instead of copying an opaque KDA page;
- initializes RecoverSSM-only verify, correction, and key/gate records locally on the consumer;
- rejects ordinary speculative scratch blocks and connectors that do not declare this capability;
- carries DCP metadata through the push handshake, maps replicated MLA slices separately from TP-sharded KDA state, and waits for every overlapping DCP producer;
- supports homogeneous TP/PP deployments by pairing matching pipeline stages and rejects mismatched hybrid PP layouts;
- includes DSpark prompt-context transport policy in the compatibility handshake so incompatible peers cannot silently connect.

This is an early-review Draft. The intended first topology is homogeneous P/D TP, PP, and DCP with `NixlPushConnector`, RecoverSSM, and DSpark context KV. It does not claim heterogeneous PP or NIXL Pull support.

Related tracking: #40017. This complements the Mooncake-specific work in #54875 but uses NIXL Push and preserves speculative decoding when compatible DSpark context pages are present.

## Test Plan

- CPU unit tests for no-spec to RecoverSSM target-state conversion with block4/block7 and DCP1/DCP4 cases.
- Unit tests for homogeneous RecoverSSM materialization and rejection of ordinary speculative scratch blocks.
- NIXL descriptor tests ensuring attention block IDs cannot address KDA staging regions.
- TP/DCP mapping and push completion-count tests for overlapping MLA ranks and TP-sharded KDA state.
- Homogeneous PP stage-selection and mismatched-HMA-PP fail-closed tests.
- Follow-up GPU E2E validation on homogeneous TP8 x PP2 x DCP4 P/D nodes before marking ready for review.

## Test Result

- `ruff check`: passed for all changed files.
- `ruff format --check`: passed for all changed files.
- `typos`: passed for all changed files.
- Python bytecode compilation: passed.
- `git diff --check`: passed.
- PyTorch/pytest and GPU E2E tests were not run in this macOS worktree because PyTorch and pytest are unavailable. This PR remains Draft until targeted Linux/GPU validation is attached.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including scope and related tracking.
- [x] The test plan and exact validation categories.
- [x] The currently available test results and explicit missing GPU coverage.
- [x] No user-facing documentation update is required while this remains an experimental Draft.
</details>