### PR TITLE
[Bugfix][Frontend] Validate batch URL and HTTP method fields

### DIFF
--- a/tests/entrypoints/launchers/test_run_batch.py
+++ b/tests/entrypoints/launchers/test_run_batch.py
@@ -153,7 +153,6 @@ INVALID_INPUT_BATCH = "\n".join(
     ]
 )
 
-
 INPUT_EMBEDDING_BATCH = "\n".join(
     json.dumps(req)
     for req in [
@@ -477,6 +476,23 @@ def test_batch_request_invalid_url_reports_validation_error(payload):
         BatchRequestInput.model_validate(payload)
 
     assert any(error["loc"] == ("url",) for error in exc_info.value.errors())
+
+
+def test_batch_request_rejects_unsupported_method():
+    payload = {
+        "custom_id": "request",
+        "method": "GET",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": "dummy",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        BatchRequestInput.model_validate(payload)
+
+    assert any(error["loc"] == ("method",) for error in exc_info.value.errors())
 
 
 def test_empty_file():

--- a/tests/entrypoints/launchers/test_run_batch.py
+++ b/tests/entrypoints/launchers/test_run_batch.py
@@ -10,11 +10,13 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 import vllm.envs as envs
 from vllm.assets.audio import AudioAsset
 from vllm.connections import HTTPConnection
 from vllm.entrypoints.launchers.run_batch import (
+    BatchRequestInput,
     BatchRequestOutput,
     BatchTranscriptionRequest,
     download_bytes_from_url,
@@ -150,6 +152,7 @@ INVALID_INPUT_BATCH = "\n".join(
         },
     ]
 )
+
 
 INPUT_EMBEDDING_BATCH = "\n".join(
     json.dumps(req)
@@ -449,6 +452,31 @@ INPUT_TOOL_CALLING_BATCH = json.dumps(
         },
     }
 )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"custom_id": "request", "method": "POST", "body": {}},
+        {
+            "custom_id": "request",
+            "method": "POST",
+            "url": None,
+            "body": {},
+        },
+        {
+            "custom_id": "request",
+            "method": "POST",
+            "url": 123,
+            "body": {},
+        },
+    ],
+)
+def test_batch_request_invalid_url_reports_validation_error(payload):
+    with pytest.raises(ValidationError) as exc_info:
+        BatchRequestInput.model_validate(payload)
+
+    assert any(error["loc"] == ("url",) for error in exc_info.value.errors())
 
 
 def test_empty_file():

--- a/vllm/entrypoints/launchers/run_batch.py
+++ b/vllm/entrypoints/launchers/run_batch.py
@@ -10,7 +10,7 @@ from argparse import Namespace
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from io import BytesIO, StringIO
-from typing import Any, NoReturn, TypeAlias
+from typing import Any, Literal, NoReturn, TypeAlias
 from urllib.parse import urlparse
 
 import aiohttp
@@ -172,7 +172,7 @@ class BatchRequestInput(OpenAIBaseModel):
 
     # The HTTP method to be used for the request. Currently only POST is
     # supported.
-    method: str
+    method: Literal["POST"]
 
     # The OpenAI API relative URL to be used for the request. Currently
     # /v1/chat/completions is supported.

--- a/vllm/entrypoints/launchers/run_batch.py
+++ b/vllm/entrypoints/launchers/run_batch.py
@@ -185,7 +185,9 @@ class BatchRequestInput(OpenAIBaseModel):
     @classmethod
     def check_type_for_url(cls, value: Any, info: ValidationInfo):
         # Use url to disambiguate models
-        url: str = info.data["url"]
+        url = info.data.get("url")
+        if not isinstance(url, str):
+            return value
         if url == "/v1/chat/completions":
             return ChatCompletionRequest.model_validate(value)
         if url == "/v1/embeddings":


### PR DESCRIPTION
Malformed batch routing fields currently bypass useful validation: missing/null/non-string `url` leaks a `KeyError` from the body validator, and unsupported HTTP methods such as GET are silently accepted even though execution only supports POST. Let URL field validation report its own error, and constrain the method to the documented POST value. Regression tests assert Pydantic errors are attached to the appropriate fields.

Duplicate check: searched open PRs for `BatchRequestInput validation`, `run_batch HTTP method`, and batch invalid URL validation. #52505 changes output persistence, not request routing validation. Closed #14153 proposed a default method value, not rejecting unsupported methods.

Validation: `.venv/bin/python -m pytest tests/entrypoints/launchers/test_run_batch.py -k 'batch_request_invalid_url or batch_request_rejects_unsupported_method' -q`: 4 passed, 26 deselected. Changed-file pre-commit checks passed. The remaining suite contains model-dependent integration tests and was not run; no model evaluation was run because this change only rejects invalid routing fields before inference.

AI assistance: OpenAI Codex assisted with implementation, review, and local validation.
