### PR TITLE
[Bugfix][Spec Decode] Keep the model dtype for regular attention layers under kv_cache_dtype=fp8_ds_mla

### DIFF
--- a/tests/v1/attention/test_attention_kv_dtype_fp8_ds_mla.py
+++ b/tests/v1/attention/test_attention_kv_dtype_fp8_ds_mla.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""``fp8_ds_mla`` is the packed DeepSeek-MLA cache layout; a regular attention
+layer built under it (a GQA drafter next to a DS-MLA target) must keep the
+model dtype instead of failing backend selection."""
+
+import os
+import tempfile
+
+import pytest
+import torch
+
+from vllm.config import CacheConfig, ModelConfig, VllmConfig, set_current_vllm_config
+from vllm.distributed import (
+    cleanup_dist_env_and_memory,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.model_executor.layers.attention import Attention
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+
+@pytest.fixture
+def single_rank_dist():
+    fd, temp_file = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        with set_current_vllm_config(VllmConfig()):
+            init_distributed_environment(
+                world_size=1,
+                rank=0,
+                distributed_init_method=f"file://{temp_file}",
+                local_rank=0,
+                backend="gloo",
+            )
+            initialize_model_parallel(1, 1)
+            yield
+        cleanup_dist_env_and_memory()
+    finally:
+        try:
+            os.unlink(temp_file)
+        except OSError:
+            pass
+
+
+def _regular_attention_backend():
+    if current_platform.is_cpu():
+        return AttentionBackendEnum.CPU_ATTN.get_class()
+    return AttentionBackendEnum.FLASH_ATTN.get_class()
+
+
+@pytest.mark.parametrize(
+    ("cache_dtype", "expected"),
+    [
+        ("fp8_ds_mla", "auto"),
+        ("auto", "auto"),
+        ("fp8", "fp8"),
+    ],
+)
+def test_regular_attention_layer_kv_cache_dtype(
+    single_rank_dist, cache_dtype: str, expected: str
+):
+    vllm_config = VllmConfig(model_config=ModelConfig(dtype="bfloat16"))
+    with set_current_vllm_config(vllm_config):
+        attn = Attention(
+            num_heads=8,
+            head_size=128,
+            scale=128**-0.5,
+            num_kv_heads=4,
+            cache_config=CacheConfig(cache_dtype=cache_dtype),
+            prefix="draft.model.layers.0.self_attn.attn",
+            attn_backend=_regular_attention_backend(),
+        )
+    assert attn.kv_cache_dtype == expected
+    if expected == "auto":
+        # The model dtype, never a byte-packed cache dtype.
+        assert attn.kv_cache_torch_dtype == torch.bfloat16

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -323,8 +323,7 @@ class Attention(nn.Module, AttentionLayerBase):
             # instead of failing backend selection.
             logger.info_once(
                 "kv_cache_dtype=fp8_ds_mla applies to DeepSeek-MLA layers only; "
-                "regular attention layers (e.g. %s) keep the model dtype.",
-                prefix,
+                "regular attention layers keep the model dtype."
             )
             kv_cache_dtype = "auto"
         self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -315,6 +315,18 @@ class Attention(nn.Module, AttentionLayerBase):
                 sliding_window,
             )
 
+        if kv_cache_dtype == "fp8_ds_mla":
+            # fp8_ds_mla is the packed DeepSeek-MLA cache layout (one 656-byte
+            # tile per token); it has no meaning for a regular attention layer.
+            # Such layers exist next to a DS-MLA target whenever a GQA drafter
+            # (EAGLE-3 / DFlash) is loaded, so keep the model dtype for them
+            # instead of failing backend selection.
+            logger.info_once(
+                "kv_cache_dtype=fp8_ds_mla applies to DeepSeek-MLA layers only; "
+                "regular attention layers (e.g. %s) keep the model dtype.",
+                prefix,
+            )
+            kv_cache_dtype = "auto"
         self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
             kv_cache_dtype, vllm_config.model_config
         )


### PR DESCRIPTION
## Purpose

`fp8_ds_mla` is the packed DeepSeek-MLA cache layout and only MLA layers can use it. When a GQA drafter (EAGLE-3 / DFlash) is loaded next to a DS-MLA target served with `--kv-cache-dtype fp8_ds_mla`, the drafter's plain `Attention` layers inherit that cache dtype and backend selection fails:

```
ValueError: No valid attention backend found for cuda with AttentionSelectorConfig(head_size=128, dtype=torch.bfloat16, kv_cache_dtype=fp8_ds_mla, block_size=256, ...)
```

## Change

In `Attention.__init__`, keep the model dtype for regular attention layers when the requested cache dtype is `fp8_ds_mla` (the same effect as `--kv-cache-dtype-skip-layers`, applied automatically where the requested layout cannot apply), with a one-time log line. MLA layers are unaffected.

## Test

GLM-5.3-Flash (`fp8_ds_mla`, `FLASHINFER_MLA_SPARSE_SM120`) + `incoai/GLM-5.3-Flash-DFlash2` (5 sliding-window GQA layers) on 2× DGX Spark, TP=2: the drafter's layers select FlashAttention with bf16 KV, the engine initializes, arithmetic gate exact, 25.4 / 56.0 tok/s prose / code single-stream decode with the drafter. Without this change the run fails at the selector as above.

Related: #55620 (GLM-5.3 aux hidden states), #55622 (GLM-5.3 KV grouping) — the three together enable DFlash on GLM-5.3-Flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
