### PR TITLE
[Model] Enable torch.compile for Sarvam MLA

### DIFF
--- a/vllm/model_executor/models/sarvam.py
+++ b/vllm/model_executor/models/sarvam.py
@@ -28,6 +28,7 @@ from itertools import islice
 import torch
 from torch import nn
 
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ParallelConfig, VllmConfig
 from vllm.distributed import (
     get_pp_group,
@@ -448,6 +449,16 @@ class SarvamMLABlock(nn.Module):
         return hidden_states, residual
 
 
+# PEP 563 stringifies annotations in this module, so the decorator cannot infer
+# these; they are the set DeepSeek-V2 infers for the same forward signature.
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": 0,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
 class SarvamMLAModel(nn.Module, EagleModelMixin):
     """Sarvam MLA backbone with stage-local EAGLE3 auxiliary capture."""
 


### PR DESCRIPTION
## Purpose

Enable `torch.compile` for `SarvamMLAModel` by adding `support_torch_compile`. Explicit dynamic dimensions cover `input_ids`, `positions`, `intermediate_tensors`, and `inputs_embeds`, since postponed annotations prevent the decorator from inferring them.

This applies only the compile changes from the existing Sarvam patch. `SarvamMoEForCausalLM` already inherits compile support through `BailingMoeModel`. No open PR covering Sarvam compile support was found in the duplicate-work search.

## Validation

The PR author reports that the model has been tested end to end.

- `ruff check vllm/model_executor/models/sarvam.py` — passed.
- `ruff format --check vllm/model_executor/models/sarvam.py` — passed.
- `git diff --check` — passed.

No tests were added or rerun for this revision. No new model-quality evaluation was run.

AI assistance was used to prepare this PR.
