### PR TITLE
[ROCm][CI] Exercise ROCM_AITER_FA and FLASH_ATTN MLA prefill backends in CI (#53944)

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1566,6 +1566,27 @@ steps:
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
 
+- label: ":amd: (MI300) MLA Prefill Backend Correctness (AITER FA)" # TBD
+  timeout_in_minutes: 60
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  dind: false
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/v1/attention/backends/mla/
+  - vllm/platforms/rocm.py
+  - vllm/_aiter_ops.py
+  - vllm/envs.py
+  - tests/v1/attention/test_mla_backends.py
+  commands:
+  # AiterFlashAttnPrefillBackend.is_available() is gated on VLLM_ROCM_USE_AITER,
+  # evaluated at collection time, so the ROCM_AITER_FA prefill cases skip on every
+  # other AMD job. Enable AITER here to actually exercise that backend; the
+  # FLASH_ATTN prefill fallback stays covered by the default V1 Attention Shard job.
+  - rocm-smi
+  - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/attention/test_mla_backends.py -k "backend_correctness and ROCM_AITER_FA"
+
 - label: ":amd: (MI300) Attention Kernels Shard %N" # TBD
   timeout_in_minutes: 70
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
@@ -3541,6 +3562,27 @@ steps:
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
+
+- label: ":amd: (MI355) MLA Prefill Backend Correctness (AITER FA)" # TBD
+  timeout_in_minutes: 60
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
+  dind: false
+  agent_pool: mi355_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/v1/attention/backends/mla/
+  - vllm/platforms/rocm.py
+  - vllm/_aiter_ops.py
+  - vllm/envs.py
+  - tests/v1/attention/test_mla_backends.py
+  commands:
+  # AiterFlashAttnPrefillBackend.is_available() is gated on VLLM_ROCM_USE_AITER,
+  # evaluated at collection time, so the ROCM_AITER_FA prefill cases skip on every
+  # other AMD job. Enable AITER here to actually exercise that backend; the
+  # FLASH_ATTN prefill fallback stays covered by the default V1 Attention Shard job.
+  - rocm-smi
+  - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/attention/test_mla_backends.py -k "backend_correctness and ROCM_AITER_FA"
 
 - label: ":amd: (MI355) Attention Kernels Shard %N" # TBD
   timeout_in_minutes: 40

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -591,7 +591,6 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - rocm-smi
   - pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k "llama-3"
 
 - label: ":amd: (MI300) Fusion E2E Quick" # TBD
@@ -610,7 +609,6 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - rocm-smi
   # Run all models and attn backends but only Inductor partition and native custom ops
   - "pytest -v -s tests/compile/fusions_e2e/test_tp1_quant.py -k 'inductor_partition and not +rms_norm and not +quant_fp8'"
   # Different from CUDA, Qwen requires +rms_norm and +quant_fp8 as rms+quant fusion is only supported on AITER
@@ -1560,7 +1558,6 @@ steps:
   - tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
   - tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
   commands:
-  - rocm-smi
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
@@ -1575,16 +1572,18 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/v1/attention/backends/mla/
+  - vllm/v1/attention/backends/fa_utils.py
+  - vllm/model_executor/layers/attention/
   - vllm/platforms/rocm.py
   - vllm/_aiter_ops.py
   - vllm/envs.py
   - tests/v1/attention/test_mla_backends.py
+  - tests/v1/attention/utils.py
   commands:
   # AiterFlashAttnPrefillBackend.is_available() is gated on VLLM_ROCM_USE_AITER,
   # evaluated at collection time, so the ROCM_AITER_FA prefill cases skip on every
   # other AMD job. Enable AITER here to actually exercise that backend; the
   # FLASH_ATTN prefill fallback stays covered by the default V1 Attention Shard job.
-  - rocm-smi
   - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/attention/test_mla_backends.py -k "backend_correctness and ROCM_AITER_FA"
 
 - label: ":amd: (MI300) Attention Kernels Shard %N" # TBD
@@ -2782,7 +2781,7 @@ steps:
   - pytest -v -s tests/v1/kv_connector/extract_hidden_states_integration
 
 - label: ":amd: (MI300) V1 Attention Shard %N" # TBD
-  timeout_in_minutes: 35
+  timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   dind: false
   agent_pool: mi300_1
@@ -3536,7 +3535,6 @@ steps:
   - vllm/platforms/rocm.py
   - vllm/_aiter_ops.py
   commands:
-  - rocm-smi
   - python3 examples/basic/offline_inference/chat.py --attention-backend TRITON_ATTN
   - pytest -v -s tests/kernels/attention/test_attention_selector.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
@@ -3557,7 +3555,6 @@ steps:
   - tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
   - tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
   commands:
-  - rocm-smi
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode_metadata.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_decode.py
   - pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
@@ -3572,16 +3569,18 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/v1/attention/backends/mla/
+  - vllm/v1/attention/backends/fa_utils.py
+  - vllm/model_executor/layers/attention/
   - vllm/platforms/rocm.py
   - vllm/_aiter_ops.py
   - vllm/envs.py
   - tests/v1/attention/test_mla_backends.py
+  - tests/v1/attention/utils.py
   commands:
   # AiterFlashAttnPrefillBackend.is_available() is gated on VLLM_ROCM_USE_AITER,
   # evaluated at collection time, so the ROCM_AITER_FA prefill cases skip on every
   # other AMD job. Enable AITER here to actually exercise that backend; the
   # FLASH_ATTN prefill fallback stays covered by the default V1 Attention Shard job.
-  - rocm-smi
   - VLLM_ROCM_USE_AITER=1 pytest -v -s v1/attention/test_mla_backends.py -k "backend_correctness and ROCM_AITER_FA"
 
 - label: ":amd: (MI355) Attention Kernels Shard %N" # TBD
@@ -3935,7 +3934,7 @@ steps:
 #------------------------------------------------------------  mi355 · v1  -------------------------------------------------------------#
 
 - label: ":amd: (MI355) V1 Attention Shard %N" # TBD
-  timeout_in_minutes: 35
+  timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
   dind: false
   agent_pool: mi355_1

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -1911,20 +1911,29 @@ def test_backend_correctness(
     qk_nope_head_dim: int,
     v_head_dim: int,
 ):
-    if (
-        batch_spec_name.startswith("spec_decode")
-        and current_platform.is_rocm()
-        and kv_cache_dtype == "auto"
-        and BATCH_SPECS[batch_spec_name].query_lens[0] > 4
-    ):
-        # ROCM_AITER_MLA (in BACKENDS_TO_TEST on ROCm, bf16 KV only) has no
-        # persistent MLA-decode kernel for query_len > 4 on gfx942; aiter's
-        # get_heuristic_kernel_mla raises (ROCm/aiter#5297). query_len <= 4 and
-        # the fp8 KV paths (TRITON_MLA only) still run. See vllm#55609.
-        pytest.skip(
-            "ROCM_AITER_MLA has no persistent MLA-decode kernel for "
-            "query_len > 4 on gfx942 (ROCm/aiter#5297). See vllm#55609."
-        )
+    if batch_spec_name.startswith("spec_decode") and current_platform.is_rocm():
+        from vllm.platforms.rocm import on_gfx942
+
+        if (
+            on_gfx942()
+            and kv_cache_dtype == "auto"
+            and BATCH_SPECS[batch_spec_name].query_lens[0] > 4
+            and tensor_parallel_size in (4, 8)
+        ):
+            # ROCM_AITER_MLA (in BACKENDS_TO_TEST on ROCm, bf16 KV only) has no
+            # persistent MLA-decode kernel for query_len > 4 on gfx942 at these
+            # head counts (32 heads at TP4, 16 heads at TP8); aiter's
+            # get_heuristic_kernel_mla raises (ROCm/aiter#5297). TP16 (8 heads)
+            # falls back to the non-persistent kernel and TP1 (128 heads) takes
+            # a separate non-persistent code path, so both are unaffected; gfx950
+            # ships the persistent kernel variant these TPs need, so it isn't
+            # affected either. query_len <= 4 and the fp8 KV paths (TRITON_MLA
+            # only) still run. See vllm#55609.
+            pytest.skip(
+                "ROCM_AITER_MLA has no persistent MLA-decode kernel for "
+                "query_len > 4 on gfx942 at TP4/TP8 (ROCm/aiter#5297). "
+                "See vllm#55609."
+            )
     _run_backend_correctness(
         default_vllm_config,
         dist_init,

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -334,7 +334,12 @@ if current_platform.is_cuda():
         ]
     )
 elif current_platform.is_rocm():
-    PREFILL_BACKENDS_TO_TEST.append(MLAPrefillBackendEnum.ROCM_AITER_FA)
+    PREFILL_BACKENDS_TO_TEST.extend(
+        [
+            MLAPrefillBackendEnum.ROCM_AITER_FA,
+            MLAPrefillBackendEnum.FLASH_ATTN,
+        ]
+    )
 
 MLA_DIMENSIONS_TO_TEST = [
     ("deepseek", 128, 128),
@@ -1412,6 +1417,7 @@ def _run_backend_correctness(
     qk_nope_head_dim: int,
     v_head_dim: int,
     chunked_prefill_workspace_size: int | None = None,
+    rtol_override: float | None = None,
 ):
     """
     Test that all backends produce similar outputs to a reference implementation
@@ -1767,7 +1773,7 @@ def _run_backend_correctness(
         kv_cache_per_block_size[block_size] = kv_cache
 
     # 4. Run vLLM backends and compare
-    rtol = 1e-2
+    rtol = rtol_override if rtol_override is not None else 1e-2
     atol = {
         "auto": 1e-2,
         "fp8": 1.5e-1,
@@ -1905,6 +1911,20 @@ def test_backend_correctness(
     qk_nope_head_dim: int,
     v_head_dim: int,
 ):
+    if (
+        batch_spec_name.startswith("spec_decode")
+        and current_platform.is_rocm()
+        and kv_cache_dtype == "auto"
+        and BATCH_SPECS[batch_spec_name].query_lens[0] > 4
+    ):
+        # ROCM_AITER_MLA (in BACKENDS_TO_TEST on ROCm, bf16 KV only) has no
+        # persistent MLA-decode kernel for query_len > 4 on gfx942; aiter's
+        # get_heuristic_kernel_mla raises (ROCm/aiter#5297). query_len <= 4 and
+        # the fp8 KV paths (TRITON_MLA only) still run. See vllm#55609.
+        pytest.skip(
+            "ROCM_AITER_MLA has no persistent MLA-decode kernel for "
+            "query_len > 4 on gfx942 (ROCm/aiter#5297). See vllm#55609."
+        )
     _run_backend_correctness(
         default_vllm_config,
         dist_init,
@@ -1936,6 +1956,15 @@ def test_chunked_context_backend_correctness(
     kv_cache_dtype: str,
 ):
     """Split, packed, and context-free requests match the SDPA reference."""
+    rtol_override = None
+    if current_platform.is_rocm() and v_head_dim == 256 and kv_cache_dtype == "auto":
+        # bf16 output at v_head_dim=256: the chunked-context online-softmax
+        # merge is a reordered reduction vs the single-pass SDPA reference, so
+        # they can disagree by ~1 ULP; rounding to adjacent bf16 grid points
+        # then makes that a 2-ULP output gap (0.03125 at magnitude ~2), above
+        # the default rtol/atol=1e-2. Not backend-specific (both decode
+        # backends show the same diff). See vllm#55609.
+        rtol_override = 2e-2
     _run_backend_correctness(
         default_vllm_config,
         dist_init,
@@ -1950,4 +1979,5 @@ def test_chunked_context_backend_correctness(
         qk_nope_head_dim=qk_nope_head_dim,
         v_head_dim=v_head_dim,
         chunked_prefill_workspace_size=1024,
+        rtol_override=rtol_override,
     )


### PR DESCRIPTION
## Summary

Closes #53944. `tests/v1/attention/test_mla_backends.py` gave the ROCm MLA
prefill backends almost no coverage: `MLAPrefillBackendEnum.ROCM_AITER_FA` is the
only ROCm prefill backend in `PREFILL_BACKENDS_TO_TEST`, and it reports
unavailable at collection time unless `VLLM_ROCM_USE_AITER=1` — which no AMD
Buildkite job sets. So every `test_backend_correctness` /
`test_chunked_context_backend_correctness` case is `skip`-marked. The skip is
decided in `_prefill_backend_dimension_params()` before any fixture runs, so a
per-test `monkeypatch.setenv` can't reach it.

## Changes

1. **`PREFILL_BACKENDS_TO_TEST` on ROCm**: `.append(ROCM_AITER_FA)` →
   `.extend([ROCM_AITER_FA, FLASH_ATTN])`. `FLASH_ATTN` is the real fallback when
   AITER is off (`_get_mla_prefill_backend_priorities` → `[ROCM_AITER_FA,
   FLASH_ATTN]` on ROCm) and the ROCm CI image ships the Dao-AILab FA CDNA wheel,
   so it is genuinely available. The existing `V1 Attention Shard %N` job (AITER
   off) now exercises real `FLASH_ATTN` MLA-prefill correctness with no CI-config
   change.

2. **`.buildkite/test-amd.yaml`**: two `optional` jobs,
   `(MI300) MLA Prefill Backend Correctness (AITER FA)` + MI355 twin, after each
   `MLA Kernels` job, running
   `VLLM_ROCM_USE_AITER=1 pytest -v -s v1/attention/test_mla_backends.py -k
   "backend_correctness and ROCM_AITER_FA"`. Dedicated job, not a blanket env
   export on the whole `v1/attention` sweep.

3. **Two ROCm MLA *decode*-path issues that unskipping the bodies exposes**
   (neither in the prefill backend being enabled) — tracked in #55609:
   - `ROCM_AITER_MLA` decode is unconditionally in `BACKENDS_TO_TEST` on ROCm and
     advertises multi-token-query support, but aiter has no persistent MLA-decode
     kernel for `query_len > 4` on gfx942. `test_backend_correctness` is `skip`ed
     for `spec_decode` + `query_len > 4` + bf16 KV on ROCm (16 cases).
     `query_len <= 4` and the fp8 KV paths still run. Before
     #55609 this was a `std::abort()` that killed the pytest worker; ROCm/aiter#5297 makes it a
     catchable
     `RuntimeError`.
   - `test_chunked_context_backend_correctness` at `v_head_dim=256` + bf16 KV:
     one element / 2.88M differs by 2 bf16 ULP (0.03125 at magnitude ~2) — the
     chunked online-softmax merge is a reordered reduction vs the single-pass
     SDPA reference, and `rtol/atol=1e-2` is below one bf16 ULP there. `rtol` is
     bumped to `2e-2` for that ROCm case only (both decode backends show the same
     diff; not backend-specific). The shared tolerance being a hair tight for
     bf16 generally is noted in #55609 as a separate, wider change.

## Why this is not a duplicate

- `gh pr list --repo vllm-project/vllm --state open --search "53944 in:body"` — empty.
- `gh pr list --repo vllm-project/vllm --state open --search "test_mla_backends"` — empty.
- The maintainer who owns `test-amd.yaml` confirmed the gap on #53944 ("This
  is legit gap. Lmk if you open a PR that addresses this.").

## Testing

Local pre-commit (ruff, ruff-format, mypy-3.10, typos, SPDX) — pass.

Full collection of `test_mla_backends.py` can't complete on a gfx1201 dev box (a
pre-existing module-level `pytest.skip` from `try_get_attention_backend(
FLASHINFER_MLA)` with `flashinfer` absent). Ran on a rented MI300X (gfx942),
`rocm/vllm-ci` image, `amd-aiter 0.1.21.post1`:

```
# FLASH_ATTN MLA prefill, AITER off  (this is what the non-optional
#   (MI355) V1 Attention Shard now runs)
pytest -q v1/attention/test_mla_backends.py \
  -k "backend_correctness and FLASH_ATTN and not spec_decode"
  -> 484 passed

# ROCM_AITER_FA MLA prefill, AITER on  (the new optional job's command)
VLLM_ROCM_USE_AITER=1 pytest -q v1/attention/test_mla_backends.py \
  -k "backend_correctness and ROCM_AITER_FA and not spec_decode"
  -> 483 passed, 1 pre-existing chunked-context tolerance diff (now rtol-bumped)

# spec_decode, AITER on, with ROCm/aiter#5297 applied
VLLM_ROCM_USE_AITER=1 pytest -q v1/attention/test_mla_backends.py \
  -k "backend_correctness and spec_decode_medium"
  -> 16 failed (RuntimeError, gqa16/ps1/qseqlen8, the skipped set), 32 passed
     (fp8 KV, TRITON_MLA).  Without ROCm/aiter#5297: SIGABRT, process killed.
```

The `spec_decode` + `query_len <= 4` cases and the `TRITON_MLA` fp8 `query_len 8`
cases are kept and pass. `op_tests/test_mla_persistent.py` and `test_mla.py`
(fetched at the aiter tag) stay green with ROCm/aiter#5297 applied — no
regression from the entrypoint wrap.

This change is test-only; it does not affect model output or serving. The `rtol`
bump is scoped to one ROCm test case and is justified by bf16 quantization (2 ULP
at magnitude 2 is 0.03125 > `1e-2`).

## Note

Please trigger the AMD CI on this PR before merge — the `FLASH_ATTN` list add
starts ~480 previously-unrun cases on the non-optional `(MI355) V1 Attention
Shard`, and while the MI300X run above is clean I'd like the MI355 twin
confirmed.

AI assistance (Claude Code) was used for this change; the author has reviewed
every line and run the tests above.

