### PR TITLE
[Perf] Bound block-hash slicing to the current prefill chunk

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1672,6 +1672,48 @@ def test_cache_blocks(hash_fn):
     assert blocks[0].block_hash is not None
 
 
+@pytest.mark.parametrize("block_size", [4, 16])
+@pytest.mark.parametrize("enable_events", [False, True])
+def test_cache_blocks_only_reads_current_chunk_hashes(block_size, enable_events):
+    """Chunk registration must not materialize the remaining prompt's hashes."""
+    num_hash_reads = 0
+
+    class CountedHashes(list):
+        def __getitem__(self, index):
+            nonlocal num_hash_reads
+            result = super().__getitem__(index)
+            num_hash_reads += len(result) if isinstance(index, slice) else 1
+            return result
+
+    req = make_request("0", list(range(128)), 4, sha256)
+    hashes = req.block_hashes
+    req.block_hashes = CountedHashes(hashes)
+    pool = BlockPool(
+        num_gpu_blocks=5,
+        enable_caching=True,
+        hash_block_size=4,
+        enable_kv_cache_events=enable_events,
+    )
+    blocks = pool.get_new_blocks(4)
+    for start in (0, 2):
+        num_hash_reads = 0
+        pool.cache_full_blocks(
+            request=req,
+            blocks=blocks,
+            num_cached_blocks=start,
+            num_full_blocks=start + 2,
+            block_size=block_size,
+            kv_cache_group_id=0,
+        )
+        # Two new hashes, plus at most one parent hash for the KV event.
+        assert num_hash_reads <= 3
+        for i in range(start, start + 2):
+            expected_hash = hashes[(i + 1) * (block_size // 4) - 1]
+            assert blocks[i].block_hash == make_block_hash_with_group_id(
+                expected_hash, 0
+            )
+
+
 def test_cache_blocks_multi_group():
     """
     This tests that blocks are cached correctly for different kv cache groups.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -264,7 +264,7 @@ class BlockPool:
             request.block_hashes, self.hash_block_size, block_size
         )
 
-        new_block_hashes = block_hashes[num_cached_blocks:]
+        new_block_hashes = block_hashes[num_cached_blocks:num_full_blocks]
         new_hashes: list[ExternalBlockHash] | None = (
             [] if self.enable_kv_cache_events else None
         )


### PR DESCRIPTION
## Purpose

`BlockPool.cache_full_blocks` slices all remaining request hashes on every prefill chunk, although its loop only consumes the hashes for the newly full blocks. Long prompts therefore repeatedly copy hashes for future chunks. When the group block size differs from the hash block size, the slice also repeatedly materializes the `BlockHashListWithBlockSize` view in Python.

Bound the slice by `num_full_blocks`, matching the existing block slice. This reduces cumulative hash materialization from quadratic to linear in prompt blocks for a fixed chunk size. Hash computation, cache insertion, and event semantics are unchanged.

The regression test counts hash elements read while registering two consecutive chunks and verifies the stored hashes. It covers equal/different block sizes and KV events enabled/disabled without timing assertions.

## Test Plan

Validation on upstream `7cc89a7ddabd6be3ff64535139bea20548062ca6`:

```bash
CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py -q
```

## Test Result

- Existing baseline: 114 passed.
- New regression against the original implementation: all 4 cases failed at the bounded-read assertion.
- Modified implementation: 118 passed.
- All 15 applicable repository lint/type/config hooks passed; `git diff --check` passed.

Real-module CPU microbenchmark on Intel Xeon Gold 6226R / Python 3.12.13, hash block size 16, chunk size 512, KV events disabled:

| Prompt tokens | Group block size | Original median | Modified median |
|---:|---:|---:|---:|
| 131,072 | 16 | 8.964 ms | 6.639 ms |
| 131,072 | 128 | 15.960 ms | 1.427 ms |
| 1,048,576 | 16 | 412.742 ms | 59.371 ms |
| 1,048,576 | 128 | 998.757 ms | 10.939 ms |

Each sample measures cumulative `cache_full_blocks` calls for one prompt and one KV group, excluding request hashing, block allocation, GC, and correctness checks. One warmup and six measured trials per configuration; 12 configurations in total, with matching final hash digests and cache lookups. These numbers are for CPU block registration, not end-to-end inference speedups. The 1M-token case is a metadata stress test.

Validation imports the exact checkout's Python source using an isolated environment with existing vLLM 0.28.0 native extensions and torch 2.13.0+cu130; it is not a full native rebuild at this SHA.

GPU generation consistency: Qwen3.5-0.8B on one RTX 3090, BF16/eager, prefix caching and chunked prefill enabled, `prefix_match_unit=16`, resolved block size 544, chunk size 1088, and 8 greedy output tokens. Every request starts with an explicitly reset prefix cache and reports zero cached tokens. At 32K/128K prompt lengths, all 11 paired outputs across A/B and reverse-order checks match (22 successful generations including warmups), without corrupted-output flags. Inputs are deterministic synthetic token IDs; this is output-consistency testing, not a task-accuracy evaluation.

No stable end-to-end latency gain was demonstrated: the 128K TTFT medians were 11.831→11.961 s in baseline-first order and 11.931→11.874 s in modified-first order. The performance claim is limited to the measured CPU registration path.

Duplicate-work screening on 2026-09-07 covered `new_block_hashes`, `cache_full_blocks`/slicing, `BlockHashListWithBlockSize`, and hash/chunk/quadratic searches, plus related prefix-cache PR diffs. No existing PR implementing this slice bound was found. Related partial-cache and event work changes different behavior.

AI assistance: Codex assisted with investigation, implementation, and validation.
