### PR TITLE
[Docker] Use zstd for CI images and offer a Docker Hub variant

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -1103,6 +1103,15 @@ steps:
 
   - block: "Publish release images to DockerHub"
     key: block-publish-release-images
+    fields:
+      - select: "Also publish the experimental CUDA 13.0 amd64 zstd image?"
+        key: publish-zstd-image
+        default: "false"
+        options:
+          - label: "No, publish normal images only"
+            value: "false"
+          - label: "Yes, also publish the zstd image"
+            value: "true"
     depends_on:
       - create-multi-arch-manifest
       - create-multi-arch-manifest-cuda-12-9

--- a/.buildkite/scripts/publish-release-images.sh
+++ b/.buildkite/scripts/publish-release-images.sh
@@ -61,6 +61,16 @@ if target_enabled cuda-13-0; then
   docker manifest create "vllm/vllm-openai:v${RELEASE_VERSION}" "vllm/vllm-openai:v${RELEASE_VERSION}-x86_64" "vllm/vllm-openai:v${RELEASE_VERSION}-aarch64"
   docker manifest push vllm/vllm-openai:latest
   docker manifest push "vllm/vllm-openai:v${RELEASE_VERSION}"
+
+  PUBLISH_ZSTD_IMAGE=$(buildkite-agent meta-data get publish-zstd-image --default false)
+  if [ "$PUBLISH_ZSTD_IMAGE" = "true" ]; then
+    ZSTD_DIGEST=$(docker buildx imagetools inspect \
+      "public.ecr.aws/q9t5s3a7/vllm-release-repo:${COMMIT}-x86_64" \
+      --format '{{json .Manifest.Digest}}' | tr -d '"')
+    .buildkite/scripts/publish-zstd-image.sh \
+      "public.ecr.aws/q9t5s3a7/vllm-release-repo@${ZSTD_DIGEST}" \
+      "vllm/vllm-openai:v${RELEASE_VERSION}-x86_64-zstd"
+  fi
 fi
 
 # ---- CUDA 12.9 ----

--- a/.buildkite/scripts/publish-zstd-image.sh
+++ b/.buildkite/scripts/publish-zstd-image.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 SOURCE@sha256:DIGEST DESTINATION-zstd" >&2
+  exit 2
+fi
+
+SOURCE=$1
+DESTINATION=$2
+if [[ ! "$SOURCE" =~ ^[a-zA-Z0-9][a-zA-Z0-9._:/-]*@sha256:[a-f0-9]{64}$ ]] ||
+  [[ ! "$DESTINATION" =~ ^[a-zA-Z0-9][a-zA-Z0-9._:/-]*:[a-zA-Z0-9_][a-zA-Z0-9_.-]*-zstd$ ]]; then
+  echo "ERROR: source must use an immutable sha256 digest and destination must end in -zstd" >&2
+  exit 2
+fi
+
+BUILDER=
+cleanup() {
+  status=$?
+  trap - EXIT INT TERM
+  if [ -n "$BUILDER" ] && ! docker buildx rm --force "$BUILDER"; then
+    echo "ERROR: failed to remove Buildx builder $BUILDER" >&2
+    [ "$status" -ne 0 ] || status=1
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+BUILDER=$(docker buildx create \
+  --driver docker-container \
+  --driver-opt network=host \
+  --driver-opt 'image=moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8')
+
+printf '# check=error=true\n\nFROM %s\n' "$SOURCE" | docker buildx build \
+  --builder "$BUILDER" \
+  --platform linux/amd64 \
+  --progress plain \
+  --provenance=mode=min \
+  --output "type=image,name=${DESTINATION},push=true,compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true" \
+  -

--- a/tests/tools/test_publish_zstd_image.py
+++ b/tests/tools/test_publish_zstd_image.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PUBLISH = ROOT / ".buildkite/scripts/publish-release-images.sh"
+HELPER = ROOT / ".buildkite/scripts/publish-zstd-image.sh"
+DIGEST = "sha256:" + "a" * 64
+SOURCE = f"localhost:5000/vllm@{DIGEST}"
+DESTINATION = "vllm/vllm-openai:v1.2.3-x86_64-zstd"
+
+
+def fake_environment(
+    root: Path, metadata: str = "false"
+) -> tuple[dict[str, str], Path]:
+    bin_dir = root / "bin"
+    bin_dir.mkdir()
+    log = root / "docker.log"
+    docker = bin_dir / "docker"
+    docker.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$DOCKER_LOG"\n'
+        'if [ "$1 $2 $3" = "buildx imagetools inspect" ]; then\n'
+        f"  printf '\"{DIGEST}\"\\n'\n"
+        'elif [ "$1 $2" = "buildx create" ]; then\n'
+        '  printf "zstd-test-builder\\n"\n'
+        'elif [ "$1 $2" = "buildx build" ]; then\n'
+        '  cat > "$DOCKERFILE_LOG"\n'
+        '  exit "${BUILD_EXIT:-0}"\n'
+        'elif [ "$1 $2 $3" = "buildx rm --force" ]; then\n'
+        '  exit "${RM_EXIT:-0}"\n'
+        "fi\n"
+    )
+    docker.chmod(0o755)
+    agent = bin_dir / "buildkite-agent"
+    agent.write_text(
+        "#!/bin/sh\n"
+        'case "$*" in\n'
+        f'  *release-version*) printf "1.2.3\\n" ;;\n'
+        f'  *publish-zstd-image*) printf "{metadata}\\n"; exit "${{META_EXIT:-0}}" ;;\n'
+        "esac\n"
+    )
+    agent.chmod(0o755)
+    aws = bin_dir / "aws"
+    aws.write_text("#!/bin/sh\nprintf password\\n\n")
+    aws.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        PATH=f"{bin_dir}:{env['PATH']}",
+        DOCKER_LOG=str(log),
+        DOCKERFILE_LOG=str(root / "Dockerfile"),
+        BUILDKITE_COMMIT="commit123",
+    )
+    return env, log
+
+
+def run(
+    script: Path, *args: str, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(script), *args], env=env, cwd=ROOT, text=True, capture_output=True
+    )
+
+
+def test_publish_zstd_image_behavior() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        env, log = fake_environment(root)
+        assert run(PUBLISH, "cuda-13-0", env=env).returncode == 0
+        assert "buildx" not in log.read_text()
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        env, log = fake_environment(root, "true")
+        assert run(PUBLISH, "cuda-12-9", env=env).returncode == 0
+        assert "buildx" not in log.read_text()
+        assert run(PUBLISH, "cuda-13-0", env=env).returncode == 0
+        calls = log.read_text()
+        assert "buildx imagetools inspect" in calls
+        assert f"type=image,name={DESTINATION},push=true,compression=zstd" in calls
+        assert "--load" not in calls
+        assert f"push {DESTINATION}" not in calls
+        assert (
+            f"FROM public.ecr.aws/q9t5s3a7/vllm-release-repo@{DIGEST}"
+            in (root / "Dockerfile").read_text()
+        )
+
+    invalid = (
+        (),
+        ("repo:tag", DESTINATION),
+        (SOURCE, "vllm/vllm-openai:v1.2.3"),
+        (SOURCE, "vllm/repo-zstd"),
+        (SOURCE, DESTINATION + ",other"),
+        (SOURCE + "\n", DESTINATION),
+        (SOURCE, DESTINATION, "extra"),
+    )
+    for args in invalid:
+        with tempfile.TemporaryDirectory() as directory:
+            env, log = fake_environment(Path(directory))
+            assert run(HELPER, *args, env=env).returncode != 0
+            assert not log.exists()
+
+    outcomes = (("0", "0", 0), ("17", "0", 17), ("0", "9", 1), ("17", "9", 17))
+    for build_exit, rm_exit, expected in outcomes:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            env, log = fake_environment(root)
+            env["BUILD_EXIT"] = build_exit
+            env["RM_EXIT"] = rm_exit
+            result = run(HELPER, SOURCE, DESTINATION, env=env)
+            assert result.returncode == expected
+            cleanup_calls = log.read_text().splitlines()
+            assert sum("buildx create" in call for call in cleanup_calls) == 1
+            assert [call for call in cleanup_calls if "buildx rm" in call] == [
+                "buildx rm --force zstd-test-builder"
+            ]
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        env, log = fake_environment(root, "true")
+        env["META_EXIT"] = "8"
+        assert run(PUBLISH, "cuda-13-0", env=env).returncode == 8
+        assert "buildx imagetools" not in log.read_text()
+
+
+if __name__ == "__main__":
+    test_publish_zstd_image_behavior()


### PR DESCRIPTION
The ordinary CUDA CI image now exports zstd level 3 under the existing ECR commit tag that test runners consume. Standard Docker Hub tags retain their separate gzip release path, and the CUDA 13.0 amd64 release action also publishes a separately tagged `-zstd` variant from an immutable release-image digest by default. The requested test script has been removed.

The CI change applies to the ordinary `test-ci` build. CPU/Arm builds and the separate Torch-nightly builder retain their existing paths. The public release variant stays separately tagged because ordinary pulls do not provide a reliable same-tag gzip fallback for unsupported zstd consumers.

## Measurement

Earlier matched images on one RTX 4090 Laptop rig, Qwen3-0.6B, four-CPU quota, local registry and three fresh-store runs per arm:

| Image | Compressed bytes | Median pull to first correct response |
|---|---:|---:|
| Bytecode, gzip | 8,664,824,384 | 144.51 s |
| Same image, zstd level 3 | 6,999,776,144 | 118.02 s |

The zstd image is 19.2% smaller, with a 22.19-second median paired saving. Paired savings differ from subtracting the arm medians. This is the earlier same-host local-registry experiment, not a measurement of production ECR or Internet delivery.

## Validation

Merged current main and passed applicable pre-commit hooks, including ShellCheck and Buildkite configuration checks. The actual ci-infra consumers select the unchanged ECR commit tag, so no separate runner tag change is needed.

[CI build 89441](https://buildkite.com/vllm/ci/builds/89441#01a0abf5-32fd-4467-8e35-6e8b54bc6ce9) exported the `69f15d2e2e0137af8d0b10a693af28e54e907fb3` image with 44 zstd layers. An independent registry read verified its manifest and both commit labels. I then pulled Linux amd64 digest `sha256:81fe52601ccf6c61d8824016483e81fd24244491211cf4973b285fda6d4408d2` on my rig: Python 3.12.3, Torch 2.13.0+cu130 and vLLM imports passed, followed by a small CUDA matrix multiplication on the selected RTX 4090 Laptop. The temporary container/image reference were removed and the existing snapshot workload was preserved. The CI exporter and zstd export helper are unchanged by the default-publication update. Mac and Linux command-spy checks passed for all release targets and export-failure cleanup; the normal gzip calls are preserved. Repository hooks passed. These orchestration checks did not publish images.

This is a published-image Docker/CUDA check, not full model-serving or cross-consumer qualification. Build 89441 was started manually without PR association, so normal PR CI is still needed. The earlier tiny-fixture harness failure and the corrected preflight-script attempt remain in the experiment record.
