### PR TITLE
[ROCm][Spec Decode] Let metadata builders declare multi-step support

### DIFF
--- a/tests/v1/spec_decode/test_llm_base_proposer.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer.py
@@ -16,10 +16,24 @@ from types import SimpleNamespace
 import pytest
 
 import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonMetadata,
+    MLACommonMetadataBuilder,
+    QueryLenSupport,
+)
+from vllm.v1.attention.backend import AttentionMetadataBuilder
+from vllm.v1.attention.backends import rocm_aiter_fa
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.worker.utils import AttentionGroup as WorkerAttentionGroup
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 SCHEDULER_BLOCK_SIZE = 256
 KERNEL_BLOCK_SIZE = 64
+
+
+class _UniformMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
+    query_len_support = QueryLenSupport.UNIFORM
 
 
 class _FakeAttentionGroup:
@@ -67,6 +81,27 @@ def _make_kv_cache_config(layer_names: set[str]) -> SimpleNamespace:
     return SimpleNamespace(kv_cache_groups=[group])
 
 
+def _make_validation_proposer(
+    supports_multi_step_drafting: bool,
+) -> EagleProposer:
+    backend = SimpleNamespace(get_name=lambda: "FakeBackend")
+    attn_group = WorkerAttentionGroup(
+        backend=backend,
+        layer_names=["draft.attn"],
+        kv_cache_spec=None,
+        kv_cache_group_id=0,
+    )
+    attn_group.metadata_builders = [
+        SimpleNamespace(
+            supports_multi_step_drafting=supports_multi_step_drafting,
+        )
+    ]
+
+    proposer = EagleProposer.__new__(EagleProposer)
+    proposer.draft_attn_groups = [attn_group]
+    return proposer
+
+
 def test_block_size_uses_kernel_block_size(monkeypatch: pytest.MonkeyPatch):
     """The proposer's slot-mapping math runs against the kernel-granularity
     block table, so block_size must come from kernel_block_sizes."""
@@ -110,3 +145,65 @@ def test_draft_layer_iteration_is_deterministic(monkeypatch: pytest.MonkeyPatch)
         assert len(proposer.draft_attn_groups) == 1
         assert proposer.draft_attn_groups[0].layer_names == expected_order
         assert proposer.block_size == KERNEL_BLOCK_SIZE
+
+
+def test_multi_step_drafting_support_defaults_to_false():
+    assert AttentionMetadataBuilder._supports_multi_step_drafting is False
+
+
+def test_mla_multi_step_drafting_support_follows_query_length_support():
+    single_only = object.__new__(MLACommonMetadataBuilder)
+    uniform = object.__new__(_UniformMLAMetadataBuilder)
+
+    assert single_only.supports_multi_step_drafting is False
+    assert uniform.supports_multi_step_drafting is True
+
+
+def test_aiter_fa_rejects_multi_step_drafting_with_shuffle_kv_cache(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    builder = object.__new__(rocm_aiter_fa.AiterFlashAttentionMetadataBuilder)
+
+    monkeypatch.setattr(
+        rocm_aiter_fa.rocm_aiter_ops,
+        "is_shuffle_kv_cache_enabled",
+        lambda: False,
+    )
+    assert builder.supports_multi_step_drafting is True
+
+    monkeypatch.setattr(
+        rocm_aiter_fa.rocm_aiter_ops,
+        "is_shuffle_kv_cache_enabled",
+        lambda: True,
+    )
+    assert builder.supports_multi_step_drafting is False
+
+
+def test_rocm_multi_step_drafting_requires_builder_support(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        llm_base_proposer,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: True),
+    )
+
+    unsupported = _make_validation_proposer(supports_multi_step_drafting=False)
+    with pytest.raises(ValueError, match="FakeBackend"):
+        unsupported._raise_if_unsupported_multi_step_drafting()
+
+    supported = _make_validation_proposer(supports_multi_step_drafting=True)
+    supported._raise_if_unsupported_multi_step_drafting()
+
+
+def test_non_rocm_multi_step_drafting_keeps_existing_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        llm_base_proposer,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: False),
+    )
+    proposer = _make_validation_proposer(supports_multi_step_drafting=False)
+
+    proposer._raise_if_unsupported_multi_step_drafting()

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2175,7 +2175,6 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
     """
 
     kv_cache_spec: AttentionSpec
-
     # Defines the level of query length support for this backend.
     # - SINGLE_ONLY: Only single-token queries (no spec decode support)
     # - UNIFORM: Supports uniform multi-token queries (spec decode with uniform lengths)
@@ -2183,6 +2182,10 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
     # If set to UNIFORM or VARLEN, this will increase `reorder_batch_threshold` when
     # speculative decoding is enabled.
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.SINGLE_ONLY
+
+    @property
+    def supports_multi_step_drafting(self) -> bool:
+        return self.query_len_support != QueryLenSupport.SINGLE_ONLY
 
     # Whether this builder can flatten a non-causal query block into decode rows.
     supports_non_causal_multi_token_decode: ClassVar[bool] = False

--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -368,6 +368,8 @@ class DeepseekV4ROCMAiterSparseSWAMetadata(DeepseekSparseSWAMetadata):
 
 
 class DeepseekV4ROCMAiterMLASparseMetadataBuilder(DeepseekV4SparseMLAMetadataBuilder):
+    _supports_multi_step_drafting = True
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.c128a_decode_topk_ragged_indices_buffer: torch.Tensor | None = None
@@ -435,6 +437,7 @@ class DeepseekV4ROCMAiterMLASparseMetadataBuilder(DeepseekV4SparseMLAMetadataBui
 
 
 class DeepseekV4ROCMAiterSparseSWAMetadataBuilder(DeepseekSparseSWAMetadataBuilder):
+    _supports_multi_step_drafting = True
     # Keep fused multi-step decode disabled until update_draft_decode_metadata()
     # also refreshes the ROCm-specific ragged SWA indices and indptrs.
     supports_draft_decode_metadata_update = False

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -230,6 +230,7 @@ class MiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[MiniMaxM3SparseMet
     # Full cudagraphs for uniform decode batches, incl. spec-decode verify
     # batches with >1 query token/request.
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    _supports_multi_step_drafting = True
     # Raised to 1 + num_speculative_tokens by _init_reorder_batch_threshold when
     # spec decode is on; must match the indexer builder so the splits agree.
     reorder_batch_threshold: int = 1

--- a/vllm/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm/models/qwen4_exp/common/qsa_cache.py
@@ -600,6 +600,7 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
     """Build QSA metadata from vLLM's cache-group-specific common metadata."""
 
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    _supports_multi_step_drafting = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -597,6 +597,8 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     # Whether all step-dependent draft decode metadata can be updated in place,
     # allowing one metadata build to be reused across autoregressive draft steps.
     supports_draft_decode_metadata_update: bool = False
+    # Whether autoregressive multi-step drafting supports this metadata builder.
+    _supports_multi_step_drafting: ClassVar[bool] = False
 
     @abstractmethod
     def __init__(
@@ -614,6 +616,10 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
 
     def set_kernel_block_size(self, kernel_block_size: int) -> None:
         self.kernel_block_size = kernel_block_size
+
+    @property
+    def supports_multi_step_drafting(self) -> bool:
+        return self._supports_multi_step_drafting
 
     @classmethod
     def get_cudagraph_support(

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -335,6 +335,8 @@ def _maybe_symmetrize_window(
 
 
 class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetadata]):
+    _supports_multi_step_drafting = True
+
     # FA3:
     # Supports full cudagraphs for all cases.
     #

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -846,6 +846,7 @@ class FlexAttentionMetadata:
 
 class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
+    _supports_multi_step_drafting = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -697,6 +697,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
     # so this is None; its own split uses self.decode_threshold.
     reorder_batch_threshold: int | None = None
     requires_block_table_width = True
+    _supports_multi_step_drafting = True
 
     @classmethod
     def get_cudagraph_support(

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -396,6 +396,7 @@ class ROCMAiterMLASparseMetadataBuilder(
     AttentionMetadataBuilder[ROCMAiterMLASparseMetadata]
 ):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    _supports_multi_step_drafting = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -496,6 +496,12 @@ class AiterFlashAttentionMetadataBuilder(
         )
         self.scale = torch.tensor([1.0], dtype=torch.float, device=self.device)
 
+    @property
+    def supports_multi_step_drafting(self) -> bool:
+        # The shuffle layout has no general multi-token fallback when Gluon
+        # declines a batch, so reject it before reaching the kernel assertion.
+        return not rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata
     ):

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -75,6 +75,7 @@ class RocmAttentionMetadata:
 
 class RocmAttentionMetadataBuilder(AttentionMetadataBuilder[RocmAttentionMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
+    _supports_multi_step_drafting = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -98,6 +98,7 @@ class TritonAttentionMetadata:
 
 class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
+    _supports_multi_step_drafting = True
     # Step-dependent fields reference persistent input buffers directly.
     supports_draft_decode_metadata_update = True
 

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
-from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -39,8 +38,6 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
-from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -259,67 +256,6 @@ class SpecDecodeBaseProposer:
             self.max_positions, dtype=torch.int64, device=device
         )
 
-        # Determine allowed attention backends once during initialization.
-        self.allowed_attn_types: tuple | None = None
-        if current_platform.is_rocm():
-            from vllm.models.deepseek_v4.amd.rocm import (
-                DeepseekV4ROCMAiterMLASparseMetadata,
-                DeepseekV4ROCMAiterSparseSWAMetadata,
-            )
-
-            # MiniMax-M3 sparse (lightning-indexer) attention. The multi-step
-            # drafting machinery is shared code at num_speculative_tokens>1.
-            # this just opts the metadata into the ROCm allowlist.
-            from vllm.models.minimax_m3.common.sparse_attention import (
-                MiniMaxM3SparseMetadata,
-            )
-            from vllm.v1.attention.backends.mla.indexer import (
-                DeepseekV32IndexerMetadata,
-            )
-            from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
-                ROCMAiterMLASparseMetadata,
-            )
-            from vllm.v1.attention.backends.rocm_attn import RocmAttentionMetadata
-
-            rocm_types = [
-                TritonAttentionMetadata,
-                RocmAttentionMetadata,
-                ROCMAiterMLASparseMetadata,
-                DeepseekV4ROCMAiterMLASparseMetadata,
-                DeepseekV4ROCMAiterSparseSWAMetadata,
-                DeepseekV32IndexerMetadata,
-                MiniMaxM3SparseMetadata,
-            ]
-            # ROCM_AITER_FA is an optional backend
-            # We check is_enabled() here to avoid importing the backend module during
-            # auto-discovery when VLLM_ROCM_USE_AITER=0, which would trigger aiter
-            # import and JIT compilation warnings. Explicit backend selection via
-            # attention_config still works because the backend module is loaded
-            # directly when selected, not through this auto-discovery path.
-            # Check if backend module exists to allow explicit selection
-            if find_spec(
-                AttentionBackendEnum.ROCM_AITER_FA.get_path(include_classname=False)
-            ):
-                from vllm.v1.attention.backends.rocm_aiter_fa import (
-                    AiterFlashAttentionMetadata,
-                )
-
-                rocm_types.append(AiterFlashAttentionMetadata)
-
-            # TRITON_MLA backend support for MLA models (e.g., DeepSeek)
-            from vllm.model_executor.layers.attention.mla_attention import (
-                MLACommonMetadata,
-            )
-
-            rocm_types.append(MLACommonMetadata)
-
-            # FlexAttention backend support
-            from vllm.v1.attention.backends.flex_attention import FlexAttentionMetadata
-
-            rocm_types.append(FlexAttentionMetadata)
-
-            self.allowed_attn_types = tuple(rocm_types)
-
     def _raise_if_padded_drafter_batch_disabled(self):
         if self.speculative_config.disable_padded_drafter_batch:
             raise NotImplementedError(
@@ -341,6 +277,24 @@ class SpecDecodeBaseProposer:
             raise NotImplementedError(
                 "Speculative Decoding with draft models or parallel drafting "
                 "does not support M-RoPE yet"
+            )
+
+    def _raise_if_unsupported_multi_step_drafting(self) -> None:
+        if not current_platform.is_rocm():
+            return
+
+        unsupported_backends = sorted(
+            {
+                attn_group.backend.get_name()
+                for attn_group in self.draft_attn_groups
+                if not attn_group.supports_multi_step_drafting
+            }
+        )
+        if unsupported_backends:
+            raise ValueError(
+                "Unsupported attention backend(s) for speculative decoding "
+                "with num_speculative_tokens > 1 on ROCm: "
+                f"{', '.join(unsupported_backends)}"
             )
 
     def set_eplb_state(self, eplb_state: EplbState) -> None:
@@ -651,15 +605,7 @@ class SpecDecodeBaseProposer:
         )
         draft_probs_list = None if draft_probs is None else [draft_probs]
 
-        if self.allowed_attn_types is not None:
-            for group_md in per_group_attn_metadata:
-                if not isinstance(group_md, self.allowed_attn_types):
-                    raise ValueError(
-                        f"Unsupported attention metadata type for speculative "
-                        "decoding with num_speculative_tokens > 1: "
-                        f"{type(group_md)}. Supported types are: "
-                        f"{self.allowed_attn_types}"
-                    )
+        self._raise_if_unsupported_multi_step_drafting()
 
         # Generate the remaining draft tokens.
         draft_token_ids_list = [draft_token_ids]

--- a/vllm/v1/spec_decode/step3p5.py
+++ b/vllm/v1/spec_decode/step3p5.py
@@ -361,15 +361,7 @@ class Step3p5MTPProposer(EagleProposer):
         )
         draft_probs_list = None if draft_probs is None else [draft_probs]
 
-        if self.allowed_attn_types is not None:
-            for group_md in per_group_attn_metadata:
-                if not isinstance(group_md, self.allowed_attn_types):
-                    raise ValueError(
-                        f"Unsupported attention metadata type for speculative "
-                        "decoding with num_speculative_tokens > 1: "
-                        f"{type(group_md)}. Supported types are: "
-                        f"{self.allowed_attn_types}"
-                    )
+        self._raise_if_unsupported_multi_step_drafting()
 
         draft_token_ids_list = [draft_token_ids]
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -317,6 +317,10 @@ class AttentionGroup:
     def supports_draft_decode_metadata_update(self) -> bool:
         return self.get_metadata_builder().supports_draft_decode_metadata_update
 
+    @property
+    def supports_multi_step_drafting(self) -> bool:
+        return self.get_metadata_builder().supports_multi_step_drafting
+
     def update_draft_decode_metadata(
         self,
         attn_metadata: Mapping[str, Any],


### PR DESCRIPTION
## Purpose

Fixes #53983.

ROCm multi-step speculative decoding currently checks generated attention metadata against a centralized tuple in `SpecDecodeBaseProposer`. That tuple requires proposer-side imports for every supported backend and has repeatedly missed valid metadata types.

This change:

- adds a fail-closed `supports_multi_step_drafting` capability to `AttentionMetadataBuilder`;
- moves existing ROCm allowlist entries to declarations on their corresponding builders;
- opts in FlashAttention and the QSA side-cache builder used by Qwen3.8-Flash-Next;
- derives MLA support from query-length support and rejects AITER FlashAttention when shuffle KV cache lacks a general multi-token fallback;
- shares one backend-level validation path between the base proposer and Step3.5; and
- removes the proposer-side metadata imports and optional-backend discovery.

The runtime gate remains ROCm-only, preserving behavior on other platforms while replacing the hand-maintained type registry.

Before submission, I searched open PR titles and bodies for `#53983`, `allowed_attn_types`, `attention metadata allowlist`, and `multi-step drafting`. I found no PR implementing this capability refactor.

AI assistance was used to inspect the codebase, implement the change, and run validation. I reviewed every changed line and understand the implementation and tests.

## Test Plan

```bash
git diff --check
pre-commit run ruff-check --files <changed files>
pre-commit run ruff-format --files <changed files>
pre-commit run mypy-3.10 --files <changed Python files>
PYTHONPATH=$PWD python -m pytest tests/v1/spec_decode/test_llm_base_proposer.py -q
```

The unit tests cover the fail-closed default, rejection and acceptance on ROCm, unchanged behavior on non-ROCm platforms, MLA query-length capability derivation, and the AITER shuffle KV cache guard.

## Test Result

- `git diff --check`: passed
- `ruff-check`: passed
- `ruff-format`: passed
- `mypy-3.10`: passed
- `tests/v1/spec_decode/test_llm_base_proposer.py`: 8 passed

ROCm hardware end-to-end testing was not available locally. No model evaluation was run because this change does not alter model outputs, accuracy, or serving behavior for already-supported backends; it refactors the support gate and adds the two metadata builders identified in #53983.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan and commands are provided.
- [x] Test results and hardware limitations are provided.
- [x] No documentation update is needed for this internal capability refactor.
</details>
