### PR TITLE
[Bugfix][Tool Parser] Preserve large integer tool arguments

### DIFF
--- a/tests/tool_parsers/test_k2_horizon_tool_parser.py
+++ b/tests/tool_parsers/test_k2_horizon_tool_parser.py
@@ -170,6 +170,29 @@ def test_request_level_format_overrides(tokenizer, tool_format, call, expected):
     assert json.loads(result.tool_calls[0].function.arguments) == expected
 
 
+@pytest.mark.parametrize("tool_format", ["json", "xml"])
+@pytest.mark.parametrize("streaming", [False, True])
+def test_number_schema_preserves_large_integer(tokenizer, tool_format, streaming):
+    request = _request(tool_format).model_copy(deep=True)
+    request.tools[0].function.parameters["properties"]["limit"] = {"type": "number"}
+    parser = K2HorizonToolParser(tokenizer, request.tools)
+    value = 2**63 - 1
+    output = _group(
+        _json_call("lookup", {"limit": value})
+        if tool_format == "json"
+        else _xml_call("lookup", [("limit", str(value))])
+    )
+
+    if streaming:
+        content, calls = _collect_stream(parser, request, output)
+        assert content == ""
+        assert calls == [("lookup", {"limit": value})]
+    else:
+        result = parser.extract_tool_calls(output, request)
+        assert result.tools_called
+        assert json.loads(result.tool_calls[0].function.arguments) == {"limit": value}
+
+
 @pytest.mark.parametrize(
     "tool_format",
     ["yaml", "python", "xml_untyped", "", None, 1],

--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -101,6 +101,15 @@ class TestCoerceToSchemaType:
             assert coerce_to_schema_type("5.0", "number") == 5
             assert isinstance(coerce_to_schema_type("5.0", "number"), int)
 
+        @pytest.mark.parametrize("value", [2**53 + 1, -(2**53 + 1), 2**63 - 1])
+        @pytest.mark.parametrize(
+            "schema_type", ["number", "double", ["number", "string"]]
+        )
+        def test_large_integer_preserved(self, value, schema_type):
+            result = coerce_to_schema_type(str(value), schema_type)
+            assert isinstance(result, int)
+            assert json.loads(json.dumps(result)) == value
+
         def test_invalid_number_fallback(self):
             assert coerce_to_schema_type("abc", "number") == "abc"
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -1124,6 +1124,10 @@ def coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
                 continue
         if candidate_type == "number":
             try:
+                return int(value)
+            except (ValueError, TypeError):
+                pass
+            try:
                 val = float(value)
             except (ValueError, TypeError):
                 continue


### PR DESCRIPTION
## Purpose

Preserve large integer tool arguments when their JSON Schema type is `number`.

`coerce_to_schema_type` currently sends every `number` value through `float`
before converting integral results back to `int`. Integer-form values above the
IEEE-754 exact range are silently changed. For example:

```text
input:  9223372036854775807
before: 9223372036854775808
after:  9223372036854775807
```

JSON Schema permits integers wherever `number` is accepted, and Python's JSON
encoder can preserve these values exactly. The change therefore tries `int`
first and falls back to the existing floating-point path for decimal and
exponent forms. Existing behavior remains unchanged for values such as `5.0`,
`1e3`, `3.14`, and non-finite inputs.

The shared conversion function is used by the parser engine and directly by the
K2 Horizon tool parser. Regression coverage exercises the K2 Horizon JSON and
XML formats in both streaming and non-streaming modes.

Related to #47179, which discusses Python/Rust tool argument coercion parity.
The Rust number converter already parses valid JSON integer literals without an
intermediate `f64` conversion.

### Duplicate-work check

I checked #47179 and searched open PRs for references to that issue, large
integer tool parsing, number precision, and `coerce_to_schema_type`. No open PR
addresses this precision-loss case. #47203 changes Rust union-type precedence,
and #53729 resolves property schemas inside combinators; neither changes this
integer conversion path.

## Test Plan

```bash
.venv/bin/python -m pytest --confcutdir=tests/tool_parsers tests/tool_parsers/test_utils.py -q
.venv/bin/python -m pytest --confcutdir=tests/tool_parsers tests/tool_parsers/test_k2_horizon_tool_parser.py -q
pre-commit run ruff-check --files vllm/tool_parsers/utils.py tests/tool_parsers/test_utils.py tests/tool_parsers/test_k2_horizon_tool_parser.py
pre-commit run ruff-format --files vllm/tool_parsers/utils.py tests/tool_parsers/test_utils.py tests/tool_parsers/test_k2_horizon_tool_parser.py
pre-commit run typos --files vllm/tool_parsers/utils.py tests/tool_parsers/test_utils.py tests/tool_parsers/test_k2_horizon_tool_parser.py
```

## Test Result

Before the implementation change, all four new K2 Horizon cases failed and
returned `9223372036854775808` instead of `9223372036854775807`:

```text
4 failed, 26 passed
```

After the change:

```text
tests/tool_parsers/test_utils.py:              183 passed
tests/tool_parsers/test_k2_horizon_tool_parser.py: 30 passed
ruff check:                                    passed
ruff format:                                   passed
typos:                                         passed
```

Model evaluation is not applicable. This changes deterministic post-generation
tool argument coercion and does not alter inference, sampling, or model output.

AI assistance was used for this change. I reviewed the diff and test results.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The before-and-after test results.
- [x] Documentation was considered; no user documentation change is needed for
  this corrective parser behavior.

