### PR TITLE
[Core] Slice instead of gather when every scheduled token yields a logit

### DIFF
--- a/tests/v1/worker/test_logits_cover_all_tokens.py
+++ b/tests/v1/worker/test_logits_cover_all_tokens.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for InputBatch.logits_cover_all_tokens.
+
+The property decides whether the model runner and the sampler may slice the
+forward-pass output instead of gathering it with logits_indices. Getting it
+wrong silently feeds the wrong hidden states to compute_logits, so the tests
+below check it against logits_indices built by the real Triton kernel.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.input_batch import (
+    InputBatch,
+    combine_sampled_and_draft_tokens,
+)
+
+# The CPU tests below run anywhere; the kernel-agreement tests need a GPU.
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for the Triton kernel"
+)
+
+# --------------------------------------------------------------------------
+# The predicate itself. Pure CPU: it only reads two integers off the batch.
+# --------------------------------------------------------------------------
+
+_predicate = InputBatch.logits_cover_all_tokens.fget
+
+
+class _Batch:
+    """Minimal stand-in exposing the two attributes the property reads."""
+
+    def __init__(self, num_logits: int, num_tokens: int):
+        self.logits_indices = torch.empty(num_logits, dtype=torch.int64)
+        self.num_tokens = num_tokens
+
+
+@pytest.mark.parametrize(
+    ("num_logits", "num_tokens", "expected"),
+    [
+        # Pure decode: one row per request, one logit per request.
+        pytest.param(8, 8, True, id="decode"),
+        # Speculative verification, 4 requests x (1 bonus + 3 draft).
+        pytest.param(16, 16, True, id="spec-verify-uniform"),
+        # Ragged verification: draft counts differ, counts still match.
+        pytest.param(11, 11, True, id="spec-verify-ragged"),
+        # A prefilling request contributes many query rows but one logit.
+        pytest.param(4, 260, False, id="chunked-prefill"),
+        pytest.param(1, 1, True, id="single-request"),
+    ],
+)
+def test_predicate(num_logits: int, num_tokens: int, expected: bool):
+    assert _predicate(_Batch(num_logits, num_tokens)) is expected
+
+
+# --------------------------------------------------------------------------
+# Agreement with the real kernel. Requires CUDA + triton.
+# --------------------------------------------------------------------------
+
+DEVICE = torch.device("cuda")
+MAX_SPEC_STEPS = 4
+
+
+def _build_logits_indices(num_scheduled: list[int], num_draft: list[int]):
+    """Drive the real kernel the way prepare_inputs does.
+
+    Returns (logits_indices, num_tokens).
+    """
+    num_reqs = len(num_scheduled)
+    # prepare_inputs asserts this; the property's reasoning depends on it.
+    assert all(s >= d + 1 for s, d in zip(num_scheduled, num_draft))
+
+    query_start_loc_np = np.zeros(num_reqs + 1, dtype=np.int32)
+    np.cumsum(num_scheduled, out=query_start_loc_np[1:])
+    num_tokens = int(query_start_loc_np[-1])
+
+    num_logits_np = np.asarray(num_draft, dtype=np.int32) + 1
+    cu_num_logits_np = np.zeros(num_reqs + 1, dtype=np.int32)
+    np.cumsum(num_logits_np, out=cu_num_logits_np[1:])
+    total_num_logits = int(cu_num_logits_np[-1])
+
+    # seq_len == prefill_len keeps every request past its prefill, so the kernel
+    # takes the draft-token branch rather than the prefill one.
+    seq_lens = torch.full((num_reqs,), 64, dtype=torch.int32, device=DEVICE)
+
+    logits_indices = combine_sampled_and_draft_tokens(
+        input_ids=torch.zeros(num_tokens, dtype=torch.int32, device=DEVICE),
+        idx_mapping=torch.arange(num_reqs, dtype=torch.int64, device=DEVICE),
+        last_sampled_tokens=torch.zeros(
+            num_reqs, MAX_SPEC_STEPS + 1, dtype=torch.int32, device=DEVICE
+        ),
+        query_start_loc=torch.from_numpy(query_start_loc_np).to(DEVICE),
+        seq_lens=seq_lens,
+        prefill_len=seq_lens.clone(),
+        draft_tokens=torch.zeros(
+            num_reqs, MAX_SPEC_STEPS, dtype=torch.int32, device=DEVICE
+        ),
+        cu_num_logits=torch.from_numpy(cu_num_logits_np).to(DEVICE),
+        num_logits=total_num_logits,
+    )
+    return logits_indices, num_tokens
+
+
+@requires_cuda
+@pytest.mark.parametrize(
+    ("num_scheduled", "num_draft"),
+    [
+        pytest.param([1, 1, 1, 1], [0, 0, 0, 0], id="decode"),
+        pytest.param([4, 4, 4], [3, 3, 3], id="spec-verify-uniform"),
+        pytest.param([4, 2, 5], [3, 1, 4], id="spec-verify-ragged"),
+        pytest.param([1], [0], id="single-request"),
+        # Mismatched counts: request 1 brings 6 query rows but only 2 logits.
+        pytest.param([4, 6, 4], [3, 1, 3], id="not-covered"),
+    ],
+)
+def test_predicate_agrees_with_kernel(num_scheduled: list[int], num_draft: list[int]):
+    """The predicate must be true exactly when slicing is safe."""
+    logits_indices, num_tokens = _build_logits_indices(num_scheduled, num_draft)
+    batch = _Batch(logits_indices.shape[0], num_tokens)
+
+    slicing_is_valid = torch.equal(
+        logits_indices, torch.arange(num_tokens, dtype=torch.int64, device=DEVICE)
+    )
+    assert _predicate(batch) is slicing_is_valid
+
+
+@requires_cuda
+def test_slice_matches_gather_on_hidden_states():
+    """End result: the slice must select the same rows the gather would."""
+    logits_indices, num_tokens = _build_logits_indices([4, 2, 5], [3, 1, 4])
+    hidden_states = torch.randn(num_tokens, 128, device=DEVICE)
+
+    assert _predicate(_Batch(logits_indices.shape[0], num_tokens))
+    assert torch.equal(hidden_states[:num_tokens], hidden_states[logits_indices])

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -109,6 +109,34 @@ class InputBatch:
     # stays valid for every replay the graph serves.
     max_query_len: int | None = None
 
+    @property
+    def logits_cover_all_tokens(self) -> bool:
+        """Whether logits_indices is exactly arange(num_tokens).
+
+        combine_sampled_and_draft_tokens() places request i's logit rows at
+        [query_end_i - num_logits_i, query_end_i), and prepare_inputs asserts
+        num_logits_i <= num_scheduled_tokens_i, so a request never selects more
+        rows than it contributed. The per-request blocks are therefore laid out
+        in batch order and each sits at the tail of its own query.
+
+        Under that bound, sum(num_logits) == sum(num_scheduled_tokens) forces
+        num_logits_i == num_scheduled_tokens_i for every i: no request can make
+        up another's shortfall. Each block then spans its whole query, the
+        blocks tile [0, num_tokens) without gaps, and logits_indices is a plain
+        arange -- so callers may slice [:num_tokens] instead of gathering.
+
+        This holds for a pure decode batch (one row per request) and equally
+        for a speculative verification step, where every request contributes
+        1 + num_draft_tokens rows and consumes exactly that many query rows,
+        including when draft counts differ across requests. It is false as soon
+        as any request is mid-prefill, since that request contributes many query
+        rows but a single logit.
+
+        Slicing returns a view of the forward pass output, not a copy. Callers
+        must not hold it past the step or write through it.
+        """
+        return self.logits_indices.shape[0] == self.num_tokens
+
     @classmethod
     def make_dummy(
         cls,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1463,7 +1463,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             logits = all_to_all_logits(local_logits, shard_metadata)
             logits = logits[:, : self.vocab_size]
         else:
-            sample_hidden_states = hidden_states[input_batch.logits_indices]
+            if input_batch.logits_cover_all_tokens:
+                sample_hidden_states = hidden_states[: input_batch.num_tokens]
+            else:
+                sample_hidden_states = hidden_states[input_batch.logits_indices]
             logits = self.model.compute_logits(sample_hidden_states)
 
         if grammar_output is not None:

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -129,8 +129,13 @@ class Sampler:
         idx_mapping_np = input_batch.idx_mapping_np
         cu_num_logits_np = input_batch.cu_num_logits_np
         expanded_local_pos = input_batch.expanded_local_pos
-        pos = input_batch.positions[input_batch.logits_indices]
-        input_ids = input_batch.input_ids[input_batch.logits_indices]
+        if input_batch.logits_cover_all_tokens:
+            # Views into the step's input buffers; consumed within this call.
+            pos = input_batch.positions[: input_batch.num_tokens]
+            input_ids = input_batch.input_ids[: input_batch.num_tokens]
+        else:
+            pos = input_batch.positions[input_batch.logits_indices]
+            input_ids = input_batch.input_ids[input_batch.logits_indices]
 
         # NOTE(woosuk): We intentionally compute num_nans before sampling to make clear
         # that num_nans is computed before applying penalties and temperature.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4564,6 +4564,16 @@ class GPUModelRunner(
                 hidden_states = model_output
                 aux_hidden_states = None
 
+            def select_logits_rows(hidden_states: torch.Tensor) -> torch.Tensor:
+                # logits_indices is arange(num_tokens_unpadded) whenever every
+                # scheduled token yields a logit -- pure decode, and speculative
+                # verification too. See InputBatch.logits_cover_all_tokens for
+                # why the counts matching implies the indices are contiguous.
+                # The slice is a view of the forward output, used within the step.
+                if logits_indices.shape[0] == num_tokens_unpadded:
+                    return hidden_states[:num_tokens_unpadded]
+                return hidden_states[logits_indices]
+
             if not self.broadcast_pp_output:
                 # Common case.
                 if not get_pp_group().is_last_rank:
@@ -4581,13 +4591,13 @@ class GPUModelRunner(
                         kv_connector_output,
                     )
 
-                sample_hidden_states = hidden_states[logits_indices]
+                sample_hidden_states = select_logits_rows(hidden_states)
                 logits = self.model.compute_logits(sample_hidden_states)
             else:
                 # Rare case.
                 assert not self.is_pooling_model
 
-                sample_hidden_states = hidden_states[logits_indices]
+                sample_hidden_states = select_logits_rows(hidden_states)
                 if not get_pp_group().is_last_rank:
                     all_gather_tensors = {
                         "residual": not is_residual_scattered_for_sp(


### PR DESCRIPTION
## Purpose

`sample_hidden_states`, `pos` and `input_ids` are selected with advanced indexing on `logits_indices` on every step:

```python
sample_hidden_states = hidden_states[logits_indices]
pos = input_batch.positions[input_batch.logits_indices]
input_ids = input_batch.input_ids[input_batch.logits_indices]
```

Three gather kernels, three device allocations and a row copy each. But `logits_indices` is frequently exactly `arange(num_tokens)`, and in that case all three select rows `0..num_tokens-1` in order — which a slice does for free.

This PR adds `InputBatch.logits_cover_all_tokens` as the predicate and takes the slice when it holds.

## The predicate

The predicate is `total_num_logits == num_tokens`, **not** `num_tokens == num_reqs`.

Both are sound, but the narrow form only covers a batch with one row per request — precisely the case that disappears once speculative decoding is on. A verification step schedules `1 + num_draft_tokens` rows per request, so `num_tokens == num_reqs` never fires there. The counts-based form covers verification too, including a ragged batch whose requests carry different draft counts, which is the hot path for a spec-decode deployment.

**Why the counts settle it.** Request `i`'s logit rows land at `[query_end_i - num_logits_i, query_end_i)` — tail-aligned within its own query — and `num_logits_i <= num_scheduled_tokens_i` always holds, so no request can select more rows than it contributed. Under that bound the sums can only match if every request matches individually: no request can make up another's shortfall. Each block then spans its whole query, the blocks tile `[0, num_tokens)` in order without gaps, and `logits_indices` is a plain arange.

A prefilling request breaks it — many query rows, a single logit — and the batch correctly falls back to the gather.

The same reasoning holds for the legacy runner, where `logits_indices` is built as `cu_num_scheduled_tokens - num_sampled_tokens` plus a per-request arange: same tail-aligned layout, same conclusion.

## Notes

- The slice is a **view** of the forward-pass output, not a fresh copy. Both call sites consume it within the step; this is documented on the property so a future caller does not stash it across steps or write through it.
- In `gpu_model_runner.py` the same selection appeared twice in adjacent branches and is now one local helper.

## Test Plan

`tests/v1/worker/test_logits_cover_all_tokens.py`:

- **CPU** — the predicate directly, over decode / uniform verification / ragged verification / chunked prefill / single request.
- **CUDA** — agreement with the real kernel: `logits_indices` is produced by `combine_sampled_and_draft_tokens` the way `prepare_inputs` drives it, and the test asserts the predicate is true **exactly** when `logits_indices` equals `arange(num_tokens)` — for decode, uniform verification, ragged verification, a single request, and a non-covering mixed batch.
- **CUDA** — the end result: `hidden_states[:num_tokens]` selects the same rows as `hidden_states[logits_indices]`.

Getting the predicate wrong would silently feed the wrong hidden states to `compute_logits`, so the tests check it against kernel output rather than against a reimplementation of the index math.

## Test Result

The 5 CPU tests pass. `ruff check` and `ruff format --check` are clean on all touched files.

The CUDA tests have not been run — the only GPU I have access to is running a production server that occupies nearly all of its memory, so I could not initialize a CUDA context on it without risking that service. I would appreciate a `/ci run` to exercise them.

## Disclosure

Claude Code was used in preparing this change, including for the analysis behind the predicate and for writing the tests. All of it has been reviewed by me, and the reasoning above is stated so it can be checked independently of how it was produced.
