### PR TITLE
[Docs] Point XPU spawn force at platforms/xpu.py

### DIFF
--- a/docs/design/multiprocessing.md
+++ b/docs/design/multiprocessing.md
@@ -67,9 +67,10 @@ If the main process is controlled via the `vllm` command,
 
 - <https://github.com/vllm-project/vllm/blob/d05f88679bedd73939251a17c3d785a354b2946c/vllm/scripts.py#L123-L140>
 
-The `multiproc_xpu_executor` forces the use of `spawn`.
+The XPU platform forces the use of `spawn` when
+`VLLM_WORKER_MULTIPROC_METHOD` is unset.
 
-- <https://github.com/vllm-project/vllm/blob/d05f88679bedd73939251a17c3d785a354b2946c/vllm/executor/multiproc_xpu_executor.py#L14-L18>
+- <https://github.com/vllm-project/vllm/blob/fd4a1512628ad17944095263c1fe89598710a3ce/vllm/platforms/xpu.py#L372-L374>
 
 There are other miscellaneous places hard-coding the use of `spawn`:
 


### PR DESCRIPTION
## Summary
- `docs/design/multiprocessing.md` still pointed at deleted `vllm/executor/multiproc_xpu_executor.py` for the XPU `spawn` force.
- That path 404s on current `main`; XPU now sets `VLLM_WORKER_MULTIPROC_METHOD=spawn` in `vllm/platforms/xpu.py` when unset.
- Update the prose and link to the live platform hook (`#L372-L374`).

## Repro
```bash
# deleted executor (404)
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/fd4a1512628ad17944095263c1fe89598710a3ce/vllm/executor/multiproc_xpu_executor.py | head -1
# live XPU spawn force (200)
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/fd4a1512628ad17944095263c1fe89598710a3ce/vllm/platforms/xpu.py | head -1
# snippet
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/fd4a1512628ad17944095263c1fe89598710a3ce/vllm/platforms/xpu.py | sed -n '372,374p'
```

Signed-off-by: ADou <ikun3.1415927@gmail.com>