### PR TITLE
[Docs] Fix ECExampleonnector typo in disagg encoder README

### DIFF
--- a/examples/disaggregated/disaggregated_encoder/README.md
+++ b/examples/disaggregated/disaggregated_encoder/README.md
@@ -57,7 +57,7 @@ The vllm instances and `disagg_encoder_proxy` supports local URIs with ```{"url"
 
 ## EC connector and KV transfer
 
-The `ECExampleonnector` is used to store the encoder cache on local disk and facilitate transfer. To enable the encoder disaggregation feature, add the following configuration:
+The `ECExampleConnector` is used to store the encoder cache on local disk and facilitate transfer. To enable the encoder disaggregation feature, add the following configuration:
 
 ```bash
 # Add to encoder instance: 


### PR DESCRIPTION
## Purpose

`examples/disaggregated/disaggregated_encoder/README.md` prose refers to `ECExampleonnector`, but the live class is `ECExampleConnector` (same README JSON blocks already use the correct name).

## Local repro (no full clone)

```bash
HEAD=$(gh api repos/vllm-project/vllm/git/ref/heads/main --jq .object.sha)
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/${HEAD}/examples/disaggregated/disaggregated_encoder/README.md" | rg -n 'ECExample'
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/${HEAD}/vllm/distributed/ec_transfer/ec_connector/example_connector.py" | rg -n 'class ECExample'
```

Observed on main `49eb2accf0610d220f451f2f3c1dfe93fe395c79`:
- README ~L60: `ECExampleonnector` (typo)
- README JSON: `"ec_connector": "ECExampleConnector"` (correct)
- Code: `class ECExampleConnector(ECConnectorBase)`

## Change

Rename the prose identifier to `ECExampleConnector`. JSON examples unchanged.