### PR TITLE
[Bugfix][Model][Spec Decode] Defer disposable GLM MTP head

### DIFF
--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -33,7 +33,7 @@ mimo_7b_dir = "XiaomiMiMo/MiMo-7B-Base"
 DEVICE_TYPE = current_platform.device_type
 
 
-def test_shared_head_can_defer_lm_head(default_vllm_config):
+def test_shared_head_can_defer_lm_head():
     config = mock.MagicMock(hidden_size=16, rms_norm_eps=1e-5, vocab_size=32)
 
     with mock.patch(

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 import torch
+import torch.nn as nn
 
 from tests.v1.attention.utils import (
     BatchSpec,
@@ -22,6 +23,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.config.load import LoadConfig
+from vllm.model_executor.models.deepseek_mtp import DeferredLMHead, SharedHead
 from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -29,6 +31,52 @@ from vllm.v1.spec_decode.eagle import EagleProposer
 
 mimo_7b_dir = "XiaomiMiMo/MiMo-7B-Base"
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_shared_head_can_defer_lm_head(default_vllm_config):
+    config = mock.MagicMock(hidden_size=16, rms_norm_eps=1e-5, vocab_size=32)
+
+    with mock.patch(
+        "vllm.model_executor.models.deepseek_mtp.ParallelLMHead"
+    ) as parallel_lm_head:
+        regular = SharedHead(config, "mtp")
+        deferred = SharedHead(config, "mtp", defer_lm_head=True)
+
+    assert regular.head is parallel_lm_head.return_value
+    assert isinstance(deferred.head, DeferredLMHead)
+    assert not tuple(deferred.head.parameters())
+    with pytest.raises(RuntimeError, match="was not replaced"):
+        deferred.head(torch.zeros(1, 16))
+
+
+def test_glm_mtp_defers_shared_head():
+    from vllm.models.glm5next.nvidia import mtp
+
+    config = mock.MagicMock(
+        hidden_size=16,
+        rms_norm_eps=1e-5,
+        index_topk=8,
+        index_kpool=4,
+    )
+    vllm_config = mock.MagicMock()
+    vllm_config.speculative_config.draft_model_config.hf_config = config
+    vllm_config.scheduler_config.max_num_batched_tokens = 4
+
+    with (
+        mock.patch.object(
+            mtp, "RMSNorm", side_effect=lambda *args, **kwargs: nn.Identity()
+        ),
+        mock.patch.object(mtp, "Glm5NextDecoderLayer", return_value=nn.Identity()),
+        mock.patch.object(mtp, "SharedHead", return_value=nn.Identity()) as shared_head,
+        mock.patch.object(mtp.current_platform, "device_type", "cpu"),
+    ):
+        mtp.Glm5NextMultiTokenPredictorLayer(vllm_config, "model.layers.1")
+
+    shared_head.assert_called_once_with(
+        config=config,
+        prefix="model.layers.1",
+        defer_lm_head=True,
+    )
 
 
 def _create_mtp_proposer(num_speculative_tokens: int) -> EagleProposer:
@@ -70,6 +118,10 @@ def test_mtp_load_model_unified(mock_get_model, mock_get_layers, mock_get_pp_gro
     # Setup mocks
     mock_model = mock.MagicMock()
     mock_model.model.embed_tokens.weight.shape = (131072, 4096)
+    draft_head = mock.MagicMock()
+    mock_model.model.layers = [
+        mock.MagicMock(shared_head=mock.MagicMock(head=draft_head))
+    ]
     mock_get_model.return_value = mock_model
     # MTP does not have its own embed_tokens or lm_head
     # so it should share them with the target model
@@ -111,6 +163,7 @@ def test_mtp_load_model_unified(mock_get_model, mock_get_layers, mock_get_pp_gro
     mock_get_model.assert_called_once()
     # MTP shares lm_head with target model
     assert proposer.model.lm_head == target_model.lm_head
+    assert proposer.model.model.layers[0].shared_head.head is target_model.lm_head
     # MTP shares embed_tokens with target model
     assert proposer.model.model.embed_tokens == target_model.model.embed_tokens
 

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -42,6 +42,7 @@ def test_shared_head_can_defer_lm_head(default_vllm_config):
         regular = SharedHead(config, "mtp")
         deferred = SharedHead(config, "mtp", defer_lm_head=True)
 
+    parallel_lm_head.assert_called_once()
     assert regular.head is parallel_lm_head.return_value
     assert isinstance(deferred.head, DeferredLMHead)
     assert not tuple(deferred.head.parameters())

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -46,21 +46,31 @@ from .utils import (
 )
 
 
+class DeferredLMHead(nn.Module):
+    def forward(self, *args, **kwargs):
+        raise RuntimeError("deferred MTP head was not replaced by the target lm_head")
+
+
 class SharedHead(nn.Module):
     def __init__(
         self,
         config: PretrainedConfig,
         prefix: str,
         quant_config: QuantizationConfig | None = None,
+        *,
+        defer_lm_head: bool = False,
     ) -> None:
         super().__init__()
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.head = ParallelLMHead(
-            config.vocab_size,
-            config.hidden_size,
-            quant_config=quant_config,
-            prefix=maybe_prefix(prefix, "head"),
-        )
+        if defer_lm_head:
+            self.head = DeferredLMHead()
+        else:
+            self.head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "head"),
+            )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.norm(hidden_states)

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -42,7 +42,6 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
         assert vllm_config.speculative_config is not None
         config = vllm_config.speculative_config.draft_model_config.hf_config
         self.config = config
-        quant_config = vllm_config.quant_config
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -66,7 +65,9 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
             device=current_platform.device_type,
         )
         self.shared_head = SharedHead(
-            config=config, prefix=prefix, quant_config=quant_config
+            config=config,
+            prefix=prefix,
+            defer_lm_head=True,
         )
         # MTP layers sit past the base model's hidden layers; parse the index
         # from the prefix (e.g. "...layers.32") so the decoder builds an MLA


### PR DESCRIPTION
## Summary

- defer the GLM MTP `ParallelLMHead` that `load_eagle_model()` replaces with the target model's head
- keep `SharedHead`'s default behavior unchanged for other MTP models
- verify the quantized placeholder is not allocated

GLM MTP constructs a per-layer `ParallelLMHead` that `load_eagle_model()` replaces with the target model's head. That temporary head caused the load-time memory peak this PR originally addressed. #52501 subsequently initialized unloaded ModelOpt NVFP4 `weight_scale` parameters to a NaN sentinel and added a check that rejects an unoverwritten sentinel during quantization processing. Because the disposable head has no checkpoint scales to load, draft loading now fails inside `get_model()`, before `load_eagle_model()` can replace it.

Fixes #57532.

## Validation

- `HF_HUB_OFFLINE=1 PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest tests/v1/spec_decode/test_mtp.py -q --tb=short` (`3 passed`)
- `pre-commit run --files vllm/model_executor/models/deepseek_mtp.py vllm/models/glm5next/common/mtp.py tests/v1/spec_decode/test_mtp.py` (passed)
- DGX Spark, 2 nodes / TP=2, GLM-5.3-Flash NVFP4, MTP=3, 8K validation context:
  - main at validation time (`4c6c1a40b3`) fails while loading the draft: `NVFP4 weight_scale for layer 'parallel_lm_head' was never loaded (still NaN)`
  - the same build with only #52501 reverted reaches ready state and serves the expected model alias
  - this PR (`67e55792ff`) reaches ready state, returns HTTP 200 from `/health`, serves `glm-5.3-flash`, and completes a deterministic short request with MTP active (96 draft tokens, 44 accepted)

Hardware validation used `67e55792ff`. The identical patch was subsequently rebased onto `44dd18fe0b` as `5517abf8da`; the focused tests and pre-commit passed again after rebase.

This PR predates #57532; duplicate searches found no competing fix.

AI assistance was used to rebase the change, run validation, and draft this description. Every changed line and the validation results were reviewed by the submitter.
