### PR TITLE
[Quantization] Layer re-quantization for linear layers through online quantization API (MXFP8 -> FP8 PTPC showcase)

### DIFF
--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -99,6 +99,35 @@ vllm serve openai/gpt-oss-20b --quantization-config.moe.activation mxfp8
 
 Combine with `--moe-backend` to pin a specific kernel family.
 
+### Re-quantizing layers to a different precision
+
+An online target can re-quantize a checkpoint-quantized (prequantized) layer at load time.
+
+vLLM uses the checkpoint method to load and dequantize the checkpoint weight, and then applies the online quantization method. This requires the checkpoint
+method to implement weight dequantization, unsupported source and target
+combinations raise an error.
+
+Currently supported combinations are:
+
+| Checkpoint layer | Online target | Requirements |
+| ---------------- | ------------- | ------------ |
+| Serialized ModelOpt MXFP8 linear | any | Target-specific hardware requirements |
+
+For example, serialized ModelOpt MXFP8 linears can be converted to
+per-channel-weight/per-token-activation FP8 at load time:
+
+```bash
+vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
+  --linear-backend auto \
+  --quantization-config.linear fp8_per_channel
+```
+
+!!! info
+
+    This is only available for linear layers at the moment.
+    
+    Checkpoint-exclusion policy is not enforced by online quantization/re-quantization. Only exclusion through `--quantization-config.targets`/`--quantization-config.ignore` is enforced. 
+
 ### Online quantization on unquantized layers from partially-quantized checkpoints
 
 Online quantization can be used on already quantized checkpoints independently of their original `quant_method` (`modelopt`, `compressed-tensors`, `quark`, etc.), for layers that are left unquantized in the original checkpoint.

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -51,6 +51,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
 )
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
+    ModelOptLinearMethod,
     ModelOptMxFp8Config,
 )
 from vllm.model_executor.layers.quantization.online.base import (
@@ -204,6 +205,14 @@ def _fully_quantized_modelopt_config() -> ModelOptFp8Config:
     )
 
 
+def _fully_quantized_modelopt_mxfp8_config() -> ModelOptMxFp8Config:
+    return ModelOptMxFp8Config(
+        is_checkpoint_mxfp8_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=["lm_head"],
+    )
+
+
 def _moe_only_compressed_tensors_config() -> CompressedTensorsConfig:
     return CompressedTensorsConfig(
         target_scheme_map={"RoutedExperts": {}},
@@ -231,10 +240,19 @@ def _write_minimal_llama_config(
 
 
 @pytest.mark.parametrize(
-    "checkpoint_config_factory,raises_conflict",
+    "checkpoint_config_factory,raises_requantization_error",
     [
         pytest.param(_fully_quantized_quark_config, True, id="quark"),
-        pytest.param(_fully_quantized_modelopt_config, True, id="modelopt"),
+        pytest.param(
+            _fully_quantized_modelopt_config,
+            True,
+            id="modelopt",
+        ),
+        pytest.param(
+            _fully_quantized_modelopt_mxfp8_config,
+            False,
+            id="modelopt_mxfp8",
+        ),
         pytest.param(
             _moe_only_compressed_tensors_config,
             False,
@@ -242,9 +260,13 @@ def _write_minimal_llama_config(
         ),
     ],
 )
+@pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_rocm()),
+    reason="MXFP8 requantization requires CUDA or ROCm.",
+)
 def test_online_prequantized_compatibility(
     checkpoint_config_factory,
-    raises_conflict: bool,
+    raises_requantization_error: bool,
     default_vllm_config,
     dist_init,
 ) -> None:
@@ -267,35 +289,35 @@ def test_online_prequantized_compatibility(
         "disable_tp": True,
     }
 
-    if raises_conflict:
-        with pytest.raises(ValueError, match="pre-quantized layer"):
-            ColumnParallelLinear(**layer_kwargs)
+    layer = ColumnParallelLinear(**layer_kwargs)
+    assert isinstance(layer.quant_method, Mxfp8OnlineLinearMethod)
+
+    if layer.weight.is_meta:
+        # Weight loading.
+        layer = layer.to_empty(device=DEVICE)
+        for parameter in layer.parameters():
+            parameter.zero_()
     else:
-        layer = ColumnParallelLinear(**layer_kwargs)
+        layer = layer.to(device=DEVICE)
+
+    if raises_requantization_error:
+        with pytest.raises(
+            NotImplementedError,
+            match="does not implement dequantize_weight|only supported for MXFP8",
+        ):
+            layer.quant_method.process_weights_after_loading(layer)
+    else:
+        layer.quant_method.process_weights_after_loading(layer)
+
+    if isinstance(checkpoint_config, ModelOptMxFp8Config):
         assert isinstance(layer.quant_method, Mxfp8OnlineLinearMethod)
-
-
-def test_online_target_rejects_prequantized_layer(
-    default_vllm_config, dist_init
-) -> None:
-    """A targets match participates in checkpoint compatibility checks."""
-    default_vllm_config.model_config = ModelConfig()
-    prefix = "model.layers.0.self_attn.o_proj"
-    quant_config = _fully_quantized_quark_config()
-    quant_config.online_quantization_config = OnlineQuantizationConfig(
-        QuantizationConfigArgs(targets={prefix: "mxfp8"})
-    )
-
-    with pytest.raises(ValueError, match="pre-quantized layer"):
-        ColumnParallelLinear(
-            input_size=32,
-            output_size=32,
-            bias=False,
-            params_dtype=torch.bfloat16,
-            quant_config=quant_config,
-            prefix=prefix,
-            disable_tp=True,
+        assert not layer.quant_method.uses_meta_device
+        assert isinstance(
+            layer.quant_method.requantization_source, ModelOptLinearMethod
         )
+    elif not raises_requantization_error:
+        assert layer.quant_method.uses_meta_device
+        assert layer.quant_method.requantization_source is None
 
 
 def test_online_ignore_keeps_checkpoint_quantization_linear(
@@ -338,7 +360,10 @@ def test_online_quantization_rejects_prequantized_moe(
         QuantizationConfigArgs(linear="mxfp4", moe="mxfp4")
     )
 
-    with pytest.raises(ValueError, match="pre-quantized layer"):
+    with pytest.raises(
+        NotImplementedError,
+        match="Requantizing checkpoint-quantized MoE layers is not supported",
+    ):
         FusedMoEFactory(
             num_experts=4,
             top_k=2,
@@ -512,30 +537,33 @@ def test_checkpoint_quantization_rejects_online_shorthand(tmp_path) -> None:
     ("model_name,quant_scheme,online_quant_args,expected_linear_cls,expected_moe_cls"),
     [
         # simple case - quantization='fp8_per_tensor'
-        (
+        pytest.param(
             GRANITE_MODEL_NAME,
             "fp8_per_tensor",
             None,
             Fp8PerTensorOnlineLinearMethod,
             Fp8PerTensorOnlineMoEMethod,
+            id="fp8_per_tensor",
         ),
         # simple case - quantization='fp8_per_block'
-        (
+        pytest.param(
             GRANITE_MODEL_NAME,
             "fp8_per_block",
             None,
             Fp8PerBlockOnlineLinearMethod,
             Fp8PerBlockOnlineMoEMethod,
+            id="fp8_per_block",
         ),
-        (
+        pytest.param(
             GRANITE_MODEL_NAME,
             "fp8_per_channel",
             None,
             Fp8PtpcOnlineLinearMethod,
             Fp8PtpcOnlineMoEMethod,
+            id="fp8_per_channel",
         ),
         # quantization='online' with per-layer-kind overrides
-        (
+        pytest.param(
             GRANITE_MODEL_NAME,
             "online",
             {
@@ -544,9 +572,10 @@ def test_checkpoint_quantization_rejects_online_shorthand(tmp_path) -> None:
             },
             Fp8PerBlockOnlineLinearMethod,
             Fp8PerTensorOnlineMoEMethod,
+            id="per_layer_kind_overrides",
         ),
         # quantization='online' with per-layer target patterns
-        (
+        pytest.param(
             GRANITE_MODEL_NAME,
             "online",
             {
@@ -557,9 +586,10 @@ def test_checkpoint_quantization_rejects_online_shorthand(tmp_path) -> None:
             },
             Fp8PerBlockOnlineLinearMethod,
             Fp8PerTensorOnlineMoEMethod,
+            id="targets",
         ),
         # ignore with direct layer name
-        (
+        pytest.param(
             GRANITE_MODEL_NAME,
             "fp8_per_tensor",
             # qkv_proj is fused from q_proj/k_proj/v_proj. The shard regex
@@ -567,13 +597,15 @@ def test_checkpoint_quantization_rejects_online_shorthand(tmp_path) -> None:
             {"ignore": ["model.layers.1.self_attn.o_proj", "re:.*[qkv]_proj"]},
             Fp8PerTensorOnlineLinearMethod,
             Fp8PerTensorOnlineMoEMethod,
+            id="ignore",
         ),
-        (
+        pytest.param(
             GRANITE_MODEL_NAME,
             "mxfp4",
             None,
             Mxfp4OnlineLinearMethod,
             Mxfp4OnlineMoEMethod,
+            id="mxfp4",
         ),
         pytest.param(
             PARTIALLY_PREQUANTIZED_MODEL_NAME,
@@ -583,16 +615,22 @@ def test_checkpoint_quantization_rejects_online_shorthand(tmp_path) -> None:
             CompressedTensorsMoEMethod,
             id="partially_prequantized_checkpoint",
         ),
-    ],
-    ids=[
-        "fp8_per_tensor",
-        "fp8_per_block",
-        "fp8_per_channel",
-        "per_layer_kind_overrides",
-        "targets",
-        "ignore",
-        "mxfp4",
-        "partially_prequantized_checkpoint",
+        pytest.param(
+            PARTIALLY_PREQUANTIZED_MODEL_NAME,
+            None,
+            {"targets": {"model.layers.1.self_attn.o_proj": "mxfp8"}},
+            Mxfp8OnlineLinearMethod,
+            CompressedTensorsMoEMethod,
+            id="partially_prequantized_checkpoint",
+        ),
+        pytest.param(
+            "mgoin/Qwen3-0.6B-MXFP8",
+            None,
+            {"linear": "fp8_per_channel"},
+            Fp8PtpcOnlineLinearMethod,
+            None,
+            id="requantization_mxfp8_ptcp_fp8",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -683,11 +721,17 @@ def test_online_quantization(
     if model_name == PARTIALLY_PREQUANTIZED_MODEL_NAME:
         o_proj = model.model.layers[1].self_attn.o_proj
         moe = model.model.layers[0].mlp.experts
+    elif model_name == "mgoin/Qwen3-0.6B-MXFP8":
+        o_proj = model.model.layers[0].self_attn.o_proj
+        moe = None
     else:
         o_proj = model.model.layers[0].self_attn.o_proj
         moe = model.model.layers[0].block_sparse_moe.experts
+
     assert isinstance(o_proj.quant_method, expected_linear_cls)
-    assert isinstance(moe._quant_method, expected_moe_cls)
+
+    if moe is not None:
+        assert isinstance(moe._quant_method, expected_moe_cls)
 
     if model_name == PARTIALLY_PREQUANTIZED_MODEL_NAME and isinstance(
         o_proj.quant_method.kernel, MarlinMxfp8LinearKernel

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -106,6 +106,7 @@ from vllm.model_executor.models.granitemoe import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
+from vllm.utils.torch_utils import set_default_torch_dtype
 
 if current_platform.is_rocm():
     from vllm.platforms.rocm import on_gfx942, on_gfx950
@@ -320,6 +321,40 @@ def test_online_prequantized_compatibility(
         assert layer.quant_method.requantization_source is None
 
 
+@pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_rocm())
+    or not is_quant_method_supported("fp8"),
+    reason="Requires FP8 support on CUDA or ROCm.",
+)
+def test_online_block_fp8_requantization_removes_source_scales(
+    default_vllm_config, dist_init, workspace_init
+) -> None:
+    """Blockwise FP8 replaces MXFP8 scales with its own scale parameter."""
+    default_vllm_config.model_config = ModelConfig(dtype="bfloat16")
+    quant_config = _fully_quantized_modelopt_mxfp8_config()
+    quant_config.online_quantization_config = OnlineQuantizationConfig(
+        QuantizationConfigArgs(linear="fp8_per_block")
+    )
+    with set_default_torch_dtype(torch.bfloat16), torch.device(DEVICE):
+        layer = ColumnParallelLinear(
+            input_size=256,
+            output_size=256,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            quant_config=quant_config,
+            prefix="model.layers.0.self_attn.o_proj",
+            disable_tp=True,
+        )
+        with torch.no_grad():
+            layer.weight.fill_(1)
+            layer.weight_scale.fill_(127)  # E8M0 encoding of scale 1.
+
+        layer.quant_method.process_weights_after_loading(layer)
+
+        assert not hasattr(layer, "weight_scale")
+        assert layer.weight_scale_inv.numel() > 0
+
+
 def test_online_ignore_keeps_checkpoint_quantization_linear(
     default_vllm_config, dist_init, monkeypatch
 ):
@@ -350,14 +385,19 @@ def test_online_ignore_keeps_checkpoint_quantization_linear(
 
 
 def test_online_quantization_rejects_prequantized_moe(
-    default_vllm_config, dist_init
+    default_vllm_config, dist_init, monkeypatch
 ) -> None:
-    """Online linear and MoE quantization reject a pre-quantized MoE layer."""
+    """Reject pre-quantized MoE before constructing an online target backend."""
     default_vllm_config.model_config = ModelConfig()
     prefix = "model.layers.0.mlp.experts"
     quant_config = _fully_quantized_quark_config()
     quant_config.online_quantization_config = OnlineQuantizationConfig(
         QuantizationConfigArgs(linear="mxfp4", moe="mxfp4")
+    )
+    monkeypatch.setattr(
+        quant_config.online_quantization_config,
+        "get_quant_method",
+        lambda *args: pytest.fail("unsupported online backend must not be constructed"),
     )
 
     with pytest.raises(

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -81,6 +81,13 @@ class QuantizeMethodBase(ABC):
         """
         return
 
+    def dequantize_weight(self, layer: nn.Module) -> torch.Tensor:
+        """Materialize a serialized quantized weight for requantization."""
+        raise NotImplementedError(
+            f"The quantization method {type(self)} does not implement "
+            "dequantize_weight. Please open an issue."
+        )
+
 
 def method_has_implemented_embedding(method_class: type[QuantizeMethodBase]) -> bool:
     """
@@ -284,13 +291,19 @@ def resolve_quant_method(
         LinearBase,
         UnquantizedLinearMethod,
     )
+    from vllm.model_executor.layers.quantization.online.fp8 import OnlineLinearBase
+    from vllm.model_executor.layers.quantization.online.moe_base import (
+        OnlineMoEMethodBase,
+    )
 
     base_quant_method = quant_config.get_quant_method(layer, prefix)
     if quant_config.online_quantization_config is None:
+        # No online configuration: retain the checkpoint method.
         return base_quant_method
     # Online quantization currently supports only LinearBase and RoutedExperts.
     # Embeddings and ParallelLMHead retain their checkpoint quantization method.
     if not isinstance(layer, (LinearBase, RoutedExperts)):
+        # Online quantization only supports linear and routed MoE layers.
         return base_quant_method
 
     quant_config.online_quantization_config.packed_modules_mapping = (
@@ -302,14 +315,29 @@ def resolve_quant_method(
     online_target = quant_config.online_quantization_config.resolve_quant_method_cls(
         layer, prefix
     )
+
     if checkpoint_is_quantized:
-        if online_target is not None:
-            raise ValueError(
-                f"Cannot apply requested online quantization {online_target[3]} to "
-                f"pre-quantized layer {prefix}: {base_quant_method} was already "
-                "selected by the checkpoint quantization config."
-            )
-        return base_quant_method
+        if online_target is None:
+            # The checkpoint quant method is applied as there is no online override.
+            return base_quant_method
+
+        online_quant_method = quant_config.online_quantization_config.get_quant_method(
+            layer, prefix
+        )
+
+        assert base_quant_method is not None and not isinstance(
+            base_quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)
+        )
+
+        assert isinstance(online_quant_method, (OnlineLinearBase, OnlineMoEMethodBase))
+        online_quant_method.set_requantization_source(base_quant_method)
+
+        # The online method dequantizes the checkpoint method before requantizing.
+        return online_quant_method
+
     if online_target is None:
+        # The layer is unquantized and no online target applies.
         return base_quant_method
+
+    # Quantize an unquantized layer with the online method.
     return quant_config.online_quantization_config.get_quant_method(layer, prefix)

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -292,9 +292,6 @@ def resolve_quant_method(
         UnquantizedLinearMethod,
     )
     from vllm.model_executor.layers.quantization.online.fp8 import OnlineLinearBase
-    from vllm.model_executor.layers.quantization.online.moe_base import (
-        OnlineMoEMethodBase,
-    )
 
     base_quant_method = quant_config.get_quant_method(layer, prefix)
     if quant_config.online_quantization_config is None:
@@ -321,6 +318,11 @@ def resolve_quant_method(
             # The checkpoint quant method is applied as there is no online override.
             return base_quant_method
 
+        if isinstance(layer, RoutedExperts):
+            raise NotImplementedError(
+                "Requantizing checkpoint-quantized MoE layers is not supported."
+            )
+
         online_quant_method = quant_config.online_quantization_config.get_quant_method(
             layer, prefix
         )
@@ -329,7 +331,7 @@ def resolve_quant_method(
             base_quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)
         )
 
-        assert isinstance(online_quant_method, (OnlineLinearBase, OnlineMoEMethodBase))
+        assert isinstance(online_quant_method, OnlineLinearBase)
         online_quant_method.set_requantization_source(base_quant_method)
 
         # The online method dequantizes the checkpoint method before requantizing.

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -74,6 +74,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_BLOCK_SIZE,
     MXFP8_SCALE_DTYPE,
     MXFP8_VALUE_DTYPE,
+    dequant_mxfp8_to_bf16,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     FP4_DTYPE,
@@ -2434,6 +2435,17 @@ class ModelOptLinearMethod(LinearMethodBase):
         maybe_fuse_global_scales(layer)
         self.fmt.post_process(layer)
         self.kernel.process_weights_after_loading(layer)
+
+    def dequantize_weight(self, layer: torch.nn.Module) -> torch.Tensor:
+        """Reconstruct serialized weights for online requantization."""
+        if self.wkey.key is kMxfp8Static:
+            return dequant_mxfp8_to_bf16(
+                layer.weight.contiguous(), layer.weight_scale.contiguous()
+            )
+        else:
+            raise NotImplementedError(
+                "ModelOpt weight dequantization is only supported for MXFP8."
+            )
 
     def apply(self, layer, x, bias=None):
         return self.fmt.apply(

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -30,6 +30,7 @@ from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
 from vllm.model_executor.layers.linear import (
     LinearMethodBase,
 )
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.layers.quantization.online.moe_base import (
     OnlineMoEMethodBase,
 )
@@ -121,6 +122,12 @@ class OnlineLinearBase(LinearMethodBase):
     def __init__(self):
         self.out_dtype = torch.get_default_dtype()
         self.input_dtype = get_current_vllm_config().model_config.dtype
+        self.requantization_source: QuantizeMethodBase | None = None
+
+    def set_requantization_source(self, source_method: QuantizeMethodBase) -> None:
+        """Configure serialized-weight conversion before online quantization."""
+        self.requantization_source = source_method
+        self.uses_meta_device = False
 
     def create_weights(
         self,
@@ -132,6 +139,18 @@ class OnlineLinearBase(LinearMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        if self.requantization_source is not None:
+            self.requantization_source.create_weights(
+                layer,
+                input_size_per_partition,
+                output_partition_sizes,
+                input_size,
+                output_size,
+                params_dtype,
+                **extra_weight_attrs,
+            )
+            return
+
         output_size_per_partition = sum(output_partition_sizes)
         weight_loader = extra_weight_attrs.get("weight_loader")
         layer.logical_widths = output_partition_sizes
@@ -154,6 +173,12 @@ class OnlineLinearBase(LinearMethodBase):
         layer.register_parameter("weight", weight)
 
         initialize_online_processing(layer)
+
+    def get_weight_for_quantization(self, layer: Module) -> torch.Tensor:
+        """Return checkpoint weights materialized for online quantization."""
+        if self.requantization_source is None:
+            return layer.weight
+        return self.requantization_source.dequantize_weight(layer)
 
 
 class Fp8PerTensorOnlineLinearMethod(OnlineLinearBase):
@@ -209,10 +234,11 @@ class Fp8PerTensorOnlineLinearMethod(OnlineLinearBase):
             return
 
         layer.input_scale = None
-        amax = weight_amax(layer.weight).reshape(1)
+        weight = self.get_weight_for_quantization(layer)
+        amax = weight_amax(weight).reshape(1)
         amax = amax_for_tp_weight_quant(amax, _is_tp_sharded(layer))
         weight_scale = _fp8_scale(amax)
-        qweight, _ = ops.scaled_fp8_quant(layer.weight, scale=weight_scale)
+        qweight, _ = ops.scaled_fp8_quant(weight, scale=weight_scale)
 
         # Update layer with new values.
         replace_parameter(layer, "weight", qweight.t().data)
@@ -308,9 +334,10 @@ class Fp8PerBlockOnlineLinearMethod(OnlineLinearBase):
 
         layer.input_scale = None
         block_size = self.weight_block_size
+        weight = self.get_weight_for_quantization(layer)
 
         qweight, weight_scale_inv = per_block_cast_to_fp8(
-            layer.weight, block_size=block_size, use_ue8m0=False
+            weight, block_size=block_size, use_ue8m0=False
         )
 
         replace_parameter(layer, "weight", qweight.data)
@@ -391,12 +418,13 @@ class Fp8PtpcOnlineLinearMethod(OnlineLinearBase):
             return
 
         layer.input_scale = None
-        amax = weight_amax(layer.weight, dim=-1, keepdim=True)
+        weight = self.get_weight_for_quantization(layer)
+        amax = weight_amax(weight, dim=-1, keepdim=True)
         amax = amax_for_tp_weight_quant(
             amax, _is_tp_sharded(layer, reduces_output_dim=False)
         )
         weight_scale = _fp8_channel_scale(amax)
-        qweight = _fp8_quant_per_channel(layer.weight, weight_scale)
+        qweight = _fp8_quant_per_channel(weight, weight_scale)
 
         replace_parameter(layer, "weight", qweight.t())
         replace_parameter(layer, "weight_scale", weight_scale)

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -343,6 +343,9 @@ class Fp8PerBlockOnlineLinearMethod(OnlineLinearBase):
         replace_parameter(layer, "weight", qweight.data)
         replace_parameter(layer, "weight_scale_inv", weight_scale_inv.data)
 
+        if self.requantization_source is not None and hasattr(layer, "weight_scale"):
+            del layer.weight_scale
+
         self.fp8_linear.process_weights_after_loading(layer)
 
         # Prevent duplicate processing (e.g., during weight reload)

--- a/vllm/model_executor/layers/quantization/online/moe_base.py
+++ b/vllm/model_executor/layers/quantization/online/moe_base.py
@@ -11,6 +11,7 @@ from vllm.model_executor.layers.fused_moe import (
     SharedExperts,
 )
 from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
     initialize_online_processing,
 )
@@ -23,6 +24,12 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
     """
 
     uses_meta_device: bool = True
+
+    def set_requantization_source(self, source_method: QuantizeMethodBase) -> None:
+        """Reject requantization from a checkpoint-quantized MoE method."""
+        raise NotImplementedError(
+            "Requantizing checkpoint-quantized MoE layers is not supported."
+        )
 
     def create_weights(
         self,

--- a/vllm/model_executor/layers/quantization/online/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp4.py
@@ -119,7 +119,8 @@ class Mxfp4OnlineLinearMethod(OnlineLinearBase):
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
 
-        weight_fp4, weight_scale = mxfp4_quantize(layer.weight.contiguous())
+        weight = self.get_weight_for_quantization(layer)
+        weight_fp4, weight_scale = mxfp4_quantize(weight.contiguous())
 
         layer.input_scale = None
         replace_parameter(layer, "weight", weight_fp4.data)

--- a/vllm/model_executor/layers/quantization/online/mxfp8.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp8.py
@@ -77,7 +77,8 @@ class Mxfp8OnlineLinearMethod(OnlineLinearBase):
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
 
-        weight_fp8, weight_scale = mxfp8_e4m3_quantize(layer.weight.contiguous())
+        weight = self.get_weight_for_quantization(layer)
+        weight_fp8, weight_scale = mxfp8_e4m3_quantize(weight.contiguous())
 
         layer.input_scale = None
         replace_parameter(layer, "weight", weight_fp8.data)


### PR DESCRIPTION
## Disclosure

AI assistance was used. The changes were reviewed and tested manually.

## Purpose

This PR allows re-quantizing linear layers to a different precision using online quantization API, as long as the `dequantize_weight` method for relevant `LinearMethodBase` subclass is implemented.

Similar features have been requested previously in specialized cases:
- https://github.com/vllm-project/vllm/pull/48427
- https://github.com/vllm-project/vllm/pull/51274

and this feature exists on sglang side https://github.com/sgl-project/sglang/pull/28291 / https://github.com/sgl-project/sglang/pull/29328.

Addresses the third item of https://github.com/vllm-project/vllm/issues/52167. This PR is adapted from https://github.com/vllm-project/vllm/pull/48427, co-authored by @tanpinsiang.

This change lets `--quantization-config.linear fp8_per_channel` convert selected serialized ModelOpt MXFP8 linears to FP8 PTPC at load time.

The original checkpoint quantization config remains responsible for unselected linears and MoE.

The composition is handled by the existing `resolve_quant_method`, so model implementations continue to receive their original checkpoint quantization config type.

Quantization methods expose an optional `dequantize_weight` method, that:

- raises `NotImplementedError` by default, or
- dequantizes the quant method weights if implemented.

This draft implements it only for `ModelOptMxFp8LinearMethod`.

Such `dequantize_weight` methods implementation can be shared across model producers (quark, modelopt, compressed-tensors, etc.) based on weight quant key, no model producer-specific code should be required.

## Test Plan

```bash
vllm serve mmangkad/Qwen3-4B-Instruct-2507-MXFP8 --quantization-config.linear "fp8_per_channel"
```

or

```bash
vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --tensor-parallel-size 4 \
  --attention-backend TRITON_ATTN \
  --moe-backend aiter \
  --linear-backend auto \
  --kv-cache-dtype fp8 \
  --no-enable-prefix-caching \
  --language-model-only \
  --quantization-config.linear fp8_per_channel
```

`pytest tests/quantization/test_online.py-s -vvvvv`

## Test Result

Unit test passing, end-to-end eval to be added.