### PR TITLE
[CI] Only run GitHub Actions on the main repo

### DIFF
--- a/.github/workflows/add_label_automerge.yml
+++ b/.github/workflows/add_label_automerge.yml
@@ -7,6 +7,7 @@ on:
             - auto_merge_enabled
 jobs:
     add-label-on-auto-merge:
+        if: github.repository_owner == 'vllm-project'
         runs-on: [self-hosted, linux, x64, vllm-runners]
         steps:
             -   name: Add label

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   proto:
+    if: github.repository_owner == 'vllm-project'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/issue_autolabel.yml
+++ b/.github/workflows/issue_autolabel.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   add-labels:
+    if: github.repository_owner == 'vllm-project'
     runs-on: ubuntu-latest
     steps:
       - name: Label issues based on keywords

--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   macos-m1-smoke-test:
+    if: github.repository_owner == 'vllm-project'
     # macos-26 (the supported target) is still a preview runner, so gate on GA
     # macos-15 and keep macos-26 non-blocking.
     strategy:

--- a/.github/workflows/new_pr_bot.yml
+++ b/.github/workflows/new_pr_bot.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   update-description:
+    if: github.repository_owner == 'vllm-project'
     runs-on: ubuntu-latest
     steps:
       - name: Update PR description
@@ -52,6 +53,7 @@ jobs:
             }
 
   reminder-comment:
+    if: github.repository_owner == 'vllm-project'
     runs-on: ubuntu-latest
     steps:
       - name: Post welcome comment for first-time contributors

--- a/.github/workflows/notify-ci-authorized.yml
+++ b/.github/workflows/notify-ci-authorized.yml
@@ -24,13 +24,14 @@ permissions:
 jobs:
   notify:
     if: >-
-      (github.event_name == 'pull_request_target' &&
+      github.repository_owner == 'vllm-project' &&
+      ((github.event_name == 'pull_request_target' &&
       github.event.action == 'labeled' &&
       (github.event.label.name == 'ready' ||
       github.event.label.name == 'ready-run-all-tests')) ||
       (github.event_name == 'workflow_run' &&
       github.event.workflow_run.event == 'pull_request_review' &&
-      github.event.workflow_run.conclusion == 'success')
+      github.event.workflow_run.conclusion == 'success'))
     runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,6 +20,7 @@ jobs:
     # - A draft PR with the `ready` label is marked ready for review.
     # - New commits are pushed to a ready PR (so its latest commit has a title check status).
     if: >-
+      github.repository_owner == 'vllm-project' &&
       github.event.pull_request.draft == false &&
       contains(github.event.pull_request.labels.*.name, 'ready') &&
       (github.event.action != 'labeled' || github.event.label.name == 'ready') &&

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   pre-run-check:
-    if: github.event_name == 'pull_request'
+    if: github.repository_owner == 'vllm-project' && github.event_name == 'pull_request'
     runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
     - name: Check PR label and author merge count
@@ -46,7 +46,7 @@ jobs:
 
   pre-commit:
     needs: pre-run-check
-    if: always() && (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
+    if: github.repository_owner == 'vllm-project' && always() && (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
     runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/record-ci-approval.yml
+++ b/.github/workflows/record-ci-approval.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   approved:
-    if: github.event.review.state == 'approved'
+    if: github.repository_owner == 'vllm-project' && github.event.review.state == 'approved'
     runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
       - run: echo "Approval recorded"

--- a/.github/workflows/run-ci-command.yml
+++ b/.github/workflows/run-ci-command.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   run-ci-command:
     if: >-
+      github.repository_owner == 'vllm-project' &&
       github.event.issue.pull_request &&
       (github.event.comment.body == '/ci run' ||
       github.event.comment.body == '/ci run all' ||


### PR DESCRIPTION
I discovered that vLLM is using ~$7.4M/year of MacOS GitHub Actions runners every year because the MacOS smoke test was running nightly on every fork that exists ($340 per year X 21.7k forks; billed to each fork owner and comes out of free monthly allowance).

This PR adds `if: github.repository_owner == 'vllm-project'` to every GitHub Actions workflow job.