### PR TITLE
[Spec Decode] Strengthen scheduling accuracy and grammar-mask isolation

### DIFF
--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-from itertools import repeat
 from typing import Any
 
 import pytest
-import torch._dynamo.config as dynamo_config
 
 from tests.utils import (
     large_gpu_mark,
@@ -122,7 +120,7 @@ def test_with_eagle3_spec_decoding(sample_json_schema, monkeypatch: pytest.Monke
 
     struct_outputs = StructuredOutputsParams(json=sample_json_schema)
 
-    test_sampling_params = [
+    test_sampling_params: list[dict[str, Any]] = [
         dict(),
         dict(frequency_penalty=-1.0),
         dict(bad_words=["the", " the"]),
@@ -157,7 +155,6 @@ def test_with_eagle3_spec_decoding(sample_json_schema, monkeypatch: pytest.Monke
     run_tests(monkeypatch, MTP_MODEL, test_configs, test_sampling_params)
 
 
-@pytest.mark.flaky(reruns=2, only_on=current_platform.is_rocm())
 @pytest.mark.skipif(
     current_platform.is_xpu(),
     reason=("XPU matmul/attention kernels are not batch-invariant"),
@@ -198,7 +195,6 @@ def test_with_ngram_gpu_spec_decoding(monkeypatch: pytest.MonkeyPatch):
     run_tests(monkeypatch, MODEL, test_configs, [{}])
 
 
-@dynamo_config.patch(cache_size_limit=16)
 def run_tests(
     monkeypatch: pytest.MonkeyPatch,
     model: str,
@@ -208,7 +204,8 @@ def run_tests(
     """Test consistency of combos of async scheduling, preemption,
     uni/multiproc executor with spec decoding."""
 
-    # Flex attention supports float32.
+    # Keep the validated numerical fixture until an alternative passes the
+    # full accuracy matrix; automatic ROCm selection has not passed it.
     attention_config = {"backend": "FLEX_ATTENTION"}
 
     with monkeypatch.context() as m:
@@ -250,10 +247,11 @@ def run_tests(
             test_logprobs,
         ), test_acceptance_rate, params in zip(
             baseline_tests,
-            baseline_acceptances or repeat(None),
+            baseline_acceptances or [None] * len(test_sampling_params),
             test_outputs,
-            test_acceptance_rates or repeat(None),
+            test_acceptance_rates or [None] * len(test_sampling_params),
             test_sampling_params,
+            strict=True,
         ):
             reason = None
             try:
@@ -268,7 +266,7 @@ def run_tests(
 
             if reason is None:
                 try:
-                    assert _all_logprobs_match(base_logprobs, test_logprobs)
+                    _assert_logprobs_match(base_logprobs, test_logprobs)
                 except AssertionError as e:
                     reason = "logprobs", e
 
@@ -374,10 +372,9 @@ def run_test(
             metrics_before = vllm_model.llm.get_metrics()
             print(f"----------- RUNNING PARAMS: {override_params}")
             results.append(
-                vllm_model.generate(
-                    example_prompts,
-                    sampling_params=SamplingParams(**default_params, **override_params),
-                    return_logprobs=True,
+                _generate_with_logprobs(
+                    vllm_model,
+                    SamplingParams(**default_params, **override_params),
                 )
             )
             metrics_after = vllm_model.llm.get_metrics()
@@ -396,7 +393,7 @@ def run_test(
         # First check that the different parameter configs
         # actually result in different output.
         for (other_test_outs, other_test_logprobs), params in zip(
-            results[1:], sampling_param_tests[1:]
+            results[1:], sampling_param_tests[1:], strict=True
         ):
             with pytest.raises(AssertionError):
                 check_outputs_equal(
@@ -405,40 +402,72 @@ def run_test(
                     name_0=f"baseline params={params}",
                     name_1=f"other params={params}",
                 )
-                assert _all_logprobs_match(results[0][1], other_test_logprobs)
+                _assert_logprobs_match(results[0][1], other_test_logprobs)
 
     return test_config, results, acceptance_rates
 
 
-def _all_logprobs_match(req_a, req_b) -> bool:
-    return (
-        req_a == req_b
-        or len(req_a) == len(req_b)
-        and all(
-            len(seq_a) == len(seq_b)
-            and all(_logprobs_match(a, b) for a, b in zip(seq_a, seq_b))
-            for seq_a, seq_b in zip(req_a, req_b)
-        )
+def _generate_with_logprobs(runner: VllmRunner, params: SamplingParams):
+    requests = runner.llm.generate(
+        runner.get_inputs(example_prompts), sampling_params=params
     )
+    assert len(requests) == len(example_prompts)
+    outputs, logprobs = [], []
+    for request in requests:
+        assert len(request.outputs) == 1
+        (completion,) = request.outputs
+        prompt_ids = request.prompt_token_ids
+        tokens = list(completion.token_ids)
+        _assert_requested_logprobs(tokens, completion.logprobs, params.logprobs)
+        if params.prompt_logprobs is None:
+            assert request.prompt_logprobs is None
+        else:
+            assert request.prompt_logprobs is not None
+            assert len(request.prompt_logprobs) == len(prompt_ids)
+            assert request.prompt_logprobs[0] is None
+            _assert_requested_logprobs(
+                prompt_ids[1:], request.prompt_logprobs[1:], params.prompt_logprobs
+            )
+        outputs.append(
+            ([prompt_ids + tokens], [(request.prompt or "") + completion.text])
+        )
+        logprobs.append((request.prompt_logprobs or []) + (completion.logprobs or []))
+    return outputs, logprobs
 
 
-def _logprobs_match(
-    lps_a: dict[int, Logprob] | None,
-    lps_b: dict[int, Logprob] | None,
-) -> bool:
-    if lps_a is None or lps_b is None:
-        return lps_a is lps_b
-    rel_tol, abs_tol = 1e-3, 1e-6
-    return (
-        len(lps_a) == len(lps_b)
-        and lps_a.keys() == lps_b.keys()
-        and all(
-            a.decoded_token == b.decoded_token
-            and a.rank == pytest.approx(b.rank, rel=0.005)
-            and a.logprob == pytest.approx(b.logprob, rel=rel_tol, abs=abs_tol)
-            for a, b in ((lps_a[x], lps_b[x]) for x in lps_a)
-        )
-    )
+def _assert_requested_logprobs(
+    tokens: list[int],
+    scores: list[dict[int, Logprob] | None] | None,
+    requested: int | None,
+):
+    # A comparison must not pass because both engines omitted requested scores.
+    if requested is None:
+        assert scores is None
+        return
+    assert scores is not None and len(scores) == len(tokens)
+    for token, token_scores in zip(tokens, scores, strict=True):
+        assert token_scores is not None and token in token_scores
+        assert max(1, requested) <= len(token_scores) <= requested + 1
+
+
+def _assert_logprobs_match(req_a, req_b) -> None:
+    assert len(req_a) == len(req_b), "logprob request count differs"
+    for request, (seq_a, seq_b) in enumerate(zip(req_a, req_b, strict=True)):
+        assert len(seq_a) == len(seq_b), f"request {request}: score count differs"
+        for position, (lps_a, lps_b) in enumerate(zip(seq_a, seq_b, strict=True)):
+            context = f"request {request}, score position {position}"
+            if lps_a is None or lps_b is None:
+                assert lps_a is lps_b, context
+                continue
+            assert lps_a.keys() == lps_b.keys(), (
+                f"{context}: token sets differ: {lps_a.keys()} != {lps_b.keys()}"
+            )
+            for token, a in lps_a.items():
+                b = lps_b[token]
+                detail = f"{context}, token {token}: baseline={a}, candidate={b}"
+                assert a.decoded_token == b.decoded_token, detail
+                assert a.rank == pytest.approx(b.rank, rel=0.005), detail
+                assert a.logprob == pytest.approx(b.logprob, rel=1e-3, abs=1e-6), detail
 
 
 def _get_acceptance_rate(before: list[Metric], after: list[Metric]) -> float:

--- a/tests/v1/spec_decode/test_mtp_structured_output.py
+++ b/tests/v1/spec_decode/test_mtp_structured_output.py
@@ -68,7 +68,7 @@ def test_bitmask_with_padded_invalid_drafts(backend):
     )
 
     assert bitmask is not None
-    assert bitmask.shape[0] == len(padded) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     assert not grammar.is_terminated()
 
 
@@ -139,7 +139,7 @@ def test_bonus_position_constrained_after_invalid_drafts(backend):
         scheduled_spec_decode_tokens={request.request_id: drafts},
     )
     assert bitmask is not None
-    assert bitmask.shape[0] == len(drafts) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
 
     assert not (bitmask[-1] == -1).all()
     assert not grammar.is_terminated()
@@ -180,11 +180,11 @@ def test_bitmask_constrained_when_reasoning_ends_midwindow(backend):
     )
 
     assert bitmask is not None
-    assert bitmask.shape[0] == len(drafts) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     assert (bitmask[0] == -1).all()
     assert (bitmask[1] == -1).all()
     assert not (bitmask[2] == -1).all()
-    assert not (bitmask[-1] == -1).all()
+    assert not (bitmask[len(drafts)] == -1).all()
     assert not grammar.is_terminated()
 
 
@@ -230,7 +230,7 @@ def test_bitmask_post_reasoning_end_drafts_skip_grammar_advance(backend, caplog)
     )
 
     assert bitmask is not None
-    assert bitmask.shape[0] == len(drafts) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     # Post-marker position is still bitmask-constrained.
     assert not (bitmask[2] == -1).all()
     # Grammar must not have advanced through the unvalidated draft.
@@ -259,7 +259,7 @@ def test_validate_tokens_then_bitmask_round_trip(backend):
         scheduled_spec_decode_tokens={request.request_id: padded},
     )
     assert bitmask is not None
-    assert bitmask.shape[0] == len(padded) + 1
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
     assert not grammar.is_terminated()
 
 

--- a/tests/v1/worker/test_gpu_batch_shard.py
+++ b/tests/v1/worker/test_gpu_batch_shard.py
@@ -21,6 +21,7 @@ from vllm.v1.worker.gpu.sample.batch_shard import (
     BatchSharder,
     _shard_grammar_output,
 )
+from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 
 DEVICE = "cuda"
 
@@ -278,14 +279,25 @@ def test_shard_no_spec():
 
 
 @pytest.mark.parametrize("tp_size", [2, 4])
-def test_shard_grammar_output(tp_size: int):
+@pytest.mark.parametrize("device", ["cpu", pytest.param("cuda", marks=requires_cuda)])
+@pytest.mark.parametrize(
+    ("num_speculative_tokens", "draft_mode"),
+    [(0, "none"), (3, "mixed"), (3, "none"), (3, "full")],
+)
+def test_shard_grammar_output(
+    tp_size: int, device: str, num_speculative_tokens: int, draft_mode: str
+):
     """The grammar filter keeps exactly the owned requests' bitmask rows, in
     grammar order, and the per-rank pieces partition the global bitmask."""
     rng = np.random.default_rng(5)
     max_num_reqs = 32
     num_reqs = 12
     slots = rng.choice(np.arange(max_num_reqs), size=num_reqs, replace=False)
-    k = rng.integers(0, 4, size=num_reqs)
+    k = rng.integers(0, num_speculative_tokens + 1, size=num_reqs)
+    if draft_mode == "none":
+        k.fill(0)
+    elif draft_mode == "full":
+        k.fill(num_speculative_tokens)
     cu = np.zeros(num_reqs + 1, dtype=np.int32)
     np.cumsum(1 + k, out=cu[1:])
     owner = slots % tp_size
@@ -294,7 +306,9 @@ def test_shard_grammar_output(tp_size: int):
     req_ids = [f"req-{i}" for i in range(num_reqs)]
     grammar_idx = list(rng.permutation(np.arange(0, num_reqs, 2)))
     grammar_req_ids = [req_ids[i] for i in grammar_idx]
-    num_grammar_rows = sum(int(cu[i + 1] - cu[i]) for i in grammar_idx)
+    # Prefill and shortened drafts still own a full block of grammar masks.
+    mask_stride = num_speculative_tokens + 1
+    num_grammar_rows = len(grammar_idx) * mask_stride
     bitmask = rng.integers(0, 2**31, size=(num_grammar_rows, 4), dtype=np.int32)
     input_batch = SimpleNamespace(req_ids=req_ids, cu_num_logits_np=cu)
 
@@ -303,11 +317,23 @@ def test_shard_grammar_output(tp_size: int):
     cursor = 0
     for i in grammar_idx:
         row_offsets[i] = cursor
-        cursor += int(cu[i + 1] - cu[i])
+        cursor += mask_stride
 
     grammar_output = GrammarOutput(
         structured_output_request_ids=grammar_req_ids,
         grammar_bitmask=bitmask,
+    )
+    vocab_size = 113  # Include a partial packed word and kernel vocabulary tile.
+    worker = (
+        StructuredOutputsWorker(
+            max_num_logits=num_reqs * mask_stride,
+            vocab_size=vocab_size,
+            device=torch.device(device),
+            mask_stride=mask_stride,
+            num_bonus_tokens=1,
+        )
+        if device == "cuda"
+        else None
     )
 
     kept_total = 0
@@ -320,15 +346,46 @@ def test_shard_grammar_output(tp_size: int):
             continue
         assert local is not None
         assert local.structured_output_request_ids == [req_ids[i] for i in expected_idx]
+        assert local.grammar_bitmask.shape == (len(expected_idx) * mask_stride, 4)
         expected_rows = np.concatenate(
             [
-                np.arange(row_offsets[i], row_offsets[i] + cu[i + 1] - cu[i])
+                np.arange(row_offsets[i], row_offsets[i] + mask_stride)
                 for i in expected_idx
             ]
         )
         assert (local.grammar_bitmask == bitmask[expected_rows.astype(int)]).all()
         kept_total += local.grammar_bitmask.shape[0]
+        if worker is not None:
+            local_indices = [req_ids.index(req_id) for req_id in local_req_ids]
+            local_counts = np.array([1 + k[i] for i in local_indices], dtype=np.int32)
+            local_cu = np.zeros(len(local_req_ids) + 1, dtype=np.int32)
+            np.cumsum(local_counts, out=local_cu[1:])
+            expected = torch.arange(int(local_cu[-1]) * vocab_size, dtype=torch.float32)
+            expected = expected.reshape(-1, vocab_size)
+            logits = expected.to(device)
+            for local_idx, global_idx in enumerate(local_indices):
+                if global_idx not in row_offsets:
+                    continue
+                for position in range(local_counts[local_idx]):
+                    packed = bitmask[row_offsets[global_idx] + position]
+                    vocab = np.arange(vocab_size)
+                    disallowed = ((packed[vocab // 32] >> (vocab % 32)) & 1) == 0
+                    expected[local_cu[local_idx] + position, disallowed] = -float("inf")
+            local_batch = SimpleNamespace(
+                req_ids=local_req_ids,
+                cu_num_logits=torch.from_numpy(local_cu).to(device),
+            )
+            worker.apply_grammar_bitmask(
+                logits,
+                local_batch,
+                local.structured_output_request_ids,
+                local.grammar_bitmask,
+            )
+            torch.testing.assert_close(logits.cpu(), expected, rtol=0, atol=0)
     assert kept_total == num_grammar_rows
+    assert _shard_grammar_output(grammar_output, input_batch, []) is None
+    non_grammar_ids = [req_id for req_id in req_ids if req_id not in grammar_req_ids]
+    assert _shard_grammar_output(grammar_output, input_batch, non_grammar_ids) is None
 
 
 @requires_cuda

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -377,6 +377,62 @@ def test_swap_states_in_input_batch(device: str, batch_size: int, swap_list: lis
     _compare_objs(input_batch, ref_input_batch)
 
 
+@pytest.mark.parametrize("device", ["cpu", *DEVICES])
+def test_condense_clears_stale_allowed_token_ids_mask(device: str):
+    """condense() must clear the mask row a constrained request is moved out
+    of. Otherwise a later request that reuses that row without
+    allowed_token_ids inherits the stale whitelist.
+    See https://github.com/vllm-project/vllm/issues/43894.
+    """
+    batch_size = 4
+    allowed_token_id = 13
+    input_batch = InputBatch(
+        max_num_reqs=batch_size,
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+        device=torch.device(device),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[1],
+        kernel_block_sizes=[1],
+        max_num_blocks_per_req=[1024],
+    )
+
+    def _make_req(suffix: int, allowed_token_ids=None) -> CachedRequestState:
+        return CachedRequestState(
+            req_id=f"req_id_{suffix}",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(allowed_token_ids=allowed_token_ids),
+            pooling_params=None,
+            mm_features=[],
+            block_ids=([],),
+            generator=None,
+            num_computed_tokens=0,
+            output_token_ids=[],
+        )
+
+    # Only req_id_2 is constrained, and it lands on the highest row.
+    assert input_batch.add_request(_make_req(0)) == 0
+    assert input_batch.add_request(_make_req(1)) == 1
+    assert input_batch.add_request(_make_req(2, [allowed_token_id])) == 2
+
+    mask = input_batch.allowed_token_ids_mask_cpu_tensor
+    assert mask is not None
+    # The constrained row masks every token except the single allowed id.
+    assert not mask[2][allowed_token_id].item()
+    assert int(mask[2].sum().item()) == VOCAB_SIZE - 1
+
+    # Free row 0, then condense: req_id_2 slides from row 2 down into row 0.
+    input_batch.remove_request("req_id_0")
+    input_batch.condense()
+    assert input_batch.req_id_to_index["req_id_2"] == 0
+    assert int(mask[2].sum().item()) == 0
+
+    # A new unrestricted request reuses row 2 and must stay unconstrained.
+    assert input_batch.add_request(_make_req(3)) == 2
+    assert "req_id_3" not in input_batch.has_allowed_token_ids
+    assert int(mask[2].sum().item()) == 0
+
+
 def _construct_pooling_request(req_id_suffix: int, pooling_params=None):
     from vllm.pooling_params import PoolingParams
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -229,6 +229,8 @@ class StructuredOutputManager:
 
         # Covers both speculative decoding and diffusion LLMs (canvas_length).
         max_num_spec_tokens = self.vllm_config.num_speculative_tokens
+        num_bonus_tokens = 0 if self.vllm_config.model_config.is_diffusion else 1
+        max_masks_per_req = max_num_spec_tokens + num_bonus_tokens
 
         if self._grammar_bitmask is None:
             assert self.backend is not None
@@ -238,14 +240,14 @@ class StructuredOutputManager:
             # one for each speculative position, and one more for the
             # bonus token / non-speculative token.
             self._grammar_bitmask = self.backend.allocate_token_bitmask(
-                max_batch_size * (1 + max_num_spec_tokens)
+                max_batch_size * max_masks_per_req
             )
 
         # Generate a batched bitmask for all structured output requests.
         # When speculative decoding is enabled, we need to include multiple
         # masks for each request, one for each possible bonus token position.
-        # These are stored inline in the tensor and unpacked by the gpu runner.
-        cumulative_index = 0
+        # Each request owns a fixed-width block so the GPU can use the actual
+        # per-request logit counts without CPU-side mask compaction.
 
         # Optimized parallel filling of bitmasks for
         # non-spec, large-batch-size cases
@@ -255,7 +257,7 @@ class StructuredOutputManager:
         ):
             promises = []
             batch = []
-            for req_id in structured_output_request_ids:
+            for grammar_idx, req_id in enumerate(structured_output_request_ids):
                 request = requests[req_id]
                 structured_output_request = request.structured_output_request
                 if TYPE_CHECKING:
@@ -265,12 +267,10 @@ class StructuredOutputManager:
                     assert isinstance(grammar, StructuredOutputGrammar)
 
                 apply_bitmask = self.should_fill_bitmask(request)
-                batch.append((grammar, cumulative_index, apply_bitmask))
+                batch.append((grammar, grammar_idx * max_masks_per_req, apply_bitmask))
                 if len(batch) == self.fill_bitmask_parallel_batch_size:
                     promises.append(self._async_submit_fill_bitmask(batch))
                     batch = []
-
-                cumulative_index += 1
             if batch:
                 promises.append(self._async_submit_fill_bitmask(batch))
 
@@ -279,7 +279,7 @@ class StructuredOutputManager:
                 promise.result()
         else:
             # Fallback to serial filling of bitmasks for small-batch-size cases
-            for req_id in structured_output_request_ids:
+            for grammar_idx, req_id in enumerate(structured_output_request_ids):
                 request = requests[req_id]
                 structured_output_request = request.structured_output_request
 
@@ -298,8 +298,9 @@ class StructuredOutputManager:
                 state_advancements = 0
                 post_reasoning_end_in_window = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
+                bitmask_index = grammar_idx * max_masks_per_req
                 for i, token in enumerate(req_tokens):
-                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                    self._fill_bitmasks(((grammar, bitmask_index + i, apply_bitmask),))
                     advance_grammar = apply_bitmask
                     if token == -1:
                         apply_bitmask = False
@@ -338,10 +339,9 @@ class StructuredOutputManager:
                             raise AssertionError(
                                 (token, req_id, scheduled_spec_decode_tokens)
                             )
-                    cumulative_index += 1
                 # Diffusion LLMs don't sample a bonus token after the
                 # scheduled positions, so skip its bitmask in that case.
-                if not (self.vllm_config.model_config.is_diffusion and req_tokens):
+                if num_bonus_tokens or not req_tokens:
                     # bonus_apply must be True when the bonus-row position
                     # should be grammar-constrained. Two triggers:
                     # - should_fill_bitmask(request): reasoning was already
@@ -353,14 +353,16 @@ class StructuredOutputManager:
                     #   reasoning_ended is only persisted later by
                     #   should_advance.
                     bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
-                    self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
-                    cumulative_index += 1
+                    self._fill_bitmasks(
+                        ((grammar, bitmask_index + len(req_tokens), bonus_apply),)
+                    )
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)
 
         bitmask_tensor = self._grammar_bitmask
-        if cumulative_index < bitmask_tensor.shape[0]:
-            bitmask_tensor = bitmask_tensor[:cumulative_index]
+        num_masks = len(structured_output_request_ids) * max_masks_per_req
+        if num_masks < bitmask_tensor.shape[0]:
+            bitmask_tensor = bitmask_tensor[:num_masks]
 
         # After finishing with the xgrammar operations, we convert to
         # np.ndarray, because that is much more efficient for serialization

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -102,8 +102,7 @@ def apply_grammar_bitmask(
     # so we receive it in that format.
     grammar_bitmask = grammar_output.grammar_bitmask
 
-    # We receive the structured output bitmask from the scheduler,
-    # compacted to contain bitmasks only for structured output requests.
+    # We receive fixed-width mask blocks only for structured output requests.
     # The order of the requests in the bitmask is not guaranteed to be the
     # same as the order of the requests in the gpu runner's batch. We need
     # to sort the bitmask to match the order of the requests used here.
@@ -131,15 +130,17 @@ def apply_grammar_bitmask(
         pin_memory=PIN_MEMORY,
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
-    cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
+    num_structured_reqs = len(grammar_output.structured_output_request_ids)
+    assert grammar_bitmask.shape[0] % num_structured_reqs == 0
+    mask_stride = grammar_bitmask.shape[0] // num_structured_reqs
+    for grammar_idx, req_id in enumerate(grammar_output.structured_output_request_ids):
         num_spec_tokens = len(spec_tokens.get(req_id, ()))
         if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
             for i in range(1 + num_spec_tokens):
                 bitmask_index = logit_idx + i
-                sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
+                source_index = grammar_idx * mask_stride + i
+                sorted_bitmask[bitmask_index] = grammar_bitmask[source_index]
                 out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)

--- a/vllm/v1/worker/gpu/sample/batch_shard.py
+++ b/vllm/v1/worker/gpu/sample/batch_shard.py
@@ -320,19 +320,19 @@ def _shard_grammar_output(
     local_req_ids: list[str],
 ) -> GrammarOutput | None:
     owned = set(local_req_ids)
-    req_id_to_idx = {req_id: i for i, req_id in enumerate(input_batch.req_ids)}
-    cu_num_logits_np = input_batch.cu_num_logits_np
+    grammar_req_ids = grammar_output.structured_output_request_ids
+    if not grammar_req_ids:
+        return None
+    assert grammar_output.grammar_bitmask.shape[0] % len(grammar_req_ids) == 0
+    mask_stride = grammar_output.grammar_bitmask.shape[0] // len(grammar_req_ids)
 
     local_ids: list[str] = []
     keep_indices: list[int] = []
-    cursor = 0
-    for req_id in grammar_output.structured_output_request_ids:
-        req_idx = req_id_to_idx[req_id]
-        num_req_logits = int(cu_num_logits_np[req_idx + 1] - cu_num_logits_np[req_idx])
+    for grammar_idx, req_id in enumerate(grammar_req_ids):
         if req_id in owned:
             local_ids.append(req_id)
-            keep_indices.extend(range(cursor, cursor + num_req_logits))
-        cursor += num_req_logits
+            start = grammar_idx * mask_stride
+            keep_indices.extend(range(start, start + mask_stride))
     if not local_ids:
         return None
     return GrammarOutput(

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -66,47 +66,40 @@ class StructuredOutputsWorker:
         if not grammar_req_ids:
             return
 
+        num_grammar_reqs = len(grammar_req_ids)
+        assert grammar_bitmask.shape[0] == num_grammar_reqs * self.mask_stride
+
         # Asynchronously copy the bitmask to GPU.
         with torch.cuda.stream(self.copy_stream):
             bitmask = async_copy_to_gpu(
                 grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
             )
 
-        # Construct bitmask -> logits mapping
-        # Key by (request, position) rather than absolute logit index:
-        # adaptive verification finalizes per-request logit offsets on
-        # device, so the kernel resolves them from the GPU cu_num_logits.
-        mapping = _build_grammar_mapping(
-            input_batch.req_ids,
-            grammar_req_ids,
-            input_batch.cu_num_logits_np,
-            input_batch.num_draft_tokens_per_req,
-            self.num_bonus_tokens,
-            self.mask_stride,
-        )
+        req_id_to_idx = {
+            req_id: req_idx for req_idx, req_id in enumerate(input_batch.req_ids)
+        }
+        req_indices = [req_id_to_idx[req_id] for req_id in grammar_req_ids]
 
-        # Asynchronously copy the mapping to GPU.
+        # Asynchronously copy the request indices to GPU.
         with torch.cuda.stream(self.copy_stream):
-            logits_indices = torch.tensor(
-                mapping, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
+            req_indices_tensor = torch.tensor(
+                req_indices, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
             )
-            logits_indices = self.logits_indices[: len(mapping)].copy_(
-                logits_indices, non_blocking=True
+            req_indices_tensor = self.logits_indices[:num_grammar_reqs].copy_(
+                req_indices_tensor, non_blocking=True
             )
 
         # Ensure all async copies are complete before launching the kernel.
         current_stream = torch.cuda.current_stream()
         current_stream.wait_stream(self.copy_stream)
 
-        num_masks = bitmask.shape[0]
-        assert num_masks == len(mapping)
         vocab_size = logits.shape[-1]
         BLOCK_SIZE = 8192
-        grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))
+        grid = (num_grammar_reqs, triton.cdiv(vocab_size, BLOCK_SIZE))
         _apply_grammar_bitmask_kernel[grid](
             logits,
             logits.stride(0),
-            logits_indices,
+            req_indices_tensor,
             input_batch.cu_num_logits,
             bitmask,
             bitmask.stride(0),
@@ -126,7 +119,7 @@ class StructuredOutputsWorker:
 def _apply_grammar_bitmask_kernel(
     logits_ptr,
     logits_stride,
-    logits_indices_ptr,
+    req_indices_ptr,
     cu_num_logits_ptr,
     bitmask_ptr,
     bitmask_stride,
@@ -134,30 +127,28 @@ def _apply_grammar_bitmask_kernel(
     MASK_STRIDE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    bitmask_idx = tl.program_id(0)
-    mapping_idx = tl.load(logits_indices_ptr + bitmask_idx)
-    req_idx = mapping_idx // MASK_STRIDE
-    position_idx = mapping_idx % MASK_STRIDE
-    logits_idx = tl.load(cu_num_logits_ptr + req_idx)
-    num_req_logits = tl.load(cu_num_logits_ptr + req_idx + 1) - logits_idx
-    logits_idx += position_idx
-    position_is_active = position_idx < num_req_logits
+    grammar_idx = tl.program_id(0)
+    req_idx = tl.load(req_indices_ptr + grammar_idx)
+    logits_start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    num_req_logits = tl.load(cu_num_logits_ptr + req_idx + 1) - logits_start_idx
 
-    # Load the bitmask.
     block_id = tl.program_id(1)
     bitmask_offset = (block_id * BLOCK_SIZE) // 32 + tl.arange(0, BLOCK_SIZE // 32)
-    packed_bitmask = tl.load(
-        bitmask_ptr + bitmask_idx * bitmask_stride + bitmask_offset,
-        mask=bitmask_offset < bitmask_stride,
-    )
-    # Unpack the bitmask.
-    bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
-    bitmask = bitmask.reshape(BLOCK_SIZE)
-
-    # Apply the bitmask to the logits.
     block_offset = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    tl.store(
-        logits_ptr + logits_idx * logits_stride + block_offset,
-        -float("inf"),
-        mask=position_is_active & bitmask & (block_offset < vocab_size),
-    )
+    for position_idx in range(MASK_STRIDE):
+        position_is_active = position_idx < num_req_logits
+        bitmask_idx = grammar_idx * MASK_STRIDE + position_idx
+        packed_bitmask = tl.load(
+            bitmask_ptr + bitmask_idx * bitmask_stride + bitmask_offset,
+            mask=position_is_active & (bitmask_offset < bitmask_stride),
+            other=0,
+        )
+        bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
+        bitmask = bitmask.reshape(BLOCK_SIZE)
+
+        logits_idx = logits_start_idx + position_idx
+        tl.store(
+            logits_ptr + logits_idx * logits_stride + block_offset,
+            -float("inf"),
+            mask=(position_is_active & bitmask & (block_offset < vocab_size)),
+        )

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -354,10 +354,13 @@ def _warmup_kernels(
             vocab_size = model_runner.model_config.get_vocab_size()
             bitmask_width = (vocab_size + 31) // 32
             grammar_bitmask = np.full(
-                (len(req_ids), bitmask_width), fill_value=-1, dtype=np.int32
+                (len(req_ids) * model_runner.decode_query_len, bitmask_width),
+                fill_value=-1,
+                dtype=np.int32,
             )
             grammar_output = GrammarOutput(
-                structured_output_request_ids=req_ids, grammar_bitmask=grammar_bitmask
+                structured_output_request_ids=req_ids,
+                grammar_bitmask=grammar_bitmask,
             )
 
         worker_sample_tokens(grammar_output)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -822,6 +822,10 @@ class InputBatch:
                 self.allowed_token_ids_mask_cpu_tensor[empty_index] = (
                     self.allowed_token_ids_mask_cpu_tensor[last_req_index]
                 )
+                # Clear the vacated source row so a later request that reuses
+                # this index without allowed_token_ids does not inherit the
+                # stale mask. False means we don't fill with -inf.
+                self.allowed_token_ids_mask_cpu_tensor[last_req_index].fill_(False)
 
             bad_words_token_ids = self.bad_words_token_ids.pop(last_req_index, None)
             if bad_words_token_ids is not None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- Strengthen async scheduling accuracy checks by validating that requested prompt and completion logprobs are present, align with tokens, and contain the requested entries; two engines omitting the same scores can no longer pass together.
- Preserve every original configuration, sampling combination, prompt, repeated batch, target-only reference, preemption assertion, and acceptance-rate check. Keep exact token/text comparisons and logprob tolerances of `rel=1e-3, abs=1e-6`, with request/position/token diagnostics and strict result-length checks.
- Remove the ROCm ngram flaky-rerun decorator and the redundant parent-process Dynamo-limit patch. Retain the Flex/FP32/`highest` numerical fixture and original platform filters and prefix-cache settings; Flex still sets its own recompilation limit.
- Include an adapted copy of the open [PR #52477](https://github.com/vllm-project/vllm/pull/52477) with original attribution: use fixed per-request grammar-mask strides across the scheduler, both GPU runners, and warmup so shortened draft windows cannot shift another request's mask. Add the missing integration with batch-sharded sampling by retaining whole request blocks, with exact CPU mask and GPU logit comparisons; preserve all existing structured-output cases and logical bonus-row checks.
- Include the open [PR #43931](https://github.com/vllm-project/vllm/pull/43931) with original attribution: clear the mask row vacated by `InputBatch.condense()` so a later unrestricted request cannot inherit an earlier whitelist; adapt its regression to current constructor arguments and CPU/GPU coverage.
- Prior-base stability validation, before rebasing onto current `main`: run each complete changed test file forty times in fresh `.venv/bin/python -m pytest -v -s --tb=long` processes: `tests/v1/e2e/general/test_async_scheduling.py` (3 cases/run), `tests/v1/spec_decode/test_mtp_structured_output.py` (18), `tests/v1/worker/test_gpu_input_batch.py` (18, with two GPUs visible), and `tests/v1/worker/test_gpu_batch_shard.py` (31). The previous base passed all 160 invocations and 2,800 cases on MI300X, with zero failures, skips, or retries and unchanged source hashes; the additional run after rebasing was cancelled before scheduling completed and is not counted as a completed qualification.
- Prior-base accuracy validation: the forty scheduling runs completed all 5,040 original ROCm batches, 171,360 requests, and 4,480 baseline comparisons. Independent pytest/XML/log audits verified every case passed forty times and every batch completed all 34 requests; all pre-commit hooks passed. Before the sharding integration fix, four of eight CPU cases failed; afterward, all sixteen CPU/GPU mask cases passed with exact logit comparisons.
- Target `main` with one commit containing our contributions, based on fetched main tip `6c73b08dec2af5052288169663549687ba61f330`. AI assistance was used for investigation, implementation, and this description. The two open upstream fixes are included integration dependencies, with their original authors credited; the new work is the stronger accuracy checks and fixed-stride sharding integration, for which duplicate searches found no matching implementation.

The investigation began with [Buildkite build 12676's MI250 failure](https://buildkite.com/vllm/amd-ci/builds/12676/list?tab=output&jid=01a07b43-0202-4af8-ad76-abab5085071e#L1984), where EAGLE3 exhausted Flex's 16-variant recompilation limit during structured-output generation. The test explicitly selects Flex for FP32 accuracy, and automatic ROCm backend probes failed the original token or logprob comparisons. We therefore retained those numerical controls and restored the full original scenario matrix after an initial rewrite weakened accuracy coverage. Mixed-request probes uncovered grammar-stride and stale-whitelist defects covered by existing upstream fixes, and integration review found the additional sharding mismatch. The [separate installation failure](https://buildkite.com/vllm/amd-ci/builds/12676/list?sid=01a07b43-0113-46e2-bc4c-494c4f754458&tab=output) came from `apt autoremove` removing `libdw1` before Torch imported; its image repair and the original MI250 compiler failure remain unresolved. All four changed test files passed forty full-file runs on MI300X before the main rebase; the rebased version passed collection and repeated unit runs but has no completed full scheduling run, and MI250 remains unverified.
