### PR TITLE
[Bugfix][Benchmark] Avoid dropping sweep figures and worker errors

### DIFF
--- a/tests/benchmarks/sweep/test_plot.py
+++ b/tests/benchmarks/sweep/test_plot.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+
+import pytest
+
+from vllm.benchmarks.sweep.plot import SweepPlotArgs, main
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+@pytest.mark.parametrize("invalid_group", [0, 1])
+def test_plot_propagates_worker_errors(tmp_path, invalid_group):
+    records = [{"model": str(i), "tensor_parallel_size": 1} for i in range(2)]
+    del records[invalid_group]["tensor_parallel_size"]
+    (tmp_path / "summary.json").write_text(json.dumps(records))
+
+    parser = SweepPlotArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            str(tmp_path),
+            "--fig-by",
+            "model",
+            "--row-by",
+            "tensor_parallel_size",
+            "--dry-run",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Cannot find metric 'tensor_parallel_size'"):
+        main(args)

--- a/vllm/benchmarks/sweep/plot.py
+++ b/vllm/benchmarks/sweep/plot.py
@@ -453,8 +453,8 @@ def plot(
     )
 
     with DummyExecutor() if len(fig_groups) <= 1 else ProcessPoolExecutor() as executor:
-        # Resolve the iterable to ensure that the workers are run
-        all(
+        # Consume every result so all figures complete and worker errors are raised.
+        list(
             executor.map(
                 partial(
                     _plot_fig,


### PR DESCRIPTION
## Purpose

Fixes #55663.

`all(executor.map(...))` stops after the first figure because `_plot_fig()` returns `None`. It hides exceptions from later workers and cancels queued figures when the iterator closes. Consume every result with `list()` instead.

The change is limited to the sweep plotting loop and a parametrized regression for failures in the first and second groups. There was no existing PR for this problem when checked. It is separate from the Pareto tie calculation in #55658/#55607 and command-option replacement in #55500. The Pareto plotting entrypoint always creates one group, so it does not have the multi-group failure and is unchanged.

## Test Plan

```sh
.venv/bin/python -m pytest --noconftest \
  tests/benchmarks/sweep/test_plot.py \
  tests/benchmarks/test_plot_filters.py \
  tests/benchmarks/sweep/test_param_sweep.py -q

.venv/bin/pre-commit run --files \
  vllm/benchmarks/sweep/plot.py tests/benchmarks/sweep/test_plot.py
```

Ran the module CLI before and after the fix with `MPLBACKEND=Agg`, reading `summary.json` inputs and writing PNGs through child processes. The issue contains a minimal CLI reproduction. A separate run limited the actual process pool to one worker to check queued figures.

## Test Result

- The regression fails on main because the second worker's exception is not raised. With the fix, all 52 focused tests pass. Pre-commit passes.
- Seven before/after CLI scenarios covered multiple valid groups, one group, dry-run, an invalid first group, an invalid later group, a filtered-out first group followed by a failure, and a later file-write failure. The three previously hidden failures now exit 1 with their exceptions. Successful runs still exit 0, and all control PNGs are byte-identical.
- With one process worker and 12 valid figure groups, main produced 4 PNGs and exited successfully. The fix produced all 12.

Validation used Python 3.12 on macOS arm64. `--noconftest` avoids the unrelated GPU-serving fixtures. This change does not affect model output or serving; no GPU inference or throughput measurements are claimed.

AI assistance: Codex prepared the change and ran the checks above.

---

- [x] Purpose and linked issue.
- [x] Test commands.
- [x] Before/after results.
- [x] No new options or documentation changes are needed.
