### PR TITLE
[Perf] Refine FlashInfer SM120 sparse-MLA cpb per capture bucket in warmup

### DIFF
--- a/tests/model_executor/test_flashinfer_sparse_mla_warmup.py
+++ b/tests/model_executor/test_flashinfer_sparse_mla_warmup.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the FlashInfer sparse-MLA warmup capture-bucket selection."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.warmup.flashinfer_sparse_mla_warmup import (
+    _sparse_mla_refine_tokens,
+)
+
+
+@pytest.mark.parametrize(
+    ("capture_sizes", "expected"),
+    [
+        # Only buckets the decode kernel can serve (<= 64) qualify; the list
+        # comes back sorted and deduplicated.
+        ([128, 64, 1, 32, 32, 0, 65, -4], (1, 32, 64)),
+        ([], ()),
+        (None, ()),
+    ],
+)
+def test_sparse_mla_refine_tokens(capture_sizes, expected):
+    worker = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            compilation_config=SimpleNamespace(cudagraph_capture_sizes=capture_sizes)
+        )
+    )
+    assert _sparse_mla_refine_tokens(worker) == expected

--- a/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
+++ b/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
@@ -41,6 +41,22 @@ _FLASHINFER_SM120_SPARSE_MLA_DECODE_LABELS = {
 
 _SPARSE_MLA_MIXED_WARMUP_TOKENS = 16
 
+# Capture buckets the sparse-MLA decode kernel can serve: the crossover probe
+# grid caps at 64, so larger buckets never route to the decode form.
+_SPARSE_MLA_REFINE_TOKEN_CAP = 64
+
+
+def _sparse_mla_refine_tokens(worker: "Worker") -> tuple[int, ...]:
+    """CUDA-graph capture sizes as decode-kernel token counts (spec-decode
+    sizes are pre-aligned to the decode query length by vLLM). Each bucket's
+    tuning-mode decode-form call refines the model's cpb pick for exactly
+    that shape (flashinfer `_sparse_mla_sm120_cpb.refine_cpb`)."""
+    sizes = (
+        getattr(worker.vllm_config.compilation_config, "cudagraph_capture_sizes", None)
+        or ()
+    )
+    return tuple(sorted({s for s in sizes if 0 < s <= _SPARSE_MLA_REFINE_TOKEN_CAP}))
+
 
 def _attention_backend_name(backend: object) -> str | None:
     get_name = getattr(backend, "get_name", None)
@@ -86,8 +102,13 @@ def _run_flashinfer_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
     allowed_backends: frozenset[str],
+    refine_tokens: tuple[int, ...] = (),
 ) -> bool:
-    """Autotune FlashInfer's SM120 sparse-MLA decode path."""
+    """Autotune FlashInfer's SM120 sparse-MLA decode path.
+
+    The mixed-batch run at ``num_tokens`` triggers the constants/crossover
+    calibrations; the per-bucket uniform-decode runs at ``refine_tokens``
+    (CUDA-graph capture sizes <= 64) then refine the cpb pick per shape."""
     runner = worker.model_runner
     log_label = _flashinfer_sparse_mla_decode_label(runner, allowed_backends)
     if log_label is None:
@@ -127,22 +148,33 @@ def _run_flashinfer_sparse_mla_decode_autotune(
             cache_path,
         )
 
+    def _refine_bucket_runs() -> None:
+        for bucket in refine_tokens:
+            runner._dummy_run(
+                num_tokens=bucket,
+                skip_eplb=True,
+                is_profile=True,
+                force_attention=True,
+                uniform_decode=True,
+            )
+
     with torch.inference_mode():
         warmup_executed = True
         if is_leader:
-            if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
-                v2_runner = cast("V2GPUModelRunner", runner)
-                warmup_executed = run_mixed_prefill_decode_warmup(
-                    v2_runner,
-                    worker.execute_model,
-                    worker.sample_tokens,
-                    num_tokens,
-                    mixed_step_context=flashinfer_autotune(True, cache=str(cache_path)),
-                    req_id_prefix="_sparse_mla_v2_warmup",
-                )
-            else:
-                with flashinfer_autotune(True, cache=str(cache_path)):
+            with flashinfer_autotune(True, cache=str(cache_path)):
+                if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
+                    v2_runner = cast("V2GPUModelRunner", runner)
+                    warmup_executed = run_mixed_prefill_decode_warmup(
+                        v2_runner,
+                        worker.execute_model,
+                        worker.sample_tokens,
+                        num_tokens,
+                        req_id_prefix="_sparse_mla_v2_warmup",
+                    )
+                else:
                     runner._dummy_run(**dummy_run_kwargs)
+                if warmup_executed:
+                    _refine_bucket_runs()
         else:
             if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
                 v2_runner = cast("V2GPUModelRunner", runner)
@@ -155,6 +187,8 @@ def _run_flashinfer_sparse_mla_decode_autotune(
                 )
             else:
                 runner._dummy_run(**dummy_run_kwargs)
+            if warmup_executed:
+                _refine_bucket_runs()
 
     if not warmup_executed:
         return False
@@ -191,18 +225,20 @@ def _run_flashinfer_sparse_mla_decode_autotune(
 def _flashinfer_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
+    refine_tokens: tuple[int, ...] = (),
 ) -> bool:
     return _run_flashinfer_sparse_mla_decode_autotune(
-        worker, num_tokens, _FLASHINFER_MLA_SPARSE_BACKENDS
+        worker, num_tokens, _FLASHINFER_MLA_SPARSE_BACKENDS, refine_tokens
     )
 
 
 def _deepseek_v4_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
+    refine_tokens: tuple[int, ...] = (),
 ) -> bool:
     return _run_flashinfer_sparse_mla_decode_autotune(
-        worker, num_tokens, _DEEPSEEK_V4_FLASHINFER_MLA_SPARSE_BACKENDS
+        worker, num_tokens, _DEEPSEEK_V4_FLASHINFER_MLA_SPARSE_BACKENDS, refine_tokens
     )
 
 
@@ -216,7 +252,9 @@ def flashinfer_sparse_mla_decode_autotune_warmup(worker: "Worker") -> None:
     mixed_tokens = _clamp_warmup_tokens(_SPARSE_MLA_MIXED_WARMUP_TOKENS, max_tokens)
     if mixed_tokens <= 0:
         return
-    _flashinfer_sparse_mla_decode_autotune(worker, mixed_tokens)
+    _flashinfer_sparse_mla_decode_autotune(
+        worker, mixed_tokens, _sparse_mla_refine_tokens(worker)
+    )
 
 
 def deepseek_v4_sparse_mla_attention_warmup(worker: "Worker") -> None:
@@ -234,7 +272,9 @@ def deepseek_v4_sparse_mla_attention_warmup(worker: "Worker") -> None:
         "Warming up DeepSeek V4 sparse MLA attention for mixed tokens=%s.",
         mixed_tokens,
     )
-    mixed_warmup_done = _deepseek_v4_sparse_mla_decode_autotune(worker, mixed_tokens)
+    mixed_warmup_done = _deepseek_v4_sparse_mla_decode_autotune(
+        worker, mixed_tokens, _sparse_mla_refine_tokens(worker)
+    )
     if not mixed_warmup_done:
         if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
             v2_runner = cast("V2GPUModelRunner", runner)

--- a/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
+++ b/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
@@ -106,9 +106,12 @@ def _run_flashinfer_sparse_mla_decode_autotune(
 ) -> bool:
     """Autotune FlashInfer's SM120 sparse-MLA decode path.
 
-    The mixed-batch run at ``num_tokens`` triggers the constants/crossover
-    calibrations; the per-bucket uniform-decode runs at ``refine_tokens``
-    (CUDA-graph capture sizes <= 64) then refine the cpb pick per shape."""
+    Every rank enters the tuning context: the calibrations and refinements
+    measure the local device and persist under its own device key, so a rank
+    that skips tuning keeps the heuristic picks. The mixed-batch run at
+    ``num_tokens`` triggers the constants/crossover calibrations; the
+    per-bucket uniform-decode runs at ``refine_tokens`` (CUDA-graph capture
+    sizes <= 64) then refine the cpb pick per shape."""
     runner = worker.model_runner
     log_label = _flashinfer_sparse_mla_decode_label(runner, allowed_backends)
     if log_label is None:
@@ -119,7 +122,7 @@ def _run_flashinfer_sparse_mla_decode_autotune(
         return False
 
     try:
-        from flashinfer.autotuner import AutoTuner
+        from flashinfer.autotuner import AutoTuner, set_autotune_process_group
     except ImportError:
         logger.warning(
             "Skipping FlashInfer SM120 sparse MLA decode autotune because "
@@ -158,24 +161,15 @@ def _run_flashinfer_sparse_mla_decode_autotune(
                 uniform_decode=True,
             )
 
-    with torch.inference_mode():
-        warmup_executed = True
-        if is_leader:
-            with flashinfer_autotune(True, cache=str(cache_path)):
-                if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
-                    v2_runner = cast("V2GPUModelRunner", runner)
-                    warmup_executed = run_mixed_prefill_decode_warmup(
-                        v2_runner,
-                        worker.execute_model,
-                        worker.sample_tokens,
-                        num_tokens,
-                        req_id_prefix="_sparse_mla_v2_warmup",
-                    )
-                else:
-                    runner._dummy_run(**dummy_run_kwargs)
-                if warmup_executed:
-                    _refine_bucket_runs()
-        else:
+    # The process group keeps any tunable op hit during these runs consistent
+    # across ranks, same as the general FlashInfer autotune pass.
+    set_autotune_process_group(world.cpu_group if world.world_size > 1 else None)
+    try:
+        with (
+            torch.inference_mode(),
+            flashinfer_autotune(True, cache=str(cache_path)),
+        ):
+            warmup_executed = True
             if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
                 v2_runner = cast("V2GPUModelRunner", runner)
                 warmup_executed = run_mixed_prefill_decode_warmup(
@@ -189,6 +183,8 @@ def _run_flashinfer_sparse_mla_decode_autotune(
                 runner._dummy_run(**dummy_run_kwargs)
             if warmup_executed:
                 _refine_bucket_runs()
+    finally:
+        set_autotune_process_group(None)
 
     if not warmup_executed:
         return False

--- a/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
+++ b/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
@@ -55,7 +55,11 @@ def _sparse_mla_refine_tokens(worker: "Worker") -> tuple[int, ...]:
         getattr(worker.vllm_config.compilation_config, "cudagraph_capture_sizes", None)
         or ()
     )
-    return tuple(sorted({s for s in sizes if 0 < s <= _SPARSE_MLA_REFINE_TOKEN_CAP}))
+    # A uniform-decode dummy run at bucket s schedules s requests; buckets past
+    # max_num_reqs cannot be formed.
+    max_reqs = getattr(worker.model_runner, "max_num_reqs", 0) or 0
+    cap = min(_SPARSE_MLA_REFINE_TOKEN_CAP, max_reqs)
+    return tuple(sorted({s for s in sizes if 0 < s <= cap}))
 
 
 def _attention_backend_name(backend: object) -> str | None:


### PR DESCRIPTION
## Purpose

FlashInfer's SM120 sparse-MLA decode path (flashinfer-ai/flashinfer#4802) picks `chunks_per_block` from a calibrated analytical model and refines the pick for the exact shape being warmed whenever a tuning-mode call reaches it (`refine_cpb`, persisted in the FlashInfer autotune cache). vLLM's sparse-MLA warmup previously exercised only the mixed batch (a T=1 decode plus one short prefill chunk), so the CUDA-graph capture buckets that production actually replays were never measured. Offline sweeps (DRAM-cold protocol) show the unrefined model pick costs up to 1.07x kernel time on dsv4 T=24 and 1.35x on dots3_swa T=32 — both real capture sizes.

This PR runs one uniform-decode dummy run per capture bucket <= 64 inside the tuning context **on every rank**: the FlashInfer calibration and refinement measure the local device and persist under its own device key, so a rank that skips tuning keeps heuristic picks (and, depending on whether the general autotune pass happens to produce a decode-routed shape, may never calibrate at all). The autotune process group is set so any tunable op hit during these runs stays consistent across ranks, matching the general autotune pass. Wall clock is unchanged — the per-device measurements run in parallel on each GPU.

## Dependency

No new FlashInfer API is called. With a FlashInfer build predating #4802 the extra runs are plain warmup; measured picks require a FlashInfer release containing #4802.

## Relationship to #53605

Same root theme — the sparse-MLA warmup under-covers shapes that production reaches — on different axes and against different FlashInfer mechanisms:

- #53605 covers the `extra_topk` **width** axis (C128A 256/384) for the per-shape AutoTuner tactic cache (`SparseMlaDecodeV3Runner tactic=-1` fallbacks). That mechanism exists in FlashInfer <= 0.6.18. flashinfer-ai/flashinfer#4802 removes it on the SM120 path: topk/extra_topk are runtime kernel arguments and cpb comes from the calibrated model, so width-keyed tactic misses no longer exist there. This PR covers the capture-bucket **T** axis for the new refinement mechanism; on FlashInfer <= 0.6.18 the bucket runs additionally pre-warm the legacy per-shape tactic entries at each bucket.
- #49072 forwards `skip_ops` into this warmup's tuning contexts — orthogonal and composes: a `sparse_mla_sm120` skip also gates this refinement loop, per the FlashInfer-side autotuner contract.

## Test evidence

- New CPU unit test: `pytest tests/model_executor/test_flashinfer_sparse_mla_warmup.py` (bucket selection: cap at 64, dedup/sort, empty/None).
- e2e, RTX PRO 6000 (SM120), DeepSeek-V4-Flash TP2 + `FLASHINFER_MLA_SPARSE_DSV4` + b12x, FlashInfer with #4802: 8K/1K serving sweep C1-C64 within +/-2% of the pre-change baseline (256/256 completed, 0 failed); GSM8K strict-match 0.9560. On this model the refined picks coincide with the model's, so e2e is unchanged by design; the gain lands on shapes with real pick error (above).
- Startup cost: the sparse-MLA warmup window measured ~7 s on a cold tuning cache with both TP2 ranks calibrating + refining in parallel (previously non-leaders were calibrated incidentally inside the general autotune pass, ~45 s into a shared window); results persist in the FlashInfer autotune cache across restarts.
- Multi-rank evidence: after the change both TP2 ranks persist the full per-bucket override set (previously the leader had 8 entries while the non-leader had exactly one, from an incidental shape in the general autotune pass).

Why not tune on the leader and share: the measurements are per-GPU-parallel anyway, so sharing saves no wall clock; the tuning cache is device-keyed by design (same-name GPUs can still differ), and a share path would add a silent-fallback failure mode. Per-rank tuning reuses the trigger path both ranks already exercise today.

This change was developed with AI assistance; I reviewed every changed line and ran the tests above.
