### PR TITLE
[Bugfix][Benchmark] Keep unset parameter groups in sweep plots

### DIFF
--- a/tests/benchmarks/sweep/test_plot_curves.py
+++ b/tests/benchmarks/sweep/test_plot_curves.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+
+import pytest
+
+from vllm.benchmarks.sweep.plot import SweepPlotArgs, main
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+@pytest.mark.parametrize("concurrencies", [(None, 32), (None,)])
+@pytest.mark.parametrize(
+    "option,group_by",
+    [
+        ("--curve-by", "max_concurrency"),
+        ("--curve-by", "model,max_concurrency"),
+        ("--curve-by", "model,dtype,max_concurrency"),
+        ("--curve-by", "model,dtype,mode,max_concurrency"),
+        ("--row-by", "max_concurrency"),
+        ("--col-by", "max_concurrency"),
+    ],
+)
+def test_plot_keeps_null_group_values(
+    tmp_path, monkeypatch, option, group_by, concurrencies
+):
+    """Unset sweep parameters must not silently remove benchmark curves."""
+    pytest.importorskip("seaborn")
+    from matplotlib.figure import Figure
+
+    records = [
+        dict(
+            model="model",
+            dtype="auto",
+            mode="default",
+            max_concurrency=concurrency,
+            total_token_throughput=100 * point,
+            median_ttft_ms=3 * index + point,
+        )
+        for index, concurrency in enumerate(concurrencies)
+        for point in (1, 2)
+    ]
+    (tmp_path / "summary.json").write_text(json.dumps(records))
+    lines: list[list[list[float]]] = []
+    savefig = Figure.savefig
+
+    def capture_lines(figure, *args, **kwargs):
+        lines.extend(
+            line.get_xydata().tolist()
+            for axis in figure.axes
+            for line in axis.lines
+            if len(line.get_xdata())
+        )
+        return savefig(figure, *args, **kwargs)
+
+    monkeypatch.setattr(Figure, "savefig", capture_lines)
+    parser = SweepPlotArgs.add_cli_args(FlexibleArgumentParser())
+    main(
+        parser.parse_args(
+            [
+                str(tmp_path),
+                option,
+                group_by,
+                "--no-error-bars",
+                "--fig-dpi",
+                "50",
+            ]
+        )
+    )
+
+    assert sorted(lines) == [
+        [[100, 3 * index + 1], [200, 3 * index + 2]]
+        for index in range(len(concurrencies))
+    ]
+    assert (tmp_path / "FIGURE.png").is_file()

--- a/vllm/benchmarks/sweep/plot.py
+++ b/vllm/benchmarks/sweep/plot.py
@@ -338,9 +338,10 @@ def _plot_fig(
     if curve_by:
         df = df.sort_values(by=curve_by)
 
+    group_labels = {k: df[k].map(str) for k in row_by + col_by + curve_by}
     df["row_group"] = (
         pd.concat(
-            [k + "=" + df[k].astype(str) for k in row_by],
+            [k + "=" + group_labels[k] for k in row_by],
             axis=1,
         ).agg("\n".join, axis=1)
         if row_by
@@ -349,7 +350,7 @@ def _plot_fig(
 
     df["col_group"] = (
         pd.concat(
-            [k + "=" + df[k].astype(str) for k in col_by],
+            [k + "=" + group_labels[k] for k in col_by],
             axis=1,
         ).agg("\n".join, axis=1)
         if col_by
@@ -357,7 +358,9 @@ def _plot_fig(
     )
 
     if len(curve_by) <= 3:
-        hue, style, size, *_ = (*curve_by, None, None, None)
+        # Seaborn drops null grouping values; label them without changing axes.
+        curve_values = [group_labels[k] if df[k].isna().any() else k for k in curve_by]
+        hue, style, size, *_ = (*curve_values, None, None, None)
 
         g = sns.relplot(
             df,
@@ -376,7 +379,7 @@ def _plot_fig(
     else:
         df["curve_group"] = (
             pd.concat(
-                [k + "=" + df[k].astype(str) for k in curve_by],
+                [k + "=" + group_labels[k] for k in curve_by],
                 axis=1,
             ).agg("\n".join, axis=1)
             if curve_by


### PR DESCRIPTION
## Purpose

Fixes #55694.

An unset benchmark parameter can remove an entire curve from a sweep plot. For example, `vllm bench serve` records `max_concurrency: null` when no limit is set, but `--curve-by max_concurrency` silently drops those runs. Null row/column labels and four-key curve labels also fail on pandas 3 because `astype(str)` leaves missing values in the strings passed to `join`.

Build grouping labels with `Series.map(str)`, and use explicit labels for nullable hue/style/size columns. Non-null columns keep their current numeric plotting semantics. The metric data is unchanged, including when an axis is also a grouping variable.

This is independent of #55658 and #55664: it does not change Pareto selection or worker iteration. Searches of open issues/PRs for the issue number, null curves, pandas/null plotting, and the label-joining error found no matching fix. No dependencies are added.

## Test Plan

```bash
MPLBACKEND=Agg PYTHONPATH="$PWD" .venv/bin/python -m pytest \
  --confcutdir=tests/benchmarks \
  tests/benchmarks/sweep/ tests/benchmarks/test_plot_filters.py -q

pre-commit run --files vllm/benchmarks/sweep/plot.py \
  tests/benchmarks/sweep/test_plot_curves.py
```

The focused tests use the real renderer, capture its line coordinates at `savefig`, and still write the PNG. They cover nullable hue, style, size, combined curve labels, rows, and columns, including all-null columns. They skip if optional seaborn is absent. `--confcutdir` avoids loading unrelated model/GPU fixtures on this macOS CPU environment; no GPU suite result is claimed.

Separately ran the plotting CLI through 17 scenarios on pandas 3.0.5 and 2.2.3, using seaborn 0.13.2 and matplotlib 3.11.1. The fixtures have the same shape as saved benchmark summaries. Renderer instrumentation observes line coordinates without replacing rendering or file output. Cases include all grouping positions, mixed/all-null values, filtering, binning, a metric used as a grouping key, and non-null/no-group controls. Also invoked the ordinary module CLI directly and inspected its before/after PNGs.

## Test Result

- Baseline pandas 3: all 12 regression cases failed. The CLI dropped curves or raised label-joining errors in 14 of 17 cases; the three controls passed.
- Baseline pandas 2: the six nullable hue/style/size cases and the filtered/binned variants failed their rendered-data checks; four-key curves and row/column facets already worked.
- Fixed sweep/filter suite: 62 passed on each pandas version.
- Fixed CLI matrix: all 17 cases pass on each pandas version. The non-null and no-group control PNGs are byte-identical to baseline. Numeric line coordinates are preserved, including the axis/group overlap case; missing metric coordinates are not invented.
- Pre-commit passes, including mypy. Reran both 62-test suites, the 17-case pandas 3 CLI matrix, and pre-commit after merging current upstream main.

This changes benchmark visualization only. No model generation, GPU serving, or inference-performance change is claimed. Implementation and validation were performed with Codex; no human review or testing is claimed.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and linked issue.
- [x] Test commands.
- [x] Before/after and end-to-end results.
- [x] Documentation considered: existing grouping options retain their meaning; no new option is introduced.

</details>
