### PR TITLE
 fix(determinism): pin matmul config selection to max_num_seqs to fix async-scheduling non-determinism

### DIFF
--- a/tests/v1/determinism/test_matmul_batch_invariant.py
+++ b/tests/v1/determinism/test_matmul_batch_invariant.py
@@ -14,7 +14,9 @@ from utils import skip_unsupported
 from vllm.model_executor.determinism.batch_invariant import matmul_batch_invariant
 from vllm.model_executor.determinism.batch_invariant_configs import (
     _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS,
+    _get_matmul_config,
     _get_tuned_matmul_arch_family,
+    set_config_max_num_seqs,
 )
 from vllm.platforms import current_platform
 
@@ -134,3 +136,40 @@ def test_matmul_batch_invariance_across_tuned_m_buckets(m, transpose_b):
     batch_output = matmul_batch_invariant(a, b)
 
     assert torch.equal(single_output[0], batch_output[0])
+
+
+def test_get_matmul_config_pinned_to_max_num_seqs():
+    # When set_config_max_num_seqs is called, _get_matmul_config must return
+    # the same config for all runtime M values that async scheduling can produce,
+    # even if those M values span multiple m_bucket thresholds.
+    capability = (
+        current_platform.get_device_capability() if current_platform.is_cuda() else None
+    )
+    arch_family = _get_tuned_matmul_arch_family(capability)
+    if arch_family not in _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS:
+        pytest.skip("No tuned persistent matmul config for this architecture")
+
+    default = {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64,
+               "GROUP_SIZE_M": 8, "num_stages": 3, "num_warps": 8}
+    dtype = torch.bfloat16
+    # Use a shape guaranteed to have per-bucket variation (present in all arches).
+    N, K = 2048, 2048
+
+    # Without pinning, M=8 and M=9 can land in different buckets.
+    set_config_max_num_seqs(0)
+    cfg_8 = _get_matmul_config(8, N, K, dtype, default)
+    cfg_9 = _get_matmul_config(9, N, K, dtype, default)
+    # Confirm they are indeed different so the test is meaningful on this arch.
+    if cfg_8 == cfg_9:
+        pytest.skip("M=8 and M=9 happen to share a bucket on this architecture")
+
+    # With pinning to max_num_seqs=16, both must return the same config.
+    set_config_max_num_seqs(16)
+    try:
+        pinned_8 = _get_matmul_config(8, N, K, dtype, default)
+        pinned_9 = _get_matmul_config(9, N, K, dtype, default)
+        assert pinned_8 == pinned_9, (
+            "Config must be identical for M=8 and M=9 when pinned to max_num_seqs=16"
+        )
+    finally:
+        set_config_max_num_seqs(0)

--- a/vllm/model_executor/determinism/batch_invariant.py
+++ b/vllm/model_executor/determinism/batch_invariant.py
@@ -11,6 +11,7 @@ import vllm.envs as envs
 from vllm.model_executor.determinism.batch_invariant_configs import (
     _get_descriptor_matmul_config,
     _get_matmul_config,
+    set_config_max_num_seqs,
     resolve_tuned_matmul_configs,
 )
 from vllm.platforms import current_platform
@@ -1159,10 +1160,12 @@ def override_envs_for_invariance():
     os.environ["VLLM_USE_AOT_COMPILE"] = "0"
 
 
-def init_batch_invariance():
+def init_batch_invariance(max_num_seqs: int = 0):
     # this will hit all the csrc overrides as well
     if envs.VLLM_BATCH_INVARIANT:
         resolve_tuned_matmul_configs()
+        if max_num_seqs > 0:
+            set_config_max_num_seqs(max_num_seqs)
         override_envs_for_invariance()
         enable_batch_invariant_mode()
 

--- a/vllm/model_executor/determinism/batch_invariant_configs.py
+++ b/vllm/model_executor/determinism/batch_invariant_configs.py
@@ -261,6 +261,20 @@ _TUNED_MATMUL_CONFIGS_FOR_DEVICE: dict[tuple[int, int], _MatmulShapeConfig] | No
 )
 _TUNED_MATMUL_CONFIGS_RESOLVED = False
 
+# When VLLM_BATCH_INVARIANT=1, kernel config selection is pinned to this bound
+# instead of the runtime M.  Async scheduling can include zombie requests that
+# inflate M by ±1, crossing m_bucket thresholds and changing Triton kernel
+# parameters (num_warps, BLOCK_SIZE_N, etc.), which alters the float32
+# accumulation order for every row and breaks bitwise reproducibility.
+# Pinning to max_num_seqs (a fixed config value) makes the selected config
+# independent of runtime batch size, eliminating the source of non-determinism.
+_config_max_num_seqs: int = 0
+
+
+def set_config_max_num_seqs(max_num_seqs: int) -> None:
+    global _config_max_num_seqs
+    _config_max_num_seqs = max_num_seqs
+
 
 def _get_tuned_matmul_arch_family(capability: DeviceCapability | None) -> str | None:
     if capability is None:
@@ -312,11 +326,15 @@ def _get_matmul_config(
     shape_config = device_configs.get((N, K))
     if shape_config is None:
         return default
+    # When VLLM_BATCH_INVARIANT is active, use max_num_seqs as the lookup key
+    # instead of the runtime M so that async-scheduling zombie requests cannot
+    # change the selected config and alter float32 accumulation order.
     # Values above the tuned range reuse the largest bucket;
     # shape-wide BLOCK_K keeps this batch-invariant.
+    lookup_m = _config_max_num_seqs if _config_max_num_seqs > 0 else M
     m_config = shape_config.m_buckets[-1][1]
     for max_m, bucket_config in shape_config.m_buckets:
-        if max_m >= M:
+        if max_m >= lookup_m:
             m_config = bucket_config
             break
     return {

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1489,7 +1489,7 @@ def init_worker_distributed_environment(
     parallel_config = vllm_config.parallel_config
     from vllm.model_executor.determinism.batch_invariant import init_batch_invariance
 
-    init_batch_invariance()
+    init_batch_invariance(vllm_config.scheduler_config.max_num_seqs)
     override_envs_for_eplb(
         parallel_config,
         moe_backend=getattr(vllm_config.kernel_config, "moe_backend", None),


### PR DESCRIPTION
## Summary

Fixes the root cause of the non-determinism reported in #51287: when `VLLM_BATCH_INVARIANT=1`, async scheduling can include **zombie requests** (completed at step N but not yet retired before batch N+1 is dispatched) that inflate the runtime M dimension by ±1. If that ±1 crosses an `m_bucket` threshold in `_get_matmul_config()`, a different Triton kernel config is selected — different `num_warps`, `BLOCK_SIZE_N`, etc. — changing the float32 accumulation order for every row and breaking bitwise reproducibility.

This is **not** a duplicate of #51287. That PR disables async scheduling as a workaround. This PR fixes the underlying mechanism so async scheduling can remain enabled.

## Root Cause

`_get_matmul_config()` selects Triton kernel parameters by looking up runtime `M` in per-shape `m_bucket` thresholds. Example (Ada SM89, shape 12288×2048):

m ≤  8  → num_warps=8
m ≤ 16  → num_warps=4   # different machine code → different accumulation order

A zombie request inflates M from 8→9, crossing the boundary, changing `num_warps`, and breaking determinism.

## Fix

Pin config selection to `max_num_seqs` (a fixed startup value) instead of runtime M:

```python
lookup_m = _config_max_num_seqs if _config_max_num_seqs > 0 else M

Same Triton config selected regardless of zombie requests. Zero effect when VLLM_BATCH_INVARIANT is not set.

Files Changed

- vllm/model_executor/determinism/batch_invariant_configs.py — _config_max_num_seqs global + set_config_max_num_seqs() + lookup_m in _get_matmul_config
- vllm/model_executor/determinism/batch_invariant.py — max_num_seqs param on init_batch_invariance() + setter call
- vllm/v1/worker/gpu_worker.py — passes scheduler_config.max_num_seqs to init_batch_invariance() at worker init
- tests/v1/determinism/test_matmul_batch_invariant.py — new test verifying M=8 and M=9 return identical configs when pinned to max_num_seqs=16

Test Results

H100 NVL (SM90, 95830 MiB), vLLM nightly 0.28.1rc1.dev337+g27a94d1ce, Torch 2.13.0+cu130:

35 passed in 9.04s
PASSED test_matmul_batch_invariant.py::test_get_matmul_config_pinned_to_max_num_seqs

Notes

- Not duplicating any existing open PR — #51287 takes a different workaround approach.

Signed-off-by: Yuval Luria yluria@redhat.com