### PR TITLE
[Bugfix][Tool Parser] Stream all parallel hy_v4 tool calls arriving in one delta

### DIFF
--- a/tests/tool_parsers/test_hy_v4_tool_parser.py
+++ b/tests/tool_parsers/test_hy_v4_tool_parser.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the HYV4 tool call parser."""
+
+from unittest.mock import Mock
+
+import pytest
+from transformers import AutoTokenizer
+
+from tests.tool_parsers.utils import run_tool_extraction_streaming
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
+from vllm.tool_parsers.hy_v4_tool_parser import HYV4ToolParser
+
+STRUCTURAL_TOKENS = [
+    "<tool_calls>",
+    "</tool_calls>",
+    "<tool_call>",
+    "</tool_call>",
+    "<arg_key>",
+    "</arg_key>",
+    "<arg_value>",
+    "</arg_value>",
+]
+
+
+@pytest.fixture(scope="module")
+def hy_v4_tokenizer():
+    # The extractor requires the structural tokens in the vocab and detects
+    # markers on token ids, so they must tokenize atomically.
+    tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
+    tokenizer.add_tokens(STRUCTURAL_TOKENS)
+    return tokenizer
+
+
+@pytest.fixture
+def hy_v4_tool_parser(hy_v4_tokenizer):
+    return HYV4ToolParser(hy_v4_tokenizer)
+
+
+@pytest.fixture
+def mock_request() -> ChatCompletionRequest:
+    request = Mock(spec=ChatCompletionRequest)
+    request.tools = [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="get_weather",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            ),
+        ),
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="get_time",
+                parameters={
+                    "type": "object",
+                    "properties": {"timezone": {"type": "string"}},
+                },
+            ),
+        ),
+    ]
+    request.tool_choice = "auto"
+    return request
+
+
+def test_parallel_tool_calls_in_one_delta(hy_v4_tool_parser, mock_request):
+    """Batched decode can deliver several newline-separated calls in one delta;
+    streaming must emit all of them, matching non-streaming."""
+    delta = (
+        "<tool_calls>"
+        "<tool_call>get_weather<arg_key>city</arg_key>"
+        "<arg_value>Tokyo</arg_value></tool_call>"
+        "\n"
+        "<tool_call>get_time<arg_key>timezone</arg_key>"
+        "<arg_value>UTC</arg_value></tool_call>"
+        "</tool_calls>"
+    )
+    reconstructor = run_tool_extraction_streaming(
+        hy_v4_tool_parser,
+        [delta],
+        request=mock_request,
+        assert_one_tool_per_delta=False,
+    )
+    assert [tc.function.name for tc in reconstructor.tool_calls] == [
+        "get_weather",
+        "get_time",
+    ]

--- a/vllm/tool_parsers/hy_v4_tool_parser.py
+++ b/vllm/tool_parsers/hy_v4_tool_parser.py
@@ -746,13 +746,15 @@ class HYV4ToolExtractor:
                 tool_calls.extend(result["tool_calls"])
 
             # Continue only after the current tool call has completed and the
-            # remaining structural payload starts with another tool call.
+            # remaining structural payload holds another tool call (possibly
+            # behind inter-tag padding, which the loop top drops).
             # A literal ``<tool_call>`` may legitimately appear inside an open
             # string argument; in that case the current tool name is still set
             # and the buffer has not been consumed, so continuing would spin on
             # the same buffer forever.
-            if self._streaming_tool_name is None and self._buffer.startswith(
-                self.tool_call_start_token
+            if (
+                self._streaming_tool_name is None
+                and self._buffer.find(self.tool_call_start_token) != -1
             ):
                 continue
             break


### PR DESCRIPTION
## Purpose

`hy_v4` streaming silently drops every parallel `<tool_call>` after the first when the calls are newline-separated and arrive in the same delta (batched decode). Non-streaming returns all of them.

The drain loop in `HYV4ToolExtractor.extract_tool_calls_streaming` only continued when the remaining buffer *started with* `<tool_call>`. After the first call completes, the buffer begins with the separator, so the loop broke and the rest was never emitted. The loop top already detects the next call by containment and drops the inter-tag padding; this makes the loop bottom consistent with it.

Caveat: the Hy4 chat template renders calls without a separator, but the non-streaming path accepts newline-separated calls and real HY-V3 outputs contain them, so streaming and non-streaming should agree.

Not a duplicate: #55550 fixes two different `hy_v4` streaming bugs (tool-name boundary, nameless calls) in the name-slicing lines and does not touch this condition. Both PRs add `tests/tool_parsers/test_hy_v4_tool_parser.py`, so whichever lands second needs a trivial rebase.

## Test Plan

```bash
pytest tests/tool_parsers/test_hy_v4_tool_parser.py tests/tool_parsers/test_hy_v3_tool_parser.py -q
pytest tests/tool_parsers -q --ignore=tests/tool_parsers/test_cohere_command_tool_parser.py
pre-commit run --files vllm/tool_parsers/hy_v4_tool_parser.py tests/tool_parsers/test_hy_v4_tool_parser.py
```

## Test Result

New test with the fix stashed:

```
AssertionError: assert ['get_weather'] == ['get_weather', 'get_time']
```

With the fix: `15 passed` (hy_v4 + hy_v3). Full `tests/tool_parsers`: `980 passed, 3 skipped, 34 xfailed`; the 15 errors are all `test_llama3_json_tool_parser.py` (gated HF repo) and the ignored cohere file needs `cohere_melody`, both pre-existing on main. pre-commit clean.

AI assistance was used for this change. I reviewed every changed line and ran the tests above myself.
