### PR TITLE
[CI] [Test] skip test_wna16_cuda_high_bit_skips_humming on non-CUDA platforms

### DIFF
--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -726,6 +726,10 @@ def test_wna16_cuda_low_bit_moe_routes_to_humming(monkeypatch, bits) -> None:
     assert captured["layer_config"] is layer_config
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="This test only exercises the CUDA Marlin path.",
+)
 @pytest.mark.parametrize("bits", [4, 8])
 def test_wna16_cuda_high_bit_skips_humming(monkeypatch, bits) -> None:
     """4/8-bit int stays on the Marlin/GPTQ/AWQ path even on CUDA so a single


### PR DESCRIPTION
## Purpose
`test_wna16_cuda_high_bit_skips_humming` fails on XPU CI runners with:
```
NotImplementedError: INC quantization with bits=4, sym=True is not supported. Only 4-bit and 8-bit symmetric quantization is supported with Marlin kernels.
```

## Root cause
The test mocks `current_platform.is_cuda/is_xpu/is_cpu` to simulate CUDA, but `AutoGPTQLinearMethod.__init__` (and `check_marlin_supported()` earlier in the call chain) perform a **real, unmocked** device-capability check. On an actual XPU host this real check fails regardless of the test's mocks, so this test only exercises the CUDA Marlin path and can only meaningfully run on real CUDA hardware.

## Fix
Skip the test when not running on real CUDA hardware (`current_platform.is_cuda()`), matching the existing pattern already used for other CUDA-only cases in this same file (see the `MODELS` parametrization's `skipif` marks).
 