### PR TITLE
[Bugfix][Frontend] Map reasoning effort to thinking budget

### DIFF
--- a/tests/entrypoints/launchers/test_cli_args.py
+++ b/tests/entrypoints/launchers/test_cli_args.py
@@ -339,6 +339,28 @@ def test_default_chat_template_kwargs_invalid_json(serve_parser):
         )
 
 
+def test_reasoning_effort_budgets_parsing(serve_parser):
+    args = serve_parser.parse_args(
+        ["--reasoning-effort-budgets", '{"low": 4096, "high": 32768}']
+    )
+    assert args.reasoning_effort_budgets == {"low": 4096, "high": 32768}
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not valid json",
+        "[]",
+        '{"low": -1}',
+        '{"low": 1.5}',
+        '{"low": true}',
+    ],
+)
+def test_reasoning_effort_budgets_rejects_invalid_values(serve_parser, value):
+    with pytest.raises(SystemExit):
+        serve_parser.parse_args(["--reasoning-effort-budgets", value])
+
+
 @pytest.mark.parametrize(
     "args, raises",
     [

--- a/tests/entrypoints/openai/chat_completion/test_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat.py
@@ -1037,6 +1037,32 @@ def test_chat_completion_request_rejects_unknown_reasoning_effort():
         )
 
 
+@pytest.mark.parametrize(
+    ("reasoning_effort", "request_budget", "expected_budget"),
+    [
+        ("low", None, 4096),
+        ("high", 123, 123),
+        ("max", None, None),
+        (None, None, None),
+    ],
+)
+def test_reasoning_effort_budget_fallback(
+    reasoning_effort, request_budget, expected_budget
+):
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        reasoning_effort=reasoning_effort,
+        thinking_token_budget=request_budget,
+    )
+    sampling_params = request.to_sampling_params(
+        max_tokens=100,
+        default_sampling_params={},
+        reasoning_effort_budgets={"low": 4096, "high": 32768},
+    )
+    assert sampling_params.thinking_token_budget == expected_budget
+
+
 def test_chat_completion_request_n_parameter_various_values():
     """Test n parameter with various values."""
     for n_value in [1, 2, 5, 10]:

--- a/vllm/entrypoints/generate/api_router.py
+++ b/vllm/entrypoints/generate/api_router.py
@@ -158,6 +158,7 @@ async def init_generate_state(
         chat_template=resolved_chat_template,
         chat_template_content_format=args.chat_template_content_format,
         default_chat_template_kwargs=default_chat_template_kwargs,
+        reasoning_effort_budgets=args.reasoning_effort_budgets,
         trust_request_chat_template=args.trust_request_chat_template,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
         enable_auto_tools=args.enable_auto_tool_choice,

--- a/vllm/entrypoints/launchers/cli_args.py
+++ b/vllm/entrypoints/launchers/cli_args.py
@@ -63,6 +63,28 @@ class LoRAParserAction(argparse.Action):
         setattr(namespace, self.dest, lora_list)
 
 
+def parse_reasoning_effort_budgets(value: str) -> dict[str, int]:
+    """Parse a JSON mapping from reasoning effort names to token budgets."""
+    try:
+        budgets = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise argparse.ArgumentTypeError(
+            "must be a JSON object mapping effort names to non-negative integers"
+        ) from e
+
+    if not isinstance(budgets, dict) or any(
+        not isinstance(key, str)
+        or not isinstance(budget, int)
+        or isinstance(budget, bool)
+        or budget < 0
+        for key, budget in budgets.items()
+    ):
+        raise argparse.ArgumentTypeError(
+            "must be a JSON object mapping effort names to non-negative integers"
+        )
+    return budgets
+
+
 @config
 class BaseFrontendArgs:
     """Base arguments for the OpenAI-compatible frontend server.
@@ -96,6 +118,11 @@ class BaseFrontendArgs:
     with request values taking precedence. Useful for setting default
     behavior for reasoning models. Example: '{"enable_thinking": false}'
     to disable thinking mode by default for Qwen3/DeepSeek models."""
+    reasoning_effort_budgets: dict[str, int] | None = None
+    """Optional JSON mapping from reasoning effort to thinking token budget.
+
+    An explicit per-request ``thinking_token_budget`` takes precedence.
+    """
     response_role: str = "assistant"
     """The role name to return if `request.add_generation_prompt=true`."""
     return_tokens_as_token_ids: bool = False
@@ -206,6 +233,9 @@ class BaseFrontendArgs:
         """
         # Special case: default_chat_template_kwargs needs json.loads type
         frontend_kwargs["default_chat_template_kwargs"]["type"] = json.loads
+        frontend_kwargs["reasoning_effort_budgets"]["type"] = (
+            parse_reasoning_effort_budgets
+        )
 
         # Special case: LoRA modules need custom parser action and
         # optional_type(str)

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -157,7 +157,9 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             )
             single_request = single_requests[i]
             sampling_params = single_request.to_sampling_params(
-                max_tokens, self.default_sampling_params
+                max_tokens,
+                self.default_sampling_params,
+                self.reasoning_effort_budgets,
             )
             self._log_inputs(
                 sub_request_id,

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -4,6 +4,7 @@
 # Adapted from
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/protocol/openai_api_protocol.py
 import time
+from collections.abc import Mapping
 from typing import Annotated, Any, ClassVar, Literal
 
 from openai.types.chat.chat_completion_audio import (
@@ -671,6 +672,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
         self,
         max_tokens: int,
         default_sampling_params: dict,
+        reasoning_effort_budgets: Mapping[str, int] | None = None,
     ) -> SamplingParams:
         # Default parameters
         if (repetition_penalty := self.repetition_penalty) is None:
@@ -718,6 +720,12 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if self.ec_transfer_params:
             # Pass in ec_transfer_params via extra_args
             extra_args["ec_transfer_params"] = self.ec_transfer_params
+        thinking_token_budget = self.thinking_token_budget
+        if thinking_token_budget is None and self.reasoning_effort is not None:
+            thinking_token_budget = (reasoning_effort_budgets or {}).get(
+                self.reasoning_effort
+            )
+
         return SamplingParams.from_optional(
             n=self.n,
             presence_penalty=self.presence_penalty,
@@ -750,7 +758,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             structured_outputs=self.extract_structured_outputs(),
             logit_bias=self.logit_bias,
             bad_words=self.bad_words,
-            thinking_token_budget=self.thinking_token_budget,
+            thinking_token_budget=thinking_token_budget,
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -3,7 +3,7 @@
 
 import asyncio
 import time
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from collections.abc import Sequence as GenericSequence
 from http import HTTPStatus
 from typing import Any, Final, cast
@@ -137,6 +137,7 @@ class OpenAIServingChat(GenerateBaseServing):
         enable_log_outputs: bool = False,
         enable_log_deltas: bool = True,
         default_chat_template_kwargs: dict[str, Any] | None = None,
+        reasoning_effort_budgets: Mapping[str, int] | None = None,
         enable_per_request_metrics: bool = False,
     ) -> None:
         super().__init__(
@@ -152,6 +153,7 @@ class OpenAIServingChat(GenerateBaseServing):
         self.chat_template_content_format: Final = chat_template_content_format
         self.trust_request_chat_template = trust_request_chat_template
         self.default_chat_template_kwargs = default_chat_template_kwargs or {}
+        self.reasoning_effort_budgets = reasoning_effort_budgets or {}
         self.enable_log_outputs = enable_log_outputs
         self.enable_log_deltas = enable_log_deltas
 
@@ -327,6 +329,7 @@ class OpenAIServingChat(GenerateBaseServing):
                 sampling_params = request.to_sampling_params(
                     max_tokens,
                     self.default_sampling_params,
+                    self.reasoning_effort_budgets,
                 )
 
             self._log_inputs(


### PR DESCRIPTION
## Summary

Fix Qwen3.5/3.6 reasoning-effort handling by allowing the server to map
`reasoning_effort` values to default `thinking_token_budget` values.

For example, starting the server with:

```bash
--reasoning-effort-budgets '{"low":4096,"medium":16384,"high":32768}'
```

lets a request that only sets `reasoning_effort: "low"` receive a 4096-token
thinking budget.

This change:

- adds the `--reasoning-effort-budgets` JSON CLI option;
- validates that values are non-negative integers;
- applies the mapping to OpenAI-compatible chat completions and batch chat
  completions;
- preserves explicit request-level `thinking_token_budget` values;
- leaves unmapped reasoning-effort values unchanged.

Fixes #55382.

## Tests

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  --confcutdir=/tmp /tmp/test_reasoning_budgets.py /tmp/test_reasoning_cli.py -q

.venv/bin/ruff check \
  vllm/entrypoints/launchers/cli_args.py \
  vllm/entrypoints/openai/chat_completion/protocol.py \
  vllm/entrypoints/openai/chat_completion/serving.py \
  vllm/entrypoints/openai/chat_completion/batch_serving.py \
  vllm/entrypoints/generate/api_router.py \
  tests/entrypoints/launchers/test_cli_args.py \
  tests/entrypoints/openai/chat_completion/test_chat.py

.venv/bin/ruff format --check \
  vllm/entrypoints/launchers/cli_args.py \
  vllm/entrypoints/openai/chat_completion/protocol.py \
  vllm/entrypoints/openai/chat_completion/serving.py \
  vllm/entrypoints/openai/chat_completion/batch_serving.py \
  vllm/entrypoints/generate/api_router.py \
  tests/entrypoints/launchers/test_cli_args.py \
  tests/entrypoints/openai/chat_completion/test_chat.py

git diff HEAD^ HEAD --check
```

Results:

- 8 CPU-only parameter and CLI tests passed;
- Ruff checks passed;
- all modified files are formatted;
- diff whitespace check passed.

This is a frontend/configuration-only change; model evaluation is not
applicable.

## Duplicate-work check

Issue #55382 was checked for open pull requests before implementation and
again immediately before pushing this branch. No open PR addressing this
issue was found.

## AI assistance

AI assistance was used for issue discovery, code investigation, test design,
and implementation. The submitting contributor has reviewed and understands
every changed line.
