### PR TITLE
[Kimi Bug] Fix kimi k3 AssertionError assert 0 <= checkpoint_idx < len(blocks)

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -651,7 +651,7 @@ def test_hash_aligned_query_end_uses_regular_partial_tail():
 
     assert new_blocks is not None
     mamba_manager = manager.coordinator.single_type_managers[1]
-    assert mamba_manager._checkpoint_positions[request.request_id] == 0
+    assert request.request_id not in mamba_manager._checkpoints
     mamba_blocks = manager.get_blocks(request.request_id).blocks[1]
     assert sum(not block.is_null for block in mamba_blocks) == 1
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1431,9 +1431,9 @@ class MambaManager(SingleTypeKVCacheManager):
             self.last_state_block_idx: dict[str, int] = {}
             # The set of the requests that have been allocated blocks
             self._allocated_block_reqs: set[str] = set()
-            # Absolute checkpoint position selected by the scheduler for the
-            # current allocation.
-            self._checkpoint_positions: dict[str, int] = {}
+            # checkpoint position and reserved block index for the current
+            # allocation.
+            self._checkpoints: dict[str, tuple[int, int]] = {}
             # Requests that registered their own last-prompt-boundary partial
             # tail (producers). A later CoW hands its private copy to the
             # connector; a request that finishes first hands off this table
@@ -1722,7 +1722,14 @@ class MambaManager(SingleTypeKVCacheManager):
                 checkpoint_position = 0
             checkpoint_block = int(checkpoint_position > 0)
             if not apply_admission_cap:
-                self._checkpoint_positions[request_id] = checkpoint_position
+                if checkpoint_position > 0:
+                    checkpoint_idx = cdiv(num_tokens, self.block_size) - 2
+                    self._checkpoints[request_id] = (
+                        checkpoint_position,
+                        checkpoint_idx,
+                    )
+                else:
+                    self._checkpoints.pop(request_id, None)
             if num_new_blocks > 0:
                 blocks_allocated = request_id in self._allocated_block_reqs
                 if not (checkpoint_block and blocks_allocated):
@@ -1760,8 +1767,7 @@ class MambaManager(SingleTypeKVCacheManager):
             num_required_blocks = (
                 cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
             )
-            checkpoint_position = self._checkpoint_positions.get(request_id, 0)
-            checkpoint_block = int(checkpoint_position > 0)
+            checkpoint_block = int(request_id in self._checkpoints)
             partial_hit = self._partial_hit_reqs.get(request_id)
             has_partial_hit = partial_hit is not None
             # `num_required_blocks` might be less than `len(req_blocks)` if blocks are
@@ -1893,7 +1899,7 @@ class MambaManager(SingleTypeKVCacheManager):
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
-            self._checkpoint_positions.pop(request_id, None)
+            self._checkpoints.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
             # An offer is only guaranteed to hold committed bytes until the end
             # of the pass that made it. This request's blocks are going back to
@@ -1963,10 +1969,9 @@ class MambaManager(SingleTypeKVCacheManager):
     ) -> BlockHashWithGroupId | None:
         hash_block_size = self.block_pool.hash_block_size
         # Re-key the reserved block at its exported checkpoint boundary.
-        checkpoint_position = self._checkpoint_positions.get(request.request_id, 0)
-        if checkpoint_position > 0:
-            # TODO: Store the reserved slot explicitly for multi-module MTP.
-            checkpoint_idx = cdiv(num_tokens, self.block_size) - 2
+        checkpoint = self._checkpoints.get(request.request_id)
+        if checkpoint is not None:
+            checkpoint_position, checkpoint_idx = checkpoint
             blocks = self.req_to_blocks[request.request_id]
             assert 0 <= checkpoint_idx < len(blocks)
             checkpoint_block = blocks[checkpoint_idx]


### PR DESCRIPTION
## Purpose

```bash

vllm serve moonshotai/Kimi-K3 \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --load-format fastsafetensors \
  --gpu-memory-utilization 0.92 \
  --enable-prefix-caching \
  --reasoning-parser kimi_k3 \
  --enable-auto-tool-choice \
  --tool-call-parser kimi_k3 \
  --host 0.0.0.0 \
  --port 30000 \
  --speculative-config '{"model":"RedHatAI/Kimi-K3-speculator.dspark","method":"dspark","num_speculative_tokens":8,"draft_sample_method":"probabilistic","rejection_sample_method":"standard"}'   --use-replayssm 


HF_HUB_CACHE=/data/engine/hub_cache HF_HUB_OFFLINE=1 guidellm run   --backend '{"kind":"openai_http","target":"http://127.0.0.1:30000","model":"moonshotai/Kimi-K3","request_format":"/v1/chat/completions","timeout":100000,"extras":{"body":{"reasoning_effort":"max","temperature":1.0,"top_p":0.95}}}'   --tokenizer '{"kind":"huggingface_auto","model":"moonshotai/Kimi-K3","load_kwargs":{"trust_remote_code":true,"local_files_only":true}}'   --data 'kind=synthetic_text,prompt_tokens=8000,output_tokens=1000'   --profile 'kind=concurrent,warmup=0.1,cooldown=0.1'   --override profile.streams '1,4,16'   --constraint 'kind=max_duration,seconds=150'   --constraint 'kind=max_errors,count=10'   --seed 'kind=static,value=42'   --metrics 'kind=generative,sample_size=20'   --output 'kind=json,path=/home/yewentao256/guidellm-results/output_vllm_kimik3_8k1k.json'
```

This will raise error

```bash
09-06 15:49:23 [core.py:1387]     self.coordinator.cache_blocks(request, num_tokens_to_cache)
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]   File "/home/yewentao256/vllm-source/vllm/v1/core/kv_cache_coordinator.py", line 778, in cache_blocks
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]     manager.cache_blocks(
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]   File "/home/yewentao256/vllm-source/vllm/v1/core/single_type_kv_cache_manager.py", line 1928, in cache_blocks
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]     partial_hash = self._cache_partial_tail_block(request, num_tokens)
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]   File "/home/yewentao256/vllm-source/vllm/v1/core/single_type_kv_cache_manager.py", line 1971, in _cache_partial_tail_block
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]     assert 0 <= checkpoint_idx < len(blocks)
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=862670) ERROR 09-06 15:49:23 [core.py:1387] AssertionError
```

This PR fixes the issue by saving additional checkpoint_idx to dict instead of recomputation (as the tokens might change by padding)

## Test

Now

```bash
(APIServer pid=957250) INFO 09-06 16:13:11 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 2.80, Accepted throughput: 495.45 tokens/s, Drafted throughput: 2196.56 tokens/s, Accepted: 4955 tokens, Drafted: 21968 tokens, Per-position acceptance rate: 0.685, 0.442, 0.291, 0.158, 0.101, 0.057, 0.040, 0.030, Avg Draft acceptance rate: 22.6%
(APIServer pid=957250) 
```