### PR TITLE
[Bugfix][Model Loader] Run post-load processing for raw Tensorizer weights

### DIFF
--- a/tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py
+++ b/tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import subprocess
 import sys
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
 
@@ -17,6 +18,7 @@ import torch
 import vllm.model_executor.model_loader.tensorizer
 from tests.utils import VLLM_PATH, RemoteOpenAIServer
 from vllm import SamplingParams
+from vllm.config.load import LoadConfig
 from vllm.engine.arg_utils import EngineArgs
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerConfig,
@@ -27,6 +29,7 @@ from vllm.model_executor.model_loader.tensorizer import (
 )
 from vllm.model_executor.model_loader.tensorizer_loader import (
     BLACKLISTED_TENSORIZER_ARGS,
+    TensorizerLoader,
 )
 from vllm.utils.import_utils import PlaceholderModule
 
@@ -161,6 +164,64 @@ def test_deserialized_hf_model_has_same_outputs(
         )
 
         assert outputs == deserialized_outputs
+
+
+@torch.inference_mode()
+def test_deserialized_hf_weights_are_ready_for_forward(tmp_path, monkeypatch):
+    """Raw weights need CPU linear post-processing before the first forward."""
+    from vllm.model_executor.layers import linear
+    from vllm.model_executor.layers import utils as layer_utils
+    from vllm.model_executor.model_loader import base_loader
+    from vllm.platforms.cpu import CpuPlatform
+
+    # Exercise the CPU method on accelerator CI hosts too.
+    for module in (linear, layer_utils, base_loader):
+        monkeypatch.setattr(module, "current_platform", CpuPlatform())
+
+    class TinyModel(torch.nn.Sequential):
+        def __init__(self):
+            super().__init__(torch.nn.Linear(3, 2, bias=False))
+            self[0].quant_method = linear.UnquantizedLinearMethod()
+            self[0]._cpu_skip_gemm_dispatch = True
+
+        def load_weights(self, weights):
+            self.load_state_dict(dict(weights))
+
+        def forward(self, inputs):
+            return self[0].quant_method.apply(self[0], inputs)
+
+    source = torch.nn.Sequential(torch.nn.Linear(3, 2, bias=False))
+    source[0].weight.copy_(torch.tensor([[1.0, 2.0, 3.0], [-2.0, 0.5, 4.0]]))
+    inputs = torch.tensor([[1.0, 2.0, 3.0], [-1.0, 0.0, 2.0]])
+    checkpoint = tmp_path / "raw.tensors"
+    with open_stream(checkpoint, "wb+") as stream:
+        serializer = TensorSerializer(stream)
+        serializer.write_module(source)
+        serializer.close()
+
+    load_config = LoadConfig(
+        load_format="tensorizer",
+        model_loader_extra_config={
+            "tensorizer_config": {"tensorizer_uri": str(checkpoint)}
+        },
+    )
+    model_config = SimpleNamespace(
+        dtype=torch.float32,
+        quantization=None,
+        word_embeddings_untied_by_checkpoint=False,
+    )
+    config = SimpleNamespace(
+        model_config=model_config,
+        load_config=load_config,
+        device_config=SimpleNamespace(device=torch.device("cpu")),
+        parallel_config=SimpleNamespace(tensor_parallel_size=1),
+        quant_config=None,
+    )
+    monkeypatch.setattr(base_loader, "initialize_model", lambda **kwargs: TinyModel())
+
+    loaded = TensorizerLoader(load_config).load_model(config, model_config)
+
+    torch.testing.assert_close(loaded(inputs), source(inputs))
 
 
 def test_load_without_tensorizer_load_format(vllm_runner, capfd, model_ref):

--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -19,10 +19,7 @@ from vllm.model_executor.model_loader.tensorizer import (
     serialize_vllm_model,
     tensorizer_weights_iterator,
 )
-from vllm.model_executor.model_loader.utils import (
-    get_model_architecture,
-    initialize_model,
-)
+from vllm.model_executor.model_loader.utils import get_model_architecture
 from vllm.utils.torch_utils import set_default_torch_dtype
 
 logger = init_logger(__name__)
@@ -64,27 +61,6 @@ class TensorizerLoader(BaseModelLoader):
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         tensorizer_args = self.tensorizer_config._construct_tensorizer_args()
         return tensorizer_weights_iterator(tensorizer_args)
-
-    def _load_model_serialized_cpu(
-        self,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-    ) -> nn.Module:
-        """Load a serialized model with tensorizer to the CPU.
-
-        This is only necessary when the model isn't vLLM-tensorized (see
-        examples/features/tensorize_vllm_model.py) This should still
-        be faster than default HuggingFace loading, but will be slower than
-        loading a vLLM-tensorized model.
-        """
-        device_config = vllm_config.device_config
-        model_config = vllm_config.model_config
-        with set_default_torch_dtype(model_config.dtype):
-            with torch.device(device_config.device):
-                model = initialize_model(vllm_config=vllm_config, prefix=prefix)
-
-            model.load_weights(self._get_weights_iterator())
-        return model.eval()
 
     def download_model(self, model_config: ModelConfig) -> None:
         self.tensorizer_config.verify_with_model_config(model_config)
@@ -136,7 +112,9 @@ class TensorizerLoader(BaseModelLoader):
                     )
             self.load_weights(model, model_config)
             return model
-        return self._load_model_serialized_cpu(vllm_config=vllm_config, prefix=prefix)
+        return super().load_model(
+            vllm_config=vllm_config, model_config=model_config, prefix=prefix
+        )
 
     @staticmethod
     def save_model(


### PR DESCRIPTION
## Purpose

Raw/Hugging Face Tensorizer checkpoints can load their weights successfully but
return a model with state required by forward still uninitialized. For example,
a CPU `UnquantizedLinearMethod` fails with
`AttributeError: 'Linear' object has no attribute 'cpu_linear'`.

Route the non-vLLM-tensorized branch through `BaseModelLoader.load_model` and
remove its separate loading helper. This reuses the existing weight iterator
and shared post-load lifecycle before returning the model. The native
vLLM-tensorized path is unchanged; its state-restoration and eval behavior are
outside this PR's scope.

Refs #55198.

The shared path also honors `model_config` and `load_config.device`, including
online-quantization finalization when applicable. Calling the existing
`load_weights` adds one format-detection read on the raw path.

Duplicate-work checks on 2026-09-04 found no open PR implementing this fix
(`55198 in:body`, `Tensorizer post-load`, and `TensorizerLoader`). #42823 excludes
Tensorizer; #37677 addresses storage URIs. The issue has a contributor's
expression of interest; this PR is limited to the reproduced raw/HF failure.

## Test Plan

The regression writes a real Tensorizer file, loads it through the public loader,
and compares the first forward with the source module. It replaces full-model
construction with a tiny module and uses vLLM's real CPU linear method. CPU
selection is local to the test so accelerator CI hosts can also execute it.

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py \
  -k 'deserialized_hf_weights_are_ready_for_forward or tensorize_vllm_model_shuts_down_engine' -q

.venv/bin/pre-commit run --files \
  vllm/model_executor/model_loader/tensorizer_loader.py \
  tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py

.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files \
  vllm/model_executor/model_loader/tensorizer_loader.py \
  tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py
```

Existing full-model comparison for the standard test environment:

```bash
.venv/bin/python -m pytest \
  tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py::test_deserialized_hf_model_has_same_outputs -q
```

## Test Result

- Targeted regression and five existing shutdown cases: **6 passed**.
- The new regression against baseline loader `9cd956c7e6`: **1 failed** at
  forward with missing `cpu_linear`. The baseline loader was loaded in memory,
  with its model factory forwarded to the same tiny-model test factory.
- Pre-commit and the Python 3.12 mypy hook: **passed**.
- Full-model comparison: **1 passed** on macOS arm64 / CPU / FP16, torch 2.13.0,
  Tensorizer 2.10.1, cached `facebook/opt-125m`. HF and raw Tensorizer-loaded vLLM
  generated identical outputs for four prompts, up to 50 greedy tokens each.
  The existing test used the public resource settings shown below.
- The local CPU extension was rebuilt against torch 2.13.0 to replace a stale
  binary. No C++ source or dependency changes are included.
- Native round-trip and GPU/quantized-model validation were not run.

<details>
<summary>Reproduce the local CPU full-model comparison</summary>

The default memory fraction exceeded this machine's available memory. The local
run used 256 MiB KV cache, eight sequences, a 1,024-token batch limit, and eager
execution. The test body, loading, kernels, and output assertions were unchanged.

The executed local helper was
`.venv/bin/python dist/contribute-pr/issue-55198/run_cpu_model_regression.py`.
That investigation file is excluded from the commit. For another checkout, save
the equivalent helper below as `run_cpu_tensorizer_test.py` at the repository root
and run `.venv/bin/python run_cpu_tensorizer_test.py` after caching OPT-125m:

```python
import os
import sys
from pathlib import Path

os.environ["VLLM_TARGET_DEVICE"] = "cpu"
os.environ["HF_HUB_OFFLINE"] = "1"
os.environ["TRANSFORMERS_OFFLINE"] = "1"
root = Path(__file__).resolve().parent
sys.path.insert(0, str(root))
os.chdir(root)

import pytest
import tests.conftest as test_config


class CpuVllmRunner(test_config.VllmRunner):
    def __init__(self, *args, **kwargs):
        kwargs.setdefault("kv_cache_memory_bytes", 256 * 1024**2)
        kwargs.setdefault("max_num_seqs", 8)
        kwargs.setdefault("max_num_batched_tokens", 1024)
        kwargs.setdefault("enforce_eager", True)
        super().__init__(*args, **kwargs)


if __name__ == "__main__":
    test_config.VllmRunner = CpuVllmRunner
    raise SystemExit(pytest.main([
        "tests/model_executor/model_loader/tensorizer_loader/"
        "test_tensorizer.py::test_deserialized_hf_model_has_same_outputs",
        "-q",
    ]))
```

</details>

AI assistance: Codex assisted with investigation, implementation, regression-test
design, and local validation.

---
<details>
<summary>Essential elements</summary>

- [x] Purpose and related issue, with the scope stated explicitly.
- [x] Test plan and commands.
- [x] Actual regression and model-output comparison results.
- [x] Documentation impact considered; no public API or configuration is added.

</details>
