### PR TITLE
[Doc] Add gemma-4-E4B-it to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -129,6 +129,7 @@ Batch invariance has been tested and verified on the following models:
 - **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
+- **Gemma-4**: `google/gemma-4-E4B-it` (TRITON_ATTN)
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
 - **Phi series**: `microsoft/Phi-3.5-mini-instruct`
 - **Granite 3.1 (MoE)**: `ibm-granite/granite-3.1-1b-a400m-instruct`, `ibm-granite/granite-3.1-3b-a800m-instruct`


### PR DESCRIPTION
## purpose

add `google/gemma-4-E4B-it` with a `TRITON_ATTN` qualifier to the batch-invariance tested-model list. related: #27433.

## overlap check

on september 12, searches for the exact model and gemma batch-invariance prs found no competing E4B tested-model row; current main had no gemma entry. this is scoped to those searches.

## validation, september 12

reran the canonical v0.28.0 triton selection on one a100 80gb, bf16, tp1. all six cases passed in each mode, **12/12, no failures or skips**. this includes the needle cases missing from the earlier a10 validation.

| canonical case | compiled | eager |
| --- | --- | --- |
| needle, default norm | 5/5 trials | 5/5 trials |
| needle, vllm_c norm | 5/5 trials | 5/5 trials |
| core [16-16] | passed | passed |
| core [8-16] | passed | passed |
| simple generation | passed | passed |
| batch-invariance-off control | passed | passed |

source: `2cf0a6915ce544dc493a0990f2ea38d81601128a`. vllm 0.28.0 release wheel, python 3.12.14, torch 2.13.0+cu130, driver 580.126.09. model revision: `ee0ef6023621cff504d758262d4e04895a5af4a2`. model/config/tokenizer fingerprints and installed vllm files were checked against publisher records, then checked unchanged after the run.

canonical prompts, assertions and seeds were retained. the existing needle memory override was `VLLM_GPU_MEMORY_UTILIZATION=0.9`; five trials, batch limit 128, max model length 5120 and max output 128 stayed at their defaults. each node ran in a fresh process, with automatic flaky reruns disabled. a separate audit plugin applied `enforce_eager` to every constructor, including the needle helper, and checked the actual engine configuration. compiled was `VLLM_COMPILE` / `FULL_AND_PIECEWISE`; eager was `NONE` / `NONE`.

the first attempt failed during flashinfer sampler initialization because the image lacked nvcc. after installing the missing build tools and compiling the same sampler successfully, the completed matrix above passed. that failed attempt is retained separately; there was no sampler fallback or assertion change.

the controls pass by detecting differences with batch invariance disabled. the core test compares generated token ids and their fp32 logprobs for 32 short prompts run individually and together. needle compares output text across mixed batches. this is scoped to those triton tests on this configuration, not full-vocabulary logits, answer quality, other backends or equality between compiled and eager outputs. the two core parameter labels do not imply different triton kernels.

## current reproduction and evidence

[validation logs, exact runner and audit plugin](https://gist.github.com/ptimizeroracle/b1bfe6d3c3102f4f61b6349a669dbbca). the runner stages the [canonical tests at the pinned source commit](https://github.com/vllm-project/vllm/blob/2cf0a6915ce544dc493a0990f2ea38d81601128a/tests/v1/determinism/test_batch_invariance.py), selects each of the six triton nodes separately and runs both modes. the linked evidence includes each command, result and actual mode.

with the documented runtime and local snapshot prepared:

```sh
export CUDA_HOME=/usr/local/cuda-13.0
export CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12
export PATH="/home/ubuntu/gemma-55343/source/.venv/bin:$CUDA_HOME/bin:/home/ubuntu/.local/bin:$PATH"
timeout 3380 bash run.sh \
  /home/ubuntu/gemma-55343/source \
  /home/ubuntu/gemma-55343/model/snapshots/ee0ef6023621cff504d758262d4e04895a5af4a2 \
  ee0ef6023621cff504d758262d4e04895a5af4a2 \
  /home/ubuntu/gemma-55343/evidence/new-run
```

<details>
<summary>earlier a10 results and correction</summary>

### september 4 a10 record

one a10, bf16, tp1, vllm 0.28.0 and python 3.10.12. the model was loaded with `revision=main`; an immutable checkpoint revision was not preserved in this archive.

the harness ran one full-suite attempt and two additional core-test attempts per mode. the successful cases cover suite-default execution and `enforce_eager=True`. the eager adaptation missed the helper used by the needle tests, so the blocked needle attempts do not establish eager coverage.

original selection:

```sh
VLLM_TEST_MODEL=google/gemma-4-E4B-it pytest \
  tests/v1/determinism/test_batch_invariance.py -v --tb=short
```

the two additional attempts per mode used `-k bitwise`. separate checkouts supplied the default and eager adaptations; this command alone does not select eager execution.

| result | suite defaults | eager adaptation |
| --- | --- | --- |
| full-suite attempt, all selected backends | 4 passed, 15 failed | 4 passed, 15 failed |
| each of two additional core attempts, all selected backends | 2 passed, 4 failed | 2 passed, 4 failed |
| each triton core parameter variant, including the full attempt | 3/3 passed | 3/3 passed |
| triton simple generation | passed | passed |
| triton batch-invariance-off negative control | passed | passed |

both triton core variants compare generated token ids and the generated tokens' fp32 logprob values for 32 short random prompts run individually and together, with up to 16 generated tokens. they do not compare full-vocabulary logits. repeats used the same fixed test seed.

### historical failures

flash attention and flex attention failed during initialization: unsupported head size and unsupported kv sharing, respectively. the triton needle tests also failed during cache initialization, before their invariance assertions ran.

the needle configuration reserved 50% of gpu memory, with `max_model_len=5120` and `max_num_seqs=128`. this failure does not establish that a10 capacity is insufficient. the september 12 run above retains those canonical prompts and assertions, uses the existing memory override and verifies the actual execution mode for every engine.

no invariance assertion failed in the cases that reached it. that september 4 record did not establish a fully passing suite or successful needle coverage. historical logs record pytest outcomes; exact checkpoint identity and successful per-token outputs were not retained.

### correction to the previous description

“full-suite pass” should have read “full-suite attempt”. each mode had three core executions in total, including the full attempt. the successful core test was not the separate needle test. the previous statement that the needle test required more than 24 gb was unsupported.


</details>

## ai assistance

i led this validation and used openai codex for test setup, gpu test execution, log analysis, evidence review and help drafting this description. this pr changes documentation only.
