### PR TITLE
[Bugfix][Kernel] Skip FlashInfer kernels that cannot run on the local CUDA toolkit

### DIFF
--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -513,3 +513,64 @@ def test_select_explicit_triton_backend(is_lora_enabled):
 
     assert selected_backend == UnquantizedMoeBackend.TRITON
     assert experts_cls is not None
+
+
+@patch(
+    "vllm.utils.flashinfer.has_flashinfer",
+    return_value=True,
+)
+@patch(
+    "vllm.model_executor.layers.fused_moe.experts.trtllm_bf16_moe.TrtLlmBf16ExpertsMonolithic.is_supported_config",
+    return_value=(False, None),
+)
+@patch(
+    "vllm.model_executor.layers.fused_moe.experts.trtllm_bf16_moe.TrtLlmBf16ExpertsModular.is_supported_config",
+    return_value=(False, None),
+)
+@patch(
+    "vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe.has_flashinfer_cutlass_fused_moe",
+    return_value=True,
+)
+@pytest.mark.parametrize(
+    ("jit_unsupported_reason", "expected_backend"),
+    [
+        (None, UnquantizedMoeBackend.FLASHINFER_CUTLASS),
+        ("SM 12.x requires CUDA >= 12.9", UnquantizedMoeBackend.TRITON),
+    ],
+)
+def test_select_cuda_flashinfer_cutlass_requires_jit_preflight(
+    mock_has_flashinfer_cutlass_moe,
+    mock_is_supported_trtllm_modular,
+    mock_is_supported_trtllm_monolithic,
+    mock_has_flashinfer,
+    jit_unsupported_reason,
+    expected_backend,
+):
+    """On SM 12.x FlashInfer CUTLASS is auto-selected ahead of Triton. When
+    FlashInfer cannot JIT-compile for the GPU (toolkit too old, #50705) the
+    oracle must fall through to Triton instead of crashing the profile run."""
+    with (
+        patch.object(current_platform, "is_cuda", return_value=True),
+        patch.object(current_platform, "is_rocm", return_value=False),
+        patch.object(current_platform, "is_cpu", return_value=False),
+        patch.object(current_platform, "is_xpu", return_value=False),
+        patch.object(current_platform, "is_tpu", return_value=False),
+        patch.object(current_platform, "is_out_of_tree", return_value=False),
+        patch.object(current_platform, "is_device_capability", return_value=False),
+        patch.object(
+            current_platform,
+            "is_device_capability_family",
+            side_effect=lambda family, device_id=0: family == 120,
+        ),
+        patch.object(current_platform, "has_device_capability", return_value=True),
+        patch(
+            "vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe.flashinfer_jit_unsupported_reason",
+            return_value=jit_unsupported_reason,
+        ),
+    ):
+        selected_backend, experts_cls = select_unquantized_moe_backend(
+            moe_config=make_dummy_moe_config()
+        )
+
+        assert selected_backend == expected_backend
+        assert experts_cls is not None

--- a/tests/model_executor/kernels/test_flashinfer_jit_preflight.py
+++ b/tests/model_executor/kernels/test_flashinfer_jit_preflight.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer JIT preflight for kernel selection.
+
+Kernels that FlashInfer JIT-compiles with nvcc must decline at selection time
+when FlashInfer cannot target the current GPU (e.g. SM 12.x with a CUDA
+toolkit older than 12.9). Otherwise they are selected and engine startup dies
+in the first JIT build with a misleading "FlashInfer requires GPUs with sm75
+or higher" error (vllm-project/vllm#50705).
+"""
+
+import sys
+import types
+
+import pytest
+
+import vllm.utils.flashinfer as fi_utils
+from vllm.platforms import current_platform
+from vllm.platforms.interface import DeviceCapability
+
+SM120 = DeviceCapability(12, 0)
+TOOLKIT_REASON = "SM 12.x requires CUDA >= 12.9"
+
+
+@pytest.fixture(autouse=True)
+def _reset_preflight_cache():
+    fi_utils.flashinfer_jit_unsupported_reason.cache_clear()
+    fi_utils.flashinfer_b12x_unsupported_reason.cache_clear()
+    yield
+    fi_utils.flashinfer_jit_unsupported_reason.cache_clear()
+    fi_utils.flashinfer_b12x_unsupported_reason.cache_clear()
+
+
+def _install_fake_flashinfer(monkeypatch, targets, normalize_error=None):
+    """Stand in for the FlashInfer internals the preflight reads."""
+    jit_core = types.SimpleNamespace(
+        current_compilation_context=types.SimpleNamespace(TARGET_CUDA_ARCHS=targets)
+    )
+
+    class CompilationContext:
+        @staticmethod
+        def _normalize_cuda_arch(major, minor):
+            if normalize_error is not None:
+                raise RuntimeError(normalize_error)
+            return (major, str(minor))
+
+    monkeypatch.setitem(sys.modules, "flashinfer.jit.core", jit_core)
+    monkeypatch.setitem(
+        sys.modules,
+        "flashinfer.compilation_context",
+        types.SimpleNamespace(CompilationContext=CompilationContext),
+    )
+
+
+def _fake_cuda_device(monkeypatch, capability=SM120):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        current_platform, "get_device_capability", lambda device_id=0: capability
+    )
+
+
+def test_preflight_passes_when_flashinfer_targets_current_gpu(monkeypatch):
+    _fake_cuda_device(monkeypatch)
+    _install_fake_flashinfer(monkeypatch, targets={(12, "0f")})
+
+    assert fi_utils.flashinfer_jit_unsupported_reason() is None
+
+
+def test_preflight_reports_toolkit_error_swallowed_by_flashinfer(monkeypatch):
+    """An empty target set means FlashInfer logged and dropped the arch
+    error; the preflight must surface that real reason."""
+    _fake_cuda_device(monkeypatch)
+    _install_fake_flashinfer(monkeypatch, targets=set(), normalize_error=TOOLKIT_REASON)
+
+    assert fi_utils.flashinfer_jit_unsupported_reason() == TOOLKIT_REASON
+
+
+def test_preflight_rejects_gpu_missing_from_target_set(monkeypatch):
+    """Targets for another GPU in the box do not make this one compilable."""
+    _fake_cuda_device(monkeypatch)
+    _install_fake_flashinfer(monkeypatch, targets={(9, "0a")})
+
+    reason = fi_utils.flashinfer_jit_unsupported_reason()
+
+    assert reason is not None
+    assert "sm_120" in reason
+
+
+def test_preflight_is_neutral_without_flashinfer(monkeypatch):
+    _fake_cuda_device(monkeypatch)
+    monkeypatch.setitem(sys.modules, "flashinfer.jit.core", None)
+
+    assert fi_utils.flashinfer_jit_unsupported_reason() is None
+
+
+def test_preflight_is_neutral_off_cuda(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: False)
+
+    assert fi_utils.flashinfer_jit_unsupported_reason() is None
+
+
+def _fp8_scaled_mm_env(monkeypatch):
+    import vllm.model_executor.kernels.linear.scaled_mm.flashinfer as mod
+
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(mod, "has_flashinfer", lambda: True)
+    return mod, mod.FlashInferFP8ScaledMMLinearKernel
+
+
+def _nvfp4_cutlass_env(monkeypatch):
+    import vllm.model_executor.kernels.linear.nvfp4.flashinfer as mod
+    import vllm.model_executor.layers.quantization.utils.nvfp4_utils as nvfp4_utils
+
+    monkeypatch.setattr(
+        current_platform, "has_device_capability", lambda cap, device_id=0: True
+    )
+    monkeypatch.setattr(nvfp4_utils, "cutlass_fp4_supported", lambda: True)
+    monkeypatch.setattr(mod, "has_flashinfer", lambda: True)
+    return mod, mod.FlashInferCutlassNvFp4LinearKernel
+
+
+def _mxfp8_cutlass_env(monkeypatch):
+    import vllm.model_executor.kernels.linear.mxfp8.flashinfer as mod
+
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        current_platform, "has_device_capability", lambda cap, device_id=0: True
+    )
+    monkeypatch.setattr(mod, "has_flashinfer", lambda: True)
+    return mod, mod.FlashInferCutlassMxfp8LinearKernel
+
+
+LINEAR_KERNEL_ENVS = pytest.mark.parametrize(
+    "setup_env",
+    [_fp8_scaled_mm_env, _nvfp4_cutlass_env, _mxfp8_cutlass_env],
+    ids=["fp8_scaled_mm", "nvfp4_cutlass", "mxfp8_cutlass"],
+)
+
+
+@LINEAR_KERNEL_ENVS
+def test_flashinfer_linear_kernel_declines_when_jit_unavailable(monkeypatch, setup_env):
+    mod, kernel_cls = setup_env(monkeypatch)
+    monkeypatch.setattr(
+        mod, "flashinfer_jit_unsupported_reason", lambda: TOOLKIT_REASON
+    )
+
+    supported, reason = kernel_cls.is_supported(120)
+
+    assert not supported
+    assert TOOLKIT_REASON in reason
+
+
+@LINEAR_KERNEL_ENVS
+def test_flashinfer_linear_kernel_accepts_when_jit_available(monkeypatch, setup_env):
+    mod, kernel_cls = setup_env(monkeypatch)
+    monkeypatch.setattr(mod, "flashinfer_jit_unsupported_reason", lambda: None)
+
+    assert kernel_cls.is_supported(120) == (True, None)
+
+
+def test_preflight_reports_import_time_failure(monkeypatch):
+    """FlashInfer builds its compilation context at import time and a
+    malformed FLASHINFER_CUDA_ARCH_LIST raises ValueError there; the
+    preflight must turn that into a reason, not crash kernel selection."""
+    _fake_cuda_device(monkeypatch)
+    broken = types.ModuleType("flashinfer.jit.core")
+
+    def _raise(name):
+        raise ValueError("not enough values to unpack (expected 2, got 1)")
+
+    vars(broken)["__getattr__"] = _raise
+    monkeypatch.setitem(sys.modules, "flashinfer.jit.core", broken)
+
+    reason = fi_utils.flashinfer_jit_unsupported_reason()
+
+    assert reason is not None
+    assert "not enough values to unpack" in reason
+
+
+def _install_fake_cuda_version(monkeypatch, version):
+    from packaging.version import Version
+
+    monkeypatch.setitem(
+        sys.modules,
+        "flashinfer.jit.cpp_ext",
+        types.SimpleNamespace(get_cuda_version=lambda: Version(version)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("cuda_version", "expected"),
+    [("13.0", None), ("13.1", None), ("12.8", "12.8"), ("12.9", "12.9")],
+)
+def test_b12x_preflight_mirrors_flashinfer_cuda13_requirement(
+    monkeypatch, cuda_version, expected
+):
+    """FlashInfer's b12x kernels raise at call time below CUDA 13; the
+    preflight must decline them at selection with the toolkit version."""
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    _install_fake_cuda_version(monkeypatch, cuda_version)
+
+    reason = fi_utils.flashinfer_b12x_unsupported_reason()
+
+    if expected is None:
+        assert reason is None
+    else:
+        assert reason is not None
+        assert "CUDA >= 13" in reason
+        assert expected in reason
+
+
+def test_b12x_preflight_is_neutral_without_flashinfer(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setitem(sys.modules, "flashinfer.jit.cpp_ext", None)
+
+    assert fi_utils.flashinfer_b12x_unsupported_reason() is None
+
+
+B12X_REASON = "FlashInfer b12x kernels require CUDA >= 13 (local toolkit 12.8)"
+
+
+def _b12x_nvfp4_env(monkeypatch):
+    import vllm.model_executor.kernels.linear.nvfp4.flashinfer as mod
+
+    monkeypatch.setattr(
+        current_platform, "has_device_capability", lambda cap, device_id=0: True
+    )
+    monkeypatch.setattr(mod, "has_flashinfer_b12x_gemm", lambda: True)
+    return mod, mod.FlashInferB12xNvFp4LinearKernel
+
+
+def test_b12x_nvfp4_kernel_declines_below_cuda13(monkeypatch):
+    mod, kernel_cls = _b12x_nvfp4_env(monkeypatch)
+    monkeypatch.setattr(mod, "flashinfer_b12x_unsupported_reason", lambda: B12X_REASON)
+
+    supported, reason = kernel_cls.is_supported(120)
+
+    assert not supported
+    assert reason == B12X_REASON
+
+
+def test_b12x_nvfp4_kernel_accepts_on_cuda13(monkeypatch):
+    mod, kernel_cls = _b12x_nvfp4_env(monkeypatch)
+    monkeypatch.setattr(mod, "flashinfer_b12x_unsupported_reason", lambda: None)
+
+    assert kernel_cls.is_supported(120) == (True, None)
+
+
+@pytest.mark.parametrize("b12x_reason", [None, B12X_REASON])
+def test_b12x_moe_experts_follow_cuda13_preflight(monkeypatch, b12x_reason):
+    import vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe as mod
+
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability_family",
+        lambda family, device_id=0: family == 120,
+    )
+    monkeypatch.setattr(mod, "has_flashinfer_b12x_moe", lambda: True)
+    monkeypatch.setattr(mod, "flashinfer_b12x_unsupported_reason", lambda: b12x_reason)
+
+    assert mod.FlashInferB12xExperts._supports_current_device() is (b12x_reason is None)

--- a/vllm/model_executor/kernels/linear/mxfp8/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/flashinfer.py
@@ -11,7 +11,11 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils import flashinfer as vllm_flashinfer
-from vllm.utils.flashinfer import has_flashinfer, has_flashinfer_cutedsl
+from vllm.utils.flashinfer import (
+    flashinfer_jit_unsupported_reason,
+    has_flashinfer,
+    has_flashinfer_cutedsl,
+)
 
 from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
 
@@ -29,6 +33,8 @@ class FlashInferCutlassMxfp8LinearKernel(Mxfp8LinearKernel):
             return False, "requires >=sm_100 (Blackwell)"
         if not has_flashinfer():
             return False, "requires FlashInfer"
+        if (reason := flashinfer_jit_unsupported_reason()) is not None:
+            return False, f"cannot JIT-compile FlashInfer for this GPU: {reason}"
         return True, None
 
     @classmethod

--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -20,6 +20,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
+    flashinfer_b12x_unsupported_reason,
+    flashinfer_jit_unsupported_reason,
     flashinfer_prepare_bf16_fp4_weights,
     flashinfer_scaled_fp4_mm,
     has_flashinfer,
@@ -190,13 +192,15 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
             cutlass_fp4_supported,
         )
 
-        if (
+        if not (
             cutlass_fp4_supported()
             and current_platform.has_device_capability(100)
             and has_flashinfer()
         ):
-            return True, None
-        return False, "FlashInfer + >=sm_100 required"
+            return False, "FlashInfer + >=sm_100 required"
+        if (reason := flashinfer_jit_unsupported_reason()) is not None:
+            return False, f"cannot JIT-compile FlashInfer for this GPU: {reason}"
+        return True, None
 
     @classmethod
     def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:
@@ -392,13 +396,17 @@ class FlashInferB12xNvFp4LinearKernel(NvFp4LinearKernel):
     def is_supported(
         cls, compute_capability: int | None = None
     ) -> tuple[bool, str | None]:
-        if current_platform.has_device_capability(120) and has_flashinfer_b12x_gemm():
-            return True, None
-        return (
-            False,
-            "FlashInfer b12x requires SM120+ and FlashInfer "
-            "with Sm120BlockScaledDenseGemmKernel",
-        )
+        if not (
+            current_platform.has_device_capability(120) and has_flashinfer_b12x_gemm()
+        ):
+            return (
+                False,
+                "FlashInfer b12x requires SM120+ and FlashInfer "
+                "with Sm120BlockScaledDenseGemmKernel",
+            )
+        if (reason := flashinfer_b12x_unsupported_reason()) is not None:
+            return False, reason
+        return True, None
 
     @classmethod
     def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:

--- a/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_fp8_blockscale_gemm,
+    flashinfer_jit_unsupported_reason,
     flashinfer_scaled_fp8_mm,
     has_flashinfer,
     is_flashinfer_fp8_blockscale_gemm_supported,
@@ -49,6 +50,9 @@ class FlashInferFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
 
         if compute_capability is not None and compute_capability < 100:
             return False, "requires compute capability 100 and above."
+
+        if (reason := flashinfer_jit_unsupported_reason()) is not None:
+            return False, f"cannot JIT-compile FlashInfer for this GPU: {reason}"
 
         return True, None
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
+    flashinfer_b12x_unsupported_reason,
     flashinfer_convert_sf_to_mma_layout,
     has_flashinfer_b12x_moe,
 )
@@ -168,6 +169,7 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             p.is_cuda()
             and p.is_device_capability_family(120)
             and has_flashinfer_b12x_moe()
+            and flashinfer_b12x_unsupported_reason() is None
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_cutlass_fused_moe,
+    flashinfer_jit_unsupported_reason,
     has_flashinfer_cutlass_fused_moe,
 )
 
@@ -137,6 +138,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                 or p.is_device_capability_family(120)
             )
             and has_flashinfer_cutlass_fused_moe()
+            and flashinfer_jit_unsupported_reason() is None
         )
 
     @staticmethod

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import importlib
 import importlib.util
+import itertools
 import os
 import shutil
 from collections.abc import Callable
@@ -82,6 +83,95 @@ def has_flashinfer() -> bool:
         )
         return False
     return True
+
+
+def _cuda_arch_minor(minor: str) -> int | None:
+    """Parse the numeric part of a FlashInfer arch minor such as ``"0f"``."""
+    digits = "".join(itertools.takewhile(str.isdigit, str(minor)))
+    return int(digits) if digits else None
+
+
+@functools.cache
+def flashinfer_jit_unsupported_reason() -> str | None:
+    """Return why FlashInfer cannot JIT-compile for the current GPU, or None.
+
+    FlashInfer swallows arch-detection errors while building its compilation
+    context (e.g. SM 12.x with a CUDA toolkit older than 12.9), leaving the
+    current GPU out of its target set. Every nvcc JIT build then fails at
+    first use, with "FlashInfer requires GPUs with sm75 or higher" or "No
+    supported CUDA architectures found for major versions [12]", which kills
+    engine startup whenever a FlashInfer-backed kernel was auto-selected.
+    Kernel selection gates call this to skip FlashInfer instead.
+    """
+    if not current_platform.is_cuda():
+        return None
+    capability = current_platform.get_device_capability()
+    if capability is None:
+        return None
+    try:
+        from flashinfer.jit.core import current_compilation_context
+    except ImportError:
+        return None
+    except Exception as e:
+        # e.g. a malformed FLASHINFER_CUDA_ARCH_LIST raises ValueError while
+        # FlashInfer builds its compilation context at import time.
+        return f"importing flashinfer.jit.core failed: {e}"
+    targets = getattr(current_compilation_context, "TARGET_CUDA_ARCHS", None)
+    if targets is None:
+        return None
+    if any(
+        major == capability.major and _cuda_arch_minor(minor) == capability.minor
+        for major, minor in targets
+    ):
+        return None
+    reason = (
+        f"sm_{capability.major}{capability.minor} is not among FlashInfer's "
+        "target architectures"
+    )
+    try:
+        # Re-derive the error FlashInfer swallowed while building its
+        # compilation context, e.g. "SM 12.x requires CUDA >= 12.9".
+        from flashinfer.compilation_context import CompilationContext
+
+        CompilationContext._normalize_cuda_arch(capability.major, capability.minor)
+    except RuntimeError as e:
+        reason = str(e)
+    except Exception:
+        pass
+    logger.warning_once(
+        "FlashInfer cannot JIT-compile kernels for this GPU: %s. "
+        "FlashInfer-backed kernels will not be auto-selected.",
+        reason,
+    )
+    return reason
+
+
+@functools.cache
+def flashinfer_b12x_unsupported_reason() -> str | None:
+    """Return why FlashInfer's b12x kernels cannot run here, or None.
+
+    FlashInfer's b12x (SM 12.x CuTe-DSL) GEMM and MoE backends refuse to run
+    below CUDA 13, but they only check at call time, so a b12x kernel picked
+    at selection kills engine startup on an older local toolkit. Mirrors the
+    ``get_cuda_version().major < 13`` check FlashInfer applies.
+    """
+    if not current_platform.is_cuda():
+        return None
+    try:
+        from flashinfer.jit.cpp_ext import get_cuda_version
+
+        cuda_version = get_cuda_version()
+    except ImportError:
+        return None
+    except Exception as e:
+        return f"cannot determine the CUDA toolkit version: {e}"
+    if cuda_version.major >= 13:
+        return None
+    reason = (
+        f"FlashInfer b12x kernels require CUDA >= 13 (local toolkit {cuda_version})"
+    )
+    logger.warning_once("%s; b12x kernels will not be auto-selected.", reason)
+    return reason
 
 
 @functools.cache
@@ -1250,6 +1340,8 @@ def is_flashinfer_cudnn_fp8_prefill_attn_supported() -> bool:
 
 __all__ = [
     "has_flashinfer",
+    "flashinfer_jit_unsupported_reason",
+    "flashinfer_b12x_unsupported_reason",
     "flashinfer_bf16_mm",
     "has_flashinfer_bf16_gemm",
     "is_flashinfer_bf16_gemm_supported",


### PR DESCRIPTION
> **AI assistance was used on this PR.** The diagnosis, the design decisions and every hardware
> measurement below are mine; Claude Code (Fable 5.1) helped write the code, the tests and this
> description, and ran an adversarial multi-agent review of the diff whose confirmed findings I
> folded in. I have reviewed every changed line and run every command listed below on my own
> machine. Attribution is in the commit trailer.

## Purpose

Fixes the fused-MoE and linear-kernel paths of #50705 on SM 12.x GPUs whose **local CUDA
toolkit is older than 12.9**, and a same-shaped failure of FlashInfer's b12x kernels below CUDA 13.

FlashInfer needs CUDA >= 12.9 to emit code for SM 12.x. With an older toolkit its
`CompilationContext` logs `Failed to get device capability: SM 12.x requires CUDA >= 12.9`, keeps
going with an **empty** target-arch set, and every nvcc JIT build then fails at first use:
`gen_jit_spec()` raises the misleading `FlashInfer requires GPUs with sm75 or higher`, and the
SM 12.x-specific modules raise `No supported CUDA architectures found for major versions [12]`.
Because vLLM auto-selects FlashInfer-backed kernels ahead of the vLLM/Triton alternatives on
SM 12.x, engine initialization dies in the profile run instead of falling back.

FlashInfer's b12x (SM 12.x CuTe-DSL) GEMM and MoE backends have the same shape of failure one
step further down the NVFP4 priority list: they require CUDA >= 13 but only check it at call time
(`b12x FP4 GEMM requires CUDA 13 or later`), so once the CUTLASS kernel declines, the next
candidate dies instead of the safe vLLM kernel being reached.

This adds two cached selection-time preflights to `vllm/utils/flashinfer.py`:

- `flashinfer_jit_unsupported_reason()` checks that the current GPU's arch is in FlashInfer's
  target set (`current_compilation_context.TARGET_CUDA_ARCHS`, the same object FlashInfer's own
  `check_cuda_arch()` reads) and, when it is not, re-derives the real reason FlashInfer swallowed.
- `flashinfer_b12x_unsupported_reason()` mirrors FlashInfer's own `get_cuda_version().major < 13`
  check.

The selection gates consult them:

| Kernel | Gate | Preflight | Next candidate in the existing priority order on SM 12.x |
|---|---|---|---|
| `FlashInferExperts` (CUTLASS fused-MoE, bf16 and fp8) | `_supports_current_device()` | JIT | `TritonExperts` |
| `FlashInferB12xExperts` | `_supports_current_device()` | b12x | next MoE backend |
| `FlashInferFP8ScaledMMLinearKernel` (per-tensor FP8 GEMM) | `is_supported()` | JIT | `CutlassFP8ScaledMMLinearKernel` |
| `FlashInferCutlassNvFp4LinearKernel` | `is_supported()` | JIT | `FlashInferB12xNvFp4LinearKernel` |
| `FlashInferB12xNvFp4LinearKernel` | `is_supported()` | b12x | `CutlassNvFp4LinearKernel` (vLLM's own) |
| `FlashInferCutlassMxfp8LinearKernel` | `is_supported()` | JIT | `MarlinMxfp8LinearKernel` |

The reason is logged once at `WARNING` (`FlashInfer cannot JIT-compile kernels for this GPU: SM 12.x
requires CUDA >= 12.9. FlashInfer-backed kernels will not be auto-selected.`). For the linear
kernels it is also what an explicit `--linear-backend flashinfer_cutlass` prints when it fails fast
through the kernel chooser. The MoE gates keep the bare-bool `_supports_current_device()` contract,
so an explicit `moe_backend="flashinfer_cutlass"` still fails at selection with the generic
"kernel does not support current device" message; the toolkit reason is the warning right above it.

Both probes read FlashInfer's state rather than gating on a version number, so when
flashinfer-ai/flashinfer#3633 lands (SM 12.x on CUDA 12.8) the JIT preflight passes on its own.
The JIT probe also covers a box where FlashInfer targets another GPU's arch but not this one, and a
malformed `FLASHINFER_CUDA_ARCH_LIST` (FlashInfer raises `ValueError` at import) becomes a reason
instead of a crash in kernel selection.

### Why the fix is in vLLM's selection layer

The root cause is FlashInfer's (an nvcc < 12.9 cannot target `compute_120f`); vLLM cannot fix
that, and #3633 is the upstream fix. What vLLM owns is its priority chain: today it selects a
backend that FlashInfer has already reported it cannot compile for, and the Triton / CUTLASS
alternatives that exist are never reached. `is_supported()` / `_supports_current_device()` already
decline on compute capability and on a missing `nvcc` (`has_flashinfer()`); this adds the two
missing toolkit checks in the same place, following the approach the issue asks for and the one
used by #48956 (sampler) and #54267 (fp8 KV attention).

### Relationship to the neighbouring PRs

| | Failure | PR |
|---|---|---|
| Path 1 | FlashInfer sampler | #48956 (mine, open) |
| Path 3 | fp8 KV cache attention backend | #54267 (@Dmytro-Khvedchuk, open) |
| **Paths 2 and 4** | fused-MoE, FP8 / NVFP4 / MXFP8 linear kernels, plus the b12x CUDA 13 gap | **this PR** |

Both open PRs inline a `check_cuda_arch()` probe at their own gate; this PR introduces the shared
helper they can adopt. I am happy to rebase #48956 onto it if a maintainer prefers one direction.
#54669 / #54719 (B12x MoE auto-selection) and #55170 (prefer W4A4 NVFP4 kernels on SM 12.x) change
priorities, not the toolkit gates; if #55170 lands, the CUTLASS and b12x kernels gated here become
the default NVFP4 path on SM 12.x.
#50751 documents this failure in `docs/usage/troubleshooting.md`; once this lands, that entry can
describe the fallback warning instead of the crash. I did not touch `docs/` here to avoid colliding
with it, and can fold a note in if the reviewers prefer.

### Why this is not a duplicate

```bash
gh issue view 50705 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "50705 in:body"
gh pr list --repo vllm-project/vllm --state open --search "flashinfer moe sm120 fallback"
gh pr list --repo vllm-project/vllm --state open --search "scaled_mm flashinfer sm120"
gh pr list --repo vllm-project/vllm --state open --search "FlashInfer requires GPUs with sm75"
gh pr list --repo vllm-project/vllm --state open --search "b12x"
```

Nothing open touches the MoE or linear-kernel gates for this failure: #50751 is a docs PR,
#48956 / #54267 are the sampler and attention paths above, #51741 handles a sampling kernel that
fails to *build* after being selected, and the b12x PRs listed above are about priority order.

## Test Plan

### Unit tests

```
.venv/bin/python -m pytest tests/model_executor/kernels/test_flashinfer_jit_preflight.py \
    tests/kernels/moe/test_unquantized_backend_selection.py -q
```

`test_flashinfer_jit_preflight.py` (new, CPU-only, no FlashInfer needed) covers both preflights
against faked FlashInfer internals (arch present / absent / empty target set with the swallowed
error / import-time `ValueError` / FlashInfer absent / non-CUDA) and each linear-kernel gate
declining and accepting; the MoE suite gets a selection test where the unquantized oracle falls
through to Triton on an SM 12.x platform when the JIT preflight fails and keeps FlashInfer CUTLASS
when it passes, plus the b12x MoE gate. Lint: `pre-commit run --files <changed files>` and
`pre-commit run mypy-3.12 --hook-stage manual`.

### End-to-end on the affected hardware (method)

RTX 5090 Laptop GPU (sm_120), driver 595.84, torch 2.11.0+cu130, flashinfer-python 0.6.18
(no `flashinfer-cubin` / `flashinfer-jit-cache`), vLLM editable at 52358e6e19 (stock) and at this
commit (patched). Same box, same session. The only variable between the two toolkit columns is
`CUDA_HOME` / `PATH` (nvcc 12.8.61 vs 13.1.115), which is what FlashInfer reads to decide whether it
can target SM 12.x. `VLLM_USE_FLASHINFER_SAMPLER=0` in every run so the sampler path (#48956) does
not mask the result; `enforce_eager=True`, `max_model_len=2048`. Each run boots the engine and
generates one greedy completion for "The capital of France is" (`e2e.py` below); `rc` is the
process exit code.

<details><summary>e2e.py</summary>

```python
import json, sys
from vllm import LLM, SamplingParams

kwargs = {"max_model_len": 2048, "gpu_memory_utilization": 0.6, "enforce_eager": True}
for kv in sys.argv[2:]:
    k, v = kv.split("=", 1)
    try:
        kwargs[k] = json.loads(v)
    except json.JSONDecodeError:
        kwargs[k] = v
llm = LLM(model=sys.argv[1], **kwargs)
out = llm.generate(["The capital of France is"], SamplingParams(max_tokens=12, temperature=0))
print("RESULT: OK", repr(out[0].outputs[0].text))
```

OLMoE runs used `gpu_memory_utilization=0.9`; NVFP4 runs used
`kernel_config={"enable_flashinfer_autotune": false}`.
</details>

## Test Result

### Unit tests and lint

```
48 passed, 1 skipped
```

`pre-commit run --files <changed files>` and `pre-commit run mypy-3.12 --hook-stage manual` pass.

### RTX 5090 Laptop GPU (sm_120, 24 GB)

| Model / path | stock, nvcc 12.8 | patched, nvcc 12.8 | patched, CUDA 13.1 (control) |
|---|---|---|---|
| `allenai/OLMoE-1B-7B-0924` (bf16, unquantized MoE) | selects `FlashInfer CUTLASS` MoE, profile run dies in `gen_cutlass_fused_moe_sm120_module`: `No supported CUDA architectures found for major versions [12]` (rc=1) | preflight warning, `TRITON` MoE backend, generates `" Paris.\n\nThe capital of the United States is Washington"` (rc=0) | selects `FlashInfer CUTLASS` MoE (preflight passes), JIT-compiles the sm120 fused-MoE module (~24 min with `MAX_JOBS=2`), generates `" Paris.\n\nThe capital of the United States is Washington"` (rc=0) |
| `southfreebird/Qwen2.5-0.5B-Instruct-FP8` (per-tensor static W8A8) | `Selected FlashInferFP8ScaledMMLinearKernel`, dies: `No supported CUDA architectures found for major versions [12]` (rc=1) | `Selected CutlassFP8ScaledMMLinearKernel`, generates `" Paris. It is the largest city in the world by population"` (rc=0) | `Selected FlashInferFP8ScaledMMLinearKernel`, JIT-compiles (~8 min), generates `" Paris. It is the largest city in the European Union and"` (rc=0) |
| `nm-testing/TinyLlama-1.1B-Chat-v1.0-NVFP4`, CuTe-DSL kernels disabled so the nvcc-JIT kernels are reached (`VLLM_DISABLED_KERNELS=FlashInferCuteDslNvFp4W4A16LinearKernel,FlashInferCuteDslNvFp4LinearKernel`, FlashInfer autotune off) | `Using FlashInferCutlassNvFp4LinearKernel`, dies: `No supported CUDA architectures found for major versions [12]` (rc=1) | JIT preflight declines the CUTLASS kernel, b12x preflight declines `FlashInferB12xNvFp4LinearKernel` (`FlashInfer b12x kernels require CUDA >= 13 (local toolkit 12.8)`), `Using CutlassNvFp4LinearKernel`, generates `" Paris.\n10. What is the capital of Italy"` (rc=0) | `Using FlashInferCutlassNvFp4LinearKernel` (both preflights pass), the sm120 FP4 GEMM module JIT-compiles (~5.5 min), then the decode warmup dies in the lm_head bf16 GEMM with `CUBLAS_STATUS_INTERNAL_ERROR`. **Stock 52358e6e19 with the same toolkit and config fails identically** (with and without FlashInfer autotune), so this is a pre-existing problem of FlashInfer's CUTLASS NVFP4 kernel with nvcc 13.1 + torch cu130 on this box, not a selection change; not investigated further here |

What the NVFP4 row shows without the b12x preflight (the intermediate state of this branch, kept
here because it is the evidence for gating b12x): with only the JIT preflight, the CUTLASS kernel
declines and `FlashInferB12xNvFp4LinearKernel` is selected next, and the engine dies at first use
with `ValueError: b12x FP4 GEMM requires CUDA 13 or later. Current CUDA version: 12.8.`; with the
b12x kernel disabled by hand, `CutlassNvFp4LinearKernel` is selected and generates
`" Paris.\n10. What is the capital of Italy"` (rc=0).

Two things this table does **not** show, stated so nobody has to discover them in review:

- With the default NVFP4 priority on SM 12.x, `FlashInferCuteDslNvFp4W4A16LinearKernel` (CuTe-DSL,
  no nvcc) is selected first for this W4A4 checkpoint, so the CUTLASS / b12x gates are not on the
  default path today (they will be if #55170 lands). That default path then dies in FlashInfer's
  autotune of `bf16_fp4_cute_dsl_gemm` with a CUDA OOM, identically on stock and patched, on both the
  24 GB laptop and the 96 GB RTX PRO 6000 (and with `Out of bound mPartial.shape[0]` under CUDA 12.9).
  That is a pre-existing problem of the CuTe-DSL W4A16 path on SM 12.x, unrelated to this change;
  #55397 covers its priority, I will file the autotune failure separately.
- `FlashInferCutlassMxfp8LinearKernel` and `FlashInferB12xExperts` were not exercised end to end
  (no SM 12.x MXFP8 / b12x-MoE checkpoint at hand). They are gated because they take the identical
  code paths (`gen_jit_spec()` calls `check_cuda_arch()` unconditionally; the b12x MoE runner has
  the same `get_cuda_version().major < 13` check), and they have the unit tests above.

### Second machine: RTX PRO 6000 Blackwell Server Edition (sm_120, 96 GB)

GCP `g4-standard-48` (48 vCPU, 176 GB RAM), driver 580.173.02, torch 2.13.0+cu132 (what
`--torch-backend=auto` resolves for that driver), flashinfer-python 0.6.18 (no cubin / jit-cache),
vLLM at this commit installed with `VLLM_USE_PRECOMPILED=1`. The VM's only toolkit is CUDA 12.9,
FlashInfer's minimum for SM 12.x, so it is the control column; a CUDA 12.8.1 toolkit was installed
side by side (`/usr/local/cuda-12.8`, default untouched) for the reproduction columns. Same
`e2e.py`, `max_model_len=4096`, `VLLM_USE_FLASHINFER_SAMPLER=0`, `MAX_JOBS=16` for the JIT builds.
The run is unattended (bucket-driven job, logs in GCS); "stock" is the same file swap as above.

| Model / path | stock, nvcc 12.8 | patched, nvcc 12.8 | patched, CUDA 12.9 (control) |
|---|---|---|---|
| `RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8` (per-tensor static W8A8) | `Selected FlashInferFP8ScaledMMLinearKernel`, dies: `No supported CUDA architectures found for major versions [12]` (rc=1) | `Selected CutlassFP8ScaledMMLinearKernel`, generates `" a city of grandeur and beauty, with a rich history"` (rc=0) | `Selected FlashInferFP8ScaledMMLinearKernel`, JIT ~3 min, generates `" Paris, which is also the most visited city in the world"` (rc=0) |
| `Qwen/Qwen3-30B-A3B` bf16 (the MoE reported in #50705) | `FlashInfer CUTLASS` MoE backend, profile run dies with the same error (rc=1) | `TRITON` MoE backend, generates `" Paris. The capital of the United Kingdom is London. The"` (rc=0) | `FlashInfer CUTLASS` MoE backend, JIT ~8 min, generates the same text (rc=0) |
| Gemma-4 31B it-qat NVFP4 (modelopt, in-house checkpoint), default priority | `FlashInferCuteDslNvFp4W4A16LinearKernel`, then CUDA OOM inside FlashInfer's autotune of `bf16_fp4_cute_dsl_gemm` (16384 tokens) on the 96 GB GPU (rc=1). Pre-existing: identical on stock and patched | same OOM (rc=1) | same kernel, dies with `ValueError: Out of bound mPartial.shape[0]` from the CuTe-DSL kernel (rc=1). Pre-existing, independent of this change |
| same Gemma-4, CuTe-DSL kernels disabled | `FlashInferCutlassNvFp4LinearKernel`, dies: `No supported CUDA architectures found for major versions [12]` (rc=1) | JIT preflight declines the CUTLASS kernel, b12x preflight declines B12x (`FlashInfer b12x kernels require CUDA >= 13 (local toolkit 12.8)`), `CutlassNvFp4LinearKernel`, generates (rc=0) | `FlashInferCutlassNvFp4LinearKernel`, JIT ~2.5 min, generates (rc=0), byte-identical output to the fallback kernel |
| `nvidia/Qwen3.6-35B-A3B-NVFP4` (the NVFP4 MoE from the fourth entry point in #50705). On SM 12.x its experts go to Marlin and its NVFP4 linears to `MarlinNvFp4LinearKernel`; the dense FP8 per-tensor layers (QKV / MergedColumn / RowParallel) are what select FlashInfer, so the CuTe-DSL-disabled variant behaves identically | `Selected FlashInferFP8ScaledMMLinearKernel` for the three FP8 layer types, dies: `No supported CUDA architectures found for major versions [12]` (rc=1) | `Selected CutlassFP8ScaledMMLinearKernel` for them, generates `" Paris, a city renowned for its rich history, culture,"` (rc=0) | `Selected FlashInferFP8ScaledMMLinearKernel`, generates `" Paris, a city renowned for its iconic landmarks such as the"` (rc=0) |

On this box the Gemma-4 output for the raw prompt is `'thought\n---\n---\n---\n---\n---'` on both
vLLM's CUTLASS kernel and FlashInfer's: an instruct model opening a thinking block on an
untemplated prompt, not a numerics difference between the kernels. The laptop's cuBLAS failure
with nvcc 13.1 did not appear with 12.9 here.

### Model evaluation

Not applicable: this changes kernel *selection* only, and only on configurations that currently
cannot start. Where FlashInfer can compile, every gate returns exactly what it returned before
(the CUDA 13.1 column above and the `accepts` unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT4Q1w39aN7hSxbdfKQ8to
