### PR TITLE
[Core][V1] Add max_concurrent_prefills to bound simultaneous prefills

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -544,6 +544,135 @@ def test_throttle_capacity_bound_guard_admits():
     assert "b" in output.num_scheduled_tokens
 
 
+@pytest.mark.parametrize("cap", [1, 2, 3])
+def test_max_concurrent_prefills_bounds_admissions(cap: int):
+    """`max_concurrent_prefills` admits at most `cap` prefills in a step, even
+    with budget to spare and more requests waiting. The rest stay WAITING in
+    arrival order, to be admitted as earlier prefills complete."""
+    scheduler = create_scheduler(
+        max_num_seqs=16, max_num_batched_tokens=8192, max_concurrent_prefills=cap
+    )
+    requests = create_requests(
+        num_requests=4, num_tokens=8, req_ids=[f"r{i}" for i in range(4)]
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert len(output.num_scheduled_tokens) == cap
+    for request in requests[:cap]:
+        assert request.request_id in output.num_scheduled_tokens
+    for request in requests[cap:]:
+        assert request.request_id not in output.num_scheduled_tokens
+        assert request.status == RequestStatus.WAITING
+
+
+def test_max_concurrent_prefills_counts_inflight_chunks():
+    """A prefill that spans several steps holds its blocks the whole time, so it
+    counts against the cap on later steps too: with a cap of 1, a waiting
+    request is held until the chunked prefill ahead of it finishes."""
+    scheduler = create_scheduler(
+        max_num_seqs=16,
+        max_num_batched_tokens=50,
+        enable_chunked_prefill=True,
+        max_concurrent_prefills=1,
+    )
+
+    # 80 tokens against a 50-token budget: prefilled in two chunks.
+    (chunk_req,) = create_requests(num_requests=1, num_tokens=80, req_ids=["chk0"])
+    scheduler.add_request(chunk_req)
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens["chk0"] == 50
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["chk0"],
+            req_id_to_index={"chk0": 0},
+            sampled_token_ids=[[]],  # no token sampled for a partial prefill
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    assert chunk_req.is_prefill_chunk
+
+    # The cap is already spent on the in-flight prefill, so this one waits even
+    # though the step has budget for it.
+    (new_req,) = create_requests(num_requests=1, num_tokens=8, req_ids=["new0"])
+    scheduler.add_request(new_req)
+    output = scheduler.schedule()
+    assert "new0" not in output.num_scheduled_tokens
+    assert new_req.status == RequestStatus.WAITING
+    # The chunked prefill itself is untouched: the cap gates admission only.
+    assert output.num_scheduled_tokens["chk0"] == 30
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["chk0"],
+            req_id_to_index={"chk0": 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    assert not chunk_req.is_prefill_chunk
+
+    # With the prefill finished, the cap frees up and the request is admitted.
+    output = scheduler.schedule()
+    assert "new0" in output.num_scheduled_tokens
+
+
+def test_max_concurrent_prefills_leaves_decode_scheduled():
+    """The cap bounds prefill admission, not decode: a request that has finished
+    prefilling no longer counts against it and keeps being scheduled while
+    waiting prefills are held back."""
+    scheduler = create_scheduler(
+        max_num_seqs=16, max_num_batched_tokens=8192, max_concurrent_prefills=1
+    )
+    (decode_req,) = create_requests(
+        num_requests=1, num_tokens=8, max_tokens=100, req_ids=["dec0"]
+    )
+    scheduler.add_request(decode_req)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["dec0"],
+            req_id_to_index={"dec0": 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    assert not decode_req.is_prefill_chunk
+
+    requests = create_requests(num_requests=2, num_tokens=8, req_ids=["new0", "new1"])
+    for request in requests:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert "dec0" in output.num_scheduled_tokens
+    assert "new0" in output.num_scheduled_tokens
+    assert "new1" not in output.num_scheduled_tokens
+
+
+def test_max_concurrent_prefills_defaults_to_unbounded():
+    """The default of 0 leaves admission exactly as it was."""
+    scheduler = create_scheduler(max_num_seqs=16, max_num_batched_tokens=8192)
+    assert scheduler.max_concurrent_prefills == 0
+
+    requests = create_requests(
+        num_requests=4, num_tokens=8, req_ids=[f"r{i}" for i in range(4)]
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert len(output.num_scheduled_tokens) == 4
+
+
 def test_no_mm_input_chunking():
     # Disable multimodal input chunking.
     scheduler = create_scheduler(

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -75,6 +75,7 @@ def create_scheduler(
     use_v2_model_runner: bool | None = None,
     kv_cache_spec: KVCacheSpec | None = None,
     per_request_spec_decode_metrics: str = "none",
+    max_concurrent_prefills: int = 0,
     scheduling_policy: SchedulerPolicy = "fcfs",
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
@@ -113,6 +114,7 @@ def create_scheduler(
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        max_concurrent_prefills=max_concurrent_prefills,
         # Ensure admission/preemption mechanics are deterministic
         watermark=0.0,
         policy=scheduling_policy,

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -187,6 +187,22 @@ class SchedulerConfig:
     once every N engine steps, aligned across DP ranks, to better balance
     per-step forward-pass times."""
 
+    max_concurrent_prefills: int = Field(default=0, ge=0)
+    """Maximum number of requests allowed to be in prefill at the same time,
+    counting requests whose prefill is still partially computed together with
+    those admitted in the current step. 0 (the default) does not bound it.
+
+    A request in prefill holds every block it has computed so far, and those
+    blocks come from the same pool that retains reusable prefixes. Admitting
+    many prefills at once therefore evicts prefixes that later requests would
+    have hit, and interleaves prefill into more of the steps that decode shares.
+    Bounding the count keeps that footprint flat, at the cost of holding
+    requests in the queue longer.
+
+    This bounds requests, not work: `long_prefill_token_threshold` and the
+    per-step token budget limit how much prefill a step computes, not how many
+    requests hold partial prefill state at once."""
+
     async_scheduling: bool | None = None
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -640,6 +640,7 @@ class EngineArgs:
 
     scheduler_reserve_full_isl: bool = SchedulerConfig.scheduler_reserve_full_isl
     prefill_schedule_interval: int = SchedulerConfig.prefill_schedule_interval
+    max_concurrent_prefills: int = SchedulerConfig.max_concurrent_prefills
 
     watermark: float = SchedulerConfig.watermark
 
@@ -1624,6 +1625,10 @@ class EngineArgs:
             **scheduler_kwargs["prefill_schedule_interval"],
         )
         scheduler_group.add_argument(
+            "--max-concurrent-prefills",
+            **scheduler_kwargs["max_concurrent_prefills"],
+        )
+        scheduler_group.add_argument(
             "--disable-hybrid-kv-cache-manager",
             **scheduler_kwargs["disable_hybrid_kv_cache_manager"],
         )
@@ -2425,6 +2430,7 @@ class EngineArgs:
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,
             watermark=self.watermark,
             prefill_schedule_interval=self.prefill_schedule_interval,
+            max_concurrent_prefills=self.max_concurrent_prefills,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -333,6 +333,7 @@ class Scheduler(SchedulerInterface):
         self.scheduler_reserve_full_isl = (
             self.scheduler_config.scheduler_reserve_full_isl
         )
+        self.max_concurrent_prefills = self.scheduler_config.max_concurrent_prefills
 
         self.has_mamba_layers = kv_cache_config.has_mamba_layers
         self.needs_kv_cache_zeroing = kv_cache_config.needs_kv_cache_zeroing
@@ -849,10 +850,18 @@ class Scheduler(SchedulerInterface):
 
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
+            # Requests still prefilling from earlier steps already hold blocks,
+            # so they count against the cap alongside this step's admissions.
+            num_concurrent_prefills = len(self._inflight_prefills)
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if input_budget <= draft_slots:
+                    break
+                if (
+                    self.max_concurrent_prefills
+                    and num_concurrent_prefills >= self.max_concurrent_prefills
+                ):
                     break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
                 # in `running` but still hold a model-runner request slot.
@@ -1222,6 +1231,7 @@ class Scheduler(SchedulerInterface):
                     # only the successfully loaded tokens.
                     request.num_computed_tokens = num_computed_tokens
                     self._inflight_prefills.add(request)
+                    num_concurrent_prefills += 1
                     if self.needs_kv_cache_zeroing:
                         # Skip zeroing of the blocks the async load will
                         # overwrite; the zeroing could race the write.
@@ -1235,6 +1245,9 @@ class Scheduler(SchedulerInterface):
                     continue
 
                 self.running.append(request)
+                # This request now holds blocks for a prefill, whether or not
+                # the prefill finishes within this step's chunk.
+                num_concurrent_prefills += 1
                 if num_external_computed_tokens > 0:
                     # load_kv_async is False here
                     has_sync_kv_loads = True


### PR DESCRIPTION
## Purpose

A request in prefill holds every block it has computed so far, and those blocks come out
of the same pool that retains reusable prefixes. Nothing in V1 bounds how many requests do
that at once: the per-step token budget and `long_prefill_token_threshold` cap how much
prefill a step *computes*, not how many requests hold partial prefill state.

On an agentic-coding trace with a deep shared prefix, that is the difference that matters.
Uncapped, the scheduler admits up to 15 prefills in a single step. Each one's blocks come
out of the space that was holding prefixes those very requests are about to hit, and the
prefill work interleaves into steps that decode has to share.

One new scheduler option, off by default:

| Flag | Default | Meaning |
| --- | --- | --- |
| `--max-concurrent-prefills N` | 0 | Maximum requests in prefill at once, counting those still partially computed from earlier steps together with those admitted in the current step. 0 does not bound it. |

Deliberate limits on scope:

- It gates **admission only**. A request that has finished prefilling stops counting, and
  in-flight prefill chunks keep being scheduled, so neither decode nor the progress of an
  already-admitted prefill is affected. Only new entries are held.
- It counts requests still mid-prefill from earlier steps, reusing the `_inflight_prefills`
  set the scheduler already maintains, so the bound is on simultaneous prefill state rather
  than on per-step admissions alone. No new bookkeeping is introduced.
- It is independent of `long_prefill_token_threshold`. A prefill holds its blocks whether
  or not chunking splits it, so a request counts either way.
- The default of 0 leaves scheduling unchanged.

## Why this is not duplicating an existing PR

**#49075** (enforce `max_num_partial_prefills` and `max_long_partial_prefills` in V1) is
the closest existing work and deserves an explicit comparison.

It restores V0's pair of knobs, and its waiting-queue limit treats a request as a partial
prefill only when `0 < long_prefill_token_threshold < full_remaining`. With
`long_prefill_token_threshold` at its default of 0, that condition is never true, so the
waiting-side limit does not engage on a deployment that has not set the threshold — which
is the configuration measured below. It also builds on a base predating **#49244**, which
removed both fields from `SchedulerConfig` as "old now unsupported".

This PR neither restores those fields nor keys off the threshold: it adds a single option
that counts every request holding prefill state, chunked or not, and defaults to off. The
two could coexist, since one bounds long chunked prefills specifically and this bounds
concurrent prefills generally. If maintainers would rather see this expressed as a revival
of `max_num_partial_prefills`, I am glad to adapt it.

**#41399** (V1 concurrent partial prefills enablement) targets the same V0 pair and has
been in a conflicting state since June.

## Benchmark results

Kimi-K3 FP4, 8x MI355X, a single engine with DCP=8, replaying an agentic-coding trace at
concurrency 52 over a 900s window, with CPU KV offloading. Interactivity is per-user output
speed at the 90th percentile. Higher is better on both metrics; percentages are against the
uncapped row.

| `max_concurrent_prefills` | tok/s/GPU | p90 interactivity (tok/s/user) |
| --- | --- | --- |
| 0 | 8,233 | 11.73 |
| 2 | 8,443 (+2.6%) | 17.38 (+48.1%) |
| 4 | 8,486 (+3.1%) | 12.81 (+9.1%) |
| 8 | 8,099 (-1.6%) | 11.81 (+0.6%) |

A cap of 8 barely engages against a 15-prefill peak, and neither metric moves. Tightening
it concentrates prefill into fewer, denser steps, leaving decode longer uninterrupted
stretches, and shrinks the live-block footprint so more of the pool holds reusable
prefixes: at a cap of 2, server-reported KV usage falls from 51.1% to 47.2% and the prefix
cache hit rate rises from 88.1% to 88.8%, the best of the sweep.

The option is off by default because the curve has an interior optimum. Tighten it far
enough and prefills serialize, starving the GPU of decode work and dropping throughput well
below the uncapped baseline. The cost is paid in queueing even where it helps, the waiting
queue deepening from 7.3 requests uncapped to 17.0 at a cap of 2, so the useful range is
workload-specific and worth measuring rather than assuming.

## Test plan

Six tests added to `tests/v1/core/test_scheduler.py`:

- `test_max_concurrent_prefills_bounds_admissions[1,2,3]` — at most N prefills admitted in
  a step, with token budget to spare and more requests waiting; the rest stay `WAITING`.
- `test_max_concurrent_prefills_counts_inflight_chunks` — a prefill spanning several steps
  keeps counting against the cap, so a waiting request is held until it finishes, while the
  chunk itself continues to be scheduled.
- `test_max_concurrent_prefills_leaves_decode_scheduled` — a request that has finished
  prefilling stops counting, and decode keeps being scheduled while prefills are held.
- `test_max_concurrent_prefills_defaults_to_unbounded` — the default of 0 admits all.

## Test result

- `tests/v1/core/test_scheduler.py`: **163 passed** (157 pre-existing + 6 new).
- `tests/engine/test_arg_utils.py`: 98 passed.
- Negative control: removing the cap check fails exactly the 5 tests that exercise it,
  while the default-behavior test still passes.
- CLI round-trip: `--max-concurrent-prefills 4` parses, the default is 0, and a negative
  value is rejected by the `ge=0` validator.
- `ruff check` and `ruff format` clean on all changed files.

Test runs on this machine intermittently fail unrelated tests in the same file with
`huggingface_hub` errors, with a different set failing each time; the runs reported above
are the ones that completed without hub errors, and the same flakiness reproduces on
unmodified `main`.
