### PR TITLE
[Bugfix] Restore Responses validation error boundary

### DIFF
--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -46,6 +46,7 @@ from vllm.entrypoints.openai.responses.utils import (
 from vllm.entrypoints.serve import create_error_response
 from vllm.entrypoints.serve.engine.protocol import ErrorResponse
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import (
     EngineInput,
     PromptType,
@@ -412,7 +413,7 @@ class OnlineRenderer:
                         messages.append(new_message)
                     if isinstance(response_message, ResponseFunctionToolCall):
                         previous_outputs.append(response_message)
-        except ValueError as exc:
+        except (ValueError, VLLMValidationError) as exc:
             return self.create_error_response(
                 str(exc),
                 err_type="invalid_request_error",


### PR DESCRIPTION
## Purpose

[#50195](https://github.com/vllm-project/vllm/pull/50195) added an `OnlineRenderer` boundary that converts Harmony `ValueError`s into typed `ErrorResponse`s. [#55701](https://github.com/vllm-project/vllm/pull/55701) subsequently migrated the underlying validation to `VLLMValidationError`, which bypassed that boundary and broke CI. This narrowly extends the existing catch to preserve both behaviors. 

## Reproducer

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/openai/responses/test_serving_responses.py::test_online_renderer_returns_typed_error_for_bad_harmony_call_reference -q
```

On main branch:

```text
FAILED ... VLLMValidationError: No call message found for missing
1 failed
```

On this branch:
```text
1 passed
```

## AI assistance disclosure
OpenAI Codex (GPT-5) assisted with identifying the root cause.