### PR TITLE
[Bugfix][Frontend] Clean up child tasks when request wrappers are cancelled

### DIFF
--- a/tests/entrypoints/serve/utils/test_api_utils.py
+++ b/tests/entrypoints/serve/utils/test_api_utils.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
 from argparse import Namespace
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,6 +14,45 @@ from vllm.entrypoints.serve.utils.api_utils import (
     redact_sensitive_args,
     should_include_usage,
 )
+
+
+@pytest.mark.asyncio
+async def test_with_cancellation_cleans_up_children_when_wrapper_is_cancelled():
+    blocker = asyncio.Event()
+    handler_started = asyncio.Event()
+    receive_started = asyncio.Event()
+    child_tasks: list[asyncio.Task] = []
+
+    async def handler(_self, _request):
+        task = asyncio.current_task()
+        assert task is not None
+        child_tasks.append(task)
+        handler_started.set()
+        await blocker.wait()
+
+    async def receive():
+        task = asyncio.current_task()
+        assert task is not None
+        child_tasks.append(task)
+        receive_started.set()
+        await blocker.wait()
+
+    wrapped = api_utils.with_cancellation(handler)
+    parent_task = asyncio.create_task(wrapped(None, SimpleNamespace(receive=receive)))
+    await asyncio.gather(handler_started.wait(), receive_started.wait())
+
+    try:
+        parent_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await parent_task
+
+        assert len(child_tasks) == 2
+        assert all(task.done() for task in child_tasks)
+    finally:
+        for task in child_tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*child_tasks, return_exceptions=True)
 
 
 @pytest.mark.parametrize(

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -79,16 +79,18 @@ def with_cancellation(handler_func):
 
         handler_task = asyncio.create_task(handler_func(*args, **kwargs))
         cancellation_task = asyncio.create_task(listen_for_disconnect(request))
+        tasks = (handler_task, cancellation_task)
 
-        done, pending = await asyncio.wait(
-            [handler_task, cancellation_task], return_when=asyncio.FIRST_COMPLETED
-        )
-        for task in pending:
-            task.cancel()
-
-        if handler_task in done:
-            return handler_task.result()
-        return None
+        try:
+            done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            if handler_task in done:
+                return handler_task.result()
+            return None
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     return wrapper
 


### PR DESCRIPTION
Cancelling a request's `with_cancellation` wrapper while it waits for the handler/disconnect race leaves both child tasks running. The wrapper has already exited, so the handler can keep consuming resources and the disconnect listener can remain pending.

Move child-task cancellation and awaiting into `finally`, so both children finish cleanup before the wrapper exits, including when the parent is externally cancelled. The existing handler result and disconnect return behavior are preserved. A deterministic regression waits until both children have started, cancels the wrapper, and checks that both children have finished.

### Duplicate check

Searched all PR states for the branch and searched open PRs for `with_cancellation`, cancellation/tasks, and wrapper cancellation. Related open PRs address different triggers:

- #49526 fixes duplicate server-load decrements and awaits the handler on client disconnect; it does not clean up both children when the parent is cancelled during `asyncio.wait`.
- #42797 changes the disconnect response from HTTP 200/null to cancellation.
- #55602 removes nested rerank cancellation decorators.

This change fixes the wrapper's child-task lifetime and does not change those behaviors.

### Validation

Against upstream `main` at `6b5a12c0f8`, the new regression fails because child tasks remain pending after the cancelled wrapper exits. With this fix:

- `.venv/bin/python -m pytest tests/entrypoints/serve/utils/test_api_utils.py -q` — 16 passed.
- Changed-file pre-commit hooks — passed, including Ruff and mypy.
- `git diff --check origin/main...HEAD` — passed.

The tests use the actual decorator and asyncio tasks without loading a model. No model evaluation was run: the change affects task cleanup after request cancellation, not prompt construction, inference, or generated output. Existing Torch deprecation warnings remain.

AI assistance (OpenAI Codex) was used to investigate, implement, and validate this change.
