### PR TITLE
[Bugfix] Install numactl in ROCm images so --numa-bind is not a silent no-op

### DIFF
--- a/docker/Dockerfile.rock
+++ b/docker/Dockerfile.rock
@@ -36,10 +36,11 @@ ARG ARG_PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
 
 # Install build dependencies and utilities
+# numactl CLI for NUMA binding at runtime (--numa-bind)
 RUN apt-get update -q -y && apt-get install -q -y \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
     apt-transport-https ca-certificates wget curl \
-    libnuma-dev ccache mold
+    libnuma-dev numactl ccache mold
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --upgrade pip
 # Note: mold is installed but not set as the system default linker because

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -36,10 +36,11 @@ ARG ARG_PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
 
 # Install build dependencies and utilities
+# numactl CLI for NUMA binding at runtime (--numa-bind)
 RUN apt-get update -q -y && apt-get install -q -y \
     sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
     apt-transport-https ca-certificates wget curl \
-    libnuma-dev ccache mold
+    libnuma-dev numactl ccache mold
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --upgrade pip
 # Note: mold is installed but not set as the system default linker because

--- a/tests/utils_/test_numa_utils.py
+++ b/tests/utils_/test_numa_utils.py
@@ -510,3 +510,25 @@ def test_configure_subprocess_numa_fallback(monkeypatch):
     with numa_utils.configure_subprocess(node_config, local_rank=0):
         assert multiprocessing.spawn.get_executable() == before
         assert numa_utils._NUMACTL_ARGS_ENV not in os.environ
+
+
+def test_resolve_numactl_args_warns_when_all_candidates_fail(monkeypatch):
+    """When numactl is missing (or rejects even the bare probe), every
+    candidate fails and the empty fallback must warn instead of returning
+    '' silently."""
+    warnings = []
+
+    def fake_warning(msg, *args):
+        warnings.append(msg % args)
+
+    def raise_filenotfound(*args, **kwargs):
+        raise FileNotFoundError("numactl not installed")
+
+    monkeypatch.setattr(numa_utils.logger, "warning", fake_warning)
+    monkeypatch.setattr(numa_utils.subprocess, "run", raise_filenotfound)
+
+    assert (
+        numa_utils._resolve_numactl_args("--cpunodebind=0 --membind=0") == ""
+    )
+    assert len(warnings) == 1
+    assert "numactl" in warnings[0]

--- a/vllm/utils/numa_utils.py
+++ b/vllm/utils/numa_utils.py
@@ -501,6 +501,12 @@ def _resolve_numactl_args(numactl_args: str) -> str:
                     candidate or "no binding",
                 )
             return candidate
+    logger.warning(
+        "numactl is not installed or not usable; launching without NUMA "
+        "binding (requested args %r). Install numactl (e.g. apt-get "
+        "install numactl) or check container permissions.",
+        numactl_args,
+    )
     return ""
 
 


### PR DESCRIPTION
Fixes #55416

## Problem

`--numa-bind` is a silent no-op on the ROCm images: `numactl` is not installed in them (`shutil.which("numactl")` is `None`), so `_probe_numactl_args` fails, `_resolve_numactl_args` returns `''`, and per-worker CPU binding never happens — while the CUDA image installs `numactl` (docker/Dockerfile, ~line 805). As the issue documents, on multi-socket hosts the missing binding produces a 177 ms cross-rank `reduce_scatter` spread and a measurable step-time penalty.

## Fix

1. **`docker/Dockerfile.rocm` + `docker/Dockerfile.rock`** — add `numactl` to the `base` stage's apt line (next to the already-present `libnuma-dev`), with a comment mirroring the CUDA Dockerfile's wording. Both files are published as `vllm/vllm-openai-rocm` nightlies by the release pipeline and both carried the identical bug. Runtime deps deliberately go in `Dockerfile.rocm` (per the repo's own comments about not rebuilding the long-lived base image), and this stage is an ancestor of both the published `vllm-openai` and CI `test` targets.
2. **`vllm/utils/numa_utils.py`** — one `logger.warning` where `_resolve_numactl_args` returns `''` after all probe candidates fail, naming numactl as the missing dependency (existing `%`-style logging). On current main a fully-missing numactl raises loudly via `configure_subprocess`, so the genuinely silent paths are all-probes-fail and direct/in-isolated calls — exactly the issue's repro — and the warning covers both without duplicating the existing fallback warning.
3. **`tests/utils_/test_numa_utils.py`** — `test_resolve_numactl_args_warns_when_all_candidates_fail`, using the file's established monkeypatch style (plain caplog is unreliable here because `vllm/logger.py` sets `propagate: False`).

## Verification

- Package name confirmed correct for both ROCm chains (Ubuntu 22.04 apt-based; `numactl` already used by the CUDA/xpu/cpu Ubuntu images).
- No docker-lint job exists in this repo's CI; the change is one token on a CI-exercised apt line.
- `_resolve_numactl_args` loaded in isolation and all four paths verified: missing numactl → warns + `''`; membind-rejected → existing fallback warning unchanged; all-succeed → no warnings; all-fail → warns + `''`.

The gfx1250 Dockerfile variants also lack `numactl` but are not CI-published; left untouched for maintainers to decide.
