### PR TITLE
[Bugfix][NIXL] Recover locally invalidated pull peer metadata

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -4,14 +4,17 @@
 import contextlib
 import inspect
 import os
+import queue
 import tempfile
 import textwrap
+import threading
 import time
 import uuid
 from collections import defaultdict
+from concurrent.futures import Future
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import msgspec
 import numpy as np
@@ -43,7 +46,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlHandshakePayload,
     NixlKVConnectorStats,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+    NixlBaseConnectorWorker,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    RemoteMeta,
+    ReqMeta,
     compute_nixl_compatibility_hash,
 )
 from vllm.distributed.kv_transfer.kv_transfer_state import (
@@ -175,6 +183,9 @@ class FakeNixlWrapper:
 
     def remove_remote_agent(self, agent: str) -> None:
         pass
+
+    def check_remote_metadata(self, agent: str) -> bool:
+        return True
 
     def send_notif(self, agent_name: str, notif_msg: bytes) -> None:
         pass
@@ -2334,6 +2345,294 @@ def test_engine_ttl_disabled(default_vllm_config, dist_init):
     # Nothing should be evicted.
     assert engine_id in worker._remote_agents
     assert engine_id in worker.dst_xfer_side_handles
+
+
+@pytest.fixture
+def peer_recovery_worker():
+    # Exercise the worker lifecycle without initializing devices or NIXL.
+    with patch.object(NixlBaseConnectorWorker, "__init__", return_value=None):
+        worker = NixlConnectorWorker(None, "local", None)
+    worker._recv_engine_by_req = {}
+    worker._failed_remote_engines = set()
+    worker._invalid_remote_engines = set()
+    worker._handshake_lock = threading.RLock()
+    worker._handshake_futures = {}
+    worker._handshake_initiation_executor = MagicMock()
+    worker._handshake_initiation_executor.submit.return_value = Future()
+    worker._ready_requests = queue.Queue()
+    worker._recving_transfers = {}
+    worker._recving_metadata = {}
+    worker._failed_recv_reqs = queue.Queue()
+    worker._invalid_block_ids = queue.Queue()
+    worker._reqs_to_send = {}
+    worker._engine_ttl = 0
+    worker._engine_last_active = {"peer": time.perf_counter()}
+    worker._engine_clock_offset = {"peer": 0.0}
+    worker._remote_agents = {"peer": {(0, 0): "agent0", (0, 1): "agent1"}}
+    worker.dst_xfer_side_handles = {"peer": {0: 100, 1: 101}}
+    worker.kv_caches_base_addr = {"peer": {0: [1024]}}
+    worker.dst_num_blocks = {"peer": 16}
+    worker.tp_mappings = {
+        "peer": SimpleNamespace(
+            all_source_ranks=[0, 1], source_ranks_per_group=[{0, 1}], local_consumers=1
+        )
+    }
+    worker.src_xfer_handles_by_block_size = {16: 99}
+    worker.src_xfer_handles_by_tp_ratio = {}
+    worker._registered_descs = []
+    worker.transfer_topo = MagicMock()
+    worker.transfer_topo.block_size_ratio.return_value = 1
+    worker.transfer_topo.tp_ratio.return_value = 1
+    worker.transfer_topo.get_engine_info.return_value = SimpleNamespace(
+        remote_block_size=16,
+        remote_physical_blocks_per_logical=1,
+        remote_tp_size=2,
+        remote_dcp_size=1,
+    )
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker._is_hma_required = False
+    worker._bidirectional_kv_xfer_enabled = False
+    worker.use_host_buffer = False
+    worker.enable_permute_local_kv = False
+    worker.enable_heterogeneous_attn_post_process = False
+    worker.use_mla = False
+    worker.dcp_size = 1
+    worker.tp_rank = 0
+    worker.nixl_wrapper = MagicMock(spec=FakeNixlWrapper)
+    worker.nixl_wrapper.get_new_notifs.return_value = {}
+    worker.nixl_wrapper.check_remote_metadata.return_value = True
+    worker.xfer_stats = MagicMock()
+    worker._sync_device_after_mamba_recv = MagicMock()
+    worker._log_failure = MagicMock()
+    yield worker
+    worker.shutdown()
+
+
+def _peer_recovery_request(worker, req_id="req", engine_id="peer", handles=()):
+    meta = ReqMeta(
+        local_block_ids=([1],),
+        local_physical_block_ids=([1],),
+        tp_size=2,
+        remote=RemoteMeta(([2],), "localhost", 1234, engine_id, f"p-{req_id}"),
+    )
+    worker._recving_metadata[req_id] = meta
+    worker._recv_engine_by_req[req_id] = engine_id
+    if handles:
+        worker._recving_transfers[req_id] = list(handles)
+    return meta
+
+
+@pytest.mark.parametrize(
+    "metadata_present", [True, False, RuntimeError("query failed")]
+)
+@pytest.mark.cpu_test
+def test_peer_recovery_requires_missing_metadata(
+    peer_recovery_worker, metadata_present
+):
+    w = peer_recovery_worker
+    _peer_recovery_request(w)
+    if isinstance(metadata_present, Exception):
+        w.nixl_wrapper.check_remote_metadata.side_effect = metadata_present
+    else:
+        w.nixl_wrapper.check_remote_metadata.return_value = metadata_present
+    w._handle_failed_transfer("req", None)
+    assert w._invalid_block_ids.get_nowait() == {1}
+    assert w.get_finished() == (set(), {"req"})
+    assert ("peer" in w._remote_agents) is (metadata_present is not False)
+    assert w.nixl_wrapper.release_dlist_handle.call_count == (
+        2 if metadata_present is False else 0
+    )
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_rehandshakes_unchanged_engine_id(peer_recovery_worker):
+    w = peer_recovery_worker
+    plan = w.tp_mappings["peer"]
+    _peer_recovery_request(w)
+    w.nixl_wrapper.check_remote_metadata.side_effect = [True, False]
+    w._handle_failed_transfer("req", None)
+    w.get_finished()
+    for mapping in (
+        w._remote_agents,
+        w.dst_xfer_side_handles,
+        w.kv_caches_base_addr,
+        w.dst_num_blocks,
+        w.tp_mappings,
+        w._engine_clock_offset,
+        w._engine_last_active,
+    ):
+        assert "peer" not in mapping
+    w.transfer_topo.unregister_remote_engine.assert_called_once_with("peer")
+    meta = _peer_recovery_request(w, "next")
+    w._read_blocks_for_req("next", meta)
+    w._handshake_initiation_executor.submit.assert_called_once_with(
+        w._nixl_handshake, "localhost", 1234, 2, "peer", 1, 1, False
+    )
+    w.nixl_wrapper.make_prepped_xfer.assert_not_called()
+    future = w._handshake_futures["peer"]
+    # Simulate the descriptors prepared by the new background handshake.
+    w.dst_xfer_side_handles["peer"] = {0: 200, 1: 201}
+    w.tp_mappings["peer"] = plan
+    fresh_agents = {(0, 0): "fresh0", (0, 1): "fresh1"}
+    future.set_result((fresh_agents, 0.5))
+    assert w._remote_agents["peer"] == fresh_agents
+    with patch.object(w, "_read_blocks") as reads:
+        w._read_blocks_for_req(*w._ready_requests.get_nowait())
+        assert [c.kwargs["remote_xfer_side_handle"] for c in reads.call_args_list] == [
+            200,
+            201,
+        ]
+    assert w.get_finished() == (set(), {"next"})
+    assert w.nixl_wrapper.release_dlist_handle.call_count == 2
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_waits_for_remaining_reads(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w, handles=(10, 11))
+    _peer_recovery_request(w, "other", "healthy", (12,))
+    w._remote_agents["healthy"] = {(0, 0): "healthy-agent"}
+    w.nixl_wrapper.check_remote_metadata.return_value = False
+    w.nixl_wrapper.check_xfer_state.side_effect = lambda h: "ERR" if h == 10 else "PROC"
+    assert w.get_finished() == (set(), {"req"})
+    assert "req" not in w._recving_metadata
+    assert w._recving_transfers["req"] == [11]
+    w.nixl_wrapper.release_dlist_handle.assert_not_called()
+
+    meta = _peer_recovery_request(w, "blocked")
+    w._read_blocks_for_req("blocked", meta)
+    w.nixl_wrapper.make_prepped_xfer.assert_not_called()
+    w.nixl_wrapper.check_xfer_state.side_effect = lambda h: (
+        "DONE" if h == 11 else "PROC"
+    )
+    assert w.get_finished() == (set(), {"blocked"})
+    assert "peer" not in w._remote_agents
+    assert "healthy" in w._remote_agents
+    assert w._recving_transfers == {"other": [12]}
+    assert w.nixl_wrapper.release_dlist_handle.call_count == 2
+    w.nixl_wrapper.remove_remote_agent.assert_any_call("agent0")
+    w.nixl_wrapper.remove_remote_agent.assert_any_call("agent1")
+    calls = w.nixl_wrapper.mock_calls
+    assert calls.index(call.release_xfer_handle(11)) < calls.index(
+        call.release_dlist_handle(100)
+    )
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_detects_late_failure_without_metadata(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w, handles=(10, 11))
+    w.nixl_wrapper.check_xfer_state.side_effect = lambda h: "ERR" if h == 10 else "PROC"
+    w.get_finished()
+    assert "req" not in w._recving_metadata
+    assert "peer" in w._remote_agents
+    w.nixl_wrapper.check_remote_metadata.return_value = False
+    w.nixl_wrapper.check_xfer_state.side_effect = None
+    w.nixl_wrapper.check_xfer_state.return_value = "ERR"
+    assert w.get_finished() == (set(), set())
+    assert "peer" not in w._remote_agents
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_defers_cleanup_during_handshake(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w)
+    w.nixl_wrapper.check_remote_metadata.return_value = False
+    w._handle_failed_transfer("req", None)
+    w._handshake_futures["other"] = Future()
+    w.get_finished()
+    w.nixl_wrapper.check_remote_metadata.assert_not_called()
+    w.nixl_wrapper.release_dlist_handle.assert_not_called()
+    w._handshake_futures.clear()
+    w.get_finished()
+    assert "peer" not in w._remote_agents
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_does_not_probe_partial_handshake(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w)
+    w._handshake_futures["peer"] = Future()
+    w._handle_failed_transfer("req", None)
+    w.nixl_wrapper.check_remote_metadata.assert_not_called()
+    assert w.get_finished() == (set(), {"req"})
+    w.nixl_wrapper.release_dlist_handle.assert_not_called()
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_success_does_not_probe(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w, handles=(10,))
+    w.nixl_wrapper.check_xfer_state.return_value = "DONE"
+    assert w.get_finished() == (set(), {"req"})
+    assert not w._recv_engine_by_req
+    w.nixl_wrapper.check_remote_metadata.assert_not_called()
+    w.nixl_wrapper.release_dlist_handle.assert_not_called()
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_cleanup_failure_is_not_swallowed(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w)
+    w.nixl_wrapper.check_remote_metadata.return_value = False
+    w._handle_failed_transfer("req", None)
+    w.nixl_wrapper.release_dlist_handle.side_effect = RuntimeError("release failed")
+    with pytest.raises(RuntimeError, match="release failed"):
+        w.get_finished()
+    assert "peer" in w._invalid_remote_engines
+    w.nixl_wrapper.remove_remote_agent.assert_not_called()
+    w.nixl_wrapper.release_dlist_handle.side_effect = None
+
+
+@pytest.mark.parametrize("invalidated", [False, True])
+@pytest.mark.cpu_test
+def test_peer_recovery_tracks_reads_through_failure(peer_recovery_worker, invalidated):
+    w = peer_recovery_worker
+    meta = _peer_recovery_request(w)
+    w._recv_engine_by_req.clear()
+
+    def read(**kwargs):
+        if invalidated:
+            w._handle_failed_transfer(kwargs["request_id"], None)
+
+    w.nixl_wrapper.check_remote_metadata.return_value = not invalidated
+    with patch.object(w, "_read_blocks", side_effect=read) as reads:
+        w._read_blocks_for_req("req", meta)
+        assert w._recv_engine_by_req == {"req": "peer"}
+        assert reads.call_count == 2
+    assert w.get_finished() == (set(), {"req"})
+    assert ("peer" not in w._remote_agents) is invalidated
+    if not invalidated:
+        w.nixl_wrapper.check_remote_metadata.assert_not_called()
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_rehandshake_failure_reports_request(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w)
+    w.nixl_wrapper.check_remote_metadata.return_value = False
+    w._handle_failed_transfer("req", None)
+    w.get_finished()
+    meta = _peer_recovery_request(w, "next")
+    w._read_blocks_for_req("next", meta)
+    w._handshake_futures["peer"].set_exception(RuntimeError("handshake failed"))
+    assert w.get_finished() == (set(), {"next"})
+    assert "peer" not in w._remote_agents
+    assert w._ready_requests.empty()
+    w.nixl_wrapper.make_prepped_xfer.assert_not_called()
+
+
+@pytest.mark.cpu_test
+def test_peer_recovery_shutdown_releases_pending_handles_once(peer_recovery_worker):
+    w = peer_recovery_worker
+    _peer_recovery_request(w, handles=(10, 11))
+    w.nixl_wrapper.check_remote_metadata.return_value = False
+    w.nixl_wrapper.check_xfer_state.side_effect = lambda h: "ERR" if h == 10 else "PROC"
+    w.get_finished()
+    w.shutdown()
+    w.shutdown()
+    assert w.nixl_wrapper.release_xfer_handle.call_args_list == [call(10), call(11)]
+    assert w.nixl_wrapper.remove_remote_agent.call_count == 2
 
 
 def test_transfer_topology_unregister():

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -384,6 +384,9 @@ def test_read_blocks_for_req_expands_remote_ids(
 
     worker = object.__new__(NixlConnectorWorker)
     worker._physical_blocks_per_logical_kv_block = local_physical_per_logical
+    worker._invalid_remote_engines = set()
+    worker._recv_engine_by_req = {}
+    worker._remote_agents = {"remote-engine": {}}
     worker._engine_last_active = {}
     worker._recving_transfers = {}
     worker._bidirectional_kv_xfer_enabled = False

--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -464,7 +464,8 @@ def test_hetero_ppl_multi_read_writes_stay_within_request_blocks():
         remote_ssm_sizes=(24, 32),
     )
     for rank in (0, 1):
-        worker.add_remote_agent(meta_r, remote_tp_rank=rank, remote_tp_size=2)
+        agent = worker.add_remote_agent(meta_r, remote_tp_rank=rank, remote_tp_size=2)
+        worker._remote_agents.setdefault(meta_r.engine_id, {})[(0, rank)] = agent
 
     # Request B: 17 matched tokens. Local: 2 logical blocks (24 tok
     # capacity); remote: 16 prefilled tokens -> 2 remote logical blocks.
@@ -564,7 +565,10 @@ def _run_hetero_case(
         remote_ssm_sizes=(48 // tp_size, 64 // tp_size),
     )
     for rank in range(tp_size):
-        worker.add_remote_agent(meta_r, remote_tp_rank=rank, remote_tp_size=tp_size)
+        agent = worker.add_remote_agent(
+            meta_r, remote_tp_rank=rank, remote_tp_size=tp_size
+        )
+        worker._remote_agents.setdefault(meta_r.engine_id, {})[(0, rank)] = agent
 
     # Sparse ids so neighbors exist between the request's blocks.
     local_attn = [2 * i + 1 for i in range(n_local)]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -39,6 +39,70 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
+        self._failed_remote_engines: set[str] = set()
+        self._invalid_remote_engines: set[str] = set()
+        # Request metadata can disappear before all of its reads have completed.
+        self._recv_engine_by_req: dict[str, str] = {}
+
+    def _handle_failed_transfer(self, req_id: str, handle: int | None):
+        meta = self._recving_metadata.get(req_id)
+        engine_id = (
+            meta.remote.engine_id
+            if meta is not None and meta.remote is not None
+            else self._recv_engine_by_req.get(req_id)
+        )
+        if engine_id is not None:
+            with self._handshake_lock:
+                self._failed_remote_engines.add(engine_id)
+        super()._handle_failed_transfer(req_id, handle)
+
+    def get_finished(self) -> tuple[set[str], set[str]]:
+        finished = super().get_finished()
+        self._recv_engine_by_req = {
+            req_id: engine_id
+            for req_id, engine_id in self._recv_engine_by_req.items()
+            if req_id in self._recving_transfers
+        }
+        if self._failed_remote_engines or self._invalid_remote_engines:
+            self._recover_remote_engines()
+        return finished
+
+    def _recover_remote_engines(self) -> None:
+        with self._handshake_lock:
+            # Handshakes load NIXL metadata outside this lock. Wait for their
+            # callbacks before querying or removing native metadata.
+            if self._handshake_futures:
+                return
+            for engine_id in self._failed_remote_engines - self._invalid_remote_engines:
+                try:
+                    # No descriptors: query local existence, not peer health.
+                    if any(
+                        not self.nixl_wrapper.check_remote_metadata(agent)
+                        for agent in self._remote_agents.get(engine_id, {}).values()
+                    ):
+                        self._invalid_remote_engines.add(engine_id)
+                        logger.info(
+                            "Remote engine %s lost local NIXL metadata; "
+                            "waiting for outstanding reads before cleanup.",
+                            engine_id,
+                        )
+                except Exception:
+                    logger.warning(
+                        "Could not check local NIXL metadata for engine %s.",
+                        engine_id,
+                        exc_info=True,
+                    )
+            self._failed_remote_engines.clear()
+            busy_engines = set(self._recv_engine_by_req.values())
+            for engine_id in self._invalid_remote_engines - busy_engines:
+                if engine_id in self._remote_agents:
+                    self._cleanup_remote_engine(engine_id, log_eviction=False)
+                self._invalid_remote_engines.remove(engine_id)
+                logger.info(
+                    "Cleared invalid NIXL state for engine %s; "
+                    "the next request will handshake again.",
+                    engine_id,
+                )
 
     def start_load_kv(self, metadata: NixlConnectorMetadata):
         """
@@ -63,14 +127,6 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             )
             # always store metadata for failure recovery
             self._recving_metadata[req_id] = meta
-            if remote_engine_id not in self._remote_agents:
-                # Initiate handshake with remote engine to exchange metadata.
-                with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
-                        self._background_nixl_handshake(req_id, remote_engine_id, meta)
-                        continue
-
-            # Handshake already completed, start async read xfer.
             self._read_blocks_for_req(req_id, meta)
 
         # Start transfers for requests whose handshakes have now finished.
@@ -130,6 +186,16 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
+        if engine_id in self._invalid_remote_engines:
+            self._handle_failed_transfer(req_id, None)
+            return
+        if engine_id not in self._remote_agents:
+            with self._handshake_lock:
+                if engine_id not in self._remote_agents:
+                    # A queued ready request may outlive invalid-peer cleanup.
+                    self._background_nixl_handshake(req_id, engine_id, meta)
+                    return
+        self._recv_engine_by_req[req_id] = engine_id
         # Update last activity from this remote. Mind that cleanup is done on main
         # thread (this one), so we don't race on this structure.
         self._engine_last_active[engine_id] = time.perf_counter()


### PR DESCRIPTION
## Summary

Recover a pull peer whose **local NIXL metadata is missing**, while Prefill is
still alive with the same engine ID. Otherwise, the cached `_remote_agents`
entry and prepared dlists can keep later requests on the stale path.

- On receive failure, query local metadata existence without descriptors.
  A transfer failure alone is not treated as evidence that Prefill is dead.
- Defer native checks/cleanup until background handshakes and the affected
  peer's receive handles finish, including handles outliving request metadata.
- Reuse existing cleanup, so a fresh request can handshake again. Preserve
  healthy peers; never replay a failed request's old remote block IDs.

Only `nixl/pull_worker.py` changes production behavior. Tests extend the existing
connector suite and initialize the HMA fixture. No new router API,
configuration, push-mode behavior, or successful-path native metadata query.

## Related Work

Related to #49238. #50047 also cleans peer state, but on a broader
dead-peer/address-replacement basis. This patch requires positive local
metadata absence and handles unchanged producer identity. There is cleanup
overlap, not a claim that the two proposals are unrelated. This narrower scope
is explained in the [#49238 discussion](https://github.com/vllm-project/vllm/issues/49238#issuecomment-5552206777). @YannikHinteregger, I would appreciate
your feedback on the overlap with #50047 and whether consolidation is preferable.

#52232 is a separate, necessary HMA fail-closed fix and is **not included here**.
Recovery alone does not prevent a failed HMA request from generating invalid
output. The integration experiment tested both changes, with attribution to
Tyler Michael Smith, and a small API terminal-error follow-up. #54689 (TTL)
and NIXL #1987 (native UCX race) are outside this patch's scope.

## Validation

### Rebase onto main (2026-09-20)

Rebased onto `03f83013872015f6addb66954e2752d2d9bccd96`. Recovery now runs from
`get_transfer_results()` (also covering the legacy `get_finished()` wrapper).
The failure override forwards the current failure set, metric flag, and boolean
handle-release result. Main's wait-for-all-reads and notify-only/full-cache-hit
behavior is preserved; the obsolete descriptor-fixture changes were dropped.

- Local CPU source harness, executing the actual class/test ASTs with a mocked
  NIXL boundary: **18 passed**. This is not a full-import vLLM test run.
- Core negative control on the same main revision: **3 expected recovery
  assertion failures, 5 controls passed**.
- Ruff lint/format, `compileall`, and `git diff --check`: passed.
- Full-import pytest collection is blocked locally by missing `tblib`.
  GPU/model, native NIXL, and full-suite validation have **not** been rerun for
  this rebase. No remote service was accessed or changed.

Focused command for a complete vLLM test environment (not claimed as executed
successfully for this rebase):

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_nixl_connector.py \
  -m cpu_test -k peer_recovery -v
```

### Previous validation (before this rebase)

The CPU and serving results below belong to the original implementation on
base `8369affa5428ca29a30f378d660fbffbad12e240`, not the rebased code.

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_nixl_connector.py \
  -m cpu_test -k peer_recovery -v
# 14 passed, full vLLM imports, mocked NIXL boundary.

.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_nixl_connector.py \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py \
  tests/v1/kv_connector/unit/test_nixl_desc_geometry.py \
  tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py \
  tests/v1/kv_connector/unit/test_nixl_push_connector.py -m cpu_test -q
# 339 passed before marking the 14 new cases as cpu_test.
# The two selections together cover 353 distinct recovery-only cases.
```

The recovery-only CPU regression selections passed 353 distinct cases across
two runs. The later combined recovery + #52232 + API integration passed 425
selected tests; this is not claimed as 425 tests of the independent diff.
Pinned Ruff lint/format, `compileall`, and `git diff --check` passed. The full
pre-commit run could not initialize its `rhysd/actionlint` dependency because
GitHub Git HTTPS timed out; it is not reported as passed. Local commit hooks
were bypassed once after that infrastructure failure, not after a code-check
failure. CI/full hook validation remains pending.

Real serving validation used isolated TP1 P/D, DeepSeek-V4-Flash-0731,
NIXL 1.3.2, fp8 HMA KV, eager mode, and `UCX_TLS=tcp,cuda_copy` with the existing
TP1 packed-layout fix. With no active reads, a private hook removed only
Decode's local remote metadata, retaining the Python cache. The actual stale
read failed with `NIXL_ERR_NOT_FOUND`; fresh requests automatically re-handshook
with the same Prefill engine ID and returned the expected short answers.

Important limits: the recovery-only failed request still emitted 32 invalid
tokens. With #52232 and the API follow-up, the final 10-request scenario
passed: two normal requests, four controlled native failures across Chat and
Completion streaming/non-streaming, and four fresh Chat recoveries. The
failed requests emitted no generated content. Full logs retain the earlier
failure and an independently wrong pre-injection arithmetic control.

This is controlled failure-path validation, not general accuracy, natural
transport-failure reproduction, RDMA/NVLink, or multi-rank native-race coverage.
Stuck reads/handshakes defer recovery; they are not forcibly released.
Native cleanup exceptions are not swallowed; this patch does not add recovery
from a failed native resource release.

[Complete selected logs, response bodies/SSE, exact test commands and patches](https://gist.github.com/xijiaat/a975858a507d6c45fd394b3675cc0ab9).
The bundle distinguishes the original four-file recovery patch from the combined
HMA/API experiment. Internal addresses/paths are anonymized; selected log
lines are retained. The additional HMA/API evidence is also reported in
[#52232](https://github.com/vllm-project/vllm/pull/52232#issuecomment-5552174526).

## AI Assistance

OpenAI Codex assisted with implementation, testing, and this report.
The human submitter reviewed and approved the original contribution; the
2026-09-20 compatibility adaptations still need human review. The limited
failure-path tests above are not a claim of comprehensive model evaluation
or production readiness.
