### PR TITLE
[Bugfix][Spec Decode] Honour the draft's load_config on Model Runner V2

### DIFF
--- a/tests/v1/spec_decode/test_draft_load_config.py
+++ b/tests/v1/spec_decode/test_draft_load_config.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The draft must load with ``draft_load_config`` from --speculative-config.
+
+``get_model`` resolves ``load_config=None`` to the target's, so these assert on
+the value ``load_eagle_model`` hands it rather than on the loaded model.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
+
+
+@dataclass
+class _CacheConfig:
+    cache_dtype: str = "auto"
+
+
+@dataclass
+class _SpeculativeConfig:
+    draft_load_config: object = None
+    kv_cache_dtype: str | None = None
+    draft_model_config: object = None
+
+
+@dataclass
+class _VllmConfig:
+    cache_config: _CacheConfig
+    speculative_config: _SpeculativeConfig
+
+
+class _Captured(Exception):
+    def __init__(self, load_config):
+        self.load_config = load_config
+
+
+def _capture_draft_load_config(draft_load_config: object) -> object:
+    cfg = _VllmConfig(
+        cache_config=_CacheConfig(),
+        speculative_config=_SpeculativeConfig(draft_load_config=draft_load_config),
+    )
+
+    def _fake_get_model(*, vllm_config, model_config, load_config=None):
+        raise _Captured(load_config)
+
+    with (
+        patch("vllm.v1.worker.gpu.spec_decode.eagle.utils.get_model", _fake_get_model),
+        pytest.raises(_Captured) as exc,
+    ):
+        load_eagle_model(object(), cfg)
+    return exc.value.load_config
+
+
+def test_draft_load_config_reaches_the_loader() -> None:
+    sentinel = object()
+    assert _capture_draft_load_config(sentinel) is sentinel
+
+
+def test_unset_draft_load_config_defers_to_the_target() -> None:
+    assert _capture_draft_load_config(None) is None

--- a/tests/v1/spec_decode/test_draft_load_config.py
+++ b/tests/v1/spec_decode/test_draft_load_config.py
@@ -21,6 +21,7 @@ class _CacheConfig:
 
 @dataclass
 class _SpeculativeConfig:
+    attention_backend: str | None = None
     draft_load_config: object = None
     kv_cache_dtype: str | None = None
     draft_model_config: object = None

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -49,7 +49,9 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
         )
     with set_model_tag("eagle_head"):
         eagle_model = get_model(
-            vllm_config=vllm_config, model_config=draft_model_config
+            vllm_config=vllm_config,
+            model_config=draft_model_config,
+            load_config=speculative_config.draft_load_config,
         )
 
     target_language_model = (


### PR DESCRIPTION
## Purpose

`load_eagle_model()` builds the draft with `get_model()` but never passes `load_config`:

```python
eagle_model = get_model(vllm_config=vllm_config, model_config=draft_model_config)
```

`get_model()` resolves that to `load_config or vllm_config.load_config`, so the draft silently inherits the **target's** load config and `SpeculativeConfig.draft_load_config` ("Load config for the draft model. If not specified, will use the load config from the target model", `vllm/config/speculative.py`) has no effect on Model Runner V2.

V1 passes it in `LLMBaseProposer._get_model()`, and V2's own Gemma4 speculator passes it in `vllm/v1/worker/gpu/spec_decode/gemma4/speculator.py`, so the eagle path is the outlier rather than a deliberate choice.

## Fix

Forward `speculative_config.draft_load_config`. It defaults to `None`, which `get_model()` already resolves to the target's load config, so nothing changes when it is unset.

## Validation

```
pytest tests/v1/spec_decode/test_draft_load_config.py -v   # 2 passed
pre-commit run --files <changed files>                     # all hooks passed
```

Run inside `vllm/vllm-openai:nightly-8a728663c1` (`0.28.1rc1.dev388+g8a728663c`), unpatched then patched against the same installed package. Without the fix the first test fails with the bug's signature:

```
assert None is <object object at 0xfbde13c30f70>
 +  where None = _capture_draft_load_config(<object object at 0xfbde13c30f70>)
```

The second test pins the unset case so the fallback to the target's load config stays intact.

## Why this is not a duplicate

I ran the checks in AGENTS.md. Nothing open touches `draft_load_config` on the V2 path. #54788 and #54826 also edit `load_eagle_model` for `moe_backend` and `attention_backend` respectively; this is a third, independent field and the three will need a trivial rebase against each other depending on merge order.

## Model evaluation

Not applicable. The draft's load config selects how its weights are read (load format, download dir), not what they are. With `draft_load_config` unset, which is the default, behaviour is byte-identical, and that case is pinned by the second test.

## AI assistance

AI assistance was used to author this change. I have reviewed every changed line, ran the tests and linters above myself, and can defend the design.
