### PR TITLE
[Bugfix][EPLB] Reject unsafe dynamic weight updates

### DIFF
--- a/docs/training/weight_transfer/README.md
+++ b/docs/training/weight_transfer/README.md
@@ -36,6 +36,13 @@ engine drives on your behalf:
 | [sparse_nccl](nccl.md#sparse-nccl) | NCCL broadcast | Checkpoint-coordinate sparse weight patches |
 | [sharded_rdt](sharded_rdt.md) | NIXL / Ray Direct Transport (pull-based) | Very large models where each worker needs only its own slice (MoE with expert parallelism) |
 
+!!! warning
+    Weight updates and `reload_weights` cannot target a model managed by Expert
+    Parallel Load Balancing (EPLB). Checkpoint loading uses the initial expert
+    placement, and pending rebalances can overwrite updated weights. Start the
+    engine with EPLB disabled for weight updates. Expert parallelism without
+    EPLB remains supported.
+
 ## Quickstart
 
 ### Inference Side

--- a/tests/v1/worker/test_gpu_worker_weight_transfer.py
+++ b/tests/v1/worker/test_gpu_worker_weight_transfer.py
@@ -7,14 +7,20 @@ delegates to the configured weight transfer engine and tracks whether an update
 session is active. These tests verify that delegation and the session guard.
 """
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import DeviceConfig, VllmConfig, get_current_vllm_config
 from vllm.lora.layers import BaseLayerWithLoRA
+from vllm.model_executor.models.interfaces import MixtureOfExperts
 from vllm.v1.worker.gpu_model_runner import _get_parameter_for_reload
 from vllm.v1.worker.gpu_worker import Worker
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 class _RecordingEngine:
@@ -54,8 +60,17 @@ class _RecordingModelRunner:
     def __init__(self) -> None:
         self.seen_config: VllmConfig | None = None
         self.reset_lora_calls = 0
+        self.model = nn.Module()
+        self.draft_model = None
+        self.eplb_state = None
 
-    def reload_weights(self) -> None:
+    def get_model(self):
+        return self.model
+
+    def get_draft_model(self):
+        return self.draft_model
+
+    def reload_weights(self, *args, **kwargs) -> None:
         self.seen_config = get_current_vllm_config()
 
     def reset_lora_state(self) -> None:
@@ -64,7 +79,7 @@ class _RecordingModelRunner:
 
 def _make_worker(engine: _RecordingEngine | None) -> Worker:
     worker = object.__new__(Worker)
-    worker.vllm_config = VllmConfig()
+    worker.vllm_config = VllmConfig(device_config=DeviceConfig("cpu"))
     worker.weight_transfer_engine = engine
     worker._weight_update_active = False
     worker._weight_update_is_draft = False
@@ -80,6 +95,74 @@ def test_reload_weights_sets_current_config():
     Worker.reload_weights(worker)
 
     assert model_runner.seen_config is worker.vllm_config
+
+
+@pytest.mark.parametrize("is_checkpoint_format", [True, False])
+def test_reload_rejects_eplb_before_delegating(is_checkpoint_format):
+    worker = _make_worker(None)
+    model = Mock(spec=MixtureOfExperts, num_moe_layers=1)
+    worker.model_runner.model = model
+    worker.model_runner.eplb_state = SimpleNamespace(
+        model_states={"model": SimpleNamespace(model=model, rebalanced=False)}
+    )
+
+    with pytest.raises(RuntimeError, match="models managed by EPLB"):
+        worker.reload_weights(is_checkpoint_format=is_checkpoint_format)
+
+    assert worker.model_runner.seen_config is None
+
+
+@pytest.mark.parametrize("is_draft", [True, False])
+@pytest.mark.parametrize("pending_rebalance", [True, False])
+def test_eplb_update_rejected_before_session_starts(is_draft, pending_rebalance):
+    engine = _RecordingEngine()
+    engine.supports_draft_weight_update = True
+    worker = _make_worker(engine)
+    model = Mock(spec=MixtureOfExperts, num_moe_layers=1)
+    target = "draft_model" if is_draft else "model"
+    setattr(worker.model_runner, target, model)
+    worker.model_runner.eplb_state = SimpleNamespace(
+        model_states={
+            "model": SimpleNamespace(model=model, rebalanced=pending_rebalance)
+        }
+    )
+    worker._set_draft_weight_update_target = Mock()
+
+    with pytest.raises(RuntimeError, match="models managed by EPLB"):
+        if is_draft:
+            worker.start_draft_weight_update()
+        else:
+            worker.start_weight_update()
+
+    assert not engine.started
+    assert engine.reset_count == 0
+    assert not worker._weight_update_active
+    worker._set_draft_weight_update_target.assert_not_called()
+
+
+@pytest.mark.parametrize("is_draft", [True, False])
+def test_dense_update_allowed_when_other_model_uses_eplb(is_draft):
+    engine = _RecordingEngine()
+    engine.supports_draft_weight_update = True
+    worker = _make_worker(engine)
+    model = Mock(spec=MixtureOfExperts, num_moe_layers=1)
+    worker.model_runner.model = model if is_draft else nn.Module()
+    worker.model_runner.draft_model = nn.Module() if is_draft else model
+    worker.model_runner.eplb_state = SimpleNamespace(
+        model_states={"model": SimpleNamespace(model=model, rebalanced=True)}
+    )
+    worker._set_draft_weight_update_target = Mock()
+
+    if is_draft:
+        worker.start_draft_weight_update()
+    else:
+        worker.start_weight_update()
+    worker.update_weights({"names": ["w"]})
+    worker.finish_weight_update()
+
+    assert engine.update_calls == [{"names": ["w"]}]
+    assert engine.finished
+    assert not worker._weight_update_active
 
 
 def test_reload_parameter_lookup_preserves_lora_module_names():

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -54,6 +54,7 @@ from vllm.distributed.weight_transfer import (
 )
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.model_executor.models.interfaces import get_mixture_of_experts_model
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
 from vllm.multimodal.gpu_ipc_memory import reserve_mm_ipc_gpu_memory
 from vllm.platforms import current_platform
@@ -514,6 +515,7 @@ class Worker(WorkerBase):
 
     def reload_weights(self, *args, **kwargs) -> None:
         with set_current_vllm_config(self.vllm_config):
+            self._check_eplb_weight_update()
             self.model_runner.reload_weights(*args, **kwargs)
 
     @torch.inference_mode()
@@ -1323,6 +1325,21 @@ class Worker(WorkerBase):
                 "Please set weight_transfer_config to enable weight transfer."
             )
 
+    def _check_eplb_weight_update(self, *, is_draft: bool = False) -> None:
+        eplb_state = self.model_runner.eplb_state
+        if eplb_state is None:
+            return
+
+        model = self.get_draft_model() if is_draft else self.get_model()
+        moe_model = get_mixture_of_experts_model(model)
+        if any(state.model is moe_model for state in eplb_state.model_states.values()):
+            raise RuntimeError(
+                "Weight updates are not supported for models managed by EPLB: "
+                "checkpoint loading does not preserve expert mappings, and pending "
+                "rebalances can overwrite updated weights. Start the engine with "
+                "enable_eplb=False to update model weights."
+            )
+
     def init_weight_transfer_engine(self, init_info: dict) -> None:
         """
         Initialize weight transfer mechanism.
@@ -1371,6 +1388,8 @@ class Worker(WorkerBase):
                 "start_weight_update called while a weight update is already "
                 "active. Call finish_weight_update first."
             )
+
+        self._check_eplb_weight_update(is_draft=is_draft)
 
         try:
             if is_draft:


### PR DESCRIPTION
## Purpose

Dynamic weight updates can silently corrupt an EPLB-managed model in two ways:

1. After a completed rebalance, checkpoint loading uses the initial expert placement while inference retains the current EPLB routing maps. A complete checkpoint therefore assigns weights to the wrong logical experts.
2. An outstanding asynchronous rebalance retains old expert weights in transfer buffers. Reload/update can succeed, then the next EPLB step copies those older weights over the updated model.

The completed-rebalance case does not require an async race. A native CPU reproduction uses the default policy to change placement from `[0, 1, 2, 3]` to `[0, 2, 1, 3]`. Reloading all gate/up/down checkpoint weights intended as `[110, 120, 130, 140]` produces routed down-projection weights `[110, 130, 120, 140]`. Initial-placement and reset-map diagnostic controls are correct.

Reject reloads and update-session starts before mutation when the target model is registered with EPLB. This is a bounded mitigation until reload supports live expert placement and async coordination. Dense main/draft targets remain updatable when the other model uses EPLB; initial loading and expert parallelism without EPLB remain supported. The compatibility restriction is documented.

Duplicate checks on 2026-09-03 found no matching open PR for EPLB weight updates/reload. Closed feature issue #33038 marks EPLB reload integration completed, but the current paths still reproduce both failures. No open PR links to that issue. The nearby #53741 changes ModelOpt fused loader granularity, not runtime placement or async update coordination; RFC #48920 excludes EPLB work.

AI assistance was used to investigate, implement, and test this change. This is ready for human review.

## Test Plan

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_worker_weight_transfer.py -q
pre-commit run --files vllm/v1/worker/gpu_worker.py \
  tests/v1/worker/test_gpu_worker_weight_transfer.py \
  docs/training/weight_transfer/README.md
```

The existing worker suite checks rejection before delegation, draft retargeting, or session activation, with and without pending work. Dense-other-model controls complete the update lifecycle normally. The fixtures explicitly use CPU and the existing cleanup opt-out marker.

Reproduction scenario: run an MoE with expert parallelism and EPLB, serve imbalanced traffic until placement changes, pause generation, then reload a complete checkpoint through `collective_rpc("reload_weights", ...)`. Subsequent inference retains the rebalanced routing while checkpoint weights occupy their original slots. With async EPLB, a pending transfer can additionally restore old weights after resume.

## Test Result

- Native worker suite: **20 passed** against a clean current-`main` merge.
- Original methods with the new tests: **6 failed, 2 controls passed** because the unsafe updates were accepted.
- All applicable pre-commit hooks and explicit mypy 3.12 passed.
- Native CPU corruption proof imports the actual RoutedExperts loader, expert-map manager, default EPLB policy, transfer/map commit, layerwise reload, and GPUModelRunner. Only model construction, stream/event contexts, and cross-rank transport are CPU fixtures. It reproduces incorrect logical weights after a fully completed rebalance.
- A separate unchanged-source async lifecycle proof verifies complete new weights immediately after reload/update, then observes old values restored by the pending EPLB result. No-pending and drain-before-update controls pass.
- Multi-GPU model evaluation was not run. The change rejects the operation before weight mutation; production CPU tensor/lifecycle proofs and native RPC regressions exercise that safety boundary. Supported inference paths are unchanged.

## Downsides

Dynamic updates to an EPLB-managed target now raise an explicit error, including before its first rebalance. Callers requiring frequent updates must start the engine with EPLB disabled. Draining pending work alone is insufficient because completed routing maps can still disagree with checkpoint placement. Resetting maps indiscriminately would also mishandle already-sharded kernel-format updates.

## Risk and rollback

The guard matches the target against actual EPLB model registrations using the same MoE resolver as registration. It rejects before weights, transfer targets, or session state change. Unexpected rejections are visible at the reload/start RPC. Reverting restores acceptance but also restores the corruption risk; use an engine without EPLB for dynamic updates instead.
