### PR TITLE
[Pooling] Honor max_embed_len for chunked embeddings

### DIFF
--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -179,7 +179,7 @@ class EmbeddingTokenizeParamsMixin(PoolingTokenizeParamsMixin):
         pooler_config = model_config.pooler_config
         if pooler_config is not None:
             if pooler_config.enable_chunked_processing:
-                max_total_tokens = None
+                max_total_tokens = pooler_config.max_embed_len
             else:
                 max_embed_len = pooler_config.max_embed_len or default_max_total_tokens
                 max_output_tokens = default_max_total_tokens - max_embed_len


### PR DESCRIPTION
## Purpose

Chunked embedding requests ignored an explicitly configured `max_embed_len` because tokenization unconditionally used an unlimited token count. This change honors the configured limit before chunk creation. It only affects explicitly configured limits, ` max_embed_len=None` retains existing unlimited chunked processing. The change only restores request-length validation before chunking,  it does not alter tokenization, MRV2 execution, pooling, or aggregation for valid inputs. MRV2 execution and valid embedding outputs are unchanged.

## Reproducer

Configuration:

```text
max_model_len=4
enable_chunked_processing=true
max_embed_len=8
input_tokens=9
```

On Main:

```text
{'max_total_tokens': None, 'accepted_tokens': 9}
```

On this branch:

```text
HTTP 400 BadRequestError
```

An eight-token boundary request still returns HTTP 200.

## Test Plan

```text
46 focused pooling tests passed
5 MRV2 long-text E2E tests passed
MRV2 HTTP probe: 8 tokens → 200; 9 tokens → 400
File-scoped pre-commit passed
```

## AI Assistance

OpenAI Codex (GPT-5) assisted with drafting the change
