### PR TITLE
[Bugfix][GLM-5.3] Fit the kpool-widened sparse top-k buffer to the 2048-wide SM120 index without a config edit

### DIFF
--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -592,7 +592,38 @@ class Glm5NextModel(nn.Module):
             # Reserve room for the incomplete pool tail.
             kpool = config.index_kpool
             assert kpool is not None
-            buffer_width = topk_tokens + (kpool - 1 if kpool > 1 else 0)
+            # The sparse-MLA decode kernels are instantiated for an index width
+            # of 2048. With kpool > 1 the always-selected tail widens the buffer
+            # past index_topk (2048 + 3 -> 2176 for GLM-5.3-Flash), which no
+            # compiled shape serves. Fit the effective top-k so that the widened
+            # buffer stays within the kernel width instead of requiring users to
+            # edit index_topk in config.json (the same 2044/2045 every GB10 /
+            # RTX PRO recipe applies by hand). select_k = topk // kpool is
+            # unchanged for 2045 vs 2044 (511 pools).
+            kernel_index_width = 2048
+            tail = kpool - 1 if kpool > 1 else 0
+            overflows = topk_tokens + tail > kernel_index_width
+            if tail and overflows and topk_tokens <= kernel_index_width:
+                fitted = kernel_index_width - tail
+                logger.info_once(
+                    "GLM-5.3 sparse indexer: index_topk=%d + kpool tail %d "
+                    "exceeds the %d-wide sparse index; using effective "
+                    "index_topk=%d (%d pools).",
+                    topk_tokens,
+                    tail,
+                    kernel_index_width,
+                    fitted,
+                    fitted // kpool,
+                )
+                topk_tokens = fitted
+                config.index_topk = fitted
+                text_config = getattr(config, "text_config", None)
+                if (
+                    text_config is not None
+                    and getattr(text_config, "index_topk", None) == fitted + tail
+                ):
+                    text_config.index_topk = fitted
+            buffer_width = topk_tokens + tail
             # Sparse MLA tiles top-k in 128 columns; padded slots remain masked.
             sparse_topk_block_n = 128
             buffer_width = (

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -637,7 +637,7 @@ class Glm5NextModel(nn.Module):
             # Reserve room for the incomplete pool tail.
             kpool = config.index_kpool
             assert kpool is not None
-            buffer_width = topk_tokens + tail
+            buffer_width = topk_tokens + (kpool - 1 if kpool > 1 else 0)
             # Sparse MLA tiles top-k in 128 columns; padded slots remain masked.
             sparse_topk_block_n = 128
             buffer_width = (

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -575,6 +575,52 @@ class Glm5NextDecoderLayer(nn.Module):
         )
 
 
+# The sparse-MLA decode kernels are instantiated for an index width of 2048.
+SPARSE_INDEX_KERNEL_WIDTH = 2048
+
+
+def fit_sparse_index_topk(config) -> int:
+    """Return the effective ``index_topk`` for the sparse indexer.
+
+    With ``index_kpool > 1`` the always-selected pool tail widens the top-k
+    buffer past ``index_topk`` (2048 + 3 -> 2176 for GLM-5.3-Flash), which no
+    compiled sparse-MLA shape serves. Fit the effective top-k so the widened
+    buffer stays within the kernel width instead of requiring users to edit
+    ``index_topk`` in ``config.json`` (the 2044/2045 every GB10 / RTX PRO
+    recipe applies by hand). ``select_k = topk // kpool`` is unchanged for
+    2045 vs 2044 (511 pools). The fitted value is written back to ``config`` so
+    every consumer of this config (target model, MTP draft, attention backend
+    checks) sees the same width.
+    """
+    topk_tokens = config.index_topk
+    assert topk_tokens is not None
+    kpool = config.index_kpool
+    assert kpool is not None
+    tail = kpool - 1 if kpool > 1 else 0
+    overflows = topk_tokens + tail > SPARSE_INDEX_KERNEL_WIDTH
+    if tail and overflows and topk_tokens <= SPARSE_INDEX_KERNEL_WIDTH:
+        fitted = SPARSE_INDEX_KERNEL_WIDTH - tail
+        logger.info_once(
+            "GLM-5.3 sparse indexer: index_topk=%d + kpool tail %d exceeds "
+            "the %d-wide sparse index; using effective index_topk=%d "
+            "(%d pools).",
+            topk_tokens,
+            tail,
+            SPARSE_INDEX_KERNEL_WIDTH,
+            fitted,
+            fitted // kpool,
+        )
+        config.index_topk = fitted
+        text_config = getattr(config, "text_config", None)
+        if (
+            text_config is not None
+            and getattr(text_config, "index_topk", None) == fitted + tail
+        ):
+            text_config.index_topk = fitted
+        return fitted
+    return topk_tokens
+
+
 class Glm5NextModel(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -587,42 +633,10 @@ class Glm5NextModel(nn.Module):
 
         self.is_v32 = config.index_topk is not None
         if self.is_v32:
-            topk_tokens = config.index_topk
-            assert topk_tokens is not None
+            topk_tokens = fit_sparse_index_topk(config)
             # Reserve room for the incomplete pool tail.
             kpool = config.index_kpool
             assert kpool is not None
-            # The sparse-MLA decode kernels are instantiated for an index width
-            # of 2048. With kpool > 1 the always-selected tail widens the buffer
-            # past index_topk (2048 + 3 -> 2176 for GLM-5.3-Flash), which no
-            # compiled shape serves. Fit the effective top-k so that the widened
-            # buffer stays within the kernel width instead of requiring users to
-            # edit index_topk in config.json (the same 2044/2045 every GB10 /
-            # RTX PRO recipe applies by hand). select_k = topk // kpool is
-            # unchanged for 2045 vs 2044 (511 pools).
-            kernel_index_width = 2048
-            tail = kpool - 1 if kpool > 1 else 0
-            overflows = topk_tokens + tail > kernel_index_width
-            if tail and overflows and topk_tokens <= kernel_index_width:
-                fitted = kernel_index_width - tail
-                logger.info_once(
-                    "GLM-5.3 sparse indexer: index_topk=%d + kpool tail %d "
-                    "exceeds the %d-wide sparse index; using effective "
-                    "index_topk=%d (%d pools).",
-                    topk_tokens,
-                    tail,
-                    kernel_index_width,
-                    fitted,
-                    fitted // kpool,
-                )
-                topk_tokens = fitted
-                config.index_topk = fitted
-                text_config = getattr(config, "text_config", None)
-                if (
-                    text_config is not None
-                    and getattr(text_config, "index_topk", None) == fitted + tail
-                ):
-                    text_config.index_topk = fitted
             buffer_width = topk_tokens + tail
             # Sparse MLA tiles top-k in 128 columns; padded slots remain masked.
             sparse_topk_block_n = 128

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -31,6 +31,7 @@ from .model import (
     Glm5NextMoE,
     _try_load_fp8_attn_proj,
     _try_load_fp8_indexer_wk,
+    fit_sparse_index_topk,
     get_spec_layer_idx_from_weight_name,
 )
 from .ops.fused_eh_norm import fused_eh_norm
@@ -50,8 +51,7 @@ class Glm5NextMultiTokenPredictorLayer(nn.Module):
 
         # Reserve room for the incomplete pool tail and align the sparse MLA
         # buffer width to BLOCK_N=128.
-        topk_tokens = config.index_topk
-        assert topk_tokens is not None
+        topk_tokens = fit_sparse_index_topk(config)
         kpool = config.index_kpool
         assert kpool is not None
         buffer_width = topk_tokens + (kpool - 1 if kpool > 1 else 0)

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -215,7 +215,14 @@ class FlashInferMLASparseSM120Backend(_FlashInferMLASparseBackendBase):
                     "FLASHINFER_MLA_SPARSE_SM120 requires a model with "
                     "index_topk config"
                 )
-            if int(index_topk) != 2048:
+            # With index_kpool > 1 the indexer widens the top-k buffer by the
+            # always-selected pool tail (kpool - 1); the glm5next model fits
+            # index_topk down to (2048 - tail) at init so the widened buffer
+            # matches the kernel's 2048-wide index. Validate the fitted value.
+            kpool = getattr(hf_text_config, "index_kpool", 1) or 1
+            tail = kpool - 1 if kpool > 1 else 0
+            fitted = min(int(index_topk), 2048 - tail) if tail else int(index_topk)
+            if ((fitted + tail + 127) // 128) * 128 != 2048:
                 return (
                     "FLASHINFER_MLA_SPARSE_SM120 requires index_topk=2048; "
                     f"got {index_topk}"


### PR DESCRIPTION
## Purpose

Let GLM-5.3-Flash serve through `FLASHINFER_MLA_SPARSE_SM120` with its stock checkpoint config, without the `index_topk=2044` hand edit that every SM120 / DGX Spark recipe currently applies.

`Glm5NextForConditionalGeneration` ships `index_topk=2048, index_kpool=4`. The kpool indexer widens the top-k buffer by the always-selected pool tail (`kpool - 1`) and pads it to a multiple of 128, so the buffer that reaches the sparse-MLA kernels is 2176 wide, while the SM120 sparse backend and its kernels are instantiated for an index width of exactly 2048. With #53969's effective-width check the stock config is rejected at startup (`requires an effective topk buffer width of 2048; got 2176`); without it, the kernel receives a 2176-wide page table.

## Change

- `vllm/models/glm5next/nvidia/model.py`: a shared helper `fit_sparse_index_topk(config)` — when `index_topk + tail` would overflow the 2048-wide index, use the effective `index_topk = 2048 - tail` (2045 for GLM-5.3-Flash; `select_k = index_topk // kpool = 511` pools, the same as the 2044 workaround) and log it once. The fitted value is written back to the config that was passed in, so the indexer and the attention backend agree.
- `vllm/models/glm5next/nvidia/mtp.py`: the MTP draft sizes its own `topk_indices_buffer` from the draft model config (a separate object), so it calls the same helper; without that the `glm5_next_mtp` speculative path still built the 2176-wide buffer and failed at init on the SM120 sparse-MLA backend (`no decode kernel for this shape: ... topk=2176`).
- `vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py`: the SM120 backend validation checks the fitted width instead of the raw config value.

No behaviour change for configs that already fit (DeepSeek-V3.2 style `index_topk=2048, kpool=1`, or hand-edited 2044/4).

## Test

2× NVIDIA DGX Spark (GB10, sm_121, CUDA 13.0), `--tensor-parallel-size 2 --nnodes 2`, RadixArk/GLM-5.3-Flash-NVFP4 with the **unedited** `config.json`, `--kv-cache-dtype fp8_ds_mla --block-size 256`, on top of #53969:

- startup logs `GLM-5.3 sparse indexer: index_topk=2048 + kpool tail 3 exceeds the 2048-wide sparse index; using effective index_topk=2045 (511 pools).`
- engine healthy (GPU KV cache 763,494 tokens at 131K max-len; 921,475 at 262K); arithmetic gate (temperature 0, e.g. `137*89 → 12193`) exact 3/3 trials on the stock config
- behaviour matches the hand-edited `index_topk=2044` config on the same hardware (same `select_k`): keyed long-context probe 46/63 on the stock config vs 44/63 on the 2044 edit (within run-to-run spread; details in the comments)
- with the MTP follow-up: `--speculative-config '{"method":"glm5_next_mtp","num_speculative_tokens":3}'` initializes and serves at 229K–262K max-len (acceptance length 3.8–4.0 of 4; details in the comments)

Related: #53906 (model), #53969 (SM120 NoPE support; this PR complements its width check), #55277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
