### PR TITLE
[Perf] Enable efficient SDPA for Granite Speech block attention

### DIFF
--- a/tests/models/multimodal/test_granite_speech_attention.py
+++ b/tests/models/multimodal/test_granite_speech_attention.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+from contextlib import contextmanager
+
+import pytest
+import torch
+import torch.nn.functional as F
+from transformers import PretrainedConfig
+
+from vllm.model_executor.models.granite_speech import (
+    GraniteSpeechConformerAttention,
+)
+
+
+def _make_config() -> PretrainedConfig:
+    return PretrainedConfig(
+        hidden_dim=16,
+        context_size=8,
+        num_heads=2,
+        dim_head=8,
+        max_pos_emb=16,
+    )
+
+
+def _make_attention_dists(config: PretrainedConfig) -> torch.Tensor:
+    seq = torch.arange(config.context_size)
+    return (
+        torch.clamp(
+            seq[:, None] - seq[None, :],
+            -config.context_size,
+            config.context_size,
+        )
+        + config.max_pos_emb
+    )
+
+
+def _reference_forward(
+    module: GraniteSpeechConformerAttention,
+    hidden_states: torch.Tensor,
+    attention_dists: torch.Tensor,
+) -> torch.Tensor:
+    hidden_states = module.pre_norm(hidden_states)
+    bsz, num_features, _ = hidden_states.shape
+    num_blocks = math.ceil(num_features / module.context_size)
+    remainder = num_features % module.context_size
+    if remainder > 0:
+        hidden_states = F.pad(hidden_states, (0, 0, 0, module.context_size - remainder))
+
+    query_states = module.to_q(hidden_states)
+    key_states, value_states = module.to_kv(hidden_states).chunk(2, dim=-1)
+    query_states = query_states.reshape(
+        bsz, num_blocks, module.context_size, module.num_heads, -1
+    ).transpose(2, 3)
+    key_states = key_states.reshape(
+        bsz, num_blocks, module.context_size, module.num_heads, -1
+    ).transpose(2, 3)
+    value_states = value_states.reshape(
+        bsz, num_blocks, module.context_size, module.num_heads, -1
+    ).transpose(2, 3)
+
+    rel_pos_emb = module.rel_pos_emb(attention_dists)
+    pos_attn = (
+        torch.einsum("bnhid,ijd->bnhij", query_states, rel_pos_emb) * module.scale
+    )
+    if remainder > 0:
+        mask = torch.ones(
+            module.context_size,
+            module.context_size,
+            dtype=torch.bool,
+            device=hidden_states.device,
+        )
+        mask[:remainder, :remainder] = False
+        mask_value = -torch.finfo(pos_attn.dtype).max
+        pos_attn[:, -1, :].masked_fill_(mask, mask_value)
+
+    with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.MATH):
+        out = F.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask=pos_attn,
+            scale=module.scale,
+        )
+    out = out.transpose(2, 3).reshape(bsz, hidden_states.shape[1], -1)
+    return module.to_out(out[:, :num_features, :])
+
+
+@pytest.mark.parametrize("num_features", [16, 13])
+def test_attention_matches_math_reference(num_features: int) -> None:
+    torch.manual_seed(17)
+    config = _make_config()
+    module = GraniteSpeechConformerAttention(config)
+    hidden_states = torch.randn(2, num_features, config.hidden_dim)
+    attention_dists = _make_attention_dists(config)
+
+    expected = _reference_forward(module, hidden_states, attention_dists)
+    actual = module(hidden_states, attention_dists)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_attention_requests_efficient_backend_before_math(monkeypatch) -> None:
+    requested_backends = []
+    original_sdpa_kernel = torch.nn.attention.sdpa_kernel
+
+    @contextmanager
+    def record_sdpa_kernel(backends, *args, **kwargs):
+        requested_backends.append(backends)
+        with original_sdpa_kernel(backends, *args, **kwargs):
+            yield
+
+    monkeypatch.setattr(torch.nn.attention, "sdpa_kernel", record_sdpa_kernel)
+    config = _make_config()
+    module = GraniteSpeechConformerAttention(config)
+    hidden_states = torch.randn(1, config.context_size, config.hidden_dim)
+
+    module(hidden_states, _make_attention_dists(config))
+
+    assert requested_backends == [
+        [
+            torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+            torch.nn.attention.SDPBackend.MATH,
+        ]
+    ]

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -412,7 +412,17 @@ class GraniteSpeechConformerAttention(nn.Module):
             mask_value = -torch.finfo(pos_attn.dtype).max
             pos_attn[:, -1, :].masked_fill_(mask, mask_value)
 
-        with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.MATH):
+        query_states = query_states.flatten(0, 1)
+        key_states = key_states.flatten(0, 1)
+        value_states = value_states.flatten(0, 1)
+        pos_attn = pos_attn.flatten(0, 1)
+
+        with torch.nn.attention.sdpa_kernel(
+            [
+                torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+                torch.nn.attention.SDPBackend.MATH,
+            ]
+        ):
             out = F.scaled_dot_product_attention(
                 query_states,
                 key_states,
@@ -420,6 +430,7 @@ class GraniteSpeechConformerAttention(nn.Module):
                 attn_mask=pos_attn,
                 scale=self.scale,
             )
+        out = out.unflatten(0, (bsz, num_blocks))
         out = out.transpose(2, 3).reshape(bsz, hidden_states.shape[1], -1)
         return self.to_out(out[:, :num_features, :])
 


### PR DESCRIPTION
## Purpose

Granite Speech block attention currently passes five-dimensional Q, K, and V
tensors to scaled-dot-product attention and explicitly selects the math
backend. PyTorch's fused SDPA backends require four-dimensional inputs, so this
prevents the memory-efficient backend from being used.

This PR flattens the independent batch and block dimensions immediately before
SDPA, requests `EFFICIENT_ATTENTION` with `MATH` as a fallback, and restores the
original dimensions afterward.

The flatten and unflatten operations remain views for the production tensor
layout. Model interfaces, weights, Shaw relative-position scores, padding masks,
and attention scaling are unchanged.

## Test Plan

### Regression tests

```bash
python -m pytest -q \
  tests/models/multimodal/test_granite_speech_attention.py \
  tests/utils_/test_tensor_schema.py
```

The focused tests instantiate the real `GraniteSpeechConformerAttention`
module and compare its final output against the previous forced-math
implementation. They cover complete and partially padded final blocks, as well
as the requested backend order.

### Granite Speech 3.3 2B generation comparison

```bash
python -m pytest -q \
  'tests/models/multimodal/generation/test_granite_speech.py::test_models[10-128-2048-bfloat16-ibm-granite/granite-speech-3.3-2b-ibm-granite/granite-speech-3.3-2b]'
```

This test loads the 5.61 GiB `ibm-granite/granite-speech-3.3-2b` checkpoint
and its audio LoRA, runs one audio prompt through both vLLM and the Transformers
reference implementation in BF16, and compares generated tokens and top-10
log probabilities. It passed on the same RTX 4090.

### Lint

```bash
ruff check \
  tests/models/multimodal/test_granite_speech_attention.py \
  vllm/model_executor/models/granite_speech.py

ruff format --check \
  tests/models/multimodal/test_granite_speech_attention.py \
  vllm/model_executor/models/granite_speech.py
```

### RTX 4090 SDPA benchmark

Hardware/software: NVIDIA RTX 4090 (SM89, 24 GB), driver 580.76.05,
CUDA 13.2, PyTorch 2.13.0+cu132. No configuration changes.

The benchmark uses Granite Speech's production attention dimensions:

```text
context size = 200
heads        = 8
head dim     = 128
```

It covers FP16/BF16, batches 1 and 2, 1/2/4/8 blocks, and final-block
remainders 0/1/100/199. Each shape uses 50 warmups, 200 timed iterations,
and ten repeats.

| Metric | Result |
|---|---:|
| Geometric-mean SDPA speedup across 64 shapes | 4.82x |
| Minimum observed speedup | 3.96x |
| Maximum observed speedup | 6.99x |
| Math maximum peak allocation | 152,453,120 bytes |
| Efficient maximum peak allocation | 46,694,400 bytes |

All 64 numerical cases passed. The maximum absolute errors were
`0.0009765625` for FP16 and `0.0078125` for BF16.

The exact production attention module was also measured with BF16
`hidden_states=[1, 800, 1024]`, including LayerNorm, projections, Shaw
relative-position scores, attention, and the output projection:

| Variant | Median latency |
|---|---:|
| Original forced-math implementation | 528.48 us |
| Efficient-SDPA candidate | 306.15 us |
| Whole-module speedup | 1.73x |

The production-module maximum absolute error was `0.0009765625`.
Profiler output confirmed that the candidate executed
`aten::_scaled_dot_product_efficient_attention`; no layout-copy CUDA kernel
was introduced. CUDA Graph replay and `torch.compile(fullgraph=True)` smoke
tests also passed.

## Test Result

```text
23 passed (focused regression tests)
1 passed (Granite Speech 3.3 2B generation comparison)
```

Focused Ruff lint and format checks and `git diff --check` passed locally.

## Limitations

Performance results were collected on one RTX 4090. The end-to-end test
validates generation correctness against Transformers, but it is not an
end-to-end transcription throughput benchmark. The math backend remains
available as a fallback for devices where memory-efficient SDPA is unsupported.
Full upstream cross-backend CI still requires maintainer activation.

## AI assistance

AI assistance was used during implementation, testing, benchmarking, and PR
drafting. The human contributor reviewed and takes responsibility for the
change and evidence.
