### PR TITLE
[Bugfix][Frontend] Emit correct `find_in_page` type for `browser.find` calls

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for vllm.entrypoints.openai.responses.harmony."""
 
+import json
+
 import pytest
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -9,6 +11,7 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseReasoningItem,
 )
+from openai.types.responses.response_function_web_search import ActionFind
 from openai.types.responses.response_output_item import McpCall
 from openai_harmony import Author, Message, Role, TextContent
 
@@ -95,6 +98,30 @@ class TestResponsePreviousInputToHarmony:
 
 class TestHarmonyToResponseOutput:
     """Tests for harmony_to_response_output function."""
+
+    def test_browser_find_action_uses_find_in_page_type(self):
+        """Browser `find` tool calls must emit the `find_in_page` action type.
+
+        The OpenAI SDK's `ActionFind` model only accepts
+        ``Literal["find_in_page"]`` (see openai-python
+        `response_function_web_search.py`), so emitting ``type="find"`` raised
+        a Pydantic ValidationError on every `browser.find` call.
+        See https://github.com/vllm-project/vllm/issues/55295.
+        """
+        message = Message.from_role_and_content(
+            Role.ASSISTANT,
+            json.dumps({"url": "https://example.com", "pattern": "vllm"}),
+        )
+        message = message.with_recipient("browser.find").with_channel("commentary")
+
+        output_items = harmony_to_response_output(message, frozenset())
+
+        assert len(output_items) == 1
+        item = output_items[0]
+        assert isinstance(item, ResponseFunctionWebSearch)
+        assert isinstance(item.action, ActionFind)
+        assert item.action.type == "find_in_page"
+        assert item.action.pattern == "vllm"
 
     @pytest.mark.parametrize("incomplete", [False, True])
     def test_commentary_with_no_recipient_creates_message(self, incomplete):

--- a/tests/entrypoints/openai/responses/test_streaming_events.py
+++ b/tests/entrypoints/openai/responses/test_streaming_events.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+
+from openai_harmony import Message, Role
+
 from vllm.entrypoints.generate.base.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
@@ -8,7 +12,9 @@ from vllm.entrypoints.generate.base.protocol import (
 )
 from vllm.entrypoints.openai.responses.streaming_events import (
     SimpleStreamingEventProcessor,
+    StreamingState,
     _StateType,
+    emit_browser_tool_events,
     split_delta,
 )
 
@@ -18,6 +24,29 @@ def _make_tool_call(
 ) -> DeltaToolCall:
     fn = DeltaFunctionCall(name=name, arguments=arguments)
     return DeltaToolCall(index=index, function=fn)
+
+
+def test_emit_browser_find_event_uses_find_in_page_type():
+    """Streaming `browser.find` events must emit the `find_in_page` action type.
+
+    `ActionFind` in the OpenAI SDK only accepts ``Literal["find_in_page"]``,
+    so emitting ``type="find"`` raised a ValidationError when building the SSE
+    events. See https://github.com/vllm-project/vllm/issues/55295.
+    """
+    previous_item = Message.from_role_and_content(
+        Role.ASSISTANT,
+        json.dumps({"url": "https://example.com", "pattern": "vllm"}),
+    )
+    previous_item = previous_item.with_recipient("browser.find").with_channel(
+        "commentary"
+    )
+
+    events = emit_browser_tool_events(previous_item, StreamingState())
+
+    added = [e for e in events if e.type == "response.output_item.added"]
+    assert len(added) == 1
+    assert added[0].item.action.type == "find_in_page"
+    assert added[0].item.action.pattern == "vllm"
 
 
 class TestSplitDelta:

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -293,7 +293,7 @@ def _parse_browser_tool_call(message: Message, recipient: str) -> ResponseOutput
         action = ActionFind(
             pattern=browser_call.get("pattern", ""),
             url=f"cursor:{browser_call.get('url', '')}",
-            type="find",
+            type="find_in_page",
         )
     else:
         raise ValueError(f"Unknown browser action: {recipient}")

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -667,7 +667,7 @@ def emit_browser_tool_events(
         )
     elif function_name == "find":
         action = response_function_web_search.ActionFind(
-            type="find",
+            type="find_in_page",
             pattern=parsed_args["pattern"],
             # TODO: translate to url
             url=f"cursor:{parsed_args.get('cursor', '')}",


### PR DESCRIPTION
Fixes #55295

**Bug**: vLLM emitted `type="find"` for `browser.find` tool calls, but the OpenAI SDK's `ActionFind` model only accepts `Literal["find_in_page"]` (openai-python `src/openai/types/responses/response_function_web_search.py`). Pydantic therefore raised a `ValidationError` on every `browser.find` call, in both the Responses API (non-streaming) and SSE streaming paths.

**Change**: emit `type="find_in_page"` in both sites:
- `harmony.py` `_parse_browser_tool_call` (non-streaming)
- `streaming_events.py` `emit_browser_tool_events` (streaming)

**Tests**: regression tests for both paths assert `action.type == "find_in_page"`. Before the fix, constructing `ActionFind(type="find")` fails immediately with a Pydantic `ValidationError`, so both tests fail on the old code.

Verified the SDK enum: `ActionFind(type="find")` → `ValidationError`, `ActionFind(type="find_in_page")` → OK.