### PR TITLE
[Docs] Add Qwen3.5 text CausalLM to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -469,6 +469,8 @@ th {
 | `Qwen3ForCausalLM` | Qwen3 | `Qwen/Qwen3-8B`, etc. | ✅︎ | ✅︎ |
 | `Qwen3MoeForCausalLM` | Qwen3MoE | `Qwen/Qwen3-30B-A3B`, etc. | ✅︎ | ✅︎ |
 | `Qwen3NextForCausalLM` | Qwen3NextMoE | `Qwen/Qwen3-Next-80B-A3B-Instruct`, etc. | ✅︎ | ✅︎ |
+| `Qwen3_5ForCausalLM` | Qwen3.5 | `codecho/Qwen3.5-0.8B-text-only`, etc. | ✅︎ | ✅︎ |
+| `Qwen3_5MoeForCausalLM` | Qwen3.5-MOE | `codecho/Qwen3.5-35B-A3B-text-only`, etc. | ✅︎ | ✅︎ |
 | `Rnj1ForCausalLM` | Rnj1 | `EssentialAI/rnj-1-instruct`, etc. | | |
 | `SarvamMoEForCausalLM` | Sarvam 2 | `sarvamai/sarvam2-30b-a3b`, etc. | ✅︎ | ✅︎ |
 | `SarvamMLAForCausalLM` | Sarvam 2 | `sarvamai/sarvam2-105b-a9b`, etc. | | ✅︎ |


### PR DESCRIPTION
## Summary
- Add `Qwen3_5ForCausalLM` and `Qwen3_5MoeForCausalLM` to the text-generation table in `docs/models/supported_models.md`.
- Both architectures are already registered and implement `SupportsLoRA` + `SupportsPP`; multimodal `Qwen3_5*ForConditionalGeneration` rows already existed.

## Repro (local / no clone)
On `main` @ `607a6e48c5b9780ae8405497f77bee65698c61c7`:

```bash
# Present in registry
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/607a6e48c5b9780ae8405497f77bee65698c61c7/vllm/model_executor/models/registry.py \
  | rg 'Qwen3_5ForCausalLM|Qwen3_5MoeForCausalLM'

# SupportsLoRA + SupportsPP
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/607a6e48c5b9780ae8405497f77bee65698c61c7/vllm/model_executor/models/qwen3_5.py \
  | rg -n 'class Qwen3_5ForCausalLM|class Qwen3_5MoeForCausalLM|SupportsLoRA|SupportsPP'

# Missing from text table (only ConditionalGeneration multimodal rows present)
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/607a6e48c5b9780ae8405497f77bee65698c61c7/docs/models/supported_models.md \
  | rg 'Qwen3_5'

# Public HF text-only checkpoints used by tests
curl -sL https://huggingface.co/codecho/Qwen3.5-0.8B-text-only/raw/main/config.json | jq .architectures
# -> ["Qwen3_5ForCausalLM"]
curl -sL https://huggingface.co/codecho/Qwen3.5-35B-A3B-text-only/raw/main/config.json | jq .architectures
# -> ["Qwen3_5MoeForCausalLM"]
```

## Test plan
- [x] Registry maps both arches to `qwen3_5` module classes
- [x] Classes declare `SupportsLoRA` and `SupportsPP` (✅︎ / ✅︎)
- [x] HF `config.json` architectures match row names
- [x] Docs-only change; table ordering after `Qwen3NextForCausalLM`