### PR TITLE
[Docs] Align Recipes converter output name with config.yml

### DIFF
--- a/docs/benchmarking/README.md
+++ b/docs/benchmarking/README.md
@@ -5,4 +5,4 @@ vLLM provides comprehensive benchmarking tools for performance testing and evalu
 - **[Benchmark CLI](./cli.md)**: `vllm bench` CLI tools and specialized benchmark scripts for interactive performance testing.
 - **[Parameter Sweeps](./sweeps.md)**: Automate `vllm bench` runs for multiple configurations, useful for [optimization and tuning](../configuration/optimization.md).
 - **[Performance Dashboard](./dashboard.md)**: Automated CI that publishes benchmarks on each commit.
-- **[Benchmark using vLLM Recipes](../../tools/recipes/README.md)**: Use the Recipe conversion tool to generate `config.yaml` and `env.sh` from [vLLM Recipes](https://recipes.vllm.ai/) for Benchmarking.
+- **[Benchmark using vLLM Recipes](../../tools/recipes/README.md)**: Use the Recipe conversion tool to generate `config.yml` and `env.sh` from [vLLM Recipes](https://recipes.vllm.ai/) for Benchmarking.

--- a/docs/configuration/serve_args.md
+++ b/docs/configuration/serve_args.md
@@ -31,7 +31,7 @@ vllm serve --config config.yaml
 
 ### Generate a configuration from vLLM Recipes
 
-[vLLM Recipes](https://recipes.vllm.ai/) can be converted into `config.yaml`
+[vLLM Recipes](https://recipes.vllm.ai/) can be converted into `config.yml`
 and `env.sh`. See the
 [Recipes conversion tool README](../../tools/recipes/README.md) for usage.
 
@@ -39,7 +39,7 @@ Source the generated environment before starting vLLM:
 
 ```bash
 source env.sh
-vllm serve --config config.yaml
+vllm serve --config config.yml
 ```
 
 !!! note

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -10,7 +10,7 @@ toc_depth: 2
 
 ## Run a vLLM Recipes configuration
 
-[vLLM Recipes](https://recipes.vllm.ai/) can be converted into `config.yaml`
+[vLLM Recipes](https://recipes.vllm.ai/) can be converted into `config.yml`
 and `env.sh`. See the
 [Recipes conversion tool README](../../tools/recipes/README.md) for usage.
 
@@ -20,13 +20,13 @@ starting vLLM:
 ```bash
 docker run --rm --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    -v "$PWD/config.yaml:/recipe/config.yaml:ro" \
+    -v "$PWD/config.yml:/recipe/config.yml:ro" \
     -v "$PWD/env.sh:/recipe/env.sh:ro" \
     -p 8000:8000 \
     --ipc=host \
     --entrypoint /bin/bash \
     vllm/vllm-openai:latest \
-    -lc 'source /recipe/env.sh && exec vllm serve --config /recipe/config.yaml'
+    -lc 'source /recipe/env.sh && exec vllm serve --config /recipe/config.yml'
 ```
 
 ## Persist the compile cache across containers

--- a/docs/models/hardware_supported_models/cpu.md
+++ b/docs/models/hardware_supported_models/cpu.md
@@ -13,7 +13,7 @@
 ## Deploy from a vLLM Recipe
 
 The **Recipe** column below links to validated Xeon 6 configurations when
-available. Use the Recipe conversion tool to generate `config.yaml` and
+available. Use the Recipe conversion tool to generate `config.yml` and
 `env.sh`; see the
 [Recipes conversion tool README](../../../tools/recipes/README.md) for usage.
 
@@ -21,7 +21,7 @@ Load the generated environment before starting vLLM:
 
 ```bash
 source env.sh
-vllm serve --config config.yaml
+vllm serve --config config.yml
 ```
 
 ## Recommended Models


### PR DESCRIPTION
## Summary
- The Recipe conversion tool writes `config.yml` by default (`tools/recipes/README.md`, `tools/recipes/recipe_json_to_vllm_config.py --config-out` default).
- Several docs still tell users the tool generates `config.yaml`, so copy-paste after conversion fails to find the file.
- Align Recipes sections in `serve_args`, Docker, CPU hardware, and benchmarking docs with the tool default. Hand-written illustrative `config.yaml` examples that are not about the converter are left unchanged.

## Repro
```bash
# Tool default output name
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/tools/recipes/recipe_json_to_vllm_config.py \
  | rg -n 'default=."config\.yml"|config\.yml'

# Docs still saying config.yaml for Recipes conversion (before this PR)
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/configuration/serve_args.md \
  | rg -n 'Recipes|config\.yaml'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/deployment/docker.md \
  | rg -n 'Recipes|config\.yaml'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/models/hardware_supported_models/cpu.md \
  | rg -n 'Recipe|config\.yaml'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/benchmarking/README.md \
  | rg -n 'Recipes|config\.yaml'
```

Expected before: docs say `config.yaml` for Recipes converter output.
Expected after: those Recipes sections say `config.yml`, matching the tool.

Signed-off-by: ADou <ikun3.1415927@gmail.com>