### PR TITLE
[Perf][Model] Compare tied weights on device outside ROCm

### DIFF
--- a/tests/model_executor/model_loader/test_weight_tying.py
+++ b/tests/model_executor/model_loader/test_weight_tying.py
@@ -12,6 +12,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from vllm.model_executor.model_loader.weight_tying import maybe_retie_word_embeddings
+from vllm.platforms import current_platform
 
 VOCAB_SIZE = 16
 HIDDEN_SIZE = 4
@@ -84,3 +85,23 @@ def test_no_retie_without_checkpoint_override():
     maybe_retie_word_embeddings(model, make_model_config())
 
     assert model.lm_head.weight is not model.embed_tokens.weight
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA-only test")
+@pytest.mark.usefixtures("dist_init")
+@pytest.mark.parametrize("identical", [True, False])
+def test_retie_compares_weights_on_cuda(monkeypatch, identical: bool):
+    model = UntiedModel().cuda()
+    if not identical:
+        model.lm_head.weight.data[-1, -1] = 2.0
+    torch_equal = torch.equal
+
+    def assert_cuda_equal(left: torch.Tensor, right: torch.Tensor) -> bool:
+        assert left.is_cuda
+        assert right.is_cuda
+        return torch_equal(left, right)
+
+    monkeypatch.setattr(torch, "equal", assert_cuda_equal)
+    maybe_retie_word_embeddings(model, make_model_config(untied_by_checkpoint=True))
+
+    assert (model.lm_head.weight is model.embed_tokens.weight) is identical

--- a/vllm/model_executor/model_loader/weight_tying.py
+++ b/vllm/model_executor/model_loader/weight_tying.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
 )
+from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -84,8 +85,14 @@ def maybe_retie_word_embeddings(model: nn.Module, model_config: ModelConfig) -> 
     if (untied := _get_untied_lm_head(model)) is None:
         return
 
-    # On device, torch.equal segfaults on ROCm when sleep mode is enabled
-    if not torch.equal(untied.lm_head.weight.cpu(), untied.embed_tokens.weight.cpu()):
+    # On device, torch.equal segfaults on ROCm when sleep mode is enabled.
+    lm_head_weight = untied.lm_head.weight
+    embed_tokens_weight = untied.embed_tokens.weight
+    if current_platform.is_rocm():
+        lm_head_weight = lm_head_weight.cpu()
+        embed_tokens_weight = embed_tokens_weight.cpu()
+
+    if not torch.equal(lm_head_weight, embed_tokens_weight):
         logger.warning(
             "The config for %s says the word embeddings are tied, but the checkpoint "
             "contains a different %s, which has been used instead of tying. "


### PR DESCRIPTION
# [Perf][Model] Compare tied weights on device outside ROCm

## Purpose

`maybe_retie_word_embeddings()` checks whether a checkpoint's `lm_head` and
input embeddings are identical before sharing their storage again. It currently
evaluates:

```python
torch.equal(lm_head.weight.cpu(), embed_tokens.weight.cpu())
```

On CUDA this synchronously transfers and materializes both complete vocabulary
matrices on the host during model startup. For Qwen3-0.6B dimensions that is
593.5 MiB of temporary host tensors; for Qwen3-1.7B dimensions it is 1,187 MiB.

The CPU fallback exists because device-side `torch.equal` can crash on ROCm
while sleep mode is enabled. This PR keeps that workaround on ROCm and performs
the same comparison on the tensors' current device everywhere else. Weight
tying, mismatch warnings, and the comparison result are unchanged.

Production diff: 9 insertions, 2 deletions. A focused CUDA regression test
adds 21 lines and verifies that both tensors remain on CUDA for this path.

## Implementation

- Select the two existing weight tensors directly by default.
- Move both to CPU only when `current_platform.is_rocm()`.
- Keep the existing `torch.equal`, warning, and `tie()` control flow.

## Validation

Hardware/software: NVIDIA A100 PCIe 40GB, driver 560.35.05, CUDA 12.6,
PyTorch 2.13.0+cu126. Baseline commit: `a1541f5742`.

### Tests and checks

```bash
pytest -q tests/model_executor/model_loader/test_weight_tying.py
pre-commit run --files \
  vllm/model_executor/model_loader/weight_tying.py \
  tests/model_executor/model_loader/test_weight_tying.py
git diff --check
```

Result: `6 passed`. All changed-file pre-commit hooks and diff checks passed.

The tests cover identical, different, quantized, genuinely untied, and CUDA
device-placement cases. The CUDA test checks both comparison outcomes and
asserts that `torch.equal` receives CUDA tensors.

### Exact comparison benchmark

The harness uses Qwen3's 151,936-token vocabulary with the hidden sizes of
Qwen3-0.6B and Qwen3-1.7B. FP16 and BF16, plus equal and last-element-different
weights, cover both outcomes of `torch.equal`. Seven samples were collected in
alternating CPU/CUDA order after three CUDA warmups. Every call is synchronized;
the table reports p20/p50/p80 for the complete comparison.

| dtype | hidden | weights | CPU p20/p50/p80 (ms) | CUDA p20/p50/p80 (ms) | p50 speedup |
|:---|---:|:---|:---|:---|---:|
| FP16 | 1,024 | equal | 389.868 / 391.525 / 393.420 | 0.873 / 0.888 / 0.937 | 440.8x |
| FP16 | 1,024 | different | 397.826 / 398.476 / 403.153 | 0.911 / 0.915 / 0.925 | 435.4x |
| BF16 | 1,024 | equal | 394.048 / 397.885 / 400.064 | 0.885 / 0.894 / 0.912 | 445.3x |
| BF16 | 1,024 | different | 383.531 / 386.805 / 389.991 | 0.914 / 0.914 / 0.916 | 423.1x |
| FP16 | 2,048 | equal | 782.470 / 786.030 / 791.280 | 1.656 / 1.662 / 1.673 | 472.9x |
| FP16 | 2,048 | different | 783.206 / 784.867 / 788.183 | 1.619 / 1.664 / 1.672 | 471.6x |
| BF16 | 2,048 | equal | 759.395 / 764.055 / 764.997 | 1.646 / 1.652 / 1.661 | 462.5x |
| BF16 | 2,048 | different | 759.143 / 760.415 / 764.495 | 1.653 / 1.656 / 1.661 | 459.2x |

All eight configurations returned the same boolean before and after. Similar
timings for equal and unequal weights show that the mismatch/warning path does
not lose the improvement.

### Qwen3-0.6B full initialization

The Qwen3-0.6B safetensors checkpoint contains both `lm_head.weight` and
`model.embed_tokens.weight`, so it executes this re-tie path. Four baseline and
four candidate initializations ran in fresh processes with alternating order,
eager mode, in-process V1, and unrelated kernel/autotune warmups disabled.

| | range | median |
|:---|:---|---:|
| baseline | 10.497–10.541 s | 10.519 s |
| this PR | 10.100–10.240 s | 10.178 s |

The median complete initialization improvement is 0.341 s (3.2%). Every run
initialized successfully. A separately instrumented run measured
`maybe_retie_word_embeddings()` itself at 394.458 ms before and 23.391 ms after.

## Limitations

The complete initialization result is a Qwen3-0.6B eager-mode result,
not a serving-throughput claim. The exact comparison benchmark isolates the
changed startup operation. ROCm deliberately retains the old CPU comparison
and was not performance-tested here. No performance claim is made for ROCm,
other accelerators, or checkpoints that do not enter this re-tie path.

No model-quality evaluation is needed because this changes where an exact
equality check executes, not its result; the differential checks and model
initialization verify the unchanged decision.
