### PR TITLE
[Docs] Add OLMo 2 to batch-invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -134,6 +134,7 @@ Batch invariance has been tested and verified on the following models:
 - **Granite 3.1 (MoE)**: `ibm-granite/granite-3.1-1b-a400m-instruct`, `ibm-granite/granite-3.1-3b-a800m-instruct`
 - **Granite 3.1 (Dense)**: `ibm-granite/granite-3.1-2b-instruct`, `ibm-granite/granite-3.1-8b-instruct`
 - **EXAONE 4.0 series**: `LGAI-EXAONE/EXAONE-4.0-1.2B`, `LGAI-EXAONE/EXAONE-4.0.1-32B`, `LGAI-EXAONE/EXAONE-4.0-32B`
+- **OLMo 2**: `allenai/OLMo-2-0425-1B-Instruct`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Summary

Add `allenai/OLMo-2-0425-1B-Instruct` to the models explicitly
validated for batch-invariant inference.

Refs #27433.

## Duplicate-work check

I reviewed issue #27433 and searched existing open pull requests for this
model. I found no PR validating `allenai/OLMo-2-0425-1B-Instruct`.

## Validation

Hardware:

- NVIDIA L4, compute capability 8.9, 23,034 MiB
- Driver 580.178.04
- PyTorch 2.13.0+cu130
- vLLM 0.28.1rc1.dev475+g6fbb00b18
- vLLM commit: 6fbb00b18874e27ba7d7adc0a3b8e93fee763ab1
- Model revision: 48d788eca847d4d7548f375ad03d3c9312f6139e

Command:

```bash
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
VLLM_TEST_MODEL=allenai/OLMo-2-0425-1B-Instruct \
.venv/bin/python -m pytest \
  tests/v1/determinism/test_batch_invariance.py -v -s --tb=short
```

Result:
  
```text
19 passed, 35 warnings in 989.00s (0:16:29)
```

HuggingFace Job:

```text
https://huggingface.co/jobs/alphonse86/6a9e6aa1e686246ca69a778b
```
