### PR TITLE
[CI][ROCm] Add cache and release build regression coverage

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -239,8 +239,13 @@ steps:
   optional: true
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
+  - .dockerignore
+  - .buildkite/scripts/cache-rocm-base-wheels.sh
+  - .buildkite/scripts/build-rocm-base-wheels.sh
   - .buildkite/scripts/docker-build-metadata-args.sh
   - .buildkite/scripts/ci-bake-rocm.sh
+  - .buildkite/scripts/rocm/refresh-base-image.sh
+  - .buildkite/scripts/rocm/smoke-test-image.sh
   - .buildkite/release-pipeline.yaml
   - docker/Dockerfile
   - docker/Dockerfile.cpu
@@ -249,9 +254,17 @@ steps:
   - docker/ci-rocm.hcl
   - docker/docker-bake.hcl
   - docker/docker-bake-rocm.hcl
+  - requirements/common.txt
+  - requirements/build/rocm.in
+  - requirements/build/rocm.txt
+  - requirements/rocm.txt
+  - requirements/test/rocm.in
+  - requirements/test/rocm.txt
   - tests/tools/test_docker_build_metadata_args.py
+  - tests/tools/test_rocm_release_build.py
+  - tools/install_torchcodec_rocm.sh
   commands:
-  - pytest -v -s tools/test_docker_build_metadata_args.py
+  - pytest -v -s tools/test_docker_build_metadata_args.py tools/test_rocm_release_build.py
 
 #########################################################################################################################################
 #                                                                                                                                       #

--- a/.buildkite/test_areas/docker.yaml
+++ b/.buildkite/test_areas/docker.yaml
@@ -6,14 +6,32 @@ steps:
   timeout_in_minutes: 20
   device: cpu-small
   source_file_dependencies:
+    - .dockerignore
     - .buildkite/release-pipeline.yaml
+    - .buildkite/scripts/build-rocm-base-wheels.sh
+    - .buildkite/scripts/cache-rocm-base-wheels.sh
+    - .buildkite/scripts/ci-bake-rocm.sh
     - .buildkite/scripts/docker-build-metadata-args.sh
+    - .buildkite/scripts/rocm/refresh-base-image.sh
+    - .buildkite/scripts/rocm/smoke-test-image.sh
     - docker/Dockerfile
     - docker/Dockerfile.cpu
+    - docker/Dockerfile.rocm
+    - docker/Dockerfile.rocm_base
+    - docker/ci-rocm.hcl
     - docker/docker-bake.hcl
+    - docker/docker-bake-rocm.hcl
+    - requirements/common.txt
+    - requirements/build/rocm.in
+    - requirements/build/rocm.txt
+    - requirements/rocm.txt
+    - requirements/test/rocm.in
+    - requirements/test/rocm.txt
     - tests/tools/test_docker_build_metadata_args.py
+    - tests/tools/test_rocm_release_build.py
+    - tools/install_torchcodec_rocm.sh
   commands:
-    - pytest -v -s tools/test_docker_build_metadata_args.py
+    - pytest -v -s tools/test_docker_build_metadata_args.py tools/test_rocm_release_build.py
   mirror:
     amd:
       label: ":amd: (MI250) Docker Build Metadata"
@@ -23,10 +41,24 @@ steps:
       depends_on:
       - image-build-amd
       source_file_dependencies:
+      - .dockerignore
+      - .buildkite/release-pipeline.yaml
+      - .buildkite/scripts/build-rocm-base-wheels.sh
+      - .buildkite/scripts/cache-rocm-base-wheels.sh
       - .buildkite/scripts/docker-build-metadata-args.sh
       - .buildkite/scripts/ci-bake-rocm.sh
+      - .buildkite/scripts/rocm/refresh-base-image.sh
+      - .buildkite/scripts/rocm/smoke-test-image.sh
       - docker/Dockerfile.rocm
       - docker/Dockerfile.rocm_base
       - docker/ci-rocm.hcl
       - docker/docker-bake-rocm.hcl
+      - requirements/common.txt
+      - requirements/build/rocm.in
+      - requirements/build/rocm.txt
+      - requirements/rocm.txt
+      - requirements/test/rocm.in
+      - requirements/test/rocm.txt
       - tests/tools/test_docker_build_metadata_args.py
+      - tests/tools/test_rocm_release_build.py
+      - tools/install_torchcodec_rocm.sh

--- a/tests/tools/test_docker_build_metadata_args.py
+++ b/tests/tools/test_docker_build_metadata_args.py
@@ -6,10 +6,25 @@ import shlex
 import subprocess
 from pathlib import Path
 
+import regex as re
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER = REPO_ROOT / ".buildkite" / "scripts" / "docker-build-metadata-args.sh"
 ROCM_CI_BAKE = REPO_ROOT / ".buildkite" / "scripts" / "ci-bake-rocm.sh"
 ROCM_IMAGE_SMOKE = REPO_ROOT / ".buildkite" / "scripts" / "rocm" / "smoke-test-image.sh"
+ROCM_BASE_WHEEL_CACHE = (
+    REPO_ROOT / ".buildkite" / "scripts" / "cache-rocm-base-wheels.sh"
+)
+ROCM_REFRESH_BASE = (
+    REPO_ROOT / ".buildkite" / "scripts" / "rocm" / "refresh-base-image.sh"
+)
+ROCM_RELEASE_PIPELINE = REPO_ROOT / ".buildkite" / "release-pipeline.yaml"
+ROCM_RELEASE_BUILD = REPO_ROOT / ".buildkite" / "scripts" / "build-rocm-base-wheels.sh"
+ROCM_BUILD_LOCK = REPO_ROOT / "requirements" / "build" / "rocm.txt"
+ROCM_TEST_INPUT = REPO_ROOT / "requirements" / "test" / "rocm.in"
+TORCHCODEC_INSTALLER = REPO_ROOT / "tools" / "install_torchcodec_rocm.sh"
 
 
 def run_helper(
@@ -197,6 +212,866 @@ def test_rocm_ci_base_metadata_inputs_cover_ci_base_files() -> None:
         "docker/Dockerfile.rocm",
     ):
         assert expected in ci_bake
+
+
+def dockerfile_stage_dependencies(dockerfile: str) -> dict[str, set[str]]:
+    global_args: dict[str, str] = {}
+    stage_dependencies: dict[str, set[str]] = {}
+    current_stage: str | None = None
+
+    def expand_args(value: str) -> str:
+        return re.sub(
+            r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)",
+            lambda match: global_args.get(
+                match.group(1) or match.group(2), match.group(0)
+            ),
+            value,
+        )
+
+    for raw_line in dockerfile.splitlines():
+        line = raw_line.split("#", maxsplit=1)[0].strip()
+        arg_match = re.match(r"ARG\s+([A-Za-z_][A-Za-z0-9_]*)(?:=(.*))?$", line, re.I)
+        if arg_match and current_stage is None and arg_match.group(2) is not None:
+            global_args[arg_match.group(1)] = arg_match.group(2).strip().strip('"')
+
+        from_match = re.match(r"FROM\s+(\S+)(?:\s+AS\s+(\S+))?", line, re.I)
+        if from_match:
+            parent = expand_args(from_match.group(1))
+            current_stage = from_match.group(2)
+            if current_stage is not None:
+                stage_dependencies[current_stage] = {parent}
+            continue
+
+        if current_stage is not None:
+            for dependency in re.findall(r"(?:--from=|,from=)([^,\s\\]+)", line, re.I):
+                stage_dependencies[current_stage].add(expand_args(dependency))
+
+    stage_names = set(stage_dependencies)
+    for dependencies in stage_dependencies.values():
+        dependencies.intersection_update(stage_names)
+    return stage_dependencies
+
+
+def dockerfile_stage_closure(
+    stage_dependencies: dict[str, set[str]], root: str
+) -> set[str]:
+    closure: set[str] = set()
+    pending = [root]
+    while pending:
+        stage = pending.pop()
+        if stage in closure:
+            continue
+        closure.add(stage)
+        pending.extend(stage_dependencies[stage])
+    return closure
+
+
+def test_rocm_stage_hashes_cover_dependency_graphs() -> None:
+    dockerfile = (REPO_ROOT / "docker" / "Dockerfile.rocm").read_text()
+    ci_bake = ROCM_CI_BAKE.read_text()
+    stage_dependencies = dockerfile_stage_dependencies(dockerfile)
+
+    for variable, root in (
+        ("DEFAULT_CI_BASE_DOCKERFILE_STAGES", "ci_base"),
+        ("DEFAULT_ROCM_CSRC_DOCKERFILE_STAGES", "csrc-build"),
+        ("DEFAULT_ROCM_RUST_DOCKERFILE_STAGES", "rust-build"),
+    ):
+        configured_stages = re.search(rf'^{variable}="([^"]+)"$', ci_bake, re.M)
+        assert configured_stages is not None
+        assert set(configured_stages.group(1).split()) == dockerfile_stage_closure(
+            stage_dependencies, root
+        )
+
+
+def test_dockerfile_stage_parser_expands_both_arg_forms() -> None:
+    dockerfile = """\
+ARG ROOT=scratch
+ARG SHARED=shared
+from ${ROOT} AS shared
+RUN echo shared
+FROM scratch AS braced
+COPY --from=${SHARED} /in /out
+FROM scratch AS unbraced
+RUN --mount=type=bind,from=$SHARED,target=/in echo unbraced
+"""
+    dependencies = dockerfile_stage_dependencies(dockerfile)
+
+    assert dependencies["braced"] == {"shared"}
+    assert dependencies["unbraced"] == {"shared"}
+
+
+def test_rocm_stage_hasher_treats_from_case_insensitively(tmp_path: Path) -> None:
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "from scratch AS first\n"
+        "RUN echo first\n"
+        "FrOm scratch as second\n"
+        "RUN echo second\n"
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; hash_dockerfile_stages "$2" first',
+            "bash",
+            str(ROCM_CI_BAKE),
+            str(dockerfile),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == [
+        "from scratch AS first",
+        "RUN echo first",
+    ]
+
+
+def requirement_names(path: Path, seen: set[Path] | None = None) -> set[str]:
+    seen = seen or set()
+    path = path.resolve()
+    if path in seen:
+        return set()
+    seen.add(path)
+
+    names = set()
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.split("#", maxsplit=1)[0].strip()
+        if not line:
+            continue
+        if line.startswith(("-r ", "--requirement ")):
+            names.update(
+                requirement_names(path.parent / line.split(maxsplit=1)[1], seen)
+            )
+        elif not line.startswith("-"):
+            names.add(canonicalize_name(Requirement(line).name))
+    return names
+
+
+def locked_requirements(path: Path) -> dict[str, Requirement]:
+    requirements = (
+        Requirement(line)
+        for line in path.read_text().splitlines()
+        if line and not line.startswith((" ", "#", "-"))
+    )
+    return {
+        canonicalize_name(requirement.name): requirement for requirement in requirements
+    }
+
+
+def test_rocm_locks_cover_their_inputs() -> None:
+    requirements = REPO_ROOT / "requirements"
+    build_input = requirements / "build" / "rocm.in"
+    build_lock = requirements / "build" / "rocm.txt"
+    test_input = requirements / "test" / "rocm.in"
+    test_lock = requirements / "test" / "rocm.txt"
+
+    assert requirement_names(build_input) <= requirement_names(build_lock)
+    assert requirement_names(test_input) <= requirement_names(test_lock)
+    build_requirements = locked_requirements(build_lock)
+    test_requirements = locked_requirements(test_lock)
+    for runtime_or_test_only in ("datasets", "peft", "pytest", "pytest-asyncio"):
+        assert runtime_or_test_only not in build_requirements
+    # TorchAudio's pinned requirements.txt installs SoundFile while building.
+    assert "soundfile" in build_requirements
+    assert str(test_requirements["datasets"].specifier) == "==3.6.0"
+    assert str(build_requirements["numpy"].specifier) == "==2.2.6"
+    assert build_requirements.keys() <= test_requirements.keys()
+    for name, build_requirement in build_requirements.items():
+        assert build_requirement == test_requirements[name]
+    for lock in (build_lock, test_lock):
+        assert all(
+            str(requirement.specifier).startswith("==")
+            for requirement in locked_requirements(lock).values()
+        )
+
+
+def test_rocm_base_wheel_cache_key_covers_declared_inputs(tmp_path: Path) -> None:
+    inputs = []
+    for name in ("Dockerfile.rocm_base", ".dockerignore", "rocm.txt", "pipeline.yaml"):
+        path = tmp_path / name
+        path.write_text(f"{name}: original\n")
+        inputs.append(path)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "ROCM_BASE_DOCKERFILE": str(inputs[0]),
+            "ROCM_BASE_CONTENT_FILES": " ".join(map(str, inputs)),
+            "ROCM_BASE_PARENT_IMAGE": "rocm/example:mutable",
+            "ROCM_BASE_PARENT_DIGEST": f"sha256:{'1' * 64}",
+            "ROCM_BASE_PYTORCH_ROCM_ARCH": "gfx90a",
+            "ROCM_BASE_USE_SCCACHE": "1",
+        }
+    )
+
+    def cache_key(**overrides: str) -> str:
+        command_env = env | overrides
+        return subprocess.run(
+            ["bash", str(ROCM_BASE_WHEEL_CACHE), "key"],
+            check=True,
+            cwd=REPO_ROOT,
+            env=command_env,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+
+    baseline = cache_key()
+    assert cache_key() == baseline
+    assert cache_key(SCCACHE_ENDPOINT="https://cache.example.invalid") == baseline
+    for path in inputs:
+        original = path.read_text()
+        path.write_text(f"{original}changed\n")
+        assert cache_key() != baseline
+        path.write_text(original)
+    for overrides in (
+        {"ROCM_BASE_PARENT_IMAGE": "rocm/example:other"},
+        {"ROCM_BASE_PARENT_DIGEST": f"sha256:{'2' * 64}"},
+        {"ROCM_BASE_PLATFORM": "linux/arm64"},
+        {"ROCM_BASE_IMAGE_TARGET": "different-image-target"},
+        {"ROCM_BASE_WHEEL_TARGET": "different-wheel-target"},
+        {"ROCM_BASE_USE_SCCACHE": "0"},
+        {"SCCACHE_DOWNLOAD_URL": "https://example.invalid/sccache.tar.gz"},
+        {"SCCACHE_VERSION": "v9.9.9"},
+        {"SCCACHE_DOWNLOAD_SHA256": "2" * 64},
+        {"SCCACHE_BUCKET_NAME": "different-bucket"},
+        {"SCCACHE_REGION_NAME": "different-region"},
+        {"SCCACHE_S3_NO_CREDENTIALS": "1"},
+        {"ROCM_BASE_PYTORCH_ROCM_ARCH": "gfx942"},
+    ):
+        assert cache_key(**overrides) != baseline
+
+
+def test_rocm_base_cache_omitted_sccache_matches_disabled(tmp_path: Path) -> None:
+    dockerfile = tmp_path / "Dockerfile.rocm_base"
+    dockerfile.write_text(
+        "ARG BASE_IMAGE=rocm/example:base\n"
+        "ARG USE_SCCACHE\n"
+        "ARG PYTORCH_ROCM_ARCH=gfx90a\n"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ROCM_BASE_DOCKERFILE": str(dockerfile),
+            "ROCM_BASE_CONTENT_FILES": str(dockerfile),
+            "ROCM_BASE_PARENT_DIGEST": f"sha256:{'1' * 64}",
+        }
+    )
+
+    def cache_key(**overrides: str) -> str:
+        return subprocess.run(
+            ["bash", str(ROCM_BASE_WHEEL_CACHE), "key"],
+            check=True,
+            cwd=REPO_ROOT,
+            env=env | overrides,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+
+    omitted = cache_key()
+    assert cache_key(ROCM_BASE_USE_SCCACHE="0") == omitted
+    assert cache_key(ROCM_BASE_USE_SCCACHE="1") != omitted
+
+
+def shell_words_assignment(path: Path, name: str) -> list[str]:
+    match = re.search(rf'^{name}="([^"]*)"$', path.read_text(), re.M)
+    assert match is not None
+    value = match.group(1).replace("${DOCKERFILE}", "docker/Dockerfile.rocm_base")
+    return shlex.split(value)
+
+
+def test_rocm_base_cache_production_content_lists_are_synchronized() -> None:
+    expected = [
+        "docker/Dockerfile.rocm_base",
+        ".dockerignore",
+        "requirements/build/rocm.txt",
+    ]
+    release_match = re.search(
+        r'export ROCM_BASE_CONTENT_FILES="([^"]+)"',
+        ROCM_RELEASE_BUILD.read_text(),
+    )
+    assert release_match is not None
+
+    assert shell_words_assignment(ROCM_BASE_WHEEL_CACHE, "DEFAULT_CONTENT_FILES") == (
+        expected
+    )
+    assert (
+        shell_words_assignment(ROCM_REFRESH_BASE, "DEFAULT_ROCM_BASE_CONTENT_FILES")
+        == expected
+    )
+    assert shlex.split(release_match.group(1)) == expected
+
+
+def test_rocm_release_does_not_expose_sccache_download_url_as_build_arg() -> None:
+    release_build = ROCM_RELEASE_BUILD.read_text()
+
+    assert "unset ROCM_BASE_PARENT_DIGEST SCCACHE_DOWNLOAD_URL" in release_build
+    assert "--build-arg SCCACHE_DOWNLOAD_URL" not in release_build
+    assert ".buildkite/scripts/build-rocm-base-wheels.sh" in (
+        ROCM_RELEASE_PIPELINE.read_text()
+    )
+
+
+def test_rocm_native_cache_inputs_use_narrow_build_lock() -> None:
+    ci_bake = ROCM_CI_BAKE.read_text()
+    ci_base_files = shell_words_assignment(
+        ROCM_CI_BAKE, "DEFAULT_CI_BASE_CONTENT_FILES"
+    )
+    csrc_files = shell_words_assignment(ROCM_CI_BAKE, "DEFAULT_ROCM_CSRC_CONTENT_FILES")
+    rust_files = shell_words_assignment(ROCM_CI_BAKE, "DEFAULT_ROCM_RUST_CONTENT_FILES")
+
+    assert "requirements/build/rocm.txt" in ci_base_files
+    assert "requirements/test/rocm.txt" in ci_base_files
+    for content_files in (csrc_files, rust_files):
+        assert "requirements/build/rocm.txt" in content_files
+        assert "requirements/test/rocm.txt" not in content_files
+    for runtime_requirements in (
+        "requirements/common.txt",
+        "requirements/rocm.txt",
+    ):
+        assert runtime_requirements not in csrc_files
+    assert "requirements/build/rocm.txt" in ci_bake
+
+
+def test_rocm_metadata_changes_trigger_the_relevant_ci_lanes() -> None:
+    docker_area = (REPO_ROOT / ".buildkite" / "test_areas" / "docker.yaml").read_text()
+    cpu_sources, amd_mirror_sources = docker_area.split(
+        "  mirror:\n    amd:", maxsplit=1
+    )
+    amd_pipeline = (REPO_ROOT / ".buildkite" / "test-amd.yaml").read_text()
+    rocm_config = (REPO_ROOT / ".buildkite" / "ci_config_rocm.yaml").read_text()
+    required_sources = (
+        ".buildkite/scripts/build-rocm-base-wheels.sh",
+        "tests/tools/test_rocm_release_build.py",
+        ".buildkite/scripts/rocm/refresh-base-image.sh",
+        ".buildkite/scripts/rocm/smoke-test-image.sh",
+        "docker/ci-rocm.hcl",
+        "docker/docker-bake-rocm.hcl",
+        "requirements/build/rocm.in",
+        "requirements/build/rocm.txt",
+    )
+
+    for source in required_sources:
+        assert source in cpu_sources
+        assert source in amd_mirror_sources
+        assert source in amd_pipeline
+    for source in required_sources[-2:]:
+        assert source in rocm_config
+
+
+def test_rocm_cache_helpers_reject_empty_content_lists(tmp_path: Path) -> None:
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("ARG BASE_IMAGE=rocm/example:base\nARG USE_SCCACHE=0\n")
+    env = os.environ.copy()
+    env.update(
+        {
+            "ROCM_BASE_DOCKERFILE": str(dockerfile),
+            "ROCM_BASE_CONTENT_FILES": "   ",
+            "ROCM_BASE_PARENT_DIGEST": f"sha256:{'1' * 64}",
+            "ROCM_BASE_PYTORCH_ROCM_ARCH": "gfx90a",
+        }
+    )
+    cache_result = subprocess.run(
+        ["bash", str(ROCM_BASE_WHEEL_CACHE), "key"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    refresh_result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; compute_base_content_hash 0 "$2" gfx90a linux/amd64',
+            "bash",
+            str(ROCM_REFRESH_BASE),
+            f"sha256:{'1' * 64}",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert cache_result.returncode != 0
+    assert "content" in cache_result.stderr.lower()
+    assert refresh_result.returncode != 0
+    assert "content" in refresh_result.stderr.lower()
+
+
+def test_rocm_forced_base_refresh_still_exports_layer_cache() -> None:
+    env = os.environ.copy()
+    env["ROCM_BASE_REFRESH_FORCE"] = "1"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; configure_rocm_base_layer_cache; '
+            'printf "%s\\n" "${ROCM_BASE_CACHE_ARGS[@]}"',
+            "bash",
+            str(ROCM_REFRESH_BASE),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    args = result.stdout.splitlines()
+
+    assert "--no-cache" in args
+    assert "--cache-to" in args
+    assert "--cache-from" not in args
+
+
+def test_rocm_base_preview_image_refs_are_source_scoped() -> None:
+    def preview_ref(repo: str) -> str:
+        env = os.environ.copy()
+        env.update(
+            {
+                "BUILDKITE": "false",
+                "BUILDKITE_BRANCH": "feature",
+                "BUILDKITE_REPO": repo,
+            }
+        )
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; scoped_base_content_ref "$2" 3',
+                "bash",
+                str(ROCM_REFRESH_BASE),
+                "a" * 64,
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+
+    first = preview_ref("https://github.com/example/one.git")
+    second = preview_ref("https://github.com/example/two.git")
+    assert first != second
+    assert first.endswith("a" * 64)
+    assert second.endswith("a" * 64)
+
+
+def test_rocm_dependency_cache_writes_are_source_scoped() -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            """
+source "$1"
+DOCKERHUB_CACHE_REPO=example/cache
+NIXL_CACHE_KEY=key
+CI_BASE_WRITE_SCOPE=preview-owner
+BUILDKITE_BUILD_ID=build-one
+trusted_dependency_cache_ref_for_target nixl-rocm-ci
+dependency_cache_ref_for_target nixl-rocm-ci
+BUILDKITE_BUILD_ID=build-two
+dependency_cache_ref_for_target nixl-rocm-ci
+CI_BASE_WRITE_SCOPE=
+dependency_cache_ref_for_target nixl-rocm-ci
+""",
+            "bash",
+            str(ROCM_CI_BAKE),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    trusted, first_write, second_write, trusted_write = result.stdout.splitlines()
+
+    assert trusted == "example/cache:nixl-rocm-key"
+    assert first_write.startswith("example/cache:nixl-rocm-preview-owner-")
+    assert second_write.startswith("example/cache:nixl-rocm-preview-owner-")
+    assert first_write != second_write
+    assert trusted_write == trusted
+
+
+def test_rocm_bake_values_are_escaped_as_literal_hcl_strings() -> None:
+    # Build arguments, metadata and cache lists must not evaluate templates or
+    # let quotes/newlines change the generated Bake configuration structure.
+    for value, escaped in (
+        ("gfx90a;gfx942", "gfx90a;gfx942"),
+        ('quote"\\path\n\r\t', 'quote\\"\\\\path\\n\\r\\t'),
+        ("${1 + 1} %{if true}value%{endif}", "$${1 + 1} %%{if true}value%%{endif}"),
+    ):
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; hcl_escape_string "$2"; printf "\\n"; '
+                'write_hcl_string_list_entries "  " "$2"',
+                "bash",
+                str(ROCM_CI_BAKE),
+                value,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout == f'{escaped}\n  "{escaped}",\n'
+
+
+def test_rocm_wrappers_reject_secret_endpoints_without_logging_them() -> None:
+    # Source the wrappers to exercise their early guard without Docker or AWS.
+    for helper in (ROCM_CI_BAKE, ROCM_REFRESH_BASE):
+        for endpoint in (
+            "https://user:secret@cache.example",
+            "https://cache.example?token=secret",
+            "https://cache.example#secret",
+            "https://cache.example\nsecret",
+        ):
+            result = subprocess.run(
+                ["bash", "-c", 'source "$1"', "bash", str(helper)],
+                env=os.environ | {"SCCACHE_ENDPOINT": endpoint},
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode != 0
+            assert "SCCACHE_ENDPOINT must not contain" in result.stderr
+            assert endpoint not in result.stdout + result.stderr
+
+        for endpoint in ("", "http://localhost:9000", "https://cache.example"):
+            subprocess.run(
+                ["bash", "-c", 'source "$1"', "bash", str(helper)],
+                env=os.environ | {"SCCACHE_ENDPOINT": endpoint},
+                check=True,
+            )
+
+
+def test_rocm_commit_image_without_revision_is_rebuilt() -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            """
+source "$1"
+TARGET=test-rocm-ci
+IMAGE_TAG=example/image:commit
+BUILDKITE_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+remote_image_exists() { return 0; }
+get_remote_image_label() { return 0; }
+maybe_skip_existing_image
+echo continued-to-build
+""",
+            "bash",
+            str(ROCM_CI_BAKE),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert "found revision: <missing>" in result.stdout
+    assert result.stdout.splitlines()[-1] == "continued-to-build"
+
+
+def test_rocm_force_disables_layers_for_non_base_targets() -> None:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            """
+source "$1"
+TARGET=test-rocm-ci
+FORCE_BUILD=1
+BAKE_TARGETS=(test-rocm-ci)
+BAKE_ALLOW_ARGS=()
+BAKE_FILES=()
+docker() { printf '%s\\n' "$*"; }
+run_bake
+""",
+            "bash",
+            str(ROCM_CI_BAKE),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert "buildx bake --no-cache" in result.stdout
+
+
+def docker_arg_value(dockerfile: str, name: str) -> str:
+    prefix = f"ARG {name}="
+    line = next(line for line in dockerfile.splitlines() if line.startswith(prefix))
+    return line.removeprefix(prefix).split("#", maxsplit=1)[0].strip().strip('"')
+
+
+def test_rocm_image_dependency_inputs_are_immutable() -> None:
+    rocm_base = (REPO_ROOT / "docker" / "Dockerfile.rocm_base").read_text()
+    rocm_ci = (REPO_ROOT / "docker" / "Dockerfile.rocm").read_text()
+
+    for dockerfile, commit_arg_names in (
+        (
+            rocm_base,
+            (
+                "TRITON_BRANCH",
+                "PYTORCH_BRANCH",
+                "PYTORCH_VISION_BRANCH",
+                "PYTORCH_AUDIO_BRANCH",
+                "FA_BRANCH",
+                "AITER_BRANCH",
+                "MORI_BRANCH",
+                "ROCPROFILER_SDK_COMMIT",
+                "ROCM_RUNTIME_COMMIT",
+            ),
+        ),
+        (
+            rocm_ci,
+            (
+                "ROCM_TRITON_KERNELS_COMMIT",
+                "NIXL_BRANCH",
+                "UCX_BRANCH",
+                "LMCACHE_REF",
+                "ROCSHMEM_BRANCH",
+                "DEEPEP_BRANCH",
+                "RDMA_CORE_COMMIT",
+                "DECORD_COMMIT",
+            ),
+        ),
+    ):
+        for name in commit_arg_names:
+            value = docker_arg_value(dockerfile, name)
+            assert len(value) == 40
+            int(value, 16)
+    for dockerfile, checksum_arg_names in (
+        (
+            rocm_base,
+            (
+                "GET_PIP_SHA256",
+                "SCCACHE_DOWNLOAD_SHA256",
+                "TRITON_LLVM_SHA256",
+                "ROCPROFILER_SDK_PR_7796_SHA256",
+                "ROCPROFILER_SDK_PR_7924_SHA256",
+            ),
+        ),
+        (
+            rocm_ci,
+            (
+                "UV_DOWNLOAD_SHA256",
+                "RUSTUP_INIT_SHA256",
+                "ROCM_TRITON_KERNELS_SHA256",
+            ),
+        ),
+    ):
+        for name in checksum_arg_names:
+            value = docker_arg_value(dockerfile, name)
+            assert len(value) == 64
+            int(value, 16)
+
+
+def test_rocm_source_builds_use_the_narrow_constraints() -> None:
+    rocm_base = (REPO_ROOT / "docker" / "Dockerfile.rocm_base").read_text()
+    rocm_ci = (REPO_ROOT / "docker" / "Dockerfile.rocm").read_text()
+
+    assert "source=requirements/test/rocm.txt" not in rocm_base
+    assert "source=requirements/build/rocm.txt" in rocm_base
+    assert "COPY requirements/build/rocm.txt" in rocm_ci
+    build_dependencies = rocm_ci.split(
+        "FROM base AS build_vllm_dependencies", maxsplit=1
+    )[1].split("FROM base AS rocm-triton-kernels", maxsplit=1)[0]
+    assert "--requirement /tmp/rocm-build-constraints.txt" in build_dependencies
+    assert "-r requirements/rocm.txt" not in build_dependencies
+    assert "/requirements/common.txt" not in build_dependencies
+    assert "/requirements/rocm.txt" not in build_dependencies
+    assert "# Native-extension-only build." in build_dependencies
+    assert "'-r common.txt' > requirements/rocm.txt" in build_dependencies
+    assert (
+        "COPY --from=export_vllm /requirements/test/rocm.txt /tmp/rocm-constraints.txt"
+    ) in rocm_ci
+    for expected in (
+        "pip wheel --no-build-isolation --no-deps",
+        "TRITON_OFFLINE_BUILD=1 TRITON_BUILD_PROTON=OFF",
+        "FLASH_ATTENTION_FORCE_BUILD=TRUE",
+        "AITER_USE_SYSTEM_TRITON=1",
+        "pip check",
+    ):
+        assert expected in rocm_base
+
+    # These two ABI-sensitive extensions must independently opt out of binary
+    # wheels; combining their flags would allow one regression to mask another.
+    assert "--no-binary arctic-inference" in rocm_ci
+    assert "--no-binary fastsafetensors" in rocm_ci
+    assert "--build-constraints /tmp/lmcache-build-constraints.txt" in rocm_ci
+
+
+def test_rocm_native_build_graph_only_serializes_aiter_on_triton() -> None:
+    rocm_base = (REPO_ROOT / "docker" / "Dockerfile.rocm_base").read_text()
+    dependencies = dockerfile_stage_dependencies(rocm_base)
+
+    assert dependencies["build_pytorch_runtime"] == {"base", "build_pytorch"}
+    assert dependencies["build_pytorch_triton_runtime"] == {
+        "build_pytorch_runtime",
+        "build_triton",
+    }
+    for stage in (
+        "build_torchvision",
+        "build_torchaudio",
+        "build_mori",
+        "build_fa",
+    ):
+        assert dependencies[stage] == {"build_pytorch_runtime"}
+    assert dependencies["build_aiter"] == {"build_pytorch_triton_runtime"}
+
+
+def test_rocm_runtime_dependency_guards_are_enforced() -> None:
+    rocm_base = (REPO_ROOT / "docker" / "Dockerfile.rocm_base").read_text()
+    rocm_ci = (REPO_ROOT / "docker" / "Dockerfile.rocm").read_text()
+    rocm_base_final = rocm_base.split("FROM base AS final", maxsplit=1)[1]
+
+    for dockerfile in (rocm_base, rocm_ci):
+        assert "ARG USE_SCCACHE\n" in dockerfile.split("FROM ", maxsplit=1)[0]
+
+    assert (
+        "apt-get purge -y software-properties-common "
+        "python3-software-properties python3-gi"
+    ) in rocm_base
+    assert "PyGObject==" not in rocm_base
+    assert "python3 -m pip check" in rocm_base
+    assert "&& pip check" in rocm_base
+    assert (
+        "pip install --constraint /tmp/rocm-constraints.txt pyyaml /install/*.whl"
+    ) in rocm_base_final
+    assert "pyyaml" in locked_requirements(ROCM_BUILD_LOCK)
+
+    assert (
+        'test "$(rustc --version | awk \'{print $2}\')" = "${RUST_TOOLCHAIN_VERSION}"'
+    ) in rocm_ci
+    assert "revision = e5fada43131d251e9c4786b04263ce98b6767ba5" in rocm_ci
+    assert "uv pip check --system" in rocm_ci
+
+
+def test_rocm_decord_and_numpy_runtime_match_the_source_builds() -> None:
+    rocm_ci = (REPO_ROOT / "docker" / "Dockerfile.rocm").read_text()
+    numpy_pin = str(
+        locked_requirements(ROCM_BUILD_LOCK)["numpy"].specifier
+    ).removeprefix("==")
+
+    for expected in (
+        "FROM ci_base_system AS build_decord",
+        "git -C /tmp/decord checkout -q --detach FETCH_HEAD",
+        'test "$(git -C /tmp/decord rev-parse HEAD)" = "${DECORD_COMMIT}"',
+        "git -C /tmp/decord submodule update --init --recursive --depth 1",
+        "-DUSE_CUDA=OFF",
+        "python3 -m pip wheel --no-cache-dir --no-build-isolation --no-deps",
+        "python3 -m pip install --no-cache-dir --force-reinstall --no-deps",
+        "python3 -c \"import decord; print('decord', decord.__version__)\"",
+    ):
+        assert expected in rocm_ci
+
+    assert numpy_pin == "2.2.6"
+    assert 'grep -Fxc "numpy<=${NUMPY_VERSION}"' in rocm_ci
+    assert f"numpy=={numpy_pin}" not in rocm_ci
+    assert '-e "s/^numpy' not in rocm_ci
+    assert "import numpy; print(numpy.__version__)" in rocm_ci
+    assert '"${NUMPY_VERSION}"' in rocm_ci
+
+
+def test_rocm_release_lmcache_installs_its_runtime_extras() -> None:
+    rocm_ci = (REPO_ROOT / "docker" / "Dockerfile.rocm").read_text()
+    rocm_test_roots = {
+        line.split("#", maxsplit=1)[0].strip()
+        for line in ROCM_TEST_INPUT.read_text().splitlines()
+    }
+    final_lmcache = rocm_ci.split(
+        "FROM final_common AS final_lmcache_true", maxsplit=1
+    )[1].split("FROM final_lmcache_${INSTALL_LMCACHE} AS final", maxsplit=1)[0]
+
+    assert "--constraint /tmp/rocm-constraints.txt" in final_lmcache
+    for dependency in (
+        "aiofile",
+        "aiofiles",
+        "awscrt",
+        "cupy-rocm-7-0",
+        "google-cloud-bigtable",
+        "opentelemetry-exporter-prometheus",
+        "sortedcontainers",
+    ):
+        assert dependency in final_lmcache
+        assert dependency in rocm_test_roots
+    assert "uv pip check --system" in final_lmcache
+
+
+def test_torchcodec_build_contract_is_abi_safe() -> None:
+    rocm_ci = (REPO_ROOT / "docker" / "Dockerfile.rocm").read_text()
+    torchcodec = TORCHCODEC_INSTALLER.read_text()
+
+    torchcodec_commit = (
+        next(
+            line
+            for line in torchcodec.splitlines()
+            if line.startswith("TORCHCODEC_COMMIT=")
+        )
+        .split(":-", maxsplit=1)[1]
+        .split("}", maxsplit=1)[0]
+    )
+    assert len(torchcodec_commit) == 40
+    int(torchcodec_commit, 16)
+    assert "TORCHCODEC_WHEEL_CACHE" not in torchcodec
+    assert "pip wheel . --no-cache-dir --no-build-isolation --no-deps" in torchcodec
+    assert 'TORCHCODEC_FORCE_REBUILD="${TORCHCODEC_FORCE_REBUILD:-0}"' in torchcodec
+    assert 'case "$TORCHCODEC_FORCE_REBUILD" in' in torchcodec
+    assert '--force-reinstall --no-deps "$BUILT_WHEEL"' in torchcodec
+    assert "TORCHCODEC_FORCE_REBUILD=1" in rocm_ci
+    assert "TORCHCODEC_CONSTRAINTS=/tmp/rocm-build-constraints.txt" in rocm_ci
+
+
+def test_torchcodec_working_install_skips_before_any_build(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    python_calls = tmp_path / "python-calls"
+    python = fake_bin / "python3"
+    python.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$FAKE_PYTHON_CALLS"\n'
+        'test "$1" = "-c"\n'
+        'test "$2" = "from torchcodec.decoders import VideoDecoder"\n'
+    )
+    python.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_PYTHON_CALLS": str(python_calls),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "TORCHCODEC_FORCE_REBUILD": "0",
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(TORCHCODEC_INSTALLER)],
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert "already installed and working" in result.stdout
+    assert python_calls.read_text().splitlines() == [
+        "-c from torchcodec.decoders import VideoDecoder"
+    ]
+
+
+def test_torchcodec_force_rebuild_rejects_invalid_values() -> None:
+    env = os.environ.copy()
+    env["TORCHCODEC_FORCE_REBUILD"] = "sometimes"
+    result = subprocess.run(
+        ["bash", str(TORCHCODEC_INSTALLER)],
+        env=env,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "must be 0 or 1" in result.stdout
 
 
 def test_rocm_ci_smoke_runs_in_shared_buildkit_graph() -> None:

--- a/tests/tools/test_rocm_release_build.py
+++ b/tests/tools/test_rocm_release_build.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / ".buildkite/scripts/build-rocm-base-wheels.sh"
+CACHE_TOOL = "cache-rocm-base-wheels.sh"
+PARENT_DIGEST = f"sha256:{'1' * 64}"
+CACHED_DIGEST = f"sha256:{'2' * 64}"
+BUILT_DIGEST = f"sha256:{'3' * 64}"
+ECR_REPOSITORY = "public.ecr.aws/q9t5s3a7/vllm-release-repo"
+
+# Run the release shell without a registry, object store, or container runtime.
+FAKE_TOOL = r"""
+import json
+import os
+import sys
+from pathlib import Path
+
+tool = Path(sys.argv[0]).name
+args = sys.argv[1:]
+env = os.environ
+with open(env["CALL_LOG"], "a") as log:
+    log.write(json.dumps({"tool": tool, "args": args, "env": {
+        key: value for key, value in env.items()
+        if key.startswith(("ROCM_BASE_", "SCCACHE_"))
+        or key in ("PYTORCH_ROCM_ARCH", "DOCKER_BUILDKIT")
+    }}) + "\n")
+if env.get("FAIL_COMMAND") == f"{tool}:{args[0]}":
+    sys.exit(17)
+if tool == "cache-rocm-base-wheels.sh":
+    if args == ["parent"]:
+        print("rocm/base:test@sha256:" + "1" * 64)
+    elif args == ["key"]:
+        print("test-cache-key")
+    elif args == ["check"]:
+        print("miss" if env.get("ROCM_BASE_WHEEL_CACHE_FORCE") == "1"
+              else env.get("CACHE_STATUS", "miss"))
+    elif args == ["download"]:
+        Path(env["ROCM_BASE_IMAGE_DIGEST_FILE"]).write_text(
+            env.get("CACHED_DIGEST", "sha256:" + "2" * 64))
+        Path("artifacts/rocm-base-wheels/cached.whl").write_text("cached")
+elif tool == "aws":
+    print("fake-login-password")
+elif tool == "docker":
+    if args[0] == "login":
+        assert sys.stdin.read().strip() == "fake-login-password"
+    elif args[:2] == ["manifest", "inspect"]:
+        sys.exit(int(env.get("MISSING_IMAGE", "0")))
+    elif args[:2] == ["buildx", "build"] and "--metadata-file" in args:
+        Path(args[args.index("--metadata-file") + 1]).write_text(json.dumps({
+            "containerimage.digest": env.get("BUILD_DIGEST", "sha256:" + "3" * 64)
+        }))
+    elif args[0] == "create":
+        print("wheel-container")
+    elif args[0] == "cp":
+        Path(args[-1], "built.whl").write_text("built")
+"""
+
+
+@pytest.fixture
+def release_build(tmp_path: Path):
+    fake_bin = tmp_path / "bin"
+    scripts = tmp_path / ".buildkite/scripts"
+    for directory in (fake_bin, scripts, tmp_path / "docker", tmp_path / "temp"):
+        directory.mkdir(parents=True)
+    for tool in [scripts / CACHE_TOOL] + [
+        fake_bin / name for name in ("aws", "docker", "buildkite-agent")
+    ]:
+        tool.write_text(f"#!{sys.executable}\n{FAKE_TOOL}")
+        tool.chmod(0o755)
+    (tmp_path / "docker/Dockerfile.rocm_base").write_text(
+        'ARG PYTORCH_ROCM_ARCH="gfx90a;gfx942"\n'
+        "ARG SCCACHE_VERSION=v0.10.0\n"
+        f"ARG SCCACHE_DOWNLOAD_SHA256={'4' * 64}\n"
+    )
+    wheels = tmp_path / "artifacts/rocm-base-wheels"
+    wheels.mkdir(parents=True)
+    (wheels / "stale.whl").touch()
+
+    def run(**overrides: str) -> tuple[subprocess.CompletedProcess[str], list[dict]]:
+        result = subprocess.run(
+            ["bash", str(HELPER)],
+            cwd=tmp_path,
+            env={
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "TMPDIR": str(tmp_path / "temp"),
+                "CALL_LOG": str(tmp_path / "calls.jsonl"),
+                "BUILDKITE_BUILD_NUMBER": "42",
+                **overrides,
+            },
+            capture_output=True,
+            text=True,
+        )
+        log = tmp_path / "calls.jsonl"
+        calls = (
+            [json.loads(line) for line in log.read_text().splitlines()]
+            if log.exists()
+            else []
+        )
+        assert not list((tmp_path / "temp").iterdir()), result.stderr
+        return result, calls
+
+    return run
+
+
+def commands(calls: list[dict], tool: str, *prefix: str) -> list[dict]:
+    return [
+        call
+        for call in calls
+        if call["tool"] == tool and call["args"][: len(prefix)] == list(prefix)
+    ]
+
+
+def build_args(call: dict) -> dict[str, str]:
+    args = call["args"]
+    return dict(
+        args[i + 1].split("=", 1)
+        for i, arg in enumerate(args[:-1])
+        if arg == "--build-arg"
+    )
+
+
+def test_full_cache_hit_publishes_paired_digest_without_building(release_build):
+    result, calls = release_build(CACHE_STATUS="hit")
+
+    assert result.returncode == 0, result.stderr
+    assert commands(calls, "aws")[0]["args"] == [
+        "ecr-public",
+        "get-login-password",
+        "--region",
+        "us-east-1",
+    ]
+    assert commands(calls, "docker", "login")[0]["args"] == [
+        "login",
+        "--username",
+        "AWS",
+        "--password-stdin",
+        "public.ecr.aws/q9t5s3a7",
+    ]
+    assert not commands(calls, "docker", "buildx", "build")
+    assert not commands(calls, CACHE_TOOL, "upload")
+    assert commands(calls, "docker", "manifest", "inspect")[0]["args"][-1] == (
+        f"{ECR_REPOSITORY}@{CACHED_DIGEST}"
+    )
+    assert commands(calls, "buildkite-agent")[0]["args"] == [
+        "meta-data",
+        "set",
+        "rocm-base-image-tag",
+        f"{ECR_REPOSITORY}@{CACHED_DIGEST}",
+    ]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {"CACHE_STATUS": "hit", "ROCM_BASE_WHEEL_CACHE_FORCE": "1"},
+        {"CACHE_STATUS": "hit", "FAIL_COMMAND": f"{CACHE_TOOL}:download"},
+        {"CACHE_STATUS": "hit", "MISSING_IMAGE": "1"},
+    ],
+)
+def test_rebuild_pairs_image_and_wheels_with_identical_inputs(
+    release_build, tmp_path: Path, overrides: dict[str, str]
+):
+    result, calls = release_build(**overrides)
+
+    assert result.returncode == 0, result.stderr
+    image, wheels = commands(calls, "docker", "buildx", "build")
+    expected = {
+        "BASE_IMAGE": f"rocm/base:test@{PARENT_DIGEST}",
+        "USE_SCCACHE": "1",
+        "PYTORCH_ROCM_ARCH": "gfx90a;gfx942",
+        "SCCACHE_VERSION": "v0.10.0",
+        "SCCACHE_DOWNLOAD_SHA256": "4" * 64,
+        "SCCACHE_ENDPOINT": "",
+        "SCCACHE_BUCKET_NAME": "vllm-build-sccache",
+        "SCCACHE_REGION_NAME": "us-west-2",
+        "SCCACHE_S3_NO_CREDENTIALS": "0",
+    }
+    assert build_args(image) == build_args(wheels) == expected
+    for build, target in ((image, "final"), (wheels, "debs_wheel_release")):
+        args = build["args"]
+        assert args[args.index("--target") + 1] == target
+        assert args[args.index("--platform") + 1] == "linux/amd64"
+        assert args[args.index("--file") + 1] == "docker/Dockerfile.rocm_base"
+        assert build["env"]["DOCKER_BUILDKIT"] == "1"
+    assert "--push" in image["args"] and "--load" in wheels["args"]
+    assert ("--no-cache" in image["args"]) == (
+        overrides.get("ROCM_BASE_WHEEL_CACHE_FORCE") == "1"
+    )
+    assert "--no-cache" not in wheels["args"]
+    assert (
+        commands(calls, CACHE_TOOL, "upload")[0]["env"]["ROCM_BASE_IMAGE_DIGEST"]
+        == BUILT_DIGEST
+    )
+    assert commands(calls, "buildkite-agent")[0]["args"][-1] == (
+        f"{ECR_REPOSITORY}@{BUILT_DIGEST}"
+    )
+    assert [p.name for p in (tmp_path / "artifacts/rocm-base-wheels").iterdir()] == [
+        "built.whl"
+    ]
+
+
+@pytest.mark.parametrize(
+    "failure", ["docker:buildx", "docker:cp", f"{CACHE_TOOL}:upload"]
+)
+def test_failure_prevents_publishing_and_cleans_resources(release_build, failure: str):
+    result, calls = release_build(FAIL_COMMAND=failure)
+
+    assert result.returncode == 17, result.stderr
+    assert not commands(calls, "buildkite-agent")
+    if failure == "docker:cp":
+        assert commands(calls, "docker", "rm")[0]["args"] == [
+            "rm",
+            "-f",
+            "wheel-container",
+        ]
+        assert not commands(calls, CACHE_TOOL, "upload")
+
+
+def test_invalid_build_digest_stops_before_wheel_export(release_build):
+    result, calls = release_build(BUILD_DIGEST="mutable-tag")
+
+    assert result.returncode == 1
+    assert "invalid ROCm base image digest" in result.stderr
+    assert len(commands(calls, "docker", "buildx", "build")) == 1
+    assert not commands(calls, CACHE_TOOL, "upload")
+    assert not commands(calls, "buildkite-agent")
+
+
+def test_unexpected_cached_image_ref_is_not_published(release_build):
+    result, calls = release_build(CACHE_STATUS="hit", CACHED_DIGEST="mutable-tag")
+
+    assert result.returncode == 1
+    assert "refusing unexpected ROCm base image ref" in result.stderr
+    assert not commands(calls, "buildkite-agent")
+
+
+def test_overrides_remain_literal_and_release_defaults_stay_pinned(
+    release_build, tmp_path: Path
+):
+    arch = "gfx942;$(touch injected); gfx90a"
+    result, calls = release_build(
+        ROCM_BASE_PYTORCH_ROCM_ARCH=arch,
+        PYTORCH_ROCM_ARCH="ignored",
+        SCCACHE_ENDPOINT="http://localhost:9000",
+        SCCACHE_VERSION="v1.2.3",
+        SCCACHE_DOWNLOAD_SHA256="5" * 64,
+        SCCACHE_DOWNLOAD_URL="https://user:secret@example.test/download",
+        SCCACHE_BUCKET_NAME="ignored",
+        SCCACHE_REGION_NAME="ignored",
+        SCCACHE_S3_NO_CREDENTIALS="1",
+        ROCM_BASE_PARENT_DIGEST="ignored",
+    )
+
+    assert result.returncode == 0, result.stderr
+    for build in commands(calls, "docker", "buildx", "build"):
+        args = build_args(build)
+        assert args["PYTORCH_ROCM_ARCH"] == arch
+        assert args["SCCACHE_ENDPOINT"] == "http://localhost:9000"
+        assert args["SCCACHE_VERSION"] == "v1.2.3"
+        assert args["SCCACHE_DOWNLOAD_SHA256"] == "5" * 64
+        assert args["SCCACHE_BUCKET_NAME"] == "vllm-build-sccache"
+        assert args["SCCACHE_REGION_NAME"] == "us-west-2"
+        assert args["SCCACHE_S3_NO_CREDENTIALS"] == "0"
+        assert "SCCACHE_DOWNLOAD_URL" not in args
+    parent = commands(calls, CACHE_TOOL, "parent")
+    assert len(parent) == 1
+    assert "ROCM_BASE_PARENT_DIGEST" not in parent[0]["env"]
+    key_env = commands(calls, CACHE_TOOL, "key")[0]["env"]
+    assert key_env["ROCM_BASE_PARENT_DIGEST"] == PARENT_DIGEST
+    assert key_env["PYTORCH_ROCM_ARCH"] == arch
+    assert "SCCACHE_DOWNLOAD_URL" not in key_env
+    assert not (tmp_path / "injected").exists()
+    assert "secret" not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://user:secret@example.test",
+        "https://example.test?secret=token",
+        "https://example.test#secret",
+        "https://example.test secret",
+        "https://example.test\nsecret",
+        "https://example.test\rsecret",
+        "https://example.test\tsecret",
+    ],
+)
+def test_private_endpoint_is_rejected_before_external_calls(release_build, endpoint):
+    result, calls = release_build(SCCACHE_ENDPOINT=endpoint)
+
+    assert result.returncode == 1
+    assert "SCCACHE_ENDPOINT must not contain" in result.stderr
+    assert "secret" not in result.stdout + result.stderr
+    assert not calls
+
+
+def test_invalid_force_value_stops_before_external_calls(release_build):
+    result, calls = release_build(ROCM_BASE_WHEEL_CACHE_FORCE="yes")
+
+    assert result.returncode == 1
+    assert "ROCM_BASE_WHEEL_CACHE_FORCE must be 0 or 1" in result.stderr
+    assert not calls


### PR DESCRIPTION
Add regression coverage for the ROCm image dependency and cache fixes in #55093. This PR is stacked on `akaratza_deps_bugfix`; review and merge #55093 first.

- Extend `tests/tools/test_docker_build_metadata_args.py` with dependency-lock, cache-key/manifest, forced-refresh, digest-handoff, TorchCodec, and literal build-argument coverage.
- Add `tests/tools/test_rocm_release_build.py` to exercise release cache hits/misses, rebuilds, failures, and cleanup with fake Docker/AWS/cache commands.
- Update the CPU and AMD Buildkite metadata jobs and file triggers to run both suites.

AI assistance was used to split the existing changes, validate the two branches, and draft this description.
