### PR TITLE
[Docs] Update Python support range to 3.10--3.14

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -74,7 +74,7 @@ For an optimized workflow when iterating on C++/CUDA kernels, see the [Increment
 For JIT kernel warmup conventions, see [JIT Kernel Warmup](./jit_kernel_warmup.md).
 
 !!! tip
-    vLLM is compatible with Python versions 3.10 to 3.13. However, vLLM's default [Dockerfile](../../docker/Dockerfile) ships with Python 3.12 and tests in CI (except `mypy`) are run with Python 3.12.
+    vLLM is compatible with Python versions 3.10 to 3.14. However, vLLM's default [Dockerfile](../../docker/Dockerfile) ships with Python 3.12 and tests in CI (except `mypy`) are run with Python 3.12.
 
     Therefore, we recommend developing with Python 3.12 to minimise the chance of your local environment clashing with our CI environment.
 

--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -30,7 +30,7 @@ When open a Github issue about the CPU backend, please add `[CPU Backend]` in th
 
 ## Requirements
 
-- Python: 3.10 -- 3.13
+- Python: 3.10 -- 3.14
 
 === "Intel/AMD x86"
 

--- a/docs/getting_started/installation/gpu.md
+++ b/docs/getting_started/installation/gpu.md
@@ -25,7 +25,7 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 ## Requirements
 
 - OS: Linux
-- Python: 3.10 -- 3.13
+- Python: 3.10 -- 3.14
 
 !!! note
     vLLM does not support Windows natively. To run vLLM on Windows, you can use the Windows Subsystem for Linux (WSL) with a compatible Linux distribution, or use some community-maintained forks, e.g. [https://github.com/SystemPanic/vllm-windows](https://github.com/SystemPanic/vllm-windows).

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -8,7 +8,7 @@ This guide will help you quickly get started with vLLM to perform:
 ## Prerequisites
 
 - OS: Linux
-- Python: 3.10 -- 3.13
+- Python: 3.10 -- 3.14
 
 !!! note
     vLLM also works on macOS with [vLLM-Metal](https://github.com/vllm-project/vllm-metal) for Apple Silicon GPU acceleration. See the [GPU installation guide](installation/gpu.md) and select the "Apple Silicon" tab.


### PR DESCRIPTION
## Purpose

Install/quickstart/contributing docs still list Python support as ending at 3.13, but `pyproject.toml` already allows `>=3.10,<3.15` and includes the `Programming Language :: Python :: 3.14` classifier.

## Changes

- `docs/getting_started/quickstart.md`: prerequisites Python range → `3.10 -- 3.14`
- `docs/getting_started/installation/gpu.md`: same
- `docs/getting_started/installation/cpu.md`: same
- `docs/contributing/README.md`: tip "compatible with Python versions 3.10 to 3.13" → `3.10 to 3.14` (Dockerfile/CI 3.12 recommendation unchanged)

## Local reproduction

```bash
# Code truth
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/pyproject.toml   | rg -n 'requires-python|Python :: 3\.1'

# Docs (still 3.13 on main before this PR)
for f in   docs/getting_started/quickstart.md   docs/getting_started/installation/gpu.md   docs/getting_started/installation/cpu.md
do
  echo "==== $f ===="
  curl -sL "https://raw.githubusercontent.com/vllm-project/vllm/main/$f"     | rg -n 'Python: 3\.10'
done

echo "==== docs/contributing/README.md ===="
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/contributing/README.md   | rg -n 'compatible with Python versions'
```

Expected on main: docs say `3.10 -- 3.13` / `3.10 to 3.13` while `requires-python = ">=3.10,<3.15"` and classifiers include 3.14.

## Test plan

- [ ] Confirm the three getting_started docs lines read `Python: 3.10 -- 3.14`
- [ ] Confirm contributing tip reads `3.10 to 3.14` and still recommends developing on 3.12
- [ ] Confirm no unrelated files changed
