### PR TITLE
[Bugfix] Scale TRTLLM NVFP4 KV attention output out of E4M3 subnormals

### DIFF
--- a/tests/v1/attention/test_trtllm_attention_integration.py
+++ b/tests/v1/attention/test_trtllm_attention_integration.py
@@ -195,9 +195,17 @@ def _create_nvfp4_hnd_kv_cache(
     return nvfp4_cache
 
 
-def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL):
+def _run_trtllm_integration(
+    batch_spec, kv_cache_dtype="auto", model_name=MODEL, kv_magnitude=1.0
+):
     """Run TRTLLM attention through the full FlashInfer pipeline
-    and compare against an SDPA reference."""
+    and compare against an SDPA reference.
+
+    Args:
+        kv_magnitude: Scales K and V while dividing the softmax scale by the
+            same factor, leaving the attention weights untouched. The returned
+            output is then exactly proportional to it.
+    """
     set_random_seed(42)
     device = torch.device(f"{DEVICE_TYPE}:0")
 
@@ -218,7 +226,9 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
     )
     head_size = vllm_config.model_config.get_head_size()
     dtype = vllm_config.model_config.dtype
-    scale = 1.0 / (head_size**0.5)
+    # Dividing by kv_magnitude keeps the QK logits, and therefore the softmax
+    # weights, identical across magnitudes.
+    scale = 1.0 / (head_size**0.5) / kv_magnitude
 
     # 1. Generate data and compute SDPA reference
     all_q, all_k, all_v = [], [], []
@@ -231,8 +241,12 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
         ctx_len = s_len - q_len
 
         q = torch.randn(q_len, num_q_heads, head_size, dtype=dtype, device=device)
-        k_full = torch.randn(s_len, num_kv_heads, head_size, dtype=dtype, device=device)
-        v_full = torch.randn(s_len, num_kv_heads, head_size, dtype=dtype, device=device)
+        k_full = torch.randn(
+            s_len, num_kv_heads, head_size, dtype=dtype, device=device
+        ).mul_(kv_magnitude)
+        v_full = torch.randn(
+            s_len, num_kv_heads, head_size, dtype=dtype, device=device
+        ).mul_(kv_magnitude)
 
         # SDPA reference (N=1, H, L, D)
         q_sdpa = q.unsqueeze(0).transpose(1, 2)
@@ -415,6 +429,7 @@ def _run_trtllm_integration(batch_spec, kv_cache_dtype="auto", model_name=MODEL)
     else:
         atol, rtol = 1e-2, 1e-2
     torch.testing.assert_close(output, sdpa_output, atol=atol, rtol=rtol)
+    return output
 
 
 @pytest.mark.parametrize(
@@ -441,4 +456,31 @@ def test_trtllm_gen_nvfp4_kv_integration(batch_spec_name: str):
         BATCH_SPECS[batch_spec_name],
         kv_cache_dtype="nvfp4",
         model_name=MODEL_NVFP4,
+    )
+
+
+@torch.inference_mode()
+def test_trtllm_gen_nvfp4_kv_output_is_magnitude_equivariant():
+    """NVFP4 KV attention must stay proportional as the KV magnitude shrinks.
+
+    The trtllm-gen NVFP4 kernel can only write FP8 E4M3, so a BF16 output is
+    round-tripped through an FP8 scratch buffer. If that round-trip does not
+    carry an output scale, small attention outputs fall under E4M3's smallest
+    normal (2**-6) and are flushed towards zero, which breaks the proportion
+    that holds everywhere else in the pipeline.
+    """
+    shrink = 1.0 / 64.0
+    reference = _run_trtllm_integration(
+        BATCH_SPECS["decode_only"],
+        kv_cache_dtype="nvfp4",
+        model_name=MODEL_NVFP4,
+    )
+    shrunk = _run_trtllm_integration(
+        BATCH_SPECS["decode_only"],
+        kv_cache_dtype="nvfp4",
+        model_name=MODEL_NVFP4,
+        kv_magnitude=shrink,
+    )
+    torch.testing.assert_close(
+        shrunk.float() / shrink, reference.float(), atol=5e-2, rtol=5e-2
     )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2227,10 +2227,9 @@ class FlashInferImpl(AttentionImpl):
                     )
 
                     # NVFP4 trtllm kernel only supports FP8 output.
-                    # Use a pre-allocated FP8 buffer and dequantize
-                    # afterwards.
-                    needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                    # Use a pre-allocated FP8 buffer and rescale afterwards.
+                    needs_fp8_out_prefill = self.is_kvcache_nvfp4 and (
+                        output.dtype not in (FP8_DTYPE, FP4_DTYPE)
                     )
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
@@ -2300,8 +2299,10 @@ class FlashInferImpl(AttentionImpl):
                     out = output[num_decode_tokens:]
 
                 # NVFP4 trtllm kernel only supports FP8 output.
-                # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                # Use a pre-allocated FP8 buffer and rescale afterwards.
+                needs_fp8_out = self.is_kvcache_nvfp4 and (
+                    output.dtype not in (FP8_DTYPE, FP4_DTYPE)
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -2405,9 +2406,11 @@ class FlashInferImpl(AttentionImpl):
                     kv_cache_for_fi = kv_cache_tuple
                 kv_cache_sf = nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
 
-                # NVFP4 kernel only supports FP8 output.
-                # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                # NVFP4 trtllm kernel only supports FP8 output.
+                # Use a pre-allocated FP8 buffer and rescale afterwards.
+                needs_fp8_out = self.is_kvcache_nvfp4 and (
+                    output.dtype not in (FP8_DTYPE, FP4_DTYPE)
+                )
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -2535,8 +2538,10 @@ class FlashInferImpl(AttentionImpl):
                     out = output[:num_decode_tokens]
 
                 # NVFP4 trtllm kernel only supports FP8 output.
-                # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                # Use a pre-allocated FP8 buffer and rescale afterwards.
+                needs_fp8_out = self.is_kvcache_nvfp4 and (
+                    output.dtype not in (FP8_DTYPE, FP4_DTYPE)
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -96,6 +96,8 @@ FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
+# Largest magnitude representable in NVFP4's E2M1 element format.
+NVFP4_E2M1_MAX = 6.0
 
 logger = init_logger(__name__)
 
@@ -1857,6 +1859,7 @@ class FlashInferImpl(AttentionImpl):
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
+        self._nvfp4_output_scale: float | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1868,6 +1871,14 @@ class FlashInferImpl(AttentionImpl):
             )
         else:
             self._nvfp4_fp8_out = None
+
+        if self.is_kvcache_nvfp4 and self.dcp_world_size > 1:
+            raise NotImplementedError(
+                "NVFP4 KV cache is not supported with decode context "
+                "parallelism. The trtllm-gen kernel writes FP8 output that the "
+                "DCP reduction cannot consume, which silently corrupts the "
+                "attention output."
+            )
 
         dcp_a2a = (
             vllm_config is not None
@@ -1945,6 +1956,19 @@ class FlashInferImpl(AttentionImpl):
 
         return query
 
+    def _copy_nvfp4_output(
+        self, output: torch.Tensor, fp8_output: torch.Tensor
+    ) -> None:
+        """Restore the FP8 scratch output into the model dtype.
+
+        Args:
+            output: Destination slice in the model dtype.
+            fp8_output: The kernel's FP8 E4M3 output for the same tokens.
+        """
+        assert self._nvfp4_output_scale is not None
+        output.copy_(fp8_output)
+        output.mul_(self._nvfp4_output_scale)
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -1981,6 +2005,22 @@ class FlashInferImpl(AttentionImpl):
             self.bmm2_scale = 1.0
             if is_quantized_kv_cache(self.kv_cache_dtype):
                 self.bmm2_scale *= layer._v_scale_float
+            if self.is_kvcache_nvfp4 and output_scale is None:
+                # The trtllm-gen NVFP4 kernel can only write FP8 E4M3, so a
+                # model-dtype output has to round-trip through the FP8 scratch
+                # buffer. Attention output is a convex combination of the
+                # dequantized values, so it is bounded by E2M1_MAX * v_scale;
+                # dividing by that bound lands it in E4M3's normal range.
+                # Without it, small outputs fall below E4M3's smallest normal
+                # (2**-6) and are silently flushed towards zero.
+                self._nvfp4_output_scale = NVFP4_E2M1_MAX * layer._v_scale_float
+                self.bmm2_scale /= self._nvfp4_output_scale
+
+        # The wrapper API takes the bmm2 scale as `v_scale`; for NVFP4 that
+        # already carries the FP8 output scale folded in above.
+        wrapper_v_scale = (
+            self.bmm2_scale if self.is_kvcache_nvfp4 else layer._v_scale_float
+        )
 
         prefill_use_trtllm = isinstance(attn_metadata.prefill, TRTLLMPrefill)
         decode_kernel = (
@@ -2206,7 +2246,7 @@ class FlashInferImpl(AttentionImpl):
                             kv_cache_for_fi,
                             self.sinks,
                             self.scale * layer._q_scale_float * layer._k_scale_float,
-                            v_scale=layer._v_scale_float,
+                            v_scale=wrapper_v_scale,
                             out=out_prefill,
                         )
                     else:
@@ -2215,15 +2255,19 @@ class FlashInferImpl(AttentionImpl):
                             kv_cache_for_fi,
                             q_scale=layer._q_scale_float,
                             k_scale=layer._k_scale_float,
-                            v_scale=layer._v_scale_float,
+                            v_scale=wrapper_v_scale,
                             out=out_prefill,
                             kv_cache_sf=kv_cache_sf,
                         )
 
                     if needs_fp8_out_prefill:
-                        output[
-                            num_decode_tokens : num_decode_tokens + num_prefill_tokens
-                        ].copy_(out_prefill)
+                        self._copy_nvfp4_output(
+                            output[
+                                num_decode_tokens : num_decode_tokens
+                                + num_prefill_tokens
+                            ],
+                            out_prefill,
+                        )
             else:
                 assert isinstance(attn_metadata.prefill, TRTLLMPrefill)
                 # prefill_query may be non-contiguous or have degenerate strides
@@ -2329,9 +2373,12 @@ class FlashInferImpl(AttentionImpl):
                 )
 
                 if needs_fp8_out:
-                    output[
-                        num_decode_tokens : num_decode_tokens + num_prefill_tokens
-                    ].copy_(out[:num_prefill_tokens])
+                    self._copy_nvfp4_output(
+                        output[
+                            num_decode_tokens : num_decode_tokens + num_prefill_tokens
+                        ],
+                        out[:num_prefill_tokens],
+                    )
 
         if num_decode_tokens > 0:
             decode_query = query[:num_decode_tokens]
@@ -2399,14 +2446,14 @@ class FlashInferImpl(AttentionImpl):
                         kv_cache_for_fi,
                         q_scale=layer._q_scale_float,
                         k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        v_scale=wrapper_v_scale,
                         out=out_decode,
                         kv_cache_sf=kv_cache_sf,
                         sinks=self.sinks,
                     )
 
-                if needs_fp8_out:
-                    output[:num_decode_tokens].copy_(out_decode)
+                    if needs_fp8_out:
+                        self._copy_nvfp4_output(output[:num_decode_tokens], out_decode)
             else:
                 assert isinstance(attn_metadata.decode, FlashInferTrtllmAPIDecode)
                 # decode_query may be non-contiguous or have degenerate strides
@@ -2568,7 +2615,7 @@ class FlashInferImpl(AttentionImpl):
                         get_dcp_group(),
                     )
                 elif needs_fp8_out:
-                    output[:num_decode_tokens].copy_(out)
+                    self._copy_nvfp4_output(output[:num_decode_tokens], out)
         return output_padded
 
     def do_kv_cache_update(


### PR DESCRIPTION


## Purpose

Fixes #55673.

On Blackwell, the FlashInfer trtllm-gen NVFP4 kernel can only write FP8 E4M3 output. When the model dtype is BF16 and output quantization is not fused, vLLM round-trips the result through an FP8 scratch buffer and casts it back with no output scale, so the payload sits at unit scale.

Clipping is not the problem — attention output is bounded well under E4M3's max. The damage is at the bottom of the range: values below E4M3's smallest normal (2**-6) are silently flushed towards zero.

This PR folds an output scale of `E2M1_MAX * v_scale` into `bmm2_scale` and restores it on copy-back. Attention output is a convex combination of the dequantized values, so that bound keeps the payload inside E4M3's normal range at every KV magnitude. Fused output quantization is unchanged.

It also rejects NVFP4 with decode context parallelism. That combination was already broken independently of this bug: the DCP branch reduces into `output`, then the FP8 copy-back overwrites it from a scratch buffer the kernel never wrote in that branch. Failing loudly beats silent corruption.

**Relationship to #55670.** That PR fixes the same defect with the same scale, and this one does not supersede it — if #55670 lands first, close this. The differences are that #55670 attributes the failure to saturation at FP8 max, and its regression test (`value_bias=1024.0`) constructs that saturation case; measured across realistic magnitudes, clipping is 0.00% while subnormal occupancy reaches 50%, so a fix that addressed only saturation would pass that test without repairing the failure. This PR also
handles the DCP path, which #55670 leaves asserting on a `None` scale. Reviewers may prefer to take those two points as review feedback on #55670 rather than merging this separately.

## Test Plan

```bash
pre-commit run --files \
  vllm/v1/attention/backends/flashinfer.py \
  tests/v1/attention/test_trtllm_attention_integration.py
```

pytest tests/v1/attention/test_trtllm_attention_integration.py -v The new test asserts a property rather than an absolute tolerance: scaling K and V by c while dividing the softmax scale by c leaves the attention weights untouched, so the output must scale by exactly c. The FP8 round-trip is the only stage that breaks that invariant. The existing NVFP4 test compares against SDPA at atol=rtol=1.0, loose enough to pass while broken.

## Test Result\

Not yet run on hardware. I do not have access to a Blackwell GPU, and the suite is uncollectable in my environment (uvloop is unavailable on Windows). ruff check and ruff format pass on both files; mypy could not be run.

What I did verify is the scale arithmetic in isolation — an E4M3 round-trip simulation of the invariant the new test asserts, deviation from the c=1 result:

kv_magnitude | before | after
-- | -- | --
1/8 | 1.46% mean, 100% max | 0.00%
1/64 | 11.50% mean, 100% max | 0.00%
1/512 | 55.82% mean, 100% max | 0.00%

The reporter's GSM8K numbers in #55673 (96.66% FP8-KV vs 6.52% NVFP4-KV on B200) are theirs; I have not reproduced them, and I have not measured end-to-end accuracy after this change. This needs a Blackwell run before merge both the integration test and a GSM8K comparison against the FP8-KV control.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>