### PR TITLE
[Docs] Fix DeltaMessage import path in reasoning outputs guide

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -430,7 +430,7 @@ You can add a new `ReasoningParser` similar to [vllm/reasoning/deepseek_r1_reaso
 
     from vllm.reasoning import ReasoningParser, ReasoningParserManager
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+    from vllm.entrypoints.generate.base.protocol import DeltaMessage
 
     # define a reasoning parser and register it to vllm
     # the name list in register_module can be used


### PR DESCRIPTION
## Summary
- The "How to support a new reasoning model" example imported `DeltaMessage` from nonexistent `vllm.entrypoints.openai.engine.protocol`.
- Point the import at `vllm.entrypoints.generate.base.protocol`, matching live reasoning parsers (`basic_parsers.py`, `deepseek_r1_reasoning_parser.py`).

## Reproduction
Verified against upstream `main` HEAD `6fbb00b18874e27ba7d7adc0a3b8e93fee763ab1`:

1. Docs example (before):
   `from vllm.entrypoints.openai.engine.protocol import DeltaMessage`
2. Module missing:
   `curl -I https://raw.githubusercontent.com/vllm-project/vllm/6fbb00b1/vllm/entrypoints/openai/engine/protocol.py` → **404**
3. Correct module exists and defines `class DeltaMessage`:
   `vllm/entrypoints/generate/base/protocol.py` → **200**
4. Live parsers already use the correct import:
   - `vllm/reasoning/basic_parsers.py`
   - `vllm/reasoning/deepseek_r1_reasoning_parser.py`
5. No open PR already covered this one-line docs path fix.

## Test plan
- [x] Confirm patched line is the only change in `docs/features/reasoning_outputs.md`
- [x] Confirm `ChatCompletionRequest` import path left unchanged (still valid)