### PR TITLE
[Docs] Stop recommending deprecated kv_both for NixlConnector

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -24,7 +24,8 @@ Now supports 9 types of connectors:
 - **NixlConnector**: refer to [tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh](../../tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh) for the example usage of NixlConnector disaggregated prefilling which support fully async send/recv. For detailed usage guide, see [NixlConnector Usage Guide](nixl_connector_usage.md). For feature compatibility details, see [NixlConnector Compatibility Matrix](nixl_connector_compatibility.md). You may specify one or multiple NIXL transfer backends, such as:
 
   ```bash
-  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both", "kv_buffer_device":"cuda", "kv_connector_extra_config":{"backends":["UCX", "GDS"]}}'
+  # Prefill instance (decode uses kv_role=kv_consumer)
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer", "kv_buffer_device":"cuda", "kv_connector_extra_config":{"backends":["UCX", "GDS"]}}'
   ```
 
 - **MooncakeConnector**: refer to [examples/disaggregated/mooncake_connector/run_mooncake_connector.sh](../../examples/disaggregated/mooncake_connector/run_mooncake_connector.sh) for the example usage of MooncakeConnector disaggregated prefilling. For detailed usage guide, see [MooncakeConnector Usage Guide](mooncake_connector_usage.md).
@@ -32,7 +33,7 @@ Now supports 9 types of connectors:
 - **MultiConnector**: take advantage of the kv_connector_extra_config: dict[str, Any] already present in KVTransferConfig to stash all the connectors we want in an ordered list of kwargs.such as:
 
   ```bash
-  --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"ExampleConnector","kv_role":"kv_both","kv_connector_extra_config":{"shared_storage_path":"local_storage"}}]}}'
+  --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_producer"},{"kv_connector":"ExampleConnector","kv_role":"kv_both","kv_connector_extra_config":{"shared_storage_path":"local_storage"}}]}}'
   ```
 
 - **OffloadingConnector**: enable offloading of KV data to CPU memory, customizing the CPU block size (in tokens) and total CPU memory bytes to allocate:

--- a/docs/serving/expert_parallel_deployment.md
+++ b/docs/serving/expert_parallel_deployment.md
@@ -236,7 +236,12 @@ For production deployments requiring strict SLA guarantees for time-to-first-tok
 
 1. **Install gdrcopy/ucx/nixl**: For maximum performance, run the [install_gdrcopy.sh](../../tools/install_gdrcopy.sh) script to install `gdrcopy` (e.g., `install_gdrcopy.sh "${GDRCOPY_OS_VERSION}" "12.8" "x64"`). You can find available OS versions [here](https://developer.download.nvidia.com/compute/redist/gdrcopy/CUDA%2012.8/). If `gdrcopy` is not installed, things will still work with a plain `pip install nixl`, just with lower performance. `nixl` and `ucx` are installed as dependencies via pip. For non-cuda platform to install nixl with non-cuda UCX build, run the [install_nixl_from_source_ubuntu.py](../../tools/install_nixl_from_source_ubuntu.py) script.
 
-2. **Configure Both Instances**: Add this flag to both prefill and decode instances `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}`. Noted, you may also specify one or multiple NIXL_Backend. Such as: `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both", "kv_connector_extra_config":{"backends":["UCX", "GDS"]}}'`
+2. **Configure Prefill and Decode roles**: Prefill instances must use `kv_role=kv_producer` and decode instances must use `kv_role=kv_consumer` (NixlConnector's `kv_both` is deprecated). For example:
+
+    - Prefill: `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'`
+    - Decode: `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'`
+
+    You may also specify one or multiple NIXL backends, such as: `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer", "kv_connector_extra_config":{"backends":["UCX", "GDS"]}}'`
 
 3. **Client Orchestration**: Use the client-side script below to coordinate prefill/decode operations. We are actively working on routing solutions.
 


### PR DESCRIPTION
## Summary

NixlConnector treats `kv_role=kv_both` as deprecated and logs a warning asking for `kv_producer` (prefill) / `kv_consumer` (decode). The canonical guide already documents this, but two other docs still recommend `kv_both` for NixlConnector.

## Repro / proof

1. Code warning in `vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py`:

```python
if vllm_config.kv_transfer_config.kv_role == "kv_both":
    logger.warning_once(
        "Using kv_role='kv_both' with NixlConnector is deprecated "
        "and will be removed in a future release. Please set "
        "kv_role='kv_producer' for prefill instances and "
        "kv_role='kv_consumer' for decode instances. "
    )
```

2. `docs/features/nixl_connector_usage.md` already marks `kv_both` deprecated for NixlConnector and shows producer/consumer examples.

3. Before this change:
   - `docs/features/disagg_prefill.md` showed `NixlConnector` + `kv_both` (including nested under MultiConnector).
   - `docs/serving/expert_parallel_deployment.md` told users to set `kv_both` on **both** prefill and decode instances.

## Changes

- `docs/features/disagg_prefill.md`: NixlConnector example uses `kv_producer`; nested NixlConnector under MultiConnector uses `kv_producer`.
- `docs/serving/expert_parallel_deployment.md`: split setup into prefill=`kv_producer` / decode=`kv_consumer`.

Left unchanged on purpose: Mooncake/LMCache/Offloading/FlexKV/ExampleConnector/DecodeBenchConnector `kv_both` (deprecation is NixlConnector-specific), and the deprecation note in `nixl_connector_usage.md`.

## Test plan

- [x] Docs-only review of the two patched snippets
- [x] Confirm remaining `NixlConnector`+`kv_both` recommendations outside the deprecation note are gone from these guides
- [x] DecodeBenchConnector `kv_both` example in EP guide intentionally retained
