### PR TITLE
[Build] Add SM110 (11.0f) to FUSED_GDN_DECODE_ARCHS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1122,7 +1122,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     cuda_archs_loose_intersection(FUSED_KDA_DECODE_ARCHS
       "9.0a;10.0f;12.0f" "${CUDA_ARCHS}")
     cuda_archs_loose_intersection(FUSED_GDN_DECODE_ARCHS
-      "8.0;8.6;8.9;9.0a;10.0f;12.0f" "${CUDA_ARCHS}")
+      "8.0;8.6;8.9;9.0a;10.0f;11.0f;12.0f" "${CUDA_ARCHS}")
   endif()
   if(FUSED_KDA_DECODE_ARCHS)
     set(FUSED_KDA_DECODE_SRC


### PR DESCRIPTION
## Purpose

`FUSED_GDN_DECODE_ARCHS` lists `10.0f` and `12.0f` but omits `11.0f`, so sm_110 (Jetson Thor / GB10-class Blackwell) never builds the fused GDN decode kernel: every Gated-DeltaNet layer logs `Falling back to the Triton GDN decode path: fused_gdn_decode_post_conv_mtp is not built`. Seven other arch lists in this file already carry `11.0f` (e.g. `FP4_SM100_ARCHS`, `MLA_ARCHS`), and the list now sits under `if(CUDA >= 13.0)`, which the `f` family suffix requires.

The `ops.h` declaration-guard mismatch that enabling this used to expose (declaration under `VLLM_ENABLE_FUSED_KDA_DECODE`, use sites under `VLLM_ENABLE_FUSED_GDN_DECODE`) was fixed separately in #52743, so this is now a one-line change. Related: #54084 (closed by me prematurely; this PR is the follow-up it promised).

## Test Plan

On Jetson AGX Thor (sm_110, CUDA 13.0, JetPack 7), build with `TORCH_CUDA_ARCH_LIST=11.0f` and this change, then:
- `pytest tests/kernels/.../test_fused_gdn_post_conv.py` and `test_gdn_fused_mtp.py`
- serve a GDN model (Qwen3.5-arch 27B) and check the GDN decode kernel log line

## Test Result

Validated at commit `6a9c69fa` (2026-08-24): build clean; `hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp") == True`; **75 passed** (`test_fused_gdn_post_conv.py`) and **12 passed** (`test_gdn_fused_mtp.py`) on Thor; runtime reports `GDN decode kernel: cuda` (previously the Triton fallback warning).

Honest notes: (1) not yet re-built at current `main` — the kernel has since gained an `output_gate_activation` parameter (#e126687a9a), orthogonal to arch flags, but I'm happy to re-validate on request; there is no sm_110 CI. (2) On the model measured (Qwen3.8-27B decode, MTP), enabling the kernel was **performance-neutral** — GDN decode is <1% of the step — so this is a completeness fix, not a speedup claim.
