### PR TITLE
[Docs] Add SmolLM3 to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -135,6 +135,7 @@ Batch invariance has been tested and verified on the following models:
 - **Granite 3.1 (Dense)**: `ibm-granite/granite-3.1-2b-instruct`, `ibm-granite/granite-3.1-8b-instruct`
 - **EXAONE 4.0 series**: `LGAI-EXAONE/EXAONE-4.0-1.2B`, `LGAI-EXAONE/EXAONE-4.0.1-32B`, `LGAI-EXAONE/EXAONE-4.0-32B`
 - **OLMo 2**: `allenai/OLMo-2-0425-1B-Instruct`
+- **SmolLM3**: `HuggingFaceTB/SmolLM3-3B`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Summary

Add `HuggingFaceTB/SmolLM3-3B` to the list of models explicitly validated for batch invariance.

## Validation

Hardware:
- NVIDIA GeForce RTX 4090 24GB (SM89)

Software:
- Python 3.12.11
- PyTorch 2.13.0+cu132
- CUDA 13.2
- vLLM 0.1.dev20944+g58ad1f3b8

Model:
- `HuggingFaceTB/SmolLM3-3B`

Test command:

```bash
VLLM_TEST_MODEL=HuggingFaceTB/SmolLM3-3B \
pytest tests/v1/determinism/test_batch_invariance.py \
-v -s --tb=short

Results:

Passed:

test_v1_generation_is_deterministic_across_batch_sizes_with_needle
test_simple_generation

Backend coverage:

FLASH_ATTN: passed
TRITON_ATTN: passed

Additional observations:

FLEX_ATTENTION logprobs-related tests failed during engine initialization.
Generation batch invariance was successfully validated.