### PR TITLE
[CI] Align extraction test with canonical auxiliary layer order

### DIFF
--- a/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
@@ -75,6 +75,7 @@ PREDICTABLE_LLAMA_MODEL_CLS = (
 )
 
 
+@create_new_process_for_each_test()
 def test_extract_hidden_states_with_predictable_dummy_model(
     predictable_llama_config_path, tmp_path, monkeypatch
 ):
@@ -82,7 +83,7 @@ def test_extract_hidden_states_with_predictable_dummy_model(
 
     Tests 3 scenarios:
 
-    1. **Basic extraction**: non-sequential layer ordering, multiple prompts
+    1. **Basic extraction**: unsorted layer selection, multiple prompts
        of varying length — verifies correct layer association and
        deterministic values.
     2. **Chunked prefill**: max_num_batched_tokens=128 with ~500-token
@@ -95,6 +96,7 @@ def test_extract_hidden_states_with_predictable_dummy_model(
     monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "fork")
 
     layer_ids = [5, 2, 10]
+    expected_layer_ids = sorted(layer_ids)
     num_layers = len(layer_ids)
     max_num_batched_tokens = 128
 
@@ -146,7 +148,7 @@ def test_extract_hidden_states_with_predictable_dummy_model(
         )
         _token_ids, hidden_states = get_and_check_output(output, expected_shape)
 
-        for idx, layer_id in enumerate(layer_ids):
+        for idx, layer_id in enumerate(expected_layer_ids):
             layer_hidden = hidden_states[:, idx, :]
             assert torch.allclose(
                 layer_hidden,
@@ -174,7 +176,7 @@ def test_extract_hidden_states_with_predictable_dummy_model(
         expected_shape = (prompt_len, num_layers, hidden_size)
         _token_ids, hidden_states = get_and_check_output(output, expected_shape)
 
-        for idx, layer_id in enumerate(layer_ids):
+        for idx, layer_id in enumerate(expected_layer_ids):
             layer_hidden = hidden_states[:, idx, :]
             assert torch.allclose(
                 layer_hidden,
@@ -236,7 +238,7 @@ def test_extract_hidden_states_with_predictable_dummy_model(
     assert hidden_states.shape == (total_tokens, num_layers, hidden_size)
 
     # Verify predictable layer values hold for all tokens (prompt + output)
-    for idx, layer_id in enumerate(layer_ids):
+    for idx, layer_id in enumerate(expected_layer_ids):
         layer_hidden = hidden_states[:, idx, :]
         assert torch.allclose(
             layer_hidden,


### PR DESCRIPTION
The H200 MIG hidden-state extraction lane fails its predictable-model layer assertion and then cannot start the following Qwen3.5 test because the first test's engine retains GPU memory ([main build 87376](https://buildkite.com/vllm/ci/builds/87376#01a07028-57b1-4f3b-a2a8-52373b5456dc)).

#50514 intentionally canonicalizes auxiliary layer IDs by sorting and deduplicating them. The integration test supplies `[5, 2, 10]` but still expects the output in that input order, while the model now returns `[2, 5, 10]`. Keep the unsorted input and check all three extraction scenarios against canonical order, consistent with the existing auxiliary-layer unit test. Run the predictable-model test in its own process using the existing helper so engine memory is released before the next test.

Duplicate checks: open-PR searches for `extraction auxiliary hidden sorted` and `extract_hidden_states` found no equivalent ordering/process-isolation fix; existing extraction PRs address separate cache layout, model coverage, and documentation changes.

Validation:
- All applicable pre-commit hooks passed on commit; `git diff --check` passed.
- `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest -q tests/v1/worker/test_eagle3_aux_hidden_states_pp.py`: 2 passed, confirming the established sorted/deduplicated contract.
- H200 GPU 2 on `h200-ci-1`, existing main image `784cac7c424db2f2fdc879b672abad7e231f5698`, with this test and current-main `vllm/model_executor/models/interfaces.py` mounted: `/tmp/.venv/bin/python -m pytest -v tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py -k 'predictable or qwen35'`: **2 passed, 1 deselected in 132.69s**. The venv was created with `uv venv --system-site-packages /tmp/.venv`.
- This is a test-only change; no model behavior changed. The exact 18 GiB MIG lane still needs CI validation: the local check used a full H200 and an existing image with the current interface overlaid, rather than a complete rebuild of current main.

AI assistance was used for investigation, implementation, and validation. Draft for human review and exact-lane CI; human line-by-line review has not been represented as completed.

CI follow-up: [Buildkite 87388](https://buildkite.com/vllm/ci/builds/87388) was triggered for this PR head. The exact regression job(s) are enabled: [(H200 MIG 18GB) Extract Hidden States Integration](https://buildkite.com/vllm/ci/builds/87388#01a0712c-2e4e-4d22-bc7b-3188d930173b). At 2026-09-05T10:52:05+00:00, they were waiting for image/dependency jobs; no successful end-to-end result is claimed.
