### PR TITLE
[FlashInfer] Migrate autotune warmup to flashinfer.autotune_v2 managed cache

### DIFF
--- a/vllm/model_executor/warmup/flashinfer_autotune_cache.py
+++ b/vllm/model_executor/warmup/flashinfer_autotune_cache.py
@@ -40,6 +40,18 @@ def resolve_flashinfer_autotune_file(runner: "GPUModelRunner") -> Path:
     return output_dir / "autotune_configs.json"
 
 
+def resolve_flashinfer_autotune_v2_root() -> Path | None:
+    """Placement root for FlashInfer's managed autotune store.
+
+    Unlike :func:`resolve_flashinfer_autotune_file`, no vLLM-side identity
+    (config hash, flashinfer version, arch) is folded into the path: the
+    managed store keys entries per op and hashes the software/hardware
+    environment itself. ``None`` selects FlashInfer's default root.
+    """
+    override_dir = envs.VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR
+    return Path(override_dir).expanduser() if override_dir else None
+
+
 def write_flashinfer_autotune_cache(cache_path: Path, contents: bytes) -> None:
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(

--- a/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
+++ b/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
@@ -9,11 +9,12 @@ import torch
 from vllm.logger import init_logger
 from vllm.model_executor.warmup.flashinfer_autotune_cache import (
     resolve_flashinfer_autotune_file,
+    resolve_flashinfer_autotune_v2_root,
     write_flashinfer_autotune_cache,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import autotune as flashinfer_autotune
-from vllm.utils.flashinfer import has_flashinfer
+from vllm.utils.flashinfer import has_flashinfer, has_flashinfer_autotune_v2
 from vllm.v1.worker.gpu.warmup import run_mixed_prefill_decode_warmup
 
 if TYPE_CHECKING:
@@ -115,7 +116,6 @@ def _run_flashinfer_sparse_mla_decode_autotune(
 
     world = get_world_group()
     is_leader = world.rank_in_group == 0
-    cache_path = resolve_flashinfer_autotune_file(runner)
 
     dummy_run_kwargs = dict(
         num_tokens=num_tokens,
@@ -124,6 +124,13 @@ def _run_flashinfer_sparse_mla_decode_autotune(
         force_attention=True,
         create_mixed_batch=True,
     )
+
+    if has_flashinfer_autotune_v2():
+        return _run_sparse_mla_decode_autotune_v2(
+            worker, num_tokens, log_label, dummy_run_kwargs
+        )
+
+    cache_path = resolve_flashinfer_autotune_file(runner)
 
     if is_leader:
         logger.info(
@@ -190,6 +197,56 @@ def _run_flashinfer_sparse_mla_decode_autotune(
         world.rank_in_group,
         cache_path,
     )
+    return True
+
+
+def _run_sparse_mla_decode_autotune_v2(
+    worker: "Worker",
+    num_tokens: int,
+    log_label: str,
+    dummy_run_kwargs: dict,
+) -> bool:
+    """Same warmup through FlashInfer's managed store: every rank tunes into
+    the shared store and re-reads its final state after the barrier, so no
+    leader broadcast or vLLM-side cache file is needed."""
+    from flashinfer import autotune_v2, autotune_v2_reload
+
+    from vllm.distributed.parallel_state import get_world_group
+
+    runner = worker.model_runner
+    world = get_world_group()
+    cache_root = resolve_flashinfer_autotune_v2_root()
+    if world.rank_in_group == 0:
+        logger.info(
+            "Autotuning FlashInfer SM120 sparse MLA %s decode into the managed "
+            "autotune cache (root=%s)",
+            log_label,
+            cache_root if cache_root is not None else "flashinfer default",
+        )
+
+    with torch.inference_mode():
+        if _uses_v2_model_runner(runner) and runner.max_num_reqs >= 2:
+            v2_runner = cast("V2GPUModelRunner", runner)
+            warmup_executed = run_mixed_prefill_decode_warmup(
+                v2_runner,
+                worker.execute_model,
+                worker.sample_tokens,
+                num_tokens,
+                mixed_step_context=autotune_v2(mode="tune", cache_root=cache_root),
+                req_id_prefix="_sparse_mla_v2_warmup",
+            )
+        else:
+            warmup_executed = True
+            with autotune_v2(mode="tune", cache_root=cache_root):
+                runner._dummy_run(**dummy_run_kwargs)
+
+    if not warmup_executed:
+        return False
+
+    if world.world_size > 1:
+        world.barrier()
+        autotune_v2_reload()
+        world.barrier()
     return True
 
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -22,6 +22,7 @@ from vllm.model_executor.warmup.deepseek_v4_mhc_warmup import (
 )
 from vllm.model_executor.warmup.flashinfer_autotune_cache import (
     resolve_flashinfer_autotune_file,
+    resolve_flashinfer_autotune_v2_root,
     write_flashinfer_autotune_cache,
 )
 from vllm.model_executor.warmup.flashinfer_sparse_mla_warmup import (
@@ -404,6 +405,10 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
         )
         autotune_kwargs["skip_ops"] = skip_ops
 
+    if fi_utils.has_flashinfer_autotune_v2():
+        _flashinfer_autotune_v2(runner, autotune_kwargs)
+        return
+
     cache_path = resolve_flashinfer_autotune_file(runner)
     if is_leader:
         logger.info_once("Using FlashInfer autotune cache file: %s", cache_path)
@@ -441,3 +446,44 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
         world.barrier()
     if is_leader:
         tuner.save_configs(str(cache_path))
+
+
+def _flashinfer_autotune_v2(runner: "GPUModelRunner", autotune_kwargs: dict) -> None:
+    """Autotune through FlashInfer's managed per-entry store.
+
+    Every rank tunes and publishes into one shared, environment-hashed store
+    (per-entry atomic publish, so concurrent ranks and warm restarts are
+    safe); entries already on disk skip re-profiling. Per-tactic timings are
+    still synchronized over the world CPU group, and the finalize step after
+    the barrier makes all ranks serve the store's final state.
+    """
+    from flashinfer import autotune_v2, autotune_v2_reload
+    from flashinfer.autotuner import set_autotune_process_group
+
+    from vllm.distributed.parallel_state import get_world_group
+
+    world = get_world_group()
+    cache_root = resolve_flashinfer_autotune_v2_root()
+    if world.rank_in_group == 0:
+        logger.info_once(
+            "Using FlashInfer managed autotune cache (root=%s)",
+            cache_root if cache_root is not None else "flashinfer default",
+        )
+
+    group = world.cpu_group if world.world_size > 1 else None
+    set_autotune_process_group(group)
+    try:
+        with (
+            torch.inference_mode(),
+            autotune_v2(mode="tune", cache_root=cache_root, **autotune_kwargs),
+        ):
+            _run_flashinfer_autotune_dummy_runs(runner)
+            replayssm_autotune_warmup(runner)
+            _autotune_kimi_k3_kda_qkvg(runner.get_model())
+    finally:
+        set_autotune_process_group(None)
+
+    if world.world_size > 1:
+        world.barrier()
+        autotune_v2_reload()
+        world.barrier()

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -286,6 +286,19 @@ autotune = _lazy_import_wrapper(
 
 
 @functools.cache
+def has_flashinfer_autotune_v2() -> bool:
+    """Return ``True`` if FlashInfer ships the managed-cache autotuner
+    (``flashinfer.autotune_v2``, flashinfer-ai/flashinfer#3861)."""
+    if not has_flashinfer():
+        return False
+    mod = _get_submodule("flashinfer")
+    return mod is not None and all(
+        callable(getattr(mod, name, None))
+        for name in ("autotune_v2", "autotune_v2_reload")
+    )
+
+
+@functools.cache
 def has_flashinfer_comm() -> bool:
     """Return `True` if FlashInfer comm module is available."""
     return has_flashinfer() and importlib.util.find_spec("flashinfer.comm") is not None
@@ -1261,6 +1274,7 @@ __all__ = [
     "flashinfer_fused_kda_decode",
     "autotune",
     "has_flashinfer_moe",
+    "has_flashinfer_autotune_v2",
     "has_flashinfer_comm",
     "has_flashinfer_nvlink_two_sided",
     "has_flashinfer_nvlink_one_sided",


### PR DESCRIPTION
> [!NOTE]
> **Draft — blocked on the FlashInfer v0.7.0 bump.** `flashinfer.autotune_v2` merged in flashinfer-ai/flashinfer#3861 (2026-09-05) and is not in the pinned `flashinfer-python==0.6.18`. The new path is gated on a capability probe, so this PR is a no-op against 0.6.18 and activates once the pin moves.

## Purpose

Move vLLM's FlashInfer autotune warmup onto FlashInfer's managed autotune cache (`autotune_v2`, design/RFC: flashinfer-ai/flashinfer#3920) and delete the persistence layer vLLM had to build around the v1 file cache.

What changes when `autotune_v2` is available (`vllm.utils.flashinfer.has_flashinfer_autotune_v2()`):

- **`kernel_warmup.flashinfer_autotune`**: the leader-only read → `broadcast_object` → per-rank atomic write → `load_configs` / `save_configs` block is replaced by `with autotune_v2(mode="tune", cache_root=..., skip_ops=...)`. Every rank tunes and publishes into one shared, environment-hashed store (per-entry atomic publish; last valid write wins), so concurrent ranks and warm restarts are safe and entries already on disk skip re-profiling. `set_autotune_process_group` is kept so per-tactic timings stay synchronized across ranks, and a `barrier → autotune_v2_reload() → barrier` finalize makes every rank serve the store's final state (the flashinfer#3186 divergence class).
- **`flashinfer_sparse_mla_warmup`** (SM120 sparse-MLA decode): same treatment. The leader-only tune + broadcast split collapses because every rank tunes into the store. This pass runs before the generic one, so every rank must attach here too.
- **Cache identity is FlashInfer's now.** `VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR` keeps its meaning as a placement override (`cache_root`); when unset the store lives at FlashInfer's default (`$FLASHINFER_WORKSPACE_BASE/.cache/flashinfer/autotune/v2/<env-hash>/`). The vLLM config hash is no longer folded into the path: entries are keyed per op, and the software/hardware environment hash is FlashInfer's responsibility.
- The legacy path is left verbatim for FlashInfer < 0.7.0. `flashinfer_autotune_cache.resolve_flashinfer_autotune_file()` stays because `flashinfer_pcie_ipc_all_reduce.py` derives a sibling tuning file from it.

Net user-visible effect once active: persistent tuning results for multi-rank deployments again (v1 could only persist through the leader), warm restarts that do not re-profile, and one fewer vLLM-owned cache format. Measurement defaults are unchanged (`autotune_v2`'s default policy reproduces v1's CUDA-event timing), so selected tactics should match today's.

## Test Plan

Environment: B200, vLLM at this branch, FlashInfer built from `main` (≥ 3a75b4e3). Baseline = same build with `has_flashinfer_autotune_v2` forced `False` (legacy path).

1. **Single GPU, cold → warm restart** (FP8 dense model, e.g. `nvidia/Llama-3.1-8B-Instruct-FP8`): start with a fresh store; confirm `.../autotune/v2/<env>/entries/*.json` is populated and the autotuner log reports profiled ops. Restart: confirm zero profiling (store hits only) and record startup time cold / warm / legacy-warm.
2. **TP=2 and TP=4**: same model; confirm all ranks publish and no hang. Restart: every rank hits the store. Rank consistency: dump the per-rank served tactic for a fixed decode shape (`FLASHINFER_LOGLEVEL=1` autotuner cache-hit lines) and check they are identical.
3. **No-regression**: `lm_eval gsm8k` (limit 200) and `vllm bench serve` decode throughput, legacy vs v2 on the same box; expect parity since the measurement policy is unchanged.
4. **Legacy path untouched**: same runs against the pinned `flashinfer-python==0.6.18` must behave exactly as before (probe returns `False`).
5. Not covered here (needs SM120 hardware): the sparse-MLA SM120 path and the second-start TP4 NVFP4-MoE+EP hang reported on flashinfer-ai/flashinfer#3920, which this change is expected to remove since ranks no longer diverge on cache hits.

## Test Result

**Local, single GPU (Blackwell SM100 engineering sample; single runs, so startup seconds are indicative only).** `nvidia/Qwen3-8B-FP4`, FlashInfer `main` @ 1989b509 built from source over the pinned wheel, `VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR` set so the store root is explicit. `VLLM_DISABLED_KERNELS=FlashInferCuteDslNvFp4LinearKernel` was needed to get a FlashInfer-autotuned op at all (see finding 1); vLLM then selected `FlashInferCuteDslNvFp4W4A16LinearKernel` → op `bf16_fp4_cute_dsl_sm100_gemm`.

| path | cold startup | warm restart | warm autotune context | persisted |
|---|---|---|---|---|
| **v2** (this PR, `has_flashinfer_autotune_v2()` = True) | 215.5 s (60 s tuning) | 120.3 s | 3 s, `Config cache hit ... source=managed cache` | 88 entries in `<root>/v2/<env-hash>/entries/` (runner `CuteDslSm100Bf16Fp4Runner`), unchanged after the warm run |
| **legacy** (pinned `flashinfer-python==0.6.18`, probe = False) | 240.6 s | 110.3 s | 2 s, `source=config file` | 1 `autotune_configs.json` under the vLLM config-hash dir |

Both paths returned the same completion (`"The capital of France is" → "Paris. The capital of Italy is Rome"`), no errors before shutdown, no autotuner warnings. Single-GPU startup is at parity, as expected — the measurement policy is unchanged; the payoff is multi-rank persistence and the deleted plumbing, which the TP runs below measure.

Store manifest written by FlashInfer for this environment: `cuda 13.0, cublas 13.1.1, cudnn 92000, cudnn_frontend 1.28.0, cutlass_dsl 4.6.2, flashinfer 0.6.18, gpu <name>` — the identity that used to be approximated by `<flashinfer-version>/<arch>/<vllm-config-hash>` in the path.

**Rebase 2026-09-11** onto vLLM main `9a35c081e` (no conflicts). Main's #55377 now nests `autotune(tuning_buckets=...)` inside the dummy runs that this PR's `autotune_v2` context wraps; FlashInfer's v1 context only pushes bucket overrides and leaves the v2 store active, so those winners publish normally. Re-validated on the rebased branch (Blackwell SM100 ES, `nvidia/Qwen3-8B-FP4`): cold 416.0 s → 88 entries published (`CutlassFp4GemmRunner`, the kernel main now selects), warm 110.3 s with store hit, entries unchanged, bucketed dummy run observed, zero errors.

Findings worth knowing when reading the numbers:
1. With vLLM's default NVFP4 kernel (`FlashInferCuteDslNvFp4LinearKernel`), `kernel_warmup` auto-adds `skip_ops={"fp4_gemm"}`, so a dense NVFP4 model tunes and persists **nothing** under either path. The default-path coverage comes from FP8 dense (`FlashInferFP8ScaledMMLinearKernel`, SM100, per-tensor scales) and the FlashInfer fused-MoE backends.
2. On Hopper (H100, `Qwen/Qwen2.5-7B-Instruct --quantization fp8`) vLLM selects `CutlassFP8ScaledMMLinearKernel` + `FLASH_ATTN`, so no FlashInfer op is autotuned; the context opens and closes empty on both paths.

**B200 (production part, 4× NVIDIA B200, computelab batch job), same venv, all 10 cases passed.** Store root fresh per `*_cold`; `*_warm` restarts against the store its `_cold` left behind. "tuning window" = first `Autotuning process starts` → `ends` on rank 0; hits/reloads are counted across all ranks' logs.

| case | model | cold startup / tuning window | warm startup / tuning window | store entries (unchanged on warm) | winners by runner | warm hits | `autotune_v2_reload()` per rank |
|---|---|---|---|---|---|---|---|
| fp4dense TP1 | `nvidia/Qwen3-8B-FP4` (CuTe-DSL W4A8 kernel disabled, see finding 1) | 405.8 s / 55 s | 140.3 s / 2 s | 88 | CuteDslSm100Bf16Fp4Runner 88 | 1 | n/a |
| fp8dense TP1 | `nvidia/Qwen3-8B-FP8` (default path) | 415.8 s / 159 s | 120.2 s / 1 s | 88 | Cublas 46 · Cudnn 33 · Cutlass 9 | 3 | n/a |
| fp8dense TP2 | `nvidia/Qwen3-8B-FP8` | 410.7 s / 128 s | 165.3 s / 1 s | 88 | Cutlass 49 · Cublas 39 | 4 | 2/2 (distinct EngineCore pids) |
| moe TP2 | `nvidia/Qwen3-30B-A3B-FP4` (default path) | 761.2 s¹ / 130 s | 195.4 s / 2 s | 66 | CuteDslSm100Bf16Fp4Runner 44 · MoERunner 22 | 4 | 2/2 |
| moe TP4 | `nvidia/Qwen3-30B-A3B-FP4` | 320.5 s / 58 s | 195.3 s / 2 s | 66 | CuteDslSm100Bf16Fp4Runner 44 · MoERunner 22 | 8 | 4/4 |

¹ includes first-time JIT of the MoE kernels into the shared FlashInfer workspace; TP4 cold reuses them.

What this shows for the PR's claims: every rank publishes into one store and no rank hangs (TP2/TP4 cold, incl. the fused-MoE path whose per-tactic collectives are the flashinfer#3186 hazard); on restart every rank serves store hits and the tuning window collapses to 1–2 s; `autotune_v2_reload()` runs once on every rank after the barrier; entry counts are identical before and after warm runs (no re-publish churn). Completions were identical cold vs warm in every case; no errors before shutdown and no autotuner warnings in any log. The FP8-dense default path is the real multi-backend competition (cuBLAS/cuDNN/CUTLASS winners persisted side by side per shape).

Not covered: SM120 sparse-MLA warmup path (no SM120 in this run) and the second-start TP4 NVFP4-MoE+EP hang from flashinfer#3920 (needs EP + the reporter's setup); the TP2/TP4 MoE cold→warm results above exercise the same mechanism without EP.

<!-- note to self: claude::28440023-66ee-410c-a0aa-234997e886d7 — "Autotuner v2 report review"
cwd /home/scratch.yanxu_libs/flashinfer · workspace /tmp/claude-25653/vllm-autotune-v2 -->



