### PR TITLE
[Docs] Add Glm5Next (GLM-5.3-Flash) to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -411,6 +411,7 @@ th {
 | `Glm4MoeForCausalLM` | GLM-4.5, GLM-4.6, GLM-4.7 | `zai-org/GLM-4.5`, etc. | ✅︎ | ✅︎ |
 | `Glm4MoeLiteForCausalLM` | GLM-4.7-Flash | `zai-org/GLM-4.7-Flash`, etc. | ✅︎ | ✅︎ |
 | `GlmMoeDsaForCausalLM` | GLM-5, GLM-5.1, GLM-5.2 | `zai-org/GLM-5`, etc. | ✅︎ | ✅︎ |
+| `Glm5NextForCausalLM` | GLM-5.3-Flash | `zai-org/GLM-5.3-Flash`, etc. | | ✅︎ |
 | `GPT2LMHeadModel` | GPT-2 | `openai-community/gpt2`, `openai-community/gpt2-xl`, etc. | | ✅︎ |
 | `GPTJForCausalLM` | GPT-J | `EleutherAI/gpt-j-6b`, `nomic-ai/gpt4all-j`, etc. | | ✅︎ |
 | `GPTNeoXForCausalLM` | GPT-NeoX, Pythia, OpenAssistant, Dolly V2, StableLM | `EleutherAI/gpt-neox-20b`, `EleutherAI/pythia-12b`, `OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5`, `databricks/dolly-v2-12b`, `stabilityai/stablelm-tuned-alpha-7b`, etc. | | ✅︎ |
@@ -557,6 +558,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `GLM4VForCausalLM`<sup>^</sup> | GLM-4V | T + I | `zai-org/glm-4v-9b`, `zai-org/cogagent-9b-20241220`, etc. | ✅︎ | ✅︎ |
 | `Glm4vForConditionalGeneration` | GLM-4.1V-Thinking | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.1V-9B-Thinking`, etc. | ✅︎ | ✅︎ |
 | `Glm4vMoeForConditionalGeneration` | GLM-4.5V | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.5V`, etc. | ✅︎ | ✅︎ |
+| `Glm5NextForConditionalGeneration` | GLM-5.3-Flash | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-5.3-Flash`, etc. | ✅︎ | ✅︎ |
 | `GlmOcrForConditionalGeneration` | GLM-OCR | T + I<sup>E+</sup> | `zai-org/GLM-OCR`, etc. | ✅︎ | ✅︎ |
 | `Granite4VisionForConditionalGeneration` | Granite 4 Vision | T + I<sup>E+</sup> | `ibm-granite/granite-4.1-3b-vision`, etc. | ✅︎ | ✅︎ |
 | `GraniteSpeechForConditionalGeneration` | Granite Speech | T + A | `ibm-granite/granite-speech-3.3-8b` | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary
- Add `Glm5NextForCausalLM` and `Glm5NextForConditionalGeneration` (GLM-5.3-Flash) to `docs/models/supported_models.md`.
- Architecture was registered in #53906 but the supported-models docs tables were not updated.

## Repro
On `main` @ `9dbdf8e9af660e3b6876b27c2d1590bcab2e2de3`:

```bash
rg -n 'Glm5NextFor(CausalLM|ConditionalGeneration)' vllm/model_executor/models/registry.py
rg -n -A2 'Glm5NextForCausalLM' tests/models/registry.py
rg -n 'Glm5Next' docs/models/supported_models.md || echo MISSING
```

Capabilities used for the rows:
- Text: `SupportsPP` only (no `SupportsLoRA`) → LoRA blank, PP check.
- Multimodal: inherits `Glm4vForConditionalGeneration` (`SupportsLoRA` + `SupportsPP`); `get_supported_mm_limits` → `{"image": None, "video": 1}` → `T + I<sup>E+</sup> + V<sup>E+</sup>` (same notation as GLM-4.1V/4.5V).

## Test plan
- [ ] Confirm text row sits after `GlmMoeDsaForCausalLM` (GLM-5 family)
- [ ] Confirm multimodal row sits between `Glm4vMoeForConditionalGeneration` and `GlmOcrForConditionalGeneration`
- [ ] Confirm HF example `zai-org/GLM-5.3-Flash` matches `tests/models/registry.py`