### PR TITLE
[Bugfix][Attention] Use packed MLA sizes for hybrid block alignment

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2521,6 +2521,7 @@ def test_get_kv_cache_config_mamba_hybrid_sharing_infeasible_no_indexer():
 def test_hybrid_mla_block_alignment_uses_packed_state_size(
     monkeypatch, cache_dtype, bytes_per_token, expected_block_size
 ):
+    from vllm.model_executor.layers.attention.mla_attention import MLAAttention
     from vllm.model_executor.models import ModelRegistry
     from vllm.platforms.interface import Platform
 
@@ -2557,6 +2558,14 @@ def test_hybrid_mla_block_alignment_uses_packed_state_size(
         config.cache_config.mamba_page_size_padded
         == expected_block_size * bytes_per_token
     )
+    layer = SimpleNamespace(
+        kv_cache_dtype=cache_dtype,
+        head_size=512,
+        sliding_window=None,
+        non_causal_multi_token_decode=False,
+    )
+    spec = MLAAttention.get_kv_cache_spec(layer, config)
+    assert config.cache_config.mamba_page_size_padded == spec.page_size_bytes
 
 
 def test_get_kv_cache_config_mamba_hybrid_sharing_prepadded_mamba():

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2514,6 +2514,51 @@ def test_get_kv_cache_config_mamba_hybrid_sharing_infeasible_no_indexer():
         kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
 
 
+@pytest.mark.parametrize(
+    ("cache_dtype", "bytes_per_token", "expected_block_size"),
+    [("fp8_ds_mla", 656, 3584), ("nvfp4_ds_mla", 352, 6656), ("fp8", 512, 4608)],
+)
+def test_hybrid_mla_block_alignment_uses_packed_state_size(
+    monkeypatch, cache_dtype, bytes_per_token, expected_block_size
+):
+    from vllm.model_executor.models import ModelRegistry
+    from vllm.platforms.interface import Platform
+
+    config = VllmConfig(
+        cache_config=CacheConfig(cache_dtype=cache_dtype, mamba_cache_mode="align")
+    )
+    config.model_config = SimpleNamespace(
+        use_mla=True,
+        architecture="Glm5NextForConditionalGeneration",
+        get_num_kv_heads=lambda parallel_config: 1,
+        get_head_size=lambda: 512,
+    )
+    model_cls = SimpleNamespace(
+        get_mamba_state_shape_from_config=lambda config: (
+            (12288, 8),
+            (32, 128, 128),
+        ),
+        get_mamba_state_dtype_from_config=lambda config: (
+            torch.bfloat16,
+            torch.float32,
+        ),
+    )
+    monkeypatch.setattr(
+        ModelRegistry, "resolve_model_cls", lambda *args, **kwargs: (model_cls, None)
+    )
+    monkeypatch.setattr(Platform, "_get_indexer_block_alignment", lambda config: 256)
+    backend = SimpleNamespace(get_supported_kernel_block_sizes=lambda: [64])
+
+    Platform._align_hybrid_block_size(config, backend)
+
+    assert config.cache_config.block_size == expected_block_size
+    assert config.cache_config.mamba_block_size == expected_block_size
+    assert (
+        config.cache_config.mamba_page_size_padded
+        == expected_block_size * bytes_per_token
+    )
+
+
 def test_get_kv_cache_config_mamba_hybrid_sharing_prepadded_mamba():
     """Platform-prepadded mamba pages (mamba_page_size_padded hint) must not
     disable slot sharing; the layout re-pads them to the MLA page."""

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -307,6 +307,7 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     get_kv_quant_mode,
+    get_mla_state_content_bytes,
 )
 
 logger = init_logger(__name__)
@@ -1280,12 +1281,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             dtype=kv_cache_dtype,
             cache_dtype_str=self.kv_cache_dtype,
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
-            # ds_mla layouts pack NoPE + RoPE + scales into one opaque per-token
-            # blob, so the size is not derivable from head_size.
-            # See flashmla_sparse.py.
-            state_content_bytes={"fp8_ds_mla": 656, "nvfp4_ds_mla": 352}.get(
-                self.kv_cache_dtype
-            ),
+            state_content_bytes=get_mla_state_content_bytes(self.kv_cache_dtype),
         )
         if self.sliding_window is not None:
             return SlidingWindowMLASpec(

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -796,6 +796,7 @@ class Platform:
             MambaSpec,
             MLAAttentionSpec,
             get_kv_quant_mode,
+            get_mla_state_content_bytes,
         )
 
         cache_config = vllm_config.cache_config
@@ -818,7 +819,7 @@ class Platform:
                 dtype=kv_cache_dtype,
                 cache_dtype_str=cache_config.cache_dtype,
                 kv_quant_mode=kv_quant_mode,
-                state_content_bytes={"fp8_ds_mla": 656, "nvfp4_ds_mla": 352}.get(
+                state_content_bytes=get_mla_state_content_bytes(
                     cache_config.cache_dtype
                 ),
             ).page_size_bytes

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -818,6 +818,9 @@ class Platform:
                 dtype=kv_cache_dtype,
                 cache_dtype_str=cache_config.cache_dtype,
                 kv_quant_mode=kv_quant_mode,
+                state_content_bytes={"fp8_ds_mla": 656, "nvfp4_ds_mla": 352}.get(
+                    cache_config.cache_dtype
+                ),
             ).page_size_bytes
         elif cache_config.cache_dtype.startswith("turboquant_"):
             # TQ has a packed K|V layout; the standard FullAttentionSpec

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -541,6 +541,12 @@ class FullAttentionSpec(AttentionSpec):
         return merged_spec
 
 
+def get_mla_state_content_bytes(cache_dtype: str) -> int | None:
+    """Packed NoPE + RoPE + scales bytes per token, or None for standard MLA."""
+    # See the ds_mla layouts in flashmla_sparse.py.
+    return {"fp8_ds_mla": 656, "nvfp4_ds_mla": 352}.get(cache_dtype)
+
+
 def _apply_alignment_padding(spec: MLAAttentionSpec | SlidingWindowMLASpec):
     if spec.alignment is None:
         return


### PR DESCRIPTION
## Purpose

Hybrid block alignment uses the semantic head size to estimate MLA pages, but packed FP8/NVFP4 caches have different physical byte widths. Use the same width lookup as MLA attention so padded Mamba pages match the final MLA pages. This fixes inconsistent cache sizing; the packed layouts themselves are unchanged.

 Duplicate check: #55219 is a separate GLM layout refactor; no other open PR was found for this sizing calculation when this PR was opened. AI-assisted contribution.

## Test Plan

```bash
HF_HUB_OFFLINE=1 .venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py \
  -k 'hybrid_mla_block_alignment or glm5 or mamba_hybrid' -q --tb=short
HF_HUB_OFFLINE=1 .venv/bin/python -m pytest tests/v1/attention/test_mla_backends.py \
  -k mla_kv_cache_spec_uses_layer_cache_dtype -q --tb=short
HF_HUB_OFFLINE=1 .venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py -q --tb=short
.venv/bin/pre-commit run --files vllm/platforms/interface.py \
  vllm/v1/kv_cache_interface.py \
  vllm/model_executor/layers/attention/mla_attention.py \
  tests/v1/core/test_kv_cache_utils.py
```

## Test Result

13 alignment/GLM/Mamba tests and 2 existing MLA-spec tests passed. The alignment regression also checks that Mamba padding matches the spec built by MLA attention. Both packed-format cases fail on base `e473e90`; ordinary FP8 passes. Full cache test file: 105 passed

Checked the real GLM-5.3-Flash TP2/MTP5 `fp8_ds_mla` configuration through the cache-spec and allocator APIs:

| | Block tokens | Padded Mamba page | Final MLA page | Physical manager block |
|---|---:|---:|---:|---:|
| Base `e473e90` | 4,608 | 2,359,296 B | 3,022,848 B | 38,098,944 B |
| PR `a120883` | 3,584 | 2,351,104 B | 2,351,104 B | 29,632,512 B |

The PR makes early Mamba padding agree with the final MLA page.
