### PR TITLE
[Core][GLM-5.3] Carry a GQA drafter's attention layers through the GLM-5.3-Flash KV cache layout

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2476,7 +2476,7 @@ def test_get_kv_cache_config_glm5_carries_gqa_drafter_group():
         for group in groups
         if isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
         and all(
-            isinstance(spec, SlidingWindowSpec)
+            isinstance(spec, SlidingWindowSpec) and not isinstance(spec, KpoolTailSpec)
             for spec in group.kv_cache_spec.kv_cache_specs.values()
         )
     )

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2456,7 +2456,7 @@ def _glm5_like_kv_cache_spec_with_gqa_drafter(
     return kv_cache_spec
 
 
-def test_get_kv_cache_config_glm5_carries_gqa_drafter_group():
+def test_get_kv_cache_config_glm5_carries_gqa_drafter_group(monkeypatch):
     """A GQA drafter next to GLM-5.3 gets its own group inside the GLM-5.3
     layout: block fitted under the MLA page, on a divisor of the model block
     (so block-aligned prefix-cache lookups still line up), page padded to the
@@ -2472,6 +2472,8 @@ def test_get_kv_cache_config_glm5_carries_gqa_drafter_group():
         is None
     )
     vllm_config.speculative_config = SimpleNamespace(use_eagle_block_drop=lambda: True)
+    # The padded-page fit is CUDA-only; the grouping logic itself is not.
+    monkeypatch.setattr(kv_cache_utils.current_platform, "is_cuda", lambda: True)
     mla_spec = cast(MLAAttentionSpec, kv_cache_spec["layers.3.attn"])
     mla_page = mla_spec.page_size_bytes
     idx_page = kv_cache_spec["layers.3.indexer"].page_size_bytes

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2447,7 +2447,7 @@ def _glm5_like_kv_cache_spec_with_gqa_drafter(
     kv_cache_spec = _glm5_like_kv_cache_spec_with_tail()
     for i in range(num_draft_layers):
         kv_cache_spec[f"draft.layers.{i}.attn"] = SlidingWindowSpec(
-            block_size=1024,
+            block_size=16,
             num_kv_heads=4,
             head_size=128,
             dtype=torch.bfloat16,
@@ -2464,11 +2464,18 @@ def test_get_kv_cache_config_glm5_carries_gqa_drafter_group():
     model_config = ModelConfig(max_model_len=8192)
     vllm_config = VllmConfig(model_config=model_config)
     kv_cache_spec = _glm5_like_kv_cache_spec_with_gqa_drafter()
+
+    # Without a speculative config the foreign layers are not a drafter and
+    # the GLM-5.3 path declines (previous behaviour).
+    assert (
+        kv_cache_utils._get_kv_cache_groups_glm5_next(vllm_config, kv_cache_spec)
+        is None
+    )
+    vllm_config.speculative_config = SimpleNamespace(use_eagle_block_drop=lambda: True)
     mla_spec = cast(MLAAttentionSpec, kv_cache_spec["layers.3.attn"])
     mla_page = mla_spec.page_size_bytes
     idx_page = kv_cache_spec["layers.3.indexer"].page_size_bytes
     draft_spec = cast(SlidingWindowSpec, kv_cache_spec["draft.layers.0.attn"])
-    assert draft_spec.page_size_bytes > mla_page
 
     groups = kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
     draft_group = next(
@@ -2487,9 +2494,17 @@ def test_get_kv_cache_config_glm5_carries_gqa_drafter_group():
         SlidingWindowSpec,
         draft_group.kv_cache_spec.kv_cache_specs["draft.layers.0.attn"],
     )
+    # At the shared block size the drafter's page would exceed the MLA page;
+    # the fit enlarges the block only up to what fits under it.
+    assert (
+        draft_spec.page_size_bytes // draft_spec.block_size * mla_spec.block_size
+        > mla_page
+    )
     per_token = draft_spec.page_size_bytes // draft_spec.block_size
-    assert fitted.block_size % 16 == 0
+    assert fitted.block_size % draft_spec.block_size == 0
     assert mla_spec.block_size % fitted.block_size == 0
+    # The drafter's group is the one the coordinator treats as the draft group.
+    assert draft_group.is_eagle_group
     assert fitted.block_size * per_token <= mla_page
     assert fitted.page_size_padded == mla_page
     assert fitted.page_size_bytes == mla_page

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2438,6 +2438,97 @@ def test_get_kv_cache_config_kpool_tail_coowns_indexer_tensor():
     )
 
 
+def _glm5_like_kv_cache_spec_with_gqa_drafter(
+    num_draft_layers: int = 5,
+) -> dict[str, KVCacheSpec]:
+    """GLM-5.3-like specs plus a GQA drafter (EAGLE-3 / DFlash style): a few
+    sliding-window layers whose bf16 K/V row is wider than the MLA row, so at
+    the shared block size their page would be the largest of all."""
+    kv_cache_spec = _glm5_like_kv_cache_spec_with_tail()
+    for i in range(num_draft_layers):
+        kv_cache_spec[f"draft.layers.{i}.attn"] = SlidingWindowSpec(
+            block_size=1024,
+            num_kv_heads=4,
+            head_size=128,
+            dtype=torch.bfloat16,
+            sliding_window=2048,
+        )
+    return kv_cache_spec
+
+
+def test_get_kv_cache_config_glm5_carries_gqa_drafter_group():
+    """A GQA drafter next to GLM-5.3 gets its own group inside the GLM-5.3
+    layout: block fitted under the MLA page, on a divisor of the model block
+    (so block-aligned prefix-cache lookups still line up), page padded to the
+    MLA page, and its layers sized, allocated and accounted for."""
+    model_config = ModelConfig(max_model_len=8192)
+    vllm_config = VllmConfig(model_config=model_config)
+    kv_cache_spec = _glm5_like_kv_cache_spec_with_gqa_drafter()
+    mla_spec = cast(MLAAttentionSpec, kv_cache_spec["layers.3.attn"])
+    mla_page = mla_spec.page_size_bytes
+    idx_page = kv_cache_spec["layers.3.indexer"].page_size_bytes
+    draft_spec = cast(SlidingWindowSpec, kv_cache_spec["draft.layers.0.attn"])
+    assert draft_spec.page_size_bytes > mla_page
+
+    groups = kv_cache_utils.get_kv_cache_groups(vllm_config, kv_cache_spec)
+    draft_group = next(
+        group
+        for group in groups
+        if isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
+        and all(
+            isinstance(spec, SlidingWindowSpec)
+            for spec in group.kv_cache_spec.kv_cache_specs.values()
+        )
+    )
+    assert sorted(draft_group.layer_names) == [
+        f"draft.layers.{i}.attn" for i in range(5)
+    ]
+    fitted = cast(
+        SlidingWindowSpec,
+        draft_group.kv_cache_spec.kv_cache_specs["draft.layers.0.attn"],
+    )
+    per_token = draft_spec.page_size_bytes // draft_spec.block_size
+    assert fitted.block_size % 16 == 0
+    assert mla_spec.block_size % fitted.block_size == 0
+    assert fitted.block_size * per_token <= mla_page
+    assert fitted.page_size_padded == mla_page
+    assert fitted.page_size_bytes == mla_page
+
+    # The layout detector returns the drafter group as its extra member and
+    # every consumer counts its layers at one MLA page each.
+    layout = kv_cache_utils._glm5_next_tensor_layout(groups)
+    assert layout is not None
+    assert layout[8] is draft_group
+    bytes_per_block = kv_cache_utils._pool_bytes_per_block(groups)
+    assert bytes_per_block == 11 * mla_page + 11 * idx_page + 5 * mla_page
+
+    kv_cache_config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, bytes_per_block * 100 + 1
+    )
+    assert kv_cache_config.num_blocks == 100
+    tensors = _tensor_by_layer(kv_cache_config)
+    idx_end = (
+        max(tensors[f"layers.{4 * i + 3}.indexer"].offset for i in range(11))
+        + idx_page * 100
+    )
+    for i in range(5):
+        tensor = tensors[f"draft.layers.{i}.attn"]
+        assert tensor.block_stride == mla_page
+        assert tensor.offset >= idx_end
+    assert {t.size for t in kv_cache_config.kv_cache_tensors} == {bytes_per_block * 100}
+
+    # Memory accounting includes the drafter group.
+    without_drafter = kv_cache_utils.get_kv_cache_groups(
+        vllm_config, _glm5_like_kv_cache_spec_with_tail()
+    )
+    assert kv_cache_utils._max_memory_usage_bytes_from_groups(
+        vllm_config, groups
+    ) > kv_cache_utils._max_memory_usage_bytes_from_groups(vllm_config, without_drafter)
+    # ...and the layout without a drafter is unchanged (no extra group).
+    layout_without = kv_cache_utils._glm5_next_tensor_layout(without_drafter)
+    assert layout_without is not None and layout_without[8] is None
+
+
 def test_glm5_kpool_tail_does_not_drag_hash_block_size():
     """The tail's kpool-sized scratch block (4 tokens) must not constrain the
     prefix-cache hash granularity: participating groups alone decide it."""

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1169,17 +1169,25 @@ _ATTN_BLOCK_GRANULARITY = 16
 
 
 def _fit_specs_under_page(
-    specs: dict[str, KVCacheSpec], page: int
+    specs: dict[str, KVCacheSpec], page: int, ref_block_size: int
 ) -> dict[str, KVCacheSpec] | None:
     """Shrink each attention spec's block so its page fits under ``page``, then
-    pad the page to exactly ``page``. Returns None if a block would drop below
-    the kernel granularity."""
+    pad the page to exactly ``page``. The block is the largest kernel-granular
+    size that fits and also divides ``ref_block_size`` (the model's own block),
+    so that block-aligned prefix-cache lookups can still line up across the
+    groups; a non-dividing block would silently make every lookup miss.
+    Returns None if no such block exists."""
     fitted: dict[str, KVCacheSpec] = {}
     for name, spec in specs.items():
         assert isinstance(spec, AttentionSpec)
         per_token = spec.unpadded_page_size_bytes // spec.block_size
-        block_size = (page // per_token) // _ATTN_BLOCK_GRANULARITY
-        block_size *= _ATTN_BLOCK_GRANULARITY
+        max_block = (page // per_token) // _ATTN_BLOCK_GRANULARITY
+        max_block *= _ATTN_BLOCK_GRANULARITY
+        block_size = 0
+        for candidate in range(max_block, 0, -_ATTN_BLOCK_GRANULARITY):
+            if ref_block_size % candidate == 0:
+                block_size = candidate
+                break
         if block_size < _ATTN_BLOCK_GRANULARITY:
             return None
         if block_size != spec.block_size:
@@ -1284,7 +1292,8 @@ def _get_kv_cache_groups_glm5_next(
 
     extra_group: KVCacheGroupSpec | None = None
     if extra_specs:
-        fitted = _fit_specs_under_page(extra_specs, mla_page)
+        mla_block = next(iter(mla_specs.values())).block_size
+        fitted = _fit_specs_under_page(extra_specs, mla_page, mla_block)
         if fitted is None:
             return None
         extra_uniform = UniformTypeKVCacheSpecs.from_specs(fitted)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1218,7 +1218,7 @@ def _get_kv_cache_groups_glm5_next(
         for name, spec in kv_cache_spec.items()
         if isinstance(spec, KpoolTailSpec)
     }
-    attn_specs = {
+    attn_specs: dict[str, KVCacheSpec] = {
         name: spec
         for name, spec in kv_cache_spec.items()
         if type(spec) is MLAAttentionSpec

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -15,6 +15,7 @@ from typing import Any, NamedTuple, NewType, TypeAlias, cast, overload
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.utils.hashing import xxhash, xxhash_cbor
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import format_gib
@@ -1177,18 +1178,27 @@ def _fit_specs_under_page(
     so that block-aligned prefix-cache lookups can still line up across the
     groups; a non-dividing block would silently make every lookup miss.
     Returns None if no such block exists."""
+    if not current_platform.is_cuda():
+        # A padded page needs the attention kernel to run the fitted block as
+        # is (no kernel block splitting); backends with a fixed set of kernel
+        # block sizes (e.g. ROCm AITER) cannot, so keep the previous behaviour.
+        return None
     fitted: dict[str, KVCacheSpec] = {}
     for name, spec in specs.items():
         assert isinstance(spec, AttentionSpec)
         per_token = spec.unpadded_page_size_bytes // spec.block_size
-        max_block = (page // per_token) // _ATTN_BLOCK_GRANULARITY
-        max_block *= _ATTN_BLOCK_GRANULARITY
+        # Multiples of the spec's own block (itself kernel-granular), so the
+        # layer's sliding-window / alignment semantics are only ever coarsened.
+        step = spec.block_size
+        if step % _ATTN_BLOCK_GRANULARITY:
+            step = _ATTN_BLOCK_GRANULARITY
+        max_block = (page // per_token) // step * step
         block_size = 0
-        for candidate in range(max_block, 0, -_ATTN_BLOCK_GRANULARITY):
+        for candidate in range(max_block, 0, -step):
             if ref_block_size % candidate == 0:
                 block_size = candidate
                 break
-        if block_size < _ATTN_BLOCK_GRANULARITY:
+        if block_size < spec.block_size or block_size < _ATTN_BLOCK_GRANULARITY:
             return None
         if block_size != spec.block_size:
             logger.info_once(
@@ -1233,6 +1243,10 @@ def _get_kv_cache_groups_glm5_next(
         if name not in attn_specs and not isinstance(spec, (MambaSpec, KpoolTailSpec))
     }
     if not mamba_specs or not attn_specs:
+        return None
+    if extra_specs and vllm_config.speculative_config is None:
+        # Only a drafter brings foreign attention layers next to GLM-5.3;
+        # anything else keeps the previous behaviour (generic grouping).
         return None
     if not all(
         isinstance(spec, AttentionSpec) and not isinstance(spec, MLAAttentionSpec)
@@ -1300,6 +1314,14 @@ def _get_kv_cache_groups_glm5_next(
         if extra_uniform is None:
             return None
         extra_group = KVCacheGroupSpec(list(fitted), extra_uniform)
+        spec_config = vllm_config.speculative_config
+        if spec_config is not None and spec_config.use_eagle_block_drop():
+            # This is the drafter's group: flag it so the coordinator applies
+            # the EAGLE last-block drop here only. Left unflagged, the
+            # coordinator flags every group, which widens the Mamba groups'
+            # lookup window past what align-mode checkpointing produces and
+            # silently drops prefix-cache reuse to zero.
+            extra_group.is_eagle_group = True
     return (
         [KVCacheGroupSpec(list(attn_specs), uniform_spec)]
         + ([tail_group] if tail_group is not None else [])
@@ -2461,7 +2483,7 @@ def _max_memory_usage_bytes_from_groups(
         ) = glm5_layout
         uniform_spec = cast(UniformTypeKVCacheSpecs, attn_group.kv_cache_spec)
         total_blocks = uniform_spec.max_memory_usage_pages(vllm_config)
-        if extra_group is not None:
+        if extra_group is not None and extra_group.layer_names:
             total_blocks += cast(
                 UniformTypeKVCacheSpecs, extra_group.kv_cache_spec
             ).max_memory_usage_pages(vllm_config)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1162,6 +1162,39 @@ def _pp_balanced_mamba_group_count(
     return num_groups
 
 
+# Attention kernels take block sizes in multiples of this many tokens; a page
+# padded to a larger physical size keeps its logical block, so the block chosen
+# here must be one the kernels can run directly (no kernel block splitting).
+_ATTN_BLOCK_GRANULARITY = 16
+
+
+def _fit_specs_under_page(
+    specs: dict[str, KVCacheSpec], page: int
+) -> dict[str, KVCacheSpec] | None:
+    """Shrink each attention spec's block so its page fits under ``page``, then
+    pad the page to exactly ``page``. Returns None if a block would drop below
+    the kernel granularity."""
+    fitted: dict[str, KVCacheSpec] = {}
+    for name, spec in specs.items():
+        assert isinstance(spec, AttentionSpec)
+        per_token = spec.unpadded_page_size_bytes // spec.block_size
+        block_size = (page // per_token) // _ATTN_BLOCK_GRANULARITY
+        block_size *= _ATTN_BLOCK_GRANULARITY
+        if block_size < _ATTN_BLOCK_GRANULARITY:
+            return None
+        if block_size != spec.block_size:
+            logger.info_once(
+                "Layer %s: block size %d -> %d so that its KV page fits the "
+                "GLM-5.3 MLA page (%d bytes); the page is padded to match.",
+                name,
+                spec.block_size,
+                block_size,
+                page,
+            )
+        fitted[name] = replace(spec, block_size=block_size, page_size_padded=page)
+    return fitted
+
+
 def _get_kv_cache_groups_glm5_next(
     vllm_config: VllmConfig,
     kv_cache_spec: dict[str, KVCacheSpec],
@@ -1180,10 +1213,22 @@ def _get_kv_cache_groups_glm5_next(
     attn_specs = {
         name: spec
         for name, spec in kv_cache_spec.items()
-        if not isinstance(spec, (MambaSpec, KpoolTailSpec))
+        if type(spec) is MLAAttentionSpec
     }
-    if not mamba_specs or not all(
-        type(spec) is MLAAttentionSpec for spec in attn_specs.values()
+    # Attention layers that are not part of GLM-5.3 itself: a GQA drafter
+    # (EAGLE-3 / DFlash) loaded next to the target. They get their own group,
+    # block-fitted under the MLA page and padded to it, so the layout below is
+    # unchanged for the model's own layers.
+    extra_specs = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if name not in attn_specs and not isinstance(spec, (MambaSpec, KpoolTailSpec))
+    }
+    if not mamba_specs or not attn_specs:
+        return None
+    if not all(
+        isinstance(spec, AttentionSpec) and not isinstance(spec, MLAAttentionSpec)
+        for spec in extra_specs.values()
     ):
         return None
 
@@ -1237,9 +1282,19 @@ def _get_kv_cache_groups_glm5_next(
     for index, name in enumerate(mamba_specs):
         mamba_grouped_names[index % num_groups].append(name)
 
+    extra_group: KVCacheGroupSpec | None = None
+    if extra_specs:
+        fitted = _fit_specs_under_page(extra_specs, mla_page)
+        if fitted is None:
+            return None
+        extra_uniform = UniformTypeKVCacheSpecs.from_specs(fitted)
+        if extra_uniform is None:
+            return None
+        extra_group = KVCacheGroupSpec(list(fitted), extra_uniform)
     return (
         [KVCacheGroupSpec(list(attn_specs), uniform_spec)]
         + ([tail_group] if tail_group is not None else [])
+        + ([extra_group] if extra_group is not None else [])
         + create_kv_cache_group_specs(padded_specs, mamba_grouped_names)
     )
 
@@ -1256,6 +1311,7 @@ def _glm5_next_tensor_layout(
         int,
         list[str],
         int,
+        KVCacheGroupSpec | None,
     ]
     | None
 ):
@@ -1270,12 +1326,20 @@ def _glm5_next_tensor_layout(
     ]
     attn_group: KVCacheGroupSpec | None = None
     tail_group: KVCacheGroupSpec | None = None
+    extra_group: KVCacheGroupSpec | None = None
     for group in uniform_groups:
         inner = cast(UniformTypeKVCacheSpecs, group.kv_cache_spec).kv_cache_specs
         if all(type(spec) is MLAAttentionSpec for spec in inner.values()):
             attn_group = group
         elif all(isinstance(spec, KpoolTailSpec) for spec in inner.values()):
             tail_group = group
+        elif all(
+            isinstance(spec, AttentionSpec) and not isinstance(spec, MLAAttentionSpec)
+            for spec in inner.values()
+        ):
+            if extra_group is not None:
+                return None
+            extra_group = group
     if attn_group is None or not mamba_groups:
         return None
     if len(uniform_groups) + len(mamba_groups) != len(kv_cache_groups):
@@ -1301,6 +1365,13 @@ def _glm5_next_tensor_layout(
     mla_page = mla_pages.pop()
     idx_page = idx_pages.pop()
     if any(group.kv_cache_spec.page_size_bytes != mla_page for group in mamba_groups):
+        return None
+    if extra_group is not None and any(
+        spec.page_size_bytes != mla_page
+        for spec in cast(
+            UniformTypeKVCacheSpecs, extra_group.kv_cache_spec
+        ).kv_cache_specs.values()
+    ):
         return None
 
     tail_names: list[str] = []
@@ -1329,6 +1400,7 @@ def _glm5_next_tensor_layout(
         idx_page,
         tail_names,
         tail_page,
+        extra_group,
     )
 
 
@@ -1555,13 +1627,33 @@ def _get_per_layer_spec(
     return spec
 
 
+def _glm5_next_extra_layer_names(extra_group: KVCacheGroupSpec | None) -> list[str]:
+    return list(extra_group.layer_names) if extra_group is not None else []
+
+
+def _glm5_next_bytes_per_block(
+    mla_names: list[str],
+    idx_names: list[str],
+    mla_page: int,
+    idx_page: int,
+    extra_group: KVCacheGroupSpec | None,
+) -> int:
+    return (
+        len(mla_names) * mla_page
+        + len(idx_names) * idx_page
+        + len(_glm5_next_extra_layer_names(extra_group)) * mla_page
+    )
+
+
 def _get_kv_cache_bytes_per_block(
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> int:
     """Return the largest cache group's bytes per block."""
     if (glm5_layout := _glm5_next_tensor_layout(kv_cache_groups)) is not None:
-        _, _, mla_names, idx_names, mla_page, idx_page, _, _ = glm5_layout
-        return len(mla_names) * mla_page + len(idx_names) * idx_page
+        _, _, mla_names, idx_names, mla_page, idx_page, _, _, extra = glm5_layout
+        return _glm5_next_bytes_per_block(
+            mla_names, idx_names, mla_page, idx_page, extra
+        )
 
     bytes_per_block = max(
         sum(
@@ -1646,8 +1738,11 @@ def get_kv_cache_config_from_groups(
             idx_page,
             tail_names,
             _,
+            extra_group,
         ) = glm5_layout
-        bytes_per_block = len(mla_names) * mla_page + len(idx_names) * idx_page
+        bytes_per_block = _glm5_next_bytes_per_block(
+            mla_names, idx_names, mla_page, idx_page, extra_group
+        )
         num_blocks = may_override_num_blocks(
             vllm_config, available_memory // bytes_per_block
         )
@@ -1689,6 +1784,14 @@ def get_kv_cache_config_from_groups(
                     UniformTypeKVCacheSpecs, tail_group.kv_cache_spec
                 ).kv_cache_specs
                 add_tensor(tail_name, tail_specs[tail_name], offset)
+        if extra_group is not None:
+            extra_specs = cast(
+                UniformTypeKVCacheSpecs, extra_group.kv_cache_spec
+            ).kv_cache_specs
+            extra_base = idx_base + len(idx_names) * idx_page * num_blocks
+            for index, extra_name in enumerate(extra_group.layer_names):
+                offset = extra_base + index * mla_page * num_blocks
+                add_tensor(extra_name, extra_specs[extra_name], offset)
 
         return KVCacheConfig(
             num_blocks=num_blocks,
@@ -2345,9 +2448,14 @@ def _max_memory_usage_bytes_from_groups(
             idx_page,
             tail_names,
             _,
+            extra_group,
         ) = glm5_layout
         uniform_spec = cast(UniformTypeKVCacheSpecs, attn_group.kv_cache_spec)
         total_blocks = uniform_spec.max_memory_usage_pages(vllm_config)
+        if extra_group is not None:
+            total_blocks += cast(
+                UniformTypeKVCacheSpecs, extra_group.kv_cache_spec
+            ).max_memory_usage_pages(vllm_config)
         total_blocks += sum(
             cdiv(
                 group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
@@ -2357,7 +2465,9 @@ def _max_memory_usage_bytes_from_groups(
         )
         if tail_names:
             total_blocks += 1
-        return total_blocks * (len(mla_names) * mla_page + len(idx_names) * idx_page)
+        return total_blocks * _glm5_next_bytes_per_block(
+            mla_names, idx_names, mla_page, idx_page, extra_group
+        )
 
     bytes_per_block = _pool_bytes_per_block(kv_cache_groups)
     total_blocks = 0


### PR DESCRIPTION
## Purpose

GLM-5.3-Flash has a dedicated KV grouping/layout in `kv_cache_utils` (`_get_kv_cache_groups_glm5_next` / `_glm5_next_tensor_layout`) that aliases the MLA, kpool-indexer, tail and KDA state pages into one block layout. It admits only those spec types, so loading a GQA drafter (EAGLE-3 / DFlash) next to the target makes it return `None`; the generic page unification then fails on the indexer cache, which that layout deliberately does not unify:

```
NotImplementedError: Layer language_model.model.layers.3.self_attn.indexer.k_cache: page size is not divisible by the maximum page size and cannot be padded. Padding is only supported for non-MLA attention layers.
```

## Change

Carry the drafter's attention layers through the GLM-5.3 path as one more group: its block is shrunk to the largest kernel-granular (multiple of 16) size whose page fits under the MLA page **and that divides the model's block** — with a sliding-window group present the KV cache coordinator only does block-aligned prefix-cache lookups, and a non-dividing block never lines up with a cached prefix (measured: 0% hit rate, every request re-prefilled) — and the page is padded to exactly the MLA page; the layout recognizer returns the group, and the three consumers (bytes per block, tensor allocation, max-memory accounting) size, allocate and count it. No change without a drafter.

The drafter's group is flagged `is_eagle_group` when the speculative config uses the EAGLE last-block drop. Left unflagged, the KV cache coordinator flags **every** group, which widens the Mamba groups' lookup window past what align-mode checkpointing produces and silently drops prefix-cache reuse to zero (`_warn_if_unannotated_eagle_mamba` describes this) — measured as a 0% hit rate on a repeated 37K-token prefix before this flag. Foreign attention layers are only treated as a drafter when a speculative config is set; the padded-page fit is applied on CUDA only (backends with a fixed set of kernel block sizes cannot run a padded page without kernel block splitting); the fitted block is a multiple of the drafter spec's own block; a drafter group with no layers on a PP rank is not charged in the max-memory accounting.

## Test

GLM-5.3-Flash (`fp8_ds_mla`, kpool indexer, KDA) + `incoai/GLM-5.3-Flash-DFlash2` (5 sliding-window GQA layers) on 2× DGX Spark, TP=2, `--max-model-len 245760`: the engine initializes with 397,776 KV tokens (1.62× concurrency), DFlash2 CUDA graphs capture, arithmetic gate exact, keyed long-context probe unchanged, 25.4 / 56.0 tok/s prose / code single-stream decode. Without this change the run fails as above (and without a drafter the layout is byte-identical to before). A unit test in `tests/v1/core/test_kv_cache_utils.py` covers the grouping, the block fit/alignment, the tensor allocation and the memory accounting with a 5-layer GQA drafter next to the GLM-5.3-like fixture.

Related: #55620 (GLM-5.3 aux hidden states), #55621 (drafter KV dtype) — the three together enable DFlash on GLM-5.3-Flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
