### PR TITLE
[Governance] Add aoshen02 as code owner for RL components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -218,6 +218,19 @@ mkdocs.yaml @hmellor
 /vllm/config/pooler.py @noooop
 /vllm/model_executor/layers/pooler @noooop
 
+# Reinforcement learning
+/vllm/distributed/weight_transfer @aoshen02
+/vllm/entrypoints/serve/dev/rlhf @njhill @aoshen02
+/tests/distributed/test_weight_transfer.py @aoshen02
+/tests/entrypoints/weight_transfer @DarkLight1337 @robertgshaw2-redhat @aarnphm @NickLucche @AndreasKaratzas @aoshen02
+/tests/entrypoints/serve/dev/rlhf @DarkLight1337 @robertgshaw2-redhat @aarnphm @NickLucche @AndreasKaratzas @aoshen02
+/tests/v1/worker/test_gpu_worker_weight_transfer.py @aoshen02
+/examples/rl @aoshen02
+/examples/features/pause_resume @aoshen02
+/docs/training/rlhf.md @aoshen02
+/docs/training/async_rl.md @aoshen02
+/docs/training/weight_transfer @aoshen02
+
 # Security guide and policies
 /docs/usage/security.md @russellb @jperezdealgaba
 /SECURITY.md @russellb @jperezdealgaba


### PR DESCRIPTION
## Purpose

Add @aoshen02 as a code owner for RL weight transfer, the RLHF development API, and their related tests, examples, and documentation, following the invitation to join the vLLM committers with an initial focus on RL. Preserve existing owners on paths with inherited ownership.

Duplicate check: searched open PRs for `CODEOWNERS in:title` and `aoshen02 CODEOWNERS in:title,body`; no matching open PRs were found. This is committer onboarding and has no associated issue.

AI assistance was used to prepare this change and PR description.

## Test Plan

- Run `git diff --check`.
- Check that all 11 added ownership paths exist using `test -e` for each path.
- Inspect the ownership rules against the existing CODEOWNERS entries.

## Test Result

Whitespace validation passed, and all 11 paths exist. Existing owners are retained for the RLHF API and entrypoint tests. Only `.github/CODEOWNERS` changes; runtime tests and model evaluations are not applicable.
