### PR TITLE
[Bugfix][Benchmarks] Validate schema and reference in structured-output correctness

### DIFF
--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -35,6 +35,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 
 import datasets
+import jsonschema
 import numpy as np
 import pandas as pd
 from backend_request_func import (
@@ -547,10 +548,11 @@ async def benchmark(
     benchmark_start_time = time.perf_counter()
     tasks: list[asyncio.Task] = []
     expected: list[str] = []
+    schemas: list = []
+    structured_flags: list[bool] = []
     async for i, request in get_request(input_requests, request_rate, burstiness):
-        extra_body = (
-            prepare_extra_body(request) if i in structured_output_req_idx else None
-        )
+        is_structured = i in structured_output_req_idx
+        extra_body = prepare_extra_body(request) if is_structured else None
         request_func_input = RequestFuncInput(
             model=model_id,
             prompt=request.prompt,
@@ -561,6 +563,8 @@ async def benchmark(
             extra_body=extra_body,
         )
         expected.append(request.completion)
+        schemas.append(request.schema)
+        structured_flags.append(is_structured)
         tasks.append(
             asyncio.create_task(
                 limited_request_func(request_func_input=request_func_input, pbar=pbar)
@@ -636,8 +640,15 @@ async def benchmark(
     }
 
     ret = [
-        {"generated": output.generated_text, "expected": gt}
-        for output, gt in zip(outputs, expected)
+        {
+            "generated": output.generated_text,
+            "expected": gt,
+            "schema": schema,
+            "structured": is_structured,
+        }
+        for output, gt, schema, is_structured in zip(
+            outputs, expected, schemas, structured_flags
+        )
     ]
 
     def process_one_metric(
@@ -703,20 +714,40 @@ async def benchmark(
     return result, ret
 
 
-def evaluate(ret, args):
-    def _eval_correctness_json(expected, actual):
-        # extract json string from string using regex
-        import regex as re
+def _eval_correctness_json(expected, actual, schema=None, structured=True):
+    # A parseable object is necessary but not sufficient. When the dataset
+    # carries a reference completion the response must match it (semantic
+    # equality, so key order and whitespace do not matter); when the request
+    # asked for structured output the response must validate against the
+    # schema it was given.
+    import regex as re
 
-        actual = actual.replace("\n", "").replace(" ", "").strip()
+    match = re.search(r"\{.*\}", actual, re.DOTALL)
+    if match is None:
+        return False
+    try:
+        actual_obj = json.loads(match.group())
+    except Exception:
+        return False
+
+    if expected is not None:
         try:
-            actual = re.search(r"\{.*\}", actual).group()
-            actual = json.loads(actual)
+            return actual_obj == json.loads(expected)
         except Exception:
+            pass  # unreadable reference; fall through to schema validation
+
+    if structured and schema is not None:
+        if isinstance(schema, str):
+            schema = json.loads(schema)
+        try:
+            jsonschema.validate(actual_obj, schema)
+        except jsonschema.ValidationError:
             return False
 
-        return True
+    return True
 
+
+def evaluate(ret, args):
     def _eval_correctness_choice(expected, actual):
         return actual in args.choice
 
@@ -725,9 +756,9 @@ def evaluate(ret, args):
 
         return re.match(args.regex, actual) is not None
 
-    def _eval_correctness(expected, actual):
+    def _eval_correctness(expected, actual, schema=None, structured=True):
         if args.structure_type == "json":
-            return _eval_correctness_json(expected, actual)
+            return _eval_correctness_json(expected, actual, schema, structured)
         elif args.structure_type == "regex":
             return _eval_correctness_regex(expected, actual)
         elif args.structure_type == "choice":
@@ -737,7 +768,12 @@ def evaluate(ret, args):
 
     scores = []
     for res in ret:
-        score = _eval_correctness(res["expected"], res["generated"])
+        score = _eval_correctness(
+            res["expected"],
+            res["generated"],
+            res.get("schema"),
+            res.get("structured", True),
+        )
         res["correctness"] = score
         scores.append(score)
 

--- a/tests/benchmarks/test_structured_output_eval.py
+++ b/tests/benchmarks/test_structured_output_eval.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the structured-output serving benchmark's correctness metric.
+
+The benchmark module imports a live-serving stack at module load time; the
+stubs below cover the pieces that are irrelevant to scoring so the real
+module can be imported and its real `evaluate` exercised.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+BENCH_PATH = (
+    Path(__file__).parent.parent.parent
+    / "benchmarks"
+    / "benchmark_serving_structured_output.py"
+)
+
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer"},
+    },
+    "required": ["name", "age"],
+}
+
+
+def _load_module():
+    # Stub the live-serving imports (and vllm itself) so the real module can
+    # be imported and scored without a server stack. Keys inserted here are
+    # removed again after load so the rest of the pytest process is unaffected.
+    stubs: dict[str, types.ModuleType] = {}
+    for name in ("datasets",):
+        stubs[name] = MagicMock()
+    brf = types.ModuleType("backend_request_func")
+    brf.ASYNC_REQUEST_FUNCS = {}
+    brf.RequestFuncInput = MagicMock()
+    brf.RequestFuncOutput = MagicMock()
+    brf.get_tokenizer = MagicMock()
+    stubs["backend_request_func"] = brf
+    for name in (
+        "vllm",
+        "vllm.tokenizers",
+        "vllm.v1",
+        "vllm.v1.structured_output",
+    ):
+        stubs[name] = types.ModuleType(name)
+    stubs["vllm.tokenizers"].get_tokenizer = MagicMock()
+    xgrammar_backend = types.ModuleType("vllm.v1.structured_output.backend_xgrammar")
+    xgrammar_backend.has_xgrammar_unsupported_json_features = MagicMock()
+    stubs["vllm.v1.structured_output.backend_xgrammar"] = xgrammar_backend
+
+    inserted = [name for name in stubs if name not in sys.modules]
+    for name in inserted:
+        sys.modules[name] = stubs[name]
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "benchmark_serving_structured_output", BENCH_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name in inserted:
+            sys.modules.pop(name, None)
+    return module
+
+
+@pytest.fixture(scope="module")
+def bench():
+    return _load_module()
+
+
+def _score(bench, ret):
+    return bench.evaluate(ret, Namespace(structure_type="json"))
+
+
+def test_schema_ignoring_backend_scores_zero(bench):
+    # A backend that ignores guided decoding and emits {} for everything used
+    # to score 100; it must now fail schema validation.
+    ret = [{"generated": "{}", "expected": None, "schema": SCHEMA, "structured": True}]
+    assert _score(bench, ret) == 0.0
+
+
+def test_conforming_object_scores_hundred(bench):
+    ret = [
+        {
+            "generated": '{"name": "John Smith", "age": 34}',
+            "expected": None,
+            "schema": SCHEMA,
+            "structured": True,
+        }
+    ]
+    assert _score(bench, ret) == 100.0
+
+
+def test_wrong_value_type_fails_validation(bench):
+    ret = [
+        {
+            "generated": '{"name": "John Smith", "age": "thirty-four"}',
+            "expected": None,
+            "schema": SCHEMA,
+            "structured": True,
+        }
+    ]
+    assert _score(bench, ret) == 0.0
+
+
+def test_schema_given_as_string_is_accepted(bench):
+    ret = [
+        {
+            "generated": '{"name": "John Smith", "age": 34}',
+            "expected": None,
+            "schema": json.dumps(SCHEMA),
+            "structured": True,
+        }
+    ]
+    assert _score(bench, ret) == 100.0
+
+
+def test_reference_completion_semantic_equality(bench):
+    # Key order and whitespace differ; the content matches.
+    ret = [
+        {
+            "generated": '{\n  "age": 34,\n  "name": "John Smith"\n}',
+            "expected": '{"name": "John Smith", "age": 34}',
+            "schema": SCHEMA,
+            "structured": True,
+        }
+    ]
+    assert _score(bench, ret) == 100.0
+
+
+def test_reference_completion_mismatch_fails(bench):
+    ret = [
+        {
+            "generated": '{"name": "Jane Doe", "age": 34}',
+            "expected": '{"name": "John Smith", "age": 34}',
+            "schema": SCHEMA,
+            "structured": True,
+        }
+    ]
+    assert _score(bench, ret) == 0.0
+
+
+def test_unstructured_request_keeps_parseability_semantics(bench):
+    # Under --structured-output-ratio < 1 the unstructured share was never
+    # asked to follow a schema; grading stays at parseability for them.
+    ret = [
+        {
+            "generated": 'here you go: {"anything": "free-form"}',
+            "expected": None,
+            "schema": SCHEMA,
+            "structured": False,
+        }
+    ]
+    assert _score(bench, ret) == 100.0
+
+
+def test_unparseable_response_fails(bench):
+    ret = [
+        {
+            "generated": "no json here",
+            "expected": None,
+            "schema": SCHEMA,
+            "structured": True,
+        }
+    ]
+    assert _score(bench, ret) == 0.0
+
+
+def test_string_values_keep_their_spaces(bench):
+    # The old grader stripped every space before parsing, so a payload with
+    # spaces inside a string was graded as different content than produced.
+    ret = [
+        {
+            "generated": '{"name": "John Smith", "age": 34}',
+            "expected": '{"name": "John Smith", "age": 34}',
+            "schema": SCHEMA,
+            "structured": True,
+        }
+    ]
+    assert _score(bench, ret) == 100.0

--- a/tests/benchmarks/test_structured_output_eval.py
+++ b/tests/benchmarks/test_structured_output_eval.py
@@ -33,6 +33,13 @@ SCHEMA = {
 }
 
 
+def _stub_module(name: str, attrs: dict) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
 def _load_module():
     # Stub the live-serving imports (and vllm itself) so the real module can
     # be imported and scored without a server stack. Keys inserted here are
@@ -40,23 +47,24 @@ def _load_module():
     stubs: dict[str, types.ModuleType] = {}
     for name in ("datasets",):
         stubs[name] = MagicMock()
-    brf = types.ModuleType("backend_request_func")
-    brf.ASYNC_REQUEST_FUNCS = {}
-    brf.RequestFuncInput = MagicMock()
-    brf.RequestFuncOutput = MagicMock()
-    brf.get_tokenizer = MagicMock()
-    stubs["backend_request_func"] = brf
-    for name in (
-        "vllm",
-        "vllm.tokenizers",
-        "vllm.v1",
-        "vllm.v1.structured_output",
-    ):
+    stubs["backend_request_func"] = _stub_module(
+        "backend_request_func",
+        {
+            "ASYNC_REQUEST_FUNCS": {},
+            "RequestFuncInput": MagicMock(),
+            "RequestFuncOutput": MagicMock(),
+            "get_tokenizer": MagicMock(),
+        },
+    )
+    for name in ("vllm", "vllm.v1", "vllm.v1.structured_output"):
         stubs[name] = types.ModuleType(name)
-    stubs["vllm.tokenizers"].get_tokenizer = MagicMock()
-    xgrammar_backend = types.ModuleType("vllm.v1.structured_output.backend_xgrammar")
-    xgrammar_backend.has_xgrammar_unsupported_json_features = MagicMock()
-    stubs["vllm.v1.structured_output.backend_xgrammar"] = xgrammar_backend
+    stubs["vllm.tokenizers"] = _stub_module(
+        "vllm.tokenizers", {"get_tokenizer": MagicMock()}
+    )
+    stubs["vllm.v1.structured_output.backend_xgrammar"] = _stub_module(
+        "vllm.v1.structured_output.backend_xgrammar",
+        {"has_xgrammar_unsupported_json_features": MagicMock()},
+    )
 
     inserted = [name for name in stubs if name not in sys.modules]
     for name in inserted:
@@ -65,6 +73,8 @@ def _load_module():
         spec = importlib.util.spec_from_file_location(
             "benchmark_serving_structured_output", BENCH_PATH
         )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"cannot load benchmark module from {BENCH_PATH}")
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
     finally:
@@ -164,7 +174,7 @@ def test_unstructured_request_keeps_parseability_semantics(bench):
     assert _score(bench, ret) == 100.0
 
 
-def test_unparseable_response_fails(bench):
+def test_unparsable_response_fails(bench):
     ret = [
         {
             "generated": "no json here",


### PR DESCRIPTION
## Purpose

Fixes #55441. The structured-output serving benchmark's headline `correct_rate(%)` only checked that a response contained a parseable JSON object: the parsed value was discarded, `expected` was never read, and every space and newline was stripped before parsing (mutating string values). A backend ignoring guided decoding entirely and emitting `{}` per request scored the same 100.0 as a fully conforming one, so the metric could not distinguish schema adherence from generic JSON emission.

The JSON arm now grades on content:

- When the dataset carries a reference completion (`--dataset xgrammar_bench`), the response must match it under semantic JSON equality, so key order and whitespace do not matter.
- When the request actually asked for structured output, the response must validate against the request's schema (via `jsonschema`, already a core dependency).
- Requests outside the `--structured-output-ratio` share keep the old parseability semantics, since they were never asked to follow a schema.
- Extraction no longer rewrites the payload; string values keep their spaces.

## Test Plan

Duplicate-work check: no open PR references #55441, and the only past PRs touching this file (#16438, #16499) are long-merged and unrelated.

New unit tests in `tests/benchmarks/test_structured_output_eval.py` import the real benchmark module (server-stack imports stubbed) and drive the real `evaluate`:

- `{}` against a required-properties schema now scores 0, a conforming object scores 100, a wrong value type scores 0.
- Reference completions compare semantically: reordered keys and reindented whitespace pass, changed content fails.
- The ratio-excluded share keeps parseability semantics; unparseable responses fail; spaces inside string values survive grading.

Commands run (Python 3.12 venv on macOS, pytest 9.1.1, jsonschema 4.26.0):

```
python -m pytest tests/benchmarks/test_structured_output_eval.py -q   # 9 passed
```

Red direction verified: with the benchmark change stashed and the tests kept, the three tests pinning the bug fail (the old code scores `{}` and a wrong-content reference as correct) and the six behavior-preserving tests still pass. `ruff` 0.14.0 check and format are clean on both files.

Model evaluation results: N/A. This changes how a benchmark computes its correctness number, not model output; the metric-level behavior is what the unit tests pin.

This contribution was prepared with AI assistance (Kimi K3). The investigation, patch, tests, and the red/green verification above were run locally by the agent and reviewed line by line before submission.
