### PR TITLE
[CI][ROCm] Temporarily skip unsupported HY-V4 initialization

### DIFF
--- a/tests/models/test_initialization.py
+++ b/tests/models/test_initialization.py
@@ -210,6 +210,12 @@ def test_can_initialize_large_subset(model_arch: str, monkeypatch: pytest.Monkey
     This test covers the complement of the tests covered in the "small subset"
     test.
     """
+    if model_arch in ("HYV4ForCausalLM", "HYV4MTPModel"):
+        from vllm.platforms import current_platform
+
+        if current_platform.is_rocm():
+            pytest.skip("HY V4 ROCm initialization requires #54405")
+
     can_initialize(model_arch, monkeypatch, HF_EXAMPLE_MODELS)
 
 


### PR DESCRIPTION
HY-V4's CUDA-only implementation in [#54160](https://github.com/vllm-project/vllm/pull/54160) raises `NotImplementedError: hy_v4 does not yet support ROCm` during the two HY initialization cases in [AMD build 12635](https://buildkite.com/vllm/amd-ci/builds/12635/list?jid=01a06dbb-c994-4dda-9277-8d85dae8eecb&tab=output) and [build 12653](https://buildkite.com/vllm/amd-ci/builds/12653/list?jid=01a070cd-0530-4d60-a5fd-a77dcc439bad&tab=output). This temporarily skips those unsupported cases while model enablement in [#54405](https://github.com/vllm-project/vllm/pull/54405) and its backend dependency [#54404](https://github.com/vllm-project/vllm/pull/54404) are completed. Remove this guard alongside ROCm model enablement; this CI-only change is separate from those support implementations.

- Skip only `HYV4ForCausalLM` and `HYV4MTPModel` initialization on ROCm.

Prepared with AI assistance (OpenAI Codex).
