### PR TITLE
[Bugfix] Parse sweep server addresses consistently with CLI options

### DIFF
--- a/tests/benchmarks/sweep/test_server.py
+++ b/tests/benchmarks/sweep/test_server.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.benchmarks.sweep.server import ServerProcess
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        ([], "http://localhost:8000"),
+        (["--host", "127.0.0.2", "--port", "8001"], "http://127.0.0.2:8001"),
+        (["--host=127.0.0.2", "--port=8001"], "http://127.0.0.2:8001"),
+        (["--host", "127.0.0.2", "-p", "8001"], "http://127.0.0.2:8001"),
+        (["--port", "8001", "--port", "8002"], "http://localhost:8002"),
+        (["-p", "8001", "--port", "8002"], "http://localhost:8002"),
+        (["--host", "::1", "--port", "8001"], "http://[::1]:8001"),
+        (["--host=::1", "--port=8001"], "http://[::1]:8001"),
+        (["--port", "8001", "--port-other", "9000"], "http://localhost:8001"),
+    ],
+)
+def test_server_address(args, expected):
+    server = ServerProcess(["vllm", "serve", "model", *args], [], show_stdout=False)
+    assert server._get_vllm_server_address() == expected

--- a/vllm/benchmarks/sweep/server.py
+++ b/vllm/benchmarks/sweep/server.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
 import contextlib
 import os
 import signal
@@ -9,6 +10,8 @@ from types import TracebackType
 
 import requests
 from typing_extensions import Self
+
+from vllm.utils.network_utils import join_host_port
 
 
 class ServerProcess:
@@ -77,23 +80,11 @@ class ServerProcess:
         self.run_subcommand(self.after_bench_cmd)
 
     def _get_vllm_server_address(self) -> str:
-        server_cmd = self.server_cmd
-
-        for host_key in ("--host",):
-            if host_key in server_cmd:
-                host = server_cmd[server_cmd.index(host_key) + 1]
-                break
-        else:
-            host = "localhost"
-
-        for port_key in ("-p", "--port"):
-            if port_key in server_cmd:
-                port = int(server_cmd[server_cmd.index(port_key) + 1])
-                break
-        else:
-            port = 8000  # The default value in vllm serve
-
-        return f"http://{host}:{port}"
+        parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+        parser.add_argument("--host", default="localhost")
+        parser.add_argument("-p", "--port", type=int, default=8000)
+        args, _ = parser.parse_known_args(self.server_cmd)
+        return f"http://{join_host_port(args.host, args.port)}"
 
     def is_server_ready(self) -> bool:
         server_address = self._get_vllm_server_address()


### PR DESCRIPTION
## Purpose

Fixes #55714.

Sweep readiness and cache resets derive the server URL by manually scanning CLI arguments. That misses `--host=...` / `--port=...`, picks the first repeated port instead of the last, and leaves IPv6 literals unbracketed.

Use `argparse.parse_known_args()` for the two address options and the existing `join_host_port()` helper for URL formatting. Defaults and the separate `-p` alias remain supported. Unrelated server options are ignored without allowing prefix abbreviation. Both readiness and all three cache resets use this shared method.

## Test Plan

```bash
pytest --confcutdir=tests/benchmarks tests/benchmarks/sweep -q
pre-commit run --files vllm/benchmarks/sweep/server.py tests/benchmarks/sweep/test_server.py
```

Also ran native `vllm bench sweep serve` end to end with a real CPU server and benchmark process for separate IPv4 options, equals options, repeated ports, and IPv6 loopback. Each run submits two requests, resets prefix/multimodal/encoder caches, writes run JSON and summary CSV, and stops the server.

The runtime is the official `vllm/vllm-openai-cpu:v0.28.0-arm64` image (digest `sha256:dbc1b4da66bbc0cb3a3f6859cd9046833f9540d34322b192625868f888e8e094`), with only pandas 3.0.5 added for benchmark summaries. Its original sweep server module is byte-identical to main `58ad1f3`. Before/after runs mount the respective module read-only. Model: SmolLM2-135M-Instruct revision `12fd25f77366fa6b3b4b768ec3050bf629380bac`, float32 CPU, four threads, max model length 256, 64 MiB KV cache, offline weights. No mocked inference or GPU claim.

## Test Result

- Regression cases: **5 fail / 4 pass before; 9 pass after**.
- Sweep test directory: **32 passed**. Pre-commit passes, including mypy and DCO.
- Native sweep: the separate-option control passes before and after. Equals options, repeated ports and IPv6 fail readiness before; **all four pass after**.
- Each final run completes both requests with zero failures and six output tokens. All three cache reset endpoints return HTTP 200, and summary export completes.

Prepared and tested with Codex. No independent human review or human-run test is claimed.

---

- [x] Purpose and linked issue
- [x] Test commands
- [x] Before/after and end-to-end results
- [x] Documentation considered; no public option was added
