### PR TITLE
[Bugfix][ROCm] Keep the AITER allreduce compile range within AITER's runtime cutoff

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1593,6 +1593,12 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
         hidden_dim = config.model_config.get_hidden_size()
         element_size = torch.tensor([], dtype=self.model_dtype).element_size()
         max_size = ca_comm.effective_max_size()
+        if max_size is None:
+            logger.warning_once(
+                "AITER allreduce-rmsnorm fusion disabled: custom all-reduce is "
+                "turned off via AITER_CUSTOM_AR_MAX_SIZE=0."
+            )
+            return
         _AITER_OLD_FUSED_AR_RMS_HIDDEN = (512, 1024, 2048, 4096)
         if (
             not ca_comm.supports_dynamic_hidden_dim

--- a/vllm/distributed/device_communicators/aiter_custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/aiter_custom_all_reduce.py
@@ -22,10 +22,30 @@ class AiterCustomAllreduce:
 
     @classmethod
     def effective_max_size(cls) -> int:
+        """Max input byte size eligible for AITER custom allreduce.
+
+        This has to agree with what AITER accepts at runtime, which is
+        ``min(_car_max_size, max_size / 2)``. ``_car_max_size`` comes from
+        ``AITER_CUSTOM_AR_MAX_SIZE`` and defaults to 64 MiB independently of
+        the registered pool, so the two can disagree.
+
+        The compile range of the fused allreduce+RMSNorm pass is derived from
+        this value. If it exceeds what ``should_custom_ar()`` will accept, the
+        pass gets compiled for message sizes AITER rejects,
+        ``custom_fused_ar_rms()`` returns ``None``, and
+        ``_rocm_aiter_fused_allreduce_rmsnorm_impl`` asserts on it -- the
+        server fails to start instead of falling back to RCCL.
         """
-        Max input byte size eligible for AITER custom allreduce.
-        """
-        return cls.MAX_SIZE // 2
+        two_shot_limit = cls.MAX_SIZE // 2
+        try:
+            # Private, but it is the only place the env var semantics live;
+            # duplicating them here would be the more fragile option.
+            from aiter.dist.device_communicators.custom_all_reduce import (
+                _resolve_car_max_size,
+            )
+        except ImportError:
+            return two_shot_limit
+        return min(two_shot_limit, _resolve_car_max_size(cls.MAX_SIZE))
 
     def __init__(
         self,

--- a/vllm/distributed/device_communicators/aiter_custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/aiter_custom_all_reduce.py
@@ -21,8 +21,12 @@ class AiterCustomAllreduce:
     MAX_SIZE: int = 8192 * 1024 * 8 * 2
 
     @classmethod
-    def effective_max_size(cls) -> int:
+    def effective_max_size(cls) -> int | None:
         """Max input byte size eligible for AITER custom allreduce.
+
+        Returns ``None`` when custom AR is disabled entirely
+        (``AITER_CUSTOM_AR_MAX_SIZE=0``), so callers skip the fusion instead of
+        building a zero-length compile range.
 
         This has to agree with what AITER accepts at runtime, which is
         ``min(_car_max_size, max_size / 2)``. ``_car_max_size`` comes from
@@ -45,7 +49,11 @@ class AiterCustomAllreduce:
             )
         except ImportError:
             return two_shot_limit
-        return min(two_shot_limit, _resolve_car_max_size(cls.MAX_SIZE))
+        car_max_size = _resolve_car_max_size(cls.MAX_SIZE)
+        if car_max_size <= 0:
+            # AITER_CUSTOM_AR_MAX_SIZE=0 turns custom AR off for every size.
+            return None
+        return min(two_shot_limit, car_max_size)
 
     def __init__(
         self,


### PR DESCRIPTION
## Purpose

Fixes #55344.

`vllm/config/vllm.py` derives the compile range of the fused allreduce+RMSNorm
pass from `AiterCustomAllreduce.effective_max_size()`, which only looks at
`MAX_SIZE`. AITER's runtime eligibility check is `min(_car_max_size, max_size /
2)`, where `_car_max_size` comes from `AITER_CUSTOM_AR_MAX_SIZE` and defaults to
a fixed 64 MiB that does not grow with the registered pool.

When the two disagree, the pass is compiled for message sizes AITER rejects.
`custom_fused_ar_rms()` then returns `None`, and
`_rocm_aiter_fused_allreduce_rmsnorm_impl` asserts on it — the server fails to
start with a bare `AssertionError` instead of falling back to RCCL. An env var
meant to *narrow* custom-AR usage should not prevent startup.

This makes `effective_max_size()` return what AITER will actually accept, so the
pass is never compiled for sizes that get rejected.

## Test Plan

MI355X (gfx950), TP4, GLM-5.3 (`hidden_size=6144`, bf16),
`--max-num-batched-tokens 8192`, AITER custom AR and `fuse_allreduce_rms`
enabled. Same image, same model, same flags in both runs — only the env var and
this patch differ:

```
AITER_CUSTOM_AR_MAX_SIZE=1048576 vllm serve <model> -tp 4 --max-num-batched-tokens 8192
```

## Test Result

Before (unmodified tree):

```
compile_ranges_endpoints: [5461, 8192]
ERROR _aiter_ops.py:956 in _rocm_aiter_fused_allreduce_rmsnorm_impl
      assert result is not None
AssertionError
RuntimeError: Engine core initialization failed.
-> died after 160 s
```

After:

```
compile_ranges_endpoints: [85, 8192]      # 1 MiB / (6144 * 2) = 85 tokens
-> serving after 340 s, zero AssertionErrors
GSM8K 49/50 = 98.0 %
```

The range now matches the cutoff exactly, which is the intended behavior: with a
1 MiB cutoff the fusion is simply out of scope for realistic batch sizes, and
those fall back to RCCL as they should.

No change with the default (`AITER_CUSTOM_AR_MAX_SIZE` unset): `min(MAX_SIZE //
2, 64 MiB)` is `min(64 MiB, 64 MiB)`, i.e. the previous value.

## Note on the import

`_resolve_car_max_size` is private in AITER, and I would rather not duplicate the
env var semantics on the vLLM side where they could drift apart. It is guarded by
`try/except ImportError` and falls back to the old value. Happy to switch to a
public accessor if AITER exports one.