### PR TITLE
[Bugfix][Pooling] Ignore token stream intervals for pooling

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -6,6 +6,7 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from tests.v1.engine.utils import (
     NUM_PROMPT_LOGPROBS_UNDER_TEST,
@@ -23,6 +24,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     FinishReason,
@@ -1411,6 +1413,50 @@ async def test_cumulative_output_collector_n():
     third = [k for k in result.outputs if k.index == 2]
     assert len(third) == 1
     assert third[0].text == "c"
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize("stream_interval", [1, 2, 10])
+@pytest.mark.parametrize("abort", [False, True])
+def test_pooling_output_ignores_token_stream_interval(stream_interval, abort):
+    """Pooling completion and cancellation must not require a detokenizer."""
+    processor = OutputProcessor(None, log_stats=False, stream_interval=stream_interval)
+    params = PoolingParams(task="embed")
+    request = EngineCoreRequest(
+        request_id="pooling",
+        external_req_id="pooling",
+        prompt_token_ids=[1, 2],
+        mm_features=None,
+        sampling_params=None,
+        pooling_params=params,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+    queue = RequestOutputCollector(params.output_kind, request.request_id)
+    processor.add_request(request, None, queue=queue)
+    embedding = torch.tensor([0.1, 0.2])
+
+    if abort:
+        processor.abort_requests([request.request_id], internal=True)
+    else:
+        processor.process_outputs(
+            [
+                EngineCoreOutput(
+                    request.request_id,
+                    [],
+                    pooling_output=embedding,
+                    finish_reason=FinishReason.STOP,
+                )
+            ]
+        )
+
+    result = queue.get_nowait()
+    assert result is not None and result.finished
+    if not abort:
+        torch.testing.assert_close(result.outputs.data, embedding)
+    assert not processor.has_unfinished_requests()
 
 
 @pytest.mark.parametrize("runner", ["generate", "pooling"])

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -296,7 +296,7 @@ class RequestState:
             # Only the final output is required in FINAL_ONLY mode.
             return None
 
-        if self.stream_interval > 1:
+        if pooling_output is None and self.stream_interval > 1:
             assert self.detokenizer is not None
 
             # Send output request only when


### PR DESCRIPTION
## Purpose

A pooling server started with `--stream-interval 2` raises an assertion on its first completed embedding. Pooling requests have no detokenizer, but the token-stream interval path requires one before it reaches the pooling output branch. In AsyncLLM this exits the shared output handler, propagates the exception to other pending requests, and leaves the frontend unhealthy. Cancellation has the same problem through its empty pooling tensor.

Apply token-stream interval handling only to generation output. Pooling results and cancellation continue directly to their existing output path.

Duplicate check on 2026-09-03: open PR searches for `pooling stream_interval`, `stream_interval detokenizer`, and `pooling output processor` found no matching fix. Issue searches found no report of this trigger. The routed-expert output work in #37094 and pooling buffer work in #48214 concern different paths.

AI assistance was used to investigate, implement, and test this change. This is ready for human review.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/engine/test_output_processor.py \
  -k test_pooling_output_ignores_token_stream_interval -q
pre-commit run --files vllm/v1/engine/output_processor.py \
  tests/v1/engine/test_output_processor.py
```

The regression uses the native OutputProcessor and covers completion and cancellation at intervals 1, 2, and 10. No tokenizer or model download is needed.

GPU E2E:

```bash
CUDA_VISIBLE_DEVICES=0 VLLM_USE_V2_MODEL_RUNNER=1 \
  .venv-gpu/bin/python -m vllm.entrypoints.cli.main serve \
  Qwen/Qwen3-Embedding-0.6B \
  --runner pooling --stream-interval 2 --max-model-len 512 \
  --gpu-memory-utilization 0.6 --enforce-eager --port 18002
```

Submit two sequential single-input requests and one four-input request to `/v1/embeddings`, with `/health` checks before and after.

Reproduction on a GPU serving environment: start an embedding model with `--runner pooling --stream-interval 2`, then submit a normal embeddings request. The first completed output reaches the assertion in `RequestState.make_request_output`.

## Test Result

- Native regression: **6 passed** on CPU.
- All applicable pre-commit hooks passed, including mypy.
- A separate native AsyncLLM output-handler harness reproduced the original failure: interval 2 stopped the shared handler and delivered AssertionError to both the completed request and an unrelated pending request; interval 1 remained healthy. With this change, both intervals returned the original embedding and kept the handler running.
- GPU MRV2 E2E on an RTX 5070 Ti with `Qwen/Qwen3-Embedding-0.6B`, `VLLM_USE_V2_MODEL_RUNNER=1`, `--runner pooling`, and `--stream-interval 2`: two sequential requests returned one 1024-dimensional embedding each, and a four-input batch returned four 1024-dimensional embeddings with indices 0 through 3. All responses were HTTP 200, `/health` remained HTTP 200, and the server logged no `AssertionError`.
- The E2E used the clean current-`main` merge of this PR. Python source came from current `main`; CUDA extensions were precompiled from the PR base commit. The fix does not alter embedding values, model computation, or generation interval behavior.

## Risk and rollback

The changed branch is in shared output processing, but excludes only non-None pooling tensors, including the cancellation sentinel. Generation retains the existing condition and behavior. Revert the commit to roll back; using the default `--stream-interval 1` avoids the original pooling failure.
