### PR TITLE
[Bugfix][KV Offload] Enable NIXL telemetry for the OBJ tier

### DIFF
--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -140,7 +140,8 @@ class MockNixlAgent:
     check_xfer_state: Callable
     query_memory: Callable
 
-    def __init__(self):
+    def __init__(self, agent_name, config):
+        self._capture_telemetry = config.capture_telemetry
         self._stored_obj_keys: set[str] = set()
         # handle_id -> (op, [obj_keys])
         self._pending: dict[int, tuple[str, list[str]]] = {}
@@ -204,6 +205,8 @@ class MockNixlAgent:
         pass
 
     def get_xfer_telemetry(self, handle):
+        if not self._capture_telemetry:
+            raise RuntimeError("Telemetry capture is disabled")
         return SimpleNamespace(xferDuration=1000)
 
     def _query_memory(self, queries, mem_type, agent_name):
@@ -233,15 +236,19 @@ def _make_tier(
     **tier_kwargs,
 ) -> tuple[ObjectStoreSecondaryTierManager, MockNixlAgent]:
     """Create a tier backed by a fresh MockNixlAgent."""
-    mock_agent = MockNixlAgent()
     if primary_kv_view is None:
         tensor = torch.zeros((num_blocks, _BLOCK_ELEMENTS), dtype=_DTYPE)
         primary_kv_view = memoryview(tensor.numpy())
     with (
-        patch("vllm.v1.kv_offload.tiering.obj.manager.nixl_agent_config"),
+        patch(
+            "vllm.v1.kv_offload.tiering.obj.manager.nixl_agent_config",
+            side_effect=lambda backends, capture_telemetry=False: SimpleNamespace(
+                capture_telemetry=capture_telemetry
+            ),
+        ),
         patch(
             "vllm.v1.kv_offload.tiering.obj.manager.nixl_agent",
-            return_value=mock_agent,
+            side_effect=MockNixlAgent,
         ),
     ):
         tier = ObjectStoreSecondaryTierManager(
@@ -252,7 +259,7 @@ def _make_tier(
             prefix=_RUN_PREFIX,
             **tier_kwargs,
         )
-    return tier, mock_agent
+    return tier, tier._agent
 
 
 def drain(
@@ -316,14 +323,16 @@ class TestMockObjTierBasic:
         assert lookup_and_wait(self.tier, [key(999)]) == [LookupResult.MISS]
 
     def test_store_then_load_roundtrip(self):
+        """Completed stores and loads report transfer timing without an env override."""
         self.tier.submit_store(make_job(1, [key(1), key(2)], [0, 1]))
         results = drain(self.tier)
-        assert results[0].success
+        assert results == [JobResult(job_id=1, success=True, transfer_time=0.001)]
 
         self.tier.submit_load(make_job(2, [key(1), key(2)], [0, 1]))
         results = drain(self.tier)
-        assert len(results) == 1
-        assert results[0].success
+        assert results == [JobResult(job_id=2, success=True, transfer_time=0.001)]
+        assert not self.tier._transfers
+        assert list(self.tier.get_finished_jobs()) == []
 
     def test_multiple_jobs_tracked_independently(self):
         self.tier.submit_store(make_job(1, [key(1)], [0]))

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -147,7 +147,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         # mark its own cached lookup verdicts False (see get_finished_jobs).
         self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
 
-        agent_config = nixl_agent_config(backends=[])
+        agent_config = nixl_agent_config(backends=[], capture_telemetry=True)
         self._agent = nixl_agent("ObjAgent", agent_config)
         obj_config = ObjStoreConfig(**store_config)
         params = {**obj_config.to_nixl_params(), "num_threads": str(io_threads)}


### PR DESCRIPTION
## Purpose

The OBJ secondary tier reads NIXL transfer telemetry for every successful store or load, but creates its agent with telemetry capture disabled by default. Without `NIXL_TELEMETRY_ENABLE`, a completed transfer raises `nixlNoTelemetryError` before releasing its handles or reporting the job result.

Enable telemetry capture when constructing the OBJ agent. Make the existing mock respect the disabled default, and extend the store/load roundtrip test to check transfer timing and completion bookkeeping.

Duplicate-work checks on 2026-09-06 found no open PR implementing this fix. Searches covered OBJ telemetry, objectstore, `capture_telemetry`, and `nixlNoTelemetryError`. The open backpressure PR #50045 touches OBJ constructor plumbing but does not enable telemetry. The telemetry read was introduced by #48798.

AI assistance was used to investigate, implement, and test this change.

## Test Plan

Tested against upstream `808f8cd3ac6751278d8b7be97f6fde5295ca4653` on Linux with Python 3.12.13 and PyTorch 2.13.0+cu130. The isolated checkout imports its own upstream Python source and reuses dependencies and binary extensions from an existing vLLM 0.28.0 installation.

```bash
# Original implementation with the regression test changes.
CUDA_VISIBLE_DEVICES="" OMP_NUM_THREADS=1 .venv/bin/python -m pytest -q tests/v1/kv_offload/tiering/test_obj_tier.py -k test_store_then_load_roundtrip --timeout=60

# Fixed implementation.
CUDA_VISIBLE_DEVICES="" OMP_NUM_THREADS=1 .venv/bin/python -m pytest -q \
  tests/v1/kv_offload/tiering/test_obj_tier.py \
  tests/v1/kv_offload/tiering/test_tiering_offloading.py \
  tests/v1/kv_offload/tiering/test_metrics.py \
  tests/v1/kv_offload/tiering/test_factory.py \
  tests/v1/kv_offload/tiering/test_async_lookup.py --timeout=60
```

Supplemental validation used the full OBJ manager with native NIXL 1.3.2, its OBJ plugin, and a loopback Moto S3 service. `NIXL_TELEMETRY_ENABLE` was unset. The check stores two CPU blocks, clears their buffer, loads them, and compares the restored bytes and job results.

## Test Result

- Baseline regression: 1 failed, 37 deselected; failure occurs at the telemetry read.
- Fixed OBJ and adjacent tiering suites: 124 passed.
- Native OBJ baseline: both S3 writes succeeded, then `NIXL_ERR_NO_TELEMETRY` prevented completion and left one tracked transfer.
- Native OBJ with the fix: store and load succeeded with transfer timing, restored bytes matched, and completed transfers were removed and reported once.
- Ruff check/format, typos, mypy for Python 3.10–3.13, and applicable repository validation hooks passed individually on the two changed files; `git diff --check` passed.
- The bulk pre-commit run timed out after 120 seconds while installing the unrelated Actionlint environment. All 15 applicable checks were subsequently run individually using the unmodified repository configuration.
- CPU validation only; CUDA remained uninitialized. No model serving, GPU, production S3, or performance benchmark was run.
