### PR TITLE
[Frontend] Support KV cache report mode request headers

### DIFF
--- a/docs/serving/online_serving/openai_compatible_server.md
+++ b/docs/serving/online_serving/openai_compatible_server.md
@@ -134,39 +134,15 @@ completion = client.chat.completions.create(
 )
 ```
 
-The `X-KV-Cache-Report-Mode` request header selects KV cache event reporting
-without adding fields to the request body. It accepts `incremental` (the default)
-or `full`. With KV cache events enabled, `full` also reports reused prefix-cache
-blocks. The header does not enable event publishing; configure `--kv-events-config`
-on the server.
+Use `extra_headers={"X-KV-Cache-Report-Mode": "full"}` to select KV cache event
+reporting. Accepted values are `incremental` (default) and `full`, which also
+reports reused prefix-cache blocks. Event publishing requires `--kv-events-config`.
+An explicit body `vllm_xargs.kv_cache_report_mode` takes precedence. Invalid header
+values are ignored.
 
-```python
-completion = client.chat.completions.create(
-    model="NousResearch/Meta-Llama-3-8B-Instruct",
-    messages=[{"role": "user", "content": "Hello!"}],
-    extra_headers={"X-KV-Cache-Report-Mode": "full"},
-)
-```
-
-An explicit `vllm_xargs.kv_cache_report_mode` in the body takes precedence over
-the header. The token-in/token-out API uses `sampling_params.extra_args` for
-this body parameter (`sampling_params.vllm_xargs` in the Rust frontend).
-Invalid header values are ignored, preserving the body value or the default mode.
-
-The Python frontend supports this header on Chat Completions, Completions,
-Responses, Anthropic Messages, Cohere Chat, batched chat, render/generate,
-generative scoring, and audio transcription/translation. Beam search preserves
-the mode across its internal generation requests. Realtime audio accepts the
-header on the WebSocket handshake and applies it to each utterance.
-
-The Rust frontend supports the header on Chat Completions, Completions,
-render/generate, and as `x-kv-cache-report-mode` metadata on both gRPC generation
-methods. Invalid report-mode metadata is ignored. Offline Python uses
-`SamplingParams.extra_args`; JSONL batch requests use `vllm_xargs` in each request
-body. Neither has HTTP request headers.
-
-The Python `--grpc` entrypoint delegates generation to `smg-grpc-servicer`.
-Metadata support on that path requires a corresponding change in that package.
+Realtime audio uses the WebSocket handshake header. Rust gRPC uses
+`x-kv-cache-report-mode` metadata; Python `--grpc` requires separate support in
+`smg-grpc-servicer`.
 
 ## API Reference
 

--- a/docs/serving/online_serving/openai_compatible_server.md
+++ b/docs/serving/online_serving/openai_compatible_server.md
@@ -151,18 +151,17 @@ completion = client.chat.completions.create(
 An explicit `vllm_xargs.kv_cache_report_mode` in the body takes precedence over
 the header. The token-in/token-out API uses `sampling_params.extra_args` for
 this body parameter (`sampling_params.vllm_xargs` in the Rust frontend).
-Invalid header values return HTTP 400, including when the body specifies a mode.
+Invalid header values are ignored, preserving the body value or the default mode.
 
 The Python frontend supports this header on Chat Completions, Completions,
 Responses, Anthropic Messages, Cohere Chat, batched chat, render/generate,
 generative scoring, and audio transcription/translation. Beam search preserves
 the mode across its internal generation requests. Realtime audio accepts the
-header on the WebSocket handshake and applies it to each utterance; invalid
-values produce an error event when generation starts.
+header on the WebSocket handshake and applies it to each utterance.
 
 The Rust frontend supports the header on Chat Completions, Completions,
 render/generate, and as `x-kv-cache-report-mode` metadata on both gRPC generation
-methods. Invalid gRPC metadata returns `INVALID_ARGUMENT`. Offline Python uses
+methods. Invalid report-mode metadata is ignored. Offline Python uses
 `SamplingParams.extra_args`; JSONL batch requests use `vllm_xargs` in each request
 body. Neither has HTTP request headers.
 

--- a/docs/serving/online_serving/openai_compatible_server.md
+++ b/docs/serving/online_serving/openai_compatible_server.md
@@ -134,6 +134,41 @@ completion = client.chat.completions.create(
 )
 ```
 
+The `X-KV-Cache-Report-Mode` request header selects KV cache event reporting
+without adding fields to the request body. It accepts `incremental` (the default)
+or `full`. With KV cache events enabled, `full` also reports reused prefix-cache
+blocks. The header does not enable event publishing; configure `--kv-events-config`
+on the server.
+
+```python
+completion = client.chat.completions.create(
+    model="NousResearch/Meta-Llama-3-8B-Instruct",
+    messages=[{"role": "user", "content": "Hello!"}],
+    extra_headers={"X-KV-Cache-Report-Mode": "full"},
+)
+```
+
+An explicit `vllm_xargs.kv_cache_report_mode` in the body takes precedence over
+the header. The token-in/token-out API uses `sampling_params.extra_args` for
+this body parameter (`sampling_params.vllm_xargs` in the Rust frontend).
+Invalid header values return HTTP 400, including when the body specifies a mode.
+
+The Python frontend supports this header on Chat Completions, Completions,
+Responses, Anthropic Messages, Cohere Chat, batched chat, render/generate,
+generative scoring, and audio transcription/translation. Beam search preserves
+the mode across its internal generation requests. Realtime audio accepts the
+header on the WebSocket handshake and applies it to each utterance; invalid
+values produce an error event when generation starts.
+
+The Rust frontend supports the header on Chat Completions, Completions,
+render/generate, and as `x-kv-cache-report-mode` metadata on both gRPC generation
+methods. Invalid gRPC metadata returns `INVALID_ARGUMENT`. Offline Python uses
+`SamplingParams.extra_args`; JSONL batch requests use `vllm_xargs` in each request
+body. Neither has HTTP request headers.
+
+The Python `--grpc` entrypoint delegates generation to `smg-grpc-servicer`.
+Metadata support on that path requires a corresponding change in that package.
+
 ## API Reference
 
 ### Completions API

--- a/rust/src/server/src/grpc/inference.rs
+++ b/rust/src/server/src/grpc/inference.rs
@@ -102,12 +102,14 @@ impl InferenceServiceImpl {
 
     async fn prepare_request(
         &self,
-        mut proto_request: pb::GenerateRequest,
+        request: Request<pb::GenerateRequest>,
         data_parallel_rank: Option<u32>,
-        kv_cache_report_mode: Option<String>,
         stream: bool,
         rpc: &'static str,
     ) -> Result<PreparedGrpcRequest, Status> {
+        let (metadata, _, mut proto_request) = request.into_parts();
+        let kv_cache_report_mode =
+            metadata.get(KV_CACHE_REPORT_MODE_HEADER).and_then(|value| value.to_str().ok());
         let started_at = Instant::now();
         let arrival_time = current_unix_timestamp_secs();
         if proto_request.request_id.is_empty() {
@@ -138,7 +140,7 @@ impl InferenceServiceImpl {
                 convert::to_text_request(proto_request, stream, self.state.served_model_names())?;
             text_request.sampling_params.vllm_xargs = merge_kv_cache_report_mode(
                 text_request.sampling_params.vllm_xargs,
-                kv_cache_report_mode.as_deref(),
+                kv_cache_report_mode,
             );
             text_request.arrival_time = Some(arrival_time);
             text_request.data_parallel_rank = data_parallel_rank;
@@ -225,26 +227,12 @@ impl pb::inference_server::Inference for InferenceServiceImpl {
         request: Request<pb::GenerateRequest>,
     ) -> Result<Response<pb::GenerateResponse>, Status> {
         let data_parallel_rank = data_parallel_rank_from_metadata(&request)?;
-        let kv_cache_report_mode = request
-            .metadata()
-            .get(KV_CACHE_REPORT_MODE_HEADER)
-            .and_then(|value| value.to_str().ok())
-            .map(str::to_owned);
-        let proto_req = request.into_inner();
-        let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
+        let response_opts = ResponseOpts::from_proto(request.get_ref().response.as_ref());
         let PreparedGrpcRequest {
             text_request,
             request_span,
             started_at,
-        } = self
-            .prepare_request(
-                proto_req,
-                data_parallel_rank,
-                kv_cache_report_mode,
-                false,
-                "Generate",
-            )
-            .await?;
+        } = self.prepare_request(request, data_parallel_rank, false, "Generate").await?;
 
         let stream = self
             .state
@@ -300,25 +288,13 @@ impl pb::inference_server::Inference for InferenceServiceImpl {
         request: Request<pb::GenerateRequest>,
     ) -> Result<Response<Self::GenerateStreamStream>, Status> {
         let data_parallel_rank = data_parallel_rank_from_metadata(&request)?;
-        let kv_cache_report_mode = request
-            .metadata()
-            .get(KV_CACHE_REPORT_MODE_HEADER)
-            .and_then(|value| value.to_str().ok())
-            .map(str::to_owned);
-        let proto_req = request.into_inner();
-        let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
+        let response_opts = ResponseOpts::from_proto(request.get_ref().response.as_ref());
         let PreparedGrpcRequest {
             text_request,
             request_span,
             started_at,
         } = self
-            .prepare_request(
-                proto_req,
-                data_parallel_rank,
-                kv_cache_report_mode,
-                true,
-                "GenerateStream",
-            )
+            .prepare_request(request, data_parallel_rank, true, "GenerateStream")
             .await?;
 
         let stream = self

--- a/rust/src/server/src/grpc/inference.rs
+++ b/rust/src/server/src/grpc/inference.rs
@@ -139,8 +139,7 @@ impl InferenceServiceImpl {
             text_request.sampling_params.vllm_xargs = merge_kv_cache_report_mode(
                 text_request.sampling_params.vllm_xargs,
                 kv_cache_report_mode.as_deref(),
-            )
-            .map_err(|error| Status::invalid_argument(error.to_error_response().error.message))?;
+            );
             text_request.arrival_time = Some(arrival_time);
             text_request.data_parallel_rank = data_parallel_rank;
 
@@ -229,7 +228,8 @@ impl pb::inference_server::Inference for InferenceServiceImpl {
         let kv_cache_report_mode = request
             .metadata()
             .get(KV_CACHE_REPORT_MODE_HEADER)
-            .map(|value| value.to_str().unwrap_or_default().to_owned());
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
         let proto_req = request.into_inner();
         let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
         let PreparedGrpcRequest {
@@ -303,7 +303,8 @@ impl pb::inference_server::Inference for InferenceServiceImpl {
         let kv_cache_report_mode = request
             .metadata()
             .get(KV_CACHE_REPORT_MODE_HEADER)
-            .map(|value| value.to_str().unwrap_or_default().to_owned());
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
         let proto_req = request.into_inner();
         let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
         let PreparedGrpcRequest {

--- a/rust/src/server/src/grpc/inference.rs
+++ b/rust/src/server/src/grpc/inference.rs
@@ -19,6 +19,7 @@ use vllm_text::{DecodedTextEvent, Prompt, SampledDelta, TextOutputStreamExt as _
 use super::convert::{self, ResponseOpts};
 use super::{InferenceServer, pb};
 use crate::state::AppState;
+use crate::utils::{KV_CACHE_REPORT_MODE_HEADER, merge_kv_cache_report_mode};
 
 pub(crate) type InferenceGrpcService = InferenceServer<InferenceServiceImpl>;
 
@@ -103,6 +104,7 @@ impl InferenceServiceImpl {
         &self,
         mut proto_request: pb::GenerateRequest,
         data_parallel_rank: Option<u32>,
+        kv_cache_report_mode: Option<String>,
         stream: bool,
         rpc: &'static str,
     ) -> Result<PreparedGrpcRequest, Status> {
@@ -134,6 +136,11 @@ impl InferenceServiceImpl {
             let media = std::mem::take(&mut proto_request.media);
             let mut text_request =
                 convert::to_text_request(proto_request, stream, self.state.served_model_names())?;
+            text_request.sampling_params.vllm_xargs = merge_kv_cache_report_mode(
+                text_request.sampling_params.vllm_xargs,
+                kv_cache_report_mode.as_deref(),
+            )
+            .map_err(|error| Status::invalid_argument(error.to_error_response().error.message))?;
             text_request.arrival_time = Some(arrival_time);
             text_request.data_parallel_rank = data_parallel_rank;
 
@@ -219,13 +226,25 @@ impl pb::inference_server::Inference for InferenceServiceImpl {
         request: Request<pb::GenerateRequest>,
     ) -> Result<Response<pb::GenerateResponse>, Status> {
         let data_parallel_rank = data_parallel_rank_from_metadata(&request)?;
+        let kv_cache_report_mode = request
+            .metadata()
+            .get(KV_CACHE_REPORT_MODE_HEADER)
+            .map(|value| value.to_str().unwrap_or_default().to_owned());
         let proto_req = request.into_inner();
         let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
         let PreparedGrpcRequest {
             text_request,
             request_span,
             started_at,
-        } = self.prepare_request(proto_req, data_parallel_rank, false, "Generate").await?;
+        } = self
+            .prepare_request(
+                proto_req,
+                data_parallel_rank,
+                kv_cache_report_mode,
+                false,
+                "Generate",
+            )
+            .await?;
 
         let stream = self
             .state
@@ -281,6 +300,10 @@ impl pb::inference_server::Inference for InferenceServiceImpl {
         request: Request<pb::GenerateRequest>,
     ) -> Result<Response<Self::GenerateStreamStream>, Status> {
         let data_parallel_rank = data_parallel_rank_from_metadata(&request)?;
+        let kv_cache_report_mode = request
+            .metadata()
+            .get(KV_CACHE_REPORT_MODE_HEADER)
+            .map(|value| value.to_str().unwrap_or_default().to_owned());
         let proto_req = request.into_inner();
         let response_opts = ResponseOpts::from_proto(proto_req.response.as_ref());
         let PreparedGrpcRequest {
@@ -288,7 +311,13 @@ impl pb::inference_server::Inference for InferenceServiceImpl {
             request_span,
             started_at,
         } = self
-            .prepare_request(proto_req, data_parallel_rank, true, "GenerateStream")
+            .prepare_request(
+                proto_req,
+                data_parallel_rank,
+                kv_cache_report_mode,
+                true,
+                "GenerateStream",
+            )
             .await?;
 
         let stream = self

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -951,6 +951,48 @@ async fn unary_generate_missing_prompt_returns_invalid_argument() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn kv_cache_report_metadata_reaches_engine_for_unary_and_streaming() {
+    for stream in [false, true] {
+        let (inference, control, health, engine_task) = setup_grpc_service_with_backend(
+            b"engine-grpc-kv-report",
+            default_stream_output_specs(),
+            Arc::new(FakeTextBackend),
+            |request| {
+                assert_eq!(
+                    serde_json::to_value(&request.sampling_params.as_ref().unwrap().extra_args)
+                        .unwrap(),
+                    serde_json::json!({"kv_cache_report_mode": "full"}),
+                );
+            },
+        )
+        .await;
+        let (channel, server_task) = start_grpc_test_server(
+            inference,
+            control,
+            health,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await;
+        let mut client = InferenceClient::new(channel);
+        let mut request = tonic::Request::new(pb::GenerateRequest {
+            model: "test-model".to_string(),
+            prompt: Some(pb::generate_request::Prompt::Text("hi".to_string())),
+            ..Default::default()
+        });
+        request.metadata_mut().insert("x-kv-cache-report-mode", "full".parse().unwrap());
+        if stream {
+            let mut output = client.generate_stream(request).await.unwrap().into_inner();
+            while output.message().await.unwrap().is_some() {}
+        } else {
+            client.generate(request).await.unwrap();
+        }
+        engine_task.await.expect("mock engine task");
+        server_task.abort();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn unary_generate_unconnected_data_parallel_rank_returns_invalid_argument() {
     let (mut client, server_task, _engine_task) = grpc_test_server(
         EngineId::from_engine_index(3),

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -60,7 +60,7 @@ pub(super) fn prepare_generate_request(
     sampling_params.vllm_xargs = crate::utils::merge_kv_cache_report_mode(
         sampling_params.vllm_xargs,
         ctx.kv_cache_report_mode.as_deref(),
-    )?;
+    );
     sampling_params.vllm_xargs = merge_kv_transfer_params(
         sampling_params.vllm_xargs,
         request.kv_transfer_params.as_ref(),

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -57,6 +57,10 @@ pub(super) fn prepare_generate_request(
     let include_logprobs = request.sampling_params.inner.logprobs.is_some();
     let include_prompt_logprobs = request.sampling_params.inner.prompt_logprobs.is_some();
     let mut sampling_params = request.sampling_params.inner;
+    sampling_params.vllm_xargs = crate::utils::merge_kv_cache_report_mode(
+        sampling_params.vllm_xargs,
+        ctx.kv_cache_report_mode.as_deref(),
+    )?;
     sampling_params.vllm_xargs = merge_kv_transfer_params(
         sampling_params.vllm_xargs,
         request.kv_transfer_params.as_ref(),

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -74,7 +74,7 @@ pub(super) fn prepare_chat_request(
     request.vllm_xargs = crate::utils::merge_kv_cache_report_mode(
         request.vllm_xargs,
         ctx.kv_cache_report_mode.as_deref(),
-    )?;
+    );
 
     let prompt_truncation = resolve_generation_prompt_truncation(
         request.truncate_prompt_tokens,

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -1428,28 +1428,6 @@ mod tests {
     }
 
     #[test]
-    fn prepare_chat_request_threads_kv_cache_report_header() {
-        let mut headers = HeaderMap::new();
-        headers.insert("x-kv-cache-report-mode", "full".parse().unwrap());
-        let request = base_request();
-        let prepared = prepare_chat_request(
-            request,
-            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
-            request_context(&headers, None),
-        )
-        .expect("prepare");
-
-        expect_test::expect![[r#"
-            Some(
-                {
-                    "kv_cache_report_mode": String("full"),
-                },
-            )
-        "#]]
-        .assert_debug_eq(&prepared.chat_request.sampling_params.vllm_xargs);
-    }
-
-    #[test]
     fn prepare_chat_request_header_priority_overrides_body() {
         let mut headers = HeaderMap::new();
         headers.insert("X-Vllm-Priority", "-5".parse().unwrap());

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -66,11 +66,15 @@ pub(super) struct ResponseOptions {
 /// `lora_resolution.model_names` must be non-empty; the first entry is used as
 /// the base `model` field in responses when no LoRA adapter is selected.
 pub(super) fn prepare_chat_request(
-    request: ChatCompletionRequest,
+    mut request: ChatCompletionRequest,
     lora_resolution: &LoraModelResolution,
     ctx: ResolvedRequestContext,
 ) -> Result<PreparedRequest, ApiError> {
     validate::validate_request_compat(&request, &lora_resolution.model_names)?;
+    request.vllm_xargs = crate::utils::merge_kv_cache_report_mode(
+        request.vllm_xargs,
+        ctx.kv_cache_report_mode.as_deref(),
+    )?;
 
     let prompt_truncation = resolve_generation_prompt_truncation(
         request.truncate_prompt_tokens,
@@ -1421,6 +1425,28 @@ mod tests {
             prepared.chat_request.session_id.as_deref(),
             Some("header-session")
         );
+    }
+
+    #[test]
+    fn prepare_chat_request_threads_kv_cache_report_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-kv-cache-report-mode", "full".parse().unwrap());
+        let request = base_request();
+        let prepared = prepare_chat_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("prepare");
+
+        expect_test::expect![[r#"
+            Some(
+                {
+                    "kv_cache_report_mode": String("full"),
+                },
+            )
+        "#]]
+        .assert_debug_eq(&prepared.chat_request.sampling_params.vllm_xargs);
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -56,12 +56,16 @@ pub(super) struct ResponseOptions {
 /// `lora_resolution.model_names` must be non-empty; the first entry is used as
 /// the base `model` field in responses when no LoRA adapter is selected.
 pub(super) fn prepare_completion_request(
-    request: CompletionRequest,
+    mut request: CompletionRequest,
     lora_resolution: &LoraModelResolution,
     ctx: ResolvedRequestContext,
     tokenizer: &dyn Tokenizer,
 ) -> Result<PreparedRequest, ApiError> {
     validate::validate_request_compat(&request, &lora_resolution.model_names)?;
+    request.vllm_xargs = crate::utils::merge_kv_cache_report_mode(
+        request.vllm_xargs,
+        ctx.kv_cache_report_mode.as_deref(),
+    )?;
 
     let prompt_truncation = resolve_generation_prompt_truncation(
         request.truncate_prompt_tokens,

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -65,7 +65,7 @@ pub(super) fn prepare_completion_request(
     request.vllm_xargs = crate::utils::merge_kv_cache_report_mode(
         request.vllm_xargs,
         ctx.kv_cache_report_mode.as_deref(),
-    )?;
+    );
 
     let prompt_truncation = resolve_generation_prompt_truncation(
         request.truncate_prompt_tokens,

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -1207,10 +1207,13 @@ where
 
     let chat = ChatLlm::from_shared_backend(test_llm(client), backend);
     (
-        build_router(Arc::new(AppState::new(
-            vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
-            chat,
-        ))),
+        build_router_with_scale_out_endpoints(
+            Arc::new(AppState::new(
+                vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+                chat,
+            )),
+            true,
+        ),
         engine_task,
     )
 }
@@ -1236,6 +1239,88 @@ async fn server_load(app: &axum::Router) -> u64 {
     let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
     let value: serde_json::Value = serde_json::from_slice(&body).expect("json body");
     value["server_load"].as_u64().expect("server_load")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn kv_cache_report_header_reaches_engine_on_all_generation_routes() {
+    for stream in [false, true] {
+        for (route, mut body) in [
+            (
+                "/v1/chat/completions",
+                json!({"messages": [{"role": "user", "content": "hi"}]}),
+            ),
+            ("/v1/completions", json!({"prompt": "hi"})),
+            (
+                "/inference/v1/generate",
+                json!({"token_ids": [1, 2], "sampling_params": {"max_tokens": 16}}),
+            ),
+        ] {
+            let (mut app, engine_task) = test_app_with_backend_and_engine_request_check(
+                Arc::new(FakeChatBackend::new()),
+                |request| {
+                    let args = &request.sampling_params.as_ref().unwrap().extra_args;
+                    assert_eq!(
+                        serde_json::to_value(args).unwrap(),
+                        json!({"kv_cache_report_mode": "full"}),
+                    );
+                },
+            )
+            .await;
+            body["model"] = json!("Qwen/Qwen1.5-0.5B-Chat");
+            body["stream"] = json!(stream);
+            let response = app
+                .call(
+                    Request::builder()
+                        .method("POST")
+                        .uri(route)
+                        .header("content-type", "application/json")
+                        .header("X-KV-Cache-Report-Mode", "full")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{route}");
+            to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            engine_task.await.expect("mock engine task");
+        }
+    }
+}
+
+#[tokio::test]
+async fn kv_cache_report_header_survives_render() {
+    for (route, mut body) in [
+        (
+            "/v1/chat/completions/render",
+            json!({"messages": [{"role": "user", "content": "hi"}]}),
+        ),
+        ("/v1/completions/render", json!({"prompt": "hi"})),
+    ] {
+        body["model"] = json!("render-model");
+        let response = test_render_app()
+            .call(
+                Request::builder()
+                    .method("POST")
+                    .uri(route)
+                    .header("content-type", "application/json")
+                    .header("x-kv-cache-report-mode", "full")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let mut rendered: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        if rendered.is_array() {
+            rendered = rendered[0].take();
+        }
+        assert_eq!(
+            rendered["sampling_params"]["vllm_xargs"],
+            json!({"kv_cache_report_mode": "full"})
+        );
+    }
 }
 
 async fn health_status(app: &axum::Router) -> (StatusCode, Bytes) {

--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -11,12 +11,35 @@ use uuid::Uuid;
 
 use crate::error::ApiError;
 
+pub const KV_CACHE_REPORT_MODE_HEADER: &str = "x-kv-cache-report-mode";
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ResolvedRequestContext {
     pub request_id: String,
     pub data_parallel_rank: Option<u32>,
     pub priority: Option<i32>,
     pub session_id: Option<String>,
+    pub kv_cache_report_mode: Option<String>,
+}
+
+/// Apply the report-mode header as a fallback for the body parameter.
+pub fn merge_kv_cache_report_mode(
+    mut xargs: Option<HashMap<String, Value>>,
+    header: Option<&str>,
+) -> Result<Option<HashMap<String, Value>>, ApiError> {
+    if let Some(mode) = header {
+        if !matches!(mode, "incremental" | "full") {
+            return Err(ApiError::invalid_request(
+                "X-KV-Cache-Report-Mode must be 'incremental' or 'full'",
+                Some("X-KV-Cache-Report-Mode"),
+            ));
+        }
+        xargs
+            .get_or_insert_with(HashMap::new)
+            .entry("kv_cache_report_mode".to_string())
+            .or_insert_with(|| Value::String(mode.to_string()));
+    }
+    Ok(xargs)
 }
 
 /// Return the current Unix timestamp in seconds for OpenAI response objects.
@@ -136,12 +159,16 @@ pub fn resolve_request_context(
         .and_then(|value| value.to_str().ok())
         .filter(|value| !value.is_empty())
         .map(str::to_owned);
+    let kv_cache_report_mode = headers
+        .get(KV_CACHE_REPORT_MODE_HEADER)
+        .map(|value| value.to_str().unwrap_or_default().to_owned());
 
     ResolvedRequestContext {
         request_id,
         data_parallel_rank,
         priority,
         session_id,
+        kv_cache_report_mode,
     }
 }
 
@@ -156,4 +183,40 @@ pub fn resolve_base_request_id(
         id.truncate(8);
         id
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn kv_cache_report_header_preserves_body_and_other_args() {
+        let xargs = serde_json::from_value(json!({
+            "kv_cache_report_mode": "incremental", "custom": 7,
+        }))
+        .unwrap();
+        let merged = merge_kv_cache_report_mode(Some(xargs), Some("full")).unwrap();
+        let sorted: std::collections::BTreeMap<_, _> = merged.unwrap().into_iter().collect();
+        expect_test::expect![[r#"
+            {
+              "custom": 7,
+              "kv_cache_report_mode": "incremental"
+            }"#]]
+        .assert_eq(&serde_json::to_string_pretty(&sorted).unwrap());
+        assert!(merge_kv_cache_report_mode(None, None).unwrap().is_none());
+    }
+
+    #[test]
+    fn kv_cache_report_rejects_invalid_headers_even_with_body() {
+        for value in ["", "FULL", "invalid", "full,incremental"] {
+            let xargs = serde_json::from_value(json!({"kv_cache_report_mode": "full"})).unwrap();
+            let error = merge_kv_cache_report_mode(Some(xargs), Some(value)).unwrap_err();
+            assert_eq!(error.status_code(), axum::http::StatusCode::BAD_REQUEST);
+            assert_eq!(
+                error.to_error_response().error.param,
+                Some("X-KV-Cache-Report-Mode".to_string())
+            );
+        }
+    }
 }

--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -26,20 +26,14 @@ pub struct ResolvedRequestContext {
 pub fn merge_kv_cache_report_mode(
     mut xargs: Option<HashMap<String, Value>>,
     header: Option<&str>,
-) -> Result<Option<HashMap<String, Value>>, ApiError> {
-    if let Some(mode) = header {
-        if !matches!(mode, "incremental" | "full") {
-            return Err(ApiError::invalid_request(
-                "X-KV-Cache-Report-Mode must be 'incremental' or 'full'",
-                Some("X-KV-Cache-Report-Mode"),
-            ));
-        }
+) -> Option<HashMap<String, Value>> {
+    if let Some(mode) = header.filter(|mode| matches!(*mode, "incremental" | "full")) {
         xargs
             .get_or_insert_with(HashMap::new)
             .entry("kv_cache_report_mode".to_string())
             .or_insert_with(|| Value::String(mode.to_string()));
     }
-    Ok(xargs)
+    xargs
 }
 
 /// Return the current Unix timestamp in seconds for OpenAI response objects.
@@ -161,7 +155,8 @@ pub fn resolve_request_context(
         .map(str::to_owned);
     let kv_cache_report_mode = headers
         .get(KV_CACHE_REPORT_MODE_HEADER)
-        .map(|value| value.to_str().unwrap_or_default().to_owned());
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
 
     ResolvedRequestContext {
         request_id,
@@ -196,7 +191,7 @@ mod tests {
             "kv_cache_report_mode": "incremental", "custom": 7,
         }))
         .unwrap();
-        let merged = merge_kv_cache_report_mode(Some(xargs), Some("full")).unwrap();
+        let merged = merge_kv_cache_report_mode(Some(xargs), Some("full"));
         let sorted: std::collections::BTreeMap<_, _> = merged.unwrap().into_iter().collect();
         expect_test::expect![[r#"
             {
@@ -204,19 +199,16 @@ mod tests {
               "kv_cache_report_mode": "incremental"
             }"#]]
         .assert_eq(&serde_json::to_string_pretty(&sorted).unwrap());
-        assert!(merge_kv_cache_report_mode(None, None).unwrap().is_none());
+        assert!(merge_kv_cache_report_mode(None, None).is_none());
     }
 
     #[test]
-    fn kv_cache_report_rejects_invalid_headers_even_with_body() {
+    fn kv_cache_report_ignores_invalid_headers() {
         for value in ["", "FULL", "invalid", "full,incremental"] {
             let xargs = serde_json::from_value(json!({"kv_cache_report_mode": "full"})).unwrap();
-            let error = merge_kv_cache_report_mode(Some(xargs), Some(value)).unwrap_err();
-            assert_eq!(error.status_code(), axum::http::StatusCode::BAD_REQUEST);
-            assert_eq!(
-                error.to_error_response().error.param,
-                Some("X-KV-Cache-Report-Mode".to_string())
-            );
+            for args in [None, Some(HashMap::new()), Some(xargs)] {
+                assert_eq!(merge_kv_cache_report_mode(args.clone(), Some(value)), args,);
+            }
         }
     }
 }

--- a/tests/entrypoints/cohere/test_api_router.py
+++ b/tests/entrypoints/cohere/test_api_router.py
@@ -44,7 +44,7 @@ from vllm.entrypoints.serve.exception_handling.handlers.validation import (
 from vllm.entrypoints.serve.exception_handling.handlers.vllm_error import (
     vllm_error_handler,
 )
-from vllm.exceptions import VLLMError, VLLMValidationError
+from vllm.exceptions import VLLMError
 from vllm.sampling_params import SamplingParams
 
 
@@ -97,20 +97,6 @@ class _RenderChatHandler:
 
     def to_chat_completion_request(self, request):
         return CohereServingChatV2._convert_v2_to_chat_completion(request)
-
-
-def test_report_header_validation_returns_client_error():
-    handler = _Handler(VLLMValidationError("Invalid X-KV-Cache-Report-Mode"))
-    with TestClient(_build_app_with_vllm_handlers(handler)) as client:
-        response = client.post(
-            "/cohere/v2/chat",
-            json={
-                "model": "m",
-                "messages": [{"role": "user", "content": "hi"}],
-            },
-        )
-    assert response.status_code == 400
-    assert "X-KV-Cache-Report-Mode" in response.json()["message"]
 
 
 class _RenderHandler:

--- a/tests/entrypoints/cohere/test_api_router.py
+++ b/tests/entrypoints/cohere/test_api_router.py
@@ -44,7 +44,7 @@ from vllm.entrypoints.serve.exception_handling.handlers.validation import (
 from vllm.entrypoints.serve.exception_handling.handlers.vllm_error import (
     vllm_error_handler,
 )
-from vllm.exceptions import VLLMError
+from vllm.exceptions import VLLMError, VLLMValidationError
 from vllm.sampling_params import SamplingParams
 
 
@@ -99,6 +99,20 @@ class _RenderChatHandler:
         return CohereServingChatV2._convert_v2_to_chat_completion(request)
 
 
+def test_report_header_validation_returns_client_error():
+    handler = _Handler(VLLMValidationError("Invalid X-KV-Cache-Report-Mode"))
+    with TestClient(_build_app_with_vllm_handlers(handler)) as client:
+        response = client.post(
+            "/cohere/v2/chat",
+            json={
+                "model": "m",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert response.status_code == 400
+    assert "X-KV-Cache-Report-Mode" in response.json()["message"]
+
+
 class _RenderHandler:
     """Minimal stand-in for :class:`ServingRender`.
 
@@ -112,7 +126,7 @@ class _RenderHandler:
         self.result = result
         self.seen_request = None
 
-    async def render_chat_request(self, request):
+    async def render_chat_request(self, request, raw_request=None):
         self.seen_request = request
         if isinstance(self.result, Exception):
             raise self.result

--- a/tests/entrypoints/generate/test_kv_cache_report_mode.py
+++ b/tests/entrypoints/generate/test_kv_cache_report_mode.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Report-mode propagation through the serving APIs, without model execution."""
+
+import asyncio
+from io import BytesIO
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import UploadFile, WebSocket
+from starlette.requests import Request
+
+from vllm.entrypoints.anthropic.protocol import AnthropicMessagesRequest
+from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
+from vllm.entrypoints.generate.generative_scoring.serving import (
+    GenerativeScoringRequest,
+    ServingGenerativeScoring,
+)
+from vllm.entrypoints.openai.chat_completion.batch_serving import OpenAIServingChatBatch
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    BatchChatCompletionRequest,
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.completion.serving import OpenAIServingCompletion
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+from vllm.entrypoints.scale_out.render.serving import ServingRender
+from vllm.entrypoints.scale_out.token_in_token_out.protocol import GenerateRequest
+from vllm.entrypoints.scale_out.token_in_token_out.serving import ServingTokens
+from vllm.entrypoints.speech_to_text.base.serving import SpeechToTextBaseServing
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection
+from vllm.entrypoints.speech_to_text.transcription.protocol import (
+    TranscriptionRequest,
+    TranscriptionResponse,
+)
+from vllm.entrypoints.speech_to_text.translation.protocol import TranslationRequest
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import SamplingParams
+
+_MESSAGES = [{"role": "user", "content": "hi"}]
+_PROMPT = {"type": "token", "prompt_token_ids": [1, 2]}
+
+
+class _EngineReached(Exception):
+    def __init__(self, params):
+        self.params = params
+
+
+def _capture_engine(prompt=None, sampling_params=None, *args, **kwargs):
+    raise _EngineReached(sampling_params)
+
+
+def _serving(cls):
+    serving = cls.__new__(cls)
+    serving.engine_client = SimpleNamespace(
+        generate=_capture_engine, errored=False, check_admission=Mock()
+    )
+    serving.has_kv_connector = False
+    serving.model_config = SimpleNamespace(
+        max_model_len=100, is_encoder_decoder=False, is_multimodal_model=False
+    )
+    serving.models = SimpleNamespace(model_name=lambda *args: "test-model")
+    serving.renderer = Mock()
+    serving._preflight = Mock()
+    serving._check_model = AsyncMock(return_value=None)
+    serving._maybe_get_adapters = Mock(return_value=None)
+    serving._extract_prompt_len = Mock(return_value=2)
+    serving._extract_prompt_components = Mock(
+        return_value=SimpleNamespace(token_ids=[1, 2])
+    )
+    serving._log_inputs = Mock()
+    serving._get_trace_headers = AsyncMock(return_value=None)
+    serving.default_sampling_params = {}
+    serving.override_max_tokens = None
+    serving.parser_cls = None
+    serving._effective_chat_template_kwargs = Mock(return_value={})
+    serving.render_chat_request = AsyncMock(return_value=([], [_PROMPT]))
+    serving.render_batch_chat_request = AsyncMock(return_value=([[]], [_PROMPT]))
+    serving.render_completion_request = AsyncMock(return_value=[_PROMPT])
+    return serving
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "api",
+    [
+        "chat",
+        "completion",
+        "responses",
+        "batch",
+        "anthropic",
+        "cohere",
+        "generate",
+        "transcription",
+        "translation",
+        "scoring",
+    ],
+)
+@pytest.mark.parametrize("mode", ["full", "incremental", "invalid"])
+async def test_kv_cache_report_header_reaches_sampling_params(api, mode):
+    raw_request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-kv-cache-report-mode", mode.encode()),
+            ],
+        }
+    )
+    if api == "chat":
+        serving = _serving(OpenAIServingChat)
+        request = ChatCompletionRequest(messages=_MESSAGES)
+        call = serving.create_chat_completion(request, raw_request)
+    elif api == "completion":
+        serving = _serving(OpenAIServingCompletion)
+        call = serving.create_completion(CompletionRequest(prompt="hi"), raw_request)
+    elif api == "responses":
+        serving = _serving(OpenAIServingResponses)
+        serving._validate_create_responses_input = Mock(return_value=None)
+        serving._validate_generator_input = Mock(return_value=None)
+        serving.enable_store = False
+        serving.use_harmony = False
+        serving.tool_server = None
+        serving.parser = None
+        serving._make_request = AsyncMock(return_value=([], [_PROMPT]))
+        serving._generate_with_builtin_tools = Mock(side_effect=_capture_engine)
+        call = serving.create_responses(ResponsesRequest(input="hi"), raw_request)
+    elif api == "batch":
+        serving = _serving(OpenAIServingChatBatch)
+        call = serving.create_batch_chat_completion(
+            BatchChatCompletionRequest(messages=[_MESSAGES]), raw_request
+        )
+    elif api == "anthropic":
+        serving = _serving(AnthropicServingMessages)
+        serving._merge_inline_system = False
+        call = serving.create_messages(
+            AnthropicMessagesRequest(
+                model="test-model", messages=_MESSAGES, max_tokens=1
+            ),
+            raw_request,
+        )
+    elif api == "cohere":
+        pytest.importorskip("cohere")
+        from vllm.entrypoints.cohere.protocol import CohereChatV2Request
+        from vllm.entrypoints.cohere.serving import CohereServingChatV2
+
+        serving = _serving(CohereServingChatV2)
+        call = serving.create_chat_v2(
+            CohereChatV2Request(model="test-model", messages=_MESSAGES), raw_request
+        )
+    elif api in ("transcription", "translation"):
+        serving = _serving(SpeechToTextBaseServing)
+        serving.task_type = "transcribe" if api == "transcription" else "translate"
+        serving._preprocess_speech_to_text = AsyncMock(
+            return_value=([_PROMPT], 1.0, [0.0])
+        )
+        request_cls = (
+            TranscriptionRequest if api == "transcription" else TranslationRequest
+        )
+        call = serving._create_speech_to_text(
+            b"audio",
+            request_cls(file=UploadFile(BytesIO()), model="test-model"),
+            raw_request,
+            TranscriptionResponse,
+            Mock(),
+        )
+    elif api == "scoring":
+        serving = _serving(ServingGenerativeScoring)
+        serving.model_config.get_vocab_size = lambda: 16
+        serving._build_prompts = AsyncMock(return_value=([_PROMPT], [2]))
+        call = serving.create_generative_scoring(
+            GenerativeScoringRequest(
+                model="test-model", query="hi", items=["hello"], label_token_ids=[3]
+            ),
+            raw_request,
+        )
+    else:
+        serving = _serving(ServingTokens)
+        serving.engine_client.vllm_config = SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_seqs=16)
+        )
+        serving.online_renderer = SimpleNamespace(
+            preprocess_completion=AsyncMock(return_value=[_PROMPT])
+        )
+        serving.force_no_detokenize = False
+        call = serving.serve_tokens(
+            GenerateRequest(
+                token_ids=[1, 2], sampling_params=SamplingParams(max_tokens=1)
+            ),
+            raw_request,
+        )
+
+    if mode == "invalid":
+        with pytest.raises(VLLMValidationError):
+            await call
+    else:
+        with pytest.raises(_EngineReached) as reached:
+            await call
+        assert reached.value.params.extra_args == {"kv_cache_report_mode": mode}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("api", ["chat", "completion", "anthropic"])
+async def test_render_preserves_kv_cache_report_header(api):
+    serving: Any = ServingRender.__new__(ServingRender)
+    serving._check_model = AsyncMock(return_value=None)
+    serving.model_config = SimpleNamespace(
+        max_model_len=100, is_encoder_decoder=False, is_multimodal_model=False
+    )
+    serving.online_renderer = SimpleNamespace(
+        render_chat=AsyncMock(return_value=([], [_PROMPT])),
+        render_completion=AsyncMock(return_value=[_PROMPT]),
+    )
+    serving._merge_inline_system = False
+    serving.default_sampling_params = {}
+    serving.override_max_tokens = None
+    raw_request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-kv-cache-report-mode", b"full"),
+            ],
+        }
+    )
+    if api == "chat":
+        rendered = await serving.render_chat_request(
+            ChatCompletionRequest(messages=_MESSAGES), raw_request
+        )
+    elif api == "completion":
+        (rendered,) = await serving.render_completion_request(
+            CompletionRequest(prompt="hi"), raw_request
+        )
+    else:
+        rendered = await serving.render_messages_request(
+            AnthropicMessagesRequest(
+                model="test-model", messages=_MESSAGES, max_tokens=1
+            ),
+            raw_request,
+        )
+    assert rendered.sampling_params.extra_args == {"kv_cache_report_mode": "full"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["full", "invalid"])
+async def test_realtime_applies_report_header_to_each_utterance(mode, monkeypatch):
+    generate = Mock(return_value=AsyncMock())
+    serving = Mock(
+        engine_client=SimpleNamespace(generate=generate),
+        model_cls=SimpleNamespace(realtime_max_tokens=10),
+    )
+    websocket = WebSocket(
+        {
+            "type": "websocket",
+            "headers": [
+                (b"x-kv-cache-report-mode", mode.encode()),
+            ],
+        },
+        AsyncMock(),
+        AsyncMock(),
+    )
+    connection = RealtimeConnection(websocket, serving)
+    send_error = AsyncMock()
+    monkeypatch.setattr(connection, "send", AsyncMock())
+    monkeypatch.setattr(connection, "send_error", send_error)
+
+    for _ in range(2):
+        await connection._run_generation(AsyncMock(), asyncio.Queue())
+
+    if mode == "invalid":
+        generate.assert_not_called()
+        assert send_error.await_count == 2
+    else:
+        assert generate.call_count == 2
+        for call in generate.call_args_list:
+            assert call.kwargs["sampling_params"].extra_args == {
+                "kv_cache_report_mode": mode
+            }

--- a/tests/entrypoints/generate/test_kv_cache_report_mode.py
+++ b/tests/entrypoints/generate/test_kv_cache_report_mode.py
@@ -39,7 +39,6 @@ from vllm.entrypoints.speech_to_text.transcription.protocol import (
     TranscriptionResponse,
 )
 from vllm.entrypoints.speech_to_text.translation.protocol import TranslationRequest
-from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams
 
 _MESSAGES = [{"role": "user", "content": "hi"}]
@@ -194,13 +193,10 @@ async def test_kv_cache_report_header_reaches_sampling_params(api, mode):
             raw_request,
         )
 
-    if mode == "invalid":
-        with pytest.raises(VLLMValidationError):
-            await call
-    else:
-        with pytest.raises(_EngineReached) as reached:
-            await call
-        assert reached.value.params.extra_args == {"kv_cache_report_mode": mode}
+    with pytest.raises(_EngineReached) as reached:
+        await call
+    expected = {} if mode == "invalid" else {"kv_cache_report_mode": mode}
+    assert (reached.value.params.extra_args or {}) == expected
 
 
 @pytest.mark.asyncio
@@ -270,12 +266,8 @@ async def test_realtime_applies_report_header_to_each_utterance(mode, monkeypatc
     for _ in range(2):
         await connection._run_generation(AsyncMock(), asyncio.Queue())
 
-    if mode == "invalid":
-        generate.assert_not_called()
-        assert send_error.await_count == 2
-    else:
-        assert generate.call_count == 2
-        for call in generate.call_args_list:
-            assert call.kwargs["sampling_params"].extra_args == {
-                "kv_cache_report_mode": mode
-            }
+    send_error.assert_not_awaited()
+    assert generate.call_count == 2
+    expected = {} if mode == "invalid" else {"kv_cache_report_mode": mode}
+    for call in generate.call_args_list:
+        assert (call.kwargs["sampling_params"].extra_args or {}) == expected

--- a/tests/entrypoints/serve/utils/test_api_utils.py
+++ b/tests/entrypoints/serve/utils/test_api_utils.py
@@ -16,38 +16,23 @@ from vllm.entrypoints.serve.utils.api_utils import (
 
 
 @pytest.mark.parametrize("mode", ["full", "incremental"])
-def test_kv_cache_report_header_preserves_other_extra_args(mode):
+@pytest.mark.parametrize("body_mode", [None, "full", "incremental"])
+def test_kv_cache_report_header_fills_missing_body_mode(mode, body_mode):
     request = Request(
         {
             "type": "http",
-            "headers": [
-                (b"x-kv-cache-report-mode", mode.encode()),
-            ],
+            "headers": [(b"x-kv-cache-report-mode", mode.encode())],
         }
     )
     extra_args = {"custom": 1}
+    if body_mode is not None:
+        extra_args["kv_cache_report_mode"] = body_mode
+    original = extra_args.copy()
 
     result = api_utils.resolve_kv_cache_report_mode(extra_args, request)
 
-    assert result == {"custom": 1, "kv_cache_report_mode": mode}
-    assert extra_args == {"custom": 1}
-
-
-@pytest.mark.parametrize("mode", [None, "full", "incremental"])
-def test_kv_cache_report_body_takes_precedence(mode):
-    request = Request(
-        {
-            "type": "http",
-            "headers": [
-                (b"x-kv-cache-report-mode", b"full"),
-            ],
-        }
-    )
-    extra_args = {} if mode is None else {"kv_cache_report_mode": mode}
-
-    result = api_utils.resolve_kv_cache_report_mode(extra_args, request)
-
-    assert result == {"kv_cache_report_mode": mode or "full"}
+    assert result == {"custom": 1, "kv_cache_report_mode": body_mode or mode}
+    assert extra_args == original
 
 
 @pytest.mark.parametrize(

--- a/tests/entrypoints/serve/utils/test_api_utils.py
+++ b/tests/entrypoints/serve/utils/test_api_utils.py
@@ -4,6 +4,7 @@
 from argparse import Namespace
 
 import pytest
+from starlette.requests import Request
 
 from vllm.entrypoints.generate.base.protocol import StreamOptions
 from vllm.entrypoints.serve.utils import api_utils
@@ -12,6 +13,67 @@ from vllm.entrypoints.serve.utils.api_utils import (
     redact_sensitive_args,
     should_include_usage,
 )
+from vllm.exceptions import VLLMValidationError
+
+
+@pytest.mark.parametrize("mode", ["full", "incremental"])
+def test_kv_cache_report_header_preserves_other_extra_args(mode):
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-kv-cache-report-mode", mode.encode()),
+            ],
+        }
+    )
+    extra_args = {"custom": 1}
+
+    result = api_utils.resolve_kv_cache_report_mode(extra_args, request)
+
+    assert result == {"custom": 1, "kv_cache_report_mode": mode}
+    assert extra_args == {"custom": 1}
+
+
+@pytest.mark.parametrize("mode", [None, "full", "incremental"])
+def test_kv_cache_report_body_takes_precedence(mode):
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-kv-cache-report-mode", b"full"),
+            ],
+        }
+    )
+    extra_args = {} if mode is None else {"kv_cache_report_mode": mode}
+
+    result = api_utils.resolve_kv_cache_report_mode(extra_args, request)
+
+    assert result == {"kv_cache_report_mode": mode or "full"}
+
+
+@pytest.mark.parametrize(
+    "raw_request", [None, Request({"type": "http", "headers": []})]
+)
+@pytest.mark.parametrize("extra_args", [None, {}, {"kv_cache_report_mode": "full"}])
+def test_kv_cache_report_without_header_preserves_body(raw_request, extra_args):
+    assert api_utils.resolve_kv_cache_report_mode(extra_args, raw_request) == extra_args
+
+
+@pytest.mark.parametrize("mode", ["", "FULL", "invalid", "full,incremental"])
+def test_kv_cache_report_rejects_invalid_header_even_with_body(mode):
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"x-kv-cache-report-mode", mode.encode()),
+            ],
+        }
+    )
+
+    with pytest.raises(VLLMValidationError, match="X-KV-Cache-Report-Mode"):
+        api_utils.resolve_kv_cache_report_mode(
+            {"kv_cache_report_mode": "incremental"}, request
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/entrypoints/serve/utils/test_api_utils.py
+++ b/tests/entrypoints/serve/utils/test_api_utils.py
@@ -13,7 +13,6 @@ from vllm.entrypoints.serve.utils.api_utils import (
     redact_sensitive_args,
     should_include_usage,
 )
-from vllm.exceptions import VLLMValidationError
 
 
 @pytest.mark.parametrize("mode", ["full", "incremental"])
@@ -60,7 +59,10 @@ def test_kv_cache_report_without_header_preserves_body(raw_request, extra_args):
 
 
 @pytest.mark.parametrize("mode", ["", "FULL", "invalid", "full,incremental"])
-def test_kv_cache_report_rejects_invalid_header_even_with_body(mode):
+@pytest.mark.parametrize(
+    "extra_args", [None, {}, {"custom": 7}, {"kv_cache_report_mode": "incremental"}]
+)
+def test_kv_cache_report_ignores_invalid_header(mode, extra_args):
     request = Request(
         {
             "type": "http",
@@ -70,10 +72,7 @@ def test_kv_cache_report_rejects_invalid_header_even_with_body(mode):
         }
     )
 
-    with pytest.raises(VLLMValidationError, match="X-KV-Cache-Report-Mode"):
-        api_utils.resolve_kv_cache_report_mode(
-            {"kv_cache_report_mode": "incremental"}, request
-        )
+    assert api_utils.resolve_kv_cache_report_mode(extra_args, request) == extra_args
 
 
 @pytest.mark.parametrize(

--- a/tests/entrypoints/speech_to_text/test_speech_to_text_cancellation.py
+++ b/tests/entrypoints/speech_to_text/test_speech_to_text_cancellation.py
@@ -71,6 +71,7 @@ async def test_non_streaming_cancel_aborts_engine_requests(
         max_completion_tokens=None,
         language="en",
         prompt="",
+        vllm_xargs=None,
         to_sampling_params=Mock(return_value=object()),
     )
     raw_request = SimpleNamespace(
@@ -143,6 +144,7 @@ async def test_non_streaming_cancel_advances_all_chunk_generators():
         max_completion_tokens=None,
         language="en",
         prompt="",
+        vllm_xargs=None,
         to_sampling_params=Mock(return_value=object()),
     )
     raw_request = SimpleNamespace(

--- a/tests/samplers/test_beam_search_online.py
+++ b/tests/samplers/test_beam_search_online.py
@@ -72,3 +72,26 @@ async def test_beam_search_handles_extra_logprob_candidates() -> None:
     assert outputs[0].outputs[0].finish_reason == "stop"
     assert outputs[0].outputs[0].token_ids == []
     assert outputs[0].outputs[0].cumulative_logprob == pytest.approx(-0.1)
+
+
+@pytest.mark.asyncio
+async def test_beam_search_preserves_kv_cache_report_mode(monkeypatch):
+    observed = []
+    generate = _EngineClient.generate
+
+    async def capture(self, prompt, params, *args, **kwargs):
+        observed.append(params.extra_args)
+        async for output in generate(self, prompt, params, *args, **kwargs):
+            yield output
+
+    monkeypatch.setattr(_EngineClient, "generate", capture)
+    async for _ in _Serving().beam_search(
+        {"type": "token", "prompt_token_ids": [1]},
+        "request",
+        BeamSearchParams(beam_width=2, max_tokens=2),
+        extra_args={"kv_cache_report_mode": "full"},
+    ):
+        pass
+
+    assert len(observed) > 1
+    assert all(args == {"kv_cache_report_mode": "full"} for args in observed)

--- a/vllm/entrypoints/cohere/api_router.py
+++ b/vllm/entrypoints/cohere/api_router.py
@@ -45,6 +45,7 @@ from vllm.entrypoints.serve.utils.api_utils import (
     validate_json_request,
     with_cancellation,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 
 _COHERE_PATH_PREFIX = "/cohere/"
@@ -137,6 +138,8 @@ if _SDK_AVAILABLE:
 
         try:
             result = await handler.create_chat_v2(request, raw_request)
+        except VLLMValidationError:
+            raise
         except Exception as e:  # noqa: BLE001 - report as 500 for parity
             logger.exception("Error in /cohere/v2/chat: %s", e)
             return JSONResponse(
@@ -192,7 +195,9 @@ if _SDK_AVAILABLE:
 
         try:
             chat_request = handler.to_chat_completion_request(request)
-            result = await render_handler.render_chat_request(chat_request)
+            result = await render_handler.render_chat_request(chat_request, raw_request)
+        except VLLMValidationError:
+            raise
         except Exception as e:  # noqa: BLE001 - report as 500 for parity
             logger.exception("Error in /cohere/v2/chat/render: %s", e)
             return JSONResponse(

--- a/vllm/entrypoints/cohere/api_router.py
+++ b/vllm/entrypoints/cohere/api_router.py
@@ -45,7 +45,6 @@ from vllm.entrypoints.serve.utils.api_utils import (
     validate_json_request,
     with_cancellation,
 )
-from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 
 _COHERE_PATH_PREFIX = "/cohere/"
@@ -138,8 +137,6 @@ if _SDK_AVAILABLE:
 
         try:
             result = await handler.create_chat_v2(request, raw_request)
-        except VLLMValidationError:
-            raise
         except Exception as e:  # noqa: BLE001 - report as 500 for parity
             logger.exception("Error in /cohere/v2/chat: %s", e)
             return JSONResponse(
@@ -196,8 +193,6 @@ if _SDK_AVAILABLE:
         try:
             chat_request = handler.to_chat_completion_request(request)
             result = await render_handler.render_chat_request(chat_request, raw_request)
-        except VLLMValidationError:
-            raise
         except Exception as e:  # noqa: BLE001 - report as 500 for parity
             logger.exception("Error in /cohere/v2/chat/render: %s", e)
             return JSONResponse(

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -4,6 +4,7 @@
 import asyncio
 from abc import ABC
 from collections.abc import AsyncGenerator, Mapping
+from typing import Any
 
 import numpy as np
 
@@ -33,6 +34,7 @@ class BeamSearchOnlineMixin(ABC):
         lora_request: LoRARequest | None = None,
         trace_headers: Mapping[str, str] | None = None,
         session_id: str | None = None,
+        extra_args: dict[str, Any] | None = None,
     ) -> AsyncGenerator[RequestOutput, None]:
         beam_width = params.beam_width
         max_tokens = params.max_tokens
@@ -63,6 +65,7 @@ class BeamSearchOnlineMixin(ABC):
             max_tokens=1,
             temperature=temperature,
             detokenize=False,
+            extra_args=extra_args,
         )
         all_beams = [
             BeamSearchSequence(

--- a/vllm/entrypoints/generate/generative_scoring/serving.py
+++ b/vllm/entrypoints/generate/generative_scoring/serving.py
@@ -25,6 +25,7 @@ from vllm.entrypoints.serve.engine.protocol import (
     UsageInfo,
 )
 from vllm.entrypoints.serve.engine.serving import BaseServing
+from vllm.entrypoints.serve.utils.api_utils import resolve_kv_cache_report_mode
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.inputs import EngineInput, tokens_input
 from vllm.logger import init_logger
@@ -255,6 +256,7 @@ class ServingGenerativeScoring(BaseServing):
             logprobs=len(request.label_token_ids),
             logprob_token_ids=request.label_token_ids,
             n=1,
+            extra_args=resolve_kv_cache_report_mode(None, raw_request),
         )
 
         # Get trace headers

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -18,7 +18,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse, UsageInfo
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
+from vllm.entrypoints.serve.utils.api_utils import (
+    get_max_tokens,
+    resolve_kv_cache_report_mode,
+)
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
@@ -114,6 +117,10 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             request.to_chat_completion_request(messages)
             for messages in request.messages
         ]
+        for single_request in single_requests:
+            single_request.vllm_xargs = resolve_kv_cache_report_mode(
+                single_request.vllm_xargs, raw_request
+            )
 
         parser: Parser | None = None
         if self.parser_cls is not None:

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -49,7 +49,11 @@ from vllm.entrypoints.serve.engine.protocol import (
     PromptTokenUsageInfo,
     UsageInfo,
 )
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens, should_include_usage
+from vllm.entrypoints.serve.utils.api_utils import (
+    get_max_tokens,
+    resolve_kv_cache_report_mode,
+    should_include_usage,
+)
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.serve.utils.tool_calls_utils import (
     maybe_filter_parallel_tool_calls,
@@ -260,6 +264,9 @@ class OpenAIServingChat(GenerateBaseServing):
         request: ChatCompletionRequest,
         raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None] | ChatCompletionResponse | ErrorResponse:
+        request.vllm_xargs = resolve_kv_cache_report_mode(
+            request.vllm_xargs, raw_request
+        )
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
@@ -351,6 +358,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     lora_request=lora_request,
                     trace_headers=trace_headers,
                     session_id=session_id,
+                    extra_args=request.vllm_xargs,
                 )
             else:
                 if not request.include_reasoning:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -35,7 +35,11 @@ from vllm.entrypoints.serve.engine.protocol import (
     PromptTokenUsageInfo,
     UsageInfo,
 )
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens, should_include_usage
+from vllm.entrypoints.serve.utils.api_utils import (
+    get_max_tokens,
+    resolve_kv_cache_report_mode,
+    should_include_usage,
+)
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.exceptions import GenerationError, VLLMValidationError
 from vllm.inputs import EngineInput
@@ -129,6 +133,9 @@ class OpenAIServingCompletion(GenerateBaseServing):
         request: CompletionRequest,
         raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None] | CompletionResponse | ErrorResponse:
+        request.vllm_xargs = resolve_kv_cache_report_mode(
+            request.vllm_xargs, raw_request
+        )
         if request.stream and request.use_beam_search:
             return self.create_error_response(
                 "Streaming is not currently supported with beam search"
@@ -200,6 +207,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                     lora_request=lora_request,
                     trace_headers=trace_headers,
                     session_id=session_id,
+                    extra_args=request.vllm_xargs,
                 )
             else:
                 generator = self.engine_client.generate(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -86,7 +86,10 @@ from vllm.entrypoints.openai.responses.utils import (
     extract_tool_types,
 )
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
+from vllm.entrypoints.serve.utils.api_utils import (
+    get_max_tokens,
+    resolve_kv_cache_report_mode,
+)
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.exceptions import GenerationError, VLLMValidationError
 from vllm.inputs import EngineInput, tokens_input
@@ -342,6 +345,9 @@ class OpenAIServingResponses(GenerateBaseServing):
         | ResponsesResponse
         | ErrorResponse
     ):
+        request.vllm_xargs = resolve_kv_cache_report_mode(
+            request.vllm_xargs, raw_request
+        )
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
             logger.error("Error with model %s", error_check_ret)

--- a/vllm/entrypoints/scale_out/render/api_router.py
+++ b/vllm/entrypoints/scale_out/render/api_router.py
@@ -42,7 +42,7 @@ async def render_chat_completion(request: ChatCompletionRequest, raw_request: Re
             "The model does not support Chat Completions Render API"
         )
 
-    result = await handler.render_chat_request(request)
+    result = await handler.render_chat_request(request, raw_request)
 
     if isinstance(result, ErrorResponse):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)
@@ -66,7 +66,7 @@ async def render_messages(request: AnthropicMessagesRequest, raw_request: Reques
     if handler is None:
         raise NotImplementedError("The model does not support Messages Render API")
 
-    result = await handler.render_messages_request(request)
+    result = await handler.render_messages_request(request, raw_request)
 
     if isinstance(result, ErrorResponse):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)
@@ -89,7 +89,7 @@ async def render_completion(request: CompletionRequest, raw_request: Request):
     if handler is None:
         raise NotImplementedError("The model does not support Completions Render API")
 
-    result = await handler.render_completion_request(request)
+    result = await handler.render_completion_request(request, raw_request)
 
     if isinstance(result, ErrorResponse):
         return JSONResponse(content=result.model_dump(), status_code=result.error.code)

--- a/vllm/entrypoints/scale_out/render/serving.py
+++ b/vllm/entrypoints/scale_out/render/serving.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import cast
 
+from fastapi import Request
+
 from vllm.entrypoints.anthropic.protocol import AnthropicMessagesRequest
 from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
@@ -18,7 +20,10 @@ from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
 )
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.engine.serving import BaseServing
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
+from vllm.entrypoints.serve.utils.api_utils import (
+    get_max_tokens,
+    resolve_kv_cache_report_mode,
+)
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.inputs import (
     EngineInput,
@@ -72,12 +77,16 @@ class ServingRender(BaseServing):
     async def render_chat_request(
         self,
         request: ChatCompletionRequest,
+        raw_request: Request | None = None,
     ) -> GenerateRequest | ErrorResponse:
         """Validate the model and preprocess a chat completion request.
 
         This is the authoritative implementation used directly by the
         GPU-less render server and delegated to by OpenAIServingChat.
         """
+        request.vllm_xargs = resolve_kv_cache_report_mode(
+            request.vllm_xargs, raw_request
+        )
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
             logger.error("Error with model %s", error_check_ret)
@@ -160,6 +169,7 @@ class ServingRender(BaseServing):
     async def render_messages_request(
         self,
         request: AnthropicMessagesRequest,
+        raw_request: Request | None = None,
     ) -> GenerateRequest | ErrorResponse:
         """Validate the model and preprocess an Anthropic Messages request.
 
@@ -170,17 +180,21 @@ class ServingRender(BaseServing):
         chat_req = AnthropicServingMessages.to_chat_completion_request(
             request, merge_inline_system=self._merge_inline_system
         )
-        return await self.render_chat_request(chat_req)
+        return await self.render_chat_request(chat_req, raw_request)
 
     async def render_completion_request(
         self,
         request: CompletionRequest,
+        raw_request: Request | None = None,
     ) -> list[GenerateRequest] | ErrorResponse:
         """Validate the model and preprocess a completion request.
 
         This is the authoritative implementation used directly by the
         GPU-less render server and delegated to by OpenAIServingCompletion.
         """
+        request.vllm_xargs = resolve_kv_cache_report_mode(
+            request.vllm_xargs, raw_request
+        )
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
             return error_check_ret

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -28,7 +28,11 @@ from vllm.entrypoints.serve.engine.protocol import (
     PromptTokenUsageInfo,
     UsageInfo,
 )
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens, should_include_usage
+from vllm.entrypoints.serve.utils.api_utils import (
+    get_max_tokens,
+    resolve_kv_cache_report_mode,
+    should_include_usage,
+)
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.exceptions import GenerationError
 from vllm.inputs import EngineInput, TokensPrompt, mm_input
@@ -126,6 +130,9 @@ class ServingTokens(GenerateBaseServing):
             raw_request.state.request_metadata = request_metadata
 
         sampling_params = request.sampling_params
+        sampling_params.extra_args = resolve_kv_cache_report_mode(
+            sampling_params.extra_args, raw_request
+        )
         max_num_seqs = self.engine_client.vllm_config.scheduler_config.max_num_seqs
         if sampling_params.n > max_num_seqs:
             return self.create_error_response(

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -14,16 +14,39 @@ from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.background import BackgroundTask, BackgroundTasks
+from starlette.requests import HTTPConnection
 
 from vllm import envs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.entrypoints.generate.base.protocol import StreamOptions
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import current_formatter_type, init_logger
 from vllm.platforms import current_platform
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 logger = init_logger(__name__)
+
+KV_CACHE_REPORT_MODE_HEADER = "X-KV-Cache-Report-Mode"
+
+
+def resolve_kv_cache_report_mode(
+    extra_args: dict[str, Any] | None,
+    raw_request: HTTPConnection | None,
+) -> dict[str, Any] | None:
+    """Apply the report-mode header as a fallback for the body parameter."""
+    if raw_request is None:
+        return extra_args
+    mode = raw_request.headers.get(KV_CACHE_REPORT_MODE_HEADER)
+    if mode is None:
+        return extra_args
+    if mode not in ("incremental", "full"):
+        raise VLLMValidationError(
+            f"{KV_CACHE_REPORT_MODE_HEADER} must be 'incremental' or 'full'",
+            parameter=KV_CACHE_REPORT_MODE_HEADER,
+        )
+    return {"kv_cache_report_mode": mode, **(extra_args or {})}
+
 
 VLLM_SUBCMD_PARSER_EPILOG = (
     "For full list:            vllm {subcmd} --help=all\n"

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -20,7 +20,6 @@ from vllm import envs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.entrypoints.generate.base.protocol import StreamOptions
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
-from vllm.exceptions import VLLMValidationError
 from vllm.logger import current_formatter_type, init_logger
 from vllm.platforms import current_platform
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -38,13 +37,8 @@ def resolve_kv_cache_report_mode(
     if raw_request is None:
         return extra_args
     mode = raw_request.headers.get(KV_CACHE_REPORT_MODE_HEADER)
-    if mode is None:
-        return extra_args
     if mode not in ("incremental", "full"):
-        raise VLLMValidationError(
-            f"{KV_CACHE_REPORT_MODE_HEADER} must be 'incremental' or 'full'",
-            parameter=KV_CACHE_REPORT_MODE_HEADER,
-        )
+        return extra_args
     return {"kv_cache_report_mode": mode, **(extra_args or {})}
 
 

--- a/vllm/entrypoints/speech_to_text/base/serving.py
+++ b/vllm/entrypoints/speech_to_text/base/serving.py
@@ -8,7 +8,7 @@ import zlib
 from collections.abc import AsyncGenerator, Callable, Set
 from concurrent.futures import ThreadPoolExecutor
 from functools import cached_property
-from typing import Final, Literal, TypeAlias, TypeVar, cast
+from typing import Any, Final, Literal, TypeAlias, TypeVar, cast
 
 import numpy as np
 from fastapi import Request
@@ -24,7 +24,10 @@ from vllm.entrypoints.generate.base.serving import GenerateBaseServing
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse, UsageInfo
 from vllm.entrypoints.serve.engine.typing import SpeechToTextRequest
-from vllm.entrypoints.serve.utils.api_utils import get_max_tokens
+from vllm.entrypoints.serve.utils.api_utils import (
+    get_max_tokens,
+    resolve_kv_cache_report_mode,
+)
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EncoderDecoderInput, EngineInput
@@ -211,6 +214,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         self,
         audio_chunk: np.ndarray,
         request_id: str,
+        extra_args: dict[str, Any] | None = None,
     ) -> str:
         """Auto-detect the spoken language from an audio chunk.
 
@@ -229,6 +233,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
             max_tokens=1,
             temperature=0.0,
             allowed_token_ids=allowed_token_ids,
+            extra_args=extra_args,
         )
 
         result_generator = self.engine_client.generate(
@@ -287,7 +292,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
         ):
             # Auto-detect language from the first chunk.
             request.language = await self._detect_language(
-                chunks[0], f"{request_id}-lang_detect"
+                chunks[0], f"{request_id}-lang_detect", extra_args=request.vllm_xargs
             )
 
         parsed_prompts: list[DictPrompt] = []
@@ -428,6 +433,9 @@ class SpeechToTextBaseServing(GenerateBaseServing):
     ) -> T | V | AsyncGenerator[str, None] | ErrorResponse:
         """Base method for speech-to-text operations like transcription and
         translation."""
+        request.vllm_xargs = resolve_kv_cache_report_mode(
+            request.vllm_xargs, raw_request
+        )
         if request.stream and request.use_beam_search:
             return self.create_error_response(
                 "Streaming is not currently supported with beam search"
@@ -555,6 +563,7 @@ class SpeechToTextBaseServing(GenerateBaseServing):
                         request_id=request_id_item,
                         lora_request=lora_request,
                         trace_headers=trace_headers,
+                        extra_args=request.vllm_xargs,
                     )
                 else:
                     generator = self.engine_client.generate(

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -15,6 +15,7 @@ from starlette.websockets import WebSocketDisconnect
 from vllm import envs
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse, UsageInfo
 from vllm.entrypoints.serve.exception_handling.utils import sanitize_message
+from vllm.entrypoints.serve.utils.api_utils import resolve_kv_cache_report_mode
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 
@@ -217,6 +218,7 @@ class RealtimeConnection:
                 temperature=0.0,
                 max_tokens=self.serving.model_cls.realtime_max_tokens,
                 output_kind=RequestOutputKind.DELTA,
+                extra_args=resolve_kv_cache_report_mode(None, self.websocket),
                 skip_clone=True,
             )
 


### PR DESCRIPTION
## Purpose

Allow clients to select KV cache event reporting without modifying request bodies:

```python
extra_headers={"X-KV-Cache-Report-Mode": "full"}
```

The header accepts `incremental` and `full`. An explicit body `kv_cache_report_mode` takes precedence. Invalid header values are ignored, preserving the body value or the default `incremental` mode. Event publishing still requires `--kv-events-config`.

Coverage:

- Python: Chat Completions, Completions, Responses, Anthropic Messages, Cohere Chat, batched chat, render/generate, generative scoring, transcription/translation, and realtime audio. The mode is preserved through online beam search and language detection. SageMaker invocations use the same serving paths.
- Rust: Chat Completions, Completions, render/generate, and `x-kv-cache-report-mode` metadata for both gRPC generation methods.

The same fallback applies to HTTP headers, WebSocket handshake headers, and Rust gRPC metadata. Realtime audio applies the handshake header to each utterance.

Python `--grpc` delegates generation to `smg-grpc-servicer`; it requires a companion change outside this PR. Offline Python and JSONL batch retain their existing body/sampling options.

Duplicate checks found no open PR adding this header: searched `kv_cache_report_mode` and report-mode/header keywords, reviewed RFC #48501 comments, and checked open PRs referencing that RFC. This change adds request transport for the existing report mode.

AI assistance was used for implementation and verification.

## Test Plan

```sh
.venv/bin/python -m pytest \
  tests/entrypoints/generate/test_kv_cache_report_mode.py \
  tests/entrypoints/serve/utils/test_api_utils.py \
  tests/samplers/test_beam_search_online.py \
  tests/entrypoints/speech_to_text/test_speech_to_text_cancellation.py \
  tests/entrypoints/cohere/test_api_router.py -q --tb=short

# From rust/:
cargo test --locked -p vllm-server --lib
cargo clippy --locked -p vllm-server --all-targets --all-features -- -D warnings

# From the repository root:
.venv/bin/pre-commit run
.venv/bin/pre-commit run mypy-3.12 --all-files --hook-stage manual
```

## Test Result

- Python: 112 passed. Covers propagation, both modes, body precedence, invalid-value fallback, and preservation of other extra arguments.
- Rust server: 387 passed, including HTTP and gRPC requests reaching the mock engine with the expected mode.
- Clippy, applicable pre-commit hooks, and Python 3.12 mypy passed.
- Regression tests reproduced missing header propagation and rejection of invalid headers before the corresponding fixes.
- Model evaluation: not run. Verification used mocked engines; no GPU model execution was performed.
