### PR TITLE
[Spec Decode] Add per-request `disable_spec_decode` to SamplingParams

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6339,3 +6339,77 @@ def test_encoder_input_skipped_when_connector_already_has_the_item(ec_role: str)
 
     assert output.num_scheduled_tokens[req_id] > 0
     assert not output.scheduled_encoder_inputs.get(req_id)
+
+
+def test_no_spec_tokens_for_disable_spec_decode_requests():
+    """Requests with `SamplingParams.disable_spec_decode=True` never get draft
+    tokens scheduled and are reported in `spec_decode_skip_req_ids`, while other
+    requests in the same batch keep speculating."""
+    num_spec_tokens = 3
+    scheduler = create_scheduler(num_speculative_tokens=num_spec_tokens)
+    # Separate create_requests calls: the helper shares one SamplingParams
+    # object across the requests of a single call.
+    (spec_req,) = create_requests(num_requests=1, num_tokens=10, req_ids=["spec"])
+    (plain_req,) = create_requests(num_requests=1, num_tokens=10, req_ids=["plain"])
+    plain_req.sampling_params.disable_spec_decode = True
+    requests = [spec_req, plain_req]
+    for req in requests:
+        scheduler.add_request(req)
+
+    # First step: prefill both.
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    assert output.spec_decode_skip_req_ids == {plain_req.request_id}
+    req_to_index = {req.request_id: i for i, req in enumerate(requests)}
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[req.request_id for req in requests],
+        req_id_to_index=req_to_index,
+        sampled_token_ids=[[42], [43]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_runner_output)
+
+    # Drafter proposes for both; the disabled request's drafts are dropped.
+    scheduler.update_draft_token_ids(
+        DraftTokenIds(
+            [spec_req.request_id, plain_req.request_id], [[1, 2, 3], [4, 5, 6]]
+        )
+    )
+    assert spec_req.spec_token_ids == [1, 2, 3]
+    assert plain_req.spec_token_ids == []
+
+    # Second step: only the speculating request gets spec tokens scheduled.
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[spec_req.request_id] == 1 + num_spec_tokens
+    assert output.num_scheduled_tokens[plain_req.request_id] == 1
+    assert output.scheduled_spec_decode_tokens == {spec_req.request_id: [1, 2, 3]}
+    assert output.spec_decode_skip_req_ids == {plain_req.request_id}
+
+
+def test_spec_decode_skip_req_ids_none_without_disabled_requests():
+    scheduler = create_scheduler(num_speculative_tokens=2)
+    requests = create_requests(num_requests=2, num_tokens=10)
+    for req in requests:
+        scheduler.add_request(req)
+    output = scheduler.schedule()
+    assert output.spec_decode_skip_req_ids is None
+
+
+def test_update_draft_token_ids_in_output_invalidates_disabled_requests():
+    """Async-scheduling path: placeholder draft slots of a request with
+    speculative decoding disabled are all reported invalid."""
+    num_spec_tokens = 2
+    scheduler = create_scheduler(num_speculative_tokens=num_spec_tokens)
+    (req,) = create_requests(num_requests=1, num_tokens=10)
+    req.sampling_params.disable_spec_decode = True
+    scheduler.add_request(req)
+    output = scheduler.schedule()
+    # Simulate the placeholder slots the async scheduler would have reserved.
+    output.scheduled_spec_decode_tokens[req.request_id] = [-1] * num_spec_tokens
+    scheduler.update_draft_token_ids_in_output(
+        DraftTokenIds([req.request_id], [[7, 8]]), output
+    )
+    assert output.scheduled_spec_decode_tokens[req.request_id] == [-1, -1]
+    assert output.num_invalid_spec_tokens == {req.request_id: num_spec_tokens}

--- a/tests/v1/e2e/spec_decode/ngram_suffix/test_disable_spec_decode.py
+++ b/tests/v1/e2e/spec_decode/ngram_suffix/test_disable_spec_decode.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.utils import single_gpu_only
+from vllm import SamplingParams
+from vllm.config import CompilationConfig
+
+from ..utils import (
+    assert_request_outputs_match,
+    get_spec_decode_metric_value,
+    get_test_prompts,
+)
+
+
+@pytest.mark.parametrize(
+    "speculative_config",
+    [
+        {
+            "method": "ngram",
+            "prompt_lookup_max": 5,
+            "prompt_lookup_min": 3,
+            "num_speculative_tokens": 3,
+        },
+    ],
+)
+@single_gpu_only
+def test_per_request_disable_spec_decode(
+    speculative_config: dict,
+    model_name: str,
+    vllm_runner,
+):
+    """`SamplingParams.disable_spec_decode` turns speculative decoding off for
+    individual requests inside a batch that otherwise speculates: outputs are
+    unchanged (greedy) and no draft tokens are produced for those requests."""
+    prompts = get_test_prompts(mm_enabled=False, num_prompts=16)
+    greedy = SamplingParams(temperature=0, max_tokens=64)
+    greedy_no_spec = SamplingParams(
+        temperature=0, max_tokens=64, disable_spec_decode=True
+    )
+
+    with vllm_runner(
+        model_name,
+        block_size=None,
+        trust_remote_code=False,
+        enable_chunked_prefill=None,
+        max_model_len=4096,
+        compilation_config=CompilationConfig(),
+        disable_log_stats=False,
+    ) as ref_runner:
+        ref_outputs = ref_runner.llm.chat(prompts, greedy)
+
+    with vllm_runner(
+        model_name,
+        block_size=None,
+        trust_remote_code=False,
+        enable_chunked_prefill=None,
+        speculative_config=speculative_config,
+        max_model_len=4096,
+        compilation_config=CompilationConfig(),
+        disable_log_stats=False,
+    ) as spec_runner:
+        # Every request has speculation disabled: no drafts at all.
+        outputs_all_disabled = spec_runner.llm.chat(prompts, greedy_no_spec)
+        metrics = spec_runner.llm.get_metrics()
+        assert get_spec_decode_metric_value(metrics, "vllm:spec_decode_num_drafts") == 0
+
+        # Mixed batch: even prompts speculate, odd prompts do not.
+        mixed_params = [
+            greedy if i % 2 == 0 else greedy_no_spec for i in range(len(prompts))
+        ]
+        outputs_mixed = spec_runner.llm.chat(prompts, mixed_params)
+        metrics = spec_runner.llm.get_metrics()
+        assert get_spec_decode_metric_value(metrics, "vllm:spec_decode_num_drafts") > 0
+
+    # The byte-exact claim is the metric above: zero drafts are scheduled for
+    # flagged requests. Output text is held to the same bar as the other
+    # spec-decode e2e tests rather than exact equality: an engine configured
+    # for speculation still runs flagged rows through the uniform-decode batch
+    # shape (placeholder padding), so floating-point tie-breaks can differ from
+    # a no-spec engine even though no draft is ever proposed or verified.
+    required = int(0.6 * len(ref_outputs)) + 1
+    assert_request_outputs_match(
+        ref_outputs,
+        outputs_all_disabled,
+        required_matches=required,
+        context=f"disable_spec_decode on all requests, {model_name}",
+    )
+    assert_request_outputs_match(
+        ref_outputs,
+        outputs_mixed,
+        required_matches=required,
+        context=f"disable_spec_decode on alternating requests, {model_name}",
+    )

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -354,6 +354,11 @@ class SamplingParams(
     _bad_words_token_ids: list[list[int]] | None = None
 
     skip_reading_prefix_cache: bool | None = None
+    disable_spec_decode: bool = False
+    """If True, speculative decoding is skipped for this request: no draft
+    tokens are proposed or verified for it, so it decodes one token per step
+    while other requests in the same batch keep speculating. Has no effect
+    when the engine is not configured for speculative decoding."""
     thinking_token_budget: int | None = None
     """Maximum number of tokens allowed for thinking operations."""
 

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -295,6 +295,11 @@ class SchedulerOutput:
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int = 0
 
+    # Request IDs scheduled in this step for which speculative decoding is
+    # skipped (see `Scheduler.spec_decode_disabled`). The model runner uses it
+    # to avoid proposing draft tokens for those requests. None if empty.
+    spec_decode_skip_req_ids: set[str] | None = None
+
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
         return cls(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -539,6 +539,7 @@ class Scheduler(SchedulerInterface):
         encoder_compute_budget = self.max_num_encoder_input_tokens
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        spec_decode_skip_req_ids: set[str] = set()
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
         # Whether any scheduled request has a synchronous connector KV load.
@@ -737,6 +738,9 @@ class Scheduler(SchedulerInterface):
             req_index += 1
 
             # Speculative decode related.
+            if self.num_spec_tokens > 0 and self.spec_decode_disabled(request):
+                spec_decode_skip_req_ids.add(request_id)
+                request.spec_token_ids = []
             if request.spec_token_ids:
                 num_scheduled_spec_tokens = (
                     num_new_tokens
@@ -1175,8 +1179,12 @@ class Scheduler(SchedulerInterface):
                     )
                 if request.status == RequestStatus.WAITING:
                     scheduled_new_reqs.append(request)
+                    if self.num_spec_tokens > 0 and self.spec_decode_disabled(request):
+                        spec_decode_skip_req_ids.add(request.request_id)
                 elif request.status == RequestStatus.PREEMPTED:
                     scheduled_resumed_reqs.append(request)
+                    if self.num_spec_tokens > 0 and self.spec_decode_disabled(request):
+                        spec_decode_skip_req_ids.add(request.request_id)
                 else:
                     raise RuntimeError(f"Invalid request status: {request.status}")
 
@@ -1362,6 +1370,7 @@ class Scheduler(SchedulerInterface):
             kv_cache_block_copies=pending_kv_cache_block_copies,
             kv_connector_block_state=kv_connector_block_state,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+            spec_decode_skip_req_ids=spec_decode_skip_req_ids or None,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
 
@@ -2328,6 +2337,14 @@ class Scheduler(SchedulerInterface):
                 # rejection or drafter gather can reference it.
                 self.encoder_cache_manager.free_encoder_input(request, input_id)
 
+    def spec_decode_disabled(self, request: Request) -> bool:
+        """Whether speculative decoding is skipped for `request` in the current
+        step: no draft tokens are scheduled for it and the model runner does not
+        propose any. Defaults to the request's `disable_spec_decode` sampling
+        parameter; subclasses may override to apply scheduler-side policies."""
+        sampling_params = request.sampling_params
+        return sampling_params is not None and sampling_params.disable_spec_decode
+
     def update_draft_token_ids(self, draft_token_ids: DraftTokenIds) -> None:
         for req_id, spec_token_ids in zip(
             draft_token_ids.req_ids,
@@ -2338,8 +2355,9 @@ class Scheduler(SchedulerInterface):
                 # The request may have been finished. Skip.
                 continue
 
-            if request.is_prefill_chunk:
-                # Ignore draft tokens for prefill chunks.
+            if request.is_prefill_chunk or self.spec_decode_disabled(request):
+                # Ignore draft tokens for prefill chunks and for requests with
+                # speculative decoding disabled.
                 if request.spec_token_ids:
                     request.spec_token_ids = []
                 continue
@@ -2373,6 +2391,9 @@ class Scheduler(SchedulerInterface):
             # Trim drafts to scheduled number of spec tokens
             # (needed for chunked prefill case for example).
             del spec_token_ids[orig_num_spec_tokens:]
+            if self.spec_decode_disabled(request):
+                # Speculative decoding disabled: every draft slot is invalid.
+                del spec_token_ids[:]
             # Filter out spec tokens which do not adhere to the grammar.
             if self.structured_output_manager.should_advance(request):
                 metadata = request.structured_output_request

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5119,6 +5119,18 @@ class GPUModelRunner(
         num_spec_tokens_to_schedule = scheduler_output.num_spec_tokens_to_schedule
         self._draft_probs = None
         self._draft_prob_req_ids = None
+        skip_req_ids = scheduler_output.spec_decode_skip_req_ids
+        if skip_req_ids and isinstance(sampled_token_ids, list):
+            # Drafters that consume CPU sampled tokens (ngram, suffix,
+            # custom_class) skip requests with no sampled tokens, so requests
+            # with speculative decoding disabled do no proposal work at all.
+            # GPU drafters are handled by the scheduler dropping their drafts.
+            sampled_token_ids = [
+                [] if req_id in skip_req_ids else token_ids
+                for req_id, token_ids in zip(
+                    self.input_batch.req_ids, sampled_token_ids
+                )
+            ]
         if spec_config.method == "ngram":
             from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 


### PR DESCRIPTION
## Summary

Speculative decoding is currently all-or-nothing per engine: once a `speculative_config` is set, every request in the batch is drafted for and verified. Some requests don't benefit from it (very short outputs, structured-output-heavy requests, latency-insensitive batch jobs mixed with interactive traffic), and operators have no way to opt individual requests out without running a second engine.

This PR adds `SamplingParams.disable_spec_decode: bool = False`. For a request with the flag set:

- the scheduler never schedules draft tokens for it (`Request.spec_token_ids` is kept empty, so it decodes one token per step through the existing `pad_spec_decode` placeholder path — no batch-shape change, no cudagraph impact);
- draft tokens the drafter still produces for it are dropped in `update_draft_token_ids` / `update_draft_token_ids_in_output`, generalizing the existing prefill-chunk skip;
- the model runner receives the set of such requests in `SchedulerOutput.spec_decode_skip_req_ids` and, for the CPU-token drafters (ngram / suffix / custom_class), blanks their sampled tokens so no proposal work is done for them (those drafters already skip requests with no sampled tokens — the same mechanism as the existing discard path).

Other requests in the same batch are unaffected. Requests without the flag behave exactly as before (`spec_decode_skip_req_ids` is `None` when the set is empty).

The policy point is a single scheduler method, `Scheduler.spec_decode_disabled(request)`, whose default is the sampling parameter; this mirrors how Dynamic SD already lets K vary at runtime and gives scheduler subclasses one overridable seam.

**Not in this PR (follow-up if wanted):** proposal-cost skipping for GPU drafters (EAGLE / draft-model / dflash). They are correct under this PR — their drafts for flagged requests are dropped by the scheduler — but they still run their forward for those rows; threading the mask into the padded-batch path is a separate change.

## Test plan

- `tests/v1/core/test_scheduler.py`: `test_no_spec_tokens_for_disable_spec_decode_requests` (mixed batch: the flagged request never gets spec tokens scheduled, its drafts are dropped, the skip set is reported), `test_spec_decode_skip_req_ids_none_without_disabled_requests`, `test_update_draft_token_ids_in_output_invalidates_disabled_requests` (async-scheduling path). Full `test_scheduler.py` passes (162 tests).
- `tests/v1/e2e/spec_decode/ngram_suffix/test_disable_spec_decode.py` (1 GPU): with the flag on every request, `vllm:spec_decode_num_drafts == 0` (no draft is ever scheduled — the exact claim) and outputs match the no-spec reference at the threshold the existing spec-decode e2e tests use (exact text on ≥60% of prompts; an engine configured for speculation still runs flagged rows through the uniform-decode batch shape, so FP tie-breaks can differ); a mixed batch (alternating flag) matches at the same threshold with drafts > 0. Observed on a Qwen3-8B run: 12/16 exact for the all-flagged arm.

## Compatibility

Additive field with a default; `SchedulerOutput` gains one optional field; no drafter signature changes; no behavior change unless the flag is set.

## AI-assisted contribution disclosure

Per the contributing guide: this PR was developed with AI assistance (Claude Code). The code was reviewed and tested by the author, who takes responsibility for it; commits carry a `Co-Authored-By` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
