### PR TITLE
[Bugfix][KV Connector] Recompute after Mooncake load failures

### DIFF
--- a/tests/v1/kv_connector/unit/test_error_propagation.py
+++ b/tests/v1/kv_connector/unit/test_error_propagation.py
@@ -90,6 +90,7 @@ def test_error_propagation_sync_load(fail_scheduler: Scheduler):
     assert output.finish_reason == FinishReason.ERROR
 
     assert len(fail_scheduler.running) == 0
+    fail_scheduler.connector.on_load_failure.assert_not_called()
 
 
 def test_error_propagation_async_load(fail_scheduler: Scheduler):
@@ -146,3 +147,4 @@ def test_error_propagation_async_load(fail_scheduler: Scheduler):
 
     assert len(fail_scheduler.waiting) == 0
     assert len(fail_scheduler.skipped_waiting) == 0
+    fail_scheduler.connector.on_load_failure.assert_not_called()

--- a/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
@@ -108,6 +108,12 @@ def test_async_load_failure(
             assert request.num_computed_tokens == num_external_computed_tokens
         assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
     assert scheduler.failed_recving_kv_req_ids == {request2.request_id}
+    if min_invalid_block_idx == 0:
+        scheduler.connector.on_load_failure.assert_called_once_with(
+            {request2.request_id}
+        )
+    else:
+        scheduler.connector.on_load_failure.assert_not_called()
     assert scheduler.connector.get_num_new_matched_tokens.call_count == 3
 
 
@@ -183,6 +189,7 @@ def test_sync_load_failure(
     assert scheduler.running[0].num_computed_tokens == (
         min(invalid_block_idxs) * scheduler.block_size
     )
+    scheduler.connector.on_load_failure.assert_not_called()
     assert scheduler.connector.get_num_new_matched_tokens.call_count == 3
     assert scheduler.connector.request_finished.call_count == 2
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -39,6 +39,7 @@ def _make_bare_scheduler(
         select_transfer_block_ids=lambda block_ids: tuple(block_ids)
     )
     scheduler.load_specs = {}
+    scheduler._load_failure_bypass_req_ids = set()
     scheduler._unfinished_request_ids = {"req-0"}
     scheduler._unfinished_requests = {}
     scheduler._request_trackers = {}
@@ -51,6 +52,28 @@ def _make_bare_scheduler(
     scheduler._pinned_saves = {}
     scheduler._boundary_state_group_ids = frozenset({1})
     return scheduler
+
+
+def test_load_failure_bypasses_external_lookup_until_allocation():
+    scheduler = _make_bare_scheduler()
+    scheduler.load_specs["req-0"] = object()
+    scheduler.on_load_failure({"req-0"})
+    request = SimpleNamespace(request_id="req-0", num_tokens=32, block_hashes=[])
+    scheduler.client = _StubLookupClient(hit_tokens=0)
+
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+    assert scheduler.client.num_tokens == []
+    assert scheduler._load_failure_bypass_req_ids == {"req-0"}
+    assert scheduler.load_specs == {}
+
+    scheduler.update_state_after_alloc(
+        request, SimpleNamespace(), num_external_tokens=0
+    )
+    assert scheduler._load_failure_bypass_req_ids == set()
+
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+    assert scheduler.client.num_tokens == [32]
 
 
 def _make_connector_block_state(

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -149,6 +149,20 @@ KVConnectorFactory.register_connector(
 )
 
 
+def test_load_failure_notifies_every_connector():
+    connector = object.__new__(MultiConnector)
+    connector._connectors = [
+        MagicMock(spec_set=KVConnectorBase_V1),
+        MagicMock(spec_set=KVConnectorBase_V1),
+    ]
+    request_ids = {"req-0", "req-1"}
+
+    connector.on_load_failure(request_ids)
+
+    for child in connector._connectors:
+        child.on_load_failure.assert_called_once_with(request_ids)
+
+
 def test_register_finished_partial_tail_notifies_every_connector():
     connector = object.__new__(MultiConnector)
     first = MagicMock(spec_set=KVConnectorBase_V1)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -530,6 +530,16 @@ class KVConnectorBase_V1(ABC):
         """
         return
 
+    def on_load_failure(self, request_ids: set[str]) -> None:
+        """Notify the connector before failed external KV loads are looked up again.
+
+        Connectors may use this callback to make a failed external cache hit a
+        request-local miss on the next scheduling attempt. The default is a
+        no-op because not every connector needs special handling before the
+        affected tokens are recomputed.
+        """
+        return
+
     def update_connector_output(self, connector_output: KVConnectorOutput):
         """
         Update KVConnector state from worker-side connectors output.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -308,6 +308,10 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         else:
             self._kv_cache_events.add_events(kv_cache_events.get_all_events())
 
+    def on_load_failure(self, request_ids: set[str]) -> None:
+        if self.connector_scheduler is not None:
+            self.connector_scheduler.on_load_failure(request_ids)
+
     def take_events(self) -> Iterable[KVCacheEvent]:
         if self._kv_cache_events is not None:
             events = self._kv_cache_events.pop_common_events()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -99,6 +99,9 @@ class MooncakeStoreScheduler:
 
         # Per-request state
         self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
+        # A failed load can rewind a request to token zero. Bypass lookups
+        # until local allocation succeeds so stale metadata cannot cause a livelock.
+        self._load_failure_bypass_req_ids: set[str] = set()
         self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
         self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
         self._unfinished_request_ids: set[str] = set()
@@ -117,6 +120,14 @@ class MooncakeStoreScheduler:
         Returns ``(None, False)`` when an async lookup is still in flight,
         signaling the scheduler to retry this request on a later step.
         """
+        if request.request_id in self._load_failure_bypass_req_ids:
+            self.load_specs.pop(request.request_id, None)
+            logger.info(
+                "Skipping Mooncake lookup for request %s after KV load failure",
+                request.request_id,
+            )
+            return 0, False
+
         if not self.enable_lookup:
             return 0, False
 
@@ -179,6 +190,7 @@ class MooncakeStoreScheduler:
 
         self._unfinished_requests[request.request_id] = (request, local_block_ids)
         self._unfinished_request_ids.add(request.request_id)
+        self._load_failure_bypass_req_ids.discard(request.request_id)
 
         if request.request_id not in self.load_specs:
             return
@@ -210,6 +222,7 @@ class MooncakeStoreScheduler:
 
         for finished_req_id in scheduler_output.finished_req_ids:
             self.client.discard(finished_req_id)
+            self._load_failure_bypass_req_ids.discard(finished_req_id)
             self.load_specs.pop(finished_req_id, None)
             self._request_trackers.pop(finished_req_id, None)
             self._unfinished_requests.pop(finished_req_id, None)
@@ -589,6 +602,10 @@ class MooncakeStoreScheduler:
                     boundary_state_offloads=accepted,
                 )
             )
+
+    def on_load_failure(self, request_ids: set[str]) -> None:
+        """Skip external lookups until requests are allocated for recompute."""
+        self._load_failure_bypass_req_ids.update(request_ids)
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Drop the block references of store jobs every rank has finished."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -426,6 +426,10 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         for c in self._connectors:
             c.on_new_request(request)
 
+    def on_load_failure(self, request_ids: set[str]) -> None:
+        for c in self._connectors:
+            c.on_load_failure(request_ids)
+
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> MultiKVConnectorMetadata:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -3118,6 +3118,17 @@ class Scheduler(SchedulerInterface):
             total_failed_tokens,
         )
 
+        # Only async requests rewound to zero return to the waiting queue and
+        # run the connector lookup again. Notify the connector so a persistent
+        # external hit cannot make that request repeat the same failed load.
+        async_relookup_req_ids = {
+            req_id
+            for req_id in async_failed_req_ids
+            if self.requests[req_id].num_computed_tokens == 0
+        }
+        if self.connector is not None and async_relookup_req_ids:
+            self.connector.on_load_failure(async_relookup_req_ids)
+
         # Mark async requests with KV load failures for retry once loading completes
         self.failed_recving_kv_req_ids |= async_failed_req_ids
         # Return sync affected IDs to skip in update_from_output


### PR DESCRIPTION
## Purpose

Fix an unbounded lookup/load loop in `MooncakeStoreConnector` with
asynchronous loading and `kv_load_failure_policy="recompute"`.

When the first external block fails to load, recovery rewinds the request
to zero. The next scheduling attempt performs the same lookup again, so
persistent data-plane failures can repeatedly return the same master-side
hit and prevent the request from making progress.

Notify the connector only for asynchronous failures rewound to zero.
MooncakeStore makes the next lookup a one-shot request-local miss, allowing
local recomputation without invalidating global metadata or changing the
default failure policy.

Duplicate check: #54870 concerns a block-table assertion during recovery,
while #55113 caps full-prompt hits on the synchronous path; neither addresses
this retry loop.

## Test Plan

- Unit tests for async first/middle/tail block failures, synchronous recovery,
  fail policy isolation, one-shot bypass, and `MultiConnector` forwarding.
- Legacy DISK integration test: retain master metadata, remove the backing
  files, then issue a matching request with async loading and recompute enabled.

## Test Result

- Recovery and MooncakeStore unit tests: 55 passed.
- Targeted `MultiConnector` test: 1 passed.
- All applicable pre-commit hooks passed.
- Integration test before the fix: 11,747 recovery attempts in about one
  minute; the request never completed.
- Integration test after the fix: one lookup, one failed load, one recovery,
  then local recomputation and HTTP 200. No second external load was attempted.

AI assistance (OpenAI Codex) was used for the analysis, implementation, and
testing; the submitter reviewed the change.