### PR TITLE
[Bugfix][Frontend] Hold partial ATEM markers out of streamed content

### DIFF
--- a/tests/tool_use/test_muse_glimmer.py
+++ b/tests/tool_use/test_muse_glimmer.py
@@ -349,35 +349,73 @@ _ATEM_MARKERS = [
 ]
 
 
-def _tool_stream_two_chunks(first: str, second: str) -> str:
-    """Feed two chunks through the tool parser; return concatenated content."""
-    out = []
+def _tool_stream_two_chunks(first: str, second: str):
+    """Feed two chunks through the tool parser.
+
+    Returns (content_deltas, reasoning_deltas, content): one slot per chunk,
+    so tests assert what each delta carried. The concatenation alone cannot
+    tell "held back" apart from "leaked early, completed later", since both
+    arrive at the same full text.
+    """
+    contents, reasonings = [], []
     prev = ""
     for cur in (first, first + second):
         delta = cur[len(prev) :]
         dm = MuseGlimmerToolParser.extract_tool_calls_streaming(
             T, prev, cur, delta, [], [], [], _FakeReq()
         )
-        if dm is not None and getattr(dm, "content", None):
-            out.append(dm.content)
+        contents.append(dm.content if dm is not None else None)
+        reasonings.append(dm.reasoning if dm is not None else None)
         prev = cur
-    return "".join(out)
+    return contents, reasonings, "".join(c for c in contents if c)
 
 
 def test_open_body_holds_partial_atem_until_tag_completes():
     first = " to=user<|message|>The answer is <atem:func"
     second = "tion_calls> as literal text"
-    assert _tool_stream_two_chunks(first, second) == (
-        "The answer is <atem:function_calls> as literal text"
-    )
+    deltas, _, content = _tool_stream_two_chunks(first, second)
+    assert deltas[0] == "The answer is "
+    assert content == "The answer is <atem:function_calls> as literal text"
 
 
 def test_open_body_holds_partial_atem_with_attributes():
     first = ' to=user<|message|>answer <atem:invoke name="rea'
     second = 'd.read"> now'
-    assert _tool_stream_two_chunks(first, second) == (
-        'answer <atem:invoke name="read.read"> now'
-    )
+    deltas, _, content = _tool_stream_two_chunks(first, second)
+    assert deltas[0] == "answer "
+    assert content == 'answer <atem:invoke name="read.read"> now'
+
+
+# A chunk boundary can also fall before the "atem:" prefix completes. The
+# fragment is still protocol data: held while the body grows, dropped at
+# truncation. "</" prefixes count too, closing tags are equally structural.
+_ATEM_PREFIX_SPLITS = [
+    ("<a", "tem:function_calls>"),
+    ("<at", "em:function_calls>"),
+    ("<ate", "m:function_calls>"),
+    ("<atem", ":function_calls>"),
+    ("</", "atem:function_calls>"),
+    ("</a", "tem:function_calls>"),
+    ("</ate", "m:function_calls>"),
+    ("</atem", ":function_calls>"),
+]
+
+
+def test_open_body_holds_atem_prefix_before_colon():
+    for fragment, rest in _ATEM_PREFIX_SPLITS:
+        deltas, _, content = _tool_stream_two_chunks(
+            f" to=user<|message|>The answer is {fragment}",
+            f"{rest} as literal text",
+        )
+        assert deltas[0] == "The answer is ", fragment
+        assert content == (f"The answer is {fragment}{rest} as literal text"), fragment
+
+
+def test_truncated_turn_drops_atem_prefix_before_colon():
+    for fragment, _ in _ATEM_PREFIX_SPLITS:
+        truncated = f" to=user<|message|>The answer is {fragment}"
+        content = MuseGlimmerToolParser._extract_content(truncated)
+        assert content == "The answer is ", fragment
 
 
 def test_reasoning_body_holds_partial_atem():
@@ -419,7 +457,23 @@ def test_every_atem_marker_split_never_leaks_into_content():
             cut = raw.find(marker[:i])
             assert cut != -1
             cut += i
-            assert _tool_stream_two_chunks(raw[:cut], raw[cut:]) == "The answer is 42."
+            *_, content = _tool_stream_two_chunks(raw[:cut], raw[cut:])
+            assert content == "The answer is 42."
+
+
+def test_atem_marker_split_in_user_body_waits_for_completion():
+    # Same split positions, but the marker sits in a visible to=user body,
+    # where the completed tag is legitimate literal text. The first delta
+    # must stop before the fragment no matter where the boundary falls;
+    # the tool-channel variant above cannot observe this at all.
+    for marker in _ATEM_MARKERS:
+        for i in range(1, len(marker)):
+            deltas, _, content = _tool_stream_two_chunks(
+                f" to=user<|message|>The answer is {marker[:i]}",
+                f"{marker[i:]} as literal text",
+            )
+            assert deltas[0] == "The answer is ", (marker, i)
+            assert content == (f"The answer is {marker} as literal text"), (marker, i)
 
 
 # ------------------------------------------------------- name normalization

--- a/tests/tool_use/test_muse_glimmer.py
+++ b/tests/tool_use/test_muse_glimmer.py
@@ -333,6 +333,95 @@ def test_truncated_cot_no_toolcall_streaming():
     assert tcs == [], f"truncated CoT invoke leaked as streaming tool call: {tcs}"
 
 
+# ------------------------------------------------------- partial ATEM markers
+#
+# An ATEM tag split across chunks is protocol data, not content: it must be
+# held until its closing `>` arrives, and dropped when the turn truncates.
+
+
+_ATEM_MARKERS = [
+    "<atem:function_calls>",
+    "</atem:function_calls>",
+    "<atem:invoke",
+    "</atem:invoke>",
+    "<atem:parameter",
+    "</atem:parameter>",
+]
+
+
+def _tool_stream_two_chunks(first: str, second: str) -> str:
+    """Feed two chunks through the tool parser; return concatenated content."""
+    out = []
+    prev = ""
+    for cur in (first, first + second):
+        delta = cur[len(prev) :]
+        dm = MuseGlimmerToolParser.extract_tool_calls_streaming(
+            T, prev, cur, delta, [], [], [], _FakeReq()
+        )
+        if dm is not None and getattr(dm, "content", None):
+            out.append(dm.content)
+        prev = cur
+    return "".join(out)
+
+
+def test_open_body_holds_partial_atem_until_tag_completes():
+    first = " to=user<|message|>The answer is <atem:func"
+    second = "tion_calls> as literal text"
+    assert _tool_stream_two_chunks(first, second) == (
+        "The answer is <atem:function_calls> as literal text"
+    )
+
+
+def test_open_body_holds_partial_atem_with_attributes():
+    first = ' to=user<|message|>answer <atem:invoke name="rea'
+    second = 'd.read"> now'
+    assert _tool_stream_two_chunks(first, second) == (
+        'answer <atem:invoke name="read.read"> now'
+    )
+
+
+def test_reasoning_body_holds_partial_atem():
+    t = " to=self<|message|>let me call <atem:function"
+    dm = MuseGlimmerToolParser.extract_tool_calls_streaming(
+        T, "", t, t, [], [], [], _FakeReq()
+    )
+    assert getattr(dm, "reasoning", None) == "let me call "
+
+
+def test_prose_atem_mention_streams_immediately():
+    t = " to=user<|message|>the <atem: protocol looks"
+    dm = MuseGlimmerToolParser.extract_tool_calls_streaming(
+        T, "", t, t, [], [], [], _FakeReq()
+    )
+    assert dm.content == "the <atem: protocol looks"
+
+
+def test_truncated_turn_drops_partial_atem_marker():
+    truncated = " to=user<|message|>The answer is <atem:func"
+    assert MuseGlimmerToolParser._extract_content(truncated) == "The answer is "
+    # a closed body keeps complete ATEM text it legitimately contains
+    closed = " to=user<|message|>use <atem:function_calls> like this<|eom|>"
+    assert MuseGlimmerToolParser._extract_content(closed) == (
+        "use <atem:function_calls> like this"
+    )
+
+
+def test_every_atem_marker_split_never_leaks_into_content():
+    raw = (
+        " to=user<|message|>The answer is 42.<|eom|>"
+        "<|start|>assistant to=read.read<|message|>"
+        '<atem:function_calls><atem:invoke name="read.read">'
+        '<atem:parameter name="path">/etc/hostname</atem:parameter>'
+        "</atem:invoke></atem:function_calls><|eom|>"
+    )
+    for marker in _ATEM_MARKERS:
+        for i in range(1, len(marker)):
+            cut = raw.find(marker[:i])
+            assert cut != -1
+            cut += i
+            assert _tool_stream_two_chunks(raw[:cut], raw[cut:]) == "The answer is 42."
+
+
 # ------------------------------------------------------- name normalization
 #
 # MuseGlimmer emits `get_weather.get_weather` for a bare-registered

--- a/vllm/tool_parsers/muse_glimmer_tool_parser.py
+++ b/vllm/tool_parsers/muse_glimmer_tool_parser.py
@@ -171,6 +171,21 @@ def _trailing_partial_marker_len(text: str) -> int:
 # text mentioning the format is never held back.
 _ATEM_TAIL_RE = re.compile(r"</?atem:(?:[A-Za-z0-9_.\-]+(?: [A-Za-z0-9_.\-\":=]*)?)?$")
 
+# The tag openers. A chunk boundary can also fall before "atem:" completes
+# ("<ate", "</atem"), so proper prefixes of these are just as structural.
+_ATEM_TAG_OPENERS = ("<atem:", "</atem:")
+_MAX_ATEM_OPENER_LEN = max(len(m) for m in _ATEM_TAG_OPENERS)
+
+
+def _trailing_atem_prefix_len(text: str) -> int:
+    """Length of the longest suffix of *text* that prefixes an ATEM tag opener."""
+    max_overlap = min(len(text), _MAX_ATEM_OPENER_LEN - 1)
+    for overlap in range(max_overlap, 0, -1):
+        suffix = text[-overlap:]
+        if any(opener.startswith(suffix) for opener in _ATEM_TAG_OPENERS):
+            return overlap
+    return 0
+
 
 def _strip_trailing_partial_atem(body: str) -> str:
     """Drop a trailing fragment that could still grow into an ATEM marker.
@@ -178,9 +193,17 @@ def _strip_trailing_partial_atem(body: str) -> str:
     ATEM framing is protocol control data, not user-visible content: an
     incomplete marker at the tail of an open body must wait for its closing
     ``>`` instead of leaking as content, and at truncation it is dropped
-    rather than emitted.
+    rather than emitted. Loops because cutting one fragment can expose
+    another right before it.
     """
-    return _ATEM_TAIL_RE.sub("", body)
+    while True:
+        stripped = _ATEM_TAIL_RE.sub("", body)
+        prefix = _trailing_atem_prefix_len(stripped)
+        if prefix:
+            stripped = stripped[: len(stripped) - prefix]
+        if stripped == body:
+            return body
+        body = stripped
 
 
 def _safe_open_body(body: str) -> str:
@@ -192,11 +215,15 @@ def _safe_open_body(body: str) -> str:
     """
     tail_to = _OPEN_TAIL_TO_RE.search(body)
     if tail_to is not None:
-        return body[: tail_to.start()]
-    partial = _trailing_partial_marker_len(body)
-    if partial:
-        body = body[: len(body) - partial]
-    return _strip_trailing_partial_atem(body)
+        body = body[: tail_to.start()]
+    while True:
+        partial = _trailing_partial_marker_len(body)
+        if partial:
+            body = body[: len(body) - partial]
+        trimmed = _strip_trailing_partial_atem(body)
+        if trimmed == body:
+            return body
+        body = trimmed
 
 
 class MuseGlimmerToolParser(ToolParser):

--- a/vllm/tool_parsers/muse_glimmer_tool_parser.py
+++ b/vllm/tool_parsers/muse_glimmer_tool_parser.py
@@ -165,6 +165,24 @@ def _trailing_partial_marker_len(text: str) -> int:
     return 0
 
 
+# A trailing fragment that could still grow into an ATEM tag, attribute
+# content included. Anything after "atem:" that cannot appear in a tag (a
+# space, for prose like "the <atem: protocol") ends the match, so ordinary
+# text mentioning the format is never held back.
+_ATEM_TAIL_RE = re.compile(r"</?atem:(?:[A-Za-z0-9_.\-]+(?: [A-Za-z0-9_.\-\":=]*)?)?$")
+
+
+def _strip_trailing_partial_atem(body: str) -> str:
+    """Drop a trailing fragment that could still grow into an ATEM marker.
+
+    ATEM framing is protocol control data, not user-visible content: an
+    incomplete marker at the tail of an open body must wait for its closing
+    ``>`` instead of leaking as content, and at truncation it is dropped
+    rather than emitted.
+    """
+    return _ATEM_TAIL_RE.sub("", body)
+
+
 def _safe_open_body(body: str) -> str:
     """Trim the tail of a still-growing body to what is safe to emit now.
 
@@ -176,7 +194,9 @@ def _safe_open_body(body: str) -> str:
     if tail_to is not None:
         return body[: tail_to.start()]
     partial = _trailing_partial_marker_len(body)
-    return body[: len(body) - partial] if partial else body
+    if partial:
+        body = body[: len(body) - partial]
+    return _strip_trailing_partial_atem(body)
 
 
 class MuseGlimmerToolParser(ToolParser):
@@ -363,9 +383,11 @@ class MuseGlimmerToolParser(ToolParser):
     @classmethod
     def _extract_content(cls, text: str) -> str | None:
         """Return the user-facing body, or the raw text when unframed."""
-        content, reasoning, _c_open, _r_open = cls._visible_channels(text)
+        content, reasoning, c_open, _r_open = cls._visible_channels(text)
         if content:
-            return content
+            # A truncated turn leaves the last body open with a partial ATEM
+            # marker on its tail; that fragment is protocol data, not content.
+            return _strip_trailing_partial_atem(content) if c_open else content
         # No framing at all -> the whole thing is plain content.
         if not reasoning and _MSG_HEADER_RE.search(text) is None:
             return text or None


### PR DESCRIPTION
Fixes #55395.

## Problem

The MuseGlimmer tool parser holds back partial channel-framing markers (`<|message|>` and friends) in an open body, but nothing covered ATEM. A suffix like `<atem:func` or an attribute-carrying `<atem:invoke name="ge` at the tail of a growing body was emitted as ordinary content immediately, so a split marker was briefly committed before the next chunk completed the tag, and a turn truncated mid-marker left the protocol fragment visible at stream end.

## Fix

New `_strip_trailing_partial_atem` drops a trailing fragment that can still grow into an ATEM tag, applied to every open body in `_safe_open_body` (streaming) and to `_extract_content` on truncated turns (non-streaming). The regex only matches tag-shaped fragments: `<atem:` or `</atem:` followed by tag characters with at most one attribute segment, so a closed body keeps ATEM text it legitimately contains, held fragments release once the closing `>` arrives, and prose like "the `<atem:` protocol" (a space, which no tag allows) streams immediately. Tool-call extraction is untouched; complete invokes parse exactly as before.

## Tests

Six new tests in `tests/tool_use/test_muse_glimmer.py`: partial markers held in content and reasoning bodies until the tag completes (then released), attribute-carrying partials held, prose mentions never held, truncated turns drop the fragment non-streaming while closed bodies keep literal ATEM text, and the issue's exhaustive version: every ATEM marker split at every character boundary, with concatenated content equal to only the preceding answer.

Verification: no GPU box here for the vllm import graph, so the parser was exercised locally by loading the module with the vllm package stubbed and running the case battery both ways: without the fix the partials leak (`'The answer is <atem:func'`, attribute partials, non-streaming), with it they are held and released correctly. The new tests encode exactly those cases for CI. ruff format/check clean.

AI assistance disclosure: prepared with AI assistance (Kimi K3). The leak mechanism was verified by running the parser locally against the reproduction before writing the fix.
