### PR TITLE
[Frontend] Accept pre-tokenized prompt_token_ids in /v1/chat/completions

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2377,7 +2377,7 @@ steps:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)"
-  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex and not test_kv_transfer_prompt_token_ids_round_trip and not test_kv_transfer_prompt_token_ids_streaming"
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex and not test_kv_transfer_prompt_token_ids_round_trip and not test_kv_transfer_prompt_token_ids_streaming and not test_prompt_token_ids_round_trip"
   - pytest -v -s entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -k "not multiple"
   - pytest -v -s entrypoints/launchers/test_shutdown.py -k "not engine_failure and not test_abort_timeout_exits_quickly"
   - pytest -v -s entrypoints/openai/test_return_token_ids.py -k "not test_comparison"

--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -28,7 +28,7 @@ steps:
   - export VLLM_USE_RUST_FRONTEND=1
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)"
-  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex and not test_kv_transfer_prompt_token_ids_round_trip and not test_kv_transfer_prompt_token_ids_streaming"
+  - pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex and not test_kv_transfer_prompt_token_ids_round_trip and not test_kv_transfer_prompt_token_ids_streaming and not test_prompt_token_ids_round_trip"
   - pytest -v -s entrypoints/openai/chat_completion/test_include_reasoning.py
   - pytest -v -s entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -k "not multiple"
   - pytest -v -s entrypoints/openai/chat_completion/test_serving_chat.py -k "test_chat_per_request_metrics_follow_server_flag or test_streaming_reasoning_usage_counts_across_deltas or test_completion_tokens_details"

--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -56,10 +56,10 @@ Now supports 9 types of connectors:
 
 In disaggregated serving, the prefill and decode stages both render the chat prompt from `messages` and tokenize it. Because the prefill stage has already produced the token ids, the decode stage can reuse them and skip its own templating and tokenization. The output is otherwise identical to a normal chat completion: it is detokenized to text, and tool and reasoning parsing, streaming, and structured output constraints all still apply.
 
-The token ids are passed to the decode stage through `kv_transfer_params`, the dict already attached to the decode request to coordinate the transfer:
+The token ids are passed to the decode stage with the `prompt_token_ids` request field:
 
 1. Send the prefill request with `return_token_ids` enabled, and read `prompt_token_ids` from the response.
-2. Set `kv_transfer_params["prompt_token_ids"]` to those ids on the decode request. `messages` is still required, but its content is not tokenized when the ids are present.
+2. Set `prompt_token_ids` to those ids on the decode request. `messages` is still required, but its content is not tokenized when the ids are present.
 
 ```python
 prefill = client.chat.completions.create(
@@ -73,9 +73,13 @@ decode = client.chat.completions.create(
     model=model,
     messages=messages,
     stream=True,
-    extra_body={"kv_transfer_params": {"do_remote_prefill": True, "prompt_token_ids": ids}},
+    extra_body={"prompt_token_ids": ids, "kv_transfer_params": {"do_remote_prefill": True}},
 )
 ```
+
+Setting `kv_transfer_params["prompt_token_ids"]` instead is still accepted for compatibility with existing proxies. If both are set they must contain the same ids.
+
+Either spelling is validated the same way. The ids are checked against the model's context length and are truncated when `truncate_prompt_tokens` is set, exactly as a prompt tokenized by the server would be, so an over-long prompt is rejected rather than silently reducing the number of output tokens. Because the prompt is no longer rendered from `messages`, a request that also carries non-text message content or sets `echo` is rejected instead of silently dropping them.
 
 ## Development
 

--- a/docs/serving/online_serving/renderer.md
+++ b/docs/serving/online_serving/renderer.md
@@ -28,6 +28,18 @@ VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1 vllm serve <model>
 
 For the post processing counterpart that turns generated token IDs back into OpenAI compatible responses, see the [Derenderer APIs](derenderer.md).
 
+## Pre-tokenized prompts on `/v1/chat/completions`
+
+A frontend that has already applied the chat template and tokenized the prompt
+(for example a router that tokenizes once for prefix-cache-aware scheduling)
+does not need the token-in / token-out engine to avoid a second tokenization.
+It can send the ids in the `prompt_token_ids` field of a regular
+`/v1/chat/completions` request, alongside the original `messages`. vLLM then
+skips templating and tokenization and uses the ids verbatim, while tool and
+reasoning parsing, streaming, and the chat-shaped response are unchanged.
+`messages` is still required and multimodal content is not supported with
+`prompt_token_ids`.
+
 ## Multimodal Render Features
 
 Multimodal render responses include a `features` object with per-modality

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -240,6 +240,11 @@ pub struct ChatCompletionRequest {
     #[validate(length(min = 1))]
     pub cache_salt: Option<String>,
 
+    /// Pre-tokenized prompt. Implemented by the Python frontend only; declared
+    /// here so that a request setting it is rejected rather than silently
+    /// re-tokenized from `messages`.
+    pub prompt_token_ids: Option<Vec<u32>>,
+
     /// KV transfer parameters for disaggregated serving
     pub kv_transfer_params: Option<HashMap<String, Value>>,
 
@@ -314,6 +319,7 @@ impl Default for ChatCompletionRequest {
             return_tokens_as_token_ids: None,
             return_token_ids: None,
             cache_salt: None,
+            prompt_token_ids: None,
             kv_transfer_params: None,
             ec_transfer_params: None,
             vllm_xargs: None,
@@ -473,6 +479,13 @@ fn validate_chat_cross_parameters(
     {
         let mut e = validator::ValidationError::new("json_schema_name_empty");
         e.message = Some("JSON schema name cannot be empty".into());
+        return Err(e);
+    }
+
+    // 5. Pre-tokenized prompts are not implemented by the Rust frontend
+    if req.prompt_token_ids.is_some() {
+        let mut e = validator::ValidationError::new("prompt_token_ids_unsupported");
+        e.message = Some("prompt_token_ids is not supported by the Rust frontend".into());
         return Err(e);
     }
 

--- a/rust/src/server/src/routes/openai/chat_completions/validate.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/validate.rs
@@ -152,6 +152,21 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_prompt_token_ids() {
+        use validator::Validate;
+
+        let request = ChatCompletionRequest {
+            prompt_token_ids: Some(vec![10, 20, 30]),
+            ..base_request()
+        };
+
+        let err = request
+            .validate()
+            .expect_err("prompt_token_ids is implemented by the Python frontend only");
+        assert!(format!("{err}").contains("prompt_token_ids"));
+    }
+
+    #[test]
     fn validate_request_compat_accepts_stop() {
         let request = ChatCompletionRequest {
             stop: Some(StringOrArray::String("stop".to_string())),

--- a/tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py
+++ b/tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py
@@ -15,6 +15,7 @@ from vllm.entrypoints.openai.chat_completion.batch_serving import (
 from vllm.entrypoints.openai.chat_completion.protocol import (
     BatchChatCompletionRequest,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.outputs import CompletionOutput, RequestOutput
 
 # any model with a chat template defined in tokenizer_config should work here
@@ -322,3 +323,23 @@ async def test_batched_echo_prepends_matching_assistant_prefix() -> None:
     )
 
     assert response.choices[0].message.content == "PREFIX ASSISTANT ANSWER"
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"prompt_token_ids": [10, 20, 30]},
+        {"kv_transfer_params": {"prompt_token_ids": [10, 20, 30]}},
+    ],
+)
+def test_batch_rejects_prompt_token_ids(extra):
+    """One pre-tokenized prompt cannot stand in for every conversation."""
+    with pytest.raises(VLLMValidationError):
+        BatchChatCompletionRequest(
+            model="test-model",
+            messages=[
+                [{"role": "user", "content": "first"}],
+                [{"role": "user", "content": "second"}],
+            ],
+            **extra,
+        )

--- a/tests/entrypoints/openai/chat_completion/test_chat_completion.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat_completion.py
@@ -247,3 +247,34 @@ async def test_kv_transfer_prompt_token_ids_streaming(client: openai.AsyncOpenAI
     # streamed text-out, reconstructed from deltas, with generated token ids.
     assert content
     assert delta_token_ids
+
+
+@pytest.mark.asyncio
+async def test_prompt_token_ids_round_trip(client: openai.AsyncOpenAI):
+    """A top-level ``prompt_token_ids`` is used verbatim, skipping tokenize.
+
+    Mirrors the kv_transfer_params round trip above, using the public field.
+    """
+    baseline = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=TOKEN_IN_MESSAGES,
+        max_completion_tokens=16,
+        temperature=0,
+        extra_body={"return_token_ids": True},
+    )
+    ids = baseline.prompt_token_ids
+    assert ids
+
+    reused = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=DECODE_MESSAGES,
+        max_completion_tokens=16,
+        temperature=0,
+        extra_body={"prompt_token_ids": ids, "return_token_ids": True},
+    )
+
+    # The engine saw the supplied ids, not the request's own messages.
+    assert reused.prompt_token_ids == ids
+    assert reused.usage.prompt_tokens == len(ids)
+    # text-out: the response is still a detokenized chat message.
+    assert reused.choices[0].message.content

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import pytest_asyncio
 from openai import OpenAI
+from pydantic import ValidationError
 
 from tests.entrypoints.openai.utils import (
     accumulate_streaming_response,
@@ -591,6 +592,15 @@ def _build_online_renderer(
         chat_template=CHAT_TEMPLATE,
         chat_template_content_format="auto",
     )
+
+
+def _build_mock_engine() -> MagicMock:
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+    return mock_engine
 
 
 def _build_serving_chat(
@@ -2445,3 +2455,256 @@ def test_make_request_with_harmony_reuses_kv_transfer_prompt_token_ids():
     assert engine_input["prompt_token_ids"] == [10, 20, 30]
     # The reuse key is consumed and other kv_transfer_params are preserved.
     assert request.kv_transfer_params == {"do_remote_prefill": True}
+
+
+def test_make_request_with_harmony_uses_prompt_token_ids():
+    """The Harmony reuse branch also honors the public ``prompt_token_ids``."""
+    engine = MockEngine()
+    engine.model_config.hf_config = MockHFConfig(model_type="gpt_oss")
+    models = OpenAIServingModels(engine, BASE_MODEL_PATHS)
+    online_renderer = _build_online_renderer(engine, models.registry)
+    assert online_renderer.use_harmony
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "hi"}],
+        prompt_token_ids=[10, 20, 30],
+    )
+    conversation, engine_inputs = online_renderer._make_request_with_harmony(request)
+
+    assert conversation == []
+    assert len(engine_inputs) == 1
+    assert engine_inputs[0]["type"] == "token"
+    assert engine_inputs[0]["prompt_token_ids"] == [10, 20, 30]
+
+
+def test_make_request_with_harmony_validates_prompt_token_ids():
+    """The Harmony reuse branch applies the same length check as the HF path."""
+    engine = MockEngine()
+    engine.model_config.hf_config = MockHFConfig(model_type="gpt_oss")
+    models = OpenAIServingModels(engine, BASE_MODEL_PATHS)
+    online_renderer = _build_online_renderer(engine, models.registry)
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "hi"}],
+        prompt_token_ids=list(range(95)),
+        max_tokens=10,
+    )
+    with pytest.raises(VLLMValidationError):
+        online_renderer._make_request_with_harmony(request)
+
+
+PROMPT_TOKEN_IDS_MESSAGES = [{"role": "user", "content": "what is 1+1?"}]
+
+
+@pytest.mark.asyncio
+async def test_chat_prompt_token_ids_skip_rendering():
+    """``prompt_token_ids`` is used verbatim; ``messages`` is not rendered."""
+    serving_chat = _build_serving_chat(_build_mock_engine())
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=PROMPT_TOKEN_IDS_MESSAGES,
+        prompt_token_ids=[10, 20, 30],
+        cache_salt="test_salt",
+        max_tokens=1,
+    )
+    result = await serving_chat.render_chat_request(request)
+    assert not isinstance(result, ErrorResponse)
+
+    conversation, engine_inputs = result
+    assert conversation == []
+    assert len(engine_inputs) == 1
+    assert engine_inputs[0]["type"] == "token"
+    assert engine_inputs[0]["prompt_token_ids"] == [10, 20, 30]
+    assert engine_inputs[0]["cache_salt"] == "test_salt"
+
+
+@pytest.mark.asyncio
+async def test_chat_prompt_token_ids_length_validation():
+    """Supplied ids go through the same length checks as tokenized prompts."""
+    mock_engine = _build_mock_engine()
+    serving_chat = _build_serving_chat(mock_engine)
+
+    # max_model_len is 100: the default max_tokens is derived from the ids.
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=PROMPT_TOKEN_IDS_MESSAGES,
+        prompt_token_ids=list(range(90)),
+    )
+    with suppress(Exception):
+        await serving_chat.create_chat_completion(request)
+    assert mock_engine.generate.call_args.args[1].max_tokens == 10
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=PROMPT_TOKEN_IDS_MESSAGES,
+        prompt_token_ids=list(range(95)),
+        max_tokens=10,
+    )
+    with pytest.raises(VLLMValidationError):
+        await serving_chat.create_chat_completion(request)
+
+
+@pytest.mark.asyncio
+async def test_chat_prompt_token_ids_truncation():
+    serving_chat = _build_serving_chat(_build_mock_engine())
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=PROMPT_TOKEN_IDS_MESSAGES,
+        prompt_token_ids=[1, 2, 3, 4],
+        truncate_prompt_tokens=2,
+        truncation_side="right",
+        max_tokens=1,
+    )
+    result = await serving_chat.render_chat_request(request)
+    assert not isinstance(result, ErrorResponse)
+
+    _, engine_inputs = result
+    assert engine_inputs[0]["prompt_token_ids"] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_chat_prompt_token_ids_kv_transfer_alias():
+    """The legacy kv_transfer_params channel keeps working and must agree."""
+    serving_chat = _build_serving_chat(_build_mock_engine())
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=PROMPT_TOKEN_IDS_MESSAGES,
+        prompt_token_ids=[10, 20, 30],
+        kv_transfer_params={
+            "prompt_token_ids": [10, 20, 30],
+            "do_remote_prefill": True,
+        },
+        max_tokens=1,
+    )
+    result = await serving_chat.render_chat_request(request)
+    assert not isinstance(result, ErrorResponse)
+
+    _, engine_inputs = result
+    assert engine_inputs[0]["prompt_token_ids"] == [10, 20, 30]
+    assert request.kv_transfer_params == {"do_remote_prefill": True}
+
+    with pytest.raises(VLLMValidationError):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=PROMPT_TOKEN_IDS_MESSAGES,
+            prompt_token_ids=[10, 20, 30],
+            kv_transfer_params={"prompt_token_ids": [1, 2, 3]},
+        )
+
+
+@pytest.mark.asyncio
+async def test_chat_kv_transfer_prompt_token_ids_are_validated():
+    """Ids forwarded in kv_transfer_params get the same checks as the field."""
+    serving_chat = _build_serving_chat(_build_mock_engine())
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=PROMPT_TOKEN_IDS_MESSAGES,
+        kv_transfer_params={"prompt_token_ids": list(range(95))},
+        max_tokens=10,
+    )
+    with pytest.raises(VLLMValidationError):
+        await serving_chat.render_chat_request(request)
+
+
+@pytest.mark.parametrize("prompt_token_ids", [[], [-1]])
+def test_chat_prompt_token_ids_rejects_invalid_ids(prompt_token_ids):
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=PROMPT_TOKEN_IDS_MESSAGES,
+            prompt_token_ids=prompt_token_ids,
+        )
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        [
+            {"type": "text", "text": "what is in this image?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+        ],
+        # A part written without a "type" is identified by its media key.
+        [{"image_url": "https://example.com/a.png"}],
+        [{"input_audio": {"data": "", "format": "wav"}}],
+        # A media key counts even when the part claims to be text, which is
+        # how chat_utils reads a part carrying a "uuid".
+        [
+            {
+                "type": "text",
+                "text": "look",
+                "uuid": "u1",
+                "image_url": "https://example.com/a.png",
+            }
+        ],
+    ],
+)
+def test_chat_prompt_token_ids_rejects_multimodal_content(content):
+    with pytest.raises(VLLMValidationError):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": content}],
+            prompt_token_ids=[10, 20, 30],
+        )
+
+
+def test_chat_kv_transfer_prompt_token_ids_rejects_multimodal_content():
+    """The older kv_transfer_params spelling gets the same checks."""
+    with pytest.raises(VLLMValidationError):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/a.png"},
+                        }
+                    ],
+                }
+            ],
+            kv_transfer_params={"prompt_token_ids": [10, 20, 30]},
+        )
+
+
+def test_chat_prompt_token_ids_allows_text_only_parts():
+    """Text-bearing part types are not multimodal and must be accepted."""
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "let me think"},
+                    {"type": "refusal", "refusal": "no"},
+                ],
+            },
+            {"role": "user", "content": "plain string"},
+        ],
+        prompt_token_ids=[10, 20, 30],
+    )
+    assert request.prompt_token_ids == [10, 20, 30]
+
+
+def test_chat_prompt_token_ids_rejects_echo_and_empty_messages():
+    with pytest.raises(VLLMValidationError):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=PROMPT_TOKEN_IDS_MESSAGES,
+            prompt_token_ids=[10, 20, 30],
+            echo=True,
+        )
+
+    with pytest.raises(VLLMValidationError):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[],
+            prompt_token_ids=[10, 20, 30],
+        )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -20,6 +20,7 @@ from pydantic import (
 
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
+    MM_PARSER_MAP,
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
 )
@@ -57,6 +58,13 @@ logger = init_logger(__name__)
 
 _INT64_MIN = -(2**63)
 _INT64_MAX = 2**63 - 1
+
+# Content part types that carry text rather than multimodal data.
+_TEXT_CONTENT_PART_TYPES = frozenset(
+    {"text", "input_text", "output_text", "refusal", "thinking", "tool_reference"}
+)
+# Keys that identify a multimodal content part written without a ``type``.
+_MEDIA_CONTENT_PART_KEYS = frozenset(MM_PARSER_MAP) - _TEXT_CONTENT_PART_TYPES
 
 
 class ChatMessage(OpenAIBaseModel):
@@ -449,6 +457,23 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "prompt string produced by chat templating. In streaming mode it "
             "is sent only on the first chunk. This is useful for inspecting "
             "exactly what was fed into the model."
+        ),
+    )
+    prompt_token_ids: list[Annotated[int, Field(ge=0)]] | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Pre-tokenized prompt. When set, chat-template rendering and "
+            "tokenization of ``messages`` are skipped and these token IDs are "
+            "used as the prompt, still subject to the model's context length "
+            "and to ``truncate_prompt_tokens``. ``messages`` is still required "
+            "and is used for tool and reasoning parser configuration and for "
+            "the response role. This lets a routing layer that already applies "
+            "the chat template and tokenizes the prompt (e.g. for "
+            "prefix-cache-aware routing) avoid tokenizing twice. Because the "
+            "IDs bypass the server's chat template, they are not supported "
+            "together with non-text message content or ``echo``, and no "
+            "``prompt_text`` is returned."
         ),
     )
 
@@ -1005,6 +1030,83 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def check_prompt_token_ids(cls, data):
+        """Validate a pre-tokenized prompt against the rest of the request.
+
+        A pre-tokenized prompt skips rendering, so anything derived from the
+        rendered prompt is unavailable: non-text parts of ``messages`` would
+        never reach the multimodal processor, and ``echo`` has no prompt text
+        to echo. Both spellings are checked, the field and the older
+        ``kv_transfer_params`` key. Runs before validation because the media
+        keys of a content part written without a ``type`` do not survive it.
+        """
+        if not isinstance(data, dict):
+            return data
+        prompt_token_ids = data.get("prompt_token_ids")
+        kv_transfer_params = data.get("kv_transfer_params")
+        kv_ids = (
+            kv_transfer_params.get("prompt_token_ids")
+            if isinstance(kv_transfer_params, dict)
+            else None
+        )
+        if prompt_token_ids is None and kv_ids is None:
+            return data
+
+        if (
+            isinstance(kv_ids, list | tuple)
+            and isinstance(prompt_token_ids, list | tuple)
+            and list(kv_ids) != list(prompt_token_ids)
+        ):
+            raise VLLMValidationError(
+                "`prompt_token_ids` and `kv_transfer_params['prompt_token_ids']` "
+                "must match when both are set.",
+                parameter="prompt_token_ids",
+            )
+
+        if data.get("echo"):
+            raise VLLMValidationError(
+                "`echo` is not supported with `prompt_token_ids` because the "
+                "prompt is not rendered from `messages`.",
+                parameter="echo",
+            )
+
+        messages = data.get("messages")
+        if isinstance(messages, list) and not messages:
+            raise VLLMValidationError(
+                "`messages` must not be empty when `prompt_token_ids` is set.",
+                parameter="messages",
+            )
+
+        for msg in messages or []:
+            if not isinstance(msg, dict):
+                continue
+            content = msg.get("content")
+            parts = [content] if isinstance(content, dict) else content
+            if not isinstance(parts, list):
+                continue
+            for part in parts:
+                if not isinstance(part, dict):
+                    continue
+                # A media key identifies a part whatever its 'type' says,
+                # mirroring _parse_chat_message_content_mm_part.
+                non_text = next(
+                    (key for key in _MEDIA_CONTENT_PART_KEYS if key in part), None
+                )
+                if non_text is None:
+                    part_type = part.get("type")
+                    if part_type is None or part_type in _TEXT_CONTENT_PART_TYPES:
+                        # Carries no media: the ids are authoritative anyway.
+                        continue
+                    non_text = part_type
+                raise VLLMValidationError(
+                    "`prompt_token_ids` is not supported together with non-text "
+                    f"message content (found a {non_text!r} part).",
+                    parameter="prompt_token_ids",
+                )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def check_system_message_content_type(cls, data):
         """Warn if system messages contain non-text content.
 
@@ -1143,6 +1245,16 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
             raise VLLMValidationError(
                 "when using `logprob_token_ids`, `logprobs` must be set to true.",
                 parameter="logprob_token_ids",
+            )
+        kv_transfer_params = data.get("kv_transfer_params")
+        if data.get("prompt_token_ids") is not None or (
+            isinstance(kv_transfer_params, dict)
+            and kv_transfer_params.get("prompt_token_ids") is not None
+        ):
+            raise VLLMValidationError(
+                "Batch chat completions do not support `prompt_token_ids`: one "
+                "pre-tokenized prompt cannot serve several conversations.",
+                parameter="prompt_token_ids",
             )
         response_format = data.get("response_format")
         if response_format is not None:

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -32,6 +32,7 @@ from vllm.inputs import (
     EngineInput,
     PromptType,
     SingletonPrompt,
+    TokensPrompt,
     tokens_input,
 )
 from vllm.logger import init_logger
@@ -48,16 +49,20 @@ logger = init_logger(__name__)
 
 
 def _reused_prompt_token_ids(request: Any) -> list[int] | None:
-    """Pop prompt token ids forwarded for decode-side reuse, if any.
+    """Return the pre-tokenized prompt attached to a chat request, if any.
 
-    Disaggregated serving carries the prefill stage's ids in
-    ``kv_transfer_params`` so the decode stage can skip re-tokenizing. Removing
-    the key keeps the id list out of the engine's sampling metadata.
+    ``prompt_token_ids`` is the public request field. Disaggregated serving may
+    instead forward the prefill stage's ids in ``kv_transfer_params`` so the
+    decode stage can skip re-tokenizing; that key is popped to keep the id list
+    out of the engine's sampling metadata. ``ChatCompletionRequest`` rejects the
+    two disagreeing.
     """
+    ids = (
+        request.prompt_token_ids if isinstance(request, ChatCompletionRequest) else None
+    )
     kv = getattr(request, "kv_transfer_params", None)
-    if not isinstance(kv, dict):
-        return None
-    return kv.pop("prompt_token_ids", None) or None
+    kv_ids = kv.pop("prompt_token_ids", None) if isinstance(kv, dict) else None
+    return ids or kv_ids or None
 
 
 class OnlineRenderer:
@@ -125,11 +130,11 @@ class OnlineRenderer:
         Called directly by render_chat_request and delegated to by
         OpenAIServingChat.render_chat_request after its engine-aware checks.
 
-        Decode-side token reuse (ids forwarded in ``kv_transfer_params``) is
-        handled deeper, in ``preprocess_chat`` / ``_make_request_with_harmony``,
-        so it skips only templating and tokenization while tool-choice
-        validation and ``adjust_request`` still run and the output is
-        detokenized (text-out).
+        Pre-tokenized prompts (``prompt_token_ids``, or ids forwarded in
+        ``kv_transfer_params`` for decode-side reuse) are handled deeper, in
+        ``preprocess_chat`` / ``_make_request_with_harmony``, so they skip only
+        templating and tokenization while tool-choice validation and
+        ``adjust_request`` still run and the output is detokenized (text-out).
         """
         tokenizer = self.renderer.tokenizer
 
@@ -225,9 +230,16 @@ class OnlineRenderer:
         """Build Harmony (GPT-OSS) messages and engine prompt from a chat request."""
         reuse_ids = _reused_prompt_token_ids(request)
         if reuse_ids:
-            # Decode-side token reuse: feed the forwarded ids straight to the
-            # engine. Harmony has no adjust_request hook to preserve.
-            engine_input = tokens_input(reuse_ids, cache_salt=request.cache_salt)
+            # Pre-tokenized prompt: bound the ids by the model's context length
+            # and honor truncate_prompt_tokens, neither of which Harmony
+            # rendering does. Harmony has no adjust_request hook to preserve.
+            tok_params = request.build_tok_params(self.model_config)
+            prompt = tok_params.apply_post_tokenization(
+                self.renderer.tokenizer, TokensPrompt(prompt_token_ids=reuse_ids)
+            )
+            engine_input = tokens_input(
+                prompt["prompt_token_ids"], cache_salt=request.cache_salt
+            )
             return [], [engine_input]
 
         messages: list[OpenAIMessage] = []
@@ -414,13 +426,15 @@ class OnlineRenderer:
 
         reuse_ids = _reused_prompt_token_ids(request)
         if reuse_ids:
-            # Decode-side token reuse: feed the forwarded ids straight to the
-            # engine, skipping templating and tokenization. ``messages`` are not
-            # tokenized, so conversation is empty. The adjust_request tail below
-            # still runs.
+            # Pre-tokenized prompt: skip templating and tokenization and run
+            # the ids through the completions path so length validation and
+            # truncation still apply. ``messages`` are not rendered, so the
+            # conversation is empty. The adjust_request tail below still runs.
             conversation: list[ConversationMessage] = []
-            engine_input = tokens_input(
-                reuse_ids, cache_salt=getattr(request, "cache_salt", None)
+            (engine_input,) = await self.preprocess_cmpl(
+                request,
+                [TokensPrompt(prompt_token_ids=reuse_ids)],
+                skip_mm_cache=skip_mm_cache,
             )
         else:
             (conversation,), (engine_input,) = await renderer.render_chat_async(


### PR DESCRIPTION
## Purpose

Fixes #55770 (see also #54937, #25051).

Adds an optional `prompt_token_ids` field to `ChatCompletionRequest`. When set, chat-template rendering and tokenization of `messages` are skipped and those token IDs become the engine prompt, while the response stays a normal `chat.completion` with tool and reasoning parsing and streaming.

The motivation is routing layers that already tokenize. A KV-cache-aware or prefix-aware router has to apply the chat template and tokenize before it can pick a replica, so today the engine tokenizes the same prompt a second time; moving those callers to `/v1/completions` instead costs them tool-call handling, reasoning parsers and chat-shaped output. The vLLM router measured 29% lower TTFT at 60k tokens and 41% at 125k when it stopped double-tokenizing.

vLLM already supports this on the chat path, but only through `kv_transfer_params["prompt_token_ids"]` (#48145). The merging maintainer noted there that stuffing it inside `kv_transfer_params` "makes the interface opaque and basically undiscoverable" and left open where token ids should live. This PR promotes that path to a first-class field and closes three gaps in it.

**Semantics.** `messages` stays required and still drives tool/`tool_choice` validation, the reasoning parser, `adjust_request` and the response role. `kv_transfer_params["prompt_token_ids"]` keeps working as an alias; if both are set they must be equal. Text-only for now: multimodal and `/v1/messages` are deferred, as agreed on #54937.

**Changes**

- `vllm/entrypoints/openai/chat_completion/protocol.py` — the field (non-empty, ids `>= 0`), placed inside the `chat-completion-extra-params` snippet markers so it renders into the OpenAI-compatible-server docs automatically, plus a `mode="before"` validator. The validator runs before pydantic coercion because the media keys of a content part written without a `type` do not survive validation, and it applies to both spellings.
- `vllm/renderers/online_renderer.py` — `_reused_prompt_token_ids` reads the field first and still pops the `kv_transfer_params` key. The HF chat branch now builds the engine input through `preprocess_cmpl`, and the Harmony branch through `apply_post_tokenization`, so `TokenizeParams` post-tokenization applies on both.
- `rust/src/server/.../chat_completions/{types,validate}.rs` — the Rust frontend does not implement the field, and without a declaration serde would drop it and silently re-tokenize `messages`. It now returns a validation error instead. (The Rust frontend also ignores `kv_transfer_params["prompt_token_ids"]`; that is pre-existing and left alone.)
- Docs: `docs/features/disagg_prefill.md` switched to the public field with the alias documented, plus a short section in `docs/serving/online_serving/renderer.md` for router authors.

**Validation added.** Rejected with 400 rather than silently mis-served: an over-long prompt (previously the reuse path skipped the length check, so it silently reduced the output budget instead); non-text message content, including a part whose media key is hidden behind a text `type` plus a `uuid`, which `_parse_chat_message_content_mm_part` reads as media; `echo`, which has no rendered prompt to echo and returned nothing; empty `messages`, which used to reach `messages[-1]` and 500; and disagreement between the two spellings. `truncate_prompt_tokens` now truncates the ids.

**Behavior changes for existing `kv_transfer_params["prompt_token_ids"]` users**, all previously silent failures, all now 400:

| Request | Before | After |
| --- | --- | --- |
| ids longer than `max_model_len - max_tokens` | output budget silently clamped | 400, standard context-length error |
| `truncate_prompt_tokens` set | ignored | honored |
| non-text content parts alongside the ids | media silently dropped | 400 |
| `echo=true` | echoed nothing | 400 |
| batch endpoint with ids | one prompt silently served every conversation | 400 |

The batch rejection also closes a pre-existing hole: `BatchChatCompletionRequest.to_chat_completion_request` uses `model_dump`, and with `extra="allow"` an undeclared `prompt_token_ids` (or the alias) propagated to every derived conversation.

**Not addressed, deliberately.** The field is not behind a server flag, matching the already-ungated `kv_transfer_params` path. Client-supplied ids do bypass the server's chat template, which is a stronger capability than `--trust-request-chat-template` contemplates, so if you would rather gate it (an `--enable-prompt-token-ids` flag, or keying off `kv_transfer_config`) say so and I will add it. `prompt_embeds` content parts and `/v1/messages` are out of scope.

## Test Plan

```bash
cd tests
VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -q entrypoints/openai/chat_completion/test_serving_chat.py \
  entrypoints/openai/chat_completion/test_batched_chat_completions.py test_request_input_bounds.py
VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -q entrypoints/openai/chat_completion/test_chat_completion.py \
  entrypoints/openai/chat_completion/test_chat_echo.py entrypoints/openai/chat_completion/test_chat_error.py
cd ../rust && cargo fmt --check && cargo clippy -p vllm-server --all-targets && cargo test -p vllm-server
pre-commit run ruff-check ruff-format typos check-spdx-header --files <changed>
pre-commit run --hook-stage manual mypy-3.10 --files vllm/entrypoints/openai/chat_completion/protocol.py vllm/renderers/online_renderer.py
```

New tests: ids used verbatim with rendering skipped and `cache_salt` preserved; `max_tokens` derived from the supplied ids and an over-long prompt rejected; `truncate_prompt_tokens`; the alias honored, validated, and rejected on mismatch; empty, negative and out-of-vocab ids; non-text content rejected for typed media, typeless media, media hidden behind a text `type` with a `uuid`, and an unknown part type reported by its own name; text-bearing parts (`text`, `thinking`, `refusal`, `tool_reference`) accepted; `echo` and empty `messages` rejected; both Harmony branches; batch rejection for both spellings; and an e2e round trip asserting `prompt_token_ids` and `usage.prompt_tokens` match the ids that were sent.

The e2e test is added to the existing Rust-frontend and AMD `-k` exclusion lists next to the #48145 tests, since the Rust frontend now rejects the field.

## Test Result

On one L4 (g6.12xlarge), vLLM main precompiled, torch 2.13.0+cu132:

| Suite | Result |
| --- | --- |
| `test_serving_chat.py` + `test_batched_chat_completions.py` + `test_request_input_bounds.py` | 93 passed, 4 skipped |
| `test_chat_completion.py` + `test_chat_echo.py` + `test_chat_error.py` (GPU e2e) | 33 passed |
| `cargo test -p vllm-server` (chat_completions) | 69 passed; `cargo fmt --check` and `clippy` clean |
| Live request matrix against `vllm serve Qwen/Qwen2.5-1.5B-Instruct` | 35/35 |

The live matrix covers, against a real server: ids used verbatim with different `messages`; `usage.prompt_tokens`; streaming, including the first-chunk `prompt_token_ids`; a forced tool call still parsed from a pre-tokenized prompt; the alias alone, in agreement, and in conflict; every rejection above for both spellings; `truncate_prompt_tokens`; out-of-vocab ids; `cache_salt`; the batch endpoint with and without the field; and `/tokenize` and `/v1/completions` unaffected.

Written with Claude Code; the design, review and testing are mine, and the commit carries a `Co-authored-by: Claude` trailer per the AI-assistance guidance in `docs/contributing/README.md`.
