### PR TITLE
[Bugfix] Fix Sweep Pareto plots including dominated throughput ties (#55561)

### DIFF
--- a/tests/benchmarks/sweep/test_plot_pareto.py
+++ b/tests/benchmarks/sweep/test_plot_pareto.py
@@ -1,0 +1,59 @@
+import pandas as pd
+
+from vllm.benchmarks.sweep.plot_pareto import _pareto_frontier
+
+
+def test_pareto_frontier_tradeoffs():
+    df = pd.DataFrame({
+        "x": [10.0, 5.0, 2.0],
+        "y": [100.0, 150.0, 200.0],
+    })
+    frontier = _pareto_frontier(df, "x", "y")
+    assert len(frontier) == 3
+    assert set(frontier.index) == {0, 1, 2}
+
+
+def test_pareto_frontier_dominated():
+    df = pd.DataFrame({
+        "x": [10.0, 5.0],
+        "y": [100.0, 90.0],
+    })
+    frontier = _pareto_frontier(df, "x", "y")
+    assert len(frontier) == 1
+    assert list(frontier.index) == [0]
+
+
+def test_pareto_frontier_ties():
+    # Issue #55561: Dominated throughput ties
+    df = pd.DataFrame({
+        "x": [10.0, 5.0],
+        "y": [100.0, 100.0],
+    })
+    frontier = _pareto_frontier(df, "x", "y")
+    assert len(frontier) == 1
+    assert list(frontier.index) == [0]
+
+
+def test_pareto_frontier_duplicates():
+    # Equal coordinates should still retain all associated runs for labeling
+    df = pd.DataFrame({
+        "x": [10.0, 10.0],
+        "y": [100.0, 100.0],
+    })
+    frontier = _pareto_frontier(df, "x", "y")
+    assert len(frontier) == 2
+    assert set(frontier.index) == {0, 1}
+
+
+def test_pareto_frontier_mixed():
+    df = pd.DataFrame({
+        "x": [10.0, 10.0, 5.0, 5.0, 2.0, 2.0],
+        "y": [100.0, 100.0, 150.0, 100.0, 140.0, 160.0],
+    })
+    frontier = _pareto_frontier(df, "x", "y")
+    assert len(frontier) == 4
+    # Expected:
+    # (10.0, 100.0) index 0 and 1
+    # (5.0, 150.0) index 2. (5.0, 100.0) index 3 is dominated by index 2.
+    # (2.0, 160.0) index 5. (2.0, 140.0) index 4 is dominated by index 5.
+    assert set(frontier.index) == {0, 1, 2, 5}

--- a/vllm/benchmarks/sweep/plot_pareto.py
+++ b/vllm/benchmarks/sweep/plot_pareto.py
@@ -145,12 +145,17 @@ def _pareto_frontier(
     sorted_df = df.sort_values([x_col, y_col], ascending=[False, False])
     frontier_indices = []
     best_y = -math.inf
+    best_x = -math.inf
 
     for idx, row in sorted_df.iterrows():
+        x_val = row[x_col]
         y_val = row[y_col]
-        if y_val >= best_y - epsilon:
+        if y_val > best_y + epsilon:
             frontier_indices.append(idx)
-            best_y = max(best_y, y_val)
+            best_y = y_val
+            best_x = x_val
+        elif abs(y_val - best_y) <= epsilon and abs(x_val - best_x) <= epsilon:
+            frontier_indices.append(idx)
 
     return df.loc[frontier_indices]
 
@@ -216,7 +221,7 @@ def _plot_fig(
         y="tokens_per_gpu",
         color="0.5",
         alpha=0.6,
-        ax=ax,
+        ax=ax,  # type: ignore
         label="All runs",
     )
     sns.lineplot(
@@ -224,7 +229,7 @@ def _plot_fig(
         x="tokens_per_user",
         y="tokens_per_gpu",
         marker="o",
-        ax=ax,
+        ax=ax,  # type: ignore
         label="Pareto frontier",
     )
 


### PR DESCRIPTION
## Summary
This fixes issue #55561 where `vllm bench sweep plot_pareto` would incorrectly include dominated configurations in the Pareto frontier. This happened when a configuration had an identical `tokens_per_gpu` value as an existing frontier point, but a strictly worse `tokens_per_user` value.

The filtering logic has been updated to track both X and Y dimensions when building the frontier, ensuring strict dominance drops inferior points while retaining exact coordinate duplicates for plotting/labeling purposes.

### AI Assistance
AI assistance (Antigravity Agent) was used to identify the logic flaw and draft the tests.

## Testing & Verification
This is a fresh fix and not a duplicate of any existing open PRs.

The following new unit tests have been added and run successfully locally:
```bash
$ uv run pytest tests/benchmarks/sweep/test_plot_pareto.py -v
tests/benchmarks/sweep/test_plot_pareto.py::test_pareto_frontier_tradeoffs PASSED [ 20%]
tests/benchmarks/sweep/test_plot_pareto.py::test_pareto_frontier_dominated PASSED [ 40%]
tests/benchmarks/sweep/test_plot_pareto.py::test_pareto_frontier_ties PASSED [ 60%]
tests/benchmarks/sweep/test_plot_pareto.py::test_pareto_frontier_duplicates PASSED [ 80%]
tests/benchmarks/sweep/test_plot_pareto.py::test_pareto_frontier_mixed PASSED [100%]
