### PR TITLE
[Bugfix] Resolve ModelScope processor paths across cache layouts

### DIFF
--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import sys
-from types import ModuleType
-from unittest.mock import Mock
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -13,6 +12,57 @@ from vllm.transformers_utils.utils import (
     is_gcs,
     is_s3,
 )
+
+
+@pytest.fixture
+def modelscope_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_USE_MODELSCOPE", "1")
+    legacy_root = tmp_path / "hub" / "models"
+    file_utils = ModuleType("modelscope.utils.file_utils")
+    monkeypatch.setattr(
+        file_utils, "get_model_cache_root", lambda: str(legacy_root), raising=False
+    )
+    hub = ModuleType("modelscope_hub")
+    monkeypatch.setattr(
+        hub,
+        "get_default_config",
+        lambda: SimpleNamespace(cache_dir=tmp_path),
+        raising=False,
+    )
+    monkeypatch.setitem(sys.modules, "modelscope", ModuleType("modelscope"))
+    monkeypatch.setitem(sys.modules, "modelscope.utils", ModuleType("modelscope.utils"))
+    monkeypatch.setitem(sys.modules, "modelscope.utils.file_utils", file_utils)
+    monkeypatch.setitem(sys.modules, "modelscope_hub", hub)
+    return tmp_path
+
+
+@pytest.mark.parametrize("revision", [None, "release/v1"])
+def test_modelscope_resolves_requested_snapshot(modelscope_cache, revision):
+    """Resolve the requested revision even when another snapshot is cached."""
+    snapshots = modelscope_cache / "models" / "org--model" / "snapshots"
+    (snapshots / "unrelated").mkdir(parents=True)
+    expected = snapshots / (revision or "master")
+    expected.mkdir(parents=True)
+    assert convert_model_repo_to_path("org/model", revision) == str(expected)
+
+
+def test_modelscope_prefers_existing_legacy_cache(modelscope_cache):
+    legacy = modelscope_cache / "hub" / "models" / "org" / "model"
+    legacy.mkdir(parents=True)
+    (modelscope_cache / "models" / "org--model" / "snapshots" / "master").mkdir(
+        parents=True
+    )
+    assert convert_model_repo_to_path("org/model") == str(legacy)
+
+
+def test_modelscope_missing_cache_preserves_legacy_path(modelscope_cache):
+    """Missing snapshots must not trigger downloads or select another revision."""
+    (modelscope_cache / "models" / "org--model" / "snapshots" / "other").mkdir(
+        parents=True
+    )
+    expected = modelscope_cache / "hub" / "models" / "org" / "model"
+    assert convert_model_repo_to_path("org/model", "missing") == str(expected)
+    assert not expected.exists()
 
 
 def test_is_gcs():
@@ -42,46 +92,3 @@ def test_is_cloud_storage():
     assert is_cloud_storage("az://model-container/path")
     assert not is_cloud_storage("/unix/local/path")
     assert not is_cloud_storage("nfs://nfs-fqdn.local")
-
-
-def test_convert_model_repo_to_path_without_modelscope(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.delenv("VLLM_USE_MODELSCOPE", raising=False)
-
-    assert convert_model_repo_to_path("org/model") == "org/model"
-
-
-def test_convert_model_repo_to_path_preserves_local_path(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-):
-    monkeypatch.setenv("VLLM_USE_MODELSCOPE", "true")
-
-    assert convert_model_repo_to_path(str(tmp_path)) == str(tmp_path)
-
-
-def test_convert_model_repo_to_path_uses_modelscope_snapshot(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setenv("VLLM_USE_MODELSCOPE", "true")
-    snapshot_path = "/cache/modelscope/models/org--model/snapshots/master"
-    snapshot_download = Mock(return_value=snapshot_path)
-    modelscope = ModuleType("modelscope")
-    modelscope.__path__ = []
-    modelscope_hub = ModuleType("modelscope.hub")
-    modelscope_hub.__path__ = []
-    snapshot_download_module = ModuleType("modelscope.hub.snapshot_download")
-    snapshot_download_module.__dict__["snapshot_download"] = snapshot_download
-    monkeypatch.setitem(sys.modules, "modelscope", modelscope)
-    monkeypatch.setitem(sys.modules, "modelscope.hub", modelscope_hub)
-    monkeypatch.setitem(
-        sys.modules, "modelscope.hub.snapshot_download", snapshot_download_module
-    )
-
-    assert convert_model_repo_to_path("org/model", revision="v1") == snapshot_path
-    snapshot_download.assert_called_once_with(
-        model_id="org/model",
-        revision="v1",
-        local_files_only=True,
-    )

--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import sys
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
 from vllm.transformers_utils.utils import (
+    convert_model_repo_to_path,
     is_azure,
     is_cloud_storage,
     is_gcs,
@@ -35,3 +42,46 @@ def test_is_cloud_storage():
     assert is_cloud_storage("az://model-container/path")
     assert not is_cloud_storage("/unix/local/path")
     assert not is_cloud_storage("nfs://nfs-fqdn.local")
+
+
+def test_convert_model_repo_to_path_without_modelscope(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("VLLM_USE_MODELSCOPE", raising=False)
+
+    assert convert_model_repo_to_path("org/model") == "org/model"
+
+
+def test_convert_model_repo_to_path_preserves_local_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    monkeypatch.setenv("VLLM_USE_MODELSCOPE", "true")
+
+    assert convert_model_repo_to_path(str(tmp_path)) == str(tmp_path)
+
+
+def test_convert_model_repo_to_path_uses_modelscope_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_USE_MODELSCOPE", "true")
+    snapshot_path = "/cache/modelscope/models/org--model/snapshots/master"
+    snapshot_download = Mock(return_value=snapshot_path)
+    modelscope = ModuleType("modelscope")
+    modelscope.__path__ = []
+    modelscope_hub = ModuleType("modelscope.hub")
+    modelscope_hub.__path__ = []
+    snapshot_download_module = ModuleType("modelscope.hub.snapshot_download")
+    snapshot_download_module.__dict__["snapshot_download"] = snapshot_download
+    monkeypatch.setitem(sys.modules, "modelscope", modelscope)
+    monkeypatch.setitem(sys.modules, "modelscope.hub", modelscope_hub)
+    monkeypatch.setitem(
+        sys.modules, "modelscope.hub.snapshot_download", snapshot_download_module
+    )
+
+    assert convert_model_repo_to_path("org/model", revision="v1") == snapshot_path
+    snapshot_download.assert_called_once_with(
+        model_id="org/model",
+        revision="v1",
+        local_files_only=True,
+    )

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -976,7 +976,10 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
 
     def _get_processor_class_name(self) -> str | None:
         return get_processor_cls_name_from_config(
-            convert_model_repo_to_path(self.ctx.model_config.model),
+            convert_model_repo_to_path(
+                self.ctx.model_config.model,
+                revision=self.ctx.model_config.revision,
+            ),
             revision=self.ctx.model_config.revision,
         )
 

--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -977,8 +977,7 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
     def _get_processor_class_name(self) -> str | None:
         return get_processor_cls_name_from_config(
             convert_model_repo_to_path(
-                self.ctx.model_config.model,
-                revision=self.ctx.model_config.revision,
+                self.ctx.model_config.model, revision=self.ctx.model_config.revision
             ),
             revision=self.ctx.model_config.revision,
         )

--- a/vllm/model_executor/models/llava_onevision2.py
+++ b/vllm/model_executor/models/llava_onevision2.py
@@ -130,7 +130,7 @@ def _load_ov2_processor(
     # nested load fall back to an interactive stdin prompt that hangs in
     # non-interactive CI. Instead, assemble the processor here with
     # trust_remote_code threaded through every component explicitly.
-    path = convert_model_repo_to_path(model)
+    path = convert_model_repo_to_path(model, revision=revision)
     revision = revision or "main"
 
     resolve_trust_remote_code(

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -600,7 +600,9 @@ class MiniCPMVProcessingInfo(BaseProcessingInfo):
     @cached_property
     def _image_processor_cls(self):
         model_config = self.ctx.model_config
-        model_path = convert_model_repo_to_path(model_config.model)
+        model_path = convert_model_repo_to_path(
+            model_config.model, revision=model_config.revision
+        )
 
         from transformers import ImageProcessingMixin
 

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -168,7 +168,7 @@ def get_video_processor_cls_name_from_config(
     processor_name: str,
     revision: str | None = "main",
 ) -> str | None:
-    processor_name = convert_model_repo_to_path(processor_name)
+    processor_name = convert_model_repo_to_path(processor_name, revision=revision)
     config_file = [
         "video_preprocessor_config.json",
         "preprocessor_config.json",
@@ -211,10 +211,13 @@ def get_processor(
     **kwargs: Any,
 ) -> _P:
     """Load a processor for the given model name via HuggingFace."""
+    modelscope_revision = revision
     if revision is None:
         revision = "main"
     try:
-        processor_name = convert_model_repo_to_path(processor_name)
+        processor_name = convert_model_repo_to_path(
+            processor_name, revision=modelscope_revision
+        )
         registered_cls_name = get_processor_cls_name_from_config(
             processor_name, revision=revision
         )
@@ -401,7 +404,7 @@ def get_feature_extractor(
     """Load an audio feature extractor for the given model name
     via HuggingFace."""
     try:
-        processor_name = convert_model_repo_to_path(processor_name)
+        processor_name = convert_model_repo_to_path(processor_name, revision=revision)
         feature_extractor = AutoFeatureExtractor.from_pretrained(
             processor_name,
             *args,
@@ -452,7 +455,7 @@ def get_image_processor(
 ):
     """Load an image processor for the given model name via HuggingFace."""
     try:
-        processor_name = convert_model_repo_to_path(processor_name)
+        processor_name = convert_model_repo_to_path(processor_name, revision=revision)
         processor_cls = processor_cls_overrides or AutoImageProcessor
         processor = processor_cls.from_pretrained(
             processor_name,
@@ -505,7 +508,7 @@ def get_video_processor(
 ):
     """Load a video processor for the given model name via HuggingFace."""
     try:
-        processor_name = convert_model_repo_to_path(processor_name)
+        processor_name = convert_model_repo_to_path(processor_name, revision=revision)
         processor_cls = processor_cls_overrides or AutoVideoProcessor
         processor = processor_cls.from_pretrained(
             processor_name,

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -166,9 +166,11 @@ def get_processor_cls_name_from_config(
 
 def get_video_processor_cls_name_from_config(
     processor_name: str,
-    revision: str | None = "main",
+    revision: str | None = None,
 ) -> str | None:
     processor_name = convert_model_repo_to_path(processor_name, revision=revision)
+    if revision is None:
+        revision = "main"
     config_file = [
         "video_preprocessor_config.json",
         "preprocessor_config.json",
@@ -211,13 +213,10 @@ def get_processor(
     **kwargs: Any,
 ) -> _P:
     """Load a processor for the given model name via HuggingFace."""
-    modelscope_revision = revision
-    if revision is None:
-        revision = "main"
     try:
-        processor_name = convert_model_repo_to_path(
-            processor_name, revision=modelscope_revision
-        )
+        processor_name = convert_model_repo_to_path(processor_name, revision=revision)
+        if revision is None:
+            revision = "main"
         registered_cls_name = get_processor_cls_name_from_config(
             processor_name, revision=revision
         )

--- a/vllm/transformers_utils/utils.py
+++ b/vllm/transformers_utils/utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import os
 import struct
 from functools import cache
 from os import PathLike
@@ -114,18 +115,29 @@ def parse_safetensors_file_metadata(path: str | PathLike) -> dict[str, Any]:
         return metadata
 
 
-def convert_model_repo_to_path(
-    model_repo: str,
-    revision: str | None = None,
-) -> str:
+def convert_model_repo_to_path(model_repo: str, revision: str | None = None) -> str:
     """When VLLM_USE_MODELSCOPE is True convert a model
     repository string to a Path str."""
     if not envs.VLLM_USE_MODELSCOPE or Path(model_repo).exists():
         return model_repo
-    from modelscope.hub.snapshot_download import snapshot_download
+    from modelscope.utils.file_utils import get_model_cache_root
 
-    return snapshot_download(
-        model_id=model_repo,
-        revision=revision,
-        local_files_only=True,
+    legacy_path = os.path.join(get_model_cache_root(), model_repo)
+    if Path(legacy_path).is_dir():
+        return legacy_path
+
+    try:
+        from modelscope_hub import get_default_config
+    except ImportError:
+        return legacy_path
+
+    snapshot_path = (
+        Path(get_default_config().cache_dir)
+        / "models"
+        / model_repo.replace("/", "--")
+        / "snapshots"
+        / (revision or "master")
     )
+    if snapshot_path.is_dir():
+        return str(snapshot_path)
+    return legacy_path

--- a/vllm/transformers_utils/utils.py
+++ b/vllm/transformers_utils/utils.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
-import os
 import struct
 from functools import cache
 from os import PathLike
@@ -115,11 +114,18 @@ def parse_safetensors_file_metadata(path: str | PathLike) -> dict[str, Any]:
         return metadata
 
 
-def convert_model_repo_to_path(model_repo: str) -> str:
+def convert_model_repo_to_path(
+    model_repo: str,
+    revision: str | None = None,
+) -> str:
     """When VLLM_USE_MODELSCOPE is True convert a model
     repository string to a Path str."""
     if not envs.VLLM_USE_MODELSCOPE or Path(model_repo).exists():
         return model_repo
-    from modelscope.utils.file_utils import get_model_cache_root
+    from modelscope.hub.snapshot_download import snapshot_download
 
-    return os.path.join(get_model_cache_root(), model_repo)
+    return snapshot_download(
+        model_id=model_repo,
+        revision=revision,
+        local_files_only=True,
+    )


### PR DESCRIPTION
## Summary

Multimodal processor loading with ModelScope 1.39.1 can fail with `HFValidationError` even when the model is cached: `convert_model_repo_to_path()` constructs the legacy directory, while the downloaded files live in a revision-specific snapshot directory.

Check the legacy directory first, then the snapshot directory under ModelScope Hub's configured cache root (`models/<org>--<repo>/snapshots/<revision>`). Pass the requested revision through processor call sites and use `master` when no revision is specified. Resolve the ModelScope path before applying the Transformers `main` default.

This helper performs local path checks only. If neither directory exists, or the newer `modelscope_hub` package is unavailable, it retains the original legacy-path fallback. It does not download missing files or validate cache completeness; first-time downloads and partial caches remain outside this fix.

Closes #55189

## Duplicate check

Rechecked the issue comments and open PRs using `55189 in:body` and `ModelScope cache`. This PR was the only matching fix found. The local dual-layout approach follows the issue author's feedback.

## Validation

- `.venv/bin/python -m pytest tests/transformers_utils/test_utils.py -q` — 8 passed, including four ModelScope cases covering the default snapshot, an explicit revision, legacy-cache precedence, and a missing requested snapshot.
- Pre-commit hooks on the changed files and during commit — passed, including Ruff and mypy.
- Model evaluations and end-to-end multimodal serving were not run. Validation is limited to path-resolution unit tests and static checks.

## AI assistance

AI assistance was used for code inspection, implementation, tests, and this PR description.
