### PR TITLE
[Bugfix][DSv4] Seed the -1 sentinel in the prefill sparse index workspace

### DIFF
--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -561,6 +561,7 @@ def combine_topk_swa_indices(
         )
     else:
         combined_indices, combined_lens = out
+        combined_indices.fill_(-1)
 
     _COMBINE_TOPK_SWA_INDICES_KERNEL(
         combined_indices,


### PR DESCRIPTION
## Purpose

`combine_topk_swa_indices` writes only the valid prefix of each row and leaves
the rest to the `-1` sentinel that `topk_length` pairs with. The `out=None` path
gets that sentinel from `torch.full`; the caller-supplied path does not seed it,
so a workspace buffer reaches the sparse attention kernel with whatever was in
those columns before.

On main this stays latent: the prefill chunk plan normally yields a single chunk,
so the same workspace slot is rewritten on every call and the padding holds last
call's valid indices. It stops being latent as soon as the plan yields many
chunks and the workspace rotates through a slot nothing has written yet — then
the padding is uninitialized memory, and the kernel reads it as KV indices.

## Repro

Reproduced on top of the in-flight DeepSeek-V4 batch-invariant work
(#54955), where the prefill chunk plan is one chunk per request. A 256-request
warmup step then walks the arena, and serving DeepSeek-V4-Flash aborts during
startup as soon as prefill is captured into a CUDA graph
(`cudagraph_mode=PIECEWISE` or `FULL_AND_PIECEWISE`, `--max-num-seqs 256`):

```
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

Instrumenting the `flash_mla_sparse_fwd` call site to compare
`combined_indices.max()` against the KV workspace row count shows the padding
being read: `idx_max=2113501039` against `kv_rows=2`, 404,096 occurrences in a
single startup. With this patch that count is 0 and the warmup prefill
completes.

The fix is the same seeding every other path already performs:

- `combine_topk_swa_indices`'s own `out=None` branch (`torch.full(fill_value=-1)`)
- the ROCm variant of this function, `models/deepseek_v4/amd/rocm.py`
- the XPU variant, `models/deepseek_v4/xpu/xpu_sparse_decode_fp8.py`
- `v1/attention/backends/mla/compressor_utils.py`, which fills a caller-supplied
  `out` buffer and carries the note this PR is a second instance of:

  ```
  # Negative positions produce bogus block indices that lead to illegal memory
  # accesses inside the block_table load.
  # NOTE: Fill -1 to the whole tensor, not just the first `num_tokens`.
  ```

The CUDA `out=` path is the only one that skips it.

## Test Plan

```bash
pre-commit run --all-files   # ruff, ruff-format, mypy
```

End-to-end on 8x GB200 (DP8/EP8/TP1, DeepSeek-V4-Flash, fp8 KV,
`--max-num-seqs 256`, `cudagraph_mode=PIECEWISE`), plus a 1-GPU 4-layer proxy of
the same model.

## Test Result

- `pre-commit`: passed (ruff, ruff-format, mypy).
- Out-of-range sparse index reads at the `flash_mla_sparse_fwd` call site:
  404,096 -> 0.
- The prefill warmup step now completes all 256 chunks instead of aborting part
  way through.
- No behavior change where the buffer was already being rewritten: this replaces
  reads of uninitialized memory with the sentinel the kernel contract assumes.

### Additional A/B validation (2026-09-05)

Both experiments used full DeepSeek-V4-Flash (revision
`553034d7dd9e06c2eeaee68cf85a17d6d4754cf0`) on 4x GB200 with TP4 + EP,
FP8 KV cache, and `FULL_AND_PIECEWISE` CUDA graphs. Within each experiment,
A is the unmodified image and B adds only `combined_indices.fill_(-1)`.
The accuracy and throughput experiments use different pinned nightly builds.

**GSM8K:** all 1,319 test questions, repository 5-shot completion prompts and
answer extraction, temperature 0, seed 42, concurrency 256, maximum 2,048
output tokens, and prefix caching disabled. Evaluated via `/v1/completions`
using the local `run_eval.py` harness based on `tests/evals/gsm8k/gsm8k_eval.py`.

| Configuration | Full runs | Correct answers | Accuracy |
|---|---:|---|---|
| A: original | 5 | 1249, 1249, 1255, 1248, 1253 / 1319 | 94.62%–95.15% |
| B: patched | 3 | 1249 / 1319 in every run | 94.69% |

All runs completed without request errors or output truncation. No clear
accuracy regression was observed. Dynamic batching produced different answers
even across unchanged baseline runs, so these results do not establish exact
output equivalence or rule out a small accuracy change.

Accuracy image: nightly built 2026-09-04 05:34 UTC, vLLM commit
`8a728663c1c3eeace834a95f5654fa653cc1998c`, ARM64 digest
`sha256:a551e05307cd2e0092139d84db32af9c97e67d2eeeff072d21e429131d8c23f0`.

**Controlled offline throughput:** exclusive 4-GPU Slurm node; fixed CPU and
NUMA memory binding; 1,024 pretokenized requests, each with 1,024 input tokens
and exactly 256 output tokens. Concurrency cap 128, token budget 8,192, model
length 8,192, block size 256, GPU memory utilization 0.85, prefix caching off,
greedy decoding with seed 42, `ignore_eos=True`, and detokenization disabled.
Each engine received four full warmup rounds followed by seven measured rounds.

The custom offline `LLM` harness pauses scheduling, enqueues all requests, and
times scheduling wake-up through completion of all outputs. This includes
prefill, decode, communication, and output collection; initialization, enqueue
submission, HTTP, tokenization, and result-file writes are excluded. No
profiler was active. Engine/frontend CPUs: 0–3; worker CPUs: 4–19, 20–35,
74–89, 90–105; worker memory nodes: 0, 0, 1, 1 via native `numa_bind`.

| Configuration | Median elapsed | Output tokens/s | Within-process CV |
|---|---:|---:|---:|
| A: original | 47.682 s | 5497.7 | 0.153% |
| B: patched | 47.985 s | 5463.0 | 0.139% |

B's measured throughput is **0.63% lower** on this workload; no throughput
improvement was measured. These are repeated measurements of one independent
engine per configuration, not seven independent engines. Further process
restarts were stopped before collecting another complete pair, so this small
difference is not evidence of a stable regression. All 22 warmup/measured
rounds generated exactly 262,144 output tokens, had identical output-token
hashes across A/B, and recorded zero preemptions. This fixed-length workload
is not an accuracy evaluation.

Throughput image: nightly built 2026-09-05 05:34 UTC, vLLM commit
`e962733e08d10f7ca65dac4df99e116460b8b174`, ARM64 digest
`sha256:df871f170ee7070fbdce162bde08fb616e311570c948a620be0d4b33fe02f87b`.

The isolated throughput harness was executed in fresh engines with:

```bash
taskset -c 0-3 /results/stable-throughput/.venv/bin/python /results/stable-throughput/bench.py A1 --numa-bind
taskset -c 0-3 /results/stable-throughput/.venv/bin/python /results/stable-throughput/bench.py B1 --numa-bind
```

Earlier unbound runs showed substantial process-to-process variation, including
an unchanged B process taking about 58.5 s per round and falling to 48.44 s
after CPU-affinity binding. Dynamic GSM8K timings also reversed direction on
A→B→A repetition. Those timings are not used to claim a PR speedup. This PR is
a workspace correctness fix, not a demonstrated end-to-end optimization.

## Related work

This is the focused sentinel-initialization fix exposed while testing #54955,
which is a broader, explicitly non-mergeable batch-invariance preview. It does
not introduce that preview's batching or kernel changes. The related open
#42504 adds a sparse-gather implementation rather than initializing this
caller's existing output workspace.

## Notes

AI assistance was used for this change: the fault was located with
instrumentation written by Claude Code, and the patch was drafted with it. The
diff is one line and I have reviewed it end to end.

The additional A/B evaluations, profiling, and reporting were performed with
Codex assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

