### PR TITLE
[Frontend] Migrate input-validation errors to VLLMValidationError (harmony/mistral/chat_utils/params)

### DIFF
--- a/tests/entrypoints/openai/test_render_parity.py
+++ b/tests/entrypoints/openai/test_render_parity.py
@@ -29,6 +29,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionReque
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import tokens_input
 from vllm.renderers.online_renderer import OnlineRenderer
 from vllm.renderers.params import ChatParams
@@ -425,6 +426,19 @@ class TestReasoningRenderParity:
                 "tool_choice": "none",
             },
         )
+
+    async def test_reasoning_effort_none_rejected_by_harmony(self, online_renderer):
+        """Harmony rejects reasoning_effort="none" as invalid user input."""
+        request = ChatCompletionRequest(
+            model=_MODEL,
+            messages=_USER,
+            reasoning_effort="none",
+        )
+        with pytest.raises(
+            VLLMValidationError, match="Harmony does not support"
+        ) as exc_info:
+            online_renderer._make_request_with_harmony(request)
+        assert exc_info.value.parameter == "reasoning_effort"
 
     async def test_explicit_enable_thinking_not_overridden(
         self, online_renderer, serving_responses

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -21,6 +21,7 @@ from vllm.entrypoints.chat_utils import (
     _postprocess_messages,
     parse_chat_messages,
     parse_chat_messages_async,
+    validate_chat_template,
 )
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import MultiModalDataDict, MultiModalUUIDDict
@@ -3138,3 +3139,12 @@ def test_tool_call_arguments_multiple_independent(caplog):
 
     assert len(caplog.records) == 1
     assert "bad" in caplog.records[0].message
+
+
+def test_validate_chat_template_rejects_invalid_type():
+    """A non-str/Path chat_template is invalid user input."""
+    with pytest.raises(
+        VLLMValidationError, match="not a valid chat template type"
+    ) as exc_info:
+        validate_chat_template(123)  # type: ignore[arg-type]
+    assert exc_info.value.parameter == "chat_template"

--- a/tests/tokenizers_/test_mistral.py
+++ b/tests/tokenizers_/test_mistral.py
@@ -11,6 +11,7 @@ from mistral_common.guidance.grammar_factory import GrammarFactory
 from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, SpecialTokens
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.exceptions import VLLMValidationError
 from vllm.tokenizers.mistral import (
     MistralTokenizer,
     _validate_apply_chat_template_args,
@@ -2279,8 +2280,20 @@ def test_validate_request_params_rejects_unsupported_effort() -> None:
         messages=[],
         reasoning_effort="medium",
     )
-    with pytest.raises(ValueError, match="reasoning_effort"):
+    with pytest.raises(VLLMValidationError, match="reasoning_effort") as exc_info:
         validate_request_params(request)
+    assert exc_info.value.parameter == "reasoning_effort"
+
+
+def test_validate_request_params_rejects_chat_template() -> None:
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+        chat_template="{{ messages }}",
+    )
+    with pytest.raises(VLLMValidationError, match="chat_template") as exc_info:
+        validate_request_params(request)
+    assert exc_info.value.parameter == "chat_template"
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1454,7 +1454,10 @@ def validate_chat_template(chat_template: Path | str | None):
                 )
 
     else:
-        raise TypeError(f"{type(chat_template)} is not a valid chat template type")
+        raise VLLMValidationError(
+            f"{type(chat_template)} is not a valid chat template type",
+            parameter="chat_template",
+        )
 
 
 def _load_chat_template(

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -28,6 +28,7 @@ from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.entrypoints.serve import create_error_response
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import (
     EngineInput,
     PromptType,
@@ -246,7 +247,10 @@ class OnlineRenderer:
         assert not self.supports_browsing
         assert not self.supports_code_interpreter
         if (reasoning_effort := request.reasoning_effort) == "none":
-            raise ValueError(f"Harmony does not support {reasoning_effort=}")
+            raise VLLMValidationError(
+                f"Harmony does not support {reasoning_effort=}",
+                parameter="reasoning_effort",
+            )
         tools = request.tools if should_include_tools else None
         messages.extend(
             build_harmony_preamble(

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -445,9 +445,15 @@ class TokenizeParams:
             return tokens
 
         if tokenizer is None:
-            raise ValueError("Cannot pad tokens when `skip_tokenizer_init=True`")
+            raise VLLMValidationError(
+                "Cannot pad tokens when `skip_tokenizer_init=True`",
+                parameter="pad_prompt_tokens",
+            )
         if not isinstance(tokens, list):
-            raise ValueError("Cannot pad tokens for embedding inputs")
+            raise VLLMValidationError(
+                "Cannot pad tokens for embedding inputs",
+                parameter="pad_prompt_tokens",
+            )
 
         return tokens + [tokenizer.pad_token_id] * (pad_length - len(tokens))
 

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -34,6 +34,7 @@ from transformers.tokenization_mistral_common import MistralCommonBackend
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.tokenizers.protocol import TokenizerLike
 
@@ -144,15 +145,19 @@ def _validate_apply_chat_template_args(
 
 def validate_request_params(request: "ChatCompletionRequest"):
     if request.chat_template is not None or request.chat_template_kwargs is not None:
-        raise ValueError("chat_template is not supported for Mistral tokenizers.")
+        raise VLLMValidationError(
+            "chat_template is not supported for Mistral tokenizers.",
+            parameter="chat_template",
+        )
 
     if request.reasoning_effort and request.reasoning_effort not in list(
         ReasoningEffort
     ):
-        raise ValueError(
+        raise VLLMValidationError(
             f"reasoning_effort={request.reasoning_effort} is not supported by "
             "Mistral models. Supported values are: "
-            f"{[e.value for e in ReasoningEffort]}."
+            f"{[e.value for e in ReasoningEffort]}.",
+            parameter="reasoning_effort",
         )
 
 


### PR DESCRIPTION
Continues the `VLLMValidationError` migration (siblings of #50254, #50257, #55701) across several DarkLight1337-owned frontend modules.

Scope was expanded per review feedback (a single migration is too small relative to CI cost). Every change is a **user-input validation** point (client 4xx) and now carries `parameter=...` so the error response points at the offending request field, via the existing `VLLMValidationError -> 400` mapping.

## Migrated

| File | Function | Field(s) |
|------|----------|----------|
| `renderers/online_renderer.py` | `_make_request_with_harmony` | `reasoning_effort` |
| `tokenizers/mistral.py` | `validate_request_params` | `chat_template`, `reasoning_effort` |
| `entrypoints/chat_utils.py` | `validate_chat_template` | `chat_template` (invalid type; sibling of the already-migrated path-like branch in the same function) |
| `renderers/params.py` | `_token_padding` | `pad_prompt_tokens` (2 padding-conflict errors) |

The Harmony `reasoning_effort` migration mirrors the one already done for the Responses parser in #50257.

## Out of scope (intentionally)

Output-parsing failures and internal-invariant errors in these modules are left as raw `ValueError` — `parameter=`-style attribution would misrepresent them as user input. Example: `pooling_params.py`'s "Unknown pooling task" branch is unreachable dead code (guarded by `verify()`), so it is not migrated.

## Test Plan / Result

- `test_render_parity.py`: `test_reasoning_effort_none_rejected_by_harmony` (Harmony-only branch, previously uncovered — existing tests run a non-Harmony model)
- `test_mistral.py`: `test_validate_request_params_rejects_unsupported_effort` updated to expect `VLLMValidationError` + assert `parameter`; new `test_validate_request_params_rejects_chat_template`
- `test_chat_utils.py`: new `test_validate_chat_template_rejects_invalid_type`

All assert `VLLMValidationError` with the correct `parameter`. To be confirmed by CI.