### PR TITLE
[Bugfix] unskip InternViT test for transformers v5 compatibility

### DIFF
--- a/tests/models/multimodal/pooling/test_intern_vit.py
+++ b/tests/models/multimodal/pooling/test_intern_vit.py
@@ -3,7 +3,7 @@
 import pytest
 import torch
 import torch.nn as nn
-from transformers import AutoConfig, AutoModel, CLIPImageProcessor
+from transformers import AutoConfig, AutoModel, CLIPImageProcessor, PreTrainedModel
 
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.platforms import current_platform
@@ -11,11 +11,6 @@ from vllm.transformers_utils.repo_utils import hf_api
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 
 from ....conftest import ImageTestAssets
-
-pytestmark = pytest.mark.skip(
-    reason="InternVisionModel's custom code is incompatible with "
-    "transformers v5 (missing all_tied_weights_keys)"
-)
 
 # we use snapshot_download to prevent conflicts between
 # dynamic_module and trust_remote_code for hf_runner
@@ -45,9 +40,23 @@ def run_intern_vit_test(
     if not getattr(config, "norm_type", None):
         config.norm_type = "rms_norm"
 
-    hf_model = AutoModel.from_pretrained(
-        model, dtype=torch_dtype, trust_remote_code=True
-    ).to(DEVICE_TYPE)
+    # Monkey-patch for transformers v5 compatibility: InternVisionModel's
+    # custom code doesn't call post_init(), so all_tied_weights_keys is
+    # never set. Remove once https://github.com/OpenGVLab/InternVL fixes it.
+    _orig_init = PreTrainedModel.__init__
+
+    def _patched_init(self, *args, **kwargs):
+        _orig_init(self, *args, **kwargs)
+        self.all_tied_weights_keys = {}
+
+    PreTrainedModel.__init__ = _patched_init
+
+    try:
+        hf_model = AutoModel.from_pretrained(
+            model, dtype=torch_dtype, trust_remote_code=True
+        ).to(DEVICE_TYPE)
+    finally:
+        PreTrainedModel.__init__ = _orig_init
     hf_outputs_per_image = [
         hf_model(pixel_value.to(DEVICE_TYPE)).last_hidden_state
         for pixel_value in pixel_values


### PR DESCRIPTION
## Purpose

Unskip `tests/models/multimodal/pooling/test_intern_vit.py`, which was skipped due to `InternVisionModel`'s custom code being incompatible with transformers v5 (missing `all_tied_weights_keys`).

## Root cause

`InternVisionModel.__init__` doesn't call `self.post_init()` , which is responsible for setting  `all_tied_weights_keys`, so `all_tied_weights_keys` is never set. Transformers v5 accesses it directly in `PreTrainedModel._move_missing_keys_from_meta_to_device` → `AttributeError`.

## Fix

There are two possible approaches:

### Option 1: Fix upstream

Fix `InternVisionModel` upstream so that its initialization is compatible with transformers v5, e.g. by ensuring the required `PreTrainedModel` initialization is performed and `all_tied_weights_keys` is properly initialized.

This is the cleaner long-term solution, as it addresses the root cause rather than working around it locally.

### Option 2: Monkey-patch

Monkey-patch `PreTrainedModel.__init__` to inject `self.all_tied_weights_keys = {}` before `AutoModel.from_pretrained` runs, then restore the original. InternViT has no tied weights, so an empty dict is correct. Works for both transformers 4.x and 5.x.

## Test plan

```bash
pytest tests/models/multimodal/pooling/test_intern_vit.py -v
```

## Test result

- HF monkey-patch verified on `transformers==5.16.1` (CPU) — model loads successfully, output shape `[1, 1025, 1024]`
- Full HF vs vLLM cosine similarity test requires GPU (vLLM's `InternVisionModel` uses `CustomOp` layers needing CUDA) — could not run in current environment

Related: #38379