### PR TITLE
[Bugfix][Model] Regression-test the Qwen3.5-MTP draft unquantized-build contract (#48816 follow-up)

### DIFF
--- a/tests/models/test_qwen3_5_mtp_draft_quant.py
+++ b/tests/models/test_qwen3_5_mtp_draft_quant.py
@@ -27,13 +27,17 @@ class _FakeQuantConfig:
     by the dynamic-exclusion branch)."""
 
     def __init__(self, name: str = "gptq"):
+        """Store the quantization method name reported by ``get_name``."""
         self._name = name
 
     def get_name(self) -> str:
+        """Return the quantization method name given at construction."""
         return self._name
 
 
 def _text_config(**overrides) -> PretrainedConfig:
+    """Build a small Qwen3.5-MTP text ``PretrainedConfig``; keyword
+    arguments override the defaults."""
     cfg = dict(
         model_type="qwen3_5_moe_text",
         architectures=["Qwen3_5MoeMTP"],
@@ -61,6 +65,8 @@ def _build_draft(monkeypatch: pytest.MonkeyPatch, dynamic):
 
     class FakeDecoderLayer(torch.nn.Module):
         def __init__(self, vllm_config, **kwargs):
+            """Stand-in draft layer that records the ``quant_config`` it is
+            constructed with."""
             super().__init__()
             quant_seen.append(getattr(vllm_config, "quant_config"))
 
@@ -122,6 +128,9 @@ def test_dynamic_mtp_exclusion_builds_draft_unquantized(monkeypatch):
 
 
 def test_no_quantization_config_keeps_draft_quantized(monkeypatch):
+    """Without any checkpoint ``quantization_config`` the unquantized-draft
+    bypass must not trigger: every draft layer is built with the model's
+    quantization config, and ``vllm_config`` keeps it."""
     vllm_config, quant_cfg, quant_seen = _build_draft(monkeypatch, dynamic=None)
     assert all(q is quant_cfg for q in quant_seen)
     assert vllm_config.quant_config is quant_cfg
@@ -139,6 +148,9 @@ def test_no_quantization_config_keeps_draft_quantized(monkeypatch):
     ],
 )
 def test_non_mtp_negative_patterns_keep_draft_quantized(monkeypatch, dynamic):
+    """``dynamic`` entries that are not ``-:``-prefixed mtp exclusions (a
+    positive mtp pattern, a non-mtp negative pattern, an empty dict) must
+    not bypass quantization."""
     _, _, quant_seen = _build_draft(monkeypatch, dynamic=dynamic)
     assert all(isinstance(q, _FakeQuantConfig) for q in quant_seen), (
         "only `-:`-prefixed patterns mentioning mtp may bypass quantization"

--- a/tests/models/test_qwen3_5_mtp_draft_quant.py
+++ b/tests/models/test_qwen3_5_mtp_draft_quant.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only regression tests for the GPTQ dynamic-MTP draft exclusion.
+
+MTP-preserved GPTQ checkpoints keep the ``mtp.*`` draft weights unquantized
+and advertise that via ``quantization_config.dynamic`` entries keyed with a
+``-:`` (negative) pattern matching ``mtp``. ``Qwen3_5MultiTokenPredictor``
+detects that and must build the draft layers with ``quant_config is None``;
+otherwise the BF16 ``mtp.*`` weights are loaded against GPTQ-packed params
+and checkpoint loading fails at serve time. These tests lock that contract —
+and its boundaries — with no GPU and no weights.
+"""
+
+import types
+
+import torch
+from transformers import PretrainedConfig
+
+import vllm.model_executor.models.qwen3_5_mtp as qwen3_5_mtp_module
+from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MultiTokenPredictor
+
+import pytest
+
+
+class _FakeQuantConfig:
+    """Minimal stand-in for a quantization config (only ``get_name`` is used
+    by the dynamic-exclusion branch)."""
+
+    def __init__(self, name: str = "gptq"):
+        self._name = name
+
+    def get_name(self) -> str:
+        return self._name
+
+
+def _text_config(**overrides) -> PretrainedConfig:
+    cfg = dict(
+        model_type="qwen3_5_moe_text",
+        architectures=["Qwen3_5MoeMTP"],
+        num_hidden_layers=8,
+        mtp_num_hidden_layers=1,
+        hidden_size=32,
+        vocab_size=128,
+        rms_norm_eps=1e-6,
+    )
+    cfg.update(overrides)
+    return PretrainedConfig(**cfg)
+
+
+def _build_draft(monkeypatch: pytest.MonkeyPatch, dynamic):
+    """Run the real Qwen3_5MultiTokenPredictor constructor on CPU with the
+    dist/kernel-heavy module members mocked out; return
+    (vllm_config, quant_cfg, quant_config_seen_per_draft_layer).
+
+    ``quant_config_seen_per_draft_layer`` records ``vllm_config.quant_config``
+    *at draft-layer construction time*: the constructor restores
+    ``vllm_config.quant_config`` after building the draft layers, so any
+    post-construction inspection would hide the bypass.
+    """
+    quant_seen: list[object] = []
+
+    class FakeDecoderLayer(torch.nn.Module):
+        def __init__(self, vllm_config, **kwargs):
+            super().__init__()
+            quant_seen.append(getattr(vllm_config, "quant_config"))
+
+    hf_config = _text_config()
+    if dynamic is not None:
+        hf_config.quantization_config = {"quant_method": "gptq", "dynamic": dynamic}
+
+    quant_cfg = _FakeQuantConfig("gptq")
+    from vllm.config import CompilationMode
+
+    vllm_config = types.SimpleNamespace(
+        model_config=types.SimpleNamespace(
+            hf_text_config=_text_config(), hf_config=hf_config
+        ),
+        quant_config=quant_cfg,
+        # @support_torch_compile reads compilation_config.mode in its __init__
+        # wrapper; NONE => do_not_compile, no dynamo machinery.
+        compilation_config=types.SimpleNamespace(mode=CompilationMode.NONE),
+    )
+
+    monkeypatch.setattr(qwen3_5_mtp_module, "Qwen3_5DecoderLayer", FakeDecoderLayer)
+    monkeypatch.setattr(
+        qwen3_5_mtp_module, "VocabParallelEmbedding", lambda *a, **k: torch.nn.Module()
+    )
+    monkeypatch.setattr(
+        qwen3_5_mtp_module, "ColumnParallelLinear", lambda *a, **k: torch.nn.Module()
+    )
+    monkeypatch.setattr(
+        qwen3_5_mtp_module,
+        "is_model_fused_shared_expert_compatible",
+        lambda *a, **k: False,
+    )
+    # Qwen3_5RMSNorm is a CustomOp whose ctor reads get_current_vllm_config();
+    # the contract is about the quant_config threaded into the *decoder
+    # layers*, so the norms are stubbed like the other heavy classes.
+    monkeypatch.setattr(
+        qwen3_5_mtp_module, "Qwen3_5RMSNorm", lambda *a, **k: torch.nn.Module()
+    )
+
+    Qwen3_5MultiTokenPredictor(vllm_config=vllm_config, prefix="mtp")
+    assert quant_seen, "no draft layers were constructed"
+    return vllm_config, quant_cfg, quant_seen
+
+
+def test_dynamic_mtp_exclusion_builds_draft_unquantized(monkeypatch):
+    """A `-:`-prefixed dynamic pattern mentioning mtp => draft layers see
+    quant_config is None; the original config is restored afterwards (no
+    leak to sibling modules)."""
+    vllm_config, quant_cfg, quant_seen = _build_draft(
+        monkeypatch, dynamic={"-:.*mtp.*": {}}
+    )
+    assert all(q is None for q in quant_seen), (
+        "MTP draft layers must be built unquantized when the checkpoint "
+        "declares a -:...mtp... dynamic exclusion"
+    )
+    assert vllm_config.quant_config is quant_cfg, (
+        "quant_config must be restored after building the draft layers"
+    )
+
+
+def test_no_quantization_config_keeps_draft_quantized(monkeypatch):
+    vllm_config, quant_cfg, quant_seen = _build_draft(monkeypatch, dynamic=None)
+    assert all(q is quant_cfg for q in quant_seen)
+    assert vllm_config.quant_config is quant_cfg
+
+
+@pytest.mark.parametrize(
+    "dynamic",
+    [
+        # No `-:` prefix: a positive pattern must not disable quantization.
+        {"mtp:.*": {}},
+        # Negative but not mtp-related: must not disable quantization either.
+        {"-:.*lm_head.*": {}},
+        # Empty dynamic: must not disable quantization.
+        {},
+    ],
+)
+def test_non_mtp_negative_patterns_keep_draft_quantized(monkeypatch, dynamic):
+    _, _, quant_seen = _build_draft(monkeypatch, dynamic=dynamic)
+    assert all(isinstance(q, _FakeQuantConfig) for q in quant_seen), (
+        "only `-:`-prefixed patterns mentioning mtp may bypass quantization"
+    )


### PR DESCRIPTION

## Problem

MTP-preserved GPTQ checkpoints store the `mtp.*` draft weights in BF16, and
`Qwen3_5MultiTokenPredictor` builds the draft unquantized **only** when the
checkpoint's `quantization_config.dynamic` carries a `-:`-prefixed pattern
mentioning `mtp` (`vllm/model_executor/models/qwen3_5_mtp.py:108-126`,
shipped by #48816 on 2026-07-23 with no test). Nothing locks that contract
today, so any refactor of the draft-construction path can silently drop it —
and when the draft is instead built quantized against such a checkpoint,
serving fails at weight-load time with GPTQ-packed attribute errors
(`AttributeError: 'RoutedExperts' object has no attribute 'w2_weight'`, the
exact failure #48816 was opened for).

Repro: `python -m pytest -p no:cacheprovider -v tests/models/test_qwen3_5_mtp_draft_quant.py`
→ 5 passed on an unmodified tree; 1 failed / 4 passed on a tree with the
nulling at `qwen3_5_mtp.py:108-117,126` removed (RED tail below).

## Change

Test-only. Adds `tests/models/test_qwen3_5_mtp_draft_quant.py`, which runs the
real `Qwen3_5MultiTokenPredictor` constructor on CPU (no weights, no GPU;
heavy sibling modules faked, modelled on the existing runner
`tests/models/test_qwen3_5_mtp_config.py`). One test captures
`vllm_config.quant_config` at draft-layer construction time — the constructor
restores the config afterwards, so post-construction inspection cannot see the
bypass — and asserts it is `None` under a `{"-:.*mtp.*": {}}` exclusion; four
boundary tests assert the draft keeps the quantization config when
`quantization_config` is absent, `dynamic` is empty, the `-:` pattern does not
mention `mtp`, or the pattern is positive (non-`-:`). The contract is locked
at the model-builder layer, which is the layer whose silent breakage decides
the serve-time failure above. The tests model `quantization_config` in its raw
dict shape (the branch at line 114 is gated on `isinstance(hf_qc, dict)`);
whether a given checkpoint delivers a `transformers` quantization-config
object — which would skip that branch — is not asserted here.

## Tests

Five collected cases (names verbatim):
`test_dynamic_mtp_exclusion_builds_draft_unquantized`,
`test_no_quantization_config_keeps_draft_quantized`, and
`test_non_mtp_negative_patterns_keep_draft_quantized[dynamic0|dynamic1|dynamic2]`.

GREEN (committed tree, main `f4eccdad`):

```
tests/models/test_qwen3_5_mtp_draft_quant.py::test_dynamic_mtp_exclusion_builds_draft_unquantized PASSED [ 20%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_no_quantization_config_keeps_draft_quantized PASSED [ 40%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_non_mtp_negative_patterns_keep_draft_quantized[dynamic0] PASSED [ 60%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_non_mtp_negative_patterns_keep_draft_quantized[dynamic1] PASSED [ 80%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_non_mtp_negative_patterns_keep_draft_quantized[dynamic2] PASSED [100%]
======================== 5 passed, 22 warnings in 4.54s ========================
```

RED (same tree with the shipped nulling removed — the regression this test
exists to detect — the boundary cases correctly stay green):

```
tests/models/test_qwen3_5_mtp_draft_quant.py::test_dynamic_mtp_exclusion_builds_draft_unquantized FAILED [ 20%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_no_quantization_config_keeps_draft_quantized PASSED [ 40%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_non_mtp_negative_patterns_keep_draft_quantized[dynamic0] PASSED [ 60%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_non_mtp_negative_patterns_keep_draft_quantized[dynamic1] PASSED [ 80%]
tests/models/test_qwen3_5_mtp_draft_quant.py::test_non_mtp_negative_patterns_keep_draft_quantized[dynamic2] PASSED [100%]
_____________ test_dynamic_mtp_exclusion_builds_draft_unquantized ______________
E       AssertionError: MTP draft layers must be built unquantized when the checkpoint declares a -:...mtp... dynamic exclusion
tests/models/test_qwen3_5_mtp_draft_quant.py:115: AssertionError
=========================== short test summary info ============================
FAILED tests/models/test_qwen3_5_mtp_draft_quant.py::test_dynamic_mtp_exclusion_builds_draft_unquantized
=================== 1 failed, 4 passed, 22 warnings in 3.65s ===================
```

## Verification

Both runs are CPU-only `pytest -p no:cacheprovider -v` in the pinned image
`vllm/vllm-openai-xpu@sha256:f01e24f6c7ff01f1e0662234255a1372297d1dbd89d003cf13c8fad3eab1ba4f`
(`vllm.__version__ == 0.27.2rc1.dev77+gac7509e2b`, `torch 2.13.0+xpu`) against
upstream/main `f4eccdadefc6501fafeb1a0bf7f171ff24f984b0`, on 2026-09-06.
A collision sweep over open+closed PRs and issues touching AutoGPTQ,
`gptq_utils` and MTP draft loading via `api.github.com` (2026-09-06) found no
existing or in-review coverage of this exclusion (nearest neighbours below).

## Related

- #48816 — merged 2026-07-23; introduced this dynamic-exclusion nulling in
  `qwen3_5_mtp.py` without a test.
- #47828 — open; forces draft `quant_config=None` for GPTQ/AWQ families,
  editing the same block, no tests; the added test locks the shipped
  `dynamic` path as merged today.
- #49553 — open; addresses the related per-layer checkpoint-config gap
  (issue #49552) with its own tests in `tests/model_executor/` (different
  file).
- #49539 (AutoGPTQ unquantized routed experts), #53414 (compressed-tensors
  `fc` bypass) — open; same failure family, different mechanisms/files.
