### PR TITLE
[Bugfix] Qwen3 parser: a malformed <parameter> element no longer leaks into streamed arguments

### DIFF
--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -1182,6 +1182,7 @@ class TestMalformedParameterElements:
 
     Measured on vLLM 0.28.0 with Qwen3.5 (vllm-project/vllm#55495): elements
     such as ``<parameter=\n...\n</parameter>`` (name missing),
+    ``<parameter=>...</parameter>`` (name empty),
     ``<parameter=ids: [...]\n</parameter>`` (``>`` missing) and
     ``<parameter=note=\n</parameter>`` (empty value, stray ``=``) made the
     partial converter emit everything up to the closing tag's ``>`` as a key.
@@ -1213,6 +1214,13 @@ class TestMalformedParameterElements:
             "<parameter=agent>handyman-01</parameter>\n"
             "<parameter=id>hm01-cla-callee-pin-bump-20260905</parameter>\n"
             "<parameter=note=\n</parameter>\n"
+            "</function>\n"
+        ),
+        # name empty but the element otherwise well formed
+        (
+            "<function=exec_command>\n"
+            "<parameter=cmd>ls</parameter>\n"
+            "<parameter=>stray value</parameter>\n"
             "</function>\n"
         ),
     ]
@@ -1250,6 +1258,15 @@ class TestMalformedParameterElements:
         final = json.loads(result.tool_calls[0].function.arguments)
 
         assert streamed == final
+
+    def test_empty_parameter_name_is_dropped(self, parser, mock_request):
+        body = self.MALFORMED_BODIES[3]
+
+        result = parser.extract_tool_calls(
+            "<tool_call>\n" + body + "</tool_call>", mock_request
+        )
+
+        assert json.loads(result.tool_calls[0].function.arguments) == {"cmd": "ls"}
 
     def test_well_formed_parameters_still_parse(self, parser, mock_request):
         body = (

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -1175,3 +1175,97 @@ class TestNestedSchemaCoercion:
         assert questions[0]["question"] == "Pick a color"
         assert questions[0]["multiSelect"] is False
         assert questions[0]["answer"] is None
+
+
+class TestMalformedParameterElements:
+    """A parameter element the model wrote slightly off must not leak.
+
+    Measured on vLLM 0.28.0 with Qwen3.5 (vllm-project/vllm#55495): elements
+    such as ``<parameter=\n...\n</parameter>`` (name missing),
+    ``<parameter=ids: [...]\n</parameter>`` (``>`` missing) and
+    ``<parameter=note=\n</parameter>`` (empty value, stray ``=``) made the
+    partial converter emit everything up to the closing tag's ``>`` as a key.
+    The final conversion did not, the streamed prefix could not be extended,
+    and the client was left with an unterminated JSON object. Streaming and
+    non-streaming must agree, and both must be valid JSON.
+    """
+
+    MALFORMED_BODIES = [
+        # name missing: the model put the value straight after ``=``
+        (
+            "<function=exec_command>\n"
+            "<parameter=cmd>timeout 7 bash -lc 'echo hi'</parameter>\n"
+            "<parameter=\necho SAC_NAME=$SAC_NAME; echo CCA=$SCITEX_CARDS_AGENT_ID\n"
+            "</parameter>\n"
+            "</function>\n"
+        ),
+        # ``>`` missing after the name
+        (
+            "<function=ack_notifications>\n"
+            "<parameter=agent>handyman-01</parameter>\n"
+            '<parameter=ids: ["n_77fe30340532", "n_6b9520e4bc2e"]\n'
+            "</parameter>\n"
+            "</function>\n"
+        ),
+        # stray ``=`` and an empty value
+        (
+            "<function=add_task>\n"
+            "<parameter=agent>handyman-01</parameter>\n"
+            "<parameter=id>hm01-cla-callee-pin-bump-20260905</parameter>\n"
+            "<parameter=note=\n</parameter>\n"
+            "</function>\n"
+        ),
+    ]
+
+    @staticmethod
+    def _chunks(body: str) -> list[str]:
+        # Mimic token-sized deltas: the malformed element arrives in pieces.
+        pieces = ["<tool_call>\n"]
+        step = 7
+        pieces.extend(body[i : i + step] for i in range(0, len(body), step))
+        pieces.append("</tool_call>")
+        return pieces
+
+    @pytest.mark.parametrize("body", MALFORMED_BODIES)
+    def test_streamed_arguments_are_valid_json(self, parser, mock_request, body):
+        results = simulate_tool_streaming(parser, mock_request, self._chunks(body))
+
+        args_text = collect_tool_arguments(results)
+        parsed = json.loads(args_text)  # must not raise
+
+        assert isinstance(parsed, dict)
+
+    @pytest.mark.parametrize("body", MALFORMED_BODIES)
+    def test_streaming_agrees_with_non_streaming(self, parser, mock_request, body):
+        streamed = json.loads(
+            collect_tool_arguments(
+                simulate_tool_streaming(parser, mock_request, self._chunks(body))
+            )
+        )
+
+        result = parser.extract_tool_calls(
+            "<tool_call>\n" + body + "</tool_call>", mock_request
+        )
+        assert result.tools_called is True
+        final = json.loads(result.tool_calls[0].function.arguments)
+
+        assert streamed == final
+
+    def test_well_formed_parameters_still_parse(self, parser, mock_request):
+        body = (
+            "<function=exec_command>\n"
+            "<parameter=cmd>timeout 7 bash -lc 'echo SAC_NAME=$SAC_NAME; "
+            "echo CCA=$SCITEX_CARDS_AGENT_ID'</parameter>\n"
+            "<parameter=cwd>/work</parameter>\n"
+            "</function>\n"
+        )
+
+        result = parser.extract_tool_calls(
+            "<tool_call>\n" + body + "</tool_call>", mock_request
+        )
+
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "cmd": "timeout 7 bash -lc 'echo SAC_NAME=$SAC_NAME; "
+            "echo CCA=$SCITEX_CARDS_AGENT_ID'",
+            "cwd": "/work",
+        }

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -1005,6 +1005,16 @@ class ParserEngine(Parser):
         prev = slot.streamed_json
         if final_json and len(final_json) > len(prev):
             if prev and not final_json.startswith(prev):
+                # The streamed prefix cannot be retracted, so the client is
+                # left with whatever was already sent — which is not valid
+                # JSON when this happens. Say so instead of failing silently.
+                logger.warning(
+                    "arg converter: final arguments do not extend the "
+                    "streamed prefix; the client keeps a truncated string "
+                    "(streamed=%r final=%r)",
+                    prev[:120],
+                    final_json[:120],
+                )
                 return None
             diff = final_json[len(prev) :]
             slot.streamed_json = final_json

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -1008,12 +1008,15 @@ class ParserEngine(Parser):
                 # The streamed prefix cannot be retracted, so the client is
                 # left with whatever was already sent — which is not valid
                 # JSON when this happens. Say so instead of failing silently.
+                # Lengths only: the arguments are user data and may hold
+                # secrets, so they must not reach the log.
                 logger.warning(
                     "arg converter: final arguments do not extend the "
                     "streamed prefix; the client keeps a truncated string "
-                    "(streamed=%r final=%r)",
-                    prev[:120],
-                    final_json[:120],
+                    "(tool=%s streamed=%d chars, final=%d chars)",
+                    slot.name,
+                    len(prev),
+                    len(final_json),
                 )
                 return None
             diff = final_json[len(prev) :]

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -54,8 +54,10 @@ PARAM_END = "</parameter>"
 # (the closing tag's) into a key; the partial converter then streamed that key
 # while the final conversion did not produce it, the prefix invariant broke, and
 # the client was left holding an unterminated JSON object
-# (vllm-project/vllm#55495).
-_PARAM_NAME = r"([^>\s<]*)"
+# (vllm-project/vllm#55495). The name is also required to be non-empty, so
+# ``<parameter=>value</parameter>`` is dropped rather than emitted as ``{"": ...}``;
+# both regexes share the group so the partial and the final conversion agree.
+_PARAM_NAME = r"([^>\s<]+)"
 _PARAM_RE = re.compile(
     r"<\s*parameter\s*=\s*" + _PARAM_NAME + r">"
     r"(.*?)"
@@ -63,7 +65,7 @@ _PARAM_RE = re.compile(
     re.DOTALL,
 )
 _PARTIAL_PARAM_RE = re.compile(
-    r"<\s*parameter\s*=\s*([^>\s<]+)>(.*)$",
+    r"<\s*parameter\s*=\s*" + _PARAM_NAME + r">(.*)$",
     re.DOTALL,
 )
 

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -48,13 +48,24 @@ FUNC_END = "</function>"
 PARAM_START = "<parameter="
 PARAM_END = "</parameter>"
 
+# A parameter NAME never contains whitespace or another tag. Accepting
+# ``[^>]`` here let a malformed element such as ``<parameter=\necho $X\n</parameter>``
+# or ``<parameter=note=\n</parameter>`` turn everything up to the *next* ``>``
+# (the closing tag's) into a key; the partial converter then streamed that key
+# while the final conversion did not produce it, the prefix invariant broke, and
+# the client was left holding an unterminated JSON object
+# (vllm-project/vllm#55495).
+_PARAM_NAME = r"([^>\s<]*)"
 _PARAM_RE = re.compile(
-    r"<\s*parameter\s*=\s*([^>]*)>"
+    r"<\s*parameter\s*=\s*" + _PARAM_NAME + r">"
     r"(.*?)"
     r"(?:<\s*/\s*parameter\s*>|(?=<\s*parameter\s*=))",
     re.DOTALL,
 )
-_PARTIAL_PARAM_RE = re.compile(r"<\s*parameter\s*=\s*([^>]+)>(.*)$", re.DOTALL)
+_PARTIAL_PARAM_RE = re.compile(
+    r"<\s*parameter\s*=\s*([^>\s<]+)>(.*)$",
+    re.DOTALL,
+)
 
 
 def _trim_wrapping_newlines(value: str) -> str:


### PR DESCRIPTION
## Purpose

Fixes #55495.

The parameter-name group of the Qwen3 XML regexes (`vllm/parser/qwen3.py`) accepted any character except `>`. When the model writes an element slightly off — `<parameter=` followed by a newline (name missing), `<parameter=ids: [...]` (the `>` missing) or `<parameter=note=` (stray `=`, empty value) — the partial converter used everything up to the *closing tag's* `>` as a key (e.g. `"echo SAC_NAME=$SAC_NAME; …\n</parameter"`) and streamed it. The final conversion did not produce that key, so the streamed prefix could not be extended, `_flush_arg_converter` returned `None` silently, and the client was left holding an unterminated JSON object:

```
{"cmd": "timeout 7\n7", "echo SAC_NAME=$SAC_NAME; echo CCA=$SCITEX_CARDS_AGENT_ID\n</parameter":
```

Clients that store tool calls verbatim (the Responses API flow, e.g. Codex CLI) then get every later request of that conversation rejected with `400 Expecting value: line 1 column 98 (char 97)` — one bad tool call ends the session.

## Changes

- `vllm/parser/qwen3.py`: the parameter name must match `[^>\s<]` (a name never contains whitespace or another tag), in both `_PARAM_RE` and `_PARTIAL_PARAM_RE`. A malformed element is now dropped consistently by the partial and the final conversion, so the prefix invariant holds and the arguments stay valid JSON.
- `vllm/parser/engine/parser_engine.py`: `_flush_arg_converter` logs a warning when the final arguments do not extend the streamed prefix, instead of returning `None` in silence.
- `tests/parser/engine/test_qwen3.py`: `TestMalformedParameterElements` — the three malformed bodies measured in production, streamed in 7-character chunks: the streamed arguments must parse and must equal the non-streaming result; a well-formed body is unchanged.

## Test plan

- `pytest tests/parser/engine/test_qwen3.py` (the new class plus the existing streaming/non-streaming classes) green.
- Positive control on the unpatched regexes: for the same three bodies the partial converter leaks exactly the keys seen in production (`…\n</parameter`), the final does not.
- Measured in production on vLLM 0.28.0 (Qwen3.5-based 27B FP8, `--tool-call-parser qwen3_xml`, Codex CLI over `/v1/responses`): 3 of 24 tool calls arrived with such truncated arguments; a synthetic run of 24 shell-shaped prompts on `/v1/chat/completions` (non-streaming) produced 0 — the defect needs the streamed path.
