### PR TITLE
[Perf][Attention] Vectorize causal-conv metadata offsets

### DIFF
--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -19,7 +19,7 @@ from vllm.config import CacheConfig, VllmConfig, get_layers_from_vllm_config
 from vllm.config.cache import _layout_from_name
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
 from vllm.utils.math_utils import cdiv
-from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d, np_to_pinned_tensor
+from vllm.utils.torch_utils import async_tensor_h2d, np_to_pinned_tensor
 from vllm.v1.kv_cache_interface import KVCacheLayout, KVCacheSpec, MambaSpec
 
 if TYPE_CHECKING:
@@ -1050,18 +1050,25 @@ def compute_causal_conv1d_metadata(
     token_chunk_offset_ptr = None
     for BLOCK_M in [8]:  # cover all BLOCK_M values
         nums = -(-seqlens // BLOCK_M)
+        nums_np = nums.numpy()
         nums_dict[BLOCK_M] = {}
         nums_dict[BLOCK_M]["nums"] = nums
-        nums_dict[BLOCK_M]["tot"] = nums.sum().item()
-        mlist = np_to_pinned_tensor(np.repeat(np.arange(len(nums)), nums))
+        num_chunks = int(nums_np.sum())
+        nums_dict[BLOCK_M]["tot"] = num_chunks
+        mlist = np_to_pinned_tensor(np.repeat(np.arange(len(nums_np)), nums_np))
         nums_dict[BLOCK_M]["mlist"] = mlist
         mlist_len = len(nums_dict[BLOCK_M]["mlist"])
         nums_dict[BLOCK_M]["mlist_len"] = mlist_len
         MAX_NUM_PROGRAMS = max(1024, mlist_len) * 2
-        offsetlist = []  # type: ignore
-        for idx, num in enumerate(nums):
-            offsetlist.extend(range(num))
-        offsetlist = torch.tensor(offsetlist, dtype=torch.int32, pin_memory=PIN_MEMORY)
+        # Build the per-row chunk offsets without a Python loop.  For a row
+        # with ``num`` chunks, the global chunk indices are shifted by the
+        # number of chunks in preceding rows, so subtracting the repeated
+        # row starts yields ``0, ..., num - 1`` for every row.
+        chunk_starts = np.cumsum(nums_np, dtype=np.int64) - nums_np
+        offsetlist = (
+            np.arange(num_chunks, dtype=np.int64) - np.repeat(chunk_starts, nums_np)
+        ).astype(np.int32, copy=False)
+        offsetlist = np_to_pinned_tensor(offsetlist)
         nums_dict[BLOCK_M]["offsetlist"] = offsetlist
 
         if batch_ptr is None:


### PR DESCRIPTION
## Purpose

`compute_causal_conv1d_metadata` builds the per-chunk offsets used by causal-convolution prefill kernels. The current implementation creates these offsets with a Python loop that calls `extend(range(...))` once for every sequence. This host-side work grows with both the prefill batch size and the total number of 8-token chunks, delaying the following Triton launch.

This change derives the same per-row offsets with NumPy prefix sums and repeated row starts, then keeps the result in the existing pinned `int32` staging-tensor path. The metadata contract and kernel inputs are unchanged. The helper is shared by Mamba, GDN, ShortConv, and Kimi K3 attention backends.

## Test Plan

Existing kernel regression suite and changed-file checks:

```bash
pytest -q tests/kernels/mamba/test_causal_conv1d.py --tb=short
pre-commit run --files vllm/v1/attention/backends/utils.py
```

The metadata output was also compared with the original implementation over 2,000 randomized CPU cases, including empty batches, zero-length rows, mixed chunk counts, and both `int32` and `int64` cumulative-length inputs. The resulting metadata was exercised through `causal_conv1d_fn` on an NVIDIA A100 over four targeted variable-length batches, with kernel output and convolution-state updates bitwise identical to the inline/original metadata path.

End-to-end metadata construction benchmark on an NVIDIA A100 PCIe 40GB, including device-buffer allocation, metadata H2D copies, and CUDA synchronization. Sequence lengths are equal within each row. Results are medians of 100 measured iterations after 10 warmups (30 iterations for the two largest rows):

| batch | sequence length | total tokens | 8-token chunks | before (µs) | after (µs) | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 2048 | 2048 | 256 | 222.29 | 208.39 | 1.07x |
| 8 | 256 | 2048 | 256 | 233.52 | 210.69 | 1.11x |
| 32 | 64 | 2048 | 256 | 269.80 | 208.63 | 1.29x |
| 128 | 16 | 2048 | 256 | 412.35 | 211.10 | 1.95x |
| 1 | 8192 | 8192 | 1024 | 281.78 | 213.45 | 1.32x |
| 8 | 1024 | 8192 | 1024 | 285.98 | 214.37 | 1.33x |
| 32 | 256 | 8192 | 1024 | 321.63 | 213.91 | 1.50x |
| 128 | 64 | 8192 | 1024 | 466.03 | 215.82 | 2.16x |
| 32 | 2048 | 65536 | 8192 | 794.17 | 245.52 | 3.23x |
| 128 | 2048 | 262144 | 32768 | 2538.63 | 329.42 | 7.71x |
| 128 | 8192 | 1048576 | 131072 | 13789.55 | 802.64 | 17.18x |

## Test Result

All 164 existing causal-convolution kernel tests passed. The 2,000-case randomized metadata comparison and targeted A100 `causal_conv1d_fn` integration checks passed, and all production changed-file pre-commit checks passed.

## Duplicate-work check

Checked the open PR list for `causal_conv1d`, `causal conv`, and `offsetlist` on 2026-09-05. No open PR was found that changes `compute_causal_conv1d_metadata` or its host-side offset construction. Related work is separate: #52611 addresses a JIT specialization race in `causal_conv1d.py`, the merged #52388 optimizes Kimi K3 state metadata, and the open #50226 adds SM103-specific GDN kernels; none changes this shared metadata helper.

## AI-assisted contribution
AI assistance was used for this change.
