### PR TITLE
[Parser][2/2] Record completed tool calls from ParserEngine

### DIFF
--- a/tests/parser/engine/test_completed_metrics.py
+++ b/tests/parser/engine/test_completed_metrics.py
@@ -50,9 +50,7 @@ _WEATHER_TOOL = ChatCompletionToolsParam(
 _HERMES_VALID = (
     '<tool_call>{"name": "get_weather", "arguments": {"city": "Dallas"}}</tool_call>'
 )
-_HERMES_INVALID_ARGS = (
-    '<tool_call>{"name": "get_weather", "arguments": {}}</tool_call>'
-)
+_HERMES_INVALID_ARGS = '<tool_call>{"name": "get_weather", "arguments": {}}</tool_call>'
 _HERMES_UNKNOWN = (
     '<tool_call>{"name": "not_a_tool", "arguments": {"city": "Dallas"}}</tool_call>'
 )
@@ -257,9 +255,7 @@ class TestParserEngineCompletedMetrics:
             request_type=RequestType.CHAT_COMPLETIONS.value,
             validation_outcome=ValidationOutcome.VALID.value,
         )
-        _, _, tool_calls = engine.parse(
-            _HERMES_UNKNOWN, _chat_request([_WEATHER_TOOL])
-        )
+        _, _, tool_calls = engine.parse(_HERMES_UNKNOWN, _chat_request([_WEATHER_TOOL]))
         assert tool_calls is None
         assert (
             _completed_value(

--- a/tests/parser/engine/test_completed_metrics.py
+++ b/tests/parser/engine/test_completed_metrics.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ParserEngine recording of vllm:tool_calls_completed_total."""
+
+from __future__ import annotations
+
+import pytest
+from prometheus_client import REGISTRY
+
+from tests.parser.engine.conftest import make_mock_tokenizer
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
+from vllm.entrypoints.openai.engine.protocol import FunctionDefinition
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.parser.engine.events import EventType, SemanticEvent
+from vllm.parser.engine.parser_engine import ParserEngine
+from vllm.parser.engine.parser_engine_config import (
+    ParserEngineConfig,
+    ParserState,
+    Transition,
+)
+from vllm.parser.kimi_k2 import KimiK2Parser
+from vllm.parser.metrics import (
+    RequestType,
+    ValidationOutcome,
+    init_parser_metrics,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+_VOCAB: dict[str, int] = {
+    "<tool_call>": 202,
+    "</tool_call>": 203,
+}
+
+_WEATHER_PARAMS = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}},
+    "required": ["city"],
+    "additionalProperties": False,
+}
+
+_WEATHER_TOOL = ChatCompletionToolsParam(
+    type="function",
+    function=FunctionDefinition(name="get_weather", parameters=_WEATHER_PARAMS),
+)
+
+_HERMES_VALID = (
+    '<tool_call>{"name": "get_weather", "arguments": {"city": "Dallas"}}</tool_call>'
+)
+_HERMES_INVALID_ARGS = (
+    '<tool_call>{"name": "get_weather", "arguments": {}}</tool_call>'
+)
+_HERMES_UNKNOWN = (
+    '<tool_call>{"name": "not_a_tool", "arguments": {"city": "Dallas"}}</tool_call>'
+)
+_HERMES_BAD_JSON = '<tool_call>{"name": "get_weather", "arguments": {</tool_call>'
+
+
+def _hermes_config(**kwargs) -> ParserEngineConfig:
+    return ParserEngineConfig(
+        name="hermes_completed_metrics",
+        terminals={
+            "TOOL_START": "<tool_call>",
+            "TOOL_END": "</tool_call>",
+        },
+        token_id_terminals={
+            "TOOL_START": "<tool_call>",
+            "TOOL_END": "</tool_call>",
+        },
+        transitions={
+            (ParserState.CONTENT, "TOOL_START"): Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
+            ),
+        },
+        content_events={
+            ParserState.CONTENT: EventType.TEXT_CHUNK,
+            ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
+        },
+        **kwargs,
+    )
+
+
+def _make_engine(
+    *,
+    tools: list | None = None,
+    validate_tool_names: bool = False,
+) -> ParserEngine:
+    return ParserEngine(
+        make_mock_tokenizer(_VOCAB),
+        tools=tools,
+        parser_engine_config=_hermes_config(validate_tool_names=validate_tool_names),
+    )
+
+
+def _chat_request(tools: list | None = None) -> ChatCompletionRequest:
+    body: dict = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    if tools is not None:
+        body["tools"] = tools
+    return ChatCompletionRequest.model_validate(body)
+
+
+def _responses_request() -> ResponsesRequest:
+    return ResponsesRequest(input="hi", tools=[])
+
+
+def _completed_value(
+    *,
+    model_name: str,
+    request_type: str,
+    validation_outcome: str,
+) -> float:
+    for metric in REGISTRY.collect():
+        for sample in metric.samples:
+            if (
+                sample.name == "vllm:tool_calls_completed_total"
+                and sample.labels.get("model_name") == model_name
+                and sample.labels.get("request_type") == request_type
+                and sample.labels.get("validation_outcome") == validation_outcome
+            ):
+                return sample.value
+    raise AssertionError(
+        f"missing series model_name={model_name} "
+        f"request_type={request_type} validation_outcome={validation_outcome}"
+    )
+
+
+def _init(model_name: str) -> None:
+    init_parser_metrics(model_name=model_name)
+
+
+class TestParserEngineCompletedMetrics:
+    def test_parse_valid_chat_completions(self):
+        model = "pe-completed-valid-chat"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        _, _, tool_calls = engine.parse(_HERMES_VALID, _chat_request([_WEATHER_TOOL]))
+        assert tool_calls is not None
+        assert tool_calls[0].name == "get_weather"
+        assert '"city": "Dallas"' in tool_calls[0].arguments
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == before + 1
+
+    def test_parse_delta_uses_same_counter_as_parse(self):
+        model = "pe-completed-stream-share"
+        _init(model)
+        request = _chat_request([_WEATHER_TOOL])
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        engine.initialize_streaming()
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        engine.parse_delta(_HERMES_VALID, [], request, finished=True)
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == before + 1
+
+    def test_responses_request_type(self):
+        model = "pe-completed-responses"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.RESPONSES.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        engine.parse(_HERMES_VALID, _responses_request())
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.RESPONSES.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == before + 1
+
+    def test_unknown_tool_when_name_not_in_catalog(self):
+        model = "pe-completed-unknown"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.UNKNOWN_TOOL.value,
+        )
+        engine.parse(_HERMES_UNKNOWN, _chat_request([_WEATHER_TOOL]))
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.UNKNOWN_TOOL.value,
+        )
+        assert after == before + 1
+
+    def test_invalid_args_when_schema_fails(self):
+        model = "pe-completed-invalid-args"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.INVALID_ARGS.value,
+        )
+        engine.parse(_HERMES_INVALID_ARGS, _chat_request([_WEATHER_TOOL]))
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.INVALID_ARGS.value,
+        )
+        assert after == before + 1
+
+    def test_classifies_client_pair_not_raw_slot_args(self):
+        """Raw Hermes envelope would fail additionalProperties=False."""
+        model = "pe-completed-client-pair"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        _, _, tool_calls = engine.parse(_HERMES_VALID, _chat_request([_WEATHER_TOOL]))
+        assert tool_calls is not None
+        slot = engine._tool_slots[0]
+        assert slot.completed is True
+        assert slot.function_call == (tool_calls[0].name, tool_calls[0].arguments)
+        assert slot.args != tool_calls[0].arguments
+        assert "get_weather" in slot.args
+
+    def test_rejected_name_is_not_a_completed_call(self):
+        model = "pe-completed-rejected"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL], validate_tool_names=True)
+        before_unknown = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.UNKNOWN_TOOL.value,
+        )
+        before_valid = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        _, _, tool_calls = engine.parse(
+            _HERMES_UNKNOWN, _chat_request([_WEATHER_TOOL])
+        )
+        assert tool_calls is None
+        assert (
+            _completed_value(
+                model_name=model,
+                request_type=RequestType.CHAT_COMPLETIONS.value,
+                validation_outcome=ValidationOutcome.UNKNOWN_TOOL.value,
+            )
+            == before_unknown
+        )
+        assert (
+            _completed_value(
+                model_name=model,
+                request_type=RequestType.CHAT_COMPLETIONS.value,
+                validation_outcome=ValidationOutcome.VALID.value,
+            )
+            == before_valid
+        )
+
+    def test_content_only_does_not_increment(self):
+        model = "pe-completed-content-only"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        engine.parse("Hello world", _chat_request([_WEATHER_TOOL]))
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == before
+
+    def test_handle_tool_end_is_idempotent(self):
+        model = "pe-completed-idempotent"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        engine.parse(_HERMES_VALID, _chat_request([_WEATHER_TOOL]))
+        mid = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        engine._handle_tool_end(
+            SemanticEvent(EventType.TOOL_CALL_END, tool_index=0),
+            [],
+        )
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == mid
+
+    def test_bad_json_args_are_invalid_args(self):
+        model = "pe-completed-bad-json"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.INVALID_ARGS.value,
+        )
+        engine.parse(_HERMES_BAD_JSON, _chat_request([_WEATHER_TOOL]))
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.INVALID_ARGS.value,
+        )
+        assert after == before + 1
+
+    def test_extract_tool_calls_from_content_records_chat_type(self):
+        model = "pe-completed-from-content"
+        _init(model)
+        engine = _make_engine(tools=[_WEATHER_TOOL])
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        result = engine.extract_tool_calls_from_content(
+            _HERMES_VALID, _chat_request([_WEATHER_TOOL])
+        )
+        assert result.tools_called is True
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == before + 1
+
+
+class TestKimiDoubleToolCallEnd:
+    """Kimi stays in TOOL_PREAMBLE after a well-formed call; finish() emits
+    TOOL_CALL_END again. Recording must stay at one increment.
+    """
+
+    def test_records_once_on_kimi_section_close(self):
+        model = "pe-completed-kimi-double-end"
+        _init(model)
+        vocab = {
+            "<think>": 1,
+            "</think>": 2,
+            "<|tool_calls_section_begin|>": 3,
+            "<|tool_calls_section_end|>": 4,
+            "<|tool_call_begin|>": 5,
+            "<|tool_call_end|>": 6,
+            "<|tool_call_argument_begin|>": 7,
+        }
+        parser = KimiK2Parser(
+            make_mock_tokenizer(vocab),
+            tools=[_WEATHER_TOOL],
+            chat_template_kwargs={"thinking": False},
+        )
+        text = (
+            "<|tool_calls_section_begin|>"
+            "<|tool_call_begin|>functions.get_weather:0"
+            '<|tool_call_argument_begin|>{"city": "Dallas"}'
+            "<|tool_call_end|>"
+            "<|tool_calls_section_end|>"
+        )
+        before = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        _, _, tool_calls = parser.parse(text, _chat_request([_WEATHER_TOOL]))
+        assert tool_calls is not None
+        assert tool_calls[0].name == "get_weather"
+        after = _completed_value(
+            model_name=model,
+            request_type=RequestType.CHAT_COMPLETIONS.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == before + 1
+        assert parser._tool_slots[0].completed is True

--- a/tests/parser/test_metrics.py
+++ b/tests/parser/test_metrics.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for parser Prometheus metrics (completed tool-call counter)."""
+
+from __future__ import annotations
+
+import pytest
+from openai.types.responses import FunctionTool
+from prometheus_client import REGISTRY
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
+from vllm.entrypoints.openai.engine.protocol import FunctionDefinition
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.parser.metrics import (
+    RequestType,
+    ValidationOutcome,
+    classify_completed_tool_call,
+    init_parser_metrics,
+    record_tool_call_completed,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+_WEATHER_PARAMS = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}},
+    "required": ["city"],
+    "additionalProperties": False,
+}
+
+FUNCTION_TOOL = FunctionTool(
+    type="function",
+    name="get_weather",
+    parameters=_WEATHER_PARAMS,
+)
+
+CHAT_TOOL = ChatCompletionToolsParam(
+    type="function",
+    function=FunctionDefinition(name="get_weather", parameters=_WEATHER_PARAMS),
+)
+
+NO_PARAMS_TOOL = ChatCompletionToolsParam(
+    type="function",
+    function=FunctionDefinition(name="no_params", parameters=None),
+)
+
+_MODEL_NAME = "test-completed-tool-calls"
+_ZERO_MODEL_NAME = "test-completed-tool-calls-zeros"
+
+
+def _chat_request() -> ChatCompletionRequest:
+    return ChatCompletionRequest.model_validate(
+        {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]}
+    )
+
+
+def _responses_request() -> ResponsesRequest:
+    return ResponsesRequest(input="hi")
+
+
+def _completed_samples(*, model_name: str):
+    for metric in REGISTRY.collect():
+        for sample in metric.samples:
+            if (
+                sample.name == "vllm:tool_calls_completed_total"
+                and sample.labels.get("model_name") == model_name
+            ):
+                yield sample
+
+
+def _completed_value(
+    *,
+    model_name: str,
+    request_type: str,
+    validation_outcome: str,
+) -> float:
+    for sample in _completed_samples(model_name=model_name):
+        if (
+            sample.labels.get("request_type") == request_type
+            and sample.labels.get("validation_outcome") == validation_outcome
+        ):
+            return sample.value
+    raise AssertionError(
+        f"missing series model_name={model_name} "
+        f"request_type={request_type} validation_outcome={validation_outcome}"
+    )
+
+
+class TestClassifyCompletedToolCall:
+    @pytest.mark.parametrize("tools", [[FUNCTION_TOOL], [CHAT_TOOL]])
+    def test_valid_args(self, tools):
+        outcome = classify_completed_tool_call(
+            "get_weather",
+            '{"city": "Dallas"}',
+            tools,
+        )
+        assert outcome is ValidationOutcome.VALID
+
+    def test_unknown_tool_name(self):
+        outcome = classify_completed_tool_call(
+            "not_a_tool",
+            '{"city": "Dallas"}',
+            [FUNCTION_TOOL],
+        )
+        assert outcome is ValidationOutcome.UNKNOWN_TOOL
+
+    @pytest.mark.parametrize("tools", [None, []])
+    def test_unknown_tool_when_catalog_missing(self, tools):
+        outcome = classify_completed_tool_call(
+            "get_weather",
+            '{"city": "Dallas"}',
+            tools,
+        )
+        assert outcome is ValidationOutcome.UNKNOWN_TOOL
+
+    def test_unknown_tool_wins_over_invalid_json(self):
+        outcome = classify_completed_tool_call(
+            "not_a_tool",
+            "{not-json",
+            [FUNCTION_TOOL],
+        )
+        assert outcome is ValidationOutcome.UNKNOWN_TOOL
+
+    def test_invalid_json_args(self):
+        outcome = classify_completed_tool_call(
+            "get_weather",
+            "{not-json",
+            [FUNCTION_TOOL],
+        )
+        assert outcome is ValidationOutcome.INVALID_ARGS
+
+    def test_schema_invalid_args(self):
+        outcome = classify_completed_tool_call(
+            "get_weather",
+            "{}",
+            [FUNCTION_TOOL],
+        )
+        assert outcome is ValidationOutcome.INVALID_ARGS
+
+    def test_missing_parameters_defaults_to_empty_object_schema(self):
+        valid = classify_completed_tool_call("no_params", "{}", [NO_PARAMS_TOOL])
+        assert valid is ValidationOutcome.VALID
+
+        extra = classify_completed_tool_call(
+            "no_params",
+            '{"x": 1}',
+            [NO_PARAMS_TOOL],
+        )
+        assert extra is ValidationOutcome.VALID
+
+        not_object = classify_completed_tool_call(
+            "no_params",
+            "[]",
+            [NO_PARAMS_TOOL],
+        )
+        assert not_object is ValidationOutcome.INVALID_ARGS
+
+    def test_invalid_schema_maps_to_invalid_args(self):
+        bad_schema_tool = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="bad_schema",
+                parameters={"type": "not-a-json-schema-type"},
+            ),
+        )
+        outcome = classify_completed_tool_call(
+            "bad_schema",
+            "{}",
+            [bad_schema_tool],
+        )
+        assert outcome is ValidationOutcome.INVALID_ARGS
+
+    def test_surprises_map_to_invalid_args(self):
+        outcome = classify_completed_tool_call("get_weather", "{}", 123)
+        assert outcome is ValidationOutcome.INVALID_ARGS
+
+    def test_never_raises(self):
+        outcome = classify_completed_tool_call("x", None, object())  # type: ignore[arg-type]
+        assert outcome is ValidationOutcome.INVALID_ARGS
+
+
+class TestRecordToolCallCompleted:
+    def test_pre_registers_zero_series(self):
+        init_parser_metrics(model_name=_ZERO_MODEL_NAME)
+        samples = list(_completed_samples(model_name=_ZERO_MODEL_NAME))
+        combos = {
+            (sample.labels["request_type"], sample.labels["validation_outcome"])
+            for sample in samples
+        }
+        expected = {
+            (request_type.value, outcome.value)
+            for request_type in RequestType
+            for outcome in ValidationOutcome
+        }
+        assert combos == expected
+        assert all(sample.value == 0 for sample in samples)
+
+    @pytest.mark.parametrize(
+        ("api_request", "request_type"),
+        [
+            (_chat_request(), RequestType.CHAT_COMPLETIONS),
+            (_responses_request(), RequestType.RESPONSES),
+            (object(), RequestType.OTHER),
+        ],
+    )
+    def test_increments_matching_labels(self, api_request, request_type):
+        init_parser_metrics(model_name=_MODEL_NAME)
+        before = _completed_value(
+            model_name=_MODEL_NAME,
+            request_type=request_type.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        record_tool_call_completed(
+            request=api_request,
+            outcome=ValidationOutcome.VALID,
+        )
+        after = _completed_value(
+            model_name=_MODEL_NAME,
+            request_type=request_type.value,
+            validation_outcome=ValidationOutcome.VALID.value,
+        )
+        assert after == before + 1
+
+    def test_noop_when_unregistered(self, monkeypatch):
+        import vllm.parser.metrics as metrics
+
+        monkeypatch.setattr(metrics, "_tool_calls_completed", None)
+        record_tool_call_completed(
+            request=_chat_request(),
+            outcome=ValidationOutcome.VALID,
+        )

--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -11,8 +11,10 @@ from pydantic import TypeAdapter
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
 )
+from vllm.entrypoints.openai.engine.protocol import FunctionDefinition
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
 from vllm.tool_parsers.utils import (
+    find_tool_parameters,
     find_tool_properties,
     get_json_schema_from_tools,
 )
@@ -394,3 +396,51 @@ class TestNonFunctionToolsSkipped:
         any_of = schema["items"]["anyOf"]
         assert len(any_of) == 1
         assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+
+    def test_find_tool_parameters_skips_web_search(self):
+        tools = [WEB_SEARCH_TOOL, FUNCTION_TOOL]
+        params = find_tool_parameters(tools, "get_weather")
+        assert params == FUNCTION_TOOL.parameters
+
+    def test_find_tool_parameters_only_non_function_tools(self):
+        params = find_tool_parameters([WEB_SEARCH_TOOL], "get_weather")
+        assert params is None
+
+
+class TestFindToolParameters:
+    """find_tool_parameters returns the full parameters object, or None."""
+
+    def test_returns_full_parameters_for_function_tool(self):
+        params = find_tool_parameters([FUNCTION_TOOL], "get_weather")
+        assert params == FUNCTION_TOOL.parameters
+        assert "required" in params
+        assert "properties" in params
+
+    def test_returns_full_parameters_for_chat_tool(self):
+        chat_tool = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="get_weather",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            ),
+        )
+        params = find_tool_parameters([chat_tool], "get_weather")
+        assert params == chat_tool.function.parameters
+
+    def test_returns_none_when_tools_empty_or_missing(self):
+        assert find_tool_parameters(None, "get_weather") is None
+        assert find_tool_parameters([], "get_weather") is None
+
+    def test_returns_none_when_name_absent(self):
+        assert find_tool_parameters([FUNCTION_TOOL], "unknown") is None
+
+    def test_returns_none_when_parameters_is_none(self):
+        chat_tool = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(name="no_params", parameters=None),
+        )
+        assert find_tool_parameters([chat_tool], "no_params") is None

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -24,13 +24,13 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.logger import init_logger
 from vllm.parser.abstract_parser import Parser, StreamState
+from vllm.parser.engine.events import EventType, SemanticEvent
+from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
+from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
 from vllm.parser.metrics import (
     classify_completed_tool_call,
     record_tool_call_completed,
 )
-from vllm.parser.engine.events import EventType, SemanticEvent
-from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
-from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
 from vllm.tool_parsers.utils import (
     coerce_to_schema_type,
     extract_types_from_schema,

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -24,6 +24,10 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.logger import init_logger
 from vllm.parser.abstract_parser import Parser, StreamState
+from vllm.parser.metrics import (
+    classify_completed_tool_call,
+    record_tool_call_completed,
+)
 from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
 from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
@@ -54,6 +58,8 @@ class ToolCallSlot:
         "name_sent",
         "string_keys",
         "streamed_json",
+        "completed",
+        "function_call",
     )
 
     def __init__(self) -> None:
@@ -64,6 +70,8 @@ class ToolCallSlot:
         self.name_sent: bool = False
         self.string_keys: set[str] | None = None
         self.streamed_json: str = ""
+        self.completed: bool = False
+        self.function_call: tuple[str, str] | None = None
 
     @property
     def args(self) -> str:
@@ -123,6 +131,7 @@ class ParserEngine(Parser):
         self._deferred_reasoning: str = ""
         self._content_has_nonws: bool = False
         self._suppress_tool_calls: bool = False
+        self._metrics_request: object | None = None
 
         self._arg_converter = parser_engine_config.arg_converter
         self._arg_structural_chars = parser_engine_config.arg_structural_chars
@@ -441,6 +450,7 @@ class ParserEngine(Parser):
         *,
         finished: bool,
     ) -> DeltaMessage | None:
+        self._metrics_request = request
         self._initialize_history_tool_call_cnt(request)
         if not self._prompt_streaming_prepared and prompt_token_ids is not None:
             # NOTE: call the hook BEFORE setting the flag, because the hook
@@ -569,6 +579,7 @@ class ParserEngine(Parser):
         output, this method starts the parser engine in ``CONTENT`` state
         so it can parse content that has already had reasoning stripped.
         """
+        self._metrics_request = request
         self._check_skip_tool_parsing(request)
         _, parsed_content, tool_call_info = self._single_pass_parse(
             content,
@@ -594,6 +605,7 @@ class ParserEngine(Parser):
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> DeltaMessage | None:
         self.initialize_streaming()
+        self._metrics_request = request
         self._check_skip_tool_parsing(request)
         events = self._feed(delta_text, delta_token_ids)
         return self._strip_trailing_reasoning(self._events_to_delta(events))
@@ -680,6 +692,7 @@ class ParserEngine(Parser):
         enable_auto_tools: bool = False,
         model_output_token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
+        self._metrics_request = request
         self._initialize_history_tool_call_cnt(request)
         self._check_skip_tool_parsing(request)
         reasoning, content, tool_call_info = self._single_pass_parse(
@@ -861,8 +874,11 @@ class ParserEngine(Parser):
         if idx >= len(self._tool_slots):
             return
 
-        remaining = self._flush_arg_converter(idx)
         slot = self._tool_slots[idx]
+        if slot.completed:
+            return
+
+        remaining = self._flush_arg_converter(idx)
 
         if not slot.name_sent:
             name = slot.name or self._try_extract_name(idx) or ""
@@ -893,6 +909,17 @@ class ParserEngine(Parser):
                     function=DeltaFunctionCall(arguments=remaining),
                 )
             )
+
+        slot.function_call = self._slot_to_function_call(slot)
+        slot.completed = True
+        if slot.function_call is None:
+            return
+
+        name, arguments = slot.function_call
+        record_tool_call_completed(
+            request=self._metrics_request,
+            outcome=classify_completed_tool_call(name, arguments, self._tools),
+        )
 
     # ── Tool-call delta coalescing ──────────────────────────────────────
 
@@ -1007,6 +1034,34 @@ class ParserEngine(Parser):
 
     # ── Build ExtractedToolCallInformation ─────────────────────────────
 
+    def _slot_to_function_call(self, slot: ToolCallSlot) -> tuple[str, str] | None:
+        """Return (name, arguments) the client would see, or None to skip."""
+        if not slot.name and not slot.args:
+            return None
+
+        name = slot.name.strip()
+        raw_body = slot.args
+
+        if not name and raw_body.strip():
+            name, args_json = self._extract_name_and_args(raw_body)
+        elif raw_body.strip():
+            converter = self._arg_converter
+            if converter is not None:
+                try:
+                    args_json = converter(raw_body, False)
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    logger.debug("arg converter failed (extract): %s", raw_body[:80])
+                    args_json = self._extract_args_json(raw_body, name)
+            else:
+                args_json = self._extract_args_json(raw_body, name)
+        else:
+            args_json = "{}"
+
+        if not self._accept_tool_name(name):
+            return None
+
+        return name, self._fix_arg_types(args_json, name)
+
     def _build_extracted_result(
         self,
         *deltas: DeltaMessage | None,
@@ -1017,39 +1072,21 @@ class ParserEngine(Parser):
                 content_parts.append(delta.content)
 
         tool_calls: list[ToolCall] = []
-        for idx, slot in enumerate(self._tool_slots):
-            if not slot.name and not slot.args:
-                continue
-
-            name = slot.name.strip()
-            raw_body = slot.args
-
-            if not name and raw_body.strip():
-                name, args_json = self._extract_name_and_args(raw_body)
-            elif raw_body.strip():
-                converter = self._arg_converter
-                if converter is not None:
-                    try:
-                        args_json = converter(raw_body, False)
-                    except (json.JSONDecodeError, ValueError, TypeError):
-                        logger.debug(
-                            "arg converter failed (extract): %s", raw_body[:80]
-                        )
-                        args_json = self._extract_args_json(raw_body, name)
-                else:
-                    args_json = self._extract_args_json(raw_body, name)
+        for slot in self._tool_slots:
+            if slot.completed:
+                function_call = slot.function_call
             else:
-                args_json = "{}"
-
-            if self._accept_tool_name(name):
-                self._ensure_tool_id(slot, name)
-                args_json = self._fix_arg_types(args_json, name)
-                tool_calls.append(
-                    ToolCall(
-                        id=slot.id,
-                        function=FunctionCall(name=name, arguments=args_json),
-                    )
+                function_call = self._slot_to_function_call(slot)
+            if function_call is None:
+                continue
+            name, args_json = function_call
+            self._ensure_tool_id(slot, name)
+            tool_calls.append(
+                ToolCall(
+                    id=slot.id,
+                    function=FunctionCall(name=name, arguments=args_json),
                 )
+            )
 
         content_str = "".join(content_parts)
         content = self._strip_content_whitespace(content_str, len(tool_calls) > 0)

--- a/vllm/parser/metrics.py
+++ b/vllm/parser/metrics.py
@@ -88,11 +88,11 @@ def init_parser_metrics(*, model_name: str) -> None:
             REGISTRY._names_to_collectors[_TOOL_CALLS_COMPLETED_TOTAL],
         )
 
-    for request_type, outcome in product(RequestType, ValidationOutcome):
+    for request_type, validation_outcome in product(RequestType, ValidationOutcome):
         _tool_calls_completed.labels(
             model_name=_model_name,
             request_type=request_type.value,
-            validation_outcome=outcome.value,
+            validation_outcome=validation_outcome.value,
         )
 
 

--- a/vllm/parser/metrics.py
+++ b/vllm/parser/metrics.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
+import json
 from enum import Enum
 from itertools import product
-from typing import cast
+from typing import Any, cast
 
 from prometheus_client import REGISTRY, Counter
 
@@ -14,6 +15,9 @@ _model_name: str | None = None
 
 _TOOL_CALL_PARSER_INVOCATIONS_TOTAL = "vllm:tool_call_parser_invocations_total"
 _tool_call_parser_invocations: Counter | None = None
+
+_TOOL_CALLS_COMPLETED_TOTAL = "vllm:tool_calls_completed_total"
+_tool_calls_completed: Counter | None = None
 
 
 class ToolCallOutcome(Enum):
@@ -25,6 +29,12 @@ class RequestType(Enum):
     CHAT_COMPLETIONS = "chat_completions"
     RESPONSES = "responses"
     OTHER = "other"
+
+
+class ValidationOutcome(Enum):
+    VALID = "valid"
+    UNKNOWN_TOOL = "unknown_tool"
+    INVALID_ARGS = "invalid_args"
 
 
 def init_parser_metrics(*, model_name: str) -> None:
@@ -61,6 +71,43 @@ def init_parser_metrics(*, model_name: str) -> None:
             request_type=request_type.value,
         )
 
+    global _tool_calls_completed
+    try:
+        _tool_calls_completed = Counter(
+            name=_TOOL_CALLS_COMPLETED_TOTAL,
+            documentation=(
+                "Total number of completed tool calls. "
+                "Incremented once per finished call. "
+                "Streaming and non-streaming share this counter."
+            ),
+            labelnames=["model_name", "request_type", "validation_outcome"],
+        )
+    except ValueError:
+        _tool_calls_completed = cast(
+            Counter,
+            REGISTRY._names_to_collectors[_TOOL_CALLS_COMPLETED_TOTAL],
+        )
+
+    for request_type, outcome in product(RequestType, ValidationOutcome):
+        _tool_calls_completed.labels(
+            model_name=_model_name,
+            request_type=request_type.value,
+            validation_outcome=outcome.value,
+        )
+
+
+def _request_type(request: object) -> RequestType:
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+    match request:
+        case ChatCompletionRequest():
+            return RequestType.CHAT_COMPLETIONS
+        case ResponsesRequest():
+            return RequestType.RESPONSES
+        case _:
+            return RequestType.OTHER
+
 
 def record_tool_parser_invocation(
     *,
@@ -79,17 +126,6 @@ def record_tool_parser_invocation(
     if _tool_call_parser_invocations is None:
         return
 
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
-
-    match request:
-        case ChatCompletionRequest():
-            request_type = RequestType.CHAT_COMPLETIONS
-        case ResponsesRequest():
-            request_type = RequestType.RESPONSES
-        case _:
-            request_type = RequestType.OTHER
-
     match is_tool_called:
         case bool():
             outcome = (
@@ -104,5 +140,52 @@ def record_tool_parser_invocation(
         model_name=_model_name,
         mode="streaming" if is_streaming else "non_streaming",
         outcome=outcome.value,
-        request_type=request_type.value,
+        request_type=_request_type(request).value,
     ).inc()
+
+
+def record_tool_call_completed(
+    *,
+    request: object,
+    outcome: ValidationOutcome,
+) -> None:
+    """Increment the completed tool-call counter when registered."""
+    if _tool_calls_completed is None:
+        return
+
+    _tool_calls_completed.labels(
+        model_name=_model_name,
+        request_type=_request_type(request).value,
+        validation_outcome=outcome.value,
+    ).inc()
+
+
+def classify_completed_tool_call(
+    name: str,
+    arguments: str,
+    tools: object | None,
+) -> ValidationOutcome:
+    """Return one validation label for a completed tool call.
+
+    Never raises. Unexpected errors map to ``invalid_args``.
+    """
+    try:
+        import jsonschema
+
+        from vllm.tool_parsers.utils import find_tool_name, find_tool_parameters
+
+        catalog = cast(Any, tools)
+        if not find_tool_name(catalog, name):
+            return ValidationOutcome.UNKNOWN_TOOL
+
+        try:
+            instance = json.loads(arguments)
+        except json.JSONDecodeError:
+            return ValidationOutcome.INVALID_ARGS
+
+        params = find_tool_parameters(catalog, name)
+        schema = params if params is not None else {"type": "object", "properties": {}}
+        jsonschema.validate(instance=instance, schema=schema)
+        return ValidationOutcome.VALID
+    except Exception:
+        return ValidationOutcome.INVALID_ARGS

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -311,6 +311,32 @@ def find_tool_name(
     return False
 
 
+def find_tool_parameters(
+    tools: list[Tool] | None,
+    tool_name: str,
+) -> dict[str, Any] | None:
+    """Find a tool by name and return its parameters dict, or None.
+
+    Returns None when *tools* is empty/None, *tool_name* is absent, or the
+    matching tool has ``parameters`` set to None. Callers must not collapse
+    those cases into one label.
+    """
+    if not tools:
+        return None
+    for tool in tools:
+        if isinstance(tool, (FunctionTool, NamespaceTool)):
+            for name, params in iter_response_function_tool_info(tool):
+                if name == tool_name:
+                    return params
+            continue
+        if not _is_function_tool(tool):
+            continue
+        name, params = _extract_tool_info(tool)
+        if name == tool_name:
+            return params
+    return None
+
+
 def _get_tool_schema_from_name_and_params(
     name: str, params: dict[str, Any] | None
 ) -> dict:


### PR DESCRIPTION
Depends on #54117

## Summary
- Record `vllm:tool_calls_completed_total` from ParserEngine `_handle_tool_end` only, once per finished call.
- Classify the same `(name, arguments)` pair the client gets (`_slot_to_function_call`), not raw slot text.
- `_handle_tool_end` is idempotent for double `TOOL_CALL_END` (Kimi stays in `TOOL_PREAMBLE` after a well-formed call).
- This PR must not merge until #54117 is in. Harmony / DelegatingParser recording is later work.

## Test plan
- [x] `pytest tests/parser/engine/test_completed_metrics.py`
- [x] `pre-commit run --hook-stage manual --from-ref origin/main --to-ref HEAD`


Made with [Cursor](https://cursor.com)