### PR TITLE
[Docs] Note EAGLE3 speculative decoding supports pipeline parallelism

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -223,7 +223,7 @@ For mitigation strategies, please refer to the FAQ entry *Can the output of a pr
 
 ## Known Feature Incompatibility
 
-1. Pipeline parallelism is not composable with speculative decoding as of `vllm<=0.15.0`
+1. Pipeline parallelism is supported with EAGLE3 speculative decoding. Other speculative methods may still lack PP support.
 2. Speculative decoding with draft models is not supported in `vllm<=0.10.0`
 
 ## Resources for vLLM contributors


### PR DESCRIPTION
## Summary

Update the Known Feature Incompatibility note in `docs/features/speculative_decoding/README.md`.

The docs still claimed pipeline parallelism is not composable with speculative decoding (`vllm<=0.15.0`). EAGLE3 + PP is supported on current `main` and covered by `tests/v1/e2e/spec_decode/eagle/test_eagle3_pp.py`. Clarify that other speculative methods may still lack PP support. Leave the historical draft-model `<=0.10.0` note unchanged.

## Local repro

```bash
# Docs still banned PP+SD on main before this change:
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/features/speculative_decoding/README.md \
  | rg -n 'Pipeline parallelism is not composable'

# EAGLE3+PP e2e test exists on main:
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/e2e/spec_decode/eagle/test_eagle3_pp.py \
  | head -1
# expect HTTP/2 200

# After this PR, the incompatibility section should say EAGLE3 supports PP.
```

## Test plan

- [ ] Confirm wording matches intended scope (EAGLE3 only; other methods may still lack PP)
- [ ] No other files changed