### PR TITLE
[Bench] Save server queue time and TTFT in detailed results

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -159,6 +159,30 @@ In this example, the benchmark observes two 40 ms ITL samples. The three tokens
 in the second streamed output do not create additional ITL samples, so mean ITL
 is 40 ms. TPOT is `(180 ms - 100 ms) / (5 - 1) = 20 ms/token`.
 
+#### Saving Server-Side Per-Request Metrics
+
+When the server is started with
+[`--enable-per-request-metrics`](../features/per_request_metrics.md#enabling),
+`vllm bench serve` can preserve the server-side queue time and TTFT for each
+request:
+
+```bash
+vllm bench serve \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --save-result \
+  --save-detailed
+```
+
+The detailed result includes `server_queue_times` and `server_ttfts`, in
+seconds, when at least one request has an available server queue time or
+TTFT. Their indices align with the other per-request arrays, with unavailable
+values represented as `null`. Both arrays are omitted when neither metric is
+available for any request.
+
+`server_queue_times` measures server scheduler waiting time, while
+`server_ttfts` measures time from scheduling to first token generation.
+These differ from the client-side `queue_times` and `ttfts`.
+
 #### Results Visualization
 
 The `--plot-timeline` and `--plot-dataset-stats` can be used to generate respectively the requests completion timeline and dataset prompt and output tokens statistics, which can be useful for debugging purpose or for deeper analysis.

--- a/rust/src/bench/src/backends/mod.rs
+++ b/rust/src/bench/src/backends/mod.rs
@@ -21,6 +21,7 @@ pub struct CompletionChunk {
     #[serde(default)]
     pub choices: Vec<CompletionChoice>,
     pub usage: Option<ChunkUsage>,
+    pub metrics: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -34,6 +35,7 @@ pub struct ChatChunk {
     #[serde(default)]
     pub choices: Vec<ChatChoice>,
     pub usage: Option<ChunkUsage>,
+    pub metrics: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -101,6 +103,8 @@ pub struct RequestFuncOutput {
     pub prompt_len: usize,
     pub error: String,
     pub start_time: f64,
+    pub server_queue_time: Option<f64>,
+    pub server_ttft: Option<f64>,
     pub num_input_sequences: usize,
 }
 
@@ -117,9 +121,27 @@ impl Default for RequestFuncOutput {
             prompt_len: 0,
             error: String::new(),
             start_time: 0.0,
+            server_queue_time: None,
+            server_ttft: None,
             num_input_sequences: 1,
         }
     }
+}
+
+fn update_server_metrics(output: &mut RequestFuncOutput, metrics: Option<&serde_json::Value>) {
+    let Some(metrics) = metrics.and_then(serde_json::Value::as_object) else {
+        return;
+    };
+
+    let to_seconds = |name| {
+        metrics
+            .get(name)
+            .and_then(serde_json::Value::as_f64)
+            .map(|value| value / 1000.0)
+    };
+
+    output.server_queue_time = to_seconds("queue_time_ms");
+    output.server_ttft = to_seconds("time_to_first_token_ms");
 }
 
 impl Default for RequestFuncInput {
@@ -212,4 +234,55 @@ pub fn build_headers(
     }
 
     headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_server_metrics_converts_ms_to_seconds() {
+        let chunk: CompletionChunk = serde_json::from_value(serde_json::json!({
+            "metrics": {
+                "queue_time_ms": 0.0,
+                "time_to_first_token_ms": 1250.0,
+            }
+        }))
+        .unwrap();
+        let mut output = RequestFuncOutput::default();
+
+        update_server_metrics(&mut output, chunk.metrics.as_ref());
+
+        assert_eq!(output.server_queue_time, Some(0.0));
+        assert_eq!(output.server_ttft, Some(1.25));
+    }
+
+    #[test]
+    fn test_update_server_metrics_tolerates_unavailable_values() {
+        for value in [
+            serde_json::json!({}),
+            serde_json::json!({"metrics": null}),
+            serde_json::json!({"metrics": "invalid"}),
+            serde_json::json!({"metrics": {"queue_time_ms": null}}),
+        ] {
+            let chunk: ChatChunk = serde_json::from_value(value).unwrap();
+            let mut output = RequestFuncOutput::default();
+
+            update_server_metrics(&mut output, chunk.metrics.as_ref());
+
+            assert_eq!(output.server_queue_time, None);
+            assert_eq!(output.server_ttft, None);
+        }
+    }
+
+    #[test]
+    fn test_update_server_metrics_handles_partial_metrics() {
+        let metrics = serde_json::json!({"time_to_first_token_ms": 500.0});
+        let mut output = RequestFuncOutput::default();
+
+        update_server_metrics(&mut output, Some(&metrics));
+
+        assert_eq!(output.server_queue_time, None);
+        assert_eq!(output.server_ttft, Some(0.5));
+    }
 }

--- a/rust/src/bench/src/backends/openai_chat.rs
+++ b/rust/src/bench/src/backends/openai_chat.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use futures::StreamExt;
 
 use super::streaming::{StreamedResponseHandler, trim_bytes};
-use super::{ChatChunk, RequestFuncInput, RequestFuncOutput, build_headers};
+use super::{ChatChunk, RequestFuncInput, RequestFuncOutput, build_headers, update_server_metrics};
 use crate::error::Result;
 
 /// Backend for OpenAI Chat Completions API (/v1/chat/completions).
@@ -106,6 +106,8 @@ impl OpenAIChatBackend {
                                 Ok(d) => d,
                                 Err(_) => continue,
                             };
+
+                            update_server_metrics(&mut output, data.metrics.as_ref());
 
                             if !data.choices.is_empty() {
                                 let content = data.choices[0]

--- a/rust/src/bench/src/backends/openai_completions.rs
+++ b/rust/src/bench/src/backends/openai_completions.rs
@@ -7,7 +7,9 @@ use std::time::Instant;
 use futures::StreamExt;
 
 use super::streaming::{StreamedResponseHandler, trim_bytes};
-use super::{CompletionChunk, RequestFuncInput, RequestFuncOutput, build_headers};
+use super::{
+    CompletionChunk, RequestFuncInput, RequestFuncOutput, build_headers, update_server_metrics,
+};
 use crate::error::Result;
 
 /// Backend for OpenAI-compatible Completions API (/v1/completions).
@@ -130,6 +132,8 @@ impl OpenAICompletionsBackend {
                                 Ok(d) => d,
                                 Err(_) => continue,
                             };
+
+                            update_server_metrics(&mut output, data.metrics.as_ref());
 
                             if !data.choices.is_empty() {
                                 let text = data.choices[0].text.as_deref().unwrap_or("");

--- a/rust/src/bench/src/output/json.rs
+++ b/rust/src/bench/src/output/json.rs
@@ -10,6 +10,31 @@ use crate::error::Result;
 use crate::metrics::{BenchmarkMetrics, MultiTurnMetrics};
 use crate::multi_turn::ConversationOutput;
 
+fn insert_server_metrics(
+    result: &mut serde_json::Map<String, Value>,
+    outputs: &[RequestFuncOutput],
+    save_detailed: bool,
+) {
+    if !save_detailed
+        || !outputs
+            .iter()
+            .any(|output| output.server_queue_time.is_some() || output.server_ttft.is_some())
+    {
+        return;
+    }
+
+    result.insert(
+        "server_queue_times".into(),
+        serde_json::json!(
+            outputs.iter().map(|output| output.server_queue_time).collect::<Vec<_>>()
+        ),
+    );
+    result.insert(
+        "server_ttfts".into(),
+        serde_json::json!(outputs.iter().map(|output| output.server_ttft).collect::<Vec<_>>()),
+    );
+}
+
 /// Build the result JSON object matching the Python output schema exactly.
 ///
 /// Mirrors serve.py:1801-1947 result_json construction.
@@ -203,6 +228,7 @@ pub fn build_result_json(
             serde_json::json!(outputs.iter().map(|o| o.start_time).collect::<Vec<_>>()),
         );
     }
+    insert_server_metrics(&mut result, outputs, config.save_detailed);
 
     // Speculative decoding stats
     if let Some(stats) = spec_decode_stats {
@@ -782,5 +808,44 @@ mod tests {
         assert_eq!(failed[1]["ttft"], 0.5);
         assert_eq!(failed[1]["output_tokens"], 3);
         assert_eq!(failed[1]["itl"], serde_json::json!([0.1, 0.12]));
+    }
+
+    #[test]
+    fn test_insert_server_metrics_preserves_alignment() {
+        let outputs = vec![
+            RequestFuncOutput {
+                server_queue_time: Some(0.0),
+                server_ttft: Some(0.2),
+                ..Default::default()
+            },
+            RequestFuncOutput::default(),
+            RequestFuncOutput {
+                server_ttft: Some(0.3),
+                ..Default::default()
+            },
+        ];
+        let mut result = serde_json::Map::new();
+
+        insert_server_metrics(&mut result, &outputs, true);
+
+        assert_eq!(
+            result["server_queue_times"],
+            serde_json::json!([0.0, null, null])
+        );
+        assert_eq!(result["server_ttfts"], serde_json::json!([0.2, null, 0.3]));
+    }
+
+    #[test]
+    fn test_insert_server_metrics_omits_unavailable_or_non_detailed() {
+        let mut result = serde_json::Map::new();
+        insert_server_metrics(&mut result, &[RequestFuncOutput::default()], true);
+        assert!(result.is_empty());
+
+        let outputs = [RequestFuncOutput {
+            server_queue_time: Some(0.1),
+            ..Default::default()
+        }];
+        insert_server_metrics(&mut result, &outputs, false);
+        assert!(result.is_empty());
     }
 }

--- a/tests/benchmarks/test_server_metrics.py
+++ b/tests/benchmarks/test_server_metrics.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from collections.abc import AsyncIterator, Callable
+from typing import Any, cast
+
+import aiohttp
+import pytest
+
+from vllm.benchmarks.lib.endpoint_request_func import (
+    RequestFuncInput,
+    RequestFuncOutput,
+    _update_server_metrics,
+    async_request_openai_chat_completions,
+    async_request_openai_completions,
+)
+from vllm.benchmarks.serve import _get_server_metrics_results
+
+
+class _ResponseContent:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def iter_any(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _Response:
+    status = 200
+    reason = ""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.content = _ResponseContent(chunks)
+
+    async def __aenter__(self) -> "_Response":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+
+class _Session:
+    def __init__(self, chunks: list[bytes], expected_url: str) -> None:
+        self._chunks = chunks
+        self._expected_url = expected_url
+
+    def post(self, **kwargs: Any) -> _Response:
+        assert kwargs["url"] == self._expected_url
+        return _Response(self._chunks)
+
+
+def _sse(data: dict[str, Any]) -> bytes:
+    return f"data: {json.dumps(data)}".encode()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("request_func", "endpoint", "choice"),
+    [
+        (
+            async_request_openai_completions,
+            "/v1/completions",
+            {"choices": [{"text": "x"}]},
+        ),
+        (
+            async_request_openai_chat_completions,
+            "/v1/chat/completions",
+            {"choices": [{"delta": {"content": "x"}}]},
+        ),
+    ],
+)
+async def test_openai_request_preserves_server_queue_time_and_ttft(
+    request_func: Callable[..., Any],
+    endpoint: str,
+    choice: dict[str, Any],
+) -> None:
+    usage = {
+        "choices": [],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 1},
+        "metrics": {
+            "queue_time_ms": 0.0,
+            "time_to_first_token_ms": 1250.0,
+        },
+    }
+    api_url = f"https://example.test{endpoint}"
+    request = RequestFuncInput(
+        prompt="test",
+        api_url=api_url,
+        prompt_len=4,
+        output_len=1,
+        model="test-model",
+    )
+
+    output = await request_func(
+        request,
+        cast(
+            aiohttp.ClientSession,
+            _Session(
+                [_sse(choice), _sse(usage), b"data: [DONE]"],
+                expected_url=api_url,
+            ),
+        ),
+    )
+
+    assert output.success
+    assert output.server_queue_time == 0.0
+    assert output.server_ttft == pytest.approx(1.25)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"metrics": None},
+        {"metrics": {"queue_time_ms": None}},
+        {"metrics": "invalid"},
+        {},
+    ],
+)
+def test_server_metrics_tolerate_unavailable_values(
+    data: dict[str, Any],
+) -> None:
+    output = RequestFuncOutput()
+
+    _update_server_metrics(output, data)
+
+    assert output.server_queue_time is None
+    assert output.server_ttft is None
+
+
+def test_server_metrics_results_preserve_alignment() -> None:
+    outputs = [
+        RequestFuncOutput(
+            server_queue_time=0.1,
+            server_ttft=0.2,
+        ),
+        RequestFuncOutput(),
+        RequestFuncOutput(
+            server_ttft=0.3,
+        ),
+    ]
+
+    assert _get_server_metrics_results(outputs) == {
+        "server_queue_times": [0.1, None, None],
+        "server_ttfts": [0.2, None, 0.3],
+    }
+    assert _get_server_metrics_results(
+        [RequestFuncOutput(server_queue_time=0.0)]
+    ) == {
+        "server_queue_times": [0.0],
+        "server_ttfts": [None],
+    }
+    assert _get_server_metrics_results(
+        [RequestFuncOutput(server_ttft=0.0)]
+    ) == {
+        "server_queue_times": [None],
+        "server_ttfts": [0.0],
+    }
+    assert _get_server_metrics_results([RequestFuncOutput()]) == {}

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -101,8 +101,25 @@ class RequestFuncOutput:
     start_time: float = 0.0
     # Time spent awaiting the benchmark client concurrency semaphore.
     client_queue_time: float = 0.0
+    server_queue_time: float | None = None
+    server_ttft: float | None = None
     input_audio_duration: float = 0.0  # in seconds
     num_input_sequences: int = 1
+
+
+def _update_server_metrics(
+    output: RequestFuncOutput,
+    data: dict[str, Any],
+) -> None:
+    metrics = data.get("metrics")
+    if not isinstance(metrics, dict):
+        return
+
+    def to_seconds(value: Any) -> float | None:
+        return value / 1000.0 if type(value) in (int, float) else None
+
+    output.server_queue_time = to_seconds(metrics.get("queue_time_ms"))
+    output.server_ttft = to_seconds(metrics.get("time_to_first_token_ms"))
 
 
 class RequestFunc(Protocol):
@@ -223,6 +240,7 @@ async def async_request_openai_completions(
 
                         if chunk != "[DONE]":
                             data = json.loads(chunk)
+                            _update_server_metrics(output, data)
 
                             # NOTE: Some completion API might have a last
                             # usage summary response without a token so we
@@ -402,6 +420,7 @@ async def async_request_openai_chat_completions(
                         if chunk != "[DONE]":
                             timestamp = time.perf_counter()
                             data = json.loads(chunk)
+                            _update_server_metrics(output, data)
 
                             if choices := data.get("choices"):
                                 content = choices[0]["delta"].get("content")

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -368,6 +368,21 @@ class EmbedBenchmarkMetrics:
     percentiles_e2el_ms: list[tuple[float, float]]
 
 
+def _get_server_metrics_results(
+    outputs: list[RequestFuncOutput],
+) -> dict[str, list[float | None]]:
+    if not any(
+        output.server_queue_time is not None or output.server_ttft is not None
+        for output in outputs
+    ):
+        return {}
+
+    return {
+        "server_queue_times": [output.server_queue_time for output in outputs],
+        "server_ttfts": [output.server_ttft for output in outputs],
+    }
+
+
 def _get_current_request_rate(
     ramp_up_strategy: Literal["linear", "exponential"] | None,
     ramp_up_start_rps: int | None,
@@ -1316,6 +1331,8 @@ async def benchmark(
             "errors": [output.error for output in outputs],
         }
 
+    result.update(_get_server_metrics_results(outputs))
+
     queue_times: list[float] | None = None
     e2els_including_queue: list[float] | None = None
     if max_concurrency is not None:
@@ -1534,7 +1551,14 @@ def save_to_pytorch_benchmark_format(
     ]
     # These raw data might be useful, but they are rather big. They can be added
     # later if needed
-    ignored_metrics = ["ttfts", "itls", "generated_texts", "errors"]
+    ignored_metrics = [
+        "ttfts",
+        "itls",
+        "generated_texts",
+        "errors",
+        "server_queue_times",
+        "server_ttfts",
+    ]
     pt_records = convert_to_pytorch_benchmark_format(
         args=args,
         metrics={k: [results[k]] for k in metrics if k in results},
@@ -2397,6 +2421,8 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
             "itls",
             "generated_texts",
             "errors",
+            "server_queue_times",
+            "server_ttfts",
         ]:
             if field in result_json:
                 del result_json[field]


### PR DESCRIPTION

## Purpose
PR #46768 added server-side per-request timing metrics to OpenAI-compatible Chat Completions and Completions responses. However, `vllm bench serve` discarded these metrics and only retained client-observed timing data.

This PR preserves two server-side metrics in detailed benchmark results:

- `server_queue_times`: time spent waiting in the server scheduler queue.
- `server_ttfts`: time from scheduling to first-token generation.

Both values are converted from milliseconds to seconds to match the existing per-request benchmark arrays. Missing values are represented as `null` while preserving request-index alignment. Both arrays are omitted if neither metric is available for any request, or if --save-detailed is not enabled.

The implementation supports both the Python benchmark client and the Rust benchmark client used with `VLLM_USE_RUST_BENCH=1`. Documentation is updated to distinguish these values from the client-side `queue_times` and `ttfts`.

This PR focuses on server-side queue time and TTFT to help **distinguish scheduler waiting time from time to first-token generation**. I’m happy to include the remaining per-request metrics if maintainers prefer a broader scope.

There is no associated issue. This is a follow-up integration to #46768.

I searched open PRs for `server_queue_times`, `server_ttfts`, and the combination of `enable-per-request-metrics` with `save-detailed`, and found no existing PR implementing this behavior.

AI assistance from OpenAI Codex was used during implementation. I reviewed every changed line and can explain and maintain the change.

## Test Plan

- Verify that both Python Chat Completions and Completions clients extract metrics from the final streaming usage chunk.
- Verify millisecond-to-second conversion, zero-valued metrics, unavailable values, and per-request array alignment.
- Verify equivalent result serialization in the Rust benchmark client.
- Run the targeted Python and Rust tests.
- Run a Python end-to-end smoke test against a live `/v1/completions` endpoint
  and inspect the saved detailed JSON.


## Test Result

### Python targeted tests

```text
python -m pytest tests/benchmarks/test_server_metrics.py -v
7 passed, 14 warnings in 3.81s
```

### Rust targeted tests

```text
 cargo test --locked --offline -p vllm-bench server_metrics
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 176 filtered out
```

### Python E2E smoke test

Behavior change:

- Before: detailed benchmark results did not contain server-side queue time
  or TTFT.
- After: detailed results include `server_queue_times` and `server_ttfts`
  when these metrics are available.

The smoke test was run on the modified version using
`gemma-4-E2B-it`, with `--enable-per-request-metrics`
enabled on the server:

```bash
vllm bench serve \
  --model /path/to/gemma-4-E2B-it \
  --dataset-name custom \
  --dataset-path toolagent_3k.jsonl \
  --num-prompts 3 \
  --disable-shuffle \
  --custom-output-len=-1 \
  --request-rate 0.6 \
  --save-result \
  --save-detailed \
  --result-dir results \
  --result-filename gemma4_server_metrics_smoke_3.json
```

Results:

- 3 successful requests, 0 failures.
- Both server timing arrays were present in the saved detailed JSON.
- Each array contained 3 non-null, non-negative values and matched the
  length of the existing per-request arrays.

Saved values, in seconds (rounded for readability):

```json
{
  "ttfts": [0.820385, 0.774362, 4.330024],
  "server_queue_times": [0.000060141, 0.000023473, 0.000028463],
  "server_ttfts": [0.709359, 0.729975, 4.277035]
}
```

This E2E run covers the Python client and `/v1/completions` endpoint.
Chat Completions and Rust behavior are covered by the targeted tests above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

