### PR TITLE
[Docs] Mark LoRA × speculative decoding as partially compatible

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -41,7 +41,7 @@ th:not(:first-child) {
 | [CP](../configuration/optimization.md#chunked-prefill) | ✅ | | | | | | | | | | | | | | |
 | [APC](automatic_prefix_caching.md) | ✅ | ✅ | | | | | | | | | | | | | |
 | [LoRA](lora.md) | ✅ | ✅ | ✅ | | | | | | | | | | | | |
-| [SD](speculative_decoding/README.md) | ✅ | ✅ | ❌ | ✅ | | | | | | | | | | | |
+| [SD](speculative_decoding/README.md) | ✅ | ✅ | 🟠† | ✅ | | | | | | | | | | | |
 | CUDA graph | ✅ | ✅ | ✅ | ✅ | ✅ | | | | | | | | | | |
 | [pooling](../models/pooling_models/README.md) | 🟠\* | 🟠\* | ✅ | ❌ | ✅ | ✅ | | | | | | | | | |
 | <abbr title="Encoder-Decoder Models">enc-dec</abbr> | ❌ | [❌](https://github.com/vllm-project/vllm/issues/7366) | ❌ | [❌](https://github.com/vllm-project/vllm/issues/7366) | ✅ | ✅ | ✅ | | | | | | | | |
@@ -56,6 +56,7 @@ th:not(:first-child) {
 
 \* Chunked prefill and prefix caching are only applicable to last-token or all pooling with causal attention.  
 <sup>^</sup> LoRA is only applicable to the language backbone of multimodal models.  
+† LoRA with speculative decoding is supported for EAGLE3 (see `tests/v1/e2e/spec_decode/draft_model/test_lora.py`); other speculative methods may still lack full LoRA coverage.  
 
 ### Feature x Hardware
 


### PR DESCRIPTION
## Summary

Update the Feature × Feature compatibility matrix in `docs/features/README.md`.

The matrix still marked LoRA × speculative decoding as `❌` (no compatibility). On current `main`, EAGLE3 + LoRA is exercised by `tests/v1/e2e/spec_decode/draft_model/test_lora.py` (`enable_lora=True` with `speculative_config.method=eagle3`). Mark the cell as partial (`🟠†`) and footnote that other speculative methods may still lack full LoRA coverage. Do not claim full ✅ for every speculative method.

## Local repro

```bash
# Matrix still bans LoRA × SD
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/features/README.md \
  | rg -n 'speculative_decoding/README.md.*❌'

# E2E test enables LoRA together with EAGLE3 speculative decoding
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/e2e/spec_decode/draft_model/test_lora.py \
  | rg -n 'enable_lora|speculative_config|eagle3|method'
```

Expected before this change: matrix cell is `❌`; test file configures both features together and asserts output parity.

## Test plan

- [ ] Confirm only `docs/features/README.md` changed
- [ ] Confirm SD×LoRA cell is `🟠†` with footnote citing `tests/v1/e2e/spec_decode/draft_model/test_lora.py`
- [ ] Docs preview / matrix renders correctly