### PR TITLE
[MyPy] Fix mypy errors in easy tests/v1/kv_connector files (kv-A)

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py
+++ b/tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py
@@ -18,13 +18,14 @@ Environment variables (set by spec_decode_acceptance_test.sh):
 import os
 from dataclasses import dataclass, field
 from types import SimpleNamespace
+from typing import cast
 from urllib.request import urlopen
 
 import openai
 import regex as re
-from transformers import AutoTokenizer
 
 from vllm.benchmarks.datasets import get_samples
+from vllm.tokenizers import get_tokenizer
 
 SERVER_HOST = os.environ.get("SERVER_HOST", "127.0.0.1")
 PROXY_BASE_URL = f"http://{SERVER_HOST}:8192/v1"
@@ -82,7 +83,7 @@ def _get_model_config() -> ModelConfig:
 
 def _get_mt_bench_prompts() -> list[str]:
     """Load MT-Bench prompts via vllm.benchmarks.datasets.get_samples."""
-    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    tokenizer = get_tokenizer(MODEL_NAME)
     args = SimpleNamespace(
         dataset_name="hf",
         dataset_path="philschmid/mt-bench",
@@ -106,7 +107,7 @@ def _get_mt_bench_prompts() -> list[str]:
         request_id_prefix="",
     )
     samples = get_samples(args, tokenizer)
-    return [sample.prompt for sample in samples]
+    return cast(list[str], [sample.prompt for sample in samples])
 
 
 def _fetch_metric(metric_name: str) -> float:

--- a/tests/v1/kv_connector/unit/test_cache_pollution_prevention.py
+++ b/tests/v1/kv_connector/unit/test_cache_pollution_prevention.py
@@ -41,6 +41,7 @@ def _make_get_num_new_matched_tokens(
 def fail_scheduler():
     """scheduler with kv_load_failure_policy='fail'"""
     vllm_config = create_vllm_config()
+    assert vllm_config.kv_transfer_config is not None
     vllm_config.kv_transfer_config.kv_load_failure_policy = "fail"
     return create_scheduler(vllm_config)
 

--- a/tests/v1/kv_connector/unit/test_error_propagation.py
+++ b/tests/v1/kv_connector/unit/test_error_propagation.py
@@ -34,6 +34,7 @@ def _make_get_num_new_matched_tokens(
 def fail_scheduler():
     """scheduler with kv_load_failure_policy='fail'"""
     vllm_config = create_vllm_config()
+    assert vllm_config.kv_transfer_config is not None
     vllm_config.kv_transfer_config.kv_load_failure_policy = "fail"
     return create_scheduler(vllm_config)
 

--- a/tests/v1/kv_connector/unit/test_flexkv_connector.py
+++ b/tests/v1/kv_connector/unit/test_flexkv_connector.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 
 from vllm.config import KVTransferConfig, VllmConfig
+from vllm.config.kv_transfer import KVRole
 from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorRole
 from vllm.v1.kv_cache_interface import KVCacheConfig
 
@@ -31,7 +32,7 @@ from .utils import create_vllm_config
 
 def _make_vllm_config(
     kv_connector: str = "FlexKVConnectorV1",
-    kv_role: str = "kv_both",
+    kv_role: KVRole = "kv_both",
 ) -> VllmConfig:
     """Return a minimal VllmConfig with a KVTransferConfig attached."""
     vllm_config = create_vllm_config(block_size=16, max_num_batched_tokens=512)

--- a/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
+++ b/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
@@ -112,7 +112,7 @@ def _run_engine_core_handshake(
         ),
     )
 
-    engine_core_module.EngineCore(vllm_config, _FakeExecutor, log_stats=False)
+    engine_core_module.EngineCore(vllm_config, _FakeExecutor, log_stats=False)  # type: ignore[arg-type]
     assert _FakeExecutor.last_instance is not None
     return _FakeExecutor.last_instance
 

--- a/tests/v1/kv_connector/unit/test_hf3fs_client.py
+++ b/tests/v1/kv_connector/unit/test_hf3fs_client.py
@@ -121,8 +121,8 @@ class TestHf3fsClientResourceManagement:
 
         # Manually point internal handles to our controllable fakes so that
         # assertions after close() can inspect them directly.
-        client.shm_r = fake_shm_r
-        client.shm_w = fake_shm_w
+        client.shm_r = fake_shm_r  # type: ignore[assignment]
+        client.shm_w = fake_shm_w  # type: ignore[assignment]
         client.file = 99
         return client, fake_shm_r, fake_shm_w
 

--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
@@ -44,6 +44,7 @@ def _make_get_num_new_matched_tokens(
 def fail_scheduler():
     """scheduler with kv_load_failure_policy='fail'"""
     vllm_config = create_vllm_config()
+    assert vllm_config.kv_transfer_config is not None
     vllm_config.kv_transfer_config.kv_load_failure_policy = "fail"
     return create_scheduler(vllm_config)
 
@@ -52,6 +53,7 @@ def fail_scheduler():
 def recompute_scheduler():
     """scheduler with kv_load_failure_policy='recompute'"""
     vllm_config = create_vllm_config()
+    assert vllm_config.kv_transfer_config is not None
     vllm_config.kv_transfer_config.kv_load_failure_policy = "recompute"
     return create_scheduler(vllm_config)
 
@@ -168,9 +170,7 @@ def test_sync_recompute_blocks_not_freed_for_running_requests(
     scheduler_output_2 = recompute_scheduler.schedule()
 
     # request should appear in the new schedule to recompute invalid blocks
-    scheduled_req_ids = [
-        req.request_id for req in scheduler_output_2.scheduled_new_reqs
-    ]
+    scheduled_req_ids = [req.req_id for req in scheduler_output_2.scheduled_new_reqs]
     if scheduler_output_2.num_scheduled_tokens:
         scheduled_req_ids.extend(scheduler_output_2.num_scheduled_tokens.keys())
 

--- a/tests/v1/kv_connector/unit/test_kv_connector_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_kv_connector_lifecycle.py
@@ -16,7 +16,7 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 
 # Importing utils registers TestExampleConnector with the factory
-from .utils import create_vllm_config
+from .utils import TestExampleConnector, create_vllm_config
 
 
 def _make_empty_scheduler_output():
@@ -68,6 +68,7 @@ def test_kv_connector_mixin_clears_metadata():
 
         # Verify clear_connector_metadata was called on the connector
         connector = get_kv_transfer_group()
+        assert isinstance(connector, TestExampleConnector)
         assert connector._connector_metadata is None
         # Test connector wrapper records method calls
         assert connector.call_record.get("bind_connector_metadata", 0) == 1

--- a/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
@@ -242,8 +242,8 @@ def test_sync_load_failure_with_shared_blocks(
 
     assert len(scheduler.running) == 2
     assert len(scheduler_output.scheduled_new_reqs) == 2
-    for request in scheduler_output.scheduled_new_reqs:
-        assert request.num_computed_tokens == expected_computed_tokens[request.req_id]
+    for new_req in scheduler_output.scheduled_new_reqs:
+        assert new_req.num_computed_tokens == expected_computed_tokens[new_req.req_id]
     assert scheduler.connector.get_num_new_matched_tokens.call_count == 2
 
     # Simulate a failure in loading some of the shared blocks.

--- a/tests/v1/kv_connector/unit/test_lmcache_connector.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_connector.py
@@ -225,7 +225,7 @@ class TestUpdateConnectorOutput:
         """Test that _kv_cache_events is set when it was None."""
         kv_events = LMCacheKVEvents(num_workers=1)
         event = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1, 2],
             block_size=16,
@@ -246,7 +246,7 @@ class TestUpdateConnectorOutput:
         # Set up existing events
         existing_events = LMCacheKVEvents(num_workers=2)
         event1 = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -262,7 +262,7 @@ class TestUpdateConnectorOutput:
         # Create new events to add
         new_events = LMCacheKVEvents(num_workers=1)
         event2 = BlockStored(
-            block_hashes=["hash2"],
+            block_hashes=[b"hash2"],
             parent_block_hash=None,
             token_ids=[2],
             block_size=16,
@@ -293,7 +293,7 @@ class TestUpdateConnectorOutput:
         # Create new events from 3 workers
         new_events = LMCacheKVEvents(num_workers=3)
         event = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -315,7 +315,7 @@ class TestUpdateConnectorOutput:
         # First update
         events1 = LMCacheKVEvents(num_workers=1)
         event1 = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -330,7 +330,7 @@ class TestUpdateConnectorOutput:
         # Second update
         events2 = LMCacheKVEvents(num_workers=2)
         event2 = BlockStored(
-            block_hashes=["hash2"],
+            block_hashes=[b"hash2"],
             parent_block_hash=None,
             token_ids=[2],
             block_size=16,
@@ -345,7 +345,7 @@ class TestUpdateConnectorOutput:
         # Third update
         events3 = LMCacheKVEvents(num_workers=1)
         event3 = BlockStored(
-            block_hashes=["hash3"],
+            block_hashes=[b"hash3"],
             parent_block_hash=None,
             token_ids=[3],
             block_size=16,
@@ -367,7 +367,7 @@ class TestUpdateConnectorOutput:
         # First update with actual events
         events1 = LMCacheKVEvents(num_workers=1)
         event1 = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -407,7 +407,7 @@ class TestTakeEvents:
         # Set up events
         kv_events = LMCacheKVEvents(num_workers=1)
         event1 = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -416,7 +416,7 @@ class TestTakeEvents:
             lora_name=None,
         )
         event2 = BlockStored(
-            block_hashes=["hash2"],
+            block_hashes=[b"hash2"],
             parent_block_hash=None,
             token_ids=[2],
             block_size=16,
@@ -443,7 +443,7 @@ class TestTakeEvents:
         # Set up events from multiple workers
         kv_events = LMCacheKVEvents(num_workers=3)
         common_event = BlockStored(
-            block_hashes=["hash_common"],
+            block_hashes=[b"hash_common"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -452,7 +452,7 @@ class TestTakeEvents:
             lora_name=None,
         )
         uncommon_event = BlockStored(
-            block_hashes=["hash_uncommon"],
+            block_hashes=[b"hash_uncommon"],
             parent_block_hash=None,
             token_ids=[2],
             block_size=16,
@@ -483,7 +483,7 @@ class TestTakeEvents:
         # First call with events
         kv_events1 = LMCacheKVEvents(num_workers=1)
         event1 = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -506,7 +506,7 @@ class TestTakeEvents:
         # Third call after adding new events
         kv_events2 = LMCacheKVEvents(num_workers=1)
         event2 = BlockStored(
-            block_hashes=["hash2"],
+            block_hashes=[b"hash2"],
             parent_block_hash=None,
             token_ids=[2],
             block_size=16,
@@ -526,7 +526,7 @@ class TestTakeEvents:
         # Set up events from 2 workers with no common events
         kv_events = LMCacheKVEvents(num_workers=2)
         event1 = BlockStored(
-            block_hashes=["hash1"],
+            block_hashes=[b"hash1"],
             parent_block_hash=None,
             token_ids=[1],
             block_size=16,
@@ -535,7 +535,7 @@ class TestTakeEvents:
             lora_name=None,
         )
         event2 = BlockStored(
-            block_hashes=["hash2"],
+            block_hashes=[b"hash2"],
             parent_block_hash=None,
             token_ids=[2],
             block_size=16,
@@ -687,8 +687,8 @@ class TestIntegrationScenarios:
 
         # Define common and unique events
         common_event = BlockStored(
-            block_hashes=["hash_common"],
-            parent_block_hash="parent_common",
+            block_hashes=[b"hash_common"],
+            parent_block_hash=b"parent_common",
             token_ids=[1, 2, 3],
             block_size=16,
             lora_id=None,
@@ -697,8 +697,8 @@ class TestIntegrationScenarios:
         )
 
         worker1_unique_event = BlockStored(
-            block_hashes=["hash_worker1"],
-            parent_block_hash="parent_w1",
+            block_hashes=[b"hash_worker1"],
+            parent_block_hash=b"parent_w1",
             token_ids=[4, 5],
             block_size=16,
             lora_id=None,
@@ -707,8 +707,8 @@ class TestIntegrationScenarios:
         )
 
         worker2_unique_event = BlockStored(
-            block_hashes=["hash_worker2"],
-            parent_block_hash="parent_w2",
+            block_hashes=[b"hash_worker2"],
+            parent_block_hash=b"parent_w2",
             token_ids=[6, 7],
             block_size=16,
             lora_id=None,
@@ -717,8 +717,8 @@ class TestIntegrationScenarios:
         )
 
         worker3_unique_event = BlockStored(
-            block_hashes=["hash_worker3"],
-            parent_block_hash="parent_w3",
+            block_hashes=[b"hash_worker3"],
+            parent_block_hash=b"parent_w3",
             token_ids=[8, 9],
             block_size=16,
             lora_id=None,
@@ -740,7 +740,7 @@ class TestIntegrationScenarios:
         worker2_events.add_events([common_event, worker3_unique_event])
 
         # Create ModelRunnerOutput instances for each worker
-        worker_outputs = []
+        worker_outputs: list[ModelRunnerOutput | None] = []
         for i, worker_events in enumerate(
             [worker0_events, worker1_events, worker2_events]
         ):
@@ -765,6 +765,8 @@ class TestIntegrationScenarios:
 
         # Use the real aggregation mechanism (like MultiprocExecutor.execute_model)
         aggregated_output = aggregator.aggregate(worker_outputs, output_rank=0)
+        assert aggregated_output is not None
+        assert aggregated_output.kv_connector_output is not None
         kv_cache_events = aggregated_output.kv_connector_output.kv_cache_events
 
         assert isinstance(kv_cache_events, LMCacheKVEvents)
@@ -781,6 +783,6 @@ class TestIntegrationScenarios:
         assert aggregated_events[0] == common_event
 
         # Verify the common event properties
-        assert aggregated_events[0].block_hashes == ["hash_common"]
-        assert aggregated_events[0].parent_block_hash == "parent_common"
+        assert aggregated_events[0].block_hashes == [b"hash_common"]
+        assert aggregated_events[0].parent_block_hash == b"parent_common"
         assert aggregated_events[0].token_ids == [1, 2, 3]

--- a/tests/v1/kv_connector/unit/test_lmcache_integration.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_integration.py
@@ -190,6 +190,7 @@ def test_sampling_params_interface():
     sampling_params = SamplingParams(
         extra_args={"kv_transfer_params": kv_transfer_params}
     )
+    assert sampling_params.extra_args is not None
     assert sampling_params.extra_args["kv_transfer_params"] == kv_transfer_params
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_stats.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_stats.py
@@ -266,7 +266,7 @@ def test_expired_request_bumps_counter():
         "tid1": SendBlockMeta(
             p_req_id="req1",
             transfer_id="tid1",
-            local_block_ids=[0, 1],
+            local_block_ids=[[0, 1]],
             ready=asyncio.Event(),
             expire_time=-1.0,  # Already expired.
             sending=0,

--- a/tests/v1/kv_connector/unit/test_moriio_tp_ack.py
+++ b/tests/v1/kv_connector/unit/test_moriio_tp_ack.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import threading
+from collections import defaultdict
 
 import pytest
 
@@ -250,7 +251,7 @@ def test_worker_get_finished_counts_structured_release_fan_in():
     worker.is_producer = True
     worker.mode = MoRIIOMode.READ
     worker.world_size = 4
-    worker.moriio_wrapper = FakeWrapper()
+    worker.moriio_wrapper = FakeWrapper()  # type: ignore[assignment]
     worker.transfer_id_to_request_id = {"tx-fanin": "req-fanin"}
     worker._consumer_notification_counts = {}
     worker._completed_consumer_notifications = set()
@@ -290,10 +291,11 @@ def test_read_completion_sends_structured_release_with_consumer_tp_size():
         def shutdown(self):
             pass
 
+    wrapper = FakeWrapper()
     worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
     worker.world_size = 8
-    worker.moriio_wrapper = FakeWrapper()
-    worker._recving_transfers = {"req": {"layer0": DoneStatus()}}
+    worker.moriio_wrapper = wrapper  # type: ignore[assignment]
+    worker._recving_transfers = defaultdict(dict, {"req": {"layer0": DoneStatus()}})
     worker._recving_transfers_callback_addr = {
         "req": ("127.0.0.1", "7000", "tx-release")
     }
@@ -301,7 +303,7 @@ def test_read_completion_sends_structured_release_with_consumer_tp_size():
     worker._recving_transfers_start = {}
 
     assert worker._pop_done_transfers() == {"tx-release"}
-    assert worker.moriio_wrapper.sent == [
+    assert wrapper.sent == [
         (
             "tx-release",
             "127.0.0.1",

--- a/tests/v1/kv_connector/unit/test_nixl_simple_cpu_offload.py
+++ b/tests/v1/kv_connector/unit/test_nixl_simple_cpu_offload.py
@@ -27,6 +27,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlConnectorMetadata,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    SimpleCPUOffloadConnector,
+)
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher
 from vllm.v1.kv_cache_interface import (
@@ -278,6 +281,8 @@ def test_cpu_offload_wins_when_nixl_has_no_match():
     assert cpu_meta.store_event >= 0, "Expected a store event on the second schedule"
 
     cpu_connector = mc._connectors[1]
+    assert isinstance(cpu_connector, SimpleCPUOffloadConnector)
+    assert cpu_connector.scheduler_manager is not None
     worker_meta = SimpleCPUOffloadWorkerMetadata(
         completed_store_events={
             cpu_meta.store_event: cpu_connector.scheduler_manager._expected_worker_count

--- a/tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py
@@ -148,6 +148,7 @@ def test_short_prompt_lifecycle():
     # Even though tokens < block_size, there will be kv xfer for partial block.
     eco = scheduler.update_from_output(scheduler_output, model_runner_output)
     kv_transfer_params = eco[0].outputs[0].kv_transfer_params
+    assert kv_transfer_params is not None
 
     assert len(kv_transfer_params["remote_block_ids"]) == 1
 
@@ -205,6 +206,7 @@ def test_prefix_cache_lifecycle():
     model_runner_output = create_model_runner_output(reqs=[request_remote])
     eco = scheduler.update_from_output(scheduler_output, model_runner_output)
     kv_transfer_params = eco[0].outputs[0].kv_transfer_params
+    assert kv_transfer_params is not None
 
     # Ensure we send all block ids, including the partial blocks,
     # even if there is a cache hit.
@@ -258,7 +260,7 @@ def test_abort_during_kv_transfer():
     scheduler_output = scheduler.schedule()
     model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
     model_runner_output.kv_connector_output = KVConnectorOutput(
-        finished_sending=[request.request_id]
+        finished_sending={request.request_id}
     )
     scheduler.update_from_output(scheduler_output, model_runner_output)
     assert_scheduler_empty(scheduler)

--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -126,6 +126,7 @@ def test_basic_lifecycle():
     scheduled_req = scheduler_output.scheduled_new_reqs[0]
     num_scheduled_tokens = scheduler_output.num_scheduled_tokens[request_id]
     num_computed_tokens = scheduled_req.num_computed_tokens
+    assert scheduled_req.prompt_token_ids is not None
     total_prompt_tokens = len(scheduled_req.prompt_token_ids)
     assert num_scheduled_tokens == total_prompt_tokens - num_computed_tokens
 
@@ -633,6 +634,7 @@ def test_p_side_chunked_prefill_mamba(mock_platform):
     # ── Step 1: first chunk ──
     scheduler_output = scheduler.schedule()
 
+    assert request.prompt_token_ids is not None
     assert len(request.prompt_token_ids) == NUM_TOKENS - 1
     assert request.max_tokens == 1
     assert scheduler_output.num_scheduled_tokens[request_id] == BATCH_SIZE

--- a/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
+++ b/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
@@ -60,7 +60,7 @@ class DummyKVConnector(KVConnectorBase_V1):
             block_ids_by_req=block_ids_by_req,
         )
 
-    def start_load_kv(self, kv_caches, finished_req_ids):
+    def start_load_kv(self, forward_context, **kwargs) -> None:
         pass
 
     def wait_for_layer_load(self, layer_name):
@@ -92,7 +92,7 @@ def _my_plugin():
         scheduler_output.block_hashes_by_req = block_hashes_by_req  # type: ignore[attr-defined]
         return connector.build_connector_meta(scheduler_output)
 
-    Scheduler._build_kv_connector_meta = _custom_build_kv_connector_meta
+    Scheduler._build_kv_connector_meta = _custom_build_kv_connector_meta  # type: ignore[method-assign]
 
 
 @pytest.fixture

--- a/tests/v1/kv_connector/unit/test_tp_mapping.py
+++ b/tests/v1/kv_connector/unit/test_tp_mapping.py
@@ -150,11 +150,11 @@ def _make_mock_worker_for_splits(group_spec_types):
     """
     worker = object.__new__(NixlConnectorWorker)
     worker._group_spec_types = group_spec_types
-    worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=False)
+    worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=False)  # type: ignore[assignment]
     worker.block_len_per_layer = []
     worker.num_regions = 0
     worker._region_is_mla = []
-    worker._conv_decomp = SimpleNamespace(local_conv_offsets=())
+    worker._conv_decomp = SimpleNamespace(local_conv_offsets=())  # type: ignore[assignment]
     worker._ssm_region_indices = [0] if MambaSpec in group_spec_types else []
     worker._ple_region_index = None
     return worker
@@ -306,7 +306,7 @@ def test_csa_linear_tp_layout_boundary(total_kv_heads, local_tp, remote_tp, comp
     worker = object.__new__(NixlConnectorWorker)
     worker.world_size = local_tp
     worker._is_csa_linear = True
-    worker.transfer_topo = SimpleNamespace(total_num_kv_heads=total_kv_heads)
+    worker.transfer_topo = SimpleNamespace(total_num_kv_heads=total_kv_heads)  # type: ignore[assignment]
 
     if compatible:
         worker._validate_csa_linear_tp_layout(remote_tp)

--- a/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
+++ b/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
@@ -29,7 +29,7 @@ def _make_topology(
         is_mla=False,
         is_mamba=False,
         total_num_kv_heads=total_num_kv_heads,
-        attn_backends=[_FakeAttentionBackend],
+        attn_backends=[_FakeAttentionBackend],  # type: ignore[list-item]
     )
 
 

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -299,6 +299,9 @@ def create_model_runner_output(
 
 
 class TestExampleConnector(ExampleConnector):
+    # Not a pytest test class despite the name.
+    __test__ = False
+
     def __init__(
         self,
         config: VllmConfig,


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5.1

## Purpose

PR **kv-A** of #49569: fix the mypy errors in the 19 "easy" files under `tests/v1/kv_connector/` 

Preparatory PR per the plan: `tests/v1/kv_connector` stays in `SEPARATE_GROUPS`; kv-C moves it to `SILENT_GROUPS` once kv-B (claimed by @ntu-b12505041) is done.

Not a duplicate: #51043 and #55485 do not touch this directory, and no open PR here addresses mypy errors.

Fixes follow the same priority as PRs 1–4: `assert x is not None` narrowing, then precise annotations, then `cast()`, and scoped `# type: ignore[code]` only for intentional test stubs. A few test literals were corrected to the real types (e.g. `set` instead of `list`, `bytes` block hashes). Counts have drifted since the plan was written (`test_lmcache_connector.py` is 27 today vs 3 in the table); all 19 files are fixed to zero.

One kv-B file is touched: `unit/utils.py` gets `TestExampleConnector.__test__ = False` (one line), because the class is now imported into a test module for an `isinstance` narrow and pytest would otherwise try to collect it. Its own 6 mypy errors are kv-B scope and left as is.

## Test Plan

```bash
FILES=$(git diff --name-only main...HEAD)
KV_A=$(echo "$FILES" | grep -v 'unit/utils.py')   # utils.py's remaining errors are kv-B scope

# silent mode, the strictness kv-C will enforce
for v in 3.10 3.12; do
  .venv/bin/mypy --python-version $v --follow-imports silent --warn-unused-ignores $KV_A
done

# hooks as CI runs them
pre-commit run mypy-3.10 --files $FILES
pre-commit run mypy-3.12 --hook-stage manual --files $FILES
pre-commit run ruff-check --files $FILES
pre-commit run ruff-format --files $FILES
pre-commit run typos --files $FILES

.venv/bin/python -m pytest -q $(echo "$FILES" | grep '^tests/v1/kv_connector/unit/test_')
```

## Test Result

- mypy 1.20.2, `--follow-imports silent`, 3.10 and 3.12: the 19 kv-A files go from 63 errors to 0, no unused ignores. The rest of `tests/v1/kv_connector` still has errors in kv-B/kv-C files, as planned.
- pre-commit `mypy-3.10`, `mypy-3.12`, `ruff-check`, `ruff-format`, `typos`: pass.
- pytest on the 18 touched unit files: `151 passed, 6 skipped` (`hf3fs_fuse.io` not installed). `test_spec_decode_acceptance.py` needs the PD server harness and was not run; its prompt loading was checked to give identical output with the new tokenizer.

AI assistance: prepared with Claude Code (Claude Fable 5.1); I reviewed every changed line and ran the commands above locally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

