### PR TITLE
[ROCm][MLA] Serve non-causal multi-token decode on the AITER ASM path

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_non_causal.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_non_causal.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pin how the AITER MLA decode kernel treats causality.
+
+Two facts are asserted here, because the ROCm MLA backend's non-causal
+multi-token support is built on the second one only being reachable via the
+first:
+
+1. The persistent ASM decode kernel masks causally regardless of the
+   ``is_causal`` flag handed to ``get_mla_metadata_v1``: a block built with
+   ``is_causal=False`` still matches a causal reference. If a future aiter
+   release starts honouring the flag, this test fails and the backend can be
+   simplified to just pass it through.
+
+2. Splitting the block into ``qseqlen=1`` rows, each over the request's whole
+   KV range, does produce non-causal attention. This is the mechanism
+   ``AiterMLAImpl._forward_decode_non_causal`` uses.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+NUM_HEADS = 16
+QLEN = 2
+SEQ_LEN = 10
+KV_LORA_RANK = 512
+QK_ROPE_HEAD_DIM = 64
+HEAD_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM
+
+
+def _reference(q, kv, scale, causal):
+    """Attention over a single request's whole KV range.
+
+    Under causal masking, query row ``t`` of a ``QLEN`` block sees
+    ``SEQ_LEN - QLEN + t + 1`` positions; non-causally every row sees all
+    ``SEQ_LEN``.
+    """
+    out = torch.empty(QLEN, NUM_HEADS, KV_LORA_RANK, dtype=torch.float32)
+    for t in range(QLEN):
+        end = SEQ_LEN - QLEN + t + 1 if causal else SEQ_LEN
+        scores = (q[t].float() @ kv[:end].float().T) * scale
+        probs = scores.softmax(dim=-1)
+        out[t] = probs @ kv[:end, :KV_LORA_RANK].float()
+    return out
+
+
+def _rel(a, b):
+    return ((a - b).norm() / b.norm().clamp_min(1e-6)).item()
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm/aiter only")
+def test_aiter_mla_decode_causality():
+    aiter = pytest.importorskip("aiter")
+    from aiter import get_mla_metadata_v1
+    from aiter.mla import mla_decode_fwd
+
+    torch.manual_seed(0)
+    device = "cuda"
+    scale = HEAD_DIM**-0.5
+    # FP8 KV is what puts a small-head verify block on the ASM path at all.
+    kv_dtype = torch.float8_e4m3fn
+
+    q_ref = torch.randn(QLEN, NUM_HEADS, HEAD_DIM, device=device) / 4
+    kv_ref = torch.randn(SEQ_LEN, HEAD_DIM, device=device) / 4
+    q = q_ref.to(kv_dtype)
+    kv_buffer = kv_ref.to(kv_dtype).view(SEQ_LEN, 1, 1, HEAD_DIM)
+
+    kv_indices = torch.arange(SEQ_LEN, dtype=torch.int32, device=device)
+    ones = torch.ones(1, dtype=torch.float32, device=device)
+
+    def run(qo_indptr, kv_indptr, indices, last_page, num_rows, max_qo, is_causal):
+        batch = last_page.numel()
+        # The buffer shapes do not depend on causality, which is why serving a
+        # non-causal block needs no re-sizing.
+        bufs = [
+            torch.empty(shape, dtype=dtype, device=device)
+            for shape, dtype in aiter.get_mla_metadata_info_v1(
+                batch, max_qo, NUM_HEADS, kv_dtype, kv_dtype, False
+            )
+        ]
+        (
+            work_meta_data,
+            work_indptr,
+            work_info_set,
+            reduce_indptr,
+            reduce_final_map,
+            reduce_partial_map,
+        ) = bufs
+        get_mla_metadata_v1(
+            qo_indptr,
+            kv_indptr,
+            last_page,
+            NUM_HEADS,
+            1,
+            is_causal,
+            work_meta_data,
+            work_info_set,
+            work_indptr,
+            reduce_indptr,
+            reduce_final_map,
+            reduce_partial_map,
+            page_size=1,
+            kv_granularity=16,
+            max_seqlen_qo=max_qo,
+            uni_seqlen_qo=max_qo,
+            fast_mode=True,
+            dtype_q=kv_dtype,
+            dtype_kv=kv_dtype,
+        )
+        meta = dict(
+            work_meta_data=work_meta_data,
+            work_indptr=work_indptr,
+            work_info_set=work_info_set,
+            reduce_indptr=reduce_indptr,
+            reduce_final_map=reduce_final_map,
+            reduce_partial_map=reduce_partial_map,
+        )
+        out = torch.zeros(
+            num_rows, NUM_HEADS, KV_LORA_RANK, dtype=torch.bfloat16, device=device
+        )
+        mla_decode_fwd(
+            q.view(num_rows, NUM_HEADS, HEAD_DIM),
+            kv_buffer,
+            out,
+            qo_indptr,
+            kv_indptr,
+            indices,
+            last_page,
+            max_qo,
+            sm_scale=scale,
+            q_scale=ones,
+            kv_scale=ones,
+            **meta,
+        )
+        torch.cuda.synchronize()
+        return out.float().cpu()
+
+    ref_causal = _reference(q_ref.cpu(), kv_ref.cpu(), scale, causal=True)
+    ref_non_causal = _reference(q_ref.cpu(), kv_ref.cpu(), scale, causal=False)
+    # fp8 quantization noise; the causal/non-causal gap is an order of
+    # magnitude larger, so this separates them comfortably.
+    tol = 5e-2
+    # Sanity: the two references really are far apart on row 0, so a match
+    # below tol identifies which one the kernel computed.
+    assert _rel(ref_causal[0], ref_non_causal[0]) > 4 * tol
+
+    # --- 1. one qseqlen=2 block, built both ways -------------------------
+    block_qo = torch.tensor([0, QLEN], dtype=torch.int32, device=device)
+    block_kv = torch.tensor([0, SEQ_LEN], dtype=torch.int32, device=device)
+    block_last = torch.ones(1, dtype=torch.int32, device=device)
+    got_causal = run(block_qo, block_kv, kv_indices, block_last, QLEN, QLEN, True)
+    got_flagged = run(block_qo, block_kv, kv_indices, block_last, QLEN, QLEN, False)
+
+    # Row 0 is where the two causalities disagree (row QLEN-1 sees everything
+    # either way).
+    assert _rel(got_causal[0], ref_causal[0]) < tol
+    # is_causal=False computed the causal answer anyway: the flag reaches the
+    # work metadata but never the mask.
+    assert _rel(got_flagged[0], ref_causal[0]) < tol
+    assert _rel(got_flagged[0], ref_non_causal[0]) > tol, (
+        "aiter now honours is_causal in the MLA decode metadata; "
+        "AiterMLAImpl._forward_decode_non_causal can be replaced by "
+        "threading the flag through get_mla_metadata_v1"
+    )
+
+    # --- 2. the same block as qseqlen=1 rows over the full range ---------
+    row_qo = torch.arange(QLEN + 1, dtype=torch.int32, device=device)
+    row_kv = torch.arange(
+        0, SEQ_LEN * (QLEN + 1), SEQ_LEN, dtype=torch.int32, device=device
+    )
+    row_last = torch.ones(QLEN, dtype=torch.int32, device=device)
+    got_rows = run(row_qo, row_kv, kv_indices.repeat(QLEN), row_last, QLEN, 1, True)
+    for t in range(QLEN):
+        assert _rel(got_rows[t], ref_non_causal[t]) < tol
+    assert _rel(got_rows[0], ref_causal[0]) > tol

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -1047,6 +1047,21 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                     "AITER MLA segmented DCP verify builds causally bounded "
                     "rows and cannot serve a non-causal block."
                 )
+            # The replay slices query positions with a uniform stride, so every
+            # request has to contribute exactly max_qo_len rows. Checking the
+            # row total alone is not enough: a mixed batch of, say, lengths
+            # (4, 4, 2, 2) still divides by a stride of 4, and would then read
+            # rows belonging to the wrong request without failing. Done on the
+            # CPU copy of query_start_loc so the hot path stays sync-free.
+            # Zero-length entries are the full-CG dummy requests, which
+            # _uniform_padded_mtp_qo_len has already forced to one qlen.
+            uneven_qo_len = qo_len[qo_len > 0] if pad_uniform_mtp else qo_len
+            if not bool(torch.all(uneven_qo_len == max_qo_len)):
+                raise NotImplementedError(
+                    "AITER MLA non-causal multi-token decode requires every "
+                    f"request in the block to have {max_qo_len} query rows, "
+                    f"got {qo_len.tolist()}."
+                )
 
         # Segmented DCP verify carries its own per-row subpage table, so the
         # flat per-token view is dead work for it. Leave the buffer alone and

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -185,6 +185,30 @@ def _segmented_mla_decode_supported() -> bool:
     return True
 
 
+def _uniform_causal(causal: "bool | torch.Tensor") -> bool:
+    """Reduce ``CommonAttentionMetadata.causal`` to a single bool.
+
+    The field is ``bool | torch.Tensor``, a tensor carrying one flag per
+    request, and it cannot simply be tested: a tensor of all-false is truthy,
+    and ``bool()`` on a multi-element one raises.
+
+    A per-request flag has nowhere to go here -- causality is a property of the
+    work metadata, which is built once per step -- and the shared MLA builder
+    already collapses the field with ``causal is False``, so a tensor never
+    selects its non-causal route. This agrees with that, so the backend and the
+    layer cannot disagree about which route is live, and refuses a tensor that
+    actually asks for non-causal attention instead of quietly masking it.
+    """
+    if not isinstance(causal, torch.Tensor):
+        return bool(causal)
+    if causal.numel() and not bool(causal.all()):
+        raise NotImplementedError(
+            "AITER MLA does not support per-request causality; "
+            "CommonAttentionMetadata.causal must be a scalar bool."
+        )
+    return True
+
+
 def _segmented_dcp_verify_supported(dcp_world_size: int, cp_interleave: int) -> bool:
     """Whether this configuration can serve DCP verify on segmented MLA.
 
@@ -259,6 +283,15 @@ class AiterMLABackend(MLACommonBackend):
     def get_builder_cls() -> type["AiterMLAMetadataBuilder"]:
         return AiterMLAMetadataBuilder
 
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        # A non-causal multi-token block is issued as one qseqlen=1 decode per
+        # query position, each over the request's whole KV range. At qseqlen=1
+        # there is no intra-block masking left to apply, so the result is
+        # non-causal by construction rather than by asking the kernel for it.
+        # See _forward_decode_non_causal.
+        return True
+
 
 @dataclass
 class AiterMLADCPVerifyMetadata:
@@ -310,6 +343,15 @@ class AiterMLADecodeMetadata(MLACommonDecodeMetadata):
     use_gluon_verify: bool = False
     # Whether persistent MLA metadata was computed
     has_persistent_metadata: bool = False
+    # This step's causality, reduced to a scalar by _uniform_causal in build()
+    # so the forward paths never re-test a tensor (which would sync per layer).
+    causal: bool = True
+    # Set when the block is non-causal and max_qo_len > 1, in which case the
+    # metadata above is sized for qseqlen=1 and the decode runs once per query
+    # position over the whole KV range. See _forward_decode_non_causal.
+    non_causal_verify: bool = False
+    # qo_indptr for one query token per row, i.e. the identity indptr.
+    row_qo_indptr: torch.Tensor | None = None
 
 
 @dataclass
@@ -346,6 +388,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
     #  https://github.com/vllm-project/vllm/issues/22945
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+    supports_non_causal_multi_token_decode: ClassVar[bool] = True
 
     @staticmethod
     def _uniform_padded_mtp_qo_len(
@@ -421,6 +464,11 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # persistent gate below and makes aiter raise a KeyError mid-run.
         self._mtp_decode_qlen = self.reorder_batch_threshold or 1
 
+        # Causality belongs to the batch, not the KV cache group
+        # (MLAAttentionSpec.merge ORs the group flag over every layer in it),
+        # so build() records the step's value here for _build_decode.
+        self._build_causal = True
+
         # Store the kernel block size from the spec. When kernel_block_size=1
         # (no spec-dec), behavior is identical to the original. When > 1
         # (e.g. 16 with Eagle3), we expand block-level indices into per-token
@@ -445,6 +493,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # once and reuse slices in both eager and cudagraph modes.
         self.paged_kv_last_page_len = torch.ones(
             max_num_reqs, dtype=torch.int32, device=device
+        )
+
+        # qo_indptr for the non-causal route, where every row is one query
+        # token: row i owns exactly q[i], so the indptr is the identity.
+        self.row_qo_indptr = torch.arange(
+            max_num_reqs + 1, dtype=torch.int32, device=device
         )
 
         # Persistent buffer for paged_kv_indices to avoid blocking boolean mask
@@ -973,6 +1027,27 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             self._supports_segmented_dcp_verify and max_qo_len > 1
         )
 
+        # A non-causal multi-token block is re-expressed as qlen=1 rows, one
+        # per query position, each reading the request's whole KV range. Only
+        # the plain ASM decode can do that: the Gluon verify entry and the
+        # segmented DCP verify both bound each query position in-kernel, and
+        # neither has a way to express the untruncated range, so a non-causal
+        # block reaching them would come back causally masked.
+        non_causal_verify = not self._build_causal and max_qo_len > 1
+        if non_causal_verify:
+            if use_gluon_verify:
+                raise NotImplementedError(
+                    "AITER MLA small-head Gluon verify applies its causal "
+                    "bound in-kernel and cannot serve a non-causal block. It "
+                    "needs an FP8 KV cache or >= 16 query heads to reach the "
+                    "ASM decode instead."
+                )
+            if use_segmented_dcp_verify:
+                raise NotImplementedError(
+                    "AITER MLA segmented DCP verify builds causally bounded "
+                    "rows and cannot serve a non-causal block."
+                )
+
         # Segmented DCP verify carries its own per-row subpage table, so the
         # flat per-token view is dead work for it. Leave the buffer alone and
         # hand the metadata None, so a future reader cannot pick up whatever
@@ -1038,6 +1113,16 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # running the same asm kernels. The predicates are disjoint -- decode
         # is qlen==1, verify is qlen>1 -- and cover both Gluon entries plus the
         # segmented DCP verify.
+        # The non-causal route issues one qseqlen=1 decode per query position,
+        # so both the kernel choice and the work metadata are sized for a
+        # single query token even though the block carries max_qo_len of them.
+        kernel_qo_len = 1 if non_causal_verify else max_qo_len
+        kernel_qo_indptr = (
+            self.row_qo_indptr[: num_kernel_reqs + 1]
+            if non_causal_verify
+            else qo_indptr
+        )
+
         use_persistent_metadata = (
             not use_gluon_decode
             and not use_gluon_verify
@@ -1047,24 +1132,33 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             # keeps the schedule -- its fold rejects non-persistent outright.
             and (
                 self._decode_num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
-                or max_qo_len <= AiterMLAHelper._ASM_PADDED_MAX_PS_QLEN
+                or kernel_qo_len <= AiterMLAHelper._ASM_PADDED_MAX_PS_QLEN
                 or is_quantized_kv_cache(self._kv_cache_dtype_str)
             )
-            and max_qo_len >= 1
-            and max_qo_len <= self._mtp_decode_qlen
+            and kernel_qo_len >= 1
+            and kernel_qo_len <= self._mtp_decode_qlen
         )
         if use_persistent_metadata:
             from aiter import get_mla_metadata_v1
 
             uni_qo_len = (
-                max_qo_len if pad_uniform_mtp or torch.all(qo_len == max_qo_len) else -1
+                kernel_qo_len
+                if non_causal_verify
+                or pad_uniform_mtp
+                or torch.all(qo_len == max_qo_len)
+                else -1
             )
             get_mla_metadata_v1(
-                qo_indptr,
+                kernel_qo_indptr,
                 paged_kv_indptr,
                 paged_kv_last_page_len,
                 self._num_attention_heads,
                 1,
+                # is_causal, left True unconditionally: the decode kernel masks
+                # causally whatever this says, so it cannot be used to request
+                # non-causal attention. Non-causal blocks get their semantics
+                # from being split into qseqlen=1 rows above, where there is no
+                # intra-block position to mask.
                 True,
                 self._mla_work_meta_data,
                 self._mla_work_info_set,
@@ -1074,7 +1168,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 self._mla_reduce_partial_map,
                 page_size=1,
                 kv_granularity=16,
-                max_seqlen_qo=max_qo_len,
+                max_seqlen_qo=kernel_qo_len,
                 uni_seqlen_qo=uni_qo_len,
                 fast_mode=True,
                 dtype_q=self._mla_q_dtype,
@@ -1125,6 +1219,9 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             use_gluon_verify=use_gluon_verify,
             attn_out_dtype=self.decode_attn_out_dtype,
             has_persistent_metadata=has_persistent_metadata,
+            causal=self._build_causal,
+            non_causal_verify=non_causal_verify,
+            row_qo_indptr=kernel_qo_indptr if non_causal_verify else None,
         )
 
         return attn_metadata
@@ -1135,6 +1232,8 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> AiterMLAMetadata:
+        # Set before super().build(), which is what calls _build_decode.
+        self._build_causal = _uniform_causal(common_attn_metadata.causal)
         attn_metadata = super().build(
             common_prefix_len, common_attn_metadata, fast_build
         )
@@ -1829,9 +1928,11 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 device=q_nope.device,
             )
             kv_buffer = kv_c_and_k_pe_cache.reshape(-1, kv_c_and_k_pe_cache.shape[-1])
-            assert attn_metadata.causal, (
-                "AITER MLA small-head verify MTP is causal-only"
-            )
+            if not decode.causal:
+                raise NotImplementedError(
+                    "AITER MLA small-head Gluon verify applies its causal "
+                    "bound in-kernel and cannot serve a non-causal block."
+                )
             # Hand mla_gluon its 4-D MTP entry instead of an expanded
             # per-verify-token paged-KV view. The flat query layout is already
             # row-major (r * qlen + t), so unflatten is a free view. mla_gluon
@@ -1867,6 +1968,15 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
 
         verify = decode.dcp_verify
         if verify is not None:
+            # The row view this path consumes is built with each query
+            # position's range truncated to context + q_pos + 1, and the
+            # segmented kernel is called with causal=True, so a non-causal
+            # block would come back silently masked rather than rejected.
+            if not decode.causal:
+                raise NotImplementedError(
+                    "AITER MLA segmented DCP verify builds causally bounded "
+                    "rows and cannot serve a non-causal block."
+                )
             if type(q) is tuple:
                 q_nope, q_pe = q
             else:
@@ -1938,6 +2048,11 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 reduce_partial_map=attn_metadata.reduce_partial_map,
             )
 
+        if decode.non_causal_verify:
+            return self._forward_decode_non_causal(
+                mla_padded_q, kv_buffer, o, decode, mla_kwargs
+            )
+
         lse = None
         if self.dcp_world_size > 1:
             # The vLLM custom-op wrapper exposes only the in-place output and
@@ -1978,3 +2093,74 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         if lse is not None:
             lse = AiterMLAHelper.get_mla_unpadded_lse(self._decode_num_heads, lse)
         return output, lse
+
+    def _forward_decode_non_causal(
+        self,
+        mla_padded_q: torch.Tensor,
+        kv_buffer: torch.Tensor,
+        o: torch.Tensor,
+        decode: AiterMLADecodeMetadata,
+        mla_kwargs: dict,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Serve a non-causal multi-token block on the ASM decode.
+
+        Every row of a request must see that request's whole KV range, and
+        seq_lens already spans the block, so the ordinary per-request paged-KV
+        view *is* that range. Issuing one qseqlen=1 decode per query position
+        therefore hands each row the untruncated range, and at qseqlen=1 there
+        is no intra-block position left for the kernel to mask, so causality
+        never enters the result.
+
+        Going through qseqlen=1 is what makes this correct rather than
+        cosmetic: the persistent decode kernel masks causally whatever
+        is_causal get_mla_metadata_v1 was given, so asking for is_causal=False
+        on a qseqlen>1 block still returns causally masked output.
+        tests/kernels/attention/test_rocm_aiter_mla_non_causal.py pins both
+        halves of that.
+
+        The cost is one pass over the KV range per query position instead of
+        one for the whole block -- the same KV traffic a per-row expanded page
+        list would move, without needing a qlen-fold page-index buffer.
+        """
+        if self.dcp_world_size > 1:
+            raise NotImplementedError(
+                "AITER MLA non-causal multi-token decode is not implemented "
+                "for decode context parallelism."
+            )
+        qlen = int(decode.max_qo_len or 1)
+        num_rows = mla_padded_q.shape[0]
+        num_reqs = num_rows // qlen
+        if num_reqs * qlen != num_rows:
+            raise ValueError(
+                f"non-causal block of {num_rows} rows is not a multiple of qlen {qlen}"
+            )
+        # Use the indptr the work metadata was built against rather than
+        # re-slicing it, so a cudagraph-padded batch stays consistent with the
+        # rest of the decode path.
+        row_qo_indptr = decode.row_qo_indptr
+        assert row_qo_indptr is not None
+
+        for pos in range(qlen):
+            # The block is row-major (r * qlen + t), so one query position is
+            # a strided slice; the contiguous copy is num_reqs rows, not the
+            # whole block. mla_decode_fwd writes its output in place, so the
+            # destination has to be contiguous too.
+            q_pos = mla_padded_q[pos::qlen].contiguous()
+            o_pos = torch.empty(
+                num_reqs, o.shape[1], o.shape[2], dtype=o.dtype, device=o.device
+            )
+            rocm_aiter_ops.mla_decode_fwd(
+                q_pos,
+                kv_buffer,
+                o_pos,
+                self.scale,
+                row_qo_indptr,
+                1,
+                decode.paged_kv_indptr,
+                decode.paged_kv_indices,
+                decode.paged_kv_last_page_len,
+                **mla_kwargs,
+            )
+            o[pos::qlen] = o_pos
+
+        return AiterMLAHelper.get_mla_unpadded_o(self._decode_num_heads, o), None


### PR DESCRIPTION
## Purpose

DSpark's draft emits a **non-causal** multi-token block: every query token in the block attends the same KV range. The AITER MLA backend had no way to express that, so such a block was refused and the group fell back to Triton.

### What changed since the first revision

The first revision of this PR threaded `is_causal=False` into `get_mla_metadata_v1`, on the theory that the decode kernel takes its causality from the work metadata. **It does not.** The persistent kernel masks causally whatever that flag says, so the block came back causally masked while the backend advertised non-causal support. I found this with a direct A/B against a plain-PyTorch reference and moved the PR to draft; that mechanism is gone now.

The smallest case where the two causalities differ visibly is `qlen=2`, `seq_len=10`, where causal gives row 0 nine KV positions and non-causal gives it ten:

| row 0 vs | `is_causal=True` | `is_causal=False` |
|---|---|---|
| causal reference | **2.32e-02** | **2.32e-02** |
| non-causal reference | 4.83e-01 | 4.83e-01 |

Both builds compute the causal answer. (This is also why an end-to-end run cannot catch it: at a 128k context the two differ by one KV position in 131072.)

### The mechanism now

Serve the block at `qseqlen=1`. `seq_lens` already spans the verify block, so a request's ordinary paged-KV view *is* exactly the range every row needs. Issuing one `qseqlen=1` decode per query position hands each row that untruncated range, and at `qseqlen=1` there is no intra-block position left to mask, so causality never enters the result — it is non-causal by construction rather than by asking the kernel for it.

Same harness, same references, this time on the `qseqlen=1` split:

| | vs non-causal reference | vs causal reference |
|---|---|---|
| rows 0 and 1 | **2.27e-02** | 4.77e-01 |

The cost is one pass over the KV range per query position, which is the traffic a per-row expanded page list would have moved, without needing a `qlen`-fold page-index buffer.

### Guards

- **Gluon small-head verify** and **segmented DCP verify** both apply their causal bound in-kernel and have no way to express the untruncated range. A non-causal block is now rejected on both — in the builder, and again in `forward_mqa`. Previously, enabling non-causal support silently routed such a block through the segmented DCP path, which builds causally bounded rows and calls the kernel with `causal=True`.
- Non-causal DCP stays off: `supports_non_causal_multi_token_dcp` is left `False`, so the shared layer refuses it with a clear error.
- `CommonAttentionMetadata.causal` is `bool | torch.Tensor` and is now reduced through a helper rather than tested directly — a tensor of all-false is truthy, and `bool()` on a multi-element one raises. The helper agrees with the shared MLA builder, which selects its non-causal route with `causal is False` and therefore never selects it for a tensor, and refuses a tensor that *does* ask for non-causal attention rather than quietly masking it.

## Test Plan

1. `tests/kernels/attention/test_rocm_aiter_mla_non_causal.py` (new) pins both halves of the mechanism on gfx950: that `is_causal` does not reach the mask, and that the `qseqlen=1` split produces non-causal attention.
2. End-to-end: Kimi-K3 (MXFP4, TP8) with the Kimi-K3-DSpark MTP draft on one MI355X node, concurrency 1, ISL 131072 / OSL 1024, fp8 KV on both target and draft. Only the draft's `attention_backend` differs between arms. Three repeats per arm, interleaved.

## Test Result

`test_rocm_aiter_mla_non_causal.py` passes on MI355X (gfx950), stable across repeated cold-container runs.

**End-to-end, 3 repeats per arm (`num_speculative_tokens=2`):**

| draft backend | p90 ITL (ms) | mean TPOT (ms) | output tok/s |
|---|---|---|---|
| `TRITON_MLA` (before this PR) | 31.99 / 32.26 / 32.23 | 13.44 avg | 33.9 avg |
| `ROCM_AITER_MLA`, non-causal `qseqlen=1` | **29.43 / 29.44 / 29.48** | 12.24 avg | 35.6 avg |

**8.4% p90 ITL improvement** and **+5.1% output throughput**, with a spread of ±0.15 ms on the Triton arm and ±0.03 ms on the aiter arm, so the gap is far outside the noise.

**Where it comes from** (rank-0 torch trace, 6 decode passes, 5 draft layers), draft attention kernels plus their MLA reduce:

| draft route | launches / pass | ms / pass |
|---|---|---|
| Triton (`_fwd_grouped_kernel_stage1` + `_fwd_kernel_stage2`) | 5 | 2.02 |
| asm `qseqlen=1` x2 (this PR) | 10 | 0.61 |
| asm `qseqlen=2` (the withdrawn causal mechanism) | 5 | 0.33 |

The ASM path is 3.3x cheaper than Triton on the draft even paying for one launch per query position. Note the last row: the withdrawn mechanism had the cheapest attention of the three and yet measured **32.49 ms p90 ITL** — no end-to-end gain over Triton at all. So the earlier 9.1% figure in this PR's original description does not reproduce, and the correct mechanism is also the faster one.

### Caveats I would not want a reviewer to miss

- **The gain depends on spec depth.** This replay issues one decode per query position, so its cost scales with the block length, while Triton reads the KV range once for the whole block. The numbers above are at `num_speculative_tokens=2`. At depth 6 the replay costs ~6 passes per draft layer and the win should shrink, possibly to nothing. Deep-spec deployments should measure before adopting.
- **Attribution is incomplete.** The attention saving I can account for in the trace is ~1.4 ms/pass, but the ITL improvement works out to ~3.4 ms/pass, and the withdrawn arm had cheaper attention with zero gain. The measurement is reproducible; my explanation of *why* is not complete, so I would treat the 8.4% as the result and not attach a mechanism claim to it.
- **Which code was measured.** The three-repeat A/B ran on a vendor image whose MLA backend predates this file's current layout, carrying an equivalent change that routes the same way (`qseqlen=1` per query position). This exact diff applies cleanly to a build tracking `upstream/main` and is running there now on 8x MI355X: patch applied, FULL cudagraph capture completed, server healthy, serving at `num_speculative_tokens=6` with no faults. I will follow up with that arm's numbers, which also settle the spec-depth question above.
