### PR TITLE
[Bugfix] Avoid routed-expert metadata crash at prompt boundary

### DIFF
--- a/tests/test_request_input_bounds.py
+++ b/tests/test_request_input_bounds.py
@@ -121,6 +121,20 @@ def test_duplicate_stop_token_ids_are_deduplicated_in_order():
     assert params.all_stop_token_ids == {7, 9, 42}
 
 
+# --- Routed experts: prompt offsets stay within request bounds -------------
+
+
+def test_routed_experts_prompt_start_rejects_negative_value():
+    with pytest.raises(
+        VLLMValidationError,
+        match="routed_experts_prompt_start.*greater than or equal to 0",
+    ) as exc_info:
+        SamplingParams(routed_experts_prompt_start=-1)
+
+    assert exc_info.value.parameter == "routed_experts_prompt_start"
+    assert exc_info.value.value == -1
+
+
 # --- Bad words: dedup, and the tokenization pass is bounded ----------------
 
 

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -51,6 +51,7 @@ from vllm.v1.outputs import (
     ECConnectorOutput,
     KVConnectorOutput,
     ModelRunnerOutput,
+    RoutedExpertsLists,
     SamplingMaskLists,
     make_empty_encoder_model_runner_output,
 )
@@ -176,6 +177,55 @@ def test_pending_hisparse_spill_keeps_scheduler_alive():
     assert scheduler.has_requests()
     pending.clear()
     assert not scheduler.has_requests()
+
+
+def test_routed_experts_prompt_start_allows_prompt_boundary():
+    scheduler = create_scheduler(block_size=4, num_blocks=8)
+    scheduler.enable_return_routed_experts = True
+    scheduler.routed_experts_mgr = Mock()
+    scheduler.routed_experts_mgr.attn_gid = 0
+    scheduler.routed_experts_mgr.routed_experts_by_slot = np.zeros(
+        (32, 2, 2), dtype=np.uint8
+    )
+    scheduler.routed_experts_mgr.get.return_value = np.empty(
+        (0, 2, 2), dtype=np.uint8
+    )
+    scheduler._re_block_ids = {}
+
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=3,
+        max_tokens=1,
+        block_size=4,
+        req_ids=["req"],
+    )
+    assert request.sampling_params is not None
+    request.sampling_params.routed_experts_prompt_start = request.num_prompt_tokens
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    num_scheduled_tokens = scheduler_output.num_scheduled_tokens[request.request_id]
+    model_output = ModelRunnerOutput(
+        req_ids=[request.request_id],
+        req_id_to_index={request.request_id: 0},
+        sampled_token_ids=[[100]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+        routed_experts=RoutedExpertsLists(
+            routing_data=np.zeros((num_scheduled_tokens, 2, 2), dtype=np.uint8),
+            slot_mapping=np.arange(num_scheduled_tokens),
+        ),
+    )
+
+    engine_core_outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    scheduler.routed_experts_mgr.get.assert_called_once()
+    assert (
+        scheduler.routed_experts_mgr.get.call_args.kwargs["token_start"]
+        == request.num_prompt_tokens
+    )
+    assert engine_core_outputs[0].outputs[0].routed_experts.shape == (0, 2, 2)
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/engine/test_input_processor_trace_replay.py
+++ b/tests/v1/engine/test_input_processor_trace_replay.py
@@ -100,6 +100,25 @@ def test_trace_request_accepted_when_feature_enabled():
     _validate(enable_trace_replay=True)
 
 
+def test_routed_experts_prompt_start_accepts_prompt_boundary():
+    params = SamplingParams(routed_experts_prompt_start=3)
+
+    InputProcessor._validate_routed_experts_prompt_start(params, prompt_len=3)
+
+
+def test_routed_experts_prompt_start_rejects_past_prompt_len():
+    params = SamplingParams(routed_experts_prompt_start=4)
+
+    with pytest.raises(
+        VLLMValidationError,
+        match="cannot exceed the prompt length of 3 tokens",
+    ) as exc_info:
+        InputProcessor._validate_routed_experts_prompt_start(params, prompt_len=3)
+
+    assert exc_info.value.parameter == "routed_experts_prompt_start"
+    assert exc_info.value.value == 4
+
+
 def test_trace_replay_requires_v2_model_runner():
     config = SimpleNamespace(
         model_config=SimpleNamespace(enable_trace_replay=True),

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -624,6 +624,13 @@ class SamplingParams(
                 parameter="stream_interval",
                 value=self.stream_interval,
             )
+        if self.routed_experts_prompt_start < 0:
+            raise VLLMValidationError(
+                "`routed_experts_prompt_start` must be greater than or equal "
+                f"to 0, got {self.routed_experts_prompt_start}.",
+                parameter="routed_experts_prompt_start",
+                value=self.routed_experts_prompt_start,
+            )
         if self.logprobs is not None and self.logprobs != -1 and self.logprobs < 0:
             raise VLLMValidationError(
                 f"logprobs must be non-negative or -1, got {self.logprobs}.",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2101,7 +2101,9 @@ class Scheduler(SchedulerInterface):
                         prompt_start = (
                             request.sampling_params.routed_experts_prompt_start
                         )
-                        assert prompt_start < request.num_prompt_tokens
+                        prompt_start = min(
+                            max(prompt_start, 0), request.num_prompt_tokens
+                        )
                     else:
                         prompt_start = 0
                     routed_experts = self.routed_experts_mgr.get(

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -182,6 +182,20 @@ class InputProcessor:
         sampling_params.stop_token_ids = []
         sampling_params._all_stop_token_ids = set()
 
+    @staticmethod
+    def _validate_routed_experts_prompt_start(
+        sampling_params: SamplingParams, prompt_len: int
+    ) -> None:
+        """Reject routed-experts prompt offsets beyond the rendered prompt."""
+        prompt_start = sampling_params.routed_experts_prompt_start
+        if prompt_start > prompt_len:
+            raise VLLMValidationError(
+                "`routed_experts_prompt_start` cannot exceed the prompt length "
+                f"of {prompt_len} tokens.",
+                parameter="routed_experts_prompt_start",
+                value=prompt_start,
+            )
+
     def _validate_lora(self, lora_request: LoRARequest | None) -> None:
         if lora_request is None:
             return
@@ -354,12 +368,15 @@ class InputProcessor:
         if isinstance(params, SamplingParams):
             # TODO: can we avoid cloning here in multiproc case?
             sampling_params = params.clone()
+            prompt_len = length_from_prompt_token_ids_or_embeds(
+                prompt_token_ids, prompt_embeds
+            )
+            self._validate_routed_experts_prompt_start(sampling_params, prompt_len)
             # If unset max tokens, then generate up to the max_model_len.
             if sampling_params.max_tokens is None:
-                seq_len = length_from_prompt_token_ids_or_embeds(
-                    prompt_token_ids, prompt_embeds
+                sampling_params.max_tokens = (
+                    self.model_config.max_model_len - prompt_len
                 )
-                sampling_params.max_tokens = self.model_config.max_model_len - seq_len
 
             sampling_params.update_from_generation_config(
                 self.generation_config_fields,
@@ -370,9 +387,7 @@ class InputProcessor:
             if sampling_params.trace_decode_token_ids:
                 self._normalize_trace_replay_params(
                     sampling_params,
-                    length_from_prompt_token_ids_or_embeds(
-                        prompt_token_ids, prompt_embeds
-                    ),
+                    prompt_len,
                 )
         else:
             pooling_params = params.clone()


### PR DESCRIPTION
## Summary
- validate `routed_experts_prompt_start` against the final prompt length in `InputProcessor`, covering OpenAI and non-OpenAI generation callers before scheduling
- reject negative native `SamplingParams.routed_experts_prompt_start` values with a request validation error
- allow `routed_experts_prompt_start == prompt_len` by making the scheduler return an empty routed-experts prompt slice instead of asserting

Fixes #55750

## Duplicate check
- Checked `gh issue view 55750 --repo vllm-project/vllm --comments`: issue is open, unassigned, and had no comments before this PR.
- Checked `gh pr list --repo vllm-project/vllm --state open --search "55750 in:body"`: no open PRs.
- Checked `gh pr list --repo vllm-project/vllm --state open --search "Routed-expert metadata request crashes EngineCore return_routed_experts"`: no open PRs.

## Tests
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --no-project python -m py_compile vllm/v1/engine/input_processor.py vllm/v1/core/sched/scheduler.py vllm/sampling_params.py tests/v1/core/test_scheduler.py tests/v1/engine/test_input_processor_trace_replay.py tests/test_request_input_bounds.py` passed.
- `git diff --check` passed.
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --no-project ruff check vllm/v1/engine/input_processor.py vllm/v1/core/sched/scheduler.py vllm/sampling_params.py tests/v1/core/test_scheduler.py tests/v1/engine/test_input_processor_trace_replay.py tests/test_request_input_bounds.py` passed.
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --no-project python -m pytest tests/test_request_input_bounds.py::test_routed_experts_prompt_start_rejects_negative_value tests/v1/engine/test_input_processor_trace_replay.py::test_routed_experts_prompt_start_accepts_prompt_boundary tests/v1/engine/test_input_processor_trace_replay.py::test_routed_experts_prompt_start_rejects_past_prompt_len tests/v1/core/test_scheduler.py::test_routed_experts_prompt_start_allows_prompt_boundary -q` could not collect tests in this local environment: installed Torch 2.5.1 lacks `torch._inductor.custom_graph_pass`, while the current checkout expects newer Torch APIs.

## Model evals
Not run. This change only affects request validation and routed-expert metadata slicing; it does not change model weights, sampling, or generated-token selection.

## AI assistance
This PR was prepared with assistance from OpenAI Codex. The follow-up revision incorporates the centralized `InputProcessor` validation approach suggested by @meghaagr13.