### PR TITLE
[Perf][GDN] Enable the FlashInfer GDN prefill kernel on SM12x

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -100,8 +100,9 @@ def _resolve_gdn_prefill_backend(
     * ``requested in ["flashinfer", "auto"]``;
     * ``platform == cuda``;
     * one of the following:
-      - Hopper (SM90) — no further constraints;
-      - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``.
+      - Hopper (SM90) - no further constraints;
+      - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``;
+      - Blackwell (SM12.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``.
 
     In-tree CuteDSL GDN prefill kernel is chosen when:
     * "cutedsl" is requested; (opt-in only)
@@ -134,6 +135,13 @@ def _resolve_gdn_prefill_backend(
     ):
         supports_flashinfer = True
         supports_cutedsl = True
+    elif (
+        current_platform.is_device_capability_family(120)
+        and head_k_dim == 128
+        and current_platform.get_cuda_runtime_major() >= 13
+    ):
+        # The in-tree CuteDSL kernel targets SM100 only, so it stays off here.
+        supports_flashinfer = True
 
     if backend in ["flashinfer", "auto"] and supports_flashinfer:
         return backend, "flashinfer"


### PR DESCRIPTION
## Purpose

FlashInfer's GDN prefill kernel is never used on SM12x, so consumer and SoC Blackwell (RTX PRO 6000, RTX 5090, DGX Spark GB10) silently runs the Triton/FLA fallback for every linear-attention layer. On Qwen3.5/3.6/3.8 that is 3 of every 4 layers.

`_resolve_gdn_prefill_backend()` only sets `supports_flashinfer` for SM90 or the SM10x family, so SM12x falls through to `return backend, "triton"`.

The gate is now stale.. It was written in #40717 (merged 2026-05-20) to enable FlashInfer's **SM100** kernel. FlashInfer's **SM120** CuTe-DSL delta rule prefill kernel landed later, in [flashinfer-ai/flashinfer#3479](https://github.com/flashinfer-ai/flashinfer/pull/3479) (merged 2026-06-17), and nothing revisited the gate afterwards. FlashInfer ships and tests it: `flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py` is on main, `gdn_prefill.py` imports `chunk_gated_delta_rule_sm120` and `cp_delta_rule_dsl_sm120`, and `tests/gdn/test_prefill_delta_rule.py` guards with *"Skip test if not SM90, SM100, or SM12x (with CUDA 13+) architecture."*

## Fix

Add an SM12x branch using the same conditions as the SM10x one (`head_k_dim == 128`, CUDA >= 13), which match what FlashInfer's own GDN prefill test requires.


## Test Result

Kernel A/B on DGX Spark GB10 (SM121), vLLM `0.28.1rc1.dev388+g8a728663c`, FlashInfer 0.6.18, both arms in one process on one node. Baseline is `vllm.third_party.flash_linear_attention.ops.chunk_gated_delta_rule`, which is what this gate currently selects. FlashInfer is invoked exactly as `fi_chunk_gated_delta_rule()` does it (l2norm, squeeze, `exp(g)`, fp32 state). Geometry from `Qwen3.8-27B`: `linear_num_key_heads=16`, `linear_num_value_heads=48`, `linear_key_head_dim=128`.

| seqlen | FLA/Triton | FlashInfer | speedup |
|---:|---:|---:|---:|
| 1024 | 1.166 ms | 0.305 ms | 3.83x |
| 2048 | 2.333 ms | 0.569 ms | 4.10x |
| 4096 | 4.581 ms | 1.056 ms | 4.34x |
| 8192 | 9.084 ms | 2.008 ms | 4.52x |

### Numerical agreement

Same setup, comparing output and `final_state` against the Triton/FLA path. GDN state layout has been a correctness trap before (the `final_state` transpose issue found on B300 during #40717 review, and flashinfer-ai/flashinfer#3155), so `final_state` is checked explicitly, including varlen batches.

| seq_lens | out max abs | out rel | state max abs | state rel |
|---|---:|---:|---:|---:|
| [1024] | 0.00098 | 0.0118 | 0.00438 | 0.0042 |
| [2048] | 0.00098 | 0.0107 | 0.00421 | 0.0059 |
| [4096] | 0.00098 | 0.0084 | 0.00425 | 0.0055 |
| [256, 256] | 0.00073 | 0.0085 | 0.00477 | 0.0057 |
| [64, 128, 512] | 0.00098 | 0.0122 | 0.00451 | 0.0046 |
| [2048, 2048] | 0.00098 | 0.0084 | 0.00429 | 0.0055 |

All within bf16 tolerance, and `final_state` agrees, so the transpose trap does not apply on this path. Device reported `cc (12, 1)`, CUDA runtime 13.0, so both gate conditions hold.

### End-to-end serving

vLLM `0.28.1rc1.dev388+g8a728663c`, FlashInfer 0.6.18, Qwen3.8-27B NVFP4 with DFlash2 `num_speculative_tokens=7`, `kv_cache_dtype=fp8`, TP1. Both arms use the same container image except for this patch. Acceptance length is forced (`synthetic_acceptance_length=5.695`, measured 5.72) so the two arms decode identical token counts and the comparison isolates prefill.

RTX PRO 6000 Max-Q (SM120), 32768-token shared prefix plus ISL 2048 / OSL 256, prefix caching enabled, measured hit rate 82.5%, `Usage Prompt Tokens` 34868:

| | Triton/FLA | FlashInfer | delta |
|---|---:|---:|---:|
| TTFT, concurrency 1 | 1061.44 ms | 1008.68 ms | 5.0% |
| TTFT, concurrency 4 | 3767.81 ms | 3518.07 ms | 6.6% |
| Request latency, c1 | 2151.66 ms | 2089.85 ms | 2.9% |
| Request latency, c4 | 5137.93 ms | 4860.53 ms | 5.4% |
| Output throughput, c1 | 118.79 tok/s | 122.23 tok/s | 2.9% |
| Output throughput, c4 | 199.20 tok/s | 209.55 tok/s | 5.2% |

DGX Spark GB10 (SM121), ISL 32768 with prefix caching disabled so every request computes all 32768 tokens:

| | Triton/FLA | FlashInfer | delta |
|---|---:|---:|---:|
| TTFT, concurrency 1 | 17972.22 ms | 16679.82 ms | 7.2% |
| TTFT, concurrency 4 | 26348.74 ms | 24400.14 ms | 7.4% |
| Request latency, c1 | 23235.23 ms | 21932.34 ms | 5.6% |
| Request latency, c4 | 78354.18 ms | 73463.86 ms | 6.2% |
| Output throughput, c1 | 11.01 tok/s | 11.67 tok/s | 6.0% |
| Output throughput, c4 | 13.03 tok/s | 13.87 tok/s | 6.4% |

The relative gain is similar across the two shapes because GDN prefill and the layers it competes with are both linear in sequence length, so the ratio is largely length invariant. What changes is the absolute saving: 52.8 ms of TTFT at ISL 2048 computed, against 1292.4 ms at ISL 32768 computed, tracking the roughly 17x difference in computed tokens.

Backend selection was confirmed from the server log on both architectures rather than inferred, with the baseline logging `Using Triton/FLA GDN prefill kernel (requested=auto, head_k_dim=128)` and the patched build logging `Using FlashInfer GDN prefill kernel (requested=auto, head_k_dim=128)`.

## Why this is not a duplicate

I ran the checks in AGENTS.md. Nothing open widens this gate. #38315 optimises the Triton `chunk_gated_delta_rule` path this change routes around, and is complementary. #36414 proposed a PyTorch GDN fallback for SM12.0+ and was closed. #43273 added the in-tree SM100 CuteDSL kernel, which this does not touch.

## AI assistance

AI assistance was used to author this change. I have reviewed every changed line, ran the benchmarks above myself, and can defend the design.
