### PR TITLE
[Bugfix] Pad FoPE sin cache with 0 so unrotated channels pass through

### DIFF
--- a/tests/model_executor/layers/test_fope_rotary_embedding.py
+++ b/tests/model_executor/layers/test_fope_rotary_embedding.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for FoPE rotary embedding cache construction."""
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config.device import DeviceConfig
+from vllm.model_executor.layers.rotary_embedding.fope import FourierRotaryEmbedding
+
+HEAD_SIZE = 64
+ROTARY_DIM = 32
+MAX_POSITION = 128
+NUM_KV_HEADS = 2
+
+
+@pytest.fixture
+def cpu_vllm_config():
+    config = VllmConfig(device_config=DeviceConfig(device="cpu"))
+    with set_current_vllm_config(config):
+        yield config
+
+
+def make_fope(fope_sep_head: bool) -> FourierRotaryEmbedding:
+    rope = FourierRotaryEmbedding(
+        head_size=HEAD_SIZE,
+        rotary_dim=ROTARY_DIM,
+        max_position_embeddings=MAX_POSITION,
+        base=10000.0,
+        is_neox_style=True,
+        dtype=torch.float32,
+        init_cache=False,
+        num_key_value_heads=NUM_KV_HEADS,
+        num_inv_freq=ROTARY_DIM // 2,
+        fope_sep_head=fope_sep_head,
+        fope_init_factor=1.0,
+    )
+    # Identity mixing coefficients reduce FoPE to plain RoPE over the
+    # retained frequencies, so any channel change beyond them is padding.
+    eye = torch.eye(rope.input_dim).unsqueeze(0).expand(NUM_KV_HEADS, -1, -1)
+    with torch.no_grad():
+        rope.cos_coef.copy_(eye)
+        rope.sin_coef.copy_(eye)
+    return rope
+
+
+@pytest.mark.parametrize("fope_sep_head", [True, False])
+def test_fope_leaves_unrotated_channels_untouched(cpu_vllm_config, fope_sep_head):
+    """Channels past the retained frequencies must pass through unchanged.
+
+    Padding sin with 1 instead of 0 turned them into x[j] - x[j + head/2].
+    """
+    rope = make_fope(fope_sep_head)
+
+    torch.manual_seed(0)
+    positions = torch.arange(4)
+    query = torch.randn(4, NUM_KV_HEADS * HEAD_SIZE)
+    key = torch.randn_like(query)
+
+    query_out, key_out = rope.forward_native(positions, query.clone(), key.clone())
+
+    n_rotated = rope.input_dim
+    for out, inp in ((query_out, query), (key_out, key)):
+        out = out.view(4, NUM_KV_HEADS, HEAD_SIZE)
+        inp = inp.view(4, NUM_KV_HEADS, HEAD_SIZE)
+        for half in range(2):
+            offset = half * (HEAD_SIZE // 2)
+            unrotated = slice(offset + n_rotated, offset + HEAD_SIZE // 2)
+            torch.testing.assert_close(out[..., unrotated], inp[..., unrotated])

--- a/vllm/model_executor/layers/rotary_embedding/fope.py
+++ b/vllm/model_executor/layers/rotary_embedding/fope.py
@@ -108,14 +108,17 @@ class FourierRotaryEmbedding(RotaryEmbedding):
             sin = torch.einsum("htD, hDd -> thd", pos_sin, self.sin_coef.float())
             cos = torch.einsum("htD, hDd -> thd", pos_cos, self.cos_coef.float())
         else:
-            sin = torch.einsum("tD, Dd -> td", pos_sin, self.sin_coef.float())
-            cos = torch.einsum("tD, Dd -> td", pos_cos, self.cos_coef.float())
+            sin = torch.einsum("tD, Dd -> td", pos_sin, self.sin_coef[0].float())
+            cos = torch.einsum("tD, Dd -> td", pos_cos, self.cos_coef[0].float())
 
+        # Channels beyond the retained frequencies keep the zero-frequency
+        # component, i.e. cos(0) = 1 and sin(0) = 0, so they pass through
+        # unrotated. Padding sin with 1 instead would mix in rotate_neox().
         sin = F.pad(
             input=sin,
             pad=(0, self.head_size // 2 - sin.size(-1)),
             mode="constant",
-            value=1,
+            value=0,
         )
         cos = F.pad(
             input=cos,


### PR DESCRIPTION


## Purpose

Fixes #55204.

`FourierRotaryEmbedding._compute_cos_sin_cache` pads both the cos and sin caches out to `head_size // 2` with `1`. Padding cos with `1` is correct, but sin must be padded with `0`. With both set to `1`, a padded channel becomes

```
out[j] = x[j] * 1 + rotate_neox(x)[j] * 1 = x[j] - x[j + head_size/2]
```

instead of passing through unchanged. The padded entries stand in for the zero-frequency component (`cos(0) = 1`, `sin(0) = 0`), so `0` is the correct pad.

The padding is reached whenever fewer than `head_size // 2` frequencies survive: 
a partial rotary factor, an explicit `num_inv_freq`, or a short `max_position_embeddings` dropping frequencies through the
`inv_freq > 2*pi / max_position_embeddings` filter. FoPE checkpoints that need no padding are unaffected. No error is raised, affected checkpoints silently compute wrong activations. Reached only via `rope_scaling.use_fope: true`; Intern-S1-Pro is
the only in-tree consumer.

This PR also fixes the second issue noted in the report: the `fope_sep_head=False` branch feeds the always-3D `sin_coef`/`cos_coef` parameters into a two-subscript einsum and raises `RuntimeError`, so that path is unreachable as written. Shared coefficients are now taken from the first head, which is correct whether a checkpoint stores `(1, D, d)` or identical per-head copies.

## Test Plan

New CPU-only regression test — no GPU, weights, or server required:

```bash
.venv/bin/python -m pytest tests/model_executor/layers/test_fope_rotary_embedding.py -v
```

With identity mixing coefficients FoPE reduces to plain RoPE over the retained frequencies, so every channel past them must be bit-identical in both halves, for q and k, under both `fope_sep_head` values.

Lint:

```bash
pre-commit run --files vllm/model_executor/layers/rotary_embedding/fope.py \
  tests/model_executor/layers/test_fope_rotary_embedding.py
```

## Test Result

After the fix:

```
tests/model_executor/layers/test_fope_rotary_embedding.py::test_fope_leaves_unrotated_channels_untouched[True]  PASSED
tests/model_executor/layers/test_fope_rotary_embedding.py::test_fope_leaves_unrotated_channels_untouched[False] PASSED
2 passed
```

Before the fix, both cases fail — `[False]` with `RuntimeError: einsum(): the number of subscripts in the equation (2) does not match the number of dimensions (3) for operand 1`, and `[True]` with a channel mismatch on the padded region.

The reproducer from #55204 reports `0/64` channels bit-identical before the fix and `32/64` (the expected `head_size - rotary_dim`) after.

Lint: ruff check, ruff format, mypy-3.10, typos, SPDX and the remaining Python hooks all pass on both files.

Model eval: not run. This changes output for `use_fope` checkpoints, but I do not have a GPU that can hold Intern-S1-Pro. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>