### PR TITLE
[ROCm] AITER bpreshuffle blockscale GEMM

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -3216,6 +3216,36 @@ class rocm_aiter_ops:
         ]
 
     @staticmethod
+    @functools.cache
+    def is_bpreshuffle_blockscale_gemm_tuned(n: int, k: int) -> bool:
+        """Whether AITER's merged a8w8_blockscale_bpreshuffle tuned table has
+        rows for this (N, K) on the current GPU (gfx + CU count). Mirrors
+        is_triton_gemm_w8a8_tuned: untuned shapes would fall to the C++
+        default-heuristic instance, which can lose to the Triton path at small M,
+        so the b-preshuffle backend is only selected for covered shapes."""
+        try:
+            from aiter import AITER_CONFIGS
+            from aiter.jit.utils.chip_info import get_cu_num
+            from aiter.jit.utils.chip_info import get_gfx_runtime as get_gfx
+
+            csv_path = AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE
+            df = pd.read_csv(csv_path)
+            if "gfx" in df.columns:
+                df = df[df["gfx"] == get_gfx()]
+            if "cu_num" in df.columns:
+                df = df[df["cu_num"].astype(int) == int(get_cu_num())]
+            return bool(((df["N"].astype(int) == n) & (df["K"].astype(int) == k)).any())
+        except Exception as e:  # noqa: BLE001
+            logger.warning_once(
+                "Could not read the AITER bpreshuffle tuned table (%r); treating "
+                "(N=%d, K=%d) as untuned.",
+                e,
+                n,
+                k,
+            )
+            return False
+
+    @staticmethod
     def is_shuffled_per_token_w8a8_gemm_tuned(
         N: int, K: int, q_dtype_w: torch.dtype
     ) -> bool:
@@ -3240,6 +3270,26 @@ class rocm_aiter_ops:
         from aiter.ops.shuffle import shuffle_weight
 
         return shuffle_weight(tensor, layout=layout)
+
+    @staticmethod
+    def unshuffle_weight(
+        tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
+    ) -> torch.Tensor:
+        """Exact inverse of aiter.ops.shuffle.shuffle_weight for a 2-D [N, K]
+        weight (the layout the CK b-preshuffle GEMMs consume). Used by
+        consumers that need the plain row-major weight back (e.g. MLA weight
+        absorption dequantizing kv_b_proj) after a kernel preshuffled it in
+        place. Pure torch; a one-time copy."""
+        assert tensor.ndim == 2, "unshuffle_weight expects a 2-D [N, K] weight"
+        n, k = tensor.shape
+        in_lane, ik = layout
+        bk = ik * 2
+        k_lane = 16 // tensor.element_size()
+        assert n % in_lane == 0 and k % bk == 0, f"cannot unshuffle shape {tuple(tensor.shape)}"
+        # shuffle_weight: view(N//BN, BN, K//BK, BK//KL, KL).permute(0, 2, 3, 1, 4)
+        x = tensor.contiguous().view(n // in_lane, k // bk, bk // k_lane, in_lane, k_lane)
+        x = x.permute(0, 3, 1, 2, 4).contiguous()
+        return x.view(n, k)
 
     @staticmethod
     def shuffle_weight_a16w4(

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -884,7 +884,14 @@ def _rocm_aiter_gemm_a8w8_blockscale_bpreshuffle_impl(
 ) -> torch.Tensor:
     from aiter import gemm_a8w8_blockscale_bpreshuffle
 
-    # B preshuffled (shuffle_weight (16,16)); As column-major group scale.
+    # B preshuffled (shuffle_weight (16,16)). The kernel reads the activation
+    # group scales column-major; convert HERE, inside the op impl, so the
+    # layout survives torch.compile: a caller-side strided transpose is not
+    # guaranteed to reach a custom op intact (inductor may normalize inputs
+    # to contiguous, silently undoing it — observed as model-level numeric
+    # corruption). A contiguous tensor with column-major data is preserved.
+    m, g = As.shape
+    As = As.transpose(0, 1).contiguous().view(m, g)
     return gemm_a8w8_blockscale_bpreshuffle(A, B, As, Bs, dtype=output_dtype)
 
 

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -881,17 +881,19 @@ def _rocm_aiter_gemm_a8w8_blockscale_bpreshuffle_impl(
     As: torch.Tensor,
     Bs: torch.Tensor,
     output_dtype: torch.dtype = torch.float16,
+    scale_transposed: bool = False,
 ) -> torch.Tensor:
     from aiter import gemm_a8w8_blockscale_bpreshuffle
 
     # B preshuffled (shuffle_weight (16,16)). The kernel reads the activation
-    # group scales column-major; convert HERE, inside the op impl, so the
-    # layout survives torch.compile: a caller-side strided transpose is not
-    # guaranteed to reach a custom op intact (inductor may normalize inputs
-    # to contiguous, silently undoing it — observed as model-level numeric
-    # corruption). A contiguous tensor with column-major data is preserved.
-    m, g = As.shape
-    As = As.transpose(0, 1).contiguous().view(m, g)
+    # group scales column-major: shape [M, G], contiguous, holding the bytes of
+    # As.T (the same layout AITER's quant producers emit with
+    # transpose_scale=True). If the producer already emitted that layout the
+    # caller passes scale_transposed=True and As goes straight through;
+    # otherwise convert here, inside the op impl (torch.compile-safe).
+    if not scale_transposed:
+        m, g = As.shape
+        As = As.transpose(0, 1).contiguous().view(m, g)
     return gemm_a8w8_blockscale_bpreshuffle(A, B, As, Bs, dtype=output_dtype)
 
 
@@ -901,6 +903,7 @@ def _rocm_aiter_gemm_a8w8_blockscale_bpreshuffle_fake(
     As: torch.Tensor,
     Bs: torch.Tensor,
     output_dtype: torch.dtype = torch.float16,
+    scale_transposed: bool = False,
 ) -> torch.Tensor:
     m = A.shape[0]
     n = B.shape[0]
@@ -1023,6 +1026,7 @@ def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_impl(
     weight: torch.Tensor,
     epsilon: float,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused AllReduce + RMSNorm + per-group FP8 quant."""
     aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
@@ -1041,7 +1045,14 @@ def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_impl(
         use_1stage=use_1stage,
     )
     assert result is not None
-    return result[0], result[1], result[2]
+    out, res_out, scale = result[0], result[1], result[2]
+    if transpose_scale:
+        # The pinned AITER (v0.1.19) has no in-kernel transposed-scale mode for
+        # this launcher; emit the column-major-bytes layout here (one small
+        # copy per layer). Switch to the launcher's transpose_scale flag once
+        # the AITER pin includes it.
+        scale = scale.transpose(0, 1).contiguous().view(scale.shape)
+    return out, res_out, scale
 
 
 def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_fake(
@@ -1050,6 +1061,7 @@ def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_fake(
     weight: torch.Tensor,
     epsilon: float,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     hidden_dim = input_.shape[-1]
     num_groups = hidden_dim // group_size
@@ -1171,6 +1183,7 @@ def _rocm_aiter_rmsnorm_with_add_fp8_group_quant_impl(
     weight: torch.Tensor,
     variance_epsilon: float,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
 
@@ -1184,6 +1197,7 @@ def _rocm_aiter_rmsnorm_with_add_fp8_group_quant_impl(
         group_size=group_size,
         dtype_quant=FP8_DTYPE,
         res1=residual,
+        transpose_scale=transpose_scale,
     )
     return (
         x_quant,
@@ -1198,6 +1212,7 @@ def _rocm_aiter_rmsnorm_with_add_fp8_group_quant_fake(
     weight: torch.Tensor,
     variance_epsilon: float,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     M, N = x.shape
     scale_shape = (M, (N + group_size - 1) // group_size)
@@ -1213,6 +1228,7 @@ def _rocm_aiter_rmsnorm_fp8_group_quant_impl(
     weight: torch.Tensor,
     variance_epsilon: float,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
 
@@ -1226,6 +1242,7 @@ def _rocm_aiter_rmsnorm_fp8_group_quant_impl(
         group_size=group_size,
         dtype_quant=FP8_DTYPE,
         res1=None,
+        transpose_scale=transpose_scale,
     )
     return (x_quant, x_quant_scales)
 
@@ -1235,6 +1252,7 @@ def _rocm_aiter_rmsnorm_fp8_group_quant_fake(
     weight: torch.Tensor,
     variance_epsilon: float,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     M, N = x.shape
     scale_shape = (M, (N + group_size - 1) // group_size)
@@ -1323,20 +1341,27 @@ def _rocm_aiter_group_fp8_quant_fake(
 def _rocm_aiter_act_mul_and_fp8_group_quant_impl(
     x: torch.Tensor,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     from aiter.ops.triton.activation import act_mul_and_fp8_group_quant
 
-    return act_mul_and_fp8_group_quant(
+    out, scale = act_mul_and_fp8_group_quant(
         x,
         activation="silu",
         group_size=group_size,
         dtype_quant=FP8_DTYPE,
     )
+    if transpose_scale:
+        # aiter's act+quant kernel has no transposed-scale mode; emit the
+        # column-major-bytes layout here (dense-MLP layers only).
+        scale = scale.transpose(0, 1).contiguous().view(scale.shape)
+    return out, scale
 
 
 def _rocm_aiter_act_mul_and_fp8_group_quant_fake(
     x: torch.Tensor,
     group_size: int,
+    transpose_scale: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     M, N = x.shape
     assert N % 2 == 0
@@ -2576,9 +2601,10 @@ class rocm_aiter_ops:
         As: torch.Tensor,
         Bs: torch.Tensor,
         output_dtype: torch.dtype = torch.float16,
+        scale_transposed: bool = False,
     ) -> torch.Tensor:
         return torch.ops.vllm.rocm_aiter_gemm_a8w8_blockscale_bpreshuffle(
-            A, B, As, Bs, output_dtype
+            A, B, As, Bs, output_dtype, scale_transposed
         )
 
     @staticmethod

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -175,18 +175,33 @@ def is_aiter_found_and_supported_on_rdna4() -> bool:
 
 @functools.cache
 def _load_gemm_tuned_configs(
-    q_dtype_w: torch.dtype, csv_path: str
+    q_dtype_w: torch.dtype | None, csv_path: str, match_device: bool = False
 ) -> set[tuple[int, int, int]]:
     try:
         df = pd.read_csv(csv_path).drop_duplicates()
-        df = df[df["q_dtype_w"] == str(q_dtype_w)]
+        if q_dtype_w is not None and "q_dtype_w" in df.columns:
+            df = df[df["q_dtype_w"] == str(q_dtype_w)]
+        if match_device:
+            from aiter.jit.utils.chip_info import get_cu_num
+            from aiter.jit.utils.chip_info import get_gfx_runtime as get_gfx
+
+            if "gfx" in df.columns:
+                df = df[df["gfx"] == get_gfx()]
+            if "cu_num" in df.columns:
+                df = df[df["cu_num"].astype(int) == int(get_cu_num())]
         return set(zip(df["N"].astype(int), df["K"].astype(int), df["M"].astype(int)))
     except Exception:
         return set()
 
 
-def _check_kernel_tuned(N: int, K: int, q_dtype_w: torch.dtype, csv_path: str) -> bool:
-    configs = _load_gemm_tuned_configs(q_dtype_w, csv_path)
+def _check_kernel_tuned(
+    N: int,
+    K: int,
+    q_dtype_w: torch.dtype | None,
+    csv_path: str,
+    match_device: bool = False,
+) -> bool:
+    configs = _load_gemm_tuned_configs(q_dtype_w, csv_path, match_device)
     l_m = (
         [1, 2, 4]
         + list(range(8, 513, 8))
@@ -885,12 +900,7 @@ def _rocm_aiter_gemm_a8w8_blockscale_bpreshuffle_impl(
 ) -> torch.Tensor:
     from aiter import gemm_a8w8_blockscale_bpreshuffle
 
-    # B preshuffled (shuffle_weight (16,16)). The kernel reads the activation
-    # group scales column-major: shape [M, G], contiguous, holding the bytes of
-    # As.T (the same layout AITER's quant producers emit with
-    # transpose_scale=True). If the producer already emitted that layout the
-    # caller passes scale_transposed=True and As goes straight through;
-    # otherwise convert here, inside the op impl (torch.compile-safe).
+    # B preshuffled (shuffle_weight (16,16))
     if not scale_transposed:
         m, g = As.shape
         As = As.transpose(0, 1).contiguous().view(m, g)
@@ -1047,10 +1057,6 @@ def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_impl(
     assert result is not None
     out, res_out, scale = result[0], result[1], result[2]
     if transpose_scale:
-        # The pinned AITER (v0.1.19) has no in-kernel transposed-scale mode for
-        # this launcher; emit the column-major-bytes layout here (one small
-        # copy per layer). Switch to the launcher's transpose_scale flag once
-        # the AITER pin includes it.
         scale = scale.transpose(0, 1).contiguous().view(scale.shape)
     return out, res_out, scale
 
@@ -1352,8 +1358,6 @@ def _rocm_aiter_act_mul_and_fp8_group_quant_impl(
         dtype_quant=FP8_DTYPE,
     )
     if transpose_scale:
-        # aiter's act+quant kernel has no transposed-scale mode; emit the
-        # column-major-bytes layout here (dense-MLP layers only).
         scale = scale.transpose(0, 1).contiguous().view(scale.shape)
     return out, scale
 
@@ -3216,34 +3220,16 @@ class rocm_aiter_ops:
         ]
 
     @staticmethod
-    @functools.cache
     def is_bpreshuffle_blockscale_gemm_tuned(n: int, k: int) -> bool:
         """Whether AITER's merged a8w8_blockscale_bpreshuffle tuned table has
-        rows for this (N, K) on the current GPU (gfx + CU count). Mirrors
-        is_triton_gemm_w8a8_tuned: untuned shapes would fall to the C++
-        default-heuristic instance, which can lose to the Triton path at small M,
-        so the b-preshuffle backend is only selected for covered shapes."""
-        try:
-            from aiter import AITER_CONFIGS
-            from aiter.jit.utils.chip_info import get_cu_num
-            from aiter.jit.utils.chip_info import get_gfx_runtime as get_gfx
+        rows for this (N, K) on the current GPU. Mirrors is_triton_gemm_w8a8_tuned:
+        untuned shapes would fall to the C++ default-heuristic instance, which can
+        lose to the Triton path at small M, so the b-preshuffle backend is only
+        selected for covered shapes."""
+        from aiter import AITER_CONFIGS
 
-            csv_path = AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE
-            df = pd.read_csv(csv_path)
-            if "gfx" in df.columns:
-                df = df[df["gfx"] == get_gfx()]
-            if "cu_num" in df.columns:
-                df = df[df["cu_num"].astype(int) == int(get_cu_num())]
-            return bool(((df["N"].astype(int) == n) & (df["K"].astype(int) == k)).any())
-        except Exception as e:  # noqa: BLE001
-            logger.warning_once(
-                "Could not read the AITER bpreshuffle tuned table (%r); treating "
-                "(N=%d, K=%d) as untuned.",
-                e,
-                n,
-                k,
-            )
-            return False
+        csv_path = AITER_CONFIGS.AITER_CONFIG_GEMM_A8W8_BLOCKSCALE_BPRESHUFFLE_FILE
+        return _check_kernel_tuned(n, k, None, csv_path, match_device=True)
 
     @staticmethod
     def is_shuffled_per_token_w8a8_gemm_tuned(
@@ -3275,11 +3261,7 @@ class rocm_aiter_ops:
     def unshuffle_weight(
         tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
     ) -> torch.Tensor:
-        """Exact inverse of aiter.ops.shuffle.shuffle_weight for a 2-D [N, K]
-        weight (the layout the CK b-preshuffle GEMMs consume). Used by
-        consumers that need the plain row-major weight back (e.g. MLA weight
-        absorption dequantizing kv_b_proj) after a kernel preshuffled it in
-        place. Pure torch; a one-time copy."""
+        # May need the row-major weight back after a kernel preshuffled it in-place
         assert tensor.ndim == 2, "unshuffle_weight expects a 2-D [N, K] weight"
         n, k = tensor.shape
         in_lane, ik = layout

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1298,11 +1298,13 @@ class AiterAllreduceFusedRMSNormGroupQuantFP8Pattern(
         dtype: torch.dtype,
         device: str | None,
         group_size: int = 128,
+        transpose_scale: bool = False,
     ) -> None:
         super().__init__(dtype, device)
         self.epsilon = epsilon
         self.dtype = dtype
         self.group_size = group_size
+        self.transpose_scale = transpose_scale
         self.FUSED_AR_RMS_QUANT_OP = (
             rocm_aiter_ops.get_fused_allreduce_rmsnorm_quant_per_group_op()
         )
@@ -1314,6 +1316,7 @@ class AiterAllreduceFusedRMSNormGroupQuantFP8Pattern(
                 symmetric=True,
             ),
             match_rocm_aiter=True,
+            transpose_scale=transpose_scale,
         )
 
     def get_inputs(self) -> list[torch.Tensor]:
@@ -1345,6 +1348,7 @@ class AiterAllreduceFusedRMSNormGroupQuantFP8Pattern(
                 weight=weight.to(input.dtype),
                 epsilon=self.epsilon,
                 group_size=self.group_size,
+                transpose_scale=self.transpose_scale,
             )
             # quant_out, scale_out (residual is unused on the no-add path,
             # mirroring how AiterAllreduceFusedRMSNormPattern drops the
@@ -1370,11 +1374,13 @@ class AiterAllreduceFusedAddRMSNormGroupQuantFP8Pattern(
         dtype: torch.dtype,
         device: str | None,
         group_size: int = 128,
+        transpose_scale: bool = False,
     ) -> None:
         super().__init__(dtype, device)
         self.epsilon = epsilon
         self.dtype = dtype
         self.group_size = group_size
+        self.transpose_scale = transpose_scale
         self.FUSED_AR_RMS_QUANT_OP = (
             rocm_aiter_ops.get_fused_allreduce_rmsnorm_quant_per_group_op()
         )
@@ -1386,6 +1392,7 @@ class AiterAllreduceFusedAddRMSNormGroupQuantFP8Pattern(
                 symmetric=True,
             ),
             match_rocm_aiter=True,
+            transpose_scale=transpose_scale,
         )
 
     def get_inputs(self) -> list[torch.Tensor]:
@@ -1425,6 +1432,7 @@ class AiterAllreduceFusedAddRMSNormGroupQuantFP8Pattern(
                 weight=weight.to(input.dtype),
                 epsilon=self.epsilon,
                 group_size=self.group_size,
+                transpose_scale=self.transpose_scale,
             )
             # quant_out, scale_out, residual_out
             return result[0], result[2], result[1]
@@ -1635,6 +1643,24 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
                         epsilon,
                         self.model_dtype,
                         self.device,
+                    )
+                )
+                # Transposed-scale variants for layers feeding the CK
+                # b-preshuffle blockscale GEMM (quant with transpose_scale=True).
+                self.register(
+                    AiterAllreduceFusedRMSNormGroupQuantFP8Pattern(
+                        epsilon,
+                        self.model_dtype,
+                        self.device,
+                        transpose_scale=True,
+                    )
+                )
+                self.register(
+                    AiterAllreduceFusedAddRMSNormGroupQuantFP8Pattern(
+                        epsilon,
+                        self.model_dtype,
+                        self.device,
+                        transpose_scale=True,
                     )
                 )
 

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -313,6 +313,7 @@ class MatcherQuantFP8(MatcherCustomOp):
         is_e8m0: bool = False,
         match_rocm_aiter: bool = False,
         is_tma_aligned: bool = False,
+        transpose_scale: bool = False,
     ) -> None:
         if enabled is None:
             enabled = QuantFP8.enabled()
@@ -323,6 +324,7 @@ class MatcherQuantFP8(MatcherCustomOp):
         self.is_e8m0 = is_e8m0
         self.match_rocm_aiter = match_rocm_aiter
         self.is_tma_aligned = is_tma_aligned
+        self.transpose_scale = transpose_scale
 
         if match_rocm_aiter:
             assert not quant_key.scale.group_shape.is_per_tensor(), (
@@ -370,7 +372,9 @@ class MatcherQuantFP8(MatcherCustomOp):
                 scale=scale,
             )
         else:
-            return self.QUANT_OP(input, quant_key_group_shape.col)  # type: ignore[no-any-return]
+            return self.QUANT_OP(  # type: ignore[no-any-return]
+                input, quant_key_group_shape.col, self.transpose_scale
+            )
 
     def forward_custom(
         self,

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -46,15 +46,21 @@ FP8_DTYPE = current_platform.fp8_dtype()
 
 class AiterRMSNormQuantPattern:
     def __init__(
-        self, epsilon: float, key: FusedRMSQuantKey, match_aiter_quant: bool = True
+        self,
+        epsilon: float,
+        key: FusedRMSQuantKey,
+        match_aiter_quant: bool = True,
+        transpose_scale: bool = False,
     ):
         self.epsilon = epsilon
         self.quant_dtype = key.quant.dtype
         self.device = torch.device("cuda")
+        self.transpose_scale = transpose_scale
 
         self.quant_matcher = MatcherQuantFP8(
             key.quant,
             match_rocm_aiter=match_aiter_quant,
+            transpose_scale=transpose_scale,
         )
 
     def empty(self, *args: Any, **kwargs: Any) -> torch.Tensor:
@@ -194,6 +200,7 @@ class AiterRMSFp8GroupQuantPattern(AiterRMSNormQuantPattern):
         group_shape: GroupShape,
         match_aiter_quant: bool = True,
         symmetric: bool = True,
+        transpose_scale: bool = False,
     ) -> None:
         scale = ScaleDesc(torch.float32, False, group_shape)
         key = FusedRMSQuantKey(
@@ -201,7 +208,7 @@ class AiterRMSFp8GroupQuantPattern(AiterRMSNormQuantPattern):
             quant=QuantKey(dtype=quant_dtype, scale=scale, symmetric=symmetric),
         )
 
-        super().__init__(epsilon, key, match_aiter_quant)
+        super().__init__(epsilon, key, match_aiter_quant, transpose_scale)
 
     def register(self, pm_pass: PatternMatcherPass) -> None:
         def pattern(
@@ -221,6 +228,7 @@ class AiterRMSFp8GroupQuantPattern(AiterRMSNormQuantPattern):
                 weight=weight,
                 variance_epsilon=self.epsilon,
                 group_size=128,
+                transpose_scale=self.transpose_scale,
             )
 
             return at[0], at[1]
@@ -250,6 +258,7 @@ class AiterFusedAddRMSFp8GroupQuantPattern(AiterRMSNormQuantPattern):
         group_shape: GroupShape,
         match_aiter_quant: bool = True,
         symmetric: bool = True,
+        transpose_scale: bool = False,
     ) -> None:
         scale = ScaleDesc(torch.float32, False, group_shape)
         key = FusedRMSQuantKey(
@@ -257,7 +266,7 @@ class AiterFusedAddRMSFp8GroupQuantPattern(AiterRMSNormQuantPattern):
             quant=QuantKey(dtype=quant_dtype, scale=scale, symmetric=symmetric),
         )
 
-        super().__init__(epsilon, key, match_aiter_quant)
+        super().__init__(epsilon, key, match_aiter_quant, transpose_scale)
 
     def register(self, pm_pass: PatternMatcherPass) -> None:
         def pattern(
@@ -283,6 +292,7 @@ class AiterFusedAddRMSFp8GroupQuantPattern(AiterRMSNormQuantPattern):
                 weight=weight,
                 variance_epsilon=self.epsilon,
                 group_size=128,
+                transpose_scale=self.transpose_scale,
             )
 
             # result, scale, residual
@@ -612,6 +622,23 @@ class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
             AiterFusedAddRMSFp8GroupQuantPattern(
                 epsilon, FP8_DTYPE, GroupShape(1, 128), match_aiter_quant_op
             ).register(self.patterns)
+            # Transposed-scale variants: layers whose GEMM runs the CK
+            # b-preshuffle blockscale kernel quantize with transpose_scale=True
+            # (column-major scale bytes); keep the rms_norm(+add) fusion for them.
+            AiterRMSFp8GroupQuantPattern(
+                epsilon,
+                FP8_DTYPE,
+                GroupShape(1, 128),
+                match_aiter_quant_op,
+                transpose_scale=True,
+            ).register(self.patterns)
+            AiterFusedAddRMSFp8GroupQuantPattern(
+                epsilon,
+                FP8_DTYPE,
+                GroupShape(1, 128),
+                match_aiter_quant_op,
+                transpose_scale=True,
+            ).register(self.patterns)
 
             # When quant_fp8 custom ops are disabled, both AITER and native
             # quant matchers trace through QuantFP8's native implementation.
@@ -688,10 +715,15 @@ class AiterSiluMulFp8GroupQuantPattern(VllmPatternReplacement):
 
     FUSED_SILU_MUL_QUANT_OP = rocm_aiter_ops.get_act_mul_fused_fp8_group_quant_op()
 
-    def __init__(self, match_aiter_quant_op: bool = True) -> None:
+    def __init__(
+        self, match_aiter_quant_op: bool = True, transpose_scale: bool = False
+    ) -> None:
+        self.transpose_scale = transpose_scale
         self.silu_and_mul_matcher = MatcherSiluAndMul()
         self.quant_matcher = MatcherQuantFP8(
-            quant_key=kFp8Dynamic128Sym, match_rocm_aiter=match_aiter_quant_op
+            quant_key=kFp8Dynamic128Sym,
+            match_rocm_aiter=match_aiter_quant_op,
+            transpose_scale=transpose_scale,
         )
 
     def get_inputs(self) -> list[torch.Tensor]:
@@ -715,7 +747,9 @@ class AiterSiluMulFp8GroupQuantPattern(VllmPatternReplacement):
         def _replacement(
             input: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor]:
-            at = self.FUSED_SILU_MUL_QUANT_OP(x=input, group_size=128)
+            at = self.FUSED_SILU_MUL_QUANT_OP(
+                x=input, group_size=128, transpose_scale=self.transpose_scale
+            )
             return at[0], at[1]
 
         return _replacement
@@ -738,6 +772,11 @@ class RocmAiterSiluMulFp8GroupQuantFusionPass(VllmFusionPatternMatcherPass):
 
         self.register(
             AiterSiluMulFp8GroupQuantPattern(match_aiter_quant_op=match_aiter_quant_op)
+        )
+        self.register(
+            AiterSiluMulFp8GroupQuantPattern(
+                match_aiter_quant_op=match_aiter_quant_op, transpose_scale=True
+            )
         )
 
         self.dump_patterns(config, self.pm_pass)

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -622,9 +622,8 @@ class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
             AiterFusedAddRMSFp8GroupQuantPattern(
                 epsilon, FP8_DTYPE, GroupShape(1, 128), match_aiter_quant_op
             ).register(self.patterns)
-            # Transposed-scale variants: layers whose GEMM runs the CK
-            # b-preshuffle blockscale kernel quantize with transpose_scale=True
-            # (column-major scale bytes); keep the rms_norm(+add) fusion for them.
+            # Layers whose GEMM runs the CK b-preshuffle blockscale kernel
+            # quantize with transpose_scale=True
             AiterRMSFp8GroupQuantPattern(
                 epsilon,
                 FP8_DTYPE,

--- a/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
@@ -393,12 +393,28 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         # ~74% of the 8K-prefill compute gap vs ATOM. Env-gated while a
         # prototype; requires weights preshuffled at load (see
         # process_weights_after_loading below).
-        self.use_bpreshuffle = (
+        bpre_requested = (
             not current_platform.is_fp8_fnuz()
             and not _on_gfx1250
             and os.environ.get("VLLM_ROCM_USE_AITER_BPRESHUFFLE_BLOCKSCALE", "0")
             == "1"
         )
+        # Tuned-shape gate (same idea as is_triton_gemm_w8a8_tuned): only
+        # commit a layer to the preshuffled layout when AITER's bpreshuffle
+        # table covers its (N, K) on this GPU; otherwise keep the triton/CK
+        # path, whose own tables do cover it.
+        self.use_bpreshuffle = (
+            bpre_requested and rocm_aiter_ops.is_bpreshuffle_blockscale_gemm_tuned(n, k)
+        )
+        if bpre_requested and not self.use_bpreshuffle:
+            logger.info_once(
+                "AITER b-preshuffle blockscale GEMM requested but (N=%d, K=%d) has "
+                "no tuned rows for this GPU; using the %s path for this shape.",
+                n,
+                k,
+                "triton" if self.use_triton else "plain CK",
+                scope="global",
+            )
         # Set per-layer in process_weights_after_loading: True only once the
         # layer's weight has actually been preshuffled.
         self.bpre_shuffled = False
@@ -415,15 +431,12 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             replace_parameter(layer, attr, _upcast_e8m0_to_fp32(ws).contiguous())
 
         if self.use_bpreshuffle:
-            # kv_b_proj's weight has a second consumer: MLA weight absorption
-            # (attention layer process_weights_after_loading, which the model
-            # loader runs AFTER quant-method processing) dequantizes
-            # layer.weight raw via get_and_maybe_dequant_weights() to build
-            # the decode W_UK/W_UV tensors. Shuffling it would feed shuffled
-            # bytes into that dequant and silently corrupt every decode step,
-            # so leave it in the plain layout (triton/CK fallback in apply).
-            if "kv_b_proj" in getattr(layer, "prefix", ""):
-                return
+            # NOTE: consumers that need the plain row-major weight back (MLA
+            # weight absorption dequantizes kv_b_proj.weight after this runs)
+            # go through get_and_maybe_dequant_weights(), which undoes the
+            # shuffle via rocm_aiter_ops.unshuffle_weight when the layer's
+            # kernel reports bpre_shuffled. Every layer can therefore be
+            # shuffled here.
             # One-time (16,16) tile preshuffle into the layout the CK
             # b_preshuffle GEMM consumes; shape [N, K] is preserved.
             w = params.weight

--- a/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import os
+
 import torch
 
 from vllm import _custom_ops as ops
@@ -384,6 +386,23 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             rocm_aiter_ops.is_triton_gemm_w8a8_tuned(n, k) or _on_gfx1250
         )
 
+        # gfx950-dsr1-opt prototype: route dense blockscale GEMMs through the
+        # CK bpreshuffle backend (ATOM's path). Microbench on MI355X / AITER
+        # eb84cb022 shows it beats the triton path in 28/30 DSR1 shape/M
+        # configs (+20..55% typical, up to +144%); trace-level it accounts for
+        # ~74% of the 8K-prefill compute gap vs ATOM. Env-gated while a
+        # prototype; requires weights preshuffled at load (see
+        # process_weights_after_loading below).
+        self.use_bpreshuffle = (
+            not current_platform.is_fp8_fnuz()
+            and not _on_gfx1250
+            and os.environ.get("VLLM_ROCM_USE_AITER_BPRESHUFFLE_BLOCKSCALE", "0")
+            == "1"
+        )
+        # Set per-layer in process_weights_after_loading: True only once the
+        # layer's weight has actually been preshuffled.
+        self.bpre_shuffled = False
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
 
@@ -394,6 +413,29 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             ws, attr = params.weight_scale, params.WEIGHT_SCALE
         if ws is not None and ws.dtype == torch.float8_e8m0fnu:
             replace_parameter(layer, attr, _upcast_e8m0_to_fp32(ws).contiguous())
+
+        if self.use_bpreshuffle:
+            # kv_b_proj's weight has a second consumer: MLA weight absorption
+            # (attention layer process_weights_after_loading, which the model
+            # loader runs AFTER quant-method processing) dequantizes
+            # layer.weight raw via get_and_maybe_dequant_weights() to build
+            # the decode W_UK/W_UV tensors. Shuffling it would feed shuffled
+            # bytes into that dequant and silently corrupt every decode step,
+            # so leave it in the plain layout (triton/CK fallback in apply).
+            if "kv_b_proj" in getattr(layer, "prefix", ""):
+                return
+            # One-time (16,16) tile preshuffle into the layout the CK
+            # b_preshuffle GEMM consumes; shape [N, K] is preserved.
+            w = params.weight
+            replace_parameter(
+                layer,
+                FP8BlockParams.WEIGHT,
+                torch.nn.Parameter(
+                    rocm_aiter_ops.shuffle_weight(w.data.contiguous()),
+                    requires_grad=False,
+                ),
+            )
+            self.bpre_shuffled = True
 
     @classmethod
     def is_supported(cls, compute_capability=None):
@@ -449,6 +491,12 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             Bs = Bs.to(torch.float32)
 
         out_dtype = self.config.out_dtype
+        if self.bpre_shuffled:
+            # Row-major As; the custom-op impl converts to the kernel's
+            # column-major layout internally (torch.compile-safe).
+            return rocm_aiter_ops.gemm_a8w8_blockscale_bpreshuffle(
+                A, B, As, Bs, output_dtype=out_dtype
+            )
         if self.use_triton:
             gemm_a8w8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
         else:

--- a/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
@@ -386,37 +386,16 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             rocm_aiter_ops.is_triton_gemm_w8a8_tuned(n, k) or _on_gfx1250
         )
 
-        # gfx950-dsr1-opt prototype: route dense blockscale GEMMs through the
-        # CK bpreshuffle backend (ATOM's path). Microbench on MI355X / AITER
-        # eb84cb022 shows it beats the triton path in 28/30 DSR1 shape/M
-        # configs (+20..55% typical, up to +144%); trace-level it accounts for
-        # ~74% of the 8K-prefill compute gap vs ATOM. Env-gated while a
-        # prototype; requires weights preshuffled at load (see
-        # process_weights_after_loading below).
         bpre_requested = (
             not current_platform.is_fp8_fnuz()
             and not _on_gfx1250
             and os.environ.get("VLLM_ROCM_USE_AITER_BPRESHUFFLE_BLOCKSCALE", "0")
             == "1"
         )
-        # Tuned-shape gate (same idea as is_triton_gemm_w8a8_tuned): only
-        # commit a layer to the preshuffled layout when AITER's bpreshuffle
-        # table covers its (N, K) on this GPU; otherwise keep the triton/CK
-        # path, whose own tables do cover it.
         self.use_bpreshuffle = (
             bpre_requested and rocm_aiter_ops.is_bpreshuffle_blockscale_gemm_tuned(n, k)
         )
-        if bpre_requested and not self.use_bpreshuffle:
-            logger.info_once(
-                "AITER b-preshuffle blockscale GEMM requested but (N=%d, K=%d) has "
-                "no tuned rows for this GPU; using the %s path for this shape.",
-                n,
-                k,
-                "triton" if self.use_triton else "plain CK",
-                scope="global",
-            )
-        # Set per-layer in process_weights_after_loading: True only once the
-        # layer's weight has actually been preshuffled.
+        # Set per-layer in process_weights_after_loading
         self.bpre_shuffled = False
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -431,14 +410,6 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             replace_parameter(layer, attr, _upcast_e8m0_to_fp32(ws).contiguous())
 
         if self.use_bpreshuffle:
-            # NOTE: consumers that need the plain row-major weight back (MLA
-            # weight absorption dequantizes kv_b_proj.weight after this runs)
-            # go through get_and_maybe_dequant_weights(), which undoes the
-            # shuffle via rocm_aiter_ops.unshuffle_weight when the layer's
-            # kernel reports bpre_shuffled. Every layer can therefore be
-            # shuffled here.
-            # One-time (16,16) tile preshuffle into the layout the CK
-            # b_preshuffle GEMM consumes; shape [N, K] is preserved.
             w = params.weight
             replace_parameter(
                 layer,
@@ -449,10 +420,7 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
                 ),
             )
             self.bpre_shuffled = True
-            # Have this layer's activation-scale producer emit the kernel's
-            # column-major layout directly, so the GEMM op needs no transpose
-            # copy (the compile-time rms/allreduce/act quant fusions carry the
-            # flag through to the fused producer ops).
+            # Ensure scaler producer ops emit the column-major layout
             self.quant_fp8.transpose_scale = True
 
     @classmethod

--- a/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
@@ -436,6 +436,11 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
                 ),
             )
             self.bpre_shuffled = True
+            # Have this layer's activation-scale producer emit the kernel's
+            # column-major layout directly, so the GEMM op needs no transpose
+            # copy (the compile-time rms/allreduce/act quant fusions carry the
+            # flag through to the fused producer ops).
+            self.quant_fp8.transpose_scale = True
 
     @classmethod
     def is_supported(cls, compute_capability=None):
@@ -492,10 +497,16 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
 
         out_dtype = self.config.out_dtype
         if self.bpre_shuffled:
-            # Row-major As; the custom-op impl converts to the kernel's
-            # column-major layout internally (torch.compile-safe).
+            # transpose_scale: the producer already emitted As in the kernel's
+            # column-major layout (the dtype conversion above preserves element
+            # order); otherwise the op impl transposes.
             return rocm_aiter_ops.gemm_a8w8_blockscale_bpreshuffle(
-                A, B, As, Bs, output_dtype=out_dtype
+                A,
+                B,
+                As,
+                Bs,
+                output_dtype=out_dtype,
+                scale_transposed=self.quant_fp8.transpose_scale,
             )
         if self.use_triton:
             gemm_a8w8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -44,6 +44,7 @@ class QuantFP8(CustomOp):
         tma_aligned_scales: bool = False,
         use_ue8m0: bool | None = None,  # for Torch compile
         compile_native: bool = True,
+        transpose_scale: bool = False,
     ):
         """
         Args:
@@ -65,6 +66,9 @@ class QuantFP8(CustomOp):
         self.num_token_padding = num_token_padding
         self.column_major_scales = column_major_scales
         self.tma_aligned_scales = tma_aligned_scales
+        # Group quant only: emit scales in the column-major-bytes layout the CK
+        # b-preshuffle blockscale GEMM consumes (shape stays [M, G]).
+        self.transpose_scale = transpose_scale
         self.use_ue8m0 = is_deep_gemm_e8m0_used() if use_ue8m0 is None else use_ue8m0
         self.use_deep_gemm_supported = is_deep_gemm_supported()
 
@@ -150,14 +154,19 @@ class QuantFP8(CustomOp):
         use_aiter_per_group_quant = use_aiter_quant and self.group_shape.is_per_group()
 
         if use_aiter_per_group_quant:
-            return rocm_aiter_ops.group_fp8_quant(x, self.group_size)
+            return rocm_aiter_ops.group_fp8_quant(
+                x, self.group_size, self.transpose_scale
+            )
         if use_aiter_per_tensor_quant:
             return rocm_aiter_ops.per_tensor_quant(x, _FP8_DTYPE, scale)
         if use_aiter_per_token_quant:
             return rocm_aiter_ops.per_token_quant(x, _FP8_DTYPE, scale)
 
         # Fallback to CUDA implementation
-        return self.forward_cuda(x, scale, scale_ub)
+        q, s = self.forward_cuda(x, scale, scale_ub)
+        if self.transpose_scale and self.is_group_quant:
+            s = s.transpose(0, 1).contiguous().view(s.shape)
+        return q, s
 
     def forward_xpu(
         self,

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -66,8 +66,8 @@ class QuantFP8(CustomOp):
         self.num_token_padding = num_token_padding
         self.column_major_scales = column_major_scales
         self.tma_aligned_scales = tma_aligned_scales
-        # Group quant only: emit scales in the column-major-bytes layout the CK
-        # b-preshuffle blockscale GEMM consumes (shape stays [M, G]).
+        # Emit scales in the column-major-bytes layout the CK
+        # b-preshuffle blockscale GEMM consumes (group-quant)
         self.transpose_scale = transpose_scale
         self.use_ue8m0 = is_deep_gemm_e8m0_used() if use_ue8m0 is None else use_ue8m0
         self.use_deep_gemm_supported = is_deep_gemm_supported()

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -521,11 +521,8 @@ def get_and_maybe_dequant_weights(
 
     weight = get_attribute_fallback(layer, ["weight", "qweight", "weight_packed"])
 
-    # A ROCm AITER b-preshuffle blockscale kernel may have permuted the weight
-    # into the CK (16,16) tile layout at load time (shape unchanged, bytes
-    # permuted). Dequantizing that layout directly would silently produce
-    # garbage (observed as corrupt MLA W_UK/W_UV for kv_b_proj), so undo the
-    # shuffle first when the layer's kernel reports it.
+    # A ROCm AITER b-preshuffle blockscale kernel may have permuted the weight;
+    # need to unshuffle before dequantizing
     kernel = getattr(getattr(layer, "quant_method", None), "fp8_linear", None)
     if getattr(kernel, "bpre_shuffled", False):
         from vllm._aiter_ops import rocm_aiter_ops

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -521,6 +521,17 @@ def get_and_maybe_dequant_weights(
 
     weight = get_attribute_fallback(layer, ["weight", "qweight", "weight_packed"])
 
+    # A ROCm AITER b-preshuffle blockscale kernel may have permuted the weight
+    # into the CK (16,16) tile layout at load time (shape unchanged, bytes
+    # permuted). Dequantizing that layout directly would silently produce
+    # garbage (observed as corrupt MLA W_UK/W_UV for kv_b_proj), so undo the
+    # shuffle first when the layer's kernel reports it.
+    kernel = getattr(getattr(layer, "quant_method", None), "fp8_linear", None)
+    if getattr(kernel, "bpre_shuffled", False):
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        weight = rocm_aiter_ops.unshuffle_weight(weight)
+
     # Unquantized layer: just return base weights
     if layer.quant_method is None or isinstance(
         layer.quant_method, UnquantizedLinearMethod


### PR DESCRIPTION
## Purpose

On ROCm, vLLM's fp8 block-scale dense linears (DeepSeek-R1's `fused_qkv_a_proj`, `q_b_proj`,
`kv_b_proj`, `o_proj` and dense-MLP GEMMs) dispatch to AITER's Triton `gemm_a8w8_blockscale`
(or plain CK for untuned shapes). AITER also has a CK b-preshuffle block-scale GEMM where
weights are pre-permuted into the CK (16,16) tile layout at load and activation scales are column-major.

This PR adds that GEMM with env `VLLM_ROCM_USE_AITER_BPRESHUFFLE_BLOCKSCALE=1` (default off)

---

**Sample GEMM kernel time per layer** (from the profiled traces, same machine/image):

| step / layer | Main (Triton) | This PR (CK b-preshuffle) | Change |
|---|---|---|---|
| Decode, MoE layer | 56.75 µs | 49.67 µs | -12.5% |
| Decode, dense-FFN layer | 89.71 µs | 73.87 µs | -17.7% |
| Prefill (1k chunk), MoE layer | 222.84 µs | 101.20 µs | -54.6% |
| Prefill (1k chunk), dense-FFN layer | 369.80 µs | 204.59 µs | -44.7% |

Before:

<img width="523" height="324" alt="image" src="https://github.com/user-attachments/assets/439a1721-f6a5-43cb-a583-4f6406070727" />

After:

<img width="449" height="324" alt="image" src="https://github.com/user-attachments/assets/aa29fb9a-f34b-49cb-85b9-cb2a4db1272f" />


## Test Plan

- Benchmark: DeepSeek-R1-0528, TP8, ISL 1024, OSL 1024, 640 prompts at concurrency 64,
  greedy client (`vllm bench serve --temperature 0.0 --top-p 1.0`), fp8 KV cache,
  `VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
  VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`
- Accuracy: full GSM8K via lm_eval (local-completions, 5-shot, n=1319)

## Test Result

> [!NOTE]
> Tests executed on an 8×MI355X node against the `vllm/vllm-openai-rocm:nightly` image
> (stock torch 2.12 / amd-aiter 0.1.19 / triton 3.7.1), as an A/B against vLLM `main`
> (1f1f628859) on the same machine and container.

### Benchmark

Concurrency | Version | Output token throughput (tok/s) | Change | Median TTFT (ms) | Change | Mean TPOT (ms) | Change |
-- | -- | -- | -- | -- | -- | -- | -- |
64 | Main | 3041.14 | — | 906.53 | — | 20.17 | — |
64 | This PR | 3146.16 | 3.45% ↑ | 839.06 | 7.44% ↓ | 19.53 | 3.17% ↓ |

### Accuracy Test

Full GSM8K evaluation with the env enabled (1,319 examples):

|Tasks|Version|     Filter     |n-shot|  Metric |Value|Stderr|
|-----|------:|----------------|-----:|-----------|-----:|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|+0.9568| ±0.0056|
|     |       |strict-match    |     5|exact_match|+0.9560|±0.0056|

Baseline `main` on the same setup: 0.9522 / 0.9507.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
