### PR TITLE
[Bugfix] Pass num_heads to is_vit_use_data_parallel in Qwen VL models

### DIFF
--- a/tests/models/test_vision.py
+++ b/tests/models/test_vision.py
@@ -572,6 +572,9 @@ def test_is_vit_use_data_parallel_divisibility(num_heads, tp_size, expected):
     from unittest.mock import patch
 
     with patch(
+        "vllm.model_executor.models.vision.get_multimodal_config",
+        return_value=None,
+    ), patch(
         "vllm.model_executor.models.vision.get_tensor_model_parallel_world_size",
         return_value=tp_size,
     ):
@@ -583,6 +586,9 @@ def test_is_vit_use_data_parallel_no_num_heads():
     from unittest.mock import patch
 
     with patch(
+        "vllm.model_executor.models.vision.get_multimodal_config",
+        return_value=None,
+    ), patch(
         "vllm.model_executor.models.vision.get_tensor_model_parallel_world_size",
         return_value=3,
     ):

--- a/tests/models/test_vision.py
+++ b/tests/models/test_vision.py
@@ -15,6 +15,7 @@ from vllm.distributed.parallel_state import (
 from vllm.model_executor.models.vision import (
     FusedInputNorm,
     get_load_balance_assignment,
+    is_vit_use_data_parallel,
     resolve_visual_encoder_outputs,
     run_dp_sharded_mrope_vision_model,
     run_dp_sharded_vision_model,
@@ -552,3 +553,38 @@ def test_fused_input_norm_identity_passthrough():
     pixel_values = torch.randn(8, 3 * 196, dtype=torch.float32)
     out = norm(pixel_values, visual_dtype=torch.bfloat16)
     torch.testing.assert_close(out, pixel_values.to(torch.bfloat16))
+
+
+@pytest.mark.parametrize(
+    ("num_heads", "tp_size", "expected"),
+    [
+        (16, 3, True),
+        (16, 5, True),
+        (16, 7, True),
+        (16, 2, False),
+        (16, 4, False),
+        (16, 8, False),
+        (12, 3, False),
+        (24, 3, False),
+    ],
+)
+def test_is_vit_use_data_parallel_divisibility(num_heads, tp_size, expected):
+    from unittest.mock import patch
+
+    with patch(
+        "vllm.model_executor.models.vision.get_tensor_model_parallel_world_size",
+        return_value=tp_size,
+    ):
+        result = is_vit_use_data_parallel(num_heads)
+    assert result is expected
+
+
+def test_is_vit_use_data_parallel_no_num_heads():
+    from unittest.mock import patch
+
+    with patch(
+        "vllm.model_executor.models.vision.get_tensor_model_parallel_world_size",
+        return_value=3,
+    ):
+        result = is_vit_use_data_parallel()
+    assert result is False

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -316,9 +316,10 @@ class Qwen2_5_VisionMLP(nn.Module):
         act_fn: Callable[[torch.Tensor], torch.Tensor] = F.silu,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        num_heads: int | None = None,
     ):
         super().__init__()
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(num_heads)
         self.gate_up_proj = MergedColumnParallelLinear(
             input_size=in_features,
             output_sizes=[hidden_features] * 2,  # [gate_proj, up_proj]
@@ -356,7 +357,7 @@ class Qwen2_5_VisionAttention(nn.Module):
     ) -> None:
         super().__init__()
         # Per attention head and per partition values.
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(num_heads)
         self.tp_size = (
             1
             if use_data_parallel
@@ -500,6 +501,7 @@ class Qwen2_5_VisionBlock(nn.Module):
             bias=True,
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",
+            num_heads=num_heads,
         )
 
     def forward(
@@ -577,9 +579,10 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
         spatial_merge_size: int = 2,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        num_heads: int | None = None,
     ) -> None:
         super().__init__()
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(num_heads)
         self.hidden_size = context_dim * (spatial_merge_size**2)
         if norm_layer is None:
             norm_layer = partial(nn.LayerNorm, eps=1e-6)
@@ -649,7 +652,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
         self.fullatt_block_indexes = vision_config.fullatt_block_indexes
         self.spatial_merge_unit = self.spatial_merge_size**2
         self._rope_by_thw_cache = LRUCache(capacity=1024)
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(self.num_heads)
         self.tp_size = (
             1
             if use_data_parallel
@@ -706,6 +709,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
             spatial_merge_size=self.spatial_merge_size,
             quant_config=quant_config,
             prefix=f"{prefix}.merger",
+            num_heads=self.num_heads,
         )
 
     @property

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -1348,7 +1348,10 @@ class Qwen2_5_VLForConditionalGeneration(
         config: Qwen2_5_VLConfig = vllm_config.model_config.hf_config
         multimodal_config = vllm_config.model_config.multimodal_config
 
-        self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+        self.use_data_parallel = (
+            multimodal_config.mm_encoder_tp_mode == "data"
+            or is_vit_use_data_parallel(config.vision_config.num_heads)
+        )
         self.config = config
         self.model_config = vllm_config.model_config
         self.vllm_config = vllm_config

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1861,7 +1861,10 @@ class Qwen3VLForConditionalGeneration(
         self.model_config = vllm_config.model_config
         self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
         self.multimodal_config = multimodal_config
-        self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+        self.use_data_parallel = (
+            multimodal_config.mm_encoder_tp_mode == "data"
+            or is_vit_use_data_parallel(config.vision_config.num_heads)
+        )
         self._init_video_pruning(multimodal_config)
 
         with self._mark_tower_model(vllm_config, {"image", "video"}):

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -407,9 +407,10 @@ class Qwen3_VisionMLP(nn.Module):
         act_fn: Callable[[torch.Tensor], torch.Tensor] = F.silu,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        num_heads: int | None = None,
     ):
         super().__init__()
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(num_heads)
         self.linear_fc1 = ColumnParallelLinear(
             in_features,
             hidden_features,
@@ -476,6 +477,7 @@ class Qwen3_VisionBlock(nn.Module):
             bias=True,
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",
+            num_heads=num_heads,
         )
 
     def forward(
@@ -510,9 +512,10 @@ class Qwen3_VisionPatchMerger(nn.Module):
         use_postshuffle_norm: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        num_heads: int | None = None,
     ) -> None:
         super().__init__()
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(num_heads)
         self.hidden_size = context_dim * (spatial_merge_size**2)
 
         self.use_postshuffle_norm = use_postshuffle_norm
@@ -584,7 +587,7 @@ class Qwen3_VisionTransformer(nn.Module):
         self.num_grid_per_side = int(self.num_position_embeddings**0.5)
         self._rot_pos_ids_cache = LRUCache(capacity=1024)
 
-        use_data_parallel = is_vit_use_data_parallel()
+        use_data_parallel = is_vit_use_data_parallel(self.num_heads)
         self.tp_size = (
             1
             if use_data_parallel
@@ -629,6 +632,7 @@ class Qwen3_VisionTransformer(nn.Module):
             spatial_merge_size=self.spatial_merge_size,
             quant_config=quant_config,
             prefix=f"{prefix}.merger",
+            num_heads=self.num_heads,
         )
 
         self.deepstack_merger_list = nn.ModuleList(
@@ -641,6 +645,7 @@ class Qwen3_VisionTransformer(nn.Module):
                     norm_layer=norm_layer,
                     quant_config=quant_config,
                     prefix=f"{prefix}.deepstack_merger_list.{layer_idx}",
+                    num_heads=self.num_heads,
                 )
                 for layer_idx in range(len(self.deepstack_visual_indexes))
             ]


### PR DESCRIPTION
## Summary

- Qwen2.5-VL and Qwen3-VL invoke `is_vit_use_data_parallel()` **without** the `num_heads` argument in several ViT components (MLP, PatchMerger, Transformer), preventing the divisibility check from ever running.
- When ViT has 16 attention heads and TP=3 (16 % 3 ≠ 0), the missing check causes `ensure_divisibility` to assert-fail during model init.
- This patch threads `num_heads` through all affected call sites so the function can detect indivisible head counts and fall back to data parallelism automatically.

Closes #55556

## Changes

| File | Change |
|------|--------|
| `qwen2_5_vl.py` | Pass `num_heads` in `VisionAttention`, `VisionMLP`, `VisionBlock`, `VisionPatchMerger`, `VisionTransformer` |
| `qwen3_vl.py` | Pass `num_heads` in `VisionMLP`, `VisionBlock`, `VisionPatchMerger`, `VisionTransformer` (incl. `deepstack_merger_list`) |
| `tests/models/test_vision.py` | Add parametrized unit tests for `is_vit_use_data_parallel` divisibility logic |

## Test plan

- [x] Unit test `test_is_vit_use_data_parallel_divisibility` — verifies the function returns `True` (data parallel fallback) when `num_heads % tp != 0`, and `False` when divisible. 8 parametrized cases covering TP={2,3,4,5,7,8} × heads={12,16,24}.
- [x] Unit test `test_is_vit_use_data_parallel_no_num_heads` — verifies the old codepath (no `num_heads`) does NOT detect the issue, confirming the bug exists without the fix.
- [x] Verified upstream code calls `is_vit_use_data_parallel()` without args at all affected sites.

## AI Assistance Disclosure

This PR was developed with AI assistance. All changes were reviewed and validated by the human submitter.