### PR TITLE
[Bugfix][Frontend] Require API key for top-level control-plane endpoints

### DIFF
--- a/tests/entrypoints/serve/middleware/test_authentication_middleware.py
+++ b/tests/entrypoints/serve/middleware/test_authentication_middleware.py
@@ -130,6 +130,38 @@ def test_auto_discovered_protected_routes_require_auth(task_routes):
         )
 
 
+CONTROL_PLANE_PATHS = (
+    "/abort_requests",
+    "/detokenize",
+    "/is_scaling_elastic_ep",
+    "/scale_elastic_ep",
+    "/start_profile",
+    "/stop_profile",
+    "/tokenize",
+)
+
+
+def test_control_plane_routes_require_auth():
+    """Stateful control-plane endpoints are mounted at the top level
+    (outside the /v1, /v2, /inference, /cohere prefixes) but must still
+    be authenticated when an API key is configured."""
+    mock_routes = [(path, ["POST"]) for path in CONTROL_PLANE_PATHS]
+    app = _create_app_with_mock_routes(mock_routes)
+    client = TestClient(app)
+
+    for path in CONTROL_PLANE_PATHS:
+        assert path.startswith(GUARDED_PREFIX), f"{path} must be guarded"
+
+        resp = client.post(path)
+        assert resp.status_code == 401, f"POST {path} should reject missing token"
+
+        resp = client.post(path, headers={"Authorization": "Bearer wrong"})
+        assert resp.status_code == 401, f"POST {path} should reject invalid token"
+
+        resp = client.post(path, headers={"Authorization": "Bearer valid-token"})
+        assert resp.status_code == 200, f"POST {path} should accept valid token"
+
+
 def test_auto_discovered_unprotected_routes_no_auth(task_routes):
     """For every auto-discovered route that does NOT start with a guarded
     prefix, verify that no authentication is required."""

--- a/vllm/entrypoints/serve/middleware/authenticate.py
+++ b/vllm/entrypoints/serve/middleware/authenticate.py
@@ -8,7 +8,26 @@ from starlette.datastructures import Headers
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-GUARDED_PREFIX = ("/v1", "/v2", "/inference", "/cohere")
+# Paths that require authentication when an API key is configured.
+# Besides the OpenAI-compatible API prefixes, this also covers stateful
+# control-plane endpoints that are mounted outside those prefixes
+# (/tokenize, /scale_elastic_ep, /abort_requests, /start_profile, ...).
+# They mutate or introspect engine state, so they must not be reachable
+# unauthenticated while the rest of the API is behind --api-key.
+# Note: "/tokenize" also covers the /tokenizer_info endpoint.
+GUARDED_PREFIX = (
+    "/v1",
+    "/v2",
+    "/inference",
+    "/cohere",
+    "/abort_requests",
+    "/detokenize",
+    "/is_scaling_elastic_ep",
+    "/scale_elastic_ep",
+    "/start_profile",
+    "/stop_profile",
+    "/tokenize",
+)
 
 
 class AuthenticationMiddleware:


### PR DESCRIPTION
## Purpose

`AuthenticationMiddleware` only authenticates request paths that start with the API prefixes (`/v1`, `/v2`, `/inference`, `/cohere`). However, several stateful control-plane endpoints are mounted at the **top level**, outside those prefixes, so on a server started with `--api-key` they were reachable **without any credentials** by anyone who could reach the port:

- `POST /scale_elastic_ep`, `POST /is_scaling_elastic_ep`: arms a global "scaling" flag that makes `ScalingMiddleware` return 503 to **every** request (including valid-key clients) for the duration of the operation, then calls `engine_client.scale_elastic_ep()` with caller-chosen `new_data_parallel_size` / `drain_timeout` (on Ray-DP elastic-EP deployments this adds/removes engine workers).
- `POST /abort_requests` (disaggregated tokens-only setup): aborts arbitrary request ids.
- `POST /start_profile`, `POST /stop_profile`: profiler control.
- `POST /tokenize`, `POST /detokenize` (prefix also covers `/tokenizer_info`): tokenizer access.

Proof of concept against an unmodified server started with `--api-key`:

```
[1] POST /v1/chat/completions no-auth   -> 401
[2] unauth POST /scale_elastic_ep accepted; scaling flag set = True
[3] POST /v1/chat/completions VALID key -> 503 {"error":"The model is currently scaling. ..."}
[4] scale op completed unauth           -> 200 {"message":"Scaled to 1 data parallel engines"}
[5] re-arm POST /scale_elastic_ep       -> 200 (repeatable)
```

Fix: extend the existing `GUARDED_PREFIX` tuple with these top-level paths — same middleware, same `startswith` idiom, no routes moved and no new dependency. Requests to those paths now return 401 exactly like `/v1/*` when a key is configured.

Behavior change: unauthenticated requests to those endpoints are now rejected when `--api-key` is set. Deployments that (deliberately) called `/tokenize` etc. without a key on a key-protected server must now send the key. Behavior is unchanged when no API key is configured (the middleware is not installed), and CORS preflights (`OPTIONS`) and `/health` remain open as before.

Deliberately not covered: the disaggregated `/generate` P/D protocol endpoint and sagemaker `/invocations` (inter-service protocol endpoints where auth is a separate design question), and `VLLM_SERVER_DEV_MODE` routers (local-development-only).

## Test Plan

Added `test_control_plane_routes_require_auth` to `tests/entrypoints/serve/middleware/test_authentication_middleware.py`, covering all seven paths: missing token -> 401, wrong token -> 401, valid token -> 200. The module's existing route auto-discovery tests pick the new prefixes up automatically.

```
PYTHONPATH=. python3 -m pytest tests/entrypoints/serve/middleware/test_authentication_middleware.py -q
```

## Test Result

- New test passes locally (`1 passed`). The parametrized auto-discovery tests could not complete on this macOS host (local env lacks `transformers` v5; pre-existing MPS allocator teardown crash) — relying on CI for the parametrized sweep.
- End-to-end PoC against a stubbed engine before the fix: unauthenticated `POST /scale_elastic_ep` was accepted, the scaling flag was set, and subsequent **valid-key** requests got 503. After the fix: unauthenticated `POST /scale_elastic_ep` -> `401 {"error":"Unauthorized"}` (same for `/is_scaling_elastic_ep`, `/start_profile`, `/abort_requests`, `/tokenize`), while an authenticated call still scales normally (`"Scaled to 2 data parallel engines"`).
