### PR TITLE
[Docs] Remove dead snippet includes left behind by refactors

### DIFF
--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -128,7 +128,6 @@ For example:
 **8. MoE:**
 
 ```python
---8<-- "vllm/model_executor/layers/fused_moe/layer.py:fused_moe"
 
 --8<-- "vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py:modular_fused_moe"
 

--- a/docs/models/pooling_models/classify.md
+++ b/docs/models/pooling_models/classify.md
@@ -71,7 +71,6 @@ The following [pooling parameters][vllm.PoolingParams] are supported.
 
 ```python
 --8<-- "vllm/pooling_params.py:common-pooling-params"
---8<-- "vllm/pooling_params.py:classify-pooling-params"
 ```
 
 ### `LLM.classify`
@@ -121,7 +120,6 @@ The following Classification API parameters are supported:
     ```python
     --8<-- "vllm/entrypoints/pooling/base/protocol.py:pooling-common-params"
     --8<-- "vllm/entrypoints/pooling/base/protocol.py:completion-params"
-    --8<-- "vllm/entrypoints/pooling/base/protocol.py:classify-params"
     ```
 
 The following extra parameters are supported:
@@ -143,7 +141,6 @@ For chat-like input (i.e. if `messages` is passed), the following parameters are
     ```python
     --8<-- "vllm/entrypoints/pooling/base/protocol.py:pooling-common-params"
     --8<-- "vllm/entrypoints/pooling/base/protocol.py:chat-params"
-    --8<-- "vllm/entrypoints/pooling/base/protocol.py:classify-params"
     ```
 
 these extra parameters are supported instead:

--- a/docs/models/pooling_models/reward.md
+++ b/docs/models/pooling_models/reward.md
@@ -82,7 +82,6 @@ The following [pooling parameters][vllm.PoolingParams] are supported.
 
 ```python
 --8<-- "vllm/pooling_params.py:common-pooling-params"
---8<-- "vllm/pooling_params.py:classify-pooling-params"
 ```
 
 ### `LLM.encode`

--- a/docs/models/pooling_models/scoring.md
+++ b/docs/models/pooling_models/scoring.md
@@ -131,7 +131,6 @@ The following [pooling parameters][vllm.PoolingParams] are only supported by cro
 
 ```python
 --8<-- "vllm/pooling_params.py:common-pooling-params"
---8<-- "vllm/pooling_params.py:classify-pooling-params"
 ```
 
 ### `LLM.score`

--- a/docs/models/pooling_models/token_classify.md
+++ b/docs/models/pooling_models/token_classify.md
@@ -84,7 +84,6 @@ The following [pooling parameters][vllm.PoolingParams] are supported.
 
 ```python
 --8<-- "vllm/pooling_params.py:common-pooling-params"
---8<-- "vllm/pooling_params.py:classify-pooling-params"
 ```
 
 ### `LLM.encode`


### PR DESCRIPTION
## Purpose

Six `--8<--` snippet includes reference marker sections that no longer exist, so the docs build raises `SnippetMissingError` (pymdownx.snippets `extract_section`) and the surrounding example blocks render with missing content:

- `docs/design/custom_op.md`: the `fused_moe` markers were removed from `layer.py` by the MoE pluggable-layer refactor (#41184); the other three includes in the same block still resolve
- `classify.md` / `scoring.md` / `reward.md` / `token_classify.md`: `classify-pooling-params` markers were removed from `pooling_params.py` by #37537 (`use_activation` is already shown via `common-pooling-params` on the same pages)
- `classify.md` (Completion/Chat Parameters blocks): `classify-params` markers never existed in `protocol.py`; classify only defines `classify-extra-params`, which the same page already includes

Each removal verified against the current tree (grep for the marker names across the repo).

## Test Plan

- [x] `mkdocs serve` snippet extraction of the referenced sections reproduced the `SnippetMissingError` before removal (pymdown-extensions)
- [x] No remaining references to the removed marker names in docs/

## Disclosure (AI-assisted contribution)

AI-assisted change (systematically swept all `--8<--` includes against their source files); Co-authored-by trailer added.
