### PR TITLE
[Bugfix][Core] Skip cascade prefixes during deferred KV frees

### DIFF
--- a/tests/v1/core/test_deferred_block_free.py
+++ b/tests/v1/core/test_deferred_block_free.py
@@ -170,6 +170,55 @@ def test_finish_frees_immediately_when_no_inflight_step():
     assert pool.get_num_free_blocks() == num_free_initially
 
 
+@pytest.mark.parametrize("remaining_share_prefix", [False, True])
+def test_cascade_prefix_waits_for_deferred_refs(remaining_share_prefix):
+    """Deferred references must not make unrelated requests share a prefix."""
+    scheduler = create_scheduler(
+        model=MODEL, async_scheduling=True, enable_prefix_caching=True
+    )
+    scheduler.defer_block_free = True
+    shared = create_requests(
+        num_requests=8,
+        num_tokens=257,
+        same_prompt=True,
+        stop_token_ids=[STOP_TOKEN_ID],
+    )
+    others = create_requests(
+        num_requests=8,
+        num_tokens=257,
+        same_prompt=remaining_share_prefix,
+        req_ids=[f"other-{i}" for i in range(8)],
+    )[1:]
+    for request in shared + others:
+        scheduler.add_request(request)
+
+    out0 = scheduler.schedule()
+    out1 = scheduler.schedule()
+    output = _make_model_runner_output(out0)
+    for request in shared[1:]:
+        output.sampled_token_ids[output.req_id_to_index[request.request_id]] = [
+            STOP_TOKEN_ID
+        ]
+    scheduler.update_from_output(out0, output)
+    assert len(scheduler.deferred_frees) == 7
+    first_blocks = {
+        scheduler.kv_cache_manager.get_block_ids(request.request_id)[0][0]
+        for request in [shared[0], *others]
+    }
+    assert len(first_blocks) == (1 if remaining_share_prefix else 8)
+
+    # Eight surviving requests can use cascade, but the finished requests'
+    # references still inflate the apparent sharing of the first prefix.
+    out2 = scheduler.schedule()
+    assert len(out2.num_scheduled_tokens) == 8
+    assert out2.num_common_prefix_blocks == [0]
+
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    assert not scheduler.deferred_frees
+    out3 = scheduler.schedule()
+    assert out3.num_common_prefix_blocks == [16 if remaining_share_prefix else 0]
+
+
 def test_abort_defers_free():
     scheduler = _create_deferring_scheduler()
     pool = scheduler.kv_cache_manager.block_pool

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1240,7 +1240,9 @@ class Scheduler(SchedulerInterface):
         # This can be potentially used for cascade attention.
         num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
         with record_function_or_nullcontext("schedule: get_num_common_prefix_blocks"):
-            if self.running:
+            # Deferred references are not request owners, so block refcounts
+            # cannot establish a shared prefix until those references drain.
+            if self.running and not self.deferred_frees:
                 any_request_id = self.running[0].request_id
                 num_common_prefix_blocks = (
                     self.kv_cache_manager.get_num_common_prefix_blocks(any_request_id)


### PR DESCRIPTION
## Purpose

Deferred KV frees can make unrelated requests appear to share a prefix. Finished requests are removed from the manager's request tables while their in-flight blocks retain references. Common-prefix detection compares each block's reference count with the remaining request count, so those retained references can satisfy the equality incorrectly.

A native scheduler reproduction starts 15 requests: eight share prefix A and seven have different prefixes. Seven A requests finish while the next batch remains in flight. The eight survivors have eight distinct first-block IDs, but the scheduler reports 16 common blocks (256 tokens). MRV1 FlashAttention accepts the cascade path for this batch and uses the first request's prefix block table for the other requests.

Leave common-prefix lengths at zero while deferred frees remain. Normal detection resumes after the fences drain. The existing suite now covers unrelated survivors and the restoration of optimization for genuinely shared survivors.

Duplicate checks on 2026-09-03 found no matching open fix for `cascade deferred`, `cascade prefix ref`, or `common prefix refcount`. Related issue #49674 and its open PR #49675 concern zero-progress preemption retries, not the common-prefix calculation or attention results.

AI assistance was used for the investigation, implementation, and tests. This is a draft for human review and GPU validation.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/core/test_deferred_block_free.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py \
  tests/v1/core/test_single_type_kv_cache_manager.py -q
pre-commit run --files vllm/v1/core/sched/scheduler.py \
  tests/v1/core/test_deferred_block_free.py
```

The minimal regression is `test_cascade_prefix_waits_for_deferred_refs`. It drives real scheduling and output processing across overlapping batches, verifies actual block identities, then drains the old batch and checks prefix detection again.

## Test Result

- Before the guard: regression **1 failed, 1 passed**, reporting `[16]` instead of `[0]` for unrelated survivors.
- After the guard: **73 tests passed** across the three suites; the deferred-free suite was independently rerun with **14 passed**.
- All applicable pre-commit hooks passed, including mypy.
- CPU validation used `VLLM_TARGET_DEVICE=cpu`, a local OPT configuration through the existing `VLLM_TEST_DEFER_FREE_MODEL` override, and the existing `skip_global_cleanup` marker applied by a temporary pytest plugin to avoid GPU allocator teardown. Scheduler and block-pool methods ran unchanged.
- A separate native scheduler harness used a mock KV consumer and the existing overlap capability seam. It confirmed eight distinct first blocks, the erroneous 256-token prefix, and acceptance by the actual FlashAttention cascade eligibility function.
- GPU/model evaluation was not run: this host has no GPU. The affected serving path is MRV1 cascade attention with a KV consumer and overlapping batches. V2 currently supplies a zero common-prefix length.

## Downsides

Cascade attention is temporarily disabled for every group while any deferred free remains, including blocks unrelated to a candidate shared prefix. Under sustained completions this may reduce optimization opportunities frequently. Throughput impact has not been measured on GPU. Separately accounting for request-owned references would permit a finer-grained optimization later.

## Risk and rollback

The fallback is ordinary attention over each request's own block table. No allocation, freeing, or fence behavior changes. Reverting restores the old optimization and its incorrect-prefix risk; affected deployments can instead disable cascade attention with `--disable-cascade-attn`.
