### PR TITLE
[Bugfix] Set stop_sequence explicitly in streaming message_delta event

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -1610,6 +1610,32 @@ class TestStopSequenceReason:
         assert msg_deltas[0]["delta"]["stop_reason"] == "stop_sequence"
         assert msg_deltas[0]["delta"]["stop_sequence"] == "</tool>"
 
+    @pytest.mark.asyncio
+    async def test_streaming_no_stop_string_emits_explicit_null_stop_sequence(self):
+        """exclude_unset=True drops stop_sequence unless it is set explicitly."""
+
+        async def sse_input():
+            yield _make_stream_chunk(delta=DeltaMessage(role="assistant"))
+            yield _make_stream_chunk(delta=DeltaMessage(content="hi"))
+            yield _make_stream_chunk(finish_reason="stop")
+            yield _make_stream_chunk(
+                choices=[],
+                usage=UsageInfo(prompt_tokens=5, total_tokens=8, completion_tokens=3),
+            )
+            yield "data: [DONE]"
+
+        converter = _make_stream_converter()
+        output = []
+        async for event in converter.message_stream_converter(sse_input()):
+            output.append(event)
+
+        events = _parse_sse_events(output)
+        msg_deltas = [data for ev_type, data in events if ev_type == "message_delta"]
+        assert len(msg_deltas) == 1
+        assert msg_deltas[0]["delta"]["stop_reason"] == "end_turn"
+        assert "stop_sequence" in msg_deltas[0]["delta"]
+        assert msg_deltas[0]["delta"]["stop_sequence"] is None
+
 
 # ======================================================================
 # Client-caused errors are 4xx, not 500 (Issue #52088)

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -842,7 +842,9 @@ class AnthropicServingMessages(OpenAIServingChat):
                                 stop_delta = AnthropicDelta(
                                     stop_reason=self.stop_reason_map.get(
                                         finish_reason or "stop"
-                                    )
+                                    ),
+                                    # Set explicitly so exclude_unset=True keeps it.
+                                    stop_sequence=None,
                                 )
                             chunk = AnthropicStreamEvent(
                                 type="message_delta",


### PR DESCRIPTION
## Purpose

Fix #55324: the `/v1/messages` streaming path builds the terminal `message_delta` event
without setting `stop_sequence` on the non-stop-sequence branch, then serializes it with
`model_dump_json(exclude_unset=True)`. Since `AnthropicDelta` declares
`stop_sequence: str | None = None`, the unset field is dropped from the wire. The field is
present on the object and absent only after serialization. Anthropic's schema lists
`stop_sequence` as a required, nullable member of `MessageDelta`, so a schema-validating proxy
rejects the stream one event from the end, after the full answer was delivered.

- Affects `end_turn`, `max_tokens` and `tool_use`: all three flow through the same `else`
  branch via `stop_reason_map`. The `isinstance(stop_sequence, str)` branch already sets the
  field and is untouched.
- `message_start` already sets `stop_sequence=None` explicitly in its constructor. #45376 applied the same explicit-set treatment to
  `message_start`'s `type`/`role` for the same `exclude_unset` reason (#45367).
- #45807 (merged 2026-08-20) rewrote this block to report a matched stop string correctly and
  left the `else` branch without the field; this sets it.
- The `message_delta` block is the only emission site. On server streams the converter forces
  `stream_options.include_usage`, so the trailing usage chunk that triggers it is present.

Fix: set `stop_sequence=None` explicitly in the `else` branch so `exclude_unset=True` keeps it.

## Test Plan

New case `TestStopSequenceReason.test_streaming_no_stop_string_emits_explicit_null_stop_sequence`,
beside the existing streaming stop-string test, asserting the terminal `message_delta` carries
`stop_reason == "end_turn"` and an explicit `stop_sequence: null`.

```
# with fix
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q

# fix reverted, new test kept
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q
```

Model-level repro (no GPU or model needed) and the raw SSE captures are in the issue.

pre-commit (ruff check/format, typos, mypy-3.12 manual stage) passes on both changed files.

## Test Result

```
# with fix
62 passed, 15 warnings in 12.38s

# fix reverted, new test kept
1 failed, 61 passed, 15 warnings in 12.54s
```

Model-level before/after on 0.26.0:

```
BEFORE: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":60,"output_tokens":37}}
AFTER : {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":60,"output_tokens":37}}
```

No model evaluation: the change adds one already-null field to the streaming envelope and does
not touch model execution, sampling, or token generation.

## Duplicate check

```
$ gh pr list --repo vllm-project/vllm --state open --search "message_delta stop_sequence"
47598  [Bugfix][Frontend] Report named Anthropic tool calls as tool_use

$ gh pr list --repo vllm-project/vllm --state open --search "anthropic stop_sequence in:body"
47598  [Bugfix][Frontend] Report named Anthropic tool calls as tool_use
52896  [Rust Frontend] Add Anthropic Messages API request surface and count_tokens (PR 1/3)
46162  [Bugfix] Forward upstream error message in Anthropic streaming converter (#46028)

$ gh issue list --repo vllm-project/vllm --state open --search "message_delta stop_sequence"
47753  [Rust Frontend][RFC] Anthropic Messages API: /v1/messages and /v1/messages/count_tokens

$ gh issue list --repo vllm-project/vllm --state open --search "stop_sequence anthropic"
48273  [Bug][Anthropic] stop_sequence never populated + unguarded json.loads crash in messages_full_converter

$ gh pr list --repo vllm-project/vllm --state closed --search "stop_sequence anthropic"
45807  fix: report stop_sequence stop_reason in Anthropic Messages API
51556  [Bugfix][Frontend] Report Cohere stop sequences correctly
46344  [Frontend] Fix Kimi K2 tool call IDs for required tool choice
21341  Add anthropic endpoint
```

None address this. #45807 is the closest prior art: it fixed the matched-stop-string case in
this block and left the `else` branch as it was. `message_start` twin: #45367 / #45376.
#48273 (open) covers the matched-stop-string value, delivered by #45807, and malformed
tool-argument JSON (#50997, closed unmerged); neither touches the absent key on the `else` branch.

Post-filing (2026-09-04):

```
$ gh issue view 55324 --repo vllm-project/vllm --comments
(no comments)

$ gh pr list --repo vllm-project/vllm --state open --search "55324 in:body"
(none)
```

## (Optional) Documentation Update

None.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

AI assistance disclosure: this PR was prepared with assistance from a mixture of AI models;
the change and test were reviewed and run
locally by the submitter.
