### PR TITLE
[Docs] Fix stale CUDAGraph replay path in troubleshooting

### DIFF
--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -75,9 +75,9 @@ If it's not, override the IP address using the environment variable `export VLLM
 
 You might also need to set `export NCCL_SOCKET_IFNAME=<your_network_interface>` and `export GLOO_SOCKET_IFNAME=<your_network_interface>` to specify the network interface for the IP address.
 
-## Error near `self.graph.replay()`
+## Error near CUDAGraph `replay()`
 
-If vLLM crashes and the error trace captures it somewhere around `self.graph.replay()` in `vllm/worker/model_runner.py`, it is a CUDA error inside CUDAGraph.
+If vLLM crashes and the error trace captures it somewhere around a CUDAGraph `replay()` call (for example in `vllm/compilation/cuda_graph.py` or under `vllm/v1/worker/`), it is a CUDA error inside CUDAGraph.
 To identify the particular CUDA operation that causes the error, you can add `--enforce-eager` to the command line, or `enforce_eager=True` to the [LLM][vllm.LLM] class to disable the CUDAGraph optimization and isolate the exact CUDA operation that causes the error.
 
 ## Incorrect hardware/driver


### PR DESCRIPTION
## Summary
Update the CUDAGraph troubleshooting note so it no longer points at the deleted V0 path `vllm/worker/model_runner.py`.

- Heading/body now refer to CUDAGraph `replay()` call sites
- Example locations: `vllm/compilation/cuda_graph.py` and helpers under `vllm/v1/worker/`
- Guidance to use `--enforce-eager` / `enforce_eager=True` is unchanged

## Repro
On `main` @ `e35298628fceb490d4ca2a21c0a6e8f63d3c6740`:

1. `docs/usage/troubleshooting.md` says the crash is near `self.graph.replay()` in `vllm/worker/model_runner.py`.
2. That file does not exist on the default branch (tree has no `vllm/worker/model_runner.py`).
3. CUDAGraph `replay()` lives in current code, e.g. `vllm/compilation/cuda_graph.py` (`entry.cudagraph.replay()`), plus V1 worker helpers under `vllm/v1/worker/` (e.g. `gpu/cudagraph_utils.py`, `encoder_cudagraph.py`).

## Test plan
- [x] Confirmed `vllm/worker/model_runner.py` absent from HEAD tree
- [x] Confirmed `replay()` still present in `vllm/compilation/cuda_graph.py` and V1 worker CUDAGraph helpers
- [x] Docs-only change; no runtime behavior change