### PR TITLE
[Perf] Tune batch-invariant matmul for Granite on Ada

### DIFF
--- a/vllm/model_executor/determinism/batch_invariant_configs.py
+++ b/vllm/model_executor/determinism/batch_invariant_configs.py
@@ -24,6 +24,55 @@ _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS: dict[
     str, dict[tuple[int, int], _MatmulShapeConfig]
 ] = {
     "ada": {
+        (3376, 768): _MatmulShapeConfig(
+            block_k=64,
+            m_buckets=(
+                (64, _MatmulMConfig(16, 64, 4, 3)),
+                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
+            ),
+        ),
+        (768, 1536): _MatmulShapeConfig(
+            block_k=64,
+            m_buckets=(
+                (64, _MatmulMConfig(16, 64, 4, 3)),
+                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
+            ),
+        ),
+        (4096, 768): _MatmulShapeConfig(
+            block_k=64,
+            m_buckets=(
+                (64, _MatmulMConfig(16, 64, 4, 3)),
+                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
+            ),
+        ),
+        (768, 2048): _MatmulShapeConfig(
+            block_k=64,
+            m_buckets=(
+                (64, _MatmulMConfig(16, 64, 4, 3)),
+                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
+            ),
+        ),
+        (1280, 768): _MatmulShapeConfig(
+            block_k=64,
+            m_buckets=(
+                (64, _MatmulMConfig(16, 64, 4, 3)),
+                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
+            ),
+        ),
+        (768, 768): _MatmulShapeConfig(
+            block_k=64,
+            m_buckets=(
+                (64, _MatmulMConfig(16, 64, 4, 3)),
+                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
+            ),
+        ),
+        (100352, 768): _MatmulShapeConfig(
+            block_k=64,
+            m_buckets=(
+                (64, _MatmulMConfig(16, 64, 4, 3)),
+                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
+            ),
+        ),
         (12288, 2048): _MatmulShapeConfig(
             block_k=64,
             m_buckets=(

--- a/vllm/model_executor/determinism/batch_invariant_configs.py
+++ b/vllm/model_executor/determinism/batch_invariant_configs.py
@@ -24,54 +24,21 @@ _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS: dict[
     str, dict[tuple[int, int], _MatmulShapeConfig]
 ] = {
     "ada": {
-        (3376, 768): _MatmulShapeConfig(
-            block_k=64,
-            m_buckets=(
-                (64, _MatmulMConfig(16, 64, 4, 3)),
-                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
-            ),
-        ),
         (768, 1536): _MatmulShapeConfig(
             block_k=64,
-            m_buckets=(
-                (64, _MatmulMConfig(16, 64, 4, 3)),
-                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
-            ),
-        ),
-        (4096, 768): _MatmulShapeConfig(
-            block_k=64,
-            m_buckets=(
-                (64, _MatmulMConfig(16, 64, 4, 3)),
-                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
-            ),
+            m_buckets=((2147483647, _MatmulMConfig(64, 64, 4, 4)),),
         ),
         (768, 2048): _MatmulShapeConfig(
             block_k=64,
-            m_buckets=(
-                (64, _MatmulMConfig(16, 64, 4, 3)),
-                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
-            ),
+            m_buckets=((2147483647, _MatmulMConfig(64, 64, 4, 4)),),
         ),
         (1280, 768): _MatmulShapeConfig(
             block_k=64,
-            m_buckets=(
-                (64, _MatmulMConfig(16, 64, 4, 3)),
-                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
-            ),
+            m_buckets=((2147483647, _MatmulMConfig(64, 64, 4, 4)),),
         ),
         (768, 768): _MatmulShapeConfig(
             block_k=64,
-            m_buckets=(
-                (64, _MatmulMConfig(16, 64, 4, 3)),
-                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
-            ),
-        ),
-        (100352, 768): _MatmulShapeConfig(
-            block_k=64,
-            m_buckets=(
-                (64, _MatmulMConfig(16, 64, 4, 3)),
-                (2147483647, _MatmulMConfig(128, 128, 8, 3)),
-            ),
+            m_buckets=((2147483647, _MatmulMConfig(64, 64, 4, 4)),),
         ),
         (12288, 2048): _MatmulShapeConfig(
             block_k=64,


### PR DESCRIPTION
## Summary

Add shape-wide BF16 batch-invariant persistent-matmul configs for four linear shapes used by Granite-4.0-H-350M on Ada:

- `(N=768, K=1536)`
- `(N=768, K=2048)`
- `(N=1280, K=768)`
- `(N=768, K=768)`

All four use `BLOCK_M=64`, `BLOCK_N=64`, `BLOCK_K=64`, 4 warps, and 4 stages for every M. Keeping one config per weight shape preserves a fixed K-reduction order and lets the existing Triton call remain inline under `torch.compile`; this patch does not require runtime-M dispatch or depend on #54503.

Related to the batch-invariance performance work in #27433. Separate from Mamba2 correctness/support in #54993.

## Why a shape-wide config

The first draft used a small-M bucket for seven Granite shapes. Whole-model testing showed that runtime dispatch could recover decode performance, but the custom-op path added measurable fixed host overhead and still regressed longer-prefill workloads.

I therefore swept for one config that was safe across the full tested M range. Four shapes had a single configuration that beat the existing fallback at every tested M. The other three Granite shapes—`(3376, 768)`, `(4096, 768)`, and `(100352, 768)`—remain on the existing fallback because the sweep did not find a meaningful shape-wide improvement.

## Experiments

Hardware and model: RTX 4090 (sm89), Granite-4.0-H-350M BF16, TP1, compiled mode, async scheduling, prefix caching disabled, seed 42, `max_num_seqs=32`, `gpu_memory_utilization=0.25`.

### Operator sweep

Each of 17 candidate configs was tested at `M in {1, 32, 64, 256, 1024, 4096}`. Outputs had to match the original batch-invariant kernel bitwise. Ratios below are candidate/original kernel time; lower is better.

| `(N, K)` | M=32 | M=1024 | M=4096 |
| --- | ---: | ---: | ---: |
| `(768, 1536)` | 0.321 | 0.597 | 0.876 |
| `(768, 2048)` | 0.310 | 0.589 | 0.874 |
| `(1280, 768)` | 0.356 | 0.864 | 0.982 |
| `(768, 768)` | 0.349 | 0.607 | 0.891 |

The selected config was no slower than the original fallback at any tested M for these four shapes.

### Whole-model throughput

Each arm used two independent engine lifetimes in baseline/candidate/candidate/baseline order, with 16 warmup requests. Values are whole-workload completion time reported by `vllm bench throughput`, excluding engine startup; they are not per-request latency percentiles.

| Input / output tokens | Requests | Token budget | Original BI | Candidate BI | Completion-time change |
| --- | ---: | ---: | ---: | ---: | ---: |
| 128 / 256 | 64 | 1024 | 3.4533 s | 2.3578 s | -31.7% |
| 2048 / 64 | 64 | 1024 | 4.3632 s | 4.2143 s | -3.4% |
| 8192 / 1 | 16 | 4096 | 1.0988 s | 1.0850 s | -1.3% |

Both arms ran on the same experimental tree. The candidate overrode only the four shape configs in-process; because those shapes were not registered for runtime dispatch in that tree, both arms followed the existing compiled inline Triton path.

Benchmark command template:

```bash
VLLM_BATCH_INVARIANT=1 VLLM_USE_FLASHINFER_SAMPLER=0 \
.venv/bin/python -m vllm.entrypoints.cli.main bench throughput \
  --model <Granite-4.0-H-350M checkpoint> --dtype bfloat16 \
  --dataset-name random --random-input-len <input> --random-output-len <output> \
  --random-range-ratio 0 --num-prompts <requests> --num-warmups 16 \
  --max-model-len <max(512,input+output)> --max-num-seqs 32 \
  --max-num-batched-tokens <budget> --enable-chunked-prefill \
  --no-enable-prefix-caching --async-scheduling --gpu-memory-utilization 0.25 \
  --disable-detokenize --seed 42 --output-json <result.json>
```

## Correctness and checks

- Seven Granite shapes, `M in {1, 32, 64, 256, 1024, 4096}`: every candidate included in the sweep matched the original BF16 kernel bitwise.
- Real-model needle prompts of 128, 257, and 513 tokens, alone versus slot 7 in a 32-request mixed batch: generated token IDs and selected-token FP32 logprob bits matched bitwise.
- The same three real-model hashes also matched between the original and selected configs.
- Config selection at M=1 and M=4096 resolves to the same launch config for all four added shapes; the three rejected shapes remain absent from the table.
- `ruff check` and `ruff format --check` pass for the changed file.

## Scope and remaining validation

This is a config-only Ada result from one RTX 4090 and one Granite model. It does not yet establish gains on other Ada GPUs or models, TP>1, eager serving, quantized dtypes, or production request distributions. CI and independent hardware validation are still needed before merge.

## Non-duplication and AI assistance

#53247 introduced the per-architecture tuning mechanism; this draft extends its Ada table to different Granite shapes. It does not replace that mechanism and no longer depends on #54503. Related #49131 targets SM80 and #53446 targets Hopper.

AI assistance (Codex) was used for experiment scripts, running tests, analyzing traces, drafting the configuration entries, and preparing this description. The results and final diff remain subject to human review.
