### PR TITLE
[Bugfix][Qwen3.8-Flash-Next] Honour the state_indices stride in the PLE short-conv kernels

### DIFF
--- a/tests/models/qwen4_exp/test_ple_conv_strided_state_indices.py
+++ b/tests/models/qwen4_exp/test_ple_conv_strided_state_indices.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The PLE short-conv kernels must honour the stride of ``state_indices``.
+
+With speculative decoding configured the Mamba block table carries
+``1 + num_speculative_blocks`` columns per request, and the base Mamba metadata
+builder hands the prefill state slots to the layer as the strided column view
+``block_table[:, 0]``. A unit-stride load resolved request ``r`` to
+``block_table[0, r]`` -- request 0's speculative checkpoint blocks -- so every
+request after the first in a prefill-only step wrote its conv state into the
+wrong slot and decoded from an unwritten one.
+"""
+
+import pytest
+import torch
+
+from vllm.models.qwen4_exp.nvidia.ops.ple import ple_conv
+from vllm.platforms import current_platform
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Triton kernel")
+@pytest.mark.parametrize("num_columns", [2, 4])
+def test_prefill_state_store_honours_state_index_stride(num_columns: int):
+    torch.manual_seed(0)
+    device = "cuda"
+    num_reqs, tokens_per_req, channels, kernel = 3, 12, 64, 4
+    dilation, state_len = 1, (kernel - 1) * 1
+    # Block 0 is the null slot; rows r*num_columns+1 are the primary slots, the
+    # other columns stand in for speculative checkpoint blocks and must never
+    # receive a prefill state.
+    num_blocks = num_reqs * num_columns + 1
+    table = torch.arange(1, num_blocks, device=device, dtype=torch.int32).view(
+        num_reqs, num_columns
+    )
+    strided = table[:, 0]
+    assert strided.stride(0) == num_columns
+    contiguous = strided.contiguous()
+
+    x = torch.randn(
+        num_reqs * tokens_per_req, channels, device=device, dtype=torch.bfloat16
+    )
+    w = torch.randn(channels, kernel, device=device, dtype=torch.bfloat16)
+    qsl = torch.arange(
+        0,
+        (num_reqs + 1) * tokens_per_req,
+        tokens_per_req,
+        device=device,
+        dtype=torch.int32,
+    )
+    has_init = torch.zeros(num_reqs, device=device, dtype=torch.bool)
+
+    def run(state_indices: torch.Tensor):
+        state = torch.zeros(
+            num_blocks, channels, state_len, device=device, dtype=torch.bfloat16
+        )
+        residual = torch.zeros_like(x)
+        ple_conv(
+            inputs=x,
+            residual=residual,
+            conv_state=state,
+            conv_weights=w,
+            state_indices=state_indices,
+            mode="prefill",
+            dilation=dilation,
+            query_start_loc=qsl,
+            has_initial_states=has_init,
+        )
+        return state, residual
+
+    state_ref, out_ref = run(contiguous)
+    state_got, out_got = run(strided)
+    torch.testing.assert_close(out_got, out_ref)
+    torch.testing.assert_close(state_got, state_ref)
+    # Every primary slot written, every checkpoint slot untouched.
+    for r in range(num_reqs):
+        assert state_ref[table[r, 0]].abs().sum() > 0
+        for c in range(1, num_columns):
+            assert state_ref[table[r, c]].abs().sum() == 0
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Triton kernel")
+@pytest.mark.parametrize("num_columns", [2, 4])
+def test_decode_state_read_honours_state_index_stride(num_columns: int):
+    """Decode reads the previous state through the same lookup; a strided index
+    vector must select the same slots as its contiguous copy."""
+    torch.manual_seed(1)
+    device = "cuda"
+    num_reqs, channels, kernel = 3, 64, 4
+    dilation, state_len = 1, (kernel - 1) * 1
+    num_blocks = num_reqs * num_columns + 1
+    table = torch.arange(1, num_blocks, device=device, dtype=torch.int32).view(
+        num_reqs, num_columns
+    )
+    strided = table[:, 0]
+    assert strided.stride(0) == num_columns
+    contiguous = strided.contiguous()
+
+    x = torch.randn(num_reqs, channels, device=device, dtype=torch.bfloat16)
+    w = torch.randn(channels, kernel, device=device, dtype=torch.bfloat16)
+    has_init = torch.ones(num_reqs, device=device, dtype=torch.bool)
+    # Distinct non-zero history in every slot, so a wrong slot changes the output.
+    state_init = torch.randn(
+        num_blocks, channels, state_len, device=device, dtype=torch.bfloat16
+    )
+
+    def run(state_indices: torch.Tensor):
+        state = state_init.clone()
+        residual = torch.zeros_like(x)
+        ple_conv(
+            inputs=x,
+            residual=residual,
+            conv_state=state,
+            conv_weights=w,
+            state_indices=state_indices,
+            mode="decode",
+            dilation=dilation,
+            has_initial_states=has_init,
+        )
+        return state, residual
+
+    state_ref, out_ref = run(contiguous)
+    state_got, out_got = run(strided)
+    torch.testing.assert_close(out_got, out_ref)
+    torch.testing.assert_close(state_got, state_ref)

--- a/vllm/models/qwen4_exp/nvidia/ops/ple.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/ple.py
@@ -323,6 +323,7 @@ def _ple_conv_kernel(
     w_ptr,
     residual_ptr,
     state_idx_ptr,
+    state_idx_stride,
     qsl_ptr,
     num_acc_ptr,
     has_init_ptr,
@@ -386,7 +387,7 @@ def _ple_conv_kernel(
         else:
             slot_off = tl.full([], 0, tl.int32)
 
-    sid = tl.load(state_idx_ptr + r).to(tl.int64)
+    sid = tl.load(state_idx_ptr + r * state_idx_stride).to(tl.int64)
     state_ok = sid != NULL_STATE_ID
     sid_safe = tl.where(state_ok, sid, 0)
     if HAS_INIT:
@@ -479,6 +480,7 @@ def _ple_conv_writeback_kernel(
     x_ptr,
     state_ptr,
     state_idx_ptr,
+    state_idx_stride,
     qsl_ptr,
     num_acc_ptr,
     has_init_ptr,
@@ -501,7 +503,7 @@ def _ple_conv_writeback_kernel(
     c_offs = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
     c_mask = c_offs < C
 
-    sid = tl.load(state_idx_ptr + r).to(tl.int64)
+    sid = tl.load(state_idx_ptr + r * state_idx_stride).to(tl.int64)
     state_ok = sid != NULL_STATE_ID
     if not state_ok:
         return
@@ -621,6 +623,7 @@ def ple_conv(
         conv_weights,
         residual,
         state_indices,
+        state_indices.stride(0),
         query_start_loc,
         num_accepted_tokens,
         has_initial_states,
@@ -649,6 +652,7 @@ def ple_conv(
             inputs,
             conv_state,
             state_indices,
+            state_indices.stride(0),
             query_start_loc,
             num_accepted_tokens,
             has_initial_states,


### PR DESCRIPTION
## Purpose

Fixes the output corruption behind #55357 (and, on this box, findings 126–130 of our record): with MTP configured, any scheduler step that prefills **two or more** requests leaves every request after batch row 0 with garbage from its second token on, and draft acceptance at ~9 % for the rest of the request. Prefix cache on or off, `--enforce-eager`, `num_speculative_tokens` 1 or 3, and prompt length make no difference; without speculation the same steps are clean; with a speculating decode row in front of the prefills they are clean too.

## Root cause

With speculative decoding configured the Mamba block table has `1 + num_speculative_blocks` columns per request (`mamba_get_block_table_tensor`, cache mode `none`). The base Mamba metadata builder passes the prefill state slots as the column view `state_indices_tensor_p = state_indices_tensor_p[:, 0]` (`vllm/v1/attention/backends/mamba_attn.py`), which is strided. The PLE short-conv kernels loaded the per-request slot as `tl.load(state_idx_ptr + r)`, so prefill row r ≥ 1 resolved `block_table[0, r]` — request 0's speculative checkpoint blocks. Its conv state went there, request 0's speculative steps overwrote it, and the request's decode read its correct, never-written slot. Row 0 is right, rows 1..3 die, row 4 lands in request 1's unused primary block and survives — the counts we measured. Without speculation the table has one column (contiguous view); with a speculating request in the batch the spec branch gathers the indices by advanced indexing (contiguous) — the two clean cases.

## Change

Both PLE conv kernels take `state_idx_stride` and index `state_idx_ptr + r * state_idx_stride`; the wrapper passes `state_indices.stride(0)`. No change for a contiguous vector.

## Test

`tests/models/qwen4_exp/test_ple_conv_strided_state_indices.py`: prefill store and decode read with a strided column view of a 2- and 4-column table against the contiguous copy; identical residual and state, primary slots written, checkpoint slots untouched. Before the fix the strided prefill writes requests 1 and 2 into request 0's columns and the strided decode reads their history from there (4 of 4 cases fail on the stock kernel, pass with the change).

End to end on a GB10 (DGX Spark, sm_121, TP1, nightly dev401), simultaneous pairs/triples, `temperature 0`, 128 tokens: stock 30–50 % of cells with a corrupted request (finding 127); with this change: **0 corrupted of 20 cells** (c=2 ×10, c=3 ×6, c=5 ×4; `acceptcell9`), and the state-index vector was observed arriving with stride 4 in both prefill and decode mode.

## Notes for reviewers

- Same class as #51682 (merged 2026-08-10), which threaded `stride_state_indices` into the AMD KDA packed-decode kernel for the same `block_table_tensor[:, 0]` view; #52207 and #51680 tried `.contiguous()` coercion for it and were closed in favour of passing the stride. Those kernels rejected a strided input; the PLE kernels used the wrong slot silently, which is why this one surfaced as output corruption rather than an error.
- The builder-side view is shared by every Mamba-style backend; `causal_conv1d_fn` and the GDN paths are stride-aware or index through torch, so only the PLE kernels were affected here. A `.contiguous()` at the builder would also hide it, at the cost of a copy per step; the kernel change is the precise fix.
- The draft model is not involved: the corruption reproduces with the drafter's forward skipped entirely (zero drafts), with the draft indexer on the unfused path, and with the drafter's ring commit withheld.

---

The code and this description were written with AI assistance (Claude); every line was reviewed by me and all measurements were run by me on the hardware named above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SuBgdp87NbfLbiigmzn1z
