### PR TITLE
[Bugfix][Benchmark] Replace stale command options in parameter sweeps

### DIFF
--- a/docs/benchmarking/sweeps.md
+++ b/docs/benchmarking/sweeps.md
@@ -74,6 +74,10 @@ Follow these steps to run the script:
 
 5. Set `--output-dir` and optionally `--experiment-name` to control where to save the results.
 
+Sweep parameters replace matching long options in the base `--serve-cmd` or `--bench-cmd`, including repeated occurrences and both `--key value` and `--key=value` forms. Hyphens and underscores in the option prefix are equivalent; nested field names retain their spelling. Top-level boolean overrides replace both positive and `--no-` forms.
+
+For example, `{"compilation_config.use_inductor_graph_partition": false}` replaces `--compilation-config.use_inductor_graph_partition true` with `--compilation-config.use_inductor_graph_partition=false`, consuming the old value.
+
 Example command:
 
 ```bash

--- a/tests/benchmarks/sweep/test_param_sweep.py
+++ b/tests/benchmarks/sweep/test_param_sweep.py
@@ -2,15 +2,83 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import json
 import tempfile
+from argparse import BooleanOptionalAction
 from pathlib import Path
 
 import pytest
 
 from vllm.benchmarks.sweep.param_sweep import ParameterSweep, ParameterSweepItem
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 
 class TestParameterSweepItem:
     """Test ParameterSweepItem functionality."""
+
+    @pytest.mark.parametrize("value", [True, False])
+    @pytest.mark.parametrize("prefix", ["compilation-config", "compilation_config"])
+    @pytest.mark.parametrize("inline", [True, False])
+    def test_override_nested_boolean_is_parseable(self, value, prefix, inline):
+        """Replacing a dotted boolean must consume its old value as well."""
+        key = f"--{prefix}.use_inductor_graph_partition"
+        old_value = "false" if value else "true"
+        original = [f"{key}={old_value}"] if inline else [key, old_value]
+        original += ["--port", "8000"]
+        item = ParameterSweepItem(
+            {"compilation_config.use_inductor_graph_partition": value}
+        )
+        cmd = item.apply_to_cmd(original)
+        parser = FlexibleArgumentParser()
+        parser.add_argument("--compilation-config", type=json.loads)
+        parser.add_argument("--port", type=int)
+
+        args = parser.parse_args(cmd)
+
+        assert args.compilation_config == {"use_inductor_graph_partition": value}
+        assert args.port == 8000
+        assert len(cmd) == 3
+
+    def test_override_inline_nested_list(self):
+        """The parser must not concatenate stale and swept capture sizes."""
+        original = ["--compilation-config.cudagraph_capture_sizes=[8,16]"]
+        item = ParameterSweepItem(
+            {"compilation_config.cudagraph_capture_sizes": [32, 64]}
+        )
+        parser = FlexibleArgumentParser()
+        parser.add_argument("--compilation-config", type=json.loads)
+
+        args = parser.parse_args(item.apply_to_cmd(original))
+
+        assert args.compilation_config == {"cudagraph_capture_sizes": [32, 64]}
+
+    @pytest.mark.parametrize(
+        "original",
+        [
+            ["--max-tokens", "100", "--max-tokens", "200"],
+            ["--max_tokens=100", "--max-tokens", "200"],
+            ["--max-tokens", "100", "--max_tokens=200"],
+        ],
+    )
+    def test_override_all_occurrences(self, original):
+        """A later base-command value must not defeat the sweep value."""
+        cmd = ParameterSweepItem({"max_tokens": 300}).apply_to_cmd(original)
+        parser = FlexibleArgumentParser()
+        parser.add_argument("--max-tokens", type=int)
+
+        assert parser.parse_args(cmd).max_tokens == 300
+        assert cmd == ["--max-tokens", "300"]
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_override_both_boolean_polarities(self, value):
+        """Positive and negative flags refer to the same sweep parameter."""
+        original = ["--enable-prefix-caching", "--no-enable-prefix-caching"]
+        cmd = ParameterSweepItem({"enable_prefix_caching": value}).apply_to_cmd(
+            original
+        )
+        parser = FlexibleArgumentParser()
+        parser.add_argument("--enable-prefix-caching", action=BooleanOptionalAction)
+
+        assert parser.parse_args(cmd).enable_prefix_caching is value
+        assert len(cmd) == 1
 
     @pytest.mark.parametrize(
         "input_dict,expected",

--- a/vllm/benchmarks/sweep/param_sweep.py
+++ b/vllm/benchmarks/sweep/param_sweep.py
@@ -131,26 +131,31 @@ class ParameterSweepItem(dict[str, object]):
             if isinstance(v, dict):
                 v = json.dumps(v)
 
-            for k_candidate in self._iter_cmd_key_candidates(k):
-                try:
-                    k_idx = cmd.index(k_candidate)
+            candidates = set(self._iter_cmd_key_candidates(k))
+            is_flag = isinstance(v, bool) and "." not in k
+            if is_flag:
+                candidates.update(self._iter_cmd_key_candidates("no-" + k))
 
-                    # Replace existing parameter
-                    normalized = self._normalize_cmd_kv_pair(k, v)
-                    if len(normalized) == 1:
-                        # Boolean flag
-                        cmd[k_idx] = normalized[0]
-                    else:
-                        # Key-value pair
-                        cmd[k_idx] = normalized[0]
-                        cmd[k_idx + 1] = normalized[1]
-
-                    break
-                except ValueError:
+            normalized = self._normalize_cmd_kv_pair(k, v)
+            updated_cmd: list[str] = []
+            replaced = False
+            args = iter(cmd)
+            for arg in args:
+                key, separator, _ = arg.partition("=")
+                if key not in candidates:
+                    updated_cmd.append(arg)
                     continue
-            else:
-                # Add new parameter
-                cmd.extend(self._normalize_cmd_kv_pair(k, v))
+
+                # Dotted booleans consume a value, unlike top-level flags.
+                if not separator and not is_flag:
+                    next(args)
+                if not replaced:
+                    updated_cmd.extend(normalized)
+                    replaced = True
+
+            if not replaced:
+                updated_cmd.extend(normalized)
+            cmd = updated_cmd
 
         return cmd
 


### PR DESCRIPTION
## Purpose

Fix benchmark sweep overrides that leave stray boolean values, concatenate stale nested lists, or allow later options to override sweep settings. Replace all matching option forms with one normalized value.

No overlapping open PR. Merged #29025 added nested-value serialization but did not fix replacement handling.

## Test Plan

```sh
.venv/bin/python -m pytest --confcutdir=tests/benchmarks/sweep tests/benchmarks/sweep/test_param_sweep.py -q
.venv/bin/pre-commit run --files docs/benchmarking/sweeps.md vllm/benchmarks/sweep/param_sweep.py tests/benchmarks/sweep/test_param_sweep.py
.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files vllm/benchmarks/sweep/param_sweep.py tests/benchmarks/sweep/test_param_sweep.py
```

## Test Result

Same suite: 14 failed, 23 passed before; 37 passed after. Pre-commit and Python 3.12 mypy passed.

Validated command generation and parsing on macOS/Python 3.12. No model/GPU evaluation or upstream CI was run; model execution code is unchanged.

AI assistance was used.