### PR TITLE
[MLA] MLA attention bmm abstraction and `kv_b_proj` online quantization through standard API

### DIFF
--- a/tests/kernels/quantization/test_rocm_fp8.py
+++ b/tests/kernels/quantization/test_rocm_fp8.py
@@ -30,7 +30,6 @@ fp8_only = pytest.mark.skipif(
 
 ENV_DEFAULTS = {
     "VLLM_ROCM_FP8_PADDING": True,
-    "VLLM_ROCM_USE_AITER_FP8BMM": True,
     "VLLM_ROCM_FP8_MFMA_PAGE_ATTN": False,
 }
 
@@ -216,8 +215,6 @@ def test_rocm_fp8_env_defaults(monkeypatch):
     [
         ("VLLM_ROCM_FP8_PADDING", "0", False),
         ("VLLM_ROCM_FP8_PADDING", "1", True),
-        ("VLLM_ROCM_USE_AITER_FP8BMM", "0", False),
-        ("VLLM_ROCM_USE_AITER_FP8BMM", "1", True),
         ("VLLM_ROCM_FP8_MFMA_PAGE_ATTN", "0", False),
         ("VLLM_ROCM_FP8_MFMA_PAGE_ATTN", "1", True),
     ],
@@ -251,30 +248,6 @@ def test_maybe_pad_fp8_weight_respects_env(monkeypatch):
         _reload_envs()
         unpadded = _maybe_pad_fp8_weight(weight)
         assert unpadded.data_ptr() == weight.data_ptr()
-
-
-@fp8_only
-@pytest.mark.parametrize(
-    ("use_aiter", "fp8bmm_enabled", "expected"),
-    [
-        (True, True, True),
-        (True, False, False),
-        (False, True, False),
-    ],
-)
-def test_aiter_fp8bmm_enabled_api_respects_env(
-    use_aiter, fp8bmm_enabled, expected, monkeypatch
-):
-    from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
-
-    assert is_aiter_found_and_supported()
-
-    with monkeypatch.context() as mp:
-        mp.setenv("VLLM_ROCM_USE_AITER", "1" if use_aiter else "0")
-        mp.setenv("VLLM_ROCM_USE_AITER_FP8BMM", "1" if fp8bmm_enabled else "0")
-        _reload_envs()
-        rocm_aiter_ops.refresh_env_variables()
-        assert rocm_aiter_ops.is_fp8bmm_enabled() is expected
 
 
 @fp8_only

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -35,6 +35,7 @@ from vllm.model_executor.kernels.linear.mxfp8.marlin import (
     MarlinMxfp8LinearKernel,
 )
 from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.attention.mla_bmm import Mxfp4MLABmm
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -100,6 +101,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader import weight_utils
 from vllm.model_executor.model_loader.base_loader import log_online_quantization
 from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
+from vllm.model_executor.model_loader.utils import get_model_architecture
 from vllm.model_executor.models.granitemoe import (
     GraniteMoeModel,
 )
@@ -228,6 +230,162 @@ def _write_minimal_llama_config(
     if quantization_config is not None:
         config["quantization_config"] = quantization_config
     (model_path / "config.json").write_text(json.dumps(config))
+
+
+def _write_minimal_mla_config(model_path: Path, architecture: str) -> None:
+    """Write a compact DeepSeek-style config usable by generic MLA models."""
+    config = {
+        "architectures": [architecture],
+        "model_type": "deepseek_v2",
+        "hidden_size": 256,
+        "intermediate_size": 512,
+        "moe_intermediate_size": 128,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "num_hidden_layers": 1,
+        "mhc": False,
+        "vocab_size": 256,
+        "max_position_embeddings": 64,
+        "q_lora_rank": 64,
+        "kv_lora_rank": 512,
+        "qk_nope_head_dim": 128,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 128,
+        "n_routed_experts": 4,
+        "num_experts": 2,
+        "num_experts_per_tok": 1,
+        "n_group": 1,
+        "topk_group": 1,
+        "n_shared_experts": 1,
+        "first_k_dense_replace": 1,
+        "moe_layer_freq": 1,
+        "layer_group_size": 1,
+        "layer_types": ["full_attention"],
+        "rms_norm_eps": 1e-6,
+        "use_bias": False,
+        "rope_theta": 10000,
+        "tie_word_embeddings": False,
+    }
+    if architecture in {
+        "DeepseekV32ForCausalLM",
+        "Dots3NoteForCausalLM",
+        "GlmMoeDsaForCausalLM",
+        "Glm5NextForCausalLM",
+    }:
+        config.update(
+            index_topk=1,
+            index_kpool=1,
+            index_n_heads=1,
+            index_head_dim=32,
+            index_kv_lora_rank=32,
+        )
+    if architecture in {
+        "Glm4MoeLiteForCausalLM",
+        "PanguProMoEV2ForCausalLM",
+        "PanguUltraMoEForCausalLM",
+        "SarvamMLAForCausalLM",
+    }:
+        config["first_k_dense_replace"] = 0
+    if architecture == "Glm5NextForCausalLM":
+        config.update(model_type="glm5_next", index_kpool=2, index_topk=2)
+    if architecture == "LongcatFlashForCausalLM":
+        config.update(zero_expert_num=1, zero_expert_type="identity")
+    (model_path / "config.json").write_text(json.dumps(config))
+
+
+@pytest.mark.skipif(
+    not on_gfx950(),
+    reason="kv_b_proj mxfp4 quantization tested only on gfx950",
+)
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "AXK1ForCausalLM",
+        "BailingMoeV2_5ForCausalLM",
+        "BailingMoeV3ForCausalLM",
+        "DeepseekForCausalLM",
+        "DeepseekV2ForCausalLM",
+        "DeepseekV3ForCausalLM",
+        "DeepseekV32ForCausalLM",
+        pytest.param(
+            "Dots3NoteForCausalLM",
+            marks=pytest.mark.skipif(
+                current_platform.is_rocm(),
+                reason="Dots3 NOTE requires the CUDA FlashAttention extension.",
+            ),
+        ),
+        "Glm4MoeLiteForCausalLM",
+        "GlmMoeDsaForCausalLM",
+        # Glm5NextDecoderLayer passes quant_config=None to its MLA layer; see
+        # vllm/models/glm5next/nvidia/model.py.
+        pytest.param(
+            "Glm5NextForCausalLM",
+            marks=pytest.mark.skip(
+                reason="GLM5 Next does not pass quant_config to MLAAttention."
+            ),
+        ),
+        pytest.param(
+            "HYV4ForCausalLM",
+            marks=pytest.mark.skipif(
+                current_platform.is_rocm(),
+                reason="HY-V4 does not support ROCm.",
+            ),
+        ),
+        "LongcatFlashForCausalLM",
+        "PanguEmbeddedForCausalLM",
+        "PanguProMoEV2ForCausalLM",
+        "PanguUltraMoEForCausalLM",
+        "SarvamMLAForCausalLM",
+    ],
+)
+def test_online_mla_kv_b_proj_quantization(
+    architecture: str,
+    tmp_path: Path,
+    dist_init,
+    workspace_init,
+    monkeypatch,
+) -> None:
+    """Online MXFP4 installs the MLA BMM captured from ``kv_b_proj``."""
+
+    _write_minimal_mla_config(tmp_path, architecture)
+    logged_messages: list[str] = []
+
+    def record_info(message: str, *args: object) -> None:
+        logged_messages.append(message % args)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.base_loader.logger.info", record_info
+    )
+    model, vllm_config = load_model_without_vllm_runner(
+        str(tmp_path),
+        dtype="bfloat16",
+        quantization="online",
+        model_config_kwargs={
+            "quantization_config": resolve_quantization_config(
+                "online", {"targets": {"*kv_b_proj*": "mxfp4"}}
+            )
+        },
+        model_loader_cls=DummyModelLoader,
+    )
+    expected_model_cls, resolved_architecture = get_model_architecture(
+        vllm_config.model_config
+    )
+    assert resolved_architecture == architecture
+    assert isinstance(model, expected_model_cls)
+
+    kv_b_projs = [
+        module for name, module in model.named_modules() if name.endswith("kv_b_proj")
+    ]
+    assert kv_b_projs, f"{architecture} did not create an MLA kv_b_proj"
+    for kv_b_proj in kv_b_projs:
+        assert isinstance(kv_b_proj.quant_method, Mxfp4OnlineLinearMethod)
+        assert isinstance(kv_b_proj.mla_bmm, Mxfp4MLABmm)
+    expected_count = len(kv_b_projs)
+    assert any(
+        f"Quantized {expected_count} layers of types:" in message
+        and "kv_b_proj" in message
+        for message in logged_messages
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -280,7 +280,7 @@ if AttentionBackendEnum.TOKENSPEED_MLA in BACKENDS_TO_TEST:
         BACKENDS_TO_TEST.remove(AttentionBackendEnum.TOKENSPEED_MLA)
 
 
-def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
+def test_mla_post_load_refreshes_unquantized_bmm_weights(monkeypatch):
     layer = MLAAttention.__new__(MLAAttention)
     torch.nn.Module.__init__(layer)
     layer.kv_lora_rank = 2
@@ -292,8 +292,6 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
         torch.arange(28.0, dtype=torch.float16).reshape(14, 2)
     )
     layer.kv_b_proj.quant_method = None
-    layer.is_aiter_triton_fp4_bmm_enabled = False
-    layer.is_aiter_triton_fp8_bmm_enabled = False
     layer.is_amx_bmm_enabled = False
     layer.dcp_q_replicate = False
     layer.quant_config = None
@@ -306,20 +304,16 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
 
     with torch.no_grad():
         layer.process_weights_after_loading(torch.float32)
-        assert isinstance(layer.W_UV, torch.nn.Parameter)
-        assert isinstance(layer.W_UK_T, torch.nn.Parameter)
-        w_uv_ptr = layer.W_UV.data_ptr()
-        w_uk_t_ptr = layer.W_UK_T.data_ptr()
-        old_w_uv = layer.W_UV.clone()
-        old_w_uk_t = layer.W_UK_T.clone()
+        assert isinstance(layer.mla_bmm, mla_attention_module.UnquantizedMlaBmm)
+        old_w_uv = layer.mla_bmm.w_uv.clone()
+        old_w_uk_t = layer.mla_bmm.w_uk_t.clone()
 
         layer.kv_b_proj.weight.add_(100)
         layer.process_weights_after_loading(torch.float32)
 
-    assert layer.W_UV.data_ptr() == w_uv_ptr
-    assert layer.W_UK_T.data_ptr() == w_uk_t_ptr
-    torch.testing.assert_close(layer.W_UV, old_w_uv + 100)
-    torch.testing.assert_close(layer.W_UK_T, old_w_uk_t + 100)
+    assert isinstance(layer.mla_bmm, mla_attention_module.UnquantizedMlaBmm)
+    torch.testing.assert_close(layer.mla_bmm.w_uv, old_w_uv + 100)
+    torch.testing.assert_close(layer.mla_bmm.w_uk_t, old_w_uk_t + 100)
 
 
 # Validate parameter combinations during collection, before GPU fixtures run.

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1757,7 +1757,6 @@ class rocm_aiter_ops:
         VLLM_ROCM_USE_AITER_MLA: Controls MLA (Multi-head Latent Attention) ops.
         VLLM_ROCM_USE_AITER_MHA: Controls MHA ops including flash_attn_varlen.
         VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: Controls Triton unified attention.
-        VLLM_ROCM_USE_AITER_FP8BMM: Controls FP8 batched matrix multiply.
         VLLM_ROCM_USE_AITER_TRITON_ROPE: Controls Triton rotary embeddings.
         VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: Controls shared expert fusion.
         VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: Controls a8w4 SiTU fused MoE variant.
@@ -1820,9 +1819,6 @@ class rocm_aiter_ops:
     _MHA_ENABLED = envs.VLLM_ROCM_USE_AITER_MHA
     _SHUFFLE_KV_CACHE_ENABLED = envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
     _TRITON_UNIFIED_ATTN_ENABLED = envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
-    # TODO: Consolidate under _LINEAR_ENABLED
-    _FP8BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP8BMM
-    _FP4BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP4BMM
     _LINEAR_HIPBMM_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR_HIPBMM
     # TODO: Consolidate under VLLM_ROCM_USE_AITER_ROPE
     _TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
@@ -1851,8 +1847,6 @@ class rocm_aiter_ops:
         cls._MHA_ENABLED = envs.VLLM_ROCM_USE_AITER_MHA
         cls._SHUFFLE_KV_CACHE_ENABLED = envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
         cls._TRITON_UNIFIED_ATTN_ENABLED = envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
-        cls._FP8BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP8BMM
-        cls._FP4BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP4BMM
         cls._LINEAR_HIPBMM_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR_HIPBMM
         cls._TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
         cls._MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
@@ -2044,19 +2038,6 @@ class rocm_aiter_ops:
     @if_aiter_supported
     def is_triton_unified_attn_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._TRITON_UNIFIED_ATTN_ENABLED
-
-    @classmethod
-    @if_aiter_supported
-    def is_fp8bmm_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._FP8BMM_ENABLED
-
-    @classmethod
-    @if_aiter_supported
-    def is_fp4bmm_enabled(cls) -> bool:
-        from vllm.platforms.rocm import get_cdna_version
-
-        # TODO GFX1250: Enable for cdna 4+ when aiter supports batched_gemm_a16wfp4 on gfx1250
-        return cls._AITER_ENABLED and cls._FP4BMM_ENABLED and get_cdna_version() == 4
 
     @classmethod
     @if_aiter_supported

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -144,8 +144,6 @@ if TYPE_CHECKING:
     VLLM_ROCM_AITER_MLA_ASM_PADDING: Literal["auto", "gluon", "asm"] = "auto"
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
-    VLLM_ROCM_USE_AITER_FP8BMM: bool = True
-    VLLM_ROCM_USE_AITER_FP4BMM: bool = True
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
@@ -1327,16 +1325,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is disabled.
     "VLLM_ROCM_USE_AITER_TRITON_ROPE": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_ROPE", "False").lower() in ("true", "1")
-    ),
-    # Whether to use aiter triton fp8 bmm kernel
-    # By default is enabled.
-    "VLLM_ROCM_USE_AITER_FP8BMM": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_FP8BMM", "True").lower() in ("true", "1")
-    ),
-    # Whether to use aiter triton fp4 bmm kernel
-    # By default is enabled.
-    "VLLM_ROCM_USE_AITER_FP4BMM": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_FP4BMM", "True").lower() in ("true", "1")
     ),
     # Use AITER triton unified attention for V1 attention
     "VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION": lambda: (

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -255,13 +255,6 @@ from vllm.model_executor.layers.quantization import (
     resolve_quant_method,
 )
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
-from vllm.model_executor.layers.quantization.online.fp8 import (
-    Fp8PerTensorOnlineLinearMethod,
-    OnlineLinearBase,
-)
-from vllm.model_executor.layers.quantization.online.mxfp4 import (
-    Mxfp4OnlineLinearMethod,
-)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     QuantKey,
@@ -448,6 +441,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         **extra_impl_args,
     ):
         super().__init__()
+        from vllm.model_executor.layers.quantization.online.fp8 import (
+            Fp8PerTensorOnlineLinearMethod,
+            OnlineLinearBase,
+        )
+        from vllm.model_executor.layers.quantization.online.mxfp4 import (
+            Mxfp4OnlineLinearMethod,
+        )
+
         self.num_heads = num_heads
         self.scale = scale
         self.qk_nope_head_dim = qk_nope_head_dim

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -241,6 +241,8 @@ from vllm.model_executor.layers.attention.kv_transfer_utils import (
 )
 from vllm.model_executor.layers.attention.mla_bmm import (
     AmxMlaBmm,
+    Fp8MLABmm,
+    Mxfp4MLABmm,
     UnquantizedMlaBmm,
     create_online_mla_bmm,
 )
@@ -471,9 +473,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
         elif isinstance(self.kv_b_proj.quant_method, OnlineLinearBase):
             raise ValueError(
-                "Online MLA BMM supports only fp8_per_tensor and mxfp4 "
-                f"kv_b_proj quantization, got "
-                f"{type(self.kv_b_proj.quant_method).__name__}."
+                "Online quantization for MLA kv_b_proj supports only fp8_per_tensor "
+                f"and mxfp4, got {type(self.kv_b_proj.quant_method).__name__}."
             )
         self.dcp_q_replicate = dcp_q_replicate
         self.head_size = kv_lora_rank + qk_rope_head_dim
@@ -1123,7 +1124,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 "DCP query replication is unsupported on head-padding MLA "
                 "backends (q_pad_num_heads)."
             )
-            if self.kv_b_proj.mla_bmm is not None:
+            if isinstance(self.kv_b_proj.mla_bmm, (Mxfp4MLABmm, Fp8MLABmm)):
                 raise NotImplementedError(
                     "DCP query replication is not implemented for quantized "
                     "MLA BMM paths."

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -212,11 +212,9 @@ from typing import ClassVar, Generic, TypeVar, cast
 import numpy as np
 import torch
 import torch.nn as nn
-from tqdm import tqdm
 
 import vllm.envs as envs
 from vllm import _custom_ops as ops
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
     CacheConfig,
@@ -228,7 +226,6 @@ from vllm.config.cache import CacheDType
 from vllm.distributed.parallel_state import (
     get_dcp_group,
     get_tp_group,
-    is_global_first_rank,
 )
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
@@ -242,6 +239,11 @@ from vllm.model_executor.layers.attention.attention import (
 from vllm.model_executor.layers.attention.kv_transfer_utils import (
     maybe_transfer_kv_layer,
 )
+from vllm.model_executor.layers.attention.mla_bmm import (
+    AmxMlaBmm,
+    UnquantizedMlaBmm,
+    create_online_mla_bmm,
+)
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -251,16 +253,21 @@ from vllm.model_executor.layers.quantization import (
     resolve_quant_method,
 )
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    Fp8PerTensorOnlineLinearMethod,
+    OnlineLinearBase,
+)
+from vllm.model_executor.layers.quantization.online.mxfp4 import (
+    Mxfp4OnlineLinearMethod,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     QuantKey,
-    get_and_maybe_dequant_weights,
     kFp8Dynamic64Sym,
     kFp8Dynamic128Sym,
     kFp8StaticTensorSym,
     kNvfp4Dynamic,
 )
-from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.math_utils import cdiv, round_down, round_up
@@ -447,8 +454,28 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
         self.kv_b_proj = kv_b_proj
+        self.kv_b_proj.mla_bmm = None
+        if isinstance(
+            self.kv_b_proj.quant_method,
+            (Fp8PerTensorOnlineLinearMethod, Mxfp4OnlineLinearMethod),
+        ):
+            self.kv_b_proj._mla_bmm_builder = lambda quant_method, weight: (
+                create_online_mla_bmm(
+                    quant_method,
+                    weight,
+                    self.num_heads,
+                    self.kv_lora_rank,
+                    self.qk_nope_head_dim,
+                    self.v_head_dim,
+                )
+            )
+        elif isinstance(self.kv_b_proj.quant_method, OnlineLinearBase):
+            raise ValueError(
+                "Online MLA BMM supports only fp8_per_tensor and mxfp4 "
+                f"kv_b_proj quantization, got "
+                f"{type(self.kv_b_proj.quant_method).__name__}."
+            )
         self.dcp_q_replicate = dcp_q_replicate
-        self.W_UK_T_dcp_qrep: torch.Tensor | None = None
         self.head_size = kv_lora_rank + qk_rope_head_dim
         self.layer_name = prefix
         self.indexer = indexer
@@ -666,15 +693,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 is_lse_base_on_e=self.impl.lse_base_on_e,
                 use_pcp=self.use_pcp,
             )
-
-        self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
-
-        # If kv_b_proj_weight is unquantized, quantize it to mxfp4 if supported
-        self.is_aiter_triton_fp4_bmm_enabled = (
-            rocm_aiter_ops.is_fp4bmm_enabled()
-            and hasattr(self.kv_b_proj, "weight")
-            and self.kv_b_proj.weight.dtype == torch.bfloat16
-        )
 
         # Attributes for forward_impl method
         self._vllm_config = get_current_vllm_config()
@@ -954,58 +972,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 mqa_pe_padded.copy_(mqa_q_pe)
                 mqa_q_pe = mqa_pe_padded
 
-            if self.is_aiter_triton_fp4_bmm_enabled:
-                from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
-
-                mqa_ql_nope = batched_gemm_a16wfp4(
-                    mqa_q_nope,
-                    self.W_K,
-                    self.W_K_scale,
-                    transpose_bm=True,
-                    prequant=True,
-                    y_scale=self._q_scale if fp8_attention else None,
-                )
-            elif self.is_aiter_triton_fp8_bmm_enabled:
-                # Multiply+Transpose (N, B, P)x(N, P, L)->(N, B, L)->(B, N, L)
-                mqa_ql_nope = rocm_aiter_ops.triton_fp8_bmm(
-                    mqa_q_nope,
-                    self.W_K,
-                    self.W_K_scale,
-                    group_size=128,
-                    transpose_bm=True,
-                )
-            elif self.is_amx_bmm_enabled:
-                # bmm_cpu computes out[n] = mat1[n] @ mat2[n]^T against
-                # AMXMLAImpl's own (N, L, P) packed W_UK -- same as prefill.
-                N, B, P = mqa_q_nope.shape
-                L = self.kv_lora_rank
-                mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
-                ops.bmm_cpu(
-                    mqa_ql_nope,
-                    mqa_q_nope,
-                    self.impl._w_uk_packed,  # type: ignore[attr-defined]
-                    True,
-                    None,
-                )
-                mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
-            else:
-                # Pads the head_dim if necessary (for the underlying kernel)
-                N, B, P = mqa_q_nope.shape
-                W_UK_T = self.W_UK_T_dcp_qrep if qrep_decode else self.W_UK_T
-                assert W_UK_T is not None
-                _, _, L = W_UK_T.shape
-
-                if self.q_pad_num_heads is not None:
-                    mqa_ql_nope = mqa_q_nope.new_empty((self.q_pad_num_heads, B, L))
-                    mqa_ql_nope.resize_((N, B, L))
-                else:
-                    mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
-
-                # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
-                torch.bmm(mqa_q_nope, W_UK_T, out=mqa_ql_nope)
-
-                # Convert from (N, B, L) to (B, N, L)
-                mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
+            assert self.kv_b_proj.mla_bmm is not None
+            mqa_ql_nope = self.kv_b_proj.mla_bmm.qk(mqa_q_nope, qrep_decode)
 
             if fp8_attention and self.impl.supports_quant_query_input:
                 assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
@@ -1143,17 +1111,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         if self.is_amx_bmm_enabled:
             # AMXMLAImpl already packed its own W_UK/W_UV above, for both
             # prefill and decode. Release the now-unused raw weight.
+            self.kv_b_proj.mla_bmm = AmxMlaBmm(self.impl, self.kv_lora_rank)
             self.kv_b_proj.weight = torch.nn.Parameter(
                 torch.empty(0), requires_grad=False
             )
             return
-
-        # we currently do not have quantized bmm's which are needed for
-        # `W_UV` and `W_UK_T`, we just store fp16/bf16 copies and perform
-        # the bmm's in 16-bit, the extra memory overhead of this is fairly low
-        kv_b_proj_weight = get_and_maybe_dequant_weights(
-            self.kv_b_proj, out_dtype=act_dtype
-        ).T
 
         if self.dcp_q_replicate:
             # qrep wired here: validate unsupported decode backends once.
@@ -1161,99 +1123,22 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 "DCP query replication is unsupported on head-padding MLA "
                 "backends (q_pad_num_heads)."
             )
-            if (
-                self.is_aiter_triton_fp4_bmm_enabled
-                or self.is_aiter_triton_fp8_bmm_enabled
-            ):
+            if self.kv_b_proj.mla_bmm is not None:
                 raise NotImplementedError(
-                    "DCP query replication is not implemented for the aiter "
-                    "FP4/FP8 MLA BMM paths."
+                    "DCP query replication is not implemented for quantized "
+                    "MLA BMM paths."
                 )
 
-        assert kv_b_proj_weight.shape == (
-            self.kv_lora_rank,
-            self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
-        ), (
-            f"{kv_b_proj_weight.shape=}, "
-            f"{self.kv_lora_rank=}, "
-            f"{self.num_heads=}, "
-            f"{self.qk_nope_head_dim=}, "
-            f"{self.v_head_dim=}"
-        )
-        kv_b_proj_weight = kv_b_proj_weight.view(
-            self.kv_lora_rank,
-            self.num_heads,
-            self.qk_nope_head_dim + self.v_head_dim,
-        )
-
-        W_UK, W_UV = kv_b_proj_weight.split(
-            [self.qk_nope_head_dim, self.v_head_dim], dim=-1
-        )
-
-        # If kv_b_proj_weight is unquantized, quantize it to mxfp4 if supported
-        if self.is_aiter_triton_fp4_bmm_enabled:
-            from vllm.model_executor.layers.quantization.quark.utils import (
-                quark_quantize_weight_to_mxfp4,
+        if self.kv_b_proj.mla_bmm is None:
+            self.kv_b_proj.mla_bmm = UnquantizedMlaBmm(
+                self.kv_b_proj,
+                self.num_heads,
+                self.kv_lora_rank,
+                self.qk_nope_head_dim,
+                self.v_head_dim,
+                act_dtype,
+                self.dcp_q_replicate,
             )
-
-            self.W_K, self.W_K_scale = quark_quantize_weight_to_mxfp4(W_UK)
-            # Convert from (L, N, P) to (N, L, P)
-            self.W_K = self.W_K.transpose(0, 1)
-            self.W_K_scale = self.W_K_scale.transpose(0, 1)
-
-            self.W_V, self.W_V_scale = quark_quantize_weight_to_mxfp4(
-                W_UV.permute(1, 2, 0)
-            )
-        elif self.is_aiter_triton_fp8_bmm_enabled:
-            W_K = W_UK.transpose(0, 1)  # 16 512 128
-            W_V = W_UV.permute(1, 2, 0)  # 16 128 512
-            self.W_K, self.W_K_scale = dynamic_per_batched_tensor_quant(
-                W_K, dtype=current_platform.fp8_dtype()
-            )
-            self.W_V, self.W_V_scale = dynamic_per_batched_tensor_quant(
-                W_V, dtype=current_platform.fp8_dtype()
-            )
-
-            # The kernel operates on non-padded inputs. Hence, pre-compiling
-            # triton kernel to avoid runtime compilation for unseen batch sizes
-            # Pre-compile for batch sizes 1 to 1024 to cover most use-cases.
-            # On DS-R1, this step adds roughly 50s to the model loading time.
-            max_batch_size = 1024  # [ToDo] Find the optimal upper limit
-            pre_compilation_list = list(range(1, max_batch_size + 1))
-            if is_global_first_rank():
-                pre_compilation_list = tqdm(
-                    pre_compilation_list,
-                    desc="[Aiter Triton] Pre-compiling fp8 BMM kernel",
-                    total=max_batch_size,
-                )
-
-            for m in pre_compilation_list:
-                x = torch.empty(
-                    (self.W_K.shape[0], m, self.W_K.shape[2]),
-                    dtype=torch.bfloat16,
-                    device=self.W_K.device,
-                )
-                rocm_aiter_ops.triton_fp8_bmm(
-                    x, self.W_K, self.W_K_scale, group_size=128, transpose_bm=True
-                )
-
-                x = torch.empty(
-                    (self.W_V.shape[0], m, self.W_V.shape[2]),
-                    dtype=torch.bfloat16,
-                    device=self.W_V.device,
-                )
-                rocm_aiter_ops.triton_fp8_bmm(
-                    x, self.W_V, self.W_V_scale, group_size=128, transpose_bm=True
-                )
-        else:
-            # Convert from (L, N, V) to (N, L, V)
-            replace_parameter(self, "W_UV", W_UV.transpose(0, 1), prefer_copy=True)
-            # Convert from (L, N, P) to (N, P, L)
-            replace_parameter(self, "W_UK_T", W_UK.permute(1, 2, 0), prefer_copy=True)
-            if self.dcp_q_replicate:
-                self.W_UK_T_dcp_qrep = get_dcp_group().all_gather(
-                    self.W_UK_T.contiguous(), dim=0
-                )
 
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]
@@ -1301,35 +1186,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         # Convert from (B, N, L) to (N, B, L)
         x = x.view(-1, self.num_heads, self.kv_lora_rank).transpose(0, 1)
         out = out.view(-1, self.num_heads, self.v_head_dim)
-        if self.is_aiter_triton_fp4_bmm_enabled:
-            out = rocm_aiter_ops.batched_gemm_a16wfp4(
-                x,
-                self.W_V,
-                self.W_V_scale,
-                out,
-                transpose_bm=True,
-                prequant=True,
-                y_scale=None,
-            )
-            x = out.view(-1, self.num_heads * self.v_head_dim)
-        elif self.is_aiter_triton_fp8_bmm_enabled:
-            # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
-            x = rocm_aiter_ops.triton_fp8_bmm(
-                x, self.W_V, self.W_V_scale, group_size=128, transpose_bm=True, YQ=out
-            )
-        elif self.is_amx_bmm_enabled:
-            # bmm_cpu computes out[n] = mat1[n] @ mat2[n]^T against
-            # AMXMLAImpl's own (N, V, L) packed W_UV -- same as prefill.
-            ops.bmm_cpu(
-                out.transpose(0, 1),
-                x,
-                self.impl._w_uv_packed,  # type: ignore[attr-defined]
-                True,
-                None,
-            )
-        else:
-            # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
-            torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+
+        assert self.kv_b_proj.mla_bmm is not None
+        self.kv_b_proj.mla_bmm.uv(x, out)
 
 
 def unified_mla_kv_cache_update(
@@ -3196,7 +3055,6 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         self.indexer = indexer
         self.q_pad_num_heads = q_pad_num_heads
         self.supports_quant_query_input = True
-        self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
 
         # Use flashinfer's optimized concat_mla_k kernel when available.
         # The kernel is optimized for DeepSeek V3 dimensions:

--- a/vllm/model_executor/layers/attention/mla_bmm.py
+++ b/vllm/model_executor/layers/attention/mla_bmm.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_and_maybe_dequant_weights,
 )
+from vllm.platforms import current_platform
 
 
 class MLABmm(ABC):
@@ -119,6 +120,9 @@ class AmxMlaBmm(MLABmm):
 
 class Fp8MLABmm(MLABmm):
     def __init__(self, w_uk: torch.Tensor, w_uv: torch.Tensor) -> None:
+        if not current_platform.is_rocm():
+            raise ValueError("Fp8MLABmm requires ROCm.")
+
         self.w_k, self.w_k_scale = quantize_fp8_per_tensor(w_uk.transpose(0, 1))
         self.w_v, self.w_v_scale = quantize_fp8_per_tensor(w_uv.permute(1, 2, 0))
         self._warm_up()
@@ -186,6 +190,9 @@ class Fp8MLABmm(MLABmm):
 
 class Mxfp4MLABmm(MLABmm):
     def __init__(self, w_uk: torch.Tensor, w_uv: torch.Tensor) -> None:
+        if not current_platform.is_rocm():
+            raise ValueError("Mxfp4MLABmm requires ROCm.")
+
         self.w_k, self.w_k_scale = mxfp4_quantize(w_uk)
         self.w_k = self.w_k.transpose(0, 1)
         self.w_k_scale = self.w_k_scale.transpose(0, 1)
@@ -234,9 +241,6 @@ def create_online_mla_bmm(
         return Fp8MLABmm(w_uk, w_uv)
 
     if isinstance(quant_method, Mxfp4OnlineLinearMethod):
-        from vllm.platforms.rocm import get_cdna_version
-
-        if weight.dtype == torch.bfloat16 and get_cdna_version() == 4:
-            return Mxfp4MLABmm(w_uk, w_uv)
+        return Mxfp4MLABmm(w_uk, w_uv)
 
     return None

--- a/vllm/model_executor/layers/attention/mla_bmm.py
+++ b/vllm/model_executor/layers/attention/mla_bmm.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from abc import ABC, abstractmethod
+
+import torch
+from tqdm import tqdm
+
+from vllm import _custom_ops as ops
+from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
+from vllm.distributed.parallel_state import get_dcp_group, is_global_first_rank
+from vllm.model_executor.layers.quantization.online.fp8 import (
+    Fp8PerTensorOnlineLinearMethod,
+)
+from vllm.model_executor.layers.quantization.online.mxfp4 import (
+    Mxfp4OnlineLinearMethod,
+)
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    quantize_fp8_per_tensor,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+    mxfp4_quantize,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_and_maybe_dequant_weights,
+)
+
+
+class MLABmm(ABC):
+    """Quantized MQA BMM operands derived from a kv_b_proj source weight."""
+
+    @abstractmethod
+    def qk(self, x: torch.Tensor, dcp_q_replicated: bool = False) -> torch.Tensor:
+        pass
+
+    @abstractmethod
+    def uv(self, x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+        pass
+
+
+class UnquantizedMlaBmm(MLABmm):
+    """BF16/FP16 MQA BMM operands."""
+
+    def __init__(
+        self,
+        kv_b_proj: torch.nn.Module,
+        num_heads: int,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        v_head_dim: int,
+        act_dtype: torch.dtype,
+        dcp_q_replicate: bool,
+    ) -> None:
+        kv_b_proj_weight = get_and_maybe_dequant_weights(
+            kv_b_proj, out_dtype=act_dtype
+        ).T
+        assert kv_b_proj_weight.shape == (
+            kv_lora_rank,
+            num_heads * (qk_nope_head_dim + v_head_dim),
+        ), (
+            f"{kv_b_proj_weight.shape=}, "
+            f"{kv_lora_rank=}, "
+            f"{num_heads=}, "
+            f"{qk_nope_head_dim=}, "
+            f"{v_head_dim=}"
+        )
+        w_uk, w_uv = kv_b_proj_weight.view(
+            kv_lora_rank,
+            num_heads,
+            qk_nope_head_dim + v_head_dim,
+        ).split([qk_nope_head_dim, v_head_dim], dim=-1)
+        w_uk_t = w_uk.permute(1, 2, 0).contiguous()
+        w_uv = w_uv.transpose(0, 1).contiguous()
+        self.w_uk_t = w_uk_t
+        self.w_uv = w_uv
+        self.w_uk_t_dcp_qrep = (
+            get_dcp_group().all_gather(w_uk_t, dim=0) if dcp_q_replicate else None
+        )
+
+    def qk(self, x: torch.Tensor, dcp_q_replicated: bool = False) -> torch.Tensor:
+        w_uk_t = self.w_uk_t_dcp_qrep if dcp_q_replicated else self.w_uk_t
+        assert w_uk_t is not None
+        return torch.bmm(x, w_uk_t).transpose(0, 1)
+
+    def uv(self, x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+        torch.bmm(x, self.w_uv, out=out.transpose(0, 1))
+        return out
+
+
+class AmxMlaBmm(MLABmm):
+    """AMX-packed MQA BMM operands."""
+
+    def __init__(self, impl: object, kv_lora_rank: int) -> None:
+        self.impl = impl
+        self.kv_lora_rank = kv_lora_rank
+
+    def qk(self, x: torch.Tensor, dcp_q_replicated: bool = False) -> torch.Tensor:
+        num_heads, batch_size, _ = x.shape
+        out = x.new_empty((num_heads, batch_size, self.kv_lora_rank))
+        ops.bmm_cpu(
+            out,
+            x,
+            self.impl._w_uk_packed,  # type: ignore[attr-defined]
+            True,
+            None,
+        )
+        return out.transpose(0, 1)
+
+    def uv(self, x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+        ops.bmm_cpu(
+            out.transpose(0, 1),
+            x,
+            self.impl._w_uv_packed,  # type: ignore[attr-defined]
+            True,
+            None,
+        )
+        return out
+
+
+class Fp8MLABmm(MLABmm):
+    def __init__(self, w_uk: torch.Tensor, w_uv: torch.Tensor) -> None:
+        self.w_k, self.w_k_scale = quantize_fp8_per_tensor(w_uk.transpose(0, 1))
+        self.w_v, self.w_v_scale = quantize_fp8_per_tensor(w_uv.permute(1, 2, 0))
+        self._warm_up()
+
+    def _warm_up(self) -> None:
+        # The kernel operates on non-padded inputs. Hence, pre-compiling
+        # triton kernel to avoid runtime compilation for unseen batch sizes
+        # Pre-compile for batch sizes 1 to 1024 to cover most use-cases.
+        # On DS-R1, this step adds roughly 50s to the model loading time.
+        max_batch_size = 1024  # [ToDo] Find the optimal upper limit
+        pre_compilation_list = list(range(1, max_batch_size + 1))
+        if is_global_first_rank():
+            pre_compilation_list = tqdm(
+                pre_compilation_list,
+                desc="[Aiter Triton] Pre-compiling fp8 BMM kernel",
+                total=max_batch_size,
+            )
+
+        for m in pre_compilation_list:
+            x = torch.empty(
+                (self.w_k.shape[0], m, self.w_k.shape[2]),
+                dtype=torch.bfloat16,
+                device=self.w_k.device,
+            )
+            rocm_aiter_ops.triton_fp8_bmm(
+                x,
+                self.w_k,
+                self.w_k_scale,
+                group_size=128,
+                transpose_bm=True,
+            )
+
+            x = torch.empty(
+                (self.w_v.shape[0], m, self.w_v.shape[2]),
+                dtype=torch.bfloat16,
+                device=self.w_v.device,
+            )
+            rocm_aiter_ops.triton_fp8_bmm(
+                x,
+                self.w_v,
+                self.w_v_scale,
+                group_size=128,
+                transpose_bm=True,
+            )
+
+    def qk(self, x: torch.Tensor, dcp_q_replicated: bool = False) -> torch.Tensor:
+        return rocm_aiter_ops.triton_fp8_bmm(
+            x,
+            self.w_k,
+            self.w_k_scale,
+            group_size=128,
+            transpose_bm=True,
+        )
+
+    def uv(self, x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+        return rocm_aiter_ops.triton_fp8_bmm(
+            x,
+            self.w_v,
+            self.w_v_scale,
+            group_size=128,
+            transpose_bm=True,
+            YQ=out,
+        )
+
+
+class Mxfp4MLABmm(MLABmm):
+    def __init__(self, w_uk: torch.Tensor, w_uv: torch.Tensor) -> None:
+        self.w_k, self.w_k_scale = mxfp4_quantize(w_uk)
+        self.w_k = self.w_k.transpose(0, 1)
+        self.w_k_scale = self.w_k_scale.transpose(0, 1)
+        self.w_v, self.w_v_scale = mxfp4_quantize(w_uv.permute(1, 2, 0))
+
+    def qk(self, x: torch.Tensor, dcp_q_replicated: bool = False) -> torch.Tensor:
+        out = x.new_empty((x.shape[1], x.shape[0], self.w_k.shape[1]))
+        return rocm_aiter_ops.batched_gemm_a16wfp4(
+            x,
+            self.w_k,
+            self.w_k_scale,
+            out,
+            transpose_bm=True,
+            prequant=True,
+        )
+
+    def uv(self, x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+        return rocm_aiter_ops.batched_gemm_a16wfp4(
+            x,
+            self.w_v,
+            self.w_v_scale,
+            out,
+            transpose_bm=True,
+            prequant=True,
+        )
+
+
+def create_online_mla_bmm(
+    quant_method: object,
+    weight: torch.Tensor,
+    num_heads: int,
+    kv_lora_rank: int,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+) -> MLABmm | None:
+    """Quantize MLA BMM weights while kv_b_proj is still in high precision."""
+    if not is_aiter_found_and_supported():
+        return None
+
+    kv_b_proj_weight = weight.T.view(
+        kv_lora_rank, num_heads, qk_nope_head_dim + v_head_dim
+    )
+    w_uk, w_uv = kv_b_proj_weight.split([qk_nope_head_dim, v_head_dim], dim=-1)
+
+    if isinstance(quant_method, Fp8PerTensorOnlineLinearMethod):
+        return Fp8MLABmm(w_uk, w_uv)
+
+    if isinstance(quant_method, Mxfp4OnlineLinearMethod):
+        from vllm.platforms.rocm import get_cdna_version
+
+        if weight.dtype == torch.bfloat16 and get_cdna_version() == 4:
+            return Mxfp4MLABmm(w_uk, w_uv)
+
+    return None

--- a/vllm/model_executor/layers/attention/mla_bmm.py
+++ b/vllm/model_executor/layers/attention/mla_bmm.py
@@ -9,12 +9,6 @@ from tqdm import tqdm
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
 from vllm.distributed.parallel_state import get_dcp_group, is_global_first_rank
-from vllm.model_executor.layers.quantization.online.fp8 import (
-    Fp8PerTensorOnlineLinearMethod,
-)
-from vllm.model_executor.layers.quantization.online.mxfp4 import (
-    Mxfp4OnlineLinearMethod,
-)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     quantize_fp8_per_tensor,
 )
@@ -229,6 +223,13 @@ def create_online_mla_bmm(
     v_head_dim: int,
 ) -> MLABmm | None:
     """Quantize MLA BMM weights while kv_b_proj is still in high precision."""
+    from vllm.model_executor.layers.quantization.online.fp8 import (
+        Fp8PerTensorOnlineLinearMethod,
+    )
+    from vllm.model_executor.layers.quantization.online.mxfp4 import (
+        Mxfp4OnlineLinearMethod,
+    )
+
     if not is_aiter_found_and_supported():
         return None
 

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -114,7 +114,6 @@ class QuantizationConfig(ABC):
         super().__init__()
         # mapping is updated by models as they initialize
         self.packed_modules_mapping: dict[str, list[str]] = dict()
-        self.online_quantization_config: OnlineQuantizationConfig | None = None
 
     @abstractmethod
     def get_name(self) -> QuantizationMethods:
@@ -203,48 +202,6 @@ class QuantizationConfig(ABC):
             method.
         """
         raise NotImplementedError
-
-    def get_effective_quant_method(
-        self, layer: torch.nn.Module, prefix: str
-    ) -> QuantizeMethodBase | None:
-        """Return the checkpoint method with configured online quantization."""
-        from vllm.model_executor.layers.fused_moe import RoutedExperts
-        from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
-            UnquantizedFusedMoEMethod,
-        )
-        from vllm.model_executor.layers.linear import (
-            LinearBase,
-            UnquantizedLinearMethod,
-        )
-
-        base_quant_method = self.get_quant_method(layer, prefix)
-        if self.online_quantization_config is None:
-            return base_quant_method
-        # Online quantization currently supports only LinearBase and RoutedExperts.
-        # Embeddings and ParallelLMHead retain their checkpoint quantization method.
-        if not isinstance(layer, (LinearBase, RoutedExperts)):
-            return base_quant_method
-
-        self.online_quantization_config.packed_modules_mapping = (
-            self.packed_modules_mapping
-        )
-        checkpoint_is_quantized = base_quant_method is not None and not isinstance(
-            base_quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)
-        )
-        online_target = self.online_quantization_config.resolve_quant_method_cls(
-            layer, prefix
-        )
-        if checkpoint_is_quantized:
-            if online_target is not None:
-                raise ValueError(
-                    f"Cannot apply requested online quantization {online_target[3]} to "
-                    f"pre-quantized layer {prefix}: {base_quant_method} was already "
-                    "selected by the checkpoint quantization config."
-                )
-            return base_quant_method
-        if online_target is None:
-            return base_quant_method
-        return self.online_quantization_config.get_quant_method(layer, prefix)
 
     @staticmethod
     def get_cache_scale_mapper() -> "WeightsMapper":

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -114,6 +114,7 @@ class QuantizationConfig(ABC):
         super().__init__()
         # mapping is updated by models as they initialize
         self.packed_modules_mapping: dict[str, list[str]] = dict()
+        self.online_quantization_config: OnlineQuantizationConfig | None = None
 
     @abstractmethod
     def get_name(self) -> QuantizationMethods:
@@ -202,6 +203,48 @@ class QuantizationConfig(ABC):
             method.
         """
         raise NotImplementedError
+
+    def get_effective_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase | None:
+        """Return the checkpoint method with configured online quantization."""
+        from vllm.model_executor.layers.fused_moe import RoutedExperts
+        from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+            UnquantizedFusedMoEMethod,
+        )
+        from vllm.model_executor.layers.linear import (
+            LinearBase,
+            UnquantizedLinearMethod,
+        )
+
+        base_quant_method = self.get_quant_method(layer, prefix)
+        if self.online_quantization_config is None:
+            return base_quant_method
+        # Online quantization currently supports only LinearBase and RoutedExperts.
+        # Embeddings and ParallelLMHead retain their checkpoint quantization method.
+        if not isinstance(layer, (LinearBase, RoutedExperts)):
+            return base_quant_method
+
+        self.online_quantization_config.packed_modules_mapping = (
+            self.packed_modules_mapping
+        )
+        checkpoint_is_quantized = base_quant_method is not None and not isinstance(
+            base_quant_method, (UnquantizedLinearMethod, UnquantizedFusedMoEMethod)
+        )
+        online_target = self.online_quantization_config.resolve_quant_method_cls(
+            layer, prefix
+        )
+        if checkpoint_is_quantized:
+            if online_target is not None:
+                raise ValueError(
+                    f"Cannot apply requested online quantization {online_target[3]} to "
+                    f"pre-quantized layer {prefix}: {base_quant_method} was already "
+                    "selected by the checkpoint quantization config."
+                )
+            return base_quant_method
+        if online_target is None:
+            return base_quant_method
+        return self.online_quantization_config.get_quant_method(layer, prefix)
 
     @staticmethod
     def get_cache_scale_mapper() -> "WeightsMapper":

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -33,6 +33,9 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.quantization.online.moe_base import (
     OnlineMoEMethodBase,
 )
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    quantize_fp8_per_tensor,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     amax_for_moe_weight_quant,
@@ -122,6 +125,11 @@ class OnlineLinearBase(LinearMethodBase):
         self.out_dtype = torch.get_default_dtype()
         self.input_dtype = get_current_vllm_config().model_config.dtype
 
+    def _capture_mla_bmm(self, layer: Module) -> None:
+        builder = getattr(layer, "_mla_bmm_builder", None)
+        if builder is not None:
+            layer.mla_bmm = builder(self, layer.weight)
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -208,11 +216,12 @@ class Fp8PerTensorOnlineLinearMethod(OnlineLinearBase):
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
 
+        self._capture_mla_bmm(layer)
         layer.input_scale = None
         amax = weight_amax(layer.weight).reshape(1)
         amax = amax_for_tp_weight_quant(amax, _is_tp_sharded(layer))
         weight_scale = _fp8_scale(amax)
-        qweight, _ = ops.scaled_fp8_quant(layer.weight, scale=weight_scale)
+        qweight, _ = quantize_fp8_per_tensor(layer.weight, weight_scale)
 
         # Update layer with new values.
         replace_parameter(layer, "weight", qweight.t().data)

--- a/vllm/model_executor/layers/quantization/online/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp4.py
@@ -119,6 +119,7 @@ class Mxfp4OnlineLinearMethod(OnlineLinearBase):
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
 
+        self._capture_mla_bmm(layer)
         weight_fp4, weight_scale = mxfp4_quantize(layer.weight.contiguous())
 
         layer.input_scale = None

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -16,6 +16,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     amax_for_moe_activation_quant,
     get_fp8_min_max,
+    weight_amax,
 )
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     all_close_1d,
@@ -77,6 +78,21 @@ def input_to_float8(
     scale = finfo.max / amax
     x_scl_sat = (x * scale).clamp(min=finfo.min, max=finfo.max)
     return x_scl_sat.to(dtype).contiguous(), scale.float().reciprocal()
+
+
+def quantize_fp8_per_tensor(
+    weight: torch.Tensor, scale: torch.Tensor | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize an arbitrary-rank weight with one FP8 scale."""
+    if scale is None:
+        fp8_max = torch.tensor(
+            get_fp8_min_max()[1], device=weight.device, dtype=torch.float32
+        )
+        scale = weight_amax(weight).reshape(1).to(torch.float32) / fp8_max
+    quantized, _ = ops.scaled_fp8_quant(
+        weight.reshape(-1, weight.shape[-1]), scale=scale
+    )
+    return quantized.reshape(weight.shape), scale
 
 
 @triton.jit

--- a/vllm/models/deepseek_v32/amd/rocm.py
+++ b/vllm/models/deepseek_v32/amd/rocm.py
@@ -99,20 +99,8 @@ class DeepseekV32MLAAttention(DeepseekV32Attention):
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         q_nope = q_nope.transpose(0, 1)  # (N, tokens, P)
 
-        if self.is_aiter_triton_fp4_bmm_enabled:
-            from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
-
-            ql_nope = batched_gemm_a16wfp4(
-                q_nope, self.W_K, self.W_K_scale, transpose_bm=True, prequant=True
-            )
-        elif self.is_aiter_triton_fp8_bmm_enabled:
-            from vllm._aiter_ops import rocm_aiter_ops
-
-            ql_nope = rocm_aiter_ops.triton_fp8_bmm(
-                q_nope, self.W_K, self.W_K_scale, group_size=128, transpose_bm=True
-            )
-        else:
-            ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
+        assert self.kv_b_proj.mla_bmm is not None
+        ql_nope = self.kv_b_proj.mla_bmm.qk(q_nope)
 
         return ql_nope, q_pe
 
@@ -151,25 +139,8 @@ class DeepseekV32MLAAttention(DeepseekV32Attention):
             num_actual, self.num_local_heads, self.v_head_dim
         )
 
-        if self.is_aiter_triton_fp4_bmm_enabled:
-            from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
-
-            batched_gemm_a16wfp4(
-                x, self.W_V, self.W_V_scale, out_view, transpose_bm=True, prequant=True
-            )
-        elif self.is_aiter_triton_fp8_bmm_enabled:
-            from vllm._aiter_ops import rocm_aiter_ops
-
-            rocm_aiter_ops.triton_fp8_bmm(
-                x,
-                self.W_V,
-                self.W_V_scale,
-                group_size=128,
-                transpose_bm=True,
-                YQ=out_view,
-            )
-        else:
-            torch.bmm(x, self.W_UV, out=out_view.transpose(0, 1))
+        assert self.kv_b_proj.mla_bmm is not None
+        self.kv_b_proj.mla_bmm.uv(x, out_view)
 
     @eager_break_during_capture
     def _fused_attention(

--- a/vllm/v1/attention/backends/mla/amx_mla.py
+++ b/vllm/v1/attention/backends/mla/amx_mla.py
@@ -164,8 +164,7 @@ class AMXMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
 
 class AMXMLAImpl(MLACommonImpl[MLACommonMetadata]):
     # Tells MLAAttention (mla_attention.py) to use this impl's own packed
-    # W_UK/W_UV + bmm_cpu for the shared decode absorb/de-absorb, mirroring
-    # is_aiter_triton_fp8_bmm_enabled/is_aiter_triton_fp4_bmm_enabled.
+    # W_UK/W_UV + bmm_cpu for the shared decode absorb/de-absorb.
     uses_amx_bmm = True
 
     def __init__(


### PR DESCRIPTION
## Disclosure

AI assistance was used. The changes were reviewed manually.

## Purpose

See context: https://github.com/vllm-project/vllm/pull/53123 / https://github.com/vllm-project/vllm/pull/48051

Remove silent FP8/MXFP4 quantization of `kv_b_proj` in MLA attention in decode on ROCm, make `kv_b_proj` quantization more independent of the accelerator.

We add an MLA BMM abstraction for MQA decode, handling different implementations and different precisions.

Online `--quantization fp8_per_tensor` and `--quantization  mxfp4` capture the high-precision `kv_b_proj` weight during online processing and build AITER-compatible BMM operands. Only FP8 per-tensor and MXFP4 online quantization are supported for `kv_b_proj` (similar to previous `is_aiter_triton_fp8_bmm_enabled`, `is_aiter_triton_fp4_bmm_enabled`).

AMX and BF16/FP16 paths use the same `MLABmm` abstraction.

Behavior change:
- `VLLM_ROCM_USE_AITER_FP8BMM`, `VLLM_ROCM_USE_AITER_FP4BMM` env vars are removed in favor of online quantization API.
- **prefill and decode now use the same precision (prefill MHA used to not be impacted by aiter env vars).**

## Test Plan

```bash
pytest tests/v1/attention/test_mla_backends.py::test_mla_post_load_refreshes_unquantized_bmm_weights -v
pytest tests/quantization/test_online.py -s -vvvvv -k "test_online_mla_kv_b_proj_quantization"
```

`VLLM_ROCM_USE_AITER=1 vllm serve zai-org/GLM-4.7-Flash --quantization-config.targets '{"*kv_b_proj*": "mxfp4"}' --tensor-parallel-size 1`

giving `(Worker_TP0 pid=1155049) INFO 09-07 15:39:13 [base_loader.py:111] Quantized 47 layers of types: self_attn.kv_b_proj: 47 (from targets: *kv_b_proj*, mxfp4)` and loading successfully with https://github.com/ROCm/aiter/pull/4181

## Test Results

`14 passed, 3 skipped, 55 deselected, 14 warnings in 17.27s`