### PR TITLE
[Bugfix][Quantization] Match compressed-tensors MoE target aliases

### DIFF
--- a/tests/quantization/test_compressed_tensors_moe.py
+++ b/tests/quantization/test_compressed_tensors_moe.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+    CompressedTensorsConfig,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe import (  # noqa: E501
+    _get_moe_scheme_dicts,
+)
+
+
+class _MockRoutedExperts(torch.nn.Module):
+    ckpt_gate_proj_name = "w1"
+    ckpt_down_proj_name = "w2"
+    ckpt_up_proj_name = "w3"
+
+
+def _make_config(target_scheme_map):
+    return CompressedTensorsConfig(
+        target_scheme_map=target_scheme_map,
+        ignore=[],
+        quant_format="mxfp4-pack-quantized",
+    )
+
+
+def test_moe_scheme_lookup_maps_mixtral_container_name():
+    scheme = {"weights": object(), "format": "mxfp4-pack-quantized"}
+    config = _make_config({r"re:.*mlp\.experts\.\d+\.(gate|up|down)_proj$": scheme})
+
+    schemes = _get_moe_scheme_dicts(
+        config,
+        _MockRoutedExperts(),
+        "model.layers.4.block_sparse_moe.experts",
+    )
+
+    assert schemes == [scheme, scheme, scheme]
+
+
+def test_moe_scheme_lookup_uses_checkpoint_projection_names():
+    scheme = {"weights": object(), "format": "mxfp4-pack-quantized"}
+    config = _make_config({r"re:.*\.experts\.\d+\.w[123]$": scheme})
+
+    schemes = _get_moe_scheme_dicts(
+        config, _MockRoutedExperts(), "model.layers.4.mlp.experts"
+    )
+
+    assert schemes == [scheme, scheme, scheme]
+
+
+def test_moe_scheme_lookup_preserves_per_layer_mixed_precision():
+    layer_3_scheme = {"weights": object(), "format": "mxfp4-pack-quantized"}
+    layer_4_scheme = {"weights": object(), "format": "mxfp8-quantized"}
+    config = _make_config(
+        {
+            r"re:.*layers\.3\.mlp\.experts\.\d+\..*_proj$": layer_3_scheme,
+            r"re:.*layers\.4\.mlp\.experts\.\d+\..*_proj$": layer_4_scheme,
+        }
+    )
+
+    schemes = _get_moe_scheme_dicts(
+        config,
+        _MockRoutedExperts(),
+        "model.layers.4.block_sparse_moe.experts",
+    )
+
+    assert schemes == [layer_4_scheme, layer_4_scheme, layer_4_scheme]
+
+
+def test_moe_scheme_lookup_honors_canonical_path_ignore():
+    scheme = {"weights": object(), "format": "mxfp4-pack-quantized"}
+    config = _make_config({"MockRoutedExperts": scheme})
+    config.ignore = [r"re:.*mlp\.experts\.\d+\.up_proj$"]
+
+    schemes = _get_moe_scheme_dicts(
+        config,
+        _MockRoutedExperts(),
+        "model.layers.4.block_sparse_moe.experts",
+    )
+
+    assert schemes == [scheme, None, scheme]

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -932,7 +932,10 @@ class CompressedTensorsConfig(QuantizationConfig):
         return scheme
 
     def get_scheme_dict(
-        self, layer: torch.nn.Module, layer_name: str | None = None
+        self,
+        layer: torch.nn.Module,
+        layer_name: str | None = None,
+        match_module: bool = True,
     ) -> dict[str, QuantizationArgs | str | None] | None:
         """
         Extract the QuantizationArgs for a given layer.
@@ -943,6 +946,11 @@ class CompressedTensorsConfig(QuantizationConfig):
                 "input_activations": QuantizationArgs | None,
                 "format": str | None
             } | None
+
+        Args:
+            layer: module being matched
+            layer_name: fully qualified module name
+            match_module: whether to fall back to matching the module class name
         """
         # TODO (@kylesayrs): support ignore module names with ct matching utils
         if should_ignore_layer(
@@ -957,6 +965,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 module=layer,
                 targets=self.target_scheme_map.keys(),
                 fused_mapping=self.packed_modules_mapping,
+                match_module=match_module,
             )
             if matched_target is not None:
                 scheme_dict = self.target_scheme_map[matched_target]

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from typing import TYPE_CHECKING
+
 import torch
 from compressed_tensors import CompressionFormat
 from compressed_tensors.quantization import (
@@ -18,9 +20,72 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa
     WNA16_SUPPORTED_BITS,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    should_ignore_layer,
+)
 from vllm.platforms import current_platform
 
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+        CompressedTensorsConfig,
+    )
+
 logger = init_logger(__name__)
+
+_MOE_PREFIX_ALIASES = ((".block_sparse_moe.experts", ".mlp.experts"),)
+_MOE_PROJECTIONS = (
+    ("gate_proj", "ckpt_gate_proj_name"),
+    ("up_proj", "ckpt_up_proj_name"),
+    ("down_proj", "ckpt_down_proj_name"),
+)
+
+
+def _get_moe_scheme_dicts(
+    quant_config: "CompressedTensorsConfig",
+    layer: torch.nn.Module,
+    layer_name: str,
+) -> list[dict | None]:
+    """Resolve each expert projection before falling back to its module class."""
+    prefixes = [layer_name]
+    for left, right in _MOE_PREFIX_ALIASES:
+        for source, target in ((left, right), (right, left)):
+            if source in layer_name:
+                prefixes.append(layer_name.replace(source, target))
+
+    schemes = []
+    for canonical_name, checkpoint_attr in _MOE_PROJECTIONS:
+        projection_names = [canonical_name]
+        checkpoint_name = getattr(layer, checkpoint_attr, canonical_name)
+        if checkpoint_name not in projection_names:
+            projection_names.append(checkpoint_name)
+        candidates = [
+            f"{prefix}.0.{projection_name}"
+            for prefix in prefixes
+            for projection_name in projection_names
+        ]
+
+        if any(
+            should_ignore_layer(
+                candidate,
+                ignore=quant_config.ignore,
+                fused_mapping=quant_config.packed_modules_mapping,
+            )
+            for candidate in candidates
+        ):
+            schemes.append(None)
+            continue
+
+        scheme = None
+        for candidate in candidates:
+            scheme = quant_config.get_scheme_dict(layer, candidate, match_module=False)
+            if scheme is not None:
+                break
+
+        if scheme is None:
+            scheme = quant_config.get_scheme_dict(layer, candidates[0])
+        schemes.append(scheme)
+
+    return schemes
 
 
 class CompressedTensorsMoEMethod(FusedMoEMethodBase):
@@ -33,14 +98,7 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
         # RoutedExperts was made by combining multiple Linears so need to
         # make sure quantization config for Linear can target it
         quant_config._add_fused_moe_to_target_scheme_map()
-        unfused_names = [
-            layer_name + proj_name
-            for proj_name in [".0.gate_proj", ".0.up_proj", ".0.down_proj"]
-        ]
-        # TODO: refactor this to use expert_mapping and check all layer numbers
-        all_scheme_dicts = [
-            quant_config.get_scheme_dict(layer, name) for name in unfused_names
-        ]
+        all_scheme_dicts = _get_moe_scheme_dicts(quant_config, layer, layer_name)
         scheme_dict = all_scheme_dicts.pop()
 
         # multiple schemes found

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -75,6 +75,7 @@ def find_matched_target(
     module: Module,
     targets: Iterable[str],
     fused_mapping: Mapping[str, list[str]] = MappingProxyType({}),
+    match_module: bool = True,
 ) -> str | None:
     """
     Helper function to look up which "target" in the compressed-tensors
@@ -98,16 +99,17 @@ def find_matched_target(
         module: torch.nn.Module
         targets: list of targets to match the layer against
         fused_mapping: map from fused layer names to its components
+        match_module: whether to fall back to matching the module class name
     """
 
     if layer_name is None:
         layer_name = ""
 
-    matched_target = (
-        _find_first_match(layer_name, targets)
-        or _match_fused_layer(layer_name, targets, fused_mapping)
-        or _find_first_match(module.__class__.__name__, targets, True)
+    matched_target = _find_first_match(layer_name, targets) or _match_fused_layer(
+        layer_name, targets, fused_mapping
     )
+    if matched_target is None and match_module:
+        matched_target = _find_first_match(module.__class__.__name__, targets, True)
 
     return matched_target
 


### PR DESCRIPTION
## Purpose

Fix compressed-tensors MoE scheme dispatch when checkpoint and runtime module names differ. This addresses vllm-project/llm-compressor#3069.

The existing lookup hard-codes canonical expert paths such as `gate_proj` under the runtime layer prefix. That misses:

- Mixtral configs exported under `mlp.experts` when vLLM uses `block_sparse_moe.experts`
- Checkpoints whose expert projections are named `w1`, `w2`, and `w3`

The new lookup checks runtime and canonical container paths together with canonical and checkpoint projection names. It resolves concrete paths before module-class fallback so per-layer mixed precision remains intact, and it honors ignore rules across aliases.

## Test Plan

```bash
python -m pytest -q tests/quantization/test_compressed_tensors_moe.py
ruff check vllm/model_executor/layers/quantization/compressed_tensors/utils.py vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe.py tests/quantization/test_compressed_tensors_moe.py
```

The unit tests cover Mixtral container aliases, checkpoint projection names, per-layer mixed precision, and canonical-path ignore rules.

## Test Result

```text
4 passed, 14 warnings in 7.67s
All checks passed!
```

The tests ran in a vLLM 0.28.0 environment on an NVIDIA A100 server. The warnings are existing PyTorch JIT deprecation warnings.

AI assistance: Codex was used for issue investigation, implementation, and test execution. The PR is left as a draft for human review in accordance with the contribution policy.