### PR TITLE
[Bugfix][DP] Make duplicate scheduler resume idempotent

### DIFF
--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -7,18 +7,21 @@ import time
 from contextlib import ExitStack
 from dataclasses import dataclass
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from vllm import SamplingParams
-from vllm.config import VllmConfig
+from vllm.config import ParallelConfig, VllmConfig
 from vllm.config.parallel import DataParallelBackend
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.inputs import PromptType
 from vllm.outputs import RequestOutput
 from vllm.platforms import current_platform
 from vllm.sampling_params import RequestOutputKind
+from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.core import DPEngineCoreProc
 from vllm.v1.engine.core_client import DPLBAsyncMPClient
 from vllm.v1.metrics.loggers import StatLoggerBase
 from vllm.v1.metrics.stats import IterationStats, MultiModalCacheStats, SchedulerStats
@@ -258,6 +261,47 @@ async def test_dp_prefill_schedule_interval(prefill_schedule_interval: int):
 DP_PAUSE_MODEL = "hmellor/tiny-random-LlamaForCausalLM"
 DP_PAUSE_MODEL_MOE = "ibm-research/PowerMoE-3b"
 DP_PAUSE_PROMPT = "This is a test of data parallel pause"
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    ("pause_state", "engines_running", "ignore_start_dp_wave", "expected_sync"),
+    [
+        (PauseState.UNPAUSED, False, False, False),
+        (PauseState.UNPAUSED, True, False, False),
+        (PauseState.PAUSED_NEW, False, True, True),
+        (PauseState.PAUSED_ALL, False, True, True),
+        pytest.param(PauseState.UNPAUSED, False, True, True, id="elastic-ep-new-rank"),
+    ],
+)
+def test_dp_resume_preserves_barrier_participation(
+    monkeypatch: pytest.MonkeyPatch,
+    pause_state: PauseState,
+    engines_running: bool,
+    ignore_start_dp_wave: bool,
+    expected_sync: bool,
+):
+    """Only paused or newly joined ranks need the resume barrier."""
+    core = object.__new__(DPEngineCoreProc)
+    core.pending_pause = False
+    core.engines_running = engines_running
+    core.ignore_start_dp_wave = ignore_start_dp_wave
+    core.scheduler = MagicMock(pause_state=pause_state)
+    core.scheduler.has_unfinished_requests.return_value = True
+    core.dp_group = object()
+    synchronize = MagicMock(return_value=True)
+    monkeypatch.setattr(ParallelConfig, "has_unfinished_dp", synchronize)
+
+    core.resume_scheduler()
+
+    if expected_sync:
+        synchronize.assert_called_once_with(core.dp_group, True)
+        core.scheduler.set_pause_state.assert_called_once_with(PauseState.UNPAUSED)
+        assert core.engines_running
+    else:
+        synchronize.assert_not_called()
+        assert core.engines_running == engines_running
+    assert not core.ignore_start_dp_wave
 
 
 def _get_dp_pause_engine_args(expert_parallel: bool) -> AsyncEngineArgs:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -2125,7 +2125,8 @@ class DPEngineCoreProc(EngineCoreProc):
                 "flight. Wait for the pause future to resolve before "
                 "resuming."
             )
-        if self.engines_running:
+        # New Elastic EP ranks have unpaused schedulers but waves disabled.
+        if not self.is_scheduler_paused() and not self.ignore_start_dp_wave:
             logger.debug("Resume called while engines are not paused, ignoring.")
             return
 


### PR DESCRIPTION
## Purpose

A duplicate resume can deadlock data-parallel engines at the start of a new request wave. `DPEngineCoreProc.resume_scheduler()` used `engines_running` to decide whether to enter its resume collective. Coordinator wave messages and utility requests arrive independently, so one already-unpaused rank can see `engines_running=True` while another still sees False. The first returns; the second waits in a collective its peer will not enter.

Check the scheduler's pause state and wave gate to recognize duplicate resumes. An already-unpaused scheduler with waves enabled returns without synchronization, regardless of wave startup state. Genuine resumes retain the barrier. New Elastic EP ranks also participate: their scheduler starts unpaused but their wave gate remains closed until this collective. The existing in-flight-pause rejection is unchanged.

Duplicate checks on 2026-09-03 found no matching open fix for `resume_scheduler`, `resume START_DP_WAVE`, and resume idempotency/deadlock searches. Nearby PR #52957 changes synchronization cadence; #53082 changes sleep layering. RFC #51476 discusses collective-divergence hazards but does not fix this duplicate-resume path.

AI assistance was used to investigate, implement, and test this change. This is a draft for human review and GPU-backed DP validation.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/distributed/test_async_llm_dp.py \
  -k test_dp_resume_preserves_barrier_participation -q
pre-commit run --files vllm/v1/engine/core.py \
  tests/v1/distributed/test_async_llm_dp.py
```

Reproduction: on a MoE DP engine, complete a pause/resume with no queued work, start a new request wave, and deliver a duplicate resume before rank 0 sees START_DP_WAVE but after rank 1 sees it. Both schedulers are unpaused. Before the fix, only the idle rank enters the resume barrier.

## Test Result

- The original four-case native regression fails the already-unpaused idle case. The final expanded regression has **5 passed**: already-unpaused idle/running states, both genuine paused states, and newly joined Elastic EP ranks.
- All applicable pre-commit hooks passed, including mypy.
- A separate two-process CPU Gloo harness executes the original resume, wave-message, and DP synchronization methods with fake scheduler/model boundaries. Before the fix, asymmetric wave arrival makes one resume return while the other rank's MAX collective and its peer's subsequent SUM collective time out. After the fix, both duplicate resumes and subsequent wave synchronization complete. Genuine paused/running controls and a mixed old/new Elastic EP rank barrier all pass.
- Model evaluation: not run; this host has no GPU. The Gloo proof omits model execution and validates protocol divergence, not an end-to-end GPU serving run. A deployed model could block in an earlier model collective instead.

## Risk and rollback

The change skips the resume collective only when the scheduler is already unpaused and its wave gate is open. Real paused-to-running transitions and newly joined Elastic EP ranks still synchronize. Revert the commit to roll back; affected callers should avoid redundant resume calls during request-wave startup until fixed.
