### PR TITLE
[Bugfix][Whisper] Apply timestamp decoding rules

### DIFF
--- a/tests/entrypoints/speech_to_text/test_whisper_timestamp.py
+++ b/tests/entrypoints/speech_to_text/test_whisper_timestamp.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.entrypoints.speech_to_text.base.serving import SpeechToTextBaseServing
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor.whisper import WHISPER_TIMESTAMP_RULES_KEY
+
+
+class _WhisperTokenizer:
+    eos_token_id = 2
+
+    def encode(self, text, add_special_tokens):
+        assert text == "<|notimestamps|>"
+        assert not add_special_tokens
+        return [5]
+
+
+def test_verbose_prompt_enters_timestamp_mode_without_forcing_zero_timestamp():
+    serving = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(model_type="whisper"))
+    )
+    prompt = {
+        "encoder_prompt": {"prompt": ""},
+        "decoder_prompt": {
+            "prompt": "<|startoftranscript|><|en|><|transcribe|><|notimestamps|>"
+        },
+    }
+
+    processed = SpeechToTextBaseServing._preprocess_verbose_prompt(serving, prompt)
+
+    decoder_prompt = processed["decoder_prompt"]["prompt"]
+    assert "<|notimestamps|>" not in decoder_prompt
+    assert not decoder_prompt.endswith("<|0.00|>")
+
+
+def test_verbose_request_enables_timestamp_rules():
+    serving = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(model_type="whisper")),
+        tokenizer=_WhisperTokenizer(),
+    )
+    sampling_params = SamplingParams(extra_args={"preserved": True})
+
+    SpeechToTextBaseServing._enable_whisper_timestamp_rules(
+        serving, sampling_params, begin_index=4
+    )
+
+    assert sampling_params.extra_args["preserved"] is True
+    assert sampling_params.extra_args[WHISPER_TIMESTAMP_RULES_KEY] == {
+        "eos_token_id": 2,
+        "no_timestamps_token_id": 5,
+        "max_initial_timestamp_index": 50,
+        "begin_index": 4,
+    }

--- a/tests/v1/logits_processors/test_whisper_timestamp.py
+++ b/tests/v1/logits_processors/test_whisper_timestamp.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm import SamplingParams
+from vllm.v1.sample.logits_processor.interface import BatchUpdate, MoveDirectionality
+from vllm.v1.sample.logits_processor.whisper import (
+    WHISPER_TIMESTAMP_RULES_KEY,
+    WhisperTimestampLogitsProcessor,
+)
+
+EOS_TOKEN_ID = 2
+NO_TIMESTAMPS_TOKEN_ID = 5
+TIMESTAMP_BEGIN = 6
+VOCAB_SIZE = 10
+
+
+def _sampling_params(enabled: bool = True) -> SamplingParams:
+    extra_args = None
+    if enabled:
+        extra_args = {
+            WHISPER_TIMESTAMP_RULES_KEY: {
+                "eos_token_id": EOS_TOKEN_ID,
+                "no_timestamps_token_id": NO_TIMESTAMPS_TOKEN_ID,
+                "max_initial_timestamp_index": 1,
+                "begin_index": 0,
+            }
+        }
+    return SamplingParams(extra_args=extra_args)
+
+
+def _processor(output_token_ids: list[int]) -> WhisperTimestampLogitsProcessor:
+    processor = WhisperTimestampLogitsProcessor(None, torch.device("cpu"), False)
+    processor.update_state(
+        BatchUpdate(
+            batch_size=1,
+            removed=[],
+            added=[(0, _sampling_params(), [], output_token_ids)],
+            moved=[],
+        )
+    )
+    return processor
+
+
+def test_initial_token_is_a_bounded_timestamp():
+    logits = _processor([]).apply(torch.zeros(1, VOCAB_SIZE))
+
+    assert torch.isneginf(logits[0, :TIMESTAMP_BEGIN]).all()
+    assert torch.isfinite(logits[0, TIMESTAMP_BEGIN : TIMESTAMP_BEGIN + 2]).all()
+    assert torch.isneginf(logits[0, TIMESTAMP_BEGIN + 2 :]).all()
+
+
+def test_timestamp_pairs_alternate_with_text():
+    after_opening_timestamp = _processor([TIMESTAMP_BEGIN]).apply(
+        torch.zeros(1, VOCAB_SIZE)
+    )
+    assert torch.isfinite(after_opening_timestamp[0, :NO_TIMESTAMPS_TOKEN_ID]).all()
+    assert torch.isneginf(after_opening_timestamp[0, NO_TIMESTAMPS_TOKEN_ID])
+    assert torch.isneginf(after_opening_timestamp[0, TIMESTAMP_BEGIN:]).all()
+
+    after_closing_timestamp = _processor([TIMESTAMP_BEGIN, 3, TIMESTAMP_BEGIN + 1])
+    logits = torch.zeros(1, VOCAB_SIZE)
+    logits[0, EOS_TOKEN_ID] = 10
+    logits = after_closing_timestamp.apply(logits)
+    assert torch.isneginf(logits[0, :EOS_TOKEN_ID]).all()
+    assert torch.isfinite(logits[0, EOS_TOKEN_ID])
+    assert torch.isfinite(logits[0, TIMESTAMP_BEGIN + 1])
+
+
+def test_timestamps_are_monotonic():
+    logits = _processor([TIMESTAMP_BEGIN, 3]).apply(torch.zeros(1, VOCAB_SIZE))
+
+    assert torch.isneginf(logits[0, TIMESTAMP_BEGIN])
+    assert torch.isfinite(logits[0, TIMESTAMP_BEGIN + 1])
+
+
+def test_timestamp_probability_mass_can_force_a_timestamp():
+    logits = torch.zeros(1, VOCAB_SIZE)
+    logits[0, TIMESTAMP_BEGIN + 1 :] = 1
+
+    processed = _processor([TIMESTAMP_BEGIN, 3]).apply(logits)
+
+    assert torch.isneginf(processed[0, :TIMESTAMP_BEGIN]).all()
+    assert torch.isfinite(processed[0, TIMESTAMP_BEGIN + 1 :]).all()
+
+
+def test_rules_are_request_scoped_and_follow_batch_moves():
+    output_token_ids = [TIMESTAMP_BEGIN]
+    processor = WhisperTimestampLogitsProcessor(None, torch.device("cpu"), False)
+    processor.update_state(
+        BatchUpdate(
+            batch_size=2,
+            removed=[],
+            added=[
+                (0, _sampling_params(), [], output_token_ids),
+                (1, _sampling_params(enabled=False), [], []),
+            ],
+            moved=[],
+        )
+    )
+
+    original = torch.zeros(2, VOCAB_SIZE)
+    processed = processor.apply(original.clone())
+    assert torch.isneginf(processed[0, TIMESTAMP_BEGIN:]).all()
+    assert torch.equal(processed[1], original[1])
+
+    processor.update_state(
+        BatchUpdate(
+            batch_size=2,
+            removed=[],
+            added=[],
+            moved=[(0, 1, MoveDirectionality.UNIDIRECTIONAL)],
+        )
+    )
+    moved = processor.apply(original.clone())
+    assert torch.equal(moved[0], original[0])
+    assert torch.isneginf(moved[1, TIMESTAMP_BEGIN:]).all()
+
+
+def test_rules_survive_batch_slot_replacement():
+    processor = _processor([TIMESTAMP_BEGIN])
+    processor.update_state(
+        BatchUpdate(
+            batch_size=1,
+            removed=[0],
+            added=[(0, _sampling_params(), [], [])],
+            moved=[],
+        )
+    )
+
+    logits = processor.apply(torch.zeros(1, VOCAB_SIZE))
+
+    assert torch.isneginf(logits[0, :TIMESTAMP_BEGIN]).all()
+    assert torch.isfinite(logits[0, TIMESTAMP_BEGIN : TIMESTAMP_BEGIN + 2]).all()
+
+
+def test_rules_include_generated_tokens_appended_to_beam_prompt():
+    sampling_params = _sampling_params()
+    sampling_params.extra_args[WHISPER_TIMESTAMP_RULES_KEY]["begin_index"] = 2
+    processor = WhisperTimestampLogitsProcessor(None, torch.device("cpu"), False)
+    processor.update_state(
+        BatchUpdate(
+            batch_size=1,
+            removed=[],
+            added=[(0, sampling_params, [3, 4, TIMESTAMP_BEGIN], [])],
+            moved=[],
+        )
+    )
+
+    logits = processor.apply(torch.zeros(1, VOCAB_SIZE))
+
+    assert torch.isfinite(logits[0, :NO_TIMESTAMPS_TOKEN_ID]).all()
+    assert torch.isneginf(logits[0, TIMESTAMP_BEGIN:]).all()

--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -121,6 +121,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
             temperature=temperature,
             detokenize=False,
             skip_clone=True,  # Internal beam search, safe to skip clone
+            extra_args=params.extra_args,
         )
         instances: list[BeamSearchInstance] = []
 

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -63,6 +63,7 @@ class BeamSearchOnlineMixin(ABC):
             max_tokens=1,
             temperature=temperature,
             detokenize=False,
+            extra_args=params.extra_args,
         )
         all_beams = [
             BeamSearchSequence(

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -39,6 +39,7 @@ from vllm.renderers.inputs.preprocess import parse_enc_dec_prompt, parse_model_p
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.tokenizers import get_tokenizer
 from vllm.utils.async_utils import make_async_with_semaphore, merge_async_iterators
+from vllm.v1.sample.logits_processor.whisper import WHISPER_TIMESTAMP_RULES_KEY
 
 from ..transcription.protocol import (
     TranscriptionResponse,
@@ -323,11 +324,34 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                 value=type(dec_prompt).__name__,
             )
 
-        dec_prompt["prompt"] = dec_prompt["prompt"].replace(
-            "<|notimestamps|>", "<|0.00|>"
-        )
+        dec_prompt["prompt"] = dec_prompt["prompt"].replace("<|notimestamps|>", "")
 
         return prompt
+
+    def _enable_whisper_timestamp_rules(
+        self,
+        sampling_params: SamplingParams | BeamSearchParams,
+        begin_index: int,
+    ) -> None:
+        if getattr(self.model_config.hf_config, "model_type", None) != "whisper":
+            return
+
+        no_timestamps_token_ids = self.tokenizer.encode(
+            "<|notimestamps|>", add_special_tokens=False
+        )
+        if len(no_timestamps_token_ids) != 1 or self.tokenizer.eos_token_id is None:
+            raise VLLMValidationError(
+                "Whisper tokenizer must define single no-timestamps and EOS tokens"
+            )
+
+        extra_args = dict(getattr(sampling_params, "extra_args", None) or {})
+        extra_args[WHISPER_TIMESTAMP_RULES_KEY] = {
+            "eos_token_id": self.tokenizer.eos_token_id,
+            "no_timestamps_token_id": no_timestamps_token_ids[0],
+            "max_initial_timestamp_index": 50,
+            "begin_index": begin_index,
+        }
+        sampling_params.extra_args = extra_args
 
     @staticmethod
     def _get_decoder_prompt_len(engine_inputs: list[EngineInput]) -> int:
@@ -498,11 +522,10 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         max_model_len = self.model_config.max_model_len
         list_result_generator: list[AsyncGenerator[RequestOutput, None]] | None = None
 
-        input_len = (
-            SpeechToTextBaseServing._get_decoder_prompt_len(engine_inputs)
-            if request.use_beam_search
-            else 0
+        decoder_prompt_len = SpeechToTextBaseServing._get_decoder_prompt_len(
+            engine_inputs
         )
+        input_len = decoder_prompt_len if request.use_beam_search else 0
 
         # Unlike most decoder-only models, whisper generation length is not
         # constrained by the size of the input audio, which is mapped to a
@@ -527,6 +550,9 @@ class SpeechToTextBaseServing(GenerateBaseServing):
 
         if request.response_format == "verbose_json":
             sampling_params.logprobs = 1
+            self._enable_whisper_timestamp_rules(
+                sampling_params, begin_index=decoder_prompt_len
+            )
 
         engine_request_ids = [
             request_id if len(engine_inputs) == 1 else f"{request_id}-{idx}"

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1286,6 +1286,7 @@ class BeamSearchParams(
     length_penalty: float = 1.0
     include_stop_str_in_output: bool = False
     structured_outputs: StructuredOutputsParams | None = None
+    extra_args: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         _verify_num_sequences(self.beam_width, "beam_width")

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -27,6 +27,7 @@ from vllm.v1.sample.logits_processor.interface import (
     MoveDirectionality,
 )
 from vllm.v1.sample.logits_processor.state import BatchUpdateBuilder, LogitsProcessors
+from vllm.v1.sample.logits_processor.whisper import WhisperTimestampLogitsProcessor
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -50,6 +51,7 @@ LOGITSPROCS_GROUP = "vllm.logits_processors"
 BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
     MinTokensLogitsProcessor,
     LogitBiasLogitsProcessor,
+    WhisperTimestampLogitsProcessor,
     MinPLogitsProcessor,
 ]
 
@@ -352,6 +354,7 @@ __all__ = [
     "LogitBiasLogitsProcessor",
     "MinPLogitsProcessor",
     "MinTokensLogitsProcessor",
+    "WhisperTimestampLogitsProcessor",
     "BatchUpdate",
     "BatchUpdateBuilder",
     "MoveDirectionality",

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -383,6 +383,12 @@ def process_dict_updates(
         return False
 
     updated = False
+    # Process removed requests before replacements added at the same index.
+    for index in batch_update.removed:
+        if req_entries.pop(index, None) is not None:
+            updated = True
+
+    # Process added requests.
     for index, params, prompt_tok_ids, output_tok_ids in batch_update.added:
         if (state := new_state(params, prompt_tok_ids, output_tok_ids)) is not None:
             req_entries[index] = state
@@ -391,11 +397,6 @@ def process_dict_updates(
             updated = True
 
     if req_entries:
-        # Process removed requests.
-        for index in batch_update.removed:
-            if req_entries.pop(index, None):
-                updated = True
-
         # Process moved requests, unidirectional (a->b) and
         # swapped (a<->b)
         for a_index, b_index, direct in batch_update.moved:

--- a/vllm/v1/sample/logits_processor/whisper.py
+++ b/vllm/v1/sample/logits_processor/whisper.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm import SamplingParams
+from vllm.v1.sample.logits_processor.builtin import process_dict_updates
+from vllm.v1.sample.logits_processor.interface import BatchUpdate, LogitsProcessor
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+WHISPER_TIMESTAMP_RULES_KEY = "_whisper_timestamp_rules"
+
+
+@dataclass(frozen=True)
+class _WhisperTimestampRules:
+    eos_token_id: int
+    no_timestamps_token_id: int
+    max_initial_timestamp_index: int | None
+    begin_index: int
+
+    @property
+    def timestamp_begin(self) -> int:
+        return self.no_timestamps_token_id + 1
+
+    @classmethod
+    def from_sampling_params(
+        cls, sampling_params: SamplingParams
+    ) -> "_WhisperTimestampRules | None":
+        extra_args = sampling_params.extra_args
+        values: Any = extra_args and extra_args.get(WHISPER_TIMESTAMP_RULES_KEY)
+        if values is None:
+            return None
+        if not isinstance(values, dict):
+            raise ValueError(f"{WHISPER_TIMESTAMP_RULES_KEY} must be a dictionary")
+
+        return cls(
+            eos_token_id=values["eos_token_id"],
+            no_timestamps_token_id=values["no_timestamps_token_id"],
+            max_initial_timestamp_index=values["max_initial_timestamp_index"],
+            begin_index=values["begin_index"],
+        )
+
+
+@dataclass(frozen=True)
+class _WhisperTimestampRequest:
+    rules: _WhisperTimestampRules
+    prompt_token_ids: Sequence[int]
+    output_token_ids: Sequence[int]
+
+    def sampled_tokens(self) -> Sequence[int]:
+        prompt_tokens = self.prompt_token_ids[self.rules.begin_index :]
+        if not prompt_tokens:
+            return self.output_token_ids
+        if not self.output_token_ids:
+            return prompt_tokens
+        return (*prompt_tokens, *self.output_token_ids)
+
+
+class WhisperTimestampLogitsProcessor(LogitsProcessor):
+    """Enforce Whisper's segment timestamp decoding rules per request."""
+
+    def __init__(
+        self, vllm_config: "VllmConfig", device: torch.device, is_pin_memory: bool
+    ) -> None:
+        self.requests: dict[int, _WhisperTimestampRequest] = {}
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    @staticmethod
+    def _new_request(
+        sampling_params: SamplingParams,
+        prompt_token_ids: list[int] | None,
+        output_token_ids: list[int],
+    ) -> _WhisperTimestampRequest | None:
+        if (
+            rules := _WhisperTimestampRules.from_sampling_params(sampling_params)
+        ) is None:
+            return None
+        return _WhisperTimestampRequest(
+            rules=rules,
+            prompt_token_ids=prompt_token_ids or (),
+            output_token_ids=output_token_ids,
+        )
+
+    def update_state(self, batch_update: BatchUpdate | None) -> None:
+        process_dict_updates(self.requests, batch_update, self._new_request)
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        for request_index, request in self.requests.items():
+            self._apply_rules(logits[request_index], request)
+        return logits
+
+    @staticmethod
+    def _apply_rules(scores: torch.Tensor, request: _WhisperTimestampRequest) -> None:
+        rules = request.rules
+        timestamp_begin = rules.timestamp_begin
+        if timestamp_begin >= scores.shape[-1]:
+            raise ValueError(
+                f"Whisper timestamp token {timestamp_begin} is outside vocabulary "
+                f"of size {scores.shape[-1]}"
+            )
+
+        scores[rules.no_timestamps_token_id] = -float("inf")
+        sampled_tokens = request.sampled_tokens()
+        last_was_timestamp = bool(
+            sampled_tokens and sampled_tokens[-1] >= timestamp_begin
+        )
+        penultimate_was_timestamp = (
+            len(sampled_tokens) < 2 or sampled_tokens[-2] >= timestamp_begin
+        )
+
+        if last_was_timestamp:
+            if penultimate_was_timestamp:
+                scores[timestamp_begin:] = -float("inf")
+            else:
+                scores[: rules.eos_token_id] = -float("inf")
+
+        timestamps = [
+            token_id for token_id in sampled_tokens if token_id >= timestamp_begin
+        ]
+        if timestamps:
+            timestamp_last = timestamps[-1]
+            if not (last_was_timestamp and not penultimate_was_timestamp):
+                timestamp_last += 1
+            scores[timestamp_begin:timestamp_last] = -float("inf")
+
+        if not sampled_tokens:
+            scores[:timestamp_begin] = -float("inf")
+            if rules.max_initial_timestamp_index is not None:
+                last_allowed = timestamp_begin + rules.max_initial_timestamp_index
+                scores[last_allowed + 1 :] = -float("inf")
+
+        logprobs = torch.nn.functional.log_softmax(scores.float(), dim=-1)
+        timestamp_logprob = logprobs[timestamp_begin:].logsumexp(dim=-1)
+        max_text_token_logprob = logprobs[:timestamp_begin].max()
+        force_timestamp = timestamp_logprob > max_text_token_logprob
+        scores[:timestamp_begin].masked_fill_(force_timestamp, -float("inf"))


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #55281.

Whisper timestamp requests did not apply the decoding rules required by the model. This change adds a native per-request timestamp logits processor for timestamp/text alternation, monotonic timestamps, bounded initial timestamps, and timestamp probability forcing. It also propagates the request rules through standard and beam-search generation, makes verbose JSON strip the no-timestamps token instead of forcing a zero timestamp, and preserves the replacement request's processor state when a persistent batch slot is recycled.

A duplicate search immediately before submission found no open or closed PR referencing #55281 or implementing this fix.

Implementation was assisted by OpenAI GPT-5. The author is responsible for reviewing and validating the change before it is marked ready for merge.

## Test Plan

- Cover initial timestamp bounds, timestamp/text alternation, monotonic timestamps, and timestamp mass forcing.
- Cover batched processor state movement and beam-search prompts with appended tokens.
- Cover removal and replacement at the same persistent batch index.
- Cover speech-to-text serving parameter propagation.
- Run the integrated timestamp test suite and Ruff checks.

The exact Whisper model checkpoint was not available on the target host, and outbound Hugging Face downloads were unavailable, so an end-to-end model evaluation was not run. The unit and integration tests exercise the processor rules and serving wiring directly.

## Test Result

- Targeted tests: `9 passed, 16 warnings in 2.44s`
- `ruff check`: all checks passed
- `ruff format --check`: 9 files already formatted

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan, including the test commands and coverage goals.
- [x] The test results, including targeted test and Ruff results.
- [x] Documentation impact considered; no documentation update is required for this bug fix.

</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
