### PR TITLE
[Bugfix] Define masked_mha_available on MLAAttentionImpl

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1114,11 +1114,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         prefill = attn_metadata.prefill
         if prefill is None:
             return False
-        # `forward_mha` is optional on MLAAttentionImpl. Sparse-MLA impls such as
-        # FLASHINFER_MLA_SPARSE_SM120 implement only `forward_mqa`, so selecting
-        # either MHA path for them would raise NotImplementedError at runtime.
-        if not type(self.impl).mha_available():
-            return False
         use_masked_mha = (
             self.prefill_backend is not None
             and self.impl.masked_mha_available

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1114,9 +1114,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         prefill = attn_metadata.prefill
         if prefill is None:
             return False
+        # `forward_mha` is optional on MLAAttentionImpl. Sparse-MLA impls such as
+        # FLASHINFER_MLA_SPARSE_SM120 implement only `forward_mqa`, so selecting
+        # either MHA path for them would raise NotImplementedError at runtime.
+        if not type(self.impl).mha_available():
+            return False
         use_masked_mha = (
             self.prefill_backend is not None
-            and self.impl.masked_mha_available  # type: ignore[attr-defined]
+            and self.impl.masked_mha_available
             and self.impl.dcp_world_size <= 1
             and _use_masked_mha(
                 backend_name=self.attn_backend.get_name(),

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -998,9 +998,10 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
 
     supports_pcp: bool = True
 
-    # Whether this impl provides the masked-MHA prefill path. Backend selection
-    # in mla_attention.py reads this attribute directly, so it must exist on
-    # every MLA impl; impls that support masked MHA set it to True themselves.
+    # Whether this impl provides the masked-MHA prefill path. Selection code in
+    # mla_attention.py reads this attribute off a bare MLAAttentionImpl, so it
+    # must be defined for every MLA impl. Impls that do support masked MHA set
+    # it to True themselves, which shadows this default.
     masked_mha_available: bool = False
 
     @abstractmethod
@@ -1042,16 +1043,6 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
     ) -> None:
         """MHA-style prefill forward pass."""
         raise NotImplementedError
-
-    @classmethod
-    def mha_available(cls) -> bool:
-        """Whether this impl overrides the default (raising) `forward_mha`.
-
-        `forward_mha` is optional: sparse-MLA impls such as the SM120 backend
-        implement only `forward_mqa`. Selection code must not route work to an
-        impl that would just raise NotImplementedError.
-        """
-        return cls.forward_mha is not MLAAttentionImpl.forward_mha
 
     @abstractmethod
     def forward_mqa(

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -998,6 +998,11 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
 
     supports_pcp: bool = True
 
+    # Whether this impl provides the masked-MHA prefill path. Backend selection
+    # in mla_attention.py reads this attribute directly, so it must exist on
+    # every MLA impl; impls that support masked MHA set it to True themselves.
+    masked_mha_available: bool = False
+
     @abstractmethod
     def __init__(
         self,
@@ -1037,6 +1042,16 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
     ) -> None:
         """MHA-style prefill forward pass."""
         raise NotImplementedError
+
+    @classmethod
+    def mha_available(cls) -> bool:
+        """Whether this impl overrides the default (raising) `forward_mha`.
+
+        `forward_mha` is optional: sparse-MLA impls such as the SM120 backend
+        implement only `forward_mqa`. Selection code must not route work to an
+        impl that would just raise NotImplementedError.
+        """
+        return cls.forward_mha is not MLAAttentionImpl.forward_mha
 
     @abstractmethod
     def forward_mqa(


### PR DESCRIPTION
## Summary

Declares `masked_mha_available: bool = False` on `MLAAttentionImpl` so the attribute is
defined for every MLA implementation, and drops the now-unnecessary `type: ignore` on the
one selection site that reads it.

`_use_sparse_mha()` in `mla_attention.py` reads `self.impl.masked_mha_available` off a bare
`MLAAttentionImpl`, but the attribute is declared only on `SparseMLACommonImpl` — hence the
`# type: ignore[attr-defined]`. Any MLA impl that does not inherit from that class simply has
no such attribute. Declaring the default makes the read well-defined; impls that do support
masked MHA continue to set it to `True` per-instance, which shadows the class default.

No behaviour change.

## History — scope reduced

This PR originally also added an `mha_available()` classmethod and an early return in
`_use_sparse_mha()`, to stop the selector routing work to an impl that implements only
`forward_mqa`. That was written against **v0.28.0**, where `FlashInferMLASparseSM120Impl`
hits `AttributeError` on this exact read and then `NotImplementedError` on `forward_mha`
(reported in #55757).

That is **already fixed on main** by #51395, which gives the SM120 impl
`supports_dense_mha_prefill = False`; the layer then sets `prefill_backend = None`, and
`_use_sparse_mha()` short-circuits on `self.prefill_backend is not None` **before** reaching
the attribute read. v0.28.0 branched roughly 19 hours before #51395 merged, which is why the
crash is reachable there and not on main. With the guard therefore dead code on main, this PR
has been narrowed to the base-class default alone.

## Test plan

- `masked_mha_available` resolves on any `MLAAttentionImpl` subclass that does not define it,
  and a per-instance `True` still shadows the class default (checked with standalone
  assertions on subclass propagation and instance-attribute shadowing).
- `py_compile` clean on both files.
- No call site changes behaviour: every impl reaching `_use_sparse_mha()` either sets the
  attribute itself or has `prefill_backend is None` and returns earlier.
