### PR TITLE
[Bugfix] Avoid nested rerank cancellation handlers

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_api_router.py
+++ b/tests/entrypoints/pooling/scoring/test_api_router.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.entrypoints.pooling.scoring.api_router import (
+    do_rerank_v1,
+    do_rerank_v2,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize("alias", [do_rerank_v1, do_rerank_v2])
+async def test_rerank_alias_uses_one_disconnect_listener(alias):
+    disconnect = asyncio.Event()
+    handler_started = asyncio.Event()
+    handler_cancelled = asyncio.Event()
+    receive_calls = 0
+
+    async def receive():
+        nonlocal receive_calls
+        receive_calls += 1
+        await disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def handler(request, raw_request):
+        handler_started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            handler_cancelled.set()
+            raise
+
+    state = SimpleNamespace(
+        enable_server_load_tracking=True,
+        server_load_metrics=0,
+        serving_scores=handler,
+    )
+    raw_request = SimpleNamespace(
+        app=SimpleNamespace(state=state),
+        receive=receive,
+    )
+
+    route_task = asyncio.create_task(alias(None, raw_request))
+    await asyncio.wait_for(handler_started.wait(), timeout=1)
+    disconnect.set()
+    assert await asyncio.wait_for(route_task, timeout=1) is None
+    await asyncio.wait_for(handler_cancelled.wait(), timeout=1)
+
+    assert receive_calls == 1
+    assert state.server_load_metrics == 0

--- a/vllm/entrypoints/pooling/scoring/api_router.py
+++ b/vllm/entrypoints/pooling/scoring/api_router.py
@@ -91,7 +91,6 @@ async def do_rerank(request: RerankRequest, raw_request: Request):
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
     },
 )
-@with_cancellation
 async def do_rerank_v1(request: RerankRequest, raw_request: Request):
     logger.warning_once(
         "To indicate that the rerank API is not part of the standard OpenAI"
@@ -110,6 +109,5 @@ async def do_rerank_v1(request: RerankRequest, raw_request: Request):
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
     },
 )
-@with_cancellation
 async def do_rerank_v2(request: RerankRequest, raw_request: Request):
     return await do_rerank(request, raw_request)


### PR DESCRIPTION
## Summary

The `/v1/rerank` and `/v2/rerank` aliases passed the same request to the already decorated `/rerank` handler. That created two concurrent consumers of `raw_request.receive()` and could leave the real rerank handler running after disconnect.

This removes the redundant outer cancellation decorators. Each alias now relies on the canonical `/rerank` handler, so every request has one disconnect listener.

I checked issue #55502 and searched open PRs for the issue number and rerank cancellation before updating this. I found no duplicate.

## Testing

- Targeted pytest for `tests/entrypoints/pooling/scoring/test_api_router.py`: 2 passed
- Pre-commit hooks for the affected files: all passed
- The regression fails for both aliases with the old nested decorators and passes after this change

No model evaluation was run because this only removes duplicate request-disconnect listeners and does not affect model output.

AI assistance was used to help investigate, implement, test, and review this change.

Fixes #55502
