### PR TITLE
[Feature][Frontend] Preserve reasoning effort in Chat Completions history

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -79,6 +79,38 @@ Next, make a request to the model that should return the reasoning content in th
 
 The `reasoning` field contains the reasoning steps that led to the final conclusion, while the `content` field contains the final conclusion.
 
+### Reasoning-effort history
+
+Chat Completions assistant messages include optional `reasoning_effort` metadata. It records the configured string value from the effective chat-template kwargs, with precedence: top-level request `reasoning_effort`, then request `chat_template_kwargs["reasoning_effort"]`, then server defaults. It does not measure actual reasoning depth or infer a template's private default. A null or absent value means unknown; vLLM does not silently assign `"medium"`.
+
+For a deployed model and template that support `"low"` and `"high"` effort, append the full serialized assistant message to retain its historical setting when changing effort on the next request:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+model = client.models.list().data[0].id
+messages = [{"role": "user", "content": "What is 15 * 37?"}]
+
+response = client.chat.completions.create(
+    model=model,
+    messages=messages,
+    reasoning_effort="low",
+)
+messages.append(response.choices[0].message.model_dump())
+messages.append({"role": "user", "content": "Explain how to check that answer."})
+
+response = client.chat.completions.create(
+    model=model,
+    messages=messages,
+    reasoning_effort="high",
+)
+```
+
+The earlier assistant message retains `"low"` independently of the current request's `"high"`. Historical messages without a known effort are not filled from the current request. vLLM passes this assistant metadata into the chat-template context, but a template must explicitly consume it to change per-turn rendering. This metadata transport alone does not change existing templates or KV-cache behavior.
+
+For streaming responses, a known `reasoning_effort` is emitted once per choice in its initial role delta. Manual stream accumulators must preserve it when assembling the assistant message for replay.
+
 ## Streaming chat completions
 
 Streaming chat completions are also supported for reasoning models. The `reasoning` field is available in the `delta` field in [chat completion response chunks](https://platform.openai.com/docs/api-reference/chat/streaming).

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -951,6 +951,105 @@ async def test_serving_chat_returns_correct_model_name():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    ("server_kwargs", "request_kwargs", "expected_effort"),
+    [
+        pytest.param(
+            {"reasoning_effort": "low"},
+            {
+                "chat_template_kwargs": {"reasoning_effort": "medium"},
+                "reasoning_effort": "high",
+            },
+            "high",
+            id="top-level-overrides-nested-and-server",
+        ),
+        pytest.param(
+            {"reasoning_effort": "low"},
+            {"chat_template_kwargs": {"reasoning_effort": "custom"}},
+            "custom",
+            id="nested-overrides-server",
+        ),
+        pytest.param(
+            {"reasoning_effort": "low"},
+            {"reasoning_effort": None},
+            "low",
+            id="server-default",
+        ),
+        pytest.param(
+            {"reasoning_effort": "high"},
+            {"reasoning_effort": "none"},
+            "none",
+            id="explicit-none-is-known",
+        ),
+        pytest.param({}, {}, None, id="absent-is-unknown"),
+        pytest.param(
+            {},
+            {"chat_template_kwargs": {"reasoning_effort": None}},
+            None,
+            id="null-is-unknown",
+        ),
+        pytest.param(
+            {"reasoning_effort": "high"},
+            {"chat_template_kwargs": {"reasoning_effort": 7}},
+            None,
+            id="non-string-is-unknown",
+        ),
+    ],
+)
+async def test_chat_response_reasoning_effort(
+    stream, server_kwargs, request_kwargs, expected_effort
+):
+    """Responses retain configured effort without guessing template defaults."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = MagicMock()
+    serving = _build_serving_chat(mock_engine)
+    serving.default_chat_template_kwargs = server_kwargs
+    messages = [{"role": "user", "content": "Test"}]
+    serving.online_renderer.render_chat = AsyncMock(
+        return_value=(messages, [{"type": "tokens", "prompt_token_ids": [1, 2, 3]}])
+    )
+    output = _make_metrics_request_output(metrics=None)
+    second_choice = _make_metrics_request_output(metrics=None).outputs[0]
+    second_choice.index = 1
+    output.outputs.append(second_choice)
+    mock_engine.generate.return_value = _single_request_output(output)
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=messages,
+        max_tokens=10,
+        n=2,
+        stream=stream,
+        **request_kwargs,
+    )
+
+    response = await serving.create_chat_completion(request)
+    if not stream:
+        assert isinstance(response, ChatCompletionResponse)
+        choices = json.loads(response.model_dump_json())["choices"]
+        assert [choice["index"] for choice in choices] == [0, 1]
+        for choice in choices:
+            assert choice["message"]["content"] == "Hello"
+            assert choice["message"]["reasoning_effort"] == expected_effort
+    else:
+        deltas_by_choice: dict[int, list[dict]] = {0: [], 1: []}
+        async for line in response:
+            payload = line.removeprefix("data: ").strip()
+            if payload == "[DONE]":
+                continue
+            for choice in json.loads(payload)["choices"]:
+                deltas_by_choice[choice["index"]].append(choice["delta"])
+        for deltas in deltas_by_choice.values():
+            assert deltas[0]["role"] == "assistant"
+            assert deltas[0].get("reasoning_effort") == expected_effort
+            assert "".join(delta.get("content", "") for delta in deltas) == "Hello"
+            assert all("reasoning_effort" not in delta for delta in deltas[1:])
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("stream", [True, False])
 async def test_admission_rejection_escapes_before_response_starts(stream):
     """Overload rejections must propagate out of create_chat_completion.

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import json
 import warnings
 from collections.abc import Mapping
 from typing import Literal
@@ -9,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
+from jinja2 import Template
 
 from vllm.assets.audio import AudioAsset
 from vllm.assets.image import ImageAsset
@@ -21,6 +23,10 @@ from vllm.entrypoints.chat_utils import (
     _postprocess_messages,
     parse_chat_messages,
     parse_chat_messages_async,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatMessage,
 )
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import MultiModalDataDict, MultiModalUUIDDict
@@ -718,6 +724,66 @@ def test_parse_chat_messages_empty_system(
         {"role": "system", "content": [{"type": "text", "text": ""}]},
         {"role": "user", "content": [{"type": "text", "text": "Who are you?"}]},
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.parametrize("content_format", ["string", "openai"])
+async def test_parse_chat_messages_replays_historical_reasoning_effort(
+    is_async, content_format
+):
+    """Replaying a response must not apply the next turn's effort to history."""
+    previous_message = ChatMessage(
+        role="assistant", content="Previous answer", reasoning_effort="low"
+    )
+    request = ChatCompletionRequest.model_validate_json(
+        json.dumps(
+            {
+                "model": "test-model",
+                "messages": [
+                    {"role": "user", "content": "Question", "reasoning_effort": "low"},
+                    previous_message.model_dump(),
+                    {"role": "assistant", "content": "Older answer"},
+                    {
+                        "role": "assistant",
+                        "content": "Unknown effort",
+                        "reasoning_effort": None,
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "Tool result",
+                        "reasoning_effort": "low",
+                    },
+                    {"role": "user", "content": "Follow-up"},
+                ],
+                "reasoning_effort": "high",
+            }
+        )
+    )
+    model_config = MagicMock(spec=ModelConfig, multimodal_config=None)
+    if is_async:
+        conversation, _, _ = await parse_chat_messages_async(
+            request.messages, model_config, content_format=content_format
+        )
+    else:
+        conversation, _, _ = parse_chat_messages(
+            request.messages, model_config, content_format=content_format
+        )
+
+    params = request.build_chat_params(None, content_format)
+    template = Template(
+        "{% for message in messages %}"
+        "{{ message.role }}:{{ message.reasoning_effort | default('missing') }};"
+        "{% endfor %}"
+        "current:{{ reasoning_effort }}"
+    )
+    assert template.render(
+        messages=conversation, **params.get_apply_chat_template_kwargs()
+    ) == (
+        "user:missing;assistant:low;assistant:missing;assistant:missing;"
+        "tool:missing;user:missing;current:high"
+    )
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -375,6 +375,9 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
     reasoning: str | None
     """The reasoning content for interleaved thinking."""
 
+    reasoning_effort: str | None
+    """The configured reasoning effort for this assistant message."""
+
     tools: list[ChatCompletionFunctionToolParam] | None
     """The tools for developer role."""
 
@@ -411,6 +414,9 @@ class ConversationMessage(TypedDict, total=False):
 
     reasoning_content: str | None
     """Deprecated: The reasoning content for interleaved thinking."""
+
+    reasoning_effort: str | None
+    """The configured reasoning effort for this assistant message."""
 
     tools: list[ChatCompletionFunctionToolParam] | None
     """The tools for developer role."""
@@ -1973,6 +1979,7 @@ def _parse_chat_message_content(
     role = message["role"]
     content = message.get("content")
     reasoning = message.get("reasoning")
+    reasoning_effort = message.get("reasoning_effort")
 
     if content is None:
         content = []
@@ -2002,6 +2009,8 @@ def _parse_chat_message_content(
                 result_msg["reasoning_content"] = cast(
                     str, reasoning
                 )  # keep compatibility
+            if reasoning_effort is not None:
+                result_msg["reasoning_effort"] = cast(str, reasoning_effort)
         elif role == "tool":
             parsed_msg = _ToolParser(message)
             if "tool_call_id" in parsed_msg:

--- a/vllm/entrypoints/generate/base/protocol.py
+++ b/vllm/entrypoints/generate/base/protocol.py
@@ -330,6 +330,7 @@ class DeltaMessage(OpenAIBaseModel):
     role: str | None = None
     content: str | None = None
     reasoning: str | None = None
+    reasoning_effort: str | None = None
     tool_calls: list[DeltaToolCall] = Field(default_factory=list)
 
     @model_serializer(mode="wrap")

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -69,6 +69,7 @@ class ChatMessage(OpenAIBaseModel):
 
     # vLLM-specific fields that are not in OpenAI spec
     reasoning: str | None = None
+    reasoning_effort: str | None = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -402,6 +402,7 @@ class OpenAIServingChat(GenerateBaseServing):
                 mm_token_counts=mm_token_counts,
             )
 
+        reasoning_effort = chat_template_kwargs.get("reasoning_effort")
         return await self.chat_completion_full_generator(
             request,
             result_generator,
@@ -412,6 +413,9 @@ class OpenAIServingChat(GenerateBaseServing):
             request_metadata,
             parser=parser,
             mm_token_counts=mm_token_counts,
+            reasoning_effort=(
+                reasoning_effort if isinstance(reasoning_effort, str) else None
+            ),
         )
 
     def get_chat_request_role(self, request: ChatCompletionRequest) -> str:
@@ -529,6 +533,9 @@ class OpenAIServingChat(GenerateBaseServing):
                     # Send first response for each request.n (index) with
                     # the role
                     role = self.get_chat_request_role(request)
+                    reasoning_effort = (chat_template_kwargs or {}).get(
+                        "reasoning_effort"
+                    )
 
                     # ``res.prompt`` is the rendered chat-templated prompt
                     prompt_text = res.prompt if request.return_prompt_text else None
@@ -545,6 +552,9 @@ class OpenAIServingChat(GenerateBaseServing):
                             logprobs=None,
                             finish_reason=None,
                         )
+
+                        if isinstance(reasoning_effort, str):
+                            choice_data.delta.reasoning_effort = reasoning_effort
 
                         # return prompt_token_ids at the first chunk ever
                         chunk = ChatCompletionStreamResponse(
@@ -920,6 +930,7 @@ class OpenAIServingChat(GenerateBaseServing):
         request_metadata: RequestResponseMetadata,
         parser: Parser | None = None,
         mm_token_counts: dict[str, int] | None = None,
+        reasoning_effort: str | None = None,
     ) -> ErrorResponse | ChatCompletionResponse:
         created_time = int(time.time())
         final_res: RequestOutput | None = None
@@ -1064,6 +1075,7 @@ class OpenAIServingChat(GenerateBaseServing):
             # citation-aware handlers use this to surface grounding
             # metadata cached on the reasoning parser.
             message = self._finalize_response_message(message, parser=parser)
+            message.reasoning_effort = reasoning_effort
 
             # In OpenAI's API, when a tool is called, the finish_reason is:
             # "tool_calls" for "auto" or "required" tool calls,


### PR DESCRIPTION
## Purpose

Add optional `reasoning_effort` metadata to Chat Completions assistant messages and preserve it when those messages are supplied as conversation history.

This enables two uses:

- **Preserve historical effort when changing effort between turns.** Clients can append the returned assistant message without separately reconstructing that turn's effort. A chat template that consumes per-message effort can then keep earlier prompt tokens unchanged when the next request selects a different effort, helping retain reusable KV-cache prefixes. This patch provides the metadata transport; it does not modify templates, guarantee cache hits, or claim a measured performance improvement.
- **Discover server-configured defaults.** When a request omits effort but the server supplies a string `reasoning_effort` through its default chat-template kwargs, the returned assistant message reports that value. Clients can inspect the configured setting without knowing the server's launch configuration.

The field reports the configured string from the existing effective chat-template kwargs, with precedence: top-level request `reasoning_effort`, request `chat_template_kwargs`, then server defaults. It does not infer defaults hidden inside a template, report model-specific normalized levels, or measure actual reasoning depth. If no string value is available, effort remains unknown rather than being assigned an implicit level.

### API behavior

- Nonstream responses expose the nullable field on `choices[].message.reasoning_effort`.
- Streaming responses emit a known value once per choice in its initial role delta. Stream accumulators must retain it when assembling the assistant message.
- Replayed assistant metadata survives normalization into chat-template context. A new request's effort does not overwrite historical effort, and absent/null historical effort stays unknown.
- No changes to the Responses API, model templates, or KV-cache engine.

### Usage

For a deployed model and template that support the selected effort levels:

```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
model = client.models.list().data[0].id
messages = [{"role": "user", "content": "What is 15 * 37?"}]

# No explicit effort: inspect the server-configured default, if available.
response = client.chat.completions.create(model=model, messages=messages)
assistant = response.choices[0].message.model_dump()
print(assistant.get("reasoning_effort"))  # A configured string, or None.
messages.append(assistant)
messages.append({"role": "user", "content": "Explain how to check that answer."})

# The new effort does not rewrite the previous assistant's recorded setting.
response = client.chat.completions.create(
    model=model, messages=messages, reasoning_effort="high"
)
```

Returning the full assistant object preserves the metadata with ordinary OpenAI Python SDK serialization. Preserving a previous prompt's token prefix still requires a compatible per-turn template and otherwise stable rendering of the conversation history.

## Test Plan

Focused regressions cover response precedence, server-default reporting, unknown values, multiple choices, first-delta streaming metadata, and HTTP JSON replay through synchronous/asynchronous normalization into template context:

```bash
python -m pytest -q \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py \
  tests/entrypoints/unit_tests/test_chat_utils.py \
  -k 'test_chat_response_reasoning_effort or test_parse_chat_messages_replays_historical_reasoning_effort'
```

A separate smoke exercised OpenAI Python SDK 3.8.0 via `httpx.MockTransport` and a mock inference engine, through the changed serving code, real `OnlineRenderer`/`HfRenderer`, normalization, and a local character tokenizer. It checked low-to-high replay, unknown history, SDK streaming accumulation/replay, and preservation of an earlier prompt-token prefix with an illustrative per-turn template. No model inference was performed.

Run applicable repository hooks on the patch:

```bash
pre-commit run --from-ref HEAD^ --to-ref HEAD --show-diff-on-failure
```

## Test Result

The focused Linux/Python 3.12.14 run passed all **18 cases** (130 deselected). The SDK-to-renderer smoke passed all five checks. All applicable pre-commit hooks passed, including Ruff, Markdown, spelling, Python 3.10 mypy, SPDX, and repository-specific import/configuration checks; hooks for unchanged file types were skipped normally.

GPU/model inference, cache-performance benchmarking, and the project-wide test suite were not run. The frontend-only validation environment emitted CUDA/NVML availability and existing deprecation warnings.

## AI assistance

AI tools assisted with implementation, tests, documentation, and review. The human submitter has reviewed and approved the patch and remains responsible for the contribution.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan includes commands and exercised behavior.
- [x] Test results and validation limitations are stated.
- [x] User-facing documentation is updated in `docs/features/reasoning_outputs.md`.
</details>
