### PR TITLE
[Quantization] Enable shared expert fusion compatibility with online `shared_expert` quantization (showcase: along Quark MXFP4 routed experts)

### DIFF
--- a/tests/quantization/test_config_utils.py
+++ b/tests/quantization/test_config_utils.py
@@ -2,11 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests quantization configuration matching utilities."""
 
-from unittest.mock import Mock
-
 import pytest
 
 from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
     should_ignore_layer,
 )
@@ -58,7 +57,7 @@ def test_online_ignore_supports_fnmatch_patterns():
     )
 
     with pytest.raises(ValueError, match="matches both quantization_config.ignore"):
-        config.resolve_quant_method_cls(Mock(), layer_name)
+        config.resolve_quant_method_cls(LinearBase, layer_name)
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -917,9 +917,7 @@ def test_online_quantization_targets_ignore_collision() -> None:
         )
     )
     with pytest.raises(ValueError, match="matches both quantization_config.ignore"):
-        config.resolve_quant_method_cls(
-            Mock(spec=LinearBase), "model.layers.0.self_attn.o_proj"
-        )
+        config.resolve_quant_method_cls(LinearBase, "model.layers.0.self_attn.o_proj")
 
 
 def test_online_quantization_targets_reject_unsupported_layer() -> None:

--- a/tests/quantization/test_online_shared_expert_fusion.py
+++ b/tests/quantization/test_online_shared_expert_fusion.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests ROCm AITER fused shared experts with online quantization."""
+
+import pytest
+import torch
+
+from tests.quantization.utils import load_model_without_vllm_runner
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.platforms import current_platform
+
+MODEL_NAME = "amd/Qwen3.5-35B-A3B-MXFP4"
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="Fused shared-expert online quantization is a ROCm AITER feature.",
+)
+def test_online_quantization(monkeypatch, dist_init, workspace_init) -> None:
+    """Quantize and fuse Qwen3.5 shared-expert weights into the MoE."""
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS", "1")
+    rocm_aiter_ops.refresh_env_variables()
+
+    logged_messages: list[str] = []
+    logged_warnings: list[str] = []
+
+    def record_info(message: str, *args: object) -> None:
+        logged_messages.append(message % args)
+
+    def record_warning(message: str, *args: object) -> None:
+        logged_warnings.append(message % args)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.base_loader.logger.info", record_info
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.utils.logger.warning", record_warning
+    )
+
+    online_quant_args = {"targets": {"*shared_expert*": "mxfp4"}}
+    model, vllm_config = load_model_without_vllm_runner(
+        MODEL_NAME,
+        model_config_kwargs={
+            "quantization_config": online_quant_args,
+            "hf_overrides": {
+                "text_config": {
+                    "num_hidden_layers": 1,
+                    "layer_types": ["linear_attention"],
+                }
+            },
+        },
+    )
+
+    mlp = model.language_model.model.layers[0].mlp
+    experts = mlp.experts
+    routed_experts = experts.routed_experts
+    online_config = vllm_config.quant_config.online_quantization_config
+
+    assert vllm_config.model_config.hf_text_config.num_hidden_layers == 1
+    assert mlp.is_fused_shared_expert_enabled
+    assert mlp.shared_expert is None
+    assert experts.expert_map_manager.num_fused_shared_experts == 1
+    assert routed_experts.w13_weight.dtype == torch.float4_e2m1fn_x2
+    assert routed_experts.w13_weight_scale.dtype == torch.uint8
+    assert routed_experts.w2_weight.dtype == torch.float4_e2m1fn_x2
+    assert routed_experts.w2_weight_scale.dtype == torch.uint8
+    assert online_config is not None
+    assert not any(
+        "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is enabled but "
+        "cannot be enabled" in warning
+        for warning in logged_warnings
+    )
+    assert logged_messages == [
+        "Quantized 2 layers of types: mlp.shared_expert.down_proj: 1 "
+        "(from targets: *shared_expert*, mxfp4); "
+        "mlp.shared_expert.gate_up_proj: 1 "
+        "(from targets: *shared_expert*, mxfp4)"
+    ]

--- a/tests/quantization/test_online_shared_expert_fusion.py
+++ b/tests/quantization/test_online_shared_expert_fusion.py
@@ -2,25 +2,186 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests ROCm AITER fused shared experts with online quantization."""
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
 import torch
 
 from tests.quantization.utils import load_model_without_vllm_runner
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.config.quantization import resolve_quantization_config
+from vllm.model_executor.layers.quantization.quark.quark_moe import (
+    QuarkOCP_MX_MoEMethod,
+)
+from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
+from vllm.model_executor.model_loader.utils import get_model_architecture
 from vllm.platforms import current_platform
 
-MODEL_NAME = "amd/Qwen3.5-35B-A3B-MXFP4"
+_QUARK_MXFP4_CONFIG: dict[str, Any] = {
+    "global_quant_config": {
+        "input_tensors": {
+            "dtype": "fp4",
+            "is_dynamic": True,
+            "qscheme": "per_group",
+            "ch_axis": -1,
+            "group_size": 32,
+            "block_size": None,
+            "symmetric": None,
+            "round_method": "half_even",
+            "scale_type": "float",
+            "scale_format": "e8m0",
+            "scale_calculation_mode": "even",
+            "mx_element_dtype": None,
+            "observer_cls": "PerBlockMXObserver",
+            "is_scale_quant": False,
+            "enable_buffer_reuse": False,
+            "max_input_numel": 4194304,
+        },
+        "output_tensors": None,
+        "weight": {
+            "dtype": "fp4",
+            "is_dynamic": False,
+            "qscheme": "per_group",
+            "ch_axis": -1,
+            "group_size": 32,
+            "block_size": None,
+            "symmetric": None,
+            "round_method": "half_even",
+            "scale_type": "float",
+            "scale_format": "e8m0",
+            "scale_calculation_mode": "even",
+            "mx_element_dtype": None,
+            "observer_cls": "PerBlockMXObserver",
+            "is_scale_quant": False,
+            "enable_buffer_reuse": False,
+            "max_input_numel": 4194304,
+        },
+        "bias": None,
+        "target_device": None,
+    },
+    "algo_config": None,
+    "softmax_quant_spec": None,
+    "quant_method": "quark",
+    "layer_type_quant_config": {},
+    "layer_quant_config": {},
+    "exclude": ["re:^(?!.*\\.mlp\\.experts(?:\\.|$)).*$"],
+    "kv_cache_quant_config": {},
+    "kv_cache_post_rope": False,
+    "quant_mode": "eager_mode",
+    "version": "0.12+9d3d471cdf1",
+    "export": {
+        "kv_cache_group": [],
+        "min_kv_scale": 0.0,
+        "pack_method": "reorder",
+        "weight_format": "real_quantized",
+        "weight_merge_groups": None,
+    },
+}
+
+_QUARK_MXFP4_LAYER_CONFIG: dict[str, Any] = _QUARK_MXFP4_CONFIG["global_quant_config"]
+_QUARK_MXFP4_CONFIG = {
+    **_QUARK_MXFP4_CONFIG,
+    "global_quant_config": {
+        "input_tensors": {},
+        "output_tensors": None,
+        "weight": {},
+        "bias": None,
+        "target_device": None,
+    },
+    "layer_quant_config": {"*mlp.experts*": _QUARK_MXFP4_LAYER_CONFIG},
+}
+
+
+def _write_minimal_moe_config(model_path: Path, architecture: str) -> None:
+    """Write a compact MoE config with one shared expert."""
+    config = {
+        "architectures": [architecture],
+        "hidden_size": 256,
+        "intermediate_size": 512,
+        "moe_intermediate_size": 256,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "head_dim": 64,
+        "num_hidden_layers": 1,
+        "vocab_size": 256,
+        "max_position_embeddings": 64,
+        "q_lora_rank": 64,
+        "kv_lora_rank": 512,
+        "qk_nope_head_dim": 128,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 128,
+        "n_routed_experts": 4,
+        "num_experts": 4,
+        "num_experts_per_tok": 1,
+        "n_group": 1,
+        "topk_group": 1,
+        "n_shared_experts": 1,
+        "first_k_dense_replace": 0,
+        "moe_layer_freq": 1,
+        "rms_norm_eps": 1e-6,
+        "hidden_act": "silu",
+        "tie_word_embeddings": False,
+        "rope_theta": 10000,
+        "quantization_config": _QUARK_MXFP4_CONFIG,
+    }
+    if architecture == "AXK1ForCausalLM":
+        config["model_type"] = "axk1"
+    elif architecture == "Glm4MoeForCausalLM":
+        config["model_type"] = "glm4_moe"
+    elif architecture == "Qwen3NextForCausalLM":
+        config.update(
+            model_type="qwen3_next",
+            layer_types=["linear_attention"],
+            head_dim=64,
+            linear_key_head_dim=64,
+            linear_value_head_dim=64,
+            linear_num_key_heads=4,
+            linear_num_value_heads=4,
+            shared_expert_intermediate_size=256,
+        )
+    else:
+        config["model_type"] = "deepseek_v3" if "V3" in architecture else "deepseek_v2"
+        if architecture == "GlmMoeDsaForCausalLM":
+            config.update(
+                index_topk=1,
+                index_kpool=1,
+                index_n_heads=1,
+                index_head_dim=32,
+                index_kv_lora_rank=32,
+            )
+    (model_path / "config.json").write_text(json.dumps(config))
 
 
 @pytest.mark.skipif(
     not current_platform.is_rocm(),
     reason="Fused shared-expert online quantization is a ROCm AITER feature.",
 )
-def test_online_quantization(monkeypatch, dist_init, workspace_init) -> None:
-    """Quantize and fuse Qwen3.5 shared-expert weights into the MoE."""
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "AXK1ForCausalLM",
+        "DeepseekForCausalLM",
+        "DeepseekV2ForCausalLM",
+        "DeepseekV3ForCausalLM",
+        "Glm4MoeForCausalLM",
+        "GlmMoeDsaForCausalLM",
+        "Qwen3NextForCausalLM",
+    ],
+)
+def test_online_quantization(
+    architecture: str,
+    tmp_path: Path,
+    monkeypatch,
+    dist_init,
+    workspace_init,
+) -> None:
+    """Online MXFP4 fuses each architecture's shared expert into its MoE."""
     monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
     monkeypatch.setenv("VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS", "1")
     rocm_aiter_ops.refresh_env_variables()
+    _write_minimal_moe_config(tmp_path, architecture)
 
     logged_messages: list[str] = []
     logged_warnings: list[str] = []
@@ -38,42 +199,57 @@ def test_online_quantization(monkeypatch, dist_init, workspace_init) -> None:
         "vllm.model_executor.layers.fused_moe.utils.logger.warning", record_warning
     )
 
-    online_quant_args = {"targets": {"*shared_expert*": "mxfp4"}}
     model, vllm_config = load_model_without_vllm_runner(
-        MODEL_NAME,
+        str(tmp_path),
+        dtype="bfloat16",
+        quantization="quark",
         model_config_kwargs={
-            "quantization_config": online_quant_args,
-            "hf_overrides": {
-                "text_config": {
-                    "num_hidden_layers": 1,
-                    "layer_types": ["linear_attention"],
-                }
-            },
+            "quantization_config": resolve_quantization_config(
+                "quark", {"targets": {"*shared_expert*": "mxfp4"}}
+            )
         },
+        model_loader_cls=DummyModelLoader,
     )
+    expected_model_cls, resolved_architecture = get_model_architecture(
+        vllm_config.model_config
+    )
+    assert resolved_architecture == architecture
+    assert isinstance(model, expected_model_cls)
 
-    mlp = model.language_model.model.layers[0].mlp
-    experts = mlp.experts
-    routed_experts = experts.routed_experts
-    online_config = vllm_config.quant_config.online_quantization_config
+    fused_moes = [
+        module
+        for module in model.modules()
+        if getattr(module, "is_fused_shared_expert_enabled", False)
+        and hasattr(module, "experts")
+    ]
+    assert len(fused_moes) == 1, f"{architecture} did not enable FSE"
+    moe = fused_moes[0]
+    shared_expert_name = (
+        "shared_expert" if hasattr(moe, "shared_expert") else "shared_experts"
+    )
+    assert getattr(moe, shared_expert_name) is None
 
-    assert vllm_config.model_config.hf_text_config.num_hidden_layers == 1
-    assert mlp.is_fused_shared_expert_enabled
-    assert mlp.shared_expert is None
-    assert experts.expert_map_manager.num_fused_shared_experts == 1
+    routed_experts = moe.experts.routed_experts
+    assert isinstance(routed_experts.quant_method, QuarkOCP_MX_MoEMethod)
+    expert_map_manager = routed_experts.expert_map_manager
+    assert expert_map_manager.num_fused_shared_experts == 1
+    assert expert_map_manager.map_global_to_local(moe.n_routed_experts) == (
+        moe.n_routed_experts
+    )
     assert routed_experts.w13_weight.dtype == torch.float4_e2m1fn_x2
     assert routed_experts.w13_weight_scale.dtype == torch.uint8
     assert routed_experts.w2_weight.dtype == torch.float4_e2m1fn_x2
     assert routed_experts.w2_weight_scale.dtype == torch.uint8
-    assert online_config is not None
+    assert vllm_config.quant_config.online_quantization_config is not None
     assert not any(
         "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is enabled but "
         "cannot be enabled" in warning
         for warning in logged_warnings
     )
     assert logged_messages == [
-        "Quantized 2 layers of types: mlp.shared_expert.down_proj: 1 "
+        "Quantized 2 layers of types: "
+        f"mlp.{shared_expert_name}.down_proj: 1 "
         "(from targets: *shared_expert*, mxfp4); "
-        "mlp.shared_expert.gate_up_proj: 1 "
+        f"mlp.{shared_expert_name}.gate_up_proj: 1 "
         "(from targets: *shared_expert*, mxfp4)"
     ]

--- a/tests/quantization/test_online_shared_expert_fusion.py
+++ b/tests/quantization/test_online_shared_expert_fusion.py
@@ -12,6 +12,9 @@ import torch
 from tests.quantization.utils import load_model_without_vllm_runner
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config.quantization import resolve_quantization_config
+from vllm.model_executor.layers.quantization.online.moe_shared_expert import (
+    OnlineMxfp4SharedExpertLoader,
+)
 from vllm.model_executor.layers.quantization.quark.quark_moe import (
     QuarkOCP_MX_MoEMethod,
 )
@@ -154,6 +157,18 @@ def _write_minimal_moe_config(model_path: Path, architecture: str) -> None:
     (model_path / "config.json").write_text(json.dumps(config))
 
 
+def test_online_shared_expert_quantization_fusion_tp() -> None:
+    """TP shared-expert weights are sharded on each projection's TP dimension."""
+    loader = OnlineMxfp4SharedExpertLoader()
+    w13 = torch.arange(48).reshape(8, 6)
+    w2 = torch.arange(48).reshape(6, 8)
+
+    assert torch.equal(loader._tp_shard(w13, "w1", tp_size=2, tp_rank=0), w13[:4])
+    assert torch.equal(loader._tp_shard(w2, "w2", tp_size=2, tp_rank=0), w2[:, :4])
+    assert torch.equal(loader._tp_shard(w13, "w3", tp_size=2, tp_rank=1), w13[4:])
+    assert torch.equal(loader._tp_shard(w2, "w2", tp_size=2, tp_rank=1), w2[:, 4:])
+
+
 @pytest.mark.skipif(
     not current_platform.is_rocm(),
     reason="Fused shared-expert online quantization is a ROCm AITER feature.",
@@ -182,6 +197,10 @@ def test_online_quantization(
     monkeypatch.setenv("VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS", "1")
     rocm_aiter_ops.refresh_env_variables()
     _write_minimal_moe_config(tmp_path, architecture)
+    expected_shared_expert_name = (
+        "shared_expert" if architecture == "Qwen3NextForCausalLM" else "shared_experts"
+    )
+    target_pattern = f"*{expected_shared_expert_name}*"
 
     logged_messages: list[str] = []
     logged_warnings: list[str] = []
@@ -205,7 +224,7 @@ def test_online_quantization(
         quantization="quark",
         model_config_kwargs={
             "quantization_config": resolve_quantization_config(
-                "quark", {"targets": {"*shared_expert*": "mxfp4"}}
+                "quark", {"targets": {target_pattern: "mxfp4"}}
             )
         },
         model_loader_cls=DummyModelLoader,
@@ -227,10 +246,14 @@ def test_online_quantization(
     shared_expert_name = (
         "shared_expert" if hasattr(moe, "shared_expert") else "shared_experts"
     )
+    assert shared_expert_name == expected_shared_expert_name
     assert getattr(moe, shared_expert_name) is None
 
     routed_experts = moe.experts.routed_experts
     assert isinstance(routed_experts.quant_method, QuarkOCP_MX_MoEMethod)
+    shared_expert_prefix = routed_experts.moe_config.shared_expert_prefix
+    assert shared_expert_prefix is not None
+    assert shared_expert_prefix.endswith(f"mlp.{shared_expert_name}")
     expert_map_manager = routed_experts.expert_map_manager
     assert expert_map_manager.num_fused_shared_experts == 1
     assert expert_map_manager.map_global_to_local(moe.n_routed_experts) == (
@@ -249,7 +272,7 @@ def test_online_quantization(
     assert logged_messages == [
         "Quantized 2 layers of types: "
         f"mlp.{shared_expert_name}.down_proj: 1 "
-        "(from targets: *shared_expert*, mxfp4); "
+        f"(from targets: {target_pattern}, mxfp4); "
         f"mlp.{shared_expert_name}.gate_up_proj: 1 "
-        "(from targets: *shared_expert*, mxfp4)"
+        f"(from targets: {target_pattern}, mxfp4)"
     ]

--- a/tests/quantization/test_online_shared_expert_fusion.py
+++ b/tests/quantization/test_online_shared_expert_fusion.py
@@ -11,12 +11,22 @@ import torch
 
 from tests.quantization.utils import load_model_without_vllm_runner
 from vllm._aiter_ops import rocm_aiter_ops
-from vllm.config.quantization import resolve_quantization_config
+from vllm.config.model import ModelConfig
+from vllm.config.quantization import (
+    QuantizationConfigArgs,
+    resolve_quantization_config,
+)
+from vllm.model_executor.layers.fused_moe import FusedMoEFactory
+from vllm.model_executor.layers.quantization.online.base import OnlineQuantizationConfig
 from vllm.model_executor.layers.quantization.online.moe_shared_expert import (
     OnlineMxfp4SharedExpertLoader,
 )
+from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
 from vllm.model_executor.layers.quantization.quark.quark_moe import (
     QuarkOCP_MX_MoEMethod,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+    mxfp4_quantize,
 )
 from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
 from vllm.model_executor.model_loader.utils import get_model_architecture
@@ -167,6 +177,79 @@ def test_online_shared_expert_quantization_fusion_tp() -> None:
     assert torch.equal(loader._tp_shard(w2, "w2", tp_size=2, tp_rank=0), w2[:, :4])
     assert torch.equal(loader._tp_shard(w13, "w3", tp_size=2, tp_rank=1), w13[4:])
     assert torch.equal(loader._tp_shard(w2, "w2", tp_size=2, tp_rank=1), w2[:, 4:])
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="MXFP4 shared-expert loading requires ROCm.",
+)
+def test_online_shared_expert_loads_bf16_weights_into_mxfp4_slot(
+    default_vllm_config,
+    dist_init,
+) -> None:
+    """A BF16 shared expert is quantized while routed MXFP4 weights are loaded."""
+    default_vllm_config.model_config = ModelConfig()
+    hidden_size = intermediate_size = 64
+    num_routed_experts = 2
+    device = current_platform.device_type
+    online_config = OnlineQuantizationConfig(
+        QuantizationConfigArgs(targets={"*shared_expert*": "mxfp4"})
+    )
+    quant_config = QuarkConfig(_QUARK_MXFP4_CONFIG)
+    quant_config.online_quantization_config = online_config
+
+    with torch.device(device):
+        runner = FusedMoEFactory(
+            num_experts=num_routed_experts,
+            top_k=1,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            n_shared_experts=1,
+            fuse_shared_experts=True,
+            shared_expert_prefix="model.layers.0.mlp.shared_expert",
+            prefix="model.layers.0.mlp.experts",
+            quant_config=quant_config,
+        )
+        layer = runner.routed_experts
+        assert isinstance(layer.quant_method, QuarkOCP_MX_MoEMethod)
+
+        routed_gate, _ = mxfp4_quantize(
+            torch.randn(intermediate_size, hidden_size, dtype=torch.bfloat16)
+        )
+        routed_up, _ = mxfp4_quantize(
+            torch.randn(intermediate_size, hidden_size, dtype=torch.bfloat16)
+        )
+        routed_down, _ = mxfp4_quantize(
+            torch.randn(hidden_size, intermediate_size, dtype=torch.bfloat16)
+        )
+        shared_gate = torch.randn(intermediate_size, hidden_size, dtype=torch.bfloat16)
+        shared_up = torch.randn(intermediate_size, hidden_size, dtype=torch.bfloat16)
+        shared_down = torch.randn(hidden_size, intermediate_size, dtype=torch.bfloat16)
+
+        list(
+            layer.load_weights(
+                [
+                    ("0.gate_proj.weight", routed_gate),
+                    ("0.up_proj.weight", routed_up),
+                    ("0.down_proj.weight", routed_down),
+                    ("2.gate_proj.weight", shared_gate),
+                    ("2.up_proj.weight", shared_up),
+                    ("2.down_proj.weight", shared_down),
+                ]
+            )
+        )
+
+    expected_gate, expected_gate_scale = mxfp4_quantize(shared_gate)
+    expected_up, expected_up_scale = mxfp4_quantize(shared_up)
+    expected_down, expected_down_scale = mxfp4_quantize(shared_down)
+    assert torch.equal(layer.w13_weight[2, :intermediate_size], expected_gate)
+    assert torch.equal(layer.w13_weight[2, intermediate_size:], expected_up)
+    assert torch.equal(layer.w2_weight[2], expected_down)
+    assert torch.equal(
+        layer.w13_weight_scale[2, :intermediate_size], expected_gate_scale
+    )
+    assert torch.equal(layer.w13_weight_scale[2, intermediate_size:], expected_up_scale)
+    assert torch.equal(layer.w2_weight_scale[2], expected_down_scale)
 
 
 @pytest.mark.skipif(

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -2,8 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for QuantizationConfigArgs parsing."""
 
-from unittest.mock import Mock
-
 import pytest
 
 from vllm.config.quantization import (
@@ -209,6 +207,4 @@ def test_targets_reject_moe_only_shorthand_for_linear_layer():
     )
 
     with pytest.raises(ValueError, match="does not define a QuantSpec"):
-        config.resolve_quant_method_cls(
-            Mock(spec=LinearBase), "model.layers.0.self_attn.o_proj"
-        )
+        config.resolve_quant_method_cls(LinearBase, "model.layers.0.self_attn.o_proj")

--- a/tests/quantization/utils.py
+++ b/tests/quantization/utils.py
@@ -13,6 +13,7 @@ from vllm.config import (
     VllmConfig,
     set_current_vllm_config,
 )
+from vllm.config.quantization import resolve_quantization_config
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 from vllm.platforms import current_platform
@@ -27,10 +28,17 @@ def _limit_num_hidden_layers(
     original_load_weights = model.load_weights
 
     def should_load_weight(name: str) -> bool:
-        for prefix in ("model.layers.", "layers."):
-            if name.startswith(prefix):
-                layer_idx = int(name.removeprefix(prefix).split(".", 1)[0])
-                return layer_idx < num_hidden_layers
+        layers_prefix = "layers."
+        if name.startswith(layers_prefix):
+            layer_name = name.removeprefix(layers_prefix)
+        elif ".layers." in name:
+            layer_name = name.split(".layers.", maxsplit=1)[1]
+        else:
+            return True
+
+        layer_idx_str = layer_name.split(".", maxsplit=1)[0]
+        if layer_idx_str.isdigit():
+            return int(layer_idx_str) < num_hidden_layers
         return True
 
     def load_weights(weights):
@@ -58,11 +66,17 @@ def load_model_without_vllm_runner(
         quantization=quantization,
         **(model_config_kwargs or {}),
     )
+    model_config.quantization_config = resolve_quantization_config(
+        model_config.quantization, model_config.quantization_config
+    )
     vllm_config_args = dict(vllm_config_kwargs or {})
     vllm_config_args.setdefault("compilation_config", CompilationConfig(mode=0))
     vllm_config = VllmConfig(model_config=model_config, **vllm_config_args)
     hf_overrides = (model_config_kwargs or {}).get("hf_overrides") or {}
-    num_hidden_layers = hf_overrides.get("num_hidden_layers")
+    text_config_overrides = hf_overrides.get("text_config") or {}
+    num_hidden_layers = text_config_overrides.get(
+        "num_hidden_layers", hf_overrides.get("num_hidden_layers")
+    )
 
     with set_current_vllm_config(vllm_config):
         model_loader = model_loader_cls(vllm_config.load_config)

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1308,6 +1308,7 @@ class FusedMoEConfig:
     max_num_tokens: int = SchedulerConfig.DEFAULT_MAX_NUM_BATCHED_TOKENS_FOR_BATCHED_DP
     has_bias: bool = False
     is_lora_enabled: bool = False
+    shared_expert_prefix: str | None = None
 
     # When True, the MoE skips its final cross-rank all-reduce (and the separate
     # shared-expert reduce), returning the partial per-rank sum. The caller is

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -39,6 +39,15 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         return self.moe_kernel is not None
 
     @property
+    def shared_expert_online_loader(self):
+        """Loader for online-quantized shared-expert weights."""
+        from vllm.model_executor.layers.quantization.online.moe_shared_expert import (
+            UnimplementedOnlineSharedExpertLoader,
+        )
+
+        return UnimplementedOnlineSharedExpertLoader(self.method_name)
+
+    @property
     def mk_can_overlap_shared_experts(self) -> bool:
         # NOTE(rob): temporary attribute to indicate support for
         # completed migration to the new internal MK interface.

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -122,6 +122,7 @@ def FusedMoEFactory(
     is_fused_checkpoint_transposed: bool = False,
     n_shared_experts: int | None = None,
     fuse_shared_experts: bool = False,
+    shared_expert_prefix: str | None = None,
     router_logits_dtype: torch.dtype | None = None,
     gate: torch.nn.Module | None = None,
     shared_experts: torch.nn.Module | None = None,
@@ -191,6 +192,7 @@ def FusedMoEFactory(
         n_shared_experts: Number of shared experts to fuse into the routed
             grouped GEMM (ROCm; requires aiter FSE or the router-append path)
         fuse_shared_experts: Whether to enable shared-expert fusion.
+        shared_expert_prefix: Checkpoint prefix for the fused shared expert.
         router_logits_dtype: Data type for router logits buffers
         gate: Pre-configured gate module
         shared_experts: Pre-configured shared experts module
@@ -350,6 +352,7 @@ def FusedMoEFactory(
         max_num_tokens=max_num_batched_tokens,
         has_bias=has_bias,
         is_lora_enabled=vllm_config.lora_config is not None,
+        shared_expert_prefix=shared_expert_prefix,
         activation=moe_activation,
         device=vllm_config.device_config.device,
         routing_method=router.routing_method_type,  # Not ideal

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -23,6 +23,10 @@ from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
     UnquantizedFusedMoEMethod,
 )
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    UnquantizedLinearMethod,
+)
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     resolve_quant_method,
@@ -913,6 +917,58 @@ class RoutedExperts(PluggableLayer):
                         for fused_name in ("gate_up_proj", "w13")
                     )
                 )
+                is_fused_shared_expert_weight = (
+                    not is_fused
+                    and qual_name.endswith(".weight")
+                    and self.expert_map_manager.num_fused_shared_experts > 0
+                    and self.moe_config.num_logical_experts
+                    <= expert_id
+                    < self.moe_config.num_logical_experts
+                    + self.expert_map_manager.num_fused_shared_experts
+                )
+                online_quantization_config = (
+                    self.quant_config.online_quantization_config
+                    if self.quant_config is not None
+                    else None
+                )
+                shared_expert_projection_prefix = (
+                    f"{self.layer_name.removesuffix('.experts')}.shared_expert."
+                    f"{'down_proj' if shard_id == 'w2' else 'gate_up_proj'}"
+                )
+                shared_expert_uses_online_quantization = False
+                if online_quantization_config is not None:
+                    quant_method_metadata = (
+                        online_quantization_config.resolve_quant_method_cls(
+                            LinearBase, shared_expert_projection_prefix
+                        )
+                    )
+
+                    if quant_method_metadata is not None:
+                        _, _, _, _, shared_expert_quant_method_cls = (
+                            quant_method_metadata
+                        )
+
+                        shared_expert_uses_online_quantization = (
+                            shared_expert_quant_method_cls is not None
+                            and shared_expert_quant_method_cls
+                            is not UnquantizedLinearMethod
+                        )
+                if (
+                    is_fused_shared_expert_weight
+                    and not isinstance(self.quant_method, UnquantizedFusedMoEMethod)
+                    and shared_expert_uses_online_quantization
+                ):
+                    shared_expert_online_loader = (
+                        self.quant_method.shared_expert_online_loader
+                    )
+                    yield from shared_expert_online_loader.load(
+                        self,
+                        global_expert_id=expert_id,
+                        shard_id=shard_id,
+                        loaded_weight=loaded_weight,
+                        weight_name=qual_name,
+                    )
+                    break
                 weight_name = qual_name.replace(weight_name, param_name)
                 param_name = weight_name.removeprefix(f"{self.layer_name}.")
                 param = getattr(self, param_name, None)

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -894,6 +894,53 @@ class RoutedExperts(PluggableLayer):
 
         return False if return_success else None
 
+    def should_load_online_quantized_fused_shared_expert(
+        self,
+        global_expert_id: int,
+        shard_id: str,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+    ) -> bool:
+        """Whether to load a fused shared expert through online quantization.
+
+        Returns:
+            Whether the online shared-expert loader should handle this weight.
+        """
+        is_fused_shared_expert = (
+            self.expert_map_manager.num_fused_shared_experts > 0
+            and self.moe_config.num_logical_experts <= global_expert_id
+            and global_expert_id
+            < self.moe_config.num_logical_experts
+            + self.expert_map_manager.num_fused_shared_experts
+        )
+        if (
+            loaded_weight.dim() == 3
+            or not weight_name.endswith(".weight")
+            or not is_fused_shared_expert
+            or isinstance(self.quant_method, UnquantizedFusedMoEMethod)
+        ):
+            return False
+
+        online_quantization_config = (
+            self.quant_config.online_quantization_config
+            if self.quant_config is not None
+            else None
+        )
+        shared_expert_prefix = self.moe_config.shared_expert_prefix
+        if online_quantization_config is None or shared_expert_prefix is None:
+            return False
+
+        projection_name = "down_proj" if shard_id == "w2" else "gate_up_proj"
+        quant_method_metadata = online_quantization_config.resolve_quant_method_cls(
+            LinearBase, f"{shared_expert_prefix}.{projection_name}"
+        )
+        if quant_method_metadata is None:
+            return False
+
+        _, _, _, _, shared_expert_quant_method_cls = quant_method_metadata
+
+        return shared_expert_quant_method_cls not in (None, UnquantizedLinearMethod)
+
     def load_weights(
         self, weights: Iterable[tuple[str, torch.Tensor]]
     ) -> Iterable[str]:
@@ -917,61 +964,33 @@ class RoutedExperts(PluggableLayer):
                         for fused_name in ("gate_up_proj", "w13")
                     )
                 )
-                is_fused_shared_expert_weight = (
-                    not is_fused
-                    and qual_name.endswith(".weight")
-                    and self.expert_map_manager.num_fused_shared_experts > 0
-                    and self.moe_config.num_logical_experts
-                    <= expert_id
-                    < self.moe_config.num_logical_experts
-                    + self.expert_map_manager.num_fused_shared_experts
-                )
-                online_quantization_config = (
-                    self.quant_config.online_quantization_config
-                    if self.quant_config is not None
-                    else None
-                )
 
-                # NOTE: `experts`, `shared_expert` are hard-coded here and this logic
-                # would break with models that do not exactly use these layer names.
-                shared_expert_projection_prefix = (
-                    f"{self.layer_name.removesuffix('.experts')}.shared_expert."
-                    f"{'down_proj' if shard_id == 'w2' else 'gate_up_proj'}"
-                )
-                shared_expert_uses_online_quantization = False
-                if online_quantization_config is not None:
-                    quant_method_metadata = (
-                        online_quantization_config.resolve_quant_method_cls(
-                            LinearBase, shared_expert_projection_prefix
-                        )
-                    )
-
-                    if quant_method_metadata is not None:
-                        _, _, _, _, shared_expert_quant_method_cls = (
-                            quant_method_metadata
-                        )
-
-                        shared_expert_uses_online_quantization = (
-                            shared_expert_quant_method_cls is not None
-                            and shared_expert_quant_method_cls
-                            is not UnquantizedLinearMethod
-                        )
-                if (
-                    is_fused_shared_expert_weight
-                    and not isinstance(self.quant_method, UnquantizedFusedMoEMethod)
-                    and shared_expert_uses_online_quantization
+                # Online quantization for shared expert with
+                # quant_method.shared_expert_online_loader.
+                if self.should_load_online_quantized_fused_shared_expert(
+                    global_expert_id=expert_id,
+                    shard_id=shard_id,
+                    loaded_weight=loaded_weight,
+                    weight_name=qual_name,
                 ):
                     shared_expert_online_loader = (
                         self.quant_method.shared_expert_online_loader
                     )
-                    yield from shared_expert_online_loader.load(
+                    loaded_params = shared_expert_online_loader.load(
                         self,
                         global_expert_id=expert_id,
                         shard_id=shard_id,
                         loaded_weight=loaded_weight,
                         weight_name=qual_name,
                     )
+
+                    # shared expert not loaded on this EP rank.
+                    if loaded_params is not None:
+                        yield from loaded_params
+
+                    # Do not fall through to the packed checkpoint loader.
                     break
+
                 weight_name = qual_name.replace(weight_name, param_name)
                 param_name = weight_name.removeprefix(f"{self.layer_name}.")
                 param = getattr(self, param_name, None)

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -931,6 +931,9 @@ class RoutedExperts(PluggableLayer):
                     if self.quant_config is not None
                     else None
                 )
+
+                # NOTE: `experts`, `shared_expert` are hard-coded here and this logic
+                # would break with models that do not exactly use these layer names.
                 shared_expert_projection_prefix = (
                     f"{self.layer_name.removesuffix('.experts')}.shared_expert."
                     f"{'down_proj' if shard_id == 'w2' else 'gate_up_proj'}"

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -83,6 +83,40 @@ def resolve_layer_fused_shared_expert(
         else (True, None)
     )
     is_fused_shared_expert_enabled = fse_requested and fse_compatible
+
+    # In online shared_expert quantization is used, register it to
+    # `online_quantization_config.quantized_layers` ahead of weight loading.
+    if is_fused_shared_expert_enabled and quant_config is not None:
+        online_quantization_config = quant_config.online_quantization_config
+        if online_quantization_config is not None:
+            from vllm.model_executor.layers.linear import (
+                LinearBase,
+                UnquantizedLinearMethod,
+            )
+
+            for projection_name in ("gate_up_proj", "down_proj"):
+                projection_prefix = f"{prefix}.{shared_expert_name}.{projection_name}"
+                quant_method_metadata = (
+                    online_quantization_config.resolve_quant_method_cls(
+                        LinearBase, projection_prefix
+                    )
+                )
+
+                if quant_method_metadata is None:
+                    continue
+
+                source, quant_key_str, target_pattern, _, quant_method_cls = (
+                    quant_method_metadata
+                )
+
+                if quant_method_cls in (None, UnquantizedLinearMethod):
+                    continue
+
+                online_quantization_config.quantized_layers[projection_prefix] = (
+                    source.value,
+                    quant_key_str,
+                    target_pattern,
+                )
     if fse_requested and not is_fused_shared_expert_enabled:
         logger.warning(
             "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is enabled but "

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -300,7 +300,7 @@ def resolve_quant_method(
         base_quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)
     )
     online_target = quant_config.online_quantization_config.resolve_quant_method_cls(
-        layer, prefix
+        type(layer), prefix
     )
     if checkpoint_is_quantized:
         if online_target is not None:

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
@@ -76,6 +76,15 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
                 "Using MarlinExperts (weight-only FP4) for AutoRound MXFP4 MoE"
             )
 
+    @property
+    def shared_expert_online_loader(self):
+        """Return the loader for online MXFP4 shared-expert weights."""
+        from vllm.model_executor.layers.quantization.online.moe_shared_expert import (
+            OnlineMxfp4SharedExpertLoader,
+        )
+
+        return OnlineMxfp4SharedExpertLoader()
+
     def create_weights(
         self,
         layer: torch.nn.Module,

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
@@ -76,15 +76,6 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
                 "Using MarlinExperts (weight-only FP4) for AutoRound MXFP4 MoE"
             )
 
-    @property
-    def shared_expert_online_loader(self):
-        """Return the loader for online MXFP4 shared-expert weights."""
-        from vllm.model_executor.layers.quantization.online.moe_shared_expert import (
-            OnlineMxfp4SharedExpertLoader,
-        )
-
-        return OnlineMxfp4SharedExpertLoader()
-
     def create_weights(
         self,
         layer: torch.nn.Module,

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -215,14 +215,14 @@ class OnlineQuantizationConfig(QuantizationConfig):
         self,
         spec: QuantSpec | None,
         table: dict[QuantKey, type],
-        layer: torch.nn.Module,
+        layer_cls: type[torch.nn.Module],
     ) -> type | None:
         """Resolve the online method class for a layer's quantization spec.
 
         Args:
             spec: Quantization specification to resolve.
             table: Mapping from weight quantization keys to method classes.
-            layer: Layer that will use the resolved method.
+            layer_cls: Type of layer that will use the resolved method.
 
         Returns:
             The matching method class, or None when ``spec`` has no weight
@@ -233,7 +233,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
         cls = table.get(spec.weight)
         if cls is None:
             raise ValueError(
-                f"online quantization for {type(layer).__name__} with "
+                f"online quantization for {layer_cls.__name__} with "
                 f"weight={spec.weight} is not supported; supported weight "
                 f"keys: {sorted(str(k) for k in table)}"
             )
@@ -248,12 +248,12 @@ class OnlineQuantizationConfig(QuantizationConfig):
         return cls
 
     def resolve_quant_method_cls(
-        self, layer: torch.nn.Module, prefix: str
+        self, layer_cls: type[torch.nn.Module], prefix: str
     ) -> tuple[OnlineQuantizationSource, str, str | None, QuantSpec, type] | None:
         """Resolve quantization metadata and method class without instantiating it.
 
         Args:
-            layer: Layer for which to resolve online quantization.
+            layer_cls: Type of layer for which to resolve online quantization.
             prefix: Fully qualified layer name.
 
         Returns:
@@ -264,17 +264,17 @@ class OnlineQuantizationConfig(QuantizationConfig):
         quant_spec: QuantSpec | None
         if self.args.targets is not None:
             resolved_pattern = self._resolve_targets_quant_method_metadata(
-                prefix, layer
+                prefix, layer_cls
             )
             if resolved_pattern is None:
                 return None
             source, quant_key_str, target_pattern, quant_spec, table = resolved_pattern
         else:
-            if isinstance(layer, LinearBase):
+            if issubclass(layer_cls, LinearBase):
                 source = OnlineQuantizationSource.linear
                 quant_spec = self.args.linear
                 table = _ONLINE_LINEAR_METHODS
-            elif isinstance(layer, RoutedExperts):
+            elif issubclass(layer_cls, RoutedExperts):
                 source = OnlineQuantizationSource.moe
                 quant_spec = self.args.moe
                 table = _ONLINE_MOE_METHODS
@@ -291,14 +291,14 @@ class OnlineQuantizationConfig(QuantizationConfig):
             quant_key_str = str(quant_spec)
             target_pattern = None
 
-        quant_method_cls = self._get_method_cls(quant_spec, table, layer)
+        quant_method_cls = self._get_method_cls(quant_spec, table, layer_cls)
         if quant_method_cls is None:
             return None
         assert quant_spec is not None
         return source, quant_key_str, target_pattern, quant_spec, quant_method_cls
 
     def _resolve_targets_quant_method_metadata(
-        self, prefix: str, layer: torch.nn.Module
+        self, prefix: str, layer_cls: type[torch.nn.Module]
     ) -> (
         tuple[OnlineQuantizationSource, str, str, QuantSpec, dict[QuantKey, type]]
         | None
@@ -307,7 +307,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
 
         Args:
             prefix: Fully qualified layer name.
-            layer: Layer matched against configured target patterns.
+            layer_cls: Type matched against configured target patterns.
 
         Returns:
             A tuple of source, quantization key string, target pattern, spec,
@@ -341,22 +341,22 @@ class OnlineQuantizationConfig(QuantizationConfig):
         target_pattern = matches[0]
         quant_key_str = self.args.targets[target_pattern]
         shorthand = _ONLINE_SHORTHANDS[quant_key_str]
-        if isinstance(layer, LinearBase):
+        if issubclass(layer_cls, LinearBase):
             quant_spec = shorthand.linear
             table = _ONLINE_LINEAR_METHODS
-        elif isinstance(layer, RoutedExperts):
+        elif issubclass(layer_cls, RoutedExperts):
             quant_spec = shorthand.moe
             table = _ONLINE_MOE_METHODS
         else:
             raise ValueError(
                 f"Layer {prefix} was matched by quantization_config.targets "
                 f"({target_pattern}), but online quantization is not supported for "
-                f"{type(layer).__name__}."
+                f"{layer_cls.__name__}."
             )
         if quant_spec is None:
             raise ValueError(
                 f"targets pattern {target_pattern} = {quant_key_str} does "
-                f"not define a QuantSpec for {type(layer).__name__} layers "
+                f"not define a QuantSpec for {layer_cls.__name__} layers "
                 f"(matched at {prefix})."
             )
         return (
@@ -371,7 +371,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         # `targets` takes precedence over `moe` and `linear` and is exclusive.
-        resolved = self.resolve_quant_method_cls(layer, prefix)
+        resolved = self.resolve_quant_method_cls(type(layer), prefix)
         if resolved is not None:
             source, quant_key_str, target_pattern, _, quant_method_cls = resolved
             self.quantized_layers[prefix] = (

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -215,14 +215,14 @@ class OnlineQuantizationConfig(QuantizationConfig):
         self,
         spec: QuantSpec | None,
         table: dict[QuantKey, type],
-        layer: torch.nn.Module,
+        layer_cls: type[torch.nn.Module],
     ) -> type | None:
         """Resolve the online method class for a layer's quantization spec.
 
         Args:
             spec: Quantization specification to resolve.
             table: Mapping from weight quantization keys to method classes.
-            layer: Layer that will use the resolved method.
+            layer_cls: Type of the layer that will use the resolved method.
 
         Returns:
             The matching method class, or None when ``spec`` has no weight
@@ -233,7 +233,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
         cls = table.get(spec.weight)
         if cls is None:
             raise ValueError(
-                f"online quantization for {type(layer).__name__} with "
+                f"online quantization for {layer_cls.__name__} with "
                 f"weight={spec.weight} is not supported; supported weight "
                 f"keys: {sorted(str(k) for k in table)}"
             )
@@ -248,12 +248,12 @@ class OnlineQuantizationConfig(QuantizationConfig):
         return cls
 
     def resolve_quant_method_cls(
-        self, layer: torch.nn.Module, prefix: str
+        self, layer_cls: type[torch.nn.Module], prefix: str
     ) -> tuple[OnlineQuantizationSource, str, str | None, QuantSpec, type] | None:
         """Resolve quantization metadata and method class without instantiating it.
 
         Args:
-            layer: Layer for which to resolve online quantization.
+            layer_cls: Type of layer for which to resolve online quantization.
             prefix: Fully qualified layer name.
 
         Returns:
@@ -264,17 +264,17 @@ class OnlineQuantizationConfig(QuantizationConfig):
         quant_spec: QuantSpec | None
         if self.args.targets is not None:
             resolved_pattern = self._resolve_targets_quant_method_metadata(
-                prefix, layer
+                prefix, layer_cls
             )
             if resolved_pattern is None:
                 return None
             source, quant_key_str, target_pattern, quant_spec, table = resolved_pattern
         else:
-            if isinstance(layer, LinearBase):
+            if issubclass(layer_cls, LinearBase):
                 source = OnlineQuantizationSource.linear
                 quant_spec = self.args.linear
                 table = _ONLINE_LINEAR_METHODS
-            elif isinstance(layer, RoutedExperts):
+            elif issubclass(layer_cls, RoutedExperts):
                 source = OnlineQuantizationSource.moe
                 quant_spec = self.args.moe
                 table = _ONLINE_MOE_METHODS
@@ -291,14 +291,14 @@ class OnlineQuantizationConfig(QuantizationConfig):
             quant_key_str = str(quant_spec)
             target_pattern = None
 
-        quant_method_cls = self._get_method_cls(quant_spec, table, layer)
+        quant_method_cls = self._get_method_cls(quant_spec, table, layer_cls)
         if quant_method_cls is None:
             return None
         assert quant_spec is not None
         return source, quant_key_str, target_pattern, quant_spec, quant_method_cls
 
     def _resolve_targets_quant_method_metadata(
-        self, prefix: str, layer: torch.nn.Module
+        self, prefix: str, layer_cls: type[torch.nn.Module]
     ) -> (
         tuple[OnlineQuantizationSource, str, str, QuantSpec, dict[QuantKey, type]]
         | None
@@ -307,7 +307,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
 
         Args:
             prefix: Fully qualified layer name.
-            layer: Layer matched against configured target patterns.
+            layer_cls: Type of layer matched against configured target patterns.
 
         Returns:
             A tuple of source, quantization key string, target pattern, spec,
@@ -341,22 +341,22 @@ class OnlineQuantizationConfig(QuantizationConfig):
         target_pattern = matches[0]
         quant_key_str = self.args.targets[target_pattern]
         shorthand = _ONLINE_SHORTHANDS[quant_key_str]
-        if isinstance(layer, LinearBase):
+        if issubclass(layer_cls, LinearBase):
             quant_spec = shorthand.linear
             table = _ONLINE_LINEAR_METHODS
-        elif isinstance(layer, RoutedExperts):
+        elif issubclass(layer_cls, RoutedExperts):
             quant_spec = shorthand.moe
             table = _ONLINE_MOE_METHODS
         else:
             raise ValueError(
                 f"Layer {prefix} was matched by quantization_config.targets "
                 f"({target_pattern}), but online quantization is not supported for "
-                f"{type(layer).__name__}."
+                f"{layer_cls.__name__}."
             )
         if quant_spec is None:
             raise ValueError(
                 f"targets pattern {target_pattern} = {quant_key_str} does "
-                f"not define a QuantSpec for {type(layer).__name__} layers "
+                f"not define a QuantSpec for {layer_cls.__name__} layers "
                 f"(matched at {prefix})."
             )
         return (
@@ -371,7 +371,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         # `targets` takes precedence over `moe` and `linear` and is exclusive.
-        resolved = self.resolve_quant_method_cls(layer, prefix)
+        resolved = self.resolve_quant_method_cls(type(layer), prefix)
         if resolved is not None:
             source, quant_key_str, target_pattern, _, quant_method_cls = resolved
             self.quantized_layers[prefix] = (

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -215,14 +215,14 @@ class OnlineQuantizationConfig(QuantizationConfig):
         self,
         spec: QuantSpec | None,
         table: dict[QuantKey, type],
-        layer_cls: type[torch.nn.Module],
+        layer: torch.nn.Module,
     ) -> type | None:
         """Resolve the online method class for a layer's quantization spec.
 
         Args:
             spec: Quantization specification to resolve.
             table: Mapping from weight quantization keys to method classes.
-            layer_cls: Type of layer that will use the resolved method.
+            layer: Layer that will use the resolved method.
 
         Returns:
             The matching method class, or None when ``spec`` has no weight
@@ -233,7 +233,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
         cls = table.get(spec.weight)
         if cls is None:
             raise ValueError(
-                f"online quantization for {layer_cls.__name__} with "
+                f"online quantization for {type(layer).__name__} with "
                 f"weight={spec.weight} is not supported; supported weight "
                 f"keys: {sorted(str(k) for k in table)}"
             )
@@ -248,12 +248,12 @@ class OnlineQuantizationConfig(QuantizationConfig):
         return cls
 
     def resolve_quant_method_cls(
-        self, layer_cls: type[torch.nn.Module], prefix: str
+        self, layer: torch.nn.Module, prefix: str
     ) -> tuple[OnlineQuantizationSource, str, str | None, QuantSpec, type] | None:
         """Resolve quantization metadata and method class without instantiating it.
 
         Args:
-            layer_cls: Type of layer for which to resolve online quantization.
+            layer: Layer for which to resolve online quantization.
             prefix: Fully qualified layer name.
 
         Returns:
@@ -264,17 +264,17 @@ class OnlineQuantizationConfig(QuantizationConfig):
         quant_spec: QuantSpec | None
         if self.args.targets is not None:
             resolved_pattern = self._resolve_targets_quant_method_metadata(
-                prefix, layer_cls
+                prefix, layer
             )
             if resolved_pattern is None:
                 return None
             source, quant_key_str, target_pattern, quant_spec, table = resolved_pattern
         else:
-            if issubclass(layer_cls, LinearBase):
+            if isinstance(layer, LinearBase):
                 source = OnlineQuantizationSource.linear
                 quant_spec = self.args.linear
                 table = _ONLINE_LINEAR_METHODS
-            elif issubclass(layer_cls, RoutedExperts):
+            elif isinstance(layer, RoutedExperts):
                 source = OnlineQuantizationSource.moe
                 quant_spec = self.args.moe
                 table = _ONLINE_MOE_METHODS
@@ -291,14 +291,14 @@ class OnlineQuantizationConfig(QuantizationConfig):
             quant_key_str = str(quant_spec)
             target_pattern = None
 
-        quant_method_cls = self._get_method_cls(quant_spec, table, layer_cls)
+        quant_method_cls = self._get_method_cls(quant_spec, table, layer)
         if quant_method_cls is None:
             return None
         assert quant_spec is not None
         return source, quant_key_str, target_pattern, quant_spec, quant_method_cls
 
     def _resolve_targets_quant_method_metadata(
-        self, prefix: str, layer_cls: type[torch.nn.Module]
+        self, prefix: str, layer: torch.nn.Module
     ) -> (
         tuple[OnlineQuantizationSource, str, str, QuantSpec, dict[QuantKey, type]]
         | None
@@ -307,7 +307,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
 
         Args:
             prefix: Fully qualified layer name.
-            layer_cls: Type matched against configured target patterns.
+            layer: Layer matched against configured target patterns.
 
         Returns:
             A tuple of source, quantization key string, target pattern, spec,
@@ -341,22 +341,22 @@ class OnlineQuantizationConfig(QuantizationConfig):
         target_pattern = matches[0]
         quant_key_str = self.args.targets[target_pattern]
         shorthand = _ONLINE_SHORTHANDS[quant_key_str]
-        if issubclass(layer_cls, LinearBase):
+        if isinstance(layer, LinearBase):
             quant_spec = shorthand.linear
             table = _ONLINE_LINEAR_METHODS
-        elif issubclass(layer_cls, RoutedExperts):
+        elif isinstance(layer, RoutedExperts):
             quant_spec = shorthand.moe
             table = _ONLINE_MOE_METHODS
         else:
             raise ValueError(
                 f"Layer {prefix} was matched by quantization_config.targets "
                 f"({target_pattern}), but online quantization is not supported for "
-                f"{layer_cls.__name__}."
+                f"{type(layer).__name__}."
             )
         if quant_spec is None:
             raise ValueError(
                 f"targets pattern {target_pattern} = {quant_key_str} does "
-                f"not define a QuantSpec for {layer_cls.__name__} layers "
+                f"not define a QuantSpec for {type(layer).__name__} layers "
                 f"(matched at {prefix})."
             )
         return (
@@ -371,7 +371,7 @@ class OnlineQuantizationConfig(QuantizationConfig):
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         # `targets` takes precedence over `moe` and `linear` and is exclusive.
-        resolved = self.resolve_quant_method_cls(type(layer), prefix)
+        resolved = self.resolve_quant_method_cls(layer, prefix)
         if resolved is not None:
             source, quant_key_str, target_pattern, _, quant_method_cls = resolved
             self.quantized_layers[prefix] = (

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -12,8 +12,6 @@ if TYPE_CHECKING:
         FusedMoEQuantConfig,
     )
     from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
-    from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
-
 import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.config import get_current_vllm_config
@@ -35,6 +33,7 @@ from vllm.model_executor.layers.quantization.online.moe_base import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
+    QuantKey,
     amax_for_moe_weight_quant,
     amax_for_tp_weight_quant,
     create_fp8_quant_key,
@@ -117,6 +116,7 @@ class OnlineLinearBase(LinearMethodBase):
     weights onto meta device and materializes them just-in-time."""
 
     uses_meta_device: bool = True
+    activation_quant_key: QuantKey | None
 
     def __init__(self):
         self.out_dtype = torch.get_default_dtype()
@@ -194,6 +194,8 @@ class Fp8PerTensorOnlineLinearMethod(OnlineLinearBase):
             **extra_weight_attrs,
         )
 
+        # TODO: init_fp8_linear_kernel should support activation_quant_key=None
+        assert self.activation_quant_key is not None
         self.fp8_linear = init_fp8_linear_kernel(
             activation_quant_key=self.activation_quant_key,
             weight_quant_key=self.weight_quant_key,
@@ -293,6 +295,8 @@ class Fp8PerBlockOnlineLinearMethod(OnlineLinearBase):
         )
         layer.weight_block_size = self.weight_block_size
 
+        # TODO: init_fp8_linear_kernel should support activation_quant_key=None
+        assert self.activation_quant_key is not None
         self.fp8_linear = init_fp8_linear_kernel(
             activation_quant_key=self.activation_quant_key,
             weight_quant_key=self.weight_quant_key,

--- a/vllm/model_executor/layers/quantization/online/moe_shared_expert.py
+++ b/vllm/model_executor/layers/quantization/online/moe_shared_expert.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+    mxfp4_quantize,
+)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+
+
+class OnlineSharedExpertLoader(ABC):
+    """Load full-precision weights into quantized expert slots."""
+
+    def load(
+        self,
+        layer: "RoutedExperts",
+        *,
+        global_expert_id: int,
+        shard_id: str,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+    ) -> tuple[str, ...]:
+        num_fused = layer.expert_map_manager.num_fused_shared_experts
+        first_fused = layer.moe_config.num_logical_experts
+
+        if not (
+            num_fused > 0
+            and first_fused <= global_expert_id < first_fused + num_fused
+            and loaded_weight.is_floating_point()
+            and weight_name.endswith(".weight")
+        ):
+            raise NotImplementedError(
+                f"{type(self).__name__} cannot load the fused shared-expert "
+                f"weight {weight_name!r}."
+            )
+
+        return self._load(
+            layer,
+            global_expert_id=global_expert_id,
+            shard_id=shard_id,
+            loaded_weight=loaded_weight,
+        )
+
+    @abstractmethod
+    def _load(
+        self,
+        layer: "RoutedExperts",
+        *,
+        global_expert_id: int,
+        shard_id: str,
+        loaded_weight: torch.Tensor,
+    ) -> tuple[str, ...]:
+        """Load a weight that has passed compatibility validation."""
+
+
+class UnimplementedOnlineSharedExpertLoader(OnlineSharedExpertLoader):
+    """Raise when a quantization method cannot load a fused shared expert."""
+
+    def __init__(self, method_name: str) -> None:
+        self.method_name = method_name
+
+    def load(
+        self,
+        layer: "RoutedExperts",
+        *,
+        global_expert_id: int,
+        shard_id: str,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+    ) -> tuple[str, ...]:
+        raise NotImplementedError(
+            "Fusing a full-precision shared expert into "
+            f"{self.method_name} requires an expert weight codec."
+        )
+
+    def _load(
+        self,
+        layer: "RoutedExperts",
+        *,
+        global_expert_id: int,
+        shard_id: str,
+        loaded_weight: torch.Tensor,
+    ) -> tuple[str, ...]:
+        raise AssertionError("Unimplemented expert weight codecs cannot load weights.")
+
+
+class OnlineMxfp4SharedExpertLoader(OnlineSharedExpertLoader):
+    """Load full-precision expert weights into packed MXFP4 MoE storage."""
+
+    @staticmethod
+    def _weight_parameter_name(layer: "RoutedExperts", stem: str) -> str:
+        """Resolve the checkpoint method's packed weight parameter name."""
+        name = f"{stem}_weight"
+        if hasattr(layer, name):
+            return name
+        packed_name = f"{name}_packed"
+        if hasattr(layer, packed_name):
+            return packed_name
+        raise AttributeError(f"{type(layer).__name__} has no {name!r} parameter")
+
+    @staticmethod
+    def _tp_shard(
+        layer: "RoutedExperts", loaded_weight: torch.Tensor, shard_id: str
+    ) -> torch.Tensor:
+        """Select this rank's full-precision projection shard."""
+        shard_dim = 1 if shard_id == "w2" else 0
+        tp_size = layer.moe_config.moe_parallel_config.tp_size
+        if tp_size == 1:
+            return loaded_weight
+        if loaded_weight.shape[shard_dim] % tp_size != 0:
+            raise ValueError(
+                f"Cannot TP-shard full-precision {shard_id} weight with shape "
+                f"{tuple(loaded_weight.shape)} across {tp_size} ranks."
+            )
+        shard_size = loaded_weight.shape[shard_dim] // tp_size
+        return loaded_weight.narrow(
+            shard_dim, layer.moe_config.tp_rank * shard_size, shard_size
+        )
+
+    @torch.no_grad()
+    def _load(
+        self,
+        layer: "RoutedExperts",
+        *,
+        global_expert_id: int,
+        shard_id: str,
+        loaded_weight: torch.Tensor,
+    ) -> tuple[str, ...]:
+        """Quantize one projection and store its packed weight and scales."""
+        local_expert_id = layer._map_global_expert_id_to_local_expert_id(
+            global_expert_id
+        )
+        if local_expert_id == -1:
+            return ()
+
+        stem = "w2" if shard_id == "w2" else "w13"
+        weight_name = self._weight_parameter_name(layer, stem)
+        scale_name = f"{stem}_weight_scale"
+        weight = getattr(layer, weight_name)[local_expert_id]
+        scale = getattr(layer, scale_name)[local_expert_id]
+
+        loaded_weight = self._tp_shard(layer, loaded_weight, shard_id)
+        if shard_id == "w2":
+            unpacked_shape = (weight.shape[0], weight.shape[1] * 2)
+            weight_dst = weight
+            scale_dst = scale
+        else:
+            shard_size = weight.shape[0] // layer.moe_config.w13_num_shards
+            shard_index = 0 if shard_id == "w1" else 1
+            unpacked_shape = (shard_size, weight.shape[1] * 2)
+            weight_dst = weight.narrow(0, shard_index * shard_size, shard_size)
+            scale_dst = scale.narrow(0, shard_index * shard_size, shard_size)
+
+        padded_weight = torch.zeros(
+            unpacked_shape,
+            dtype=loaded_weight.dtype,
+            device=weight.device,
+        )
+        loaded_weight = loaded_weight.to(device=weight.device)
+        assert (
+            loaded_weight.ndim == 2
+            and loaded_weight.shape[0] <= padded_weight.shape[0]
+            and loaded_weight.shape[1] <= padded_weight.shape[1]
+        ), (
+            f"Full-precision {shard_id} weight has shape "
+            f"{tuple(loaded_weight.shape)}, which exceeds the expected "
+            f"unpacked shape {unpacked_shape}."
+        )
+        rows = min(padded_weight.shape[0], loaded_weight.shape[0])
+        columns = min(padded_weight.shape[1], loaded_weight.shape[1])
+        padded_weight[:rows, :columns].copy_(loaded_weight[:rows, :columns])
+
+        quantized, quantized_scale = mxfp4_quantize(padded_weight)
+        weight_dst.copy_(quantized)
+        scale_dst.copy_(quantized_scale)
+        return weight_name, scale_name

--- a/vllm/model_executor/layers/quantization/online/moe_shared_expert.py
+++ b/vllm/model_executor/layers/quantization/online/moe_shared_expert.py
@@ -24,7 +24,7 @@ class OnlineSharedExpertLoader(ABC):
         shard_id: str,
         loaded_weight: torch.Tensor,
         weight_name: str,
-    ) -> tuple[str, ...]:
+    ) -> tuple[str, str] | None:
         num_fused = layer.expert_map_manager.num_fused_shared_experts
         first_fused = layer.moe_config.num_logical_experts
 
@@ -53,7 +53,7 @@ class OnlineSharedExpertLoader(ABC):
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
-    ) -> tuple[str, ...]:
+    ) -> tuple[str, str] | None:
         """Load a weight that has passed compatibility validation."""
 
 
@@ -70,7 +70,7 @@ class UnimplementedOnlineSharedExpertLoader(OnlineSharedExpertLoader):
         shard_id: str,
         loaded_weight: torch.Tensor,
         weight_name: str,
-    ) -> tuple[str, ...]:
+    ) -> tuple[str, str] | None:
         raise NotImplementedError(
             "Fusing a full-precision shared expert into "
             f"{self.method_name} requires an expert weight codec."
@@ -82,7 +82,7 @@ class UnimplementedOnlineSharedExpertLoader(OnlineSharedExpertLoader):
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
-    ) -> tuple[str, ...]:
+    ) -> tuple[str, str] | None:
         raise AssertionError("Unimplemented expert weight codecs cannot load weights.")
 
 
@@ -102,11 +102,13 @@ class OnlineMxfp4SharedExpertLoader(OnlineSharedExpertLoader):
 
     @staticmethod
     def _tp_shard(
-        layer: "RoutedExperts", loaded_weight: torch.Tensor, shard_id: str
+        loaded_weight: torch.Tensor,
+        shard_id: str,
+        tp_size: int,
+        tp_rank: int,
     ) -> torch.Tensor:
         """Select this rank's full-precision projection shard."""
         shard_dim = 1 if shard_id == "w2" else 0
-        tp_size = layer.moe_config.moe_parallel_config.tp_size
         if tp_size == 1:
             return loaded_weight
         if loaded_weight.shape[shard_dim] % tp_size != 0:
@@ -115,9 +117,7 @@ class OnlineMxfp4SharedExpertLoader(OnlineSharedExpertLoader):
                 f"{tuple(loaded_weight.shape)} across {tp_size} ranks."
             )
         shard_size = loaded_weight.shape[shard_dim] // tp_size
-        return loaded_weight.narrow(
-            shard_dim, layer.moe_config.tp_rank * shard_size, shard_size
-        )
+        return loaded_weight.narrow(shard_dim, tp_rank * shard_size, shard_size)
 
     @torch.no_grad()
     def _load(
@@ -126,13 +126,13 @@ class OnlineMxfp4SharedExpertLoader(OnlineSharedExpertLoader):
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
-    ) -> tuple[str, ...]:
+    ) -> tuple[str, str] | None:
         """Quantize one projection and store its packed weight and scales."""
         local_expert_id = layer._map_global_expert_id_to_local_expert_id(
             global_expert_id
         )
         if local_expert_id == -1:
-            return ()
+            return None
 
         stem = "w2" if shard_id == "w2" else "w13"
         weight_name = self._weight_parameter_name(layer, stem)
@@ -140,7 +140,12 @@ class OnlineMxfp4SharedExpertLoader(OnlineSharedExpertLoader):
         weight = getattr(layer, weight_name)[local_expert_id]
         scale = getattr(layer, scale_name)[local_expert_id]
 
-        loaded_weight = self._tp_shard(layer, loaded_weight, shard_id)
+        loaded_weight = self._tp_shard(
+            loaded_weight,
+            shard_id,
+            tp_size=layer.moe_config.moe_parallel_config.tp_size,
+            tp_rank=layer.moe_config.tp_rank,
+        )
         if shard_id == "w2":
             unpacked_shape = (weight.shape[0], weight.shape[1] * 2)
             weight_dst = weight

--- a/vllm/model_executor/layers/quantization/online/moe_shared_expert.py
+++ b/vllm/model_executor/layers/quantization/online/moe_shared_expert.py
@@ -20,7 +20,6 @@ class OnlineSharedExpertLoader(ABC):
     def load(
         self,
         layer: "RoutedExperts",
-        *,
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
@@ -51,7 +50,6 @@ class OnlineSharedExpertLoader(ABC):
     def _load(
         self,
         layer: "RoutedExperts",
-        *,
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
@@ -68,7 +66,6 @@ class UnimplementedOnlineSharedExpertLoader(OnlineSharedExpertLoader):
     def load(
         self,
         layer: "RoutedExperts",
-        *,
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
@@ -82,7 +79,6 @@ class UnimplementedOnlineSharedExpertLoader(OnlineSharedExpertLoader):
     def _load(
         self,
         layer: "RoutedExperts",
-        *,
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
@@ -127,7 +123,6 @@ class OnlineMxfp4SharedExpertLoader(OnlineSharedExpertLoader):
     def _load(
         self,
         layer: "RoutedExperts",
-        *,
         global_expert_id: int,
         shard_id: str,
         loaded_weight: torch.Tensor,
@@ -156,6 +151,12 @@ class OnlineMxfp4SharedExpertLoader(OnlineSharedExpertLoader):
             unpacked_shape = (shard_size, weight.shape[1] * 2)
             weight_dst = weight.narrow(0, shard_index * shard_size, shard_size)
             scale_dst = scale.narrow(0, shard_index * shard_size, shard_size)
+
+            if loaded_weight.ndim == 2 and loaded_weight.shape[0] > shard_size:
+                raise NotImplementedError(
+                    "Online quantization does not support fused shared-expert "
+                    "gate_up_proj checkpoint weights. Please open an issue."
+                )
 
         padded_weight = torch.zeros(
             unpacked_shape,

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -1234,6 +1234,15 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             f"Using {self.mxfp4_backend.value} backend for {self.ocp_mx_scheme}"
         )
 
+    @property
+    def shared_expert_online_loader(self):
+        """Return the loader for online MXFP4 shared-expert weights."""
+        from vllm.model_executor.layers.quantization.online.moe_shared_expert import (
+            OnlineMxfp4SharedExpertLoader,
+        )
+
+        return OnlineMxfp4SharedExpertLoader()
+
     def maybe_roundup_sizes(
         self,
         hidden_size: int,

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -79,6 +79,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kInt8StaticTensorAsym,
     kInt8StaticTensorSym,
     kMxfp4Dynamic,
+    kMxfp4Static,
     kNvfp4Dynamic,
     kNvfp4Static,
 )
@@ -1237,6 +1238,9 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
     @property
     def shared_expert_online_loader(self):
         """Return the loader for online MXFP4 shared-expert weights."""
+        if self.weight_quant_key != kMxfp4Static:
+            return super().shared_expert_online_loader
+
         from vllm.model_executor.layers.quantization.online.moe_shared_expert import (
             OnlineMxfp4SharedExpertLoader,
         )

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -8,8 +8,12 @@ from typing import TYPE_CHECKING
 
 import regex as re
 
+from vllm.logger import init_logger
+
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+logger = init_logger(__name__)
 
 
 def get_quark_ocp_mx_group_size(
@@ -64,18 +68,86 @@ def is_shared_expert_quant_fse_compatible(
     Returns:
         A compatibility flag and, when incompatible, the reason.
     """
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+    from vllm.model_executor.layers.quantization.online.fp8 import OnlineLinearBase
+    from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        is_layer_skipped,
+    )
+    from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
+
     if projection_names is None:
         projection_names = ["gate_up_proj", "down_proj"]
 
     if quant_config is None:
         return True, None
 
-    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
-    from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
-    from vllm.model_executor.layers.quantization.utils.quant_utils import (
-        is_layer_skipped,
-    )
-    from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
+    online_quant_config = quant_config.online_quantization_config
+    if online_quant_config is not None:
+        from vllm.model_executor.layers.fused_moe import (
+            RoutedExperts,
+            UnquantizedFusedMoEMethod,
+        )
+        from vllm.model_executor.layers.linear import (
+            LinearBase,
+            UnquantizedLinearMethod,
+        )
+
+        online_quant_config.packed_modules_mapping = quant_config.packed_modules_mapping
+        shared_expert_targets = [
+            online_quant_config.resolve_quant_method_cls(
+                LinearBase, f"{shared_expert_prefix}.{projection_name}"
+            )
+            for projection_name in projection_names
+        ]
+
+        # TODO: Extend with use at your own risk.
+        if isinstance(quant_config, QuarkConfig):
+            routed_weight_key, routed_activation_key, routed_method_cls = (
+                quant_config.get_quant_method_target(expert_prefix, RoutedExperts)
+            )
+        else:
+            reason = (
+                "online quantization FSE compatibility check is not implemented for "
+                f"{type(quant_config).__name__}"
+            )
+            logger.warning(reason)
+            return False, reason
+
+        if routed_method_cls in (None, UnquantizedFusedMoEMethod):
+            return False, "routed-expert quantization target is unavailable"
+
+        for shared_expert_target in shared_expert_targets:
+            if shared_expert_target is None:
+                return (False, "shared expert is not quantized")
+
+            _, _, _, shared_quant_spec, shared_method_cls = shared_expert_target
+            if shared_method_cls in (None, UnquantizedLinearMethod):
+                return (
+                    False,
+                    "online quantization excludes FSE weights at "
+                    f"{shared_expert_prefix}",
+                )
+            assert issubclass(shared_method_cls, OnlineLinearBase)
+            shared_weight_key = shared_quant_spec.weight
+
+            # NOTE: We can not rely on shared_quant_spec.activation_quant_key
+            # as _ONLINE_SHORTHANDS: dict[str, QuantSpec] in quantization.py
+            # does not define the default activation quant key.
+            # `online_quant_config.resolve_quant_method_cls` should return the
+            # activation quant key as well.
+            shared_activation_key = shared_method_cls.activation_quant_key
+
+            if (
+                shared_weight_key != routed_weight_key
+                or shared_activation_key != routed_activation_key
+            ):
+                return (
+                    False,
+                    "online shared-expert quantization keys do not match the "
+                    "routed expert keys",
+                )
+        return True, None
 
     if isinstance(quant_config, DeepseekV4FP8Config):
         from vllm.config import get_current_vllm_config

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -88,6 +88,9 @@ def is_shared_expert_quant_fse_compatible(
             RoutedExperts,
             UnquantizedFusedMoEMethod,
         )
+        from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
+            FusedMoEMethodBase,
+        )
         from vllm.model_executor.layers.linear import (
             LinearBase,
             UnquantizedLinearMethod,
@@ -116,6 +119,18 @@ def is_shared_expert_quant_fse_compatible(
 
         if routed_method_cls in (None, UnquantizedFusedMoEMethod):
             return False, "routed-expert quantization target is unavailable"
+        assert routed_method_cls is not None
+        if not issubclass(routed_method_cls, FusedMoEMethodBase):
+            return False, "routed-expert quantization is not a fused-MoE method"
+        assert issubclass(routed_method_cls, FusedMoEMethodBase)
+        if (
+            routed_method_cls.shared_expert_online_loader
+            is FusedMoEMethodBase.shared_expert_online_loader
+        ):
+            return (
+                False,
+                "routed-expert quantization has no shared-expert online loader",
+            )
 
         for shared_expert_target in shared_expert_targets:
             if shared_expert_target is None:

--- a/vllm/model_executor/models/AXK1.py
+++ b/vllm/model_executor/models/AXK1.py
@@ -200,6 +200,7 @@ class AXK1MoE(nn.Module):
             if self.is_fused_shared_expert_enabled
             else None,
             fuse_shared_experts=self.is_fused_shared_expert_enabled,
+            shared_expert_prefix=f"{prefix}.shared_experts",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -392,6 +392,7 @@ class DeepseekV2MoE(nn.Module):
             if self.is_fused_shared_expert_enabled
             else None,
             fuse_shared_experts=self.is_fused_shared_expert_enabled,
+            shared_expert_prefix=f"{prefix}.shared_experts",
             router_logits_dtype=self.gate.out_dtype,
         )
 

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -205,6 +205,7 @@ class Glm4MoE(nn.Module):
                 config.n_shared_experts if self.is_fused_shared_expert_enabled else None
             ),
             fuse_shared_experts=self.is_fused_shared_expert_enabled,
+            shared_expert_prefix=f"{prefix}.shared_experts",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -229,6 +229,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             is_sequence_parallel=self.is_sequence_parallel,
             n_shared_experts=1 if self.shared_expert is None else None,
             fuse_shared_experts=self.is_fused_shared_expert_enabled,
+            shared_expert_prefix=f"{prefix}.shared_expert",
             shared_expert_gate=self.shared_expert_gate
             if self.shared_expert is None
             else None,


### PR DESCRIPTION
## Disclosure

AI assistance was used. The changes were reviewed and tested manually.

## Purpose

This PR enables compatibility of online `shared_expert` quantization with fused shared expert optimization. As an example, it implements it for for `QuarkOCP_MX_MoEMethod` (and `INCMxfp4MoEMethod` to showcase extensibility, possibly to be removed).

The main idea is that given https://github.com/vllm-project/vllm/blob/f27ae25473af7520dde3f8b9e0705041940be0c9/vllm/model_executor/models/qwen3_next.py#L168-L180 `self.shared_expert = Qwen3NextMLP` is not defined when using `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`, we use weight loading in the `RoutedExperts` to capture the shared expert weight loading, quantize it there, and copy the quantized shared expert into the correct quantized fused expert slot.

The original `quant_method` is preserved (e.g. `QuarkOCP_MX_MoEMethod`).

This PR does NOT implement `experts` + `shared_expert` joint online quantization + fusion. `experts` is expected to be already quantized in this PR (loaded through `QuarkOCP_MX_MoEMethod`/`INCMxfp4MoEMethod`)

Main design goal is to be as much as possible quant method agnostic (currently: based on weight quant key, NOT quant method). See compatibility of `OnlineMxfp4SharedExpertLoader` with `QuarkOCP_MX_MoEMethod` and `INCMxfp4MoEMethod` with very minimal change there.

We also preserve quant config compatibility checks for fused shared expert, that could be extended to accommodate new precisions e.g. https://github.com/vllm-project/vllm/pull/53161

## Test Plan

Testing:

```bash
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 \
HIP_VISIBLE_DEVICES="6,7" \
vllm serve \
    amd/Qwen3.5-35B-A3B-MXFP4 \
    --quantization-config.targets '{"*shared_expert*": "mxfp4"}' \
    --tensor-parallel-size 2
```

`pytest tests/quantization/test_online_shared_expert_fusion.py -s -vvvvv`

## Test Result

`test_online_shared_expert_fusion.py` passing `7 passed, 14 warnings in 10.31s`

Displayed to user: `(EngineCore pid=27900) INFO 08-17 10:29:41 [base_loader.py:109] Quantized 80 layers of types: mlp.shared_expert.down_proj: 40 (from linear: QuantSpec(weight=QuantKey(dtype=torch.uint8, scale=ScaleDesc(dtype=torch.uint8, static=True, group_shape=GroupShape(row=1, col=32)), scale2=None, symmetric=True), activation=None)); mlp.shared_expert.gate_up_proj: 40 (from linear: QuantSpec(weight=QuantKey(dtype=torch.uint8, scale=ScaleDesc(dtype=torch.uint8, static=True, group_shape=GroupShape(row=1, col=32)), scale2=None, symmetric=True), activation=None))`