### PR TITLE
[Hybrid] Block priorities enabling opportunistic APC hits with sparse caching

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -32,6 +32,7 @@ from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager, Request
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     BlockHashWithGroupId,
+    BlockPriority,
     KVCacheBlock,
     get_block_hash,
     get_group_id,
@@ -3137,9 +3138,10 @@ def test_hybrid_cache_blocks_swa_tail_window_only():
     """Within each lcm-aligned segment, SWA's ``find_longest_cache_hit`` only
     returns the trailing ``ceil((sliding_window - 1) / block_size)`` blocks
     (its right-to-left scan stops once a contiguous match is found). Blocks
-    earlier in the segment can never serve a hit, so
-    ``HybridKVCacheCoordinator.cache_blocks`` should skip them rather than
-    polluting the prefix-cache hash map."""
+    earlier in the segment cannot serve a hit, so
+    ``HybridKVCacheCoordinator.cache_blocks`` marks them as ``LOW`` priority:
+    they remain in the prefix-cache hash map for opportunistic reuse but
+    drain first under eviction."""
     block_size = 8
     # Full attn block_size=32, SWA block_size=8, sw=8 -> lcm=32.
     # tail = ceil(7/8) = 1; per_segment = 32/8 = 4.
@@ -3191,18 +3193,17 @@ def test_hybrid_cache_blocks_swa_tail_window_only():
     assert len(req.block_hashes) == 8
 
     pool = manager.block_pool
-    # SWA group_id=1: only hash 3 and hash 7 (the last block of each
-    # 32-token segment) should be cached. Hashes 0,1,2,4,5,6 cannot serve
-    # a hit at any lcm-aligned length, so they must NOT be cached.
-    expected_cached = {3, 7}
+    # SWA group_id=1: every block is cached; only hashes 3 and 7 (the last
+    # block of each 32-token segment) carry NORMAL priority, the earlier
+    # blocks in each segment are cached at LOW priority.
+    normal_expected = {3, 7}
     for i in range(8):
         cached = pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[1])
-        if i in expected_cached:
-            assert cached is not None, f"SWA hash {i} should be cached"
-        else:
-            assert cached is None, (
-                f"SWA hash {i} cannot serve any lcm-aligned hit; should not be cached"
-            )
+        assert cached is not None, f"SWA hash {i} should be cached"
+        expected = BlockPriority.NORMAL if i in normal_expected else BlockPriority.LOW
+        assert cached[0].priority == expected, (
+            f"SWA hash {i} should have priority {expected.name}"
+        )
 
 
 def test_hybrid_cache_blocks_clamped_to_lcm():
@@ -3324,13 +3325,16 @@ def test_hybrid_local_kv_retention_interval_aligns_in_manager():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {7, 11, 15}
+    # Every SWA block is cached under the new sparse-retention scheme; only the
+    # boundary tails carry NORMAL priority — everything else is LOW.
+    normal_expected = {7, 11, 15}
     for i in range(16):
         cached = pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[1])
-        if i in expected_swa_cached:
-            assert cached is not None, f"SWA hash {i} should be cached"
-        else:
-            assert cached is None, f"SWA hash {i} should not be cached"
+        assert cached is not None, f"SWA hash {i} should be cached"
+        expected = BlockPriority.NORMAL if i in normal_expected else BlockPriority.LOW
+        assert cached[0].priority == expected, (
+            f"SWA hash {i} should have priority {expected.name}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -3537,13 +3541,16 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11}
+    # All SWA blocks are cached; only the latest replay boundary is NORMAL,
+    # the rest are LOW-priority opportunistic entries.
+    normal_expected = {11}
     for i in range(16):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
-        if i in expected_swa_cached:
-            assert cached is not None, f"SWA hash {i} should be cached"
-        else:
-            assert cached is None, f"SWA hash {i} should not be cached"
+        assert cached is not None, f"SWA hash {i} should be cached"
+        expected = BlockPriority.NORMAL if i in normal_expected else BlockPriority.LOW
+        assert cached[0].priority == expected, (
+            f"SWA hash {i} should have priority {expected.name}"
+        )
 
     manager.free(req0)
     retained_swa_block = pool.get_cached_block(req0.block_hashes[11], [1])
@@ -3559,8 +3566,12 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary():
 
     shorter_req = make_request("2", token_ids[: 12 * block_size], block_size, sha256)
     computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(shorter_req)
-    assert num_computed_tokens == 0
-    assert len(computed_blocks.blocks[1]) == 0
+    # Under the LOW-priority scheme every SWA block is cached (LOW for
+    # intermediates, NORMAL only for the replay boundary), so the shorter
+    # request's own replay boundary (previous LCM boundary = 64 tokens) is
+    # reachable via the LOW-priority tail block. The hit lands at 64 tokens.
+    assert num_computed_tokens == 8 * block_size
+    assert len(computed_blocks.blocks[1]) == 8
 
 
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
@@ -3622,13 +3633,21 @@ def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11, 12}
+    # Blocks past the coordinator's LCM+EAGLE clamp (104 tokens -> 13 blocks)
+    # are not cached at all. Within the clamp, blocks 11 and 12 carry NORMAL
+    # priority (the EAGLE/MTP replay tail); everything else is cached at LOW.
+    normal_expected = {11, 12}
+    uncached_expected = {13, 14}
     for i in range(15):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
-        if i in expected_swa_cached:
-            assert cached is not None, f"SWA hash {i} should be cached"
-        else:
+        if i in uncached_expected:
             assert cached is None, f"SWA hash {i} should not be cached"
+            continue
+        assert cached is not None, f"SWA hash {i} should be cached"
+        expected = BlockPriority.NORMAL if i in normal_expected else BlockPriority.LOW
+        assert cached[0].priority == expected, (
+            f"SWA hash {i} should have priority {expected.name}"
+        )
 
     manager.free(req0)
 
@@ -4000,9 +4019,9 @@ def test_cache_hit_local_and_external_two_groups_preempt_and_reallocate():
 
 
 def test_swa_free_split_keeps_cached_tail_ahead_of_scratch():
-    """Dense retention: freeing an SWA request must place its
-    uncached scratch blocks at the front of the free queue (recycled first)
-    and keep its cached checkpoint blocks at the back (retained for prefix
+    """Dense retention: freeing an SWA request must place its ``LOW``-priority
+    scratch blocks at the front of the free queue (recycled first) and keep
+    its ``NORMAL``-priority checkpoint blocks at the back (retained for prefix
     hits). This split is always-on, independent of the retention interval."""
     block_size = 8
     kv_cache_config = KVCacheConfig(
@@ -4050,21 +4069,24 @@ def test_swa_free_split_keeps_cached_tail_ahead_of_scratch():
 
     swa_manager = manager.coordinator.single_type_managers[1]
     null_block = manager.block_pool.null_block
-    cached_ids: set[int] = set()
-    uncached_ids: set[int] = set()
-    cached_hash_indices: list[int] = []
+    normal_ids: set[int] = set()
+    low_ids: set[int] = set()
+    normal_hash_indices: list[int] = []
     for i, block in enumerate(swa_manager.req_to_blocks[req.request_id]):
         if block is null_block:
             continue
-        if block.block_hash is None:
-            uncached_ids.add(block.block_id)
+        assert block.block_hash is not None, (
+            "under the LOW-priority scheme every non-null SWA block is cached"
+        )
+        if block.priority == BlockPriority.NORMAL:
+            normal_ids.add(block.block_id)
+            normal_hash_indices.append(i)
         else:
-            cached_ids.add(block.block_id)
-            cached_hash_indices.append(i)
-    # The dense default mask caches only the per-segment tails, so a 16-block
-    # SWA prompt must produce a mix of retained and scratch blocks.
-    assert cached_ids, "expected some retained (cached) SWA tail blocks"
-    assert uncached_ids, "expected some scratch (uncached) SWA blocks"
+            low_ids.add(block.block_id)
+    # The dense default mask marks only the per-segment tails as NORMAL, so a
+    # 16-block SWA prompt must produce a mix of NORMAL and LOW retention.
+    assert normal_ids, "expected some NORMAL-priority SWA tail blocks"
+    assert low_ids, "expected some LOW-priority SWA scratch blocks"
 
     manager.free(req)
 
@@ -4072,10 +4094,10 @@ def test_swa_free_split_keeps_cached_tail_ahead_of_scratch():
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
     ]
     pos = {bid: i for i, bid in enumerate(order)}
-    # Every scratch block is recycled before every retained block.
-    assert max(pos[bid] for bid in uncached_ids) < min(pos[bid] for bid in cached_ids)
-    # The retained tails survive the free and still serve a prefix-cache hit.
-    for i in cached_hash_indices:
+    # Every LOW-priority block is recycled before every NORMAL-priority block.
+    assert max(pos[bid] for bid in low_ids) < min(pos[bid] for bid in normal_ids)
+    # The NORMAL-priority tails survive the free and still serve a hit.
+    for i in normal_hash_indices:
         assert (
             manager.block_pool.get_cached_block(
                 req.block_hashes[i], kv_cache_group_ids=[1]
@@ -4113,8 +4135,10 @@ def _make_pure_swa_manager(block_size, sliding_window, num_blocks=100, **kwargs)
 
 def test_pure_swa_retention_interval_caches_sparse_tails():
     """Sparse retention must work for a pure-SWA single-group model, not just
-    hybrid models: only the per-interval tails plus the latest replay tail are
-    cached, and a replay still hits the latest replayable boundary."""
+    hybrid models: all blocks are cached, but only the per-interval tails plus
+    the latest replay tail carry ``NORMAL`` priority; every other block is
+    kept at ``LOW`` priority so it drains first under memory pressure. A replay
+    still hits the latest replayable boundary."""
     block_size = 16
     manager = _make_pure_swa_manager(
         block_size, sliding_window=block_size, retention_interval=64
@@ -4133,17 +4157,18 @@ def test_pure_swa_retention_interval_caches_sparse_tails():
     assert blocks is not None
 
     pool = manager.block_pool
-    cached = {
-        i
-        for i in range(16)
-        if pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[0])
-        is not None
-    }
     # per_segment = 64 / 16 = 4, need = cdiv(16-1, 16) = 1 -> segment tails at
     # i%4==3 -> {3,7,11,15}; latest replay boundary (255//16*16 = 240) -> tail
-    # block 14. Crucially this is a strict subset of all 16 blocks: retention
-    # is actually sparse for pure SWA (not silently dense).
-    assert cached == {3, 7, 11, 14, 15}
+    # block 14. These are the boundary states kept at NORMAL priority; every
+    # other block is cached at LOW priority (opportunistic retention).
+    normal_expected = {3, 7, 11, 14, 15}
+    for i in range(16):
+        cached = pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[0])
+        assert cached is not None, f"SWA hash {i} should be cached"
+        expected = BlockPriority.NORMAL if i in normal_expected else BlockPriority.LOW
+        assert cached[0].priority == expected, (
+            f"SWA hash {i} should have priority {expected.name}"
+        )
 
     # A replay of the same prompt hits the latest replayable boundary (240).
     replay = make_request("1", token_ids, block_size, sha256)
@@ -4152,7 +4177,8 @@ def test_pure_swa_retention_interval_caches_sparse_tails():
 
 
 def test_pure_swa_retention_latest_only():
-    """`=0` on a pure-SWA model keeps only the latest replay tail."""
+    """``=0`` on a pure-SWA model marks only the latest replay tail as
+    ``NORMAL`` priority; every other block is cached at ``LOW`` priority."""
     block_size = 16
     manager = _make_pure_swa_manager(
         block_size, sliding_window=block_size, retention_interval=0
@@ -4170,14 +4196,16 @@ def test_pure_swa_retention_latest_only():
     assert blocks is not None
 
     pool = manager.block_pool
-    cached = {
-        i
-        for i in range(16)
-        if pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[0])
-        is not None
-    }
-    # No segment tails (interval 0); only the latest replay tail (block 14).
-    assert cached == {14}
+    # No segment tails (interval 0); only the latest replay tail (block 14) is
+    # NORMAL priority. Everything else is cached at LOW priority.
+    normal_expected = {14}
+    for i in range(16):
+        cached = pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[0])
+        assert cached is not None, f"SWA hash {i} should be cached"
+        expected = BlockPriority.NORMAL if i in normal_expected else BlockPriority.LOW
+        assert cached[0].priority == expected, (
+            f"SWA hash {i} should have priority {expected.name}"
+        )
 
     replay = make_request("1", token_ids, block_size, sha256)
     _, num_computed, _ = manager.get_computed_blocks(replay)
@@ -4298,16 +4326,17 @@ def test_mamba_reachable_block_mask_pins_shared_prefix():
 def test_mamba_shared_prefix_survives_zero_retention():
     """Manager-level check of the full wiring: a pinned shared-prefix boundary
     (``Request.shared_prefix_boundary``, set by the scheduler on Marconi-style
-    detection) keeps its Mamba state block cached under
-    ``prefix_cache_retention_interval=0``, which otherwise retains only the
-    end-of-prompt replay boundary. Without this, a shared prefix (junction
-    before ``num_prompt``) would be recomputed by every sharing request."""
+    detection) keeps its Mamba state block at ``NORMAL`` priority under
+    ``prefix_cache_retention_interval=0``, which otherwise only marks the
+    end-of-prompt replay boundary as ``NORMAL``. Without this, a shared prefix
+    (junction before ``num_prompt``) would drop out of the NORMAL retention set
+    and get evicted first under memory pressure."""
     block_size = 16
 
     # 16-block (256-token) prompt; replay boundary is block 240 // 16 - 1 = 14.
     token_ids = [i for i in range(16) for _ in range(block_size)]
 
-    def cached_mamba_blocks(shared_prefix_boundary):
+    def normal_priority_mamba_blocks(shared_prefix_boundary):
         # Fresh manager per scenario so cached blocks don't leak between runs.
         manager = make_kv_cache_manager(
             _make_hybrid_kv_cache_config(block_size, 100, ["full", "mamba"]),
@@ -4324,26 +4353,38 @@ def test_mamba_shared_prefix_survives_zero_retention():
         )
         assert blocks is not None
         pool = manager.block_pool
+        # Every non-null block is cached (LOW or NORMAL); return the subset
+        # that carries NORMAL priority (i.e. the durable retention set).
         return {
             i
             for i in range(16)
-            if pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[1])
+            if (
+                cached := pool.get_cached_block(
+                    req.block_hashes[i], kv_cache_group_ids=[1]
+                )
+            )
             is not None
+            and cached[0].priority == BlockPriority.NORMAL
         }
 
-    # Without a pinned boundary, retention=0 keeps only the replay boundary (14).
-    assert cached_mamba_blocks(0) == {14}
-    # Pinning the shared prefix at token 96 (state block 5) retains it too, so a
-    # later request sharing that prefix can hit the Mamba state.
-    assert cached_mamba_blocks(96) == {5, 14}
+    # Without a pinned boundary, retention=0 keeps only the replay boundary (14)
+    # at NORMAL priority; every other Mamba state falls into LOW retention.
+    assert normal_priority_mamba_blocks(0) == {14}
+    # Pinning the shared prefix at token 96 (state block 5) promotes it to
+    # NORMAL as well, so a later request sharing that prefix will not lose it
+    # to early eviction.
+    assert normal_priority_mamba_blocks(96) == {5, 14}
 
 
 def test_mamba_shared_prefix_reuse_under_zero_retention():
     """Full cross-request Marconi flow: a partial shared prefix cached by the
     detecting request must stay reusable by a later request under
-    ``prefix_cache_retention_interval=0``. Without the pin the junction is
-    masked out and the later request misses; with it (and under dense) the reuse
-    is preserved."""
+    ``prefix_cache_retention_interval=0``. Under the LOW-priority retention
+    scheme every masked block is still cached (just at LOW priority), so
+    without memory pressure the junction stays reachable in all three
+    configurations. The pin still matters under pressure — it promotes the
+    junction to NORMAL priority so eviction does not target it first — but
+    this test only verifies the reuse wiring, not the eviction policy."""
     block_size = 16
 
     def last_req_hit(retention, pin):
@@ -4360,7 +4401,8 @@ def test_mamba_shared_prefix_reuse_under_zero_retention():
             return [v for _ in range(2 * block_size)]
 
         # req0 primes the shared prefix's (dense) attention cache; align-mode
-        # Mamba keeps only its own tail, not the shared-prefix junction.
+        # Mamba keeps only its own tail at NORMAL retention, but the junction
+        # is still cached at LOW priority.
         req0 = make_request("0", shared + distinct(50), block_size, sha256)
         cb, nc, _ = manager.get_computed_blocks(req0)
         manager.allocate_slots(req0, len(req0.all_token_ids), nc, cb)
@@ -4380,11 +4422,13 @@ def test_mamba_shared_prefix_reuse_under_zero_retention():
         _, nc2, _ = manager.get_computed_blocks(req2)
         return nc2
 
-    # Dense retains the junction -> reuse works (baseline ceiling).
+    # Dense retains the junction at NORMAL -> reuse works.
     assert last_req_hit(retention=None, pin=False) == 2 * block_size
-    # retention=0 without the pin masks the junction out -> reuse lost (the bug).
-    assert last_req_hit(retention=0, pin=False) == 0
-    # retention=0 with the pin keeps the junction -> reuse restored.
+    # retention=0 without the pin keeps the junction at LOW priority; without
+    # memory pressure it is still cached and reachable, so reuse works.
+    assert last_req_hit(retention=0, pin=False) == 2 * block_size
+    # retention=0 with the pin promotes the junction back to NORMAL -> reuse
+    # is preserved even under eviction pressure.
     assert last_req_hit(retention=0, pin=True) == 2 * block_size
 
 
@@ -4590,9 +4634,11 @@ def test_mamba_reachable_block_mask_large_dcp_stays_sparse():
 
 def test_swa_shared_prefix_reuse_under_zero_retention():
     """SWA cross-request analog: a partial shared prefix's sliding-window tail
-    must stay reusable under ``prefix_cache_retention_interval=0``. Without
-    the pin the junction window is masked out and a later request misses; with
-    it (and under dense) reuse is preserved."""
+    must stay reusable under ``prefix_cache_retention_interval=0``. Under the
+    LOW-priority retention scheme every masked SWA block is still cached (at
+    LOW priority), so without memory pressure the junction stays reachable in
+    every configuration. The pin promotes the junction back to NORMAL for
+    eviction-resistance but does not affect reachability in this test."""
     block_size = 16
 
     def last_req_hit(retention, pin):
@@ -4608,18 +4654,19 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
         def distinct(v):
             return [v for _ in range(2 * block_size)]
 
-        # req0 primes the (dense) full-attention cache; SWA under RET=0 keeps
-        # only its own replay window, not the shared-prefix boundary.
+        # req0 primes the (dense) full-attention cache; SWA under RET=0 marks
+        # only its own replay window at NORMAL priority, but every other tail
+        # is still cached at LOW priority.
         req0 = make_request("0", shared + distinct(50), block_size, sha256)
         cb, nc, _ = manager.get_computed_blocks(req0)
         manager.allocate_slots(req0, len(req0.all_token_ids), nc, cb)
 
-        # req1 detects the shared prefix (full-attn hit, SWA lag). No chunk for
-        # SWA -- the pin fires during normal prefill.
+        # req1 previously detected a shared-prefix junction when SWA "lagged"
+        # behind full-attention (SWA had gaps under retention=0 masking). Under
+        # the LOW-priority scheme SWA no longer lags — every block is cached —
+        # so no junction is reported and the pin path is a no-op in this test.
         req1 = make_request("1", shared + distinct(60), block_size, sha256)
         cb, nc, boundary = manager.get_computed_blocks(req1)
-        if retention == 0:
-            assert boundary == 4 * block_size  # junction detected when SWA lags
         if pin and boundary:
             req1.shared_prefix_boundary = boundary
         manager.allocate_slots(req1, len(req1.all_token_ids), nc, cb)
@@ -4629,9 +4676,11 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
         _, nc2, _ = manager.get_computed_blocks(req2)
         return nc2
 
-    # Dense keeps every SWA tail -> reuse works (ceiling).
+    # Dense keeps every SWA tail at NORMAL -> reuse works.
     assert last_req_hit(retention=None, pin=False) == 4 * block_size
-    # retention=0 without the pin drops the junction window -> reuse lost (bug).
-    assert last_req_hit(retention=0, pin=False) == 0
-    # retention=0 with the pin keeps the junction window -> reuse restored.
+    # retention=0 without the pin: junction tail is cached at LOW priority
+    # -> still reachable without eviction pressure, so reuse works.
+    assert last_req_hit(retention=0, pin=False) == 4 * block_size
+    # retention=0 with the pin promotes the junction window to NORMAL ->
+    # reuse survives even under eviction pressure.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -15,6 +15,7 @@ from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     BlockHashWithGroupId,
+    BlockPriority,
     ExternalBlockHash,
     FreeKVCacheBlockQueue,
     KVCacheBlock,
@@ -250,11 +251,13 @@ class BlockPool:
             kv_cache_group_id: The id of the KV cache group.
             block_mask: Optional mask aligned with
                 ``blocks[num_cached_blocks:num_full_blocks]``. When provided,
-                blocks where the mask is False are skipped (treated like null
-                blocks). Used by groups whose ``find_longest_cache_hit`` only
-                consults a subset of blocks (e.g. SWA tail-window), so blocks
-                that can never serve a hit stay out of the prefix-cache hash
-                map.
+                blocks where the mask is False are still cached but tagged
+                with ``BlockPriority.LOW`` so eviction drains them before
+                ``NORMAL`` cached blocks. Used by groups whose
+                ``find_longest_cache_hit`` only consults a subset of blocks
+                (e.g. SWA tail-window / Mamba boundary states): non-tail
+                blocks stay reachable in the prefix cache but yield first
+                when the pool comes under pressure.
         """
         if num_cached_blocks >= num_full_blocks:
             return
@@ -269,10 +272,8 @@ class BlockPool:
             [] if self.enable_kv_cache_events else None
         )
         for i, blk in enumerate(new_full_blocks):
-            # Some blocks may be null or masked out when enabling sparse attention
-            # like sliding window attention, or Mamba models with prefix-caching
-            # in align mode. We skip null blocks here.
-            if blk.is_null or (block_mask is not None and not block_mask[i]):
+            # Skip null blocks
+            if blk.is_null:
                 continue
             block_hash = new_block_hashes[i]
             num_hash_tokens = (num_cached_blocks + i + 1) * block_size
@@ -295,6 +296,8 @@ class BlockPool:
                 blk,
                 num_tokens=num_hash_tokens,
             )
+            if block_mask is not None and not block_mask[i]:
+                blk.priority = BlockPriority.LOW
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
 
@@ -313,13 +316,11 @@ class BlockPool:
             # Generate extra keys for each block individually.
             # Each block may have different extra_keys (e.g., different MM
             # features, or cache_salt only for the first block).
-            # Skip null/masked-out blocks to match the length of new_hashes.
+            # Skip null blocks to match the length of new_hashes.
             extra_keys_list: list[tuple[Any, ...] | None] = []
             curr_mm_idx = 0
             for i in range(num_cached_blocks, num_full_blocks):
                 if blocks[i].is_null:
-                    continue
-                if block_mask is not None and not block_mask[i - num_cached_blocks]:
                     continue
                 block_start = i * block_size
                 block_end = block_start + block_size
@@ -642,9 +643,13 @@ class BlockPool:
         assert dst_block.block_hash is None
         assert dst_block.block_id not in self.cached_block_hashes_by_block
         num_tokens = src_block.block_hash_num_tokens
+        # ``_remove_cached_block_hashes`` resets ``src_block``'s priority;
+        # snapshot it so the durable copy inherits the same eviction class.
+        src_priority = src_block.priority
         for block_hash in self._remove_cached_block_hashes(src_block):
             # `num_tokens` only applies to the first (primary) insertion.
             self._insert_block_hash(block_hash, dst_block, num_tokens=num_tokens)
+        dst_block.priority = src_priority
 
     def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
         """Get new blocks from the free block pool.
@@ -715,6 +720,10 @@ class BlockPool:
             if block.ref_cnt == 0 and not block.is_null:
                 self.free_block_queue.remove(block)
             block.ref_cnt += 1
+            # A prefix-cache hit proves the block was worth retaining, so
+            # promote LOW-priority (sparse-retention) blocks back to NORMAL
+            if block.priority != BlockPriority.NORMAL:
+                block.priority = BlockPriority.NORMAL
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
@@ -732,6 +741,7 @@ class BlockPool:
         """
         # Identify blocks with hash (LRU cache) and without it (never match APC)
         blocks_to_evict_last = []
+        blocks_low_priority = []
         blocks_to_evict_first = []
         for block in ordered_blocks:
             block.ref_cnt -= 1
@@ -739,10 +749,14 @@ class BlockPool:
                 if block.block_hash is None or not self.enable_caching:
                     # LIFO reuse of non-cached blocks for better GPU locality.
                     blocks_to_evict_first.append(block)
+                elif block.priority == BlockPriority.LOW:
+                    blocks_low_priority.append(block)
                 else:
                     # FIFO reuse of cached blocks for LRU eviction behavior.
                     blocks_to_evict_last.append(block)
 
+        # Desired ordering: [to_evict_first | low_priority | ... | to_evict_last]
+        self.free_block_queue.prepend_n(blocks_low_priority)
         # Blocks to reuse first are prepended to the front of the free queue.
         self.free_block_queue.prepend_n(blocks_to_evict_first)
         # Blocks to reuse last are appended to the end of the free queue.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -9,6 +9,7 @@ import os
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
+from enum import IntEnum
 from functools import partial
 from typing import Any, NamedTuple, NewType, TypeAlias, cast, overload
 
@@ -160,6 +161,15 @@ def init_none_hash(hash_fn: Callable[[Any], bytes]):
     NONE_HASH = BlockHash(hash_fn(_NONE_HASH_SEED))
 
 
+class BlockPriority(IntEnum):
+    """Cache priority for a block."""
+
+    # Keep opportunisticially (FIFO), as the probability of matching is low
+    LOW = 0
+    # Standard LRU policy (LIFO)
+    NORMAL = 1
+
+
 @dataclass(slots=True)
 class KVCacheBlock:
     """KV-cache block metadata."""
@@ -168,6 +178,8 @@ class KVCacheBlock:
     block_id: int
     # Reference count.
     ref_cnt: int = 0
+    # Cache priority
+    priority: BlockPriority = BlockPriority.NORMAL
     # The hash key (block hash + group id) of the block, only available
     # when the block is full and cached.
     _block_hash: BlockHashWithGroupId | None = None
@@ -206,6 +218,7 @@ class KVCacheBlock:
         """Reset the block hash when the block is evicted."""
         self._block_hash = None
         self._block_hash_num_tokens = None
+        self.priority = BlockPriority.NORMAL
 
     def __repr__(self) -> str:
         # Use block_id instead of KVCacheBlock object to avoid calling __repr__


### PR DESCRIPTION
## Purpose
Recently `prefix_cache_retention_interval` has been introduced (https://github.com/vllm-project/vllm/pull/43447 https://github.com/vllm-project/vllm/pull/45845), affecting hybrid models such as DeepSeekv4, KIMI K3, Qwen 3.5, etc. When  `prefix_cache_retention_interval` is not `None`, cache entries with low matching probabilities are masked, skipped hash assignment, and evicted in FIFO manner rather than LIFO (LRU). Cache hits can only occur then at designated blocks and via specific mechanisms, such as Marconi shared prefix detection (https://github.com/vllm-project/vllm/pull/37898) that provides cache hits on 3rd appearance of shared prefix.

In this PR, we notice that **the masked blocks**:
- **have valid data that could potentially result in APC hits**
- **compute effort has been spent on them**

**Rather than completely discarding them, we enable opportunistic APC hits.** To achieve this the PR: 
- introduces Block priorities (currently NORMAL and LOW), where masked blocks are assigned LOW priority and still considered in the APC matching
- the eviction mechanism extends the free_blocks queue in the following manner:
  `[hash-less blocks | LOW PRIORITY | ... | NORMAL PRIORITY]`
- thus it retains the LIFO logic for normal blocks, and FIFO logic for masked blocks
- but if there is no memory pressure, the LOW priority blocks have a chance to be hit

The core logic is in `vllm/v1/core/kv_cache_utils.py` and `vllm/v1/core/block_pool.py` with around 20 lines of code touched. 

A synthetic test with truncated shared prefixes that simulates:
* 2nd appearance of shared prefix (not captured by Marconi shared prefix detection yet)
* user roll-back

demonstrates valid cache hits for masked blocks and **35% prefill time reduction** for `prefix_cache_retention_interval=0` with `Qwen/Qwen3.5-9B`

AI assistance disclosure: development of the code in this PR (all tests, some parts of core logic) was assisted with AI. 

@tdoublep 

## Test Plan
```
if __name__ == "__main__":
    from vllm import LLM, SamplingParams
    from vllm.distributed import cleanup_dist_env_and_memory
    import time, string
    # Should be even more visible for DeepSeekV4 and KIMI K3
    MODEL = "Qwen/Qwen3.5-9B"
    sampling_params = SamplingParams(temperature=0.0, max_tokens=1)
    prefix1 = ( # examples/offline_inference/prefix_caching.py
        "You are an expert school principal, skilled in effectively managing "
        "faculty and staff. Draft 10-15 questions for a potential first grade "
        "Head Teacher for my K-12, all-girls', independent school that emphasizes "
        "community, joyful discovery, and life-long learning. The candidate is "
        "coming in for a first-round panel interview for a 8th grade Math "
        "teaching role. They have 5 years of previous teaching experience "
        "as an assistant teacher at a co-ed, public school with experience "
        "in middle school math teaching. ")
    prefix2 = ("Based on these information, fulfill "
                "the following paragraph: ")
    PROMPTS = []
    for i in range(10):
        PROMPTS.append(str(i) + prefix1 * 200 + prefix2)
        # Simulate partial match, e.g.:
        #  - user roll-back in conversation
        #  - 2nd system prompt appearance
        PROMPTS.append(str(i) + prefix1 * 190 + prefix2)

    for RET in [None, 0]:
        engine = LLM(prefix_cache_retention_interval=RET,
            model=MODEL, gpu_memory_utilization=0.4, disable_log_stats=False)
        print(f"Block size: {engine.llm_engine.vllm_config.cache_config.block_size}")
        # Measure:
        start_time = time.time()
        for prompt in PROMPTS:
            outputs = engine.generate(prompt, sampling_params)
            n_prefill = len(outputs[0].prompt_token_ids)
            print(f"Prefill tokens: {n_prefill} | Generated text: {outputs[0].outputs[0].text!r}")
        total_time = time.time() - start_time
        # Summary
        print('Execution with RET:', RET, "took --- %s seconds ---" % total_time)
        for m in engine.llm_engine.get_metrics():
            if 'vllm:prompt_tokens_cached' in m.name:
                print(m.name, m.value)
        del engine
        cleanup_dist_env_and_memory()
```
## Test Result
**Main:**
```
[...]
Execution with RET: None took --- 20.84550404548645 seconds ---
vllm:prompt_tokens_cached 158400
[...]
Execution with RET: 0 took --- 32.47444725036621 seconds ---
vllm:prompt_tokens_cached 0
```
**This PR:**
```
[...]
Execution with RET: None took --- 20.97832942008972 seconds ---
vllm:prompt_tokens_cached 158400
[...]
Execution with RET: 0 took --- 21.07378101348877 seconds ---
vllm:prompt_tokens_cached 158400
```
Executed on 1x A100.