### PR TITLE
[Bugfix] Seed hybrid mamba state index with mamba_block_size on prefix-cache hits

### DIFF
--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -118,8 +118,14 @@ class MambaHybridModelState(DefaultModelState):
         self.num_accepted_tokens_gpu[req_index].fill_(1)
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
+            # Mamba state blocks are sized by mamba_block_size, not by
+            # cache_config.block_size: the latter is lowered by EngineCore to
+            # the smallest prefix-cacheable group (e.g. a sliding-window drafter
+            # group with block 64), which would index the mamba block table in
+            # the wrong units and read past the row on a prefix-cache hit.
             self._mamba_state_idx_gpu[req_index].fill_(
-                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
+                (new_req_data.num_computed_tokens - 1)
+                // self.cache_config.mamba_block_size
             )
 
     def _get_mamba_group_info(


### PR DESCRIPTION
## Purpose

Fix an out-of-bounds read on prefix-cache hits for hybrid mamba models whose KV config contains a prefix-cacheable attention group with a block size smaller than `mamba_block_size` (e.g. a DFlash2/EAGLE sliding-window drafter group with block 64).

`MambaHybridModelState.add_request` seeds the running mamba state slot with `(num_computed_tokens - 1) // self.cache_config.block_size`. By then `EngineCore._initialize_kv_caches` has reassigned `cache_config.block_size = min(block_size of prefix-cacheable groups)`, so on GLM-5.3-Flash (KDA + sparse MLA, mamba block 7168, drafter block 64/1024) the seed is in the wrong units. `preprocess_mamba_align_fused_kernel` takes it as `src_col` and `_copy_mamba_state_block` reads `block_table[src_col]` past the row width (`cdiv(max_model_len, mamba_block_size) + num_speculative_blocks`): cached prefixes of ≥ 8 mamba blocks fault (`Xid 31`, `cudaErrorIllegalAddress` at the next sync), shorter hits silently restore the wrong recurrent state.

The fix divides by `cache_config.mamba_block_size`, the unit used for mamba blocks everywhere else (`MambaSpec.block_size`, the preprocess kernel, the block-table width; `mamba_attn.py` already derives the same quantity from `kv_cache_spec.block_size`).

Fixes #55600.

## Test Plan

No unit test is included; the failure needs a hybrid model whose KV groups include a smaller-block prefix-cacheable group. Manual verification on GLM-5.3-Flash (EXL3, TP=1, DFlash2 `num_speculative_tokens=5`, `--enable-prefix-caching`, `max_num_seqs=1`) on a DGX Spark, before/after on identical inputs.

## Test Result

- Prompt A = 57 344 tokens (8 full mamba blocks), then A + a different question: before → HTTP 500 in 0.2 s, `NVRM: Xid 31 ... FAULT_PDE ACCESS_TYPE_VIRT_READ`; after → completes in 11.7 s with 50 176 cached tokens.
- After: 13-, 34- and 63-block prefix hits complete; multi-needle recall on warm (cached) requests equals cold at 100k / 250k / 450k tokens (5/5 each); warm TTFT 8.7 s vs 139 s cold at 100k.
- 3-hour soak (57 multi-turn conversation turns with a prefix hit on every turn, contexts up to 184k tokens, fresh 41k–354k-token prompts): 133/133 requests OK, zero faults.
