### PR TITLE
[Bugfix] Seed the mamba align state index with the mamba block size

### DIFF
--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -118,8 +118,22 @@ class MambaHybridModelState(DefaultModelState):
         self.num_accepted_tokens_gpu[req_index].fill_(1)
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
+            # The divisor must be the MAMBA group's block size, not the
+            # attention/CLI block size: on hybrids they differ (here 1616 vs the
+            # mamba spec), and a resume over a cached prefix then seeds an
+            # out-of-range block_table column, so the fused align pre-copy reads
+            # a garbage block id (illegal memory access on sm_121, silently
+            # wrong state where the read stays mapped) -- vllm#53142.
+            # ``_mamba_spec`` is populated by the first batch's preprocess;
+            # fresh requests seed from num_computed_tokens=0 either way, so the
+            # fallback is safe.
+            mamba_bs = (
+                self._mamba_spec.block_size
+                if self._mamba_spec is not None
+                else self.cache_config.block_size
+            )
             self._mamba_state_idx_gpu[req_index].fill_(
-                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
+                (new_req_data.num_computed_tokens - 1) // mamba_bs
             )
 
     def _get_mamba_group_info(
@@ -169,9 +183,9 @@ class MambaHybridModelState(DefaultModelState):
         ctx = self._mamba_ctx
         if not ctx.is_initialized:
             forward_context = self.vllm_config.compilation_config.static_forward_context
-            # block_tables are batch-order slices of the persistent
-            # input_block_tables (stable data_ptr), so the metadata is captured
-            # once here and reused across steps.
+            # ``block_tables`` are the SOURCE per-request-slot tables (stable
+            # data_ptr, req-indexed), so the metadata is captured once here and
+            # reused across steps; the copy kernels index rows by req_idx.
             ctx.initialize_from_forward_context(
                 kv_cache_config,
                 forward_context,


### PR DESCRIPTION
## Problem

Fixes #53142.

`MambaHybridModelState.add_request` seeds the per-request running-state block column with

```python
(new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
```

but that column indexes the **mamba group's** block table, whose granularity is `MambaSpec.block_size`. On hybrids the two differ (`cache_config.block_size` is the CLI/scheduler block size — here 1616 vs the mamba spec), so a request resumed over a cached prefix seeds an **out-of-range column**. The fused align pre-copy then reads a block id from outside the row:

* illegal memory access where the read lands unmapped,
* silently wrong recurrent state where it stays mapped.

## Change

Use the mamba group's block size. `_mamba_spec` is populated by the first batch's `preprocess_state`; a brand-new request seeds from `num_computed_tokens == 0` either way, so falling back to `cache_config.block_size` before that is safe.

One line of logic, no behaviour change for models where the two block sizes coincide.

## Notes

Found while chasing a separate PP + MTP + prefix-caching state-corruption bug; this divisor is independent of it. Credit to @zebgop-ops, who identified it first and documented it (with no upstream fix) at <https://github.com/zebgop-ops/qwen38-flashnext-pp>.
