### PR TITLE
[Docs] Add MiniCPMV4_6ForConditionalGeneration to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -590,7 +590,8 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `MiDashengLMModel` | MiDashengLM | T + A<sup>+</sup> | `mispeech/midashenglm-7b` | | ✅︎ |
 | `MiMoV2OmniForCausalLM` | MiMo-V2.5-Omni | T + I<sup>E+</sup> + V<sup>E+</sup> + A<sup>+</sup> | `XiaomiMiMo/MiMo-V2.5-Omni` | | ✅︎ |
 | `MiniCPMO` | MiniCPM-O | T + I<sup>E+</sup> + V<sup>E+</sup> + A<sup>E+</sup> | `openbmb/MiniCPM-o-2_6`, etc. | ✅︎ | ✅︎ |
-| `MiniCPMV` | MiniCPM-V | T + I<sup>E+</sup> + V<sup>E+</sup> | `openbmb/MiniCPM-V-2` (see note), `openbmb/MiniCPM-Llama3-V-2_5`, `openbmb/MiniCPM-V-2_6`, `openbmb/MiniCPM-V-4`, `openbmb/MiniCPM-V-4_5`, `openbmb/MiniCPM-V-4_6`, etc. | ✅︎ | |
+| `MiniCPMV` | MiniCPM-V | T + I<sup>E+</sup> + V<sup>E+</sup> | `openbmb/MiniCPM-V-2` (see note), `openbmb/MiniCPM-Llama3-V-2_5`, `openbmb/MiniCPM-V-2_6`, `openbmb/MiniCPM-V-4`, `openbmb/MiniCPM-V-4_5`, etc. | ✅︎ | |
+| `MiniCPMV4_6ForConditionalGeneration` | MiniCPM-V-4.6 | T + I<sup>E+</sup> + V<sup>E+</sup> | `openbmb/MiniCPM-V-4_6`, etc. | ✅︎ | ✅︎ |
 | `MiniMaxM3SparseForConditionalGeneration` | MiniMax-M3 | T + I<sup>+</sup> + V<sup>+</sup> | `MiniMaxAI/MiniMax-M3`, `MiniMaxAI/MiniMax-M3-MXFP8`, etc. | | ✅︎ |
 | `MiniMaxVL01ForConditionalGeneration` | MiniMax-VL | T + I<sup>E+</sup> | `MiniMaxAI/MiniMax-VL-01`, etc. | | ✅︎ |
 | `Mistral3ForConditionalGeneration` | Mistral3 (HF Transformers) | T + I<sup>+</sup> | `mistralai/Mistral-Small-3.1-24B-Instruct-2503`, etc. | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Purpose

`openbmb/MiniCPM-V-4_6` is registered and tested under architecture `MiniCPMV4_6ForConditionalGeneration` (`vllm/model_executor/models/minicpmv4_6.py`, `tests/models/registry.py`), with LoRA + PP support (`SupportsLoRA`, `SupportsPP`). The multimodal supported-models table still listed MiniCPM-V-4_6 under the older `MiniCPMV` architecture (tests for `MiniCPMV` only cover through 4.5).

This PR:
- Adds a `MiniCPMV4_6ForConditionalGeneration` row (T+I+V, LoRA ✅︎, PP ✅︎)
- Removes `openbmb/MiniCPM-V-4_6` from the `MiniCPMV` example list

## Repro

```bash
# Architecture registered separately from MiniCPMV
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/model_executor/models/registry.py \
  | rg -n 'MiniCPMV4_6ForConditionalGeneration|"MiniCPMV"'

# Test registry: MiniCPM-V-4_6 maps to MiniCPMV4_6*; MiniCPMV extras stop at 4.5
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/tests/models/registry.py \
  | rg -n -A6 'MiniCPMV4_6|"MiniCPMV"'

# Docs previously attributed 4_6 to MiniCPMV
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/models/supported_models.md \
  | rg -n 'MiniCPMV|MiniCPM-V-4_6'
```

## Test Plan

- [x] Confirm registry + tests map `openbmb/MiniCPM-V-4_6` → `MiniCPMV4_6ForConditionalGeneration`
- [x] Confirm class implements `SupportsLoRA` and `SupportsPP`
- [x] Docs table row + MiniCPMV example list updated

## Test Result

Verified against HEAD `06334fae` via gh API/raw (no local clone).