### PR TITLE
[Kernel] Add a fused Triton kernel for GemmaRMSNorm on CUDA

### DIFF
--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -232,6 +232,48 @@ def test_fused_rms_norm_quant(
         )
 
 
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("strided_input", [False, True])
+@torch.inference_mode()
+def test_gemma_rms_norm(
+    default_vllm_config,
+    num_tokens: int,
+    hidden_size: int,
+    add_residual: bool,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    strided_input: bool,
+) -> None:
+    """The fused CUDA path must match forward_native, which keeps the +1
+    weight offset and the multiply in fp32."""
+    set_random_seed(seed)
+    torch.set_default_device(device)
+    layer = GemmaRMSNorm(hidden_size, eps=1e-6).to(dtype=dtype)
+    layer.weight.data.normal_(mean=0.0, std=0.1)
+    scale = 1 / (2 * hidden_size)
+    last_dim = 2 * hidden_size if strided_input else hidden_size
+    x = torch.randn(num_tokens, last_dim, dtype=dtype)[..., :hidden_size]
+    assert x.is_contiguous() != strided_input
+    x *= scale
+    residual = x.new_empty_strided(x.size(), x.stride()) if add_residual else None
+    if residual is not None:
+        residual.normal_(std=scale)
+        ref_out = layer.forward_native(x, residual.clone())
+        out = layer(x, residual)
+        torch.testing.assert_close(out[0], ref_out[0], atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(out[1], ref_out[1], atol=1e-2, rtol=1e-2)
+    else:
+        ref_out = layer.forward_native(x)
+        out = layer(x)
+        torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
+
+
 @torch.inference_mode()
 def test_gemma_rms_norm_mixed_input_weight_dtype(default_vllm_config) -> None:
     if not torch.cuda.is_available():

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -7,6 +7,7 @@ import torch
 from tests.kernels.quant_utils import FP8_DTYPE
 from tests.kernels.utils import fp8_allclose, fp8_ulp_distance, opcheck
 from vllm import ir
+from vllm.kernels.triton.gemma_rms_norm import gemma_rms_norm_supported
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -272,6 +273,41 @@ def test_gemma_rms_norm(
         ref_out = layer.forward_native(x)
         out = layer(x)
         torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
+
+
+@torch.inference_mode()
+def test_gemma_rms_norm_layouts_off_the_fused_path(default_vllm_config) -> None:
+    device = CUDA_DEVICES[0]
+    torch.set_default_device(device)
+    hidden_size = 128
+    layer = GemmaRMSNorm(hidden_size, eps=1e-6).to(dtype=torch.bfloat16)
+    layer.weight.data.normal_(mean=0.0, std=0.1)
+
+    def sliced(seed: int) -> torch.Tensor:
+        set_random_seed(seed)
+        return torch.randn((4, 3, hidden_size), dtype=torch.bfloat16)[::2]
+
+    assert not gemma_rms_norm_supported(sliced(0), layer.weight.data, sliced(1))
+    ref = layer.forward_native(sliced(0), sliced(1))
+    out = layer(sliced(0), sliced(1))
+    torch.testing.assert_close(out[0], ref[0], atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(out[1], ref[1], atol=1e-2, rtol=1e-2)
+
+    x = torch.randn(4, hidden_size, dtype=torch.bfloat16)
+    residual = torch.randn(4, hidden_size, dtype=torch.float32)
+    assert not gemma_rms_norm_supported(x, layer.weight.data, residual)
+    ref = layer.forward_native(x, residual)
+    out = layer(x, residual)
+    assert out[1].dtype == ref[1].dtype
+    torch.testing.assert_close(out[0], ref[0], atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(out[1], ref[1], atol=1e-2, rtol=1e-2)
+
+    set_random_seed(0)
+    weight = torch.randn(1, dtype=torch.bfloat16).expand(hidden_size)
+    layer.weight = torch.nn.Parameter(weight, requires_grad=False)
+    x = torch.randn(4, hidden_size, dtype=torch.bfloat16)
+    assert not gemma_rms_norm_supported(x, weight, None)
+    torch.testing.assert_close(layer(x), layer.forward_native(x), atol=1e-2, rtol=1e-2)
 
 
 @torch.inference_mode()

--- a/vllm/kernels/triton/gemma_rms_norm.py
+++ b/vllm/kernels/triton/gemma_rms_norm.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused Gemma-style RMSNorm: x * rsqrt(mean(x^2) + eps) * (1 + w).
+
+The +1 offset and the weight multiply happen in fp32 and the result is cast
+once at the end, matching ``GemmaRMSNorm.forward_native``. The vLLM C kernels
+cannot be used directly because they require the weight to share the
+activation dtype, and rounding ``1 + w`` to bf16 changes the output.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+_MAX_BLOCK_SIZE = 65536
+
+
+@triton.jit
+def _gemma_rms_norm_kernel(
+    x_ptr,
+    residual_ptr,
+    weight_ptr,
+    out_ptr,
+    x_row_stride,
+    residual_row_stride,
+    out_row_stride,
+    n_cols,
+    eps,
+    HAS_RESIDUAL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    cols = tl.arange(0, BLOCK_SIZE)
+    mask = cols < n_cols
+
+    x = tl.load(x_ptr + row * x_row_stride + cols, mask=mask, other=0.0)
+    x = x.to(tl.float32)
+    if HAS_RESIDUAL:
+        residual_ptrs = residual_ptr + row * residual_row_stride + cols
+        residual = tl.load(residual_ptrs, mask=mask, other=0.0)
+        x = x + residual.to(tl.float32)
+        tl.store(residual_ptrs, x.to(residual_ptr.dtype.element_ty), mask=mask)
+
+    variance = tl.sum(x * x, axis=0) / n_cols
+    x = x * tl.rsqrt(variance + eps)
+
+    weight = tl.load(weight_ptr + cols, mask=mask, other=0.0)
+    out = x * (weight.to(tl.float32) + 1.0)
+    tl.store(
+        out_ptr + row * out_row_stride + cols,
+        out.to(out_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+
+def gemma_rms_norm_supported(hidden_size: int) -> bool:
+    return triton.next_power_of_2(hidden_size) <= _MAX_BLOCK_SIZE
+
+
+def gemma_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    residual: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Returns the normalized tensor; with ``residual`` given, ``x + residual``
+    is also written back into ``residual`` (matching ``fused_add_rms_norm``)."""
+    hidden_size = x.shape[-1]
+    x_2d = x.reshape(-1, hidden_size)
+    if x_2d.stride(-1) != 1:
+        x_2d = x_2d.contiguous()
+    out = torch.empty_like(x_2d)
+    n_rows = x_2d.shape[0]
+    if n_rows == 0:
+        return out.reshape(x.shape)
+
+    if residual is not None:
+        residual_2d = residual.view(-1, hidden_size)
+        assert residual_2d.stride(-1) == 1
+        residual_row_stride = residual_2d.stride(0)
+    else:
+        residual_2d = out
+        residual_row_stride = 0
+
+    block_size = triton.next_power_of_2(hidden_size)
+    num_warps = min(max(block_size // 1024, 1), 16)
+    _gemma_rms_norm_kernel[(n_rows,)](
+        x_2d,
+        residual_2d,
+        weight,
+        out,
+        x_2d.stride(0),
+        residual_row_stride,
+        out.stride(0),
+        hidden_size,
+        eps,
+        HAS_RESIDUAL=residual is not None,
+        BLOCK_SIZE=block_size,
+        num_warps=num_warps,
+    )
+    return out.reshape(x.shape)

--- a/vllm/kernels/triton/gemma_rms_norm.py
+++ b/vllm/kernels/triton/gemma_rms_norm.py
@@ -60,7 +60,16 @@ def gemma_rms_norm_supported(
         return False
     if weight.shape != x.shape[-1:] or weight.stride(-1) != 1:
         return False
-    return residual is None or (residual.shape == x.shape and residual.stride(-1) == 1)
+    if residual is None:
+        return True
+    if residual.shape != x.shape or residual.dtype != x.dtype:
+        return False
+    if residual.stride(-1) != 1:
+        return False
+    return all(
+        residual.stride(i) == residual.size(i + 1) * residual.stride(i + 1)
+        for i in range(residual.dim() - 2)
+    )
 
 
 def gemma_rms_norm(

--- a/vllm/kernels/triton/gemma_rms_norm.py
+++ b/vllm/kernels/triton/gemma_rms_norm.py
@@ -56,12 +56,9 @@ def _gemma_rms_norm_kernel(
 def gemma_rms_norm_supported(
     x: torch.Tensor, weight: torch.Tensor, residual: torch.Tensor | None
 ) -> bool:
-    """The kernel derives both the row count and the column count from x,
-    so weight and residual have to match it exactly. Everything else,
-    broadcasting included, belongs on the reference path."""
     if triton.next_power_of_2(x.shape[-1]) > _MAX_BLOCK_SIZE:
         return False
-    if weight.shape != x.shape[-1:]:
+    if weight.shape != x.shape[-1:] or weight.stride(-1) != 1:
         return False
     return residual is None or (residual.shape == x.shape and residual.stride(-1) == 1)
 

--- a/vllm/kernels/triton/gemma_rms_norm.py
+++ b/vllm/kernels/triton/gemma_rms_norm.py
@@ -53,8 +53,17 @@ def _gemma_rms_norm_kernel(
     )
 
 
-def gemma_rms_norm_supported(hidden_size: int) -> bool:
-    return triton.next_power_of_2(hidden_size) <= _MAX_BLOCK_SIZE
+def gemma_rms_norm_supported(
+    x: torch.Tensor, weight: torch.Tensor, residual: torch.Tensor | None
+) -> bool:
+    """The kernel derives both the row count and the column count from x,
+    so weight and residual have to match it exactly. Everything else,
+    broadcasting included, belongs on the reference path."""
+    if triton.next_power_of_2(x.shape[-1]) > _MAX_BLOCK_SIZE:
+        return False
+    if weight.shape != x.shape[-1:]:
+        return False
+    return residual is None or (residual.shape == x.shape and residual.stride(-1) == 1)
 
 
 def gemma_rms_norm(
@@ -65,6 +74,7 @@ def gemma_rms_norm(
 ) -> torch.Tensor:
     """Returns the normalized tensor; with ``residual`` given, ``x + residual``
     is also written back into ``residual`` (matching ``fused_add_rms_norm``)."""
+    assert gemma_rms_norm_supported(x, weight, residual)
     hidden_size = x.shape[-1]
     x_2d = x.reshape(-1, hidden_size)
     if x_2d.stride(-1) != 1:
@@ -76,7 +86,6 @@ def gemma_rms_norm(
 
     if residual is not None:
         residual_2d = residual.view(-1, hidden_size)
-        assert residual_2d.stride(-1) == 1
         residual_row_stride = residual_2d.stride(0)
     else:
         residual_2d = out

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -9,9 +9,14 @@ import torch.nn.functional as F
 # Import kernels
 import vllm.kernels  # noqa: F401
 from vllm import envs, ir
+from vllm.kernels.triton.gemma_rms_norm import (
+    gemma_rms_norm,
+    gemma_rms_norm_supported,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.determinism.batch_invariant import rms_norm_batch_invariant
+from vllm.triton_utils import HAS_TRITON
 
 logger = init_logger(__name__)
 
@@ -164,7 +169,19 @@ class GemmaRMSNorm(CustomOp):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        return self.forward_native(x, residual)
+        # The vLLM C kernels need the weight in the activation dtype, and
+        # rounding `1 + w` to bf16 changes the result, so use a Triton kernel
+        # that keeps the +1 offset and the multiply in fp32 like forward_native.
+        if (
+            not HAS_TRITON
+            or not gemma_rms_norm_supported(x.shape[-1])
+            or (residual is not None and residual.stride(-1) != 1)
+        ):
+            return self.forward_native(x, residual)
+        out = gemma_rms_norm(x, self.weight.data, self.variance_epsilon, residual)
+        if residual is None:
+            return out
+        return out, residual
 
     def forward_xpu(
         self,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -172,10 +172,8 @@ class GemmaRMSNorm(CustomOp):
         # The vLLM C kernels need the weight in the activation dtype, and
         # rounding `1 + w` to bf16 changes the result, so use a Triton kernel
         # that keeps the +1 offset and the multiply in fp32 like forward_native.
-        if (
-            not HAS_TRITON
-            or not gemma_rms_norm_supported(x.shape[-1])
-            or (residual is not None and residual.stride(-1) != 1)
+        if not HAS_TRITON or not gemma_rms_norm_supported(
+            x, self.weight.data, residual
         ):
             return self.forward_native(x, residual)
         out = gemma_rms_norm(x, self.weight.data, self.variance_epsilon, residual)


### PR DESCRIPTION
# [Kernel] Add fused Triton kernel for GemmaRMSNorm on CUDA

## Purpose

`GemmaRMSNorm.forward_cuda` currently delegates to `forward_native`, which passes an **fp32** `weight + 1` to `ir.ops.rms_norm`.

Existing fused RMSNorm implementations require the weight dtype to match the activation dtype, so GemmaRMSNorm falls back to the unfused reference implementation:

```text
rms_norm impls: ['native', 'aiter', 'oink', 'vllm_c']
vllm_c: fp32 weight / bf16 x -> unsupported
aiter: unsupported
oink: unsupported
native: supported
```

The fallback performs `.float()`, `pow`, `mean`, `rsqrt`, multiplies, and `.to()`, resulting in 5–6 kernels and two fp32 round trips per norm.

This affects Gemma models and Qwen3-Next / Qwen3.5 / Qwen3.8 through:

```python
Qwen3NextRMSNorm = GemmaRMSNorm
```

XPU already has a fused `xpu_gemma_rms_norm`; CUDA did not.

This PR targets the `custom_ops` path used when Inductor is disabled (`--enforce-eager`, `-cc.mode=none`, or explicit `+gemma_rms_norm`). The default compiled path remains unchanged because Inductor already fuses the native decomposition.

Casting `1 + weight` to bf16 and calling `_C.rms_norm` is not equivalent: it changes outputs by up to ~3e-2.

## Change

- Add `vllm/kernels/triton/gemma_rms_norm.py`
  - one row per Triton program
  - optional fused residual add
  - fp32 accumulation
  - computes `float(weight) + 1` and the final multiply in fp32
  - casts once at the end
  - supports strided rows
  - falls back to `forward_native` for hidden sizes >64K or non-unit-stride residuals
- Use the Triton kernel from `GemmaRMSNorm.forward_cuda`, mirroring the XPU path.
- Add `test_gemma_rms_norm` covering:
  - fp16 / bf16 / fp32
  - 6 hidden sizes
  - residual / no residual
  - contiguous / strided input
  - 3 token counts

## Not a duplicate

I checked the current open PRs/issues for GemmaRMSNorm fusion.

#42251 addresses native custom-op fallbacks using a generic `torch.compile` wrapper. This PR instead adds an explicit CUDA kernel with no compile step and reference-compatible numerics, matching the existing XPU approach.

#54787, #43953, #47270, and #53273 are ROCm/AITER or Gemma4-related fusions. #36016 is GemmaRMSNorm + FP8 fusion in the compile-time path.

None provides a fused CUDA implementation for `GemmaRMSNorm.forward_cuda`.

Re-checked against main @ `9cd956c7e`.

## Test Plan

```bash
python -m pytest tests/kernels/core/test_layernorm.py -k gemma -q

pre-commit run --files \
    vllm/model_executor/layers/layernorm.py \
    vllm/kernels/triton/gemma_rms_norm.py \
    tests/kernels/core/test_layernorm.py
```

Also benchmarked `forward_native` vs `forward_cuda` using CUDA-graph replay and ran end-to-end eager-mode inference before/after.

## Results

Tested on:

- RTX 5090 (sm_120), PyTorch 2.13.0+cu130, Triton 3.7.1
- H100 80GB, PyTorch 2.13.0+cu132

**Tests**

- `test_gemma_rms_norm`: 217 passed
- full `test_layernorm.py`: 1189 passed
- pre-commit: passed

**Correctness vs `forward_native`**

Maximum absolute difference across all parametrizations:

| dtype | max \|diff\| |
| --- | ---: |
| bf16 | 4.9e-4 |
| fp16 | 9.8e-4 |
| fp32 | 4.8e-7 |

On H100, bf16 is bitwise equal to the reference. On RTX 5090, a few values differ by 1 ULP due to fp32 reduction order.

### Kernel benchmark

Hidden size 5120, bf16, CUDA-graph replay, median:

| M | native, 5090 | Triton, 5090 | native, H100 | Triton, H100 |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 0.0116 ms | 0.0018 ms (6.4x) | 0.0173 ms | 0.0022 ms (7.9x) |
| 64 | 0.0190 ms | 0.0020 ms (9.5x) | 0.0276 ms | 0.0023 ms (11.8x) |
| 2048 | 0.1240 ms | 0.0094 ms (13.2x) | 0.1887 ms | 0.0154 ms (12.3x) |

The fused residual path shows similar gains.

### End-to-end

`--enforce-eager`, batch size 1, 256 tokens, median of 3:

| model | GPUs | before | after |
| --- | --- | ---: | ---: |
| Qwen3.8-27B, NVFP4A16 | 1x RTX 5090 | 43.6 tok/s | **57.5 tok/s (+32%)** |
| Qwen3.5-9B, bf16 | 1x H100 | 43.2 tok/s | **56.5 tok/s (+31%)** |
| Qwen3-Next-80B-A3B-Instruct-FP8, TP=2 | 2x H100 | 11.0 tok/s | **12.2 tok/s (+11%)** |

Profiling Qwen3.8-27B shows the norm decomposition collapsing from multiple `mean` / `rsqrt` / `pow` / `mul` / `add` / copy launches into a single `_gemma_rms_norm_kernel` per norm.

As expected, performance is unchanged for:

- default compiled mode, where Inductor already fuses `forward_native`
- Qwen3.8-Flash-Next-FP8, which uses `GroupedGemmaRMSNorm` and a different fused kernel

## Model evaluation

No separate accuracy evaluation was run because the kernel reproduces `forward_native` arithmetic except for fp32 reduction order. The parametrized tests cover all supported dtypes and shapes using the existing RMSNorm tolerances.

## AI assistance

This change was developed with AI assistance. The submitter reviewed every changed line and ran all tests and benchmarks above.