### PR TITLE
[Bugfix] Pad manual NVFP4 fusion scale buffers to full swizzled tiles

### DIFF
--- a/tests/compile/passes/test_silu_mul_quant_manual_fusion.py
+++ b/tests/compile/passes/test_silu_mul_quant_manual_fusion.py
@@ -29,6 +29,7 @@ from vllm.model_executor.kernels.linear import (
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fusion.fused_act_quant import (
     _FUSED_ACT_QUANT,
+    _silu_and_mul_nvfp4_dynamic,
     maybe_fused_act_quant,
 )
 from vllm.model_executor.layers.fusion.quant_activation import (
@@ -63,6 +64,36 @@ CUDA_KERNELS = [
     PerTensorTorchFP8ScaledMMLinearKernel,
 ]
 TEST_KERNELS = ROCM_KERNELS if current_platform.is_rocm() else CUDA_KERNELS
+
+
+@pytest.mark.parametrize("num_tokens", [1, 5, 32, 127, 128, 129])
+@pytest.mark.parametrize("hidden_size", [256, 11008])
+def test_nvfp4_scale_allocation_covers_swizzled_writes(
+    monkeypatch, num_tokens, hidden_size
+):
+    """Every scale written by the CUDA kernel must fit, including partial tiles."""
+
+    def check_writes(output, scales, x, global_scale):
+        # cvt_quant_to_fp4_get_sf_out_offset uses [M/128, K/64, 32, 4, 4].
+        rows = torch.arange(num_tokens, device="cpu")[:, None]
+        cols = torch.arange(hidden_size // 16, device="cpu")[None, :]
+        offsets = (
+            ((rows // 128) * (hidden_size // 64) + cols // 4) * 512
+            + (rows % 32) * 16
+            + ((rows // 32) % 4) * 4
+            + cols % 4
+        )
+        assert int(offsets.max()) < scales.numel() * scales.element_size()
+
+    monkeypatch.setattr(
+        torch.ops._C, "silu_and_mul_nvfp4_quant", check_writes, raising=False
+    )
+    x = torch.empty((num_tokens, hidden_size * 2), dtype=torch.bfloat16, device="cpu")
+    linear = MockLinearForFusion(
+        kNvfp4Dynamic, input_global_scale=torch.ones(1, device="cpu")
+    )
+    result = _silu_and_mul_nvfp4_dynamic(x, linear)
+    assert result.data.shape == (num_tokens, hidden_size // 2)
 
 
 @pytest.mark.parametrize("num_tokens", [32, 64])
@@ -205,6 +236,7 @@ def test_manual_fusion_fp8_dynamic_128(dtype: torch.dtype):
         )
 
 
+@pytest.mark.parametrize("num_tokens", [1, 5, 32, 127, 128, 129])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="NVFP4 CUDA only")
 @pytest.mark.skipif(
@@ -213,7 +245,7 @@ def test_manual_fusion_fp8_dynamic_128(dtype: torch.dtype):
 @pytest.mark.skipif(
     envs.VLLM_TARGET_DEVICE not in ["cuda", "rocm"], reason="Only test on CUDA and ROCm"
 )
-def test_manual_fusion_nvfp4_dynamic(dtype: torch.dtype):
+def test_manual_fusion_nvfp4_dynamic(dtype: torch.dtype, num_tokens: int):
     """Test kNvfp4Dynamic fusion path.
 
     Compares fused (silu_and_mul_nvfp4_quant) vs unfused (silu_and_mul)
@@ -228,8 +260,7 @@ def test_manual_fusion_nvfp4_dynamic(dtype: torch.dtype):
     torch.set_default_dtype(dtype)
 
     # NVFP4 requires hidden_size divisible by 16 (block size) and by 2 (packing).
-    # M (num_tokens) must be >= 128 for the 128x4 swizzled scale layout.
-    num_tokens, hidden_size = 128, 256
+    hidden_size = 256
     x = torch.rand(num_tokens, hidden_size * 2)
     input_global_scale = torch.tensor([1.0], dtype=torch.float32, device="cuda")
 

--- a/vllm/model_executor/layers/fusion/fused_act_quant.py
+++ b/vllm/model_executor/layers/fusion/fused_act_quant.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 
 import torch
 
+from vllm._custom_ops import create_fp4_output_tensors
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.linear import LinearBase
@@ -30,7 +31,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 
 FP8_DTYPE = current_platform.fp8_dtype()
-FP4_DTYPE = torch.uint8
 
 
 def _silu_and_mul_fp8_static(
@@ -102,15 +102,11 @@ def _silu_and_mul_nvfp4_dynamic(
     out_shape = x.shape[:-1] + (d,)
     num_tokens = x.shape[0]
 
-    # NVFP4 packs 2 values into 1 byte
-    result = torch.empty((num_tokens, d // 2), dtype=FP4_DTYPE, device=x.device)
-
-    # Block scale output shape: swizzled layout for tensor cores
-    # Each group of 16 elements shares one FP8 scale
-    num_k_tiles = (d + 63) // 64
-    block_scale = torch.empty(
-        (num_tokens, num_k_tiles * 4), dtype=FP8_DTYPE, device=x.device
+    # The kernel writes 128-row swizzled scale tiles even for smaller batches.
+    result, block_scale = create_fp4_output_tensors(
+        num_tokens, d, x.device, is_sf_swizzled_layout=True
     )
+    block_scale = block_scale.view(FP8_DTYPE)
 
     input_global_scale = getattr(linear, "input_global_scale", None)
     assert input_global_scale is not None, (


### PR DESCRIPTION
The manual SiLU+NVFP4 fusion introduced in #51415 allocates scale storage as `[num_tokens, ceil(K/64)*4]`. Its CUDA kernel uses the 128x4 swizzled layout and writes scale offsets in full 128-row tiles. Small batches and partial final tiles therefore write beyond the allocation.

Main [B200 Kernels Shard 2, build 87376](https://buildkite.com/vllm/ci/builds/87376#01a07028-579a-47b9-b7a7-ee4eb240d2cb) records `CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS` in `vllm::silu_mul_cvt_fp16_to_fp4<__nv_bfloat16, false>` for both FlashInfer-CUTLASS NVFP4 test variants. This is the faulting kernel from the CUDA dump, not an attribution based on the later Python synchronization stack. The open alert has 17 failures, beginning after #51415 merged.

Use the existing `create_fp4_output_tensors` allocator, which pads scale rows to a multiple of 128 and columns to a multiple of four. Extend the existing manual-fusion tests to cover 1, 5, 32, 127, 128, and 129 tokens. Add a CPU regression that checks every kernel scale-write offset fits the allocation for both a small hidden dimension and Llama's 11008-wide intermediate dimension.

This may also explain the B200 NVFP4 Sequence Parallel and AsyncTP output mismatches, which use the same affected producer; those lanes still need hardware reruns before attributing their failures conclusively.

Duplicate checks: open PR searches for `fused_act_quant` and NVFP4 scale/128 found no equivalent fix. The nearby #53793 and #53875 add different activation fusion paths.

Validation:
```
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/compile/passes/test_silu_mul_quant_manual_fusion.py -k scale_allocation -q
```
- Unmodified main with the new regression tests: **10 failed, 2 passed**. Only the existing exactly-128-token cases are safe.
- Patched producer: **12 passed**.
- All applicable pre-commit hooks and `git diff --check`: passed.

B200 GPU tests/model evaluation remain required: the extended `test_manual_fusion_nvfp4_dynamic` matrix, `tests/models/quantization/test_nvfp4.py -k flashinfer_cutlass`, and the NVFP4 Sequence Parallel/AsyncTP correctness lanes. B200 access was unavailable; no GPU or model-evaluation pass is claimed.

AI assistance was used in the investigation, implementation, and validation. Draft for human review and hardware validation; human review is not represented as completed.

CI follow-up: [Buildkite 87387](https://buildkite.com/vllm/ci/builds/87387) was triggered for this PR head. The exact regression job(s) are enabled: [(B200) Kernels Shard 2](https://buildkite.com/vllm/ci/builds/87387#01a0712c-2fdd-45e2-94c2-152926e4423f), [(B200) AsyncTP Correctness](https://buildkite.com/vllm/ci/builds/87387#01a0712c-2f1f-4204-9ecd-dca8add3a74e), [(B200) Sequence Parallel Correctness](https://buildkite.com/vllm/ci/builds/87387#01a0712c-2f21-410a-b942-eee3382fb5da), [(B200) Fusion and Compile](https://buildkite.com/vllm/ci/builds/87387#01a0712c-2f20-4e50-86b5-f95418654c6d). At 2026-09-05T10:52:05+00:00, they were waiting for image/dependency jobs; no successful end-to-end result is claimed.


Follow-up diagnosis (September 6): the remaining eager/compiled NVFP4 CUTLASS output failures in [Kernels Shard 2, build 87387](https://buildkite.com/vllm/ci/builds/87387#01a0712c-2fdd-45e2-94c2-152926e4423f) involve a separate scale-contract mismatch. `_silu_and_mul_nvfp4_dynamic` passes `input_global_scale`, while the unfused CUTLASS path consumes `input_global_scale_inv`. Existing [#55505](https://github.com/vllm-project/vllm/pull/55505) addresses that mismatch and adds non-unit-scale coverage. This PR fixes the scale-buffer allocation; the two fixes still require combined Blackwell validation. No duplicate scale-contract change is added here.
