### PR TITLE
[Bugfix] Fall back to T1 when ARC cannot reclaim enough entries from T2

### DIFF
--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -782,6 +782,61 @@ class TestARCPolicy:
         assert counting_t1.items_yielded == len(t1_order)
         assert counting_t2.items_yielded == len(t2_order)
 
+    @pytest.mark.parametrize(
+        "pinned, protected, new_keys, expected_evicted",
+        [
+            ([], [], [7, 8, 9], [6, 5, 3]),
+            ([], [], [7, 8, 9, 10], [6, 5, 3, 4]),
+            ([5, 6], [], [7, 8], [3, 4]),
+            ([], [5, 6], [7, 8], [3, 4]),
+            ([5, 6], [3], [7], [4]),
+            ([5, 6], [3], [7, 8], None),
+        ],
+    )
+    def test_store_falls_back_to_t1_when_t2_cannot_satisfy_eviction(
+        self, pinned, protected, new_keys, expected_evicted
+    ):
+        """A preference for T2 must not reject stores that can reclaim T1."""
+        manager, policy = self._make_manager(enable_events=False)
+        for keys in ([1, 2, 3, 4], [5, 6]):
+            assert manager.prepare_store(to_keys(keys), _EMPTY_REQ_CTX) is not None
+            manager.complete_store(to_keys(keys), _EMPTY_REQ_CTX)
+
+        # Ghost hits raise the target to 3; promotion leaves only 2 entries in T1.
+        manager.touch(to_keys([1, 2]), _EMPTY_REQ_CTX)
+        manager.touch(to_keys([1]), _EMPTY_REQ_CTX)
+        manager.touch(to_keys([5, 6]), _EMPTY_REQ_CTX)
+        assert policy.target_t1_size == 3
+        assert list(policy.t1) == to_keys([3, 4])
+        assert list(policy.t2) == to_keys([6, 5])
+        manager.prepare_load(to_keys(pinned), _EMPTY_REQ_CTX)
+
+        counting_t1 = _CountingOrderedDict(policy.t1)
+        counting_t2 = _CountingOrderedDict(policy.t2)
+        policy.t1 = counting_t1
+        policy.t2 = counting_t2
+        before = [list(q.items()) for q in (policy.t1, policy.t2, policy.b1, policy.b2)]
+        counting_t1.items_yielded = counting_t2.items_yielded = 0
+        output = manager.prepare_store(to_keys(protected + new_keys), _EMPTY_REQ_CTX)
+        assert counting_t1.items_yielded <= len(before[0])
+        assert counting_t2.items_yielded <= len(before[1])
+
+        if expected_evicted is None:
+            assert output is None
+            assert [
+                list(q.items()) for q in (policy.t1, policy.t2, policy.b1, policy.b2)
+            ] == before
+        else:
+            assert output is not None
+            assert output.keys_to_store == to_keys(new_keys)
+            assert output.evicted_keys == to_keys(expected_evicted)
+            manager.complete_store(to_keys(new_keys), _EMPTY_REQ_CTX)
+            for key in new_keys:
+                assert manager.lookup(to_key(key), _EMPTY_REQ_CTX) is LookupResult.HIT
+        for key in pinned + protected:
+            assert manager.lookup(to_key(key), _EMPTY_REQ_CTX) is LookupResult.HIT
+        manager.complete_load(to_keys(pinned), _EMPTY_REQ_CTX)
+
     def test_batch_eviction_failure_is_atomic(self):
         """Finding only some candidates must not partially evict the cache."""
         cpu_manager, arc_policy = self._make_manager(num_blocks=4, enable_events=False)

--- a/vllm/v1/kv_offload/cpu/policies/arc.py
+++ b/vllm/v1/kv_offload/cpu/policies/arc.py
@@ -145,9 +145,15 @@ class ARCCachePolicy(CachePolicy):
 
             if candidate is None:
                 entry = next_candidate(t2_iter)
+                if entry is not None:
+                    candidate = (*entry, False)
+
+            if candidate is None:
+                entry = next_candidate(t1_iter)
                 if entry is None:
                     return None
-                candidate = (*entry, False)
+                candidate = (*entry, True)
+                virtual_t1_size -= 1
 
             candidates.append(candidate)
 


### PR DESCRIPTION
## Purpose

CPU KV offload stores can fail even when ARC has enough evictable entries. When T1 is below its adaptive target, eviction prefers T2 but currently returns `None` once T2 has no eligible candidates. This also occurs partway through a batch, or when T2 entries are pinned or protected.

Fall back to eligible T1 entries after exhausting T2. Preserve the existing preference order, monotonic queue scans, pin/protection rules, and atomic failure when the total candidate count is insufficient. Add six parameterized cases to the existing manager suite using normal stores and ghost hits to reproduce the adaptive state.

Duplicate-work checks on 2026-09-05 found no open PR implementing this CPU ARC fallback. #50422 adds session-aware policy context without fixing this selection path; #40270 targets GPU BlockPool ARC; #51787 concerns LRU transfer ordering. This change preserves the single-pass optimization merged in #50992.

AI assistance was used to investigate, implement, and test this change.

## Test Plan

Tested against upstream `7fbd44cbe0a90b9c8fd3a94a0f0401ac4b1bc719` on Linux with Python 3.12.13 and PyTorch 2.13.0+cu130. The isolated checkout imports its own upstream Python source and reuses dependencies and binary extensions from an existing vLLM 0.28.0 installation.

```bash
# Baseline: original ARC implementation with the new regression test.
CUDA_VISIBLE_DEVICES="" OMP_NUM_THREADS=1 .venv/bin/python -m pytest -q tests/v1/kv_offload/cpu/test_manager.py -k test_store_falls_back_to_t1_when_t2_cannot_satisfy_eviction --timeout=60

# Fixed implementation.
CUDA_VISIBLE_DEVICES="" OMP_NUM_THREADS=1 .venv/bin/python -m pytest -q tests/v1/kv_offload/cpu/test_manager.py --timeout=60
CUDA_VISIBLE_DEVICES="" OMP_NUM_THREADS=1 .venv/bin/python -m pytest -q tests/v1/kv_offload/cpu/policies/test_factory.py tests/v1/kv_offload/tiering/test_tiering_offloading.py --timeout=60
```

## Test Result

- Baseline regression: 5 failed, 1 passed. All five requests with sufficient eligible capacity failed; the insufficient-capacity control passed.
- Fixed manager suite: 34 passed.
- Policy factory and tiering suites: 62 passed.
- Ruff check/format, typos, mypy for Python 3.10–3.13, and the applicable repository validation hooks passed individually on the two changed files; `git diff --check` passed.
- The bulk pre-commit invocation was blocked during unrelated Actionlint environment installation by TLS/download timeouts. Applicable Python checks were subsequently run individually using the unmodified repository configuration.

These are CPU unit tests. No model evaluation, GPU test, or end-to-end offload throughput benchmark was run; no performance or model-quality claim is made.
