### PR TITLE
docs: note that enforce_eager also disables torch.compile

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -242,7 +242,10 @@ class ModelConfig:
     """Whether to always use eager-mode PyTorch. If True, we will disable CUDA
     graph and always execute the model in eager mode. If False, we will use
     CUDA graph and eager execution in hybrid for maximal performance and
-    flexibility."""
+    flexibility.
+
+    NOTE: This disables both `torch.compile` and CUDA graphs, and is
+    equivalent to setting `-cc.mode=none -cc.cudagraph_mode=none`."""
     enable_return_routed_experts: bool = False
     """Whether to return routed experts."""
     return_sampling_mask: bool = False


### PR DESCRIPTION



## Purpose

The `enforce_eager` docstring only mentions disabling CUDA graphs, but `VllmConfig` also sets `compilation_config.mode = CompilationMode.NONE`, which turns off `torch.compile` as well ([vllm/config/vllm.py#L1378-L1384](https://github.com/vllm-project/vllm/blob/main/vllm/config/vllm.py#L1378-L1384)).

The runtime already logs a warning saying exactly this, but the docstring does not — and the docstring is what generates `vllm serve --help` and the config reference docs. This change brings the docstring in line with the warning the code already emits.

Docs-only; no functional change.

## Test Plan

No functional code touched. Docstring wording only.

## Test Result

N/A — no behavior change. The added text restates the warning already emitted at `vllm/config/vllm.py:1380`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

