### PR TITLE
[CI] Synchronize shared offload unlink test before observing pathname

### DIFF
--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -204,6 +204,8 @@ def _mp_barrier_construct_and_hold(
             cpu_page_size=PAGE_SIZE,
             barrier=lambda: barrier.wait(30),
         )
+        # The constructor's barrier precedes the creator's unlink.
+        barrier.wait(30)
         t = region.create_next_worker_view(PAGE_SIZE)
         t[:, :] = fill_value
         done_queue.put(


### PR DESCRIPTION
The V1 Core KV Offload lane failed in [build 87386](https://buildkite.com/vllm/ci/builds/87386#01a0712c-28d0-459e-b0d5-078b04ad1f61) because `test_mp_barrier_unlinks_file_and_survives_sigkill` observed the mmap pathname before its creator unlinked it. The constructor's barrier synchronizes mapping, then the creator unlinks; a peer may return and inspect the pathname while that unlink is still pending.

Synchronize the test workers again after construction, before reporting the pathname state. Keep the existing assertions for a shared inode, pathname removal, and mappings surviving until SIGKILL. Production behavior is unchanged.

Duplicate checks: searched open PRs for `shared_offload_region` and `unlink barrier`. #53073 changes creator ownership, #54619 reaps orphaned regions, and #51317 changes region reclamation. Their changes do not provide this post-constructor synchronization in the existing test.

Validation on Linux, public main commit `6865e67f0b` plus this patch:
- `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest -q tests/v1/kv_offload/cpu/test_shared_offload_region.py`: **40 passed**.
- Deterministic reproduction, using a temporary test-only 0.5-second delay in `os.unlink`: the original test failed its pathname assertion; the patched test passed with the same delay. The delay was removed afterward and is not part of this change.
- `pre-commit run --files tests/v1/kv_offload/cpu/test_shared_offload_region.py`: all applicable hooks passed.

CI follow-up: in [build 87454](https://buildkite.com/vllm/ci/builds/87454#01a0780d-a209-4946-ad1e-8c837811a4d4) on head `08e1e2f78c`, the `tests/v1/kv_offload` suite passed **570 tests, 1 skipped**, including the previously failing test. The broader V1 Core + KV + Metrics job continues with other suites, so this is not a claim that the whole build has passed.

AI assistance was used to investigate, implement, and validate this change. Published as a draft for human review; human review is not claimed as completed. No model behavior changes or model evaluations are involved.
