### PR TITLE
[KV Connector][Mooncake] Add endpoint-neutral semantic region keys

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_layout.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_layout.py
@@ -7,15 +7,18 @@ import random
 
 import pytest
 import torch
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.kv_cache_utils import BlockHash
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     LBHNCStoreLayout,
     LBNHCStoreLayout,
+    PoolKey,
     RankLocalStoreLayout,
+    endpoint_neutral_region_metadata,
 )
-from vllm.utils.math_utils import cdiv
 
 BLOCK_SIZE = 128
 
@@ -77,6 +80,90 @@ def test_rank_local_descriptors_handle_empty_and_invalid_chunks():
     assert layout.prepare_values([], [1, 2, 3], []) == ([], [], [])
     with pytest.raises(AssertionError):
         layout.prepare_values([(0, BLOCK_SIZE + 1)], [0, 1], [0])
+
+
+def test_semantic_region_key_is_endpoint_neutral():
+    prefill = KeyMetadata(
+        "test-model",
+        tp_rank=2,
+        pcp_rank=0,
+        dcp_rank=2,
+        pp_rank=0,
+        group_id=1,
+        cache_prefix="experiment",
+        store_namespace="@schema:v1",
+    )
+    decode = KeyMetadata(
+        "test-model",
+        tp_rank=2,
+        pcp_rank=0,
+        dcp_rank=2,
+        pp_rank=1,
+        group_id=5,
+        cache_prefix="experiment",
+        store_namespace="@schema:v1",
+    )
+
+    prefill_region = endpoint_neutral_region_metadata(prefill, "layer.4:target_conv")
+    decode_region = endpoint_neutral_region_metadata(decode, "layer.4:target_conv")
+
+    assert (
+        PoolKey(prefill_region, "abc").to_string()
+        == PoolKey(decode_region, "abc").to_string()
+    )
+    assert (
+        "@pp_rank:-1@group:-1@region:layer.4:target_conv@abc"
+        in PoolKey(prefill_region, "abc").to_string()
+    )
+
+
+def test_legacy_key_format_is_unchanged_without_region_id():
+    metadata = KeyMetadata("test-model", 1, 2, 3, 4, group_id=5)
+    assert (
+        PoolKey(metadata, "abc").to_string()
+        == "test-model@tp_rank:1@pcp2@dcp3@pp_rank:4@group:5@abc"
+    )
+
+
+def test_semantic_region_database_separates_content_length_from_stride():
+    database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 1, 0, 1, 1, group_id=7),
+        block_size=16,
+    )
+    region = ChunkedTokenDatabase.from_semantic_region(
+        database,
+        region_id="layer.9:base_recurrent",
+        base_addr=0x1000,
+        block_stride=4096,
+        content_len=768,
+    )
+
+    assert region.key_for(BlockHash(b"hash")).startswith(
+        "test-model@tp_rank:1@pcp0@dcp1@pp_rank:-1@group:-1"
+        "@region:layer.9:base_recurrent@"
+    )
+    assert region.prepare_value_for_block(3) == ([0x1000 + 3 * 4096], [768])
+
+    region.store_layout.set_block_stride([0])
+    assert region.prepare_value_for_block(3) == ([0x1000], [768])
+
+
+@pytest.mark.parametrize(
+    ("block_stride", "content_len"),
+    [(63, 64), (0, 0), (-1, 1)],
+)
+def test_semantic_region_database_rejects_invalid_geometry(
+    block_stride: int, content_len: int
+):
+    database = ChunkedTokenDatabase(KeyMetadata("test-model", 0, 0, 0, 0), 16)
+    with pytest.raises(ValueError, match="stride"):
+        ChunkedTokenDatabase.from_semantic_region(
+            database,
+            region_id="layer.0:page",
+            base_addr=0x1000,
+            block_stride=block_stride,
+            content_len=content_len,
+        )
 
 
 @pytest.mark.parametrize(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -6,12 +6,11 @@
 """Data classes for MooncakeStoreConnector."""
 
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import cast
 
 import numpy as np
 import torch
-
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorWorkerMetadata,
@@ -115,6 +114,19 @@ class KeyMetadata:
     # Complete namespace for an opt-in Store payload format. Empty keeps
     # historical keys byte-identical.
     store_namespace: str = ""
+    # Optional semantic identity for one transport field. Semantic data uses
+    # endpoint-neutral PP/group ranks; legacy keys leave this empty.
+    region_id: str = ""
+
+
+def endpoint_neutral_region_metadata(
+    metadata: KeyMetadata,
+    region_id: str,
+) -> KeyMetadata:
+    """Return metadata for a field whose identity is independent of HMA layout."""
+    if not region_id:
+        raise ValueError("Semantic region ID must not be empty")
+    return replace(metadata, pp_rank=-1, group_id=-1, region_id=region_id)
 
 
 @dataclass(order=True)
@@ -135,6 +147,7 @@ class PoolKey:
                 self.key_metadata.dcp_rank,
                 self.key_metadata.pp_rank,
                 self.key_metadata.group_id,
+                self.key_metadata.region_id,
                 self.chunk_hash,
             )
         )
@@ -147,10 +160,12 @@ class PoolKey:
         pcp_rank: int | None = None,
         dcp_rank: int | None = None,
         pp_rank: int | None = None,
+        group_id: int | None = None,
+        region_id: str | None = None,
     ) -> str:
         """Return the stable prefix for a Mooncake pool key."""
         prefix = f"{key_metadata.cache_prefix}@" if key_metadata.cache_prefix else ""
-        return (
+        key_prefix = (
             f"{prefix}"
             f"{key_metadata.model_name}"
             f"{key_metadata.store_namespace}"
@@ -158,8 +173,12 @@ class PoolKey:
             f"@pcp{key_metadata.pcp_rank if pcp_rank is None else pcp_rank}"
             f"@dcp{key_metadata.dcp_rank if dcp_rank is None else dcp_rank}"
             f"@pp_rank:{key_metadata.pp_rank if pp_rank is None else pp_rank}"
-            f"@group:{key_metadata.group_id}"
+            f"@group:{key_metadata.group_id if group_id is None else group_id}"
         )
+        resolved_region_id = key_metadata.region_id if region_id is None else region_id
+        if resolved_region_id:
+            key_prefix += f"@region:{resolved_region_id}"
+        return key_prefix
 
     @staticmethod
     def build_key_string(key_prefix: str, chunk_hash: str) -> str:
@@ -235,6 +254,7 @@ class RankLocalStoreLayout(StoreLayout):
         self._key_prefix = PoolKey.build_prefix(metadata)
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
+        self.block_stride: list[int] = []
 
     @property
     def local_shard_ids(self) -> tuple[StoreShardId, ...]:
@@ -264,6 +284,25 @@ class RankLocalStoreLayout(StoreLayout):
 
     def set_block_len(self, block_lens: list[int]) -> None:
         self.block_len = block_lens
+        # Historical layouts store complete dense pages, so content length and
+        # physical stride are identical unless a semantic descriptor overrides it.
+        self.block_stride = list(block_lens)
+
+    def set_block_stride(self, block_strides: list[int]) -> None:
+        if len(block_strides) != len(self.block_len):
+            raise ValueError("Block stride and content length counts must match")
+        if any(
+            content_len <= 0
+            or block_stride < 0
+            or (block_stride != 0 and block_stride < content_len)
+            for content_len, block_stride in zip(
+                self.block_len, block_strides, strict=True
+            )
+        ):
+            raise ValueError(
+                "Block stride must be zero or cover a positive content length"
+            )
+        self.block_stride = block_strides
 
     def register_kv_caches(
         self,
@@ -302,6 +341,7 @@ class RankLocalStoreLayout(StoreLayout):
                 block_lens.append(cache.stride(0) * cache.element_size())
         self.kv_caches_base_addr = base_addrs
         self.block_len = block_lens
+        self.block_stride = list(block_lens)
 
     def prepare_values(
         self,
@@ -329,7 +369,11 @@ class RankLocalStoreLayout(StoreLayout):
             dtype=np.int64,
             count=n,
         )
-        addrs = base[None, :] + bids[:, None] * blen[None, :]
+        stride = np.asarray(
+            [self.block_stride[i % length] for i in range(base.shape[0])],
+            dtype=np.int64,
+        )
+        addrs = base[None, :] + bids[:, None] * stride[None, :]
         block_counts = (spans + self.block_size - 1) // self.block_size
         sizes = blen[None, :] * block_counts[:, None]
         return addrs.tolist(), sizes.tolist(), bids.tolist()
@@ -338,7 +382,7 @@ class RankLocalStoreLayout(StoreLayout):
         length = len(self.block_len)
         return (
             [
-                base_addr + block_id * self.block_len[index % length]
+                base_addr + block_id * self.block_stride[index % length]
                 for index, base_addr in enumerate(self.kv_caches_base_addr)
             ],
             [
@@ -574,6 +618,33 @@ class ChunkedTokenDatabase:
             )
         self.store_layout = store_layout or RankLocalStoreLayout(
             metadata, block_size, self.hash_block_size
+        )
+
+    @classmethod
+    def from_semantic_region(
+        cls,
+        database: "ChunkedTokenDatabase",
+        *,
+        region_id: str,
+        base_addr: int,
+        block_stride: int,
+        content_len: int,
+    ) -> "ChunkedTokenDatabase":
+        """Build a one-field database with endpoint-neutral object keys."""
+        metadata = endpoint_neutral_region_metadata(database.metadata, region_id)
+        layout = RankLocalStoreLayout(
+            metadata,
+            database.block_size,
+            database.hash_block_size,
+        )
+        layout.set_kv_caches_base_addr([base_addr])
+        layout.set_block_len([content_len])
+        layout.set_block_stride([block_stride])
+        return cls(
+            metadata,
+            database.block_size,
+            hash_block_size=database.hash_block_size,
+            store_layout=layout,
         )
 
     @property


### PR DESCRIPTION
## TL;DR

Adds endpoint-neutral Mooncake semantic-region keys so identical model fields do not miss merely because producer and consumer use different local PP stages or HMA group numbers. It also separates physical block stride from transferred content length while preserving the historical key format when semantic regions are disabled.

## Purpose

Introduce the Store-key and descriptor foundation needed to persist hybrid cache fields independently of endpoint-local HMA layouts.

A producer and consumer can assign the same logical layer to different PP stages or cache-group numbers. Reusing `pp_rank` and `group_id` in the data-object key therefore creates deterministic false misses even when the semantic field and bytes match. This PR adds:

- an optional semantic `region_id` in `KeyMetadata` and `PoolKey`;
- `endpoint_neutral_region_metadata`, which deliberately sets PP rank and group ID to `-1` for data objects;
- independent physical `block_stride` and logical `content_len` in rank-local Store descriptors, required when a transport field occupies only part of a larger physical page;
- `ChunkedTokenDatabase.from_semantic_region` for constructing one-field Store databases without changing legacy key behavior.

Legacy keys remain byte-for-byte unchanged when no region ID is supplied.

This is a focused Draft and a prerequisite for the follow-up semantic manifest/commit integration. It does not by itself switch MooncakeStore requests to semantic-region transport.

Related hybrid P/D tracking: #40017. Mooncake group lifecycle caveat: https://github.com/kvcache-ai/Mooncake/issues/2127.

## Test Plan

- Verify two endpoints with different local PP/group numbering produce the same semantic object key.
- Verify historical keys are unchanged when semantic regions are disabled.
- Verify descriptor addresses use physical block stride while transfer sizes use semantic content length.
- Verify constant-address marker descriptors and invalid region geometry.

## Test Result

- `ruff check`: passed for changed files.
- `ruff format --check`: passed for changed files.
- `typos`: passed for changed files.
- Python bytecode compilation: passed.
- `git diff --check`: passed.
- PyTorch/pytest tests were not executed in this macOS worktree because PyTorch and pytest are unavailable; this remains Draft pending Linux test execution.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and failure mode are documented.
- [x] Test plan is included.
- [x] Available test results and missing runtime coverage are explicit.
- [x] No user-facing documentation update is needed for this opt-in foundation.
</details>