### PR TITLE
[Benchmark] Use effective prompt count for workload sweep bounds

### DIFF
--- a/tests/benchmarks/sweep/test_serve_workload.py
+++ b/tests/benchmarks/sweep/test_serve_workload.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+
+from vllm.benchmarks.datasets import DEFAULT_NUM_PROMPTS
+from vllm.benchmarks.sweep.param_sweep import ParameterSweepItem
+from vllm.benchmarks.sweep.serve_workload import explore_comb_workloads
+
+
+@pytest.mark.parametrize(
+    "options,overrides,expected",
+    [
+        ([], {}, DEFAULT_NUM_PROMPTS),
+        (["--num-prompts", "4"], {}, 4),
+        (["--num-prompts=4"], {}, 4),
+        (["--num_prompts", "4"], {}, 4),
+        (["--num_prompts=4"], {}, 4),
+        (["--num-prompts", "2", "--num-prompts", "4"], {}, 4),
+        ([], {"num_prompts": 4}, 4),
+        ([], {"num-prompts": 4}, 4),
+        (["--num-prompts", "7"], {"num-prompts": 4}, 4),
+    ],
+)
+def test_workload_uses_effective_prompt_count(
+    options, overrides, expected, tmp_path, monkeypatch
+):
+    """Use the same prompt count as the benchmark after applying overrides."""
+    run_workload = Mock(return_value=None)
+    monkeypatch.setattr(
+        "vllm.benchmarks.sweep.serve_workload.run_comb_workload", run_workload
+    )
+
+    explore_comb_workloads(
+        None,
+        ["vllm", "bench", "serve", *options],
+        serve_comb=ParameterSweepItem(),
+        bench_comb=ParameterSweepItem(overrides),
+        link_vars=[],
+        workload_var="request_rate",
+        workload_iters=2,
+        experiment_dir=tmp_path,
+        num_runs=1,
+        dry_run=True,
+    )
+
+    serial, batch = run_workload.call_args_list
+    assert serial.kwargs["workload_value"] == 1
+    assert batch.kwargs["workload_value"] == expected
+    assert batch.kwargs["bench_comb"]["max_concurrency"] == expected

--- a/vllm/benchmarks/sweep/serve_workload.py
+++ b/vllm/benchmarks/sweep/serve_workload.py
@@ -106,17 +106,12 @@ def explore_comb_workloads(
     if workload_iters < 2:
         raise ValueError("`workload_iters` should be at least 2")
 
-    dataset_size = DEFAULT_NUM_PROMPTS
-    if "num_prompts" in bench_comb:
-        dataset_size = int(bench_comb["num_prompts"])  # type: ignore
-    else:
-        for i, arg in enumerate(bench_cmd):
-            if arg == "--num-prompts" and i + 1 < len(bench_cmd):
-                dataset_size = int(bench_cmd[i + 1])
-                break
-            elif arg.startswith("--num-prompts="):
-                dataset_size = int(arg.split("=", 1)[1])
-                break
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--num-prompts", "--num_prompts", type=int, default=DEFAULT_NUM_PROMPTS
+    )
+    bench_args, _ = parser.parse_known_args(bench_comb.apply_to_cmd(bench_cmd))
+    dataset_size = bench_args.num_prompts
 
     print(f"Dataset size: {dataset_size}")
 


### PR DESCRIPTION
## Purpose

Use the benchmark's effective prompt count for the initial workload bounds in `vllm bench sweep serve_workload`. Fixes #55739.

The manual scan misses underscored CLI options and hyphenated JSON keys, and chooses the first repeated option even though the benchmark uses the last. Apply the existing `ParameterSweepItem.apply_to_cmd` helper first, then parse both supported spellings with stdlib argparse. No change to parameter replacement or workload-search policy.

## Test Plan

```sh
pytest tests/benchmarks/sweep/test_serve_workload.py tests/benchmarks/sweep/test_param_sweep.py -q
pre-commit run --files vllm/benchmarks/sweep/serve_workload.py tests/benchmarks/sweep/test_serve_workload.py
```

The regression test runs the workload explorer and checks both the batch workload value and `max_concurrency`. It covers the default, both CLI spellings in separate and equals forms, repeated options, both JSON spellings, and a JSON override of an existing CLI option.

I also ran the native `vllm bench sweep serve_workload` CLI before and after the patch, with a CPU model server, two workload iterations and one run per point. Four cases each start the server, reset its caches, execute both benchmarks and write the summary CSV. Every benchmark completes four requests with three output tokens each.

## Test Result

- Five regression cases fail before; all nine pass after. Together with the existing parameter-sweep tests: 32 passed.
- Pre-commit passes.
- Native end-to-end results:

| Benchmark count input | Batch request rate / concurrency before | After |
| --- | --- | --- |
| `--num-prompts 4` control | 4 / 4 | 4 / 4 |
| `--num_prompts=4` | 1000 / 1000 | 4 / 4 |
| `--num-prompts 2 --num-prompts 4` | 2 / 2 | 4 / 4 |
| `--num-prompts 7`, JSON `{"num-prompts": 4}` | 7 / 7 | 4 / 4 |

All 16 before/after benchmark runs have identical generated text, input/output lengths, completion counts, errors and total token counts. Timing measurements are not compared for equality.

Validation environment: Linux arm64, Python 3.12, official `vllm/vllm-openai-cpu:v0.28.0-arm64` image, SmolLM2-135M-Instruct revision `12fd25f77366fa6b3b4b768ec3050bf629380bac`, float32 eager CPU inference, pandas 3.0.5. Current-repository `serve_workload.py` snapshots were mounted into the fixed runtime; this is not a full current-main engine or GPU validation.

Prepared and tested with Codex.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and linked issue.
- [x] Test plan and commands.
- [x] Before/after test results.
- [x] No documentation change needed for corrected argument handling.

</details>
