### PR TITLE
[BugFix] [Attention] Restore scale from TRTLLM NVFP4 KV FP8 scratch output

### DIFF
--- a/tests/v1/attention/test_trtllm_attention_integration.py
+++ b/tests/v1/attention/test_trtllm_attention_integration.py
@@ -195,7 +195,9 @@ def _create_nvfp4_hnd_kv_cache(
     return nvfp4_cache
 
 
-def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL):
+def _run_trtllm_integration(
+    batch_spec, kv_cache_dtype="auto", model_name=MODEL, value_bias=0.0
+):
     """Run TRTLLM attention through the full FlashInfer pipeline
     and compare against an SDPA reference."""
     set_random_seed(42)
@@ -232,7 +234,9 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
 
         q = torch.randn(q_len, num_q_heads, head_size, dtype=dtype, device=device)
         k_full = torch.randn(s_len, num_kv_heads, head_size, dtype=dtype, device=device)
-        v_full = torch.randn(s_len, num_kv_heads, head_size, dtype=dtype, device=device)
+        v_full = torch.randn(
+            s_len, num_kv_heads, head_size, dtype=dtype, device=device
+        ).add_(value_bias)
 
         # SDPA reference (N=1, H, L, D)
         q_sdpa = q.unsqueeze(0).transpose(1, 2)
@@ -410,7 +414,10 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
         )
 
     # 4. Compare against SDPA reference
-    if is_nvfp4:
+    if value_bias:
+        # Exercise NVFP4's FP8-only kernel output above the unscaled FP8 range.
+        atol, rtol = 16.0, 0.15
+    elif is_nvfp4:
         atol, rtol = 1.0, 1.0  # nvfp4 has higher quantization error
     else:
         atol, rtol = 1e-2, 1e-2
@@ -441,4 +448,16 @@ def test_trtllm_gen_nvfp4_kv_integration(batch_spec_name: str):
         BATCH_SPECS[batch_spec_name],
         kv_cache_dtype="nvfp4",
         model_name=MODEL_NVFP4,
+    )
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("batch_spec_name", list(BATCH_SPECS))
+def test_trtllm_gen_nvfp4_kv_rescales_fp8_output(batch_spec_name: str):
+    """Test high-range NVFP4 output rescaling in prefill and decode."""
+    _run_trtllm_integration(
+        BATCH_SPECS[batch_spec_name],
+        kv_cache_dtype="nvfp4",
+        model_name=MODEL_NVFP4,
+        value_bias=1024.0,
     )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2004,7 +2004,10 @@ class FlashInferImpl(AttentionImpl):
                 self.bmm1_scale *= layer._q_scale_float * layer._k_scale_float
 
         needs_nvfp4_fp8_out = (
-            self.is_kvcache_nvfp4 and output_scale is None and output.dtype != FP8_DTYPE
+            self.is_kvcache_nvfp4
+            and self.dcp_world_size == 1
+            and output_scale is None
+            and output.dtype != FP8_DTYPE
         )
 
         if self.bmm2_scale is None:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -96,6 +96,7 @@ FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
+NVFP4_E2M1_MAX = 6.0
 
 logger = init_logger(__name__)
 
@@ -1872,6 +1873,7 @@ class FlashInferImpl(AttentionImpl):
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
+        self._nvfp4_output_scale: float | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1960,6 +1962,13 @@ class FlashInferImpl(AttentionImpl):
 
         return query
 
+    def _copy_nvfp4_output(
+        self, output: torch.Tensor, fp8_output: torch.Tensor
+    ) -> None:
+        assert self._nvfp4_output_scale is not None
+        output.copy_(fp8_output)
+        output.mul_(self._nvfp4_output_scale)
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -1994,10 +2003,23 @@ class FlashInferImpl(AttentionImpl):
             if is_quantized_kv_cache(self.kv_cache_dtype):
                 self.bmm1_scale *= layer._q_scale_float * layer._k_scale_float
 
+        needs_nvfp4_fp8_out = (
+            self.is_kvcache_nvfp4 and output_scale is None and output.dtype != FP8_DTYPE
+        )
+
         if self.bmm2_scale is None:
             self.bmm2_scale = 1.0
             if is_quantized_kv_cache(self.kv_cache_dtype):
                 self.bmm2_scale *= layer._v_scale_float
+            if needs_nvfp4_fp8_out and self.dcp_world_size == 1:
+                # TRTLLM NVFP4 attention can only write FP8. Scale its output
+                # to cover the full E2M1 value range before converting it back
+                # to the model dtype; a plain dtype cast saturates at FP8 max.
+                self._nvfp4_output_scale = NVFP4_E2M1_MAX * layer._v_scale_float
+                self.bmm2_scale /= self._nvfp4_output_scale
+        wrapper_v_scale = (
+            self.bmm2_scale if self.is_kvcache_nvfp4 else layer._v_scale_float
+        )
 
         prefill_use_trtllm = isinstance(attn_metadata.prefill, TRTLLMPrefill)
         decode_kernel = (
@@ -2208,9 +2230,7 @@ class FlashInferImpl(AttentionImpl):
                     # NVFP4 trtllm kernel only supports FP8 output.
                     # Use a pre-allocated FP8 buffer and dequantize
                     # afterwards.
-                    needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
-                    )
+                    needs_fp8_out_prefill = needs_nvfp4_fp8_out
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
                     else:
@@ -2225,7 +2245,7 @@ class FlashInferImpl(AttentionImpl):
                             kv_cache_for_fi,
                             self.sinks,
                             self.scale * layer._q_scale_float * layer._k_scale_float,
-                            v_scale=layer._v_scale_float,
+                            v_scale=wrapper_v_scale,
                             out=out_prefill,
                         )
                     else:
@@ -2234,15 +2254,19 @@ class FlashInferImpl(AttentionImpl):
                             kv_cache_for_fi,
                             q_scale=layer._q_scale_float,
                             k_scale=layer._k_scale_float,
-                            v_scale=layer._v_scale_float,
+                            v_scale=wrapper_v_scale,
                             out=out_prefill,
                             kv_cache_sf=kv_cache_sf,
                         )
 
                     if needs_fp8_out_prefill:
-                        output[
-                            num_decode_tokens : num_decode_tokens + num_prefill_tokens
-                        ].copy_(out_prefill)
+                        self._copy_nvfp4_output(
+                            output[
+                                num_decode_tokens : num_decode_tokens
+                                + num_prefill_tokens
+                            ],
+                            out_prefill,
+                        )
             else:
                 assert isinstance(attn_metadata.prefill, TRTLLMPrefill)
                 # prefill_query may be non-contiguous or have degenerate strides
@@ -2276,7 +2300,7 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = needs_nvfp4_fp8_out
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -2348,9 +2372,12 @@ class FlashInferImpl(AttentionImpl):
                 )
 
                 if needs_fp8_out:
-                    output[
-                        num_decode_tokens : num_decode_tokens + num_prefill_tokens
-                    ].copy_(out[:num_prefill_tokens])
+                    self._copy_nvfp4_output(
+                        output[
+                            num_decode_tokens : num_decode_tokens + num_prefill_tokens
+                        ],
+                        out[:num_prefill_tokens],
+                    )
 
         if num_decode_tokens > 0:
             decode_query_tokens = num_decode_tokens
@@ -2384,7 +2411,7 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = needs_nvfp4_fp8_out
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -2405,7 +2432,7 @@ class FlashInferImpl(AttentionImpl):
                         kv_cache_for_fi,
                         q_scale=layer._q_scale_float,
                         k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        v_scale=wrapper_v_scale,
                         out=output_tmp,
                         lse=lse,
                         return_lse=True,
@@ -2423,14 +2450,14 @@ class FlashInferImpl(AttentionImpl):
                         kv_cache_for_fi,
                         q_scale=layer._q_scale_float,
                         k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        v_scale=wrapper_v_scale,
                         out=out_decode,
                         kv_cache_sf=kv_cache_sf,
                         sinks=self.sinks,
                     )
 
                 if needs_fp8_out:
-                    output[:num_decode_tokens].copy_(out_decode)
+                    self._copy_nvfp4_output(output[:num_decode_tokens], out_decode)
             else:
                 assert isinstance(attn_metadata.decode, FlashInferTrtllmAPIDecode)
                 # decode_query may be non-contiguous or have degenerate strides
@@ -2514,7 +2541,7 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = needs_nvfp4_fp8_out
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 
@@ -2582,7 +2609,7 @@ class FlashInferImpl(AttentionImpl):
                         query_start_loc=attn_metadata.decode.dcp_query_start_loc,
                     )
                 elif needs_fp8_out:
-                    output[:num_decode_tokens].copy_(out)
+                    self._copy_nvfp4_output(output[:num_decode_tokens], out)
         return output_padded
 
     def do_kv_cache_update(


### PR DESCRIPTION
## Purpose

Preserve the output scale when FlashInfer's TensorRT-LLM attention backend uses an NVFP4 KV cache and returns an FP8 E4M3 scratch tensor to a BF16 model on Blackwell.

The backend previously copied that FP8 scratch tensor directly into BF16. This change chooses a scale that covers the NVFP4 E2M1 value range, passes the corresponding scale to the TensorRT-LLM kernel, and restores it while copying the scratch result to the model dtype.

This low-level defect is demonstrated by the focused high-range integration regression below. It was found while investigating corrupted `Qwen/Qwen3.5-397B-A17B-FP8` generation, but the full-model failure remains unresolved: applying this patch did not recover its GSM8K accuracy. This PR therefore does not claim to fix that model-level failure.

## Reproduction

One tensor-parallel-4 engine runs on four B200 GPUs with the equivalent serving command below. The benchmark runs two identical engines on one eight-GPU node and divides the requests between them.

```bash
vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
  --tensor-parallel-size 4 \
  --kv-cache-dtype nvfp4 \
  --max-num-seqs 64 \
  --max-model-len 32768 \
  --max-num-batched-tokens 8192 \
  --block-size 128 \
  --gpu-memory-utilization 0.9 \
  --trust-remote-code \
  --no-enable-prefix-caching \
  --linear-backend marlin \
  --moe-backend marlin \
  --compilation-config '{"cudagraph_capture_sizes":[1,2,4,8,16,32,64],"inductor_compile_config":{"enable_auto_functionalized_v2":true}}'
```

All full-model measurements use the complete 1,319-question GSM8K test set, five worked examples per prompt, temperature 0, and at most 1,024 generated tokens per answer.

| KV cache and maximum concurrent sequences | Flexible exact match | Invalid answers |
|---|---:|---:|
| NVFP4, 64, before patch | 6.520% | 93.177% |
| NVFP4, 512, before patch | 4.549% | 94.920% |
| FP8, 512, matched control | 96.664% | 0.682% |
| NVFP4, 64, after patch | 4.776% | 94.845% |

The unchanged failure phenotype shows that the output-scale defect fixed here is not sufficient to explain the Qwen serving failure.

## Implementation

For an NVFP4 KV cache returning a non-FP8 model output without fused output quantization:

1. Select an FP8 output scale covering the NVFP4 E2M1 range.
2. Incorporate its inverse into `bmm2_scale` passed to TensorRT-LLM.
3. Copy the mandatory FP8 scratch output to the model dtype and restore the scale.

The FP8 scratch path is gated on `output_scale is None`, preserving the existing fused FP4 output-quantization path. The same guard is shared by prefill and decode.

The change is enabled when decode-context parallelism has group size one. Tensor, data, and expert parallelism remain supported. A larger decode-context parallel group uses a separate log-sum-exp combine path and needs its scale carried through that combine before enabling this conversion there.

Low-level scaling contract:

https://github.com/vllm-project/vllm/blob/7c5dc571cbd1064ecc8a9b1045637ff647aa22cb/tests/kernels/attention/test_flashinfer_trtllm_attention.py#L298-L338

Original NVFP4 KV support:

https://github.com/vllm-project/vllm/pull/40177

## Test plan and results

The Blackwell integration regression drives vLLM's metadata-builder, NVFP4 cache-update, and attention-forward paths. It biases V above the unscaled E4M3 range and compares the result with a BF16 reference for decode-only, prefill-only, and mixed batches.

```bash
pytest -q tests/v1/attention/test_trtllm_attention_integration.py::test_trtllm_gen_nvfp4_kv_rescales_fp8_output
```

**B200 result: PASS — decode-only, prefill-only, and mixed.**

```text
3 passed in 23.74s
```
