### PR TITLE
docs(nixl): Document metrics aggregation semantics across TP ranks (closes #41230 part)

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -22,6 +22,20 @@ class KVConnectorStats:
     metrics or otherwise important telemetry from the connector.
     All sub-classes need to be serializable as stats are sent from worker to
     logger process.
+
+    Pipeline:
+    1. Worker calls `record_transfer()` / `record_failed_*()` on its local
+       stats object (per-engine).
+    2. Periodically, stats are sent to the logger process via `to_dict()`.
+    3. Logger calls `aggregate()` to combine stats from all workers into a
+       single cumulative `KVConnectorStats` object.
+    4. Logger calls `reduce()` to produce a summary dict for CLI logging.
+    5. Logger calls `log()` to print the summary.
+    6. Logger calls `reset()` to clear for the next interval.
+
+    For NIXL connector, aggregation uses `list.extend()` so the combined
+    pool contains observations from ALL TP ranks. Reduction then computes
+    statistics (mean, P90, throughput) over this combined pool.
     """
 
     data: dict[str, Any] = field(default_factory=dict)
@@ -37,15 +51,22 @@ class KVConnectorStats:
     def aggregate(self, other: "KVConnectorStats") -> "KVConnectorStats":
         """
         Aggregate stats with another `KVConnectorStats` object.
+
+        The default expectation is list-wise concatenation (for NIXL this
+        combines observations from all TP ranks into a single list per metric).
         """
         raise NotImplementedError
 
     def reduce(self) -> dict[str, int | float]:
         """
         Reduce the observations collected during a time interval to one or
-        more representative values (eg avg/median/sum of the series).
+        more representative values (e.g., avg, P90, sum of the series).
         This is meant to be called by the logger to produce a summary of the
         stats for the last time interval.
+
+        For NIXL, the input is already the **combined pool of all TP ranks'
+        observations** (see `aggregate()`). The reduction computes stats over
+        this combined pool, not per-rank or per-engine.
         """
         raise NotImplementedError
 
@@ -55,6 +76,25 @@ class KVConnectorStats:
 
 
 class KVConnectorLogging:
+    """
+    Manages the observe -> aggregate -> reduce -> log pipeline for KV
+    connector transfer metrics.
+
+    Pipeline per logging interval:
+    1. `observe()` - Called periodically when connector syncs with scheduler.
+       Receives `transfer_stats_data` already aggregated across ALL workers
+       (see `aggregate()` in KVConnectorStats). Builds a stats object via
+       connector's `build_kv_connector_stats()`.
+    2. `aggregate()` - Combines current interval stats with accumulator
+       (list-wise concatenation for NIXL, combining all TP ranks).
+    3. `log()` - Calls `reduce()` on accumulator to get summary dict,
+       formats and logs it, then calls `reset()`.
+
+    The `transfer_stats_data` passed to `observe()` is expected to be
+    pre-aggregated across all workers (for MultiConnector, this means
+    all TP ranks are already combined).
+    """
+
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -26,9 +26,11 @@ class KVConnectorStats:
     Pipeline:
     1. Worker calls `record_transfer()` / `record_failed_*()` on its local
        stats object (per-engine).
-    2. Periodically, stats are sent to the logger process via `to_dict()`.
-    3. Logger calls `aggregate()` to combine stats from all workers into a
-       single cumulative `KVConnectorStats` object.
+    2. Stats from all workers are aggregated across workers (for NIXL, all
+       TP ranks) into a single cumulative `KVConnectorStats` object.
+    3. Logger calls `aggregate()` to accumulate the current interval's stats
+       into the logging accumulator (list-wise concatenation), not to combine
+       workers.
     4. Logger calls `reduce()` to produce a summary dict for CLI logging.
     5. Logger calls `log()` to print the summary.
     6. Logger calls `reset()` to clear for the next interval.
@@ -83,16 +85,15 @@ class KVConnectorLogging:
     Pipeline per logging interval:
     1. `observe()` - Called periodically when connector syncs with scheduler.
        Receives `transfer_stats_data` already aggregated across ALL workers
-       (see `aggregate()` in KVConnectorStats). Builds a stats object via
-       connector's `build_kv_connector_stats()`.
-    2. `aggregate()` - Combines current interval stats with accumulator
-       (list-wise concatenation for NIXL, combining all TP ranks).
+       (for MultiConnector, all TP ranks are already combined). Builds a
+       stats object via connector's `build_kv_connector_stats()`.
+    2. `aggregate()` - Accumulates current interval stats into the logging
+       accumulator (list-wise concatenation), NOT cross-worker aggregation.
     3. `log()` - Calls `reduce()` on accumulator to get summary dict,
        formats and logs it, then calls `reset()`.
 
-    The `transfer_stats_data` passed to `observe()` is expected to be
-    pre-aggregated across all workers (for MultiConnector, this means
-    all TP ranks are already combined).
+    Cross-worker aggregation happens before `observe()`: the
+    `transfer_stats_data` arrives already combined across all workers.
     """
 
     def __init__(self, kv_transfer_config: KVTransferConfig | None):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,28 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Container for transfer performance metrics.
+
+    This class collects per-transfer telemetry from NIXL KV cache transfers
+    and provides aggregation/reduction methods for logging.
+
+    IMPORTANT: All metrics are **aggregated across all TP ranks** before
+    summary statistics are computed. This means:
+    - "Num successful transfers" is the total count across all ranks,
+      not per-rank.
+    - "Avg MB per transfer" is the average over all individual rank-level
+      transfers, not the total bytes moved for a single KV cache transfer
+      operation.
+    - "Throughput (MB/s)" is `total_MB_all_ranks / total_time_all_ranks` —
+      effectively an average per-rank throughput over the combined pool of
+      observations, not the aggregate system throughput.
+    - Percentiles (P90) are computed over the combined distribution of
+      all ranks' transfer times.
+
+    This aggregation behavior is a deliberate design choice (fire-and-forget
+    from workers) and matches how `aggregate()` concatenates lists via
+    `list.extend()` and `reduce()` computes statistics over the combined pool.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -84,6 +105,15 @@ class NixlKVConnectorStats(KVConnectorStats):
         return self
 
     def reduce(self) -> dict[str, int | float]:
+        """Reduce collected observations to summary statistics for logging.
+
+        All computations are performed over the **combined pool of observations
+        from all TP ranks** (see class docstring for aggregation semantics).
+        The returned dict keys match the CLI log line:
+        "Num successful transfers", "Avg xfer time (ms)", "P90 xfer time (ms)",
+        "Avg post time (ms)", "P90 post time (ms)", "Avg MB per transfer",
+        "Throughput (MB/s)", "Avg number of descriptors".
+        """
         # Compute compact representative stats suitable for CLI logging
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in


### PR DESCRIPTION
## Summary

Addresses items 1-3 of #41230 (source-level documentation in stats.py and metrics.py). Item 4 (docs page) was already completed in #44055.

## Changes

### `vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py`

- **NixlKVConnectorStats class docstring**: Added detailed explanation that all metrics are **aggregated across all TP ranks** before summary statistics are computed. This clarifies what each CLI log metric represents:
  - "Num successful transfers" = total count across all ranks
  - "Avg MB per transfer" = average over individual rank-level transfers
  - "Throughput (MB/s)" = total_MB_all_ranks / total_time_all_ranks (average per-rank throughput, not aggregate system throughput)
  - Percentiles (P90) = computed over combined distribution of all ranks' transfer times

- **NixlKVConnectorStats.reduce() docstring**: Clarifies that computations are over the combined pool of all ranks' observations.

### `vllm/distributed/kv_transfer/kv_connector/v1/metrics.py`

- **KVConnectorStats base class docstring**: Documents the observe -> aggregate -> reduce -> log pipeline and that aggregation uses list.extend() combining all TP ranks.

- **KVConnectorLogging class docstring**: Documents the observe -> aggregate -> reduce -> log pipeline and that stats arrive pre-aggregated across workers.

## Verification

- Ruff lint passes (no new errors)
- Ruff format passes
- Changes are docstring-only, no runtime behavior modification

## Related issue

Closes items 1-3 of #41230.
