### PR TITLE
[Bugfix][Core] Fix logging calls whose arguments do not match their placeholders

### DIFF
--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -173,10 +173,10 @@ class QuickAllReduce:
         regime_str = envs.VLLM_ROCM_QUICK_REDUCE_QUANTIZATION
         if regime_str not in QuickReduceRegime.__members__:
             logger.warning(
-                "Custom quick allreduce:",
-                f"Invalid quantization level: {regime_str}. "
-                "Supported levels: "
-                f"{list(QuickReduceRegime.__members__.keys())}",
+                "Custom quick allreduce: Invalid quantization level: %s. "
+                "Supported levels: %s",
+                regime_str,
+                list(QuickReduceRegime.__members__.keys()),
             )
             return
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1503,7 +1503,7 @@ class MoRIIOConnectorWorker:
                 elif msg == MoRIIOConstants.POP_DONE_RECV:
                     _, req_id = sock.recv_multipart()
                     logger.debug(
-                        "MoRIIO handshake listener received done recv for req",
+                        "MoRIIO handshake listener received done recv for req %s",
                         req_id.decode(),
                     )
 

--- a/vllm/v1/engine/tensor_ipc.py
+++ b/vllm/v1/engine/tensor_ipc.py
@@ -147,9 +147,11 @@ class TensorIpcReceiver:
                 if tensor is not None:
                     if sender.current_message_id != message_id:
                         while tensors and (mid := next(iter(tensors))) < message_id:
-                            if sender.tensors.pop(mid):
+                            popped = sender.tensors.pop(mid)
+                            if popped:
                                 logger.warning(
                                     "Discarding %d stale tensors from sender %s",
+                                    len(popped),
                                     sender_id,
                                 )
                         sender.current_message_id = message_id


### PR DESCRIPTION
## Purpose

Three `logger` calls have placeholder/argument mismatches. `logging` swallows the resulting `TypeError` via `handleError`, so the messages never rendered and a traceback was printed to stderr instead:

1. `vllm/v1/engine/tensor_ipc.py` — "Discarding %d stale tensors from sender %s" passed only `sender_id`. The fix captures the popped tensors and passes `len(popped)`.
2. `vllm/distributed/device_communicators/quick_all_reduce.py` — the invalid `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION` diagnostic was passed as a second argument while the message had no placeholder; merged into the message with two `%s` placeholders.
3. `vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py` — the handshake done-recv debug message had no `%s` for `req_id`.

## Test Plan

Each call was reproduced failing before the fix (`TypeError: %d format: a real number is required, not str` / `not all arguments converted during string formatting`) and formats cleanly after. The stale-tensor branch in tensor_ipc is not exercised by `tests/v1/test_tensor_ipc_queue.py`, which is why it survived.

## Disclosure (AI-assisted contribution)

These commits are AI-assisted (agent-located by scanning for logging placeholder/argument mismatches and verified in context; Co-authored-by trailer added).
