### PR TITLE
[Bugfix][Parser] Coerce nested strings in decoded XML arguments

### DIFF
--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -1092,12 +1092,15 @@ class TestNestedSchemaCoercion:
             parser_engine_config=qwen3_config(thinking=False),
         )
 
-    def test_nested_object_coerced(self, parser_with_tools, mock_request):
+    @pytest.mark.parametrize("raw_min_stars", ["100", '"100"'])
+    def test_nested_object_coerced(
+        self, parser_with_tools, mock_request, raw_min_stars
+    ):
         text = (
             "<tool_call>\n"
             "<function=search>\n"
             '<parameter=filters>{"language": "python",'
-            ' "min_stars": 100}</parameter>\n'
+            f' "min_stars": {raw_min_stars}}}</parameter>\n'
             "</function>\n"
             "</tool_call>"
         )
@@ -1106,11 +1109,14 @@ class TestNestedSchemaCoercion:
         assert args["filters"] == {"language": "python", "min_stars": 100}
         assert isinstance(args["filters"]["min_stars"], int)
 
-    def test_nested_array_items_coerced(self, parser_with_tools, mock_request):
+    @pytest.mark.parametrize("raw_limits", ["[10, 20, 30]", '["10", "20", "30"]'])
+    def test_nested_array_items_coerced(
+        self, parser_with_tools, mock_request, raw_limits
+    ):
         text = (
             "<tool_call>\n"
             "<function=search>\n"
-            "<parameter=limits>[10, 20, 30]</parameter>\n"
+            f"<parameter=limits>{raw_limits}</parameter>\n"
             "</function>\n"
             "</tool_call>"
         )
@@ -1132,15 +1138,55 @@ class TestNestedSchemaCoercion:
         assert args["tags"] == ["ml", "42"]
         assert all(isinstance(v, str) for v in args["tags"])
 
+    @pytest.mark.parametrize("value", [1, True, None])
+    @pytest.mark.parametrize("container_type", ["object", "array"])
+    @pytest.mark.parametrize("schema_kind", ["empty", "description", "const", "string"])
+    def test_decoded_container_preserves_native_scalars(
+        self, tools, mock_tokenizer, mock_request, value, container_type, schema_kind
+    ):
+        """Recursing into decoded JSON must preserve its native scalar values."""
+        field_schema = {
+            "empty": {},
+            "description": {"description": "A value"},
+            "const": {"const": value},
+            "string": {"type": "string"},
+        }[schema_kind]
+        payload: dict[str, object] | list[object]
+        if container_type == "object":
+            payload = {"value": value}
+            payload_schema = {"type": "object", "properties": {"value": field_schema}}
+        else:
+            payload = [value]
+            payload_schema = {"type": "array", "items": field_schema}
+        tools[0].function.parameters["properties"]["payload"] = payload_schema
+        parser = ParserEngine(
+            mock_tokenizer,
+            tools=tools,
+            parser_engine_config=qwen3_config(thinking=False),
+        )
+        text = (
+            "<tool_call><function=search>"
+            f"<parameter=payload>{json.dumps(payload)}</parameter>"
+            "</function></tool_call>"
+        )
+        result = parser.extract_tool_calls(text, mock_request)
+        actual = json.loads(result.tool_calls[0].function.arguments)["payload"]
+        assert actual == payload
+        leaf = actual["value"] if container_type == "object" else actual[0]
+        assert type(leaf) is type(value)
+
+    @pytest.mark.parametrize(
+        "raw_bool,raw_null", [("false", "null"), ('"false"', '"null"')]
+    )
     def test_array_of_objects_with_bool_and_null_coerced(
-        self, parser_with_tools, mock_request
+        self, parser_with_tools, mock_request, raw_bool, raw_null
     ):
         text = (
             "<tool_call>\n"
             "<function=AskUserQuestion>\n"
             "<parameter=questions>"
             '[{"question": "Pick a color",'
-            ' "multiSelect": false, "answer": null}]'
+            f' "multiSelect": {raw_bool}, "answer": {raw_null}}}]'
             "</parameter>\n"
             "</function>\n"
             "</tool_call>"
@@ -1154,14 +1200,17 @@ class TestNestedSchemaCoercion:
         assert questions[0]["multiSelect"] is False
         assert questions[0]["answer"] is None
 
+    @pytest.mark.parametrize(
+        "raw_bool,raw_null", [("false", "null"), ('"false"', '"null"')]
+    )
     def test_streaming_array_of_objects_with_bool_and_null_coerced(
-        self, parser_with_tools, mock_request
+        self, parser_with_tools, mock_request, raw_bool, raw_null
     ):
         chunks = [
             "<tool_call>\n",
             "<function=AskUserQuestion>\n",
             '<parameter=questions>[{"question": "Pick a color",',
-            ' "multiSelect": false, "answer": null}]',
+            f' "multiSelect": {raw_bool}, "answer": {raw_null}}}]',
             "</parameter>\n",
             "</function>\n",
             "</tool_call>",

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -238,22 +238,32 @@ class ParserEngine(Parser):
     # ── Schema-aware type correction ─────────────────────────────────
 
     @staticmethod
-    def _coerce_value(value: object, schema: dict) -> tuple[object, bool]:
+    def _coerce_value(
+        value: object, schema: dict, *, coerce_native_scalars: bool = True
+    ) -> tuple[object, bool]:
         """Coerce a single value according to its schema.
 
         Returns ``(coerced_value, changed)``.
+        Newly decoded containers preserve native scalars while their
+        string values are recursively coerced.
         """
         if isinstance(value, str):
             types = extract_types_from_schema(schema)
             coerced = coerce_to_schema_type(value, types)
             if coerced is not value:
+                if isinstance(coerced, (dict, list)):
+                    coerced, _ = ParserEngine._coerce_value(
+                        coerced, schema, coerce_native_scalars=False
+                    )
                 return coerced, True
             return value, False
 
         if isinstance(value, dict):
             nested_props = schema.get("properties")
             if isinstance(nested_props, dict):
-                _, changed = ParserEngine._coerce_dict(value, nested_props)
+                _, changed = ParserEngine._coerce_dict(
+                    value, nested_props, coerce_native_scalars=coerce_native_scalars
+                )
                 return value, changed
             return value, False
 
@@ -263,12 +273,17 @@ class ParserEngine(Parser):
                 changed = False
                 for i, item in enumerate(value):
                     coerced, item_changed = ParserEngine._coerce_value(
-                        item, items_schema
+                        item,
+                        items_schema,
+                        coerce_native_scalars=coerce_native_scalars,
                     )
                     if item_changed:
                         value[i] = coerced
                         changed = True
                 return value, changed
+            return value, False
+
+        if not coerce_native_scalars:
             return value, False
 
         types = extract_types_from_schema(schema)
@@ -279,14 +294,18 @@ class ParserEngine(Parser):
         return value, False
 
     @staticmethod
-    def _coerce_dict(args: dict, properties: dict) -> tuple[dict, bool]:
+    def _coerce_dict(
+        args: dict, properties: dict, *, coerce_native_scalars: bool = True
+    ) -> tuple[dict, bool]:
         """Coerce all values in *args* using *properties* schemas."""
         changed = False
         for key, value in args.items():
             prop = properties.get(key)
             if not isinstance(prop, dict):
                 continue
-            coerced, val_changed = ParserEngine._coerce_value(value, prop)
+            coerced, val_changed = ParserEngine._coerce_value(
+                value, prop, coerce_native_scalars=coerce_native_scalars
+            )
             if val_changed:
                 args[key] = coerced
                 changed = True


### PR DESCRIPTION
## Purpose

The XML tool parser decodes an object or array parameter from a string, but
`ParserEngine._coerce_value` immediately returns that container without applying
the existing `properties`/`items` recursion. For an inline schema declaring an
array of integers, `<parameter=limits>["10", "20", "30"]</parameter>` therefore
produces string elements. Nested numeric, boolean and nullable fields have the
same problem, including in streaming responses. Clients expecting the declared
argument types can reject these tool calls.

After a string successfully converts to a dict or list, recurse through its
`properties`/`items` and coerce nested strings. An internal
`coerce_native_scalars` flag keeps the decoded container's existing JSON
numbers, booleans and nulls unchanged. Without that distinction, the existing
fallback to `string` for untyped schemas would turn `{"n": 1}` into
`{"n": "1"}` under `properties: {n: {}}`, introducing a regression.

Existing native scalar coercion remains enabled by default for native JSON
input. Stringified container children in such input also gain the new
recursion. String conversion, union precedence and best-effort failure behavior
are unchanged.
This is a nested-string correction, not full schema normalization: a decoded
native `1` still remains `1` even if its schema requests `string`, as it did
before. No JSON Schema keyword support is added.

Extend the existing Qwen3 parser tests to cover both native JSON values and
string values requiring nested conversion. The existing string-array guard
continues to ensure that values such as `"42"` stay strings when requested.
Add native scalar preservation cases for objects and arrays with empty,
description-only, `const`, and explicit string schemas.

## Duplicate-work check

This is the independent recursion bug explicitly identified and deferred by
the author of #50933 in [this comment](https://github.com/vllm-project/vllm/pull/50933#issuecomment-5254562064),
while investigating #46924. It reproduces with inline schemas and does not
implement the `$ref`/`$defs` resolution in #50933. #54964 fixes a separate
Hermes/Granite outer-arguments double-encoding problem. This PR does not claim
to close #46924.

Read #46924 and its comments and searched open PRs for `46924 in:body`,
`nested coercion`, `XML recursive`, and `_coerce_value` before preparing this
change.
Checked the actual patches of #53729, #51577 and #49318 as well. #53729 changes
adjacent coercion statements for schemas without concrete types but retains
the string-to-container early return. This change avoids depending on its
type-inference changes by preserving decoded native scalars. #51577
migrates Llama JSON parsing and still delegates string coercion to this method.
#49318 adds Kimi argument conversion and tests native nested objects, without
changing this string-to-container path.

## Test Plan and Results

Environment: WSL Ubuntu 24.04, Python 3.12.14, PyTorch 2.13.0+cu132. Python source
base: `569adb5a9780f9c02d22a6b29826acf711512356`. Parser tests use CPU and the
existing mock-tokenizer fixtures; they exercise the public streaming and
non-streaming parser entry points.

```bash
.venv/bin/python -m pytest tests/parser/engine/test_qwen3.py \
  -k TestNestedSchemaCoercion -q --tb=short
.venv/bin/python -m pytest tests/parser/engine -q --tb=short
```

- Original five nested-schema tests: **5 passed**. Their container contents
  already had the expected JSON types, so they did not catch the missing step.
- Same expanded nested-schema cases, before the fix: **4 failed, 5 passed**.
  Failures cover numeric object fields, numeric array items, and boolean/null
  fields in an array of objects in non-streaming and streaming responses.
- With the final fix, the entire parser engine suite: **3855 passed**,
  including 24 native-scalar preservation cases.

Model smoke check: Qwen2.5-0.5B-Instruct at revision
`7ae557604adf67be50417f59c2c2f167def9a775`, FP16 on an RTX 4060 Laptop 8 GB,
eager TRITON_ATTN, max model length/batched tokens 1024, max sequences 2,
memory utilization 0.55, prefix caching off, seed 0, temperature 0,
256 output-token limit. V1 model runner and PyTorch sampling were selected
for WSL compatibility.

Generated seven XML calls and replayed each exact text and generated token-ID
sequence through the public `ParserEngine.parse` before and after the change.
The baseline restores both `_coerce_value` and `_coerce_dict` from the source
base above. No generated output was edited or replaced.

- Tool calls matching the expected values and schema: **2/7 before, 5/7 after**.
- Three generated outputs changed from failure to success: two integer arrays
  containing quoted numbers, and an object with `min_stars: "125"`.
- No previously successful call regressed. The string-array control and the
  native-scalar object with empty/const schemas stayed correct.
- Two generations remained unsuccessful in both versions: malformed XML for
  the boolean/null array, and an untyped array where the model emitted `"1"`
  instead of the requested native `1`. One intended native-integer control
  also emitted quoted numbers and therefore became a fix witness instead.

This is a targeted shared-parser smoke check using prompted Qwen2.5 outputs,
not a Qwen3-Coder evaluation or a general accuracy/throughput benchmark.
Boolean/null coercion and native-array preservation are covered by the unit
tests above.

Runtime provenance: imported this checkout via explicit `PYTHONPATH`, with
official cu130 native artifacts for the exact source base above. An editable
packaging pass was stopped after artifact extraction because WSL file scans
were slow; existing package registration was retained. New and old dependency
requirements matched, and the actual source/extension import paths and CUDA
availability were verified before the smoke run.

Applicable pre-commit hooks and the additional Python 3.12 mypy hook passed
on both changed files:

```bash
SKIP=actionlint pre-commit run --files \
  vllm/parser/engine/parser_engine.py tests/parser/engine/test_qwen3.py
SKIP=actionlint pre-commit run mypy-3.12 --hook-stage manual --files \
  vllm/parser/engine/parser_engine.py tests/parser/engine/test_qwen3.py
```

The unused `actionlint` hook was excluded because no workflow YAML changed
and its Go environment bootstrap previously timed out on this host.

All applicable commit hooks and the DCO sign-off hook passed during creation
of the final commit. The separate final Python 3.12 mypy run also exited 0.

AI assistance: Codex assisted with issue triage, diagnosis, implementation,
regression tests and local validation. Commits include AI attribution and DCO
sign-off.
