### PR TITLE
[Docs] Add NemotronH_Nano_VL_V2 to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -600,6 +600,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `MossTranscribeDiarizeForConditionalGeneration` | MOSS-Transcribe-Diarize | T + A | `OpenMOSS-Team/MOSS-Transcribe-Diarize` | | ✅︎ |
 | `Moondream3ForCausalLM` | Moondream3 | T + I | `moondream/moondream3-preview` | | ✅︎ |
 | `MuseGlimmerForCausalLM`, `MuseGlimmerForConditionalGeneration` | Muse Glimmer | T + I<sup>+</sup> + V<sup>+</sup> | `meta-models/Muse-Glimmer-30B` | ✅︎ | ✅︎ |
+| `NemotronH_Nano_VL_V2`, `NemotronH_Nano_Omni_Reasoning_V3`, `NemotronH_Super_Omni_Reasoning_V3`, `NemotronH_Omni_Reasoning_V3` | Nemotron Nano VL V2 / Nano Omni | T + I<sup>E+</sup> + V<sup>E+</sup> + (A<sup>+</sup>) | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16`, `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | | |
 | `NVLM_D_Model` | NVLM-D 1.0 | T + I<sup>+</sup> | `nvidia/NVLM-D-72B`, etc. | | ✅︎ |
 | `OpenCUAForConditionalGeneration` | OpenCUA-7B | T + I<sup>E+</sup> | `xlangai/OpenCUA-7B` | ✅︎ | ✅︎ |
 | `OpenPanguVLForConditionalGeneration` | openpangu-VL | T + I<sup>E+</sup> + V<sup>E+</sup> | `FreedomIntelligence/openPangu-VL-7B` | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary
- Add `NemotronH_Nano_VL_V2` (and Omni aliases that map to the same implementation) to the multimodal supported-models table.
- Architecture is already registered in `vllm/model_executor/models/registry.py` and covered by tests against `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` / Omni Reasoning checkpoints.

## Repro
```bash
# On upstream tip (e.g. 6b5a12c0)
rg 'NemotronH_Nano_VL_V2' vllm/model_executor/models/registry.py
# registered; Omni aliases also map to nano_nemotron_vl.NemotronH_Nano_VL_V2

rg 'NemotronH_Nano_VL_V2' docs/models/supported_models.md
# empty before this change

rg 'NVIDIA-Nemotron-Nano-12B-v2-VL' tests/models/registry.py
# example HF model: nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16

# Class bases (multimodal + hybrid; no SupportsLoRA/SupportsPP on the VL wrapper):
rg -n 'class NemotronH_Nano_VL_V2' -A3 vllm/model_executor/models/nano_nemotron_vl.py
# Audio gated on sound_config (Omni variants); image/video embeds supported
```

## Test plan
- [ ] Confirm the new row appears in Multimodal → Generative → Text Generation, alphabetically near other `N*` rows (before `NVLM_D_Model`)
- [ ] Confirm architecture strings match registry keys exactly
- [ ] Confirm Inputs `T + I<sup>E+</sup> + V<sup>E+</sup> + (A<sup>+</sup>)` and empty LoRA/PP match the implementation
