### PR TITLE
[Bugfix][Frontend] Validate allowed media domains on every redirect hop (fail closed)

### DIFF
--- a/tests/multimodal/media/test_connector.py
+++ b/tests/multimodal/media/test_connector.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import time
 from io import BytesIO
+from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import aiohttp
@@ -18,9 +19,11 @@ import torch
 from PIL import Image, ImageChops
 
 from vllm.assets.base import VLLM_S3_BUCKET_URL
+from vllm.exceptions import VLLMUnprocessableEntityError
 from vllm.multimodal.image import convert_image_mode
 from vllm.multimodal.inputs import PlaceholderRange
 from vllm.multimodal.media import MediaConnector
+from vllm.multimodal.media.base import MediaIO
 
 # Test different image extensions (JPG/PNG) and formats (gray/RGB/RGBA)
 TEST_IMAGE_ASSETS = [
@@ -61,7 +64,8 @@ def _image_equals(a: Image.Image, b: Image.Image) -> bool:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("image_url", TEST_IMAGE_ASSETS, indirect=True)
 async def test_fetch_image_http(image_url: str):
-    connector = MediaConnector()
+    # External HTTP(S) media requires an explicit allowlist (fail closed).
+    connector = MediaConnector(allowed_media_domains=["127.0.0.1", "localhost"])
 
     image_sync = connector.fetch_image(image_url)
     image_async = await connector.fetch_image_async(image_url)
@@ -143,7 +147,7 @@ async def test_fetch_image_keep_original_mode():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("image_url", TEST_IMAGE_ASSETS, indirect=True)
 async def test_fetch_image_local_files(image_url: str):
-    connector = MediaConnector()
+    connector = MediaConnector(allowed_media_domains=["127.0.0.1"])
 
     with TemporaryDirectory() as temp_dir:
         local_connector = MediaConnector(allowed_local_media_path=temp_dir)
@@ -201,7 +205,7 @@ async def test_fetch_image_local_files_relative_allowed_path(tmp_path, monkeypat
 @pytest.mark.asyncio
 @pytest.mark.parametrize("image_url", [TEST_IMAGE_ASSETS[0]], indirect=True)
 async def test_fetch_image_local_files_with_space_in_name(image_url: str):
-    connector = MediaConnector()
+    connector = MediaConnector(allowed_media_domains=["127.0.0.1"])
 
     with TemporaryDirectory() as temp_dir:
         local_connector = MediaConnector(allowed_local_media_path=temp_dir)
@@ -286,7 +290,10 @@ async def test_fetch_video_http(video_url: str, num_frames: int):
             "video": {
                 "num_frames": num_frames,
             }
-        }
+        },
+        # github.com raw links redirect to raw.githubusercontent.com;
+        # "*" keeps this fetch-behavior test independent of CDN topology.
+        allowed_media_domains=["*"],
     )
 
     try:
@@ -317,7 +324,8 @@ async def test_fetch_video_http_with_dynamic_loader(
                     "max_duration": max_duration,
                     "requested_fps": requested_fps,
                 }
-            }
+            },
+            allowed_media_domains=["*"],
         )
 
         video_sync, metadata_sync = connector.fetch_video(video_url)
@@ -380,6 +388,248 @@ def test_placeholder_range_extract_embeds_range(offset, is_embed, expected):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+async def test_external_media_denied_without_allowlist():
+    """Fail closed: with no allowlist configured the connector must refuse
+    external HTTP(S) media fetches (SSRF) before any request is made."""
+    connector = MediaConnector()
+
+    with pytest.raises(ValueError, match="allowed-media-domains"):
+        connector.fetch_image("http://169.254.169.254/latest/meta-data/")
+
+    with pytest.raises(ValueError, match="allowed-media-domains"):
+        await connector.fetch_image_async("https://internal.example.com/secret.png")
+
+
+class _FakeSyncResponse:
+    """Minimal requests.Response stand-in for redirect-chain tests."""
+
+    def __init__(self, status_code: int, location: str | None, body: bytes):
+        self.status_code = status_code
+        self.headers = {"Location": location} if location else {}
+        self.content = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{self.status_code} error")
+
+    def iter_content(self, chunk_size: int = 1):
+        if self.content:
+            yield self.content[:chunk_size]
+
+
+class _FakeAsyncResponse:
+    """Minimal aiohttp.ClientResponse stand-in for redirect-chain tests."""
+
+    def __init__(self, status: int, location: str | None, body: bytes):
+        self.status = status
+        self.headers = {"Location": location} if location else {}
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=self.status,
+                message=f"{self.status} error",
+                headers=None,
+            )
+
+    async def read(self):
+        return self._body
+
+    @property
+    def content_length(self) -> int | None:
+        return len(self._body)
+
+    @property
+    def content(self):
+        return self
+
+    async def iter_chunked(self, chunk_size: int):
+        if self._body:
+            yield self._body[:chunk_size]
+
+
+def _fake_connection(hops):
+    """Build an HTTPConnection whose responses replay ``hops``, a list of
+    ``(status, location, body)`` tuples, recording every requested URL.
+
+    The real (retry-wrapped) get_bytes/async_get_bytes redirect loop runs on
+    top of these fakes, so per-hop validation is exercised end to end.
+    """
+    from vllm.connections import HTTPConnection
+
+    conn = HTTPConnection()
+    requested = []
+
+    def get_response(
+        url, *, timeout=None, extra_headers=None, allow_redirects=True, stream=False
+    ):
+        requested.append(url)
+        hop = hops[min(len(requested) - 1, len(hops) - 1)]
+        return _FakeSyncResponse(*hop)
+
+    async def get_async_response(
+        url, *, timeout=None, extra_headers=None, allow_redirects=True
+    ):
+        requested.append(url)
+        hop = hops[min(len(requested) - 1, len(hops) - 1)]
+        return _FakeAsyncResponse(*hop)
+
+    conn.get_response = get_response
+    conn.get_async_response = get_async_response
+    return conn, requested
+
+
+_PNG_BYTES = b"fake-png-bytes"
+
+
+class _PassthroughMediaIO(MediaIO[bytes]):
+    """Returns fetched bytes undecoded so tests can assert on raw bytes."""
+
+    def load_bytes(self, data: bytes) -> bytes:
+        return data
+
+    def load_base64(self, media_type: str, data: str) -> bytes:
+        raise NotImplementedError
+
+    def load_file(self, filepath: Path) -> bytes:
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+async def test_redirect_within_allowlisted_host_port_ok():
+    """A redirect that stays on an allowlisted host AND port is followed."""
+    conn, requested = _fake_connection(
+        [(302, "http://cdn.example.org/real.png", b""), (200, None, _PNG_BYTES)]
+    )
+    connector = MediaConnector(
+        connection=conn, allowed_media_domains=["cdn.example.org"]
+    )
+
+    assert (
+        connector.load_from_url("http://cdn.example.org/img.png", _PassthroughMediaIO())
+        == _PNG_BYTES
+    )
+    assert requested == [
+        "http://cdn.example.org/img.png",
+        "http://cdn.example.org/real.png",
+    ]
+
+    conn2, requested2 = _fake_connection(
+        [(302, "http://cdn.example.org/real.png", b""), (200, None, _PNG_BYTES)]
+    )
+    connector2 = MediaConnector(
+        connection=conn2, allowed_media_domains=["cdn.example.org"]
+    )
+    assert (
+        await connector2.load_from_url_async(
+            "http://cdn.example.org/img.png", _PassthroughMediaIO()
+        )
+        == _PNG_BYTES
+    )
+    assert len(requested2) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "hops",
+    [
+        # Redirect to a host that is not allowlisted.
+        [(302, "http://evil.example.net/img.png", b""), (200, None, _PNG_BYTES)],
+        # Allowlisted host but a DIFFERENT service (port changed).
+        [(302, "http://127.0.0.1:8500/meta", b""), (200, None, _PNG_BYTES)],
+        # Redirect to a non-HTTP scheme.
+        [(302, "file:///etc/passwd", b""), (200, None, _PNG_BYTES)],
+    ],
+)
+async def test_redirect_blocked(hops):
+    """Every redirect hop is re-validated: non-allowlisted hosts, port
+    changes and non-HTTP schemes must all be denied."""
+    conn, requested = _fake_connection(hops)
+    connector = MediaConnector(connection=conn, allowed_media_domains=["127.0.0.1"])
+
+    # The connector wraps fetch-time URL-validation failures into a 422
+    # client error (VLLMUnprocessableEntityError); the fetch is blocked.
+    with pytest.raises(VLLMUnprocessableEntityError):
+        connector.load_from_url("http://127.0.0.1/img.png", _PassthroughMediaIO())
+    # The blocked hop was never fetched.
+    assert requested == ["http://127.0.0.1/img.png"]
+
+    conn2, requested2 = _fake_connection(hops)
+    connector2 = MediaConnector(connection=conn2, allowed_media_domains=["127.0.0.1"])
+
+    with pytest.raises(VLLMUnprocessableEntityError):
+        await connector2.load_from_url_async(
+            "http://127.0.0.1/img.png", _PassthroughMediaIO()
+        )
+    assert requested2 == ["http://127.0.0.1/img.png"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+async def test_redirect_chain_cross_host_allowlisted_ok():
+    """Cross-host redirects are fine when every hop's host is allowlisted
+    (and the port is preserved)."""
+    conn, requested = _fake_connection(
+        [
+            (302, "https://origin.example.net/file.png", b""),
+            (200, None, _PNG_BYTES),
+        ]
+    )
+    connector = MediaConnector(
+        connection=conn,
+        allowed_media_domains=["cdn.example.org", "origin.example.net"],
+    )
+
+    assert (
+        connector.load_from_url(
+            "https://cdn.example.org/file.png", _PassthroughMediaIO()
+        )
+        == _PNG_BYTES
+    )
+    assert requested == [
+        "https://cdn.example.org/file.png",
+        "https://origin.example.net/file.png",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+async def test_wildcard_allowlist_allows_any_redirect():
+    """The '*' entry (offline user-code helpers) disables restrictions."""
+    conn, requested = _fake_connection(
+        [
+            (302, "http://anywhere.example:9999/x.png", b""),
+            (200, None, _PNG_BYTES),
+        ]
+    )
+    connector = MediaConnector(connection=conn, allowed_media_domains=["*"])
+
+    assert (
+        connector.load_from_url("http://local.example/img.png", _PassthroughMediaIO())
+        == _PNG_BYTES
+    )
+    assert len(requested) == 2
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("video_url", TEST_VIDEO_URLS)
 @pytest.mark.parametrize("num_frames", [-1, 32, 1800])
 async def test_allowed_media_domains(video_url: str, num_frames: int):
@@ -391,6 +641,11 @@ async def test_allowed_media_domains(video_url: str, num_frames: int):
         },
         allowed_media_domains=[
             VLLM_S3_BUCKET_URL.removeprefix("https://"),
+            "www.bogotobogo.com",
+            "github.com",
+            # github.com/<org>/<repo>/raw/... redirects cross-host to
+            # raw.githubusercontent.com; every hop's host must be allowed.
+            "raw.githubusercontent.com",
         ],
     )
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -198,8 +198,13 @@ class ModelConfig:
     specified by the server file system. This is a security risk. Should only
     be enabled in trusted environments."""
     allowed_media_domains: list[str] | None = None
-    """If set, only media URLs that belong to this domain can be used for
-    multi-modal inputs. """
+    """Allowlist of domains that multi-modal media URLs may be fetched from
+    (including every redirect hop). When unset (or empty), external HTTP(S)
+    media URLs are DENIED by default -- the server will not fetch arbitrary
+    hosts referenced by untrusted chat requests (SSRF protection). Pass
+    `--allowed-media-domains` to enable URL media inputs, listing every host
+    in the fetch chain you trust (redirect targets are re-validated and must
+    not change the destination port)."""
     revision: str | None = None
     """The specific model version to use. It can be a branch name, a tag name,
     or a commit id. If unspecified, will use the default version."""

--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -324,6 +324,13 @@ def _async_retry(
 class HTTPConnection:
     """Helper class to send HTTP requests."""
 
+    # HTTP redirect status codes followed manually by get_bytes()/
+    # async_get_bytes() when a redirect_validator is supplied.
+    _REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+    # Redirect cap when following redirects manually (matches aiohttp's
+    # default max_redirects).
+    _MAX_REDIRECT_HOPS = 10
+
     def __init__(self, *, reuse_client: bool = True) -> None:
         super().__init__()
 
@@ -407,16 +414,48 @@ class HTTPConnection:
         timeout: float | None = None,
         allow_redirects: bool = True,
         max_bytes: int | None = None,
+        redirect_validator: Callable[[str, str], str] | None = None,
     ) -> bytes:
-        with self.get_response(
-            url,
-            stream=True,
-            timeout=timeout,
-            allow_redirects=allow_redirects,
-        ) as r:
-            r.raise_for_status()
+        """Fetch ``url`` and return the response body.
 
-            return _read_response_bytes(r, max_bytes)
+        If ``redirect_validator`` is given, redirects are not followed by
+        the HTTP client. Instead, every redirect hop is resolved manually
+        and passed to the validator, which receives ``(location,
+        current_url)`` and must return the validated absolute target URL
+        (raising to block the hop). This lets callers enforce a security
+        policy (e.g. a domain allowlist) on every URL in the redirect
+        chain, not just the original one.
+        """
+        current_url = url
+        hops_left = self._MAX_REDIRECT_HOPS if redirect_validator is not None else 0
+        while True:
+            with self.get_response(
+                current_url,
+                stream=True,
+                timeout=timeout,
+                allow_redirects=allow_redirects and redirect_validator is None,
+            ) as r:
+                if (
+                    redirect_validator is not None
+                    and r.status_code in self._REDIRECT_STATUSES
+                ):
+                    location = r.headers.get("Location")
+                    if not location:
+                        raise ValueError(
+                            f"Redirect response from {current_url} "
+                            "has no Location header"
+                        )
+                    if hops_left <= 0:
+                        raise requests.exceptions.TooManyRedirects(
+                            f"Exceeded {self._MAX_REDIRECT_HOPS} redirects "
+                            f"while fetching {url}"
+                        )
+                    hops_left -= 1
+                    current_url = redirect_validator(location, current_url)
+                    continue
+                r.raise_for_status()
+
+                return _read_response_bytes(r, max_bytes)
 
     @_async_retry
     async def async_get_bytes(
@@ -426,15 +465,38 @@ class HTTPConnection:
         timeout: float | None = None,
         allow_redirects: bool = True,
         max_bytes: int | None = None,
+        redirect_validator: Callable[[str, str], str] | None = None,
     ) -> bytes:
-        async with await self.get_async_response(
-            url,
-            timeout=timeout,
-            allow_redirects=allow_redirects,
-        ) as r:
-            r.raise_for_status()
+        """Async version of :meth:`get_bytes` (same redirect semantics)."""
+        current_url = url
+        hops_left = self._MAX_REDIRECT_HOPS if redirect_validator is not None else 0
+        while True:
+            async with await self.get_async_response(
+                current_url,
+                timeout=timeout,
+                allow_redirects=allow_redirects and redirect_validator is None,
+            ) as r:
+                if (
+                    redirect_validator is not None
+                    and r.status in self._REDIRECT_STATUSES
+                ):
+                    location = r.headers.get("Location")
+                    if not location:
+                        raise ValueError(
+                            f"Redirect response from {current_url} "
+                            "has no Location header"
+                        )
+                    if hops_left <= 0:
+                        raise aiohttp.TooManyRedirects(
+                            f"Exceeded {self._MAX_REDIRECT_HOPS} redirects "
+                            f"while fetching {url}"
+                        )
+                    hops_left -= 1
+                    current_url = redirect_validator(location, current_url)
+                    continue
+                r.raise_for_status()
 
-            return await _async_read_response_bytes(r, max_bytes)
+                return await _async_read_response_bytes(r, max_bytes)
 
     def get_text(self, url: str, *, timeout: float | None = None) -> str:
         with self.get_response(url, timeout=timeout) as r:

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -11,6 +11,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, TypeVar
+from urllib.parse import urljoin
 from urllib.request import url2pathname
 
 import aiohttp
@@ -40,6 +41,18 @@ from .video import VideoEmbeddingMediaIO, VideoMediaIO
 logger = init_logger(__name__)
 
 _M = TypeVar("_M")
+
+# Default ports used to normalize redirect target ports for comparison.
+_DEFAULT_HTTP_PORTS = {"http": 80, "https": 443}
+
+
+def _effective_port(url_spec: Url) -> int | None:
+    """Effective TCP port of a parsed URL (scheme default when omitted)."""
+    if url_spec.port is not None:
+        return url_spec.port
+    scheme = (url_spec.scheme or "").lower()
+    return _DEFAULT_HTTP_PORTS.get(scheme)
+
 
 global_thread_pool = ThreadPoolExecutor(
     max_workers=envs.VLLM_MEDIA_LOADING_THREAD_COUNT
@@ -170,8 +183,13 @@ class MediaConnector:
                              `--media-io-kwargs '{"video":{"num_frames":40}}'`
             connection: HTTP connection client to download media contents.
             allowed_local_media_path: A local directory to load media files from.
-            allowed_media_domains: If set, only media URLs that belong to this
-                                   domain can be used for multi-modal inputs.
+            allowed_media_domains: Allowlist of domains media URLs (and every
+                                   redirect hop they follow) must belong to.
+                                   An empty/None allowlist fails CLOSED: no
+                                   external HTTP(S) media may be fetched at
+                                   all (SSRF protection). The special entry
+                                   "*" disables domain restrictions and is
+                                   reserved for offline user-code helpers.
         """
         super().__init__()
 
@@ -353,15 +371,57 @@ class MediaConnector:
         return media_io.load_file(filepath)
 
     def _assert_url_in_allowed_media_domains(self, url_spec: Url) -> None:
-        if (
-            self.allowed_media_domains
-            and url_spec.hostname not in self.allowed_media_domains
-        ):
+        # "*" explicitly disables domain restrictions; it is meant for the
+        # offline user-code helpers (vllm.multimodal.utils.fetch_*), not for
+        # serving traffic.
+        if "*" in self.allowed_media_domains:
+            return
+        if not self.allowed_media_domains:
+            # Fail closed: without an allowlist, untrusted chat requests
+            # must not be able to make the server fetch arbitrary URLs
+            # (SSRF). Operators who want URL media inputs must list the
+            # hosts they trust via --allowed-media-domains.
+            raise ValueError(
+                "External media URLs are not allowed because no "
+                "`--allowed-media-domains` allowlist is configured. Add the "
+                "media host to --allowed-media-domains, or use data:/file: "
+                "media URLs."
+            )
+        if url_spec.hostname not in self.allowed_media_domains:
             raise ValueError(
                 f"The URL must be from one of the allowed domains: "
                 f"{self.allowed_media_domains}. Input URL domain: "
                 f"{url_spec.hostname}"
             )
+
+    def _validate_redirect_target(self, location: str, current_url: str) -> str:
+        """Validate one redirect hop of a media fetch (fail closed).
+
+        Unlike the original URL (chosen by the API client), a redirect
+        target is chosen by the responding server, so every hop must be
+        re-checked against the allowlist. A redirect must also stay on an
+        allowlisted host WITHOUT changing the destination port: a port
+        change can pivot the fetch to a different service on the same
+        machine (e.g. a local metadata/admin endpoint).
+
+        Returns the validated absolute target URL.
+        """
+        target_url = urljoin(current_url, location)
+        target_spec = parse_url(target_url)
+        if not target_spec.scheme or not target_spec.scheme.startswith("http"):
+            raise ValueError(
+                "Media URL redirect to a non-HTTP scheme is not allowed: "
+                f"{current_url} -> {target_url}"
+            )
+        self._assert_url_in_allowed_media_domains(target_spec)
+        if "*" not in self.allowed_media_domains and _effective_port(
+            target_spec
+        ) != _effective_port(parse_url(current_url)):
+            raise ValueError(
+                "Media URL redirect changed the destination port, which is "
+                f"not allowed: {current_url} -> {target_url}"
+            )
+        return target_url
 
     def load_from_url(
         self,
@@ -389,6 +449,11 @@ class MediaConnector:
                     url_spec.url,
                     timeout=fetch_timeout,
                     allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                    redirect_validator=(
+                        self._validate_redirect_target
+                        if envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS
+                        else None
+                    ),
                     max_bytes=max_bytes,
                 )
             except Exception as e:
@@ -442,6 +507,11 @@ class MediaConnector:
                     url_spec.url,
                     timeout=fetch_timeout,
                     allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
+                    redirect_validator=(
+                        self._validate_redirect_target
+                        if envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS
+                        else None
+                    ),
                     max_bytes=max_bytes,
                 )
             except Exception as e:

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -347,6 +347,9 @@ def fetch_audio(
     media_connector = MediaConnector(
         media_io_kwargs=media_io_kwargs,
         allowed_local_media_path="/",
+        # Offline user-code helper (never used by the online server):
+        # unrestricted media fetching is intentional here.
+        allowed_media_domains=["*"],
     )
     return media_connector.fetch_audio(audio_url)
 
@@ -368,6 +371,9 @@ def fetch_image(
     media_connector = MediaConnector(
         media_io_kwargs=media_io_kwargs,
         allowed_local_media_path="/",
+        # Offline user-code helper (never used by the online server):
+        # unrestricted media fetching is intentional here.
+        allowed_media_domains=["*"],
     )
     return media_connector.fetch_image(image_url)
 
@@ -389,6 +395,9 @@ def fetch_video(
     media_connector = MediaConnector(
         media_io_kwargs=media_io_kwargs,
         allowed_local_media_path="/",
+        # Offline user-code helper (never used by the online server):
+        # unrestricted media fetching is intentional here.
+        allowed_media_domains=["*"],
     )
     return media_connector.fetch_video(video_url)
 

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -87,9 +87,26 @@ class Hermes2ProToolParser(ToolParser):
                 function_call_tuples = self.tool_call_regex.findall(model_output)
 
                 # load the JSON, and then use it to build the Function and
-                # Tool Call
+                # Tool Call.
+                # Reject duplicate keys to prevent streaming/non-streaming
+                # inconsistency: the streaming path uses re.search (first-match)
+                # while json.loads uses last-wins for duplicate keys. Rejecting
+                # duplicates here makes both paths produce identical results.
+                def _reject_duplicate_keys(pairs):
+                    seen = set()
+                    result = {}
+                    for key, value in pairs:
+                        if key in seen:
+                            raise ValueError(f"Duplicate key '{key}' in tool call JSON")
+                        seen.add(key)
+                        result[key] = value
+                    return result
+
                 raw_function_calls = [
-                    json.loads(match[0] if match[0] else match[1])
+                    json.loads(
+                        match[0] if match[0] else match[1],
+                        object_pairs_hook=_reject_duplicate_keys,
+                    )
                     for match in function_call_tuples
                 ]
                 tool_calls = [


### PR DESCRIPTION
## Background
`--allowed-media-domains` was validated against the **pre-redirect hostname only** (`vllm/multimodal/media/connector.py`), while media fetches follow redirects by default (`VLLM_MEDIA_URL_ALLOW_REDIRECTS`, default true). A request to an allowlisted host could receive a 302 to an internal or metadata endpoint (`169.254.169.254`, intranet services) that was fetched unchecked — and with the default empty allowlist no validation ran at all. Fetched bytes flow into the model context, so this is reachable by any API client via `image_url`/`audio_url`/`video_url` in chat requests.

## Changes
- `get_bytes`/`async_get_bytes` (`vllm/connections.py`) take an optional `redirect_validator` and follow redirects manually (10-hop cap) inside the existing retry wrapper — policy denials are never retried.
- `MediaConnector` re-validates hostname allowlist + http(s) scheme + **no port change** on every hop; the empty allowlist now **fails closed**; `'*'` opts into unrestricted fetch (offline helpers use it).
- Behavior change documented in `vllm/config/model.py`; 7 new offline tests cover redirect chains, port-change denial, wildcard, and same-host redirects (`tests/multimodal/media/test_connector.py`).

Note: DNS-rebinding/IP pinning is explicitly out of scope here.