### PR TITLE
[Qwen3.8-Flash-Next] Fuse PLE residual and QSA output gate

### DIFF
--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -1304,6 +1304,12 @@ def test_fused_conv_correctness(
         dtype=torch.bfloat16,
         generator=rng,
     )
+    outer_residual = torch.randn(
+        inputs.shape,
+        device=device,
+        dtype=torch.bfloat16,
+        generator=rng,
+    )
     null_state = conv_state[NULL_BLOCK_ID].clone()
     residual_kernel = residual.clone()
     residual_reference = residual.clone()
@@ -1311,6 +1317,7 @@ def test_fused_conv_correctness(
     module._short_conv_dilated_dispatch(
         inputs=inputs,
         residual=residual_kernel,
+        outer_residual=outer_residual,
         metadata=metadata,
         conv_state=conv_state,
         conv_weights=weights,
@@ -1324,6 +1331,7 @@ def test_fused_conv_correctness(
         conv_state_len=module.conv_state_len,
         dilation=module.short_conv_dilation,
     )
+    residual_reference = outer_residual + residual_reference
 
     torch.testing.assert_close(
         residual_kernel.float(), residual_reference.float(), atol=3e-2, rtol=3e-2
@@ -1332,7 +1340,8 @@ def test_fused_conv_correctness(
     assert torch.equal(conv_state[NULL_BLOCK_ID], null_state)
     if case.graph_padding:
         assert torch.equal(
-            residual_kernel[num_real_tokens:], residual[num_real_tokens:]
+            residual_kernel[num_real_tokens:],
+            (outer_residual + residual)[num_real_tokens:],
         )
 
 

--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -889,6 +889,7 @@ def test_qsa_sparse_paged_attention_correctness(
     q = torch.randn(
         num_rows, num_query_heads, head_dim, device="cuda", dtype=torch.bfloat16
     )
+    output_gate = torch.randn_like(q)
     kv_cache = torch.randn(
         num_cache_blocks,
         page_size,
@@ -968,6 +969,7 @@ def test_qsa_sparse_paged_attention_correctness(
         block_table,
         token_to_req,
         use_prefill_config=use_prefill_config,
+        output_gate=output_gate,
     )
     expected = _qsa_sparse_paged_attention_reference(
         q,
@@ -978,6 +980,7 @@ def test_qsa_sparse_paged_attention_correctness(
         token_to_req,
         scale,
     )
+    expected = expected * torch.sigmoid(output_gate)
 
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -297,7 +297,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
 
             if input_ids is None or query_start_loc is None or ngram_context is None:
                 raise RuntimeError("PLE inputs were not prepared")
-            hidden_states = hidden_states + self.ple(
+            hidden_states = self.ple(
                 hidden_states,
                 input_ids,
                 query_start_loc,

--- a/vllm/models/qwen4_exp/nvidia/ops/ple.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/ple.py
@@ -322,6 +322,7 @@ def _ple_conv_kernel(
     state_ptr,
     w_ptr,
     residual_ptr,
+    outer_residual_ptr,
     state_idx_ptr,
     qsl_ptr,
     num_acc_ptr,
@@ -442,11 +443,21 @@ def _ple_conv_kernel(
         mask=c_mask,
         other=0.0,
     )
+    # Preserve the original eager operation boundaries: short convolution is
+    # first accumulated into the BF16/FP16 PLE output, then the outer residual
+    # is added to that rounded value.
+    ple_output = (residual + conv_output).to(residual_ptr.dtype.element_ty)
+    outer_residual = tl.load(
+        outer_residual_ptr + output_t * C + c_offs,
+        mask=c_mask,
+        other=0.0,
+    )
+    ple_output = outer_residual + ple_output
     if launch_pdl:
         tl.extra.cuda.gdc_launch_dependents()
     tl.store(
         residual_ptr + output_t * C + c_offs,
-        residual + conv_output,
+        ple_output,
         mask=c_mask,
     )
 
@@ -564,6 +575,7 @@ def ple_conv(
     conv_state: torch.Tensor,
     conv_weights: torch.Tensor,
     state_indices: torch.Tensor,
+    outer_residual: torch.Tensor,
     *,
     mode: Literal["decode", "spec", "prefill"],
     dilation: int,
@@ -573,7 +585,7 @@ def ple_conv(
     spec_query_len: int = 1,
     token_indices: torch.Tensor | None = None,
 ) -> None:
-    """Add short-convolution output to ``residual`` and update its state."""
+    """Add short convolution and the outer residual; update state."""
     BLOCK_C = 512
     kernel_spec_query_len = spec_query_len if mode == "spec" else 1
     T, C = inputs.shape
@@ -624,6 +636,7 @@ def ple_conv(
         conv_state,
         conv_weights,
         residual,
+        outer_residual,
         state_indices,
         query_start_loc,
         num_accepted_tokens,

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -24,6 +24,7 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     partial_output_ptr,
     partial_lse_ptr,
     output_ptr,
+    output_gate_ptr,
     stride_q_row,
     stride_q_head,
     stride_k_block,
@@ -36,6 +37,8 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     stride_table_req,
     stride_output_row,
     stride_output_head,
+    stride_output_gate_row,
+    stride_output_gate_head,
     num_rows,
     num_cache_blocks,
     num_requests,
@@ -151,6 +154,21 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     )
     output_mask = head_offsets[:, None] < GROUP_SIZE
     if NUM_SPLITS == 1:
+        if output_gate_ptr is not None:
+            # Preserve the unfused path's BF16 attention-output rounding before
+            # applying the gate in FP32.
+            normalized_output = normalized_output.to(output_ptr.dtype.element_ty)
+            output_gate = tl.load(
+                output_gate_ptr
+                + row * stride_output_gate_row
+                + (first_head + head_offsets[:, None]) * stride_output_gate_head
+                + dim_offsets[None, :],
+                mask=output_mask,
+                other=0.0,
+            ).to(tl.float32)
+            normalized_output = normalized_output.to(tl.float32) * tl.sigmoid(
+                output_gate
+            )
         tl.store(
             output_ptr
             + row * stride_output_row
@@ -186,8 +204,11 @@ def _qsa_merge_splitk_kernel(
     partial_output_ptr,
     partial_lse_ptr,
     output_ptr,
+    output_gate_ptr,
     stride_output_row,
     stride_output_head,
+    stride_output_gate_row,
+    stride_output_gate_head,
     num_rows,
     HEAD_DIM: tl.constexpr,
     NUM_QUERY_HEADS: tl.constexpr,
@@ -219,6 +240,17 @@ def _qsa_merge_splitk_kernel(
     )
     merged = tl.sum(partial_output * weights[:, None], axis=0)
     merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    if output_gate_ptr is not None:
+        # Preserve the unfused path's BF16 attention-output rounding before
+        # applying the gate in FP32.
+        merged = merged.to(output_ptr.dtype.element_ty)
+        output_gate = tl.load(
+            output_gate_ptr
+            + row * stride_output_gate_row
+            + head * stride_output_gate_head
+            + dim_offsets
+        ).to(tl.float32)
+        merged = merged.to(tl.float32) * tl.sigmoid(output_gate)
     tl.store(
         output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
         merged,
@@ -455,6 +487,7 @@ def qsa_sparse_paged_attention(
     token_to_req: torch.Tensor,
     use_prefill_config: bool,
     out: torch.Tensor | None = None,
+    output_gate: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run sparse GQA directly over paged BF16 K/V caches.
 
@@ -496,6 +529,7 @@ def qsa_sparse_paged_attention(
         raise ValueError("QSA sparse output must match its query")
     assert out.dtype == q.dtype and out.device == q.device
     assert out.stride(2) == 1
+    output_gate_view = output_gate.view_as(q) if output_gate is not None else None
     if not q.shape[0]:
         return out
 
@@ -533,6 +567,7 @@ def qsa_sparse_paged_attention(
         partial_output,
         partial_lse,
         out,
+        output_gate_view,
         q.stride(0),
         q.stride(1),
         k_cache.stride(0),
@@ -545,6 +580,8 @@ def qsa_sparse_paged_attention(
         block_table.stride(0),
         out.stride(0),
         out.stride(1),
+        output_gate_view.stride(0) if output_gate_view is not None else 0,
+        output_gate_view.stride(1) if output_gate_view is not None else 0,
         q.shape[0],
         k_cache.shape[0],
         block_table.shape[0],
@@ -568,8 +605,11 @@ def qsa_sparse_paged_attention(
         partial_output,
         partial_lse,
         out,
+        output_gate_view,
         out.stride(0),
         out.stride(1),
+        output_gate_view.stride(0) if output_gate_view is not None else 0,
+        output_gate_view.stride(1) if output_gate_view is not None else 0,
         q.shape[0],
         HEAD_DIM=q.shape[2],
         NUM_QUERY_HEADS=q.shape[1],

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -636,6 +636,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         self,
         inputs: torch.Tensor,
         residual: torch.Tensor,
+        outer_residual: torch.Tensor,
         metadata: PleShortConvAttentionMetadata,
         conv_state: torch.Tensor,
         conv_weights: torch.Tensor,
@@ -650,6 +651,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         has_non_spec = has_prefill or has_decode
         inputs = inputs[: metadata.num_actual_tokens]
         residual = residual[: metadata.num_actual_tokens]
+        outer_residual = outer_residual[: metadata.num_actual_tokens]
 
         spec_token_indices = None
         non_spec_token_indices = None
@@ -676,6 +678,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 conv_state=conv_state,
                 conv_weights=conv_weights,
                 state_indices=spec_state_indices,
+                outer_residual=outer_residual,
                 mode="spec",
                 dilation=self.short_conv_dilation,
                 query_start_loc=query_start_loc,
@@ -700,11 +703,17 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 residual_d, residual_p = torch.split(
                     residual, [num_decode_tokens, num_prefill_tokens], dim=0
                 )
+                outer_residual_d, outer_residual_p = torch.split(
+                    outer_residual,
+                    [num_decode_tokens, num_prefill_tokens],
+                    dim=0,
+                )
                 token_indices_d = None
                 token_indices_p = None
             else:
                 inputs_d = inputs_p = inputs
                 residual_d = residual_p = residual
+                outer_residual_d = outer_residual_p = outer_residual
                 token_indices_d, token_indices_p = torch.split(
                     non_spec_token_indices,
                     [num_decode_tokens, num_prefill_tokens],
@@ -718,6 +727,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                     conv_state=conv_state,
                     conv_weights=conv_weights,
                     state_indices=state_indices_d,
+                    outer_residual=outer_residual_d,
                     mode="decode",
                     dilation=self.short_conv_dilation,
                     has_initial_states=metadata.has_initial_states_d,
@@ -739,6 +749,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 conv_state=conv_state,
                 conv_weights=conv_weights,
                 state_indices=state_indices_p,
+                outer_residual=outer_residual_p,
                 mode="prefill",
                 dilation=self.short_conv_dilation,
                 query_start_loc=query_start_loc,
@@ -757,6 +768,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 conv_state=conv_state,
                 conv_weights=conv_weights,
                 state_indices=state_indices[:num_decode_rows],
+                outer_residual=outer_residual,
                 mode="decode",
                 dilation=self.short_conv_dilation,
                 has_initial_states=metadata.has_initial_states_d,
@@ -765,12 +777,18 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
 
     # State routing consumes the current request metadata on every replay.
     @eager_break_during_capture
-    def _short_conv(self, inputs: torch.Tensor, residual: torch.Tensor) -> None:
+    def _short_conv(
+        self,
+        inputs: torch.Tensor,
+        residual: torch.Tensor,
+        outer_residual: torch.Tensor,
+    ) -> None:
         forward_context = get_forward_context()
         attn_metadata = forward_context.attn_metadata
-        # Profiling omits all metadata or this Mamba entry. The residual
-        # already contains the gated output, so short convolution is a no-op.
+        # Profiling omits all metadata or this Mamba entry. Short convolution
+        # is a no-op there, but preserve the outer residual addition.
         if attn_metadata is None:
+            residual.add_(outer_residual)
             return
 
         if not isinstance(attn_metadata, dict):
@@ -781,6 +799,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
 
         layer_attn_metadata = attn_metadata.get(self.prefix)
         if layer_attn_metadata is None:
+            residual.add_(outer_residual)
             return
         if not isinstance(layer_attn_metadata, PleShortConvAttentionMetadata):
             raise TypeError(
@@ -808,6 +827,7 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         self._short_conv_dilated_dispatch(
             inputs=inputs,
             residual=residual,
+            outer_residual=outer_residual,
             metadata=layer_attn_metadata,
             conv_state=conv_state,
             conv_weights=conv_weights.to(dtype=inputs.dtype),
@@ -840,7 +860,9 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
             self.norm_conv.weight,
             self.norm_key.eps,
         )
-        self._short_conv(conv_input, gated_output)
+        # State routing depends on runtime request metadata and remains outside
+        # the graph; short convolution accumulates into gated_output.
+        self._short_conv(conv_input, gated_output, hidden_states)
         return gated_output
 
 

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -121,6 +121,7 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
         output: torch.Tensor,
         token_to_req: torch.Tensor,
         use_prefill_config: bool,
+        output_gate: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
@@ -157,6 +158,7 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
             token_to_req,
             use_prefill_config,
             output[:num_tokens],
+            output_gate=None if output_gate is None else output_gate[:num_tokens],
         )
         return output
 
@@ -353,6 +355,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         key: torch.Tensor,
         value: torch.Tensor,
         output: torch.Tensor,
+        output_gate: torch.Tensor | None,
     ) -> None:
         metadata = get_forward_context().attn_metadata
         if isinstance(metadata, list):
@@ -396,6 +399,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             output,
             token_to_req=side_metadata.token_to_req,
             use_prefill_config=main_metadata.max_query_len > self._max_decode_query_len,
+            output_gate=output_gate,
         )
 
     def forward(
@@ -419,10 +423,9 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             key,
             value,
             attn_output,
+            gate,
         )
         flat_output = attn_output.view(num_tokens, -1)
-        if gate is not None:
-            flat_output = flat_output * torch.sigmoid(gate)
         output, _ = self.o_proj(flat_output)
         return output
 


### PR DESCRIPTION
## Summary

- fuse the outer PLE residual add into the existing short-convolution kernel
- fuse the optional QSA output gate into both the single-split attention epilogue and the split-K merge kernel
- preserve the original BF16/FP16 rounding boundaries before each fused post-op
- keep the existing model-level `support_torch_compile` behavior unchanged

This removes two standalone pointwise operations from the Qwen4Exp NVIDIA path.

## Relationship to #55272

This change is complementary to #55272, not covered by it. #55272 removes model-level compile/custom-op plumbing, but its current diff still performs the PLE outer residual add and QSA output-gate multiplication as separate PyTorch operations. If #55272 lands first, this PR will be rebased onto its breakable-graph call structure.

## Validation

- `CUDA_VISIBLE_DEVICES=4 python3 -m pytest -q tests/models/qwen4_exp/test_ple.py -k fused_conv_correctness` — 12 passed
- `CUDA_VISIBLE_DEVICES=4 python3 -m pytest -q tests/models/qwen4_exp/test_qsa_reference.py -k qsa_sparse_paged_attention_correctness` — 5 passed
- `pre-commit run --from-ref main --to-ref HEAD` — passed

## Kernel microbenchmark

NVIDIA B200, CUDA 13.0, PyTorch 2.13.0+cu130, BF16; cold-L2 CUPTI medians with CUDA graphs. Both the main baseline and fused callables are captured with `torch.compile(fullgraph=True, dynamic=False)`, and materialized outputs are checked before timing. The baseline is this PR's parent, `848ab131bc`; the fused revision is `1bdb8f29bd`.

### PLE outer residual

Model dimensions are `H=2560`, `HC=4`, `C=10240`, convolution kernel size 4, and dilation 3. The baseline is the existing PLE short convolution followed by the compiled outer residual add; the current path performs the same BF16-rounded add inside the short-convolution kernel. Decode rows represent batch size, while prefill rows represent tokens in one request.

The timed PLE operands use zero convolution weights and a zero outer residual so repeated in-place CUDA graph replay is idempotent. Kernel control flow, launches, and memory accesses are data-independent; the random-valued correctness cases above cover the fused numerics.

#### Decode

| Batch rows | Main compiled (us) | Fused (us) | Speedup |
|---:|---:|---:|---:|
| 1 | 6.464 | 4.480 | 1.443x |
| 16 | 13.088 | 11.488 | 1.139x |
| 64 | 28.640 | 27.072 | 1.058x |
| 256 | 84.160 | 82.431 | 1.021x |

#### Prefill

| Tokens | Main compiled (us) | Fused (us) | Speedup |
|---:|---:|---:|---:|
| 16 | 8.960 | 6.944 | 1.290x |
| 64 | 12.032 | 9.440 | 1.275x |
| 256 | 22.272 | 18.816 | 1.184x |
| 2048 | 118.175 | 102.368 | 1.154x |
| 8192 | 454.944 | 386.719 | 1.176x |

PLE improves by 1.44x for single-row decode and by 1.15x-1.29x across the measured prefill sizes. At larger decode batches, the short convolution dominates and the relative benefit of removing the pointwise add decreases.

### QSA output gate

The QSA benchmark uses the model's TP4 shape: 6 query heads, 1 KV head, head dimension 256, page size 1024, and selection width 2051 (`token_topk=2048` plus the expansion tail), with selected tokens spread across 64 pages. The baseline runs sparse paged attention followed by the compiled sigmoid gate multiplication; the current path applies the gate in the single-split epilogue or split-K merge kernel.

| Query rows | Main compiled (us) | Fused (us) | Speedup |
|---:|---:|---:|---:|
| 1 | 12.832 | 11.616 | 1.105x |
| 16 | 22.048 | 20.896 | 1.055x |
| 32 | 27.344 | 26.559 | 1.030x |
| 257 | 110.528 | 109.440 | 1.010x |
| 513 | 229.248 | 226.783 | 1.011x |

The gate fusion improves the latency-sensitive one-row path by 10.5%. As row count grows, sparse attention dominates total time, so the benefit converges to about 1% while remaining non-regressive in the measured cases.
