### PR TITLE
[Docs] Clarify VLLM_CPU_KVCACHE_SPACE unset auto-sizes

### DIFF
--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -80,7 +80,7 @@ llm = LLM(model="meta-llama/Llama-3.1-8B-Instruct", enforce_eager=True)
 If you run out of CPU RAM, try the following options:
 
 - (Multi-modal models only) you can set the size of multi-modal cache by setting `mm_processor_cache_gb` engine argument (default 4 GiB).
-- (CPU backend only) you can set the size of KV cache using `VLLM_CPU_KVCACHE_SPACE` environment variable (default 4 GiB).
+- (CPU backend only) you can set the size of KV cache using the `VLLM_CPU_KVCACHE_SPACE` environment variable (GiB). If unset, KV cache is auto-sized from available CPU/NUMA memory using `--gpu-memory-utilization` (default 0.9).
 
 ## Multi-modal input limits
 

--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -148,7 +148,7 @@ VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu
 
 ## Related runtime environment variables
 
-- `VLLM_CPU_KVCACHE_SPACE`: specify the KV Cache size (e.g, `VLLM_CPU_KVCACHE_SPACE=40` means 40 GiB space for KV cache), larger setting will allow vLLM to run more requests in parallel. This parameter should be set based on the hardware configuration and memory management pattern of users. Default value is `0`.
+- `VLLM_CPU_KVCACHE_SPACE`: specify the KV Cache size in GiB (e.g, `VLLM_CPU_KVCACHE_SPACE=40` means 40 GiB space for KV cache), larger setting will allow vLLM to run more requests in parallel. This parameter should be set based on the hardware configuration and memory management pattern of users. If unset, there is no fixed GiB default; KV cache is auto-sized using `--gpu-memory-utilization`.
 - `VLLM_CPU_OMP_THREADS_BIND`: specify the CPU cores dedicated to the OpenMP threads, can be set as CPU id lists, `auto` (by default), or `nobind` (to disable binding to individual CPU cores and to inherit user-defined OpenMP variables). For example, `VLLM_CPU_OMP_THREADS_BIND=0-31` means there will be 32 OpenMP threads bound on 0-31 CPU cores. `VLLM_CPU_OMP_THREADS_BIND=0-31|32-63` means there will be 2 tensor parallel processes, 32 OpenMP threads of rank0 are bound on 0-31 CPU cores, and the OpenMP threads of rank1 are bound on 32-63 CPU cores. By setting to `auto`, the OpenMP threads of each rank are bound to the CPU cores in each NUMA node respectively. If set to `nobind`, the number of OpenMP threads is determined by the standard `OMP_NUM_THREADS` environment variable.
 - `VLLM_CPU_NUM_OF_RESERVED_CPU`: specify the number of CPU cores which are not dedicated to the OpenMP threads for each rank. The variable only takes effect when VLLM_CPU_OMP_THREADS_BIND is set to `auto`. Default value is `None`. If the value is not set and use `auto` thread binding, no CPU will be reserved for `world_size == 1`, 1 CPU per rank will be reserved for `world_size > 1`.
 - `CPU_VISIBLE_MEMORY_NODES`: specify visible NUMA memory nodes for vLLM CPU workers, similar to ```CUDA_VISIBLE_DEVICES```. The variable only takes effect when VLLM_CPU_OMP_THREADS_BIND is set to `auto`. The variable provides more control for the auto thread-binding feature, such as masking nodes and changing nodes binding sequence.
@@ -290,7 +290,7 @@ See [AMD Zen optimizations](#amd-zen-optimizations) for detection rules, support
 
 ### How to decide `VLLM_CPU_KVCACHE_SPACE`?
 
-This value is 4GB by default. Larger space can support more concurrent requests, longer context length. However, users should take care of memory capacity of each NUMA node. The memory usage of each TP rank is the sum of `weight shard size` and `VLLM_CPU_KVCACHE_SPACE`, if it exceeds the capacity of a single NUMA node, the TP worker will be killed with `exitcode 9` due to out-of-memory.
+If unset, KV cache size is auto-derived from available CPU/NUMA memory using `--gpu-memory-utilization` (default 0.9) after model load. Set `VLLM_CPU_KVCACHE_SPACE` (GiB) to pin an explicit size. Larger space can support more concurrent requests and longer context length. However, users should take care of memory capacity of each NUMA node. The memory usage of each TP rank is the sum of `weight shard size` and the KV cache allocation; if it exceeds the capacity of a single NUMA node, the TP worker will be killed with `exitcode 9` due to out-of-memory.
 
 ### How to do performance tuning for vLLM CPU?
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -872,8 +872,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Pipeline stage partition strategy
     "VLLM_PP_LAYER_PARTITION": lambda: os.getenv("VLLM_PP_LAYER_PARTITION", None),
-    # (CPU backend only) CPU key-value cache space.
-    # default is None and will be set as 4 GB
+    # (CPU backend only) CPU key-value cache space in GiB.
+    # Default is None (unset). When set, overrides auto sizing via
+    # --gpu-memory-utilization on the CPU backend.
     "VLLM_CPU_KVCACHE_SPACE": lambda: (
         int(os.getenv("VLLM_CPU_KVCACHE_SPACE", "0"))
         if "VLLM_CPU_KVCACHE_SPACE" in os.environ


### PR DESCRIPTION
## Summary

Docs for `VLLM_CPU_KVCACHE_SPACE` incorrectly claimed a fixed default (`4 GiB` / `4GB` / `0`). When the env var is unset, `envs.py` returns `None`, `platforms/cpu.py` only applies an explicit GiB override when set, and the CPU worker auto-sizes KV cache from available memory using `--gpu-memory-utilization`.

This PR updates:
- `docs/configuration/conserving_memory.md`
- `docs/getting_started/installation/cpu.md`
- stale comment in `vllm/envs.py`

## Repro

```bash
# Unset → None (not 4 / 0)
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/envs.py \
  | sed -n '/VLLM_CPU_KVCACHE_SPACE/,+6p'

# Override applied only when env is set
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/platforms/cpu.py \
  | sed -n '/VLLM_CPU_KVCACHE_SPACE/,+5p'

# Auto-size path when kv_cache_memory_bytes is None
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/v1/worker/cpu_worker.py \
  | sed -n '/explicit_kv_cache_size/,+40p'

# Stale docs wording on main
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/configuration/conserving_memory.md \
  | sed -n '80,85p'
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/getting_started/installation/cpu.md \
  | sed -n '148,153p;290,295p'
```

## Test plan

- [x] Re-verified against current `main` raw sources (`envs.py`, `platforms/cpu.py`, `cpu_worker.py`, both docs)
- [ ] Docs preview / wording review