### PR TITLE
[ROCm][Perf] Remove AITER paged-MQA outputs guard for DeepSeek-V4

### DIFF
--- a/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
+++ b/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
@@ -285,68 +285,6 @@ def _launch_sparse_decode_reduce(
 
 
 @torch.inference_mode()
-def test_paged_mqa_logits_do_not_contain_nan(monkeypatch) -> None:
-    from vllm._aiter_ops import rocm_aiter_ops
-    from vllm.v1.attention.ops import rocm_aiter_mla_sparse as mod
-
-    device = torch.device("cuda")
-
-    class FakeWorkspaceManager:
-        def get_simultaneous(self, *shapes_and_dtypes):
-            return [
-                torch.empty(shape, dtype=dtype, device=device)
-                for shape, dtype in shapes_and_dtypes
-            ]
-
-    def fake_paged_mqa_logits(
-        q_fp8,
-        kv_cache_fp8,
-        weights,
-        out_logits,
-        context_lens,
-        block_tables,
-        max_seq_len,
-        **kwargs,
-    ):
-        del (
-            q_fp8,
-            kv_cache_fp8,
-            weights,
-            context_lens,
-            block_tables,
-            max_seq_len,
-            kwargs,
-        )
-        out_logits.fill_(float("nan"))
-
-    monkeypatch.setattr(mod, "_ON_GFX942", False)
-    monkeypatch.setattr(mod, "_ON_GFX950", True)
-    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: True)
-    monkeypatch.setattr(
-        mod,
-        "paged_mqa_logits_module",
-        lambda: SimpleNamespace(deepgemm_fp8_paged_mqa_logits=fake_paged_mqa_logits),
-    )
-    monkeypatch.setattr(
-        mod, "current_workspace_manager", lambda: FakeWorkspaceManager()
-    )
-
-    q_fp8 = torch.empty((1, 1, 1, 1), dtype=torch.uint8, device=device)
-    kv_cache_fp8 = torch.empty((1, 1, 1, 5), dtype=torch.uint8, device=device)
-    logits = mod.rocm_fp8_paged_mqa_logits(
-        q_fp8,
-        kv_cache_fp8,
-        torch.empty((1, 1), dtype=torch.float32, device=device),
-        torch.ones(1, dtype=torch.int32, device=device),
-        torch.zeros((1, 1), dtype=torch.int32, device=device),
-        torch.empty(0, dtype=torch.int32, device=device),
-        1,
-    )
-
-    assert not torch.isnan(logits).any()
-
-
-@torch.inference_mode()
 def test_compute_global_topk_ragged_indices_and_indptr() -> None:
     from vllm.models.deepseek_v4.amd.rocm import (
         compute_global_topk_ragged_indices_and_indptr,

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -657,7 +657,6 @@ def rocm_fp8_paged_mqa_logits(
                 KVBlockSize=block_size,
                 WavePerEU=2,
             )
-            out_logits.nan_to_num_(float("-inf"))
             return out_logits
         deepgemm_fp8_paged_mqa_logits_stage1 = (
             aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits_stage1


### PR DESCRIPTION
## Purpose

To fix https://github.com/Fangzhou-Ai/vllm/issues/13, https://github.com/vllm-project/vllm/pull/49714 added an additional element-wise kernel after `deepgemm_fp8_paged_mqa_logits`, which could introduce costs.

<img width="1909" height="310" alt="Snipaste_2026-09-08_14-14-51" src="https://github.com/user-attachments/assets/9df30a96-96a5-4536-bb99-4476c4105647" />

This issue has been fixed in AITER side in https://github.com/ROCm/aiter/pull/4774 (already contains in `v0.1.21.post1`), so we can move this check now.

## Test Plan

### Functional Test

As mentioned in https://github.com/Fangzhou-Ai/vllm/issues/13, launch the server:

```bash
vllm serve \
--model /shared/models/deepseek-ai/DeepSeek-V4-Pro \
--port 8333 \
--tensor-parallel-size 8 \
--data-parallel-size 1 \
--async-scheduling \
--no-enable-prefix-caching \
--distributed-executor-backend mp \
--gpu-memory-utilization 0.8 \
--kv-cache-dtype fp8 \
--trust-remote-code \
--tokenizer-mode deepseek_v4 \
--reasoning-parser deepseek_v4 \
--moe-backend aiter \
--compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
--max-model-len 9472
```

Then send requests with 64 conc (the script could be found in https://github.com/Fangzhou-Ai/vllm/issues/13):

```bash
docker run --rm \
--network=host \
--volume "$PWD:/repro" \
--volume /mnt/dcgpuval:/shared \
--entrypoint python \
vllm/vllm-openai-rocm:nightly \
/repro/repro_high_conc_gsm8k.py \
--prompts /repro/gsm8k_20shot_prompts_64.jsonl \
--base-url http://127.0.0.1:8333 \
--model /shared/models/deepseek-ai/DeepSeek-V4-Pro \
--num-prompts 64 \
--concurrency 64 \
--max-tokens 16 \
--waves 3 \
--timeout 300 \
--output /repro/report.json
```

### Benchmark

Benchmark with SA InferenceX `8k1k` workload (conc=1/4/16/64).

## Test Result

### Functional Test

All requests are correctly processed.

```bash
# Client
{"wave": 1, "requested": 64, "completed": 64, "failed": 0, "health_status": 200, "elapsed_s": 14.222921347012743}
{"wave": 2, "requested": 64, "completed": 64, "failed": 0, "health_status": 200, "elapsed_s": 14.297744342009537}
{"wave": 3, "requested": 64, "completed": 64, "failed": 0, "health_status": 200, "elapsed_s": 14.362902717024554}
```

### Benchmark

Concurrency | Version | Output token throughput (tok/s) | Change | Mean TTFT (ms) | Change | Mean TPOT (ms) | Change
-- | -- | -- | -- | -- | -- | -- | --
1 | Main | 62.04 | — | 405.86 | — | 15.70 | —
  | This PR | 62.03 | 0.02% ↓ | 471.35 | 16.14% ↑ | 15.63 | 0.45% ↓
4 | Main | 202.34 | — | 498.23 | — | 18.77 | —
  | This PR | 202.94 | 0.30% ↑ | 507.68 | 1.90% ↑ | 18.70 | 0.37% ↓
16 | Main | 560.66 | — | 806.20 | — | 26.78 | —
  | This PR | 567.07 | 1.14% ↑ | 793.03 | 1.63% ↓ | 26.47 | 1.16% ↓
64 | Main | 1093.95 | — | 1757.46 | — | 55.60 | —
  | This PR | 1116.49 | 2.06% ↑ | 1760.17 | 0.15% ↑ | 54.43 | 2.10% ↓

The output token throughput improves by 0.30% at concurrency 4, 1.14% at concurrency 16, and 2.06% at concurrency 64, while remaining essentially unchanged at concurrency 1 (-0.02%). This indicates that the PR scales slightly better as concurrency increases.

Mean TPOT also improves across all concurrency levels, decreasing by 0.45%, 0.37%, 1.16%, and 2.10% at concurrency 1, 4, 16, and 64, respectively. The larger reduction at higher concurrency suggests that the PR provides better token generation efficiency under heavier workloads.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

