### PR TITLE
[Perf] Use 1024 threads per block in the prefill top-k kernel

### DIFF
--- a/csrc/libtorch_stable/sampler.cu
+++ b/csrc/libtorch_stable/sampler.cu
@@ -849,7 +849,11 @@ void top_k_per_row_prefill(const torch::stable::Tensor& logits,
                            torch::stable::Tensor& indices, int64_t numRows,
                            int64_t stride0, int64_t stride1, int64_t topK) {
   constexpr int kSortingAlgorithmThreshold = 12288;
-  constexpr int kNumThreadsPerBlock = 512;
+  // The histogram and the final-sort buffer are both 2048 entries, so 1024
+  // threads halve the number of rounds per block (2 instead of 4) and the
+  // per-thread items in the final radix sort. Measured faster across topK
+  // 512/1024/2048 on gfx950; see the PR description for the numbers.
+  constexpr int kNumThreadsPerBlock = 1024;
   const torch::stable::accelerator::DeviceGuard device_guard(
       logits.get_device_index());
   const cudaStream_t stream = get_current_cuda_stream();


### PR DESCRIPTION
## Purpose

`topKPerRowPrefill` launches one block per row with 512 threads. Both the
histogram (`kNumBins`) and the final-sort buffer (`kNumFinalItems`) hold 2048
entries, so 1024 threads halve the rounds per block (2 instead of 4) and the
per-thread item count in `cub::BlockRadixSort`. The 512 has been there since the
kernel was added, without a measurement attached to it.

## Test Plan

Called `torch.ops._C.top_k_per_row_prefill` directly on MI355X (gfx950), 15
shapes (512–32768 rows x 8k/32k/128k KV), median of 15 runs each, causal
`cu_seqlen_ks/ke` as in a real prefill. Same build throughout — the launch config
was switched at runtime, so the two arms cannot differ by anything else. Every
result checked against `torch.topk` on the longest row.

Repeated at three values of topK, because if the gain were topK-dependent this
would belong in a policy rather than a constant.

## Test Result

```
topK=2048   mean -12.9 %   14 of 15 shapes faster   best -22.1 %
topK=1024   mean -13.4 %   14 of 15 shapes faster   best -21.8 %
topK= 512   mean -13.4 %   14 of 15 shapes faster   best -22.5 %
```

Selected shapes at topK=1024:

| rows | KV | 512 thr | 1024 thr | |
|---|---|---|---|---|
| 512 | 131072 | 119.4 µs | 97.2 | −18.6 % |
| 2048 | 131072 | 496.8 µs | 388.4 | −21.8 % |
| 8192 | 131072 | 1726.5 µs | 1427.5 | −17.3 % |
| 16384 | 131072 | 3395.0 µs | 2805.7 | −17.4 % |
| 32768 | 32768 | 1701.3 µs | 1345.0 | −20.9 % |
| **8192** | **8192** | **111.3 µs** | **115.9** | **+4.2 %** |

Correctness: exact index match (2048/2048 where topK=2048) and max value delta
`0.00e+00` on every shape in all three runs.

## The one regression

`8192 rows x 8192 KV` is 3–4 % slower — 3.6 µs on a 103 µs kernel. That is a
chunk as long as the entire context, which does not arise with chunked prefill on
long sequences; at 128k KV the same row count gains 17 %. If you would rather not
take any regression at all, I can gate on `numRows * 16 < numColumns` or similar,
but that seemed like more machinery than the case warrants.

I only have gfx950 to measure on. If someone can run the same sweep on H100/B200
before this lands, that would be worth having — the reasoning (2048-entry buffers
divide evenly by 1024) is not ROCm-specific, but the measurement is.