### PR TITLE
[Bugfix][MoE] Warm up the Triton fused MoE GEMMs

### DIFF
--- a/tests/model_executor/test_triton_moe_warmup.py
+++ b/tests/model_executor/test_triton_moe_warmup.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExpert
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.warmup.triton_moe_warmup import (
     _naive_block_assignment_max_m,
+    _sample_local_expert_ids,
     _triton_experts,
     _warmup_m_values,
     triton_moe_warmup,
@@ -53,21 +54,81 @@ def _worker(modules: list[object], *, is_pooling_model: bool = False):
 def test_warmup_m_values_end_at_the_token_budget() -> None:
     # The budget must be warmed even when it is off-grid, and nothing may run
     # past it.
-    assert max(_warmup_m_values(40, 8)) == 40
-    assert 40 in _warmup_m_values(40, 8)
-    assert _warmup_m_values(1, 0) == [1]
+    assert max(_warmup_m_values(40, 8, 8)) == 40
+    assert 40 in _warmup_m_values(40, 8, 8)
+    # A budget of one token leaves no room for a companion.
+    assert _warmup_m_values(1, 0, 8) == [1]
 
 
-def test_warmup_m_values_pair_every_tile_config_with_both_parities() -> None:
-    # EM and num_valid_tokens scale with M, and Triton keys their
-    # 16-divisibility separately. Every M that can select a tile config needs
-    # an odd and an even representative, or half the variants stay uncompiled.
-    values = _warmup_m_values(4096, naive_max_m=8)
-    for m in (1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 256, 512, 1024, 1536, 2048):
-        assert m in values, m
-        assert (m + 1) in values, m + 1
-    # Both sides of the naive block assignment cutoff, with both parities.
-    assert {8, 9, 10}.issubset(values)
+def test_warmup_m_values_cover_both_divisibility_classes() -> None:
+    # num_valid_tokens is M * top_k and Triton keys its 16-divisibility
+    # separately, so every M that can select a tile config needs a divisible
+    # and a non-divisible representative. Pairing on M parity alone is not
+    # enough: at top_k=1 neither 24 nor 25 is divisible.
+    for top_k in (1, 2, 3, 5, 8):
+        values = _warmup_m_values(4096, naive_max_m=8, top_k=top_k)
+        for m in (1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 256, 512, 1024, 2048):
+            assert m in values, (top_k, m)
+            warmed = [v for v in values if abs(v - m) <= 16]
+            assert any((v * top_k) % 16 == 0 for v in warmed), (top_k, m)
+            assert any((v * top_k) % 16 != 0 for v in warmed), (top_k, m)
+
+
+def test_warmup_m_values_cover_the_naive_block_assignment_cutoff() -> None:
+    # The tile config just above the cutoff is shared by too few grid entries
+    # to be reached by the grid alone.
+    values = _warmup_m_values(4096, naive_max_m=8, top_k=8)
+    assert {8, 9}.issubset(values)
+
+
+def test_warmup_m_values_fall_back_downward_at_the_budget() -> None:
+    # At the token budget there is no larger neighbour, so the companion has
+    # to come from below or the non-divisible variant is never compiled.
+    values = _warmup_m_values(4096, naive_max_m=8, top_k=8)
+    assert 4096 in values
+    assert 4095 in values
+
+
+def test_warmup_m_values_when_no_second_divisibility_class_exists() -> None:
+    # With top_k a multiple of 16, M * top_k is always divisible; there is no
+    # second variant to warm and the search must not invent one.
+    values = _warmup_m_values(64, naive_max_m=4, top_k=16)
+    assert all((m * 16) % 16 == 0 for m in values)
+    assert values == sorted(set(values))
+
+
+def test_sampled_expert_ids_are_global_when_not_expert_parallel() -> None:
+    ids = _sample_local_expert_ids((16, 4), 8, None, torch.device("cpu"))
+    assert ids.shape == (16, 4)
+    assert ids.dtype == torch.int32
+    assert int(ids.min()) >= 0
+    assert int(ids.max()) < 8
+
+
+def test_sampled_expert_ids_stay_on_this_rank_under_expert_parallelism() -> None:
+    # topk_ids carries global ids; a rank whose slice does not start at 0 would
+    # warm nothing if the local id range were sampled instead, because
+    # moe_align_block_size drops ids the map sends to -1.
+    global_num_experts, local_num_experts, start = 256, 32, 32  # rank 1, linear
+    expert_map = torch.full((global_num_experts,), -1, dtype=torch.int32)
+    expert_map[start : start + local_num_experts] = torch.arange(
+        local_num_experts, dtype=torch.int32
+    )
+
+    ids = _sample_local_expert_ids(
+        (64, 8), global_num_experts, expert_map, torch.device("cpu")
+    )
+
+    assert ids.dtype == torch.int32
+    assert bool((expert_map[ids.long()] >= 0).all())
+    assert int(ids.min()) >= start
+    assert int(ids.max()) < start + local_num_experts
+
+
+def test_sampled_expert_ids_tolerate_a_rank_owning_nothing() -> None:
+    expert_map = torch.full((16,), -1, dtype=torch.int32)
+    ids = _sample_local_expert_ids((4, 2), 16, expert_map, torch.device("cpu"))
+    assert ids.shape == (4, 2)
 
 
 def test_naive_block_assignment_cutoff_matches_the_kernel_condition() -> None:

--- a/tests/model_executor/test_triton_moe_warmup.py
+++ b/tests/model_executor/test_triton_moe_warmup.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.model_executor.warmup.triton_moe_warmup as warmup_mod
+from vllm.model_executor.layers.fused_moe.experts.triton_deep_gemm_moe import (
+    TritonOrDeepGemmExperts,
+)
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+from vllm.model_executor.warmup.triton_moe_warmup import (
+    _naive_block_assignment_max_m,
+    _triton_experts,
+    _warmup_m_values,
+    triton_moe_warmup,
+)
+
+
+def _routed_experts(experts: object, n: int = 4) -> SimpleNamespace:
+    return SimpleNamespace(
+        quant_method=SimpleNamespace(
+            moe_kernel=SimpleNamespace(impl=SimpleNamespace(fused_experts=experts))
+        ),
+        w13_weight=torch.empty((4, n, 8)),
+        w2_weight=torch.empty((4, 8, n // 2)),
+    )
+
+
+def _moe_runner(routed_experts: object) -> MoERunner:
+    # MoERunner is an nn.Module whose __init__ builds a full MoE layer, and
+    # `_quant_method` is a property forwarding to routed_experts; populate
+    # __dict__ directly to keep the isinstance checks under test real.
+    runner = object.__new__(MoERunner)
+    object.__setattr__(runner, "__dict__", {"routed_experts": routed_experts})
+    return runner
+
+
+def _triton_experts_instance() -> TritonExperts:
+    return object.__new__(TritonExperts)
+
+
+def _worker(modules: list[object], *, is_pooling_model: bool = False):
+    return SimpleNamespace(
+        get_model=lambda: SimpleNamespace(modules=lambda: iter(modules)),
+        model_runner=SimpleNamespace(is_pooling_model=is_pooling_model),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=64),
+    )
+
+
+def test_warmup_m_values_end_at_the_token_budget() -> None:
+    # The budget must be warmed even when it is off-grid, and nothing may run
+    # past it.
+    assert max(_warmup_m_values(40, 8)) == 40
+    assert 40 in _warmup_m_values(40, 8)
+    assert _warmup_m_values(1, 0) == [1]
+
+
+def test_warmup_m_values_pair_every_tile_config_with_both_parities() -> None:
+    # EM and num_valid_tokens scale with M, and Triton keys their
+    # 16-divisibility separately. Every M that can select a tile config needs
+    # an odd and an even representative, or half the variants stay uncompiled.
+    values = _warmup_m_values(4096, naive_max_m=8)
+    for m in (1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 256, 512, 1024, 1536, 2048):
+        assert m in values, m
+        assert (m + 1) in values, m + 1
+    # Both sides of the naive block assignment cutoff, with both parities.
+    assert {8, 9, 10}.issubset(values)
+
+
+def test_naive_block_assignment_cutoff_matches_the_kernel_condition() -> None:
+    # `num_tokens * top_k * 4 <= global_num_experts`, and expert parallelism
+    # disables the naive path entirely.
+    assert _naive_block_assignment_max_m(256, 8, None) == 8
+    assert _naive_block_assignment_max_m(64, 8, None) == 2
+    assert _naive_block_assignment_max_m(256, 8, torch.empty(256)) == 0
+
+
+def test_triton_experts_found_through_deepgemm_fallback() -> None:
+    triton = _triton_experts_instance()
+    fallback = object.__new__(TritonOrDeepGemmExperts)
+    object.__setattr__(fallback, "__dict__", {"fallback_experts": triton})
+
+    assert _triton_experts(_moe_runner(_routed_experts(triton))) is triton
+    assert _triton_experts(_moe_runner(_routed_experts(fallback))) is triton
+
+
+def test_triton_experts_skips_layers_that_never_reach_triton() -> None:
+    # A non-MoE module, a MoE layer whose kernel is not built yet, and a MoE
+    # layer on a non-Triton expert implementation are all skipped.
+    assert _triton_experts(SimpleNamespace()) is None
+
+    unbuilt = _moe_runner(
+        SimpleNamespace(quant_method=SimpleNamespace(moe_kernel=None))
+    )
+    assert _triton_experts(unbuilt) is None
+
+    assert _triton_experts(_moe_runner(_routed_experts(object()))) is None
+
+
+def test_warmup_runs_once_per_weight_shape(monkeypatch) -> None:
+    triton = _triton_experts_instance()
+    modules: list[object] = [
+        _moe_runner(_routed_experts(triton, n=4)),
+        _moe_runner(_routed_experts(triton, n=4)),
+        _moe_runner(_routed_experts(triton, n=8)),
+        SimpleNamespace(),
+    ]
+
+    warmed: list[int] = []
+    synchronized: list[bool] = []
+    monkeypatch.setattr(
+        warmup_mod, "current_platform", SimpleNamespace(is_cuda_alike=lambda: True)
+    )
+    monkeypatch.setattr(
+        warmup_mod,
+        "_warmup_expert_gemms",
+        lambda experts, layer, max_tokens: warmed.append(layer.w13_weight.size(1)),
+    )
+    monkeypatch.setattr(
+        warmup_mod.torch.accelerator, "synchronize", lambda: synchronized.append(True)
+    )
+
+    triton_moe_warmup(_worker(modules))
+
+    assert warmed == [4, 8]
+    assert synchronized == [True]
+
+
+def test_warmup_skipped_for_pooling_models_and_non_cuda(monkeypatch) -> None:
+    runner = _moe_runner(_routed_experts(_triton_experts_instance()))
+    calls: list[object] = []
+    monkeypatch.setattr(
+        warmup_mod, "_warmup_expert_gemms", lambda *args: calls.append(args)
+    )
+
+    monkeypatch.setattr(
+        warmup_mod, "current_platform", SimpleNamespace(is_cuda_alike=lambda: False)
+    )
+    triton_moe_warmup(_worker([runner]))
+
+    monkeypatch.setattr(
+        warmup_mod, "current_platform", SimpleNamespace(is_cuda_alike=lambda: True)
+    )
+    triton_moe_warmup(_worker([runner], is_pooling_model=True))
+
+    assert calls == []
+
+
+def test_warmup_stops_on_out_of_memory(monkeypatch) -> None:
+    triton = _triton_experts_instance()
+    modules: list[object] = [
+        _moe_runner(_routed_experts(triton, n=4)),
+        _moe_runner(_routed_experts(triton, n=8)),
+    ]
+    attempts: list[int] = []
+
+    def raise_oom(experts, layer, max_tokens):
+        attempts.append(layer.w13_weight.size(1))
+        raise torch.cuda.OutOfMemoryError("out of memory")
+
+    monkeypatch.setattr(
+        warmup_mod, "current_platform", SimpleNamespace(is_cuda_alike=lambda: True)
+    )
+    monkeypatch.setattr(warmup_mod, "_warmup_expert_gemms", raise_oom)
+    monkeypatch.setattr(warmup_mod.torch.accelerator, "synchronize", lambda: None)
+
+    # OOM must not fail startup, and must not keep trying larger shapes.
+    triton_moe_warmup(_worker(modules))
+
+    assert attempts == [4]

--- a/tests/model_executor/test_triton_moe_warmup.py
+++ b/tests/model_executor/test_triton_moe_warmup.py
@@ -125,10 +125,12 @@ def test_sampled_expert_ids_stay_on_this_rank_under_expert_parallelism() -> None
     assert int(ids.max()) < start + local_num_experts
 
 
-def test_sampled_expert_ids_tolerate_a_rank_owning_nothing() -> None:
+def test_no_sampled_ids_when_the_rank_owns_no_expert() -> None:
+    # Returning a tensor here would hand uninitialised ids to `apply` as global
+    # expert ids, which can index expert_map out of bounds; the caller has to
+    # skip the warmup instead.
     expert_map = torch.full((16,), -1, dtype=torch.int32)
-    ids = _sample_local_expert_ids((4, 2), 16, expert_map, torch.device("cpu"))
-    assert ids.shape == (4, 2)
+    assert _sample_local_expert_ids((4, 2), 16, expert_map, torch.device("cpu")) is None
 
 
 def test_naive_block_assignment_cutoff_matches_the_kernel_condition() -> None:

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -44,6 +44,7 @@ from vllm.model_executor.warmup.replayssm_warmup import (
 from vllm.model_executor.warmup.spec_decode_rejection_warmup import (
     spec_decode_rejection_warmup,
 )
+from vllm.model_executor.warmup.triton_moe_warmup import triton_moe_warmup
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import is_deep_gemm_supported
 from vllm.utils.flashinfer import has_flashinfer
@@ -168,6 +169,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
         fa4_cutedsl_warmup(worker)
         spec_decode_rejection_warmup(worker)
         qwen4_exp_qsa_triton_warmup(worker)
+        triton_moe_warmup(worker)
 
     if current_platform.has_device_capability(90):
         _warmup_ll_bf16_router_gemm(worker.get_model())

--- a/vllm/model_executor/warmup/triton_moe_warmup.py
+++ b/vllm/model_executor/warmup/triton_moe_warmup.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Warm up the Triton fused MoE expert GEMMs before serving.
+
+``fused_moe_kernel`` is the expert GEMM whenever DeepGEMM declines the shape.
+The most common case is ``N <= 512``, which every shard of a model with a
+small ``moe_intermediate_size`` hits at high TP -- GLM-5.2-FP8 at TP=8 gives
+``N=256``, so its MoE runs on Triton for every request.
+
+Startup never compiles every variant that real batches select. Two things
+vary with the token count ``M``: the tile config, and the 16-divisibility of
+``EM`` and ``num_valid_tokens``, which Triton specializes on. Profiling and
+CUDA graph capture only reach a few of the combinations, so the first request
+landing on an uncompiled one pays the Triton JIT mid-serving.
+
+This walks the ``M`` values that can select a distinct tile config, each
+paired with a neighbour of opposite parity so both divisibility variants get
+compiled, and runs the expert GEMMs once for every value.
+"""
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+    from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+    from vllm.v1.worker.gpu_worker import Worker
+
+logger = init_logger(__name__)
+
+# M values that can select a distinct tile config: the union of the tuned
+# config-file keys and the `get_default_config` breakpoints. Larger batches
+# reuse the largest entry's config.
+_WARMUP_M_GRID = (
+    1,
+    2,
+    4,
+    8,
+    16,
+    24,
+    32,
+    48,
+    64,
+    96,
+    128,
+    256,
+    512,
+    1024,
+    1536,
+    2048,
+    3072,
+    4096,
+)
+
+
+def _triton_experts(module: torch.nn.Module) -> "TritonExperts | None":
+    """Return the TritonExperts instance this MoE layer can dispatch to."""
+    from vllm.model_executor.layers.fused_moe.experts.fallback import FallbackExperts
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+    from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+
+    if not isinstance(module, MoERunner):
+        return None
+
+    moe_kernel = getattr(module._quant_method, "moe_kernel", None)
+    experts = getattr(getattr(moe_kernel, "impl", None), "fused_experts", None)
+    if isinstance(experts, FallbackExperts):
+        experts = experts.fallback_experts
+    return experts if isinstance(experts, TritonExperts) else None
+
+
+def _naive_block_assignment_max_m(
+    global_num_experts: int,
+    top_k: int,
+    expert_map: torch.Tensor | None,
+) -> int:
+    """Largest M that still takes the naive block assignment path.
+
+    Mirrors the condition in `_prepare_expert_assignment`, which is a
+    ``naive_block_assignment`` constexpr to the kernel.
+    """
+    if expert_map is not None:
+        return 0
+    return global_num_experts // (top_k * 4)
+
+
+def _warmup_m_values(max_tokens: int, naive_max_m: int) -> list[int]:
+    values: set[int] = set()
+    for m in _WARMUP_M_GRID:
+        if m > max_tokens:
+            break
+        values.add(m)
+        # A neighbour of opposite parity keeps the same tile config but flips
+        # the 16-divisibility of EM and num_valid_tokens, which is a separate
+        # Triton compile key. Config-file keys are almost all even, so without
+        # this the non-divisible variant never gets compiled.
+        values.add(min(m + 1, max_tokens))
+    # The tile config just above the naive cutoff is shared by too few grid
+    # entries to be guaranteed both parities, so pin them explicitly.
+    values.update(m for m in (naive_max_m + 1, naive_max_m + 2) if 0 < m <= max_tokens)
+    values.add(max_tokens)
+    if max_tokens > 1:
+        values.add(max_tokens - 1)
+    return sorted(values)
+
+
+def _warmup_expert_gemms(
+    experts: "TritonExperts",
+    layer: "RoutedExperts",
+    max_tokens: int,
+) -> None:
+    from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
+
+    w13 = layer.w13_weight
+    w2 = layer.w2_weight
+    top_k = layer.top_k
+    num_experts = w13.size(0)
+    hidden_size = w2.size(1)
+    device = w13.device
+    act_dtype = layer.params_dtype
+    quant_config = experts.quant_config
+
+    m_values = _warmup_m_values(
+        max_tokens,
+        _naive_block_assignment_max_m(
+            layer.global_num_experts, top_k, layer.expert_map
+        ),
+    )
+    max_m = m_values[-1]
+
+    # Allocate for the largest M once and slice; `apply` resizes the
+    # workspaces it is given, so an oversized buffer is fine.
+    hidden_states = torch.zeros((max_m, hidden_size), device=device, dtype=act_dtype)
+    # Spread tokens over all experts so every expert block is exercised and
+    # the token-to-block assignment matches a realistic batch.
+    topk_ids = torch.randint(
+        0, num_experts, (max_m, top_k), device=device, dtype=torch.int32
+    )
+    topk_weights = torch.ones((max_m, top_k), device=device, dtype=torch.float32)
+    workspace13_shape, workspace2_shape, output_shape = experts.workspace_shapes(
+        max_m,
+        w13.size(1) // 2,
+        hidden_size,
+        top_k,
+        layer.global_num_experts,
+        layer.local_num_experts,
+        None,
+        layer.activation,
+    )
+    workspace_dtype = experts.workspace_dtype(act_dtype)
+    workspace13 = torch.zeros(workspace13_shape, device=device, dtype=workspace_dtype)
+    workspace2 = torch.zeros(workspace2_shape, device=device, dtype=workspace_dtype)
+    output = torch.zeros(output_shape, device=device, dtype=act_dtype)
+
+    for num_tokens in m_values:
+        # Quantize exactly like the prepare step would, so the activation
+        # dtype and scale layout reaching the kernel match serving.
+        a1q, a1q_scale = moe_kernel_quantize_input(
+            hidden_states[:num_tokens],
+            quant_config.a1_scale,
+            quant_config.quant_dtype,
+            quant_config.per_act_token_quant,
+            quant_config.block_shape,
+            quantization_emulation=experts.quantization_emulation,
+        )
+        experts.apply(
+            output=output[:num_tokens],
+            hidden_states=a1q,
+            w1=w13,
+            w2=w2,
+            topk_weights=topk_weights[:num_tokens],
+            topk_ids=topk_ids[:num_tokens],
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            a1q_scale=a1q_scale,
+            a2_scale=quant_config.a2_scale,
+            workspace13=workspace13,
+            workspace2=workspace2,
+            expert_tokens_meta=None,
+            apply_router_weight_on_input=False,
+        )
+
+
+def triton_moe_warmup(worker: "Worker") -> None:
+    """Compile the Triton fused MoE GEMMs for the tile configs used at runtime."""
+    if not current_platform.is_cuda_alike():
+        return
+    if worker.model_runner.is_pooling_model:
+        return
+
+    # Above the largest grid entry the tile config no longer changes, so
+    # there is nothing to gain from warming the full token budget.
+    max_tokens = min(worker.scheduler_config.max_num_batched_tokens, _WARMUP_M_GRID[-1])
+    if max_tokens <= 0:
+        return
+
+    # All MoE layers of a model share weight shapes, so one representative
+    # per (w13, w2) shape pair covers every layer.
+    layers: dict[tuple[torch.Size, torch.Size], tuple] = {}
+    for module in worker.get_model().modules():
+        experts = _triton_experts(module)
+        if experts is None:
+            continue
+        layer = module.routed_experts
+        layers.setdefault(
+            (layer.w13_weight.shape, layer.w2_weight.shape), (experts, layer)
+        )
+
+    if not layers:
+        return
+
+    logger.info_once(
+        "Warming up Triton fused MoE kernels for %d weight shape(s).", len(layers)
+    )
+    with torch.inference_mode():
+        for experts, layer in layers.values():
+            try:
+                _warmup_expert_gemms(experts, layer, max_tokens)
+            except torch.cuda.OutOfMemoryError:
+                logger.warning(
+                    "Skipping Triton fused MoE warmup: out of memory while "
+                    "building warmup activations."
+                )
+                break
+        torch.accelerator.synchronize()

--- a/vllm/model_executor/warmup/triton_moe_warmup.py
+++ b/vllm/model_executor/warmup/triton_moe_warmup.py
@@ -88,24 +88,74 @@ def _naive_block_assignment_max_m(
     return global_num_experts // (top_k * 4)
 
 
-def _warmup_m_values(max_tokens: int, naive_max_m: int) -> list[int]:
+def _divisibility_companion(m: int, top_k: int, max_tokens: int) -> int | None:
+    """An M near ``m`` whose ``num_valid_tokens`` flips 16-divisibility.
+
+    ``num_valid_tokens`` is ``M * top_k``, and Triton keys its 16-divisibility
+    separately, so a tile config needs both a divisible and a non-divisible
+    representative. ``m + 1`` does not guarantee that: with ``top_k=1`` neither
+    24 nor 25 is divisible. Scan the 16 neighbours that span every residue,
+    preferring larger M but falling back to smaller ones at the token budget.
+
+    Returns ``None`` when no neighbour flips the predicate, which happens when
+    ``top_k`` is a multiple of 16 -- then ``M * top_k`` is always divisible and
+    the non-divisible variant does not exist.
+    """
+    want_divisible = (m * top_k) % 16 != 0
+    candidates = list(range(m + 1, m + 16 + 1)) + list(range(m - 1, m - 16 - 1, -1))
+    for candidate in candidates:
+        if not 0 < candidate <= max_tokens:
+            continue
+        if (((candidate * top_k) % 16) == 0) == want_divisible:
+            return candidate
+    return None
+
+
+def _warmup_m_values(max_tokens: int, naive_max_m: int, top_k: int) -> list[int]:
     values: set[int] = set()
+
+    def add_with_companion(m: int) -> None:
+        if not 0 < m <= max_tokens:
+            return
+        values.add(m)
+        companion = _divisibility_companion(m, top_k, max_tokens)
+        if companion is not None:
+            values.add(companion)
+
     for m in _WARMUP_M_GRID:
         if m > max_tokens:
             break
-        values.add(m)
-        # A neighbour of opposite parity keeps the same tile config but flips
-        # the 16-divisibility of EM and num_valid_tokens, which is a separate
-        # Triton compile key. Config-file keys are almost all even, so without
-        # this the non-divisible variant never gets compiled.
-        values.add(min(m + 1, max_tokens))
+        add_with_companion(m)
     # The tile config just above the naive cutoff is shared by too few grid
-    # entries to be guaranteed both parities, so pin them explicitly.
-    values.update(m for m in (naive_max_m + 1, naive_max_m + 2) if 0 < m <= max_tokens)
-    values.add(max_tokens)
-    if max_tokens > 1:
-        values.add(max_tokens - 1)
+    # entries to be guaranteed both divisibility classes, so pin it explicitly.
+    add_with_companion(naive_max_m + 1)
+    add_with_companion(max_tokens)
     return sorted(values)
+
+
+def _sample_local_expert_ids(
+    shape: tuple[int, int],
+    global_num_experts: int,
+    expert_map: torch.Tensor | None,
+    device: torch.device,
+) -> torch.Tensor:
+    """Sample routed expert ids that this rank actually owns.
+
+    ``topk_ids`` carries global ids. Under expert parallelism ``expert_map``
+    maps a global id to a local one, or to ``-1`` when the expert lives on
+    another rank, and ``moe_align_block_size`` drops the invalid ones before the
+    GEMMs. Sampling the local id range would therefore warm nothing on every
+    rank whose slice does not start at 0, so draw from the owned global ids.
+    """
+    if expert_map is None:
+        return torch.randint(
+            0, global_num_experts, shape, device=device, dtype=torch.int32
+        )
+    owned = torch.nonzero(expert_map >= 0, as_tuple=True)[0]
+    if owned.numel() == 0:
+        return torch.empty(shape, device=device, dtype=torch.int32)
+    picks = torch.randint(0, owned.numel(), shape, device=device)
+    return owned[picks].to(torch.int32)
 
 
 def _warmup_expert_gemms(
@@ -118,7 +168,6 @@ def _warmup_expert_gemms(
     w13 = layer.w13_weight
     w2 = layer.w2_weight
     top_k = layer.top_k
-    num_experts = w13.size(0)
     hidden_size = w2.size(1)
     device = w13.device
     act_dtype = layer.params_dtype
@@ -129,16 +178,17 @@ def _warmup_expert_gemms(
         _naive_block_assignment_max_m(
             layer.global_num_experts, top_k, layer.expert_map
         ),
+        top_k,
     )
     max_m = m_values[-1]
 
     # Allocate for the largest M once and slice; `apply` resizes the
     # workspaces it is given, so an oversized buffer is fine.
     hidden_states = torch.zeros((max_m, hidden_size), device=device, dtype=act_dtype)
-    # Spread tokens over all experts so every expert block is exercised and
-    # the token-to-block assignment matches a realistic batch.
-    topk_ids = torch.randint(
-        0, num_experts, (max_m, top_k), device=device, dtype=torch.int32
+    # Spread tokens over the experts this rank owns so every expert block is
+    # exercised and the token-to-block assignment matches a realistic batch.
+    topk_ids = _sample_local_expert_ids(
+        (max_m, top_k), layer.global_num_experts, layer.expert_map, device
     )
     topk_weights = torch.ones((max_m, top_k), device=device, dtype=torch.float32)
     workspace13_shape, workspace2_shape, output_shape = experts.workspace_shapes(

--- a/vllm/model_executor/warmup/triton_moe_warmup.py
+++ b/vllm/model_executor/warmup/triton_moe_warmup.py
@@ -138,7 +138,7 @@ def _sample_local_expert_ids(
     global_num_experts: int,
     expert_map: torch.Tensor | None,
     device: torch.device,
-) -> torch.Tensor:
+) -> torch.Tensor | None:
     """Sample routed expert ids that this rank actually owns.
 
     ``topk_ids`` carries global ids. Under expert parallelism ``expert_map``
@@ -146,6 +146,9 @@ def _sample_local_expert_ids(
     another rank, and ``moe_align_block_size`` drops the invalid ones before the
     GEMMs. Sampling the local id range would therefore warm nothing on every
     rank whose slice does not start at 0, so draw from the owned global ids.
+
+    Returns ``None`` when the rank owns no expert, since then there is no expert
+    GEMM to warm.
     """
     if expert_map is None:
         return torch.randint(
@@ -153,7 +156,7 @@ def _sample_local_expert_ids(
         )
     owned = torch.nonzero(expert_map >= 0, as_tuple=True)[0]
     if owned.numel() == 0:
-        return torch.empty(shape, device=device, dtype=torch.int32)
+        return None
     picks = torch.randint(0, owned.numel(), shape, device=device)
     return owned[picks].to(torch.int32)
 
@@ -182,14 +185,20 @@ def _warmup_expert_gemms(
     )
     max_m = m_values[-1]
 
-    # Allocate for the largest M once and slice; `apply` resizes the
-    # workspaces it is given, so an oversized buffer is fine.
-    hidden_states = torch.zeros((max_m, hidden_size), device=device, dtype=act_dtype)
     # Spread tokens over the experts this rank owns so every expert block is
     # exercised and the token-to-block assignment matches a realistic batch.
+    # Sampled before any buffer is allocated so a rank that owns no expert
+    # returns without reserving memory.
     topk_ids = _sample_local_expert_ids(
         (max_m, top_k), layer.global_num_experts, layer.expert_map, device
     )
+    if topk_ids is None:
+        # No expert lives on this rank, so there is no expert GEMM to warm.
+        return
+
+    # Allocate for the largest M once and slice; `apply` resizes the
+    # workspaces it is given, so an oversized buffer is fine.
+    hidden_states = torch.zeros((max_m, hidden_size), device=device, dtype=act_dtype)
     topk_weights = torch.ones((max_m, top_k), device=device, dtype=torch.float32)
     workspace13_shape, workspace2_shape, output_shape = experts.workspace_shapes(
         max_m,


### PR DESCRIPTION
## Purpose

`fused_moe_kernel` is the expert GEMM whenever DeepGEMM declines the shape. The
dominant case is the `N <= 512` early-out in `_valid_deep_gemm`
(`experts/deep_gemm_moe.py`): a model with a small `moe_intermediate_size`
crosses that threshold as soon as TP is high enough, and from then on never uses
DeepGEMM. GLM-5.2-FP8 at TP=8 gives `w2 = (256, 6144, 256)`, i.e. `N=256`, so its
whole MoE stack runs on Triton for every request.

Nothing in the startup path compiles that kernel for the variants real batches
select. Two things vary with the token count `M`:

1. the tile config, chosen by `try_get_optimal_moe_config` from a tuned config
   file or `get_default_config`;
2. the 16-divisibility of `EM` and `num_valid_tokens`, which Triton attaches as
   a `tt.divisibility` attribute and keys separately.

Profiling and CUDA graph capture only reach a few of these combinations, so the
first request landing on an uncompiled one JIT-compiles mid-serving. Measured on
GLM-5.2-FP8 at TP=8, main compiles 4 distinct variants per rank during
inference (32 events across 8 ranks). With `--jit-monitor-mode=error` that is a
hard failure; with the default `warn` it is a latency spike.

## Changes

- New `vllm/model_executor/warmup/triton_moe_warmup.py`: walks the `M` values
  that can select a distinct tile config, pairs each with a neighbour that flips
  the 16-divisibility of `num_valid_tokens` so both variants compile, and runs
  the expert GEMMs through `TritonExperts.apply` once per value.
- Called from `kernel_warmup` inside the existing `enable_jit_warmup` block.

Design notes:

- Warmup drives `TritonExperts.apply` rather than reconstructing the ~30 kernel
  arguments. `invoke_fused_moe_triton_kernel` derives the strides, `EM`,
  `SWAP_AB` and the effective `BLOCK_SIZE_K` from the tensors it is handed, so
  going through the real path is the only way to guarantee the compiled key
  matches the serving key. A compile-only draft built on `TritonWarmupTensor`
  was discarded for that reason.
- Activations are quantized with `moe_kernel_quantize_input` using the layer's
  own `FusedMoEQuantConfig`, matching what the prepare step produces. When the
  MoE is unquantized this returns the input unchanged with a `None` scale.
- The companion `M` is chosen from the kernel's own predicate, not from `M`
  parity. `num_valid_tokens` is `M * top_k`, so `M + 1` does not always cross
  the 16-divisibility boundary: at `top_k=1` neither 24 nor 25 is divisible and
  one specialization would stay uncompiled. The search scans the neighbourhood
  for an `M` that flips the predicate, preferring larger `M` but falling back to
  smaller ones at the token budget, and yields no companion when `top_k` is a
  multiple of 16 (there the non-divisible class cannot exist).
- Routed expert ids are sampled from the global ids this rank owns
  (`expert_map >= 0`). `topk_ids` carries global ids, so sampling the local id
  range would leave every rank whose slice does not start at 0 with no valid
  ids at all -- `moe_align_block_size` maps them to `-1` and the GEMMs are
  skipped.
- MoE layers of one model share weight shapes, so one representative per
  `(w13, w2)` shape pair covers all of them (78 layers collapse to 1 on
  GLM-5.2).
- `M` is capped at the largest grid entry (4096); above it the tile config no
  longer changes, so warming the full token budget would only cost workspace
  memory.
- OOM while building warmup activations is caught and skips the remainder
  instead of failing startup.

## Why this is not a duplicate

- #42193 (`[Bugfix][V1][MoE] Warm up WNA16 MoE Triton kernels`, closed) targeted
  `fused_moe_kernel_gptq_awq` on the WNA16 path, proposing `do_not_specialize`
  plus a compile-only key contract. Different kernel, different quantization
  path, closed without merging.
- #47599 (closed) warmed the FlashInfer b12x NVFP4 MoE, a different backend.
- #53567 (`[7/N][warmup][DSv4] Migrate MoE execution and distributed kernels`,
  open) migrates the DSv4 top-k / fused router / MegaMoE prepare / fused batched
  / NVFP4 emulation / TRT-LLM LoRA kernels to the shared warmup contract. It does
  not touch `fused_moe_kernel` and adds nothing under `warmup/`, so the two do
  not overlap. See the note below on why this PR does not use that contract.
- On current main, `grep -rn "fused_moe_kernel" vllm/model_executor/warmup/`
  returns nothing; none of the modules under `warmup/` touch the Triton fused
  MoE path.
- Searches run: `gh pr list --repo vllm-project/vllm --search "moe warmup"`,
  `"triton moe warmup"`, `"fused_moe_kernel JIT"`, `"glm_moe_dsa"`.

On the shared warmup contract: `VllmJitKernel` / `JitWarmupRegistry` requires the
dispatch to be expressed as an AST-restricted pure expression (local assignments
plus `return self.CompileKey(...)`), while this kernel's key depends on 30+
tensor-derived arguments (strides, `EM`, `SWAP_AB`, and `BLOCK_SIZE_K` after the
`min(cfg_bsk, min(block_shape))` clamp). Rebuilding those by hand is easy to get
subtly wrong — a first draft did exactly that and produced keys that did not
match serving. Driving the real `apply()` mirrors the already-merged
`deep_gemm_warmup` and `b12x_warmup`.

## Test Plan

```bash
.venv/bin/python -m pytest tests/model_executor/test_triton_moe_warmup.py -v
SKIP=actionlint,shellcheck,clang-format,markdownlint,pip-compile,dockerfilelint \
  pre-commit run --files \
    vllm/model_executor/warmup/triton_moe_warmup.py \
    vllm/model_executor/warmup/kernel_warmup.py \
    tests/model_executor/test_triton_moe_warmup.py
pre-commit run mypy-3.12 --hook-stage manual --files <same three files>
```

End-to-end on 8x H20-3e (SM90), GLM-5.2-FP8, TP=8, `--max-model-len 32768`,
`--max-num-batched-tokens 8192`, `--kv-cache-dtype fp8`, `--block-size 64`,
`--jit-monitor-verbose` so every compilation is logged. Same three workloads
per build, run strictly one at a time:

1. prefill, 4.5k-token prompts, concurrency 32, 64 requests
2. decode, concurrency 32, 12 s warmup then a 40 s steady-state window
3. prefill, 31.5k-token prompts, concurrency 10, 10 requests (chunked)

## Test Result

Unit tests: 8 passed.

Lint: `ruff-check`, `ruff-format`, `typos`, `mypy-3.10` and `mypy-3.12` all pass.
(`actionlint` and the other non-Python hooks were skipped locally because
installing the `actionlint` Go binary needs network access this machine does not
have; the change is Python-only.)

Runtime JIT events reported by the JIT monitor across all three workloads
(8 ranks):

| build | `fused_moe_kernel` events | distinct variants per rank |
| --- | --- | --- |
| main | 32 | 4 (`BSM=16` and `BSM=64`, each for the w13 and w2 GEMM) |
| this PR | **0** | 0 |

Throughput on the same workloads:

| workload | main | this PR | delta |
| --- | --- | --- | --- |
| prefill 4.5k x 32 | 3650.4 tok/s | 3650.0 tok/s | -0.01% |
| decode, 32 streams | 882.8 tok/s (27.59/stream) | 884.5 tok/s (27.64/stream) | +0.2% |
| prefill 31.5k x 10 | 3510.7 tok/s (p50 51.31 s, p90 89.55 s) | 3513.1 tok/s (p50 51.27 s, p90 89.49 s) | +0.07% |

Steady-state throughput is unchanged: this removes compile stalls, it is not a
throughput optimization.

Startup cost of the warmup: about 3 s for one weight shape (36 `M` values, all
ranks in parallel). For comparison, `deep_gemm_warmup` on the same machine runs
2139 steps.

How the divisibility half of the problem was identified, since it is not visible
in the Triton signature (which only carries `i32`/`i64`) but in the attrs
descriptor: with the tile config pinned, launching `M=2048` compiles and `M=2050`
hits the cache, but `M=2049` compiles again and `M=2051` then hits the cache. The
second compilation's attrs lack `tt.divisibility=16` on argument indices 12 and
13, which are `EM` and `num_valid_tokens`. A grid built from the tuned
config-file keys alone leaves one variant uncompiled, which is why each grid
entry is paired with a neighbour that crosses the boundary.

The predicate is `num_valid_tokens = M * top_k`, not `M` itself (raised in
review). Re-probing at `top_k=1` shows it directly: `M=24` (24, not divisible)
compiles, `M=25` (25) is a cache hit, and only `M=32` (32) compiles the variant
whose attrs carry index 13. At `top_k=8` the pairing is unaffected, so the
numbers above stand.

## Not covered by this PR

- The residual `BuildPrefillChunkMetadataKernel.kernel` events on the 31.5k
  workload (16 with this PR, 24 on main). Those come from a separate gap in that
  kernel's own `get_warmup_keys`, where `query_slice_start=WarmupIntRange(0, 2)`
  only supplies `0` and `1` and so misses the same non-divisible specialization
  class.
- Unquantized bf16 MoE was verified by code-path analysis only, not measured:
  `moe_kernel_quantize_input` returns the input unchanged with a `None` scale when
  `quant_dtype is None`, and the config falls into the `get_default_config` else
  branch (`block_m=128` for `M>512`, still covered by the 4096 grid cap). Happy
  to measure it on a real bf16 MoE model if a reviewer wants that before merging.

## AI assistance

AI assistance was used for this change (investigation, patch, tests, and this
description). All measurements above come from real runs on the machine
described, and I have reviewed every changed line.

