### PR TITLE
[Core] Size the KV cache from this process's own device memory, not the device-wide delta

### DIFF
--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import multiprocessing as mp
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from vllm_test_utils.monitor import monitor
 
+from vllm.platforms import current_platform
 from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
 
 from ..utils import create_new_process_for_each_test
@@ -148,3 +151,121 @@ def test_memory_snapshot_uses_cuda_on_discrete_gpu():
         assert snapshot.free_memory == mock_cuda_free
         assert snapshot.total_memory == mock_cuda_total
         mock_psutil.virtual_memory.assert_not_called()
+
+
+def _mock_measurements(mock_platform, mock_accelerator, free_values, process_values):
+    """Feed one (free memory, process memory) pair per MemorySnapshot.measure()."""
+    total = 80 * 1024**3
+    mock_accelerator.get_memory_info.side_effect = [(f, total) for f in free_values]
+    mock_accelerator.memory_stats.return_value = {
+        "allocated_bytes.all.peak": 0,
+        "allocated_bytes.all.current": 0,
+    }
+    mock_accelerator.memory_reserved.return_value = 0
+    mock_accelerator.current_device = lambda: "cuda:0"
+    mock_platform.is_integrated_gpu.return_value = False
+    mock_platform.get_process_memory_usage.side_effect = list(process_values)
+
+
+def test_memory_profiling_uses_process_scoped_consumption():
+    """Another process allocating during load/profile must not be charged
+    to this instance when per-process usage is available."""
+    gib = 1024**3
+    with (
+        patch("vllm.utils.mem_utils.current_platform") as mock_platform,
+        patch("torch.accelerator") as mock_accelerator,
+    ):
+        # baseline -> before_profile -> after_profile:
+        # this process grows 1 GiB then 1 GiB more; another process takes
+        # 2 GiB in the same window, so the device-wide delta is 4 GiB.
+        _mock_measurements(
+            mock_platform,
+            mock_accelerator,
+            free_values=[70 * gib, 69 * gib, 66 * gib],
+            process_values=[1 * gib, 2 * gib, 3 * gib],
+        )
+        baseline = MemorySnapshot(device="cuda:0")
+        with memory_profiling(baseline_snapshot=baseline) as result:
+            pass
+
+    assert baseline.process_memory == 1 * gib
+    assert result.process_scoped
+    assert result.total_consumed == 2 * gib
+    assert result.non_kv_cache_memory == 2 * gib
+
+
+def test_memory_profiling_falls_back_to_device_delta_without_process_usage():
+    gib = 1024**3
+    with (
+        patch("vllm.utils.mem_utils.current_platform") as mock_platform,
+        patch("torch.accelerator") as mock_accelerator,
+    ):
+        _mock_measurements(
+            mock_platform,
+            mock_accelerator,
+            free_values=[70 * gib, 69 * gib, 66 * gib],
+            process_values=[None, None, None],
+        )
+        baseline = MemorySnapshot(device="cuda:0")
+        with memory_profiling(baseline_snapshot=baseline) as result:
+            pass
+
+    assert baseline.process_memory is None
+    assert not result.process_scoped
+    assert result.total_consumed == 4 * gib
+
+
+def test_memory_snapshot_subtraction_keeps_process_memory():
+    a = MemorySnapshot(device="cuda:0", auto_measure=False)
+    b = MemorySnapshot(device="cuda:0", auto_measure=False)
+    a.process_memory, b.process_memory = 5, 2
+    assert (a - b).process_memory == 3
+    b.process_memory = None
+    assert (a - b).process_memory is None
+
+
+def _hold_device_memory(num_bytes: int, ready, release):
+    import torch
+
+    buf = torch.empty(num_bytes, dtype=torch.uint8, device="cuda")
+    torch.cuda.synchronize()
+    ready.set()
+    release.wait()
+    del buf
+
+
+@create_new_process_for_each_test()
+def test_memory_profiling_ignores_other_process_allocations():
+    """End-to-end on a real device: a second process allocates 512 MiB while
+    this one is profiling; total_consumed must only reflect our own 256 MiB."""
+    _warmup = torch.zeros(1, device="cuda")
+    del _warmup
+    torch.accelerator.empty_cache()
+    if current_platform.get_process_memory_usage(torch.cuda.current_device()) is None:
+        pytest.skip("platform cannot report per-process device memory usage")
+
+    baseline_snapshot = MemorySnapshot()
+    weights = torch.randn(64, 1024, 1024, device="cuda", dtype=torch.float32)
+    weights_memory = 64 * 1024 * 1024 * 4  # 256 MiB
+
+    ctx = mp.get_context("spawn")
+    ready, release = ctx.Event(), ctx.Event()
+    other = ctx.Process(
+        target=_hold_device_memory, args=(512 * 1024 * 1024, ready, release)
+    )
+    other.start()
+    try:
+        with memory_profiling(
+            baseline_snapshot=baseline_snapshot, weights_memory=weights_memory
+        ) as result:
+            assert ready.wait(timeout=120), "helper process did not allocate"
+    finally:
+        release.set()
+        other.join(timeout=60)
+
+    assert result.process_scoped
+    ratio = result.total_consumed / weights_memory
+    assert abs(ratio - 1) <= 0.05, (
+        f"total_consumed={result.total_consumed}, expected~{weights_memory}"
+    )
+    del weights

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -818,6 +818,30 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     @with_nvml_context
+    def get_process_memory_usage(cls, device_id: int = 0) -> int | None:
+        """Device memory used by this process on the visible device
+        ``device_id`` as reported by NVML.
+
+        Returns ``None`` whenever NVML cannot attribute memory to this
+        process (no entry for our PID, e.g. a container whose PID namespace
+        NVML does not see, WDDM, MIG, or an NVML error) so that callers fall
+        back to device-level accounting.
+        """
+        try:
+            physical_device_id = cls.visible_device_id_to_physical_device_id(device_id)
+            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+            processes = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
+        except (pynvml.NVMLError, IndexError, ValueError):
+            return None
+        pid = os.getpid()
+        for proc in processes:
+            if proc.pid == pid:
+                used = proc.usedGpuMemory
+                return int(used) if isinstance(used, int) else None
+        return None
+
+    @classmethod
+    @with_nvml_context
     def is_fully_connected(cls, physical_device_ids: list[int]) -> bool:
         """
         query if the set of gpus are fully connected by nvlink (1 hop)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -1037,6 +1037,15 @@ class Platform:
         raise NotImplementedError
 
     @classmethod
+    def get_process_memory_usage(cls, device_id: int = 0) -> int | None:
+        """
+        Return the device memory in bytes used by the current process on the
+        visible device ``device_id``, or ``None`` when the platform cannot
+        attribute device memory to processes.
+        """
+        return None
+
+    @classmethod
     def get_punica_wrapper(cls) -> str:
         """
         Return the punica wrapper for current platform.

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -18,6 +18,10 @@ from .mem_constants import GiB_bytes, KiB_bytes, MiB_bytes
 
 logger = init_logger(__name__)
 
+# Device-wide vs. per-process consumption differences below this are not
+# reported (CUDA runtime bookkeeping, other processes' minor fluctuations).
+_OTHER_PROCESS_DELTA_WARN_BYTES = 128 * MiB_bytes
+
 
 def format_kib(b: int) -> str:
     return f"{round(b / KiB_bytes, 2)}"
@@ -116,6 +120,9 @@ class MemorySnapshot:
     cuda_memory: int = 0
     torch_memory: int = 0
     non_torch_memory: int = 0
+    # Memory used by this process alone (per-process accounting, e.g. NVML);
+    # None when the platform cannot attribute device memory to processes.
+    process_memory: int | None = None
     timestamp: float = 0.0
 
     device: torch.types.Device = None
@@ -162,6 +169,10 @@ class MemorySnapshot:
         self.torch_memory = torch.accelerator.memory_reserved(device)
 
         self.non_torch_memory = self.cuda_memory - self.torch_memory
+        process_memory = current_platform.get_process_memory_usage(device.index or 0)
+        self.process_memory = (
+            process_memory if isinstance(process_memory, int) else None
+        )
         self.timestamp = time.time()
 
     def __sub__(self, other: "MemorySnapshot") -> "MemorySnapshot":
@@ -179,10 +190,20 @@ class MemorySnapshot:
             cuda_memory=self.cuda_memory - other.cuda_memory,
             torch_memory=self.torch_memory - other.torch_memory,
             non_torch_memory=self.non_torch_memory - other.non_torch_memory,
+            process_memory=(
+                self.process_memory - other.process_memory
+                if self.process_memory is not None and other.process_memory is not None
+                else None
+            ),
             timestamp=self.timestamp - other.timestamp,
             device=self.device_,
             auto_measure=False,
         )
+
+    def _format_process_memory(self) -> str:
+        if self.process_memory is None:
+            return "n/a"
+        return f"{format_gib(self.process_memory)}GiB"
 
     def __repr__(self) -> str:
         return (
@@ -193,6 +214,7 @@ class MemorySnapshot:
             f"{current_platform.device_name}_memory={format_gib(self.cuda_memory)}GiB, "
             f"torch_memory={format_gib(self.torch_memory)}GiB, "
             f"non_torch_memory={format_gib(self.non_torch_memory)}GiB, "
+            f"process_memory={self._format_process_memory()}, "
             f"timestamp={self.timestamp}, "
             f"auto_measure={self.auto_measure}"
         )
@@ -206,6 +228,9 @@ class MemoryProfilingResult:
     torch_peak_increase: int = 0
     non_torch_increase: int = 0
     total_consumed: int = 0
+    # True when total_consumed comes from this process's own device memory
+    # usage rather than from the device-wide free-memory delta.
+    process_scoped: bool = False
     transient_peak_headroom: int = 0
     weights_memory: int = 0
     before_create: MemorySnapshot = field(default_factory=MemorySnapshot)
@@ -314,9 +339,33 @@ def memory_profiling(
     # Measure total consumption via mem_get_info() instead of
     # memory_reserved(), which goes negative when pluggable allocators
     # (e.g. cumem) bypass PyTorch's tracking.
-    result.total_consumed = (
+    device_consumed = (
         result.before_create.free_memory - result.after_profile.free_memory
     )
+    before_process = result.before_create.process_memory
+    after_process = result.after_profile.process_memory
+    if before_process is not None and after_process is not None:
+        # Per-process accounting: memory that other processes on the same
+        # device allocate or release while this instance loads and profiles
+        # must not be charged to (or credited against) this instance.
+        result.total_consumed = after_process - before_process
+        result.process_scoped = True
+        other_processes_delta = device_consumed - result.total_consumed
+        if abs(other_processes_delta) >= _OTHER_PROCESS_DELTA_WARN_BYTES:
+            logger.warning(
+                "Other processes on %s changed their device memory usage by "
+                "%s GiB while this instance was loading and profiling. The "
+                "KV cache budget is based on this process's own usage "
+                "(%s GiB) rather than the device-wide change (%s GiB); make "
+                "sure the instances sharing this device do not request more "
+                "memory than it has in total.",
+                result.before_create.device_,
+                format_gib(other_processes_delta),
+                format_gib(result.total_consumed),
+                format_gib(device_consumed),
+            )
+    else:
+        result.total_consumed = device_consumed
 
     # total_consumed already covers persistent torch allocations; add only the
     # transient peak headroom to avoid double-counting.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -591,7 +591,17 @@ class Worker(WorkerBase):
         init_free_memory = self.init_snapshot.free_memory
         free_gpu_memory = profile_result.after_profile.free_memory
         rocm_fallback = maybe_rocm_profiling_fallback(profile_result)
-        if rocm_fallback is None:
+        if rocm_fallback is None and profile_result.process_scoped:
+            # The budget is based on this process's own memory usage, so
+            # other processes releasing memory during profiling is harmless.
+            if init_free_memory < free_gpu_memory:
+                logger.warning(
+                    "Other processes released %s GiB on the device while this "
+                    "instance was profiling; ignored because the KV cache "
+                    "budget uses this process's own memory usage.",
+                    format_gib(free_gpu_memory - init_free_memory),
+                )
+        elif rocm_fallback is None:
             # NOTE(woosuk): Here we assume that the other processes using the same
             # GPU did not change their memory usage during the profiling.
             assert init_free_memory >= free_gpu_memory, (


### PR DESCRIPTION
## Purpose

`memory_profiling()` derives `total_consumed` (weights + non-torch overhead, the base of the KV cache budget) from the
device-wide free-memory delta between the worker's init snapshot and the end of the profile run. Anything another
process allocates or releases on the same device in that window is charged to, or credited against, this instance:
two instances started at the same time on one GPU shrink each other's KV cache or fail with
`No available memory for the cache blocks`, and a release by another process trips the
`init_free_memory >= free_gpu_memory` assertion. Fixes #55827; #55169 hit the same mechanism with sleep/wake
model swapping (closed as interference from concurrent GPU use), #35920 is the UMA variant, and #56830 is the
assertion side of the same mechanism (a co-tenant releasing memory during profiling, or host memory moving on
a unified-memory part with no co-tenant at all).

Changes:

- `Platform.get_process_memory_usage(device_id)` returns the device memory used by the current process
  (`None` when the platform cannot attribute memory to processes); `NvmlCudaPlatform` implements it through
  `nvmlDeviceGetComputeRunningProcesses` and returns `None` for any NVML error, missing PID entry (e.g. a container
  whose PID namespace NVML does not see), WDDM/MIG (`usedGpuMemory` unavailable).
- `MemorySnapshot` records it as `process_memory`; `memory_profiling()` uses `after − before` of that value as
  `total_consumed` when both snapshots have it (`MemoryProfilingResult.process_scoped = True`) and logs a warning when
  the device-wide delta differs from it by ≥ 128 MiB (other processes changed their usage while we were loading).
  Without per-process data the behaviour is unchanged.
- `Worker.determine_available_memory` keeps the release-during-profiling assertion only for the device-level path;
  with per-process accounting a release by others is logged and ignored.

`gpu_memory_utilization` keeps its meaning (this instance uses at most that fraction of the device); the start-time
check that the requested memory is free is unchanged, so co-tenants that together request more than the device has
still fail at allocation time rather than silently.

## Test Plan

- `tests/utils_/test_mem_utils.py`: mocked platform — another process allocating between the snapshots is not
  counted (`process_scoped`), fallback to the device delta when per-process usage is unavailable, snapshot
  subtraction; real device — a spawned helper process allocates 512 MiB while this process profiles, `total_consumed`
  must reflect only this process's 256 MiB (skipped when the platform cannot report per-process usage). Existing
  `test_memory_profiling` unchanged (own allocations are counted identically by both methods).
- End to end (repro from #55827): `Qwen/Qwen3-ASR-1.7B` at util 0.35 and `Qwen/Qwen3-ForcedAligner-0.6B` at
  util 0.20 started sequentially (reference), concurrently, and the aligner 1 s after killing the ASR.

## Test Result

- Unit tests: 7 passed (`tests/utils_/test_mem_utils.py`, RTX 6000 Ada, main + this patch as an overlay).
- End to end, RTX 6000 Ada 48 GB (bare metal, driver 595.84), main @ 8a0a7ee + this patch as an overlay,
  `Qwen/Qwen3-ASR-1.7B` at util 0.35 and `Qwen/Qwen3-ForcedAligner-0.6B` at util 0.20:

  | start order | ASR KV before | aligner KV before | ASR KV after | aligner KV after |
  |---|---|---|---|---|
  | sequential (reference) | 10.82 GiB | 6.50 GiB | 10.82 GiB | 6.50 GiB |
  | both at once | 9.01 GiB | −0.01 GiB → `No available memory for the cache blocks` | 10.82 GiB | 6.50 GiB |
  | aligner started 1 s after killing the ASR | – | 6.50 GiB | – | 6.50 GiB, no assertion |

  With the patch the concurrent start logs, e.g. for the ASR, `Other processes on cuda:0 changed their device memory
  usage by 8.32 GiB while this instance was loading and profiling. The KV cache budget is based on this process's own
  usage (4.68 GiB) rather than the device-wide change (13.0 GiB)`.
- RTX 5090 32 GB (docker, driver 595.80; NVML reports the container PID), main @ 144e79c + this patch as an overlay,
  same models and utilisations:

  | start order | ASR KV before | aligner KV before | ASR KV after | aligner KV after |
  |---|---|---|---|---|
  | sequential (reference) | 4.72 GiB | 2.82 GiB | 4.72 GiB | 2.82 GiB |
  | both at once | 2.50 GiB | −3.86 GiB → `No available memory for the cache blocks` | 4.72 GiB | 2.82 GiB |
  | aligner started 1 s after killing the ASR | – | 2.82 GiB | – | 2.82 GiB |

  Unit tests: 7 passed there as well.

Developed with AI assistance (Claude); I reviewed every changed line and ran the tests above.

Independently verified on an integrated-GPU part (DGX Spark / GB10, unified memory) by hclsys — see [this comment](https://github.com/vllm-project/vllm/pull/55828#issuecomment-5666318843): host-only memory churn trips the unpatched assertion, and the patched KV budget is unchanged by it.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


