### PR TITLE
[Examples] Point disaggregated_serving README at sibling mooncake_connector

### DIFF
--- a/examples/disaggregated/disaggregated_serving/README.md
+++ b/examples/disaggregated/disaggregated_serving/README.md
@@ -6,4 +6,4 @@ This example contains scripts that demonstrate the disaggregated serving feature
 
 - `disagg_proxy_demo.py` - Demonstrates XpYd (X prefill instances, Y decode instances).
 - `kv_events.sh` - Demonstrates KV cache event publishing.
-- `mooncake_connector` - A proxy demo for MooncakeConnector.
+- [`../mooncake_connector/`](../mooncake_connector/) — MooncakeConnector proxy demo (`run_mooncake_connector.sh`, `mooncake_connector_proxy.py`).


### PR DESCRIPTION
## Summary

The `## Files` list in `examples/disaggregated/disaggregated_serving/README.md` claims `mooncake_connector` is a same-directory entry, but that path 404s. The MooncakeConnector proxy demo lives in the sibling directory `examples/disaggregated/mooncake_connector/` (`mooncake_connector_proxy.py`, `run_mooncake_connector.sh`).

This PR replaces the ghost bullet with a relative link to that sibling directory. No other README content is changed.

## Repro

```bash
# Ghost same-dir path (404)
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/examples/disaggregated/disaggregated_serving/mooncake_connector

# Sibling demo files (200)
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/examples/disaggregated/mooncake_connector/mooncake_connector_proxy.py
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/examples/disaggregated/mooncake_connector/run_mooncake_connector.sh
```

Contents listing of `examples/disaggregated/disaggregated_serving/` has no `mooncake_connector`; sibling `examples/disaggregated/mooncake_connector/` contains the two files above.

## Fix

Point the bullet at [`../mooncake_connector/`](../mooncake_connector/) and name the real entry scripts.
