### PR TITLE
[Bugfix][Tokenizer] Render DeepSeek V3.2 tools after system prompt

### DIFF
--- a/tests/tokenizers_/test_deepseek_v32.py
+++ b/tests/tokenizers_/test_deepseek_v32.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.tokenizers.deepseek_v32 import get_deepseek_v32_tokenizer
+
+
+class FakeHfTokenizer:
+    def get_added_vocab(self) -> dict[str, int]:
+        return {}
+
+    def encode(
+        self,
+        text: str,
+        add_special_tokens: bool = False,
+        **kwargs,
+    ) -> list[int]:
+        return [len(text)]
+
+
+def _tokenizer():
+    return get_deepseek_v32_tokenizer(FakeHfTokenizer())
+
+
+_ONE_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def test_deepseek_v32_tools_render_after_the_system_prompt():
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "system", "content": "SYSTEM_MARKER"},
+            {"role": "user", "content": "Weather?"},
+        ],
+        tools=_ONE_TOOL,
+        tokenize=False,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert prompt.index("SYSTEM_MARKER") < prompt.index("## Tools")
+    assert "SYSTEM_MARKER\n\n## Tools" in prompt
+
+
+def test_deepseek_v32_tools_render_without_a_leading_system_message():
+    prompt = _tokenizer().apply_chat_template(
+        [{"role": "user", "content": "Weather?"}],
+        tools=_ONE_TOOL,
+        tokenize=False,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert '"name": "get_weather"' in prompt
+
+
+def test_deepseek_v32_request_tools_replace_message_tools():
+    messages = [
+        {
+            "role": "system",
+            "content": "SYSTEM_MARKER",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "old_tool",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        },
+        {"role": "user", "content": "Weather?"},
+    ]
+
+    prompt = _tokenizer().apply_chat_template(
+        messages,
+        tools=_ONE_TOOL,
+        tokenize=False,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert "get_weather" in prompt
+    assert "old_tool" not in prompt
+    assert "tools" not in messages[0]

--- a/vllm/tokenizers/deepseek_v32.py
+++ b/vllm/tokenizers/deepseek_v32.py
@@ -34,10 +34,20 @@ def get_deepseek_v32_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             if not thinking:
                 thinking_mode = "chat"
             conversation = kwargs.get("conversation", messages)
-            messages = conversation.copy()
+            messages = list(conversation)
             if tools is not None and len(tools) > 0:
-                messages.insert(0, {"role": "system"})
-                messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                # Attach request-level tools to the leading system/developer message
+                # so they render after its content, matching the reference encoder.
+                # If there is no such message, create one to preserve tool support.
+                if messages and messages[0].get("role") in ("system", "developer"):
+                    head = dict(messages[0])
+                    head["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                    messages[0] = head
+                else:
+                    messages.insert(
+                        0,
+                        {"role": "system", "tools": tools},  # type: ignore[typeddict-unknown-key]
+                    )
 
             # Historical reasoning content is dropped when a new user message
             # is introduced


### PR DESCRIPTION
Fixes #54911

## Summary

- Attach request-level tools to the leading system or developer message when present.
- Keep the fallback system message for conversations without a leading system/developer message.
- Add tokenizer regression tests for prompt ordering, fallback rendering, replacement semantics, and input immutability.

## Validation

- `uvx --from ruff ruff check vllm/tokenizers/deepseek_v32.py tests/tokenizers_/test_deepseek_v32.py`
- `python3 -m compileall -q vllm/tokenizers/deepseek_v32.py tests/tokenizers_/test_deepseek_v32.py`
- `git diff --check`
- Full pytest execution is delegated to GitHub CI; the configured A100 server was temporarily unavailable because password authentication was rejected.

This pull request was prepared with assistance from OpenAI Codex. The author will manually review every line and is responsible for the final changes.