### PR TITLE
[Bugfix][Quantization] Load the FP8 PLE n-gram table under a ModelOpt NVFP4 checkpoint

### DIFF
--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -16,6 +16,7 @@ import vllm.model_executor.parameter as parameter_module
 from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMixedPrecisionConfig,
+    ModelOptNvFp4Config,
 )
 from vllm.models.qwen4_exp.common.ple import (
     PLEShardOverlap,
@@ -318,6 +319,55 @@ def test_ple_fp8_embedding_supports_mixed_precision_config() -> None:
             quant_config,
             "model.language_model.layers.2.moe.gate_proj",
         )
+        is None
+    )
+
+
+def _nvfp4_config(exclude_modules: list[str]) -> ModelOptNvFp4Config:
+    """Mirrors ``config.json``'s ``quantization_config`` in NVFP4 checkpoints."""
+    return ModelOptNvFp4Config.from_config(
+        {
+            "quant_algo": "NVFP4",
+            "quant_method": "modelopt",
+            "ignore": exclude_modules,
+            "group_size": 16,
+        }
+    )
+
+
+def test_ple_fp8_embedding_loads_under_nvfp4_checkpoint() -> None:
+    """An NVFP4 body keeps the FP8 PLE table's global scale (see #54765)."""
+    prefix = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding"
+    quant_config = _nvfp4_config(["*.ple.*"])
+
+    assert isinstance(
+        _get_ple_embedding_quant_method(quant_config, prefix, "float8_e4m3fn"),
+        Qwen4ExpPLEFp8EmbeddingMethod,
+    )
+    assert isinstance(
+        _get_ple_embedding_quant_method(quant_config, prefix, torch.float8_e4m3fn),
+        Qwen4ExpPLEFp8EmbeddingMethod,
+    )
+
+
+@pytest.mark.parametrize(
+    "exclude_modules,ple_embedding_dtype",
+    [
+        # The table is excluded but stored unquantized.
+        (["*.ple.*"], None),
+        (["*.ple.*"], "bfloat16"),
+        # The table is not excluded, so NVFP4 shards are expected.
+        ([], "float8_e4m3fn"),
+    ],
+)
+def test_ple_fp8_embedding_skipped_for_non_fp8_nvfp4_tables(
+    exclude_modules: list[str], ple_embedding_dtype: object
+) -> None:
+    prefix = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding"
+    quant_config = _nvfp4_config(exclude_modules)
+
+    assert (
+        _get_ple_embedding_quant_method(quant_config, prefix, ple_embedding_dtype)
         is None
     )
 

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMixedPrecisionConfig,
+    ModelOptNvFp4Config,
 )
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     create_fp8_scale_parameter,
@@ -130,9 +131,20 @@ class Qwen4ExpPLEFp8EmbeddingMethod(QuantizeMethodBase):
         return F.embedding(input_, layer.weight)
 
 
+def _ple_checkpoint_is_fp8(ple_embedding_dtype: object) -> bool:
+    """Whether ``ple_embedding_dtype`` declares FP8 PLE shards."""
+
+    if isinstance(ple_embedding_dtype, str):
+        ple_embedding_dtype = getattr(
+            torch, ple_embedding_dtype.rsplit(".", 1)[-1], None
+        )
+    return isinstance(ple_embedding_dtype, torch.dtype) and is_fp8(ple_embedding_dtype)
+
+
 def _get_ple_embedding_quant_method(
     quant_config: QuantizationConfig | None,
     prefix: str,
+    ple_embedding_dtype: object = None,
 ) -> QuantizeMethodBase | None:
     """Select global-scale FP8 only for quantized PLE checkpoint shards."""
 
@@ -140,6 +152,15 @@ def _get_ple_embedding_quant_method(
         if quant_config._resolve_quant_algo(prefix) == "FP8":
             return Qwen4ExpPLEFp8EmbeddingMethod()
         return None
+
+    if isinstance(quant_config, ModelOptNvFp4Config):
+        # NVFP4 checkpoints exclude the PLE table and store it as FP8 shards
+        # with one global scale, which ``ple_embedding_dtype`` records.
+        if not quant_config.is_layer_excluded(prefix):
+            return None
+        if not _ple_checkpoint_is_fp8(ple_embedding_dtype):
+            return None
+        return Qwen4ExpPLEFp8EmbeddingMethod()
 
     if not isinstance(quant_config, Fp8Config):
         return None
@@ -326,7 +347,9 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             padding_size=divisor,
             prefix=f"{prefix}.ngram_embedding",
             quant_method=_get_ple_embedding_quant_method(
-                quant_config, f"{prefix}.ngram_embedding"
+                quant_config,
+                f"{prefix}.ngram_embedding",
+                getattr(config, "ple_embedding_dtype", None),
             ),
         )
 


### PR DESCRIPTION
## Purpose

Fixes #54765.

ModelOpt NVFP4 checkpoints of Qwen3.8-Flash-Next exclude `*.ple.*` from NVFP4 and ship the 51.2B-parameter n-gram table separately as FP8 shards with one global scale. That is exactly the layout `Qwen4ExpPLEFp8EmbeddingMethod` implements, but `_get_ple_embedding_quant_method` only selects it for `Fp8Config` or `ModelOptMixedPrecisionConfig`. Under a plain `ModelOptNvFp4Config` the unquantized embedding is built, no `weight_scale` parameter is registered, and loading fails:

```
ValueError: There is no module or parameter named 'ngram_embedding.weight_scale' in
Qwen4ExpNGramEmbedding. The available parameters belonging to ngram_embedding
(PLEVocabParallelEmbedding) are: {'ngram_embedding.weight'}
```

\#54882 fixed this for `quant_algo: MIXED_PRECISION`. Checkpoints that declare `quant_algo: NVFP4` still fail, which is the layout of the most widely used NVFP4 build of this model.

## Fix

Select the FP8 embedding method under `ModelOptNvFp4Config` when both hold:

1. the PLE layer is excluded from NVFP4 (`is_layer_excluded`), and
2. the config declares the table as FP8 via `ple_embedding_dtype`.

Requiring both means a checkpoint that excludes the PLE but keeps it in bf16 still takes the unquantized path. `ple_embedding_dtype` is the same signal #53899 uses for this.

## Validation

Unit level, plus checkpoint metadata inspection. I did not run a full serving load of a 135 GB checkpoint.

```
pytest tests/models/qwen4_exp/test_ple.py -k ple_fp8_embedding -v   # 9 passed
pytest tests/models/qwen4_exp/test_ple.py                           # 14 passed, 23 skipped
pre-commit run --files <changed files>                              # all hooks passed
```

Run inside `vllm/vllm-openai:nightly-8a728663c1` (`0.28.1rc1.dev388+g8a728663c`) on both an sm_121 and an sm_120 host, unpatched then patched. The new tests fail against the unpatched selector and pass with the fix; the five pre-existing PLE tests pass in both.

Note on the red-before-green: the unpatched failures are `TypeError` from the added parameter, not assertion failures. `test_ple_fp8_embedding_loads_under_nvfp4_checkpoint` is the one that encodes the bug, since the unpatched selector returns `None` for this checkpoint. The three `skipped_for_non_fp8` cases assert behaviour the unpatched code also has, so they are regression guards rather than proof of the fix.

Table dtypes read from the safetensors headers of published checkpoints:

| checkpoint | `ple_embedding_dtype` | table on disk |
|---|---|---|
| `RadixArk/Qwen3.8-Flash-Next-NVFP4` | `float8_e4m3fn` | F8_E4M3 + `weight_scale` |
| `dealignai/Qwen3.8-Flash-Next-ABLITERATED-NVFP4` | `float8_e4m3fn` | F8_E4M3 + `weight_scale` |
| `Inferact/Qwen3.8-Flash-Next-NVFP4`, `nota-ai/Qwen3.8-Flash-Next-Nota-NVFP4` | absent | BF16 |

## Note on `ple_embedding_dtype`

`primitive-ai/Qwen3.8-Flash-Next-NVFP4` and `primitive-ai/Qwen3.8-Flash-Next-mixed-NVFP4-FP8` declare `ple_embedding_dtype: float8_e4m3fn` but ship bf16 tables with no `weight_scale`. They load today and would fail at startup after this change, with the clear scale-sentinel error added in #54722. I think the config is wrong rather than the gate, but flagging it since it is a visible behaviour change for those two repos. Happy to key on something else if a maintainer prefers.

## Why this is not a duplicate

I ran the checks in AGENTS.md. No open PR references #54765. The same selector is touched by the PLE offload PRs (#53899, #54371, #54070, #54129), which are large unmerged features; this is the standalone load fix and does not conflict with the direction they take.

## Model evaluation

Not applicable. Affected checkpoints currently fail to load, so there is no baseline to regress against. The change only decides which method reads an embedding table that the checkpoint already stores in FP8; unaffected checkpoints keep their existing path, which the second test pins.

## AI assistance

AI assistance was used to author this change. I have reviewed every changed line, ran the tests and linters above myself, and can defend the design.
