### PR TITLE
[Bugfix][Frontend] Return all logprobs when completions requests logprobs=-1

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -15,6 +15,7 @@ from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.scale_out.render.serving import ServingRender
 from vllm.exceptions import GenerationError, VLLMValidationError
+from vllm.logprobs import Logprob
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.renderers.hf import HfRenderer
 from vllm.renderers.online_renderer import OnlineRenderer
@@ -592,6 +593,45 @@ def test_logprobs_minus_one_allowed():
         logprobs=-1,
     )
     assert request.logprobs == -1
+
+
+def _minimal_serving_completion() -> OpenAIServingCompletion:
+    """A serving object with only what `_create_completion_logprobs` reads."""
+    serving = OpenAIServingCompletion.__new__(OpenAIServingCompletion)
+    serving.return_tokens_as_token_ids = False
+    return serving
+
+
+@pytest.mark.parametrize(
+    ("num_output_top_logprobs", "expected"),
+    [(-1, 3), (1, 2), (2, 3)],
+)
+def test_completion_logprobs_honors_requested_count(
+    num_output_top_logprobs: int, expected: int
+):
+    """`logprobs=-1` asks for every logprob, so none may be filtered out.
+
+    The validator accepts -1 and the sampler expands it to the vocabulary, so
+    dropping the candidates here would return an empty `top_logprobs` for every
+    position while still charging for the full computation.
+    """
+    tokenizer = MagicMock()
+    tokenizer.decode = lambda token_ids: f"tok{token_ids[0]}"
+    step_logprobs = {
+        10: Logprob(logprob=-0.1, decoded_token="a"),
+        11: Logprob(logprob=-0.2, decoded_token="b"),
+        12: Logprob(logprob=-0.3, decoded_token="c"),
+    }
+
+    logprobs = _minimal_serving_completion()._create_completion_logprobs(
+        token_ids=[10],
+        top_logprobs=[step_logprobs],
+        num_output_top_logprobs=num_output_top_logprobs,
+        tokenizer=tokenizer,
+    )
+
+    assert logprobs.top_logprobs is not None
+    assert len(logprobs.top_logprobs[0]) == expected
 
 
 def test_logprobs_below_minus_one_rejected():

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -720,7 +720,9 @@ class OpenAIServingCompletion(GenerateBaseServing):
                             return_as_token_id=should_return_as_token_id,
                         ): max(top_lp[1].logprob, -9999.0)
                         for i, top_lp in enumerate(step_top_logprobs.items())
-                        if logprob_token_ids or num_output_top_logprobs >= i
+                        if logprob_token_ids
+                        or num_output_top_logprobs == -1
+                        or num_output_top_logprobs >= i
                     }
                 )
 


### PR DESCRIPTION
## Purpose

`logprobs=-1` on `/v1/completions` means "return every logprob". The request validator accepts it explicitly (`completion/protocol.py:538-547` special-cases `-1` as valid) and `SamplingParams` expands it to the vocabulary size (`sampling_params.py:818-820`), so the engine computes full-vocabulary logprobs. But the serialization filter is purely `>=`-based:

```python
for i, top_lp in enumerate(step_top_logprobs.items())
if logprob_token_ids or num_output_top_logprobs >= i
```

With `num_output_top_logprobs == -1`, `-1 >= 0` is False, so the comprehension drops every candidate at every position. The client gets HTTP 200 with `logprobs.tokens` and `logprobs.token_logprobs` populated but `top_logprobs == [{}, {}, ...]` — silent data loss, after paying the full-vocabulary compute cost.

The chat handler already handles this correctly (`chat_completion/serving.py:1236-1238`):

```python
if return_all
or top_logprobs == -1
or (top_logprobs is not None and i < top_logprobs)
```

This applies the same rule to completions. One-line condition change plus regression coverage.

**Not a duplicate.** Per the duplicate-work checks in `AGENTS.md`:

```
gh pr list --repo vllm-project/vllm --state open --search "completion logprobs"
gh pr list --repo vllm-project/vllm --state open --search "top_logprobs"
gh issue list --repo vllm-project/vllm --state open --search "completions logprobs -1"
```

The nearest open PRs address different defects: #53722 guards a `KeyError` when the sampled token is missing from top logprobs; #47838 preserves logprobs when `top_logprobs` is *null*; #49320 handles an empty `logprob_token_ids` list. None touches the `-1` path. No open issue reports this.

**Existing coverage gap.** `tests/entrypoints/openai/completion/test_completion_error.py::test_logprobs_minus_one_allowed` asserts only that the *request validator* accepts `-1` (`assert request.logprobs == -1`) — it never inspects the response. The chat side does assert the full-vocabulary result (`test_chat_echo.py:110-131`, `len(top_logprobs) == vocab_size`). That asymmetry is why this survived.

## Test Plan

The defect is in result serialization, so it is reachable without an engine, a model, or a GPU. `_create_completion_logprobs` reads only `self.return_tokens_as_token_ids`, so the test constructs the serving object via `__new__` — the same pattern `tests/entrypoints/openai/chat_completion/test_serving_chat.py:625-640` already uses.

Added `test_completion_logprobs_honors_requested_count`, parametrized over `-1`, `1`, `2` against a three-candidate step, next to the existing `-1` validator test.

```bash
cd vllm
.venv/bin/python -m pytest tests/entrypoints/openai/completion/test_completion_error.py
.venv/bin/python -m pre_commit run --files \
  vllm/entrypoints/openai/completion/serving.py \
  tests/entrypoints/openai/completion/test_completion_error.py
```

## Test Result

```text
$ .venv/bin/python -m pytest tests/entrypoints/openai/completion/test_completion_error.py
34 passed in 17.84s

$ .venv/bin/python -m pre_commit run --files <the two files above>
ruff check .......... Passed
ruff format ......... Passed
typos ............... Passed
(exit 0)
```

Negative control — reverting only `serving.py` and keeping the tests:

```text
>       assert len(logprobs.top_logprobs[0]) == expected
E       assert 0 == 3
1 failed, 2 passed
```

Only the `-1` case flips. The `1 → 2` and `2 → 3` cases pass both before and after, so the change is scoped to the broken path and does not alter the normal one.

**Model evals:** not applicable. This changes only how already-computed logprobs are serialized into the HTTP response; it does not touch sampling, the model, or generated token ids. No accuracy or serving-quality metric is affected.

**Environment note:** vLLM publishes no precompiled wheel for macOS arm64, so `VLLM_USE_PRECOMPILED=1 uv pip install -e .` is unavailable on this machine. The tests above ran against the source tree in a `uv` venv with CPU torch and the transitive imports installed; they exercise pure-Python serialization and need no compiled kernels. Full-CI confirmation is welcome.

## Open question for maintainers

`logprobs=0` is handled inconsistently between the two endpoints, and I have deliberately **not** changed it here since it would alter existing behaviour:

| value | completions (`num_output_top_logprobs >= i`) | chat (`i < top_logprobs`) |
|---|---|---|
| `0` | keeps 1 candidate | keeps 0 candidates |
| `1` | keeps 2 | keeps 1 |
| `-1` | keeps 0 *(this PR: all)* | keeps all |

OpenAI's completions API documents `logprobs=n` as "the n most likely tokens", so completions returning `n + 1` looks off-by-one — but it is long-standing behaviour that clients may depend on, and `test_completion.py` has cases built around it. Happy to follow up in a separate PR if you would like it aligned.

---

*AI assistance was used for this change.* An agent located the defect by auditing the entrypoints package, drafted the fix and the tests, and ran the commands above. I reviewed every changed line, ran the test suite and the negative control myself, and can defend the change end-to-end.
