### PR TITLE
[CI] Report unsafe and partial cross-commit retries

### DIFF
--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import html
 import json
 import os
 import random
+import re
 import sys
 import time
 import urllib.error
@@ -67,16 +69,22 @@ ACTIVE_BUILD_STATES = {
 RETRY_STATES = "failed,timed_out,expired"
 CANCELABLE_BUILD_STATES = ("scheduled", "running", "failing")
 SETUP_STEP_KEYS = {
+    "bootstrap",
     "ensure-ci-base-amd",
     "pre-commit",
     "refresh-rocm-base-amd",
 }
+GENERATOR_ERROR_ANNOTATION_CONTEXT = "pipeline-generator-error"
 
 
 class ApiError(RuntimeError):
     def __init__(self, status: int | None, message: str) -> None:
         super().__init__(message)
         self.status = status
+
+
+class Refusal(str):
+    """A command the bot declined to run, reported with a cross, not a tick."""
 
 
 def rate_limit_jitter() -> float:
@@ -403,6 +411,13 @@ class BuildkiteClient:
             path=f"/{number}/retry_failed_jobs",
         )
 
+    def list_annotations(self, build_number: int) -> list[dict[str, Any]]:
+        number = urllib.parse.quote(str(build_number), safe="")
+        response = self._request(path=f"/{number}/annotations")
+        if not isinstance(response, list):
+            raise ApiError(None, "Buildkite API returned an invalid annotation list.")
+        return response
+
     def cancel_build(self, build_number: int) -> dict[str, Any]:
         number = urllib.parse.quote(str(build_number), safe="")
         return self._request(method="PUT", path=f"/{number}/cancel")
@@ -656,6 +671,56 @@ def create_retry_build_payload(
     return payload
 
 
+def is_setup_step(step_key: str) -> bool:
+    return step_key.startswith("image-build") or step_key in SETUP_STEP_KEYS
+
+
+def generator_error(buildkite: BuildkiteClient, build_number: int) -> str | None:
+    """The pipeline generator's own error for this build, if it recorded one.
+
+    ci-infra annotates every generation failure so the cause can be quoted on
+    the PR instead of left in the bootstrap log. Needs only the read_builds
+    scope, and a build that failed before generating a pipeline has no
+    annotation, which usually means infrastructure rather than configuration.
+    """
+    try:
+        annotations = buildkite.list_annotations(build_number)
+    except ApiError as error:
+        print(f"Could not read build annotations: {error}", file=sys.stderr)
+        return None
+    for annotation in annotations:
+        if annotation.get("context") != GENERATOR_ERROR_ANNOTATION_CONTEXT:
+            continue
+        body = re.sub(r"<[^>]+>", " ", str(annotation.get("body_html") or ""))
+        text = " ".join(html.unescape(body).split())
+        if text:
+            return text[:500]
+    return None
+
+
+def setup_failure(
+    buildkite: BuildkiteClient,
+    build: Mapping[str, Any],
+    ci_name: str,
+    *,
+    retry_command: str,
+    run_command: str,
+) -> Refusal:
+    link = f"[Buildkite {ci_name} #{build['number']}]({build['web_url']})"
+    reason = generator_error(buildkite, build["number"])
+    if reason is None:
+        return Refusal(
+            f"{link} failed during CI setup before generating its pipeline, so "
+            "its test failure set is incomplete. No configuration error was "
+            f"reported, so this may be infrastructure. Comment `{retry_command}` "
+            f"to try again, or `{run_command}` for a full build."
+        )
+    return Refusal(
+        f"{link} failed during CI setup, so its test failure set is incomplete."
+        f"\n\nCI setup reported:\n\n```\n{reason}\n```\n\nUse `{run_command}`."
+    )
+
+
 def add_reaction_safely(
     github: GitHubClient,
     comment_id: int,
@@ -870,6 +935,22 @@ def handle_retry_failed(
                 f"{ci_name} was already requested by this comment: {build['web_url']}"
             )
 
+        # A retry build pins VLLM_CI_ONLY_STEP_KEYS, so re-running its setup in
+        # place can only fail the same way. An ordinary run's bootstrap may have
+        # flaked, so it stays retryable.
+        if metadata.get("github-retry-source-build") and any(
+            is_setup_step(str(job.get("step_key") or ""))
+            for job in buildkite.list_failed_jobs(build["number"])
+            if job.get("type") == "script"
+        ):
+            return setup_failure(
+                buildkite,
+                build,
+                ci_name,
+                retry_command=retry_command,
+                run_command=run_command,
+            )
+
         retried = buildkite.retry_failed_jobs(build["number"], RETRY_STATES)
         if retried["retried_jobs_count"] == 0:
             return (
@@ -910,7 +991,7 @@ def handle_retry_failed(
     failed_script_jobs = [job for job in failed_jobs if job.get("type") == "script"]
     missing_step_keys = [job for job in failed_script_jobs if not job.get("step_key")]
     if missing_step_keys:
-        return (
+        return Refusal(
             f"[Buildkite {ci_name} #{source_build['number']}]"
             f"({source_build['web_url']}) has failed jobs without stable step "
             "keys, so they cannot be retried on a new commit. "
@@ -919,15 +1000,15 @@ def handle_retry_failed(
 
     failed_step_keys = {str(job["step_key"]) for job in failed_script_jobs}
     setup_failures = sorted(
-        step_key
-        for step_key in failed_step_keys
-        if step_key.startswith("image-build") or step_key in SETUP_STEP_KEYS
+        step_key for step_key in failed_step_keys if is_setup_step(step_key)
     )
     if setup_failures:
-        return (
-            f"[Buildkite {ci_name} #{source_build['number']}]"
-            f"({source_build['web_url']}) failed during CI setup, so its test "
-            f"failure set is incomplete. Use `{run_command}` for the new commit."
+        return setup_failure(
+            buildkite,
+            source_build,
+            ci_name,
+            retry_command=retry_command,
+            run_command=run_command,
         )
 
     step_keys = sorted(failed_step_keys)
@@ -1097,8 +1178,13 @@ def run(
             )
         else:
             raise ValueError(f"Unsupported CI command: {command}")
-        add_reaction_safely(github, comment_id, "rocket")
-        github.add_comment(issue_number, f"✅ {message}")
+        # Both reactions are terminal for is_already_handled, so a refused
+        # command is not reprocessed if the workflow runs again.
+        icon, reaction = (
+            ("❌", "-1") if isinstance(message, Refusal) else ("✅", "rocket")
+        )
+        add_reaction_safely(github, comment_id, reaction)
+        github.add_comment(issue_number, f"{icon} {message}")
     except Exception:
         add_reaction_safely(github, comment_id, "confused")
         raise

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -138,7 +138,10 @@ class FakeBuildkite:
         self,
         build_lists: list[list[dict[str, Any]]] | None = None,
         failed_job_lists: list[list[dict[str, Any]]] | None = None,
+        annotations: list[dict[str, Any]] | None = None,
     ) -> None:
+        self.annotations = annotations
+        self.annotation_calls: list[int] = []
         self.build_lists = build_lists or []
         self.created_builds: list[dict[str, Any]] = []
         self.failed_job_lists = failed_job_lists or []
@@ -189,6 +192,12 @@ class FakeBuildkite:
     def list_failed_jobs(self, build_number: int) -> list[dict[str, Any]]:
         self.job_list_calls.append(build_number)
         return self.failed_job_lists.pop(0)
+
+    def list_annotations(self, build_number: int) -> list[dict[str, Any]]:
+        self.annotation_calls.append(build_number)
+        if self.annotations is None:
+            raise ApiError(403, "Forbidden")
+        return self.annotations
 
 
 class FakeTransport:
@@ -998,6 +1007,8 @@ class RunCiCommandTest(unittest.TestCase):
         run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
 
         self.assertEqual(buildkite.created_builds, [])
+        self.assertEqual(github.reactions, ["eyes", "-1"])
+        self.assertTrue(github.comments[0].startswith("❌ "))
         self.assertIn("without stable step keys", github.comments[0])
         self.assertIn("Use `/ci run`", github.comments[0])
 
@@ -1035,8 +1046,144 @@ class RunCiCommandTest(unittest.TestCase):
         run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
 
         self.assertEqual(buildkite.created_builds, [])
+        self.assertEqual(github.reactions, ["eyes", "-1"])
+        self.assertTrue(github.comments[0].startswith("❌ "))
         self.assertIn("failed during CI setup", github.comments[0])
+        self.assertIn("this may be infrastructure", github.comments[0])
+
+    def _stale_source_build(self) -> dict[str, Any]:
+        return {
+            "commit": "old-commit",
+            "created_at": "2026-09-03T13:00:00Z",
+            "finished_at": "2026-09-03T13:01:00Z",
+            "number": 87079,
+            "pull_request": {"id": 42},
+            "state": "failed",
+            "web_url": "https://buildkite.example/builds/87079",
+        }
+
+    def test_ci_retry_new_head_rejects_bootstrap_failure(self) -> None:
+        # A build whose bootstrap failed reports bootstrap as its only failed
+        # job. Forwarding that key to a retry asks the generator for a step
+        # that does not exist, which is what made /ci retry loop.
+        github = FakeGitHub(permission="read", pr=make_pr(labels=[{"name": "ready"}]))
+        buildkite = FakeBuildkite(
+            [[], [self._stale_source_build()]],
+            [[{"state": "failed", "step_key": "bootstrap", "type": "script"}]],
+            annotations=[],
+        )
+
+        run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
+
+        self.assertEqual(buildkite.created_builds, [])
+        self.assertEqual(github.reactions, ["eyes", "-1"])
+        self.assertIn("failed during CI setup", github.comments[0])
+
+    def test_ci_retry_quotes_the_generator_error(self) -> None:
+        github = FakeGitHub(permission="read", pr=make_pr(labels=[{"name": "ready"}]))
+        buildkite = FakeBuildkite(
+            [[], [self._stale_source_build()]],
+            [[{"state": "failed", "step_key": "bootstrap", "type": "script"}]],
+            annotations=[
+                {"context": "docs-only", "body_html": "<p>CI skipped</p>"},
+                {
+                    "context": "pipeline-generator-error",
+                    "body_html": (
+                        "<p>Pipeline generation failed: Unknown CI step "
+                        "key(s): removed-test</p>"
+                    ),
+                },
+            ],
+        )
+
+        run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
+
+        self.assertEqual(buildkite.created_builds, [])
+        self.assertEqual(buildkite.annotation_calls, [87079])
+        self.assertIn(
+            "Pipeline generation failed: Unknown CI step key(s): removed-test",
+            github.comments[0],
+        )
+        self.assertNotIn("<p>", github.comments[0])
         self.assertIn("Use `/ci run`", github.comments[0])
+
+    def test_ci_retry_reports_infrastructure_without_an_annotation(self) -> None:
+        # A missing annotation (or a token that cannot read them) must degrade
+        # to advice, never to a stack trace or a wrong "fix your config".
+        github = FakeGitHub(permission="read", pr=make_pr(labels=[{"name": "ready"}]))
+        buildkite = FakeBuildkite(
+            [[], [self._stale_source_build()]],
+            [[{"state": "failed", "step_key": "bootstrap", "type": "script"}]],
+            annotations=None,
+        )
+
+        run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
+
+        self.assertIn("this may be infrastructure", github.comments[0])
+        self.assertIn("`/ci retry`", github.comments[0])
+        self.assertNotIn("CI setup reported", github.comments[0])
+
+    def test_ci_retry_in_place_refuses_a_wedged_retry_build(self) -> None:
+        # Retrying a filtered retry build in place re-runs bootstrap against
+        # the same pinned VLLM_CI_ONLY_STEP_KEYS, so it can only fail again.
+        github = FakeGitHub(permission="read", pr=make_pr(labels=[{"name": "ready"}]))
+        buildkite = FakeBuildkite(
+            [
+                [
+                    {
+                        "commit": "abc123",
+                        "created_at": "2026-09-03T14:00:00Z",
+                        "finished_at": "2026-09-03T14:01:00Z",
+                        "meta_data": {"github-retry-source-build": "87079"},
+                        "number": 87081,
+                        "pull_request": {"id": 42},
+                        "state": "failed",
+                        "web_url": "https://buildkite.example/builds/87081",
+                    }
+                ]
+            ],
+            [[{"state": "failed", "step_key": "bootstrap", "type": "script"}]],
+            annotations=[
+                {
+                    "context": "pipeline-generator-error",
+                    "body_html": (
+                        "Pipeline generation failed: Unknown CI step key(s): bootstrap"
+                    ),
+                }
+            ],
+        )
+
+        run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
+
+        self.assertEqual(buildkite.retry_calls, [])
+        self.assertEqual(github.reactions, ["eyes", "-1"])
+        self.assertIn("Unknown CI step key(s): bootstrap", github.comments[0])
+
+    def test_ci_retry_in_place_still_retries_an_ordinary_build(self) -> None:
+        # An ordinary run pins no step keys, so a flaky bootstrap stays
+        # retryable in place and no annotation lookup happens.
+        github = FakeGitHub(permission="read", pr=make_pr(labels=[{"name": "ready"}]))
+        buildkite = FakeBuildkite(
+            [
+                [
+                    {
+                        "commit": "abc123",
+                        "created_at": "2026-09-03T14:00:00Z",
+                        "finished_at": "2026-09-03T14:01:00Z",
+                        "number": 87082,
+                        "pull_request": {"id": 42},
+                        "state": "failed",
+                        "web_url": "https://buildkite.example/builds/87082",
+                    }
+                ]
+            ],
+        )
+
+        run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
+
+        self.assertEqual(buildkite.retry_calls, [(87082, RETRY_STATES)])
+        self.assertEqual(buildkite.annotation_calls, [])
+        self.assertTrue(github.comments[0].startswith("✅ "))
 
     def test_buildkite_retry_uses_retry_failed_jobs_endpoint(self) -> None:
         transport = FakeTransport({"retried_jobs_count": 2})


### PR DESCRIPTION
## Purpose

Make cross-commit `/ci retry` report step-key validation clearly on the PR while keeping GitHub credentials out of Buildkite.

In PR #54557, a retry forwarded a generated AMD mirror key that bootstrap did not recognize. A later retry forwarded `bootstrap` itself, causing another bootstrap failure.

This PR:

- Classifies `bootstrap` and the partial-retry validation marker as setup steps.
- Rejects cross-commit retries when failed jobs have no stable key or setup failed. It posts a `❌` PR comment, creates no Buildkite build, and fails the GitHub Actions workflow.
- After dispatch, polls Buildkite metadata for up to 120 seconds using the existing Buildkite API token.
- Posts a `⚠️` PR comment listing valid and missing keys when Buildkite reports a partial retry.
- Posts `❌` and fails GitHub Actions when every requested key is missing.
- Never sends the GitHub token to Buildkite.

The generator and metadata producer are implemented in vllm-project/ci-infra#512. That PR should merge first.

## Test Plan

- Cover setup and missing-stable-key rejection.
- Cover Buildkite metadata polling.
- Cover all-valid, partially-valid, and all-missing requested key sets.
- Run the full CI command bot test suite and Ruff checks.

## Test Result

- Full suite: 53 passed.
- Ruff lint and format checks passed.
- Partial retry test verifies one `⚠️` comment containing both valid and missing key lists.
- All-missing test verifies a `❌` comment and failed GitHub Actions path.