### PR TITLE
[Bugfix] error cleanly when vllm serve --model has no value

### DIFF
--- a/tests/utils/test_flexible_argument_parser_model.py
+++ b/tests/utils/test_flexible_argument_parser_model.py
@@ -4,9 +4,12 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 
 def _serve_parser() -> FlexibleArgumentParser:
+    # Mirror the real CLI: `serve` is a subparser that owns model_tag.
     parser = FlexibleArgumentParser(description="test")
-    parser.add_argument("model_tag", nargs="?")
-    parser.add_argument("--port", type=int, default=8000)
+    subparsers = parser.add_subparsers(dest="subparser", required=False)
+    serve = subparsers.add_parser("serve")
+    serve.add_argument("model_tag", nargs="?")
+    serve.add_argument("--port", type=int, default=8000)
     return parser
 
 

--- a/tests/utils/test_flexible_argument_parser_model.py
+++ b/tests/utils/test_flexible_argument_parser_model.py
@@ -1,0 +1,29 @@
+import pytest
+
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+def _serve_parser() -> FlexibleArgumentParser:
+    parser = FlexibleArgumentParser(description="test")
+    parser.add_argument("model_tag", nargs="?")
+    parser.add_argument("--port", type=int, default=8000)
+    return parser
+
+
+def test_serve_model_flag_missing_value_errors():
+    parser = _serve_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["serve", "--model"])
+
+
+def test_serve_model_flag_followed_by_option_errors():
+    parser = _serve_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["serve", "--model", "--port", "8001"])
+
+
+def test_serve_model_flag_rewrites_to_positional():
+    parser = _serve_parser()
+    args = parser.parse_args(["serve", "--model", "facebook/opt-125m", "--port", "8001"])
+    assert args.model_tag == "facebook/opt-125m"
+    assert args.port == 8001

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -281,6 +281,10 @@ class FlexibleArgumentParser(ArgumentParser):
                 )
 
                 if args[model_idx] == "--model":
+                    if model_idx + 1 >= len(args) or str(args[model_idx + 1]).startswith(
+                        "-"
+                    ):
+                        self.error("argument --model: expected one argument")
                     model_tag = args[model_idx + 1]
                     rest_start_idx = model_idx + 2
                 else:


### PR DESCRIPTION
## Summary
- Legacy `vllm serve --model` rewriting indexed `args[model_idx + 1]` without a bounds/value check.
- Trailing `--model` (or `--model` followed by another flag) raised `IndexError` instead of an argparse error.
- Validate the value before rewriting the flag into a positional model tag.

## Test plan
- [x] `tests/utils/test_flexible_argument_parser_model.py` covers missing value, flag-as-value, and successful rewrite