### PR TITLE
Read the activation declaration on the MXFP4 path, as the NVFP4 branch does

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -1019,3 +1019,112 @@ def test_compressed_tensors_mxfp4(vllm_runner):
         llm.apply_model(check_model)
         output = llm.generate_greedy("Hello my name is", max_tokens=4)
         assert output
+
+
+def _mxfp4_args(num_bits: int = 4, group_size: int = 32) -> QuantizationArgs:
+    return QuantizationArgs(
+        num_bits=num_bits,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.GROUP.value,
+        symmetric=True,
+        dynamic=True,
+        group_size=group_size,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_quant,capability,expect_warning",
+    [
+        # weight-only was declared and weight-only is what runs
+        pytest.param(None, 80, False, id="no_activation_declaration"),
+        # W4A4 declared, realized weight-only below SM100
+        pytest.param(_mxfp4_args(), 80, True, id="mxfp4_activations_sm80"),
+        pytest.param(_mxfp4_args(), 90, True, id="mxfp4_activations_sm90"),
+        # W4A4 declared and realizable, so nothing is reported
+        pytest.param(_mxfp4_args(), 100, False, id="mxfp4_activations_sm100"),
+        # an activation format the MXFP4 path does not apply
+        pytest.param(
+            QuantizationArgs(
+                num_bits=8,
+                type=QuantizationType.FLOAT,
+                strategy=QuantizationStrategy.TENSOR.value,
+                symmetric=True,
+                dynamic=True,
+            ),
+            100,
+            True,
+            id="non_mxfp4_activations",
+        ),
+    ],
+)
+def test_mxfp4_activation_declaration_is_reported(
+    input_quant, capability, expect_warning, caplog, monkeypatch, disable_log_dedup
+):
+    """An MXFP4 artifact whose activation declaration is not realized is reported.
+
+    The MXFP4 scheme is true W4A4 only on SM100+ with FlashInfer and W4A16
+    weight-only otherwise, while `get_min_capability()` returns 80. Reading the
+    declaration makes that difference visible at load time; it does not change
+    which scheme is selected or whether the artifact is accepted.
+    """
+    monkeypatch.setattr(
+        CompressedTensorsConfig,
+        "_check_scheme_supported",
+        staticmethod(
+            lambda min_capability, error=True, match_exact=False: (
+                capability >= min_capability
+            )
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        CompressedTensorsConfig._warn_on_unrealized_mxfp4_activations(input_quant)
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert bool(warnings) is expect_warning
+    if expect_warning:
+        assert "weight-only" in warnings[0]
+
+
+@pytest.mark.parametrize(
+    "input_quant,expect_warning",
+    [
+        pytest.param(None, False, id="no_activation_declaration"),
+        pytest.param(_mxfp4_args(), True, id="mxfp4_activations"),
+    ],
+)
+def test_mxfp4_branch_reports_but_still_selects_the_same_scheme(
+    input_quant, expect_warning, caplog, monkeypatch, disable_log_dedup
+):
+    """The MXFP4 branch reads the declaration and selects the scheme it always did.
+
+    The scheme is stubbed because constructing the real one requires an MXFP4
+    linear kernel. What is under test is the branch: that it consults the
+    activation declaration, and that doing so changes neither which scheme is
+    returned nor whether the artifact is accepted.
+    """
+    import vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors as ct_module  # noqa: E501
+
+    class StubMxfp4Scheme:
+        pass
+
+    monkeypatch.setattr(ct_module, "CompressedTensorsW4A4Mxfp4", StubMxfp4Scheme)
+    monkeypatch.setattr(
+        CompressedTensorsConfig,
+        "_check_scheme_supported",
+        staticmethod(lambda min_capability, error=True, match_exact=False: False),
+    )
+    config = CompressedTensorsConfig(
+        target_scheme_map={}, ignore=[], quant_format="mxfp4-pack-quantized"
+    )
+
+    with caplog.at_level("WARNING"):
+        scheme = config._get_scheme_from_parts(
+            weight_quant=_mxfp4_args(),
+            input_quant=input_quant,
+            format="mxfp4-pack-quantized",
+        )
+
+    assert isinstance(scheme, StubMxfp4Scheme)
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert bool(warnings) is expect_warning

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -719,6 +719,47 @@ class CompressedTensorsConfig(QuantizationConfig):
             and is_per_token_or_group_input
         )
 
+    @classmethod
+    def _warn_on_unrealized_mxfp4_activations(
+        cls, input_quant: QuantizationArgs | None
+    ) -> None:
+        """
+        Report an MXFP4 artifact whose activation declaration this configuration
+        does not realize.
+
+        `CompressedTensorsW4A4Mxfp4` is true W4A4 only on SM100+ with FlashInfer
+        and W4A16 weight-only via Marlin otherwise, as its own docstring records,
+        while its `get_min_capability()` returns 80. An artifact declaring
+        quantized activations is therefore admitted from sm_80 up and served
+        weight-only below SM100.
+
+        This reports that difference and changes nothing about it: no artifact is
+        refused, no scheme selection changes, and the model loads exactly as
+        before. The check is conservative -- it reports only the cases that are
+        weight-only for certain, so SM100+ without FlashInfer is not reported.
+        """
+        if input_quant is None:
+            # Weight-only was declared and weight-only is what runs.
+            return
+
+        if not cls._is_mxfp4(input_quant):
+            logger.warning_once(
+                "This checkpoint declares %d-bit input activation quantization "
+                "alongside MXFP4 weights. The MXFP4 scheme quantizes activations "
+                "to MXFP4 or not at all, so the declared activation format is not "
+                "applied and these layers run weight-only.",
+                input_quant.num_bits,
+            )
+            return
+
+        if not cls._check_scheme_supported(100, error=False):
+            logger.warning_once(
+                "This checkpoint declares MXFP4 input activations (W4A4), but "
+                "dynamic activation quantization requires SM100+ with FlashInfer. "
+                "On this device these layers run W4A16 weight-only via Marlin; "
+                "the weights are as declared, the activations are not quantized."
+            )
+
     def _get_scheme_from_parts(
         self,
         weight_quant: QuantizationArgs,
@@ -743,6 +784,11 @@ class CompressedTensorsConfig(QuantizationConfig):
             return CompressedTensorsW4A4Fp4()
 
         if self._is_mxfp4(weight_quant):
+            # Read the activation declaration here for the same reason the NVFP4
+            # branch above reads it: the two declarations name different
+            # realizations. Unlike that branch this only reports the difference;
+            # the artifact is still accepted and the scheme is unchanged.
+            self._warn_on_unrealized_mxfp4_activations(input_quant)
             return CompressedTensorsW4A4Mxfp4()
 
         if self._is_mxfp8(weight_quant):


### PR DESCRIPTION
## Purpose

Inside `_get_scheme_from_parts`, the NVFP4 branch reads the artifact's activation declaration:

```python
if self._is_nvfp4_format(weight_quant):
    if input_quant is None:
        return CompressedTensorsW4A4Fp4(use_a16=True)

    if not self._is_nvfp4_format(input_quant):
        raise ValueError(
            "For NVFP4 weights, input quantization must also be NVFP4 "
            "format, None for NVFP4A16"
        )
    return CompressedTensorsW4A4Fp4()
```

Eleven lines later, the MXFP4 branch dispatches on the weight declaration alone:

```python
if self._is_mxfp4(weight_quant):
    return CompressedTensorsW4A4Mxfp4()
```

So an artifact declaring MXFP4 weights **and** MXFP4 activations, and an artifact declaring MXFP4 weights and no activation quantization at all, take the same path and produce the same scheme.

What that scheme then does is already documented, by the scheme itself:

> On SM100+ with FlashInfer: true W4A4 (activations dynamically quantized). Otherwise: W4A16 weight-only via Marlin.

and `CompressedTensorsW4A4Mxfp4.get_min_capability()` returns `80`, so the artifact is admitted from sm_80 up. On sm_80–sm_90 a checkpoint that declares quantized activations is served weight-only.

**Nothing here is incorrect and no checkpoint is being called into question.** The substitution is deliberate, it is the reason `get_min_capability()` is 80 rather than 100, and it is written down in the class docstring. The weights are exactly as declared. This is a request about what the loader *says*, not about what it does: today the only place that substitution is visible is the source, and a user who chose MXFP4 for its activation quantization and is running on A100 or H100 gets the weight-only realization with nothing in the log to distinguish it from the W4A4 they asked for.

This reads the declaration on the MXFP4 path and reports the difference.

**What this deliberately does not do.** It does not refuse the artifact, does not raise, does not change scheme selection, and does not change what any model does. That is a weaker ask than full consistency with the neighbouring branch — NVFP4 raises where this only reports — and the asymmetry is intentional rather than an oversight: refusing an artifact that loads today is a much larger change than this is asking for, and I would rather land the declaration being read than argue about fail-closed. If you would prefer it stricter, that is easy to change and I would rather you choose it than have me assume it.

**On the cost, stated plainly:** this is the consumer side, so it can put a new warning in the logs of models that load cleanly today — specifically MXFP4 checkpoints that declare activation quantization running below SM100. That is a real cost. The check is deliberately conservative to bound it: `input_quant is None` is silent because weight-only was declared and weight-only is what runs, and SM100+ is silent because W4A4 may well be realized there. Only the cases that are weight-only for certain are reported, and `warning_once` means at most one line per distinct declaration rather than one per layer.

## Test Plan

`tests/quantization/test_compressed_tensors.py`:

- `test_mxfp4_activation_declaration_is_reported` — parametrized over the declaration and the device capability: no activation declaration is silent; MXFP4 activations on sm_80 and sm_90 are reported; MXFP4 activations on SM100 are silent; an activation format the MXFP4 path does not apply is reported.
- `test_mxfp4_branch_reports_but_still_selects_the_same_scheme` — the branch consults the declaration and returns the same scheme either way, so reading it changes neither the selection nor whether the artifact is accepted.

Both use the existing `disable_log_dedup` fixture, since `warning_once` is `lru_cache`d.

```
pytest tests/quantization/test_compressed_tensors.py
```

## Test Result

7 new tests pass. I verified `test_mxfp4_branch_reports_but_still_selects_the_same_scheme` fails without the call site in the MXFP4 branch and passes with it, so the wiring is covered rather than only the helper.

`ruff check` and `ruff format --check` clean on both files.

My host is CPU-only with no compiled vLLM, so the model-loading tests in this file cannot run here. Rather than report a filtered number, I ran the whole file on this branch and on `main` and compared:

| | passed | failed | skipped | errors |
|---|---|---|---|---|
| `main` | 33 | 3 | 11 | 8 |
| this branch | **40** | 3 | 11 | 8 |

Identical failures and errors on both — all of them device or model-loading (`RuntimeError: Device string must not be empty`, and `vllm_runner` fixture setup) — and exactly +7, the new tests. No regressions introduced. The GPU paths still need CI.

---

*Disclosure: this change was written with AI assistance. I have read and understand every line, and I am responsible for it.*
