### PR TITLE
[Bugfix][DBO] Handle a microbatch that leaves the step before its peers

### DIFF
--- a/tests/v1/worker/test_gpu_ubatch_slicing.py
+++ b/tests/v1/worker/test_gpu_ubatch_slicing.py
@@ -39,7 +39,11 @@ from vllm.v1.worker.ubatch_utils import (
     maybe_create_ubatch_slices,
     split_attn_metadata,
 )
-from vllm.v1.worker.ubatching import dbo_current_ubatch_id, dbo_yield
+from vllm.v1.worker.ubatching import (
+    dbo_current_ubatch_id,
+    dbo_register_recv_hook,
+    dbo_yield,
+)
 
 MAX_NUM_REQS = 32
 MAX_NUM_TOKENS = 128
@@ -538,11 +542,9 @@ def test_ubatch_runner_names_the_microbatch_that_failed():
     """A failing microbatch surfaces as a named error, not a downstream KeyError.
 
     The model here never yields, so the microbatches run back to back and no
-    handoff is left outstanding when one of them dies. A microbatch that fails
-    *while its sibling is parked at a yield* hangs the step instead -- the
-    shared handoff protocol in `ubatching.py` has no way to unwind a parked
-    microbatch, and the V1 runner has the same gap. Fixing that means changing
-    `ubatching.py`, which is out of scope for the V2 runner.
+    handoff is left outstanding when one of them dies. The case where a sibling
+    *is* parked at a yield is covered by
+    `test_a_parked_sibling_unwinds_when_its_peer_dies`.
     """
     vllm_config = _make_dbo_config()
     device = torch.device("cuda:0")
@@ -581,3 +583,83 @@ def test_ubatch_runner_names_the_microbatch_that_failed():
     assert isinstance(result["error"], RuntimeError)
     assert "Microbatch 0" in str(result["error"])
     assert isinstance(result["error"].__cause__, ValueError)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="DBO needs a GPU")
+def test_a_parked_sibling_unwinds_when_its_peer_dies():
+    """A microbatch parked at a yield must not wait for a handoff that cannot come.
+
+    Microbatches pass control around a ring, so one that raises mid-forward
+    never yields again. Without an abort signal the survivor blocks in
+    `_cpu_yield` forever and wedges the whole step.
+    """
+    vllm_config = _make_dbo_config()
+    device = torch.device("cuda:0")
+    runner = _make_execution_runner(vllm_config)
+
+    class _FailAfterYield(torch.nn.Module):
+        def forward(self, input_ids, positions, **kwargs):
+            # Microbatch 1 parks here waiting for 0 to hand control back.
+            dbo_yield()
+            if dbo_current_ubatch_id() == 0:
+                raise ValueError("boom")
+            return input_ids.float().unsqueeze(-1)
+
+    model_inputs = _make_model_inputs(8, device)
+    ubatch_state = _make_ubatch_state(
+        vllm_config,
+        [
+            UBatchSlice(slice(0, 2), slice(0, 4)),
+            UBatchSlice(slice(2, 4), slice(4, 8)),
+        ],
+    )
+
+    result: dict[str, BaseException] = {}
+
+    def _call():
+        try:
+            runner.run(_FailAfterYield(), model_inputs, ubatch_state)
+        except BaseException as e:  # noqa: BLE001
+            result["error"] = e
+
+    caller = threading.Thread(target=_call, daemon=True)
+    caller.start()
+    caller.join(timeout=60.0)
+    assert not caller.is_alive(), (
+        "the surviving microbatch stayed parked on a handoff that never came"
+    )
+    assert isinstance(result["error"], RuntimeError)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="DBO needs a GPU")
+def test_recv_hook_registered_after_the_peer_left_is_dropped():
+    """Registering a receive hook must tolerate a peer that already finished.
+
+    `__exit__` clears the peer's slot, so a microbatch still running its tail
+    finds `None` where its neighbour used to be. There is nobody left to run
+    the hook, so it is dropped rather than dereferenced.
+    """
+    vllm_config = _make_dbo_config()
+    device = torch.device("cuda:0")
+    runner = _make_execution_runner(vllm_config)
+
+    class _RegisterAfterPeerExits(torch.nn.Module):
+        def forward(self, input_ids, positions, **kwargs):
+            if dbo_current_ubatch_id() == 1:
+                # 0 has already run to completion and cleared its slot.
+                dbo_register_recv_hook(lambda: None)
+            else:
+                dbo_yield()
+            return input_ids.float().unsqueeze(-1)
+
+    model_inputs = _make_model_inputs(8, device)
+    ubatch_state = _make_ubatch_state(
+        vllm_config,
+        [
+            UBatchSlice(slice(0, 2), slice(0, 4)),
+            UBatchSlice(slice(2, 4), slice(4, 8)),
+        ],
+    )
+
+    output = runner.run(_RegisterAfterPeerExits(), model_inputs, ubatch_state)
+    assert output.shape[0] == 8

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -17,6 +17,16 @@ _NUM_UBATCHES: int = 2
 _CURRENT_CONTEXTS: list["UBatchContext | None"] = []
 
 
+class UBatchAbortedError(RuntimeError):
+    """Raised in a microbatch whose sibling left the step early."""
+
+
+def _wake_all_ubatch_waiters() -> None:
+    for ctx in _CURRENT_CONTEXTS:
+        if ctx is not None:
+            ctx.cpu_wait_event.set()
+
+
 class UBatchContext:
     """
     Context manager for micro-batching synchronization using threading events.
@@ -33,6 +43,7 @@ class UBatchContext:
         cpu_signal_event: threading.Event,
         gpu_comm_done_event: torch.Event,
         gpu_compute_done_event: torch.Event,
+        aborted: threading.Event,
         schedule: str = "default",
     ):
         self.id = id
@@ -47,6 +58,7 @@ class UBatchContext:
         self.gpu_compute_done_event = gpu_compute_done_event
         self.schedule = schedule
         self.recv_hook = None
+        self.aborted = aborted
 
     def __enter__(self):
         global _CURRENT_CONTEXTS, _THREAD_ID_TO_CONTEXT
@@ -66,9 +78,17 @@ class UBatchContext:
         global _CURRENT_CONTEXTS, _THREAD_ID_TO_CONTEXT
         _CURRENT_CONTEXTS[self.id] = None
         del _THREAD_ID_TO_CONTEXT[threading.get_ident()]
+        if exc_type is not None:
+            # Leaving mid-forward: the peers hand control around a ring, so a
+            # microbatch that never yields again would park the survivors on a
+            # handoff that cannot arrive. Mark the run aborted and wake every
+            # waiter so they unwind instead of hanging the step.
+            self.aborted.set()
         self.maybe_run_recv_hook()
         self.cpu_signal_event.set()
         self.cpu_wait_event.clear()
+        if self.aborted.is_set():
+            _wake_all_ubatch_waiters()
         return False
 
     def _restore_context(self):
@@ -102,6 +122,11 @@ class UBatchContext:
         self.cpu_signal_event.set()
         self.cpu_wait_event.wait()
         self.cpu_wait_event.clear()
+        if self.aborted.is_set():
+            raise UBatchAbortedError(
+                f"Microbatch {self.id} aborted: a sibling microbatch left the "
+                "step before handing control back"
+            )
         self._restore_context()
 
     def switch_to_comm(self):
@@ -157,11 +182,20 @@ def dbo_current_ubatch_id() -> int:
     return _THREAD_ID_TO_CONTEXT[threading.get_ident()]
 
 
+def _current_ubatch_context() -> "UBatchContext | None":
+    """The calling thread's context, or None once it has left the step."""
+    if len(_THREAD_ID_TO_CONTEXT) == 0:
+        return None
+    ctx_idx = _THREAD_ID_TO_CONTEXT.get(threading.get_ident())
+    if ctx_idx is None:
+        return None
+    return _CURRENT_CONTEXTS[ctx_idx]
+
+
 def _register_ubatch_function(func):
     def wrapper(*args, **kwargs):
-        if len(_THREAD_ID_TO_CONTEXT) > 0:
-            ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
-            ctx = _CURRENT_CONTEXTS[ctx_idx]
+        ctx = _current_ubatch_context()
+        if ctx is not None:
             func(ctx, *args, **kwargs)
 
     return wrapper
@@ -184,16 +218,19 @@ dbo_switch_to_compute_sync = _register_ubatch_function(
 
 
 def dbo_register_recv_hook(recv_hook):
-    if len(_THREAD_ID_TO_CONTEXT) > 0:
-        ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
-        next_ctx = _CURRENT_CONTEXTS[(ctx_idx + 1) % _NUM_UBATCHES]
+    if len(_THREAD_ID_TO_CONTEXT) == 0:
+        return
+    ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
+    next_ctx = _CURRENT_CONTEXTS[(ctx_idx + 1) % _NUM_UBATCHES]
+    # The peer may already have left the step, in which case there is nobody
+    # left to run the hook and dropping it is the correct behaviour.
+    if next_ctx is not None:
         next_ctx.recv_hook = recv_hook
 
 
 def dbo_get_previous_event(func, *args, **kwargs):
-    if len(_THREAD_ID_TO_CONTEXT) > 0:
-        ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
-        ctx = _CURRENT_CONTEXTS[ctx_idx]
+    ctx = _current_ubatch_context()
+    if ctx is not None:
         # execute callable on the ubatch compute stream to record/wait events there
         with torch.cuda.stream(ctx.compute_stream):
             return func(*args, **kwargs)
@@ -219,6 +256,8 @@ def make_ubatch_contexts(
     Create a context manager for micro-batching synchronization.
     """
     cpu_events = [threading.Event() for _ in range(num_micro_batches)]
+    # Shared by the whole group: set when any microbatch leaves early.
+    aborted = threading.Event()
     gpu_comm_done_events = [torch.Event() for _ in range(num_micro_batches)]
     gpu_compute_done_events = [torch.Event() for _ in range(num_micro_batches)]
 
@@ -234,6 +273,7 @@ def make_ubatch_contexts(
             cpu_signal_event=cpu_events[(i + 1) % num_micro_batches],
             gpu_comm_done_event=gpu_comm_done_events[i],
             gpu_compute_done_event=gpu_compute_done_events[i],
+            aborted=aborted,
             schedule=schedule,
         )
         ctxs.append(ctx)


### PR DESCRIPTION
## Purpose

Microbatches pass control around a ring of `threading.Event` handoffs, and
`UBatchContext.__exit__` clears the leaving context's slot in
`_CURRENT_CONTEXTS` while the other microbatches are still running. Two
failures follow from that, both reachable on the V2 runner.

**A survivor dereferences the empty slot.** `dbo_register_recv_hook` and the
wrappers built by `_register_ubatch_function` guard on `_THREAD_ID_TO_CONTEXT`
being non-empty. That answers "is a DBO step running", not "is my peer still
here" — the caller's own entry keeps it non-empty after the peer has gone — so
the lookup returns `None` and is dereferenced:

```
AttributeError: 'NoneType' object has no attribute 'recv_hook'
```

`__exit__` signals the next context on its way out, so the survivor is woken
precisely into this window.

**A parked survivor waits for a handoff that cannot arrive.** A microbatch that
raises never yields again. The exit signal releases the survivor once, and it
blocks in `_cpu_yield` at the following yield with nobody left to wake it; the
step hangs instead of failing. `tests/v1/worker/test_gpu_ubatch_slicing.py`
documents this today:

> A microbatch that fails *while its sibling is parked at a yield* hangs the
> step instead -- the shared handoff protocol in `ubatching.py` has no way to
> unwind a parked microbatch […] Fixing that means changing `ubatching.py`,
> which is out of scope for the V2 runner.

This PR does that change. Both fixes are in the shared `ubatching.py`, so V1
gets them too, but the motivation and the tests are on the V2 path.

## Approach

- Route the context lookups through one `_current_ubatch_context()` helper that
  returns `None` once the caller has left, and skip the work instead of
  dereferencing. Dropping a receive hook whose target has finished is the
  correct behaviour — there is no longer anyone to run it.
- Give each context group a shared `aborted` event. An exceptional `__exit__`
  sets it and wakes every waiter; a waiter that resumes with it set raises
  `UBatchAbortedError` rather than continuing into a step whose sibling is
  gone. A clean exit does not set it, so the normal path is unchanged.

## Test Plan

Two regression tests added to `tests/v1/worker/test_gpu_ubatch_slicing.py`,
next to the existing threaded-execution coverage:

- `test_a_parked_sibling_unwinds_when_its_peer_dies` — the survivor is parked
  at a yield when its peer raises; the step must fail rather than hang. Run
  behind a watchdog join so a regression fails the suite instead of wedging it.
- `test_recv_hook_registered_after_the_peer_left_is_dropped` — registering a
  hook after the peer cleared its slot must not raise.

The stale docstring on `test_ubatch_runner_names_the_microbatch_that_failed`,
which recorded the hang as unfixable from the V2 runner, now points at the new
test instead.

## Test Result

Both failure modes were first reproduced against unmodified `ubatching.py` on
a GB200 node by driving the handoff protocol directly (2 microbatches, real
threads and CUDA streams), then re-run with the patch applied:

| case | before | after |
|---|---|---|
| peer's slot cleared, survivor registers a hook | `AttributeError: 'NoneType' object has no attribute 'recv_hook'` | no error; hook dropped |
| peer raises while survivor is parked at a yield | **hung** (20s watchdog expired) | no hang; survivor raises `UBatchAbortedError`, the original `ValueError` is preserved on the failing microbatch |

`ruff check`, `ruff format` and `mypy --python-version 3.10 --follow-imports
skip tests/v1/worker` all pass; mypy reports the same "no issues found in 49
source files" with and without the change.

The two new tests are `@pytest.mark.skipif(not torch.cuda.is_available())` and
exercise the V2 `UBatchRunner`, so they need a GPU **and** a build recent
enough to contain `vllm/v1/worker/gpu/ubatch_utils.py`. The GPU I had available
runs an older vLLM without the V2 runner, so I could not execute them there —
the direct protocol reproduction above is what I was able to run end to end,
and it covers the same two behaviours at the `ubatching.py` level where the fix
lives. CI is the check that matters for the tests as written.

## Not a duplicate

Checked the open DBO PRs (#52176, #52177, #54511, #54512, #48659, #49542,
#49645, #43966, #51700). They cover profile-run sizing, the DeepEP V2 backend,
backend validation, attention-metadata cache keys, ubatch metadata slicing and
FULL cudagraph capture. None touches the peer-context lookups or the handoff
unwind path.

## AI assistance

Written with Claude Code. The mechanism was established by reading the ring
handoff in `ubatching.py` and then confirmed by the direct reproduction above;
my first two repro cases were built on a wrong assumption about the ordering
and had to be rewritten before they exercised the intended paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
