### PR TITLE
[Docs] Use HF architecture key NVLM_D in supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -600,7 +600,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `MossTranscribeDiarizeForConditionalGeneration` | MOSS-Transcribe-Diarize | T + A | `OpenMOSS-Team/MOSS-Transcribe-Diarize` | | ✅︎ |
 | `Moondream3ForCausalLM` | Moondream3 | T + I | `moondream/moondream3-preview` | | ✅︎ |
 | `MuseGlimmerForCausalLM`, `MuseGlimmerForConditionalGeneration` | Muse Glimmer | T + I<sup>+</sup> + V<sup>+</sup> | `meta-models/Muse-Glimmer-30B` | ✅︎ | ✅︎ |
-| `NVLM_D_Model` | NVLM-D 1.0 | T + I<sup>+</sup> | `nvidia/NVLM-D-72B`, etc. | | ✅︎ |
+| `NVLM_D` | NVLM-D 1.0 | T + I<sup>+</sup> | `nvidia/NVLM-D-72B`, etc. | | ✅︎ |
 | `OpenCUAForConditionalGeneration` | OpenCUA-7B | T + I<sup>E+</sup> | `xlangai/OpenCUA-7B` | ✅︎ | ✅︎ |
 | `OpenPanguVLForConditionalGeneration` | openpangu-VL | T + I<sup>E+</sup> + V<sup>E+</sup> | `FreedomIntelligence/openPangu-VL-7B` | ✅︎ | ✅︎ |
 | `OpenVLAForActionPrediction` | OpenVLA | T + I | `openvla/openvla-7b` | | ✅︎ |


### PR DESCRIPTION
## Summary

The Architecture column is documented as matching Hugging Face `config.json` `"architectures"` / vLLM registry keys. The NVLM-D multimodal row listed the implementation class `NVLM_D_Model` instead of the HF/registry key `NVLM_D`.

| Was (impl class) | Should be (HF/registry key) |
|---|---|
| `NVLM_D_Model` | `NVLM_D` |

## Repro

```bash
SHA=9ea8f3ffc354901b740f0b31988900897b7221d7

# Registry key is NVLM_D; class is NVLM_D_Model
curl -sL "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/vllm/model_executor/models/registry.py" \
  | rg 'NVLM_D'
# "NVLM_D": ("nvlm_d", "NVLM_D_Model"),

# HF architectures field
curl -sL "https://huggingface.co/nvidia/NVLM-D-72B/raw/main/config.json" \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['architectures'])"
# ['NVLM_D']

# Docs (before) listed the class name
curl -sL "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/docs/models/supported_models.md" \
  | rg 'NVLM'
# | `NVLM_D_Model` | NVLM-D 1.0 | ...
```

## Test plan

- [ ] Confirm Architecture row shows `NVLM_D`
- [ ] Confirm no other rows changed