### PR TITLE
[Security] Drop NixlPush WRITEs after the producer request ends

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -341,6 +341,8 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         w._pending_completion_notifs = queue.Queue()
         w._evict_finished_inbox = queue.Queue()
         w._deferred_push_inbox = queue.Queue()
+        w._abandoned_push_lock = threading.Lock()
+        w._abandoned_push_ids = {}
         w._push_writer_wake = threading.Event()
         w._push_writer_stop = threading.Event()
         w._push_writer_thread = None
@@ -603,6 +605,96 @@ def test_do_start_push_kv_defers_then_writes_when_handshake_ready():
     assert meta.remote.request_id == "req-hs"
 
 
+def test_do_start_push_kv_drops_deferred_write_after_request_ends():
+    """If the producer lease ends while the P→D handshake is still
+    in flight, the completion callback must not queue a WRITE: those
+    source blocks may already have been reused by another request."""
+    w = _StubWriterWorker.fresh()
+    w._logical_to_kernel_block_ids = lambda x, ratio: x
+    xfer_calls: list[dict[str, Any]] = []
+    w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
+
+    fut: Future = Future()
+    w._ensure_handshake = lambda *a, **k: fut
+
+    rd = _registration_data("req-stale")
+    _real_do_start_push_kv(w, "req-stale", ([1, 2, 3],), rd)
+    w._abandon_push("req-stale")
+    fut.set_result(({(0, 0): "agent"}, 0.0))
+
+    assert w._deferred_push_inbox.qsize() == 0
+    assert xfer_calls == []
+    assert not w._push_writer_wake.is_set()
+
+
+def test_do_start_push_kv_skips_ready_write_after_request_ends():
+    """Handshake already ready: an expired/finished request must not
+    submit a WRITE from leftover logical block ids."""
+    w = _StubWriterWorker.fresh()
+    w._logical_to_kernel_block_ids = lambda x, ratio: x
+    xfer_calls: list[dict[str, Any]] = []
+    w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
+    w._ensure_handshake = lambda *a, **k: None
+    w._abandon_push("req-done")
+
+    _real_do_start_push_kv(w, "req-done", ([4, 5],), _registration_data("req-done"))
+
+    assert xfer_calls == []
+
+
+def test_push_reg_match_skips_write_after_request_ends():
+    """A PUSH_REG that matches leftover finished blocks must not WRITE
+    once the producer request has been abandoned."""
+    w = _StubWriterWorker.fresh()
+    w._logical_to_kernel_block_ids = lambda x, ratio: x
+    xfer_calls: list[dict[str, Any]] = []
+    w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
+    w._ensure_handshake = lambda *a, **k: None
+    w._push_finished_blocks["req-A"] = ([200, 201],)
+    w._abandon_push("req-A")
+    w._do_start_push_kv = (
+        lambda rid, blocks, rd: NixlPushConnectorWorker._do_start_push_kv(
+            w, rid, blocks, rd
+        )
+    )
+
+    notif = PUSH_REG_NOTIF_PREFIX + msgspec.msgpack.encode(_registration_data("req-A"))
+    w._handle_push_reg_notif(notif)
+
+    assert xfer_calls == []
+    assert w.start_push_calls == []
+
+
+def test_writer_loop_skips_abandoned_deferred_push():
+    """A deferred inbox entry for an abandoned request is dropped and
+    does not re-enter ``_do_start_push_kv``."""
+    w = _StubWriterWorker.fresh()
+    w.nixl_wrapper = MagicMock()
+    w.nixl_wrapper.get_new_notifs.return_value = {}
+    w._abandon_push("req-dead")
+
+    processed = threading.Event()
+
+    def _tracked(rid, blocks, rd):
+        w.start_push_calls.append((rid, blocks, rd))
+        processed.set()
+
+    w._do_start_push_kv = _tracked  # type: ignore[method-assign]
+    w._deferred_push_inbox.put(("req-dead", ([1, 2],), _registration_data("req-dead")))
+    w._push_writer_wake.set()
+
+    t = threading.Thread(target=w._push_writer_loop, daemon=True)
+    t.start()
+    try:
+        assert not processed.wait(timeout=1.0)
+    finally:
+        w._push_writer_stop.set()
+        w._push_writer_wake.set()
+        t.join(timeout=2)
+
+    assert w.start_push_calls == []
+
+
 def test_do_start_push_kv_drops_request_on_handshake_failure():
     """Handshake raises: the request is dropped (not re-queued, no WRITE) and
     the failure is logged. Blocks are reclaimed by the lease/watchdog, matching
@@ -759,6 +851,7 @@ class TestPushWriterNotifs:
             except queue.Empty:
                 break
         assert evicted == ["req-done"]
+        assert w._is_push_abandoned("req-done")
         assert w._push_writer_wake.is_set()
 
 

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -26,6 +26,7 @@ import threading
 import time
 from collections import defaultdict
 from concurrent.futures import Future
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -33,6 +34,7 @@ import msgspec
 import pytest
 
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    PUSH_FAIL_NOTIF_PREFIX,
     PUSH_REG_NOTIF_PREFIX,
     NixlAgentMetadata,
     NixlConnectorMetadata,
@@ -343,6 +345,15 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         w._deferred_push_inbox = queue.Queue()
         w._abandoned_push_lock = threading.Lock()
         w._abandoned_push_ids = {}
+        w._pending_handshake_callbacks = {}
+        w._abandoned_push_notified = set()
+        w._failed_write_reqs = set()
+        w._failed_recv_reqs = queue.Queue()
+        w._invalid_block_ids = queue.Queue()
+        w._is_hma_required = False
+        w.kv_cache_config = SimpleNamespace(kv_cache_groups=[object()])
+        w.xfer_stats = MagicMock()
+        w._handshake_lock = threading.RLock()
         w._push_writer_wake = threading.Event()
         w._push_writer_stop = threading.Event()
         w._push_writer_thread = None
@@ -605,12 +616,29 @@ def test_do_start_push_kv_defers_then_writes_when_handshake_ready():
     assert meta.remote.request_id == "req-hs"
 
 
+def _abandoned_worker() -> _StubWriterWorker:
+    """Stub with a decode agent so abandoned-push notifs can be observed."""
+    w = _StubWriterWorker.fresh()
+    w._logical_to_kernel_block_ids = lambda x, ratio: x
+    w.nixl_wrapper = MagicMock()
+    w._remote_agents["decode-engine"] = {(0, 0): "agent-decode"}
+    return w
+
+
+def _assert_abandoned_push_notified(w: _StubWriterWorker, request_id: str) -> None:
+    w.nixl_wrapper.send_notif.assert_called()
+    call = w.nixl_wrapper.send_notif.call_args
+    assert call.args[0] == "agent-decode"
+    notif = call.kwargs["notif_msg"]
+    assert notif.startswith(PUSH_FAIL_NOTIF_PREFIX)
+    assert notif == PUSH_FAIL_NOTIF_PREFIX + f"{request_id}:{w.world_size}".encode()
+
+
 def test_do_start_push_kv_drops_deferred_write_after_request_ends():
     """If the producer lease ends while the P→D handshake is still
     in flight, the completion callback must not queue a WRITE: those
     source blocks may already have been reused by another request."""
-    w = _StubWriterWorker.fresh()
-    w._logical_to_kernel_block_ids = lambda x, ratio: x
+    w = _abandoned_worker()
     xfer_calls: list[dict[str, Any]] = []
     w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
 
@@ -625,13 +653,13 @@ def test_do_start_push_kv_drops_deferred_write_after_request_ends():
     assert w._deferred_push_inbox.qsize() == 0
     assert xfer_calls == []
     assert not w._push_writer_wake.is_set()
+    _assert_abandoned_push_notified(w, "req-stale")
 
 
 def test_do_start_push_kv_skips_ready_write_after_request_ends():
     """Handshake already ready: an expired/finished request must not
     submit a WRITE from leftover logical block ids."""
-    w = _StubWriterWorker.fresh()
-    w._logical_to_kernel_block_ids = lambda x, ratio: x
+    w = _abandoned_worker()
     xfer_calls: list[dict[str, Any]] = []
     w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
     w._ensure_handshake = lambda *a, **k: None
@@ -640,59 +668,148 @@ def test_do_start_push_kv_skips_ready_write_after_request_ends():
     _real_do_start_push_kv(w, "req-done", ([4, 5],), _registration_data("req-done"))
 
     assert xfer_calls == []
+    _assert_abandoned_push_notified(w, "req-done")
 
 
 def test_push_reg_match_skips_write_after_request_ends():
     """A PUSH_REG that matches leftover finished blocks must not WRITE
     once the producer request has been abandoned."""
-    w = _StubWriterWorker.fresh()
-    w._logical_to_kernel_block_ids = lambda x, ratio: x
+    w = _abandoned_worker()
     xfer_calls: list[dict[str, Any]] = []
     w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
     w._ensure_handshake = lambda *a, **k: None
     w._push_finished_blocks["req-A"] = ([200, 201],)
     w._abandon_push("req-A")
-    w._do_start_push_kv = (
-        lambda rid, blocks, rd: NixlPushConnectorWorker._do_start_push_kv(
-            w, rid, blocks, rd
-        )
-    )
+
+    def _start(rid, blocks, rd):
+        NixlPushConnectorWorker._do_start_push_kv(w, rid, blocks, rd)
+
+    object.__setattr__(w, "_do_start_push_kv", _start)
 
     notif = PUSH_REG_NOTIF_PREFIX + msgspec.msgpack.encode(_registration_data("req-A"))
     w._handle_push_reg_notif(notif)
 
     assert xfer_calls == []
     assert w.start_push_calls == []
+    _assert_abandoned_push_notified(w, "req-A")
 
 
-def test_writer_loop_skips_abandoned_deferred_push():
-    """A deferred inbox entry for an abandoned request is dropped and
-    does not re-enter ``_do_start_push_kv``."""
-    w = _StubWriterWorker.fresh()
-    w.nixl_wrapper = MagicMock()
+def test_writer_loop_notifies_decode_for_abandoned_deferred_push():
+    """A deferred inbox entry for an abandoned request does not WRITE;
+    D is told so the decode request can fail instead of waiting."""
+    w = _abandoned_worker()
     w.nixl_wrapper.get_new_notifs.return_value = {}
     w._abandon_push("req-dead")
+    xfer_calls: list[dict[str, Any]] = []
+    w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
 
-    processed = threading.Event()
+    notified = threading.Event()
+    orig = w._notify_abandoned_push
 
-    def _tracked(rid, blocks, rd):
-        w.start_push_calls.append((rid, blocks, rd))
-        processed.set()
+    def _tracked(rid, rd):
+        orig(rid, rd)
+        notified.set()
 
-    w._do_start_push_kv = _tracked  # type: ignore[method-assign]
+    w._notify_abandoned_push = _tracked  # type: ignore[method-assign]
     w._deferred_push_inbox.put(("req-dead", ([1, 2],), _registration_data("req-dead")))
     w._push_writer_wake.set()
 
     t = threading.Thread(target=w._push_writer_loop, daemon=True)
     t.start()
     try:
-        assert not processed.wait(timeout=1.0)
+        assert notified.wait(timeout=2.0), "writer did not notify abandoned push"
     finally:
         w._push_writer_stop.set()
         w._push_writer_wake.set()
         t.join(timeout=2)
 
-    assert w.start_push_calls == []
+    assert xfer_calls == []
+    _assert_abandoned_push_notified(w, "req-dead")
+
+
+def test_abandoned_id_kept_while_handshake_callback_pending(monkeypatch):
+    """A handshake callback still pending after the tombstone TTL must
+    not queue a WRITE: GC of abandoned ids skips in-flight callbacks."""
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker."
+        "_ABANDONED_PUSH_TTL_S",
+        0.01,
+    )
+    w = _abandoned_worker()
+    xfer_calls: list[dict[str, Any]] = []
+    w._xfer_blocks_for_req = lambda **kw: xfer_calls.append(kw)
+    fut: Future = Future()
+    w._ensure_handshake = lambda *a, **k: fut
+
+    rd = _registration_data("req-stale")
+    _real_do_start_push_kv(w, "req-stale", ([1, 2, 3],), rd)
+    w._abandon_push("req-stale")
+    time.sleep(0.02)
+    # A later abandon would have GC'd req-stale if the pending callback
+    # did not pin the tombstone.
+    w._abandon_push("req-other")
+    assert w._is_push_abandoned("req-stale")
+
+    fut.set_result(({(0, 0): "agent"}, 0.0))
+
+    assert w._deferred_push_inbox.qsize() == 0
+    assert xfer_calls == []
+    _assert_abandoned_push_notified(w, "req-stale")
+
+
+def test_abandoned_id_expires_after_ttl_without_pending_callback(monkeypatch):
+    """Ids with no in-flight handshake are still reclaimed after the TTL."""
+    monkeypatch.setattr(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker."
+        "_ABANDONED_PUSH_TTL_S",
+        0.01,
+    )
+    w = _StubWriterWorker.fresh()
+    w._abandon_push("req-old")
+    time.sleep(0.02)
+    w._abandon_push("req-new")
+    assert not w._is_push_abandoned("req-old")
+    assert w._is_push_abandoned("req-new")
+
+
+def test_decode_fails_recv_on_abandoned_push_notif():
+    """D treats the stand-in notif as a failed WRITE and fails the recv
+    instead of waiting for a completion that will never arrive."""
+    w = _StubWriterWorker.fresh()
+    w.transfer_topo = MagicMock()
+    w._recving_metadata["req-stale"] = SimpleNamespace(
+        pp_size=1, local_block_ids=([100, 101],)
+    )
+    body = f"req-stale:{w.world_size}"
+    w._pending_completion_notifs.put(PUSH_FAIL_NOTIF_PREFIX + body.encode())
+
+    notified = w._get_new_notifs()
+
+    assert notified == set()
+    assert w._failed_recv_reqs.get_nowait() == "req-stale"
+    assert "req-stale" not in w._recving_transfers
+    assert w._invalid_block_ids.get_nowait() == {100, 101}
+    w.xfer_stats.record_failed_transfer.assert_called_once()
+
+
+def test_abandoned_push_notif_waits_for_sibling_producer_ranks():
+    """Do not fail D on the first PUSH_FAIL when another producer rank
+    may still have a WRITE in flight."""
+    w = _StubWriterWorker.fresh()
+    w.transfer_topo = MagicMock()
+    w._recving_metadata["d-req"] = SimpleNamespace(
+        pp_size=1, local_block_ids=([100, 101],)
+    )
+    body = "d-req:2"
+    w._pending_completion_notifs.put(PUSH_FAIL_NOTIF_PREFIX + body.encode())
+    w._get_new_notifs()
+    assert w._failed_recv_reqs.empty()
+    assert w.consumer_notification_counts_by_req["d-req"] == 1
+
+    w._pending_completion_notifs.put(body.encode())
+    w._get_new_notifs()
+    assert w._failed_recv_reqs.get_nowait() == "d-req"
+    assert "d-req" not in w._recving_transfers
 
 
 def test_do_start_push_kv_drops_request_on_handshake_failure():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -24,6 +24,11 @@ GET_META_MSG = b"get_meta_msg"
 # Sent worker-to-worker over NIXL: D worker -> P worker, encoded as
 # PUSH_REG_NOTIF_PREFIX + msgpack(registration_data).
 PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
+
+# Push-mode WRITE failure notification. Sent P worker -> D worker as
+# PUSH_FAIL_NOTIF_PREFIX + the completion notification body; stands in for a
+# WRITE that could not be posted so the consumer's count still adds up.
+PUSH_FAIL_NOTIF_PREFIX = b"PUSH_FAIL:"
 #
 # NIXL Connector Version
 #

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -26,9 +26,11 @@ event-driven: the engine main thread sets ``_push_writer_wake`` from
 the handshake-completion callback sets the same event after a deferred
 PUSH_REG send or a deferred push WRITE has been queued. When a request's
 lease expires (the base worker reports it via ``done_sending``) or the WRITE completes,
-``get_finished`` enqueues an eviction onto ``_evict_finished_inbox`` so
-the writer drops any leftover ``_push_finished_blocks`` /
-``_pending_d_registrations`` and stops self-polling.
+``get_finished`` marks the request abandoned and enqueues an eviction onto
+``_evict_finished_inbox`` so the writer drops leftover
+``_push_finished_blocks`` / ``_pending_d_registrations`` and so a late
+P→D handshake callback cannot WRITE from blocks the scheduler has
+already freed.
 """
 
 import queue
@@ -72,6 +74,10 @@ logger = init_logger(__name__)
 # main thread (start_load_kv / get_finished). Smaller -> lower latency
 # while active, slightly more CPU.
 _PUSH_WRITER_POLL_INTERVAL_MS = 1.0
+
+# How long a finished/expired request id stays abandoned so a late
+# handshake callback cannot WRITE after the producer lease ended.
+_ABANDONED_PUSH_TTL_S = 300.0
 
 
 class NixlPushConnectorWorker(NixlBaseConnectorWorker):
@@ -119,6 +125,11 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         self._evict_finished_inbox: queue.Queue[str] = queue.Queue()
         # Handshakes that have just completed and are ready for the WRITE on wthread
         self._deferred_push_inbox = queue.Queue[tuple[str, BlockIds, dict[str, Any]]]()
+        # Request ids whose producer lease ended or whose WRITE finished.
+        # Checked on the handshake callback and again at WRITE submit so
+        # a late callback cannot transfer from reused source blocks.
+        self._abandoned_push_lock = threading.Lock()
+        self._abandoned_push_ids: dict[str, float] = {}
 
         # Wake signal from engine main thread (start_load_kv / get_finished).
         # Writer self-polls at _PUSH_WRITER_POLL_INTERVAL_MS while it has
@@ -154,6 +165,25 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                     self.nixl_wrapper.release_xfer_handle(handle)
             self._sending_transfers.clear()
         super().shutdown()
+
+    def _abandon_push(self, req_id: str) -> None:
+        """Remember that *req_id* must not start a WRITE.
+
+        Called from the engine main thread when the producer lease expires
+        or the WRITE has already completed. A late handshake callback on
+        another thread consults this before queueing a deferred WRITE.
+        """
+        now = time.perf_counter()
+        cutoff = now - _ABANDONED_PUSH_TTL_S
+        with self._abandoned_push_lock:
+            self._abandoned_push_ids[req_id] = now
+            stale = [rid for rid, ts in self._abandoned_push_ids.items() if ts < cutoff]
+            for rid in stale:
+                del self._abandoned_push_ids[rid]
+
+    def _is_push_abandoned(self, req_id: str) -> bool:
+        with self._abandoned_push_lock:
+            return req_id in self._abandoned_push_ids
 
     # --- Engine-main-thread entry point -------------------------------- #
 
@@ -232,7 +262,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                         rid, blocks, rd = self._deferred_push_inbox.get_nowait()
                     except queue.Empty:
                         break
-                    self._do_start_push_kv(rid, blocks, rd)
+                    if not self._is_push_abandoned(rid):
+                        self._do_start_push_kv(rid, blocks, rd)
 
                 # 3. P-side finished blocks; match against pending regs.
                 while True:
@@ -423,6 +454,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         if not local_block_ids:
             logger.warning("No local blocks to push for request %s", request_id)
             return
+        if self._is_push_abandoned(request_id):
+            logger.debug("Skipping push WRITE for abandoned request %s", request_id)
+            return
 
         # ``local_block_ids`` are P's logical block IDs; ``remote_block_ids``
         # (D's, from the PUSH_REG notif) are also logical.
@@ -451,11 +485,21 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                         failure_type="push_handshake_failed", req_id=rid, error=e
                     )
                     return
+                if self._is_push_abandoned(rid):
+                    logger.debug("Dropping deferred push for abandoned request %s", rid)
+                    return
                 self._deferred_push_inbox.put((rid, blocks, rd))
                 self._push_writer_wake.set()
 
             fut.add_done_callback(_on_handshake)
             return
+        # Re-check after the handshake is ready: the lease may have
+        # expired while we waited, and those source blocks may already
+        # belong to another request.
+        if self._is_push_abandoned(request_id):
+            logger.debug("Skipping push WRITE for abandoned request %s", request_id)
+            return
+
         # Keep the engine alive while it is actively receiving pushes, mirroring
         # how pull-mode transfers touch _engine_last_active in start_load_kv.
         self._engine_last_active[decode_engine_id] = time.perf_counter()
@@ -788,7 +832,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # Tell the writer to drop any state it still holds for any
         # request that just finished (push completed) or expired
         # (lease ran out without a D registration ever arriving).
+        # Mark abandoned on this thread first so a handshake callback
+        # that completes after eviction cannot queue a stale WRITE.
         for req_id in done_sending:
+            self._abandon_push(req_id)
             self._evict_finished_inbox.put(req_id)
         if done_sending:
             self._push_writer_wake.set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -47,6 +47,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    PUSH_FAIL_NOTIF_PREFIX,
     PUSH_REG_NOTIF_PREFIX,
     NixlConnectorMetadata,
     RemoteMeta,
@@ -77,7 +78,13 @@ _PUSH_WRITER_POLL_INTERVAL_MS = 1.0
 
 # How long a finished/expired request id stays abandoned so a late
 # handshake callback cannot WRITE after the producer lease ended.
+# IDs with an in-flight handshake callback are never expired: the
+# callback itself is the bound, and the NIXL handshake receive timeout
+# is 5s. The TTL only reclaims ids that have no pending callback.
 _ABANDONED_PUSH_TTL_S = 300.0
+
+# Notifs are decoded to str before dispatch; keep a str twin of the prefix.
+_PUSH_FAIL_PREFIX_STR = PUSH_FAIL_NOTIF_PREFIX.decode()
 
 
 class NixlPushConnectorWorker(NixlBaseConnectorWorker):
@@ -128,8 +135,14 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # Request ids whose producer lease ended or whose WRITE finished.
         # Checked on the handshake callback and again at WRITE submit so
         # a late callback cannot transfer from reused source blocks.
+        # IDs with a pending handshake callback are not TTL-expired.
         self._abandoned_push_lock = threading.Lock()
         self._abandoned_push_ids: dict[str, float] = {}
+        self._pending_handshake_callbacks: dict[str, int] = {}
+        self._abandoned_push_notified: set[str] = set()
+        # D-side: requests where P reported a WRITE it could not post.
+        # Failed only once the expected notif count completes.
+        self._failed_write_reqs: set[ReqId] = set()
 
         # Wake signal from engine main thread (start_load_kv / get_finished).
         # Writer self-polls at _PUSH_WRITER_POLL_INTERVAL_MS while it has
@@ -172,18 +185,95 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         Called from the engine main thread when the producer lease expires
         or the WRITE has already completed. A late handshake callback on
         another thread consults this before queueing a deferred WRITE.
+        Ids with an in-flight handshake callback are kept past the TTL so
+        the callback cannot WRITE after the tombstone is forgotten.
         """
         now = time.perf_counter()
         cutoff = now - _ABANDONED_PUSH_TTL_S
         with self._abandoned_push_lock:
             self._abandoned_push_ids[req_id] = now
-            stale = [rid for rid, ts in self._abandoned_push_ids.items() if ts < cutoff]
+            stale = [
+                rid
+                for rid, ts in self._abandoned_push_ids.items()
+                if ts < cutoff and self._pending_handshake_callbacks.get(rid, 0) == 0
+            ]
             for rid in stale:
                 del self._abandoned_push_ids[rid]
+                self._abandoned_push_notified.discard(rid)
 
     def _is_push_abandoned(self, req_id: str) -> bool:
         with self._abandoned_push_lock:
-            return req_id in self._abandoned_push_ids
+            ts = self._abandoned_push_ids.get(req_id)
+            if ts is None:
+                return False
+            if self._pending_handshake_callbacks.get(req_id, 0) > 0:
+                return True
+            if time.perf_counter() - ts >= _ABANDONED_PUSH_TTL_S:
+                del self._abandoned_push_ids[req_id]
+                self._abandoned_push_notified.discard(req_id)
+                return False
+            return True
+
+    def _note_pending_handshake_callback(self, req_id: str) -> None:
+        with self._abandoned_push_lock:
+            self._pending_handshake_callbacks[req_id] = (
+                self._pending_handshake_callbacks.get(req_id, 0) + 1
+            )
+
+    def _handshake_callback_finished(self, req_id: str) -> None:
+        with self._abandoned_push_lock:
+            n = self._pending_handshake_callbacks.get(req_id, 0) - 1
+            if n <= 0:
+                self._pending_handshake_callbacks.pop(req_id, None)
+            else:
+                self._pending_handshake_callbacks[req_id] = n
+
+    def _notify_abandoned_push(
+        self, request_id: str, registration_data: dict[str, Any]
+    ) -> None:
+        """Tell D the WRITE will not run so it can fail instead of waiting.
+
+        Best-effort: if the P→D handshake never completed there are no
+        remote agents and D falls back to its registration watchdog.
+        """
+        with self._abandoned_push_lock:
+            if request_id in self._abandoned_push_notified:
+                return
+            self._abandoned_push_notified.add(request_id)
+
+        self._log_failure(
+            failure_type="push_write_abandoned",
+            req_id=request_id,
+            msg="Producer request ended before WRITE; notifying decode",
+        )
+        decode_engine_id = registration_data.get("decode_engine_id")
+        decode_request_id = registration_data.get("request_id")
+        if not isinstance(decode_engine_id, str) or not isinstance(
+            decode_request_id, str
+        ):
+            return
+        notif_msg = (
+            PUSH_FAIL_NOTIF_PREFIX + f"{decode_request_id}:{self.world_size}".encode()
+        )
+        handshake_lock = getattr(self, "_handshake_lock", None)
+        if handshake_lock is not None:
+            with handshake_lock:
+                agents = dict(self._remote_agents.get(decode_engine_id) or {})
+        else:
+            agents = dict(self._remote_agents.get(decode_engine_id) or {})
+        nixl = getattr(self, "nixl_wrapper", None)
+        if nixl is None or not agents:
+            return
+        for rank, agent_name in agents.items():
+            try:
+                nixl.send_notif(agent_name, notif_msg=notif_msg)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="push_fail_notif_failed",
+                    req_id=request_id,
+                    error=e,
+                    remote_rank=rank,
+                )
 
     # --- Engine-main-thread entry point -------------------------------- #
 
@@ -262,7 +352,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                         rid, blocks, rd = self._deferred_push_inbox.get_nowait()
                     except queue.Empty:
                         break
-                    if not self._is_push_abandoned(rid):
+                    if self._is_push_abandoned(rid):
+                        self._notify_abandoned_push(rid, rd)
+                    else:
                         self._do_start_push_kv(rid, blocks, rd)
 
                 # 3. P-side finished blocks; match against pending regs.
@@ -454,9 +546,6 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         if not local_block_ids:
             logger.warning("No local blocks to push for request %s", request_id)
             return
-        if self._is_push_abandoned(request_id):
-            logger.debug("Skipping push WRITE for abandoned request %s", request_id)
-            return
 
         # ``local_block_ids`` are P's logical block IDs; ``remote_block_ids``
         # (D's, from the PUSH_REG notif) are also logical.
@@ -465,6 +554,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         decode_request_id = registration_data["request_id"]
 
         # Runs on the background executor; defer the WRITE until it's ready.
+        # Even an already-abandoned request still handshakes so we can tell
+        # D the WRITE will not run instead of leaving it on the watchdog.
         fut = self._ensure_handshake(
             decode_engine_id,
             registration_data["decode_host"],
@@ -472,6 +563,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             registration_data["decode_tp_size"],
         )
         if fut is not None:
+            self._note_pending_handshake_callback(request_id)
 
             def _on_handshake(
                 f: Future[tuple[dict[tuple[int, int], str], float]],
@@ -479,17 +571,20 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 blocks: BlockIds = local_block_ids,
                 rd: dict[str, Any] = registration_data,
             ) -> None:
-                if (e := f.exception()) is not None:
-                    # The engine reclaims the blocks via the TTL so we dont free here
-                    self._log_failure(
-                        failure_type="push_handshake_failed", req_id=rid, error=e
-                    )
-                    return
-                if self._is_push_abandoned(rid):
-                    logger.debug("Dropping deferred push for abandoned request %s", rid)
-                    return
-                self._deferred_push_inbox.put((rid, blocks, rd))
-                self._push_writer_wake.set()
+                try:
+                    if (e := f.exception()) is not None:
+                        # Blocks are reclaimed via the lease TTL.
+                        self._log_failure(
+                            failure_type="push_handshake_failed", req_id=rid, error=e
+                        )
+                        return
+                    if self._is_push_abandoned(rid):
+                        self._notify_abandoned_push(rid, rd)
+                        return
+                    self._deferred_push_inbox.put((rid, blocks, rd))
+                    self._push_writer_wake.set()
+                finally:
+                    self._handshake_callback_finished(rid)
 
             fut.add_done_callback(_on_handshake)
             return
@@ -497,7 +592,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # expired while we waited, and those source blocks may already
         # belong to another request.
         if self._is_push_abandoned(request_id):
-            logger.debug("Skipping push WRITE for abandoned request %s", request_id)
+            self._notify_abandoned_push(request_id, registration_data)
             return
 
         # Keep the engine alive while it is actively receiving pushes, mirroring
@@ -524,6 +619,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         )
 
         t0 = time.perf_counter()
+        if self._is_push_abandoned(request_id):
+            self._notify_abandoned_push(request_id, registration_data)
+            return
         self._xfer_blocks_for_req(req_id=request_id, meta=push_meta)
         elapsed_ms = (time.perf_counter() - t0) * 1000.0
         if elapsed_ms > 200.0:
@@ -769,32 +867,24 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._handle_heartbeat(msg[3:])
                 continue
 
+            failed_write = msg.startswith(_PUSH_FAIL_PREFIX_STR)
+            if failed_write:
+                msg = msg[len(_PUSH_FAIL_PREFIX_STR) :]
+
             req_id, tp_size = msg.rsplit(":", 1)
 
             # Not tracked as a P-side send/process for this notif.
             if req_id not in self._reqs_to_send and req_id not in self._reqs_to_process:
-                if (meta := self._recving_metadata.get(req_id)) is not None:
-                    # Consumer waits for one notif per producer rank writing
-                    # here: pp_size stages * producers-per-consumer (>1 when
-                    # producer TP > consumer TP; tp_size is the producer TP).
-                    producers_per_consumer = max(1, int(tp_size) // self.world_size)
-                    expected_notifs = meta.pp_size * producers_per_consumer
-                    self.consumer_notification_counts_by_req[req_id] += 1
-                    notifs = self.consumer_notification_counts_by_req[req_id]
-                    if notifs < expected_notifs:
-                        continue
-                    del self.consumer_notification_counts_by_req[req_id]
-                    # P drove the transfer (we own no NIXL handle), so
-                    # materialise an empty ``_recving_transfers`` entry for
-                    # ``_pop_done_transfers`` to report done.
-                    self._recving_transfers.setdefault(req_id, [])
-                else:
-                    # Not tracked on either side (lease may have expired
-                    # before the notif arrived). Log and skip.
-                    logger.error(
-                        "Unrecognized request %s notif (may have expired).",
-                        req_id,
-                    )
+                self._count_consumer_notif(req_id, int(tp_size), failed_write)
+                continue
+
+            if failed_write:
+                # Counting it here would retire our own lease.
+                logger.error(
+                    "Ignoring failed-WRITE report for %s, which this worker is "
+                    "itself producing",
+                    req_id,
+                )
                 continue
 
             n_consumers = int(tp_size)
@@ -811,6 +901,66 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._reqs_to_send.pop(req_id, None)
         return notified_req_ids
 
+    def _count_consumer_notif(
+        self, req_id: str, producer_tp_size: int, failed_write: bool
+    ) -> None:
+        """Count one notif for a request this node is receiving.
+
+        A failed WRITE reports in place of its completion, so a failure
+        never short-circuits the count: every posted WRITE has landed by
+        the time the request is failed.
+        """
+        meta = self._recving_metadata.get(req_id)
+        if meta is None:
+            logger.error("Unrecognized request %s notif (may have expired).", req_id)
+            return
+
+        if failed_write:
+            self._failed_write_reqs.add(req_id)
+
+        producers_per_consumer = max(1, producer_tp_size // self.world_size)
+        expected_notifs = meta.pp_size * producers_per_consumer
+        self.consumer_notification_counts_by_req[req_id] += 1
+        if self.consumer_notification_counts_by_req[req_id] < expected_notifs:
+            return
+
+        del self.consumer_notification_counts_by_req[req_id]
+        if req_id not in self._failed_write_reqs:
+            # P drove the transfer (we own no NIXL handle), so materialise an
+            # empty ``_recving_transfers`` entry for ``_pop_done_transfers``
+            # to report done.
+            self._recving_transfers.setdefault(req_id, [])
+            return
+
+        self._failed_write_reqs.discard(req_id)
+        self._fail_incomplete_push(req_id, meta)
+
+    def _fail_incomplete_push(self, req_id: str, meta: ReqMeta) -> None:
+        """Fail a request whose producer could not post every WRITE."""
+        # ``_handle_failed_transfer`` invalidates one group only. With no
+        # blocks recorded the scheduler promotes the request as a successful
+        # load over a cache that was never written, so leave it to its lease.
+        if self._is_hma_required or len(self.kv_cache_config.kv_cache_groups) > 1:
+            reason = "recovery is unsupported for hybrid or multi-group models"
+        elif not any(meta.local_block_ids):
+            reason = "it has no local blocks to invalidate"
+        else:
+            reason = None
+
+        if reason is not None:
+            logger.error(
+                "Producer could not write all KV for request %s and %s; it will "
+                "hold its blocks until it is aborted",
+                req_id,
+                reason,
+            )
+            return
+
+        logger.warning(
+            "Producer could not write all KV for request %s; failing it.", req_id
+        )
+        self._handle_failed_transfer(req_id, None)
+
     def get_finished(self) -> tuple[set[str], set[str]]:
         # Engine main thread asking for completions: also wake the writer
         # so it gets a chance to drain NIXL notifs (heartbeats, completion
@@ -818,6 +968,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         self._push_writer_wake.set()
 
         done_sending, done_recving = super().get_finished()
+
+        # A request retired before its count completed would leak its flag.
+        self._failed_write_reqs.difference_update(done_recving)
 
         # ``_pop_done_transfers`` mutates ``_sending_transfers``; the
         # writer thread also appends to it, so guard the pop.


### PR DESCRIPTION
## Summary
When `NixlPushConnector` waits on a P→D handshake, the completion callback captured the original logical block ids and later submitted a WRITE even if `get_finished` had already reported the producer request done (lease expiry or completed push). Those source blocks can already belong to another request, so the still-live decode request can generate from the wrong KV while the API returns HTTP 200. This change marks finished/expired requests abandoned on the engine thread and refuses the WRITE at the handshake callback, the deferred-inbox drain, and the transfer sink.

A follow-up on the same branch closes two remaining holes: abandoned ids with an in-flight handshake callback are not forgotten after the 300s tombstone TTL, and dropping the WRITE notifies decode (`PUSH_FAIL`) so the request fails instead of waiting out the lease.

This is not a duplicate of open NixlPush work: #50754 reports NIXL WRITEs that failed to post, and #54757 hardens the handshake listener. Neither invalidates a deferred WRITE after the producer lease ends. The `PUSH_FAIL` wire format matches #50754 so the two compose; this PR also consumes that notif on D for the abandoned-before-WRITE case.

## Changes
- `vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py`: abandon request ids in `get_finished`; skip WRITE if abandoned; pin tombstones while a handshake callback is pending; notify D when the WRITE is dropped.
- `vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py`: `PUSH_FAIL` notif prefix (same bytes as #50754).
- `tests/v1/kv_connector/unit/test_nixl_push_connector.py`: regression and completeness coverage for the deferred-callback, ready-handshake, PUSH_REG, writer-loop, TTL, and D-side fail paths.

## Codepath coverage
- Scheduler `request_finished` → `start_load_kv` → writer match → deferred handshake → WRITE: abandoned before the callback can queue work; sink also refuses; D is notified.
- Handshake already ready (no defer): sink refuses and notifies D.
- `PUSH_REG` match → `_do_start_push_kv`: sink refuses and notifies D.
- Writer deferred-inbox drain: notifies D and does not WRITE.
- Pending handshake callback past the tombstone TTL: id stays abandoned until the callback runs.
- Other HTTP/gRPC/batch entry points share this worker sink.
- D-side `_reg_send_inbox` handshake (destination abort) is a different path and is not changed here.

## Tests
- `test_do_start_push_kv_drops_deferred_write_after_request_ends` — late handshake must not queue a WRITE; D is notified.
- `test_do_start_push_kv_skips_ready_write_after_request_ends` — ready handshake must not submit.
- `test_push_reg_match_skips_write_after_request_ends` — PUSH_REG match after abandon must not submit.
- `test_writer_loop_notifies_decode_for_abandoned_deferred_push` — writer drain notifies D instead of WRITE.
- `test_abandoned_id_kept_while_handshake_callback_pending` — TTL GC cannot drop an id with a pending callback.
- `test_abandoned_id_expires_after_ttl_without_pending_callback` — idle ids are still reclaimed.
- `test_decode_fails_recv_on_abandoned_push_notif` — D fails the recv on `PUSH_FAIL`.
- `test_abandoned_push_notif_waits_for_sibling_producer_ranks` — D waits for the expected notif count before failing.
- `test_get_finished_evicts_completed_state` — `get_finished` now also marks the request abandoned.

```
PYTHONPATH=. .venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_push_connector.py --noconftest -v
```

52 passed.

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)