### PR TITLE
[Kernel] SM 12.x blockwise FP8: gate the CTA swizzle on the activation size too

### DIFF
--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm120_fp8.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm120_fp8.cu
@@ -21,11 +21,29 @@ namespace {
 // 6000 Blackwell / GB202: 96-128 MiB) keep the default order, which is also
 // the faster one there (2560x6144 at 15 MiB: 178 vs 163 at M=2048).
 constexpr int kBlockwiseFp8SwizzleSize = 8;
+// Above the L2 the swizzled order is not unconditionally better. On a GB10
+// (24 MiB L2) it loses to the default order across a band of middling
+// activation sizes -- worst at M = 2560 (5120x5120 -10.4 %, 10240x2560
+// -9.4 %, 16384x2560 -6.4 %), and 3-5 % at M = 4096 on the 2560-wide weights.
+// It wins again once the activation slab is large (up to 3.2x), and it wins at
+// very small M. Over four starts on 6 shapes x M = 1024..6144 (66 cells),
+// gating on the weight alone leaves 118.8 percentage points on the table, the
+// activation term alone 54.0, and the two together 35.3.
+//
+// The small-M island stops at 1024 because it is K-dependent: at K = 2560 the
+// swizzle wins there, at K = 5120 the default order does, so an island reaching
+// M = 2048 gives back 6.9-8.5 % on the 5120-wide weights.
+constexpr int64_t kBlockwiseFp8SwizzleMinActivationBytes = 14ll << 20;
+constexpr int64_t kBlockwiseFp8SwizzleSmallM = 1024;
 
-int blockwise_fp8_swizzle_size(int64_t weight_bytes) {
+int blockwise_fp8_swizzle_size(int64_t m, int64_t k, int64_t weight_bytes) {
   const int64_t l2_bytes = get_device_prop()->l2CacheSize;
-  return (l2_bytes > 0 && weight_bytes > l2_bytes) ? kBlockwiseFp8SwizzleSize
-                                                   : 1;
+  if (l2_bytes <= 0 || weight_bytes <= l2_bytes) return 1;
+  if (m <= kBlockwiseFp8SwizzleSmallM) return kBlockwiseFp8SwizzleSize;
+  // FP8 activations: one byte per element.
+  return (m * k >= kBlockwiseFp8SwizzleMinActivationBytes)
+             ? kBlockwiseFp8SwizzleSize
+             : 1;
 }
 
 }  // namespace
@@ -35,7 +53,8 @@ void cutlass_scaled_mm_blockwise_sm120_fp8(
     torch::stable::Tensor const& b, torch::stable::Tensor const& a_scales,
     torch::stable::Tensor const& b_scales) {
   // b is [K, N] FP8 (one byte per element).
-  const int swizzle = blockwise_fp8_swizzle_size(b.size(1) * b.size(0));
+  const int swizzle =
+      blockwise_fp8_swizzle_size(a.size(0), a.size(1), b.size(1) * b.size(0));
   if (out.scalar_type() == torch::headeronly::ScalarType::BFloat16) {
     cutlass_gemm_blockwise_sm120_fp8_dispatch<cutlass::bfloat16_t>(
         out, a, b, a_scales, b_scales, swizzle);

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -229,14 +229,19 @@ def test_cutlass_fp8_gemm_padded(
     torch.testing.assert_close(out, baseline, rtol=5e-1, atol=1.5e-1)
 
 
-# Two prefill-sized cases for the SM 12.x blockwise path, where the op switches
-# the tile scheduler to a swizzled CTA order once the weight exceeds the L2
-# (16384x2560 = 40 MiB and 5120x5120 = 25 MiB on a 24 MiB L2 part); the odd M
+# Prefill-sized cases for the SM 12.x blockwise path, where the op switches the
+# tile scheduler to a swizzled CTA order. On a 24 MiB L2 part the weights here
+# exceed the L2 (16384x2560 = 40 MiB, 5120x5120 = 25 MiB) and the three arms of
+# the gate are then covered by M: 8193 and 5120 take the swizzled order via the
+# activation term, 2560 takes the default order in the band where the swizzle
+# loses, and 1024 takes the swizzled order via the small-M island. The odd M
 # also covers the non-swap-AB dispatch. Elsewhere they run the default order
 # like the rest of the list.
 BLOCKWISE_PREFILL_FACTORS = [
     (8193, 16384, 2560),
     (5120, 5120, 5120),
+    (2560, 16384, 2560),
+    (1024, 16384, 2560),
 ]
 
 


### PR DESCRIPTION
## Purpose

#55180 (merged) switches the SM 12.x blockwise FP8 tile scheduler to a swizzled CTA order whenever the weight exceeds the L2. Above the L2 that order is not unconditionally better, so the weight-only gate leaves a measurable amount on the table. This adds the activation term back, with the small-M island that the earlier version of it was missing.

```c++
if (weight_bytes <= l2_bytes)     return 1;
if (m <= 1024)                    return 8;
return (m * k >= 14 MiB) ? 8 : 1;   // FP8 activations: 1 byte/element
```

An activation-slab term was in #55180 and was dropped during review, correctly at the time: as written it also kept the default order at small M, where the swizzle wins. The island fixes exactly that case, and the sweep below is a much finer grid than the one that informed the original.

## Test Plan

Measured with the swizzle **forced both ways at the same shape** — a standalone build of this dispatch with `max_swizzle_size` exposed as an argument — so the two orders are compared directly rather than inferred across a gate. 6 shapes x M = 1024..6144 in steps of 512 = 66 cells, **four starts**, medians. GB10 (sm_121, 24 MiB L2), TP=1. Then the same 66 cells run through the gate as committed here, checking bit-identity against the stock op and that the gated launch lands on the arm the predicate selects.

`pytest tests/kernels/quantization/test_cutlass_scaled_mm.py -k blockwise`

## Test Result

Summed percentage left on the table against the per-cell best, over all 66 cells:

| gate | regret | worst cell |
| --- | --- | --- |
| never swizzle | 732.7 pp | 69.1 % |
| `weight > L2` (current) | 118.8 pp | 9.9 % |
| `+ (m <= 2560 \|\| m*k >= 14 MiB)` | 90.2 pp | 9.9 % |
| `+ (m*k >= 14 MiB)`, no island | 54.0 pp | 7.4 % |
| `+ (m <= 2048 \|\| m*k >= 14 MiB)` | 48.6 pp | 8.7 % |
| **`+ (m <= 1024 \|\| m*k >= 14 MiB)` (this PR)** | **35.3 pp** | **5.8 %** |

The current gate's worst cells are at M = 2560 — 5120x5120 −10.4 %, 10240x2560 −9.4 %, 16384x2560 −6.4 % — a point the coarser sweep behind #55180 (M stepping by 2048) did not sample. At M = 4096 the 2560-wide weights lose 3–5 %.

The island stops at 1024 rather than 2048 because it is K-dependent: at K = 2560 the swizzle wins at low M, at K = 5120 the default order does, so a wider island gives back 6.9–8.5 % on the 5120-wide weights. M <= 1024 and M <= 1536 are indistinguishable (35.3 vs 35.2 pp); 2048 is not.

What the gate must not lose, and does not: the large wins, all at an activation slab above ~22 MiB — 7168x5120 at M = 6144 **+223 %**, M = 5632 +199 %, 14336x4096 at M = 6144 +158 %, 5120x5120 at M = 4608 +93 %.

Verification of the code as committed: **bit-identical to the stock op on 66/66 cells** (twice), and on the 26 cells where the two orders differ by more than 30 % the gated launch tracks the arm the predicate selects, 26/26.

Honest limits: this is one part (GB10, 24 MiB L2). Parts whose L2 holds the weight are unaffected by construction, so SM120 desktop parts (96–128 MiB L2) keep the default order exactly as before. A scalar gate cannot capture all of the structure — 17 of 66 cells still take the worse order, all by 5.8 % or less. And the default order is the noisy one here: its start-to-start spread is median 4.7 % and up to 26 %, against ~1.5 % for the swizzled order, which is why this needed four starts; at two starts the island candidates could not be separated at all.

## Essential Elements

- [x] Purpose clearly explained
- [x] Test plan and test results included
- [x] Not a duplicate: `gh pr list --search` on `scaled_mm_blockwise_sm120`, `max_swizzle_size`, `swizzle`, `blockwise fp8 sm120` — no open PR touches this dispatch
- [x] Model evaluation: not applicable, the swizzle only reorders CTAs and output is bit-identical (asserted on all 66 cells)
- [x] **AI assistance was used for this change**; every line was reviewed by me before pushing

cc @gau-nernst — this is the follow-up to the gate we simplified in #55180.
