### PR TITLE
[XPU][Tests] Enable test_per_token_group_quant_int8 on XPU

### DIFF
--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -408,9 +408,12 @@ def test_per_token_group_quant_fp8_packed_large_mn():
 
 @pytest.mark.parametrize("shape", [(32, 128), (64, 256), (16, 512)])
 @pytest.mark.parametrize("group_size", [64, 128])
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
+    reason="Only test on CUDA/ROCm/XPU.",
+)
 def test_per_token_group_quant_int8(shape, group_size: int):
-    device = "cuda"
+    device = current_platform.device_type
 
     torch.manual_seed(42)
     num_tokens, hidden_dim = shape


### PR DESCRIPTION
## Summary
- `test_per_token_group_quant_int8` was gated on `torch.cuda.is_available()` and hardcoded `device="cuda"`, so it never ran on XPU even though `int8_utils.per_token_group_quant_int8` already has a Triton fallback for any non-CUDA-alike device 

## Test plan
- `pytest tests/kernels/quantization/test_per_token_group_quant.py::test_per_token_group_quant_int8 -v` on Intel Arc Pro B70 (XPU): **6 passed** (previously 6 skipped, "CUDA not available").
