### PR TITLE
[Observability] Add bounded in-flight queue diagnostics

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_basic.py
+++ b/tests/entrypoints/serve/instrumentator/test_basic.py
@@ -206,6 +206,29 @@ async def test_server_load(server: RemoteOpenAIServer):
 
 
 @pytest.mark.asyncio
+async def test_server_load_with_inflight_diagnostics():
+    from vllm.entrypoints.serve.instrumentator.basic import get_server_load_metrics
+
+    mock_request = Mock(spec=Request)
+    mock_request.app.state.server_load_metrics = 2
+    mock_request.app.state.engine_client = AsyncMock()
+    mock_request.app.state.engine_client.get_inflight_queue_diagnostics.return_value = [
+        {"data_parallel_rank": 0, "queues": []}
+    ]
+
+    response = await get_server_load_metrics(
+        mock_request, include_inflight=True, inflight_limit=10
+    )
+
+    assert response.body == (
+        b'{"server_load":2,"inflight":[{"data_parallel_rank":0,"queues":[]}]}'
+    )
+    mock_request.app.state.engine_client.get_inflight_queue_diagnostics.assert_awaited_once_with(
+        10
+    )
+
+
+@pytest.mark.asyncio
 async def test_health_check_engine_dead_error():
     # Import the health function directly to test it in isolation
     from vllm.entrypoints.serve.instrumentator.health import health

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
+import time
 from concurrent.futures import Future
 from unittest.mock import Mock
 
@@ -145,6 +146,29 @@ def test_get_num_unfinished_requests():
     for i, request in enumerate(requests):
         scheduler.finish_requests(request.request_id, RequestStatus.FINISHED_STOPPED)
         assert scheduler.get_num_unfinished_requests() == len(requests) - i - 1
+
+
+def test_get_inflight_queue_diagnostics():
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=3)
+    for request in requests:
+        request.arrival_time = time.time() - 1
+        scheduler.add_request(request)
+
+    scheduler.running.append(scheduler.waiting.pop_request())
+    scheduler.running[0].status = RequestStatus.RUNNING
+
+    diagnostics = scheduler.get_inflight_queue_diagnostics(limit=2)
+
+    assert diagnostics["data_parallel_rank"] == 0
+    assert [queue["name"] for queue in diagnostics["queues"]] == [
+        "running",
+        "waiting",
+        "skipped_waiting",
+    ]
+    assert [len(queue["requests"]) for queue in diagnostics["queues"]] == [1, 1, 0]
+    assert diagnostics["queues"][0]["requests"][0]["status"] == "RUNNING"
+    assert diagnostics["queues"][0]["requests"][0]["age_seconds"] >= 1
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -150,6 +150,7 @@ def test_get_num_unfinished_requests():
 
 def test_get_inflight_queue_diagnostics():
     scheduler = create_scheduler()
+    scheduler.parallel_config.data_parallel_index = 1
     requests = create_requests(num_requests=3)
     for request in requests:
         request.arrival_time = time.time() - 1
@@ -160,7 +161,7 @@ def test_get_inflight_queue_diagnostics():
 
     diagnostics = scheduler.get_inflight_queue_diagnostics(limit=2)
 
-    assert diagnostics["data_parallel_rank"] == 0
+    assert diagnostics["data_parallel_rank"] == 1
     assert [queue["name"] for queue in diagnostics["queues"]] == [
         "running",
         "waiting",

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -296,3 +296,7 @@ class EngineClient(ABC):
     async def get_weight_version(self) -> str:
         """Return the latest committed weight version."""
         raise NotImplementedError
+
+    async def get_inflight_queue_diagnostics(self, limit: int) -> list[dict[str, Any]]:
+        """Return bounded snapshots of in-flight request queues."""
+        raise NotImplementedError

--- a/vllm/entrypoints/serve/instrumentator/basic.py
+++ b/vllm/entrypoints/serve/instrumentator/basic.py
@@ -28,7 +28,9 @@ def engine_client(request: Request) -> EngineClient:
 
 
 @router.get("/load")
-async def get_server_load_metrics(request: Request):
+async def get_server_load_metrics(
+    request: Request, include_inflight: bool = False, inflight_limit: int = 100
+):
     # This endpoint returns the current server load metrics.
     # It tracks requests utilizing the GPU from the following routes:
     # - /v1/responses
@@ -47,7 +49,12 @@ async def get_server_load_metrics(request: Request):
     # - /rerank
     # - /v1/rerank
     # - /v2/rerank
-    return JSONResponse(content={"server_load": request.app.state.server_load_metrics})
+    content = {"server_load": request.app.state.server_load_metrics}
+    if include_inflight:
+        content["inflight"] = await engine_client(
+            request
+        ).get_inflight_queue_diagnostics(inflight_limit)
+    return JSONResponse(content=content)
 
 
 @router.get("/version")

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -3,7 +3,7 @@
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 
@@ -233,6 +233,11 @@ class SchedulerInterface(ABC):
     @abstractmethod
     def get_request_counts(self) -> tuple[int, int]:
         """Returns (num_running_reqs, num_waiting_reqs)."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_inflight_queue_diagnostics(self, limit: int) -> dict[str, Any]:
+        """Return a bounded snapshot of in-flight request queues."""
         raise NotImplementedError
 
     def get_kv_cache_usage(self) -> float:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2391,6 +2391,40 @@ class Scheduler(SchedulerInterface):
         """Returns (num_running_reqs, num_waiting_reqs)."""
         return len(self.running), len(self.waiting) + len(self.skipped_waiting)
 
+    def get_inflight_queue_diagnostics(self, limit: int) -> dict[str, Any]:
+        """Return a bounded snapshot of in-flight request queues."""
+        now = time.time()
+        remaining = max(0, min(limit, 1000))
+        queues = []
+
+        for name, requests in (
+            ("running", self.running),
+            ("waiting", self.waiting),
+            ("skipped_waiting", self.skipped_waiting),
+        ):
+            entries = []
+            for request in requests:
+                if remaining == 0:
+                    break
+                entries.append(
+                    {
+                        "request_id": request.request_id,
+                        "status": request.status.name,
+                        "age_seconds": round(max(0.0, now - request.arrival_time), 3),
+                        "prompt_tokens": request.num_prompt_tokens,
+                        "output_tokens": request.num_output_tokens,
+                    }
+                )
+                remaining -= 1
+            queues.append(
+                {"name": name, "num_requests": len(requests), "requests": entries}
+            )
+
+        return {
+            "data_parallel_rank": self.parallel_config.data_parallel_rank,
+            "queues": queues,
+        }
+
     def get_kv_cache_usage(self) -> float:
         """Returns the fraction of the KV cache currently in use (0.0-1.0)."""
         return self.kv_cache_manager.usage

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2421,7 +2421,7 @@ class Scheduler(SchedulerInterface):
             )
 
         return {
-            "data_parallel_rank": self.parallel_config.data_parallel_rank,
+            "data_parallel_rank": self.parallel_config.data_parallel_index,
             "queues": queues,
         }
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1240,3 +1240,6 @@ class AsyncLLM(EngineClient):
     async def get_weight_version(self) -> str:
         """Return the latest committed weight version."""
         return await self.engine_core.get_weight_version_async()
+
+    async def get_inflight_queue_diagnostics(self, limit: int) -> list[dict[str, Any]]:
+        return await self.engine_core.get_inflight_queue_diagnostics_async(limit)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -996,6 +996,9 @@ class EngineCore:
         """Return the latest committed weight version."""
         return self._weight_version
 
+    def get_inflight_queue_diagnostics(self, limit: int) -> dict[str, Any]:
+        return self.scheduler.get_inflight_queue_diagnostics(limit)
+
     def preprocess_add_request(self, request: EngineCoreRequest) -> tuple[Request, int]:
         """Preprocess the request.
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -209,6 +209,9 @@ class EngineCoreClient(ABC):
     def get_weight_version(self) -> str:
         raise NotImplementedError
 
+    def get_inflight_queue_diagnostics(self, limit: int) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
     async def execute_dummy_batch_async(self) -> None:
         raise NotImplementedError
 
@@ -216,6 +219,11 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def get_weight_version_async(self) -> str:
+        raise NotImplementedError
+
+    async def get_inflight_queue_diagnostics_async(
+        self, limit: int
+    ) -> list[dict[str, Any]]:
         raise NotImplementedError
 
     def abort_requests(self, request_ids: list[str]) -> None:
@@ -413,6 +421,9 @@ class InprocClient(EngineCoreClient):
 
     def get_weight_version(self) -> str:
         return self.engine_core.get_weight_version()
+
+    def get_inflight_queue_diagnostics(self, limit: int) -> list[dict[str, Any]]:
+        return [self.engine_core.get_inflight_queue_diagnostics(limit)]
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.engine_core.add_lora(lora_request)
@@ -1028,6 +1039,9 @@ class SyncMPClient(MPClient):
     def get_weight_version(self) -> str:
         return self.call_utility("get_weight_version")
 
+    def get_inflight_queue_diagnostics(self, limit: int) -> list[dict[str, Any]]:
+        return [self.call_utility("get_inflight_queue_diagnostics", limit)]
+
     def collective_rpc(
         self,
         method: str | Callable[..., _R],
@@ -1271,6 +1285,12 @@ class AsyncMPClient(MPClient):
 
     async def get_weight_version_async(self) -> str:
         return await self.call_utility_async("get_weight_version")
+
+    async def get_inflight_queue_diagnostics_async(
+        self, limit: int
+    ) -> list[dict[str, Any]]:
+        result = await self.call_utility_async("get_inflight_queue_diagnostics", limit)
+        return [result]
 
     async def add_lora_async(self, lora_request: LoRARequest) -> bool:
         return await self.call_utility_async("add_lora", lora_request)
@@ -1606,6 +1626,18 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                 ]
             )
         )[0]
+
+    async def get_inflight_queue_diagnostics_async(
+        self, limit: int
+    ) -> list[dict[str, Any]]:
+        return await asyncio.gather(
+            *[
+                self._call_utility_async(
+                    "get_inflight_queue_diagnostics", limit, engine=engine
+                )
+                for engine in self.core_engines
+            ]
+        )
 
     @staticmethod
     async def process_engine_outputs(

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -443,6 +443,9 @@ class LLMEngine:
         """Return the latest committed weight version."""
         return self.engine_core.get_weight_version()
 
+    def get_inflight_queue_diagnostics(self, limit: int) -> list[dict[str, Any]]:
+        return self.engine_core.get_inflight_queue_diagnostics(limit)
+
     def apply_model(self, func: Callable[[nn.Module], _R]) -> list[_R]:
         return self.collective_rpc("apply_model", args=(func,))
 


### PR DESCRIPTION
## Summary

Add opt-in, bounded in-flight queue diagnostics to the existing `/load` endpoint.

- `GET /load` remains unchanged by default.
- `GET /load?include_inflight=true&inflight_limit=100` returns per-DP-rank snapshots of running, waiting, and skipped-waiting queues.
- Each request entry contains only its ID, scheduler status, age, and token counts; prompt and output contents are not exposed.
- The scheduler caps each rank's snapshot at 1000 entries, and internal DP load balancing gathers all managed engine snapshots.

## Motivation

A scalar frontend load count cannot explain a stuck request: operators cannot tell which scheduler stage it occupies, how long it has been there, or whether only one data-parallel rank is affected. This adds a debug-only view without adding work to the normal scheduling path or changing the default endpoint contract.

## Duplicate-work check

I searched open vLLM issues and pull requests for in-flight queue diagnostics, `/load` request details, and stuck-request inspection. I did not find an active focused implementation. Existing load tracking exposes aggregate counts rather than bounded per-request scheduler state.

## Tests

- `tests/v1/core/test_scheduler.py::test_get_inflight_queue_diagnostics`
- `tests/entrypoints/serve/instrumentator/test_basic.py::test_server_load_with_inflight_diagnostics`
- `pre-commit run --files <all changed files>`

Both targeted tests pass. All pre-commit hooks for the changed files pass, including Ruff and mypy.

## AI assistance

This change was implemented with OpenAI Codex assistance and reviewed against the existing scheduler, EngineCore utility RPC, data-parallel client, and `/load` endpoint architecture.
