### PR TITLE
[ROCm] Harden DeepSeek-V4 sparse prefill against zero-query-token chunks

### DIFF
--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -941,6 +941,23 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
             chunk_start = chunk_idx * self.PREFILL_CHUNK_SIZE
             chunk_end = min(chunk_start + self.PREFILL_CHUNK_SIZE, num_prefills)
             chunk_size = chunk_end - chunk_start
+            query_start = (
+                query_start_loc_cpu[num_decodes + chunk_start] - prefill_token_base
+            )
+            query_end = (
+                query_start_loc_cpu[num_decodes + chunk_end] - prefill_token_base
+            )
+            if query_end <= query_start:
+                # Every request in this chunk has a zero-length query.
+                # split_decodes_and_prefills() derives num_prefills as the
+                # suffix num_reqs - first_prefill, so padded request slots
+                # (query_start_loc[num_reqs + 1:] = num_tokens) land in the
+                # prefill range even though they carry no query tokens. With
+                # PREFILL_CHUNK_SIZE such slots can fill a whole chunk. The
+                # gathers and the sparse-attention call below would then run
+                # over an empty query range, and combine_topk_swa_indices()
+                # cannot reshape(0, -1).
+                continue
             if not swa_only:
                 assert attn_metadata is not None
                 assert compressed_k_cache is not None
@@ -967,13 +984,6 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
                 block_size=swa_metadata.block_size,
                 offset=N,
                 use_fnuz=current_platform.is_fp8_fnuz(),
-            )
-
-            query_start = (
-                query_start_loc_cpu[num_decodes + chunk_start] - prefill_token_base
-            )
-            query_end = (
-                query_start_loc_cpu[num_decodes + chunk_end] - prefill_token_base
             )
 
             combined_indices, combined_lens = combine_topk_swa_indices(


### PR DESCRIPTION
`_forward_prefill()` can be handed a prefill chunk covering zero query tokens,
and `combine_topk_swa_indices()` cannot reshape that. This adds the missing
guard.

## How an empty chunk arises

`_forward_prefill()` chunks the prefill range by request count with
`PREFILL_CHUNK_SIZE = 4`, over the range reported by
`split_decodes_and_prefills()`, which returns `num_prefills` as a suffix,
`num_reqs - first_prefill`. Request slots with zero query tokens are never
themselves flagged as prefills, but any that trail the first real prefill fall
inside that suffix. Such slots are an intentional artifact of request-dimension
padding: `vllm/v1/worker/gpu/input_batch.py` writes
`query_start_loc[num_reqs + 1:] = num_tokens`, and
`split_decodes_and_prefills()` documents them itself ("some requests may have a
query length of 0 but since they are padding ...").

Once `PREFILL_CHUNK_SIZE` such slots trail the last real prefill, a whole chunk
covers zero query tokens and `topk_indices.reshape(topk_indices.shape[0], -1)`
becomes ambiguous.

## Change

Hoist the query range computation above the K-cache gathers (it only reads
`query_start_loc_cpu`) and skip chunks with an empty range. This also drops two
`dequantize_and_gather_k_cache()` calls and one `rocm_sparse_attn_prefill()`
launch per padding-only chunk, which had nothing to compute.

## What I can show

Driving the real `split_decodes_and_prefills()` and replaying the real chunk
loop over `[1 + k, 256] + [0] * pad`, for `k` (`num_speculative_tokens`) in
`{0, 1, 2, 3, 4, 5, 7}` and `pad` in `{0, 1, 3, 4, 5, 8}`:

| | unguarded | guarded |
| --- | --- | --- |
| shapes that raise | 21 / 42 | 0 / 42 |
| non-empty chunks executed | identical, 0 mismatches | |

The 21 are exactly those with `pad >= PREFILL_CHUNK_SIZE`. `k` does not enter
the condition, so this is not specific to speculative decoding. Copy-paste
reproduction, no GPU or weights needed:
https://github.com/vllm-project/vllm/pull/55695#issuecomment-5580073174

## What I cannot show

Reachability on `main`. The state was hit for real on v0.26.0 (full traceback,
all four TP ranks, `EngineDeadError`), but on current `main` two full DSpark
runs with the same configuration produced zero empty chunks across 90,988
instrumented prefill-chunk invocations:
https://github.com/vllm-project/vllm/pull/55695#issuecomment-5578723131

So this is hardening a path that is reachable by construction, not a fix for an
observable regression. Reasonable to decline on that basis — I would still
argue for it since the suffix semantics and the padding convention are both
unchanged, and the guard removes work rather than adding it.

---

Found and upstreamed by [Hyperloom](https://github.com/AMD-AGI/Hyperloom), an
autonomous inference-optimization agent, which hit the crash while tuning
DeepSeek-V4-Flash on MI355X and produced the reproduction and the fix.
Reviewed and verified by Zheng Gong <zgong@amd.com>.
