### PR TITLE
[Test][Determinism] Cover chunked prefill in the batch-invariance suite

### DIFF
--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -433,8 +433,11 @@ def test_logprobs_bitwise_batch_invariance_ragged_chunked_prefill(backend):
         if any(logprobs is None for logprobs, _ in bs1):
             pytest.skip("Logprobs are not available on RequestOutput.")
 
+        outs_batched = llm.generate(prompts, sp, use_tqdm=False)
+        assert len(outs_batched) == len(prompts)
+
         mismatches = []
-        for i, out in enumerate(llm.generate(prompts, sp, use_tqdm=False)):
+        for i, out in enumerate(outs_batched):
             logprobs, tokens = _extract_step_logprobs(out)
             bs1_logprobs, bs1_tokens = bs1[i]
             n = prompt_lens[i]

--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -6,6 +6,7 @@ import random
 
 import pytest
 import torch
+from transformers import AutoTokenizer
 from utils import (
     BACKENDS,
     TEST_MODEL,
@@ -203,13 +204,8 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
     # Use more realistic prompts for better token generation
     prompts = [_random_prompt(10, 50) for _ in range(32)]
 
-    # TODO: Update prompts to have ragged lengths in order to test chunked prefill
-    #       The above tests are not currently long enough to exercise chunking.
-    # prompts = (
-    #     [_random_prompt(10, 50) for _ in range(28)]
-    #     + [_random_prompt(256, 512) for _ in range(50)]
-    #     + [_random_prompt(2048, 4096) for _ in range(50)]
-    # )
+    # Chunked prefill is covered by
+    # test_logprobs_bitwise_batch_invariance_ragged_chunked_prefill below.
 
     sp = SamplingParams(
         temperature=0.6,
@@ -387,6 +383,77 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
             f"{len(prompts)} prompts. See output above for details."
         )
         pytest.fail(msg)
+
+
+@skip_unsupported
+@pytest.mark.parametrize(
+    "backend",
+    BACKENDS,
+)
+def test_logprobs_bitwise_batch_invariance_ragged_chunked_prefill(backend):
+    """Batch invariance must hold when a prefill is split across chunks."""
+    random.seed(int(os.getenv("VLLM_TEST_SEED", "12345")))
+
+    prompts = (
+        [_random_prompt(10, 50) for _ in range(8)]
+        + [_random_prompt(300, 450) for _ in range(4)]
+        + [_random_prompt(800, 1200) for _ in range(2)]
+    )
+    random.shuffle(prompts)
+
+    # _random_prompt takes a word target, not a token count, and the ratio
+    # depends on the tokenizer, so derive the budget rather than hardcode it:
+    # half the longest prompt splits that prefill whatever TEST_MODEL is, while
+    # the shorter prompts are still co-scheduled whole. Floor is max_num_seqs.
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL)
+    prompt_lens = [len(tokenizer(p).input_ids) for p in prompts]
+    max_num_batched_tokens = max(len(prompts), max(prompt_lens) // 2)
+    assert max_num_batched_tokens < max(prompt_lens), (
+        f"a {max_num_batched_tokens}-token budget does not split the longest "
+        f"prompt ({max(prompt_lens)} tokens), so nothing would be chunked"
+    )
+
+    sp = SamplingParams(
+        temperature=0.6, top_p=1.0, max_tokens=16, seed=1234, logprobs=5
+    )
+    llm = LLM_with_max_seqs(
+        model=TEST_MODEL,
+        max_num_seqs=len(prompts),
+        gpu_memory_utilization=float(os.getenv("VLLM_GPU_MEMORY_UTILIZATION", "0.5")),
+        max_model_len=4096,
+        attention_config={"backend": backend},
+        max_num_batched_tokens=max_num_batched_tokens,
+    )
+
+    try:
+        bs1 = []
+        for p in prompts:
+            out = llm.generate([p], sp, use_tqdm=False)[0]
+            bs1.append(_extract_step_logprobs(out))
+        if any(logprobs is None for logprobs, _ in bs1):
+            pytest.skip("Logprobs are not available on RequestOutput.")
+
+        mismatches = []
+        for i, out in enumerate(llm.generate(prompts, sp, use_tqdm=False)):
+            logprobs, tokens = _extract_step_logprobs(out)
+            bs1_logprobs, bs1_tokens = bs1[i]
+            n = prompt_lens[i]
+            if tokens != bs1_tokens:
+                mismatches.append(f"prompt {i} ({n} tokens): tokens differ")
+            elif not torch.equal(bs1_logprobs, logprobs):
+                delta = torch.max(torch.abs(bs1_logprobs - logprobs)).item()
+                mismatches.append(
+                    f"prompt {i} ({n} tokens): logprobs differ, max|delta|={delta:.3e}"
+                )
+
+        assert not mismatches, (
+            "Batch invariance violated under chunked prefill "
+            f"(max_num_batched_tokens={max_num_batched_tokens}): "
+            + "; ".join(mismatches)
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            llm.shutdown()
 
 
 @skip_unsupported
@@ -926,6 +993,7 @@ def LLM_with_max_seqs(
     max_model_len: int,
     attention_config: dict | None = None,
     kernel_config: dict | None = None,
+    max_num_batched_tokens: int | None = None,
 ) -> LLM:
     """
     Helper to construct an LLM with a specific max_num_seqs (batch-size limit)
@@ -934,6 +1002,8 @@ def LLM_with_max_seqs(
     extra_kwargs: dict = {}
     if kernel_config is not None:
         extra_kwargs["kernel_config"] = kernel_config
+    if max_num_batched_tokens is not None:
+        extra_kwargs["max_num_batched_tokens"] = max_num_batched_tokens
     return LLM(
         model=model,
         max_num_seqs=max_num_seqs,


### PR DESCRIPTION
## Purpose

Batch invariance is what stops the same request coming back with different text
depending on how busy the server was. `tests/v1/determinism/` guards that — but
not for chunked prefill, which is what a loaded server does constantly: a long
prompt is split across several scheduler steps, and the later chunks attend over
KV computed in the earlier ones.

The suite says so itself, in a TODO left by #32561:

```python
# TODO: Update prompts to have ragged lengths in order to test chunked prefill
#       The above tests are not currently long enough to exercise chunking.
```

It is accurate. Every prompt in
`test_logprobs_bitwise_batch_invariance_bs1_vs_bsN` is short — 356 tokens for
the whole 32-prompt batch against a default budget of 2048 — so a prefill is
never split, and nothing checks that a user gets identical output whether or not
the scheduler chopped their prompt up.

## What this adds

`test_logprobs_bitwise_batch_invariance_ragged_chunked_prefill`: a ragged batch
of short, medium and long prompts with the token budget set below the longest
prompt, asserting bitwise-identical logprobs and identical sampled tokens
between bs=1 and bs=N.

I checked against the scheduler that prefills really are split, and that bs=1
and bs=N split the *same* prompt differently — different chunk boundaries, and
sometimes a different number of chunks. That difference is the point: the output
has to stay put regardless.

The budget is derived from the tokenized prompts rather than hardcoded, so the
test cannot quietly stop chunking if `VLLM_TEST_MODEL` changes the tokenizer.
`LLM_with_max_seqs` gains an optional `max_num_batched_tokens` (default `None`).
No non-test code is touched.

## Test Plan

1x RTX 3060 (12 GiB, sm_86), on the default model `Qwen/Qwen3-1.7B`:

```bash
VLLM_GPU_MEMORY_UTILIZATION=0.5 pytest \
  tests/v1/determinism/test_batch_invariance.py -q -k ragged_chunked_prefill
# 3 passed in 115.52s   (FLASH_ATTN, TRITON_ATTN, FLEX_ATTENTION)
```

Re-run with `VLLM_BATCH_INVARIANT=0` it fails on every prompt on every backend
(42/42), so it can actually catch a regression. The needle test — the only other
caller of the helper — still passes (6 passed, at reduced settings to fit
12 GiB). `pre-commit run --files ...` is clean.

**SM90 confirmed** — @yuvalluria ran the three parametrisations on an H100 NVL
(Torch 2.13.0+cu130, vLLM 0.28.1rc1.dev580+g385dce36b): FLASH_ATTN,
FLEX_ATTENTION and TRITON_ATTN all pass, 3 passed in 208.27s. That covers the
path I could not reach on sm_86, where the Triton matmul overrides and cuBLAS
workspace pinning differ.

The A100/H100/B200 Batch Invariance jobs in `.buildkite/test_areas/misc.yaml`
run this file with no `-k` filter and list `tests/v1/determinism/` in
`source_file_dependencies`, so CI will exercise it on all three.

Cost is ~2 min for three backends, mostly engine startup, and only in those
dedicated jobs.

## Model evaluation

Not applicable: a test plus an optional keyword argument on a test-local helper.
No model, kernel or serving code changes.

## Not a duplicate

Checked 2026-09-10. No open PR adds chunked-prefill coverage here. #45819
(GDN_ATTN) re-indents this same test function and carries the TODO along
unchanged — happy to rebase if it lands first. #46592 (prefix cache) adds a
canonical prefill chunk size, which this test would then cover.

The new test does share its comparison loop with `bs1_vs_bsN`. That duplication
predates this PR — `bs1_vs_bsN` and `..._should_fail` are already 107 identical
lines out of 128 — and I would rather deduplicate all three in a follow-up than
reshape two existing tests here.

## AI assistance

Developed with AI assistance (Claude). I reviewed every changed line and ran the
tests and linters above on my own hardware.