### PR TITLE
[Bugfix][Compilation] Warn when RoPE KV cache fusion registers no patterns

### DIFF
--- a/tests/compile/passes/test_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rope_kvcache_fusion.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from unittest.mock import patch
+
 import pytest
 import torch
 from torch._higher_order_ops import auto_functionalized
@@ -13,7 +15,10 @@ from tests.v1.attention.utils import (
     dense_kv_cache_views,
 )
 from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
-from vllm.compilation.passes.fusion import rope_kvcache_fusion
+from vllm.compilation.passes.fusion import (
+    qk_norm_rope_kvcache_fusion,
+    rope_kvcache_fusion,
+)
 from vllm.compilation.passes.fusion.matcher_utils import ROTARY_OP
 from vllm.compilation.passes.fusion.rope_kvcache_fusion import RopeKVCacheFusionPass
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
@@ -95,6 +100,45 @@ def test_rope_kvcache_fusion_default_keeps_large_ranges_unfused():
     assert fusion_pass.is_applicable_for_range(Range(1, 256))
     assert not fusion_pass.is_applicable_for_range(Range(257, 11650))
     assert not fusion_pass.is_applicable_for_range(Range(11651, 16384))
+
+
+@pytest.mark.parametrize(
+    ("pass_cls", "pass_module", "warning"),
+    [
+        (
+            RopeKVCacheFusionPass,
+            rope_kvcache_fusion,
+            "RoPE + KV cache fusion is enabled",
+        ),
+        (
+            qk_norm_rope_kvcache_fusion.QkNormRopeKvCacheFusionPass,
+            qk_norm_rope_kvcache_fusion,
+            "QK Norm + RoPE + KV cache fusion is enabled",
+        ),
+    ],
+)
+def test_rope_kvcache_pass_warns_when_no_attention_layers(
+    pass_cls, pass_module, warning
+):
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(dtype=torch.bfloat16),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            pass_config=PassConfig(
+                fuse_rope_kvcache=True,
+                fuse_qk_norm_rope_kvcache=True,
+            ),
+        ),
+    )
+
+    with (
+        patch.object(pass_module, "get_layers_from_vllm_config", return_value={}),
+        patch.object(pass_module.logger, "warning") as warning_mock,
+    ):
+        pass_cls(vllm_config)
+
+    warning_mock.assert_called_once()
+    assert warning in warning_mock.call_args.args[0]
 
 
 class QKRoPEKVCacheTestModel(torch.nn.Module):

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -440,6 +440,12 @@ class QkNormRopeKvCacheFusionPass(VllmPatternMatcherPass):
             return
 
         attn_layers = get_layers_from_vllm_config(config, Attention)
+        if not attn_layers:
+            logger.warning(
+                "QK Norm + RoPE + KV cache fusion is enabled, but no attention "
+                "layers were found in CompilationConfig.static_forward_context, "
+                "so no fusion patterns were registered."
+            )
 
         for _, layer in attn_layers.items():
             if not layer.impl.fused_qk_norm_rope_kvcache_supported():

--- a/vllm/compilation/passes/fusion/rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/rope_kvcache_fusion.py
@@ -434,6 +434,12 @@ class RopeKVCacheFusionPass(VllmPatternMatcherPass):
         self.max_token_num = cc.pass_config.rope_kvcache_fusion_max_token_num
 
         attn_layers = get_layers_from_vllm_config(config, Attention)
+        if not attn_layers:
+            logger.warning(
+                "RoPE + KV cache fusion is enabled, but no attention layers were "
+                "found in CompilationConfig.static_forward_context, so no fusion "
+                "patterns were registered."
+            )
         # When _USE_LAYERNAME is enabled, layer_name is a wildcard so all
         # layers produce the same pattern — register once then break.
         for _, layer in attn_layers.items():


### PR DESCRIPTION
## Summary

- Warn when `fuse_rope_kvcache` is enabled but no standard attention layers are present.
- Warn when `fuse_qk_norm_rope_kvcache` is enabled but no standard attention layers are present.
- Add a parameterized regression test covering both passes.

Fixes #55720.

## Why This Is Not a Duplicate

I checked issue #55720 and searched open PRs for the issue number and the RoPE/KV-cache fusion area. No open PR addresses this no-op warning. The issue author withdrew the original performance measurements and left the silent zero-pattern registration as the actionable problem.

## Testing

- `uvx ruff check ...`: passed
- `uvx ruff format --check ...`: passed
- `.venv/bin/python -m compileall -q ...`: passed
- `git diff --check`: passed
- Targeted pytest was not run: this macOS `.venv` has neither `torch` nor `pytest`, and `uv run` cannot resolve the repository's Linux/CPU Torch dependency constraints on macOS.

This is a compilation observability change and does not affect model outputs; no model evaluation is applicable.

AI assistance was used to inspect the issue, implement the change, and prepare this draft. A human maintainer should review every changed line and run the targeted test on a supported vLLM environment.