### PR TITLE
[Bugfix][Model] Fix Qwen3 MoE 1D input handling

### DIFF
--- a/tests/model_executor/test_qwen3_moe.py
+++ b/tests/model_executor/test_qwen3_moe.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.models.qwen3_moe import Qwen3MoeSparseMoeBlock
+
+
+class _Experts:
+    def __call__(self, hidden_states, router_logits):
+        return hidden_states.clone()
+
+
+def _make_block() -> Qwen3MoeSparseMoeBlock:
+    block = Qwen3MoeSparseMoeBlock.__new__(Qwen3MoeSparseMoeBlock)
+    block.experts = _Experts()
+    block.is_sequence_parallel = False
+    return block
+
+
+def test_sparse_moe_block_supports_1d_input():
+    block = _make_block()
+    hidden_states = torch.randn(8)
+
+    output = Qwen3MoeSparseMoeBlock.forward(block, hidden_states)
+
+    assert output.shape == hidden_states.shape
+    assert torch.equal(output, hidden_states)
+
+
+def test_sparse_moe_block_preserves_2d_input():
+    block = _make_block()
+    hidden_states = torch.randn(4, 8)
+
+    output = Qwen3MoeSparseMoeBlock.forward(block, hidden_states)
+
+    assert output.shape == hidden_states.shape
+    assert torch.equal(output, hidden_states)

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -217,7 +217,8 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             "Qwen3MoeSparseMoeBlock only supports 1D or 2D inputs"
         )
         is_input_1d = hidden_states.dim() == 1
-        num_tokens, hidden_dim = hidden_states.shape
+        hidden_dim = hidden_states.shape[-1]
+        num_tokens = 1 if is_input_1d else hidden_states.shape[0]
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         if self.is_sequence_parallel:


### PR DESCRIPTION
## Purpose

Fixes #55205.

`Qwen3MoeSparseMoeBlock.forward` explicitly supports 1D and 2D inputs, but it unconditionally unpacked `hidden_states.shape` into `num_tokens, hidden_dim`. This raises a `ValueError` for a valid 1D input before the existing 1D handling can run.

This change derives `hidden_dim` from the final dimension and treats a 1D tensor as a single token, while preserving the existing 2D behavior.

A focused regression test covers both the previously failing 1D case and the existing 2D case.

## Duplicate-work check

Before opening this PR, I checked issue #55205 and searched open PRs both by issue number and by the Qwen3 MoE 1D input area. I did not find an existing PR addressing this bug.

## Test Plan

```bash
.venv/bin/python -m pytest tests/model_executor/test_qwen3_moe.py -v

pre-commit run --files \
  vllm/model_executor/models/qwen3_moe.py \
  tests/model_executor/test_qwen3_moe.py

git diff --check
```

## Test Results

Before the fix:

- 1D input regression test: failed with `ValueError: not enough values to unpack`
- 2D input behavior test: passed

After the fix:

- 2 passed
- all applicable pre-commit hooks passed
- `git diff --check` passed

No model evaluation was run because this change restores the existing 1D input-shape contract and does not change the numerical behavior of the existing 2D model path.

## AI assistance

AI assistance from ChatGPT was used for repository navigation, issue triage, test planning, and review of the implementation. I reproduced the issue locally, reviewed the changed lines, ran the tests and pre-commit checks, and am responsible for the contribution.