### PR TITLE
[Bugfix][Frontend] Keep MuseGlimmer tool call arguments valid JSON for non-finite values

### DIFF
--- a/tests/tool_use/test_muse_glimmer.py
+++ b/tests/tool_use/test_muse_glimmer.py
@@ -154,6 +154,83 @@ def test_json_object_array_and_bool_params_decode():
     }
 
 
+def _reject_json_constants(name: str):
+    """``parse_constant`` hook that refuses the ``NaN``/``Infinity`` extension.
+
+    ``json.loads`` accepts those tokens, but they are not part of JSON
+    (RFC 8259), so a strict client such as JavaScript ``JSON.parse`` rejects
+    them. Failing here is what a non-Python consumer of ``arguments`` would do.
+    """
+    msg = f"not valid JSON: {name}"
+    raise AssertionError(msg)
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    [
+        "NaN",
+        "Infinity",
+        "-Infinity",
+        # Valid JSON on the way in, but overflows to inf while decoding.
+        "1e999",
+        "-1e999",
+        # Non-finite nested inside a decoded container.
+        "[1e999]",
+        '{"limit": 1e999}',
+    ],
+)
+def test_non_finite_params_stay_raw_so_arguments_remain_valid_json(raw_value: str):
+    """Values that cannot round-trip to JSON are kept as the raw string.
+
+    ``json.loads`` accepts ``NaN``/``Infinity`` and overflows large exponents to
+    ``inf``, and ``json.dumps`` then writes those back as bare ``NaN``/
+    ``Infinity`` tokens. Emitting that would put an ``arguments`` payload on the
+    wire that no strict JSON parser can read, so the raw string is preserved
+    instead.
+    """
+    raw = (
+        "<|start|>assistant to=set_limit<|message|>"
+        '<atem:function_calls>\n<atem:invoke name="set_limit">\n'
+        f'<atem:parameter name="value">{raw_value}</atem:parameter>\n'
+        "</atem:invoke>\n</atem:function_calls><|eot|>"
+    )
+    out = MuseGlimmerToolParser.extract_tool_calls(T, raw, None)
+    arguments = out.tool_calls[0].function.arguments
+
+    # The payload a strict (non-Python) client would have to parse.
+    parsed = json.loads(arguments, parse_constant=_reject_json_constants)
+    assert parsed == {"value": raw_value}
+
+
+def test_finite_numeric_params_still_decode():
+    """Guard for the check above: ordinary numbers must keep decoding.
+
+    Rejecting non-finite values must not turn every numeric parameter into a
+    string, so this pins the exponent and float forms that do round-trip.
+    """
+    raw = (
+        "<|start|>assistant to=set_limit<|message|>"
+        '<atem:function_calls>\n<atem:invoke name="set_limit">\n'
+        '<atem:parameter name="exp">1e5</atem:parameter>\n'
+        '<atem:parameter name="neg_exp">1e-5</atem:parameter>\n'
+        '<atem:parameter name="pi">3.14</atem:parameter>\n'
+        '<atem:parameter name="count">123</atem:parameter>\n'
+        '<atem:parameter name="nested">[1, 2.5]</atem:parameter>\n'
+        "</atem:invoke>\n</atem:function_calls><|eot|>"
+    )
+    out = MuseGlimmerToolParser.extract_tool_calls(T, raw, None)
+    assert json.loads(
+        out.tool_calls[0].function.arguments,
+        parse_constant=_reject_json_constants,
+    ) == {
+        "exp": 100000.0,
+        "neg_exp": 1e-5,
+        "pi": 3.14,
+        "count": 123,
+        "nested": [1, 2.5],
+    }
+
+
 # ------------------------------------------------- reasoning -> tool handoff
 
 

--- a/vllm/tool_parsers/muse_glimmer_tool_parser.py
+++ b/vllm/tool_parsers/muse_glimmer_tool_parser.py
@@ -105,11 +105,26 @@ def _decode_value(raw: str):
     """JSON-decode a parameter value when possible, else keep the raw string.
 
     Mirrors the schema's ``x-parser: json`` with ``allow_non_json: True``.
+
+    Values that decode to a non-finite float are kept as the raw string.
+    ``json.loads`` accepts ``NaN``/``Infinity``/``-Infinity`` and overflows
+    large exponents such as ``1e999`` to ``inf``, but ``json.dumps`` renders
+    those back as bare ``NaN``/``Infinity`` tokens, which are not valid JSON
+    (RFC 8259). Emitting them would put an unparseable ``arguments`` string on
+    the wire for any strict client. This matches the handling in
+    ``vllm/tool_parsers/utils.py``.
     """
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
     except (json.JSONDecodeError, ValueError):
         return raw
+    # ``allow_nan=False`` raises on any non-finite float, including ones nested
+    # inside a decoded list or dict (e.g. ``[1e999]``).
+    try:
+        json.dumps(parsed, allow_nan=False)
+    except (ValueError, TypeError):
+        return raw
+    return parsed
 
 
 def _iter_messages(text: str) -> Iterator[tuple[str | None, str, bool]]:


### PR DESCRIPTION
## Summary

The MuseGlimmer tool parser can emit a tool call whose `arguments` string is not valid JSON, so a strict client cannot parse the call at all.

`_decode_value` JSON-decodes each `<atem:parameter>` value and falls back to the raw string when decoding fails:

```python
try:
    return json.loads(raw)
except (json.JSONDecodeError, ValueError):
    return raw
```

`json.loads` accepts the `NaN` / `Infinity` / `-Infinity` extension, and it overflows large exponents such as `1e999` to `inf`. None of those raise, so they are kept as floats. `_parse_tool_calls` then serializes the dict with `json.dumps`, which writes them back as bare `NaN` / `Infinity` tokens — not valid JSON under RFC 8259.

## Reproduction

Model output:

```
<atem:invoke name="set_temp"><atem:parameter name="value">NaN</atem:parameter></atem:invoke>
```

Emitted arguments, on `main` (`40824284bc`):

```
{"value": NaN}
```

JavaScript `JSON.parse`, Go `encoding/json` and Rust `serde_json` all reject that. Seven inputs hit it, including ones that are perfectly valid JSON on the way in and only become non-finite while decoding:

| parameter value | decoded | emitted `arguments` |
|---|---|---|
| `NaN` | `nan` | `{"x": NaN}` |
| `Infinity` | `inf` | `{"x": Infinity}` |
| `-Infinity` | `-inf` | `{"x": -Infinity}` |
| `1e999` | `inf` | `{"x": Infinity}` |
| `-1e999` | `-inf` | `{"x": -Infinity}` |
| `[1e999]` | `[inf]` | `{"x": [Infinity]}` |
| `{"a": 1e999}` | `{'a': inf}` | `{"x": {"a": Infinity}}` |

## Not a duplicate

`muse_glimmer` has several PRs in flight, so per `AGENTS.md` I checked the overlapping ones. The three that touch the same two files are #55396, #55419 and #54585, and none of them modifies `_decode_value` — they address partial/incomplete ATEM markers in streamed content and the port to the Streaming Parser Engine, which is a different defect from the `json.dumps` output being unparseable. The other open `muse_glimmer` PRs (#54462, #54454, #54091, #54238, #52390, #53404, #54467) are in the reasoning parser, structured outputs, or token counting, not parameter decoding.

Checks run:

```bash
gh pr list --repo vllm-project/vllm --state open --search "muse_glimmer"
gh pr list --repo vllm-project/vllm --state open --search "muse glimmer tool parser"
gh pr diff <n> --repo vllm-project/vllm | grep -c "_decode_value"   # 0 for each
```

There is no linked issue: I found this by reading the decoder rather than from a report, so nothing is being claimed from another contributor.

## Fix

Reject non-finite decode results and keep the raw string, which is what this repo already does elsewhere. `vllm/tool_parsers/utils.py` has an `_is_json_finite` helper whose docstring describes this exact failure mode, and uses it at two call sites with the comment *"Preserve the raw string instead."* This change applies the same rule in the one decoder that was missing it, rather than introducing a new policy.

`json.dumps(..., allow_nan=False)` is used as the probe because it also catches non-finite floats nested inside a decoded list or dict, which an `isinstance` / `math.isfinite` check on the top-level value would miss.

Finite values are untouched — `1e5` still decodes to `100000.0`, and objects, arrays, booleans, `null` and plain strings are unchanged.

## Tests

This parser has no test file under `tests/tool_parsers/`, so the new tests extend the existing `tests/tool_use/test_muse_glimmer.py` next to the current parameter-decoding test.

The tests parse the emitted `arguments` with a `parse_constant` hook that refuses `NaN` / `Infinity`, so they assert what a non-Python consumer sees rather than what Python happens to tolerate. `test_finite_numeric_params_still_decode` is a guard in the other direction: it pins the exponent and float forms that must keep decoding, so a future over-broad fix cannot turn every number into a string.

**These tests are load-bearing.** Reverting the parser change fails 7 of them:

```
7 failed, 22 passed
E  AssertionError: not valid JSON: Infinity
```

## How did you verify your code works?

- `tests/tool_use/test_muse_glimmer.py` → **29 passed** (21 before; +8 from this change)
- `tests/tool_use/test_muse_glimmer.py` + `test_muse_glimmer_parse_delta.py` → 29 passed, 5 skipped
- `tests/tool_parsers/` → **953 passed**, 3 skipped, 34 xfailed
- `ruff format --check` and `ruff check` clean on both files

Two pre-existing failures in my environment, both unrelated to this change and both confirmed identical on a clean tree via `git stash`:

- `tests/tool_parsers/test_cohere_command_tool_parser.py` fails to import (`cohere_melody` not installed)
- 15 errors in `tests/tool_parsers/test_llama3_json_tool_parser.py` (missing tokenizer dependency)

Re-verified in a clean environment built the way `AGENTS.md` prescribes (`uv venv --python 3.12`, `uv pip install`, `.venv/bin/python` throughout — my first run had used a 3.14 venv and bare `pip`, so I rebuilt it to match). Results were identical on Python 3.12.13:

- `tests/tool_use/test_muse_glimmer.py` + `test_muse_glimmer_parse_delta.py` → 29 passed, 5 skipped
- `tests/tool_parsers/` → 953 passed, 3 skipped, 34 xfailed
- `ruff format --check` / `ruff check` (0.16.5, the pinned hook version) → clean
- `tools/pre_commit/mypy.py "3.10"` → 1 error at line 212, `Argument 1 to "__init__" of "ToolParser" has incompatible type "PreTrainedTokenizerBase"; expected "TokenizerLike"`. That line is not part of this diff, and I confirmed the identical error on a clean checkout, so it is a local `transformers`/stub version mismatch rather than something this change introduces.

I could not run the GPU or full `make` stack locally — this is a macOS box with no CUDA, so verification is limited to the offline parser suites above. The change is pure Python string/JSON handling with no device or kernel involvement, and it does not affect model output, accuracy or serving behavior, so no model evaluation results are applicable.

## Release note

Fixed the MuseGlimmer tool parser emitting invalid JSON in tool call `arguments` when a parameter value was `NaN`, `Infinity`, `-Infinity`, or a numeric literal that overflows to infinity (such as `1e999`). Such values are now preserved as raw strings.

---

*AI disclosure, per the [AI Assisted Contributions](https://github.com/vllm-project/vllm/blob/main/docs/contributing/README.md) policy: this change was developed with AI assistance (attributed via a `Co-authored-by` trailer on the commit). I reviewed every changed line, confirmed the defect and the fix by running the emitted `arguments` through a strict JSON parser, and verified the new tests fail without the fix.*

