### PR TITLE
[CI] Restore clean GPU state before OAI Triton MoE tests

### DIFF
--- a/tests/kernels/moe/conftest.py
+++ b/tests/kernels/moe/conftest.py
@@ -10,6 +10,7 @@ NEEDS_CLEAN_ENTRY = frozenset(
         # which they used to get only as a side effect of the preceding test
         # cleaning up after itself.
         "test_moe_layer.py",
+        "test_modular_oai_triton_moe.py",
         "test_ocp_mx_moe.py",
         "test_zero_expert_moe.py",
         # Execute no test on ROCm, where this was measured, so nothing is known


### PR DESCRIPTION
The H100 FP8 MoE lane has failed across 13 main-branch alert observations. In build [87376](https://buildkite.com/vllm/ci/builds/87376#01a0704f-ad66-493c-ae87-0d6c5c501a76), 14 cases in `test_modular_oai_triton_moe.py` fail waiting for GPU usage to fall below 10%; allocator usage stays at 14.40 GiB on a 79.65 GiB GPU.

#54954 disabled per-test global cleanup for MoE tests and added a clean-entry allowlist. This file explicitly calls `wait_for_gpu_memory_to_clear` in both test functions but was omitted from that list. Restore its clean entry using the existing mechanism, retaining the cleanup opt-out for the rest of the directory. This is a functional CI regression fix; it does not relax the memory guard or numerical assertions.

Duplicate checks: no open PR matched `NEEDS_CLEAN_ENTRY`; searches for `test_modular_oai_triton_moe` and MoE cleanup found no equivalent fix (#54202 changes dispatch coverage).

Validation:
- `pre-commit run --files tests/kernels/moe/conftest.py`: passed all applicable hooks.
- `git diff --check`: passed.
- Imported the actual conftest with a recording cleanup function: two consecutive OAI test setups each invoke cleanup, while an unrelated MoE file does not. The same check fails on unmodified main (0 cleanup calls).
- H200 GPU validation in the existing main CI image `784cac7c424db2f2fdc879b672abad7e231f5698`, isolated on GPU 1 of `h200-ci-1`: `uv venv --system-site-packages /tmp/.venv`, then `/tmp/.venv/bin/python -m pytest -v kernels/moe/test_modular_oai_triton_moe.py` from `tests/`: **21 passed in 32.53s** with the patch.
- Same GPU and image, unmodified conftest, `--maxfail=1`: **1 failed, 7 passed in 134.02s**, reproducing the exact memory wait failure at `[True-4-128-2-512-384-dtype0]`.
- The exact H100 CI lane still needs a green run; the local GPU validation used H200.

AI assistance was used for investigation, the patch, and validation. Draft for human review and the exact H100 CI lane; human line-by-line review has not been represented as completed.

CI follow-up: [Buildkite 87384](https://buildkite.com/vllm/ci/builds/87384) was triggered for this PR head. The exact regression job(s) are enabled: [(H100) FP8 MoE Kernels](https://buildkite.com/vllm/ci/builds/87384#01a0712b-fc55-4ed9-8bb5-11d29a9067c0). At 2026-09-05T10:52:05+00:00, they were waiting for image/dependency jobs; no successful end-to-end result is claimed.
