### PR TITLE
[Tests] Update SarvamMLA transformers v5 compatibility reason to hf

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -538,9 +538,9 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
         is_available_online=True,
         max_transformers_version="5.3",
         transformers_version_reason={
-            "vllm": (
-                "vllm upgraded transformers above v5.4 where "
-                "validate_rope() no longer accepts ignore_keys param"
+            "hf": (
+                "Transformers v5.4 removed the ignore_keys param from "
+                "validate_rope(); vLLM patches validate_rope() and is unaffected"
             )
         },
     ),


### PR DESCRIPTION
## Purpose
Fixes part of tracking issue #38379 ("Transformers v5 Compatibility").

In tracking issue #38379, models incompatible with Transformers v5 were gated in `tests/models/registry.py`. Specifically, sub-issue #38734 tracked that `sarvamai/sarvam-105b` (`SarvamMLAForCausalLM`) failed on Transformers v5+ because Hugging Face removed the `ignore_keys` parameter from `validate_rope()`.

PR #38804 fixed forward compatibility in vLLM by adding `_patch_hf_transformers_validate_rope()` and including `"sarvam_mla"` in `_PATCH_HF_VALIDATE_ROPE`, closing #38734.

However, `tests/models/registry.py` still attributed the incompatibility reason to `"vllm"`, causing test suites checking vLLM (e.g. `test_registry_imports` in `tests/models/test_registry.py`) to skip `SarvamMLAForCausalLM`.

This PR updates `transformers_version_reason` from `"vllm"` to `"hf"` (matching the pattern used by `Step3VLForConditionalGeneration`), which unblocks vLLM tests while continuing to guard raw HF reference tests against upstream Hub incompatibilities.

## Why this is not duplicating an existing PR
I performed duplicate-work checks before opening this PR:
- `gh pr list --repo vllm-project/vllm --state open --search "SarvamMLA"` -> 0 open PRs
- `gh pr list --repo vllm-project/vllm --state open --search "sarvam-105b"` -> 0 open PRs
- `gh pr list --repo vllm-project/vllm --state open --search "validate_rope"` -> 0 open PRs
- `gh pr list --repo vllm-project/vllm --state open --search "38379 in:body"` -> checked related PRs; this pending item in #38379 is unclaimed.

## Test Plan
Run registry tests and pre-commit linters:
- `.venv/bin/python -m pytest tests/models/test_registry.py -k SarvamMLA -v -rs`
- `pre-commit run --files tests/models/registry.py`

## Test Result
1. `tests/models/test_registry.py`:
```console
$ .venv/bin/python -m pytest tests/models/test_registry.py -k SarvamMLA -v -rs
============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /Users/abhi/Desktop/bugs fix/vllm-agi/vllm-agi/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/abhi/Desktop/bugs fix/vllm-agi/vllm-agi
configfile: pyproject.toml
plugins: mock-3.15.1, timeout-2.4.0, asyncio-1.4.0, rerunfailures-16.6.1, forked-1.7.5, anyio-4.15.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 399 items / 398 deselected / 1 selected

tests/models/test_registry.py::test_registry_imports[SarvamMLAForCausalLM] PASSED [100%]

================ 1 passed, 398 deselected, 14 warnings in 0.71s ================
```
(Previously, this test was `SKIPPED [1] tests/models/registry.py:179: 'transformers==5.16.1' installed, but 'transformers<=5.3' is required to run this model. Reason(vllm): vllm upgraded transformers above v5.4 where validate_rope() no longer accepts ignore_keys param`).

2. All pre-commit hooks passed:
```console
$ pre-commit run --files tests/models/registry.py
ruff check...............................................................Passed
ruff format..............................................................Passed
typos....................................................................Passed
Run mypy for Python 3.10.................................................Passed
Check SPDX headers.......................................................Passed
Check root lazy imports..................................................Passed
Check for spaces in all filenames........................................Passed
Update Dockerfile dependency graph.......................................Passed
Check for forbidden imports..............................................Passed
Prevent new 'torch.cuda' APIs call.......................................Passed
Validate configuration has default values and that each field has a docstring...Passed
Check for boolean ops in with-statements.................................Passed
Suggestion...............................................................Passed
Sign-off Commit..........................................................Passed
```

## Model Evaluation
N/A - This change only updates the test suite metadata in `tests/models/registry.py` and does not affect model weights, kernels, or output generation.

## AI Assistance Disclosure
This pull request was prepared with the assistance of an AI coding agent (Antigravity). All changes and tests have been reviewed and verified locally.
