### PR TITLE
[Docs] Fix stale speculative decoding losslessness test links

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -201,11 +201,11 @@ speculative decoding, breaking down the guarantees into three key areas:
    \- vLLM’s implementation of speculative decoding is algorithmically validated to be lossless. Key validation tests include:
 
     > - **Rejection Sampler Convergence**: Ensures that samples from vLLM’s rejection sampler align with the target
-    >   distribution. [View Test Code](https://github.com/vllm-project/vllm/blob/47b65a550866c7ffbd076ecb74106714838ce7da/tests/samplers/test_rejection_sampler.py#L252)
+    >   distribution. [View Test Code](../../../tests/v1/sample/test_rejection_sampler.py#L380)
     > - **Greedy Sampling Equality**: Confirms that greedy sampling with speculative decoding matches greedy sampling
     >   without it. This verifies that vLLM's speculative decoding framework, when integrated with the vLLM forward pass and the vLLM rejection sampler,
-    >   provides a lossless guarantee. Almost all of the tests in [tests/spec_decode/e2e](../../../tests/v1/spec_decode)
-    >   verify this property using [this assertion implementation](https://github.com/vllm-project/vllm/blob/b67ae00cdbbe1a58ffc8ff170f0c8d79044a684a/tests/spec_decode/e2e/conftest.py#L291)
+    >   provides a lossless guarantee. Almost all of the tests in [tests/v1/e2e/spec_decode](../../../tests/v1/e2e/spec_decode)
+    >   verify this property using [this assertion implementation](../../../tests/v1/e2e/spec_decode/utils.py#L125)
 
 3. **vLLM Logprob Stability**
    \- vLLM does not currently guarantee stable token log probabilities (logprobs). This can result in different outputs for the


### PR DESCRIPTION
## Summary
Update the Algorithmic Losslessness section in `docs/features/speculative_decoding/README.md` so test links point at the current V1 paths.

- Rejection sampler convergence: deleted `tests/samplers/test_rejection_sampler.py` → `tests/v1/sample/test_rejection_sampler.py#L380` (`test_rejection_sampling_approximates_target_distribution`)
- Greedy equality suite: deleted `tests/spec_decode/e2e` / `tests/spec_decode/e2e/conftest.py` → `tests/v1/e2e/spec_decode/` and `tests/v1/e2e/spec_decode/utils.py#L125` (`assert_request_outputs_match`)

## Local repro
```bash
# Deleted V0 paths (404)
curl -s -o /dev/null -w '%{http_code}\n' \
  https://raw.githubusercontent.com/vllm-project/vllm/main/tests/samplers/test_rejection_sampler.py
# 404
curl -s -o /dev/null -w '%{http_code}\n' \
  https://raw.githubusercontent.com/vllm-project/vllm/main/tests/spec_decode/e2e/conftest.py
# 404

# Current V1 paths (200)
curl -s -o /dev/null -w '%{http_code}\n' \
  https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/sample/test_rejection_sampler.py
# 200
curl -s https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/sample/test_rejection_sampler.py \
  | sed -n '380,382p'
# def test_rejection_sampling_approximates_target_distribution():

curl -s -o /dev/null -w '%{http_code}\n' \
  https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/e2e/spec_decode/utils.py
# 200
curl -s https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/e2e/spec_decode/utils.py \
  | sed -n '125,126p'
# def assert_request_outputs_match(
```

## Test plan
- [ ] Confirm rendered README links resolve to the V1 files above
- [ ] Docs-only change; no runtime impact