### PR TITLE
[Bugfix][CI] skip conftest for NPU compatibility test

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-npu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-npu-test.sh
@@ -76,21 +76,12 @@ FROM ${BASE_IMAGE_NAME}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SOC_VERSION="ascend910b1"
 
-# Install uv and configure uv to use internal PyPI mirror
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
-ENV UV_SYSTEM_PYTHON=true
-ENV UV_INDEX_URL="http://cache-service-vllm.nginx-pypi-cache.svc.cluster.local:${PYPI_CACHE_PORT}/pypi/simple"
-ENV UV_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
-
-RUN apt-get update -y && \
-    apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake libnuma-dev && \
-    rm -rf /var/cache/apt/* && \
-    rm -rf /var/lib/apt/lists/*
+RUN pip config set global.index-url http://cache-service-vllm.nginx-pypi-cache.svc.cluster.local:${PYPI_CACHE_PORT}/pypi/simple && \
+    pip config set global.trusted-host cache-service-vllm.nginx-pypi-cache.svc.cluster.local
 
 # Install for pytest to make the docker build cache layer always valid
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install pytest>=6.0  'modelscope<1.38' --quiet
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install pytest>=6.0
 
 WORKDIR /workspace/vllm
 
@@ -167,5 +158,5 @@ docker run \
     "${image_name}" \
     bash -c '
     set -e
-    pytest -v -s tests/e2e/vllm_interface/test_vllm_pr_interface_compatibility.py
+    pytest --noconftest -v -s tests/e2e/vllm_interface/test_vllm_pr_interface_compatibility.py
 '


### PR DESCRIPTION
## Purpose
The current NPU CI test fails with ModuleNotFoundError: No module named 'huggingface_hub'. The vllm-interface test cases do not require this component. By adding `--noconftest` to skip loading `conftest.py`, the issue is resolved.

## Test Plan

- [x] local test
- [ ] CI test

## Test Result
Local testing has been completed successfully.
<img width="1562" height="536" alt="image" src="https://github.com/user-attachments/assets/714ce12f-dbe2-4702-a741-c7f92bc2c44f" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
