### PR TITLE
[Bugfix][MLA] Restore DSpark cache-group capability under optimized Python

### DIFF
--- a/tests/v1/attention/test_mla_noncausal.py
+++ b/tests/v1/attention/test_mla_noncausal.py
@@ -20,7 +20,9 @@ class _NonCausalMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
 
 
 def _metadata(
-    query_start_loc: list[int], num_tokens: int | None = None
+    query_start_loc: list[int],
+    num_tokens: int | None = None,
+    causal: bool = False,
 ) -> CommonAttentionMetadata:
     num_reqs = len(query_start_loc) - 1
     num_tokens = query_start_loc[-1] if num_tokens is None else num_tokens
@@ -38,7 +40,7 @@ def _metadata(
             num_reqs, 3
         ),
         slot_mapping=torch.arange(num_tokens),
-        causal=False,
+        causal=causal,
         seq_lens_cpu_upper_bound=None,
     )
 
@@ -50,6 +52,7 @@ def _builder(marked: bool = True) -> _NonCausalMLAMetadataBuilder:
     builder.query_len_support = QueryLenSupport.SINGLE_ONLY
     builder.non_causal_multi_token_decode = marked
     builder.dcp_world_size = 1
+    builder.use_pcp = False
     builder.metadata_cls = MLACommonMetadata
     builder.model_config = SimpleNamespace(
         dtype=torch.bfloat16, get_head_size=lambda: 576
@@ -57,9 +60,19 @@ def _builder(marked: bool = True) -> _NonCausalMLAMetadataBuilder:
     return builder
 
 
-def test_noncausal_block_uses_decode_without_cpu_lengths():
+def test_group_capability_keeps_runtime_causality_per_step():
+    builder = _builder()
+
+    target_metadata = builder.build(0, _metadata([0, 1, 2], causal=True))
+    assert (
+        target_metadata.num_decodes,
+        target_metadata.num_decode_tokens,
+        target_metadata.num_prefills,
+        target_metadata.causal,
+    ) == (2, 2, 0, True)
+
     common_metadata = _metadata([0, 8, 16])
-    metadata = _builder().build(0, common_metadata)
+    metadata = builder.build(0, common_metadata)
 
     assert metadata.num_decodes == 2
     assert metadata.num_decode_tokens == 16
@@ -109,7 +122,7 @@ def test_noncausal_decode_metadata_keeps_live_request_buffers():
     )
 
 
-def test_mla_cache_marker_is_a_group_property():
+def test_mla_cache_marker_is_promoted_to_group_capability():
     kwargs = {
         "block_size": 64,
         "num_kv_heads": 1,
@@ -123,5 +136,4 @@ def test_mla_cache_marker_is_a_group_property():
     assert not MLAAttentionSpec.merge(
         [unmarked, unmarked]
     ).non_causal_multi_token_decode
-    with pytest.raises(AssertionError, match="non_causal_multi_token_decode"):
-        MLAAttentionSpec.merge([marked, unmarked])
+    assert MLAAttentionSpec.merge([unmarked, marked]).non_causal_multi_token_decode

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3,8 +3,11 @@
 import copy
 import hashlib
 import importlib
+import subprocess
+import sys
 from collections.abc import Callable
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -1462,6 +1465,28 @@ def test_is_kv_cache_spec_uniform():
         "layer_2": new_sliding_window_spec(num_kv_heads=32, sliding_window=2),
     }
     assert not is_kv_cache_spec_uniform(kv_cache_spec)
+
+    script = """
+import sys
+
+from vllm.v1.core.kv_cache_utils import is_kv_cache_spec_uniform
+from vllm.v1.kv_cache_interface import KVCacheSpec
+
+if sys.flags.optimize < 1:
+    raise RuntimeError("subprocess is not running with optimization enabled")
+specs = {
+    "a": KVCacheSpec(block_size=1),
+    "b": KVCacheSpec(block_size=2),
+}
+if is_kv_cache_spec_uniform(specs):
+    raise RuntimeError("different specs were treated as uniform")
+"""
+    subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        cwd=Path(__file__).resolve().parents[3],
+        check=True,
+        timeout=60,
+    )
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -224,9 +224,10 @@ class KVCacheSpec:
         """
         Merge a list of KVCacheSpec objects into a single KVCacheSpec object.
         """
-        assert all(spec == specs[0] for spec in specs[1:]), (
-            "All layers in the same KV cache group must be the same."
-        )
+        if not all(spec == specs[0] for spec in specs[1:]):
+            raise AssertionError(
+                "All layers in the same KV cache group must be the same."
+            )
         return copy.deepcopy(specs[0])
 
     def is_uniform_with_collection(
@@ -558,7 +559,8 @@ class MLAAttentionSpec(FullAttentionSpec):
     model_version: str | None = None
     storage_block_size: int | None = None
     """Token width used to view storage when it differs from the kernel block."""
-    # Marks draft groups that flatten a non-causal query block into decode rows.
+    # Group capability enabled when any member flattens a non-causal query block
+    # into decode rows. Runtime metadata still selects causal vs. non-causal mode.
     non_causal_multi_token_decode: bool = False
     # MLA stores a single latent vector per state; there is no separate V.
     head_size_v: int = 0
@@ -586,11 +588,6 @@ class MLAAttentionSpec(FullAttentionSpec):
             "quantization method, tokens per state, model version, and storage "
             "block size."
         )
-        non_causal_mtd_set = {spec.non_causal_multi_token_decode for spec in specs}
-        assert len(non_causal_mtd_set) == 1, (
-            "All attention layers in the same KV cache group must agree on "
-            "non_causal_multi_token_decode."
-        )
         merged_spec = cls(
             block_size=specs[0].block_size,
             num_kv_heads=specs[0].num_kv_heads,
@@ -604,7 +601,9 @@ class MLAAttentionSpec(FullAttentionSpec):
             tokens_per_state=tokens_per_state_set.pop(),
             model_version=model_version_set.pop(),
             storage_block_size=storage_block_size_set.pop(),
-            non_causal_multi_token_decode=non_causal_mtd_set.pop(),
+            non_causal_multi_token_decode=any(
+                spec.non_causal_multi_token_decode for spec in specs
+            ),
         )
         for spec in specs:
             for f in fields(AttentionSpec):


### PR DESCRIPTION
## Summary

- restore `non_causal_multi_token_decode` as an MLA cache-group capability, promoted when any group member needs the non-causal draft path;
- keep the inherited KV-cache merge incompatibility check active under `python -O` while preserving the `AssertionError` contract used by grouping callers;
- extend existing tests to cover a causal target and non-causal draft sharing one capability-enabled builder, plus the optimized-Python fallback.

## Why

#54277 changed `non_causal_multi_token_decode` from `any()` aggregation into an equality constraint. That made allocation compatibility depend on runtime causality even though the target and draft use the same physical MLA cache layout. Execution already selects the causal target path or non-causal draft path from each invocation's `CommonAttentionMetadata.causal`, so the group only needs to advertise the union of supported behavior.

Optimized Python removes the default `KVCacheSpec.merge` assertion. `MambaSpec` inherits that implementation, so unequal Kimi-K3 cache specs could then be reported as uniform and collapsed. Raising the same `AssertionError` explicitly keeps the existing `is_kv_cache_spec_uniform()` fallback behavior under `-O`.

## Non-duplication

This is materially different from #55187, which broadly converts merge assertions to `ValueError`. Existing cache-group compatibility probes catch `AssertionError`, so changing only the exception type makes normal incompatibility abort grouping. This PR instead preserves the caller contract and removes the target/draft marker mismatch by restoring capability semantics. #51065 addresses a Triton-specific causal multi-token execution path; this issue reproduces with FlashInfer MLA and originates in KV-cache grouping.

The distinction and validation were documented on #54649 before opening this PR: https://github.com/vllm-project/vllm/issues/54649#issuecomment-5531763473.

## Testing

- `uvx --offline ruff check vllm/v1/kv_cache_interface.py tests/v1/attention/test_mla_noncausal.py tests/v1/core/test_kv_cache_utils.py` — passed.
- `uvx --offline ruff format --check vllm/v1/kv_cache_interface.py tests/v1/attention/test_mla_noncausal.py tests/v1/core/test_kv_cache_utils.py` — passed.
- Reserved `pod4-gb300-4-tray10-f3`, applied the production patch to the pinned nightly image, and ran the updated `tests/v1/attention/test_mla_noncausal.py` through a uv-created `.venv` — 6 passed.
- Ran the new uniformity probe with `.venv/bin/python -O`; unequal inherited specs correctly took the non-uniform fallback.
- Full model evaluation on two reserved GB300 nodes with `PYTHONOPTIMIZE=1`, Kimi-K3 target revision `37743f8aa061dea001dc89e11d13520d8973090c`, Kimi-K3-DSpark draft revision `6f659232a007121d5203e9619d3e97b81756887c`, TP8/DCP8, FlashInfer MLA for both models, and full/piecewise CUDA graphs: completion returned HTTP 200 with the expected answer (`56`), DSpark accepted 81/220 drafted tokens, and neither node logged CUDA, engine-core, or Mamba-state errors.
- Validation processes and temporary runtime directories were removed, and all machine reservations were released.

## AI assistance

OpenAI Codex assisted with implementation, test execution, and drafting this description. The human submitter reviewed the design decisions and is responsible for the change.

Fixes #54649
