### PR TITLE
[Bugfix] Detect NVFP4 in compressed-tensors mixed-precision checkpoints

### DIFF
--- a/tests/config/test_nvfp4_detection.py
+++ b/tests/config/test_nvfp4_detection.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Detection of NVFP4 in compressed-tensors quantization configs.
+
+Regression tests for mixed-precision checkpoints (format "mixed-precision"),
+whose top-level format string never names nvfp4 even when config groups are
+nvfp4 -- and which must NOT match W4A4-float MXFP4 groups.
+"""
+
+from types import SimpleNamespace
+
+from vllm.config.model import ModelConfig, _is_nvfp4_quant_group
+
+NVFP4_GROUP = {
+    # unsloth/Qwen3.8-27B-NVFP4 config_groups.group_1 (trimmed)
+    "format": "nvfp4-pack-quantized",
+    "targets": [r"re:.*mlp\.(gate|up|down)_proj$"],
+    "weights": {
+        "num_bits": 4,
+        "type": "float",
+        "strategy": "tensor_group",
+        "group_size": 16,
+        "symmetric": True,
+    },
+    "input_activations": {
+        "num_bits": 4,
+        "type": "float",
+        "strategy": "tensor_group",
+        "group_size": 16,
+        "dynamic": "local",
+    },
+}
+
+MXFP4_GROUP = {
+    # INCModel3/GLM-5.3-Flash-MXFP4-Mixed-CT-AutoRound group_0 (trimmed):
+    # also W4A4 float, but strategy "group" with group_size 32
+    "format": "mxfp4-pack-quantized",
+    "targets": ["Linear"],
+    "weights": {
+        "num_bits": 4,
+        "type": "float",
+        "strategy": "group",
+        "group_size": 32,
+        "symmetric": True,
+    },
+    "input_activations": {
+        "num_bits": 4,
+        "type": "float",
+        "strategy": "group",
+        "group_size": 32,
+    },
+}
+
+FP8_GROUP = {
+    "weights": {"num_bits": 8, "type": "float", "strategy": "channel"},
+    "input_activations": {"num_bits": 8, "type": "float"},
+}
+
+
+def _model_config(quantization, quant_config):
+    """The method only touches these two attributes; avoid a full ModelConfig."""
+    fake = SimpleNamespace(
+        quantization=quantization,
+        model_arch_config=SimpleNamespace(quantization_config=quant_config),
+    )
+    return ModelConfig.is_nvfp4_quantized(fake)
+
+
+def test_group_scheme_match_without_per_group_format():
+    group = {k: v for k, v in NVFP4_GROUP.items() if k != "format"}
+    assert _is_nvfp4_quant_group(group)
+
+
+def test_group_per_group_format_match():
+    group = {"format": "nvfp4-pack-quantized", "weights": {}, "targets": ["Linear"]}
+    assert _is_nvfp4_quant_group(group)
+
+
+def test_group_mxfp4_not_matched():
+    assert not _is_nvfp4_quant_group(MXFP4_GROUP)
+    # even without its per-group format, the scheme fields must not match
+    group = {k: v for k, v in MXFP4_GROUP.items() if k != "format"}
+    assert not _is_nvfp4_quant_group(group)
+
+
+def test_group_preset_name_value_does_not_crash():
+    # compressed-tensors allows {"NVFP4": ["Linear"]}-style preset groups;
+    # vLLM cannot load those configs, so they must simply not match.
+    assert not _is_nvfp4_quant_group(["Linear"])
+
+
+def test_modelopt_fp4():
+    assert _model_config("modelopt_fp4", None)
+
+
+def test_ct_packed_format():
+    assert _model_config("compressed-tensors", {"format": "nvfp4-pack-quantized"})
+
+
+def test_ct_mixed_precision_with_nvfp4_group():
+    qc = {
+        "format": "mixed-precision",
+        "config_groups": {"group_0": FP8_GROUP, "group_1": NVFP4_GROUP},
+    }
+    assert _model_config("compressed-tensors", qc)
+
+
+def test_ct_mixed_precision_mxfp4_only():
+    qc = {
+        "format": "mixed-precision",
+        "config_groups": {"group_0": FP8_GROUP, "group_1": MXFP4_GROUP},
+    }
+    assert not _model_config("compressed-tensors", qc)
+
+
+def test_ct_pure_mxfp4_unchanged():
+    # non-mixed formats must not consult config_groups at all
+    qc = {
+        "format": "mxfp4-pack-quantized",
+        "config_groups": {"group_0": MXFP4_GROUP},
+    }
+    assert not _model_config("compressed-tensors", qc)
+
+
+def test_ct_mixed_precision_fp8_only():
+    qc = {"format": "mixed-precision", "config_groups": {"group_0": FP8_GROUP}}
+    assert not _model_config("compressed-tensors", qc)
+
+
+def test_non_ct_quantization():
+    assert not _model_config("fp8", {"format": "nvfp4-pack-quantized"})
+
+
+def test_missing_config():
+    assert not _model_config("compressed-tensors", None)

--- a/tests/config/test_nvfp4_detection.py
+++ b/tests/config/test_nvfp4_detection.py
@@ -83,6 +83,21 @@ def test_group_mxfp4_not_matched():
     assert not _is_nvfp4_quant_group(group)
 
 
+def test_group_activation_layout_must_also_match():
+    # upstream requires _is_nvfp4_format on input_quant as well ("For NVFP4
+    # weights, input quantization must also be NVFP4 format"); a group with
+    # nvfp4 weights but group/32 activations must not match.
+    base = {k: v for k, v in NVFP4_GROUP.items() if k != "format"}
+    wrong_strategy = dict(
+        base, input_activations=dict(base["input_activations"], strategy="group")
+    )
+    assert not _is_nvfp4_quant_group(wrong_strategy)
+    wrong_group_size = dict(
+        base, input_activations=dict(base["input_activations"], group_size=32)
+    )
+    assert not _is_nvfp4_quant_group(wrong_group_size)
+
+
 def test_group_preset_name_value_does_not_crash():
     # compressed-tensors allows {"NVFP4": ["Linear"]}-style preset groups;
     # vLLM cannot load those configs, so they must simply not match.

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -150,6 +150,9 @@ def _is_nvfp4_quant_group(group: object) -> bool:
         and bool(weights.get("symmetric", True))
         and acts.get("num_bits") == 4
         and acts.get("type") == "float"
+        and acts.get("strategy") == "tensor_group"
+        and acts.get("group_size") == 16
+        and bool(acts.get("symmetric", True))
     )
 
 class ModelConfig:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -121,6 +121,37 @@ AttnTypeStr = Literal[
 
 
 @config(config=ConfigDict(arbitrary_types_allowed=True))
+
+def _is_nvfp4_quant_group(group: object) -> bool:
+    """Whether one compressed-tensors config group describes an NVFP4 scheme.
+
+    A group is NVFP4 if its own per-group ``format`` names nvfp4, or if it
+    matches the NVFP4 scheme (4-bit float weights and activations with
+    16-element tensor-group scales), mirroring
+    ``CompressedTensorsConfig._is_nvfp4_format``. The scheme check is
+    deliberately strict so that W4A4-float MXFP4 groups (strategy "group",
+    group_size 32) are not misclassified as NVFP4.
+    """
+    if not isinstance(group, dict):
+        # config_groups may map preset scheme names to target lists; such
+        # configs are not loadable by vLLM, so simply do not match them.
+        return False
+    if "nvfp4" in str(group.get("format") or "").lower():
+        return True
+    weights = group.get("weights") or {}
+    acts = group.get("input_activations") or {}
+    if not (isinstance(weights, dict) and isinstance(acts, dict)):
+        return False
+    return (
+        weights.get("num_bits") == 4
+        and weights.get("type") == "float"
+        and weights.get("strategy") == "tensor_group"
+        and weights.get("group_size") == 16
+        and bool(weights.get("symmetric", True))
+        and acts.get("num_bits") == 4
+        and acts.get("type") == "float"
+    )
+
 class ModelConfig:
     """Configuration for the model."""
 
@@ -2167,10 +2198,20 @@ class ModelConfig:
         # For Compressed Tensors we look for `"format": "nvfp4-pack-quantized"`
         # in the quantization config
         quant_config = self.model_arch_config.quantization_config
-        return (
-            self.quantization == "compressed-tensors"
-            and quant_config is not None
-            and "nvfp4" in quant_config.get("format", "").lower()
+        if self.quantization != "compressed-tensors" or quant_config is None:
+            return False
+        fmt = quant_config.get("format", "").lower()
+        if "nvfp4" in fmt:
+            return True
+        # Mixed-precision checkpoints declare per-group schemes, so the
+        # top-level format string never names nvfp4 even when some groups
+        # are. Detect an nvfp4 group so FP4-specific behavior (e.g. the
+        # activation-quant fusion pass) still applies to those layers.
+        if "mixed" not in fmt:
+            return False
+        return any(
+            _is_nvfp4_quant_group(group)
+            for group in (quant_config.get("config_groups") or {}).values()
         )
 
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -120,8 +120,6 @@ AttnTypeStr = Literal[
 ]
 
 
-@config(config=ConfigDict(arbitrary_types_allowed=True))
-
 def _is_nvfp4_quant_group(group: object) -> bool:
     """Whether one compressed-tensors config group describes an NVFP4 scheme.
 
@@ -155,6 +153,8 @@ def _is_nvfp4_quant_group(group: object) -> bool:
         and bool(acts.get("symmetric", True))
     )
 
+
+@config(config=ConfigDict(arbitrary_types_allowed=True))
 class ModelConfig:
     """Configuration for the model."""
 


### PR DESCRIPTION
## Purpose

`ModelConfig.is_nvfp4_quantized()` detects NVFP4 by looking for `"nvfp4"` in the quantization config's **top-level** `format` string. Compressed-tensors **mixed-precision** checkpoints declare per-group schemes instead — the top-level format is `"mixed-precision"` and never names nvfp4 even when groups plainly are.

Concrete case: `unsloth/Qwen3.8-27B-NVFP4` (`format: "mixed-precision"`, `config_groups.group_1` = W4A4 float, `tensor_group`, `group_size 16`, per-group `format: "nvfp4-pack-quantized"`, targeting `mlp.(gate|up|down)_proj` — 56 of 64 MLP layers). The check returns False → `enable_act_fusion()` returns False → `pass_config.fuse_act_quant` stays False at **every** optimization level → `ActivationQuantFusionPass` never runs → the fused CUDA op `silu_and_mul_nvfp4_quant` is unreachable (it is referenced only from that pass) and Inductor handles silu+mul+fp4-quant — which `enable_act_fusion`'s own docstring says it cannot: *"FP4 quant is always custom so Inductor cannot fuse it."*

Fix: when the top-level format is mixed, inspect `config_groups`. A group counts as NVFP4 if its per-group `format` names nvfp4, **or** it matches the NVFP4 scheme exactly (W4A4 float + `tensor_group` + `group_size 16` + symmetric), mirroring `CompressedTensorsConfig._is_nvfp4_format`. The strictness is load-bearing: **MXFP4 is also W4A4 float** (strategy `group`, group_size 32) — e.g. `INCModel3/GLM-5.3-Flash-MXFP4-Mixed-CT-AutoRound` — and must not be misclassified. Non-dict (preset-name) groups are guarded; non-mixed formats never consult groups, so e.g. pure `mxfp4-pack-quantized` behavior is unchanged.

Design note, pre-flagged: a mixed-precision model is only *partly* NVFP4, so a model-level boolean is arguably the wrong shape for this question; if maintainers prefer keying off resolved per-layer schemes, I'm glad to rework — this PR is the minimal fix at the existing seam (single call site: `enable_act_fusion`).

## Test Plan

- `pytest tests/config/test_nvfp4_detection.py` (added; 12 cases including the real unsloth NVFP4 and GLM-MXFP4 group shapes, preset-name groups, pure-mxfp4 no-change, modelopt_fp4/packed-format unchanged)
- On-device (Jetson Thor, sm_110): serve the unsloth checkpoint before/after and compare the resolved `pass_config`, compiled artifacts, and an nsys capture.

## Test Result

- Unit tests: **12/12 pass.**
- On device: resolved engine config flips `'fuse_act_quant': False → True` (`Enabled custom fusions: act_quant`); compiled-graph caches are mutually exclusive (**9 files call `silu_and_mul_nvfp4_quant` / 0 contain the Inductor Triton kernel**, vs **0 / 26** unpatched); nsys shows `vllm::silu_mul_cvt_fp16_to_fp4` executing (12.73 µs/call vs the Triton kernel's 17.36 µs).
- **Measured caveat, stated up front:** on this model + MTP speculative decoding, enabling the fusion is performance-neutral end-to-end (`pass_s` −0.1% in a controlled A/B/A) and *reduces* MTP acceptance on code content (AL 3.16 → 2.83/2.59, −11…−18% tok/s; accuracy unchanged at ARC 96.25% but generations differ — the fused kernel rounds differently, so drafted tokens flip). This PR is filed as **correctness-of-intent** (the config should mean what it says), not as a speedup; whether the fusion *should* be enabled for FP4 models under spec-decode may deserve its own discussion.
