### PR TITLE
[Bugfix][KV Connector] Apply KV recompute threshold to NIXL remote-prefill pulls

### DIFF
--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -234,7 +234,7 @@ Additional configuration options in `kv_connector_extra_config`:
 | Parameter | Default | Description |
 | --------- | ------- | ----------- |
 | `bidirectional_kv_xfer` | `false` | Enable bidirectional D→P KV transfer. |
-| `kv_recompute_threshold` | `64` | Minimum number of remote tokens required to trigger a D→P pull. Below this threshold, P recomputes locally instead of pulling (to amortize transfer latency). |
+| `kv_recompute_threshold` | `64` for bidirectional KV transfer, `0` otherwise | Minimum number of remote tokens required to trigger a NIXL KV pull. Below this threshold, the request recomputes locally instead of pulling (to amortize transfer latency). Applies to both standard P→D remote-prefill requests and bidirectional D→P requests when configured. Set to `0` to disable this policy. |
 | `decoder_kv_blocks_ttl` | `480` | TTL (seconds) for KV blocks cached on D for bidirectional reuse. Blocks are released after this duration. Not renewed via heartbeats. |
 
 ### Multi-turn proxy setup

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -65,6 +65,80 @@ def test_sw_sizes(mock_platform, swa_enabled, expected_sw_sizes):
 
 @pytest.mark.cpu_test
 @pytest.mark.parametrize(
+    "extra_config,expected_threshold",
+    [
+        ({}, 0),
+        ({"bidirectional_kv_xfer": True}, 64),
+        ({"kv_recompute_threshold": 128}, 128),
+    ],
+)
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler.current_platform"
+)
+def test_kv_recompute_threshold_default(
+    mock_platform, extra_config, expected_threshold
+):
+    """Keep the existing defaults while allowing P→D opt-in."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler import (
+        NixlConnectorScheduler,
+    )
+
+    mock_platform.device_type = "cpu"
+    vllm_config = create_vllm_config(
+        block_size=16,
+        kv_connector_extra_config=extra_config,
+    )
+    scheduler = NixlConnectorScheduler(
+        vllm_config=vllm_config,
+        engine_id="test-engine",
+        kv_cache_config=make_kv_cache_config(block_size=16),
+    )
+
+    assert scheduler.kv_recompute_threshold == expected_threshold
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "threshold,num_computed_tokens,expected",
+    [
+        pytest.param(8, 0, (0, False), id="below-threshold-recomputes"),
+        pytest.param(10, 0, (10, True), id="at-threshold-pulls"),
+        pytest.param(0, 0, (10, True), id="zero-disables-policy"),
+    ],
+)
+def test_remote_prefill_recompute_threshold(
+    threshold, num_computed_tokens, expected
+):
+    """Apply the threshold to the standard D-side P→D pull path."""
+    scheduler = make_nixl_scheduler()
+    scheduler.kv_recompute_threshold = threshold
+    request = create_request(num_tokens=10, do_remote_prefill=True)
+
+    assert (
+        scheduler.get_num_new_matched_tokens(request, num_computed_tokens) == expected
+    )
+
+
+@pytest.mark.cpu_test
+def test_remote_decode_recompute_threshold():
+    """Keep applying the threshold to the existing bidirectional D→P path."""
+    scheduler = make_nixl_scheduler()
+    scheduler.kv_recompute_threshold = 8
+    request = create_request(num_tokens=10, do_remote_decode=True)
+    request.kv_transfer_params.update(
+        remote_block_ids=[0],
+        remote_engine_id="decode-engine",
+        remote_request_id="decode-request",
+        remote_host="decode-host",
+        remote_port=5678,
+        remote_num_tokens=6,
+    )
+
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
     "use_mla,source_ranks,tp_ratio,expected",
     [
         pytest.param(True, (0,), -2, False, id="pure_mla_with_remote_dcp"),

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -526,6 +526,7 @@ def make_nixl_scheduler(
     sched = object.__new__(NixlConnectorScheduler)
     sched._has_mamba = has_mamba
     sched._is_hma_required = is_hma_required
+    sched.kv_recompute_threshold = 0
     sched.kv_cache_config = make_kv_cache_config(
         block_size=16,
         mamba_enabled=has_mamba,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -156,15 +156,6 @@ class NixlBaseConnectorScheduler:
             vllm_config.cache_config.mamba_cache_mode == "all"
         )
 
-        # Threshold to decide whether to compute kv cache locally
-        # or pull from a remote node: minimum number of remote
-        # tokens to amortize the xfer latencies
-        self.kv_recompute_threshold: int = int(
-            vllm_config.kv_transfer_config.get_from_extra_config(
-                "kv_recompute_threshold", 64
-            )
-        )
-
         # Bi-directional KV transfer feature supports KV block
         # transfers from D node to P node
         self.is_bidirectional_kv_xfer_enabled = (
@@ -172,6 +163,22 @@ class NixlBaseConnectorScheduler:
                 "bidirectional_kv_xfer", False
             )
         )
+
+        # Threshold to decide whether to compute KV cache locally
+        # or pull from a remote node: minimum number of remote
+        # tokens to amortize the xfer latencies. Keep the existing
+        # 64-token default for bidirectional D->P pulls. For standard
+        # P->D remote-prefill pulls, opt in explicitly so enabling this
+        # policy does not change the default scheduling behavior.
+        default_recompute_threshold = (
+            64 if self.is_bidirectional_kv_xfer_enabled else 0
+        )
+        self.kv_recompute_threshold: int = int(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "kv_recompute_threshold", default_recompute_threshold
+            )
+        )
+
         self.decoder_kv_blocks_ttl = (
             vllm_config.kv_transfer_config.get_from_extra_config(
                 "decoder_kv_blocks_ttl", 480

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -31,6 +31,29 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
     ):
         super().__init__(vllm_config, engine_id, kv_cache_config)
 
+    def _should_recompute_remote_kv(
+        self, request: "Request", count: int
+    ) -> bool:
+        """Return whether a remote KV pull should be recomputed locally.
+
+        The recompute threshold applies to both remote-prefill requests
+        (P→D) and remote-decode requests (D→P). In either case, pulling a
+        small number of tokens can cost more than computing them locally due
+        to the fixed transfer setup overhead.
+        """
+        if (
+            self.kv_recompute_threshold > 0
+            and 0 < count < self.kv_recompute_threshold
+        ):
+            logger.debug(
+                "Skipping remote pull for %s: %d remote tokens < threshold %d",
+                request.request_id,
+                count,
+                self.kv_recompute_threshold,
+            )
+            return True
+        return False
+
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
     ) -> tuple[int, bool]:
@@ -63,6 +86,8 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             actual = self._get_remote_prefill_token_count(len(token_ids))
             count = actual - num_computed_tokens
             if count > 0:
+                if self._should_recompute_remote_kv(request, count):
+                    return 0, False
                 return count, True
 
         if (
@@ -88,18 +113,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                 min(remote_num_tokens, request.num_prompt_tokens) - num_computed_tokens
             )
             if count > 0:
-                # Check kv_recompute_threshold: skip pull if
-                # remote tokens are below the threshold.
-                if (
-                    self.kv_recompute_threshold > 0
-                    and count < self.kv_recompute_threshold
-                ):
-                    logger.debug(
-                        "Skipping remote pull for %s: %d remote tokens < threshold %d",
-                        request.request_id,
-                        count,
-                        self.kv_recompute_threshold,
-                    )
+                if self._should_recompute_remote_kv(request, count):
                     return 0, False
                 return count, True
 


### PR DESCRIPTION
# NIXL: apply KV recompute threshold to remote-prefill pulls

## Summary

The NIXL pull scheduler applies `kv_recompute_threshold` only to the
`do_remote_decode` path. Standard 1P1D requests use `do_remote_prefill`,
which returns remote KV tokens without checking the threshold.

Small KV transfers therefore pay the fixed NIXL transfer overhead even when
local recomputation is cheaper.

## Changes

- Share `_should_recompute_remote_kv()` between remote-prefill and
  remote-decode paths.
- Skip the NIXL pull when:
  `0 < remote_tokens < kv_recompute_threshold`.
- Preserve existing behavior when the threshold is `0`.
- Add unit tests for defaults, threshold boundaries, remote-prefill, and
  remote-decode behavior.
- Update NIXL connector documentation.

## Tests

- `git diff --check` passed.
- `git apply --check` passed.
- Reference 1P1D NIXL small-KV run with threshold `128`:
  - 64/64 requests used local recomputation.
  - No NIXL transfer metrics were emitted.
- Full unit tests and Ruff checks still need to be run in the upstream
  development environment.
  
## Performance
Concurrency | Output throughput | TTFT p95
:---------- | :---------------- | :--------
16          | 273.10 → 298.45 tok/s (+9.3%) | 1483.1 → 1207.4 ms (-18.6%)
32          | 273.62 → 300.44 tok/s (+9.8%) | 3194.2 → 2854.4 ms (-10.6%)

**Note**: The performance data is for the small-KV workload and is not intended to represent large-KV behavior.