### PR TITLE
[Core][Performance] Overlap async KV loads

### DIFF
--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -250,10 +250,7 @@ def test_interleaved_lifecycle():
 
 def test_async_load_admitted_after_token_budget_exhausted():
     batch_size = 16
-    vllm_config = create_vllm_config(
-        max_num_batched_tokens=batch_size,
-        kv_role="kv_producer",
-    )
+    vllm_config = create_vllm_config(max_num_batched_tokens=batch_size)
     scheduler = create_scheduler(vllm_config)
 
     local_request = create_request(request_id=1, num_tokens=batch_size)

--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -248,6 +248,37 @@ def test_interleaved_lifecycle():
     assert_scheduler_empty(scheduler)
 
 
+def test_async_load_admitted_after_token_budget_exhausted():
+    batch_size = 16
+    vllm_config = create_vllm_config(
+        max_num_batched_tokens=batch_size,
+        kv_role="kv_producer",
+    )
+    scheduler = create_scheduler(vllm_config)
+
+    local_request = create_request(request_id=1, num_tokens=batch_size)
+    remote_request = create_request(
+        request_id=2,
+        num_tokens=batch_size * 2,
+        do_remote_prefill=True,
+    )
+    scheduler.add_request(local_request)
+    scheduler.add_request(remote_request)
+
+    with patch.object(
+        scheduler.connector,
+        "get_num_new_matched_tokens",
+        side_effect=[(0, False), (batch_size, True)],
+    ):
+        scheduler_output = scheduler.schedule()
+
+    assert scheduler_output.num_scheduled_tokens == {
+        local_request.request_id: batch_size
+    }
+    assert remote_request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert remote_request in scheduler.skipped_waiting
+
+
 def test_no_spurious_prefix_caching():
     """
     With P/D, blocks can be allocated but uncomputed for

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -149,11 +149,6 @@ class Scheduler(SchedulerInterface):
         # KVConnectorBase_V1.requires_kv_delivery.
         self.requires_kv_delivery = False
         kv_transfer_config = self.vllm_config.kv_transfer_config
-        self._allow_zero_budget_async_kv_loads = (
-            kv_transfer_config is not None
-            and kv_transfer_config.is_kv_producer
-            and not kv_transfer_config.is_kv_consumer
-        )
         if kv_transfer_config is not None:
             assert not self.is_encoder_decoder, (
                 "Encoder-decoder models are not currently supported with KV connectors"
@@ -826,10 +821,12 @@ class Scheduler(SchedulerInterface):
             step_skipped_waiting = create_request_queue(self.policy)
 
             while self.waiting or self.skipped_waiting:
-                async_load_only = token_budget <= 0 or input_budget <= draft_slots
+                compute_budget_exhausted = (
+                    token_budget <= 0 or input_budget <= draft_slots
+                )
                 if (
-                    async_load_only
-                    and not self._has_pending_waiting_async_load_candidate()
+                    compute_budget_exhausted
+                    and self.vllm_config.kv_transfer_config is None
                 ):
                     break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
@@ -1001,7 +998,7 @@ class Scheduler(SchedulerInterface):
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
-                elif async_load_only:
+                elif compute_budget_exhausted:
                     request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
@@ -2322,15 +2319,6 @@ class Scheduler(SchedulerInterface):
             return self.waiting if waiting_req < skipped_req else self.skipped_waiting
 
         return self.waiting or self.skipped_waiting or None
-
-    def _has_pending_waiting_async_load_candidate(self) -> bool:
-        if not self._allow_zero_budget_async_kv_loads or self.connector is None:
-            return False
-        return any(
-            request.status == RequestStatus.WAITING for request in self.waiting
-        ) or any(
-            request.status == RequestStatus.WAITING for request in self.skipped_waiting
-        )
 
     def _handle_stopped_request(self, request: Request) -> bool:
         """Return True if finished (can be False for resumable requests)."""

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -149,6 +149,11 @@ class Scheduler(SchedulerInterface):
         # KVConnectorBase_V1.requires_kv_delivery.
         self.requires_kv_delivery = False
         kv_transfer_config = self.vllm_config.kv_transfer_config
+        self._allow_zero_budget_async_kv_loads = (
+            kv_transfer_config is not None
+            and kv_transfer_config.is_kv_producer
+            and not kv_transfer_config.is_kv_consumer
+        )
         if kv_transfer_config is not None:
             assert not self.is_encoder_decoder, (
                 "Encoder-decoder models are not currently supported with KV connectors"
@@ -820,8 +825,12 @@ class Scheduler(SchedulerInterface):
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
 
-            while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if input_budget <= draft_slots:
+            while self.waiting or self.skipped_waiting:
+                async_load_only = token_budget <= 0 or input_budget <= draft_slots
+                if (
+                    async_load_only
+                    and not self._has_pending_waiting_async_load_candidate()
+                ):
                     break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
                 # in `running` but still hold a model-runner request slot.
@@ -992,6 +1001,10 @@ class Scheduler(SchedulerInterface):
                     # KVTransfer: loading remote KV, do not allocate for new work.
                     assert num_external_computed_tokens > 0
                     num_new_tokens = 0
+                elif async_load_only:
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
                 elif defer_prefills and num_computed_tokens < request.num_tokens - 1:
                     # DP prefill balancing: defer this step's local prefill
                     # compute to a cadence-aligned step.
@@ -2309,6 +2322,15 @@ class Scheduler(SchedulerInterface):
             return self.waiting if waiting_req < skipped_req else self.skipped_waiting
 
         return self.waiting or self.skipped_waiting or None
+
+    def _has_pending_waiting_async_load_candidate(self) -> bool:
+        if not self._allow_zero_budget_async_kv_loads or self.connector is None:
+            return False
+        return any(
+            request.status == RequestStatus.WAITING for request in self.waiting
+        ) or any(
+            request.status == RequestStatus.WAITING for request in self.skipped_waiting
+        )
 
     def _handle_stopped_request(self, request: Request) -> bool:
         """Return True if finished (can be False for resumable requests)."""


### PR DESCRIPTION
## Purpose

A scheduler with a KV connector may load cached KV asynchronously. The waiting-request admission loop currently exits as soon as running requests consume the step's token or input budget. This delays an eligible remote load until a later step and prevents the transfer from overlapping current model execution.

This change lets configurations with `kv_transfer_config` inspect WAITING requests after the local compute budgets are exhausted. In this path, only requests for which the connector returns `load_kv_async=True` are admitted with zero scheduled tokens. Requests that still need local compute are requeued. Configurations without KV transfer keep the existing behavior.

Duplicate check: open pull requests were searched for `async KV zero token budget`, `async KV load scheduler`, `producer async KV admission`, and `WAITING token budget KV`. Related pull requests #42568 and #45406 address request-limit accounting and blocked queue-head recovery respectively; neither enables zero-budget async-load admission.

## Test Plan


## Test Result


## Documentation Update

None. The change does not add or alter a user-facing option.