### PR TITLE
[Docs] Add LagunaForCausalLM to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -433,6 +433,7 @@ th {
 | `JambaForCausalLM` | Jamba | `ai21labs/AI21-Jamba-1.5-Large`, `ai21labs/AI21-Jamba-1.5-Mini`, `ai21labs/Jamba-v0.1`, etc. | ✅︎ | ✅︎ |
 | `K2HorizonForCausalLM` | K2-Horizon | `IFM/K2-Horizon-7B`, `IFM/K2-Horizon-375B` | | ✅︎ |
 | `KimiLinearForCausalLM` | Kimi-Linear-48B-A3B-Base, Kimi-Linear-48B-A3B-Instruct | `moonshotai/Kimi-Linear-48B-A3B-Base`, `moonshotai/Kimi-Linear-48B-A3B-Instruct` | | ✅︎ |
+| `LagunaForCausalLM` | Laguna | `poolside/Laguna-XS.2`, `poolside/Laguna-S-2.1`, `poolside/Laguna-XS-2.1`, etc. | ✅︎ | ✅︎ |
 | `Lfm2ForCausalLM` | LFM2 | `LiquidAI/LFM2-1.2B`, `LiquidAI/LFM2-700M`, `LiquidAI/LFM2-350M`, etc. | ✅︎ | ✅︎ |
 | `Lfm2MoeForCausalLM` | LFM2MoE | `LiquidAI/LFM2-8B-A1B-preview`, etc. | ✅︎ | ✅︎ |
 | `LlamaForCausalLM` | Llama 3.1, Llama 3, Llama 2, LLaMA, Yi | `meta-llama/Meta-Llama-3.1-405B-Instruct`, `meta-llama/Meta-Llama-3.1-70B`, `meta-llama/Meta-Llama-3-70B-Instruct`, `meta-llama/Llama-2-70b-hf`, `01-ai/Yi-34B`, etc. | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Purpose

`LagunaForCausalLM` is registered in the model registry and has public Hugging Face weights, but `docs/models/supported_models.md` had no Laguna row.

## Changes

- Add `LagunaForCausalLM` to the text-generation supported-models table (LoRA ✅︎, PP ✅︎), placed alphabetically between `KimiLinearForCausalLM` and `Lfm2ForCausalLM`.

## Test Plan

- [x] Registry maps `LagunaForCausalLM` → `laguna` / `LagunaForCausalLM`
- [x] Implementation declares `SupportsLoRA` and `SupportsPP`
- [x] HF example `poolside/Laguna-XS.2` (also `poolside/Laguna-S-2.1`, `poolside/Laguna-XS-2.1`, etc.)
- [x] Confirm the new row sits between KimiLinear and Lfm2