### PR TITLE
[Security] Drop leftover NIXL empty-recv metadata

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -40,9 +40,13 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlAgentMetadata,
     NixlConnectorMetadata,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_worker import (
+    NixlPullConnectorWorker,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
     NixlPushConnectorWorker,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import ReadSpec
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
     get_base_request_id,
 )
@@ -545,6 +549,79 @@ class TestPushWriterStartLoadKv:
         assert w._push_writer_wake.is_set()
         assert w.start_push_calls == []
 
+    def test_start_load_kv_empty_recv_does_not_persist_metadata(self):
+        """Abort-before-schedule empty recvs must not stay in
+        _recving_metadata: no WRITE will complete, so get_finished would
+        never pop them, and reporting them as finished_recving would trip
+        the scheduler assert on a request it is not holding."""
+        w = _StubWriterWorker.fresh()
+        w._send_heartbeats = lambda metadata: None
+        w._logical_to_kernel_block_ids = lambda x, ratio: x
+
+        meta = NixlConnectorMetadata()
+        meta.add_new_req_to_recv(
+            "req-abort",
+            [],
+            {
+                "remote_block_ids": (),
+                "remote_engine_id": "prefill-engine",
+                "remote_request_id": "prefill-req-abort",
+                "remote_host": "10.0.0.1",
+                "remote_port": 5601,
+            },
+        )
+        w.start_load_kv(meta)
+
+        assert "req-abort" not in w._recving_metadata
+        assert "req-abort" not in w._recving_transfers
+
+    def test_start_load_kv_repeated_empty_recvs_do_not_grow_metadata(self):
+        """Sequential empty recvs must not accumulate worker metadata."""
+        w = _StubWriterWorker.fresh()
+        w._send_heartbeats = lambda metadata: None
+        w._logical_to_kernel_block_ids = lambda x, ratio: x
+
+        for i in range(8):
+            meta = NixlConnectorMetadata()
+            meta.add_new_req_to_recv(
+                f"req-{i}",
+                [],
+                {
+                    "remote_block_ids": (),
+                    "remote_engine_id": "prefill-engine",
+                    "remote_request_id": f"prefill-req-{i}",
+                    "remote_host": "10.0.0.1",
+                    "remote_port": 5601,
+                },
+            )
+            w.start_load_kv(meta)
+
+        assert w._recving_metadata == {}
+        assert dict(w._recving_transfers) == {}
+
+    def test_start_load_kv_nonempty_recv_still_tracks_metadata(self):
+        """A real D-side recv with local blocks is still tracked until the
+        producer WRITE completes."""
+        w = _StubWriterWorker.fresh()
+        w._send_heartbeats = lambda metadata: None
+        w._logical_to_kernel_block_ids = lambda x, ratio: x
+
+        meta = NixlConnectorMetadata()
+        meta.add_new_req_to_recv(
+            "req-live",
+            ([1, 2],),
+            {
+                "remote_block_ids": (),
+                "remote_engine_id": "prefill-engine",
+                "remote_request_id": "prefill-req-live",
+                "remote_host": "10.0.0.1",
+                "remote_port": 5601,
+            },
+        )
+        w.start_load_kv(meta)
+
+        assert "req-live" in w._recving_metadata
+
     def test_noncanonical_pcp_rank_skips_producer_work(self):
         w = _StubWriterWorker.fresh()
         w.pcp_rank = 1
@@ -840,6 +917,28 @@ class TestPushSchedulerNegative:
         assert "req-empty" not in sched._finished_request_blocks
         assert "req-empty" not in sched._newly_finished_push_blocks
         assert "req-empty" not in sched._reqs_need_send
+
+    def test_request_finished_aborted_remote_prefill_enqueues_empty_recv(
+        self,
+    ):
+        """A D-side request aborted before alloc still enqueues an empty recv
+        so the worker can release the prefiller, and consumes do_remote_prefill
+        so the recv is not re-issued."""
+        from vllm.v1.request import RequestStatus
+
+        sched = make_nixl_push_scheduler()
+        request = _make_request(request_id="req-abort")
+        request.status = RequestStatus.FINISHED_ABORTED
+
+        delay, ret = sched.request_finished(request, ([],))
+
+        assert delay is False
+        assert ret is None
+        assert "req-abort" in sched._reqs_need_recv
+        _, block_ids, _ = sched._reqs_need_recv["req-abort"]
+        assert block_ids == []
+        assert request.kv_transfer_params["do_remote_prefill"] is False
+        assert request.kv_transfer_params["remote_block_ids"] == ()
 
     def test_update_connector_output_unknown_request_is_noop(self):
         """Idempotent cleanup: clearing a request that was never staged
@@ -1404,3 +1503,65 @@ class TestPushPrefixCaching:
         local, remote = self._written_block_ids(w)
         assert local == [10, 11, 12]
         assert remote == [500, 501, 502]
+
+
+def _stub_pull_worker() -> NixlPullConnectorWorker:
+    """Minimal pull worker for the empty-recv notify path."""
+    w = object.__new__(NixlPullConnectorWorker)
+    w.transfer_topo = MagicMock()
+    remote_info = MagicMock()
+    remote_info.remote_block_size = 16
+    w.transfer_topo.get_engine_info.return_value = remote_info
+    w.transfer_topo.block_size_ratio.return_value = 1
+    w._remote_agents = {"eng": {(0, 0): "agent"}}
+    w.nixl_wrapper = MagicMock()
+    w.xfer_stats = MagicMock()
+    w._recving_transfers = {}
+    w._recving_metadata = {}
+    return w
+
+
+class TestPullEmptyRecv:
+    def test_empty_recv_drops_metadata_without_registering_transfer(self):
+        """Notify-only empty recvs must not stay in _recving_metadata.
+
+        No transfer handle is registered, so get_finished would never pop
+        them, and reporting them as done_recving would trip the scheduler
+        assert on a request it is not holding.
+        """
+        w = _stub_pull_worker()
+        w._recving_metadata["req"] = MagicMock()
+
+        w._read_blocks(
+            read_spec=ReadSpec(remote_rank=0, local_block_ids=(), remote_block_ids=()),
+            dst_engine_id="eng",
+            request_id="req",
+            remote_request_id="prefill-req",
+            local_xfer_side_handle=1,
+            remote_xfer_side_handle=1,
+            expected_consumers=1,
+        )
+
+        w.nixl_wrapper.send_notif.assert_called_once()
+        assert "req" not in w._recving_metadata
+        assert "req" not in w._recving_transfers
+
+    def test_empty_recv_keeps_metadata_when_transfer_already_registered(self):
+        """A seeded empty transfer list (prefix-hit / DCP) still needs
+        metadata until get_finished reports the request."""
+        w = _stub_pull_worker()
+        w._recving_metadata["req"] = MagicMock()
+        w._recving_transfers["req"] = []
+
+        w._read_blocks(
+            read_spec=ReadSpec(remote_rank=0, local_block_ids=(), remote_block_ids=()),
+            dst_engine_id="eng",
+            request_id="req",
+            remote_request_id="prefill-req",
+            local_xfer_side_handle=1,
+            remote_xfer_side_handle=1,
+            expected_consumers=1,
+        )
+
+        assert "req" in w._recving_metadata
+        assert w._recving_transfers["req"] == []

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -387,6 +387,12 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     remote_agent_name=agent_name,
                 )
                 self.xfer_stats.record_failed_notification()
+            # Empty recvs that never registered a transfer (abort-before-
+            # schedule notify-only) must not stay in _recving_metadata: no
+            # handle will complete, and reporting them via get_finished
+            # trips the scheduler assert on a request it is not holding.
+            if request_id not in self._recving_transfers:
+                self._recving_metadata.pop(request_id, None)
             return True
 
         if read_spec.block_ids_by_region:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -184,6 +184,12 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 len(meta.local_physical_block_ids),
                 len(meta.remote.block_ids),
             )
+            # Abort-before-schedule empty recv: no WRITE will complete, so
+            # get_finished would never pop this entry. Do not persist it, and
+            # do not report finished_recving (the request is already gone
+            # from the scheduler).
+            if not any(len(group) > 0 for group in meta.local_block_ids):
+                continue
             self._recving_metadata[req_id] = meta
 
         # --- D-side: registrations to send to P via NIXL ---


### PR DESCRIPTION
## Summary

When a decode-side request is rejected before scheduling, NIXL still enqueues an empty recv so the prefiller can be released. The push worker stored that recv in `_recving_metadata` even though no WRITE will ever complete, so `get_finished` never popped the entry and the dict grew without bound. Reporting the request as `finished_recving` would also trip the scheduler assert on a request that is already gone.

This change drops empty abort recvs from worker tracking without reporting them as finished. Pull's notify-only empty path is the same leftover: after the producer notification, metadata is popped unless a transfer list was already seeded (prefix-hit / DCP).

This is not a duplicate of the open prefix-cache-hit finished-recving work: that path must still be reported when the scheduler is waiting. Notify-only abort recvs must not.

## Changes

- `push_worker.py`: do not persist `_recving_metadata` for recvs with no local blocks.
- `pull_worker.py`: after the empty-block notify, pop `_recving_metadata` unless `_recving_transfers` already has an entry.
- `test_nixl_push_connector.py`: regression and completeness coverage for both workers.

## Codepath coverage

- `/v1/completions`, `/v1/chat/completions`, `/v1/responses` (and SageMaker `/invocations` via the same serving wrapper) → KV rejection cleanup → `abort_immediately` → NIXL `request_finished` empty recv → worker `start_load_kv` / `_read_blocks`. Fixed at the worker sink.
- Direct engine `abort_immediately` with `do_remote_prefill` still set. Fixed at the same sink.
- Push recvs that have local blocks are still tracked until the producer WRITE completes.
- Pull empty recvs that already seeded `_recving_transfers` keep metadata until `get_finished`.

## Tests

- `test_start_load_kv_empty_recv_does_not_persist_metadata`
- `test_start_load_kv_repeated_empty_recvs_do_not_grow_metadata`
- `test_start_load_kv_nonempty_recv_still_tracks_metadata`
- `test_request_finished_aborted_remote_prefill_enqueues_empty_recv`
- `test_empty_recv_drops_metadata_without_registering_transfer`
- `test_empty_recv_keeps_metadata_when_transfer_already_registered`

Commands run:

```
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_push_connector.py -v
.venv/bin/pre-commit run --files vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py tests/v1/kv_connector/unit/test_nixl_push_connector.py
```

Results: 50 passed; pre-commit passed.

## AI assistance

This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)