### PR TITLE
[Bugfix][Tool Parser] Anchor Jamba streamed tool arguments to what was sent

### DIFF
--- a/tests/tool_parsers/test_jamba_tool_parser.py
+++ b/tests/tool_parsers/test_jamba_tool_parser.py
@@ -337,3 +337,34 @@ def test_extract_tool_calls_streaming_arguments_in_single_delta(jamba_tool_parse
                 streamed_arguments += arguments
 
     assert json.loads(streamed_arguments) == {"city": "Dallas", "state": "TX"}
+
+
+def test_extract_tool_calls_streaming_partial_args_with_name_delta(jamba_tool_parser):
+    """Arguments first parsed in the name delta must not lose their prefix."""
+    deltas = [
+        '<tool_calls>[{"name": "get_current_weather"',
+        ', "arguments": {"city": "Dallas", "state": "',
+        'TX"}}]',
+        "</tool_calls>",
+    ]
+
+    streamed_arguments = ""
+    current_text = ""
+    for delta_text in deltas:
+        previous_text = current_text
+        current_text += delta_text
+        delta_message = jamba_tool_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
+        if delta_message and delta_message.tool_calls:
+            arguments = delta_message.tool_calls[0].function.arguments
+            if arguments:
+                streamed_arguments += arguments
+
+    assert json.loads(streamed_arguments) == {"city": "Dallas", "state": "TX"}

--- a/vllm/tool_parsers/jamba_tool_parser.py
+++ b/vllm/tool_parsers/jamba_tool_parser.py
@@ -24,7 +24,7 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
-from vllm.tool_parsers.utils import extract_intermediate_diff, is_complete_json
+from vllm.tool_parsers.utils import find_common_prefix, is_complete_json
 from vllm.utils.mistral import is_mistral_tokenizer
 
 logger = init_logger(__name__)
@@ -197,8 +197,12 @@ class JambaToolParser(ToolParser):
                     diff: str | None = current_tool_call.get("arguments")
 
                     if diff:
-                        diff = json.dumps(diff, ensure_ascii=False).replace(
-                            self.streamed_args_for_tool[self.current_tool_id], ""
+                        diff = json.dumps(diff, ensure_ascii=False)
+                        streamed = self.streamed_args_for_tool[self.current_tool_id]
+                        diff = (
+                            diff[len(streamed) :]
+                            if diff.startswith(streamed)
+                            else diff.replace(streamed, "", 1)
                         )
                         delta = DeltaMessage(
                             tool_calls=[
@@ -302,9 +306,20 @@ class JambaToolParser(ToolParser):
                         prev_args_json,
                     )
 
-                    argument_diff = extract_intermediate_diff(
-                        cur_args_json, prev_args_json
+                    streamed_len = len(
+                        self.streamed_args_for_tool[self.current_tool_id]
                     )
+                    if is_complete_json(parsable_arr):
+                        argument_diff = cur_args_json[streamed_len:]
+                    elif cur_args_json != prev_args_json:
+                        # Diff against what has actually been streamed. The
+                        # previous completion can contain argument keys that
+                        # were never sent, e.g. when the first complete pair
+                        # arrives in the same delta as the tool name.
+                        prefix = find_common_prefix(prev_args_json, cur_args_json)
+                        argument_diff = prefix[streamed_len:]
+                    else:
+                        argument_diff = ""
                     logger.debug("got arguments diff: %s", argument_diff)
                     delta = DeltaMessage(
                         tool_calls=[


### PR DESCRIPTION
## Purpose

Streaming tool calls with the `jamba` parser lose the start of the arguments when the delta that delivers the function name also carries a complete argument pair.

The name-sending delta updates `prev_tool_call_arr` with everything `partial_json_parser` could complete at that point — including argument keys that were never streamed. The next delta takes the `cur_arguments and prev_arguments` branch and diffs with `extract_intermediate_diff(cur, prev)`, which yields only the new tail (say `', "state": "TX'`). The `{"city": "Dallas` prefix never goes out, so the arguments the client accumulates are not valid JSON, and the end-of-stream rescue in `get_remaining_unstreamed_args()` cannot recover it because the streamed text is no longer a prefix of the expected JSON. Non-streaming requests return the full arguments.

Multi-token deltas of this shape are routine since incremental detokenization buffers output — it is how the single-delta regression fixed in #48852 came about. That fix covers arguments arriving complete in one delta *after* the name; arguments that begin inside the name delta itself were still broken.

Both argument-diff paths now anchor to `streamed_args_for_tool`, the approach `llama_tool_parser.py` already uses:

- the same-tool branch sends `cur_args_json` from the streamed length, with a full flush once the JSON completes, instead of diffing against the previous completion
- the flush when moving to the next tool slices the unsent arguments by streamed length instead of `str.replace`

## Not a duplicate

- #50461 stops tail truncation by reconciling the last diff once the JSON is complete. It does not cover this case: with the prefix lost, `cur_args_json.startswith(streamed + argument_diff)` fails and nothing is sent. I applied its patch on top of main and the new test fails the same way.
- #48709 adds `count=1` to the `str.replace()` scan on the tool-transition flush. This PR replaces that path with length-based slicing (keeping a guarded replace as fallback), which resolves the same corruption; its regression scenario passes with this change.
- #48295 / #48852 handle calls that arrive whole in a single delta, a different failure mode; that limitation (#48294) is unchanged here.

No open issue describes the name-delta prefix loss; happy to file one if it helps tracking.

## Test Plan

```
pytest tests/tool_parsers/test_jamba_tool_parser.py -q
```

The new test feeds the triggering sequence (name and the first complete pair in one delta, completion in a later delta) and asserts the accumulated arguments parse back to the original dict. Before the fix it fails with `JSONDecodeError` on `', "state": "TX'`.

I also compared the patched and unpatched parser across ~2800 random splittings of single- and parallel-tool outputs (strings, numbers, booleans, null, nested objects, unicode): the patched version produces complete arguments everywhere the unpatched one did, plus ~1700 splittings the unpatched one mangles. The remaining failures are the pre-existing single-blob limitation tracked by #48294.

## Test Result

Run against the v0.28.0 wheel with this parser file applied (main and v0.28 differ in this file only by an import-path move):

```
before:  1 failed, 9 passed   # new test fails, JSONDecodeError
after:  10 passed
```

This change was written with AI assistance; I reviewed every line and ran the tests above myself.
