### PR TITLE
[Bugfix][Quantization] Dispatch FP8_BLOCK_SCALES routed experts in ModelOpt MIXED_PRECISION

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -248,6 +248,68 @@ def test_modelopt_mixed_precision_quantizes_parallel_lm_head():
     assert method.spec.activation is kNvfp4Dynamic
 
 
+def test_modelopt_mixed_precision_dispatches_fp8_block_scales_moe():
+    """FP8_BLOCK_SCALES routed experts must reach a block-quantised Fp8MoEMethod.
+
+    Without a branch for it, get_quant_method falls through to None, the expert
+    layer is built unquantised and never registers weight_scale_inv, and loading
+    a checkpoint that carries one dies with:
+
+        AttributeError: Layer ... has no parameter 'w2_weight_scale_inv'
+
+    See https://github.com/vllm-project/vllm/issues/55496. The block size comes
+    from the layer's own group_size, and weight_block_size is what makes
+    Fp8MoEMethod name its scales weight_scale_inv.
+    """
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+
+    config = _mixed_precision_config(
+        {
+            "model.layers.0.mlp.experts": {
+                "quant_algo": "FP8_BLOCK_SCALES",
+                "group_size": 128,
+            }
+        }
+    )
+    layer = Mock(spec=RoutedExperts)
+    layer.__class__ = RoutedExperts
+    layer.moe_config = MagicMock()
+
+    # Constructing the real method selects a device-specific kernel backend,
+    # which is not what this test is about: assert the dispatch decision and the
+    # block size handed to it.
+    with patch(
+        "vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod"
+    ) as mock_moe:
+        method = config.get_quant_method(
+            layer, prefix="model.layers.0.mlp.experts"
+        )
+
+    assert method is mock_moe.return_value
+    quant_config = mock_moe.call_args.args[0]
+    assert quant_config.weight_block_size == [128, 128]
+    assert quant_config.is_checkpoint_fp8_serialized
+
+
+def test_modelopt_mixed_precision_fp8_block_scales_defaults_block_size():
+    """An entry without group_size falls back to the 128 ModelOpt always emits."""
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+
+    config = _mixed_precision_config(
+        {"model.layers.0.mlp.experts": {"quant_algo": "FP8_BLOCK_SCALES"}}
+    )
+    layer = Mock(spec=RoutedExperts)
+    layer.__class__ = RoutedExperts
+    layer.moe_config = MagicMock()
+
+    with patch(
+        "vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod"
+    ) as mock_moe:
+        config.get_quant_method(layer, prefix="model.layers.0.mlp.experts")
+
+    assert mock_moe.call_args.args[0].weight_block_size == [128, 128]
+
+
 def test_modelopt_mixed_precision_resolves_declared_packed_projection():
     config = _mixed_precision_config(
         {

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -278,12 +278,8 @@ def test_modelopt_mixed_precision_dispatches_fp8_block_scales_moe():
     # Constructing the real method selects a device-specific kernel backend,
     # which is not what this test is about: assert the dispatch decision and the
     # block size handed to it.
-    with patch(
-        "vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod"
-    ) as mock_moe:
-        method = config.get_quant_method(
-            layer, prefix="model.layers.0.mlp.experts"
-        )
+    with patch("vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod") as mock_moe:
+        method = config.get_quant_method(layer, prefix="model.layers.0.mlp.experts")
 
     assert method is mock_moe.return_value
     quant_config = mock_moe.call_args.args[0]
@@ -302,9 +298,7 @@ def test_modelopt_mixed_precision_fp8_block_scales_defaults_block_size():
     layer.__class__ = RoutedExperts
     layer.moe_config = MagicMock()
 
-    with patch(
-        "vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod"
-    ) as mock_moe:
+    with patch("vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod") as mock_moe:
         config.get_quant_method(layer, prefix="model.layers.0.mlp.experts")
 
     assert mock_moe.call_args.args[0].weight_block_size == [128, 128]
@@ -335,9 +329,7 @@ def test_modelopt_mixed_precision_fp8_block_scales_sibling_entry_block_size():
     prefix = "model.layers.0.moe.experts"
     assert config._resolve_quant_algo(prefix) == "FP8_BLOCK_SCALES"
 
-    with patch(
-        "vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod"
-    ) as mock_moe:
+    with patch("vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod") as mock_moe:
         config.get_quant_method(layer, prefix=prefix)
 
     assert mock_moe.call_args.args[0].weight_block_size == [64, 64]

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -310,6 +310,60 @@ def test_modelopt_mixed_precision_fp8_block_scales_defaults_block_size():
     assert mock_moe.call_args.args[0].weight_block_size == [128, 128]
 
 
+def test_modelopt_mixed_precision_fp8_block_scales_sibling_entry_block_size():
+    """Block size must survive the ".experts" -> parent sibling fallback.
+
+    _resolve_quant_algo resolves a "...moe.experts" layer from sibling entries
+    like "...moe.gate_proj". The block size has to resolve the same way, or a
+    non-128 checkpoint silently gets 128 and Fp8MoEMethod registers
+    weight_scale_inv at shapes the checkpoint does not have.
+    """
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+
+    config = _mixed_precision_config(
+        {
+            "model.layers.0.moe.gate_proj": {
+                "quant_algo": "FP8_BLOCK_SCALES",
+                "group_size": 64,
+            }
+        }
+    )
+    layer = Mock(spec=RoutedExperts)
+    layer.__class__ = RoutedExperts
+    layer.moe_config = MagicMock()
+
+    prefix = "model.layers.0.moe.experts"
+    assert config._resolve_quant_algo(prefix) == "FP8_BLOCK_SCALES"
+
+    with patch(
+        "vllm.model_executor.layers.quantization.fp8.Fp8MoEMethod"
+    ) as mock_moe:
+        config.get_quant_method(layer, prefix=prefix)
+
+    assert mock_moe.call_args.args[0].weight_block_size == [64, 64]
+
+
+def test_modelopt_mixed_precision_fp8_block_scales_gates_quant_fp8():
+    """FP8_BLOCK_SCALES is block-scaled, so it must enable "+quant_fp8".
+
+    Without it QuantFP8 falls back to forward_native, which emits unpacked fp32
+    group scales and the block GEMM fails to launch. A checkpoint whose only
+    block-scaled layers are FP8_BLOCK_SCALES must still report blocked weights.
+    """
+    config = _mixed_precision_config(
+        {"model.layers.0.mlp.experts": {"quant_algo": "FP8_BLOCK_SCALES"}}
+    )
+    assert config.has_blocked_weights()
+
+
+def test_modelopt_mixed_precision_non_blocked_algo_does_not_gate_quant_fp8():
+    """A checkpoint with no block-scaled layer must not turn "+quant_fp8" on."""
+    config = _mixed_precision_config(
+        {"model.layers.0.mlp.experts": {"quant_algo": "NVFP4", "group_size": 16}}
+    )
+    assert not config.has_blocked_weights()
+
+
 def test_modelopt_mixed_precision_resolves_declared_packed_projection():
     config = _mixed_precision_config(
         {

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -135,6 +135,12 @@ LINEAR_ALGOS: dict[str, tuple[str, str]] = {
 # table above.
 QUANT_ALGOS = [*LINEAR_ALGOS, "MIXED_PRECISION"]
 
+# Block-scaled FP8 for routed experts. Not a linear algo: the LINEAR_ALGOS table
+# above drives linear dispatch only, and no ModelOpt sub-config models a
+# block-quantised FP8 MoE, so mixed-precision dispatch builds one on demand.
+# ModelOpt records the block size as group_size; this is the fallback.
+_DEFAULT_FP8_BLOCK_SIZE = 128
+
 
 def algos_owned_by(config_name: str) -> tuple[str, ...]:
     """The linear algos a given config accepts, for its quant_algo validation."""
@@ -1604,6 +1610,25 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
             mxfp8_config=mxfp8_config,
         )
 
+    def _fp8_moe_block_size(self, prefix: str) -> int:
+        """Block size declared for a block-scaled FP8 layer.
+
+        ModelOpt records it as ``group_size`` on the layer's own entry (128 in
+        every checkpoint seen so far). RoutedExperts prefixes may name the
+        parent module, so fall back to the first child entry.
+        """
+        for candidate in self._quantized_layer_prefix_candidates(prefix):
+            info = self.quantized_layers.get(candidate)
+            if info is None:
+                prefix_dot = candidate + "."
+                for key, entry in self.quantized_layers.items():
+                    if key.startswith(prefix_dot):
+                        info = entry
+                        break
+            if info is not None and info.get("group_size"):
+                return int(info["group_size"])
+        return _DEFAULT_FP8_BLOCK_SIZE
+
     def _resolve_quant_algo(self, prefix: str) -> str | None:
         """Look up the quant_algo for a vLLM-side layer prefix.
 
@@ -1749,6 +1774,28 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                 return ModelOptMxFp8FusedMoE(
                     quant_config=self.mxfp8_config,
                     moe_config=layer.moe_config,
+                )
+            if quant_algo == "FP8_BLOCK_SCALES":
+                # Block-scaled FP8 experts (DeepSeek-style weight_scale_inv).
+                # Fp8MoEMethod already implements this once weight_block_size
+                # is set: it selects kFp8Static128BlockSym/kFp8Dynamic128Sym
+                # and names its scales weight_scale_inv, which is what these
+                # checkpoints carry. Built here rather than hung off a shared
+                # sub-config because none of the ModelOpt sub-configs models a
+                # block-quantised FP8 MoE.
+                from vllm.model_executor.layers.quantization.fp8 import (
+                    Fp8Config,
+                    Fp8MoEMethod,
+                )
+
+                block = self._fp8_moe_block_size(prefix)
+                return Fp8MoEMethod(
+                    Fp8Config(
+                        is_checkpoint_fp8_serialized=True,
+                        activation_scheme="dynamic",
+                        weight_block_size=[block, block],
+                    ),
+                    layer,
                 )
             return None
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -141,6 +141,11 @@ QUANT_ALGOS = [*LINEAR_ALGOS, "MIXED_PRECISION"]
 # ModelOpt records the block size as group_size; this is the fallback.
 _DEFAULT_FP8_BLOCK_SIZE = 128
 
+# Algos whose weights are block-scaled, and which therefore must turn on
+# "+quant_fp8" via has_blocked_weights(): without it QuantFP8 falls back to
+# forward_native and emits unpacked fp32 group scales that DeepGEMM rejects.
+_BLOCK_SCALED_ALGOS = frozenset({"FP8_PB_WO", "FP8_BLOCK_SCALES"})
+
 
 def algos_owned_by(config_name: str) -> tuple[str, ...]:
     """The linear algos a given config accepts, for its quant_algo validation."""
@@ -1501,7 +1506,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
         # Same gate as ModelOptFp8Config.has_blocked_weights, resolved per
         # layer: "+quant_fp8" must be on as soon as any layer is block-scaled.
         return any(
-            info.get("quant_algo", "").upper() == "FP8_PB_WO"
+            info.get("quant_algo", "").upper() in _BLOCK_SCALED_ALGOS
             for info in self.quantized_layers.values()
         )
 
@@ -1627,6 +1632,18 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                         break
             if info is not None and info.get("group_size"):
                 return int(info["group_size"])
+
+        # Mirror _resolve_quant_algo's final RoutedExperts fallback: the layer
+        # is "...moe.experts" while ModelOpt lists "...moe.gate_proj" etc. The
+        # algo resolves through that path, so the block size must too, or a
+        # non-128 checkpoint silently gets 128 and its weight_scale_inv shapes
+        # will not match.
+        if prefix.endswith(".experts"):
+            parent_dot = prefix.rsplit(".experts", 1)[0] + "."
+            for key, entry in self.quantized_layers.items():
+                if key.startswith(parent_dot) and entry.get("group_size"):
+                    return int(entry["group_size"])
+
         return _DEFAULT_FP8_BLOCK_SIZE
 
     def _resolve_quant_algo(self, prefix: str) -> str | None:


### PR DESCRIPTION
## Purpose

ModelOpt `MIXED_PRECISION` checkpoints may declare routed experts as `FP8_BLOCK_SCALES`, which `ModelOptMixedPrecisionConfig.get_quant_method` does not dispatch. The `RoutedExperts` branch handles `FP8`, `NVFP4`, `W4A16_NVFP4` and `MXFP8`, then falls through to `None`. The layer is built unquantised and never registers `weight_scale_inv`, so loading dies with:

```
AttributeError: Layer mtp.layers.48.mlp.experts has no parameter 'w2_weight_scale_inv'
  for checkpoint weight 'mtp.layers.48.mlp.experts.0.down_proj.weight_scale_inv'
```

Nothing validates per-layer algos at parse time, so it surfaces during weight loading rather than at config time.

The tensors are ordinary DeepSeek-style 128x128 block FP8:

```
mtp.layers.0.mlp.experts.0.down_proj.weight            F8_E4M3  [2560, 640]
mtp.layers.0.mlp.experts.0.down_proj.weight_scale_inv  BF16     [20, 5]
```

`Fp8MoEMethod` already implements exactly this: with `weight_block_size` set it selects `kFp8Static128BlockSym`/`kFp8Dynamic128Sym` and names its scales `weight_scale_inv` — the parameter the loader reports missing. This dispatches to it, taking the block size from the layer's own `group_size`.

`has_blocked_weights()` also had to learn about the format: it matched only `FP8_PB_WO`, so a checkpoint whose only block-scaled layers are `FP8_BLOCK_SCALES` never enabled `+quant_fp8`, and per the existing comment on that gate QuantFP8 then falls back to `forward_native` and emits unpacked fp32 group scales the block GEMM rejects.

There is an existing asymmetry this closes: `FP8_PB_WO`, described in `LINEAR_ALGOS` as *"FP8 128x128 per-block weight"*, **is** dispatched for linear layers via the `LINEAR_ALGOS`/`resolve()` table, but the `RoutedExperts` branch is a hardcoded chain supporting no block-scaled FP8 at all.

## Why this is not a duplicate

Checked per AGENTS.md. No open PR or issue mentions `FP8_BLOCK_SCALES`, and none adds block-scaled FP8 to the `RoutedExperts` dispatch.

The nearest neighbour is **#50617** (*Serve modelopt_mixed checkpoints with FP8_PB layers*), and the relationship is worth stating explicitly:

- It adds `FP8_PB`, which uses the same DeepSeek 2-D `weight_scale_inv` serialization these expert tensors carry — so `FP8_BLOCK_SCALES` may well be ModelOpt's name for the same scheme. If maintainers prefer, this could become an alias into that path rather than a separate branch; I did not assume that, since #50617 is unmerged and scoped to linear layers.
- It is a large refactor of this same file and touches `has_blocked_weights`, so **these two will conflict on merge**. Happy to rebase on it or to fold this in, whichever is preferred.
- It does not address the MoE dispatch: `FP8_BLOCK_SCALES` appears nowhere in it, and its `RoutedExperts` branch is unchanged context.

Also related: #54367 dispatched `FP8_PER_CHANNEL_PER_TOKEN` in this file — same shape as this change. #54882 (merged) fixed FP8 PLE loading for these checkpoints and is also required by the model that surfaced this.

## Scope

Fixes **half** of #55496. That issue reports a second, independent defect: `Qwen4ExpMultiTokenPredictor` builds its draft at `mtp.layers.{num_hidden_layers}` while ModelOpt names the same layer `mtp.layers.0`, so `_resolve_quant_algo` returns `None` and this branch is never reached for that model. That is the same class as #53790, and its correct fix location (a mapper on the model class vs. the quant config) is a maintainer call — deliberately not addressed here. Both are needed for `nvidia/Qwen3.8-Flash-Next-NVFP4` to load with MTP.

## Test commands and results

Run against `main` at `0.28.1rc1.dev437+ge962733e0`, using the official nightly image `vllm/vllm-openai:nightly-e962733e08d10f7ca65dac4df99e116460b8b174` (aarch64):

```
python3 -m pytest -q --noconftest tests/quantization/test_modelopt.py
```

| | stock main | with this PR |
|---|---|---|
| `tests/quantization/test_modelopt.py` | 30 passed, 4 skipped, 3 errors | **35 passed, 4 skipped, 3 errors** |

The 4 skips and 3 errors are pre-existing device-fixture cases and are identical on both sides. The 5 new tests cover: the dispatch decision, the `group_size` default, a non-128 sibling-entry block size, and `has_blocked_weights` positive and negative.

Dispatch check against the real `config.json` of `nvidia/Qwen3.8-Flash-Next-NVFP4`:

| | before | after |
|---|---|---|
| `get_quant_method` at the experts prefix | `None` | `Fp8MoEMethod(weight_block_size=[128, 128])` |

No regression: dispatch for every other MoE algo (FP8, NVFP4, W4A16_NVFP4, MXFP8) and every linear algo (FP8, FP8_PER_CHANNEL_PER_TOKEN, FP8_PB_WO, NVFP4, MXFP8) is byte-identical before and after.

**Deviation from AGENTS.md worth flagging:** these ran with the container's bundled interpreter rather than `uv` + `.venv/bin/python`, because building vLLM from source for this platform was not practical here. Re-running under the prescribed workflow on x86 CUDA would be a reasonable thing to ask for.

## Serving / evaluation results

This fix plus the #55496 prefix fix let `nvidia/Qwen3.8-Flash-Next-NVFP4` serve with MTP3 on 2x DGX Spark (GB10, `sm_121a`) at TP=2 with expert parallelism:

| | this checkpoint (both fixes) | `RadixArk/Qwen3.8-Flash-Next-NVFP4` (natively supported) |
|---|---|---|
| MTP acceptance rate | **59.1%** | **60.8%** |
| Mean acceptance length | 2.67 – 3.74 | — |
| Decode, single stream | 44.2 tok/s | 44.8 tok/s |

Acceptance rate is the meaningful check: speculative decoding verifies every drafted token against the target, so a mis-loaded draft would still emit correct output and simply be rejected — it would show as an acceptance rate near zero. At 59.1% against 60.8% for a natively-supported quantisation of the same base model, the experts load correctly.

Also passing on that deployment: `vllm:spec_decode` metrics healthy, and an 8-point functional smoke (tool calling, reasoning path, 52k-token needle retrieval, 4x concurrent burst) at 8/8.

**Where each claim was tested:** the dispatch behaviour, the no-regression comparison and the unit tests were run against `main` as stated above. The serving numbers were produced on `0.1.dev20073+g8e685d198` with this change back-ported, because building `main` for GB10 was not practical — so "the config layer selects the right method on main" and "the model serves" were established on different builds. Note also that the checkpoint I have uses `group_size: 128` throughout, so the serving run would not have caught the non-128 block-size bug fixed in the second commit.

## AI assistance

This change was AI-assisted, per AGENTS.md. The submitter has reviewed every changed line and is able to defend the change; the diagnosis, reproduction, and the serving measurements above come from a real 2-node deployment rather than from inspection alone. The two review findings from CodeRabbit were each verified against the source before being acted on.
