### PR TITLE
[ROCm] Add gelu_tanh to the AITER fp8 fused MoE and zero-allocate the padded expert weights

### DIFF
--- a/tests/kernels/moe/test_moe_kernel_oracle.py
+++ b/tests/kernels/moe/test_moe_kernel_oracle.py
@@ -49,3 +49,26 @@ class TestUnquantizedDelegation:
             None,  # routing_tables default
         )
         assert out is sentinel_kernel
+
+
+def test_fp8_round_up_intermediate_size_for_aiter() -> None:
+    """Ensure fp8 MoE GEMM is rounded up to factor 128 when on AITER."""
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+        Fp8MoeBackend,
+        fp8_round_up_hidden_size_and_intermediate_size,
+    )
+
+    # Should round
+    assert fp8_round_up_hidden_size_and_intermediate_size(
+        Fp8MoeBackend.AITER, 2048, 704
+    ) == (2048, 768)
+
+    # no-op
+    assert fp8_round_up_hidden_size_and_intermediate_size(
+        Fp8MoeBackend.AITER, 2048, 1024
+    ) == (2048, 1024)
+
+    # Non-AITER backends are untouched even when non-128-aligned.
+    assert fp8_round_up_hidden_size_and_intermediate_size(
+        Fp8MoeBackend.TRITON, 2048, 704
+    ) == (2048, 704)

--- a/tests/kernels/moe/test_moe_kernel_oracle.py
+++ b/tests/kernels/moe/test_moe_kernel_oracle.py
@@ -52,7 +52,10 @@ class TestUnquantizedDelegation:
 
 
 def test_fp8_round_up_intermediate_size_for_aiter() -> None:
-    """Ensure fp8 MoE GEMM is rounded up to factor 128 when on AITER."""
+    """The fp8 MoE intermediate size is rounded up to a multiple of 128 only for
+    the AITER backend with gelu_tanh, the one combination that always lands on
+    the CK 2-stage GEMM."""
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
     from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
         Fp8MoeBackend,
         fp8_round_up_hidden_size_and_intermediate_size,
@@ -60,15 +63,22 @@ def test_fp8_round_up_intermediate_size_for_aiter() -> None:
 
     # Should round
     assert fp8_round_up_hidden_size_and_intermediate_size(
-        Fp8MoeBackend.AITER, 2048, 704
+        Fp8MoeBackend.AITER, 2048, 704, MoEActivation.GELU_TANH
     ) == (2048, 768)
 
-    # no-op
+    # no-op when already aligned
     assert fp8_round_up_hidden_size_and_intermediate_size(
-        Fp8MoeBackend.AITER, 2048, 1024
+        Fp8MoeBackend.AITER, 2048, 1024, MoEActivation.GELU_TANH
     ) == (2048, 1024)
+
+    # silu/gelu on AITER keep their size (AITER has 1-stage kernels for them
+    # that take non-128-aligned shapes).
+    for activation in (MoEActivation.SILU, MoEActivation.GELU):
+        assert fp8_round_up_hidden_size_and_intermediate_size(
+            Fp8MoeBackend.AITER, 2048, 704, activation
+        ) == (2048, 704)
 
     # Non-AITER backends are untouched even when non-128-aligned.
     assert fp8_round_up_hidden_size_and_intermediate_size(
-        Fp8MoeBackend.TRITON, 2048, 704
+        Fp8MoeBackend.TRITON, 2048, 704, MoEActivation.GELU_TANH
     ) == (2048, 704)

--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -220,6 +220,8 @@ def ref_moe_forward(
             act = F.silu(gate) * up
         elif activation == "gelu":
             act = F.gelu(gate) * up
+        elif activation == "gelu_tanh":
+            act = F.gelu(gate, approximate="tanh") * up
         else:
             raise ValueError(f"Unknown activation: {activation}")
         output[expert_mask] = act @ w2_f[expert_idx].T
@@ -600,6 +602,7 @@ def test_activation_method_enum_values():
 
     assert ActivationMethod.SILU == 0
     assert ActivationMethod.GELU == 1
+    assert ActivationMethod.GELU_TANH == 4
 
 
 # MXFP4 kernel tests ------------------------------------------------------
@@ -845,6 +848,51 @@ def test_aiter_fused_moe_gelu_accuracy():
         out.float(),
         ref_out,
         label="gelu_accuracy",
+        atol=0.05,
+        rtol=0.0,
+    )
+
+
+def test_aiter_fused_moe_gelu_tanh_accuracy():
+    """The tanh-approx GELU variant (Gemma-family MoE) should stay aligned with
+    the float32 tanh-approx reference."""
+    from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+        ActivationMethod,
+        QuantMethod,
+    )
+
+    _assert_aiter_supported()
+    case = _make_moe_case(
+        num_tokens=32,
+        hidden_dim=512,
+        intermediate_dim=1024,
+        num_experts=4,
+        topk=2,
+        seed=42,
+    )
+    ref_out = ref_moe_forward(
+        case["hidden_states"],
+        case["w1"],
+        case["w2"],
+        case["topk_weights"],
+        case["topk_ids"],
+        activation="gelu_tanh",
+    )
+    out = _run_fused_moe(
+        case["hidden_states"],
+        case["w1"],
+        case["w2"],
+        case["topk_weights"],
+        case["topk_ids"],
+        activation_method=int(ActivationMethod.GELU_TANH),
+        quant_method=int(QuantMethod.NO),
+    )
+
+    assert out.shape == case["hidden_states"].shape
+    _assert_close_budget(
+        out.float(),
+        ref_out,
+        label="gelu_tanh_accuracy",
         atol=0.05,
         rtol=0.0,
     )

--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -896,6 +896,26 @@ def test_aiter_fused_moe_gelu_tanh_accuracy():
         atol=0.05,
         rtol=0.0,
     )
+    # The tolerance above cannot tell tanh-GELU from exact GELU on its own: make
+    # sure the kernel actually applied the tanh variant by checking it sits closer
+    # to the tanh reference than to the exact-GELU reference on inputs where the
+    # two references measurably differ.
+    ref_exact = ref_moe_forward(
+        case["hidden_states"],
+        case["w1"],
+        case["w2"],
+        case["topk_weights"],
+        case["topk_ids"],
+        activation="gelu",
+    )
+    ref_gap = (ref_out - ref_exact).abs().mean().item()
+    assert ref_gap > 1e-4, f"references indistinguishable (gap={ref_gap:.2e})"
+    err_tanh = (out.float() - ref_out).abs().mean().item()
+    err_exact = (out.float() - ref_exact).abs().mean().item()
+    assert err_tanh < err_exact, (
+        f"kernel closer to exact GELU ({err_exact:.3e}) "
+        f"than to tanh GELU ({err_tanh:.3e})"
+    )
 
 
 def test_aiter_fused_moe_determinism():

--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -962,6 +962,7 @@ def test_aiter_fused_moe_gelu_tanh_padded_matches_unpadded_reference(quant: str)
     garbage tail is live weight and must not."""
     from tests.kernels.moe.utils import make_test_weights
     from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
     from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
         ActivationMethod,
         QuantMethod,
@@ -977,7 +978,7 @@ def test_aiter_fused_moe_gelu_tanh_padded_matches_unpadded_reference(quant: str)
 
     hidden_dim, intermediate_dim = 512, 704
     _, intermediate_dim_padded = fp8_round_up_hidden_size_and_intermediate_size(
-        Fp8MoeBackend.AITER, hidden_dim, intermediate_dim
+        Fp8MoeBackend.AITER, hidden_dim, intermediate_dim, MoEActivation.GELU_TANH
     )
     assert intermediate_dim_padded == 768
     case = _make_moe_case(

--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -863,7 +863,7 @@ def test_aiter_fused_moe_gelu_tanh_accuracy():
 
     _assert_aiter_supported()
     case = _make_moe_case(
-        num_tokens=32,
+        num_tokens=128,
         hidden_dim=512,
         intermediate_dim=1024,
         num_experts=4,
@@ -896,10 +896,12 @@ def test_aiter_fused_moe_gelu_tanh_accuracy():
         atol=0.05,
         rtol=0.0,
     )
-    # The tolerance above cannot tell tanh-GELU from exact GELU on its own: make
-    # sure the kernel actually applied the tanh variant by checking it sits closer
-    # to the tanh reference than to the exact-GELU reference on inputs where the
-    # two references measurably differ.
+    # The budget above cannot tell tanh-GELU from exact GELU: the two references
+    # differ by ~1e-4 per element while the bf16 kernel's own noise is ~1e-3. So
+    # project the kernel's deviation from the exact-GELU reference onto the
+    # (tanh - exact) direction. The least-squares coefficient is ~1 when the
+    # kernel applied tanh-GELU and ~0 when it applied exact GELU; with this many
+    # output elements its noise is well under 0.1.
     ref_exact = ref_moe_forward(
         case["hidden_states"],
         case["w1"],
@@ -908,13 +910,14 @@ def test_aiter_fused_moe_gelu_tanh_accuracy():
         case["topk_ids"],
         activation="gelu",
     )
-    ref_gap = (ref_out - ref_exact).abs().mean().item()
-    assert ref_gap > 1e-4, f"references indistinguishable (gap={ref_gap:.2e})"
-    err_tanh = (out.float() - ref_out).abs().mean().item()
-    err_exact = (out.float() - ref_exact).abs().mean().item()
-    assert err_tanh < err_exact, (
-        f"kernel closer to exact GELU ({err_exact:.3e}) "
-        f"than to tanh GELU ({err_tanh:.3e})"
+    direction = (ref_out - ref_exact).flatten()
+    assert direction.norm() > 0, "references identical"
+    coeff = torch.dot((out.float() - ref_exact).flatten(), direction) / torch.dot(
+        direction, direction
+    )
+    assert coeff.item() > 0.5, (
+        f"kernel does not follow tanh-GELU (coefficient {coeff.item():.2f}; "
+        "1 = tanh-GELU, 0 = exact GELU)"
     )
 
 
@@ -1059,6 +1062,148 @@ def test_aiter_fused_moe_gelu_tanh_padded_matches_unpadded_reference(quant: str)
         assert max_diff > atol, (
             f"garbage tail did not affect the output ({max_diff:.3e})"
         )
+
+
+def _make_fp8_routed_experts(hidden_size: int, intermediate_size: int):
+    """A small fp8-serialized RoutedExperts layer built the way the model
+    loader builds one (quant method selection, size round-up, create_weights)."""
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig,
+        FusedMoEParallelConfig,
+        RoutingMethodType,
+    )
+    from vllm.model_executor.layers.fused_moe.expert_map_manager import (
+        ExpertMapManager,
+    )
+    from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+
+    num_experts, topk, max_num_tokens = 4, 2, 16
+    moe_config = FusedMoEConfig(
+        num_experts=num_experts,
+        experts_per_token=topk,
+        hidden_dim=hidden_size,
+        intermediate_size=intermediate_size,
+        num_local_experts=num_experts,
+        num_logical_experts=num_experts,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        activation=MoEActivation.GELU_TANH,
+        in_dtype=torch.bfloat16,
+        device="cuda",
+        routing_method=RoutingMethodType.TopK,
+        max_num_tokens=max_num_tokens,
+    )
+    expert_map_manager = ExpertMapManager(
+        max_num_batched_tokens=max_num_tokens,
+        top_k=topk,
+        global_num_experts=num_experts,
+        num_redundant_experts=0,
+        num_expert_group=None,
+        moe_parallel_config=moe_config.moe_parallel_config,
+        placement_strategy="linear",
+        enable_eplb=False,
+    )
+    return RoutedExperts(
+        "experts",
+        torch.bfloat16,
+        moe_config,
+        quant_config=Fp8Config(
+            is_checkpoint_fp8_serialized=True, activation_scheme="dynamic"
+        ),
+        expert_map_manager=expert_map_manager,
+    )
+
+
+@pytest.mark.skipif(
+    not (on_gfx942() or on_gfx950()),
+    reason="AITER fp8 MoE is gfx942/gfx950 only",
+)
+def test_fp8_moe_create_weights_zeroes_rounded_up_experts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """End to end through the layer: with the AITER fp8 backend, RoutedExperts
+    rounds a 704 intermediate size up to 768, Fp8MoEMethod.create_weights hands
+    the loader zeroed expert weights, and after loading a 704-wide checkpoint the
+    real rows sit where the kernel expects them while the padding is still zero."""
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+    from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+
+    _assert_aiter_supported()
+    hidden_size, intermediate_size, intermediate_size_padded = 512, 704, 768
+
+    with monkeypatch.context() as mp:
+        mp.setenv("VLLM_ROCM_USE_AITER", "1")
+        mp.setenv("VLLM_ROCM_USE_AITER_MOE", "1")
+        _reload_envs()
+        rocm_aiter_ops.refresh_env_variables()
+        # Parameters land on the default device, as when a model is built on GPU.
+        with torch.device("cuda"):
+            layer = _make_fp8_routed_experts(hidden_size, intermediate_size)
+
+    assert isinstance(layer.quant_method, Fp8MoEMethod)
+    assert layer.quant_method.fp8_backend == Fp8MoeBackend.AITER
+    moe_config = layer.moe_config
+    assert moe_config.intermediate_size_per_partition_unpadded == intermediate_size
+    assert moe_config.intermediate_size_per_partition == intermediate_size_padded
+    assert moe_config.hidden_dim == moe_config.hidden_dim_unpadded == hidden_size
+
+    num_experts = moe_config.num_local_experts
+    w13, w2 = layer.w13_weight, layer.w2_weight
+    assert w13.device.type == w2.device.type == "cuda"
+    assert w13.shape == (num_experts, 2 * intermediate_size_padded, hidden_size)
+    assert w2.shape == (num_experts, hidden_size, intermediate_size_padded)
+    # create_weights must hand the loader zeroed tensors (fp8 zero is bit pattern
+    # 0), since the loader only writes the checkpoint's rows/columns.
+    assert not w13.view(torch.uint8).any()
+    assert not w2.view(torch.uint8).any()
+
+    # Load a checkpoint with the unpadded size the way the model loader does.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(0)
+
+    def _rand_fp8(*shape: int) -> torch.Tensor:
+        return (torch.randn(*shape, generator=generator, device="cuda") / 4).to(
+            w13.dtype
+        )
+
+    checkpoint: dict[str, torch.Tensor] = {}
+    for expert_id in range(num_experts):
+        checkpoint[f"{expert_id}.gate_proj.weight"] = _rand_fp8(
+            intermediate_size, hidden_size
+        )
+        checkpoint[f"{expert_id}.up_proj.weight"] = _rand_fp8(
+            intermediate_size, hidden_size
+        )
+        checkpoint[f"{expert_id}.down_proj.weight"] = _rand_fp8(
+            hidden_size, intermediate_size
+        )
+    loaded = set(layer.load_weights(checkpoint.items()))
+    assert {"w13_weight", "w2_weight"} <= loaded
+
+    def _bits(t: torch.Tensor) -> torch.Tensor:
+        return t.view(torch.uint8)
+
+    up_rows = slice(
+        intermediate_size_padded, intermediate_size_padded + intermediate_size
+    )
+    for expert_id in range(num_experts):
+        gate = checkpoint[f"{expert_id}.gate_proj.weight"]
+        up = checkpoint[f"{expert_id}.up_proj.weight"]
+        down = checkpoint[f"{expert_id}.down_proj.weight"]
+        # gate rows at [0, 704), up rows at [768, 768 + 704): each half of w13 is
+        # padded on its own, which is where the kernel's N/2 split expects them.
+        assert torch.equal(_bits(w13[expert_id, :intermediate_size]), _bits(gate))
+        assert torch.equal(_bits(w13[expert_id, up_rows]), _bits(up))
+        assert not _bits(
+            w13[expert_id, intermediate_size:intermediate_size_padded]
+        ).any()
+        assert not _bits(
+            w13[expert_id, intermediate_size_padded + intermediate_size :]
+        ).any()
+        assert torch.equal(_bits(w2[expert_id, :, :intermediate_size]), _bits(down))
+        assert not _bits(w2[expert_id, :, intermediate_size:]).any()
 
 
 def test_aiter_fused_moe_determinism():

--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -918,6 +918,149 @@ def test_aiter_fused_moe_gelu_tanh_accuracy():
     )
 
 
+def _pad_intermediate_dim(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    intermediate_dim_padded: int,
+    *,
+    fill: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Lay out ``w1``/``w2`` with the intermediate dim rounded up to
+    ``intermediate_dim_padded`` the way the fp8 MoE methods allocate them, with
+    the checkpoint's rows/columns in place and the tail either zeroed or filled
+    with garbage (an uninitialized allocation)."""
+    num_experts, two_intermediate, hidden_dim = w1.shape
+    intermediate_dim = two_intermediate // 2
+    assert w2.shape == (num_experts, hidden_dim, intermediate_dim)
+    assert intermediate_dim_padded >= intermediate_dim
+
+    def _alloc(*shape: int) -> torch.Tensor:
+        if fill == "zeros":
+            return torch.zeros(*shape, dtype=w1.dtype, device=w1.device)
+        assert fill == "garbage"
+        return torch.randn(*shape, dtype=torch.float32, device=w1.device).to(w1.dtype)
+
+    # w13 stacks the gate rows above the up rows, so each half is padded on its own,
+    # matching where the loader places the checkpoint in the rounded-up parameter.
+    w1_padded = _alloc(num_experts, 2 * intermediate_dim_padded, hidden_dim)
+    w1_padded[:, :intermediate_dim] = w1[:, :intermediate_dim]
+    up_rows = slice(intermediate_dim_padded, intermediate_dim_padded + intermediate_dim)
+    w1_padded[:, up_rows] = w1[:, intermediate_dim:]
+    w2_padded = _alloc(num_experts, hidden_dim, intermediate_dim_padded)
+    w2_padded[:, :, :intermediate_dim] = w2
+    return w1_padded, w2_padded
+
+
+@pytest.mark.parametrize("quant", ["bf16", "fp8_per_tensor"])
+def test_aiter_fused_moe_gelu_tanh_padded_matches_unpadded_reference(quant: str):
+    """The fp8 MoE path rounds a non-128-aligned intermediate size up (704 -> 768
+    for Gemma4-26B-A4B) and allocates the padded expert weights zeroed. With a
+    zero tail, padding + gelu_tanh must reproduce the unpadded reference; a
+    garbage tail is live weight and must not."""
+    from tests.kernels.moe.utils import make_test_weights
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+        ActivationMethod,
+        QuantMethod,
+    )
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+        Fp8MoeBackend,
+        fp8_round_up_hidden_size_and_intermediate_size,
+    )
+
+    _assert_aiter_supported()
+    if quant == "fp8_per_tensor" and not (on_gfx942() or on_gfx950()):
+        pytest.skip("AITER fp8 MoE is gfx942/gfx950 only")
+
+    hidden_dim, intermediate_dim = 512, 704
+    _, intermediate_dim_padded = fp8_round_up_hidden_size_and_intermediate_size(
+        Fp8MoeBackend.AITER, hidden_dim, intermediate_dim
+    )
+    assert intermediate_dim_padded == 768
+    case = _make_moe_case(
+        num_tokens=32,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=4,
+        topk=2,
+        seed=7,
+    )
+    hidden_states = case["hidden_states"]
+    # Unpadded bf16 weights feed the reference; the kernel gets their padded
+    # (and, for fp8, quantized) layout.
+    w1_ref, w2_ref = case["w1"], case["w2"]
+    w1_kernel, w2_kernel = w1_ref, w2_ref
+    kernel_kwargs: dict[str, torch.Tensor] = {}
+    if quant == "bf16":
+        quant_method = QuantMethod.NO
+        atol, budget_kwargs = 0.05, {}
+    else:
+        hidden_states = hidden_states / 10
+        (w1_ref, w1_kernel, w1_scale, _), (w2_ref, w2_kernel, w2_scale, _) = (
+            make_test_weights(
+                case["w1"].shape[0],
+                intermediate_dim,
+                hidden_dim,
+                torch.bfloat16,
+                torch.float8_e4m3fn,
+                per_out_ch_quant=False,
+            )
+        )
+        _, a1_scale = rocm_aiter_ops.per_tensor_quant(
+            hidden_states, current_platform.fp8_dtype()
+        )
+        kernel_kwargs = dict(w1_scale=w1_scale, w2_scale=w2_scale, a1_scale=a1_scale)
+        quant_method = QuantMethod.PER_TENSOR
+        atol, budget_kwargs = 0.02, dict(pass_rate=1.0, max_violation_factor=1.5)
+
+    ref_out = ref_moe_forward(
+        hidden_states,
+        w1_ref,
+        w2_ref,
+        case["topk_weights"],
+        case["topk_ids"],
+        activation="gelu_tanh",
+    )
+
+    def _run_padded(fill: str) -> torch.Tensor:
+        w1_padded, w2_padded = _pad_intermediate_dim(
+            w1_kernel, w2_kernel, intermediate_dim_padded, fill=fill
+        )
+        w1_shuffled, w2_shuffled = _shuffle_moe_weights(w1_padded, w2_padded)
+        return torch.ops.vllm.rocm_aiter_fused_moe(
+            hidden_states,
+            w1_shuffled,
+            w2_shuffled,
+            case["topk_weights"],
+            case["topk_ids"],
+            expert_mask=None,
+            activation_method=int(ActivationMethod.GELU_TANH),
+            quant_method=int(quant_method),
+            doweight_stage1=False,
+            **kernel_kwargs,
+        ).float()
+
+    out = _run_padded("zeros")
+    assert out.shape == hidden_states.shape
+    _assert_close_budget(
+        out,
+        ref_out,
+        label=f"gelu_tanh_padded_zero_tail quant={quant}",
+        atol=atol,
+        rtol=0.0,
+        **budget_kwargs,
+    )
+
+    if quant == "bf16":
+        # The check above only means something if the tail is live weight: an
+        # uninitialized (garbage) tail must move the output well outside the budget.
+        out_garbage = _run_padded("garbage")
+        max_diff = (out_garbage - ref_out).abs().max().item()
+        assert max_diff > atol, (
+            f"garbage tail did not affect the output ({max_diff:.3e})"
+        )
+
+
 def test_aiter_fused_moe_determinism():
     """The BF16 fused-MoE kernel should stay bitwise deterministic for the
     same inputs."""

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+
 import torch
 from torch._ops import OpOverload
 
@@ -1907,6 +1908,18 @@ class rocm_aiter_ops:
         # _MOE_SITUV2_A8W4 is a variant of aiter fused moe, so aiter
         # fused moe must be enabled as well.
         return cls.is_fused_moe_enabled() and cls._MOE_SITUV2_A8W4
+
+    @staticmethod
+    @functools.lru_cache(maxsize=1)
+    def fused_moe_supports_gelu_tanh() -> bool:
+        """aiter >= v0.1.21 (ROCm/aiter#4620) exposes ActivationType.GeluTanh for the
+        CK 2-stage fused MoE; older releases have no such enum member and the FP8
+        tkw1 path would reject the wire value."""
+        try:
+            from aiter import ActivationType
+        except ImportError:
+            return False
+        return hasattr(ActivationType, "GeluTanh")
 
     @classmethod
     @if_aiter_supported

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -6,7 +6,6 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-
 import torch
 from torch._ops import OpOverload
 
@@ -1908,18 +1907,6 @@ class rocm_aiter_ops:
         # _MOE_SITUV2_A8W4 is a variant of aiter fused moe, so aiter
         # fused moe must be enabled as well.
         return cls.is_fused_moe_enabled() and cls._MOE_SITUV2_A8W4
-
-    @staticmethod
-    @functools.lru_cache(maxsize=1)
-    def fused_moe_supports_gelu_tanh() -> bool:
-        """aiter >= v0.1.21 (ROCm/aiter#4620) exposes ActivationType.GeluTanh for the
-        CK 2-stage fused MoE; older releases have no such enum member and the FP8
-        tkw1 path would reject the wire value."""
-        try:
-            from aiter import ActivationType
-        except ImportError:
-            return False
-        return hasattr(ActivationType, "GeluTanh")
 
     @classmethod
     @if_aiter_supported

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -55,6 +55,7 @@ class ActivationMethod(IntEnum):
     # without importing the ActivationType enum from AITER globally.
     SILU = 0
     GELU = 1
+    GELU_TANH = 4
 
 
 aiter_topK_meta_data: tuple[torch.Tensor, torch.Tensor] | None = None
@@ -262,6 +263,8 @@ def rocm_aiter_fused_experts(
         activation_method = ActivationMethod.SILU
     elif activation == MoEActivation.GELU:
         activation_method = ActivationMethod.GELU
+    elif activation == MoEActivation.GELU_TANH:
+        activation_method = ActivationMethod.GELU_TANH
     elif activation == MoEActivation.SWIGLUOAI:
         activation_method = rocm_aiter_ops.get_aiter_activation_type("swiglu")
     elif activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
@@ -491,6 +494,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         return activation in [
             MoEActivation.SILU,
             MoEActivation.GELU,
+            MoEActivation.GELU_TANH,
             MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -264,6 +264,8 @@ def rocm_aiter_fused_experts(
     elif activation == MoEActivation.GELU:
         activation_method = ActivationMethod.GELU
     elif activation == MoEActivation.GELU_TANH:
+        if not rocm_aiter_ops.fused_moe_supports_gelu_tanh():
+            raise ValueError("AITER GELU_TANH fused MoE needs aiter >= v0.1.21")
         activation_method = ActivationMethod.GELU_TANH
     elif activation == MoEActivation.SWIGLUOAI:
         activation_method = rocm_aiter_ops.get_aiter_activation_type("swiglu")
@@ -491,10 +493,13 @@ class AiterExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
+        if activation == MoEActivation.GELU_TANH:
+            # Needs aiter >= v0.1.21 (ActivationType.GeluTanh); otherwise fall back
+            # to the non-AITER experts instead of failing at dispatch time.
+            return rocm_aiter_ops.fused_moe_supports_gelu_tanh()
         return activation in [
             MoEActivation.SILU,
             MoEActivation.GELU,
-            MoEActivation.GELU_TANH,
             MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -55,7 +55,7 @@ class ActivationMethod(IntEnum):
     # without importing the ActivationType enum from AITER globally.
     SILU = 0
     GELU = 1
-    GELU_TANH = 4  # aiter >= v0.1.21 (ActivationType.GeluTanh)
+    GELU_TANH = 4
 
 
 aiter_topK_meta_data: tuple[torch.Tensor, torch.Tensor] | None = None

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -55,7 +55,7 @@ class ActivationMethod(IntEnum):
     # without importing the ActivationType enum from AITER globally.
     SILU = 0
     GELU = 1
-    GELU_TANH = 4
+    GELU_TANH = 4  # aiter >= v0.1.21 (ActivationType.GeluTanh)
 
 
 aiter_topK_meta_data: tuple[torch.Tensor, torch.Tensor] | None = None
@@ -264,8 +264,6 @@ def rocm_aiter_fused_experts(
     elif activation == MoEActivation.GELU:
         activation_method = ActivationMethod.GELU
     elif activation == MoEActivation.GELU_TANH:
-        if not rocm_aiter_ops.fused_moe_supports_gelu_tanh():
-            raise ValueError("AITER GELU_TANH fused MoE needs aiter >= v0.1.21")
         activation_method = ActivationMethod.GELU_TANH
     elif activation == MoEActivation.SWIGLUOAI:
         activation_method = rocm_aiter_ops.get_aiter_activation_type("swiglu")
@@ -493,13 +491,10 @@ class AiterExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        if activation == MoEActivation.GELU_TANH:
-            # Needs aiter >= v0.1.21 (ActivationType.GeluTanh); otherwise fall back
-            # to the non-AITER experts instead of failing at dispatch time.
-            return rocm_aiter_ops.fused_moe_supports_gelu_tanh()
         return activation in [
             MoEActivation.SILU,
             MoEActivation.GELU,
+            MoEActivation.GELU_TANH,
             MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -77,8 +77,11 @@ def fp8_round_up_hidden_size_and_intermediate_size(
     if backend == Fp8MoeBackend.AITER:
         # AITER's 2-stage CK fp8 MoE GEMM is numerically broken for intermediate
         # sizes that aren't 128-aligned (e.g. Gemma4-26B-A4B's 704;
-        # activation-independent). Align to 128; the padded tail is zeroed by the
-        # standard weight-loading narrow-and-copy path.
+        # activation-independent). Align to 128. NOTE: the loader only
+        # narrow-copies the checkpoint's real rows/columns into the padded
+        # parameters, so the expert weights must be allocated zeroed (see the
+        # fp8 MoE methods' create_weights); an uninitialized tail is live
+        # garbage weight for the kernel.
         intermediate_size = round_up(intermediate_size, 128)
     return hidden_size, intermediate_size
 

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -36,6 +36,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
 )
 from vllm.platforms import current_platform
+from vllm.utils.math_utils import round_up
 
 logger = init_logger(__name__)
 
@@ -65,6 +66,21 @@ class Fp8MoeBackend(Enum):
     TRITON_MXFP8 = "TRITON_MXFP8"
     # MXFP8 MoE via AITER (FlyDSL two-stage grouped GEMM) on gfx950.
     AITER_MXFP8 = "AITER_MXFP8"
+
+
+def fp8_round_up_hidden_size_and_intermediate_size(
+    backend: Fp8MoeBackend,
+    hidden_size: int,
+    intermediate_size: int,
+) -> tuple[int, int]:
+    """Round up hidden_size and intermediate_size based on backend requirements."""
+    if backend == Fp8MoeBackend.AITER:
+        # AITER's 2-stage CK fp8 MoE GEMM is numerically broken for intermediate
+        # sizes that aren't 128-aligned (e.g. Gemma4-26B-A4B's 704;
+        # activation-independent). Align to 128; the padded tail is zeroed by the
+        # standard weight-loading narrow-and-copy path.
+        intermediate_size = round_up(intermediate_size, 128)
+    return hidden_size, intermediate_size
 
 
 def _get_priority_backends(

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -77,11 +77,7 @@ def fp8_round_up_hidden_size_and_intermediate_size(
     if backend == Fp8MoeBackend.AITER:
         # AITER's 2-stage CK fp8 MoE GEMM is numerically broken for intermediate
         # sizes that aren't 128-aligned (e.g. Gemma4-26B-A4B's 704;
-        # activation-independent). Align to 128. NOTE: the loader only
-        # narrow-copies the checkpoint's real rows/columns into the padded
-        # parameters, so the expert weights must be allocated zeroed (see the
-        # fp8 MoE methods' create_weights); an uninitialized tail is live
-        # garbage weight for the kernel.
+        # activation-independent). Align to 128.
         intermediate_size = round_up(intermediate_size, 128)
     return hidden_size, intermediate_size
 

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -11,6 +11,7 @@ from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
     maybe_make_prepare_finalize,
 )
@@ -72,12 +73,15 @@ def fp8_round_up_hidden_size_and_intermediate_size(
     backend: Fp8MoeBackend,
     hidden_size: int,
     intermediate_size: int,
+    activation: MoEActivation,
 ) -> tuple[int, int]:
     """Round up hidden_size and intermediate_size based on backend requirements."""
-    if backend == Fp8MoeBackend.AITER:
-        # AITER's 2-stage CK fp8 MoE GEMM is numerically broken for intermediate
-        # sizes that aren't 128-aligned (e.g. Gemma4-26B-A4B's 704;
-        # activation-independent). Align to 128.
+    if backend == Fp8MoeBackend.AITER and activation == MoEActivation.GELU_TANH:
+        # AITER has no 1-stage fp8 MoE kernel for gelu_tanh, so it always lands on
+        # the CK 2-stage GEMM, which needs a 128-aligned intermediate size (e.g.
+        # Gemma4-26B-A4B's 704 -> 768). silu/gelu keep their size: AITER routes
+        # their non-128-aligned shapes to 1-stage kernels, so padding would only
+        # add work there.
         intermediate_size = round_up(intermediate_size, 128)
     return hidden_size, intermediate_size
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -11,6 +11,7 @@ from compressed_tensors.quantization import (
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
+    FusedMoEParallelConfig,
     FusedMoeWeightScaleSupported,
     RoutedExperts,
     SharedExperts,
@@ -21,6 +22,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     convert_to_fp8_moe_kernel_format,
+    fp8_round_up_hidden_size_and_intermediate_size,
     make_fp8_moe_kernel,
     make_fp8_moe_quant_config,
     select_fp8_moe_backend,
@@ -108,6 +110,23 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             weight_key=weight_key,
             activation_key=activation_key,
             allow_vllm_cutlass=True,
+        )
+
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            act_dtype=act_dtype,
+            moe_parallel_config=moe_parallel_config,
+        )
+        return fp8_round_up_hidden_size_and_intermediate_size(
+            self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -119,15 +119,21 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         act_dtype: torch.dtype,
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> tuple[int, int]:
+        original = (hidden_size, intermediate_size_per_partition)
         hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
             hidden_size=hidden_size,
             intermediate_size_per_partition=intermediate_size_per_partition,
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        return fp8_round_up_hidden_size_and_intermediate_size(
+        rounded = fp8_round_up_hidden_size_and_intermediate_size(
             self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
+        # The loader only narrow-copies the checkpoint into padded parameters, so
+        # padded expert weights (either dimension rounded up, by this method or by
+        # the base class) must be allocated zeroed; see create_weights.
+        self._pad_expert_weights = rounded != original
+        return rounded
 
     def create_weights(
         self,
@@ -172,8 +178,13 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
                 )
 
         # WEIGHTS
+        # Padded (rounded-up) expert weights must start zeroed: the loader only writes
+        # the checkpoint's real rows/columns and an uninitialized tail is live weight.
+        alloc = (
+            torch.zeros if getattr(self, "_pad_expert_weights", False) else torch.empty
+        )
         w13_weight = torch.nn.Parameter(
-            torch.zeros(
+            alloc(
                 num_experts,
                 w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
@@ -185,7 +196,7 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = torch.nn.Parameter(
-            torch.zeros(
+            alloc(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -173,7 +173,7 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
 
         # WEIGHTS
         w13_weight = torch.nn.Parameter(
-            torch.empty(
+            torch.zeros(
                 num_experts,
                 w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
@@ -185,7 +185,7 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = torch.nn.Parameter(
-            torch.empty(
+            torch.zeros(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -119,21 +119,15 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         act_dtype: torch.dtype,
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> tuple[int, int]:
-        original = (hidden_size, intermediate_size_per_partition)
         hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
             hidden_size=hidden_size,
             intermediate_size_per_partition=intermediate_size_per_partition,
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        rounded = fp8_round_up_hidden_size_and_intermediate_size(
+        return fp8_round_up_hidden_size_and_intermediate_size(
             self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
-        # The loader only narrow-copies the checkpoint into padded parameters, so
-        # padded expert weights (either dimension rounded up, by this method or by
-        # the base class) must be allocated zeroed; see create_weights.
-        self._pad_expert_weights = rounded != original
-        return rounded
 
     def create_weights(
         self,
@@ -178,11 +172,15 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
                 )
 
         # WEIGHTS
-        # Padded (rounded-up) expert weights must start zeroed: the loader only writes
-        # the checkpoint's real rows/columns and an uninitialized tail is live weight.
-        alloc = (
-            torch.zeros if getattr(self, "_pad_expert_weights", False) else torch.empty
+        # Rounded-up (padded) expert weights must start zeroed: the loader only writes
+        # the checkpoint's real rows/columns, and an uninitialized tail is live weight
+        # for the kernel.
+        is_padded = (
+            hidden_size != self.moe.hidden_dim_unpadded
+            or intermediate_size_per_partition
+            != self.moe.intermediate_size_per_partition_unpadded
         )
+        alloc = torch.zeros if is_padded else torch.empty
         w13_weight = torch.nn.Parameter(
             alloc(
                 num_experts,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -126,7 +126,10 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             moe_parallel_config=moe_parallel_config,
         )
         return fp8_round_up_hidden_size_and_intermediate_size(
-            self.fp8_backend, hidden_size, intermediate_size_per_partition
+            self.fp8_backend,
+            hidden_size,
+            intermediate_size_per_partition,
+            activation=self.moe.activation,
         )
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -604,7 +604,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         # WEIGHTS
         w13_weight = torch.nn.Parameter(
-            torch.empty(
+            torch.zeros(
                 num_experts,
                 self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
@@ -616,7 +616,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = torch.nn.Parameter(
-            torch.empty(
+            torch.zeros(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -542,15 +542,21 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         act_dtype: torch.dtype,
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> tuple[int, int]:
+        original = (hidden_size, intermediate_size_per_partition)
         hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
             hidden_size=hidden_size,
             intermediate_size_per_partition=intermediate_size_per_partition,
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        return fp8_round_up_hidden_size_and_intermediate_size(
+        rounded = fp8_round_up_hidden_size_and_intermediate_size(
             self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
+        # The loader only narrow-copies the checkpoint into padded parameters, so
+        # padded expert weights (either dimension rounded up, by this method or by
+        # the base class) must be allocated zeroed; see create_weights.
+        self._pad_expert_weights = rounded != original
+        return rounded
 
     def create_weights(
         self,
@@ -603,8 +609,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 block_n, block_k = moe_block_shape
 
         # WEIGHTS
+        # Padded (rounded-up) expert weights must start zeroed: the loader only writes
+        # the checkpoint's real rows/columns and an uninitialized tail is live weight.
+        alloc = (
+            torch.zeros if getattr(self, "_pad_expert_weights", False) else torch.empty
+        )
         w13_weight = torch.nn.Parameter(
-            torch.zeros(
+            alloc(
                 num_experts,
                 self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
@@ -616,7 +627,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = torch.nn.Parameter(
-            torch.zeros(
+            alloc(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -19,6 +19,7 @@ from vllm.model_executor.kernels.linear.scaled_mm import (
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEMethodBase,
+    FusedMoEParallelConfig,
     FusedMoeWeightScaleSupported,
     RoutedExperts,
     SharedExperts,
@@ -29,6 +30,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     convert_to_fp8_moe_kernel_format,
+    fp8_round_up_hidden_size_and_intermediate_size,
     make_fp8_moe_kernel,
     make_fp8_moe_quant_config,
     refine_fp8_moe_block_shape,
@@ -531,6 +533,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             weight_key=weight_key,
             activation_key=activation_key,
             allow_vllm_cutlass=False,
+        )
+
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            act_dtype=act_dtype,
+            moe_parallel_config=moe_parallel_config,
+        )
+        return fp8_round_up_hidden_size_and_intermediate_size(
+            self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -542,21 +542,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         act_dtype: torch.dtype,
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> tuple[int, int]:
-        original = (hidden_size, intermediate_size_per_partition)
         hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
             hidden_size=hidden_size,
             intermediate_size_per_partition=intermediate_size_per_partition,
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        rounded = fp8_round_up_hidden_size_and_intermediate_size(
+        return fp8_round_up_hidden_size_and_intermediate_size(
             self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
-        # The loader only narrow-copies the checkpoint into padded parameters, so
-        # padded expert weights (either dimension rounded up, by this method or by
-        # the base class) must be allocated zeroed; see create_weights.
-        self._pad_expert_weights = rounded != original
-        return rounded
 
     def create_weights(
         self,
@@ -609,11 +603,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 block_n, block_k = moe_block_shape
 
         # WEIGHTS
-        # Padded (rounded-up) expert weights must start zeroed: the loader only writes
-        # the checkpoint's real rows/columns and an uninitialized tail is live weight.
-        alloc = (
-            torch.zeros if getattr(self, "_pad_expert_weights", False) else torch.empty
+        # Rounded-up (padded) expert weights must start zeroed: the loader only writes
+        # the checkpoint's real rows/columns, and an uninitialized tail is live weight
+        # for the kernel.
+        is_padded = (
+            hidden_size != self.moe.hidden_dim_unpadded
+            or intermediate_size_per_partition
+            != self.moe.intermediate_size_per_partition_unpadded
         )
+        alloc = torch.zeros if is_padded else torch.empty
         w13_weight = torch.nn.Parameter(
             alloc(
                 num_experts,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -549,7 +549,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             moe_parallel_config=moe_parallel_config,
         )
         return fp8_round_up_hidden_size_and_intermediate_size(
-            self.fp8_backend, hidden_size, intermediate_size_per_partition
+            self.fp8_backend,
+            hidden_size,
+            intermediate_size_per_partition,
+            activation=self.moe.activation,
         )
 
     def create_weights(


### PR DESCRIPTION
## Purpose

Supersedes #53259 (draft; its two commits are carried here unchanged, authored by @simondanielsson, co-authored with @elliotz-ai) and adds the one thing that PR's round-up needs to be safe: **allocating the padded fp8 MoE expert weights zeroed.**

1. Add `gelu_tanh` to the AITER fp8 fused-MoE backend (Gemma4-style models), via `ActivationMethod.GELU_TANH = 4` from aiter v0.1.21 (ROCm/aiter#4620). **Depends on the AITER bump in #52826.**
2. AITER's 2-stage CK fp8 MoE GEMM is numerically broken for non-128-aligned intermediate sizes (Gemma4-26B-A4B: 704), so #53259 rounds the size up to 768 for the AITER backend. Its comment claims the padded tail is zeroed by the loader — it is not: `create_weights` allocates `w13_weight`/`w2_weight` with `torch.empty` and the loader only narrow-copies the checkpoint's real 704 rows/columns. Rows 704–767 of `w13` (gate/up) and columns 704–767 of `w2` keep whatever the caching allocator hands out — device memory freed earlier in the same process — and that is live weight for the kernel: non-zero pad activations after GELU pollute the per-token `a2` quant scale and leak through the `w2` tail into the layer output.

## How this shows up

Whether a given process gets harmful leftovers in the padding depends on the allocation order at load time, so most processes look fine and an occasional one produces sporadically implausible tokens (typo-like output) with no error or warning. A load-time probe of the padded region in fresh processes finds non-zero bytes there; deliberately filling one layer's padding with stale-weight-like bytes reproduces the symptom, and filling every layer collapses the model. Zero-allocating removes the effect.

The other users of `maybe_roundup_sizes` (mxfp4, quark nvfp4) already allocate with `torch.zeros`; this makes the fp8 methods do the same and corrects the comment. The memset is a one-time cost at load.

## Test Plan

- Unit tests from #53259 (`test_fp8_round_up_intermediate_size_for_aiter`, `test_activation_method_enum_values`, `test_aiter_fused_moe_gelu_tanh_accuracy`).
- Gemma4-26B-A4B compressed-tensors FP8 (per-channel weights, per-token activations) on MI325X with `VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1`: with zeroed allocation, sampled reply length and plausibility under the bf16 model match the non-AITER path; with `torch.empty` and garbage in the padding, the corruption reproduces.

## Test Result

ROCm-only; needs a runner with aiter ≥ v0.1.21 (after #52826).



**Tracking the AITER-side fix** (remove the manual padding requirement so the round-up here can go away): ROCm/aiter#5413
