### PR TITLE
[Bugfix][Tool Parser] HY-V4 streaming: fix name boundary, drop nameless calls

### DIFF
--- a/tests/tool_parsers/test_hy_v4_tool_parser.py
+++ b/tests/tool_parsers/test_hy_v4_tool_parser.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the HYV4 tool call parser."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from transformers import AutoTokenizer
+
+from tests.tool_parsers.common_tests import ToolParserTestConfig, ToolParserTests
+from tests.tool_parsers.utils import (
+    run_tool_extraction,
+    run_tool_extraction_streaming,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.hy_v4_tool_parser import (
+    HYV4ToolParser,
+    build_tool_extractor,
+    detect_token_suffix,
+)
+
+STRUCTURAL_TOKENS = [
+    "<tool_calls>",
+    "</tool_calls>",
+    "<tool_call>",
+    "</tool_call>",
+    "<arg_key>",
+    "</arg_key>",
+    "<arg_value>",
+    "</arg_value>",
+]
+
+
+def _tokenizer_with_structural_tokens(suffix: str = "") -> TokenizerLike:
+    """gpt2 plus the HYV4 structural tokens, so they tokenize atomically.
+
+    The extractor requires the tool-call tokens in ``get_vocab()`` and the
+    streaming path detects markers on token ids, so the shared suite needs a
+    real tokenizer whose vocab carries them.
+    """
+    tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
+    tokenizer.add_tokens([t.replace(">", f"{suffix}>") for t in STRUCTURAL_TOKENS])
+    return tokenizer
+
+
+class _FakeVocabTokenizer:
+    """Minimal stand-in for ``detect_token_suffix``, which only reads a vocab."""
+
+    def __init__(self, tokens: list[str], init_kwargs: dict | None = None):
+        self._tokens = tokens
+        self.init_kwargs = init_kwargs or {}
+
+    def get_vocab(self) -> dict[str, int]:
+        return {token: i for i, token in enumerate(self._tokens)}
+
+
+class TestHYV4ToolParser(ToolParserTests):
+    @pytest.fixture(scope="class")
+    def tokenizer(self) -> TokenizerLike:
+        return _tokenizer_with_structural_tokens()
+
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return ToolParserTestConfig(
+            parser_name="hy_v4",
+            no_tool_calls_output=(
+                "How can I help you today? I can check the weather for you."
+            ),
+            single_tool_call_output=(
+                "<tool_calls><tool_call>get_weather\n"
+                "<arg_key>city</arg_key><arg_value>Tokyo</arg_value>\n"
+                "<arg_key>unit</arg_key><arg_value>celsius</arg_value>\n"
+                "</tool_call></tool_calls>"
+            ),
+            parallel_tool_calls_output=(
+                "<tool_calls><tool_call>get_weather\n"
+                "<arg_key>city</arg_key><arg_value>Tokyo</arg_value>\n"
+                "</tool_call><tool_call>search_hotels\n"
+                "<arg_key>location</arg_key><arg_value>Tokyo</arg_value>\n"
+                "</tool_call></tool_calls>"
+            ),
+            various_data_types_output=(
+                "<tool_calls><tool_call>test_function\n"
+                "<arg_key>string_field</arg_key><arg_value>hello</arg_value>\n"
+                "<arg_key>int_field</arg_key><arg_value>42</arg_value>\n"
+                "<arg_key>float_field</arg_key><arg_value>3.14</arg_value>\n"
+                "<arg_key>bool_field</arg_key><arg_value>true</arg_value>\n"
+                "<arg_key>null_field</arg_key><arg_value>null</arg_value>\n"
+                '<arg_key>array_field</arg_key><arg_value>["a", "b"]</arg_value>\n'
+                "<arg_key>object_field</arg_key>"
+                '<arg_value>{"nested": "value"}</arg_value>\n'
+                "</tool_call></tool_calls>"
+            ),
+            empty_arguments_output=(
+                "<tool_calls><tool_call>get_current_time</tool_call></tool_calls>"
+            ),
+            surrounding_text_output=(
+                "Let me check the weather for you."
+                "<tool_calls><tool_call>get_weather\n"
+                "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                "</tool_call></tool_calls>"
+            ),
+            escaped_strings_output=(
+                "<tool_calls><tool_call>send_message\n"
+                "<arg_key>text</arg_key>"
+                '<arg_value>He said "hello"</arg_value>\n'
+                "<arg_key>path</arg_key>"
+                "<arg_value>C:\\Users\\file</arg_value>\n"
+                "</tool_call></tool_calls>"
+            ),
+            malformed_input_outputs=[
+                # no inner <tool_call> tags -> nothing extracted
+                "<tool_calls>get_weather\n"
+                "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                "</tool_calls>",
+                # tags present, function name absent
+                "<tool_calls><tool_call>\n"
+                "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                "</tool_call></tool_calls>",
+                # unbalanced <tool_call> vs </tool_call>
+                "<tool_calls><tool_call>get_weather\n"
+                "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                "</tool_calls>",
+                # unbalanced <arg_key> vs </arg_key>
+                "<tool_calls><tool_call>get_weather\n"
+                "<arg_key>city<arg_value>Paris</arg_value>\n"
+                "</tool_call></tool_calls>",
+            ],
+            single_tool_call_expected_name="get_weather",
+            single_tool_call_expected_args={"city": "Tokyo", "unit": "celsius"},
+            single_tool_call_expected_content=None,
+            parallel_tool_calls_count=2,
+            parallel_tool_calls_names=["get_weather", "search_hotels"],
+            # HYV4 types arguments from the tool's JSON Schema; the shared suite
+            # sends no tools, so every value stays a string. Typed parsing is
+            # covered by test_arguments_typed_from_tool_schema below.
+            supports_typed_arguments=False,
+            xfail_streaming={
+                "test_malformed_input": (
+                    "The shared tool_parser fixture reuses one instance across "
+                    "every malformed input. The unbalanced-<tool_call> input "
+                    "never closes its call, so the next input streams into "
+                    "leaked state and trips the reconstructor's id/index "
+                    "assertions. Harness artifact, not a serving path; #51559 "
+                    "moves the suite to per-request instances."
+                ),
+            },
+            xfail_nonstreaming={},
+        )
+
+
+@pytest.fixture(scope="module")
+def hy_v4_tokenizer() -> TokenizerLike:
+    return _tokenizer_with_structural_tokens()
+
+
+@pytest.fixture
+def hy_v4_tool_parser(hy_v4_tokenizer) -> HYV4ToolParser:
+    return HYV4ToolParser(hy_v4_tokenizer)
+
+
+@pytest.fixture
+def typed_request() -> ChatCompletionRequest:
+    request = Mock(spec=ChatCompletionRequest)
+    request.tools = [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="test_function",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "count": {"type": "integer"},
+                        "ratio": {"type": "number"},
+                        "enabled": {"type": "boolean"},
+                        "label": {"type": "string"},
+                        "items": {"type": "array"},
+                    },
+                },
+            ),
+        )
+    ]
+    request.tool_choice = "auto"
+    request.structured_outputs = None
+    return request
+
+
+class TestHYV4SuffixDetection:
+    def test_unsuffixed_vocab(self):
+        tokenizer = _FakeVocabTokenizer(STRUCTURAL_TOKENS)
+        assert detect_token_suffix(tokenizer) == ""
+
+    def test_suffixed_vocab(self):
+        suffix = ":6124c78e"
+        tokens = [t.replace(">", f"{suffix}>") for t in STRUCTURAL_TOKENS]
+        assert detect_token_suffix(tokenizer=_FakeVocabTokenizer(tokens)) == suffix
+
+    def test_no_structural_tokens(self):
+        assert detect_token_suffix(_FakeVocabTokenizer(["hello", "world"])) == ""
+
+    def test_transformers_5_model_specific_tokens_rejected(self):
+        import transformers
+
+        if int(transformers.__version__.split(".")[0]) < 5:
+            pytest.skip("branch only reachable on transformers 5")
+        tokenizer = _FakeVocabTokenizer(
+            STRUCTURAL_TOKENS,
+            init_kwargs={
+                "model_specific_special_tokens": {"think_begin_token": "<think>"}
+            },
+        )
+        with pytest.raises(RuntimeError, match="transformers 5 no longer supports"):
+            detect_token_suffix(tokenizer)
+
+    def test_missing_tool_call_tokens_raises(self):
+        tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
+        with pytest.raises(RuntimeError, match="could not locate tool call"):
+            build_tool_extractor(tokenizer, strict=True)
+
+
+class TestHYV4Arguments:
+    def test_arguments_typed_from_tool_schema(self, hy_v4_tool_parser, typed_request):
+        output = (
+            "<tool_calls><tool_call>test_function\n"
+            "<arg_key>count</arg_key><arg_value>42</arg_value>\n"
+            "<arg_key>ratio</arg_key><arg_value>3.14</arg_value>\n"
+            "<arg_key>enabled</arg_key><arg_value>true</arg_value>\n"
+            "<arg_key>label</arg_key><arg_value>hello</arg_value>\n"
+            '<arg_key>items</arg_key><arg_value>["a", "b"]</arg_value>\n'
+            "</tool_call></tool_calls>"
+        )
+        result = hy_v4_tool_parser.extract_tool_calls(output, request=typed_request)
+        assert result.tools_called
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "count": 42,
+            "ratio": 3.14,
+            "enabled": True,
+            "label": "hello",
+            "items": ["a", "b"],
+        }
+
+
+class TestHYV4Strictness:
+    """The adapter hardcodes strict=True; both extractor paths stay reachable."""
+
+    MALFORMED = (
+        "<tool_calls><tool_call>get_weather\n"
+        "<arg_key>city</arg_key><arg_value>Tokyo</arg_value>\n"
+        "trailing junk\n"
+        "</tool_call></tool_calls>"
+    )
+
+    def test_strict_rejects_unparsed_payload(self, hy_v4_tokenizer):
+        extractor = build_tool_extractor(hy_v4_tokenizer, strict=True)
+        result = extractor.extract_tool_calls(self.MALFORMED, None)
+        assert not result["tools_called"]
+        assert result["tool_calls"] == []
+        assert result["content"] == self.MALFORMED
+
+    def test_non_strict_accepts_unparsed_payload(self, hy_v4_tokenizer):
+        extractor = build_tool_extractor(hy_v4_tokenizer, strict=False)
+        result = extractor.extract_tool_calls(self.MALFORMED, None)
+        assert result["tools_called"]
+        assert result["tool_calls"][0]["name"] == "get_weather"
+
+    def test_adapter_is_strict(self, hy_v4_tool_parser):
+        request = ChatCompletionRequest(messages=[], model="test-model")
+        result = hy_v4_tool_parser.extract_tool_calls(self.MALFORMED, request)
+        assert not result.tools_called
+        assert result.content == self.MALFORMED
+
+
+class TestHYV4BatchedDelta:
+    """One engine delta can carry several complete tool calls (batched or
+    speculative decode). The name boundary and the buffer restart must both
+    stop at the nearer tag, or the first call's name runs into the second and
+    the second call's arguments land on the first."""
+
+    @staticmethod
+    def _assert_matches_nonstreaming(parser, output):
+        streamed = run_tool_extraction_streaming(
+            parser, [output], assert_one_tool_per_delta=False
+        ).tool_calls
+        _, expected = run_tool_extraction(parser, output, streaming=False)
+        assert [
+            (tc.function.name, json.loads(tc.function.arguments)) for tc in streamed
+        ] == [(tc.function.name, json.loads(tc.function.arguments)) for tc in expected]
+        return [tc.function.name for tc in streamed]
+
+    def test_argless_call_then_call_with_args(self, hy_v4_tool_parser):
+        output = (
+            "<tool_calls><tool_call>get_time</tool_call>"
+            "<tool_call>get_weather\n"
+            "<arg_key>city</arg_key><arg_value>Tokyo</arg_value>\n"
+            "</tool_call></tool_calls>"
+        )
+        names = self._assert_matches_nonstreaming(hy_v4_tool_parser, output)
+        assert names == ["get_time", "get_weather"]
+
+    def test_empty_name_then_call_with_args(self, hy_v4_tool_parser):
+        output = (
+            "<tool_calls><tool_call></tool_call>"
+            "<tool_call>get_weather\n"
+            "<arg_key>city</arg_key><arg_value>Tokyo</arg_value>\n"
+            "</tool_call></tool_calls>"
+        )
+        streamed = run_tool_extraction_streaming(
+            hy_v4_tool_parser, [output], assert_one_tool_per_delta=False
+        ).tool_calls
+        assert [tc.function.name for tc in streamed] == ["get_weather"]
+        assert json.loads(streamed[0].function.arguments) == {"city": "Tokyo"}
+
+
+class TestHYV4StreamingState:
+    def test_state_is_aliased_to_extractor(self, hy_v4_tool_parser):
+        assert hy_v4_tool_parser.prev_tool_call_arr is (
+            hy_v4_tool_parser._extractor.prev_tool_call_arr
+        )
+        assert hy_v4_tool_parser.streamed_args_for_tool is (
+            hy_v4_tool_parser._extractor.streamed_args_for_tool
+        )
+
+    def test_empty_function_name_is_not_streamed(self, hy_v4_tool_parser):
+        """A nameless tool call is dropped, not emitted for the client to call."""
+        output = (
+            "<tool_calls><tool_call>\n"
+            "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+            "</tool_call></tool_calls>"
+        )
+        _, tool_calls = run_tool_extraction(hy_v4_tool_parser, output, streaming=True)
+        assert tool_calls == []
+
+    def test_state_populated_after_streaming(self, hy_v4_tool_parser):
+        output = (
+            "<tool_calls><tool_call>get_weather\n"
+            "<arg_key>city</arg_key><arg_value>Tokyo</arg_value>\n"
+            "</tool_call></tool_calls>"
+        )
+        _, tool_calls = run_tool_extraction(hy_v4_tool_parser, output, streaming=True)
+        assert len(tool_calls) == 1
+        assert hy_v4_tool_parser.prev_tool_call_arr
+        assert hy_v4_tool_parser.prev_tool_call_arr[-1]["name"] == "get_weather"
+        assert json.loads(hy_v4_tool_parser.streamed_args_for_tool[-1]) == {
+            "city": "Tokyo"
+        }

--- a/tests/tool_parsers/test_hy_v4_tool_parser.py
+++ b/tests/tool_parsers/test_hy_v4_tool_parser.py
@@ -116,21 +116,29 @@ class TestHYV4ToolParser(ToolParserTests):
             ),
             malformed_input_outputs=[
                 # no inner <tool_call> tags -> nothing extracted
-                "<tool_calls>get_weather\n"
-                "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
-                "</tool_calls>",
+                (
+                    "<tool_calls>get_weather\n"
+                    "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                    "</tool_calls>"
+                ),
                 # tags present, function name absent
-                "<tool_calls><tool_call>\n"
-                "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
-                "</tool_call></tool_calls>",
+                (
+                    "<tool_calls><tool_call>\n"
+                    "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                    "</tool_call></tool_calls>"
+                ),
                 # unbalanced <tool_call> vs </tool_call>
-                "<tool_calls><tool_call>get_weather\n"
-                "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
-                "</tool_calls>",
+                (
+                    "<tool_calls><tool_call>get_weather\n"
+                    "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                    "</tool_calls>"
+                ),
                 # unbalanced <arg_key> vs </arg_key>
-                "<tool_calls><tool_call>get_weather\n"
-                "<arg_key>city<arg_value>Paris</arg_value>\n"
-                "</tool_call></tool_calls>",
+                (
+                    "<tool_calls><tool_call>get_weather\n"
+                    "<arg_key>city<arg_value>Paris</arg_value>\n"
+                    "</tool_call></tool_calls>"
+                ),
             ],
             single_tool_call_expected_name="get_weather",
             single_tool_call_expected_args={"city": "Tokyo", "unit": "celsius"},

--- a/vllm/tool_parsers/hy_v4_tool_parser.py
+++ b/vllm/tool_parsers/hy_v4_tool_parser.py
@@ -710,15 +710,26 @@ class HYV4ToolExtractor:
                     break
 
                 name_start = start_idx + len(self.tool_call_start_token)
-                name_end = arg_idx if arg_idx != -1 else end_idx
+                # Both are searched from start_idx, so a buffered delta that
+                # holds a complete argument-less call followed by a call with
+                # arguments has arg_idx pointing into the second call. The name
+                # ends at whichever tag comes first.
+                name_end = min(i for i in (arg_idx, end_idx) if i != -1)
 
                 tool_name = cur_text[name_start:name_end].strip()
+                if not tool_name:
+                    # Mirror the strict non-streaming guard: a tool call with
+                    # no function name is never emitted, since the client would
+                    # try to dispatch it. Skip the malformed call once its
+                    # closing tag has arrived.
+                    if end_idx == -1:
+                        self._buffer = cur_text[start_idx:]
+                        break
+                    self._buffer = cur_text[end_idx + len(self.tool_call_end_token) :]
+                    continue
                 self._streaming_tool_name = tool_name
 
-                if arg_idx != -1:
-                    self._buffer = cur_text[arg_idx:]
-                else:
-                    self._buffer = cur_text[end_idx:]
+                self._buffer = cur_text[name_end:]
 
                 # Increment tool_id and mark that a name chunk should be emitted
                 self.current_tool_id += 1


### PR DESCRIPTION
## Purpose

`vllm/tool_parsers/hy_v4_tool_parser.py` is registered as `hy_v4` and is selectable by
any user via `--tool-call-parser hy_v4`. At the time of writing, `grep -rl hy_v4 tests/`
returned nothing. No test module in the repo exercised it.

Adding that coverage surfaced two bugs in the streaming path, both in the few lines that
slice the tool name out of the buffer. This PR fixes both and adds the test module.

### Bug 1: name boundary picks the wrong tag

Once a `<tool_call>` start is buffered, the parser searches forward for the first
`<arg_key>` and the first `</tool_call>`, both from `start_idx`:

```python
arg_idx = cur_text.find(self.arg_key_start_token, start_idx)
end_idx = cur_text.find(self.tool_call_end_token, start_idx)
name_end = arg_idx if arg_idx != -1 else end_idx
```

`arg_idx` wins whenever it is not `-1`, even when `end_idx` is closer. When one delta
carries an argument-less call followed by a call with arguments, `arg_idx` points into
the second call, and the name slice runs through the first call's closing tag. For:

```
<tool_call>get_time</tool_call><tool_call>get_weather<arg_key>city</arg_key>...
```

streaming emitted one call named `get_time</tool_call><tool_call>get_weather`, and
`get_time` was lost. The buffer restart three lines down had the same preference, so
after fixing `name_end` alone the second call's opener was skipped and its arguments
were attached to `get_time`.

Both sites now use the nearer tag: `name_end = min(i for i in (arg_idx, end_idx) if i != -1)`
and `self._buffer = cur_text[name_end:]`.

Single-token deltas never trigger this, which is why the shared suite's streaming tests
did not catch it. Batched and speculative decode deliver the whole
`</tool_call><tool_call>name<arg_key>` sequence in one delta and do.

### Bug 2: empty function name is emitted

The name was set without checking it was non-empty. For a malformed block:

```
<tool_calls><tool_call>
<arg_key>city</arg_key><arg_value>Paris</arg_value>
</tool_call></tool_calls>
```

the strict non-streaming path returns `tools_called=False` (it raises
`"Empty function name in tool call."` internally), while streaming emitted a
`DeltaToolCall` with `function.name == ""`, which a client will attempt to dispatch.
Same class of defect as #53539 in HY-V3.

The fix mirrors the strict guard: when the name is empty, skip the malformed call once
its closing tag has arrived. Two branches are needed because streaming sees partial text;
if `</tool_call>` has not arrived yet the call is known to be bad but cannot be skipped,
so it buffers and waits. The skip runs before `current_tool_id += 1`, so a valid call
following a nameless one keeps its index.

Bug 1 also defeated this guard: `<tool_call></tool_call><tool_call>get_weather<arg_key>`
in one delta produced `tool_name = "</tool_call><tool_call>get_weather"`, which is
non-empty garbage, so the emptiness check never fired. Fixing bug 1 makes the guard
reliable.

### Known limitations, not changed here

- When the empty-name guard skips a call, streaming yields `content=None`, whereas
  non-streaming returns the raw block as content. The malformed text is dropped rather
  than surfaced. This is still strictly better than emitting a nameless call, but it is
  not full parity.
- For a block with an unbalanced `<tool_call>` (no closing tag), streaming emits a call
  with unterminated argument JSON (`{"city": "Paris"`) via the existing end-of-output
  handling. Pre-existing and independent of this change; noted so it is not mistaken for
  a regression.
- The non-strict `_extract_tool_calls` path has no empty-name guard. It is unreachable in
  serving because `HYV4ToolParser` hardcodes `strict=True`, and I did not want to widen
  the diff into a path the adapter never takes.

## Not a duplicate

Searches run against `vllm-project/vllm`, open PRs:

```
gh pr list --repo vllm-project/vllm --state open --search "hy_v4"
gh pr list --repo vllm-project/vllm --state open --search "hunyuan tool parser"
gh pr list --repo vllm-project/vllm --state open --search "tool parser test coverage"
```

No open PR adds `hy_v4` tests or touches either defect. The nearest neighbours are
distinct:

- **#55154**, **#54432**: open HY-V4 work, but kernel and ROCm respectively, not the parser.
- **#51559**: extends the shared parity suite to hermes, granite4, pythonic, llama4_pythonic, olmo3, minimax_m2. Different parsers.
- **#55079**: adds a streaming split-invariance test to the common suite. Different test, and it applies to all parsers.
- **#55255**: unpaired reasoning closers across six other parsers.
- **#49535**: hunyuan_a13b / xlam streaming, a different code path.
- **#53539**: the same class of bug as bug 2, but in HY-V3, a separate parser file.
- **#54488**, **#52133**: Rust frontend implementations, separate code path.

Related: #51706 adds a coverage ratchet requiring every registered parser to map to a
test module or sit in `PENDING_COVERAGE`. `hy_v4` was registered in #54160 (2026-08-29),
after that PR opened (2026-08-10), so it appears in neither its mapping nor its pending
list and would currently be flagged as unclassified. This PR closes that gap.

## Test Plan

```
.venv/bin/python -m pytest tests/tool_parsers/test_hy_v4_tool_parser.py -v
.venv/bin/python -m pytest tests/tool_parsers -q
pre-commit run --files vllm/tool_parsers/hy_v4_tool_parser.py \
                       tests/tool_parsers/test_hy_v4_tool_parser.py
pre-commit run mypy-3.12 --all-files --hook-stage manual
```

## Test Result

New module:

```
$ .venv/bin/python -m pytest tests/tool_parsers/test_hy_v4_tool_parser.py -q
30 passed, 1 xfailed, 15 warnings in 14.47s
```

The xfail is `test_malformed_input[True]`. It is not a parser limitation: the shared
`tool_parser` fixture reuses one instance across all four malformed inputs, and the
unbalanced-`<tool_call>` input never closes its call, so the next input streams into
leaked `_streaming_tool_name` state and trips `StreamingToolReconstructor`'s id/index
assertions. With a fresh parser per input, none of the four raises. #51559 moves the
harness to per-request instances, which would remove the need for this mark. It is
strict, so it fails as XPASS the moment that happens.

Full directory, no collateral damage:

```
$ .venv/bin/python -m pytest tests/tool_parsers -q
1081 passed, 1 skipped, 35 xfailed, 21 warnings, 15 errors in 434.73s (0:07:14)
```

The 15 errors are pre-existing and unrelated. Every one is a setup error in
`tests/tool_parsers/test_llama3_json_tool_parser.py` from a gated model download
(`401 Unauthorized` for `meta-llama/Llama-3.2-1B-Instruct`). I confirmed all 15
reproduce on this branch's base commit.

Bug 1 verified directly by feeding the entire output as a single delta, which is what
batched decode does:

| input (one delta) | before | after |
|---|---|---|
| `get_time` (no args) then `get_weather(city)` | 1 call: `get_time</tool_call><tool_call>get_weather` | `get_time`, `get_weather`, arguments matching non-streaming |
| empty name then `get_weather(city)` | 1 call: `</tool_call><tool_call>get_weather` | `get_weather` with `{"city": "Tokyo"}` |

Bug 2 verified directly, fresh parser per input, token-level deltas:

| input | non-streaming | streaming (before) | streaming (after) |
|---|---|---|---|
| empty function name | 0 calls | 1 call, `name=''` | 0 calls |
| empty name, then a valid call | 0 calls | n/a | 1 call, `get_weather`, index 0 |
| valid single call | `get_weather` | `get_weather` | `get_weather` |
| valid parallel calls | `get_weather`, `search_hotels` | same | same |

Lint:

```
$ pre-commit run --files vllm/tool_parsers/hy_v4_tool_parser.py tests/tool_parsers/test_hy_v4_tool_parser.py
ruff check....Passed   ruff format....Passed   typos....Passed
Run mypy for Python 3.10....Passed   Check SPDX headers....Passed
Check for forbidden imports....Passed
```

### On model evals

AGENTS.md asks for eval results on changes affecting output. `tests/evals/` currently
holds only model-level suites (`gsm8k`, `mrcr`, `gpt_oss`, `qwen4_exp`), none of which
exercises tool-call parsing, so there is no eval to run for this change. The evidence
here is the unit coverage above, including the shared suite's streaming/non-streaming
agreement test and the new single-delta agreement tests, which are what a tool-parser
regression would trip. I am happy to run something specific if a reviewer wants it.

## AI assistance

AI tooling (Claude Code) assisted with this change: exploring the parser, drafting the
test module, and drafting this description. A separate AI-assisted review pass found
bug 1 after the initial fix for bug 2 was written; I verified that finding against the
source before acting on it. The commit carries a matching `Co-authored-by` trailer. I
have reviewed every changed line, ran the commands above myself, and can defend the
change in review.
