### PR TITLE
[Bugfix][Renderer] Preserve prompt text when constructing embedding inputs

### DIFF
--- a/tests/renderers/test_completions.py
+++ b/tests/renderers/test_completions.py
@@ -530,6 +530,26 @@ class TestRenderEmbedPrompt:
         assert len(results) == 1
         assert torch.equal(results[0]["prompt_embeds"], tensor_input)
 
+    def test_prompt_embed_preserves_prompt_text(self):
+        renderer = _build_renderer(MockModelConfig(hidden_size=4))
+        prompt = {
+            "prompt_embeds": torch.zeros(2, 4),
+            "prompt": "source prompt",
+            "prompt_token_ids": [11, 12],
+            "prompt_is_token_ids": [True, False],
+        }
+        (rendered,) = renderer.render_prompts(
+            _preprocess_prompt(renderer.model_config, prompt)
+        )
+        tokenized = renderer.tokenize_prompt(
+            rendered,
+            TokenizeParams(max_total_tokens=10),
+        )
+
+        engine_input = renderer.process_for_engine(tokenized, arrival_time=1.0)
+
+        assert engine_input["prompt"] == "source prompt"
+
     def test_multiple_prompt_embeds(self):
         hidden_size = 512
         renderer = _build_renderer(MockModelConfig(hidden_size=hidden_size))

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -944,6 +944,7 @@ class BaseRenderer(ABC, Generic[_T]):
 
         return embeds_input(
             prompt_embeds=prompt_embeds,
+            prompt=prompt.get("prompt"),
             cache_salt=prompt.get("cache_salt"),
             prompt_token_ids=prompt.get("prompt_token_ids"),
             is_token_ids=prompt.get("prompt_is_token_ids"),


### PR DESCRIPTION
Embedding prompts can carry their original prompt text, but `BaseRenderer._process_embeds()` drops that field when constructing the engine input. Forward the optional text through the existing `embeds_input(prompt=...)` parameter so downstream consumers retain it. A regression covers rendering, tokenization, and conversion to the engine input for a mixed embedding prompt.

Duplicate check: searched open PRs for `process_embeds prompt` and `EmbedsInput prompt`; none addresses this missing text field. Earlier #40720 concerns prompt token IDs, which are already forwarded independently.

Validation: `.venv/bin/python -m pytest tests/renderers/test_completions.py -q`: 29 passed. Changed-file pre-commit checks passed. No model inference evaluation was run: this forwards text metadata while preserving embeddings, token IDs, and their mixed-input mask.

AI assistance: OpenAI Codex assisted with implementation, review, and local validation.
