### PR TITLE
[Perf][MLA][DCP] Fold empty-shard masking into the A2A pack kernel

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -469,6 +469,157 @@ class TestPackedA2AKernels:
         assert torch.isneginf(actual_lse[:1]).all()
         assert torch.isfinite(actual_output[1:]).all()
 
+    @pytest.mark.skipif(
+        torch.accelerator.device_count() < 1, reason="CUDA is required."
+    )
+    @pytest.mark.parametrize("num_seqs", [1, 5, 17, 200])
+    def test_pack_send_empty_mask_matches_reference(self, num_seqs: int):
+        """In-kernel empty-shard masking must match the standalone pass.
+
+        Sizes straddle the block-scan width so the multi-iteration path is
+        covered, and every case mixes empty shards, non-empty shards and
+        trailing padding rows.
+        """
+        from vllm.v1.attention.ops.dcp import (
+            _dcp_a2a_lse_pack_dim,
+            _dcp_a2a_pack_send,
+            _dcp_a2a_unpack_combine,
+            mask_dcp_empty_shards_,
+        )
+
+        device = torch.device("cuda")
+        world_size, h_per_rank, head_dim = 2, 2, 32
+        num_heads = world_size * h_per_rank
+        torch.manual_seed(num_seqs)
+
+        # Varying query lengths, every third shard empty, plus padded rows.
+        query_lens = [1 + (i % 3) for i in range(num_seqs)]
+        query_start_loc_list = [0]
+        for q in query_lens:
+            query_start_loc_list.append(query_start_loc_list[-1] + q)
+        num_tokens = query_start_loc_list[-1] + 3  # trailing padding rows
+        seq_lens = torch.tensor(
+            [0 if i % 3 == 0 else 8 for i in range(num_seqs)],
+            device=device,
+            dtype=torch.int32,
+        )
+        query_start_loc = torch.tensor(
+            query_start_loc_list, device=device, dtype=torch.int32
+        )
+
+        output = torch.randn(
+            num_tokens, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        )
+        lse = torch.randn(num_tokens, num_heads, device=device, dtype=output.dtype)
+        lse_pack_dim = _dcp_a2a_lse_pack_dim(output.dtype)
+
+        def run(masked_ahead: bool):
+            out = output.clone()
+            this_lse = lse.clone()
+            send_buffer = torch.empty(
+                (world_size, num_tokens, h_per_rank, head_dim + lse_pack_dim),
+                device=device,
+                dtype=output.dtype,
+            )
+            if masked_ahead:
+                # Reference: pre-mask, then pack with masking disabled.
+                mask_dcp_empty_shards_(this_lse, seq_lens, query_start_loc)
+                args = (None, None)
+            else:
+                args = (seq_lens, query_start_loc)
+            _dcp_a2a_pack_send(
+                out,
+                this_lse,
+                send_buffer,
+                world_size,
+                h_per_rank,
+                head_dim,
+                lse_pack_dim,
+                seq_lens=args[0],
+                query_start_loc=args[1],
+            )
+            return _dcp_a2a_unpack_combine(
+                send_buffer,
+                head_dim,
+                lse_pack_dim,
+                return_lse=True,
+                is_lse_base_on_e=True,
+            )
+
+        ref_out, ref_lse = run(masked_ahead=True)
+        got_out, got_lse = run(masked_ahead=False)
+
+        empty_rows = torch.isneginf(ref_lse).all(dim=-1)
+        # Padding rows are always empty; a mix of both needs >1 sequence.
+        assert empty_rows.any()
+        if num_seqs > 1:
+            assert not empty_rows.all()
+        torch.testing.assert_close(got_lse, ref_lse)
+        torch.testing.assert_close(got_out, ref_out)
+
+    @pytest.mark.skipif(
+        torch.accelerator.device_count() < 1, reason="CUDA is required."
+    )
+    def test_pack_send_empty_rows_neutralize_stale_buffer(self):
+        """Skipping the store on an empty row must not leak the send buffer.
+
+        The packed output store is masked off for rows whose shard is empty, so
+        whatever the (uninitialized, possibly recycled) send buffer already held
+        stays there. Correctness then rests on the ``-inf`` LSE neutralizing it
+        in the combine. Poison the buffer to prove that holds rather than
+        relying on it happening to contain benign values.
+        """
+        from vllm.v1.attention.ops.dcp import (
+            _dcp_a2a_lse_pack_dim,
+            _dcp_a2a_pack_send,
+            _dcp_a2a_unpack_combine,
+        )
+
+        device = torch.device("cuda")
+        world_size, num_tokens, h_per_rank, head_dim = 2, 4, 2, 32
+        num_heads = world_size * h_per_rank
+        output = torch.randn(
+            num_tokens, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        )
+        lse = torch.randn(num_tokens, num_heads, device=device, dtype=output.dtype)
+        # Row 0 empty via seq_len, row 3 empty as trailing padding.
+        seq_lens = torch.tensor([0, 4, 4], device=device, dtype=torch.int32)
+        query_start_loc = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int32)
+        lse_pack_dim = _dcp_a2a_lse_pack_dim(output.dtype)
+        send_buffer = torch.full(
+            (world_size, num_tokens, h_per_rank, head_dim + lse_pack_dim),
+            float("nan"),
+            device=device,
+            dtype=output.dtype,
+        )
+
+        _dcp_a2a_pack_send(
+            output,
+            lse,
+            send_buffer,
+            world_size,
+            h_per_rank,
+            head_dim,
+            lse_pack_dim,
+            seq_lens=seq_lens,
+            query_start_loc=query_start_loc,
+        )
+        actual_output, actual_lse = _dcp_a2a_unpack_combine(
+            send_buffer,
+            head_dim,
+            lse_pack_dim,
+            return_lse=True,
+            is_lse_base_on_e=True,
+        )
+
+        empty = [0, 3]
+        assert torch.isneginf(actual_lse[empty]).all()
+        assert not torch.isnan(actual_output).any()
+        torch.testing.assert_close(
+            actual_output[empty], torch.zeros_like(actual_output[empty])
+        )
+        assert torch.isfinite(actual_output[[1, 2]]).all()
+
 
 def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
     update_environment_variables(env)

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -442,6 +442,9 @@ def _dcp_a2a_pack_send_kernel(
     out_ptr,
     lse_ptr,
     send_ptr,
+    seq_lens_ptr,
+    query_start_loc_ptr,
+    num_seqs,
     out_stride_B,
     out_stride_H,
     out_stride_D,
@@ -455,10 +458,29 @@ def _dcp_a2a_pack_send_kernel(
     HEAD_DIM: tl.constexpr,
     H_PER_RANK: tl.constexpr,
     LSE_PACK_DIM: tl.constexpr,
+    HAS_EMPTY_MASK: tl.constexpr,
+    BLOCK_SEQ: tl.constexpr,
 ):
     batch_idx = tl.program_id(0).to(tl.int64)
     local_head_idx = tl.program_id(1).to(tl.int64)
     d_offsets = tl.arange(0, HEAD_DIM)
+
+    # Rows whose local KV shard is empty carry undefined out/lse, so they must
+    # not contribute to the cross-rank merge. Folding the test in here avoids a
+    # separate masking pass (and its `.contiguous()` on the LSE) per layer.
+    empty_kv = batch_idx < 0  # tl.int1 zero, kept a tensor for the `~` below
+    if HAS_EMPTY_MASK:
+        # Trailing rows past the last sequence are padding.
+        empty_kv = batch_idx >= tl.load(query_start_loc_ptr + num_seqs)
+        seq_offs = tl.arange(0, BLOCK_SEQ)
+        for seq_base in tl.range(0, num_seqs, BLOCK_SEQ):
+            idx = seq_base + seq_offs
+            in_range = idx < num_seqs
+            seq_start = tl.load(query_start_loc_ptr + idx, mask=in_range, other=0)
+            seq_end = tl.load(query_start_loc_ptr + idx + 1, mask=in_range, other=0)
+            seq_len = tl.load(seq_lens_ptr + idx, mask=in_range, other=1)
+            hit = in_range & (batch_idx >= seq_start) & (batch_idx < seq_end)
+            empty_kv |= tl.sum((hit & (seq_len == 0)).to(tl.int32)) > 0
 
     for rank_idx in tl.static_range(N):
         src_head_idx = rank_idx * H_PER_RANK + local_head_idx
@@ -476,11 +498,13 @@ def _dcp_a2a_pack_send_kernel(
         tl.store(
             send_ptr + send_base + d_offsets * send_stride_D,
             tl.load(out_ptr + out_offsets),
+            mask=~empty_kv,
         )
 
         lse_val = tl.load(
             lse_ptr + batch_idx * lse_stride_B + src_head_idx * lse_stride_H
         ).to(tl.float32)
+        lse_val = tl.where(empty_kv, -float("inf"), lse_val)
         if LSE_PACK_DIM == 1:
             tl.store(
                 send_ptr + send_base + HEAD_DIM * send_stride_D,
@@ -636,12 +660,30 @@ def _dcp_a2a_pack_send(
     seq_lens: torch.Tensor | None = None,
     query_start_loc: torch.Tensor | None = None,
 ) -> None:
-    mask_dcp_empty_shards_(cp_attn_lse, seq_lens, query_start_loc)
+    # Empty-shard masking is folded into the pack kernel below rather than run
+    # as a separate pass, so the a2a combine costs one launch per layer instead
+    # of one plus the masking chain. The decision is made from device pointers,
+    # which keeps it correct under CUDA graph replay and identical on both model
+    # runners (Model Runner V2 has no CPU mirror of the DCP local seq lens).
+    if seq_lens is None or query_start_loc is None:
+        if seq_lens is not None or query_start_loc is not None:
+            raise ValueError("seq_lens and query_start_loc must be provided together")
+        has_empty_mask = False
+    else:
+        if seq_lens.ndim != 1 or query_start_loc.ndim != 1:
+            raise ValueError("seq_lens and query_start_loc must be 1-D")
+        if query_start_loc.shape[0] != seq_lens.shape[0] + 1:
+            raise ValueError("query_start_loc must contain one boundary per sequence")
+        has_empty_mask = True
+
     grid = (cp_attn_out.shape[0], h_per_rank, 1)
     _dcp_a2a_pack_send_kernel[grid](
         cp_attn_out,
         cp_attn_lse,
         send_buffer,
+        seq_lens if has_empty_mask else cp_attn_lse,
+        query_start_loc if has_empty_mask else cp_attn_lse,
+        seq_lens.shape[0] if has_empty_mask else 0,
         cp_attn_out.stride(0),
         cp_attn_out.stride(1),
         cp_attn_out.stride(2),
@@ -655,6 +697,8 @@ def _dcp_a2a_pack_send(
         HEAD_DIM=head_dim,
         H_PER_RANK=h_per_rank,
         LSE_PACK_DIM=lse_pack_dim,
+        HAS_EMPTY_MASK=has_empty_mask,
+        BLOCK_SEQ=128,
     )
 
 


### PR DESCRIPTION
## Purpose

Under DCP the KV cache is sharded across the group, so for a given row a rank whose local shard is empty produces undefined output and LSE. The A2A combine guards against this by running `mask_dcp_empty_shards_` before packing, driving those rows' LSE to `-inf` so they cannot contribute to the cross-rank merge.

That guard is a separate kernel chain (`arange` + `searchsorted` + compare + `masked_fill_`) on **every MLA layer of every decode step**, and it writes the LSE in place purely to communicate with the pack kernel that runs immediately afterwards. `MLAAttention` is the shared MLA layer, so the cost is paid by every MLA model running DCP with the `a2a` backend, and at least one model selects that backend by default via `set_dcp_defaults()`.

This folds the test into `_dcp_a2a_pack_send_kernel`, which already visits every `(row, head)` and can therefore decide per row, pack `-inf`, and skip the output store. The row → sequence lookup is a runtime-bounded block scan over `query_start_loc`, so a single compiled kernel covers any batch size rather than specialising per sequence count.

### Why on device

The decision stays entirely on device pointers, which matters for where the runner is heading: Model Runner V2 computes the DCP local sequence lengths with a device kernel documented as CUDA graph safe and, unlike V1, keeps no CPU mirror of them. A host-side "no shard is empty" flag would be unavailable there, and baking one into a captured graph would freeze a per-step decision. Nothing here reads host state or needs a device-to-host sync, so behaviour is identical on both runners and under graph replay.

### Scope

- **Affected:** MLA models running DCP with the `a2a` comm backend.
- **Unaffected:** the FlashAttention and FlashInfer DCP combines pass no sequence lengths, so they neither masked before nor mask now.
- `mask_dcp_empty_shards_` is retained for the AG+RS combine path.

## Test Plan

- `tests/distributed/test_dcp_a2a.py::TestPackedA2AKernels::test_pack_send_empty_mask_matches_reference` — compares packed output and LSE against the standalone `mask_dcp_empty_shards_` reference for `num_seqs ∈ {1, 5, 17, 200}`, straddling the block-scan width so the multi-iteration path is covered. Every case mixes empty shards, non-empty shards and trailing padding rows.
- `tests/distributed/test_dcp_a2a.py::TestPackedA2AKernels::test_pack_send_empty_rows_neutralize_stale_buffer` — the store is masked off for empty rows, so the send buffer keeps whatever it held. Poisons the buffer with NaN to prove the `-inf` LSE neutralises it in the combine rather than relying on the buffer happening to be benign.
- End-to-end on an 8-way TP/DCP deployment of a large MLA MoE model with the `a2a` backend and real weights: greedy decoding compared token-by-token against the unmodified baseline.

## Test Result

`tests/distributed/test_dcp_a2a.py`: 28 passed, 4 skipped. Four `test_pack_unpack_combine_matches_reference` cases fail identically on unmodified `main` in the same container (an unrelated `float32` vs `bfloat16` LSE dtype assertion), so they are not attributable to this change.

Reverse-verified: injecting a fault into the folded padding-row check turns all four `test_pack_send_empty_mask_matches_reference` cases red.

**Correctness (end to end):** greedy decoding is token-identical to the unmodified baseline across prompts leaving 7/8, 6/8 and 0/8 shards empty. A control build with the masking deliberately disabled diverges on exactly the prompts that have empty shards and agrees on those that do not, confirming the comparison can detect this class of error.

**Performance (end to end, real weights):** decode throughput 222.80 → 225.54 tok/s (+1.23%), mean TPOT 142.48 → 140.72 ms, with the two arms' ranges disjoint across repeats.

**Performance (isolated):** the masking chain costs ~44 µs per layer eagerly and ~15 µs per layer under graph replay, and is independent of batch size — it is dispatch bound, which is why folding it removes essentially all of it (13.7 µs versus 13.5 µs for the pack alone).
