### PR TITLE
fixed metrics support parallel sampling

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -32,7 +32,7 @@ from vllm.v1.engine.output_processor import (
     RequestOutputCollector,
     RequestState,
 )
-from vllm.v1.metrics.stats import IterationStats, SchedulerStats
+from vllm.v1.metrics.stats import IterationStats, RequestStateStats, SchedulerStats
 
 
 @pytest.mark.parametrize("flat_logprobs", [False, True])
@@ -1328,6 +1328,68 @@ async def test_request_output_collector():
     # Cumulative logprobs should be the last one.
     cumulative_logprob_expected = 1.0 * num_to_put
     assert output.outputs[0].cumulative_logprob == cumulative_logprob_expected
+
+
+@pytest.mark.asyncio
+async def test_request_output_collector_preserves_merged_metrics():
+    collector = RequestOutputCollector(
+        RequestOutputKind.DELTA, request_id="my-request-id-int"
+    )
+    metrics = RequestStateStats(
+        num_generation_tokens=2,
+        arrival_time=1.0,
+        queued_ts=2.0,
+        scheduled_ts=3.0,
+        first_token_ts=4.0,
+        last_token_ts=5.0,
+        first_token_latency=3.0,
+    )
+    outputs = [
+        RequestOutput(
+            request_id="my-request-id",
+            prompt=None,
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="a",
+                    token_ids=[0],
+                    cumulative_logprob=None,
+                    logprobs=None,
+                    finish_reason=None,
+                )
+            ],
+            finished=False,
+            metrics=None,
+        ),
+        RequestOutput(
+            request_id="my-request-id",
+            prompt=None,
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="b",
+                    token_ids=[1],
+                    cumulative_logprob=None,
+                    logprobs=None,
+                    finish_reason="length",
+                )
+            ],
+            finished=True,
+            metrics=metrics,
+        ),
+    ]
+
+    for output in outputs:
+        collector.put(output)
+
+    output = await collector.get()
+
+    assert output.finished
+    assert output.metrics is metrics
 
 
 @pytest.mark.asyncio

--- a/tests/v1/engine/test_parallel_sampling.py
+++ b/tests/v1/engine/test_parallel_sampling.py
@@ -8,6 +8,7 @@ from vllm.outputs import CompletionOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.parallel_sampling import ParentRequest
+from vllm.v1.metrics.stats import RequestStateStats
 
 
 def test_parent_request_to_output_stream() -> None:
@@ -82,6 +83,51 @@ def test_parallel_sampling_child_requests_preserve_session_id() -> None:
         child_request.sampling_params = child_params
 
         assert child_request.session_id == "session-1"
+
+
+def test_parent_request_aggregates_child_stats() -> None:
+    parent_request = ParentRequest(make_request(SamplingParams(n=2)))
+    parent_request.register_child_stats(
+        "child_id_0",
+        RequestStateStats(
+            num_generation_tokens=2,
+            num_preemptions=1,
+            arrival_time=1.0,
+            queued_ts=2.0,
+            scheduled_ts=4.0,
+            first_token_ts=6.0,
+            last_token_ts=8.0,
+            first_token_latency=5.0,
+            is_corrupted=False,
+        ),
+    )
+    parent_request.register_child_stats(
+        "child_id_1",
+        RequestStateStats(
+            num_generation_tokens=3,
+            num_preemptions=2,
+            arrival_time=0.5,
+            queued_ts=1.5,
+            scheduled_ts=3.0,
+            first_token_ts=5.0,
+            last_token_ts=10.0,
+            first_token_latency=4.5,
+            is_corrupted=True,
+        ),
+    )
+
+    stats = parent_request.aggregate_stats()
+
+    assert stats is not None
+    assert stats.num_generation_tokens == 5
+    assert stats.num_preemptions == 3
+    assert stats.arrival_time == 0.5
+    assert stats.queued_ts == 1.5
+    assert stats.scheduled_ts == 3.0
+    assert stats.first_token_ts == 5.0
+    assert stats.last_token_ts == 10.0
+    assert stats.first_token_latency == 4.5
+    assert stats.is_corrupted
 
 
 def make_request(sampling_params: SamplingParams) -> EngineCoreRequest:

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -176,6 +176,8 @@ class RequestOutput:
         self.finished |= next_output.finished
         self.kv_transfer_params = next_output.kv_transfer_params
         self.ec_transfer_params = next_output.ec_transfer_params
+        if next_output.metrics is not None:
+            self.metrics = next_output.metrics
 
         for next_completion in next_output.outputs:
             for i, completion in enumerate(self.outputs):

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -334,8 +334,11 @@ class RequestState:
             outputs = [output]
         else:
             outputs, finished = self.parent_req.get_outputs(self.request_id, output)
+            if self.stats is not None:
+                self.parent_req.register_child_stats(self.request_id, self.stats)
             if not outputs:
                 return None
+
             external_req_id = self.parent_req.external_req_id
 
         return self._new_request_output(
@@ -377,6 +380,12 @@ class RequestState:
         else:
             prompt_logprobs = self.logprobs_processor.prompt_logprobs
 
+        metrics = self.stats
+        if self.parent_req is not None and finished:
+            metrics = self.parent_req.aggregate_stats()
+        elif self.parent_req is not None and not finished:
+            metrics = None
+
         return RequestOutput(
             request_id=external_req_id,  # request_id is what was provided externally
             lora_request=self.lora_request,
@@ -389,7 +398,7 @@ class RequestState:
             ec_transfer_params=ec_transfer_params,
             num_cached_tokens=self.num_cached_tokens,
             num_cache_creation_tokens=self.num_cache_creation_tokens,
-            metrics=self.stats,
+            metrics=metrics,
         )
 
     def _new_completion_output(

--- a/vllm/v1/engine/parallel_sampling.py
+++ b/vllm/v1/engine/parallel_sampling.py
@@ -7,7 +7,7 @@ from typing import cast
 from vllm.outputs import CompletionOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.v1.engine import EngineCoreRequest
-from vllm.v1.metrics.stats import IterationStats
+from vllm.v1.metrics.stats import IterationStats, RequestStateStats
 
 
 class ParentRequest:
@@ -21,8 +21,10 @@ class ParentRequest:
     external_req_id: str
     sampling_params: SamplingParams
 
-    # To track the completion of child requests
+    # To track the completion and stats of child requests
     child_requests: set[str]
+    child_request_stats: dict[str, RequestStateStats]
+
 
     # To aggregate child completions when not streaming
     output_aggregator: list[CompletionOutput]
@@ -41,6 +43,7 @@ class ParentRequest:
         self.sampling_params = sampling_params
 
         self.child_requests = set()
+        self.child_request_stats = {}
         self.output_aggregator = (
             [cast(CompletionOutput, None)] * sampling_params.n
             if (sampling_params.output_kind == RequestOutputKind.FINAL_ONLY)
@@ -92,6 +95,35 @@ class ParentRequest:
         child_req_id = f"{index}_{self.request_id}"
         self.child_requests.add(child_req_id)
         return child_req_id, self._get_child_sampling_params(index)
+
+    def register_child_stats(
+        self,
+        child_request_id: str,
+        child_request_stats: RequestStateStats,
+    ) -> None:
+        if child_request_id not in self.child_request_stats:
+            self.child_request_stats[child_request_id] = child_request_stats
+
+    def aggregate_stats(self) -> RequestStateStats | None:
+        if not self.child_request_stats:
+            return None
+
+        child_stats = self.child_request_stats.values()
+        return RequestStateStats(
+            num_generation_tokens=sum(
+                stats.num_generation_tokens for stats in child_stats
+            ),
+            num_preemptions=sum(stats.num_preemptions for stats in child_stats),
+            arrival_time=min(stats.arrival_time for stats in child_stats),
+            queued_ts=min(stats.queued_ts for stats in child_stats),
+            scheduled_ts=min(stats.scheduled_ts for stats in child_stats),
+            first_token_ts=min(stats.first_token_ts for stats in child_stats),
+            last_token_ts=max(stats.last_token_ts for stats in child_stats),
+            first_token_latency=min(
+                stats.first_token_latency for stats in child_stats
+            ),
+            is_corrupted=any(stats.is_corrupted for stats in child_stats),
+        )
 
     @property
     def n(self) -> int:


### PR DESCRIPTION
## Summary

This PR adds parent-level request metrics support for V1 parallel sampling requests.

When `n > 1`, V1 parallel sampling splits a request into child requests. Each child already accumulates `RequestStateStats`, but the final parent `RequestOutput.metrics` did not synthesize those child stats. This change aggregates child metrics back into the parent output once all children finish.

The aggregation uses:
- sum for generated tokens and preemptions
- earliest timestamp for arrival, queued, scheduled, and first-token timing
- latest timestamp for last-token timing
- `any(...)` for corruption status

It also preserves metrics when streamed `RequestOutput`s are merged by `RequestOutputCollector`, so async DELTA streaming does not drop the final aggregated metrics.

Fixes #13792.

## Duplicate-work check

I checked the issue discussion for #13792 and this implementation targets the remaining gap described there: synthesizing parent request metrics from child request metrics for V1 parallel sampling.

Before opening this PR, please also run:

```bash
gh issue view 13792 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "13792 in:body"
gh pr list --repo vllm-project/vllm --state open --search "parallel sampling metrics"
```

At the time of preparing this description, I could not complete the `gh` checks locally because GitHub CLI was not authenticated.

## Tests

```bash
.venv/bin/python -m pytest tests/v1/engine/test_parallel_sampling.py tests/v1/engine/test_output_processor.py::test_request_output_collector_preserves_merged_metrics -q
```

Result:

```text
5 passed
```

Also ran:

```bash
git diff --check -- vllm/v1/engine/parallel_sampling.py vllm/v1/engine/output_processor.py vllm/outputs.py tests/v1/engine/test_parallel_sampling.py tests/v1/engine/test_output_processor.py
```

Result: passed with no whitespace errors.

## Model evaluation

Not applicable. This change affects request metrics reporting and does not change model outputs, sampling behavior, or serving accuracy.
