### PR TITLE
[Bugfix][Parser] Hide incomplete Muse Glimmer ATEM markers

### DIFF
--- a/tests/tool_use/test_muse_glimmer.py
+++ b/tests/tool_use/test_muse_glimmer.py
@@ -268,6 +268,15 @@ RAW_ANSWER = (
     "<|start|>assistant to=user<|message|>The answer is 42.<|eot|>"
 )
 
+ATEM_MARKERS = (
+    "<atem:function_calls>",
+    "</atem:function_calls>",
+    "<atem:invoke",
+    "</atem:invoke>",
+    "<atem:parameter",
+    "</atem:parameter>",
+)
+
 # NO closing <|eom|> -> truncated CoT
 RAW_TRUNCATED = (
     " to=self<|message|>Maybe I should call "
@@ -316,6 +325,36 @@ def test_streaming_reasoning_then_content():
     assert reasoning == "Think about it.", repr(reasoning)
     assert content == "The answer is 42.", repr(content)
     assert tcs == []
+
+
+@pytest.mark.parametrize("marker", ATEM_MARKERS)
+def test_tool_phase_atem_marker_split_at_every_boundary(marker):
+    prefix = " to=user<|message|>Visible answer"
+    for split in range(1, len(marker)):
+        parser = MuseGlimmerToolParser(object())
+        partial = prefix + marker[:split]
+        first = parser.extract_tool_calls_streaming(
+            "", partial, partial, [], [], [], _FakeReq()
+        )
+        complete = prefix + marker
+        second = parser.extract_tool_calls_streaming(
+            partial, complete, marker[split:], [], [], [], _FakeReq()
+        )
+        content = "".join(dm.content or "" for dm in (first, second) if dm is not None)
+        assert content == "Visible answer", (marker, split, content)
+
+
+@pytest.mark.parametrize("marker", ATEM_MARKERS)
+def test_tool_phase_final_incomplete_atem_marker_is_dropped(marker):
+    prefix = " to=user<|message|>Visible answer"
+    for truncated_at in range(1, len(marker)):
+        parser = MuseGlimmerToolParser(object())
+        partial = prefix + marker[:truncated_at]
+        delta = parser.extract_tool_calls_streaming(
+            "", partial, partial, [], [], [], _FakeReq()
+        )
+        assert delta is not None
+        assert delta.content == "Visible answer", (marker, truncated_at, delta)
 
 
 def test_truncated_cot_no_toolcall_nonstreaming():

--- a/vllm/tool_parsers/muse_glimmer_tool_parser.py
+++ b/vllm/tool_parsers/muse_glimmer_tool_parser.py
@@ -81,10 +81,26 @@ _MSG_END_RE = re.compile(r"<\|eom\|>|<\|eot\|>")
 _REASONING_RECIPIENT = "self"
 _USER_RECIPIENT = "user"
 
+_ATEM_CONTROL_MARKERS = (
+    "<atem:function_calls>",
+    "</atem:function_calls>",
+    "<atem:invoke",
+    "</atem:invoke>",
+    "<atem:parameter",
+    "</atem:parameter>",
+)
+
 # Structural markers that must never reach the client. A streamed body is held
 # back by up to len(marker)-1 characters so a marker split across two chunks is
-# not emitted as content.
-_STRUCTURAL_MARKERS = ("<|eom|>", "<|eot|>", "<|start|>", "<|message|>")
+# not emitted as content. This includes ATEM markers: a generation that ends in
+# a partial marker is a truncated control sequence, not ordinary content.
+_STRUCTURAL_MARKERS = (
+    "<|eom|>",
+    "<|eot|>",
+    "<|start|>",
+    "<|message|>",
+    *_ATEM_CONTROL_MARKERS,
+)
 _MAX_MARKER_LEN = max(len(m) for m in _STRUCTURAL_MARKERS)
 # A trailing " to=NAME" that could still grow into a bare message header (the
 # first message of a turn has no <|start|> prefix -- the prompt ends with
@@ -283,7 +299,8 @@ class MuseGlimmerToolParser(ToolParser):
                 reasoning_parts.append(body)
                 reasoning_open = not closed
             elif rcpt is None or rcpt == _USER_RECIPIENT:
-                content_parts.append(body)
+                if not any(marker in body for marker in _ATEM_CONTROL_MARKERS):
+                    content_parts.append(body)
                 content_open = not closed
         return (
             "".join(content_parts),


### PR DESCRIPTION
## Purpose

Prevent the legacy Muse Glimmer tool parser from exposing complete or partial ATEM protocol markers as ordinary streamed content.

A marker split across chunks is held until it completes. If generation terminates after a proper marker prefix, the incomplete control fragment is dropped rather than surfaced or interpreted as a fabricated tool call.

Fixes #55395.

This is not duplicating an existing PR: #54585 migrates only the reasoning parser and explicitly leaves the legacy ATEM tool parser unchanged. This draft is the complementary tool-parser fix and depends on coordinating with that migration.

## Tests

```bash
python -m pytest -q tests/tool_use/test_muse_glimmer.py
pre-commit run --files \
  tests/tool_use/test_muse_glimmer.py \
  vllm/tool_parsers/muse_glimmer_tool_parser.py
```

Results:

- Muse Glimmer parser suite: **33 passed**.
- All applicable pre-commit hooks passed, including Ruff, mypy, SPDX, import checks, and configuration validation.
- Added split-at-every-boundary and final-truncation coverage for all function-call, invoke, and parameter ATEM markers.

No model weights or logits are changed. This is a protocol-layer output fix; model-quality evaluation is not applicable. The original real-traffic reproduction ended after a partial `<atem:function_calls` opener and leaked it into visible content.

## AI assistance

Agentcloud was used to help port the previously validated fix and run tests. This PR remains draft until the human submitter reviews every changed line and can explain and defend the change end to end.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR and linked issue.
- [x] The test plan and results.
- [x] Why this does not duplicate an existing PR.
- [ ] Human submitter has reviewed every changed line.

</details>
