### PR TITLE
[Rust Frontend] Only accept XGrammar backend for structured outputs

### DIFF
--- a/rust/src/chat/src/output/default/structural_tag.rs
+++ b/rust/src/chat/src/output/default/structural_tag.rs
@@ -4,9 +4,7 @@
 //! Applies xgrammar structural-tag constraints for strict tool calling.
 
 use thiserror_ext::AsReport;
-use vllm_engine_core_client::protocol::structured_outputs::{
-    StructuredOutputBackend, StructuredOutputsParams,
-};
+use vllm_engine_core_client::protocol::structured_outputs::StructuredOutputsParams;
 use vllm_parser::tool::StructuralTagBuilder;
 use xgrammar_structural_tag::builders::StructuralTagOptions;
 use xgrammar_structural_tag::{
@@ -55,10 +53,8 @@ pub(super) fn apply_structural_tag_constraint(
     })?;
 
     // Overwrite any existing structured output settings with the structural tag constraint.
-    request.sampling_params.structured_outputs = Some(StructuredOutputsParams {
-        backend: StructuredOutputBackend::Xgrammar,
-        ..StructuredOutputsParams::structural_tag(structural_tag)
-    });
+    request.sampling_params.structured_outputs =
+        Some(StructuredOutputsParams::structural_tag(structural_tag));
 
     Ok(())
 }
@@ -86,9 +82,7 @@ fn structural_tag_tool_choice(request: &ChatRequest) -> Option<StructuralTagTool
 #[cfg(test)]
 mod tests {
     use serde_json::{Value, json};
-    use vllm_engine_core_client::protocol::structured_outputs::{
-        StructuredOutputBackend, StructuredOutputsParams,
-    };
+    use vllm_engine_core_client::protocol::structured_outputs::StructuredOutputsParams;
     use vllm_parser::tool::{Qwen3CoderToolParser, Tool, ToolParser};
 
     use super::*;
@@ -127,7 +121,6 @@ mod tests {
             .structured_outputs
             .as_ref()
             .expect("structured outputs should be set");
-        assert_eq!(params.backend, StructuredOutputBackend::Xgrammar);
         let structural_tag = params
             .constraint
             .as_structural_tag()
@@ -219,12 +212,10 @@ mod tests {
     }
 
     #[test]
-    fn auto_strict_tool_choice_overwrites_existing_json_guidance() {
+    fn auto_strict_tool_choice_overwrites_existing_json_constraint() {
         let mut request = request(ChatToolChoice::Auto, vec![chat_tool("search", Some(true))]);
-        request.sampling_params.structured_outputs = Some(StructuredOutputsParams {
-            backend: StructuredOutputBackend::Xgrammar,
-            ..StructuredOutputsParams::json(json!({"type": "object"}))
-        });
+        request.sampling_params.structured_outputs =
+            Some(StructuredOutputsParams::json(json!({"type": "object"})));
         let parser = qwen3_coder_parser(request.tools());
 
         apply_structural_tag_constraint(&mut request, parser.structural_tag_builder())
@@ -251,12 +242,9 @@ mod tests {
     }
 
     #[test]
-    fn required_tool_choice_overwrites_existing_json_object_guidance() {
+    fn required_tool_choice_overwrites_existing_json_object_constraint() {
         let mut request = request(ChatToolChoice::Required, vec![chat_tool("search", None)]);
-        request.sampling_params.structured_outputs = Some(StructuredOutputsParams {
-            backend: StructuredOutputBackend::Xgrammar,
-            ..StructuredOutputsParams::json_object()
-        });
+        request.sampling_params.structured_outputs = Some(StructuredOutputsParams::json_object());
         let parser = qwen3_coder_parser(request.tools());
 
         apply_structural_tag_constraint(&mut request, parser.structural_tag_builder())
@@ -299,12 +287,9 @@ mod tests {
     }
 
     #[test]
-    fn none_tool_choice_preserves_existing_json_object_guidance() {
+    fn none_tool_choice_preserves_existing_json_object_constraint() {
         let mut request = request(ChatToolChoice::None, vec![chat_tool("search", Some(true))]);
-        request.sampling_params.structured_outputs = Some(StructuredOutputsParams {
-            backend: StructuredOutputBackend::Xgrammar,
-            ..StructuredOutputsParams::json_object()
-        });
+        request.sampling_params.structured_outputs = Some(StructuredOutputsParams::json_object());
         let parser = qwen3_coder_parser(request.tools());
 
         apply_structural_tag_constraint(&mut request, parser.structural_tag_builder())

--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -19,13 +19,14 @@ use clap::{Args, Parser, Subcommand};
 use educe::Educe;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use serde_with::{DefaultOnNull, OneOrMany, serde_as};
 use thiserror_ext::AsReport as _;
 use uuid::Uuid;
 use vllm_chat::multimodal::MmLimitPerPrompt;
 use vllm_chat::{GenerationConfigMode, ReasoningParserFactory};
 use vllm_engine_core_client::TransportMode;
+use vllm_engine_core_client::protocol::structured_outputs::XGrammarBackend;
 use vllm_managed_engine::ManagedEngineConfig;
 use vllm_managed_engine::cli::{ManagedEngineArgs, repartition_managed_engine_args};
 use vllm_server::{
@@ -382,6 +383,11 @@ pub struct SharedRuntimeArgs {
     #[serde(default)]
     pub profiler_config: Option<ProfilerConfig>,
 
+    /// Structured outputs configuration.
+    #[arg(long, value_parser = parse_json::<StructuredOutputsConfig>, value_name = "JSON")]
+    #[serde(default)]
+    structured_outputs_config: Option<StructuredOutputsConfig>,
+
     /// Unsupported Python vLLM frontend arguments recognized but not yet
     /// implemented in Rust.
     #[educe(Debug(ignore))]
@@ -421,6 +427,16 @@ impl SharedRuntimeArgs {
             .map(serde_json::to_string)
             .transpose()
             .expect("profiler config serialization should not fail")
+    }
+
+    /// Return the structured outputs config for managed Python engine
+    /// forwarding.
+    pub fn structured_outputs_config_json(&self) -> Option<String> {
+        self.structured_outputs_config
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()
+            .expect("structured outputs config serialization should not fail")
     }
 
     /// Return the per-modality limits as JSON for managed Python engine
@@ -607,6 +623,15 @@ pub struct ProfilerConfig {
     pub extra: serde_json::Map<String, Value>,
 }
 
+/// Structured-output configuration forwarded to the managed Python engine.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+struct StructuredOutputsConfig {
+    backend: XGrammarBackend,
+    #[serde(flatten)]
+    extra: Map<String, Value>,
+}
+
 fn parse_json<T: DeserializeOwned>(value: &str) -> Result<T, String> {
     serde_json::from_str(value).map_err(|e| format!("invalid JSON object: {}", e.as_report()))
 }
@@ -739,6 +764,7 @@ impl ServeArgs {
         let reasoning_parser =
             effective_engine_reasoning_parser(&self.runtime.reasoning_parser, &self.runtime.model);
         let profiler_config = self.runtime.profiler_config_json();
+        let structured_outputs_config = self.runtime.structured_outputs_config_json();
 
         self.managed_engine.clone().into_config(
             self.runtime.model.clone(),
@@ -750,6 +776,7 @@ impl ServeArgs {
             self.runtime.shutdown_timeout,
             handshake_port,
             self.runtime.limit_mm_per_prompt_json(),
+            structured_outputs_config,
         )
     }
 }

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -205,6 +205,7 @@ fn serve_args_forward_python_flags_with_separator() {
                             ssl_ciphers: None,
                         },
                         profiler_config: None,
+                        structured_outputs_config: None,
                     },
                     managed_engine: ManagedEngineArgs {
                         python: "../vllm/.venv/bin/python",
@@ -349,6 +350,48 @@ fn serve_args_forward_profiler_config_to_managed_engine() {
             "torch_profiler_dir": "/tmp/profile",
         })
     );
+}
+
+#[test]
+fn serve_args_normalize_and_forward_structured_outputs_config() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--structured-outputs-config",
+        r#"{"backend":"auto","disable_any_whitespace":true}"#,
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    let config = args.to_managed_engine_config(5555);
+    let flag_index = config
+        .python_args
+        .iter()
+        .position(|arg| arg == "--structured-outputs-config")
+        .expect("structured outputs config flag");
+    let structured_outputs_config: serde_json::Value =
+        serde_json::from_str(&config.python_args[flag_index + 1])
+            .expect("structured outputs config json");
+
+    assert_eq!(structured_outputs_config["backend"], "xgrammar");
+    assert_eq!(structured_outputs_config["disable_any_whitespace"], true);
+}
+
+#[test]
+fn serve_args_reject_non_xgrammar_structured_outputs_backend() {
+    let error = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--structured-outputs-config",
+        r#"{"backend":"guidance"}"#,
+    ])
+    .unwrap_err();
+
+    assert!(error.to_string().contains("expected `auto` or `xgrammar`"));
 }
 
 #[test]
@@ -1024,6 +1067,7 @@ fn frontend_args_accept_json() {
                             ssl_ciphers: None,
                         },
                         profiler_config: None,
+                        structured_outputs_config: None,
                     },
                 },
             ),
@@ -1621,6 +1665,7 @@ fn serve_args_accept_handshake_aliases() {
                             ssl_ciphers: None,
                         },
                         profiler_config: None,
+                        structured_outputs_config: None,
                     },
                     managed_engine: ManagedEngineArgs {
                         python: "python3",

--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -329,10 +329,6 @@ pub struct EngineUnsupportedArgs {
     #[arg(long)]
     pub stream_interval: Option<Unsupported>,
 
-    /// Structured outputs configuration.
-    #[arg(long)]
-    pub structured_outputs_config: Option<Noop>,
-
     /// Log aggregate rather than per-engine statistics when using data
     /// parallelism.
     #[arg(long, default_missing_value = "true", num_args = 0..=1)]

--- a/rust/src/engine-core-client/src/protocol/structured_outputs.rs
+++ b/rust/src/engine-core-client/src/protocol/structured_outputs.rs
@@ -7,19 +7,32 @@ use serde_json::Value;
 
 use crate::error::{Error, Result};
 
-/// Structured-output backend selected for EngineCore grammar compilation.
-///
-/// Python vLLM stores this in `StructuredOutputsParams._backend` after request
-/// validation. The Rust frontend currently always lowers structured-output
-/// requests to guidance, while ignoring any user-supplied `_backend` value.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum StructuredOutputBackend {
-    Xgrammar,
-    #[default]
-    Guidance,
-    Outlines,
-    LmFormatEnforcer,
+/// The only structured-output backend supported by the Rust frontend.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct XGrammarBackend;
+
+impl Serialize for XGrammarBackend {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str("xgrammar")
+    }
+}
+
+impl<'de> Deserialize<'de> for XGrammarBackend {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match String::deserialize(deserializer)?.as_str() {
+            "auto" | "xgrammar" => Ok(Self),
+            backend => Err(serde::de::Error::unknown_variant(
+                backend,
+                &["auto", "xgrammar"],
+            )),
+        }
+    }
 }
 
 /// The single structured-output constraint selected for a request.
@@ -44,10 +57,6 @@ pub enum StructuredOutputConstraint {
 pub struct StructuredOutputOptions {
     /// Disable any additional whitespace in guided JSON output.
     pub disable_any_whitespace: bool,
-    /// Disable `additionalProperties` in JSON schema output.
-    pub disable_additional_properties: bool,
-    /// Custom whitespace pattern for guided JSON output.
-    pub whitespace_pattern: Option<String>,
 }
 
 /// Parameters for configuring structured outputs (guided decoding).
@@ -62,12 +71,6 @@ pub struct StructuredOutputOptions {
 pub struct StructuredOutputsParams {
     pub constraint: StructuredOutputConstraint,
     pub options: StructuredOutputOptions,
-    /// Structured-output backend, mirroring Python's internal `_backend`.
-    ///
-    /// User-supplied values are ignored during deserialization. This matches
-    /// Python's request boundary, where `_backend` is set by validation rather
-    /// than accepted as a request-level backend selector.
-    pub backend: StructuredOutputBackend,
 }
 
 impl StructuredOutputsParams {
@@ -101,7 +104,6 @@ impl StructuredOutputsParams {
         Self {
             constraint,
             options: StructuredOutputOptions::default(),
-            backend: StructuredOutputBackend::default(),
         }
     }
 }
@@ -127,12 +129,8 @@ struct WireStructuredOutputsParams {
     disable_additional_properties: bool,
     whitespace_pattern: Option<String>,
     structural_tag: Option<String>,
-    #[serde(
-        default,
-        rename = "_backend",
-        deserialize_with = "serde_with::rust::deserialize_ignore_any"
-    )]
-    backend: StructuredOutputBackend,
+    #[serde(default, rename = "_backend")]
+    backend: XGrammarBackend,
 }
 
 impl TryFrom<WireStructuredOutputsParams> for StructuredOutputsParams {
@@ -140,6 +138,18 @@ impl TryFrom<WireStructuredOutputsParams> for StructuredOutputsParams {
 
     fn try_from(raw: WireStructuredOutputsParams) -> Result<Self> {
         use StructuredOutputConstraint::*;
+
+        if raw.disable_additional_properties {
+            return Err(Error::InvalidStructuredOutputsParams {
+                message: "structured_outputs.disable_additional_properties is not supported in Rust frontend".to_string(),
+            });
+        }
+        if raw.whitespace_pattern.is_some() {
+            return Err(Error::InvalidStructuredOutputsParams {
+                message: "structured_outputs.whitespace_pattern is not supported in Rust frontend"
+                    .to_string(),
+            });
+        }
 
         let mut constraint = None;
 
@@ -184,10 +194,7 @@ impl TryFrom<WireStructuredOutputsParams> for StructuredOutputsParams {
             })?,
             options: StructuredOutputOptions {
                 disable_any_whitespace: raw.disable_any_whitespace,
-                disable_additional_properties: raw.disable_additional_properties,
-                whitespace_pattern: raw.whitespace_pattern,
             },
-            backend: raw.backend,
         })
     }
 }
@@ -196,9 +203,7 @@ impl From<StructuredOutputsParams> for WireStructuredOutputsParams {
     fn from(params: StructuredOutputsParams) -> Self {
         let mut raw = Self {
             disable_any_whitespace: params.options.disable_any_whitespace,
-            disable_additional_properties: params.options.disable_additional_properties,
-            whitespace_pattern: params.options.whitespace_pattern,
-            backend: params.backend,
+            backend: XGrammarBackend,
             ..Self::default()
         };
 
@@ -242,18 +247,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn structured_outputs_backend_ignores_deserialized_value() {
+    fn xgrammar_backend_normalizes_auto_and_xgrammar() {
+        for input in ["auto", "xgrammar"] {
+            let backend: XGrammarBackend = serde_json::from_value(input.into()).unwrap();
+            assert_eq!(serde_json::to_value(backend).unwrap(), "xgrammar");
+        }
+    }
+
+    #[test]
+    fn xgrammar_backend_rejects_other_backends() {
+        let error = serde_json::from_value::<XGrammarBackend>("guidance".into()).unwrap_err();
+        assert!(error.to_string().contains("expected `auto` or `xgrammar`"));
+    }
+
+    #[test]
+    fn structured_outputs_normalizes_input_backend_to_xgrammar() {
         let params: StructuredOutputsParams = serde_json::from_value(serde_json::json!({
             "json_object": true,
-            "_backend": "xgrammar",
+            "_backend": "auto",
         }))
         .unwrap();
 
-        assert_eq!(params.backend, StructuredOutputBackend::Guidance);
         assert_eq!(params.constraint, StructuredOutputConstraint::JsonObject);
 
         let value = serde_json::to_value(params).unwrap();
-        assert_eq!(value["_backend"], "guidance");
+        assert_eq!(value["_backend"], "xgrammar");
+    }
+
+    #[test]
+    fn structured_outputs_rejects_non_xgrammar_input_backend() {
+        let error = serde_json::from_value::<StructuredOutputsParams>(serde_json::json!({
+            "json_object": true,
+            "_backend": "guidance",
+        }))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("expected `auto` or `xgrammar`"));
     }
 
     #[test]
@@ -290,13 +319,29 @@ mod tests {
     }
 
     #[test]
+    fn structured_outputs_rejects_guidance_only_options() {
+        for option in [
+            serde_json::json!({
+                "json_object": true,
+                "disable_additional_properties": true,
+            }),
+            serde_json::json!({
+                "json_object": true,
+                "whitespace_pattern": "\\s*",
+            }),
+        ] {
+            let error = serde_json::from_value::<StructuredOutputsParams>(option).unwrap_err();
+            assert!(error.to_string().contains("is not supported in Rust frontend"));
+        }
+    }
+
+    #[test]
     fn structured_outputs_serializes_through_raw_shape() {
         let params = StructuredOutputsParams {
             constraint: StructuredOutputConstraint::StructuralTag(
                 r#"{"type":"structural_tag"}"#.to_string(),
             ),
             options: StructuredOutputOptions::default(),
-            backend: StructuredOutputBackend::Xgrammar,
         };
 
         let value = serde_json::to_value(params).unwrap();

--- a/rust/src/managed-engine/src/cli.rs
+++ b/rust/src/managed-engine/src/cli.rs
@@ -92,6 +92,7 @@ impl ManagedEngineArgs {
         shutdown_timeout: u64,
         handshake_port: u16,
         limit_mm_per_prompt: Option<String>,
+        structured_outputs_config: Option<String>,
     ) -> ManagedEngineConfig {
         let mut python_args = self.python_args;
         // Manually forward some args to the Python engine.
@@ -130,6 +131,10 @@ impl ManagedEngineArgs {
         if let Some(limit_mm_per_prompt) = limit_mm_per_prompt {
             python_args.push("--limit-mm-per-prompt".to_string());
             python_args.push(limit_mm_per_prompt);
+        }
+        if let Some(structured_outputs_config) = structured_outputs_config {
+            python_args.push("--structured-outputs-config".to_string());
+            python_args.push(structured_outputs_config);
         }
 
         ManagedEngineConfig {

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -92,6 +92,10 @@ class XgrammarBackend(StructuredOutputBackend):
             )
         elif request_type == StructuredOutputOptions.GRAMMAR:
             ctx = self.compiler.compile_grammar(grammar_spec)
+        elif request_type == StructuredOutputOptions.CHOICE:
+            ctx = self.compiler.compile_grammar(
+                choice_as_grammar(json.loads(grammar_spec))
+            )
         elif request_type == StructuredOutputOptions.REGEX:
             ctx = compile_regex_with_timeout(
                 self.compiler.compile_regex,
@@ -334,8 +338,6 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
             raise VLLMValidationError(
                 f"Failed to transform choices into a grammar: {err}"
             ) from err
-        so_params.choice = None
-        so_params.grammar = choice_grammar
         return
 
     if so_params.json:


### PR DESCRIPTION
## Summary

- make Rust frontend structured-output requests consistently use XGrammar
- accept `auto`/`xgrammar` startup config and forward it as `xgrammar`
- compile `choice` in the XGrammar backend and reject unsupported Rust options

No open PR covers this Rust frontend backend-consolidation scope.

## Testing

- Rust DTO and CLI nextest suites
- Rust structural-tag nextest suite
- Rust Clippy and rustfmt
- Python structured-output validation tests
- real XGrammar `choice` compilation smoke test

Model evals were not run; this changes structured-output backend routing and protocol handling. AI assistance was used, and all changes were reviewed.
