### PR TITLE
[Bugfix][Mooncake] Fix mixed-TP GQA and indexer cache transfers for MiniMax-M3

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -26,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     SendBlockMeta,
     TransferRegion,
     _align_transfer_regions,
+    _validate_asymmetric_region_lengths,
     get_mooncake_bootstrap_addr,
     should_launch_bootstrap_server,
 )
@@ -38,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheLayout,
+    MLAAttentionSpec,
 )
 from vllm.v1.request import RequestStatus
 
@@ -1402,3 +1404,203 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
 
         prefill_worker.sender_loop = origin_sender_loop
         prefill_worker.shutdown()
+
+
+@pytest.mark.parametrize(
+    "producer_tp,consumer_tp,gqa_len,mla_len,valid",
+    [
+        (4, 1, 16384, 8192, True),
+        (4, 1, 8192, 8192, False),
+        (4, 1, 16384, 4096, False),
+        (1, 4, 1024, 8192, True),
+        (1, 4, 4096, 8192, False),
+        (1, 4, 1024, 4096, False),
+    ],
+)
+def test_validate_asymmetric_region_lengths_mixed_replicated(
+    producer_tp, consumer_tp, gqa_len, mla_len, valid
+):
+    """Validate GQA shards and full MLA side-cache blocks in both TP directions."""
+
+    def region(name, length, replicated=False):
+        return TransferRegion(
+            layer_name=name,
+            layer_index=0,
+            base_addr=0,
+            block_len=length,
+            kv_block_len=length,
+            replicated=replicated,
+        )
+
+    error = _validate_asymmetric_region_lengths(
+        [region("gqa", 4096), region("indexer", 8192, True)],
+        [region("gqa", gqa_len), region("indexer", mla_len, True)],
+        local_tp_size=producer_tp,
+        remote_tp_size=consumer_tp,
+        producer_cache_replicated=False,
+    )
+    assert (error is None) == valid
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "p_tp_rank", [0, 1], ids=["rank0_sends_mla", "rank1_skips_mla"]
+)
+async def test_send_kv_to_decode_mixed_replicated_regions(monkeypatch, p_tp_rank):
+    """Mixed GQA+MLA model: het-TP send plans replicated regions per region.
+
+    Producer TP=4 sends to a consumer TP=1. The TP-sharded GQA region is
+    written at the producer rank's slice offset, while the TP-invariant MLA
+    region (e.g. MiniMax-M3's lightning indexer) is sent whole at offset 0
+    by producer rank 0 only.
+    """
+
+    P_TP_SIZE = 4
+    GQA_BLOCK_LEN = 4096
+    MLA_BLOCK_LEN = 8192
+
+    monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    )
+
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        prefill_connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            _make_test_kv_cache_config(),
+        )
+        prefill_worker = prefill_connector.connector_worker
+
+        # Override TP rank/size to simulate P TP=4.
+        prefill_worker.tp_rank = p_tp_rank
+        prefill_worker.tp_size = P_TP_SIZE
+        prefill_worker._tp_size[prefill_worker.engine_id] = P_TP_SIZE
+        prefill_worker.transfer_topo.tp_rank = p_tp_rank
+        prefill_worker.transfer_topo.tp_size = P_TP_SIZE
+
+        prefill_worker._layer_specs["model.layers.0.self_attn"] = FullAttentionSpec(
+            block_size=16,
+            num_kv_heads=4,
+            head_size=64,
+            dtype=torch.float16,
+        )
+        prefill_worker._layer_specs["model.layers.0.indexer"] = MLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=64,
+            dtype=torch.float16,
+        )
+
+        prefill_worker.kv_caches_base_addr = [0x1000, 0x3000]
+        prefill_worker.block_len_per_layer = [GQA_BLOCK_LEN, MLA_BLOCK_LEN]
+        prefill_worker.kv_block_len_per_layer = [GQA_BLOCK_LEN, MLA_BLOCK_LEN]
+        prefill_worker.registered_layer_names = [
+            "model.layers.0.self_attn",
+            "model.layers.0.indexer",
+        ]
+        prefill_worker.registered_layer_indices = [0, 0]
+
+        origin_sender_loop = prefill_worker.sender_loop
+        prefill_worker.sender_loop = asyncio.get_event_loop()
+
+        transfer_id = "xfer-mixed-1"
+        send_meta = SendBlockMeta(
+            p_req_id="p-req-mixed",
+            transfer_id=transfer_id,
+            local_block_ids=[[10, 11]],
+            ready=asyncio.Event(),
+        )
+        prefill_worker.reqs_need_send[transfer_id] = send_meta
+        send_meta.ready.set()
+
+        xfer_meta = MooncakeXferMetadata(
+            remote_hostname="consumer-host",
+            remote_port=54321,
+            remote_tp_size=1,
+            remote_tp_rank=0,
+            req_blocks={"d-req-mixed": (transfer_id, [[20, 21]])},
+            kv_caches_base_addr=[0xA000, 0xB000],
+            block_lens=[GQA_BLOCK_LEN * P_TP_SIZE, MLA_BLOCK_LEN],
+            kv_block_lens=[GQA_BLOCK_LEN * P_TP_SIZE, MLA_BLOCK_LEN],
+            registered_layer_names=[
+                "model.layers.0.self_attn",
+                "model.layers.0.indexer",
+            ],
+            registered_layer_indices=[0, 0],
+        )
+        mock_socket = AsyncMock(spec=zmq.asyncio.Socket)
+        mock_socket.send_multipart = AsyncMock()
+        identity = b"consumer-mixed"
+
+        with patch.object(
+            prefill_worker, "_send_blocks", return_value=0
+        ) as mock_send_blocks:
+            await prefill_worker.send_kv_to_decode(identity, mock_socket, xfer_meta)
+
+        src_ptrs, dst_ptrs, lengths = mock_send_blocks.call_args[0][1:]
+
+        # The GQA shard lands at this rank's TP-ratio slice of the remote
+        # region (no coalescing: remote block is tp_ratio times larger).
+        gqa_dst_off = (p_tp_rank % P_TP_SIZE) * GQA_BLOCK_LEN
+        expected_src = [
+            0x1000 + 10 * GQA_BLOCK_LEN,
+            0x1000 + 11 * GQA_BLOCK_LEN,
+        ]
+        expected_dst = [
+            0xA000 + 20 * GQA_BLOCK_LEN * P_TP_SIZE + gqa_dst_off,
+            0xA000 + 21 * GQA_BLOCK_LEN * P_TP_SIZE + gqa_dst_off,
+        ]
+        expected_lengths = [GQA_BLOCK_LEN, GQA_BLOCK_LEN]
+        if p_tp_rank == 0:
+            # The replicated MLA region is sent whole by rank 0 only, as one
+            # coalesced transfer at offset 0.
+            expected_src.append(0x3000 + 10 * MLA_BLOCK_LEN)
+            expected_dst.append(0xB000 + 20 * MLA_BLOCK_LEN)
+            expected_lengths.append(2 * MLA_BLOCK_LEN)
+
+        assert src_ptrs == expected_src
+        assert dst_ptrs == expected_dst
+        assert lengths == expected_lengths
+
+        mock_socket.send_multipart.assert_called_once()
+        _, sent_payload = mock_socket.send_multipart.call_args[0][0]
+        response = prefill_worker._xfer_resp_decoder.decode(sent_payload)
+        assert response.status == MooncakeXferResponseStatus.FINISH
+        assert response.ok_reqs == ["d-req-mixed"]
+
+        prefill_worker.sender_loop = origin_sender_loop
+        prefill_worker.shutdown()
+
+
+def test_replicated_layer_classification_per_group():
+    """Replication is classified per layer from the spec type.
+
+    MiniMax-M3 mixes a TP-sharded GQA cache (FullAttentionSpec) with a
+    1-head MLA-typed indexer side cache (replicated). A GQA layer must not
+    be classified replicated from num_kv_heads: the spec carries the
+    per-rank head count (total // tp_size), so a TP-sharded layer is
+    indistinguishable from a replicated one by head count alone.
+    """
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    )
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        connector = MooncakeConnector(
+            vllm_config, KVConnectorRole.WORKER, _make_test_kv_cache_config()
+        )
+        worker = connector.connector_worker
+        worker.tp_size = 4
+        worker._layer_specs["gqa_sharded"] = FullAttentionSpec(
+            block_size=16, num_kv_heads=1, head_size=64, dtype=torch.float16
+        )
+        worker._layer_specs["indexer"] = MLAAttentionSpec(
+            block_size=16, num_kv_heads=1, head_size=64, dtype=torch.float16
+        )
+
+        # Per-rank num_kv_heads=1 on a TP=4 producer: still TP-sharded.
+        assert not worker._is_replicated_layer("gqa_sharded")
+        assert worker._is_replicated_layer("indexer")
+        assert not worker._is_replicated_layer("unknown")
+
+        worker.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -59,6 +59,8 @@ from vllm.v1.kv_cache_interface import (
     KpoolTailSpec,
     KVCacheSpec,
     MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
     SlidingWindowSpec,
 )
 from vllm.v1.request import RequestStatus
@@ -94,6 +96,9 @@ class TransferRegion:
     block_len: int
     kv_block_len: int
     group_index: int = 0
+    # TP-invariant region (e.g. MLA): every TP rank holds the full block,
+    # so it transfers whole regardless of the producer/consumer TP ratio.
+    replicated: bool = False
 
 
 def _get_tp_ratio(local_tp_size: int, remote_tp_size: int) -> int:
@@ -124,6 +129,7 @@ def _expand_transfer_regions(
     layer_names: list[str],
     layer_indices: list[int],
     group_indices: list[int] | None = None,
+    replicated_flags: list[bool] | None = None,
 ) -> list[TransferRegion]:
     """Expand registered KV tensors into the regions transferred by Mooncake."""
     assert (
@@ -145,6 +151,13 @@ def _expand_transfer_regions(
         "Mooncake transfer regions require matching group metadata lengths, "
         f"got group_indices={len(group_indices)}, layer_names={len(layer_names)}."
     )
+    if replicated_flags is None:
+        replicated_flags = [False] * len(layer_names)
+    assert len(replicated_flags) == len(layer_names), (
+        "Mooncake transfer regions require matching replicated metadata "
+        f"lengths, got replicated_flags={len(replicated_flags)}, "
+        f"layer_names={len(layer_names)}."
+    )
     regions: list[TransferRegion] = []
     for (
         base_addr,
@@ -153,6 +166,7 @@ def _expand_transfer_regions(
         layer_name,
         layer_index,
         group_index,
+        replicated,
     ) in zip(
         base_addrs,
         block_lens,
@@ -160,6 +174,7 @@ def _expand_transfer_regions(
         layer_names,
         layer_indices,
         group_indices,
+        replicated_flags,
     ):
         regions.append(
             TransferRegion(
@@ -169,6 +184,7 @@ def _expand_transfer_regions(
                 block_len=block_len,
                 kv_block_len=kv_block_len,
                 group_index=group_index,
+                replicated=replicated,
             )
         )
     return regions
@@ -253,6 +269,18 @@ def _validate_asymmetric_region_lengths(
     for idx, (local_region, remote_region) in enumerate(
         zip(local_regions, remote_regions)
     ):
+        if local_region.replicated or remote_region.replicated:
+            # TP-invariant region (e.g. an MLA side cache of a mixed GQA+MLA
+            # model): every TP rank holds the full block, so lengths must
+            # match regardless of the TP ratio. kv_block_len is already in
+            # kernel-block units on both sides.
+            if local_region.kv_block_len != remote_region.kv_block_len:
+                return (
+                    "Mooncake replicated KV region length mismatch at region "
+                    f"{idx}: local={local_region.kv_block_len}, "
+                    f"remote={remote_region.kv_block_len}."
+                )
+            continue
         if tp_ratio == 1:
             if local_region.kv_block_len != remote_region.kv_block_len:
                 return (
@@ -1531,6 +1559,7 @@ class MooncakeConnectorWorker:
                     remote_kv_block_len=remote_region.kv_block_len,
                     remote_tp_rank=agent_meta.remote_tp_rank,
                     remote_tp_size=agent_meta.remote_tp_size,
+                    region_replicated=local_region.replicated,
                 )
                 if not should_transfer:
                     # Replicated KV cache: only one producer rank in the TP group
@@ -2035,6 +2064,18 @@ class MooncakeConnectorWorker:
     def _producer_cache_is_replicated(self) -> bool:
         return self.transfer_topo.local_replicates_kv_cache
 
+    def _is_replicated_layer(self, layer_name: str) -> bool:
+        """Whether the layer's KV cache is TP-invariant (held in full by
+        every TP rank), e.g. an MLA attention or side cache.
+
+        A KV-head-count rule cannot be applied here: the spec's
+        num_kv_heads is the per-rank count (total // tp_size), so a
+        TP-sharded GQA layer is indistinguishable from a replicated one.
+        Whole-engine replicated GQA stays covered by the global
+        producer_cache_replicated flag."""
+        spec = self._layer_specs.get(layer_name)
+        return isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+
     def _get_transfer_regions(
         self,
         base_addrs: list[int],
@@ -2056,6 +2097,12 @@ class MooncakeConnectorWorker:
             layer_names=layer_names,
             layer_indices=layer_indices,
             group_indices=group_indices,
+            # Both sides register the same model's layers, so the local spec
+            # lookup also classifies the remote regions (region alignment
+            # keys on layer name).
+            replicated_flags=[
+                self._is_replicated_layer(layer_name) for layer_name in layer_names
+            ],
         )
 
     def _get_sender_transfer_plan(
@@ -2064,6 +2111,7 @@ class MooncakeConnectorWorker:
         remote_kv_block_len: int,
         remote_tp_rank: int,
         remote_tp_size: int,
+        region_replicated: bool = False,
     ) -> tuple[bool, int, int, int]:
         return _compute_sender_transfer_plan(
             local_tp_rank=self.tp_rank,
@@ -2072,7 +2120,12 @@ class MooncakeConnectorWorker:
             remote_tp_size=remote_tp_size,
             local_kv_block_len=local_kv_block_len,
             remote_kv_block_len=remote_kv_block_len,
-            producer_cache_replicated=self._producer_cache_is_replicated(),
+            # A replicated region follows the same plan a fully replicated
+            # (e.g. MLA) producer cache would: whole block at offset 0, sent
+            # by exactly one producer rank per consumer region.
+            producer_cache_replicated=(
+                self._producer_cache_is_replicated() or region_replicated
+            ),
         )
 
     def _log_debug_cache_registration(


### PR DESCRIPTION
## Purpose

Fix Mooncake heterogeneous-TP transfers for MiniMax-M3's mixed GQA and lightning-indexer caches. With prefill TP4 and decode TP1/DP8, the main GQA block is TP-sharded, while the indexer registers an `MLAAttentionSpec` and holds the full block on every TP rank. The engine-wide TP-ratio validation rejects that indexer region:

```
region 60: local=32768, remote=32768, tp_ratio=4
```

Classify replication per transfer region from the layer's MLA spec type. Validate replicated regions with equal block lengths and reuse the existing whole-block replicated sender plan; retain TP-ratio slicing for the main GQA regions. The producer derives the classification from its local layer specs for aligned local/remote regions, so the wire format does not change. Per-rank KV head counts are not used to infer replication.

The diff contains only transfer-region classification, validation, sender planning, and corresponding tests. Scheduler and receive-failure handling are unchanged.

## Related work

- #52516 fixes replicated GQA-head mappings across the KV-head replication boundary. This case instead combines sharded GQA and an independently TP-invariant MLA-typed side cache in one model; P=TP4/D=TP1 with four GQA KV heads does not cross that boundary.
- #53078 covers hybrid GDN/Mamba state layouts. This change covers mixed attention regions without Mamba/GDN state.
- Failure reporting is tracked separately in #50984. This PR does not include that work or the lifecycle follow-up proposed for it. It is independent of that PR.
- Fits the mixed-attention transfer gaps discussed in #36948. Open PR searches for Mooncake/MiniMax/heterogeneous TP and the roadmap issue found no duplicate of this region-specific fix.

## Tests

On OSS base `f4eccdade`, **74 passed**:

```bash
PYTHONPATH=$PWD HF_HUB_OFFLINE=1 /home/zhewen/repos/vllm/.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector_hma.py \
  tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py \
  tests/v1/kv_connector/unit/test_mooncake_stats.py -q
/home/zhewen/repos/vigil/.venv/bin/pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py
```

All applicable pre-commit hooks passed, including ruff and mypy. New tests validate mixed GQA/MLA lengths in both TP directions, reject genuinely mismatched regions, check per-layer classification, and exercise sender offsets and the single sending rank for the replicated indexer. The older serving baseline's corresponding suites also pass: **72 passed**.

## Model evaluation

**PASS: TP-only patch**, 2026-09-06, vigil Slurm job 12216 on 12 GB300 GPUs. MiniMax-M3, prefill TP4 on one node and decode TP1/DP8 on two nodes; GSM8K 5-shot, greedy, concurrency 512.

| Check | Result |
| --- | --- |
| GSM8K samples / request errors | **1319/1319 / 0** |
| Flexible-extract / strict-match | **0.9143 / 0.9143** |
| Prefill / decode HTTP statuses | **1319 × 200 / 1319 × 200**, no other statuses |
| Sampled producer transfers | **2400 successful, 0 failed** |
| TP-ratio rejection, scheduler assert, rendezvous timeout, local fallback, EngineCore fatal | **0 each** |
| Slurm terminal state | COMPLETED |

```bash
cd /home/zhewen/repos/vigil
.venv/bin/vigil -c recipes/minimax_m3/1p1d_tp4_dep8_mooncake_gsm8k_tp_only.yaml --dry-run </dev/null
.venv/bin/vigil -c recipes/minimax_m3/1p1d_tp4_dep8_mooncake_gsm8k_tp_only.yaml </dev/null
```

For compatibility with the installed compiled artifacts, serving used `78edd1f70e` plus the existing local baseline changes and **only this TP patch**, in `/home/zhewen/repos/vllm-wt-m3-tp-only` via PYTHONPATH. The runtime scheduler matched the original local baseline byte-for-byte, and the connector's receive-failure methods were unchanged. The separate router fixes (valid prefill DP rank and P-leg status checking) were present. This is a fresh run of the isolated patch, not the earlier combined TP/failure patch's result.

All-successful P/D access logs, positive transfer metrics, and zero fallback signatures establish real transfer coverage. Transfer counts are sampled metric-interval totals rather than unique requests. Local run evidence is under `vigil/logs/1p1d_tp4_dep8_mooncake_gsm8k_tp_only/2026-09-06/20260906_014958/`: results, source hashes, actual runtime diff, and unit/lint logs.

## AI assistance

AI assistance (Codex) was used to prepare the implementation, regression tests, and validation report. The transfer-region design was isolated from the earlier combined patch developed with Kimi Code/Codex assistance. The reported tests were executed in the shared development environment.
