### PR TITLE
[Bugfix] Restore GLM-5.3-Flash startup memory and KV capacity

### DIFF
--- a/tests/renderers/test_warmup.py
+++ b/tests/renderers/test_warmup.py
@@ -65,6 +65,7 @@ def _make_renderer_mock(mm_limits: dict[str, int]) -> MagicMock:
     renderer._mm_warmup_done = False
     renderer.clear_mm_cache = MagicMock()
     renderer.model_config.max_model_len = 128
+    renderer.config.scheduler_config.max_num_batched_tokens = 8192
     renderer.model_config.get_multimodal_config.return_value.limit_per_prompt = {}
 
     return renderer
@@ -114,6 +115,23 @@ class TestMmWarmupZeroLimitFiltering:
 class TestMmWarmupRunsNormally:
     # MM warmup must run when mm_processor is set and limits > 0; the chat
     # template warmup must run alongside it.
+
+    @pytest.mark.parametrize(
+        ("max_model_len", "expected_seq_len"), [(491520, 8192), (128, 128)]
+    )
+    def test_warmup_sequence_length_is_bounded(self, max_model_len, expected_seq_len):
+        renderer = _make_renderer_mock({"image": 1, "video": 1})
+        renderer.model_config.max_model_len = max_model_len
+
+        with patch("vllm.multimodal.processing.TimingContext", autospec=True):
+            BaseRenderer.warmup(renderer, ChatParams())
+
+        get_inputs = renderer.mm_processor.dummy_inputs.get_dummy_processor_inputs
+        get_inputs.assert_called_once_with(
+            seq_len=expected_seq_len,
+            mm_counts={"image": 1, "video": 1},
+            mm_options={},
+        )
 
     def test_processor_apply_called(self):
         renderer = _make_renderer_mock({"image": 1})

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2514,6 +2514,51 @@ def test_get_kv_cache_config_mamba_hybrid_sharing_infeasible_no_indexer():
         kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
 
 
+@pytest.mark.parametrize(
+    ("cache_dtype", "bytes_per_token", "expected_block_size"),
+    [("fp8_ds_mla", 656, 3584), ("nvfp4_ds_mla", 352, 6656), ("fp8", 512, 4608)],
+)
+def test_hybrid_mla_block_alignment_uses_packed_state_size(
+    monkeypatch, cache_dtype, bytes_per_token, expected_block_size
+):
+    from vllm.model_executor.models import ModelRegistry
+    from vllm.platforms.interface import Platform
+
+    config = VllmConfig(
+        cache_config=CacheConfig(cache_dtype=cache_dtype, mamba_cache_mode="align")
+    )
+    config.model_config = SimpleNamespace(
+        use_mla=True,
+        architecture="Glm5NextForConditionalGeneration",
+        get_num_kv_heads=lambda parallel_config: 1,
+        get_head_size=lambda: 512,
+    )
+    model_cls = SimpleNamespace(
+        get_mamba_state_shape_from_config=lambda config: (
+            (12288, 8),
+            (32, 128, 128),
+        ),
+        get_mamba_state_dtype_from_config=lambda config: (
+            torch.bfloat16,
+            torch.float32,
+        ),
+    )
+    monkeypatch.setattr(
+        ModelRegistry, "resolve_model_cls", lambda *args, **kwargs: (model_cls, None)
+    )
+    monkeypatch.setattr(Platform, "_get_indexer_block_alignment", lambda config: 256)
+    backend = SimpleNamespace(get_supported_kernel_block_sizes=lambda: [64])
+
+    Platform._align_hybrid_block_size(config, backend)
+
+    assert config.cache_config.block_size == expected_block_size
+    assert config.cache_config.mamba_block_size == expected_block_size
+    assert (
+        config.cache_config.mamba_page_size_padded
+        == expected_block_size * bytes_per_token
+    )
+
+
 def test_get_kv_cache_config_mamba_hybrid_sharing_prepadded_mamba():
     """Platform-prepadded mamba pages (mamba_page_size_padded hint) must not
     disable slot sharing; the layout re-pads them to the MLA page."""

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -103,6 +103,89 @@ def test_mamba_speculative_block_relocation_requires_exclusive_ownership():
         manager._relocate_speculative_block([pinned_block], 0)
 
 
+@pytest.mark.parametrize("chunk_blocks", [1, 2])
+@pytest.mark.parametrize("in_flight_chunks", [0, 1, 2])
+def test_mamba_sparse_retirement_preserves_in_flight_states(
+    chunk_blocks, in_flight_chunks
+):
+    block_size = 4
+    num_speculative_blocks = 5
+    spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=num_speculative_blocks,
+    )
+    pool = BlockPool(num_gpu_blocks=32, enable_caching=True, hash_block_size=4)
+    manager = MambaManager(
+        spec,
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+    chunk = chunk_blocks * block_size
+    for step in range(12):
+        computed = step * chunk
+        committed = max(0, computed - in_flight_chunks * chunk)
+        first_live_block = max(0, committed - 1) // block_size
+        before = list(manager.req_to_blocks["r"])
+
+        manager.remove_skipped_blocks("r", committed)
+
+        blocks = manager.req_to_blocks["r"]
+        assert blocks[first_live_block:] == before[first_live_block:]
+        assert all(
+            block.is_null or block.ref_cnt == 1 for block in blocks[first_live_block:]
+        )
+        assert all(block.is_null for block in blocks[:first_live_block])
+        target = computed + chunk
+        manager.get_num_blocks_to_allocate("r", target, [], computed, computed, target)
+        manager.allocate_new_blocks("r", target, target)
+        held = pool.num_gpu_blocks - 1 - pool.get_num_free_blocks()
+        assert held <= num_speculative_blocks + 2 + in_flight_chunks
+
+
+def test_mamba_sparse_retirement_does_not_rescan_freed_prefix():
+    class CountingBlocks(list):
+        accesses = 0
+
+        def __getitem__(self, index):
+            self.accesses += 1
+            return super().__getitem__(index)
+
+    spec = MambaSpec(
+        block_size=4,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    pool = BlockPool(num_gpu_blocks=16, enable_caching=False, hash_block_size=4)
+    manager = MambaManager(
+        spec,
+        block_pool=pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=4,
+    )
+    blocks = CountingBlocks(pool.get_new_blocks(8))
+    manager.req_to_blocks["r"] = blocks
+    for boundary in range(1, 8):
+        blocks.accesses = 0
+        manager.remove_skipped_blocks("r", boundary * 4 + 1)
+        assert blocks.accesses <= 2
+        blocks.accesses = 0
+        manager.remove_skipped_blocks("r", boundary * 4 + 1)
+        assert blocks.accesses == 0
+
+    manager.free("r")
+    manager.req_to_blocks["r"] = pool.get_new_blocks(2)
+    manager.remove_skipped_blocks("r", 5)
+    assert manager.req_to_blocks["r"][0].is_null
+    assert manager.req_to_blocks["r"][1].ref_cnt == 1
+
+
 def get_sliding_window_manager(
     sliding_window_spec,
     block_pool,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -818,6 +818,9 @@ class Platform:
                 dtype=kv_cache_dtype,
                 cache_dtype_str=cache_config.cache_dtype,
                 kv_quant_mode=kv_quant_mode,
+                state_content_bytes={"fp8_ds_mla": 656, "nvfp4_ds_mla": 352}.get(
+                    cache_config.cache_dtype
+                ),
             ).page_size_bytes
         elif cache_config.cache_dtype.startswith("turboquant_"):
             # TQ has a packed K|V layout; the standard FullAttentionSpec

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -254,7 +254,10 @@ class BaseRenderer(ABC, Generic[_T]):
 
         start_time = time.perf_counter()
         processor_inputs = processor.dummy_inputs.get_dummy_processor_inputs(
-            seq_len=model_config.max_model_len,
+            seq_len=min(
+                model_config.max_model_len,
+                self.config.scheduler_config.max_num_batched_tokens,
+            ),
             mm_counts=dict.fromkeys(mm_limits, 1),
             mm_options=mm_config.limit_per_prompt,
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1404,6 +1404,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # Mapping from request ID to the index of the block
             # allocated in the previous step
             self.last_state_block_idx: dict[str, int] = {}
+            self._num_retired_blocks: dict[str, int] = {}
             # The set of the requests that have been allocated blocks
             self._allocated_block_reqs: set[str] = set()
             # Number of internal checkpoint blocks required by each request's
@@ -1552,6 +1553,27 @@ class MambaManager(SingleTypeKVCacheManager):
                 mask[boundary_block - start_block] = True
 
         return mask
+
+    def _remove_blocks_in_range(
+        self, request_id: str, first_block: int, last_block: int
+    ) -> None:
+        if self.mamba_cache_mode != "align":
+            return super()._remove_blocks_in_range(request_id, first_block, last_block)
+        blocks = self.req_to_blocks.get(request_id, [])
+        first_block = max(first_block, self._num_retired_blocks.get(request_id, 0))
+        last_block = min(last_block, len(blocks))
+        if first_block >= last_block:
+            return
+        freed: list[KVCacheBlock] = []
+        # Mamba prefill leaves null gaps between states awaiting retirement.
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i].is_null:
+                continue
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+        self._num_retired_blocks[request_id] = last_block
 
     def remove_skipped_blocks(
         self,
@@ -1838,6 +1860,7 @@ class MambaManager(SingleTypeKVCacheManager):
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
+            self._num_retired_blocks.pop(request_id, None)
             self._num_checkpoint_blocks.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
             # An offer is only guaranteed to hold committed bytes until the end


### PR DESCRIPTION
Superseded by three independent PRs: #55448 (renderer warmup), #55449 (packed MLA alignment), and #55450 (Mamba retirement).

## Purpose

GLM-5.3-Flash lost loadable KV-cache capacity on GB10 when moving to current main with the required #54110 fix. This restores startup headroom and usable hybrid-cache capacity:

- Bound renderer warmup to the prefill token budget; full-context dummy preprocessing retains CPU allocator memory in the persistent executor introduced by #54557.
- Use packed MLA state sizes for hybrid block alignment after #51724.
- Retire Mamba states across null gaps without crossing the committed-token boundary. Asynchronous prefill otherwise leaves old states allocated and exhausts the pool.

No equivalent open fix was found. #55219 refactors GLM packing and tail rings; this corrects the existing aligner. #54076 changes chunking; this fixes retirement with existing chunk sizes. AI-assisted contribution.

## Test Plan

```bash
.venv/bin/python -m pytest tests/renderers/test_warmup.py tests/v1/core/test_kv_cache_utils.py \
  tests/v1/core/test_single_type_kv_cache_manager.py \
  -k 'warmup or hybrid_mla_block_alignment or glm5 or mamba_hybrid or mamba_sparse_retirement' -q
```

## Test Result

46 passed. Each regression was reproduced before its fix.

At 491,520 context / 8,192 batch tokens, anonymous process memory after real GLM preprocessing falls from 3.580 to 1.474 GiB. FP8 hybrid blocks return from 4,608 to 3,584 tokens. A CPU manager replay of 480k prefill with one in-flight chunk retains eight Mamba states per group instead of 71.

Observed TP2 capacity with FP8 KV, MTP5 and c2:

| Build | Memory utilization | KV tokens |
| --- | ---: | ---: |
| Old production (`487ecf187`), original recipe | 0.898 | 1,081,344 |
| Old production, matched guarded retest | 0.880 | 857,088 |
| Earlier main (`a69e75b9`), before these fixes | 0.871 | 674,411 |
| Main (`c81ace1`) + this PR + MTP-head deferral (#55442) | 0.880 | 777,216 / 817,152 |

Before the renderer/KV fixes, later main launches failed the pre-load memory check at 0.876 and 0.898. Recovering startup headroom makes a larger KV budget loadable: both fixed 0.880 runs passed vision checks, a 50k request and concurrent 480k+262k requests with zero preemptions or guard exits.

These are observed operating points across successive builds; the historical production recipe differs from the guarded retest, and no unfixed `c81ace1` control was completed at 0.880. The table therefore shows recovered loadability rather than an isolated percentage gain from this PR. At matched 0.880 flags, old production preempted once; fixed-main worker profiles remained 0.36–0.72 GiB higher. Exact baseline capacity parity remains unproven.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
