### PR TITLE
[Bugfix][DeepSeek V4] Forward input IDs across pipeline stages

### DIFF
--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -12,6 +12,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 from vllm.models.deepseek_v4.nvidia.dspark import DSparkDeepseekV4ForCausalLM
 from vllm.models.deepseek_v4.nvidia.model import (
     DeepseekV4ForCausalLM,
+    DeepseekV4Model,
     DeepseekV4MegaMoEExperts,
     DeepseekV4MoE,
     make_deepseek_v4_expert_params_mapping,
@@ -24,6 +25,22 @@ pytestmark = pytest.mark.skipif(
     not current_platform.is_cuda(),
     reason="DeepSeek V4 MegaMoE requires CUDA",
 )
+
+
+def test_deepseek_v4_pp_intermediate_tensors_include_input_ids():
+    model = DeepseekV4Model.__new__(DeepseekV4Model)
+    model.hc_mult = 4
+    model.config = SimpleNamespace(hidden_size=16)
+
+    tensors = model.make_empty_intermediate_tensors(
+        batch_size=8,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+
+    assert tensors["hidden_states"].shape == (8, 4, 16)
+    assert tensors["input_ids"].shape == (8,)
+    assert tensors["input_ids"].dtype == torch.int64
 
 
 def test_deepseek_v4_mega_moe_expert_mapping():

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1386,17 +1386,23 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     dtype=dtype,
                     device=device,
                 ),
+                "input_ids": torch.zeros(
+                    batch_size,
+                    dtype=torch.int64,
+                    device=device,
+                ),
             }
         )
 
     def forward(
         self,
-        input_ids: torch.Tensor,
+        input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
+            assert input_ids is not None
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
             else:
@@ -1404,6 +1410,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         else:
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
+            input_ids = intermediate_tensors["input_ids"]
 
         if self.use_mega_moe:
             input_ids = input_ids.to(torch.int64)
@@ -1457,6 +1464,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             return IntermediateTensors(
                 {
                     "hidden_states": hidden_states,
+                    "input_ids": input_ids,
                     **self.pack_local_aux_hidden_states(aux_hidden_states),
                 }
             )


### PR DESCRIPTION
## Purpose

DeepSeek V4 MegaMoE routing consumes the original token IDs in every decoder layer. Under pipeline parallelism, the V2 runner only supplies `input_ids` to the first pipeline rank, while later ranks receive `None` plus the intermediate tensor payload. As a result, TP2 x PP3 serving fails when a non-first pipeline stage tries to use the missing IDs.

This change carries `input_ids` alongside `hidden_states` in the DeepSeek V4 pipeline intermediate tensors. It preserves the integer dtype required by MegaMoE and keeps existing auxiliary hidden-state payloads intact.

Duplicate searches were performed for DeepSeek V4 pipeline-parallel `input_ids` issues and PRs; no matching fix was found.

## Test Plan

- Verify the intermediate tensor factory allocates `input_ids` with the expected shape and `torch.int64` dtype.
- Launch DeepSeek-V4-Flash-Vision-Exp on six RTX 5090 GPUs with tensor parallel size 2 and pipeline parallel size 3.
- Send one text chat completion and one local-image chat completion.
- Confirm both requests terminate normally rather than failing on a non-first pipeline rank.

## Test Result

- `git diff --check`: passed.
- Focused regression test added: `test_deepseek_v4_pp_intermediate_tensors_include_input_ids`.
- Real serving configuration: vLLM V2, TP=2, PP=3, FP8 KV cache, max model length 8192.
- Health endpoint became ready across all six workers.
- Text request completed with `finish_reason=stop` and returned `PP_TEXT_OK`.
- Vision request using `inference/examples/images/corn.jpeg` completed with `finish_reason=stop` and returned `玉米`.
- Before the fix, non-first pipeline stages received no token IDs. With the fix, all three pipeline stages completed sparse-MLA warmup and end-to-end generation.

## AI assistance disclosure

AI assistance was used to investigate the failure, prepare the patch, and draft this description. The submitter reviewed every changed line and the test evidence before submission.