### PR TITLE
[Bugfix][Compile] Fold LoRA wrap state into the AOT cache key

### DIFF
--- a/tests/compile/test_lora_wrap_cache_key.py
+++ b/tests/compile/test_lora_wrap_cache_key.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from torch import nn
+
+from vllm.compilation.caching import lora_wrap_hash_factor
+from vllm.lora.layers import BaseLayerWithLoRA
+
+
+def _toy(wrapped: bool) -> nn.Module:
+    root = nn.Module()
+    root.linear = nn.Linear(4, 4)
+    if wrapped:
+        wrapper = BaseLayerWithLoRA()
+        wrapper.base_layer = root.linear
+        root.linear = wrapper
+    return root
+
+
+def test_wrap_state_changes_factor():
+    # Regression for #55383: wrapping moves weights under base_layer, so a
+    # wrapped and an unwrapped tree must not share an AOT artifact directory.
+    assert lora_wrap_hash_factor(_toy(False)) != lora_wrap_hash_factor(_toy(True))
+
+
+def test_same_wrap_state_same_factor():
+    assert lora_wrap_hash_factor(_toy(True)) == lora_wrap_hash_factor(_toy(True))
+
+
+def test_unwrapped_factor_is_stable():
+    assert lora_wrap_hash_factor(_toy(False)) == lora_wrap_hash_factor(_toy(False))
+
+
+def test_wrap_path_not_wrap_count():
+    first = nn.Module()
+    first.a = nn.Module()
+    first.a.linear = BaseLayerWithLoRA()
+    first.a.linear.base_layer = nn.Linear(4, 4)
+    second = nn.Module()
+    second.b = nn.Module()
+    second.b.linear = BaseLayerWithLoRA()
+    second.b.linear.base_layer = nn.Linear(4, 4)
+    assert lora_wrap_hash_factor(first) != lora_wrap_hash_factor(second)

--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -589,6 +589,21 @@ def aot_compile_hash_factors(vllm_config: VllmConfig) -> list[str]:
     return factors
 
 
+def lora_wrap_hash_factor(model: torch.nn.Module) -> str:
+    # LoRA wrapping moves weights from <prefix>.weight to
+    # <prefix>.base_layer.weight, and VllmConfig does not see the wrap state,
+    # so two runs whose module trees differ only in wrapping would otherwise
+    # share one AOT artifact directory (#55383).
+    from vllm.lora.layers import BaseLayerWithLoRA
+
+    wrapped = sorted(
+        name
+        for name, mod in model.named_modules()
+        if isinstance(mod, BaseLayerWithLoRA)
+    )
+    return hashlib.sha256(str(wrapped).encode()).hexdigest()
+
+
 def _compute_code_hash_with_content(file_contents: dict[str, str]) -> str:
     items = list(sorted(file_contents.items(), key=lambda x: x[0]))
     hash_content = []

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -536,11 +536,12 @@ def _support_torch_compile(
             serialized backend artifacts), then we need to generate a new AOT
             compile artifact from scratch.
             """
-            from .caching import aot_compile_hash_factors
+            from .caching import aot_compile_hash_factors, lora_wrap_hash_factor
 
             factors: list[str] = aot_compile_hash_factors(self.vllm_config)
 
             factors.append(_model_hash_key(self.forward))
+            factors.append(lora_wrap_hash_factor(self))
             hash_key = hashlib.sha256(str(factors).encode()).hexdigest()
             cache_dir = os.path.join(
                 envs.VLLM_CACHE_ROOT,


### PR DESCRIPTION
Fixes #55383.

## Problem

With `VLLM_USE_AOT_COMPILE=1`, the artifact directory key is built from env factors, `vllm_config.compute_hash()`, optional inductor factors, and the forward source hash. None of them see the module tree. LoRA wrapping moves weights from `<prefix>.weight` to `<prefix>.base_layer.weight`, so a run that wraps a layer (e.g. the fused MLA `q_a_proj`) and an earlier run that did not resolve to the same directory, and the later run loads a graph compiled against the other parameter naming. The load side does not catch it (`disable_guard_check()` when `evaluate_guards` is off) and the failure is a bare `KeyError: 'weight'` inside `profile_run` with no module name attached.

## Fix

Hash the sorted set of LoRA-wrapped module paths (`BaseLayerWithLoRA` instances over `named_modules()`) and append it as a factor next to the forward hash in `decorators.py`. Identical config with identical wrap state keeps hitting the cache; a wrap-state flip lands in its own directory and compiles fresh instead of crashing. One tree walk, negligible next to an AOT compile.

The reporter's second suggestion (load-side validation that falls back to recompile on unresolvable parameter names) is a good second line of defense, deliberately not bundled here to keep this small.

## Tests

`tests/compile/test_lora_wrap_cache_key.py`: wrap flip changes the factor, identical wrap state is stable, unwrapped trees are stable, and the keyed value is the wrap path (not just the presence of a wrapper). Not run locally (no GPU dev box for the vllm import graph); lint/format clean via ruff, execution is on CI.

AI assistance disclosure: this change was prepared with AI assistance (Kimi K3). The mechanism was verified by reading `caching.py`, `decorators.py`, and `vllm/lora/layers/base.py` on current main, and the cache-key collision was cross-checked against the reproduction in the issue.
