### PR TITLE
[CPU] Clamp KV-cache auto-sizing to cgroup memory limit on non-NUMA hosts too, add CI coverage

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -79,6 +79,28 @@ steps:
       pytest -x -v -s tests/models/language/generation tests/models/language/pooling tests/v1/e2e/test_cpu_linear_attn_chunked_prefix.py -m cpu_model --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB"
   parallelism: 3
 
+- label: CPU-Cgroup Memory Clamp Test
+  key: cpu-cgroup-memory-clamp-test
+  depends_on: []
+  device: intel_cpu
+  no_plugin: true
+  source_file_dependencies:
+  - vllm/utils/cpu_resource_utils.py
+  - vllm/v1/worker/cpu_worker.py
+  - vllm/platforms/cpu.py
+  - .buildkite/scripts/hardware_ci/run-cpu-test.sh
+  - tests/v1/e2e/test_cpu_cgroup_memory_limit.py
+  commands:
+    # Runs under a real container --memory cgroup, with the legacy
+    # VLLM_CPU_KVCACHE_SPACE knob explicitly unset, so the fraction-of-
+    # available-memory auto-sizing path in CPUWorker.determine_available_memory
+    # actually runs and must clamp to this container's limit rather than the
+    # CI host's much larger RAM (see vllm/utils/cpu_resource_utils.py).
+    - |
+      CONTAINER_MEMORY_LIMIT=4294967296 VLLM_CPU_KVCACHE_SPACE= \
+      bash .buildkite/scripts/hardware_ci/run-cpu-test.sh 15m "
+      pytest -x -v -s tests/v1/e2e/test_cpu_cgroup_memory_limit.py"
+
 - label: CPU-Quantization Model Tests
   key: cpu-quantization-model-tests
   depends_on: []

--- a/.buildkite/scripts/hardware_ci/run-cpu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test.sh
@@ -12,6 +12,19 @@ IMAGE_NAME="cpu-test-${NUMA_NODE}${AGENT_SLOT:+-${AGENT_SLOT}}"
 TIMEOUT_VAL=$1
 TEST_COMMAND=$2
 
+# KV-cache sizing. Every job defaults to a fixed, generous budget so the
+# fraction-of-available-memory auto-sizing path (VLLM_CPU_KVCACHE_SPACE
+# unset) never runs on these uncapped hosts. A caller that wants to
+# exercise that path for real (the cgroup-clamp regression test) sets
+# VLLM_CPU_KVCACHE_SPACE="" explicitly to opt out of the default.
+VLLM_CPU_KVCACHE_SPACE=${VLLM_CPU_KVCACHE_SPACE-16}
+
+# Optional container memory cap (docker --memory syntax, e.g. "4g" or a
+# plain byte count) for jobs that need to run under a real cgroup limit,
+# such as the cgroup-clamp regression test. Unset by default so existing
+# jobs keep running against the host's full memory.
+CONTAINER_MEMORY_LIMIT=${CONTAINER_MEMORY_LIMIT:-}
+
 # Disk hygiene knobs. Reclaim space only once the Docker root filesystem crosses
 # DISK_USAGE_THRESHOLD percent, and cap the shared BuildKit cache at
 # BUILDKIT_CACHE_MAX so subsequent builds keep reusing the hottest layers.
@@ -54,6 +67,23 @@ prune_if_disk_pressure
 echo "--- :docker: Building Docker image"
 docker build --progress plain --tag "$IMAGE_NAME" --target vllm-test -f docker/Dockerfile.cpu .
 
+KVCACHE_ENV_ARGS=()
+if [ -n "${VLLM_CPU_KVCACHE_SPACE}" ]; then
+    KVCACHE_ENV_ARGS+=(-e "VLLM_CPU_KVCACHE_SPACE=${VLLM_CPU_KVCACHE_SPACE}")
+fi
+
+# --memory-swap pinned to the same value disables swap headroom, so a
+# regression that over-allocates actually OOMs here instead of being
+# masked by swap.
+MEMORY_ARGS=()
+if [ -n "${CONTAINER_MEMORY_LIMIT}" ]; then
+    MEMORY_ARGS+=(
+        --memory="${CONTAINER_MEMORY_LIMIT}"
+        --memory-swap="${CONTAINER_MEMORY_LIMIT}"
+        -e "CONTAINER_MEMORY_LIMIT=${CONTAINER_MEMORY_LIMIT}"
+    )
+fi
+
 # Run the image, setting --shm-size=4g for tensor parallel.
-docker run --rm --cpuset-cpus="$CORE_RANGE" --cpuset-mems="$NUMA_NODE" -v ~/.cache/huggingface:/root/.cache/huggingface --privileged=true -e HF_TOKEN -e VLLM_CPU_KVCACHE_SPACE=16 -e VLLM_CPU_CI_ENV=1 -e VLLM_CPU_SIM_MULTI_NUMA=1 -e VLLM_CPU_ATTN_SPLIT_KV=0 --shm-size=4g "$IMAGE_NAME" \
+docker run --rm --cpuset-cpus="$CORE_RANGE" --cpuset-mems="$NUMA_NODE" -v ~/.cache/huggingface:/root/.cache/huggingface --privileged=true -e HF_TOKEN "${KVCACHE_ENV_ARGS[@]}" -e VLLM_CPU_CI_ENV=1 -e VLLM_CPU_SIM_MULTI_NUMA=1 -e VLLM_CPU_ATTN_SPLIT_KV=0 --shm-size=4g "${MEMORY_ARGS[@]}" "$IMAGE_NAME" \
         timeout "$TIMEOUT_VAL" bash -c "set -euox pipefail; echo \"--- Print packages\"; pip list; echo \"--- Running tests\"; ${TEST_COMMAND}"

--- a/tests/utils_/test_cpu_resource_utils.py
+++ b/tests/utils_/test_cpu_resource_utils.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Cgroup-aware memory detection for the CPU backend.
+
+`get_memory_node_info` feeds `CPUWorker.determine_available_memory`'s
+fraction-of-available-memory KV-cache auto-sizing. Without the cgroup clamp
+tested here, that path sizes off host/NUMA-node RAM instead of the
+container's memory.max and over-allocates on a memory-limited K8s pod or CI
+container, OOM-killing the process (or a sibling, e.g. dockerd in a DinD
+sidecar) instead of vLLM itself raising a clean error.
+"""
+
+import sys
+from io import StringIO
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.utils import cpu_resource_utils as cru
+from vllm.utils.mem_constants import GiB_bytes
+
+_V2_LIMIT_PATH = "/sys/fs/cgroup/memory.max"
+_V2_USAGE_PATH = "/sys/fs/cgroup/memory.current"
+_V1_LIMIT_PATH = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+_V1_USAGE_PATH = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+_NUMA_MEMINFO_PATH = "/sys/devices/system/node/node0/meminfo"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cgroup_cache():
+    cru.get_cgroup_memory_limit.cache_clear()
+    yield
+    cru.get_cgroup_memory_limit.cache_clear()
+
+
+def _stub_files(monkeypatch, files: dict):
+    """Stub ``open()`` for a fixed set of paths; ``None`` -> OSError (missing)."""
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path in files:
+            content = files[path]
+            if content is None:
+                raise OSError(f"no such file: {path}")
+            return StringIO(content)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+
+def _stub_no_cgroup_files(monkeypatch):
+    _stub_files(monkeypatch, {_V2_LIMIT_PATH: None, _V1_LIMIT_PATH: None})
+
+
+def _fake_vm(total, available):
+    return SimpleNamespace(total=total, available=available)
+
+
+# --------------------------------------------------------------------------
+# get_cgroup_memory_limit
+# --------------------------------------------------------------------------
+
+
+def test_cgroup_v2_limit_and_usage(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    _stub_files(
+        monkeypatch,
+        {_V2_LIMIT_PATH: f"{20 * GiB_bytes}\n", _V2_USAGE_PATH: f"{5 * GiB_bytes}\n"},
+    )
+    assert cru.get_cgroup_memory_limit() == (20 * GiB_bytes, 5 * GiB_bytes)
+
+
+def test_cgroup_v2_unlimited_falls_back_to_v1(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    _stub_files(
+        monkeypatch,
+        {
+            _V2_LIMIT_PATH: "max\n",
+            _V1_LIMIT_PATH: f"{8 * GiB_bytes}\n",
+            _V1_USAGE_PATH: f"{1 * GiB_bytes}\n",
+        },
+    )
+    assert cru.get_cgroup_memory_limit() == (8 * GiB_bytes, 1 * GiB_bytes)
+
+
+def test_cgroup_v1_limit_and_usage(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    _stub_files(
+        monkeypatch,
+        {
+            _V2_LIMIT_PATH: None,
+            _V1_LIMIT_PATH: f"{8 * GiB_bytes}\n",
+            _V1_USAGE_PATH: f"{2 * GiB_bytes}\n",
+        },
+    )
+    assert cru.get_cgroup_memory_limit() == (8 * GiB_bytes, 2 * GiB_bytes)
+
+
+def test_cgroup_v1_unlimited_sentinel_is_ignored(monkeypatch):
+    """cgroup v1 reports a huge sentinel (close to PAGE_COUNTER_MAX) for an
+    unconstrained cgroup; that must read as "no limit", not a literal
+    multi-exabyte cap."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    _stub_files(
+        monkeypatch, {_V2_LIMIT_PATH: None, _V1_LIMIT_PATH: f"{(1 << 63) - 1}\n"}
+    )
+    assert cru.get_cgroup_memory_limit() == (None, None)
+
+
+def test_cgroup_no_limit_files_present(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    _stub_no_cgroup_files(monkeypatch)
+    assert cru.get_cgroup_memory_limit() == (None, None)
+
+
+def test_cgroup_skipped_on_non_linux(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    # Even if a v2 file happened to exist, non-Linux must short-circuit.
+    _stub_files(monkeypatch, {_V2_LIMIT_PATH: f"{1 * GiB_bytes}\n"})
+    assert cru.get_cgroup_memory_limit() == (None, None)
+
+
+# --------------------------------------------------------------------------
+# get_memory_node_info
+# --------------------------------------------------------------------------
+
+
+def test_numa_meminfo_clamped_to_cgroup_limit(monkeypatch):
+    """A big multi-socket box running one pod with a tight cgroup limit
+    must report the pod's limit, not the host's full NUMA-node RAM."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(cru.os.path, "exists", lambda path: path == _NUMA_MEMINFO_PATH)
+    host_total_kb = 775 * GiB_bytes // 1024
+    host_free_kb = host_total_kb - 10 * GiB_bytes // 1024
+    meminfo = (
+        f"Node 0 MemTotal:       {host_total_kb} kB\n"
+        f"Node 0 MemFree:        {host_free_kb} kB\n"
+        "Node 0 Active(file):   0 kB\n"
+        "Node 0 Inactive(file): 0 kB\n"
+        "Node 0 SReclaimable:   0 kB\n"
+    )
+    _stub_files(
+        monkeypatch,
+        {
+            _NUMA_MEMINFO_PATH: meminfo,
+            _V2_LIMIT_PATH: f"{20 * GiB_bytes}\n",
+            _V2_USAGE_PATH: f"{5 * GiB_bytes}\n",
+        },
+    )
+    info = cru.get_memory_node_info(0)
+    assert info.total_memory == 20 * GiB_bytes
+    assert info.available_memory == 15 * GiB_bytes
+
+
+def test_non_numa_fallback_clamped_to_cgroup_limit(monkeypatch):
+    """Non-NUMA hosts (no per-node meminfo) fall back to psutil, but that
+    still reports host-wide RAM -- it must be clamped to the cgroup limit
+    exactly like the NUMA path, or a constrained non-NUMA pod would size
+    its KV cache off the host instead of its own memory.max."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(cru.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(
+        cru.psutil, "virtual_memory", lambda: _fake_vm(775 * GiB_bytes, 700 * GiB_bytes)
+    )
+    _stub_files(
+        monkeypatch,
+        {_V2_LIMIT_PATH: f"{20 * GiB_bytes}\n", _V2_USAGE_PATH: f"{5 * GiB_bytes}\n"},
+    )
+    info = cru.get_memory_node_info(0)
+    assert info.total_memory == 20 * GiB_bytes
+    assert info.available_memory == 15 * GiB_bytes
+
+
+def test_non_numa_fallback_uses_host_values_without_cgroup_limit(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(cru.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(
+        cru.psutil, "virtual_memory", lambda: _fake_vm(775 * GiB_bytes, 700 * GiB_bytes)
+    )
+    _stub_no_cgroup_files(monkeypatch)
+    info = cru.get_memory_node_info(0)
+    assert info.total_memory == 775 * GiB_bytes
+    assert info.available_memory == 700 * GiB_bytes
+
+
+def test_cgroup_limit_at_or_above_host_total_is_not_a_clamp(monkeypatch):
+    """An unconstrained/oversized cgroup limit (>= host RAM) must not
+    "clamp" upward -- the host figure stays authoritative."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(cru.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(
+        cru.psutil, "virtual_memory", lambda: _fake_vm(20 * GiB_bytes, 15 * GiB_bytes)
+    )
+    _stub_files(
+        monkeypatch, {_V2_LIMIT_PATH: f"{775 * GiB_bytes}\n", _V2_USAGE_PATH: "0\n"}
+    )
+    info = cru.get_memory_node_info(0)
+    assert info.total_memory == 20 * GiB_bytes
+    assert info.available_memory == 15 * GiB_bytes

--- a/tests/v1/e2e/test_cpu_cgroup_memory_limit.py
+++ b/tests/v1/e2e/test_cpu_cgroup_memory_limit.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for the CPU backend's cgroup-aware KV-cache sizing.
+
+Only meaningful under a real container memory cgroup -- see the
+"CPU-Cgroup Memory Clamp Test" Buildkite step
+(.buildkite/hardware_tests/cpu.yaml), which runs this through
+.buildkite/scripts/hardware_ci/run-cpu-test.sh with CONTAINER_MEMORY_LIMIT
+set and VLLM_CPU_KVCACHE_SPACE explicitly unset.
+
+With no explicit --kv-cache-memory-bytes / VLLM_CPU_KVCACHE_SPACE, the CPU
+worker's fraction-of-available-memory auto-sizing path
+(CPUWorker.determine_available_memory) must size off the container's
+memory.max, not the host's/NUMA-node's full RAM -- otherwise it
+over-allocates and gets OOM-killed on a memory-limited K8s pod or CI
+container (see vllm/utils/cpu_resource_utils.py::get_memory_node_info).
+"""
+
+import os
+
+import pytest
+
+from vllm import LLM, SamplingParams
+from vllm.platforms import current_platform
+from vllm.utils.cpu_resource_utils import get_memory_node_info
+
+pytestmark = pytest.mark.cpu_model
+
+if not current_platform.is_cpu():
+    pytest.skip("skipping CPU-only tests", allow_module_level=True)
+
+_LIMIT_ENV = "CONTAINER_MEMORY_LIMIT"
+
+
+def _require_container_memory_limit() -> int:
+    raw = os.environ.get(_LIMIT_ENV)
+    if not raw:
+        pytest.skip(
+            f"{_LIMIT_ENV} not set; only meaningful under a memory-capped "
+            "container (see the CPU-Cgroup Memory Clamp Test Buildkite step)"
+        )
+        raise AssertionError("unreachable")  # pytest.skip always raises
+    return int(raw)
+
+
+def test_cgroup_limit_is_detected_not_host_ram():
+    """get_memory_node_info() must report (at most) the container's own
+    cap, not the CI host's much larger physical RAM."""
+    limit_bytes = _require_container_memory_limit()
+    info = get_memory_node_info()
+    assert info.total_memory <= limit_bytes, (
+        f"reported total_memory={info.total_memory} exceeds the container's "
+        f"{limit_bytes}-byte cgroup limit -- the cgroup clamp did not apply "
+        "and this run sized off host RAM instead"
+    )
+
+
+def test_auto_sized_kv_cache_does_not_oom_under_cgroup_limit():
+    """Boot a tiny model with no explicit KV-cache size: the fraction-of-
+    available-memory auto-sizing path must clamp to the container's cgroup
+    limit instead of trying to claim a fraction of host RAM, which would
+    get this process (or a sibling, e.g. dockerd in a DinD sidecar)
+    OOM-killed before it ever reaches this assertion."""
+    _require_container_memory_limit()
+    assert "VLLM_CPU_KVCACHE_SPACE" not in os.environ, (
+        "this test only exercises the auto-sizing path; "
+        "VLLM_CPU_KVCACHE_SPACE must be unset"
+    )
+    llm = LLM(
+        model="facebook/opt-125m",
+        dtype="bfloat16",
+        max_model_len=256,
+        enforce_eager=True,
+    )
+    outputs = llm.generate(["Hello, my name is"], SamplingParams(max_tokens=8))
+    assert outputs[0].outputs[0].text

--- a/vllm/utils/cpu_resource_utils.py
+++ b/vllm/utils/cpu_resource_utils.py
@@ -119,58 +119,53 @@ def parse_id_list(raw_str: str) -> list[int]:
     return sorted(list(set(result)))
 
 
-def get_memory_node_info(node_id: int = 0) -> MemoryNodeInfo:
-    if sys.platform == "darwin":
-        # MacOS has no memory node
-        vm = psutil.virtual_memory()
-        total_memory, available_memory = vm.total, vm.available
-    else:
-        meminfo_path = f"/sys/devices/system/node/node{node_id}/meminfo"
-        if not os.path.exists(meminfo_path):
-            # Non-NUMA systems (e.g. many RISC-V boards, and some
-            # containers) don't expose per-node meminfo. Fall back to
-            # system-wide numbers from psutil.
-            vm = psutil.virtual_memory()
-            total_memory, available_memory = vm.total, vm.available
-        else:
-            meminfo = {}
-            with open(meminfo_path) as f:
-                for line in f:
-                    # Each line looks like: "Node 0 MemTotal: 97421888 kB"
-                    parts = line.split()
-                    key = parts[2].rstrip(":")
-                    # convert to Bytes
-                    value = int(parts[3]) * 1024
-                    meminfo[key] = value
-
-            total_memory = meminfo["MemTotal"]
-            free_memory = meminfo["MemFree"]
-            active_file_memory = meminfo["Active(file)"]
-            inactive_file_memory = meminfo["Inactive(file)"]
-            reclaimable_memory = meminfo["SReclaimable"]
-            available_memory = (
-                free_memory
-                + active_file_memory
-                + inactive_file_memory
-                + reclaimable_memory
-            )
-
-    # Honor cgroup memory limit (containers / k8s pods), on every path
-    # above -- not just the NUMA-meminfo one. Host-wide numbers (NUMA
-    # meminfo or psutil) would otherwise apply gpu_memory_utilization to
-    # host RAM instead of the pod's limit on non-NUMA hosts too. cgroup
-    # does not expose per-NUMA-node limits, so we just clamp the totals
-    # against the pod-wide limit here.
+def _with_cgroup_clamp(total_memory: int, available_memory: int) -> MemoryNodeInfo:
+    """Honor cgroup memory limit (containers / k8s pods). Host-wide numbers
+    (NUMA meminfo or psutil) would otherwise apply gpu_memory_utilization to
+    host RAM instead of the pod's limit. cgroup does not expose per-NUMA-node
+    limits, so we just clamp the totals against the pod-wide limit here."""
     cgroup_limit, cgroup_usage = get_cgroup_memory_limit()
     if cgroup_limit is not None and cgroup_limit < total_memory:
         total_memory = cgroup_limit
         cgroup_available = cgroup_limit - (cgroup_usage or 0)
         available_memory = max(0, min(available_memory, cgroup_available))
+    return MemoryNodeInfo(total_memory=total_memory, available_memory=available_memory)
 
-    return MemoryNodeInfo(
-        total_memory=total_memory,
-        available_memory=available_memory,
+
+def get_memory_node_info(node_id: int = 0) -> MemoryNodeInfo:
+    if sys.platform == "darwin":
+        # MacOS has no memory node
+        vm = psutil.virtual_memory()
+        return _with_cgroup_clamp(vm.total, vm.available)
+
+    meminfo_path = f"/sys/devices/system/node/node{node_id}/meminfo"
+    if not os.path.exists(meminfo_path):
+        # Non-NUMA systems (e.g. many RISC-V boards, and some containers)
+        # don't expose per-node meminfo. Fall back to system-wide numbers
+        # from psutil.
+        vm = psutil.virtual_memory()
+        return _with_cgroup_clamp(vm.total, vm.available)
+
+    meminfo = {}
+    with open(meminfo_path) as f:
+        for line in f:
+            # Each line looks like: "Node 0 MemTotal: 97421888 kB"
+            parts = line.split()
+            key = parts[2].rstrip(":")
+            # convert to Bytes
+            value = int(parts[3]) * 1024
+            meminfo[key] = value
+
+    total_memory = meminfo["MemTotal"]
+    free_memory = meminfo["MemFree"]
+    active_file_memory = meminfo["Active(file)"]
+    inactive_file_memory = meminfo["Inactive(file)"]
+    reclaimable_memory = meminfo["SReclaimable"]
+    available_memory = (
+        free_memory + active_file_memory + inactive_file_memory + reclaimable_memory
     )
+
+    return _with_cgroup_clamp(total_memory, available_memory)
 
 
 def get_allowed_cpu_list() -> list[LogicalCPUInfo]:

--- a/vllm/utils/cpu_resource_utils.py
+++ b/vllm/utils/cpu_resource_utils.py
@@ -122,43 +122,43 @@ def parse_id_list(raw_str: str) -> list[int]:
 def get_memory_node_info(node_id: int = 0) -> MemoryNodeInfo:
     if sys.platform == "darwin":
         # MacOS has no memory node
-        return MemoryNodeInfo(
-            total_memory=psutil.virtual_memory().total,
-            available_memory=psutil.virtual_memory().available,
-        )
-
-    meminfo_path = f"/sys/devices/system/node/node{node_id}/meminfo"
-    if not os.path.exists(meminfo_path):
-        # Non-NUMA systems (e.g. many RISC-V boards) don't expose per-node
-        # meminfo. Fall back to system-wide numbers from psutil.
         vm = psutil.virtual_memory()
-        return MemoryNodeInfo(
-            total_memory=vm.total,
-            available_memory=vm.available,
-        )
+        total_memory, available_memory = vm.total, vm.available
+    else:
+        meminfo_path = f"/sys/devices/system/node/node{node_id}/meminfo"
+        if not os.path.exists(meminfo_path):
+            # Non-NUMA systems (e.g. many RISC-V boards, and some
+            # containers) don't expose per-node meminfo. Fall back to
+            # system-wide numbers from psutil.
+            vm = psutil.virtual_memory()
+            total_memory, available_memory = vm.total, vm.available
+        else:
+            meminfo = {}
+            with open(meminfo_path) as f:
+                for line in f:
+                    # Each line looks like: "Node 0 MemTotal: 97421888 kB"
+                    parts = line.split()
+                    key = parts[2].rstrip(":")
+                    # convert to Bytes
+                    value = int(parts[3]) * 1024
+                    meminfo[key] = value
 
-    meminfo = {}
-    with open(meminfo_path) as f:
-        for line in f:
-            # Each line looks like: "Node 0 MemTotal: 97421888 kB"
-            parts = line.split()
-            key = parts[2].rstrip(":")
-            # convert to Bytes
-            value = int(parts[3]) * 1024
-            meminfo[key] = value
+            total_memory = meminfo["MemTotal"]
+            free_memory = meminfo["MemFree"]
+            active_file_memory = meminfo["Active(file)"]
+            inactive_file_memory = meminfo["Inactive(file)"]
+            reclaimable_memory = meminfo["SReclaimable"]
+            available_memory = (
+                free_memory
+                + active_file_memory
+                + inactive_file_memory
+                + reclaimable_memory
+            )
 
-    total_memory = meminfo["MemTotal"]
-    free_memory = meminfo["MemFree"]
-    active_file_memory = meminfo["Active(file)"]
-    inactive_file_memory = meminfo["Inactive(file)"]
-    reclaimable_memory = meminfo["SReclaimable"]
-    available_memory = (
-        free_memory + active_file_memory + inactive_file_memory + reclaimable_memory
-    )
-
-    # Honor cgroup memory limit (containers / k8s pods). NUMA meminfo
-    # reflects host-wide numbers; without this, gpu_memory_utilization
-    # would be applied to host RAM instead of the pod's limit. cgroup
+    # Honor cgroup memory limit (containers / k8s pods), on every path
+    # above -- not just the NUMA-meminfo one. Host-wide numbers (NUMA
+    # meminfo or psutil) would otherwise apply gpu_memory_utilization to
+    # host RAM instead of the pod's limit on non-NUMA hosts too. cgroup
     # does not expose per-NUMA-node limits, so we just clamp the totals
     # against the pod-wide limit here.
     cgroup_limit, cgroup_usage = get_cgroup_memory_limit()


### PR DESCRIPTION
## Summary

The CPU backend's KV-cache auto-sizing reserves a fraction of "available memory" for the KV cache. `get_memory_node_info()` correctly clamps that figure to the container's cgroup memory limit when per-NUMA-node meminfo is available — but skips the clamp on the fallback path used when that meminfo isn't exposed (some containers, non-NUMA hosts), which silently returns raw host-wide RAM instead. On a memory-limited container that hits this fallback, auto-sizing reserves a fraction of the *host's* RAM instead of the container's own limit, and gets OOM-killed.

This patch applies the same cgroup clamp uniformly, regardless of which path produced the memory figures.

## Changes

- Fix in `vllm/utils/cpu_resource_utils.py`.
- `tests/utils_/test_cpu_resource_utils.py`: unit tests for cgroup-limit detection and clamping (cgroup v1/v2, the v1 "unlimited" sentinel, and both memory-info paths). One test fails against the pre-fix code — confirmed locally before writing the fix.
- `tests/v1/e2e/test_cpu_cgroup_memory_limit.py`: boots a small model under a real memory-capped container with no explicit KV-cache size, catching the failure end-to-end.
- New "CPU-Cgroup Memory Clamp Test" Buildkite step that runs under a real `docker --memory` cap — today CPU CI never runs under any memory limit, so this class of bug has no CI coverage.
- `run-cpu-test.sh` gains two opt-in env knobs for this; all existing jobs are unaffected.

## Test plan

New unit tests pass; `ruff`/`mypy`/`shellcheck` clean on all changed files. The e2e test's memory threshold (4 GiB) is a reasonable estimate but untested against buildkite. An analog was tested against gitlab with k8s runners (against pure CPU systems). It corrected an issue where single CPU LLM tests would take 90% of the entire node's RAM.

AI-assisted change (Claude Code), reviewed before opening.