### PR TITLE
Clarify metadata-only multimodal semantics in token_in_token_out protocol

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_protocol.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_protocol.py
@@ -9,7 +9,11 @@ fail loudly if the validator semantics ever drift.
 
 import json
 
-from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
+    GenerateRequest,
+    MultiModalFeatures,
+    PlaceholderRangeInfo,
+)
 from vllm.sampling_params import SamplingParams
 
 
@@ -68,3 +72,98 @@ def test_internal_instance_construction_treats_all_as_provided():
     assert req.is_sampling_param_provided("temperature")
     # And keys we never touched should also count as provided in this path.
     assert req.is_sampling_param_provided("top_p")
+
+
+# ---------------------------------------------------------------------------
+# Metadata-only payload tests
+# ---------------------------------------------------------------------------
+
+
+def _mm_features(kwargs_data: dict | None = None) -> MultiModalFeatures:
+    return MultiModalFeatures(
+        mm_hashes={"image": ["hash0"]},
+        mm_placeholders={"image": [PlaceholderRangeInfo(offset=0, length=10)]},
+        kwargs_data=kwargs_data,
+    )
+
+
+def _mm_payload(
+    kwargs_data: dict | None = None,
+    kv_transfer_params: dict | None = None,
+    ec_transfer_params: dict | None = None,
+) -> dict:
+    features = _mm_features(kwargs_data)
+    payload = _base_payload()
+    payload["features"] = features.model_dump()
+    if kv_transfer_params is not None:
+        payload["kv_transfer_params"] = kv_transfer_params
+    if ec_transfer_params is not None:
+        payload["ec_transfer_params"] = ec_transfer_params
+    return payload
+
+
+def test_hash_only_decode_with_kv_transfer_params_accepted():
+    """Metadata-only request with kv_transfer_params (remote prefill decode)
+    is legal — embeddings arrive out-of-band via the EC connector."""
+    payload = _mm_payload(
+        kwargs_data=None,
+        kv_transfer_params={"do_remote_prefill": True},
+    )
+    req = GenerateRequest.model_validate(payload)
+    assert req.features.kwargs_data is None
+    assert req.kv_transfer_params == {"do_remote_prefill": True}
+
+
+def test_hash_only_decode_with_ec_transfer_params_accepted():
+    """Metadata-only request with ec_transfer_params is legal — embeddings
+    arrive via the encoder-cache transfer path."""
+    payload = _mm_payload(
+        kwargs_data=None,
+        ec_transfer_params={"hash0": {"metadata": {}}},
+    )
+    req = GenerateRequest.model_validate(payload)
+    assert req.features.kwargs_data is None
+    assert req.ec_transfer_params is not None
+
+
+def test_metadata_only_without_transfer_params_accepted():
+    """Metadata-only request with no transfer params stays valid. Whether
+    it can be served is a runtime cache-residency question resolved by the
+    generate worker — a hit uses the receiver cache, a miss raises
+    MultiModalCacheMissError and the caller retries with data."""
+    payload = _mm_payload(kwargs_data=None)
+    req = GenerateRequest.model_validate(payload)
+    assert req.features.kwargs_data is None
+    assert req.kv_transfer_params is None
+    assert req.ec_transfer_params is None
+
+
+def test_full_payload_with_kwargs_data_accepted_without_transfer_params():
+    """Full payload (kwargs_data present) needs no transfer params — the
+    generate worker has the tensor data inline."""
+    payload = _mm_payload(
+        kwargs_data={"image": ["base64encodeddata"]},
+    )
+    req = GenerateRequest.model_validate(payload)
+    assert req.features.kwargs_data is not None
+    assert req.kv_transfer_params is None
+    assert req.ec_transfer_params is None
+
+
+def test_no_features_accepted_without_transfer_params():
+    """Text-only request (no features) needs no transfer params."""
+    req = GenerateRequest.model_validate(_base_payload())
+    assert req.features is None
+
+
+def test_hash_only_decode_json_roundtrip():
+    """Hash-only decode request survives JSON serialization roundtrip."""
+    payload = _mm_payload(
+        kwargs_data=None,
+        kv_transfer_params={"do_remote_prefill": True, "remote_engine_id": 42},
+    )
+    json_str = json.dumps(payload)
+    req = GenerateRequest.model_validate_json(json_str)
+    assert req.features.kwargs_data is None
+    assert req.features.mm_hashes == {"image": ["hash0"]}
+    assert req.kv_transfer_params["remote_engine_id"] == 42

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -48,8 +48,17 @@ class MultiModalFeatures(BaseModel):
     """Lightweight multimodal metadata produced by the render step.
 
     Carries hashes (for cache lookup / identification) and placeholder
-    positions so the downstream `/generate` service knows *where* in
+    positions so the downstream ``/generate`` service knows *where* in
     the token sequence each multimodal item lives.
+
+    ``kwargs_data`` is optional.  When it is ``None`` the request is
+    metadata-only and items are resolved by hash at generate time — from
+    the receiver's multimodal cache on a hit, or via out-of-band
+    transfer (``kv_transfer_params`` / ``ec_transfer_params``) in
+    disaggregated-prefill deployments.  Whether a metadata-only request
+    can be served is a runtime property (cache residency), not something
+    the protocol layer can know or enforce; a cache miss raises
+    ``MultiModalCacheMissError`` and the caller retries with full data.
     """
 
     mm_hashes: dict[str, list[str]]


### PR DESCRIPTION
## Motivation

`token_in_token_out` `GenerateRequest` accepts metadata-only multimodal requests (`features.kwargs_data is None`). These are resolved by hash at generate time — from the receiver's multimodal cache on a hit, or out-of-band via `kv_transfer_params` / `ec_transfer_params` in disaggregated-prefill deployments. A cache miss already raises the retryable `MultiModalCacheMissError`, which the engine handles by invalidating stale entries and asking the client to resend with data.

Whether a metadata-only request can be served is **runtime cache state that the request payload does not carry**, so the protocol layer cannot distinguish a request that will hit the local cache from one that will miss. Rejecting metadata-only requests merely for lacking transfer parameters would break the supported local cache-hit path (#55332 proposed exactly that rejection; the premise does not hold).

## Changes

- Rewrite the `MultiModalFeatures` docstring to state the metadata-only contract: `kwargs_data=None` items are resolved by hash at generate time via the receiver cache or out-of-band transfer; cache residency is runtime state and is not validated at the protocol layer.
- Add unit tests asserting metadata-only payloads validate with or without transfer params, guarding against reintroducing a protocol-level rejection.

This PR intentionally makes **no behavioral change** — the previous draft validator was removed after review (see CodeRabbit finding: it rejects the supported local-cache path, since cache residency is not represented in the request).

## Test Commands

```bash
.venv/bin/python -m pytest tests/entrypoints/scale_out/token_in_token_out/test_protocol.py -v
```

Expected: 11/11 PASSED (5 existing + 6 new). Result to be confirmed by the submitting human in a full environment; `ruff check` and `ruff format --check` pass on both changed files.

## AI Assistance

This PR was developed with AI assistance. The submitting human has reviewed every changed line.
