### PR TITLE
[Model] Mamba2: Add exact replay for bit-identical SSM paths

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -118,6 +118,47 @@ for output in outputs:
     print(f"Generated: {generated_text!r}\n")
 ```
 
+## Mamba2 Models: Exact-Replay Mode
+
+Mamba2 layers run two different kernels: a chunked scan for prefill and a
+recurrent state update for decode. The two are not bit-identical, so without
+further measures a request's logits depend on how it was scheduled (prefill
+versus decode, chunked-prefill split points, recompute after preemption), and
+batch-invariant mode rejects Mamba2 models.
+
+`--mamba-exact-replay` (experimental) removes that dependence. The SSM state is
+kept in fp32, and every scan call for a sequence (prefill, chunked-prefill
+continuation and each decode step) starts from the fp32 state at the
+sequence's last chunk boundary and re-feeds the inputs of the current partial
+chunk from a per-sequence buffer. The kernels therefore always see the chunk
+grid of a single-shot prefill, and the Mamba2 SSM computation produces
+identical bits for prefill, chunked prefill and decode. This covers the SSM
+path only: bit-identical logits also need the batch-invariant kernels of the
+other layers, i.e. `VLLM_BATCH_INVARIANT=1`, under which the Mamba2 backend
+is accepted when this option is set.
+
+```bash
+VLLM_BATCH_INVARIANT=1 vllm serve <mamba2-model> \
+    --mamba-exact-replay --mamba-ssm-cache-dtype float32 \
+    --no-enable-prefix-caching --enforce-eager
+```
+
+Requirements and current limitations: `--mamba-ssm-cache-dtype float32`,
+`--no-enable-prefix-caching`, `--enforce-eager`, the Triton mamba backend,
+tensor- and pipeline-parallel size 1, no speculative decoding, no async
+scheduling, and not together with `--use-replayssm`. Only models that declare
+support (`Mamba2ForCausalLM`) accept the option; other configurations fail at
+startup.
+
+Costs: each decode step runs the chunked-scan kernels over the current partial
+chunk instead of the single-token update, and the per-layer mamba state grows
+from two tensors (conv state, SSM state) to six: the four partial-chunk
+buffers `x`, raw `dt`, `B` and `C` hold `chunk_size` tokens of scan inputs per
+sequence in addition to the fp32 SSM state. For a layer with `nheads` heads of size `head_dim` and
+`ngroups` groups of size `dstate` in bf16, the buffer takes
+`chunk_size * (nheads * head_dim + 2 * ngroups * dstate + nheads) * 2` bytes
+per sequence.
+
 ## Tested Models
 
 Batch invariance has been tested and verified on the following models:

--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -147,8 +147,10 @@ Requirements and current limitations: `--mamba-ssm-cache-dtype float32`,
 `--no-enable-prefix-caching`, `--enforce-eager`, the Triton mamba backend,
 tensor- and pipeline-parallel size 1, no speculative decoding, no async
 scheduling, and not together with `--use-replayssm`. Only models that declare
-support (`Mamba2ForCausalLM`) accept the option; other configurations fail at
-startup.
+support (`Mamba2ForCausalLM`, `GraniteMoeHybridForCausalLM`) accept the
+option; other configurations fail at startup. In a hybrid model the attention
+layers keep using their own batch-invariant kernels; the option only changes
+the Mamba2 layers.
 
 Costs: each decode step runs the chunked-scan kernels over the current partial
 chunk instead of the single-token update, and the per-layer mamba state grows
@@ -173,6 +175,7 @@ Batch invariance has been tested and verified on the following models:
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
 - **Phi series**: `microsoft/Phi-3.5-mini-instruct`
 - **Granite 3.1 (MoE)**: `ibm-granite/granite-3.1-1b-a400m-instruct`, `ibm-granite/granite-3.1-3b-a800m-instruct`
+- **Mamba2 with `--mamba-exact-replay`**: `AntonV/mamba2-130m-hf`, `ibm-granite/granite-4.0-h-350m` (Mamba2 + attention hybrid, including scheduler preemption)
 - **Granite 3.1 (Dense)**: `ibm-granite/granite-3.1-2b-instruct`, `ibm-granite/granite-3.1-8b-instruct`
 - **EXAONE 4.0 series**: `LGAI-EXAONE/EXAONE-4.0-1.2B`, `LGAI-EXAONE/EXAONE-4.0.1-32B`, `LGAI-EXAONE/EXAONE-4.0-32B`
 

--- a/tests/kernels/mamba/test_mamba2_exact_replay.py
+++ b/tests/kernels/mamba/test_mamba2_exact_replay.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mamba2 exact-replay mode reproduces single-shot prefill bit for bit.
+
+The schedule below mixes, in the same batches, sequences that are at different
+chunk offsets: a first prefill call that splits prompts at unaligned points, a
+second call that resumes them, then token-by-token decode until each sequence
+reaches its length (so the batch composition changes as sequences finish and
+chunk boundaries are crossed at different steps). Every produced output row
+must equal the row of a single-shot prefill of the whole sequence.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.exact_replay import (
+    ExactReplayBuffers,
+    exact_replay_ssd,
+)
+from vllm.model_executor.layers.mamba.ops.ssd_combined import (
+    mamba_chunk_scan_combined_varlen,
+)
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.mamba2_attn import build_exact_replay_metadata
+
+DEVICE = current_platform.device_type
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Mamba2 SSD Triton kernels require a CUDA-alike device.",
+)
+
+
+def _single_shot(x, dt, A, B, C, D, dt_bias, chunk_size):
+    """Reference: the whole sequence in one chunked-scan call from position 0."""
+    seqlen = x.shape[0]
+    cu_chunk = list(range(0, seqlen, chunk_size)) + [seqlen]
+    n_chunks = len(cu_chunk) - 1
+    i32 = lambda v: torch.tensor(v, dtype=torch.int32, device=x.device)  # noqa: E731
+    out = torch.empty_like(x)
+    mamba_chunk_scan_combined_varlen(
+        x,
+        dt,
+        A,
+        B,
+        C,
+        chunk_size=chunk_size,
+        cu_seqlens=i32([0, seqlen]),
+        cu_chunk_seqlens=i32(cu_chunk),
+        last_chunk_indices=i32([n_chunks - 1]),
+        seq_idx=i32([0] * n_chunks),
+        out=out,
+        D=D,
+        z=None,
+        dt_bias=dt_bias,
+        initial_states=None,
+        dt_softplus=True,
+        dt_limit=(0.0, float("inf")),
+        state_dtype=torch.float32,
+    )
+    return out
+
+
+def _carve_states(num_slots, shapes, dtypes, device, pad_bytes):
+    """Carve state tensors out of one paged buffer the way MambaBase does.
+
+    Every slot is one page; the per-state views are therefore strided in the
+    slot dimension, which is the layout the production code sees.
+    """
+    sizes = [
+        int(torch.empty(shape, dtype=dtype).numel() * dtype.itemsize)
+        for shape, dtype in zip(shapes, dtypes)
+    ]
+    page_bytes = sum(sizes) + pad_bytes
+    pages = torch.zeros(num_slots, page_bytes, dtype=torch.uint8, device=device)
+    states, offset = [], 0
+    for shape, dtype, nbytes in zip(shapes, dtypes, sizes):
+        state = pages[:, offset : offset + nbytes].view(dtype)
+        states.append(state.view(-1, *shape))
+        offset += nbytes
+    return states
+
+
+@pytest.mark.parametrize("chunk_size", [64])
+@pytest.mark.parametrize("seed", [0, 1])
+@pytest.mark.parametrize("layout", ["contiguous", "paged"])
+def test_exact_replay_matches_single_shot_prefill(chunk_size, seed, layout):
+    torch.manual_seed(seed)
+    device = torch.device(DEVICE)
+    nheads, head_dim, ngroups, dstate = 8, 64, 1, 64
+    dtype = torch.bfloat16
+
+    # Realistic Mamba2 initialisation: slow heads keep a large part of their
+    # state across a chunk, which is what makes boundary handling observable.
+    A = -(torch.rand(nheads, device=device) * 15 + 1)
+    dt_target = torch.exp(
+        torch.rand(nheads, device=device)
+        * (torch.log(torch.tensor(0.1)) - torch.log(torch.tensor(1e-3)))
+        + torch.log(torch.tensor(1e-3))
+    )
+    dt_bias = dt_target + torch.log(-torch.expm1(-dt_target))
+    D = torch.ones(nheads, device=device)
+
+    # total length, prompt length and the split point of the first prefill call
+    total_lens = [150, 210, 64, 130]
+    prompt_lens = [100, 133, 20, 64]
+    first_split = [37, 100, 20, 30]
+    n = len(total_lens)
+
+    xs = [torch.randn(L, nheads, head_dim, device=device).to(dtype) for L in total_lens]
+    dts = [(0.5 * torch.randn(L, nheads, device=device)).to(dtype) for L in total_lens]
+    Bs = [torch.randn(L, ngroups, dstate, device=device).to(dtype) for L in total_lens]
+    Cs = [torch.randn(L, ngroups, dstate, device=device).to(dtype) for L in total_lens]
+    refs = [
+        _single_shot(xs[i], dts[i], A, Bs[i], Cs[i], D, dt_bias, chunk_size)
+        for i in range(n)
+    ]
+
+    # engine-side state: slot 0 is the null block, sequences use slots 1..n
+    num_slots = n + 1
+    shapes = [
+        (nheads, head_dim, dstate),
+        (chunk_size, nheads, head_dim),
+        (chunk_size, nheads),
+        (chunk_size, ngroups, dstate),
+        (chunk_size, ngroups, dstate),
+    ]
+    dtypes = [torch.float32, dtype, dtype, dtype, dtype]
+    if layout == "contiguous":
+        states = [
+            torch.zeros(num_slots, *shape, dtype=dt_, device=device)
+            for shape, dt_ in zip(shapes, dtypes)
+        ]
+    else:
+        states = _carve_states(num_slots, shapes, dtypes, device, pad_bytes=4096)
+    ssm_state = states[0]
+    buffers = ExactReplayBuffers(*states[1:])
+    all_slots = torch.arange(1, n + 1, dtype=torch.int32, device=device)
+    outs = [torch.empty_like(x) for x in xs]
+    computed = [0] * n
+
+    def run_step(active, lens):
+        x = torch.cat(
+            [
+                xs[i][computed[i] : computed[i] + length]
+                for i, length in zip(active, lens)
+            ]
+        )
+        dt = torch.cat(
+            [
+                dts[i][computed[i] : computed[i] + length]
+                for i, length in zip(active, lens)
+            ]
+        )
+        B = torch.cat(
+            [
+                Bs[i][computed[i] : computed[i] + length]
+                for i, length in zip(active, lens)
+            ]
+        )
+        C = torch.cat(
+            [
+                Cs[i][computed[i] : computed[i] + length]
+                for i, length in zip(active, lens)
+            ]
+        )
+        slots = all_slots[torch.tensor(active, device=device)]
+        meta = build_exact_replay_metadata(
+            [computed[i] for i in active], lens, slots, chunk_size, device
+        )
+        out = torch.empty_like(x)
+        exact_replay_ssd(
+            x,
+            dt,
+            B,
+            C,
+            A=A,
+            D=D,
+            dt_bias=dt_bias,
+            out=out,
+            ssm_state=ssm_state,
+            slots=slots,
+            meta=meta,
+            chunk_size=chunk_size,
+            buffers=buffers,
+        )
+        off = 0
+        for i, length in zip(active, lens):
+            outs[i][computed[i] : computed[i] + length] = out[off : off + length]
+            off += length
+            computed[i] += length
+
+    # 1) first prefill call: every prompt split at an unaligned point (or whole)
+    run_step(list(range(n)), first_split)
+    # 2) resume the remaining prompt tokens of the split prompts
+    rest = [i for i in range(n) if computed[i] < prompt_lens[i]]
+    run_step(rest, [prompt_lens[i] - computed[i] for i in rest])
+    # 3) decode: one token per active sequence per step, batch shrinks over time
+    while any(computed[i] < total_lens[i] for i in range(n)):
+        active = [i for i in range(n) if computed[i] < total_lens[i]]
+        run_step(active, [1] * len(active))
+
+    for i in range(n):
+        assert torch.equal(outs[i].view(torch.int16), refs[i].view(torch.int16)), (
+            f"sequence {i}: exact replay diverged from single-shot prefill"
+        )

--- a/tests/kernels/mamba/test_mamba2_exact_replay.py
+++ b/tests/kernels/mamba/test_mamba2_exact_replay.py
@@ -166,7 +166,7 @@ def test_exact_replay_matches_single_shot_prefill(chunk_size, seed, layout):
         )
         slots = all_slots[torch.tensor(active, device=device)]
         meta = build_exact_replay_metadata(
-            [computed[i] for i in active], lens, slots, chunk_size, device
+            [computed[i] for i in active], lens, chunk_size, device
         )
         out = torch.empty_like(x)
         exact_replay_ssd(
@@ -203,4 +203,85 @@ def test_exact_replay_matches_single_shot_prefill(chunk_size, seed, layout):
     for i in range(n):
         assert torch.equal(outs[i].view(torch.int16), refs[i].view(torch.int16)), (
             f"sequence {i}: exact replay diverged from single-shot prefill"
+        )
+
+
+def test_shared_metadata_writes_each_groups_own_slots():
+    """One metadata object must serve layers with different state slots.
+
+    In a hybrid model the model runner builds the Mamba metadata once and hands
+    the other KV cache groups a copy with only the block table swapped, so two
+    layers see the same ``ExactReplayMetadata`` but different ``slots``. Each
+    layer must read and store its partial-chunk inputs at its own slots.
+    """
+    torch.manual_seed(0)
+    device = torch.device(DEVICE)
+    nheads, head_dim, ngroups, dstate, chunk_size = 4, 32, 1, 32, 64
+    dtype = torch.bfloat16
+    A = -(torch.rand(nheads, device=device) * 15 + 1)
+    dt_bias = torch.zeros(nheads, device=device)
+    D = torch.ones(nheads, device=device)
+    total, prompt = 100, 70  # prompt ends 6 tokens into the second chunk
+
+    def make_layer():
+        x = torch.randn(total, nheads, head_dim, device=device).to(dtype)
+        dt = (0.5 * torch.randn(total, nheads, device=device)).to(dtype)
+        B = torch.randn(total, ngroups, dstate, device=device).to(dtype)
+        C = torch.randn(total, ngroups, dstate, device=device).to(dtype)
+        ref = _single_shot(x, dt, A, B, C, D, dt_bias, chunk_size)
+        return x, dt, B, C, ref
+
+    layers = [make_layer(), make_layer()]
+    # both layers' states live in the same paged tensors (KV cache groups of a
+    # hybrid model alias one allocation); layer 0 owns slot 1, layer 1 slot 2
+    num_slots = 3
+    shapes = [
+        (nheads, head_dim, dstate),
+        (chunk_size, nheads, head_dim),
+        (chunk_size, nheads),
+        (chunk_size, ngroups, dstate),
+        (chunk_size, ngroups, dstate),
+    ]
+    dtypes = [torch.float32, dtype, dtype, dtype, dtype]
+    states = _carve_states(num_slots, shapes, dtypes, device, pad_bytes=512)
+    ssm_state, buffers = states[0], ExactReplayBuffers(*states[1:])
+    slots = [
+        torch.tensor([1], dtype=torch.int32, device=device),
+        torch.tensor([2], dtype=torch.int32, device=device),
+    ]
+    outs = [torch.empty_like(layer[0]) for layer in layers]
+
+    def run(step_start, step_len):
+        # one metadata object for both layers, as the model runner does
+        meta = build_exact_replay_metadata([step_start], [step_len], chunk_size, device)
+        for li, (x, dt, B, C, _ref) in enumerate(layers):
+            sl = slice(step_start, step_start + step_len)
+            exact_replay_ssd(
+                x[sl],
+                dt[sl],
+                B[sl],
+                C[sl],
+                A=A,
+                D=D,
+                dt_bias=dt_bias,
+                out=outs[li][sl],
+                ssm_state=ssm_state,
+                slots=slots[li],
+                meta=meta,
+                chunk_size=chunk_size,
+                buffers=buffers,
+            )
+
+    run(0, prompt)
+    # after the prefill every layer's trailing partial chunk sits in its own slot
+    for li, (x, _dt, _B, _C, _ref) in enumerate(layers):
+        stored = buffers.x[li + 1, : prompt % chunk_size]
+        assert torch.equal(
+            stored.view(torch.int16), x[chunk_size:prompt].view(torch.int16)
+        ), f"layer {li} stored its partial chunk in another layer's slot"
+    for pos in range(prompt, total):
+        run(pos, 1)
+    for li, (_x, _dt, _B, _C, ref) in enumerate(layers):
+        assert torch.equal(outs[li].view(torch.int16), ref.view(torch.int16)), (
+            f"layer {li}: exact replay diverged from single-shot prefill"
         )

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -171,8 +171,9 @@ def test_registry_supports_replayssm(model_arch, supported):
 @pytest.mark.parametrize(
     "model_arch,supported",
     [
-        # Exact replay is opt-in per model; only Mamba2ForCausalLM sets the flag.
+        # Exact replay is opt-in per model.
         ("Mamba2ForCausalLM", True),
+        ("GraniteMoeHybridForCausalLM", True),
         ("NemotronHForCausalLM", False),
         ("Zamba2ForCausalLM", False),
     ],

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -167,6 +167,22 @@ def test_registry_supports_replayssm(model_arch, supported):
     assert model_info.supports_replayssm is supported
 
 
+@create_new_process_for_each_test()
+@pytest.mark.parametrize(
+    "model_arch,supported",
+    [
+        # Exact replay is opt-in per model; only Mamba2ForCausalLM sets the flag.
+        ("Mamba2ForCausalLM", True),
+        ("NemotronHForCausalLM", False),
+        ("Zamba2ForCausalLM", False),
+    ],
+)
+def test_registry_supports_mamba_exact_replay(model_arch, supported):
+    model_info = ModelRegistry._try_inspect_model_cls(model_arch)
+    assert model_info is not None
+    assert model_info.supports_mamba_exact_replay is supported
+
+
 def test_lazy_modelinfo_package_hash_includes_submodules(tmp_path):
     package_dir = tmp_path / "model_package"
     package_dir.mkdir()

--- a/tests/v1/attention/test_mamba2_exact_replay_config.py
+++ b/tests/v1/attention/test_mamba2_exact_replay_config.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Configuration gates of Mamba2 exact-replay mode.
+
+The mode must fail closed on every unsupported combination, and the mamba
+backend selector must accept the Mamba2 backend under VLLM_BATCH_INVARIANT=1
+only when the mode is on (a config-level decision, not process state).
+"""
+
+import pytest
+
+from vllm.config import CacheConfig, SchedulerConfig, VllmConfig
+from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionBackend
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.selector import (
+    _cached_get_mamba_attn_backend,
+    _mamba_backend_supports_batch_invariance,
+    get_mamba_attn_backend,
+)
+
+
+def _cache(**overrides) -> CacheConfig:
+    kwargs = dict(
+        mamba_exact_replay=True,
+        mamba_ssm_cache_dtype="float32",
+        enable_prefix_caching=False,
+    )
+    kwargs.update(overrides)
+    return CacheConfig(**kwargs)
+
+
+def _supported_config(**cache_overrides) -> VllmConfig:
+    # Async scheduling is resolved on by default in some setups; the mode
+    # requires it off, so pin it explicitly.
+    return VllmConfig(
+        cache_config=_cache(**cache_overrides),
+        scheduler_config=SchedulerConfig(
+            max_model_len=2048, is_encoder_decoder=False, async_scheduling=False
+        ),
+    )
+
+
+def test_exact_replay_accepts_the_supported_configuration():
+    _supported_config()
+
+
+def test_exact_replay_requires_fp32_ssm_cache():
+    with pytest.raises(ValueError, match="float32"):
+        _supported_config(mamba_ssm_cache_dtype="auto")
+
+
+@pytest.mark.parametrize(
+    "mutate,message",
+    [
+        (lambda c: setattr(c.cache_config, "mamba_cache_mode", "align"), "prefix"),
+        (
+            lambda c: setattr(c.cache_config, "use_replayssm", True),
+            "mutually exclusive",
+        ),
+        (
+            lambda c: setattr(c.scheduler_config, "async_scheduling", True),
+            "async scheduling",
+        ),
+        (lambda c: setattr(c.parallel_config, "enable_dbo", True), "micro-batching"),
+        (
+            lambda c: setattr(c.parallel_config, "tensor_parallel_size", 2),
+            "TP=1 and PP=1",
+        ),
+    ],
+)
+def test_exact_replay_fails_closed_on_unsupported_settings(mutate, message):
+    # Other validators reject some of these combinations earlier at
+    # construction time, so exercise this mode's validator directly.
+    cfg = _supported_config()
+    mutate(cfg)
+    with pytest.raises(ValueError, match=message):
+        cfg.validate_mamba_exact_replay()
+
+
+def test_mamba2_backend_batch_invariance_depends_on_exact_replay():
+    assert Mamba2AttentionBackend.supports_batch_invariance() is False
+    assert not _mamba_backend_supports_batch_invariance(Mamba2AttentionBackend, False)
+    assert _mamba_backend_supports_batch_invariance(Mamba2AttentionBackend, True)
+
+
+def test_mamba_backend_selector_gate(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    _cached_get_mamba_attn_backend.cache_clear()
+    try:
+        with pytest.raises(RuntimeError, match="batch_invariant"):
+            get_mamba_attn_backend(MambaAttentionBackendEnum.MAMBA2)
+        backend = get_mamba_attn_backend(
+            MambaAttentionBackendEnum.MAMBA2, mamba_exact_replay=True
+        )
+        assert backend is Mamba2AttentionBackend
+    finally:
+        _cached_get_mamba_attn_backend.cache_clear()

--- a/tests/v1/attention/test_mamba2_exact_replay_metadata.py
+++ b/tests/v1/attention/test_mamba2_exact_replay_metadata.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Host-side metadata construction for Mamba2 exact-replay mode."""
+
+import pytest
+import torch
+
+from vllm.v1.attention.backends.mamba2_attn import build_exact_replay_metadata
+
+CHUNK = 256
+DEVICE = torch.device("cpu")
+
+
+def _build(num_computed, query_lens, slots):
+    return build_exact_replay_metadata(
+        num_computed,
+        query_lens,
+        torch.tensor(slots, dtype=torch.int32),
+        CHUNK,
+        DEVICE,
+    )
+
+
+def test_decode_rows_mid_chunk_at_boundary_and_completing_chunk():
+    # three decode rows: 300 computed (44 tokens into a chunk), exactly at a
+    # boundary, and one token short of completing a chunk
+    m = _build([300, 512, 767], [1, 1, 1], [5, 6, 7])
+    assert m.num_aug_tokens == 44 + 1 + 1 + 255 + 1
+    assert m.cu_seqlens.tolist() == [0, 45, 46, 302]
+    # every augmented sequence is a single chunk
+    assert m.cu_chunk_seqlens.tolist() == [0, 45, 46, 302]
+    assert m.last_chunk_indices.tolist() == [0, 1, 2]
+    assert m.seq_idx.tolist() == [0, 1, 2]
+    assert m.has_boundary_state.tolist() == [True, True, True]
+    # only the third row fills its chunk this step
+    assert m.boundary_rows.tolist() == [2]
+    assert m.boundary_chunk_idx.tolist() == [2]
+    # buffered tokens: 44 from slot 5, none from slot 6, 255 from slot 7
+    assert m.buffered_slot.tolist() == [5] * 44 + [7] * 255
+    assert m.buffered_pos.tolist() == list(range(44)) + list(range(255))
+    assert m.buffered_dst.tolist() == list(range(44)) + list(range(46, 301))
+    assert m.step_dst.tolist() == [44, 45, 301]
+    # rows 0 and 1 append their token to the buffer; row 2 completed a chunk
+    assert m.store_src.tolist() == [44, 45]
+    assert m.store_slot.tolist() == [5, 6]
+    assert m.store_pos.tolist() == [44, 0]
+
+
+def test_prefill_rows_fresh_and_resumed_at_unaligned_positions():
+    # fresh 600-token prefill; resume at 300 with 213 tokens; resume at 100
+    # with 413 tokens
+    m = _build([0, 300, 100], [600, 213, 413], [1, 2, 3])
+    assert m.num_aug_tokens == 600 + (44 + 213) + (100 + 413)
+    assert m.cu_seqlens.tolist() == [0, 600, 857, 1370]
+    assert m.cu_chunk_seqlens.tolist() == [0, 256, 512, 600, 856, 857, 1113, 1369, 1370]
+    assert m.last_chunk_indices.tolist() == [2, 4, 7]
+    assert m.seq_idx.tolist() == [0, 0, 0, 1, 1, 2, 2, 2]
+    # row 1 resumes at 300 -> boundary 256 holds a state; the others start
+    # from zero (row 2's boundary is 0)
+    assert m.has_boundary_state.tolist() == [False, True, False]
+    # last completed chunks: row 0 -> [256,512) (chunk 1); row 1 -> the chunk
+    # ending at 512 (chunk 3); row 2 -> the chunk ending at 512 (chunk 6)
+    assert m.boundary_rows.tolist() == [0, 1, 2]
+    assert m.boundary_chunk_idx.tolist() == [1, 3, 6]
+    # buffered tokens re-fed for rows 1 and 2
+    assert m.buffered_slot.tolist() == [2] * 44 + [3] * 100
+    assert m.buffered_dst.tolist() == list(range(600, 644)) + list(range(857, 957))
+    # trailing partial chunks stored back: 88 tokens of row 0, 1 of row 1,
+    # 1 of row 2, all at buffer positions starting from 0
+    assert m.store_src.tolist() == list(range(512, 600)) + [856] + [1369]
+    assert m.store_slot.tolist() == [1] * 88 + [2] + [3]
+    assert m.store_pos.tolist() == list(range(88)) + [0] + [0]
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_augmented_layout_invariants(seed):
+    gen = torch.Generator().manual_seed(seed)
+    n = int(torch.randint(1, 6, (1,), generator=gen))
+    num_computed = torch.randint(0, 5 * CHUNK, (n,), generator=gen).tolist()
+    query_lens = torch.randint(1, 3 * CHUNK, (n,), generator=gen).tolist()
+    # decode rows are the common case: make about half of them single-token
+    for i in range(n):
+        if torch.rand(1, generator=gen).item() < 0.5:
+            query_lens[i] = 1
+    slots = torch.randperm(64, generator=gen)[:n].tolist()
+    m = _build(num_computed, query_lens, slots)
+
+    # buffered and step destinations partition the augmented layout
+    dst = torch.cat([m.buffered_dst, m.step_dst])
+    assert sorted(dst.tolist()) == list(range(m.num_aug_tokens))
+    assert m.step_dst.numel() == sum(query_lens)
+    # chunks tile the layout and never span sequences or exceed chunk_size
+    chunks = m.cu_chunk_seqlens.tolist()
+    assert chunks[0] == 0 and chunks[-1] == m.num_aug_tokens
+    for a, b in zip(chunks, chunks[1:]):
+        assert 0 < b - a <= CHUNK
+    cu = m.cu_seqlens.tolist()
+    for i, (lo, hi) in enumerate(zip(cu, cu[1:])):
+        own = [c for c in range(len(chunks) - 1) if lo <= chunks[c] < hi]
+        assert m.seq_idx.tolist()[own[0] : own[-1] + 1] == [i] * len(own)
+        assert m.last_chunk_indices.tolist()[i] == own[-1]
+        # chunks of a sequence start at its start plus multiples of chunk_size
+        assert all((chunks[c] - lo) % CHUNK == 0 for c in own)
+    # stored positions stay inside the buffer; every store goes to its own slot
+    assert (m.store_pos < CHUNK).all()
+    assert (m.buffered_pos < CHUNK).all()
+    for i, (nc, q) in enumerate(zip(num_computed, query_lens)):
+        n_pre = nc % CHUNK
+        aug = n_pre + q
+        if aug // CHUNK == 0:
+            # nothing completed: this step's tokens are appended after n_pre
+            mask = m.store_slot == slots[i]
+            assert m.store_pos[mask].tolist() == list(range(n_pre, aug))
+        else:
+            assert i in m.boundary_rows.tolist()

--- a/tests/v1/attention/test_mamba2_exact_replay_metadata.py
+++ b/tests/v1/attention/test_mamba2_exact_replay_metadata.py
@@ -11,20 +11,14 @@ CHUNK = 256
 DEVICE = torch.device("cpu")
 
 
-def _build(num_computed, query_lens, slots):
-    return build_exact_replay_metadata(
-        num_computed,
-        query_lens,
-        torch.tensor(slots, dtype=torch.int32),
-        CHUNK,
-        DEVICE,
-    )
+def _build(num_computed, query_lens):
+    return build_exact_replay_metadata(num_computed, query_lens, CHUNK, DEVICE)
 
 
 def test_decode_rows_mid_chunk_at_boundary_and_completing_chunk():
     # three decode rows: 300 computed (44 tokens into a chunk), exactly at a
     # boundary, and one token short of completing a chunk
-    m = _build([300, 512, 767], [1, 1, 1], [5, 6, 7])
+    m = _build([300, 512, 767], [1, 1, 1])
     assert m.num_aug_tokens == 44 + 1 + 1 + 255 + 1
     assert m.cu_seqlens.tolist() == [0, 45, 46, 302]
     # every augmented sequence is a single chunk
@@ -35,21 +29,21 @@ def test_decode_rows_mid_chunk_at_boundary_and_completing_chunk():
     # only the third row fills its chunk this step
     assert m.boundary_rows.tolist() == [2]
     assert m.boundary_chunk_idx.tolist() == [2]
-    # buffered tokens: 44 from slot 5, none from slot 6, 255 from slot 7
-    assert m.buffered_slot.tolist() == [5] * 44 + [7] * 255
+    # buffered tokens: 44 of row 0, none of row 1, 255 of row 2
+    assert m.buffered_seq.tolist() == [0] * 44 + [2] * 255
     assert m.buffered_pos.tolist() == list(range(44)) + list(range(255))
     assert m.buffered_dst.tolist() == list(range(44)) + list(range(46, 301))
     assert m.step_dst.tolist() == [44, 45, 301]
     # rows 0 and 1 append their token to the buffer; row 2 completed a chunk
     assert m.store_src.tolist() == [44, 45]
-    assert m.store_slot.tolist() == [5, 6]
+    assert m.store_seq.tolist() == [0, 1]
     assert m.store_pos.tolist() == [44, 0]
 
 
 def test_prefill_rows_fresh_and_resumed_at_unaligned_positions():
     # fresh 600-token prefill; resume at 300 with 213 tokens; resume at 100
     # with 413 tokens
-    m = _build([0, 300, 100], [600, 213, 413], [1, 2, 3])
+    m = _build([0, 300, 100], [600, 213, 413])
     assert m.num_aug_tokens == 600 + (44 + 213) + (100 + 413)
     assert m.cu_seqlens.tolist() == [0, 600, 857, 1370]
     assert m.cu_chunk_seqlens.tolist() == [0, 256, 512, 600, 856, 857, 1113, 1369, 1370]
@@ -63,12 +57,12 @@ def test_prefill_rows_fresh_and_resumed_at_unaligned_positions():
     assert m.boundary_rows.tolist() == [0, 1, 2]
     assert m.boundary_chunk_idx.tolist() == [1, 3, 6]
     # buffered tokens re-fed for rows 1 and 2
-    assert m.buffered_slot.tolist() == [2] * 44 + [3] * 100
+    assert m.buffered_seq.tolist() == [1] * 44 + [2] * 100
     assert m.buffered_dst.tolist() == list(range(600, 644)) + list(range(857, 957))
     # trailing partial chunks stored back: 88 tokens of row 0, 1 of row 1,
     # 1 of row 2, all at buffer positions starting from 0
     assert m.store_src.tolist() == list(range(512, 600)) + [856] + [1369]
-    assert m.store_slot.tolist() == [1] * 88 + [2] + [3]
+    assert m.store_seq.tolist() == [0] * 88 + [1] + [2]
     assert m.store_pos.tolist() == list(range(88)) + [0] + [0]
 
 
@@ -82,8 +76,7 @@ def test_augmented_layout_invariants(seed):
     for i in range(n):
         if torch.rand(1, generator=gen).item() < 0.5:
             query_lens[i] = 1
-    slots = torch.randperm(64, generator=gen)[:n].tolist()
-    m = _build(num_computed, query_lens, slots)
+    m = _build(num_computed, query_lens)
 
     # buffered and step destinations partition the augmented layout
     dst = torch.cat([m.buffered_dst, m.step_dst])
@@ -101,15 +94,17 @@ def test_augmented_layout_invariants(seed):
         assert m.last_chunk_indices.tolist()[i] == own[-1]
         # chunks of a sequence start at its start plus multiples of chunk_size
         assert all((chunks[c] - lo) % CHUNK == 0 for c in own)
-    # stored positions stay inside the buffer; every store goes to its own slot
+    # stored positions stay inside the buffer; every store goes to its own row
     assert (m.store_pos < CHUNK).all()
     assert (m.buffered_pos < CHUNK).all()
+    # the metadata names batch rows only, never state slots
+    assert (m.store_seq < n).all() and (m.buffered_seq < n).all()
     for i, (nc, q) in enumerate(zip(num_computed, query_lens)):
         n_pre = nc % CHUNK
         aug = n_pre + q
         if aug // CHUNK == 0:
             # nothing completed: this step's tokens are appended after n_pre
-            mask = m.store_slot == slots[i]
+            mask = m.store_seq == i
             assert m.store_pos[mask].tolist() == list(range(n_pre, aug))
         else:
             assert i in m.boundary_rows.tolist()

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -208,6 +208,17 @@ class CacheConfig:
     replayssm_buffer_len, but this is not required."""
     use_kda_recoverssm: bool = field(default=False, init=False)
     """Whether Kimi-K3 KDA uses RecoverSSM speculative decode."""
+    mamba_exact_replay: bool = False
+    """Mamba2 exact-replay mode. Every SSD call for a sequence (prefill, chunked
+    prefill or decode) starts from the fp32 SSM state at the sequence's last
+    chunk boundary and re-feeds the inputs (x, dt, B, C) of the current partial
+    chunk from a per-sequence buffer, so the chunk grid seen by the kernels is
+    the one of a single-shot prefill and the Mamba2 SSM computation produces
+    identical bits on every path. Bit-identical logits additionally need the
+    batch-invariant kernels for the other layers (VLLM_BATCH_INVARIANT=1).
+    Requires mamba_ssm_cache_dtype 'float32', mamba_cache_mode 'none'
+    (prefix caching disabled) and the Triton mamba backend; no speculative
+    decoding; mutually exclusive with use_replayssm. Experimental."""
 
     # Will be set after profiling.
     num_gpu_blocks: int | None = field(default=None, init=False)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1924,6 +1924,10 @@ class ModelConfig:
         return self._model_info.supports_replayssm
 
     @property
+    def supports_mamba_exact_replay(self) -> bool:
+        return self._model_info.supports_mamba_exact_replay
+
+    @property
     def use_mla(self) -> bool:
         if envs.VLLM_MLA_DISABLE:
             return False

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2974,6 +2974,72 @@ class VllmConfig:
             )
         return self
 
+    @model_validator(mode="after")
+    def validate_mamba_exact_replay(self) -> "VllmConfig":
+        if not self.cache_config.mamba_exact_replay:
+            return self
+        # Exact replay adds a 4-tensor partial-chunk buffer to the mamba state;
+        # only models that opt in build a consistent shape on both the layer and
+        # config paths. Reject others so the mamba page size cannot desync.
+        if (
+            self.model_config is not None
+            and not self.model_config.supports_mamba_exact_replay
+        ):
+            raise ValueError(
+                "--mamba-exact-replay is not supported for architecture "
+                f"{self.model_config.architecture!r}"
+            )
+        if self.cache_config.use_replayssm:
+            raise ValueError(
+                "--mamba-exact-replay and --use-replayssm are mutually exclusive"
+            )
+        if self.cache_config.mamba_ssm_cache_dtype != "float32":
+            raise ValueError(
+                "--mamba-exact-replay requires --mamba-ssm-cache-dtype float32: "
+                "the chunk-boundary state must round-trip losslessly for "
+                "replayed steps to reproduce single-shot prefill bits"
+            )
+        if self.cache_config.mamba_cache_mode != "none":
+            raise ValueError(
+                "--mamba-exact-replay does not support prefix caching yet; "
+                "pass --no-enable-prefix-caching"
+            )
+        if self.num_speculative_tokens > 0:
+            raise ValueError(
+                "--mamba-exact-replay does not support speculative decoding"
+            )
+        if self.mamba_config.backend != MambaBackendEnum.TRITON:
+            raise ValueError("--mamba-exact-replay requires --mamba-backend triton")
+        if (
+            self.parallel_config.tensor_parallel_size > 1
+            or self.parallel_config.pipeline_parallel_size > 1
+        ):
+            raise ValueError(
+                "--mamba-exact-replay currently supports TP=1 and PP=1 only"
+            )
+        if self.scheduler_config.async_scheduling:
+            raise ValueError(
+                "--mamba-exact-replay does not support async scheduling yet"
+            )
+        if self.parallel_config.use_ubatching:
+            # A request split across micro-batches keeps its original
+            # num_computed_tokens in the second slice and the two slices
+            # would read and write the same replay buffers concurrently.
+            raise ValueError(
+                "--mamba-exact-replay does not support DBO / micro-batching"
+            )
+        if self.model_config is not None and not self.model_config.enforce_eager:
+            raise ValueError(
+                "--mamba-exact-replay currently requires --enforce-eager "
+                "(CUDA graphs and torch.compile are not supported yet)"
+            )
+        if (
+            self.kv_transfer_config is not None
+            and self.kv_transfer_config.is_kv_transfer_instance
+        ):
+            raise ValueError("--mamba-exact-replay is incompatible with KV connectors")
+        return self
+
 
 _current_vllm_config: VllmConfig | None = None
 _current_prefix: str | None = None

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -727,6 +727,7 @@ class EngineArgs:
     mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
     replayssm_buffer_len: int = CacheConfig.replayssm_buffer_len
     use_replayssm: bool = CacheConfig.use_replayssm
+    mamba_exact_replay: bool = CacheConfig.mamba_exact_replay
 
     mamba_backend: MambaBackendEnum = MambaBackendEnum.TRITON
     mamba_ssu_algorithm: MambaSSUAlgorithm | None = None
@@ -1283,6 +1284,9 @@ class EngineArgs:
             "--replayssm-buffer-len", **cache_kwargs["replayssm_buffer_len"]
         )
         cache_group.add_argument("--use-replayssm", **cache_kwargs["use_replayssm"])
+        cache_group.add_argument(
+            "--mamba-exact-replay", **cache_kwargs["mamba_exact_replay"]
+        )
         cache_group.add_argument(
             "--kv-offloading-size", **cache_kwargs["kv_offloading_size"]
         )
@@ -2059,6 +2063,7 @@ class EngineArgs:
             mamba_cache_mode=self.mamba_cache_mode,
             replayssm_buffer_len=self.replayssm_buffer_len,
             use_replayssm=self.use_replayssm,
+            mamba_exact_replay=self.mamba_exact_replay,
             kv_offloading_size=self.kv_offloading_size,
             kv_offloading_backend=self.kv_offloading_backend,
         )

--- a/vllm/model_executor/layers/mamba/abstract.py
+++ b/vllm/model_executor/layers/mamba/abstract.py
@@ -87,4 +87,6 @@ class MambaBase(AttentionLayerBase):
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         """Get the attention backend class for this Mamba layer."""
-        return get_mamba_attn_backend(self.mamba_type)
+        return get_mamba_attn_backend(
+            self.mamba_type, getattr(self, "exact_replay", False)
+        )

--- a/vllm/model_executor/layers/mamba/exact_replay.py
+++ b/vllm/model_executor/layers/mamba/exact_replay.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mamba2 exact-replay mode: one SSD step that reproduces single-shot prefill.
+
+In exact-replay mode every SSD call for a sequence starts at the sequence's
+last chunk boundary. The fp32 state at that boundary lives in the regular SSM
+cache; the inputs of the partial chunk after it (x, raw dt, B, C) live in four
+per-slot buffers appended to the mamba state. Re-feeding those inputs in front
+of the current step's tokens makes the chunked-scan kernels see exactly the
+chunk grid of a single-shot prefill, so prefill, chunked prefill and decode
+produce identical bits.
+"""
+
+from typing import NamedTuple
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.ssd_combined import (
+    mamba_chunk_scan_combined_varlen,
+)
+
+
+class ExactReplayBuffers(NamedTuple):
+    """Per-slot partial-chunk input buffers, each ``(num_slots, chunk_size, ...)``.
+
+    The tensors are views into the paged mamba cache, so the slot dimension is
+    not contiguous with the position dimension: index them as ``buf[slot, pos]``
+    and never flatten the two leading dimensions.
+    """
+
+    x: torch.Tensor
+    """``(num_slots, chunk_size, nheads, head_dim)`` in the activation dtype."""
+    dt: torch.Tensor
+    """``(num_slots, chunk_size, nheads)``, raw dt before bias and softplus."""
+    B: torch.Tensor
+    """``(num_slots, chunk_size, ngroups, dstate)``."""
+    C: torch.Tensor
+    """``(num_slots, chunk_size, ngroups, dstate)``."""
+
+
+def exact_replay_ssd(
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    *,
+    A: torch.Tensor,
+    D: torch.Tensor,
+    dt_bias: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state: torch.Tensor,
+    slots: torch.Tensor,
+    meta,
+    chunk_size: int,
+    buffers: ExactReplayBuffers,
+) -> None:
+    """Run one exact-replay SSD step for a batch of sequences.
+
+    Works for prefill rows and decode rows alike. Every sequence is processed
+    from its last chunk boundary: the buffered inputs of its partial chunk are
+    re-fed first, followed by this step's tokens. Only this step's outputs are
+    written to ``out``; the boundary state in ``ssm_state`` is advanced only
+    for sequences that complete a chunk, and the inputs of the trailing partial
+    chunk are stored back into ``buffers``.
+
+    Args:
+        x: ``(num_tokens, nheads, head_dim)`` inputs of this step's tokens.
+        dt: ``(num_tokens, nheads)`` raw dt of this step's tokens.
+        B: ``(num_tokens, ngroups, dstate)``.
+        C: ``(num_tokens, ngroups, dstate)``.
+        A: ``(nheads,)`` fp32 per-head decay parameter.
+        D: ``(nheads,)`` skip-connection parameter.
+        dt_bias: ``(nheads,)`` dt bias (softplus is applied by the kernel).
+        out: ``(num_tokens, nheads, head_dim)`` preallocated output, written
+            in place.
+        ssm_state: the fp32 SSM cache, ``(num_slots, nheads, head_dim, dstate)``.
+        slots: ``(num_seqs,)`` state slot of each sequence, in batch order.
+        meta: an ``ExactReplayMetadata`` built for these sequences.
+        chunk_size: the model's SSD chunk size.
+        buffers: the partial-chunk input buffers.
+    """
+    nheads, head_dim = x.shape[1], x.shape[2]
+    ngroups, dstate = B.shape[1], B.shape[2]
+    n_aug = meta.num_aug_tokens
+    augmented = meta.buffered_slot.numel() > 0
+    if augmented:
+        x_aug = x.new_empty((n_aug, nheads, head_dim))
+        dt_aug = dt.new_empty((n_aug, nheads))
+        B_aug = B.new_empty((n_aug, ngroups, dstate))
+        C_aug = C.new_empty((n_aug, ngroups, dstate))
+        x_aug[meta.buffered_dst] = buffers.x[meta.buffered_slot, meta.buffered_pos]
+        dt_aug[meta.buffered_dst] = buffers.dt[meta.buffered_slot, meta.buffered_pos]
+        B_aug[meta.buffered_dst] = buffers.B[meta.buffered_slot, meta.buffered_pos]
+        C_aug[meta.buffered_dst] = buffers.C[meta.buffered_slot, meta.buffered_pos]
+        x_aug[meta.step_dst] = x
+        dt_aug[meta.step_dst] = dt
+        B_aug[meta.step_dst] = B
+        C_aug[meta.step_dst] = C
+        out_aug = torch.empty_like(x_aug)
+    else:
+        x_aug, dt_aug, B_aug, C_aug, out_aug = x, dt, B, C, out
+
+    initial_states = torch.where(
+        meta.has_boundary_state[:, None, None, None], ssm_state[slots], 0
+    )
+    states = mamba_chunk_scan_combined_varlen(
+        x_aug,
+        dt_aug,
+        A,
+        B_aug,
+        C_aug,
+        chunk_size=chunk_size,
+        D=D,
+        z=None,
+        dt_bias=dt_bias,
+        seq_idx=meta.seq_idx,
+        cu_seqlens=meta.cu_seqlens,
+        cu_chunk_seqlens=meta.cu_chunk_seqlens,
+        last_chunk_indices=meta.last_chunk_indices,
+        initial_states=initial_states,
+        return_intermediate_states=True,
+        dt_softplus=True,
+        dt_limit=(0.0, float("inf")),
+        out=out_aug,
+        state_dtype=ssm_state.dtype,
+    )
+    if augmented:
+        out.copy_(out_aug[meta.step_dst])
+    if meta.boundary_rows.numel() > 0:
+        ssm_state[slots[meta.boundary_rows]] = states[meta.boundary_chunk_idx]
+    if meta.store_src.numel() > 0:
+        buffers.x[meta.store_slot, meta.store_pos] = x_aug[meta.store_src]
+        buffers.dt[meta.store_slot, meta.store_pos] = dt_aug[meta.store_src]
+        buffers.B[meta.store_slot, meta.store_pos] = B_aug[meta.store_src]
+        buffers.C[meta.store_slot, meta.store_pos] = C_aug[meta.store_src]

--- a/vllm/model_executor/layers/mamba/exact_replay.py
+++ b/vllm/model_executor/layers/mamba/exact_replay.py
@@ -75,6 +75,8 @@ def exact_replay_ssd(
             in place.
         ssm_state: the fp32 SSM cache, ``(num_slots, nheads, head_dim, dstate)``.
         slots: ``(num_seqs,)`` state slot of each sequence, in batch order.
+            These are the calling layer's own state indices; the metadata
+            only refers to batch rows.
         meta: an ``ExactReplayMetadata`` built for these sequences.
         chunk_size: the model's SSD chunk size.
         buffers: the partial-chunk input buffers.
@@ -82,16 +84,18 @@ def exact_replay_ssd(
     nheads, head_dim = x.shape[1], x.shape[2]
     ngroups, dstate = B.shape[1], B.shape[2]
     n_aug = meta.num_aug_tokens
-    augmented = meta.buffered_slot.numel() > 0
+    slots64 = slots.to(torch.int64)
+    augmented = meta.buffered_seq.numel() > 0
     if augmented:
+        buffered_slot = slots64[meta.buffered_seq]
         x_aug = x.new_empty((n_aug, nheads, head_dim))
         dt_aug = dt.new_empty((n_aug, nheads))
         B_aug = B.new_empty((n_aug, ngroups, dstate))
         C_aug = C.new_empty((n_aug, ngroups, dstate))
-        x_aug[meta.buffered_dst] = buffers.x[meta.buffered_slot, meta.buffered_pos]
-        dt_aug[meta.buffered_dst] = buffers.dt[meta.buffered_slot, meta.buffered_pos]
-        B_aug[meta.buffered_dst] = buffers.B[meta.buffered_slot, meta.buffered_pos]
-        C_aug[meta.buffered_dst] = buffers.C[meta.buffered_slot, meta.buffered_pos]
+        x_aug[meta.buffered_dst] = buffers.x[buffered_slot, meta.buffered_pos]
+        dt_aug[meta.buffered_dst] = buffers.dt[buffered_slot, meta.buffered_pos]
+        B_aug[meta.buffered_dst] = buffers.B[buffered_slot, meta.buffered_pos]
+        C_aug[meta.buffered_dst] = buffers.C[buffered_slot, meta.buffered_pos]
         x_aug[meta.step_dst] = x
         dt_aug[meta.step_dst] = dt
         B_aug[meta.step_dst] = B
@@ -127,9 +131,10 @@ def exact_replay_ssd(
     if augmented:
         out.copy_(out_aug[meta.step_dst])
     if meta.boundary_rows.numel() > 0:
-        ssm_state[slots[meta.boundary_rows]] = states[meta.boundary_chunk_idx]
+        ssm_state[slots64[meta.boundary_rows]] = states[meta.boundary_chunk_idx]
     if meta.store_src.numel() > 0:
-        buffers.x[meta.store_slot, meta.store_pos] = x_aug[meta.store_src]
-        buffers.dt[meta.store_slot, meta.store_pos] = dt_aug[meta.store_src]
-        buffers.B[meta.store_slot, meta.store_pos] = B_aug[meta.store_src]
-        buffers.C[meta.store_slot, meta.store_pos] = C_aug[meta.store_src]
+        store_slot = slots64[meta.store_seq]
+        buffers.x[store_slot, meta.store_pos] = x_aug[meta.store_src]
+        buffers.dt[store_slot, meta.store_pos] = dt_aug[meta.store_src]
+        buffers.B[store_slot, meta.store_pos] = B_aug[meta.store_src]
+        buffers.C[store_slot, meta.store_pos] = C_aug[meta.store_src]

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -26,6 +26,10 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.exact_replay import (
+    ExactReplayBuffers,
+    exact_replay_ssd,
+)
 from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateDtypeCalculator,
     MambaStateShapeCalculator,
@@ -526,6 +530,22 @@ class MambaMixer2(MambaBase, PluggableLayer):
             )
         # ReplaySSM appends x/dt/B rings to (conv_state, ssm_state).
         _n_state = 5 if self.use_replayssm else 2
+        # Exact-replay mode appends the partial-chunk input buffers (x, dt, B, C).
+        self.exact_replay = (
+            cache_config.mamba_exact_replay if cache_config is not None else False
+        )
+        self.replay_chunk_size: int | None = None
+        if self.exact_replay:
+            if self.use_replayssm:
+                raise ValueError(
+                    "--mamba-exact-replay and --use-replayssm are mutually exclusive"
+                )
+            assert model_config is not None
+            self.replay_chunk_size = model_config.get_mamba_chunk_size()
+            assert self.replay_chunk_size is not None, (
+                "exact-replay mode needs chunk_size in the model config"
+            )
+            _n_state = 6
         self.kv_cache = tuple(torch.tensor([]) for _ in range(_n_state))
         self._replayssm_ring_start = torch.empty(0, dtype=torch.int32)
         self._replayssm_prev_num_accepted = torch.empty(0, dtype=torch.int32)
@@ -741,6 +761,13 @@ class MambaMixer2(MambaBase, PluggableLayer):
                     prev_num_accepted = self._replayssm_prev_num_accepted
             else:
                 x_cache = dt_cache = B_cache = None
+            if self.exact_replay:
+                replay_bufs = ExactReplayBuffers(*self.kv_cache[2:6])
+                exact_replay_p = attn_metadata.exact_replay_p
+                exact_replay_d = attn_metadata.exact_replay_d
+            else:
+                replay_bufs = None
+                exact_replay_p = exact_replay_d = None
             has_initial_states_p = attn_metadata.has_initial_states_p
             prep_initial_states = attn_metadata.prep_initial_states
             chunk_size = attn_metadata.chunk_size
@@ -869,7 +896,14 @@ class MambaMixer2(MambaBase, PluggableLayer):
 
             # 3. State Space Model sequence transformation
             initial_states = None
-            if has_initial_states_p is not None and prep_initial_states:
+            # Exact replay gathers its own boundary states inside
+            # exact_replay_ssd; skip the baseline gather to avoid a second
+            # (num_prefills, nheads, headdim, dstate) temporary.
+            if (
+                has_initial_states_p is not None
+                and prep_initial_states
+                and not self.exact_replay
+            ):
                 assert state_indices_tensor_p is not None
                 kernel_ssm_indices = state_indices_tensor_p
                 if is_mamba_cache_all:
@@ -882,128 +916,161 @@ class MambaMixer2(MambaBase, PluggableLayer):
                     0,
                 )
 
-            # NOTE: final output is an in-place update of out tensor
-            assert preallocated_ssm_out_p is not None
-            varlen_states = mamba_chunk_scan_combined_varlen(
-                hidden_states_p.view(
-                    num_prefill_tokens, self.num_heads // self.tp_size, self.head_dim
-                ),
-                dt_p,
-                self.A,
-                B_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
-                C_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
-                chunk_size=chunk_size,
-                D=self.D,
-                z=None,
-                dt_bias=self.dt_bias,
-                seq_idx=seq_idx_p,
-                cu_seqlens=query_start_loc_p,
-                cu_chunk_seqlens=cu_chunk_seqlen_p,
-                last_chunk_indices=last_chunk_indices_p,
-                initial_states=initial_states,
-                return_intermediate_states=is_mamba_cache_all,
-                dt_softplus=True,
-                dt_limit=(0.0, float("inf")),
-                out=preallocated_ssm_out_p.view(num_prefill_tokens, -1, self.head_dim),
-                state_dtype=ssm_state.dtype,
-            )
-
-            if is_mamba_cache_all:
-                assert mamba_block_size is not None
+            if self.exact_replay:
+                # Exact replay: start every sequence at its last chunk boundary.
+                assert exact_replay_p is not None
+                assert preallocated_ssm_out_p is not None
                 assert state_indices_tensor_p is not None
-                assert block_idx_first_scheduled_token_p is not None
-                assert block_idx_last_scheduled_token_p is not None
-                assert last_chunk_indices_p is not None
-                assert num_computed_tokens_p is not None
+                assert replay_bufs is not None
+                exact_replay_ssd(
+                    hidden_states_p.view(
+                        num_prefill_tokens,
+                        self.num_heads // self.tp_size,
+                        self.head_dim,
+                    ),
+                    dt_p,
+                    B_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
+                    C_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
+                    A=self.A,
+                    D=self.D,
+                    dt_bias=self.dt_bias,
+                    out=preallocated_ssm_out_p.view(
+                        num_prefill_tokens, -1, self.head_dim
+                    ),
+                    ssm_state=ssm_state,
+                    slots=state_indices_tensor_p,
+                    meta=exact_replay_p,
+                    chunk_size=chunk_size,
+                    buffers=replay_bufs,
+                )
+            else:
+                # NOTE: final output is an in-place update of out tensor
+                assert preallocated_ssm_out_p is not None
+                varlen_states = mamba_chunk_scan_combined_varlen(
+                    hidden_states_p.view(
+                        num_prefill_tokens,
+                        self.num_heads // self.tp_size,
+                        self.head_dim,
+                    ),
+                    dt_p,
+                    self.A,
+                    B_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
+                    C_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
+                    chunk_size=chunk_size,
+                    D=self.D,
+                    z=None,
+                    dt_bias=self.dt_bias,
+                    seq_idx=seq_idx_p,
+                    cu_seqlens=query_start_loc_p,
+                    cu_chunk_seqlens=cu_chunk_seqlen_p,
+                    last_chunk_indices=last_chunk_indices_p,
+                    initial_states=initial_states,
+                    return_intermediate_states=is_mamba_cache_all,
+                    dt_softplus=True,
+                    dt_limit=(0.0, float("inf")),
+                    out=preallocated_ssm_out_p.view(
+                        num_prefill_tokens, -1, self.head_dim
+                    ),
+                    state_dtype=ssm_state.dtype,
+                )
 
-                # The chunk_stride is the number of chunks per mamba block
-                # e.g., if mamba_block_size = 512 and chunk_size = 256,
-                # then chunk_stride = 2
-                chunk_stride = mamba_block_size // chunk_size
+                if is_mamba_cache_all:
+                    assert mamba_block_size is not None
+                    assert state_indices_tensor_p is not None
+                    assert block_idx_first_scheduled_token_p is not None
+                    assert block_idx_last_scheduled_token_p is not None
+                    assert last_chunk_indices_p is not None
+                    assert num_computed_tokens_p is not None
 
-                # The per-sequence loop below uses these as Python scalars.
-                # TODO avoid sync here?
-                with gpu_sync_allowed():
-                    block_idx_first_cpu = block_idx_first_scheduled_token_p.tolist()
-                    block_idx_last_cpu = block_idx_last_scheduled_token_p.tolist()
-                    num_computed_tokens_p_cpu = num_computed_tokens_p.tolist()
-                    last_chunk_indices_p_cpu = last_chunk_indices_p.tolist()
+                    # The chunk_stride is the number of chunks per mamba block
+                    # e.g., if mamba_block_size = 512 and chunk_size = 256,
+                    # then chunk_stride = 2
+                    chunk_stride = mamba_block_size // chunk_size
 
-                # Save state for sequences with more than just final state
-                for seq_idx in range(num_prefills):
-                    # Block index for the first scheduled token
-                    block_idx_first_scheduled_token = block_idx_first_cpu[seq_idx]
+                    # The per-sequence loop below uses these as Python scalars.
+                    # TODO avoid sync here?
+                    with gpu_sync_allowed():
+                        block_idx_first_cpu = block_idx_first_scheduled_token_p.tolist()
+                        block_idx_last_cpu = block_idx_last_scheduled_token_p.tolist()
+                        num_computed_tokens_p_cpu = num_computed_tokens_p.tolist()
+                        last_chunk_indices_p_cpu = last_chunk_indices_p.tolist()
 
-                    # Block index for the last scheduled token
-                    block_idx_last_scheduled_token = block_idx_last_cpu[seq_idx]
+                    # Save state for sequences with more than just final state
+                    for seq_idx in range(num_prefills):
+                        # Block index for the first scheduled token
+                        block_idx_first_scheduled_token = block_idx_first_cpu[seq_idx]
 
-                    # Number of blocks that need to be written
-                    n_blocks_to_fill = (
-                        block_idx_last_scheduled_token - block_idx_first_scheduled_token
-                    )
+                        # Block index for the last scheduled token
+                        block_idx_last_scheduled_token = block_idx_last_cpu[seq_idx]
 
-                    # Skip sequences that don't have any blocks to fill
-                    if n_blocks_to_fill == 0:
-                        continue
-
-                    # Look up the state indices
-                    cache_blocks_to_fill = state_indices_tensor_p[
-                        seq_idx,
-                        block_idx_first_scheduled_token:block_idx_last_scheduled_token,
-                    ]
-
-                    # First chunk index for this sequence
-                    if seq_idx == 0:
-                        first_chunk = 0
-                    else:
-                        first_chunk = 1 + last_chunk_indices_p_cpu[seq_idx - 1]
-
-                    # First chunk that is aligned on the mamba block boundary
-                    first_aligned_chunk = first_chunk + chunk_stride - 1
-
-                    # Calculate the number of computed tokens that were not
-                    # already cached
-                    num_unaligned_computed_tokens = (
-                        num_computed_tokens_p_cpu[seq_idx] % mamba_block_size
-                    )
-
-                    if num_unaligned_computed_tokens > 0:
-                        # If the number of computed tokens is not block aligned,
-                        # then we need to shift the index accordingly
-                        first_aligned_chunk -= (
-                            num_unaligned_computed_tokens // chunk_size
+                        # Number of blocks that need to be written
+                        n_blocks_to_fill = (
+                            block_idx_last_scheduled_token
+                            - block_idx_first_scheduled_token
                         )
 
-                    # Get states to write
-                    from_where = varlen_states[
-                        first_aligned_chunk : first_aligned_chunk
-                        + n_blocks_to_fill * chunk_stride : chunk_stride
-                    ]
+                        # Skip sequences that don't have any blocks to fill
+                        if n_blocks_to_fill == 0:
+                            continue
 
-                    # Write the states
-                    ssm_state[cache_blocks_to_fill] = from_where
+                        # Look up the state indices
+                        cache_blocks_to_fill = state_indices_tensor_p[
+                            seq_idx,
+                            block_idx_first_scheduled_token:block_idx_last_scheduled_token,
+                        ]
 
-                # For all seqs, store the last state (note: might be partial):
-                assert state_indices_tensor_p is not None
-                ssm_state[
-                    state_indices_tensor_p.gather(
-                        1, block_idx_last_scheduled_token_p.unsqueeze(1)
-                    ).squeeze(1)
-                ] = varlen_states[last_chunk_indices_p]
+                        # First chunk index for this sequence
+                        if seq_idx == 0:
+                            first_chunk = 0
+                        else:
+                            first_chunk = 1 + last_chunk_indices_p_cpu[seq_idx - 1]
 
-            else:
-                # update ssm states
-                # - varlen state is a (num_prefills, nheads, headdim, dstate)
-                #   tensor
-                assert state_indices_tensor_p is not None
-                ssm_state[state_indices_tensor_p] = varlen_states
-                if ring_start is not None and self._updates_replayssm_trackers:
-                    assert prev_num_accepted is not None
-                    reset_replayssm_ring_trackers(
-                        ring_start,
-                        prev_num_accepted,
-                        state_indices_tensor_p,
-                    )
+                        # First chunk that is aligned on the mamba block boundary
+                        first_aligned_chunk = first_chunk + chunk_stride - 1
+
+                        # Calculate the number of computed tokens that were not
+                        # already cached
+                        num_unaligned_computed_tokens = (
+                            num_computed_tokens_p_cpu[seq_idx] % mamba_block_size
+                        )
+
+                        if num_unaligned_computed_tokens > 0:
+                            # If the number of computed tokens is not block aligned,
+                            # then we need to shift the index accordingly
+                            first_aligned_chunk -= (
+                                num_unaligned_computed_tokens // chunk_size
+                            )
+
+                        # Get states to write
+                        from_where = varlen_states[
+                            first_aligned_chunk : first_aligned_chunk
+                            + n_blocks_to_fill * chunk_stride : chunk_stride
+                        ]
+
+                        # Write the states
+                        ssm_state[cache_blocks_to_fill] = from_where
+
+                    # For all seqs, store the last state (note: might be partial):
+                    assert state_indices_tensor_p is not None
+                    ssm_state[
+                        state_indices_tensor_p.gather(
+                            1, block_idx_last_scheduled_token_p.unsqueeze(1)
+                        ).squeeze(1)
+                    ] = varlen_states[last_chunk_indices_p]
+
+                else:
+                    # update ssm states
+                    # - varlen state is a (num_prefills, nheads, headdim, dstate)
+                    #   tensor
+                    assert state_indices_tensor_p is not None
+                    ssm_state[state_indices_tensor_p] = varlen_states
+                    if ring_start is not None and self._updates_replayssm_trackers:
+                        assert prev_num_accepted is not None
+                        reset_replayssm_ring_trackers(
+                            ring_start,
+                            prev_num_accepted,
+                            state_indices_tensor_p,
+                        )
 
         # Process decode requests
         if has_decode:
@@ -1056,65 +1123,120 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 hidden_states_B_C_d
             )
 
-            # 3. State Space Model sequence transformation
-            n_groups = self.n_groups // self.tp_size
-            A_d = (
-                self.A[:, None, ...][:, :, None]
-                .expand(-1, self.head_dim, self.ssm_state_size)
-                .to(dtype=torch.float32)
-            )
-            dt_d = dt_d[:, :, None].expand(-1, -1, self.head_dim)
-            dt_bias = self.dt_bias[:, None, ...].expand(-1, self.head_dim)
-            D_d = self.D[:, None, ...].expand(-1, self.head_dim)
-            B_d = B_d.view(-1, n_groups, B_d.shape[1] // n_groups)
-            C_d = C_d.view(-1, n_groups, C_d.shape[1] // n_groups)
-            hidden_states_d = hidden_states_d.view(
-                -1, self.num_heads // self.tp_size, self.head_dim
-            )
+            if self.exact_replay:
+                assert exact_replay_d is not None
+                assert preallocated_ssm_out_d is not None
+                assert replay_bufs is not None
+                n_groups = self.n_groups // self.tp_size
+                slots_d = state_indices_tensor_d_input
+                if slots_d.dim() == 2:
+                    slots_d = slots_d[:, 0]
+                exact_replay_ssd(
+                    hidden_states_d.view(
+                        -1, self.num_heads // self.tp_size, self.head_dim
+                    ),
+                    dt_d,
+                    B_d.view(-1, n_groups, B_d.shape[1] // n_groups),
+                    C_d.view(-1, n_groups, C_d.shape[1] // n_groups),
+                    A=self.A,
+                    D=self.D,
+                    dt_bias=self.dt_bias,
+                    out=preallocated_ssm_out_d.view(
+                        num_decode_tokens, -1, self.head_dim
+                    ),
+                    ssm_state=ssm_state,
+                    slots=slots_d,
+                    meta=exact_replay_d,
+                    chunk_size=chunk_size,
+                    buffers=replay_bufs,
+                )
+            else:
+                # 3. State Space Model sequence transformation
+                n_groups = self.n_groups // self.tp_size
+                A_d = (
+                    self.A[:, None, ...][:, :, None]
+                    .expand(-1, self.head_dim, self.ssm_state_size)
+                    .to(dtype=torch.float32)
+                )
+                dt_d = dt_d[:, :, None].expand(-1, -1, self.head_dim)
+                dt_bias = self.dt_bias[:, None, ...].expand(-1, self.head_dim)
+                D_d = self.D[:, None, ...].expand(-1, self.head_dim)
+                B_d = B_d.view(-1, n_groups, B_d.shape[1] // n_groups)
+                C_d = C_d.view(-1, n_groups, C_d.shape[1] // n_groups)
+                hidden_states_d = hidden_states_d.view(
+                    -1, self.num_heads // self.tp_size, self.head_dim
+                )
 
-            assert preallocated_ssm_out_d is not None
-            # - the hidden is reshaped into (bs, num_heads, head_dim)
-            # - mamba_cache_params.ssm_state's slots will be selected
-            #   using state_indices_tensor_d
-            # NOTE: final output is an in-place update of out tensor
-            preallocated_ssm_out_d = preallocated_ssm_out_d.view(
-                num_decode_tokens, -1, self.head_dim
-            )
-            if self.use_replayssm:
-                assert self.replayssm_buffer_len is not None
-                if self.mamba_config.backend == MambaBackendEnum.FLASHINFER:
-                    assert ring_start is not None
-                    assert prev_num_accepted is not None
-                    assert attn_metadata.replayssm_scratch is not None
-                    selective_state_update_replayssm_flashinfer(
-                        ssm_state,
-                        hidden_states_d,
-                        dt_d,
-                        A_d,
-                        B_d,
-                        C_d,
-                        preallocated_ssm_out_d,
-                        x_cache,
-                        B_cache,
-                        dt_cache,
-                        ring_start,
-                        prev_num_accepted,
-                        logical_window=self.replayssm_buffer_len,
-                        D=D_d,
-                        dt_bias=dt_bias,
-                        dt_softplus=True,
-                        state_batch_indices=state_indices_tensor_d_input,
-                        scratch=attn_metadata.replayssm_scratch,
-                        update_trackers=self._updates_replayssm_trackers,
-                        enable_stochastic_rounding=(
-                            self.mamba_config.enable_stochastic_rounding
-                        ),
-                        stochastic_rounding_philox_rounds=(
-                            self.mamba_config.stochastic_rounding_philox_rounds
-                        ),
-                    )
+                assert preallocated_ssm_out_d is not None
+                # - the hidden is reshaped into (bs, num_heads, head_dim)
+                # - mamba_cache_params.ssm_state's slots will be selected
+                #   using state_indices_tensor_d
+                # NOTE: final output is an in-place update of out tensor
+                preallocated_ssm_out_d = preallocated_ssm_out_d.view(
+                    num_decode_tokens, -1, self.head_dim
+                )
+                if self.use_replayssm:
+                    assert self.replayssm_buffer_len is not None
+                    if self.mamba_config.backend == MambaBackendEnum.FLASHINFER:
+                        assert ring_start is not None
+                        assert prev_num_accepted is not None
+                        assert attn_metadata.replayssm_scratch is not None
+                        selective_state_update_replayssm_flashinfer(
+                            ssm_state,
+                            hidden_states_d,
+                            dt_d,
+                            A_d,
+                            B_d,
+                            C_d,
+                            preallocated_ssm_out_d,
+                            x_cache,
+                            B_cache,
+                            dt_cache,
+                            ring_start,
+                            prev_num_accepted,
+                            logical_window=self.replayssm_buffer_len,
+                            D=D_d,
+                            dt_bias=dt_bias,
+                            dt_softplus=True,
+                            state_batch_indices=state_indices_tensor_d_input,
+                            scratch=attn_metadata.replayssm_scratch,
+                            update_trackers=self._updates_replayssm_trackers,
+                            enable_stochastic_rounding=(
+                                self.mamba_config.enable_stochastic_rounding
+                            ),
+                            stochastic_rounding_philox_rounds=(
+                                self.mamba_config.stochastic_rounding_philox_rounds
+                            ),
+                        )
+                    else:
+                        selective_state_update_replayssm_output_only(
+                            ssm_state,
+                            hidden_states_d,
+                            dt_d,
+                            A_d,
+                            B_d,
+                            C_d,
+                            D_d,
+                            dt_bias,
+                            dt_softplus=True,
+                            x_cache=x_cache,
+                            dt_cache=dt_cache,
+                            B_cache=B_cache,
+                            bc_pre=attn_metadata.bc_pre_scratch,
+                            write_pos=attn_metadata.write_pos_d,
+                            is_flush=attn_metadata.is_flush_d,
+                            max_cache_len=self.replayssm_buffer_len,
+                            state_batch_indices=state_indices_tensor_d_input,
+                            out=preallocated_ssm_out_d,
+                            enable_stochastic_rounding=(
+                                self.mamba_config.enable_stochastic_rounding
+                            ),
+                            cache_philox_rounds=(
+                                self.mamba_config.stochastic_rounding_philox_rounds
+                            ),
+                        )
                 else:
-                    selective_state_update_replayssm_output_only(
+                    selective_state_update(
                         ssm_state,
                         hidden_states_d,
                         dt_d,
@@ -1124,40 +1246,13 @@ class MambaMixer2(MambaBase, PluggableLayer):
                         D_d,
                         dt_bias,
                         dt_softplus=True,
-                        x_cache=x_cache,
-                        dt_cache=dt_cache,
-                        B_cache=B_cache,
-                        bc_pre=attn_metadata.bc_pre_scratch,
-                        write_pos=attn_metadata.write_pos_d,
-                        is_flush=attn_metadata.is_flush_d,
-                        max_cache_len=self.replayssm_buffer_len,
                         state_batch_indices=state_indices_tensor_d_input,
+                        dst_state_batch_indices=state_indices_tensor_d_output,
                         out=preallocated_ssm_out_d,
-                        enable_stochastic_rounding=(
-                            self.mamba_config.enable_stochastic_rounding
-                        ),
-                        cache_philox_rounds=(
-                            self.mamba_config.stochastic_rounding_philox_rounds
-                        ),
+                        num_accepted_tokens=num_accepted_tokens,
+                        cu_seqlens=query_start_loc_d,
+                        is_blackwell=self.is_blackwell,
                     )
-            else:
-                selective_state_update(
-                    ssm_state,
-                    hidden_states_d,
-                    dt_d,
-                    A_d,
-                    B_d,
-                    C_d,
-                    D_d,
-                    dt_bias,
-                    dt_softplus=True,
-                    state_batch_indices=state_indices_tensor_d_input,
-                    dst_state_batch_indices=state_indices_tensor_d_output,
-                    out=preallocated_ssm_out_d,
-                    num_accepted_tokens=num_accepted_tokens,
-                    cu_seqlens=query_start_loc_d,
-                    is_blackwell=self.is_blackwell,
-                )
 
     def get_state_dtype(self) -> tuple[torch.dtype, ...]:
         assert self.model_config is not None
@@ -1167,6 +1262,10 @@ class MambaMixer2(MambaBase, PluggableLayer):
             self.cache_config.mamba_cache_dtype,
             self.cache_config.mamba_ssm_cache_dtype,
         )
+        if self.exact_replay:
+            return MambaStateDtypeCalculator.append_exact_replay_buffers(
+                base_dtype, self.model_config.dtype
+            )
         if self.use_replayssm:
             return MambaStateDtypeCalculator.append_replayssm_ring(
                 base_dtype, self.model_config.dtype
@@ -1185,6 +1284,14 @@ class MambaMixer2(MambaBase, PluggableLayer):
             conv_kernel=self.conv_kernel_size,
             num_spec=self.num_spec,
         )
+        if self.exact_replay:
+            assert self.replay_chunk_size is not None
+            return MambaStateShapeCalculator.append_exact_replay_buffers(
+                base_shape,
+                self.n_groups,
+                tp_world_size,
+                self.replay_chunk_size,
+            )
         if self.use_replayssm:
             assert self.replayssm_buffer_len is not None
             return MambaStateShapeCalculator.append_replayssm_ring(

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -95,6 +95,19 @@ class MambaStateDtypeCalculator:
         return (*base_dtypes, activation_dtype, torch.float32, activation_dtype)
 
     @classmethod
+    def append_exact_replay_buffers(
+        cls,
+        base_dtypes: tuple[torch.dtype, ...],
+        model_dtype: ModelDType | torch.dtype,
+    ) -> tuple[torch.dtype, ...]:
+        """Append the exact-replay partial-chunk buffer dtypes to a base
+        ``(conv, ssm)`` tuple: ``(x, dt, B, C)``, all in the activation dtype.
+        dt is stored raw (before bias and softplus), as the SSD kernels expect.
+        """
+        activation_dtype = get_kv_cache_torch_dtype("auto", model_dtype)
+        return (*base_dtypes, *([activation_dtype] * 4))
+
+    @classmethod
     def _mamba_state_dtype(
         cls,
         model_dtype: ModelDType | torch.dtype,
@@ -234,6 +247,28 @@ class MambaStateShapeCalculator:
             (local_nheads, ring_buffer_len, head_dim),
             (local_nheads, ring_buffer_len),
             (local_ngroups, ring_buffer_len, state_size),
+        )
+
+    @classmethod
+    def append_exact_replay_buffers(
+        cls,
+        base_shapes: tuple[tuple[int, ...], ...],
+        n_groups: int,
+        tp_world_size: int,
+        chunk_size: int,
+    ) -> tuple[tuple[int, ...], ...]:
+        """Append the exact-replay partial-chunk buffer shapes ``(x, dt, B, C)``
+        to a base ``(conv, ssm)`` tuple. Buffers are token-major so that a prefix
+        of one slot's buffer is directly in the SSD kernels' varlen layout.
+        """
+        local_nheads, head_dim, state_size = base_shapes[1]
+        local_ngroups = divide(n_groups, tp_world_size)
+        return (
+            *base_shapes,
+            (chunk_size, local_nheads, head_dim),
+            (chunk_size, local_nheads),
+            (chunk_size, local_ngroups, state_size),
+            (chunk_size, local_ngroups, state_size),
         )
 
     @classmethod

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -252,11 +252,18 @@ class MambaStateShapeCalculator:
     @classmethod
     def append_exact_replay_buffers(
         cls,
-        base_shapes: tuple[tuple[int, ...], ...],
+        base_shapes: tuple[tuple[int, int], tuple[int, int, int]],
         n_groups: int,
         tp_world_size: int,
         chunk_size: int,
-    ) -> tuple[tuple[int, ...], ...]:
+    ) -> tuple[
+        tuple[int, int],
+        tuple[int, int, int],
+        tuple[int, int, int],
+        tuple[int, int],
+        tuple[int, int, int],
+        tuple[int, int, int],
+    ]:
         """Append the exact-replay partial-chunk buffer shapes ``(x, dt, B, C)``
         to a base ``(conv, ssm)`` tuple. Buffers are token-major so that a prefix
         of one slot's buffer is directly in the SSD kernels' varlen layout.

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -41,7 +41,9 @@ from .granitemoeshared import GraniteMoeSharedMLP
 from .interfaces import (
     HasInnerState,
     IsHybrid,
+    MambaStateShapes,
     SupportsLoRA,
+    SupportsMambaExactReplay,
     SupportsMambaPrefixCaching,
     SupportsPP,
     SupportsQuant,
@@ -592,6 +594,7 @@ class GraniteMoeHybridForCausalLM(
     IsHybrid,
     SupportsQuant,
     SupportsMambaPrefixCaching,
+    SupportsMambaExactReplay,
 ):
     packed_modules_mapping: dict[str, list[str]] = {
         "qkv_proj": [
@@ -612,18 +615,23 @@ class GraniteMoeHybridForCausalLM(
     def get_mamba_state_dtype_from_config(
         cls,
         vllm_config: "VllmConfig",
-    ) -> tuple[torch.dtype, torch.dtype]:
-        return MambaStateDtypeCalculator.mamba2_state_dtype(
+    ) -> tuple[torch.dtype, ...]:
+        base_dtypes = MambaStateDtypeCalculator.mamba2_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
             vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
+        if vllm_config.cache_config.mamba_exact_replay:
+            return MambaStateDtypeCalculator.append_exact_replay_buffers(
+                base_dtypes, vllm_config.model_config.dtype
+            )
+        return base_dtypes
 
     @classmethod
     def get_mamba_state_shape_from_config(
         cls,
         vllm_config: "VllmConfig",
-    ) -> tuple[tuple[int, int], tuple[int, int, int]]:
+    ) -> MambaStateShapes:
         """Calculate shapes for Mamba's convolutional and state caches.
 
         Args:
@@ -638,7 +646,7 @@ class GraniteMoeHybridForCausalLM(
         hf_config = vllm_config.model_config.hf_config
         intermediate_size = hf_config.mamba_expand * hf_config.hidden_size
 
-        return MambaStateShapeCalculator.mamba2_state_shape(
+        base_shapes = MambaStateShapeCalculator.mamba2_state_shape(
             intermediate_size=intermediate_size,
             tp_world_size=parallel_config.tensor_parallel_size,
             n_groups=hf_config.mamba_n_groups,
@@ -647,6 +655,16 @@ class GraniteMoeHybridForCausalLM(
             state_size=hf_config.mamba_d_state,
             conv_kernel=hf_config.mamba_d_conv,
         )
+        if vllm_config.cache_config.mamba_exact_replay:
+            chunk_size = vllm_config.model_config.get_mamba_chunk_size()
+            assert chunk_size is not None
+            return MambaStateShapeCalculator.append_exact_replay_buffers(
+                base_shapes,
+                hf_config.mamba_n_groups,
+                parallel_config.tensor_parallel_size,
+                chunk_size,
+            )
+        return base_shapes
 
     @classmethod
     def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1203,6 +1203,35 @@ def supports_replayssm(
 
 
 @runtime_checkable
+class SupportsMambaExactReplay(Protocol):
+    """The interface for models whose Mamba2 layers support exact-replay mode
+    (bit-identical prefill, chunked prefill and decode).
+
+    This is currently experimental.
+    """
+
+    supports_mamba_exact_replay: ClassVar[Literal[True]] = True
+
+
+@overload
+def supports_mamba_exact_replay(
+    model: type[object],
+) -> TypeIs[type[SupportsMambaExactReplay]]: ...
+
+
+@overload
+def supports_mamba_exact_replay(
+    model: object,
+) -> TypeIs[SupportsMambaExactReplay]: ...
+
+
+def supports_mamba_exact_replay(
+    model: type[object] | object,
+) -> TypeIs[type[SupportsMambaExactReplay]] | TypeIs[SupportsMambaExactReplay]:
+    return getattr(model, "supports_mamba_exact_replay", False)
+
+
+@runtime_checkable
 class SupportsCrossEncoding(Protocol):
     """The interface required for all models that support cross encoding."""
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -90,6 +90,16 @@ MambaStateShapes: TypeAlias = (
         tuple[int, int, int],
         tuple[int, int, int],
     ]
+    # Mamba2 exact replay: (conv, ssm) plus the partial-chunk buffers
+    # (x, dt, B, C), see MambaStateShapeCalculator.append_exact_replay_buffers.
+    | tuple[
+        tuple[int, int],
+        tuple[int, int, int],
+        tuple[int, int, int],
+        tuple[int, int],
+        tuple[int, int, int],
+        tuple[int, int, int],
+    ]
 )
 
 

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.models.interfaces import (
     HasInnerState,
     IsAttentionFree,
+    MambaStateShapes,
     SupportsMambaExactReplay,
     SupportsMambaPrefixCaching,
 )
@@ -197,7 +198,7 @@ class Mamba2ForCausalLM(
     def get_mamba_state_shape_from_config(
         cls,
         vllm_config: "VllmConfig",
-    ) -> tuple[tuple[int, ...], ...]:
+    ) -> MambaStateShapes:
         """Calculate shapes for Mamba's convolutional and state caches.
 
         Args:

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.models.interfaces import (
     HasInnerState,
     IsAttentionFree,
+    SupportsMambaExactReplay,
     SupportsMambaPrefixCaching,
 )
 from vllm.sequence import IntermediateTensors
@@ -168,7 +169,11 @@ class Mamba2Model(nn.Module):
 
 
 class Mamba2ForCausalLM(
-    nn.Module, HasInnerState, IsAttentionFree, SupportsMambaPrefixCaching
+    nn.Module,
+    HasInnerState,
+    IsAttentionFree,
+    SupportsMambaPrefixCaching,
+    SupportsMambaExactReplay,
 ):
     hf_to_vllm_mapper = WeightsMapper(orig_to_new_substr={".A_log": ".A"})
 
@@ -176,18 +181,23 @@ class Mamba2ForCausalLM(
     def get_mamba_state_dtype_from_config(
         cls,
         vllm_config: "VllmConfig",
-    ) -> tuple[torch.dtype, torch.dtype]:
-        return MambaStateDtypeCalculator.mamba2_state_dtype(
+    ) -> tuple[torch.dtype, ...]:
+        base_dtypes = MambaStateDtypeCalculator.mamba2_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
             vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
+        if vllm_config.cache_config.mamba_exact_replay:
+            return MambaStateDtypeCalculator.append_exact_replay_buffers(
+                base_dtypes, vllm_config.model_config.dtype
+            )
+        return base_dtypes
 
     @classmethod
     def get_mamba_state_shape_from_config(
         cls,
         vllm_config: "VllmConfig",
-    ) -> tuple[tuple[int, int], tuple[int, int, int]]:
+    ) -> tuple[tuple[int, ...], ...]:
         """Calculate shapes for Mamba's convolutional and state caches.
 
         Args:
@@ -197,12 +207,15 @@ class Mamba2ForCausalLM(
             Tuple containing:
             - conv_state_shape: Shape for convolutional state cache
             - temporal_state_shape: Shape for state space model cache
+            - with mamba_exact_replay: four partial-chunk buffer shapes
+              (x, dt, B, C) appended, see
+              MambaStateShapeCalculator.append_exact_replay_buffers
         """
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_config
         intermediate_size = hf_config.expand * hf_config.hidden_size
 
-        return MambaStateShapeCalculator.mamba2_state_shape(
+        base_shapes = MambaStateShapeCalculator.mamba2_state_shape(
             intermediate_size=intermediate_size,
             tp_world_size=parallel_config.tensor_parallel_size,
             n_groups=hf_config.n_groups,
@@ -212,6 +225,18 @@ class Mamba2ForCausalLM(
             conv_kernel=hf_config.conv_kernel,
             num_spec=vllm_config.num_speculative_tokens,
         )
+        if vllm_config.cache_config.mamba_exact_replay:
+            # Same resolver as the layer and the metadata builder, so the
+            # page size computed here cannot diverge from the allocation.
+            chunk_size = vllm_config.model_config.get_mamba_chunk_size()
+            assert chunk_size is not None
+            return MambaStateShapeCalculator.append_exact_replay_buffers(
+                base_shapes,
+                hf_config.n_groups,
+                parallel_config.tensor_parallel_size,
+                chunk_size,
+            )
+        return base_shapes
 
     @classmethod
     def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -50,6 +50,7 @@ from .interfaces import (
     is_attention_free,
     is_hybrid,
     requires_raw_input_tokens,
+    supports_mamba_exact_replay,
     supports_mamba_prefix_caching,
     supports_multimodal,
     supports_multimodal_encoder_tp_data,
@@ -855,6 +856,7 @@ class _ModelInfo:
     is_hybrid: bool
     has_noops: bool
     supports_mamba_prefix_caching: bool
+    supports_mamba_exact_replay: bool
     supports_replayssm: bool
     supports_transcription: bool
     supports_transcription_only: bool
@@ -884,6 +886,7 @@ class _ModelInfo:
             is_attention_free=is_attention_free(model),
             is_hybrid=is_hybrid(model),
             supports_mamba_prefix_caching=supports_mamba_prefix_caching(model),
+            supports_mamba_exact_replay=supports_mamba_exact_replay(model),
             supports_replayssm=supports_replayssm(model),
             supports_transcription=supports_transcription(model),
             supports_transcription_only=(

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, ClassVar
 
 import torch
 
@@ -101,6 +101,161 @@ class Mamba2AttentionBackend(AttentionBackend):
     def is_ssm(cls) -> bool:
         return True
 
+    # Batch-invariant mode is only sound for Mamba2 layers when prefill, chunked
+    # prefill and decode produce the same bits. The plain SSD/SSU pair does not
+    # (supports_batch_invariance() stays False); exact-replay mode does, so the
+    # mamba backend selector accepts this backend when that cache option is on.
+    supports_batch_invariance_with_exact_replay: ClassVar[bool] = True
+
+
+@dataclass
+class ExactReplayMetadata:
+    """Per-step metadata for Mamba2 exact-replay mode.
+
+    One instance describes the prefill rows of a step, another the decode
+    rows. Every sequence is re-expanded to an *augmented* sequence that starts
+    at its last chunk boundary: the buffered inputs of the partial chunk come
+    first, then this step's tokens. Index tensors are int64 device tensors;
+    the varlen/chunk metadata consumed by the SSD kernels is int32.
+
+    Attributes:
+        num_aug_tokens: total number of tokens in the augmented layout.
+        buffered_slot: state slot of each buffered token to re-feed.
+        buffered_pos: position of each buffered token inside its slot's buffer.
+        buffered_dst: destination of each buffered token in the augmented layout.
+        step_dst: destination of each of this step's tokens in the augmented
+            layout (in input order).
+        cu_seqlens: ``(num_seqs + 1,)`` cumulative augmented sequence lengths.
+        cu_chunk_seqlens: ``(num_chunks + 1,)`` chunk offsets in the augmented
+            layout.
+        last_chunk_indices: ``(num_seqs,)`` index of each sequence's last chunk.
+        seq_idx: ``(num_chunks,)`` sequence index of each chunk.
+        has_boundary_state: ``(num_seqs,)`` bool, whether the slot holds a valid
+            boundary state (False while a sequence is still in its first chunk).
+        boundary_rows: sequences that complete at least one chunk this step.
+        boundary_chunk_idx: for each of those sequences, the chunk (indexed into
+            the kernel's intermediate states) whose end state becomes the new
+            boundary state.
+        store_src: positions in the augmented layout of the trailing partial
+            chunk's tokens that must be stored into the buffers.
+        store_slot: destination slot of each stored token.
+        store_pos: destination position of each stored token.
+    """
+
+    num_aug_tokens: int
+    buffered_slot: torch.Tensor
+    buffered_pos: torch.Tensor
+    buffered_dst: torch.Tensor
+    step_dst: torch.Tensor
+    cu_seqlens: torch.Tensor
+    cu_chunk_seqlens: torch.Tensor
+    last_chunk_indices: torch.Tensor
+    seq_idx: torch.Tensor
+    has_boundary_state: torch.Tensor
+    boundary_rows: torch.Tensor
+    boundary_chunk_idx: torch.Tensor
+    store_src: torch.Tensor
+    store_slot: torch.Tensor
+    store_pos: torch.Tensor
+
+
+def _cdiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def build_exact_replay_metadata(
+    num_computed: list[int],
+    query_lens: list[int],
+    slots: torch.Tensor,
+    chunk_size: int,
+    device: torch.device,
+) -> ExactReplayMetadata:
+    """Build :class:`ExactReplayMetadata` on the host.
+
+    Args:
+        num_computed: per sequence, tokens processed before this step.
+        query_lens: per sequence, tokens scheduled in this step.
+        slots: ``(num_seqs,)`` device tensor with each sequence's state slot.
+        chunk_size: the model's SSD chunk size.
+        device: device for the returned tensors.
+
+    Returns:
+        The metadata describing the augmented layout of these sequences.
+    """
+    buffered_seq: list[int] = []
+    buffered_pos: list[int] = []
+    buffered_dst: list[int] = []
+    step_dst: list[int] = []
+    cu_seqlens = [0]
+    cu_chunk: list[int] = []
+    seq_idx: list[int] = []
+    last_chunk: list[int] = []
+    has_boundary: list[bool] = []
+    boundary_rows: list[int] = []
+    boundary_chunk_idx: list[int] = []
+    store_src: list[int] = []
+    store_seq: list[int] = []
+    store_pos: list[int] = []
+    offset = 0
+    for i, (nc, q) in enumerate(zip(num_computed, query_lens)):
+        n_pre = nc % chunk_size
+        aug_len = n_pre + q
+        buffered_seq.extend([i] * n_pre)
+        buffered_pos.extend(range(n_pre))
+        buffered_dst.extend(range(offset, offset + n_pre))
+        step_dst.extend(range(offset + n_pre, offset + aug_len))
+        first_chunk = len(cu_chunk)
+        n_chunks = _cdiv(aug_len, chunk_size)
+        cu_chunk.extend(offset + k * chunk_size for k in range(n_chunks))
+        seq_idx.extend([i] * n_chunks)
+        last_chunk.append(len(cu_chunk) - 1)
+        has_boundary.append(nc - n_pre > 0)
+        full = aug_len // chunk_size
+        if full >= 1:
+            boundary_rows.append(i)
+            boundary_chunk_idx.append(first_chunk + full - 1)
+        tail_len = aug_len % chunk_size
+        if full == 0:
+            # the buffer already holds positions [0, n_pre): append this step
+            store_src.extend(range(offset + n_pre, offset + aug_len))
+            store_seq.extend([i] * q)
+            store_pos.extend(range(n_pre, aug_len))
+        elif tail_len > 0:
+            base = offset + aug_len - tail_len
+            store_src.extend(range(base, base + tail_len))
+            store_seq.extend([i] * tail_len)
+            store_pos.extend(range(tail_len))
+        offset += aug_len
+        cu_seqlens.append(offset)
+    cu_chunk.append(offset)
+
+    def i64(v: list[int]) -> torch.Tensor:
+        return async_tensor_h2d(v, dtype=torch.int64, device=device)
+
+    def i32(v: list[int]) -> torch.Tensor:
+        return async_tensor_h2d(v, dtype=torch.int32, device=device)
+
+    slots64 = slots.to(torch.int64)
+    return ExactReplayMetadata(
+        num_aug_tokens=offset,
+        buffered_slot=slots64[i64(buffered_seq)],
+        buffered_pos=i64(buffered_pos),
+        buffered_dst=i64(buffered_dst),
+        step_dst=i64(step_dst),
+        cu_seqlens=i32(cu_seqlens),
+        cu_chunk_seqlens=i32(cu_chunk),
+        last_chunk_indices=i32(last_chunk),
+        seq_idx=i32(seq_idx),
+        has_boundary_state=async_tensor_h2d(
+            has_boundary, dtype=torch.bool, device=device
+        ),
+        boundary_rows=i64(boundary_rows),
+        boundary_chunk_idx=i64(boundary_chunk_idx),
+        store_src=i64(store_src),
+        store_slot=slots64[i64(store_seq)],
+        store_pos=i64(store_pos),
+    )
+
 
 @dataclass
 class Mamba2AttentionMetadata(BaseMambaAttentionMetadata):
@@ -109,6 +264,9 @@ class Mamba2AttentionMetadata(BaseMambaAttentionMetadata):
 
     # Chunk-related metadata (only for prefill)
     seq_idx_p: torch.Tensor | None = None
+    # Exact-replay mode (None when disabled or when there are no such rows)
+    exact_replay_p: ExactReplayMetadata | None = None
+    exact_replay_d: ExactReplayMetadata | None = None
 
 
 class Mamba2AttentionMetadataBuilder(
@@ -129,6 +287,7 @@ class Mamba2AttentionMetadataBuilder(
             "chunk_size needs to be set in the model config for Mamba2 models"
         )
         self.chunk_size: int = chunk_size
+        self.exact_replay: bool = vllm_config.cache_config.mamba_exact_replay
 
     def build(
         self,
@@ -169,6 +328,50 @@ class Mamba2AttentionMetadataBuilder(
                 )
             )
 
+        exact_replay_p = None
+        exact_replay_d = None
+        if self.exact_replay:
+            device = common_attn_metadata.query_start_loc.device
+            # Derive per-row computed-token counts from CPU metadata only:
+            # `seq_lens_cpu_upper_bound` is exact for every row when async
+            # scheduling and speculative decoding are off, which exact-replay
+            # mode requires, and it avoids the D2H sync of the deprecated
+            # `num_computed_tokens_cpu` property.
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+            if seq_lens_cpu is None:
+                raise ValueError(
+                    "mamba_exact_replay needs CPU sequence lengths in the "
+                    "attention metadata"
+                )
+            query_lens = torch.diff(common_attn_metadata.query_start_loc_cpu)
+            num_computed_cpu = (seq_lens_cpu - query_lens).tolist()
+            query_lens_cpu = query_lens.tolist()
+            num_reqs = common.num_reqs
+            if common.num_decodes > 0:
+                assert common.state_indices_tensor_d is not None
+                slots_d = common.state_indices_tensor_d
+                if slots_d.dim() == 2:
+                    slots_d = slots_d[:, 0]
+                exact_replay_d = build_exact_replay_metadata(
+                    num_computed_cpu[: common.num_decodes],
+                    query_lens_cpu[: common.num_decodes],
+                    slots_d,
+                    self.chunk_size,
+                    device,
+                )
+            if common.num_prefills > 0:
+                assert common.state_indices_tensor_p is not None
+                slots_p = common.state_indices_tensor_p
+                if slots_p.dim() == 2:
+                    slots_p = slots_p[:, 0]
+                exact_replay_p = build_exact_replay_metadata(
+                    num_computed_cpu[num_reqs - common.num_prefills : num_reqs],
+                    query_lens_cpu[num_reqs - common.num_prefills : num_reqs],
+                    slots_p,
+                    self.chunk_size,
+                    device,
+                )
+
         return replace(
             common,
             prep_initial_states=prep_initial_states,
@@ -176,4 +379,6 @@ class Mamba2AttentionMetadataBuilder(
             seq_idx_p=seq_idx_p,
             cu_chunk_seqlen_p=cu_chunk_seqlen_p,
             last_chunk_indices_p=last_chunk_indices_p,
+            exact_replay_p=exact_replay_p,
+            exact_replay_d=exact_replay_d,
         )

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -118,9 +118,15 @@ class ExactReplayMetadata:
     first, then this step's tokens. Index tensors are int64 device tensors;
     the varlen/chunk metadata consumed by the SSD kernels is int32.
 
+    The metadata refers to sequences by their row in the batch and never to
+    state slots: the slots come from the layer's own state indices at call
+    time. This keeps one instance valid for every KV cache group of a hybrid
+    model, where the model runner builds the metadata once and only swaps the
+    block table per group.
+
     Attributes:
         num_aug_tokens: total number of tokens in the augmented layout.
-        buffered_slot: state slot of each buffered token to re-feed.
+        buffered_seq: batch row of the sequence each buffered token belongs to.
         buffered_pos: position of each buffered token inside its slot's buffer.
         buffered_dst: destination of each buffered token in the augmented layout.
         step_dst: destination of each of this step's tokens in the augmented
@@ -138,12 +144,12 @@ class ExactReplayMetadata:
             boundary state.
         store_src: positions in the augmented layout of the trailing partial
             chunk's tokens that must be stored into the buffers.
-        store_slot: destination slot of each stored token.
+        store_seq: batch row of the sequence each stored token belongs to.
         store_pos: destination position of each stored token.
     """
 
     num_aug_tokens: int
-    buffered_slot: torch.Tensor
+    buffered_seq: torch.Tensor
     buffered_pos: torch.Tensor
     buffered_dst: torch.Tensor
     step_dst: torch.Tensor
@@ -155,7 +161,7 @@ class ExactReplayMetadata:
     boundary_rows: torch.Tensor
     boundary_chunk_idx: torch.Tensor
     store_src: torch.Tensor
-    store_slot: torch.Tensor
+    store_seq: torch.Tensor
     store_pos: torch.Tensor
 
 
@@ -166,7 +172,6 @@ def _cdiv(a: int, b: int) -> int:
 def build_exact_replay_metadata(
     num_computed: list[int],
     query_lens: list[int],
-    slots: torch.Tensor,
     chunk_size: int,
     device: torch.device,
 ) -> ExactReplayMetadata:
@@ -175,7 +180,6 @@ def build_exact_replay_metadata(
     Args:
         num_computed: per sequence, tokens processed before this step.
         query_lens: per sequence, tokens scheduled in this step.
-        slots: ``(num_seqs,)`` device tensor with each sequence's state slot.
         chunk_size: the model's SSD chunk size.
         device: device for the returned tensors.
 
@@ -235,10 +239,9 @@ def build_exact_replay_metadata(
     def i32(v: list[int]) -> torch.Tensor:
         return async_tensor_h2d(v, dtype=torch.int32, device=device)
 
-    slots64 = slots.to(torch.int64)
     return ExactReplayMetadata(
         num_aug_tokens=offset,
-        buffered_slot=slots64[i64(buffered_seq)],
+        buffered_seq=i64(buffered_seq),
         buffered_pos=i64(buffered_pos),
         buffered_dst=i64(buffered_dst),
         step_dst=i64(step_dst),
@@ -252,7 +255,7 @@ def build_exact_replay_metadata(
         boundary_rows=i64(boundary_rows),
         boundary_chunk_idx=i64(boundary_chunk_idx),
         store_src=i64(store_src),
-        store_slot=slots64[i64(store_seq)],
+        store_seq=i64(store_seq),
         store_pos=i64(store_pos),
     )
 
@@ -347,27 +350,21 @@ class Mamba2AttentionMetadataBuilder(
             num_computed_cpu = (seq_lens_cpu - query_lens).tolist()
             query_lens_cpu = query_lens.tolist()
             num_reqs = common.num_reqs
+            # The metadata carries batch rows, not state slots, so the copy
+            # that `update_block_table` hands to the other KV cache groups of a
+            # hybrid model stays valid: each layer resolves its own slots from
+            # its state indices when it runs the SSD step.
             if common.num_decodes > 0:
-                assert common.state_indices_tensor_d is not None
-                slots_d = common.state_indices_tensor_d
-                if slots_d.dim() == 2:
-                    slots_d = slots_d[:, 0]
                 exact_replay_d = build_exact_replay_metadata(
                     num_computed_cpu[: common.num_decodes],
                     query_lens_cpu[: common.num_decodes],
-                    slots_d,
                     self.chunk_size,
                     device,
                 )
             if common.num_prefills > 0:
-                assert common.state_indices_tensor_p is not None
-                slots_p = common.state_indices_tensor_p
-                if slots_p.dim() == 2:
-                    slots_p = slots_p[:, 0]
                 exact_replay_p = build_exact_replay_metadata(
                     num_computed_cpu[num_reqs - common.num_prefills : num_reqs],
                     query_lens_cpu[num_reqs - common.num_prefills : num_reqs],
-                    slots_p,
                     self.chunk_size,
                     device,
                 )

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -214,19 +214,40 @@ def _cached_get_attn_backend(
 
 def get_mamba_attn_backend(
     mamba_type: MambaAttentionBackendEnum,
+    mamba_exact_replay: bool = False,
 ) -> type[AttentionBackend]:
-    """Select which mamba attention backend to use and lazily import it."""
-    return _cached_get_mamba_attn_backend(mamba_type)
+    """Select which mamba attention backend to use and lazily import it.
+
+    Args:
+        mamba_type: the layer's mamba backend kind.
+        mamba_exact_replay: whether Mamba2 exact-replay mode is enabled; a
+            backend whose batch-invariance support depends on it is only
+            accepted in batch-invariant mode when it is set.
+    """
+    return _cached_get_mamba_attn_backend(mamba_type, mamba_exact_replay)
+
+
+def _mamba_backend_supports_batch_invariance(
+    backend: type[AttentionBackend], mamba_exact_replay: bool
+) -> bool:
+    if backend.supports_batch_invariance():
+        return True
+    return mamba_exact_replay and bool(
+        getattr(backend, "supports_batch_invariance_with_exact_replay", False)
+    )
 
 
 @cache
 def _cached_get_mamba_attn_backend(
     mamba_type: MambaAttentionBackendEnum,
+    mamba_exact_replay: bool = False,
 ) -> type[AttentionBackend]:
     assert mamba_type and isinstance(mamba_type, MambaAttentionBackendEnum)
 
     mamba_attn_backend = mamba_type.get_class()
-    if envs.VLLM_BATCH_INVARIANT and not mamba_attn_backend.supports_batch_invariance():
+    if envs.VLLM_BATCH_INVARIANT and not _mamba_backend_supports_batch_invariance(
+        mamba_attn_backend, mamba_exact_replay
+    ):
         raise RuntimeError(
             "VLLM batch_invariant mode is not supported for "
             f"{mamba_attn_backend.get_name()}."


### PR DESCRIPTION
## Purpose

Mamba2 layers run the chunked scan (SSD) for prefill and the recurrent update (SSU) for decode; the two are not bit-identical, so a request's Mamba-layer outputs depend on how it was scheduled. This adds an opt-in, default-off `--mamba-exact-replay` mode in which every SSD call for a sequence starts from the fp32 state at the sequence's last chunk boundary and re-feeds the buffered inputs (x, raw dt, B, C) of the current partial chunk, so prefill, chunked prefill and decode all see the chunk grid of a single-shot prefill and the Mamba2 SSM computation produces identical bits on every path. Bit-identical logits additionally need the batch-invariant kernels for the other layers; in this mode the Mamba2 attention backend is accepted by `VLLM_BATCH_INVARIANT=1`.

Design discussion: #55524. Data behind the design: vllm-project/vllm#54993 (comments), issue #27433.

## Why this is not a duplicate

- #54993 (fixed physical chunking of prefill in the scheduler) and its author's packed-history recovery prototype (#27433, 2026-09-03) make *recovery after preemption reproduce the SSU decode numerics*, which gives scheduling-independent served logprobs at no per-step cost. This PR makes *decode reproduce the SSD prefill numerics*, which additionally gives `prefill(prefix + token) == decode(token)` (the property `tests/v1/determinism/test_batch_invariance.py::test_decode_logprobs_match_prefill_logprobs` checks) — needed for RL training/inference alignment, where the trainer scores generated tokens with the chunked scan. The two are complementary and can coexist; this mode is an independent opt-in.
- The combination with #54993's scheduler change has not been tested; the two are independent options.
- ReplaySSM (`--use-replayssm`) is a decode bandwidth optimisation with its own 16-slot ring; its `dt_cache` holds softplus(dt + bias) and its cursor counts flush steps, so it cannot serve as the replay buffer. The modes are mutually exclusive.

## Changes

- `CacheConfig.mamba_exact_replay` / `--mamba-exact-replay`; `VllmConfig.validate_mamba_exact_replay` fails closed unless: model opts in (`SupportsMambaExactReplay`, currently `Mamba2ForCausalLM`), `mamba_ssm_cache_dtype=float32`, `mamba_cache_mode=none`, Triton mamba backend, no speculative decoding, no ReplaySSM, no KV connectors, TP=1/PP=1, no async scheduling, no DBO / micro-batching, `enforce_eager`.
- Four token-major partial-chunk buffers (`x`, raw `dt`, `B`, `C`; `chunk_size` entries per slot) appended to the mamba state; shapes/dtypes added consistently on the model-config path (`get_mamba_state_{shape,dtype}_from_config`) and the layer path so the page size cannot desync.
- `vllm/model_executor/layers/mamba/exact_replay.py`: `ExactReplayBuffers` and `exact_replay_ssd()`, one function for prefill and decode rows (prepend buffered tokens, run the SSD kernels, write back only this step's outputs, advance the fp32 boundary state only when a chunk completes, store the trailing partial chunk).
- `Mamba2AttentionMetadata.exact_replay_{p,d}` built on the host from `num_computed_tokens` (`build_exact_replay_metadata`); `MambaMixer2` routes both prefill and decode rows through `exact_replay_ssd` when the mode is on.
- Batch-invariance gate: `get_mamba_attn_backend(mamba_type, mamba_exact_replay)` accepts the Mamba2 backend in batch-invariant mode only when the option is set (config-level, no process-global state).
- Docs: `docs/features/batch_invariance.md`, section "Mamba2 Models: Exact-Replay Mode".

## Test plan

Commands run on GB200, on the v0.28.0-based branch and again on this main-based branch (nightly binaries for the base commit):

```
python -m pytest tests/v1/attention/test_mamba2_exact_replay_metadata.py \
    tests/v1/attention/test_mamba2_exact_replay_config.py \
    tests/kernels/mamba/test_mamba2_exact_replay.py
python -m pytest tests/models/test_registry.py -k exact_replay
```

- Metadata unit tests: two exact layouts (decode rows mid-chunk / at boundary / completing a chunk; fresh and unaligned-resumed prefill rows) plus 20 random layouts checked against structural invariants.
- Config tests: the supported configuration is accepted; fp32 SSM cache, no prefix caching, no ReplaySSM, no async scheduling and no DBO are enforced; the selector accepts the Mamba2 backend under `VLLM_BATCH_INVARIANT=1` only with the option; the registry reports the opt-in for `Mamba2ForCausalLM` only.
- Kernel-level test: four sequences of different lengths, first prefill split at unaligned points, resumed, then interleaved decode until each finishes (batch composition and chunk offsets differ every step); every output row equals the single-shot prefill row bitwise; run with contiguous buffers and with buffers carved from paged storage the way the mamba cache is.
- Engine-level (script outside the repo, `AntonV/mamba2-130m-hf`, 24 Mamba2 layers, bf16, fp32 SSM cache, eager, TP1, one request, random 900-token stream; full raw-logit rows compared with `torch.equal` against a single-shot prefill):
  - baseline: forced token-by-token decode differs in 299/299 rows; chunked prefill (`max_num_batched_tokens=100`) differs in 800/900 rows;
  - exact replay: 0/299 and 0/900 rows differ, with and without `VLLM_BATCH_INVARIANT=1`; single-shot prefill logits unchanged by the mode; `VLLM_BATCH_INVARIANT=1` without the option fails closed at startup.
- Cost (launch-bound, eager, batch 1): 300 decode steps 6.5 s → 11.9 s (≈ +0.75 ms per layer per step); memory for this model 0.887 MiB buffers + 0.750 MiB fp32 state per layer per request (≈ 39.3 MiB per request over 24 layers).

Not yet covered (WIP): real scheduler preemption on a hybrid model, multi-request mixed-offset decode at the engine level (kernel-level test only), TP > 1, CUDA graphs, spec decode, prefix caching, performance beyond the launch-bound setting.

## AI assistance

AI tools assisted with the implementation, tests and documentation. I reviewed every changed line and ran the tests above.