### PR TITLE
[Bugfix] do not treat weight filenames as custom proposer paths

### DIFF
--- a/tests/config/test_speculative_custom_path.py
+++ b/tests/config/test_speculative_custom_path.py
@@ -1,0 +1,12 @@
+from vllm.config.speculative import SpeculativeConfig
+
+
+def test_weight_filenames_are_not_custom_proposer_paths():
+    assert not SpeculativeConfig._is_custom_proposer_path("draft.pt")
+    assert not SpeculativeConfig._is_custom_proposer_path("model.safetensors")
+    assert not SpeculativeConfig._is_custom_proposer_path("eagle.weights")
+
+
+def test_python_import_paths_still_detected():
+    assert SpeculativeConfig._is_custom_proposer_path("my_module.MyProposer")
+    assert SpeculativeConfig._is_custom_proposer_path("pkg.sub.Proposer")

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1069,6 +1069,22 @@ class SpeculativeConfig:
             return False
         if "/" in model:
             return False
+        # Weight / config filenames are dotted but are not Python import paths.
+        lower = model.lower()
+        if lower.endswith(
+            (
+                ".pt",
+                ".pth",
+                ".bin",
+                ".safetensors",
+                ".ckpt",
+                ".json",
+                ".npz",
+                ".npz.index",
+                ".onnx",
+            )
+        ):
+            return False
         parts = model.split(".")
         return len(parts) >= 2 and all(part.isidentifier() for part in parts)
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1082,6 +1082,7 @@ class SpeculativeConfig:
                 ".npz",
                 ".npz.index",
                 ".onnx",
+                ".weights",
             )
         ):
             return False


### PR DESCRIPTION
## Summary
- Auto-detection treated any slash-free dotted identifier string as a custom proposer import path.
- Filenames like `draft.pt` / `model.safetensors` / `eagle.weights` incorrectly forced `method=custom_class`.
- Exclude common weight and config suffixes from that heuristic.

## Test plan
- [x] `tests/config/test_speculative_custom_path.py`
