### PR TITLE
[Perf] Fuse small Gemma3n AltUp residual updates with baddbmm

### DIFF
--- a/tests/model_executor/test_gemma3n_altup.py
+++ b/tests/model_executor/test_gemma3n_altup.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.model_executor.models.gemma3n import Gemma3nAltUp
+
+
+class PredictionCoefs(nn.Module):
+    def __init__(self, output: torch.Tensor) -> None:
+        super().__init__()
+        self.output = output
+
+    def forward(self, modalities: torch.Tensor) -> torch.Tensor:
+        return self.output
+
+
+def make_altup(all_coefs: torch.Tensor) -> Gemma3nAltUp:
+    altup = Gemma3nAltUp.__new__(Gemma3nAltUp)
+    nn.Module.__init__(altup)
+    altup.altup_num_inputs = 4
+    altup.altup_active_idx = 0
+
+    def compute_router_modalities(hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states[:, :4]
+
+    altup._compute_router_modalities = compute_router_modalities
+    altup.prediction_coefs = PredictionCoefs(all_coefs)
+    return altup
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "expected_baddbmm_calls"),
+    [(32, 1), (33, 0)],
+)
+def test_predict_dispatches_baddbmm_at_token_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+    num_tokens: int,
+    expected_baddbmm_calls: int,
+) -> None:
+    generator = torch.Generator().manual_seed(55062 + num_tokens)
+    hidden_states = torch.randn(4, num_tokens, 32, generator=generator)
+    all_coefs_t = torch.randn(num_tokens, 4, 4, generator=generator)
+    all_coefs = all_coefs_t.permute(0, 2, 1).reshape(num_tokens, 16)
+    altup = make_altup(all_coefs)
+    original_hidden = hidden_states.clone()
+    original_baddbmm = torch.baddbmm
+    baddbmm_calls = 0
+
+    def counted_baddbmm(*args, **kwargs):
+        nonlocal baddbmm_calls
+        baddbmm_calls += 1
+        return original_baddbmm(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "baddbmm", counted_baddbmm)
+    actual = altup.predict(hidden_states)
+
+    hidden_t = hidden_states.permute(1, 2, 0)
+    expected = torch.matmul(hidden_t, all_coefs_t) + hidden_t
+    expected = expected.permute(2, 0, 1).contiguous()
+
+    assert baddbmm_calls == expected_baddbmm_calls
+    assert actual.shape == hidden_states.shape
+    assert actual.is_contiguous()
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(hidden_states, original_hidden, rtol=0, atol=0)

--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -59,6 +59,7 @@ from .utils import (
 logger = init_logger(__name__)
 
 EPS = torch.tensor(torch.finfo().min)
+_ALTUP_BADDBMM_MAX_TOKENS = 32
 
 
 class Gemma3nAltUp(nn.Module):
@@ -151,8 +152,13 @@ class Gemma3nAltUp(nn.Module):
         ).permute(0, 2, 1)
 
         # hidden_states to [num_tokens, hidden_size, altup_num_inputs]
-        predictions = torch.matmul(hidden_states.permute(1, 2, 0), all_coefs_T)
-        # [altup_num_inputs, num_tokens, hidden_size]
+        hidden_states_t = hidden_states.permute(1, 2, 0)
+        if hidden_states_t.shape[0] <= _ALTUP_BADDBMM_MAX_TOKENS:
+            predictions = torch.baddbmm(hidden_states_t, hidden_states_t, all_coefs_T)
+            # [altup_num_inputs, num_tokens, hidden_size]
+            return predictions.permute(2, 0, 1).contiguous()
+
+        predictions = torch.matmul(hidden_states_t, all_coefs_T)
         predictions = predictions.permute(2, 0, 1)
         predictions += hidden_states
         return predictions.contiguous()


### PR DESCRIPTION
## Purpose

Gemma3n AltUp prediction currently launches a batched matrix multiplication and
then a separate in-place residual add. This PR uses standard `torch.baddbmm`
to accumulate the residual directly for decode-sized token batches:

```text
before (<=32 tokens): {matmul: 1, add_: 1}
after  (<=32 tokens): {baddbmm: 1}
```

For larger token batches, the existing `matmul`, permute, and residual-add path
is preserved. This removes one launch from the small-token path while keeping a
portable PyTorch implementation with no custom kernel or device-specific
branch.

## Test Plan

### Regression test

```bash
.venv/bin/python -m pytest -q tests/model_executor/test_gemma3n_altup.py
```

The test exercises the real `Gemma3nAltUp.predict` method at the 32/33-token
boundary. It checks the selected operator, output shape and contiguity,
numerical equivalence to the previous expression, and input immutability.

### Lint and pre-commit

```bash
pre-commit run ruff-check --files \
  tests/model_executor/test_gemma3n_altup.py \
  vllm/model_executor/models/gemma3n.py
pre-commit run ruff-format --files \
  tests/model_executor/test_gemma3n_altup.py \
  vllm/model_executor/models/gemma3n.py
pre-commit run typos --files \
  tests/model_executor/test_gemma3n_altup.py \
  vllm/model_executor/models/gemma3n.py
pre-commit run mypy-3.12 --hook-stage manual --files \
  tests/model_executor/test_gemma3n_altup.py \
  vllm/model_executor/models/gemma3n.py
```

### RTX 4090 eager/CUDA Graph microbenchmark

```bash
python bench_gemma3n_altup_baddbmm.py \
  --mode benchmark --threshold 32 \
  --tokens 1 8 16 32 64 128 256 512 1024 2048 \
  --dtypes float16 bfloat16 \
  --executions eager cudagraph \
  --warmups 25 --iterations 200 --repeats 10 \
  --output threshold-32.csv
```

Hardware/software: NVIDIA RTX 4090, driver 580.76.05, CUDA 13.0,
PyTorch 2.13.0+cu130. No configuration changes.

| dtype | tokens | execution | Old p10/p50/p90 (us) | New p10/p50/p90 (us) | p50 speedup |
|:---|---:|:---|:---|:---|---:|
| FP16 | 1 | eager | 80.90 / 81.92 / 85.04 | 49.13 / 49.15 / 50.18 | 1.67x |
| BF16 | 8 | eager | 74.75 / 75.78 / 76.80 | 44.03 / 45.06 / 46.08 | 1.68x |
| FP16 | 32 | eager | 75.78 / 76.80 / 78.85 | 45.06 / 45.60 / 47.10 | 1.68x |
| BF16 | 64 | CUDA Graph | 15.36 / 16.38 / 16.38 | 15.36 / 16.38 / 16.38 | 1.00x |
| FP16 | 128 | eager | 75.78 / 76.80 / 77.82 | 76.80 / 77.82 / 78.85 | 0.99x |
| FP16 | 2048 | eager | 240.64 / 241.66 / 244.74 | 240.64 / 242.69 / 245.81 | 1.00x |

Across the full shape matrix, the dispatch path achieved a 1.23x eager
geometric-mean speedup and a 1.00x CUDA Graph geometric mean. The observed
minimum was 0.99x. All 1,200 baseline, unconditional-`baddbmm`, and dispatch
rows passed numerical validation with zero harness-reported allocation
regressions.

The threshold was selected conservatively. A 128-token candidate was rejected
after BF16 at 64 tokens under CUDA Graph measured 0.94x; a focused 50-repeat,
500-iteration rerun reproduced 0.94x. FP16/BF16 changed-input CUDA Graph replay
and a focused `torch.compile(fullgraph=True)` smoke test at 32/33 tokens also
passed.

## Test Result

```text
2 passed
```

`ruff-check`, `ruff-format`, `typos`, Python 3.12 `mypy`, and
`git diff --check` passed locally.

## Limitations

These are isolated AltUp prediction-chain results from one RTX 4090 run, not
end-to-end Gemma3n throughput. No performance claim is made for other
architectures or backends. Full upstream cross-backend CI still requires a
maintainer `ready` or `verified` label.

## AI assistance

AI assistance was used during implementation, testing, benchmarking, and PR
drafting. The human contributor reviewed and takes responsibility for the
change and evidence.
