### PR TITLE
[Docs] Add Inkling to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -425,6 +425,7 @@ th {
 | `HYV3ForCausalLM` | HY3 | `tencent/Hy3-preview-Base`, `tencent/Hy3-preview`, `tencent/Hy3`, `tencent/Hy3-FP8` | ✅︎ | ✅︎ |
 | `HYV4ForCausalLM` | HY4 | `tencent/Hy4-preview`, `tencent/Hy4-preview-FP8` | ✅︎ | ✅︎ |
 | `HyperCLOVAXForCausalLM` | HyperCLOVAX-SEED-Think-14B | `naver-hyperclovax/HyperCLOVAX-SEED-Think-14B` | ✅︎ | ✅︎ |
+| `InklingForCausalLM` | Inkling | `thinkingmachines/Inkling`, `thinkingmachines/Inkling-NVFP4`, etc. | ✅︎ | ✅︎ |
 | `InternLM2ForCausalLM` | InternLM2 | `internlm/internlm2-7b`, `internlm/internlm2-chat-7b`, etc. | ✅︎ | ✅︎ |
 | `InternLM3ForCausalLM` | InternLM3 | `internlm/internlm3-8b-instruct`, etc. | ✅︎ | ✅︎ |
 | `IQuestCoderForCausalLM` | IQuestCoderV1 | `IQuestLab/IQuest-Coder-V1-40B-Instruct`, etc. | | |
@@ -564,6 +565,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `HCXVisionV2ForCausalLM` | HyperCLOVAX-SEED-Think-32B | T + I<sup>+</sup> + V<sup>+</sup> | `naver-hyperclovax/HyperCLOVAX-SEED-Think-32B` | | |
 | `H2OVLChatModel` | H2OVL | T + I<sup>E+</sup> | `h2oai/h2ovl-mississippi-800m`, `h2oai/h2ovl-mississippi-2b`, etc. | ✅︎ | ✅︎ |
 | `Idefics3ForConditionalGeneration` | Idefics3 | T + I | `HuggingFaceM4/Idefics3-8B-Llama3`, etc. | ✅︎ | |
+| `InklingForConditionalGeneration` | Inkling | T + I + A | `thinkingmachines/Inkling`, `thinkingmachines/Inkling-NVFP4`, etc. | ✅︎ | ✅︎ |
 | `IsaacForConditionalGeneration` | Isaac | T + I<sup>+</sup> | `PerceptronAI/Isaac-0.1` | ✅︎ | ✅︎ |
 | `InternS1ForConditionalGeneration` | Intern-S1 | T + I<sup>E+</sup> + V<sup>E+</sup> | `internlm/Intern-S1`, `internlm/Intern-S1-mini`, etc. | ✅︎ | ✅︎ |
 | `InternS1ProForConditionalGeneration` | Intern-S1-Pro | T + I<sup>E+</sup> + V<sup>E+</sup> | `internlm/Intern-S1-Pro`, etc. | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Purpose

`InklingForCausalLM` and `InklingForConditionalGeneration` are already registered in `vllm/model_executor/models/registry.py` (package `vllm.models.inkling`) with public HF weights, but `docs/models/supported_models.md` had no Inkling rows.

This adds:

- Text-only: `InklingForCausalLM` (LoRA ✅︎, PP ✅︎)
- Multimodal: `InklingForConditionalGeneration` with inputs `T + I + A` (image + audio; LoRA ✅︎, PP ✅︎)

Example HF models: `thinkingmachines/Inkling`, `thinkingmachines/Inkling-NVFP4`.

## Local repro (no full clone)

```bash
HEAD=$(gh api repos/vllm-project/vllm/commits/main --jq .sha)

curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/${HEAD}/vllm/model_executor/models/registry.py" | rg -n 'InklingFor(CausalLM|ConditionalGeneration)'
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/${HEAD}/vllm/models/inkling/nvidia/model.py" | rg -n 'class InklingFor|SupportsLoRA|SupportsPP|SupportsMultiModal|Only image or audio'
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/${HEAD}/tests/models/registry.py" | rg -n -A3 'InklingForCausalLM'
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/${HEAD}/docs/models/supported_models.md" | rg -n 'Inkling' || echo 'MISSING on main (expected before this PR)'
```

## Test plan

- [ ] Confirm both new rows appear in the text-only and multimodal tables
- [ ] Confirm alphabetical placement (after HyperCLOVAX / Idefics3)
- [ ] Confirm LoRA/PP markers match SupportsLoRA / SupportsPP
- [ ] Confirm multimodal Inputs are T + I + A only
