### PR TITLE
[Perf][Multimodal] Avoid sorting MiMo vision window indices

### DIFF
--- a/vllm/model_executor/models/mimo_v2_omni.py
+++ b/vllm/model_executor/models/mimo_v2_omni.py
@@ -615,7 +615,12 @@ class MiMoVisionTransformer(nn.Module):
         window_index_1d_col = self.get_window_index_1d(grid_thw, col=True).to(
             device=x.device
         )
-        reverse_window_index_1d_col = torch.argsort(window_index_1d_col)
+        reverse_window_index_1d_col = torch.empty_like(window_index_1d_col)
+        reverse_window_index_1d_col[window_index_1d_col] = torch.arange(
+            window_index_1d_col.numel(),
+            device=window_index_1d_col.device,
+            dtype=window_index_1d_col.dtype,
+        )
 
         # Col-based rotary embeddings (reordered at spatial_merge_unit granularity).
         # apply_index reorders groups of spatial_merge_unit tokens, just like x.


### PR DESCRIPTION
## Purpose

`MiMoVisionTransformer` uses `torch.argsort` to invert
`window_index_1d_col`. The index is a permutation, so its inverse can be
constructed directly with `inverse[permutation] = arange(n)`, avoiding a
general sort without changing model APIs or layouts.

This does not duplicate an open PR. #24443 made the same optimization for
Qwen2.5-VL, while MiMo has a separate implementation. The open PRs touching
`mimo_v2_omni.py` change unrelated code and do not overlap this hunk.

## Test Plan

```bash
pre-commit run --files vllm/model_executor/models/mimo_v2_omni.py
.venv/bin/python -m py_compile vllm/model_executor/models/mimo_v2_omni.py
git diff --check
```

I also checked inverse parity over mixed-shape image/video batches, benchmarked
both inverse implementations on 8 H200 GPUs, and ran three sequential cold-start
MiMo-V2.5 image/video evaluations on the same four H200 GPUs.

## Test Result

- All 13 applicable changed-file pre-commit hooks passed; syntax and diff
  checks passed.
- An exhaustive small-grid sweep covered 81,756 batches; every direct inverse
  matched `torch.argsort` and restored the original order exactly.
- In an H200 component microbenchmark covering 7 shapes × 8 GPUs with 12
  balanced rounds per GPU, the direct inverse reduced inverse latency by
  36.0%–79.7% and complete window-index preparation by 2.8%–34.9%. It was
  faster in all 56 case/GPU comparisons. No model end-to-end performance was
  measured.
- MiMo-V2.5 FP8 TP4 evaluation used one image and one 8-frame video. With
  byte-identical requests, two cold base runs and the candidate matched
  pairwise exactly on prompt token IDs, the single output token ID, top-20
  logprobs, text, token counts, and finish reason.

The model evaluation applied #53242 to both revisions only to load the
official FP8 checkpoint. FlashInfer autotuning was disabled equally because
the validation container has an older FlashInfer; this run is used for correctness,
not end-to-end performance.

No repository test is added because it would repeat the inverse-permutation
identity already exercised by the shape sweep and model evaluation.

I reviewed every changed line and the validation results above. This
contribution was developed with AI assistance.
