### PR TITLE
[Bugfix][Core] Make encoder-decoder encoder-cache frees idempotent

### DIFF
--- a/tests/v1/core/test_encoder_cache_manager.py
+++ b/tests/v1/core/test_encoder_cache_manager.py
@@ -453,3 +453,37 @@ def test_encoder_decoder_cache_manager_reset_allows_fresh_allocations():
 
     assert manager.num_free_slots == 2
     assert "img2" in manager.allocated
+
+
+def test_encoder_decoder_repeated_free_is_noop():
+    """The scheduler frees a request's encoder inputs on every step; freeing
+    the same input again must not inflate the budget beyond cache_size."""
+    manager = EncoderDecoderCacheManager(cache_size=100)
+    req = MockRequest("r1", ["imgA"], [40])
+
+    manager.allocate(req, 0)
+    assert manager.num_free_slots == 60
+
+    for _ in range(5):
+        for input_id in list(manager.get_cached_input_ids(req)):
+            manager.free_encoder_input(req, input_id)
+
+    assert manager.num_free_slots == 100
+
+
+def test_encoder_decoder_free_then_reallocate_is_freeable_again():
+    """After preemption frees all inputs, a resumed request re-allocates and
+    its inputs must be freeable again."""
+    manager = EncoderDecoderCacheManager(cache_size=100)
+    req = MockRequest("r1", ["imgA"], [40])
+
+    manager.allocate(req, 0)
+    manager.free(req)
+    assert manager.num_free_slots == 100
+
+    manager.allocate(req, 0)
+    assert manager.num_free_slots == 60
+
+    for _ in range(2):
+        manager.free_encoder_input(req, 0)
+    assert manager.num_free_slots == 100

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -350,12 +350,17 @@ class EncoderDecoderCacheManager(EncoderCacheManager):
         self.num_free_slots = cache_size
         self.allocated: list[str] = []
         self.to_free: list[str] = []
+        # Track freed encoder inputs per request: the scheduler frees the
+        # inputs of a request on every step, and re-freeing must not
+        # inflate num_free_slots.
+        self.freed_inputs: dict[str, set[int]] = {}
 
     def reset(self) -> None:
         """Reset the encoder cache to its initial state."""
         self.num_free_slots = self.cache_size
         self.allocated.clear()
         self.to_free.clear()
+        self.freed_inputs.clear()
 
     def check_and_update_cache(self, request: Request, input_id: int) -> bool:
         return False
@@ -383,9 +388,14 @@ class EncoderDecoderCacheManager(EncoderCacheManager):
         mm_hash = request.mm_features[input_id].identifier
         self.allocated.append(mm_hash)
 
+        # A re-allocated input must be freeable again (e.g. after
+        # preemption and resume).
+        self.freed_inputs.setdefault(request.request_id, set()).discard(input_id)
+
     def free(self, request: Request) -> None:
         for input_id in range(len(request.mm_features)):
             self.free_encoder_input(request, input_id)
+        self.freed_inputs.pop(request.request_id, None)
 
     def get_cached_input_ids(self, request: Request) -> set[int]:
         return set(range(len(request.mm_features)))
@@ -401,5 +411,10 @@ class EncoderDecoderCacheManager(EncoderCacheManager):
         return to_free
 
     def free_encoder_input(self, request: Request, input_id: int) -> None:
+        freed = self.freed_inputs.setdefault(request.request_id, set())
+        if input_id in freed:
+            # Already freed: the scheduler calls this on every step.
+            return
+        freed.add(input_id)
         num_encoder_embeds = request.get_num_encoder_embeds(input_id)
         self.num_free_slots += num_encoder_embeds


### PR DESCRIPTION
## Purpose

Fixes #55733. The scheduler frees a request's encoder inputs on every step (`update_from_output` → `_free_encoder_inputs`), but for encoder-decoder models `EncoderDecoderCacheManager.get_cached_input_ids` returns all inputs each call and `free_encoder_input` unconditionally re-added `num_encoder_embeds` to `num_free_slots`. The budget inflates by the encoder size per decode step (100 → 300 in 5 steps in the repro), so `can_allocate` admits more concurrent encoder-decoder prefills than the cache allows. Track freed inputs per request; a re-allocated input (preemption/resume) is freeable again.

## Test Plan

.venv/bin/python -m pytest tests/v1/core/test_encoder_cache_manager.py -v

## Test Result

Without fix: 2 failed (repeated free inflates the budget; re-allocated input not freeable). With fix: 22 passed.

AI assistance: fix and tests drafted with GLM-5.3; reviewed and verified by hand.
