### PR TITLE
Selective Weight Reload for RL Training

### DIFF
--- a/docs/design/weight-update/fp8-moe-reload-plan.md
+++ b/docs/design/weight-update/fp8-moe-reload-plan.md
@@ -86,3 +86,26 @@ staging and temporary tensors. Prevalidation prevents ordinary layout errors
 from causing partial writes but is not model-wide transactional rollback if
 a GPU copy fails. Cold load may still install activation and derived scale
 Parameters; the no-replacement invariant applies to runtime reload writes.
+
+## Reduced-model day0 NCCL validation
+
+`Qwen3-30B-A3B-FP8` was reduced to two transformer layers while preserving its
+original block-wise FP8 checkpoint and 128 experts. A/B checkpoints were
+constructed from the real seven-shard checkpoint; B halves only the stored MoE
+`down_proj` FP8 weights, leaving scales and non-MoE tensors unchanged.
+
+The run used the dedicated remote vLLM worktree and a separate day0-kit
+worktree pinned to kit commit `152c2c0`, plus a compatibility adapter for the
+current NCCL request API. Server GPU 1 and publisher GPU 2 joined one NCCL
+group (`transfer world size=2`). The server selected `FLASHINFER_CUTLASS` and
+the extension found the expected `Fp8MoEMethod` layers. START/update/FINISH
+completed through NCCL; warm-B runtime hashes, Parameter/kernel/config
+identities and pointers matched independent cold-B, and three deterministic
+completion prompts matched exactly.
+
+Evidence: `/inspire/hdd/global_user/wangtongyu-25057/day0-moe-block-qwen3-validation-20260906-02/`
+(`comparison.json`: `status=PASS`, `layers=2`, `runtime_changed=true`,
+`warm_matches_cold=true`; `update.json`, `evidence.json`, server logs and
+`client.log` are present). The first attempt with the latest kit failed before
+NCCL because its `WeightTransferStartRequest` API was newer than this vLLM
+branch; it is not counted. The compatibility run is authoritative.

--- a/docs/design/weight-update/fp8-moe-reload-plan.md
+++ b/docs/design/weight-update/fp8-moe-reload-plan.md
@@ -1,0 +1,88 @@
+# CUTLASS FP8 MoE reload: phases 1–3
+
+Base: `5968e6b39f` (FP8 dense per-tensor selective reload).
+Local worktree: `/home/tttony/workspace/vllm-fp8-moe-reload`.
+Remote worktree: `/inspire/hdd/global_user/wangtongyu-25057/vllm-fp8-moe-reload`.
+The original local and remote workspaces are not used for this implementation.
+
+## Scope and phases
+
+1. **Source/runtime contracts — implemented.** Include serialized per-tensor
+   and block-wise FP8 from the first phase. Use the selectable
+   `FLASHINFER_CUTLASS` backend and the real `RoutedExperts.weight_loader`.
+   Save checkpoint shape/dtype/loader metadata before cold PWAL.
+2. **Conversion and runtime allocation — implemented.**
+   `_prepare_moe_runtime` allocates final weight/scale shells from source
+   metadata before conversion. `_convert_moe_runtime` performs requantization
+   and backend layout conversion. `_install_moe_kernel` fills cold runtime
+   storage and constructs the kernel. Reload uses cloned source tensors and
+   an isolated layer/config view so padding does not mutate the live config.
+3. **Staging, FINISH and kernel reuse — implemented.** Load into source-layout
+   staging, track actual expert/row/column writes, validate source completeness
+   and every output layout before copying. Reuse kernel, Parameter objects,
+   storage and quant-config-owned alpha/reciprocal tensors. Repeated refresh
+   with no staged data is a no-op.
+4. **Later work, not enabled here.** Other MoE backends, EPLB and FNUZ. EPLB
+   explicitly stays on fallback. Native VLLM_CUTLASS variants are already
+   disabled by the method's existing backend selector.
+
+## Layouts
+
+For gated experts, E is local expert count, N intermediate size, K hidden size.
+
+| Tensor | Checkpoint | FlashInfer CUTLASS runtime |
+| --- | --- | --- |
+| w13_weight | E × 2N × K, gate/up | up/gate, per-tensor N alignment padding |
+| w2_weight | E × K × N | per-tensor N alignment padding |
+| w13_weight_scale | E × 2 | E, max scale with gate/up requantization |
+| w2_weight_scale | E | E |
+| w13_weight_scale_inv | E × 2ceil(N/Bn) × ceil(K/Bk) | swapped block rows, existing minimum clamp |
+| w2_weight_scale_inv | E × ceil(K/Bn) × ceil(N/Bk) | existing minimum clamp |
+| static input scales | E per projection | scalar maximum without EPLB |
+
+Per-tensor g1/g2 alpha = weight scale × activation scale. a1/a2 global scale
+= reciprocal activation scale. Kernel-held references are updated with copy_.
+Identical w1/w3 activation scales can share one source slot; a repeated shard
+or conflicting alias is rejected. Conflicting values are not silently
+resolved by checkpoint iteration order.
+
+## H200 evidence
+
+All Python tests ran inside H200 with the fixed interpreter:
+`/inspire/hdd/global_user/wangtongyu-25057/miniconda3/envs/vllm/bin/python`.
+Use `CUDA_VISIBLE_DEVICES=1`, `HF_HUB_OFFLINE=1`, and PYTHONPATH pointing to
+the dedicated remote worktree. No local GPU tests were run.
+
+- `tests/quantization/test_fp8.py -k moe_ -q --tb=short`: **20 passed**, H200
+  `status=ok rc=0 seconds=18.79` on the final runtime-shell implementation.
+- Actual lifecycle cases: per-tensor N=256, per-tensor N=257 (padding),
+  block-wise N=256 with 128×128 blocks; four experts, top-k=2. Two reloads,
+  runtime unchanged before FINISH, no PWAL/kernel reconstruction, stable
+  Parameters and kernel/config-derived pointers, exact cold-B runtime tensor
+  and actual CUTLASS kernel-output comparisons.
+- Other selected tests cover real expert weight/scale loaders, fused 3D
+  expert copies, overlap rejection, missing expert/scale rejection before
+  conversion, invalid destination rejection before any write, real W31 and
+  requant conversions, and alpha/reciprocal refresh.
+- Dense FP8 regression: `-k per_tensor_refresh_without_pwal`, **20 passed**.
+- Ruff 0.14.0: the three modified Python files formatted and checked in H200.
+
+## Reusing the compiled backend
+
+Set FLASHINFER_WORKSPACE_BASE to the remote worktree's `jit-cuda130` directory.
+For rebuilding, MAX_JOBS=4 and CPATH containing only these fixed-environment
+subdirectories were used:
+`lib/python3.12/site-packages/nvidia/cublas/include` and
+`lib/python3.12/site-packages/nvidia/cuda_nvrtc/include`.
+Do not add the broad cu13/include directory: it conflicted with nvcc 13.0.88.
+Initial successful build/test job `320454c75c06`: rc=0, two original lifecycle
+cases passed in 3204.44 seconds. Subsequent runs reuse its cache.
+
+## Limitations for review
+
+These are real-layer/kernel tests, not a pretrained-model quality evaluation,
+multi-node/EP acceptance or CUDA graph replay test. Conversion allocates
+staging and temporary tensors. Prevalidation prevents ordinary layout errors
+from causing partial writes but is not model-wide transactional rollback if
+a GPU copy fails. Cold load may still install activation and derived scale
+Parameters; the no-replacement invariant applies to runtime reload writes.

--- a/docs/design/weight-update/fp8-reload-results.md
+++ b/docs/design/weight-update/fp8-reload-results.md
@@ -1,0 +1,22 @@
+# FP8 per-tensor reload
+
+This change covers serialized per-tensor FP8 weights using the CUTLASS FP8
+linear kernel. Block-FP8, non-serialized FP8, and Marlin FP8 remain on the
+existing fallback path.
+
+The reload path stages checkpoint-layout `weight`, `weight_scale`, and optional
+`input_scale` tensors. At FINISH it validates complete, non-overlapping shard
+coverage, applies the existing per-tensor requantization/transpose/padding
+logic, and copies the result into the existing runtime storage. It does not
+call method or kernel `process_weights_after_loading()` during reload.
+
+H200 validation (fixed environment
+`/inspire/hdd/global_user/wangtongyu-25057/miniconda3/envs/vllm`):
+
+- `tests/quantization/test_fp8.py -k test_per_tensor_refresh_without_pwal`:
+  20 passed.
+- The matrix covers dynamic/static activation scales, complete and missing
+  shards, duplicate/overlapping shards, missing scales, repeated refreshes,
+  and stable parameter addresses.
+- Ruff 0.14.0 format/check passed for the modified Python files.
+

--- a/examples/rl/day0_nccl_compat.py
+++ b/examples/rl/day0_nccl_compat.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adapt day0-kit 152c2c0's sender API to the current vLLM NCCL primitives."""
+
+from dataclasses import dataclass
+
+import torch
+
+from vllm.distributed.weight_transfer.nccl_common import trainer_init
+from vllm.distributed.weight_transfer.nccl_engine import (
+    NCCLWeightTransferUpdateInfo as CurrentUpdateInfo,
+)
+from vllm.distributed.weight_transfer.packed_tensor import packed_nccl_broadcast_producer
+
+
+def NCCLWeightTransferUpdateInfo(*, packed, **kwargs):
+    # Packing is negotiated at communicator initialization in current vLLM.
+    return CurrentUpdateInfo(**kwargs)
+
+
+@dataclass
+class NCCLTrainerSendWeightsArgs:
+    group: object
+    packed: bool
+    packed_buffer_size_bytes: int
+    packed_num_buffers: int
+
+
+class NCCLWeightTransferEngine:
+    trainer_init = staticmethod(trainer_init)
+
+    @staticmethod
+    def trainer_send_weights(iterator, args):
+        if args.packed:
+            packed_nccl_broadcast_producer(
+                iterator=iterator, group=args.group, src=0,
+                post_iter_func=lambda item: item[1],
+                buffer_size_bytes=args.packed_buffer_size_bytes,
+                num_buffers=args.packed_num_buffers,
+            )
+        else:
+            for _, tensor in iterator:
+                args.group.broadcast(tensor.contiguous(), src=0,
+                                     stream=torch.cuda.current_stream())
+        torch.cuda.synchronize()

--- a/examples/rl/moe_reload_evidence.py
+++ b/examples/rl/moe_reload_evidence.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Worker-side evidence for the reduced-model day0 NCCL experiment."""
+
+import hashlib
+
+import torch
+
+from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+
+
+class MoEReloadEvidence:
+    def inspect_moe_reload(self, arm=False):
+        result = {}
+        for name, layer in self.model_runner.model.named_modules():
+            method = getattr(layer, "quant_method", None)
+            if not isinstance(method, Fp8MoEMethod):
+                continue
+            assert method.supports_selective_reload()
+            assert method.fp8_backend.name == "FLASHINFER_CUTLASS"
+            if arm:
+                def forbidden(*args, **kwargs):
+                    raise AssertionError("MoE PWAL or runtime reconstruction after cold load")
+                method.process_weights_after_loading = forbidden
+                method._prepare_moe_runtime = forbidden
+                method._install_moe_kernel = forbidden
+            tensors = dict(layer.named_parameters(recurse=False))
+            for key in ("a1_gscale", "a2_gscale", "g1_alphas", "g2_alphas"):
+                value = getattr(method.moe_quant_config, key, None)
+                if value is not None:
+                    tensors[f"config.{key}"] = value
+            evidence = {}
+            for key, value in tensors.items():
+                raw = value.detach().contiguous().reshape(-1).view(torch.uint8)
+                evidence[key] = {"id": id(value), "ptr": value.data_ptr(),
+                                 "shape": list(value.shape), "dtype": str(value.dtype),
+                                 "hash": hashlib.sha256(raw.cpu().numpy().tobytes()).hexdigest()}
+            result[name] = {"backend": method.fp8_backend.name, "block": method.block_quant,
+                            "method": id(method), "kernel": id(method.moe_kernel),
+                            "config": id(method.moe_quant_config), "tensors": evidence}
+        assert result, "No Fp8MoEMethod found"
+        return result

--- a/examples/rl/prepare_reduced_fp8_moe.py
+++ b/examples/rl/prepare_reduced_fp8_moe.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prepare genuine reduced block-FP8 MoE checkpoints for day0 A/B validation."""
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--layers", type=int, default=2)
+    args = parser.parse_args()
+    print(sys.executable, sys.prefix, flush=True)
+    config = json.loads((args.source / "config.json").read_text())
+    assert config["model_type"] == "qwen3_moe"
+    assert config["quantization_config"]["weight_block_size"] == [128, 128]
+    assert 0 < args.layers < config["num_hidden_layers"]
+    original_layers = config["num_hidden_layers"]
+    config["num_hidden_layers"] = args.layers
+    index = json.loads((args.source / "model.safetensors.index.json").read_text())
+    selected = {}
+    for name, shard in index["weight_map"].items():
+        match = re.search(r"\.layers\.(\d+)\.", name)
+        if match is None or int(match[1]) < args.layers:
+            selected.setdefault(shard, []).append(name)
+    args.output.mkdir(parents=True, exist_ok=False)
+    tensors = {}
+    for shard, names in selected.items():
+        with safe_open(str(args.source / shard), framework="pt", device="cpu") as handle:
+            for name in names:
+                tensors[name] = handle.get_tensor(name)
+    changed = [name for name in tensors if ".experts." in name and name.endswith(".down_proj.weight")]
+    assert len(changed) == args.layers * config["num_experts"]
+    for variant in ("a", "b"):
+        target = args.output / variant
+        target.mkdir()
+        for source in args.source.iterdir():
+            if source.is_file() and source.suffix in (".json", ".txt", ".model"):
+                if source.name not in ("config.json", "model.safetensors.index.json"):
+                    shutil.copy2(source, target / source.name)
+        (target / "config.json").write_text(json.dumps(config, indent=2))
+        if variant == "b":
+            for name in changed:
+                value = tensors[name]
+                tensors[name] = (value.float() * 0.5).to(value.dtype)
+        save_file(tensors, str(target / "model.safetensors"))
+    manifest = {"source": str(args.source.resolve()), "original_layers": original_layers,
+                "layers": args.layers, "quantization": config["quantization_config"],
+                "tensor_count": len(tensors), "changed_names": changed,
+                "change": "B halves stored FP8 MoE down_proj weights; scales unchanged"}
+    (args.output / "provenance.json").write_text(json.dumps(manifest, indent=2))
+    print(f"Prepared {args.layers} layers, {len(tensors)} tensors; B changes {len(changed)} MoE weights", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rl/run_reduced_moe_day0.py
+++ b/examples/rl/run_reduced_moe_day0.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run reduced-model cold/warm/cold validation using the actual day0 publisher."""
+
+import argparse
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoints", type=Path, required=True)
+    parser.add_argument("--kit", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--port", type=int, default=28491)
+    args = parser.parse_args()
+    print(sys.executable, sys.prefix, flush=True)
+    args.output.mkdir(parents=True, exist_ok=False)
+    checkout = Path(__file__).resolve().parents[2]
+    env = dict(os.environ, PYTHONPATH=f"{Path(__file__).parent}:{checkout}",
+               VLLM_SERVER_DEV_MODE="1", VLLM_PLUGINS="", HF_HUB_OFFLINE="1",
+               VLLM_USE_DEEP_GEMM="0", NCCL_DEBUG="INFO", NCCL_SOCKET_IFNAME="lo",
+               VLLM_HOST_IP="127.0.0.1",
+               FLASHINFER_WORKSPACE_BASE=str(checkout / "jit-cuda130"))
+    base = f"http://127.0.0.1:{args.port}"
+    evidence = {}
+
+    def inspect(arm=False):
+        response = requests.post(base + "/collective_rpc", json={
+            "method": "inspect_moe_reload", "args": [arm]}, timeout=120)
+        response.raise_for_status()
+        return response.json()["results"][0]
+
+    def generate():
+        results = []
+        for prompt in ("The capital of France is", "1 + 1 =", "Write a short greeting:"):
+            response = requests.post(base + "/v1/completions", json={
+                "model": "experiment", "prompt": prompt, "temperature": 0,
+                "max_tokens": 16, "logprobs": 5, "seed": 0}, timeout=120)
+            response.raise_for_status()
+            choice = response.json()["choices"][0]
+            results.append({"text": choice["text"], "logprobs": choice["logprobs"]})
+        return results
+
+    for variant in ("a", "b"):
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", args.port))
+        with (args.output / f"server-{variant}.log").open("w") as log:
+            server = subprocess.Popen([
+                sys.executable, "-m", "vllm.entrypoints.openai.api_server",
+                "--model", str(args.checkpoints / variant), "--served-model-name", "experiment",
+                "--port", str(args.port), "--max-model-len", "128", "--enforce-eager",
+                "--gpu-memory-utilization", "0.2", "--kv-cache-memory-bytes", "268435456",
+                "--moe-backend", "flashinfer_cutlass", "--no-enable-flashinfer-autotune",
+                "--worker-extension-cls", "moe_reload_evidence.MoEReloadEvidence",
+                "--weight-transfer-config", '{"backend":"nccl"}',
+            ], env=dict(env, CUDA_VISIBLE_DEVICES="1"), stdout=log, stderr=log,
+                start_new_session=True)
+            try:
+                for _ in range(240):
+                    if server.poll() is not None:
+                        raise RuntimeError(f"Server exited: server-{variant}.log")
+                    try:
+                        if requests.get(base + "/health", timeout=2).ok:
+                            break
+                    except requests.RequestException:
+                        pass
+                    time.sleep(1)
+                else:
+                    raise TimeoutError("Server did not become healthy")
+                evidence[f"cold_{variant}"] = inspect(variant == "a")
+                evidence[f"cold_{variant}_output"] = generate()
+                if variant == "a":
+                    with (args.output / "client.log").open("w") as client_log:
+                        subprocess.run([
+                            sys.executable, str(args.kit / "scripts/vllm_weight_update_client/run_vllm_weight_update.py"),
+                            "--base-url", base, "--model", str(args.checkpoints / "b"),
+                            "--revision", "main", "--checkpoint-path", str(args.checkpoints / "b"),
+                            "--device", "cuda:0", "--output", str(args.output / "update.json"),
+                        ], env=dict(env, CUDA_VISIBLE_DEVICES="2"), stdout=client_log,
+                            stderr=client_log, timeout=600, check=True)
+                    requests.get(base + "/health", timeout=30).raise_for_status()
+                    evidence["warm_b"] = inspect()
+                    evidence["warm_b_output"] = generate()
+            finally:
+                (args.output / "evidence.json").write_text(json.dumps(evidence, indent=2))
+                if server.poll() is None:
+                    os.killpg(server.pid, signal.SIGTERM)
+                    try:
+                        server.wait(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        os.killpg(server.pid, signal.SIGKILL)
+                        server.wait()
+    assert evidence["cold_a"].keys() == evidence["warm_b"].keys() == evidence["cold_b"].keys()
+    changed = False
+    for name, warm in evidence["warm_b"].items():
+        old, cold = evidence["cold_a"][name], evidence["cold_b"][name]
+        for key in ("method", "kernel", "config"):
+            assert warm[key] == old[key]
+        assert warm["tensors"].keys() == cold["tensors"].keys() == old["tensors"].keys()
+        for key, tensor in warm["tensors"].items():
+            assert tensor["id"] == old["tensors"][key]["id"]
+            assert tensor["ptr"] == old["tensors"][key]["ptr"]
+            assert tensor["hash"] == cold["tensors"][key]["hash"]
+            changed |= tensor["hash"] != old["tensors"][key]["hash"]
+    assert changed
+    assert evidence["warm_b_output"] == evidence["cold_b_output"]
+    result = {"status": "PASS", "layers": len(evidence["warm_b"]),
+              "runtime_changed": changed, "warm_matches_cold": True}
+    (args.output / "comparison.json").write_text(json.dumps(result, indent=2))
+    print(json.dumps(result), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -516,6 +516,124 @@ def test_fp8_reloading(
     method.process_weights_after_loading(layer)
 
 
+@pytest.mark.parametrize("activation_scheme", ["dynamic", "static"])
+@pytest.mark.parametrize("width", [16, 17])
+@pytest.mark.parametrize(
+    "shard_case", ["complete", "missing", "duplicate", "overlap", "missing_scale"]
+)
+def test_per_tensor_refresh_without_pwal(
+    default_vllm_config, dist_init, monkeypatch, activation_scheme, width, shard_case
+):
+    """Fused shard scales refresh twice without rebuilding runtime objects."""
+    from unittest.mock import Mock
+
+    from vllm.model_executor.model_loader.reload import (
+        finalize_layerwise_reload,
+        initialize_layerwise_reload,
+        record_metadata_for_reloading,
+    )
+
+    default_vllm_config.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    default_vllm_config.kernel_config.linear_backend = "cutlass"
+
+    def weight_loader(param, loaded_weight, shard_id=None, offset=None):
+        if offset is not None:
+            param.data.narrow(0, offset, loaded_weight.shape[0]).copy_(loaded_weight)
+        elif shard_id is None:
+            default_weight_loader(param, loaded_weight)
+        else:
+            param.data.narrow(0, shard_id * width, width).copy_(loaded_weight)
+
+    with torch.device("cuda:0"):
+        method = Fp8LinearMethod(Fp8Config(True, activation_scheme))
+        layer = torch.nn.Module()
+        layer.quant_method = method
+        method.create_weights(
+            layer,
+            32,
+            [width, width],
+            32,
+            2 * width,
+            torch.bfloat16,
+            weight_loader=weight_loader,
+        )
+        record_metadata_for_reloading(layer)
+        layer.weight.data.fill_(1)
+        layer.weight_scale.data.fill_(1)
+        if activation_scheme == "static":
+            layer.input_scale.data.fill_(1)
+        method.process_weights_after_loading(layer)
+        assert method.supports_selective_reload()
+        originals = dict(layer.named_parameters())
+        pointers = {k: v.data_ptr() for k, v in originals.items()}
+        kernel = method.fp8_linear
+        monkeypatch.setattr(
+            method,
+            "process_weights_after_loading",
+            Mock(side_effect=AssertionError("method PWAL called during reload")),
+        )
+        monkeypatch.setattr(
+            kernel,
+            "process_weights_after_loading",
+            Mock(side_effect=AssertionError("kernel PWAL called during reload")),
+        )
+        for generation in (2, 4):
+            initialize_layerwise_reload(layer)
+            source = torch.full((width, 32), 8, dtype=torch.float8_e4m3fn)
+            values = {
+                "weight_scale": torch.tensor([generation / 2, generation]),
+            }
+            if activation_scheme == "static":
+                values["input_scale"] = torch.tensor([0.5, 2.0])
+            if shard_case == "missing_scale":
+                values.pop("weight_scale")
+            for name, value in values.items():
+                param = getattr(layer, name)
+                param.weight_loader(param, value)
+            param = layer.weight
+            param.weight_loader(param, source, shard_id=0)
+            if shard_case in ("duplicate", "overlap"):
+                before = originals["weight"].float().clone()
+                with pytest.raises(ValueError, match="overlapping shards"):
+                    param.weight_loader(
+                        param,
+                        source,
+                        offset=0 if shard_case == "duplicate" else width // 2,
+                    )
+                torch.testing.assert_close(originals["weight"].float(), before)
+            if shard_case in ("complete", "missing_scale"):
+                param.weight_loader(param, source, shard_id=1)
+            # Runtime is not mutated before FINISH.
+            assert originals["weight_scale"].item() == generation / 2
+            if shard_case != "complete":
+                before = originals["weight"].float().clone()
+                error = (
+                    "requires weight and all scale parameters"
+                    if shard_case == "missing_scale"
+                    else "incomplete shards for weight"
+                )
+                with pytest.raises(ValueError, match=error):
+                    finalize_layerwise_reload(layer, None)
+                torch.testing.assert_close(layer.weight.float(), before, rtol=0, atol=0)
+                assert layer.weight is originals["weight"]
+                break
+            finalize_layerwise_reload(layer, None)
+            method.refresh_derived_state(layer)
+            assert method.fp8_linear is kernel
+            assert layer.weight_scale.item() == generation
+            expected = torch.zeros(layer.weight.shape, dtype=torch.float32)
+            expected[:, :width] = 4
+            expected[:, width : 2 * width] = 8
+            torch.testing.assert_close(layer.weight.float(), expected, rtol=0, atol=0)
+            for name, original in originals.items():
+                assert getattr(layer, name) is original
+                assert original.data_ptr() == pointers[name]
+            if activation_scheme == "static":
+                assert layer.input_scale.item() == 2
+        method.process_weights_after_loading.assert_not_called()
+        kernel.process_weights_after_loading.assert_not_called()
+
+
 def test_kv_cache_scale_sync_to_host_copies():
     """Test device-to-host sync of the k/v quantization scales, for both the
     checkpoint-load and runtime-calc paths that produce them.

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -634,6 +634,444 @@ def test_per_tensor_refresh_without_pwal(
         kernel.process_weights_after_loading.assert_not_called()
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize("fused", [False, True])
+def test_moe_reload_tracker_covers_expert_column_shards(fused):
+    """Expert and fused-column shards are tracked without overlap."""
+    from vllm.model_executor.model_loader.reload.meta import ReloadMoETracker
+
+    target = torch.zeros(2, 8, 4, device="cuda")
+    regions = []
+    with ReloadMoETracker(target, regions):
+        if fused:
+            target[:, :, :2].copy_(torch.ones(2, 8, 2, device="cuda"))
+            with pytest.raises(ValueError, match="Overlapping"):
+                target[:, :, 1:3].copy_(torch.full((2, 8, 2), 9.0, device="cuda"))
+            target[:, :, 2:].copy_(torch.ones(2, 8, 2, device="cuda"))
+            torch.testing.assert_close(target, torch.ones_like(target))
+            return
+        target[0, :, :2].copy_(torch.ones(8, 2, device="cuda"))
+        target[0, :, 2:].copy_(torch.ones(8, 2, device="cuda"))
+        with pytest.raises(ValueError, match="Overlapping"):
+            target[0, :, 1:3].copy_(torch.ones(8, 2, device="cuda"))
+        target[1].copy_(torch.ones(8, 4, device="cuda"))
+    torch.testing.assert_close(target, torch.ones_like(target))
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize("block_quant", [False, True])
+@pytest.mark.parametrize("failure", [None, "layout", "missing_expert", "missing_scale"])
+def test_moe_finish_validates_all_layouts_before_write(
+    monkeypatch, block_quant, failure
+):
+    """FINISH counts expert rectangles and validates every target before copying."""
+    from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+
+    method = object.__new__(Fp8MoEMethod)
+    method.quant_config = SimpleNamespace(activation_scheme="dynamic")
+    method.weight_scale_name = "weight_scale_inv" if block_quant else "weight_scale"
+    names = (
+        "w13_weight",
+        "w2_weight",
+        f"w13_{method.weight_scale_name}",
+        f"w2_{method.weight_scale_name}",
+    )
+    shapes = (
+        (2, 8, 4),
+        (2, 4, 4),
+        (2, 2, 1) if block_quant else (2, 2),
+        (2, 1, 1) if block_quant else (2,),
+    )
+    layer = torch.nn.Module()
+    staging, regions = {}, {}
+    for name, shape in zip(names, shapes):
+        layer.register_parameter(
+            name,
+            torch.nn.Parameter(torch.zeros(shape, device="cuda"), requires_grad=False),
+        )
+        staging[name] = torch.ones(shape, device="cuda")
+        regions[name] = (
+            [(e, 0, shape[1], 0, shape[2]) for e in range(shape[0])]
+            if len(shape) == 3
+            else [(0, staging[name].numel())]
+        )
+    layer._fp8_moe_reload_staging = staging
+    layer._fp8_moe_reload_regions = regions
+    original = dict(layer.named_parameters())
+    pointers = {name: value.data_ptr() for name, value in original.items()}
+    if failure == "missing_expert":
+        regions["w13_weight"].pop()
+    elif failure == "missing_scale":
+        staging.pop(names[-1])
+    converted = []
+
+    def convert(runtime_layer, w13, w2, s13, s2, *unused):
+        converted.append(True)
+        w13.add_(1)
+        assert torch.equal(staging["w13_weight"], torch.ones_like(w13))
+        return w13, w2, s13, s2.flatten()[:0] if failure == "layout" else s2
+
+    monkeypatch.setattr(method, "_convert_moe_runtime", convert)
+    if failure:
+        message = {
+            "layout": "runtime layout changed",
+            "missing_expert": "incomplete shards",
+            "missing_scale": "requires all expert weights and scales",
+        }[failure]
+        with pytest.raises(ValueError, match=message):
+            method.refresh_derived_state(layer)
+        assert staging
+        if failure != "layout":
+            assert not converted
+    else:
+        method.refresh_derived_state(layer)
+        method.refresh_derived_state(layer)
+        assert not staging and not regions
+    for name, value in original.items():
+        assert getattr(layer, name) is value and value.data_ptr() == pointers[name]
+        expected = 0 if failure else (2 if name == "w13_weight" else 1)
+        torch.testing.assert_close(value, torch.full_like(value, expected))
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+def test_moe_finish_refreshes_kernel_owned_scales(monkeypatch):
+    """Refresh alpha and reciprocal storage retained by the CUTLASS kernel."""
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+    from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+
+    method = object.__new__(Fp8MoEMethod)
+    method.block_quant = False
+    method.weight_scale_name = "weight_scale"
+    method.fp8_backend = Fp8MoeBackend.FLASHINFER_CUTLASS
+    method.quant_config = SimpleNamespace(activation_scheme="static")
+    layer = torch.nn.Module()
+    names = (
+        "w13_weight",
+        "w2_weight",
+        "w13_weight_scale",
+        "w2_weight_scale",
+        "w13_input_scale",
+        "w2_input_scale",
+    )
+    for name in names:
+        shape = () if "input_scale" in name else (2,)
+        layer.register_parameter(
+            name,
+            torch.nn.Parameter(torch.ones(shape, device="cuda"), requires_grad=False),
+        )
+    method.moe_quant_config = SimpleNamespace(
+        g1_alphas=torch.ones(2, device="cuda"),
+        g2_alphas=torch.ones(2, device="cuda"),
+        a1_gscale=torch.ones((), device="cuda"),
+        a2_gscale=torch.ones((), device="cuda"),
+    )
+    config = method.moe_quant_config
+    original = vars(config).copy()
+    pointers = {name: value.data_ptr() for name, value in original.items()}
+    monkeypatch.setattr(
+        method,
+        "_convert_moe_runtime",
+        lambda layer, w13, w2, s13, s2, *unused: (w13, w2, s13, s2),
+    )
+    for scale in (2.0, 4.0):
+        layer._fp8_moe_reload_staging = {
+            name: torch.full((2,), scale, device="cuda") for name in names
+        }
+        layer._fp8_moe_reload_regions = {name: [(0, 2)] for name in names}
+        method.refresh_derived_state(layer)
+        method.refresh_derived_state(layer)
+        assert method.moe_quant_config is config
+        for name, value in original.items():
+            assert getattr(config, name) is value
+            assert value.data_ptr() == pointers[name]
+            expected = scale * scale if "alphas" in name else 1 / scale
+            torch.testing.assert_close(value, torch.full_like(value, expected))
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize("block_quant", [False, True])
+def test_moe_finish_runs_flashinfer_cutlass_conversion(block_quant):
+    """Exercise real requantization/W31 conversion, not a conversion substitute."""
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+    from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+
+    method = object.__new__(Fp8MoEMethod)
+    method.block_quant = block_quant
+    method.weight_scale_name = "weight_scale_inv" if block_quant else "weight_scale"
+    method.fp8_backend = Fp8MoeBackend.FLASHINFER_CUTLASS
+    method.quant_config = SimpleNamespace(
+        activation_scheme="dynamic" if block_quant else "static"
+    )
+    method.moe = SimpleNamespace(
+        w13_num_shards=2, is_act_and_mul=True, intermediate_size_per_partition=128
+    )
+    layer = torch.nn.Module()
+    layer.moe_config = method.moe
+    layer.local_num_experts = 2
+    layer.activation = MoEActivation.SILU
+    layer.weight_block_size = [128, 128] if block_quant else None
+    s13, s2 = f"w13_{method.weight_scale_name}", f"w2_{method.weight_scale_name}"
+    with torch.device("cuda"):
+        sources = {
+            "w13_weight": torch.full((2, 256, 128), 8.0, dtype=torch.float8_e4m3fn),
+            "w2_weight": torch.full((2, 128, 128), 8.0, dtype=torch.float8_e4m3fn),
+            s13: torch.tensor([[1.0, 2.0], [1.0, 2.0]]),
+            s2: torch.ones(2),
+        }
+        if block_quant:
+            sources[s13] = sources[s13].unsqueeze(-1)
+            sources[s2] = sources[s2].reshape(2, 1, 1)
+        else:
+            sources.update(w13_input_scale=torch.ones(2), w2_input_scale=torch.ones(2))
+            method.moe_quant_config = SimpleNamespace(
+                g1_alphas=torch.ones(2),
+                g2_alphas=torch.ones(2),
+                a1_gscale=torch.ones(()),
+                a2_gscale=torch.ones(()),
+            )
+        for name, source in sources.items():
+            shape = source.shape
+            if not block_quant and name == s13:
+                shape = (2,)
+            elif "input_scale" in name:
+                shape = ()
+            layer.register_parameter(
+                name,
+                torch.nn.Parameter(
+                    torch.zeros(shape, dtype=source.dtype), requires_grad=False
+                ),
+            )
+    layer._fp8_moe_reload_staging = sources
+    layer._fp8_moe_reload_regions = {
+        name: (
+            [(e, 0, value.shape[1], 0, value.shape[2]) for e in range(2)]
+            if value.ndim == 3
+            else [(0, value.numel())]
+        )
+        for name, value in sources.items()
+    }
+    method.refresh_derived_state(layer)
+    assert layer.moe_config is method.moe
+    assert method.moe.intermediate_size_per_partition == 128
+    expected = torch.full_like(layer.w13_weight.float(), 8.0)
+    if not block_quant:
+        expected[:, 128:] = 4.0
+    torch.testing.assert_close(layer.w13_weight.float(), expected, rtol=0, atol=0)
+    expected_scale = (
+        torch.tensor([[[2.0], [1.0]], [[2.0], [1.0]]], device="cuda")
+        if block_quant
+        else torch.full((2,), 2.0, device="cuda")
+    )
+    torch.testing.assert_close(getattr(layer, s13), expected_scale, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize("block_quant", [False, True])
+def test_moe_checkpoint_staging_uses_routed_experts_loader(block_quant):
+    """Use real expert/TP shard loading while keeping runtime storage unchanged."""
+    import inspect
+
+    from vllm.model_executor.layers.fused_moe import (
+        FusedMoeWeightScaleSupported,
+        RoutedExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+    from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+    from vllm.model_executor.model_loader.reload.meta import to_meta_tensor
+
+    method = object.__new__(Fp8MoEMethod)
+    method.fp8_backend = Fp8MoeBackend.FLASHINFER_CUTLASS
+    method.quant_config = SimpleNamespace(is_checkpoint_fp8_serialized=True)
+    method.weight_scale_refine = None
+    layer = RoutedExperts.__new__(RoutedExperts)
+    torch.nn.Module.__init__(layer)
+    layer.quant_config = None
+    layer.quant_method = method
+    layer.expert_map_manager = SimpleNamespace(map_global_to_local=lambda e: e)
+    layer.moe_config = SimpleNamespace(
+        is_act_and_mul=True, tp_rank=0, moe_parallel_config=SimpleNamespace(tp_size=1)
+    )
+    layer._fp8_moe_reload_staging = {}
+    layer._fp8_moe_reload_regions = {}
+    loader = layer.weight_loader
+    with torch.device("cuda"):
+        for name, shape, shard_shape in (
+            ("w13_weight", (2, 256, 128), (128, 128)),
+            ("w2_weight", (2, 128, 128), (128, 128)),
+            (
+                "w13_weight_scale_inv" if block_quant else "w13_weight_scale",
+                (2, 2, 1) if block_quant else (2, 2),
+                (1, 1) if block_quant else (),
+            ),
+            (
+                "w2_weight_scale_inv" if block_quant else "w2_weight_scale",
+                (2, 1, 1) if block_quant else (2,),
+                (1, 1) if block_quant else (),
+            ),
+        ):
+            target = torch.nn.Parameter(torch.zeros(shape), requires_grad=False)
+            target.quant_method = (
+                FusedMoeWeightScaleSupported.BLOCK.value
+                if block_quant
+                else FusedMoeWeightScaleSupported.TENSOR.value
+            )
+            metadata = to_meta_tensor(target)
+            for expert in range(2):
+                for shard in ("w1", "w3") if name.startswith("w13") else ("w2",):
+                    args = inspect.signature(loader).bind(
+                        metadata, torch.ones(shard_shape), name, shard, expert
+                    )
+                    args.apply_defaults()
+                    assert method.reload_parameter(layer, name, target, args, loader)
+            torch.testing.assert_close(target, torch.zeros_like(target))
+            staged = layer._fp8_moe_reload_staging[name]
+            torch.testing.assert_close(staged, torch.ones_like(staged))
+        if not block_quant:
+            target = torch.nn.Parameter(torch.zeros(2), requires_grad=False)
+            metadata = to_meta_tensor(target)
+            for expert in range(2):
+                for shard in ("w1", "w3"):
+                    args = inspect.signature(loader).bind(
+                        metadata, torch.tensor(2.0), "w13_input_scale", shard, expert
+                    )
+                    args.apply_defaults()
+                    assert method.reload_parameter(
+                        layer, "w13_input_scale", target, args, loader
+                    )
+            with pytest.raises(ValueError, match="Duplicate"):
+                method.reload_parameter(layer, "w13_input_scale", target, args, loader)
+            assert layer._fp8_moe_reload_regions["w13_input_scale"] == [(0, 1), (1, 2)]
+            torch.testing.assert_close(target, torch.zeros_like(target))
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "block_quant,intermediate_size", [(False, 256), (False, 257), (True, 256)]
+)
+def test_moe_cutlass_reload_lifecycle(
+    default_vllm_config,
+    dist_init,
+    workspace_init,
+    monkeypatch,
+    block_quant,
+    intermediate_size,
+):
+    """Cold and warm CUTLASS executions agree after real expert-loader reload."""
+    from vllm.model_executor.model_loader.reload import (
+        finalize_layerwise_reload,
+        initialize_layerwise_reload,
+        record_metadata_for_reloading,
+    )
+
+    default_vllm_config.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    default_vllm_config.kernel_config.moe_backend = "flashinfer_cutlass"
+    config = Fp8Config(
+        True,
+        "dynamic" if block_quant else "static",
+        weight_block_size=[128, 128] if block_quant else None,
+    )
+
+    def cold(generation):
+        with torch.device("cuda"):
+            runner = FusedMoEFactory(
+                4,
+                2,
+                256,
+                intermediate_size,
+                params_dtype=torch.bfloat16,
+                quant_config=config,
+                prefix=f"cold_{generation}",
+            )
+            layer = runner.routed_experts
+            method = layer.quant_method
+            record_metadata_for_reloading(layer)
+            sources = {}
+            for name, param in layer.named_parameters(recurse=False):
+                value = 0.125 * generation if "scale" in name else 0.25 * generation
+                sources[name] = torch.full_like(param, value)
+                param.data.copy_(sources[name])
+            method.process_weights_after_loading(layer)
+        return runner, layer, method, sources
+
+    runner, layer, method, _ = cold(1)
+    reference_runner, reference, reference_method, sources = cold(2)
+    originals = dict(layer.named_parameters(recurse=False))
+    pointers = {name: p.data_ptr() for name, p in originals.items()}
+    kernel = method.moe_kernel
+    quant_state = method.moe_quant_config
+    derived = {
+        name: getattr(quant_state, name)
+        for name in ("a1_gscale", "a2_gscale", "g1_alphas", "g2_alphas")
+        if getattr(quant_state, name) is not None
+    }
+    derived_pointers = {name: value.data_ptr() for name, value in derived.items()}
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("Reload must not rerun PWAL or rebuild the MoE kernel")
+
+    monkeypatch.setattr(method, "process_weights_after_loading", forbidden)
+    monkeypatch.setattr(method, "_install_moe_kernel", forbidden)
+    monkeypatch.setattr(method, "_prepare_moe_runtime", forbidden)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.make_fp8_moe_kernel", forbidden
+    )
+    for _ in range(2):
+        before = {name: value.detach().clone() for name, value in originals.items()}
+        initialize_layerwise_reload(layer)
+        for name, value in sources.items():
+            param = getattr(layer, name)
+            for expert in range(4):
+                for shard in ("w1", "w3") if name.startswith("w13") else ("w2",):
+                    incoming = value[expert]
+                    if name.startswith("w13") and "input_scale" not in name:
+                        incoming = incoming.chunk(2, dim=0)[shard == "w3"]
+                    param.weight_loader(param, incoming, name, shard, expert)
+        for name, original in originals.items():
+            torch.testing.assert_close(
+                original.float(), before[name].float(), rtol=0, atol=0
+            )
+        finalize_layerwise_reload(layer, default_vllm_config.model_config)
+        method.refresh_derived_state(layer)
+    assert method.moe_kernel is kernel
+    assert method.moe_quant_config is quant_state
+    for name, original in derived.items():
+        assert getattr(quant_state, name) is original
+        assert original.data_ptr() == derived_pointers[name]
+        torch.testing.assert_close(
+            original, getattr(reference_method.moe_quant_config, name), rtol=0, atol=0
+        )
+    for name, original in originals.items():
+        assert (
+            getattr(layer, name) is original and original.data_ptr() == pointers[name]
+        )
+        torch.testing.assert_close(
+            original.float(), getattr(reference, name).float(), rtol=0, atol=0
+        )
+    x = torch.full((4, 256), 0.125, device="cuda", dtype=torch.bfloat16)
+    ids = torch.tensor(
+        [[0, 1], [1, 2], [2, 3], [3, 0]], device="cuda", dtype=torch.int32
+    )
+    weights = torch.full((4, 2), 0.5, device="cuda")
+
+    def run(target, quant):
+        return quant.moe_kernel.apply(
+            x.clone(),
+            target.w13_weight,
+            target.w2_weight,
+            weights,
+            ids,
+            activation=target.activation,
+            global_num_experts=4,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+        )
+
+    torch.testing.assert_close(
+        run(layer, method), run(reference, reference_method), rtol=0, atol=0
+    )
+
+
 def test_kv_cache_scale_sync_to_host_copies():
     """Test device-to-host sync of the k/v quantization scales, for both the
     checkpoint-load and runtime-calc paths that produce them.

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -71,6 +71,31 @@ class QuantizeMethodBase(ABC):
         """
         return
 
+    def supports_selective_reload(self) -> bool:
+        """Whether this method supports in-place selective weight reload."""
+        return False
+
+    def restore_weights_before_loading(self, layer: nn.Module) -> None:
+        """Restore runtime storage to checkpoint layout before an update."""
+        return
+
+    def reload_parameter(self, layer, parameter_name, target, bound_args, loader):
+        """Optionally consume one reload parameter directly into runtime storage."""
+        return False
+
+    def refresh_derived_state(
+        self,
+        layer: nn.Module,
+        updated_parameter_names: frozenset[str] | None = None,
+    ) -> None:
+        """Refresh derived runtime state in-place after a weight update.
+
+        Implementations must preserve storage identity and be safe to call
+        repeatedly. The default is intentionally fail-closed: methods must
+        opt in explicitly before a selective reload dispatcher uses them.
+        """
+        return
+
 
 def method_has_implemented_embedding(method_class: type[QuantizeMethodBase]) -> bool:
     """

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -413,6 +413,97 @@ class Fp8LinearMethod(LinearMethodBase):
 
         self.fp8_linear.process_weights_after_loading(layer)
 
+    def supports_selective_reload(self) -> bool:
+        """Only the audited tensor-scaled CUTLASS layout is supported."""
+        return (
+            self.quant_config.is_checkpoint_fp8_serialized
+            and not self.block_quant
+            and type(getattr(self, "fp8_linear", None))
+            is CutlassFP8ScaledMMLinearKernel
+        )
+
+    def restore_weights_before_loading(self, layer: torch.nn.Module) -> None:
+        if self.supports_selective_reload():
+            layer._fp8_reload_staging = {}
+            layer._fp8_reload_regions = {}
+
+    def reload_parameter(self, layer, parameter_name, target, bound_args, loader):
+        if not self.supports_selective_reload():
+            return False
+        from vllm.model_executor.model_loader.reload.meta import (
+            ReloadCopyTracker,
+            materialize_meta_tensor,
+        )
+
+        staging = layer._fp8_reload_staging
+        if parameter_name not in staging:
+            with torch.device(target.device):
+                staging[parameter_name] = materialize_meta_tensor(
+                    bound_args.arguments["param"]
+                )
+        source = staging[parameter_name]
+        incoming = bound_args.arguments.get("loaded_weight")
+        if incoming is not None and incoming.dtype != source.dtype:
+            raise ValueError("Serialized FP8 reload requires checkpoint tensor dtype")
+        bound_args.arguments["param"] = source
+        regions = layer._fp8_reload_regions.setdefault(parameter_name, [])
+        with ReloadCopyTracker(source, regions):
+            loader(*bound_args.args, **bound_args.kwargs)
+        return True
+
+    def refresh_derived_state(
+        self,
+        layer: torch.nn.Module,
+        updated_parameter_names: frozenset[str] | None = None,
+    ) -> None:
+        """Merge staged shard scales and copy into existing CUTLASS storage."""
+        staging = getattr(layer, "_fp8_reload_staging", None)
+        if not staging:
+            return
+        required = {"weight", "weight_scale"}
+        if self.act_q_static:
+            required.add("input_scale")
+        if not required.issubset(staging):
+            raise ValueError("FP8 reload requires weight and all scale parameters")
+        regions = layer._fp8_reload_regions
+        for name, value in staging.items():
+            if (
+                sum(end - start for start, end in regions.get(name, []))
+                != value.numel()
+            ):
+                raise ValueError(f"FP8 reload has incomplete shards for {name}")
+        # The conversion may requantize its input in-place. Keep canonical
+        # staging intact until every destination has been validated and copied.
+        weight, scale, input_scale = process_fp8_weight_tensor_strategy(
+            staging["weight"].clone(),
+            staging["weight_scale"].clone(),
+            layer.logical_widths,
+            staging.get("input_scale"),
+        )
+        weight = weight.t()
+        pad_k = layer.weight.shape[0] - weight.shape[0]
+        pad_n = layer.weight.shape[1] - weight.shape[1]
+        if pad_k < 0 or pad_n < 0:
+            raise ValueError("FP8 reload changed runtime weight shape")
+        if pad_k or pad_n:
+            weight = torch.nn.functional.pad(
+                weight.t().contiguous(), (0, pad_k, 0, pad_n)
+            ).t()
+        values = {"weight": weight, "weight_scale": scale}
+        if self.act_q_static:
+            assert input_scale is not None
+            values["input_scale"] = input_scale.max()
+        values.update({k: v for k, v in staging.items() if k not in required})
+        for name, value in values.items():
+            target = getattr(layer, name)
+            if target.shape != value.shape or target.dtype != value.dtype:
+                raise ValueError(f"FP8 reload changed runtime layout for {name}")
+        with torch.no_grad():
+            for name, value in values.items():
+                getattr(layer, name).copy_(value)
+        staging.clear()
+        regions.clear()
+
     def apply(
         self,
         layer: torch.nn.Module,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+    Fp8MoeBackend,
     convert_to_fp8_moe_kernel_format,
     make_fp8_moe_kernel,
     make_fp8_moe_quant_config,
@@ -785,8 +786,65 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         w13_input_scale: torch.Tensor | None,
         w2_input_scale: torch.Tensor | None,
     ) -> None:
-        # Shuffle weights to runtime format.
-        w13, w2, w13_scale, w2_scale = convert_to_fp8_moe_kernel_format(
+        if self.supports_selective_reload():
+            self._prepare_moe_runtime(layer, w13, w2, w13_scale, w2_scale)
+        w13, w2, w13_scale, w2_scale = self._convert_moe_runtime(
+            layer=layer,
+            w13=w13,
+            w2=w2,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
+            w13_input_scale=w13_input_scale,
+            w2_input_scale=w2_input_scale,
+        )
+
+        self._install_moe_kernel(layer, w13, w2, w13_scale, w2_scale)
+
+    def _prepare_moe_runtime(self, layer, w13, w2, w13_scale, w2_scale) -> None:
+        """Allocate final weight/scale storage using source metadata only."""
+        w13_shape, w2_shape = list(w13.shape), list(w2.shape)
+        scale_shape = w13_scale.shape
+        if not self.block_quant:
+            alignment = 16 if layer.activation.is_gated else 128
+            intermediate = w2_shape[-1]
+            padded = (intermediate + alignment - 1) // alignment * alignment
+            w13_shape[-2] = padded * self.moe.w13_num_shards
+            w2_shape[-1] = padded
+            scale_shape = (w13_scale.shape[0],)
+        for name, shape, source in (
+            ("w13_weight", w13_shape, w13),
+            ("w2_weight", w2_shape, w2),
+            (f"w13_{self.weight_scale_name}", scale_shape, w13_scale),
+            (f"w2_{self.weight_scale_name}", w2_scale.shape, w2_scale),
+        ):
+            layer.register_parameter(
+                name,
+                torch.nn.Parameter(
+                    torch.empty(shape, dtype=source.dtype, device=source.device),
+                    requires_grad=False,
+                ),
+            )
+
+    def _convert_moe_runtime(
+        self,
+        layer: RoutedExperts,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        w13_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        w13_input_scale: torch.Tensor | None = None,
+        w2_input_scale: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Convert source-layout expert tensors without changing layer state."""
+        if not self.block_quant:
+            w13, w13_scale = process_fp8_weight_tensor_strategy_moe(
+                w13,
+                w13_scale,
+                w13.shape[1] // self.moe.w13_num_shards,
+                layer.local_num_experts,
+                is_act_and_mul=self.moe.is_act_and_mul,
+            )
+        return convert_to_fp8_moe_kernel_format(
             fp8_backend=self.fp8_backend,
             layer=layer,
             w13=w13,
@@ -797,12 +855,27 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             w2_input_scale=w2_input_scale,
         )
 
-        # Replace parameters with updated versions. Note that this helper
-        # function ensures the replacement is compatible with RL weight reloads.
-        replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, f"w13_{self.weight_scale_name}", w13_scale)
-        replace_parameter(layer, f"w2_{self.weight_scale_name}", w2_scale)
+    def _install_moe_kernel(
+        self, layer: RoutedExperts, w13, w2, w13_scale, w2_scale
+    ) -> None:
+        """Install cold-load runtime tensors and construct the kernel once."""
+        values = {
+            "w13_weight": w13,
+            "w2_weight": w2,
+            f"w13_{self.weight_scale_name}": w13_scale,
+            f"w2_{self.weight_scale_name}": w2_scale,
+        }
+        if self.supports_selective_reload():
+            for name, value in values.items():
+                target = getattr(layer, name)
+                if target.shape != value.shape or target.dtype != value.dtype:
+                    raise ValueError(f"FP8 MoE cold runtime layout mismatch: {name}")
+            with torch.no_grad():
+                for name, value in values.items():
+                    getattr(layer, name).copy_(value)
+        else:
+            for name, value in values.items():
+                replace_parameter(layer, name, value)
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.moe_quant_config is not None
@@ -816,6 +889,25 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        if self.supports_selective_reload():
+            layer._fp8_moe_source_metadata = {
+                name: (
+                    getattr(layer, name).shape,
+                    getattr(layer, name).dtype,
+                    dict(getattr(layer, name).__dict__),
+                )
+                for name in (
+                    "w13_weight",
+                    "w2_weight",
+                    f"w13_{self.weight_scale_name}",
+                    f"w2_{self.weight_scale_name}",
+                    "w13_input_scale",
+                    "w2_input_scale",
+                    "w13_bias",
+                    "w2_bias",
+                )
+                if hasattr(layer, name) and getattr(layer, name) is not None
+            }
         # Allow for accessing weights and scales in standard way.
         w13 = layer.w13_weight
         w2 = layer.w2_weight
@@ -849,22 +941,181 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             replace_parameter(layer, "w13_input_scale", w13_input_scale)
             replace_parameter(layer, "w2_input_scale", w2_input_scale)
 
-        # Per tensor kernels require single weight scale for w13 per expert, but
-        # on disk there is a scale for w1 and w3. Use the max to requantize.
-        if not self.block_quant:
-            shard_size = layer.intermediate_size_per_partition
-            w13, w13_scale = process_fp8_weight_tensor_strategy_moe(
-                w13,
-                w13_scale,
-                shard_size,
-                layer.local_num_experts,
-                is_act_and_mul=self.moe.is_act_and_mul,
-            )
-
         # Shuffle weights to runtime format and setup kernel.
         self._setup_kernel(
             layer, w13, w2, w13_scale, w2_scale, w13_input_scale, w2_input_scale
         )
+
+    def supports_selective_reload(self) -> bool:
+        """Enable staged reload for the FlashInfer CUTLASS FP8 MoE backend."""
+        parallel = getattr(getattr(self, "moe", None), "moe_parallel_config", None)
+        return (
+            self.quant_config.is_checkpoint_fp8_serialized
+            and self.fp8_backend == Fp8MoeBackend.FLASHINFER_CUTLASS
+            and not getattr(parallel, "enable_eplb", False)
+        )
+
+    def restore_weights_before_loading(self, layer: RoutedExperts) -> None:
+        if self.supports_selective_reload():
+            layer._fp8_moe_reload_staging = {}
+            layer._fp8_moe_reload_regions = {}
+            layer._fp8_moe_input_aliases = set()
+            for name, (shape, dtype, attrs) in layer._fp8_moe_source_metadata.items():
+                if not hasattr(layer, name):
+                    continue
+                parameter = torch.nn.Parameter(
+                    torch.empty(shape, dtype=dtype, device="meta"),
+                    requires_grad=False,
+                )
+                parameter.__dict__.update(attrs)
+                layer._parameters[name] = parameter
+
+    def reload_parameter(self, layer, parameter_name, target, bound_args, loader):
+        if not self.supports_selective_reload():
+            return False
+        from vllm.model_executor.model_loader.reload.meta import (
+            ReloadCopyTracker,
+            ReloadMoETracker,
+            materialize_meta_tensor,
+        )
+
+        staging = layer._fp8_moe_reload_staging
+        if parameter_name not in staging:
+            with torch.device(target.device):
+                staging[parameter_name] = materialize_meta_tensor(
+                    bound_args.arguments["param"]
+                )
+        source = staging[parameter_name]
+        incoming = bound_args.arguments.get("loaded_weight")
+        if incoming is not None and incoming.dtype != source.dtype:
+            raise ValueError("FP8 MoE reload checkpoint dtype changed")
+        bound_args.arguments["param"] = source
+        regions = layer._fp8_moe_reload_regions.setdefault(parameter_name, [])
+        if parameter_name == "w13_input_scale":
+            shard = bound_args.arguments.get("shard_id")
+            expert = layer._map_global_expert_id_to_local_expert_id(
+                bound_args.arguments["expert_id"]
+            )
+            if expert >= 0 and shard in ("w1", "w3"):
+                aliases = getattr(layer, "_fp8_moe_input_aliases", None)
+                if aliases is None:
+                    aliases = layer._fp8_moe_input_aliases = set()
+                key = (expert, shard)
+                if key in aliases:
+                    raise ValueError("Duplicate FP8 MoE activation-scale shard")
+                other = (expert, "w3" if shard == "w1" else "w1")
+                if other in aliases:
+                    if incoming is None or not torch.equal(
+                        source[expert], incoming.to(source.device).reshape(())
+                    ):
+                        raise ValueError("FP8 MoE w1/w3 activation scales must match")
+                    aliases.add(key)
+                    return True
+                aliases.add(key)
+        tracker = (
+            ReloadMoETracker(source, regions)
+            if source.ndim == 3
+            else ReloadCopyTracker(source, regions)
+        )
+        with tracker:
+            loader(*bound_args.args, **bound_args.kwargs)
+        return True
+
+    def refresh_derived_state(self, layer: RoutedExperts, updated_parameter_names=None):
+        del updated_parameter_names
+        staging = getattr(layer, "_fp8_moe_reload_staging", None)
+        if not staging:
+            return
+        required = {
+            "w13_weight",
+            "w2_weight",
+            f"w13_{self.weight_scale_name}",
+            f"w2_{self.weight_scale_name}",
+        }
+        if self.quant_config.activation_scheme == "static":
+            required.update(("w13_input_scale", "w2_input_scale"))
+        if not required.issubset(staging):
+            raise ValueError("FP8 MoE reload requires all expert weights and scales")
+        for name, value in staging.items():
+            regions = layer._fp8_moe_reload_regions.get(name, [])
+            covered = (
+                sum((r1 - r0) * (c1 - c0) for _, r0, r1, c0, c1 in regions)
+                if value.ndim == 3
+                else sum(end - start for start, end in regions)
+            )
+            if covered != value.numel():
+                raise ValueError(f"FP8 MoE reload has incomplete shards for {name}")
+        from copy import copy
+
+        conversion_layer = copy(layer)
+        if hasattr(layer, "moe_config"):
+            conversion_layer.moe_config = copy(layer.moe_config)
+        values = self._convert_moe_runtime(
+            conversion_layer,
+            staging["w13_weight"].clone(),
+            staging["w2_weight"].clone(),
+            staging[f"w13_{self.weight_scale_name}"].clone(),
+            staging[f"w2_{self.weight_scale_name}"].clone(),
+            staging.get("w13_input_scale"),
+            staging.get("w2_input_scale"),
+        )
+        names = (
+            "w13_weight",
+            "w2_weight",
+            f"w13_{self.weight_scale_name}",
+            f"w2_{self.weight_scale_name}",
+        )
+        updates = dict(zip(names, values))
+        for name in ("w13_bias", "w2_bias"):
+            if name in staging:
+                updates[name] = staging[name]
+        for name in ("w13_input_scale", "w2_input_scale"):
+            if name in staging:
+                updates[name] = staging[name].max()
+        derived_updates = []
+        if (
+            getattr(self, "fp8_backend", None) == Fp8MoeBackend.FLASHINFER_CUTLASS
+            and not self.block_quant
+        ):
+            config = self.moe_quant_config
+            for index, prefix in ((1, "w13"), (2, "w2")):
+                activation_scale = updates[f"{prefix}_input_scale"]
+                weight_scale = updates[f"{prefix}_{self.weight_scale_name}"]
+                derived_updates.extend(
+                    (
+                        (
+                            getattr(config, f"g{index}_alphas"),
+                            weight_scale * activation_scale,
+                        ),
+                        (
+                            getattr(config, f"a{index}_gscale"),
+                            activation_scale.reciprocal(),
+                        ),
+                    )
+                )
+        for name, value in updates.items():
+            target = getattr(layer, name)
+            if (
+                target.shape != value.shape
+                or target.dtype != value.dtype
+                or target.device != value.device
+            ):
+                raise ValueError(f"FP8 MoE runtime layout changed for {name}")
+        for target, value in derived_updates:
+            if (
+                target is None
+                or target.shape != value.shape
+                or target.dtype != value.dtype
+                or target.device != value.device
+            ):
+                raise ValueError("FP8 MoE derived scale layout changed")
+        with torch.no_grad():
+            for name, value in updates.items():
+                getattr(layer, name).copy_(value)
+            for target, value in derived_updates:
+                target.copy_(value)
+        staging.clear()
+        layer._fp8_moe_reload_regions.clear()
 
     def get_fused_moe_quant_config(self, layer: RoutedExperts) -> FusedMoEQuantConfig:
         w1_scale = getattr(layer, f"w13_{self.weight_scale_name}")

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "finalize_layerwise_reload",
     "set_torchao_reload_attrs",
     "support_quantized_model_reload_from_hp_weights",
+    "refresh_derived_state",
 ]
 
 from .layerwise import (
@@ -36,3 +37,4 @@ from .torchao_decorator import (
     set_torchao_reload_attrs,
     support_quantized_model_reload_from_hp_weights,
 )
+from .selective import refresh_derived_state

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -109,6 +109,12 @@ def initialize_layerwise_reload(model: torch.nn.Module):
 
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
+        # Restore transformed runtime tensors to checkpoint layout before the
+        # incoming loaders materialize this layer. The default hook is a no-op.
+        quant_method = getattr(layer, "quant_method", None)
+        restore = getattr(quant_method, "restore_weights_before_loading", None)
+        if callable(restore):
+            restore(layer)
         # snapshot now: restore_layer_on_meta drops alias buffers from the live set
         info.kernel_non_persistent_buffers = set(layer._non_persistent_buffers_set)
 
@@ -183,6 +189,16 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         bound_args = loader_signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
 
+        quant_method = getattr(layer, "quant_method", None)
+        target = info.kernel_tensors[0].get(param_name) if info.kernel_tensors else None
+        reload_parameter = getattr(quant_method, "reload_parameter", None)
+        if target is not None and callable(reload_parameter):
+            num_loaded, ret = get_numel_loaded(original_loader, bound_args)
+            if reload_parameter(layer, param_name, target, bound_args, original_loader):
+                info.load_numel += num_loaded
+                info.eager_parameter_names.add(param_name)
+                return ret
+
         # Buffer loaded weights, track loading progress
         info.loaded_weights.append((param_name, bound_args))
         num_loaded, ret = get_numel_loaded(original_loader, bound_args)
@@ -217,7 +233,8 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
 
         # Process and copy when all weights are loaded
         if info.load_numel >= info.load_numel_total:  # type: ignore[operator]
-            _layerwise_process(layer, info)
+            if info.loaded_weights:
+                _layerwise_process(layer, info)
             LOADING_LAYERS.discard(layer)
 
         return ret
@@ -225,7 +242,11 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
     return online_process_loader
 
 
-def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelConfig):
+def finalize_layerwise_processing(
+    model: torch.nn.Module,
+    model_config: ModelConfig,
+    updated_parameter_names: frozenset[str] | None = None,
+):
     """
     Apply processing to any layers which were not layerwise processed during loading.
     This includes attention layers and layers which have weight elements which are not
@@ -272,6 +293,8 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         # if the created weight has extra padding elements which are not loaded
         # Having too many of these delayed layers can lead to excess memory usage
         # see Limitations(4)
+        elif info.eager_parameter_names and not info.loaded_weights:
+            _place_kernel_tensors(layer, info)
         elif info.load_numel > 0 and info.load_numel < info.load_numel_total:  # type: ignore[operator]
             logger.debug("%s: Delayed processing", layer.__class__.__name__)
             _layerwise_process(layer, info)
@@ -282,6 +305,12 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
     for layer, info in deferred_attn:
         _finalize_attention_layer(layer, info, model_config)
         info.reset()
+
+    # Opted-in modules defer derived-state work until every checkpoint tensor
+    # has arrived. Unrecognized modules remain on the layerwise fallback path.
+    from .selective import refresh_derived_state
+
+    refresh_derived_state(model, updated_parameter_names)
 
     LOADING_LAYERS.clear()
 
@@ -329,7 +358,11 @@ def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -
     _copy_and_restore_kernel_tensors(layer, info)
 
 
-def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
+def _layerwise_process(
+    layer: torch.nn.Module,
+    info: LayerReloadingInfo,
+    updated_parameter_names: frozenset[str] | None = None,
+):
     """
     Finalize layer loading after all weights have been buffered.
 
@@ -359,13 +392,27 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
 
     # Process weights (quantization, repacking, etc.)
     quant_method = getattr(layer, "quant_method", None)
-    if isinstance(quant_method, QuantizeMethodBase):
+    selective_reload = _supports_selective_reload(layer)
+    if isinstance(quant_method, QuantizeMethodBase) and not selective_reload:
         quant_method.process_weights_after_loading(layer)
         # Re-reconcile parameter TP state: process_weights_after_loading may
         # have re-created Parameters (stamped with the global rank), which would
         # otherwise break replicated (disable_tp) weights on a subsequent reload.
         if hasattr(layer, "update_param_tp_status"):
             layer.update_param_tp_status()
+
+    # Selective methods receive checkpoint-layout parameters in this temporary
+    # layer. They must rebuild runtime-derived state before the transformed
+    # values are copied back to the original storage captured above. This keeps
+    # PWAL on the cold-load path only.
+    if selective_reload:
+        refresh = getattr(quant_method, "refresh_derived_state", None)
+        if refresh is None:
+            raise RuntimeError(
+                f"{type(quant_method).__name__} opted into selective reload "
+                "without refresh_derived_state"
+            )
+        refresh(layer, updated_parameter_names)
 
     # Copy processed values into original tensor storage (preserves cudagraph refs)
     # this code is a no-op if not reloading (because kernel tensors is empty)
@@ -374,6 +421,13 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
 
     info.reset()
     logger.debug("%s: Processed", layer.__class__.__name__)
+
+
+def _supports_selective_reload(layer: torch.nn.Module) -> bool:
+    """Return whether a layer explicitly opts into derived-state refresh."""
+    owner = getattr(layer, "quant_method", None) or layer
+    capability = getattr(owner, "supports_selective_reload", None)
+    return callable(capability) and bool(capability())
 
 
 def _get_original_loader(tensor: torch.Tensor) -> Callable:

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -186,6 +186,62 @@ class ReloadCopyTracker(TorchDispatchMode):
         return func(*args, **(kwargs or {}))
 
 
+class ReloadMoETracker(TorchDispatchMode):
+    """Track non-overlapping expert and column shard copies."""
+
+    def __init__(self, target: torch.Tensor, regions: list[tuple[int, ...]]):
+        super().__init__()
+        self.target = target
+        self.regions = regions
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if func is torch.ops.aten.copy_.default:
+            dest = args[0]
+            if (
+                dest.untyped_storage().data_ptr()
+                == self.target.untyped_storage().data_ptr()
+            ):
+                if (
+                    self.target.ndim != 3
+                    or dest.ndim not in (2, 3)
+                    or dest.stride(-1) != 1
+                ):
+                    raise ValueError("Unsupported FP8 MoE shard layout")
+                width = self.target.shape[-1]
+                plane = self.target.shape[-2] * width
+                offset = dest.storage_offset() - self.target.storage_offset()
+                expert, rem = divmod(offset, plane)
+                row, col = divmod(rem, width)
+                rows, cols = dest.shape[-2:]
+                experts = dest.shape[0] if dest.ndim == 3 else 1
+                if (
+                    dest.stride(-2) != width
+                    or expert < 0
+                    or expert + experts > self.target.shape[0]
+                    or (dest.ndim == 3 and dest.stride(0) != plane)
+                ):
+                    raise ValueError("Unsupported FP8 MoE shard layout")
+                if row + rows > self.target.shape[-2] or col + cols > width:
+                    raise ValueError("FP8 MoE shard exceeds staging parameter")
+                candidates = [
+                    (e, row, row + rows, col, col + cols)
+                    for e in range(expert, expert + experts)
+                ]
+                if any(
+                    expert <= e < expert + experts
+                    and row < r1
+                    and r0 < row + rows
+                    and col < c1
+                    and c0 < col + cols
+                    for e, r0, r1, c0, c1 in self.regions
+                ):
+                    raise ValueError("Overlapping FP8 MoE shards")
+                result = func(*args, **(kwargs or {}))
+                self.regions.extend(candidates)
+                return result
+        return func(*args, **(kwargs or {}))
+
+
 class CopyCounter(TorchDispatchMode):
     """
     Tracks total number of elements modified with `copy_`.

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -154,6 +154,38 @@ def materialize_layer(layer: torch.nn.Module, info: LayerReloadingInfo):
                 setattr(layer, name, materialize_meta_tensor(tensor))
 
 
+class ReloadCopyTracker(TorchDispatchMode):
+    """Track disjoint contiguous writes into one checkpoint staging parameter."""
+
+    def __init__(self, target: torch.Tensor, regions: list[tuple[int, int]]):
+        super().__init__()
+        self.target = target
+        self.regions = regions
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if func is torch.ops.aten.copy_.default:
+            destination = args[0]
+            same_storage = (
+                destination.untyped_storage().data_ptr()
+                == self.target.untyped_storage().data_ptr()
+            )
+            if same_storage:
+                if not destination.is_contiguous():
+                    raise ValueError(
+                        "FP8 reload requires contiguous destination shards"
+                    )
+                start = destination.storage_offset() - self.target.storage_offset()
+                end = start + destination.numel()
+                if start < 0 or end > self.target.numel():
+                    raise ValueError("FP8 reload write exceeds staging parameter")
+                if any(start < stop and begin < end for begin, stop in self.regions):
+                    raise ValueError("FP8 reload has overlapping shards")
+                result = func(*args, **(kwargs or {}))
+                self.regions.append((start, end))
+                return result
+        return func(*args, **(kwargs or {}))
+
+
 class CopyCounter(TorchDispatchMode):
     """
     Tracks total number of elements modified with `copy_`.

--- a/vllm/model_executor/model_loader/reload/selective.py
+++ b/vllm/model_executor/model_loader/reload/selective.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Selective, in-place refresh of runtime-derived weight state."""
+
+from __future__ import annotations
+
+import torch
+
+
+def refresh_derived_state(
+    model: torch.nn.Module,
+    updated_parameter_names: frozenset[str] | None = None,
+) -> None:
+    """Refresh explicitly opted-in modules without rebuilding runtime objects.
+
+    Modules opt in by implementing ``refresh_derived_state`` and exposing a
+    truthy ``supports_selective_reload`` capability on their quantization
+    method. Unrecognized modules are intentionally skipped until they are
+    audited, preserving the existing layerwise fallback.
+    """
+    names = updated_parameter_names
+    for module in model.modules():
+        method = getattr(module, "quant_method", None)
+        module_capability = getattr(module, "supports_selective_reload", None)
+        method_capability = getattr(method, "supports_selective_reload", None)
+        module_opted_in = callable(module_capability) and module_capability()
+        method_opted_in = callable(method_capability) and method_capability()
+        if not (module_opted_in or method_opted_in):
+            continue
+        refresh = getattr(module, "refresh_derived_state", None)
+        if refresh is not None:
+            refresh(names)
+        elif method_opted_in:
+            method.refresh_derived_state(module, names)

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -25,6 +25,7 @@ class LayerReloadingInfo:
 
     # used by `online_process_loader` to buffer args and tensors until ready to load
     loaded_weights: list[tuple[str, BoundArguments]] = field(default_factory=list)
+    eager_parameter_names: set[str] = field(default_factory=set)
 
     # kernel formatted tensors, copied into by `_layerwise_process` when reloading
     kernel_tensors: LayerTensors | None = None


### PR DESCRIPTION
## Summary

This PR adds selective weight reload support for RL training workflows, with staged runtime storage updates for FP8 per-tensor and block-wise weights using the CUTLASS MoE backend. The implementation preserves runtime tensor and kernel addresses during reload and refreshes derived state in place.

The work is related to [RFC #54477](https://github.com/vllm-project/vllm/issues/54477).

## Why this is not a duplicate

The required duplicate-work checks found no open PR whose body references issue 54477. The open-PR search for `selective reload` did not identify an existing PR implementing this FP8 MoE staged reload design. This contribution covers the CUTLASS-backed FP8 per-tensor/block-wise reload path and its end-to-end validation.

## Validation

Focused H200 tests were run in the fixed vLLM environment:

```text
-k moe_cutlass_reload_lifecycle
2 passed, 51 deselected

-k moe_
20 passed, 38 deselected

-k moe_checkpoint_staging
2 passed
```

All reported `h200_ncu status=ok rc=0`.

A reduced two-layer Qwen3 MoE checkpoint was also validated through the NCCL `vllm-day0-kit` flow on H200 (server GPU 1, publisher GPU 2). The native HF checkpoint was passed directly for reload without recomputing or converting its scales:

```json
{
  "status": "PASS",
  "layers": 2,
  "runtime_changed": true,
  "warm_matches_cold": true
}
```

The validation covered START/update/FINISH, NCCL communicator initialization, runtime identity/address stability, and deterministic warm-vs-cold output comparison for the reduced FP8 MoE model.

## AI assistance

AI assistance was used during implementation, test development, and validation. The submitting human must review every changed line and verify the reported tests before merging.



## Detailed design and support matrix

The FP8 MoE load path is split into shell allocation, source-parameter staging, FP8-to-CUTLASS conversion, and in-place copy into existing runtime storage. Reload restores checkpoint metadata/loader attributes, validates all ranges before writes, then refreshes derived and kernel-owned state without replacing Parameters, rebuilding kernels, or changing addresses. This applies to per-tensor and block-wise expert weights; block-wise scales remain 2-D and expert slices support rectangular 3-D coverage.

Validated formats are native HF FP8 per-tensor checkpoints with static activation scales, FP8 block-wise 128x128 checkpoints, and the FlashInfer CUTLASS backend. The reduced two-layer Qwen3 per-tensor checkpoint is a regenerated BF16-derived debugging artifact retaining HF naming/config/index structure. H200 focused suites passed, and NCCL vllm-day0-kit validation passed for two-layer Qwen3 with START/update/FINISH, runtime identity/address checks, and warm-vs-cold matching.

Not tested or supported: dynamic-activation FP8, non-CUTLASS MoE backends, AWQ/Marlin (including AutoAWQMarlinLinearMethod), EPLB-enabled configurations, and arbitrary loader layouts or scale naming conventions.
