### PR TITLE
[Bugfix][Multimodal] Bound renderer warmup to the prefill token budget

### DIFF
--- a/tests/multimodal/test_registry.py
+++ b/tests/multimodal/test_registry.py
@@ -6,10 +6,11 @@ Qwen2.5-VL visual component loading behavior.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+from vllm.config import SchedulerConfig
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 from ..models.utils import build_model_context
@@ -17,31 +18,32 @@ from ..models.utils import build_model_context
 pytestmark = pytest.mark.cpu_test
 
 
-@pytest.mark.parametrize("seq_len", [None, 8192])
-@pytest.mark.parametrize("token_count", [3, 9000])
-def test_dummy_inputs_sequence_budget_preserves_profiling_default(seq_len, token_count):
-    """Warmup may override the budget; profiling keeps full-context padding."""
+@pytest.mark.parametrize(
+    ("chunked_prefill", "max_model_len", "expected_seq_len"),
+    [(None, 491520, 491520), (True, 491520, 8192), (True, 128, 128), (False, 128, 128)],
+)
+def test_dummy_inputs_scheduler_budget(
+    chunked_prefill, max_model_len, expected_seq_len
+):
     model_config = MagicMock()
-    model_config.max_model_len = 491520
+    model_config.max_model_len = max_model_len
     processor = MagicMock()
-    processor.apply.return_value = {"prompt_token_ids": [7] * token_count}
-    kwargs = {} if seq_len is None else {"seq_len": seq_len}
-    with patch.object(MULTIMODAL_REGISTRY, "create_processor") as create:
-        result = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
-            model_config, {"image": 1}, processor=processor, **kwargs
+    processor.apply.return_value = {"prompt_token_ids": [7]}
+    kwargs = {}
+    if chunked_prefill is not None:
+        kwargs["scheduler_config"] = SchedulerConfig(
+            max_model_len=max_model_len,
+            is_encoder_decoder=False,
+            max_num_batched_tokens=8192,
+            max_num_seqs=1,
+            enable_chunked_prefill=chunked_prefill,
         )
-    expected = model_config.max_model_len if seq_len is None else seq_len
+    result = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+        model_config, {"image": 1}, processor=processor, **kwargs
+    )
     get_inputs = processor.dummy_inputs.get_dummy_processor_inputs
-    assert get_inputs.call_args.kwargs["seq_len"] == expected
-    assert get_inputs.call_args.kwargs["mm_options"] is (
-        model_config.get_multimodal_config.return_value.limit_per_prompt
-    )
-    assert result["prompt_token_ids"] == [7] * token_count + [0] * max(
-        0, expected - token_count
-    )
-    create.assert_not_called()
-    processor.apply.assert_called_once()
-    assert model_config.max_model_len == 491520
+    assert get_inputs.call_args.kwargs["seq_len"] == expected_seq_len
+    assert len(result["prompt_token_ids"]) == expected_seq_len
 
 
 @pytest.mark.parametrize(

--- a/tests/multimodal/test_registry.py
+++ b/tests/multimodal/test_registry.py
@@ -6,6 +6,7 @@ Qwen2.5-VL visual component loading behavior.
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -14,6 +15,33 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 from ..models.utils import build_model_context
 
 pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize("seq_len", [None, 8192])
+@pytest.mark.parametrize("token_count", [3, 9000])
+def test_dummy_inputs_sequence_budget_preserves_profiling_default(seq_len, token_count):
+    """Warmup may override the budget; profiling keeps full-context padding."""
+    model_config = MagicMock()
+    model_config.max_model_len = 491520
+    processor = MagicMock()
+    processor.apply.return_value = {"prompt_token_ids": [7] * token_count}
+    kwargs = {} if seq_len is None else {"seq_len": seq_len}
+    with patch.object(MULTIMODAL_REGISTRY, "create_processor") as create:
+        result = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+            model_config, {"image": 1}, processor=processor, **kwargs
+        )
+    expected = model_config.max_model_len if seq_len is None else seq_len
+    get_inputs = processor.dummy_inputs.get_dummy_processor_inputs
+    assert get_inputs.call_args.kwargs["seq_len"] == expected
+    assert get_inputs.call_args.kwargs["mm_options"] is (
+        model_config.get_multimodal_config.return_value.limit_per_prompt
+    )
+    assert result["prompt_token_ids"] == [7] * token_count + [0] * max(
+        0, expected - token_count
+    )
+    create.assert_not_called()
+    processor.apply.assert_called_once()
+    assert model_config.max_model_len == 491520
 
 
 @pytest.mark.parametrize(

--- a/tests/renderers/test_warmup.py
+++ b/tests/renderers/test_warmup.py
@@ -119,30 +119,16 @@ class TestMmWarmupRunsNormally:
     # template warmup must run alongside it.
 
     @pytest.mark.parametrize(
-        ("max_model_len", "chunked_prefill", "expected_seq_len"),
-        [
-            (491520, True, 8192),
-            (128, True, 128),
-            (491520, False, 491520),
-            (128, False, 128),
-        ],
+        ("max_model_len", "expected_seq_len"), [(491520, 8192), (128, 128)]
     )
-    @pytest.mark.parametrize("readonly", [False, True])
-    def test_warmup_sequence_length_is_bounded(
-        self, max_model_len, chunked_prefill, expected_seq_len, readonly
-    ):
+    def test_warmup_sequence_length_is_bounded(self, max_model_len, expected_seq_len):
         renderer = _make_renderer_mock({"image": 1, "video": 1})
         renderer.model_config.max_model_len = max_model_len
-        renderer.config.scheduler_config.enable_chunked_prefill = chunked_prefill
-        processor = renderer.mm_processor
-        if readonly:
-            renderer.mm_processor = None
-            renderer._readonly_mm_processor = processor
 
         with patch("vllm.multimodal.processing.TimingContext", autospec=True):
             BaseRenderer.warmup(renderer, ChatParams())
 
-        get_inputs = processor.dummy_inputs.get_dummy_processor_inputs
+        get_inputs = renderer.mm_processor.dummy_inputs.get_dummy_processor_inputs
         assert get_inputs.call_args.kwargs["seq_len"] == expected_seq_len
 
     def test_processor_apply_called(self):

--- a/tests/renderers/test_warmup.py
+++ b/tests/renderers/test_warmup.py
@@ -65,6 +65,7 @@ def _make_renderer_mock(mm_limits: dict[str, int]) -> MagicMock:
     renderer._mm_warmup_done = False
     renderer.clear_mm_cache = MagicMock()
     renderer.model_config.max_model_len = 128
+    renderer.config.scheduler_config.max_num_batched_tokens = 8192
     renderer.model_config.get_multimodal_config.return_value.limit_per_prompt = {}
 
     return renderer
@@ -114,6 +115,19 @@ class TestMmWarmupZeroLimitFiltering:
 class TestMmWarmupRunsNormally:
     # MM warmup must run when mm_processor is set and limits > 0; the chat
     # template warmup must run alongside it.
+
+    @pytest.mark.parametrize(
+        ("max_model_len", "expected_seq_len"), [(491520, 8192), (128, 128)]
+    )
+    def test_warmup_sequence_length_is_bounded(self, max_model_len, expected_seq_len):
+        renderer = _make_renderer_mock({"image": 1, "video": 1})
+        renderer.model_config.max_model_len = max_model_len
+
+        with patch("vllm.multimodal.processing.TimingContext", autospec=True):
+            BaseRenderer.warmup(renderer, ChatParams())
+
+        get_inputs = renderer.mm_processor.dummy_inputs.get_dummy_processor_inputs
+        assert get_inputs.call_args.kwargs["seq_len"] == expected_seq_len
 
     def test_processor_apply_called(self):
         renderer = _make_renderer_mock({"image": 1})

--- a/tests/renderers/test_warmup.py
+++ b/tests/renderers/test_warmup.py
@@ -45,6 +45,7 @@ def _make_renderer_mock(mm_limits: dict[str, int]) -> MagicMock:
     # MM processor with configurable limits
     mm_processor = MagicMock()
     mm_processor.info.allowed_mm_limits = mm_limits
+    mm_processor.apply.return_value = {"prompt_token_ids": [1]}
     renderer.mm_processor = mm_processor
     renderer._readonly_mm_processor = None
     renderer._warmup_mm_processor = BaseRenderer._warmup_mm_processor.__get__(
@@ -66,6 +67,7 @@ def _make_renderer_mock(mm_limits: dict[str, int]) -> MagicMock:
     renderer.clear_mm_cache = MagicMock()
     renderer.model_config.max_model_len = 128
     renderer.config.scheduler_config.max_num_batched_tokens = 8192
+    renderer.config.scheduler_config.enable_chunked_prefill = True
     renderer.model_config.get_multimodal_config.return_value.limit_per_prompt = {}
 
     return renderer
@@ -117,16 +119,30 @@ class TestMmWarmupRunsNormally:
     # template warmup must run alongside it.
 
     @pytest.mark.parametrize(
-        ("max_model_len", "expected_seq_len"), [(491520, 8192), (128, 128)]
+        ("max_model_len", "chunked_prefill", "expected_seq_len"),
+        [
+            (491520, True, 8192),
+            (128, True, 128),
+            (491520, False, 491520),
+            (128, False, 128),
+        ],
     )
-    def test_warmup_sequence_length_is_bounded(self, max_model_len, expected_seq_len):
+    @pytest.mark.parametrize("readonly", [False, True])
+    def test_warmup_sequence_length_is_bounded(
+        self, max_model_len, chunked_prefill, expected_seq_len, readonly
+    ):
         renderer = _make_renderer_mock({"image": 1, "video": 1})
         renderer.model_config.max_model_len = max_model_len
+        renderer.config.scheduler_config.enable_chunked_prefill = chunked_prefill
+        processor = renderer.mm_processor
+        if readonly:
+            renderer.mm_processor = None
+            renderer._readonly_mm_processor = processor
 
         with patch("vllm.multimodal.processing.TimingContext", autospec=True):
             BaseRenderer.warmup(renderer, ChatParams())
 
-        get_inputs = renderer.mm_processor.dummy_inputs.get_dummy_processor_inputs
+        get_inputs = processor.dummy_inputs.get_dummy_processor_inputs
         assert get_inputs.call_args.kwargs["seq_len"] == expected_seq_len
 
     def test_processor_apply_called(self):

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -29,7 +29,12 @@ from .processing import (
 )
 
 if TYPE_CHECKING:
-    from vllm.config import ModelConfig, ObservabilityConfig, VllmConfig
+    from vllm.config import (
+        ModelConfig,
+        ObservabilityConfig,
+        SchedulerConfig,
+        VllmConfig,
+    )
     from vllm.model_executor.models.interfaces import SupportsMultiModal
 
 logger = init_logger(__name__)
@@ -243,16 +248,16 @@ class MultiModalRegistry:
         *,
         cache: BaseMultiModalProcessorCache | None = None,
         processor: BaseMultiModalProcessor | None = None,
-        seq_len: int | None = None,
+        scheduler_config: "SchedulerConfig | None" = None,
     ) -> MultiModalInput:
         """
         Create dummy data for profiling the memory usage of a model.
 
-        The model is identified by `model_config`. If `seq_len` is omitted,
-        use the model's full context length for profiling.
+        The model is identified by `model_config`.
         """
-        if seq_len is None:
-            seq_len = model_config.max_model_len
+        seq_len = model_config.max_model_len
+        if scheduler_config is not None and scheduler_config.enable_chunked_prefill:
+            seq_len = min(seq_len, scheduler_config.max_num_batched_tokens)
 
         if processor is None:
             processor = self.create_processor(model_config, cache=cache)

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -243,13 +243,16 @@ class MultiModalRegistry:
         *,
         cache: BaseMultiModalProcessorCache | None = None,
         processor: BaseMultiModalProcessor | None = None,
+        seq_len: int | None = None,
     ) -> MultiModalInput:
         """
         Create dummy data for profiling the memory usage of a model.
 
-        The model is identified by `model_config`.
+        The model is identified by `model_config`. If `seq_len` is omitted,
+        use the model's full context length for profiling.
         """
-        seq_len = model_config.max_model_len
+        if seq_len is None:
+            seq_len = model_config.max_model_len
 
         if processor is None:
             processor = self.create_processor(model_config, cache=cache)

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -247,18 +247,14 @@ class BaseRenderer(ABC, Generic[_T]):
         log_prefix: str,
     ) -> None:
         model_config = self.model_config
-        scheduler_config = self.config.scheduler_config
         mm_limits = {k: v for k, v in processor.info.allowed_mm_limits.items() if v > 0}
-        seq_len = model_config.max_model_len
-        if scheduler_config.enable_chunked_prefill:
-            seq_len = min(seq_len, scheduler_config.max_num_batched_tokens)
 
         start_time = time.perf_counter()
         _ = mm_registry.get_dummy_mm_inputs(
             model_config,
             mm_counts=dict.fromkeys(mm_limits, 1),
             processor=processor,
-            seq_len=seq_len,
+            scheduler_config=self.config.scheduler_config,
         )
 
         elapsed = time.perf_counter() - start_time

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -246,22 +246,20 @@ class BaseRenderer(ABC, Generic[_T]):
         *,
         log_prefix: str,
     ) -> None:
-        from vllm.multimodal.processing import TimingContext
-
         model_config = self.model_config
-        mm_config = model_config.get_multimodal_config()
+        scheduler_config = self.config.scheduler_config
         mm_limits = {k: v for k, v in processor.info.allowed_mm_limits.items() if v > 0}
+        seq_len = model_config.max_model_len
+        if scheduler_config.enable_chunked_prefill:
+            seq_len = min(seq_len, scheduler_config.max_num_batched_tokens)
 
         start_time = time.perf_counter()
-        processor_inputs = processor.dummy_inputs.get_dummy_processor_inputs(
-            seq_len=min(
-                model_config.max_model_len,
-                self.config.scheduler_config.max_num_batched_tokens,
-            ),
+        _ = mm_registry.get_dummy_mm_inputs(
+            model_config,
             mm_counts=dict.fromkeys(mm_limits, 1),
-            mm_options=mm_config.limit_per_prompt,
+            processor=processor,
+            seq_len=seq_len,
         )
-        _ = processor.apply(processor_inputs, timing_ctx=TimingContext(enabled=False))
 
         elapsed = time.perf_counter() - start_time
         logger.info("%s warmup completed in %.3fs", log_prefix, elapsed)

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -254,7 +254,10 @@ class BaseRenderer(ABC, Generic[_T]):
 
         start_time = time.perf_counter()
         processor_inputs = processor.dummy_inputs.get_dummy_processor_inputs(
-            seq_len=model_config.max_model_len,
+            seq_len=min(
+                model_config.max_model_len,
+                self.config.scheduler_config.max_num_batched_tokens,
+            ),
             mm_counts=dict.fromkeys(mm_limits, 1),
             mm_options=mm_config.limit_per_prompt,
         )


### PR DESCRIPTION
## Purpose

Long-context multimodal renderer warmup retains unnecessary CPU memory. Let `MultiModalRegistry.get_dummy_mm_inputs` derive the warmup budget from the renderer's scheduler config, capped by `max_num_batched_tokens` only with chunked prefill enabled. Existing profiling callers retain full-context inputs.

Replaces the renderer fix in #55435. Duplicate check: no other open PR found for this warmup budget. AI-assisted contribution.

## Test Plan

```bash
.venv/bin/python -m pytest tests/renderers/test_warmup.py tests/multimodal/test_registry.py -k 'not supports_multimodal_inputs' -q --tb=short
```

## Test Result

31 passed, 4 unrelated model-config tests deselected. Changed-file pre-commit hooks passed.

Earlier combined-fix GLM-5.3-Flash TP2 validation passed vision checks and 50k/480k/262k-token prompts.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

