### PR TITLE
[KV Connector][Mooncake] Add fail-closed semantic commit manifests

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_layout.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_layout.py
@@ -7,15 +7,18 @@ import random
 
 import pytest
 import torch
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.kv_cache_utils import BlockHash
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     LBHNCStoreLayout,
     LBNHCStoreLayout,
+    PoolKey,
     RankLocalStoreLayout,
+    endpoint_neutral_region_metadata,
 )
-from vllm.utils.math_utils import cdiv
 
 BLOCK_SIZE = 128
 
@@ -77,6 +80,90 @@ def test_rank_local_descriptors_handle_empty_and_invalid_chunks():
     assert layout.prepare_values([], [1, 2, 3], []) == ([], [], [])
     with pytest.raises(AssertionError):
         layout.prepare_values([(0, BLOCK_SIZE + 1)], [0, 1], [0])
+
+
+def test_semantic_region_key_is_endpoint_neutral():
+    prefill = KeyMetadata(
+        "test-model",
+        tp_rank=2,
+        pcp_rank=0,
+        dcp_rank=2,
+        pp_rank=0,
+        group_id=1,
+        cache_prefix="experiment",
+        store_namespace="@schema:v1",
+    )
+    decode = KeyMetadata(
+        "test-model",
+        tp_rank=2,
+        pcp_rank=0,
+        dcp_rank=2,
+        pp_rank=1,
+        group_id=5,
+        cache_prefix="experiment",
+        store_namespace="@schema:v1",
+    )
+
+    prefill_region = endpoint_neutral_region_metadata(prefill, "layer.4:target_conv")
+    decode_region = endpoint_neutral_region_metadata(decode, "layer.4:target_conv")
+
+    assert (
+        PoolKey(prefill_region, "abc").to_string()
+        == PoolKey(decode_region, "abc").to_string()
+    )
+    assert (
+        "@pp_rank:-1@group:-1@region:layer.4:target_conv@abc"
+        in PoolKey(prefill_region, "abc").to_string()
+    )
+
+
+def test_legacy_key_format_is_unchanged_without_region_id():
+    metadata = KeyMetadata("test-model", 1, 2, 3, 4, group_id=5)
+    assert (
+        PoolKey(metadata, "abc").to_string()
+        == "test-model@tp_rank:1@pcp2@dcp3@pp_rank:4@group:5@abc"
+    )
+
+
+def test_semantic_region_database_separates_content_length_from_stride():
+    database = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 1, 0, 1, 1, group_id=7),
+        block_size=16,
+    )
+    region = ChunkedTokenDatabase.from_semantic_region(
+        database,
+        region_id="layer.9:base_recurrent",
+        base_addr=0x1000,
+        block_stride=4096,
+        content_len=768,
+    )
+
+    assert region.key_for(BlockHash(b"hash")).startswith(
+        "test-model@tp_rank:1@pcp0@dcp1@pp_rank:-1@group:-1"
+        "@region:layer.9:base_recurrent@"
+    )
+    assert region.prepare_value_for_block(3) == ([0x1000 + 3 * 4096], [768])
+
+    region.store_layout.set_block_stride([0])
+    assert region.prepare_value_for_block(3) == ([0x1000], [768])
+
+
+@pytest.mark.parametrize(
+    ("block_stride", "content_len"),
+    [(63, 64), (0, 0), (-1, 1)],
+)
+def test_semantic_region_database_rejects_invalid_geometry(
+    block_stride: int, content_len: int
+):
+    database = ChunkedTokenDatabase(KeyMetadata("test-model", 0, 0, 0, 0), 16)
+    with pytest.raises(ValueError, match="stride"):
+        ChunkedTokenDatabase.from_semantic_region(
+            database,
+            region_id="layer.0:page",
+            base_addr=0x1000,
+            block_stride=block_stride,
+            content_len=content_len,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/kv_connector/unit/test_mooncake_store_semantic_manifest.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_semantic_manifest.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import pytest
+from vllm.v1.core.kv_cache_utils import BlockHash
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.semantic_manifest import (  # noqa: E501
+    SemanticCommitProtocol,
+    SemanticRegionManifest,
+)
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.objects: set[str] = set()
+        self.put_result = 0
+        self.short_exists_result = False
+
+    def batch_is_exist(self, keys: list[str]) -> list[int]:
+        results = [1 if key in self.objects else 0 for key in keys]
+        return results[:-1] if self.short_exists_result else results
+
+    def batch_put_from_multi_buffers(
+        self,
+        keys: list[str],
+        addrs: list[list[int]],
+        sizes: list[list[int]],
+        replicate_config: Any,
+    ) -> list[int]:
+        assert len(keys) == len(addrs) == len(sizes) == 1
+        if self.put_result >= 0:
+            self.objects.update(keys)
+        return [self.put_result]
+
+
+def _manifest(
+    *,
+    pp_rank: int = 0,
+    group_id: int = 0,
+    stride_scale: int = 1,
+    schema: str = "target-state-v1",
+) -> SemanticRegionManifest:
+    database = ChunkedTokenDatabase(
+        KeyMetadata(
+            "test-model",
+            tp_rank=2,
+            pcp_rank=0,
+            dcp_rank=2,
+            pp_rank=pp_rank,
+            group_id=group_id,
+            store_namespace="@semantic:v1",
+        ),
+        block_size=16,
+    )
+    regions = tuple(
+        ChunkedTokenDatabase.from_semantic_region(
+            database,
+            region_id=region_id,
+            base_addr=base_addr,
+            block_stride=content_len * stride_scale,
+            content_len=content_len,
+        )
+        for region_id, base_addr, content_len in (
+            ("layer.4:target_conv", 0x1000, 256),
+            ("layer.4:base_recurrent", 0x2000, 512),
+        )
+    )
+    return SemanticRegionManifest(schema, regions)
+
+
+def test_manifest_identity_ignores_endpoint_layout():
+    producer = _manifest(pp_rank=0, group_id=1, stride_scale=1)
+    consumer = _manifest(pp_rank=1, group_id=5, stride_scale=2)
+    block_hash = BlockHash(b"hash")
+
+    assert producer.wire_fingerprint == consumer.wire_fingerprint
+    assert producer.data_keys(block_hash) == consumer.data_keys(block_hash)
+    assert producer.commit_key(block_hash) == consumer.commit_key(block_hash)
+
+
+def test_publish_requires_every_region_then_verifies_commit():
+    store = FakeStore()
+    manifest = _manifest()
+    block_hash = BlockHash(b"hash")
+    protocol = SemanticCommitProtocol(store, replicate_config=object())
+
+    data_keys = manifest.data_keys(block_hash)
+    store.objects.add(data_keys[0])
+    assert not protocol.publish(manifest, block_hash, marker_addr=0x3000)
+    assert manifest.commit_key(block_hash) not in store.objects
+
+    store.objects.add(data_keys[1])
+    assert protocol.publish(manifest, block_hash, marker_addr=0x3000)
+    assert protocol.is_loadable(manifest, block_hash)
+
+
+def test_load_rejects_region_evicted_after_commit():
+    store = FakeStore()
+    manifest = _manifest()
+    block_hash = BlockHash(b"hash")
+    protocol = SemanticCommitProtocol(store, replicate_config=object())
+    store.objects.update(manifest.data_keys(block_hash))
+    assert protocol.publish(manifest, block_hash, marker_addr=0x3000)
+
+    store.objects.remove(manifest.data_keys(block_hash)[0])
+    assert manifest.commit_key(block_hash) in store.objects
+    assert not protocol.is_loadable(manifest, block_hash)
+
+
+def test_protocol_fails_closed_on_malformed_store_results():
+    store = FakeStore()
+    manifest = _manifest()
+    block_hash = BlockHash(b"hash")
+    protocol = SemanticCommitProtocol(store, replicate_config=object())
+    store.objects.update(manifest.data_keys(block_hash))
+    store.short_exists_result = True
+
+    assert not protocol.publish(manifest, block_hash, marker_addr=0x3000)
+    assert not protocol.is_loadable(manifest, block_hash)
+
+
+def test_protocol_fails_closed_when_commit_put_fails():
+    store = FakeStore()
+    manifest = _manifest()
+    block_hash = BlockHash(b"hash")
+    protocol = SemanticCommitProtocol(store, replicate_config=object())
+    store.objects.update(manifest.data_keys(block_hash))
+    store.put_result = -1
+
+    assert not protocol.publish(manifest, block_hash, marker_addr=0x3000)
+
+
+def test_schema_change_uses_a_different_commit_key():
+    block_hash = BlockHash(b"hash")
+    assert _manifest(schema="v1").commit_key(block_hash) != _manifest(
+        schema="v2"
+    ).commit_key(block_hash)
+
+
+def test_manifest_rejects_duplicate_region_ids():
+    manifest = _manifest()
+    duplicate = (manifest.region_databases[0],) * 2
+    with pytest.raises(ValueError, match="unique"):
+        SemanticRegionManifest(manifest.schema, duplicate)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -655,6 +655,10 @@ class ChunkedTokenDatabase:
     def block_len(self) -> list[int]:
         return self._rank_local_layout().block_len
 
+    @property
+    def block_stride(self) -> list[int]:
+        return self._rank_local_layout().block_stride
+
     def _rank_local_layout(self) -> RankLocalStoreLayout:
         if not isinstance(self.store_layout, RankLocalStoreLayout):
             raise RuntimeError("This operation requires a rank-local Store layout")

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -6,12 +6,11 @@
 """Data classes for MooncakeStoreConnector."""
 
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import cast
 
 import numpy as np
 import torch
-
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorWorkerMetadata,
@@ -115,6 +114,19 @@ class KeyMetadata:
     # Complete namespace for an opt-in Store payload format. Empty keeps
     # historical keys byte-identical.
     store_namespace: str = ""
+    # Optional semantic identity for one transport field. Semantic data uses
+    # endpoint-neutral PP/group ranks; legacy keys leave this empty.
+    region_id: str = ""
+
+
+def endpoint_neutral_region_metadata(
+    metadata: KeyMetadata,
+    region_id: str,
+) -> KeyMetadata:
+    """Return metadata for a field whose identity is independent of HMA layout."""
+    if not region_id:
+        raise ValueError("Semantic region ID must not be empty")
+    return replace(metadata, pp_rank=-1, group_id=-1, region_id=region_id)
 
 
 @dataclass(order=True)
@@ -135,6 +147,7 @@ class PoolKey:
                 self.key_metadata.dcp_rank,
                 self.key_metadata.pp_rank,
                 self.key_metadata.group_id,
+                self.key_metadata.region_id,
                 self.chunk_hash,
             )
         )
@@ -147,10 +160,12 @@ class PoolKey:
         pcp_rank: int | None = None,
         dcp_rank: int | None = None,
         pp_rank: int | None = None,
+        group_id: int | None = None,
+        region_id: str | None = None,
     ) -> str:
         """Return the stable prefix for a Mooncake pool key."""
         prefix = f"{key_metadata.cache_prefix}@" if key_metadata.cache_prefix else ""
-        return (
+        key_prefix = (
             f"{prefix}"
             f"{key_metadata.model_name}"
             f"{key_metadata.store_namespace}"
@@ -158,8 +173,12 @@ class PoolKey:
             f"@pcp{key_metadata.pcp_rank if pcp_rank is None else pcp_rank}"
             f"@dcp{key_metadata.dcp_rank if dcp_rank is None else dcp_rank}"
             f"@pp_rank:{key_metadata.pp_rank if pp_rank is None else pp_rank}"
-            f"@group:{key_metadata.group_id}"
+            f"@group:{key_metadata.group_id if group_id is None else group_id}"
         )
+        resolved_region_id = key_metadata.region_id if region_id is None else region_id
+        if resolved_region_id:
+            key_prefix += f"@region:{resolved_region_id}"
+        return key_prefix
 
     @staticmethod
     def build_key_string(key_prefix: str, chunk_hash: str) -> str:
@@ -235,6 +254,7 @@ class RankLocalStoreLayout(StoreLayout):
         self._key_prefix = PoolKey.build_prefix(metadata)
         self.kv_caches_base_addr: list[int] = []
         self.block_len: list[int] = []
+        self.block_stride: list[int] = []
 
     @property
     def local_shard_ids(self) -> tuple[StoreShardId, ...]:
@@ -264,6 +284,25 @@ class RankLocalStoreLayout(StoreLayout):
 
     def set_block_len(self, block_lens: list[int]) -> None:
         self.block_len = block_lens
+        # Historical layouts store complete dense pages, so content length and
+        # physical stride are identical unless a semantic descriptor overrides it.
+        self.block_stride = list(block_lens)
+
+    def set_block_stride(self, block_strides: list[int]) -> None:
+        if len(block_strides) != len(self.block_len):
+            raise ValueError("Block stride and content length counts must match")
+        if any(
+            content_len <= 0
+            or block_stride < 0
+            or (block_stride != 0 and block_stride < content_len)
+            for content_len, block_stride in zip(
+                self.block_len, block_strides, strict=True
+            )
+        ):
+            raise ValueError(
+                "Block stride must be zero or cover a positive content length"
+            )
+        self.block_stride = block_strides
 
     def register_kv_caches(
         self,
@@ -302,6 +341,7 @@ class RankLocalStoreLayout(StoreLayout):
                 block_lens.append(cache.stride(0) * cache.element_size())
         self.kv_caches_base_addr = base_addrs
         self.block_len = block_lens
+        self.block_stride = list(block_lens)
 
     def prepare_values(
         self,
@@ -329,7 +369,11 @@ class RankLocalStoreLayout(StoreLayout):
             dtype=np.int64,
             count=n,
         )
-        addrs = base[None, :] + bids[:, None] * blen[None, :]
+        stride = np.asarray(
+            [self.block_stride[i % length] for i in range(base.shape[0])],
+            dtype=np.int64,
+        )
+        addrs = base[None, :] + bids[:, None] * stride[None, :]
         block_counts = (spans + self.block_size - 1) // self.block_size
         sizes = blen[None, :] * block_counts[:, None]
         return addrs.tolist(), sizes.tolist(), bids.tolist()
@@ -338,7 +382,7 @@ class RankLocalStoreLayout(StoreLayout):
         length = len(self.block_len)
         return (
             [
-                base_addr + block_id * self.block_len[index % length]
+                base_addr + block_id * self.block_stride[index % length]
                 for index, base_addr in enumerate(self.kv_caches_base_addr)
             ],
             [
@@ -574,6 +618,33 @@ class ChunkedTokenDatabase:
             )
         self.store_layout = store_layout or RankLocalStoreLayout(
             metadata, block_size, self.hash_block_size
+        )
+
+    @classmethod
+    def from_semantic_region(
+        cls,
+        database: "ChunkedTokenDatabase",
+        *,
+        region_id: str,
+        base_addr: int,
+        block_stride: int,
+        content_len: int,
+    ) -> "ChunkedTokenDatabase":
+        """Build a one-field database with endpoint-neutral object keys."""
+        metadata = endpoint_neutral_region_metadata(database.metadata, region_id)
+        layout = RankLocalStoreLayout(
+            metadata,
+            database.block_size,
+            database.hash_block_size,
+        )
+        layout.set_kv_caches_base_addr([base_addr])
+        layout.set_block_len([content_len])
+        layout.set_block_stride([block_stride])
+        return cls(
+            metadata,
+            database.block_size,
+            hash_block_size=database.hash_block_size,
+            store_layout=layout,
         )
 
     @property

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/semantic_manifest.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/semantic_manifest.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fail-closed commit protocol for Mooncake semantic region objects."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from vllm.v1.core.kv_cache_utils import BlockHash
+
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    ChunkedTokenDatabase,
+    KeyMetadata,
+    PoolKey,
+    endpoint_neutral_region_metadata,
+)
+
+SEMANTIC_COMMIT_REGION = "__semantic_commit_v1__"
+
+
+class MooncakeManifestStore(Protocol):
+    """Subset of the Mooncake client used by the commit protocol."""
+
+    def batch_is_exist(self, keys: list[str]) -> Sequence[int]: ...
+
+    def batch_put_from_multi_buffers(
+        self,
+        keys: list[str],
+        addrs: list[list[int]],
+        sizes: list[list[int]],
+        replicate_config: Any,
+    ) -> Sequence[int]: ...
+
+
+@dataclass(frozen=True)
+class SemanticRegionManifest:
+    """Expected semantic fields for one model shard and wire schema."""
+
+    schema: str
+    region_databases: tuple[ChunkedTokenDatabase, ...]
+
+    def __post_init__(self) -> None:
+        if not self.schema:
+            raise ValueError("Semantic manifest schema must not be empty")
+        if not self.region_databases:
+            raise ValueError("Semantic manifest must contain at least one region")
+
+        region_ids = [db.metadata.region_id for db in self.region_databases]
+        if any(not region_id for region_id in region_ids):
+            raise ValueError("Semantic manifest regions require semantic IDs")
+        if len(set(region_ids)) != len(region_ids):
+            raise ValueError("Semantic manifest region IDs must be unique")
+
+        shard_identities = {
+            (
+                db.metadata.cache_prefix,
+                db.metadata.model_name,
+                db.metadata.store_namespace,
+                db.metadata.tp_rank,
+                db.metadata.pcp_rank,
+                db.metadata.dcp_rank,
+            )
+            for db in self.region_databases
+        }
+        if len(shard_identities) != 1:
+            raise ValueError("Semantic manifest regions must belong to one shard")
+
+        for db in self.region_databases:
+            if len(db.block_len) != 1 or len(db.block_stride) != 1:
+                raise ValueError("Semantic manifest regions must have one field")
+
+    @property
+    def wire_entries(self) -> tuple[tuple[str, int], ...]:
+        """Canonical fields; physical strides are endpoint-local details."""
+        return tuple(
+            sorted(
+                (db.metadata.region_id, db.block_len[0]) for db in self.region_databases
+            )
+        )
+
+    @property
+    def wire_fingerprint(self) -> str:
+        payload = json.dumps(
+            (self.schema, self.wire_entries),
+            separators=(",", ":"),
+        ).encode()
+        return hashlib.blake2b(payload, digest_size=16).hexdigest()
+
+    @property
+    def commit_metadata(self) -> KeyMetadata:
+        base = self.region_databases[0].metadata
+        return endpoint_neutral_region_metadata(
+            base,
+            f"{SEMANTIC_COMMIT_REGION}:{self.wire_fingerprint}",
+        )
+
+    def data_keys(self, chunk_hash: BlockHash) -> list[str]:
+        return [db.key_for(chunk_hash) for db in self.region_databases]
+
+    def commit_key(self, chunk_hash: BlockHash) -> str:
+        return PoolKey(self.commit_metadata, chunk_hash.hex()).to_string()
+
+
+class SemanticCommitProtocol:
+    """Publish commits only after all fields exist and revalidate on load."""
+
+    def __init__(
+        self,
+        store: MooncakeManifestStore,
+        replicate_config: Any,
+    ) -> None:
+        self.store = store
+        self.replicate_config = replicate_config
+
+    def _all_exist(self, keys: list[str]) -> bool:
+        if not keys:
+            return False
+        try:
+            results = self.store.batch_is_exist(keys)
+        except Exception:
+            return False
+        return len(results) == len(keys) and all(result == 1 for result in results)
+
+    def publish(
+        self,
+        manifest: SemanticRegionManifest,
+        chunk_hash: BlockHash,
+        *,
+        marker_addr: int,
+        marker_size: int = 1,
+    ) -> bool:
+        """Publish one immutable commit after every expected region is visible."""
+        if marker_size <= 0:
+            raise ValueError("Semantic commit marker size must be positive")
+        if not self._all_exist(manifest.data_keys(chunk_hash)):
+            return False
+
+        commit_key = manifest.commit_key(chunk_hash)
+        if self._all_exist([commit_key]):
+            return True
+        try:
+            results = self.store.batch_put_from_multi_buffers(
+                [commit_key],
+                [[marker_addr]],
+                [[marker_size]],
+                self.replicate_config,
+            )
+        except Exception:
+            return False
+        return len(results) == 1 and results[0] >= 0 and self._all_exist([commit_key])
+
+    def is_loadable(
+        self,
+        manifest: SemanticRegionManifest,
+        chunk_hash: BlockHash,
+    ) -> bool:
+        """Reject partial groups even when their commit object still exists."""
+        return self._all_exist([manifest.commit_key(chunk_hash)]) and self._all_exist(
+            manifest.data_keys(chunk_hash)
+        )


### PR DESCRIPTION
## TL;DR

Adds a schema-fingerprinted commit protocol that publishes a semantic cache entry only after every expected region is visible and revalidates all regions before loading. Partial writes, malformed Store responses, and `commit present + region evicted` therefore become safe misses; this is a stacked Draft on #55217 and still needs asynchronous worker wiring.

## Purpose

Add the commit-protocol core for Mooncake semantic region objects. Mooncake group IDs are lifecycle hints, not a transaction boundary: a commit marker can remain visible after one member is evicted, and partial writes can become observable independently. This protocol therefore treats a semantic cache entry as loadable only when both its schema-specific commit and every expected immutable region object are visible.

The implementation provides:

- a canonical wire manifest over `(schema, region_id, content_len)` while keeping physical strides endpoint-local;
- a schema fingerprint embedded in the commit key;
- commit publication only after all expected data keys pass an exact existence check;
- post-put commit visibility verification;
- load-time revalidation of every region, so `marker present + region missing` is a safe miss;
- fail-closed behavior for exceptions, malformed result counts, missing objects, and failed puts.

This is a stacked Draft on #55217. Until #55217 merges, GitHub shows its endpoint-neutral key commit in this diff as well. This PR intentionally exposes the protocol as a small reviewable unit; wiring it into the asynchronous MooncakeStore worker path and attaching GPU E2E results are required before it is ready for merge.

Related hybrid P/D tracking: #40017. Mooncake partial-group discussion: https://github.com/kvcache-ai/Mooncake/issues/2127.

## Test Plan

- Confirm producer and consumer manifests match despite different PP/group numbering and physical strides.
- Refuse commit publication when any semantic region is absent.
- Publish and verify a commit after all regions become visible.
- Refuse a load when a region is evicted while its commit remains.
- Fail closed on short existence responses and failed commit puts.
- Ensure schema changes produce different commit keys and duplicate region IDs are rejected.

## Test Result

- `ruff check`: passed for changed files.
- `ruff format --check`: passed for changed files.
- `typos`: passed for changed files.
- Python bytecode compilation: passed.
- `git diff --check`: passed.
- PyTorch/pytest tests were not executed in this macOS worktree because PyTorch and pytest are unavailable. Async worker integration and Linux/GPU validation remain explicit Draft blockers.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose, protocol guarantees, dependency, and remaining integration are explicit.
- [x] Test plan is included.
- [x] Available test results and missing runtime coverage are explicit.
- [x] No user-facing documentation update is needed before worker integration.
</details>