### PR TITLE
[Bugfix][MoE] Deterministic expert selection in the grouped_topk Python fallback

### DIFF
--- a/tests/kernels/moe/test_grouped_topk.py
+++ b/tests/kernels/moe/test_grouped_topk.py
@@ -18,6 +18,7 @@ from vllm.config import (
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     GroupedTopk,
     fused_grouped_topk,
+    grouped_topk,
 )
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -367,3 +368,337 @@ def test_grouped_topk_single_group_nonfinite_scores(
 
     torch.testing.assert_close(actual_ids, expected_ids)
     torch.testing.assert_close(actual_values, expected_values, atol=2e-5, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Determinism of the pure-PyTorch fallback (`grouped_topk`)
+#
+# Everything above exercises the fused CUDA kernel and is therefore skipped on
+# non-CUDA platforms. The tests below deliberately are NOT skipped: the code
+# under test is the Python fallback, which is the live path on ROCm (whenever
+# AITER MoE is off) and is also reached on CUDA whenever the fused kernel is
+# not taken -- `VLLM_USE_FUSED_MOE_GROUPED_TOPK=0`, `e_score_correction_bias
+# is None`, or a shape outside the kernel's tier table.
+#
+# The fallback used to select with `torch.topk(..., sorted=False)`, and
+# `sorted=False` licenses the backend to return the k results in any order.
+# Above 256 columns `torch.topk` takes a multi-pass path whose order is not
+# merely unsorted but differs between calls on identical input. Measured on
+# gfx1151 / torch 2.11+rocm10.0, 20 identical `torch.topk(x, k=8,
+# sorted=False)` calls on a 64xE tensor gave 1 distinct result for E <= 256
+# and 20 distinct for E >= 257, with the same split for any k >= 4.
+#
+# Hence _DET_NUM_EXPERTS = 288 below: at E <= 256 -- which includes
+# DeepSeek-V3/R1's 256, sitting exactly on the safe side of the boundary --
+# the stock implementation happens to return sorted, stable output and these
+# tests pass against unfixed code.
+# ---------------------------------------------------------------------------
+
+# The fallback is device-agnostic; run on whatever the runner has. (On ROCm
+# builds torch.cuda.is_available() is True and "cuda" is the right device
+# string -- HIP presents itself through the CUDA API.)
+_DET_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+_DET_NUM_REPEAT = 20
+_DET_NUM_EXPERTS = 288
+_DET_TOPK = 8
+_DET_NUM_TOKENS = 64
+
+
+def _run_python_grouped_topk(
+    logits: torch.Tensor,
+    bias: torch.Tensor | None,
+    topk: int,
+    *,
+    num_expert_group: int = 1,
+    topk_group: int = 1,
+    scoring_func: str = "sigmoid",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Call the Python fallback exactly as the router does when the fused
+    kernel is not taken."""
+    return grouped_topk(
+        hidden_states=torch.empty(
+            (logits.shape[0], 0), dtype=logits.dtype, device=logits.device
+        ),
+        gating_output=logits,
+        topk=topk,
+        renormalize=False,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        scoring_func=scoring_func,
+        e_score_correction_bias=bias,
+    )
+
+
+def _det_scores(logits: torch.Tensor, scoring_func: str) -> torch.Tensor:
+    if scoring_func == "sigmoid":
+        return logits.sigmoid()
+    return torch.softmax(logits, dim=-1)
+
+
+def _det_biased_scores(
+    logits: torch.Tensor, bias: torch.Tensor | None, scoring_func: str
+) -> torch.Tensor:
+    scores = _det_scores(logits, scoring_func)
+    if bias is not None:
+        scores = scores + bias.unsqueeze(0)
+    return scores
+
+
+def _force_python_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force the Python path on every platform (including CUDA), and make it
+    # explicit that determinism must not require VLLM_BATCH_INVARIANT, which
+    # is documented as NVIDIA SM90+ only and so cannot be enabled on every
+    # stack that reaches this code.
+    monkeypatch.setenv("VLLM_USE_FUSED_MOE_GROUPED_TOPK", "0")
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "0")
+
+
+def _det_random_inputs(
+    bias_is_none: bool, seed: int = 0
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    logits = torch.randn(
+        _DET_NUM_TOKENS, _DET_NUM_EXPERTS, generator=gen, dtype=torch.float32
+    ).to(_DET_DEVICE)
+    bias = (
+        None
+        if bias_is_none
+        else torch.randn(_DET_NUM_EXPERTS, generator=gen, dtype=torch.float32).to(
+            _DET_DEVICE
+        )
+    )
+    return logits, bias
+
+
+def _assert_all_identical(
+    results: list[tuple[torch.Tensor, torch.Tensor]],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    first_w, first_i = results[0]
+    for n, (w, i) in enumerate(results[1:], start=1):
+        assert torch.equal(i, first_i), (
+            f"expert ids differ between call 0 and call {n}: "
+            f"{(i != first_i).sum().item()} of {i.numel()} positions"
+        )
+        # Bitwise, not merely value-wise: this also catches a -0.0/0.0 flip
+        # and any reordering among equal weights.
+        assert w.view(torch.int32).equal(first_w.view(torch.int32)), (
+            f"routing weights differ between call 0 and call {n}"
+        )
+    return first_w, first_i
+
+
+def _make_tie_logits(
+    num_experts: int, k: int, tie_lo: int, tie_hi: int
+) -> torch.Tensor:
+    """One row with a deliberate, bitwise-exact tie at the k-boundary.
+
+    Experts ``0 .. k-2`` get well-separated descending logits, experts
+    ``tie_lo`` (= k-1) and ``tie_hi`` get the *same* logit value, and every
+    other expert sits strictly below the pair. Because the tied pair has
+    identical input bits and the scoring activation is elementwise, the two
+    biased scores are bitwise-equal on every backend, eager or compiled --
+    the tie is constructed, not a rounding accident. The pair occupies
+    positions k-1 and k of the value-descending order, i.e. the last selected
+    slot and the first dropped one.
+    """
+    assert tie_lo == k - 1 and tie_hi > tie_lo and tie_hi < num_experts
+    logits = torch.zeros(num_experts, dtype=torch.float32)
+    logits[: k - 1] = torch.linspace(8.0, 4.0, k - 1)
+    logits[tie_lo] = 3.0
+    logits[tie_hi] = 3.0
+    rest = torch.ones(num_experts, dtype=torch.bool)
+    rest[: k - 1] = False
+    rest[tie_lo] = False
+    rest[tie_hi] = False
+    logits[rest] = torch.linspace(2.9, 0.1, int(rest.sum()))
+    return logits
+
+
+@pytest.mark.parametrize("scoring_func", ["sigmoid", "softmax"])
+@pytest.mark.parametrize("bias_is_none", [False, True])
+@pytest.mark.parametrize(
+    ("num_expert_group", "topk_group"), [(1, 1), (8, 4)], ids=["1grp", "8grp"]
+)
+def test_grouped_topk_repeat_determinism(
+    monkeypatch: pytest.MonkeyPatch,
+    scoring_func: str,
+    bias_is_none: bool,
+    num_expert_group: int,
+    topk_group: int,
+):
+    """Identical inputs must give bitwise-identical routing.
+
+    No tie is needed: with ``sorted=False`` the fallback returned the same k
+    experts in a *different order* on every call once E > 256, which permutes
+    the routing weights and so changes the order the expert outputs are summed
+    in downstream.
+    """
+    _force_python_fallback(monkeypatch)
+    logits, bias = _det_random_inputs(bias_is_none)
+
+    # A fresh clone per call so the input buffer address varies, as it does in
+    # a real forward.
+    results = [
+        _run_python_grouped_topk(
+            logits.clone(),
+            bias,
+            _DET_TOPK,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            scoring_func=scoring_func,
+        )
+        for _ in range(_DET_NUM_REPEAT)
+    ]
+    _assert_all_identical(results)
+
+
+@pytest.mark.parametrize("scoring_func", ["sigmoid", "softmax"])
+@pytest.mark.parametrize("bias_is_none", [False, True])
+def test_grouped_topk_returns_value_descending_order(
+    monkeypatch: pytest.MonkeyPatch, scoring_func: str, bias_is_none: bool
+):
+    """The selected experts must come back in descending score order.
+
+    This is the order the fused kernel already produces -- ``moeTopKFuncs.cuh``
+    packs ``65535 - idx`` into the comparison key and the multi-group path uses
+    ``WarpSelect<..., is_stable=true>`` -- and the order
+    ``_single_group_reference`` above already assumes, via a stable descending
+    ``argsort``. It is a single-call assertion, so it cannot be flaky.
+    """
+    _force_python_fallback(monkeypatch)
+    logits, bias = _det_random_inputs(bias_is_none)
+    biased = _det_biased_scores(logits, bias, scoring_func)
+
+    _, topk_ids = _run_python_grouped_topk(
+        logits, bias, _DET_TOPK, scoring_func=scoring_func
+    )
+
+    selected = biased.gather(1, topk_ids.to(torch.long))
+    bad = (selected[:, :-1] < selected[:, 1:]).any(dim=1)
+    assert not bool(bad.any()), (
+        f"{int(bad.sum())} of {bad.numel()} rows are not in descending score "
+        f"order; first offending row {int(bad.nonzero()[0])}: "
+        f"{selected[int(bad.nonzero()[0])].tolist()}"
+    )
+
+    # Same experts as the reference: on tie-free input this order is exactly
+    # what topk(..., sorted=True) already returns, i.e. pinning the order does
+    # not change the selection.
+    ref_ids = biased.topk(_DET_TOPK, dim=-1, sorted=True)[1].to(torch.int32)
+    torch.testing.assert_close(topk_ids, ref_ids)
+
+
+@pytest.mark.parametrize("scoring_func", ["sigmoid", "softmax"])
+@pytest.mark.parametrize("bias_is_none", [False, True])
+def test_grouped_topk_tie_broken_by_lower_expert_index(
+    monkeypatch: pytest.MonkeyPatch, scoring_func: str, bias_is_none: bool
+):
+    """An exact tie at the k-boundary is resolved by the lower expert index.
+
+    This is the same contract as ``test_grouped_topk_single_group_stable_ties``
+    asserts for the fused kernel, but for the fallback. Such ties do occur in
+    practice: a live 740x288 router score tensor from a GLM-5.3-Flash prefill
+    had k-boundary ties on 2 of 740 rows, between experts whose logits *and*
+    biases both differ but whose fp32 sums round to the same value.
+    """
+    _force_python_fallback(monkeypatch)
+
+    tie_lo, tie_hi = _DET_TOPK - 1, 200
+    logits = _make_tie_logits(_DET_NUM_EXPERTS, _DET_TOPK, tie_lo, tie_hi)[None].to(
+        _DET_DEVICE
+    )
+    bias = None if bias_is_none else torch.zeros(_DET_NUM_EXPERTS, device=_DET_DEVICE)
+
+    biased = _det_biased_scores(logits, bias, scoring_func)
+    # Self-validate the construction before asserting anything about the op.
+    tie_val = biased[0, tie_lo]
+    assert biased[0, tie_lo].item() == biased[0, tie_hi].item()
+    assert int((biased[0] > tie_val).sum()) == _DET_TOPK - 1
+    assert int((biased[0] == tie_val).sum()) == 2
+
+    results = [
+        _run_python_grouped_topk(
+            logits.clone(), bias, _DET_TOPK, scoring_func=scoring_func
+        )
+        for _ in range(_DET_NUM_REPEAT)
+    ]
+    first_w, first_i = _assert_all_identical(results)
+
+    assert int(first_i[0, _DET_TOPK - 1]) == tie_lo
+    assert tie_hi not in first_i[0].tolist()
+
+    # The full selection is the value-descending one: experts 0..k-2 by
+    # construction, then the tie winner tie_lo = k-1.
+    expected_ids = torch.arange(_DET_TOPK, dtype=torch.int32, device=_DET_DEVICE)[None]
+    torch.testing.assert_close(first_i, expected_ids)
+
+    # Weights are the unbiased scores of the selected experts. A small
+    # tolerance vs the eager reference: the compiled elementwise activation
+    # may differ from eager by an ULP on some backends.
+    expected_w = _det_scores(logits, scoring_func).gather(1, first_i.to(torch.long))
+    torch.testing.assert_close(first_w, expected_w, atol=2e-6, rtol=0)
+
+
+@pytest.mark.parametrize("scoring_func", ["sigmoid", "softmax"])
+def test_grouped_topk_group_tie_broken_by_lower_group_index(
+    monkeypatch: pytest.MonkeyPatch, scoring_func: str
+):
+    """A bitwise-exact tie at the *group* boundary is broken by ascending
+    group index, covering the group-selection site.
+
+    This one stays small on purpose: the group top-k is over
+    ``num_expert_group`` values (8 for real DeepSeek/GLM configs), always far
+    below topk's 256-column threshold, so a genuine tie is the only way to
+    make the group-selection site observable.
+    """
+    _force_python_fallback(monkeypatch)
+
+    # 4 groups of 8 experts. Group 0 is clearly best (its top-2 dominate),
+    # groups 1 and 2 are bitwise-identical -- a deliberate exact tie for the
+    # second of the two selected groups -- and group 3 is clearly worst. The
+    # non-top logits inside each group are kept low so that the top-4
+    # individuals of the union {group 0, group 1} are exactly experts
+    # 0, 1, 8, 9; had group 2 won the tie they would be 0, 1, 16, 17.
+    g0 = [8.0, 7.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4]
+    g12 = [4.0, 3.5, 1.3, 1.2, 1.1, 1.0, 0.95, 0.9]
+    g3 = [0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
+    logits = torch.tensor(g0 + g12 + g12 + g3, dtype=torch.float32)[None].to(
+        _DET_DEVICE
+    )
+    num_experts = logits.shape[1]
+    bias = torch.zeros(num_experts, device=_DET_DEVICE)
+
+    # The group scores (top-2 sum within each group) of groups 1 and 2 must be
+    # bitwise-equal: identical inputs, elementwise activation, values-only
+    # reduction. (Ties inside that top-2-by-value reduction are between equal
+    # values, so the sum is unaffected -- which is why that reduction needs no
+    # tie-break of its own.)
+    def group_scores(row: torch.Tensor) -> torch.Tensor:
+        return row.view(1, 4, -1).topk(2, dim=-1)[0].sum(dim=-1)
+
+    gs = group_scores(_det_biased_scores(logits, bias, scoring_func))
+    assert gs[0, 1].item() == gs[0, 2].item()
+    assert gs[0, 0] > gs[0, 1] and gs[0, 3] < gs[0, 1]
+
+    results = [
+        _run_python_grouped_topk(
+            logits.clone(),
+            bias,
+            4,
+            num_expert_group=4,
+            topk_group=2,
+            scoring_func=scoring_func,
+        )
+        for _ in range(_DET_NUM_REPEAT)
+    ]
+    _, first_i = _assert_all_identical(results)
+
+    # Group 1 (the lower index) wins the tie, so the experts are drawn from
+    # groups 0 and 1 only.
+    expected_ids = torch.tensor([[0, 1, 8, 9]], dtype=torch.int32, device=_DET_DEVICE)
+    torch.testing.assert_close(first_i, expected_ids)
+
+    order = _det_biased_scores(logits, bias, scoring_func).gather(
+        1, first_i.to(torch.long)
+    )
+    assert torch.all(order[:, :-1] >= order[:, 1:])

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -71,6 +71,18 @@ def fused_grouped_topk(
     return topk_values, topk_indices
 
 
+def _deterministic_topk_indices(x: torch.Tensor, k: int) -> torch.Tensor:
+    """Top-k indices under a total order: value descending, index ascending.
+
+    `torch.topk` guarantees no tie-break, and on some backends is
+    nondeterministic on exact ties; with `sorted=False` it additionally
+    permutes the returned order run-to-run. Both make expert selection
+    irreproducible. A stable descending sort gives the same ordering the fused
+    kernel uses (value desc, then lower index first).
+    """
+    return x.sort(dim=-1, descending=True, stable=True).indices[..., :k]
+
+
 # This is used by the Deepseek-V2 and Deepseek-V3 model
 @torch.compile(
     dynamic=True,
@@ -130,11 +142,8 @@ def grouped_topk(
             scores.view(num_token, num_expert_group, -1).max(dim=-1).values
         )  # [n, n_group]
 
-    # For batch invariance, use sorted=True to ensure deterministic expert selection
-    use_sorted = envs.VLLM_BATCH_INVARIANT
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=use_sorted)[
-        1
-    ]  # [n, top_k_group]
+    # [n, top_k_group]
+    group_idx = _deterministic_topk_indices(group_scores, topk_group)
     group_mask = torch.zeros_like(group_scores)  # [n, n_group]
     group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
     score_mask = (
@@ -145,13 +154,12 @@ def grouped_topk(
     tmp_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))  # [n, e]
 
     if e_score_correction_bias is not None:
-        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=use_sorted)[1]
+        topk_ids = _deterministic_topk_indices(tmp_scores, topk)
         # Use original unbiased scores for the routing weights
         topk_weights = original_scores.gather(1, topk_ids)
     else:
-        topk_weights, topk_ids = torch.topk(
-            tmp_scores, k=topk, dim=-1, sorted=use_sorted
-        )
+        topk_ids = _deterministic_topk_indices(tmp_scores, topk)
+        topk_weights = tmp_scores.gather(1, topk_ids)
 
     if renormalize:
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)


### PR DESCRIPTION
## The strongest argument, up front: the fallback does not match the kernel

This PR does not introduce a new ordering. **Value descending, expert index
ascending is already the defined, implemented and tested output contract of
the fused CUDA kernel** — the Python fallback simply does not match it.

The single-group fused kernel packs value and index into one comparison key
(`csrc/libtorch_stable/moe/moeTopKFuncs.cuh`):

```cpp
static __host__ __device__ inline TypeCmp makeCmpVal(T val, int32_t idx = 0) {
    auto valueBits = cub::Traits<T>::TwiddleIn(...);
    TypeCmp compactTmp = valueBits;
    compactTmp = (compactTmp << kMoveBits) | (0xFFFF & (kMaxIdx - idx));
    // Use 65535 minus idx to give higher priority to elements with smaller
    // indices.
    return compactTmp;
}
```

The multi-group path is stable for the same reason
(`csrc/libtorch_stable/moe/grouped_topk_kernels.cu`):

```cpp
template <bool greater, typename T, typename idxT>
__forceinline__ __device__ bool is_better_than(T val, T baseline, idxT index,
                                               idxT baseline_index) {
  bool res = (val > baseline && greater) || (val < baseline && !greater);
  if (val == baseline) {
    res = (index < baseline_index && greater) ||
          (index < baseline_index && !greater);
  }
  return res;
}
```

And the contract is already asserted by an existing test,
`tests/kernels/moe/test_grouped_topk.py::test_grouped_topk_single_group_stable_ties`
(all-zero logits → every score tied → the expected ids are ascending):

```python
def test_grouped_topk_single_group_stable_ties(num_experts: int):
    logits = torch.zeros((1, num_experts), dtype=torch.bfloat16, device="cuda")
    bias = torch.zeros((num_experts,), dtype=torch.float32, device="cuda")
    ...
    expected_ids = torch.arange(16, dtype=torch.int32, device="cuda")[None]
```

Most tellingly, the **reference implementation in that same test file already
uses precisely the ordering this PR installs** — a stable descending sort:

```python
def _single_group_reference(...):
    ...
    indices = torch.argsort(
        scores + bias.float(), dim=-1, descending=True, stable=True
    )[:, :topk]
```

So the fused kernel, the test suite's reference, and #55122's convention for
the sparse indexer all agree on value-desc/index-asc. The Python fallback is
the only piece that does not, and it is the piece that actually runs on ROCm.
This PR makes it agree.

This PR makes the Python fallback select under the same total order
(value descending, index ascending on bitwise-equal scores), so the two
implementations of `grouped_topk` finally agree on ties. It also matches the
convention #55122 chose for the sparse indexer's `persistent_topk`
("ascending index order ... top-k by value desc, index asc").

## The bug, for someone with no context

The Python `grouped_topk` selects experts with
`torch.topk(..., sorted=envs.VLLM_BATCH_INVARIANT)` — i.e. `sorted=False` by
default — at three sites in
`vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py`
(group selection L135, expert selection L148 and L152-154 as of 8bf39632).

Measured on a real router score tensor from a GLM-5.3 prefill (740x288 fp32,
k=8; gfx1151, ROCm 10.0, torch 2.11), 20 identical calls of the raw ops:

| arm | distinct raw results / 20 | distinct selected sets / 20 |
|---|---:|---:|
| `sort(descending=True, stable=True)[:k]` (this PR) | **1** | **1** |
| `topk(sorted=False)` (today's default) | **20** | 2 |
| `topk(sorted=True)` | 2 | 2 |

Two independent defects:

1. **`sorted=False` permutes the returned order on every row, every call.**
   The selected set is correct, but the order of the returned top-k differs
   on 740/740 rows from call to call (a 20-call follow-up on other layers
   measured ≥715/740 — essentially every row). The gathered routing weights
   are permuted to match, so the downstream k-term summation order changes
   and the MoE output differs run-to-run.
2. **`sorted=True` still flips the selected set.** The real tensors contain
   bitwise-equal fp32 biased scores exactly at the k-boundary (rows 40 and
   549: experts {12, 202} and {243, 250} — different logits *and* different
   biases whose fp32 sums round to the same value), and `torch.topk`
   guarantees no tie-break between equal values. On row 40, 20-call sampling
   shows the set flipping between expert 202 (39/60) and expert 12 (21/60).
3. `torch.use_deterministic_algorithms(True)` does **not** help: neither in
   `warn_only` nor `strict` mode does it raise, warn, or change `topk`'s
   behaviour on these tensors.

### Why this has stayed invisible: the boundary is at 256 experts

`sorted=False` licenses *any* order, and above 256 columns `torch.topk` takes
a multi-pass path whose output order is not merely unsorted but differs
between calls. The boundary is exact. 20 identical
`torch.topk(x, k=8, sorted=False)` calls on a `64 x E` tensor, same stack as
above:

| experts (E) | distinct results / 20 | output descending |
|:--|---:|:--|
| 128, 250, 255, **256** | 1 | yes |
| **257**, 258, 260, 264, 272, 288, 512, 1024, 2048 | **20** | no |

The same split holds for any `k >= 4` (`k <= 2` is order-trivial), and
`sorted=True` at E=288 gives 1/20 - consistent with defect 2 needing a real
tie rather than mere width.

So the blast radius is **models with more than 256 routed experts**.
DeepSeek-V3/R1 has exactly 256 and sits on the safe side of the boundary,
which is presumably why this has gone unnoticed; GLM-5.3's 288 is over it. The
boundary is an implementation detail of one `topk` on one backend, though -
the fallback should not depend on unspecified ordering at any width.

## The change

A module-level helper realising the kernel's total order, used at all three
selection sites:

```python
def _deterministic_topk_indices(x: torch.Tensor, k: int) -> torch.Tensor:
    """Top-k indices under a total order: value descending, index ascending."""
    return x.sort(dim=-1, descending=True, stable=True).indices[..., :k]
```

- L135: `group_idx = _deterministic_topk_indices(group_scores, topk_group)`
- L148: `topk_ids = _deterministic_topk_indices(tmp_scores, topk)`
- L152-154: `topk_ids = _deterministic_topk_indices(tmp_scores, topk)`
  followed by `topk_weights = tmp_scores.gather(1, topk_ids)` (weights keep
  coming from `tmp_scores`; the bias branch still gathers from
  `original_scores`)

The now-unused `use_sorted = envs.VLLM_BATCH_INVARIANT` local and its
comment are removed. The group-score reduction at L126
(`view(...).topk(2)[0].sum(-1)`) is deliberately untouched: it reduces
values only, and a tie at its k-boundary is between equal values, so the
sum is unaffected.

## This is not ROCm-only

The fused `_moe_C` kernel is taken only when *all* of the following hold
(`grouped_topk_router.py` L91-97):

```python
envs.VLLM_USE_FUSED_MOE_GROUPED_TOPK   # default True
and current_platform.is_cuda()         # False on ROCm
and num_expert_group <= 32
and topk <= 32
and e_score_correction_bias is not None
```

So **CUDA also runs the Python path** whenever `e_score_correction_bias is
None` (softmax-grouped models without a correction bias), or
`VLLM_USE_FUSED_MOE_GROUPED_TOPK=0`, or a shape outside the kernel's tier
table (`num_expert_group > 32`, `topk > 32`). The bug is ROCm-*default*, not
ROCm-only — it is latent on CUDA for the no-bias configs.

## Performance

Same real 740x288 fp32 tensor, k=8, CUDA-event timing, N=50 after warmup
(gfx1151; the GPU is shared so absolute values are contention-inflated —
the relative ordering was reproduced three times):

| arm | median | p90 |
|---|---:|---:|
| `topk(sorted=False)` (today) | 97.8 us | 99.5 us |
| `topk(sorted=True)` | 101.7 us | 102.5 us |
| `sort(stable=True)` + slice (this PR) | **71.6 us** | 72.6 us |

Per prefill forward (42 MoE layers): 4.11 ms -> 3.01 ms, i.e. the fix
**saves ~1.1 ms of a ~2.4 s prefill** rather than costing anything. Cost in
memory: ~2.4 MiB transient per call at this shape (832 KiB values + 1.6 MiB
int64 indices, freed immediately; scales with tokens x experts — ~107 MiB at
32k tokens x 288 experts) vs ~69 KiB for `topk`.

Honest caveat: a full sort is O(E log E) vs `topk`'s O(E log k), so at much
larger expert counts the trade could invert. It is also data-dependent: on
`randn` synthetic scores at this shape `topk` costs ~78 us and the two arms
are comparable — the measured win is on real router data, not universal.
An env-gated variant is possible, but `VLLM_BATCH_INVARIANT` is documented
NVIDIA-SM90-only, so ROCm users cannot opt into a gated mitigation in a
supported way; correctness fixes should not be platform-flag-gated.

## Behavioural delta

- Confined to exact bitwise ties: **1 row in 740** on the real tensors.
- The ascending-index winner is always one of the outcomes `topk` already
  produced (across all measured tensors: 0 rows where the ascending-index
  selection was never returned by `topk` in 60 calls) — the fix pins the
  winner, it does not introduce a new selection.
- On tie-free rows the result is bitwise identical to `topk(sorted=True)`
  in both set and order. Relative to today's default (`sorted=False`), the
  returned order becomes fully sorted — that order change is the point of
  the fix.
- Verified picks on the real tensors: row 40 -> expert 12 (not 202),
  row 549 -> 243, layer-34 row 651 -> 58 — the lower index in every case.

## Known gap (pre-existing, disclosed)

AITER's `biased_grouped_topk` (taken on ROCm when `VLLM_ROCM_USE_AITER_MOE=1`)
is deterministic, but its tie-break is opaque and demonstrably **not**
ascending-index: on the real tie rows it picks 202/250/188 where the
ascending-index rule picks 12/243/58, and a 9-configuration synthetic sweep
found no index rule at all (`{5,200}->200` but `{0,279}->0`). After this PR
the Python fallback and the CUDA `_moe_C` kernel agree on ties; the aiter
kernel keeps its own (deterministic, kernel-defined) tie-break, so a
cross-path inconsistency remains on ROCm-with-aiter. That divergence is
pre-existing and not created by this patch; fixing it means teaching the
aiter kernel the same rule, which is out of scope here.

`fused_topk_bias_router.py` (L330-333) carries the same
`use_sorted = envs.VLLM_BATCH_INVARIANT` pattern; it is reachable only via
the invalid-grouping fallback path and is left to a follow-up so this PR
stays minimal and reviewable.

## Test plan

- New regression tests in `tests/kernels/moe/test_grouped_topk.py`
  (staged copy: they are **not CUDA-gated**, unlike the existing tests in
  that file, because the Python fallback is the code under test — it must
  also run on ROCm and CPU CI):

  ```
  pytest tests/kernels/moe/test_grouped_topk.py -k "determinism or descending or tie_broken"
  ```

  - `test_grouped_topk_repeat_determinism`: 20 identical calls must return
    bitwise-identical `topk_ids` and `topk_weights`. No tie required - this is
    defect 1, the ordering one. Parametrized over sigmoid/softmax,
    bias/no-bias, and 1-group/8-group.
  - `test_grouped_topk_returns_value_descending_order`: the selected experts
    come back in descending score order, and the selected *set* equals
    `topk(..., sorted=True)`'s. This is a single-call assertion - no
    repetition, so it cannot be flaky - and it is the one that pins the
    fallback to the kernel's existing contract.
  - `test_grouped_topk_tie_broken_by_lower_expert_index`: a deliberate,
    bitwise-exact tie at the k-boundary (two experts with identical logit
    bits, so the tie survives any elementwise rounding, eager or compiled) is
    won by the ascending expert index.
  - `test_grouped_topk_group_tie_broken_by_lower_group_index`: a
    bitwise-exact tie at the *group* boundary (`topk_group > 1`) is broken by
    ascending group index, covering the group-selection site at L135.

  **These fail on `main` and pass with this PR**: 16 of 18 cases fail before
  the change, all 18 pass after, same GPU and same command. The 2 that
  already passed are the group-tie pair, whose top-k is over
  `num_expert_group` = 4 values and therefore never crosses the 256-column
  threshold; they are kept as contract tests for the L135 site.

  The tests use **288 experts on purpose**. Per the table above, `topk`'s
  ordering only degrades past 256 columns, so the same tests written at
  DeepSeek-V3's 256 - or at the 32 experts the existing
  `test_grouped_topk_single_group_stable_ties` uses - pass against the
  unfixed code and demonstrate nothing. This was checked the wrong way round
  first: an earlier draft at 32 experts passed on stock and had to be
  rewritten.
- End-to-end on the affected deployment (GLM-5.3, 2x TP, gfx1151, greedy,
  740-token prefill, repeated N times, comparing first-token and full
  completion bit-identity before/after):

  Validated on the affected deployment (GLM-5.3-Flash AWQ-W4A16, TP=2 over
  2x gfx1151, ROCm 10.0, torch 2.11, `--enforce-eager`, speculative decoding
  off, prefix caching off, engine warmed). 5 byte-identical greedy requests
  per prompt length, comparing full completions:

  | prompt tokens | before | after |
  |---:|---:|---:|
  | 244 | 5 distinct / 5 | **1 / 5** |
  | 614 | 5 distinct / 5 | **1 / 5** |
  | 1196 | 3 distinct / 5 | **1 / 5** |
  | 1421 | 5 distinct / 5 | **1 / 5** |
  | 1797 | 5 distinct / 5 | **1 / 5** |

  Per-layer verification: with a hash tap after every one of the 45 decoder
  layers, all layers are bit-identical across repeated forwards **on both TP
  ranks** at 740 prompt tokens (they were not before). Op-level, the patched
  `grouped_topk` gives 1 distinct result in 30 identical calls where a stock
  control in the same process gives 30 — so the test is sensitive, not merely
  passing.

  No regressions: 4 chat prompts return correct, coherent answers; tool
  calling still yields `finish_reason: tool_calls` with valid-JSON arguments,
  streaming and non-streaming; prefill throughput 340 / 328 / 317 tok/s at
  2K / 8K / 32K prompts, inside the 284-334 tok/s pre-patch baseline.

  **Scope of the claim — this fixes the router, not the platform.** Above
  `index_topk` (2048 for this checkpoint) a *separate* defect remains, and this
  PR does not address it: the DSA sparse-attention indexer's own top-k. A
  six-point tap inside the first sparse-attention layer, both ranks, one boot,
  isolates it cleanly — at 719 prompt tokens all six points are deterministic;
  at 2497 the divergence enters at the attention output
  (`self.self_attn(...)`, 6 of 6 distinct) with its input bit-identical, and
  everything downstream merely cascades. That is #54521's original diagnosis
  and is being fixed in #55122. So: greedy decoding becomes reproducible below
  `index_topk`, and the remaining nondeterminism above it is tracked elsewhere.
  Other nondeterministic ops are tracked in #42259.

## Cross-references

- #54521 — the greedy nondeterminism thread this was diagnosed in (the
  gfx1151 GLM-5.3 arm); the router tie is the missing explanation for the
  layer-21/34 divergence there.
- #42259 — determinism/logits-semantics tracker; a row for router expert
  selection would belong in its table (it currently tracks MoE *combine*
  #45683 and sampler top-k ties #50979, but not router selection).
- #55122 — the same value-desc/index-asc convention being fixed for the
  sparse indexer's `persistent_topk`; same bug class, different op.

---

**DCO / attribution**

```
Signed-off-by: David Canar <davidcanar@gmail.com>
```

This PR was prepared with AI assistance (analysis of the nondeterminism,
the fix, the tests and this description); every line has been reviewed and
validated by the human submitter, per the AI Assisted Contributions policy.

```
Co-authored-by: Claude
```


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
