### PR TITLE
[Bugfix][Spec Decode] Default num_speculative_tokens from draft n_predict for MTP

### DIFF
--- a/tests/config/test_speculative_num_speculative_tokens.py
+++ b/tests/config/test_speculative_num_speculative_tokens.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ``num_speculative_tokens`` resolution in ``SpeculativeConfig``.
+
+``num_speculative_tokens`` is documented to default to the draft config's
+``n_predict`` when omitted. For MTP models this default was unreachable: method
+auto-detection compared ``num_speculative_tokens > 1`` before the ``n_predict``
+default was applied, so omitting it raised ``TypeError: '>' not supported
+between instances of 'NoneType' and 'int'`` (#55323).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from transformers import PretrainedConfig
+
+from vllm.config.parallel import ParallelConfig
+from vllm.config.speculative import SpeculativeConfig
+
+
+def _make_mtp_speculative_config(
+    num_speculative_tokens: int | None,
+    n_predict: int | None = 1,
+) -> SpeculativeConfig:
+    """Build an MTP ``SpeculativeConfig`` offline (no draft weights loaded).
+
+    ``ModelConfig`` is patched so the draft config is a synthetic
+    ``PretrainedConfig`` whose ``model_type`` is an MTP type; ``n_predict``
+    stands in for the value a real draft checkpoint would carry.
+    """
+    draft_hf_config = PretrainedConfig(
+        architectures=["Qwen4ExpMTP"],
+        model_type="qwen4_exp_mtp",
+        num_hidden_layers=1,
+    )
+    if n_predict is not None:
+        draft_hf_config.n_predict = n_predict
+    draft_model_config = MagicMock(
+        model="draft",
+        hf_config=draft_hf_config,
+        architectures=draft_hf_config.architectures,
+        max_model_len=128,
+    )
+    target_model_config = MagicMock(
+        model="target",
+        max_model_len=128,
+        quantization=None,
+        hf_overrides={},
+    )
+
+    kwargs = dict(
+        model="draft",
+        method="mtp",
+        target_model_config=target_model_config,
+        target_parallel_config=ParallelConfig(),
+    )
+    if num_speculative_tokens is not None:
+        kwargs["num_speculative_tokens"] = num_speculative_tokens
+
+    with patch("vllm.config.speculative.ModelConfig", return_value=draft_model_config):
+        return SpeculativeConfig(**kwargs)
+
+
+@pytest.mark.cpu_test
+def test_mtp_num_speculative_tokens_defaults_from_n_predict():
+    """Omitting ``num_speculative_tokens`` for an MTP draft defaults it to the
+    draft config's ``n_predict`` rather than raising ``TypeError`` (#55323)."""
+    spec = _make_mtp_speculative_config(num_speculative_tokens=None, n_predict=2)
+    assert spec.num_speculative_tokens == 2
+
+
+@pytest.mark.cpu_test
+def test_mtp_explicit_num_speculative_tokens_is_preserved():
+    """An explicit ``num_speculative_tokens`` is honored, not overwritten by
+    the ``n_predict`` default."""
+    spec = _make_mtp_speculative_config(num_speculative_tokens=1, n_predict=1)
+    assert spec.num_speculative_tokens == 1
+
+
+@pytest.mark.cpu_test
+def test_mtp_missing_n_predict_raises_value_error():
+    """When neither ``num_speculative_tokens`` nor the draft's ``n_predict`` is
+    available, the failure is a clear ``ValueError``, never a ``TypeError``."""
+    with pytest.raises(ValueError, match="num_speculative_tokens"):
+        _make_mtp_speculative_config(num_speculative_tokens=None, n_predict=None)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1316,7 +1316,8 @@ class SpeculativeConfig:
                 ):
                     self.method = "mtp"
                     if (
-                        self.num_speculative_tokens > 1
+                        self.num_speculative_tokens is not None
+                        and self.num_speculative_tokens > 1
                         and self.draft_model_config.hf_config.model_type
                         not in ("step3p5_mtp", "inkling_mtp")
                     ):


### PR DESCRIPTION
## Summary

For MTP models, `num_speculative_tokens` is documented to default to the draft
config's `n_predict` ("It will default to the number in the draft model config
if present, otherwise, it is required." — `vllm/config/speculative.py`). That
default was **unreachable**: MTP method auto-detection compares
`self.num_speculative_tokens > 1` *before* the `n_predict` default is applied
~100 lines later. So omitting `num_speculative_tokens` (the documented path):

```bash
vllm serve <mtp-model> --speculative-config '{"method":"mtp","model":"<mtp-model>"}'
```

crashed with:

```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

Fixes #55323.

## Fix

Guard the comparison against `None` so execution reaches the existing
`n_predict` resolution, which then populates `num_speculative_tokens` as
documented. When neither `num_speculative_tokens` nor the draft's `n_predict`
is available, the pre-existing clear `ValueError` in `_verify_args` applies —
no more `TypeError`.

```diff
                     self.method = "mtp"
                     if (
-                        self.num_speculative_tokens > 1
+                        self.num_speculative_tokens is not None
+                        and self.num_speculative_tokens > 1
                         and self.draft_model_config.hf_config.model_type
                         not in ("step3p5_mtp", "inkling_mtp")
                     ):
```

## Not a duplicate

Per `AGENTS.md`, checked open PRs before submitting:
`gh pr list --search "55323 in:body"` and keyword searches over
`MTP` / `num_speculative_tokens` / `n_predict` — no open PR addresses this
`TypeError` / default-resolution path. Related spec-decode PRs (e.g. #54631,
#51338) touch unrelated concerns.

## Tests

Added `tests/config/test_speculative_num_speculative_tokens.py` — CPU-only unit
tests that patch `ModelConfig` (no weights, no GPU), mirroring the existing
offline pattern in `tests/config/test_speculative_draft_hf_overrides.py`:

- `test_mtp_num_speculative_tokens_defaults_from_n_predict` — omitted →
  defaults to the draft's `n_predict` (the previously crashing path)
- `test_mtp_explicit_num_speculative_tokens_is_preserved`
- `test_mtp_missing_n_predict_raises_value_error` — clear `ValueError`, never
  `TypeError`

**Commands run and results:**

```
$ pytest --noconftest tests/config/test_speculative_num_speculative_tokens.py
3 passed
```
(`--noconftest` only because the repo's root `conftest.py` has import-time
issues on macOS/CPU; Linux CI runs it normally.)

- With the fix reverted, `test_mtp_num_speculative_tokens_defaults_from_n_predict`
  fails with `TypeError: '>' not supported between instances of 'NoneType' and 'int'`,
  reproducing #55323.
- Existing `tests/config/test_speculative_draft_hf_overrides.py`: 8/8 pass (no regression).
- `ruff check` and `ruff format --check` on both changed files: clean.

This is a config-only change with no effect on model output/accuracy, so no
eval runs were performed.

## AI assistance disclosure

Per `AGENTS.md`: AI assistance (Claude Code) was used to investigate and draft
this change. I reviewed every changed line and ran the tests above.
