### PR TITLE
[Bugfix][SM120][MLA] Support NoPE sparse MLA (GLM-5.3-Flash) on the FlashInfer SM120 backend

### DIFF
--- a/csrc/libtorch_stable/cache_kernels.cu
+++ b/csrc/libtorch_stable/cache_kernels.cu
@@ -539,16 +539,23 @@ __global__ void concat_and_cache_ds_mla_kernel(
   scalar_t* kv_cache_16bit =
       reinterpret_cast<scalar_t*>(&kv_cache[dst_idx_start]);
 
-  // The last warp handles the RoPE part
+  // The last warp handles the RoPE part. NoPE models (pe_dim == 0) have no
+  // RoPE tail: zero the reserved bytes so any reader of the fixed 656-byte
+  // row sees exact zeros instead of stale memory (a zero rope lane is
+  // bit-exact NoPE for q_pe · k_pe).
   if (threadIdx.x >= 64) {
     // Each thread handles two elements of RoPE
     const int8_t pe_idx_start = (threadIdx.x - 64) * 2;
-    const int64_t src_idx = token_idx * k_pe_stride + pe_idx_start;
-    // Vectorized load of two 16-bit values, performed as one 32-bit load
-    const int32_t vals = *reinterpret_cast<const int32_t*>(&k_pe[src_idx]);
     // RoPE values start after the packed 8-bit NoPE values and the
     // 32-bit scales
     const int64_t dst_idx = kv_lora_rank / 2 + 8 + pe_idx_start;
+    if (pe_dim == 0) {
+      *reinterpret_cast<int32_t*>(&kv_cache_16bit[dst_idx]) = 0;
+      return;
+    }
+    const int64_t src_idx = token_idx * k_pe_stride + pe_idx_start;
+    // Vectorized load of two 16-bit values, performed as one 32-bit load
+    const int32_t vals = *reinterpret_cast<const int32_t*>(&k_pe[src_idx]);
     // Vectorized store of two 16-bit values, performed as one 32-bit store
     *reinterpret_cast<int32_t*>(&kv_cache_16bit[dst_idx]) = vals;
     return;
@@ -925,7 +932,11 @@ void concat_and_cache_mla(
   if (kv_cache_dtype == "fp8_ds_mla") {
     STD_TORCH_CHECK(kv_lora_rank == 512,
                     "kv_lora_rank must be 512 for fp8_ds_mla");
-    STD_TORCH_CHECK(pe_dim == 64, "pe_dim must be 64 for fp8_ds_mla");
+    // pe_dim 64 carries the RoPE tail; pe_dim 0 is the NoPE form (e.g.
+    // GLM-5.3 sparse layers), whose packed rows keep bytes 528:656 as
+    // zeroed reserved padding.
+    STD_TORCH_CHECK(pe_dim == 64 || pe_dim == 0,
+                    "pe_dim must be 64 or 0 for fp8_ds_mla");
     STD_TORCH_CHECK(kv_cache.size(2) == 656 / kv_cache.element_size(),
                     "kv_cache.size(2) must be 656 bytes for fp8_ds_mla");
     STD_TORCH_CHECK(kv_c.element_size() == 2,

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -911,6 +911,72 @@ def test_concat_and_cache_ds_mla(
         torch.testing.assert_close(kv_rope, ref_rope, atol=0.001, rtol=0.1)
 
 
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
+def test_concat_and_cache_ds_mla_nope(device: str) -> None:
+    # NoPE models (pe_dim=0, e.g. GLM-5.3-Flash sparse layers) keep the fixed
+    # 656-byte fp8_ds_mla row; the kernel must zero the 128-byte reserved tail
+    # so readers of the DS-shaped row never see stale memory.
+    if current_platform.is_rocm():
+        pytest.skip("concat_and_cache_mla doesn't support fp8_ds_mla on ROCm")
+    num_tokens, block_size, num_blocks = 8, 64, 8
+    kv_lora_rank = 512
+    dtype = torch.bfloat16
+    set_random_seed(0)
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+
+    total_slots = num_blocks * block_size
+    slot_mapping = torch.tensor(
+        random.sample(range(total_slots), num_tokens), dtype=torch.long, device=device
+    )
+    kv_c = torch.randn(num_tokens, kv_lora_rank, dtype=dtype, device=device)
+    k_pe = torch.empty(num_tokens, 0, dtype=dtype, device=device)
+    scale = torch.tensor(1.0, dtype=torch.float32, device=device)
+    kv_cache = _create_mla_cache(
+        num_blocks,
+        block_size,
+        656,
+        dtype=torch.uint8,
+        kv_cache_dtype="fp8_ds_mla",
+        device=device,
+    )
+    # Sentinel fill: without the zeroing store the tail would survive as 0xFF.
+    kv_cache.fill_(0xFF)
+
+    opcheck(
+        torch.ops._C_cache_ops.concat_and_cache_mla,
+        (kv_c, k_pe, kv_cache, slot_mapping, "fp8_ds_mla", scale),
+        test_utils=DEFAULT_OPCHECK_TEST_UTILS,
+    )
+    ops.concat_and_cache_mla(kv_c, k_pe, kv_cache, slot_mapping, "fp8_ds_mla", scale)
+
+    for i in range(num_tokens):
+        slot = slot_mapping[i].item()
+        row = kv_cache[slot // block_size, slot % block_size]
+        kv_c_f = kv_c[i].to(torch.float32)
+        for tile_idx in range(kv_lora_rank // 128):
+            tile = kv_c_f[tile_idx * 128 : (tile_idx + 1) * 128]
+            tile_scale = tile.abs().max() / 448.0
+            torch.testing.assert_close(
+                row.view(torch.float32)[128 + tile_idx], tile_scale
+            )
+            ref_tile = torch.empty(128, dtype=torch.uint8, device=device)
+            ops.convert_fp8(
+                ref_tile,
+                kv_c[i][tile_idx * 128 : (tile_idx + 1) * 128],
+                tile_scale.item(),
+                kv_dtype="fp8",
+            )
+            torch.testing.assert_close(
+                row[tile_idx * 128 : (tile_idx + 1) * 128],
+                ref_tile,
+                atol=0.001,
+                rtol=0.1,
+            )
+        assert (row[528:656] == 0).all()
+
+
 # Bytes per token for the nvfp4_ds_mla cache layout (see flashmla_sparse.py).
 NVFP4_DS_MLA_ENTRY_SIZE = 352
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -129,6 +129,14 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
             ),
         )
 
+        # page_table width = topk buffer width, which kpool widens past
+        # index_topk (topk_tokens) and rounds up to a multiple of 128. The
+        # kernel treats sparse_mla_top_k as the page-table *capacity* and
+        # bounds the active per-query length by the -1 padding, so use the
+        # actual buffer width instead of the fixed topk_tokens, which
+        # mismatches the page_table when index_kpool > 1.
+        sparse_topk_capacity = topk_indices_physical.shape[1]
+
         output = q.new_empty(
             (num_actual_toks, self.num_heads, self.kv_lora_rank),
             dtype=q.dtype,
@@ -150,11 +158,11 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
             qk_rope_head_dim=self.qk_rope_head_dim,
             block_tables=topk_indices_physical.unsqueeze(1),
             seq_lens=None,
-            max_seq_len=attn_metadata.topk_tokens,
+            max_seq_len=sparse_topk_capacity,
             out=output.unsqueeze(1),
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
-            sparse_mla_top_k=attn_metadata.topk_tokens,
+            sparse_mla_top_k=sparse_topk_capacity,
             kv_scale_format=self.kv_scale_format,
         )
         return out.squeeze(1), None


### PR DESCRIPTION
## Purpose

Make the `FLASHINFER_MLA_SPARSE_SM120` backend usable for GLM-5.3-Flash (`glm5_next`, #53906), whose sparse MLA layers are NoPE (`qk_rope_head_dim=0`) with a kpool-widened top-k buffer. Two independent breakages are fixed:

1. **`concat_and_cache` fp8_ds_mla rejects NoPE rows.** The packed fp8_ds_mla row layout is unchanged for NoPE models (512B latent + 16B tile scales + 128B reserved RoPE/padding = 656B), but the host check required `pe_dim == 64` and the kernel's RoPE warp assumed 64 tail elements. Relax the check to `pe_dim ∈ {64, 0}` and have the RoPE warp zero the reserved bytes when `pe_dim == 0`, so consumers of the DS-shaped row (e.g. `cp_gather_and_upconvert_fp8_kv_cache` on the chunked-context path) read exact zeros rather than stale memory — a zero rope lane is bit-exact NoPE for `q_pe · k_pe`. The FlashInfer GLM53_NOPE kernels never read the tail either way. A sentinel-filled regression test covers the NoPE row layout.

2. **Sparse page-table sized by `topk_tokens` instead of the actual buffer width.** GLM-5.3-Flash widens the top-k buffer past `index_topk` with a kpool tail (2048 → 2176, rounded to a multiple of 128), so `topk_indices_physical.shape[1] != attn_metadata.topk_tokens` and FlashInfer rejects `block_tables (B, 1, 2176)` against `sparse_mla_top_k=2048`. Mirror the generic `flashinfer_mla_sparse` backend: derive `sparse_mla_top_k`/`max_seq_len` from the converted buffer width; the kernel treats it as page-table capacity and bounds the active length by the `-1` padding.

No behavior change for DSv3.2/DSv4 (RoPE, kpool=1): the packed row write is identical when `pe_dim == 64`, and `shape[1] == topk_tokens` when there is no kpool tail.

Requires FlashInfer with GLM53_NOPE support plus the companion check-scoping fix flashinfer-ai/flashinfer#4947 — both ride the same post-flashinfer#4802 release boundary, so no additional wait.

## Relation to #53969

#53969 made this model servable before the native GLM53_NOPE kernel existed, by zero-padding the rope lane on both the KV-write and query side and routing through the GLM_NSA kernel — its own comment notes the shim "can be removed if the kernels grow native pe_dim == 0 support". This PR is that native support: no padding writes, no wasted rope MMA (~11% of the QK dims), and the decode goes to the dedicated GLM53_NOPE kernels with per-H tuning. The effective-topk half is the same fix (credit to @hamiltongaianimd for surfacing the kpool width issue first); whichever PR lands second rebases.

## Test Plan

- Hardware: 4×RTX PRO 6000 (SM120), TP4, GLM-5.3-Flash-NVFP4 (text-only, `--language-model-only`), `max_model_len=65536`, FULL_AND_PIECEWISE cudagraphs.
- Server boots, CUDA graph capture succeeds, completions are coherent.
- GSM8K strict-match: **0.9325** (1319 problems, concurrency 32, max_tokens 2048), consistent with the 0.973 reported for this model on GB200 in #55219.

## Test Result

Pass. Without these commits the same server crashes at startup (`pe_dim must be 64 for fp8_ds_mla`) and then at capture (`expects sparse block_tables shape (512, 1, 2048), got (512, 1, 2176)`).

---
Signed-off-by: Zihua Wu <zihuaw@nvidia.com>
