### PR TITLE
[Bugfix] Support GPTQ-quantized DFlash draft models in the context-KV precompute path

### DIFF
--- a/tests/v1/spec_decode/test_dflash_quantized_weights.py
+++ b/tests/v1/spec_decode/test_dflash_quantized_weights.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPTQ dequantization helper for the DFlash context-KV precompute path.
+
+The DFlash context-KV precompute rebuilds float K/V weights from GPTQ-packed
+parameters when the draft model is quantized (see _dequantize_gptq_proj_weight
+in qwen3_dflash.py). These tests pin the packed-layout assumptions (bit order,
+grouping, zero points) so that a regression in the format handling fails
+loudly without needing a quantized checkpoint.
+"""
+
+import torch
+
+from vllm.model_executor.models.qwen3_dflash import (
+    _dequantize_gptq_proj_weight,
+)
+
+
+class _FakeGptqLinear:
+
+    def __init__(self, qweight: torch.Tensor, scales: torch.Tensor,
+                 qzeros: torch.Tensor):
+        self.qweight = qweight
+        self.scales = scales
+        self.qzeros = qzeros
+
+
+def _pack_last_axis(codes: torch.Tensor) -> torch.Tensor:
+    """Pack 8 4-bit codes (0..15) per int32, LSB first, along the last dim.
+
+    codes: [..., n] with n % 8 == 0 -> packed [..., n // 8].
+    """
+    n = codes.shape[-1]
+    c = codes.reshape(*codes.shape[:-1], n // 8, 8)
+    packed = torch.zeros(*codes.shape[:-1], n // 8, dtype=torch.int32)
+    for b in range(8):
+        packed += (c[..., b] << (4 * b)).int()
+    return packed
+
+
+def test_dequantize_gptq_proj_weight_roundtrip():
+    """Random asymmetric codes/zero points round-trip exactly.
+
+    Exercises the bit order of both the input-axis code packing and the
+    output-axis zero-point packing, plus the per-group scale broadcast.
+    """
+    torch.manual_seed(0)
+    n_in, n_out, group_size = 512, 384, 128
+    num_groups = n_in // group_size
+    codes = torch.randint(0, 16, (n_in, n_out), dtype=torch.int32)
+    zeros = torch.randint(0, 16, (num_groups, n_out), dtype=torch.int32)
+    scales = torch.rand(num_groups, n_out, dtype=torch.float16) * 0.05 + 1e-3
+
+    # qweight: codes packed LSB-first along in -> [in/8, out]
+    qweight = _pack_last_axis(codes.t()).t()
+    # qzeros: zero points packed LSB-first along out -> [in/gs, out/8]
+    qzeros = _pack_last_axis(zeros)
+
+    rebuilt = _dequantize_gptq_proj_weight(
+        _FakeGptqLinear(qweight, scales, qzeros))  # [out, in]
+
+    group_ids = torch.arange(n_in) // group_size
+    expected = ((codes.float() - zeros[group_ids].float()) *
+                scales[group_ids].float()).t()
+    torch.testing.assert_close(rebuilt, expected, atol=1e-2, rtol=1e-2)
+
+
+def test_dequantize_gptq_proj_weight_symmetric():
+    """Symmetric quantizers store zero point 8 in every nibble."""
+    torch.manual_seed(1)
+    n_in, n_out, group_size = 256, 192, 64
+    num_groups = n_in // group_size
+    weight = torch.randn(n_out, n_in)
+    # Reference grouped symmetric int4 quantization.
+    grouped = weight.t().reshape(num_groups, group_size, n_out)
+    scale = grouped.abs().amax(dim=1, keepdim=True).clamp_min(1e-8) / 8.0
+    # Codes carry the unsigned +8 offset.
+    codes = torch.clamp(torch.round(grouped / scale), -8, 7).to(
+        torch.int32) + 8
+    codes = codes.reshape(n_in, n_out)
+
+    qweight = _pack_last_axis(codes.t()).t()
+    # Zero point 8 (0x8 in every nibble) along the output axis; the int32
+    # signed form of 0x88888888 is -2004318072.
+    qzeros = torch.full((num_groups, n_out // 8),
+                        -2004318072,
+                        dtype=torch.int32)
+    rebuilt = _dequantize_gptq_proj_weight(
+        _FakeGptqLinear(qweight, scale.squeeze(1).to(torch.float16), qzeros))
+
+    group_ids = torch.arange(n_in) // group_size
+    expected = ((codes.float() - 8.0) *
+                scale.squeeze(1)[group_ids].float()).t()
+    torch.testing.assert_close(rebuilt, expected, atol=1e-2, rtol=1e-2)

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -23,8 +23,10 @@ from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQLinearMethod
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -53,6 +55,66 @@ logger = init_logger(__name__)
 
 
 _SLIDING_ATTENTION = "sliding_attention"
+
+def _dequantize_gptq_proj_weight(
+    linear: nn.Module,
+) -> torch.Tensor:
+    """Rebuild a GPTQ-packed linear's float weight, shape [out, in].
+
+    DFlash's context-KV path (precompute_and_store_context_kv) fuses all
+    layers' K/V projections into a single float GEMM, so it needs actual float
+    weights, but GPTQ/Marlin linears only keep packed tensors. This handles
+    the pre-Marlin (checkpoint) layout, i.e. the parameter state when the
+    model's load_weights runs (before process_weights_after_loading converts
+    them to the Marlin layout):
+      - qweight: [in / 8, out] int32, 8 4-bit codes per word, LSB first,
+        along the input axis (input column i = 8 * w + b holds code b of
+        word w);
+      - scales: [in / group_size, out];
+      - qzeros: [in / group_size, out / 8] int32, 8 4-bit zero points per
+        word, LSB first, along the output axis.
+    Zero points are stored unsigned and the reconstruction is
+    (code - zero) * scale, so symmetric quantizers simply store 8 in every
+    zero-point nibble.
+    """
+    qweight = linear.qweight
+    scales = linear.scales
+    qzeros = linear.qzeros
+    group_size = qweight.shape[0] * 8 // scales.shape[0]
+    num_groups = scales.shape[0]
+    # Unpack the 4-bit codes along the input axis (LSB first).
+    codes = torch.stack(
+        [(qweight >> (4 * b)) & 0xF for b in range(8)], dim=1
+    ).reshape(-1, qweight.shape[1])  # [in, out]
+    # Unpack the 4-bit zero points along the output axis (LSB first).
+    zeros = torch.stack(
+        [(qzeros >> (4 * b)) & 0xF for b in range(8)], dim=-1
+    ).reshape(num_groups, -1)  # [in / group_size, out]
+    group_ids = torch.arange(
+        codes.shape[0], device=qweight.device, dtype=torch.long
+    ) // group_size
+    return ((codes.float() - zeros[group_ids].float())
+            * scales[group_ids].float()).t()
+
+
+def _kv_weight_slice(qkv_proj: nn.Module, q_size: int) -> torch.Tensor:
+    """K/V rows [2 * kv_size, in] of a QKV projection weight.
+
+    Float projections expose .weight directly; GPTQ-quantized ones must be
+    rebuilt from the packed representation first. Other quantized methods are
+    rejected: their parameters do not follow the GPTQ layout this path reads.
+    """
+    if isinstance(qkv_proj.quant_method, AutoGPTQLinearMethod):
+        weight = _dequantize_gptq_proj_weight(qkv_proj)
+    elif isinstance(qkv_proj.quant_method, UnquantizedLinearMethod):
+        weight = qkv_proj.weight
+    else:
+        raise NotImplementedError(
+            "DFlash context-KV precompute needs float K/V weights; quantized "
+            f"drafts using {type(qkv_proj.quant_method).__name__} are not "
+            "supported yet."
+        )
+    return weight[q_size:]
 
 
 def _dflash_layer_causal(config: Qwen3Config, layer_idx: int) -> bool:
@@ -468,9 +530,15 @@ class DFlashQwen3Model(nn.Module):
     ) -> None:
         self._hidden_norm_weight = self.hidden_norm.weight.data
 
-        # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
-        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
-        self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+        # KV projection weights: [num_layers * 2 * kv_size, hidden_size].
+        # Quantized drafts have no float .weight; rebuild it from the packed
+        # representation, keeping every buffer in the model's param dtype.
+        kv_weights = [
+            _kv_weight_slice(a.qkv_proj, a.q_size) for a in layers_attn
+        ]
+        self._fused_kv_weight = torch.cat(kv_weights, dim=0).to(
+            dtype=self._hidden_norm_weight.dtype
+        )
         if has_bias:
             kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
             self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)


### PR DESCRIPTION
# [Bugfix] Support GPTQ-quantized DFlash draft models in the context-KV precompute path

## Summary

Quantized (GPTQ) DFlash draft models fail to load with:

```
AttributeError: 'QKVParallelLinear' object has no attribute 'weight'. Did you mean: 'qweight'?
```

`DFlashModel._build_context_kv_buffers` slices `qkv_proj.weight[q_size:]` to build the fused K/V weight buffer used by `precompute_and_store_context_kv`. GPTQ/Marlin linears only keep packed parameters (`qweight`/`qzeros`/`scales`), no float `.weight`, so any GPTQ-quantized DFlash draft (e.g. an INT4 quantization of `z-lab/Qwen3.5-9B-DFlash`) aborts during weight loading.

## Fix

In `_build_context_kv_buffers`, route through a new helper that:

- for float projections (`UnquantizedLinearMethod`) keeps the existing `.weight[q_size:]` slice — the fused single-GEMM path is untouched;
- for GPTQ projections (`AutoGPTQLinearMethod`) dequantizes the packed weight and slices the K/V rows from the reconstructed float weight;
- raises `NotImplementedError` for any other quantized method (their parameters do not follow the GPTQ layout this path reads) instead of silently reading wrong attributes.

The dequantization reads the **checkpoint layout**, which is the parameter state while `load_weights` runs — `process_weights_after_loading` converts to the Marlin layout afterwards, and the fused buffers built here are standalone tensors, so no interaction with the Marlin conversion. Layout handled:

- `qweight`: `[in/8, out]` int32, 8 4-bit codes per word, LSB first, along the input axis (input column `i = 8w + b` holds code `b` of word `w`);
- `scales`: `[in/group_size, out]`;
- `qzeros`: `[in/group_size, out/8]` int32, 8 4-bit zero points per word, LSB first, along the output axis.

Reconstruction is `(code - zero) * scale` with unsigned zero points; symmetric quantizers simply store `8` in every zero-point nibble (verified against the original BF16 draft weights: RMS abs error 0.0075 — quantization-noise level — versus 0.17 for a wrong zero-point interpretation).

## Why this approach

The context-KV precompute deliberately fuses all layers' K/V projections into a single float GEMM for performance. Two alternatives were considered and rejected:

1. Running each layer's quantized `qkv_proj` forward instead of the fused GEMM — correct but loses the fusion, and would need to move buffer construction out of `load_weights` (the linear methods are not usable until `process_weights_after_loading` runs).
2. Exposing a dequantize API on the quant method — cleaner long-term, but a much larger API surface change; the model-local helper keeps the change scoped to the DFlash path.

## Validation (manual)

- Draft: INT4 GPTQ quantization of `z-lab/Qwen3.5-9B-DFlash` (`group_size=128`, `desc_act=False`, `sym=True`); target: `Qwen3.5-9B` GPTQ (mssfj), vLLM 0.28.0, RTX 4090.
- Server loads, serves and generates coherent output; speculative acceptance 21.5% — identical to the unquantized BF16 draft — and the tool-calling cycle works end to end.
- Throughput (same script, 512 output tokens, 3 runs):
  - BF16 draft: 269–272 tok/s
  - INT4 draft (this fix): 304–307 tok/s
  - no speculation baseline: 128 tok/s
- Unquantized-draft behavior unchanged (same code path, `isinstance` guard only).

## Test plan

Unit test for the dequantization helper is included (CPU, synthetic weights, no model download). Model-level coverage would require a quantized DFlash draft checkpoint in HF Hub, which does not exist publicly today; happy to add one if maintainers point at the preferred test-model org.
