### PR TITLE
[Docs] Add DiffusionGemma, LongcatFlashNgram, and Step3Text to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -437,6 +437,7 @@ th {
 | `Lfm2MoeForCausalLM` | LFM2MoE | `LiquidAI/LFM2-8B-A1B-preview`, etc. | ✅︎ | ✅︎ |
 | `LlamaForCausalLM` | Llama 3.1, Llama 3, Llama 2, LLaMA, Yi | `meta-llama/Meta-Llama-3.1-405B-Instruct`, `meta-llama/Meta-Llama-3.1-70B`, `meta-llama/Meta-Llama-3-70B-Instruct`, `meta-llama/Llama-2-70b-hf`, `01-ai/Yi-34B`, etc. | ✅︎ | ✅︎ |
 | `LongcatFlashForCausalLM` | LongCat-Flash | `meituan-longcat/LongCat-Flash-Chat`, `meituan-longcat/LongCat-Flash-Chat-FP8` | ✅︎ | ✅︎ |
+| `LongcatFlashNgramForCausalLM` | LongCat-Flash-Lite | `meituan-longcat/LongCat-Flash-Lite` | ✅︎ | ✅︎ |
 | `MambaForCausalLM` | Mamba | `state-spaces/mamba-130m-hf`, `state-spaces/mamba-790m-hf`, `state-spaces/mamba-2.8b-hf`, etc. | | ✅︎ |
 | `Mamba2ForCausalLM` | Mamba2 | `mistralai/Mamba-Codestral-7B-v0.1`, etc. | | ✅︎ |
 | `MellumForCausalLM` | Mellum 2 | `JetBrains/Mellum2-12B-A2.5B-Base`, etc. | | ✅︎ |
@@ -476,6 +477,7 @@ th {
 | `SolarForCausalLM` | Solar Pro | `upstage/solar-pro-preview-instruct`, etc. | ✅︎ | ✅︎ |
 | `StableLmForCausalLM` | StableLM | `stabilityai/stablelm-3b-4e1t`, `stabilityai/stablelm-base-alpha-7b-v2`, etc. | | |
 | `Step1ForCausalLM` | Step-Audio | `stepfun-ai/Step-Audio-EditX`, etc. | ✅︎ | ✅︎ |
+| `Step3TextForCausalLM` | Step3 | `stepfun-ai/step3` | | ✅︎ |
 | `Step3p5ForCausalLM` | Step-3.5-flash | `stepfun-ai/Step-3.5-Flash`, etc. | | ✅︎ |
 | `TeleChat2ForCausalLM` | TeleChat2 | `Tele-AI/TeleChat2-3B`, `Tele-AI/TeleChat2-7B`, `Tele-AI/TeleChat2-35B`, etc. | ✅︎ | ✅︎ |
 | `TeleChat3ForCausalLM` | TeleChat3 | `Tele-AI/TeleChat3-36B-Thinking`, `Tele-AI/TeleChat3-Coder-36B-Thinking`, etc. | ✅︎ | ✅︎ |
@@ -554,6 +556,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Gemma3nForConditionalGeneration` | Gemma 3n | T + I + A | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it`, etc. | | |
 | `Gemma4ForConditionalGeneration` | Gemma 4 | T + I<sup>+</sup> + V + A<sup>*</sup> | `google/gemma-4-E2B-it`, etc. | ✅︎ | ✅︎ |
 | `Gemma4UnifiedForConditionalGeneration` | Gemma 4 Unified | T + I<sup>+</sup> + V + A | `google/gemma-4-12B-it`, etc. | | ✅︎ |
+| `DiffusionGemmaForBlockDiffusion` | DiffusionGemma | T + I + V | `google/diffusiongemma-26B-A4B-it` | | |
 | `GLM4VForCausalLM`<sup>^</sup> | GLM-4V | T + I | `zai-org/glm-4v-9b`, `zai-org/cogagent-9b-20241220`, etc. | ✅︎ | ✅︎ |
 | `Glm4vForConditionalGeneration` | GLM-4.1V-Thinking | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.1V-9B-Thinking`, etc. | ✅︎ | ✅︎ |
 | `Glm4vMoeForConditionalGeneration` | GLM-4.5V | T + I<sup>E+</sup> + V<sup>E+</sup> | `zai-org/GLM-4.5V`, etc. | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary
- Add `DiffusionGemmaForBlockDiffusion` to the multimodal supported-models table (`google/diffusiongemma-26B-A4B-it`; image + video).
- Add `LongcatFlashNgramForCausalLM` to the text table (`meituan-longcat/LongCat-Flash-Lite`).
- Add `Step3TextForCausalLM` to the text table (`stepfun-ai/step3` text arch; VL row already documents the multimodal twin).

All three are already registered in `vllm/model_executor/models/registry.py` and have HF examples in `tests/models/registry.py`.

## Repro
```bash
REF=869f78732b64454293d2ba42ae0008386fdaa6a6

# registry has the architectures
gh api repos/vllm-project/vllm/contents/vllm/model_executor/models/registry.py?ref=$REF   -H 'Accept: application/vnd.github.raw' | rg 'DiffusionGemmaForBlockDiffusion|LongcatFlashNgramForCausalLM|Step3TextForCausalLM'

# docs lacked them before this change
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/$REF/docs/models/supported_models.md   | rg 'DiffusionGemma|LongcatFlashNgram|Step3Text' || echo '(empty before)'

# test HF examples
gh api repos/vllm-project/vllm/contents/tests/models/registry.py?ref=$REF   -H 'Accept: application/vnd.github.raw'   | rg -A2 'DiffusionGemmaForBlockDiffusion|LongcatFlashNgramForCausalLM|Step3TextForCausalLM'
```

## Feature columns
- `LongcatFlashNgramForCausalLM`: `SupportsLoRA` + `SupportsPP` → LoRA/PP ✅︎
- `Step3TextForCausalLM`: `SupportsPP` only → PP ✅︎
- `DiffusionGemmaForBlockDiffusion`: multimodal (`SupportsMultiModal`); no `SupportsLoRA`/`SupportsPP` on the class → columns left empty
