### PR TITLE
[Bugfix] Fix double BOS in LLM.chat() for multimodal models

### DIFF
--- a/tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py
+++ b/tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py
@@ -286,3 +286,133 @@ def test_preprocess_chat_omits_mm_processor_kwargs_when_no_override() -> None:
     assert call_args.args[1].mm_processor_kwargs is None
     assert call_args.args[2] == "tok-params"
     assert call_args.kwargs["prompt_extras"] is None
+
+
+def test_preprocess_chat_defaults_add_special_tokens_to_false() -> None:
+    # Matches `ChatCompletionRequest.add_special_tokens` on the server.
+    llm = _make_mock_llm()
+    messages = [[{"role": "user", "content": "hi"}]]
+
+    renderer = Mock()
+    renderer.tokenizer = object()
+    renderer.default_chat_tok_params = Mock()
+    renderer.default_chat_tok_params.with_kwargs.return_value = "tok-params"
+    renderer.render_chat.return_value = (messages, ["engine-input"])
+    llm.renderer = renderer
+
+    llm._preprocess_chat(messages)
+
+    renderer.default_chat_tok_params.with_kwargs.assert_called_once_with(
+        add_special_tokens=False
+    )
+
+
+def test_preprocess_chat_tokenization_kwargs_override_add_special_tokens() -> None:
+    llm = _make_mock_llm()
+    messages = [[{"role": "user", "content": "hi"}]]
+
+    renderer = Mock()
+    renderer.tokenizer = object()
+    renderer.default_chat_tok_params = Mock()
+    renderer.default_chat_tok_params.with_kwargs.return_value = "tok-params"
+    renderer.render_chat.return_value = (messages, ["engine-input"])
+    llm.renderer = renderer
+
+    llm._preprocess_chat(
+        messages,
+        tokenization_kwargs={"add_special_tokens": True, "truncate_prompt_tokens": 8},
+    )
+
+    renderer.default_chat_tok_params.with_kwargs.assert_called_once_with(
+        add_special_tokens=True, truncate_prompt_tokens=8
+    )
+
+
+@pytest.fixture(scope="module")
+def llava_llm():
+    from vllm.config import ModelConfig, VllmConfig
+    from vllm.renderers.hf import HfRenderer
+    from vllm.tokenizers import cached_tokenizer_from_config
+
+    # A real multimodal model (Llama tokenizer, BOS=1) so that the real
+    # processor default (`add_special_tokens=True`) is in play. Only
+    # config/tokenizer/processor files are fetched, no weights.
+    model_config = ModelConfig(model="llava-hf/llava-1.5-7b-hf", max_model_len=128)
+    renderer = HfRenderer(
+        VllmConfig(model_config=model_config),
+        cached_tokenizer_from_config(model_config),
+    )
+    assert renderer.default_chat_tok_params.add_special_tokens is True
+
+    llm = _make_mock_llm()
+    # `_preprocess_cmpl` parses prompts against the real model config.
+    llm.model_config = model_config
+    llm.renderer = renderer
+    return llm
+
+
+class TestChatAddSpecialTokensDefault:
+    """`LLM.chat()` renders the chat template to text and then tokenizes it.
+    The multimodal processor default is `add_special_tokens=True`, so a
+    template that emits `bos_token` used to get a second BOS from the
+    tokenizer. `_preprocess_chat` now defaults `add_special_tokens=False`
+    like the online chat API does (`ChatCompletionRequest`), unless the
+    caller overrides it via `tokenization_kwargs`.
+    """
+
+    # Mirrors the Gemma 3 chat template and the bundled deepseek_vl2 /
+    # deepseek_ocr templates, whose rendered output starts with the BOS token.
+    BOS_TEMPLATE = (
+        "{{ bos_token }}{% for m in messages %}{{ m['content'] }}{% endfor %}"
+    )
+    MESSAGES = [[{"role": "user", "content": "hi"}]]
+
+    def _chat_token_ids(self, llm, **kwargs):
+        (engine_input,) = llm._preprocess_chat(
+            self.MESSAGES,
+            chat_template=self.BOS_TEMPLATE,
+            add_generation_prompt=False,
+            **kwargs,
+        )
+        return engine_input["prompt_token_ids"]
+
+    def test_chat_does_not_duplicate_template_bos(self, llava_llm):
+        bos = llava_llm.renderer.tokenizer.bos_token_id
+        prompt_token_ids = self._chat_token_ids(llava_llm)
+
+        assert prompt_token_ids[0] == bos
+        assert prompt_token_ids.count(bos) == 1
+
+    def test_chat_matches_online_chat_api(self, llava_llm):
+        from vllm.renderers.params import ChatParams, TokenizeParams
+
+        # `ChatCompletionRequest.add_special_tokens` defaults to `False`.
+        online_tok_params = TokenizeParams(
+            max_total_tokens=llava_llm.renderer.model_config.max_model_len,
+            add_special_tokens=False,
+        )
+        chat_params = ChatParams(
+            chat_template=self.BOS_TEMPLATE,
+            chat_template_kwargs=dict(tokenize=False, add_generation_prompt=False),
+        )
+        _, (online_input,) = llava_llm.renderer.render_chat(
+            self.MESSAGES, chat_params, online_tok_params
+        )
+
+        assert self._chat_token_ids(llava_llm) == online_input["prompt_token_ids"]
+
+    def test_explicit_tokenization_kwargs_override_default(self, llava_llm):
+        bos = llava_llm.renderer.tokenizer.bos_token_id
+        prompt_token_ids = self._chat_token_ids(
+            llava_llm, tokenization_kwargs={"add_special_tokens": True}
+        )
+
+        assert prompt_token_ids.count(bos) == 2
+
+    def test_generate_keeps_processor_default(self, llava_llm):
+        # Raw prompts have no chat template to emit BOS, so `LLM.generate()`
+        # must keep letting the tokenizer add it.
+        bos = llava_llm.renderer.tokenizer.bos_token_id
+        (engine_input,) = llava_llm._preprocess_cmpl(["hi"])
+
+        assert engine_input["prompt_token_ids"][0] == bos

--- a/vllm/entrypoints/offline_utils.py
+++ b/vllm/entrypoints/offline_utils.py
@@ -196,9 +196,16 @@ class OfflineInferenceMixin:
             ),
             mm_processor_kwargs=mm_processor_kwargs,
         )
-        tok_params = renderer.default_chat_tok_params.with_kwargs(
-            **(tokenization_kwargs or {})
-        )
+        # The chat template is responsible for emitting BOS/EOS, so do not let
+        # the tokenizer add them again unless the caller asks for it. This
+        # matches the online chat API (`ChatCompletionRequest.add_special_tokens`
+        # defaults to `False`) and avoids a double BOS for multimodal models,
+        # whose processor default is `add_special_tokens=True` (#55197).
+        tokenization_kwargs = {
+            "add_special_tokens": False,
+            **(tokenization_kwargs or {}),
+        }
+        tok_params = renderer.default_chat_tok_params.with_kwargs(**tokenization_kwargs)
         prompt_extras = (
             None
             if mm_processor_kwargs is None


### PR DESCRIPTION
## Purpose

Fixes #55197.

`LLM.chat()` renders the chat template to text and tokenizes it with `renderer.default_chat_tok_params`. For multimodal models that returns the processor default `add_special_tokens=True` (right for raw prompts in `LLM.generate()`), so every template that emits `bos_token` gets a second BOS. The online chat API does not have this problem because `ChatCompletionRequest.add_special_tokens` defaults to `False`, so the same conversation was tokenized differently offline and online.

Gemma 3 with its own chat template (`unsloth/gemma-3-1b-it` tokenizer); the bundled `template_deepseek_vl2.jinja` / `template_deepseek_ocr.jinja` (4 architectures) start with `{{ bos_token }}` too:

```
before: prompt_token_ids = [2, 2, 105, 2364, 107, ...]   # <bos><bos><start_of_turn>user
after:  prompt_token_ids = [2, 105, 2364, 107, ...]
```

Of the 115 `_MULTIMODAL_MODELS` entries, 11 model files override `get_default_tok_params` to `False`, mostly to preserve the HF processor's raw-prompt semantics for `LLM.generate()`; only `gemma4_mm.py` documents the chat double-BOS symptom (see #38826 / #39842 / #52304 for how a per-model override cannot tell the chat and raw-prompt paths apart).

### Fix

`LLM.chat()` (and `LLM.enqueue_chat()`, which shares `_preprocess_chat`) now defaults `tokenization_kwargs` to `add_special_tokens=False`, matching `ChatCompletionRequest.add_special_tokens` on the server and where #16081 originally placed it; an explicit `tokenization_kwargs={"add_special_tokens": True}` still wins. The renderer, `LLM.generate()` and other `render_chat` callers (online server, pooling) are unchanged.

Behavior change: for a multimodal model whose chat template does not emit `bos_token`, `LLM.chat()` no longer gets BOS from the tokenizer, the same as the online chat API and HF `apply_chat_template(tokenize=True)`; pass `tokenization_kwargs={"add_special_tokens": True}` to restore the previous behavior.

## Not a duplicate

`gh pr list --search "55197 in:body"` and `"double BOS" in:title` return nothing. #52304 is related (Gemma 4 raw-text BOS on XPU) but changes the per-model override for the `generate()` path; this PR only changes the offline chat entrypoint and does not touch Gemma 4.

## Test Plan

`tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py`:
- mock-level: `_preprocess_chat` calls `default_chat_tok_params.with_kwargs(add_special_tokens=False)` by default and passes the caller's `tokenization_kwargs` through unchanged when given.
- behavior-level (`TestChatAddSpecialTokensDefault`, real `HfRenderer` for `llava-hf/llava-1.5-7b-hf`, config/tokenizer only, processor default asserted `True`): a `bos_token`-emitting template yields one BOS and the same ids as the online API's `add_special_tokens=False`; `{"add_special_tokens": True}` yields two; `_preprocess_cmpl` still gets BOS from the tokenizer.

```
pytest tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py -v
pytest tests/renderers/ tests/entrypoints/multimodal/llm/test_mm_processor_kwargs.py
pre-commit run --all-files
```

## Test Result

On `main`: `3 failed, 3 passed` (`expected call not found`; `assert 2 == 1`; `assert [1, 1, 7251] == [1, 7251]`). With the fix: `6 passed`; the whole file 17 passed. `tests/renderers/` + this file: 484 passed, 2 skipped; the remaining failures are identical on `main` (gated models, missing optional `cohere_melody`). `pre-commit run --all-files` passes.

Not run: an end-to-end multimodal checkpoint; the change only affects the `add_special_tokens` value `LLM.chat()` passes to the tokenizer.

## AI assistance disclosure

Developed with AI assistance; the root-cause history, the fix and the tests were reviewed, run and verified by me.
