### PR TITLE
[Docs] Add NemotronParse to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -600,6 +600,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `MossTranscribeDiarizeForConditionalGeneration` | MOSS-Transcribe-Diarize | T + A | `OpenMOSS-Team/MOSS-Transcribe-Diarize` | | ✅︎ |
 | `Moondream3ForCausalLM` | Moondream3 | T + I | `moondream/moondream3-preview` | | ✅︎ |
 | `MuseGlimmerForCausalLM`, `MuseGlimmerForConditionalGeneration` | Muse Glimmer | T + I<sup>+</sup> + V<sup>+</sup> | `meta-models/Muse-Glimmer-30B` | ✅︎ | ✅︎ |
+| `NemotronParseForConditionalGeneration` | Nemotron-Parse | T + I<sup>+</sup> | `nvidia/NVIDIA-Nemotron-Parse-v1.2` | | |
 | `NVLM_D_Model` | NVLM-D 1.0 | T + I<sup>+</sup> | `nvidia/NVLM-D-72B`, etc. | | ✅︎ |
 | `OpenCUAForConditionalGeneration` | OpenCUA-7B | T + I<sup>E+</sup> | `xlangai/OpenCUA-7B` | ✅︎ | ✅︎ |
 | `OpenPanguVLForConditionalGeneration` | openpangu-VL | T + I<sup>E+</sup> + V<sup>E+</sup> | `FreedomIntelligence/openPangu-VL-7B` | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary
- Add `NemotronParseForConditionalGeneration` to the multimodal supported-models table.
- Architecture is already registered in `vllm/model_executor/models/registry.py` and covered by tests against `nvidia/NVIDIA-Nemotron-Parse-v1.2`.

## Repro
```bash
# On upstream tip (e.g. 6b5a12c0)
rg 'NemotronParseForConditionalGeneration' vllm/model_executor/models/registry.py
# registered under multimodal models

rg 'NemotronParseForConditionalGeneration' docs/models/supported_models.md
# empty before this change

rg 'NVIDIA-Nemotron-Parse' tests/models/registry.py tests/models/multimodal/generation/test_nemotron_parse.py
# example HF model: nvidia/NVIDIA-Nemotron-Parse-v1.2

# Class bases (image multimodal only; no SupportsLoRA/SupportsPP):
rg -n 'class NemotronParseForConditionalGeneration' -A2 vllm/model_executor/models/nemotron_parse.py
```

## Test plan
- [ ] Confirm the new row appears in Multimodal → Generative → Text Generation, alphabetically near other `N*` rows
- [ ] Confirm architecture string matches the registry key exactly
- [ ] Confirm Inputs `T + I<sup>+</sup>` and empty LoRA/PP match `SupportsMultiModal`-only implementation