### PR TITLE
[Bugfix][CPU] Reject unavailable WNA16 operator

### DIFF
--- a/tests/kernels/quantization/test_cpu_wna16_kernel_selection.py
+++ b/tests/kernels/quantization/test_cpu_wna16_kernel_selection.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for CPU WNA16 kernel selection guards."""
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear import MPLinearLayerConfig
+from vllm.model_executor.kernels.linear.mixed_precision import (
+    CPUWNA16LinearKernel,
+)
+from vllm.model_executor.kernels.linear.mixed_precision import cpu as cpu_kernel
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+pytestmark = pytest.mark.cpu_test
+
+if not current_platform.is_cpu():
+    pytest.skip("CPU-only tests", allow_module_level=True)
+
+
+def _config() -> MPLinearLayerConfig:
+    return MPLinearLayerConfig(
+        full_weight_shape=(4096, 4096),
+        partition_weight_shape=(4096, 4096),
+        weight_type=scalar_types.uint4b8,
+        act_type=torch.bfloat16,
+        group_size=128,
+        zero_points=False,
+        has_g_idx=False,
+    )
+
+
+def test_cpu_wna16_rejects_unregistered_operator(monkeypatch):
+    monkeypatch.setattr(cpu_kernel, "_has_cpu_gemm_wna16", lambda: False)
+
+    can_implement, reason = CPUWNA16LinearKernel.can_implement(_config())
+
+    assert not can_implement
+    assert reason == (
+        "torch.ops._C.cpu_gemm_wna16 is not registered; CPU WNA16 "
+        "requires a build with WNA16 CPU support"
+    )
+
+
+def test_cpu_wna16_accepts_registered_operator(monkeypatch):
+    monkeypatch.setattr(cpu_kernel, "_has_cpu_gemm_wna16", lambda: True)
+
+    can_implement, reason = CPUWNA16LinearKernel.can_implement(_config())
+
+    assert can_implement
+    assert reason is None

--- a/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
@@ -17,6 +17,10 @@ from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 _CPUWNA16_SUPPORTED_QUANT_TYPES = (scalar_types.uint4, scalar_types.uint4b8)
 
 
+def _has_cpu_gemm_wna16() -> bool:
+    return hasattr(getattr(torch.ops, "_C", None), "cpu_gemm_wna16")
+
+
 class CPUWNA16LinearKernel(MPLinearKernel):
     @classmethod
     def get_min_capability(cls) -> int:
@@ -27,33 +31,50 @@ class CPUWNA16LinearKernel(MPLinearKernel):
         if not current_platform.is_cpu():
             return False, "CPUWNA16 only supported on CPU"
 
+        if not _has_cpu_gemm_wna16():
+            return (
+                False,
+                (
+                    "torch.ops._C.cpu_gemm_wna16 is not registered; CPU WNA16 "
+                    "requires a build with WNA16 CPU support"
+                ),
+            )
+
         if c.weight_type not in _CPUWNA16_SUPPORTED_QUANT_TYPES:
             return (
                 False,
-                f"Quant type ({c.weight_type}) not supported by "
-                "CPUWNA16, supported types are: "
-                f"{_CPUWNA16_SUPPORTED_QUANT_TYPES}",
+                (
+                    f"Quant type ({c.weight_type}) not supported by "
+                    "CPUWNA16, supported types are: "
+                    f"{_CPUWNA16_SUPPORTED_QUANT_TYPES}"
+                ),
             )
 
         if c.group_size != -1 and c.group_size % 2 != 0:
             return (
                 False,
-                f"Group size ({c.group_size}) not supported by "
-                "CPUWNA16, supported group sizes are multiples of 2",
+                (
+                    f"Group size ({c.group_size}) not supported by "
+                    "CPUWNA16, supported group sizes are multiples of 2"
+                ),
             )
 
         if c.partition_weight_shape[0] % 32 != 0:
             return (
                 False,
-                f"Input size ({c.partition_weight_shape[0]}) not supported by "
-                "CPUWNA16, supported sizes are multiples of 32",
+                (
+                    f"Input size ({c.partition_weight_shape[0]}) not supported by "
+                    "CPUWNA16, supported sizes are multiples of 32"
+                ),
             )
 
         if c.partition_weight_shape[1] % 32 != 0:
             return (
                 False,
-                f"Output size ({c.partition_weight_shape[1]}) not supported by "
-                "CPUWNA16, supported sizes are multiples of 32",
+                (
+                    f"Output size ({c.partition_weight_shape[1]}) not supported by "
+                    "CPUWNA16, supported sizes are multiples of 32"
+                ),
             )
 
         return True, None


### PR DESCRIPTION
## Summary

Fixes #55613.

On CPU builds where the compiled `torch.ops._C.cpu_gemm_wna16` operator is not registered, reject `CPUWNA16LinearKernel` during kernel selection with a clear reason instead of allowing execution to fail later with an opaque `AttributeError`. This covers the current AVX2-only behavior; it does not claim to add a portable AVX2 WNA16 implementation.

## Changes

- Check the registered PyTorch custom op before accepting the CPU WNA16 kernel.
- Add CPU-only unit coverage for both registered and missing operator states.

## Duplicate check

Checked issue #55613 and searched open vLLM PRs for `55613`; no open PR was found for this issue. The change is limited to the first requested item in the issue.

## Validation

Passed:

- `uvx ruff check vllm/model_executor/kernels/linear/mixed_precision/cpu.py tests/kernels/quantization/test_cpu_wna16_kernel_selection.py`
- `uvx ruff format --check vllm/model_executor/kernels/linear/mixed_precision/cpu.py tests/kernels/quantization/test_cpu_wna16_kernel_selection.py`
- `.venv/bin/python -m compileall -q vllm/model_executor/kernels/linear/mixed_precision/cpu.py tests/kernels/quantization/test_cpu_wna16_kernel_selection.py`
- `git diff --check`

Not run: pytest, because the local Mac mini environment has neither `pytest` nor `torch` installed in `.venv`. GPU/AVX2 runtime validation was not available in this environment.

AI assistance was used to investigate, implement, and validate this change. Please have a human reviewer inspect all changed code and test assumptions before merging.