### PR TITLE
[Bugfix] Fall back to detected content format when openai is incompatible

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -534,6 +534,47 @@ def test_resolve_content_format_examples(template_path, expected_format):
 
 
 @pytest.mark.parametrize(
+    ("template_path", "given_format", "expected_resolved"),
+    [
+        # Forcing openai on a string-only template must fall back to string
+        ("template_chatml.jinja", "openai", "string"),
+        ("template_alpaca.jinja", "openai", "string"),
+        # Forcing string on an openai template is fine (string is always safe)
+        ("tool_chat_template_llama3.1_json.jinja", "string", "string"),
+        # Matching force is a no-op
+        ("template_chatml.jinja", "string", "string"),
+        ("tool_chat_template_llama3.1_json.jinja", "openai", "openai"),
+    ],
+)
+def test_resolve_content_format_forced_fallback(
+    template_path, given_format, expected_resolved
+):
+    model = "Qwen/Qwen2-VL-2B-Instruct"  # Dummy
+    model_config = ModelConfig(
+        model,
+        tokenizer=model,
+        trust_remote_code=True,
+    )
+    dummy_tokenizer = get_tokenizer(
+        model,
+        trust_remote_code=model_config.trust_remote_code,
+    )
+    dummy_tokenizer.chat_template = None
+
+    chat_template = load_chat_template(EXAMPLES_DIR / template_path)
+
+    resolved_format = resolve_chat_template_content_format(
+        chat_template,
+        None,
+        given_format,
+        dummy_tokenizer,
+        model_config=model_config,
+    )
+
+    assert resolved_format == expected_resolved
+
+
+@pytest.mark.parametrize(
     "model,template,add_generation_prompt,continue_final_message,expected_output",
     MODEL_TEMPLATE_GENERATION_OUTPUT,
 )

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -591,7 +591,19 @@ def resolve_chat_template_content_format(
             "You can set `--chat-template-content-format` to override this.",
             detected_format,
         )
-    elif given_format != detected_format:
+        return detected_format
+
+    if given_format != detected_format:
+        if given_format == "openai" and detected_format == "string":
+            logger.warning_once(
+                "You specified `--chat-template-content-format openai` "
+                "but the chat template expects plain string content. "
+                "Falling back to 'string' to prevent request failures. "
+                "If our automatic detection is incorrect, please consider "
+                "opening a GitHub issue so that we can improve it: "
+                "https://github.com/vllm-project/vllm/issues/new/choose",
+            )
+            return detected_format
         logger.warning_once(
             "You specified `--chat-template-content-format %s` "
             "which is different from the detected format '%s'. "
@@ -602,7 +614,7 @@ def resolve_chat_template_content_format(
             detected_format,
         )
 
-    return detected_format if given_format == "auto" else given_format
+    return given_format
 
 
 # adapted from https://github.com/huggingface/transformers/blob/v4.56.2/src/transformers/utils/chat_template_utils.py#L398-L412


### PR DESCRIPTION
## Summary

- When `--chat-template-content-format openai` is forced on a template that only supports plain string content (e.g. Phi-4, ChatML, Alpaca), every request crashes with `ValueError: can only concatenate str (not "list") to str`.
- PR #54622 restored the detection + warning but still honoured the forced format, so the warning fires once at startup and then every request 500s.
- This PR makes the resolver fall back to the detected format (`string`) when forcing `openai` would be incompatible. The reverse (forcing `string` on an `openai` template) is always safe.

Closes #55556

## Test plan

- Added `test_resolve_content_format_forced_fallback` covering five scenarios:
  - Forcing `openai` on `string`-detected templates → falls back to `string`
  - Forcing `string` on `openai`-detected templates → stays `string` (safe)
  - Matching force → no change
- Verified on a Bernard deployment (Qwen3.8-27B, A800 TP2) that list-type content and tool calls work correctly.
- `python -m pytest tests/renderers/test_hf.py::test_resolve_content_format_forced_fallback -v`

## AI assistance

This PR was created with AI assistance. All changes were reviewed and tested by a human.