### PR TITLE
[Bugfix] Defer adaptive verification until after kernel warmup

### DIFF
--- a/tests/v1/worker/test_gpu_warmup_blocks.py
+++ b/tests/v1/worker/test_gpu_warmup_blocks.py
@@ -88,6 +88,7 @@ def _make_runner(
     """Stub model runner exposing only what the warmup entry points read."""
     return SimpleNamespace(
         num_speculative_steps=num_spec_steps,
+        adaptive_verification=None,
         decode_query_len=num_spec_steps + 1,
         is_pooling_model=False,
         is_encoder_decoder=False,

--- a/tests/v1/worker/test_mixed_warmup_gate.py
+++ b/tests/v1/worker/test_mixed_warmup_gate.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from vllm.v1.worker.gpu import warmup
 from vllm.v1.worker.gpu.warmup import run_mixed_prefill_decode_warmup
 
 
@@ -28,3 +29,24 @@ def test_mixed_warmup_skipped_for_single_seq(max_num_reqs):
         )
         is False
     )
+
+
+@pytest.mark.parametrize("fail_warmup", [False, True])
+def test_kernel_warmup_restores_uncalibrated_adaptive_manager(monkeypatch, fail_warmup):
+    """Startup must warm fixed drafts before calibration and retain its manager."""
+    manager = SimpleNamespace(cost_tables=None)
+    runner = SimpleNamespace(adaptive_verification=manager)
+
+    def run_steps(model_runner, execute, sample):
+        assert model_runner.adaptive_verification is None
+        if fail_warmup:
+            raise RuntimeError("warmup failed")
+
+    monkeypatch.setattr(warmup, "_warmup_kernels", run_steps)
+    if fail_warmup:
+        with pytest.raises(RuntimeError, match="warmup failed"):
+            warmup.warmup_kernels(runner, _fail, _fail)
+    else:
+        warmup.warmup_kernels(runner, _fail, _fail)
+    assert runner.adaptive_verification is manager
+    assert manager.cost_tables is None

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -220,6 +220,21 @@ def warmup_kernels(
     We must call the provided worker's execute_model for pipeline parallel
     coordination.
     """
+    # Adaptive costs are calibrated during capture, after this warmup. Exercise
+    # fixed draft counts here, then restore the manager for capture and serving.
+    adaptive_verification = model_runner.adaptive_verification
+    model_runner.adaptive_verification = None
+    try:
+        _warmup_kernels(model_runner, worker_execute_model, worker_sample_tokens)
+    finally:
+        model_runner.adaptive_verification = adaptive_verification
+
+
+def _warmup_kernels(
+    model_runner: GPUModelRunner,
+    worker_execute_model: Callable[[SchedulerOutput], Any],
+    worker_sample_tokens: Callable[[GrammarOutput | None], Any],
+) -> None:
     if model_runner.vllm_config.is_mm_encoder_only:
         return
 


### PR DESCRIPTION
The B200 LM Eval Spec Decode lane fails during DeepSeek-V4-Flash DSpark startup. The full log from [main build 87376](https://buildkite.com/vllm/ci/builds/87376#01a07028-57a6-4e1f-9e5e-8d39298b7cb4) reaches `AdaptiveVerificationManager.get_num_tokens` from `warmup_kernels` and asserts because `cost_tables` is still `None`.

`GPUWorker.compile_or_warm_up_model` deliberately runs kernel warmup before `capture_model`. Adaptive cost calibration happens inside `capture_model`, so the warmup's synthetic speculative decode steps cannot use calibrated budgets yet. Temporarily suspend the runner's adaptive manager during kernel warmup, exercising fixed draft counts, and restore it in `finally` for graph capture and serving. Keep adaptive verification enabled for actual requests.

Duplicate checks: no open PR matches `cost_tables warmup`. #54065 changes calibration batch shapes, and #52233 caches calibrated profiles; neither fixes this pre-calibration warmup call.

Validation on Linux with PyTorch 2.13.0+cpu:
```
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/worker/test_mixed_warmup_gate.py \
  tests/v1/spec_decode/test_adaptive_verification.py \
  tests/v1/worker/test_gpu_warmup_blocks.py -q
```
**11 passed, 26 skipped** (GPU-only cases). New tests cover restoring the same uncalibrated manager on both successful warmup and exceptions. All applicable pre-commit hooks and `git diff --check` pass.

B200 model evaluation remains required: run the exact LM Eval Spec Decode lane and verify DeepSeek-V4-Flash-DSpark-confidence-TEP4 startup and GSM8K accuracy. No GPU or model-evaluation success is claimed yet.

AI assistance was used for investigation, implementation, and tests. Draft for human review and hardware validation; human review is not represented as completed.

CI follow-up: [Buildkite 87386](https://buildkite.com/vllm/ci/builds/87386) was triggered for this PR head. The exact regression job(s) are enabled: [(B200) LM Eval Spec Decode](https://buildkite.com/vllm/ci/builds/87386#01a0712c-28bc-4bd6-9adb-1fbff932b9aa). At 2026-09-05T10:52:05+00:00, they were waiting for image/dependency jobs; no successful end-to-end result is claimed.
