### PR TITLE
[Quantization] Expose input quantization scales through linear kernel contract

### DIFF
--- a/tests/compile/passes/test_silu_mul_quant_manual_fusion.py
+++ b/tests/compile/passes/test_silu_mul_quant_manual_fusion.py
@@ -32,6 +32,7 @@ from vllm.model_executor.layers.fusion.fused_act_quant import (
     maybe_fused_act_quant,
 )
 from vllm.model_executor.layers.fusion.quant_activation import (
+    InputQuantScales,
     QuantizedActivation,
     expose_input_quant_key,
 )
@@ -62,6 +63,11 @@ class MockLinearForFusion(torch.nn.Module):
             self.input_global_scale = input_global_scale
         if input_global_scale_inv is not None:
             self.input_global_scale_inv = input_global_scale_inv
+
+        self._input_quant_scales = lambda layer: InputQuantScales(
+            static_scale=getattr(layer, "input_scale", None),
+            global_scale_inv=getattr(layer, "input_global_scale_inv", None),
+        )
 
 
 ROCM_KERNELS = [ROCmFP8ScaledMMLinearKernel, PerTensorTorchFP8ScaledMMLinearKernel]
@@ -214,10 +220,14 @@ def test_manual_fusion_fp8_dynamic_128(dtype: torch.dtype):
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+<<<<<<< HEAD
 # Cover M < 128 (padded swizzled SF tiles) and hidden_size that makes the
 # kernel launch grid.y > 1 (num_packed_cols = hidden_size / 16 > 512).
 @pytest.mark.parametrize("num_tokens", [1, 127, 128])
 @pytest.mark.parametrize("hidden_size", [256, 14336])
+=======
+@pytest.mark.parametrize("global_scale_value", [0.01, 2.0])
+>>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="NVFP4 CUDA only")
 @pytest.mark.skipif(
     not current_platform.has_device_capability(100), reason="NVFP4 requires SM100+"
@@ -225,9 +235,13 @@ def test_manual_fusion_fp8_dynamic_128(dtype: torch.dtype):
 @pytest.mark.skipif(
     envs.VLLM_TARGET_DEVICE not in ["cuda", "rocm"], reason="Only test on CUDA and ROCm"
 )
+<<<<<<< HEAD
 def test_manual_fusion_nvfp4_dynamic(
     dtype: torch.dtype, num_tokens: int, hidden_size: int
 ):
+=======
+def test_manual_fusion_nvfp4_dynamic(dtype: torch.dtype, global_scale_value: float):
+>>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
     """Test kNvfp4Dynamic fusion path.
 
     Compares fused (silu_and_mul_nvfp4_quant) vs unfused (silu_and_mul)
@@ -243,11 +257,17 @@ def test_manual_fusion_nvfp4_dynamic(
 
     # NVFP4 requires hidden_size divisible by 16 (block size) and by 2 (packing).
     x = torch.rand(num_tokens, hidden_size * 2)
+<<<<<<< HEAD
     # Non-1.0 global scale so the test is sensitive to the scale direction:
     # the fused producer must quantize with input_global_scale_inv (the GEMM's
     # alpha divides by input_global_scale), matching the unfused path.
     input_global_scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
     input_global_scale_inv = 1.0 / input_global_scale
+=======
+    input_global_scale = torch.tensor(
+        [global_scale_value], dtype=torch.float32, device="cuda"
+    )
+>>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
 
     config = VllmConfig(
         compilation_config=CompilationConfig(custom_ops=["none"]),
@@ -295,7 +315,11 @@ def test_manual_fusion_nvfp4_dynamic(
         dequant_result = dequantize_nvfp4_to_dtype(
             tensor_fp4=result_fused.data,
             tensor_sf=result_fused.scale,
+<<<<<<< HEAD
             global_scale=input_global_scale_inv,
+=======
+            global_scale=mock_linear_with_key.input_global_scale_inv,
+>>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
             dtype=dtype,
             device="cuda",
             block_size=16,

--- a/tests/compile/passes/test_silu_mul_quant_manual_fusion.py
+++ b/tests/compile/passes/test_silu_mul_quant_manual_fusion.py
@@ -220,14 +220,11 @@ def test_manual_fusion_fp8_dynamic_128(dtype: torch.dtype):
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-<<<<<<< HEAD
 # Cover M < 128 (padded swizzled SF tiles) and hidden_size that makes the
 # kernel launch grid.y > 1 (num_packed_cols = hidden_size / 16 > 512).
 @pytest.mark.parametrize("num_tokens", [1, 127, 128])
 @pytest.mark.parametrize("hidden_size", [256, 14336])
-=======
 @pytest.mark.parametrize("global_scale_value", [0.01, 2.0])
->>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="NVFP4 CUDA only")
 @pytest.mark.skipif(
     not current_platform.has_device_capability(100), reason="NVFP4 requires SM100+"
@@ -235,13 +232,9 @@ def test_manual_fusion_fp8_dynamic_128(dtype: torch.dtype):
 @pytest.mark.skipif(
     envs.VLLM_TARGET_DEVICE not in ["cuda", "rocm"], reason="Only test on CUDA and ROCm"
 )
-<<<<<<< HEAD
 def test_manual_fusion_nvfp4_dynamic(
-    dtype: torch.dtype, num_tokens: int, hidden_size: int
+    dtype: torch.dtype, num_tokens: int, hidden_size: int, global_scale_value: float
 ):
-=======
-def test_manual_fusion_nvfp4_dynamic(dtype: torch.dtype, global_scale_value: float):
->>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
     """Test kNvfp4Dynamic fusion path.
 
     Compares fused (silu_and_mul_nvfp4_quant) vs unfused (silu_and_mul)
@@ -257,17 +250,13 @@ def test_manual_fusion_nvfp4_dynamic(dtype: torch.dtype, global_scale_value: flo
 
     # NVFP4 requires hidden_size divisible by 16 (block size) and by 2 (packing).
     x = torch.rand(num_tokens, hidden_size * 2)
-<<<<<<< HEAD
     # Non-1.0 global scale so the test is sensitive to the scale direction:
     # the fused producer must quantize with input_global_scale_inv (the GEMM's
     # alpha divides by input_global_scale), matching the unfused path.
-    input_global_scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
-    input_global_scale_inv = 1.0 / input_global_scale
-=======
     input_global_scale = torch.tensor(
         [global_scale_value], dtype=torch.float32, device="cuda"
     )
->>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
+    input_global_scale_inv = 1.0 / input_global_scale
 
     config = VllmConfig(
         compilation_config=CompilationConfig(custom_ops=["none"]),
@@ -315,11 +304,7 @@ def test_manual_fusion_nvfp4_dynamic(dtype: torch.dtype, global_scale_value: flo
         dequant_result = dequantize_nvfp4_to_dtype(
             tensor_fp4=result_fused.data,
             tensor_sf=result_fused.scale,
-<<<<<<< HEAD
             global_scale=input_global_scale_inv,
-=======
-            global_scale=mock_linear_with_key.input_global_scale_inv,
->>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
             dtype=dtype,
             device="cuda",
             block_size=16,

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.fusion.quant_activation import (
     QuantizedActivation,
     as_quantized_activation,
     expose_input_quant_key,
+    get_input_quant_scales,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
@@ -133,3 +134,50 @@ def test_as_quantized_activation_validates_key():
         as_quantized_activation(qa, None)
     assert as_quantized_activation(torch.zeros(2, 4), kFp8StaticTensorSym) is None
     assert as_quantized_activation(qa, kFp8StaticTensorSym) is qa
+
+
+@pytest.mark.parametrize("kernel_cls", sorted(SUPPORTING, key=lambda cls: cls.__name__))
+@pytest.mark.parametrize("compiled", [False, True])
+def test_input_quant_scales_follow_parameter_replacement(kernel_cls, compiled):
+    """Resolve consumer scales after loading and replacement, even in a full graph."""
+    kernel = _probe(kernel_cls)
+    nvfp4 = issubclass(kernel_cls, NvFp4LinearKernel)
+    if not nvfp4:
+        kernel.layer_param_names = (
+            "weight",
+            "weight_scale",
+            "activation_scale",
+            "input_scale_ub",
+        )
+
+    layer = torch.nn.Module()
+    # The bridge runs before post-load processing creates the runtime scales.
+    expose_input_quant_key(layer, kernel)
+    scale_name = "input_global_scale_inv" if nvfp4 else "activation_scale"
+    layer.register_parameter(
+        scale_name, torch.nn.Parameter(torch.tensor(4.0), requires_grad=False)
+    )
+
+    def quantize(x):
+        scales = get_input_quant_scales(layer)
+        if nvfp4:
+            return x * scales.global_scale_inv
+        return x / scales.static_scale
+
+    if compiled:
+        quantize = torch.compile(quantize, backend="eager", fullgraph=True)
+
+    x = torch.tensor([2.0])
+    for scale_value in (4.0, 8.0):
+        scale = torch.nn.Parameter(torch.tensor(scale_value), requires_grad=False)
+        setattr(layer, scale_name, scale)
+        scales = get_input_quant_scales(layer)
+        if nvfp4:
+            assert scales.global_scale_inv is scale
+            assert scales.static_scale is None
+            expected = x * scale_value
+        else:
+            assert scales.static_scale is scale
+            assert scales.global_scale_inv is None
+            expected = x / scale_value
+        torch.testing.assert_close(quantize(x), expected)

--- a/tests/kernels/test_fused_quant_activation.py
+++ b/tests/kernels/test_fused_quant_activation.py
@@ -8,7 +8,10 @@ import vllm._custom_ops as ops
 from tests.kernels.utils import opcheck
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fusion.fused_act_quant import maybe_fused_act_quant
-from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.fusion.quant_activation import (
+    InputQuantScales,
+    QuantizedActivation,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
 )
@@ -93,6 +96,9 @@ class MockLinearFp8Static(torch.nn.Module):
         super().__init__()
         self.input_quant_key = kFp8StaticTensorSym
         self.input_scale = input_scale
+        self._input_quant_scales = lambda layer: InputQuantScales(
+            static_scale=layer.input_scale
+        )
 
 
 class MockLinearFp8Dynamic128(torch.nn.Module):

--- a/vllm/model_executor/kernels/linear/nvfp4/base.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/base.py
@@ -38,6 +38,7 @@ class NvFp4LinearKernel(ABC):
     def input_quant_key(self) -> QuantKey | None:
         """Return the input quantization key supported by this kernel. If the kernel
         does not support input quantization outside of the kernel, return None.
+        Kernels that return a key must also implement input_quant_scales.
         """
         return None
 

--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -5,6 +5,7 @@ import torch
 
 from vllm._custom_ops import scaled_fp4_quant
 from vllm.model_executor.layers.fusion.quant_activation import (
+    InputQuantScales,
     QuantizedActivation,
     as_quantized_activation,
 )
@@ -181,6 +182,9 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
         """This kernel supports dynamic quantization of the input. By
         convention, pre-quantized blockscales must use the swizzled layout."""
         return kNvfp4Dynamic
+
+    def input_quant_scales(self, layer: torch.nn.Module) -> InputQuantScales:
+        return InputQuantScales(global_scale_inv=layer.input_global_scale_inv)
 
     @classmethod
     def is_supported(

--- a/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
@@ -9,6 +9,7 @@ from typing import Generic, TypeVar
 import torch
 
 from vllm.model_executor.layers.fusion.quant_activation import (
+    InputQuantScales,
     QuantizedActivation,
     as_quantized_activation,
 )
@@ -82,7 +83,8 @@ class ScaledMMLinearKernel(Generic[_ConfigT, _ParamsT], ABC):
         quantization out of apply_weights into an upstream fused kernel.
         Return None when the kernel needs in-kernel quantization (custom
         padding or swizzling, dynamic scales, etc.). Kernels that return a
-        key must consume the activation via as_quantized_activation.
+        key must consume the activation via as_quantized_activation and
+        expose the scales that key needs via input_quant_scales.
         """
         return None
 
@@ -122,6 +124,11 @@ class FP8ScaledMMLinearKernel(
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         pass
+
+    def input_quant_scales(self, layer: torch.nn.Module) -> InputQuantScales:
+        return InputQuantScales(
+            static_scale=getattr(layer, self.layer_param_names[2], None)
+        )
 
     def _get_layer_params(self, layer) -> _FP8ParamsT:
         w, w_s, x_s, x_s_ub = self.layer_param_names

--- a/vllm/model_executor/layers/fusion/fused_act_quant.py
+++ b/vllm/model_executor/layers/fusion/fused_act_quant.py
@@ -123,17 +123,6 @@ def _silu_and_mul_nvfp4_dynamic(
     # consumer GEMM's alpha (= input_global_scale * weight_global_scale)
     # divides it back out, so quantize with the reciprocal like the unfused
     # scaled_fp4_quant path does.
-    input_global_scale_inv = getattr(linear, "input_global_scale_inv", None)
-    assert input_global_scale_inv is not None, (
-        "input_global_scale_inv is required for NVFP4 quantization"
-    )
-
-<<<<<<< HEAD
-    torch.ops._C.silu_and_mul_nvfp4_quant(
-        result, block_scale, x, input_global_scale_inv
-    )
-
-=======
     global_scale_inv = get_input_quant_scales(linear).global_scale_inv
     assert global_scale_inv is not None, (
         "NVFP4 quantization requires an inverse global scale"
@@ -141,7 +130,6 @@ def _silu_and_mul_nvfp4_dynamic(
 
     torch.ops._C.silu_and_mul_nvfp4_quant(result, block_scale, x, global_scale_inv)
 
->>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
     return QuantizedActivation(
         data=result.view(out_shape[:-1] + (d // 2,)),
         scale=block_scale,

--- a/vllm/model_executor/layers/fusion/fused_act_quant.py
+++ b/vllm/model_executor/layers/fusion/fused_act_quant.py
@@ -19,7 +19,10 @@ from collections.abc import Callable
 import torch
 
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    get_input_quant_scales,
+)
 from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -41,9 +44,8 @@ def _silu_and_mul_fp8_static(
     d = x.shape[-1] // 2
     out_shape = x.shape[:-1] + (d,)
     result = torch.empty(out_shape, dtype=FP8_DTYPE, device=x.device)
-    # TODO(mgoin): read the consumer scale via the contract instead of reaching
-    # into the kernel-specific input_scale attribute.
-    scale = linear.input_scale
+    scale = get_input_quant_scales(linear).static_scale
+    assert scale is not None, "Static FP8 quantization requires an input scale"
     torch.ops._C.silu_and_mul_quant(result, x, scale)
     return QuantizedActivation(
         data=result,
@@ -126,10 +128,20 @@ def _silu_and_mul_nvfp4_dynamic(
         "input_global_scale_inv is required for NVFP4 quantization"
     )
 
+<<<<<<< HEAD
     torch.ops._C.silu_and_mul_nvfp4_quant(
         result, block_scale, x, input_global_scale_inv
     )
 
+=======
+    global_scale_inv = get_input_quant_scales(linear).global_scale_inv
+    assert global_scale_inv is not None, (
+        "NVFP4 quantization requires an inverse global scale"
+    )
+
+    torch.ops._C.silu_and_mul_nvfp4_quant(result, block_scale, x, global_scale_inv)
+
+>>>>>>> 1941015b2c ([Quantization] Expose input quantization scales through linear kernel contract)
     return QuantizedActivation(
         data=result.view(out_shape[:-1] + (d // 2,)),
         scale=block_scale,

--- a/vllm/model_executor/layers/fusion/quant_activation.py
+++ b/vllm/model_executor/layers/fusion/quant_activation.py
@@ -3,9 +3,9 @@
 """
 A QuantizedActivation is a pre-quantized activation produced by a fused kernel
 and consumed directly by a linear layer, letting the layer skip its own input
-quantization. A linear advertises the key its kernel can consume via
-expose_input_quant_key; the kernel validates and reads the activation via
-as_quantized_activation.
+quantization. A linear advertises the key its kernel can consume, and the
+accessor for the scales that key needs, via expose_input_quant_key; the kernel
+validates and reads the activation via as_quantized_activation.
 """
 
 from dataclasses import dataclass
@@ -35,21 +35,39 @@ class QuantizedActivation:
     quant_key: QuantKey
 
 
+@dataclass(frozen=True)
+class InputQuantScales:
+    """Consumer scales needed by an upstream quantization kernel.
+
+    static_scale is the FP8 quantization divisor (and dequantization scale).
+    global_scale_inv is the NVFP4 global quantization multiplier. Dynamic
+    per-token or per-block scales are produced by the quantizer, not stored here.
+    """
+
+    static_scale: torch.Tensor | None = None
+    global_scale_inv: torch.Tensor | None = None
+
+
 def expose_input_quant_key(layer: torch.nn.Module, kernel) -> None:
-    """Advertise the kernel's pre-quantized input key on the layer, if any.
+    """Advertise the kernel's pre-quantized input key and scale accessor, if any.
 
     This is the bridge from a kernel's input_quant_key() to the
     layer.input_quant_key attribute that fusion call sites read. The attribute
     is left unset when the kernel quantizes its own input, so non-supporting
     backends never receive a QuantizedActivation.
 
-    TODO(mgoin): Producers also need the consumer's quantization scales (e.g.
-    static input scale, global scale). Expose those here as well so producers
-    do not reach into kernel-specific layer attributes.
+    Scales are resolved through the kernel at use time: weight processing may
+    create or replace the parameters after this bridge is called.
     """
     key = kernel.input_quant_key()
     if key is not None:
         layer.input_quant_key = key
+        layer._input_quant_scales = kernel.input_quant_scales
+
+
+def get_input_quant_scales(layer: torch.nn.Module) -> InputQuantScales:
+    """Read current scales from a layer advertising pre-quantized input support."""
+    return layer._input_quant_scales(layer)
 
 
 def as_quantized_activation(


### PR DESCRIPTION


## Purpose
Fused activation-quantization producers currently need consumer-owned quantization scales, but access them through quantization-specific `Linear` attributes. For example, static FP8 reads `linear.input_scale`, while NVFP4 previously read the downstream layer's global scale directly.

This PR extends the existing `QuantizedActivation` consumer contract so linear kernels expose the input quantization scales required by upstream fused producers.

The model-facing API remains unchanged:

```python
maybe_fused_act_quant(act_fn, x, self.down_proj)
```

The main changes are:

- add `InputQuantScales` for consumer-owned input quantization scales;
- expose a scale accessor alongside `input_quant_key`;
- move FP8 and NVFP4 parameter lookup into their linear-kernel implementations;
- resolve scales at use time instead of caching tensors when the contract is installed, since weight post-processing may later create or replace those parameters;
- remove direct accesses to quantization-specific scale attributes from `fused_act_quant.py`.

This also corrects the NVFP4 manual-fusion path to use `input_global_scale_inv`, matching the regular NVFP4 input-quantization path. The previous test used a global scale of `1.0`, which made the scale and its reciprocal indistinguishable; the updated test covers non-unit values.

I searched open PRs for `input_quant_scales` and `input quantization scales` and found no PR implementing the same consumer-scale contract.
## Test Plan
Run the affected contract and fusion tests:

```bash
.venv/bin/python -m pytest \
  tests/fusion/test_quant_activation_contract.py \
  tests/kernels/test_fused_quant_activation.py \
  tests/compile/passes/test_silu_mul_quant_manual_fusion.py \
  -v
```

The contract tests cover eager and `torch.compile(fullgraph=True)` execution and verify that scale lookup observes parameters replaced after the contract is installed.

The NVFP4 fusion test uses non-unit global-scale values so a scale/inverse-scale mix-up is observable.

## Test Result
```text
140 passed, 4 skipped
```

The four skipped cases require SM100+ hardware for NVFP4 execution; the available GPU does not support those kernels.

The FP8 fusion path passes with the real kernel scale accessor. The contract tests also pass with parameter replacement after `expose_input_quant_key()` and under `torch.compile(fullgraph=True)`.

During test validation, replacing the late-bound accessor with a cached scale causes the parameter-replacement tests to fail, and using `input_global_scale` instead of `input_global_scale_inv` causes the non-unit NVFP4 cases to fail.

No user-facing documentation update is required because this changes an internal quantization contract.

## AI Assistance

OpenAI Codex assisted with implementation, testing, source inspection, and review. I reviewed the changed code and am responsible for understanding and defending the change end-to-end.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

