### PR TITLE
[Bugfix][Rust Frontend][Parser] Preserve text between GLM XML tool calls

### DIFF
--- a/rust/src/parser/src/tool/glm_xml/glm47_moe.rs
+++ b/rust/src/parser/src/tool/glm_xml/glm47_moe.rs
@@ -44,11 +44,12 @@ impl ToolParser for Glm47MoeToolParser {
 
 #[cfg(test)]
 mod tests {
+    use expect_test::expect;
     use serde_json::{Value, json};
 
     use super::Glm47MoeToolParser;
-    use crate::tool::ToolParserTestExt as _;
     use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
+    use crate::tool::{ToolParser as _, ToolParserOutput, ToolParserTestExt as _};
 
     fn glm47_tool_call(function_name: &str, params: &[(&str, &str)]) -> String {
         let params = params
@@ -101,6 +102,64 @@ mod tests {
             serde_json::from_str::<Value>(&output.calls()[1].arguments).unwrap(),
             json!({"x": 1, "y": 2})
         );
+    }
+
+    #[test]
+    fn glm47_preserves_text_between_tool_calls_across_chunk_boundaries() {
+        let input = format!(
+            "{}\nsome text\n{}\ndone",
+            glm47_tool_call("get_weather", &[("city", "Paris")]),
+            glm47_tool_call("add", &[("x", "1")]),
+        );
+        let parse = |chunks: &[&str]| -> ToolParserOutput {
+            let mut parser = Glm47MoeToolParser::new(&test_tools());
+            let mut output = ToolParserOutput::default();
+            for chunk in chunks {
+                parser.parse_into(chunk, &mut output).unwrap();
+            }
+            output.append(parser.finish().unwrap());
+            output
+        };
+
+        let expected = parse(&[&input]);
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"Paris\"}",
+                        },
+                    ),
+                    Text(
+                        "\nsome text\n",
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 1,
+                            name: Some(
+                                "add",
+                            ),
+                            arguments: "{\"x\":1}",
+                        },
+                    ),
+                    Text(
+                        "\ndone",
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&expected);
+
+        for (split, _) in input.char_indices().skip(1) {
+            assert_eq!(parse(&[&input[..split], &input[split..]]), expected);
+        }
+        for chunk_chars in [1, 2, 3, 5, 7, 11] {
+            assert_eq!(parse(&split_by_chars(&input, chunk_chars)), expected);
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/tool/glm_xml/mod.rs
+++ b/rust/src/parser/src/tool/glm_xml/mod.rs
@@ -5,7 +5,7 @@ use winnow::ascii::multispace0 as ws0;
 use winnow::combinator::{alt, eof, repeat, seq, terminated};
 use winnow::prelude::*;
 use winnow::stream::Partial;
-use winnow::token::{literal, rest, take_until, take_while};
+use winnow::token::{literal, take_until, take_while};
 
 use super::parameters::ToolSchemas;
 use super::utils::{MarkerScanState, parse_buffered_event, safe_text_len, take_until_marker};
@@ -31,7 +31,6 @@ type GlmInput<'i> = Partial<&'i str>;
 enum GlmMode {
     Text,
     ToolCall { tool_call_end_scan: MarkerScanState },
-    AfterToolCall,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,7 +53,6 @@ enum GlmEvent {
         name: String,
         raw_params: Vec<(String, String)>,
     },
-    IgnoredRest,
 }
 
 /// Tool parser core for GLM XML-style tool calls.
@@ -90,7 +88,7 @@ impl GlmXmlToolParser {
                 };
             }
             GlmEvent::ToolCall { name, raw_params } => {
-                self.mode = GlmMode::AfterToolCall;
+                self.mode = GlmMode::Text;
                 let arguments = self.tool_parameters.convert_params_with_schema(&name, raw_params);
                 let arguments = serde_json::to_string(&arguments)
                     .map_err(|error| parsing_failed!("failed to serialize arguments: {}", error))?;
@@ -102,7 +100,6 @@ impl GlmXmlToolParser {
                 });
                 self.emitted_tool_count += 1;
             }
-            GlmEvent::IgnoredRest => {}
         }
         Ok(())
     }
@@ -134,7 +131,6 @@ impl GlmXmlToolParser {
                 GlmMode::ToolCall { .. } => {
                     return Err(parsing_failed!("incomplete GLM MoE tool call"));
                 }
-                GlmMode::AfterToolCall => {}
             }
         }
         let _ = self.reset();
@@ -153,7 +149,6 @@ fn parse_next_glm_event(
         GlmMode::ToolCall { tool_call_end_scan } => {
             tool_call_event(input, separator, tool_call_end_scan)
         }
-        GlmMode::AfterToolCall => after_tool_call_event(input),
     }
 }
 
@@ -170,17 +165,6 @@ fn tool_call_start_event(input: &mut GlmInput<'_>) -> ModalResult<GlmEvent> {
 /// Parse a safe text run before the next GLM marker.
 fn safe_text_event(input: &mut GlmInput<'_>) -> ModalResult<GlmEvent> {
     safe_text_len(input, TOOL_CALL_START).map(|len| GlmEvent::Text { len })
-}
-
-/// Parse text after a completed GLM tool call.
-fn after_tool_call_event(input: &mut GlmInput<'_>) -> ModalResult<GlmEvent> {
-    ws0.void().parse_next(input)?;
-    alt((tool_call_start_event, ignored_rest_event)).parse_next(input)
-}
-
-/// Parse a trailing rest after GLM tool calls.
-fn ignored_rest_event(input: &mut GlmInput<'_>) -> ModalResult<GlmEvent> {
-    rest.value(GlmEvent::IgnoredRest).parse_next(input)
 }
 
 /// Parse a complete GLM tool call.
@@ -324,7 +308,7 @@ mod tests {
         let chunks = split_by_chars(&output, 11);
         let output = collect_stream(&mut parser, &chunks);
 
-        assert_eq!(output.normal_text(), "");
+        assert_eq!(output.normal_text(), "\n");
         assert_eq!(output.calls().len(), 2);
         assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
         assert_eq!(output.calls()[1].name.as_deref(), Some("add"));
@@ -429,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn glm45_streaming_ignores_trailing_text_after_tool_calls() {
+    fn glm45_streaming_preserves_trailing_text_after_tool_calls() {
         let mut parser = Glm45MoeToolParser::new(&test_tools());
 
         let output = collect_stream(
@@ -440,7 +424,7 @@ mod tests {
             )],
         );
 
-        assert_eq!(output.normal_text(), "");
+        assert_eq!(output.normal_text(), "<|endoftext|>");
         assert_eq!(output.calls().len(), 1);
     }
 }


### PR DESCRIPTION



## Purpose

  The Rust GLM XML tool parser entered a special post-call state after parsing
  the first `</tool_call>`. When ordinary text and another `<tool_call>` appeared
  in the same buffered chunk, the remaining buffer was consumed without
  producing the text or parsing the later call.

  For example:

  ```
  <tool_call>first...</tool_call>
  intermediate text
  <tool_call>second...</tool_call>
```

  The result depended on chunk boundaries: parsing the output in one chunk could
  return only the first call, while some streaming splits returned both calls.

  Return the GLM XML parser to text mode after every completed tool call.
  Intermediate and trailing text is now preserved, later tool calls are parsed
  normally, and equivalent input produces the same event sequence regardless of
  chunk boundaries. The behavior also matches the Python GLM parser.

## Test Plan

```
cargo nextest run -p vllm-parser glm47_preserves_text_between_tool_calls_across_chunk_boundaries

cargo nextest run -p vllm-parser  'tool::glm_xml::'
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

