### PR TITLE
[Spec Decode][GLM-5.3] Expose auxiliary hidden states (EAGLE-3 / DFlash) from Glm5Next

### DIFF
--- a/tests/models/glm5next/test_aux_hidden_states.py
+++ b/tests/models/glm5next/test_aux_hidden_states.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""EAGLE-3 / DFlash auxiliary hidden states on GLM-5.3 (Glm5Next)."""
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.models.glm5next.nvidia.model as glm5next_model
+from vllm.model_executor.models.interfaces import supports_eagle3
+from vllm.models.glm5next.nvidia.model import (
+    Glm5NextForCausalLM,
+    Glm5NextForConditionalGeneration,
+    Glm5NextModel,
+)
+
+
+def test_both_model_classes_advertise_eagle3():
+    assert supports_eagle3(Glm5NextForCausalLM)
+    assert supports_eagle3(Glm5NextForConditionalGeneration)
+
+
+class _FakeMhcLayer:
+    """Stands in for an mHC decoder layer: records the deferred post-mix call."""
+
+    def __init__(self, n: int):
+        self.n = n
+        self.calls: list[tuple] = []
+
+    def hc_post(self, x, residual, post, comb):
+        self.calls.append((x, residual, post, comb))
+        # Pretend the post-mix returns the widened residual stream.
+        return residual
+
+
+def _fake_model(layers, sequence_parallel: bool = False):
+    return SimpleNamespace(layers=layers, is_sequence_parallel=sequence_parallel)
+
+
+def test_aux_state_before_layer_zero_is_the_embedding():
+    model = _fake_model([_FakeMhcLayer(n=4)])
+    hidden = torch.randn(5, 8)
+    out = Glm5NextModel._aux_hidden_state(model, 0, hidden, None, None, None, 5)
+    assert out is hidden
+
+
+def test_aux_state_inside_mhc_stack_applies_previous_post_mix_and_contracts(
+    monkeypatch,
+):
+    n = 4
+    layers = [_FakeMhcLayer(n) for _ in range(3)]
+    model = _fake_model(layers)
+    x = torch.randn(5, 8)
+    residual = torch.randn(5, n * 8)
+    post, comb = torch.randn(5, n), torch.randn(5, n)
+    contracted = torch.randn(5, 8)
+    seen = {}
+
+    def fake_contract(stream, mult):
+        seen["stream"], seen["mult"] = stream, mult
+        return contracted
+
+    monkeypatch.setattr(glm5next_model, "hc_contract", fake_contract)
+    out = Glm5NextModel._aux_hidden_state(model, 2, x, residual, post, comb, 5)
+    # The stream entering layer 2 is layer 1's deferred post-mix, contracted.
+    assert layers[1].calls == [(x, residual, post, comb)]
+    assert layers[0].calls == [] and layers[2].calls == []
+    assert seen["stream"] is residual and seen["mult"] == n
+    assert out is contracted
+
+
+def test_aux_state_non_mhc_layer_is_the_summed_stream():
+    model = _fake_model([_FakeMhcLayer(n=1), _FakeMhcLayer(n=1)])
+    hidden = torch.randn(5, 8)
+    # Non-mHC layers return (summed hidden_states, residual, None, None):
+    # with post None the stream is hidden_states itself.
+    out = Glm5NextModel._aux_hidden_state(model, 1, hidden, hidden, None, None, 5)
+    assert out is hidden

--- a/tests/models/glm5next/test_aux_hidden_states.py
+++ b/tests/models/glm5next/test_aux_hidden_states.py
@@ -1,12 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""EAGLE-3 / DFlash auxiliary hidden states on GLM-5.3 (Glm5Next)."""
+"""EAGLE-3 / DFlash auxiliary hidden states on GLM-5.3 (Glm5Next).
+
+The mHC layers defer the hyper-connection post-mix into the next layer's
+fused pre-op, so the residual stream entering layer ``i`` is not materialized;
+the aux capture applies the previous layer's post-mix and contracts the
+streams. These tests use the torch-native mHC ops with the real tensor
+shapes: x ``(tokens, hidden)``, residual ``(tokens, n, hidden)``,
+post ``(tokens, n, 1)``, comb ``(tokens, n, n)``.
+"""
 
 from types import SimpleNamespace
 
 import torch
 
-import vllm.models.glm5next.nvidia.model as glm5next_model
+from vllm.model_executor.kernels.mhc.torch import mhc_post_torch
+from vllm.model_executor.layers.mhc import hc_contract
 from vllm.model_executor.models.interfaces import supports_eagle3
 from vllm.models.glm5next.nvidia.model import (
     Glm5NextForCausalLM,
@@ -20,17 +29,16 @@ def test_both_model_classes_advertise_eagle3():
     assert supports_eagle3(Glm5NextForConditionalGeneration)
 
 
-class _FakeMhcLayer:
-    """Stands in for an mHC decoder layer: records the deferred post-mix call."""
+class _MhcLayer:
+    """A decoder layer stand-in whose post-mix is the torch-native mHC op."""
 
     def __init__(self, n: int):
         self.n = n
-        self.calls: list[tuple] = []
+        self.calls = 0
 
     def hc_post(self, x, residual, post, comb):
-        self.calls.append((x, residual, post, comb))
-        # Pretend the post-mix returns the widened residual stream.
-        return residual
+        self.calls += 1
+        return mhc_post_torch(x, residual, post, comb)
 
 
 def _fake_model(layers, sequence_parallel: bool = False):
@@ -38,39 +46,34 @@ def _fake_model(layers, sequence_parallel: bool = False):
 
 
 def test_aux_state_before_layer_zero_is_the_embedding():
-    model = _fake_model([_FakeMhcLayer(n=4)])
+    model = _fake_model([_MhcLayer(n=4)])
     hidden = torch.randn(5, 8)
     out = Glm5NextModel._aux_hidden_state(model, 0, hidden, None, None, None, 5)
     assert out is hidden
 
 
-def test_aux_state_inside_mhc_stack_applies_previous_post_mix_and_contracts(
-    monkeypatch,
-):
-    n = 4
-    layers = [_FakeMhcLayer(n) for _ in range(3)]
+def test_aux_state_inside_mhc_stack_is_previous_post_mix_contracted():
+    torch.manual_seed(0)
+    tokens, n, hidden = 5, 4, 8
+    layers = [_MhcLayer(n) for _ in range(3)]
     model = _fake_model(layers)
-    x = torch.randn(5, 8)
-    residual = torch.randn(5, n * 8)
-    post, comb = torch.randn(5, n), torch.randn(5, n)
-    contracted = torch.randn(5, 8)
-    seen = {}
+    x = torch.randn(tokens, hidden)
+    residual = torch.randn(tokens, n, hidden)
+    post = torch.randn(tokens, n, 1)
+    comb = torch.randn(tokens, n, n)
 
-    def fake_contract(stream, mult):
-        seen["stream"], seen["mult"] = stream, mult
-        return contracted
+    out = Glm5NextModel._aux_hidden_state(model, 2, x, residual, post, comb, tokens)
 
-    monkeypatch.setattr(glm5next_model, "hc_contract", fake_contract)
-    out = Glm5NextModel._aux_hidden_state(model, 2, x, residual, post, comb, 5)
-    # The stream entering layer 2 is layer 1's deferred post-mix, contracted.
-    assert layers[1].calls == [(x, residual, post, comb)]
-    assert layers[0].calls == [] and layers[2].calls == []
-    assert seen["stream"] is residual and seen["mult"] == n
-    assert out is contracted
+    # Only the previous layer's post-mix is applied, then the streams are
+    # averaged: what the last layer does before the final norm.
+    expected = hc_contract(mhc_post_torch(x, residual, post, comb), n)
+    assert out.shape == (tokens, hidden)
+    torch.testing.assert_close(out, expected)
+    assert [layer.calls for layer in layers] == [0, 1, 0]
 
 
 def test_aux_state_non_mhc_layer_is_the_summed_stream():
-    model = _fake_model([_FakeMhcLayer(n=1), _FakeMhcLayer(n=1)])
+    model = _fake_model([_MhcLayer(n=1), _MhcLayer(n=1)])
     hidden = torch.randn(5, 8)
     # Non-mHC layers return (summed hidden_states, residual, None, None):
     # with post None the stream is hidden_states itself.

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -60,9 +60,11 @@ from vllm.model_executor.models.glm4_1v import (
     Glm4vForConditionalGeneration,
 )
 from vllm.model_executor.models.interfaces import (
+    EagleModelMixin,
     HasInnerState,
     IsHybrid,
     MixtureOfExperts,
+    SupportsEagle3,
     SupportsPP,
 )
 from vllm.model_executor.models.utils import (
@@ -575,7 +577,7 @@ class Glm5NextDecoderLayer(nn.Module):
         )
 
 
-class Glm5NextModel(nn.Module):
+class Glm5NextModel(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -682,9 +684,23 @@ class Glm5NextModel(nn.Module):
         if self.is_sequence_parallel:
             hidden_states = sp_shard(hidden_states)
 
-        for layer in self._active_layers:
+        aux_hidden_states: list[torch.Tensor] = []
+        capture_layers = self.aux_hidden_state_layers
+        for layer_idx, layer in enumerate(self._active_layers, self.start_layer):
+            if layer_idx in capture_layers:
+                aux_hidden_states.append(
+                    self._aux_hidden_state(
+                        layer_idx, hidden_states, residual, post, comb, full_num_tokens
+                    )
+                )
             hidden_states, residual, post, comb = layer(
                 positions, hidden_states, residual, post, comb
+            )
+        if self.end_layer in capture_layers:
+            aux_hidden_states.append(
+                self._aux_hidden_state(
+                    self.end_layer, hidden_states, residual, post, comb, full_num_tokens
+                )
             )
 
         if not get_pp_group().is_last_rank:
@@ -701,7 +717,39 @@ class Glm5NextModel(nn.Module):
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
 
         hidden_states = self.norm(hidden_states)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
         return hidden_states
+
+    def _aux_hidden_state(
+        self,
+        layer_idx: int,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        post: torch.Tensor | None,
+        comb: torch.Tensor | None,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        """Residual stream entering ``layer_idx`` (HF ``hidden_states[layer_idx]``).
+
+        Used for EAGLE-3 / DFlash auxiliary hidden states. mHC layers defer the
+        hyper-connection post-mix into the next layer's fused pre-op, so the
+        plain stream is never materialized between layers: apply the previous
+        layer's post-mix here and contract the streams, exactly as the last
+        layer does before the final norm. Non-mHC layers, and the embedding
+        before layer 0, already carry the summed stream in ``hidden_states``.
+        """
+        if post is not None:
+            assert residual is not None and comb is not None
+            prev = self.layers[layer_idx - 1]
+            value = hc_contract(
+                prev.hc_post(hidden_states, residual, post, comb), prev.n
+            )
+        else:
+            value = hidden_states
+        if self.is_sequence_parallel:
+            value = sp_all_gather(value)[:num_tokens]
+        return value
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [
@@ -887,7 +935,7 @@ class Glm5NextModel(nn.Module):
 
 
 class Glm5NextForCausalLM(
-    nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid
+    nn.Module, HasInnerState, SupportsPP, SupportsEagle3, MixtureOfExperts, IsHybrid
 ):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -983,7 +1031,11 @@ class Glm5NextForCausalLM(
     dummy_inputs=Glm4vDummyInputsBuilder,
 )
 class Glm5NextForConditionalGeneration(
-    Glm4vForConditionalGeneration, HasInnerState, IsHybrid, MixtureOfExperts
+    Glm4vForConditionalGeneration,
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    SupportsEagle3,
 ):
     # The text model (KDA + dense-MLA + MoE) is a hybrid mamba model. The
     # multimodal wrapper must declare the same interfaces so vLLM treats it as

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -473,7 +473,8 @@ class Glm5NextDecoderLayer(nn.Module):
         # Attention needs the full token sequence; mHC above ran on the SP
         # shard. Gather for attention, scatter back afterward (DSv4 pattern).
         if self.is_sequence_parallel:
-            x = sp_all_gather(x)[: positions.shape[0]]
+            # positions may be (3, num_tokens) under M-RoPE: use the token dim.
+            x = sp_all_gather(x)[: positions.shape[-1]]
 
         x = self.self_attn(
             hidden_states=x,
@@ -708,11 +709,12 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
         if not get_pp_group().is_last_rank:
             # PP is gated off for GLM-5.3-Flash (no make_empty_intermediate_tensors),
             # so this branch is not exercised. Auxiliary hidden states are not
-            # relayed across PP ranks either (supports_aux_hidden_states_over_pp
-            # stays False, so the runner rejects EAGLE-3 / DFlash with PP > 1). post/comb are the deferred
-            # hc_post state of this rank's last mHC layer; a future PP path
-            # would need to propagate them, but for now they are dropped (the
-            # receiving rank's first layer would fall back to standalone pre).
+            # relayed across PP ranks either: supports_aux_hidden_states_over_pp
+            # stays False, so the runner rejects EAGLE-3 / DFlash with PP > 1.
+            # post/comb are the deferred hc_post state of this rank's last mHC
+            # layer; a future PP path would need to propagate them, but for now
+            # they are dropped (the receiving rank's first layer would fall back
+            # to standalone pre).
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -662,7 +662,7 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -680,7 +680,9 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
             post = None
             comb = None
 
-        full_num_tokens = positions.shape[0]
+        # Token count before sequence-parallel sharding; positions may be
+        # (3, num_tokens) under M-RoPE, so take it from the hidden states.
+        full_num_tokens = hidden_states.shape[0]
         if self.is_sequence_parallel:
             hidden_states = sp_shard(hidden_states)
 
@@ -705,7 +707,9 @@ class Glm5NextModel(nn.Module, EagleModelMixin):
 
         if not get_pp_group().is_last_rank:
             # PP is gated off for GLM-5.3-Flash (no make_empty_intermediate_tensors),
-            # so this branch is not exercised. post/comb are the deferred
+            # so this branch is not exercised. Auxiliary hidden states are not
+            # relayed across PP ranks either (supports_aux_hidden_states_over_pp
+            # stays False, so the runner rejects EAGLE-3 / DFlash with PP > 1). post/comb are the deferred
             # hc_post state of this rank's last mHC layer; a future PP path
             # would need to propagate them, but for now they are dropped (the
             # receiving rank's first layer would fall back to standalone pre).
@@ -970,7 +974,7 @@ class Glm5NextForCausalLM(
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         hidden_states = self.model(
             input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs
         )


### PR DESCRIPTION
## Purpose

DFlash / DFlash2 drafters for GLM-5.3-Flash (e.g. `incoai/GLM-5.3-Flash-DFlash2`, `dflash_config.target_layer_ids = [5, 14, 24, 33, 42]`) consume the target's residual stream at a handful of layers, but `Glm5NextForCausalLM` / `Glm5NextForConditionalGeneration` did not implement the EAGLE-3 auxiliary-hidden-state interface, so `--speculative-config '{"method": "dflash", ...}'` failed at init:

```
RuntimeError: Model does not support EAGLE3 interface but aux_hidden_state_outputs was requested
```

## Change

Implement `SupportsEagle3` / `EagleModelMixin` on `Glm5NextModel` and both model classes.

The value captured at index `i` is the stream **entering** layer `i` (HF `hidden_states[i]`), which is the convention the runner's `+1` mapping of DFlash's `target_layer_ids` expects. GLM-5.3's mHC layers defer the hyper-connection post-mix into the next layer's fused pre-op, so the plain stream is not materialized between layers: the capture applies the previous layer's post-mix (`hc_post`) and contracts the streams (`hc_contract`), exactly as the last layer does before the final norm. Non-mHC layers and the embedding already carry the summed stream. Sequence-parallel runs all-gather the captured value. No change when no aux layers are set.

## Test

2× NVIDIA DGX Spark (GB10, sm_121), `--tensor-parallel-size 2 --nnodes 2`, GLM-5.3-Flash NVFP4, `fp8_ds_mla` KV, `--max-model-len 245760`, `--speculative-config '{"method":"dflash","model":"incoai/GLM-5.3-Flash-DFlash2","num_speculative_tokens":7}'`, together with the drafter KV dtype fix and the GLM-5.3 KV grouping fix (separate PRs, referenced below):

- init passes the interface check and the DFlash2 CUDA graphs capture
- arithmetic gate exact; per-request reasoning-effort levers unchanged
- single-stream decode 25.4 tok/s prose / 56.0 tok/s code (bare: 16.7; MTP ×3: 24.5 / 35.7); prefill 956 tok/s
- keyed long-context probe 15/22 at 8K, same as without a drafter

Related: #53906 (model), #55621 (drafter KV dtype), #55622 (GLM-5.3 KV grouping) — the three together enable DFlash on GLM-5.3-Flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
