### PR TITLE
[Perf][Tool Parser] Track DeepSeek streaming delimiters incrementally

### DIFF
--- a/tests/tool_parsers/test_deepseek_streaming_state.py
+++ b/tests/tool_parsers/test_deepseek_streaming_state.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.tool_parsers.deepseek_streaming_state import DeepSeekStreamingTokenState
+
+
+class CountedList(list[int]):
+    def __init__(self, values: list[int]):
+        super().__init__(values)
+        self.contains_calls = 0
+        self.count_calls = 0
+
+    def __contains__(self, value: object) -> bool:
+        self.contains_calls += 1
+        return super().__contains__(value)
+
+    def count(self, value: int) -> int:
+        self.count_calls += 1
+        return super().count(value)
+
+
+def test_cumulative_tokens_are_only_inspected_on_first_update():
+    state = DeepSeekStreamingTokenState(1, 2, 3)
+    previous = CountedList([9] * 1024)
+    current = CountedList([9] * 1025)
+    delta = CountedList([9])
+
+    assert state.update(previous, current, delta) is None
+    assert current.contains_calls == 1
+    assert previous.count_calls == current.count_calls == 0
+
+    previous = CountedList([9] * 1025)
+    current = CountedList([9] * 1026)
+    delta = CountedList([9])
+    assert state.update(previous, current, delta) is None
+    assert current.contains_calls == 0
+    assert previous.count_calls == current.count_calls == 0
+
+
+def test_first_update_preserves_cumulative_marker_detection():
+    state = DeepSeekStreamingTokenState(1, 2, 3)
+
+    assert state.update([1, 2], [1, 2, 3], [3]) == (1, 0, 1, 1)
+
+
+def test_counts_are_updated_from_deltas_after_tool_calls_start():
+    state = DeepSeekStreamingTokenState(1, 2, 3)
+    assert state.update([], [1, 2], [1, 2]) == (0, 0, 1, 0)
+
+    previous = CountedList([1, 2])
+    current = CountedList([1, 2, 2, 2, 3])
+    assert state.update(previous, current, [2, 2, 3]) == (1, 0, 3, 1)
+    assert previous.count_calls == 0
+    assert current.count_calls == 0

--- a/vllm/tool_parsers/deepseek_streaming_state.py
+++ b/vllm/tool_parsers/deepseek_streaming_state.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass
+class DeepSeekStreamingTokenState:
+    tool_calls_start_token_id: int
+    tool_call_start_token_id: int | None
+    tool_call_end_token_id: int | None
+    tool_calls_started: bool = False
+    tool_start_count: int = 0
+    tool_end_count: int = 0
+    initialized: bool = False
+
+    def update(
+        self,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> tuple[int, int, int, int] | None:
+        """Return previous/current inner tool-tag counts after a delta."""
+        if not self.tool_calls_started:
+            start_in_delta = self.tool_calls_start_token_id in delta_token_ids
+            if not self.initialized:
+                self.initialized = True
+                if (
+                    not start_in_delta
+                    and self.tool_calls_start_token_id not in current_token_ids
+                ):
+                    return None
+            elif not start_in_delta:
+                return None
+
+            self.tool_calls_started = True
+            previous_start_count = previous_token_ids.count(
+                self.tool_call_start_token_id
+            )
+            previous_end_count = previous_token_ids.count(self.tool_call_end_token_id)
+            self.tool_start_count = current_token_ids.count(
+                self.tool_call_start_token_id
+            )
+            self.tool_end_count = current_token_ids.count(self.tool_call_end_token_id)
+        else:
+            previous_start_count = self.tool_start_count
+            previous_end_count = self.tool_end_count
+            self.tool_start_count += delta_token_ids.count(
+                self.tool_call_start_token_id
+            )
+            self.tool_end_count += delta_token_ids.count(self.tool_call_end_token_id)
+
+        return (
+            previous_start_count,
+            previous_end_count,
+            self.tool_start_count,
+            self.tool_end_count,
+        )

--- a/vllm/tool_parsers/deepseekv31_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv31_tool_parser.py
@@ -20,6 +20,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
+from vllm.tool_parsers.deepseek_streaming_state import DeepSeekStreamingTokenState
 
 logger = init_logger(__name__)
 
@@ -74,6 +75,12 @@ class DeepSeekV31ToolParser(ToolParser):
                 "DeepSeek-V3.1 Tool parser could not locate tool call "
                 "start/end tokens in the tokenizer!"
             )
+
+        self.streaming_token_state = DeepSeekStreamingTokenState(
+            self.tool_calls_start_token_id,
+            self.tool_call_start_token_id,
+            self.tool_call_end_token_id,
+        )
 
     def extract_tool_calls(
         self,
@@ -131,8 +138,10 @@ class DeepSeekV31ToolParser(ToolParser):
     ) -> DeltaMessage | None:
         logger.debug("delta_text: %s", delta_text)
         logger.debug("delta_token_ids: %s", delta_token_ids)
-        # check to see if we should be streaming a tool call - is there a
-        if self.tool_calls_start_token_id not in current_token_ids:
+        token_counts = self.streaming_token_state.update(
+            previous_token_ids, current_token_ids, delta_token_ids
+        )
+        if token_counts is None:
             logger.debug("No tool call tokens found!")
             return DeltaMessage(content=delta_text)
         delta_text = delta_text.replace(self.tool_calls_start_token, "").replace(
@@ -141,14 +150,12 @@ class DeepSeekV31ToolParser(ToolParser):
         try:
             # figure out where we are in the parsing by counting tool call
             # start & end tags
-            prev_tool_start_count = previous_token_ids.count(
-                self.tool_call_start_token_id
-            )
-            prev_tool_end_count = previous_token_ids.count(self.tool_call_end_token_id)
-            cur_tool_start_count = current_token_ids.count(
-                self.tool_call_start_token_id
-            )
-            cur_tool_end_count = current_token_ids.count(self.tool_call_end_token_id)
+            (
+                prev_tool_start_count,
+                prev_tool_end_count,
+                cur_tool_start_count,
+                cur_tool_end_count,
+            ) = token_counts
             tool_call_portion = None
             text_portion = None
 

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -23,6 +23,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
+from vllm.tool_parsers.deepseek_streaming_state import DeepSeekStreamingTokenState
 
 logger = init_logger(__name__)
 
@@ -77,6 +78,12 @@ class DeepSeekV3ToolParser(ToolParser):
                 "DeepSeek-V3 Tool parser could not locate tool call start/end "
                 "tokens in the tokenizer!"
             )
+
+        self.streaming_token_state = DeepSeekStreamingTokenState(
+            self.tool_calls_start_token_id,
+            self.tool_call_start_token_id,
+            self.tool_call_end_token_id,
+        )
 
     def extract_tool_calls(
         self,
@@ -134,8 +141,10 @@ class DeepSeekV3ToolParser(ToolParser):
     ) -> DeltaMessage | None:
         logger.debug("delta_text: %s", delta_text)
         logger.debug("delta_token_ids: %s", delta_token_ids)
-        # check to see if we should be streaming a tool call - is there a
-        if self.tool_calls_start_token_id not in current_token_ids:
+        token_counts = self.streaming_token_state.update(
+            previous_token_ids, current_token_ids, delta_token_ids
+        )
+        if token_counts is None:
             logger.debug("No tool call tokens found!")
             return DeltaMessage(content=delta_text)
         delta_text = delta_text.replace(self.tool_calls_start_token, "").replace(
@@ -144,14 +153,12 @@ class DeepSeekV3ToolParser(ToolParser):
         try:
             # figure out where we are in the parsing by counting tool call
             # start & end tags
-            prev_tool_start_count = previous_token_ids.count(
-                self.tool_call_start_token_id
-            )
-            prev_tool_end_count = previous_token_ids.count(self.tool_call_end_token_id)
-            cur_tool_start_count = current_token_ids.count(
-                self.tool_call_start_token_id
-            )
-            cur_tool_end_count = current_token_ids.count(self.tool_call_end_token_id)
+            (
+                prev_tool_start_count,
+                prev_tool_end_count,
+                cur_tool_start_count,
+                cur_tool_end_count,
+            ) = token_counts
             tool_call_portion = None
             text_portion = None
 


### PR DESCRIPTION

## Purpose

The DeepSeek V3 and V3.1 streaming tool parsers scan the complete accumulated
token sequence on every delta. Before a tool call begins they execute a
membership check over `current_token_ids`; after it begins they repeatedly
count the inner start/end delimiters in both previous and current histories.

The common no-tool response therefore performs work proportional to
`1 + 2 + ... + T`, even though each call only needs to know whether the newest
delta contains the outer tool marker.

This PR makes delimiter tracking incremental without changing parser output or
malformed/incomplete-input behavior.

Production diff: 93 insertions, 20 deletions across one shared state class and
the two parser integrations. A focused state-machine test adds 54 lines.

## Implementation

- Before the outer tool marker appears, inspect only `delta_token_ids`.
- On the first marker, initialize inner delimiter counts once from the
  accumulated sequences.
- On subsequent deltas, update the counts only from `delta_token_ids`.
- Share the state implementation between DeepSeek V3 and V3.1 while leaving
  each parser's text/JSON reconstruction unchanged.

## Validation

Hardware/software: one pinned core of an Intel Xeon Gold 6330, PyTorch
2.13.0+cu126. Both sides use the actual DeepSeek V3/V3.1 tokenizers. Baseline
commit: `a1541f5742`.

### Tests and checks

```bash
pytest -q \
  tests/tool_parsers/test_deepseekv3_tool_parser.py \
  tests/tool_parsers/test_deepseekv31_tool_parser.py \
  tests/tool_parsers/test_deepseek_streaming_state.py
pre-commit run --files \
  vllm/tool_parsers/deepseek_streaming_state.py \
  vllm/tool_parsers/deepseekv3_tool_parser.py \
  vllm/tool_parsers/deepseekv31_tool_parser.py \
  tests/tool_parsers/test_deepseek_streaming_state.py
git diff --check
```

Result: `21 passed, 1 xfailed`. All changed-file pre-commit hooks and diff
checks passed.

### Differential output validation

The baseline and candidate were run independently over 230 tokenizer-backed
streaming cases:

- both DeepSeek V3 and V3.1 parsers;
- plain text, surrounding text, one tool, multiple tools, and incomplete tool
  input;
- one-token deltas, fixed 2/4-token deltas, and 20 deterministic random
  partitions with chunk widths 1–4.

Results were normalized to content plus ordered tool names/arguments, excluding
random tool-call IDs, then serialized deterministically. Baseline and candidate
produced the same SHA-256:

```text
e5ffff831225ff6877fce5978d5ab675491be4ab7068834eaa70cbd14cef41b4
```

DeepSeek V3.1 logs an existing `IndexError` for a few multi-token malformed
partitions; the same cases and normalized results occur on both sides. This PR
does not claim to fix that separate parser issue.

### Complete parser-loop benchmark

Each row constructs the real parser and executes its complete streaming method
for every delta on a no-tool response. After two warmups, 11 samples were
collected; p20–p80 variation was small for the reported rows. Chunk size 1
models ordinary token streaming, while chunk size 4 models multi-token engine
updates. The lengths are normal supported output sizes rather than stress-test
histories.

| parser | tokens | tokens/delta | baseline p50 (ms) | this PR p50 (ms) | speedup |
|:---|---:|---:|---:|---:|---:|
| V3 | 512 | 1 | 3.069 | 2.290 | 1.34x |
| V3 | 512 | 4 | 0.990 | 0.814 | 1.22x |
| V3 | 2,048 | 1 | 21.852 | 8.209 | 2.66x |
| V3 | 2,048 | 4 | 5.735 | 2.353 | 2.44x |
| V3 | 8,192 | 1 | 251.693 | 31.812 | 7.91x |
| V3 | 8,192 | 4 | 63.379 | 8.312 | 7.62x |
| V3.1 | 512 | 1 | 3.104 | 2.274 | 1.37x |
| V3.1 | 512 | 4 | 1.007 | 0.807 | 1.25x |
| V3.1 | 2,048 | 1 | 22.036 | 8.266 | 2.67x |
| V3.1 | 2,048 | 4 | 5.826 | 2.410 | 2.42x |
| V3.1 | 8,192 | 1 | 252.809 | 32.083 | 7.88x |
| V3.1 | 8,192 | 4 | 63.642 | 8.518 | 7.47x |

### Tool-call no-regression benchmark

A complete single-tool streaming reconstruction, including real tokenization,
was measured over 31 samples. The p20/p50/p80 intervals overlap:

| parser | baseline p20/p50/p80 (ms) | this PR p20/p50/p80 (ms) |
|:---|:---|:---|
| V3 | 1.704 / 1.720 / 1.874 | 1.709 / 1.723 / 1.898 |
| V3.1 | 1.333 / 1.345 / 1.372 | 1.350 / 1.366 / 1.417 |

The optimization improves the no-tool path and introduces no stable regression
in the actual tool-call path.

## Limitations

These are parser-boundary CPU timings, not end-to-end server latency or GPU
throughput measurements. End-to-end impact depends on output length, delta
size, tokenizer/frontend overhead, and the share of requests using these
parsers. No performance claim is made for other parser implementations.

No model-quality evaluation is needed because model execution is unchanged;
the 230-case differential reconstruction directly validates the affected
output contract.

## AI assistance

AI assistance was used for this contribution.