### PR TITLE
[Bugfix][EPLB] Use group-local ranks for torch P2P transfers

### DIFF
--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -782,3 +782,42 @@ def test_rearrange_expert_weights_profile_mode(world_size):
         _test_rearrange_expert_weights_profile_mode,
         world_size,
     )
+
+
+def _test_eplb_communicator_pipeline_parallel(env, world_size, backend):
+    set_env_vars_and_device(env)
+    config = VllmConfig()
+    config.parallel_config.tensor_parallel_size = 2
+    config.parallel_config.pipeline_parallel_size = world_size // 2
+
+    with set_current_vllm_config(config):
+        ensure_model_parallel_initialized(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=world_size // 2,
+        )
+        ep_group = get_tp_group()
+        peer_rank = 1 - ep_group.rank_in_group
+        rank = torch.distributed.get_rank()
+        send_tensor = torch.full((16,), rank, device="cuda", dtype=torch.int32)
+        recv_tensor = torch.empty_like(send_tensor)
+        communicator = create_eplb_communicator_or_raise(
+            group_coordinator=ep_group,
+            backend=backend,
+            expert_weights=[[send_tensor]],
+            expert_buffer=[recv_tensor],
+        )
+        communicator.add_send([send_tensor], peer_rank, expert_id=0)
+        communicator.add_recv([recv_tensor], peer_rank, expert_id=0)
+        communicator.execute()
+
+        expected = torch.full_like(recv_tensor, ep_group.ranks[peer_rank])
+        torch.testing.assert_close(recv_tensor, expected)
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("backend", ["torch_nccl", "torch_gloo"])
+def test_eplb_communicator_pipeline_parallel(world_size, backend):
+    """Transfer weights within each PP stage, including nonzero global ranks."""
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip(f"Need at least {world_size} GPUs to run the test")
+    distributed_run(_test_eplb_communicator_pipeline_parallel, world_size, backend)

--- a/vllm/distributed/eplb/eplb_communicator.py
+++ b/vllm/distributed/eplb/eplb_communicator.py
@@ -120,8 +120,8 @@ class TorchDistNcclEplbCommunicator(EplbCommunicator):
                 P2POp(
                     torch.distributed.isend,
                     tensor,
-                    dst_rank,
-                    self._ep_group,
+                    group=self._ep_group,
+                    group_peer=dst_rank,
                 )
             )
 
@@ -136,8 +136,8 @@ class TorchDistNcclEplbCommunicator(EplbCommunicator):
                 P2POp(
                     torch.distributed.irecv,
                     tensor,
-                    src_rank,
-                    self._ep_group,
+                    group=self._ep_group,
+                    group_peer=src_rank,
                 )
             )
 
@@ -199,8 +199,8 @@ class TorchDistGlooStagedEplbCommunicator(EplbCommunicator):
                         P2POp(
                             torch.distributed.isend,
                             cpu_tensor,
-                            peer_rank,
-                            self._cpu_group,
+                            group=self._cpu_group,
+                            group_peer=peer_rank,
                         )
                     )
                     continue
@@ -209,8 +209,8 @@ class TorchDistGlooStagedEplbCommunicator(EplbCommunicator):
                     P2POp(
                         torch.distributed.irecv,
                         cpu_tensor,
-                        peer_rank,
-                        self._cpu_group,
+                        group=self._cpu_group,
+                        group_peer=peer_rank,
                     )
                 )
                 recv_staging.append((tensor, cpu_tensor))


### PR DESCRIPTION
## Purpose

With pipeline parallelism, EPLB passes EP-group-local peer ranks to its
communicators, but the torch NCCL and Gloo backends pass them as `P2POp.peer`,
which is a global rank. For an EP group containing global ranks `[2, 3]`,
local peer `1` is therefore interpreted as global rank `1`, outside the group,
and expert-weight transfer fails.

Use `group=...` and `group_peer=...` for both send and receive in the two
torch.distributed communicators. Add a transfer regression covering PP=1 and
PP=2 with two ranks per EP group and both backends.

Duplicate-work checks on 2026-09-08 found no matching open PR in searches for
`EPLB`, `EPLB P2POp`, and `group_peer`. The related explicit EP topology PR
#52099 does not modify this communicator file.

AI assistance was used to prepare the implementation, regression, and local
validation. Backend and model validation were performed by the PR author.

## Test Plan

On a configured vLLM environment with four GPUs:

```bash
.venv/bin/python -m pytest tests/distributed/test_eplb_execute.py \
  -k test_eplb_communicator_pipeline_parallel -q
```

The regression exchanges rank-tagged tensors within each two-rank EP group
and checks the received values against the global rank of the expected peer.
The four-rank case covers the nonzero-rank group `[2, 3]`.

## Test Result

The author validated EPLB with pipeline parallelism using both `torch_gloo`
and `torch_nccl`:

- Before the fix, both backends raised the following error:

  ```text
  ValueError: Global rank {global_rank} is not part of group {group}
  ```

- After the fix, tests completed successfully with both backends.
- Model evaluation after the fix: **Qwen3.6-35B-A3B**, using the **Gloo**
  backend, achieved **96.51% GSM8K accuracy**.

Additional local checks:

- Supplemental local CPU validation with PyTorch 2.14.0: both communicator
  classes were loaded from the production source and exercised with real Gloo
  process groups and real `P2POp`/`batch_isend_irecv`. Only CUDA stream contexts
  and synchronization were replaced with CPU no-ops; the NCCL class also used
  Gloo transport, so this is not NCCL device-transport validation.
- Before the fix, both classes fail in group `[2, 3]` with
  `Global rank 0/1 is not part of group`; the two-rank PP=1 controls pass.
  After the fix, all four combinations of communicator and world size (2, 4)
  transfer the expected tensor values successfully.
- Ruff 0.14.0 lint and format checks, Python compilation, and
  `git diff --check`: passed.
- `pre-commit run --files vllm/distributed/eplb/eplb_communicator.py
  tests/distributed/test_eplb_execute.py`: all applicable hooks passed with
  the Python 3.12 virtual environment on `PATH`.
- Native pytest command above: blocked during collection by missing `tblib`
  in the local macOS environment. The backend and GSM8K results above come
  from the author's separate test environment.
