### PR TITLE
[Frontend] Migrate Responses harmony input validation to VLLMValidationError

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -16,6 +16,7 @@ from vllm.entrypoints.openai.responses.harmony import (
     harmony_to_response_output,
     response_previous_input_to_harmony,
 )
+from vllm.exceptions import VLLMValidationError
 
 
 class TestResponsePreviousInputToHarmony:
@@ -91,6 +92,16 @@ class TestResponsePreviousInputToHarmony:
         assert messages[0].author.role == Role.TOOL
         assert messages[0].author.name == "functions.empty_tool"
         assert messages[0].content[0].text == ""
+
+    def test_chat_message_without_role_raises_validation_error(self):
+        """A chat-format message missing the 'role' key is invalid input."""
+        chat_msg = {"content": "hello, no role here"}
+
+        with pytest.raises(
+            VLLMValidationError, match="Message has no 'role' key"
+        ) as exc_info:
+            response_previous_input_to_harmony(chat_msg)
+        assert exc_info.value.parameter == "input"
 
 
 class TestHarmonyToResponseOutput:

--- a/tests/entrypoints/openai/responses/test_response_input_to_harmony.py
+++ b/tests/entrypoints/openai/responses/test_response_input_to_harmony.py
@@ -281,9 +281,7 @@ class TestResponseInputToHarmonyMessage:
     # -----------------------------------------------------------------------
 
     def test_unknown_type_raises_validation_error(self):
-        with pytest.raises(
-            VLLMValidationError, match="Unknown input type"
-        ) as exc_info:
+        with pytest.raises(VLLMValidationError, match="Unknown input type") as exc_info:
             response_input_to_harmony(
                 {"type": "image_url", "url": "https://example.com/img.png"},
                 prev_responses=[],

--- a/tests/entrypoints/openai/responses/test_response_input_to_harmony.py
+++ b/tests/entrypoints/openai/responses/test_response_input_to_harmony.py
@@ -15,6 +15,7 @@ from openai.types.responses.response_reasoning_item import (
 from openai_harmony import DeveloperContent, Role
 
 from vllm.entrypoints.openai.responses.harmony import response_input_to_harmony
+from vllm.exceptions import VLLMValidationError
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -252,7 +253,9 @@ class TestResponseInputToHarmonyMessage:
         assert msg.author.name == "functions.get_weather"
 
     def test_function_call_output_raises_if_no_matching_call(self):
-        with pytest.raises(ValueError, match="No call message found for"):
+        with pytest.raises(
+            VLLMValidationError, match="No call message found for"
+        ) as exc_info:
             response_input_to_harmony(
                 {
                     "type": "function_call_output",
@@ -261,21 +264,28 @@ class TestResponseInputToHarmonyMessage:
                 },
                 prev_responses=[_PREV_CALL],
             )
+        assert exc_info.value.parameter == "input"
 
     def test_function_call_output_raises_on_empty_prev_responses(self):
-        with pytest.raises(ValueError, match="No call message found for"):
+        with pytest.raises(
+            VLLMValidationError, match="No call message found for"
+        ) as exc_info:
             response_input_to_harmony(
                 {"type": "function_call_output", "call_id": "call_test", "output": "x"},
                 prev_responses=[],
             )
+        assert exc_info.value.parameter == "input"
 
     # -----------------------------------------------------------------------
     # Error cases
     # -----------------------------------------------------------------------
 
-    def test_unknown_type_raises_value_error(self):
-        with pytest.raises(ValueError, match="Unknown input type"):
+    def test_unknown_type_raises_validation_error(self):
+        with pytest.raises(
+            VLLMValidationError, match="Unknown input type"
+        ) as exc_info:
             response_input_to_harmony(
                 {"type": "image_url", "url": "https://example.com/img.png"},
                 prev_responses=[],
             )
+        assert exc_info.value.parameter == "input"

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -40,6 +40,7 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponseInputOutputItem,
     ResponsesRequest,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.utils import random_uuid
 
@@ -88,7 +89,10 @@ def _parse_chat_format_message(chat_msg: dict) -> list[Message]:
     """Parse an OpenAI chat-format dict into Harmony messages."""
     role = chat_msg.get("role")
     if role is None:
-        raise ValueError(f"Message has no 'role' key: {chat_msg}")
+        raise VLLMValidationError(
+            f"Message has no 'role' key: {chat_msg}",
+            parameter="input",
+        )
 
     # Assistant message with tool calls
     tool_calls = chat_msg.get("tool_calls")
@@ -184,7 +188,10 @@ def response_input_to_harmony(
                 call_response = prev_response
                 break
         if call_response is None:
-            raise ValueError(f"No call message found for {call_id}")
+            raise VLLMValidationError(
+                f"No call message found for {call_id}",
+                parameter="input",
+            )
         msg = Message.from_author_and_content(
             Author.new(Role.TOOL, f"functions.{call_response.name}"),
             response_msg["output"],
@@ -205,7 +212,10 @@ def response_input_to_harmony(
         msg = msg.with_recipient(f"functions.{response_msg['name']}")
         msg = msg.with_content_type("json")
     else:
-        raise ValueError(f"Unknown input type: {response_msg['type']}")
+        raise VLLMValidationError(
+            f"Unknown input type: {response_msg['type']}",
+            parameter="input",
+        )
     return msg
 
 


### PR DESCRIPTION

Continues the VLLMValidationError migration (siblings of #50254, #50257) for the remaining request-input validation points in Responses harmony input parsing. These raise on malformed user input, so they belong to the client-error (4xx) hierarchy and now carry parameter="input" so the error response can point at the offending field.

Migrated (all in the input-parsing paths of
vllm/entrypoints/openai/responses/harmony.py):
- _parse_chat_format_message: message missing 'role' key
- response_input_to_harmony: function_call_output with no matching call
- response_input_to_harmony: unknown input type

Output-parsing failures (unknown channel / browser action, streaming unknown function name) are intentionally left out: they parse model-generated Harmony output, not user input, so parameter="input" would misattribute them. They should migrate to a server-error type separately.

Tests updated to expect VLLMValidationError and assert exc_info.value.parameter == "input"; adds coverage for the previously untested missing-'role' path.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

