### PR TITLE
[Bugfix] Pass CPU sequence lengths to TRT-LLM ragged prefill

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -9,7 +9,7 @@ Known Issues:
 """
 
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -46,6 +46,9 @@ from vllm.v1.attention.backends.mla.prefill.base import MLADimensions
 from vllm.v1.attention.backends.mla.prefill.selector import (
     MLAPrefillSelectorConfig,
 )
+from vllm.v1.attention.backends.mla.prefill.trtllm_ragged import (
+    TrtllmRaggedPrefillBackend,
+)
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.ops.flashmla import is_flashmla_dense_supported
 from vllm.v1.kv_cache_interface import (
@@ -67,6 +70,47 @@ if current_platform.is_rocm():
     BACKENDS_TO_TEST.append(AttentionBackendEnum.ROCM_AITER_MLA)
 
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_trtllm_ragged_prefill_passes_cpu_sequence_lengths(monkeypatch):
+    calls = []
+
+    def fake_trtllm_ragged_attention_deepseek(**kwargs):
+        calls.append(kwargs)
+        if kwargs["return_lse"]:
+            query = kwargs["query"]
+            lse = torch.empty(query.shape[:2])
+            return kwargs["out"], lse
+        return kwargs["out"]
+
+    prefill_module = ModuleType("flashinfer.prefill")
+    prefill_module.__dict__["trtllm_ragged_attention_deepseek"] = (
+        fake_trtllm_ragged_attention_deepseek
+    )
+    flashinfer_module = ModuleType("flashinfer")
+    flashinfer_module.__dict__["prefill"] = prefill_module
+    monkeypatch.setitem(sys.modules, "flashinfer", flashinfer_module)
+    monkeypatch.setitem(sys.modules, "flashinfer.prefill", prefill_module)
+
+    backend = object.__new__(TrtllmRaggedPrefillBackend)
+    backend.scale = 0.125
+    backend._workspace_buffer = torch.empty(1, dtype=torch.uint8)
+    query_lens_cpu = torch.tensor([2, 3], dtype=torch.int32)
+    prefill_metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
+        query_lens_cpu=query_lens_cpu,
+        max_query_len=3,
+        output_dtype=torch.float16,
+    )
+    backend.prepare_metadata(prefill_metadata)
+
+    q = torch.empty(5, 2, 4)
+    k = torch.empty_like(q)
+    v = torch.empty_like(q)
+    backend.run_prefill_new_tokens(q, k, v, return_softmax_lse=False)
+
+    assert calls[0]["q_seq_lens_cpu"] is query_lens_cpu
+    assert calls[0]["kv_seq_lens_cpu"] is query_lens_cpu
 
 
 @pytest.mark.parametrize(
@@ -1383,6 +1427,8 @@ def run_attention_backend(
             common_prefix_len=0,
             common_attn_metadata=common_attn_metadata,
         )
+        if attn_metadata.prefill is not None:
+            assert attn_metadata.prefill.query_lens_cpu is not None
 
         # Create output buffer
         num_tokens = query.shape[0]

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2542,6 +2542,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 output_dtype=self.model_config.dtype,
                 q_data_type=self.q_data_type,
                 prefill_backend=self._prefill_backend,
+                query_lens_cpu=prefill_query_lens_cpu,
             )
 
             self._prefill_backend.prepare_metadata(prefill_metadata)

--- a/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
+++ b/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
@@ -91,6 +91,8 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
         self._query_seq_lens = (
             prefill_metadata.query_start_loc[1:] - prefill_metadata.query_start_loc[:-1]
         )
+        assert prefill_metadata.query_lens_cpu is not None
+        self._query_seq_lens_cpu = prefill_metadata.query_lens_cpu
 
     def supports_out(self) -> bool:
         # Output head dim is v.shape[-1] == v_head_dim, so `out` is unpadded.
@@ -135,6 +137,8 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
             is_causal=True,
             return_lse=return_softmax_lse,
             out=out,
+            q_seq_lens_cpu=self._query_seq_lens_cpu,
+            kv_seq_lens_cpu=self._query_seq_lens_cpu,
         )
 
         if isinstance(ret, tuple):
@@ -180,6 +184,8 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
             is_causal=False,
             return_lse=True,
             out=out,
+            q_seq_lens_cpu=self._query_seq_lens_cpu[chunk.request_slice],
+            kv_seq_lens_cpu=chunk.seq_lens,
         )
 
         # Convert from (q_len, num_heads) to (num_heads, q_len)


### PR DESCRIPTION
## Purpose

The B200 LM Eval PCP lane fails deterministically for both GLM-5.2 configs when the DeepSeek-v3.2 sparse-MLA prefill path calls FlashInfer's `trtllm_ragged_attention_deepseek`. Without trusted host sequence lengths, FlashInfer derives them from CUDA indptrs and evaluates `.any().item()`, which vLLM correctly rejects as a GPU-to-CPU synchronization.

This change:

- preserves the already-computed CPU query lengths in `MLACommonPrefillMetadata`;
- passes trusted CPU query/KV lengths to FlashInfer for new-token prefill;
- passes the corresponding host query/context lengths for context chunks.

This avoids the synchronization without disabling vLLM's sync guard or reverting PCP. It addresses the current synchronization failure in issue #49810; it does not claim to resolve every PCP issue tracked there.

Duplicate-work checks found no open PR referencing #49810 and no open PR matching the TRT-LLM ragged/CPU-sequence-length fix. The older PR #49196 is a much broader PCP revert and is not equivalent.

AI assistance was used to investigate the failure, prepare the code and tests, and draft this description. The human submitter reviewed every changed line and confirmed running the relevant tests before PR submission.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/attention/test_mla_backends.py -q
.venv/bin/python -m pytest \
  tests/v1/attention/test_mla_context_chunks.py \
  tests/v1/attention/test_mla_prefill_registry.py -q
.venv/bin/pre-commit run --files \
  tests/v1/attention/test_mla_backends.py \
  vllm/model_executor/layers/attention/mla_attention.py \
  vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
git diff --check origin/main...HEAD
```

Post-fix model evaluation requires B200 hardware and was not available locally. Request the exact `B200: LM Eval (PCP)` lane on this PR; the fix should not be considered proven until both GLM-5.2 PCP configs complete successfully.

## Test Result

- `test_mla_backends.py`: **42 passed, 292 skipped**
- MLA context-chunk and prefill-registry tests: **20 passed**
- Focused CPU-sequence-length regression test: **1 passed, 333 deselected**
- Pre-commit hooks on all changed files: **passed**
- `git diff --check`: **passed**

Pre-fix exact evidence: upstream main build #87024 failed the B200 PCP job on both the original and retry across two B200 hosts with the same FlashInfer `.any().item()` synchronization stack; builds #86943 and #86851 show the same failure family.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the related issue and non-duplicate explanation.
- [x] The test plan, including exact commands.
- [x] The local test results and required B200 model-evaluation follow-up.
- [x] No documentation update is needed for this internal attention-backend fix.
</details>
