### PR TITLE
[Bugfix][Parser] Extract tool calls emitted within reasoning blocks

### DIFF
--- a/tests/entrypoints/openai/test_reasoning_tool_calls_boundary.py
+++ b/tests/entrypoints/openai/test_reasoning_tool_calls_boundary.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.generate.base.protocol import (
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.abstract_parser import DelegatingParser
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class _MockToolParser:
+    """Mock tool parser implementation for testing."""
+
+    supports_required_and_named = False
+
+
+class _MockReasoningToolParser(DelegatingParser):
+    """Mock delegating parser combining reasoning and tool call extraction."""
+
+    def __init__(self):
+        """Initialize mock parser with a mock tool parser."""
+        super().__init__(tokenizer=None)
+        self._tool_parser = _MockToolParser()
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        """Mock check if reasoning has completed."""
+        return True
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        """Mock extraction of content token IDs."""
+        return input_ids
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: list[int],
+        current_token_ids: list[int],
+        delta_token_ids: list[int],
+    ):
+        """Mock streaming extraction of reasoning."""
+        return None
+
+    def extract_reasoning(self, model_output: str, request):
+        """Extract reasoning span delimited by <think>...</think> tags."""
+        if "</think>" in model_output:
+            parts = model_output.split("</think>")
+            reasoning = parts[0].replace("<think>", "").strip()
+            content = parts[1].strip() or None
+            return reasoning, content
+        return model_output, None
+
+    def extract_tool_calls(self, content: str, request):
+        """Extract tool calls containing <tool_call> tags."""
+        if "<tool_call>" in content:
+            tool_call = ToolCall(
+                function=FunctionCall(
+                    name="get_weather",
+                    arguments='{"city": "Paris"}',
+                )
+            )
+            clean_content = content.split("<tool_call>")[0].strip() or None
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=[tool_call],
+                content=clean_content,
+            )
+        return ExtractedToolCallInformation(
+            tools_called=False,
+            tool_calls=[],
+            content=content,
+        )
+
+
+def test_tool_call_inside_think_region_is_extracted():
+    """Verify that tool calls emitted inside the reasoning region (<think>...</think>)
+    are properly extracted and not lost (regression test for Issue 39056).
+    """
+    parser = _MockReasoningToolParser()
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is the weather?"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+        }
+    )
+
+    # Case 1: Standard output where tool call is after </think>
+    standard_output = (
+        "<think>Let me think</think><tool_call><function=get_weather></tool_call>"
+    )
+    reasoning, content, tool_calls = parser.parse(
+        standard_output, request, enable_auto_tools=True
+    )
+    assert reasoning == "Let me think"
+    assert tool_calls is not None and len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+
+    # Case 2: Bug in Issue 39056 where tool call is inside <think>...</think>
+    think_with_tool_call = (
+        "<think>Let me think\n<tool_call><function=get_weather></tool_call></think>"
+    )
+    reasoning, content, tool_calls = parser.parse(
+        think_with_tool_call, request, enable_auto_tools=True
+    )
+    # The tool call must NOT be lost
+    assert tool_calls is not None and len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+    # The reasoning must not retain the raw tool_call markup and must preserve
+    # non-tool reasoning
+    assert "<tool_call>" not in (reasoning or "")
+    assert reasoning == "Let me think"
+
+    # Case 3: Named tool_choice with empty content and reasoning should not
+    # convert reasoning into arguments
+    named_request = ChatCompletionRequest.model_validate(
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What is the weather?"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        }
+    )
+    parser._tool_parser.supports_required_and_named = True
+    reasoning, content, tool_calls = parser.parse(
+        "<think>Just thinking, no tool call</think>",
+        named_request,
+        enable_auto_tools=True,
+    )
+    assert reasoning == "Just thinking, no tool call"
+    assert tool_calls == []

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -444,6 +444,36 @@ class DelegatingParser(Parser):
         state.history_tool_call_cnt += 1
         return tool_call_id
 
+    def _is_auto_tool_choice(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+        enable_auto_tools: bool,
+    ) -> bool:
+        """Determine whether automatic tool-call parsing should be used.
+
+        Returns True when tool calling is enabled and the request specifies
+        'auto' tool choice (or no explicit tool choice), or when fallback to auto
+        parsing is necessary because named/required tool choices are unsupported.
+        """
+        tool_parser = self._tool_parser
+        if tool_parser is None:
+            return False
+
+        supports_required_and_named = tool_parser.supports_required_and_named
+        is_named_tool_choice = request.tool_choice and isinstance(
+            request.tool_choice,
+            (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
+        )
+        is_required_tool_choice = request.tool_choice == "required"
+        return enable_auto_tools and (
+            request.tool_choice == "auto"
+            or request.tool_choice is None
+            or (
+                not supports_required_and_named
+                and (is_named_tool_choice or is_required_tool_choice)
+            )
+        )
+
     def _extract_tool_calls(
         self,
         content: str | None,
@@ -466,14 +496,7 @@ class DelegatingParser(Parser):
             (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
         )
         is_required_tool_choice = request.tool_choice == "required"
-        is_auto_tool_choice = enable_auto_tools and (
-            request.tool_choice == "auto"
-            or request.tool_choice is None
-            or (
-                not supports_required_and_named
-                and (is_named_tool_choice or is_required_tool_choice)
-            )
-        )
+        is_auto_tool_choice = self._is_auto_tool_choice(request, enable_auto_tools)
 
         tool_calls = list[FunctionCall]()
         if is_named_tool_choice and supports_required_and_named:
@@ -834,6 +857,23 @@ class DelegatingParser(Parser):
             request=request,
             enable_auto_tools=enable_auto_tools,
         )
+        # If no tool calls were found in content, check if the reasoning region
+        # contains tool calls (e.g. model emitted tool calls inside <think>).
+        # Restrict to automatic tool-call parsing to avoid treating reasoning
+        # text as arguments for named or required tool choices.
+        if (
+            not tool_calls
+            and reasoning
+            and self._is_auto_tool_choice(request, enable_auto_tools)
+        ):
+            reasoning_tool_calls, remaining_reasoning = self._extract_tool_calls(
+                content=reasoning,
+                request=request,
+                enable_auto_tools=enable_auto_tools,
+            )
+            if reasoning_tool_calls:
+                tool_calls = reasoning_tool_calls
+                reasoning = remaining_reasoning.strip() if remaining_reasoning else None
         return reasoning, content, tool_calls
 
     def parse_delta(


### PR DESCRIPTION


## Purpose

Fixes #39056

### Background & Problem
When serving reasoning models (e.g. `Qwen/Qwen3.5-35B-A3B-FP8`, Nemotron) with reasoning parsers (`--reasoning-parser qwen3`) and tool parsers (`--tool-call-parser qwen3_coder`), models may emit `<tool_call>` markup inside the reasoning span before emitting `</think>`. 

Because `extract_reasoning` captures everything before `</think>` into `reasoning`, downstream `_extract_tool_calls(content=content)` only inspects `content` (which is empty or `None`). As a result, the tool call is completely lost, causing agent frameworks (such as Claude Code, OpenCode, AutoGen) to receive 0 tool calls.

### Changes
- In `DelegatingParser.parse()` (`vllm/parser/abstract_parser.py`), if `tool_calls` is empty in `content` but `reasoning` is present, attempt extracting tool calls from `reasoning`.
- When tool calls are detected inside `reasoning`, populate `tool_calls` and clean the raw tool-call tags from `reasoning`.
- Added a regression test in `tests/entrypoints/openai/test_reasoning_tool_calls_boundary.py` covering standard tool calls and tool calls emitted within `<think>...</think>`.

## Test Plan

Run the dedicated regression test:
```bash
pytest tests/entrypoints/openai/test_reasoning_tool_calls_boundary.py