### PR TITLE
[ROCm][Bugfix] Stop the worker-kill schedule from preempting the EngineCore cleanup grace

### DIFF
--- a/tests/v1/executor/test_worker_shutdown_grace.py
+++ b/tests/v1/executor/test_worker_shutdown_grace.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for the worker shutdown grace on ROCm.
+
+The executor escalates to SIGKILL after
+``worker_shutdown_grace_s() + WORKER_SIGTERM_GRACE_S``. On ROCm the EngineCore
+process manager separately allows ``ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S``
+for device teardown, so the executor's schedule must not expire first, or the
+workers holding the device memory are killed inside the window that exists to
+protect them.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import vllm.envs as envs
+from vllm.v1.engine.utils import ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S
+from vllm.v1.executor import multiproc_executor
+from vllm.v1.executor.multiproc_executor import (
+    WORKER_SIGTERM_GRACE_S,
+    worker_shutdown_grace_s,
+)
+
+ENV = "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS"
+
+
+def _grace(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    is_rocm: bool,
+    explicit: str | None = None,
+    configured: int = 5,
+) -> float:
+    monkeypatch.setattr(envs, ENV, configured)
+    monkeypatch.setattr(
+        multiproc_executor,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: is_rocm),
+    )
+    if explicit is None:
+        monkeypatch.delenv(ENV, raising=False)
+    else:
+        monkeypatch.setenv(ENV, explicit)
+    return worker_shutdown_grace_s()
+
+
+def test_rocm_default_does_not_expire_before_engine_process_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The point of the fix: the inner schedule must not preempt the outer."""
+    grace = _grace(monkeypatch, is_rocm=True)
+    assert grace + WORKER_SIGTERM_GRACE_S >= ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S
+
+
+def test_rocm_default_is_stretched_above_the_generic_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _grace(monkeypatch, is_rocm=True) > 5.0
+
+
+def test_non_rocm_default_is_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert _grace(monkeypatch, is_rocm=False) == 5.0
+
+
+def test_explicit_setting_is_honoured_on_rocm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user who asks for a short grace gets it, even on ROCm."""
+    assert _grace(monkeypatch, is_rocm=True, explicit="2", configured=2) == 2.0
+
+
+def test_explicit_setting_above_the_rocm_floor_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _grace(monkeypatch, is_rocm=True, explicit="60", configured=60) == 60.0
+
+
+def test_rocm_floor_never_shortens_a_larger_generic_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the unset default ever exceeds the ROCm floor, keep the larger one."""
+    assert _grace(monkeypatch, is_rocm=True, configured=120) == 120.0

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -74,6 +74,38 @@ from vllm.v1.worker.worker_base import WorkerWrapperBase
 
 logger = init_logger(__name__)
 
+# Time allowed for workers to exit after SIGTERM before escalating to SIGKILL.
+WORKER_SIGTERM_GRACE_S = 4.0
+
+
+def worker_shutdown_grace_s() -> float:
+    """Seconds to wait for workers to exit on their own before escalating.
+
+    ``VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS`` defaults to 5s, which is shorter
+    than ROCm worker teardown normally takes: releasing the KV cache and
+    destroying the communicators runs past it, and while the worker main thread
+    is inside those native calls it cannot service SIGTERM either, so the
+    escalation runs to completion and SIGKILLs the workers mid-cleanup.
+
+    The EngineCore process manager already allows
+    ``ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S`` for this exact reason, but that
+    budget covers the EngineCore process rather than the workers holding the
+    device memory, so the shorter schedule here preempts it and the outer grace
+    never applies. Derive the ROCm default from the same constant, leaving room
+    for the SIGTERM step, so the two levels agree instead of racing.
+
+    An explicitly configured value is always honoured.
+    """
+    grace = float(envs.VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS)
+    if os.getenv("VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS") is not None:
+        return grace
+    if not current_platform.is_rocm():
+        return grace
+    # Deferred: vllm.v1.engine.utils imports this package.
+    from vllm.v1.engine.utils import ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S
+
+    return max(grace, ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S - WORKER_SIGTERM_GRACE_S)
+
 
 class FutureWrapper(Future):
     def __init__(
@@ -473,9 +505,7 @@ class MultiprocExecutor(Executor):
             "[shutdown] Executor: waiting for worker exit count=%d",
             initial_count,
         )
-        if wait_for_termination(
-            active_procs(), timeout=envs.VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS
-        ):
+        if wait_for_termination(active_procs(), timeout=worker_shutdown_grace_s()):
             logger.info_once("[shutdown] Executor: all workers exited gracefully")
             return
 
@@ -488,7 +518,7 @@ class MultiprocExecutor(Executor):
         )
         for p in remaining:
             p.terminate()
-        if not wait_for_termination(active_procs(), 4):
+        if not wait_for_termination(active_procs(), WORKER_SIGTERM_GRACE_S):
             # Send SIGKILL if still running
             remaining = active_procs()
             logger.warning(


### PR DESCRIPTION
## Purpose

Fixes #55632.

On ROCm, two nested shutdown timers disagree, and the inner one force-kills the
processes the outer one exists to protect.

`get_engine_process_shutdown_timeout()` returns
`ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S` (15s) on the zero/zero path so the
EngineCore process can release device resources before it is force-killed. Its
docstring states the reason directly:

> ROCm teardown can take longer than the generic best-effort window, and
> force-killing during teardown can leave VRAM resident.

That grace covers the **EngineCore process**. But
`MultiprocExecutor._ensure_worker_termination()` is platform-agnostic and runs
its own, shorter schedule against the **worker processes**:

1. wait `VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS` — default `5`
2. `terminate()` (SIGTERM)
3. wait a hardcoded `4`
4. `kill()` (SIGKILL)

Those 9s always expire inside the 15s window, and the workers are the processes
actually holding device memory. So on ROCm they are SIGKILLed mid-teardown and
the outer grace never gets to apply — in our runs
`Process manager: force killing remaining processes` never fires, because the
inner escalation has already finished by +9s.

SIGTERM does not rescue it. The worker handler raises `SystemExit`, which cannot
propagate while the main thread is inside native teardown (`worker.shutdown()`,
`destroy_model_parallel()`, `destroy_distributed_environment()` — RCCL
communicator destruction and KV pool release), so step 3 elapses and step 4
lands.

## Fix

Derive the ROCm worker grace from the same constant that governs the outer
window, minus the SIGTERM step, so the two levels agree instead of racing.

- An explicitly configured `VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS` is still
  honoured, including a value *shorter* than the ROCm floor — this only changes
  the unset default.
- Non-ROCm behaviour is unchanged.
- The previously hardcoded `4` becomes `WORKER_SIGTERM_GRACE_S`, so the
  arithmetic relating the inner schedule to the outer window is explicit rather
  than implied by two separate literals.
- The import of `ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S` is deferred because
  `vllm.v1.engine.utils` imports the executor package.

## Test

New `tests/v1/executor/test_worker_shutdown_grace.py`, pure-Python and no GPU
required. The load-bearing assertion is the invariant rather than a magic
number:

```python
assert grace + WORKER_SIGTERM_GRACE_S >= ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S
```

so the test keeps holding if either constant is retuned later. The rest cover
the platform gate, explicit configuration in both directions, and the case
where a future generic default already exceeds the ROCm floor.

```
tests/v1/executor/test_multiproc_executor_timeout.py  5 passed
tests/v1/executor/test_worker_shutdown_grace.py       6 passed
```

## Evidence

8x MI355X, TP=8, vLLM `0.28.1rc1.dev199+g7c5dc571c.rocm723`, ROCm 7.2.3, five
independent 1-hour serving runs with `VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS`
unset. Offsets are relative to `Executor: waiting for worker exit`:

| run | workers | SIGTERM | SIGKILL | `all workers exited gracefully` | outer force-kill | leaked-resource warnings |
|---|---|---|---|---|---|---|
| 1 | 8 | +5s | +9s | never | no | 1 |
| 2 | 8 | +5s | +9s | never | no | 2 |
| 3 | 8 | +5s | +9s | never | no | 2 |
| 4 | 8 | +5s | +9s | never | no | 2 |
| 5 | 8 | +5s | +9s | never | no | 2 |

Deterministic across all five, and the graceful-exit path is never taken. The
leaked semaphores (one per worker) and shared-memory segment are the expected
debris of killing 8 workers mid-cleanup.

## What is not yet established

**How long ROCm worker teardown actually needs is still unmeasured.** It has
never been allowed to finish on our hardware — every run was cut off at 5s — so
`> 5s` is the only claim the data supports directly. This PR therefore does not
invent a number; it reuses the budget the outer manager already grants, which is
correct regardless of the true duration.

The case that would need a follow-up is teardown exceeding ~15s. Then this
change stops the *worker* SIGKILL but the outer manager force-kills the
EngineCore process instead, and `ROCM_ENGINE_PROCESS_SHUTDOWN_TIMEOUT_S` needs
raising too — an additive change that composes with this one. An end-to-end run
on MI355X measuring the real teardown duration is queued behind a long benchmark
on the same node; I will post the number here when it lands, and I am happy to
hold the merge until then.

## Related

- #55632 — the bug report, with full logs.
- #48745 / #49000 — the spurious `EngineDeadError` logged during the same
  teardown. Separate and already being fixed; not addressed here. Our data
  indicates the two are independent: the one run of five that did *not* log
  `EngineDeadError` SIGKILLed its workers identically to the four that did.
- #52281 — added the ROCm EngineCore grace this PR extends to the workers. It
  was motivated by GPU memory remaining at 11.72 GB for a full 120s release
  wait, which is the symptom still reachable today because the memory is held by
  the workers rather than their parent.
