### PR TITLE
[Bugfix] reject empty prompt lists in CompletionRequest

### DIFF
--- a/tests/entrypoints/openai/completion/test_empty_prompt_list.py
+++ b/tests/entrypoints/openai/completion/test_empty_prompt_list.py
@@ -1,0 +1,14 @@
+import pytest
+
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.exceptions import VLLMValidationError
+
+
+def test_empty_prompt_list_rejected():
+    with pytest.raises(VLLMValidationError, match="prompt or prompt_embeds"):
+        CompletionRequest(model="m", prompt=[])
+
+
+def test_nonempty_prompt_list_ok():
+    req = CompletionRequest(model="m", prompt=["hello"])
+    assert req.prompt == ["hello"]

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -560,7 +560,11 @@ class CompletionRequest(OpenAIBaseModel):
         prompt = data.get("prompt")
         prompt_embeds = data.get("prompt_embeds")
 
-        prompt_is_empty = prompt is None or (isinstance(prompt, str) and prompt == "")
+        prompt_is_empty = (
+            prompt is None
+            or (isinstance(prompt, str) and prompt == "")
+            or (isinstance(prompt, list) and len(prompt) == 0)
+        )
         embeds_is_empty = prompt_embeds is None or (
             isinstance(prompt_embeds, list) and len(prompt_embeds) == 0
         )


### PR DESCRIPTION
## Summary
- `CompletionRequest` treated `prompt=[]` as present while rejecting empty `prompt_embeds`.
- Empty prompt lists can now fail validation with the existing non-empty prompt/embeds error.

## Test plan
- [x] `tests/entrypoints/openai/completion/test_empty_prompt_list.py`
