### PR TITLE
[Perf][Model Runner V2] GDN all-mode decode-path optimizations: packed QKV, fused index prep, weight de-interleave + GEMM fold

### DIFF
--- a/tests/kernels/mamba/test_fla_chunk_block_states.py
+++ b/tests/kernels/mamba/test_fla_chunk_block_states.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""T1: numerical-parity test for the per-chunk intermediate states (`h`) newly
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Numerical-parity test for the per-chunk intermediate states (`h`) newly
 exposed by chunk_gated_delta_rule(..., return_intermediate_states=True).
 
 Semantics under test (verified from chunk_delta_h.py: h is stored at the START of
@@ -9,19 +10,24 @@ each chunk loop iteration, before the chunk update):
     h[:, 0] == initial_state
     final_state == state after all tokens.
 
-This pins the index mapping the Stage-3 scatter relies on:
+This pins the index mapping gdn_scatter_block_checkpoints relies on:
     checkpoint after m*block_size tokens == h[:, m*(block_size//FLA_CHUNK_SIZE)].
 """
+
 import pytest
 import torch
 import torch.nn.functional as F
 
+from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.chunk import chunk_gated_delta_rule
 from vllm.third_party.flash_linear_attention.ops.index import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
 )
 from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+
+if not current_platform.is_cuda():
+    pytest.skip(reason="FLA chunk kernels require CUDA", allow_module_level=True)
 
 DEVICE = "cuda"
 DT = torch.bfloat16
@@ -56,7 +62,13 @@ def test_block_states_equal_len():
     h0 = torch.randn(1, H, V, K, dtype=torch.float32, device=DEVICE)
 
     o, final_state, h = chunk_gated_delta_rule(
-        q, k, v, g, beta, initial_state=h0, output_final_state=True,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=h0,
+        output_final_state=True,
         return_intermediate_states=True,
     )
     assert h is not None and h.shape == (B, NT, H, V, K), h.shape
@@ -68,8 +80,13 @@ def test_block_states_equal_len():
     # h[:,c] == replay(first c chunks).final_state  for c in 1..NT-1
     for c in range(1, NT):
         _, fs_c = chunk_gated_delta_rule(
-            q[:, : c * C], k[:, : c * C], v[:, : c * C], g[:, : c * C], beta[:, : c * C],
-            initial_state=h0, output_final_state=True,
+            q[:, : c * C],
+            k[:, : c * C],
+            v[:, : c * C],
+            g[:, : c * C],
+            beta[:, : c * C],
+            initial_state=h0,
+            output_final_state=True,
         )
         md, ok = _close(h[:, c], fs_c)
         assert ok, f"h[{c}] mismatch vs replay({c} chunks), maxdiff={md}"
@@ -80,7 +97,13 @@ def test_block_states_equal_len():
         )
     # final_state == replay(all)
     _, fs_all = chunk_gated_delta_rule(
-        q, k, v, g, beta, initial_state=h0, output_final_state=True,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=h0,
+        output_final_state=True,
     )
     _, okf = _close(final_state, fs_all)
     assert okf
@@ -100,8 +123,16 @@ def test_block_states_varlen():
     h0 = torch.randn(len(lens), H, V, K, dtype=torch.float32, device=DEVICE)
 
     o, final_state, h = chunk_gated_delta_rule(
-        q, k, v, g, beta, initial_state=h0, output_final_state=True,
-        cu_seqlens=cu, chunk_indices=ci, chunk_offsets=co,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=cu,
+        chunk_indices=ci,
+        chunk_offsets=co,
         return_intermediate_states=True,
     )
     # per-sequence: h[0, chunk_offsets[n] + c] == replay(seq n, first c chunks)
@@ -121,17 +152,23 @@ def test_block_states_varlen():
             bs = beta[:, s : s + c * C]
             cu_c = torch.tensor([0, c * C], dtype=torch.int32, device=DEVICE)
             _, fs_c = chunk_gated_delta_rule(
-                qs, ks, vs, gs, bs, initial_state=h0[n : n + 1],
-                output_final_state=True, cu_seqlens=cu_c,
+                qs,
+                ks,
+                vs,
+                gs,
+                bs,
+                initial_state=h0[n : n + 1],
+                output_final_state=True,
+                cu_seqlens=cu_c,
                 chunk_indices=prepare_chunk_indices(cu_c, C),
                 chunk_offsets=prepare_chunk_offsets(cu_c, C),
             )
             md, ok = _close(h[:, base + c], fs_c)
-            assert ok, f"seq{n} h[{base+c}] mismatch, maxdiff={md}"
+            assert ok, f"seq{n} h[{base + c}] mismatch, maxdiff={md}"
     print("varlen OK")
 
 
 if __name__ == "__main__":
     test_block_states_equal_len()
     test_block_states_varlen()
-    print("T1 ALL PASS")
+    print("ALL PASS")

--- a/tests/kernels/mamba/test_fla_chunk_block_states.py
+++ b/tests/kernels/mamba/test_fla_chunk_block_states.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T1: numerical-parity test for the per-chunk intermediate states (`h`) newly
+exposed by chunk_gated_delta_rule(..., return_intermediate_states=True).
+
+Semantics under test (verified from chunk_delta_h.py: h is stored at the START of
+each chunk loop iteration, before the chunk update):
+    h[:, c] == recurrent state AFTER the first c chunks (i.e. before chunk c),
+              == replay(first c*FLA_CHUNK_SIZE tokens).final_state
+    h[:, 0] == initial_state
+    final_state == state after all tokens.
+
+This pins the index mapping the Stage-3 scatter relies on:
+    checkpoint after m*block_size tokens == h[:, m*(block_size//FLA_CHUNK_SIZE)].
+"""
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.third_party.flash_linear_attention.ops.chunk import chunk_gated_delta_rule
+from vllm.third_party.flash_linear_attention.ops.index import (
+    prepare_chunk_indices,
+    prepare_chunk_offsets,
+)
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+
+DEVICE = "cuda"
+DT = torch.bfloat16
+ATOL, RTOL = 3e-2, 3e-2
+
+
+def _mk(B, T, H, K, V, seed):
+    gen = torch.Generator(device=DEVICE).manual_seed(seed)
+    q = torch.randn(B, T, H, K, dtype=DT, device=DEVICE, generator=gen)
+    k = F.normalize(
+        torch.randn(B, T, H, K, dtype=DT, device=DEVICE, generator=gen), p=2, dim=-1
+    )
+    v = torch.randn(B, T, H, V, dtype=DT, device=DEVICE, generator=gen)
+    beta = torch.rand(B, T, H, dtype=DT, device=DEVICE, generator=gen).sigmoid()
+    g = F.logsigmoid(torch.rand(B, T, H, dtype=DT, device=DEVICE, generator=gen))
+    return q, k, v, g, beta
+
+
+def _close(a, b):
+    a = a.float()
+    b = b.float()
+    return (a - b).abs().max().item(), torch.allclose(a, b, atol=ATOL, rtol=RTOL)
+
+
+def test_block_states_equal_len():
+    """Single sequence, equal-length path (cu_seqlens=None)."""
+    B, H, K, V = 1, 4, 64, 64
+    C = FLA_CHUNK_SIZE
+    L = 4 * C  # 4 chunks
+    NT = L // C
+    q, k, v, g, beta = _mk(B, L, H, K, V, seed=1)
+    h0 = torch.randn(1, H, V, K, dtype=torch.float32, device=DEVICE)
+
+    o, final_state, h = chunk_gated_delta_rule(
+        q, k, v, g, beta, initial_state=h0, output_final_state=True,
+        return_intermediate_states=True,
+    )
+    assert h is not None and h.shape == (B, NT, H, V, K), h.shape
+
+    # h[:,0] == initial_state
+    md0, ok0 = _close(h[:, 0], h0)
+    assert ok0, f"h[0] != initial_state, maxdiff={md0}"
+
+    # h[:,c] == replay(first c chunks).final_state  for c in 1..NT-1
+    for c in range(1, NT):
+        _, fs_c = chunk_gated_delta_rule(
+            q[:, : c * C], k[:, : c * C], v[:, : c * C], g[:, : c * C], beta[:, : c * C],
+            initial_state=h0, output_final_state=True,
+        )
+        md, ok = _close(h[:, c], fs_c)
+        assert ok, f"h[{c}] mismatch vs replay({c} chunks), maxdiff={md}"
+        # discriminating: h[c] must NOT match the adjacent (wrong) checkpoint
+        md_off, ok_off = _close(h[:, c - 1], fs_c)
+        assert not ok_off or md_off < md, (
+            f"off-by-one not discriminated at c={c}: md_off={md_off} md={md}"
+        )
+    # final_state == replay(all)
+    _, fs_all = chunk_gated_delta_rule(
+        q, k, v, g, beta, initial_state=h0, output_final_state=True,
+    )
+    _, okf = _close(final_state, fs_all)
+    assert okf
+    print("equal_len OK")
+
+
+def test_block_states_varlen():
+    """Varlen path (B=1, cu_seqlens) — the real GDN prefill path."""
+    H, K, V = 4, 64, 64
+    C = FLA_CHUNK_SIZE
+    lens = [3 * C, 5 * C]  # 2 seqs, 3 and 5 chunks
+    T = sum(lens)
+    cu = torch.tensor([0, lens[0], T], dtype=torch.int32, device=DEVICE)
+    ci = prepare_chunk_indices(cu, C)
+    co = prepare_chunk_offsets(cu, C)
+    q, k, v, g, beta = _mk(1, T, H, K, V, seed=2)
+    h0 = torch.randn(len(lens), H, V, K, dtype=torch.float32, device=DEVICE)
+
+    o, final_state, h = chunk_gated_delta_rule(
+        q, k, v, g, beta, initial_state=h0, output_final_state=True,
+        cu_seqlens=cu, chunk_indices=ci, chunk_offsets=co,
+        return_intermediate_states=True,
+    )
+    # per-sequence: h[0, chunk_offsets[n] + c] == replay(seq n, first c chunks)
+    for n, ln in enumerate(lens):
+        s = cu[n].item()
+        e = cu[n + 1].item()
+        base = co[n].item()
+        nch = (e - s) // C
+        # h[:,0] of the sequence == its initial state
+        md0, ok0 = _close(h[:, base], h0[n : n + 1])
+        assert ok0, f"seq{n} h[base] != init, md={md0}"
+        for c in range(1, nch):
+            qs = q[:, s : s + c * C]
+            ks = k[:, s : s + c * C]
+            vs = v[:, s : s + c * C]
+            gs = g[:, s : s + c * C]
+            bs = beta[:, s : s + c * C]
+            cu_c = torch.tensor([0, c * C], dtype=torch.int32, device=DEVICE)
+            _, fs_c = chunk_gated_delta_rule(
+                qs, ks, vs, gs, bs, initial_state=h0[n : n + 1],
+                output_final_state=True, cu_seqlens=cu_c,
+                chunk_indices=prepare_chunk_indices(cu_c, C),
+                chunk_offsets=prepare_chunk_offsets(cu_c, C),
+            )
+            md, ok = _close(h[:, base + c], fs_c)
+            assert ok, f"seq{n} h[{base+c}] mismatch, maxdiff={md}"
+    print("varlen OK")
+
+
+if __name__ == "__main__":
+    test_block_states_equal_len()
+    test_block_states_varlen()
+    print("T1 ALL PASS")

--- a/tests/kernels/mamba/test_fused_sigmoid_gating_dual_index.py
+++ b/tests/kernels/mamba/test_fused_sigmoid_gating_dual_index.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Stage-4 / K2 unit test: dual-anchor (separate read vs write) SSM state indices
+"""Unit test: dual-anchor (separate read vs write) SSM state indices
 for the GDN decode kernel ``fused_sigmoid_gating_delta_rule_update``.
 
 The all-mode + MTP decode path must read the initial recurrent state from one set
@@ -17,10 +17,10 @@ property plus backward compatibility (output index ``None`` -> in-place).
 import pytest
 import torch
 
+from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops import (
     fused_sigmoid_gating_delta_rule_update,
 )
-from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 DEVICE = current_platform.device_type

--- a/tests/kernels/mamba/test_fused_sigmoid_gating_dual_index.py
+++ b/tests/kernels/mamba/test_fused_sigmoid_gating_dual_index.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Stage-4 / K2 unit test: dual-anchor (separate read vs write) SSM state indices
+for the GDN decode kernel ``fused_sigmoid_gating_delta_rule_update``.
+
+The all-mode + MTP decode path must read the initial recurrent state from one set
+of physical blocks (``ssm_state_indices``, the previous-step anchor) while writing
+the updated state into a *different* set of blocks (``ssm_state_indices_output``,
+the current-step anchor). This mirrors Mamba2's
+``state_batch_indices`` (read) vs ``dst_state_batch_indices`` (write) split in
+``selective_state_update``.
+
+These tests use tiny dummy tensors and assert the exact read/write isolation
+property plus backward compatibility (output index ``None`` -> in-place).
+"""
+
+import pytest
+import torch
+
+from vllm.third_party.flash_linear_attention.ops import (
+    fused_sigmoid_gating_delta_rule_update,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+DEVICE = current_platform.device_type
+
+
+@pytest.fixture(autouse=True)
+def _default_device():
+    """Run every test with the CUDA default device, then restore —
+    a leaked default device makes later tests in the same process
+    silently materialize CPU tensors on CUDA."""
+    torch.set_default_device(DEVICE)
+    yield
+    torch.set_default_device(None)
+
+
+def _make_decode_inputs(
+    num_reqs, num_k_heads, num_v_heads, head_k_dim, head_v_dim, dtype, tp_size=1
+):
+    """Build single-token-per-request decode inputs matching the existing
+    ``test_fused_sigmoid_gating_delta_rule`` shapes."""
+    key_dim = head_k_dim * num_k_heads
+    value_dim = head_v_dim * num_v_heads
+    mixed_qkv_dim = (key_dim * 2 + value_dim) // tp_size
+    num_tokens = num_reqs  # seq_len == 1 for decode
+
+    mixed_qkv = torch.rand(num_tokens, mixed_qkv_dim, dtype=dtype)
+    query, key, value = torch.split(
+        mixed_qkv,
+        [key_dim // tp_size, key_dim // tp_size, value_dim // tp_size],
+        dim=-1,
+    )
+    query = query.view(1, num_tokens, num_k_heads, head_k_dim)
+    key = key.view(1, num_tokens, num_k_heads, head_k_dim)
+    value = value.view(1, num_tokens, num_v_heads, head_v_dim)
+
+    A_log = torch.rand(num_v_heads // tp_size, dtype=dtype)
+    dt_bias = torch.rand(num_v_heads // tp_size, dtype=dtype)
+    a = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    cu_seqlens = torch.arange(0, num_tokens + 1, dtype=torch.int32)
+    return dict(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=query,
+        k=key,
+        v=value,
+        cu_seqlens=cu_seqlens,
+        num_tokens=num_tokens,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+    )
+
+
+@pytest.mark.parametrize("num_reqs", [1, 2, 4])
+@pytest.mark.parametrize("num_k_heads", [16])
+@pytest.mark.parametrize("num_v_heads", [32])
+@pytest.mark.parametrize("head_k_dim", [128])
+@pytest.mark.parametrize("head_v_dim", [128])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_dual_index_read_write_isolation(
+    num_reqs, num_k_heads, num_v_heads, head_k_dim, head_v_dim, dtype
+):
+    """Reading from slot set A while writing to a *disjoint* slot set B must:
+    (1) leave the A slots unchanged, (2) land the computed final state in B, and
+    (3) produce the same attention output as the in-place run."""
+    set_random_seed(0)
+    ins = _make_decode_inputs(
+        num_reqs, num_k_heads, num_v_heads, head_k_dim, head_v_dim, dtype
+    )
+    num_tokens = ins["num_tokens"]
+    HV, K, V = ins["num_v_heads"], ins["head_k_dim"], ins["head_v_dim"]
+
+    total_entries = num_tokens * 4
+    # disjoint read / write slot sets (avoid NULL_BLOCK_ID==0)
+    perm = torch.randperm(total_entries - 1, dtype=torch.int32) + 1
+    read_idx = perm[:num_tokens].contiguous()
+    write_idx = perm[num_tokens : 2 * num_tokens].contiguous()
+    assert set(read_idx.tolist()).isdisjoint(set(write_idx.tolist()))
+
+    base_state = torch.rand(total_entries, HV, V, K, dtype=dtype)
+
+    def call(state, out_idx):
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            initial_state=state,
+            inplace_final_state=True,
+            ssm_state_indices=read_idx,
+            ssm_state_indices_output=out_idx,
+            cu_seqlens=ins["cu_seqlens"],
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    # Reference: in-place (output index defaults to read index) -> final lands in A.
+    state_ref = base_state.clone()
+    read_orig = state_ref[read_idx].clone()
+    out_ref, _ = call(state_ref, None)
+    final_at_read = state_ref[read_idx].clone()
+    # in-place actually mutated the read slots (sanity: state changed)
+    assert not torch.allclose(final_at_read, read_orig, atol=1e-3, rtol=1e-3)
+
+    # Dual-anchor: read from A, write to B.
+    state_dual = base_state.clone()
+    a_before = state_dual[read_idx].clone()
+    out_dual, _ = call(state_dual, write_idx)
+
+    # (1) read slots untouched
+    torch.testing.assert_close(state_dual[read_idx], a_before, atol=0, rtol=0)
+    # (2) computed final state landed in the write slots (== the in-place result)
+    torch.testing.assert_close(
+        state_dual[write_idx], final_at_read, atol=1e-2, rtol=1e-2
+    )
+    # (3) attention output identical regardless of where the state is written
+    torch.testing.assert_close(out_dual, out_ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_dual_index_none_is_inplace(dtype):
+    """``ssm_state_indices_output=None`` must reproduce exactly the legacy
+    in-place behavior (write index == read index)."""
+    set_random_seed(0)
+    ins = _make_decode_inputs(2, 16, 32, 128, 128, dtype)
+    num_tokens = ins["num_tokens"]
+    HV, K, V = ins["num_v_heads"], ins["head_k_dim"], ins["head_v_dim"]
+
+    total_entries = num_tokens * 4
+    perm = torch.randperm(total_entries - 1, dtype=torch.int32) + 1
+    read_idx = perm[:num_tokens].contiguous()
+    base_state = torch.rand(total_entries, HV, V, K, dtype=dtype)
+
+    def call(state, out_idx):
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            initial_state=state,
+            inplace_final_state=True,
+            ssm_state_indices=read_idx,
+            ssm_state_indices_output=out_idx,
+            cu_seqlens=ins["cu_seqlens"],
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    # None (default) vs explicitly passing read_idx as the output index: identical.
+    state_none = base_state.clone()
+    out_none, _ = call(state_none, None)
+
+    state_explicit = base_state.clone()
+    out_explicit, _ = call(state_explicit, read_idx)
+
+    torch.testing.assert_close(out_none, out_explicit, atol=0, rtol=0)
+    torch.testing.assert_close(
+        state_none[read_idx], state_explicit[read_idx], atol=0, rtol=0
+    )
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [1, 3])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_dual_index_spec_2d(num_speculative_tokens, dtype):
+    """2-D index case (the MTP spec-decode shape): read anchor at the accepted
+    position from one block row, write the per-token states into a different
+    block row. Validates the read row stays intact and the write row receives
+    the states for every speculative position."""
+    set_random_seed(0)
+    tp_size = 1
+    num_k_heads, num_v_heads, head_k_dim, head_v_dim = 16, 32, 128, 128
+    num_reqs = 2
+    seq = num_speculative_tokens + 1
+    key_dim = head_k_dim * num_k_heads
+    value_dim = head_v_dim * num_v_heads
+    mixed_qkv_dim = (key_dim * 2 + value_dim) // tp_size
+    num_tokens = num_reqs * seq
+
+    mixed_qkv = torch.rand(num_tokens, mixed_qkv_dim, dtype=dtype)
+    query, key, value = torch.split(
+        mixed_qkv,
+        [key_dim // tp_size, key_dim // tp_size, value_dim // tp_size],
+        dim=-1,
+    )
+    query = query.view(1, num_tokens, num_k_heads, head_k_dim)
+    key = key.view(1, num_tokens, num_k_heads, head_k_dim)
+    value = value.view(1, num_tokens, num_v_heads, head_v_dim)
+    A_log = torch.rand(num_v_heads // tp_size, dtype=dtype)
+    dt_bias = torch.rand(num_v_heads // tp_size, dtype=dtype)
+    a = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    num_accepted_tokens = torch.randint(1, seq + 1, (num_reqs,), dtype=torch.int32)
+    cu_seqlens = torch.arange(0, num_tokens + 1, seq, dtype=torch.int32)
+
+    HV, K, V = num_v_heads, head_k_dim, head_v_dim
+    total_entries = num_tokens * 4
+    perm = torch.randperm(total_entries - 1, dtype=torch.int32) + 1
+    read_2d = perm[: num_reqs * seq].view(num_reqs, seq).contiguous()
+    write_2d = (
+        perm[num_reqs * seq : 2 * num_reqs * seq].view(num_reqs, seq).contiguous()
+    )
+    base_state = torch.rand(total_entries, HV, V, K, dtype=dtype)
+
+    def call(state, in_idx, out_idx):
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=query,
+            k=key,
+            v=value,
+            initial_state=state,
+            inplace_final_state=True,
+            ssm_state_indices=in_idx,
+            ssm_state_indices_output=out_idx,
+            num_accepted_tokens=num_accepted_tokens,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    # in-place reference: read AND write through read_2d.
+    state_ref = base_state.clone()
+    out_ref, _ = call(state_ref, read_2d, None)
+    # in-place wrote the per-token states into the read_2d rows
+    final_at_read = state_ref[read_2d.flatten()].clone()
+
+    # dual-anchor: read read_2d, write write_2d
+    state_dual = base_state.clone()
+    read_before = state_dual[read_2d.flatten()].clone()
+    out_dual, _ = call(state_dual, read_2d, write_2d)
+
+    # read rows untouched
+    torch.testing.assert_close(
+        state_dual[read_2d.flatten()], read_before, atol=0, rtol=0
+    )
+    # write rows now hold the same per-token states the in-place run wrote to read rows
+    torch.testing.assert_close(
+        state_dual[write_2d.flatten()], final_at_read, atol=1e-2, rtol=1e-2
+    )
+    # output identical
+    torch.testing.assert_close(out_dual, out_ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [3])
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_dual_index_noncontiguous_2d(num_speculative_tokens, dtype):
+    """P1 Fix 3: a NON-contiguous 2-D index tensor (transposed/strided view)
+    must produce identical results to its .contiguous() copy. The kernel
+    indexes the token dim with an implicit stride of 1, so before the wrapper
+    normalization a strided view silently read wrong offsets."""
+    set_random_seed(0)
+    tp_size = 1
+    num_k_heads, num_v_heads, head_k_dim, head_v_dim = 16, 32, 128, 128
+    num_reqs = 2
+    seq = num_speculative_tokens + 1
+    key_dim = head_k_dim * num_k_heads
+    value_dim = head_v_dim * num_v_heads
+    mixed_qkv_dim = (key_dim * 2 + value_dim) // tp_size
+    num_tokens = num_reqs * seq
+
+    mixed_qkv = torch.rand(num_tokens, mixed_qkv_dim, dtype=dtype)
+    query, key, value = torch.split(
+        mixed_qkv,
+        [key_dim // tp_size, key_dim // tp_size, value_dim // tp_size],
+        dim=-1,
+    )
+    query = query.view(1, num_tokens, num_k_heads, head_k_dim)
+    key = key.view(1, num_tokens, num_k_heads, head_k_dim)
+    value = value.view(1, num_tokens, num_v_heads, head_v_dim)
+    A_log = torch.rand(num_v_heads // tp_size, dtype=dtype)
+    dt_bias = torch.rand(num_v_heads // tp_size, dtype=dtype)
+    a = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    num_accepted_tokens = torch.randint(1, seq + 1, (num_reqs,), dtype=torch.int32)
+    cu_seqlens = torch.arange(0, num_tokens + 1, seq, dtype=torch.int32)
+
+    HV, K, V = num_v_heads, head_k_dim, head_v_dim
+    total_entries = num_tokens * 4
+    perm = torch.randperm(total_entries - 1, dtype=torch.int32) + 1
+    read_contig = perm[: num_reqs * seq].view(num_reqs, seq).contiguous()
+    write_contig = (
+        perm[num_reqs * seq : 2 * num_reqs * seq].view(num_reqs, seq).contiguous()
+    )
+    # Same logical values, NON-contiguous layout: strides (1, num_reqs).
+    read_strided = read_contig.t().contiguous().t()
+    write_strided = write_contig.t().contiguous().t()
+    assert read_strided.stride(-1) != 1  # genuinely non-contiguous view
+    torch.testing.assert_close(read_strided, read_contig, atol=0, rtol=0)
+    base_state = torch.rand(total_entries, HV, V, K, dtype=dtype)
+
+    def call(state, in_idx, out_idx):
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=query,
+            k=key,
+            v=value,
+            initial_state=state,
+            inplace_final_state=True,
+            ssm_state_indices=in_idx,
+            ssm_state_indices_output=out_idx,
+            num_accepted_tokens=num_accepted_tokens,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    # REGRESSION: contiguous path (reference).
+    state_ref = base_state.clone()
+    out_ref, _ = call(state_ref, read_contig, write_contig)
+
+    # NEW: strided views must give bit-identical behavior to the contiguous run.
+    state_strided = base_state.clone()
+    out_strided, _ = call(state_strided, read_strided, write_strided)
+
+    torch.testing.assert_close(out_strided, out_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state_strided, state_ref, atol=0, rtol=0)

--- a/tests/kernels/mamba/test_fused_sigmoid_gating_packed.py
+++ b/tests/kernels/mamba/test_fused_sigmoid_gating_packed.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Step-1 packed-qkv tests for ``fused_sigmoid_gating_delta_rule_update``.
+
+The GDN spec-decode SSM kernel accepts the packed conv output (``mixed_qkv``)
+directly, addressing q/k/v with per-tensor offsets in-kernel (same arithmetic
+as ``fused_recurrent_gated_delta_rule_packed_decode``) instead of requiring
+host-side ``rearrange_mixed_qkv`` (cat + 3 contiguous copies, ~375 us/step at
+c32). Test groups (kernel-opt plan, Step 1 test plan):
+
+- A: kernel-level packed-vs-tensor parity — decode (T=1), the packed x table
+  4-combo matrix, and the T>1 pointer-advance case (non-standard row stride).
+- B: golden parity — the tensor path is code-identical to the pre-change
+  kernel when ``mixed_qkv=None`` (the PACKED branches are constexpr-pruned),
+  so its result is the golden reference; packed must match bit-exactly.
+- C: wrapper assertion tests (mutual exclusivity, last-dim contiguity,
+  required head geometry).
+- D: layer-level A/B parity through ``VLLM_GDN_PACKED_SPEC_QKV`` with a
+  monkeypatched call counter on ``rearrange_mixed_qkv`` (reusing the
+  test_gdn_all_mode_spec_decode / test_gdn_all_mode_prefill harnesses).
+
+Groups E/F of the plan (GPU battery + nsys A/B) run outside pytest.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="GDN packed-qkv tests require CUDA (Triton/FLA kernels).",
+        allow_module_level=True,
+    )
+
+from tests.kernels.mamba import (  # noqa: E402
+    test_gdn_all_mode_decode as decode_harness,
+)
+from tests.kernels.mamba import (  # noqa: E402
+    test_gdn_all_mode_prefill as prefill_harness,
+)
+from tests.kernels.mamba import (  # noqa: E402
+    test_gdn_all_mode_spec_decode as spec_harness,
+)
+from tests.v1.attention.utils import BatchSpec  # noqa: E402
+from vllm.third_party.flash_linear_attention.ops import (  # noqa: E402
+    fused_sigmoid_gating_delta_rule_update,
+)
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (  # noqa: E402
+    QwenGatedDeltaNetAttention,
+)
+from vllm.utils.torch_utils import set_random_seed  # noqa: E402
+
+H = 4  # num qk heads
+HV = 8  # num value heads
+K = 128  # head_qk_dim
+V = 128  # head_v_dim
+PACKED_DIM = 2 * H * K + HV * V
+
+GEOMETRY = dict(num_qk_heads=H, head_qk_dim=K, num_v_heads=HV, head_v_dim=V)
+
+
+def _make_inputs(num_reqs, seq, dtype, device, row_pad=0, seed=0):
+    """Packed buffer + the equivalent split q/k/v views (tensor-path input).
+
+    ``row_pad`` widens the underlying rows so ``mixed_qkv.stride(0)`` differs
+    from the packed width — the per-token advance must follow the stride.
+    """
+    set_random_seed(seed)
+    num_tokens = num_reqs * seq
+    buf = torch.rand(num_tokens, PACKED_DIM + row_pad, dtype=dtype, device=device)
+    mixed_qkv = buf[:, :PACKED_DIM]
+    assert mixed_qkv.stride(-1) == 1
+    query, key, value = torch.split(mixed_qkv, [H * K, H * K, HV * V], dim=-1)
+    query = query.reshape(1, num_tokens, H, K)
+    key = key.reshape(1, num_tokens, H, K)
+    value = value.reshape(1, num_tokens, HV, V)
+    A_log = torch.rand(HV, dtype=dtype, device=device)
+    dt_bias = torch.rand(HV, dtype=dtype, device=device)
+    a = torch.rand(num_tokens, HV, dtype=dtype, device=device)
+    b = torch.rand(num_tokens, HV, dtype=dtype, device=device)
+    cu_seqlens = torch.arange(0, num_tokens + 1, seq, dtype=torch.int32, device=device)
+    return dict(
+        mixed_qkv=mixed_qkv,
+        q=query,
+        k=key,
+        v=value,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        a=a,
+        b=b,
+        cu_seqlens=cu_seqlens,
+        num_tokens=num_tokens,
+    )
+
+
+def _make_state(num_slots, dtype, device):
+    """State pool with slot 0 reserved (NULL_BLOCK_ID)."""
+    return torch.rand(num_slots, HV, V, K, dtype=dtype, device=device)
+
+
+def _call(ins, state, packed, **index_kwargs):
+    qkv = (
+        dict(mixed_qkv=ins["mixed_qkv"], **GEOMETRY)
+        if packed
+        else dict(q=ins["q"], k=ins["k"], v=ins["v"])
+    )
+    return fused_sigmoid_gating_delta_rule_update(
+        A_log=ins["A_log"],
+        a=ins["a"],
+        b=ins["b"],
+        dt_bias=ins["dt_bias"],
+        initial_state=state,
+        inplace_final_state=True,
+        cu_seqlens=ins["cu_seqlens"],
+        use_qk_l2norm_in_kernel=True,
+        **qkv,
+        **index_kwargs,
+    )
+
+
+# --------------------------------------------------------------------------
+# Group A: kernel-level packed-vs-tensor parity
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_packed_matches_tensor_decode(dtype):
+    """A1: single-token decode (T=1, 1D indices) — the packed path must
+    reproduce the tensor path bit-exactly (same loads, same arithmetic)."""
+    device = torch.device("cuda")
+    num_reqs = 4
+    ins = _make_inputs(num_reqs, 1, dtype, device)
+    perm = torch.randperm(4 * num_reqs - 1, dtype=torch.int32, device=device) + 1
+    idx = perm[:num_reqs].contiguous()
+    base_state = _make_state(4 * num_reqs, torch.float32, device)
+
+    state_ref = base_state.clone()
+    out_ref, _ = _call(ins, state_ref, packed=False, ssm_state_indices=idx)
+    state_packed = base_state.clone()
+    out_packed, _ = _call(ins, state_packed, packed=True, ssm_state_indices=idx)
+
+    torch.testing.assert_close(out_packed, out_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state_packed, state_ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("packed", [False, True])
+@pytest.mark.parametrize("use_table", [False, True])
+def test_packed_table_matrix(packed, use_table):
+    """A2-A5: {packed, tensor} x {2D indices, block_table + anchors} — all
+    four combos of the spec-decode configuration must agree bit-exactly with
+    the tensor + indices reference (outputs and the full state pool)."""
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_reqs, seq = 2, 3
+    ins = _make_inputs(num_reqs, seq, dtype, device)
+    accepted = torch.tensor([2, 1], dtype=torch.int32, device=device)
+
+    # Per-request table row: read window [0, seq), write window [seq, 2*seq).
+    width = 2 * seq
+    perm = (
+        torch.randperm(4 * num_reqs * width - 1, dtype=torch.int32, device=device) + 1
+    )
+    table = perm[: num_reqs * width].view(num_reqs, width).contiguous()
+    read_anchor = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+    write_anchor = torch.full((num_reqs,), seq, dtype=torch.int32, device=device)
+    base_state = _make_state(int(table.max().item()) + 1, torch.float32, device)
+
+    def index_kwargs(with_table):
+        if with_table:
+            return dict(
+                block_table=table,
+                read_anchor=read_anchor,
+                write_anchor=write_anchor,
+                num_accepted_tokens=accepted,
+            )
+        return dict(
+            ssm_state_indices=table[:, :seq],
+            ssm_state_indices_output=table[:, seq:],
+            num_accepted_tokens=accepted,
+        )
+
+    state_ref = base_state.clone()
+    out_ref, _ = _call(ins, state_ref, packed=False, **index_kwargs(False))
+
+    state_run = base_state.clone()
+    out_run, _ = _call(ins, state_run, packed=packed, **index_kwargs(use_table))
+
+    torch.testing.assert_close(out_run, out_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state_run, state_ref, atol=0, rtol=0)
+
+
+def test_packed_pointer_advance_multi_token():
+    """A6: T>1 with a non-standard row stride — the packed per-token advance
+    must follow ``mixed_qkv.stride(0)`` (a padded buffer breaks any H*K-based
+    advance) and the per-sequence base must be ``bos * stride``."""
+    device = torch.device("cuda")
+    num_reqs, seq = 3, 4
+    ins = _make_inputs(num_reqs, seq, torch.bfloat16, device, row_pad=32)
+    assert ins["mixed_qkv"].stride(0) == PACKED_DIM + 32
+    accepted = torch.tensor([3, 1, 4], dtype=torch.int32, device=device)
+    perm = (
+        torch.randperm(4 * num_reqs * seq - 1, dtype=torch.int32, device=device) + 1
+    )
+    idx = perm[: num_reqs * seq].view(num_reqs, seq).contiguous()
+    base_state = _make_state(4 * num_reqs * seq, torch.float32, device)
+
+    state_ref = base_state.clone()
+    out_ref, _ = _call(
+        ins,
+        state_ref,
+        packed=False,
+        ssm_state_indices=idx,
+        num_accepted_tokens=accepted,
+    )
+    state_packed = base_state.clone()
+    out_packed, _ = _call(
+        ins,
+        state_packed,
+        packed=True,
+        ssm_state_indices=idx,
+        num_accepted_tokens=accepted,
+    )
+
+    torch.testing.assert_close(out_packed, out_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state_packed, state_ref, atol=0, rtol=0)
+
+
+# --------------------------------------------------------------------------
+# Group B: golden parity against the (unchanged) tensor path
+# --------------------------------------------------------------------------
+
+
+def test_packed_matches_tensor_golden():
+    """B7: golden tensors from the tensor path of the patched kernel — that
+    path is code-identical to the pre-change kernel when ``mixed_qkv=None``
+    (PACKED branches constexpr-pruned), so bit-exact equality here proves the
+    packed path reproduces the pre-change numerics (torch.equal, not
+    assert_close)."""
+    device = torch.device("cuda")
+    num_reqs, seq = 2, 3
+    ins = _make_inputs(num_reqs, seq, torch.bfloat16, device, seed=1234)
+    accepted = torch.tensor([2, 3], dtype=torch.int32, device=device)
+    width = 2 * seq
+    perm = (
+        torch.randperm(4 * num_reqs * width - 1, dtype=torch.int32, device=device) + 1
+    )
+    table = perm[: num_reqs * width].view(num_reqs, width).contiguous()
+    read_anchor = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+    write_anchor = torch.full((num_reqs,), seq, dtype=torch.int32, device=device)
+    base_state = _make_state(int(table.max().item()) + 1, torch.float32, device)
+
+    kwargs = dict(
+        block_table=table,
+        read_anchor=read_anchor,
+        write_anchor=write_anchor,
+        num_accepted_tokens=accepted,
+    )
+    golden_state = base_state.clone()
+    golden_out, _ = _call(ins, golden_state, packed=False, **kwargs)
+    state = base_state.clone()
+    out, _ = _call(ins, state, packed=True, **kwargs)
+
+    assert torch.equal(out, golden_out)
+    assert torch.equal(state, golden_state)
+
+
+# --------------------------------------------------------------------------
+# Group C: wrapper assertions
+# --------------------------------------------------------------------------
+
+
+def _assert_case_inputs():
+    device = torch.device("cuda")
+    ins = _make_inputs(2, 1, torch.bfloat16, device)
+    idx = torch.tensor([1, 2], dtype=torch.int32, device=device)
+    state = _make_state(4, torch.float32, device)
+    return ins, idx, state
+
+
+def test_packed_rejects_qkv_tensors():
+    """C8: ``mixed_qkv`` and ``q``/``k``/``v`` are mutually exclusive."""
+    ins, idx, state = _assert_case_inputs()
+    with pytest.raises(AssertionError, match="mutually exclusive"):
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            mixed_qkv=ins["mixed_qkv"],
+            **GEOMETRY,
+            initial_state=state,
+            ssm_state_indices=idx,
+            cu_seqlens=ins["cu_seqlens"],
+        )
+
+
+def test_packed_rejects_noncontiguous_last_dim():
+    """C9: a ``mixed_qkv`` view with ``stride(-1) != 1`` must be rejected —
+    the kernel's per-tensor offsets assume unit element stride."""
+    ins, idx, state = _assert_case_inputs()
+    strided = torch.rand(
+        2, 2 * PACKED_DIM, dtype=torch.bfloat16, device=ins["mixed_qkv"].device
+    )[:, ::2]
+    assert strided.stride(-1) != 1
+    with pytest.raises(AssertionError, match="contiguous in the last dim"):
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            mixed_qkv=strided,
+            **GEOMETRY,
+            initial_state=state,
+            ssm_state_indices=idx,
+            cu_seqlens=ins["cu_seqlens"],
+        )
+
+
+def test_packed_requires_head_geometry():
+    """C10: head geometry can't be inferred from a packed buffer, so the
+    geometry kwargs are mandatory in packed mode."""
+    ins, idx, state = _assert_case_inputs()
+    with pytest.raises(AssertionError, match="head geometry"):
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            mixed_qkv=ins["mixed_qkv"],
+            initial_state=state,
+            ssm_state_indices=idx,
+            cu_seqlens=ins["cu_seqlens"],
+        )
+
+
+# --------------------------------------------------------------------------
+# Group D: layer-level A/B via VLLM_GDN_PACKED_SPEC_QKV
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rearrange_counter(monkeypatch):
+    """Count material ``rearrange_mixed_qkv`` calls (``None`` passthroughs on
+    empty partitions are free and don't count)."""
+    calls = {"n": 0}
+    orig = QwenGatedDeltaNetAttention.rearrange_mixed_qkv
+
+    def counting(self, mixed_qkv):
+        if mixed_qkv is not None:
+            calls["n"] += 1
+        return orig(self, mixed_qkv)
+
+    monkeypatch.setattr(QwenGatedDeltaNetAttention, "rearrange_mixed_qkv", counting)
+    return calls
+
+
+def test_layer_pure_spec_packed_matches_rearrange(monkeypatch, rearrange_counter):
+    """D11: pure-spec batch through the real ``_forward_core`` — the packed
+    path (flag on, default) must be bit-identical to the rearrange path (flag
+    off), and the counter must show the rearrange was actually skipped."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = prefill_harness._make_weights(device)
+    batch = BatchSpec(seq_lens=[103, 231], query_lens=[3, 3])
+    inputs = prefill_harness._make_inputs(6, device)
+    st = spec_harness._rand_states(device, 8)
+    seeds = {}
+    for i, col in enumerate((1, 2, 3)):
+        seeds[(0, col)] = (st[i][0] if col == 1 else None, st[i][1])
+    for i, col in enumerate((3, 4, 5)):
+        seeds[(1, col)] = (st[4 + i][0] if col == 3 else None, st[4 + i][1])
+    drafts = [spec_harness.NUM_SPEC, spec_harness.NUM_SPEC]
+
+    monkeypatch.setenv("VLLM_GDN_PACKED_SPEC_QKV", "0")
+    out_rearr, _, ssm_rearr, _ = spec_harness._run_spec(
+        "all", batch, inputs, weights, drafts, [2, 1], seeds
+    )
+    assert rearrange_counter["n"] == 1
+
+    rearrange_counter["n"] = 0
+    monkeypatch.setenv("VLLM_GDN_PACKED_SPEC_QKV", "1")
+    out_packed, _, ssm_packed, _ = spec_harness._run_spec(
+        "all", batch, inputs, weights, drafts, [2, 1], seeds
+    )
+    assert rearrange_counter["n"] == 0
+
+    torch.testing.assert_close(out_packed, out_rearr, atol=0, rtol=0)
+    torch.testing.assert_close(ssm_packed, ssm_rearr, atol=0, rtol=0)
+
+
+def test_layer_peeled_decode_packed_matches_rearrange(monkeypatch, rearrange_counter):
+    """D12: mixed decode+prefill batch (peeled decode rows) — flag on/off A/B
+    in one process: identical outputs and final states, rearrange skipped on
+    the packed run."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = prefill_harness._make_weights(device)
+    # Row 0: in-block decode (seq 101, block 1); row 1: fresh 192-token
+    # prefill — the proven mixed-batch shape of test_gdn_all_mode_decode.
+    batch = BatchSpec(seq_lens=[101, 192], query_lens=[1, 192])
+    inputs = prefill_harness._make_inputs(193, device)
+    conv_s = torch.randn_like(
+        prefill_harness._make_pools(1, torch.float32, device)[0][0]
+    )
+    ssm_s = torch.randn_like(
+        prefill_harness._make_pools(1, torch.float32, device)[1][0]
+    )
+    seeds = {(0, 1): (conv_s, ssm_s)}
+
+    monkeypatch.setenv("VLLM_GDN_PACKED_SPEC_QKV", "0")
+    out_rearr, conv_rearr, ssm_rearr, _ = decode_harness._run_mode(
+        "align", batch, inputs, False, seeds, weights
+    )
+    assert rearrange_counter["n"] == 1
+
+    rearrange_counter["n"] = 0
+    monkeypatch.setenv("VLLM_GDN_PACKED_SPEC_QKV", "1")
+    out_packed, conv_packed, ssm_packed, _ = decode_harness._run_mode(
+        "align", batch, inputs, False, seeds, weights
+    )
+    assert rearrange_counter["n"] == 0
+
+    torch.testing.assert_close(out_packed, out_rearr, atol=0, rtol=0)
+    torch.testing.assert_close(conv_packed, conv_rearr, atol=0, rtol=0)
+    torch.testing.assert_close(ssm_packed, ssm_rearr, atol=0, rtol=0)

--- a/tests/kernels/mamba/test_gdn_all_mode_decode.py
+++ b/tests/kernels/mamba/test_gdn_all_mode_decode.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-level tests for GDN all-mode decode (dual read/write anchor).
+
+All-mode decode must READ the running conv/SSM state from the last *computed*
+block and WRITE to the last *scheduled* block. Within a mamba block the two
+anchors are the same physical block, so in-block decode must be bit-identical
+to align mode; exactly at a block-boundary crossing they differ and the state
+must migrate into the fresh block (the runner does not copy mamba state across
+blocks in all-mode). Covered paths:
+
+* the packed non-spec decode fast path (``_forward_core_decode_non_spec``,
+  in-place kernels -> carry-copy),
+* the non-packed decode branches in ``_forward_core`` (kernel-side dual
+  index: conv block args + K2 ``ssm_state_indices_output``),
+* the peeled decode rows of a mixed decode+prefill batch.
+
+Reuses the harness of test_gdn_all_mode_prefill (real ``_forward_core`` +
+real ``GDNAttentionMetadataBuilder`` metadata on GPU).
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="GDN all-mode decode tests require CUDA (Triton/FLA kernels).",
+        allow_module_level=True,
+    )
+
+from tests.kernels.mamba import test_gdn_all_mode_prefill as harness  # noqa: E402
+from tests.v1.attention.utils import BatchSpec  # noqa: E402
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (  # noqa: E402
+    QwenGatedDeltaNetAttention,
+)
+
+BLOCK = 64
+
+
+def _build_decode_layer(cfg, conv_state, ssm_state, weights, packed):
+    layer = harness._build_layer(cfg, BLOCK, conv_state, ssm_state, weights)
+    layer.enable_packed_recurrent_decode = packed
+    layer._forward_core_decode_non_spec = types.MethodType(
+        QwenGatedDeltaNetAttention._forward_core_decode_non_spec, layer
+    )
+    return layer
+
+
+def _run_mode(mode, batch, inputs, packed, seed_blocks, weights):
+    """Run one decode batch in `mode`; seed_blocks maps (seq, block_idx) in
+    the block table -> (conv, ssm) source states to pre-place."""
+    device = torch.device("cuda")
+    mixed_qkv, b, a = inputs
+    num_tokens = mixed_qkv.shape[0]
+    cfg = harness._make_vllm_config(BLOCK, mode)
+    meta, common = harness._build_metadata(cfg, batch, BLOCK, device)
+    pool_size = int(common.block_table_tensor.max().item()) + 1
+    conv_state, ssm_state = harness._make_pools(pool_size, torch.float32, device)
+    for (seq, block_idx), (conv_src, ssm_src) in seed_blocks.items():
+        blk = int(common.block_table_tensor[seq, block_idx].item())
+        conv_state[blk] = conv_src
+        ssm_state[blk] = ssm_src
+    layer = _build_decode_layer(cfg, conv_state, ssm_state, weights, packed)
+    out = harness._run_forward_core(layer, meta, mixed_qkv, b, a, num_tokens)
+    return out, conv_state, ssm_state, common.block_table_tensor
+
+
+@pytest.mark.parametrize("packed", [True, False])
+def test_decode_in_block_matches_align(packed):
+    """Within a mamba block, read == write anchor: all-mode decode must be
+    bit-identical to align mode (same seeded state, same physical block)."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    inputs = harness._make_inputs(1, device)
+    # seq 101 with 1 new token: ncomp=100 -> mid-block of block 1 for both
+    # modes (align's sliced table also lands on block 1).
+    batch = BatchSpec(seq_lens=[101], query_lens=[1])
+    conv_s = torch.randn_like(harness._make_pools(1, torch.float32, device)[0][0])
+    ssm_s = torch.randn_like(harness._make_pools(1, torch.float32, device)[1][0])
+
+    out_all, conv_all, ssm_all, table = _run_mode(
+        "all", batch, inputs, packed, {(0, 1): (conv_s, ssm_s)}, weights
+    )
+    out_align, conv_align, ssm_align, _ = _run_mode(
+        "align", batch, inputs, packed, {(0, 1): (conv_s, ssm_s)}, weights
+    )
+    torch.testing.assert_close(out_all, out_align, atol=0, rtol=0)
+    blk = int(table[0, 1].item())
+    torch.testing.assert_close(ssm_all[blk], ssm_align[blk], atol=0, rtol=0)
+    torch.testing.assert_close(conv_all[blk], conv_align[blk], atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("packed", [True, False])
+def test_decode_boundary_crossing_carries_state(packed):
+    """At a block-boundary crossing (ncomp == 2*BLOCK), all-mode must read
+    the running state from the previous block and write the updated state
+    into the fresh block — matching an align run whose state already sits in
+    the current block."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    inputs = harness._make_inputs(1, device)
+    # seq 129 with 1 new token: ncomp=128=2*BLOCK. Read anchor = block 1
+    # (state after 128 tokens), write anchor = block 2 (fresh).
+    batch = BatchSpec(seq_lens=[129], query_lens=[1])
+    conv_s = torch.randn_like(harness._make_pools(1, torch.float32, device)[0][0])
+    ssm_s = torch.randn_like(harness._make_pools(1, torch.float32, device)[1][0])
+
+    # all-mode: running state lives in block 1; block 2 is empty.
+    out_all, conv_all, ssm_all, table = _run_mode(
+        "all", batch, inputs, packed, {(0, 1): (conv_s, ssm_s)}, weights
+    )
+    # align reference: the runner has already placed the state in block 2.
+    out_align, conv_align, ssm_align, _ = _run_mode(
+        "align", batch, inputs, packed, {(0, 2): (conv_s, ssm_s)}, weights
+    )
+    torch.testing.assert_close(out_all, out_align, atol=0, rtol=0)
+    # The updated running state must land in block 2 in both runs.
+    blk2 = int(table[0, 2].item())
+    torch.testing.assert_close(ssm_all[blk2], ssm_align[blk2], atol=0, rtol=0)
+    torch.testing.assert_close(conv_all[blk2], conv_align[blk2], atol=0, rtol=0)
+    # And block 1 (the read anchor) must keep its checkpoint intact: it is
+    # the content-addressed cache entry for tokens [64, 128).
+    blk1 = int(table[0, 1].item())
+    torch.testing.assert_close(ssm_all[blk1], ssm_s.to(ssm_all.dtype))
+
+
+@pytest.mark.parametrize("packed", [True, False])
+def test_prefill_then_decode_matches_single_prefill(packed):
+    """Continuation parity across a boundary: all-mode prefill of 120 tokens
+    followed by 16 single-token decode steps (crossing the 128 boundary) must
+    reproduce the single-shot 136-token prefill: outputs and the final block
+    state."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    total, prefill_len = 136, 120
+    mixed_qkv, b, a = harness._make_inputs(total, device)
+    cfg = harness._make_vllm_config(BLOCK, "all")
+
+    # Reference: single-shot prefill.
+    ref_batch = BatchSpec(seq_lens=[total], query_lens=[total])
+    meta_ref, common_ref = harness._build_metadata(cfg, ref_batch, BLOCK, device)
+    pool_size = int(common_ref.block_table_tensor.max().item()) + 1
+    conv_ref, ssm_ref = harness._make_pools(pool_size, torch.float32, device)
+    layer_ref = _build_decode_layer(cfg, conv_ref, ssm_ref, weights, packed)
+    out_ref = harness._run_forward_core(layer_ref, meta_ref, mixed_qkv, b, a, total)
+
+    # Prefill 120, then decode token-by-token on the same pools.
+    conv_state, ssm_state = harness._make_pools(pool_size, torch.float32, device)
+    layer = _build_decode_layer(cfg, conv_state, ssm_state, weights, packed)
+    p_batch = BatchSpec(seq_lens=[prefill_len], query_lens=[prefill_len])
+    meta_p, common_p = harness._build_metadata(cfg, p_batch, BLOCK, device)
+    torch.testing.assert_close(
+        common_p.block_table_tensor,
+        common_ref.block_table_tensor[:, : common_p.block_table_tensor.shape[1]],
+    )
+    harness._run_forward_core(
+        layer,
+        meta_p,
+        mixed_qkv[:prefill_len],
+        b[:prefill_len],
+        a[:prefill_len],
+        prefill_len,
+    )
+
+    decode_outs = []
+    for i in range(prefill_len, total):
+        d_batch = BatchSpec(seq_lens=[i + 1], query_lens=[1])
+        meta_d, _ = harness._build_metadata(cfg, d_batch, BLOCK, device)
+        assert meta_d.num_decodes == 1
+        out_d = harness._run_forward_core(
+            layer, meta_d, mixed_qkv[i : i + 1], b[i : i + 1], a[i : i + 1], 1
+        )
+        decode_outs.append(out_d)
+
+    out_decode = torch.cat(decode_outs, dim=0)
+    # Recurrent decode vs chunk prefill accumulate differently; use the
+    # kernel-parity tolerances of the forward-core split test.
+    atol = rtol = 2e-2
+    torch.testing.assert_close(out_decode, out_ref[prefill_len:], atol=atol, rtol=rtol)
+    # Final running state (block 2, after 136 tokens) must match.
+    blk2 = int(common_ref.block_table_tensor[0, 2].item())
+    torch.testing.assert_close(ssm_state[blk2], ssm_ref[blk2], atol=atol, rtol=rtol)
+    # Interior checkpoint for block 1 (boundary 128) was written by the
+    # decode path at the crossing in the continuation run, by the prefill
+    # scatter in the reference run.
+    blk1 = int(common_ref.block_table_tensor[0, 1].item())
+    torch.testing.assert_close(ssm_state[blk1], ssm_ref[blk1], atol=atol, rtol=rtol)
+
+
+def test_mixed_decode_prefill_all_mode_matches_align():
+    """The peeled decode rows of a mixed decode+prefill batch use the K2
+    dual-index; in-block (read == write) the whole batch must match align
+    bit-exactly (prefill part already proven by the prefill tests)."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    # Row 0: in-block decode (seq 101, block 1); row 1: fresh 192-token
+    # prefill (3 blocks).
+    batch = BatchSpec(seq_lens=[101, 192], query_lens=[1, 192])
+    inputs = harness._make_inputs(193, device)
+    conv_s = torch.randn_like(harness._make_pools(1, torch.float32, device)[0][0])
+    ssm_s = torch.randn_like(harness._make_pools(1, torch.float32, device)[1][0])
+
+    out_all, _, _, _ = _run_mode(
+        "all", batch, inputs, False, {(0, 1): (conv_s, ssm_s)}, weights
+    )
+    out_align, _, _, _ = _run_mode(
+        "align", batch, inputs, False, {(0, 1): (conv_s, ssm_s)}, weights
+    )
+    torch.testing.assert_close(out_all, out_align, atol=0, rtol=0)

--- a/tests/kernels/mamba/test_gdn_all_mode_decode.py
+++ b/tests/kernels/mamba/test_gdn_all_mode_decode.py
@@ -12,7 +12,7 @@ blocks in all-mode). Covered paths:
 * the packed non-spec decode fast path (``_forward_core_decode_non_spec``,
   in-place kernels -> carry-copy),
 * the non-packed decode branches in ``_forward_core`` (kernel-side dual
-  index: conv block args + K2 ``ssm_state_indices_output``),
+  index: conv block args + ``ssm_state_indices_output``),
 * the peeled decode rows of a mixed decode+prefill batch.
 
 Reuses the harness of test_gdn_all_mode_prefill (real ``_forward_core`` +
@@ -197,7 +197,7 @@ def test_prefill_then_decode_matches_single_prefill(packed):
 
 
 def test_mixed_decode_prefill_all_mode_matches_align():
-    """The peeled decode rows of a mixed decode+prefill batch use the K2
+    """The peeled decode rows of a mixed decode+prefill batch use the
     dual-index; in-block (read == write) the whole batch must match align
     bit-exactly (prefill part already proven by the prefill tests)."""
     torch.manual_seed(0)

--- a/tests/kernels/mamba/test_gdn_all_mode_prefill.py
+++ b/tests/kernels/mamba/test_gdn_all_mode_prefill.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-level tests for GDN all-mode prefill (cached-block load + per-block
+SSM checkpoint scatter) through the REAL ``_forward_core``.
+
+All-mode changes only WHERE states are cached, never WHAT is computed, so:
+
+* an all-mode prefill must produce bit-identical core-attention output to the
+  align-mode prefill on the same inputs, while additionally writing one SSM
+  checkpoint per scheduled block (interior blocks from FLA's per-chunk state
+  exports -- the +1-chunk start-of-chunk shift -- and the final block from the
+  final recurrent state);
+* continuing a sequence from a cached block boundary (warm) must match the
+  suffix of the single-shot (cold) prefill: outputs and written states.
+
+Metadata is built by the real ``GDNAttentionMetadataBuilder`` with
+``mamba_cache_mode="all"`` so the builder's block-index computation is part of
+what is being tested. The Triton/FLA prefill backend is forced: it is the only
+GDN chunk backend that exports per-chunk states.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="GDN all-mode prefill tests require CUDA (Triton/FLA kernels).",
+        allow_module_level=True,
+    )
+
+from tests.v1.attention.utils import (  # noqa: E402
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import set_current_vllm_config  # noqa: E402
+from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn  # noqa: E402
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (  # noqa: E402
+    ChunkGatedDeltaRule,
+    QwenGatedDeltaNetAttention,
+)
+from vllm.model_executor.layers.mamba.mamba_utils import (  # noqa: E402
+    MambaStateShapeCalculator,
+)
+from vllm.v1.attention.backends.gdn_attn import (  # noqa: E402
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import MambaSpec  # noqa: E402
+
+H = 4  # num key heads
+HV = 8  # num value heads
+K = 128  # head_k_dim
+V = 128  # head_v_dim
+CONV_KERNEL = 4
+KEY_DIM = H * K
+VALUE_DIM = HV * V
+CONV_DIM = 2 * KEY_DIM + VALUE_DIM
+PREFIX = "model.layers.0.linear_attn"
+
+
+def _make_vllm_config(mamba_block_size: int, mamba_cache_mode: str):
+    cfg = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B",
+        block_size=mamba_block_size,
+    )
+    # The Triton/FLA chunk kernel is the only backend with per-chunk state
+    # export (all-mode); force it for both modes so outputs are comparable.
+    cfg.additional_config = {"gdn_prefill_backend": "triton"}
+    cfg.cache_config.mamba_cache_mode = mamba_cache_mode
+    cfg.cache_config.mamba_block_size = mamba_block_size
+    return cfg
+
+
+def _build_layer(vllm_config, mamba_block_size, conv_state, ssm_state, weights):
+    """A minimal object that runs the real ``_forward_core`` bound to it."""
+    A_log, dt_bias, conv_weight, conv_bias = weights
+    layer = types.SimpleNamespace()
+    layer.prefix = PREFIX
+    layer.enable_packed_recurrent_decode = False
+    layer.tp_size = 1
+    layer.num_k_heads = H
+    layer.num_v_heads = HV
+    layer.head_k_dim = K
+    layer.head_v_dim = V
+    layer.key_dim = KEY_DIM
+    layer.value_dim = VALUE_DIM
+    layer.activation = "silu"
+    layer.A_log = A_log
+    layer.dt_bias = dt_bias
+    layer.conv1d = types.SimpleNamespace(weight=conv_weight, bias=conv_bias)
+    layer.kv_cache = (conv_state, ssm_state)
+    layer.cache_config = types.SimpleNamespace(mamba_block_size=mamba_block_size)
+    with set_current_vllm_config(vllm_config):
+        layer.chunk_gated_delta_rule = ChunkGatedDeltaRule()
+    assert layer.chunk_gated_delta_rule.gdn_prefill_backend == "triton"
+    for name in ("rearrange_mixed_qkv", "_forward_core"):
+        setattr(
+            layer,
+            name,
+            types.MethodType(getattr(QwenGatedDeltaNetAttention, name), layer),
+        )
+    return layer
+
+
+def _build_metadata(vllm_config, batch, mamba_block_size, device):
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=mamba_block_size,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+        ),
+        layer_names=[PREFIX],
+        vllm_config=vllm_config,
+        device=device,
+    )
+    common = create_common_attn_metadata(
+        batch, mamba_block_size, device, arange_block_indices=True
+    )
+    # Block id 0 is the reserved NULL block (NULL_BLOCK_ID): the conv kernel
+    # skips any sequence whose gathered state index is 0. Real block tables
+    # never contain it; shift the synthetic arange table to match.
+    common.block_table_tensor.add_(1)
+    with set_current_vllm_config(vllm_config):
+        meta = builder.build(common_prefix_len=0, common_attn_metadata=common)
+    return meta, common
+
+
+def _run_forward_core(layer, meta, mixed_qkv, b, a, num_tokens):
+    core_attn_out = torch.zeros(
+        num_tokens, HV, V, dtype=mixed_qkv.dtype, device=mixed_qkv.device
+    )
+    ctx = types.SimpleNamespace(attn_metadata={PREFIX: meta})
+    with patch.object(qwen_gdn_linear_attn, "get_forward_context", return_value=ctx):
+        layer._forward_core(
+            mixed_qkv=mixed_qkv.clone(),
+            b=b.clone(),
+            a=a.clone(),
+            core_attn_out=core_attn_out,
+        )
+    return core_attn_out
+
+
+def _make_weights(device):
+    A_log = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
+    dt_bias = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
+    conv_weight = (
+        torch.randn(CONV_DIM, 1, CONV_KERNEL, dtype=torch.bfloat16, device=device) * 0.1
+    )
+    conv_bias = torch.randn(CONV_DIM, dtype=torch.bfloat16, device=device) * 0.1
+    return A_log, dt_bias, conv_weight, conv_bias
+
+
+def _make_pools(pool_size, state_dtype, device):
+    conv_shape, ssm_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
+        1, H, HV, K, V, CONV_KERNEL, num_spec=0
+    )
+    conv_state = torch.zeros(
+        pool_size, *conv_shape, dtype=torch.bfloat16, device=device
+    )
+    ssm_state = torch.zeros(pool_size, *ssm_shape, dtype=state_dtype, device=device)
+    return conv_state, ssm_state
+
+
+def _make_inputs(num_tokens, device):
+    mixed_qkv = (
+        torch.randn(num_tokens, CONV_DIM, dtype=torch.bfloat16, device=device) * 0.1
+    )
+    a = torch.randn(num_tokens, HV, dtype=torch.bfloat16, device=device) * 0.1
+    b = torch.randn(num_tokens, HV, dtype=torch.bfloat16, device=device) * 0.1
+    return mixed_qkv, b, a
+
+
+def test_all_mode_prefill_matches_align_and_writes_interior_checkpoints():
+    """All-mode cold prefill: identical outputs to align mode; interior
+    per-block checkpoints written (align leaves them untouched); final block
+    state identical across modes."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    mamba_block_size = 64
+    # Two fresh prefills; 320 = 5 blocks, 192 = 3 blocks.
+    batch = BatchSpec(seq_lens=[320, 192], query_lens=[320, 192])
+    num_tokens = 512
+    weights = _make_weights(device)
+    mixed_qkv, b, a = _make_inputs(num_tokens, device)
+
+    outs, pools, metas = {}, {}, {}
+    for mode in ("align", "all"):
+        cfg = _make_vllm_config(mamba_block_size, mode)
+        meta, common = _build_metadata(cfg, batch, mamba_block_size, device)
+        pool_size = int(common.block_table_tensor.max().item()) + 1
+        conv_state, ssm_state = _make_pools(pool_size, torch.float32, device)
+        layer = _build_layer(cfg, mamba_block_size, conv_state, ssm_state, weights)
+        outs[mode] = _run_forward_core(layer, meta, mixed_qkv, b, a, num_tokens)
+        pools[mode] = (conv_state, ssm_state)
+        metas[mode] = (meta, common)
+
+    meta_all, common_all = metas["all"]
+    assert meta_all.all_state_indices_tensor is not None
+    # Same computation, different cache placement: outputs bit-identical.
+    torch.testing.assert_close(outs["all"], outs["align"], atol=0, rtol=0)
+
+    block_table = common_all.block_table_tensor
+    ssm_align, ssm_all = pools["align"][1], pools["all"][1]
+    # Final blocks (seq0: idx 4, seq1: idx 2) hold the final state in BOTH
+    # modes (align writes it via its sliced table, all via the scatter).
+    for seq, last_idx in ((0, 4), (1, 2)):
+        blk = int(block_table[seq, last_idx].item())
+        torch.testing.assert_close(ssm_all[blk], ssm_align[blk], atol=0, rtol=0)
+    # Interior blocks: written only by all-mode.
+    for seq, interior in ((0, (0, 1, 2, 3)), (1, (0, 1))):
+        for j in interior:
+            blk = int(block_table[seq, j].item())
+            assert ssm_align[blk].abs().max().item() == 0.0
+            assert ssm_all[blk].abs().max().item() > 0.0
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("mamba_block_size", [64, 128])
+def test_all_mode_cold_warm_parity(state_dtype, mamba_block_size):
+    """The 8a acceptance: resuming from a cached block boundary reproduces the
+    cold run's suffix outputs and block states (interior mapping exact for
+    chunk-stride 1 and 2)."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    total = 5 * mamba_block_size
+    cached = 3 * mamba_block_size
+    suffix = total - cached
+    weights = _make_weights(device)
+    mixed_qkv, b, a = _make_inputs(total, device)
+    cfg = _make_vllm_config(mamba_block_size, "all")
+
+    # Cold: single-shot full prefill.
+    cold_batch = BatchSpec(seq_lens=[total], query_lens=[total])
+    meta_cold, common_cold = _build_metadata(cfg, cold_batch, mamba_block_size, device)
+    pool_size = int(common_cold.block_table_tensor.max().item()) + 1
+    conv_state, ssm_state = _make_pools(pool_size, state_dtype, device)
+    layer = _build_layer(cfg, mamba_block_size, conv_state, ssm_state, weights)
+    out_cold = _run_forward_core(layer, meta_cold, mixed_qkv, b, a, total)
+    ssm_cold = ssm_state.clone()
+
+    # Warm: continue the last `suffix` tokens on the same pools, as if the
+    # first `cached` tokens hit the prefix cache.
+    warm_batch = BatchSpec(seq_lens=[total], query_lens=[suffix])
+    meta_warm, common_warm = _build_metadata(cfg, warm_batch, mamba_block_size, device)
+    torch.testing.assert_close(
+        common_warm.block_table_tensor, common_cold.block_table_tensor
+    )
+    assert meta_warm.num_computed_tokens.tolist() == [cached]
+    out_warm = _run_forward_core(
+        layer, meta_warm, mixed_qkv[cached:], b[cached:], a[cached:], suffix
+    )
+
+    # Chunk-aligned resume follows the same accumulation order as the cold
+    # suffix; the only divergence is the checkpoint's round-trip through the
+    # pool dtype.
+    if state_dtype == torch.float32:
+        atol = rtol = 2e-3
+    else:
+        atol = rtol = 4e-2
+    torch.testing.assert_close(out_warm, out_cold[cached:], atol=atol, rtol=rtol)
+
+    # Re-written blocks (the ones at/after the resume point) match the cold
+    # run's checkpoints.
+    block_table = common_cold.block_table_tensor
+    for j in range(cached // mamba_block_size, 5):
+        blk = int(block_table[0, j].item())
+        torch.testing.assert_close(ssm_state[blk], ssm_cold[blk], atol=atol, rtol=rtol)
+
+
+def test_all_mode_interior_checkpoint_equals_shorter_prefill_final_state():
+    """The +1-chunk shift, independently verified: the block-j interior
+    checkpoint of a long prefill equals the FINAL state of a fresh prefill
+    truncated at that block boundary."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    mamba_block_size = 64
+    long_len = 5 * mamba_block_size
+    short_len = 4 * mamba_block_size  # ends exactly at block 3's boundary
+    weights = _make_weights(device)
+    mixed_qkv, b, a = _make_inputs(long_len, device)
+    cfg = _make_vllm_config(mamba_block_size, "all")
+
+    def run(seq_len):
+        batch = BatchSpec(seq_lens=[seq_len], query_lens=[seq_len])
+        meta, common = _build_metadata(cfg, batch, mamba_block_size, device)
+        pool_size = int(common.block_table_tensor.max().item()) + 1
+        conv_state, ssm_state = _make_pools(pool_size, torch.float32, device)
+        layer = _build_layer(cfg, mamba_block_size, conv_state, ssm_state, weights)
+        _run_forward_core(
+            layer, meta, mixed_qkv[:seq_len], b[:seq_len], a[:seq_len], seq_len
+        )
+        return ssm_state, common.block_table_tensor
+
+    ssm_long, table_long = run(long_len)
+    ssm_short, table_short = run(short_len)
+
+    # Long run's interior checkpoint for block 3 (boundary at 256 tokens)
+    # vs short run's final state (written from last_recurrent_state). The two
+    # runs use different chunk grids (5 vs 4 chunks), so tiny accumulation
+    # noise is expected; an off-by-one-chunk shift would differ by a full
+    # chunk of state updates (orders of magnitude above this tolerance).
+    blk_long = int(table_long[0, 3].item())
+    blk_short = int(table_short[0, 3].item())
+    torch.testing.assert_close(
+        ssm_long[blk_long], ssm_short[blk_short], atol=5e-4, rtol=5e-3
+    )
+
+
+def test_chunk_wrapper_rejects_intermediate_states_on_non_triton():
+    """FlashInfer/CuteDSL chunk backends cannot export per-chunk states; the
+    wrapper must fail fast rather than silently skip checkpoints."""
+    for fwd in (
+        ChunkGatedDeltaRule.forward_cuda,
+        ChunkGatedDeltaRule.forward_cutedsl,
+    ):
+        with pytest.raises(AssertionError):
+            fwd(
+                None,  # self: unused before the assert
+                q=None,
+                k=None,
+                v=None,
+                g=None,
+                beta=None,
+                initial_state=None,
+                output_final_state=True,
+                return_intermediate_states=True,
+            )
+
+
+def test_backend_resolver_allows_triton_for_all_mode():
+    """Requesting Triton with all-mode resolves cleanly on any platform."""
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+        _resolve_gdn_prefill_backend,
+    )
+
+    cfg = _make_vllm_config(64, "all")
+    requested, active = _resolve_gdn_prefill_backend(cfg)
+    assert (requested, active) == ("triton", "triton")
+
+
+def test_backend_resolver_auto_prefers_triton_for_all_mode():
+    """'auto' + all-mode must resolve to Triton on every platform (all-mode
+    is the default for supporting models with prefix caching on, so 'auto'
+    configs must keep working rather than fail the explicit-backend guard)."""
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+        _resolve_gdn_prefill_backend,
+    )
+
+    cfg = _make_vllm_config(64, "all")
+    cfg.additional_config = {}
+    requested, active = _resolve_gdn_prefill_backend(cfg)
+    assert (requested, active) == ("auto", "triton")
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="CuteDSL GDN prefill resolves only on SM10x",
+)
+def test_backend_resolver_rejects_non_triton_for_all_mode():
+    """A non-Triton GDN prefill backend cannot export per-chunk states:
+    all-mode must fail fast at backend resolution (startup), not with a
+    kernel assert on the first real prefill. Align mode keeps its choice."""
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+        _resolve_gdn_prefill_backend,
+    )
+
+    def cutedsl_cfg(mode):
+        cfg = create_vllm_config(
+            model_name="Qwen/Qwen3.5-0.8B",
+            block_size=64,
+            hf_config_override={"linear_key_head_dim": 128},
+        )
+        cfg.additional_config = {"gdn_prefill_backend": "cutedsl"}
+        cfg.cache_config.mamba_cache_mode = mode
+        return cfg
+
+    with pytest.raises(ValueError, match="Triton/FLA"):
+        _resolve_gdn_prefill_backend(cutedsl_cfg("all"))
+
+    _, active = _resolve_gdn_prefill_backend(cutedsl_cfg("align"))
+    assert active == "cutedsl"

--- a/tests/kernels/mamba/test_gdn_all_mode_spec_decode.py
+++ b/tests/kernels/mamba/test_gdn_all_mode_spec_decode.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-level tests for GDN all-mode speculative decode (dual anchor).
+
+All-mode spec decode gathers per-spec-token state slots from the full block
+table: READ slots at the previous step's last-scheduled anchor + [0..num_spec]
+(where that step wrote its per-token states; the kernel picks the resume slot
+via num_accepted_tokens), WRITE slots at the current last-scheduled anchor +
+[0..num_spec]. The spec conv reads its initial state from the last computed
+block and writes to the last scheduled block in-kernel.
+
+Align mode's sliced spec table addresses the same physical blocks whenever the
+anchors are in-block, so all-vs-align must be bit-identical there; at a
+boundary crossing the read window shifts to the previous anchor and the two
+modes are compared with equivalently seeded state sequences (the slot the
+kernel selects is the same in both).
+
+Reuses the harness of test_gdn_all_mode_prefill (real ``_forward_core`` +
+real ``GDNAttentionMetadataBuilder`` metadata on GPU).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="GDN all-mode spec tests require CUDA (Triton/FLA kernels).",
+        allow_module_level=True,
+    )
+
+from tests.kernels.mamba import test_gdn_all_mode_prefill as harness  # noqa: E402
+from tests.v1.attention.utils import (  # noqa: E402
+    BatchSpec,
+    create_common_attn_metadata,
+)
+from vllm.config import SpeculativeConfig, set_current_vllm_config  # noqa: E402
+from vllm.v1.attention.backends.gdn_attn import (  # noqa: E402
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import MambaSpec  # noqa: E402
+
+BLOCK = 64
+NUM_SPEC = 2
+
+
+def _make_spec_config(mode):
+    cfg = harness._make_vllm_config(BLOCK, mode)
+    cfg.speculative_config = SpeculativeConfig(
+        method="ngram", num_speculative_tokens=NUM_SPEC
+    )
+    return cfg
+
+
+def _build_spec_metadata(cfg, batch, device, drafts, accepted, prev=None):
+    """Build spec metadata on a table widened by the speculative blocks
+    (real tables carry num_speculative_blocks extra columns; the synthetic
+    arange table must too, or the anchor+offset gathers go out of range)."""
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            num_speculative_blocks=NUM_SPEC,
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=device,
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK, device, arange_block_indices=True
+    )
+    table = common.block_table_tensor
+    n, w = table.shape
+    extra = torch.arange(n * NUM_SPEC, dtype=table.dtype, device=table.device).reshape(
+        n, NUM_SPEC
+    ) + int(table.max().item() + 1)
+    common.block_table_tensor = torch.cat([table, extra], dim=1)
+    # Shift past the reserved NULL block (id 0), as in the base harness.
+    common.block_table_tensor.add_(1)
+    kwargs = {
+        "num_decode_draft_tokens_cpu": torch.tensor(drafts, dtype=torch.int32),
+        "num_accepted_tokens": torch.tensor(accepted, dtype=torch.int32, device=device),
+    }
+    if prev is not None:
+        kwargs["prev_last_scheduled_idx"] = torch.tensor(
+            prev, dtype=torch.int32, device=device
+        )
+    with set_current_vllm_config(cfg):
+        meta = builder.build(common_prefix_len=0, common_attn_metadata=common, **kwargs)
+    return meta, common
+
+
+def _build_spec_layer(cfg, conv_state, ssm_state, weights):
+    layer = harness._build_layer(cfg, BLOCK, conv_state, ssm_state, weights)
+    layer.num_spec = NUM_SPEC
+    layer._decode_state_offsets = torch.arange(
+        1 + NUM_SPEC, dtype=torch.int64, device=ssm_state.device
+    ).unsqueeze(0)
+    return layer
+
+
+def _run_spec(mode, batch, inputs, weights, drafts, accepted, seed_blocks, prev=None):
+    """seed_blocks: (seq_row, table_col) -> (conv, ssm) states to pre-place."""
+    device = torch.device("cuda")
+    mixed_qkv, b, a = inputs
+    num_tokens = mixed_qkv.shape[0]
+    cfg = _make_spec_config(mode)
+    meta, common = _build_spec_metadata(cfg, batch, device, drafts, accepted, prev)
+    pool_size = int(common.block_table_tensor.max().item()) + 1
+    conv_state, ssm_state = harness._make_pools(pool_size, torch.float32, device)
+    for (seq, col), (conv_src, ssm_src) in seed_blocks.items():
+        blk = int(common.block_table_tensor[seq, col].item())
+        if conv_src is not None:
+            conv_state[blk] = conv_src
+        if ssm_src is not None:
+            ssm_state[blk] = ssm_src
+    layer = _build_spec_layer(cfg, conv_state, ssm_state, weights)
+    out = harness._run_forward_core(layer, meta, mixed_qkv, b, a, num_tokens)
+    return out, conv_state, ssm_state, common.block_table_tensor
+
+
+def _rand_states(device, n):
+    conv0 = harness._make_pools(1, torch.float32, device)
+    return [
+        (torch.randn_like(conv0[0][0]), torch.randn_like(conv0[1][0])) for _ in range(n)
+    ]
+
+
+def test_spec_in_block_matches_align():
+    """First spec step inside a block: read anchor == write anchor == align's
+    sliced table; all-vs-align must be bit-identical (outputs and the written
+    per-token states)."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    # seq 103, 3 spec tokens: ncomp=100 -> anchors all in block 1; slots
+    # [1, 2, 3] in both modes.
+    batch = BatchSpec(seq_lens=[103], query_lens=[3])
+    inputs = harness._make_inputs(3, device)
+    (conv_c, _), *states = _rand_states(device, 4)
+    seeds = {
+        (0, 1): (conv_c, states[0][1]),
+        (0, 2): (None, states[1][1]),
+        (0, 3): (None, states[2][1]),
+    }
+
+    out_all, _, ssm_all, table = _run_spec(
+        "all", batch, inputs, weights, [NUM_SPEC], [2], seeds
+    )
+    out_align, _, ssm_align, _ = _run_spec(
+        "align", batch, inputs, weights, [NUM_SPEC], [2], seeds
+    )
+    torch.testing.assert_close(out_all, out_align, atol=0, rtol=0)
+    for col in (1, 2, 3):
+        blk = int(table[0, col].item())
+        torch.testing.assert_close(ssm_all[blk], ssm_align[blk], atol=0, rtol=0)
+
+
+def test_spec_crossing_reads_prev_anchor():
+    """Spec step just after a block-boundary crossing: the read window sits at
+    the PREVIOUS step's anchor (plumbed via prev_last_scheduled_idx), the
+    write window at the current anchor. Equivalently-seeded align run (same
+    state sequence at its own read window) must match bit-exactly."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    # ncomp=129 (crossed 128), 3 spec tokens -> seq 132. Current anchor =
+    # block 2 (write slots [2, 3, 4]); previous step's anchor = 1 (read slots
+    # [1, 2, 3]). Align reads and writes at its sliced window [2, 3, 4].
+    batch = BatchSpec(seq_lens=[132], query_lens=[3])
+    inputs = harness._make_inputs(3, device)
+    (conv_c, _), *states = _rand_states(device, 4)
+    s0, s1, s2 = (s[1] for s in states)
+
+    # all-mode: prev-step states at cols [1, 2, 3]; conv state at the last
+    # computed block (col 2).
+    out_all, _, ssm_all, table = _run_spec(
+        "all",
+        batch,
+        inputs,
+        weights,
+        [NUM_SPEC],
+        [2],
+        {(0, 1): (None, s0), (0, 2): (conv_c, s1), (0, 3): (None, s2)},
+        prev=[1],
+    )
+    # align: the same state sequence at its read window [2, 3, 4]; conv state
+    # in its current block (col 2).
+    out_align, _, ssm_align, _ = _run_spec(
+        "align",
+        batch,
+        inputs,
+        weights,
+        [NUM_SPEC],
+        [2],
+        {(0, 2): (conv_c, s0), (0, 3): (None, s1), (0, 4): (None, s2)},
+    )
+    torch.testing.assert_close(out_all, out_align, atol=0, rtol=0)
+    # Both modes write the new per-token states at cols [2, 3, 4].
+    for col in (2, 3, 4):
+        blk = int(table[0, col].item())
+        torch.testing.assert_close(ssm_all[blk], ssm_align[blk], atol=0, rtol=0)
+    # The all-mode read-window head (col 1) keeps its checkpoint: it is the
+    # APC entry for its token range.
+    blk1 = int(table[0, 1].item())
+    torch.testing.assert_close(ssm_all[blk1], s0.to(ssm_all.dtype))
+
+
+def test_spec_pure_batch_uses_request_level_tensors():
+    """Pure-spec batch (the cudagraph-captured shape) takes the full
+    request-level tensor path — two rows, both in-block, must match align
+    bit-exactly."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    # Rows: seq 103 (anchors block 1) and seq 231 (anchors block 3).
+    batch = BatchSpec(seq_lens=[103, 231], query_lens=[3, 3])
+    inputs = harness._make_inputs(6, device)
+    st = _rand_states(device, 8)
+    seeds = {}
+    for i, col in enumerate((1, 2, 3)):
+        seeds[(0, col)] = (st[i][0] if col == 1 else None, st[i][1])
+    for i, col in enumerate((3, 4, 5)):
+        seeds[(1, col)] = (st[4 + i][0] if col == 3 else None, st[4 + i][1])
+
+    out_all, _, ssm_all, table = _run_spec(
+        "all", batch, inputs, weights, [NUM_SPEC, NUM_SPEC], [2, 1], seeds
+    )
+    out_align, _, ssm_align, _ = _run_spec(
+        "align", batch, inputs, weights, [NUM_SPEC, NUM_SPEC], [2, 1], seeds
+    )
+    torch.testing.assert_close(out_all, out_align, atol=0, rtol=0)
+    for seq, cols in ((0, (1, 2, 3)), (1, (3, 4, 5))):
+        for col in cols:
+            blk = int(table[seq, col].item())
+            torch.testing.assert_close(ssm_all[blk], ssm_align[blk], atol=0, rtol=0)
+
+
+def test_spec_mixed_with_prefill_matches_align():
+    """Mixed spec + prefill batch (eager): the spec rows are boolean-selected
+    from the request-level tensors; whole-batch outputs must match align
+    bit-exactly (the prefill half is covered by the prefill tests)."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    weights = harness._make_weights(device)
+    # Row 0: fresh 192-token prefill; row 1: in-block spec row (seq 103).
+    batch = BatchSpec(seq_lens=[192, 103], query_lens=[192, 3])
+    inputs = harness._make_inputs(195, device)
+    (conv_c, _), *states = _rand_states(device, 4)
+    seeds = {
+        (1, 1): (conv_c, states[0][1]),
+        (1, 2): (None, states[1][1]),
+        (1, 3): (None, states[2][1]),
+    }
+
+    out_all, _, _, _ = _run_spec(
+        "all", batch, inputs, weights, [-1, NUM_SPEC], [1, 2], seeds
+    )
+    out_align, _, _, _ = _run_spec(
+        "align", batch, inputs, weights, [-1, NUM_SPEC], [1, 2], seeds
+    )
+    torch.testing.assert_close(out_all, out_align, atol=0, rtol=0)

--- a/tests/kernels/mamba/test_gdn_hoist_mask_selects.py
+++ b/tests/kernels/mamba/test_gdn_hoist_mask_selects.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ``VLLM_GDN_HOIST_MASK_SELECTS`` — the all-mode mixed-batch
+mask-select hoist (host-sync attribution doc, component 1).
+
+In mixed (spec + prefill) eager batches every GDN layer boolean-indexed
+request-level metadata with the DEVICE spec mask; each such select runs
+torch.nonzero -> count DtoH + cudaStreamSynchronize (9-11 per layer, 324+
+per prefill-containing step). The builder now pre-selects the row slices
+once per step with the already-available CPU mask (sync-free). Tests:
+
+- builder: hoisted slices bit-equal the device-mask selects; populated only
+  for mixed batches with the flag on (pure-spec / nospec / prefill-only and
+  flag-off builds keep them None).
+- layer: the real ``_forward_core`` on flag-on vs flag-off metadata is
+  bit-identical, and the layer performs ZERO CUDA-bool-mask index ops under
+  the flag (dispatch counter) vs >= 9 without it.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="GDN mask-hoist tests require CUDA (Triton/FLA kernels).",
+        allow_module_level=True,
+    )
+
+from tests.kernels.mamba import test_gdn_all_mode_prefill as harness  # noqa: E402
+from tests.kernels.mamba import (  # noqa: E402
+    test_gdn_all_mode_spec_decode as spec_harness,
+)
+from tests.kernels.mamba.test_gdn_index_prep import (  # noqa: E402
+    _prep_from_common,
+    _run_layer_with_meta,
+)
+from tests.v1.attention.utils import BatchSpec  # noqa: E402
+from vllm.config import set_current_vllm_config  # noqa: E402
+
+DEVICE = torch.device("cuda")
+BLOCK = spec_harness.BLOCK
+NUM_SPEC = spec_harness.NUM_SPEC
+
+MIXED_BATCH = BatchSpec(seq_lens=[192, 103], query_lens=[192, 3])
+MIXED_DRAFTS = [-1, NUM_SPEC]
+MIXED_ACCEPTED = [1, 2]
+MIXED_PREV = [-1, 1]
+
+SEL_FIELDS = (
+    ("ns_all_state_indices_sel", "all_state_indices_tensor", False),
+    ("ns_block_idx_last_computed_sel", "block_idx_last_computed_token", False),
+    (
+        "ns_block_idx_first_scheduled_sel",
+        "block_idx_first_scheduled_token",
+        False,
+    ),
+    ("ns_block_idx_last_scheduled_sel", "block_idx_last_scheduled_token", False),
+    ("ns_num_computed_tokens_sel", "num_computed_tokens", False),
+    ("spec_all_state_indices_sel", "all_state_indices_tensor", True),
+    ("spec_block_idx_last_scheduled_sel", "block_idx_last_scheduled_token", True),
+    ("spec_block_idx_last_computed_sel", "block_idx_last_computed_token", True),
+    (
+        "spec_block_idx_prev_step_sel",
+        "block_idx_last_scheduled_token_prev_step",
+        True,
+    ),
+    ("spec_block_idx_packed_anchors_sel", "block_idx_packed_anchors", True),
+    (
+        "spec_block_idx_packed_anchors_spec_sel",
+        "block_idx_packed_anchors_spec",
+        True,
+    ),
+)
+
+
+class _CudaBoolIndexCounter(TorchDispatchMode):
+    """Counts aten.index.Tensor calls indexed by a CUDA bool tensor — the
+    dispatch-level signature of the device-mask selects whose internal
+    nonzero forces the DtoH + streamSync."""
+
+    def __init__(self):
+        super().__init__()
+        self.count = 0
+
+    def __torch_dispatch__(self, func, types_, args=(), kwargs=None):
+        if func.overloadpacket.__name__ == "index":
+            indices = args[1] if len(args) > 1 else ()
+            for t in indices or ():
+                if (
+                    isinstance(t, torch.Tensor)
+                    and t.is_cuda
+                    and t.dtype == torch.bool
+                ):
+                    self.count += 1
+                    break
+        return func(*args, **(kwargs or {}))
+
+
+def _build_mixed(monkeypatch, hoist, with_prep):
+    cfg = spec_harness._make_spec_config("all")
+    monkeypatch.setenv("VLLM_GDN_HOIST_MASK_SELECTS", "1" if hoist else "0")
+    meta, common = _build_spec_meta(
+        cfg, MIXED_BATCH, MIXED_DRAFTS, MIXED_ACCEPTED, MIXED_PREV, with_prep
+    )
+    return cfg, meta, common
+
+
+def _build_spec_meta(cfg, batch, drafts, accepted, prev, with_prep):
+    from tests.v1.attention.utils import create_common_attn_metadata
+    from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            num_speculative_blocks=NUM_SPEC,
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=DEVICE,
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK, DEVICE, arange_block_indices=True
+    )
+    table = common.block_table_tensor
+    n, _ = table.shape
+    extra = torch.arange(
+        n * NUM_SPEC, dtype=table.dtype, device=table.device
+    ).reshape(n, NUM_SPEC) + int(table.max().item() + 1)
+    common.block_table_tensor = torch.cat([table, extra], dim=1)
+    common.block_table_tensor.add_(1)
+    prev_t = torch.tensor(prev, dtype=torch.int32, device=DEVICE)
+    kwargs = dict(
+        num_decode_draft_tokens_cpu=torch.tensor(drafts, dtype=torch.int32),
+        num_accepted_tokens=torch.tensor(
+            accepted, dtype=torch.int32, device=DEVICE
+        ),
+        prev_last_scheduled_idx=prev_t,
+    )
+    if with_prep:
+        kwargs["block_idx_prep"] = _prep_from_common(common, prev_t, BLOCK)
+    with set_current_vllm_config(cfg):
+        meta = builder.build(0, common, **kwargs)
+    return meta, common
+
+
+@pytest.mark.parametrize("with_prep", [False, True])
+def test_builder_hoisted_selects_match_device_mask(monkeypatch, with_prep):
+    """Every hoisted slice is bit-equal to the device-mask select of the
+    corresponding unselected field (spec and non-spec sides), with and
+    without the CS1 prep buffers (packed-anchor slices)."""
+    torch.manual_seed(0)
+    _, meta, _ = _build_mixed(monkeypatch, hoist=True, with_prep=with_prep)
+    assert meta.spec_sequence_masks is not None
+    mask = meta.spec_sequence_masks
+    for sel_name, src_name, is_spec in SEL_FIELDS:
+        src = getattr(meta, src_name)
+        sel = getattr(meta, sel_name)
+        if src is None:
+            assert sel is None, sel_name
+            continue
+        ref = src[mask] if is_spec else src[~mask]
+        assert sel is not None, sel_name
+        assert torch.equal(sel, ref), sel_name
+        assert not sel.is_cpu
+
+
+def test_builder_hoist_only_for_mixed_batches(monkeypatch):
+    """Flag off, pure-spec, prefill-only and nospec builds keep every
+    hoisted field None."""
+    torch.manual_seed(0)
+    # Flag off on a mixed batch.
+    _, meta, _ = _build_mixed(monkeypatch, hoist=False, with_prep=False)
+    for sel_name, _, _ in SEL_FIELDS:
+        assert getattr(meta, sel_name) is None, sel_name
+    monkeypatch.setenv("VLLM_GDN_HOIST_MASK_SELECTS", "1")
+    # Pure-spec batch (no prefills).
+    cfg = spec_harness._make_spec_config("all")
+    meta, _ = _build_spec_meta(
+        cfg,
+        BatchSpec(seq_lens=[103, 231], query_lens=[3, 3]),
+        [NUM_SPEC, NUM_SPEC],
+        [2, 1],
+        [1, -1],
+        False,
+    )
+    for sel_name, _, _ in SEL_FIELDS:
+        assert getattr(meta, sel_name) is None, sel_name
+    # Nospec mixed decode+prefill and prefill-only (no spec mask at all).
+    from tests.v1.attention.utils import create_common_attn_metadata
+    from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    cfg_ns = harness._make_vllm_config(BLOCK, "all")
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK, shapes=((16, 64),), dtypes=(torch.float16,)
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg_ns,
+        device=DEVICE,
+    )
+    for batch in (
+        BatchSpec(seq_lens=[101, 192], query_lens=[1, 192]),
+        BatchSpec(seq_lens=[320], query_lens=[320]),
+    ):
+        common = create_common_attn_metadata(
+            batch, BLOCK, DEVICE, arange_block_indices=True
+        )
+        common.block_table_tensor.add_(1)
+        with set_current_vllm_config(cfg_ns):
+            meta = builder.build(0, common)
+        for sel_name, _, _ in SEL_FIELDS:
+            assert getattr(meta, sel_name) is None, sel_name
+
+
+@pytest.mark.parametrize("with_prep", [False, True])
+def test_layer_mixed_parity_and_zero_device_mask_selects(
+    monkeypatch, with_prep
+):
+    """The real _forward_core on flag-on metadata is bit-identical to the
+    flag-off run, and performs ZERO CUDA-bool-mask index ops (vs >= 9
+    without the hoist)."""
+    torch.manual_seed(0)
+    weights = harness._make_weights(DEVICE)
+    inputs = harness._make_inputs(195, DEVICE)
+    (conv_c, _), *states = spec_harness._rand_states(DEVICE, 4)
+    seeds = {
+        (1, 1): (conv_c, states[0][1]),
+        (1, 2): (None, states[1][1]),
+        (1, 3): (None, states[2][1]),
+    }
+
+    cfg, meta_off, common = _build_mixed(
+        monkeypatch, hoist=False, with_prep=with_prep
+    )
+    with _CudaBoolIndexCounter() as c_off:
+        out_off, conv_off, ssm_off = _run_layer_with_meta(
+            cfg, meta_off, common, inputs, weights, seeds, num_spec=NUM_SPEC
+        )
+    assert c_off.count >= 9
+
+    cfg, meta_on, common = _build_mixed(
+        monkeypatch, hoist=True, with_prep=with_prep
+    )
+    with _CudaBoolIndexCounter() as c_on:
+        out_on, conv_on, ssm_on = _run_layer_with_meta(
+            cfg, meta_on, common, inputs, weights, seeds, num_spec=NUM_SPEC
+        )
+    assert c_on.count == 0
+
+    assert torch.equal(out_on, out_off)
+    assert torch.equal(conv_on, conv_off)
+    assert torch.equal(ssm_on, ssm_off)

--- a/tests/kernels/mamba/test_gdn_index_prep.py
+++ b/tests/kernels/mamba/test_gdn_index_prep.py
@@ -1,0 +1,971 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CS1 tests for the GDN all-mode block-index prep kernel + A3 table-walk
+trims (design doc allmode_decode_opt_design.md, tests T1-T12).
+
+- T1-T5: the fused prep kernel reproduces the eager anchor chain
+  (``compute_mamba_prefix_caching_block_indices`` + the spec read-anchor
+  fallback of gdn_attn.py) elementwise (torch.equal) across block sizes,
+  boundary patterns, prev/fallback resolution and padded rows.
+- T6: ``GDNAttentionMetadataBuilder.build()`` with the shared prep buffers
+  supplied is field-bit-identical to the eager build, and issues zero
+  aten.floor_divide / aten.neg kernels (TorchDispatchMode counter); the
+  layer-level wiring (packed anchors through the real ``_forward_core``)
+  is exercised on decode and spec batches.
+- T7-T11: packed (read, write) anchor single-load parity for the three decode
+  kernels (sigmoid gating incl. the hoisted write-anchor loop, conv update
+  incl. the skip-second-lookup branch, packed recurrent decode), bit-exact
+  against the separate-anchor path (which is code-identical to the pre-change
+  kernels, constexpr-pruned) and against the host-gathered index oracle;
+  NULL rows skipped.
+- T12: wrapper assertion tests (mutual exclusivity, shape/dtype/contiguity).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="GDN index-prep tests require CUDA (Triton/FLA kernels).",
+        allow_module_level=True,
+    )
+
+from tests.kernels.mamba import test_gdn_all_mode_prefill as harness  # noqa: E402
+from tests.kernels.mamba import (  # noqa: E402
+    test_gdn_all_mode_spec_decode as spec_harness,
+)
+from tests.v1.attention.utils import (  # noqa: E402
+    BatchSpec,
+    create_common_attn_metadata,
+)
+from vllm.config import set_current_vllm_config  # noqa: E402
+from vllm.third_party.flash_linear_attention.ops import (  # noqa: E402
+    fused_sigmoid_gating_delta_rule_update,
+)
+from vllm.third_party.flash_linear_attention.ops.fused_recurrent import (  # noqa: E402
+    fused_recurrent_gated_delta_rule_packed_decode,
+)
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import (  # noqa: E402
+    causal_conv1d_update,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_index_prep import (  # noqa: E402
+    GDNBlockIdxPrepBuffers,
+)
+from vllm.v1.attention.backends.gdn_attn import (  # noqa: E402
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.attention.backends.mamba_attn import (  # noqa: E402
+    compute_mamba_prefix_caching_block_indices,
+)
+from vllm.v1.kv_cache_interface import MambaSpec  # noqa: E402
+
+DEVICE = torch.device("cuda")
+
+
+# --------------------------------------------------------------------------
+# T1-T5: prep kernel == eager anchor chain
+# --------------------------------------------------------------------------
+
+
+def _eager_chain(num_computed, seq_lens, prev, block_size):
+    """The exact eager formulas the prep kernel replaces
+    (mamba_attn.py:91-101 + gdn_attn.py:497-506)."""
+    lc, fs, ls = compute_mamba_prefix_caching_block_indices(
+        num_computed, seq_lens, block_size
+    )
+    fallback = torch.clamp((num_computed - 1) // block_size, min=0)
+    ra = torch.where(prev >= 0, prev, fallback) if prev is not None else fallback
+    return lc, fs, ls, ra
+
+
+def _run_prep(seq_lens, num_computed, prev, block_size):
+    bufs = GDNBlockIdxPrepBuffers(seq_lens.shape[0], seq_lens.device)
+    bufs.prepare(seq_lens, num_computed, prev, block_size, seq_lens.shape[0])
+    return bufs
+
+
+def _assert_prep_matches(num_computed, seq_lens, prev, block_size):
+    lc, fs, ls, ra = _eager_chain(num_computed, seq_lens, prev, block_size)
+    bufs = _run_prep(
+        seq_lens,
+        num_computed,
+        prev if prev is not None else torch.full_like(num_computed, -1),
+        block_size,
+    )
+    n = seq_lens.shape[0]
+    assert torch.equal(bufs.block_idx_last_computed_token[:n], lc)
+    assert torch.equal(bufs.block_idx_first_scheduled_token[:n], fs)
+    assert torch.equal(bufs.block_idx_last_scheduled_token[:n], ls)
+    assert torch.equal(bufs.block_idx_last_scheduled_token_prev_step[:n], ra)
+    # Packed pairs mirror the scalar outputs exactly.
+    assert torch.equal(bufs.packed_anchors[:n, 0], lc)
+    assert torch.equal(bufs.packed_anchors[:n, 1], ls)
+    assert torch.equal(bufs.packed_anchors_spec[:n, 0], ra)
+    assert torch.equal(bufs.packed_anchors_spec[:n, 1], ls)
+    return bufs
+
+
+@pytest.mark.parametrize("block_size", [2, 4, 64, 576, 1152])
+@pytest.mark.parametrize("num_reqs", [1, 2, 17, 64, 257])
+def test_prep_matches_eager_dense_grid(block_size, num_reqs):
+    """T1: elementwise formula fidelity (cdiv + clamp placement, unclamped
+    first_scheduled) over boundary-straddling num_computed patterns, T=1/4."""
+    torch.manual_seed(0)
+    b = block_size
+    pattern = [0, 1, b - 1, b, b + 1, 3 * b - 1, 3 * b, 3 * b + 1, 100 * b + 7]
+    nct = torch.tensor(
+        [pattern[i % len(pattern)] for i in range(num_reqs)],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    prev = torch.tensor(
+        [-1 if i % 3 == 0 else i % 5 for i in range(num_reqs)],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    for t in (1, 4):
+        seq_lens = nct + t
+        _assert_prep_matches(nct, seq_lens, prev, block_size)
+
+
+@pytest.mark.parametrize(
+    "block_size,nct_vals,expected",
+    [
+        # b=2, T=4: windows advancing the write anchor by 1 and 2 blocks.
+        (2, [0, 1, 2, 5], [1, 2, 2, 2]),
+        # b=4, T=4: 0-, and 1-block windows (incl. exactly-aligned starts).
+        (4, [0, 1, 4, 6], [0, 1, 1, 1]),
+    ],
+)
+def test_prep_multi_crossing_window(block_size, nct_vals, expected):
+    """T2: T=4 windows spanning 0, 1 and 2 block boundaries; the
+    last_scheduled - last_computed delta equals the crossing count the
+    decode kernels consume."""
+    t = 4
+    nct = torch.tensor(nct_vals, dtype=torch.int32, device=DEVICE)
+    seq_lens = nct + t
+    prev = torch.full_like(nct, -1)
+    bufs = _assert_prep_matches(nct, seq_lens, prev, block_size)
+    n = nct.shape[0]
+    crossings = bufs.block_idx_last_scheduled_token[
+        :n
+    ] - bufs.block_idx_last_computed_token[:n]
+    assert crossings.tolist() == expected
+
+
+def test_prep_first_block_edge():
+    """T3: request birth (num_computed=0, prev=-1) clamps last_computed and
+    the fallback to 0; seq_len=0 rows clamp last_scheduled to 0."""
+    nct = torch.tensor([0, 0, 0], dtype=torch.int32, device=DEVICE)
+    seq_lens = torch.tensor([1, 4, 0], dtype=torch.int32, device=DEVICE)
+    prev = torch.tensor([-1, -1, -1], dtype=torch.int32, device=DEVICE)
+    bufs = _assert_prep_matches(nct, seq_lens, prev, 4)
+    assert bufs.block_idx_last_computed_token[:3].tolist() == [0, 0, 0]
+    assert bufs.block_idx_last_scheduled_token_prev_step[:3].tolist() == [0, 0, 0]
+    assert bufs.block_idx_last_scheduled_token[:3].tolist() == [0, 0, 0]
+
+
+def test_prep_spec_prev_fallback_resolution():
+    """T4: where(prev >= 0, prev, clamp((nct-1)//B, 0)) reproduced for
+    all-fallback, all-tracked and mixed prev vectors."""
+    nct = torch.tensor([0, 5, 128, 129, 300], dtype=torch.int32, device=DEVICE)
+    seq_lens = nct + 4
+    for prev_vals in (
+        [-1, -1, -1, -1, -1],
+        [3, 0, 1, 2, 4],
+        [-1, 2, -1, 0, -1],
+    ):
+        prev = torch.tensor(prev_vals, dtype=torch.int32, device=DEVICE)
+        _assert_prep_matches(nct, seq_lens, prev, 64)
+
+
+def test_prep_padded_tail_contract():
+    """T5: padded rows (seq_len=0, query_len=0, prev=-1) produce exactly the
+    fill values (0) of the pre-change staging contract."""
+    nct = torch.tensor([100, 0, 0], dtype=torch.int32, device=DEVICE)
+    seq_lens = torch.tensor([104, 0, 0], dtype=torch.int32, device=DEVICE)
+    prev = torch.tensor([1, -1, -1], dtype=torch.int32, device=DEVICE)
+    bufs = _run_prep(seq_lens, nct, prev, 64)
+    for buf in (
+        bufs.block_idx_last_computed_token,
+        bufs.block_idx_first_scheduled_token,
+        bufs.block_idx_last_scheduled_token,
+        bufs.block_idx_last_scheduled_token_prev_step,
+    ):
+        assert buf[1:3].tolist() == [0, 0]
+    assert bufs.packed_anchors[1:3].flatten().tolist() == [0, 0, 0, 0]
+    assert bufs.packed_anchors_spec[1:3].flatten().tolist() == [0, 0, 0, 0]
+
+
+# --------------------------------------------------------------------------
+# T6: builder integration parity + eager-kernel-count assertion
+# --------------------------------------------------------------------------
+
+
+class _OpCounter(TorchDispatchMode):
+    """Counts CUDA-tensor aten ops (the eager GDN block-index math; CPU-side
+    chunk-index prep of prefill builds is out of scope)."""
+
+    def __init__(self):
+        super().__init__()
+        self.counts = Counter()
+
+    def __torch_dispatch__(self, func, types_, args=(), kwargs=None):
+        if any(isinstance(t, torch.Tensor) and t.is_cuda for t in args):
+            self.counts[func.overloadpacket.__name__] += 1
+        return func(*args, **(kwargs or {}))
+
+
+BLOCK = spec_harness.BLOCK
+NUM_SPEC = spec_harness.NUM_SPEC
+
+
+def _prep_from_common(common, prev, block_size):
+    n = common.num_reqs
+    bufs = GDNBlockIdxPrepBuffers(n, DEVICE)
+    if prev is None:
+        prev = torch.full((n,), -1, dtype=torch.int32, device=DEVICE)
+    bufs.prepare(
+        common.seq_lens,
+        common.compute_num_computed_tokens(),
+        prev,
+        block_size,
+        n,
+    )
+    return bufs
+
+
+def _meta_fields(meta):
+    return {
+        f: getattr(meta, f)
+        for f in (
+            "block_idx_last_scheduled_token",
+            "block_idx_first_scheduled_token",
+            "block_idx_last_computed_token",
+            "block_idx_last_scheduled_token_prev_step",
+            "num_computed_tokens",
+            "all_state_indices_tensor",
+            "spec_state_indices_tensor",
+            "non_spec_state_indices_tensor",
+            "num_accepted_tokens",
+        )
+    }
+
+
+def _assert_meta_equal(meta_eager, meta_prep):
+    for name, ref in _meta_fields(meta_eager).items():
+        got = getattr(meta_prep, name)
+        if ref is None:
+            assert got is None, name
+        else:
+            assert got is not None, name
+            assert torch.equal(got, ref), name
+
+
+@pytest.mark.parametrize(
+    "batch",
+    [
+        BatchSpec(seq_lens=[101, 231], query_lens=[1, 1]),  # pure decode
+        BatchSpec(seq_lens=[320, 192], query_lens=[320, 192]),  # prefill-only
+        BatchSpec(seq_lens=[101, 192], query_lens=[1, 192]),  # mixed
+    ],
+)
+def test_builder_parity_non_spec(batch):
+    """T6 (non-spec): flag-on build (prep buffers supplied) is bit-identical
+    per field to the eager build, with zero floor_divide/neg eager kernels."""
+    torch.manual_seed(0)
+    cfg = harness._make_vllm_config(BLOCK, "all")
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK, shapes=((16, 64),), dtypes=(torch.float16,)
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=DEVICE,
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK, DEVICE, arange_block_indices=True
+    )
+    common.block_table_tensor.add_(1)
+    with set_current_vllm_config(cfg):
+        meta_eager = builder.build(0, common)
+        bufs = _prep_from_common(common, None, BLOCK)
+        # Prime the num_computed cache the way the runner does (its subs are
+        # issued once per step by the prep helper, not per build).
+        common.compute_num_computed_tokens()
+        with _OpCounter() as counter:
+            meta_prep = builder.build(0, common, block_idx_prep=bufs)
+    _assert_meta_equal(meta_eager, meta_prep)
+    assert counter.counts["floor_divide"] == 0
+    assert counter.counts["neg"] == 0
+    assert meta_prep.block_idx_packed_anchors is not None
+    assert torch.equal(
+        meta_prep.block_idx_packed_anchors[:, 0],
+        meta_eager.block_idx_last_computed_token,
+    )
+    assert torch.equal(
+        meta_prep.block_idx_packed_anchors[:, 1],
+        meta_eager.block_idx_last_scheduled_token,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch,drafts,accepted,prev",
+    [
+        (
+            BatchSpec(seq_lens=[103, 231], query_lens=[3, 3]),
+            [NUM_SPEC, NUM_SPEC],
+            [2, 1],
+            [1, -1],
+        ),
+        (
+            BatchSpec(seq_lens=[192, 103], query_lens=[192, 3]),
+            [-1, NUM_SPEC],
+            [1, 2],
+            [-1, 1],
+        ),
+    ],
+)
+def test_builder_parity_spec(batch, drafts, accepted, prev):
+    """T6 (spec): pure-spec and mixed spec+prefill builds bit-identical with
+    the prep buffers supplied, including the prev-step read anchor."""
+    torch.manual_seed(0)
+    cfg = spec_harness._make_spec_config("all")
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            num_speculative_blocks=NUM_SPEC,
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=DEVICE,
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK, DEVICE, arange_block_indices=True
+    )
+    table = common.block_table_tensor
+    n, _ = table.shape
+    extra = torch.arange(
+        n * NUM_SPEC, dtype=table.dtype, device=table.device
+    ).reshape(n, NUM_SPEC) + int(table.max().item() + 1)
+    common.block_table_tensor = torch.cat([table, extra], dim=1)
+    common.block_table_tensor.add_(1)
+    prev_t = torch.tensor(prev, dtype=torch.int32, device=DEVICE)
+    kwargs = dict(
+        num_decode_draft_tokens_cpu=torch.tensor(drafts, dtype=torch.int32),
+        num_accepted_tokens=torch.tensor(
+            accepted, dtype=torch.int32, device=DEVICE
+        ),
+        prev_last_scheduled_idx=prev_t,
+    )
+    with set_current_vllm_config(cfg):
+        meta_eager = builder.build(0, common, **kwargs)
+        bufs = _prep_from_common(common, prev_t, BLOCK)
+        common.compute_num_computed_tokens()
+        with _OpCounter() as counter:
+            meta_prep = builder.build(0, common, block_idx_prep=bufs, **kwargs)
+    _assert_meta_equal(meta_eager, meta_prep)
+    assert counter.counts["floor_divide"] == 0
+    assert counter.counts["neg"] == 0
+    assert meta_prep.block_idx_packed_anchors_spec is not None
+    assert torch.equal(
+        meta_prep.block_idx_packed_anchors_spec[:, 0],
+        meta_eager.block_idx_last_scheduled_token_prev_step,
+    )
+
+
+def _run_layer_with_meta(cfg, meta, common, inputs, weights, seed_blocks,
+                         num_spec=0):
+    mixed_qkv, b, a = inputs
+    pool_size = int(common.block_table_tensor.max().item()) + 1
+    conv_state, ssm_state = harness._make_pools(pool_size, torch.float32, DEVICE)
+    for (seq, col), (conv_src, ssm_src) in seed_blocks.items():
+        blk = int(common.block_table_tensor[seq, col].item())
+        if conv_src is not None:
+            conv_state[blk] = conv_src
+        if ssm_src is not None:
+            ssm_state[blk] = ssm_src
+    layer = harness._build_layer(cfg, BLOCK, conv_state, ssm_state, weights)
+    if num_spec:
+        layer.num_spec = num_spec
+    out = harness._run_forward_core(
+        layer, meta, mixed_qkv, b, a, mixed_qkv.shape[0]
+    )
+    return out, conv_state, ssm_state
+
+
+def test_layer_decode_prep_metadata_parity():
+    """T6 (layer wiring, decode): the real _forward_core on flag-on metadata
+    (packed anchors populated) is bit-identical to the eager metadata run,
+    across an in-block row and a boundary-crossing row."""
+    torch.manual_seed(0)
+    weights = harness._make_weights(DEVICE)
+    inputs = harness._make_inputs(2, DEVICE)
+    # Row 0 in-block (ncomp=100); row 1 crossing (ncomp=128=2*BLOCK).
+    batch = BatchSpec(seq_lens=[101, 129], query_lens=[1, 1])
+    cfg = harness._make_vllm_config(BLOCK, "all")
+    builder_spec = MambaSpec(
+        block_size=BLOCK, shapes=((16, 64),), dtypes=(torch.float16,)
+    )
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=builder_spec,
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=DEVICE,
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK, DEVICE, arange_block_indices=True
+    )
+    common.block_table_tensor.add_(1)
+    with set_current_vllm_config(cfg):
+        meta_eager = builder.build(0, common)
+        bufs = _prep_from_common(common, None, BLOCK)
+        meta_prep = builder.build(0, common, block_idx_prep=bufs)
+    assert meta_prep.block_idx_packed_anchors is not None
+
+    conv_s = torch.randn_like(harness._make_pools(1, torch.float32, DEVICE)[0][0])
+    ssm_s = torch.randn_like(harness._make_pools(1, torch.float32, DEVICE)[1][0])
+    seeds = {(0, 1): (conv_s, ssm_s), (1, 1): (conv_s, ssm_s)}
+    out_e, conv_e, ssm_e = _run_layer_with_meta(
+        cfg, meta_eager, common, inputs, weights, seeds
+    )
+    out_p, conv_p, ssm_p = _run_layer_with_meta(
+        cfg, meta_prep, common, inputs, weights, seeds
+    )
+    assert torch.equal(out_p, out_e)
+    assert torch.equal(conv_p, conv_e)
+    assert torch.equal(ssm_p, ssm_e)
+
+
+def test_layer_spec_prep_metadata_parity():
+    """T6 (layer wiring, spec): pure-spec batch through the real
+    _forward_core — flag-on metadata (packed spec anchors) bit-identical to
+    the eager metadata run, including a prev-step read anchor crossing."""
+    torch.manual_seed(0)
+    weights = harness._make_weights(DEVICE)
+    batch = BatchSpec(seq_lens=[132], query_lens=[3])
+    inputs = harness._make_inputs(3, DEVICE)
+    cfg = spec_harness._make_spec_config("all")
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            num_speculative_blocks=NUM_SPEC,
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=DEVICE,
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK, DEVICE, arange_block_indices=True
+    )
+    table = common.block_table_tensor
+    n, _ = table.shape
+    extra = torch.arange(
+        n * NUM_SPEC, dtype=table.dtype, device=table.device
+    ).reshape(n, NUM_SPEC) + int(table.max().item() + 1)
+    common.block_table_tensor = torch.cat([table, extra], dim=1)
+    common.block_table_tensor.add_(1)
+    prev_t = torch.tensor([1], dtype=torch.int32, device=DEVICE)
+    kwargs = dict(
+        num_decode_draft_tokens_cpu=torch.tensor([NUM_SPEC], dtype=torch.int32),
+        num_accepted_tokens=torch.tensor([2], dtype=torch.int32, device=DEVICE),
+        prev_last_scheduled_idx=prev_t,
+    )
+    with set_current_vllm_config(cfg):
+        meta_eager = builder.build(0, common, **kwargs)
+        bufs = _prep_from_common(common, prev_t, BLOCK)
+        meta_prep = builder.build(0, common, block_idx_prep=bufs, **kwargs)
+    assert meta_prep.block_idx_packed_anchors_spec is not None
+
+    (conv_c, _), *states = spec_harness._rand_states(DEVICE, 4)
+    seeds = {
+        (0, 1): (None, states[0][1]),
+        (0, 2): (conv_c, states[1][1]),
+        (0, 3): (None, states[2][1]),
+    }
+    out_e, conv_e, ssm_e = _run_layer_with_meta(
+        cfg, meta_eager, common, inputs, weights, seeds, num_spec=NUM_SPEC
+    )
+    out_p, conv_p, ssm_p = _run_layer_with_meta(
+        cfg, meta_prep, common, inputs, weights, seeds, num_spec=NUM_SPEC
+    )
+    assert torch.equal(out_p, out_e)
+    assert torch.equal(conv_p, conv_e)
+    assert torch.equal(ssm_p, ssm_e)
+
+
+# --------------------------------------------------------------------------
+# T7-T11: packed-anchor kernel parity (A3 trims)
+# --------------------------------------------------------------------------
+
+
+def _gating_inputs(num_reqs, seq, h, hv, k, v, dtype, seed=0):
+    torch.manual_seed(seed)
+    num_tokens = num_reqs * seq
+    q = torch.rand(1, num_tokens, h, k, dtype=dtype, device=DEVICE)
+    key = torch.rand(1, num_tokens, h, k, dtype=dtype, device=DEVICE)
+    val = torch.rand(1, num_tokens, hv, v, dtype=dtype, device=DEVICE)
+    return dict(
+        A_log=torch.rand(hv, dtype=dtype, device=DEVICE),
+        dt_bias=torch.rand(hv, dtype=dtype, device=DEVICE),
+        a=torch.rand(num_tokens, hv, dtype=dtype, device=DEVICE),
+        b=torch.rand(num_tokens, hv, dtype=dtype, device=DEVICE),
+        q=q,
+        k=key,
+        v=val,
+        cu_seqlens=torch.arange(
+            0, num_tokens + 1, seq, dtype=torch.int32, device=DEVICE
+        ),
+    )
+
+
+def _anchored_table(num_reqs, width, max_anchor, null_row=None, seed=0):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    perm = torch.randperm(4 * num_reqs * width - 1, generator=g).to(torch.int32) + 1
+    table = perm[: num_reqs * width].view(num_reqs, width).contiguous().to(DEVICE)
+    if null_row is not None:
+        table[null_row] = 0
+    read = torch.randint(
+        0, max_anchor + 1, (num_reqs,), generator=g, dtype=torch.int32
+    ).to(DEVICE)
+    write = torch.randint(
+        0, max_anchor + 1, (num_reqs,), generator=g, dtype=torch.int32
+    ).to(DEVICE)
+    packed = torch.stack([read, write], dim=1).contiguous()
+    assert packed.shape == (num_reqs, 2) and packed.stride() == (2, 1)
+    return table, read, write, packed
+
+
+@pytest.mark.parametrize("geom", [(4, 8, 128, 128), (2, 16, 64, 64)])
+@pytest.mark.parametrize("seq", [1, 2, 4])
+@pytest.mark.parametrize("num_reqs", [1, 2, 7])
+def test_sigmoid_gating_packed_anchor_parity(geom, seq, num_reqs):
+    """T7: packed-anchor + hoisted-write-loop path vs the separate-anchor
+    path (code-identical to the pre-change kernel): outputs and the full
+    state pool bit-equal, incl. NULL rows and every accepted count."""
+    h, hv, k, v = geom
+    ins = _gating_inputs(num_reqs, seq, h, hv, k, v, torch.bfloat16)
+    width = 2 * seq + 4
+    null_row = num_reqs - 1 if num_reqs > 2 else None
+    table, read, write, packed = _anchored_table(
+        num_reqs, width, width - seq, null_row=null_row
+    )
+    accepted = (
+        torch.arange(num_reqs, dtype=torch.int32, device=DEVICE) % seq + 1
+        if seq > 1
+        else None
+    )
+    base_state = torch.rand(
+        int(table.max().item()) + 1, hv, v, k, dtype=torch.float32, device=DEVICE
+    )
+
+    def call(state, use_packed):
+        anchor_kw = (
+            dict(packed_anchors=packed)
+            if use_packed
+            else dict(read_anchor=read, write_anchor=write)
+        )
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            initial_state=state,
+            inplace_final_state=True,
+            cu_seqlens=ins["cu_seqlens"],
+            block_table=table,
+            num_accepted_tokens=accepted,
+            use_qk_l2norm_in_kernel=True,
+            **anchor_kw,
+        )
+
+    state_ref = base_state.clone()
+    out_ref, _ = call(state_ref, use_packed=False)
+    state_packed = base_state.clone()
+    out_packed, _ = call(state_packed, use_packed=True)
+    if null_row is not None:
+        # NULL rows return without stores: compare only valid rows' outputs.
+        valid = [i for i in range(num_reqs) if i != null_row]
+        tok = torch.tensor(
+            [i * seq + t for i in valid for t in range(seq)], device=DEVICE
+        )
+        assert torch.equal(out_packed[:, tok], out_ref[:, tok])
+    else:
+        assert torch.equal(out_packed, out_ref)
+    assert torch.equal(state_packed, state_ref)
+
+
+def test_sigmoid_gating_packed_anchor_vs_gather_oracle():
+    """T10: packed-anchor result also equals the ORIGINAL host-gathered
+    index-tensor path (ssm_state_indices/_output), tying the whole in-kernel
+    chain back to the pre-fixC semantics."""
+    h, hv, k, v = 4, 8, 128, 128
+    num_reqs, seq = 2, 3
+    ins = _gating_inputs(num_reqs, seq, h, hv, k, v, torch.bfloat16, seed=1234)
+    table, read, write, packed = _anchored_table(num_reqs, 2 * seq, seq)
+    accepted = torch.tensor([2, 3], dtype=torch.int32, device=DEVICE)
+    base_state = torch.rand(
+        int(table.max().item()) + 1, hv, v, k, dtype=torch.float32, device=DEVICE
+    )
+    offs = torch.arange(seq, dtype=torch.int64, device=DEVICE).unsqueeze(0)
+    gather_in = table.gather(1, read.long().unsqueeze(1) + offs)
+    gather_out = table.gather(1, write.long().unsqueeze(1) + offs)
+
+    def base_kwargs():
+        return dict(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            inplace_final_state=True,
+            cu_seqlens=ins["cu_seqlens"],
+            num_accepted_tokens=accepted,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    state_gather = base_state.clone()
+    out_gather, _ = fused_sigmoid_gating_delta_rule_update(
+        initial_state=state_gather,
+        ssm_state_indices=gather_in.to(torch.int32).contiguous(),
+        ssm_state_indices_output=gather_out.to(torch.int32).contiguous(),
+        **base_kwargs(),
+    )
+    state_packed = base_state.clone()
+    out_packed, _ = fused_sigmoid_gating_delta_rule_update(
+        initial_state=state_packed,
+        block_table=table,
+        packed_anchors=packed,
+        **base_kwargs(),
+    )
+    assert torch.equal(out_packed, out_gather)
+    assert torch.equal(state_packed, state_gather)
+
+
+CONV_DIM = 1300  # deliberately not a multiple of BLOCK_N=256
+CONV_WIDTH = 4
+
+
+def _conv_pool(num_lines, state_len):
+    return torch.rand(
+        num_lines, CONV_DIM, state_len, dtype=torch.float32, device=DEVICE
+    )
+
+
+@pytest.mark.parametrize("crossing", [False, True])
+@pytest.mark.parametrize("spec", [False, True])
+def test_conv_update_packed_anchor_parity(crossing, spec):
+    """T8: conv update with packed anchors vs separate anchors, on both sides
+    of the skip-second-lookup predicate (write == / != read), spec + nospec,
+    dim not a multiple of BLOCK_N."""
+    torch.manual_seed(0)
+    num_reqs, seq = 3, (3 if spec else 1)
+    width = 6
+    table, read, write, packed = _anchored_table(num_reqs, width, width - seq - 1)
+    if not crossing:
+        write = read.clone()
+        packed = torch.stack([read, write], dim=1).contiguous()
+    weight = torch.rand(CONV_DIM, CONV_WIDTH, dtype=torch.float32, device=DEVICE)
+    bias = torch.rand(CONV_DIM, dtype=torch.float32, device=DEVICE)
+    state_len = CONV_WIDTH - 1 + (seq - 1 if spec else 0)
+    base_pool = _conv_pool(int(table.max().item()) + 1, state_len)
+    if spec:
+        x = torch.rand(num_reqs * seq, CONV_DIM, dtype=torch.float32, device=DEVICE)
+        qsl = torch.arange(
+            0, num_reqs * seq + 1, seq, dtype=torch.int32, device=DEVICE
+        )
+        accepted = torch.tensor([1, 2, 3], dtype=torch.int32, device=DEVICE)
+        extra = dict(
+            num_accepted_tokens=accepted, query_start_loc=qsl, max_query_len=seq
+        )
+    else:
+        x = torch.rand(num_reqs, CONV_DIM, dtype=torch.float32, device=DEVICE)
+        extra = {}
+
+    def call(pool, use_packed):
+        anchor_kw = (
+            dict(packed_anchors=packed)
+            if use_packed
+            else dict(
+                block_idx_last_scheduled_token=write, initial_state_idx=read
+            )
+        )
+        return causal_conv1d_update(
+            x.clone(),
+            pool,
+            weight,
+            bias,
+            activation="silu",
+            conv_state_indices=table,
+            validate_data=False,
+            **anchor_kw,
+            **extra,
+        )
+
+    pool_ref = base_pool.clone()
+    out_ref = call(pool_ref, use_packed=False)
+    pool_packed = base_pool.clone()
+    out_packed = call(pool_packed, use_packed=True)
+    assert torch.equal(out_packed, out_ref)
+    assert torch.equal(pool_packed, pool_ref)
+
+
+def test_packed_recurrent_packed_anchor_parity():
+    """T9: packed recurrent decode (T=1) with packed anchors vs separate
+    anchors; boundary-crossing rows must leave the read block untouched and
+    populate the write block identically."""
+    torch.manual_seed(0)
+    h, hv, k, v = 4, 8, 128, 128
+    num_reqs = 4
+    packed_dim = 2 * h * k + hv * v
+    mixed_qkv = torch.rand(
+        num_reqs, packed_dim, dtype=torch.bfloat16, device=DEVICE
+    )
+    a = torch.rand(num_reqs, hv, dtype=torch.bfloat16, device=DEVICE)
+    b = torch.rand(num_reqs, hv, dtype=torch.bfloat16, device=DEVICE)
+    a_log = torch.rand(hv, dtype=torch.bfloat16, device=DEVICE)
+    dt_bias = torch.rand(hv, dtype=torch.bfloat16, device=DEVICE)
+    table, read, write, packed = _anchored_table(num_reqs, 5, 4)
+    # Force crossing rows (read != write) and one in-block row.
+    read[0], write[0] = 1, 2
+    read[1], write[1] = 1, 1
+    packed = torch.stack([read, write], dim=1).contiguous()
+    base_state = torch.rand(
+        int(table.max().item()) + 1, hv, v, k, dtype=torch.float32, device=DEVICE
+    )
+
+    def call(state, use_packed):
+        out = torch.zeros(
+            num_reqs, 1, hv, v, dtype=mixed_qkv.dtype, device=DEVICE
+        )
+        anchor_kw = (
+            dict(packed_anchors=packed)
+            if use_packed
+            else dict(read_anchor=read, write_anchor=write)
+        )
+        fused_recurrent_gated_delta_rule_packed_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            scale=k**-0.5,
+            initial_state=state,
+            out=out,
+            block_table=table,
+            use_qk_l2norm_in_kernel=True,
+            **anchor_kw,
+        )
+        return out
+
+    state_ref = base_state.clone()
+    out_ref = call(state_ref, use_packed=False)
+    state_packed = base_state.clone()
+    out_packed = call(state_packed, use_packed=True)
+    assert torch.equal(out_packed, out_ref)
+    assert torch.equal(state_packed, state_ref)
+    # Crossing row 0: read block untouched, write block updated.
+    read_blk = int(table[0, 1].item())
+    write_blk = int(table[0, 2].item())
+    assert torch.equal(state_packed[read_blk], base_state[read_blk])
+    assert not torch.equal(state_packed[write_blk], base_state[write_blk])
+
+
+def test_packed_recurrent_null_row_skipped():
+    """T11: a NULL (block id 0) row under packed anchors stores a zero output
+    and leaves the state pool byte-identical."""
+    torch.manual_seed(0)
+    h, hv, k, v = 4, 8, 128, 128
+    num_reqs = 2
+    packed_dim = 2 * h * k + hv * v
+    mixed_qkv = torch.rand(num_reqs, packed_dim, dtype=torch.bfloat16, device=DEVICE)
+    a = torch.rand(num_reqs, hv, dtype=torch.bfloat16, device=DEVICE)
+    b = torch.rand(num_reqs, hv, dtype=torch.bfloat16, device=DEVICE)
+    a_log = torch.rand(hv, dtype=torch.bfloat16, device=DEVICE)
+    dt_bias = torch.rand(hv, dtype=torch.bfloat16, device=DEVICE)
+    table, read, write, packed = _anchored_table(num_reqs, 4, 3, null_row=1)
+    base_state = torch.rand(
+        int(table.max().item()) + 1, hv, v, k, dtype=torch.float32, device=DEVICE
+    )
+    state = base_state.clone()
+    out = torch.full(
+        (num_reqs, 1, hv, v), 7.0, dtype=mixed_qkv.dtype, device=DEVICE
+    )
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        scale=k**-0.5,
+        initial_state=state,
+        out=out,
+        block_table=table,
+        packed_anchors=packed,
+        use_qk_l2norm_in_kernel=True,
+    )
+    assert (out[1] == 0).all()  # NULL row: zeros stored
+    # No state slot belonging to the NULL row was written (its table is all
+    # zeros, and slot 0 is the reserved null block, not in row 0's table).
+    row0_write = int(table[0, int(write[0].item())].item())
+    untouched = [
+        i for i in range(base_state.shape[0]) if i != row0_write
+    ]
+    assert torch.equal(state[untouched], base_state[untouched])
+
+
+# --------------------------------------------------------------------------
+# T12: wrapper assertions
+# --------------------------------------------------------------------------
+
+
+def _tiny_gating_case():
+    h, hv, k, v = 4, 8, 128, 128
+    ins = _gating_inputs(2, 1, h, hv, k, v, torch.bfloat16)
+    table, read, write, packed = _anchored_table(2, 3, 2)
+    state = torch.rand(
+        int(table.max().item()) + 1, hv, v, k, dtype=torch.float32, device=DEVICE
+    )
+    return ins, table, read, write, packed, state
+
+
+def test_wrapper_rejects_packed_plus_separate_anchors():
+    ins, table, read, write, packed, state = _tiny_gating_case()
+    with pytest.raises(AssertionError, match="mutually exclusive"):
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            initial_state=state,
+            cu_seqlens=ins["cu_seqlens"],
+            block_table=table,
+            read_anchor=read,
+            write_anchor=write,
+            packed_anchors=packed,
+        )
+
+
+def test_wrapper_rejects_packed_without_table():
+    ins, table, read, write, packed, state = _tiny_gating_case()
+    with pytest.raises(AssertionError, match="requires block_table"):
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            initial_state=state,
+            cu_seqlens=ins["cu_seqlens"],
+            ssm_state_indices=table[:, :1].contiguous(),
+            packed_anchors=packed,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    ["dtype", "shape", "stride"],
+)
+def test_wrapper_rejects_malformed_packed_anchors(mutate):
+    ins, table, read, write, packed, state = _tiny_gating_case()
+    if mutate == "dtype":
+        bad = packed.to(torch.int64)
+    elif mutate == "shape":
+        bad = torch.cat([packed, packed], dim=1)  # (N, 4)
+    else:
+        bad = torch.stack([read, write], dim=0).t()  # stride (1, N)
+    with pytest.raises(AssertionError, match="packed_anchors"):
+        fused_sigmoid_gating_delta_rule_update(
+            A_log=ins["A_log"],
+            a=ins["a"],
+            b=ins["b"],
+            dt_bias=ins["dt_bias"],
+            q=ins["q"],
+            k=ins["k"],
+            v=ins["v"],
+            initial_state=state,
+            cu_seqlens=ins["cu_seqlens"],
+            block_table=table,
+            packed_anchors=bad,
+        )
+
+
+def test_conv_wrapper_rejects_packed_plus_separate_anchors():
+    torch.manual_seed(0)
+    table, read, write, packed = _anchored_table(2, 4, 2)
+    pool = _conv_pool(int(table.max().item()) + 1, CONV_WIDTH - 1)
+    weight = torch.rand(CONV_DIM, CONV_WIDTH, dtype=torch.float32, device=DEVICE)
+    x = torch.rand(2, CONV_DIM, dtype=torch.float32, device=DEVICE)
+    with pytest.raises(AssertionError, match="mutually exclusive"):
+        causal_conv1d_update(
+            x,
+            pool,
+            weight,
+            None,
+            activation="silu",
+            conv_state_indices=table,
+            initial_state_idx=read,
+            block_idx_last_scheduled_token=write,
+            packed_anchors=packed,
+        )
+
+
+def test_recurrent_wrapper_rejects_packed_misuse():
+    torch.manual_seed(0)
+    h, hv, k, v = 4, 8, 128, 128
+    packed_dim = 2 * h * k + hv * v
+    mixed_qkv = torch.rand(2, packed_dim, dtype=torch.bfloat16, device=DEVICE)
+    a = torch.rand(2, hv, dtype=torch.bfloat16, device=DEVICE)
+    b = torch.rand(2, hv, dtype=torch.bfloat16, device=DEVICE)
+    a_log = torch.rand(hv, dtype=torch.bfloat16, device=DEVICE)
+    dt_bias = torch.rand(hv, dtype=torch.bfloat16, device=DEVICE)
+    table, read, write, packed = _anchored_table(2, 4, 3)
+    state = torch.rand(
+        int(table.max().item()) + 1, hv, v, k, dtype=torch.float32, device=DEVICE
+    )
+    out = torch.zeros(2, 1, hv, v, dtype=mixed_qkv.dtype, device=DEVICE)
+    kwargs = dict(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        scale=k**-0.5,
+        initial_state=state,
+        out=out,
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        fused_recurrent_gated_delta_rule_packed_decode(
+            block_table=table,
+            read_anchor=read,
+            write_anchor=write,
+            packed_anchors=packed,
+            **kwargs,
+        )
+    with pytest.raises(ValueError, match="requires `block_table`"):
+        fused_recurrent_gated_delta_rule_packed_decode(
+            ssm_state_indices=table[:, 0].contiguous(),
+            packed_anchors=packed,
+            **kwargs,
+        )

--- a/tests/kernels/mamba/test_gdn_inkernel_ckpt_write.py
+++ b/tests/kernels/mamba/test_gdn_inkernel_ckpt_write.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CS2 tests for GDN all-mode in-kernel checkpoint writes
+(``VLLM_GDN_INKERNEL_CKPT_WRITE``; design doc allmode_decode_opt_design.md,
+tests T13-T17).
+
+- T13-T15: the single-launch Triton scatter
+  (``gdn_scatter_block_checkpoints_triton``) reproduces the Python-looped
+  ``gdn_scatter_block_checkpoints`` (run as golden) bit-exactly on the full
+  state pool: every interior-block-count/crossing pattern, multi-sequence
+  adjacent chunk ranges (the seq_hi clamp), resumed prefills, the
+  unaligned-skip (never-poison-APC) rule, and the fp32 -> pool-dtype cast.
+- T16: builder staging elimination — flag-on metadata aliases the runner
+  block table (data_ptr equality), flag-off keeps the builder-local copy;
+  values identical either way.
+- T17: DtoD copy_-count assertion — the anchor + table staging copies
+  actually disappear under the flags (delta == 4 spec / 3 nospec per build).
+- Layer level: the real ``_forward_core`` prefill under WRITE=1 equals the
+  WRITE=0 run bit-exactly (outputs + full pools).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="GDN in-kernel ckpt-write tests require CUDA (Triton kernels).",
+        allow_module_level=True,
+    )
+
+from tests.kernels.mamba import test_gdn_all_mode_prefill as harness  # noqa: E402
+from tests.kernels.mamba import (  # noqa: E402
+    test_gdn_all_mode_spec_decode as spec_harness,
+)
+from tests.v1.attention.utils import (  # noqa: E402
+    BatchSpec,
+    create_common_attn_metadata,
+)
+from vllm.config import CUDAGraphMode, set_current_vllm_config  # noqa: E402
+from vllm.model_executor.layers.mamba.gdn.all_mode_utils import (  # noqa: E402
+    gdn_scatter_block_checkpoints,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_scatter import (  # noqa: E402
+    gdn_scatter_block_checkpoints_triton,
+)
+from vllm.v1.attention.backends.gdn_attn import (  # noqa: E402
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import MambaSpec  # noqa: E402
+
+DEVICE = torch.device("cuda")
+CHUNK = 4
+BLK = 8  # mamba block = 2 chunks (same grid as test_gdn_scatter)
+STATE_SHAPE = (3, 5, 7)  # deliberately odd per-block state shape
+
+
+# --------------------------------------------------------------------------
+# T13-T15: scatter kernel == Python-looped golden
+# --------------------------------------------------------------------------
+
+
+def _run_both(seqs, state_dtype=torch.float32, pool_blocks=64, seed=0):
+    """seqs: list of (first, last, ncomp, num_chunks). Returns (golden, run)
+    pools after the eager and Triton scatters on identical inputs."""
+    torch.manual_seed(seed)
+    num_seqs = len(seqs)
+    nt = sum(s[3] for s in seqs)
+    inter = torch.randn(nt, *STATE_SHAPE, dtype=torch.float32, device=DEVICE)
+    final = torch.randn(
+        num_seqs, *STATE_SHAPE, dtype=torch.float32, device=DEVICE
+    )
+    width = max(s[1] for s in seqs) + 2
+    perm = torch.randperm(pool_blocks - 1, dtype=torch.int32, device=DEVICE) + 1
+    table = perm[: num_seqs * width].view(num_seqs, width).contiguous()
+    first = torch.tensor([s[0] for s in seqs], dtype=torch.int32, device=DEVICE)
+    last = torch.tensor([s[1] for s in seqs], dtype=torch.int32, device=DEVICE)
+    ncomp = torch.tensor([s[2] for s in seqs], dtype=torch.int32, device=DEVICE)
+    chunk_offsets = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor([s[3] for s in seqs]), 0)),
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    base_pool = torch.randn(
+        pool_blocks, *STATE_SHAPE, dtype=torch.float32, device=DEVICE
+    ).to(state_dtype)
+    num_prefill_tokens = int(sum(s[1] - s[0] + 1 for s in seqs)) * BLK
+
+    pool_golden = base_pool.clone()
+    gdn_scatter_block_checkpoints(
+        pool_golden, inter, final, table, first, last, ncomp,
+        chunk_offsets, BLK, CHUNK,
+    )
+    pool_run = base_pool.clone()
+    gdn_scatter_block_checkpoints_triton(
+        pool_run, inter, final, table, first, last, ncomp,
+        chunk_offsets, BLK, CHUNK, num_prefill_tokens,
+    )
+    return pool_golden, pool_run, base_pool, table
+
+
+@pytest.mark.parametrize(
+    "seqs",
+    [
+        # n interior blocks = last - first in {0, 1, 2, 5}; fresh + resumed
+        # (ncomp = j*BLK) starts; final partial and exactly-full.
+        [(0, 0, 0, 1)],  # first == last (final block only)
+        [(0, 1, 0, 3)],  # 1 interior
+        [(0, 2, 0, 5)],  # 2 interior
+        [(0, 5, 0, 11)],  # 5 interior
+        [(1, 2, 8, 3)],  # resumed at block boundary (ncomp = BLK)
+        [(2, 4, 16, 6)],  # resumed 2 blocks in, exactly-full final chunk
+        # multi-sequence, adjacent chunk ranges (seq_hi clamp defense)
+        [(0, 2, 0, 5), (0, 1, 0, 4), (1, 3, 8, 5)],
+        [(0, 0, 0, 1), (0, 4, 0, 9)],
+    ],
+)
+def test_scatter_kernel_matches_golden(seqs):
+    """T13: full-pool bit-equality with the Python-looped scatter across
+    crossing patterns, multi-seq ranges and resumed prefills."""
+    pool_golden, pool_run, _, _ = _run_both(seqs)
+    assert torch.equal(pool_run, pool_golden)
+
+
+def test_scatter_kernel_unaligned_skip():
+    """T14: rows with ncomp % chunk != 0 skip interior checkpoints (pool
+    untouched there) but still write the final block; aligned rows in the
+    same batch scatter normally."""
+    seqs = [(0, 2, 2, 5), (0, 2, 0, 5)]  # row 0 unaligned (2 % 4 != 0)
+    pool_golden, pool_run, base_pool, table = _run_both(seqs)
+    assert torch.equal(pool_run, pool_golden)
+    # Row 0 interior blocks untouched, final written.
+    for j in (0, 1):
+        blk = int(table[0, j].item())
+        assert torch.equal(pool_run[blk], base_pool[blk])
+    assert not torch.equal(
+        pool_run[int(table[0, 2].item())], base_pool[int(table[0, 2].item())]
+    )
+    # Row 1 interior blocks written.
+    for j in (0, 1):
+        blk = int(table[1, j].item())
+        assert not torch.equal(pool_run[blk], base_pool[blk])
+
+
+@pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float16])
+def test_scatter_kernel_dtype_cast(state_dtype):
+    """T15: fp32 chunk states stored into a narrower pool dtype cast exactly
+    like the eager ``.to(ssm_state.dtype)``."""
+    pool_golden, pool_run, _, _ = _run_both(
+        [(0, 2, 0, 5), (1, 3, 8, 5)], state_dtype=state_dtype
+    )
+    assert torch.equal(pool_run, pool_golden)
+
+
+# --------------------------------------------------------------------------
+# T16/T17: builder staging elimination + copy-count assertions
+# --------------------------------------------------------------------------
+
+BLOCK = spec_harness.BLOCK
+NUM_SPEC = spec_harness.NUM_SPEC
+
+
+class _CudaCopyCounter(TorchDispatchMode):
+    def __init__(self):
+        super().__init__()
+        self.counts = Counter()
+
+    def __torch_dispatch__(self, func, types_, args=(), kwargs=None):
+        name = func.overloadpacket.__name__
+        if name == "copy_" and all(
+            (not isinstance(t, torch.Tensor)) or t.is_cuda for t in args
+        ):
+            self.counts["cuda_copy_"] += 1
+        return func(*args, **(kwargs or {}))
+
+
+def _spec_builder_and_common(batch, drafts, accepted, prev):
+    cfg = spec_harness._make_spec_config("all")
+    cfg.compilation_config.cudagraph_mode = CUDAGraphMode.FULL
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            num_speculative_blocks=NUM_SPEC,
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=DEVICE,
+    )
+    assert builder.use_full_cuda_graph
+    common = create_common_attn_metadata(
+        batch, BLOCK, DEVICE, arange_block_indices=True
+    )
+    table = common.block_table_tensor
+    n, _ = table.shape
+    extra = torch.arange(
+        n * NUM_SPEC, dtype=table.dtype, device=table.device
+    ).reshape(n, NUM_SPEC) + int(table.max().item() + 1)
+    common.block_table_tensor = torch.cat([table, extra], dim=1)
+    common.block_table_tensor.add_(1)
+    kwargs = dict(
+        num_decode_draft_tokens_cpu=torch.tensor(drafts, dtype=torch.int32),
+        num_accepted_tokens=torch.tensor(
+            accepted, dtype=torch.int32, device=DEVICE
+        ),
+        prev_last_scheduled_idx=torch.tensor(
+            prev, dtype=torch.int32, device=DEVICE
+        ),
+    )
+    return cfg, builder, common, kwargs
+
+
+def _decode_builder_and_common(batch):
+    cfg = harness._make_vllm_config(BLOCK, "all")
+    cfg.compilation_config.cudagraph_mode = CUDAGraphMode.FULL
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK, shapes=((16, 64),), dtypes=(torch.float16,)
+        ),
+        layer_names=[harness.PREFIX],
+        vllm_config=cfg,
+        device=DEVICE,
+    )
+    assert builder.use_full_cuda_graph
+    common = create_common_attn_metadata(
+        batch, BLOCK, DEVICE, arange_block_indices=True
+    )
+    common.block_table_tensor.add_(1)
+    return cfg, builder, common
+
+
+def test_staging_elimination_metadata_aliasing(monkeypatch):
+    """T16: WRITE=1 metadata aliases the (runner-owned) block table tensor
+    (data_ptr equality); WRITE=0 stages a builder-local copy; contents
+    identical either way."""
+    torch.manual_seed(0)
+    batch = BatchSpec(seq_lens=[101, 231], query_lens=[1, 1])
+
+    monkeypatch.setenv("VLLM_GDN_INKERNEL_CKPT_WRITE", "0")
+    cfg, builder, common = _decode_builder_and_common(batch)
+    with set_current_vllm_config(cfg):
+        meta_off = builder.build(0, common)
+    assert (
+        meta_off.all_state_indices_tensor.data_ptr()
+        != common.block_table_tensor.data_ptr()
+    )
+    assert (
+        meta_off.all_state_indices_tensor.data_ptr()
+        == builder.all_state_indices_tensor.data_ptr()
+    )
+
+    monkeypatch.setenv("VLLM_GDN_INKERNEL_CKPT_WRITE", "1")
+    with set_current_vllm_config(cfg):
+        meta_on = builder.build(0, common)
+    assert (
+        meta_on.all_state_indices_tensor.data_ptr()
+        == common.block_table_tensor.data_ptr()
+    )
+    assert torch.equal(
+        meta_on.all_state_indices_tensor, meta_off.all_state_indices_tensor
+    )
+    for f in (
+        "block_idx_last_scheduled_token",
+        "block_idx_last_computed_token",
+        "non_spec_state_indices_tensor",
+    ):
+        assert torch.equal(getattr(meta_on, f), getattr(meta_off, f)), f
+
+
+@pytest.mark.parametrize("spec", [True, False])
+def test_staging_copy_count_drops(monkeypatch, spec):
+    """T17: the anchor + table staging copies disappear under the flags —
+    CUDA copy_ count per build drops by exactly 4 (spec: table + 3 anchors)
+    or 3 (nospec decode: table + 2 anchors), with bit-identical metadata."""
+    torch.manual_seed(0)
+    from tests.kernels.mamba.test_gdn_index_prep import _prep_from_common
+
+    if spec:
+        batch = BatchSpec(seq_lens=[103, 231], query_lens=[3, 3])
+        cfg, builder, common, kwargs = _spec_builder_and_common(
+            batch, [NUM_SPEC, NUM_SPEC], [2, 1], [1, -1]
+        )
+        prev = kwargs["prev_last_scheduled_idx"]
+        expected_delta = 4
+    else:
+        batch = BatchSpec(seq_lens=[101, 231], query_lens=[1, 1])
+        cfg, builder, common = _decode_builder_and_common(batch)
+        kwargs = {}
+        prev = None
+        expected_delta = 3
+
+    def build(flags_on):
+        monkeypatch.setenv(
+            "VLLM_GDN_INKERNEL_CKPT_WRITE", "1" if flags_on else "0"
+        )
+        extra = dict(kwargs)
+        if flags_on:
+            extra["block_idx_prep"] = _prep_from_common(common, prev, BLOCK)
+            common.compute_num_computed_tokens()
+        with set_current_vllm_config(cfg), _CudaCopyCounter() as counter:
+            meta = builder.build(0, common, **extra)
+        return meta, counter.counts["cuda_copy_"]
+
+    meta_off, copies_off = build(False)
+    meta_on, copies_on = build(True)
+    assert copies_off - copies_on == expected_delta, (copies_off, copies_on)
+    for f in (
+        "all_state_indices_tensor",
+        "block_idx_last_scheduled_token",
+        "block_idx_last_computed_token",
+        "block_idx_last_scheduled_token_prev_step",
+    ):
+        ref, got = getattr(meta_off, f), getattr(meta_on, f)
+        if ref is None:
+            assert got is None, f
+        else:
+            assert torch.equal(got, ref), f
+
+
+# --------------------------------------------------------------------------
+# Layer-level: prefill scatter A/B through the real _forward_core
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("resumed", [False, True])
+def test_layer_prefill_scatter_flag_ab(monkeypatch, resumed):
+    """WRITE=1 vs WRITE=0 through the real prefill path: outputs and the
+    full conv/SSM pools bit-identical (fresh and resumed prefills)."""
+    torch.manual_seed(0)
+    mamba_block_size = 64
+    total = 5 * mamba_block_size
+    cached = 3 * mamba_block_size if resumed else 0
+    weights = harness._make_weights(DEVICE)
+    mixed_qkv, b, a = harness._make_inputs(total, DEVICE)
+    cfg = harness._make_vllm_config(mamba_block_size, "all")
+
+    def run():
+        batch = BatchSpec(seq_lens=[total], query_lens=[total - cached])
+        meta, common = harness._build_metadata(
+            cfg, batch, mamba_block_size, DEVICE
+        )
+        pool_size = int(common.block_table_tensor.max().item()) + 1
+        conv_state, ssm_state = harness._make_pools(
+            pool_size, torch.float32, DEVICE
+        )
+        layer = harness._build_layer(
+            cfg, mamba_block_size, conv_state, ssm_state, weights
+        )
+        out = harness._run_forward_core(
+            layer, meta, mixed_qkv[cached:], b[cached:], a[cached:],
+            total - cached,
+        )
+        return out, conv_state, ssm_state
+
+    monkeypatch.setenv("VLLM_GDN_INKERNEL_CKPT_WRITE", "0")
+    out_off, conv_off, ssm_off = run()
+    monkeypatch.setenv("VLLM_GDN_INKERNEL_CKPT_WRITE", "1")
+    out_on, conv_on, ssm_on = run()
+    assert torch.equal(out_on, out_off)
+    assert torch.equal(conv_on, conv_off)
+    assert torch.equal(ssm_on, ssm_off)

--- a/tests/kernels/mamba/test_gdn_scatter.py
+++ b/tests/kernels/mamba/test_gdn_scatter.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit test for gdn_scatter_block_checkpoints (Stage 3 all-mode scatter).
+
+CPU-only, deterministic: inter_states[c] is filled with the value c, final_states[s]
+with 100+s, so we can assert exactly which chunk/final state lands in which block.
+Validates the FLA start-of-chunk index mapping (h[c]=state before chunk c) and the
+final-block-from-final-state rule, for fresh / varlen / chunked-continuation cases.
+"""
+import torch
+
+from vllm.model_executor.layers.mamba.gdn.all_mode_utils import (
+    gdn_scatter_block_checkpoints,
+)
+
+D = 2  # tiny per-state dim
+CHUNK = 4
+BLK = 8  # chunk_stride = 2
+
+
+def _state(num_blocks):
+    return torch.full((num_blocks, D), -1.0)
+
+
+def _inter(nt):
+    return torch.stack([torch.full((D,), float(c)) for c in range(nt)])
+
+
+def _final(n):
+    return torch.stack([torch.full((D,), 100.0 + s) for s in range(n)])
+
+
+def test_scatter_single_fresh():
+    # 20-token seq, num_computed=0: blocks 0,1 full + block 2 partial(final).
+    ssm = _state(20)
+    inter = _inter(5)  # chunks 0..4
+    final = _final(1)
+    block_table = torch.tensor([[10, 11, 12, 0, 0]])
+    gdn_scatter_block_checkpoints(
+        ssm, inter, final, block_table,
+        block_idx_first_scheduled_token_p=torch.tensor([0]),
+        block_idx_last_scheduled_token_p=torch.tensor([2]),
+        num_computed_tokens_p=torch.tensor([0]),
+        first_chunk_p=torch.tensor([0]),
+        mamba_block_size=BLK, chunk_size=CHUNK,
+    )
+    assert (ssm[10] == 2).all(), ssm[10]   # end of block 0 == h[2]
+    assert (ssm[11] == 4).all(), ssm[11]   # end of block 1 == h[4]
+    assert (ssm[12] == 100).all(), ssm[12]  # final (partial) block == final_states[0]
+    print("single_fresh OK")
+
+
+def test_scatter_varlen_two_seqs():
+    ssm = _state(40)
+    inter = _inter(8)  # seq0 chunks 0-4, seq1 chunks 5-7
+    final = _final(2)
+    block_table = torch.tensor([[10, 11, 12, 0, 0], [20, 21, 0, 0, 0]])
+    gdn_scatter_block_checkpoints(
+        ssm, inter, final, block_table,
+        block_idx_first_scheduled_token_p=torch.tensor([0, 0]),
+        block_idx_last_scheduled_token_p=torch.tensor([2, 1]),
+        num_computed_tokens_p=torch.tensor([0, 0]),
+        first_chunk_p=torch.tensor([0, 5]),
+        mamba_block_size=BLK, chunk_size=CHUNK,
+    )
+    assert (ssm[10] == 2).all() and (ssm[11] == 4).all() and (ssm[12] == 100).all()
+    assert (ssm[20] == 7).all(), ssm[20]    # seq1 block0 end == h[5+2]=h[7]
+    assert (ssm[21] == 101).all(), ssm[21]  # seq1 final block == final_states[1]
+    print("varlen_two_seqs OK")
+
+
+def test_scatter_continuation():
+    # num_computed=8 (block 0 already cached), schedule tokens 8..20 (3 chunks).
+    ssm = _state(40)
+    inter = _inter(3)  # scheduled chunks 0..2 (global)
+    final = _final(1)
+    block_table = torch.tensor([[30, 31, 32]])
+    gdn_scatter_block_checkpoints(
+        ssm, inter, final, block_table,
+        block_idx_first_scheduled_token_p=torch.tensor([1]),
+        block_idx_last_scheduled_token_p=torch.tensor([2]),
+        num_computed_tokens_p=torch.tensor([8]),
+        first_chunk_p=torch.tensor([0]),
+        mamba_block_size=BLK, chunk_size=CHUNK,
+    )
+    assert (ssm[30] == -1).all(), ssm[30]   # already-cached block untouched
+    assert (ssm[31] == 2).all(), ssm[31]    # block 1 end == h[2]
+    assert (ssm[32] == 100).all(), ssm[32]  # final block == final_states[0]
+    print("continuation OK")
+
+
+def test_scatter_multiblock_continuation():
+    # num_computed=16 (blocks 0,1 already cached), schedule blocks 2,3 full + block 4
+    # partial(final). Exercises num_computed spanning >1 cached block + >1 interior block.
+    ssm = _state(60)
+    inter = _inter(5)  # scheduled chunks 0..4 (global)
+    final = _final(1)
+    block_table = torch.tensor([[40, 41, 42, 43, 44]])
+    gdn_scatter_block_checkpoints(
+        ssm, inter, final, block_table,
+        block_idx_first_scheduled_token_p=torch.tensor([2]),
+        block_idx_last_scheduled_token_p=torch.tensor([4]),
+        num_computed_tokens_p=torch.tensor([16]),
+        first_chunk_p=torch.tensor([0]),
+        mamba_block_size=BLK, chunk_size=CHUNK,
+    )
+    assert (ssm[40] == -1).all() and (ssm[41] == -1).all()  # cached blocks untouched
+    assert (ssm[42] == 2).all(), ssm[42]    # block 2 end: k=((3)*8-16)/4=2 -> h[2]
+    assert (ssm[43] == 4).all(), ssm[43]    # block 3 end: k=((4)*8-16)/4=4 -> h[4]
+    assert (ssm[44] == 100).all(), ssm[44]  # final (partial) block == final_states[0]
+    print("multiblock_continuation OK")
+
+
+def test_scatter_unaligned_num_computed_skips_interior():
+    # NEW (Defect 2a): a non-chunk-aligned num_computed_tokens must NOT write an
+    # approximate ("nearest chunk") interior SSM checkpoint into the content-hash-
+    # addressed prefix cache. Instead the interior scatter is skipped for that
+    # sequence (no crash) so it never poisons APC. The final block is still
+    # written from final_states (exact regardless of alignment). This must not
+    # crash because the startup CUDA-graph dummy run feeds synthetic, unaligned
+    # num_computed to throwaway state.
+    ssm = _state(60)
+    inter = _inter(2)  # chunks 0,1 only
+    final = _final(1)
+    block_table = torch.tensor([[50, 51]])
+    gdn_scatter_block_checkpoints(
+        ssm, inter, final, block_table,
+        block_idx_first_scheduled_token_p=torch.tensor([0]),
+        block_idx_last_scheduled_token_p=torch.tensor([1]),
+        num_computed_tokens_p=torch.tensor([2]),  # 2 % CHUNK(4) != 0 -> skip interior
+        first_chunk_p=torch.tensor([0]),
+        mamba_block_size=BLK, chunk_size=CHUNK,
+    )
+    assert (ssm[50] == -1).all(), ssm[50]   # interior block skipped (untouched)
+    assert (ssm[51] == 100).all(), ssm[51]  # final block still written (exact)
+    print("unaligned_num_computed_skips_interior OK")
+
+
+def test_scatter_mixed_alignment_skips_only_unaligned():
+    # NEW (Defect 2a): in a mixed batch, only the unaligned sequence's interior
+    # blocks are skipped; the aligned sequence is scattered normally, and both
+    # sequences' final blocks are written.
+    ssm = _state(60)
+    inter = _inter(6)
+    final = _final(2)
+    block_table = torch.tensor([[10, 11, 12, 0], [20, 21, 22, 0]])
+    gdn_scatter_block_checkpoints(
+        ssm, inter, final, block_table,
+        block_idx_first_scheduled_token_p=torch.tensor([0, 0]),
+        block_idx_last_scheduled_token_p=torch.tensor([2, 2]),
+        num_computed_tokens_p=torch.tensor([0, 5]),  # seq1: 5 % 4 != 0 -> skip
+        first_chunk_p=torch.tensor([0, 3]),
+        mamba_block_size=BLK, chunk_size=CHUNK,
+    )
+    # seq0 (aligned): interior blocks written.
+    assert (ssm[10] != -1).all() and (ssm[11] != -1).all()
+    assert (ssm[12] == 100).all()   # seq0 final
+    # seq1 (unaligned): interior blocks skipped, final still written.
+    assert (ssm[20] == -1).all() and (ssm[21] == -1).all()
+    assert (ssm[22] == 101).all()   # seq1 final
+    print("mixed_alignment_skips_only_unaligned OK")
+
+
+if __name__ == "__main__":
+    test_scatter_single_fresh()
+    test_scatter_varlen_two_seqs()
+    test_scatter_continuation()
+    test_scatter_multiblock_continuation()
+    test_scatter_unaligned_num_computed_skips_interior()
+    test_scatter_mixed_alignment_skips_only_unaligned()
+    print("SCATTER ALL PASS")

--- a/tests/kernels/mamba/test_gdn_scatter.py
+++ b/tests/kernels/mamba/test_gdn_scatter.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit test for gdn_scatter_block_checkpoints (Stage 3 all-mode scatter).
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for gdn_scatter_block_checkpoints (the all-mode checkpoint scatter).
 
 CPU-only, deterministic: inter_states[c] is filled with the value c, final_states[s]
 with 100+s, so we can assert exactly which chunk/final state lands in which block.
 Validates the FLA start-of-chunk index mapping (h[c]=state before chunk c) and the
 final-block-from-final-state rule, for fresh / varlen / chunked-continuation cases.
 """
+
 import torch
 
 from vllm.model_executor.layers.mamba.gdn.all_mode_utils import (
@@ -36,15 +38,19 @@ def test_scatter_single_fresh():
     final = _final(1)
     block_table = torch.tensor([[10, 11, 12, 0, 0]])
     gdn_scatter_block_checkpoints(
-        ssm, inter, final, block_table,
+        ssm,
+        inter,
+        final,
+        block_table,
         block_idx_first_scheduled_token_p=torch.tensor([0]),
         block_idx_last_scheduled_token_p=torch.tensor([2]),
         num_computed_tokens_p=torch.tensor([0]),
         first_chunk_p=torch.tensor([0]),
-        mamba_block_size=BLK, chunk_size=CHUNK,
+        mamba_block_size=BLK,
+        chunk_size=CHUNK,
     )
-    assert (ssm[10] == 2).all(), ssm[10]   # end of block 0 == h[2]
-    assert (ssm[11] == 4).all(), ssm[11]   # end of block 1 == h[4]
+    assert (ssm[10] == 2).all(), ssm[10]  # end of block 0 == h[2]
+    assert (ssm[11] == 4).all(), ssm[11]  # end of block 1 == h[4]
     assert (ssm[12] == 100).all(), ssm[12]  # final (partial) block == final_states[0]
     print("single_fresh OK")
 
@@ -55,15 +61,19 @@ def test_scatter_varlen_two_seqs():
     final = _final(2)
     block_table = torch.tensor([[10, 11, 12, 0, 0], [20, 21, 0, 0, 0]])
     gdn_scatter_block_checkpoints(
-        ssm, inter, final, block_table,
+        ssm,
+        inter,
+        final,
+        block_table,
         block_idx_first_scheduled_token_p=torch.tensor([0, 0]),
         block_idx_last_scheduled_token_p=torch.tensor([2, 1]),
         num_computed_tokens_p=torch.tensor([0, 0]),
         first_chunk_p=torch.tensor([0, 5]),
-        mamba_block_size=BLK, chunk_size=CHUNK,
+        mamba_block_size=BLK,
+        chunk_size=CHUNK,
     )
     assert (ssm[10] == 2).all() and (ssm[11] == 4).all() and (ssm[12] == 100).all()
-    assert (ssm[20] == 7).all(), ssm[20]    # seq1 block0 end == h[5+2]=h[7]
+    assert (ssm[20] == 7).all(), ssm[20]  # seq1 block0 end == h[5+2]=h[7]
     assert (ssm[21] == 101).all(), ssm[21]  # seq1 final block == final_states[1]
     print("varlen_two_seqs OK")
 
@@ -75,43 +85,52 @@ def test_scatter_continuation():
     final = _final(1)
     block_table = torch.tensor([[30, 31, 32]])
     gdn_scatter_block_checkpoints(
-        ssm, inter, final, block_table,
+        ssm,
+        inter,
+        final,
+        block_table,
         block_idx_first_scheduled_token_p=torch.tensor([1]),
         block_idx_last_scheduled_token_p=torch.tensor([2]),
         num_computed_tokens_p=torch.tensor([8]),
         first_chunk_p=torch.tensor([0]),
-        mamba_block_size=BLK, chunk_size=CHUNK,
+        mamba_block_size=BLK,
+        chunk_size=CHUNK,
     )
-    assert (ssm[30] == -1).all(), ssm[30]   # already-cached block untouched
-    assert (ssm[31] == 2).all(), ssm[31]    # block 1 end == h[2]
+    assert (ssm[30] == -1).all(), ssm[30]  # already-cached block untouched
+    assert (ssm[31] == 2).all(), ssm[31]  # block 1 end == h[2]
     assert (ssm[32] == 100).all(), ssm[32]  # final block == final_states[0]
     print("continuation OK")
 
 
 def test_scatter_multiblock_continuation():
-    # num_computed=16 (blocks 0,1 already cached), schedule blocks 2,3 full + block 4
-    # partial(final). Exercises num_computed spanning >1 cached block + >1 interior block.
+    # num_computed=16 (blocks 0,1 already cached), schedule blocks 2,3 full +
+    # block 4 partial(final). Exercises num_computed spanning >1 cached block
+    # + >1 interior block.
     ssm = _state(60)
     inter = _inter(5)  # scheduled chunks 0..4 (global)
     final = _final(1)
     block_table = torch.tensor([[40, 41, 42, 43, 44]])
     gdn_scatter_block_checkpoints(
-        ssm, inter, final, block_table,
+        ssm,
+        inter,
+        final,
+        block_table,
         block_idx_first_scheduled_token_p=torch.tensor([2]),
         block_idx_last_scheduled_token_p=torch.tensor([4]),
         num_computed_tokens_p=torch.tensor([16]),
         first_chunk_p=torch.tensor([0]),
-        mamba_block_size=BLK, chunk_size=CHUNK,
+        mamba_block_size=BLK,
+        chunk_size=CHUNK,
     )
     assert (ssm[40] == -1).all() and (ssm[41] == -1).all()  # cached blocks untouched
-    assert (ssm[42] == 2).all(), ssm[42]    # block 2 end: k=((3)*8-16)/4=2 -> h[2]
-    assert (ssm[43] == 4).all(), ssm[43]    # block 3 end: k=((4)*8-16)/4=4 -> h[4]
+    assert (ssm[42] == 2).all(), ssm[42]  # block 2 end: k=((3)*8-16)/4=2 -> h[2]
+    assert (ssm[43] == 4).all(), ssm[43]  # block 3 end: k=((4)*8-16)/4=4 -> h[4]
     assert (ssm[44] == 100).all(), ssm[44]  # final (partial) block == final_states[0]
     print("multiblock_continuation OK")
 
 
 def test_scatter_unaligned_num_computed_skips_interior():
-    # NEW (Defect 2a): a non-chunk-aligned num_computed_tokens must NOT write an
+    # A non-chunk-aligned num_computed_tokens must NOT write an
     # approximate ("nearest chunk") interior SSM checkpoint into the content-hash-
     # addressed prefix cache. Instead the interior scatter is skipped for that
     # sequence (no crash) so it never poisons APC. The final block is still
@@ -123,20 +142,24 @@ def test_scatter_unaligned_num_computed_skips_interior():
     final = _final(1)
     block_table = torch.tensor([[50, 51]])
     gdn_scatter_block_checkpoints(
-        ssm, inter, final, block_table,
+        ssm,
+        inter,
+        final,
+        block_table,
         block_idx_first_scheduled_token_p=torch.tensor([0]),
         block_idx_last_scheduled_token_p=torch.tensor([1]),
         num_computed_tokens_p=torch.tensor([2]),  # 2 % CHUNK(4) != 0 -> skip interior
         first_chunk_p=torch.tensor([0]),
-        mamba_block_size=BLK, chunk_size=CHUNK,
+        mamba_block_size=BLK,
+        chunk_size=CHUNK,
     )
-    assert (ssm[50] == -1).all(), ssm[50]   # interior block skipped (untouched)
+    assert (ssm[50] == -1).all(), ssm[50]  # interior block skipped (untouched)
     assert (ssm[51] == 100).all(), ssm[51]  # final block still written (exact)
     print("unaligned_num_computed_skips_interior OK")
 
 
 def test_scatter_mixed_alignment_skips_only_unaligned():
-    # NEW (Defect 2a): in a mixed batch, only the unaligned sequence's interior
+    # In a mixed batch, only the unaligned sequence's interior
     # blocks are skipped; the aligned sequence is scattered normally, and both
     # sequences' final blocks are written.
     ssm = _state(60)
@@ -144,19 +167,23 @@ def test_scatter_mixed_alignment_skips_only_unaligned():
     final = _final(2)
     block_table = torch.tensor([[10, 11, 12, 0], [20, 21, 22, 0]])
     gdn_scatter_block_checkpoints(
-        ssm, inter, final, block_table,
+        ssm,
+        inter,
+        final,
+        block_table,
         block_idx_first_scheduled_token_p=torch.tensor([0, 0]),
         block_idx_last_scheduled_token_p=torch.tensor([2, 2]),
         num_computed_tokens_p=torch.tensor([0, 5]),  # seq1: 5 % 4 != 0 -> skip
         first_chunk_p=torch.tensor([0, 3]),
-        mamba_block_size=BLK, chunk_size=CHUNK,
+        mamba_block_size=BLK,
+        chunk_size=CHUNK,
     )
     # seq0 (aligned): interior blocks written.
     assert (ssm[10] != -1).all() and (ssm[11] != -1).all()
-    assert (ssm[12] == 100).all()   # seq0 final
+    assert (ssm[12] == 100).all()  # seq0 final
     # seq1 (unaligned): interior blocks skipped, final still written.
     assert (ssm[20] == -1).all() and (ssm[21] == -1).all()
-    assert (ssm[22] == 101).all()   # seq1 final
+    assert (ssm[22] == 101).all()  # seq1 final
     print("mixed_alignment_skips_only_unaligned OK")
 
 

--- a/tests/kernels/mamba/test_gdn_traffic_opt.py
+++ b/tests/kernels/mamba/test_gdn_traffic_opt.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the GDN traffic-opt weight-layout transforms (C9 de-interleave +
+C6 tiny-GEMM concat).
+
+Covers:
+ - permutation round-trip vs the interleaved unpack (bit-exact)
+ - GEMM pipeline equivalence old-vs-new at real serve dtypes (C9 must be
+   bit-exact; C6 is torch.equal-first with ULP quantification on failure)
+ - conv/gating decode kernels accepting row-strided mixed_qkv (the new
+   regime: mixed_qkv is a view into the projection output)
+ - MoE router+shared-expert-gate weight concat math
+ - view-identity dispatch asserts (the unpack glue copies are gone by
+   construction when the flags are on)
+"""
+
+import os
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    QwenGatedDeltaNetAttention,
+    build_ba_deinterleave_perm,
+    build_qkvz_deinterleave_perm,
+    gdn_concat_router_gate_enabled,
+    gdn_concat_tiny_gemms_enabled,
+    gdn_deinterleave_qkvz_enabled,
+)
+
+H, HV, K, V = 16, 32, 128, 128  # TP1 Qwen3-Next-80B GDN geometry
+NG = H
+NVG = HV // H
+HIDDEN = 2048
+QKVZ_N = 2 * H * K + 2 * HV * V  # 12288
+QKV_N = 2 * H * K + HV * V  # 8192
+BA_N = 2 * HV  # 64
+T = 4  # spec tokens per seq (k=3 + bonus)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+class Duck:
+    gqa_interleaved_layout = True
+    num_k_heads = H
+    num_v_heads = HV
+    head_k_dim = K
+    head_v_dim = V
+    tp_size = 1
+    key_dim = H * K
+    value_dim = HV * V
+
+
+def _unpack_interleaved(qkvz: torch.Tensor, ba: torch.Tensor):
+    """The exact old (interleaved) unpack, via the module's own method."""
+    fn = QwenGatedDeltaNetAttention.prepare_gdn_attention_core_inputs
+    return fn(Duck(), qkvz, ba, qkvz.shape[0])
+
+
+def _split_flat(qkvz: torch.Tensor, ba: torch.Tensor):
+    """The new (de-interleaved) unpack: views only."""
+    mixed_qkv, z = qkvz.split([QKV_N, HV * V], dim=-1)
+    z = z.reshape(z.size(0), HV, V)
+    b, a = ba.chunk(2, dim=-1)
+    return mixed_qkv, z, b.contiguous(), a.contiguous()
+
+
+def _drift_stats(x: torch.Tensor, y: torch.Tensor) -> dict:
+    """Quantify bf16 drift: max abs diff, max diff relative to the tensor
+    scale, and the fraction of exactly-equal elements. (A raw int16-bit
+    "ULP" distance misreads sign flips near zero, so scale-relative abs
+    diff is the honest metric for reassociation drift.)"""
+    xf, yf = x.float(), y.float()
+    d = (xf - yf).abs()
+    scale = yf.abs().max().clamp_min(1e-12)
+    return {
+        "max_abs": d.max().item(),
+        "max_rel_to_scale": (d.max() / scale).item(),
+        "equal_frac": (x == y).float().mean().item(),
+    }
+
+
+def test_flag_defaults_and_off(monkeypatch):
+    monkeypatch.delenv("VLLM_GDN_DEINTERLEAVE_QKVZ", raising=False)
+    monkeypatch.delenv("VLLM_GDN_CONCAT_TINY_GEMMS", raising=False)
+    monkeypatch.delenv("VLLM_GDN_CONCAT_ROUTER_GATE", raising=False)
+    assert gdn_deinterleave_qkvz_enabled()
+    assert gdn_concat_tiny_gemms_enabled()
+    # router-gate fold is default OFF (measured in-graph negative unpadded,
+    # marginal padded, plus routing-logit drift)
+    assert not gdn_concat_router_gate_enabled()
+    monkeypatch.setenv("VLLM_GDN_DEINTERLEAVE_QKVZ", "0")
+    monkeypatch.setenv("VLLM_GDN_CONCAT_TINY_GEMMS", "0")
+    monkeypatch.setenv("VLLM_GDN_CONCAT_ROUTER_GATE", "1")
+    assert not gdn_deinterleave_qkvz_enabled()
+    assert not gdn_concat_tiny_gemms_enabled()
+    assert gdn_concat_router_gate_enabled()
+
+
+@pytest.mark.parametrize("ntok", [1, 7, 128])
+def test_deinterleave_perm_round_trip(ntok):
+    """Permuting the projection output columns must reproduce exactly what
+    the interleaved unpack produced (bit-exact, pure data movement)."""
+    torch.manual_seed(0)
+    dev = torch.device("cuda")
+    qkvz = torch.randn(ntok, QKVZ_N, dtype=torch.bfloat16, device=dev)
+    ba = torch.randn(ntok, BA_N, dtype=torch.bfloat16, device=dev)
+
+    mq_old, z_old, b_old, a_old = _unpack_interleaved(qkvz, ba)
+
+    perm_qkvz = build_qkvz_deinterleave_perm(NG, K, V, NVG, device=dev)
+    perm_ba = build_ba_deinterleave_perm(NG, NVG, device=dev)
+    mq_new, z_new, b_new, a_new = _split_flat(qkvz[:, perm_qkvz], ba[:, perm_ba])
+
+    assert torch.equal(mq_old, mq_new)
+    assert torch.equal(z_old, z_new)
+    assert torch.equal(b_old, b_new)
+    assert torch.equal(a_old, a_new)
+
+
+@pytest.mark.parametrize("ntok", [16, 128])
+def test_gemm_pipeline_c9_bit_exact(ntok):
+    """C9 alone: row-permuted weights -> same GEMM shape -> outputs must be
+    bit-exact against the old two-GEMM + interleaved-unpack pipeline."""
+    torch.manual_seed(1)
+    dev = torch.device("cuda")
+    w_qkvz = torch.randn(QKVZ_N, HIDDEN, dtype=torch.bfloat16, device=dev) * 0.02
+    w_ba = torch.randn(BA_N, HIDDEN, dtype=torch.bfloat16, device=dev) * 0.02
+    h = torch.randn(ntok, HIDDEN, dtype=torch.bfloat16, device=dev)
+
+    qkvz_old = torch.nn.functional.linear(h, w_qkvz)
+    ba_old = torch.nn.functional.linear(h, w_ba)
+    mq_old, z_old, b_old, a_old = _unpack_interleaved(qkvz_old, ba_old)
+
+    perm_qkvz = build_qkvz_deinterleave_perm(NG, K, V, NVG, device=dev)
+    perm_ba = build_ba_deinterleave_perm(NG, NVG, device=dev)
+    qkvz_new = torch.nn.functional.linear(h, w_qkvz[perm_qkvz].contiguous())
+    ba_new = torch.nn.functional.linear(h, w_ba[perm_ba].contiguous())
+    mq_new, z_new, b_new, a_new = _split_flat(qkvz_new, ba_new)
+
+    assert torch.equal(mq_old, mq_new), "C9 must be bit-exact (row perm only)"
+    assert torch.equal(z_old, z_new)
+    assert torch.equal(b_old, b_new)
+    assert torch.equal(a_old, a_new)
+    # dispatch assert: the new unpack is views into the GEMM output
+    assert mq_new.data_ptr() == qkvz_new.data_ptr()
+    assert z_new.data_ptr() == qkvz_new.data_ptr() + QKV_N * qkvz_new.element_size()
+
+
+@pytest.mark.parametrize("ntok", [16, 128])
+def test_gemm_pipeline_c6_concat(ntok):
+    """C6 (+C9): one fused [12352, hidden] GEMM. torch.equal first; if the
+    larger N picks a different tile config, quantify the ULP delta (must
+    stay ULP-class) and report."""
+    torch.manual_seed(2)
+    dev = torch.device("cuda")
+    w_qkvz = torch.randn(QKVZ_N, HIDDEN, dtype=torch.bfloat16, device=dev) * 0.02
+    w_ba = torch.randn(BA_N, HIDDEN, dtype=torch.bfloat16, device=dev) * 0.02
+    h = torch.randn(ntok, HIDDEN, dtype=torch.bfloat16, device=dev)
+
+    perm_qkvz = build_qkvz_deinterleave_perm(NG, K, V, NVG, device=dev)
+    perm_ba = build_ba_deinterleave_perm(NG, NVG, device=dev)
+    w_qkvz_p = w_qkvz[perm_qkvz].contiguous()
+    w_ba_p = w_ba[perm_ba].contiguous()
+
+    ref_qkvz = torch.nn.functional.linear(h, w_qkvz_p)
+    ref_ba = torch.nn.functional.linear(h, w_ba_p)
+
+    w_fused = torch.cat([w_qkvz_p, w_ba_p], dim=0)
+    out = torch.nn.functional.linear(h, w_fused)
+    got_qkvz = out[:, :QKVZ_N]
+    got_ba = out[:, QKVZ_N:]
+
+    bitexact = torch.equal(got_qkvz, ref_qkvz) and torch.equal(got_ba, ref_ba)
+    if not bitexact:
+        s_qkvz = _drift_stats(got_qkvz.contiguous(), ref_qkvz)
+        s_ba = _drift_stats(got_ba.contiguous(), ref_ba)
+        print(
+            f"\nC6 in_proj concat NOT bit-exact at ntok={ntok}: "
+            f"qkvz={s_qkvz} ba={s_ba}"
+        )
+        assert s_qkvz["max_rel_to_scale"] <= 2**-7, (
+            "C6 in_proj drift exceeds ULP-class; investigate before shipping"
+        )
+        assert s_ba["max_rel_to_scale"] <= 2**-7
+    # dispatch assert: both consumers are views of ONE GEMM output
+    assert got_qkvz.data_ptr() == out.data_ptr()
+    assert got_ba.data_ptr() == out.data_ptr() + QKVZ_N * out.element_size()
+
+
+@pytest.mark.parametrize("ntok", [16, 128])
+def test_moe_gate_concat(ntok):
+    """C6 router-gate fold: [512+1, hidden] fused logits vs the two
+    separate GEMMs. torch.equal first, ULP quantification on failure."""
+    torch.manual_seed(3)
+    dev = torch.device("cuda")
+    w_gate = torch.randn(512, HIDDEN, dtype=torch.bfloat16, device=dev) * 0.02
+    w_seg = torch.randn(1, HIDDEN, dtype=torch.bfloat16, device=dev) * 0.02
+    h = torch.randn(ntok, HIDDEN, dtype=torch.bfloat16, device=dev)
+
+    ref_logits = torch.nn.functional.linear(h, w_gate)
+    ref_seg = torch.nn.functional.linear(h, w_seg)
+
+    # padded fold (N 513 -> 528), as the runner builds it
+    combined = torch.cat([w_gate, w_seg], dim=0)
+    pad = (-combined.shape[0]) % 16
+    combined = torch.cat(
+        [combined, combined.new_zeros(pad, combined.shape[1])], dim=0
+    )
+    fused = torch.nn.functional.linear(h, combined)
+    got_logits = fused[:, :512].contiguous()
+    got_seg = fused[:, 512:513]
+
+    bitexact = torch.equal(got_logits, ref_logits) and torch.equal(
+        got_seg.contiguous(), ref_seg
+    )
+    if not bitexact:
+        # KNOWN + REPORTED: N=512 vs N=513 picks a different cuBLAS
+        # reduction, so reassociation drift is expected. The bound below is
+        # ULP-class relative to the logit scale; near-zero logits may flip
+        # sign. Whether this flips near-tie top-k routing picks is
+        # validated by the greedy-sha e2e comparison (report both).
+        s_l = _drift_stats(got_logits, ref_logits)
+        s_s = _drift_stats(got_seg.contiguous(), ref_seg)
+        print(
+            f"\nMoE gate concat NOT bit-exact at ntok={ntok}: "
+            f"logits={s_l} segate={s_s}"
+        )
+        assert s_l["max_rel_to_scale"] <= 2**-7
+        assert s_s["max_rel_to_scale"] <= 2**-7
+    # relocated sigmoid scaling is the same op on the same values
+    se_out = torch.randn(ntok, HIDDEN, dtype=torch.bfloat16, device=dev)
+    old = torch.nn.functional.sigmoid(ref_seg) * se_out
+    new = torch.sigmoid(got_seg) * se_out
+    if torch.equal(ref_seg, got_seg.contiguous()):
+        assert torch.equal(old, new)
+
+
+@pytest.mark.parametrize("batch", [4, 32])
+def test_decode_kernels_accept_row_strided_qkv(batch):
+    """The new regime feeds the conv+gating decode pair a row-strided
+    mixed_qkv view (token stride 12352, stride(-1)==1). Outputs and final
+    states must be bit-identical to the contiguous input."""
+    from vllm.third_party.flash_linear_attention.ops import (
+        fused_sigmoid_gating_delta_rule_update,
+    )
+    from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+        causal_conv1d_update,
+    )
+
+    torch.manual_seed(4)
+    dev = torch.device("cuda")
+    ntok = batch * T
+    DIM = QKV_N
+    W = 4
+    WT = 16
+    NB = batch * WT + 16
+
+    # row-strided view: mixed_qkv occupies the first DIM cols of a wider
+    # (fused-GEMM-shaped) buffer
+    wide = torch.randn(ntok, QKVZ_N + BA_N, dtype=torch.bfloat16, device=dev)
+    x_strided = wide[:, :DIM]
+    x_contig = x_strided.contiguous()
+    assert x_strided.stride(0) == QKVZ_N + BA_N
+
+    a = torch.rand(ntok, HV, dtype=torch.bfloat16, device=dev)
+    b = torch.rand(ntok, HV, dtype=torch.bfloat16, device=dev)
+    A_log = torch.rand(HV, dtype=torch.float32, device=dev)
+    dtb = torch.rand(HV, dtype=torch.float32, device=dev)
+    wgt = torch.rand(DIM, W, dtype=torch.bfloat16, device=dev)
+    bias = torch.rand(DIM, dtype=torch.bfloat16, device=dev)
+    cu = torch.arange(0, ntok + 1, T, dtype=torch.int32, device=dev)
+    acc = torch.full((batch,), T, dtype=torch.int32, device=dev)
+
+    ids = torch.randperm(NB - 1, device=dev)[: batch * WT].int() + 1
+    table = ids.view(batch, WT).contiguous()
+    pa = torch.stack(
+        [
+            torch.zeros(batch, dtype=torch.int32, device=dev),
+            torch.ones(batch, dtype=torch.int32, device=dev),
+        ],
+        1,
+    ).contiguous()
+
+    outs = {}
+    for name, x in (("strided", x_strided), ("contig", x_contig)):
+        torch.manual_seed(5)  # identical pools per arm
+        conv_pool = torch.rand(
+            NB, DIM, W - 1 + T - 1, dtype=torch.bfloat16, device=dev
+        )
+        ssm_pool = torch.rand(NB, HV, V, K, dtype=torch.bfloat16, device=dev)
+        conv_out = causal_conv1d_update(
+            x,
+            conv_pool,
+            wgt,
+            bias,
+            "silu",
+            conv_state_indices=table,
+            packed_anchors=pa,
+            num_accepted_tokens=acc,
+            query_start_loc=cu,
+            max_query_len=T,
+        )
+        core, _ = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dtb,
+            mixed_qkv=conv_out,
+            num_qk_heads=H,
+            head_qk_dim=K,
+            num_v_heads=HV,
+            head_v_dim=V,
+            initial_state=ssm_pool,
+            inplace_final_state=True,
+            cu_seqlens=cu,
+            block_table=table,
+            packed_anchors=pa,
+            num_accepted_tokens=acc,
+            use_qk_l2norm_in_kernel=True,
+        )
+        outs[name] = (conv_out.clone(), core.clone(), conv_pool, ssm_pool)
+
+    assert torch.equal(outs["strided"][0], outs["contig"][0]), "conv out"
+    assert torch.equal(outs["strided"][1], outs["contig"][1]), "core out"
+    assert torch.equal(outs["strided"][2], outs["contig"][2]), "conv state"
+    assert torch.equal(outs["strided"][3], outs["contig"][3]), "ssm state"
+
+
+def test_gating_kernel_strided_direct():
+    """fused_sigmoid_gating also directly accepts a strided mixed_qkv
+    (decode paths that skip conv rewrites)."""
+    from vllm.third_party.flash_linear_attention.ops import (
+        fused_sigmoid_gating_delta_rule_update,
+    )
+
+    torch.manual_seed(6)
+    dev = torch.device("cuda")
+    batch, ntok = 8, 8 * T
+    DIM = QKV_N
+    WT = 8
+    NB = batch * WT + 16
+
+    wide = torch.randn(ntok, QKVZ_N + BA_N, dtype=torch.bfloat16, device=dev)
+    x_strided = wide[:, :DIM]
+    x_contig = x_strided.contiguous()
+
+    a = torch.rand(ntok, HV, dtype=torch.bfloat16, device=dev)
+    b = torch.rand(ntok, HV, dtype=torch.bfloat16, device=dev)
+    A_log = torch.rand(HV, dtype=torch.float32, device=dev)
+    dtb = torch.rand(HV, dtype=torch.float32, device=dev)
+    cu = torch.arange(0, ntok + 1, T, dtype=torch.int32, device=dev)
+    acc = torch.full((batch,), T, dtype=torch.int32, device=dev)
+    ids = torch.randperm(NB - 1, device=dev)[: batch * WT].int() + 1
+    table = ids.view(batch, WT).contiguous()
+    pa = torch.stack(
+        [
+            torch.zeros(batch, dtype=torch.int32, device=dev),
+            torch.ones(batch, dtype=torch.int32, device=dev),
+        ],
+        1,
+    ).contiguous()
+
+    results = []
+    for x in (x_strided, x_contig):
+        torch.manual_seed(7)
+        ssm_pool = torch.rand(NB, HV, V, K, dtype=torch.bfloat16, device=dev)
+        core, _ = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dtb,
+            mixed_qkv=x,
+            num_qk_heads=H,
+            head_qk_dim=K,
+            num_v_heads=HV,
+            head_v_dim=V,
+            initial_state=ssm_pool,
+            inplace_final_state=True,
+            cu_seqlens=cu,
+            block_table=table,
+            packed_anchors=pa,
+            num_accepted_tokens=acc,
+            use_qk_l2norm_in_kernel=True,
+        )
+        results.append((core.clone(), ssm_pool.clone()))
+
+    assert torch.equal(results[0][0], results[1][0])
+    assert torch.equal(results[0][1], results[1][1])

--- a/tests/kernels/moe/test_mono_agrs_selection.py
+++ b/tests/kernels/moe/test_mono_agrs_selection.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GDN R3: monolithic trtllm-gen NVFP4 MoE backend under allgather-EP.
+
+Selection-level tests for the ``VLLM_GDN_MOE_MONO_AGRS`` gate on
+``TrtLlmNvFp4ExpertsMonolithic._supports_parallel_config``:
+
+- TP4+EP (allgather_reducescatter all2all, sequence-parallel MoE):
+  flag=1 (opt-in) -> Monolithic accepted, wins oracle ordering, and
+  pairs with ``MoEPrepareAndFinalizeNaiveDPEPMonolithic``;
+  flag unset/=0 (default) -> exact previous behavior (Monolithic rejected ->
+  Modular + ``MoEPrepareAndFinalizeNaiveDPEPModular``).
+- TP1 (no EP, no all2all): Monolithic accepted under BOTH flag values —
+  TP1 selection is provably untouched by the gate.
+- Every other all2all backend and the EPLB case remain rejected under both
+  flag values.
+
+The predicate/factory tests are pure-CPU. The oracle-path test exercises
+``is_supported_config`` exactly as ``select_nvfp4_moe_backend`` does and
+therefore requires a Blackwell GPU + flashinfer (skipped elsewhere).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.fused_moe.experts.trtllm_nvfp4_moe import (
+    TrtLlmNvFp4ExpertsModular,
+    TrtLlmNvFp4ExpertsMonolithic,
+)
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
+    backend_to_kernel_cls,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize import (
+    make_moe_prepare_and_finalize_naive_dp_ep,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize.naive_dp_ep import (
+    MoEPrepareAndFinalizeNaiveDPEPModular,
+    MoEPrepareAndFinalizeNaiveDPEPMonolithic,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kNvfp4Dynamic,
+    kNvfp4Static,
+)
+
+FLAG = "VLLM_GDN_MOE_MONO_AGRS"
+
+
+def _parallel_config(
+    *,
+    ep_size: int = 1,
+    sp_size: int = 1,
+    dp_size: int = 1,
+    all2all_backend: str = "allgather_reducescatter",
+    enable_eplb: bool = False,
+) -> FusedMoEParallelConfig:
+    """Build the config exactly as FusedMoEParallelConfig.make does.
+
+    TP4 + --enable-expert-parallel + allgather_reducescatter (the GDN serve
+    shape) flattens to: tp_size=1, ep_size=4, dp_size=1, sp_size=4
+    (use_sequence_parallel_moe), so use_all2all_kernels is True via the
+    sequence-parallel branch.
+    """
+    return FusedMoEParallelConfig(
+        tp_size=1,
+        pcp_size=1,
+        dp_size=dp_size,
+        ep_size=ep_size,
+        tp_rank=0,
+        pcp_rank=0,
+        dp_rank=0,
+        ep_rank=0,
+        sp_size=sp_size,
+        use_ep=ep_size > 1,
+        all2all_backend=all2all_backend,
+        enable_eplb=enable_eplb,
+    )
+
+
+def _tp4_ep_agrs(**kwargs) -> FusedMoEParallelConfig:
+    return _parallel_config(ep_size=4, sp_size=4, **kwargs)
+
+
+def _tp1() -> FusedMoEParallelConfig:
+    return _parallel_config()
+
+
+def _set_flag(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    if value is None:
+        monkeypatch.delenv(FLAG, raising=False)
+    else:
+        monkeypatch.setenv(FLAG, value)
+
+
+def _select_trtllm_kernel(moe_parallel_config) -> type[mk.FusedMoEExperts]:
+    """First kernel class whose parallel predicate accepts the config, in
+    oracle preference order (mirrors select_nvfp4_moe_backend's loop for the
+    parallel-config axis)."""
+    for k_cls in backend_to_kernel_cls(NvFp4MoeBackend.FLASHINFER_TRTLLM):
+        if k_cls._supports_parallel_config(moe_parallel_config):
+            return k_cls
+    raise AssertionError("no trtllm kernel accepted the parallel config")
+
+
+class TestParallelConfigSanity:
+    def test_tp4_ep_agrs_shape(self):
+        cfg = _tp4_ep_agrs()
+        assert cfg.use_all2all_kernels
+        assert cfg.use_ag_rs_all2all_kernels
+
+    def test_tp1_shape(self):
+        cfg = _tp1()
+        assert not cfg.use_all2all_kernels
+        assert not cfg.use_ag_rs_all2all_kernels
+
+    def test_oracle_prefers_monolithic(self):
+        # Selection order is Monolithic first — required for the flag to
+        # change the outcome at all.
+        assert backend_to_kernel_cls(NvFp4MoeBackend.FLASHINFER_TRTLLM) == [
+            TrtLlmNvFp4ExpertsMonolithic,
+            TrtLlmNvFp4ExpertsModular,
+        ]
+
+
+class TestMonoAgrsPredicate:
+    @pytest.mark.parametrize("flag", ["1"])
+    def test_tp4_ep_agrs_flag_on_selects_monolithic(self, monkeypatch, flag):
+        _set_flag(monkeypatch, flag)
+        cfg = _tp4_ep_agrs()
+        assert TrtLlmNvFp4ExpertsMonolithic._supports_parallel_config(cfg)
+        assert _select_trtllm_kernel(cfg) is TrtLlmNvFp4ExpertsMonolithic
+
+    @pytest.mark.parametrize("flag", [None, "0"])
+    def test_tp4_ep_agrs_flag_off_selects_modular(self, monkeypatch, flag):
+        _set_flag(monkeypatch, flag)
+        cfg = _tp4_ep_agrs()
+        assert not TrtLlmNvFp4ExpertsMonolithic._supports_parallel_config(cfg)
+        # Exact previous behavior: fall through to the Modular kernel.
+        assert TrtLlmNvFp4ExpertsModular._supports_parallel_config(cfg)
+        assert _select_trtllm_kernel(cfg) is TrtLlmNvFp4ExpertsModular
+
+    @pytest.mark.parametrize("flag", [None, "0", "1"])
+    def test_tp1_selects_monolithic_under_both_flags(self, monkeypatch, flag):
+        _set_flag(monkeypatch, flag)
+        cfg = _tp1()
+        assert TrtLlmNvFp4ExpertsMonolithic._supports_parallel_config(cfg)
+        assert _select_trtllm_kernel(cfg) is TrtLlmNvFp4ExpertsMonolithic
+
+    @pytest.mark.parametrize("flag", [None, "0", "1"])
+    @pytest.mark.parametrize(
+        "backend",
+        [
+            "deepep_high_throughput",
+            "deepep_low_latency",
+            "flashinfer_all2allv",
+            "naive",
+        ],
+    )
+    def test_other_all2all_backends_still_rejected(self, monkeypatch, flag, backend):
+        _set_flag(monkeypatch, flag)
+        cfg = _tp4_ep_agrs(all2all_backend=backend)
+        assert not TrtLlmNvFp4ExpertsMonolithic._supports_parallel_config(cfg)
+
+    @pytest.mark.parametrize("flag", [None, "0", "1"])
+    def test_eplb_still_rejected(self, monkeypatch, flag):
+        _set_flag(monkeypatch, flag)
+        cfg = _tp4_ep_agrs(enable_eplb=True)
+        assert not TrtLlmNvFp4ExpertsMonolithic._supports_parallel_config(cfg)
+        # EPLB without any all2all is also rejected (pre-existing behavior).
+        cfg_no_a2a = _parallel_config(enable_eplb=True)
+        assert not TrtLlmNvFp4ExpertsMonolithic._supports_parallel_config(cfg_no_a2a)
+
+
+class TestPrepareFinalizePairing:
+    """The oracle passes use_monolithic=issubclass(experts_cls,
+    FusedMoEExpertsMonolithic) into maybe_make_prepare_finalize, which for the
+    ag_rs backend calls make_moe_prepare_and_finalize_naive_dp_ep. Verify the
+    subclass relationships and the factory mapping."""
+
+    def test_kernel_interface_subclassing(self):
+        assert issubclass(TrtLlmNvFp4ExpertsMonolithic, mk.FusedMoEExpertsMonolithic)
+        assert not issubclass(TrtLlmNvFp4ExpertsModular, mk.FusedMoEExpertsMonolithic)
+
+    def test_factory_monolithic(self):
+        pf = make_moe_prepare_and_finalize_naive_dp_ep(
+            use_monolithic=True, is_sequence_parallel=True, num_dispatchers=4
+        )
+        assert type(pf) is MoEPrepareAndFinalizeNaiveDPEPMonolithic
+        assert pf.num_dispatchers() == 4
+
+    def test_factory_modular(self):
+        pf = make_moe_prepare_and_finalize_naive_dp_ep(
+            use_monolithic=False, is_sequence_parallel=True, num_dispatchers=4
+        )
+        assert type(pf) is MoEPrepareAndFinalizeNaiveDPEPModular
+
+
+def _fake_moe_config(moe_parallel_config) -> SimpleNamespace:
+    """Just the attributes is_supported_config reads."""
+    return SimpleNamespace(
+        is_act_and_mul=True,
+        activation=MoEActivation.SILU,
+        moe_parallel_config=moe_parallel_config,
+        routing_method=RoutingMethodType.Renormalize,
+        router_logits_dtype=torch.bfloat16,
+        hidden_dim=2048,
+        is_lora_enabled=False,
+    )
+
+
+def _oracle_select(moe_parallel_config) -> type[mk.FusedMoEExperts]:
+    """Mirror select_nvfp4_moe_backend's _return_or_raise over the trtllm
+    kernel list, through the real is_supported_config entry point."""
+    moe_config = _fake_moe_config(moe_parallel_config)
+    for k_cls in backend_to_kernel_cls(NvFp4MoeBackend.FLASHINFER_TRTLLM):
+        supported, _ = k_cls.is_supported_config(
+            k_cls,
+            moe_config,
+            kNvfp4Static,
+            kNvfp4Dynamic,
+            mk.FusedMoEActivationFormat.Standard,
+        )
+        if supported:
+            return k_cls
+    raise AssertionError("no trtllm kernel supported the config")
+
+
+requires_trtllm_device = pytest.mark.skipif(
+    not TrtLlmNvFp4ExpertsMonolithic._supports_current_device(),
+    reason="requires Blackwell GPU with flashinfer trtllm fused MoE",
+)
+
+
+@requires_trtllm_device
+class TestOracleSelection:
+    """Full is_supported_config path (device + quant + routing + parallel)."""
+
+    @pytest.mark.parametrize("flag", ["1"])
+    def test_tp4_ep_agrs_flag_on(self, monkeypatch, flag):
+        _set_flag(monkeypatch, flag)
+        assert _oracle_select(_tp4_ep_agrs()) is TrtLlmNvFp4ExpertsMonolithic
+
+    @pytest.mark.parametrize("flag", [None, "0"])
+    def test_tp4_ep_agrs_flag_off(self, monkeypatch, flag):
+        _set_flag(monkeypatch, flag)
+        assert _oracle_select(_tp4_ep_agrs()) is TrtLlmNvFp4ExpertsModular
+
+    @pytest.mark.parametrize("flag", [None, "0", "1"])
+    def test_tp1_both_flags(self, monkeypatch, flag):
+        _set_flag(monkeypatch, flag)
+        assert _oracle_select(_tp1()) is TrtLlmNvFp4ExpertsMonolithic

--- a/tests/models/test_qwen3_next_prefix_caching.py
+++ b/tests/models/test_qwen3_next_prefix_caching.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen3Next declares SupportsMambaPrefixCaching: mamba_cache_mode='all'
+(per-block SSM checkpointing for GDN layers) is enabled instead of being
+silently downgraded to 'align' or rejected at model init."""
+
+from types import SimpleNamespace
+
+from vllm.model_executor.models.config import MambaModelConfig
+from vllm.model_executor.models.interfaces import supports_mamba_prefix_caching
+from vllm.model_executor.models.qwen3_next import Qwen3NextForCausalLM
+
+
+def test_qwen3_next_declares_mamba_prefix_caching_support():
+    assert supports_mamba_prefix_caching(Qwen3NextForCausalLM)
+
+
+def _fake_vllm_config(mamba_cache_mode, supports):
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            supports_mamba_prefix_caching=supports,
+            architecture="Qwen3NextForCausalLM",
+        ),
+        cache_config=SimpleNamespace(
+            enable_prefix_caching=True,
+            mamba_cache_mode=mamba_cache_mode,
+            mamba_block_size=None,
+            block_size=16,
+        ),
+        scheduler_config=SimpleNamespace(enable_chunked_prefill=True),
+    )
+
+
+def test_supported_model_defaults_to_all_mode():
+    """With prefix caching on and no explicit mode, a supporting model gets
+    'all' (previously Qwen3Next fell to 'align')."""
+    cfg = _fake_vllm_config("none", supports=True)
+    MambaModelConfig.verify_and_update_config(cfg)
+    assert cfg.cache_config.mamba_cache_mode == "all"
+
+
+def test_supported_model_keeps_explicit_all_mode():
+    """Explicit --mamba-cache-mode=all is no longer downgraded."""
+    cfg = _fake_vllm_config("all", supports=True)
+    MambaModelConfig.verify_and_update_config(cfg)
+    assert cfg.cache_config.mamba_cache_mode == "all"
+
+
+def test_unsupported_model_still_downgrades_to_align():
+    """REGRESSION: models without the interface keep the align fallback."""
+    cfg = _fake_vllm_config("all", supports=False)
+    MambaModelConfig.verify_and_update_config(cfg)
+    assert cfg.cache_config.mamba_cache_mode == "align"

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -125,6 +125,7 @@ GDN_BUILD_TEST_CASES = {
 def _create_gdn_builder(
     num_speculative_tokens: int = 0,
     full_cuda_graph: bool = False,
+    mamba_cache_mode: str = "align",
 ) -> GDNAttentionMetadataBuilder:
     """Create a GDNAttentionMetadataBuilder with minimal config."""
     vllm_config = create_vllm_config(
@@ -138,6 +139,11 @@ def _create_gdn_builder(
             method="ngram",
             num_speculative_tokens=num_speculative_tokens,
         )
+    vllm_config.cache_config.mamba_cache_mode = mamba_cache_mode
+    if mamba_cache_mode == "all":
+        # all-mode requires the Triton/FLA prefill backend (the resolver
+        # fails fast on any other), exactly as production configs must.
+        vllm_config.additional_config = {"gdn_prefill_backend": "triton"}
     mamba_spec = MambaSpec(
         block_size=BLOCK_SIZE,
         shapes=((16, 64),),
@@ -155,6 +161,7 @@ def _build(
     builder: GDNAttentionMetadataBuilder,
     batch_spec: BatchSpec,
     num_decode_draft_tokens: list[int] | None = None,
+    prev_last_scheduled_idx: list[int] | None = None,
 ) -> GDNAttentionMetadata:
     """Build GDN attention metadata, optionally with spec-decode kwargs."""
     common = create_common_attn_metadata(batch_spec, BLOCK_SIZE, DEVICE)
@@ -165,6 +172,10 @@ def _build(
         )
         kwargs["num_accepted_tokens"] = torch.ones(
             batch_spec.batch_size, dtype=torch.int32, device=DEVICE
+        )
+    if prev_last_scheduled_idx is not None:
+        kwargs["prev_last_scheduled_idx"] = torch.tensor(
+            prev_last_scheduled_idx, dtype=torch.int32, device=DEVICE
         )
     return builder.build(common_prefix_len=0, common_attn_metadata=common, **kwargs)
 
@@ -196,6 +207,141 @@ def test_has_initial_state_after_reclassification():
     assert meta.has_initial_state is not None
     # req0 has context_lens = 65 - 1 = 64 > 0, so has_initial_state[0] = True
     assert meta.has_initial_state[0].item() is True
+
+
+def test_align_mode_all_mode_fields_are_none():
+    """REGRESSION: outside "all" mode the block-index metadata stays None."""
+    builder = _create_gdn_builder()
+    batch = BatchSpec(seq_lens=[40, 30, 20], query_lens=[1, 1, 1])
+    meta = _build(builder, batch)
+
+    assert meta.block_idx_last_scheduled_token is None
+    assert meta.block_idx_first_scheduled_token is None
+    assert meta.block_idx_last_computed_token is None
+    assert meta.block_idx_last_scheduled_token_prev_step is None
+    assert meta.num_computed_tokens is None
+    assert meta.all_state_indices_tensor is None
+
+
+def test_all_mode_block_indices_match_hand_computed():
+    """All-mode decode batch: block indices follow the shared cdiv formulas
+    (mirrors BaseMambaAttentionMetadataBuilder) and the full block table is
+    exposed unsliced."""
+    builder = _create_gdn_builder(mamba_cache_mode="all")
+    batch = BatchSpec(seq_lens=[40, 30, 20], query_lens=[1, 1, 1])
+    meta = _build(builder, batch)
+
+    # num_computed = seq_len - query_len = [39, 29, 19]; block = 16.
+    assert meta.num_computed_tokens is not None
+    assert meta.num_computed_tokens.tolist() == [39, 29, 19]
+    # cdiv(ncomp, 16) - 1, clamped at 0.
+    assert meta.block_idx_last_computed_token.tolist() == [2, 1, 1]
+    # cdiv(ncomp + 1, 16) - 1.
+    assert meta.block_idx_first_scheduled_token.tolist() == [2, 1, 1]
+    # cdiv(seq_len, 16) - 1, clamped at 0.
+    assert meta.block_idx_last_scheduled_token.tolist() == [2, 1, 1]
+    # No spec rows in the batch -> no prev-step anchor.
+    assert meta.block_idx_last_scheduled_token_prev_step is None
+    assert meta.all_state_indices_tensor is not None
+    assert meta.all_state_indices_tensor.dim() == 2
+    assert meta.all_state_indices_tensor.shape[0] == batch.batch_size
+
+
+def test_all_mode_first_scheduled_crosses_block_boundary():
+    """A request whose next token starts a fresh block: first_scheduled must
+    exceed last_computed (ncomp = 32 = 2 full blocks -> first scheduled token
+    is the first of block 2, last computed is the last of block 1)."""
+    builder = _create_gdn_builder(mamba_cache_mode="all")
+    batch = BatchSpec(seq_lens=[33], query_lens=[1])
+    meta = _build(builder, batch)
+
+    assert meta.num_computed_tokens.tolist() == [32]
+    assert meta.block_idx_last_computed_token.tolist() == [1]
+    assert meta.block_idx_first_scheduled_token.tolist() == [2]
+    assert meta.block_idx_last_scheduled_token.tolist() == [2]
+
+
+def test_all_mode_spec_prev_step_where_semantics():
+    """Spec decode: prev_last_scheduled_idx >= 0 is used as-is; negative
+    entries fall back to the last computed block of the previous step."""
+    builder = _create_gdn_builder(num_speculative_tokens=2, mamba_cache_mode="all")
+    batch = BatchSpec(seq_lens=[50, 30], query_lens=[3, 3])
+    meta = _build(
+        builder,
+        batch,
+        num_decode_draft_tokens=[2, 2],
+        prev_last_scheduled_idx=[-1, 5],
+    )
+
+    # ncomp = [47, 27]; fallback = clamp((ncomp - 1) // 16, 0) = [2, 1].
+    assert meta.block_idx_last_scheduled_token_prev_step.tolist() == [2, 5]
+
+
+def test_all_mode_spec_prev_step_fallback_when_not_plumbed():
+    """Until the runner plumbs prev_last_scheduled_idx, the prev-step anchor
+    degrades to the last computed block (first-step semantics)."""
+    builder = _create_gdn_builder(num_speculative_tokens=2, mamba_cache_mode="all")
+    batch = BatchSpec(seq_lens=[50, 30], query_lens=[3, 3])
+    meta = _build(builder, batch, num_decode_draft_tokens=[2, 2])
+
+    assert meta.block_idx_last_scheduled_token_prev_step.tolist() == [2, 1]
+
+
+def test_all_mode_full_cudagraph_spec_uses_persistent_buffers():
+    """FULL cudagraph + all-mode pure-spec batch: the block-index metadata
+    must be views of the builder's persistent buffers (stable device pointers
+    across steps) with request-level padding."""
+    builder = _create_gdn_builder(
+        num_speculative_tokens=3,
+        full_cuda_graph=True,
+        mamba_cache_mode="all",
+    )
+    batch = BatchSpec(seq_lens=[80, 96], query_lens=[4, 4])
+    meta = _build(builder, batch, num_decode_draft_tokens=[3, 3])
+
+    assert meta.num_spec_decodes == batch.batch_size
+    assert (
+        meta.all_state_indices_tensor.data_ptr()
+        == builder.all_state_indices_tensor.data_ptr()
+    )
+    assert (
+        meta.block_idx_last_scheduled_token.data_ptr()
+        == builder.block_idx_last_scheduled_token.data_ptr()
+    )
+    assert (
+        meta.block_idx_last_computed_token.data_ptr()
+        == builder.block_idx_last_computed_token.data_ptr()
+    )
+    assert (
+        meta.block_idx_last_scheduled_token_prev_step.data_ptr()
+        == builder.block_idx_last_scheduled_token_prev_step.data_ptr()
+    )
+    # Values survive the buffer round-trip: ncomp = [76, 92], block = 16.
+    assert meta.block_idx_last_computed_token.tolist() == [4, 5]
+    assert meta.block_idx_last_scheduled_token.tolist() == [4, 5]
+
+
+def test_all_mode_full_cudagraph_decode_uses_persistent_buffers():
+    """FULL cudagraph + all-mode non-spec decode batch takes the second
+    capture branch and must also land in the persistent buffers."""
+    builder = _create_gdn_builder(full_cuda_graph=True, mamba_cache_mode="all")
+    batch = BatchSpec(seq_lens=[40, 30], query_lens=[1, 1])
+    meta = _build(builder, batch)
+
+    assert meta.num_decodes == batch.batch_size
+    assert (
+        meta.all_state_indices_tensor.data_ptr()
+        == builder.all_state_indices_tensor.data_ptr()
+    )
+    assert (
+        meta.block_idx_last_scheduled_token.data_ptr()
+        == builder.block_idx_last_scheduled_token.data_ptr()
+    )
+    assert (
+        meta.block_idx_last_computed_token.data_ptr()
+        == builder.block_idx_last_computed_token.data_ptr()
+    )
+    assert meta.block_idx_last_computed_token.tolist() == [2, 1]
 
 
 def test_full_cudagraph_spec_metadata_uses_request_count():

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -287,10 +287,16 @@ def test_all_mode_spec_prev_step_fallback_when_not_plumbed():
     assert meta.block_idx_last_scheduled_token_prev_step.tolist() == [2, 1]
 
 
-def test_all_mode_full_cudagraph_spec_uses_persistent_buffers():
+@pytest.mark.parametrize("inkernel_write", [True, False])
+def test_all_mode_full_cudagraph_spec_uses_persistent_buffers(
+    monkeypatch, inkernel_write
+):
     """FULL cudagraph + all-mode pure-spec batch: the block-index metadata
-    must be views of the builder's persistent buffers (stable device pointers
-    across steps) with request-level padding."""
+    must be views of stable device pointers with request-level padding —
+    the builder's staging buffers with VLLM_GDN_INKERNEL_CKPT_WRITE off, or
+    (block table only) the runner-persistent table directly when the staging
+    copy is skipped by the in-kernel checkpoint-write path."""
+    monkeypatch.setenv("VLLM_GDN_INKERNEL_CKPT_WRITE", "1" if inkernel_write else "0")
     builder = _create_gdn_builder(
         num_speculative_tokens=3,
         full_cuda_graph=True,
@@ -300,10 +306,16 @@ def test_all_mode_full_cudagraph_spec_uses_persistent_buffers():
     meta = _build(builder, batch, num_decode_draft_tokens=[3, 3])
 
     assert meta.num_spec_decodes == batch.batch_size
-    assert (
-        meta.all_state_indices_tensor.data_ptr()
-        == builder.all_state_indices_tensor.data_ptr()
-    )
+    if inkernel_write:
+        assert (
+            meta.all_state_indices_tensor.data_ptr()
+            != builder.all_state_indices_tensor.data_ptr()
+        )
+    else:
+        assert (
+            meta.all_state_indices_tensor.data_ptr()
+            == builder.all_state_indices_tensor.data_ptr()
+        )
     assert (
         meta.block_idx_last_scheduled_token.data_ptr()
         == builder.block_idx_last_scheduled_token.data_ptr()
@@ -321,18 +333,29 @@ def test_all_mode_full_cudagraph_spec_uses_persistent_buffers():
     assert meta.block_idx_last_scheduled_token.tolist() == [4, 5]
 
 
-def test_all_mode_full_cudagraph_decode_uses_persistent_buffers():
+@pytest.mark.parametrize("inkernel_write", [True, False])
+def test_all_mode_full_cudagraph_decode_uses_persistent_buffers(
+    monkeypatch, inkernel_write
+):
     """FULL cudagraph + all-mode non-spec decode batch takes the second
-    capture branch and must also land in the persistent buffers."""
+    capture branch; block-table staging follows the in-kernel
+    checkpoint-write gate (see the spec variant above)."""
+    monkeypatch.setenv("VLLM_GDN_INKERNEL_CKPT_WRITE", "1" if inkernel_write else "0")
     builder = _create_gdn_builder(full_cuda_graph=True, mamba_cache_mode="all")
     batch = BatchSpec(seq_lens=[40, 30], query_lens=[1, 1])
     meta = _build(builder, batch)
 
     assert meta.num_decodes == batch.batch_size
-    assert (
-        meta.all_state_indices_tensor.data_ptr()
-        == builder.all_state_indices_tensor.data_ptr()
-    )
+    if inkernel_write:
+        assert (
+            meta.all_state_indices_tensor.data_ptr()
+            != builder.all_state_indices_tensor.data_ptr()
+        )
+    else:
+        assert (
+            meta.all_state_indices_tensor.data_ptr()
+            == builder.all_state_indices_tensor.data_ptr()
+        )
     assert (
         meta.block_idx_last_scheduled_token.data_ptr()
         == builder.block_idx_last_scheduled_token.data_ptr()

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -167,9 +167,7 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
     scheduler_block_size = block_size * dcp_world_size
     hash_block_size = 32
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(
-            block_size=block_size, mamba_cache_mode="align"
-        ),
+        cache_config=SimpleNamespace(block_size=block_size, mamba_cache_mode="align"),
         max_num_scheduled_tokens=8192,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
@@ -217,9 +215,7 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
     token_budget = 8192
     prompt_length = 30000
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(
-            block_size=block_size, mamba_cache_mode="align"
-        ),
+        cache_config=SimpleNamespace(block_size=block_size, mamba_cache_mode="align"),
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
@@ -256,9 +252,7 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
     long_prefill_threshold = 384
     prompt_length = 1300
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(
-            block_size=block_size, mamba_cache_mode="align"
-        ),
+        cache_config=SimpleNamespace(block_size=block_size, mamba_cache_mode="align"),
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(
             long_prefill_token_threshold=long_prefill_threshold

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -167,7 +167,9 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
     scheduler_block_size = block_size * dcp_world_size
     hash_block_size = 32
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(block_size=block_size),
+        cache_config=SimpleNamespace(
+            block_size=block_size, mamba_cache_mode="align"
+        ),
         max_num_scheduled_tokens=8192,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
@@ -215,7 +217,9 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
     token_budget = 8192
     prompt_length = 30000
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(block_size=block_size),
+        cache_config=SimpleNamespace(
+            block_size=block_size, mamba_cache_mode="align"
+        ),
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,
@@ -252,7 +256,9 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
     long_prefill_threshold = 384
     prompt_length = 1300
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(block_size=block_size),
+        cache_config=SimpleNamespace(
+            block_size=block_size, mamba_cache_mode="align"
+        ),
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(
             long_prefill_token_threshold=long_prefill_threshold

--- a/tests/v1/core/test_mamba_all_mode_split.py
+++ b/tests/v1/core/test_mamba_all_mode_split.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""_mamba_block_aligned_split: all-mode kernel-chunk clipping tests.
+
+mamba_cache_mode='all' with a GDN/FLA-style prefill kernel (fixed chunk grid
+relative to each scheduled chunk's start, no SSD-style short-first-chunk
+realignment) requires prefill chunk STARTS to stay kernel-chunk (64) aligned so
+every block-boundary SSM checkpoint is exactly materializable from the
+kernel's per-chunk state export. The scheduler clips chunk ends to kernel-chunk
+multiples — a much weaker constraint than align mode's block-size split.
+"""
+
+from types import SimpleNamespace
+
+from vllm.config import CacheConfig
+from vllm.v1.core.sched.scheduler import Scheduler
+
+
+def _sched(mode="all", align_size=64, block_size=576, hash_block_size=576,
+           use_eagle=False, partial_hit=False):
+    """Minimal stand-in exposing the fields _mamba_block_aligned_split reads."""
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(
+            mamba_cache_mode=mode,
+            mamba_all_mode_prefill_align_size=align_size,
+            block_size=block_size,
+        ),
+        hash_block_size=hash_block_size,
+        use_eagle=use_eagle,
+        mamba_partial_cache_hit=partial_hit,
+    )
+
+
+def _req(num_computed=0, num_prompt=100_000, num_tokens=None,
+         shared_prefix_boundary=0):
+    return SimpleNamespace(
+        num_computed_tokens=num_computed,
+        num_prompt_tokens=num_prompt,
+        num_tokens=num_tokens if num_tokens is not None else num_prompt,
+        shared_prefix_boundary=shared_prefix_boundary,
+    )
+
+
+def _split(sched, req, num_new_tokens):
+    return Scheduler._mamba_block_aligned_split(sched, req, num_new_tokens)
+
+
+# ------------------------------ all-mode (NEW) ------------------------------
+
+
+def test_all_mode_clips_end_to_chunk_multiple():
+    """Mid-prompt bite ends get clipped down to a 64-multiple."""
+    # 32,010 is not a 64-multiple; the nearest below is 32,000 (= 500*64).
+    assert _split(_sched(), _req(num_computed=0), 32_010) == 32_000
+
+
+def test_all_mode_aligned_budget_unchanged():
+    """A 64-multiple budget passes through untouched."""
+    assert _split(_sched(), _req(num_computed=0), 32_768) == 32_768
+
+
+def test_all_mode_chunk_starts_stay_aligned_inductively():
+    """After a clipped bite, the next start is 64-aligned again."""
+    first = _split(_sched(), _req(num_computed=0), 1_000)
+    assert first % 64 == 0
+    second = _split(_sched(), _req(num_computed=first), 1_000)
+    assert (first + second) % 64 == 0
+
+
+def test_all_mode_small_budget_yields_empty_chunk():
+    """Budget below one kernel chunk -> 0 (caller skips the request)."""
+    assert _split(_sched(), _req(num_computed=64), 63) == 0
+
+
+def test_all_mode_misaligned_start_realigns_at_next_boundary():
+    """Externally misaligned start (e.g. loaded KV): the catch-up bite stops
+    at the next 64-boundary so subsequent bites start aligned."""
+    got = _split(_sched(), _req(num_computed=100), 32_000)
+    assert 100 + got == 128  # next multiple of 64
+
+
+def test_all_mode_final_chunk_unclipped():
+    """The bite that finishes the prompt may end anywhere (tail is handled by
+    kernel masking + the final-state write)."""
+    assert _split(_sched(), _req(num_computed=99_968, num_prompt=100_000),
+                  5_000) == 5_000
+
+
+# --------------------------- align-mode regression ---------------------------
+
+
+def test_align_mode_block_clip_unchanged():
+    """REGRESSION: align mode still clips to block_size multiples."""
+    got = _split(_sched(mode="align"), _req(num_computed=0), 32_000)
+    assert got == (32_000 // 576) * 576
+
+
+# ------------------------------- config field --------------------------------
+
+
+def test_cache_config_field_default_none_and_not_init():
+    cfg = CacheConfig()
+    assert cfg.mamba_all_mode_prefill_align_size is None
+    import dataclasses
+    f = {f.name: f for f in dataclasses.fields(CacheConfig)}[
+        "mamba_all_mode_prefill_align_size"]
+    assert f.init is False

--- a/tests/v1/core/test_mamba_all_mode_split.py
+++ b/tests/v1/core/test_mamba_all_mode_split.py
@@ -16,8 +16,14 @@ from vllm.config import CacheConfig
 from vllm.v1.core.sched.scheduler import Scheduler
 
 
-def _sched(mode="all", align_size=64, block_size=576, hash_block_size=576,
-           use_eagle=False, partial_hit=False):
+def _sched(
+    mode="all",
+    align_size=64,
+    block_size=576,
+    hash_block_size=576,
+    use_eagle=False,
+    partial_hit=False,
+):
     """Minimal stand-in exposing the fields _mamba_block_aligned_split reads."""
     return SimpleNamespace(
         cache_config=SimpleNamespace(
@@ -31,8 +37,7 @@ def _sched(mode="all", align_size=64, block_size=576, hash_block_size=576,
     )
 
 
-def _req(num_computed=0, num_prompt=100_000, num_tokens=None,
-         shared_prefix_boundary=0):
+def _req(num_computed=0, num_prompt=100_000, num_tokens=None, shared_prefix_boundary=0):
     return SimpleNamespace(
         num_computed_tokens=num_computed,
         num_prompt_tokens=num_prompt,
@@ -82,8 +87,9 @@ def test_all_mode_misaligned_start_realigns_at_next_boundary():
 def test_all_mode_final_chunk_unclipped():
     """The bite that finishes the prompt may end anywhere (tail is handled by
     kernel masking + the final-state write)."""
-    assert _split(_sched(), _req(num_computed=99_968, num_prompt=100_000),
-                  5_000) == 5_000
+    assert (
+        _split(_sched(), _req(num_computed=99_968, num_prompt=100_000), 5_000) == 5_000
+    )
 
 
 # --------------------------- align-mode regression ---------------------------
@@ -102,6 +108,8 @@ def test_cache_config_field_default_none_and_not_init():
     cfg = CacheConfig()
     assert cfg.mamba_all_mode_prefill_align_size is None
     import dataclasses
+
     f = {f.name: f for f in dataclasses.fields(CacheConfig)}[
-        "mamba_all_mode_prefill_align_size"]
+        "mamba_all_mode_prefill_align_size"
+    ]
     assert f.init is False

--- a/tests/v1/core/test_mamba_block_size_validation.py
+++ b/tests/v1/core/test_mamba_block_size_validation.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""validate_block_size mamba-mode scheduler-budget gating.
+
+Align mode splits prefill chunks on block boundaries, so its constraints key
+on block_size. All mode with a kernel-chunk-aligned prefill split (GDN/FLA:
+``mamba_all_mode_prefill_align_size`` set) clips chunk ends to align-size
+multiples instead, so its constraints key on the (much smaller) align size —
+a budget below it would floor every prefill step to 0 tokens and hang. All
+mode WITHOUT the field (SSD-style kernels with in-kernel realignment) has no
+split and therefore no scheduler-budget constraint.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import VllmConfig
+
+
+def _fake_cfg(
+    mode,
+    block_size,
+    align_size=None,
+    max_num_batched_tokens=32768,
+    long_prefill_token_threshold=0,
+    disable_chunked_mm_input=False,
+):
+    """Minimal stand-in exposing exactly the fields validate_block_size reads."""
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=block_size,
+            mamba_cache_mode=mode,
+            mamba_all_mode_prefill_align_size=align_size,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            dcp_kv_cache_interleave_size=1,
+            cp_kv_cache_interleave_size=1,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=max_num_batched_tokens,
+            long_prefill_token_threshold=long_prefill_token_threshold,
+            disable_chunked_mm_input=disable_chunked_mm_input,
+        ),
+    )
+
+
+def _validate(cfg):
+    # Call unbound so the minimal stand-in can act as self.
+    VllmConfig.validate_block_size(cfg)
+
+
+# --------------------------- REGRESSION (align/none) ---------------------------
+
+
+def test_align_oversized_block_still_asserts():
+    with pytest.raises(AssertionError, match="align mode"):
+        _validate(_fake_cfg("align", block_size=65536, max_num_batched_tokens=32768))
+
+
+def test_align_valid_config_still_passes():
+    _validate(_fake_cfg("align", block_size=544, max_num_batched_tokens=32768))
+
+
+def test_none_mode_unaffected_by_oversized_block():
+    _validate(_fake_cfg("none", block_size=65536, max_num_batched_tokens=32768))
+
+
+# ------------------------------- NEW (all-mode) --------------------------------
+
+
+def test_all_budget_below_align_size_asserts():
+    """all + chunk-aligned split: a budget below the align size hangs the
+    scheduler (every mid-prompt bite floors to 0) and must fail validation."""
+    with pytest.raises(AssertionError, match="all mode"):
+        _validate(
+            _fake_cfg("all", block_size=576, align_size=64, max_num_batched_tokens=32)
+        )
+
+
+def test_all_valid_config_passes():
+    _validate(
+        _fake_cfg("all", block_size=576, align_size=64, max_num_batched_tokens=32768)
+    )
+
+
+def test_all_block_size_may_exceed_budget():
+    """Unlike align, all-mode only needs the budget to cover one kernel chunk:
+    block_size larger than the budget is fine (blocks fill across steps)."""
+    _validate(
+        _fake_cfg("all", block_size=65536, align_size=64, max_num_batched_tokens=1024)
+    )
+
+
+def test_all_without_split_field_has_no_budget_constraint():
+    """all-mode kernels with in-kernel realignment (SSD-style) never take the
+    scheduler split; no align size -> no constraint."""
+    _validate(
+        _fake_cfg("all", block_size=65536, align_size=None, max_num_batched_tokens=32)
+    )
+
+
+def test_all_long_prefill_threshold_below_align_size_asserts():
+    with pytest.raises(AssertionError):
+        _validate(
+            _fake_cfg(
+                "all",
+                block_size=576,
+                align_size=64,
+                long_prefill_token_threshold=32,
+            )
+        )
+
+
+def test_all_disable_chunked_mm_input_asserts():
+    with pytest.raises(AssertionError, match="Chunked MM input"):
+        _validate(
+            _fake_cfg(
+                "all", block_size=576, align_size=64, disable_chunked_mm_input=True
+            )
+        )

--- a/tests/v1/core/test_mamba_chunk_size.py
+++ b/tests/v1/core/test_mamba_chunk_size.py
@@ -40,14 +40,18 @@ def test_gdn_marker_returns_fla_chunk_size():
     """NEW: GDN models (linear_conv_kernel_dim present, no chunk fields)
     resolve to the FLA kernel tile, not the Mamba1 default."""
     assert FLA_CHUNK_SIZE == 64
-    assert (ModelConfig.get_mamba_chunk_size(
-        _cfg(linear_conv_kernel_dim=4)) == FLA_CHUNK_SIZE)
+    assert (
+        ModelConfig.get_mamba_chunk_size(_cfg(linear_conv_kernel_dim=4))
+        == FLA_CHUNK_SIZE
+    )
 
 
 def test_gdn_marker_with_explicit_chunk_keeps_explicit():
     """NEW: an explicit chunk field wins over the GDN marker."""
-    assert ModelConfig.get_mamba_chunk_size(
-        _cfg(linear_conv_kernel_dim=4, chunk_size=256)) == 256
+    assert (
+        ModelConfig.get_mamba_chunk_size(_cfg(linear_conv_kernel_dim=4, chunk_size=256))
+        == 256
+    )
 
 
 # ------------- post-resolution all-mode block-size validation -------------

--- a/tests/v1/core/test_mamba_chunk_size.py
+++ b/tests/v1/core/test_mamba_chunk_size.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""get_mamba_chunk_size resolution tests.
+
+GDN / gated-delta models (e.g. Qwen3-Next) carry no mamba_chunk_size/chunk_size
+config field; before the GDN branch they fell through to the Mamba1 2048
+default, which the all-mode block-size resolution then used as base_chunk_size,
+resolving a 3.5x-oversized mamba cache block (2048 instead of 576 for
+Qwen3-Next-80B at TP4). The FLA prefill kernel's real tile is FLA_CHUNK_SIZE
+(64), a hard kernel constant.
+"""
+
+from types import SimpleNamespace
+
+from vllm.config import ModelConfig
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+
+
+def _cfg(**fields):
+    """Minimal stand-in exposing only hf_text_config (all the method reads)."""
+    return SimpleNamespace(hf_text_config=SimpleNamespace(**fields))
+
+
+def test_explicit_mamba_chunk_size_honored():
+    """REGRESSION: Bamba/FalconH1-style mamba_chunk_size is returned as-is."""
+    assert ModelConfig.get_mamba_chunk_size(_cfg(mamba_chunk_size=128)) == 128
+
+
+def test_explicit_chunk_size_honored():
+    """REGRESSION: Mamba2/NemotronH-style chunk_size is returned as-is."""
+    assert ModelConfig.get_mamba_chunk_size(_cfg(chunk_size=256)) == 256
+
+
+def test_mamba1_fallback_unchanged():
+    """REGRESSION: no chunk fields and no GDN marker -> Mamba1 default 2048."""
+    assert ModelConfig.get_mamba_chunk_size(_cfg()) == 2048
+
+
+def test_gdn_marker_returns_fla_chunk_size():
+    """NEW: GDN models (linear_conv_kernel_dim present, no chunk fields)
+    resolve to the FLA kernel tile, not the Mamba1 default."""
+    assert FLA_CHUNK_SIZE == 64
+    assert (ModelConfig.get_mamba_chunk_size(
+        _cfg(linear_conv_kernel_dim=4)) == FLA_CHUNK_SIZE)
+
+
+def test_gdn_marker_with_explicit_chunk_keeps_explicit():
+    """NEW: an explicit chunk field wins over the GDN marker."""
+    assert ModelConfig.get_mamba_chunk_size(
+        _cfg(linear_conv_kernel_dim=4, chunk_size=256)) == 256
+
+
+# ------------- post-resolution all-mode block-size validation -------------
+
+
+def test_all_mode_block_validation_passes_chunk_multiples():
+    """REGRESSION-shape: auto-resolved all-mode blocks (chunk multiples by
+    construction) pass — e.g. 576/1152 (GDN, chunk 64) and 2048 (Mamba1)."""
+    from vllm.platforms.interface import validate_all_mode_mamba_block_size
+
+    validate_all_mode_mamba_block_size(576, 64)
+    validate_all_mode_mamba_block_size(1152, 64)
+    validate_all_mode_mamba_block_size(2048, 2048)
+
+
+def test_all_mode_block_validation_rejects_non_multiple():
+    """NEW: a user-forced block that is not a kernel-chunk multiple fails fast
+    (e.g. 560 with chunk 64 -> off-boundary checkpoints would poison APC)."""
+    import pytest
+
+    from vllm.platforms.interface import validate_all_mode_mamba_block_size
+
+    with pytest.raises(ValueError, match="multiple of the kernel chunk"):
+        validate_all_mode_mamba_block_size(560, 64)

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1160,7 +1160,9 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
     # junction (absolute) and stops the chunk there (req_2 has num_computed 0).
     # Create minimal mock with just the needed attributes
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(block_size=block_size),
+        cache_config=SimpleNamespace(
+            block_size=block_size, mamba_cache_mode="align"
+        ),
         max_num_scheduled_tokens=3 * block_size,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1160,9 +1160,7 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
     # junction (absolute) and stops the chunk there (req_2 has num_computed 0).
     # Create minimal mock with just the needed attributes
     mock = SimpleNamespace(
-        cache_config=SimpleNamespace(
-            block_size=block_size, mamba_cache_mode="align"
-        ),
+        cache_config=SimpleNamespace(block_size=block_size, mamba_cache_mode="align"),
         max_num_scheduled_tokens=3 * block_size,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         use_eagle=False,

--- a/tests/v1/worker/test_mamba_hybrid_prev_anchor.py
+++ b/tests/v1/worker/test_mamba_hybrid_prev_anchor.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for the V2 model-runner all-mode write-anchor tracking kernel
+(``_track_mamba_all_write_anchor_kernel``).
+
+The kernel must mirror the V1 ``postprocess_mamba_all`` /
+``preprocess_mamba_all_specdec`` pair in a single pass:
+  * stage the previous step's per-request anchors into batch order
+    (``staged[row] = tracking[idx_mapping[row]]``), then
+  * record this step's anchor ``max(0, (seq_len - 1) // block)`` for rows
+    scheduling exactly ``1 + num_spec_tokens`` tokens (a full decode window),
+    and untrack (-1) every other scheduled row.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        reason="Triton anchor-tracking kernel requires CUDA", allow_module_level=True
+    )
+
+from vllm.v1.worker.gpu.model_states.mamba_hybrid import (
+    _track_mamba_all_write_anchor_kernel,
+)
+
+BLOCK = 8
+NUM_SPEC = 3
+FULL = 1 + NUM_SPEC
+
+
+def _step(idx_mapping, query_lens, seq_lens, tracking):
+    num_reqs = len(query_lens)
+    idx = torch.tensor(idx_mapping, dtype=torch.int32, device="cuda")
+    qsl = torch.zeros(num_reqs + 1, dtype=torch.int32, device="cuda")
+    qsl[1:] = torch.cumsum(
+        torch.tensor(query_lens, dtype=torch.int32, device="cuda"), 0
+    )
+    sl = torch.tensor(seq_lens, dtype=torch.int32, device="cuda")
+    staged = torch.full((num_reqs,), -7, dtype=torch.int32, device="cuda")
+    _track_mamba_all_write_anchor_kernel[(num_reqs,)](
+        idx,
+        qsl,
+        sl,
+        tracking,
+        staged,
+        FULL_DECODE_LEN=FULL,
+        MAMBA_BLOCK_SIZE=BLOCK,
+    )
+    return staged
+
+
+def _reference(idx_mapping, query_lens, seq_lens, tracking_before):
+    """V1 semantics: stage prev, then track full-decode rows / untrack others."""
+    staged = [tracking_before[slot] for slot in idx_mapping]
+    tracking_after = list(tracking_before)
+    for row, slot in enumerate(idx_mapping):
+        if query_lens[row] == FULL:
+            tracking_after[slot] = max(0, (seq_lens[row] - 1) // BLOCK)
+        else:
+            tracking_after[slot] = -1
+    return staged, tracking_after
+
+
+def test_stage_then_track():
+    tracking = torch.full((6,), -1, dtype=torch.int32, device="cuda")
+    tracking[3] = 7  # slot 3 tracked by an earlier step
+    idx_mapping = [3, 0, 5]
+    query_lens = [FULL, 17, FULL]  # decode window, prefill chunk, decode window
+    seq_lens = [20, 33, 8]
+
+    exp_staged, exp_after = _reference(
+        idx_mapping, query_lens, seq_lens, tracking.tolist()
+    )
+    staged = _step(idx_mapping, query_lens, seq_lens, tracking)
+
+    assert staged.tolist() == exp_staged  # [7, -1, -1]
+    assert tracking.tolist() == exp_after  # slots 3 -> 2, 0 -> -1, 5 -> 0
+    # rows not in the batch keep their value
+    assert tracking[1].item() == -1 and tracking[2].item() == -1
+
+
+def test_two_step_chain_and_untrack():
+    tracking = torch.full((4,), -1, dtype=torch.int32, device="cuda")
+
+    # step 1: both rows run full decode windows
+    idx_mapping = [2, 1]
+    seq_lens = [17, 9]
+    staged1 = _step(idx_mapping, [FULL, FULL], seq_lens, tracking)
+    assert staged1.tolist() == [-1, -1]  # nothing tracked yet
+    assert tracking.tolist() == [-1, (9 - 1) // BLOCK, (17 - 1) // BLOCK, -1]
+
+    # step 2: row order changes; slot 1 falls back to a partial (chunked) step
+    staged2 = _step([1, 2], [3, FULL], [12, 21], tracking)
+    # staged must serve step 1's anchors in the new batch order
+    assert staged2.tolist() == [(9 - 1) // BLOCK, (17 - 1) // BLOCK]
+    # slot 1 untracked (partial), slot 2 re-tracked at the new position
+    assert tracking.tolist() == [-1, -1, (21 - 1) // BLOCK, -1]

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,9 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFuncsByType,
     get_conv_copy_spec,
     get_temporal_copy_spec,
+)
+from vllm.v1.attention.backends.mamba_attn import (
+    compute_mamba_prefix_caching_block_indices,
 )
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
@@ -31,7 +35,9 @@ from vllm.v1.worker.mamba_utils import (
     collect_mamba_copy_meta,
     do_mamba_copy_block,
     get_mamba_groups,
+    postprocess_mamba_all,
     preprocess_mamba,
+    preprocess_mamba_all_specdec,
     stage_postprocess_inputs_to_gpu,
 )
 
@@ -164,6 +170,101 @@ def test_resumed_req_ids_cleared_from_mamba_state_idx():
         )
 
     assert mamba_state_idx == {"keep": 99}
+
+
+# -----------------------------------------------------------------------------
+# All-mode spec-decode prev-step anchor tracking. postprocess_mamba_all
+# records where each full spec step wrote its running state;
+# preprocess_mamba_all_specdec feeds it to the metadata builders as
+# prev_last_scheduled_idx (Mamba2 and GDN — the next step's read window).
+# -----------------------------------------------------------------------------
+
+
+def _run_postprocess_mamba_all(
+    mamba_state_idx, scheduled, requests, num_spec, block_size=64
+):
+    spec = MagicMock(block_size=block_size)
+    sched = MagicMock(num_scheduled_tokens=scheduled)
+    input_batch = MagicMock(req_ids=list(scheduled.keys()))
+    with patch(
+        "vllm.v1.worker.mamba_utils.get_mamba_groups",
+        return_value=([0], spec),
+    ):
+        postprocess_mamba_all(
+            sched,
+            MagicMock(),  # kv_cache_config (consumed by the patched getter)
+            input_batch,
+            requests,
+            mamba_state_idx,
+            num_spec,
+            len(scheduled),
+        )
+
+
+def test_postprocess_mamba_all_anchor_matches_builder_formula():
+    """CONTRACT: the recorded prev-step anchor must equal the
+    block_idx_last_scheduled_token the attention builders compute for the
+    same step (the shared cdiv formula) — the next step's spec-decode read
+    window is anchored exactly where this step wrote its per-token states.
+    Covers in-block, at-boundary and just-past-boundary positions."""
+    block_size = 64
+    num_spec = 2
+    ncomps = [0, 61, 64, 100, 125, 128, 129, 189]
+    req_ids = [f"r{i}" for i in range(len(ncomps))]
+    scheduled = dict.fromkeys(req_ids, 1 + num_spec)
+    requests = {
+        rid: SimpleNamespace(num_computed_tokens=nc) for rid, nc in zip(req_ids, ncomps)
+    }
+    mamba_state_idx: dict[str, int] = {}
+    _run_postprocess_mamba_all(
+        mamba_state_idx, scheduled, requests, num_spec, block_size
+    )
+
+    ncomp_t = torch.tensor(ncomps, dtype=torch.int32)
+    seq_lens = ncomp_t + 1 + num_spec
+    _, _, block_idx_last_scheduled = compute_mamba_prefix_caching_block_indices(
+        ncomp_t, seq_lens, block_size
+    )
+    for rid, expected in zip(req_ids, block_idx_last_scheduled.tolist()):
+        assert mamba_state_idx[rid] == expected
+
+
+def test_postprocess_mamba_all_untracks_partial_and_nospec_steps():
+    """Only a full spec decode step (1 + num_spec scheduled tokens) leaves a
+    tracked anchor; anything else (prefill chunk, partial step) pops the
+    entry so the builder falls back to the last computed block. With no
+    speculation the function is a no-op."""
+    num_spec = 2
+    scheduled = {"full": 3, "chunk": 512, "single": 1}
+    requests = {rid: SimpleNamespace(num_computed_tokens=100) for rid in scheduled}
+    mamba_state_idx = {"chunk": 5, "single": 7}
+    _run_postprocess_mamba_all(mamba_state_idx, scheduled, requests, num_spec)
+    assert mamba_state_idx == {"full": 1}  # (100 + 3 - 1) // 64
+
+    untouched = {"full": 42}
+    _run_postprocess_mamba_all(untouched, scheduled, requests, num_spec=0)
+    assert untouched == {"full": 42}
+
+
+def test_preprocess_mamba_all_specdec_buffer_convention():
+    """The prev_last_scheduled_idx buffer gets the tracked anchor per request
+    and -1 everywhere else (untracked rows and the padded tail) — the
+    builders' where(prev >= 0, prev, fallback) contract. Stale entries of
+    finished requests are cleaned before filling."""
+    buf = SimpleNamespace(np=np.full(6, 99, dtype=np.int32), copy_to_gpu=lambda: None)
+    mamba_state_idx = {"a": 3, "gone": 7}
+    sched = _make_scheduler_output(
+        finished_req_ids={"gone"},
+        preempted_req_ids=set(),
+        resumed_req_ids=set(),
+    )
+    input_batch = MagicMock(req_ids=["a", "b"])
+    preprocess_mamba_all_specdec(sched, input_batch, mamba_state_idx, 2, buf)
+
+    assert buf.np[0] == 3  # tracked
+    assert buf.np[1] == -1  # untracked -> builder fallback
+    assert (buf.np[2:] == -1).all()  # padded tail
+    assert "gone" not in mamba_state_idx
 
 
 # -----------------------------------------------------------------------------

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -57,6 +57,15 @@ def create_fp4_scale_tensor(
         rounded_m = round_up(m, 128)
         scale_n = n // block_size
         rounded_n = round_up(scale_n, 4)
+        if rounded_m == m and rounded_n == scale_n:
+            # No padding: the quant kernel writes one scale per 16-element
+            # block of every row, i.e. every element the downstream NVFP4
+            # GEMM reads. Zero-init would be pure overhead (a FillFunctor
+            # launch per quant call; ~3/layer in decode graphs whose token
+            # count is a multiple of 128).
+            return torch.empty(
+                (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
+            )
         # Must be zero-initialized: the swizzled scale buffer is padded to
         # (round_up(m, 128), round_up(scale_n, 4) // 4) but the NVFP4 quant
         # kernel does not write every padded element that the downstream

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -168,6 +168,13 @@ class CacheConfig:
     mamba_page_size_padded: int | None = None
     """ Optional override for mamba page size; used by hybrid mamba/attention
     models to ensure exact alignment with attention page size."""
+    mamba_all_mode_prefill_align_size: int | None = field(default=None, init=False)
+    """Set during block-size alignment for mamba_cache_mode='all' models whose
+    prefill kernel materializes per-chunk states on a fixed grid relative to
+    each scheduled chunk's start (e.g. GDN/FLA, which lacks the SSD kernels'
+    short-first-chunk realignment). The scheduler clips prefill chunks to
+    multiples of this size so chunk starts stay kernel-chunk aligned and every
+    block-boundary SSM checkpoint is exactly materializable."""
     skip_page_size_padded: int | None = None
     """Optional override for the page size of layers skipped from KV cache
     quantization (``--kv-cache-dtype-skip-layers``); set during block-size
@@ -273,6 +280,7 @@ class CacheConfig:
             # Prefix-caching implementation detail (doesn't affect compiled graph).
             "prefix_match_unit",
             "mamba_page_size_padded",
+            "mamba_all_mode_prefill_align_size",
             "skip_page_size_padded",
             "user_specified_block_size",
             "user_specified_mamba_block_size",

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1658,6 +1658,16 @@ class ModelConfig:
             # used by e.g. Mamba2, NemotronH, Zamba
             chunk_size = getattr(self.hf_text_config, "chunk_size", None)
 
+        # GDN / gated-delta models (e.g. Qwen3-Next) carry no mamba_chunk_size/
+        # chunk_size config field; their FLA prefill kernel tiles at
+        # FLA_CHUNK_SIZE (64). Use that instead of the Mamba1 2048 default so
+        # the all-mode mamba cache block aligns to the real kernel chunk
+        # (avoids a 3.5x-oversized block).
+        if chunk_size is None and getattr(
+                self.hf_text_config, "linear_conv_kernel_dim", None) is not None:
+            from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+            chunk_size = FLA_CHUNK_SIZE
+
         # Since Mamba1 does not have a chunk notion
         # we use a default chunk size of 2048.
         if chunk_size is None:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1663,9 +1663,12 @@ class ModelConfig:
         # FLA_CHUNK_SIZE (64). Use that instead of the Mamba1 2048 default so
         # the all-mode mamba cache block aligns to the real kernel chunk
         # (avoids a 3.5x-oversized block).
-        if chunk_size is None and getattr(
-                self.hf_text_config, "linear_conv_kernel_dim", None) is not None:
+        if (
+            chunk_size is None
+            and getattr(self.hf_text_config, "linear_conv_kernel_dim", None) is not None
+        ):
             from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
+
             chunk_size = FLA_CHUNK_SIZE
 
         # Since Mamba1 does not have a chunk notion

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1080,6 +1080,27 @@ class VllmConfig:
 
         self._resolve_mm_encoder_only()
 
+        # Mamba prefix caching relies on the checkpoints it materializes
+        # (all: one per block; align: step ends) actually being retained.
+        # The sparse retention default (interval 0 = semantic checkpoints
+        # only) interacts with the speculative-decoding last-block drop to
+        # zero realized SSM reuse. Default mamba modes to dense retention;
+        # an explicit positive interval still bounds retention as
+        # documented. Must run here (config construction) so the value is
+        # in place before get_kv_cache_configs copies it into KVCacheConfig.
+        if (
+            self.cache_config.mamba_cache_mode in ("all", "align")
+            and self.cache_config.prefix_cache_retention_interval == 0
+        ):
+            logger.info_once(
+                "mamba_cache_mode='%s': prefix_cache_retention_interval 0 "
+                "(sparse) would disable SSM prefix reuse; using dense "
+                "retention (None). Set a positive interval to bound "
+                "retained checkpoints.",
+                self.cache_config.mamba_cache_mode,
+            )
+            self.cache_config.prefix_cache_retention_interval = None
+
         if self.performance_mode != "balanced":
             logger.info_once("Performance mode set to '%s'.", self.performance_mode)
 
@@ -2815,6 +2836,28 @@ class VllmConfig:
                 "Chunked MM input is required because we need the flexibility "
                 "to schedule a multiple of block_size tokens even if they are "
                 "in the middle of a mm input"
+            )
+        # Mamba all-mode with a kernel-chunk-aligned prefill split (GDN/FLA):
+        # the scheduler clips prefill chunk ends down to multiples of the
+        # align size, so the token budget must always cover at least one
+        # kernel chunk or the split floors a prefill step to 0 tokens and the
+        # engine makes no forward progress.
+        elif (
+            self.cache_config.mamba_cache_mode == "all"
+            and self.cache_config.mamba_all_mode_prefill_align_size is not None
+        ):
+            align_size = self.cache_config.mamba_all_mode_prefill_align_size
+            assert align_size <= self.scheduler_config.max_num_batched_tokens, (
+                "In Mamba cache all mode, the prefill align size "
+                f"({align_size}) must be <= max_num_batched_tokens "
+                f"({self.scheduler_config.max_num_batched_tokens})."
+            )
+            if self.scheduler_config.long_prefill_token_threshold > 0:
+                assert self.scheduler_config.long_prefill_token_threshold >= align_size
+            assert not self.scheduler_config.disable_chunked_mm_input, (
+                "Chunked MM input is required because we need the flexibility "
+                "to schedule a multiple of the prefill align size even if it "
+                "lands in the middle of a mm input"
             )
 
     @model_validator(mode="after")

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 
 import torch
 
@@ -477,10 +478,24 @@ class TrtLlmNvFp4ExpertsMonolithic(
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
-        """The modular implementation should be used for the Dp/Ep or EPLB case."""
+        """The modular implementation should be used for the Dp/Ep or EPLB case.
+
+        GDN R3 (fused routing): additionally allow the monolithic kernel under
+        the naive allgather-reducescatter all2all backend. The monolithic
+        prepare/finalize (MoEPrepareAndFinalizeNaiveDPEPMonolithic) allgathers
+        the activations + router logits and the trtllm-gen kernel routes
+        internally with local_expert_offset, so no dispatch metadata is
+        needed. Gated by VLLM_GDN_MOE_MONO_AGRS (default "0" = the previous
+        behavior, the Modular kernel; set "1" to opt in). The
+        EPLB exclusion and every other all2all backend rejection are kept.
+        """
+        if moe_parallel_config.enable_eplb:
+            return False
+        if not moe_parallel_config.use_all2all_kernels:
+            return True
         return (
-            not moe_parallel_config.use_all2all_kernels
-            and not moe_parallel_config.enable_eplb
+            moe_parallel_config.use_ag_rs_all2all_kernels
+            and os.environ.get("VLLM_GDN_MOE_MONO_AGRS", "0") == "1"
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -272,13 +272,31 @@ class MoERunner(MoERunnerInterface):
         self.routed_experts = routed_experts
         self.enable_dbo = enable_dbo
 
-        # When both gates are present and FSE is enabled, fuse their
+        # When both gates are present and FSE is enabled (shared experts
+        # fused into the routed experts, no separate module), fuse their
         # weight matrices into [num_experts + num_shared, hidden] so one
         # F.linear produces combined logits. The topk kernel can then
         # apply routing softmax and shared expert activation (sigmoid)
         # in a single launch.
-        self._fse_fuse_gate = gate is not None and shared_expert_gate is not None
+        self._fse_fuse_gate = (
+            gate is not None
+            and shared_expert_gate is not None
+            and shared_experts is None
+        )
+        # When a separate shared-experts module AND its 1-row sigmoid gate
+        # are both handed to the runner, fold the gate rows into the router
+        # gate GEMM (one [num_experts + 1, hidden] F.linear instead of a
+        # tiny splitK GEMM) and apply sigmoid scaling to the shared expert
+        # output in _forward_impl. The shared-experts module must NOT apply
+        # its own expert gate in this mode.
+        self._concat_shared_gate = (
+            gate is not None
+            and shared_expert_gate is not None
+            and shared_experts is not None
+        )
         self._combined_gate_weight: torch.Tensor | None = None
+        self._gate_out_features: int | None = None
+        self._shared_gate_out_features: int | None = None
 
         self._shared_experts: SharedExperts | None = None
         if shared_experts is not None:
@@ -353,10 +371,24 @@ class MoERunner(MoERunnerInterface):
         """
         if self._combined_gate_weight is None:
             assert self.gate is not None and self.shared_expert_gate is not None
-            self._combined_gate_weight = torch.cat(
+            self._gate_out_features = self.gate.weight.shape[0]
+            self._shared_gate_out_features = self.shared_expert_gate.weight.shape[0]
+            combined = torch.cat(
                 [self.gate.weight, self.shared_expert_gate.weight],
                 dim=0,
             )
+            if self._concat_shared_gate:
+                # Pad N to a multiple of 16: odd-N bf16 GEMMs hit a cuBLAS
+                # cliff on B200 (N=513 is 3-5x the N=528 kernel in-graph).
+                # The FSE path must NOT be padded (its topk kernel consumes
+                # exactly num_experts + num_shared columns).
+                pad = (-combined.shape[0]) % 16
+                if pad:
+                    combined = torch.cat(
+                        [combined, combined.new_zeros(pad, combined.shape[1])],
+                        dim=0,
+                    )
+            self._combined_gate_weight = combined
 
     @property
     def _quant_method(self) -> FusedMoEMethodBase:
@@ -894,10 +926,24 @@ class MoERunner(MoERunnerInterface):
         # If the Runner holds the gate, apply it after the stream sync,
         # so it can run overlapped with the
         # NOTE: in future PR, MoE runner will always hold the gate.
+        shared_gate_logit: torch.Tensor | None = None
         if self.gate is not None:
             if self._fse_fuse_gate:
                 self._maybe_fuse_gate_weights()
                 router_logits = F.linear(hidden_states, self._combined_gate_weight)
+            elif self._concat_shared_gate:
+                # Folded router + shared-expert gate GEMM: the original
+                # router columns are sliced back out (contiguous for the
+                # routing kernels); the extra column scales the shared
+                # expert output below.
+                self._maybe_fuse_gate_weights()
+                fused_logits = F.linear(hidden_states, self._combined_gate_weight)
+                router_logits = fused_logits[:, : self._gate_out_features].contiguous()
+                shared_gate_logit = fused_logits[
+                    :,
+                    self._gate_out_features : self._gate_out_features
+                    + self._shared_gate_out_features,
+                ]
             else:
                 router_logits, _ = self.gate(hidden_states)
 
@@ -917,6 +963,11 @@ class MoERunner(MoERunnerInterface):
                 input_ids=input_ids,
                 shared_experts_overlapping=shared_experts_overlapping,
             )
+
+            if shared_gate_logit is not None and shared_output is not None:
+                # Sigmoid expert gate relocated from the shared-experts
+                # module (main stream, after the aux-stream join).
+                shared_output = torch.sigmoid(shared_gate_logit) * shared_output
 
             return self._maybe_combine(
                 shared_output,

--- a/vllm/model_executor/layers/mamba/gdn/all_mode_utils.py
+++ b/vllm/model_executor/layers/mamba/gdn/all_mode_utils.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Helpers for GDN ``mamba_cache_mode='all'`` prefix caching.
+
+The per-block SSM checkpoint scatter mirrors Mamba2 (mamba_mixer2.py:872-949) but
+adapts to FLA's ``chunk_gated_delta_rule`` intermediate states:
+
+  Mamba2 ``varlen_states[c]`` = state at the END of chunk c.
+  FLA    ``h[c]``             = state at the START of chunk c (== end of chunk c-1).
+
+So the strided gather index is shifted by +1 chunk vs Mamba2, and the final
+(possibly partial) block is written from the sequence's final recurrent state
+(``last_recurrent_state``) rather than from ``h``.
+"""
+
+import torch
+
+
+def gdn_scatter_block_checkpoints(
+    ssm_state: torch.Tensor,
+    inter_states: torch.Tensor,
+    final_states: torch.Tensor,
+    block_table_p: torch.Tensor,
+    block_idx_first_scheduled_token_p: torch.Tensor,
+    block_idx_last_scheduled_token_p: torch.Tensor,
+    num_computed_tokens_p: torch.Tensor,
+    first_chunk_p: torch.Tensor,
+    mamba_block_size: int,
+    chunk_size: int,
+) -> None:
+    """Write per-block SSM checkpoints into ``ssm_state`` (in place) for all-mode.
+
+    Args:
+        ssm_state: [num_blocks, ...] recurrent-state cache (written in place).
+        inter_states: FLA ``h`` squeezed to [NT, ...] — h[c] is the state BEFORE
+            global chunk c (i.e. after the first c chunks).
+        final_states: [num_prefills, ...] — each sequence's final recurrent state
+            (``last_recurrent_state`` from chunk_gated_delta_rule).
+        block_table_p: [num_prefills, max_blocks] — per-prefill-seq block ids.
+        block_idx_first_scheduled_token_p: [num_prefills] — first scheduled block idx.
+        block_idx_last_scheduled_token_p: [num_prefills] — last scheduled block idx.
+        num_computed_tokens_p: [num_prefills] — already-computed tokens per seq.
+        first_chunk_p: [num_prefills] — global index of each seq's first chunk
+            (= chunk_offsets[seq]).
+        mamba_block_size: cache block size in tokens.
+        chunk_size: FLA chunk size in tokens (FLA_CHUNK_SIZE).
+    """
+    num_prefills = block_idx_last_scheduled_token_p.shape[0]
+
+    # Final (possibly partial) block for every sequence == the seq's final state.
+    last_blocks = block_table_p.gather(
+        1, block_idx_last_scheduled_token_p.long().unsqueeze(1)
+    ).squeeze(1)
+    ssm_state[last_blocks] = final_states.to(ssm_state.dtype)
+
+    # Interior full blocks [first, last) == per-block-boundary states from h.
+    # Interior block j ends after (j+1)*mamba_block_size sequence tokens; that boundary
+    # is ((j+1)*mamba_block_size - num_computed) *scheduled* tokens in, i.e. FLA chunk
+    #   k = ((j+1)*mamba_block_size - num_computed) // chunk_size
+    # and h[c] is the state at the START of chunk c, so the checkpoint is the global
+    #   h index = first_chunk[s] + k.
+    # This is exact when block boundaries coincide with chunk boundaries, i.e.
+    # num_computed % chunk_size == 0 (guaranteed by the all-mode chunk-aligned
+    # prefill split, which clips bites to chunk_size multiples). We index explicitly per
+    # boundary (arange) and clamp into h's valid range: this replaces the previous
+    # open-ended strided slice `inter_states[fla_first : fla_first+n*stride : stride]`,
+    # which silently returned fewer than n rows once fla_first ran past the last
+    # sequence's chunk range in h -> the [0]-vs-[n] shape-mismatch crash on long
+    # cache-hit prompts. Sequences whose num_computed is not chunk-aligned are
+    # skipped below (never write an approximate interior checkpoint into APC).
+    nt = inter_states.shape[0]
+    # An interior-block SSM checkpoint is only exact when the block boundary
+    # coincides with an FLA chunk boundary, i.e. num_computed_tokens is a
+    # multiple of chunk_size. In a valid all-mode config this always holds
+    # (config validation requires mamba_block_size % FLA_CHUNK_SIZE == 0, and the
+    # all-mode chunk-aligned prefill split keeps num_computed a multiple of
+    # chunk_size). Writing an interior checkpoint at a non-boundary offset
+    # would poison the content-hash-addressed prefix cache, so we SKIP the
+    # interior scatter for any sequence whose num_computed is not chunk-aligned
+    # rather than write a wrong ("nearest chunk") checkpoint. This also makes the
+    # startup CUDA-graph memory dummy run safe: it feeds synthetic, unaligned
+    # num_computed to throwaway state and must not crash. The final (possibly
+    # partial) block is written from ``final_states`` above and is exact
+    # regardless of alignment, so it is always kept.
+    for s in range(num_prefills):
+        first = int(block_idx_first_scheduled_token_p[s])
+        last = int(block_idx_last_scheduled_token_p[s])
+        n = last - first
+        if n <= 0:
+            continue
+        ncomp = int(num_computed_tokens_p[s])
+        if ncomp % chunk_size != 0:
+            # Not chunk-aligned: cannot map interior block boundaries to exact FLA
+            # chunk states. Skip (never write an approximate checkpoint into APC).
+            continue
+        cache_blocks = block_table_p[s, first:last]
+        fc = int(first_chunk_p[s])
+        # This sequence's chunks occupy h[fc : seq_hi_excl); clamp the gather to that
+        # per-sequence range (not just the global [0, nt)) so a would-be overshoot can
+        # never bleed into an adjacent sequence's chunks. Exact indices already fall in
+        # range when block boundaries are chunk-aligned; this is defense-in-depth.
+        seq_hi = (
+            int(first_chunk_p[s + 1]) - 1
+            if (s + 1) < first_chunk_p.shape[0]
+            else nt - 1
+        )
+        j = torch.arange(first, last, device=cache_blocks.device)
+        k = ((j + 1) * mamba_block_size - ncomp) // chunk_size
+        chunk_idx = (fc + k).clamp_(fc, seq_hi)
+        from_where = inter_states[chunk_idx]
+        ssm_state[cache_blocks] = from_where.to(ssm_state.dtype)

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -28,6 +28,9 @@ from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     RowParallelLinear,
 )
+from vllm.model_executor.layers.mamba.gdn.all_mode_utils import (
+    gdn_scatter_block_checkpoints,
+)
 from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
 from vllm.model_executor.layers.mamba.mamba_mixer2 import mamba_v2_sharded_weight_loader
 from vllm.model_executor.layers.mamba.mamba_utils import (
@@ -134,11 +137,37 @@ def _resolve_gdn_prefill_backend(
         supports_flashinfer = True
         supports_cutedsl = True
 
+    # GDN all-mode prefix caching needs the per-chunk intermediate states
+    # that only the Triton/FLA prefill kernel exposes
+    # (``return_intermediate_states``); the FlashInfer/CuteDSL prefill paths
+    # cannot export them. With "auto", all-mode simply resolves to Triton;
+    # an explicitly requested non-Triton backend fails fast at startup
+    # instead of asserting on the first real prefill.
+    cache_config = getattr(vllm_config, "cache_config", None)
+    mamba_cache_mode = getattr(cache_config, "mamba_cache_mode", "none")
+    if mamba_cache_mode == "all" and backend == "auto":
+        logger.info_once(
+            "GDN prefill backend resolved to Triton/FLA: mamba_cache_mode="
+            "'all' needs its per-chunk state export."
+        )
+        return backend, "triton"
+
     if backend in ["flashinfer", "auto"] and supports_flashinfer:
-        return backend, "flashinfer"
-    if backend == "cutedsl" and supports_cutedsl:
-        return backend, "cutedsl"
-    return backend, "triton"
+        active_backend: Literal["triton", "flashinfer", "cutedsl"] = "flashinfer"
+    elif backend == "cutedsl" and supports_cutedsl:
+        active_backend = "cutedsl"
+    else:
+        active_backend = "triton"
+
+    if mamba_cache_mode == "all" and active_backend != "triton":
+        raise ValueError(
+            "GDN mamba_cache_mode='all' (prefix caching) requires the "
+            "Triton/FLA prefill backend, but the resolved GDN prefill "
+            f"backend is '{active_backend}'. Set "
+            "additional_config={'gdn_prefill_backend': 'triton'} or disable "
+            "all-mode prefix caching."
+        )
+    return backend, active_backend
 
 
 def _log_gdn_backend_decision(
@@ -265,7 +294,10 @@ class ChunkGatedDeltaRule(CustomOp):
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
         core_attn_out: torch.Tensor | None = None,
+        return_intermediate_states: bool = False,
     ):
+        # Only the Triton/FLA backend exports per-chunk states (all-mode).
+        assert not return_intermediate_states
         o, final_state = fi_chunk_gated_delta_rule(
             q=q,
             k=k,
@@ -297,6 +329,7 @@ class ChunkGatedDeltaRule(CustomOp):
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
         core_attn_out: torch.Tensor | None = None,
+        return_intermediate_states: bool = False,
     ):
         return fla_chunk_gated_delta_rule(
             q=q,
@@ -311,6 +344,7 @@ class ChunkGatedDeltaRule(CustomOp):
             chunk_offsets=chunk_offsets,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
             core_attn_out=core_attn_out,
+            return_intermediate_states=return_intermediate_states,
         )
 
     def forward_cutedsl(
@@ -327,7 +361,11 @@ class ChunkGatedDeltaRule(CustomOp):
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
         core_attn_out: torch.Tensor | None = None,
+        return_intermediate_states: bool = False,
     ):
+        # Only the Triton/FLA backend exports per-chunk states (all-mode).
+        assert not return_intermediate_states
+
         from vllm.model_executor.layers.mamba.ops.gdn_chunk_cutedsl import (
             chunk_gated_delta_rule_cutedsl,
         )
@@ -1317,6 +1355,44 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
 
+        # all-mode prefix caching is active when the builder populated the
+        # full block table. The request-level block-index metadata is sliced
+        # to the NON-SPEC partition here (prefill + peeled decodes) because
+        # the prefill conv/kernel paths below process only the ~spec rows
+        # (has_initial_state is already ~spec-sliced by the builder). Gated on
+        # num_prefills so the boolean selects only run in eager batches:
+        # batches with prefills are never cudagraph-captured, and captured
+        # (pure-spec / decode-only) batches must not reach a nonzero()-based
+        # row select. With no spec rows this is the identity.
+        is_all_mode = attn_metadata.all_state_indices_tensor is not None
+        ns_all_state_indices = ns_block_idx_last_computed = None
+        ns_block_idx_first_scheduled = ns_block_idx_last_scheduled = None
+        ns_num_computed_tokens = None
+        if is_all_mode and attn_metadata.num_prefills > 0:
+            if attn_metadata.spec_sequence_masks is not None:
+                _ns = ~attn_metadata.spec_sequence_masks
+                ns_all_state_indices = attn_metadata.all_state_indices_tensor[_ns]
+                ns_block_idx_last_computed = (
+                    attn_metadata.block_idx_last_computed_token[_ns]
+                )
+                ns_block_idx_first_scheduled = (
+                    attn_metadata.block_idx_first_scheduled_token[_ns]
+                )
+                ns_block_idx_last_scheduled = (
+                    attn_metadata.block_idx_last_scheduled_token[_ns]
+                )
+                ns_num_computed_tokens = attn_metadata.num_computed_tokens[_ns]
+            else:
+                ns_all_state_indices = attn_metadata.all_state_indices_tensor
+                ns_block_idx_last_computed = attn_metadata.block_idx_last_computed_token
+                ns_block_idx_first_scheduled = (
+                    attn_metadata.block_idx_first_scheduled_token
+                )
+                ns_block_idx_last_scheduled = (
+                    attn_metadata.block_idx_last_scheduled_token
+                )
+                ns_num_computed_tokens = attn_metadata.num_computed_tokens
+
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         b = b[:num_actual_tokens]
         a = a[:num_actual_tokens]
@@ -1342,23 +1418,94 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv_non_spec = mixed_qkv
 
         # 1.1: Process the multi-query part
+        # all-mode spec dual-anchor block table + read/write anchors for the
+        # SSM update (set below when all-mode; None means in-place update at
+        # spec_state_indices_tensor).
+        spec_table = None
+        spec_block_idx_prev_step = None
+        spec_block_idx_last_scheduled = None
         if spec_sequence_masks is not None:
             # spec_state_indices_tensor is always set when spec_sequence_masks is set
             assert spec_state_indices_tensor is not None
-            mixed_qkv_spec = causal_conv1d_update(
-                mixed_qkv_spec,
-                conv_state,
-                conv_weights,
-                self.conv1d.bias,
-                self.activation,
-                conv_state_indices=spec_state_indices_tensor[:, 0][  # type: ignore[index]
-                    : attn_metadata.num_spec_decodes  # type: ignore[attr-defined]
-                ],
-                num_accepted_tokens=num_accepted_tokens,
-                query_start_loc=spec_query_start_loc,
-                max_query_len=spec_state_indices_tensor.size(-1),
-                validate_data=False,
-            )
+            if is_all_mode:
+                # all-mode spec dual anchor: the decode kernels derive the
+                # read/write state slots of the 1 + num_spec speculative
+                # tokens directly from the full block table in-kernel. Read
+                # anchor = the previous step's last-scheduled block (where
+                # that step wrote its per-token states); write anchor = this
+                # step's last-scheduled block. In a pure-spec batch (the only
+                # cudagraph-captured case) every request is a spec row, so
+                # the request-level buffer views are used directly (capture-
+                # safe); a mixed batch is eager-only and boolean-selects the
+                # spec rows. Mirrors mamba_mixer2's spec decode.
+                assert (
+                    attn_metadata.block_idx_last_scheduled_token_prev_step is not None
+                )
+                if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+                    spec_table = attn_metadata.all_state_indices_tensor
+                    spec_block_idx_last_scheduled = (
+                        attn_metadata.block_idx_last_scheduled_token
+                    )
+                    spec_block_idx_last_computed = (
+                        attn_metadata.block_idx_last_computed_token
+                    )
+                    spec_block_idx_prev_step = (
+                        attn_metadata.block_idx_last_scheduled_token_prev_step
+                    )
+                else:
+                    spec_table = attn_metadata.all_state_indices_tensor[
+                        spec_sequence_masks
+                    ]
+                    spec_block_idx_last_scheduled = (
+                        attn_metadata.block_idx_last_scheduled_token[
+                            spec_sequence_masks
+                        ]
+                    )
+                    spec_block_idx_last_computed = (
+                        attn_metadata.block_idx_last_computed_token[spec_sequence_masks]
+                    )
+                    spec_block_idx_prev_step = (
+                        attn_metadata.block_idx_last_scheduled_token_prev_step[
+                            spec_sequence_masks
+                        ]
+                    )
+                # The conv reads its initial state from the last *computed*
+                # block and writes to the last *scheduled* block in-kernel.
+                mixed_qkv_spec = causal_conv1d_update(
+                    mixed_qkv_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=spec_table,
+                    block_idx_last_scheduled_token=spec_block_idx_last_scheduled,
+                    initial_state_idx=spec_block_idx_last_computed,
+                    num_accepted_tokens=num_accepted_tokens,
+                    query_start_loc=spec_query_start_loc,
+                    # True spec query width (num_spec_tokens + 1), NOT the block-table
+                    # width: max_query_len sizes the kernel's NP2_STATELEN state tile,
+                    # while the per-sequence lengths are re-derived from
+                    # spec_query_start_loc and the state addressing travels via
+                    # conv_state_indices. Passing spec_table.size(-1) (~456) inflated
+                    # the tile to 512 lanes for 3 real tokens (10-20x per call).
+                    max_query_len=spec_state_indices_tensor.size(-1),
+                    validate_data=False,
+                )
+            else:
+                mixed_qkv_spec = causal_conv1d_update(
+                    mixed_qkv_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=spec_state_indices_tensor[:, 0][  # type: ignore[index]
+                        : attn_metadata.num_spec_decodes  # type: ignore[attr-defined]
+                    ],
+                    num_accepted_tokens=num_accepted_tokens,
+                    query_start_loc=spec_query_start_loc,
+                    max_query_len=spec_state_indices_tensor.size(-1),
+                    validate_data=False,
+                )
 
         # 1.2: Process the remaining part
         if attn_metadata.num_prefills > 0:
@@ -1366,6 +1513,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
             # - "cache_indices" updates the conv_state cache in positions
             #   pointed to by "state_indices_tensor"
+            # In all-mode the conv reads its initial state from the last
+            # computed block, writes block-aligned conv-state checkpoints,
+            # and indexes the full per-request block table (mirrors
+            # mamba_mixer2). The extra args are None/0 otherwise.
             mixed_qkv_non_spec = causal_conv1d_fn(
                 mixed_qkv_non_spec_T,
                 conv_weights,
@@ -1373,23 +1524,57 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 activation=self.activation,
                 conv_states=conv_state,
                 has_initial_state=has_initial_state,
-                cache_indices=non_spec_state_indices_tensor,
+                cache_indices=(
+                    ns_all_state_indices
+                    if is_all_mode
+                    else non_spec_state_indices_tensor
+                ),
+                block_idx_first_scheduled_token=ns_block_idx_first_scheduled,
+                block_idx_last_scheduled_token=ns_block_idx_last_scheduled,
+                initial_state_idx=ns_block_idx_last_computed,
+                num_computed_tokens=ns_num_computed_tokens,
+                block_size_to_align=(
+                    self.cache_config.mamba_block_size if is_all_mode else 0
+                ),
                 query_start_loc=non_spec_query_start_loc,
                 metadata=attn_metadata,
             ).transpose(0, 1)
         elif attn_metadata.num_decodes > 0:
             assert mixed_qkv_non_spec is not None
-            mixed_qkv_non_spec = causal_conv1d_update(
-                mixed_qkv_non_spec,
-                conv_state,
-                conv_weights,
-                self.conv1d.bias,
-                self.activation,
-                conv_state_indices=non_spec_state_indices_tensor[  # type: ignore[index]
-                    : attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
-                ],
-                validate_data=True,
-            )
+            if is_all_mode:
+                # all-mode decode dual anchor (mirrors mamba_mixer2's decode
+                # conv): read the running conv state from the last computed
+                # block, write to the last scheduled block, in-kernel. Only
+                # buffer views are consumed — cudagraph-capturable.
+                mixed_qkv_non_spec = causal_conv1d_update(
+                    mixed_qkv_non_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=attn_metadata.all_state_indices_tensor[
+                        :num_actual_tokens
+                    ],
+                    block_idx_last_scheduled_token=(
+                        attn_metadata.block_idx_last_scheduled_token[:num_actual_tokens]
+                    ),
+                    initial_state_idx=attn_metadata.block_idx_last_computed_token[
+                        :num_actual_tokens
+                    ],
+                    validate_data=False,
+                )
+            else:
+                mixed_qkv_non_spec = causal_conv1d_update(
+                    mixed_qkv_non_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=non_spec_state_indices_tensor[  # type: ignore[index]
+                        : attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
+                    ],
+                    validate_data=True,
+                )
         else:
             mixed_qkv_non_spec = None
 
@@ -1472,7 +1657,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                         : attn_metadata.num_spec_decodes
                         + 1  # type: ignore[attr-defined]
                     ],
-                    ssm_state_indices=spec_state_indices_tensor,
+                    # all-mode: the kernel derives its read/write slots from
+                    # the block table in-kernel — read via the prev-step
+                    # anchor, write the updated per-token states via the
+                    # current-step anchor (dual anchor); align/none: in-place
+                    # at spec_state_indices_tensor.
+                    ssm_state_indices=(
+                        None if is_all_mode else spec_state_indices_tensor
+                    ),
+                    block_table=spec_table,
+                    read_anchor=spec_block_idx_prev_step,
+                    write_anchor=spec_block_idx_last_scheduled,
                     num_accepted_tokens=num_accepted_tokens,
                     use_qk_l2norm_in_kernel=True,
                 )
@@ -1485,6 +1680,21 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(
                 mixed_qkv_non_spec[:num_decode_tokens]  # type: ignore[index]
             )
+            if is_all_mode:
+                # all-mode dual anchor for the peeled decode rows: the kernel
+                # derives its slots from the block table in-kernel — read the
+                # last computed block, write the last scheduled block (K2
+                # dual-index). Mixed batches are eager-only, ns_* available.
+                assert ns_all_state_indices is not None
+                decode_state_indices = None
+                decode_block_table = ns_all_state_indices
+                decode_read_anchor = ns_block_idx_last_computed
+                decode_write_anchor = ns_block_idx_last_scheduled
+            else:
+                decode_state_indices = non_spec_state_indices_tensor
+                decode_block_table = None
+                decode_read_anchor = None
+                decode_write_anchor = None
             core_attn_out_decode, _ = fused_sigmoid_gating_delta_rule_update(
                 A_log=self.A_log,
                 a=a[:num_decode_tokens],
@@ -1498,7 +1708,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
                     : attn_metadata.num_decodes + 1
                 ],
-                ssm_state_indices=non_spec_state_indices_tensor,
+                ssm_state_indices=decode_state_indices,
+                block_table=decode_block_table,
+                read_anchor=decode_read_anchor,
+                write_anchor=decode_write_anchor,
                 use_qk_l2norm_in_kernel=True,
             )
         else:
@@ -1514,12 +1727,32 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefill_has_initial_state = attn_metadata.prefill_has_initial_state
             assert prefill_state_indices is not None
             assert prefill_has_initial_state is not None
-            initial_state = ssm_state[prefill_state_indices]
+            if is_all_mode:
+                # Peel decode rows off the non-spec slices: the chunk kernel
+                # and the checkpoint scatter process prefill rows only (the
+                # chunk metadata is already prefill-only, see the builder).
+                num_decodes = attn_metadata.num_decodes
+                assert ns_all_state_indices is not None
+                assert ns_block_idx_first_scheduled is not None
+                assert ns_block_idx_last_scheduled is not None
+                assert ns_block_idx_last_computed is not None
+                assert ns_num_computed_tokens is not None
+                p_all_state_indices = ns_all_state_indices[num_decodes:]
+                p_block_idx_first_scheduled = ns_block_idx_first_scheduled[num_decodes:]
+                p_block_idx_last_scheduled = ns_block_idx_last_scheduled[num_decodes:]
+                p_block_idx_last_computed = ns_block_idx_last_computed[num_decodes:]
+                p_num_computed_tokens = ns_num_computed_tokens[num_decodes:]
+                # Load the initial recurrent state from the last *computed*
+                # block boundary (the prefix-cache hit), not the leading
+                # block of the table.
+                init_idx = p_all_state_indices.gather(
+                    1, p_block_idx_last_computed.long().unsqueeze(1)
+                ).squeeze(1)
+                initial_state = ssm_state[init_idx]
+            else:
+                initial_state = ssm_state[prefill_state_indices]
             initial_state[~prefill_has_initial_state, ...] = 0
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = self.chunk_gated_delta_rule(
+            outputs = self.chunk_gated_delta_rule(
                 q=query_non_spec,
                 k=key_non_spec,
                 v=value_non_spec,
@@ -1531,9 +1764,33 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 chunk_indices=attn_metadata.chunk_indices,
                 chunk_offsets=attn_metadata.chunk_offsets,
                 use_qk_l2norm_in_kernel=False,
+                return_intermediate_states=is_all_mode,
             )
-            # Init cache
-            ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
+            if is_all_mode:
+                core_attn_out_non_spec, last_recurrent_state, inter_states = outputs
+                # Scatter per-block SSM checkpoints into every scheduled
+                # block (final block from the final state; interior blocks
+                # from the per-chunk exports). Replaces the blanket
+                # final-state write below.
+                assert attn_metadata.chunk_offsets is not None
+                gdn_scatter_block_checkpoints(
+                    ssm_state,
+                    inter_states.squeeze(0),
+                    last_recurrent_state,
+                    p_all_state_indices,
+                    p_block_idx_first_scheduled,
+                    p_block_idx_last_scheduled,
+                    p_num_computed_tokens,
+                    attn_metadata.chunk_offsets,
+                    self.cache_config.mamba_block_size,
+                    FLA_CHUNK_SIZE,
+                )
+            else:
+                core_attn_out_non_spec, last_recurrent_state = outputs
+                # Init cache
+                ssm_state[prefill_state_indices] = last_recurrent_state.to(
+                    ssm_state.dtype
+                )
 
             if split_non_spec:
                 # Stitch the peeled decode outputs in front of the prefill
@@ -1542,6 +1799,22 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     [core_attn_out_decode, core_attn_out_non_spec], dim=1
                 )
         elif attn_metadata.num_decodes > 0:
+            if is_all_mode:
+                # all-mode decode dual anchor: the kernel derives its slots
+                # from the block table in-kernel — read the last computed
+                # block, write the last scheduled block (K2 dual-index). Same
+                # block within a mamba block; differs exactly at a
+                # block-boundary crossing, where the state migrates to the
+                # fresh block. Buffer views only — cudagraph-capturable.
+                decode_state_indices = None
+                decode_block_table = attn_metadata.all_state_indices_tensor
+                decode_read_anchor = attn_metadata.block_idx_last_computed_token
+                decode_write_anchor = attn_metadata.block_idx_last_scheduled_token
+            else:
+                decode_state_indices = non_spec_state_indices_tensor
+                decode_block_table = None
+                decode_read_anchor = None
+                decode_write_anchor = None
             core_attn_out_non_spec, last_recurrent_state = (
                 fused_sigmoid_gating_delta_rule_update(
                     A_log=self.A_log,
@@ -1557,7 +1830,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                         : attn_metadata.num_decodes
                         + 1  # type: ignore[attr-defined]
                     ],
-                    ssm_state_indices=non_spec_state_indices_tensor,
+                    ssm_state_indices=decode_state_indices,
+                    block_table=decode_block_table,
+                    read_anchor=decode_read_anchor,
+                    write_anchor=decode_write_anchor,
                     use_qk_l2norm_in_kernel=True,
                 )
             )
@@ -1589,6 +1865,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     ):
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+        all_mode_read_idx = None
+        if attn_metadata.all_state_indices_tensor is not None:
+            # all-mode decode dual anchor — same carry pattern as the packed
+            # CUDA fast path (the AITER kernels update state in place).
+            all_idx = attn_metadata.all_state_indices_tensor
+            non_spec_state_indices_tensor = all_idx.gather(
+                1, attn_metadata.block_idx_last_scheduled_token.long().unsqueeze(1)
+            ).squeeze(1)
+            all_mode_read_idx = all_idx.gather(
+                1, attn_metadata.block_idx_last_computed_token.long().unsqueeze(1)
+            ).squeeze(1)
         self_kv_cache = self.kv_cache
         # conv_state must be (..., dim, width-1) for the conv kernels.
         # DS layout stores it that way directly; SD layout needs a transpose.
@@ -1598,6 +1885,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             else self_kv_cache[0].transpose(-1, -2)
         )
         ssm_state = self_kv_cache[1]
+
+        if all_mode_read_idx is not None:
+            num_actual_tokens = attn_metadata.num_actual_tokens
+            write_idx = non_spec_state_indices_tensor[:num_actual_tokens]
+            read_idx = all_mode_read_idx[:num_actual_tokens]
+            conv_state[write_idx] = conv_state[read_idx]
+            ssm_state[write_idx] = ssm_state[read_idx]
 
         # 1. Convolution sequence transformation
         conv_weights = self.conv1d.weight.view(
@@ -1657,6 +1951,20 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         Core attention computation with a packed non-spec decode fast path.
         """
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+        block_table = None
+        read_anchor = None
+        write_anchor = None
+        if attn_metadata.all_state_indices_tensor is not None:
+            # all-mode decode dual anchor: both the conv update and the
+            # packed recurrent decode kernels derive their state slots from
+            # the block table in-kernel — read the last computed block (read
+            # anchor), write the last scheduled block (write anchor). Within
+            # a mamba block the anchors are the same physical block; at a
+            # block-boundary crossing the state migrates into the fresh
+            # block. Buffer views only — cudagraph-capturable.
+            block_table = attn_metadata.all_state_indices_tensor
+            read_anchor = attn_metadata.block_idx_last_computed_token
+            write_anchor = attn_metadata.block_idx_last_scheduled_token
         self_kv_cache = self.kv_cache
         # conv_state must be (..., dim, width-1) for the conv kernels.
         # DS layout stores it that way directly; SD layout needs a transpose.
@@ -1672,6 +1980,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         b = b[:num_actual_tokens]
         a = a[:num_actual_tokens]
 
+        if block_table is not None:
+            block_table = block_table[:num_actual_tokens]
+            read_anchor = read_anchor[:num_actual_tokens]
+            write_anchor = write_anchor[:num_actual_tokens]
+
         conv_weights = self.conv1d.weight.view(
             self.conv1d.weight.size(0), self.conv1d.weight.size(2)
         )
@@ -1681,7 +1994,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             conv_weights,
             self.conv1d.bias,
             self.activation,
-            conv_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
+            conv_state_indices=(
+                block_table
+                if block_table is not None
+                else non_spec_state_indices_tensor[:num_actual_tokens]  # type: ignore[index]
+            ),
+            block_idx_last_scheduled_token=write_anchor,
+            initial_state_idx=read_anchor,
             validate_data=False,
         )
         out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
@@ -1694,7 +2013,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             scale=self.head_k_dim**-0.5,
             initial_state=ssm_state,
             out=out_buf,
-            ssm_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
+            ssm_state_indices=(
+                None
+                if block_table is not None
+                else non_spec_state_indices_tensor[:num_actual_tokens]  # type: ignore[index]
+            ),
+            block_table=block_table,
+            read_anchor=read_anchor,
+            write_anchor=write_anchor,
             use_qk_l2norm_in_kernel=True,
         )
         return

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -400,6 +400,76 @@ class ChunkGatedDeltaRule(CustomOp):
         return o, final_state
 
 
+def gdn_deinterleave_qkvz_enabled() -> bool:
+    """C9: row-permute in_proj_qkvz/in_proj_ba weights at load so the
+    projection output is already in flat [q, k, v, z] / [b, a] layout and
+    the interleaved-GQA unpack glue kernels are not needed. Bit-exact by
+    construction (pure row permutation of the GEMM output). Default on;
+    "0" restores the exact old interleaved path."""
+    return os.environ.get("VLLM_GDN_DEINTERLEAVE_QKVZ", "1") != "0"
+
+
+def gdn_concat_tiny_gemms_enabled() -> bool:
+    """C6: fold the tiny in_proj_ba GEMM rows into the in_proj_qkvz GEMM
+    (N 12288 -> 12352 at TP1) at weight load. Kills the splitK GEMM +
+    splitKreduce partner; measured in-graph on B200 the fused GEMM also
+    beats the separate qkvz GEMM (-3.1 us at ntok=16 / -4.5 us at 128 for
+    the projection). Output columns are torch.equal-bit-exact on B200.
+    Default on; "0" restores the exact old two-GEMM path."""
+    return os.environ.get("VLLM_GDN_CONCAT_TINY_GEMMS", "1") != "0"
+
+
+def gdn_concat_router_gate_enabled() -> bool:
+    """C6 router-gate fold: fold the 1-row shared_expert_gate into the MoE
+    router gate GEMM (padded N 512 -> 528; see MoERunner). DEFAULT OFF:
+    measured in-graph on B200 the unpadded N=513 GEMM is a cuBLAS cliff
+    (+17..+22 us/layer vs the separate pair) and even the padded variant
+    nets only -0.8..-1.5 us/layer after the contiguous router-logits
+    slice, while introducing ULP-class drift on the routing logits
+    (~0.5-0.8% of logit scale) that can flip near-tie top-k picks.
+    Set "1" to opt in."""
+    return os.environ.get("VLLM_GDN_CONCAT_ROUTER_GATE", "0") != "0"
+
+
+def build_qkvz_deinterleave_perm(
+    num_groups: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    v_heads_per_group: int,
+    device=None,
+) -> torch.Tensor:
+    """Row permutation taking the interleaved-GQA in_proj_qkvz output
+    layout [g0:(q k v z), g1:(q k v z), ...] to flat [q_all, k_all, v_all,
+    z_all] (the Qwen3.5 layout `prepare_gdn_attention_core_inputs`
+    expects). Flattened per-group order matches the order the old unpack
+    produced, so outputs are bit-identical element-for-element."""
+    group = 2 * head_k_dim + 2 * v_heads_per_group * head_v_dim
+    idx = torch.arange(num_groups * group, dtype=torch.long, device=device)
+    idx = idx.view(num_groups, group)
+    q = idx[:, :head_k_dim]
+    k = idx[:, head_k_dim : 2 * head_k_dim]
+    v = idx[:, 2 * head_k_dim : 2 * head_k_dim + v_heads_per_group * head_v_dim]
+    z = idx[:, 2 * head_k_dim + v_heads_per_group * head_v_dim :]
+    return torch.cat(
+        [q.reshape(-1), k.reshape(-1), v.reshape(-1), z.reshape(-1)], dim=0
+    )
+
+
+def build_ba_deinterleave_perm(
+    num_groups: int,
+    v_heads_per_group: int,
+    device=None,
+) -> torch.Tensor:
+    """Row permutation taking the interleaved in_proj_ba output layout
+    [b_g0, a_g0, b_g1, a_g1, ...] to flat [b_all, a_all]."""
+    idx = torch.arange(num_groups * 2 * v_heads_per_group, dtype=torch.long,
+                       device=device)
+    idx = idx.view(num_groups, 2 * v_heads_per_group)
+    b = idx[:, :v_heads_per_group]
+    a = idx[:, v_heads_per_group:]
+    return torch.cat([b.reshape(-1), a.reshape(-1)], dim=0)
+
+
 @PluggableLayer.register("qwen_gated_delta_net_attention")
 class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def get_state_shape(
@@ -540,6 +610,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.chunk_gated_delta_rule = ChunkGatedDeltaRule()
         self.gdn_prefill_backend = self.chunk_gated_delta_rule.gdn_prefill_backend
         self._prefill_kernels_warmed_up = False
+        # Post-load weight-layout transforms (see
+        # apply_traffic_opt_weight_transforms). Both default False until the
+        # model's load_weights applies them.
+        self._qkvz_deinterleaved = False
+        self._in_proj_concat = False
+        self._in_proj_fused_weight: torch.Tensor | None = None
+        self._qkvz_local_rows = 0
         self.enable_packed_recurrent_decode = (
             envs.VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE
         )
@@ -657,6 +734,77 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             and not self.gqa_interleaved_layout
             and isinstance(quant_config, (AutoAWQConfig, AutoGPTQConfig, INCConfig))
         )
+
+    def apply_traffic_opt_weight_transforms(self) -> None:
+        """Accuracy-neutral post-load weight-layout transforms.
+
+        Must be called after every full checkpoint load (a reload rewrites
+        the raw interleaved layout, so this re-applies from scratch).
+
+        C9 (VLLM_GDN_DEINTERLEAVE_QKVZ): row-permute the local
+        in_proj_qkvz / in_proj_ba weight shards from the interleaved-GQA
+        checkpoint layout to flat [q, k, v, z] / [b, a]. The projection
+        output then splits into kernel inputs with views only -- the
+        interleaved unpack's cat+slice forced copy disappears. Bit-exact:
+        each output element is the same dot product, just at a different
+        output position.
+
+        C6 (VLLM_GDN_CONCAT_TINY_GEMMS): place both weight shards in one
+        [qkvz_rows + ba_rows, hidden] buffer and run a single GEMM in
+        forward; the parameters become views into the fused buffer so
+        weight reloading still works. Kills the tiny in_proj_ba splitK
+        GEMM + its splitKreduce partner.
+
+        Only applied on CUDA for the interleaved (Qwen3-Next) layout with
+        unquantized in_proj weights (the NVFP4 checkpoint excludes
+        in_proj_qkvz/in_proj_ba from quantization).
+        """
+        self._qkvz_deinterleaved = False
+        self._in_proj_concat = False
+        self._in_proj_fused_weight = None
+        if not (current_platform.is_cuda() and self.gqa_interleaved_layout):
+            return
+        qkvz_w = getattr(self.in_proj_qkvz, "weight", None)
+        ba_w = getattr(self.in_proj_ba, "weight", None)
+        if qkvz_w is None or ba_w is None:
+            return
+        if qkvz_w.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+            # quantized/packed in_proj: layouts are backend-owned, skip.
+            return
+        if qkvz_w.dtype != ba_w.dtype or qkvz_w.shape[1] != ba_w.shape[1]:
+            return
+
+        ng = self.num_k_heads // self.tp_size
+        nvg = self.num_v_heads // self.num_k_heads
+        qkvz_rows = ng * (2 * self.head_k_dim + 2 * nvg * self.head_v_dim)
+        ba_rows = ng * 2 * nvg
+        if qkvz_w.shape[0] != qkvz_rows or ba_w.shape[0] != ba_rows:
+            return
+
+        if gdn_deinterleave_qkvz_enabled():
+            perm_qkvz = build_qkvz_deinterleave_perm(
+                ng, self.head_k_dim, self.head_v_dim, nvg, device=qkvz_w.device
+            )
+            perm_ba = build_ba_deinterleave_perm(ng, nvg, device=ba_w.device)
+            qkvz_w.data = qkvz_w.data[perm_qkvz].contiguous()
+            ba_w.data = ba_w.data[perm_ba].contiguous()
+            self._qkvz_deinterleaved = True
+
+        if gdn_concat_tiny_gemms_enabled():
+            fused = torch.empty(
+                (qkvz_rows + ba_rows, qkvz_w.shape[1]),
+                dtype=qkvz_w.dtype,
+                device=qkvz_w.device,
+            )
+            fused[:qkvz_rows].copy_(qkvz_w.data)
+            fused[qkvz_rows:].copy_(ba_w.data)
+            # Keep the parameter objects (and their weight_loader attrs)
+            # alive as views into the fused buffer so reloads write through.
+            qkvz_w.data = fused[:qkvz_rows]
+            ba_w.data = fused[qkvz_rows:]
+            self._in_proj_fused_weight = fused
+            self._qkvz_local_rows = qkvz_rows
+            self._in_proj_concat = True
 
     def split_ba(self, ba: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         b, a = ba.chunk(2, dim=-1)
@@ -943,11 +1091,25 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        if self._in_proj_concat:
+            # C6: single fused GEMM over [qkvz_rows + ba_rows, hidden];
+            # slice views replace the second (splitK) GEMM.
+            qkvzba = torch.nn.functional.linear(
+                hidden_states, self._in_proj_fused_weight
+            )
+            mixed_qkvz = qkvzba[:, : self._qkvz_local_rows]
+            ba = qkvzba[:, self._qkvz_local_rows :]
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
 
+        # Upstream's fused norm-packed decode consumes the raw interleaved
+        # GEMM output; it cannot run over de-interleaved weights. The
+        # de-interleave transform (measured win on the packed path) takes
+        # precedence when enabled; interplay to be re-benchmarked.
         use_fused_gdn_decode = (
             self.enable_fused_gdn_decode
+            and not self._qkvz_deinterleaved
             and hidden_states.dtype == torch.bfloat16
             and self.norm.weight.dtype in (torch.bfloat16, torch.float32)
         )
@@ -966,7 +1128,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             output, _ = self.out_proj(core_attn_out.flatten(-2))
             return output
 
-        if self.gqa_interleaved_layout:
+        if self.gqa_interleaved_layout and not self._qkvz_deinterleaved:
             # Qwen3-Next: unpack the interleaved GQA layout
             query, key, value, z, b, a = self.fix_query_key_value_ordering(
                 mixed_qkvz, ba
@@ -976,7 +1138,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
             mixed_qkv = torch.cat((query, key, value), dim=-1)
         else:
-            # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
+            # Qwen3.5 checkpoint layout, or Qwen3-Next after the C9
+            # de-interleave weight transform: [q, k, v, z] and [b, a]
+            # order. mixed_qkv stays a row-strided view (stride(-1) == 1);
+            # the conv/gating kernels take a token-row stride.
             qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
             z_size = self.value_dim // self.tp_size
             mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -42,6 +42,10 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from vllm.model_executor.layers.mamba.ops.gdn_scatter import (
+    gdn_inkernel_ckpt_write_enabled,
+    gdn_scatter_block_checkpoints_triton,
+)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQConfig
@@ -1370,7 +1374,21 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         ns_block_idx_first_scheduled = ns_block_idx_last_scheduled = None
         ns_num_computed_tokens = None
         if is_all_mode and attn_metadata.num_prefills > 0:
-            if attn_metadata.spec_sequence_masks is not None:
+            if attn_metadata.ns_all_state_indices_sel is not None:
+                # Builder pre-selected these once per step with the CPU spec
+                # mask — no per-layer device-mask nonzero syncs.
+                ns_all_state_indices = attn_metadata.ns_all_state_indices_sel
+                ns_block_idx_last_computed = (
+                    attn_metadata.ns_block_idx_last_computed_sel
+                )
+                ns_block_idx_first_scheduled = (
+                    attn_metadata.ns_block_idx_first_scheduled_sel
+                )
+                ns_block_idx_last_scheduled = (
+                    attn_metadata.ns_block_idx_last_scheduled_sel
+                )
+                ns_num_computed_tokens = attn_metadata.ns_num_computed_tokens_sel
+            elif attn_metadata.spec_sequence_masks is not None:
                 _ns = ~attn_metadata.spec_sequence_masks
                 ns_all_state_indices = attn_metadata.all_state_indices_tensor[_ns]
                 ns_block_idx_last_computed = (
@@ -1425,6 +1443,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         spec_table = None
         spec_block_idx_prev_step = None
         spec_block_idx_last_scheduled = None
+        # Packed (read, write) anchor pairs (single 64-bit anchor load in the
+        # kernels), populated by the builder only with the prep kernel on:
+        # the SSM pair reads the prev-step anchor, the conv pair the last
+        # computed block.
+        spec_packed_anchors = None
+        conv_spec_packed_anchors = None
         if spec_sequence_masks is not None:
             # spec_state_indices_tensor is always set when spec_sequence_masks is set
             assert spec_state_indices_tensor is not None
@@ -1453,6 +1477,26 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     spec_block_idx_prev_step = (
                         attn_metadata.block_idx_last_scheduled_token_prev_step
                     )
+                    spec_packed_anchors = attn_metadata.block_idx_packed_anchors_spec
+                    conv_spec_packed_anchors = attn_metadata.block_idx_packed_anchors
+                elif attn_metadata.spec_all_state_indices_sel is not None:
+                    # Builder pre-selected (CPU spec mask, no device sync).
+                    spec_table = attn_metadata.spec_all_state_indices_sel
+                    spec_block_idx_last_scheduled = (
+                        attn_metadata.spec_block_idx_last_scheduled_sel
+                    )
+                    spec_block_idx_last_computed = (
+                        attn_metadata.spec_block_idx_last_computed_sel
+                    )
+                    spec_block_idx_prev_step = (
+                        attn_metadata.spec_block_idx_prev_step_sel
+                    )
+                    spec_packed_anchors = (
+                        attn_metadata.spec_block_idx_packed_anchors_spec_sel
+                    )
+                    conv_spec_packed_anchors = (
+                        attn_metadata.spec_block_idx_packed_anchors_sel
+                    )
                 else:
                     spec_table = attn_metadata.all_state_indices_tensor[
                         spec_sequence_masks
@@ -1470,6 +1514,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                             spec_sequence_masks
                         ]
                     )
+                    if attn_metadata.block_idx_packed_anchors_spec is not None:
+                        spec_packed_anchors = (
+                            attn_metadata.block_idx_packed_anchors_spec[
+                                spec_sequence_masks
+                            ]
+                        )
+                        conv_spec_packed_anchors = (
+                            attn_metadata.block_idx_packed_anchors[
+                                spec_sequence_masks
+                            ]
+                        )
                 # The conv reads its initial state from the last *computed*
                 # block and writes to the last *scheduled* block in-kernel.
                 mixed_qkv_spec = causal_conv1d_update(
@@ -1479,8 +1534,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     self.conv1d.bias,
                     self.activation,
                     conv_state_indices=spec_table,
-                    block_idx_last_scheduled_token=spec_block_idx_last_scheduled,
-                    initial_state_idx=spec_block_idx_last_computed,
+                    block_idx_last_scheduled_token=(
+                        None
+                        if conv_spec_packed_anchors is not None
+                        else spec_block_idx_last_scheduled
+                    ),
+                    initial_state_idx=(
+                        None
+                        if conv_spec_packed_anchors is not None
+                        else spec_block_idx_last_computed
+                    ),
+                    packed_anchors=conv_spec_packed_anchors,
                     num_accepted_tokens=num_accepted_tokens,
                     query_start_loc=spec_query_start_loc,
                     # True spec query width (num_spec_tokens + 1), NOT the block-table
@@ -1547,6 +1611,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 # conv): read the running conv state from the last computed
                 # block, write to the last scheduled block, in-kernel. Only
                 # buffer views are consumed — cudagraph-capturable.
+                decode_conv_packed = attn_metadata.block_idx_packed_anchors
                 mixed_qkv_non_spec = causal_conv1d_update(
                     mixed_qkv_non_spec,
                     conv_state,
@@ -1557,11 +1622,24 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                         :num_actual_tokens
                     ],
                     block_idx_last_scheduled_token=(
-                        attn_metadata.block_idx_last_scheduled_token[:num_actual_tokens]
+                        None
+                        if decode_conv_packed is not None
+                        else attn_metadata.block_idx_last_scheduled_token[
+                            :num_actual_tokens
+                        ]
                     ),
-                    initial_state_idx=attn_metadata.block_idx_last_computed_token[
-                        :num_actual_tokens
-                    ],
+                    initial_state_idx=(
+                        None
+                        if decode_conv_packed is not None
+                        else attn_metadata.block_idx_last_computed_token[
+                            :num_actual_tokens
+                        ]
+                    ),
+                    packed_anchors=(
+                        None
+                        if decode_conv_packed is None
+                        else decode_conv_packed[:num_actual_tokens]
+                    ),
                     validate_data=False,
                 )
             else:
@@ -1680,8 +1758,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                         None if is_all_mode else spec_state_indices_tensor
                     ),
                     block_table=spec_table,
-                    read_anchor=spec_block_idx_prev_step,
-                    write_anchor=spec_block_idx_last_scheduled,
+                    read_anchor=(
+                        None
+                        if spec_packed_anchors is not None
+                        else spec_block_idx_prev_step
+                    ),
+                    write_anchor=(
+                        None
+                        if spec_packed_anchors is not None
+                        else spec_block_idx_last_scheduled
+                    ),
+                    packed_anchors=spec_packed_anchors,
                     num_accepted_tokens=num_accepted_tokens,
                     use_qk_l2norm_in_kernel=True,
                 )
@@ -1708,13 +1795,19 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 assert ns_all_state_indices is not None
                 decode_state_indices = None
                 decode_block_table = ns_all_state_indices
-                decode_read_anchor = ns_block_idx_last_computed
-                decode_write_anchor = ns_block_idx_last_scheduled
+                decode_packed_anchors = attn_metadata.block_idx_packed_anchors
+                if decode_packed_anchors is not None:
+                    decode_read_anchor = None
+                    decode_write_anchor = None
+                else:
+                    decode_read_anchor = ns_block_idx_last_computed
+                    decode_write_anchor = ns_block_idx_last_scheduled
             else:
                 decode_state_indices = non_spec_state_indices_tensor
                 decode_block_table = None
                 decode_read_anchor = None
                 decode_write_anchor = None
+                decode_packed_anchors = None
             core_attn_out_decode, _ = fused_sigmoid_gating_delta_rule_update(
                 A_log=self.A_log,
                 a=a[:num_decode_tokens],
@@ -1737,6 +1830,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 block_table=decode_block_table,
                 read_anchor=decode_read_anchor,
                 write_anchor=decode_write_anchor,
+                packed_anchors=decode_packed_anchors,
                 use_qk_l2norm_in_kernel=True,
             )
         else:
@@ -1798,18 +1892,33 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 # from the per-chunk exports). Replaces the blanket
                 # final-state write below.
                 assert attn_metadata.chunk_offsets is not None
-                gdn_scatter_block_checkpoints(
-                    ssm_state,
-                    inter_states.squeeze(0),
-                    last_recurrent_state,
-                    p_all_state_indices,
-                    p_block_idx_first_scheduled,
-                    p_block_idx_last_scheduled,
-                    p_num_computed_tokens,
-                    attn_metadata.chunk_offsets,
-                    self.cache_config.mamba_block_size,
-                    FLA_CHUNK_SIZE,
-                )
+                if gdn_inkernel_ckpt_write_enabled():
+                    gdn_scatter_block_checkpoints_triton(
+                        ssm_state,
+                        inter_states.squeeze(0),
+                        last_recurrent_state,
+                        p_all_state_indices,
+                        p_block_idx_first_scheduled,
+                        p_block_idx_last_scheduled,
+                        p_num_computed_tokens,
+                        attn_metadata.chunk_offsets,
+                        self.cache_config.mamba_block_size,
+                        FLA_CHUNK_SIZE,
+                        attn_metadata.num_prefill_tokens,
+                    )
+                else:
+                    gdn_scatter_block_checkpoints(
+                        ssm_state,
+                        inter_states.squeeze(0),
+                        last_recurrent_state,
+                        p_all_state_indices,
+                        p_block_idx_first_scheduled,
+                        p_block_idx_last_scheduled,
+                        p_num_computed_tokens,
+                        attn_metadata.chunk_offsets,
+                        self.cache_config.mamba_block_size,
+                        FLA_CHUNK_SIZE,
+                    )
             else:
                 core_attn_out_non_spec, last_recurrent_state = outputs
                 # Init cache
@@ -1833,13 +1942,19 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 # fresh block. Buffer views only — cudagraph-capturable.
                 decode_state_indices = None
                 decode_block_table = attn_metadata.all_state_indices_tensor
-                decode_read_anchor = attn_metadata.block_idx_last_computed_token
-                decode_write_anchor = attn_metadata.block_idx_last_scheduled_token
+                decode_packed_anchors = attn_metadata.block_idx_packed_anchors
+                if decode_packed_anchors is not None:
+                    decode_read_anchor = None
+                    decode_write_anchor = None
+                else:
+                    decode_read_anchor = attn_metadata.block_idx_last_computed_token
+                    decode_write_anchor = attn_metadata.block_idx_last_scheduled_token
             else:
                 decode_state_indices = non_spec_state_indices_tensor
                 decode_block_table = None
                 decode_read_anchor = None
                 decode_write_anchor = None
+                decode_packed_anchors = None
             core_attn_out_non_spec, last_recurrent_state = (
                 fused_sigmoid_gating_delta_rule_update(
                     A_log=self.A_log,
@@ -1859,6 +1974,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     block_table=decode_block_table,
                     read_anchor=decode_read_anchor,
                     write_anchor=decode_write_anchor,
+                    packed_anchors=decode_packed_anchors,
                     use_qk_l2norm_in_kernel=True,
                 )
             )
@@ -1979,6 +2095,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         block_table = None
         read_anchor = None
         write_anchor = None
+        packed_anchors = None
         if attn_metadata.all_state_indices_tensor is not None:
             # all-mode decode dual anchor: both the conv update and the
             # packed recurrent decode kernels derive their state slots from
@@ -1988,8 +2105,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             # block-boundary crossing the state migrates into the fresh
             # block. Buffer views only — cudagraph-capturable.
             block_table = attn_metadata.all_state_indices_tensor
-            read_anchor = attn_metadata.block_idx_last_computed_token
-            write_anchor = attn_metadata.block_idx_last_scheduled_token
+            packed_anchors = attn_metadata.block_idx_packed_anchors
+            if packed_anchors is None:
+                read_anchor = attn_metadata.block_idx_last_computed_token
+                write_anchor = attn_metadata.block_idx_last_scheduled_token
         self_kv_cache = self.kv_cache
         # conv_state must be (..., dim, width-1) for the conv kernels.
         # DS layout stores it that way directly; SD layout needs a transpose.
@@ -2007,8 +2126,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         if block_table is not None:
             block_table = block_table[:num_actual_tokens]
-            read_anchor = read_anchor[:num_actual_tokens]
-            write_anchor = write_anchor[:num_actual_tokens]
+            if packed_anchors is not None:
+                packed_anchors = packed_anchors[:num_actual_tokens]
+            else:
+                read_anchor = read_anchor[:num_actual_tokens]
+                write_anchor = write_anchor[:num_actual_tokens]
 
         conv_weights = self.conv1d.weight.view(
             self.conv1d.weight.size(0), self.conv1d.weight.size(2)
@@ -2026,6 +2148,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             ),
             block_idx_last_scheduled_token=write_anchor,
             initial_state_idx=read_anchor,
+            packed_anchors=packed_anchors,
             validate_data=False,
         )
         out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
@@ -2046,6 +2169,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             block_table=block_table,
             read_anchor=read_anchor,
             write_anchor=write_anchor,
+            packed_anchors=packed_anchors,
             use_qk_l2norm_in_kernel=True,
         )
         return

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen3-Next/Qwen3.5 model."""
 
+import functools
 import os
 from typing import Literal
 
@@ -1578,7 +1579,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             mixed_qkv_non_spec = None
 
-        query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
+        # Packed spec/decode qkv: hand the packed conv output straight to the
+        # gating kernel (per-tensor offsets in-kernel) instead of splitting it
+        # into contiguous q/k/v via rearrange_mixed_qkv (cat + 3 copies).
+        # VLLM_GDN_PACKED_SPEC_QKV=0 restores the rearrange path (A/B tests).
+        use_packed_spec_qkv = os.environ.get("VLLM_GDN_PACKED_SPEC_QKV", "1") != "0"
+        if use_packed_spec_qkv:
+            query_spec = key_spec = value_spec = None
+        else:
+            query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
 
         # Split mixed non-spec-decode+prefill to process independently
         split_non_spec = (
@@ -1651,6 +1660,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     q=query_spec,
                     k=key_spec,
                     v=value_spec,
+                    mixed_qkv=mixed_qkv_spec if use_packed_spec_qkv else None,
+                    num_qk_heads=self.num_k_heads // self.tp_size,
+                    head_qk_dim=self.head_k_dim,
+                    num_v_heads=self.num_v_heads // self.tp_size,
+                    head_v_dim=self.head_v_dim,
                     initial_state=ssm_state,
                     inplace_final_state=True,
                     cu_seqlens=spec_query_start_loc[  # type: ignore[index]
@@ -1677,9 +1691,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 2.2: Process non-spec-decode part
         if split_non_spec:
-            query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(
+            mixed_qkv_decode = (
                 mixed_qkv_non_spec[:num_decode_tokens]  # type: ignore[index]
             )
+            if use_packed_spec_qkv:
+                query_decode = key_decode = value_decode = None
+            else:
+                query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(
+                    mixed_qkv_decode
+                )
             if is_all_mode:
                 # all-mode dual anchor for the peeled decode rows: the kernel
                 # derives its slots from the block table in-kernel — read the
@@ -1703,6 +1723,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 q=query_decode,
                 k=key_decode,
                 v=value_decode,
+                mixed_qkv=mixed_qkv_decode if use_packed_spec_qkv else None,
+                num_qk_heads=self.num_k_heads // self.tp_size,
+                head_qk_dim=self.head_k_dim,
+                num_v_heads=self.num_v_heads // self.tp_size,
+                head_v_dim=self.head_v_dim,
                 initial_state=ssm_state,
                 inplace_final_state=True,
                 cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -771,6 +771,7 @@ def _causal_conv1d_update_kernel(
     query_start_loc_ptr,  # (batch + 1)
     block_idx_last_scheduled_token,  # (batch,)
     initial_state_idx,  # (batch,)
+    packed_anchors_ptr,  # (batch, 2) int32 viewed as (batch,) int64
     o_ptr,  # (batch, dim, seqlen)
     # Matrix dimensions
     batch: int,
@@ -800,6 +801,7 @@ def _causal_conv1d_update_kernel(
     IS_VARLEN: tl.constexpr,
     IS_APC_ENABLED: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
+    HAS_PACKED_ANCHORS: tl.constexpr,
     NP2_STATELEN: tl.constexpr,
     HAS_NULL_BLOCK: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -819,9 +821,16 @@ def _causal_conv1d_update_kernel(
     idx_feats = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
 
     if IS_APC_ENABLED:
-        # Get the state from the initial_state_idx
-        conv_state_init = tl.load(initial_state_idx + idx_seq)
-        current_last_index = tl.load(block_idx_last_scheduled_token + idx_seq)
+        if HAS_PACKED_ANCHORS:
+            # Packed (read, write) anchor pair: one 64-bit load, low word =
+            # read (initial-state) anchor, high word = write anchor.
+            anchor_pair = tl.load(packed_anchors_ptr + idx_seq)
+            conv_state_init = anchor_pair & 0xFFFFFFFF
+            current_last_index = anchor_pair >> 32
+        else:
+            # Get the state from the initial_state_idx
+            conv_state_init = tl.load(initial_state_idx + idx_seq)
+            current_last_index = tl.load(block_idx_last_scheduled_token + idx_seq)
     else:
         conv_state_init = 0
         current_last_index = 0
@@ -943,9 +952,24 @@ def _causal_conv1d_update_kernel(
 
     # Get the state from the initial_state_idx
     # cache_idx
-    conv_states_offset = tl.load(
-        conv_state_indices_ptr + idx_seq * stride_state_indices + current_last_index
-    ).to(tl.int64)
+    if HAS_PACKED_ANCHORS:
+        # Second table walk only on a block-boundary crossing (write !=
+        # read); predicated, not branched, so the FP codegen is unaffected.
+        crossed = current_last_index != conv_state_init
+        loaded_offset = tl.load(
+            conv_state_indices_ptr
+            + idx_seq * stride_state_indices
+            + current_last_index,
+            mask=crossed,
+            other=0,
+        ).to(tl.int64)
+        conv_states_offset = tl.where(
+            crossed, loaded_offset, conv_states_input_coord
+        )
+    else:
+        conv_states_offset = tl.load(
+            conv_state_indices_ptr + idx_seq * stride_state_indices + current_last_index
+        ).to(tl.int64)
     conv_state_ptrs_target = (
         conv_state_ptr
         + (conv_states_offset * stride_conv_state_seq)  # Offset from seq
@@ -1106,6 +1130,7 @@ def causal_conv1d_update(
     null_block_id: int = NULL_BLOCK_ID,
     block_idx_last_scheduled_token: torch.Tensor | None = None,
     initial_state_idx: torch.Tensor | None = None,
+    packed_anchors: torch.Tensor | None = None,
     validate_data=False,
     out: torch.Tensor | None = None,
 ):
@@ -1128,6 +1153,11 @@ def causal_conv1d_update(
         The pointer into conv_state_indices, where the last cache block to be filled is located.
     initial_state_idx: (batch,), dtype int32
         The pointer into conv_state_indices, where the cache block containing the initial state is located.
+    packed_anchors: (batch, 2), dtype int32
+        The (initial_state_idx, block_idx_last_scheduled_token) pairs packed
+        so the kernel fetches both with a single 64-bit load ([:, 0] read,
+        [:, 1] write). Mutually exclusive with the two separate tensors;
+        results are identical.
     num_accepted_tokens: (batch,), dtype int32
         If not None, it indicates the number of accepted tokens for each
         sequence in the batch.
@@ -1151,6 +1181,20 @@ def causal_conv1d_update(
     if validate_data:
         assert null_block_id is not None
         assert x.stride(1) == 1
+    if packed_anchors is not None:
+        assert block_idx_last_scheduled_token is None and initial_state_idx is None, (
+            "packed_anchors and the separate anchor tensors are mutually exclusive"
+        )
+        assert (
+            packed_anchors.ndim == 2
+            and packed_anchors.shape[-1] == 2
+            and packed_anchors.dtype == torch.int32
+            and packed_anchors.stride(-1) == 1
+            and packed_anchors.stride(0) == 2
+        ), "packed_anchors must be a contiguous (batch, 2) int32 tensor"
+        # Reinterpret each (read, write) int32 pair as one int64 so the
+        # kernel fetches both anchors with a single load.
+        packed_anchors = packed_anchors.view(torch.int64).squeeze(-1)
     if isinstance(activation, bool):
         activation = "silu" if activation is True else None
     elif activation is not None:
@@ -1240,6 +1284,7 @@ def causal_conv1d_update(
         query_start_loc,
         block_idx_last_scheduled_token,
         initial_state_idx,
+        packed_anchors,
         out,
         # Matrix dimensions
         batch,
@@ -1267,8 +1312,11 @@ def causal_conv1d_update(
         KERNEL_WIDTH=width,
         SILU_ACTIVATION=activation in ["silu", "swish"],
         IS_VARLEN=query_start_loc is not None,
-        IS_APC_ENABLED=block_idx_last_scheduled_token is not None,
+        IS_APC_ENABLED=(
+            block_idx_last_scheduled_token is not None or packed_anchors is not None
+        ),
         IS_SPEC_DECODING=num_accepted_tokens is not None,
+        HAS_PACKED_ANCHORS=packed_anchors is not None,
         NP2_STATELEN=np2_statelen,
         HAS_NULL_BLOCK=null_block_id is not None,
         BLOCK_N=256,

--- a/vllm/model_executor/layers/mamba/ops/gdn_index_prep.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_index_prep.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Once-per-step block-index prep kernel for GDN ``mamba_cache_mode='all'``.
+
+Fuses the per-request block-anchor arithmetic of
+``compute_mamba_prefix_caching_block_indices`` (mamba_attn.py) and the
+spec-decode read-anchor resolution (gdn_attn.py) into a single Triton launch
+that writes runner-owned persistent buffers shared by every GDN metadata
+builder — replacing the eager cdiv/sub/clamp tensor chains that otherwise run
+once per builder (3x per step) between cudagraph replays. Gated by
+``VLLM_GDN_INKERNEL_CKPT_IDX`` (default on; "0" restores the eager
+per-builder math bit-for-bit).
+"""
+
+import os
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+def gdn_inkernel_ckpt_idx_enabled() -> bool:
+    return os.environ.get("VLLM_GDN_INKERNEL_CKPT_IDX", "1") != "0"
+
+
+@triton.jit
+def _gdn_block_idx_prep_kernel(
+    seq_lens_ptr,  # (num_reqs,) int32
+    num_computed_ptr,  # (num_reqs,) int32 (seq_lens - query_lens)
+    prev_idx_ptr,  # (num_reqs,) int32, prev-step anchors or dummy
+    out_last_computed_ptr,  # (num_reqs,) int32
+    out_first_scheduled_ptr,  # (num_reqs,) int32
+    out_last_scheduled_ptr,  # (num_reqs,) int32
+    out_prev_step_ptr,  # (num_reqs,) int32 (spec only)
+    out_packed_ptr,  # (num_reqs, 2) int32: [last_computed, last_scheduled]
+    out_packed_spec_ptr,  # (num_reqs, 2) int32: [prev_step, last_scheduled]
+    num_reqs,
+    BLOCK_SIZE: tl.constexpr,  # mamba_block_size
+    HAS_SPEC: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    offs = tl.program_id(0) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offs < num_reqs
+    sl = tl.load(seq_lens_ptr + offs, mask=mask, other=0)
+    nct = tl.load(num_computed_ptr + offs, mask=mask, other=0)
+    # Verbatim semantics of compute_mamba_prefix_caching_block_indices
+    # (mamba_attn.py:91-101): cdiv(n, B) - 1 with the same clamp placement
+    # (first_scheduled deliberately unclamped). Domain restriction: the
+    # formulas require nct >= 0 and sl >= 0 (for nct <= -B the unclamped fs
+    # would diverge from torch's floor division under Triton's truncating
+    # `//`). This always holds in the shipped wiring — nct = seq_lens -
+    # query_lens with both >= 0 and padded rows zeroed by the runner — but
+    # unit tests feeding raw tensors must respect it too.
+    lc = tl.maximum((nct + BLOCK_SIZE - 1) // BLOCK_SIZE - 1, 0)
+    fs = (nct + BLOCK_SIZE) // BLOCK_SIZE - 1
+    ls = tl.maximum((sl + BLOCK_SIZE - 1) // BLOCK_SIZE - 1, 0)
+    tl.store(out_last_computed_ptr + offs, lc, mask=mask)
+    tl.store(out_first_scheduled_ptr + offs, fs, mask=mask)
+    tl.store(out_last_scheduled_ptr + offs, ls, mask=mask)
+    tl.store(out_packed_ptr + offs * 2, lc, mask=mask)
+    tl.store(out_packed_ptr + offs * 2 + 1, ls, mask=mask)
+    if HAS_SPEC:
+        # Spec read-anchor resolution (gdn_attn.py:497-506): prev-step
+        # anchor when tracked, else clamp((nct - 1) // B, 0). The lone
+        # negative numerator (nct == 0) lands at 0 after the clamp under
+        # both floor and trunc division.
+        prev = tl.load(prev_idx_ptr + offs, mask=mask, other=-1)
+        fb = tl.maximum((nct - 1) // BLOCK_SIZE, 0)
+        ra = tl.where(prev >= 0, prev, fb)
+        tl.store(out_prev_step_ptr + offs, ra, mask=mask)
+        tl.store(out_packed_spec_ptr + offs * 2, ra, mask=mask)
+        tl.store(out_packed_spec_ptr + offs * 2 + 1, ls, mask=mask)
+
+
+class GDNBlockIdxPrepBuffers:
+    """Runner-owned persistent buffers written once per step by the prep
+    kernel and consumed by every GDN metadata builder (and, through the
+    metadata, by the captured decode kernels — stable device addresses).
+    ``packed_anchors[*]`` hold (read, write) pairs for the kernels' single
+    64-bit anchor load: nospec read = last computed block, spec read = the
+    resolved prev-step anchor; write = last scheduled block for both.
+    """
+
+    def __init__(self, max_num_reqs: int, device: torch.device):
+        self.max_num_reqs = max_num_reqs
+        kw = dict(dtype=torch.int32, device=device)
+        self.block_idx_last_computed_token = torch.zeros(max_num_reqs, **kw)
+        self.block_idx_first_scheduled_token = torch.zeros(max_num_reqs, **kw)
+        self.block_idx_last_scheduled_token = torch.zeros(max_num_reqs, **kw)
+        self.block_idx_last_scheduled_token_prev_step = torch.zeros(
+            max_num_reqs, **kw
+        )
+        self.packed_anchors = torch.zeros((max_num_reqs, 2), **kw)
+        self.packed_anchors_spec = torch.zeros((max_num_reqs, 2), **kw)
+
+    def prepare(
+        self,
+        seq_lens: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+        prev_last_scheduled_idx: torch.Tensor | None,
+        mamba_block_size: int,
+        num_reqs: int,
+    ) -> None:
+        assert num_reqs <= self.max_num_reqs
+        has_spec = prev_last_scheduled_idx is not None
+        grid = (triton.cdiv(num_reqs, 256),)
+        _gdn_block_idx_prep_kernel[grid](
+            seq_lens,
+            num_computed_tokens,
+            prev_last_scheduled_idx if has_spec else seq_lens,
+            self.block_idx_last_computed_token,
+            self.block_idx_first_scheduled_token,
+            self.block_idx_last_scheduled_token,
+            self.block_idx_last_scheduled_token_prev_step,
+            self.packed_anchors,
+            self.packed_anchors_spec,
+            num_reqs,
+            BLOCK_SIZE=mamba_block_size,
+            HAS_SPEC=has_spec,
+            BLOCK_N=256,
+        )

--- a/vllm/model_executor/layers/mamba/ops/gdn_scatter.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_scatter.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Single-launch Triton checkpoint scatter for GDN ``mamba_cache_mode='all'``.
+
+Replaces the Python-looped ``gdn_scatter_block_checkpoints``
+(all_mode_utils.py) — which issues four ``int(tensor)`` GPU syncs plus
+arange/index_put chains per prefill sequence, per layer — with one kernel
+launch that emits bit-identical stores: the FLA +1-chunk shift
+(``h[c]`` = state at the START of chunk c), the per-sequence ``seq_hi``
+clamp, and the skip-unaligned-interior rule (never poison APC) are preserved
+exactly. Gated by ``VLLM_GDN_INKERNEL_CKPT_WRITE`` (default on; "0" restores
+the Python loop).
+"""
+
+import os
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+def gdn_inkernel_ckpt_write_enabled() -> bool:
+    return os.environ.get("VLLM_GDN_INKERNEL_CKPT_WRITE", "1") != "0"
+
+
+@triton.jit
+def _gdn_scatter_block_ckpt_kernel(
+    ssm_state_ptr,  # (num_blocks, ...) written in place
+    inter_ptr,  # (NT, ...) FLA h, state at the START of each chunk
+    final_ptr,  # (num_prefills, ...) final recurrent states
+    block_table_ptr,  # (num_prefills, max_blocks)
+    first_ptr,  # (num_prefills,) block_idx_first_scheduled_token_p
+    last_ptr,  # (num_prefills,) block_idx_last_scheduled_token_p
+    ncomp_ptr,  # (num_prefills,) num_computed_tokens_p
+    first_chunk_ptr,  # (first_chunk_len,) chunk_offsets
+    nt,
+    first_chunk_len,
+    numel,
+    stride_ssm,
+    stride_inter,
+    stride_final,
+    stride_bt,
+    BLOCK_SIZE: tl.constexpr,  # mamba_block_size
+    CHUNK: tl.constexpr,  # FLA chunk size
+    BLOCK_N: tl.constexpr,
+):
+    i_s = tl.program_id(0)
+    j_rel = tl.program_id(1)
+    i_tile = tl.program_id(2)
+    first = tl.load(first_ptr + i_s).to(tl.int64)
+    last = tl.load(last_ptr + i_s).to(tl.int64)
+    # n interior blocks (may be <= 0: final block only, like the loop).
+    n = tl.maximum(last - first, 0)
+    if j_rel > n:
+        return
+    offs = i_tile * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offs < numel
+    # src is upcast to fp32 (lossless from bf16/fp16/fp32 chunk states) so
+    # both branches agree on one type; the store rounds once to the pool
+    # dtype, matching the eager .to(ssm_state.dtype) cast.
+    if j_rel == n:
+        # Final (possibly partial) block <- the sequence's final state.
+        dst = tl.load(block_table_ptr + i_s * stride_bt + last).to(tl.int64)
+        src = tl.load(final_ptr + i_s * stride_final + offs, mask=mask).to(
+            tl.float32
+        )
+    else:
+        ncomp = tl.load(ncomp_ptr + i_s).to(tl.int64)
+        if ncomp % CHUNK != 0:
+            # Not chunk-aligned: interior boundaries don't map to exact FLA
+            # chunk states — skip rather than poison APC (the final block
+            # above is exact regardless).
+            return
+        j = first + j_rel
+        fc = tl.load(first_chunk_ptr + i_s).to(tl.int64)
+        if i_s + 1 < first_chunk_len:
+            seq_hi = tl.load(first_chunk_ptr + i_s + 1).to(tl.int64) - 1
+        else:
+            seq_hi = tl.zeros((), tl.int64) + nt - 1
+        # Interior block j ends after (j+1)*B sequence tokens, i.e.
+        # ((j+1)*B - ncomp) // CHUNK scheduled chunks in; h[c] is the state
+        # at the START of chunk c (+1-chunk shift vs Mamba2), clamped to
+        # this sequence's chunk range (defense-in-depth).
+        k = ((j + 1) * BLOCK_SIZE - ncomp) // CHUNK
+        cidx = tl.minimum(tl.maximum(fc + k, fc), seq_hi)
+        dst = tl.load(block_table_ptr + i_s * stride_bt + j).to(tl.int64)
+        src = tl.load(inter_ptr + cidx * stride_inter + offs, mask=mask).to(
+            tl.float32
+        )
+    p_dst = ssm_state_ptr + dst * stride_ssm + offs
+    tl.store(p_dst, src.to(p_dst.dtype.element_ty), mask=mask)
+
+
+def gdn_scatter_block_checkpoints_triton(
+    ssm_state: torch.Tensor,
+    inter_states: torch.Tensor,
+    final_states: torch.Tensor,
+    block_table_p: torch.Tensor,
+    block_idx_first_scheduled_token_p: torch.Tensor,
+    block_idx_last_scheduled_token_p: torch.Tensor,
+    num_computed_tokens_p: torch.Tensor,
+    first_chunk_p: torch.Tensor,
+    mamba_block_size: int,
+    chunk_size: int,
+    num_prefill_tokens: int,
+) -> None:
+    """Drop-in kernel equivalent of ``gdn_scatter_block_checkpoints``.
+
+    ``num_prefill_tokens`` (host int) bounds the per-sequence interior block
+    count so the grid needs no GPU sync.
+    """
+    num_prefills = block_idx_last_scheduled_token_p.shape[0]
+    if num_prefills == 0:
+        return
+    numel = ssm_state[0].numel()
+    assert ssm_state[0].is_contiguous()
+    assert inter_states[0].is_contiguous() and inter_states[0].numel() == numel
+    assert final_states[0].is_contiguous() and final_states[0].numel() == numel
+    assert block_table_p.stride(-1) == 1
+    max_j = num_prefill_tokens // mamba_block_size + 2
+    block_n = 2048
+    grid = (num_prefills, max_j, triton.cdiv(numel, block_n))
+    _gdn_scatter_block_ckpt_kernel[grid](
+        ssm_state,
+        inter_states,
+        final_states,
+        block_table_p,
+        block_idx_first_scheduled_token_p,
+        block_idx_last_scheduled_token_p,
+        num_computed_tokens_p,
+        first_chunk_p,
+        inter_states.shape[0],
+        first_chunk_p.shape[0],
+        numel,
+        ssm_state.stride(0),
+        inter_states.stride(0),
+        final_states.stride(0),
+        block_table_p.stride(0),
+        BLOCK_SIZE=mamba_block_size,
+        CHUNK=chunk_size,
+        BLOCK_N=block_n,
+    )

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -65,6 +65,7 @@ from .interfaces import (
     MixtureOfExperts,
     SupportsEagle3,
     SupportsLoRA,
+    SupportsMambaPrefixCaching,
     SupportsPP,
 )
 from .utils import (
@@ -803,6 +804,7 @@ class Qwen3NextForCausalLM(
     QwenNextMixtureOfExperts,
     IsHybrid,
     SupportsEagle3,
+    SupportsMambaPrefixCaching,
 ):
     # MTP weights are loaded by the draft model, not this one.
     hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix={"mtp.": None})
@@ -822,14 +824,8 @@ class Qwen3NextForCausalLM(
         config = vllm_config.model_config.hf_text_config
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
-        cache_config = vllm_config.cache_config
 
         scheduler_config = vllm_config.scheduler_config
-        if cache_config.mamba_cache_mode == "all":
-            raise NotImplementedError(
-                "Qwen3Next currently does not support 'all' prefix caching, "
-                "please use '--mamba-cache-mode=align' instead"
-            )
         self.quant_config = vllm_config.quant_config
 
         super().__init__()

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -35,6 +35,7 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     QwenGatedDeltaNetAttention,
+    gdn_concat_router_gate_enabled,
 )
 from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFunc,
@@ -194,6 +195,16 @@ class Qwen3NextSparseMoeBlock(nn.Module):
                 prefix,
                 shared_expert_name="shared_expert",
             )
+        # C6 router-gate fold (VLLM_GDN_CONCAT_ROUTER_GATE, default off --
+        # measured in-graph negative unpadded, marginal padded): hand the
+        # 1-row shared expert gate to the MoE runner, which folds its rows
+        # into the (padded) router gate GEMM and applies the sigmoid
+        # scaling itself; the MLP then must not apply its own expert gate.
+        _concat_shared_gate = (
+            gdn_concat_router_gate_enabled()
+            and not self.is_fused_shared_expert_enabled
+            and config.shared_expert_intermediate_size > 0
+        )
 
         if (
             self.is_fused_shared_expert_enabled
@@ -207,7 +218,9 @@ class Qwen3NextSparseMoeBlock(nn.Module):
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,
-                expert_gate=self.shared_expert_gate,
+                expert_gate=None
+                if _concat_shared_gate
+                else self.shared_expert_gate,
                 is_sequence_parallel=self.is_sequence_parallel,
                 disable_tp=self.replicate_shared_expert,
                 prefix=f"{prefix}.shared_expert",
@@ -231,7 +244,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             n_shared_experts=1 if self.shared_expert is None else None,
             fuse_shared_experts=self.is_fused_shared_expert_enabled,
             shared_expert_gate=self.shared_expert_gate
-            if self.shared_expert is None
+            if (self.shared_expert is None or _concat_shared_gate)
             else None,
         )
 
@@ -751,7 +764,20 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             ckpt_prefix="mlp.shared_expert",
         )
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        # Accuracy-neutral weight-layout transforms (de-interleave /
+        # tiny-GEMM concat). load_weights can be invoked more than once per
+        # engine init (e.g. the MTP draft-model load streams the checkpoint
+        # again), and re-permuting already-permuted weights scrambles them,
+        # so transform a layer ONLY when THIS call actually (re)wrote its
+        # in_proj weights (which are then in raw checkpoint layout).
+        for name, module in self.named_modules():
+            if (
+                isinstance(module, QwenGatedDeltaNetAttention)
+                and f"{name}.in_proj_qkvz.weight" in loaded
+            ):
+                module.apply_traffic_opt_weight_transforms()
+        return loaded
 
 
 class QwenNextMixtureOfExperts(MixtureOfExperts):

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -187,13 +187,9 @@ class Qwen3NextMTP(nn.Module, QwenNextMixtureOfExperts):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         config = vllm_config.model_config.hf_config
         self.vllm_config = vllm_config
-        cache_config = vllm_config.cache_config
-        if cache_config.mamba_cache_mode == "all":
-            raise NotImplementedError(
-                "Qwen3NextMTP currently does not support 'all' prefix caching, "
-                "please use '--mamba-cache-mode=align' instead"
-            )
-
+        # The MTP head is full-attention only (no GDN/mamba layers), so
+        # mamba_cache_mode='all' is a no-op for it; all-mode prefix caching
+        # on the target model composes with MTP speculative decoding.
         self.quant_config = vllm_config.quant_config
 
         super().__init__()

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -949,9 +949,7 @@ class Platform:
             # aligned. Ask the scheduler to clip prefill chunks accordingly
             # (a much weaker constraint than align mode's block-size split).
             if (
-                getattr(
-                    model_config.hf_text_config, "linear_conv_kernel_dim", None
-                )
+                getattr(model_config.hf_text_config, "linear_conv_kernel_dim", None)
                 is not None
             ):
                 cache_config.mamba_all_mode_prefill_align_size = (

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -64,6 +64,37 @@ def in_wsl() -> bool:
     return "microsoft" in " ".join(platform.uname()).lower()
 
 
+def validate_all_mode_mamba_block_size(
+    mamba_block_size: int, kernel_chunk_size: int
+) -> None:
+    """Fail fast when an all-mode mamba block size is not kernel-chunk aligned.
+
+    mamba_cache_mode="all" caches one SSM checkpoint per mamba block, mapped to
+    kernel chunk boundaries. The mapping is only lossless when each block
+    boundary lands on a chunk boundary; otherwise per-block checkpoints would
+    be written at within-block offsets and poison the content-hash-addressed
+    prefix cache. Auto-resolved block sizes satisfy this by construction (the
+    resolution builds a chunk multiple); only a user-specified
+    --mamba-block-size that is not a chunk multiple can violate it.
+
+    Called post-resolution (from ``_align_hybrid_block_size``) rather than at
+    layer init: model load runs before block-size resolution, so a layer-init
+    check would see the pre-resolution block_size placeholder.
+
+    Raises:
+        ValueError: if ``mamba_block_size`` is not a multiple of
+            ``kernel_chunk_size``.
+    """
+    if mamba_block_size % kernel_chunk_size != 0:
+        raise ValueError(
+            "mamba_cache_mode='all' (prefix caching) requires the resolved "
+            f"mamba_block_size ({mamba_block_size}) to be a multiple of the "
+            f"kernel chunk size ({kernel_chunk_size}). Remove or correct the "
+            "user-specified --mamba-block-size, or disable prefix caching / "
+            "all-mode."
+        )
+
+
 class PlatformEnum(enum.Enum):
     """Enumeration of supported hardware platforms."""
 
@@ -905,6 +936,27 @@ class Platform:
             chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
             attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
             cache_config.mamba_block_size = attn_block_size
+            # A user-specified --mamba-block-size replaces base_chunk_size
+            # wholesale above; reject it post-resolution if the resulting
+            # block is not aligned to the model's real kernel chunk.
+            validate_all_mode_mamba_block_size(
+                attn_block_size, model_config.get_mamba_chunk_size()
+            )
+            # GDN/FLA prefill kernels materialize per-chunk states on a fixed
+            # grid relative to each scheduled chunk's start (no SSD-style
+            # short-first-chunk realignment), so all-mode per-block SSM
+            # checkpoints are only exact when chunk starts stay kernel-chunk
+            # aligned. Ask the scheduler to clip prefill chunks accordingly
+            # (a much weaker constraint than align mode's block-size split).
+            if (
+                getattr(
+                    model_config.hf_text_config, "linear_conv_kernel_dim", None
+                )
+                is not None
+            ):
+                cache_config.mamba_all_mode_prefill_align_size = (
+                    model_config.get_mamba_chunk_size()
+                )
         else:
             # Without prefix caching, use minimum block size that satisfies
             # both backend alignment and mamba page size compatibility

--- a/vllm/third_party/flash_linear_attention/ops/chunk.py
+++ b/vllm/third_party/flash_linear_attention/ops/chunk.py
@@ -33,6 +33,7 @@ def chunk_gated_delta_rule_fwd(
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     core_attn_out: torch.Tensor | None = None,
+    return_intermediate_states: bool = False,
 ):
     g = chunk_local_cumsum(
         g, chunk_size=FLA_CHUNK_SIZE, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
@@ -80,10 +81,13 @@ def chunk_gated_delta_rule_fwd(
         chunk_indices=chunk_indices,
         core_attn_out=core_attn_out,
     )
+    # h[:, c] is the recurrent state BEFORE chunk c (i.e. after the first
+    # c * FLA_CHUNK_SIZE tokens). Exposed for all-mode prefix-cache checkpointing.
+    intermediate_states = h if return_intermediate_states else None
     if SUPPRESS_LEVEL < 3:
-        return g, o, A, final_state, None, None, None
+        return g, o, A, final_state, None, None, None, intermediate_states
     elif SUPPRESS_LEVEL >= 3:
-        return g, o, A, final_state, w, h, v_new
+        return g, o, A, final_state, w, h, v_new, intermediate_states
 
 
 class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
@@ -105,24 +109,28 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = False,
         core_attn_out: torch.Tensor | None = None,
+        return_intermediate_states: bool = False,
     ):
         if use_qk_l2norm_in_kernel:
             q = l2norm_fwd(q)
             k = l2norm_fwd(k)
 
-        g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
-            q=q,
-            k=k,
-            v=v,
-            g=g,
-            beta=beta,
-            scale=scale,
-            initial_state=initial_state,
-            output_final_state=output_final_state,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            chunk_offsets=chunk_offsets,
-            core_attn_out=core_attn_out,
+        g, o, A, final_state, w, h, v_new, intermediate_states = (
+            chunk_gated_delta_rule_fwd(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                chunk_offsets=chunk_offsets,
+                core_attn_out=core_attn_out,
+                return_intermediate_states=return_intermediate_states,
+            )
         )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
@@ -131,7 +139,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
                 "core_attn_out buffer reuse is only supported for inference"
             )
             assert q.dtype == o.dtype, "Incompatible dtype for inplace computation"
-        return o.to(q.dtype), final_state
+        return o.to(q.dtype), final_state, intermediate_states
 
 
 @torch.compiler.disable
@@ -149,6 +157,7 @@ def chunk_gated_delta_rule(
     chunk_offsets: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     core_attn_out: torch.Tensor | None = None,
+    return_intermediate_states: bool = False,
 ):
     r"""
     Args:
@@ -227,7 +236,7 @@ def chunk_gated_delta_rule(
             )
     if scale is None:
         scale = k.shape[-1] ** -0.5
-    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+    o, final_state, intermediate_states = ChunkGatedDeltaRuleFunction.apply(
         q,
         k,
         v,
@@ -241,5 +250,8 @@ def chunk_gated_delta_rule(
         chunk_offsets,
         use_qk_l2norm_in_kernel,
         core_attn_out,
+        return_intermediate_states,
     )
+    if return_intermediate_states:
+        return o, final_state, intermediate_states
     return o, final_state

--- a/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
@@ -263,6 +263,9 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     h0,
     ht,
     ssm_state_indices,
+    block_table,
+    read_anchor,
+    write_anchor,
     scale,
     stride_mixed_qkv_tok: tl.constexpr,
     stride_a_tok: tl.constexpr,
@@ -270,6 +273,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     stride_init_state_token: tl.constexpr,
     stride_final_state_token: tl.constexpr,
     stride_indices_seq: tl.constexpr,
+    stride_block_table_seq: tl.constexpr,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
@@ -278,6 +282,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     BV: tl.constexpr,
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    HAS_TABLE: tl.constexpr,
     SPLIT_BATCH_HEAD_GRID: tl.constexpr,
 ):
     if SPLIT_BATCH_HEAD_GRID:
@@ -293,7 +298,15 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     mask_v = o_v < V
     mask_h = mask_v[:, None] & mask_k[None, :]
 
-    state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq).to(tl.int64)
+    if HAS_TABLE:
+        # Derive the write slot in-kernel from the block table:
+        # block_table[i_n, write_anchor[i_n]].
+        o_w = tl.load(write_anchor + i_n).to(tl.int64)
+        state_idx = tl.load(block_table + i_n * stride_block_table_seq + o_w).to(
+            tl.int64
+        )
+    else:
+        state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq).to(tl.int64)
     p_o = o + (i_n * HV + i_hv) * V + o_v
 
     # Skip if state index is invalid (NULL_BLOCK_ID=0)
@@ -302,7 +315,19 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
         tl.store(p_o, zero, mask=mask_v)
         return
 
-    p_h0 = h0 + state_idx * stride_init_state_token
+    if HAS_TABLE:
+        # Read slot (last computed block): block_table[i_n, read_anchor[i_n]].
+        # Same block as the write slot within a mamba block; differs at a
+        # block-boundary crossing, where the state migrates to the fresh
+        # block.
+        o_r = tl.load(read_anchor + i_n).to(tl.int64)
+        read_idx = tl.load(block_table + i_n * stride_block_table_seq + o_r).to(
+            tl.int64
+        )
+    else:
+        read_idx = state_idx
+
+    p_h0 = h0 + read_idx * stride_init_state_token
     p_h0 = p_h0 + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
     b_h = tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
@@ -349,9 +374,21 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     scale: float,
     initial_state: torch.Tensor,
     out: torch.Tensor,
-    ssm_state_indices: torch.Tensor,
+    ssm_state_indices: torch.Tensor | None = None,
+    block_table: torch.Tensor | None = None,
+    read_anchor: torch.Tensor | None = None,
+    write_anchor: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Single-token packed decode.
+
+    State slots are given either as per-seq ``ssm_state_indices`` (in-place
+    read/write at that slot) or, exclusively, as ``block_table`` (2D, per-seq
+    rows) plus per-seq ``read_anchor`` / ``write_anchor``: the kernel then
+    derives read slot ``block_table[i, read_anchor[i]]`` and write slot
+    ``block_table[i, write_anchor[i]]`` in-kernel — equivalent to host-side
+    ``block_table.gather(1, anchor.unsqueeze(1)).squeeze(1)`` tensors.
+    """
     if mixed_qkv.ndim != 2:
         raise ValueError(
             f"`mixed_qkv` must be a 2D tensor (got ndim={mixed_qkv.ndim})."
@@ -368,7 +405,22 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         raise ValueError("`A_log`/`dt_bias` must be 1D tensors.")
     if A_log.stride(0) != 1 or dt_bias.stride(0) != 1:
         raise ValueError("`A_log`/`dt_bias` must be contiguous.")
-    if ssm_state_indices.ndim != 1:
+    if (ssm_state_indices is None) == (block_table is None):
+        raise ValueError(
+            "Exactly one of `ssm_state_indices` and `block_table` must be provided."
+        )
+    if block_table is not None:
+        if read_anchor is None or write_anchor is None:
+            raise ValueError(
+                "`read_anchor` and `write_anchor` are required with `block_table`."
+            )
+        if block_table.ndim != 2 or block_table.stride(-1) != 1:
+            raise ValueError(
+                "`block_table` must be 2D and contiguous in the last dim."
+            )
+        if read_anchor.ndim != 1 or write_anchor.ndim != 1:
+            raise ValueError("`read_anchor`/`write_anchor` must be 1D tensors.")
+    elif ssm_state_indices.ndim != 1:
         raise ValueError(
             f"`ssm_state_indices` must be 1D for packed decode (got ndim={ssm_state_indices.ndim})."
         )
@@ -376,6 +428,11 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         raise ValueError("`out` must be contiguous.")
 
     dev = mixed_qkv.device
+    index_tensors = (
+        (ssm_state_indices,)
+        if ssm_state_indices is not None
+        else (block_table, read_anchor, write_anchor)
+    )
     if (
         a.device != dev
         or b.device != dev
@@ -383,7 +440,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         or dt_bias.device != dev
         or initial_state.device != dev
         or out.device != dev
-        or ssm_state_indices.device != dev
+        or any(t.device != dev for t in index_tensors)
     ):
         raise ValueError("All inputs must be on the same device.")
 
@@ -393,9 +450,19 @@ def fused_recurrent_gated_delta_rule_packed_decode(
             "Mismatched batch sizes: "
             f"mixed_qkv.shape[0]={B}, a.shape[0]={a.shape[0]}, b.shape[0]={b.shape[0]}."
         )
-    if ssm_state_indices.shape[0] != B:
+    if ssm_state_indices is not None and ssm_state_indices.shape[0] != B:
         raise ValueError(
             f"`ssm_state_indices` must have shape [B] (got {tuple(ssm_state_indices.shape)}; expected ({B},))."
+        )
+    if block_table is not None and (
+        block_table.shape[0] != B
+        or read_anchor.shape[0] != B
+        or write_anchor.shape[0] != B
+    ):
+        raise ValueError(
+            "`block_table`/`read_anchor`/`write_anchor` must have B="
+            f"{B} rows (got {block_table.shape[0]}, {read_anchor.shape[0]}, "
+            f"{write_anchor.shape[0]})."
         )
 
     if initial_state.ndim != 4:
@@ -447,7 +514,10 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     stride_b_tok = b.stride(0)
     stride_init_state_token = initial_state.stride(0)
     stride_final_state_token = initial_state.stride(0)
-    stride_indices_seq = ssm_state_indices.stride(0)
+    stride_indices_seq = (
+        ssm_state_indices.stride(0) if ssm_state_indices is not None else 0
+    )
+    stride_block_table_seq = block_table.stride(0) if block_table is not None else 0
 
     NV = triton.cdiv(V, BV)
     # CUDA limits grid Y/Z dimensions to 65535.
@@ -463,6 +533,9 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         h0=initial_state,
         ht=initial_state,
         ssm_state_indices=ssm_state_indices,
+        block_table=block_table,
+        read_anchor=read_anchor,
+        write_anchor=write_anchor,
         scale=scale,
         stride_mixed_qkv_tok=stride_mixed_qkv_tok,
         stride_a_tok=stride_a_tok,
@@ -470,6 +543,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         stride_init_state_token=stride_init_state_token,
         stride_final_state_token=stride_final_state_token,
         stride_indices_seq=stride_indices_seq,
+        stride_block_table_seq=stride_block_table_seq,
         H=H,
         HV=HV,
         K=K,
@@ -478,6 +552,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         BV=BV,
         SOFTPLUS_THRESHOLD=20.0,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        HAS_TABLE=block_table is not None,
         SPLIT_BATCH_HEAD_GRID=split_batch_head_grid,
         num_warps=num_warps,
         num_stages=num_stages,

--- a/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
@@ -266,6 +266,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     block_table,
     read_anchor,
     write_anchor,
+    packed_anchors,
     scale,
     stride_mixed_qkv_tok: tl.constexpr,
     stride_a_tok: tl.constexpr,
@@ -284,6 +285,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     HAS_TABLE: tl.constexpr,
     SPLIT_BATCH_HEAD_GRID: tl.constexpr,
+    HAS_PACKED_ANCHORS: tl.constexpr,
 ):
     if SPLIT_BATCH_HEAD_GRID:
         i_v, i_hv, i_n = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -301,7 +303,13 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     if HAS_TABLE:
         # Derive the write slot in-kernel from the block table:
         # block_table[i_n, write_anchor[i_n]].
-        o_w = tl.load(write_anchor + i_n).to(tl.int64)
+        if HAS_PACKED_ANCHORS:
+            # Packed (read, write) anchor pair: one 64-bit load, low word =
+            # read anchor, high word = write anchor.
+            b_pair = tl.load(packed_anchors + i_n)
+            o_w = b_pair >> 32
+        else:
+            o_w = tl.load(write_anchor + i_n).to(tl.int64)
         state_idx = tl.load(block_table + i_n * stride_block_table_seq + o_w).to(
             tl.int64
         )
@@ -320,7 +328,10 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
         # Same block as the write slot within a mamba block; differs at a
         # block-boundary crossing, where the state migrates to the fresh
         # block.
-        o_r = tl.load(read_anchor + i_n).to(tl.int64)
+        if HAS_PACKED_ANCHORS:
+            o_r = b_pair & 0xFFFFFFFF
+        else:
+            o_r = tl.load(read_anchor + i_n).to(tl.int64)
         read_idx = tl.load(block_table + i_n * stride_block_table_seq + o_r).to(
             tl.int64
         )
@@ -378,6 +389,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     block_table: torch.Tensor | None = None,
     read_anchor: torch.Tensor | None = None,
     write_anchor: torch.Tensor | None = None,
+    packed_anchors: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Single-token packed decode.
@@ -388,6 +400,9 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     derives read slot ``block_table[i, read_anchor[i]]`` and write slot
     ``block_table[i, write_anchor[i]]`` in-kernel — equivalent to host-side
     ``block_table.gather(1, anchor.unsqueeze(1)).squeeze(1)`` tensors.
+    The two anchors may instead be given packed as ``packed_anchors``
+    (``(num_seqs, 2)`` int32, ``[:, 0]`` read / ``[:, 1]`` write): the kernel
+    then fetches both with a single 64-bit load. Results are identical.
     """
     if mixed_qkv.ndim != 2:
         raise ValueError(
@@ -410,7 +425,24 @@ def fused_recurrent_gated_delta_rule_packed_decode(
             "Exactly one of `ssm_state_indices` and `block_table` must be provided."
         )
     if block_table is not None:
-        if read_anchor is None or write_anchor is None:
+        if packed_anchors is not None:
+            if read_anchor is not None or write_anchor is not None:
+                raise ValueError(
+                    "`packed_anchors` and `read_anchor`/`write_anchor` are "
+                    "mutually exclusive."
+                )
+            if (
+                packed_anchors.ndim != 2
+                or packed_anchors.shape[-1] != 2
+                or packed_anchors.dtype != torch.int32
+                or packed_anchors.stride(-1) != 1
+                or packed_anchors.stride(0) != 2
+            ):
+                raise ValueError(
+                    "`packed_anchors` must be a contiguous (num_seqs, 2) "
+                    "int32 tensor."
+                )
+        elif read_anchor is None or write_anchor is None:
             raise ValueError(
                 "`read_anchor` and `write_anchor` are required with `block_table`."
             )
@@ -418,8 +450,12 @@ def fused_recurrent_gated_delta_rule_packed_decode(
             raise ValueError(
                 "`block_table` must be 2D and contiguous in the last dim."
             )
-        if read_anchor.ndim != 1 or write_anchor.ndim != 1:
+        if packed_anchors is None and (
+            read_anchor.ndim != 1 or write_anchor.ndim != 1
+        ):
             raise ValueError("`read_anchor`/`write_anchor` must be 1D tensors.")
+    elif packed_anchors is not None:
+        raise ValueError("`packed_anchors` requires `block_table`.")
     elif ssm_state_indices.ndim != 1:
         raise ValueError(
             f"`ssm_state_indices` must be 1D for packed decode (got ndim={ssm_state_indices.ndim})."
@@ -428,10 +464,11 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         raise ValueError("`out` must be contiguous.")
 
     dev = mixed_qkv.device
-    index_tensors = (
-        (ssm_state_indices,)
-        if ssm_state_indices is not None
-        else (block_table, read_anchor, write_anchor)
+    index_tensors = tuple(
+        t
+        for t in (ssm_state_indices, block_table, read_anchor, write_anchor,
+                  packed_anchors)
+        if t is not None
     )
     if (
         a.device != dev
@@ -454,16 +491,21 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         raise ValueError(
             f"`ssm_state_indices` must have shape [B] (got {tuple(ssm_state_indices.shape)}; expected ({B},))."
         )
-    if block_table is not None and (
-        block_table.shape[0] != B
-        or read_anchor.shape[0] != B
-        or write_anchor.shape[0] != B
-    ):
-        raise ValueError(
-            "`block_table`/`read_anchor`/`write_anchor` must have B="
-            f"{B} rows (got {block_table.shape[0]}, {read_anchor.shape[0]}, "
-            f"{write_anchor.shape[0]})."
+    if block_table is not None:
+        anchor_rows = (
+            packed_anchors.shape[0]
+            if packed_anchors is not None
+            else (read_anchor.shape[0], write_anchor.shape[0])
         )
+        if block_table.shape[0] != B or (
+            packed_anchors.shape[0] != B
+            if packed_anchors is not None
+            else (read_anchor.shape[0] != B or write_anchor.shape[0] != B)
+        ):
+            raise ValueError(
+                "`block_table` and its anchors must have B="
+                f"{B} rows (got {block_table.shape[0]}, {anchor_rows})."
+            )
 
     if initial_state.ndim != 4:
         raise ValueError(
@@ -518,6 +560,10 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         ssm_state_indices.stride(0) if ssm_state_indices is not None else 0
     )
     stride_block_table_seq = block_table.stride(0) if block_table is not None else 0
+    if packed_anchors is not None:
+        # Reinterpret each (read, write) int32 pair as one int64 so the
+        # kernel fetches both anchors with a single load.
+        packed_anchors = packed_anchors.view(torch.int64).squeeze(-1)
 
     NV = triton.cdiv(V, BV)
     # CUDA limits grid Y/Z dimensions to 65535.
@@ -536,6 +582,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         block_table=block_table,
         read_anchor=read_anchor,
         write_anchor=write_anchor,
+        packed_anchors=packed_anchors,
         scale=scale,
         stride_mixed_qkv_tok=stride_mixed_qkv_tok,
         stride_a_tok=stride_a_tok,
@@ -554,6 +601,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         HAS_TABLE=block_table is not None,
         SPLIT_BATCH_HEAD_GRID=split_batch_head_grid,
+        HAS_PACKED_ANCHORS=packed_anchors is not None,
         num_warps=num_warps,
         num_stages=num_stages,
     )

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -20,6 +20,7 @@ from vllm.triton_utils import tl, triton
         or args["block_table"] is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
         "HAS_TABLE": lambda args: args["block_table"] is not None,
+        "PACKED": lambda args: args["mixed_qkv"] is not None,
     }
 )
 @triton.jit(do_not_specialize=["N", "T"])
@@ -33,6 +34,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     q,
     k,
     v,
+    mixed_qkv,
     o,
     h0,
     ht,
@@ -59,6 +61,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     stride_indices_tok: tl.constexpr,
     stride_indices_output_seq: tl.constexpr,
     stride_block_table_seq: tl.constexpr,
+    stride_mixed_qkv_tok: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,  # whether to use initial state
     INPLACE_FINAL_STATE: tl.constexpr,  # whether to store final state inplace
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
@@ -66,6 +69,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
     HAS_TABLE: tl.constexpr,
+    PACKED: tl.constexpr,
     IS_KDA: tl.constexpr,
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -89,9 +93,17 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     o_k = i_k * BK + tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
 
-    p_q = q + (bos * H + i_h) * K + o_k
-    p_k = k + (bos * H + i_h) * K + o_k
-    p_v = v + (bos * HV + i_hv) * V + o_v
+    if PACKED:
+        # q/k/v live interleaved per token in a single packed buffer; the
+        # per-tensor offsets mirror fused_recurrent_gated_delta_rule_packed_decode.
+        p_mixed = mixed_qkv + bos * stride_mixed_qkv_tok
+        p_q = p_mixed + i_h * K + o_k
+        p_k = p_mixed + (H * K) + i_h * K + o_k
+        p_v = p_mixed + (2 * H * K) + i_hv * V + o_v
+    else:
+        p_q = q + (bos * H + i_h) * K + o_k
+        p_k = k + (bos * H + i_h) * K + o_k
+        p_v = v + (bos * HV + i_hv) * V + o_v
 
     p_A_log = A_log + i_hv
     if not IS_KDA:
@@ -195,10 +207,15 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
         # Update pointers for next timestep
-        p_q += H * K
-        p_k += H * K
+        if PACKED:
+            p_q += stride_mixed_qkv_tok
+            p_k += stride_mixed_qkv_tok
+            p_v += stride_mixed_qkv_tok
+        else:
+            p_q += H * K
+            p_k += H * K
+            p_v += HV * V
         p_o += HV * V
-        p_v += HV * V
         p_b += HV
         p_a += HV
 
@@ -208,9 +225,9 @@ def fused_sigmoid_gating_delta_rule_update(
     a: torch.Tensor,
     b: torch.Tensor,
     dt_bias: torch.Tensor,
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
+    q: torch.Tensor | None = None,
+    k: torch.Tensor | None = None,
+    v: torch.Tensor | None = None,
     beta: float = 1.0,
     threshold: float = 20.0,
     scale: float = None,
@@ -223,6 +240,11 @@ def fused_sigmoid_gating_delta_rule_update(
     block_table: torch.Tensor | None = None,
     read_anchor: torch.Tensor | None = None,
     write_anchor: torch.Tensor | None = None,
+    mixed_qkv: torch.Tensor | None = None,
+    num_qk_heads: int | None = None,
+    head_qk_dim: int | None = None,
+    num_v_heads: int | None = None,
+    head_v_dim: int | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     is_kda: bool = False,
 ):
@@ -238,9 +260,38 @@ def fused_sigmoid_gating_delta_rule_update(
     ``num_accepted_tokens`` in spec mode) and write slot
     ``block_table[i, write_anchor[i] + i_t]`` per token — equivalent to the
     host-side ``block_table.gather(1, anchor.unsqueeze(1) + arange(T))``.
+
+    When ``mixed_qkv`` (2D ``(num_tokens, 2 * key_dim + value_dim)``, the
+    packed conv output) is given instead of ``q``/``k``/``v``, the kernel
+    reads q/k/v straight from the packed buffer with per-tensor offsets
+    (same addressing as ``fused_recurrent_gated_delta_rule_packed_decode``),
+    skipping the host-side rearrange copies. The head geometry cannot be
+    inferred from a packed buffer, so ``num_qk_heads``/``head_qk_dim``/
+    ``num_v_heads``/``head_v_dim`` are required in this mode.
     """
-    B, T, H, K, V = *k.shape, v.shape[-1]
-    HV = v.shape[2]
+    if mixed_qkv is not None:
+        assert q is None and k is None and v is None, (
+            "mixed_qkv and q/k/v are mutually exclusive"
+        )
+        assert mixed_qkv.stride(-1) == 1, (
+            "mixed_qkv must be contiguous in the last dim"
+        )
+        assert (
+            num_qk_heads is not None
+            and head_qk_dim is not None
+            and num_v_heads is not None
+            and head_v_dim is not None
+        ), "head geometry kwargs are required with mixed_qkv"
+        H, K, HV, V = num_qk_heads, head_qk_dim, num_v_heads, head_v_dim
+        if cu_seqlens is not None:
+            B, T = 1, mixed_qkv.shape[0]
+        else:
+            B, T = mixed_qkv.shape[0], 1
+        stride_mixed_qkv_tok = mixed_qkv.stride(0)
+    else:
+        B, T, H, K, V = *k.shape, v.shape[-1]
+        HV = v.shape[2]
+        stride_mixed_qkv_tok = 0
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)
     NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
@@ -248,22 +299,25 @@ def fused_sigmoid_gating_delta_rule_update(
     num_stages = 3
     num_warps = 4
 
-    if cu_seqlens is not None and q.shape[0] != 1:
+    if cu_seqlens is not None and q is not None and q.shape[0] != 1:
         raise ValueError(
             f"The batch size is expected to be 1 rather than {q.shape[0]}"
             f" when using `cu_seqlens`. Please flatten variable-length"
             f" inputs before processing."
         )
     if scale is None:
-        scale = k.shape[-1] ** -0.5
+        scale = K**-0.5
     else:
         assert scale > 0, "scale must be positive"
 
-    o = q.new_empty(NK, *v.shape)
+    if mixed_qkv is not None:
+        o = mixed_qkv.new_empty(NK, B, T, HV, V)
+    else:
+        o = q.new_empty(NK, *v.shape)
     if inplace_final_state:
         final_state = initial_state
     else:
-        final_state = q.new_empty(T, HV, V, K, dtype=initial_state.dtype)
+        final_state = o.new_empty(T, HV, V, K, dtype=initial_state.dtype)
 
     stride_init_state_token = initial_state.stride(0)
     stride_final_state_token = final_state.stride(0)
@@ -316,9 +370,10 @@ def fused_sigmoid_gating_delta_rule_update(
         dt_bias=dt_bias,
         beta=beta,
         threshold=threshold,
-        q=q.contiguous(),
-        k=k.contiguous(),
-        v=v.contiguous(),
+        q=q.contiguous() if q is not None else None,
+        k=k.contiguous() if k is not None else None,
+        v=v.contiguous() if v is not None else None,
+        mixed_qkv=mixed_qkv,
         o=o,
         h0=initial_state,
         ht=final_state,
@@ -345,6 +400,7 @@ def fused_sigmoid_gating_delta_rule_update(
         stride_indices_tok=stride_indices_tok,
         stride_indices_output_seq=stride_indices_output_seq,
         stride_block_table_seq=stride_block_table_seq,
+        stride_mixed_qkv_tok=stride_mixed_qkv_tok,
         INPLACE_FINAL_STATE=inplace_final_state,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=is_kda,

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -20,6 +20,7 @@ from vllm.triton_utils import tl, triton
         or args["block_table"] is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
         "HAS_TABLE": lambda args: args["block_table"] is not None,
+        "HAS_PACKED_ANCHORS": lambda args: args["packed_anchors"] is not None,
         "PACKED": lambda args: args["mixed_qkv"] is not None,
     }
 )
@@ -45,6 +46,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     block_table,
     read_anchor,
     write_anchor,
+    packed_anchors,
     scale,
     N: tl.int64,  # num of sequences
     T: tl.int64,  # num of tokens
@@ -69,6 +71,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
     HAS_TABLE: tl.constexpr,
+    HAS_PACKED_ANCHORS: tl.constexpr,
     PACKED: tl.constexpr,
     IS_KDA: tl.constexpr,
 ):
@@ -89,6 +92,14 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     if T == 0:
         # no tokens to process for this sequence
         return
+
+    if HAS_PACKED_ANCHORS:
+        # Packed (read, write) anchor pair: one 64-bit load, low word = read
+        # anchor, high word = write anchor. The write-side block-table base is
+        # hoisted out of the token loop (loop-invariant).
+        b_pair = tl.load(packed_anchors + i_n)
+        o_anchor_r = b_pair & 0xFFFFFFFF
+        p_bt_w = block_table + i_n * stride_block_table_seq + (b_pair >> 32)
 
     o_k = i_k * BK + tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
@@ -128,7 +139,11 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             else:
                 i_t = 0
             # Load state index and check for invalid entries
-            if HAS_TABLE:
+            if HAS_PACKED_ANCHORS:
+                state_idx = tl.load(
+                    block_table + i_n * stride_block_table_seq + o_anchor_r + i_t
+                ).to(tl.int64)
+            elif HAS_TABLE:
                 # Derive the read slot in-kernel from the block table:
                 # block_table[i_n, read_anchor[i_n] + i_t].
                 o_r = tl.load(read_anchor + i_n).to(tl.int64)
@@ -185,7 +200,9 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
         # keep the states for multi-query tokens
         if INPLACE_FINAL_STATE:
             # Load state index and check for invalid entries
-            if HAS_TABLE:
+            if HAS_PACKED_ANCHORS:
+                final_state_idx = tl.load(p_bt_w + i_t).to(tl.int64)
+            elif HAS_TABLE:
                 # Derive the write slot in-kernel from the block table:
                 # block_table[i_n, write_anchor[i_n] + i_t].
                 o_w = tl.load(write_anchor + i_n).to(tl.int64)
@@ -240,6 +257,7 @@ def fused_sigmoid_gating_delta_rule_update(
     block_table: torch.Tensor | None = None,
     read_anchor: torch.Tensor | None = None,
     write_anchor: torch.Tensor | None = None,
+    packed_anchors: torch.Tensor | None = None,
     mixed_qkv: torch.Tensor | None = None,
     num_qk_heads: int | None = None,
     head_qk_dim: int | None = None,
@@ -260,6 +278,10 @@ def fused_sigmoid_gating_delta_rule_update(
     ``num_accepted_tokens`` in spec mode) and write slot
     ``block_table[i, write_anchor[i] + i_t]`` per token — equivalent to the
     host-side ``block_table.gather(1, anchor.unsqueeze(1) + arange(T))``.
+    The two anchors may instead be given packed as ``packed_anchors``
+    (``(num_seqs, 2)`` int32, ``[:, 0]`` read / ``[:, 1]`` write): the kernel
+    then fetches both with a single 64-bit load and hoists the write-side
+    table base out of the token loop. Results are identical.
 
     When ``mixed_qkv`` (2D ``(num_tokens, 2 * key_dim + value_dim)``, the
     packed conv output) is given instead of ``q``/``k``/``v``, the kernel
@@ -356,10 +378,27 @@ def fused_sigmoid_gating_delta_rule_update(
         assert ssm_state_indices is None and ssm_state_indices_output is None, (
             "block_table and ssm_state_indices are mutually exclusive"
         )
-        assert read_anchor is not None and write_anchor is not None
+        if packed_anchors is not None:
+            assert read_anchor is None and write_anchor is None, (
+                "packed_anchors and read_anchor/write_anchor are "
+                "mutually exclusive"
+            )
+            assert (
+                packed_anchors.ndim == 2
+                and packed_anchors.shape[-1] == 2
+                and packed_anchors.dtype == torch.int32
+                and packed_anchors.stride(-1) == 1
+                and packed_anchors.stride(0) == 2
+            ), "packed_anchors must be a contiguous (num_seqs, 2) int32 tensor"
+            # Reinterpret each (read, write) int32 pair as one int64 so the
+            # kernel fetches both anchors with a single load.
+            packed_anchors = packed_anchors.view(torch.int64).squeeze(-1)
+        else:
+            assert read_anchor is not None and write_anchor is not None
         assert block_table.stride(-1) == 1
         stride_block_table_seq = block_table.stride(0)
     else:
+        assert packed_anchors is None, "packed_anchors requires block_table"
         stride_block_table_seq = 0
 
     grid = (NK, NV, N * HV)
@@ -384,6 +423,7 @@ def fused_sigmoid_gating_delta_rule_update(
         block_table=block_table,
         read_anchor=read_anchor,
         write_anchor=write_anchor,
+        packed_anchors=packed_anchors,
         scale=scale,
         N=N,
         T=T,

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -16,8 +16,10 @@ from vllm.triton_utils import tl, triton
     {
         "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
-        "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
+        "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None
+        or args["block_table"] is not None,
         "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
+        "HAS_TABLE": lambda args: args["block_table"] is not None,
     }
 )
 @triton.jit(do_not_specialize=["N", "T"])
@@ -36,7 +38,11 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     ht,
     cu_seqlens,
     ssm_state_indices,
+    ssm_state_indices_output,
     num_accepted_tokens,
+    block_table,
+    read_anchor,
+    write_anchor,
     scale,
     N: tl.int64,  # num of sequences
     T: tl.int64,  # num of tokens
@@ -51,12 +57,15 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     stride_final_state_token: tl.constexpr,
     stride_indices_seq: tl.constexpr,
     stride_indices_tok: tl.constexpr,
+    stride_indices_output_seq: tl.constexpr,
+    stride_block_table_seq: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,  # whether to use initial state
     INPLACE_FINAL_STATE: tl.constexpr,  # whether to store final state inplace
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     IS_CONTINUOUS_BATCHING: tl.constexpr,
     IS_SPEC_DECODING: tl.constexpr,
+    HAS_TABLE: tl.constexpr,
     IS_KDA: tl.constexpr,
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
@@ -107,9 +116,17 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             else:
                 i_t = 0
             # Load state index and check for invalid entries
-            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                tl.int64
-            )
+            if HAS_TABLE:
+                # Derive the read slot in-kernel from the block table:
+                # block_table[i_n, read_anchor[i_n] + i_t].
+                o_r = tl.load(read_anchor + i_n).to(tl.int64)
+                state_idx = tl.load(
+                    block_table + i_n * stride_block_table_seq + o_r + i_t
+                ).to(tl.int64)
+            else:
+                state_idx = tl.load(
+                    ssm_state_indices + i_n * stride_indices_seq + i_t
+                ).to(tl.int64)
             # Skip if state index is invalid (NULL_BLOCK_ID=0)
             if state_idx <= 0:
                 return
@@ -156,9 +173,17 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
         # keep the states for multi-query tokens
         if INPLACE_FINAL_STATE:
             # Load state index and check for invalid entries
-            final_state_idx = tl.load(
-                ssm_state_indices + i_n * stride_indices_seq + i_t
-            ).to(tl.int64)
+            if HAS_TABLE:
+                # Derive the write slot in-kernel from the block table:
+                # block_table[i_n, write_anchor[i_n] + i_t].
+                o_w = tl.load(write_anchor + i_n).to(tl.int64)
+                final_state_idx = tl.load(
+                    block_table + i_n * stride_block_table_seq + o_w + i_t
+                ).to(tl.int64)
+            else:
+                final_state_idx = tl.load(
+                    ssm_state_indices_output + i_n * stride_indices_output_seq + i_t
+                ).to(tl.int64)
             # Only store if state index is valid (not NULL_BLOCK_ID=0)
             if final_state_idx > 0:
                 p_ht = ht + final_state_idx * stride_final_state_token
@@ -193,7 +218,11 @@ def fused_sigmoid_gating_delta_rule_update(
     inplace_final_state: bool = True,
     cu_seqlens: torch.Tensor | None = None,
     ssm_state_indices: torch.Tensor | None = None,
+    ssm_state_indices_output: torch.Tensor | None = None,
     num_accepted_tokens: torch.Tensor | None = None,
+    block_table: torch.Tensor | None = None,
+    read_anchor: torch.Tensor | None = None,
+    write_anchor: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     is_kda: bool = False,
 ):
@@ -201,6 +230,14 @@ def fused_sigmoid_gating_delta_rule_update(
     Fused triton implementation of sigmoid gating delta rule update.
     This function uses a single fused kernel that combines both sigmoid gating
     computation and the recurrent delta rule update for better performance.
+
+    When ``block_table`` (2D, per-seq rows) plus per-seq ``read_anchor`` /
+    ``write_anchor`` are given instead of ``ssm_state_indices``, the kernel
+    derives its own state slots in-kernel: read slot
+    ``block_table[i, read_anchor[i] + i_t]`` (with ``i_t`` selected by
+    ``num_accepted_tokens`` in spec mode) and write slot
+    ``block_table[i, write_anchor[i] + i_t]`` per token — equivalent to the
+    host-side ``block_table.gather(1, anchor.unsqueeze(1) + arange(T))``.
     """
     B, T, H, K, V = *k.shape, v.shape[-1]
     HV = v.shape[2]
@@ -231,12 +268,45 @@ def fused_sigmoid_gating_delta_rule_update(
     stride_init_state_token = initial_state.stride(0)
     stride_final_state_token = final_state.stride(0)
 
+    # The kernel indexes both 2-D index tensors with an implicit token stride of
+    # 1 (`... + i_n * stride_seq + i_t`), so a non-contiguous last dim (e.g. a
+    # transposed/strided view) would silently read wrong offsets. Normalize to
+    # contiguous here — a no-op on the current (gather-produced, contiguous)
+    # all-mode spec path, a safety net otherwise.
+    if ssm_state_indices is not None and ssm_state_indices.stride(-1) != 1:
+        ssm_state_indices = ssm_state_indices.contiguous()
+    if (ssm_state_indices_output is not None
+            and ssm_state_indices_output.stride(-1) != 1):
+        ssm_state_indices_output = ssm_state_indices_output.contiguous()
+
     if ssm_state_indices is None:
         stride_indices_seq, stride_indices_tok = 1, 1
     elif ssm_state_indices.ndim == 1:
         stride_indices_seq, stride_indices_tok = ssm_state_indices.stride(0), 1
     else:
         stride_indices_seq, stride_indices_tok = ssm_state_indices.stride()
+
+    # all-mode dual-anchor: write the final state via a separate output index tensor
+    # while reading h0 via ssm_state_indices. Defaults to in-place (output == input).
+    if ssm_state_indices_output is None:
+        ssm_state_indices_output = ssm_state_indices
+    stride_indices_output_seq = (
+        ssm_state_indices_output.stride(0)
+        if ssm_state_indices_output is not None
+        else 1
+    )
+
+    # Direct-block-table mode: the kernel derives its own read/write slots
+    # from block_table + per-seq anchors (no host-gathered index tensors).
+    if block_table is not None:
+        assert ssm_state_indices is None and ssm_state_indices_output is None, (
+            "block_table and ssm_state_indices are mutually exclusive"
+        )
+        assert read_anchor is not None and write_anchor is not None
+        assert block_table.stride(-1) == 1
+        stride_block_table_seq = block_table.stride(0)
+    else:
+        stride_block_table_seq = 0
 
     grid = (NK, NV, N * HV)
     fused_sigmoid_gating_delta_rule_update_kernel[grid](
@@ -254,7 +324,11 @@ def fused_sigmoid_gating_delta_rule_update(
         ht=final_state,
         cu_seqlens=cu_seqlens,
         ssm_state_indices=ssm_state_indices,
+        ssm_state_indices_output=ssm_state_indices_output,
         num_accepted_tokens=num_accepted_tokens,
+        block_table=block_table,
+        read_anchor=read_anchor,
+        write_anchor=write_anchor,
         scale=scale,
         N=N,
         T=T,
@@ -269,6 +343,8 @@ def fused_sigmoid_gating_delta_rule_update(
         stride_final_state_token=stride_final_state_token,
         stride_indices_seq=stride_indices_seq,
         stride_indices_tok=stride_indices_tok,
+        stride_indices_output_seq=stride_indices_output_seq,
+        stride_block_table_seq=stride_block_table_seq,
         INPLACE_FINAL_STATE=inplace_final_state,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=is_kda,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -8,12 +8,16 @@ from typing import Literal
 import torch
 
 from vllm.config import VllmConfig
+from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.mamba_attn import (
+    compute_mamba_prefix_caching_block_indices,
 )
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
@@ -64,6 +68,21 @@ class GDNAttentionMetadata:
     non_spec_token_indx: torch.Tensor | None = None
 
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
+
+    # The following tensors are only populated for prefix caching in "all"
+    # mode and are None otherwise. They are request-level, in build order
+    # (spec rows in place per spec_sequence_masks, not compacted), and drive
+    # the per-block SSM checkpoint scatter in prefill and the dual-anchor
+    # state read/write split in (spec) decode.
+    block_idx_last_scheduled_token: torch.Tensor | None = None  # shape: [batch,]
+    block_idx_first_scheduled_token: torch.Tensor | None = None  # shape: [batch,]
+    block_idx_last_computed_token: torch.Tensor | None = None  # shape: [batch,]
+    block_idx_last_scheduled_token_prev_step: torch.Tensor | None = None
+    # Only consumed by prefill (never by captured decode kernels).
+    num_computed_tokens: torch.Tensor | None = None  # shape: [batch,]
+    # Full per-request block table (all blocks, not sliced to the leading
+    # 1 + num_spec entries); the all-mode scatter/gather indexes into it.
+    all_state_indices_tensor: torch.Tensor | None = None
 
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
@@ -165,6 +184,43 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             device=device,
         )
 
+        # all-mode prefix caching: persistent buffers for the request-level
+        # block-index metadata read by captured decode kernels (mirrors
+        # BaseMambaAttentionMetadataBuilder). block_idx_first_scheduled_token
+        # and num_computed_tokens are prefill-only consumers and need no
+        # buffers (capture is decode-only).
+        if self.vllm_config.cache_config.mamba_cache_mode == "all":
+            max_num_blocks = (
+                cdiv(
+                    self.vllm_config.model_config.max_model_len,
+                    kv_cache_spec.block_size,
+                )
+                + kv_cache_spec.num_speculative_blocks
+            )
+            self.all_state_indices_tensor: torch.Tensor = torch.empty(
+                (self.decode_cudagraph_max_bs, max_num_blocks),
+                dtype=torch.int32,
+                device=device,
+            )
+            self.block_idx_last_scheduled_token: torch.Tensor = torch.empty(
+                (self.decode_cudagraph_max_bs,),
+                dtype=torch.int32,
+                device=device,
+            )
+            self.block_idx_last_computed_token: torch.Tensor = torch.empty(
+                (self.decode_cudagraph_max_bs,),
+                dtype=torch.int32,
+                device=device,
+            )
+            if self.use_spec_decode:
+                self.block_idx_last_scheduled_token_prev_step: torch.Tensor = (
+                    torch.empty(
+                        (self.decode_cudagraph_max_bs,),
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                )
+
     def _build_chunk_metadata(
         self,
         prefill_query_start_loc: torch.Tensor,
@@ -213,6 +269,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         common_attn_metadata: CommonAttentionMetadata,
         num_accepted_tokens: torch.Tensor | None = None,
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        prev_last_scheduled_idx: torch.Tensor | None = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
         m = common_attn_metadata
@@ -397,8 +454,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 query_start_loc.device,
             )
 
+        # Computed unconditionally: the all-mode prefix-caching block below
+        # needs it even for decode-only batches (e.g. cudagraph capture).
+        context_lens_tensor = m.compute_num_computed_tokens()
         if num_prefills > 0:
-            context_lens_tensor = m.compute_num_computed_tokens()
             has_initial_state = context_lens_tensor > 0
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
@@ -421,6 +480,44 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         assert not (num_decodes > 0 and num_spec_decodes > 0), (
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
+
+        # all-mode prefix caching: per-request block-index metadata (request-
+        # level, build order). Drives the prefill checkpoint scatter and the
+        # (spec-)decode dual-anchor state read/write split.
+        block_idx_last_scheduled_token = None
+        block_idx_first_scheduled_token = None
+        block_idx_last_computed_token = None
+        block_idx_last_scheduled_token_prev_step = None
+        num_computed_tokens = None
+        all_state_indices_tensor = None
+        if self.vllm_config.cache_config.mamba_cache_mode == "all":
+            mamba_block_size = self.kv_cache_spec.block_size
+            num_computed_tokens = context_lens_tensor
+            (
+                block_idx_last_computed_token,
+                block_idx_first_scheduled_token,
+                block_idx_last_scheduled_token,
+            ) = compute_mamba_prefix_caching_block_indices(
+                num_computed_tokens, m.seq_lens, mamba_block_size
+            )
+            # In all-mode, mamba_get_block_table_tensor returns the full
+            # (#requests, #max blocks) table unsliced.
+            all_state_indices_tensor = block_table_tensor
+            if self.use_spec_decode and num_accepted_tokens is not None:
+                # Spec-decode read anchor: the block the previous step
+                # checkpointed its running state into (plumbed by the runner);
+                # fall back to the last computed block for first-step or
+                # untracked requests (and during cudagraph capture).
+                fallback = torch.clamp(
+                    (num_computed_tokens - 1) // mamba_block_size, min=0
+                )
+                if prev_last_scheduled_idx is not None:
+                    prev = prev_last_scheduled_idx[: fallback.shape[0]]
+                    block_idx_last_scheduled_token_prev_step = torch.where(
+                        prev >= 0, prev, fallback
+                    )
+                else:
+                    block_idx_last_scheduled_token_prev_step = fallback
 
         # Prepare per-request tensors for cudagraph. m.num_actual_tokens is
         # token-padded for FULL graph replay, but the GDN state/query/accepted
@@ -494,6 +591,70 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
             non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
 
+        # all-mode + FULL cudagraph: move the request-level block-index
+        # metadata into the persistent buffers so captured decode kernels read
+        # stable device memory updated in-place each step. Same decode-only
+        # guards as the spec/non-spec branches above; padded tail rows get
+        # NULL_BLOCK_ID state indices (kernels skip them) and block index 0.
+        if (
+            all_state_indices_tensor is not None
+            and self.use_full_cuda_graph
+            and num_prefills == 0
+            and (
+                (
+                    num_decodes == 0
+                    and num_spec_decodes <= self.decode_cudagraph_max_bs
+                    and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
+                )
+                or (
+                    num_spec_decodes == 0
+                    and num_decodes <= self.decode_cudagraph_max_bs
+                )
+            )
+        ):
+            # One of the two counts is zero (asserted above); real request
+            # rows always precede padded rows in build order.
+            num_real_reqs = num_decodes + num_spec_decodes
+            num_blocks = all_state_indices_tensor.size(1)
+            self.all_state_indices_tensor[:num_real_reqs, :num_blocks].copy_(
+                all_state_indices_tensor[:num_real_reqs], non_blocking=True
+            )
+            all_state_indices_tensor = self.all_state_indices_tensor[
+                :batch_size, :num_blocks
+            ]
+            all_state_indices_tensor[num_real_reqs:].fill_(NULL_BLOCK_ID)
+
+            assert block_idx_last_scheduled_token is not None
+            self.block_idx_last_scheduled_token[:num_real_reqs].copy_(
+                block_idx_last_scheduled_token[:num_real_reqs], non_blocking=True
+            )
+            block_idx_last_scheduled_token = self.block_idx_last_scheduled_token[
+                :batch_size
+            ]
+            block_idx_last_scheduled_token[num_real_reqs:].fill_(0)
+
+            assert block_idx_last_computed_token is not None
+            self.block_idx_last_computed_token[:num_real_reqs].copy_(
+                block_idx_last_computed_token[:num_real_reqs], non_blocking=True
+            )
+            block_idx_last_computed_token = self.block_idx_last_computed_token[
+                :batch_size
+            ]
+            block_idx_last_computed_token[num_real_reqs:].fill_(0)
+
+            if (
+                self.use_spec_decode
+                and block_idx_last_scheduled_token_prev_step is not None
+            ):
+                self.block_idx_last_scheduled_token_prev_step[:num_real_reqs].copy_(
+                    block_idx_last_scheduled_token_prev_step[:num_real_reqs],
+                    non_blocking=True,
+                )
+                block_idx_last_scheduled_token_prev_step = (
+                    self.block_idx_last_scheduled_token_prev_step[:batch_size]
+                )
+                block_idx_last_scheduled_token_prev_step[num_real_reqs:].fill_(0)
+
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
@@ -516,6 +677,14 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            block_idx_last_scheduled_token=block_idx_last_scheduled_token,
+            block_idx_first_scheduled_token=block_idx_first_scheduled_token,
+            block_idx_last_computed_token=block_idx_last_computed_token,
+            block_idx_last_scheduled_token_prev_step=(
+                block_idx_last_scheduled_token_prev_step
+            ),
+            num_computed_tokens=num_computed_tokens,
+            all_state_indices_tensor=all_state_indices_tensor,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -2,12 +2,16 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Backend for GatedDeltaNet attention."""
 
+import os
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import torch
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.mamba.ops.gdn_scatter import (
+    gdn_inkernel_ckpt_write_enabled,
+)
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
@@ -26,6 +30,15 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import MambaSpec
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.mamba.ops.gdn_index_prep import (
+        GDNBlockIdxPrepBuffers,
+    )
+
+
+def gdn_hoist_mask_selects_enabled() -> bool:
+    return os.environ.get("VLLM_GDN_HOIST_MASK_SELECTS", "1") != "0"
 
 
 class GDNAttentionBackend(AttentionBackend):
@@ -78,11 +91,36 @@ class GDNAttentionMetadata:
     block_idx_first_scheduled_token: torch.Tensor | None = None  # shape: [batch,]
     block_idx_last_computed_token: torch.Tensor | None = None  # shape: [batch,]
     block_idx_last_scheduled_token_prev_step: torch.Tensor | None = None
+    # Packed (read, write) anchor pairs for the decode kernels' single 64-bit
+    # anchor load ([:, 0] = read, [:, 1] = write). Only populated when the
+    # runner supplies the shared prep-kernel buffers
+    # (VLLM_GDN_INKERNEL_CKPT_IDX); the nospec pair reads the last computed
+    # block, the spec pair the resolved prev-step anchor.
+    block_idx_packed_anchors: torch.Tensor | None = None  # shape: [batch, 2]
+    block_idx_packed_anchors_spec: torch.Tensor | None = None  # shape: [batch, 2]
     # Only consumed by prefill (never by captured decode kernels).
     num_computed_tokens: torch.Tensor | None = None  # shape: [batch,]
     # Full per-request block table (all blocks, not sliced to the leading
     # 1 + num_spec entries); the all-mode scatter/gather indexes into it.
     all_state_indices_tensor: torch.Tensor | None = None
+
+    # Builder-preselected all-mode row slices for mixed (spec + prefill)
+    # eager batches, selected once per step with the CPU spec mask (sync-free;
+    # a device-bool-mask select in the layer runs torch.nonzero -> count DtoH
+    # + cudaStreamSynchronize, once per select per GDN layer). ns_* = non-spec
+    # rows, spec_* = spec rows, both in build order. Populated only when
+    # VLLM_GDN_HOIST_MASK_SELECTS is on and the batch is mixed.
+    ns_all_state_indices_sel: torch.Tensor | None = None
+    ns_block_idx_last_computed_sel: torch.Tensor | None = None
+    ns_block_idx_first_scheduled_sel: torch.Tensor | None = None
+    ns_block_idx_last_scheduled_sel: torch.Tensor | None = None
+    ns_num_computed_tokens_sel: torch.Tensor | None = None
+    spec_all_state_indices_sel: torch.Tensor | None = None
+    spec_block_idx_last_scheduled_sel: torch.Tensor | None = None
+    spec_block_idx_last_computed_sel: torch.Tensor | None = None
+    spec_block_idx_prev_step_sel: torch.Tensor | None = None
+    spec_block_idx_packed_anchors_sel: torch.Tensor | None = None
+    spec_block_idx_packed_anchors_spec_sel: torch.Tensor | None = None
 
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
@@ -270,6 +308,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_accepted_tokens: torch.Tensor | None = None,
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         prev_last_scheduled_idx: torch.Tensor | None = None,
+        block_idx_prep: "GDNBlockIdxPrepBuffers | None" = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
         m = common_attn_metadata
@@ -488,36 +527,125 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         block_idx_first_scheduled_token = None
         block_idx_last_computed_token = None
         block_idx_last_scheduled_token_prev_step = None
+        block_idx_packed_anchors = None
+        block_idx_packed_anchors_spec = None
         num_computed_tokens = None
         all_state_indices_tensor = None
+        ns_all_state_indices_sel = None
+        ns_block_idx_last_computed_sel = None
+        ns_block_idx_first_scheduled_sel = None
+        ns_block_idx_last_scheduled_sel = None
+        ns_num_computed_tokens_sel = None
+        spec_all_state_indices_sel = None
+        spec_block_idx_last_scheduled_sel = None
+        spec_block_idx_last_computed_sel = None
+        spec_block_idx_prev_step_sel = None
+        spec_block_idx_packed_anchors_sel = None
+        spec_block_idx_packed_anchors_spec_sel = None
         if self.vllm_config.cache_config.mamba_cache_mode == "all":
             mamba_block_size = self.kv_cache_spec.block_size
             num_computed_tokens = context_lens_tensor
-            (
-                block_idx_last_computed_token,
-                block_idx_first_scheduled_token,
-                block_idx_last_scheduled_token,
-            ) = compute_mamba_prefix_caching_block_indices(
-                num_computed_tokens, m.seq_lens, mamba_block_size
-            )
             # In all-mode, mamba_get_block_table_tensor returns the full
             # (#requests, #max blocks) table unsliced.
             all_state_indices_tensor = block_table_tensor
-            if self.use_spec_decode and num_accepted_tokens is not None:
-                # Spec-decode read anchor: the block the previous step
-                # checkpointed its running state into (plumbed by the runner);
-                # fall back to the last computed block for first-step or
-                # untracked requests (and during cudagraph capture).
-                fallback = torch.clamp(
-                    (num_computed_tokens - 1) // mamba_block_size, min=0
+            if block_idx_prep is not None:
+                # The block anchors were computed once per step by the
+                # runner's prep kernel into shared persistent buffers (they
+                # are identical for every GDN group); point the metadata at
+                # the shared buffers instead of recomputing per builder.
+                block_idx_last_computed_token = (
+                    block_idx_prep.block_idx_last_computed_token[: m.num_reqs]
                 )
-                if prev_last_scheduled_idx is not None:
-                    prev = prev_last_scheduled_idx[: fallback.shape[0]]
-                    block_idx_last_scheduled_token_prev_step = torch.where(
-                        prev >= 0, prev, fallback
+                block_idx_first_scheduled_token = (
+                    block_idx_prep.block_idx_first_scheduled_token[: m.num_reqs]
+                )
+                block_idx_last_scheduled_token = (
+                    block_idx_prep.block_idx_last_scheduled_token[: m.num_reqs]
+                )
+                block_idx_packed_anchors = block_idx_prep.packed_anchors[
+                    : m.num_reqs
+                ]
+                if self.use_spec_decode and num_accepted_tokens is not None:
+                    block_idx_last_scheduled_token_prev_step = (
+                        block_idx_prep.block_idx_last_scheduled_token_prev_step[
+                            : m.num_reqs
+                        ]
                     )
-                else:
-                    block_idx_last_scheduled_token_prev_step = fallback
+                    block_idx_packed_anchors_spec = (
+                        block_idx_prep.packed_anchors_spec[: m.num_reqs]
+                    )
+            else:
+                (
+                    block_idx_last_computed_token,
+                    block_idx_first_scheduled_token,
+                    block_idx_last_scheduled_token,
+                ) = compute_mamba_prefix_caching_block_indices(
+                    num_computed_tokens, m.seq_lens, mamba_block_size
+                )
+                if self.use_spec_decode and num_accepted_tokens is not None:
+                    # Spec-decode read anchor: the block the previous step
+                    # checkpointed its running state into (plumbed by the
+                    # runner); fall back to the last computed block for
+                    # first-step or untracked requests (and during cudagraph
+                    # capture).
+                    fallback = torch.clamp(
+                        (num_computed_tokens - 1) // mamba_block_size, min=0
+                    )
+                    if prev_last_scheduled_idx is not None:
+                        prev = prev_last_scheduled_idx[: fallback.shape[0]]
+                        block_idx_last_scheduled_token_prev_step = torch.where(
+                            prev >= 0, prev, fallback
+                        )
+                    else:
+                        block_idx_last_scheduled_token_prev_step = fallback
+
+            # Mixed (spec + prefill) eager batches: pre-select the ns_*/spec_*
+            # row slices once per step with the CPU spec mask — CPU-mask
+            # indexing of device tensors does not sync (the
+            # spec_state_indices_tensor select above already relies on this).
+            # The layer otherwise re-selects with the DEVICE mask in every GDN
+            # layer, each select costing a torch.nonzero count DtoH +
+            # cudaStreamSynchronize.
+            if (
+                gdn_hoist_mask_selects_enabled()
+                and num_prefills > 0
+                and spec_sequence_masks_cpu is not None
+            ):
+                ns_cpu = ~spec_sequence_masks_cpu
+                ns_all_state_indices_sel = all_state_indices_tensor[ns_cpu]
+                ns_block_idx_last_computed_sel = block_idx_last_computed_token[
+                    ns_cpu
+                ]
+                ns_block_idx_first_scheduled_sel = block_idx_first_scheduled_token[
+                    ns_cpu
+                ]
+                ns_block_idx_last_scheduled_sel = block_idx_last_scheduled_token[
+                    ns_cpu
+                ]
+                ns_num_computed_tokens_sel = num_computed_tokens[ns_cpu]
+                spec_all_state_indices_sel = all_state_indices_tensor[
+                    spec_sequence_masks_cpu
+                ]
+                spec_block_idx_last_scheduled_sel = block_idx_last_scheduled_token[
+                    spec_sequence_masks_cpu
+                ]
+                spec_block_idx_last_computed_sel = block_idx_last_computed_token[
+                    spec_sequence_masks_cpu
+                ]
+                if block_idx_last_scheduled_token_prev_step is not None:
+                    spec_block_idx_prev_step_sel = (
+                        block_idx_last_scheduled_token_prev_step[
+                            spec_sequence_masks_cpu
+                        ]
+                    )
+                if block_idx_packed_anchors is not None:
+                    spec_block_idx_packed_anchors_sel = block_idx_packed_anchors[
+                        spec_sequence_masks_cpu
+                    ]
+                if block_idx_packed_anchors_spec is not None:
+                    spec_block_idx_packed_anchors_spec_sel = (
+                        block_idx_packed_anchors_spec[spec_sequence_masks_cpu]
+                    )
 
         # Prepare per-request tensors for cudagraph. m.num_actual_tokens is
         # token-padded for FULL graph replay, but the GDN state/query/accepted
@@ -616,44 +744,56 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             # rows always precede padded rows in build order.
             num_real_reqs = num_decodes + num_spec_decodes
             num_blocks = all_state_indices_tensor.size(1)
-            self.all_state_indices_tensor[:num_real_reqs, :num_blocks].copy_(
-                all_state_indices_tensor[:num_real_reqs], non_blocking=True
-            )
-            all_state_indices_tensor = self.all_state_indices_tensor[
-                :batch_size, :num_blocks
-            ]
-            all_state_indices_tensor[num_real_reqs:].fill_(NULL_BLOCK_ID)
+            if not gdn_inkernel_ckpt_write_enabled():
+                self.all_state_indices_tensor[:num_real_reqs, :num_blocks].copy_(
+                    all_state_indices_tensor[:num_real_reqs], non_blocking=True
+                )
+                all_state_indices_tensor = self.all_state_indices_tensor[
+                    :batch_size, :num_blocks
+                ]
+                all_state_indices_tensor[num_real_reqs:].fill_(NULL_BLOCK_ID)
+            # else: captured kernels read the runner-persistent block table
+            # directly — it is a stable row-0-based slice of a per-run
+            # allocation, and the runner NULL-fills padded rows every step,
+            # so both reasons for the staging copy are already satisfied.
 
-            assert block_idx_last_scheduled_token is not None
-            self.block_idx_last_scheduled_token[:num_real_reqs].copy_(
-                block_idx_last_scheduled_token[:num_real_reqs], non_blocking=True
-            )
-            block_idx_last_scheduled_token = self.block_idx_last_scheduled_token[
-                :batch_size
-            ]
-            block_idx_last_scheduled_token[num_real_reqs:].fill_(0)
-
-            assert block_idx_last_computed_token is not None
-            self.block_idx_last_computed_token[:num_real_reqs].copy_(
-                block_idx_last_computed_token[:num_real_reqs], non_blocking=True
-            )
-            block_idx_last_computed_token = self.block_idx_last_computed_token[
-                :batch_size
-            ]
-            block_idx_last_computed_token[num_real_reqs:].fill_(0)
-
-            if (
-                self.use_spec_decode
-                and block_idx_last_scheduled_token_prev_step is not None
-            ):
-                self.block_idx_last_scheduled_token_prev_step[:num_real_reqs].copy_(
-                    block_idx_last_scheduled_token_prev_step[:num_real_reqs],
+            # With the prep kernel the anchors already live in shared
+            # runner-persistent buffers (padded rows included) — no staging.
+            if block_idx_prep is None:
+                assert block_idx_last_scheduled_token is not None
+                self.block_idx_last_scheduled_token[:num_real_reqs].copy_(
+                    block_idx_last_scheduled_token[:num_real_reqs],
                     non_blocking=True,
                 )
-                block_idx_last_scheduled_token_prev_step = (
-                    self.block_idx_last_scheduled_token_prev_step[:batch_size]
+                block_idx_last_scheduled_token = self.block_idx_last_scheduled_token[
+                    :batch_size
+                ]
+                block_idx_last_scheduled_token[num_real_reqs:].fill_(0)
+
+                assert block_idx_last_computed_token is not None
+                self.block_idx_last_computed_token[:num_real_reqs].copy_(
+                    block_idx_last_computed_token[:num_real_reqs],
+                    non_blocking=True,
                 )
-                block_idx_last_scheduled_token_prev_step[num_real_reqs:].fill_(0)
+                block_idx_last_computed_token = self.block_idx_last_computed_token[
+                    :batch_size
+                ]
+                block_idx_last_computed_token[num_real_reqs:].fill_(0)
+
+                if (
+                    self.use_spec_decode
+                    and block_idx_last_scheduled_token_prev_step is not None
+                ):
+                    self.block_idx_last_scheduled_token_prev_step[
+                        :num_real_reqs
+                    ].copy_(
+                        block_idx_last_scheduled_token_prev_step[:num_real_reqs],
+                        non_blocking=True,
+                    )
+                    block_idx_last_scheduled_token_prev_step = (
+                        self.block_idx_last_scheduled_token_prev_step[:batch_size]
+                    )
+                    block_idx_last_scheduled_token_prev_step[num_real_reqs:].fill_(0)
 
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,
@@ -683,6 +823,21 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             block_idx_last_scheduled_token_prev_step=(
                 block_idx_last_scheduled_token_prev_step
             ),
+            block_idx_packed_anchors=block_idx_packed_anchors,
+            block_idx_packed_anchors_spec=block_idx_packed_anchors_spec,
+            ns_all_state_indices_sel=ns_all_state_indices_sel,
+            ns_block_idx_last_computed_sel=ns_block_idx_last_computed_sel,
+            ns_block_idx_first_scheduled_sel=ns_block_idx_first_scheduled_sel,
+            ns_block_idx_last_scheduled_sel=ns_block_idx_last_scheduled_sel,
+            ns_num_computed_tokens_sel=ns_num_computed_tokens_sel,
+            spec_all_state_indices_sel=spec_all_state_indices_sel,
+            spec_block_idx_last_scheduled_sel=spec_block_idx_last_scheduled_sel,
+            spec_block_idx_last_computed_sel=spec_block_idx_last_computed_sel,
+            spec_block_idx_prev_step_sel=spec_block_idx_prev_step_sel,
+            spec_block_idx_packed_anchors_sel=spec_block_idx_packed_anchors_sel,
+            spec_block_idx_packed_anchors_spec_sel=(
+                spec_block_idx_packed_anchors_spec_sel
+            ),
             num_computed_tokens=num_computed_tokens,
             all_state_indices_tensor=all_state_indices_tensor,
             nums_dict=nums_dict,
@@ -692,7 +847,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         return attn_metadata
 
     def build_for_cudagraph_capture(
-        self, common_attn_metadata: CommonAttentionMetadata
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        block_idx_prep: "GDNBlockIdxPrepBuffers | None" = None,
     ):
         """
         This method builds the metadata for full cudagraph capture.
@@ -714,4 +871,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_accepted_tokens = torch.diff(m.query_start_loc)
         num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()
 
-        return self.build(0, m, num_accepted_tokens, num_decode_draft_tokens_cpu)
+        return self.build(
+            0,
+            m,
+            num_accepted_tokens,
+            num_decode_draft_tokens_cpu,
+            block_idx_prep=block_idx_prep,
+        )

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -82,6 +82,37 @@ class BaseMambaAttentionMetadata:
     bc_pre_scratch: torch.Tensor | None = None
 
 
+def compute_mamba_prefix_caching_block_indices(
+    num_computed_tokens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    mamba_block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-request block indices for "all" mode prefix caching.
+
+    Shared by the Mamba and GDN metadata builders. Returns
+    (block_idx_last_computed_token, block_idx_first_scheduled_token,
+    block_idx_last_scheduled_token).
+    """
+    # Block index of the last computed token
+    block_idx_last_computed_token = cdiv(num_computed_tokens, mamba_block_size) - 1
+    # which is <= block index for the first scheduled token
+    block_idx_first_scheduled_token = (
+        cdiv(num_computed_tokens + 1, mamba_block_size) - 1
+    )
+    # which is <= block index of the last scheduled token
+    block_idx_last_scheduled_token = cdiv(seq_lens, mamba_block_size) - 1
+    # -1 in case it's non-computed and causes later issues with indexing
+    block_idx_last_computed_token = torch.clamp(block_idx_last_computed_token, min=0)
+    # -1 in the case we have a padded request (0 seq-len)
+    block_idx_last_scheduled_token = torch.clamp(block_idx_last_scheduled_token, min=0)
+
+    return (
+        block_idx_last_computed_token,
+        block_idx_first_scheduled_token,
+        block_idx_last_scheduled_token,
+    )
+
+
 class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
     kv_cache_spec: MambaSpec
     metadata_cls: type[M]
@@ -391,43 +422,10 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         common_attn_metadata: CommonAttentionMetadata,
         mamba_block_size: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        num_computed_tokens = common_attn_metadata.compute_num_computed_tokens()
-        # Block index of the last computed token
-        block_idx_last_computed_token = (
-            torch.div(
-                num_computed_tokens + mamba_block_size - 1,
-                mamba_block_size,
-                rounding_mode="floor",
-            )
-            - 1
-        )
-        # which is <= block index for the first scheduled token
-        block_idx_first_scheduled_token = (
-            torch.div(
-                num_computed_tokens + mamba_block_size,
-                mamba_block_size,
-                rounding_mode="floor",
-            )
-            - 1
-        )
-        # which is <= block index of the last scheduled token
-        block_idx_last_scheduled_token = (
-            torch.div(
-                common_attn_metadata.seq_lens + mamba_block_size - 1,
-                mamba_block_size,
-                rounding_mode="floor",
-            )
-            - 1
-        )
-        # -1 in case it's non-computed and causes later issues with indexing
-        block_idx_last_computed_token.clamp_(min=0)
-        # -1 in the case we have a padded request (0 seq-len)
-        block_idx_last_scheduled_token.clamp_(min=0)
-
-        return (
-            block_idx_last_computed_token,
-            block_idx_first_scheduled_token,
-            block_idx_last_scheduled_token,
+        return compute_mamba_prefix_caching_block_indices(
+            common_attn_metadata.compute_num_computed_tokens(),
+            common_attn_metadata.seq_lens,
+            mamba_block_size,
         )
 
     def _compute_common_metadata(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -108,9 +108,17 @@ class KVCacheCoordinator(ABC):
         self.eagle_group_ids: set[int] = {
             i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
         }
-        # Conservatively fall back to flag all groups when no group is flagged.
+        # Conservatively fall back to flag all groups when no group is
+        # flagged — except Mamba groups: an attention-only drafter can never
+        # own a Mamba group, and flagging one widens its lookup window beyond
+        # what block-granular SSM checkpoints can satisfy, silently disabling
+        # all Mamba prefix reuse under MTP/EAGLE.
         if use_eagle and not self.eagle_group_ids:
-            self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
+            self.eagle_group_ids = {
+                i
+                for i, g in enumerate(kv_cache_config.kv_cache_groups)
+                if not isinstance(g.kv_cache_spec, MambaSpec)
+            }
 
         # During chunked prefill with EAGLE, the single next prefill lookahead
         # token past the chunk boundary is combined with the final hidden state

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1892,11 +1892,10 @@ def _warn_if_unannotated_eagle_mamba(
         return
     logger.warning(
         "Speculative decoding (method=%s) is enabled but no KV cache group "
-        "could be identified as the draft model's, so every group -- "
-        "including Mamba groups %s -- will be treated as a draft group. A "
-        "Mamba group cannot satisfy the widened lookup window that implies, "
-        "so prefix-cache reuse across requests will be disabled and any "
-        "external KV offload tier will store without ever serving a hit.",
+        "could be identified as the draft model's; non-Mamba groups will be "
+        "conservatively treated as draft groups. Mamba groups %s are exempt "
+        "from this fallback (an attention-only drafter cannot own a Mamba "
+        "group; flagging one would silently disable SSM prefix reuse).",
         spec_config.method,
         mamba_groups,
     )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -323,8 +323,16 @@ class Scheduler(SchedulerInterface):
         # Blocks that async KV loads will overwrite this step, skipped from
         # zeroing since the zeroing could race the out-of-band write.
         self._skip_zero_block_ids: set[int] = set()
-        self.need_mamba_block_aligned_split = (
-            self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
+        self.need_mamba_block_aligned_split = self.has_mamba_layers and (
+            self.cache_config.mamba_cache_mode == "align"
+            # all-mode with a kernel that lacks short-first-chunk realignment
+            # (e.g. GDN/FLA): clip prefill chunks to kernel-chunk multiples so
+            # per-block SSM checkpoints stay exactly materializable. Set by
+            # Platform._align_hybrid_block_size.
+            or (
+                self.cache_config.mamba_cache_mode == "all"
+                and self.cache_config.mamba_all_mode_prefill_align_size is not None
+            )
         )
         self.mamba_has_prefill_checkpoint_blocks = (
             self.has_mamba_layers
@@ -341,6 +349,9 @@ class Scheduler(SchedulerInterface):
         # hash boundary, so the split adds that stop.
         self.mamba_partial_cache_hit = (
             self.need_mamba_block_aligned_split
+            # align-only: all-mode materializes states from within-chunk h
+            # exports, not at chunk ends, so partial-tail steering is moot.
+            and self.cache_config.mamba_cache_mode == "align"
             and self.hash_block_size < self.block_size
             and self.kv_cache_manager.coordinator.enable_partial_hash_hits
         )
@@ -408,6 +419,27 @@ class Scheduler(SchedulerInterface):
         prefill_end = max(request.num_prompt_tokens, request.num_tokens - 1)
         if start >= prefill_end:
             return num_new_tokens
+
+        if self.cache_config.mamba_cache_mode == "all":
+            # All-mode (kernel without short-first-chunk realignment): block
+            # boundary states materialize from within-chunk h exports, so the
+            # only requirement is that chunk STARTS stay kernel-chunk aligned
+            # — clip chunk ends to kernel-chunk multiples (<=63 tokens/step
+            # deferred, vs align mode's <= block_size-1). The final prefill
+            # chunk may end anywhere (tail handled by kernel masking; its
+            # state lands via the final-state write, not a full-block hash).
+            align = self.cache_config.mamba_all_mode_prefill_align_size
+            assert align is not None
+            end = start + num_new_tokens
+            last_aligned = max(request.num_prompt_tokens, request.num_tokens - 1)
+            if end < last_aligned:
+                # Re-align a misaligned start (e.g. externally loaded KV)
+                # at the next boundary; otherwise clip the end down.
+                if start % align != 0:
+                    end = min(end, (start // align + 1) * align)
+                else:
+                    end = end // align * align
+            return max(end - start, 0)
 
         block_size = self.cache_config.block_size
         # The last block-aligned position whose state can be cached. With

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -315,8 +315,17 @@ def build_attn_metadata(
         for attn_group in attn_groups[i]:
             attn_metadata_builder = attn_group.get_metadata_builder(0)
             if for_cudagraph_capture:
+                capture_extra_kwargs = (
+                    model_specific_attn_metadata.get_capture_extra_attn_kwargs(
+                        attn_metadata_builder,
+                        num_reqs,
+                    )
+                    if model_specific_attn_metadata is not None
+                    else {}
+                )
                 metadata = attn_metadata_builder.build_for_cudagraph_capture(
-                    common_attn_metadata
+                    common_attn_metadata,
+                    **capture_extra_kwargs,
                 )
             else:
                 attn_metadata_extra_kwargs = (

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -41,6 +41,16 @@ class ModelSpecificAttnMetadata:
     ) -> dict[str, Any]:
         return {}
 
+    def get_capture_extra_attn_kwargs(
+        self,
+        attn_metadata_builder: Any,
+        num_reqs: int,
+    ) -> dict[str, Any]:
+        """Extra kwargs for build_for_cudagraph_capture. Only kwargs the
+        builder's capture signature accepts may be returned (capture builds
+        synthesize the rest themselves)."""
+        return {}
+
 
 class ModelState(ABC):
     supports_prompt_embeds: ClassVar[bool] = False

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -41,6 +41,7 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     is_prefilling: torch.Tensor
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
+    prev_last_scheduled_idx: torch.Tensor | None = None
 
     def get_extra_common_attn_kwargs(
         self,
@@ -64,7 +65,7 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             ),
         ):
             return {}
-        return {
+        extra_kwargs: dict[str, Any] = {
             "num_accepted_tokens": None
             if self.num_accepted_tokens is None
             else self.num_accepted_tokens[:num_reqs],
@@ -72,6 +73,14 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             if self.num_decode_draft_tokens_cpu is None
             else self.num_decode_draft_tokens_cpu[:num_reqs],
         }
+        if self.prev_last_scheduled_idx is not None and isinstance(
+            attn_metadata_builder,
+            (Mamba2AttentionMetadataBuilder, GDNAttentionMetadataBuilder),
+        ):
+            extra_kwargs["prev_last_scheduled_idx"] = self.prev_last_scheduled_idx[
+                :num_reqs
+            ]
+        return extra_kwargs
 
 
 class MambaHybridModelState(DefaultModelState):
@@ -97,6 +106,10 @@ class MambaHybridModelState(DefaultModelState):
         self.recoverssm = (
             RecoverSSMState() if self.cache_config.use_kda_recoverssm else None
         )
+        self._mamba_ctx: MambaSpecDecodeGPUContext | None = None
+        self._mamba_group_ids: list[int] = []
+        self._mamba_spec: MambaSpec | None = None
+        self._mamba_state_copy_funcs: MambaStateCopyFuncsByType | None = None
         if self._align_mode:
             self._mamba_state_idx_gpu = torch.zeros(
                 self.max_num_reqs, dtype=torch.int32, device=self.device
@@ -107,15 +120,34 @@ class MambaHybridModelState(DefaultModelState):
             self._mamba_src_off_gpu = torch.zeros(
                 self.max_num_reqs, dtype=torch.int32, device=self.device
             )
-            self._mamba_ctx: MambaSpecDecodeGPUContext | None = None
-            self._mamba_group_ids: list[int] = []
-            self._mamba_spec: MambaSpec | None = None
-            self._mamba_state_copy_funcs: MambaStateCopyFuncsByType | None = None
+        # All-mode spec decode: per-request tracking of the block index the
+        # running SSM state was written to on the previous step, so the next
+        # step's in-place writes stay anchored when accepted drafts leave the
+        # sequence at a non-block-aligned position (the V1
+        # postprocess_mamba_all / preprocess_mamba_all_specdec pair). Kept
+        # GPU-resident to preserve the no-CPU-sync step. -1 = untracked (the
+        # builders fall back to the last computed block).
+        self._mamba_prev_last_scheduled_idx_gpu: torch.Tensor | None = None
+        self._mamba_prev_last_scheduled_idx_staged: torch.Tensor | None = None
+        if (
+            self.cache_config.mamba_cache_mode == "all"
+            and vllm_config.num_speculative_tokens > 0
+        ):
+            self._mamba_prev_last_scheduled_idx_gpu = torch.full(
+                (self.max_num_reqs,), -1, dtype=torch.int32, device=self.device
+            )
+            self._mamba_prev_last_scheduled_idx_staged = torch.full(
+                (self.max_num_reqs,), -1, dtype=torch.int32, device=self.device
+            )
 
     def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
         super().add_request(req_index, new_req_data)
         # Must reset the speculative acceptance count in this idx which could be stale.
         self.num_accepted_tokens_gpu[req_index].fill_(1)
+        if self._mamba_prev_last_scheduled_idx_gpu is not None:
+            # New/resumed requests start untracked; the builders use the
+            # last-computed-block fallback on their first step.
+            self._mamba_prev_last_scheduled_idx_gpu[req_index].fill_(-1)
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
             self._mamba_state_idx_gpu[req_index].fill_(
@@ -187,16 +219,35 @@ class MambaHybridModelState(DefaultModelState):
         kv_cache_config: KVCacheConfig,
         num_computed_tokens: torch.Tensor,
     ) -> None:
-        """Migrate each request's mamba state across block boundaries before the
-        forward (V1 align semantics, done on GPU). Runs on real batches only
-        (dummy DP/profiling runs skip preprocess_state), and before
-        ``prepare_attn`` gathers ``num_accepted_tokens``, so the boundary reset
-        is visible to the forward kernels.
+        """Per-step mamba state bookkeeping before the forward, on GPU. Runs on
+        real batches only (dummy DP/profiling runs skip preprocess_state), and
+        before ``prepare_attn`` gathers ``num_accepted_tokens``.
+
+        Align mode: migrate each request's mamba state across block boundaries
+        (V1 align semantics), so the boundary reset is visible to the forward
+        kernels.
+
+        All mode + spec decode: stage the previous step's write anchors in
+        batch order for ``prepare_attn``, then record this step's anchor (the
+        block holding the last scheduled token) for rows running a full decode
+        window; all other scheduled rows become untracked (-1). Mirrors the V1
+        ``postprocess_mamba_all`` / ``preprocess_mamba_all_specdec`` pair.
         """
-        if not self._align_mode:
-            return
         num_reqs = input_batch.num_reqs
         if num_reqs == 0:
+            return
+        if self._mamba_prev_last_scheduled_idx_gpu is not None:
+            _, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+            _track_mamba_all_write_anchor_kernel[(num_reqs,)](
+                input_batch.idx_mapping,
+                input_batch.query_start_loc,
+                input_batch.seq_lens,
+                self._mamba_prev_last_scheduled_idx_gpu,
+                self._mamba_prev_last_scheduled_idx_staged,
+                FULL_DECODE_LEN=1 + self.vllm_config.num_speculative_tokens,
+                MAMBA_BLOCK_SIZE=mamba_spec.block_size,
+            )
+        if not self._align_mode:
             return
         mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
         ctx = self._ensure_align_ctx(kv_cache_config, mamba_group_ids, block_tables)
@@ -263,11 +314,24 @@ class MambaHybridModelState(DefaultModelState):
         # compute them during actual (non-capture) forward execution.
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
+        prev_last_scheduled_idx = None
         if not for_capture and self.vllm_config.num_speculative_tokens > 0:
             num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
             num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
                 input_batch.idx_mapping
             ]
+
+            if self._mamba_prev_last_scheduled_idx_staged is not None:
+                # Staged in batch order by preprocess_state; padded rows are
+                # untracked (-1) so the builders take their fallback anchor.
+                prev_last_scheduled_idx = (
+                    self._mamba_prev_last_scheduled_idx_staged.new_full(
+                        (num_reqs,), -1
+                    )
+                )
+                prev_last_scheduled_idx[: input_batch.num_reqs] = (
+                    self._mamba_prev_last_scheduled_idx_staged[: input_batch.num_reqs]
+                )
 
             # GDN uses >= 0 to select spec-decode rows, so non-decode rows
             # need the -1 sentinel rather than a raw zero draft count.
@@ -307,6 +371,7 @@ class MambaHybridModelState(DefaultModelState):
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            prev_last_scheduled_idx=prev_last_scheduled_idx,
         )
         attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
@@ -387,6 +452,30 @@ class MambaHybridModelState(DefaultModelState):
                 num_computed_tokens,
                 idx_mapping,
             )
+
+
+@triton.jit
+def _track_mamba_all_write_anchor_kernel(
+    idx_mapping_ptr,  # [num_reqs] batch_idx -> req_state_idx
+    query_start_loc_ptr,  # [num_reqs + 1]
+    seq_lens_ptr,  # [num_reqs] num_computed (pre-step) + num_scheduled
+    prev_anchor_ptr,  # [max_num_reqs] persistent write-anchor tracking
+    staged_prev_ptr,  # [num_reqs] out: previous step's anchors, batch order
+    FULL_DECODE_LEN: tl.constexpr,  # 1 + num_spec_tokens
+    MAMBA_BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    req_state_idx = tl.load(idx_mapping_ptr + row)
+    tl.store(staged_prev_ptr + row, tl.load(prev_anchor_ptr + req_state_idx))
+    num_query = tl.load(query_start_loc_ptr + row + 1) - tl.load(
+        query_start_loc_ptr + row
+    )
+    seq_len = tl.load(seq_lens_ptr + row)
+    anchor = tl.maximum((seq_len - 1) // MAMBA_BLOCK_SIZE, 0)
+    tl.store(
+        prev_anchor_ptr + req_state_idx,
+        tl.where(num_query == FULL_DECODE_LEN, anchor, -1),
+    )
 
 
 @triton.jit

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -129,6 +129,11 @@ class MambaHybridModelState(DefaultModelState):
         # builders fall back to the last computed block).
         self._mamba_prev_last_scheduled_idx_gpu: torch.Tensor | None = None
         self._mamba_prev_last_scheduled_idx_staged: torch.Tensor | None = None
+        # Consume-once marker: the staged buffer is only meaningful for the
+        # batch whose preprocess_state filled it. Dummy runs skip
+        # preprocess_state, so without this they would read the previous real
+        # batch's anchors in the wrong row order.
+        self._mamba_prev_anchor_staged_valid = False
         if (
             self.cache_config.mamba_cache_mode == "all"
             and vllm_config.num_speculative_tokens > 0
@@ -247,6 +252,7 @@ class MambaHybridModelState(DefaultModelState):
                 FULL_DECODE_LEN=1 + self.vllm_config.num_speculative_tokens,
                 MAMBA_BLOCK_SIZE=mamba_spec.block_size,
             )
+            self._mamba_prev_anchor_staged_valid = True
         if not self._align_mode:
             return
         mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
@@ -324,14 +330,19 @@ class MambaHybridModelState(DefaultModelState):
             if self._mamba_prev_last_scheduled_idx_staged is not None:
                 # Staged in batch order by preprocess_state; padded rows are
                 # untracked (-1) so the builders take their fallback anchor.
+                # Consumed at most once per staging: batches that skipped
+                # preprocess_state (dummy runs) get all -1 instead of another
+                # batch's rows.
                 prev_last_scheduled_idx = (
-                    self._mamba_prev_last_scheduled_idx_staged.new_full(
-                        (num_reqs,), -1
+                    self._mamba_prev_last_scheduled_idx_staged.new_full((num_reqs,), -1)
+                )
+                if self._mamba_prev_anchor_staged_valid:
+                    self._mamba_prev_anchor_staged_valid = False
+                    prev_last_scheduled_idx[: input_batch.num_reqs] = (
+                        self._mamba_prev_last_scheduled_idx_staged[
+                            : input_batch.num_reqs
+                        ]
                     )
-                )
-                prev_last_scheduled_idx[: input_batch.num_reqs] = (
-                    self._mamba_prev_last_scheduled_idx_staged[: input_batch.num_reqs]
-                )
 
             # GDN uses >= 0 to select spec-decode rows, so non-decode rows
             # need the -1 sentinel rather than a raw zero draft count.

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -10,6 +10,10 @@ import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFuncsByType
+from vllm.model_executor.layers.mamba.ops.gdn_index_prep import (
+    GDNBlockIdxPrepBuffers,
+    gdn_inkernel_ckpt_idx_enabled,
+)
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
@@ -42,6 +46,7 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
     prev_last_scheduled_idx: torch.Tensor | None = None
+    block_idx_prep: "GDNBlockIdxPrepBuffers | None" = None
 
     def get_extra_common_attn_kwargs(
         self,
@@ -80,7 +85,24 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             extra_kwargs["prev_last_scheduled_idx"] = self.prev_last_scheduled_idx[
                 :num_reqs
             ]
+        if self.block_idx_prep is not None and isinstance(
+            attn_metadata_builder, GDNAttentionMetadataBuilder
+        ):
+            extra_kwargs["block_idx_prep"] = self.block_idx_prep
         return extra_kwargs
+
+    def get_capture_extra_attn_kwargs(
+        self,
+        attn_metadata_builder: Any,
+        num_reqs: int,
+    ) -> dict[str, Any]:
+        # Captured decode graphs must bake the shared prep-buffer addresses so
+        # the once-per-step prep launch feeds them between replays.
+        if self.block_idx_prep is not None and isinstance(
+            attn_metadata_builder, GDNAttentionMetadataBuilder
+        ):
+            return {"block_idx_prep": self.block_idx_prep}
+        return {}
 
 
 class MambaHybridModelState(DefaultModelState):
@@ -144,6 +166,15 @@ class MambaHybridModelState(DefaultModelState):
             self._mamba_prev_last_scheduled_idx_staged = torch.full(
                 (self.max_num_reqs,), -1, dtype=torch.int32, device=self.device
             )
+        # All-mode fused block-index prep (VLLM_GDN_INKERNEL_CKPT_IDX): one
+        # Triton launch per step into shared persistent buffers consumed by
+        # every GDN metadata builder, replacing the eager per-builder anchor
+        # math. Lazily allocated once GDN groups are known.
+        self._gdn_block_idx_prep: GDNBlockIdxPrepBuffers | None = None
+        self._gdn_block_idx_prep_enabled = (
+            self.cache_config.mamba_cache_mode == "all"
+            and gdn_inkernel_ckpt_idx_enabled()
+        )
 
     def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
         super().add_request(req_index, new_req_data)
@@ -378,11 +409,20 @@ class MambaHybridModelState(DefaultModelState):
                 for group_idx, builder in aligned_index_builders:
                     builder.mamba_aligned_state_indices = all_group_indices[group_idx]
 
+        block_idx_prep = self._prepare_gdn_block_idx(
+            input_batch,
+            num_reqs,
+            attn_groups,
+            kv_cache_config,
+            prev_last_scheduled_idx,
+        )
+
         mamba_attn_metadata = MambaHybridAttnMetadata(
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
             prev_last_scheduled_idx=prev_last_scheduled_idx,
+            block_idx_prep=block_idx_prep,
         )
         attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
@@ -409,6 +449,54 @@ class MambaHybridModelState(DefaultModelState):
                 for_capture=for_capture,
             )
         return attn_metadata
+
+    def _prepare_gdn_block_idx(
+        self,
+        input_batch: InputBatch,
+        num_reqs: int,
+        attn_groups: list[list[AttentionGroup]],
+        kv_cache_config: KVCacheConfig,
+        prev_last_scheduled_idx: torch.Tensor | None,
+    ) -> GDNBlockIdxPrepBuffers | None:
+        """All-mode GDN (VLLM_GDN_INKERNEL_CKPT_IDX): run the once-per-step
+        block-index prep kernel into shared persistent buffers consumed by
+        every GDN metadata builder (the V2 counterpart of the V1 runner's
+        _prepare_gdn_block_idx). Runs during cudagraph capture too, so the
+        captured metadata bakes the shared buffer addresses; spec-decode
+        anchor outputs are only written on real steps, when
+        prev_last_scheduled_idx is provided.
+        """
+        if not self._gdn_block_idx_prep_enabled:
+            return None
+        if self._gdn_block_idx_prep is None:
+            # attn_groups may be mamba-stripped (is_profile dummy runs), so a
+            # negative probe must NOT be memoized — re-probe until real
+            # groups show a GDN builder.
+            has_gdn = any(
+                isinstance(group.get_metadata_builder(0), GDNAttentionMetadataBuilder)
+                for groups in attn_groups
+                for group in groups
+            )
+            if not has_gdn:
+                return None
+            self._gdn_block_idx_prep = GDNBlockIdxPrepBuffers(
+                self.max_num_reqs * (self.vllm_config.num_speculative_tokens + 1),
+                self.device,
+            )
+        _, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+        seq_lens = input_batch.seq_lens[:num_reqs]
+        query_lens = (
+            input_batch.query_start_loc[1 : num_reqs + 1]
+            - input_batch.query_start_loc[:num_reqs]
+        )
+        self._gdn_block_idx_prep.prepare(
+            seq_lens,
+            seq_lens - query_lens,
+            prev_last_scheduled_idx,
+            mamba_spec.block_size,
+            num_reqs,
+        )
+        return self._gdn_block_idx_prep
 
     def postprocess_state(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -67,6 +67,10 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     bind_routed_experts_capturer,
 )
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFuncsByType
+from vllm.model_executor.layers.mamba.ops.gdn_index_prep import (
+    GDNBlockIdxPrepBuffers,
+    gdn_inkernel_ckpt_idx_enabled,
+)
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
@@ -1004,6 +1008,14 @@ class GPUModelRunner(
             self.mamba_prev_last_scheduled_idx = self._make_buffer(
                 self.max_num_reqs, dtype=torch.int32
             )
+        # All-mode GDN: shared per-step block-index buffers written by the
+        # once-per-step prep kernel and consumed by every GDN metadata builder
+        # (allocated lazily once GDN attn groups are known).
+        self.gdn_block_idx_prep: GDNBlockIdxPrepBuffers | None = None
+        self._gdn_block_idx_prep_enabled = (
+            self.cache_config.mamba_cache_mode == "all"
+            and gdn_inkernel_ckpt_idx_enabled()
+        )
         self.layerwise_nvtx_hooks_registered = False
 
     def update_max_model_len(self, max_model_len: int) -> None:
@@ -2315,6 +2327,47 @@ class GPUModelRunner(
             int(num_sampled_tokens.max()),
         )
 
+    def _prepare_gdn_block_idx(
+        self,
+        cm_base: CommonAttentionMetadata,
+        num_reqs_padded: int,
+    ) -> GDNBlockIdxPrepBuffers | None:
+        """All-mode GDN (VLLM_GDN_INKERNEL_CKPT_IDX): run the once-per-step
+        block-index prep kernel into shared persistent buffers consumed by
+        every GDN metadata builder."""
+        if (
+            not self._gdn_block_idx_prep_enabled
+            or self.cache_config.mamba_block_size is None
+        ):
+            return None
+        if self.gdn_block_idx_prep is None:
+            if not self.attn_groups:
+                return None
+            has_gdn = any(
+                isinstance(group.get_metadata_builder(), GDNAttentionMetadataBuilder)
+                for groups in self.attn_groups
+                for group in groups
+            )
+            if not has_gdn:
+                self._gdn_block_idx_prep_enabled = False
+                return None
+            self.gdn_block_idx_prep = GDNBlockIdxPrepBuffers(
+                self.max_num_reqs * (self.num_spec_tokens + 1), self.device
+            )
+        prev = (
+            self.mamba_prev_last_scheduled_idx.gpu[:num_reqs_padded]
+            if self.mamba_prev_last_scheduled_idx is not None
+            else None
+        )
+        self.gdn_block_idx_prep.prepare(
+            cm_base.seq_lens,
+            cm_base.compute_num_computed_tokens(),
+            prev,
+            self.cache_config.mamba_block_size,
+            num_reqs_padded,
+        )
+        return self.gdn_block_idx_prep
+
     def _build_attention_metadata(
         self,
         num_tokens: int,
@@ -2504,6 +2557,11 @@ class GPUModelRunner(
                 logits_indices
             )
 
+        # All-mode GDN: compute the per-request block anchors once per step
+        # (one kernel launch) into shared persistent buffers instead of the
+        # eager cdiv/clamp chains in each of the GDN builders.
+        gdn_block_idx_prep = self._prepare_gdn_block_idx(cm_base, num_reqs_padded)
+
         # Cache attention metadata builds across hybrid KV-cache groups
         # The only thing that changes between different hybrid KV-cache groups when the
         # same metadata builder and KVCacheSpec is the same is the block table, so we
@@ -2533,6 +2591,13 @@ class GPUModelRunner(
             )
 
             extra_attn_metadata_args = {}
+            # GDN metadata (and the shared prep buffers) are global-row
+            # indexed, while per-ubatch builds receive request-sliced,
+            # renumbered metadata — fail loudly for ANY GDN ubatch build,
+            # not just the spec-decode ones asserted below.
+            assert ubid is None or not isinstance(
+                builder, GDNAttentionMetadataBuilder
+            ), "UBatching not supported with GDN yet"
             if use_spec_decode and isinstance(
                 builder,
                 (
@@ -2564,11 +2629,34 @@ class GPUModelRunner(
                     extra_attn_metadata_args["prev_last_scheduled_idx"] = (
                         self.mamba_prev_last_scheduled_idx.gpu[:num_reqs_padded]
                     )
+            if (
+                ubid is None
+                and gdn_block_idx_prep is not None
+                and isinstance(builder, GDNAttentionMetadataBuilder)
+            ):
+                # Never hand the global-row prep buffers to a per-ubatch
+                # (request-sliced) build — it would consume another ubatch's
+                # anchors; sliced builds fall back to the eager per-builder
+                # math, which is per-slice-correct.
+                assert (
+                    self.cache_config.mamba_block_size
+                    == builder.kv_cache_spec.block_size
+                ), "prep-kernel block size diverged from the GDN kv_cache_spec"
+                extra_attn_metadata_args["block_idx_prep"] = gdn_block_idx_prep
 
             if for_cudagraph_capture:
-                attn_metadata_i = builder.build_for_cudagraph_capture(
-                    common_attn_metadata
-                )
+                if gdn_block_idx_prep is not None and isinstance(
+                    builder, GDNAttentionMetadataBuilder
+                ):
+                    # Capture must bake the shared prep-buffer addresses the
+                    # replay-time prep kernel refreshes.
+                    attn_metadata_i = builder.build_for_cudagraph_capture(
+                        common_attn_metadata, block_idx_prep=gdn_block_idx_prep
+                    )
+                else:
+                    attn_metadata_i = builder.build_for_cudagraph_capture(
+                        common_attn_metadata
+                    )
             elif (
                 cache_key in cached_attn_metadata
                 and builder.supports_update_block_table

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2552,7 +2552,13 @@ class GPUModelRunner(
                     ],
                 )
                 if (
-                    isinstance(builder, Mamba2AttentionMetadataBuilder)
+                    isinstance(
+                        builder,
+                        (
+                            Mamba2AttentionMetadataBuilder,
+                            GDNAttentionMetadataBuilder,
+                        ),
+                    )
                     and self.mamba_prev_last_scheduled_idx is not None
                 ):
                     extra_attn_metadata_args["prev_last_scheduled_idx"] = (


### PR DESCRIPTION
## Purpose

Decode-path performance optimizations for GDN hybrid models with `mamba_cache_mode="all"` prefix caching + MTP speculative decoding, on **Model Runner V2**. Four commits, each independently flag-gated or self-contained, measured cumulatively on B200 (Qwen3-Next-80B-A3B-Instruct-NVFP4, MTP k=3):

- **Optimization 1 — packed mixed_qkv input for the fused gating kernel** (`51b571bf`): the spec-decode gating kernel consumes the projection output as a packed row-strided view instead of a materialized copy chain.
- **Optimization 2 — fused block-index prep, in-kernel checkpoint stores, mask-select hoist** (`e34de8a4`): replaces per-step host-side checkpoint index preparation with one fused Triton kernel (V1 + V2 wiring; V2 via `MambaHybridModelState`/`GDNBlockIdxPrepBuffers`).
- **Optimization 3 — weight de-interleave + tiny-GEMM fold at load time** (`eb874270`): row-permutes the local `in_proj_qkvz` shards so `mixed_qkv`/`z` are zero-copy views of the GEMM output, and folds the `in_proj_ba` rows into the main GEMM (N 12288 → 12352), removing the split-K fp32 workspace round-trip (`VLLM_GDN_DEINTERLEAVE_QKVZ`, `VLLM_GDN_CONCAT_TINY_GEMMS`, default on; the router-gate fold ships default-off).
- **Optimization 4 — monolithic trtllm-gen NvFp4 experts under allgather EP, opt-in** (`8e5c5707`): one predicate widening behind `VLLM_GDN_MOE_MONO_AGRS` (default off). Note: at TP4+EP with DP=1 current main already selects the monolithic path (`MoEPrepareAndFinalizeNoDPEPMonolithic`), so this flag only changes behavior for DP>1 ag_rs deployments; our A/A control below confirms bit-identical behavior at DP=1.

## Relationship to existing PRs

Stacks on **#54637** (same author; the V2 all-mode prefix-caching base) — the first 7 commits here are that PR; **only the top 4 commits are new in this PR**. Supersedes **#54612**, which carried the same optimizations on the pre-V2 base (will be closed when this lands). No third-party open PR implements these changes (checked `GDN decode optimization`, `gated delta net performance`; #51954 targets decode gate copies, a different path).

## Correctness

- Unit suites (B200, CUDA 12.9 container, branch tip): **87 passed / 0 failed**, including the two new suites added by this PR:

```
pytest tests/v1/worker/test_mamba_hybrid_prev_anchor.py \
       tests/kernels/mamba/test_gdn_scatter.py \
       tests/kernels/mamba/test_fla_chunk_block_states.py \
       tests/kernels/mamba/test_fused_sigmoid_gating_dual_index.py \
       tests/v1/attention/test_gdn_metadata_builder.py \
       tests/kernels/mamba/test_gdn_traffic_opt.py \
       tests/kernels/moe/test_mono_agrs_selection.py
```

- Cold/warm byte-identity probes on the fully-optimized build (greedy, ~8.9k-token prompt sent twice, `Using V2 Model Runner` confirmed in serve logs): outputs byte-identical with warm `cached_tokens` 6912/8894 (TP1 all), 8064/8894 (TP4+EP all), 6720 / 7840 (align references) — SSM-state reuse stays lossless with every optimization active. Probes repeated per build stage during the ladder (10/10 byte-identical).
- De-interleave is bit-identical by construction; the tiny-GEMM fold is ULP-class (adjudicated at greedy logit ties on the donor lineage); optimization 4's expert selection verified exact-match (782/782 token rows).

## Performance

Cumulative ladder, measured stage-by-stage on one node per TP (aiperf, 240 requests/cell, OSL 1024 ignore_eos, temperature 0, seed 42, prefix cache reset per cell, full c1–c128 sweep per stage; A/A control build puts node noise at ±0.8%):

| cumulative build | TP1 system tok/s delta | TP4+EP system tok/s delta |
|---|---|---|
| + optimization 2 over optimization 1 | +3.0% → +12.2% (grows with concurrency) | +3.3% → +14.6% |
| + optimization 3 over optimization 2 | +0.8% → +6.9% | +2.1% → +7.0% |
| **optimization 1 → optimizations 1+2+3** | **+10.1% → +14.3%** | **+10.5% → +18.5%** |

Per-user throughput (latency axis) improves in lockstep (+9–18% at TP4) — the frontier translates up and right rather than trading throughput for latency.

Baseline (#54637 build) vs fully-optimized, TP4+EP — the all-mode-vs-align crossover from #54637's Pareto is eliminated: all-mode now matches or beats the align reference at every concurrency (all/align throughput ratio 1.012–1.070, peak c128; TP1 is parity within noise):

![TP4 baseline vs optimized pareto](https://raw.githubusercontent.com/anuragdutt/vllm/pr-assets-gdn-allmode/v2/v2_step_pareto_tp4_final.png)

![TP4 cumulative optimization bars](https://raw.githubusercontent.com/anuragdutt/vllm/pr-assets-gdn-allmode/v2/v2opt_bars_tp4_c8c64_5_v2_opt4_moeflag.png)

(Bar chart baseline group measured in the #54637 campaign on a different node — ±3–5% cross-node variance applies to that comparison only; all optimization stages are same-node.)

## Disclosure

AI assistance (Claude Code) was used to develop and test this change. The submitting human has reviewed every changed line and will run/re-run any requested validation.
