### PR TITLE
[Docs] Fix context_extension example filename in link text

### DIFF
--- a/docs/features/context_extension.md
+++ b/docs/features/context_extension.md
@@ -6,7 +6,7 @@ This directory contains examples for extending the context length of models usin
 
 ## Offline Inference Example
 
-The [`context_extension.py`](../../examples/features/context_extension/context_extension_offline.py) script demonstrates how to extend the context length of a Qwen model using the YARN method (rope_parameters) and run a simple chat example.
+The [`context_extension_offline.py`](../../examples/features/context_extension/context_extension_offline.py) script demonstrates how to extend the context length of a Qwen model using the YARN method (rope_parameters) and run a simple chat example.
 
 ### Usage
 


### PR DESCRIPTION
## Purpose

The offline-inference section of `docs/features/context_extension.md` linked to the correct example file, but the markdown **display text** still said `context_extension.py`. On `main`, the only file under `examples/features/context_extension/` is `context_extension_offline.py` (there is no `context_extension.py`), so the link label was stale/misleading.

## Local reproduction

Verified against `vllm-project/vllm` default `main` HEAD `58ad1f3b8973b23943107b51230d594050b42ec3` via GitHub Contents / raw (no local clone):

```bash
# Only context_extension_offline.py exists
gh api repos/vllm-project/vllm/contents/examples/features/context_extension?ref=main --jq '.[].name'
# -> context_extension_offline.py

# Doc link label still says context_extension.py
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/features/context_extension.md | sed -n '9p'
# -> The [`context_extension.py`](.../context_extension_offline.py) script ...
```

The Usage block already uses the correct path; only the link label was wrong.

## Changes

- `docs/features/context_extension.md`: link display text `context_extension.py` → `context_extension_offline.py` (href unchanged).
