### PR TITLE
[Docs] Fix ghost --kv-ip/--kv-port in security guide

### DIFF
--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -18,8 +18,8 @@ The following options control internode communications in vLLM:
 
 #### 2. **KV Cache Transfer Configuration:**
 
-- `--kv-ip`: The IP address for KV cache transfer communications (default: 127.0.0.1)
-- `--kv-port`: The port for KV cache transfer communications (default: 14579)
+- `--kv-transfer-config.kv-ip` (or via `--kv-transfer-config '{"kv_ip":"..."}'`): The IP address for KV cache transfer communications (default: 127.0.0.1)
+- `--kv-transfer-config.kv-port` (or via `--kv-transfer-config '{"kv_port":...}'`): The port for KV cache transfer communications (default: 14579)
 
 #### 3. **Data Parallel Configuration:**
 


### PR DESCRIPTION
## Summary
`docs/usage/security.md` documented top-level `--kv-ip` / `--kv-port` for KV cache transfer. Those flags are not registered on the CLI.

Live wiring:
- `vllm/engine/arg_utils.py` registers `--kv-transfer-config` only (no `--kv-ip` / `--kv-port`).
- `vllm/config/kv_transfer.py` defines `KVTransferConfig.kv_ip` (default `127.0.0.1`) and `kv_port` (default `14579`).
- `FlexibleArgumentParser` accepts dotted nested keys, e.g. `--kv-transfer-config.kv-ip` / `--kv-transfer-config.kv-port`, or a JSON blob via `--kv-transfer-config '{"kv_ip":"...","kv_port":...}'`.

This PR updates the security guide to the live nested forms. Defaults unchanged.

## Local repro
```bash
# At main tip (9cc7793e or later)
# 1) Confirm ghost flags are not registered
python - <<'PY'
from vllm.engine.arg_utils import AsyncEngineArgs
from vllm.utils.argparse_utils import FlexibleArgumentParser
p = FlexibleArgumentParser()
AsyncEngineArgs.add_cli_args(p)
opts = {o for a in p._actions for o in a.option_strings}
assert "--kv-transfer-config" in opts
assert "--kv-ip" not in opts and "--kv-port" not in opts
print("ok: only --kv-transfer-config")
PY

# 2) Confirm KVTransferConfig defaults
python - <<'PY'
from vllm.config.kv_transfer import KVTransferConfig
assert KVTransferConfig().kv_ip == "127.0.0.1"
assert KVTransferConfig().kv_port == 14579
print("ok: defaults")
PY

# 3) Confirm docs before/after
rg -n "kv-ip|kv-port" docs/usage/security.md
```

## Test plan
- [ ] Docs-only; no runtime change
- [ ] Confirm `rg` on patched file shows `--kv-transfer-config.kv-ip` / `.kv-port`
