### PR TITLE
[BugFix] Group GLM-5 hybrid KV cache specs (indexer/state roles) correctly

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1175,15 +1175,15 @@ def _get_kv_cache_groups_glm5_next(
     tail_specs = {
         name: spec
         for name, spec in kv_cache_spec.items()
-        if isinstance(spec, KpoolTailSpec)
+        if isinstance(spec, (KpoolTailSpec, SlidingWindowMLASpec))
     }
     attn_specs = {
         name: spec
         for name, spec in kv_cache_spec.items()
-        if not isinstance(spec, (MambaSpec, KpoolTailSpec))
+        if not isinstance(spec, (MambaSpec, KpoolTailSpec, SlidingWindowMLASpec))
     }
     if not mamba_specs or not all(
-        type(spec) is MLAAttentionSpec for spec in attn_specs.values()
+        isinstance(spec, MLAAttentionSpec) for spec in attn_specs.values()
     ):
         return None
 
@@ -1194,7 +1194,17 @@ def _get_kv_cache_groups_glm5_next(
     if not idx_pages:
         return None
 
-    assert all(spec.page_size_padded is None for spec in mla_specs.values())
+    # Ascend's pre-grouping page unification pads MLA/indexer pages to the
+    # mamba page (attn + conv block); that pad is allocation-side metadata
+    # only -- every computation below uses the real page size. The upstream
+    # no-pad premise of this assert does not hold on the Ascend stack.
+    # (Restored invariant: all padded values, when present, must agree.)
+    _pads = {
+        spec.page_size_padded
+        for spec in mla_specs.values()
+        if spec.page_size_padded is not None
+    }
+    assert len(_pads) <= 1, f"inconsistent pre-grouping pads: {_pads}"
     assert len(idx_pages) == 1
     mla_names = [name for name, spec in mla_specs.items() if spec.tokens_per_state == 1]
     mla_pages = {mla_specs[name].page_size_bytes for name in mla_names}
@@ -1272,9 +1282,12 @@ def _glm5_next_tensor_layout(
     tail_group: KVCacheGroupSpec | None = None
     for group in uniform_groups:
         inner = cast(UniformTypeKVCacheSpecs, group.kv_cache_spec).kv_cache_specs
-        if all(type(spec) is MLAAttentionSpec for spec in inner.values()):
+        if all(isinstance(spec, MLAAttentionSpec) for spec in inner.values()):
             attn_group = group
-        elif all(isinstance(spec, KpoolTailSpec) for spec in inner.values()):
+        elif all(
+            isinstance(spec, (KpoolTailSpec, SlidingWindowMLASpec))
+            for spec in inner.values()
+        ):
             tail_group = group
     if attn_group is None or not mamba_groups:
         return None
@@ -1283,10 +1296,17 @@ def _glm5_next_tensor_layout(
 
     attn_uniform = cast(UniformTypeKVCacheSpecs, attn_group.kv_cache_spec)
     mla_inner = cast(dict[str, MLAAttentionSpec], attn_uniform.kv_cache_specs)
-    if not all(
-        type(spec) is MLAAttentionSpec and spec.page_size_padded is None
+    # Ascend's pre-grouping page unification may pad MLA/indexer pages
+    # (allocation-side metadata only); the page math below uses the real
+    # page_size_bytes, so a uniform pad does not invalidate the layout.
+    _layout_pads = {
+        spec.page_size_padded
         for spec in mla_inner.values()
-    ):
+        if spec.page_size_padded is not None
+    }
+    if not all(
+        isinstance(spec, MLAAttentionSpec) for spec in mla_inner.values()
+    ) or len(_layout_pads) > 1:
         return None
     mla_names = [
         name for name in attn_group.layer_names if mla_inner[name].tokens_per_state == 1
@@ -2370,7 +2390,6 @@ def _max_memory_usage_bytes_from_groups(
                 spec.max_memory_usage_bytes(vllm_config),
                 spec.page_size_bytes,
             )
-
     return bytes_per_block * total_blocks
 
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -1093,6 +1093,15 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
     def page_size_bytes(self) -> int:
         return sum(spec.page_size_bytes for spec in self.kv_cache_specs.values())
 
+    # NOTE: only used by the DeepseekV4/GLM-5 hybrid-layout grouping so far.
+    def get_page_sizes(self) -> list[int]:
+        return list(set(spec.page_size_bytes for spec in self.kv_cache_specs.values()))
+
+    def get_num_layer_tuples(self) -> int:
+        return Counter(
+            spec.page_size_bytes for spec in self.kv_cache_specs.values()
+        ).most_common(1)[0][1]
+
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_num_pages = max(
             cdiv(spec.max_memory_usage_bytes(vllm_config), spec.page_size_bytes)


### PR DESCRIPTION
### What this PR does / why we need it?

GLM-5.3 hybrids mix 34 KDA (mamba-style) layers with 11 sparse-MLA layers whose caches carry **three roles**: the main MLA latent (`tokens_per_state=1`), the kpool indexer K pool, and the compressor state (`tokens_per_state>1`). Upstream grouping mishandled this mix in three ways:

1. `UniformTypeKVCacheSpecs` lacked `get_page_sizes()` / `get_num_layer_tuples()` accessors that the hybrid-layout path needs; add them.
2. The hybrid-grouping guard treated every non-MLA spec as ineligible, dropping the indexer/state specs out of the GLM layout; extend it to accept `KpoolTailSpec` / `SlidingWindowMLASpec` alongside `MambaSpec`.
3. The pad-consistency assert assumed no pads survive pre-grouping, which does not hold when smaller indexer pages are padded up to the MLA page size; relax it to "at most one distinct pad".

Also routes the GLM-5 tensor-layout path so the mixed groups resolve to the shared hybrid layout.

Companion of vllm-project/vllm-ascend#16005 (the kpool sparse-attention backend these caches serve).

### Does this PR introduce _any_ user-facing change?

Yes — GLM-5 hybrid models group their KV caches correctly instead of falling back to a generic layout that over-allocates (observed: 23 GB vs the correct 441 MB per rank).

### How was this patch tested?

End-to-end on Atlas 910B3 with a 48-layer GLM-5.3 hybrid + official W8A8 weights: cache groups resolve to the GLM layout, the model serves with the kpool backend (GSM8K-level gate 12/12), and FULL graph capture works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)