### PR TITLE
fix: fix Heterogeneous TP bug of Mamba2 conv state

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -889,7 +889,8 @@ def _make_mock_worker_for_desc_ids(
 
 
 @pytest.mark.cpu_test
-def test_get_block_descs_ids_hybrid_ssm():
+@pytest.mark.parametrize("skip_replicated_conv", [False, True])
+def test_get_block_descs_ids_hybrid_ssm(skip_replicated_conv):
     """Test _compute_desc_ids uses per-group strides for hybrid
     FA+SSM when ratio=1 (no kernel block size mismatch)."""
     from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
@@ -908,9 +909,14 @@ def test_get_block_descs_ids_hybrid_ssm():
         dst_num_blocks=100,
         block_size_ratio=None,
         physical_blocks_per_logical=1,
+        skip_replicated_conv=skip_replicated_conv,
     )
 
-    expected = [3, 5, 103, 105, 201, 202, 301, 302, 401, 402, 501, 502]
+    expected = (
+        [3, 5, 103, 105, 201, 202, 501, 502]
+        if skip_replicated_conv
+        else [3, 5, 103, 105, 201, 202, 301, 302, 401, 402, 501, 502]
+    )
     assert list(result) == expected, f"Expected {expected}, got {list(result)}"
 
 
@@ -1412,6 +1418,9 @@ def test_compute_physical_blocks_per_logical(ssm_sizes, block_len, expected_rati
 @pytest.mark.parametrize(
     "mamba_type,local_tp,conv_dim_local,conv_rows,temporal_shape,expected_proj_dims",
     [
+        # Falcon-H1-0.5B: single B/C group is replicated across TP ranks.
+        ("mamba2", 1, 1792, 3, (24, 64, 128), (1536, 128, 128)),
+        ("mamba2", 2, 1024, 3, (12, 64, 128), (768, 128, 128)),
         # nvidia/Nemotron-H-8B-Base-8K (Mamba2)
         # mamba_num_heads=128, head_dim=64, n_groups=8, ssm_state_size=128
         pytest.param(
@@ -1564,6 +1573,54 @@ def test_derive_mamba_conv_split(
     out = derive_mamba_conv_split(spec, local_tp=local_tp)
     assert out.local_proj_dims == expected_proj_dims
     assert out.conv_rows == conv_rows
+    if mamba_type == "mamba2":
+        assert out.mamba2_state_size == temporal_shape[2]
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "x_dim,tp_ratio,rank,remote_bytes,expected",
+    [
+        (768, 2, 0, 10752, [(0, 4608), (9216, 768), (9984, 768)]),
+        (768, 2, 1, 10752, [(4608, 4608), (9216, 768), (9984, 768)]),
+        (1536, -2, 0, 6144, [(0, 4608), (4608, 768), (5376, 768)]),
+    ],
+)
+def test_mamba_remote_conv_replicated_offsets(
+    x_dim, tp_ratio, rank, remote_bytes, expected
+):
+    """Single-group B/C reads stay whole in both TP transfer directions."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+        MambaConvSplitInfo,
+    )
+
+    split = MambaConvSplitInfo(3, (x_dim, 128, 128), 2, (0, 0), 128)
+    assert split.remote_conv_offsets(rank, tp_ratio, remote_bytes) == expected
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("remote_conv_bytes", [0, 10751, 10754, 11520, 19968])
+def test_mamba_remote_conv_rejects_incompatible_layout(remote_conv_bytes):
+    """Reject partial columns, mismatched groups and invalid advertised sizes."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+        MambaConvSplitInfo,
+    )
+
+    split = MambaConvSplitInfo(3, (768, 128, 128), 2, (6144, 196608), 128)
+    with pytest.raises(ValueError):
+        split.remote_conv_offsets(0, 2, remote_conv_bytes)
+
+
+@pytest.mark.cpu_test
+def test_mamba_remote_conv_rejects_read_into_next_projection():
+    """An invalid rank offset must not read B while remaining inside conv."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+        MambaConvSplitInfo,
+    )
+
+    split = MambaConvSplitInfo(3, (768, 128, 128), 2, (6144, 196608), 128)
+    with pytest.raises(ValueError, match="exceeds its remote projection"):
+        split.remote_conv_offsets(2, 2, 10752)
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -244,7 +244,9 @@ def test_overlaid_transfer_groups_share_region_geometry():
     assert worker._block_ids_by_region(([0], [2]), worker.region_group_ids) == [[0, 2]]
 
 
-def _make_mla_hybrid_worker(local_block_size, kernel_block_size, num_logical_blocks):
+def _make_mla_hybrid_worker(
+    local_block_size, kernel_block_size, num_logical_blocks, state_tp_size=2
+):
     """Build a real pull worker with a hybrid MLA + 2xKDA HMA layout."""
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
         base_worker as bw,
@@ -270,7 +272,8 @@ def _make_mla_hybrid_worker(local_block_size, kernel_block_size, num_logical_blo
     unified_page = mla_spec.page_size_bytes
     kda_spec = MambaSpec(
         block_size=local_block_size,
-        shapes=((8, 3), (1, 4, 4)),
+        # Keep complete convolution columns in every TP shard.
+        shapes=((4 * state_tp_size, 3), (state_tp_size, 2, 4)),
         dtypes=(torch.float16, torch.float32),
         page_size_padded=unified_page,
         mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
@@ -699,15 +702,15 @@ def _run_hetero_case(
         local_block_size=local_block,
         kernel_block_size=kernel,
         num_logical_blocks=max(2 * n_local + 4, 8),
+        state_tp_size=tp_size,
     )
-    # Local KDA state pages are (48, 64) bytes; the remote holds 1/tp_size
-    # shards of each.
+    # The remote holds 1/tp_size of every state projection.
     meta_r = _make_remote_meta(
         worker,
         remote_block_size=remote_block,
         remote_kernel_block_size=remote_kernel,
         remote_num_logical=max(2 * n_remote + 4, 8),
-        remote_ssm_sizes=(48 // tp_size, 64 // tp_size),
+        remote_ssm_sizes=tuple(size // tp_size for size in worker._mamba_ssm_size),
     )
     for rank in range(tp_size):
         worker.add_remote_agent(meta_r, remote_tp_rank=rank, remote_tp_size=tp_size)

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -679,6 +679,7 @@ def _eviction_worker(engine_ttl: float) -> NixlPushConnectorWorker:
     w.kv_caches_base_addr = {}
     w.dst_num_blocks = {}
     w.tp_mappings = {}
+    w._mamba_conv_replicated = {}
     w.transfer_topo = None
     w._logical_to_kernel_block_ids = lambda blocks, ratio: blocks
     w.writes = []
@@ -708,6 +709,7 @@ def test_stale_engine_evicted_on_push():
     across D scale up/down (S1)."""
     w = _eviction_worker(engine_ttl=30.0)
     w._remote_agents["D-old"] = {(0, 0): "agent-D-old"}
+    w._mamba_conv_replicated["D-old"] = True
     w._engine_last_active["D-old"] = time.perf_counter() - 10_000.0
     # The engine being pushed to is already connected.
     w._remote_agents["decode-engine"] = {(0, 0): "agent-decode"}
@@ -716,6 +718,7 @@ def test_stale_engine_evicted_on_push():
 
     assert "D-old" not in w._remote_agents
     assert "D-old" not in w._engine_last_active
+    assert "D-old" not in w._mamba_conv_replicated
     w.nixl_wrapper.remove_remote_agent.assert_called_once_with("agent-D-old")
 
 

--- a/tests/v1/kv_connector/unit/test_tp_mapping.py
+++ b/tests/v1/kv_connector/unit/test_tp_mapping.py
@@ -196,6 +196,82 @@ class TestBuildSrcSplitHandles:
 class TestMambaPlanSplitHandles:
     """Verify split handles for Mamba with FA/SSM distinction."""
 
+    @pytest.mark.parametrize("mode", ["pull", "push"])
+    @pytest.mark.parametrize("local_tp,remote_tp", [(1, 2), (2, 1), (2, 4), (4, 2)])
+    def test_replicated_conv_has_one_writer(self, mode, local_tp, remote_tp):
+        """Both READ and WRITE transfers select one B/C source per consumer."""
+        writes = [0] * (local_tp if mode == "pull" else remote_tp)
+        for rank in range(local_tp):
+            worker = _make_mock_worker_for_splits((FullAttentionSpec, MambaSpec))
+            worker._has_mamba = True
+            worker._TRANSFER_MODE = mode
+            worker.tp_rank = rank
+            ratio = (
+                local_tp // remote_tp
+                if local_tp >= remote_tp
+                else -(remote_tp // local_tp)
+            )
+            worker.transfer_topo = SimpleNamespace(
+                get_engine_info=lambda _: SimpleNamespace(remote_tp_size=remote_tp),
+                tp_ratio=lambda _, ratio=ratio: ratio,
+            )
+            plan = _compute_mapping(
+                tp_rank=rank,
+                tp_size=local_tp,
+                remote_tp_size=remote_tp,
+                group_spec_types=(FullAttentionSpec, MambaSpec),
+            )
+            worker.tp_mappings = {"peer": plan}
+            worker._mamba_conv_replicated = {"peer": True}
+            for remote_rank in plan.all_source_ranks:
+                if not worker._skip_replicated_mamba_conv("peer", remote_rank):
+                    writes[rank if mode == "pull" else remote_rank] += 1
+        assert writes == [1] * len(writes)
+
+    def test_replicated_conv_splits_only_x_and_temporal_state(self):
+        """Gather head shards while keeping each B/C destination whole."""
+        plan = _compute_mapping(
+            tp_size=1,
+            remote_tp_size=2,
+            group_spec_types=(FullAttentionSpec, MambaSpec),
+        )
+        worker = _make_mock_worker_for_splits((FullAttentionSpec, MambaSpec))
+        worker._logical_num_blocks = 1
+        # One FA descriptor followed by x, B, C and temporal state.
+        src_blocks_data = np.array(
+            [
+                (1000, 200, 0),
+                (2000, 400, 0),
+                (3000, 100, 0),
+                (4000, 100, 0),
+                (5000, 800, 0),
+            ],
+            dtype=np.uint64,
+        )
+
+        splits = list(
+            worker._build_local_splits_from_plan(
+                plan, src_blocks_data, 1, replicated_conv=True
+            )
+        )
+
+        assert splits == [
+            [
+                (1000, 100, 0),
+                (2000, 200, 0),
+                (3000, 100, 0),
+                (4000, 100, 0),
+                (5000, 400, 0),
+            ],
+            [
+                (1100, 100, 0),
+                (2200, 200, 0),
+                (3000, 100, 0),
+                (4000, 100, 0),
+                (5400, 400, 0),
+            ],
+        ]
+
     def test_fa_and_ssm_different_split_factors(self):
         """Section 0 split by num_attn_reads, section 1 by abs_tp."""
         fa_readers = (0,)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -168,6 +168,7 @@ class NixlBaseConnectorWorker:
         region_num_blocks: list[int] | None = None,
         region_group_ids: list[int] | None = None,
         uses_region_group_mapping: bool | None = None,
+        skip_replicated_conv: bool = False,
     ) -> np.ndarray:
         """Compute NIXL descriptor IDs for given block IDs."""
         num_ssm_regions = 0
@@ -266,6 +267,10 @@ class NixlBaseConnectorWorker:
                     if i == self._ple_group_index
                     else np.arange(num_ssm_regions, dtype=np.int32)
                 )[:, None]
+                if skip_replicated_conv and i != self._ple_group_index:
+                    ssm_region_ids = ssm_region_ids[
+                        ~np.isin(ssm_region_ids[:, 0] % ssm_regions_per_layer, (1, 2))
+                    ]
                 all_descs.append(
                     (
                         ssm_region_ids * logical_blocks
@@ -286,6 +291,7 @@ class NixlBaseConnectorWorker:
         src_blocks_data: np.ndarray,
         num_fa_descs: int,
         block_size_ratio: int = 1,
+        replicated_conv: bool = False,
     ) -> Iterator[list[tuple[int, int, int]]]:
         """Build split handle data for P_TP > D_TP scenario.
 
@@ -337,8 +343,20 @@ class NixlBaseConnectorWorker:
                         chunk = local_len // fa_num_splits
                         handle.append((addr + fa_slot * chunk, chunk, dev))
                 elif j < sharded_desc_end:
-                    chunk = local_len // ssm_num_splits
-                    handle.append((addr + p_idx * chunk, chunk, dev))
+                    projection = (
+                        (j - num_fa_descs) // self._logical_num_blocks % 4
+                        if replicated_conv
+                        else -1
+                    )
+                    if projection in (1, 2):
+                        handle.append((addr, local_len, dev))
+                    else:
+                        if local_len % ssm_num_splits:
+                            raise ValueError(
+                                "SSM region is not divisible by source count"
+                            )
+                        chunk = local_len // ssm_num_splits
+                        handle.append((addr + p_idx * chunk, chunk, dev))
                 else:
                     handle.append((addr, local_len, dev))
             yield handle
@@ -748,6 +766,7 @@ class NixlBaseConnectorWorker:
 
         # Per-engine TP mappings. Generated during handshake.
         self.tp_mappings: dict[EngineId, TPMapping] = {}
+        self._mamba_conv_replicated: dict[EngineId, bool] = {}
 
         self.enforce_compat_hash = self.kv_transfer_config.get_from_extra_config(
             "enforce_handshake_compat", True
@@ -1670,12 +1689,23 @@ class NixlBaseConnectorWorker:
         )
         assert self._conv_decomp is not None
         effective_ratio = max(tp_ratio, 1)
-        # Mamba conv state is always TP-sharded, even when attention KV
-        # is replicated (num_kv_heads < tp_size).
+        # x and temporal state are head-sharded; Mamba2 B/C may be replicated.
         local_offset = self.tp_rank % effective_ratio
         conv_size_remote = nixl_agent_meta.ssm_sizes[0]
 
-        conv_offsets = self._conv_decomp.remote_conv_offsets(local_offset, tp_ratio)
+        conv_offsets = self._conv_decomp.remote_conv_offsets(
+            local_offset, tp_ratio, conv_size_remote
+        )
+        expected_ssm_size = (
+            self._mamba_ssm_size[1] * tp_ratio
+            if tp_ratio > 0
+            else nixl_agent_meta.ssm_sizes[1] * -tp_ratio
+        )
+        actual_ssm_size = (
+            nixl_agent_meta.ssm_sizes[1] if tp_ratio > 0 else self._mamba_ssm_size[1]
+        )
+        if expected_ssm_size != actual_ssm_size:
+            raise ValueError("Remote temporal state does not match the TP ratio")
         if tp_ratio >= 1:
             ssm_read_size = self._mamba_ssm_size[1]
         else:
@@ -2049,6 +2079,14 @@ class NixlBaseConnectorWorker:
         # this is the ratio between the two sizes.
         tp_ratio = transfer_topo.tp_ratio(remote_tp_size)
 
+        replicated_conv = False
+        if self._has_mamba:
+            assert self._conv_decomp is not None
+            _, replicated_conv = self._conv_decomp.remote_conv_layout(
+                nixl_agent_meta.ssm_sizes[0], tp_ratio
+            )
+            self._mamba_conv_replicated[engine_id] = replicated_conv
+
         logger.debug(
             "Registering remote agent (%s, rank %s) memory regions with tp_ratio %s",
             engine_id,
@@ -2090,6 +2128,7 @@ class NixlBaseConnectorWorker:
                 src_blocks_data,
                 self.num_descs * block_size_ratio,
                 block_size_ratio,
+                replicated_conv=replicated_conv,
             ):
                 if self._mixed_mem_types:
                     handle_data = np.asarray(handle_data, dtype=np.uint64)
@@ -2149,6 +2188,22 @@ class NixlBaseConnectorWorker:
         )
 
         return remote_agent_name
+
+    def _skip_replicated_mamba_conv(
+        self, remote_engine_id: EngineId, remote_rank: int
+    ) -> bool:
+        """Select one writer for replicated B/C when gathering head shards."""
+        if not self._has_mamba or not self._mamba_conv_replicated.get(
+            remote_engine_id, False
+        ):
+            return False
+        assert self.transfer_topo is not None
+        info = self.transfer_topo.get_engine_info(remote_engine_id)
+        ratio = self.transfer_topo.tp_ratio(info.remote_tp_size)
+        if self._TRANSFER_MODE == "push":
+            return ratio > 1 and self.tp_rank % ratio != 0
+        plan = self.tp_mappings[remote_engine_id]
+        return ratio < 0 and remote_rank != plan.all_source_ranks[0]
 
     def _validate_remote_agent_handshake(
         self,
@@ -3172,6 +3227,7 @@ class NixlBaseConnectorWorker:
         self.dst_uses_region_group_mapping.pop(engine_id, None)
         self.dst_region_mem_types.pop(engine_id, None)
         self.tp_mappings.pop(engine_id, None)
+        self._mamba_conv_replicated.pop(engine_id, None)
         if self.transfer_topo is not None:
             self.transfer_topo.unregister_remote_engine(engine_id)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -403,6 +403,9 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # workers will issue xfers to parts of the P worker remote kv caches.
 
         # Get descs ids.
+        skip_replicated_conv = self._skip_replicated_mamba_conv(
+            dst_engine_id, remote_rank
+        )
         remote_block_descs_ids = self._compute_desc_ids(
             block_ids=remote_block_ids,
             dst_num_blocks=self.dst_num_blocks[dst_engine_id],
@@ -419,6 +422,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 if read_spec.block_ids_by_region
                 else self.dst_uses_region_group_mapping[dst_engine_id]
             ),
+            skip_replicated_conv=skip_replicated_conv,
         )
         local_block_descs_ids = self._compute_desc_ids(
             block_ids=local_block_ids,
@@ -436,6 +440,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 if read_spec.block_ids_by_region
                 else self._uses_region_group_mapping
             ),
+            skip_replicated_conv=skip_replicated_conv,
         )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -660,6 +660,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             )
 
         # Get descs ids.
+        skip_replicated_conv = self._skip_replicated_mamba_conv(
+            dst_engine_id, remote_rank
+        )
         remote_block_descs_ids = self._compute_desc_ids(
             block_ids=remote_block_ids,
             dst_num_blocks=self.dst_num_blocks[dst_engine_id],
@@ -668,6 +671,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             region_num_blocks=self.dst_region_num_blocks[dst_engine_id],
             region_group_ids=self.dst_region_group_ids[dst_engine_id],
             uses_region_group_mapping=self.dst_uses_region_group_mapping[dst_engine_id],
+            skip_replicated_conv=skip_replicated_conv,
         )
         local_block_descs_ids = self._compute_desc_ids(
             block_ids=local_block_ids,
@@ -677,6 +681,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             region_num_blocks=self.dst_region_num_blocks[self.engine_id],
             region_group_ids=self.region_group_ids,
             uses_region_group_mapping=self._uses_region_group_mapping,
+            skip_replicated_conv=skip_replicated_conv,
         )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/ssm_conv_transfer_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/ssm_conv_transfer_utils.py
@@ -42,6 +42,7 @@ class MambaConvSplitInfo:
     local_proj_dims: tuple[int, ...]
     conv_dtype_size: int  # bytes per element (e.g. 2 for float16)
     ssm_sizes: tuple[int, int]  # (conv_state_bytes, ssm_state_bytes)
+    mamba2_state_size: int | None = None
 
     @property
     def local_conv_dim(self) -> int:
@@ -68,8 +69,48 @@ class MambaConvSplitInfo:
             offset += size
         return offsets
 
+    def remote_conv_layout(
+        self, remote_conv_bytes: int, tp_ratio: int
+    ) -> tuple[tuple[int, ...], bool]:
+        """Recover remote projection sizes and whether B/C are replicated."""
+        if tp_ratio == 0:
+            raise ValueError("TP ratio must be nonzero")
+
+        def scale(size: int) -> int:
+            if tp_ratio > 0:
+                return size * tp_ratio
+            if size % -tp_ratio:
+                raise ValueError("Sharded projection is not divisible by TP ratio")
+            return size // -tp_ratio
+
+        local_sizes = self.proj_bytes
+        replicated = False
+        if self.mamba2_state_size is None:
+            remote_sizes = tuple(scale(size) for size in local_sizes)
+        else:
+            x_size = scale(local_sizes[0])
+            remainder = remote_conv_bytes - x_size
+            if remainder <= 0 or remainder % 2:
+                raise ValueError("Remote Mamba2 convolution has invalid B/C sizes")
+            group_size = remainder // 2
+            remote_sizes = (x_size, group_size, group_size)
+            if (
+                group_size == local_sizes[1]
+                and self.local_proj_dims[1] == self.mamba2_state_size
+            ):
+                replicated = abs(tp_ratio) != 1
+            elif group_size != scale(local_sizes[1]):
+                raise ValueError("Remote Mamba2 group layout is incompatible")
+
+        row_bytes = self.conv_rows * self.conv_dtype_size
+        if sum(remote_sizes) != remote_conv_bytes or any(
+            size <= 0 or size % row_bytes for size in remote_sizes
+        ):
+            raise ValueError("Remote convolution sizes do not match its projections")
+        return remote_sizes, replicated
+
     def remote_conv_offsets(
-        self, local_rank_offset: int, tp_ratio: int
+        self, local_rank_offset: int, tp_ratio: int, remote_conv_bytes: int
     ) -> list[tuple[int, int]]:
         """(byte_offset, byte_size) of this D rank's sub-projection slices
         within one P page.
@@ -81,25 +122,24 @@ class MambaConvSplitInfo:
             tp_ratio: signed TP ratio.
                 >= 1:  D_TP >= P_TP — P page is larger, D reads its slice.
                 < 0:   P_TP > D_TP — P pages are smaller, D reads entire
-                       P page.  Local dims are scaled down by |tp_ratio|
-                       to get P-sized offsets.
+                       P projection.
+            remote_conv_bytes: actual remote convolution size from the handshake.
         """
+        remote_sizes, replicated = self.remote_conv_layout(remote_conv_bytes, tp_ratio)
         offsets: list[tuple[int, int]] = []
-        if tp_ratio >= 1:
-            remote_base = 0
-            for size in self.proj_bytes:
-                offsets.append((remote_base + local_rank_offset * size, size))
-                remote_base += size * tp_ratio
-        else:
-            # NOTE (ZhanqiuHu): tp_ratio < 0 means P_TP > D_TP, so P pages
-            # are smaller than D's. Local dims are D-sized, but we need
-            # P-sized offsets. Scale down by |tp_ratio|.
-            abs_ratio = -tp_ratio
-            remote_base = 0
-            for size in self.proj_bytes:
-                remote_size = size // abs_ratio
-                offsets.append((remote_base, remote_size))
-                remote_base += remote_size
+        remote_base = 0
+        for i, (local_size, remote_size) in enumerate(
+            zip(self.proj_bytes, remote_sizes)
+        ):
+            if tp_ratio > 0:
+                size = local_size
+                offset = 0 if replicated and i in (1, 2) else local_rank_offset * size
+            else:
+                size, offset = remote_size, 0
+            if offset < 0 or offset + size > remote_size:
+                raise ValueError("Convolution read exceeds its remote projection")
+            offsets.append((remote_base + offset, size))
+            remote_base += remote_size
         return offsets
 
 
@@ -214,6 +254,11 @@ def derive_mamba_conv_split(
         local_proj_dims=local_proj_dims,
         conv_dtype_size=conv_dtype_size,
         ssm_sizes=(conv_state_bytes, ssm_state_bytes),
+        mamba2_state_size=(
+            mamba_spec.shapes[1][2]
+            if mamba_spec.mamba_type == MambaAttentionBackendEnum.MAMBA2
+            else None
+        ),
     )
 
 


### PR DESCRIPTION


## Purpose

Fixes #55208.

NIXL currently scales every Mamba2 convolution projection by the TP ratio. With `n_groups=1`, B/C are replicated across ranks while x is sharded. For Falcon-H1-0.5B-Base with P TP=1 and D TP=2, this makes one rank read C as B and both ranks read temporal state as C, even though the NIXL transfers succeeded.

This PR **derives remote projection boundaries from the advertised convolution size**, **preserves replicated B/C during reverse gathers**, and **selects one B/C writer per destination in both pull and push modes**. It also validates projection bounds and temporal-state sizes. Uniformly sharded Mamba1, Mamba2 and GDN layouts retain their existing transfer semantics.

Duplicate-work check: reviewed the issue comments and searched open PRs for `55208 in:body` and `Mamba conv heterogeneous`. No open PR addressing this NIXL fix was found. Related Mooncake and MoRIIO work targets different connectors.

**AI assistance** was used for implementation, test development, experiments and this description.


## Test Plan

Regression coverage includes replicated B/C offsets in both TP directions, local gather slices, single-writer selection for pull/push, descriptor filtering, incompatible layouts and engine cleanup.

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_tp_mapping.py \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py \
  -q -k 'not fewer_blocks_with_hma'

.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_nixl_push_connector.py -q
```

Project pre-commit hooks `ruff-check`, `ruff-format` and `mypy-3.12` (manual stage) were run on the modified files, along with `git diff --check`.

Real-model validation used **Falcon-H1-0.5B-Base** on **4 × RTX 5090** with BF16, greedy decoding, seed 42 and 64 generated tokens. Each configuration ran 20 fixed prompts twice, including attention block-boundary lengths. P1D2, P2D1, P1D1 and P2D2 used real NIXL pull transfers and were compared with the unmodified baseline. Push was validated with unit tests only.


## Test Result

- TP mapping and HMA tests: **119 passed, 1 deselected**. The excluded integration test requires an additional Gemma model.
- Push connector tests: **44 passed**.
- Ruff check, Ruff format, mypy and `git diff --check`: **passed**.

P/D denote prefill/decode TP sizes. Counts below are unequal generated token sequences out of 40 requests, not task error rates.

| Comparison | Before | After |
|---|---:|---:|
| P1D2 vs ordinary TP2 | 6/40 | **0/40** |
| P1D2 vs P2D2 | 4/40 | 2/40 |
| P2D1 vs ordinary TP1 | 4/40 | 4/40 |
| P2D1 vs P1D1 | 6/40 | 2/40 |

P1D1 and P2D2 each retained identical token sequences before and after the change. All repeated runs were deterministic, and all four patched configurations reported zero transfer or notification failures.

The remaining P1D2/P2D2 difference is the prompt where the homogeneous baseline already differs from ordinary inference. P2D1 still differs from P1D1 on one prompt in both repetitions; that residual difference has not been independently attributed. These results establish the P1D2 correction, not full generation equivalence across all TP configurations or benchmark accuracy.

Environment limitation: Python source was based on `d6bce42983bc0b2095ad6422dbf1399e219ae572`, with CUDA 12.9 precompiled extensions from `27a94d1ce4e3fc100c4732439ccec10f8246a804` because of driver compatibility. All before/after comparisons used the same binaries. This was not a full source build of the target commit. The full test dependency installation was blocked by an unrelated `arctic-inference` Torch requirement; focused test dependencies were installed with uv instead.

The tests could be compressed if reviewers think they are superfluous and not that necessary.

PTAL.

---

- [x] Purpose and linked issue included.
- [x] Test commands and results included.
- [x] Model evaluation results and limitations included.
- [x] Duplicate-work check and AI assistance disclosed.
- [x] Human submitter has reviewed every changed line, run the relevant tests and can explain the change end-to-end.
