### PR TITLE
[Docker] Compile Python bytecode at image build time

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -847,6 +847,7 @@ ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 ENV UV_CACHE_DIR=/opt/uv/cache
+ENV UV_COMPILE_BYTECODE=1
 RUN mkdir -p "${UV_PYTHON_INSTALL_DIR}" "${UV_CACHE_DIR}" \
     && chgrp -R 0 /opt/uv \
     && chmod -R g+rwX,a+rX /opt/uv

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -99,6 +99,7 @@ ENV UV_HTTP_TIMEOUT=500
 # Install Python dependencies
 ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE="copy"
+ENV UV_COMPILE_BYTECODE=1
 
 # PyTorch provides its own indexes for standard and nightly builds.
 # PYTORCH_NIGHTLY=1 builds the CPU image against torch nightly (parity with the

--- a/docker/Dockerfile.ppc64le
+++ b/docker/Dockerfile.ppc64le
@@ -22,6 +22,7 @@ ENV HOME=/root \
     RUSTUP_HOME=/root/.rustup \
     UV_CACHE_DIR=$HOME/.cache/uv \
     PATH=/root/.cargo/bin:/root/.rustup/bin:${VIRTUAL_ENV}/bin:$PATH
+ENV UV_COMPILE_BYTECODE=1
 
 RUN echo "DEBUG: VLLM_VERSION=${VLLM_VERSION}"
 RUN --mount=type=cache,target=/var/cache/dnf \

--- a/docker/Dockerfile.rock
+++ b/docker/Dockerfile.rock
@@ -878,6 +878,7 @@ ENV VLLM_GPU_SYNC_CHECK=error
 # -----------------------
 # Final vLLM image
 FROM mori_base AS final_common
+ENV UV_COMPILE_BYTECODE=1
 
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -913,6 +913,7 @@ COPY --from=test_smoke /vllm-smoke-ok /
 # -----------------------
 # Final vLLM image
 FROM mori_base AS final_common
+ENV UV_COMPILE_BYTECODE=1
 
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.rocm_gfx1250
+++ b/docker/Dockerfile.rocm_gfx1250
@@ -646,6 +646,7 @@ RUN mkdir src && mv vllm src/vllm
 # -----------------------
 # Final vLLM image
 FROM mori_base AS final
+ENV UV_COMPILE_BYTECODE=1
 
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.s390x
+++ b/docker/Dockerfile.s390x
@@ -161,6 +161,7 @@ ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
 ENV LD_LIBRARY_PATH="/opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:/usr/local/lib:/opt/rh/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH"
 ENV C_INCLUDE_PATH="/usr/local/include:$C_INCLUDE_PATH"
 ENV UV_LINK_MODE=copy
+ENV UV_COMPILE_BYTECODE=1
 ENV CARGO_HOME=/root/.cargo
 ENV RUSTUP_HOME=/root/.rustup
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -202,6 +202,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
            /tmp/ucx_source /tmp/nixl_source
 
 FROM vllm-base AS vllm-openai
+ENV UV_COMPILE_BYTECODE=1
 
 # Must match the ucx-nixl-build stage above: ARG does not cross stages, so a stale
 # value here installs a meta package that disagrees with the wheel built there.


### PR DESCRIPTION
## Purpose

Fresh containers compile thousands of Python files during startup. This PR sets `UV_COMPILE_BYTECODE=1` in eight Dockerfiles, moving that work into image construction through uv's existing option. The complete diff is eight ENV additions; the CPU checkout and quantization fixes are now on main.

## Current CI (September 22)

[CI 90337](https://buildkite.com/vllm/ci/builds/90337) finished on `80c1a6a5800d`: 411 jobs passed; three failed. The remaining failures are [CPU Kernel 2](https://buildkite.com/vllm/ci/builds/90337#01a0c715-c7d9-4108-b164-72a3ca9f1900) and [Qwen2.5-VL](https://buildkite.com/vllm/ci/builds/90337#01a0c6fa-ffba-4275-8c22-ad08c57ee339) stopping during LLVM downloads before tests, plus an MI355 kernel assertion that [also fails on current main](https://buildkite.com/vllm/ci/builds/90426#01a0c963-90fa-4df0-8625-5a5ee4fa3414). CPU image, PP+TP and H200 kernel retries passed; CPU Kernel 2 repeated the download failure. [AMD 13360](https://buildkite.com/vllm/amd-ci/builds/13360) stopped without starting an agent, and [Intel 12076](https://buildkite.com/vllm/intel-ci/builds/12076) failed during pipeline bootstrap. The diff remains eight ENV additions.

## Results

### Matched build, delivery, and serving

I built `470fe3942ecdb889b2f3c0b57ace4b09d61dd103` with and without the CUDA Dockerfile ENV line (`vllm-openai`, CUDA sm_89, Python 3.12.3, Torch 2.13.0+cu130, uv 0.12.10). Source, interpreter, 244 Python distributions, 26,734 Python files, native payloads, and non-bytecode site-packages bytes matched. Each observation pulled from a loopback registry into an empty Docker store, then served local/offline Qwen3-0.6B through the first correct HTTP completion on one RTX 4090 Laptop with a four-CPU quota.

| Artifact | Compressed runtime layers | Median pull to correct response |
|---|---:|---:|
| Control, gzip | 8,511,741,380 bytes | 155.7265 s |
| Bytecode, gzip | 8,664,824,384 bytes | 144.5137 s |

The bytecode image adds 153,083,004 compressed bytes (+1.7985%). Its median paired saving is **15.3606 s**, n=3 pairs, and all three pairs improved. Five independent next-token checks and four-request bursts passed per activation with matching choices and usage. Candidate import compiled zero source files; control import compiled 5,257. Bypassing candidate caches restored 5,478 compilations.

### Native serving attribution

In a separate installed vLLM 0.28.0 experiment, the same 8.85 GB of Python and shared-object files were 100% page-resident before every start. First-correct-response medians were **57.0394 s without bytecode and 47.6911 s with it**, with a **10.1300 s median paired saving**, n=3 pairs; all pairs and output checks passed. The measured startup saving includes avoided compilation, cache-file work, and normal parent/child reuse. It is not entirely compiler CPU. [Protocol, observations, and limits](https://github.com/vllm-project/vllm/pull/55422#issuecomment-5608794542).

### Direct compiler reproduction

The exact 5,118-file import corpus, 78.60 MB and about 2.16 million source lines, was read into memory and compiled without execution or bytecode writes. Native CPython 3.12.3 took **6.3033 s median**, n=3 whole-corpus passes. A real uncached serving-CLI import took 12.2019 s with 6.9880 s inside 5,118 compiler calls; cached import took 5.0095 s and made zero compiler calls. Source hashes and 196 package versions match the resident-page study, but the Python binary build changed, so absolute times are not interchangeable. To reproduce without vLLM or a GPU, invoke `compile(source_bytes, filename, "exec", dont_inherit=True, optimize=0)` over the recorded trace paths in a fresh `python3.12 -I -S -B` process after preloading the sources.

### Inclusive import roots

Fresh-process medians below use fully resident source/native pages, n=3 paired runs per root. Rows include transitive imports and are **not additive**. Paired-saving medians need not equal differences of arm medians.

| Entry point | No bytecode | Bytecode | Median paired saving |
|---|---:|---:|---:|
| `import torch` | 2.1306 s | 0.8025 s | 1.3281 s |
| `import transformers` | 1.2943 s | 0.6760 s | 0.6018 s |
| `import vllm` | 6.7075 s | 2.1068 s | 4.6007 s |
| `import vllm.entrypoints.cli.serve` | 12.2659 s | 5.0198 s | 7.2461 s |

In this vLLM 0.28.0 environment (Torch 2.13.0, Transformers 5.17.0), bare Torch did not load Dynamo, Inductor, or SymPy; importing vLLM loaded all three. Bare Transformers did not load Torch. One eager path is the Inductor patch in `vllm.env_override`. Dependency-file ownership therefore does not tell us which entry point introduces the import cost.

### Bytecode portability

Pure-Python timestamp and checked-hash caches created on macOS ARM64, CPython 3.12.13 loaded unchanged on Linux x86-64, CPython 3.12.3 with source compilation blocked. Both used cache tag `cpython-312` and magic `cb0d0d0a`; all nine reuse and validation cases matched their expected outcomes. [Python documents compiled modules as architecture-independent](https://docs.python.org/3.12/tutorial/modules.html#compiled-python-files), with compatible interpreter format still required. The image pins its Python/native platform; the PR compiles within that build path and retains source. This fixture is not a full cross-platform vLLM deployment.

### Known caveats

uv [recommends bytecode compilation for production images](https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode), trading build work and image size for startup time. The upstream issues I found concern [reproducible cache/image bytes](https://github.com/python/cpython/issues/129724) and [compilation hangs under affected QEMU-user setups](https://github.com/astral-sh/uv/issues/6105). I reproduced the former on Mac CPython 3.12.13: identical source and checked-hash headers produced different serialized bytes depending on compilation order, but equal decoded code objects and correct execution. We should not claim reproducible image digests. The QEMU report concerns the build environment; native CUDA validation does not qualify emulated builds. No cache-format or concurrency workaround is added by this PR.

<details>
<summary>Secondary observations, reproduction details, and limits</summary>

Native serving pairs, without/with bytecode: 54.7488/44.6188 s, 57.0394/47.6911 s, and 60.6387/48.4054 s. Its separate September 9 CLI trace measured 8.1962 s in 5,118 source-compilation calls. The September 15 preloaded direct-compile passes were 6.2461, 6.3033 and 6.3194 s; their Python 3.12.3 build is newer, despite matching source hashes and package versions.

Separate diagnostic import-root traces measured compiler time/source files as Torch 1.3441 s/871, Transformers 0.6780 s/398, vLLM 4.7605 s/2,293 and serving CLI 7.5139 s/5,118. These hooked traces are excluded from the uninstrumented root medians above. The cached serving trace made zero compiler calls. Within the uncached CLI trace, exclusive compiler costs by source-file owner were Torch 2.852 s, SymPy 1.032 s, Transformers 0.498 s and vLLM 0.431 s, plus other dependencies. These are compiler timings, not inclusive package-import durations.

The earlier unchanged-runtime mechanism fixture used the published vLLM 0.28.0 image plus `python3 -m compileall -q -j 8 /usr/local/lib/python3.12/dist-packages`. With image and model present, medians were 63.967 s control and 51.953 s bytecode, with a 12.014 s median paired saving, n=5. With the image absent and model present, loopback pull-through-response medians were 145.041 s and 134.109 s, with a 10.337 s median paired saving, n=3. Its added gzip layer was 153,159,438 bytes. This fixture isolates the mechanism but is not a matched full build of this PR.

Exact-head paired pull-through-response observations were 149.8156/134.4550 s, 155.7265/144.5137 s, and 162.3850/146.2806 s for control/bytecode. Host source pages were warm or uncontrolled in that experiment. The same bytecode artifact exported with the separate opt-in zstd change was 17.7633% smaller than control and saved 37.7032 s median paired, but those combined numbers include both changes and are not this PR's isolated effect.

The full-build recipes shared one recorded host-network preparation because the rig lacks `docker0`. The first control build failed in 1.32 s before installation; no timed cell was affected. Build durations, 688.83 s control and 629.16 s candidate, are not a matched build-time comparison. In the older delivery fixture, one post-timing mount cleanup failed after the clock and functional checks; that observation was retained without replacement and cleanup was resolved before continuing. The resident-page study retained two excluded preparation attempts and corrected a TCP cleanup probe before its six measured cells. The import-root study's first preparation reached 98.0101% residency and timed no imports; equal mmap page touches then produced 100% residency without relaxing the gate.

These are one-host medians with local models, no Internet transfer, warm or controlled pages as stated, and no p95 or throughput claim. They do not validate missing-model startup, every accelerator image, published multi-platform size, slow links, fleets, pip installs, or the earlier A10/Qwen3-8B baseline. Normal source-backed loader validation has limits: a corrupt marshalled body can fail without source fallback, and timestamp caches can accept changed same-size/same-mtime source. uv initially compiled only the reinstalled vLLM distribution in the package study, so the ENV line alone does not prove complete cache coverage for every image variant.

</details>

Related to #48193. An open-PR title search for bytecode on September 15 returned only this PR. AI assistance was used for implementation, experiment tooling, and analysis.
