### PR TITLE
[Bugfix][Core] Preserve terminal metadata when coalescing outputs

### DIFF
--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -3,7 +3,8 @@
 
 import pytest
 
-from vllm.outputs import RequestOutput
+from vllm.outputs import CompletionOutput, RequestOutput, SamplingMask
+from vllm.v1.metrics.stats import RequestSpecDecodeMetrics
 
 pytestmark = pytest.mark.cpu_test
 
@@ -19,3 +20,51 @@ def test_request_output_forward_compatible():
         example_arg_added_in_new_version="some_value",
     )
     assert output is not None
+
+
+def test_request_output_add_preserves_terminal_metadata():
+    accumulated = RequestOutput(
+        request_id="request",
+        prompt=None,
+        prompt_token_ids=[],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text="first",
+                token_ids=[1],
+                cumulative_logprob=None,
+                logprobs=None,
+            )
+        ],
+        finished=False,
+    )
+    sampling_mask = SamplingMask([[10], [20]])
+    spec_decode_metrics = RequestSpecDecodeMetrics.new(num_spec_tokens=2)
+    spec_decode_metrics.observe(num_draft_tokens=2, num_accepted=1)
+    terminal = RequestOutput(
+        request_id="request",
+        prompt=None,
+        prompt_token_ids=[],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text="second",
+                token_ids=[2],
+                cumulative_logprob=None,
+                logprobs=None,
+                finish_reason="length",
+                sampling_mask=sampling_mask,
+                spec_decode_metrics=spec_decode_metrics,
+            )
+        ],
+        finished=True,
+    )
+
+    accumulated.add(terminal, aggregate=True)
+
+    output = accumulated.outputs[0]
+    assert output.token_ids == [1, 2]
+    assert output.sampling_mask is sampling_mask
+    assert output.spec_decode_metrics is spec_decode_metrics

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -189,6 +189,12 @@ class RequestOutput:
                         if next_completion.logprobs:
                             assert completion.logprobs is not None
                             completion.logprobs.extend(next_completion.logprobs)  # type: ignore[arg-type]
+                        if next_completion.sampling_mask is not None:
+                            completion.sampling_mask = next_completion.sampling_mask
+                        if next_completion.spec_decode_metrics is not None:
+                            completion.spec_decode_metrics = (
+                                next_completion.spec_decode_metrics
+                            )
                         completion.cumulative_logprob = (
                             next_completion.cumulative_logprob
                         )


### PR DESCRIPTION
When a slow async consumer coalesces DELTA outputs, `RequestOutput.add(aggregate=True)` copies tokens and finish state but drops the final completion's `sampling_mask` and `spec_decode_metrics`. Preserve non-null values for those fields when updating the accumulated completion. A regression merges an unfinished output with a terminal output and checks both metadata objects and the combined tokens.

Duplicate check: open-PR searches for `sampling_mask coalesc` and `spec_decode_metrics RequestOutput` found no matching fix. #37094 handles routed-expert token alignment, #44052 introduces separate speculative metrics plumbing, and #54335 adds fixed-token prefill scoring; none copies these existing terminal fields in completion aggregation.

Validation: `.venv/bin/python -m pytest tests/test_outputs.py -q`: 2 passed. Changed-file pre-commit checks passed. No model evaluation was run: this preserves already-produced output metadata and does not change sampling or model execution.

AI assistance: OpenAI Codex assisted with implementation, review, and local validation.
