### PR TITLE
[Feature] Add reasoning_eos_policy to close think on mid-reasoning EOS

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -264,10 +264,12 @@ Some reasoning models (notably Qwen3.8) occasionally sample the chat EOS token (
 
 `reasoning_eos_policy` is a per-request sampling parameter (Chat Completions and Completions, same placement as `thinking_token_budget`):
 
-| Value | Behavior |
-|-------|----------|
-| `"stop"` (default) | Current behavior. EOS/stop inside `<think>` ends the request. |
-| `"force_end"` | If the request is still in the think block and EOS/stop would be sampled (greedy-top, or an accepted speculative token), vLLM masks those tokens and forces `reasoning_end_str`, then continues into the answer. The same `ThinkingBudgetStateHolder` path as an exhausted `thinking_token_budget`. |
+- `"stop"` (default): current behavior. EOS/stop inside `<think>` ends the request.
+- `"force_end"`: if the request is still in the think block and EOS/stop would
+  be sampled (greedy-top, or an accepted speculative token), vLLM masks those
+  tokens and forces `reasoning_end_str`, then continues into the answer. This
+  uses the same `ThinkingBudgetStateHolder` path as an exhausted
+  `thinking_token_budget`.
 
 `ignore_eos` is unchanged: this policy never suppresses EOS outside the think block. A Qwen3 `<tool_call>` started inside `<think>` counts as leaving the think block, so the policy does not rewrite tool-call tokens.
 

--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -258,6 +258,44 @@ To use this feature:
 
 If `thinking_token_budget` is not specified, no explicit reasoning limit is applied beyond normal generation constraints such as `max_tokens`.
 
+## Reasoning EOS Policy
+
+Some reasoning models (notably Qwen3.8) occasionally sample the chat EOS token (`<|im_end|>`) *inside* `<think>`. vLLM treats that as a real stop: the request ends with `finish_reason: "stop"`, the parser routes the unfinished think block to `reasoning`, and `content` is empty. The HTTP status is still 200, so a client cannot tell this apart from a legitimate empty answer.
+
+`reasoning_eos_policy` is a per-request sampling parameter (Chat Completions and Completions, same placement as `thinking_token_budget`):
+
+| Value | Behavior |
+|-------|----------|
+| `"stop"` (default) | Current behavior. EOS/stop inside `<think>` ends the request. |
+| `"force_end"` | If the request is still in the think block and EOS/stop would be sampled (greedy-top, or an accepted speculative token), vLLM masks those tokens and forces `reasoning_end_str`, then continues into the answer. The same `ThinkingBudgetStateHolder` path as an exhausted `thinking_token_budget`. |
+
+`ignore_eos` is unchanged: this policy never suppresses EOS outside the think block. A Qwen3 `<tool_call>` started inside `<think>` counts as leaving the think block, so the policy does not rewrite tool-call tokens.
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-8B",
+    "messages": [
+      { "role": "user", "content": "9.11 and 9.8, which is greater?" }
+    ],
+    "reasoning_eos_policy": "force_end"
+  }'
+```
+
+Offline:
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(model="Qwen/Qwen3-8B", reasoning_parser="qwen3")
+sampling_params = SamplingParams(reasoning_eos_policy="force_end")
+outputs = llm.chat(
+    [{"role": "user", "content": "9.11 and 9.8, which is greater?"}],
+    sampling_params=sampling_params,
+)
+```
+
 `--reasoning-config` accepts a JSON object corresponding to  
 [ReasoningConfig][vllm.config.ReasoningConfig] with the following fields:
 

--- a/rust/src/engine-core-client/src/protocol/sampling.rs
+++ b/rust/src/engine-core-client/src/protocol/sampling.rs
@@ -24,6 +24,20 @@ fn default_max_tokens() -> u32 {
     16
 }
 
+/// What to do when an EOS/stop token would end generation inside a reasoning
+/// block.
+///
+/// Mirrors Python's `SamplingParams.reasoning_eos_policy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEosPolicy {
+    /// Current behavior: EOS ends the request while still in `<think>`.
+    #[default]
+    Stop,
+    /// Mask EOS and force `reasoning_end_str`, then continue into the answer.
+    ForceEnd,
+}
+
 ///
 /// Parameters for detecting repetitive N-gram patterns in output tokens.
 ///
@@ -86,6 +100,9 @@ pub struct EngineCoreSamplingParams {
     /// reaching this DTO, so only non-negative values are sent. Enforced
     /// engine-side (and only when a reasoning parser is configured).
     pub thinking_token_budget: Option<u64>,
+    /// What to do when EOS/stop would end generation inside a reasoning block.
+    /// Omitted Python `omit_defaults` maps to [`ReasoningEosPolicy::Stop`].
+    pub reasoning_eos_policy: ReasoningEosPolicy,
     /// Number of log probabilities to return per generated token.
     ///
     /// `None` disables sample logprobs. `-1` requests the full vocabulary.
@@ -161,6 +178,7 @@ impl EngineCoreSamplingParams {
             max_tokens: 65536,
             min_tokens: 0,
             thinking_token_budget: None,
+            reasoning_eos_policy: ReasoningEosPolicy::Stop,
             logprobs: None,
             prompt_logprobs: None,
             min_p: 0.0,

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2668,6 +2668,7 @@ fn python_msgpack_fixtures_match_rust_encoding() {
             max_tokens: 16,
             min_tokens: 0,
             thinking_token_budget: None,
+            reasoning_eos_policy: crate::protocol::sampling::ReasoningEosPolicy::Stop,
             logprobs: None,
             prompt_logprobs: None,
             min_p: 0.0,

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -40,6 +40,7 @@ class EngineCoreSamplingParams(msgspec.Struct, dict=True, omit_defaults=True):
     max_tokens: int = 16
     min_tokens: int = 0
     thinking_token_budget: int | None = None
+    reasoning_eos_policy: str = "stop"
     min_p: float = 0.0
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -193,6 +193,31 @@ mod tests {
     }
 
     #[test]
+    fn prepare_generate_request_forwards_reasoning_eos_policy() {
+        let request: GenerateRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "token_ids": [11, 22, 33],
+            "sampling_params": {
+                "reasoning_eos_policy": "force_end"
+            }
+        }))
+        .expect("parse request");
+
+        let prepared = prepare_generate_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+            None,
+        )
+        .expect("prepare");
+
+        assert_eq!(
+            prepared.text_request.sampling_params.reasoning_eos_policy,
+            vllm_text::ReasoningEosPolicy::ForceEnd
+        );
+    }
+
+    #[test]
     fn prepare_generate_request_gates_continuous_usage_on_include_usage() {
         let request: GenerateRequest = serde_json::from_value(json!({
             "model": "Qwen/Qwen1.5-0.5B-Chat",

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -156,6 +156,7 @@ pub(super) fn prepare_chat_request(
             max_tokens: request.max_completion_tokens,
             min_tokens: request.min_tokens,
             thinking_token_budget: request.thinking_token_budget,
+            reasoning_eos_policy: request.reasoning_eos_policy,
             logprobs: request.logprobs.then_some(top_logprobs),
             prompt_logprobs,
             min_p: request.min_p,
@@ -899,6 +900,26 @@ mod tests {
         assert_eq!(prepare(Some(64)), Some(64));
         assert_eq!(prepare(Some(-1)), Some(-1));
         assert_eq!(prepare(None), None);
+    }
+
+    #[test]
+    fn prepare_chat_request_passes_through_reasoning_eos_policy() {
+        use vllm_text::ReasoningEosPolicy;
+
+        let prepared = prepare_chat_request(
+            ChatCompletionRequest {
+                reasoning_eos_policy: ReasoningEosPolicy::ForceEnd,
+                ..base_request()
+            },
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+
+        assert_eq!(
+            prepared.chat_request.sampling_params.reasoning_eos_policy,
+            ReasoningEosPolicy::ForceEnd
+        );
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -178,6 +178,10 @@ pub struct ChatCompletionRequest {
     /// to "no budget").
     pub thinking_token_budget: Option<i64>,
 
+    /// What to do when EOS/stop would end generation inside a reasoning block.
+    #[serde(default)]
+    pub reasoning_eos_policy: vllm_text::ReasoningEosPolicy,
+
     /// Whether to include reasoning content in the response
     #[serde(default = "default_true")]
     pub include_reasoning: bool,
@@ -279,6 +283,7 @@ impl Default for ChatCompletionRequest {
             tool_choice: None,
             reasoning_effort: None,
             thinking_token_budget: None,
+            reasoning_eos_policy: vllm_text::ReasoningEosPolicy::Stop,
             include_reasoning: true,
             parallel_tool_calls: None,
             user: None,

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -121,6 +121,7 @@ pub(super) fn prepare_completion_request(
             max_tokens,
             min_tokens: request.min_tokens,
             thinking_token_budget: request.thinking_token_budget,
+            reasoning_eos_policy: request.reasoning_eos_policy,
             logprobs,
             prompt_logprobs,
             min_p: request.min_p,

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -164,6 +164,10 @@ pub struct CompletionRequest {
     /// to "no budget").
     pub thinking_token_budget: Option<i64>,
 
+    /// What to do when EOS/stop would end generation inside a reasoning block.
+    #[serde(default)]
+    pub reasoning_eos_policy: vllm_text::ReasoningEosPolicy,
+
     /// Request scheduling priority (lower means earlier; default 0)
     pub priority: Option<i32>,
 

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -23,6 +23,7 @@ pub use output::{
     TextOutputStreamExt, TokenAnchor, TokenAttribution,
 };
 pub use request::{Prompt, SamplingParams, TextRequest, normalize_top_k};
+pub use vllm_engine_core_client::protocol::sampling::ReasoningEosPolicy;
 use trait_set::trait_set;
 use vllm_engine_core_client::EngineCoreClient;
 pub use vllm_llm::FinishReason;

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -98,6 +98,7 @@ pub fn lower_sampling_params(
         max_tokens,
         min_tokens,
         thinking_token_budget,
+        reasoning_eos_policy,
         logprobs,
         prompt_logprobs,
         min_p,
@@ -170,6 +171,7 @@ pub fn lower_sampling_params(
         max_tokens,
         min_tokens,
         thinking_token_budget,
+        reasoning_eos_policy,
         logprobs,
         prompt_logprobs,
         min_p,
@@ -416,6 +418,21 @@ mod tests {
     }
 
     #[test]
+    fn lower_sampling_params_forwards_reasoning_eos_policy() {
+        use vllm_engine_core_client::protocol::sampling::ReasoningEosPolicy;
+
+        let params = lower_sampling_params_with_limits(
+            SamplingParams {
+                reasoning_eos_policy: ReasoningEosPolicy::ForceEnd,
+                ..SamplingParams::default()
+            },
+            sample_sampling_limits(),
+        )
+        .unwrap();
+        assert_eq!(params.reasoning_eos_policy, ReasoningEosPolicy::ForceEnd);
+    }
+
+    #[test]
     fn lower_sampling_params_rejects_min_tokens_above_resolved_max_tokens() {
         let error = lower_sampling_params_with_limits(
             SamplingParams {
@@ -638,6 +655,7 @@ mod tests {
                 max_tokens: 999997,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                reasoning_eos_policy: Stop,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -692,6 +710,7 @@ mod tests {
                 max_tokens: 999997,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                reasoning_eos_policy: Stop,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -859,6 +878,7 @@ mod tests {
                 max_tokens: 40957,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                reasoning_eos_policy: Stop,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -923,6 +943,7 @@ mod tests {
                 max_tokens: 999997,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                reasoning_eos_policy: Stop,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -995,6 +1016,7 @@ mod tests {
                 max_tokens: 32,
                 min_tokens: 2,
                 thinking_token_budget: None,
+                reasoning_eos_policy: Stop,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.1,
@@ -1245,6 +1267,7 @@ mod tests {
                 max_tokens: 128,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                reasoning_eos_policy: Stop,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.1,

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -9,7 +9,9 @@ use serde_json::Value;
 use vllm_engine_core_client::protocol::lora::LoraRequest;
 use vllm_engine_core_client::protocol::multimodal::MmFeatures;
 use vllm_engine_core_client::protocol::request::ReasoningParserKwargs;
-use vllm_engine_core_client::protocol::sampling::RepetitionDetectionParams;
+use vllm_engine_core_client::protocol::sampling::{
+    ReasoningEosPolicy, RepetitionDetectionParams,
+};
 use vllm_engine_core_client::protocol::structured_outputs::StructuredOutputsParams;
 
 use crate::error::{Error, Result};
@@ -86,6 +88,9 @@ pub struct SamplingParams {
     /// here; `-1` is normalized to `None` (and other negatives rejected) during
     /// lowering (see `lower_sampling_params`).
     pub thinking_token_budget: Option<i64>,
+    /// What to do when EOS/stop would end generation inside a reasoning block.
+    #[serde(default)]
+    pub reasoning_eos_policy: ReasoningEosPolicy,
     /// Number of log probabilities to return per generated token.
     ///
     /// `None` disables sample logprobs. `-1` requests the full vocabulary.
@@ -150,6 +155,7 @@ impl Default for SamplingParams {
             max_tokens: None,
             min_tokens: None,
             thinking_token_budget: None,
+            reasoning_eos_policy: ReasoningEosPolicy::Stop,
             logprobs: None,
             prompt_logprobs: None,
             min_p: None,

--- a/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py
+++ b/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py
@@ -65,6 +65,64 @@ def test_completion_request_accepts_valid_thinking_token_budget():
     assert request.thinking_token_budget == 5
 
 
+def test_chat_completion_request_accepts_reasoning_eos_policy():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_eos_policy": "force_end",
+        }
+    )
+    assert request.reasoning_eos_policy == "force_end"
+
+
+def test_chat_completion_request_rejects_invalid_reasoning_eos_policy():
+    with pytest.raises(Exception, match="reasoning_eos_policy"):
+        ChatCompletionRequest.model_validate(
+            {
+                "model": "qwen",
+                "messages": [{"role": "user", "content": "hello"}],
+                "reasoning_eos_policy": "drop",
+            }
+        )
+
+
+def test_chat_completion_request_to_sampling_params_forwards_policy():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_eos_policy": "force_end",
+        }
+    )
+    params = request.to_sampling_params(max_tokens=16, default_sampling_params={})
+    assert params.reasoning_eos_policy == "force_end"
+
+
+def test_completion_request_accepts_reasoning_eos_policy():
+    request = CompletionRequest.model_validate(
+        {
+            "model": "qwen",
+            "prompt": "hello",
+            "reasoning_eos_policy": "force_end",
+        }
+    )
+    assert request.reasoning_eos_policy == "force_end"
+    params = request.to_sampling_params(max_tokens=16, default_sampling_params={})
+    assert params.reasoning_eos_policy == "force_end"
+
+
+def test_completion_request_rejects_invalid_reasoning_eos_policy():
+    with pytest.raises(Exception, match="reasoning_eos_policy"):
+        CompletionRequest.model_validate(
+            {
+                "model": "qwen",
+                "prompt": "hello",
+                "reasoning_eos_policy": "drop",
+            }
+        )
+
+
 def test_completion_request_accepts_minus_one_as_unlimited():
     request = CompletionRequest.model_validate(
         {

--- a/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py
+++ b/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py
@@ -77,7 +77,7 @@ def test_chat_completion_request_accepts_reasoning_eos_policy():
 
 
 def test_chat_completion_request_rejects_invalid_reasoning_eos_policy():
-    with pytest.raises(Exception, match="reasoning_eos_policy"):
+    with pytest.raises(VLLMValidationError, match="reasoning_eos_policy"):
         ChatCompletionRequest.model_validate(
             {
                 "model": "qwen",
@@ -113,7 +113,7 @@ def test_completion_request_accepts_reasoning_eos_policy():
 
 
 def test_completion_request_rejects_invalid_reasoning_eos_policy():
-    with pytest.raises(Exception, match="reasoning_eos_policy"):
+    with pytest.raises(VLLMValidationError, match="reasoning_eos_policy"):
         CompletionRequest.model_validate(
             {
                 "model": "qwen",

--- a/tests/v1/sample/test_thinking_budget_state.py
+++ b/tests/v1/sample/test_thinking_budget_state.py
@@ -287,6 +287,81 @@ def test_force_end_does_not_protect_tool_call_inside_think():
     assert float(out[0, THINK_END]) == 0.0
 
 
+def test_force_end_does_not_rewrite_eos_after_speculative_tool_call():
+    h = ThinkingBudgetStateHolder(
+        _MockReasoningConfigWithToolCall(),
+        8,
+        2,
+        torch.device("cpu"),
+        False,
+    )
+    tokens = [THINK_START, 10, 11]
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[
+                (
+                    0,
+                    SamplingParams(
+                        reasoning_eos_policy="force_end",
+                        thinking_token_budget=10_000,
+                        stop_token_ids=[EOS],
+                    ),
+                    None,
+                    tokens,
+                )
+            ],
+            moved=(),
+        )
+    )
+    h.update_state([tokens], [[TOOL_CALL, EOS]])
+    assert h._state[0]["in_end"] is False
+    assert h._state[0]["force_index"] == []
+
+    logits = torch.zeros((2, VOCAB), dtype=torch.float32)
+    logits[1, EOS] = 5.0
+    out = h.apply_to_logits(logits, False, [[TOOL_CALL, EOS]])
+    assert float(out[1, EOS]) == 5.0
+    assert float(out[0, THINK_END]) == 0.0
+    assert float(out[1, THINK_END]) == 0.0
+
+
+def test_force_end_empty_spec_does_not_mask_next_request_row():
+    h = ThinkingBudgetStateHolder(
+        _MockReasoningConfig(),
+        8,
+        2,
+        torch.device("cpu"),
+        False,
+    )
+    tokens = [THINK_START, 10, 11]
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=2,
+            removed=(),
+            added=[
+                (
+                    0,
+                    SamplingParams(
+                        reasoning_eos_policy="force_end",
+                        stop_token_ids=[EOS],
+                    ),
+                    None,
+                    tokens,
+                ),
+            ],
+            moved=(),
+        )
+    )
+    h.update_state([tokens, [1]], [[], [7]])
+    logits = torch.zeros((1, VOCAB), dtype=torch.float32)
+    logits[0, EOS] = 5.0
+    out = h.apply_to_logits(logits, False, [[], [7]])
+    assert float(out[0, EOS]) == 5.0
+    assert float(out[0, THINK_END]) == 0.0
+
+
 def test_force_end_forces_at_speculative_eos_index():
     h = ThinkingBudgetStateHolder(
         _MockReasoningConfig(),
@@ -355,6 +430,29 @@ def test_from_optional_forwards_reasoning_eos_policy():
     assert SamplingParams.from_optional().reasoning_eos_policy == "stop"
     params = SamplingParams.from_optional(reasoning_eos_policy="force_end")
     assert params.reasoning_eos_policy == "force_end"
+
+
+def test_from_optional_preserves_positional_include_stop_str_in_output():
+    # thinking_token_budget is the 13th positional arg; include_stop_str_in_output
+    # must still bind at the 14th, not to reasoning_eos_policy.
+    params = SamplingParams.from_optional(
+        1,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        1.0,
+        0,
+        0.0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        True,
+    )
+    assert params.include_stop_str_in_output is True
+    assert params.reasoning_eos_policy == "stop"
 
 
 def test_stop_token_ids_that_finish_request_respects_ignore_eos():

--- a/tests/v1/sample/test_thinking_budget_state.py
+++ b/tests/v1/sample/test_thinking_budget_state.py
@@ -433,14 +433,15 @@ def test_from_optional_forwards_reasoning_eos_policy():
 
 
 def test_from_optional_preserves_positional_include_stop_str_in_output():
-    # thinking_token_budget is the 13th positional arg; include_stop_str_in_output
-    # must still bind at the 14th, not to reasoning_eos_policy.
+    # thinking_token_budget is the 14th positional arg; include_stop_str_in_output
+    # must still bind at the 15th, not to reasoning_eos_policy.
     params = SamplingParams.from_optional(
         1,
         0.0,
         0.0,
         1.0,
         1.0,
+        False,
         1.0,
         0,
         0.0,

--- a/tests/v1/sample/test_thinking_budget_state.py
+++ b/tests/v1/sample/test_thinking_budget_state.py
@@ -2,19 +2,38 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for ThinkingBudgetStateHolder batch index moves."""
 
+import pytest
 import torch
 
-from vllm.sampling_params import SamplingParams
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import SamplingParams, validate_reasoning_eos_policy
 from vllm.v1.sample.logits_processor.interface import (
     BatchUpdate,
     MoveDirectionality,
 )
 from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
 
+THINK_START = 20
+THINK_END = 21
+TOOL_CALL = 22
+EOS = 2
+VOCAB = 32
+
+
+@pytest.fixture(autouse=True)
+def _cpu_async_h2d(monkeypatch: pytest.MonkeyPatch) -> None:
+    # async_tensor_h2d pins by default; CPU-only torch has no pinned allocator.
+    monkeypatch.setattr("vllm.utils.torch_utils.PIN_MEMORY", False)
+
 
 class _MockReasoningConfig:
-    reasoning_start_token_ids = [151667]
-    reasoning_end_token_ids = [151668]
+    reasoning_start_token_ids = [THINK_START]
+    reasoning_end_token_ids = [THINK_END]
+    implicit_reasoning_end_token_ids = None
+
+
+class _MockReasoningConfigWithToolCall(_MockReasoningConfig):
+    implicit_reasoning_end_token_ids = [TOOL_CALL]
 
 
 def _make_holder() -> ThinkingBudgetStateHolder:
@@ -93,3 +112,256 @@ def test_swap_exchanges_two_budgeted_states():
     )
     assert h._state[0]["thinking_token_budget"] == b1
     assert h._state[1]["thinking_token_budget"] == b0
+
+
+def _holder_with_tool_call() -> ThinkingBudgetStateHolder:
+    return ThinkingBudgetStateHolder(
+        _MockReasoningConfigWithToolCall(),
+        8,
+        0,
+        torch.device("cpu"),
+        False,
+    )
+
+
+def _add_in_think(
+    holder: ThinkingBudgetStateHolder,
+    params: SamplingParams,
+    output: list[int] | None = None,
+) -> None:
+    tokens = output if output is not None else [THINK_START, 10, 11]
+    holder.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[(0, params, None, tokens)],
+            moved=(),
+        )
+    )
+    holder.update_state([tokens], None)
+
+
+def test_default_policy_does_not_track_without_budget():
+    h = _make_holder()
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[(0, SamplingParams(), None, [])],
+            moved=(),
+        )
+    )
+    assert not h.has_tracked_requests()
+
+
+def test_force_end_tracks_without_budget():
+    h = _make_holder()
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[
+                (0, SamplingParams(reasoning_eos_policy="force_end"), None, []),
+            ],
+            moved=(),
+        )
+    )
+    assert h.has_tracked_requests()
+    assert h._state[0]["thinking_token_budget"] is None
+    assert h._state[0]["reasoning_eos_policy"] == "force_end"
+
+
+def test_force_end_replaces_eos_argmax_with_reasoning_end():
+    h = _make_holder()
+    _add_in_think(
+        h,
+        SamplingParams(
+            reasoning_eos_policy="force_end",
+            stop_token_ids=[EOS],
+        ),
+    )
+    assert h._state[0]["in_think"] is True
+
+    logits = torch.zeros((1, VOCAB), dtype=torch.float32)
+    logits[0, EOS] = 5.0
+    logits[0, 7] = 1.0
+    out = h.apply_to_logits(logits, False, None)
+    assert float(out[0, THINK_END]) >= 1.0e8
+    assert torch.isneginf(out[0, EOS])
+    assert h._state[0]["in_end"] is True
+
+
+def test_force_end_masks_eos_when_it_is_not_argmax():
+    h = _make_holder()
+    _add_in_think(
+        h,
+        SamplingParams(
+            reasoning_eos_policy="force_end",
+            stop_token_ids=[EOS],
+        ),
+    )
+    logits = torch.zeros((1, VOCAB), dtype=torch.float32)
+    logits[0, EOS] = 1.0
+    logits[0, 7] = 5.0
+    out = h.apply_to_logits(logits, False, None)
+    assert torch.isneginf(out[0, EOS])
+    assert float(out[0, THINK_END]) == 0.0
+    assert h._state[0]["in_end"] is False
+
+
+def test_stop_policy_leaves_eos_argmax_unchanged():
+    h = _make_holder()
+    _add_in_think(
+        h,
+        SamplingParams(
+            thinking_token_budget=10_000,
+            stop_token_ids=[EOS],
+        ),
+    )
+    logits = torch.zeros((1, VOCAB), dtype=torch.float32)
+    logits[0, EOS] = 5.0
+    out = h.apply_to_logits(logits, False, None)
+    assert float(out[0, EOS]) == 5.0
+    assert float(out[0, THINK_END]) == 0.0
+
+
+def test_force_end_does_not_apply_outside_think_block():
+    h = _make_holder()
+    tokens = [THINK_START, 10, THINK_END, 15]
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[
+                (
+                    0,
+                    SamplingParams(
+                        reasoning_eos_policy="force_end",
+                        stop_token_ids=[EOS],
+                    ),
+                    None,
+                    tokens,
+                )
+            ],
+            moved=(),
+        )
+    )
+    h.update_state([tokens], None)
+    assert h._state[0]["in_think"] is False
+
+    logits = torch.zeros((1, VOCAB), dtype=torch.float32)
+    logits[0, EOS] = 5.0
+    out = h.apply_to_logits(logits, False, None)
+    assert float(out[0, EOS]) == 5.0
+    assert float(out[0, THINK_END]) == 0.0
+
+
+def test_force_end_does_not_protect_tool_call_inside_think():
+    h = _holder_with_tool_call()
+    tokens = [THINK_START, 10, 11, TOOL_CALL, 30]
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[
+                (
+                    0,
+                    SamplingParams(
+                        reasoning_eos_policy="force_end",
+                        stop_token_ids=[EOS],
+                    ),
+                    None,
+                    tokens,
+                )
+            ],
+            moved=(),
+        )
+    )
+    h.update_state([tokens], None)
+    assert h._state[0]["in_think"] is False
+
+    logits = torch.zeros((1, VOCAB), dtype=torch.float32)
+    logits[0, EOS] = 5.0
+    out = h.apply_to_logits(logits, False, None)
+    assert float(out[0, EOS]) == 5.0
+    assert float(out[0, THINK_END]) == 0.0
+
+
+def test_force_end_forces_at_speculative_eos_index():
+    h = ThinkingBudgetStateHolder(
+        _MockReasoningConfig(),
+        8,
+        2,
+        torch.device("cpu"),
+        False,
+    )
+    tokens = [THINK_START, 10, 11]
+    h.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[
+                (
+                    0,
+                    SamplingParams(
+                        reasoning_eos_policy="force_end",
+                        thinking_token_budget=10_000,
+                        stop_token_ids=[EOS],
+                    ),
+                    None,
+                    tokens,
+                )
+            ],
+            moved=(),
+        )
+    )
+    h.update_state([tokens], [[EOS, 7]])
+    assert h._state[0]["in_end"] is True
+    assert h._state[0]["force_index"] == [0]
+
+    logits = torch.zeros((2, VOCAB), dtype=torch.float32)
+    out = h.apply_to_logits(logits, False, [[EOS, 7]])
+    assert float(out[0, THINK_END]) >= 1.0e8
+
+
+def test_ignore_eos_does_not_treat_eos_as_stop():
+    h = _make_holder()
+    _add_in_think(
+        h,
+        SamplingParams(
+            reasoning_eos_policy="force_end",
+            ignore_eos=True,
+            stop_token_ids=[],
+        ),
+    )
+    logits = torch.zeros((1, VOCAB), dtype=torch.float32)
+    logits[0, EOS] = 5.0
+    out = h.apply_to_logits(logits, False, None)
+    assert float(out[0, EOS]) == 5.0
+    assert h._state[0]["in_end"] is False
+
+
+def test_validate_reasoning_eos_policy_defaults_and_rejects():
+    assert validate_reasoning_eos_policy(None) == "stop"
+    assert validate_reasoning_eos_policy("stop") == "stop"
+    assert validate_reasoning_eos_policy("force_end") == "force_end"
+    with pytest.raises(VLLMValidationError, match="reasoning_eos_policy"):
+        validate_reasoning_eos_policy("drop")
+    with pytest.raises(VLLMValidationError, match="reasoning_eos_policy"):
+        SamplingParams(reasoning_eos_policy="drop")  # type: ignore[arg-type]
+
+
+def test_from_optional_forwards_reasoning_eos_policy():
+    assert SamplingParams.from_optional().reasoning_eos_policy == "stop"
+    params = SamplingParams.from_optional(reasoning_eos_policy="force_end")
+    assert params.reasoning_eos_policy == "force_end"
+
+
+def test_stop_token_ids_that_finish_request_respects_ignore_eos():
+    params = SamplingParams(stop_token_ids=[5], ignore_eos=False)
+    params.update_from_generation_config({}, eos_token_id=EOS)
+    assert set(params.stop_token_ids_that_finish_request()) == {5, EOS}
+
+    ignored = SamplingParams(stop_token_ids=[5], ignore_eos=True)
+    ignored.update_from_generation_config({}, eos_token_id=EOS)
+    assert ignored.stop_token_ids_that_finish_request() == [5]

--- a/tests/v1/sample/test_thinking_budget_state.py
+++ b/tests/v1/sample/test_thinking_budget_state.py
@@ -29,7 +29,7 @@ def _cpu_async_h2d(monkeypatch: pytest.MonkeyPatch) -> None:
 class _MockReasoningConfig:
     reasoning_start_token_ids = [THINK_START]
     reasoning_end_token_ids = [THINK_END]
-    implicit_reasoning_end_token_ids = None
+    implicit_reasoning_end_token_ids: list[int] | None = None
 
 
 class _MockReasoningConfigWithToolCall(_MockReasoningConfig):

--- a/tests/v1/worker/test_gpu_sampler_flags.py
+++ b/tests/v1/worker/test_gpu_sampler_flags.py
@@ -49,6 +49,11 @@ def _make_sampler() -> Sampler:
         pytest.param(
             SamplingParams(thinking_token_budget=3), True, id="thinking-budget"
         ),
+        pytest.param(
+            SamplingParams(reasoning_eos_policy="force_end"),
+            True,
+            id="reasoning-eos-policy",
+        ),
         pytest.param(SamplingParams(logit_bias={1: 1.0}), True, id="logit-bias"),
         pytest.param(SamplingParams(frequency_penalty=0.1), True, id="penalty"),
         pytest.param(SamplingParams(_bad_words_token_ids=[[1]]), True, id="bad-words"),

--- a/tests/v1/worker/test_gpu_thinking_budget.py
+++ b/tests/v1/worker/test_gpu_thinking_budget.py
@@ -32,7 +32,7 @@ class MockReasoningConfig:
     reasoning_start_token_ids = [START]
     reasoning_end_token_ids = [END]
     natural_reasoning_end_token_ids = [END]
-    implicit_reasoning_end_token_ids = None
+    implicit_reasoning_end_token_ids: list[int] | None = None
 
 
 EOS = 3

--- a/tests/v1/worker/test_gpu_thinking_budget.py
+++ b/tests/v1/worker/test_gpu_thinking_budget.py
@@ -28,6 +28,15 @@ class MockReasoningConfig:
     reasoning_start_token_ids = [START]
     reasoning_end_token_ids = [END]
     natural_reasoning_end_token_ids = [END]
+    implicit_reasoning_end_token_ids = None
+
+
+EOS = 3
+TOOL_CALL = 4
+
+
+class MockReasoningConfigWithToolCall(MockReasoningConfig):
+    implicit_reasoning_end_token_ids = [TOOL_CALL]
 
 
 class MockMultiTokenEndReasoningConfig:
@@ -299,3 +308,66 @@ def test_v2_thinking_budget_continues_end_prefix_from_prompt():
 
     assert out[0, END_B] == pytest.approx(1.0e9)
     assert out[0, END_A] == 0
+
+
+def test_v2_force_end_replaces_eos_argmax_with_reasoning_end():
+    req_states = _make_req_states([1, START, 10, 11], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(
+        3,
+        SamplingParams(
+            reasoning_eos_policy="force_end",
+            stop_token_ids=[EOS],
+        ),
+    )
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    logits[0, EOS] = 5.0
+    logits[0, 7] = 1.0
+    out = _apply(state, logits, input_ids=[11], local_pos=[0])
+
+    assert out[0, END] == pytest.approx(1.0e9)
+    assert out[0, EOS] < 0
+
+
+def test_v2_force_end_masks_eos_when_not_argmax():
+    req_states = _make_req_states([1, START, 10, 11], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(
+        3,
+        SamplingParams(
+            reasoning_eos_policy="force_end",
+            stop_token_ids=[EOS],
+        ),
+    )
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    logits[0, EOS] = 1.0
+    logits[0, 7] = 5.0
+    out = _apply(state, logits, input_ids=[11], local_pos=[0])
+
+    assert out[0, EOS] < 0
+    assert out[0, END] == 0
+    assert out[0, 7] == pytest.approx(5.0)
+
+
+def test_v2_force_end_does_not_protect_tool_call():
+    req_states = _make_req_states([1, START, 10, TOOL_CALL, 30], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfigWithToolCall())
+    state.add_request(
+        3,
+        SamplingParams(
+            reasoning_eos_policy="force_end",
+            stop_token_ids=[EOS],
+        ),
+    )
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    logits[0, EOS] = 5.0
+    out = _apply(state, logits, input_ids=[30], local_pos=[0])
+
+    assert out[0, EOS] == pytest.approx(5.0)
+    assert out[0, END] == 0

--- a/tests/v1/worker/test_gpu_thinking_budget.py
+++ b/tests/v1/worker/test_gpu_thinking_budget.py
@@ -13,7 +13,11 @@ if not torch.cuda.is_available():
 
 from vllm.sampling_params import SamplingParams
 from vllm.v1.worker.gpu.sample.sampler import Sampler
-from vllm.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
+from vllm.v1.worker.gpu.sample.thinking_budget import (
+    _COLD_SCAN_BLOCK,
+    _MAX_STOP_IDS,
+    ThinkingBudgetState,
+)
 from vllm.v1.worker.gpu.states import RequestState
 
 DEVICE = torch.device("cuda")
@@ -351,6 +355,41 @@ def test_v2_force_end_masks_eos_when_not_argmax():
     assert out[0, EOS] < 0
     assert out[0, END] == 0
     assert out[0, 7] == pytest.approx(5.0)
+
+
+def test_v2_force_end_rejects_too_many_stop_token_ids():
+    req_states = _make_req_states([1, START, 10], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    with pytest.raises(ValueError, match="reasoning_eos_policy"):
+        state.add_request(
+            3,
+            SamplingParams(
+                reasoning_eos_policy="force_end",
+                stop_token_ids=list(range(_MAX_STOP_IDS + 1)),
+            ),
+        )
+
+
+def test_v2_force_end_keeps_tool_call_across_cold_scan_blocks():
+    pad = [10] * _COLD_SCAN_BLOCK
+    tokens = [1, START, *pad, TOOL_CALL, 30]
+    req_states = _make_req_states(tokens, prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfigWithToolCall())
+    state.add_request(
+        3,
+        SamplingParams(
+            reasoning_eos_policy="force_end",
+            stop_token_ids=[EOS],
+        ),
+    )
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    logits[0, EOS] = 5.0
+    out = _apply(state, logits, input_ids=[30], local_pos=[0])
+
+    assert out[0, EOS] == pytest.approx(5.0)
+    assert out[0, END] == 0
 
 
 def test_v2_force_end_does_not_protect_tool_call():

--- a/vllm/config/reasoning.py
+++ b/vllm/config/reasoning.py
@@ -39,6 +39,10 @@ class ReasoningConfig:
         default=None, init=False, repr=False
     )
     """Token IDs that naturally terminate reasoning, as defined by the parser."""
+    _implicit_reasoning_end_token_ids: list[int] | None = field(
+        default=None, init=False, repr=False
+    )
+    """Token IDs that implicitly end reasoning (e.g. Qwen3 ``<tool_call>``)."""
 
     _enabled: bool = field(default=False, init=False, repr=False)
     """Private field indicating whether reasoning token IDs have been initialized.
@@ -66,6 +70,16 @@ class ReasoningConfig:
         """Token IDs that indicate the model naturally ended reasoning."""
         return self._natural_reasoning_end_token_ids
 
+    @property
+    def implicit_reasoning_end_token_ids(self) -> list[int] | None:
+        """Token IDs that implicitly end reasoning, such as a tool-call start.
+
+        Used by the sampler so a ``<tool_call>`` started inside ``<think>`` is
+        not treated as still-in-think (thinking budget and
+        ``reasoning_eos_policy``). The reasoning parser itself is unchanged.
+        """
+        return self._implicit_reasoning_end_token_ids
+
     def initialize_token_ids(self, model_config: ModelConfig) -> None:
         """Initialize reasoning token IDs from strings using the tokenizer."""
         if (
@@ -80,6 +94,7 @@ class ReasoningConfig:
         reasoning_start_str = self.reasoning_start_str
         reasoning_end_str = self.reasoning_end_str
         natural_reasoning_end_str = ""
+        implicit_reasoning_end_strs: list[str] = []
         if self.reasoning_parser:
             parser_cls = ReasoningParserManager.get_reasoning_parser(
                 self.reasoning_parser
@@ -93,6 +108,9 @@ class ReasoningConfig:
             if end_token and not reasoning_end_str:
                 reasoning_end_str = end_token
             natural_reasoning_end_str = end_token or ""
+            implicit_reasoning_end_strs = list(
+                getattr(reasoning_parser, "implicit_reasoning_end_strs", None) or []
+            )
 
         if not natural_reasoning_end_str:
             natural_reasoning_end_str = reasoning_end_str
@@ -110,6 +128,15 @@ class ReasoningConfig:
         self._natural_reasoning_end_token_ids = tokenizer.encode(
             natural_reasoning_end_str, add_special_tokens=False
         )
+        implicit_ids: list[int] = []
+        for implicit_str in implicit_reasoning_end_strs:
+            if not implicit_str:
+                continue
+            encoded = tokenizer.encode(implicit_str, add_special_tokens=False)
+            if encoded:
+                implicit_ids = encoded
+                break
+        self._implicit_reasoning_end_token_ids = implicit_ids
 
         if (
             not self._reasoning_start_token_ids

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -44,6 +44,7 @@ from vllm.logprobs import Logprob
 from vllm.renderers import ChatParams, TokenizeParams, merge_kwargs
 from vllm.sampling_params import (
     BeamSearchParams,
+    ReasoningEosPolicy,
     RepetitionDetectionParams,
     RequestOutputKind,
     SamplingParams,
@@ -256,6 +257,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
         ),
     )
     thinking_token_budget: ThinkingTokenBudget = None
+    reasoning_eos_policy: ReasoningEosPolicy = "stop"
     include_reasoning: bool = True
     parallel_tool_calls: bool | None = True
 
@@ -753,6 +755,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             logit_bias=self.logit_bias,
             bad_words=self.bad_words,
             thinking_token_budget=self.thinking_token_budget,
+            reasoning_eos_policy=self.reasoning_eos_policy,
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -27,6 +27,7 @@ from vllm.logprobs import Logprob
 from vllm.renderers import TokenizeParams
 from vllm.sampling_params import (
     BeamSearchParams,
+    ReasoningEosPolicy,
     RepetitionDetectionParams,
     RequestOutputKind,
     SamplingParams,
@@ -249,6 +250,14 @@ class CompletionRequest(OpenAIBaseModel):
             "-1 means unlimited (treated as unset)."
         ),
     )
+    reasoning_eos_policy: ReasoningEosPolicy = Field(
+        default="stop",
+        description=(
+            "What to do when EOS/stop would end generation inside a "
+            "reasoning block. 'stop' keeps current behavior; 'force_end' "
+            "emits reasoning_end_str and continues into the answer."
+        ),
+    )
 
     stream_interval: Annotated[int, Field(ge=1)] | None = Field(
         default=None,
@@ -402,6 +411,7 @@ class CompletionRequest(OpenAIBaseModel):
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
             thinking_token_budget=self.thinking_token_budget,
+            reasoning_eos_policy=self.reasoning_eos_policy,
             routed_experts_prompt_start=self.routed_experts_prompt_start,
         )
 

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -115,6 +115,12 @@ class ParserEngineReasoningAdapter(ReasoningParser):
     def reasoning_end_token_ids(self) -> frozenset[int]:
         return self._parser_engine.reasoning_end_token_ids
 
+    @property
+    def implicit_reasoning_end_strs(self) -> list[str]:
+        return list(
+            getattr(self._parser_engine, "implicit_reasoning_end_strs", None) or []
+        )
+
     def adjust_request(
         self,
         request: ChatCompletionRequest | ResponsesRequest,

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -220,6 +220,10 @@ class Qwen3Parser(ParserEngine):
     TOOL_END = TOOL_CALL_END
     TURN_BOUNDARIES: frozenset[str] = CHATML_TURN_BOUNDARIES
 
+    @property
+    def implicit_reasoning_end_strs(self) -> list[str]:
+        return [self.TOOL_START]
+
     def __init__(
         self,
         tokenizer: TokenizerLike,

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -58,6 +58,16 @@ class ReasoningParser:
         """
         return None
 
+    @property
+    def implicit_reasoning_end_strs(self) -> list[str]:
+        """Strings that implicitly end reasoning (e.g. Qwen3 ``<tool_call>``).
+
+        The sampler uses these so thinking-budget forcing and
+        ``reasoning_eos_policy`` treat a tool call started inside ``<think>``
+        as having left the think block. Extraction/streaming is unchanged.
+        """
+        return []
+
     def has_engine_confirmed_reasoning_end(self) -> bool:
         """Whether the engine has confirmed the reasoning end transition.
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -8,7 +8,7 @@ import math
 from dataclasses import field
 from enum import Enum, IntEnum
 from functools import cached_property
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import msgspec
 from pydantic import BeforeValidator
@@ -74,6 +74,27 @@ def validate_thinking_token_budget(value: int | float | bool | None) -> int | No
 ThinkingTokenBudget = Annotated[
     int | None,
     BeforeValidator(validate_thinking_token_budget),
+]
+
+_REASONING_EOS_POLICIES = ("stop", "force_end")
+
+
+def validate_reasoning_eos_policy(value: str | None) -> str:
+    """Validate ``reasoning_eos_policy``; default ``"stop"`` if unset."""
+    if value is None:
+        return "stop"
+    if not isinstance(value, str) or value not in _REASONING_EOS_POLICIES:
+        raise VLLMValidationError(
+            '`reasoning_eos_policy` must be "stop" or "force_end".',
+            parameter="reasoning_eos_policy",
+            value=value,
+        )
+    return value
+
+
+ReasoningEosPolicy = Annotated[
+    Literal["stop", "force_end"],
+    BeforeValidator(validate_reasoning_eos_policy),
 ]
 
 
@@ -358,6 +379,20 @@ class SamplingParams(
     skip_reading_prefix_cache: bool | None = None
     thinking_token_budget: int | None = None
     """Maximum number of tokens allowed for thinking operations."""
+    reasoning_eos_policy: Literal["stop", "force_end"] = "stop"
+    """What to do when an EOS or stop token would end generation while the
+    request is still inside a reasoning block.
+
+    * ``"stop"`` (default): current behavior. The request finishes with
+      ``finish_reason="stop"`` and the unfinished think block is parsed as
+      reasoning, leaving ``content`` empty.
+    * ``"force_end"``: mask those stop tokens for the step and force
+      ``reasoning_end_str`` (the same path as an exhausted
+      ``thinking_token_budget``). Generation then continues into the answer.
+      Has no effect outside a think block and does not change ``ignore_eos``.
+      An implicit reasoning end such as Qwen3 ``<tool_call>`` counts as
+      leaving the think block, so the policy does not rewrite tool calls.
+    """
 
     repetition_detection: RepetitionDetectionParams | None = None
     """Parameters for detecting repetitive N-gram patterns in output tokens.
@@ -396,6 +431,7 @@ class SamplingParams(
         stop_token_ids: list[int] | None = None,
         bad_words: list[str] | None = None,
         thinking_token_budget: int | None = None,
+        reasoning_eos_policy: Literal["stop", "force_end"] = "stop",
         include_stop_str_in_output: bool = False,
         ignore_eos: bool = False,
         max_tokens: int | None = 16,
@@ -462,6 +498,7 @@ class SamplingParams(
             stop_token_ids=stop_token_ids,
             bad_words=bad_words,
             thinking_token_budget=thinking_token_budget,
+            reasoning_eos_policy=reasoning_eos_policy,
             include_stop_str_in_output=include_stop_str_in_output,
             ignore_eos=ignore_eos,
             max_tokens=max_tokens,
@@ -500,6 +537,9 @@ class SamplingParams(
 
         self.thinking_token_budget = validate_thinking_token_budget(
             self.thinking_token_budget
+        )
+        self.reasoning_eos_policy = validate_reasoning_eos_policy(
+            self.reasoning_eos_policy
         )
 
         if self.stop is None:
@@ -794,6 +834,18 @@ class SamplingParams(
     def all_stop_token_ids(self) -> set[int]:
         return self._all_stop_token_ids
 
+    def stop_token_ids_that_finish_request(self) -> list[int]:
+        """Token ids that would finish generation if sampled.
+
+        ``ignore_eos`` keeps its meaning: the primary EOS id is omitted, but
+        caller-supplied ``stop_token_ids`` still count.
+        """
+        if self.ignore_eos:
+            ids = self.stop_token_ids or []
+        else:
+            ids = list(self.all_stop_token_ids)
+        return list(dict.fromkeys(int(tok) for tok in ids))
+
     @property
     def bad_words_token_ids(self) -> list[list[int]] | None:
         # For internal use only. Backward compatibility not guaranteed
@@ -979,6 +1031,11 @@ class SamplingParams(
         if self.thinking_token_budget is not None:
             raise ValueError(
                 "trace_decode_token_ids is not supported with thinking_token_budget."
+            )
+        if self.reasoning_eos_policy == "force_end":
+            raise ValueError(
+                "trace_decode_token_ids is not supported with "
+                'reasoning_eos_policy="force_end".'
             )
         if self.bad_words:
             raise ValueError("trace_decode_token_ids is not supported with bad_words.")
@@ -1266,6 +1323,7 @@ class SamplingParams(
             f"stop_token_ids={self.stop_token_ids}, "
             f"bad_words={self.bad_words}, "
             f"thinking_token_budget={self.thinking_token_budget}, "
+            f"reasoning_eos_policy={self.reasoning_eos_policy}, "
             f"include_stop_str_in_output={self.include_stop_str_in_output}, "
             f"ignore_eos={self.ignore_eos}, "
             f"max_tokens={self.max_tokens}, "

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -79,17 +79,19 @@ ThinkingTokenBudget = Annotated[
 _REASONING_EOS_POLICIES = ("stop", "force_end")
 
 
-def validate_reasoning_eos_policy(value: str | None) -> str:
+def validate_reasoning_eos_policy(
+    value: str | None,
+) -> Literal["stop", "force_end"]:
     """Validate ``reasoning_eos_policy``; default ``"stop"`` if unset."""
-    if value is None:
+    if value is None or value == "stop":
         return "stop"
-    if not isinstance(value, str) or value not in _REASONING_EOS_POLICIES:
-        raise VLLMValidationError(
-            '`reasoning_eos_policy` must be "stop" or "force_end".',
-            parameter="reasoning_eos_policy",
-            value=value,
-        )
-    return value
+    if value == "force_end":
+        return "force_end"
+    raise VLLMValidationError(
+        '`reasoning_eos_policy` must be "stop" or "force_end".',
+        parameter="reasoning_eos_policy",
+        value=value,
+    )
 
 
 ReasoningEosPolicy = Annotated[

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -431,7 +431,6 @@ class SamplingParams(
         stop_token_ids: list[int] | None = None,
         bad_words: list[str] | None = None,
         thinking_token_budget: int | None = None,
-        reasoning_eos_policy: Literal["stop", "force_end"] = "stop",
         include_stop_str_in_output: bool = False,
         ignore_eos: bool = False,
         max_tokens: int | None = 16,
@@ -453,6 +452,7 @@ class SamplingParams(
         routed_experts_prompt_start: int = 0,
         # Debugging / RL-specific parameters.
         trace_decode_token_ids: list[int] | None = None,
+        reasoning_eos_policy: Literal["stop", "force_end"] = "stop",
     ) -> "SamplingParams":
         if logit_bias is not None:
             # Fast path uses a dict comprehension; on failure we iterate once

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -112,14 +112,22 @@ class InputProcessor:
                         "bound sampling mask size, reduce transfer overhead, "
                         "and avoid potential OOMs"
                     )
-            if params.thinking_token_budget is not None and (
+            reasoning_missing = (
                 self.vllm_config.reasoning_config is None
                 or not self.vllm_config.reasoning_config.enabled
-            ):
+            )
+            if params.thinking_token_budget is not None and reasoning_missing:
                 raise VLLMValidationError(
                     "thinking_token_budget is set but reasoning_config is "
                     "not configured. Please set --reasoning-parser "
                     "and/or --reasoning-config to use thinking_token_budget."
+                )
+            if params.reasoning_eos_policy == "force_end" and reasoning_missing:
+                raise VLLMValidationError(
+                    'reasoning_eos_policy="force_end" is set but '
+                    "reasoning_config is not configured. Please set "
+                    "--reasoning-parser and/or --reasoning-config to use "
+                    "reasoning_eos_policy."
                 )
             if (
                 params.trace_decode_token_ids

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -280,6 +280,20 @@ class ThinkingBudgetStateHolder:
         stop_set = set(stop_ids)
         return any(tok in stop_set for tok in state.get("spec_token_ids") or [])
 
+    @staticmethod
+    def _sequence_at(tokens: list[int], index: int, sequence: list[int]) -> bool:
+        n = len(sequence)
+        return bool(n) and tokens[index : index + n] == sequence
+
+    def _spec_reasoning_exit_index(self, spec: list[int]) -> int | None:
+        """First spec index that leaves think (implicit end or ``</think>``)."""
+        for i in range(len(spec)):
+            if self._sequence_at(spec, i, self.implicit_end_token_ids):
+                return i
+            if self._sequence_at(spec, i, self.think_end_token_ids):
+                return i
+        return None
+
     def _maybe_force_end_from_spec_eos(self, state: dict[str, Any]) -> None:
         if (
             state.get("reasoning_eos_policy") != "force_end"
@@ -290,8 +304,11 @@ class ThinkingBudgetStateHolder:
         stop_ids = set(state.get("stop_token_ids") or [])
         if not stop_ids:
             return
-        for i, token_id in enumerate(state.get("spec_token_ids") or []):
-            if token_id in stop_ids:
+        spec = state.get("spec_token_ids") or []
+        exit_at = self._spec_reasoning_exit_index(spec)
+        limit = len(spec) if exit_at is None else exit_at
+        for i in range(limit):
+            if spec[i] in stop_ids:
                 state["in_think"] = False
                 state["in_end"] = True
                 state["end_count"] = 0
@@ -595,9 +612,14 @@ class ThinkingBudgetStateHolder:
     ) -> int:
         if not self.in_spec_mode or predict_bonus_token:
             return 1
-        if seq_idx < len(spec_token_ids_for_layout):
-            return max(len(spec_token_ids_for_layout[seq_idx]), 1)
-        return 1
+        if seq_idx >= len(spec_token_ids_for_layout):
+            return 0
+        spec = spec_token_ids_for_layout[seq_idx]
+        n_rows = len(spec)
+        exit_at = self._spec_reasoning_exit_index(spec)
+        if exit_at is not None:
+            n_rows = min(n_rows, exit_at)
+        return n_rows
 
     def _apply_eos_policy_to_logits(
         self,

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -15,6 +15,14 @@ from vllm.v1.sample.logits_processor.interface import (
 
 if TYPE_CHECKING:
     from vllm.config.reasoning import ReasoningConfig
+    from vllm.sampling_params import SamplingParams
+
+
+def _should_track_request(params: "SamplingParams") -> bool:
+    return (
+        params.thinking_token_budget is not None
+        or params.reasoning_eos_policy == "force_end"
+    )
 
 
 def maybe_create_thinking_budget_state_holder(
@@ -56,11 +64,16 @@ class ThinkingBudgetStateHolder:
         if reasoning_config is None:
             self.think_start_token_ids = []
             self.think_end_token_ids = []
+            self.implicit_end_token_ids: list[int] = []
         else:
             rs = reasoning_config.reasoning_start_token_ids
             re = reasoning_config.reasoning_end_token_ids
+            implicit = getattr(
+                reasoning_config, "implicit_reasoning_end_token_ids", None
+            )
             self.think_start_token_ids = rs if rs else []
             self.think_end_token_ids = re if re else []
+            self.implicit_end_token_ids = implicit if implicit else []
 
         self.device = device
         self._state: dict[int, dict[str, Any]] = {}
@@ -72,11 +85,11 @@ class ThinkingBudgetStateHolder:
             self._mask_capacity = max_num_reqs
 
     def has_tracked_requests(self) -> bool:
-        """True when ``sync_batch`` has state for a ``thinking_token_budget`` row.
+        """True when ``sync_batch`` has state for a budget or force-end row.
 
         Used to decide whether sampling needs output-token rows and spec combining;
         distinct from merely having a holder instance (reasoning may be on with no
-        budgeted requests in this batch).
+        tracked requests in this batch).
         """
         return bool(self._state)
 
@@ -88,10 +101,12 @@ class ThinkingBudgetStateHolder:
             self._state.pop(index, None)
 
         for index, params, prompt_tok_ids, output_tok_ids in batch_update.added:
-            thinking_token_budget = params.thinking_token_budget
-            if thinking_token_budget is not None:
+            if _should_track_request(params):
                 self._state[index] = self._init_state_entry(
-                    prompt_tok_ids, thinking_token_budget
+                    prompt_tok_ids,
+                    params.thinking_token_budget,
+                    params.reasoning_eos_policy,
+                    params.stop_token_ids_that_finish_request(),
                 )
                 self._state[index]["output_tok_ids"] = output_tok_ids
                 self._state[index]["spec_token_ids"] = []
@@ -157,6 +172,8 @@ class ThinkingBudgetStateHolder:
         if not self.is_enabled or not self._state:
             return logits
         spec_lists = spec_token_ids or []
+        self._prepare_cu_num_tokens(predict_bonus_token, spec_lists)
+        self._apply_eos_policy_to_logits(logits, predict_bonus_token, spec_lists)
         return self._apply_forcing_to_logits(logits, predict_bonus_token, spec_lists)
 
     @staticmethod
@@ -168,29 +185,43 @@ class ThinkingBudgetStateHolder:
                 return i
         return -1
 
+    def _find_last_end_index(self, tokens: list[int], scan_offset: int = 0) -> int:
+        """Latest of forced/natural ``</think>`` and implicit ends (tool call)."""
+        output_slice = tokens[scan_offset:]
+        end = self._find_last_sequence_index(output_slice, self.think_end_token_ids)
+        impl = (
+            self._find_last_sequence_index(output_slice, self.implicit_end_token_ids)
+            if self.implicit_end_token_ids
+            else -1
+        )
+        chosen = max(end, impl)
+        return chosen + scan_offset if chosen >= 0 else -1
+
     def _init_state_entry(
-        self, prompt_tok_ids: list[int] | None, thinking_token_budget: int
+        self,
+        prompt_tok_ids: list[int] | None,
+        thinking_token_budget: int | None,
+        reasoning_eos_policy: str = "stop",
+        stop_token_ids: list[int] | None = None,
     ) -> dict[str, Any]:
+        has_budget = thinking_token_budget is not None
+        countdown = thinking_token_budget if has_budget else 0
         if prompt_tok_ids is None:
             last_start = -1
             last_end = -1
             in_think = False
             think_count = 0
             start_thinking = -1
-            countdown = thinking_token_budget
             continue_thinking = False
             in_end = False
         else:
             start_thinking = -1
-            countdown = thinking_token_budget
             continue_thinking = False
             in_end = False
             last_start = self._find_last_sequence_index(
                 prompt_tok_ids, self.think_start_token_ids
             )
-            last_end = self._find_last_sequence_index(
-                prompt_tok_ids, self.think_end_token_ids
-            )
+            last_end = self._find_last_end_index(prompt_tok_ids)
             in_think = last_start > last_end
             # load metrics such as think count, start thinking
             # if request is in thinking mode, already
@@ -202,8 +233,9 @@ class ThinkingBudgetStateHolder:
                 countdown -= think_count
                 continue_thinking = True
                 # check if the token is exhausted within prompt
-                token_exhausted = thinking_token_budget - think_count
-                in_end = token_exhausted <= 0
+                if has_budget:
+                    token_exhausted = thinking_token_budget - think_count
+                    in_end = token_exhausted <= 0
             else:
                 think_count = 0
 
@@ -216,6 +248,8 @@ class ThinkingBudgetStateHolder:
             "prompt_tok_ids": prompt_tok_ids,
             "output_tok_ids": [],
             "thinking_token_budget": thinking_token_budget,
+            "reasoning_eos_policy": reasoning_eos_policy,
+            "stop_token_ids": stop_token_ids or [],
             "prev_output_length": 0,
             "spec_token_ids": [],
             "force_index": [],
@@ -227,8 +261,47 @@ class ThinkingBudgetStateHolder:
             "scan_offset": 0,
         }
 
+    @staticmethod
+    def _has_token_budget(state: dict[str, Any]) -> bool:
+        budget = state.get("thinking_token_budget")
+        return isinstance(budget, int) and budget >= 0
+
+    @staticmethod
+    def _reset_countdown(state: dict[str, Any]) -> None:
+        budget = state.get("thinking_token_budget")
+        state["check_count_down"] = (
+            budget if isinstance(budget, int) and budget >= 0 else 0
+        )
+
+    def _spec_contains_stop_token(self, state: dict[str, Any]) -> bool:
+        stop_ids = state.get("stop_token_ids") or []
+        if not stop_ids:
+            return False
+        stop_set = set(stop_ids)
+        return any(tok in stop_set for tok in state.get("spec_token_ids") or [])
+
+    def _maybe_force_end_from_spec_eos(self, state: dict[str, Any]) -> None:
+        if (
+            state.get("reasoning_eos_policy") != "force_end"
+            or not state.get("in_think")
+            or state.get("in_end")
+        ):
+            return
+        stop_ids = set(state.get("stop_token_ids") or [])
+        if not stop_ids:
+            return
+        for i, token_id in enumerate(state.get("spec_token_ids") or []):
+            if token_id in stop_ids:
+                state["in_think"] = False
+                state["in_end"] = True
+                state["end_count"] = 0
+                state["force_index"] = [i]
+                return
+
     def _update_think_state(self, state: dict[str, Any]) -> None:
-        if state.get("thinking_token_budget", -1) == -1:
+        if state.get("thinking_token_budget", -1) == -1 and (
+            state.get("reasoning_eos_policy") != "force_end"
+        ):
             return
         if len(self.think_end_token_ids) == 0:
             state["thinking_token_budget"] = -1
@@ -246,14 +319,10 @@ class ThinkingBudgetStateHolder:
                 start_thinking += scan_offset
             state["start_thinking"] = start_thinking
         if state["end_thinking"] == -1:
-            scan_offset = state.get("scan_offset", 0)
-            output_slice = state.get("output_tok_ids", [])[scan_offset:]
-            end_thinking = self._find_last_sequence_index(
-                output_slice, self.think_end_token_ids
+            state["end_thinking"] = self._find_last_end_index(
+                state.get("output_tok_ids", []),
+                state.get("scan_offset", 0),
             )
-            if end_thinking >= 0:
-                end_thinking += scan_offset
-            state["end_thinking"] = end_thinking
 
         if (
             not state.get("in_end", False)
@@ -268,7 +337,7 @@ class ThinkingBudgetStateHolder:
             state["start_thinking"] = -1
             state["end_thinking"] = -1
             state["scan_offset"] = len(state.get("output_tok_ids", []))
-            state["check_count_down"] = state["thinking_token_budget"]
+            self._reset_countdown(state)
             return
 
         if state["start_thinking"] == -1:
@@ -297,14 +366,20 @@ class ThinkingBudgetStateHolder:
         # detected (end_thinking != -1), fall through to handle the exit —
         # even if the budget hasn't expired yet. For continue_thinking=False,
         # the early natural-end detection block above already handles it.
+        # force_end also falls through when a speculative token is EOS so we
+        # can substitute reasoning_end before the budget expires.
         natural_end_with_continue = (
             state.get("continue_thinking", False) and state["end_thinking"] != -1
         )
+        spec_eos_pending = state.get(
+            "reasoning_eos_policy"
+        ) == "force_end" and self._spec_contains_stop_token(state)
         if (
             not state.get("in_end", False)
             and predicted_countdown >= 0
             and state["start_thinking"] > -1
             and not natural_end_with_continue
+            and not spec_eos_pending
         ):
             state["check_count_down"] = current_step_countdown
             state["prev_output_length"] = len(state.get("output_tok_ids", []))
@@ -325,17 +400,23 @@ class ThinkingBudgetStateHolder:
 
         if current_length <= prev_length:
             if state.get("in_end", False):
-                remaining_budget = state["thinking_token_budget"] - state["think_count"]
                 spec_len = len(state["spec_token_ids"])
-                if spec_len > 0:
-                    if 0 < remaining_budget < spec_len:
-                        state["force_index"] = [remaining_budget]
-                    elif remaining_budget <= 0:
-                        state["force_index"] = [0]
+                if self._has_token_budget(state):
+                    remaining_budget = (
+                        state["thinking_token_budget"] - state["think_count"]
+                    )
+                    if spec_len > 0:
+                        if 0 < remaining_budget < spec_len:
+                            state["force_index"] = [remaining_budget]
+                        elif remaining_budget <= 0:
+                            state["force_index"] = [0]
+                        else:
+                            state["force_index"] = [spec_len]
                     else:
-                        state["force_index"] = [spec_len]
+                        state["force_index"] = [0]
                 else:
-                    state["force_index"] = [0]
+                    existing = state.get("force_index")
+                    state["force_index"] = [0] if spec_len == 0 else existing or [0]
             return
 
         state["prev_output_length"] = current_length
@@ -405,13 +486,17 @@ class ThinkingBudgetStateHolder:
                 state["think_count"] = (
                     len(state["output_tok_ids"]) + think_tokens_in_prompt
                 )
-            if state["in_think"]:
+            if state["in_think"] and self._has_token_budget(state):
                 remaining_budget = max(
                     0, state["thinking_token_budget"] - state["think_count"]
                 )
                 state["check_count_down"] = remaining_budget
-            else:
-                state["check_count_down"] = state["thinking_token_budget"]
+            elif not state["in_think"]:
+                self._reset_countdown(state)
+
+            # Same placement as budget exhaustion: set in_end here so the
+            # rejected-end-token reset above does not undo it this step.
+            self._maybe_force_end_from_spec_eos(state)
 
             total_thinking_tokens = (
                 state["think_count"] + len(state["spec_token_ids"]) + 1
@@ -421,6 +506,7 @@ class ThinkingBudgetStateHolder:
             # we need to transition to end mode
             if (
                 state["in_think"]
+                and self._has_token_budget(state)
                 and total_thinking_tokens > state["thinking_token_budget"]
             ):
                 # Calculate force_index: position within spec_token_ids where
@@ -468,7 +554,6 @@ class ThinkingBudgetStateHolder:
                     {
                         "in_end": False,
                         "end_count": 0,
-                        "check_count_down": state["thinking_token_budget"],
                         "start_thinking": -1,
                         "end_thinking": -1,
                         "think_count": 0,
@@ -476,13 +561,13 @@ class ThinkingBudgetStateHolder:
                         "scan_offset": len(state.get("output_tok_ids", [])),
                     }
                 )
+                self._reset_countdown(state)
 
-    def _apply_forcing_to_logits(
+    def _prepare_cu_num_tokens(
         self,
-        logits: torch.Tensor,
         predict_bonus_token: bool,
         spec_token_ids_for_layout: list[list[int]],
-    ) -> torch.Tensor:
+    ) -> None:
         cumulative_total = 0
         self.cu_num_tokens.clear()
 
@@ -501,6 +586,111 @@ class ThinkingBudgetStateHolder:
                 cumulative_total += len(spec_tokens) if not predict_bonus_token else 1
             else:
                 cumulative_total += 1
+
+    def _request_row_count(
+        self,
+        seq_idx: int,
+        predict_bonus_token: bool,
+        spec_token_ids_for_layout: list[list[int]],
+    ) -> int:
+        if not self.in_spec_mode or predict_bonus_token:
+            return 1
+        if seq_idx < len(spec_token_ids_for_layout):
+            return max(len(spec_token_ids_for_layout[seq_idx]), 1)
+        return 1
+
+    def _apply_eos_policy_to_logits(
+        self,
+        logits: torch.Tensor,
+        predict_bonus_token: bool,
+        spec_token_ids_for_layout: list[list[int]],
+    ) -> None:
+        """Mask stop tokens in-think and force reasoning_end when EOS is argmax."""
+        if not self.think_end_token_ids:
+            return
+
+        entries: list[tuple[int, int, list[int]]] = []
+        for seq_idx in sorted(self._state.keys()):
+            if seq_idx not in self.cu_num_tokens:
+                continue
+            state = self._state[seq_idx]
+            if state.get("reasoning_eos_policy") != "force_end":
+                continue
+            if not state.get("in_think") and not state.get("in_end"):
+                continue
+            stop_ids = state.get("stop_token_ids") or []
+            if not stop_ids:
+                continue
+            n_rows = self._request_row_count(
+                seq_idx, predict_bonus_token, spec_token_ids_for_layout
+            )
+            base = self.cu_num_tokens[seq_idx]
+            for offset in range(n_rows):
+                row = base + offset
+                if row >= logits.shape[0]:
+                    break
+                entries.append((seq_idx, row, stop_ids))
+
+        if not entries:
+            return
+
+        device = logits.device
+        vocab = logits.shape[1]
+        rows = async_tensor_h2d(
+            [row for _, row, _ in entries], dtype=torch.long, device=device
+        )
+        row_logits = logits.index_select(0, rows)
+        row_max = row_logits.max(dim=-1).values
+        max_stops = max(len(stops) for _, _, stops in entries)
+        stop_cpu = torch.zeros((len(entries), max_stops), dtype=torch.long)
+        valid_cpu = torch.zeros((len(entries), max_stops), dtype=torch.bool)
+        for i, (_, _, stops) in enumerate(entries):
+            clipped = [s for s in stops if 0 <= s < vocab]
+            if clipped:
+                stop_cpu[i, : len(clipped)] = torch.as_tensor(clipped, dtype=torch.long)
+                valid_cpu[i, : len(clipped)] = True
+        stop_ids_t = stop_cpu.to(device, non_blocking=True)
+        valid = valid_cpu.to(device, non_blocking=True)
+        gathered = row_logits.gather(1, stop_ids_t)
+        gathered = gathered.masked_fill(~valid, float("-inf"))
+        stop_max = gathered.max(dim=-1).values
+        is_eos_argmax = (stop_max >= row_max).tolist()
+
+        first_eos_row: dict[int, int] = {}
+        mask_rows: list[int] = []
+        mask_cols: list[int] = []
+        for i, (seq_idx, row, stops) in enumerate(entries):
+            for stop_id in stops:
+                if 0 <= stop_id < logits.shape[1]:
+                    mask_rows.append(row)
+                    mask_cols.append(stop_id)
+            if is_eos_argmax[i] and seq_idx not in first_eos_row:
+                first_eos_row[seq_idx] = row - self.cu_num_tokens[seq_idx]
+
+        if mask_rows:
+            mask_row_t = async_tensor_h2d(mask_rows, dtype=torch.long, device=device)
+            mask_col_t = async_tensor_h2d(mask_cols, dtype=torch.long, device=device)
+            logits.index_put_(
+                (mask_row_t, mask_col_t),
+                logits.new_full((len(mask_rows),), float("-inf")),
+            )
+
+        for seq_idx, force_offset in first_eos_row.items():
+            state = self._state[seq_idx]
+            if state.get("in_end"):
+                continue
+            state["in_think"] = False
+            state["in_end"] = True
+            state["end_count"] = 0
+            state["force_index"] = [force_offset]
+
+    def _apply_forcing_to_logits(
+        self,
+        logits: torch.Tensor,
+        predict_bonus_token: bool,
+        spec_token_ids_for_layout: list[list[int]],
+    ) -> torch.Tensor:
+        self._prepare_cu_num_tokens(predict_bonus_token, spec_token_ids_for_layout)
 
         # Build the active index / forced-token lists entirely on CPU so we
         # avoid per-iteration scalar sync writes to GPU tensors.

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -204,8 +204,7 @@ class ThinkingBudgetStateHolder:
         reasoning_eos_policy: str = "stop",
         stop_token_ids: list[int] | None = None,
     ) -> dict[str, Any]:
-        has_budget = thinking_token_budget is not None
-        countdown = thinking_token_budget if has_budget else 0
+        countdown = 0 if thinking_token_budget is None else thinking_token_budget
         if prompt_tok_ids is None:
             last_start = -1
             last_end = -1
@@ -233,7 +232,7 @@ class ThinkingBudgetStateHolder:
                 countdown -= think_count
                 continue_thinking = True
                 # check if the token is exhausted within prompt
-                if has_budget:
+                if thinking_token_budget is not None:
                     token_exhausted = thinking_token_budget - think_count
                     in_end = token_exhausted <= 0
             else:

--- a/vllm/v1/worker/gpu/sample/thinking_budget.py
+++ b/vllm/v1/worker/gpu/sample/thinking_budget.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 _INT32_MAX = np.iinfo(np.int32).max
 _COLD_SCAN_BLOCK = 1024
+_MAX_STOP_IDS = 16
+_VOCAB_MAX_BLOCK = 1024
 
 
 class ThinkingBudgetState:
@@ -45,6 +47,12 @@ class ThinkingBudgetState:
             if reasoning_config is None
             else reasoning_config.natural_reasoning_end_token_ids or []
         )
+        implicit_end_ids = (
+            []
+            if reasoning_config is None
+            else getattr(reasoning_config, "implicit_reasoning_end_token_ids", None)
+            or []
+        )
         self.enabled = bool(start_ids and end_ids and natural_end_ids)
         if not self.enabled:
             return
@@ -67,6 +75,7 @@ class ThinkingBudgetState:
         )
         self._reset_reqs: list[int] = []
         self._budget_dirty = False
+        self._eos_dirty = False
 
         self.reasoning_start_token_ids = torch.tensor(
             start_ids, dtype=torch.int32, device=self.device
@@ -77,20 +86,50 @@ class ThinkingBudgetState:
         self.reasoning_end_token_ids = torch.tensor(
             end_ids, dtype=torch.int32, device=self.device
         )
+        self.implicit_reasoning_end_token_ids = torch.tensor(
+            implicit_end_ids or [-1], dtype=torch.int32, device=self.device
+        )
+        self._implicit_end_len = len(implicit_end_ids)
+        self.reasoning_eos_policy = torch.zeros(
+            self.max_num_reqs, dtype=torch.int32, device=self.device
+        )
+        self._policy_cpu = np.zeros(self.max_num_reqs, dtype=np.int32)
+        # Keep a live CPU tensor view so non-blocking copy_ cannot dangle.
+        self._policy_cpu_t = torch.from_numpy(self._policy_cpu)
+        self.stop_token_ids = torch.full(
+            (self.max_num_reqs, _MAX_STOP_IDS),
+            -1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self._stop_cpu = np.full((self.max_num_reqs, _MAX_STOP_IDS), -1, dtype=np.int32)
+        self._stop_cpu_t = torch.from_numpy(self._stop_cpu)
 
     def add_request(self, req_idx: int, sampling_params: SamplingParams) -> None:
         if not self.enabled:
             return
         budget = sampling_params.thinking_token_budget
-        self.use_thinking_budget[req_idx] = budget is not None
-        if budget is None:
-            budget = -1
-        else:
-            budget = min(budget, _INT32_MAX)
+        policy = 1 if sampling_params.reasoning_eos_policy == "force_end" else 0
+        track = budget is not None or policy == 1
+        self.use_thinking_budget[req_idx] = track
+        budget = -1 if budget is None else min(budget, _INT32_MAX)
+        if track:
             self._reset_reqs.append(req_idx)
         if self.thinking_token_budget.np[req_idx] != budget:
             self.thinking_token_budget.np[req_idx] = budget
             self._budget_dirty = True
+        if self._policy_cpu[req_idx] != policy:
+            self._policy_cpu[req_idx] = policy
+            self._eos_dirty = True
+        self._stop_cpu[req_idx].fill(-1)
+        if policy == 1:
+            stop_ids = sampling_params.stop_token_ids_that_finish_request()
+            n_stop = min(len(stop_ids), _MAX_STOP_IDS)
+            if n_stop:
+                self._stop_cpu[req_idx, :n_stop] = np.asarray(
+                    stop_ids[:n_stop], dtype=np.int32
+                )
+            self._eos_dirty = True
 
     def apply_staged_writes(self) -> None:
         if not self.enabled:
@@ -106,6 +145,10 @@ class ThinkingBudgetState:
         if self._budget_dirty:
             self.thinking_token_budget.copy_to_uva()
             self._budget_dirty = False
+        if self._eos_dirty:
+            self.reasoning_eos_policy.copy_(self._policy_cpu_t, non_blocking=True)
+            self.stop_token_ids.copy_(self._stop_cpu_t, non_blocking=True)
+            self._eos_dirty = False
 
     def apply(
         self,
@@ -134,6 +177,10 @@ class ThinkingBudgetState:
             self.reasoning_start_token_ids,
             self.natural_reasoning_end_token_ids,
             self.reasoning_end_token_ids,
+            self.implicit_reasoning_end_token_ids,
+            self._implicit_end_len,
+            self.reasoning_eos_policy,
+            self.stop_token_ids,
         )
 
 
@@ -168,14 +215,18 @@ def _update_committed_marker_cache_kernel(
     cached_scan_pos_ptr,
     reasoning_start_token_ids_ptr,
     natural_reasoning_end_token_ids_ptr,
+    implicit_reasoning_end_token_ids_ptr,
+    reasoning_eos_policy_ptr,
     START_LEN: tl.constexpr,
     NATURAL_END_LEN: tl.constexpr,
+    IMPLICIT_LEN: tl.constexpr,
     MAX_LEN: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     req_state_idx = tl.load(req_ids_ptr + tl.program_id(0))
     budget = tl.load(thinking_token_budget_ptr + req_state_idx)
-    if budget < 0:
+    policy = tl.load(reasoning_eos_policy_ptr + req_state_idx)
+    if budget < 0 and policy != 1:
         return
 
     total_len = tl.load(total_len_ptr + req_state_idx)
@@ -221,6 +272,21 @@ def _update_committed_marker_cache_kernel(
 
             last_start = tl.max(tl.where(start_match, offs, -1), axis=0)
             last_end = tl.max(tl.where(end_match, offs, -1), axis=0)
+            if IMPLICIT_LEN > 0:
+                impl_match = (offs < block_hi) & (offs + IMPLICIT_LEN <= total_len)
+                for j in tl.static_range(0, IMPLICIT_LEN):
+                    expected = tl.load(implicit_reasoning_end_token_ids_ptr + j)
+                    actual = tl.load(
+                        all_token_ids_ptr
+                        + req_state_idx * all_token_ids_stride
+                        + offs
+                        + j,
+                        mask=offs + j < total_len,
+                        other=-1,
+                    )
+                    impl_match = impl_match & (actual == expected)
+                last_impl = tl.max(tl.where(impl_match, offs, -1), axis=0)
+                last_end = tl.maximum(last_end, last_impl)
             block_hi = block_lo
     else:
         for i in tl.range(scan_pos, total_len):
@@ -244,6 +310,17 @@ def _update_committed_marker_cache_kernel(
                     )
                     end_match = end_match & (actual == expected)
                 if end_match:
+                    last_end = i
+
+            if IMPLICIT_LEN > 0 and i + IMPLICIT_LEN <= total_len:
+                impl_match = True
+                for j in tl.static_range(0, IMPLICIT_LEN):
+                    expected = tl.load(implicit_reasoning_end_token_ids_ptr + j)
+                    actual = tl.load(
+                        all_token_ids_ptr + req_state_idx * all_token_ids_stride + i + j
+                    )
+                    impl_match = impl_match & (actual == expected)
+                if impl_match:
                     last_end = i
 
     tl.store(cached_last_start_ptr + req_state_idx, last_start)
@@ -270,14 +347,22 @@ def _thinking_budget_kernel(
     reasoning_start_token_ids_ptr,
     natural_reasoning_end_token_ids_ptr,
     reasoning_end_token_ids_ptr,
+    implicit_reasoning_end_token_ids_ptr,
+    reasoning_eos_policy_ptr,
+    stop_token_ids_ptr,
     START_LEN: tl.constexpr,
     NATURAL_END_LEN: tl.constexpr,
     END_LEN: tl.constexpr,
+    IMPLICIT_LEN: tl.constexpr,
+    MAX_STOP: tl.constexpr,
+    VOCAB_SIZE: tl.constexpr,
+    VOCAB_BLOCK: tl.constexpr,
 ):
     token_idx = tl.program_id(0).to(tl.int64)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     budget = tl.load(thinking_token_budget_ptr + req_state_idx)
-    if budget < 0:
+    policy = tl.load(reasoning_eos_policy_ptr + req_state_idx)
+    if budget < 0 and policy != 1:
         return
 
     local_pos = tl.load(expanded_local_pos_ptr + token_idx)
@@ -328,6 +413,27 @@ def _thinking_budget_kernel(
         if end_match:
             last_end = i
 
+    if IMPLICIT_LEN > 0:
+        impl_lo = total_len - IMPLICIT_LEN + 1
+        if impl_lo < 0:
+            impl_lo = 0
+        for i in tl.range(impl_lo, effective_len - IMPLICIT_LEN + 1):
+            impl_match = True
+            for j in tl.static_range(0, IMPLICIT_LEN):
+                expected = tl.load(implicit_reasoning_end_token_ids_ptr + j)
+                actual = _load_effective_token(
+                    all_token_ids_ptr,
+                    all_token_ids_stride,
+                    input_ids_ptr,
+                    cur_req_first_pos,
+                    req_state_idx,
+                    total_len,
+                    i + j,
+                )
+                impl_match = impl_match & (actual == expected)
+            if impl_match:
+                last_end = i
+
     if last_start < 0 or last_start <= last_end:
         return
 
@@ -335,7 +441,30 @@ def _thinking_budget_kernel(
     # If the request resumes from a prompt that already contains generated
     # reasoning content, count it against the remaining budget.
     num_reasoning_tokens = effective_len - reasoning_start
-    if num_reasoning_tokens < budget:
+    budget_hit = (budget >= 0) and (num_reasoning_tokens >= budget)
+    eos_force = False
+    if policy == 1:
+        row_max = -1.0e30
+        for start in tl.range(0, VOCAB_SIZE, VOCAB_BLOCK):
+            offs = start + tl.arange(0, VOCAB_BLOCK)
+            mask = offs < VOCAB_SIZE
+            vals = tl.load(
+                logits_ptr + token_idx * logits_stride + offs,
+                mask=mask,
+                other=-1.0e30,
+            )
+            row_max = tl.maximum(row_max, tl.max(vals, axis=0))
+        for j in tl.static_range(0, MAX_STOP):
+            sid = tl.load(stop_token_ids_ptr + req_state_idx * MAX_STOP + j)
+            if sid >= 0 and sid < VOCAB_SIZE:
+                elog = tl.load(logits_ptr + token_idx * logits_stride + sid)
+                if elog >= row_max:
+                    eos_force = True
+                tl.store(
+                    logits_ptr + token_idx * logits_stride + sid,
+                    -1.0e30,
+                )
+    if (not budget_hit) and (not eos_force):
         return
 
     # If the tail already ends with a prefix of the forced end sequence
@@ -384,11 +513,16 @@ def apply_thinking_budget(
     reasoning_start_token_ids: torch.Tensor,
     natural_reasoning_end_token_ids: torch.Tensor,
     reasoning_end_token_ids: torch.Tensor,
+    implicit_reasoning_end_token_ids: torch.Tensor,
+    implicit_end_len: int,
+    reasoning_eos_policy: torch.Tensor,
+    stop_token_ids: torch.Tensor,
 ) -> None:
     num_tokens = logits.shape[0]
     start_len = reasoning_start_token_ids.shape[0]
     natural_end_len = natural_reasoning_end_token_ids.shape[0]
     end_len = reasoning_end_token_ids.shape[0]
+    marker_max = max(start_len, natural_end_len, implicit_end_len, 1)
 
     _update_committed_marker_cache_kernel[(req_ids.shape[0],)](
         req_ids,
@@ -401,9 +535,12 @@ def apply_thinking_budget(
         cached_scan_pos,
         reasoning_start_token_ids,
         natural_reasoning_end_token_ids,
+        implicit_reasoning_end_token_ids,
+        reasoning_eos_policy,
         START_LEN=start_len,
         NATURAL_END_LEN=natural_end_len,
-        MAX_LEN=max(start_len, natural_end_len),
+        IMPLICIT_LEN=implicit_end_len,
+        MAX_LEN=marker_max,
         BLOCK=_COLD_SCAN_BLOCK,
     )
 
@@ -422,7 +559,14 @@ def apply_thinking_budget(
         reasoning_start_token_ids,
         natural_reasoning_end_token_ids,
         reasoning_end_token_ids,
+        implicit_reasoning_end_token_ids,
+        reasoning_eos_policy,
+        stop_token_ids,
         START_LEN=start_len,
         NATURAL_END_LEN=natural_end_len,
         END_LEN=end_len,
+        IMPLICIT_LEN=implicit_end_len,
+        MAX_STOP=_MAX_STOP_IDS,
+        VOCAB_SIZE=logits.shape[1],
+        VOCAB_BLOCK=_VOCAB_MAX_BLOCK,
     )

--- a/vllm/v1/worker/gpu/sample/thinking_budget.py
+++ b/vllm/v1/worker/gpu/sample/thinking_budget.py
@@ -124,11 +124,14 @@ class ThinkingBudgetState:
         self._stop_cpu[req_idx].fill(-1)
         if policy == 1:
             stop_ids = sampling_params.stop_token_ids_that_finish_request()
-            n_stop = min(len(stop_ids), _MAX_STOP_IDS)
-            if n_stop:
-                self._stop_cpu[req_idx, :n_stop] = np.asarray(
-                    stop_ids[:n_stop], dtype=np.int32
+            n_stop = len(stop_ids)
+            if n_stop > _MAX_STOP_IDS:
+                raise ValueError(
+                    "reasoning_eos_policy='force_end' supports at most "
+                    f"{_MAX_STOP_IDS} finishing stop token IDs"
                 )
+            if n_stop:
+                self._stop_cpu[req_idx, :n_stop] = np.asarray(stop_ids, dtype=np.int32)
             self._eos_dirty = True
 
     def apply_staged_writes(self) -> None:
@@ -240,11 +243,11 @@ def _update_committed_marker_cache_kernel(
         last_end = -1
 
     if scan_pos == 0 and last_start < 0 and last_end < 0:
-        # Cold scan: walk backward in vectorized blocks, stopping at the first
-        # block with a marker; only the relative order of the two positions
-        # found matters below.
+        # Cold scan: walk backward in vectorized blocks. Keep the latest start
+        # and end across blocks so an implicit end in a later block is not
+        # overwritten when an earlier block has only ``<think>``.
         block_hi = total_len
-        while block_hi > 0 and last_start < 0 and last_end < 0:
+        while block_hi > 0 and (last_start < 0 or last_end < 0):
             block_lo = block_hi - BLOCK
             if block_lo < 0:
                 block_lo = 0
@@ -270,8 +273,12 @@ def _update_committed_marker_cache_kernel(
                 )
                 end_match = end_match & (actual == expected)
 
-            last_start = tl.max(tl.where(start_match, offs, -1), axis=0)
-            last_end = tl.max(tl.where(end_match, offs, -1), axis=0)
+            last_start = tl.maximum(
+                last_start, tl.max(tl.where(start_match, offs, -1), axis=0)
+            )
+            last_end = tl.maximum(
+                last_end, tl.max(tl.where(end_match, offs, -1), axis=0)
+            )
             if IMPLICIT_LEN > 0:
                 impl_match = (offs < block_hi) & (offs + IMPLICIT_LEN <= total_len)
                 for j in tl.static_range(0, IMPLICIT_LEN):


### PR DESCRIPTION
Fixes #55420

## Purpose

Qwen3.8 (and similar reasoning models) sometimes sample `<|im_end|>` while still inside `<think>`. vLLM treats that as a real stop, the parser parks the unfinished think block in `reasoning_content`, and `content` is empty with `finish_reason: "stop"`. HTTP 200, so a client cannot tell this apart from a legitimate empty answer.

This adds a per-request sampling parameter, same placement as `thinking_token_budget`:

- `reasoning_eos_policy="stop"` (default): current behavior
- `reasoning_eos_policy="force_end"`: while the request is in-think, mask EOS/stop tokens. If EOS would be sampled (greedy-top, or an accepted speculative token), force `reasoning_end_str` on the existing `ThinkingBudgetStateHolder` / v2 thinking-budget kernel path, then continue into the answer

`ignore_eos` is unchanged. The policy does nothing outside a think block. A Qwen3 `<tool_call>` started inside `<think>` counts as leaving think, so tool-call tokens are not rewritten (the implicit-end case from #44676).

I searched open PRs for `55420`, `reasoning_eos_policy`, and `force_end`. I did not find another PR implementing this parameter. Closest related work is stop-string handling inside reasoning (#52486) and loop-breaking by forcing reasoning end (#52677); those are different problems.

AI assistance was used to implement and test this. I reviewed the sampler/holder changes and the API wiring.

## Test Plan

```bash
.venv/bin/ruff check <changed python files>
.venv/bin/ruff format --check <changed python files>
PYTHONPATH=. .venv/bin/python -m pytest \
  tests/v1/sample/test_thinking_budget_state.py \
  tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py \
  -v --noconftest
```

v2 GPU kernel tests in `tests/v1/worker/test_gpu_thinking_budget.py` skip without CUDA. I could not run a Qwen3.8 serve eval in this environment.

## Test Result

- ruff check/format: passed on the changed Python files
- 29 unit tests passed (holder behavior, OpenAI Chat/Completions validation and `to_sampling_params`)
- GPU kernel tests: not run (no CUDA)
- Model eval: not run. I do not have a Qwen3.8 checkpoint or GPU here. Happy to follow up with a serve log if someone can try `reasoning_eos_policy=force_end` on the reproduction from the issue

## Docs

`docs/features/reasoning_outputs.md` has a short section and curl/offline examples.