### PR TITLE
[Bugfix] Preserve benchmark headers when stopping the profiler

### DIFF
--- a/tests/benchmarks/test_serve_profile.py
+++ b/tests/benchmarks/test_serve_profile.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from vllm.benchmarks import serve
+from vllm.benchmarks.datasets import SampleRequest
+from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
+
+
+@pytest.mark.parametrize(
+    "headers", [None, {"Authorization": "Bearer test-key", "X-Tenant": "test"}]
+)
+def test_benchmark_profile_headers(monkeypatch, headers):
+    request_func = AsyncMock(
+        return_value=RequestFuncOutput(
+            success=True, latency=0.1, ttft=0.1, prompt_len=1, output_tokens=1
+        )
+    )
+    monkeypatch.setitem(serve.ASYNC_REQUEST_FUNCS, "test", request_func)
+    monkeypatch.setattr(
+        serve, "fetch_spec_decode_metrics", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(serve, "fetch_diffusion_metrics", AsyncMock(return_value=None))
+
+    asyncio.run(
+        serve.benchmark(
+            task_type=serve.TaskType.GENERATION,
+            endpoint_type="test",
+            api_url="http://localhost/v1/completions",
+            base_url="http://localhost",
+            model_id="test-model",
+            model_name="test-model",
+            tokenizer=None,
+            input_requests=[
+                SampleRequest(prompt="hello", prompt_len=1, expected_output_len=1)
+            ],
+            logprobs=None,
+            request_rate=float("inf"),
+            burstiness=1.0,
+            disable_tqdm=True,
+            num_warmups=0,
+            profile=True,
+            selected_percentile_metrics=[],
+            selected_percentiles=[99.0],
+            ignore_eos=False,
+            goodput_config_dict={},
+            max_concurrency=None,
+            lora_modules=None,
+            extra_headers=headers,
+            extra_body=None,
+            ready_check_timeout_sec=0,
+        )
+    )
+
+    inputs = [
+        call.kwargs["request_func_input"] for call in request_func.await_args_list
+    ]
+    assert [request.api_url for request in inputs] == [
+        "http://localhost/start_profile",
+        "http://localhost/v1/completions",
+        "http://localhost/stop_profile",
+    ]
+    assert [request.extra_headers for request in inputs] == [headers] * 3

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1466,6 +1466,7 @@ async def benchmark(
             prompt_len=test_prompt_len,
             output_len=test_output_len,
             logprobs=logprobs,
+            extra_headers=extra_headers,
         )
         profile_output = await request_func(
             request_func_input=profile_input, session=session


### PR DESCRIPTION
## Purpose

Fixes #55746.

Keep custom benchmark headers on `/stop_profile`, matching `/start_profile` and inference requests. Without them, an authenticating proxy rejects the stop request even though inference succeeds, leaving profiling active without an exported trace.

The fix passes the existing `extra_headers` argument into the stop request. No server authentication behavior changes.

## Test Plan

```sh
pytest tests/benchmarks/test_serve_profile.py tests/benchmarks/sweep/test_param_sweep.py -q
pre-commit run --files vllm/benchmarks/serve.py tests/benchmarks/test_serve_profile.py
```

Also ran eight native benchmark/server lifecycles: completion and chat backends, with custom-header protection and without it, before and after the fix. Each uses a fresh CPU server, two actual inference requests, a forwarding HTTP proxy and the PyTorch profiler. The protected cases require both `Authorization` and `X-Tenant`; unauthenticated control requests are rejected.

## Test Result

- The new header regression fails before; its no-header control passes. Afterward all 25 profile/sweep tests and pre-commit pass.
- Before: both protected backends start profiling with HTTP 200 and complete both inference requests, but stopping returns 401. No trace exists at benchmark completion.
- After: both start and stop return 200 in all four cases. Each writes a compressed trace containing CPU operations.
- Generated text, input/output token counts and inference success counts match the corresponding baseline cases.

Validation used current-repository benchmark source inside the official vLLM 0.28.0 arm64 CPU image, with SmolLM2-135M-Instruct revision `12fd25f77366fa6b3b4b768ec3050bf629380bac`. The engine is the released image, not a build of current main. No GPU or cloud-provider validation is claimed.

Assisted-by: Codex.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and linked issue.
- [x] Test plan and commands.
- [x] Before/after test results.
- [x] Documentation considered; no API or CLI change.
</details>
