### PR TITLE
[Bugfix] Fix V1 GDN state recovery across mixed speculative batches

### DIFF
--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -392,3 +392,43 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("accepted", [1, 2, 3, 6])
+@pytest.mark.parametrize("seqlen", [1, 2, 8, 17])
+@pytest.mark.parametrize("dim_first", [False, True])
+def test_causal_conv1d_prefill_restores_accepted_window(accepted, seqlen, dim_first):
+    set_random_seed(123)
+    dim, width, slots = 64, 4, 9
+    shape = (4, dim, slots) if dim_first else (4, slots, dim)
+    cache = torch.randn(shape, device=DEVICE, dtype=torch.bfloat16)
+    if not dim_first:
+        cache = cache.transpose(1, 2)
+    original = cache.clone()
+    x = torch.randn(dim, seqlen, device=DEVICE, dtype=torch.bfloat16)
+    weight = torch.randn(dim, width, device=DEVICE, dtype=torch.bfloat16)
+    bias = torch.randn(dim, device=DEVICE, dtype=torch.bfloat16)
+    offset = accepted - 1
+    initial = original[2, :, offset : offset + width - 1].unsqueeze(0)
+    expected, final = causal_conv1d_ref(
+        x.unsqueeze(0),
+        weight,
+        bias,
+        initial_states=initial,
+        return_final_states=True,
+    )
+    actual = causal_conv1d_fn(
+        x,
+        weight,
+        bias,
+        conv_states=cache,
+        has_initial_state=torch.tensor([True], device=DEVICE),
+        cache_indices=torch.tensor([2], dtype=torch.int32, device=DEVICE),
+        query_start_loc=torch.tensor([0, seqlen], dtype=torch.int32, device=DEVICE),
+        num_accepted_tokens=torch.tensor([accepted], dtype=torch.int32, device=DEVICE),
+    )
+    torch.testing.assert_close(actual, expected.squeeze(0), rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(
+        cache[2, :, : width - 1], final.squeeze(0), rtol=0, atol=0
+    )
+    torch.testing.assert_close(cache[[0, 1, 3]], original[[0, 1, 3]], rtol=0, atol=0)

--- a/tests/kernels/mamba/test_gdn_spec_state_restore.py
+++ b/tests/kernels/mamba/test_gdn_spec_state_restore.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import dataclasses
+import types
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import SpeculativeConfig, set_current_vllm_config
+from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateShapeCalculator,
+    is_conv_state_dim_first,
+)
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.kv_cache_interface import MambaSpec
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="CUDA GDN state-restoration test"
+)
+
+
+@pytest.mark.parametrize("accepted", [1, 3])
+@pytest.mark.parametrize("mode", ["decode", "packed_decode", "mixed"])
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+def test_forward_core_restores_spec_state(accepted, mode, state_dtype):
+    torch.manual_seed(7)
+    device = torch.device("cuda")
+    cfg = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B",
+        block_size=16,
+        hf_config_override={"linear_key_head_dim": 128},
+    )
+    cfg.additional_config = {"gdn_prefill_backend": "triton"}
+    cfg.cache_config.mamba_cache_mode = "none"
+    cfg.speculative_config = SpeculativeConfig(method="ngram", num_speculative_tokens=2)
+    mixed = mode == "mixed"
+    query_lens = [1, 1, 3] if mixed else [1, 1]
+    counts = [accepted, 1, 2] if mixed else [accepted, 1]
+    drafts = [-1, -1, 2] if mixed else None
+    batch = BatchSpec(seq_lens=[65] * len(query_lens), query_lens=query_lens)
+    common = create_common_attn_metadata(batch, 16, device, arange_block_indices=True)
+    common.block_table_tensor.add_(1)
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=16, shapes=((16, 64),), dtypes=(torch.float16,)
+        ),
+        layer_names=["gdn"],
+        vllm_config=cfg,
+        device=device,
+    )
+    with set_current_vllm_config(cfg):
+        meta = builder.build(
+            common_prefix_len=0,
+            common_attn_metadata=common,
+            num_accepted_tokens=torch.tensor(counts, dtype=torch.int32, device=device),
+            num_decode_draft_tokens_cpu=(
+                torch.tensor(drafts, dtype=torch.int32) if drafts is not None else None
+            ),
+        )
+    h, hv, k, v = 4, 8, 128, 128
+    conv_dim = 2 * h * k + hv * v
+    conv_shape, ssm_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
+        1, h, hv, k, v, 4, num_spec=2
+    )
+    pool_size = int(common.block_table_tensor.max().item()) + 1
+    conv = (
+        torch.randn(pool_size, *conv_shape, device=device, dtype=torch.bfloat16) * 0.05
+    )
+    ssm = torch.randn(pool_size, *ssm_shape, device=device, dtype=state_dtype) * 0.05
+    conv_ref, ssm_ref = conv.clone(), ssm.clone()
+    destination = meta.non_spec_state_indices_tensor[:2]
+    source = (
+        common.block_table_tensor[:2, :]
+        .gather(1, torch.tensor([[accepted - 1], [0]], device=device))
+        .squeeze(1)
+    )
+    ssm_ref[destination] = ssm[source]
+    conv_view = conv if is_conv_state_dim_first() else conv.transpose(-1, -2)
+    ref_view = conv_ref if is_conv_state_dim_first() else conv_ref.transpose(-1, -2)
+    for i, count in enumerate([accepted, 1]):
+        ref_view[destination[i], :, :3] = conv_view[
+            destination[i], :, count - 1 : count + 2
+        ]
+    meta_ref = dataclasses.replace(
+        meta,
+        spec_decode_src_indices=None,
+        non_spec_num_accepted=torch.ones(2, device=device, dtype=torch.int32)
+        if mixed
+        else None,
+        num_accepted_tokens=meta.num_accepted_tokens if mixed else None,
+    )
+    weight = torch.randn(conv_dim, 1, 4, device=device, dtype=torch.bfloat16) * 0.1
+    bias = torch.randn(conv_dim, device=device, dtype=torch.bfloat16) * 0.1
+    a_log = torch.randn(hv, device=device) * 0.1
+    dt_bias = torch.randn(hv, device=device) * 0.1
+    tokens = sum(query_lens)
+    qkv = torch.randn(tokens, conv_dim, device=device, dtype=torch.bfloat16) * 0.1
+    a = torch.randn(tokens, hv, device=device, dtype=torch.bfloat16) * 0.1
+    b = torch.randn_like(a)
+    outputs = []
+    for conv_pool, ssm_pool, metadata in [
+        (conv, ssm, meta),
+        (conv_ref, ssm_ref, meta_ref),
+    ]:
+        layer = types.SimpleNamespace(
+            prefix="gdn",
+            enable_packed_recurrent_decode=mode == "packed_decode",
+            tp_size=1,
+            num_k_heads=h,
+            num_v_heads=hv,
+            head_k_dim=k,
+            head_v_dim=v,
+            key_dim=h * k,
+            value_dim=hv * v,
+            activation="silu",
+            A_log=a_log,
+            dt_bias=dt_bias,
+            conv1d=types.SimpleNamespace(weight=weight, bias=bias),
+            kv_cache=(conv_pool, ssm_pool),
+        )
+        with set_current_vllm_config(cfg):
+            layer.chunk_gated_delta_rule = gdn.ChunkGatedDeltaRule()
+        for name in (
+            "rearrange_mixed_qkv",
+            "_forward_core",
+            "_forward_core_decode_non_spec",
+        ):
+            setattr(
+                layer,
+                name,
+                types.MethodType(getattr(gdn.QwenGatedDeltaNetAttention, name), layer),
+            )
+        out = torch.zeros(tokens, hv, v, device=device, dtype=torch.bfloat16)
+        ctx = types.SimpleNamespace(attn_metadata={"gdn": metadata})
+        with patch.object(gdn, "get_forward_context", return_value=ctx):
+            layer._forward_core(qkv.clone(), b.clone(), a.clone(), out)
+        outputs.append(out)
+    torch.testing.assert_close(outputs[0], outputs[1], rtol=1e-2, atol=1e-3)
+    torch.testing.assert_close(ssm, ssm_ref, rtol=1e-2, atol=1e-3)
+    torch.testing.assert_close(
+        conv_view[destination, :, :3], ref_view[destination, :, :3], rtol=0, atol=0
+    )

--- a/tests/kernels/mamba/test_gdn_spec_state_restore.py
+++ b/tests/kernels/mamba/test_gdn_spec_state_restore.py
@@ -3,7 +3,7 @@
 
 import dataclasses
 import types
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -20,14 +20,141 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     is_conv_state_dim_first,
 )
 from vllm.platforms import current_platform
-from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionMetadata,
+    GDNAttentionMetadataBuilder,
+)
 from vllm.v1.kv_cache_interface import MambaSpec
 
-pytestmark = pytest.mark.skipif(
+
+@pytest.mark.parametrize("recover_state", [False, True])
+@pytest.mark.parametrize("interleaved", [False, True])
+def test_rocm_decode_routes_state_recovery(recover_state, interleaved):
+    """AITER decode must not bypass recovery after a speculative step."""
+    metadata = GDNAttentionMetadata(
+        num_prefills=0,
+        num_prefill_tokens=0,
+        num_decodes=2,
+        num_decode_tokens=2,
+        num_spec_decodes=0,
+        num_spec_decode_tokens=0,
+        num_actual_tokens=2,
+        spec_decode_src_indices=torch.tensor([3, 5]) if recover_state else None,
+        num_accepted_tokens=torch.tensor([3, 1]) if recover_state else None,
+    )
+    qkvz = torch.randn(2, 8)
+    ba = torch.randn(2, 2)
+    qkv, z, b, a = torch.randn(2, 6), torch.randn(2, 2), ba[:, :1], ba[:, 1:]
+    z_out = torch.empty_like(z)
+    out = torch.ones(2, 1, 2)
+    layer = types.SimpleNamespace(
+        prefix="gdn",
+        gqa_interleaved_layout=interleaved,
+        _forward_core_decode_aiter=Mock(),
+        prepare_gdn_attention_core_inputs=Mock(return_value=(qkv, z, b, a)),
+        _forward_core=Mock(),
+    )
+    context = types.SimpleNamespace(attn_metadata={"gdn": metadata})
+    with patch.object(gdn, "get_forward_context", return_value=context):
+        gdn.QwenGatedDeltaNetAttention._forward_core_rocm(layer, qkvz, ba, z_out, out)
+    if interleaved and not recover_state:
+        layer._forward_core_decode_aiter.assert_called_once_with(
+            qkvz=qkvz,
+            ba=ba,
+            z_out=z_out,
+            core_attn_out=out,
+            attn_metadata=metadata,
+        )
+        layer.prepare_gdn_attention_core_inputs.assert_not_called()
+        layer._forward_core.assert_not_called()
+    else:
+        layer._forward_core_decode_aiter.assert_not_called()
+        layer.prepare_gdn_attention_core_inputs.assert_called_once_with(qkvz, ba, 2)
+        layer._forward_core.assert_called_once_with(
+            mixed_qkv=qkv, b=b, a=a, core_attn_out=out
+        )
+        torch.testing.assert_close(z_out, z)
+        assert torch.count_nonzero(out) == 0
+
+
+@pytest.mark.parametrize("accepted", [1, 3])
+@pytest.mark.parametrize("dim_first", [False, True])
+def test_rocm_decode_preserves_recovery_inputs(accepted, dim_first):
+    """Execute recovery on CPU while mocking only preprocessing and kernels."""
+    destination = torch.tensor([1, 4])
+    source = torch.tensor([accepted, 4])
+    counts = torch.tensor([accepted, 1], dtype=torch.int32)
+    metadata = GDNAttentionMetadata(
+        num_prefills=0,
+        num_prefill_tokens=0,
+        num_decodes=2,
+        num_decode_tokens=2,
+        num_spec_decodes=0,
+        num_spec_decode_tokens=0,
+        num_actual_tokens=2,
+        non_spec_state_indices_tensor=destination,
+        spec_decode_src_indices=source,
+        num_accepted_tokens=counts,
+    )
+    ssm = torch.arange(6 * 4, dtype=torch.float32).reshape(6, 1, 2, 2)
+    expected = ssm.clone()
+    expected[destination] = ssm[source]
+    conv = torch.zeros(6, 6, 5) if dim_first else torch.zeros(6, 5, 6)
+    qkv = torch.ones(2, 6)
+    a, b = torch.zeros(2, 1), torch.zeros(2, 1)
+    z = torch.ones(2, 1, 2)
+    layer = types.SimpleNamespace(
+        prefix="gdn",
+        gqa_interleaved_layout=True,
+        enable_packed_recurrent_decode=True,
+        kv_cache=(conv, ssm),
+        head_k_dim=2,
+        activation="silu",
+        A_log=torch.zeros(1),
+        dt_bias=torch.zeros(1),
+        conv1d=types.SimpleNamespace(weight=torch.ones(6, 1, 4), bias=None),
+        prepare_gdn_attention_core_inputs=Mock(return_value=(qkv, z, b, a)),
+        _forward_core_decode_aiter=Mock(),
+    )
+    for name in ("_forward_core", "_forward_core_decode_non_spec"):
+        setattr(
+            layer,
+            name,
+            types.MethodType(getattr(gdn.QwenGatedDeltaNetAttention, name), layer),
+        )
+    context = types.SimpleNamespace(attn_metadata={"gdn": metadata})
+    with (
+        patch.object(gdn, "get_forward_context", return_value=context),
+        patch.object(gdn, "is_conv_state_dim_first", return_value=dim_first),
+        patch.object(gdn, "causal_conv1d_update", return_value=qkv) as conv_update,
+        patch.object(
+            gdn, "fused_recurrent_gated_delta_rule_packed_decode"
+        ) as recurrent,
+    ):
+        gdn.QwenGatedDeltaNetAttention._forward_core_rocm(
+            layer,
+            torch.zeros(2, 8),
+            torch.zeros(2, 2),
+            torch.empty_like(z),
+            torch.zeros_like(z),
+        )
+    layer._forward_core_decode_aiter.assert_not_called()
+    conv_update.assert_called_once()
+    recurrent.assert_called_once()
+    assert conv_update.call_args.kwargs["num_accepted_tokens"] is counts
+    torch.testing.assert_close(
+        conv_update.call_args.kwargs["conv_state_indices"], destination
+    )
+    torch.testing.assert_close(
+        conv_update.call_args.args[1], conv if dim_first else conv.transpose(-1, -2)
+    )
+    assert recurrent.call_args.kwargs["initial_state"] is ssm
+    torch.testing.assert_close(ssm, expected)
+
+
+@pytest.mark.skipif(
     not current_platform.is_cuda(), reason="CUDA GDN state-restoration test"
 )
-
-
 @pytest.mark.parametrize("accepted", [1, 3])
 @pytest.mark.parametrize("mode", ["decode", "packed_decode", "mixed"])
 @pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -241,3 +241,30 @@ def test_regular_decode_restores_previous_spec_state():
     ]
     assert meta.num_accepted_tokens is not None
     assert meta.num_accepted_tokens.tolist() == [3]
+
+
+def test_mixed_batch_restores_non_spec_state():
+    builder = _create_gdn_builder(num_speculative_tokens=2)
+    builder.vllm_config.cache_config.mamba_cache_mode = "none"
+    batch = BatchSpec(seq_lens=[65, 20], query_lens=[1, 3])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
+
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.tensor([3, 2], dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor([-1, 2], dtype=torch.int32),
+    )
+
+    assert meta.non_spec_state_indices_tensor is not None
+    assert meta.non_spec_state_indices_tensor.tolist() == [
+        common.block_table_tensor[0, 0].item()
+    ]
+    assert meta.spec_decode_src_indices is not None
+    assert meta.spec_decode_src_indices.tolist() == [
+        common.block_table_tensor[0, 2].item()
+    ]
+    assert meta.non_spec_num_accepted is not None
+    assert meta.non_spec_num_accepted.tolist() == [3]
+    assert meta.num_accepted_tokens is not None
+    assert meta.num_accepted_tokens.tolist() == [2]

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -223,6 +223,36 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
     assert meta.num_accepted_tokens.shape == (batch.batch_size,)
 
 
+@pytest.mark.parametrize("num_decodes,batch_size", [(1, 4), (3, 8), (4, 4)])
+def test_full_cudagraph_regular_decode_accepted_counts(num_decodes, batch_size):
+    """Zero-token graph padding remains request-aligned in regular decode."""
+    builder = _create_gdn_builder(num_speculative_tokens=2, full_cuda_graph=True)
+    builder.vllm_config.cache_config.mamba_cache_mode = "none"
+    batch = BatchSpec(
+        seq_lens=[65] * num_decodes + [0] * (batch_size - num_decodes),
+        query_lens=[1] * num_decodes + [0] * (batch_size - num_decodes),
+    )
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
+    common.num_actual_tokens = batch_size
+    common.block_table_tensor[num_decodes:].zero_()
+    counts = torch.ones(batch_size, dtype=torch.int32, device=DEVICE)
+    counts[:num_decodes] = 3
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=counts,
+    )
+    assert meta.num_decodes == batch_size
+    assert meta.num_accepted_tokens.shape == meta.non_spec_state_indices_tensor.shape
+    torch.testing.assert_close(meta.num_accepted_tokens, counts)
+    assert meta.num_accepted_tokens[num_decodes:].tolist() == [1] * (
+        batch_size - num_decodes
+    )
+    assert meta.spec_decode_src_indices[num_decodes:].tolist() == [0] * (
+        batch_size - num_decodes
+    )
+
+
 def test_regular_decode_restores_previous_spec_state():
     builder = _create_gdn_builder(num_speculative_tokens=2)
     builder.vllm_config.cache_config.mamba_cache_mode = "none"

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -268,3 +268,24 @@ def test_mixed_batch_restores_non_spec_state():
     assert meta.non_spec_num_accepted.tolist() == [3]
     assert meta.num_accepted_tokens is not None
     assert meta.num_accepted_tokens.tolist() == [2]
+
+
+@pytest.mark.parametrize("accepted", [1, 2, 3])
+@pytest.mark.parametrize("spec_first", [False, True])
+def test_mixed_batch_keeps_independent_accepted_counts(accepted, spec_first):
+    builder = _create_gdn_builder(num_speculative_tokens=2)
+    builder.vllm_config.cache_config.mamba_cache_mode = "none"
+    query_lens = [3, 1, 1] if spec_first else [1, 1, 3]
+    drafts = [2, -1, -1] if spec_first else [-1, -1, 2]
+    counts = [3, accepted, 1] if spec_first else [accepted, 1, 3]
+    batch = BatchSpec(seq_lens=[65, 65, 65], query_lens=query_lens)
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.tensor(counts, dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor(drafts, dtype=torch.int32),
+    )
+    assert meta.non_spec_num_accepted is not None
+    assert meta.non_spec_num_accepted.tolist() == [accepted, 1]
+    assert meta.num_accepted_tokens.tolist() == [3]

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -221,3 +221,23 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
     assert meta.spec_query_start_loc.shape == (batch.batch_size + 1,)
     assert meta.num_accepted_tokens is not None
     assert meta.num_accepted_tokens.shape == (batch.batch_size,)
+
+
+def test_regular_decode_restores_previous_spec_state():
+    builder = _create_gdn_builder(num_speculative_tokens=2)
+    builder.vllm_config.cache_config.mamba_cache_mode = "none"
+    batch = BatchSpec(seq_lens=[65], query_lens=[1])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
+
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.tensor([3], dtype=torch.int32),
+    )
+
+    assert meta.spec_decode_src_indices is not None
+    assert meta.spec_decode_src_indices.tolist() == [
+        common.block_table_tensor[0, 2].item()
+    ]
+    assert meta.num_accepted_tokens is not None
+    assert meta.num_accepted_tokens.tolist() == [3]

--- a/tests/v1/worker/test_gdn_accepted_metadata.py
+++ b/tests/v1/worker/test_gdn_accepted_metadata.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
+from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm.v1.worker.ubatch_utils import UBatchSlice
+
+
+@pytest.mark.parametrize(
+    "builder_type", [GDNAttentionMetadataBuilder, Mamba2AttentionMetadataBuilder]
+)
+@pytest.mark.parametrize("use_spec_decode", [False, True])
+@pytest.mark.parametrize("ubatching", [False, True])
+def test_accepted_metadata_rejects_ubatching(builder_type, use_spec_decode, ubatching):
+    """Both speculative and recovery-only paths reject unsliced accepted counts."""
+    builder = Mock(spec=builder_type)
+    builder.supports_update_block_table = False
+    group = SimpleNamespace(
+        get_metadata_builder=Mock(return_value=builder), layer_names=["layer.0"]
+    )
+    spec = MambaSpec(block_size=16, shapes=((16, 64),), dtypes=(torch.float16,))
+    block_table = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int32)
+    query_start = torch.tensor([0, 1, 2], dtype=torch.int32)
+    counts = torch.tensor([3, 1], dtype=torch.int32)
+    runner = SimpleNamespace(
+        kv_cache_config=SimpleNamespace(
+            kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec)]
+        ),
+        optimistic_seq_lens_cpu=torch.tensor([65, 65], dtype=torch.int32),
+        input_batch=SimpleNamespace(
+            block_table=[
+                SimpleNamespace(get_device_tensor=Mock(return_value=block_table))
+            ],
+            num_computed_tokens_cpu_tensor=torch.tensor([64, 64]),
+            num_prompt_tokens_cpu_tensor=torch.tensor([8, 8]),
+        ),
+        routed_experts_initialized=False,
+        use_async_spec_decode=False,
+        is_mm_prefix_lm=False,
+        model_config=SimpleNamespace(rswa_window=None),
+        cache_config=SimpleNamespace(
+            use_replayssm=False, kv_sharing_fast_prefill=False
+        ),
+        query_start_loc=SimpleNamespace(gpu=query_start, cpu=query_start),
+        seq_lens=torch.tensor([65, 65], dtype=torch.int32),
+        positions=torch.tensor([64, 64]),
+        dcp_world_size=1,
+        speculative_config=object(),
+        drafter=None,
+        attn_groups=[[group]],
+        num_accepted_tokens=SimpleNamespace(gpu=counts),
+        num_decode_draft_tokens=SimpleNamespace(cpu=torch.tensor([0, 0])),
+        mamba_prev_last_scheduled_idx=None,
+        _get_encoder_seq_lens=Mock(return_value=(None, None)),
+    )
+    slices = (
+        [UBatchSlice(slice(0, 1), slice(0, 1)), UBatchSlice(slice(1, 2), slice(1, 2))]
+        if ubatching
+        else None
+    )
+    context = (
+        pytest.raises(AssertionError, match="UBatching not supported")
+        if ubatching
+        else nullcontext()
+    )
+    with context:
+        GPUModelRunner._build_attention_metadata(
+            runner,
+            num_tokens=2,
+            num_reqs=2,
+            max_query_len=1,
+            ubatch_slices=slices,
+            use_spec_decode=use_spec_decode,
+            slot_mappings={0: torch.tensor([1, 2])},
+        )
+    if ubatching:
+        builder.build.assert_not_called()
+    else:
+        builder.build.assert_called_once()
+        torch.testing.assert_close(
+            builder.build.call_args.kwargs["num_accepted_tokens"], counts
+        )

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1316,6 +1316,13 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         ssm_state = self_kv_cache[1]
         num_actual_tokens = attn_metadata.num_actual_tokens
         num_accepted_tokens = attn_metadata.num_accepted_tokens
+        spec_decode_src_indices = attn_metadata.spec_decode_src_indices
+
+        if spec_decode_src_indices is not None:
+            assert non_spec_state_indices_tensor is not None
+            num_corrected_states = spec_decode_src_indices.shape[0]
+            destination_indices = non_spec_state_indices_tensor[:num_corrected_states]
+            ssm_state[destination_indices] = ssm_state[spec_decode_src_indices]
 
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         b = b[:num_actual_tokens]
@@ -1364,6 +1371,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if attn_metadata.num_prefills > 0:
             assert mixed_qkv_non_spec is not None
             mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
+            conv_num_accepted = (
+                num_accepted_tokens if spec_decode_src_indices is not None else None
+            )
             # - "cache_indices" updates the conv_state cache in positions
             #   pointed to by "state_indices_tensor"
             mixed_qkv_non_spec = causal_conv1d_fn(
@@ -1375,10 +1385,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 has_initial_state=has_initial_state,
                 cache_indices=non_spec_state_indices_tensor,
                 query_start_loc=non_spec_query_start_loc,
+                num_accepted_tokens=conv_num_accepted,
                 metadata=attn_metadata,
             ).transpose(0, 1)
         elif attn_metadata.num_decodes > 0:
             assert mixed_qkv_non_spec is not None
+            conv_num_accepted = (
+                num_accepted_tokens if spec_decode_src_indices is not None else None
+            )
             mixed_qkv_non_spec = causal_conv1d_update(
                 mixed_qkv_non_spec,
                 conv_state,
@@ -1388,6 +1402,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 conv_state_indices=non_spec_state_indices_tensor[  # type: ignore[index]
                     : attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
                 ],
+                num_accepted_tokens=conv_num_accepted,
                 validate_data=True,
             )
         else:
@@ -1667,6 +1682,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
         ssm_state = self_kv_cache[1]
         num_actual_tokens = attn_metadata.num_actual_tokens
+        num_accepted_tokens = attn_metadata.num_accepted_tokens
+        spec_decode_src_indices = attn_metadata.spec_decode_src_indices
+
+        if spec_decode_src_indices is not None:
+            assert non_spec_state_indices_tensor is not None
+            num_corrected_states = spec_decode_src_indices.shape[0]
+            destination_indices = non_spec_state_indices_tensor[:num_corrected_states]
+            ssm_state[destination_indices] = ssm_state[spec_decode_src_indices]
 
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         b = b[:num_actual_tokens]
@@ -1682,6 +1705,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             self.conv1d.bias,
             self.activation,
             conv_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
+            num_accepted_tokens=num_accepted_tokens,
             validate_data=False,
         )
         out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1372,7 +1372,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             assert mixed_qkv_non_spec is not None
             mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
             conv_num_accepted = (
-                num_accepted_tokens if spec_decode_src_indices is not None else None
+                attn_metadata.non_spec_num_accepted
+                if attn_metadata.non_spec_num_accepted is not None
+                else num_accepted_tokens
             )
             # - "cache_indices" updates the conv_state cache in positions
             #   pointed to by "state_indices_tensor"

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1203,8 +1203,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         qkvz/ba layout.
 
         For decode-only (no spec, no prefill) interleaved-GQA layouts,
-        dispatches directly to ``_forward_core_decode_aiter``. Otherwise unpacks
-        the packed layout and falls through to ``_forward_core``.
+        dispatches directly to ``_forward_core_decode_aiter`` unless recovery
+        from a previous speculative step is required. Otherwise unpacks the
+        packed layout and falls through to ``_forward_core`` for state recovery.
 
         Args:
             qkvz: packed [q, k, v, z] projection (num_tokens, qkvz_dim)
@@ -1232,6 +1233,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if (
             self.gqa_interleaved_layout
             and attn_metadata.spec_sequence_masks is None
+            and attn_metadata.spec_decode_src_indices is None
             and attn_metadata.num_prefills == 0
             and attn_metadata.num_decodes > 0
         ):

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -31,6 +31,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     block_idx_last_scheduled_token,  # (batch,)
     initial_state_idx,  # (batch,)
     num_computed_tokens,  # (batch,)
+    num_accepted_tokens_ptr,  # (batch,) or None
     o_ptr,  # (dim, seqlen) - actually pointing to x_ptr
     # Matrix dimensions
     dim: tl.constexpr,
@@ -55,6 +56,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     KERNEL_WIDTH: tl.constexpr,
     SILU_ACTIVATION: tl.constexpr,
     IS_APC_ENABLED: tl.constexpr,
+    IS_SPEC_DECODING: tl.constexpr,
     HAS_NULL_BLOCK: tl.constexpr,
     NP2_STATELEN: tl.constexpr,
     BLOCK_M: tl.constexpr,
@@ -78,6 +80,13 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
 
     # single-sequence id
     idx_seq = tl.load(batch_ptr + tl.program_id(0)).to(tl.int64)
+
+    if IS_SPEC_DECODING:
+        conv_state_token_offset = (
+            tl.load(num_accepted_tokens_ptr + idx_seq).to(tl.int64) - 1
+        )
+    else:
+        conv_state_token_offset = 0
     chunk_offset = tl.load(token_chunk_offset_ptr + tl.program_id(0))
 
     # BLOCK_N elements along the feature-dimension (channel)
@@ -162,7 +171,10 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         load_init_state = tl.load(has_initial_states_ptr + idx_seq).to(tl.int1)
         if load_init_state:
             # load from conv_states
-            prior_tokens = conv_states_base + (state_len - 1) * stride_conv_state_tok
+            prior_tokens = (
+                conv_states_base
+                + (state_len - 1 + conv_state_token_offset) * stride_conv_state_tok
+            )
             mask_w = idx_feats < dim
             if KERNEL_WIDTH == 2:
                 conv_states_ptrs = prior_tokens  # [BLOCK_N]
@@ -252,7 +264,10 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
                     conv_states_ptr
                     + (conv_states_input_coord * stride_conv_state_seq)
                     + (idx_feats * stride_conv_state_dim)[None, :]
-                    + ((idx_tokens_conv + seqlen) * stride_conv_state_tok)[:, None]
+                    + (
+                        (idx_tokens_conv + seqlen + conv_state_token_offset)
+                        * stride_conv_state_tok
+                    )[:, None]
                 )  # [BLOCK_M, BLOCK_N]
                 mask = (
                     (conv_states_input_coord < num_cache_lines)
@@ -489,6 +504,7 @@ def causal_conv1d_fn(
     activation: str | None = "silu",
     pad_slot_id: int = PAD_SLOT_ID,
     null_block_id: int = NULL_BLOCK_ID,
+    num_accepted_tokens: torch.Tensor | None = None,
     block_idx_first_scheduled_token: torch.Tensor | None = None,
     block_idx_last_scheduled_token: torch.Tensor | None = None,
     initial_state_idx: torch.Tensor | None = None,
@@ -724,6 +740,7 @@ def causal_conv1d_fn(
         block_idx_last_scheduled_token,
         initial_state_idx,
         num_computed_tokens,
+        num_accepted_tokens,
         out,
         # Matrix dimensions
         dim,
@@ -748,6 +765,7 @@ def causal_conv1d_fn(
         KERNEL_WIDTH=width,
         SILU_ACTIVATION=activation in ["silu", "swish"],
         IS_APC_ENABLED=block_idx_last_scheduled_token is not None,
+        IS_SPEC_DECODING=num_accepted_tokens is not None,
         HAS_NULL_BLOCK=null_block_id is not None,
         NP2_STATELEN=np2_statelen,
         # launch_cooperative_grid=True

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -69,6 +69,7 @@ class GDNAttentionMetadata:
     # When set, conv/ssm state must be copied from these blocks to the
     # blocks in non_spec_state_indices_tensor before the decode kernel.
     spec_decode_src_indices: torch.Tensor | None = None
+    non_spec_num_accepted: torch.Tensor | None = None
 
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
@@ -252,6 +253,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 )
 
         spec_decode_src_indices = None
+        non_spec_num_accepted = None
         if spec_sequence_masks is None:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
                 split_decodes_and_prefills(m, decode_threshold=1)
@@ -389,6 +391,28 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     dim=0,
                     out=non_spec_query_start_loc_cpu[1:],
                 )
+
+                assert num_accepted_tokens is not None
+                non_spec_num_accepted = num_accepted_tokens[non_spec_sequence_masks_cpu]
+                if (
+                    self.use_spec_decode
+                    and non_spec_num_accepted.numel() > 0
+                    and (non_spec_num_accepted > 1).any()
+                ):
+                    non_spec_block_rows = block_table_tensor[
+                        non_spec_sequence_masks_cpu
+                    ]
+                    source_columns = (non_spec_num_accepted - 1).clamp(min=0)
+                    spec_decode_src_indices = non_spec_block_rows[
+                        torch.arange(
+                            non_spec_block_rows.size(0),
+                            device=block_table_tensor.device,
+                        ),
+                        source_columns,
+                    ]
+                    non_spec_num_accepted = non_spec_num_accepted.clamp(min=1)
+                else:
+                    non_spec_num_accepted = None
 
             assert num_accepted_tokens is not None
             num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
@@ -545,6 +569,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
             spec_decode_src_indices=spec_decode_src_indices,
+            non_spec_num_accepted=non_spec_num_accepted,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -393,26 +393,18 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 )
 
                 assert num_accepted_tokens is not None
-                non_spec_num_accepted = num_accepted_tokens[non_spec_sequence_masks_cpu]
-                if (
-                    self.use_spec_decode
-                    and non_spec_num_accepted.numel() > 0
-                    and (non_spec_num_accepted > 1).any()
-                ):
-                    non_spec_block_rows = block_table_tensor[
-                        non_spec_sequence_masks_cpu
-                    ]
-                    source_columns = (non_spec_num_accepted - 1).clamp(min=0)
-                    spec_decode_src_indices = non_spec_block_rows[
-                        torch.arange(
-                            non_spec_block_rows.size(0),
-                            device=block_table_tensor.device,
-                        ),
-                        source_columns,
-                    ]
-                    non_spec_num_accepted = non_spec_num_accepted.clamp(min=1)
-                else:
-                    non_spec_num_accepted = None
+                non_spec_num_accepted = num_accepted_tokens[
+                    non_spec_sequence_masks_cpu
+                ].clamp(min=1)
+                non_spec_block_rows = block_table_tensor[non_spec_sequence_masks_cpu]
+                source_columns = non_spec_num_accepted - 1
+                spec_decode_src_indices = non_spec_block_rows[
+                    torch.arange(
+                        non_spec_block_rows.size(0),
+                        device=block_table_tensor.device,
+                    ),
+                    source_columns,
+                ]
 
             assert num_accepted_tokens is not None
             num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -65,6 +65,11 @@ class GDNAttentionMetadata:
 
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
 
+    # 1D source block indices for state recovery after spec decode.
+    # When set, conv/ssm state must be copied from these blocks to the
+    # blocks in non_spec_state_indices_tensor before the decode kernel.
+    spec_decode_src_indices: torch.Tensor | None = None
+
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
@@ -246,6 +251,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     spec_sequence_masks_cpu, device=query_start_loc.device
                 )
 
+        spec_decode_src_indices = None
         if spec_sequence_masks is None:
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
                 split_decodes_and_prefills(m, decode_threshold=1)
@@ -254,11 +260,34 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx = None
             non_spec_token_indx = None
             spec_state_indices_tensor = None
-            non_spec_state_indices_tensor = block_table_tensor[:, 0]
             spec_query_start_loc = None
             non_spec_query_start_loc = query_start_loc
             non_spec_query_start_loc_cpu = query_start_loc_cpu
-            num_accepted_tokens = None
+            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            if (
+                self.use_spec_decode
+                and num_accepted_tokens is not None
+                and num_decodes > 0
+            ):
+                col_indices = (num_accepted_tokens[:num_decodes] - 1).clamp(min=0)
+                spec_decode_src_indices = block_table_tensor[
+                    torch.arange(num_decodes, device=block_table_tensor.device),
+                    col_indices,
+                ]
+                num_accepted_tokens = num_accepted_tokens[:num_decodes]
+                if num_prefills > 0:
+                    num_accepted_tokens = torch.cat(
+                        [
+                            num_accepted_tokens,
+                            torch.ones(
+                                num_prefills,
+                                dtype=num_accepted_tokens.dtype,
+                                device=num_accepted_tokens.device,
+                            ),
+                        ]
+                    )
+            else:
+                num_accepted_tokens = None
         else:
             query_lens = query_start_loc[1:] - query_start_loc[:-1]
             assert spec_sequence_masks_cpu is not None
@@ -515,6 +544,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            spec_decode_src_indices=spec_decode_src_indices,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2583,6 +2583,13 @@ class GPUModelRunner(
                     extra_attn_metadata_args["prev_last_scheduled_idx"] = (
                         self.mamba_prev_last_scheduled_idx.gpu[:num_reqs_padded]
                     )
+            elif self.speculative_config is not None and isinstance(
+                builder,
+                (Mamba2AttentionMetadataBuilder, GDNAttentionMetadataBuilder),
+            ):
+                extra_attn_metadata_args = dict(
+                    num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
+                )
 
             if for_cudagraph_capture:
                 attn_metadata_i = builder.build_for_cudagraph_capture(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2587,6 +2587,9 @@ class GPUModelRunner(
                 builder,
                 (Mamba2AttentionMetadataBuilder, GDNAttentionMetadataBuilder),
             ):
+                assert ubid is None, (
+                    "UBatching not supported with GDN or linear attn yet"
+                )
                 extra_attn_metadata_args = dict(
                     num_accepted_tokens=self.num_accepted_tokens.gpu[:num_reqs_padded],
                 )


### PR DESCRIPTION
## Purpose

Fix GDN accepted-state recovery in the V1 model runner when a request transitions from speculative decoding to a regular decode, including batches containing both kinds of requests.

This builds on #40738 and the mixed-batch follow-up by @bhaktatejas922 (`04e09d548739c628b4fe7f66820ac592097074c6`). Their attribution is preserved. This is prepared as a successor, not claimed as an independently invented replacement.

In addition to rebasing those changes, this fixes a remaining partition bug: when every non-speculative request has an accepted-token count of 1, the previous combined implementation discarded the non-speculative counts. The convolution caller then fell back to the counts from the speculative partition. That can provide both the wrong offsets and the wrong number of entries.

The fix keeps the partitions independent even when all non-speculative counts equal 1. It also removes the GPU-value-dependent Python branch used to decide whether to preserve those counts.

The scope is V1 GDN conv/SSM restoration with `mamba_cache_mode=none`. This does not claim to fix every speculative-decoding output difference or to modify the V2 runner.

I utilized AI tools to assist in refining the implementation, executing tests, and analyzing logs.

## Test Plan

- Reproduce the all-one-count partition failure in both request orderings.
- Run the GDN metadata suite and the causal convolution suite.
- Compare CUDA convolution outputs and final history against the PyTorch reference across accepted offsets, sequence lengths, and both cache layouts.
- Call the real GDN forward and compare with manually restored conv/SSM state: ordinary decode, packed decode, and mixed batches; FP32/BF16 SSM states.
- Run Qwen3.5-0.8B plain/ngram decoding at BS1 and BS8.
- Inspect top-5 logprobs at the first residual output divergence.
- Run Ruff and whitespace checks.

## Test Result

- Before the additional fix: 2 new boundary cases failed, 4 passed.
- Metadata and convolution suites: **213 passed**.
- Real GDN forward / state restoration: **12 passed**.
- Ruff check, Ruff format, and `git diff --check`: passed.

Commands from the source checkout in the isolated runtime:

```bash
PYTHONPATH="$PWD" CUDA_VISIBLE_DEVICES=2 ../.venv-main/bin/python -c 'import torch, pytest; torch.backends.cudnn.enabled=False; raise SystemExit(pytest.main(["tests/v1/attention/test_gdn_metadata_builder.py", "tests/kernels/mamba/test_causal_conv1d.py", "-q"]))'
PYTHONPATH="$PWD" CUDA_VISIBLE_DEVICES=3 ../.venv-main/bin/python -m pytest tests/kernels/mamba/test_gdn_spec_state_restore.py -q
```

cuDNN was disabled only for the reference-convolution test process because the local PyTorch reference path segfaulted inside cuDNN. The tested Triton implementation was unchanged by that setting.

Model check: Qwen3.5-0.8B revision `2fc06364715b967f1860aea9cf38778875588b17`, BF16 greedy, seed 2026, TP1, eager, 8 prompts, ngram 5, lookup 2–10, prefill budget 64, 256 max output tokens, prefix caching off.

| Exact plain/ngram token-sequence agreement | Unpatched main | Previous combined patch | This fix |
|---|---:|---:|---:|
| BS1 | 1/8 | 7/8 | 7/8 |
| BS8 | 1/8 | 3/8 | 5/8 |

The two additional speculative-only divergences disappear. The remaining BS8 differences affect the same three requests that also diverge between plain BS1 and BS8. At each first divergent position, the selected tokens are each other's top-2; one execution has an exact tie, while the other has a 0.125 logprob margin. This supports a numerical-ranking explanation but is not a claim of universal token parity.

Environment: main source `f4eccdadefc6501fafeb1a0bf7f171ff24f984b0` plus this change, CUDA SM90, PyTorch 2.13.0+cu129, explicit `VLLM_USE_V2_MODEL_RUNNER=0`, native sampler. Existing official prebuilt extensions were reused; the modified Triton kernels were compiled from this source. Newly rebuilt fused GDN kernels and the V2 runner were not validated by these runs.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

