### PR TITLE
[Bugfix][CPU] Voxtral realtime: scale attention metadata out of place

### DIFF
--- a/vllm/model_executor/models/whisper_causal.py
+++ b/vllm/model_executor/models/whisper_causal.py
@@ -158,13 +158,27 @@ def create_whisper_attention_backend_with_block_pooling(
             fast_build: bool = False,
         ) -> AttentionMetadata:
             new_common_attn_metadata = copy.deepcopy(common_attn_metadata)
-            new_common_attn_metadata.query_start_loc *= block_pool_size
-            new_common_attn_metadata.query_start_loc_cpu *= block_pool_size
-            new_common_attn_metadata.seq_lens *= block_pool_size
-            if new_common_attn_metadata._seq_lens_cpu is not None:
-                new_common_attn_metadata._seq_lens_cpu *= block_pool_size
-            if new_common_attn_metadata._num_computed_tokens_cpu is not None:
-                new_common_attn_metadata._num_computed_tokens_cpu *= block_pool_size
+            # Scale out of place: the V1 CPU model runner points every
+            # `CpuGpuBuffer.gpu` at its `.cpu` tensor, so a device field and its
+            # `_cpu` counterpart can share storage (`deepcopy` preserves the
+            # sharing), and in-place scaling would apply `block_pool_size` twice.
+            new_common_attn_metadata.query_start_loc = (
+                common_attn_metadata.query_start_loc * block_pool_size
+            )
+            new_common_attn_metadata.query_start_loc_cpu = (
+                common_attn_metadata.query_start_loc_cpu * block_pool_size
+            )
+            new_common_attn_metadata.seq_lens = (
+                common_attn_metadata.seq_lens * block_pool_size
+            )
+            if common_attn_metadata._seq_lens_cpu is not None:
+                new_common_attn_metadata._seq_lens_cpu = (
+                    common_attn_metadata._seq_lens_cpu * block_pool_size
+                )
+            if common_attn_metadata._num_computed_tokens_cpu is not None:
+                new_common_attn_metadata._num_computed_tokens_cpu = (
+                    common_attn_metadata._num_computed_tokens_cpu * block_pool_size
+                )
             new_common_attn_metadata.num_actual_tokens *= block_pool_size
             new_common_attn_metadata.max_query_len *= block_pool_size
             new_common_attn_metadata.max_seq_len *= block_pool_size


### PR DESCRIPTION
This is a follow up PR to #53921 which introduces CPU support for mistralai/Voxtral-Mini-4B-Realtime-2602 model.
Now Voxtral-Mini-4B-Realtime-2602 crashes with Segfault on vLLM CPU backend if run natively while it works on docker.

**Reproducer**

Full vLLM build from source according to https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#build-wheel-from-source.
```
pip install mistral-common[soundfile]
vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602
. . .
(APIServer pid=519002) INFO 09-03 10:50:58 [model.py:688] Resolved architecture: VoxtralRealtimeGeneration
. . .
(APIServer pid=519002) WARNING 09-03 10:51:00 [vllm.py:667] Model Runner V2 requires Triton; using the V1 model runner instead.
WARNING 09-03 10:51:04 [importing.py:45] Triton is installed, but doesn't include CPU backend. Disabling Triton.
. . .
(APIServer pid=520457) INFO:     Application startup complete.
```
Testing
```
python examples/speech_to_text/realtime/openai_realtime_client.py 
WARNING 09-03 11:00:27 [importing.py:45] Triton is installed, but doesn't include CPU backend. Disabling Triton.
INFO 09-03 11:00:27 [importing.py:74] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 09-03 11:00:27 [importing.py:98] Triton not installed or not compatible; certain GPU-related functions will not be available.
No audio path provided, using default: /home/user/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Session created: sess-9d3300c858ac57f8
Loading audio from: /home/user/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Sending 125 audio chunks...
Audio sent. Waiting for transcription...

Transcription: 
Error: EngineCore encountered an issue. See stack trace (above) for the root cause.
```
Error on serving side
```
(APIServer pid=522058) INFO:     127.0.0.1:49736 - "WebSocket /v1/realtime" [accepted]
(APIServer pid=522058) INFO:     connection open
!!!!!!! Segfault encountered !!!!!!!
  File "<unknown>", line 0, in tcmalloc::ThreadCache::ReleaseToCentralCache(tcmalloc::ThreadCache::FreeList*, unsigned int, int)
  File "<unknown>", line 0, in tcmalloc::ThreadCache::Scavenge()
. . .
(EngineCore pid=522260) ERROR 09-03 11:05:46 [core.py:1376] EngineCore encountered a fatal error.
```

**Root cause**

The problem is that `WhisperCausalAttentionWithBlockPoolingBuilder.build()` scaled the attention metadata by `block_pool_size` **in place** on a `copy.deepcopy`. On the V1 CPU model runner, `query_start_loc` and `query_start_loc_cpu` are `.gpu` / `.cpu` slices of one `CpuGpuBuffer` that `CPUModelRunner._postprocess_tensors` aliases (`v.gpu = v.cpu`), and `deepcopy` preserves that sharing - so the two statements compound to `block_pool_size ** 2`.

The fix is to apply scaling out of place.

## Purpose
Scale attention metadata out of place to avoid double scaling and heap corruption.

## Test Plan
```
vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602
python examples/speech_to_text/realtime/openai_realtime_client.py 
```
## Test Result
```
python examples/speech_to_text/realtime/openai_realtime_client.py 
WARNING 09-03 11:46:03 [importing.py:45] Triton is installed, but doesn't include CPU backend. Disabling Triton.
INFO 09-03 11:46:03 [importing.py:74] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 09-03 11:46:03 [importing.py:98] Triton not installed or not compatible; certain GPU-related functions will not be available.
No audio path provided, using default: /home/sdp/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Session created: sess-8667690e98689ad0
Loading audio from: /home/sdp/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Sending 125 audio chunks...
Audio sent. Waiting for transcription...

Transcription:  First words I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, it squeaked with quite a flow, and everywhere that Mary went, the lamb was sure to go.

Final transcription:  First words I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, it squeaked with quite a flow, and everywhere that Mary went, the lamb was sure to go.
Usage: {'prompt_tokens': 39, 'total_tokens': 249, 'completion_tokens': 210, 'prompt_tokens_details': None, 'completion_tokens_details': None}
```
---
<details>
- [ ] Bugfix for mistralai/Voxtral-Mini-4B-Realtime-2602
- [ ] python examples/speech_to_text/realtime/openai_realtime_client.py 
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
</details>

