### PR TITLE
[Entrypoints] Enable configured tool parser for forced tool choices w…

### DIFF
--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -9,6 +9,7 @@ import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.abstract_parser import DelegatingParser
+from vllm.parser.parser_manager import ParserManager
 from vllm.parser.utils import count_history_tool_calls
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
@@ -417,3 +418,58 @@ def test_parse_auto_tools_no_calls_returns_none(tokenizer):
     assert reasoning is None
     assert content == PLAIN_TEXT
     assert tool_calls is None
+
+
+def test_parser_manager_get_tool_parser_without_auto_tools():
+    parser_cls = ParserManager.get_tool_parser(
+        tool_parser_name="hermes",
+        enable_auto_tools=False,
+    )
+    assert parser_cls is not None
+    assert parser_cls is Hermes2ProToolParser
+
+
+def test_parser_manager_get_parser_without_auto_tools():
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="hermes",
+        enable_auto_tools=False,
+    )
+    assert parser_cls is not None
+    assert parser_cls.tool_parser_cls is Hermes2ProToolParser
+
+
+def test_parse_forced_named_tool_choice_without_auto_tools(tokenizer, monkeypatch):
+    monkeypatch.setattr(Hermes2ProToolParser, "supports_required_and_named", False)
+    parser = make_parser(tokenizer, reasoning=False, tool=True)
+    request = make_request(
+        tools=TOOLS,
+        tool_choice={
+            "type": "function",
+            "function": {"name": "get_weather"},
+        },
+    )
+    reasoning, content, tool_calls = parser.parse(
+        TOOL_CALL_ONLY, request, enable_auto_tools=False
+    )
+    assert reasoning is None
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+    assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}
+
+
+def test_parse_forced_required_tool_choice_without_auto_tools(tokenizer, monkeypatch):
+    monkeypatch.setattr(Hermes2ProToolParser, "supports_required_and_named", False)
+    parser = make_parser(tokenizer, reasoning=False, tool=True)
+    request = make_request(
+        tools=TOOLS,
+        tool_choice="required",
+    )
+    reasoning, content, tool_calls = parser.parse(
+        TOOL_CALL_ONLY, request, enable_auto_tools=False
+    )
+    assert reasoning is None
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "get_weather"
+    assert json.loads(tool_calls[0].arguments) == {"city": "Dallas"}

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -451,13 +451,12 @@ class DelegatingParser(Parser):
             (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
         )
         is_required_tool_choice = request.tool_choice == "required"
-        is_auto_tool_choice = enable_auto_tools and (
-            request.tool_choice == "auto"
-            or request.tool_choice is None
-            or (
-                not supports_required_and_named
-                and (is_named_tool_choice or is_required_tool_choice)
-            )
+        is_auto_tool_choice = (
+            enable_auto_tools
+            and (request.tool_choice == "auto" or request.tool_choice is None)
+        ) or (
+            not supports_required_and_named
+            and (is_named_tool_choice or is_required_tool_choice)
         )
 
         tool_calls = list[FunctionCall]()

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -31,9 +31,10 @@ class ParserManager:
         from vllm.tool_parsers import ToolParserManager
 
         parser: type[ToolParser] | None = None
-        if not enable_auto_tools or tool_parser_name is None:
+        if tool_parser_name is None:
             return parser
-        logger.info_once('"auto" tool choice has been enabled.')
+        if enable_auto_tools:
+            logger.info_once('"auto" tool choice has been enabled.')
 
         try:
             if (

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-from openai.types.responses import ResponseFunctionToolCall, ResponseOutputItem
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputItem,
+    ToolChoiceFunction,
+)
 from openai.types.responses.tool import Mcp, Tool
 from openai_harmony import Message as OpenAIMessage
 from openai_harmony import ToolNamespaceConfig
@@ -194,29 +198,27 @@ class OnlineRenderer:
             _mt.truncate_tool_call_ids(request)  # type: ignore[arg-type]
             _mt.validate_request_params(request)
 
-        # Check if tool parsing is unavailable (common condition)
-        tool_parsing_unavailable = (
-            tool_parser is None
-            and not is_mistral_tokenizer(tokenizer)
-            and not self.use_harmony
-        )
-
         # Validate tool_choice when tool parsing is required but unavailable
-        if tool_parsing_unavailable and request.tool_choice not in (
-            None,
-            "none",
+        if (
+            not is_mistral_tokenizer(tokenizer)
+            and not self.use_harmony
+            and request.tool_choice not in (None, "none")
         ):
-            if request.tool_choice == "auto" and not self.enable_auto_tools:
+            if request.tool_choice == "auto" and (
+                not self.enable_auto_tools or tool_parser is None
+            ):
                 # for hf tokenizers, "auto" tools requires
                 # --enable-auto-tool-choice and --tool-call-parser
                 return self.create_error_response(
                     '"auto" tool choice requires '
                     "--enable-auto-tool-choice and --tool-call-parser to be set"
                 )
-            elif request.tool_choice != "auto":
+            elif request.tool_choice != "auto" and tool_parser is None:
                 # "required" or named tool requires tool parser
                 if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
                     tool_choice_desc = f'function "{request.tool_choice.function.name}"'
+                elif isinstance(request.tool_choice, ToolChoiceFunction):
+                    tool_choice_desc = f'function "{request.tool_choice.name}"'
                 else:
                     tool_choice_desc = f'"{request.tool_choice}"'
                 return self.create_error_response(
@@ -303,6 +305,38 @@ class OnlineRenderer:
                 err_type="invalid_request_error",
                 param="previous_response_id",
             )
+
+        if (
+            not is_mistral_tokenizer(self.renderer.tokenizer)
+            and not self.use_harmony
+            and request.tools
+        ):
+            tool_parser = (
+                self.parser.tool_parser_cls if self.parser is not None else None
+            )
+            if request.tool_choice == "auto" and (
+                not self.enable_auto_tools or tool_parser is None
+            ):
+                return self.create_error_response(
+                    '"auto" tool choice requires '
+                    "--enable-auto-tool-choice and --tool-call-parser to be set"
+                )
+            elif (
+                request.tool_choice not in (None, "none", "auto")
+                and tool_parser is None
+            ):
+                if isinstance(request.tool_choice, ToolChoiceFunction):
+                    tool_choice_desc = f'function "{request.tool_choice.name}"'
+                elif isinstance(
+                    request.tool_choice, ChatCompletionNamedToolChoiceParam
+                ):
+                    tool_choice_desc = f'function "{request.tool_choice.function.name}"'
+                else:
+                    tool_choice_desc = f'"{request.tool_choice}"'
+                return self.create_error_response(
+                    f"tool_choice={tool_choice_desc} requires "
+                    "--tool-call-parser to be set"
+                )
 
         tool_dicts = construct_tool_dicts(
             request.tools,


### PR DESCRIPTION
closes #55754
It is ready-run-all-tests
1. Root Cause
ParserManager.get_tool_parser() gating: ParserManager.get_tool_parser() previously returned None whenever enable_auto_tools was False, even if a valid --tool-call-parser (e.g. hermes) was configured. As a result, forced named tool calls (e.g., tool_choice: {"type": "function", "function": {"name": "check"}}) and tool_choice: "required" failed with an HTTP 400 error claiming that --tool-call-parser was required despite being configured on the CLI.
Structural tag fallback gating: In 
DelegatingParser._extract_tool_calls
, parsers using structural tags (where supports_required_and_named = False) fell back to extract_tool_calls() only if is_auto_tool_choice was true. However, is_auto_tool_choice was guarded by enable_auto_tools, causing non-streaming forced tool calls to be dropped when --enable-auto-tool-choice was absent.
Request-level auto-choice validation: Because tool_parser was never loaded when enable_auto_tools was False, OnlineRenderer conflated missing parser errors with missing auto-tool flags. Additionally, the Responses API endpoint lacked explicit validation for tool choice options when --enable-auto-tool-choice is disabled.
2. Changes Implemented
ParserManager.get_tool_parser()
:

Separated parser loading from enable_auto_tools. The configured ToolParser class is now always loaded and returned when tool_parser_name is set.
Preserved the log notification logger.info_once('"auto" tool choice has been enabled.') when enable_auto_tools is True.
DelegatingParser._extract_tool_calls()
:

Updated is_auto_tool_choice so that forced named and required tool choices falling back to extract_tool_calls() (when not supports_required_and_named) are executed regardless of enable_auto_tools.
Maintained opt-in protection so that automatic tool choices (tool_choice="auto" or tool_choice=None) still require enable_auto_tools=True.
OnlineRenderer.render_chat() & OnlineRenderer.render_responses()
:

Separated request-level validation:
tool_choice == "auto" is validated to require --enable-auto-tool-choice (and --tool-call-parser), preserving native Mistral and Harmony exceptions.
Forced named/required tool choices only require --tool-call-parser and succeed without requiring --enable-auto-tool-choice.
Added the corresponding validation to render_responses() when tools are provided.
Unit Tests
:

Added unit tests verifying ParserManager.get_tool_parser() and ParserManager.get_parser() with enable_auto_tools=False.
Added tests verifying forced named and required tool choices correctly parse with supports_required_and_named=False when enable_auto_tools=False.
