### PR TITLE
[Bugfix][DSv4] Add missing Hadamard rotation to sparse indexer quant kernels

### DIFF
--- a/tests/kernels/test_compressor_kv_cache.py
+++ b/tests/kernels/test_compressor_kv_cache.py
@@ -39,7 +39,7 @@ from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
     indexer_k_quant_and_cache_triton,
 )
 
-from .test_fused_indexer_q_rope_quant import quantize_to_mxfp4
+from .test_fused_indexer_q_rope_quant import _hadamard_rotate, quantize_to_mxfp4
 
 
 def _on_gfx950() -> bool:
@@ -741,11 +741,14 @@ def _reference_kv_compress_norm_rope(
     rms_eps: float = 1e-6,
     fp8_max: float = 448.0,
     return_full_cache: bool = False,
+    rotate: bool = False,
 ):
     """Compress → RMSNorm → GPT-J RoPE → quantize.
 
     Gathers (1+overlap)*compress_ratio state entries per output token, applies
     per-element softmax over the scores, and computes the weighted kv sum.
+    With ``rotate=True``, the RoPE output is Hadamard-rotated (scaled by
+    head_dim**-0.5) before quantization, mirroring the indexer kernels.
     Returns (quantized_values, scale) matching the kernel's output layout.
     """
     device = state_cache.device
@@ -785,14 +788,23 @@ def _reference_kv_compress_norm_rope(
         var = (compressed * compressed).mean()
         normed = compressed * torch.rsqrt(var + rms_eps) * rms_weight.float()
         compressed_pos = (pos // compress_ratio) * compress_ratio
-        cos, sin = cos_sin_cache[compressed_pos].float().chunk(2)
+        cos, sin = cos_sin_cache[compressed_pos].double().chunk(2)
         nope, rope = normed.split([nope_dim, rope_dim])
+        # Emulate the kernels' pinned FMA contraction in fp64 (fp32 products
+        # are exact in fp64; rounding once reproduces tl.fma bit-exactly).
+        ev, od = rope[0::2].double(), rope[1::2].double()
         rope = torch.stack(
-            [rope[0::2] * cos - rope[1::2] * sin, rope[1::2] * cos + rope[0::2] * sin],
+            [
+                (ev * cos - (od * sin).float().double()).float(),
+                (od * cos + (ev * sin).float().double()).float(),
+            ],
             dim=-1,
         ).reshape(rope_dim)
         results.append(torch.cat([nope, rope]).to(state_cache.dtype))
     result = torch.stack(results)
+
+    if rotate:
+        result = _hadamard_rotate(result)
 
     if return_full_cache:
         # Contiguous 512-wide bf16 row (nope unrotated + rope rotated), matching
@@ -912,6 +924,7 @@ def test_fused_kv_insert_indexer(num_tokens: int, kv_block_size: int, use_fp4: b
         TOKEN_STRIDE=TOKEN_STRIDE,
         SCALE_DIM=SCALE_DIM,
         KV_BLOCK_STRIDE=kv_cache.stride(0),
+        HADAMARD=True,
         num_warps=1,
     )
 
@@ -926,6 +939,7 @@ def test_fused_kv_insert_indexer(num_tokens: int, kv_block_size: int, use_fp4: b
         use_fp4,
         rms_eps=RMS_EPS,
         fp8_max=FP8_MAX,
+        rotate=True,
     )
 
     if use_fp4:
@@ -960,6 +974,139 @@ def test_fused_kv_insert_indexer(num_tokens: int, kv_block_size: int, use_fp4: b
             )
             assert torch.equal(actual_scale, scale[i : i + 1]), (
                 f"token {i}: scale {actual_scale.item()} != {scale[i].item()}"
+            )
+
+
+@pytest.mark.parametrize(
+    "use_fp4",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not (
+                    current_platform.is_cuda()
+                    and current_platform.is_device_capability_family(100)
+                ),
+                reason="MXFP4 indexer cache requires an SM100-family GPU",
+            ),
+        ),
+    ],
+)
+@torch.inference_mode()
+def test_fused_kv_insert_indexer_dimension_guard(use_fp4: bool):
+    """Off-production indexer dims (head_dim=64, rope_dim=32) bypass the
+    Hadamard rotation: the shared launcher takes the original unrotated
+    path (no 128/64 static_assert) and the output is bit-exact against a
+    rotate=False reference."""
+    head_dim, rope_dim = 64, 32
+    block_size = 16  # state cache block size
+    rms_eps = 1e-6
+    num_tokens = 7
+    kv_block_size = 16
+    compress_ratio = 4
+    overlap = 1  # matching DeepseekCompressor logic at compress_ratio == 4
+
+    if use_fp4:
+        token_stride = head_dim // 2
+        scale_dim = head_dim // 32
+        quant_block = 32
+    else:
+        token_stride = head_dim
+        scale_dim = 4  # 1 float32: 4 bytes
+        quant_block = head_dim
+
+    device = "cuda"
+    torch.manual_seed(42)
+    coff = 1 + overlap
+    num_pages = (compress_ratio * num_tokens - 1) // block_size + 2
+    state_cache = torch.randn(
+        num_pages,
+        block_size,
+        2 * coff * head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    block_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+    token_to_req = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    slot_mapping = torch.arange(num_tokens, dtype=torch.int64, device=device)
+    positions = torch.arange(
+        compress_ratio - 1,
+        compress_ratio * num_tokens,
+        compress_ratio,
+        dtype=torch.int64,
+        device=device,
+    )
+    rms_weight = torch.randn(head_dim, dtype=torch.bfloat16, device=device)
+    cos_sin_cache = torch.randn(
+        compress_ratio * num_tokens, rope_dim, dtype=torch.bfloat16, device=device
+    )
+
+    kv_n_blocks = (num_tokens + kv_block_size - 1) // kv_block_size + 1
+    kv_cache = torch.zeros(
+        kv_n_blocks,
+        kv_block_size,
+        token_stride + scale_dim,
+        dtype=torch.uint8,
+        device=device,
+    )
+
+    compress_norm_rope_store_triton(
+        state_cache=state_cache,
+        num_actual=num_tokens,
+        token_to_req_indices=token_to_req,
+        positions=positions,
+        slot_mapping=slot_mapping,
+        block_table=block_table,
+        block_size=block_size,
+        state_width=coff * head_dim,
+        cos_sin_cache=cos_sin_cache,
+        kv_cache=kv_cache,
+        k_cache_metadata=SimpleNamespace(slot_mapping=slot_mapping),
+        pdl_kwargs={},
+        head_dim=head_dim,
+        rope_head_dim=rope_dim,
+        compress_ratio=compress_ratio,
+        overlap=overlap,
+        use_fp4_cache=use_fp4,
+        rms_norm_weight=rms_weight,
+        rms_norm_eps=rms_eps,
+        quant_block=quant_block,
+        token_stride=token_stride,
+        scale_dim=scale_dim,
+    )
+
+    k_ref, s_ref = _reference_kv_compress_norm_rope(
+        state_cache,
+        block_table,
+        positions,
+        rms_weight,
+        cos_sin_cache,
+        compress_ratio,
+        overlap,
+        use_fp4,
+        rms_eps=rms_eps,
+        fp8_max=448.0,  # K-side kernels pin tl.float8e4nv/448 on all platforms
+        rotate=False,
+    )
+
+    kv_flat = kv_cache.view(kv_n_blocks, -1)
+    if not use_fp4:
+        k_ref = k_ref.view(torch.uint8)
+    for i in range(num_tokens):
+        blk, pos = i // kv_block_size, i % kv_block_size
+        val_off = pos * token_stride
+        val_actual = kv_flat[blk, val_off : val_off + token_stride]
+        assert torch.equal(k_ref[i], val_actual), f"token {i}: values differ"
+        scale_off = kv_block_size * token_stride + pos * scale_dim
+        scale_actual = kv_flat[blk, scale_off : scale_off + scale_dim]
+        if use_fp4:
+            assert torch.equal(scale_actual, s_ref[i]), (
+                f"token {i}: ue8m0 {scale_actual.tolist()} != {s_ref[i].tolist()}"
+            )
+        else:
+            assert torch.equal(scale_actual.view(torch.float32), s_ref[i : i + 1]), (
+                f"token {i}: scale differs"
             )
 
 

--- a/tests/kernels/test_fused_indexer_hadamard.py
+++ b/tests/kernels/test_fused_indexer_hadamard.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the Hadamard rotation in the DeepSeek-V4 sparse indexer
+quant kernels.
+
+The indexer Q and K Triton kernels rotate the full 128-dim vector by a
+Sylvester Hadamard matrix (scaled by head_dim**-0.5, computed as a
+fixed-order fp32 butterfly) after RoPE and before quantization, matching the
+reference implementation's rotate_activation. These tests assert bit-exact
+equality against unfused rope → hadamard → quant references (using an fp8
+quant oracle independent of per_token_group_quant_fp8) and check that the
+orthogonal rotation preserves indexer QK dot products.
+"""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+    compress_norm_rope_store_triton,
+)
+from vllm.models.deepseek_v4.common.ops.fused_indexer_q import (
+    fused_indexer_q_rope_quant,
+)
+from vllm.platforms import current_platform
+
+from .test_compressor_kv_cache import _reference_kv_compress_norm_rope
+from .test_fused_indexer_q_rope_quant import (
+    _hadamard_rotate,
+    _rope_gptj_tail,
+    quantize_to_mxfp4,
+)
+
+HEAD_DIM = 128
+ROPE_DIM = 64
+N_HEAD = 8
+MAX_POS = 4096
+# The K-side indexer kernels pin tl.float8e4nv/448 on every platform, while
+# the Q kernel follows current_platform.fp8_dtype() (fnuz/224 on gfx942) and
+# is resolved at runtime in the test.
+FP8_MAX = 448.0
+
+requires_sm100 = pytest.mark.skipif(
+    not (
+        current_platform.is_cuda() and current_platform.is_device_capability_family(100)
+    ),
+    reason="MXFP4 indexer cache requires an SM100-family GPU",
+)
+
+
+def _sylvester_hadamard(n: int, device: torch.device) -> torch.Tensor:
+    h = torch.ones((1, 1), dtype=torch.float32)
+    while h.shape[0] < n:
+        h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+    return h.to(device)
+
+
+def _ue8m0_fp8_quant(x: torch.Tensor, fp8_dtype: torch.dtype, fp8_max: float):
+    """Per-row ue8m0 fp8 quant over the last dim, mirroring the Triton
+    kernels' math (fp32 absmax, power-of-two scale)."""
+    rows = x.float().reshape(-1, x.shape[-1])
+    out = torch.empty_like(rows, dtype=fp8_dtype)
+    scales = torch.empty(rows.shape[0], dtype=torch.float32, device=x.device)
+    for i, row in enumerate(rows):
+        amax = max(row.abs().max().item(), 1e-4)
+        scale = 2.0 ** math.ceil(math.log2(amax / fp8_max))
+        out[i] = (row / scale).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+        scales[i] = scale
+    return out.view(x.shape), scales.view(x.shape[:-1])
+
+
+def _reference_q(
+    positions: torch.Tensor,
+    q: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    weights: torch.Tensor,
+    softmax_scale: float,
+    head_scale: float,
+    use_fp4: bool,
+    fp8_dtype: torch.dtype,
+    fp8_max: float,
+):
+    """Unfused oracle: GPT-J RoPE + bf16 roundtrip → Hadamard rotation →
+    quant, mirroring the fused Q kernels' math."""
+    x = _rope_gptj_tail(q, positions, cos_sin_cache)
+    x = _hadamard_rotate(x)
+    if use_fp4:
+        q_packed, ue8m0 = quantize_to_mxfp4(x)
+        q_scale = ue8m0.view(torch.int32).squeeze(-1)
+        weights_out = weights.float() * softmax_scale * head_scale
+        return (q_packed, q_scale), weights_out
+    q_fp8, q_scale = _ue8m0_fp8_quant(x, fp8_dtype, fp8_max)
+    weights_out = weights.float() * q_scale * softmax_scale * head_scale
+    return q_fp8, weights_out
+
+
+def _assert_q_bitwise(expected, actual, use_fp4: bool):
+    if use_fp4:
+        (packed_exp, scale_exp), (packed_act, scale_act) = expected, actual
+        assert torch.equal(scale_exp, scale_act), (
+            f"ue8m0 scales differ: {(scale_exp != scale_act).sum().item()} bytes"
+        )
+        assert torch.equal(packed_exp, packed_act), (
+            f"packed e2m1 bytes differ: {(packed_exp != packed_act).sum().item()}"
+        )
+    else:
+        assert torch.equal(expected.view(torch.uint8), actual.view(torch.uint8)), (
+            "fp8 bytes differ: "
+            f"{(expected.view(torch.uint8) != actual.view(torch.uint8)).sum().item()}"
+        )
+
+
+def _rope_gptj_tail_dims(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    rope_dim: int,
+) -> torch.Tensor:
+    """_rope_gptj_tail generalized to arbitrary head/rope dims (unrotated)."""
+    nope_dim = x.shape[-1] - rope_dim
+    cos = cos_sin_cache[positions, : rope_dim // 2].double().unsqueeze(1)
+    sin = cos_sin_cache[positions, rope_dim // 2 :].double().unsqueeze(1)
+    out = x.double()
+    ev, od = out[..., nope_dim::2], out[..., nope_dim + 1 :: 2]
+    r_ev = (ev * cos - (od * sin).float().double()).float()
+    r_od = (od * cos + (ev * sin).float().double()).float()
+    out = out.clone()
+    out[..., nope_dim::2] = r_ev
+    out[..., nope_dim + 1 :: 2] = r_od
+    return out.to(torch.bfloat16).float()
+
+
+@pytest.mark.parametrize("num_tokens", [1, 37])
+@pytest.mark.parametrize("cache_dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("use_fp4", [False, pytest.param(True, marks=requires_sm100)])
+@torch.inference_mode()
+def test_indexer_q_hadamard(num_tokens, cache_dtype, use_fp4):
+    """Bit-exact check of the fused indexer Q RoPE+Hadamard+quant Triton
+    kernel against an unfused reference with an independent fp8 oracle."""
+    device = "cuda"
+    torch.manual_seed(0)
+    q = torch.randn(num_tokens, N_HEAD, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    positions = torch.randint(
+        0, MAX_POS, (num_tokens,), dtype=torch.int64, device=device
+    )
+    cos_sin_cache = torch.randn(MAX_POS, ROPE_DIM, dtype=cache_dtype, device=device)
+    weights = torch.randn(num_tokens, N_HEAD, dtype=torch.bfloat16, device=device)
+    softmax_scale = HEAD_DIM**-0.5
+    head_scale = N_HEAD**-0.5
+    # Match the launcher, which resolves the fp8 flavor at runtime.
+    fp8_dtype = current_platform.fp8_dtype()
+    fp8_max = 224.0 if fp8_dtype == torch.float8_e4m3fnuz else 448.0
+
+    out, w_out = fused_indexer_q_rope_quant(
+        positions,
+        q.clone(),
+        cos_sin_cache,
+        weights,
+        softmax_scale,
+        head_scale,
+        use_fp4,
+    )
+    ref, w_ref = _reference_q(
+        positions,
+        q,
+        cos_sin_cache,
+        weights,
+        softmax_scale,
+        head_scale,
+        use_fp4,
+        fp8_dtype,
+        fp8_max,
+    )
+    _assert_q_bitwise(ref, out, use_fp4)
+    assert torch.equal(w_ref, w_out)
+
+
+@pytest.mark.parametrize("use_fp4", [False, pytest.param(True, marks=requires_sm100)])
+@torch.inference_mode()
+def test_indexer_k_hadamard(use_fp4):
+    """Bit-exact check of the fused indexer K compress+RoPE+Hadamard+quant+
+    insert Triton kernels via the shared launcher."""
+    head_dim, rope_dim = 128, 64
+    block_size = 16  # state cache block size
+    rms_eps = 1e-6
+    num_tokens = 7
+    kv_block_size = 16
+    compress_ratio = 4
+    overlap = 1  # matching DeepseekCompressor logic at compress_ratio == 4
+
+    if use_fp4:
+        token_stride = head_dim // 2  # packed nibbles: 64 bytes
+        scale_dim = head_dim // 32  # ue8m0 bytes: 4
+        quant_block = 32
+    else:
+        token_stride = head_dim  # FP8 bytes: 128
+        scale_dim = 4  # 1 float32: 4 bytes
+        quant_block = head_dim
+
+    device = "cuda"
+    torch.manual_seed(42)
+    coff = 1 + overlap
+    num_pages = (compress_ratio * num_tokens - 1) // block_size + 2
+    state_cache = torch.randn(
+        num_pages,
+        block_size,
+        2 * coff * head_dim,  # kv_state + score_state, each coff*head_dim wide
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    block_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+    token_to_req = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    slot_mapping = torch.arange(num_tokens, dtype=torch.int64, device=device)
+    positions = torch.arange(
+        compress_ratio - 1,
+        compress_ratio * num_tokens,
+        compress_ratio,
+        dtype=torch.int64,
+        device=device,
+    )
+    rms_weight = torch.randn(head_dim, dtype=torch.bfloat16, device=device)
+    cos_sin_cache = torch.randn(compress_ratio * num_tokens, rope_dim, device=device)
+
+    kv_n_blocks = (num_tokens + kv_block_size - 1) // kv_block_size + 1
+    # 3-D (blocks, tokens/block, bytes/token): the launcher reads
+    # kv_cache.shape[1] as the paged cache block size in tokens.
+    kv_cache = torch.zeros(
+        kv_n_blocks,
+        kv_block_size,
+        token_stride + scale_dim,
+        dtype=torch.uint8,
+        device=device,
+    )
+
+    compress_norm_rope_store_triton(
+        state_cache=state_cache,
+        num_actual=num_tokens,
+        token_to_req_indices=token_to_req,
+        positions=positions,
+        slot_mapping=slot_mapping,
+        block_table=block_table,
+        block_size=block_size,
+        state_width=coff * head_dim,
+        cos_sin_cache=cos_sin_cache,
+        kv_cache=kv_cache,
+        k_cache_metadata=SimpleNamespace(slot_mapping=slot_mapping),
+        pdl_kwargs={},
+        head_dim=head_dim,
+        rope_head_dim=rope_dim,
+        compress_ratio=compress_ratio,
+        overlap=overlap,
+        use_fp4_cache=use_fp4,
+        rms_norm_weight=rms_weight,
+        rms_norm_eps=rms_eps,
+        quant_block=quant_block,
+        token_stride=token_stride,
+        scale_dim=scale_dim,
+    )
+
+    k_ref, s_ref = _reference_kv_compress_norm_rope(
+        state_cache,
+        block_table,
+        positions,
+        rms_weight,
+        cos_sin_cache,
+        compress_ratio,
+        overlap,
+        use_fp4,
+        rms_eps=rms_eps,
+        fp8_max=FP8_MAX,
+        rotate=True,
+    )
+
+    kv_flat = kv_cache.view(kv_n_blocks, -1)
+    if not use_fp4:
+        k_ref = k_ref.view(torch.uint8)
+    for i in range(num_tokens):
+        blk, pos = i // kv_block_size, i % kv_block_size
+        val_off = pos * token_stride
+        val_actual = kv_flat[blk, val_off : val_off + token_stride]
+        assert torch.equal(k_ref[i], val_actual), f"token {i}: values differ"
+        scale_off = kv_block_size * token_stride + pos * scale_dim
+        scale_actual = kv_flat[blk, scale_off : scale_off + scale_dim]
+        if use_fp4:
+            assert torch.equal(scale_actual, s_ref[i]), (
+                f"token {i}: ue8m0 {scale_actual.tolist()} != {s_ref[i].tolist()}"
+            )
+        else:
+            assert torch.equal(scale_actual.view(torch.float32), s_ref[i : i + 1]), (
+                f"token {i}: scale differs"
+            )
+
+
+@pytest.mark.parametrize(
+    # Parity is only guaranteed where main's Triton kernels work: fp8 needs a
+    # power-of-2 nope dim (tl.arange), mxfp4 needs nope/rope dims divisible
+    # by 32 and head_dim % 128 == 0 (launcher int32 scale view).
+    "head_dim, rope_dim, use_fp4",
+    [
+        (96, 32, False),  # head_dim != 128
+        pytest.param(128, 32, True, marks=requires_sm100),  # rope_dim != 64
+    ],
+)
+@torch.inference_mode()
+def test_indexer_q_hadamard_dimension_guard(
+    head_dim, rope_dim, use_fp4, monkeypatch: pytest.MonkeyPatch
+):
+    """Off-production dims (head_dim != 128 or rope_dim != 64) bypass the
+    Hadamard rotation and take main's original path: the kernel compiles
+    (the 128/64 static_assert is scoped to HADAMARD) and the output is
+    bit-exact against an unrotated rope → quant reference."""
+    # Force the Triton path; the cutedsl dispatch for off-dims configs is
+    # unchanged from main and not exercised here. Object-form setattr: the
+    # shim pre-registers the submodule in sys.modules without a parent
+    # attribute, so dotted-string resolution fails.
+    import importlib
+
+    fiq_mod = importlib.import_module(
+        "vllm.models.deepseek_v4.common.ops.fused_indexer_q"
+    )
+    monkeypatch.setattr(fiq_mod, "has_cutedsl", lambda: False)
+    device = "cuda"
+    torch.manual_seed(0)
+    num_tokens, n_head = 37, 8
+    q = torch.randn(num_tokens, n_head, head_dim, dtype=torch.bfloat16, device=device)
+    positions = torch.randint(
+        0, MAX_POS, (num_tokens,), dtype=torch.int64, device=device
+    )
+    cos_sin_cache = torch.randn(MAX_POS, rope_dim, dtype=torch.bfloat16, device=device)
+    weights = torch.randn(num_tokens, n_head, dtype=torch.bfloat16, device=device)
+    softmax_scale = head_dim**-0.5
+    head_scale = n_head**-0.5
+    fp8_dtype = current_platform.fp8_dtype()
+    fp8_max = 224.0 if fp8_dtype == torch.float8_e4m3fnuz else 448.0
+
+    out, w_out = fused_indexer_q_rope_quant(
+        positions,
+        q.clone(),
+        cos_sin_cache,
+        weights,
+        softmax_scale,
+        head_scale,
+        use_fp4,
+    )
+    x = _rope_gptj_tail_dims(q, positions, cos_sin_cache, rope_dim)
+    if use_fp4:
+        packed_ref, ue8m0_ref = quantize_to_mxfp4(x)
+        packed, scale = out
+        assert torch.equal(ue8m0_ref.view(torch.int32).squeeze(-1), scale)
+        assert torch.equal(packed_ref, packed)
+        assert torch.equal(w_out, weights.float() * softmax_scale * head_scale)
+    else:
+        q_fp8, q_scale = _ue8m0_fp8_quant(x, fp8_dtype, fp8_max)
+        assert torch.equal(q_fp8.view(torch.uint8), out.view(torch.uint8))
+        assert torch.equal(
+            w_out, weights.float() * q_scale * softmax_scale * head_scale
+        )
+
+
+@torch.inference_mode()
+def test_hadamard_rotation_preserves_qk_dot():
+    """The Sylvester matrix is symmetric with H @ H == n*I, so the scaled
+    rotation is orthogonal and preserves indexer QK dot products."""
+    device = torch.device("cuda")
+    hadamard = _sylvester_hadamard(HEAD_DIM, device)
+    assert torch.equal(hadamard, hadamard.t())
+    identity = torch.eye(HEAD_DIM, device=device) * HEAD_DIM
+    assert torch.equal(hadamard @ hadamard, identity)
+
+    # The butterfly oracle computes the same rotation (up to fp32 rounding).
+    torch.manual_seed(0)
+    q = torch.randn(256, HEAD_DIM, device=device, dtype=torch.float64)
+    k = torch.randn(256, HEAD_DIM, device=device, dtype=torch.float64)
+    h64 = hadamard.double()
+    q_rot = (q @ h64) * (HEAD_DIM**-0.5)
+    k_rot = (k @ h64) * (HEAD_DIM**-0.5)
+    torch.testing.assert_close(
+        _hadamard_rotate(q.float()).double(), q_rot, rtol=1e-5, atol=1e-5
+    )
+    torch.testing.assert_close((q_rot * k_rot).sum(-1), (q * k).sum(-1))

--- a/tests/kernels/test_fused_indexer_hadamard.py
+++ b/tests/kernels/test_fused_indexer_hadamard.py
@@ -8,8 +8,10 @@ Sylvester Hadamard matrix (scaled by head_dim**-0.5, computed as a
 fixed-order fp32 butterfly) after RoPE and before quantization, matching the
 reference implementation's rotate_activation. These tests assert bit-exact
 equality against unfused rope → hadamard → quant references (using an fp8
-quant oracle independent of per_token_group_quant_fp8) and check that the
-orthogonal rotation preserves indexer QK dot products.
+quant oracle independent of per_token_group_quant_fp8), check that the
+orthogonal rotation preserves indexer QK dot products, and measure the
+rotation's quantization-quality value: reduced QK dot-product error on
+outlier-heavy post-RoPE-like activations, neutrality on iid Gaussian input.
 """
 
 import math
@@ -380,3 +382,239 @@ def test_hadamard_rotation_preserves_qk_dot():
         _hadamard_rotate(q.float()).double(), q_rot, rtol=1e-5, atol=1e-5
     )
     torch.testing.assert_close((q_rot * k_rot).sum(-1), (q * k).sum(-1))
+
+
+# ---------------------------------------------------------------------------
+# Quantization-quality property test (value of the rotation, not bit-exactness)
+# ---------------------------------------------------------------------------
+
+
+def _dequant_mxfp4(packed: torch.Tensor, ue8m0: torch.Tensor) -> torch.Tensor:
+    """Inverse of quantize_to_mxfp4: packed [..., D//2] uint8 (low nibble =
+    even index) plus ue8m0 [..., D//32] scale bytes, back to fp32."""
+    levels = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], device=packed.device
+    )
+    nibbles = torch.stack([packed & 0x0F, packed >> 4], dim=-1)
+    nibbles = nibbles.reshape(*packed.shape[:-1], -1)
+    vals = levels[(nibbles & 0x7).long()]
+    vals = torch.where(nibbles > 7, -vals, vals)  # 0x8 is the sign bit
+    scales = torch.exp2(ue8m0.float() - 127.0)
+    out = vals.reshape(*vals.shape[:-1], -1, 32) * scales.unsqueeze(-1)
+    return out.reshape(*packed.shape[:-1], -1)
+
+
+def _power_law_spectrum() -> torch.Tensor:
+    """Channel-pair magnitude spectrum shared by Q and K: a power law over
+    frequency with a per-pair jitter, mimicking the energy concentration in
+    low-frequency channel pairs of post-RoPE activations."""
+    g = torch.Generator().manual_seed(20260906)
+    freq = torch.arange(1, HEAD_DIM // 2 + 1, dtype=torch.float32)
+    mag = 8.0 * freq**-1.2
+    return mag * torch.exp(0.3 * torch.randn(HEAD_DIM // 2, generator=g))
+
+
+def _rope_like_activation(
+    batch: int,
+    spectrum: torch.Tensor | None,
+    seed_shift: int,
+    device: str,
+) -> torch.Tensor:
+    """Synthetic post-RoPE activations: channel pairs sharing the power-law
+    ``spectrum`` with independent random phase/amplitude per vector, plus a
+    small noise floor. ``spectrum=None`` gives the iid Gaussian control."""
+    g = torch.Generator().manual_seed(20260906 + seed_shift)
+    if spectrum is None:
+        return torch.randn(batch, HEAD_DIM, generator=g).to(device)
+    n_pairs = HEAD_DIM // 2
+    phase = torch.rand(batch, n_pairs, generator=g) * (2 * math.pi)
+    amp = torch.randn(batch, n_pairs, generator=g).abs() + 0.3
+    even = amp * spectrum * torch.cos(phase)
+    odd = amp * spectrum * torch.sin(phase)
+    x = torch.stack([even, odd], dim=-1).reshape(batch, HEAD_DIM)
+    x += 0.05 * torch.randn(batch, HEAD_DIM, generator=g)
+    return x.to(device)
+
+
+def _q_quantized_variants(q, use_fp4, fp8_dtype, fp8_max):
+    """Run the fused indexer Q kernel on bf16 activations with identity RoPE
+    (cos=1, sin=0) and unit weights/scales, and return the dequantized kernel
+    output alongside the dequantized unrotated oracle (main's math)."""
+    num_tokens, n_head = q.shape[0], q.shape[1]
+    device = q.device
+    positions = torch.arange(num_tokens, dtype=torch.int64, device=device)
+    cos_sin_cache = torch.zeros(num_tokens, ROPE_DIM, device=device)
+    cos_sin_cache[:, : ROPE_DIM // 2] = 1.0
+    weights = torch.ones(num_tokens, n_head, dtype=torch.bfloat16, device=device)
+    out, w_out = fused_indexer_q_rope_quant(
+        positions, q.clone(), cos_sin_cache, weights, 1.0, 1.0, use_fp4
+    )
+    if use_fp4:
+        packed, q_scale = out
+        ue8m0 = q_scale.unsqueeze(-1).contiguous().view(torch.uint8)
+        kernel_deq = _dequant_mxfp4(packed, ue8m0)
+        oracle_deq = _dequant_mxfp4(*quantize_to_mxfp4(q.float()))
+    else:
+        # weights/softmax_scale/head_scale are all 1, so w_out == q_scale.
+        kernel_deq = out.float() * w_out.unsqueeze(-1)
+        q_fp8, q_scale_ref = _ue8m0_fp8_quant(q.float(), fp8_dtype, fp8_max)
+        oracle_deq = q_fp8.float() * q_scale_ref.unsqueeze(-1)
+    return kernel_deq, oracle_deq
+
+
+def _k_quantized_variants(k_act, use_fp4):
+    """Run the fused indexer K kernel on raw bf16 activations with
+    compress_ratio=1, overlap=0, identity RoPE and unit RMSNorm weight, and
+    return (dequantized kernel output, dequantized unrotated oracle, exact
+    fp64 quant input)."""
+    head_dim, rope_dim = HEAD_DIM, ROPE_DIM
+    device = k_act.device
+    num_tokens = k_act.shape[0]
+    block_size = 16
+    kv_block_size = 16
+    if use_fp4:
+        token_stride, scale_dim, quant_block = head_dim // 2, head_dim // 32, 32
+    else:
+        token_stride, scale_dim, quant_block = head_dim, 4, head_dim
+
+    num_pages = (num_tokens - 1) // block_size + 2
+    state_cache = torch.zeros(
+        num_pages, block_size, 2 * head_dim, dtype=torch.bfloat16, device=device
+    )
+    state_cache.view(-1, 2 * head_dim)[:num_tokens, :head_dim] = k_act
+    block_table = torch.arange(num_pages, dtype=torch.int32, device=device).unsqueeze(0)
+    positions = torch.arange(num_tokens, dtype=torch.int64, device=device)
+    slot_mapping = torch.arange(num_tokens, dtype=torch.int64, device=device)
+    token_to_req = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    rms_weight = torch.ones(head_dim, dtype=torch.bfloat16, device=device)
+    cos_sin_cache = torch.zeros(num_tokens, rope_dim, device=device)
+    cos_sin_cache[:, : rope_dim // 2] = 1.0
+    kv_cache = torch.zeros(
+        (num_tokens + kv_block_size - 1) // kv_block_size + 1,
+        kv_block_size,
+        token_stride + scale_dim,
+        dtype=torch.uint8,
+        device=device,
+    )
+    compress_norm_rope_store_triton(
+        state_cache=state_cache,
+        num_actual=num_tokens,
+        token_to_req_indices=token_to_req,
+        positions=positions,
+        slot_mapping=slot_mapping,
+        block_table=block_table,
+        block_size=block_size,
+        state_width=head_dim,
+        cos_sin_cache=cos_sin_cache,
+        kv_cache=kv_cache,
+        k_cache_metadata=SimpleNamespace(slot_mapping=slot_mapping),
+        pdl_kwargs={},
+        head_dim=head_dim,
+        rope_head_dim=rope_dim,
+        compress_ratio=1,
+        overlap=False,
+        use_fp4_cache=use_fp4,
+        rms_norm_weight=rms_weight,
+        rms_norm_eps=1e-6,
+        quant_block=quant_block,
+        token_stride=token_stride,
+        scale_dim=scale_dim,
+    )
+
+    ref_args = (
+        state_cache,
+        block_table,
+        positions,
+        rms_weight,
+        cos_sin_cache,
+        1,  # compress_ratio
+        0,  # overlap
+        use_fp4,
+    )
+    # Exact reference: the kernel's quantization input (bf16 of the normed
+    # activations), unrotated — the rotation preserves dot products.
+    k_exact = _reference_kv_compress_norm_rope(
+        *ref_args, rms_eps=1e-6, return_full_cache=True, rotate=False
+    ).double()
+    o_vals, o_scales = _reference_kv_compress_norm_rope(
+        *ref_args, rms_eps=1e-6, fp8_max=FP8_MAX, rotate=False
+    )
+
+    kv_flat = kv_cache.view(kv_cache.shape[0], -1)
+    val_region = kv_flat[:, : kv_block_size * token_stride]
+    val_region = val_region.reshape(-1, token_stride)[:num_tokens]
+    scale_region = kv_flat[:, kv_block_size * token_stride :]
+    scale_region = scale_region.reshape(-1, scale_dim)[:num_tokens]
+    if use_fp4:
+        kernel_deq = _dequant_mxfp4(val_region, scale_region)
+        oracle_deq = _dequant_mxfp4(o_vals, o_scales)
+    else:
+        scales = scale_region.view(torch.float32).squeeze(-1)
+        kernel_deq = val_region.view(torch.float8_e4m3fn).float() * scales[:, None]
+        oracle_deq = o_vals.float() * o_scales.unsqueeze(-1)
+    return kernel_deq, oracle_deq, k_exact
+
+
+@pytest.mark.parametrize("use_fp4", [False, pytest.param(True, marks=requires_sm100)])
+@torch.inference_mode()
+def test_indexer_hadamard_quant_quality(use_fp4):
+    """The Hadamard rotation reduces indexer QK dot-product quantization
+    error on outlier-heavy post-RoPE-like activations, and is neutral on
+    outlier-free (iid Gaussian) ones.
+
+    Post-RoPE activations concentrate energy in low-frequency channel pairs
+    (power-law spectrum), so per-group quant scales are set by outlier
+    channels and the rest of the group loses resolution. The orthogonal
+    rotation spreads energy evenly — preserving exact dot products — and
+    shrinks the dot-product error the indexer actually consumes. On real
+    DSv4 indexer activations (official reference impl, TP4, 8192 tokens)
+    the rotation cuts the fp8 dot-error mean by 1.25-1.46x and mxfp4 by
+    1.18-1.66x across layers, landing on the iid-Gaussian baseline
+    (rotated-real/iid ratio 0.97-1.02). Per-vector fp8 relative L2 error
+    is neutral by design — the per-row scale absorbs outliers into the
+    exponent (real K: 0.0262 unrotated vs 0.0267 rotated) — so this test
+    asserts on dot-product error only.
+
+    With identity RoPE and unit weights/scales, the fused kernels quantize
+    the synthetic activations directly; the oracle applies the same
+    quantizers without the rotation, which is exactly what main's kernels
+    compute. On main the error ratio is therefore ~1.0 and the outlier
+    assertion fails; here the rotation drives it well below the threshold.
+    """
+    device = "cuda"
+    num_tokens, n_head, num_kv = 128, 64, 128
+    fp8_dtype = current_platform.fp8_dtype()
+    fp8_max = 224.0 if fp8_dtype == torch.float8_e4m3fnuz else FP8_MAX
+    spectrum = _power_law_spectrum()
+
+    for label, spec in (("outlier", spectrum), ("iid", None)):
+        q_act = _rope_like_activation(num_tokens * n_head, spec, 1, device)
+        q_act = q_act.reshape(num_tokens, n_head, HEAD_DIM).to(torch.bfloat16)
+        k_act = _rope_like_activation(num_kv, spec, 2, device).to(torch.bfloat16)
+        q_kernel, q_oracle = _q_quantized_variants(q_act, use_fp4, fp8_dtype, fp8_max)
+        k_kernel, k_oracle, k_exact = _k_quantized_variants(k_act, use_fp4)
+
+        exact = torch.einsum("thd,sd->ths", q_act.double(), k_exact)
+        err_kernel = (
+            torch.einsum("thd,sd->ths", q_kernel.double(), k_kernel.double()) - exact
+        ).abs()
+        err_oracle = (
+            torch.einsum("thd,sd->ths", q_oracle.double(), k_oracle.double()) - exact
+        ).abs()
+        mean_ratio = (err_kernel.mean() / err_oracle.mean()).item()
+        max_ratio = (err_kernel.max() / err_oracle.max()).item()
+        if label == "outlier":
+            # Measured on this branch (SM100): 0.21 fp8 / 0.25 mxfp4; main's
+            # unrotated kernels are identical to the oracle, giving ~1.0.
+            # 0.5 keeps >=2x distance from both.
+            assert mean_ratio < 0.5, (
+                f"rotation should cut dot-product quantization error on "
+                f"outlier activations (use_fp4={use_fp4}): mean-error ratio "
+                f"{mean_ratio:.3f} (max {max_ratio:.3f}) >= 0.5"
+            )
+        else:
+            assert 0.8 <= mean_ratio <= 1.25, (
+                f"rotation should be neutral on iid activations "
+                f"(use_fp4={use_fp4}): mean-error ratio {mean_ratio:.3f} "
+                f"outside [0.8, 1.25]"
+            )

--- a/tests/kernels/test_fused_indexer_q_rope_quant.py
+++ b/tests/kernels/test_fused_indexer_q_rope_quant.py
@@ -2,33 +2,31 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit test for fused_indexer_q_rope_quant.
 
-Compares the fused Triton kernel against the unfused reference flow used by
-the DeepseekV4 indexer in model_tracking:
-    q_rot = ops.rotary_embedding(positions, q, None, head_dim, cos_sin_cache,
-                                 is_neox_style=False,
-                                 rope_dim_offset=head_dim - rope_dim)
-    q_fp8, q_scale = per_token_group_quant_fp8(q_rot, head_dim, use_ue8m0=True)
+Compares the fused Triton kernel against the unfused reference flow matching
+the DeepSeek-V4 reference indexer (rotate_activation before quantization):
+    q_rot = gptj_rope(positions, q, cos_sin_cache)  # tail ROPE_DIM dims
+    q_rot = q_rot @ H * HEAD_DIM**-0.5              # Hadamard rotation
+    q_fp8, q_scale = per_token_group_quant_fp8(q_rot, HEAD_DIM, use_ue8m0=True)
     weights_out = weights * q_scale * softmax_scale * head_scale
 
-Expects bit-exact equality on both q_fp8 and weights_out.
+Expects bit-exact equality on both q_fp8 and weights_out. The RoPE oracle
+emulates the kernels' pinned FMA contraction in fp64 (plain fp32 eager
+double-rounds and can differ by 1 bf16 ulp, which the full-width rotation
+then spreads across all dims).
 """
-
-import contextlib
-from unittest import mock
 
 import pytest
 import torch
 
-from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
 )
 from vllm.models.deepseek_v4.common.ops import fused_indexer_q_rope_quant
 from vllm.platforms import current_platform
-from vllm.utils.import_utils import has_cutedsl
 
 HEAD_DIM = 128
 ROPE_DIM = 64
+NOPE_DIM = HEAD_DIM - ROPE_DIM
 N_HEAD = 64
 MAX_POS = 4096
 
@@ -83,6 +81,41 @@ def quantize_to_mxfp4(
     return packed, scales
 
 
+def _rope_gptj_tail(
+    x: torch.Tensor, positions: torch.Tensor, cos_sin_cache: torch.Tensor
+) -> torch.Tensor:
+    """GPT-J interleaved RoPE on the last ROPE_DIM dims plus a bf16
+    roundtrip, matching the Triton kernels' numerics. The kernels pin FMA
+    contraction (tl.fma); fp32 products are exact in fp64, so emulating the
+    fused form in fp64 and rounding once reproduces it bit-exactly (plain
+    fp32 eager double-rounds and can differ by 1 bf16 ulp)."""
+    cos = cos_sin_cache[positions, : ROPE_DIM // 2].double().unsqueeze(1)
+    sin = cos_sin_cache[positions, ROPE_DIM // 2 :].double().unsqueeze(1)
+    out = x.double()
+    ev, od = out[..., NOPE_DIM::2], out[..., NOPE_DIM + 1 :: 2]
+    r_ev = (ev * cos - (od * sin).float().double()).float()
+    r_od = (od * cos + (ev * sin).float().double()).float()
+    out = out.clone()
+    out[..., NOPE_DIM::2] = r_ev
+    out[..., NOPE_DIM + 1 :: 2] = r_od
+    return out.to(torch.bfloat16).float()
+
+
+def _hadamard_rotate(x: torch.Tensor) -> torch.Tensor:
+    """Sylvester Hadamard rotation y = (H @ x) * n**-0.5 as a matrix-free
+    fp32 butterfly with fixed stage order — every step is a single fp32
+    add/sub, so it bitwise matches the kernels' _hadamard_rotate."""
+    n = x.shape[-1]
+    y = x.float()
+    s = n // 2
+    while s > 0:
+        y = y.reshape(*y.shape[:-1], n // (2 * s), 2, s)
+        a, b = y.unbind(dim=-2)
+        y = torch.stack((a + b, a - b), dim=-2).reshape(*x.shape[:-1], n)
+        s //= 2
+    return y * (n**-0.5)
+
+
 def _reference(
     positions: torch.Tensor,
     q: torch.Tensor,
@@ -92,37 +125,27 @@ def _reference(
     head_scale: float,
     use_fp4: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    q_rot = q.clone()
-    ops.rotary_embedding(
-        positions,
-        q_rot,
-        None,
-        HEAD_DIM,
-        cos_sin_cache,
-        False,  # is_neox_style=False → GPT-J interleaved
-        HEAD_DIM - ROPE_DIM,  # rope_dim_offset → rotate the tail
-        False,
-    )
+    x = _rope_gptj_tail(q, positions, cos_sin_cache)
+    x = _hadamard_rotate(x)
 
     if use_fp4:
-        q_packed, ue8m0 = quantize_to_mxfp4(q_rot.view(-1, N_HEAD, HEAD_DIM))
+        q_packed, ue8m0 = quantize_to_mxfp4(x.view(-1, N_HEAD, HEAD_DIM))
         # Pack 4 ue8m0 bytes into 1 int32
         q_scale = ue8m0.view(torch.int32).squeeze(-1)
         # FP4 path: q_scale stays separate (cannot be folded into a per-token scalar)
         weights_out = weights.to(torch.float32) * softmax_scale * head_scale
         return (q_packed, q_scale), weights_out
 
-    else:
-        q_fp8, q_scale = per_token_group_quant_fp8(
-            q_rot.view(-1, HEAD_DIM).contiguous(),
-            HEAD_DIM,
-            use_ue8m0=True,
-        )
-        q_fp8 = q_fp8.view(-1, N_HEAD, HEAD_DIM)
-        q_scale = q_scale.view(-1, N_HEAD)
+    q_fp8, q_scale = per_token_group_quant_fp8(
+        x.view(-1, HEAD_DIM).contiguous(),
+        HEAD_DIM,
+        use_ue8m0=True,
+    )
+    q_fp8 = q_fp8.view(-1, N_HEAD, HEAD_DIM)
+    q_scale = q_scale.view(-1, N_HEAD)
 
-        weights_out = weights.to(torch.float32) * q_scale * softmax_scale * head_scale
-        return q_fp8, weights_out
+    weights_out = weights.to(torch.float32) * q_scale * softmax_scale * head_scale
+    return q_fp8, weights_out
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 32, 257, 1023])
@@ -143,14 +166,8 @@ def _reference(
         ),
     ],
 )
-@pytest.mark.parametrize("use_cutedsl", [False, True])
 @torch.inference_mode()
-def test_fused_indexer_q_rope_quant_matches_unfused(
-    num_tokens, cache_dtype, use_fp4, use_cutedsl
-):
-    if use_cutedsl and not has_cutedsl():
-        pytest.skip("cutedsl (cutlass) not installed")
-
+def test_fused_indexer_q_rope_quant_matches_unfused(num_tokens, cache_dtype, use_fp4):
     device = "cuda"
     torch.manual_seed(0)
 
@@ -166,26 +183,15 @@ def test_fused_indexer_q_rope_quant_matches_unfused(
     q_quant_ref, weights_ref = _reference(
         positions, q, cos_sin_cache, weights, softmax_scale, head_scale, use_fp4
     )
-    # use_cutedsl=False: force the triton path even when cutedsl is installed
-    # by patching the dispatcher's has_cutedsl() binding to return False.
-    cutedsl_patch = (
-        mock.patch(
-            "vllm.models.deepseek_v4.common.ops.fused_indexer_q.has_cutedsl",
-            return_value=False,
-        )
-        if not use_cutedsl
-        else contextlib.nullcontext()
+    q_quant_fused, weights_fused = fused_indexer_q_rope_quant(
+        positions,
+        q.clone(),
+        cos_sin_cache,
+        weights,
+        softmax_scale,
+        head_scale,
+        use_fp4,
     )
-    with cutedsl_patch:
-        q_quant_fused, weights_fused = fused_indexer_q_rope_quant(
-            positions,
-            q.clone(),
-            cos_sin_cache,
-            weights,
-            softmax_scale,
-            head_scale,
-            use_fp4,
-        )
 
     if use_fp4:
         q_quant_ref, q_scale_ref = q_quant_ref

--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
@@ -7,9 +7,9 @@ Three specialized kernels:
   - _fused_kv_compress_norm_rope_insert_sparse_attn:
         head=512, nope=448 FP8 + rope=64 bf16
   - _fused_kv_compress_norm_rope_insert_indexer_attn:
-        head=128, all FP8, 1 block/token
+        head=128, Hadamard-rotated, all FP8, 1 block/token
   - _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn:
-        head=128, MXFP4 (block=32), 4 ue8m0 bytes
+        head=128, Hadamard-rotated, MXFP4 (block=32), 4 ue8m0 bytes
 
 RoPE is register-based via tl.reshape -> tl.split -> tl.interleave (or the
 even/odd halves are consumed directly for MXFP4, no interleave needed).
@@ -32,7 +32,7 @@ if current_platform.is_rocm():
 else:
     _ON_GFX950 = False
 
-from .fused_indexer_q import _fp32x2_to_fp4x2
+from .fused_indexer_q import _fp32x2_to_fp4x2, _hadamard_rotate
 
 
 def compress_norm_rope_store_triton(
@@ -64,18 +64,22 @@ def compress_norm_rope_store_triton(
     Picks one of the three kernels in this module based on ``head_dim`` and
     ``use_fp4_cache``. Identical launch signature for all three.
     """
+    # The Hadamard rotation applies to the production indexer dims only
+    # (head_dim=128, rope_dim=64); other dims take the original path.
+    hadamard = head_dim == 128 and rope_head_dim == 64
+    kernel_kwargs: dict[str, Any] = {}
     if head_dim == 512:
         kernel = _fused_kv_compress_norm_rope_insert_sparse_attn
+        kernel_kwargs["SANITIZE_CACHE_NANS"] = _ON_GFX950
         num_warps = 4
-        kernel_kwargs = {"SANITIZE_CACHE_NANS": _ON_GFX950}
     elif use_fp4_cache:
         kernel = _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn
+        kernel_kwargs["HADAMARD"] = hadamard
         num_warps = 1
-        kernel_kwargs = {}
     else:
         kernel = _fused_kv_compress_norm_rope_insert_indexer_attn
+        kernel_kwargs["HADAMARD"] = hadamard
         num_warps = 1
-        kernel_kwargs = {}
 
     kernel[(num_actual,)](
         # state cache
@@ -708,8 +712,12 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     TOKEN_STRIDE: tl.constexpr,  # 128 for indexer
     SCALE_DIM: tl.constexpr,  # 4 for indexer (1 float32)
     KV_BLOCK_STRIDE: tl.constexpr,
+    HADAMARD: tl.constexpr = False,
 ):
-    """Fused compress → RMSNorm → RoPE → FP8 quant → store.
+    """Fused compress → RMSNorm → RoPE → Hadamard → FP8 quant → store.
+
+    The Hadamard rotation only runs when HADAMARD is set (production indexer
+    dims head_dim=128, rope_dim=64); other dims take the original path.
 
     One program per token; early-exits for non-boundary positions.
 
@@ -817,8 +825,10 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     cos_v = tl.load(cache_base + cs_idx, mask=is_rope_pair, other=1.0)
     sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope_pair, other=0.0)
 
-    new_even = even * cos_v - odd * sin_v
-    new_odd = odd * cos_v + even * sin_v
+    # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction of
+    # the unfused rotary_embedding flow on every platform.
+    new_even = tl.fma(even, cos_v, -(odd * sin_v))
+    new_odd = tl.fma(odd, cos_v, even * sin_v)
     result = tl.interleave(new_even, new_odd)  # fp32
 
     # ── FP8 UE8M0 quant: single block, flat reduction ────────────────
@@ -829,6 +839,11 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     INV_FP8_MAX: tl.constexpr = 1.0 / FP8_MAX
 
     result_bf16 = result.to(tl.bfloat16).to(tl.float32)
+    if HADAMARD:
+        # Hadamard rotation (reference rotate_activation) after RoPE, before
+        # quantization.
+        tl.static_assert(TRITON_BLOCK_SIZE == HEAD_SIZE)
+        result_bf16 = _hadamard_rotate(result_bf16, HEAD_SIZE)
     absmax = tl.max(tl.abs(result_bf16), axis=0)  # scalar
     absmax = tl.maximum(absmax, 1e-4)
     raw_scale = absmax * INV_FP8_MAX
@@ -885,8 +900,12 @@ def _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn(
     TOKEN_STRIDE: tl.constexpr,  # HEAD_SIZE // 2 = 64 packed bytes/token
     SCALE_DIM: tl.constexpr,  # HEAD_SIZE // QUANT_BLOCK = 4 ue8m0 bytes/token
     KV_BLOCK_STRIDE: tl.constexpr,
+    HADAMARD: tl.constexpr = False,
 ):
-    """Fused compress → RMSNorm → RoPE → MXFP4 quant → store.
+    """Fused compress → RMSNorm → RoPE → Hadamard → MXFP4 quant → store.
+
+    The Hadamard rotation only runs when HADAMARD is set (production indexer
+    dims head_dim=128, rope_dim=64); other dims take the original path.
 
     One program per token; early-exits for non-boundary positions.
 
@@ -998,12 +1017,23 @@ def _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn(
     cos_v = tl.load(cache_base + cs_idx, mask=is_rope_pair, other=1.0)
     sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope_pair, other=0.0)
 
-    new_even = even * cos_v - odd * sin_v
-    new_odd = odd * cos_v + even * sin_v
+    # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction of
+    # the unfused rotary_embedding flow on every platform.
+    new_even = tl.fma(even, cos_v, -(odd * sin_v))
+    new_odd = tl.fma(odd, cos_v, even * sin_v)
 
     # bf16 roundtrip for parity with reference / Q-side kernel numerics.
     new_even = new_even.to(tl.bfloat16).to(tl.float32)
     new_odd = new_odd.to(tl.bfloat16).to(tl.float32)
+
+    if HADAMARD:
+        # Hadamard rotation (reference rotate_activation) after RoPE, before
+        # per-block quant. Rotation mixes all dims, so it must precede the
+        # (N_BLOCKS, HALF_BLOCK) tiling below.
+        x_full = tl.interleave(new_even, new_odd)  # [HEAD_SIZE] fp32
+        x_rot = _hadamard_rotate(x_full, HEAD_SIZE)
+        x_rot2d = tl.reshape(x_rot, (NUM_PAIRS, 2))
+        new_even, new_odd = tl.split(x_rot2d)
 
     # ── MXFP4 quant: tile even/odd halves into (N_BLOCKS, HALF_BLOCK) ──
     # Each MXFP4 block of QUANT_BLOCK elements = HALF_BLOCK consecutive pairs,

--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
@@ -32,7 +32,7 @@ if current_platform.is_rocm():
 else:
     _ON_GFX950 = False
 
-from .fused_indexer_q import _fp32x2_to_fp4x2, _hadamard_rotate
+from .fused_indexer_q import _fp32x2_to_fp4x2, _rope_hadamard_full
 
 
 def compress_norm_rope_store_triton(
@@ -805,31 +805,18 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
         + kv_pos_in_block * SCALE_DIM
     )
 
-    NOPE_HEAD_DIM: tl.constexpr = HEAD_SIZE - ROPE_HEAD_DIM
-    HALF_ROPE: tl.constexpr = ROPE_HEAD_DIM // 2
-
-    # ── Register-based GPT-J forward RoPE in fp32 ─────────────────────
-    NUM_PAIRS: tl.constexpr = TRITON_BLOCK_SIZE // 2
-    NOPE_PAIRS: tl.constexpr = NOPE_HEAD_DIM // 2
-
-    normed_2d = tl.reshape(normed, (NUM_PAIRS, 2))
-    even, odd = tl.split(normed_2d)  # each [NUM_PAIRS] fp32
-
-    pair_idx = tl.arange(0, NUM_PAIRS)
-    rope_pair_local = pair_idx - NOPE_PAIRS
-    is_rope_pair = rope_pair_local >= 0
-    cs_idx = tl.maximum(rope_pair_local, 0)
-
+    # ── Register-based GPT-J forward RoPE in fp32, bf16 roundtrip, and
+    # (when HADAMARD) the Hadamard rotation ────────────────────────────
     compressed_pos = (position // COMPRESS_RATIO) * COMPRESS_RATIO
-    cache_base = cos_sin_cache_ptr + compressed_pos * cos_sin_stride
-    cos_v = tl.load(cache_base + cs_idx, mask=is_rope_pair, other=1.0)
-    sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope_pair, other=0.0)
-
-    # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction of
-    # the unfused rotary_embedding flow on every platform.
-    new_even = tl.fma(even, cos_v, -(odd * sin_v))
-    new_odd = tl.fma(odd, cos_v, even * sin_v)
-    result = tl.interleave(new_even, new_odd)  # fp32
+    result_bf16 = _rope_hadamard_full(
+        normed,
+        cos_sin_cache_ptr,
+        cos_sin_stride,
+        compressed_pos,
+        HEAD_SIZE,
+        ROPE_HEAD_DIM,
+        HADAMARD,
+    )
 
     # ── FP8 UE8M0 quant: single block, flat reduction ────────────────
     tl.static_assert(
@@ -838,12 +825,6 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     )
     INV_FP8_MAX: tl.constexpr = 1.0 / FP8_MAX
 
-    result_bf16 = result.to(tl.bfloat16).to(tl.float32)
-    if HADAMARD:
-        # Hadamard rotation (reference rotate_activation) after RoPE, before
-        # quantization.
-        tl.static_assert(TRITON_BLOCK_SIZE == HEAD_SIZE)
-        result_bf16 = _hadamard_rotate(result_bf16, HEAD_SIZE)
     absmax = tl.max(tl.abs(result_bf16), axis=0)  # scalar
     absmax = tl.maximum(absmax, 1e-4)
     raw_scale = absmax * INV_FP8_MAX
@@ -995,45 +976,21 @@ def _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn(
         + kv_pos_in_block * SCALE_DIM
     )
 
-    NOPE_HEAD_DIM: tl.constexpr = HEAD_SIZE - ROPE_HEAD_DIM
-    HALF_ROPE: tl.constexpr = ROPE_HEAD_DIM // 2
-
-    # ── Register-based GPT-J forward RoPE in fp32 ─────────────────────
-    # We keep the even/odd halves (no tl.interleave afterwards) because the
-    # MXFP4 per-block absmax / pack naturally operates on (even, odd) pairs.
-    NUM_PAIRS: tl.constexpr = TRITON_BLOCK_SIZE // 2
-    NOPE_PAIRS: tl.constexpr = NOPE_HEAD_DIM // 2
-
-    normed_2d = tl.reshape(normed, (NUM_PAIRS, 2))
-    even, odd = tl.split(normed_2d)  # each [NUM_PAIRS] fp32
-
-    pair_idx = tl.arange(0, NUM_PAIRS)
-    rope_pair_local = pair_idx - NOPE_PAIRS
-    is_rope_pair = rope_pair_local >= 0
-    cs_idx = tl.maximum(rope_pair_local, 0)
-
+    # ── Register-based GPT-J forward RoPE in fp32, bf16 roundtrip, and
+    # (when HADAMARD) the Hadamard rotation; split back into even/odd
+    # halves because the MXFP4 per-block absmax / pack below naturally
+    # operates on (even, odd) pairs. ───────────────────────────────────
     compressed_pos = (position // COMPRESS_RATIO) * COMPRESS_RATIO
-    cache_base = cos_sin_cache_ptr + compressed_pos * cos_sin_stride
-    cos_v = tl.load(cache_base + cs_idx, mask=is_rope_pair, other=1.0)
-    sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope_pair, other=0.0)
-
-    # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction of
-    # the unfused rotary_embedding flow on every platform.
-    new_even = tl.fma(even, cos_v, -(odd * sin_v))
-    new_odd = tl.fma(odd, cos_v, even * sin_v)
-
-    # bf16 roundtrip for parity with reference / Q-side kernel numerics.
-    new_even = new_even.to(tl.bfloat16).to(tl.float32)
-    new_odd = new_odd.to(tl.bfloat16).to(tl.float32)
-
-    if HADAMARD:
-        # Hadamard rotation (reference rotate_activation) after RoPE, before
-        # per-block quant. Rotation mixes all dims, so it must precede the
-        # (N_BLOCKS, HALF_BLOCK) tiling below.
-        x_full = tl.interleave(new_even, new_odd)  # [HEAD_SIZE] fp32
-        x_rot = _hadamard_rotate(x_full, HEAD_SIZE)
-        x_rot2d = tl.reshape(x_rot, (NUM_PAIRS, 2))
-        new_even, new_odd = tl.split(x_rot2d)
+    x_full = _rope_hadamard_full(
+        normed,
+        cos_sin_cache_ptr,
+        cos_sin_stride,
+        compressed_pos,
+        HEAD_SIZE,
+        ROPE_HEAD_DIM,
+        HADAMARD,
+    )
+    new_even, new_odd = tl.split(tl.reshape(x_full, (HEAD_SIZE // 2, 2)))
 
     # ── MXFP4 quant: tile even/odd halves into (N_BLOCKS, HALF_BLOCK) ──
     # Each MXFP4 block of QUANT_BLOCK elements = HALF_BLOCK consecutive pairs,

--- a/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
@@ -34,6 +34,50 @@ def _hadamard_rotate(x, N: tl.constexpr):
 
 
 @triton.jit
+def _rope_hadamard_full(
+    x,
+    cos_sin_ptr,
+    cos_sin_stride,
+    pos,
+    HEAD_DIM: tl.constexpr,
+    ROT_DIM: tl.constexpr,
+    ROTATE: tl.constexpr = True,
+):
+    """Full-width GPT-J RoPE (nope pairs masked to identity) with pinned FMA
+    contraction, a bf16 roundtrip matching the unfused reference numerics,
+    and — when ROTATE — the Hadamard rotation. Returns the full-width fp32
+    vector. Shared by all four indexer quant kernels (Q fp8/mxfp4, K
+    fp8/mxfp4) so the RoPE/roundtrip/rotation semantics stay bit-identical.
+    """
+    HALF_ROT: tl.constexpr = ROT_DIM // 2
+    NOPE_PAIRS: tl.constexpr = (HEAD_DIM - ROT_DIM) // 2
+    pairs = tl.reshape(x, (HEAD_DIM // 2, 2))
+    ev, od = tl.split(pairs)  # [HEAD_DIM // 2] fp32 each
+    pidx = tl.arange(0, HEAD_DIM // 2)
+    is_rope = pidx >= NOPE_PAIRS
+    cs_i = tl.maximum(pidx - NOPE_PAIRS, 0)
+    row_ptr = cos_sin_ptr + pos * cos_sin_stride
+    cos_v = tl.load(row_ptr + cs_i, mask=is_rope, other=1.0).to(tl.float32)
+    sin_v = tl.load(row_ptr + HALF_ROT + cs_i, mask=is_rope, other=0.0).to(tl.float32)
+    # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction of
+    # the unfused rotary_embedding flow on every platform.
+    new_ev = tl.fma(ev, cos_v, -(od * sin_v))
+    new_od = tl.fma(od, cos_v, ev * sin_v)
+    x_rope = tl.interleave(new_ev, new_od)  # [HEAD_DIM] fp32
+    # Match reference numerics: fp32 → bf16 → fp32 before rotation/quant.
+    # Post-interleave; equivalent to roundtripping the halves since the
+    # interleave is a permutation and the roundtrip is elementwise.
+    x_rope = x_rope.to(tl.bfloat16).to(tl.float32)
+    if ROTATE:
+        # Hadamard rotation (reference rotate_activation) after RoPE, before
+        # quantization.
+        tl.static_assert(HEAD_DIM == 128)
+        tl.static_assert(ROT_DIM == 64)
+        x_rope = _hadamard_rotate(x_rope, HEAD_DIM)
+    return x_rope
+
+
+@triton.jit
 def _get_cos_sin(
     cos_sin_cache_ptr,
     cos_sin_cache_stride,
@@ -130,32 +174,19 @@ def _fused_indexer_q_rope_quant_kernel(
 
     pos = tl.load(pos_ptr + tok_idx)
     base_ptr = index_q_ptr + tok_idx * index_q_stride0 + head_idx * index_q_stride1
-    # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction of
-    # the unfused rotary_embedding flow on every platform.
     if HADAMARD:
         # Full-width flow: rope with the nope region masked to identity,
         # bf16 roundtrip, Hadamard rotation, full-width ue8m0 FP8 quant.
-        tl.static_assert(INDEX_Q_HEAD_DIM == 128)
-        tl.static_assert(INDEX_Q_ROT_DIM == 64)
         full_idx = tl.arange(0, INDEX_Q_HEAD_DIM)
         x_full = tl.load(base_ptr + full_idx).to(tl.float32)
-        pairs = tl.reshape(x_full, (INDEX_Q_HEAD_DIM // 2, 2))
-        ev, od = tl.split(pairs)  # [64] fp32 each
-        pidx = tl.arange(0, INDEX_Q_HEAD_DIM // 2)
-        NOPE_PAIRS: tl.constexpr = INDEX_Q_NOPE_DIM // 2
-        is_rope = pidx >= NOPE_PAIRS
-        cs_i = tl.maximum(pidx - NOPE_PAIRS, 0)
-        row_ptr = index_q_cos_sin_ptr + pos * index_q_cos_sin_stride
-        cos_v = tl.load(row_ptr + cs_i, mask=is_rope, other=1.0).to(tl.float32)
-        sin_v = tl.load(
-            row_ptr + INDEX_Q_HALF_ROT_DIM + cs_i, mask=is_rope, other=0.0
-        ).to(tl.float32)
-        new_ev = tl.fma(ev, cos_v, -(od * sin_v))
-        new_od = tl.fma(od, cos_v, ev * sin_v)
-        x_rope = tl.interleave(new_ev, new_od)  # [128] fp32
-        # Match reference numerics: fp32 → bf16 → fp32 before rotation/quant.
-        x_rope = x_rope.to(tl.bfloat16).to(tl.float32)
-        x_h = _hadamard_rotate(x_rope, INDEX_Q_HEAD_DIM)
+        x_h = _rope_hadamard_full(
+            x_full,
+            index_q_cos_sin_ptr,
+            index_q_cos_sin_stride,
+            pos,
+            INDEX_Q_HEAD_DIM,
+            INDEX_Q_ROT_DIM,
+        )
         amax = tl.max(tl.abs(x_h))
     else:
         # Interleaved (GPT-J) RoPE on dims [NOPE_DIM, HEAD_DIM):
@@ -170,6 +201,8 @@ def _fused_indexer_q_rope_quant_kernel(
         rot_base = base_ptr + INDEX_Q_NOPE_DIM
         x_even = tl.load(rot_base + half_offset * 2).to(tl.float32)
         x_odd = tl.load(rot_base + half_offset * 2 + 1).to(tl.float32)
+        # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction
+        # of the unfused rotary_embedding flow on every platform.
         r_even = tl.fma(x_even, cos, -(x_odd * sin))
         r_odd = tl.fma(x_odd, cos, x_even * sin)
         # Match reference numerics: fp32 → bf16 → fp32 before the ue8m0
@@ -287,27 +320,16 @@ def _fused_indexer_q_rope_mxfp4_kernel(
     if HADAMARD:
         # Full-width flow: GPT-J RoPE (nope masked to identity) → bf16
         # roundtrip → Hadamard rotation → per-32-block MXFP4 quant.
-        tl.static_assert(INDEX_Q_HEAD_DIM == 128)
-        tl.static_assert(INDEX_Q_ROT_DIM == 64)
         full_idx = tl.arange(0, INDEX_Q_HEAD_DIM)
         x_full = tl.load(q_base + full_idx).to(tl.float32)
-        pairs = tl.reshape(x_full, (INDEX_Q_HEAD_DIM // 2, 2))
-        ev, od = tl.split(pairs)  # [64] fp32 each
-        pidx = tl.arange(0, INDEX_Q_HEAD_DIM // 2)
-        NOPE_PAIRS: tl.constexpr = INDEX_Q_NOPE_DIM // 2
-        is_rope = pidx >= NOPE_PAIRS
-        cs_i = tl.maximum(pidx - NOPE_PAIRS, 0)
-        row_ptr = index_q_cos_sin_ptr + pos * index_q_cos_sin_stride
-        cos_v = tl.load(row_ptr + cs_i, mask=is_rope, other=1.0).to(tl.float32)
-        sin_v = tl.load(
-            row_ptr + INDEX_Q_HALF_ROT_DIM + cs_i, mask=is_rope, other=0.0
-        ).to(tl.float32)
-        # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction
-        # of the unfused rotary_embedding flow on every platform.
-        new_ev = tl.fma(ev, cos_v, -(od * sin_v)).to(tl.bfloat16).to(tl.float32)
-        new_od = tl.fma(od, cos_v, ev * sin_v).to(tl.bfloat16).to(tl.float32)
-        x_rope = tl.interleave(new_ev, new_od)  # [128] fp32
-        x_h = _hadamard_rotate(x_rope, INDEX_Q_HEAD_DIM)
+        x_h = _rope_hadamard_full(
+            x_full,
+            index_q_cos_sin_ptr,
+            index_q_cos_sin_stride,
+            pos,
+            INDEX_Q_HEAD_DIM,
+            INDEX_Q_ROT_DIM,
+        )
         # Per-block MXFP4 quant on the rotated vector, vectorized over the
         # blocks: each block of MXFP4_BLOCK consecutive elements is
         # HALF_BLOCK (even, odd) pairs.

--- a/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_indexer_q.py
@@ -12,6 +12,28 @@ MXFP4_BLOCK_SIZE = 32
 
 
 @triton.jit
+def _hadamard_stage(x, N: tl.constexpr, S: tl.constexpr):
+    a, b = tl.split(tl.trans(tl.reshape(x, (N // (2 * S), 2, S)), 0, 2, 1))
+    return tl.reshape(tl.trans(tl.join(a + b, a - b), 0, 2, 1), (N,))
+
+
+@triton.jit
+def _hadamard_rotate(x, N: tl.constexpr):
+    """Sylvester Hadamard rotation y = (H @ x) * N**-0.5 as a matrix-free
+    fp32 butterfly: log2(N) fixed-order stages of single fp32 add/subs, so
+    the result is bitwise reproducible with elementwise torch ops."""
+    tl.static_assert(N == 128)
+    x = _hadamard_stage(x, N, 64)
+    x = _hadamard_stage(x, N, 32)
+    x = _hadamard_stage(x, N, 16)
+    x = _hadamard_stage(x, N, 8)
+    x = _hadamard_stage(x, N, 4)
+    x = _hadamard_stage(x, N, 2)
+    x = _hadamard_stage(x, N, 1)
+    return x * 0.08838834764831845  # 128**-0.5
+
+
+@triton.jit
 def _get_cos_sin(
     cos_sin_cache_ptr,
     cos_sin_cache_stride,
@@ -91,12 +113,14 @@ def _fused_indexer_q_rope_quant_kernel(
     index_weights_out_stride,
     FP8_MAX: tl.constexpr = 448.0,
     USE_FNUZ: tl.constexpr = False,
-    USE_EXPLICIT_FMA: tl.constexpr = False,
+    HADAMARD: tl.constexpr = False,
 ):
     # Layout matches the unfused reference (DeepseekV4ScalingRotaryEmbedding
     # + per_token_group_quant_fp8): GPT-J interleaved RoPE applied to the
     # LAST rope_dim dims of each head; the leading [0, NOPE_DIM) is passed
-    # through unchanged.
+    # through unchanged. With HADAMARD (production indexer dims 128/64), the
+    # full vector is Hadamard-rotated after a bf16 roundtrip and before
+    # quantization, matching the reference rotate_activation.
     INDEX_Q_ROT_DIM: tl.constexpr = 2 * INDEX_Q_HALF_ROT_DIM
     INDEX_Q_NOPE_DIM: tl.constexpr = INDEX_Q_HEAD_DIM - INDEX_Q_ROT_DIM
     tl.static_assert(INDEX_Q_NOPE_DIM >= 0)
@@ -105,61 +129,87 @@ def _fused_indexer_q_rope_quant_kernel(
     head_idx = tl.program_id(1)
 
     pos = tl.load(pos_ptr + tok_idx)
-    cos, sin = _get_cos_sin(
-        index_q_cos_sin_ptr,
-        index_q_cos_sin_stride,
-        pos,
-        INDEX_Q_HALF_ROT_DIM,
-    )
-    half_offset = tl.arange(0, INDEX_Q_HALF_ROT_DIM)
     base_ptr = index_q_ptr + tok_idx * index_q_stride0 + head_idx * index_q_stride1
-
-    # Interleaved (GPT-J) RoPE on dims [NOPE_DIM, HEAD_DIM):
-    #   even = q[NOPE_DIM + 2*i],  odd = q[NOPE_DIM + 2*i + 1]
-    rot_base = base_ptr + INDEX_Q_NOPE_DIM
-    x_even = tl.load(rot_base + half_offset * 2).to(tl.float32)
-    x_odd = tl.load(rot_base + half_offset * 2 + 1).to(tl.float32)
-    if USE_EXPLICIT_FMA:
-        # Match HIP rotary_embedding contraction before bf16 materialization.
+    # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction of
+    # the unfused rotary_embedding flow on every platform.
+    if HADAMARD:
+        # Full-width flow: rope with the nope region masked to identity,
+        # bf16 roundtrip, Hadamard rotation, full-width ue8m0 FP8 quant.
+        tl.static_assert(INDEX_Q_HEAD_DIM == 128)
+        tl.static_assert(INDEX_Q_ROT_DIM == 64)
+        full_idx = tl.arange(0, INDEX_Q_HEAD_DIM)
+        x_full = tl.load(base_ptr + full_idx).to(tl.float32)
+        pairs = tl.reshape(x_full, (INDEX_Q_HEAD_DIM // 2, 2))
+        ev, od = tl.split(pairs)  # [64] fp32 each
+        pidx = tl.arange(0, INDEX_Q_HEAD_DIM // 2)
+        NOPE_PAIRS: tl.constexpr = INDEX_Q_NOPE_DIM // 2
+        is_rope = pidx >= NOPE_PAIRS
+        cs_i = tl.maximum(pidx - NOPE_PAIRS, 0)
+        row_ptr = index_q_cos_sin_ptr + pos * index_q_cos_sin_stride
+        cos_v = tl.load(row_ptr + cs_i, mask=is_rope, other=1.0).to(tl.float32)
+        sin_v = tl.load(
+            row_ptr + INDEX_Q_HALF_ROT_DIM + cs_i, mask=is_rope, other=0.0
+        ).to(tl.float32)
+        new_ev = tl.fma(ev, cos_v, -(od * sin_v))
+        new_od = tl.fma(od, cos_v, ev * sin_v)
+        x_rope = tl.interleave(new_ev, new_od)  # [128] fp32
+        # Match reference numerics: fp32 → bf16 → fp32 before rotation/quant.
+        x_rope = x_rope.to(tl.bfloat16).to(tl.float32)
+        x_h = _hadamard_rotate(x_rope, INDEX_Q_HEAD_DIM)
+        amax = tl.max(tl.abs(x_h))
+    else:
+        # Interleaved (GPT-J) RoPE on dims [NOPE_DIM, HEAD_DIM):
+        #   even = q[NOPE_DIM + 2*i],  odd = q[NOPE_DIM + 2*i + 1]
+        cos, sin = _get_cos_sin(
+            index_q_cos_sin_ptr,
+            index_q_cos_sin_stride,
+            pos,
+            INDEX_Q_HALF_ROT_DIM,
+        )
+        half_offset = tl.arange(0, INDEX_Q_HALF_ROT_DIM)
+        rot_base = base_ptr + INDEX_Q_NOPE_DIM
+        x_even = tl.load(rot_base + half_offset * 2).to(tl.float32)
+        x_odd = tl.load(rot_base + half_offset * 2 + 1).to(tl.float32)
         r_even = tl.fma(x_even, cos, -(x_odd * sin))
         r_odd = tl.fma(x_odd, cos, x_even * sin)
-    else:
-        r_even = x_even * cos - x_odd * sin
-        r_odd = x_odd * cos + x_even * sin
-
-    # Match reference numerics: fp32 → bf16 → fp32 before the ue8m0 absmax.
-    # Same pattern as the K-side compressor kernel (fused_compress_quant_cache.py).
-    r_even = r_even.to(tl.bfloat16).to(tl.float32)
-    r_odd = r_odd.to(tl.bfloat16).to(tl.float32)
-
-    amax = tl.maximum(tl.max(tl.abs(r_even)), tl.max(tl.abs(r_odd)))
-    if INDEX_Q_NOPE_DIM > 0:
-        nope_offset = tl.arange(0, INDEX_Q_NOPE_DIM)
-        x_nope = tl.load(base_ptr + nope_offset).to(tl.float32)
-        amax = tl.maximum(amax, tl.max(tl.abs(x_nope)))
+        # Match reference numerics: fp32 → bf16 → fp32 before the ue8m0
+        # absmax. Same pattern as the K-side kernel.
+        r_even = r_even.to(tl.bfloat16).to(tl.float32)
+        r_odd = r_odd.to(tl.bfloat16).to(tl.float32)
+        amax = tl.maximum(tl.max(tl.abs(r_even)), tl.max(tl.abs(r_odd)))
+        if INDEX_Q_NOPE_DIM > 0:
+            nope_offset = tl.arange(0, INDEX_Q_NOPE_DIM)
+            x_nope = tl.load(base_ptr + nope_offset).to(tl.float32)
+            amax = tl.maximum(amax, tl.max(tl.abs(x_nope)))
     index_q_scale = tl.div_rn(tl.maximum(amax, 1e-4), FP8_MAX)
     index_q_scale = tl.math.exp2(tl.math.ceil(tl.math.log2(index_q_scale)))
 
-    # Store quantized values to index_q_fp8. FNUZ (e4m3fnuz) on gfx942, OCP
-    # (e4m3fn) elsewhere -- matches the K cache.
+    # Store quantized values to index_q_fp8. FNUZ (e4m3fnuz) on gfx942,
+    # OCP (e4m3fn) elsewhere -- matches the K cache.
     fp8_dtype = tl.float8e4b8 if USE_FNUZ else tl.float8e4nv
     fp8_base_ptr = (
         index_q_fp8_ptr + tok_idx * index_q_fp8_stride0 + head_idx * index_q_fp8_stride1
     )
-    if INDEX_Q_NOPE_DIM > 0:
+    if HADAMARD:
         tl.store(
-            fp8_base_ptr + nope_offset,
-            tl.div_rn(x_nope, index_q_scale).to(fp8_dtype),
+            fp8_base_ptr + full_idx,
+            tl.div_rn(x_h, index_q_scale).to(fp8_dtype),
         )
-    fp8_rot_base = fp8_base_ptr + INDEX_Q_NOPE_DIM
-    tl.store(
-        fp8_rot_base + half_offset * 2,
-        tl.div_rn(r_even, index_q_scale).to(fp8_dtype),
-    )
-    tl.store(
-        fp8_rot_base + half_offset * 2 + 1,
-        tl.div_rn(r_odd, index_q_scale).to(fp8_dtype),
-    )
+    else:
+        if INDEX_Q_NOPE_DIM > 0:
+            tl.store(
+                fp8_base_ptr + nope_offset,
+                tl.div_rn(x_nope, index_q_scale).to(fp8_dtype),
+            )
+        fp8_rot_base = fp8_base_ptr + INDEX_Q_NOPE_DIM
+        tl.store(
+            fp8_rot_base + half_offset * 2,
+            tl.div_rn(r_even, index_q_scale).to(fp8_dtype),
+        )
+        tl.store(
+            fp8_rot_base + half_offset * 2 + 1,
+            tl.div_rn(r_odd, index_q_scale).to(fp8_dtype),
+        )
 
     # FP8 weight-fold contract:
     #   index_weights_out = index_weights * q_scale * softmax_scale * head_scale
@@ -209,15 +259,12 @@ def _fused_indexer_q_rope_mxfp4_kernel(
     index_weights_head_scale,
     index_weights_out_ptr,
     index_weights_out_stride,
+    HADAMARD: tl.constexpr = False,
 ):
     INDEX_Q_ROT_DIM: tl.constexpr = 2 * INDEX_Q_HALF_ROT_DIM
     INDEX_Q_NOPE_DIM: tl.constexpr = INDEX_Q_HEAD_DIM - INDEX_Q_ROT_DIM
-    NUM_NOPE_BLOCKS: tl.constexpr = INDEX_Q_NOPE_DIM // MXFP4_BLOCK
-    NUM_ROPE_BLOCKS: tl.constexpr = INDEX_Q_ROT_DIM // MXFP4_BLOCK
     HALF_BLOCK: tl.constexpr = MXFP4_BLOCK // 2
     tl.static_assert(INDEX_Q_NOPE_DIM >= 0)
-    tl.static_assert(INDEX_Q_NOPE_DIM % MXFP4_BLOCK == 0)
-    tl.static_assert(INDEX_Q_ROT_DIM % MXFP4_BLOCK == 0)
     tl.static_assert(MXFP4_BLOCK % 2 == 0)
 
     tok_idx = tl.program_id(0)
@@ -237,42 +284,94 @@ def _fused_indexer_q_rope_mxfp4_kernel(
         + head_idx * index_q_scale_stride1
     )
 
-    half_off = tl.arange(0, HALF_BLOCK)
-
-    # ---- NoPE blocks: direct load, pair as (even-index, odd-index) values ----
-    for b in tl.static_range(NUM_NOPE_BLOCKS):
-        base = b * MXFP4_BLOCK
-        x_lo = tl.load(q_base + base + half_off * 2).to(tl.float32)
-        x_hi = tl.load(q_base + base + half_off * 2 + 1).to(tl.float32)
-        packed, ue8m0 = _quantize_mxfp4_pair(x_lo, x_hi)
-        tl.store(out_base + base // 2 + half_off, packed)
-        tl.store(scale_base + b, ue8m0)
-
-    # ---- RoPE blocks: apply GPT-J interleaved RoPE to the block's 16 pairs,
-    # then quantize. Each block covers HALF_BLOCK (=16) cos/sin pairs. ----
-    rot_q_base = q_base + INDEX_Q_NOPE_DIM
-    for b in tl.static_range(NUM_ROPE_BLOCKS):
-        pair_off = b * HALF_BLOCK + half_off  # indices in [0, HALF_ROT_DIM)
-        cos_b = tl.load(
-            index_q_cos_sin_ptr + pos * index_q_cos_sin_stride + pair_off
+    if HADAMARD:
+        # Full-width flow: GPT-J RoPE (nope masked to identity) → bf16
+        # roundtrip → Hadamard rotation → per-32-block MXFP4 quant.
+        tl.static_assert(INDEX_Q_HEAD_DIM == 128)
+        tl.static_assert(INDEX_Q_ROT_DIM == 64)
+        full_idx = tl.arange(0, INDEX_Q_HEAD_DIM)
+        x_full = tl.load(q_base + full_idx).to(tl.float32)
+        pairs = tl.reshape(x_full, (INDEX_Q_HEAD_DIM // 2, 2))
+        ev, od = tl.split(pairs)  # [64] fp32 each
+        pidx = tl.arange(0, INDEX_Q_HEAD_DIM // 2)
+        NOPE_PAIRS: tl.constexpr = INDEX_Q_NOPE_DIM // 2
+        is_rope = pidx >= NOPE_PAIRS
+        cs_i = tl.maximum(pidx - NOPE_PAIRS, 0)
+        row_ptr = index_q_cos_sin_ptr + pos * index_q_cos_sin_stride
+        cos_v = tl.load(row_ptr + cs_i, mask=is_rope, other=1.0).to(tl.float32)
+        sin_v = tl.load(
+            row_ptr + INDEX_Q_HALF_ROT_DIM + cs_i, mask=is_rope, other=0.0
         ).to(tl.float32)
-        sin_b = tl.load(
-            index_q_cos_sin_ptr
-            + pos * index_q_cos_sin_stride
-            + pair_off
-            + INDEX_Q_HALF_ROT_DIM
-        ).to(tl.float32)
-        x_even = tl.load(rot_q_base + pair_off * 2).to(tl.float32)
-        x_odd = tl.load(rot_q_base + pair_off * 2 + 1).to(tl.float32)
-        r_even = x_even * cos_b - x_odd * sin_b
-        r_odd = x_odd * cos_b + x_even * sin_b
-        # bf16 roundtrip for parity with the FP8 kernel / reference numerics.
-        r_even = r_even.to(tl.bfloat16).to(tl.float32)
-        r_odd = r_odd.to(tl.bfloat16).to(tl.float32)
-        packed, ue8m0 = _quantize_mxfp4_pair(r_even, r_odd)
-        rope_byte_off = (INDEX_Q_NOPE_DIM + b * MXFP4_BLOCK) // 2
-        tl.store(out_base + rope_byte_off + half_off, packed)
-        tl.store(scale_base + NUM_NOPE_BLOCKS + b, ue8m0)
+        # Pinned FMA contraction, matching the fused (NVCC/HIP) contraction
+        # of the unfused rotary_embedding flow on every platform.
+        new_ev = tl.fma(ev, cos_v, -(od * sin_v)).to(tl.bfloat16).to(tl.float32)
+        new_od = tl.fma(od, cos_v, ev * sin_v).to(tl.bfloat16).to(tl.float32)
+        x_rope = tl.interleave(new_ev, new_od)  # [128] fp32
+        x_h = _hadamard_rotate(x_rope, INDEX_Q_HEAD_DIM)
+        # Per-block MXFP4 quant on the rotated vector, vectorized over the
+        # blocks: each block of MXFP4_BLOCK consecutive elements is
+        # HALF_BLOCK (even, odd) pairs.
+        NQB: tl.constexpr = INDEX_Q_HEAD_DIM // MXFP4_BLOCK
+        x2 = tl.reshape(x_h, (INDEX_Q_HEAD_DIM // 2, 2))
+        lo, hi = tl.split(x2)  # lo[k]=x_h[2k], hi[k]=x_h[2k+1]
+        lo2 = tl.reshape(lo, (NQB, HALF_BLOCK))
+        hi2 = tl.reshape(hi, (NQB, HALF_BLOCK))
+        amax = tl.maximum(tl.max(tl.abs(lo2), 1), tl.max(tl.abs(hi2), 1))
+        # 6 * 2^-126 is from https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/inference/kernel.py#L163
+        amax = tl.maximum(amax, 6.0 * (2**-126))
+        # ue8m0 block scale: 2^ceil(log2(amax/6.0)).
+        log2_ratio = tl.ceil(tl.log2(amax * (1.0 / 6.0)))
+        log2_ratio = tl.minimum(tl.maximum(log2_ratio, -127.0), 127.0)
+        inv_scale = tl.exp2(-log2_ratio)
+        ue8m0 = (log2_ratio + 127.0).to(tl.uint8)  # [NQB]
+        inv_col = tl.reshape(inv_scale, (NQB, 1))
+        packed = _fp32x2_to_fp4x2(lo2 * inv_col, hi2 * inv_col)
+        packed_flat = tl.reshape(packed, (INDEX_Q_HEAD_DIM // 2,))
+        tl.store(out_base + tl.arange(0, INDEX_Q_HEAD_DIM // 2), packed_flat)
+        tl.store(scale_base + tl.arange(0, NQB), ue8m0)
+    else:
+        NUM_NOPE_BLOCKS: tl.constexpr = INDEX_Q_NOPE_DIM // MXFP4_BLOCK
+        NUM_ROPE_BLOCKS: tl.constexpr = INDEX_Q_ROT_DIM // MXFP4_BLOCK
+        tl.static_assert(INDEX_Q_NOPE_DIM % MXFP4_BLOCK == 0)
+        tl.static_assert(INDEX_Q_ROT_DIM % MXFP4_BLOCK == 0)
+        half_off = tl.arange(0, HALF_BLOCK)
+
+        # ---- NoPE blocks: direct load, pair as (even, odd) values ----
+        for b in tl.static_range(NUM_NOPE_BLOCKS):
+            base = b * MXFP4_BLOCK
+            x_lo = tl.load(q_base + base + half_off * 2).to(tl.float32)
+            x_hi = tl.load(q_base + base + half_off * 2 + 1).to(tl.float32)
+            packed, ue8m0 = _quantize_mxfp4_pair(x_lo, x_hi)
+            tl.store(out_base + base // 2 + half_off, packed)
+            tl.store(scale_base + b, ue8m0)
+
+        # ---- RoPE blocks: GPT-J interleaved RoPE on the block's 16 pairs,
+        # then quantize. Each block covers HALF_BLOCK cos/sin pairs. ----
+        rot_q_base = q_base + INDEX_Q_NOPE_DIM
+        for b in tl.static_range(NUM_ROPE_BLOCKS):
+            pair_off = b * HALF_BLOCK + half_off  # indices in [0, HALF_ROT_DIM)
+            cos_b = tl.load(
+                index_q_cos_sin_ptr + pos * index_q_cos_sin_stride + pair_off
+            ).to(tl.float32)
+            sin_b = tl.load(
+                index_q_cos_sin_ptr
+                + pos * index_q_cos_sin_stride
+                + pair_off
+                + INDEX_Q_HALF_ROT_DIM
+            ).to(tl.float32)
+            x_even = tl.load(rot_q_base + pair_off * 2).to(tl.float32)
+            x_odd = tl.load(rot_q_base + pair_off * 2 + 1).to(tl.float32)
+            # Pinned FMA contraction, matching the fused (NVCC/HIP)
+            # contraction of the unfused rotary_embedding flow.
+            r_even = tl.fma(x_even, cos_b, -(x_odd * sin_b))
+            r_odd = tl.fma(x_odd, cos_b, x_even * sin_b)
+            # bf16 roundtrip for parity with the FP8 kernel / reference.
+            r_even = r_even.to(tl.bfloat16).to(tl.float32)
+            r_odd = r_odd.to(tl.bfloat16).to(tl.float32)
+            packed, ue8m0 = _quantize_mxfp4_pair(r_even, r_odd)
+            rope_byte_off = (INDEX_Q_NOPE_DIM + b * MXFP4_BLOCK) // 2
+            tl.store(out_base + rope_byte_off + half_off, packed)
+            tl.store(scale_base + NUM_NOPE_BLOCKS + b, ue8m0)
 
     # MXFP4 weight-fold contract:
     #   index_weights_out = index_weights * softmax_scale * head_scale
@@ -307,6 +406,12 @@ def fused_indexer_q_rope_quant(
 ]:
     """Fused RoPE + quantize Q for the sparse indexer.
 
+    For the production indexer dims (head_dim=128, rope_dim=64) a Sylvester
+    Hadamard rotation (scaled by head_dim**-0.5) follows RoPE and precedes
+    quantization, matching the reference implementation's rotate_activation.
+    Being orthogonal, it preserves indexer QK dot products. Other dims take
+    the original unrotated path.
+
     Weight-fold semantics (important — the two paths differ):
 
     FP8 path (use_fp4=False, default):
@@ -337,6 +442,9 @@ def fused_indexer_q_rope_quant(
     num_tokens = positions.shape[0]
     num_index_q_heads = index_q.shape[1]
     index_q_head_dim = index_q.shape[2]
+    # The Hadamard rotation applies to the production indexer dims only
+    # (head_dim=128, rope_dim=64); other dims take the original path.
+    hadamard = index_q_head_dim == 128 and index_q_cos_sin_cache.shape[-1] == 64
 
     index_weights_out = torch.empty_like(index_weights, dtype=torch.float32)
 
@@ -356,7 +464,7 @@ def fused_indexer_q_rope_quant(
             dtype=torch.uint8,
             device=index_q.device,
         )
-        if has_cutedsl():
+        if not hadamard and has_cutedsl():
             # lazily import, otherwise some tests fail due to CUDA driver init failure.
             from vllm.models.deepseek_v4.nvidia.ops.fused_indexer_q_cutedsl import (
                 fused_indexer_q_rope_quant_mxfp4_cutedsl,
@@ -386,6 +494,10 @@ def fused_indexer_q_rope_quant(
                 index_weights_out,
             )
         else:
+            # NOTE: the cutedsl indexer-Q kernels predate the Hadamard
+            # rotation and would skip it; when the rotation applies
+            # (head_dim=128, rope_dim=64) always launch the Triton kernel
+            # until they implement the rotation.
             _fused_indexer_q_rope_mxfp4_kernel[(num_tokens, num_index_q_heads)](
                 positions,
                 index_q,
@@ -408,7 +520,8 @@ def fused_indexer_q_rope_quant(
                 index_weights_head_scale,
                 index_weights_out,
                 index_weights_out.stride(0),
-                num_warps=1,  # TODO: Tune this
+                HADAMARD=hadamard,
+                num_warps=1,
             )
 
         # Values stay uint8 (2 E2M1 nibbles per byte). Scales are 4 ue8m0
@@ -425,7 +538,7 @@ def fused_indexer_q_rope_quant(
     use_fnuz = fp8_dtype == torch.float8_e4m3fnuz
     fp8_max = 224.0 if use_fnuz else 448.0
     index_q_fp8 = torch.empty_like(index_q, dtype=fp8_dtype)
-    if has_cutedsl():
+    if not hadamard and has_cutedsl():
         # lazily import, otherwise some tests fail due to CUDA driver init failure.
         from vllm.models.deepseek_v4.nvidia.ops.fused_indexer_q_cutedsl import (
             fused_indexer_q_rope_quant_fp8_cutedsl,
@@ -453,6 +566,10 @@ def fused_indexer_q_rope_quant(
             index_weights_out,
         )
     else:
+        # NOTE: the cutedsl indexer-Q kernels predate the Hadamard rotation
+        # and would skip it; when the rotation applies (head_dim=128,
+        # rope_dim=64) always launch the Triton kernel until they implement
+        # the rotation.
         _fused_indexer_q_rope_quant_kernel[(num_tokens, num_index_q_heads)](
             positions,
             index_q,
@@ -473,7 +590,7 @@ def fused_indexer_q_rope_quant(
             index_weights_out.stride(0),
             FP8_MAX=fp8_max,
             USE_FNUZ=use_fnuz,
-            USE_EXPLICIT_FMA=current_platform.is_rocm(),
-            num_warps=1,  # TODO: Tune this
+            HADAMARD=hadamard,
+            num_warps=1,
         )
     return index_q_fp8, index_weights_out


### PR DESCRIPTION
## Problem

`DeepseekV4Attention` / `DeepseekV4Indexer` pass `rotate=True` to
`DeepseekCompressor`, but `DeepseekCompressor.rotate` is stored and never
read — a dead parameter. The fused Triton kernels
(`fused_indexer_q.py` fp8/mxfp4 Q, `fused_compress_quant_cache.py` fp8/mxfp4 K)
apply RoPE and then quantize directly, skipping the Hadamard rotation that the
official DeepSeek-V4 inference reference applies to the indexer path:

- `inference/model.py` in `deepseek-ai/DeepSeek-V4-Flash-0731`:
  `rotate_activation(...)` (fast_hadamard_transform, scale = dim^-0.5, bf16)
  is applied to indexer Q and to the indexer K compressor (`rotate=True`).
  (The main-attention 512-dim compressor uses `rotate=False` and is untouched
  here.)
- SGLang's DSA indexer does the same (`_get_k_bf16` -> `rotate_activation` /
  `hadamard_transform`).

Because the rotation mixes each 128-dim vector before per-group quantization,
skipping it changes the quantized values themselves, not only their rounding —
the indexer top-k selection (and thus which tokens sparse attention attends
to) can diverge from the reference implementation.

## Fix

Apply the Sylvester Hadamard rotation (scaled by `head_dim**-0.5`) in all
four indexer kernels, after RoPE + bf16 round-trip and before quantization:

- Q kernels (`fused_indexer_q.py`): masked full-width GPT-J RoPE -> bf16
  round-trip -> rotate -> fp8 / mxfp4 (per-32-block e2m1) quantization.
- K kernels (`fused_compress_quant_cache.py`): same rotation inserted after
  RoPE + bf16 round-trip, before fp8 / mxfp4 cache quantization.

The rotation is orthogonal and applied to **both** Q and K, so indexer QK dot
products are preserved (a property test asserts this); only the quantized
representations change. Indexer cache contents change bit-wise for DSv4
deployments — that is the intended alignment with the reference
implementation.

**Dimension gating (no env, no opt-in).** The kernels take a `HADAMARD`
constexpr and the launchers set it when `head_dim == 128 and rope_dim == 64`
(the production DSv4 indexer config). Off-dims configs keep main's exact
behavior: the original Triton code paths are preserved (the 128/64
`static_assert`s are scoped to the `HADAMARD` branch) and the Q launcher's
cutedsl dispatch still serves the dims it served on main. Main's own
generality envelope is unchanged — its fp8 Triton kernel needs a power-of-2
nope dim, and its mxfp4 Q launcher needs `head_dim % 128 == 0` for the int32
scale view. (Note: the cutedsl indexer-Q kernels are effectively
production-dims only — at (96, 32) main's cutedsl fp8 path runs but diverges
from the unfused rope+quant reference; pre-existing on main, untouched here.)
Dimension-guard tests assert bit-exact parity with the unrotated reference
for off-dims configs (Q 96/32 fp8, Q 128/32 mxfp4, K 64/32 fp8+mxfp4).

## Implementation notes

- **Matrix-free fp32 butterfly, not a matrix multiply.** The rotation runs as
  7 fixed-order butterfly stages (`_hadamard_stage` x S=64..1 in
  `fused_indexer_q.py`), each a single elementwise fp32 add/sub, followed by
  the `128**-0.5` scale. Every step is reproducible with plain torch
  elementwise ops, so the unfused oracle in the tests matches the kernel
  bit-exactly at any token count and any `num_warps`. A broadcast-mul +
  `tl.sum` formulation is not bit-stable: torch eager switches reduction
  strategy with problem size, which broke oracle equality at large sizes
  (e.g. 257/1023 tokens x 64 heads). The full RoPE → bf16-roundtrip →
  rotation block is a single `@triton.jit` helper (`_rope_hadamard_full`,
  returning the rotated full-width vector) shared by all four indexer
  kernels, so the two Q and two K kernels cannot drift apart (post-review
  dedup; verified byte-identical before/after over 236M output elements).
- **Pinned FMA contraction.** The RoPE even/odd updates in all four indexer
  kernels now use explicit `tl.fma` on every platform, matching the
  contraction NVCC/HIP already apply in the unfused `rotary_embedding` flow.
  This removes the ROCm-only `USE_EXPLICIT_FMA` divergence and makes results
  independent of the `cos_sin_cache` dtype (bf16 vs fp32). The head=512
  kernels are not FMA-pinned (out of scope; their tests use `assert_close`).

## Scope and follow-ups

- **Only the head=128 indexer path rotates** (see Problem: reference uses
  `rotate=False` for the 512-dim compressor). The 512-wide kernels and the
  Triton/cutedsl 512 read paths are deliberately unchanged.
- **cutedsl**: the cutedsl indexer-Q kernels predate the rotation and would
  silently skip it, so for the rotated production dims (128/64) the launcher
  in `fused_indexer_q.py` always uses the Triton kernel (with a `NOTE` in
  code) until the cutedsl kernels implement the rotation; off-dims configs
  keep main's cutedsl dispatch (see "Dimension gating"). The cutedsl files
  themselves are untouched. Implementing the rotation there is a follow-up —
  it requires a cross-thread butterfly over the 8-thread subwarp that owns
  each 128-dim row, and bit-exact parity with the Triton path (their existing
  test asserts `torch.equal`).
- **XPU**: the closed-source
  `torch.ops.vllm.xpu_deepseek_fused_indexer_q_rope_{fp8,mxfp4}` ops still
  skip the rotation and need a follow-up from the XPU op owners. ROCm uses
  the Triton kernels and gets the rotation automatically.

## Test plan

Command (GB200, SM100; the `dsv4_hadamard_upstream_shim` conftest plugin only
redirects the dsv4 ops modules to this source tree):

```bash
CUDA_VISIBLE_DEVICES=3 VLLM_DSV4_CUTEDSL_OPS="" \
  PYTHONPATH=<shim-dir> python -m pytest -p dsv4_hadamard_upstream_shim \
  tests/kernels/test_fused_indexer_hadamard.py \
  tests/kernels/test_fused_indexer_q_rope_quant.py \
  tests/kernels/test_compressor_kv_cache.py -q
```

Test changes:

- `tests/kernels/test_fused_indexer_hadamard.py` (new): bit-exact Q and K
  tests against unfused oracles — fp64 FMA emulation for RoPE, a butterfly
  oracle for the rotation, an independent per-row ue8m0 oracle for fp8 (not
  `per_token_group_quant_fp8`) — plus the orthogonality property test
  (H symmetric, H@H = 128*I exact, fp64 QK dot product preserved) and a
  quantization-quality property test: on outlier-heavy post-RoPE-like
  activations the rotated kernels' QK dot-product quant error is <0.5x the
  unrotated oracle's (measured 0.21 fp8 / 0.25 mxfp4; main's kernels are
  identical to that oracle, i.e. ratio ~1.0, so the test fails on main),
  and neutral (ratio in [0.8, 1.25], measured ~1.00) on iid Gaussian input. The Q-side
  oracle resolves the fp8 flavor at runtime via `current_platform.fp8_dtype()`
  (fnuz/224 on gfx942, e4m3fn/448 elsewhere), mirroring the launcher; the
  K-side oracle keeps e4m3fn/448 because the K kernels pin `tl.float8e4nv`
  on every platform.
- `tests/kernels/test_fused_indexer_q_rope_quant.py`: oracle rewritten to
  rope -> bf16 round-trip -> Hadamard -> quant; the `use_cutedsl`
  parametrization is dropped since the launcher no longer dispatches to
  cutedsl for indexer Q.
- `tests/kernels/test_compressor_kv_cache.py`: reference gains
  `rotate: bool` (fp64 FMA emulation + butterfly oracle); the indexer test
  passes `rotate=True` and launches with `num_warps=1` like the production
  launcher.

## Test result

**Kernel suites**: **82 passed, 11 skipped** (all skips are pre-existing
ROCm/gfx950-only gates). Breakdown: hadamard 15 + q_rope_quant 20 +
compressor 47. Lint: `ruff format --check` clean on all 5 touched files
(ruff 0.14.0).

**Quantization quality on real indexer activations** (why the rotation
matters). We captured the actual post-RoPE indexer Q and compressor-K
vectors from the official reference implementation (torchrun TP4, synthetic
8192-token input, layers 2/22/40) and measured quantization quality with and
without the rotation:

- Real indexer Q is firmly in the outlier regime the reference's rotation
  targets: per-vector kurtosis 17.5-44.9 (iid Gaussian = 3), top-8 channels
  carry 24-34% of channel energy. After rotation: kurtosis 4.5-5.7, top-8
  share 9-13% — near-incoherent.
- QK dot-product error (the quantity the indexer actually consumes) improves
  in **every** layer x format cell: fp8 mean 1.25-1.46x (max 2.0-2.6x);
  mxfp4 mean 1.18-1.66x (p99 up to 2.0x). Rotation exactness: max
  |dot(qH,kH) - dot(q,k)| = 1.6e-5.
- Post-rotation, real vectors quantize exactly like norm-matched iid Gaussian
  vectors (relL2 ratio 0.97-1.02 over all 12 layer x format cells) — the
  rotation closes the gap to the incoherent bound, which is the mechanism by
  which it stabilizes indexer top-k selection.
- fp8 per-vector relL2 is rotation-neutral (0.0264 vs 0.0264): expected for a
  floating-point format whose per-row scale absorbs outliers into the
  exponent — the fp8 gain appears in dot products (error deconcentration),
  not per-element MSE. mxfp4 (4-bit, 32-dim blocks, ~4.6-binade dynamic
  range per block) improves per-vector as well (layer-22 Q p99 relL2
  0.377 -> 0.288).

**E2E accuracy vs the reference implementation** (synthetic programmatic
8192-token technical document, identical raw token ids fed to both sides;
reference = official open-source `inference/` stack, torchrun TP4,
full-position top-20 logprobs; vLLM = this branch, TP4,
`/v1/completions?prompt_logprobs=20`, 8191 aligned positions): top-1
agreement 95.0%; on behavior-relevant tokens (reference logprob > -2) median
|dlogprob| 0.0000 nats, p95 0.114 nats; teacher-forced actual-token mean
|dlogprob| 0.013 nats. On bulk text the rotated and unrotated configs are
nearly indistinguishable end-to-end (top-1 agreement with the reference
95.04% vs 95.01%) — expected, since top-2048-of-8192 selection is permissive
and bulk argmax margins are large. The fix's value is algorithmic parity with
the reference (a dead `rotate` parameter is not merely suboptimal, it is
unimplemented behavior) plus the quantization-quality gains above, with no
e2e regression.

**Performance.** Kernel latency (GB200, median of 50 iters, committed
branch vs main): Q kernels within ±5% at all token counts (several faster,
e.g. fp8 @37 tokens -12.6%); K kernels within ±5% except mxfp4 @16384 tokens
+8.2% (absolute ~2-4 us per 16k tokens, ~0.2 ns/token — the intrinsic cost of
the added rotation in the mxfp4 kernel). E2E serving (TP4, spec decode,
synthetic 8k input): ITL 15.12 vs 15.15 ms/step (-0.18%, within run-to-run
jitter). The rotation itself is performance-neutral: an earlier revision that
also bumped the indexer kernels to num_warps=4 regressed K by +404% at 16k
tokens; the committed branch keeps num_warps=1 and matches or beats main.

## Why this is not a duplicate

Checked 2026-09-05 via the GitHub search API (`gh` CLI unavailable in this
environment) for open PRs in vllm-project/vllm: `hadamard indexer`,
`deepseek indexer rotate`, `rotate_activation`, `hadamard` (16 hits). No open
PR addresses this fix. The only nominal indexer hit is #41834 ("[New
Model][Nvidia] Add SM12x support for DeepSeek V4 Flash"), a different scope —
SM12x enablement for another DSv4 variant; its body contains no
Hadamard/rotation change to these kernels. All other `hadamard` hits are
unrelated quantization work (AutoRound MXFP4, humming, QuIP/hadacore,
TurboQuant, KVarN).

## AI assistance

This change was developed with AI assistance (Kimi Code CLI): implementation,
test rewrites, and this description were authored by the agent and reviewed by
the human submitter.
