### PR TITLE
[Bugfix] Don't require gate_proj when checking MoE quant scheme consistency

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
@@ -33,10 +33,14 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
         # RoutedExperts was made by combining multiple Linears so need to
         # make sure quantization config for Linear can target it
         quant_config._add_fused_moe_to_target_scheme_map()
-        unfused_names = [
-            layer_name + proj_name
-            for proj_name in [".0.gate_proj", ".0.up_proj", ".0.down_proj"]
-        ]
+        # A gateless MoE has no gate_proj. Asking for its scheme makes the
+        # absence resolve differently from the projections that do exist,
+        # and the check below then reports a conflict where there is only
+        # a missing projection. The layer already knows which kind it is.
+        proj_names = [".0.up_proj", ".0.down_proj"]
+        if layer.moe_config.is_act_and_mul:
+            proj_names.insert(0, ".0.gate_proj")
+        unfused_names = [layer_name + proj_name for proj_name in proj_names]
         # TODO: refactor this to use expert_mapping and check all layer numbers
         all_scheme_dicts = [
             quant_config.get_scheme_dict(layer, name) for name in unfused_names


### PR DESCRIPTION
## Purpose

`CompressedTensorsMoEMethod.get_moe_method` checks that a routed expert's
projections share one quantization scheme by resolving `.0.gate_proj`,
`.0.up_proj` and `.0.down_proj`.

A **gateless** MoE has no `gate_proj`. The missing name resolves differently
from the two that do exist, so the consistency check reports a conflict where
there is only an absence, and startup fails with:

```
ValueError: All MoE projections need to have same quantization scheme but found multiple
```

This makes any compressed-tensors quantization of a gateless MoE unloadable.
NemotronH is one — `nemotron_h.py` builds its `FusedMoE` with
`activation=activation_without_mul(...)`, so `moe_config.is_act_and_mul` is
already `False`. vLLM knows the layer is not gated; this check simply did not
ask.

The fix asks: `gate_proj` is included only when the layer says it has one.
Gated MoEs are unaffected — the same three names are resolved as before.

## Test Plan

A W4A16 compressed-tensors (GPTQ) quantization of
`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`, served on a single
RTX 3090:

```
vllm serve <pack> --tensor-parallel-size 1 --gpu-memory-utilization 0.92 \
  --max-model-len 8192 --mamba-cache-mode=align \
  --speculative-config '{"method":"mtp","num_speculative_tokens":2}'
```

## Test Result

**Before:** engine core fails to start with the `ValueError` above.

**After:** the server starts and answers correctly.

```
prompt : "What is 17 * 24? Answer with just the number."
output : ... 24 * 10 = 240, 24 * 7 = 168, 240 + 168 = 408
```

Speculative decoding through the model's MTP head also works on the same
build: 73.2% draft acceptance, mean accepted length 2.46, over 12 sequential
requests read from the cumulative `spec_decode` counters.

No behaviour change for gated MoEs: when `is_act_and_mul` is true the list is
identical to the one this replaces.
