### PR TITLE
Fix for negative prompt length

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -44,6 +44,7 @@ from vllm.v1.outputs import (
     ECConnectorOutput,
     KVConnectorOutput,
     ModelRunnerOutput,
+    RoutedExpertsLists,
     SamplingMaskLists,
     make_empty_encoder_model_runner_output,
 )
@@ -122,6 +123,48 @@ def test_add_requests():
         scheduler.add_request(request)
         assert request.request_id in scheduler.requests
         assert len(scheduler.waiting) == i + 1
+
+
+def test_routed_experts_prompt_start_at_prompt_end():
+    """A prompt-end offset should return empty routing data, not crash."""
+    scheduler = create_scheduler()
+    (request,) = create_requests(num_requests=1)
+    assert request.sampling_params is not None
+    request.sampling_params.routed_experts_prompt_start = request.num_prompt_tokens
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    num_scheduled_tokens = scheduler_output.num_scheduled_tokens[request.request_id]
+
+    routed_experts_manager = Mock()
+    routed_experts_manager.routed_experts_by_slot = np.empty((0, 1, 1), dtype=np.uint8)
+    routed_experts_manager.get.return_value = np.empty((0, 1, 1), dtype=np.uint8)
+    scheduler.enable_return_routed_experts = True
+    scheduler.routed_experts_mgr = routed_experts_manager
+    scheduler._re_block_ids = {request.request_id: []}
+
+    outputs = scheduler.update_from_output(
+        scheduler_output,
+        ModelRunnerOutput(
+            req_ids=[request.request_id],
+            req_id_to_index={request.request_id: 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+            routed_experts=RoutedExpertsLists(
+                routing_data=np.zeros((num_scheduled_tokens, 1, 1), dtype=np.uint8),
+                slot_mapping=np.arange(num_scheduled_tokens),
+            ),
+        ),
+    )
+
+    routed_experts_manager.get.assert_called_once_with(
+        [],
+        request.num_prompt_tokens,
+        token_start=request.num_prompt_tokens,
+    )
+    assert outputs[request.client_index].outputs[0].routed_experts.shape == (0, 1, 1)
 
 
 def test_finish_request():

--- a/tests/v1/engine/test_preprocess_error_handling.py
+++ b/tests/v1/engine/test_preprocess_error_handling.py
@@ -5,11 +5,23 @@ import pytest
 import torch.cuda
 
 from vllm import LLM, SamplingParams
+from vllm.exceptions import VLLMValidationError
 from vllm.platforms import current_platform
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.core import EngineCore
+from vllm.v1.engine.input_processor import InputProcessor
 
 MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
+
+
+def test_routed_experts_prompt_start_cannot_exceed_prompt_len():
+    params = SamplingParams(routed_experts_prompt_start=4)
+
+    with pytest.raises(
+        VLLMValidationError,
+        match="cannot exceed the prompt length of 3 tokens",
+    ):
+        InputProcessor._validate_routed_experts_prompt_start(params, prompt_len=3)
 
 
 def test_preprocess_error_handling(monkeypatch: pytest.MonkeyPatch):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2069,7 +2069,7 @@ class Scheduler(SchedulerInterface):
                         prompt_start = (
                             request.sampling_params.routed_experts_prompt_start
                         )
-                        assert prompt_start < request.num_prompt_tokens
+                        assert prompt_start <= request.num_prompt_tokens
                     else:
                         prompt_start = 0
                     routed_experts = self.routed_experts_mgr.get(

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -182,6 +182,19 @@ class InputProcessor:
         sampling_params.stop_token_ids = []
         sampling_params._all_stop_token_ids = set()
 
+    @staticmethod
+    def _validate_routed_experts_prompt_start(
+        sampling_params: SamplingParams, prompt_len: int
+    ) -> None:
+        prompt_start = sampling_params.routed_experts_prompt_start
+        if prompt_start > prompt_len:
+            raise VLLMValidationError(
+                "`routed_experts_prompt_start` cannot exceed the prompt length "
+                f"of {prompt_len} tokens.",
+                parameter="routed_experts_prompt_start",
+                value=prompt_start,
+            )
+
     def _validate_lora(self, lora_request: LoRARequest | None) -> None:
         if lora_request is None:
             return
@@ -354,12 +367,15 @@ class InputProcessor:
         if isinstance(params, SamplingParams):
             # TODO: can we avoid cloning here in multiproc case?
             sampling_params = params.clone()
+            prompt_len = length_from_prompt_token_ids_or_embeds(
+                prompt_token_ids, prompt_embeds
+            )
+            self._validate_routed_experts_prompt_start(sampling_params, prompt_len)
             # If unset max tokens, then generate up to the max_model_len.
             if sampling_params.max_tokens is None:
-                seq_len = length_from_prompt_token_ids_or_embeds(
-                    prompt_token_ids, prompt_embeds
+                sampling_params.max_tokens = (
+                    self.model_config.max_model_len - prompt_len
                 )
-                sampling_params.max_tokens = self.model_config.max_model_len - seq_len
 
             sampling_params.update_from_generation_config(
                 self.generation_config_fields,
@@ -370,9 +386,7 @@ class InputProcessor:
             if sampling_params.trace_decode_token_ids:
                 self._normalize_trace_replay_params(
                     sampling_params,
-                    length_from_prompt_token_ids_or_embeds(
-                        prompt_token_ids, prompt_embeds
-                    ),
+                    prompt_len,
                 )
         else:
             pooling_params = params.clone()


### PR DESCRIPTION

  - Changed the scheduler check from < to <=, allowing an offset exactly at the prompt boundary.
  - Added centralized validation in InputProcessor so an offset greater than the prompt length raises VLLMValidationError before reaching EngineCore.

## Purpose
Fix https://github.com/vllm-project/vllm/issues/55750

## Test Plan
  - Added a test for the oversized-offset case.
  - Ran both focused tests successfully:

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

