### PR TITLE
[Bugfix][V1] Don't assert on a KV transfer completion for a freed request

### DIFF
--- a/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 import pytest
 
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request, RequestStatus
 
 from .utils import (
@@ -31,6 +32,12 @@ def _make_get_num_new_matched_tokens(
 @pytest.fixture
 def scheduler():
     vllm_config = create_vllm_config(kv_load_failure_policy="recompute")
+    return create_scheduler(vllm_config)
+
+
+@pytest.fixture
+def failing_scheduler():
+    vllm_config = create_vllm_config(kv_load_failure_policy="fail")
     return create_scheduler(vllm_config)
 
 
@@ -337,3 +344,87 @@ def test_async_progressive_load_failure(
         assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
         assert scheduler.failed_recving_kv_req_ids == {request.request_id}
         assert scheduler.connector.get_num_new_matched_tokens.call_count == 1
+
+
+def test_fail_policy_tolerates_late_recv_for_freed_request(
+    failing_scheduler: Scheduler,
+):
+    """A load completion arriving after the request was failed is ignored.
+
+    A sync load failure lands on a RUNNING request, and ``finish_requests``
+    only delays the free for requests in WAITING_FOR_REMOTE_KVS, so this
+    request and its blocks are gone in the same step that reported the invalid
+    blocks. A notification for a transfer that was already in flight then names
+    a request the scheduler no longer holds. The recompute policy parks such
+    requests in ``failed_recving_kv_req_ids`` and has somewhere to put the
+    completion; this policy does not.
+    """
+    scheduler = failing_scheduler
+    num_prompt_tokens = 100 * scheduler.block_size
+    num_external_computed_tokens = 99 * scheduler.block_size
+
+    requests = [create_request(num_tokens=num_prompt_tokens) for _ in range(3)]
+    for request in requests:
+        scheduler.add_request(request=request)
+
+    scheduler.connector = Mock()
+    scheduler.connector.get_num_new_matched_tokens.side_effect = (
+        _make_get_num_new_matched_tokens(
+            {request.request_id: num_external_computed_tokens for request in requests},
+            async_load=False,
+        )
+    )
+    scheduler.connector.take_events.return_value = ()
+    scheduler.connector.request_finished.return_value = (False, None)
+
+    scheduler_output = scheduler.schedule()
+
+    assert len(scheduler.running) == 3
+    failing = requests[1]
+    block_ids = {
+        req.req_id: req.block_ids[0] for req in scheduler_output.scheduled_new_reqs
+    }
+
+    scheduler.update_from_output(
+        scheduler_output,
+        create_model_runner_output(
+            requests,
+            invalid_block_ids={block_ids[failing.request_id][0]},
+            use_eos=True,
+        ),
+    )
+
+    assert failing.request_id not in scheduler.requests
+
+    # The connector now reports the transfer that was in flight when it failed.
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(finished_recving={failing.request_id})
+    )
+
+    # Ignored rather than revived: the blocks were freed with the request.
+    assert failing.request_id not in scheduler.requests
+    assert failing.request_id not in scheduler.finished_recving_kv_req_ids
+
+
+def test_fail_policy_tolerates_late_send_for_freed_request(
+    failing_scheduler: Scheduler,
+):
+    """Same contract on the send side, which frees blocks rather than parking."""
+    scheduler = failing_scheduler
+    request = create_request(num_tokens=8 * scheduler.block_size)
+    scheduler.add_request(request=request)
+
+    scheduler.connector = Mock()
+    scheduler.connector.get_num_new_matched_tokens.side_effect = (
+        _make_get_num_new_matched_tokens({}, async_load=False)
+    )
+    scheduler.connector.take_events.return_value = ()
+
+    scheduler.schedule()
+
+    scheduler._update_from_kv_xfer_finished(
+        KVConnectorOutput(finished_sending={"a-request-that-was-already-freed"})
+    )
+
+    # The live request is untouched by the stray notification.
+    assert request.request_id in scheduler.requests

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2937,17 +2937,31 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                # A KV load failure under failure_policy="fail" errors the
+                # request out and frees it in the same step, so a completion
+                # notification for a transfer that was already in flight can
+                # arrive after the request is gone. Its blocks were freed with
+                # it, so there is nothing left to do.
+                logger.debug(
+                    "Ignoring finished recv for already freed request %s", req_id
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                self._free_blocks(req)
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug(
+                    "Ignoring finished send for already freed request %s", req_id
+                )
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose

`_update_from_kv_xfer_finished` asserts that every request named in `finished_recving` / `finished_sending` is still held by the scheduler. Under `kv_load_failure_policy="fail"` that does not hold, and the assertion takes down EngineCore along with every request in flight.

The window opens because `finish_requests` only delays the block free for requests in `WAITING_FOR_REMOTE_KVS`:

```python
for request in valid_requests:
    delay_free_blocks = False
    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
        delay_free_blocks = (
            request.request_id not in self.finished_recving_kv_req_ids
        )
```

A **sync** KV load failure lands on a `RUNNING` request, so `delay_free_blocks` stays `False` and the request is freed and removed in the same step that reported the invalid blocks. A completion notification for the transfer that was already in flight then arrives for a request that is gone.

The `recompute` policy is not exposed to this: it parks async failures in `failed_recving_kv_req_ids` and keeps the request, so it always has somewhere to put the completion. Only the `fail` policy drops the request outright, and it has no corresponding bookkeeping.

## How it showed up

Kimi-K3 FP4 on 8x MI355X, TP8 with decode context parallelism (DCP8) and LMCache CPU KV offload, replaying an agentic-coding trace at concurrency 52. An LMCache retrieve failed for one 577,536-token request across all 8 workers:

```
LMCache ERROR: Something went wrong when processing the retrieve request for request_id=chatcmpl-a06e...
ERROR [scheduler.py] Failing 1 request(s) due to KV load failure
      (failure_policy=fail, 577536 tokens affected).
```

and the following step died:

```
ERROR [core.py] EngineCore encountered a fatal error.
  File "vllm/v1/engine/core.py", in _process_engine_step
  File "vllm/v1/core/sched/scheduler.py", in update_from_output
  File "vllm/v1/core/sched/scheduler.py", in _update_from_kv_xfer_finished
    assert req_id in self.requests
AssertionError
```

With the engine gone the run could not recover: 48 of 473 requests (10.1%) failed. One request whose external KV could not be loaded should degrade to a recompute or an error for that request, not end the server.

## Fix

Skip a notification whose request is no longer present, and log it at debug. The blocks were freed with the request, so there is nothing left to release, and nothing is leaked by skipping. `update_from_output` already tolerates the same situation a few lines away for requests aborted mid-execution:

> The request is already finished. This can happen if the request is aborted while the model is executing it (e.g., in pipeline parallelism or in async scheduling).

## Test Plan

Two regression tests in `tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py`, which had no `fail`-policy coverage before this (all four existing tests use `kv_load_failure_policy="recompute"`, which is why this path went unexercised).

- `test_fail_policy_tolerates_late_recv_for_freed_request` reproduces the reported sequence end to end: three requests with a sync external load, one gets invalid blocks, is failed and freed, and the connector then reports its in-flight recv.
- `test_fail_policy_tolerates_late_send_for_freed_request` covers the send loop, which frees blocks rather than parking the request.

## Test Result

```
13 passed          # 11 pre-existing + 2 new
```

Negative control, with the fix reverted and the tests kept, fails exactly the two new tests and nothing else, on the same assertion as production:

```
vllm/v1/core/sched/scheduler.py:2940: in _update_from_kv_xfer_finished
    assert req_id in self.requests
E   AssertionError
vllm/v1/core/sched/scheduler.py:2949: in _update_from_kv_xfer_finished
    assert req_id in self.requests
E   AssertionError
```

`ruff 0.14.0` clean on both files.

## Question for reviewers

I have taken the conservative fix: tolerate the late notification where it lands. The alternative is to close the window at the source, by having the `fail` path delay the free until outstanding transfers report, the way `recompute` tracks them. That is the stronger invariant, since it would also cover any connector that writes into blocks after the failure is reported rather than only reporting bookkeeping. It is also a larger change to a path that currently has no `fail`-policy tests, which is why I did not lead with it. Happy to reshape it that way if you prefer.
