### PR TITLE
[BugFix] force_first_config: tolerate backend-specific triton error classes

### DIFF
--- a/vllm/triton_utils/force_first_config.py
+++ b/vllm/triton_utils/force_first_config.py
@@ -27,10 +27,23 @@ def install() -> None:
 
     autotuner_mod = importlib.import_module("triton.runtime.autotuner")
     Autotuner = autotuner_mod.Autotuner
-    from triton.compiler.errors import CompileTimeAssertionFailure
-    from triton.runtime.errors import OutOfResources, PTXASError
-
-    _invalid_config_errors = (OutOfResources, CompileTimeAssertionFailure, PTXASError)
+    # triton-ascend (NPU) lacks the CUDA-only PTXASError, and some forks
+    # omit CompileTimeAssertionFailure; tolerate both so the deterministic
+    # first-config patch also works on non-CUDA backends.
+    _err_classes = []
+    for _err_path, _err_name in (
+        ("triton.compiler.errors", "CompileTimeAssertionFailure"),
+        ("triton.runtime.errors", "OutOfResources"),
+        ("triton.runtime.errors", "PTXASError"),
+    ):
+        try:
+            _mod = importlib.import_module(_err_path)
+            _err_classes.append(getattr(_mod, _err_name))
+        except (ImportError, AttributeError):
+            pass
+    if not _err_classes:
+        return
+    _invalid_config_errors = tuple(_err_classes)
     _picked_cache: dict[tuple, int] = {}
     seen_kernels: set[str] = set()
 


### PR DESCRIPTION
### What this PR does / why we need it?

`VLLM_TRITON_FORCE_FIRST_CONFIG`'s `install()` unconditionally imported `PTXASError` from `triton.runtime.errors`. That class is CUDA-only and does not exist in triton-ascend (NPU), so enabling the flag on NPU crashed at import with `ImportError` before any patching happened.

Collect the invalid-config error classes individually (`OutOfResources`, `CompileTimeAssertionFailure`, `PTXASError`) and skip the ones the current triton build lacks; if none exist, install is a no-op.

### Does this PR introduce _any_ user-facing change?

Yes — `VLLM_TRITON_FORCE_FIRST_CONFIG=1` now works on NPU backends instead of crashing at startup.

### How was this patch tested?

Import + `install()` smoke on Atlas 910B3 with triton-ascend (previously ImportError at import; now installs cleanly). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)