### PR TITLE
[Feat][MM UUIDs] Use UUIDs for media cache lookups and make them auto-derivable from URLs

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import hashlib
 import warnings
 from collections.abc import Mapping
 from typing import Literal
@@ -9,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
+from PIL import Image
 
 from vllm.assets.audio import AudioAsset
 from vllm.assets.image import ImageAsset
@@ -276,6 +278,70 @@ def test_parse_chat_messages_single_image(
     ]
     _assert_mm_data_is_image_input(mm_data, 1)
     _assert_mm_uuids(mm_uuids, 1, expected_uuids=[None])
+
+
+def test_parse_chat_messages_auto_derives_uuids_from_urls(
+    phi3v_model_config,
+    monkeypatch,
+):
+    monkeypatch.setenv("VLLM_UUID_AUTO_DERIVE", "1")
+    image_urls = [
+        encode_image_url(Image.new("RGB", (1, 1), color=color))
+        for color in ("red", "blue")
+    ]
+
+    _, mm_data, mm_uuids = parse_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": url}}
+                    for url in image_urls
+                ],
+            }
+        ],
+        phi3v_model_config,
+        content_format="string",
+    )
+
+    expected_uuids: list[str | None] = [
+        hashlib.sha256(url.encode()).hexdigest() for url in image_urls
+    ]
+    assert expected_uuids[0] != expected_uuids[1]
+    _assert_mm_data_is_image_input(mm_data, 2)
+    _assert_mm_uuids(mm_uuids, 2, expected_uuids=expected_uuids)
+
+
+def test_parse_chat_messages_explicit_uuid_overrides_auto_derivation(
+    phi3v_model_config,
+    monkeypatch,
+):
+    monkeypatch.setenv("VLLM_UUID_AUTO_DERIVE", "1")
+    image_urls = [
+        encode_image_url(Image.new("RGB", (1, 1), color=color))
+        for color in ("red", "blue")
+    ]
+
+    _, mm_data, mm_uuids = parse_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": url},
+                        "uuid": "shared-uuid",
+                    }
+                    for url in image_urls
+                ],
+            }
+        ],
+        phi3v_model_config,
+        content_format="string",
+    )
+
+    _assert_mm_data_is_image_input(mm_data, 2)
+    _assert_mm_uuids(mm_uuids, 2, expected_uuids=["shared-uuid", "shared-uuid"])
 
 
 def test_parse_chat_messages_single_image_with_uuid(

--- a/tests/multimodal/media/test_connector.py
+++ b/tests/multimodal/media/test_connector.py
@@ -7,7 +7,9 @@ import os
 import shutil
 import time
 from io import BytesIO
+from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from unittest.mock import MagicMock
 
 import aiohttp
 import numpy as np
@@ -18,9 +20,10 @@ import torch
 from PIL import Image, ImageChops
 
 from vllm.assets.base import VLLM_S3_BUCKET_URL
+from vllm.connections import HTTPConnection
 from vllm.multimodal.image import convert_image_mode
 from vllm.multimodal.inputs import PlaceholderRange
-from vllm.multimodal.media import MediaConnector
+from vllm.multimodal.media import MediaConnector, MediaIO
 
 # Test different image extensions (JPG/PNG) and formats (gray/RGB/RGBA)
 TEST_IMAGE_ASSETS = [
@@ -462,7 +465,7 @@ async def test_ssrf_bypass_backslash_disallowed_domain():
         await connector.fetch_image_async(bypass_url)
 
 
-def _make_cached_connector(cache_dir, *, max_mb=10, ttl_hours=24):
+def _make_cached_connector(cache_dir, *, connection=None, max_mb=10, ttl_hours=24):
     """Create a MediaConnector with caching enabled via monkeypatched internals.
 
     We bypass __init__'s env-var path and wire up the cache fields directly
@@ -470,7 +473,9 @@ def _make_cached_connector(cache_dir, *, max_mb=10, ttl_hours=24):
     only used as cache keys (hashed to derive filenames); no HTTP requests
     are made.
     """
-    connector = MediaConnector()
+    connector = MediaConnector(
+        **({"connection": connection} if connection is not None else {})
+    )
     connector._media_cache_dir = cache_dir
     connector._media_cache_max_bytes = max_mb * 1024 * 1024
     connector._media_cache_ttl_secs = ttl_hours * 3600
@@ -487,6 +492,29 @@ def test_cache_put_and_get():
         connector._put_cached_bytes(url, data)
         cached = connector._get_cached_bytes(url)
         assert cached == data
+
+
+def test_uuid_is_the_authoritative_media_cache_key_over_url():
+    """An explicit UUID identifies one cached download independent of its URL."""
+    connection = MagicMock(spec=HTTPConnection)
+    connection.get_bytes.side_effect = [b"first-payload", b"second-payload"]
+
+    media_io = MagicMock(spec=MediaIO)
+    media_io.get_max_bytes.return_value = None
+    media_io.load_bytes.side_effect = lambda data: data
+
+    with TemporaryDirectory() as cache_dir:
+        connector = _make_cached_connector(cache_dir, connection=connection)
+        first = connector.load_from_url(
+            "https://first.example/image.png", media_io, uuid="shared-uuid"
+        )
+        second = connector.load_from_url(
+            "https://second.example/image.jpg", media_io, uuid="shared-uuid"
+        )
+
+        assert first == second == b"first-payload"
+        connection.get_bytes.assert_called_once()
+        assert len(list(Path(cache_dir).iterdir())) == 1
 
 
 def test_cache_ttl_expiry():

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -65,7 +65,11 @@ from vllm.multimodal.inputs import (
     VisionChunkImage,
     VisionChunkVideo,
 )
-from vllm.multimodal.media import MEDIA_CONNECTOR_REGISTRY, MediaConnector
+from vllm.multimodal.media import (
+    MEDIA_CONNECTOR_REGISTRY,
+    MediaConnector,
+    derive_media_uuid,
+)
 from vllm.multimodal.processing import BaseMultiModalProcessor
 from vllm.renderers.embed_utils import (
     safe_load_prompt_embeds,
@@ -100,6 +104,12 @@ MODALITY_PLACEHOLDERS_MAP = {
     "video": "<##VIDEO##>",
     "prompt_embeds": "<##PROMPT_EMBEDS##>",
 }
+
+
+def _resolve_media_uuid(url: str | None, uuid: str | None) -> str | None:
+    if uuid is None and url is not None and envs.VLLM_UUID_AUTO_DERIVE:
+        return derive_media_uuid(url)
+    return uuid
 
 
 PROMPT_EMBEDS_PLACEHOLDER_TOKEN: Final[str] = "<prompt_embeds>"
@@ -1036,6 +1046,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder("prompt_embeds", PROMPT_EMBEDS_PLACEHOLDER_TOKEN)
 
     def parse_image(self, image_url: str | None, uuid: str | None = None) -> None:
+        uuid = _resolve_media_uuid(image_url, uuid)
         image = self._connector.fetch_image(image_url, uuid=uuid) if image_url else None
 
         placeholder = self._tracker.add("image", (image, uuid))
@@ -1102,6 +1113,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder("image", placeholder)
 
     def parse_audio(self, audio_url: str | None, uuid: str | None = None) -> None:
+        uuid = _resolve_media_uuid(audio_url, uuid)
         audio = self._connector.fetch_audio(audio_url, uuid=uuid) if audio_url else None
 
         placeholder = self._tracker.add("audio", (audio, uuid))
@@ -1124,6 +1136,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         return self.parse_audio(audio_url, uuid)
 
     def parse_video(self, video_url: str | None, uuid: str | None = None) -> None:
+        uuid = _resolve_media_uuid(video_url, uuid)
         video = (
             self._connector.fetch_video(
                 video_url=video_url,
@@ -1240,6 +1253,7 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return image, uuid
 
     def parse_image(self, image_url: str | None, uuid: str | None = None) -> None:
+        uuid = _resolve_media_uuid(image_url, uuid)
         placeholder = self._tracker.add(
             "image", partial(self._image_with_uuid_async, image_url, uuid)
         )
@@ -1338,6 +1352,7 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return audio, uuid
 
     def parse_audio(self, audio_url: str | None, uuid: str | None = None) -> None:
+        uuid = _resolve_media_uuid(audio_url, uuid)
         placeholder = self._tracker.add(
             "audio", partial(self._audio_with_uuid_async, audio_url, uuid)
         )
@@ -1372,6 +1387,7 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         return video, uuid
 
     def parse_video(self, video_url: str | None, uuid: str | None = None) -> None:
+        uuid = _resolve_media_uuid(video_url, uuid)
         placeholder = self._tracker.add(
             "video", partial(self._video_with_uuid_async, video_url, uuid)
         )

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1036,7 +1036,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder("prompt_embeds", PROMPT_EMBEDS_PLACEHOLDER_TOKEN)
 
     def parse_image(self, image_url: str | None, uuid: str | None = None) -> None:
-        image = self._connector.fetch_image(image_url) if image_url else None
+        image = self._connector.fetch_image(image_url, uuid=uuid) if image_url else None
 
         placeholder = self._tracker.add("image", (image, uuid))
         self._add_placeholder("image", placeholder)
@@ -1102,7 +1102,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         self._add_placeholder("image", placeholder)
 
     def parse_audio(self, audio_url: str | None, uuid: str | None = None) -> None:
-        audio = self._connector.fetch_audio(audio_url) if audio_url else None
+        audio = self._connector.fetch_audio(audio_url, uuid=uuid) if audio_url else None
 
         placeholder = self._tracker.add("audio", (audio, uuid))
         self._add_placeholder("audio", placeholder)
@@ -1128,6 +1128,7 @@ class MultiModalContentParser(BaseMultiModalContentParser):
             self._connector.fetch_video(
                 video_url=video_url,
                 video_processor=self._tracker.video_processor_name,
+                uuid=uuid,
             )
             if video_url
             else None
@@ -1142,7 +1143,9 @@ class MultiModalContentParser(BaseMultiModalContentParser):
             and self._mm_processor_kwargs
             and self._mm_processor_kwargs.get("use_audio_in_video", False)
         ):
-            audio = self._connector.fetch_audio(video_url) if video_url else None
+            audio = (
+                self._connector.fetch_audio(video_url, uuid=uuid) if video_url else None
+            )
             audio_placeholder = self._tracker.add("audio", (audio, uuid))
             self._add_placeholder("audio", audio_placeholder)
 
@@ -1230,7 +1233,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
 
     async def _image_with_uuid_async(self, image_url: str | None, uuid: str | None):
         image = (
-            await self._connector.fetch_image_async(image_url) if image_url else None
+            await self._connector.fetch_image_async(image_url, uuid=uuid)
+            if image_url
+            else None
         )
         return image, uuid
 
@@ -1326,7 +1331,9 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
 
     async def _audio_with_uuid_async(self, audio_url: str | None, uuid: str | None):
         audio = (
-            await self._connector.fetch_audio_async(audio_url) if audio_url else None
+            await self._connector.fetch_audio_async(audio_url, uuid=uuid)
+            if audio_url
+            else None
         )
         return audio, uuid
 
@@ -1357,6 +1364,7 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
             await self._connector.fetch_video_async(
                 video_url,
                 video_processor=self._tracker.video_processor_name,
+                uuid=uuid,
             )
             if video_url
             else None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     VLLM_MEDIA_CACHE: str = ""
     VLLM_MEDIA_CACHE_MAX_SIZE_MB: int = 5120
     VLLM_MEDIA_CACHE_TTL_HOURS: float = 24
+    VLLM_UUID_AUTO_DERIVE: bool = False
     VLLM_MEDIA_FETCH_MAX_RETRIES: int = 3
     VLLM_MAX_MEDIA_DOWNLOAD_SIZE_MB: int = 256
     VLLM_MEDIA_URL_ALLOW_REDIRECTS: bool = True
@@ -978,6 +979,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MEDIA_CACHE_TTL_HOURS": lambda: float(
         os.getenv("VLLM_MEDIA_CACHE_TTL_HOURS", "24")
     ),
+    # Whether to derive multimodal UUIDs from media URLs when none are provided.
+    "VLLM_UUID_AUTO_DERIVE": lambda: bool(int(os.getenv("VLLM_UUID_AUTO_DERIVE", "0"))),
     # Maximum number of retries for fetching media (images, audio, video)
     # from URLs. Each retry quadruples the timeout. Default is 3.
     "VLLM_MEDIA_FETCH_MAX_RETRIES": lambda: int(
@@ -2346,6 +2349,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_MEDIA_CACHE",
         "VLLM_MEDIA_CACHE_MAX_SIZE_MB",
         "VLLM_MEDIA_CACHE_TTL_HOURS",
+        "VLLM_UUID_AUTO_DERIVE",
         "VLLM_MEDIA_FETCH_MAX_RETRIES",
         "VLLM_MEDIA_URL_ALLOW_REDIRECTS",
         "VLLM_MEDIA_LOADING_THREAD_COUNT",

--- a/vllm/multimodal/media/__init__.py
+++ b/vllm/multimodal/media/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from .audio import AudioEmbeddingMediaIO, AudioMediaIO
 from .base import MediaIO, MediaWithBytes
-from .connector import MEDIA_CONNECTOR_REGISTRY, MediaConnector
+from .connector import MEDIA_CONNECTOR_REGISTRY, MediaConnector, derive_media_uuid
 from .image import ImageEmbeddingMediaIO, ImageMediaIO
 from .video import VIDEO_LOADER_REGISTRY, VideoMediaIO
 
@@ -17,4 +17,5 @@ __all__ = [
     "VideoMediaIO",
     "MEDIA_CONNECTOR_REGISTRY",
     "MediaConnector",
+    "derive_media_uuid",
 ]

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -55,6 +55,10 @@ MODALITY_IO_MAP: dict[str, type[MediaIO]] = {
 }
 
 
+def derive_media_uuid(url: str) -> str:
+    return hashlib.sha256(url.encode()).hexdigest()
+
+
 def _wrap_media_fetch_error(
     url: str, exc: Exception
 ) -> VLLMUnprocessableEntityError | Exception:

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -229,11 +229,11 @@ class MediaConnector:
                     media_cache,
                 )
 
-    def _get_cached_bytes(self, url: str) -> bytes | None:
-        """Return cached bytes for a URL, or None if not cached/expired."""
+    def _get_cached_bytes(self, cache_key: str) -> bytes | None:
+        """Return cached bytes for a key, or None if not cached/expired."""
         if not self._media_cache_dir:
             return None
-        cache_path = self._media_cache_path(url)
+        cache_path = self._media_cache_path(cache_key)
         # Check TTL
         try:
             age = time.time() - cache_path.stat().st_mtime
@@ -249,11 +249,11 @@ class MediaConnector:
         except OSError:
             return None
 
-    def _put_cached_bytes(self, url: str, data: bytes) -> None:
+    def _put_cached_bytes(self, cache_key: str, data: bytes) -> None:
         """Store downloaded bytes and evict if over budget."""
         if not self._media_cache_dir:
             return
-        cache_path = self._media_cache_path(url)
+        cache_path = self._media_cache_path(cache_key)
         # Atomic write via temp file + rename
         tmp_path = None
         try:
@@ -305,10 +305,10 @@ class MediaConnector:
         for f in expired:
             f.unlink(missing_ok=True)
 
-    def _media_cache_path(self, url: str) -> Path:
-        url_hash = hashlib.sha256(url.encode()).hexdigest()[:20]
-        ext = Path(url.split("?", 1)[0]).suffix or ""
-        return Path(self._media_cache_dir) / f"{url_hash}{ext}"  # type: ignore[arg-type]
+    def _media_cache_path(self, cache_key: str) -> Path:
+        key_hash = hashlib.sha256(cache_key.encode()).hexdigest()[:20]
+        ext = Path(cache_key.split("?", 1)[0]).suffix or ""
+        return Path(self._media_cache_dir) / f"{key_hash}{ext}"  # type: ignore[arg-type]
 
     def _load_data_url(
         self,
@@ -368,6 +368,7 @@ class MediaConnector:
         url: str,
         media_io: MediaIO[_M],
         *,
+        uuid: str | None = None,
         fetch_timeout: int | None = None,
     ) -> _M:  # type: ignore[type-var]
         if url[:5].lower() == "data:":
@@ -378,8 +379,9 @@ class MediaConnector:
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
             max_bytes = media_io.get_max_bytes()
+            cache_key = uuid if uuid is not None else url
 
-            cached = self._get_cached_bytes(url)
+            cached = self._get_cached_bytes(cache_key)
             if cached is not None:
                 return media_io.load_bytes(cached)
 
@@ -397,7 +399,7 @@ class MediaConnector:
                     raise wrapped from e
                 raise
 
-            self._put_cached_bytes(url, data)
+            self._put_cached_bytes(cache_key, data)
             return media_io.load_bytes(data)
 
         if url_spec.scheme == "file":
@@ -411,6 +413,7 @@ class MediaConnector:
         url: str,
         media_io: MediaIO[_M],
         *,
+        uuid: str | None = None,
         fetch_timeout: int | None = None,
     ) -> _M:
         loop = asyncio.get_running_loop()
@@ -426,9 +429,10 @@ class MediaConnector:
         if url_spec.scheme and url_spec.scheme.startswith("http"):
             self._assert_url_in_allowed_media_domains(url_spec)
             max_bytes = media_io.get_max_bytes()
+            cache_key = uuid if uuid is not None else url
 
             cached = await loop.run_in_executor(
-                global_thread_pool, self._get_cached_bytes, url
+                global_thread_pool, self._get_cached_bytes, cache_key
             )
             if cached is not None:
                 future = loop.run_in_executor(
@@ -451,7 +455,7 @@ class MediaConnector:
                 raise
 
             await loop.run_in_executor(
-                global_thread_pool, self._put_cached_bytes, url, data
+                global_thread_pool, self._put_cached_bytes, cache_key, data
             )
             future = loop.run_in_executor(global_thread_pool, media_io.load_bytes, data)
             return await future
@@ -467,6 +471,8 @@ class MediaConnector:
     def fetch_audio(
         self,
         audio_url: str,
+        *,
+        uuid: str | None = None,
     ) -> tuple[np.ndarray, int | float]:
         """
         Load audio from a URL.
@@ -476,12 +482,15 @@ class MediaConnector:
         return self.load_from_url(
             audio_url,
             audio_io,
+            uuid=uuid,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
         )
 
     async def fetch_audio_async(
         self,
         audio_url: str,
+        *,
+        uuid: str | None = None,
     ) -> tuple[np.ndarray, int | float]:
         """
         Asynchronously fetch audio from a URL.
@@ -491,6 +500,7 @@ class MediaConnector:
         return await self.load_from_url_async(
             audio_url,
             audio_io,
+            uuid=uuid,
             fetch_timeout=envs.VLLM_AUDIO_FETCH_TIMEOUT,
         )
 
@@ -499,6 +509,7 @@ class MediaConnector:
         image_url: str,
         *,
         image_mode: str | None = "RGB",
+        uuid: str | None = None,
     ) -> Image.Image:
         """
         Load a PIL image from an HTTP or base64 data URL.
@@ -515,6 +526,7 @@ class MediaConnector:
             return self.load_from_url(
                 image_url,
                 image_io,
+                uuid=uuid,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
             )
         except UnidentifiedImageError as e:
@@ -526,6 +538,7 @@ class MediaConnector:
         image_url: str,
         *,
         image_mode: str | None = "RGB",
+        uuid: str | None = None,
     ) -> Image.Image:
         """
         Asynchronously load a PIL image from an HTTP or base64 data URL.
@@ -542,6 +555,7 @@ class MediaConnector:
             return await self.load_from_url_async(
                 image_url,
                 image_io,
+                uuid=uuid,
                 fetch_timeout=envs.VLLM_IMAGE_FETCH_TIMEOUT,
             )
         except UnidentifiedImageError as e:
@@ -554,6 +568,7 @@ class MediaConnector:
         *,
         image_mode: str | None = "RGB",
         video_processor: str | None = None,
+        uuid: str | None = None,
     ) -> MediaWithBytes[tuple[npt.NDArray, dict[str, Any]]]:
         """
         Load video from an HTTP or base64 data URL.
@@ -571,6 +586,7 @@ class MediaConnector:
         return self.load_from_url(
             video_url,
             video_io,
+            uuid=uuid,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
         )
 
@@ -580,6 +596,7 @@ class MediaConnector:
         *,
         image_mode: str | None = "RGB",
         video_processor: str | None = None,
+        uuid: str | None = None,
     ) -> MediaWithBytes[tuple[npt.NDArray, dict[str, Any]]]:
         """
         Asynchronously load video from an HTTP or base64 data URL.
@@ -601,6 +618,7 @@ class MediaConnector:
         return await self.load_from_url_async(
             video_url,
             video_io,
+            uuid=uuid,
             fetch_timeout=envs.VLLM_VIDEO_FETCH_TIMEOUT,
         )
 


### PR DESCRIPTION

## Purpose
This PR combines 2 small changes related to making multi-modal UUIDs the source of truth for media identity:

* ***Media Cache keys*** - make UUIDs authoritative media cache keys over URLs; that way two requests with different URLs but same UUID can share a media cache entry
* ***Opt-in UUID auto derivation***  - if `VLLM_UUID_AUTO_DERIVE` is set then we derive `media_uuid=hash(media_url)`. If https://github.com/vllm-project/vllm/pull/55583 is merged, this will enable automatic early mm cache lookups on repeated url's.

## Test Plan
### Media Cache keys
```bash
.venv/bin/python -m pytest \
  tests/multimodal/media/test_connector.py::test_uuid_is_the_authoritative_media_cache_key_over_url \
  -q
```

### Opt-in UUID auto derivation
```bash
.venv/bin/python -m pytest \
  tests/entrypoints/unit_tests/test_chat_utils.py::test_parse_chat_messages_auto_derives_uuids_from_urls \
  tests/entrypoints/unit_tests/test_chat_utils.py::test_parse_chat_messages_explicit_uuid_overrides_auto_derivation \
  -q
```

## Test Result
All tests failed before the PR, but pass now.
### Media Cache keys
```bash
.                                                                        [100%]
1 passed, 15 warnings in 0.11s
```

### Opt-in UUID auto derivation
```bash
..                                                                       [100%]
2 passed, 14 warnings in 2.28s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
