### PR TITLE
[Bugfix] Rank NVFP4 CuteDSL W4A16 kernel below the native W4A4 kernels

### DIFF
--- a/tests/model_executor/kernels/test_nvfp4_kernel_priority.py
+++ b/tests/model_executor/kernels/test_nvfp4_kernel_priority.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Priority invariants for NVFP4 linear kernel auto-selection."""
+
+from vllm.model_executor.kernels.linear import (
+    _POSSIBLE_NVFP4_KERNELS,
+    FlashInferCuteDslNvFp4W4A16LinearKernel,
+    MarlinNvFp4LinearKernel,
+)
+from vllm.platforms import PlatformEnum
+
+_CUDA_KERNELS = _POSSIBLE_NVFP4_KERNELS[PlatformEnum.CUDA]
+
+
+def test_w4a16_cutedsl_stays_in_the_a16_tier():
+    """Complements ``test_nvfp4_kernel_selection.py``, which pins the W4A16
+    kernel below the W4A4 kernels that run on sm_12x. This pins the other
+    side: it must stay immediately above Marlin.
+
+    The A16 kernels form a tier -- Marlin has always outranked Trtllm, cuDNN
+    and Fbgemm, so "every W4A4 kernel first" is not the invariant here.
+    Demoting the CuTe-DSL W4A16 kernel below those three would promote them
+    above the A16 tier for the first time on any release; promoting it splits
+    the two A16 siblings apart.
+    """
+    assert (
+        _CUDA_KERNELS.index(FlashInferCuteDslNvFp4W4A16LinearKernel)
+        == _CUDA_KERNELS.index(MarlinNvFp4LinearKernel) - 1
+    ), "the two A16 kernels must stay adjacent, CuTe-DSL W4A16 preferred"


### PR DESCRIPTION


## Purpose

Fixes #55397.

`_POSSIBLE_NVFP4_KERNELS[PlatformEnum.CUDA]` is scanned first-match-wins. `FlashInferCuteDslNvFp4W4A16LinearKernel` sat at position 2 with a gate accepting `120 <= cc < 130`, while the CuteDSL W4A4 kernel above it is gated to sm_10x. So on any SM12x device the scan rejects #1, stops on #2 — which dequantizes to 16-bit activations — and never reaches the native W4A4 kernels beneath it. A W4A4 checkpoint silently gets an A16 path. Reported as ~31% prefill loss on GB10, fully recovered by `VLLM_DISABLED_KERNELS=FlashInferCuteDslNvFp4W4A16LinearKernel`.

This moves the kernel down to its A16 peers, above `MarlinNvFp4LinearKernel`. That preserves the CuteDSL-over-Marlin preference the explicit `use_a16` path already encodes, and resolves a contradiction: that path deliberately sends SM12x to Marlin, while the default W4A4 path handed SM12x to this kernel first.

**The change is confined to sm_12x by construction.** `has_flashinfer_bf16_fp4()` transitively requires `has_flashinfer()`, so this kernel's availability is a strict subset of the sm_10x CuteDSL kernel's — on sm_100/103 that kernel wins whenever this one would have. Position 2 was reachable only on sm_12x.

The issue's alternative (widening #1's gate to family 120) was not taken: the CuteDSL MMA op hardcodes sm_100a/sm_103a (NVIDIA/TensorRT-LLM#11368), and it would leave the ordering defect for the next A16 kernel added near the top.

Not a duplicate — #55397 has no fix PR, and the open SM12x/NVFP4 PRs (#50288, #47577, #46329, #41834) are MoE/KV-cache/MLA paths. #54666 is the MoE-side analogue, untouched here.

## Test Plan

```bash
.venv/bin/python -m pytest tests/model_executor/kernels/test_nvfp4_kernel_priority.py -v
.venv/bin/python -m pytest tests/model_executor/kernels/test_b12x_linear.py \
                           tests/fusion/test_quant_activation_contract.py -q
pre-commit run --files vllm/model_executor/kernels/linear/__init__.py \
                       tests/model_executor/kernels/test_nvfp4_kernel_priority.py
```

## Test Result

| Check | Result |
|---|---|
| `test_nvfp4_kernel_priority.py` (new) | **1 passed** — verified genuine: fails on unmodified code (`assert 2 < 1`), passes with the reorder |
| `test_b12x_linear.py` + `test_quant_activation_contract.py` | 28 passed, 5 errors — byte-identical on unmodified code, environmental (`Failed to infer device type`; vLLM not built in this checkout) |
| ruff check / ruff format | Passed |
| mypy (3.10) | Passed |
| SPDX headers, typos, import checks | Passed |
| `update-dockerfile-graph` | Fails with `Executable /bin/bash not found` on this Windows host — identical on untouched files; no Dockerfile in the diff |

**Selected kernel on sm_121:**

| | NVFP4 GEMM kernel |
|---|---|
| Before | `FlashInferCuteDslNvFp4W4A16LinearKernel` |
| After | `FlashInferCutlassNvFp4LinearKernel` |

Matches the reporter's recovered arm exactly, i.e. the configuration they benchmarked at **+27.5% prefill** in their single-variable TP=1 repro.

Those throughput numbers are the reporter's, not reproduced here. I have no SM12x hardware, so no model eval accompanies this PR; since kernel choice can affect numerics (native W4A4 vs dequantized W4A16), an eval on GB10 is still wanted. Behavior on other SM12x parts (RTX 5090, sm_120) is unverified — `cutlass_fp4_supported()` is a runtime check, and if it fails there selection continues to B12x/Cutlass rather than W4A16, still better than today but untested.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>