### PR TITLE
[KV Connector] Support piecewise prefix loading with NIXL connectors

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -4,19 +4,25 @@ import filecmp
 import shutil
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 
-from tests.v1.kv_connector.unit.utils import create_vllm_config
+from tests.v1.kv_connector.unit.utils import (
+    create_request,
+    create_scheduler,
+    create_vllm_config,
+)
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorRole
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
+    KVLoadRange,
     SupportsHMA,
     supports_hma,
 )
@@ -30,8 +36,16 @@ from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlKVConnectorStats,
 )
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.outputs import KVConnectorOutput, KVConnectorWorkerMetadata
+from vllm.v1.request import RequestStatus
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 
@@ -99,12 +113,14 @@ class MockHMAConnector(KVConnectorBase_V1, SupportsHMA):
     """Mock connector that supports HMA for testing."""
 
     _supports_divergent_local_hybrid_hits = False
+    _supports_load_range = False
 
     def __new__(cls, *args, **kwargs):
         mock = MagicMock(spec_set=cls)
         mock.supports_divergent_local_hybrid_hits = (
             cls._supports_divergent_local_hybrid_hits
         )
+        mock.supports_load_range = cls._supports_load_range
         mock.get_kv_connector_stats.return_value = None
         return mock
 
@@ -137,10 +153,17 @@ class MockDivergentHMAConnector(MockHMAConnector):
     _supports_divergent_local_hybrid_hits = True
 
 
+class MockRangeHMAConnector(MockHMAConnector):
+    _supports_load_range = True
+
+
 # Register mock connectors
 KVConnectorFactory.register_connector("MockConnector", __name__, MockConnector.__name__)
 KVConnectorFactory.register_connector(
     "MockHMAConnector", __name__, MockHMAConnector.__name__
+)
+KVConnectorFactory.register_connector(
+    "MockRangeHMAConnector", __name__, MockRangeHMAConnector.__name__
 )
 KVConnectorFactory.register_connector(
     "MockDivergentHMAConnector",
@@ -167,6 +190,14 @@ def test_register_finished_partial_tail_notifies_every_connector():
     second.register_finished_partial_tail.assert_called_once_with(
         request, block_ids, offloads
     )
+
+
+def test_multi_connector_aggregates_load_errors(mc: MultiConnector):
+    first, second = mc._connectors
+    first.get_block_ids_with_load_errors.return_value = {1, 2}
+    second.get_block_ids_with_load_errors.return_value = {2, 3}
+
+    assert mc.get_block_ids_with_load_errors() == {1, 2, 3}
 
 
 @pytest.fixture
@@ -196,6 +227,492 @@ def mc() -> MultiConnector:
     )
 
     return mc
+
+
+def _make_policy_connector(
+    matches: list[tuple[int | None, bool]],
+    supports_range: list[bool],
+) -> MultiConnector:
+    connector = MultiConnector.__new__(MultiConnector)
+    connector._connectors = []
+    for match, supports in zip(matches, supports_range):
+        child = MagicMock(spec_set=KVConnectorBase_V1)
+        child.get_num_new_matched_tokens.return_value = match
+        child.supports_load_range = supports
+        child.load_range_alignment = None
+        connector._connectors.append(child)
+    connector._range_load = True
+    connector._scheduler_block_size = 16
+    connector._requests_to_connector = {}
+    connector._request_load_ranges = {}
+    connector._request_async_loads = {}
+    connector._async_loads_to_send = {}
+    connector._async_load_sources = {}
+    connector._pending_async_loads = {}
+    connector._extra_async_saves = {}
+    return connector
+
+
+def _make_hybrid_policy_config(
+    load_policy: str = "range_aware",
+    connector_name: str = "MockHMAConnector",
+):
+    child_config = {
+        "kv_connector": connector_name,
+        "kv_role": "kv_both",
+        "kv_connector_module_path": __name__,
+    }
+    return create_vllm_config(
+        kv_connector="MultiConnector",
+        kv_connector_extra_config={
+            "load_policy": load_policy,
+            "connectors": [child_config, child_config],
+        },
+    )
+
+
+def _make_unequal_group_cache_config() -> KVCacheConfig:
+    full = FullAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+    )
+    swa = SlidingWindowSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=16,
+    )
+    return KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full"], full),
+            KVCacheGroupSpec(["swa"], swa),
+        ],
+    )
+
+
+def _make_recurrent_cache_config(*, wrapped: bool = False) -> KVCacheConfig:
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+    )
+    group_spec = (
+        UniformTypeKVCacheSpecs(
+            block_size=16,
+            kv_cache_specs={"mamba": mamba_spec},
+        )
+        if wrapped
+        else mamba_spec
+    )
+    return KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["mamba"],
+                group_spec,
+            )
+        ],
+    )
+
+
+def test_range_aware_init_uses_scheduler_block_size_for_hybrid_groups():
+    connector = MultiConnector(
+        _make_hybrid_policy_config(),
+        KVConnectorRole.SCHEDULER,
+        _make_unequal_group_cache_config(),
+    )
+
+    assert connector._scheduler_block_size == 256
+
+
+def test_multi_connector_rejects_unknown_load_policy():
+    with pytest.raises(ValueError, match="Unknown MultiConnector load_policy"):
+        MultiConnector(
+            _make_hybrid_policy_config("range-aware"),
+            KVConnectorRole.SCHEDULER,
+            _make_unequal_group_cache_config(),
+        )
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_range_aware_recurrent_cache_requires_range_capable_children(wrapped: bool):
+    with pytest.raises(ValueError, match="requires every child connector"):
+        MultiConnector(
+            _make_hybrid_policy_config(),
+            KVConnectorRole.SCHEDULER,
+            _make_recurrent_cache_config(wrapped=wrapped),
+        )
+
+
+def test_range_aware_recurrent_cache_accepts_range_capable_children():
+    MultiConnector(
+        _make_hybrid_policy_config(connector_name="MockRangeHMAConnector"),
+        KVConnectorRole.SCHEDULER,
+        _make_recurrent_cache_config(),
+    )
+
+
+def test_range_aware_load_assigns_contiguous_ranges():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    leading, suffix = connector._connectors
+    leading.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    suffix.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96)
+    )
+    assert connector._async_loads_to_send == {"req": (0, 1)}
+
+
+def test_range_aware_load_gives_range_capable_leader_explicit_ownership():
+    connector = _make_policy_connector([(64, True), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    leading, suffix = connector._connectors
+    leading.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(0, 64, is_terminal=False)
+    )
+    suffix.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96)
+    )
+
+
+def test_range_aware_load_respects_scheduler_declining_external_load():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 0)
+
+    for child in connector._connectors:
+        child.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+        child.update_state_after_alloc_for_range.assert_not_called()
+    assert connector._async_loads_to_send == {}
+
+
+def test_scheduler_partial_local_tail_cancels_range_load():
+    scheduler = create_scheduler(_make_hybrid_policy_config())
+    connector = scheduler.connector
+    assert isinstance(connector, MultiConnector)
+    first, second = connector._connectors
+    first.get_num_new_matched_tokens.return_value = (0, True)
+    second.get_num_new_matched_tokens.return_value = (6, True)
+    second.supports_load_range = True
+    second.load_range_alignment = None
+
+    request = create_request(num_tokens=32, block_size=16)
+    scheduler.add_request(request)
+    scheduler._get_local_prefix_cache_hit = MagicMock(
+        return_value=(
+            scheduler.kv_cache_manager.empty_kv_cache_blocks,
+            6,
+            0,
+            False,
+        )
+    )
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == 26
+    assert request.status == RequestStatus.RUNNING
+    first.update_state_after_alloc.assert_called_once_with(
+        request, scheduler.kv_cache_manager.get_blocks(request.request_id), 0
+    )
+    second.update_state_after_alloc.assert_called_once_with(
+        request, scheduler.kv_cache_manager.get_blocks(request.request_id), 0
+    )
+    second.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_range_aware_load_rejects_changed_positive_token_count():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+
+    with pytest.raises(ValueError, match="expected 96, got 80"):
+        connector.update_state_after_alloc(request, MagicMock(), 80)
+
+
+def test_range_aware_load_extends_a_local_hit():
+    connector = _make_policy_connector([(32, True), (64, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 32) == (64, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 64)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 32)
+    second.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96)
+    )
+
+
+def test_range_aware_load_rounds_previous_range_to_next_alignment():
+    connector = _make_policy_connector([(60, True), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    assert connector._request_load_ranges["req"] == {
+        0: KVLoadRange(0, 48, is_terminal=False),
+        1: KVLoadRange(48, 96, is_terminal=True),
+    }
+
+
+def test_range_aware_load_does_not_trim_legacy_leader():
+    connector = _make_policy_connector([(60, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+    first.update_state_after_alloc_for_range.assert_not_called()
+    second.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_range_aware_load_does_not_mix_sync_and_async_ranges():
+    connector = _make_policy_connector([(64, False), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+    first.update_state_after_alloc_for_range.assert_not_called()
+    second.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_range_aware_load_falls_back_when_aligned_range_is_empty():
+    connector = _make_policy_connector([(12, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+
+
+def test_range_aware_load_combines_adjacent_and_scheduler_alignments():
+    connector = _make_policy_connector([(60, True), (96, True)], [True, True])
+    connector._connectors[0].load_range_alignment = 24
+    connector._connectors[1].load_range_alignment = 4
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    assert connector._request_load_ranges["req"] == {
+        0: KVLoadRange(0, 48, is_terminal=False),
+        1: KVLoadRange(48, 96, is_terminal=True),
+    }
+
+
+def test_range_aware_load_skips_unaligned_explicit_leader():
+    connector = _make_policy_connector(
+        [(32, True), (64, True), (96, True)], [True, True, True]
+    )
+    connector._connectors[0].load_range_alignment = 64
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 16) == (96, True)
+    assert connector._request_load_ranges["req"] == {
+        1: KVLoadRange(16, 80, is_terminal=False),
+        2: KVLoadRange(80, 112, is_terminal=True),
+    }
+
+
+def test_range_aware_load_falls_back_when_all_leaders_are_unaligned():
+    connector = _make_policy_connector([(32, True), (64, True)], [True, True])
+    for child in connector._connectors:
+        child.load_range_alignment = 64
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 16) == (64, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 64)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    for child in connector._connectors:
+        child.update_state_after_alloc_for_range.assert_not_called()
+
+
+@pytest.mark.parametrize("alignment", [0, -1])
+def test_range_aware_load_rejects_non_positive_alignment(alignment: int):
+    connector = _make_policy_connector([(64, True), (96, True)], [True, True])
+    connector._connectors[1].load_range_alignment = alignment
+
+    with pytest.raises(ValueError, match="load_range_alignment must be positive"):
+        connector.get_num_new_matched_tokens(SimpleNamespace(request_id="req"), 0)
+
+
+def test_range_aware_load_combines_three_sources():
+    connector = _make_policy_connector(
+        [(64, True), (96, True), (128, True)], [False, True, True]
+    )
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (128, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 128)
+
+    first, second, third = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96, is_terminal=False)
+    )
+    third.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(96, 128)
+    )
+    assert connector._async_loads_to_send == {"req": (0, 1, 2)}
+
+
+def test_range_aware_load_skips_unsupported_intermediate_source():
+    connector = _make_policy_connector(
+        [(64, True), (96, True), (128, True)], [False, False, True]
+    )
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (128, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 128)
+
+    first, second, third = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc_for_range.assert_not_called()
+    third.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 128)
+    )
+
+
+def test_range_aware_load_allows_unaligned_final_tail():
+    connector = _make_policy_connector([(64, True), (70, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (70, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 70)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 70)
+    )
+
+
+def test_range_aware_load_uses_one_source_for_equal_hits():
+    connector = _make_policy_connector([(96, True), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    assert connector._async_loads_to_send == {"req": (0,)}
+
+
+def test_range_aware_load_waits_for_all_async_sources():
+    scheduler = _make_policy_connector(
+        [(64, True), (96, True), (128, True)], [False, True, True]
+    )
+    request = SimpleNamespace(request_id="req")
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (128, True)
+    scheduler.update_state_after_alloc(request, MagicMock(), 128)
+
+    metadata = scheduler.build_connector_meta(MagicMock())
+    assert metadata.pending_async_loads == {"req": (0, 1, 2)}
+
+    worker = _make_policy_connector(
+        [(0, False), (0, False), (0, False)], [False, True, True]
+    )
+    worker.bind_connector_metadata(metadata)
+    first, second, third = worker._connectors
+    first.get_finished.return_value = (None, {"req"})
+    second.get_finished.return_value = (None, None)
+    third.get_finished.return_value = (None, None)
+
+    assert worker.get_finished(set()) == (None, None)
+
+    first.get_finished.return_value = (None, None)
+    second.get_finished.return_value = (None, {"req"})
+    assert worker.get_finished(set()) == (None, None)
+
+    second.get_finished.return_value = (None, None)
+    third.get_finished.return_value = (None, {"req"})
+    assert worker.get_finished(set()) == (None, {"req"})
+
+    third.get_finished.return_value = (None, None)
+    first.get_finished.return_value = (None, {"req"})
+    assert worker.get_finished(set()) == (None, None)
+
+    first.get_finished.return_value = (None, None)
+    assert worker.get_finished({"req"}) == (None, None)
+    assert worker._async_load_sources == {}
+
+
+def test_range_aware_second_allocation_update_is_forwarded_as_no_load():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, MagicMock(), 96)
+    for child in connector._connectors:
+        child.reset_mock()
+
+    blocks = MagicMock()
+    connector.update_state_after_alloc(request, blocks, 0)
+
+    for child in connector._connectors:
+        child.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+        child.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_default_load_policy_still_selects_first_hit():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    connector._range_load = False
+    load_ranges = connector._request_load_ranges = MagicMock()
+    async_loads = connector._request_async_loads = MagicMock()
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (64, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 64)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    load_ranges.pop.assert_not_called()
+    async_loads.pop.assert_not_called()
+
+
+def test_prom_metrics_skips_configured_connector_without_exporter():
+    metrics = MultiKVConnectorPromMetrics.__new__(MultiKVConnectorPromMetrics)
+    supported = MagicMock()
+    metrics._prom_metrics = {"Supported": supported, "Unsupported": None}
+
+    metrics.observe(
+        {
+            "Supported": {"bytes": 1},
+            "Unsupported": {"bytes": 2},
+        },
+        engine_idx=3,
+    )
+
+    supported.observe.assert_called_once_with({"bytes": 1}, 3)
 
 
 # Helper function to compare directories recursively
@@ -873,6 +1390,9 @@ def test_multi_connector_overrides_all_base_methods():
         "role",
         "has_connector_metadata",
         "get_kv_connector_kv_cache_events",
+        "supports_load_range",
+        "load_range_alignment",
+        "update_state_after_alloc_for_range",
     }
 
     base_members = {

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -11,6 +11,7 @@ import torch
 from tests.v1.attention.utils import MockMambaBuilder
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVLoadRange
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SlidingWindowManager,
@@ -93,7 +94,16 @@ def test_needs_split_local_xfer_handles(use_mla, source_ranks, tp_ratio, expecte
 
 
 @pytest.mark.cpu_test
-def test_update_state_after_alloc_tracks_cached_blocks_per_group():
+@pytest.mark.parametrize(
+    "transfer_group_ids,expected_num_computed_blocks",
+    [
+        pytest.param((0, 1), (2, 1), id="all_groups"),
+        pytest.param((1,), (1,), id="nonzero_transfer_group"),
+    ],
+)
+def test_update_state_after_alloc_tracks_cached_blocks_per_group(
+    transfer_group_ids, expected_num_computed_blocks
+):
     """Hybrid SWA+FA requests can have different prefix-cache-hit counts per
     KV cache group. Each group's count must be tracked independently rather
     than collapsed to a single scalar, or DCP read-phase alignment
@@ -112,7 +122,10 @@ def test_update_state_after_alloc_tracks_cached_blocks_per_group():
     scheduler.is_bidirectional_kv_xfer_enabled = False
     scheduler._is_hma_required = False
     scheduler.kv_cache_config = MagicMock(
-        select_transfer_block_ids=lambda block_ids: block_ids
+        transfer_group_ids=transfer_group_ids,
+        select_transfer_block_ids=lambda block_ids: tuple(
+            block_ids[group_id] for group_id in transfer_group_ids
+        ),
     )
 
     def cached(block_id):
@@ -134,8 +147,102 @@ def test_update_state_after_alloc_tracks_cached_blocks_per_group():
 
     scheduler.update_state_after_alloc(request, blocks, num_external_tokens=2)
 
-    _, _, local_num_computed_blocks = scheduler._reqs_need_recv[request.request_id]
-    assert local_num_computed_blocks == (2, 1)
+    _, local_block_ids, local_num_computed_blocks, load_start, load_end = (
+        scheduler._reqs_need_recv[request.request_id]
+    )
+    assert len(local_block_ids) == len(local_num_computed_blocks)
+    assert local_num_computed_blocks == expected_num_computed_blocks
+    assert (load_start, load_end) == (
+        request.num_computed_tokens,
+        request.num_computed_tokens + 2,
+    )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("wrapped_mamba", [False, True])
+def test_range_load_selects_attention_suffix_and_terminal_mamba_state(
+    wrapped_mamba: bool,
+):
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_scheduler import (
+        NixlPullConnectorScheduler,
+    )
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        MambaSpec,
+        UniformTypeKVCacheSpecs,
+    )
+
+    full = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+    )
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((16,), (16,)),
+        dtypes=(torch.float16,),
+        mamba_cache_mode="align",
+    )
+    mamba_group_spec = (
+        UniformTypeKVCacheSpecs(
+            block_size=16,
+            kv_cache_specs={"mamba": mamba},
+        )
+        if wrapped_mamba
+        else mamba
+    )
+    scheduler = object.__new__(NixlPullConnectorScheduler)
+    scheduler._scheduler_block_size = 64
+    scheduler._range_group_block_sizes = (16, 16)
+    scheduler._range_transfer_group_block_sizes = (16, 16)
+    scheduler._is_hma_required = True
+    scheduler.blocks_per_sw = [0, 0]
+    scheduler._ssm_spec_blocks = [None, 0]
+    scheduler._ssm_state_slots_are_positional = False
+    scheduler.kv_cache_config = MagicMock()
+    scheduler.kv_cache_config.kv_cache_groups = (
+        MagicMock(kv_cache_spec=full),
+        MagicMock(kv_cache_spec=mamba_group_spec),
+    )
+    scheduler.kv_cache_config.transfer_groups = (
+        scheduler.kv_cache_config.kv_cache_groups
+    )
+    scheduler.kv_cache_config.select_transfer_block_ids.side_effect = lambda ids: ids
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = (
+        [10, 11, 12, 13, 14, 15, 16, 17],
+        [20, 21, 22],
+    )
+
+    terminal = scheduler.get_range_block_ids(blocks, KVLoadRange(64, 96))
+    nonterminal = scheduler.get_range_block_ids(
+        blocks, KVLoadRange(64, 96, is_terminal=False)
+    )
+
+    assert terminal == ([14, 15], [22])
+    assert nonterminal == ([14, 15], [])
+    assert scheduler.get_range_start_blocks(KVLoadRange(64, 96)) == (4, 4)
+    scheduler._reqs_in_batch = set()
+    scheduler._reqs_need_save = {}
+    scheduler._reqs_need_recv = {}
+    scheduler.use_host_buffer = False
+    scheduler.is_bidirectional_kv_xfer_enabled = False
+    request = create_request(do_remote_prefill=True)
+
+    scheduler.update_state_after_alloc_for_range(
+        request,
+        blocks,
+        KVLoadRange(64, 96),
+    )
+
+    assert scheduler._reqs_need_recv[request.request_id] == (
+        request,
+        ([14, 15], [22]),
+        (4, 4),
+        64,
+        96,
+    )
 
 
 @pytest.mark.cpu_test
@@ -514,6 +621,15 @@ def test_apply_prefix_caching_mamba_hybrid(
     "local_block_ids,remote_block_ids,"
     "expected_local,expected_remote",
     [
+        pytest.param(
+            10,
+            10,
+            [list(range(10)), []],
+            [list(range(10)), [42]],
+            [list(range(10)), []],
+            [list(range(10)), []],
+            id="nonterminal_range_skips_ssm_state",
+        ),
         # SSM prefix caching: remote has 3 placeholder + 1 real block,
         # local has only the 1 real block. FA blocks are equal (no trim).
         pytest.param(
@@ -635,6 +751,7 @@ def test_apply_prefix_caching_ssm_unpairable_slots_rejected():
 @pytest.mark.cpu_test
 @pytest.mark.parametrize(
     "local_physical_per_logical,remote_physical_per_logical,"
+    "load_start_token,load_end_token,"
     "remote_fa_blocks,local_fa_blocks,ssm_blocks,"
     "correct_remote_fa,correct_local_fa",
     [
@@ -644,16 +761,17 @@ def test_apply_prefix_caching_ssm_unpairable_slots_rejected():
         # 1st local logical block cached → suffix [6..11]
         # Correct: transfer only uncached suffix tokens (384-639)
         #   = remote [6,7,8,9] → local [6,7,8,9].
-        # Actual (front-trim): remote[:6]=[0..5] → local [6..11]. Wrong.
         pytest.param(
             6,
             10,
+            384,
+            640,
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
             [6, 7, 8, 9, 10, 11],
             [42],
             [6, 7, 8, 9],
             [6, 7, 8, 9],
-            id="local6_remote10_fail",
+            id="local6_remote10",
         ),
         # 15 kernel blocks of data (960 tokens).
         # remote physical_per_logical=6  → 3 logical → 18 kernel [0..17]
@@ -661,36 +779,35 @@ def test_apply_prefix_caching_ssm_unpairable_slots_rejected():
         # 1st local logical block cached → suffix [10..19]
         # Correct: transfer only uncached suffix tokens (640-959)
         #   = remote [10,11,12,13,14] → local [10,11,12,13,14].
-        # Actual (front-trim): remote[:10]=[0..9] → local [10..19]. Wrong.
         pytest.param(
             10,
             6,
+            640,
+            960,
             list(range(18)),
             list(range(10, 20)),
             [42],
             [10, 11, 12, 13, 14],
             [10, 11, 12, 13, 14],
-            id="local10_remote6_fail",
+            id="local10_remote6",
         ),
     ],
 )
-def test_mismatched_physical_per_logical_fails_with_prefix_caching(
+def test_mismatched_physical_per_logical_uses_token_window(
     local_physical_per_logical,
     remote_physical_per_logical,
+    load_start_token,
+    load_end_token,
     remote_fa_blocks,
     local_fa_blocks,
     ssm_blocks,
     correct_remote_fa,
     correct_local_fa,
 ):
-    """Demonstrate that _apply_prefix_caching front-trims ([:N])
-    in the Mamba hybrid path, which fails when prefix caching produces
-    suffix-only local blocks.
+    """Token-offset pairing avoids prefix/suffix misalignment.
 
-    Prefix caching operates at logical block granularity. When a logical
-    block is cached locally, the decode side only allocates kernel blocks
-    for the uncached suffix. The front-trim pairs remote prefix blocks
-    with local suffix slots — a silent data corruption.
+    Prefix caching can allocate different numbers of padded kernel blocks on
+    P and D. The explicit token window selects the same semantic suffix.
     """
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
         NixlConnectorWorker,
@@ -703,6 +820,7 @@ def test_mismatched_physical_per_logical_fails_with_prefix_caching(
         mamba_enabled=True,
     )
     worker._has_mamba = True
+    worker.block_size = 64
     worker._group_spec_types = tuple(
         type(g.kv_cache_spec) for g in worker.kv_cache_config.kv_cache_groups
     )
@@ -715,16 +833,84 @@ def test_mismatched_physical_per_logical_fails_with_prefix_caching(
         remote_block_ids,
         local_physical_per_logical,
         remote_physical_per_logical,
+        load_start_token=load_start_token,
+        load_end_token=load_end_token,
     )
 
-    assert (
-        aligned_remote[0] != correct_remote_fa or aligned_local[0] != correct_local_fa
-    ), (
-        f"Prefix caching with mismatched physical_per_logical should not "
-        f"produce correct transfer ids: "
-        f"remote={aligned_remote[0]}, local={aligned_local[0]}, "
-        f"correct_remote={correct_remote_fa}, correct_local={correct_local_fa}"
+    assert aligned_remote[0] == correct_remote_fa
+    assert aligned_local[0] == correct_local_fa
+
+
+@pytest.mark.cpu_test
+def test_full_attention_range_uses_token_window():
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
     )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = False
+    worker.block_size = 16
+    worker._group_spec_types = (FullAttentionSpec,)
+
+    local, remote = worker._apply_prefix_caching(
+        ([100, 101],),
+        ([0, 1, 2, 3, 4, 5],),
+        1,
+        1,
+        load_start_token=64,
+        load_end_token=96,
+    )
+
+    assert local == [[100, 101]]
+    assert remote == [[4, 5]]
+
+
+@pytest.mark.cpu_test
+def test_full_attention_range_uses_remote_block_size_window():
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = False
+    worker.block_size = 16
+    worker._group_spec_types = (FullAttentionSpec,)
+
+    local, remote = worker._apply_prefix_caching(
+        ([100, 101],),
+        ([0, 1, 2, 3, 4, 5, 6, 7],),
+        1,
+        1,
+        load_start_token=32,
+        load_end_token=48,
+        block_size_ratio=2,
+    )
+
+    assert local == [[100, 101]]
+    assert remote == [[4, 5]]
+
+
+@pytest.mark.cpu_test
+def test_heterogeneous_hybrid_prefix_cache_rejects_missing_wire_window():
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker._has_mamba = True
+    worker._prefix_caching_enabled = True
+    worker._group_spec_types = (FullAttentionSpec, MambaSpec)
+
+    with pytest.raises(RuntimeError, match="explicit token load range"):
+        worker._apply_prefix_caching(
+            ([10, 11], [20]),
+            ([0, 1, 2], [30]),
+            decode_physical_per_logical=2,
+            prefill_physical_per_logical=3,
+        )
 
 
 @pytest.mark.parametrize("model_name, sw_size", [("google/gemma-3-1b-it", 512)])

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock, patch
 import msgspec
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVLoadRange
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
     NixlAgentMetadata,
@@ -154,6 +155,7 @@ class TestPushScheduler:
         assert reg["decode_port"] == sched.side_channel_port
         assert reg["local_block_ids"] == ([10, 11, 12],)
         assert reg["remote_engine_id"] == "prefill-engine"
+        assert (reg["load_start_token"], reg["load_end_token"]) == (64, 112)
 
         # Watchdog deadline set in the future.
         deadline = sched._push_registration_deadlines[request.request_id]
@@ -162,6 +164,24 @@ class TestPushScheduler:
         assert request.kv_transfer_params["do_remote_prefill"] is False
         # Tracked as awaiting a recv.
         assert request.request_id in sched._reqs_need_recv
+
+    def test_d_side_range_load_registers_only_owned_suffix(self):
+        sched = make_nixl_push_scheduler()
+        sched.get_range_block_ids = MagicMock(return_value=([12, 13],))
+        request = _make_request(request_id="req-d-range")
+        blocks = _BlocksMock(block_ids=([10, 11, 12, 13],))
+
+        sched.update_state_after_alloc_for_range(
+            request,
+            blocks,
+            KVLoadRange(32, 64),
+        )
+
+        registration = sched._push_pending_registrations[request.request_id]
+        assert registration["local_block_ids"] == ([12, 13],)
+        assert registration["load_start_token"] == 32
+        assert registration["load_end_token"] == 64
+        sched.get_range_block_ids.assert_called_once_with(blocks, KVLoadRange(32, 64))
 
     def test_p_side_request_finished_stages_blocks(self):
         """P scheduler pushes blocks into both _finished_request_blocks (lease)
@@ -391,6 +411,8 @@ def _registration_data(
     remote_host: str = "10.0.0.1",
     remote_port: int = 5601,
     remote_tp_size: int = 1,
+    load_start_token: int = 0,
+    load_end_token: int = 0,
 ) -> dict[str, Any]:
     return {
         "request_id": request_id,
@@ -403,6 +425,8 @@ def _registration_data(
         "remote_host": remote_host,
         "remote_port": remote_port,
         "remote_tp_size": remote_tp_size,
+        "load_start_token": load_start_token,
+        "load_end_token": load_end_token,
     }
 
 
@@ -601,6 +625,7 @@ def test_do_start_push_kv_defers_then_writes_when_handshake_ready():
     assert meta.remote.engine_id == "decode-engine"
     # RemoteMeta.request_id is D's request id from the registration.
     assert meta.remote.request_id == "req-hs"
+    assert (meta.load_start_token, meta.load_end_token) == (0, 0)
 
 
 def test_do_start_push_kv_drops_request_on_handshake_failure():
@@ -1336,7 +1361,12 @@ class TestPushPrefixCaching:
         """D registered only its 2 uncomputed suffix blocks; P finished the
         full 5-block sequence. P must WRITE its LAST 2 blocks into D's slots."""
         w, _ = self._worker_driving_xfer()
-        reg = _registration_data("req-pc", local_block_ids=([500, 501],))
+        reg = _registration_data(
+            "req-pc",
+            local_block_ids=([500, 501],),
+            load_start_token=48,
+            load_end_token=80,
+        )
 
         NixlPushConnectorWorker._do_start_push_kv(
             w, "req-pc", ([10, 11, 12, 13, 14],), reg
@@ -1357,3 +1387,28 @@ class TestPushPrefixCaching:
         local, remote = self._written_block_ids(w)
         assert local == [10, 11, 12]
         assert remote == [500, 501, 502]
+
+    def test_heterogeneous_logical_pages_use_token_window(self):
+        w, _ = self._worker_driving_xfer()
+        w._has_mamba = True
+        w._physical_blocks_per_logical_kv_block = 10
+        remote_info = w.transfer_topo.get_engine_info.return_value
+        remote_info.remote_physical_blocks_per_logical = 6
+        w._compute_desc_ids = lambda block_ids, **_: list(block_ids[0])
+        reg = _registration_data(
+            "req-hetero",
+            local_block_ids=([500, 501, 502, 503],),
+            load_start_token=96,
+            load_end_token=160,
+        )
+
+        NixlPushConnectorWorker._do_start_push_kv(
+            w,
+            "req-hetero",
+            (list(range(10)),),
+            reg,
+        )
+
+        local, remote = self._written_block_ids(w)
+        assert local == [6, 7, 8, 9]
+        assert remote == [500, 501, 502, 503]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -43,6 +43,7 @@ The class provides the following primitives:
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -78,6 +79,26 @@ CopyBlocksOp = Callable[
     ],
     None,
 ]
+
+
+@dataclass(frozen=True)
+class KVLoadRange:
+    """Half-open absolute token range assigned to one connector.
+
+    A boundary shared by two sources is aligned for both connectors and the
+    scheduler's KV block layout. Only a terminal range may end in a partial
+    scheduler block.
+    """
+
+    start_token: int
+    end_token: int
+    # The terminal range owns any recurrent state at end_token.
+    is_terminal: bool = True
+
+    @property
+    def num_tokens(self) -> int:
+        return self.end_token - self.start_token
+
 
 logger = init_logger(__name__)
 
@@ -506,6 +527,41 @@ class KVConnectorBase_V1(ABC):
                 external KV cache. 0 means nothing should be loaded.
         """
         pass
+
+    @property
+    def supports_load_range(self) -> bool:
+        """Whether this connector accepts an explicitly assigned load range.
+
+        MultiConnector only composes children whose lookup results agree on
+        synchronous versus asynchronous loading; otherwise it uses one child.
+        """
+        return False
+
+    @property
+    def load_range_alignment(self) -> int | None:
+        """Additional positive alignment for inter-source boundaries.
+
+        MultiConnector combines this value with the scheduler block size and
+        the neighboring connector's requirement. ``None`` adds no constraint.
+        """
+        return None
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> None:
+        """Load an absolute token range into the request's allocated blocks.
+
+        ``blocks`` is the request's complete allocated block table, not a view
+        sliced to ``load_range``. Implementations must locate each KV group's
+        destination blocks from the absolute token offsets. A later
+        ``update_state_after_alloc(request, blocks, 0)`` is allowed and must
+        remain a no-load operation. Load failures follow the
+        ``get_block_ids_with_load_errors`` contract.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def build_connector_meta(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -3,6 +3,7 @@
 import copy
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from math import lcm
 from typing import TYPE_CHECKING, Any, cast
 
 import torch
@@ -18,6 +19,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorRole,
     KVConnectorWorkerMetadata,
+    KVLoadRange,
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -28,6 +30,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
 )
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 
@@ -46,6 +49,7 @@ logger = init_logger(__name__)
 class MultiKVConnectorMetadata(KVConnectorMetadata):
     metadata: tuple[KVConnectorMetadata, ...]
     extra_async_saves: dict[str, int] | None = None
+    pending_async_loads: dict[str, tuple[int, ...]] | None = None
 
 
 @dataclass
@@ -116,7 +120,7 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
         metric_types: dict[type[PromMetric], type[PromMetricT]],
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
-        prom_metrics: dict[str, KVConnectorPromMetrics],
+        prom_metrics: dict[str, KVConnectorPromMetrics | None],
     ):
         super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
         self._prom_metrics = prom_metrics
@@ -124,20 +128,23 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         for connector_id, stats_data in transfer_stats_data.items():
             assert connector_id in self._prom_metrics, (
-                f"{connector_id} is not contained in the list of registered connectors "
-                f"with Prometheus metrics support: {self._prom_metrics.keys()}"
+                f"{connector_id} is not a configured connector: "
+                f"{self._prom_metrics.keys()}"
             )
-            self._prom_metrics[connector_id].observe(stats_data, engine_idx)
+            if connector_prom := self._prom_metrics[connector_id]:
+                connector_prom.observe(stats_data, engine_idx)
 
 
 class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     """
     A wrapper for using multiple KVConnectors at the same time.
 
-    The current logic is:
-    - Load KV from the first connector that advertises available tokens from
-      get_num_new_matched_tokens(), based on the order in the config.
+    The default logic is:
+    - Load KV from the first connector that advertises available tokens.
     - Save to all connectors.
+
+    With ``load_policy=range_aware``, ordered connectors may load contiguous,
+    non-overlapping ranges of the same prefix.
     """
 
     @classmethod
@@ -181,6 +188,12 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config
         )
 
+        assert vllm_config.kv_transfer_config is not None
+        extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
+        load_policy = extra_config.get("load_policy")
+        if load_policy not in (None, "range_aware"):
+            raise ValueError(f"Unknown MultiConnector load_policy: {load_policy!r}")
+
         self._connectors: list[KVConnectorBase_V1] = []
         self._ktc_kv_transfer_config = []
         for connector_cls, temp_config in self._get_connector_classes_and_configs(
@@ -189,7 +202,21 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             self._connectors.append(connector_cls(temp_config, role, kv_cache_config))
             self._ktc_kv_transfer_config.append(temp_config.kv_transfer_config)
 
-        assert vllm_config.kv_transfer_config is not None
+        self._range_load = load_policy == "range_aware"
+        self._scheduler_block_size = None
+        if self._range_load:
+            if (
+                role == KVConnectorRole.SCHEDULER
+                and kv_cache_config.has_mamba_layers
+                and not all(c.supports_load_range for c in self._connectors)
+            ):
+                raise ValueError(
+                    "MultiConnector range_aware loading with recurrent KV cache "
+                    "groups requires every child connector to support range loads"
+                )
+            self._scheduler_block_size, _ = resolve_kv_cache_block_sizes(
+                kv_cache_config, vllm_config
+            )
         self._all_support_hma = MultiConnector.all_children_support_hma(
             vllm_config.kv_transfer_config
         )
@@ -201,11 +228,15 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         # A mapping from request id to the index of the connector chosen to
         # load the request from (if any).
         self._requests_to_connector: dict[str, int] = {}
+        self._request_load_ranges: dict[str, dict[int, KVLoadRange]] = {}
+        self._request_async_loads: dict[str, tuple[int, ...]] = {}
+        self._async_loads_to_send: dict[str, tuple[int, ...]] = {}
+        self._async_load_sources: dict[str, set[int]] = {}
+        self._pending_async_loads: dict[str, set[int]] = {}
 
         # Keeps track of *additional* remaining async saves (beyond 1) to be
-        # finished per request. Not needed for async loads since we only allow
-        # a single connector to load.
-        # Propagated from scheduler to worker side via the connector metadata.
+        # finished per request. Propagated from scheduler to worker side via
+        # the connector metadata.
         self._extra_async_saves: dict[str, int] = {}
 
     @property
@@ -263,6 +294,20 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(connector_metadata, MultiKVConnectorMetadata)
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        if self._range_load and connector_metadata.pending_async_loads:
+            sources = {
+                req_id: set(connector_ids)
+                for req_id, connector_ids in (
+                    connector_metadata.pending_async_loads.items()
+                )
+            }
+            self._async_load_sources.update(sources)
+            self._pending_async_loads.update(
+                {
+                    req_id: set(connector_ids)
+                    for req_id, connector_ids in sources.items()
+                }
+            )
         for c, cm in zip(self._connectors, connector_metadata.metadata):
             c.bind_connector_metadata(cm)
         super().bind_connector_metadata(connector_metadata)
@@ -315,12 +360,32 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     ) -> tuple[set[str] | None, set[str] | None]:
         finished_sending: set[str] = set()
         finished_recving: set[str] = set()
-        for c in self._connectors:
+        if self._range_load and self._async_load_sources:
+            for req_id in finished_req_ids:
+                self._pending_async_loads.pop(req_id, None)
+                self._async_load_sources.pop(req_id, None)
+
+        for i, c in enumerate(self._connectors):
             sending, recving = c.get_finished(finished_req_ids)
             if not recving and not sending:
                 continue
-            # Aggregate finished recving request ids.
-            finished_recving.update(recving or ())
+            if not self._range_load:
+                finished_recving.update(recving or ())
+            else:
+                for req_id in recving or ():
+                    sources = self._async_load_sources.get(req_id)
+                    if sources is not None and i not in sources:
+                        continue
+                    pending = self._pending_async_loads.get(req_id)
+                    if sources is not None and pending is None:
+                        continue
+                    if pending is None:
+                        finished_recving.add(req_id)
+                        continue
+                    pending.discard(i)
+                    if not pending:
+                        del self._pending_async_loads[req_id]
+                        finished_recving.add(req_id)
             # Aggregate finished sending request ids - only include
             # once we've drained the "extra" count (for cases where
             # more than one connector is async-saving the same request).
@@ -389,13 +454,42 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     # ==============================
     # Scheduler-side methods
     # ==============================
+    def _effective_load_range_alignment(self, connector: KVConnectorBase_V1) -> int:
+        assert self._scheduler_block_size is not None
+        connector_alignment = connector.load_range_alignment
+        if connector_alignment is None:
+            return self._scheduler_block_size
+        if connector_alignment <= 0:
+            raise ValueError(
+                "Connector load_range_alignment must be positive, got "
+                f"{connector_alignment} for {connector.__class__.__name__}"
+            )
+        return lcm(self._scheduler_block_size, connector_alignment)
+
     def get_num_new_matched_tokens(
         self,
         request: "Request",
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
-        to_return = (0, False)
-        for i, c in enumerate(self._connectors):
+        if not self._range_load:
+            to_return = (0, False)
+            for i, c in enumerate(self._connectors):
+                toks, load_async = c.get_num_new_matched_tokens(
+                    request, num_computed_tokens
+                )
+                if toks is None:
+                    return (None, False)
+                if to_return[0] == 0 and toks > 0:
+                    self._requests_to_connector[request.request_id] = i
+                    to_return = (toks, load_async)
+            return to_return
+
+        req_id = request.request_id
+        self._requests_to_connector.pop(req_id, None)
+        self._request_load_ranges.pop(req_id, None)
+        self._request_async_loads.pop(req_id, None)
+        matches: list[tuple[int, bool]] = []
+        for c in self._connectors:
             toks, load_async = c.get_num_new_matched_tokens(
                 request, num_computed_tokens
             )
@@ -403,17 +497,126 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             # we return None to indicate that we are not done yet.
             if toks is None:
                 return (None, False)
-            # The first connector that has new matched tokens will be assigned
-            # to this request.
-            if to_return[0] == 0 and toks > 0:
-                self._requests_to_connector[request.request_id] = i
-                to_return = (toks, load_async)
-        return to_return
+            matches.append((toks, load_async))
+
+        covered = num_computed_tokens
+        ranges: dict[int, KVLoadRange] = {}
+        for i, ((toks, load_async), connector) in enumerate(
+            zip(matches, self._connectors)
+        ):
+            endpoint = num_computed_tokens + toks
+            if endpoint <= covered:
+                continue
+            if ranges:
+                if not connector.supports_load_range:
+                    continue
+                alignment = self._effective_load_range_alignment(connector)
+                previous_connector = next(reversed(ranges))
+                previous = self._connectors[previous_connector]
+                if previous.supports_load_range:
+                    alignment = lcm(
+                        alignment,
+                        self._effective_load_range_alignment(previous),
+                    )
+                if covered % alignment:
+                    aligned_covered = covered // alignment * alignment
+                    if not previous.supports_load_range:
+                        return self._select_single_load(req_id, matches)
+                    previous_range = ranges[previous_connector]
+                    if aligned_covered <= previous_range.start_token:
+                        break
+                    ranges[previous_connector] = KVLoadRange(
+                        previous_range.start_token,
+                        aligned_covered,
+                        is_terminal=False,
+                    )
+                    covered = aligned_covered
+            elif (
+                connector.supports_load_range
+                and covered % self._effective_load_range_alignment(connector)
+            ):
+                continue
+            ranges[i] = KVLoadRange(covered, endpoint, is_terminal=False)
+            covered = endpoint
+
+        if not ranges:
+            return self._select_single_load(req_id, matches)
+
+        terminal_connector = next(reversed(ranges))
+        terminal_range = ranges[terminal_connector]
+        ranges[terminal_connector] = KVLoadRange(
+            terminal_range.start_token,
+            terminal_range.end_token,
+            is_terminal=True,
+        )
+
+        if len(ranges) == 1:
+            return self._select_single_load(req_id, matches)
+
+        async_loads = tuple(i for i in ranges if matches[i][1])
+        if async_loads and len(async_loads) != len(ranges):
+            # A range request has one scheduler-level completion state. Mixing
+            # sync and async children can acknowledge tokens that a sync child
+            # has not loaded in the step where the request is parked.
+            return self._select_single_load(req_id, matches)
+
+        longest_single = max(matches, key=lambda match: match[0])
+        if longest_single[0] > covered - num_computed_tokens:
+            return self._select_single_load(req_id, matches)
+
+        self._request_load_ranges[req_id] = ranges
+        if async_loads:
+            self._request_async_loads[req_id] = async_loads
+        return covered - num_computed_tokens, bool(async_loads)
+
+    def _select_single_load(
+        self, request_id: str, matches: list[tuple[int, bool]]
+    ) -> tuple[int, bool]:
+        """Fall back to the connector with the longest complete prefix."""
+        chosen = max(range(len(matches)), key=lambda i: matches[i][0])
+        toks, load_async = matches[chosen]
+        if toks > 0:
+            self._requests_to_connector[request_id] = chosen
+            if load_async:
+                self._request_async_loads[request_id] = (chosen,)
+        return (toks, load_async) if toks > 0 else (0, False)
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ):
-        chosen_connector = self._requests_to_connector.get(request.request_id, -1)
+        req_id = request.request_id
+        if self._range_load:
+            load_ranges = self._request_load_ranges.pop(req_id, None)
+            async_loads = self._request_async_loads.pop(req_id, None)
+            if load_ranges is not None:
+                expected_tokens = sum(r.num_tokens for r in load_ranges.values())
+                if num_external_tokens == 0:
+                    load_ranges = None
+                elif num_external_tokens != expected_tokens:
+                    raise ValueError(
+                        "Range load token count changed after lookup: "
+                        f"expected {expected_tokens}, got {num_external_tokens} "
+                        f"for request {req_id}"
+                    )
+            if num_external_tokens > 0 and async_loads:
+                self._async_loads_to_send[req_id] = async_loads
+            if load_ranges is not None:
+                first_connector = next(iter(load_ranges))
+                for i, c in enumerate(self._connectors):
+                    load_range = load_ranges.get(i)
+                    if load_range is None:
+                        c.update_state_after_alloc(request, blocks, 0)
+                    elif i == first_connector and not c.supports_load_range:
+                        c.update_state_after_alloc(
+                            request, blocks, load_range.num_tokens
+                        )
+                    else:
+                        c.update_state_after_alloc_for_range(
+                            request, blocks, load_range
+                        )
+                return
+
+        chosen_connector = self._requests_to_connector.get(req_id, -1)
         for i, c in enumerate(self._connectors):
             if i == chosen_connector:
                 # Forward call to the chosen connector (if any).
@@ -437,6 +640,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         if self._extra_async_saves:
             metadata.extra_async_saves = self._extra_async_saves
             self._extra_async_saves = {}
+        if self._range_load and self._async_loads_to_send:
+            metadata.pending_async_loads = self._async_loads_to_send
+            self._async_loads_to_send = {}
         return metadata
 
     def update_connector_output(self, connector_output: KVConnectorOutput):
@@ -515,6 +721,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             self._extra_async_saves[request.request_id] = async_saves - 1
 
         self._requests_to_connector.pop(request.request_id, None)
+        self._request_load_ranges.pop(request.request_id, None)
+        self._request_async_loads.pop(request.request_id, None)
+        self._async_loads_to_send.pop(request.request_id, None)
 
         return async_saves > 0, kv_txfer_params
 
@@ -657,7 +866,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
     ) -> KVConnectorPromMetrics:
-        prom_metrics: dict[str, KVConnectorPromMetrics] = {}
+        prom_metrics: dict[str, KVConnectorPromMetrics | None] = {}
         seen_classes: set[type] = set()
         for connector_cls, temp_config in cls._get_connector_classes_and_configs(
             vllm_config
@@ -668,8 +877,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             connector_prom = connector_cls.build_prom_metrics(
                 temp_config, metric_types, labelnames, per_engine_labelvalues
             )
-            if connector_prom is not None:
-                prom_metrics[connector_cls.__name__] = connector_prom
+            prom_metrics[connector_cls.__name__] = connector_prom
         return MultiKVConnectorPromMetrics(
             vllm_config,
             metric_types,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -18,6 +18,7 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
+    KVLoadRange,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     GET_META_MSG,
@@ -31,11 +32,16 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import make_zmq_path
+from vllm.v1.core.kv_cache_utils import (
+    resolve_dcp_kv_block_size,
+    resolve_kv_cache_block_sizes,
+)
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     MambaSpec,
     SlidingWindowSpec,
+    iter_layer_specs,
 )
 
 if TYPE_CHECKING:
@@ -85,17 +91,27 @@ class NixlBaseConnectorScheduler:
             self.use_host_buffer = (
                 vllm_config.kv_transfer_config.kv_buffer_device == "cpu"
             )
+        transfer_specs = tuple(
+            next(iter(iter_layer_specs(group.kv_cache_spec)))
+            for group in kv_cache_config.transfer_groups
+        )
         self._is_hma_required = (
             not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
             # Also handle unlikely SW-only model case instead of checking num_groups>1.
-            and any(
-                not isinstance(g.kv_cache_spec, FullAttentionSpec)
-                for g in kv_cache_config.transfer_groups
-            )
+            and any(not isinstance(spec, FullAttentionSpec) for spec in transfer_specs)
         )
-        self._has_mamba = any(
-            isinstance(g.kv_cache_spec, MambaSpec)
-            for g in kv_cache_config.transfer_groups
+        self._has_mamba = any(isinstance(spec, MambaSpec) for spec in transfer_specs)
+        self._scheduler_block_size, _ = resolve_kv_cache_block_sizes(
+            kv_cache_config, vllm_config
+        )
+        dcp_size = vllm_config.parallel_config.decode_context_parallel_size
+        self._range_group_block_sizes = tuple(
+            resolve_dcp_kv_block_size(group.kv_cache_spec, dcp_size)
+            for group in kv_cache_config.kv_cache_groups
+        )
+        self._range_transfer_group_block_sizes = tuple(
+            resolve_dcp_kv_block_size(group.kv_cache_spec, dcp_size)
+            for group in kv_cache_config.transfer_groups
         )
 
         logger.info("Initializing NIXL Scheduler %s", engine_id)
@@ -110,7 +126,8 @@ class NixlBaseConnectorScheduler:
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
         self._reqs_need_recv: dict[
-            ReqId, tuple[Request, BlockIds, tuple[int, ...]]
+            ReqId,
+            tuple[Request, BlockIds, tuple[int, ...], int, int],
         ] = {}
         self._reqs_need_save: dict[ReqId, Request] = {}
         # Reqs to send and their expiration time
@@ -130,10 +147,10 @@ class NixlBaseConnectorScheduler:
         # Gather Sliding Window sizes for each kv cache group (if any) in number of
         # blocks per KV cache group. This is used to clip the local attention window.
         sw_sizes_tokens: list[tuple[int, int]] = [
-            (g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size)
-            if isinstance(g.kv_cache_spec, SlidingWindowSpec)
+            (spec.sliding_window, spec.block_size)
+            if isinstance(spec, SlidingWindowSpec)
             else (0, self.block_size)
-            for g in kv_cache_config.transfer_groups
+            for spec in transfer_specs
         ]
         # cdiv(n_tokens, block_size) gives blocks/window; add 1 to conservatively
         # account for boundary overlap eg window isn't fully aligned with blocks.
@@ -145,10 +162,8 @@ class NixlBaseConnectorScheduler:
         # Trailing scratch slots that mamba managers co-allocate per request
         # for speculative decoding; None for non-SSM groups.
         self._ssm_spec_blocks = [
-            g.kv_cache_spec.num_speculative_blocks
-            if isinstance(g.kv_cache_spec, MambaSpec)
-            else None
-            for g in kv_cache_config.transfer_groups
+            spec.num_speculative_blocks if isinstance(spec, MambaSpec) else None
+            for spec in transfer_specs
         ]
         # Only "all" mode keeps a state per block position; the other modes
         # keep a single running state in the last non-speculative slot.
@@ -292,6 +307,46 @@ class NixlBaseConnectorScheduler:
                     blocks = blocks[-1:]
             clipped.append(blocks)
         return tuple(clipped)
+
+    @property
+    def supports_load_range(self) -> bool:
+        return True
+
+    @property
+    def load_range_alignment(self) -> int:
+        return self._scheduler_block_size
+
+    def get_range_block_ids(
+        self,
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> BlockIds:
+        """Return destination blocks owned by a piecewise load range."""
+        assert load_range.start_token % self._scheduler_block_size == 0
+        block_ids = blocks.get_block_ids()
+        selected: list[list[int]] = []
+        for group, cache_group, block_size in zip(
+            block_ids,
+            self.kv_cache_config.kv_cache_groups,
+            self._range_group_block_sizes,
+            strict=True,
+        ):
+            if any(
+                isinstance(spec, MambaSpec)
+                for spec in iter_layer_specs(cache_group.kv_cache_spec)
+            ):
+                selected.append(list(group) if load_range.is_terminal else [])
+                continue
+            start_block = load_range.start_token // block_size
+            end_block = cdiv(load_range.end_token, block_size)
+            selected.append(list(group[start_block:end_block]))
+        return self.get_exchange_clipped_blocks(tuple(selected))
+
+    def get_range_start_blocks(self, load_range: KVLoadRange) -> tuple[int, ...]:
+        return tuple(
+            load_range.start_token // block_size
+            for block_size in self._range_transfer_group_block_sizes
+        )
 
     def set_xfer_handshake_metadata(
         self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
@@ -456,13 +511,21 @@ class NixlBaseConnectorScheduler:
         meta = NixlConnectorMetadata()
 
         # Loop through scheduled reqs and convert to ReqMeta.
-        for req_id, (req, block_ids, cached) in self._reqs_need_recv.items():
+        for req_id, (
+            req,
+            block_ids,
+            cached,
+            load_start_token,
+            load_end_token,
+        ) in self._reqs_need_recv.items():
             assert req.kv_transfer_params is not None
             meta.add_new_req_to_recv(
                 request_id=req_id,
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
                 local_num_computed_blocks=cached,
+                load_start_token=load_start_token,
+                load_end_token=load_end_token,
             )
 
         if self.use_host_buffer:
@@ -511,6 +574,14 @@ class NixlBaseConnectorScheduler:
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ):
+        raise NotImplementedError
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> None:
         raise NotImplementedError
 
     def request_finished(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -48,6 +48,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
     TPMapping,
     _is_attention_spec,
+    _is_full_attention_spec,
     _is_ssm_spec,
     compute_tp_mapping,
 )
@@ -69,6 +70,7 @@ from vllm.distributed.parallel_state import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import make_zmq_path
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.kv_cache_interface import (
@@ -142,6 +144,8 @@ def _uses_dense_virtual_transfer_pages(
 
 class NixlBaseConnectorWorker:
     """Base implementation of Worker side methods shared by pull and push."""
+
+    _prefix_caching_enabled = False
 
     # Transfer mode included in the NIXL compatibility hash so that a push
     # (WRITE) connector and a pull (READ) connector never handshake together.
@@ -630,6 +634,7 @@ class NixlBaseConnectorWorker:
         )
 
         self.block_size = vllm_config.cache_config.block_size
+        self._prefix_caching_enabled = vllm_config.cache_config.enable_prefix_caching
         self.model_config = vllm_config.model_config
 
         self.use_mla = self.model_config.use_mla
@@ -1997,13 +2002,35 @@ class NixlBaseConnectorWorker:
             != self._physical_blocks_per_logical_kv_block
             and self.vllm_config.cache_config.enable_prefix_caching
         ):
-            raise RuntimeError(
+            base_err = (
                 "Prefix caching with heterogeneous physical_blocks_per_logical "
-                "is not supported for Mamba hybrid models. "
-                f"Local: {self._physical_blocks_per_logical_kv_block}, "
-                f"Remote: {remote_physical_per_logical}. "
-                "Disable prefix caching with --no-enable-prefix-caching."
+                f"(local: {self._physical_blocks_per_logical_kv_block}, "
+                f"remote: {remote_physical_per_logical}) "
             )
+            if self.use_host_buffer:
+                raise RuntimeError(
+                    base_err + "requires a supported device-buffer transfer path."
+                )
+            if block_size_ratio != 1:
+                raise RuntimeError(
+                    base_err + "requires matching kernel block sizes. "
+                    f"Local: {self.block_size}, remote: {nixl_agent_meta.block_size}."
+                )
+            if self.dcp_size > 1 or remote_info.remote_dcp_size > 1:
+                raise RuntimeError(
+                    base_err + "is not supported with decode context parallelism."
+                )
+            if any(
+                _is_attention_spec(t) and not _is_full_attention_spec(t)
+                for t in self._group_spec_types
+            ):
+                raise RuntimeError(
+                    base_err + "is not supported with sliding-window attention groups."
+                )
+            if self.vllm_config.cache_config.mamba_cache_mode == "all":
+                raise RuntimeError(
+                    base_err + "requires a non-positional Mamba cache mode."
+                )
 
         if block_size_ratio != 1:
             # Heterogeneous block sizes transfer at remote-block granularity;
@@ -2368,8 +2395,7 @@ class NixlBaseConnectorWorker:
             # transfer clipped. The latter happens either at remote-block
             # granularity (block_size_ratio > 1) or at kernel-block
             # granularity, when equal kernel pages meet differing logical
-            # block sizes and _apply_prefix_caching front-trims to the
-            # minimum count (hybrid heterogeneous TP).
+            # block sizes and _apply_prefix_caching selects a token window.
             remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
             block_size_ratio = self.transfer_topo.block_size_ratio(
                 remote_info.remote_block_size
@@ -2378,16 +2404,34 @@ class NixlBaseConnectorWorker:
                 remote_info.remote_physical_blocks_per_logical
                 != self._physical_blocks_per_logical_kv_block
             )
-            if block_size_ratio > 1 or self.enable_permute_local_kv or hetero_ppl:
+            windowed = (
+                meta.load_end_token > meta.load_start_token
+                and self.dcp_size == 1
+                and remote_info.remote_dcp_size == 1
+            )
+            if (
+                block_size_ratio > 1
+                or self.enable_permute_local_kv
+                or hetero_ppl
+                or windowed
+            ):
                 for g, local_group in enumerate(meta.local_physical_block_ids):
                     if not local_group or _is_ssm_spec(self._group_spec_types[g]):
                         continue
                     # Number of remote-sized sub-blocks the transfer covered;
                     # everything past this was clipped and must be zeroed.
-                    covered_sub_blocks = min(
-                        len(local_group) * block_size_ratio,
-                        len(meta.remote.block_ids[g]),
-                    )
+                    if windowed and _is_full_attention_spec(self._group_spec_types[g]):
+                        _, covered_sub_blocks = self._kernel_block_window(
+                            meta.load_start_token,
+                            meta.load_end_token,
+                            block_size_ratio,
+                        )
+                        assert len(local_group) * block_size_ratio >= covered_sub_blocks
+                    else:
+                        covered_sub_blocks = min(
+                            len(local_group) * block_size_ratio,
+                            len(meta.remote.block_ids[g]),
+                        )
                     block_ids_for_blocksize_post_process[block_size_ratio].append(
                         (local_group, covered_sub_blocks)
                     )
@@ -2718,41 +2762,86 @@ class NixlBaseConnectorWorker:
         matched_blocks = min(len(local_slice), len(remote_slice))
         return local_slice[:matched_blocks], remote_slice[:matched_blocks]
 
+    def _kernel_block_window(
+        self,
+        load_start_token: int,
+        load_end_token: int,
+        block_size_ratio: int = 1,
+    ) -> tuple[int, int]:
+        """Return the remote-granularity block start and transfer count."""
+        assert 0 <= load_start_token <= load_end_token
+        assert block_size_ratio >= 1
+        assert self.block_size % block_size_ratio == 0
+        transfer_block_size = self.block_size // block_size_ratio
+        assert load_start_token % transfer_block_size == 0, (
+            f"Load start {load_start_token} is not aligned to transfer block size "
+            f"{transfer_block_size}"
+        )
+        start = load_start_token // transfer_block_size
+        return start, cdiv(load_end_token, transfer_block_size) - start
+
+    def _slice_attention_to_load_window(
+        self,
+        decode_blocks: list[int],
+        prefill_blocks: list[int],
+        load_start_token: int,
+        load_end_token: int,
+        block_size_ratio: int = 1,
+    ) -> tuple[list[int], list[int]]:
+        start, count = self._kernel_block_window(
+            load_start_token, load_end_token, block_size_ratio
+        )
+        assert len(decode_blocks) >= count
+        assert len(prefill_blocks) >= start + count
+        return decode_blocks[:count], prefill_blocks[start : start + count]
+
     def _apply_prefix_caching(
         self,
         decode_block_ids: BlockIds,
         prefill_block_ids: BlockIds,
         decode_physical_per_logical: int,
         prefill_physical_per_logical: int,
+        load_start_token: int = 0,
+        load_end_token: int = 0,
+        block_size_ratio: int = 1,
     ) -> tuple[BlockIds, BlockIds]:
-        """Trim block ID lists so only the uncomputed suffix is transferred.
+        """Pair Decode destinations with the same Prefill token window.
 
-        Inputs are *kernel* (physical) block IDs, already expanded from logical IDs
-        with each side's physical-per-logical ratio. Both pull and push call this after
-        that expansion so the trim happens at kernel granularity.
-
-        The prefix-cache hit is always on the decode (D) side, so ``decode``
-        holds only its uncomputed blocks while prefill (P) holds the full
-        sequence. This is mode-independent: pull passes its own (D) blocks as
-        ``decode``, push passes the remote D registration as ``decode``.
-
-        For non-Mamba models: end-trim ``prefill`` to match ``decode`` count, so
-        already-cached prefix blocks are skipped in the transfer.
-
-        For Mamba hybrid: SSM groups pair state slots by position and FA
-        groups end-trim to the uncomputed suffix when physical-per-logical
-        matches.
+        Inputs are kernel-block IDs. Without an explicit window this preserves
+        the legacy suffix trim. Recurrent-state groups are paired by position.
         """
-        # Partial prefix cache hit: just transfer uncomputed blocks.
-        # Skip mamba groups — their blocks represent full state (conv+ssm),
-        # not per-token data, so trimming would corrupt the transfer.
         prefill_block_ids = list(prefill_block_ids)
+        has_window = load_end_token > load_start_token
+        if (
+            self._has_mamba
+            and decode_physical_per_logical != prefill_physical_per_logical
+            and not has_window
+            and self._prefix_caching_enabled
+        ):
+            raise RuntimeError(
+                "Hybrid prefix caching with heterogeneous logical block sizes "
+                "requires an explicit token load range."
+            )
         if not self._has_mamba:
+            decode_block_ids = list(decode_block_ids)
             for i, prefill_group in enumerate(prefill_block_ids):
                 num_decode_blocks = len(decode_block_ids[i])
+                if has_window and _is_full_attention_spec(self._group_spec_types[i]):
+                    decode_block_ids[i], prefill_block_ids[i] = (
+                        self._slice_attention_to_load_window(
+                            decode_block_ids[i],
+                            prefill_group,
+                            load_start_token,
+                            load_end_token,
+                            block_size_ratio,
+                        )
+                    )
+                    continue
                 assert num_decode_blocks <= len(prefill_group)
                 if num_decode_blocks < len(prefill_group):
-                    prefill_block_ids[i] = prefill_group[-num_decode_blocks:]
+                    prefill_block_ids[i] = (
+                        prefill_group[-num_decode_blocks:] if num_decode_blocks else []
+                    )
         else:
             # (NOTE: ZhanqiuHu) HeteroTP can cause different kernel block counts
             # due to logical block rounding.
@@ -2772,7 +2861,12 @@ class NixlBaseConnectorWorker:
             for i, prefill_group in enumerate(prefill_block_ids):
                 num_decode_blocks = len(decode_block_ids[i])
                 num_prefill_blocks = len(prefill_group)
+                if num_decode_blocks == num_prefill_blocks == 0:
+                    continue
                 if _is_ssm_spec(self._group_spec_types[i]):
+                    if num_decode_blocks == 0:
+                        prefill_block_ids[i] = []
+                        continue
                     if num_decode_blocks == num_prefill_blocks:
                         continue
                     # Only state-bearing slots reach here, single-state modes
@@ -2791,12 +2885,24 @@ class NixlBaseConnectorWorker:
                         prefill_block_ids[i] = prefill_group[-num_blocks:]
                     else:
                         decode_block_ids[i] = decode_block_ids[i][:num_blocks]
+                elif has_window and _is_full_attention_spec(self._group_spec_types[i]):
+                    decode_block_ids[i], prefill_block_ids[i] = (
+                        self._slice_attention_to_load_window(
+                            decode_block_ids[i],
+                            prefill_group,
+                            load_start_token,
+                            load_end_token,
+                            block_size_ratio,
+                        )
+                    )
                 elif (
                     decode_physical_per_logical == prefill_physical_per_logical
                     and num_decode_blocks < num_prefill_blocks
                 ):
                     # Partial prefix cache hit for FA group.
-                    prefill_block_ids[i] = prefill_group[-num_decode_blocks:]
+                    prefill_block_ids[i] = (
+                        prefill_group[-num_decode_blocks:] if num_decode_blocks else []
+                    )
                 else:
                     # TODO Handle prefix caching with different block_sizes
                     # Allocation rounding legitimately leaves up to

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -26,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
     KVConnectorRole,
+    KVLoadRange,
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -181,6 +182,29 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.update_state_after_alloc(
             request, blocks, num_external_tokens
+        )
+
+    @property
+    def supports_load_range(self) -> bool:
+        return bool(
+            self.connector_scheduler and self.connector_scheduler.supports_load_range
+        )
+
+    @property
+    def load_range_alignment(self) -> int | None:
+        if self.connector_scheduler is None:
+            return None
+        return self.connector_scheduler.load_range_alignment
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.update_state_after_alloc_for_range(
+            request, blocks, load_range
         )
 
     def build_connector_meta(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -46,8 +46,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   8: Add dcp_size and pcp_size to NixlAgentMetadata
 #   9: Add block_strides
 #  10: Add dense virtual transfer pages for compressed MLA caches
+#  11: Add explicit token windows to range-load metadata
 #
-NIXL_CONNECTOR_VERSION: int = 10
+NIXL_CONNECTOR_VERSION: int = 11
 
 
 @dataclass
@@ -241,6 +242,9 @@ class ReqMeta:
     remote_block_size: int | None = None
     # Remote producer pipeline-parallel size (push mode, D side).
     pp_size: int = 1
+    # Token range loaded from the remote. An end of 0 means unspecified.
+    load_start_token: int = 0
+    load_end_token: int = 0
 
 
 class NixlConnectorMetadata(KVConnectorMetadata):
@@ -270,6 +274,8 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         local_block_ids: BlockIds,
         kv_transfer_params: dict[str, Any],
         local_num_computed_blocks: tuple[int, ...] = (),
+        load_start_token: int = 0,
+        load_end_token: int = 0,
     ) -> ReqMeta:
         return ReqMeta(
             local_block_ids=local_block_ids,
@@ -280,6 +286,8 @@ class NixlConnectorMetadata(KVConnectorMetadata):
             remote_block_size=kv_transfer_params.get("remote_block_size"),
             pp_size=kv_transfer_params.get("pp_size", 1),
             local_num_computed_blocks=local_num_computed_blocks,
+            load_start_token=load_start_token,
+            load_end_token=load_end_token,
         )
 
     def add_new_req_to_save(
@@ -298,9 +306,15 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         local_block_ids: BlockIds,
         kv_transfer_params: dict[str, Any],
         local_num_computed_blocks: tuple[int, ...] = (),
+        load_start_token: int = 0,
+        load_end_token: int = 0,
     ):
         req = self._add_new_req(
-            local_block_ids, kv_transfer_params, local_num_computed_blocks
+            local_block_ids,
+            kv_transfer_params,
+            local_num_computed_blocks,
+            load_start_token,
+            load_end_token,
         )
         req.remote = RemoteMeta(
             block_ids=kv_transfer_params["remote_block_ids"],

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -6,6 +6,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVLoadRange
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
     NixlBaseConnectorScheduler,
 )
@@ -109,11 +110,42 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ):
+        self._update_state_after_alloc(request, blocks, num_external_tokens)
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> None:
+        self._update_state_after_alloc(
+            request, blocks, load_range.num_tokens, load_range
+        )
+
+    def _update_state_after_alloc(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        num_external_tokens: int,
+        load_range: KVLoadRange | None = None,
+    ) -> None:
         params = request.kv_transfer_params
+        if load_range is not None:
+            load_start_token = load_range.start_token
+            load_end_token = load_range.end_token
+        elif num_external_tokens > 0:
+            # Legacy single-source loads still need an explicit window. A P
+            # engine can serve Store misses and piecewise Store hits in any
+            # order, so transfer semantics cannot be cached per engine.
+            load_start_token = request.num_computed_tokens
+            load_end_token = load_start_token + num_external_tokens
+        else:
+            load_start_token = load_end_token = 0
         logger.debug(
             "NIXLConnector update_state_after_alloc: "
-            "num_external_tokens=%s, kv_transfer_params=%s",
+            "num_external_tokens=%s, load_range=%s, kv_transfer_params=%s",
             num_external_tokens,
+            load_range,
             params,
         )
 
@@ -147,24 +179,28 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                     # a full prefix cache hit on the local node. We need to call
                     # send_notif in _read_blocks to free the memory on the remote node.
 
-                    unhashed_local_block_ids: BlockIds = (
-                        blocks.get_unhashed_block_ids_all_groups()
-                        if num_external_tokens > 0
-                        else ()
-                    )
-                    local_block_ids = self.get_exchange_clipped_blocks(
-                        unhashed_local_block_ids
-                    )
-                    # Blocks covered by the local prefix cache, per KV cache group.
-                    # Each count fixes where that group's DCP slice starts, which the
-                    # worker needs to line up with the remote's slice.
-                    local_num_computed_blocks = tuple(
-                        sum(
-                            block.block_hash is not None and not block.is_null
-                            for block in group
+                    if load_range is not None:
+                        local_block_ids = self.get_range_block_ids(blocks, load_range)
+                        local_num_computed_blocks = self.get_range_start_blocks(
+                            load_range
                         )
-                        for group in blocks.blocks
-                    )
+                    else:
+                        unhashed_local_block_ids: BlockIds = (
+                            blocks.get_unhashed_block_ids_all_groups()
+                            if num_external_tokens > 0
+                            else ()
+                        )
+                        local_block_ids = self.get_exchange_clipped_blocks(
+                            unhashed_local_block_ids
+                        )
+                        # Each count fixes where that group's DCP slice starts.
+                        local_num_computed_blocks = tuple(
+                            sum(
+                                block.block_hash is not None and not block.is_null
+                                for block in blocks.blocks[group_id]
+                            )
+                            for group_id in self.kv_cache_config.transfer_group_ids
+                        )
 
                     # Get unhashed blocks to pull from remote. Mind that a full prefix
                     # cache hit is indicated with an empty list.
@@ -172,6 +208,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                         request,
                         local_block_ids,
                         local_num_computed_blocks,
+                        load_start_token,
+                        load_end_token,
                     )
 
                 else:
@@ -224,7 +262,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             # To avoid stranding the prefill blocks in the prefill instance,
             # we must add empty block_ids to _reqs_need_recv so that our
             # worker side will notify and free blocks in the prefill instance.
-            self._reqs_need_recv[request.request_id] = (request, [], ())
+            self._reqs_need_recv[request.request_id] = (request, [], (), 0, 0)
             params["do_remote_prefill"] = False
             return False, None
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -254,6 +254,8 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
                 expected_consumers=plan.local_consumers,
+                load_start_token=meta.load_start_token,
+                load_end_token=meta.load_end_token,
             )
 
         if self.use_mla and tp_ratio < 0 and len(read_specs) == 1:
@@ -276,6 +278,8 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
         expected_consumers: int,
+        load_start_token: int = 0,
+        load_end_token: int = 0,
     ):
         """
         Post a READ point-to-point xfer request from a single local worker to
@@ -347,6 +351,9 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 prefill_physical_per_logical=(
                     remote_info.remote_physical_blocks_per_logical
                 ),
+                load_start_token=load_start_token,
+                load_end_token=load_end_token,
+                block_size_ratio=block_size_ratio,
             )
 
         # NOTE (nicolo) With homogeneous TP, each TP worker loads KV from

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 from vllm.distributed.kv_transfer.kv_connector.utils import BlockIds
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
+    KVLoadRange,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
     NixlBaseConnectorScheduler,
@@ -128,14 +129,44 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
     def update_state_after_alloc(
         self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
+        self._update_state_after_alloc(request, blocks, num_external_tokens)
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        load_range: KVLoadRange,
+    ) -> None:
+        self._update_state_after_alloc(
+            request, blocks, load_range.num_tokens, load_range
+        )
+
+    def _update_state_after_alloc(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        num_external_tokens: int,
+        load_range: KVLoadRange | None = None,
+    ) -> None:
         """In push mode, D stores registration data for the worker to send
         to P via NIXL notification (deferred to ``build_connector_meta``).
         """
         params = request.kv_transfer_params
+        if load_range is not None:
+            load_start_token = load_range.start_token
+            load_end_token = load_range.end_token
+        elif num_external_tokens > 0:
+            # Carry the window for ordinary NIXL loads too: range and
+            # non-range requests share the same remote engine and handshake.
+            load_start_token = request.num_computed_tokens
+            load_end_token = load_start_token + num_external_tokens
+        else:
+            load_start_token = load_end_token = 0
         logger.debug(
             "NixlPushConnector update_state_after_alloc: "
-            "num_external_tokens=%s, kv_transfer_params=%s",
+            "num_external_tokens=%s, load_range=%s, kv_transfer_params=%s",
             num_external_tokens,
+            load_range,
             params,
         )
 
@@ -168,8 +199,13 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             "KV PUSH mode: D node storing registration for request %s",
             request.request_id,
         )
-        local_block_ids: BlockIds = blocks.get_unhashed_block_ids_all_groups()
-        local_block_ids = self.get_exchange_clipped_blocks(local_block_ids)
+        local_block_ids: BlockIds = (
+            self.get_range_block_ids(blocks, load_range)
+            if load_range is not None
+            else self.get_exchange_clipped_blocks(
+                blocks.get_unhashed_block_ids_all_groups()
+            )
+        )
 
         # ``remote_*`` fields are P's coordinates (from D's perspective).
         # ``decode_*`` fields are D's own info that P needs for the
@@ -186,6 +222,8 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             "remote_port": params["remote_port"],
             "remote_tp_size": params["tp_size"],
             "remote_pp_size": params.get("pp_size", 1),
+            "load_start_token": load_start_token,
+            "load_end_token": load_end_token,
         }
         self._push_registration_deadlines[request.request_id] = (
             time.perf_counter() + self._push_registration_timeout
@@ -198,7 +236,13 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         # ReqMeta without a KeyError — the actual remote block IDs are
         # learned by P over the NIXL handshake at WRITE time.
         params["remote_block_ids"] = ()
-        self._reqs_need_recv[request.request_id] = (request, local_block_ids, ())
+        self._reqs_need_recv[request.request_id] = (
+            request,
+            local_block_ids,
+            (),
+            load_start_token,
+            load_end_token,
+        )
 
         # Mark as processed so a re-entry (e.g. preemption + reschedule)
         # doesn't re-stage the registration.
@@ -240,7 +284,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             # recv so the worker emits a notif that lets P free them.
             # Seed remote_block_ids so add_new_req_to_recv won't KeyError.
             params["remote_block_ids"] = ()
-            self._reqs_need_recv[request.request_id] = (request, [], ())
+            self._reqs_need_recv[request.request_id] = (request, [], (), 0, 0)
             params["do_remote_prefill"] = False
             return False, None
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -429,7 +429,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         decode_engine_id = registration_data["decode_engine_id"]
         remote_block_ids = registration_data["local_block_ids"]
         decode_request_id = registration_data["request_id"]
-
+        load_start_token = registration_data["load_start_token"]
+        load_end_token = registration_data["load_end_token"]
         # Runs on the background executor; defer the WRITE until it's ready.
         fut = self._ensure_handshake(
             decode_engine_id,
@@ -470,6 +471,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             local_block_ids=logical_local,
             local_physical_block_ids=physical_local,
             tp_size=self.world_size,
+            load_start_token=load_start_token,
+            load_end_token=load_end_token,
             remote=RemoteMeta(
                 block_ids=logical_remote,
                 host="",
@@ -585,6 +588,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                load_start_token=meta.load_start_token,
+                load_end_token=meta.load_end_token,
             )
             if handle is not None:
                 handles.append(handle)
@@ -604,6 +609,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        load_start_token: int = 0,
+        load_end_token: int = 0,
     ) -> int | None:
         """Post a WRITE point-to-point xfer request.
 
@@ -632,14 +639,16 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             logger.warning("No blocks to push for request %s", request_id)
             return None
 
-        # Prefix caching: D allocated only uncached blocks, so on a partial hit it
-        # sends fewer than P's. End-trim P's blocks to that same suffix so we WRITE only
-        # the uncomputed tail into D's slots. Runs on kernel ids, post-expansion.
+        # Pair the registered D range with the same P token window. Legacy
+        # registrations without a window retain the existing suffix trim.
         remote_block_ids, local_block_ids = self._apply_prefix_caching(
             decode_block_ids=remote_block_ids,
             prefill_block_ids=local_block_ids,
             decode_physical_per_logical=remote_info.remote_physical_blocks_per_logical,
             prefill_physical_per_logical=self._physical_blocks_per_logical_kv_block,
+            load_start_token=load_start_token,
+            load_end_token=load_end_token,
+            block_size_ratio=block_size_ratio,
         )
 
         local_block_ids = list(local_block_ids)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/tp_mapping.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/tp_mapping.py
@@ -12,7 +12,12 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
     BlockIds,
     TransferTopology,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheSpec, MambaSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    FullAttentionSpec,
+    KVCacheSpec,
+    MambaSpec,
+)
 
 # ======================================================================
 # Data structures
@@ -30,6 +35,10 @@ class ReadSpec:
 
 def _is_attention_spec(spec_type: type[KVCacheSpec]) -> bool:
     return issubclass(spec_type, AttentionSpec)
+
+
+def _is_full_attention_spec(spec_type: type[KVCacheSpec]) -> bool:
+    return issubclass(spec_type, FullAttentionSpec)
 
 
 def _is_ssm_spec(spec_type: type[KVCacheSpec]) -> bool:


### PR DESCRIPTION
## Purpose

This PR follows #54240 and implements its `MultiConnector` range-load interface
for the NIXL P/D connectors. When paired with a range-capable leading connector,
for example `MooncakeStoreConnector` supplying the prefix, NIXL can supply only
the remainder.

With `MultiConnector`'s opt-in `range_aware` policy, Decode can load a cached
prefix `[0, S)` directly from Mooncake Store while receiving only the remaining
prompt range `[S, N)` from Prefill through NIXL. The two sources use the same
Decode block allocation and complete independently before the request resumes.
The default first-hit policy and legacy full-range NIXL behavior remain
unchanged.

The implementation supports both `NixlConnector` Pull and `NixlPushConnector`
Push, including Full Attention and hybrid Mamba/GDN models. For hybrid models,
only the NIXL range serving the end of the prompt transfers recurrent state.
NIXL metadata carries an explicit token window for every request. Ordinary
single-source loads carry the window as well, so a remote engine can alternate
between Store misses and piecewise Store hits without reusing incorrect
per-engine state. The worker maps the window at the remote transfer-block
granularity, selecting the same semantic suffix when P/D tensor-parallel sizes,
physical blocks per logical page, or block sizes differ.

This PR also:

- advertises the scheduler-block alignment required by NIXL and accepts the
  explicit range assigned by the framework;
- maps NIXL destination and source blocks by request-scoped token window for
  both Pull and Push;
- transfers recurrent state for terminal ranges while selecting only Attention
  blocks for non-terminal ranges, including Mamba state wrapped in packed
  cache-group specs;
- carries explicit windows for ordinary NIXL loads to avoid ambiguity when
  range and non-range requests share a remote engine;
- preserves the existing suffix mapping for requests without an assigned range;
- increments the NIXL connector compatibility version to 11 for the new range
  metadata.

## Test Plan

### Unit and static checks

```bash
git diff --name-only -z HEAD^..HEAD | \
  xargs -0 pre-commit run --files

for test_file in \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py \
  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py \
  tests/v1/kv_connector/unit/test_multi_connector.py \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py \
  tests/v1/kv_connector/unit/test_nixl_push_connector.py; do
  python -m pytest -q "$test_file"
done
```

Each test file is run in a fresh pytest process so the real-LLM EngineCore test
does not inherit CUDA state initialized by an earlier HMA test.

The unit tests cover connector-specific range alignment, terminal-range
ownership, Store group filtering, Pull and Push metadata propagation,
interleaved ordinary and range requests, Full Attention token windows, packed
Mamba groups, hybrid Attention plus recurrent-state transfer, heterogeneous
block sizes, and physical-pages-per-logical-page mappings.

### RDMA cluster tests

The reusable test scripts are available at:

https://github.com/ScaleX-IO/vllm/tree/decode-offloading-e2e-tests-nixl/examples/disaggregated/mooncake_store_connector/piecewise_nixl_cluster

Environment:

- Alibaba Cloud Linux 3, x86_64
- Python 3.12.13 and PyTorch 2.13.0 with CUDA 13.0
- one node with 8 NVIDIA H20-3e GPUs
- latest unit and static-check revision: `877a3c671e`
- RDMA E2E revision: `3d195f663a`
- Store/NIXL accounting E2E revision: `9727f15f2f`
- standalone Mooncake Store over RDMA on `mlx5_bond_0`
- block size 16, max model length 2048, prefix caching, eager execution
- `Qwen3-32B-FP8` for Full Attention cases
- `Qwen3.6-27B-FP8` for hybrid Mamba/GDN cases

Each case first seeds Mooncake Store, then runs a reference request without a
Decode-side Store load, and finally replays the same request with piecewise
Store + NIXL loading. The test verifies contiguous Store/NIXL ranges and compares
generated token IDs with the reference.

## Test Result

### Unit and static checks

```text
All pre-commit hooks passed.
226 passed
```

### Single-node RDMA tests

| Model | P/D TP | NIXL mode | Store range | NIXL range | Output check |
|---|---:|---|---:|---:|---|
| Qwen3-32B-FP8 | 1/1 | Pull | `[0, 1040)` | `[1040, 1056)` | 8 tokens exact |
| Qwen3-32B-FP8 | 1/1 | Push | `[0, 1040)` | `[1040, 1056)` | 8 tokens exact |
| Qwen3-32B-FP8 | 2/1 | Pull | `[0, 1024)` | `[1024, 1056)` | 8 tokens exact |
| Qwen3-32B-FP8 | 2/1 | Push | `[0, 1024)` | `[1024, 1056)` | 8 tokens exact |
| Qwen3.6-27B-FP8 | 2/2 | Pull | `[0, 1568)` | `[1568, 1631)` | first token exact (`28513`) |
| Qwen3.6-27B-FP8 | 2/2 | Push | `[0, 1568)` | `[1568, 1631)` | first token exact (`28513`) |
| Qwen3.6-27B-FP8 | 4/2 | Pull | `[0, 1568)` | `[1568, 1631)` | first token exact (`6`) |
| Qwen3.6-27B-FP8 | 4/2 | Push | `[0, 1568)` | `[1568, 1631)` | first token exact (`6`) |

All 8 cases passed. Full Attention continuations matched all 8 generated tokens.
For the FP8 hybrid model, the E2E assertion compares the first Decode token;
byte-level unit tests separately verify the complete Attention page window and
terminal recurrent state. This avoids treating TP-dependent FP8/GDN numerical
trajectory differences as a transfer-integrity failure.

### Store/NIXL contribution matrix

A single-node H20 E2E matrix additionally measured the bytes contributed by
Mooncake Store and NIXL for the same 1280-token cached prompt.

| Case | Store load | NIXL transfer | Result |
|---|---:|---:|---|
| Piecewise Pull | 256 MiB | 64 MiB | PASS |
| Piecewise Push | 256 MiB | 64 MiB | PASS |
| Store miss | 0 MiB | 320 MiB | PASS |
| Store full | 316 MiB | 4 MiB | PASS |

All four cases reported 1280 cached tokens, produced the same 8-token
continuation as the cold reference, recorded no Store or NIXL transfer
failures, and used contiguous non-overlapping ranges. The measured NIXL traffic
also satisfied `Store full < piecewise < Store miss`.

The remaining 4 MiB NIXL transfer in the Store-full case is one 16-token
terminal block, following Mooncake Store's existing aligned `num_tokens - 1`
lookup behavior.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and relationship to the range-load framework PR.
- [x] Unit, static, and RDMA E2E test plans.
- [x] Unit and E2E test results.

</details>