### PR TITLE
[Bugfix] Unreadable `prompt_embeds` payload should be a 400, not a 500

### DIFF
--- a/tests/renderers/test_prompt_embeds_payload_validation.py
+++ b/tests/renderers/test_prompt_embeds_payload_validation.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""`prompt_embeds` payloads that are not tensor files must be client errors.
+
+`prompt_embeds` is a base64 blob the caller writes, and every other way of
+getting it wrong -- wrong rank, wrong hidden_size, wrong dtype, not a tensor at
+all -- already answers 400. A payload that `torch.load` cannot read at all was
+the exception: torch has no single error type for that (the zip reader raises
+`RuntimeError`, the legacy pickle path raises `UnpicklingError`, `KeyError` or
+`IndexError`, an empty payload raises `EOFError`), none of them is a
+`ValueError`, and the entrypoints' fallback therefore mapped them to 500.
+
+The assertions go through `create_error_response`, which is what actually turns
+an exception into a status code, so they pin the HTTP answer rather than the
+exception class alone.
+"""
+
+import io
+import pickle
+import zipfile
+
+import pybase64 as base64
+import pytest
+import torch
+
+from vllm.entrypoints.serve.exception_handling.error_response import (
+    create_error_response,
+)
+from vllm.exceptions import VLLMValidationError
+from vllm.renderers.embed_utils import safe_load_prompt_embeds
+
+
+@pytest.fixture
+def model_config():
+    from vllm.config import ModelConfig
+
+    return ModelConfig(
+        model="facebook/opt-125m",
+        tokenizer="facebook/opt-125m",
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        dtype="float32",
+        seed=0,
+        enable_prompt_embeds=True,
+    )
+
+
+def _encode(raw: bytes) -> bytes:
+    return base64.b64encode(raw)
+
+
+def _zip_without_a_tensor() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("junk.txt", "hello")
+    return buffer.getvalue()
+
+
+def _saved_tensor(tensor: torch.Tensor) -> bytes:
+    buffer = io.BytesIO()
+    torch.save(tensor, buffer)
+    return buffer.getvalue()
+
+
+UNPARSEABLE_PAYLOADS = [
+    pytest.param(b"", id="empty"),
+    pytest.param(b"\x80", id="single-byte"),
+    pytest.param(b"\x00\x01\x02\x03not-a-tensor", id="random-bytes"),
+    pytest.param(b"hello world this is not a torch file", id="ascii-text"),
+    pytest.param(b"PK\x03\x04" + b"\x00" * 20, id="truncated-zip"),
+    pytest.param(_zip_without_a_tensor(), id="zip-without-a-tensor"),
+    pytest.param(pickle.dumps(42), id="legacy-pickle-of-an-int"),
+]
+
+
+@pytest.mark.parametrize("payload", UNPARSEABLE_PAYLOADS)
+def test_unreadable_prompt_embeds_payload_is_a_client_error(model_config, payload):
+    with pytest.raises(VLLMValidationError) as excinfo:
+        safe_load_prompt_embeds(model_config, _encode(payload))
+
+    assert excinfo.value.parameter == "prompt_embeds"
+    assert int(create_error_response(excinfo.value).error.code) == 400
+
+
+@pytest.mark.parametrize("payload", UNPARSEABLE_PAYLOADS)
+def test_the_error_body_stays_bounded(model_config, payload):
+    """torch's reason is built from the caller's bytes, so it must be truncated.
+
+    An unpickler that reports the offending global, for instance, quotes a name
+    the caller chose; without a bound a large one would be reflected whole.
+    """
+    padding = b"A" * 100_000
+    with pytest.raises(VLLMValidationError) as excinfo:
+        safe_load_prompt_embeds(model_config, _encode(payload + padding))
+
+    assert len(str(excinfo.value)) < 500
+
+
+def test_a_well_formed_payload_still_loads(model_config):
+    """Positive control: the healthy path is untouched."""
+    hidden_size = model_config.get_hidden_size()
+    tensor = torch.zeros(3, hidden_size, dtype=torch.float32)
+
+    loaded = safe_load_prompt_embeds(model_config, _encode(_saved_tensor(tensor)))
+
+    assert loaded.shape == (3, hidden_size)
+    assert loaded.dtype == model_config.dtype
+
+
+def test_a_payload_that_is_not_base64_is_still_a_client_error(model_config):
+    """Positive control: the base64 stage already answered 400 and still does."""
+    with pytest.raises(ValueError) as excinfo:
+        safe_load_prompt_embeds(model_config, b"!!!!not base64!!!!")
+
+    assert int(create_error_response(excinfo.value).error.code) == 400

--- a/tests/renderers/test_sparse_tensor_concurrent_race.py
+++ b/tests/renderers/test_sparse_tensor_concurrent_race.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from vllm.config import ModelConfig
+from vllm.exceptions import VLLMValidationError
 from vllm.multimodal.media import AudioEmbeddingMediaIO, ImageEmbeddingMediaIO
 from vllm.renderers.embed_utils import safe_load_prompt_embeds
 from vllm.utils.sparse_utils import check_sparse_tensor_invariants_threadsafe
@@ -54,7 +55,7 @@ class TestNegativeControlWithoutRace:
 
     def test_malicious_sparse_rejected_by_prompt_loader(self, model_config):
         encoded = _encode_tensor(_create_malicious_sparse_tensor())
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises((RuntimeError, ValueError, VLLMValidationError)):
             safe_load_prompt_embeds(model_config, encoded)
 
     def test_malicious_sparse_rejected_by_image_loader(self):
@@ -147,7 +148,7 @@ class TestConcurrentRaceProtection:
             try:
                 safe_load_prompt_embeds(model_config, malicious_encoded)
                 bypassed.append(True)
-            except (RuntimeError, ValueError):
+            except (RuntimeError, ValueError, VLLMValidationError):
                 rejected.append(True)
 
         with ThreadPoolExecutor(max_workers=num_workers) as pool:
@@ -192,7 +193,7 @@ class TestGlobalFlagRestoration:
         initial = torch.sparse.check_sparse_tensor_invariants.is_enabled()
         malicious_encoded = _encode_tensor(_create_malicious_sparse_tensor())
 
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises((RuntimeError, ValueError, VLLMValidationError)):
             safe_load_prompt_embeds(model_config, malicious_encoded)
 
         assert torch.sparse.check_sparse_tensor_invariants.is_enabled() == initial
@@ -203,7 +204,7 @@ class TestGlobalFlagRestoration:
         malicious_encoded = _encode_tensor(_create_malicious_sparse_tensor())
 
         def attempt_load(_):
-            with contextlib.suppress(RuntimeError, ValueError):
+            with contextlib.suppress(RuntimeError, ValueError, VLLMValidationError):
                 safe_load_prompt_embeds(model_config, malicious_encoded)
 
         with ThreadPoolExecutor(max_workers=4) as pool:
@@ -244,7 +245,7 @@ class TestCrossLoaderLockSharing:
         # serialization — one finishes before the other starts), AND invalid
         # tensors are still rejected.
         malicious = _encode_tensor(_create_malicious_sparse_tensor())
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises((RuntimeError, ValueError, VLLMValidationError)):
             safe_load_prompt_embeds(model_config, malicious)
         with pytest.raises((RuntimeError, ValueError)):
             io_handler.load_base64("", malicious.decode("utf-8"))

--- a/tests/renderers/test_sparse_tensor_validation.py
+++ b/tests/renderers/test_sparse_tensor_validation.py
@@ -117,8 +117,10 @@ class TestPromptEmbedsValidation:
         malicious_tensor = _create_malicious_sparse_tensor()
         encoded = _encode_tensor(malicious_tensor)
 
-        # Should raise RuntimeError due to invalid sparse tensor
-        with pytest.raises((RuntimeError, ValueError)) as exc_info:
+        # The invariant check raises RuntimeError from inside torch.load;
+        # safe_load_prompt_embeds now reports that as a client error so the
+        # caller gets a 400 rather than the 500 a bare RuntimeError produced.
+        with pytest.raises(VLLMValidationError) as exc_info:
             safe_load_prompt_embeds(model_config, encoded)
 
         # Error should indicate sparse tensor validation failure
@@ -137,7 +139,7 @@ class TestPromptEmbedsValidation:
         )
         encoded = _encode_tensor(malicious_tensor)
 
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises(VLLMValidationError):
             safe_load_prompt_embeds(model_config, encoded)
 
     def test_negative_indices_rejected(self, model_config):
@@ -152,7 +154,7 @@ class TestPromptEmbedsValidation:
         )
         encoded = _encode_tensor(malicious_tensor)
 
-        with pytest.raises((RuntimeError, ValueError)):
+        with pytest.raises(VLLMValidationError):
             safe_load_prompt_embeds(model_config, encoded)
 
     def test_hidden_size_mismatch_rejected(self, model_config):
@@ -379,8 +381,8 @@ class TestSparseTensorValidationIntegration:
         # Step 1-2: Attacker creates malicious payload
         attack_payload = _encode_tensor(_create_malicious_sparse_tensor())
 
-        # Step 3-4: Server processes and should reject
-        with pytest.raises((RuntimeError, ValueError)):
+        # Step 3-4: Server processes and should reject, as a client error
+        with pytest.raises(VLLMValidationError):
             safe_load_prompt_embeds(model_config, attack_payload)
 
     def test_attack_scenario_chat_api_image(self):

--- a/vllm/renderers/embed_utils.py
+++ b/vllm/renderers/embed_utils.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from io import BytesIO
-from typing import TYPE_CHECKING
+from pickle import UnpicklingError
+from typing import TYPE_CHECKING, Final
+from zipfile import BadZipFile
 
 import pybase64
 import torch
@@ -17,6 +19,26 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
 
+# How much of torch's own reason is repeated back to the caller. The reason is
+# built from bytes the caller sent, so it is bounded rather than echoed whole.
+_MAX_EMBED_ERROR_REASON_CHARS: Final = 200
+
+# What `torch.load` raises when the payload is not a tensor file at all. It has
+# no single error type for that: the zip reader raises `RuntimeError`, the
+# legacy pickle path raises `UnpicklingError`, `KeyError` or `IndexError`, and
+# an empty payload raises `EOFError`. None of these is a `ValueError`, so the
+# entrypoints' fallback mapped them to 500 -- for a blob the caller supplied.
+# `torch.OutOfMemoryError` subclasses `RuntimeError` and is a server condition,
+# so it is re-raised before this tuple is consulted.
+_UNPARSEABLE_EMBED_ERRORS: Final = (
+    EOFError,
+    LookupError,
+    RuntimeError,
+    UnpicklingError,
+    BadZipFile,
+)
+
+
 def safe_load_prompt_embeds(
     model_config: "ModelConfig",
     embed: bytes,
@@ -28,11 +50,24 @@ def safe_load_prompt_embeds(
         )
 
     with check_sparse_tensor_invariants_threadsafe():
-        tensor = torch.load(
-            BytesIO(pybase64.b64decode(embed, validate=True)),
-            weights_only=True,
-            map_location=torch.device("cpu"),
-        )
+        try:
+            tensor = torch.load(
+                BytesIO(pybase64.b64decode(embed, validate=True)),
+                weights_only=True,
+                map_location=torch.device("cpu"),
+            )
+        except torch.OutOfMemoryError:
+            raise
+        except _UNPARSEABLE_EMBED_ERRORS as exc:
+            # torch's reason is worth keeping -- for a malformed sparse tensor
+            # it names the offending index -- but it is built from the caller's
+            # own bytes, so it is truncated rather than echoed whole.
+            reason = str(exc).strip() or type(exc).__name__
+            raise VLLMValidationError(
+                "`prompt_embeds` could not be deserialized as a torch tensor: "
+                f"{reason[:_MAX_EMBED_ERROR_REASON_CHARS]}",
+                parameter="prompt_embeds",
+            ) from exc
         tensor = safe_to_dense(tensor, parameter="prompt_embeds")
 
     if tensor.dim() > 2:


### PR DESCRIPTION
## Purpose

`prompt_embeds` is a base64 blob the caller writes, and `safe_load_prompt_embeds` already answers **400** for every other way of getting it wrong — wrong rank, wrong `hidden_size`, non-float dtype, a payload that deserializes to something other than a tensor, a body that is not valid base64. A payload `torch.load` cannot read *at all* was the one hole: it came back **500**.

torch has no single error type for that, which is why the existing mapping missed it:

| payload | what `torch.load` raises |
|---|---|
| empty | `EOFError` |
| single byte | `IndexError` |
| random bytes | `UnpicklingError` |
| ascii text | `KeyError` |
| truncated zip | `RuntimeError` |
| zip without a tensor | `RuntimeError` |
| legacy pickle of an int | `RuntimeError` |

None of those is a `ValueError`, so `create_error_response` fell through to its `InternalServerError` branch:

```python
elif isinstance(exc, (ValueError, TypeError, OverflowError)):
    err_type = "BadRequestError"
    status_code = HTTPStatus.BAD_REQUEST
...
else:
    err_type = "InternalServerError"
    status_code = HTTPStatus.INTERNAL_SERVER_ERROR
```

`render_prompt` calls `safe_load_prompt_embeds` with no `try` between it and the route, so the caller gets a 500 for a body they simply got wrong. This needs the server started with `--enable-prompt-embeds`; the guard for that flag is the first thing the function checks and is unchanged.

## Test Plan

Each payload is run through the **real** `safe_load_prompt_embeds` and then through the **real** `create_error_response`, so the assertion is about the status code the entrypoints actually produce, not about the exception class alone.

`tests/renderers/test_prompt_embeds_payload_validation.py` (new):

- `test_unreadable_prompt_embeds_payload_is_a_client_error` — 7 payloads, each must raise `VLLMValidationError` with `parameter="prompt_embeds"` and map to 400.
- `test_the_error_body_stays_bounded` — the same 7 payloads with 100 KB of padding appended; the message must stay under 500 characters.
- `test_a_well_formed_payload_still_loads` — positive control.
- `test_a_payload_that_is_not_base64_is_still_a_client_error` — positive control for the stage that already answered 400.

## Test Result

**On `main` (e473e9036), the same seven payloads:**

```
  200  well-formed 2D tensor (control): loaded (3, 8)
*** 500  empty payload: EOFError
*** 500  random bytes: UnpicklingError
*** 500  ascii text: KeyError
*** 500  truncated zip: RuntimeError
*** 500  valid zip, no tensor: RuntimeError
*** 500  legacy pickle of an int: RuntimeError
*** 500  single byte: IndexError
    400  not base64 at all: Error
```

**With this PR:**

```
  200  well-formed (control): (3, 8)
    400  empty payload: VLLMValidationError
    400  random bytes: VLLMValidationError
    400  ascii text: VLLMValidationError
    400  truncated zip: VLLMValidationError
    400  valid zip, no tensor: VLLMValidationError
    400  legacy pickle of an int: VLLMValidationError
    400  single byte: VLLMValidationError
    400  not base64 at all: Error
```

**Regression proven.** The new test file applied to a `main` worktree: **14 failed, 2 passed** — the 2 that pass are the positive controls, which is the point of including them. All 16 pass here.

**Suites:**

- `tests/renderers/test_prompt_embeds_payload_validation.py` + `test_sparse_tensor_validation.py` + `test_sparse_tensor_concurrent_race.py` → **69 passed**
- Whole `tests/renderers/` → 487 passed with 4 failures, all reproduced identically on `main`: 3 in `test_hf.py` (gated HF repos, no network here) and `test_cohere.py::test_async_cohere_renderer_does_not_block_event_loop` (an event-loop timing test; fails on `main` and on this branch in the same run).
- `ruff check` / `ruff format --check` clean on all four files.

## Two things worth flagging for review

**1. The sparse-tensor path changes status code too.** `check_sparse_tensor_invariants_threadsafe()` makes `torch.load` raise `RuntimeError` for a malicious sparse tensor, so that rejection was answering 500 as well. It now answers 400 and keeps torch's own reason:

```
`prompt_embeds` could not be deserialized as a torch tensor:
size is inconsistent with indices: for dim 0, size is 10 but found index 999999
```

The rejection itself is unchanged — same payloads refused at the same point.

**2. That required touching two existing test files.** `test_sparse_tensor_validation.py` (4 assertions) and `test_sparse_tensor_concurrent_race.py` (5 assertions) asserted `(RuntimeError, ValueError)` for the **prompt-embeds loader specifically**; they now accept the client error. The `MediaIO` assertions in the same files are deliberately untouched — `ImageEmbeddingMediaIO` / `AudioEmbeddingMediaIO` still surface torch's `RuntimeError`, and this PR does not change that path.

## Notes

- `torch.OutOfMemoryError` subclasses `RuntimeError` and is a server condition, so it is re-raised before the client-error tuple is consulted.
- torch's reason is truncated to 200 characters rather than echoed whole, because it is built from bytes the caller sent — an unpickler that reports an offending global quotes a name the caller chose.
- Found by fuzzing caller-supplied fields of the OpenAI entrypoints and classifying every exception through `create_error_response`. The same sweep put 120,000 malformed multimodal content parts through `_parse_chat_message_content_mm_part` and found **no** 500-class outcome there, so this PR is scoped to the one place that had them.
