### PR TITLE
[Attention] Include SM110 in FA4 auto-selection

### DIFF
--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -99,8 +99,10 @@ def get_flash_attn_version(
         if device_capability.major == 9 and is_fa_version_supported(3):
             # Hopper (SM90): prefer FA3
             fa_version = 3
-        elif device_capability.major == 10 and is_fa_version_supported(4):
-            # Blackwell (SM100+, restrict to SM100 for now): prefer FA4
+        elif device_capability.major in (10, 11) and is_fa_version_supported(4):
+            # Blackwell (SM100/SM110): prefer FA4. _is_fa4_supported() already
+            # lists is_device_capability_family(110), and the hd256 handling
+            # below already checks major in (10, 11).
             fa_version = 4
         else:
             # Fallback to FA2


### PR DESCRIPTION
## Purpose

`get_flash_attn_version()` gates FA4 auto-selection on `device_capability.major == 10` ("restrict to SM100 for now"), while:
- `_is_fa4_supported()` explicitly lists `is_device_capability_family(110)`, and
- the newer hd256 handling in the same file already checks `major in (10, 11)`.

So on sm_110 (Jetson Thor) the support probe returns True but auto-selection silently falls back to FA2. This PR aligns the default with both of those.

**If the SM100-only gate is deliberate staging pending sm_110 validation, please treat this PR as the request for that call** — blame shows the gate and the family-110 support listing were introduced together in the original FA4 integration (#32974), so I am not asserting this is a bug.

Scope notes:
- FA4 head-dim-256 remains correctly blocked on sm_110 by the deliberate guard from #52050 (tracked at Dao-AILab/flash-attention#2456); this change benefits sm_110 models with head_dim ≤ 128.
- FA4 is already reachable today via the explicit `--attention-config.flash_attn_version=4` override; this PR only changes the default.
- The vendored FA4 interface (pinned vllm-flash-attn) validates and dispatches compute capability 11 throughout (`_validate_head_dims`, SM100-class kernel selection). One edge worth maintainer eyes: the vendored kernels assert `arch // 10 == 10` for **FP8** FA4 — currently unreachable on sm_110 only because `flash_attn_supports_kv_cache_dtype` gates FA4-fp8 on `family(100)`.

## Test Plan

On Jetson AGX Thor (sm_110, CUDA 13.0): with this change, `get_flash_attn_version()` should return 4; a head_dim-256 model should still fall back (hd256 guard); no sm_110 CI exists, so on-device verification.

## Test Result

Verified on Thor: patched `get_flash_attn_version()` returns **4** (was 2); the head_dim-256 model correctly still hits the #52050 guard and falls back. I do not have an sm_110 head_dim ≤ 128 FA4 correctness/perf run to attach — if there's a preferred validation model/suite, happy to run it on Thor.
