### PR TITLE
[Perf][Multimodal] Avoid scanning every source video frame

### DIFF
--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -124,6 +124,53 @@ def sample_frames_from_video(frames: npt.NDArray, num_frames: int) -> npt.NDArra
     return sampled_frames
 
 
+def _sample_frames_by_interval(
+    total_frames: int,
+    seconds_per_frame: float,
+    sample_interval: float,
+    stop_time: float,
+    max_samples: int | None = None,
+) -> list[int]:
+    """Select the first source frame at each sampling timestamp."""
+    if total_frames <= 0:
+        return []
+    if seconds_per_frame <= 0:
+        return [0]
+
+    frame_indices: list[int] = []
+    sample_time = 0.0
+    if max_samples is not None and total_frames <= max_samples * 8:
+        for frame in range(total_frames):
+            if frame * seconds_per_frame >= sample_time:
+                frame_indices.append(frame)
+                sample_time += sample_interval
+                if sample_time >= stop_time:
+                    break
+        return frame_indices
+
+    next_frame = 0
+    while next_frame < total_frames:
+        frame = max(next_frame, math.ceil(sample_time / seconds_per_frame))
+
+        # Preserve the original floating-point comparison at exact boundaries.
+        while frame > next_frame and (frame - 1) * seconds_per_frame >= sample_time:
+            frame -= 1
+        while frame < total_frames and frame * seconds_per_frame < sample_time:
+            frame += 1
+        if frame >= total_frames:
+            break
+
+        frame_indices.append(frame)
+        if max_samples is not None and len(frame_indices) > max_samples:
+            break
+        sample_time += sample_interval
+        if sample_time >= stop_time:
+            break
+        next_frame = frame + 1
+
+    return frame_indices
+
+
 class VideoLoader:
     @classmethod
     def compute_frames_index_to_sample(
@@ -624,15 +671,14 @@ class GLM46VVideoBackend(VideoBackend):
                 0, total_frames_num - 1, extract_t, dtype=int
             ).tolist()
         else:
-            frame_indices = []
-            current_second = 0.0
             inv_fps = 1 / (temporal_patch_size * target_fps)
-            for frame_index in range(total_frames_num):
-                if frame_index * duration_per_frame >= current_second:
-                    current_second += inv_fps
-                    frame_indices.append(frame_index)
-                    if current_second >= max_second:
-                        break
+            frame_indices = _sample_frames_by_interval(
+                total_frames_num,
+                duration_per_frame,
+                inv_fps,
+                max_second,
+                max_samples=extract_t,
+            )
 
         if len(frame_indices) < extract_t:
             if len(frame_indices) == 0:
@@ -825,15 +871,14 @@ class GLMGAVideoBackend(VideoBackend):
                 math.floor(i * total_frames_num / extract_t) for i in range(extract_t)
             ]
         else:
-            frame_indices = []
-            current_second = 0.0
             inv_fps = 1 / target_fps
-            for frame_index in range(total_frames_num):
-                if frame_index * duration_per_frame >= current_second:
-                    current_second += inv_fps
-                    frame_indices.append(frame_index)
-                    if current_second >= duration - inv_fps:
-                        break
+            frame_indices = _sample_frames_by_interval(
+                total_frames_num,
+                duration_per_frame,
+                inv_fps,
+                duration - inv_fps,
+                max_samples=extract_t,
+            )
 
         if len(frame_indices) < extract_t:
             if len(frame_indices) == 0:


### PR DESCRIPTION
## Purpose

`GLM46VVideoBackend` and `GLMGAVideoBackend` currently find each sampled frame
by iterating over every source frame until its timestamp reaches the next
sampling timestamp. This makes frame-index selection O(source frames), even
though both backends retain at most 640 frames. A long, high-FPS video can
therefore spend several milliseconds in a Python loop before sparse decoding
starts.

This change computes the first source-frame index at each sampling timestamp
directly. It corrects the computed index against the original floating-point
comparison at timestamp boundaries, so the selected indices remain unchanged.
It also stops after `extract_t + 1` samples when the caller will replace an
oversized result with uniform sampling. Dense, short videos keep the linear
scan because it is faster when most source frames are selected.

The online path is exercised whenever GLM-4.6V or GLM-GA receives video input:
the backend computes these indices before the decoder reads the selected
frames. The change affects only CPU frame-index selection and does not alter
video decoding, preprocessing, or model execution.

### Duplicate-work check

Open PRs were searched for `GLM video frame sampling performance`,
`source frame scan video`, and `GLMGA GLM46V video`. #54396 adds validation for
an unknown GLM-GA source FPS; it does not change the valid-FPS sampling loop.
Merged #46543 removed the full intermediate timestamp list from these loops,
but the loops still visit source frames one by one. This change addresses the
remaining O(source frames) scan and does not duplicate either PR.

## Test Plan

### Existing video tests

```bash
.venv/bin/python -m pytest tests/multimodal/test_video.py -q
pre-commit run --files vllm/multimodal/video.py
git diff --check
```

No test code is added. The existing suite covers GLM-4.6V dynamic FPS
thresholds, missing-duration estimation, even-frame padding, GLM-GA request
caps, short videos, and normal sampling.

### Differential validation

The complete public `compute_frames_index_to_sample` methods were compared
against the previous linear scan for 10,000 deterministic randomized cases per
backend (20,000 total). The matrix varied source frame count, source FPS
(including 23.976, 29.97, 59.94, 120, and 240), reported or derived duration,
target FPS, temporal patch size, and maximum frame count.

The patched methods were also compared with the corresponding Transformers
`Glm46VVideoProcessor.sample_frames` and `GlmgaVideoProcessor.sample_frames`
implementations for 1,000 deterministic cases per backend (2,000 total). This
comparison covered durations through 2,400 seconds, the 30- and 300-second
dynamic-FPS boundaries, fractional source frame rates, temporal patch sizes,
target frame rates, and frame caps. GLM-GA's existing post-decode even-frame
padding was included when comparing its complete output contract.

These checks validate behavior at two boundaries: the patched vLLM methods
return exactly the same indices as the previous implementation, and the
resulting samples remain aligned with the upstream Transformers processors.
Because the decoder receives the same indices in the same order, decoded
frames and downstream model inputs are unchanged.

### Frame-index selection benchmark

The actual GLM-4.6V and GLM-GA public methods were benchmarked on a dual-socket
Intel Xeon Gold 6330 host. Baseline and patched calls were alternated within
each trial. Seven samples were collected per version and shape, each averaging
eight complete method calls; the table reports the median time per call. Both
versions received the same metadata and returned identical frame indices.

## Test Result

### Existing tests and checks

- Relevant existing video tests: **18 passed**
- Full `tests/multimodal/test_video.py`: **87 passed, 2 skipped**
- Full pre-commit hooks for the production file: passed
- `git diff --check`: passed
- Public-method differential comparison: **20,000 / 20,000 exact**
- Transformers sampler comparison: **2,000 / 2,000 exact**

### Frame-index selection benchmark

| Backend | Source | Duration | Retained | Unmodified (ms) | Patched (ms) | Speedup |
| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
| GLM-4.6V | 240 @ 24 FPS | 10 s | 60 | 0.0356 | 0.0357 | 1.00x |
| GLM-4.6V | 900 @ 30 FPS | 30 s | 180 | 0.1334 | 0.1335 | 1.00x |
| GLM-4.6V | 9,000 @ 30 FPS | 300 s | 600 | 1.0751 | 0.6333 | **1.70x** |
| GLM-4.6V | 36,000 @ 60 FPS | 600 s | 600 | 1.7885 | 0.2990 | **5.98x** |
| GLM-4.6V | 144,000 @ 60 FPS | 2,400 s | 640 | 7.0468 | 0.3456 | **20.39x** |
| GLM-4.6V | 288,000 @ 120 FPS | 2,400 s | 640 | 13.7587 | 0.3420 | **40.23x** |
| GLM-GA | 240 @ 24 FPS | 10 s | 20 | 0.0226 | 0.0194 | **1.16x** |
| GLM-GA | 900 @ 30 FPS | 30 s | 60 | 0.0604 | 0.0392 | **1.54x** |
| GLM-GA | 9,000 @ 30 FPS | 300 s | 600 | 0.5368 | 0.3027 | **1.77x** |
| GLM-GA | 36,000 @ 60 FPS | 600 s | 640 | 1.9323 | 0.3245 | **5.96x** |
| GLM-GA | 144,000 @ 60 FPS | 2,400 s | 640 | 7.5320 | 0.3222 | **23.38x** |
| GLM-GA | 288,000 @ 120 FPS | 2,400 s | 640 | 14.8955 | 0.3261 | **45.67x** |

Short dense inputs remain neutral, while the gain scales with the number of
source frames skipped. At the 640-frame output cap, patched latency remains
approximately 0.32-0.35 ms instead of growing with source duration and FPS.

No model output changes are expected: the 20,000-case differential comparison
shows that both public backends return the exact same frame indices, and the
2,000-case Transformers comparison independently confirms the sampling
contract. Decoded frames and all downstream model inputs are therefore
unchanged.

### AI-assisted contribution

This contribution was developed with AI assistance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
