### PR TITLE
[ROCm][CI] Bump ROCk release image build timeout to 3h

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -1034,7 +1034,7 @@ steps:
             allow_failure: false
         agents:
           queue: cpu_queue_release
-        timeout_in_minutes: 60
+        timeout_in_minutes: 180
         commands:
           - |
             set -euo pipefail


### PR DESCRIPTION
## Purpose

Raise `build-rock-release-image`'s `timeout_in_minutes` from 60 to 180.

In nightly `release-v2` #6097 (first run after the ROCm 10.0 base landed, #55246), `:docker: Build release image - x86_64 - ROCk` timed out at 60.8 min mid-compile, which blocked the `nightly-rocm100` publish. The ROCk release image builds vLLM (csrc + NIXL/mori/lmcache/deepep) against a freshly built base with a **cold sccache** for the TheRock toolchain, so it compiles from scratch — the apt `Build release image - ROCm` step passes at 60 min only because it builds against a warm cache. 180 min gives the cold seed room to finish and warm the cache; warm runs finish well under it.

Not a duplicate; AI assistance (Claude Code) was used, reviewed and owned by me.

## Test Plan

```bash
python3 -c "import yaml; yaml.safe_load(open('.buildkite/release-pipeline.yaml'))"
```

## Test Result

YAML parses. Effect verified by the next nightly `release-v2` run.
