### PR TITLE
fix: handle multiple KV groups in _update_requests_with_invalid_blocks (HMA/hybrid models)

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2991,8 +2991,16 @@ class Scheduler(SchedulerInterface):
             is_affected = False
             marked_invalid_block = False
             req_id = request.request_id
-            # TODO (davidb): add support for hybrid memory allocator
-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            # get_block_ids() returns a tuple of lists, one per KV cache group.
+            # For hybrid (HMA / attention + Mamba/GDN) models there are multiple
+            # groups, so a single-value unpack `(req_block_ids,) =` raises
+            # "too many values to unpack" -> EngineDeadError. Flatten all groups
+            # so the invalid-block scan covers every KV space.
+            req_block_ids = [
+                bid
+                for grp_block_ids in self.kv_cache_manager.get_block_ids(req_id)
+                for bid in grp_block_ids
+            ]
             # We iterate only over blocks that may contain externally computed
             # tokens
             req_num_computed_tokens = (


### PR DESCRIPTION
# [Bugfix] Fix `_update_requests_with_invalid_blocks` crash on hybrid (HMA) models

## Title (suggested)
`Fix single-value unpack of get_block_ids() in _update_requests_with_invalid_blocks for hybrid models`

## Summary
`Scheduler._update_requests_with_invalid_blocks` does
`(req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)` which
single-unpacks the return value. `get_block_ids()` returns a
`tuple[list[int], ...]` with **one list per KV cache group**. For hybrid
models (attention + Mamba/GDN, enabled via the hybrid KV cache manager),
there are multiple groups (attention KV + conv state + SSM state), so the
single-value unpack raises `ValueError: too many values to unpack (expected 1)`,
propagating to `EngineDeadError` and killing the whole engine.

This triggers specifically when a request's KV cache blocks are invalidated
(e.g. on KV-connector reload / eviction) — the exact path hit by
`KVConnector`-based PD disaggregation with the Mooncake store on hybrid models.

## Root cause
`scheduler.py` (line ~2873 in v0.28, line ~2995 on main):

```python
# TODO (davidb): add support for hybrid memory allocator
(req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
```

`KVCacheManager.get_block_ids()` (kv_cache_manager.py:710):

```python
def get_block_ids(self, request_id: str) -> tuple[list[int], ...]:
    """Get the block ids of a request."""
    return self.get_blocks(request_id).get_block_ids()
```

The function returns multiple block-id lists for hybrid models. The rest of
`_update_requests_with_invalid_blocks` only uses `req_block_ids` as a flat
sequence (`zip(range(...), req_block_ids)` and `req_block_ids[idx:]`), so it
needs the groups flattened.

## Fix
Flatten all groups into one list of block IDs:

```python
req_block_ids = [
    bid
    for grp_block_ids in self.kv_cache_manager.get_block_ids(req_id)
    for bid in grp_block_ids
]
```

Downstream scan logic is unchanged and now correctly covers every KV space.

## Repro
- Model: hybrid architecture (attention + Mamba1/GDN), HMA enabled.
- Engine: vLLM serving with `--kv-transfer-config` using a `MooncakeStoreConnector`
  (or any connector that triggers block invalidation / reload).
- Steps: send a large prompt (e.g. 150k tokens) so it is prefilled and written
  to the store; fill the GPU KV pool until that prompt's blocks are LRU-evicted;
  re-request the same prompt so it reloads from the store.
- Observed before fix:
  ```
  ERROR [core.py:1348] ValueError: too many values to unpack (expected 1)
  ERROR [async_llm.py:744] EngineDeadError: EngineCore encountered an issue.
  ```
- Observed after fix: reload of ~5.2 GB prefix completes; no crash.

## Testing
- `python -m py_compile` passes.
- Local logic test: multi-group `get_block_ids()` flattens correctly; invalid
  block in a non-attention group is detected and the downstream eviction slice
  is correct.
- End-to-end: served a hybrid model with a Mooncake store connector, ran a
  concurrent workload that forced GPU eviction + store reload (~5.2 GB); engine
  stays alive, 0 crashes.