### PR TITLE
[Bugfix] Validate extension integers before engine serialization

### DIFF
--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -49,3 +49,25 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+@pytest.mark.parametrize("value", [-(2**63) - 1, 2**64])
+def test_extra_args_rejects_nested_integer_overflow(value):
+    """Reject extension values before they reach the engine transport."""
+    with pytest.raises(VLLMValidationError, match="extra_args integers"):
+        SamplingParams(extra_args={"ec_transfer_params": {"nested": [{"x": value}]}})
+
+
+@pytest.mark.parametrize("value", [-(2**63), 2**63 - 1, 2**63, 2**64 - 1, True])
+def test_extra_args_accepts_messagepack_integer_boundaries(value):
+    extra_args = {"kv_transfer_params": {"nested": [{"x": value}]}}
+    assert SamplingParams(extra_args=extra_args).extra_args == extra_args
+
+
+def test_extra_args_preserves_custom_objects_and_shared_containers():
+    custom = object()
+    shared = [custom, (None, "value", 1.5)]
+    extra_args = {"first": shared, "second": shared}
+    params = SamplingParams(extra_args=extra_args)
+    assert params.extra_args["first"][0] is custom
+    assert params.extra_args["first"] is params.extra_args["second"]

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -544,6 +544,8 @@ class SamplingParams(
 
     def _verify_args(self) -> None:
         _verify_num_sequences(self.n, "n")
+        if self.extra_args:
+            self._verify_extra_args()
         if not -2.0 <= self.presence_penalty <= 2.0:
             raise VLLMValidationError(
                 f"presence_penalty must be in [-2, 2], got {self.presence_penalty}."
@@ -654,6 +656,26 @@ class SamplingParams(
                 f"bad_words cannot contain an empty string. "
                 f"Got bad_words={self.bad_words}"
             )
+
+    def _verify_extra_args(self) -> None:
+        # JSON accepts arbitrary integers, but the engine's MessagePack
+        # transport only supports signed/unsigned 64-bit integers.
+        pending: list[Any] = [self.extra_args]
+        visited: set[int] = set()
+        while pending:
+            value = pending.pop()
+            if isinstance(value, int) and not -(2**63) <= value < 2**64:
+                raise VLLMValidationError(
+                    "extra_args integers must be between -2**63 and 2**64 - 1.",
+                    parameter="extra_args",
+                )
+            if isinstance(value, (dict, list, tuple)) and id(value) not in visited:
+                visited.add(id(value))
+                if isinstance(value, dict):
+                    pending.extend(value.keys())
+                    pending.extend(value.values())
+                else:
+                    pending.extend(value)
 
     def _verify_greedy_sampling(self) -> None:
         if self.n > 1:


### PR DESCRIPTION
The OpenAI schema test failed with a 500 and an empty error message in [build 87389](https://buildkite.com/vllm/ci/builds/87389#01a0712c-2d63-40f8-918e-bed30aa34054). Its generated `ec_transfer_params` contained a nested integer outside MessagePack's supported range. The API accepts arbitrary JSON integers, but encoding the engine request raises `OverflowError` after request processing has begun.

Validate nested integers in `SamplingParams.extra_args` during construction and raise `VLLMValidationError` before engine submission. This covers `ec_transfer_params`, `kv_transfer_params`, and `vllm_xargs`, which flow into the same extension dictionary. Accept the full MessagePack range, `-2**63` through `2**64 - 1`, including unsigned 64-bit values. Preserve custom extension objects, shared containers, and other value types.

Reproduction: `{"messages":[{"role":"user","content":"hi"}],"max_tokens":2,"ec_transfer_params":{"x":18446744073709551616}}` returns 500 before the fix. Both positive and negative overflow reproduce; adjacent valid boundaries return 200. This was confirmed on H200 with the public CI image for commit `784cac7c424db2f2fdc879b672abad7e231f5698`, including the exact original CI payload.

Duplicate checks: searched open PRs and issues for `msgpack integer`, `extra_args overflow`, `ec_transfer_params 500`, and integer/validation combinations. #50353 prevents mutation of request extension dictionaries; #55290 handles remote encoder-transfer failures. Neither validates integer bounds before serialization.

Validation:
- `VLLM_TARGET_DEVICE=cpu /tmp/vllm-ci-api-validation/.venv/bin/python -m pytest --noconftest -q tests/test_sampling_params.py`: **19 passed** on macOS CPU. This suite uses no shared fixtures; `--noconftest` avoids loading unrelated GPU integration fixtures.
- Direct request-path checks with `ChatCompletionRequest.to_sampling_params` and `create_error_response`: the exact CI payload and both overflow boundaries produce **400 / BadRequestError**, with `param=extra_args`.
- `MsgpackEncoder.encode` still succeeds for all four signed/unsigned boundary values.
- `pre-commit run --files vllm/sampling_params.py tests/test_sampling_params.py`: all applicable hooks, including mypy, passed.
- `git diff --check`: passed.

The patched full GPU/API suite remains pending CI. The H200 HTTP reproduction above is the pre-fix baseline; the post-fix checks are local request-path/unit tests, not a claim of full GPU execution. Valid model inputs and generation behavior are unchanged, so no model evaluation result is claimed or required for this validation-only change.

CI: [build 87457](https://buildkite.com/vllm/ci/builds/87457) runs head `778b9bb391`. The original failing [Entrypoints Integration (API Server OpenAI - Part 1) lane](https://buildkite.com/vllm/ci/builds/87457#01a0781e-0ab7-4ede-bd99-d152e0df756b) is enabled and waiting for dependencies.

AI assistance was used to investigate, implement, and validate this change. Published as a draft for human review; human review is not claimed as completed.
