### PR TITLE
[Frontend] glm47 tool parser: required-first schema order in prompt rendering and strict structural tags

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -401,8 +401,13 @@ Supported models:
 
 * `zai-org/GLM-4.7`
 * `zai-org/GLM-4.7-Flash`
+* `zai-org/GLM-5.x` (including `GLM-5.3-Flash`)
 
-Flags: `--tool-call-parser glm47`
+Flags: `--tool-call-parser glm47 --reasoning-parser glm45`
+
+Tool schemas are rendered into the prompt with required properties first, and strict-mode
+structural tags use that same order, so the grammar guarantees every required argument while
+the model keeps the key order it was shown.
 
 ### FunctionGemma Models (`functiongemma`)
 

--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -4,13 +4,17 @@
 """Tests for the GLM-4.7 tool call parser."""
 
 import json
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
+import xgrammar as xgr
 from openai.types.responses import ResponseFunctionToolCall
+from xgrammar.testing import _is_grammar_accept_string
 
 from vllm.entrypoints.generate.base.protocol import FunctionCall
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedFunction,
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
     ChatCompletionToolsParam,
     FunctionDefinition,
@@ -266,3 +270,115 @@ class TestGlm47Streaming:
         ]
         args = json.loads("".join(arguments))
         assert args["city"] == "Beijing"
+
+
+def _preferences_tool(strict: bool | None) -> ChatCompletionToolsParam:
+    return ChatCompletionToolsParam(
+        function=FunctionDefinition(
+            name="collect_preferences",
+            strict=strict,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "note": {"type": "string"},
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "prompt": {"type": "string"},
+                                "choices": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "tag": {"type": "string"},
+                            },
+                            "required": ["prompt", "tag"],
+                        },
+                    },
+                },
+                "required": ["items"],
+            },
+        ),
+    )
+
+
+def _json_schema_formats(node) -> list[dict]:
+    if isinstance(node, dict):
+        found = [node] if node.get("type") == "json_schema" else []
+        return found + [f for v in node.values() for f in _json_schema_formats(v)]
+    if isinstance(node, list):
+        return [f for v in node for f in _json_schema_formats(v)]
+    return []
+
+
+def _call(items: str, note: str | None = None) -> str:
+    args = f"<arg_key>items</arg_key><arg_value>{items}</arg_value>"
+    if note is not None:
+        args += f"<arg_key>note</arg_key><arg_value>{note}</arg_value>"
+    return f"<tool_call>collect_preferences{args}</tool_call>"
+
+
+class TestGlm47StructuralTag:
+    """Strict mode must enforce the same required-first key order the prompt
+    shows the model: the grammar then guarantees required arguments instead of
+    fighting the order the model was primed with."""
+
+    @staticmethod
+    def _tag(tool_choice, strict):
+        tools = [_preferences_tool(strict)]
+        parser = Glm47MoeModelToolParser(MagicMock(), tools=tools)
+        request = ChatCompletionRequest(messages=[], model="m", tools=tools)
+        request.tool_choice = tool_choice
+        tag = parser.get_structural_tag(request)
+        # The request keeps the client's schema order.
+        assert list(tools[0].function.parameters["properties"]) == ["note", "items"]
+        return tag
+
+    def test_auto_without_strict_is_unconstrained(self):
+        assert self._tag("auto", strict=None) is None
+
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "auto",
+            "required",
+            ChatCompletionNamedToolChoiceParam(
+                function=ChatCompletionNamedFunction(name="collect_preferences")
+            ),
+        ],
+    )
+    def test_embedded_schema_uses_required_first_order(self, tool_choice):
+        formats = _json_schema_formats(self._tag(tool_choice, strict=True).model_dump())
+        assert len(formats) == 1
+        schema = formats[0]["json_schema"]
+        assert list(schema["properties"]) == ["items", "note"]
+        assert list(schema["properties"]["items"]["items"]["properties"]) == [
+            "prompt",
+            "tag",
+            "choices",
+        ]
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            _call('[{"prompt": "q", "tag": "t", "choices": ["a"]}]'),
+            _call('[{"prompt": "q", "tag": "t"}]', note="n"),
+            _call("[]"),
+        ],
+    )
+    def test_grammar_accepts_required_first_output(self, output):
+        grammar = xgr.Grammar.from_structural_tag(self._tag("required", strict=True))
+        assert _is_grammar_accept_string(grammar, output, require_termination=False)
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            _call('[{"prompt": "q", "choices": ["a"]}]'),
+            "<tool_call>collect_preferences<arg_key>note</arg_key><arg_value>n"
+            "</arg_value></tool_call>",
+        ],
+    )
+    def test_grammar_rejects_missing_required_key(self, output):
+        grammar = xgr.Grammar.from_structural_tag(self._tag("required", strict=True))
+        assert not _is_grammar_accept_string(grammar, output, require_termination=False)

--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -3,6 +3,7 @@
 
 import ast
 import json
+from typing import Any
 
 import pytest
 
@@ -18,6 +19,7 @@ from vllm.tool_parsers.utils import (
     make_valid_python,
     normalize_leading_zero_ints,
     rename_reserved_kwargs,
+    reorder_properties_required_first,
     restore_reserved_kwarg_names,
 )
 
@@ -764,3 +766,64 @@ class TestRenameReservedKwargs:
             "path": "x",
             "from": 1,
         }
+
+
+class TestReorderPropertiesRequiredFirst:
+    def test_required_first_in_declaration_order(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "tag": {"type": "string"},
+                "choices": {"type": "array"},
+                "prompt": {"type": "string"},
+            },
+            "required": ["prompt", "tag"],
+        }
+        reorder_properties_required_first(schema)
+        assert list(schema["properties"]) == ["prompt", "tag", "choices"]
+
+    def test_recurses_into_array_items(self):
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "detail": {"type": "string"},
+                            "title": {"type": "string"},
+                        },
+                        "required": ["title", "detail"],
+                    },
+                }
+            },
+            "required": ["items"],
+        }
+        reorder_properties_required_first(schema)
+        nested = schema["properties"]["items"]["items"]
+        assert list(nested["properties"]) == ["title", "detail"]
+
+    def test_no_required_keeps_order(self):
+        schema = {
+            "type": "object",
+            "properties": {"b": {"type": "string"}, "a": {"type": "string"}},
+        }
+        reorder_properties_required_first(schema)
+        assert list(schema["properties"]) == ["b", "a"]
+
+    def test_required_entry_missing_from_properties_is_skipped(self):
+        schema = {
+            "type": "object",
+            "properties": {"b": {"type": "string"}, "a": {"type": "string"}},
+            "required": ["missing", "a"],
+        }
+        reorder_properties_required_first(schema)
+        assert list(schema["properties"]) == ["a", "b"]
+
+    def test_non_dict_schemas_pass_through(self):
+        assert reorder_properties_required_first(None) is None
+        assert reorder_properties_required_first(True) is True
+        assert reorder_properties_required_first([{"type": "string"}]) == [
+            {"type": "string"}
+        ]

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -178,6 +178,17 @@ class OnlineRenderer:
             tool_dicts = None
         else:
             tool_dicts = [tool.model_dump() for tool in request.tools]
+            if tool_parser is not None and getattr(
+                tool_parser, "reorder_tool_schema_required_first", False
+            ):
+                from vllm.tool_parsers.utils import (
+                    reorder_properties_required_first,
+                )
+
+                for tool_dict in tool_dicts:
+                    params = tool_dict.get("function", {}).get("parameters")
+                    if params is not None:
+                        reorder_properties_required_first(params)
 
         if not self.use_harmony:
             # Common case.

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -30,7 +30,11 @@ from vllm.sampling_params import (
     StructuredOutputsParams,
 )
 from vllm.tokenizers import TokenizerLike
-from vllm.tool_parsers.utils import Tool, get_json_schema_from_tools
+from vllm.tool_parsers.utils import (
+    Tool,
+    get_json_schema_from_tools,
+    reorder_tools_required_first,
+)
 from vllm.utils.collection_utils import is_list_of
 from vllm.utils.import_utils import import_plugin
 
@@ -59,6 +63,10 @@ class ToolParser:
     # xgrammar builtin structural tag model key. Subclasses set this when
     # their parsed tool-call syntax matches a builtin xgrammar format.
     structural_tag_model: str | None = None
+    # Render each tool's object schemas with required properties first, both
+    # in the prompt (OnlineRenderer) and in the structural tag, so the order
+    # the model is shown is the order the grammar enforces.
+    reorder_tool_schema_required_first: bool = False
     engine_based_streaming: bool = False
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -176,9 +184,12 @@ class ToolParser:
             return None
         from vllm.tool_parsers.structural_tag_registry import get_model_structural_tag
 
+        tools = request.tools
+        if self.reorder_tool_schema_required_first and tools:
+            tools = reorder_tools_required_first(tools)
         return get_model_structural_tag(
             model=self.structural_tag_model,
-            tools=request.tools,
+            tools=tools,
             tool_choice=request.tool_choice,
             reasoning=reasoning,
         )

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -12,4 +12,5 @@ class Glm47MoeModelToolParser(Glm47MoeParserToolAdapter):  # type: ignore[valid-
     # GLM renders tool schemas verbatim into the prompt and follows the
     # property order when emitting arguments; putting required fields first
     # keeps the model from omitting them once it starts on optional fields.
+    # The strict-mode grammar (xgrammar glm_4_7) enforces the same order.
     reorder_tool_schema_required_first = True

--- a/vllm/tool_parsers/glm47_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm47_moe_tool_parser.py
@@ -9,3 +9,7 @@ from vllm.parser.engine.registered_adapters import Glm47MoeParserToolAdapter
 class Glm47MoeModelToolParser(Glm47MoeParserToolAdapter):  # type: ignore[valid-type, misc]
     supports_required_and_named = False
     structural_tag_model = "glm_4_7"
+    # GLM renders tool schemas verbatim into the prompt and follows the
+    # property order when emitting arguments; putting required fields first
+    # keeps the model from omitting them once it starts on optional fields.
+    reorder_tool_schema_required_first = True

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -1089,6 +1089,24 @@ def reorder_properties_required_first(schema: Any) -> Any:
     return schema
 
 
+def reorder_tools_required_first(tools: list[Tool]) -> list[Tool]:
+    """Return copies of *tools* whose parameter schemas are reordered with
+    :func:`reorder_properties_required_first`. Non-function tools pass
+    through unchanged."""
+    reordered: list[Tool] = []
+    for tool in tools:
+        if isinstance(tool, ChatCompletionToolsParam):
+            tool = tool.model_copy(deep=True)
+            tool.function.parameters = reorder_properties_required_first(
+                tool.function.parameters
+            )
+        elif isinstance(tool, FunctionTool):
+            tool = tool.model_copy(deep=True)
+            tool.parameters = reorder_properties_required_first(tool.parameters)
+        reordered.append(tool)
+    return reordered
+
+
 _TYPE_ALIASES: dict[str, str] = {
     "str": "string",
     "text": "string",

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -1050,6 +1050,45 @@ def extract_types_from_schema(schema: Any) -> list[str]:
     return list(types) if types else ["string"]
 
 
+def reorder_properties_required_first(schema: Any) -> Any:
+    """Reorder an object schema's ``properties`` so that fields declared in
+    ``required`` come first (in ``required`` declaration order), followed by
+    optional fields in their original order. Recurses into nested schemas.
+
+    Property order is not semantically meaningful for JSON Schema
+    validation, but chat templates render schemas verbatim into the prompt
+    and models tend to emit arguments in the rendered order; putting
+    required fields first makes the model commit to them before it starts
+    on bulky optional fields (which it may otherwise never return from).
+
+    May mutate and return *schema*; only call it on per-request copies.
+    """
+    if isinstance(schema, list):
+        return [reorder_properties_required_first(s) for s in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    for key in ("properties", "$defs", "definitions"):
+        if isinstance(sub := schema.get(key), dict):
+            schema[key] = {
+                k: reorder_properties_required_first(v) for k, v in sub.items()
+            }
+    for key in ("items", "additionalProperties", "contains"):
+        if isinstance(sub := schema.get(key), (dict, list)):
+            schema[key] = reorder_properties_required_first(sub)
+    for key in ("anyOf", "oneOf", "allOf", "prefixItems"):
+        if isinstance(sub := schema.get(key), list):
+            schema[key] = [reorder_properties_required_first(s) for s in sub]
+
+    props = schema.get("properties")
+    required = schema.get("required")
+    if isinstance(props, dict) and isinstance(required, list) and required:
+        ordered = {k: props[k] for k in required if k in props}
+        ordered.update((k, v) for k, v in props.items() if k not in ordered)
+        schema["properties"] = ordered
+    return schema
+
+
 _TYPE_ALIASES: dict[str, str] = {
     "str": "string",
     "text": "string",


### PR DESCRIPTION
## Purpose

Fix a tool-calling failure mode of the glm47 parser family (GLM-4.5/4.6/4.7/5.x, incl. GLM-5.3-Flash): **the model omits a required property of a nested object when a bulky optional property precedes it in the schema**.

A request (a `collect_preferences` tool whose `items[]` objects require `prompt` + `tag`, with an optional `choices` array declared between them) fails 50-66% of the time on vLLM with GLM-5.3-Flash: the emitted `items[]` objects are missing `tag`. The same failure reproduces on sglang at the same rate (46-60%), so this is a model-behavior boundary issue, not a stack bug.

Mechanism (measured with prefix logprob probes on `/v1/completions`):

- GLM renders tool schemas verbatim into the prompt and tends to emit argument keys following the schema's property order.
- The first key of each item object is a near-tie between the content fields (`p(choices)=0.62` vs `p(prompt)=0.38`, `p(tag)~=0` — the model never opens an object with the label field). Once it starts with the optional `choices` array, the object "feels complete" after `prompt` and `tag` is skipped (`p(tag)` after choices ≈ 0.0002; after prompt ≈ 0.9998). At temp=0 the outcome is still non-deterministic — kernel noise flips the near-tie.
- The coupling is stack-independent (vLLM: prompt-first → 65/65 keep tag, choices-first → 78% lose it; sglang: 11/11 vs 77%).

Fix (two commits on this branch):

1. **`reorder_tool_schema_required_first`**: render each object schema's `properties` with `required` fields first (declaration order), recursing into nested object/array schemas. JSON Schema property order is not semantically meaningful, so validation and clients are unaffected. Opt-in per tool parser; enabled for the glm47 parser family. The reorder runs in `OnlineRenderer` right after the per-request tool dicts are built — the parser's `adjust_request` hook runs *after* chat-template rendering, which is too late to affect the prompt.
2. **Strict-mode alignment**: the structural tag for guided tool calling is now built from the same reordered schema. xgrammar's builtin glm_4_7 tag pins object keys to the schema's declared order (`any_order=False`), so previously the prompt and the grammar disagreed: after the model committed to a required key that the prompt placed early, every optional key declared before it became unreachable and was silently dropped (and we observed a ~1-2% runaway-to-`max_tokens` pathology under concurrency, consistent with the grammar fighting the model's key-order prior). `any_order=True` is not an alternative: per `GrammarCompiler.compile_json_schema` it only bounds the number of entries and does not check key presence or uniqueness.

Not a duplicate: the only in-flight GLM-5.3-Flash PRs we found (#55219 KV layout, #55358 indexer move) are orthogonal; no open PR touches tool-schema rendering order or the glm47 structural tag.

## Test Plan

Unit:

```bash
pytest tests/tool_parsers/test_utils.py -k ReorderPropertiesRequiredFirst   # 5 passed
pytest tests/tool_parsers/test_glm47_moe_tool_parser.py                     # incl. new -k StructuralTag (9 passed)
```

E2E on 4x GB300, `zai-org/GLM-5.3-Flash` (native FP8, TP4, `--tool-call-parser glm47 --reasoning-parser glm45`), the request verbatim, serial non-streaming runs:

## Test Result

Schema-compliance failure rate (`items[]` missing the required `tag`), before → after:

| configuration | baseline | with this PR |
|---|---|---|
| GLM-5.3-Flash, original client payload | 64.5% (129/200; earlier arms 50%/66% at n=30/100) | **14.0% (28/200)** |
| GLM-5.3-Flash, same reorder applied client-side | — | 3% (1/30) |
| GLM-5.3-Flash, this PR + `strict: true` | — | **0% (0/144)** |
| GLM-5.3-NVFP4 (`GlmMoeDsa`, same parser/template) | 12% (6/50) | **0% (0/50)** |
| sglang (`xinyuan/glm-5.3-flash-support`), same payload, for reference | 46.5% (93/200) | — |

Residual failures all start the item object with the optional `choices` key first (the J1 coin flip can still land wrong; only guided decoding or a model-side fix eliminates it).

Strict mode eliminates the residual failures entirely: `"strict": true` on the tool definition with `tool_choice: "auto"` (free text and reasoning stay unconstrained; once the model starts a `<tool_call>`, its arguments are grammar-enforced to match the schema). No server-side flag needed beyond the parser flags above.

## Performance

**Prompt-side reorder cost** (`reorder_properties_required_first` + the per-request `model_dump` copy it operates on): **~48 µs per request** for the original schema (9 µs for the reorder walk alone; the deepcopy dominates and `model_dump` was already happening). Negligible against ~1s request latencies.

**Strict-mode guided decoding overhead**, measured on the same 4x GB300 GLM-5.3-Flash setup with the request (~180 completion tokens, almost all inside the grammar-constrained `<arg_value>` body — a near-worst-case constrained fraction):

| concurrency (n) | baseline | strict (this PR) |
|---|---|---|
| 1 (32) | 1.21s p50, 143.9 tok/s/req | 1.09s p50, 143.9 tok/s/req |
| 16 (48) | 2.89s p50, 6.45s p99 | 2.46s p50, 7.66s p99 |
| 32 (64) | 3.74s p50, 7.78s p99 | 3.51s p50, 7.75s p99 |
| 64 (128) | 4.90s p50, 1677 tok/s agg, 9.81 req/s | 4.84s p50, **1768 tok/s** agg, 9.94 req/s |

Strict is never slower (slightly faster in aggregate: constrained outputs are shorter and more regular). TTFT is unchanged once the grammar is compiled; the first request with a new schema pays the ~0.5s compile (cached per schema afterwards).

> **Per-token grammar cost** (isolated microbenchmark of the xgrammar matcher on this schema): `fill_next_token_bitmask` 82.5 µs/tok + `accept_token` 1.0 µs/tok ≈ **83.5 µs per constrained token**, i.e. ~8.4% of one CPU core per 1000 constrained tok/s of aggregate traffic. The glm_4_7 structural tag is trigger-gated: only tokens inside `<tool_call>` blocks pay this; reasoning and free text are unconstrained.

Behavioral scope note: the reorder changes the rendered prompt for every model served with `--tool-call-parser glm47`/`glm45` (GLM-4.5/4.6/4.7/5.x). On the GLM-5.3 family it strictly helps (table above); other glm47-family models share the same emission-order prior.

`docs/features/tool_calling.md` updated for the GLM-5.x entry.

This change was implemented with AI assistance and reviewed by JaredforReal.
