### PR TITLE
[CI][ROCm] Restore Wikitext coverage for Qwen OCP-MX

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP4-A-MXFP6.yaml
+++ b/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP4-A-MXFP6.yaml
@@ -1,5 +1,0 @@
-model_name: "fxmarty/qwen1.5_moe_a2.7b_chat_w_fp4_a_fp6_e2m3"
-accuracy_threshold: 0.4405
-num_questions: 50
-num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP6-A-MXFP6.yaml
+++ b/tests/evals/gsm8k/configs/Qwen-1.5-MOE-W-MXFP6-A-MXFP6.yaml
@@ -1,5 +1,0 @@
-model_name: "fxmarty/qwen1.5_moe_a2.7b_chat_w_fp6_e3m2_a_fp6_e3m2"
-accuracy_threshold: 0.5049
-num_questions: 50
-num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/models-gfx950-large.txt
+++ b/tests/evals/gsm8k/configs/models-gfx950-large.txt
@@ -7,5 +7,3 @@
 # DeepSeek-V4-Pro-NVFP4.yaml
 DeepSeek-V4-Flash-NVFP4.yaml
 Qwen3-30B-A3B-NVFP4-quark.yaml
-Qwen-1.5-MOE-W-MXFP4-A-MXFP6.yaml
-Qwen-1.5-MOE-W-MXFP6-A-MXFP6.yaml

--- a/tests/evals/gsm8k/configs/models-mi3xx.txt
+++ b/tests/evals/gsm8k/configs/models-mi3xx.txt
@@ -6,5 +6,3 @@ Qwen3-30B-A3B-NVFP4.yaml
 Qwen3-30B-A3B-NVFP4-quark.yaml
 Qwen3.5-35B-A3B-MXFP4-AITER-TP2.yaml
 Qwen3.5-35B-A3B-MXFP4-EMU-TP2.yaml
-Qwen-1.5-MOE-W-MXFP4-A-MXFP6.yaml
-Qwen-1.5-MOE-W-MXFP6-A-MXFP6.yaml

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -1125,6 +1125,44 @@ class AccuracyTestConfig:
         return model_args
 
 
+WIKITEXT_ACCURACY_CONFIGS = [
+    AccuracyTestConfig(
+        model_name="fxmarty/qwen1.5_moe_a2.7b_chat_w_fp4_a_fp6_e2m3",
+        excepted_value=11.3,
+    ),
+    AccuracyTestConfig(
+        model_name="fxmarty/qwen1.5_moe_a2.7b_chat_w_fp6_e3m2_a_fp6_e3m2",
+        excepted_value=10.6,
+    ),
+]
+
+
+@pytest.mark.skipif(
+    not QUARK_MXFP4_AVAILABLE,
+    reason=f"amd-quark>={QUARK_MXFP4_MIN_VERSION} is not available",
+)
+@pytest.mark.parametrize(
+    "config", WIKITEXT_ACCURACY_CONFIGS, ids=lambda config: config.model_name
+)
+@pytest.mark.parametrize("tp_size", [1, 2])
+def test_ocp_mx_wikitext_correctness(config: AccuracyTestConfig, tp_size: int):
+    device_count = torch.accelerator.device_count()
+    if device_count < tp_size:
+        pytest.skip(f"This test requires >={tp_size} gpus, got only {device_count}")
+
+    results = lm_eval.simple_evaluate(
+        model="vllm",
+        model_args=config.get_model_args(
+            tp_size=tp_size, kwargs={"cudagraph_capture_sizes": [16]}
+        ),
+        tasks="wikitext",
+        batch_size=64,
+    )
+
+    measured_value = results["results"]["wikitext"]["word_perplexity,none"]
+    assert measured_value == pytest.approx(config.excepted_value, abs=0.1)
+
+
 GSM8K_ACCURACY_CONFIGS = [
     # Private model.
     AccuracyTestConfig(


### PR DESCRIPTION
- Restore Wikitext perplexity checks for the two Qwen 1.5 MoE OCP-MX checkpoints.
- Preserve the original baselines (11.3 and 10.6), absolute tolerance 0.1, and TP1/TP2 coverage.
- Remove their two 50-question GSM8K configs and MI3xx/gfx950 model-list entries.

[#53291](https://github.com/vllm-project/vllm/pull/53291) moved these models to GSM8K, and [AMD nightly 12635](https://buildkite.com/vllm/amd-ci/builds/12635#01a06ba6-75e5-4917-b8e0-5e93030cfc74) failed at 0.42 against a 0.4249 minimum before passing its retry at 0.54. This replaces GSM8K reasoning coverage with quantization/perplexity coverage; the answer variation despite fixed questions, temperature 0, and seed 42 remains unexplained.
