### PR TITLE
[Perf][Reasoning] Cache thinking-token history membership

### DIFF
--- a/tests/reasoning/test_deepseekr1_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekr1_reasoning_parser.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Sequence
+from typing import overload
+
 import pytest
 from transformers import AutoTokenizer
 
 from tests.reasoning.utils import run_reasoning_extraction
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
 
 parser_name = "deepseek_r1"
 start_token = "<think>"
@@ -17,6 +21,85 @@ REASONING_MODEL_NAME = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 @pytest.fixture(scope="module")
 def deepseek_r1_qwen_tokenizer():
     return AutoTokenizer.from_pretrained(REASONING_MODEL_NAME)
+
+
+class _CountingSequence(Sequence[int]):
+    items_read = 0
+
+    def __init__(self, values: list[int]) -> None:
+        self._values = values
+
+    @overload
+    def __getitem__(self, index: int) -> int: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[int]: ...
+
+    def __getitem__(self, index: int | slice) -> int | Sequence[int]:
+        if isinstance(index, slice):
+            value = self._values[index]
+            type(self).items_read += len(value)
+            return value
+        type(self).items_read += 1
+        return self._values[index]
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+
+class _TestTokenizer:
+    def get_vocab(self) -> dict[str, int]:
+        return {"<think>": 1, "</think>": 2, "token": 3}
+
+
+def test_streaming_membership_only_reads_new_token_ids():
+    parser = DeepSeekR1ReasoningParser(_TestTokenizer())
+    _CountingSequence.items_read = 0
+
+    for length in range(500):
+        previous_ids = [3] * length
+        delta = parser.extract_reasoning_streaming(
+            previous_text="x" * length,
+            current_text="x" * (length + 1),
+            delta_text="x",
+            previous_token_ids=_CountingSequence(previous_ids),
+            current_token_ids=previous_ids + [3],
+            delta_token_ids=[3],
+        )
+        assert delta is not None
+        assert delta.reasoning == "x"
+
+    # The cache reads the new tail plus constant-size boundary checks.
+    # Re-scanning the accumulated list per probe would read ~125k items.
+    assert _CountingSequence.items_read <= 3 * 500
+
+
+def test_streaming_membership_rebuilds_after_history_rewind():
+    parser = DeepSeekR1ReasoningParser(_TestTokenizer())
+
+    # History holds both markers, so the delta is post-reasoning content.
+    delta = parser.extract_reasoning_streaming(
+        previous_text="<think>a</think>",
+        current_text="<think>a</think>b",
+        delta_text="b",
+        previous_token_ids=[1, 3, 2],
+        current_token_ids=[1, 3, 2, 3],
+        delta_token_ids=[3],
+    )
+    assert delta is not None
+    assert delta.content == "b"
+
+    # A rewound history must not leave the stale markers in the cache.
+    delta = parser.extract_reasoning_streaming(
+        previous_text="a",
+        current_text="ab",
+        delta_text="b",
+        previous_token_ids=[3],
+        current_token_ids=[3, 3],
+        delta_token_ids=[3],
+    )
+    assert delta is not None
+    assert delta.reasoning == "b"
 
 
 SIMPLE_REASONING = {

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -69,6 +69,10 @@ class BaseThinkingReasoningParser(ReasoningParser):
         self.start_token_id: int = start_token_id
         self.end_token_id: int = end_token_id
 
+        self._seen_token_ids: set[int] = set()
+        self._seen_len = 0
+        self._seen_tail: int | None = None
+
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         start_token_id = self.start_token_id
         end_token_id = self.end_token_id
@@ -95,6 +99,27 @@ class BaseThinkingReasoningParser(ReasoningParser):
         else:
             return input_ids[input_ids.index(self.end_token_id) + 1 :]
 
+    def _refresh_seen_token_ids(self, previous_token_ids: Sequence[int]) -> None:
+        """Refresh the cached set of token ids seen so far in this stream.
+
+        ``previous_token_ids`` grows by one delta per streaming call, so
+        probing it with ``in`` costs O(len) per call and O(n^2) over a
+        completion. Mirroring it into a set keeps those probes constant time.
+        Only the newly appended tail is folded in; if the caller hands over a
+        sequence that does not extend the previous one, the set is rebuilt.
+        """
+        length = len(previous_token_ids)
+        extends_previous = length >= self._seen_len and (
+            self._seen_len == 0
+            or previous_token_ids[self._seen_len - 1] == self._seen_tail
+        )
+        if extends_previous:
+            self._seen_token_ids.update(previous_token_ids[self._seen_len :])
+        else:
+            self._seen_token_ids = set(previous_token_ids)
+        self._seen_len = length
+        self._seen_tail = previous_token_ids[-1] if length else None
+
     def extract_reasoning_streaming(
         self,
         previous_text: str,
@@ -109,6 +134,8 @@ class BaseThinkingReasoningParser(ReasoningParser):
         Handles streaming output where previous + delta = current.
         Uses token IDs for faster processing.
         """
+        self._refresh_seen_token_ids(previous_token_ids)
+
         # Skip single special tokens
         if len(delta_token_ids) == 1 and (
             delta_token_ids[0] in [self.start_token_id, self.end_token_id]
@@ -117,7 +144,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
 
         # Check if start token is present in previous or delta.
         # Keep compatibility with models that don't generate start tokens.
-        if self.start_token_id in previous_token_ids:
+        if self.start_token_id in self._seen_token_ids:
             if self.end_token_id in delta_token_ids:
                 # start token in previous, end token in delta,
                 # extract reasoning content
@@ -127,7 +154,7 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 return DeltaMessage(
                     reasoning=reasoning, content=content if content else None
                 )
-            elif self.end_token_id in previous_token_ids:
+            elif self.end_token_id in self._seen_token_ids:
                 # start token in previous, end token in previous,
                 # reasoning content continues
                 return DeltaMessage(content=delta_text)

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -44,7 +44,7 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
         )
         if (
             ret is not None
-            and self.start_token_id not in previous_token_ids
+            and self.start_token_id not in self._seen_token_ids
             and self.start_token_id not in delta_token_ids
         ):
             if self.end_token_id in delta_token_ids:
@@ -57,7 +57,7 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
                     reasoning=reasoning,
                     content=content if content else None,
                 )
-            elif self.end_token_id in previous_token_ids:
+            elif self.end_token_id in self._seen_token_ids:
                 # end token in previous, thinking content ends
                 return DeltaMessage(content=delta_text)
             else:


### PR DESCRIPTION
## Purpose

`BaseThinkingReasoningParser.extract_reasoning_streaming` probes the accumulated `previous_token_ids` with `in` several times per streamed delta. `previous_token_ids` is the full output history, so each probe scans a growing prefix: O(len) per call and O(n²) over a completion. On long reasoning responses this shows up as steadily rising inter-token latency.

This change mirrors the history into a set that is extended by the newly appended tail on each call, and probes the set instead. Membership becomes O(1) amortized.

The cache is derived entirely from the argument the caller passes in. When the incoming sequence does not extend the previous one — a rewind, or a fresh stream on a reused parser instance — the set is rebuilt from scratch rather than assuming a particular call pattern. That keeps the change safe without having to prove that `extract_reasoning_streaming` is always invoked exactly once per delta, in order.

Fixing this in the base class covers every `<think>`-style parser built on it, including `deepseek_r1` and the parsers that delegate to it (`deepseek_v3`, `holo2`, `poolside_v1`).

Parser-only microbenchmark, one single-token delta per step, history grown in place so the harness stays O(1):

| generated tokens | before | after | speedup |
| ---: | ---: | ---: | ---: |
| 5,000 | 0.0462 s | 0.0061 s | 7.5x |
| 20,000 | 0.6973 s | 0.0245 s | 28.4x |

4x more tokens costs the current code ~15x more time (quadratic) and the patched code ~4x more (linear).

This PR is scoped to the repeated membership scans. It does not change how the frontend constructs the accumulated token histories.

### Duplicate check

Before submission I searched open PRs and issues for `previous_token_ids reasoning parser O(n²)`, `streaming reasoning parser quadratic`, and `membership previous_token_ids`; no PR covers this extraction path. #51238 optimizes `is_reasoning_end_streaming` for engine-backed parsers, and #54454 addresses full-sequence decoding in the Muse Glimmer parser. Neither touches these membership scans.

## Test Plan

```bash
python -m pytest tests/reasoning/ -q --ignore=tests/reasoning/test_cohere_command_reasoning_parser.py
python -m pytest tests/reasoning/test_deepseekr1_reasoning_parser.py \
                 tests/reasoning/test_deepseekv3_reasoning_parser.py \
                 tests/reasoning/test_base_thinking_reasoning_parser.py -q
pre-commit run --files vllm/reasoning/basic_parsers.py \
                       vllm/reasoning/deepseek_r1_reasoning_parser.py \
                       tests/reasoning/test_deepseekr1_reasoning_parser.py
```

Parser output is unchanged, so the existing suite is the primary check. Two regression tests were added:

- `test_streaming_membership_only_reads_new_token_ids` drives 500 deltas through a counting `Sequence` and asserts the parser reads only the new tail plus constant-size boundary checks. Reverting the cache takes this from ~1.5k element reads to ~127k.
- `test_streaming_membership_rebuilds_after_history_rewind` asserts a rewound history clears stale markers. Forcing the append-only path unconditionally makes it fail.

I verified both tests fail against mutated implementations, so neither is vacuous.

## Test Result

```text
435 passed  (tests/reasoning, cohere parser skipped: cohere_melody not installed)
 54 passed  (deepseek_r1 + deepseek_v3 + base_thinking)
```

`ruff check` and `ruff format --check` are clean on all three changed files.

---

AI assistance (Cursor) was used to trace the call path, implement the change, and run the tests. The submitter reviewed every changed line, understands the implementation, and personally ran the relevant tests before submission.

Made with [Cursor](https://cursor.com)
