### PR TITLE
[CI] Recover empty multi-node Docker networks and finish partial cleanup

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -121,18 +121,6 @@ clear_ci_orchestration_env() {
     VLLM_ALLOW_DEPRECATED_BEAM_SEARCH
 }
 
-cleanup_network() {
-  local max_nodes=${NUM_NODES:-2}
-  for node in $(seq 0 $((max_nodes - 1))); do
-    if docker ps -a -q -f name="node${node}" | grep -q .; then
-      docker stop "node${node}" || true
-    fi
-  done
-  if docker network ls | grep -q docker-net; then
-    docker network rm docker-net || true
-  fi
-}
-
 amd_ci_teardown_log() {
   local event=$1
   shift
@@ -1704,13 +1692,11 @@ if is_multi_node "$commands"; then
 
     /bin/bash -c "${composite_command}"
     exit_code=$?
-    cleanup_network
     handle_pytest_exit "$exit_code"
   else
     echo "Multi-node job detected but failed to parse bracket command syntax."
     echo "Expected format: prefix ; [node0_cmd1, node0_cmd2] && [node1_cmd1, node1_cmd2]"
     echo "Got: $commands"
-    cleanup_network
     exit 111
   fi
 else

--- a/.buildkite/scripts/run-multi-node-test.sh
+++ b/.buildkite/scripts/run-multi-node-test.sh
@@ -38,8 +38,19 @@ for command in "${COMMANDS[@]}"; do
 done
 
 
+STARTED_CONTAINERS=()
+NETWORK_CREATED=0
+
 start_network() {
+    if docker network inspect docker-net > /dev/null 2>&1; then
+        if [ "$(docker network inspect --format '{{len .Containers}}' docker-net)" != 0 ]; then
+            echo "docker-net still has attached containers; refusing to reuse it." >&2
+            return 1
+        fi
+        docker network rm docker-net
+    fi
     docker network create --subnet=192.168.10.0/24 docker-net
+    NETWORK_CREATED=1
 }
 
 start_nodes() {
@@ -67,10 +78,11 @@ start_nodes() {
         # 3. map the huggingface cache directory to the container
         # 3. assign ip addresses to the containers (head node: 192.168.10.10, worker nodes:
         #    starting from 192.168.10.11)
-        docker run -d "${GPU_DEVICES[@]}" --shm-size=10.24gb -e HF_TOKEN \
+        CONTAINER_ID=$(docker run -d "${GPU_DEVICES[@]}" --shm-size=10.24gb -e HF_TOKEN \
             -v ~/.cache/huggingface:/root/.cache/huggingface --name "node$node" \
             --network docker-net --ip 192.168.10.$((10 + $node)) --rm "$DOCKER_IMAGE" \
-            /bin/bash -c "tail -f /dev/null"
+            /bin/bash -c "tail -f /dev/null")
+        STARTED_CONTAINERS+=("$CONTAINER_ID")
 
         # organize containers into a ray cluster
         if [ "$node" -eq 0 ]; then
@@ -115,13 +127,20 @@ run_nodes() {
     done
 }
 cleanup() {
-    for node in $(seq 0 $(($NUM_NODES-1))); do
-        docker stop "node$node"
+    local status=$?
+    local cleanup_status=0
+    for container_id in "${STARTED_CONTAINERS[@]}"; do
+        docker stop "$container_id" || cleanup_status=$?
     done
-    docker network rm docker-net
+    if [ "$NETWORK_CREATED" -eq 1 ]; then
+        docker network rm docker-net || cleanup_status=$?
+    fi
+    if [ "$status" -ne 0 ]; then
+        return "$status"
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 start_network
 start_nodes
 run_nodes
-

--- a/.buildkite/scripts/run-multi-node-test.sh
+++ b/.buildkite/scripts/run-multi-node-test.sh
@@ -40,6 +40,8 @@ done
 
 STARTED_CONTAINERS=()
 NETWORK_CREATED=0
+RUN_DIR=$(mktemp -d)
+NETWORK_NAME="docker-net-${RUN_DIR##*/}"
 
 start_network() {
     if docker network inspect docker-net > /dev/null 2>&1; then
@@ -49,7 +51,7 @@ start_network() {
         fi
         docker network rm docker-net
     fi
-    docker network create --subnet=192.168.10.0/24 docker-net
+    docker network create --subnet=192.168.10.0/24 "$NETWORK_NAME"
     NETWORK_CREATED=1
 }
 
@@ -79,20 +81,20 @@ start_nodes() {
         # 3. assign ip addresses to the containers (head node: 192.168.10.10, worker nodes:
         #    starting from 192.168.10.11)
         CONTAINER_ID=$(docker run -d "${GPU_DEVICES[@]}" --shm-size=10.24gb -e HF_TOKEN \
-            -v ~/.cache/huggingface:/root/.cache/huggingface --name "node$node" \
-            --network docker-net --ip 192.168.10.$((10 + $node)) --rm "$DOCKER_IMAGE" \
+            -v ~/.cache/huggingface:/root/.cache/huggingface --name "$NETWORK_NAME-node$node" \
+            --network "$NETWORK_NAME" --ip 192.168.10.$((10 + $node)) --rm "$DOCKER_IMAGE" \
             /bin/bash -c "tail -f /dev/null")
         STARTED_CONTAINERS+=("$CONTAINER_ID")
 
         # organize containers into a ray cluster
         if [ "$node" -eq 0 ]; then
             # start the ray head node
-            docker exec -d "node$node" /bin/bash -c "ray start --head --port=6379 --block"
+            docker exec -d "$CONTAINER_ID" /bin/bash -c "ray start --head --port=6379 --block"
             # wait for the head node to be ready
             sleep 10
         else
             # start the ray worker nodes, and connect them to the head node
-            docker exec -d "node$node" /bin/bash -c "ray start --address=192.168.10.10:6379 --block"
+            docker exec -d "$CONTAINER_ID" /bin/bash -c "ray start --address=192.168.10.10:6379 --block"
         fi
     done
 
@@ -100,7 +102,7 @@ start_nodes() {
     sleep 10
 
     # print the cluster status
-    docker exec node0 /bin/bash -c "ray status"
+    docker exec "${STARTED_CONTAINERS[0]}" /bin/bash -c "ray status"
 }
 
 run_nodes() {
@@ -118,23 +120,26 @@ run_nodes() {
         done
         echo "Running node$node with GPU devices: $DEVICE_LIST"
         if [ "$node" -ne 0 ]; then
-            docker exec -d "node$node" /bin/bash -c "cd $WORKING_DIR ; ${COMMANDS[$node]}"
+            docker exec -d "${STARTED_CONTAINERS[$node]}" /bin/bash -c "cd $WORKING_DIR ; ${COMMANDS[$node]}"
         else
             # Allocate a TTY (-t -i) for the foreground head node so its output
             # keeps ANSI color in the Buildkite log (see run-amd-test.sh).
-            docker exec -t -i "node$node" /bin/bash -c "cd $WORKING_DIR ; ${COMMANDS[$node]}"
+            docker exec -t -i "${STARTED_CONTAINERS[$node]}" /bin/bash -c "cd $WORKING_DIR ; ${COMMANDS[$node]}"
         fi
     done
 }
 cleanup() {
     local status=$?
     local cleanup_status=0
-    for container_id in "${STARTED_CONTAINERS[@]}"; do
-        docker stop "$container_id" || cleanup_status=$?
-    done
-    if [ "$NETWORK_CREATED" -eq 1 ]; then
-        docker network rm docker-net || cleanup_status=$?
+    if [ "${#STARTED_CONTAINERS[@]}" -gt 0 ]; then
+        for container_id in "${STARTED_CONTAINERS[@]}"; do
+            docker stop "$container_id" || cleanup_status=$?
+        done
     fi
+    if [ "$NETWORK_CREATED" -eq 1 ]; then
+        docker network rm "$NETWORK_NAME" || cleanup_status=$?
+    fi
+    rmdir "$RUN_DIR" || cleanup_status=$?
     if [ "$status" -ne 0 ]; then
         return "$status"
     fi


### PR DESCRIPTION
The L4 Distributed 2-Node lane fails before any test starts because `docker-net` already exists. Its EXIT trap then stops at `docker stop node0` when the container does not exist, so the network is never removed. Main build [87376](https://buildkite.com/vllm/ci/builds/87376#01a07028-5744-42f8-9c74-5978833f02e4) demonstrates both failures; the open alert has eight failure observations.

Recover an existing empty legacy `docker-net`, reject an occupied legacy network, and give new networks and containers invocation-specific names. Execute commands and clean up using the container IDs actually created by this invocation. This prevents another invocation from deleting a newly created empty network during startup. Cleanup attempts every owned container and the owned network even after an earlier stop fails. Preserve the original command error; report cleanup failure when the command itself succeeded.

Remove the AMD wrapper's redundant global cleanup, which previously could stop `node0`/`node1` after the helper refused an occupied network. The helper owns its cleanup on success and failure.

Duplicate checks: searches for `run-multi-node-test`, `docker network`, and the exact lane found no equivalent open fix; #47484 adds a separate ROCm multinode protocol.

Validation:
- `bash -n` on both modified scripts: passed.
- `pre-commit run --files .buildkite/scripts/run-multi-node-test.sh .buildkite/scripts/hardware_ci/run-amd-test.sh`: all applicable hooks, including ShellCheck, passed.
- Seven subprocess scenarios using a recording Docker executable: empty stale network recovery; refusing an occupied network without stopping/removing resources; partial second-container startup failure; continuing cleanup after a stop error; preserving the test exit status despite a cleanup error; subnet conflict without touching existing resources; reporting network removal failure. All passed. The harness also checks invocation names differ and all exec calls use owned container IDs.
- `git diff --check`: passed.
- Real Docker/Ray smoke test on two idle H200 GPUs, using public CI image `784cac7c424db2f2fdc879b672abad7e231f5698`: two nodes joined, head command `ray status` and worker command `true` completed, and the EXIT trap removed both containers and the invocation-specific network. Exit 0. This checks the helper lifecycle, not the full distributed model suite.

The fixed subnet is retained because test commands use its head IP. Concurrent invocations on one daemon may fail network creation due to subnet overlap; they do not delete each other's resources. SIGKILL cannot run an EXIT trap, so a forcibly killed invocation may still require cleanup of its identifiable resources. Full two-node GPU execution remains required. AI assistance was used to investigate, implement, and validate this change; no human review or successful GPU validation is claimed as completed.

CI before this follow-up: [(L4) Distributed 2-Node in build 87385](https://buildkite.com/vllm/ci/builds/87385#01a0712c-28c4-495b-a673-14d595f0f09c) recovered the stale network, then failed during container startup with an NVIDIA driver RPC timeout (exit 125). Cleanup removed the network. [Build 87455](https://buildkite.com/vllm/ci/builds/87455) tests follow-up commit `7171d8104e`; its [L4 Distributed 2-Node lane](https://buildkite.com/vllm/ci/builds/87455#01a0780f-6924-453d-b475-d6db05445edd) is explicitly enabled.
