### PR TITLE
[Bugfix] Exclude dominated ties from sweep Pareto frontier

### DIFF
--- a/tests/benchmarks/test_plot_pareto.py
+++ b/tests/benchmarks/test_plot_pareto.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pandas as pd
+import pytest
+
+from vllm.benchmarks.sweep.plot_pareto import _pareto_frontier
+
+
+@pytest.mark.parametrize(
+    "points,expected_indices",
+    [
+        ([], []),
+        ([(10, 5)], [0]),
+        ([(5, 5), (10, 5)], [1]),
+        ([(10, 3), (10, 5)], [1]),
+        ([(10, 3), (5, 5), (3, 10)], [0, 1, 2]),
+        ([(5, 5), (10, 10), (3, 3)], [1]),
+        ([(10, 5), (10, 5), (5, 5)], [0, 1]),
+        ([(10, 5), (5, 5 + 1e-10), (3, 6)], [0, 2]),
+    ],
+)
+def test_pareto_frontier(points, expected_indices):
+    df = pd.DataFrame(points, columns=["tokens_per_user", "tokens_per_gpu"])
+
+    frontier = _pareto_frontier(df, "tokens_per_user", "tokens_per_gpu")
+
+    pd.testing.assert_frame_equal(frontier, df.loc[expected_indices])

--- a/vllm/benchmarks/sweep/plot_pareto.py
+++ b/vllm/benchmarks/sweep/plot_pareto.py
@@ -144,12 +144,15 @@ def _pareto_frontier(
 ) -> "pd.DataFrame":
     sorted_df = df.sort_values([x_col, y_col], ascending=[False, False])
     frontier_indices = []
+    best_x = math.inf
     best_y = -math.inf
 
     for idx, row in sorted_df.iterrows():
+        x_val = row[x_col]
         y_val = row[y_col]
-        if y_val >= best_y - epsilon:
+        if y_val > best_y + epsilon or (x_val == best_x and y_val >= best_y - epsilon):
             frontier_indices.append(idx)
+            best_x = x_val
             best_y = max(best_y, y_val)
 
     return df.loc[frontier_indices]


### PR DESCRIPTION
## Purpose

Fixes #55561.

Sweep Pareto plots currently include runs with lower tokens/s/user when tokens/s/GPU is tied. For example, two runs producing 100 tokens/s with concurrency 10 and 20 both appear on the frontier, even though the second provides no throughput benefit.

Track the last accepted x-coordinate and require a y improvement beyond the existing tolerance when x decreases. Keep duplicate optimal runs so their configuration labels remain available.

Related PR: #55607 addresses the same issue. This is an alternative patch using exact x-coordinate equality for duplicate retention, with no changes to the plotting calls. It includes regression cases for empty inputs, ties, duplicates, tradeoffs, and the existing epsilon tolerance, plus before/after plotting validation.

Prepared with Codex. The submitter reviewed the diff and ran the relevant tests.

## Test Plan

Run the focused plotting and parameter-sweep suites:

```bash
.venv/bin/python -m pytest --noconftest \
  tests/benchmarks/test_plot_pareto.py \
  tests/benchmarks/test_plot_filters.py \
  tests/benchmarks/sweep/test_param_sweep.py -q

.venv/bin/pre-commit run --files \
  vllm/benchmarks/sweep/plot_pareto.py \
  tests/benchmarks/test_plot_pareto.py
```

These self-contained suites ran on macOS arm64 with Python 3.12. `--noconftest` avoids importing the GPU/model test infrastructure from the global test setup.

Run the actual plotting entry point against controlled sweep `summary.json` files, on both the base code and this branch:

```bash
MPLBACKEND=Agg .venv/bin/python -m vllm.benchmarks.sweep.plot_pareto \
  EXPERIMENT_DIR --label-by run
```

The two-run reproducer uses:

```json
[
  {"run": "better", "output_throughput": 100, "max_concurrency": 10, "tensor_parallel_size": 1},
  {"run": "dominated", "output_throughput": 100, "max_concurrency": 20, "tensor_parallel_size": 1}
]
```

## Test Result

- 58 tests passed, including all eight Pareto regression cases.
- Pre-commit checks passed.
- The plotting CLI read the sweep files and rendered PNGs successfully in all three end-to-end scenarios:

| Input | Frontier size before | Frontier size after |
| --- | --- | --- |
| Two equal-throughput runs with different concurrency | 2 | 1 |
| Six runs containing ties, duplicate coordinates, and a tradeoff | 5 | 3 |
| Three-run control without ties | 2 | 2 |

The fixed plots exclude dominated tie points and retain duplicate optimal runs. The control PNG is byte-identical before and after (SHA-256 `110a420992a03d61b77b835709476873dba0087f508830194b837f8a25420cd5`).

This changes plotting only. No model output or serving behavior changes; GPU inference and new throughput measurements were not run.
