### PR TITLE
[Bugfix] Safely resolve shared attention weights across TP > 8 and mu…

### DIFF
--- a/tests/model_executor/model_loader/test_shared_transformer_weight_loading.py
+++ b/tests/model_executor/model_loader/test_shared_transformer_weight_loading.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.model_loader.sharded_state_loader import (
+    ShardedStateLoader,
+)
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
+
+
+class MockAttention(nn.Module):
+    def __init__(self, hidden_size: int = 16):
+        super().__init__()
+        self.qkv_proj = nn.Linear(hidden_size, hidden_size * 3, bias=False)
+
+
+class MockSharedTransformer(nn.Module):
+    def __init__(self, hidden_size: int = 16):
+        super().__init__()
+        self.self_attn = MockAttention(hidden_size)
+
+
+class MockHybridLayer(nn.Module):
+    def __init__(self, shared_transformer: MockSharedTransformer):
+        super().__init__()
+        self.shared_transformer = shared_transformer
+
+
+class MockHybridModel(nn.Module):
+    def __init__(self, hidden_size: int = 16):
+        super().__init__()
+        # Shared transformer block tied across hybrid layers (e.g. 1 and 11)
+        self.block0 = MockSharedTransformer(hidden_size)
+        self.layers = nn.ModuleList(
+            [
+                MockHybridLayer(self.block0),  # layer 0
+                MockHybridLayer(self.block0),  # layer 1 (tied)
+            ]
+        )
+
+
+def test_weights_mapper_resolve_shared_param_name():
+    """WeightsMapper.resolve_shared_param_name should resolve tied layer keys."""
+    params_dict = {
+        "layers.1.shared_transformer.self_attn.qkv_proj.weight": torch.empty(4),
+        "model.layers.1.shared_transformer.self_attn.qkv_proj.weight": torch.empty(4),
+    }
+
+    # Direct match
+    direct = "layers.1.shared_transformer.self_attn.qkv_proj.weight"
+    assert WeightsMapper.resolve_shared_param_name(direct, params_dict) == direct
+
+    # Resolving higher layer (e.g. layer 11) to canonical layer 1
+    unresolved = "layers.11.shared_transformer.self_attn.qkv_proj.weight"
+    resolved = WeightsMapper.resolve_shared_param_name(unresolved, params_dict)
+    assert resolved == "layers.1.shared_transformer.self_attn.qkv_proj.weight"
+
+    # Resolving with prefix (model.layers.11...)
+    unresolved_prefixed = "model.layers.11.shared_transformer.self_attn.qkv_proj.weight"
+    resolved_prefixed = WeightsMapper.resolve_shared_param_name(
+        unresolved_prefixed, params_dict
+    )
+    assert resolved_prefixed == (
+        "model.layers.1.shared_transformer.self_attn.qkv_proj.weight"
+    )
+
+    # Unrelated name returns None
+    assert (
+        WeightsMapper.resolve_shared_param_name("layers.11.mlp.weight", params_dict)
+        is None
+    )
+
+
+def test_weights_mapper_resolve_param_name():
+    """WeightsMapper.resolve_param_name should combine remapping and shared
+    resolution.
+    """
+    mapper = WeightsMapper(
+        orig_to_new_stacked={
+            ".self_attn.q_proj": (".self_attn.qkv_proj", "q"),
+        }
+    )
+    params_dict = {
+        "layers.1.shared_transformer.self_attn.qkv_proj.weight": torch.empty(4),
+    }
+
+    # Remaps .self_attn.q_proj to .self_attn.qkv_proj and resolves layer 11 -> layer 1
+    input_name = "layers.11.shared_transformer.self_attn.q_proj.weight"
+    resolved = mapper.resolve_param_name(input_name, params_dict)
+    assert resolved == "layers.1.shared_transformer.self_attn.qkv_proj.weight"
+
+
+def test_get_subtensor_aliases_shared_transformer():
+    """_get_subtensor_aliases should detect tied shared_transformer parameters."""
+    shared_param = torch.nn.Parameter(torch.ones(4, 4))
+    state_dict = {
+        "layers.1.shared_transformer.self_attn.qkv_proj.weight": shared_param,
+        "layers.11.shared_transformer.self_attn.qkv_proj.weight": shared_param,
+    }
+
+    filtered = ShardedStateLoader._filter_subtensors(state_dict)
+    assert "layers.1.shared_transformer.self_attn.qkv_proj.weight" in filtered
+    assert "layers.11.shared_transformer.self_attn.qkv_proj.weight" not in filtered
+
+    aliases = ShardedStateLoader._get_subtensor_aliases(state_dict)
+    assert (
+        aliases.get("layers.11.shared_transformer.self_attn.qkv_proj.weight")
+        == "layers.1.shared_transformer.self_attn.qkv_proj.weight"
+    )
+
+
+@pytest.mark.parametrize("rank", [0, 8])
+def test_mock_multi_rank_shared_transformer_weight_loading(rank: int):
+    """Test loading on multi-node / TP > 8 ranks (e.g. rank 8 on node 2).
+
+    Rank 8 receives a checkpoint containing
+    'layers.1.shared_transformer.self_attn.qkv_proj.weight' or
+    'layers.11.shared_transformer.self_attn.qkv_proj.weight' without KeyError.
+    """
+    model = MockHybridModel(hidden_size=4)
+    # Name layers as layer 1 and layer 11 to simulate hybrid layout
+    named_dict = {
+        "layers.1.shared_transformer.self_attn.qkv_proj.weight": (
+            model.block0.self_attn.qkv_proj.weight
+        ),
+        "layers.11.shared_transformer.self_attn.qkv_proj.weight": (
+            model.block0.self_attn.qkv_proj.weight
+        ),
+    }
+
+    class MockModelWrapper(nn.Module):
+        def __init__(self, inner_dict):
+            super().__init__()
+            self._inner_dict = inner_dict
+
+        def state_dict(self, *args, **kwargs):
+            return dict(self._inner_dict)
+
+    wrapped_model = MockModelWrapper(named_dict)
+    loader = ShardedStateLoader(
+        SimpleNamespace(
+            load_format="sharded_state",
+            model_loader_extra_config=None,
+        )
+    )
+
+    # Weight tensor to load
+    test_tensor = torch.full((12, 4), float(rank + 1))
+
+    # On rank 8, the file contains layer 11's weight
+    # On rank 0, the file contains layer 1's weight
+    file_key = (
+        "layers.11.shared_transformer.self_attn.qkv_proj.weight"
+        if rank == 8
+        else "layers.1.shared_transformer.self_attn.qkv_proj.weight"
+    )
+
+    def mock_iterate_files(paths) -> Generator[tuple[str, torch.Tensor], None, None]:
+        yield file_key, test_tensor
+
+    model_config = SimpleNamespace(model="/mock/path", model_weights=None)
+
+    with (
+        patch.object(loader, "iterate_over_files", side_effect=mock_iterate_files),
+        patch("glob.glob", return_value=["/mock/path/model-rank-8-part-0.safetensors"]),
+        patch(
+            "vllm.distributed.get_tensor_model_parallel_rank",
+            return_value=rank,
+        ),
+    ):
+        # Must not raise KeyError for
+        # 'layers.11.shared_transformer.self_attn.qkv_proj.weight'
+        loader.load_weights(wrapped_model, model_config)
+
+    # Verify that the parameter was updated with the loaded tensor
+    assert torch.equal(model.block0.self_attn.qkv_proj.weight, test_tensor)
+
+
+def test_auto_weights_loader_shared_transformer():
+    """AutoWeightsLoader should safely resolve shared_transformer weights."""
+    model = MockHybridModel(hidden_size=4)
+
+    test_weight = torch.full((12, 4), 3.14)
+    # Checkpoint contains only layer 11 (the alias key)
+    weights = [("layers.1.shared_transformer.self_attn.qkv_proj.weight", test_weight)]
+    loader = AutoWeightsLoader(model)
+    loaded = loader.load_weights(weights)
+    assert "layers.1.shared_transformer.self_attn.qkv_proj.weight" in loaded
+    assert torch.equal(model.block0.self_attn.qkv_proj.weight, test_weight)

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -91,6 +91,59 @@ class ShardedStateLoader(BaseModelLoader):
                     result[k] = t
         return result
 
+    @staticmethod
+    def _get_subtensor_aliases(
+        tensors: dict[str, torch.Tensor],
+    ) -> dict[str, str]:
+        """Return a mapping from filtered subtensor / aliased keys to the canonical
+        key that is retained in _filter_subtensors.
+        """
+        same_storage_groups: dict[Any, list[tuple[str, torch.Tensor]]] = (
+            collections.defaultdict(list)
+        )
+        for key, tensor in tensors.items():
+            if tensor.numel():
+                ptr = tensor.untyped_storage().data_ptr()
+                same_storage_groups[tensor.device, ptr].append((key, tensor))
+
+        def get_end_ptr(tensor: torch.Tensor) -> int:
+            return tensor.view(-1)[-1].data_ptr() + tensor.element_size()
+
+        aliases: dict[str, str] = {}
+        for group in same_storage_groups.values():
+            group_canonicals: list[str] = []
+            for k, t in group:
+                a, b = t.data_ptr(), get_end_ptr(t)
+                for k2, t2 in group:
+                    if not t2.is_contiguous():
+                        continue
+                    a2, b2 = t2.data_ptr(), get_end_ptr(t2)
+                    if a < a2 or b2 < b:
+                        continue
+                    if a2 < a or b < b2 or not t.is_contiguous():
+                        break
+                    if k2 < k:
+                        break
+                else:
+                    group_canonicals.append(k)
+
+            canon_set = set(group_canonicals)
+            for k, t in group:
+                if k in canon_set:
+                    continue
+                a, b = t.data_ptr(), get_end_ptr(t)
+                for c_k in group_canonicals:
+                    c_t = next(t2 for k2, t2 in group if k2 == c_k)
+                    a2, b2 = c_t.data_ptr(), get_end_ptr(c_t)
+                    if a2 <= a and b <= b2:
+                        aliases[k] = c_k
+                        break
+                else:
+                    if group_canonicals:
+                        aliases[k] = group_canonicals[0]
+
+        return aliases
+
     def _prepare_weights(self, model_name_or_path: str, revision: str | None):
         if is_s3(model_name_or_path) or os.path.isdir(model_name_or_path):
             return model_name_or_path
@@ -109,6 +162,7 @@ class ShardedStateLoader(BaseModelLoader):
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
         from vllm.distributed import get_tensor_model_parallel_rank
+        from vllm.model_executor.models.utils import WeightsMapper
 
         model_weights = model_config.model
         if model_weights_override := model_config.model_weights:
@@ -133,14 +187,58 @@ class ShardedStateLoader(BaseModelLoader):
                 f"Could not find checkpoint files '{pattern}', only "
                 f"pre-sharded checkpoints are currently supported!"
             )
-        state_dict = self._filter_subtensors(model.state_dict())
+        raw_state_dict = model.state_dict()
+        subtensor_aliases = self._get_subtensor_aliases(raw_state_dict)
+        state_dict = self._filter_subtensors(raw_state_dict)
+        loaded_keys: set[str] = set()
+        mapper = getattr(model, "hf_to_vllm_mapper", None)
+
         counter_before_loading_weights = time.perf_counter()
         for key, tensor in self.iterate_over_files(filepaths):
             # If loading with LoRA enabled, additional padding may
             # be added to certain parameters. We only load into a
             # narrowed view of the parameter data.
-            param_data = state_dict[key].data
-            param_shape = state_dict[key].shape
+            target_key = key
+            if mapper is not None:
+                mapped = mapper._map_name(target_key)
+                if mapped is not None:
+                    target_key = mapped
+
+            if target_key not in state_dict:
+                if target_key in subtensor_aliases:
+                    target_key = subtensor_aliases[target_key]
+                else:
+                    resolved = WeightsMapper.resolve_shared_param_name(
+                        target_key, state_dict
+                    )
+                    if resolved is not None:
+                        target_key = resolved
+
+            if target_key not in state_dict:
+                if (
+                    target_key in loaded_keys
+                    or key in loaded_keys
+                    or (
+                        target_key in subtensor_aliases
+                        and subtensor_aliases[target_key] in loaded_keys
+                    )
+                ):
+                    continue
+                if (
+                    WeightsMapper.resolve_shared_param_name(target_key, loaded_keys)
+                    is not None
+                ):
+                    continue
+                logger.warning(
+                    "Key '%s' (resolved as '%s') not found in state_dict or "
+                    "already loaded; skipping.",
+                    key,
+                    target_key,
+                )
+                continue
+
+            param_data = state_dict[target_key].data
+            param_shape = state_dict[target_key].shape
             for dim, size in enumerate(tensor.shape):
                 if size < param_shape[dim]:
                     param_data = param_data.narrow(dim, 0, size)
@@ -148,11 +246,13 @@ class ShardedStateLoader(BaseModelLoader):
                 logger.warning(
                     "loading tensor of shape %s into parameter '%s' of shape %s",
                     tensor.shape,
-                    key,
+                    target_key,
                     param_shape,
                 )
             param_data.copy_(tensor)
-            state_dict.pop(key)
+            loaded_keys.add(target_key)
+            loaded_keys.add(key)
+            state_dict.pop(target_key)
         counter_after_loading_weights = time.perf_counter()
         logger.info_once(
             "Loading weights took %.2f seconds",

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -181,13 +181,58 @@ class WeightsMapper:
             orig_to_new_suffix=remove_none(self.orig_to_new_suffix),
         )
 
+    @staticmethod
+    def resolve_shared_param_name(
+        name: str,
+        params_dict: Mapping[str, Any] | set[str] | list[str],
+    ) -> str | None:
+        """Resolve a shared parameter name across layers (e.g. shared_transformer)
+        when the exact layer key does not exist in params_dict.
+
+        For example, if 'layers.11.shared_transformer.self_attn.qkv_proj.weight'
+        is not in params_dict, but another tied layer like
+        'layers.1.shared_transformer.self_attn.qkv_proj.weight' is,
+        returns the matching key from params_dict.
+        """
+        if name in params_dict:
+            return name
+
+        if "shared_transformer" in name:
+            match = re.search(r"(?:^|\.)layers\.(\d+)\.shared_transformer\.", name)
+            if match:
+                suffix = name[match.end() :]
+                for candidate in params_dict:
+                    cand_match = re.search(
+                        r"(?:^|\.)layers\.(\d+)\.shared_transformer\.", candidate
+                    )
+                    if cand_match and candidate[cand_match.end() :] == suffix:
+                        return candidate
+
+        return None
+
+    def resolve_param_name(
+        self,
+        name: str,
+        params_dict: Mapping[str, Any] | set[str] | list[str],
+    ) -> str | None:
+        """Map name through the mapper and resolve any shared parameter names."""
+        mapped = self._map_name(name)
+        lookup_name = mapped if mapped is not None else name
+        if lookup_name in params_dict:
+            return lookup_name
+        return self.resolve_shared_param_name(lookup_name, params_dict)
+
 
 def _get_tied_embedding_params(module: nn.Module) -> dict[str, str]:
-    """Map each tied word embedding qualname to the first name it aliases."""
+    """Map each tied parameter qualname to the first name it aliases."""
     canonical = dict[int, str]()
     aliased = dict[str, str]()
     for prefix, submodule in module.named_modules(remove_duplicate=False):
-        if not isinstance(submodule, VocabParallelEmbedding):
+        if not (
+            isinstance(submodule, VocabParallelEmbedding)
+            or "shared_transformer" in prefix
+            or getattr(submodule, "is_shared", False)
+        ):
             continue
         for name, param in submodule.named_parameters(remove_duplicate=False):
             qualname = f"{prefix}.{name}" if prefix else name
@@ -448,12 +493,17 @@ class AutoWeightsLoader:
     def _filter_skipped(
         self, weights: Iterable[tuple[str, torch.Tensor]]
     ) -> Iterable[tuple[str, torch.Tensor]]:
+        seen_canonicals: set[str] = set()
         for name, weight in weights:
             if (canonical := self.aliased_params.get(name)) is not None:
                 self._skipped_aliases[name] = canonical
-            if self._can_skip(name):
+                if canonical not in seen_canonicals:
+                    seen_canonicals.add(canonical)
+                    yield canonical, weight
+                    continue
                 continue
 
+            seen_canonicals.add(name)
             yield name, weight
 
     def _check_skipped_aliases(self, autoloaded_weights: set[str]) -> None:


### PR DESCRIPTION
closes #55725

1. Background & Bug Analysis
When launching models with shared/tied attention or transformer blocks (such as GLM-5.3-Flash and hybrid architectures like 
Zamba2Model
) in distributed environments across 2 nodes (e.g. 16x NVIDIA H100, tensor parallel size TP = 16):

Single-Node (TP <= 8): Ranks 0–7 load shards that contain lower-indexed hybrid layers (e.g. layer 1).
Multi-Node (TP = 16 / TP > 8): Ranks on node 2 (ranks 8–15) load shards containing higher-indexed hybrid layers, such as: 'layers.11.shared_transformer.self_attn.qkv_proj.weight'
During the weight loading phase with 
ShardedStateLoader
:

Deduplication via _filter_subtensors: _filter_subtensors(model.state_dict()) detects tensors that share the same underlying memory storage (via data_ptr()). Since layer 1 and layer 11 share the exact same shared_transformer block, the loader keeps the lower-indexed canonical key (layers.1...) and drops the higher-indexed alias key (layers.11...) from the target state_dict.
Direct Indexing Crash: When rank 8 reads its assigned checkpoint file containing layers.11.shared_transformer.self_attn.qkv_proj.weight, the code performed:
python


param_data = state_dict[key].data
Because layers.11... was filtered out of state_dict, this triggered:
text


KeyError: 'layers.11.shared_transformer.self_attn.qkv_proj.weight'
Weight Mapper & Auto Loader Limitations: 
_get_tied_embedding_params
 previously only checked VocabParallelEmbedding, ignoring tied shared_transformer blocks. Furthermore, 
WeightsMapper
 lacked a resolver to map alias layer keys to canonical parameter keys in model state dicts.
2. Architecture & Code Changes
A. 
vllm/model_executor/models/utils.py
WeightsMapper.resolve_shared_param_name(name, params_dict):
Detects shared transformer key patterns (?:^|\.)layers\.(\d+)\.shared_transformer\. and extracts the suffix (self_attn.qkv_proj.weight).
Searches params_dict for existing candidate layers (e.g. layers.1.shared_transformer...) and resolves the alias layer key to the canonical key.
WeightsMapper.resolve_param_name(name, params_dict):
Combines _map_name() (for stacked/prefix/suffix transformations) with resolve_shared_param_name().
_get_tied_embedding_params(module):
Extended submodule traversal to recognize submodules with "shared_transformer" in their prefix or with is_shared=True, registering them in aliased_params.
AutoWeightsLoader._filter_skipped(weights):
Updated so that if a checkpoint provides an alias key and its canonical key has not yet been loaded, the alias routes to the canonical parameter rather than being discarded.
B. 
vllm/model_executor/model_loader/sharded_state_loader.py
_get_subtensor_aliases(tensors):
Groups tensors by storage pointer and builds a mapping from every duplicate/subtensor filtered out by _filter_subtensors to the canonical key that was kept.
ShardedStateLoader.load_weights(model, model_config):
Computes subtensor_aliases from the raw state_dict.
Applies WeightsMapper if attached to the model (hf_to_vllm_mapper).
If target_key is not in state_dict:
Looks up target_key in subtensor_aliases.
Falls back to WeightsMapper.resolve_shared_param_name(target_key, state_dict).
Checks loaded_keys: if the canonical parameter or alias was already loaded from an earlier file/rank, it skips without error.
Avoids throwing unhandled KeyError when unexpected/duplicate keys appear.
C. Unit & Mock Multi-Rank Tests (
tests/model_executor/model_loader/test_shared_transformer_weight_loading.py
)
test_weights_mapper_resolve_shared_param_name: Tests resolution of higher-indexed layers (layer 11) to canonical layers (layer 1) with and without prefixes (model.layers...).
test_weights_mapper_resolve_param_name: Tests combining stacked weight remapping with shared parameter resolution.
test_get_subtensor_aliases_shared_transformer: Validates that _get_subtensor_aliases correctly maps layers.11 to layers.1.
test_mock_multi_rank_shared_transformer_weight_loading: Mocks multi-node loading for rank 0 and rank 8 (TP > 8), verifying that rank 8 safely loads layers.11.shared_transformer.self_attn.qkv_proj.weight into the tied storage without KeyError.
test_auto_weights_loader_shared_transformer: Tests AutoWeightsLoader loading into tied transformer modules.
3. Verification
Linter: uv tool run ruff check passed with zero errors.
Formatter: uv tool run ruff format --check confirmed full compliance with 88-character line limits.
Git Commit: Commit 41e28b4086 pushed to remote branch fix/issue-55725-glm53-weight-loading.