### PR TITLE
[Bugfix][GDN] Reclassify a partial final speculative group as prefill at the max-model-len boundary

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -108,6 +108,20 @@ GDN_BUILD_TEST_CASES = {
         expected_num_prefill_tokens=3,
         expected_num_spec_decodes=1,
     ),
+    # Pure-spec batch at the max-model-len boundary: the scheduler hands the
+    # final speculative step fewer than num_spec + 1 query tokens per
+    # sequence. The partial group must be reclassified as a stateful
+    # non-spec prefill so the request can finish without padding.
+    "partial_final_spec_group_at_max_len_uses_full_group": GDNBuildTestCase(
+        seq_lens=[4, 4],
+        query_lens=[3, 2],
+        num_decode_draft_tokens=[2, 2],
+        num_speculative_tokens=2,
+        expected_num_decodes=0,
+        expected_num_prefills=2,
+        expected_num_prefill_tokens=5,
+        expected_num_spec_decodes=0,
+    ),
     # Zero-length padded sequence excluded from counts
     "zero_length_padding_with_spec": GDNBuildTestCase(
         seq_lens=[16, 65, 20],
@@ -221,3 +235,81 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
     assert meta.spec_query_start_loc.shape == (batch.batch_size + 1,)
     assert meta.num_accepted_tokens is not None
     assert meta.num_accepted_tokens.shape == (batch.batch_size,)
+
+
+def test_partial_final_spec_group_reclassified_as_prefill():
+    """A truncated pure-spec step (fewer than num_spec + 1 query tokens per
+    sequence) must come out as a non-spec prefill batch, not as a spec
+    batch with a partial group: spec metadata is None, state indices and
+    has_initial_state point at the existing mamba state blocks."""
+    num_speculative_tokens = 2
+    builder = _create_gdn_builder(num_speculative_tokens=num_speculative_tokens)
+    batch = BatchSpec(seq_lens=[4, 4], query_lens=[3, 2])
+    meta = _build(builder, batch, num_decode_draft_tokens=[2, 2])
+
+    assert meta.num_spec_decodes == 0
+    assert meta.num_spec_decode_tokens == 0
+    assert meta.num_prefills == 2
+    assert meta.num_prefill_tokens == 5
+    assert meta.num_decodes == 0
+    assert meta.spec_sequence_masks is None
+    assert meta.spec_token_indx is None
+    assert meta.spec_state_indices_tensor is None
+    assert meta.spec_query_start_loc is None
+    assert meta.num_accepted_tokens is None
+    assert meta.non_spec_query_start_loc is not None
+    # (CPU mirror of non_spec_query_start_loc is a build-local, not a
+    # metadata field; assert the group itself carries the full 5 tokens.)
+    assert meta.non_spec_query_start_loc.tolist() == [0, 3, 5]
+    assert meta.non_spec_state_indices_tensor is not None
+    assert meta.non_spec_state_indices_tensor.shape == (batch.batch_size,)
+    assert meta.has_initial_state is not None
+    assert meta.has_initial_state.tolist() == [True, True]
+
+
+def test_partial_final_spec_group_padded_batch_shapes():
+    """A truncated pure-spec step in a batch that also carries a trailing
+    zero-length padded sequence must expose non-spec metadata sized by the
+    reclassified rows only, matching the fused non-spec op contract:
+    non_spec_query_start_loc is sized num_prefills + num_decodes + 1 and
+    non_spec_state_indices_tensor / has_initial_state are sized
+    num_prefills + num_decodes. Full-batch sizing (the pre-fix
+    ``block_table_tensor[:, 0]`` / ``query_start_loc`` pass-through) leaks
+    the padded row into these tensors and trips the kernel-side shape
+    checks on a CUDA-graph-padded batch."""
+    num_speculative_tokens = 2
+    builder = _create_gdn_builder(num_speculative_tokens=num_speculative_tokens)
+    # Rows 0-1: one complete 3-token group plus a final group truncated to
+    # 2 of num_spec + 1 tokens at the max-model-len boundary; row 2 is a
+    # zero-length CUDA-graph padding slot.
+    batch = BatchSpec(seq_lens=[4, 4, 16], query_lens=[3, 2, 0])
+    meta = _build(builder, batch, num_decode_draft_tokens=[2, 2, -1])
+
+    # Reclassification semantics: the partial final group is counted as a
+    # stateful non-spec prefill, not kept as a (partial) spec group.
+    assert meta.num_spec_decodes == 0
+    assert meta.num_spec_decode_tokens == 0
+    assert meta.num_decodes == 0
+    assert meta.num_prefills == 2  # both spec rows, partial group included
+    assert meta.num_prefill_tokens == 5
+    assert meta.spec_sequence_masks is None
+    assert meta.spec_token_indx is None
+    assert meta.spec_state_indices_tensor is None
+    assert meta.spec_query_start_loc is None
+    assert meta.num_accepted_tokens is None
+
+    # Op-contract sizing: the padded row must not be counted.
+    assert meta.non_spec_query_start_loc is not None
+    assert meta.non_spec_query_start_loc.size(0) == (
+        meta.num_prefills + meta.num_decodes + 1
+    )
+    assert meta.non_spec_query_start_loc.tolist() == [0, 3, 5]
+    assert meta.non_spec_state_indices_tensor is not None
+    assert meta.non_spec_state_indices_tensor.size(0) == (
+        meta.num_prefills + meta.num_decodes
+    )
+    assert meta.has_initial_state is not None
+    assert meta.has_initial_state.size(0) == meta.num_prefills + meta.num_decodes
+    # Only the two continuing sequences carry an initial state; the padded
+    # row's stale (True) entry must be excluded.
+    assert meta.has_initial_state.tolist() == [True, True]

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -227,6 +227,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         )
 
         spec_sequence_masks_cpu: torch.Tensor | None = None
+        num_reclassified_rows: int | None = None
         if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
             spec_sequence_masks = None
             num_spec_decodes = 0
@@ -290,29 +291,65 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 num_decode_tokens = 0
 
             if num_prefills == 0 and num_decodes == 0:
-                spec_token_size = min(
-                    num_spec_decodes * (self.num_spec + 1),
-                    query_start_loc_cpu[-1].item(),
-                )
-                spec_token_indx = torch.arange(
-                    spec_token_size,
-                    dtype=torch.int32,
-                    device=query_start_loc.device,
-                )
-                non_spec_token_indx = torch.empty(
-                    0, dtype=torch.int32, device=query_start_loc.device
-                )
-                # Filter by spec_sequence_masks to exclude padded sequences
-                spec_state_indices_tensor = block_table_tensor[
-                    spec_sequence_masks_cpu, : self.num_spec + 1
-                ]
-                non_spec_state_indices_tensor = None
-                # Padded sequences are always at the back, so the first
-                # num_spec_decodes + 1 entries of query_start_loc already
-                # contain the correct cumulative token counts.
-                spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
-                non_spec_query_start_loc = None
-                non_spec_query_start_loc_cpu = None
+                expected_spec_token_size = num_spec_decodes * (self.num_spec + 1)
+                actual_spec_token_size = query_start_loc_cpu[-1].item()
+                if actual_spec_token_size < expected_spec_token_size:
+                    # The max-sequence boundary can truncate the final
+                    # speculative group. The fused GDN kernels require
+                    # complete groups, so process this final partial group
+                    # through the existing stateful non-spec prefill path.
+                    num_reclassified_rows = num_spec_decodes
+                    spec_sequence_masks = None
+                    spec_sequence_masks_cpu = None
+                    num_prefills = num_spec_decodes
+                    num_prefill_tokens = actual_spec_token_size
+                    num_spec_decodes = 0
+                    num_spec_decode_tokens = 0
+                    spec_token_indx = None
+                    non_spec_token_indx = None
+                    spec_state_indices_tensor = None
+                    # Sized by the reclassified rows only: the non-spec
+                    # kernels contract on non_spec_state_indices_tensor
+                    # .size(0) == num_prefills + num_decodes, so trailing
+                    # zero-length padded sequences must not leak in.
+                    non_spec_state_indices_tensor = block_table_tensor[
+                        :num_reclassified_rows, 0
+                    ]
+                    spec_query_start_loc = None
+                    # Padded sequences are always at the back, so the
+                    # first num_reclassified_rows + 1 entries of
+                    # query_start_loc carry the correct cumulative
+                    # token counts for the reclassified rows (same
+                    # convention as the complete-group path below), and
+                    # non_spec_query_start_loc.size(0) matches the
+                    # num_prefills + num_decodes + 1 kernel contract.
+                    non_spec_query_start_loc = query_start_loc[
+                        :num_reclassified_rows + 1
+                    ]
+                    non_spec_query_start_loc_cpu = query_start_loc_cpu[
+                        :num_reclassified_rows + 1
+                    ]
+                    num_accepted_tokens = None
+                else:
+                    spec_token_indx = torch.arange(
+                        expected_spec_token_size,
+                        dtype=torch.int32,
+                        device=query_start_loc.device,
+                    )
+                    non_spec_token_indx = torch.empty(
+                        0, dtype=torch.int32, device=query_start_loc.device
+                    )
+                    # Filter by spec_sequence_masks to exclude padded sequences
+                    spec_state_indices_tensor = block_table_tensor[
+                        spec_sequence_masks_cpu, : self.num_spec + 1
+                    ]
+                    non_spec_state_indices_tensor = None
+                    # Padded sequences are always at the back, so the first
+                    # num_spec_decodes + 1 entries of query_start_loc already
+                    # contain the correct cumulative token counts.
+                    spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+                    non_spec_query_start_loc = None
+                    non_spec_query_start_loc_cpu = None
             else:
                 spec_token_masks = torch.repeat_interleave(
                     spec_sequence_masks,
@@ -361,8 +398,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     out=non_spec_query_start_loc_cpu[1:],
                 )
 
-            assert num_accepted_tokens is not None
-            num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
+            if spec_sequence_masks_cpu is not None:
+                assert num_accepted_tokens is not None
+                num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
 
         chunk_indices: torch.Tensor | None = None
         chunk_offsets: torch.Tensor | None = None
@@ -399,7 +437,13 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         if num_prefills > 0:
             context_lens_tensor = m.compute_num_computed_tokens()
             has_initial_state = context_lens_tensor > 0
-            if spec_sequence_masks_cpu is not None:
+            if num_reclassified_rows is not None:
+                # Keep only the reclassified (formerly spec) rows so
+                # has_initial_state lines up with the row-sized
+                # non-spec tensors (num_prefills + num_decodes rows).
+                has_initial_state = has_initial_state[:num_reclassified_rows]
+                assert non_spec_query_start_loc_cpu is not None
+            elif spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
                 assert non_spec_query_start_loc_cpu is not None
             nums_dict, batch_ptr, token_chunk_offset_ptr = (

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -214,6 +214,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
+        """Build the GDN attention metadata for one batch.
+
+        Splits the batch into spec-decode and non-spec rows and builds the
+        kernel-facing mask, index, and cumulative-query-length tensors for
+        each path; prefill batches additionally get pre-computed FLA chunk
+        metadata. A pure-spec batch whose final speculative group is
+        truncated at the max-model-len boundary is reclassified as a
+        stateful non-spec prefill, since the fused GDN kernels require
+        complete groups.
+        """
         m = common_attn_metadata
 
         query_start_loc = m.query_start_loc


### PR DESCRIPTION
## Problem

A completion that ends at exactly `max-model-len` yields one **incomplete** speculative token group (fewer than `num_speculative_tokens + 1` tokens). `GDNAttentionMetadataBuilder.build()` still classifies the batch as pure spec decode and hands the fused GDN kernels a batch that violates their complete-group invariant (`spec_token == num_spec_decodes * (num_speculative_tokens + 1)`), so the final tokens of an exact full-context generation can never complete.

Repro: MTP4 on a GDN-hybrid Qwen checkpoint — a 131,072-token completion stalled at 124/128 outputs because the last step produced a 4-token group instead of 5.

## Fix

In the pure-spec branch, detect the truncated final group and reclassify it as a **stateful non-spec prefill** (the prefill path already handles initial state). Complete groups are untouched. The classification lives in the shared builder, so every backend benefits; the kernel-side complete-group TORCH_CHECK stays intact as a live guard.

Sizing invariants of the reclassified batch, `N` = reclassified spec rows — sized by `N` alone, never the padded batch size (which may carry trailing zero-length sequences): `num_spec_decodes=0`, spec fields `None`, `num_prefills=N`, `non_spec_query_start_loc(_cpu) = query_start_loc(_cpu)[:N + 1]`, `non_spec_state_indices = block_table[:N, 0]`, `has_initial_state = (computed_tokens > 0)[:N]`, `num_accepted_tokens=None`.

## Tests (3 new)

- `test_gdn_build_classification[partial_final_spec_group_at_max_len_uses_full_group]` — truncated step classifies as `num_prefills=2`, `num_spec_decodes=0`.
- `test_partial_final_spec_group_reclassified_as_prefill` — no spec metadata leaks; `non_spec_query_start_loc.tolist() == [0, 3, 5]`.
- `test_partial_final_spec_group_padded_batch_shapes` — with a trailing zero-length padded sequence, asserts the fused-op sizing above (values `[0, 3, 5]`, `[True, True]`) — the padded row is sliced out, not leaked.

## Verification

CPU-only (no GPU) in `vllm/vllm-openai-xpu@sha256:f01e24f6c7ff01f1e0662234255a1372297d1dbd89d003cf13c8fad3eab1ba4f` (`vllm 0.27.2rc1.dev77+gac7509e2b`, torch `2.13.0+xpu`): `pytest -p no:cacheprovider -v tests/v1/attention/test_gdn_metadata_builder.py`.

Regression-first — padded test against a build without the `[:N]` slices (padded row leaks `[0, 3, 5, 5]`):

```
E       AssertionError: assert 4 == ((2 + 0) + 1)
================== 1 failed, 11 passed, 22 warnings in 47.33s ==================
```

With the slices: `12 passed, 22 warnings in 43.27s`, exit 0.

Kernel-contract checks (`TORCH_CHECK(spec_token == num_spec_decodes * (num_speculative_tokens + 1))` etc.) verified against `vllm-xpu-kernels` `gdn_attn_interface.cpp`; on-device evidence follows in a comment.

## Not #391 (vllm-xpu-kernels)

#391 (open, 2026-06-03, @ehartford/QuixiAI, fixes #389) relaxes metadata *shape* checks for graph-padded buffers whose groups are still complete, leaving the uniform-stride invariant intact. This PR handles a *genuinely ragged* final group by reclassifying it out of the spec path upstream of the kernel.

## Related, none claiming this fix (checked 2026-09-05)

#50623 (cudagraph padding branch, different condition) · #50021 (accepted-token bounds, kernel-side) · #37052 (`block_table` OOB, different bug) · #55404 (merged; rewrote `build_for_cudagraph_capture` above this region — diff regenerated after it, applies at exact hunk positions).
