### PR TITLE
[ROCm] Hold the router weight in fp32 when fp32 routing is requested

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -318,6 +318,13 @@ class DeepseekV2MoE(nn.Module):
             config.hidden_size,
             config.n_routed_experts,
             out_dtype=self.router_dtype,
+            # When fp32 routing is requested, hold the weight in fp32 too.
+            # GateLinear only casts when the platform has no specialized kernel
+            # that expects the model dtype, so this is a no-op on the paths that
+            # already have one -- but it is what makes the fp32 router GEMMs
+            # reachable, including the gfx950 kernel whose shape table lists
+            # (6144, 256).
+            force_fp32_compute=self.router_dtype == torch.float32,
             prefix=f"{prefix}.gate",
         )
         if getattr(config, "topk_method", None) == "noaux_tc":


### PR DESCRIPTION
## Purpose

Fixes #55351.

`_get_moe_router_dtype()` returns `torch.float32` unconditionally for
`glm_moe_dsa`, and GLM-5.3's own config carries `"moe_router_dtype": "float32"`.
But `GateLinear` is constructed without `params_dtype`, so only the *output* is
fp32 — the weight stays in the model dtype (bf16).

`GateLinear` gates every fp32 router GEMM on `self.weight.dtype ==
torch.float32`, so those kernels are unreachable for DeepSeek-family models. That
includes the gfx950 kernel added in #54845, whose
`ROCM_FP32_ROUTER_GEMM_SUPPORTED_SHAPES` explicitly lists `(6144, 256)` — exactly
GLM-5.3's router shape. A log line at construction time:

```
gfx950=True, shape (6144, 256) supported=True, weight=torch.bfloat16
  -> fp32 path OFF
```

vLLM already has the mechanism for this. `force_fp32_compute` stores the weight
in fp32 *only* when the platform has no specialized kernel expecting the model
dtype, so it is a no-op wherever such a kernel exists. `nemotron_h.py` uses it;
the DeepSeek path did not.

## Test Plan

MI355X (gfx950), TP4, GLM-5.3 (MXFP4 experts + fp8 attention),
`--max-model-len 1048576`, MTP k=3. Same image, same flags, only this line
differing.

## Test Result

The path is reached:

```
gfx950=True, shape (6144, 256) supported=True, weight=torch.float32
  -> fp32 path ON
```

| | path off | path on |
|---|---|---|
| single stream (median of 4) | 171.3 tok/s | 175.6 |
| throughput, 64 concurrent | 2005 / 2219 tok/s | 1969 / 2198 |
| GSM8K (150) | 98.0 % | 98.7 % |
| GPU KV cache | — | 2,843,584 tokens |

I would rather be straight about this: **on my setup it is noise in both
directions**, and it costs ~230 MB per rank for the fp32 copies of the router
weights. So I am not claiming a speedup.

What the patch fixes is the inconsistency: a model that declares fp32 routing
gets an fp32 output from a bf16 weight, and the kernels written for that case
never run. Platforms where the specialized fp32 kernel is a larger win over the
generic fallback should benefit more than mine does.

If you would rather not pay the memory for every DeepSeek-family model, the
alternative is to drop `(6144, 256)` from the ROCm shape table, since the
DeepSeek path can never reach it today. Either way the current state seems worth
resolving — happy to switch to that instead.