### PR TITLE
[XPU] [Test] Scope memory-settle wait to the engine's own devices, honoring pinned device_ids

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1000,6 +1000,16 @@ class VllmRunner:
 
         from vllm.platforms import current_platform
 
+        # Only wait on the devices this engine will actually occupy. On a shared
+        # node the visible set can include GPUs owned by other processes that
+        # never free, which would otherwise time out the settle wait below.
+        num_engine_devices = (
+            tensor_parallel_size
+            * int(kwargs.get("pipeline_parallel_size", 1))
+            * int(kwargs.get("data_parallel_size", 1))
+        )
+        engine_devices = list(range(num_engine_devices))
+
         if current_platform.is_rocm():
             gpu_memory_utilization = kwargs.get(
                 "gpu_memory_utilization",
@@ -1010,7 +1020,10 @@ class VllmRunner:
             # VRAM from a previous process, so wait before constructing LLM.
             from tests.utils import wait_for_memory_to_settle
 
-            wait_for_memory_to_settle(threshold_ratio=1.0 - gpu_memory_utilization)
+            wait_for_memory_to_settle(
+                threshold_ratio=1.0 - gpu_memory_utilization,
+                devices=engine_devices,
+            )
         elif current_platform.is_xpu():
             # The XPU/oneAPI runtime keeps ~1 GiB of context resident in the
             # parent pytest process for its whole lifetime (grown by in-process
@@ -1025,7 +1038,10 @@ class VllmRunner:
             # previous engine shuts down, so wait before constructing LLM.
             from tests.utils import wait_for_memory_to_settle
 
-            wait_for_memory_to_settle(threshold_ratio=1.0 - gpu_memory_utilization)
+            wait_for_memory_to_settle(
+                threshold_ratio=1.0 - gpu_memory_utilization,
+                devices=engine_devices,
+            )
 
         with init_ctx:
             self.llm = LLM(
@@ -1351,23 +1367,30 @@ class VllmRunner:
     def __enter__(self):
         return self
 
-    def _wait_for_memory_release(self, gpu_memory_utilization: float) -> None:
+    def _wait_for_memory_release(
+        self, gpu_memory_utilization: float, devices: list[int] | None = None
+    ) -> None:
         from tests.utils import wait_for_memory_to_settle
 
         # V1 startup requires free_memory >= total * gpu_memory_utilization.
         # Wait for the complementary used-memory ratio so the next runner does
         # not fail the startup guard immediately after this runner exits. The
         # wait is bounded so cleanup failures fail this test instead of hanging.
-        wait_for_memory_to_settle(threshold_ratio=1.0 - gpu_memory_utilization)
+        wait_for_memory_to_settle(
+            threshold_ratio=1.0 - gpu_memory_utilization,
+            devices=devices,
+        )
 
     def __exit__(self, exc_type, exc_value, traceback):
         # Explicitly shutdown the engine core to release GPU resources
         # This is needed because when executing consecutive tests, the GC
         # might not be fast enough in shutting down the llm engine. This can lead to OOMs
         # because when the next test starts some GPU memory is still in use.
-        gpu_memory_utilization = (
-            self.llm.llm_engine.vllm_config.cache_config.gpu_memory_utilization
-        )
+        vllm_config = self.llm.llm_engine.vllm_config
+        gpu_memory_utilization = vllm_config.cache_config.gpu_memory_utilization
+        # Only wait on the devices this engine occupied so the settle wait does
+        # not block on GPUs owned by other processes sharing the node.
+        engine_devices = list(range(vllm_config.parallel_config.world_size_across_dp))
         from vllm.platforms import current_platform
 
         try:
@@ -1386,7 +1409,7 @@ class VllmRunner:
         del self.llm
         torch._dynamo.reset()
         cleanup_dist_env_and_memory()
-        self._wait_for_memory_release(gpu_memory_utilization)
+        self._wait_for_memory_release(gpu_memory_utilization, devices=engine_devices)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1003,12 +1003,24 @@ class VllmRunner:
         # Only wait on the devices this engine will actually occupy. On a shared
         # node the visible set can include GPUs owned by other processes that
         # never free, which would otherwise time out the settle wait below.
+        # ``device_ids`` may pin the engine to specific, possibly non-contiguous
+        # GPUs; see ``resolve_engine_devices``.
+        from tests.utils import resolve_engine_devices
+
+        device_ids = kwargs.get("device_ids")
         num_engine_devices = (
             tensor_parallel_size
             * int(kwargs.get("pipeline_parallel_size", 1))
+            * int(kwargs.get("prefill_context_parallel_size", 1))
             * int(kwargs.get("data_parallel_size", 1))
         )
-        engine_devices = list(range(num_engine_devices))
+        engine_devices = resolve_engine_devices(device_ids, num_engine_devices)
+        pinned = bool(device_ids) and all(
+            isinstance(d, int) for d in (device_ids or [])
+        )
+        self._engine_device_ids: list[int] | None = (
+            list(engine_devices) if pinned else None
+        )
 
         if current_platform.is_rocm():
             gpu_memory_utilization = kwargs.get(
@@ -1389,8 +1401,16 @@ class VllmRunner:
         vllm_config = self.llm.llm_engine.vllm_config
         gpu_memory_utilization = vllm_config.cache_config.gpu_memory_utilization
         # Only wait on the devices this engine occupied so the settle wait does
-        # not block on GPUs owned by other processes sharing the node.
-        engine_devices = list(range(vllm_config.parallel_config.world_size_across_dp))
+        # not block on GPUs owned by other processes sharing the node. Reuse the
+        # visible-set indices resolved at construction (``device_ids`` when
+        # pinned, possibly non-contiguous), falling back to the contiguous range
+        # ``[0, world_size_across_dp)``.
+        from tests.utils import resolve_engine_devices
+
+        engine_devices = resolve_engine_devices(
+            self._engine_device_ids,
+            vllm_config.parallel_config.world_size_across_dp,
+        )
         from vllm.platforms import current_platform
 
         try:

--- a/tests/test_engine_wait_devices.py
+++ b/tests/test_engine_wait_devices.py
@@ -1,130 +1,90 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for scoping the ``VllmRunner`` memory-settle wait to the
-devices an engine actually occupies.
-
-These exercise :func:`resolve_engine_devices` across the four dimensions
-that determine which visible-set device indices the memory-query path must
-wait on: platform (CUDA vs XPU), presence of a visibility mask
-(``CUDA_VISIBLE_DEVICES`` / ``ZE_AFFINITY_MASK``), and ``device_ids`` (unset,
-contiguous, non-contiguous, or UUID strings). Integer ``device_ids`` are
-visible ordinals on *both* platforms, so the selected indices are independent
-of the platform and of any mask -- the mask only relabels which physical GPU
-each visible ordinal points at, downstream of this selection.
+"""Regression test for scoping the ``VllmRunner`` memory-settle wait to the
+devices an engine actually occupies, so it never blocks on GPUs pinned to a
+different, concurrently-running engine.
 """
 
-import pytest
-
-from tests.utils import resolve_engine_devices
+from tests.utils import multi_gpu_test
 
 
-@pytest.mark.parametrize(
-    ("device_ids", "num_devices", "expected"),
-    [
-        # No pin -> contiguous fallback [0, num_devices).
-        (None, 4, [0, 1, 2, 3]),
-        ([], 2, [0, 1]),
-        # Contiguous integer pin is returned as-is.
-        ([0, 1], 2, [0, 1]),
-        # Non-contiguous integer pin (the regression the reviewer flagged).
-        ([2, 3, 5, 7], 4, [2, 3, 5, 7]),
-        ([1, 3], 2, [1, 3]),
-    ],
-)
-def test_resolve_engine_devices(device_ids, num_devices, expected):
-    assert resolve_engine_devices(device_ids, num_devices) == expected
+@multi_gpu_test(num_gpus=2)
+def test_two_engines_do_not_cross_wait_on_memory(vllm_runner):
+    """Two engines pinned to distinct devices must not wait on each other's
+    memory during the bounded memory-settle guard.
 
+    Engine A stays resident on visible device 0. While it is alive, engine B is
+    built on visible device 1 and then torn down. Both of B's memory-settle
+    waits -- the pre-construction wait (XPU/ROCm) and the teardown wait (every
+    platform) -- must be scoped to B's own device, never device 0. Otherwise
+    the bounded wait blocks on A's still-occupied GPU and times out with
+    ``ValueError: Memory of devices ... not free``.
 
-def test_uuid_device_ids_fall_back_to_range():
-    # UUID strings are not visible ordinals; fall back to the contiguous range
-    # (same as the pre-existing behavior, no regression) rather than guessing.
-    assert resolve_engine_devices(["GPU-abcd", "GPU-ef01"], 2) == [0, 1]
+    Instead of relying only on that slow (240 s) timeout, this spies on
+    ``wait_for_memory_to_settle`` and asserts every wait B issues is scoped to
+    ``[1]``. The regression then fails fast and stays meaningful even on CUDA,
+    where the wait itself is a no-op but the ``devices`` argument still carries
+    the scope.
 
-
-def test_returns_plain_int_list():
-    # numpy-style ints or other integer subclasses should be normalized.
-    result = resolve_engine_devices([1, 3], 4)
-    assert result == [1, 3]
-    assert all(type(d) is int for d in result)
-
-
-# ---------------------------------------------------------------------------
-# Four-dimension combination: platform x mask x device_ids -> queried device.
-#
-# ``resolve_engine_devices`` yields *visible* ordinals. What those ordinals
-# resolve to downstream differs per platform:
-#   * CUDA: the memory query maps visible -> physical via CUDA_VISIBLE_DEVICES
-#     (``get_physical_device_indices``) before hitting NVML, which always
-#     indexes by physical id. CUDA preserves the *listed* order of the mask, so
-#     a non-contiguous / reordered CVD maps ``visible[i] -> int(cvd_list[i])``.
-#   * XPU: the query indexes ``torch.xpu.mem_get_info`` by visible ordinal
-#     directly; ``get_physical_device_indices`` is a no-op because it only
-#     reads CUDA_VISIBLE_DEVICES, not ZE_AFFINITY_MASK. The waited-on indices
-#     are therefore the visible ordinals themselves, independent of the mask's
-#     contiguity *and* of its listed order. (Empirically Level Zero even sorts
-#     the mask ascending, e.g. ``ZE_AFFINITY_MASK=3,1`` binds visible 0 ->
-#     physical 1; this is irrelevant here because parent and worker share the
-#     same runtime and both address devices by visible ordinal.)
-# The cases below assert the *engine-occupied physical GPUs* each platform ends
-# up waiting on, which must match the GPUs the engine actually binds.
-# ---------------------------------------------------------------------------
-
-_COMBINATIONS = [
-    # (platform, mask, device_ids, num_devices, expected_physical)
-    # -- CUDA, no mask: visible == physical.
-    ("cuda", None, None, 2, [0, 1]),
-    ("cuda", None, [2, 3, 5, 7], 4, [2, 3, 5, 7]),
-    # -- CUDA + contiguous CUDA_VISIBLE_DEVICES.
-    ("cuda", "4,5,6,7", None, 2, [4, 5]),
-    ("cuda", "4,5,6,7", [1, 3], 2, [5, 7]),
-    # -- CUDA + non-contiguous CVD: visible ordinal -> listed physical id.
-    ("cuda", "2,3,5,7", None, 2, [2, 3]),
-    ("cuda", "2,3,5,7", [0, 3], 2, [2, 7]),
-    ("cuda", "1,4,6,7", [0, 2], 2, [1, 6]),
-    # -- CUDA + reordered (descending) non-contiguous CVD: order preserved.
-    ("cuda", "7,5,3,1", [0, 1], 2, [7, 5]),
-    # -- XPU, no mask: visible == physical.
-    ("xpu", None, None, 2, [0, 1]),
-    ("xpu", None, [1, 3], 2, [1, 3]),
-    # -- XPU + ZE_AFFINITY_MASK: query stays in the visible namespace, so the
-    #    visible ordinals themselves are what gets waited on regardless of the
-    #    mask's contiguity or order. get_physical_device_indices must NOT remap.
-    ("xpu", "4,5,6,7", None, 2, [0, 1]),
-    ("xpu", "4,5,6,7", [1, 3], 2, [1, 3]),
-    ("xpu", "2,3,5,7", None, 2, [0, 1]),
-    ("xpu", "2,3,5,7", [1, 3], 2, [1, 3]),
-    ("xpu", "7,3", [0, 1], 2, [0, 1]),
-]
-
-
-@pytest.mark.parametrize(
-    ("platform", "mask", "device_ids", "num_devices", "expected_physical"),
-    _COMBINATIONS,
-)
-def test_platform_mask_device_ids_combination(
-    monkeypatch, platform, mask, device_ids, num_devices, expected_physical
-):
+    ``device_ids`` are visible ordinals within whatever set the launcher's mask
+    (``ZE_AFFINITY_MASK`` / ``CUDA_VISIBLE_DEVICES``) assigned to this process,
+    so the test does not depend on which physical GPUs CI happens to hand out.
+    """
     from tests import utils as test_utils
+    from vllm import SamplingParams
 
-    # This drives the real ``get_physical_device_indices``, which hardcodes
-    # ``CUDA_VISIBLE_DEVICES``. The env var name below is deliberately that
-    # literal, matching the function under test -- do NOT switch it to
-    # ``current_platform.device_control_env_var`` (that would be
-    # ``ZE_AFFINITY_MASK`` on an XPU host, which the function ignores, so the
-    # "cuda" cases would stop mapping and the test would break). ``platform``
-    # here is a logical label, not the host platform.
-    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    if platform == "cuda" and mask is not None:
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+    prompts = ["The capital of France is"]
+    params = SamplingParams(max_tokens=1, temperature=0.0)
 
-    visible = resolve_engine_devices(device_ids, num_devices)
+    engine_a_device = 0
+    engine_b_device = 1
+    capturing_b = False
+    b_wait_scopes: list[list[int] | None] = []
+    original_wait = test_utils.wait_for_memory_to_settle
 
-    if platform == "cuda":
-        # CUDA memory query maps visible -> physical via CUDA_VISIBLE_DEVICES.
-        queried_physical = test_utils.get_physical_device_indices(visible)
-    else:
-        # XPU query indexes by visible ordinal; get_physical_device_indices is
-        # a no-op for ZE_AFFINITY_MASK, so the visible ordinals are used as-is.
-        queried_physical = test_utils.get_physical_device_indices(visible)
+    def spy_wait(*, threshold_ratio=0.1, timeout_s=240, devices=None):
+        if capturing_b:
+            b_wait_scopes.append(devices)
+            assert devices == [engine_b_device], (
+                f"engine B's memory-settle wait was scoped to {devices}, "
+                f"expected [{engine_b_device}]; None -- or anything including "
+                f"device {engine_a_device} -- means the wait would block on "
+                "engine A's still-occupied GPU."
+            )
+        return original_wait(
+            threshold_ratio=threshold_ratio, timeout_s=timeout_s, devices=devices
+        )
 
-    assert queried_physical == expected_physical
+    test_utils.wait_for_memory_to_settle = spy_wait
+    try:
+        with vllm_runner(
+            "facebook/opt-125m",
+            device_ids=[engine_a_device],
+            max_model_len=256,
+            gpu_memory_utilization=0.3,
+            enforce_eager=True,
+        ) as engine_a:
+            out_a = engine_a.get_llm().generate(prompts, params)
+            assert out_a and out_a[0].outputs
+
+            # Only B's construction and teardown waits must be scoped to [1].
+            capturing_b = True
+            try:
+                with vllm_runner(
+                    "facebook/opt-125m",
+                    device_ids=[engine_b_device],
+                    max_model_len=256,
+                    gpu_memory_utilization=0.3,
+                    enforce_eager=True,
+                ) as engine_b:
+                    out_b = engine_b.get_llm().generate(prompts, params)
+                    assert out_b and out_b[0].outputs
+            finally:
+                capturing_b = False
+
+        assert b_wait_scopes, (
+            "engine B never invoked the memory-settle wait; the scoping was "
+            "not exercised."
+        )
+    finally:
+        test_utils.wait_for_memory_to_settle = original_wait

--- a/tests/test_engine_wait_devices.py
+++ b/tests/test_engine_wait_devices.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for scoping the ``VllmRunner`` memory-settle wait to the
+devices an engine actually occupies.
+
+These exercise :func:`resolve_engine_devices` across the four dimensions
+that determine which visible-set device indices the memory-query path must
+wait on: platform (CUDA vs XPU), presence of a visibility mask
+(``CUDA_VISIBLE_DEVICES`` / ``ZE_AFFINITY_MASK``), and ``device_ids`` (unset,
+contiguous, non-contiguous, or UUID strings). Integer ``device_ids`` are
+visible ordinals on *both* platforms, so the selected indices are independent
+of the platform and of any mask -- the mask only relabels which physical GPU
+each visible ordinal points at, downstream of this selection.
+"""
+
+import pytest
+
+from tests.utils import resolve_engine_devices
+
+
+@pytest.mark.parametrize(
+    ("device_ids", "num_devices", "expected"),
+    [
+        # No pin -> contiguous fallback [0, num_devices).
+        (None, 4, [0, 1, 2, 3]),
+        ([], 2, [0, 1]),
+        # Contiguous integer pin is returned as-is.
+        ([0, 1], 2, [0, 1]),
+        # Non-contiguous integer pin (the regression the reviewer flagged).
+        ([2, 3, 5, 7], 4, [2, 3, 5, 7]),
+        ([1, 3], 2, [1, 3]),
+    ],
+)
+def test_resolve_engine_devices(device_ids, num_devices, expected):
+    assert resolve_engine_devices(device_ids, num_devices) == expected
+
+
+def test_uuid_device_ids_fall_back_to_range():
+    # UUID strings are not visible ordinals; fall back to the contiguous range
+    # (same as the pre-existing behavior, no regression) rather than guessing.
+    assert resolve_engine_devices(["GPU-abcd", "GPU-ef01"], 2) == [0, 1]
+
+
+def test_returns_plain_int_list():
+    # numpy-style ints or other integer subclasses should be normalized.
+    result = resolve_engine_devices([1, 3], 4)
+    assert result == [1, 3]
+    assert all(type(d) is int for d in result)
+
+
+# ---------------------------------------------------------------------------
+# Four-dimension combination: platform x mask x device_ids -> queried device.
+#
+# ``resolve_engine_devices`` yields *visible* ordinals. What those ordinals
+# resolve to downstream differs per platform:
+#   * CUDA: the memory query maps visible -> physical via CUDA_VISIBLE_DEVICES
+#     (``get_physical_device_indices``) before hitting NVML, which always
+#     indexes by physical id. CUDA preserves the *listed* order of the mask, so
+#     a non-contiguous / reordered CVD maps ``visible[i] -> int(cvd_list[i])``.
+#   * XPU: the query indexes ``torch.xpu.mem_get_info`` by visible ordinal
+#     directly; ``get_physical_device_indices`` is a no-op because it only
+#     reads CUDA_VISIBLE_DEVICES, not ZE_AFFINITY_MASK. The waited-on indices
+#     are therefore the visible ordinals themselves, independent of the mask's
+#     contiguity *and* of its listed order. (Empirically Level Zero even sorts
+#     the mask ascending, e.g. ``ZE_AFFINITY_MASK=3,1`` binds visible 0 ->
+#     physical 1; this is irrelevant here because parent and worker share the
+#     same runtime and both address devices by visible ordinal.)
+# The cases below assert the *engine-occupied physical GPUs* each platform ends
+# up waiting on, which must match the GPUs the engine actually binds.
+# ---------------------------------------------------------------------------
+
+_COMBINATIONS = [
+    # (platform, mask, device_ids, num_devices, expected_physical)
+    # -- CUDA, no mask: visible == physical.
+    ("cuda", None, None, 2, [0, 1]),
+    ("cuda", None, [2, 3, 5, 7], 4, [2, 3, 5, 7]),
+    # -- CUDA + contiguous CUDA_VISIBLE_DEVICES.
+    ("cuda", "4,5,6,7", None, 2, [4, 5]),
+    ("cuda", "4,5,6,7", [1, 3], 2, [5, 7]),
+    # -- CUDA + non-contiguous CVD: visible ordinal -> listed physical id.
+    ("cuda", "2,3,5,7", None, 2, [2, 3]),
+    ("cuda", "2,3,5,7", [0, 3], 2, [2, 7]),
+    ("cuda", "1,4,6,7", [0, 2], 2, [1, 6]),
+    # -- CUDA + reordered (descending) non-contiguous CVD: order preserved.
+    ("cuda", "7,5,3,1", [0, 1], 2, [7, 5]),
+    # -- XPU, no mask: visible == physical.
+    ("xpu", None, None, 2, [0, 1]),
+    ("xpu", None, [1, 3], 2, [1, 3]),
+    # -- XPU + ZE_AFFINITY_MASK: query stays in the visible namespace, so the
+    #    visible ordinals themselves are what gets waited on regardless of the
+    #    mask's contiguity or order. get_physical_device_indices must NOT remap.
+    ("xpu", "4,5,6,7", None, 2, [0, 1]),
+    ("xpu", "4,5,6,7", [1, 3], 2, [1, 3]),
+    ("xpu", "2,3,5,7", None, 2, [0, 1]),
+    ("xpu", "2,3,5,7", [1, 3], 2, [1, 3]),
+    ("xpu", "7,3", [0, 1], 2, [0, 1]),
+]
+
+
+@pytest.mark.parametrize(
+    ("platform", "mask", "device_ids", "num_devices", "expected_physical"),
+    _COMBINATIONS,
+)
+def test_platform_mask_device_ids_combination(
+    monkeypatch, platform, mask, device_ids, num_devices, expected_physical
+):
+    from tests import utils as test_utils
+
+    # This drives the real ``get_physical_device_indices``, which hardcodes
+    # ``CUDA_VISIBLE_DEVICES``. The env var name below is deliberately that
+    # literal, matching the function under test -- do NOT switch it to
+    # ``current_platform.device_control_env_var`` (that would be
+    # ``ZE_AFFINITY_MASK`` on an XPU host, which the function ignores, so the
+    # "cuda" cases would stop mapping and the test would break). ``platform``
+    # here is a logical label, not the host platform.
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    if platform == "cuda" and mask is not None:
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", mask)
+
+    visible = resolve_engine_devices(device_ids, num_devices)
+
+    if platform == "cuda":
+        # CUDA memory query maps visible -> physical via CUDA_VISIBLE_DEVICES.
+        queried_physical = test_utils.get_physical_device_indices(visible)
+    else:
+        # XPU query indexes by visible ordinal; get_physical_device_indices is
+        # a no-op for ZE_AFFINITY_MASK, so the visible ordinals are used as-is.
+        queried_physical = test_utils.get_physical_device_indices(visible)
+
+    assert queried_physical == expected_physical

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1728,6 +1728,7 @@ def wait_for_memory_to_settle(
     *,
     threshold_ratio: float | dict[int, float] | None = 0.1,
     timeout_s: float = 240,
+    devices: list[int] | None = None,
 ) -> None:
     """Block until ROCm or XPU device VRAM usage drops below ``threshold_ratio``.
 
@@ -1735,6 +1736,15 @@ def wait_for_memory_to_settle(
     loads in a single test process can OOM the *next* engine/model startup
     even after ``cleanup_dist_env_and_memory``. This gives the driver time to
     actually release VRAM before the next allocation. No-op off ROCm.
+
+    Args:
+        threshold_ratio: Per-device (or shared) used-memory ratio to wait for.
+        timeout_s: Give up after this many seconds.
+        devices: Logical device indices to wait on. Defaults to every visible
+            device. Pass the indices the current engine actually used so the
+            wait does not block on GPUs owned by other processes sharing the
+            node (e.g. under an ``ZE_AFFINITY_MASK``/``CUDA_VISIBLE_DEVICES``
+            that still exposes several devices).
     """
     if not current_platform.is_rocm() and not current_platform.is_xpu():
         return
@@ -1742,11 +1752,17 @@ def wait_for_memory_to_settle(
     num_gpus = current_platform.device_count()
     if num_gpus == 0:
         return
+    if devices is None:
+        devices = list(range(num_gpus))
+    else:
+        devices = [device for device in devices if 0 <= device < num_gpus]
+    if not devices:
+        return
     if threshold_ratio is None:
         threshold_ratio = 0.1
 
     wait_for_gpu_memory_to_clear(
-        devices=list(range(num_gpus)),
+        devices=devices,
         threshold_ratio=threshold_ratio,
         timeout_s=timeout_s,
         stable_duration_s=2.0,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -314,6 +314,22 @@ class RemoteVLLMServer:
         )
         self._request_shutdown_timeout = float(args.shutdown_timeout)
 
+        # Devices this server will occupy, as *visible* ordinals. Used to scope
+        # GPU memory measurements to the server's own devices so a busy neighbor
+        # on unrelated GPUs of a shared node does not keep the teardown
+        # memory-release wait from ever succeeding. ``device_ids`` may pin the
+        # server to specific, possibly non-contiguous devices; otherwise this is
+        # the contiguous range ``[0, world_size)``.
+        self._num_gpu_devices = (
+            int(getattr(args, "tensor_parallel_size", 1) or 1)
+            * int(getattr(args, "pipeline_parallel_size", 1) or 1)
+            * int(getattr(args, "prefill_context_parallel_size", 1) or 1)
+            * int(getattr(args, "data_parallel_size", 1) or 1)
+        )
+        self._engine_device_ids = resolve_engine_devices(
+            getattr(args, "device_ids", None), self._num_gpu_devices
+        )
+
         with _temporarily_sanitized_pythonpath_env():
             self._pre_download_model(model, args)
         self._shutdown_complete = False
@@ -595,14 +611,21 @@ class RemoteVLLMServer:
         return members
 
     def _get_gpu_memory_used(self) -> float | None:
-        """Get total GPU memory used across all visible devices in bytes."""
+        """Get GPU memory used across this server's devices in bytes.
+
+        Only the devices this server occupies are counted (``self.
+        _engine_device_ids``, i.e. the pinned ``device_ids`` or the contiguous
+        ``[0, world_size)`` fallback). On a shared node this avoids attributing
+        a neighbor's memory on unrelated GPUs to this server, which would
+        otherwise stall the teardown memory-release wait.
+        """
         try:
+            device_count = current_platform.device_count()
+            visible = [d for d in self._engine_device_ids if 0 <= d < device_count]
             if current_platform.is_rocm():
                 with _nvml():
                     handles = amdsmi_get_processor_handles()
-                    devices = get_physical_device_indices(
-                        list(range(current_platform.device_count()))
-                    )
+                    devices = get_physical_device_indices(visible)
                     total_used_mib = 0
                     for device in devices:
                         handle = handles[device]
@@ -619,16 +642,15 @@ class RemoteVLLMServer:
             elif current_platform.is_cuda():
                 with _nvml():
                     total_used = 0
-                    device_count = current_platform.device_count()
-                    for i in range(device_count):
+                    # NVML indexes by physical id, so map visible -> physical.
+                    for i in get_physical_device_indices(visible):
                         handle = nvmlDeviceGetHandleByIndex(i)
                         mem_info = nvmlDeviceGetMemoryInfo(handle)
                         total_used += mem_info.used
                     return total_used
             elif current_platform.is_xpu():
                 total_used = 0
-                device_count = current_platform.device_count()
-                for i in range(device_count):
+                for i in visible:
                     free, total = torch.xpu.mem_get_info(i)
                     total_used += total - free
                 return total_used
@@ -1551,6 +1573,34 @@ def get_physical_device_indices(devices: list[int]):
     visible_indices = [int(x) for x in visible_devices.split(",")]
     index_mapping = {i: physical for i, physical in enumerate(visible_indices)}
     return [index_mapping[i] for i in devices if i in index_mapping]
+
+
+def resolve_engine_devices(
+    device_ids: Sequence[Any] | None,
+    num_devices: int,
+) -> list[int]:
+    """Resolve the visible-set device indices an engine occupies.
+
+    The result scopes GPU memory-settle waits to just these devices. The
+    memory-query path indexes devices by their *visible* ordinal -- the index
+    into ``CUDA_VISIBLE_DEVICES`` / ``ZE_AFFINITY_MASK`` (or all GPUs when
+    unset) -- on both CUDA and XPU. Integer ``device_ids`` are exactly those
+    visible ordinals, so they are returned as-is (this handles non-contiguous
+    pins such as ``[2, 3, 5, 7]``). When there is no explicit integer mapping
+    (``device_ids`` unset or given as UUID strings), fall back to the
+    contiguous range ``[0, num_devices)``.
+
+    Args:
+        device_ids: The ``device_ids`` passed to the engine, or ``None``.
+        num_devices: Number of devices the engine occupies, used for the
+            contiguous fallback.
+
+    Returns:
+        The visible-set device indices the engine occupies.
+    """
+    if device_ids and all(isinstance(d, int) for d in device_ids):
+        return [int(d) for d in device_ids]
+    return list(range(num_devices))
 
 
 def get_nvml_device_handle(device: int):

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -130,12 +130,44 @@ class XPUWorker(Worker):
             and device.type == "xpu"
             and current_platform.is_xpu()
         ):
-            self.device = torch.device(f"xpu:{self.local_rank}")
+            assigned_physical_gpu_ids = self.parallel_config.assigned_physical_gpu_ids
+            if assigned_physical_gpu_ids is not None:
+                from vllm.platforms.interface import set_assigned_physical_gpu_ids
+
+                set_assigned_physical_gpu_ids(assigned_physical_gpu_ids)
+                assert self.local_rank < len(assigned_physical_gpu_ids), (
+                    f"local_rank {self.local_rank} is out of bounds for "
+                    f"assigned_physical_gpu_ids {assigned_physical_gpu_ids}"
+                )
+                # NOTE: local_world_size is derived from parallel_config.nnodes,
+                # which is only set for the "mp" multi-node backend. With the
+                # "ray"/"external_launcher" backends nnodes stays 1, so
+                # local_world_size collapses to the full world_size and this
+                # check wrongly fires on cross-node deployments.
+                # assigned_physical_gpu_ids is already per-node and the
+                # local_rank bound above fully validates the mapping for
+                # these backends, so skip the check for them.
+                if parallel_config.distributed_executor_backend not in (
+                    "ray",
+                    "external_launcher",
+                ):
+                    assert parallel_config.local_world_size <= len(
+                        assigned_physical_gpu_ids
+                    ), (
+                        f"local_world_size ({parallel_config.local_world_size})"
+                        " exceeds assigned_physical_gpu_ids count "
+                        f"({len(assigned_physical_gpu_ids)})"
+                    )
+
+            visible_device_index = (
+                current_platform.logical_device_id_to_visible_device_id(self.local_rank)
+            )
+            self.device = torch.device(f"xpu:{visible_device_index}")
             torch.accelerator.set_device_index(self.device)
             current_platform.check_if_supports_dtype(self.model_config.dtype)
             torch.accelerator.empty_cache()
             self.init_gpu_memory = torch.xpu.get_device_properties(
-                self.local_rank
+                visible_device_index
             ).total_memory
         else:
             raise RuntimeError(f"Unsupported device type: {self.device_config.device}")


### PR DESCRIPTION
## Purpose

`VllmRunner` (and `RemoteVLLMServer`) call `wait_for_memory_to_settle(...)` both before constructing the engine and after tearing it down. The helper originally waited on **every visible GPU** (`range(current_platform.device_count())`).

The key point is that **"visible" is not the same as "used by this engine"**. `ZE_AFFINITY_MASK` / `CUDA_VISIBLE_DEVICES` (or no mask at all) define the set of GPUs the pytest process *can see*, but a single runner usually occupies only a **subset** of them (`TP * PP * PCP * DP`, or the GPUs pinned via `--device-ids`). The remaining visible GPUs are not owned by this engine; on a shared node they are held by **other processes** — other users, or other concurrent tests in the same job — that never free. Two concrete cases:

- **No mask**: the whole node is visible (e.g. 8 GPUs) but the test runs `TP=1`; the other 7 belong to others.
- **Mask broader than the engine**: the job is pinned to e.g. `ZE_AFFINITY_MASK=4,5,6,7` (4 visible), but a given test only spins up a `TP=1`/`TP=2` engine on 1–2 of them; the rest stay busy with other work.

Because the wait iterated over **all** visible GPUs, those foreign GPUs never drop below the threshold and the bounded wait times out, failing otherwise-passing tests:

```
ValueError: Memory of devices devices=[0, 1, 2, 3, 4, 5, 6, 7] not free after dur_s=240.29 (threshold='device=0: 0.100; ...; device=7: 0.100')
```

Observed on XPU with `tests/quantization/test_online.py` while GPUs 4–7 were busy (~95%) with another user's workload.

## Fix

Wait only on the devices the engine actually occupies:

- `wait_for_memory_to_settle` gains an optional `devices` argument (defaults to all visible devices, preserving current behavior).
- A shared helper `resolve_engine_devices(device_ids, num_devices)` resolves the engine's **visible-set** device indices: integer `device_ids` are used as-is (they are visible ordinals — this handles non-contiguous pins like `[2, 3, 5, 7]`), while UUID/unset `device_ids` fall back to the contiguous range `[0, N)` with `N = TP * PP * PCP * DP`.
- Both `VllmRunner` (`__init__` / `__exit__`) and `RemoteVLLMServer` use it to scope their memory-settle / teardown waits.
 
 
