### PR TITLE
[SpecDecode]Fix spec decode warmup device selection

### DIFF
--- a/vllm/model_executor/warmup/spec_decode_rejection_warmup.py
+++ b/vllm/model_executor/warmup/spec_decode_rejection_warmup.py
@@ -44,7 +44,7 @@ def spec_decode_rejection_warmup(worker: Worker) -> None:
     use_block_verification = rejection_method == "block"
     use_synthetic = rejection_method == "synthetic"
 
-    device = torch.device("cuda")
+    device = worker.device
     num_reqs = 1
     tokens_per_req = num_spec + 1
     num_logits = num_reqs * tokens_per_req


### PR DESCRIPTION
## Purpose
Fix the speculative decoding rejection sampler warmup on XPU.

The warmup previously hardcoded `torch.device("cuda")`, causing XPU workers to
attempt CUDA tensor allocations and skip the rejection sampler warmup. Use the
worker's initialized device instead, preserving both the accelerator type and
device index.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

