### PR TITLE
[Fix] Guard out-of-bounds gather in DeepSeek-V4 cache_utils Triton ke…

### DIFF
--- a/tests/kernels/test_deepseek_v4_cache_utils.py
+++ b/tests/kernels/test_deepseek_v4_cache_utils.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression and unit tests for DeepSeek-V4 cache utils Triton kernels."""
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.common.ops.cache_utils import (
+    compute_global_topk_indices_and_lens,
+)
+
+
+def _ref_compute_global_topk(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+    num_reqs: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if num_reqs is None:
+        num_reqs = block_table.shape[0]
+    num_tokens, topk = topk_indices.shape
+    stride = block_table.stride(0)
+    ref_indices = torch.full_like(topk_indices, fill_value=-1)
+    ref_lens = torch.zeros(num_tokens, dtype=torch.int32, device=topk_indices.device)
+
+    for t in range(num_tokens):
+        req = token_to_req_indices[t].item()
+        valid_tok = is_valid_token[t].item()
+        count = 0
+        if 0 <= req < num_reqs:
+            for k in range(topk):
+                loc = topk_indices[t, k].item()
+                if loc >= 0:
+                    b_idx = loc // block_size
+                    if b_idx < stride:
+                        b_num = block_table[req, b_idx].item()
+                        slot = b_num * block_size + (loc % block_size)
+                        ref_indices[t, k] = slot
+                        count += 1
+        if valid_tok:
+            ref_lens[t] = count
+    return ref_indices, ref_lens
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compute_global_topk_indices_and_lens_basic():
+    """Verify normal valid lookup matches reference."""
+    device = torch.device("cuda")
+    block_size = 64
+    num_reqs = 4
+    num_blocks = 8
+    topk = 16
+    num_tokens = 6
+
+    block_table = torch.arange(
+        num_reqs * num_blocks, dtype=torch.int32, device=device
+    ).view(num_reqs, num_blocks)
+    token_to_req = torch.tensor([0, 1, 2, 3, 0, 1], dtype=torch.int32, device=device)
+    is_valid_token = torch.tensor(
+        [True, True, True, True, True, False], dtype=torch.bool, device=device
+    )
+
+    # Valid local indices: block indices in [0, 4)
+    topk_indices = torch.randint(
+        0, 4 * block_size, (num_tokens, topk), dtype=torch.int32, device=device
+    )
+    # Some invalid local indices (-1)
+    topk_indices[0, 2] = -1
+    topk_indices[1, 5] = -1
+
+    global_indices, topk_lens = compute_global_topk_indices_and_lens(
+        topk_indices, token_to_req, block_table, block_size, is_valid_token
+    )
+
+    ref_indices, ref_lens = _ref_compute_global_topk(
+        topk_indices, token_to_req, block_table, block_size, is_valid_token
+    )
+
+    torch.testing.assert_close(global_indices, ref_indices)
+    torch.testing.assert_close(topk_lens, ref_lens)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compute_global_topk_indices_out_of_bounds_req_idx():
+    """Verify out-of-bounds req_idx yields -1 and 0 lens without memory fault."""
+    device = torch.device("cuda")
+    block_size = 64
+    num_reqs = 2
+    num_blocks = 4
+    topk = 32
+    num_tokens = 5
+
+    block_table = torch.randint(
+        1, 100, (num_reqs, num_blocks), dtype=torch.int32, device=device
+    )
+    # Token 0, 1: valid req_idx (0, 1)
+    # Token 2: req_idx == num_reqs (out of bounds)
+    # Token 3: req_idx > num_reqs (out of bounds, e.g. padding request slot)
+    # Token 4: req_idx == -1 (negative invalid)
+    token_to_req = torch.tensor([0, 1, 2, 100, -1], dtype=torch.int32, device=device)
+    is_valid_token = torch.tensor(
+        [True, True, True, True, True], dtype=torch.bool, device=device
+    )
+
+    topk_indices = torch.randint(
+        0, 2 * block_size, (num_tokens, topk), dtype=torch.int32, device=device
+    )
+
+    global_indices, topk_lens = compute_global_topk_indices_and_lens(
+        topk_indices, token_to_req, block_table, block_size, is_valid_token
+    )
+
+    ref_indices, ref_lens = _ref_compute_global_topk(
+        topk_indices, token_to_req, block_table, block_size, is_valid_token
+    )
+
+    # Verify out-of-bounds tokens produced -1 for all topk entries
+    assert (global_indices[2] == -1).all()
+    assert (global_indices[3] == -1).all()
+    assert (global_indices[4] == -1).all()
+    assert topk_lens[2].item() == 0
+    assert topk_lens[3].item() == 0
+    assert topk_lens[4].item() == 0
+
+    torch.testing.assert_close(global_indices, ref_indices)
+    torch.testing.assert_close(topk_lens, ref_lens)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compute_global_topk_indices_out_of_bounds_block_indices():
+    """Verify block_indices exceeding column stride safely clamp/mask to -1."""
+    device = torch.device("cuda")
+    block_size = 64
+    num_reqs = 3
+    num_blocks = 4  # column stride = 4
+
+    block_table = torch.randint(
+        1, 50, (num_reqs, num_blocks), dtype=torch.int32, device=device
+    )
+    token_to_req = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    is_valid_token = torch.tensor([True, True], dtype=torch.bool, device=device)
+
+    # Craft local_idx where some block indices are in-bounds (< 4)
+    # and some are out-of-bounds (>= 4, i.e. local_idx >= 4 * 64 = 256)
+    topk_indices = torch.tensor(
+        [
+            [0, 63, 64, 128, 256, 320, 500, 10000],
+            [10, 20, 255, 256, 1000, -1, 512, 1024],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    global_indices, topk_lens = compute_global_topk_indices_and_lens(
+        topk_indices, token_to_req, block_table, block_size, is_valid_token
+    )
+
+    ref_indices, ref_lens = _ref_compute_global_topk(
+        topk_indices, token_to_req, block_table, block_size, is_valid_token
+    )
+
+    # In token 0:
+    # 0, 63 -> block 0 (valid)
+    # 64 -> block 1 (valid)
+    # 128 -> block 2 (valid)
+    # 256, 320, 500, 10000 -> block >= 4 (out of bounds -> must be -1)
+    assert (global_indices[0, :4] >= 0).all()
+    assert (global_indices[0, 4:] == -1).all()
+    assert topk_lens[0].item() == 4
+
+    # In token 1:
+    # 10, 20 -> block 0 (valid)
+    # 255 -> block 3 (valid, 255 // 64 == 3 < 4)
+    # 256, 1000 -> block >= 4 (out of bounds -> -1)
+    # -1 -> local_idx < 0 (-1)
+    # 512, 1024 -> block >= 4 (out of bounds -> -1)
+    assert (global_indices[1, :3] >= 0).all()
+    assert (global_indices[1, 3:] == -1).all()
+    assert topk_lens[1].item() == 3
+
+    torch.testing.assert_close(global_indices, ref_indices)
+    torch.testing.assert_close(topk_lens, ref_lens)

--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -438,6 +438,7 @@ def compute_global_topk_indices_and_lens(
     block_table: torch.Tensor,
     block_size: int,
     is_valid_token: torch.Tensor,
+    num_reqs: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Map local topk indices to global KV cache slots and count valid entries.
 
@@ -447,6 +448,8 @@ def compute_global_topk_indices_and_lens(
     3. Masking padding tokens to length 0
     """
     num_tokens = topk_indices.shape[0]
+    if num_reqs is None:
+        num_reqs = block_table.shape[0]
     global_topk_indices = torch.empty_like(topk_indices)
     topk_lens = torch.empty(num_tokens, dtype=torch.int32, device=topk_indices.device)
     _compute_global_topk_indices_and_lens_kernel[(num_tokens,)](
@@ -461,6 +464,7 @@ def compute_global_topk_indices_and_lens(
         block_table.stride(0),
         block_size,
         is_valid_token,
+        num_reqs,
         TRITON_BLOCK_SIZE=1024,
     )
     return global_topk_indices, topk_lens
@@ -479,6 +483,7 @@ def _compute_global_topk_indices_and_lens_kernel(
     block_table_stride: tl.constexpr,
     block_size: tl.constexpr,
     is_valid_token_ptr,
+    num_reqs,
     TRITON_BLOCK_SIZE: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
@@ -495,23 +500,31 @@ def _compute_global_topk_indices_and_lens_kernel(
             mask=mask,
             other=-1,
         )
-        is_valid = local_idx >= 0
-
         block_indices = local_idx // block_size
+        valid_mask = (
+            (local_idx >= 0)
+            & (req_idx >= 0)
+            & (req_idx < num_reqs)
+            & (block_indices < block_table_stride)
+        )
+
+        safe_req_idx = tl.where((req_idx >= 0) & (req_idx < num_reqs), req_idx, 0)
+        safe_block_indices = tl.where(valid_mask, block_indices, 0)
         block_numbers = tl.load(
-            block_table_ptr + req_idx * block_table_stride + block_indices,
-            mask=mask & is_valid,
+            block_table_ptr + safe_req_idx * block_table_stride + safe_block_indices,
+            mask=mask & valid_mask,
+            other=-1,
         )
         block_offsets = local_idx % block_size
 
         slot_ids = block_numbers * block_size + block_offsets
-        slot_ids = tl.where(is_valid, slot_ids, -1)
+        slot_ids = tl.where(valid_mask, slot_ids, -1)
         tl.store(
             global_topk_indices_ptr + token_idx * global_topk_indices_stride + offset,
             slot_ids,
             mask=mask,
         )
-        count += tl.sum(is_valid.to(tl.int32), axis=0)
+        count += tl.sum((valid_mask & mask).to(tl.int32), axis=0)
 
     # Zero out length for padding tokens.
     tl.store(topk_lens_ptr + token_idx, tl.where(is_valid_token, count, 0))


### PR DESCRIPTION
#closes 55692
ready-run-all-tests
Root Cause
In vllm/models/deepseek_v4/common/ops/cache_utils.py, _compute_global_topk_indices_and_lens_kernel performs a block-table lookup to map token top-k indices to global KV cache slots:

python


block_table_ptr + req_idx * block_table_stride + block_indices
Previously, the kernel only checked local_idx >= 0. It failed to validate:

Row index bounds: req_idx (request index) could be out of range (req_idx < 0 or req_idx >= num_reqs), e.g., during CUDA-graph padding or unmasked request slots.
Column index bounds: block_indices could exceed block_table_stride.
This allowed unmasked loads from invalid memory addresses (causing cudaErrorIllegalAddress) or corrupted slot lookups, and incorrectly incremented active sequence counts in topk_lens.

Key Fixes Made
Row Boundary Parameter (
cache_utils.py
):
compute_global_topk_indices_and_lens now extracts num_reqs = block_table.shape[0] (with an optional parameter override) and passes num_reqs into _compute_global_topk_indices_and_lens_kernel.
Comprehensive Gather Masking:
Defined valid_mask in Triton to enforce both row and column boundaries:
python


valid_mask = (
    (local_idx >= 0)
    & (req_idx >= 0)
    & (req_idx < num_reqs)
    & (block_indices < block_table_stride)
)
Safe Memory Load & Index Clamping:
Clamped request and block indices (safe_req_idx, safe_block_indices) prior to pointer calculation so address arithmetic remains in-bounds.
Guarded tl.load with mask=mask & valid_mask, other=-1.
Set slot_ids = tl.where(valid_mask, slot_ids, -1) so invalid entries resolve to -1.
Updated length calculation count += tl.sum((valid_mask & mask).to(tl.int32), axis=0) to exclude invalid entries from topk_lens.
Regression Test Suite (
test_deepseek_v4_cache_utils.py
):
Added unit tests comparing kernel outputs against a PyTorch reference implementation across normal lookups, out-of-bounds req_idx (req_idx >= block_table.shape[0], req_idx < 0), out-of-bounds block_indices, and padding token masks.