### PR TITLE
[Spec Decode] Support optional DFlash2 confidence-based adaptive verification

### DIFF
--- a/docs/features/speculative_decoding/adaptive_verification.md
+++ b/docs/features/speculative_decoding/adaptive_verification.md
@@ -12,7 +12,7 @@ The practical effect is that one configuration holds up across the whole load ra
 
 ## Support
 
-Adaptive verification needs per-position acceptance estimates, so today it is only supported for DSpark with a **confidence head**.
+Adaptive verification needs per-position acceptance estimates. It supports DSpark and DFlash2 checkpoints with a trained **confidence head**. The attention-backend requirements below still apply.
 
 ## Usage
 
@@ -31,6 +31,10 @@ vllm serve deepseek-ai/DeepSeek-V4-Flash-DSpark \
 ```
 
 Set `enable_adaptive_verification: false` to verify the full block for every request.
+
+For DFlash2, use `method: "dflash"` with a DFlash2 checkpoint and explicitly set `enable_adaptive_verification: true`. The selector estimates confidence conditioned on the predecessor actually chosen along the draft path. Enabling AV without loaded confidence-head weights raises an error.
+
+A DFlash2 checkpoint containing a confidence head can also be served with fixed-budget drafting: loading the head does not enable AV. With AV disabled (the default), vLLM neither computes confidence scores nor allocates their output buffer.
 
 ## Requirements and limitations
 

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -71,7 +71,7 @@ def test_selector_edges_match_sequential_reference():
     torch.testing.assert_close(actual, expected)
 
 
-def _stub_base(monkeypatch, draft_logits):
+def _stub_base(monkeypatch, draft_logits, *, adaptive=False):
     """A DFlashSpeculator.__init__ that allocates only what the base class would.
 
     The real base class fills draft_logits from draft_logits_spec, so callers
@@ -79,6 +79,7 @@ def _stub_base(monkeypatch, draft_logits):
     """
 
     def init_base(self, _vllm_config, device):
+        self.speculative_config = SimpleNamespace(enable_adaptive_verification=adaptive)
         self.draft_model_config = SimpleNamespace(
             hf_config=SimpleNamespace(dflash_config={"selector_top_k": 3})
         )
@@ -116,6 +117,165 @@ def test_selector_asks_for_fp32_proposal_logits():
 
     assert dtype is torch.float32
     assert fill == float("-inf")
+
+
+@pytest.mark.parametrize("adaptive", [False, True])
+def test_confidence_buffer_is_only_allocated_for_adaptive(monkeypatch, adaptive):
+    _stub_base(monkeypatch, None, adaptive=adaptive)
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    confidence = speculator.draft_token_confidence_probs
+    if adaptive:
+        assert confidence.shape == speculator.draft_tokens.shape
+        assert confidence.dtype == torch.float32
+    else:
+        assert confidence is None
+
+
+@pytest.mark.parametrize("adaptive", [False, True])
+@pytest.mark.parametrize("has_head", [False, True])
+def test_adaptive_requires_loaded_confidence_weights(monkeypatch, adaptive, has_head):
+    _stub_base(monkeypatch, None, adaptive=adaptive)
+    selector = SimpleNamespace(
+        confidence_head=torch.nn.Linear(2, 1) if has_head else None
+    )
+    model = SimpleNamespace(model=SimpleNamespace(candidate_selector=selector))
+    monkeypatch.setattr(DFlashSpeculator, "load_draft_model", lambda *args: model)
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    if adaptive and not has_head:
+        with pytest.raises(ValueError, match="confidence head"):
+            speculator.load_draft_model(None, set())
+    else:
+        assert speculator.load_draft_model(None, set()) is model
+
+
+@pytest.mark.parametrize("compute_confidence", [False, True])
+def test_selector_confidence_is_opt_in_and_does_not_change_scores(
+    monkeypatch, compute_confidence
+):
+    """A serialized head must not add work or change proposals in fixed mode."""
+    from vllm.model_executor.models import qwen3_dflash2 as module
+
+    predecessors = torch.tensor([[0.0, 0.0], [1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    candidates = torch.tensor([[[1, 2], [2, 3]]])
+    hidden = torch.tensor([[[2.0, 3.0], [5.0, 7.0]]])
+    anchors = torch.tensor([3])
+    unary = torch.zeros(1, 2, 2)
+    head = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        head.weight.copy_(torch.tensor([[2.0, -1.0]]))
+        head.bias.fill_(0.5)
+    selector = SimpleNamespace(
+        hidden_projection=torch.nn.Identity(),
+        predecessor_codebook=predecessors,
+        successor_codebook=predecessors,
+        confidence_head=head,
+        top_k=2,
+    )
+    if not compute_confidence:
+
+        def unexpected_confidence(*args, **kwargs):
+            pytest.fail("fixed-budget drafting must not compute confidence")
+
+        monkeypatch.setattr(module, "_confidence_rows", unexpected_confidence)
+
+    scores, confidence = module.CandidateSelector.forward(
+        selector,
+        candidates,
+        unary,
+        hidden,
+        anchors,
+        compute_confidence=compute_confidence,
+    )
+    torch.testing.assert_close(
+        scores,
+        _score_edges(predecessors, predecessors, candidates, unary, hidden, anchors, 2),
+        rtol=0,
+        atol=0,
+    )
+    if compute_confidence:
+        # The anchor conditions every row at p0; p1 uses p0's candidates.
+        torch.testing.assert_close(
+            confidence, torch.tensor([[[2.5, 2.5], [-3.5, 2.5]]])
+        )
+    else:
+        assert confidence is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("adaptive", [False, True])
+def test_selector_walk_confidence_follows_selected_predecessors(monkeypatch, adaptive):
+    _stub_base(monkeypatch, None, adaptive=adaptive)
+    speculator = DFlash2Speculator(None, torch.device("cuda"))
+    speculator.num_speculative_steps = 3
+    speculator.selector_top_k = 2
+    speculator.use_fp64_gumbel = False
+    speculator.sample_pos = torch.arange(3, device="cuda").view(1, 3)
+    speculator.sample_idx_mapping = torch.zeros(
+        (1, 3), dtype=torch.int32, device="cuda"
+    )
+    speculator.temperature = torch.zeros(1, device="cuda")
+    speculator.seeds = torch.zeros(1, dtype=torch.int64, device="cuda")
+    speculator.draft_tokens = torch.empty((1, 3), dtype=torch.int64, device="cuda")
+    speculator._selector_scores = torch.empty((1, 3, 2), device="cuda")
+    speculator.draft_token_confidence_probs = (
+        torch.full((1, 3), -1.0, device="cuda") if adaptive else None
+    )
+    candidates = torch.tensor([[[10, 11], [20, 21], [30, 31]]], device="cuda")
+    scores = torch.tensor(
+        [
+            [
+                [[0.0, 2.0], [0.0, 2.0]],
+                [[0.0, 3.0], [4.0, 0.0]],
+                [[0.0, 5.0], [6.0, 0.0]],
+            ]
+        ],
+        device="cuda",
+    )
+    confidence = torch.tensor([[[0.1, 0.9], [0.2, 0.8], [0.3, 0.7]]], device="cuda")
+    speculator._sample_path(candidates, scores, 1, confidence if adaptive else None)
+    assert speculator.draft_tokens.tolist() == [[11, 20, 31]]
+    if adaptive:
+        torch.testing.assert_close(
+            speculator.draft_token_confidence_probs,
+            torch.tensor([[0.1, 0.8, 0.3]], device="cuda").sigmoid(),
+        )
+
+
+@pytest.mark.parametrize("adaptive", [False, True])
+def test_generate_draft_uses_selector_call_with_opt_in_confidence(
+    monkeypatch, adaptive
+):
+    """Both modes must use __call__, which owns the selector's compile wrapper."""
+    _stub_base(monkeypatch, None, adaptive=adaptive)
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    hidden = torch.zeros(5, 2)
+    candidates = torch.arange(12).view(4, 3)
+    scores = torch.zeros(1, 4, 3, 3)
+    confidence = torch.zeros(1, 4, 3) if adaptive else None
+
+    class Selector:
+        def __call__(self, ids, unary, states, anchors, *, compute_confidence):
+            assert compute_confidence is adaptive
+            return scores, confidence
+
+    speculator.model = SimpleNamespace(
+        compute_candidates=lambda _: (candidates, torch.zeros(4, 3)),
+        model=SimpleNamespace(candidate_selector=Selector()),
+    )
+    speculator.input_buffers = SimpleNamespace(
+        input_ids=torch.zeros(5, dtype=torch.long)
+    )
+    speculator.sample_indices = torch.arange(4)
+    speculator._run_model = lambda *args: hidden
+    sampled = []
+    speculator._sample_path = lambda *args: sampled.append(args)
+    speculator._generate_draft(1, 5, None, None, None)
+    assert len(sampled) == 1
+    ids, actual_scores, num_reqs, actual_confidence = sampled[0]
+    torch.testing.assert_close(ids, candidates.view(1, 4, 3))
+    assert actual_scores is scores
+    assert num_reqs == 1
+    assert actual_confidence is confidence
 
 
 @pytest.mark.skip_global_cleanup

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -538,7 +538,7 @@ class SpeculativeConfig:
 
     enable_adaptive_verification: bool = False
     """Whether to adaptively size the draft-verification budget from per-request
-    confidence. Currently only supported for method="dspark"."""
+    confidence. Supported for DSpark and DFlash2 with a trained confidence head."""
 
     @staticmethod
     def _acceptance_length_to_rates(length: float, n: int) -> list[float]:
@@ -1516,8 +1516,19 @@ class SpeculativeConfig:
                 self.index_share_for_mtp_iteration
             )
 
-        if self.method != "dspark" and self.enable_adaptive_verification:
-            raise ValueError("Adaptive verification only supported with DSpark")
+        dflash2_adaptive = (
+            self.method == "dflash"
+            and self.draft_model_config is not None
+            and "DFlash2DraftModel" in self.draft_model_config.architectures
+        )
+        if (
+            self.enable_adaptive_verification
+            and self.method != "dspark"
+            and not dflash2_adaptive
+        ):
+            raise ValueError(
+                "Adaptive verification is only supported with DSpark or DFlash2"
+            )
 
         return self
 

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -186,6 +186,25 @@ def _score_edges(
     )
 
 
+def _confidence_rows(
+    predecessor_table: torch.Tensor,
+    candidate_ids: torch.Tensor,
+    hidden: torch.Tensor,
+    anchor_token_ids: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    predecessor_ids = torch.cat(
+        (
+            anchor_token_ids[:, None, None].expand(-1, 1, candidate_ids.shape[-1]),
+            candidate_ids[:, :-1],
+        ),
+        dim=1,
+    )
+    context = predecessor_table[predecessor_ids] * hidden[:, :, None]
+    return torch.einsum("blpr,r->blp", context, weight) + bias
+
+
 @support_torch_compile
 class CandidateSelector(nn.Module):
     def __init__(
@@ -215,10 +234,7 @@ class CandidateSelector(nn.Module):
             prefix=maybe_prefix(prefix, "hidden_projection"),
             return_bias=False,
         )
-        # Optional: some DFlash2 checkpoints ship a trained confidence head that
-        # scores each predecessor-conditioned candidate. Nothing in this change
-        # consumes it; building it here is what lets such a checkpoint load at
-        # all, instead of failing with an unknown-parameter error.
+        # Loading the optional head does not enable confidence computation.
         self.confidence_head: ReplicatedLinear | None = None
         if enable_confidence_head:
             self.confidence_head = ReplicatedLinear(
@@ -237,9 +253,10 @@ class CandidateSelector(nn.Module):
         unary_logits: torch.Tensor,
         hidden_states: torch.Tensor,
         anchor_token_ids: torch.Tensor,
-    ) -> torch.Tensor:
+        compute_confidence: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         hidden = self.hidden_projection(hidden_states)
-        return _score_edges(
+        scores = _score_edges(
             self.predecessor_codebook,
             self.successor_codebook,
             candidate_ids,
@@ -248,6 +265,17 @@ class CandidateSelector(nn.Module):
             anchor_token_ids,
             self.top_k,
         )
+        if not compute_confidence or self.confidence_head is None:
+            return scores, None
+        confidence_logits = _confidence_rows(
+            self.predecessor_codebook,
+            candidate_ids,
+            hidden,
+            anchor_token_ids,
+            self.confidence_head.weight.squeeze(0),
+            self.confidence_head.bias.squeeze(0),
+        )
+        return scores, confidence_logits
 
 
 class DFlash2Qwen3Model(DFlashQwen3Model):

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Iterable
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -192,6 +194,7 @@ class CandidateSelector(nn.Module):
         vocab_size: int,
         rank: int,
         top_k: int,
+        enable_confidence_head: bool,
         params_dtype: torch.dtype,
         prefix: str,
     ) -> None:
@@ -212,6 +215,21 @@ class CandidateSelector(nn.Module):
             prefix=maybe_prefix(prefix, "hidden_projection"),
             return_bias=False,
         )
+        # Optional: some DFlash2 checkpoints ship a trained confidence head that
+        # scores each predecessor-conditioned candidate. Nothing in this change
+        # consumes it; building it here is what lets such a checkpoint load at
+        # all, instead of failing with an unknown-parameter error.
+        self.confidence_head: ReplicatedLinear | None = None
+        if enable_confidence_head:
+            self.confidence_head = ReplicatedLinear(
+                rank,
+                1,
+                bias=True,
+                params_dtype=params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "confidence_head"),
+                return_bias=False,
+            )
 
     def forward(
         self,
@@ -258,6 +276,9 @@ class DFlash2Qwen3Model(DFlashQwen3Model):
                 vocab_size=self.config.vocab_size,
                 rank=int(draft_config["selector_rank"]),
                 top_k=int(draft_config["selector_top_k"]),
+                enable_confidence_head=bool(
+                    draft_config.get("enable_confidence_head", False)
+                ),
                 params_dtype=vllm_config.model_config.dtype,
                 prefix=maybe_prefix(prefix, "candidate_selector"),
             )
@@ -285,6 +306,24 @@ class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
         return self.candidate_logits_processor.get_top_k_tokens(
             self.lm_head, hidden_states, self.model.candidate_selector.top_k
         )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        includes_confidence_head = False
+
+        def tracked_weights():
+            nonlocal includes_confidence_head
+            for name, loaded_weight in weights:
+                if "candidate_selector.confidence_head" in name:
+                    includes_confidence_head = True
+                yield name, loaded_weight
+
+        loaded = super().load_weights(tracked_weights())
+        # `enable_confidence_head` is a property of the checkpoint, so a config
+        # that claims a head the weights do not contain would otherwise leave an
+        # uninitialized module behind. Drop it rather than serve random values.
+        if not includes_confidence_head:
+            self.model.candidate_selector.confidence_head = None
+        return loaded
 
 
 EntryClass = DFlash2Qwen3ForCausalLM

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -149,6 +149,7 @@ def update_dflash2(config_dict: dict, pre_trained_config: dict) -> None:
         "conv_group_size",
         "selector_rank",
         "selector_top_k",
+        "enable_confidence_head",
     ):
         if config_dict.get(key) is not None:
             pre_trained_config["dflash_config"][key] = config_dict[key]

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
@@ -22,11 +22,14 @@ def _selector_walk_kernel(
     seeds_ptr,
     tokens_ptr,
     realized_scores_ptr,
+    confidence_logits_ptr,
+    realized_confidence_ptr,
     num_steps: tl.constexpr,
     top_k: tl.constexpr,
     BLOCK_K: tl.constexpr,
     SAMPLE_PROBABILISTIC: tl.constexpr,
     USE_FP64: tl.constexpr,
+    USE_CONFIDENCE: tl.constexpr,
 ):
     row = tl.program_id(0)
     offsets = tl.arange(0, BLOCK_K)
@@ -38,6 +41,17 @@ def _selector_walk_kernel(
     previous = 0
     for step in range(num_steps):
         flat = row * num_steps + step
+        if USE_CONFIDENCE:
+            confidence_logit = tl.load(
+                confidence_logits_ptr + flat * top_k + previous,
+                mask=valid,
+                other=0.0,
+            ).to(tl.float32)
+            tl.store(
+                realized_confidence_ptr + flat,
+                tl.sigmoid(confidence_logit),
+                mask=valid,
+            )
         score_base = (flat * top_k + previous) * top_k
         scores = tl.load(
             scores_ptr + score_base + offsets,
@@ -129,6 +143,31 @@ class DFlash2Speculator(DFlashSpeculator):
         self._cached_candidate_ids = torch.zeros(
             self._selector_scores.shape, dtype=torch.int64, device=device
         )
+        self.enable_adaptive_verification = (
+            self.speculative_config.enable_adaptive_verification
+        )
+        self.draft_token_confidence_probs = (
+            torch.empty_like(self.draft_tokens, dtype=torch.float32)
+            if self.enable_adaptive_verification
+            else None
+        )
+
+    def load_draft_model(
+        self,
+        target_model: torch.nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> torch.nn.Module:
+        model = super().load_draft_model(target_model, target_attn_layer_names)
+        if (
+            self.enable_adaptive_verification
+            and model.model.candidate_selector.confidence_head is None
+        ):
+            raise ValueError(
+                "DFlash2 adaptive verification requires a trained confidence head "
+                "in the draft checkpoint. Disable enable_adaptive_verification "
+                "to use fixed-budget drafting."
+            )
+        return model
 
     def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
         # fp32 so the walk and the rejection that checks it read the same
@@ -141,6 +180,7 @@ class DFlash2Speculator(DFlashSpeculator):
         candidate_ids: torch.Tensor,
         scores: torch.Tensor,
         num_reqs: int,
+        confidence_logits: torch.Tensor | None = None,
     ) -> None:
         block_k = triton.next_power_of_2(self.selector_top_k)
         _selector_walk_kernel[(num_reqs,)](
@@ -152,11 +192,16 @@ class DFlash2Speculator(DFlashSpeculator):
             self.seeds,
             self.draft_tokens,
             self._selector_scores,
+            confidence_logits if confidence_logits is not None else scores,
+            self.draft_token_confidence_probs
+            if self.draft_token_confidence_probs is not None
+            else self._selector_scores,
             num_steps=self.num_speculative_steps,
             top_k=self.selector_top_k,
             BLOCK_K=block_k,
             SAMPLE_PROBABILISTIC=self.draft_logits is not None,
             USE_FP64=self.use_fp64_gumbel,
+            USE_CONFIDENCE=confidence_logits is not None,
             num_warps=1,
         )
 
@@ -206,12 +251,13 @@ class DFlash2Speculator(DFlashSpeculator):
         )
         unary_logits = unary_logits.view_as(candidate_ids)
         anchor_token_ids = self.input_buffers.input_ids[self._anchor_indices[:num_reqs]]
-        scores = self.model.model.candidate_selector(
+        scores, confidence_logits = self.model.model.candidate_selector(
             candidate_ids,
             unary_logits,
             hidden_states,
             anchor_token_ids,
+            compute_confidence=self.enable_adaptive_verification,
         )
-        self._sample_path(candidate_ids, scores, num_reqs)
+        self._sample_path(candidate_ids, scores, num_reqs, confidence_logits)
         if self.draft_logits is not None:
             self._cache_draft_logits(candidate_ids, num_sample)


### PR DESCRIPTION
## Purpose

Support optional confidence-head loading for DFlash2 checkpoints.

## Test Plan

Main + #54154 + #54475 + this PR

```bash
vllm serve ornith-ai/Ornith-1.5-35B-A3B \
  --tensor-parallel-size 1 \
  --enable-prefix-caching \
  --enable-auto-tool-choice \
  --tool-call-parser qwen3_xml \
  --reasoning-parser qwen3 \
  --speculative-config '{
    "method": "dflash",
    "model": "DaoCloud/Ornith-1.5-35B-A3B-DFlash2-2.6B-A0.3B",
    "num_speculative_tokens": 7
  }'
```

## Test Result

https://huggingface.co/DaoCloud/Ornith-1.5-35B-A3B-DFlash2-2.6B-A0.3B

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
