### PR TITLE
[Bugfix][XPU] Fix KDA RecoverSSM device-pointer overflow

### DIFF
--- a/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
+++ b/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
@@ -13,6 +13,17 @@ from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 
+def _reinterpret_u64_as_i64(value: int) -> int:
+    """Preserve a uint64 pointer bit pattern in a torch.int64 tensor.
+
+    XPU device pointers can exceed 2**63, which a signed int64 tensor cannot
+    hold. The kernels below recover the address with ``tl.pointer_type``, which
+    reinterprets the word rather than converting it, so the wrapped value
+    round-trips exactly.
+    """
+    return value if value < (1 << 63) else value - (1 << 64)
+
+
 @triton.jit
 def _kda_gate(
     raw_g,
@@ -854,7 +865,7 @@ class KDARecoverSSMCommitContext:
 
         def _base_addrs(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
             return torch.tensor(
-                [tensor.data_ptr() for tensor in tensors],
+                [_reinterpret_u64_as_i64(tensor.data_ptr()) for tensor in tensors],
                 dtype=torch.int64,
                 device=device,
             )


### PR DESCRIPTION
## Purpose

`KDARecoverSSMCommitContext` stores raw device pointers in a `torch.int64`
tensor. XPU USM addresses exceed `2**63`, so building the metadata raises before
any kernel launches:

```
XPU data_ptr() = 0xffffd556b6400000 = 18446697167134392320 > int64 max 9223372036854775807

vllm/models/kimi_k3/nvidia/ops/recoverssm.py:856: ValueError
E   ValueError: Overflow when unpacking long long
```

Not a regression: `recoverssm.py` has one commit ever (#51855), which added the
code and the failing tests together. CUDA/ROCm pointers are always below
`2**63`.

## Fix

Wrap `data_ptr()` in the two's-complement rewrite the tree already uses twice for
this exact problem — `_reinterpret_u64_as_i64` in `vllm/v1/worker/mamba_utils.py`
(#48109) and `_to_i64_ptr` in `vllm/device_allocator/xpumem.py`. The kernels
recover the address via `tl.pointer_type`, which reinterprets rather than
converts, so the wrapped value round-trips. Below `2**63` the helper is the
identity, leaving CUDA/ROCm provably unchanged.

`_base_addrs` is the single funnel for all four pointer buffers. Strides stay
`int64` — they are element counts, not addresses. Deduplicating the three copies
is RFC #50834's scope (open, unimplemented); this PR stays on the bug.

## Not a duplicate

`is:pr is:open recoverssm` (#55688, #55215, #54495, #54255, #54103, #53298) and
`is:pr is:open pointer overflow xpu` — none touches device pointers in this file.
RFC #50834 has no implementation and does not mention K3.

## Test plan and result

Arc Pro B70, torch 2.13.0+xpu, triton 3.7.2. Tested file sha256-matched to the
committed blob.

```bash
pytest tests/models/kimi_k3/test_kda.py -k recoverssm -q  # 4F/1P    -> 5 passed
pytest tests/models/kimi_k3/test_kda.py -q                # 47P/4F/11S -> 51P/0F/11S
```

The 11 skips are pre-existing platform gates, unchanged. No CUDA run: the change
is an identity below `2**63`.

The reachable XPU config is `Kimi-Linear-48B --use-replayssm
--num-speculative-tokens N --mamba-backend triton` — the validator accepts
`KimiLinearForCausalLM` and requires the Triton mamba backend. I have not run
that end-to-end; it needs TP=4 and my box is single-card.

## Model evaluation

N/A: a provable no-op on CUDA/ROCm, and on XPU the path raised before any kernel
ran, so there is no prior behaviour to compare against. The four existing tests
check RecoverSSM against a reference, not just the absence of a crash.

## AI assistance

AI assistance (Claude Code) was used for the investigation, the XPU measurements
and this description. As the submitting human I reviewed every changed line.
