### PR TITLE
[Core] Refactor sequence parallel collectives into linear layers

### DIFF
--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -22,6 +22,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ...models.registry import HF_EXAMPLE_MODELS, _HfExamplesInfo
+from ...models.utils import check_logprobs_close
 from ...utils import compare_all_settings, create_new_process_for_each_test
 
 logger = init_logger("test_sequence_parallel")
@@ -29,6 +30,54 @@ logger = init_logger("test_sequence_parallel")
 VLLM_MULTI_NODE = os.getenv("VLLM_MULTI_NODE", "0") == "1"
 NVFP4_MODEL_ID = "nvidia/Llama-3.1-8B-Instruct-NVFP4"
 NVFP4_MODEL_INFO = _HfExamplesInfo(NVFP4_MODEL_ID)
+
+
+@pytest.mark.parametrize("is_moe", [False, True])
+def test_qwen35_explicit_sp_dp1(vllm_runner, is_moe):
+    """Compare SP with TP across long prefill, threshold and decode steps."""
+    model_env = "SP_MOE_MODEL" if is_moe else "SP_DENSE_MODEL"
+    model = os.environ.get(model_env)
+    if model is None:
+        pytest.skip(f"Set {model_env} to a local Qwen3.5 model")
+    if not current_platform.is_cuda() or current_platform.device_count() < 2:
+        pytest.skip("Requires two CUDA GPUs")
+
+    outputs = []
+    for enabled in (False, True):
+        with vllm_runner(
+            model,
+            tensor_parallel_size=2,
+            data_parallel_size=1,
+            distributed_executor_backend="mp",
+            enable_expert_parallel=is_moe,
+            all2all_backend="allgather_reducescatter",
+            enable_sequence_parallel=enabled,
+            enforce_eager=True,
+            max_model_len=2048,
+            max_num_batched_tokens=1536,
+            max_num_seqs=1,
+            enable_prefix_caching=False,
+        ) as runner:
+            token_ids = runner.llm.get_tokenizer().encode(
+                "Explain sequence parallelism.", add_special_tokens=False
+            )
+            step_outputs = []
+            for size in (1001, 1000, 17):
+                prompt = (token_ids * (size // len(token_ids) + 1))[:size]
+                step_outputs.extend(
+                    runner.generate_greedy_logprobs(
+                        [prompt], max_tokens=8, num_logprobs=5
+                    )
+                )
+            outputs.append(step_outputs)
+    check_logprobs_close(
+        outputs_0_lst=outputs[0],
+        outputs_1_lst=outputs[1],
+        name_0="SP off",
+        name_1="SP on",
+        always_check_logprobs=True,
+        warn_on_mismatch=False,
+    )
 
 
 class ParallelSetup(NamedTuple):

--- a/tests/config/test_sequence_parallel.py
+++ b/tests/config/test_sequence_parallel.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import ParallelConfig
+from vllm.platforms import current_platform
+
+
+@pytest.mark.parametrize("enabled", [None, False, True])
+@pytest.mark.parametrize("num_tokens", [999, 1000, 1001, 1002])
+def test_dense_sp_threshold(monkeypatch, enabled, num_tokens):
+    monkeypatch.setattr(current_platform, "device_count", lambda: 2)
+    config = ParallelConfig(
+        tensor_parallel_size=2,
+        is_moe_model=False,
+        enable_sequence_parallel=enabled,
+    )
+    assert config.sequence_parallel_enabled_for_tokens(num_tokens) is (
+        enabled is True and num_tokens > 1000
+    )
+
+
+def test_sp_validation_after_model_type_is_known(monkeypatch):
+    monkeypatch.setattr(current_platform, "device_count", lambda: 2)
+    config = ParallelConfig(tensor_parallel_size=2, enable_sequence_parallel=True)
+    config.is_moe_model = True
+    with pytest.raises(ValueError, match="MoE sequence parallelism requires"):
+        config.validate_sequence_parallel()
+
+
+def test_pipeline_parallel_disables_sp(monkeypatch):
+    monkeypatch.setattr(current_platform, "device_count", lambda: 4)
+    config = ParallelConfig(
+        tensor_parallel_size=2,
+        pipeline_parallel_size=2,
+        is_moe_model=False,
+        enable_sequence_parallel=True,
+    )
+    assert not config.sequence_parallel_enabled_for_tokens(1001)

--- a/tests/model_executor/layers/test_linear_sequence_parallel.py
+++ b/tests/model_executor/layers/test_linear_sequence_parallel.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 
+from vllm.forward_context import ForwardContext, override_forward_context
 from vllm.lora.layers.column_parallel_linear import ColumnParallelLinearWithLoRA
 from vllm.lora.layers.row_parallel_linear import RowParallelLinearWithLoRA
 from vllm.model_executor import parameter as parameter_module
@@ -81,6 +82,34 @@ def _row_layer(*, sequence_parallel: bool = True) -> RowParallelLinear:
         sequence_parallel=sequence_parallel,
         return_bias=False,
     )
+
+
+def test_sequence_parallel_layers_switch_back_to_tp_per_forward(monkeypatch):
+    """A short dense step keeps all tokens and uses TP all-reduce."""
+    all_gather = Mock(side_effect=AssertionError("unexpected all-gather"))
+    reduce_scatter = Mock(side_effect=AssertionError("unexpected reduce-scatter"))
+    all_reduce = Mock(side_effect=lambda x: x * 2)
+    monkeypatch.setattr(linear_module, "tensor_model_parallel_all_gather", all_gather)
+    monkeypatch.setattr(
+        linear_module, "tensor_model_parallel_reduce_scatter", reduce_scatter
+    )
+    monkeypatch.setattr(linear_module, "tensor_model_parallel_all_reduce", all_reduce)
+    column, row = _column_layer(), _row_layer()
+    inputs = torch.ones(3, 4)
+    partial = torch.ones(3, 8)
+    with override_forward_context(
+        ForwardContext(
+            no_compile_layers={},
+            attn_metadata={},
+            slot_mapping={},
+            sequence_parallel_enabled=False,
+        )
+    ):
+        assert column.prepare_input(inputs) is inputs
+        torch.testing.assert_close(row.reduce_output(partial), partial * 2)
+    all_reduce.assert_called_once()
+    all_gather.assert_not_called()
+    reduce_scatter.assert_not_called()
 
 
 def test_column_parallel_linear_gathers_sequence_shards(monkeypatch) -> None:

--- a/tests/model_executor/layers/test_linear_sequence_parallel.py
+++ b/tests/model_executor/layers/test_linear_sequence_parallel.py
@@ -8,6 +8,7 @@ import torch
 
 from vllm.lora.layers.column_parallel_linear import ColumnParallelLinearWithLoRA
 from vllm.lora.layers.row_parallel_linear import RowParallelLinearWithLoRA
+from vllm.model_executor import parameter as parameter_module
 from vllm.model_executor.layers import linear as linear_module
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -39,6 +40,23 @@ def _tp_size_two(monkeypatch):
         "get_tensor_model_parallel_rank",
         lambda: 0,
     )
+    monkeypatch.setattr(
+        parameter_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(
+        parameter_module,
+        "get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        linear_module,
+        "dispatch_unquantized_gemm",
+        lambda: lambda layer, x, weight, bias: torch.nn.functional.linear(
+            x, weight, bias
+        ),
+    )
 
 
 def _column_layer(*, sequence_parallel: bool = True) -> ColumnParallelLinear:
@@ -69,9 +87,7 @@ def test_column_parallel_linear_gathers_sequence_shards(monkeypatch) -> None:
     local_input = torch.arange(8, dtype=torch.float32).view(2, 4)
     gathered_input = torch.cat([local_input, local_input + 8], dim=0)
     all_gather = Mock(return_value=gathered_input)
-    monkeypatch.setattr(
-        linear_module, "tensor_model_parallel_all_gather", all_gather
-    )
+    monkeypatch.setattr(linear_module, "tensor_model_parallel_all_gather", all_gather)
 
     layer = _column_layer()
     _fill_weights(layer)
@@ -82,13 +98,27 @@ def test_column_parallel_linear_gathers_sequence_shards(monkeypatch) -> None:
     torch.testing.assert_close(output, gathered_input @ layer.weight.T)
 
 
+def test_column_parallel_linear_removes_sequence_padding(monkeypatch) -> None:
+    local_input = torch.arange(8, dtype=torch.float32).view(2, 4)
+    gathered_input = torch.cat([local_input, local_input + 8], dim=0)
+    monkeypatch.setattr(
+        linear_module,
+        "tensor_model_parallel_all_gather",
+        Mock(return_value=gathered_input),
+    )
+    layer = _column_layer()
+    _fill_weights(layer)
+
+    output = layer(local_input, sequence_parallel_unpadded_size=3)
+
+    torch.testing.assert_close(output, gathered_input[:3] @ layer.weight.T)
+
+
 def test_column_parallel_linear_keeps_shards_without_sequence_parallel(
     monkeypatch,
 ) -> None:
     all_gather = Mock(side_effect=AssertionError("unexpected all-gather"))
-    monkeypatch.setattr(
-        linear_module, "tensor_model_parallel_all_gather", all_gather
-    )
+    monkeypatch.setattr(linear_module, "tensor_model_parallel_all_gather", all_gather)
 
     layer = _column_layer(sequence_parallel=False)
     _fill_weights(layer)
@@ -101,11 +131,12 @@ def test_column_parallel_linear_keeps_shards_without_sequence_parallel(
 
 
 def test_row_parallel_linear_reduce_scatters_sequence_shards(monkeypatch) -> None:
-    input_parallel = torch.arange(16, dtype=torch.float32).view(4, 2)
+    input_parallel = torch.arange(6, dtype=torch.float32).view(3, 2)
     layer = _row_layer()
     _fill_weights(layer)
     output_parallel = input_parallel @ layer.weight.T
-    local_output = output_parallel[:2]
+    padded_output = torch.nn.functional.pad(output_parallel, (0, 0, 0, 1))
+    local_output = padded_output[:2]
     reduce_scatter = Mock(return_value=local_output)
     all_reduce = Mock(side_effect=AssertionError("unexpected all-reduce"))
     monkeypatch.setattr(
@@ -121,7 +152,10 @@ def test_row_parallel_linear_reduce_scatters_sequence_shards(monkeypatch) -> Non
 
     output = layer(input_parallel)
 
-    reduce_scatter.assert_called_once_with(output_parallel, dim=0)
+    reduce_scatter.assert_called_once()
+    reduce_scatter_input = reduce_scatter.call_args.args[0]
+    assert reduce_scatter.call_args.kwargs == {"dim": 0}
+    torch.testing.assert_close(reduce_scatter_input, padded_output)
     all_reduce.assert_not_called()
     torch.testing.assert_close(output, local_output)
 
@@ -157,22 +191,24 @@ def test_column_parallel_lora_reuses_base_input_preparation() -> None:
     base_layer = _column_layer()
     base_layer.prepare_input = Mock(return_value=gathered_input)
     lora_layer = object.__new__(ColumnParallelLinearWithLoRA)
+    torch.nn.Module.__init__(lora_layer)
     lora_layer.base_layer = base_layer
     lora_layer.tp_size = 2
     object.__setattr__(lora_layer, "apply", Mock(return_value=torch.zeros(4, 4)))
 
-    lora_layer(local_input)
+    lora_layer(local_input, sequence_parallel_unpadded_size=3)
 
-    base_layer.prepare_input.assert_called_once_with(local_input)
+    base_layer.prepare_input.assert_called_once_with(local_input, 3)
 
 
 def test_row_parallel_lora_reuses_base_output_reduction() -> None:
-    input_parallel = torch.arange(16, dtype=torch.float32).view(4, 2)
+    input_parallel = torch.arange(8, dtype=torch.float32).view(4, 2)
     output_parallel = torch.cat([input_parallel, input_parallel], dim=1)
     local_output = output_parallel[:2]
     base_layer = _row_layer()
     base_layer.reduce_output = Mock(return_value=local_output)
     lora_layer = object.__new__(RowParallelLinearWithLoRA)
+    torch.nn.Module.__init__(lora_layer)
     lora_layer.base_layer = base_layer
     lora_layer.tp_rank = 0
     lora_layer.tp_size = 2

--- a/tests/model_executor/layers/test_linear_sequence_parallel.py
+++ b/tests/model_executor/layers/test_linear_sequence_parallel.py
@@ -69,14 +69,16 @@ def test_column_parallel_linear_gathers_sequence_shards(monkeypatch) -> None:
     local_input = torch.arange(8, dtype=torch.float32).view(2, 4)
     gathered_input = torch.cat([local_input, local_input + 8], dim=0)
     all_gather = Mock(return_value=gathered_input)
-    monkeypatch.setattr(linear_module, "sequence_parallel_all_gather", all_gather)
+    monkeypatch.setattr(
+        linear_module, "tensor_model_parallel_all_gather", all_gather
+    )
 
     layer = _column_layer()
     _fill_weights(layer)
 
     output = layer(local_input)
 
-    all_gather.assert_called_once_with(local_input)
+    all_gather.assert_called_once_with(local_input, dim=0)
     torch.testing.assert_close(output, gathered_input @ layer.weight.T)
 
 
@@ -84,7 +86,9 @@ def test_column_parallel_linear_keeps_shards_without_sequence_parallel(
     monkeypatch,
 ) -> None:
     all_gather = Mock(side_effect=AssertionError("unexpected all-gather"))
-    monkeypatch.setattr(linear_module, "sequence_parallel_all_gather", all_gather)
+    monkeypatch.setattr(
+        linear_module, "tensor_model_parallel_all_gather", all_gather
+    )
 
     layer = _column_layer(sequence_parallel=False)
     _fill_weights(layer)
@@ -106,7 +110,7 @@ def test_row_parallel_linear_reduce_scatters_sequence_shards(monkeypatch) -> Non
     all_reduce = Mock(side_effect=AssertionError("unexpected all-reduce"))
     monkeypatch.setattr(
         linear_module,
-        "sequence_parallel_reduce_scatter",
+        "tensor_model_parallel_reduce_scatter",
         reduce_scatter,
     )
     monkeypatch.setattr(
@@ -117,7 +121,7 @@ def test_row_parallel_linear_reduce_scatters_sequence_shards(monkeypatch) -> Non
 
     output = layer(input_parallel)
 
-    reduce_scatter.assert_called_once_with(output_parallel)
+    reduce_scatter.assert_called_once_with(output_parallel, dim=0)
     all_reduce.assert_not_called()
     torch.testing.assert_close(output, local_output)
 
@@ -134,7 +138,7 @@ def test_row_parallel_linear_keeps_all_reduce_by_default(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         linear_module,
-        "sequence_parallel_reduce_scatter",
+        "tensor_model_parallel_reduce_scatter",
         reduce_scatter,
     )
 

--- a/tests/model_executor/layers/test_linear_sequence_parallel.py
+++ b/tests/model_executor/layers/test_linear_sequence_parallel.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.lora.layers.column_parallel_linear import ColumnParallelLinearWithLoRA
+from vllm.lora.layers.row_parallel_linear import RowParallelLinearWithLoRA
+from vllm.model_executor.layers import linear as linear_module
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+
+
+def _fill_weights(layer: torch.nn.Module) -> None:
+    with torch.no_grad():
+        for param in layer.parameters():
+            param.copy_(torch.arange(param.numel(), dtype=torch.float32).view_as(param))
+
+
+@pytest.fixture(autouse=True)
+def _tp_size_two(monkeypatch):
+    """Fake a two-rank TP group.
+
+    ``RowParallelLinear`` reads the TP size/rank from the distributed state
+    at construction time, so the layer constructors below would otherwise
+    fall back to tp_size == 1 and never exercise the sequence-parallel paths.
+    """
+    monkeypatch.setattr(
+        linear_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(
+        linear_module,
+        "get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+
+
+def _column_layer(*, sequence_parallel: bool = True) -> ColumnParallelLinear:
+    return ColumnParallelLinear(
+        input_size=4,
+        output_size=8,
+        bias=False,
+        quant_config=None,
+        sequence_parallel=sequence_parallel,
+        tp_size=2,
+        tp_rank=0,
+        return_bias=False,
+    )
+
+
+def _row_layer(*, sequence_parallel: bool = True) -> RowParallelLinear:
+    return RowParallelLinear(
+        input_size=4,
+        output_size=8,
+        bias=False,
+        quant_config=None,
+        sequence_parallel=sequence_parallel,
+        return_bias=False,
+    )
+
+
+def test_column_parallel_linear_gathers_sequence_shards(monkeypatch) -> None:
+    local_input = torch.arange(8, dtype=torch.float32).view(2, 4)
+    gathered_input = torch.cat([local_input, local_input + 8], dim=0)
+    all_gather = Mock(return_value=gathered_input)
+    monkeypatch.setattr(linear_module, "sequence_parallel_all_gather", all_gather)
+
+    layer = _column_layer()
+    _fill_weights(layer)
+
+    output = layer(local_input)
+
+    all_gather.assert_called_once_with(local_input)
+    torch.testing.assert_close(output, gathered_input @ layer.weight.T)
+
+
+def test_column_parallel_linear_keeps_shards_without_sequence_parallel(
+    monkeypatch,
+) -> None:
+    all_gather = Mock(side_effect=AssertionError("unexpected all-gather"))
+    monkeypatch.setattr(linear_module, "sequence_parallel_all_gather", all_gather)
+
+    layer = _column_layer(sequence_parallel=False)
+    _fill_weights(layer)
+    local_input = torch.arange(8, dtype=torch.float32).view(2, 4)
+
+    output = layer(local_input)
+
+    all_gather.assert_not_called()
+    torch.testing.assert_close(output, local_input @ layer.weight.T)
+
+
+def test_row_parallel_linear_reduce_scatters_sequence_shards(monkeypatch) -> None:
+    input_parallel = torch.arange(16, dtype=torch.float32).view(4, 2)
+    layer = _row_layer()
+    _fill_weights(layer)
+    output_parallel = input_parallel @ layer.weight.T
+    local_output = output_parallel[:2]
+    reduce_scatter = Mock(return_value=local_output)
+    all_reduce = Mock(side_effect=AssertionError("unexpected all-reduce"))
+    monkeypatch.setattr(
+        linear_module,
+        "sequence_parallel_reduce_scatter",
+        reduce_scatter,
+    )
+    monkeypatch.setattr(
+        linear_module,
+        "tensor_model_parallel_all_reduce",
+        all_reduce,
+    )
+
+    output = layer(input_parallel)
+
+    reduce_scatter.assert_called_once_with(output_parallel)
+    all_reduce.assert_not_called()
+    torch.testing.assert_close(output, local_output)
+
+
+def test_row_parallel_linear_keeps_all_reduce_by_default(monkeypatch) -> None:
+    output_parallel = torch.arange(16, dtype=torch.float32).view(2, 8)
+    reduced_output = output_parallel + 1
+    all_reduce = Mock(return_value=reduced_output)
+    reduce_scatter = Mock(side_effect=AssertionError("unexpected reduce-scatter"))
+    monkeypatch.setattr(
+        linear_module,
+        "tensor_model_parallel_all_reduce",
+        all_reduce,
+    )
+    monkeypatch.setattr(
+        linear_module,
+        "sequence_parallel_reduce_scatter",
+        reduce_scatter,
+    )
+
+    layer = _row_layer(sequence_parallel=False)
+
+    output = layer.reduce_output(output_parallel)
+
+    all_reduce.assert_called_once_with(output_parallel)
+    reduce_scatter.assert_not_called()
+    torch.testing.assert_close(output, reduced_output)
+
+
+def test_column_parallel_lora_reuses_base_input_preparation() -> None:
+    local_input = torch.arange(8, dtype=torch.float32).view(2, 4)
+    gathered_input = torch.cat([local_input, local_input + 8], dim=0)
+    base_layer = _column_layer()
+    base_layer.prepare_input = Mock(return_value=gathered_input)
+    lora_layer = object.__new__(ColumnParallelLinearWithLoRA)
+    lora_layer.base_layer = base_layer
+    lora_layer.tp_size = 2
+    object.__setattr__(lora_layer, "apply", Mock(return_value=torch.zeros(4, 4)))
+
+    lora_layer(local_input)
+
+    base_layer.prepare_input.assert_called_once_with(local_input)
+
+
+def test_row_parallel_lora_reuses_base_output_reduction() -> None:
+    input_parallel = torch.arange(16, dtype=torch.float32).view(4, 2)
+    output_parallel = torch.cat([input_parallel, input_parallel], dim=1)
+    local_output = output_parallel[:2]
+    base_layer = _row_layer()
+    base_layer.reduce_output = Mock(return_value=local_output)
+    lora_layer = object.__new__(RowParallelLinearWithLoRA)
+    lora_layer.base_layer = base_layer
+    lora_layer.tp_rank = 0
+    lora_layer.tp_size = 2
+    object.__setattr__(lora_layer, "apply", Mock(return_value=output_parallel))
+
+    output = lora_layer(input_parallel)
+
+    base_layer.reduce_output.assert_called_once_with(output_parallel)
+    torch.testing.assert_close(output, local_output)

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -112,9 +112,11 @@ def test_sp_padding_mask_marks_added_rows(
 
 
 @pytest.mark.parametrize(
-    ("data_parallel_size", "enable_sequence_parallel_moe", "expected"),
+    ("data_parallel_size", "enable_sequence_parallel", "expected"),
     [
         (1, None, False),
+        (1, True, True),
+        (1, False, False),
         (2, None, True),
         (2, False, False),
         (2, True, True),
@@ -123,7 +125,7 @@ def test_sp_padding_mask_marks_added_rows(
 def test_moe_sequence_parallel_config_override(
     monkeypatch,
     data_parallel_size: int,
-    enable_sequence_parallel_moe: bool | None,
+    enable_sequence_parallel: bool | None,
     expected: bool,
 ):
     monkeypatch.setattr(current_platform, "device_count", lambda: 2)
@@ -132,10 +134,10 @@ def test_moe_sequence_parallel_config_override(
         data_parallel_size=data_parallel_size,
         enable_expert_parallel=True,
         all2all_backend="allgather_reducescatter",
-        enable_sequence_parallel_moe=enable_sequence_parallel_moe,
+        enable_sequence_parallel=enable_sequence_parallel,
     )
 
-    assert parallel_config.use_sequence_parallel_moe is expected
+    assert parallel_config.use_sequence_parallel is expected
 
 
 def test_moe_sequence_parallel_config_rejects_unsupported_topology(monkeypatch):
@@ -143,11 +145,12 @@ def test_moe_sequence_parallel_config_rejects_unsupported_topology(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match="enable_sequence_parallel_moe=True requires a MoE model",
+        match="MoE sequence parallelism requires",
     ):
         ParallelConfig(
             tensor_parallel_size=2,
-            enable_sequence_parallel_moe=True,
+            enable_sequence_parallel=True,
+            is_moe_model=True,
         )
 
 

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -112,15 +112,18 @@ def test_sp_padding_mask_marks_added_rows(
 
 
 @pytest.mark.parametrize(
-    ("data_parallel_size", "expected"),
+    ("data_parallel_size", "enable_sequence_parallel_moe", "expected"),
     [
-        (1, False),
-        (2, True),
+        (1, None, False),
+        (2, None, True),
+        (2, False, False),
+        (2, True, True),
     ],
 )
-def test_moe_sequence_parallel_requires_data_parallel(
+def test_moe_sequence_parallel_config_override(
     monkeypatch,
     data_parallel_size: int,
+    enable_sequence_parallel_moe: bool | None,
     expected: bool,
 ):
     monkeypatch.setattr(current_platform, "device_count", lambda: 2)
@@ -129,9 +132,23 @@ def test_moe_sequence_parallel_requires_data_parallel(
         data_parallel_size=data_parallel_size,
         enable_expert_parallel=True,
         all2all_backend="allgather_reducescatter",
+        enable_sequence_parallel_moe=enable_sequence_parallel_moe,
     )
 
     assert parallel_config.use_sequence_parallel_moe is expected
+
+
+def test_moe_sequence_parallel_config_rejects_unsupported_topology(monkeypatch):
+    monkeypatch.setattr(current_platform, "device_count", lambda: 2)
+
+    with pytest.raises(
+        ValueError,
+        match="enable_sequence_parallel_moe=True requires a MoE model",
+    ):
+        ParallelConfig(
+            tensor_parallel_size=2,
+            enable_sequence_parallel_moe=True,
+        )
 
 
 def test_kimi_decoder_layer_keeps_moe_states_sequence_sharded(monkeypatch):

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -170,9 +170,10 @@ class ParallelConfig:
     When unset (default), the effective value is derived from
     :attr:`all2all_backend`, :attr:`enable_expert_parallel`,
     :attr:`tensor_parallel_size` and :attr:`data_parallel_size` (the legacy
-    heuristic). When set explicitly, it overrides the derived value so that
-    sequence parallelism can be enabled (or disabled) for any model with
-    ``tensor_parallel_size > 1``, dense models included.
+    heuristic). Setting this to ``False`` disables MoE sequence parallelism.
+    Setting it to ``True`` requires the same supported MoE/EP topology as the
+    default heuristic. Dense sequence parallelism is controlled independently
+    by :class:`PassConfig` and its token threshold.
     """
     enable_batch_sharded_sampling: bool | None = None
     """Use sharded sampling across tensor parallel ranks. Each rank samples
@@ -710,10 +711,7 @@ class ParallelConfig:
     # In this case, ensure the input to the experts is sequence parallel
     # to avoid the excess work.
     #
-    @property
-    def use_sequence_parallel_moe(self) -> bool:
-        if self.enable_sequence_parallel_moe is not None:
-            return self.enable_sequence_parallel_moe
+    def _supports_sequence_parallel_moe(self) -> bool:
         return (
             self.all2all_backend
             in (
@@ -728,7 +726,14 @@ class ParallelConfig:
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1
             and self.data_parallel_size > 1
+            and self.is_moe_model is not False
         )
+
+    @property
+    def use_sequence_parallel_moe(self) -> bool:
+        if self.enable_sequence_parallel_moe is False:
+            return False
+        return self._supports_sequence_parallel_moe()
 
     @property
     def use_all2all(self) -> bool:
@@ -880,9 +885,14 @@ class ParallelConfig:
             * self.prefill_context_parallel_size
         )
 
-        if self.enable_sequence_parallel_moe and self.tensor_parallel_size == 1:
+        if (
+            self.enable_sequence_parallel_moe
+            and not self._supports_sequence_parallel_moe()
+        ):
             raise ValueError(
-                "enable_sequence_parallel_moe=True requires tensor_parallel_size > 1."
+                "enable_sequence_parallel_moe=True requires a MoE model with "
+                "enable_expert_parallel=True, tensor_parallel_size > 1, "
+                "data_parallel_size > 1, and a supported all2all_backend."
             )
 
         if self.distributed_executor_backend == "external_launcher":

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -164,6 +164,16 @@ class ParallelConfig:
     """Whether the deployed model is MoE (if known)."""
     enable_expert_parallel: bool = False
     """Use expert parallelism instead of tensor parallelism for MoE layers."""
+    enable_sequence_parallel_moe: bool | None = None
+    """Enable sequence parallelism for MoE models.
+
+    When unset (default), the effective value is derived from
+    :attr:`all2all_backend`, :attr:`enable_expert_parallel`,
+    :attr:`tensor_parallel_size` and :attr:`data_parallel_size` (the legacy
+    heuristic). When set explicitly, it overrides the derived value so that
+    sequence parallelism can be enabled (or disabled) for any model with
+    ``tensor_parallel_size > 1``, dense models included.
+    """
     enable_batch_sharded_sampling: bool | None = None
     """Use sharded sampling across tensor parallel ranks. Each rank samples
     a slice of the batch instead of every rank sampling all of it. Currently
@@ -702,6 +712,8 @@ class ParallelConfig:
     #
     @property
     def use_sequence_parallel_moe(self) -> bool:
+        if self.enable_sequence_parallel_moe is not None:
+            return self.enable_sequence_parallel_moe
         return (
             self.all2all_backend
             in (
@@ -867,6 +879,11 @@ class ParallelConfig:
             * self.tensor_parallel_size
             * self.prefill_context_parallel_size
         )
+
+        if self.enable_sequence_parallel_moe and self.tensor_parallel_size == 1:
+            raise ValueError(
+                "enable_sequence_parallel_moe=True requires tensor_parallel_size > 1."
+            )
 
         if self.distributed_executor_backend == "external_launcher":
             logger.info("Using external launcher for distributed inference.")

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -164,16 +164,15 @@ class ParallelConfig:
     """Whether the deployed model is MoE (if known)."""
     enable_expert_parallel: bool = False
     """Use expert parallelism instead of tensor parallelism for MoE layers."""
-    enable_sequence_parallel_moe: bool | None = None
-    """Enable sequence parallelism for MoE models.
+    enable_sequence_parallel: bool | None = None
+    """Enable sequence parallelism.
 
     When unset (default), the effective value is derived from
     :attr:`all2all_backend`, :attr:`enable_expert_parallel`,
     :attr:`tensor_parallel_size` and :attr:`data_parallel_size` (the legacy
-    heuristic). Setting this to ``False`` disables MoE sequence parallelism.
-    Setting it to ``True`` requires the same supported MoE/EP topology as the
-    default heuristic. Dense sequence parallelism is controlled independently
-    by :class:`PassConfig` and its token threshold.
+    heuristic). ``False`` disables it. ``True`` requires TP > 1; MoE also
+    requires EP and a supported all2all backend, but permits DP = 1.
+    Dense models use SP only for steps with more than 1000 tokens.
     """
     enable_batch_sharded_sampling: bool | None = None
     """Use sharded sampling across tensor parallel ranks. Each rank samples
@@ -725,21 +724,40 @@ class ParallelConfig:
             )
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1
-            and self.data_parallel_size > 1
             and self.is_moe_model is not False
         )
 
     @property
-    def use_sequence_parallel_moe(self) -> bool:
-        if self.enable_sequence_parallel_moe is False:
+    def use_sequence_parallel(self) -> bool:
+        if self.pipeline_parallel_size > 1 or self.enable_sequence_parallel is False:
             return False
-        return self._supports_sequence_parallel_moe()
+        if self.enable_sequence_parallel is True:
+            return self.tensor_parallel_size > 1 and (
+                self.is_moe_model is False or self._supports_sequence_parallel_moe()
+            )
+        return self.data_parallel_size > 1 and self._supports_sequence_parallel_moe()
+
+    def sequence_parallel_enabled_for_tokens(self, num_tokens: int) -> bool:
+        return self.use_sequence_parallel and (
+            self.is_moe_model is not False or num_tokens > 1000
+        )
+
+    def validate_sequence_parallel(self) -> None:
+        if self.enable_sequence_parallel is not True:
+            return
+        if self.tensor_parallel_size <= 1:
+            raise ValueError("enable_sequence_parallel=True requires TP > 1.")
+        if self.is_moe_model is True and not self._supports_sequence_parallel_moe():
+            raise ValueError(
+                "MoE sequence parallelism requires enable_expert_parallel=True "
+                "and a supported all2all_backend."
+            )
 
     @property
     def use_all2all(self) -> bool:
         return (
             self.data_parallel_size > 1
-            or self.use_sequence_parallel_moe
+            or self.use_sequence_parallel
             or (self.enable_expert_parallel and self.prefill_context_parallel_size > 1)
         )
 
@@ -885,15 +903,7 @@ class ParallelConfig:
             * self.prefill_context_parallel_size
         )
 
-        if (
-            self.enable_sequence_parallel_moe
-            and not self._supports_sequence_parallel_moe()
-        ):
-            raise ValueError(
-                "enable_sequence_parallel_moe=True requires a MoE model with "
-                "enable_expert_parallel=True, tensor_parallel_size > 1, "
-                "data_parallel_size > 1, and a supported all2all_backend."
-            )
+        self.validate_sequence_parallel()
 
         if self.distributed_executor_backend == "external_launcher":
             logger.info("Using external launcher for distributed inference.")

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1094,6 +1094,7 @@ class VllmConfig:
             self.model_config.verify_dual_chunk_attention_config(self.load_config)
 
             self.parallel_config.is_moe_model = self.model_config.is_moe
+            self.parallel_config.validate_sequence_parallel()
 
         if (
             self.model_config is not None
@@ -1589,6 +1590,17 @@ class VllmConfig:
                 self.compilation_config.cudagraph_capture_sizes = []
             else:
                 self.compilation_config.cudagraph_num_of_warmups = 1
+
+            if (
+                self.parallel_config.use_sequence_parallel
+                and self.parallel_config.is_moe_model is False
+            ):
+                logger.info_once(
+                    "CUDA graphs are disabled for dynamic dense sequence parallelism."
+                )
+                self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+                self.compilation_config.max_cudagraph_capture_size = 0
+                self.compilation_config.cudagraph_capture_sizes = []
 
             self._set_cudagraph_sizes()
 

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -28,50 +28,6 @@ def tensor_model_parallel_reduce_scatter(
     return get_tp_group().reduce_scatter(input_, dim)
 
 
-def _custom_sequence_parallel_collective(
-    name: str, input_: torch.Tensor
-) -> torch.Tensor | None:
-    device_communicator = get_tp_group().device_communicator
-    if device_communicator is None:
-        return None
-    collective = getattr(device_communicator, name, None)
-    return None if collective is None else collective(input_)
-
-
-def sequence_parallel_all_gather(input_: torch.Tensor) -> torch.Tensor:
-    """Gather token shards across the tensor-parallel group.
-
-    Sequence parallelism keeps the token dimension sharded between linear
-    layers; column-parallel layers re-gather it right before the matrix
-    multiplication.
-    """
-    output = _custom_sequence_parallel_collective("custom_all_gather", input_)
-    if output is None:
-        output = tensor_model_parallel_all_gather(input_, dim=0)
-    return output
-
-
-def sequence_parallel_reduce_scatter(input_: torch.Tensor) -> torch.Tensor:
-    """Sum partial results and scatter them along the token dimension.
-
-    The token count must already be a multiple of the tensor-parallel size:
-    the model runner pads to TP alignment, and this function deliberately does
-    not pad so invalid shapes fail fast in eager mode.
-    """
-    tp_size = get_tp_group().world_size
-    assert input_.shape[0] % tp_size == 0, (
-        f"sequence_parallel_reduce_scatter got {input_.shape[0]} tokens with "
-        f"tensor_parallel_size={tp_size}; token count must be a multiple of "
-        "the tensor parallel size (the model runner should pad to TP "
-        "alignment before the forward pass)."
-    )
-
-    output = _custom_sequence_parallel_collective("custom_reduce_scatter", input_)
-    if output is not None:
-        return output
-    return tensor_model_parallel_reduce_scatter(input_, dim=0)
-
-
 def tensor_model_parallel_gather(
     input_: torch.Tensor, dst: int = 0, dim: int = -1
 ) -> torch.Tensor | None:

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -28,6 +28,50 @@ def tensor_model_parallel_reduce_scatter(
     return get_tp_group().reduce_scatter(input_, dim)
 
 
+def _custom_sequence_parallel_collective(
+    name: str, input_: torch.Tensor
+) -> torch.Tensor | None:
+    device_communicator = get_tp_group().device_communicator
+    if device_communicator is None:
+        return None
+    collective = getattr(device_communicator, name, None)
+    return None if collective is None else collective(input_)
+
+
+def sequence_parallel_all_gather(input_: torch.Tensor) -> torch.Tensor:
+    """Gather token shards across the tensor-parallel group.
+
+    Sequence parallelism keeps the token dimension sharded between linear
+    layers; column-parallel layers re-gather it right before the matrix
+    multiplication.
+    """
+    output = _custom_sequence_parallel_collective("custom_all_gather", input_)
+    if output is None:
+        output = tensor_model_parallel_all_gather(input_, dim=0)
+    return output
+
+
+def sequence_parallel_reduce_scatter(input_: torch.Tensor) -> torch.Tensor:
+    """Sum partial results and scatter them along the token dimension.
+
+    The token count must already be a multiple of the tensor-parallel size:
+    the model runner pads to TP alignment, and this function deliberately does
+    not pad so invalid shapes fail fast in eager mode.
+    """
+    tp_size = get_tp_group().world_size
+    assert input_.shape[0] % tp_size == 0, (
+        f"sequence_parallel_reduce_scatter got {input_.shape[0]} tokens with "
+        f"tensor_parallel_size={tp_size}; token count must be a multiple of "
+        "the tensor parallel size (the model runner should pad to TP "
+        "alignment before the forward pass)."
+    )
+
+    output = _custom_sequence_parallel_collective("custom_reduce_scatter", input_)
+    if output is not None:
+        return output
+    return tensor_model_parallel_reduce_scatter(input_, dim=0)
+
+
 def tensor_model_parallel_gather(
     input_: torch.Tensor, dst: int = 0, dim: int = -1
 ) -> torch.Tensor | None:

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -354,7 +354,7 @@ class ElasticEPScalingExecutor:
     def _make_eep_moe_config(self, module, dp_group, ep_group):
         parallel_config = self.worker.vllm_config.parallel_config
         tp_size = get_tp_group().world_size
-        sp_size = tp_size if parallel_config.use_sequence_parallel_moe else 1
+        sp_size = tp_size if parallel_config.use_sequence_parallel else 1
         moe_parallel_config = FusedMoEParallelConfig.make(
             tp_size_=tp_size,
             pcp_size_=get_pcp_group().world_size,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -497,9 +497,7 @@ class EngineArgs:
     data_parallel_multi_port_external_lb: bool = False
     data_parallel_backend: DataParallelBackend = ParallelConfig.data_parallel_backend
     enable_expert_parallel: bool = ParallelConfig.enable_expert_parallel
-    enable_sequence_parallel_moe: bool | None = (
-        ParallelConfig.enable_sequence_parallel_moe
-    )
+    enable_sequence_parallel: bool | None = ParallelConfig.enable_sequence_parallel
     enable_batch_sharded_sampling: bool | None = (
         ParallelConfig.enable_batch_sharded_sampling
     )
@@ -1171,8 +1169,8 @@ class EngineArgs:
             **parallel_kwargs["enable_expert_parallel"],
         )
         parallel_group.add_argument(
-            "--enable-sequence-parallel-moe",
-            **parallel_kwargs["enable_sequence_parallel_moe"],
+            "--enable-sequence-parallel",
+            **parallel_kwargs["enable_sequence_parallel"],
         )
         parallel_group.add_argument(
             "--enable-batch-sharded-sampling",
@@ -2309,7 +2307,7 @@ class EngineArgs:
             data_parallel_hybrid_lb=self.data_parallel_hybrid_lb,
             is_moe_model=model_config.is_moe,
             enable_expert_parallel=self.enable_expert_parallel,
-            enable_sequence_parallel_moe=self.enable_sequence_parallel_moe,
+            enable_sequence_parallel=self.enable_sequence_parallel,
             enable_batch_sharded_sampling=self.enable_batch_sharded_sampling,
             enable_ep_weight_filter=self.enable_ep_weight_filter,
             all2all_backend=self.all2all_backend,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -497,6 +497,9 @@ class EngineArgs:
     data_parallel_multi_port_external_lb: bool = False
     data_parallel_backend: DataParallelBackend = ParallelConfig.data_parallel_backend
     enable_expert_parallel: bool = ParallelConfig.enable_expert_parallel
+    enable_sequence_parallel_moe: bool | None = (
+        ParallelConfig.enable_sequence_parallel_moe
+    )
     enable_batch_sharded_sampling: bool | None = (
         ParallelConfig.enable_batch_sharded_sampling
     )
@@ -1166,6 +1169,10 @@ class EngineArgs:
             "--enable-expert-parallel",
             "-ep",
             **parallel_kwargs["enable_expert_parallel"],
+        )
+        parallel_group.add_argument(
+            "--enable-sequence-parallel-moe",
+            **parallel_kwargs["enable_sequence_parallel_moe"],
         )
         parallel_group.add_argument(
             "--enable-batch-sharded-sampling",
@@ -2302,6 +2309,7 @@ class EngineArgs:
             data_parallel_hybrid_lb=self.data_parallel_hybrid_lb,
             is_moe_model=model_config.is_moe,
             enable_expert_parallel=self.enable_expert_parallel,
+            enable_sequence_parallel_moe=self.enable_sequence_parallel_moe,
             enable_batch_sharded_sampling=self.enable_batch_sharded_sampling,
             enable_ep_weight_filter=self.enable_ep_weight_filter,
             all2all_backend=self.all2all_backend,

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -85,7 +85,7 @@ class DPMetadata:
         assert num_tokens_across_dp_cpu is not None
         assert (
             parallel_config.data_parallel_size > 1
-            or parallel_config.use_sequence_parallel_moe
+            or parallel_config.use_sequence_parallel
         )
         assert parallel_config.is_moe_model is not False
         dp_rank = parallel_config.data_parallel_rank
@@ -186,6 +186,7 @@ class ForwardContext:
     moe_layer_index: int = 0
 
     additional_kwargs: dict[str, Any] = field(default_factory=dict)
+    sequence_parallel_enabled: bool = True
 
     def __post_init__(self):
         assert self.cudagraph_runtime_mode.is_valid_runtime_mode(), (
@@ -207,6 +208,10 @@ def get_forward_context() -> ForwardContext:
 
 def is_forward_context_available() -> bool:
     return _forward_context is not None
+
+
+def is_sequence_parallel_enabled() -> bool:
+    return _forward_context is None or _forward_context.sequence_parallel_enabled
 
 
 def create_forward_context(
@@ -268,6 +273,7 @@ def set_forward_context(
     slot_mapping: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None,
     skip_compiled: bool = False,
     is_padding: torch.Tensor | None = None,
+    sequence_parallel_num_tokens: int | None = None,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -282,7 +288,7 @@ def set_forward_context(
     if (
         (
             vllm_config.parallel_config.data_parallel_size > 1
-            or vllm_config.parallel_config.use_sequence_parallel_moe
+            or vllm_config.parallel_config.use_sequence_parallel
         )
         and vllm_config.parallel_config.is_moe_model is not False
         and (attn_metadata is not None or num_tokens is not None)
@@ -337,6 +343,14 @@ def set_forward_context(
         additional_kwargs,
         skip_compiled,
         is_padding=is_padding,
+    )
+
+    forward_context.sequence_parallel_enabled = (
+        vllm_config.parallel_config.sequence_parallel_enabled_for_tokens(
+            sequence_parallel_num_tokens
+            if sequence_parallel_num_tokens is not None
+            else num_tokens or 0
+        )
     )
 
     try:

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -130,7 +130,8 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
         return lora_b
 
     def forward(
-        self, input_: torch.Tensor
+        self,
+        input_: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
         """Forward of ColumnParallelLinear
 
@@ -141,6 +142,7 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
             - output
             - bias
         """
+        input_ = self.base_layer.prepare_input(input_)
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
 
         # Matrix multiply.

--- a/vllm/lora/layers/column_parallel_linear.py
+++ b/vllm/lora/layers/column_parallel_linear.py
@@ -132,6 +132,8 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
     def forward(
         self,
         input_: torch.Tensor,
+        *,
+        sequence_parallel_unpadded_size: int | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
         """Forward of ColumnParallelLinear
 
@@ -142,7 +144,7 @@ class ColumnParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
             - output
             - bias
         """
-        input_ = self.base_layer.prepare_input(input_)
+        input_ = self.base_layer.prepare_input(input_, sequence_parallel_unpadded_size)
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
 
         # Matrix multiply.

--- a/vllm/lora/layers/row_parallel_linear.py
+++ b/vllm/lora/layers/row_parallel_linear.py
@@ -70,10 +70,7 @@ class RowParallelLinearWithLoRA(BaseLinearLayerWithLoRA):
             else self.base_layer.bias
         )
         output_parallel = self.apply(input_parallel, bias_)
-        if self.base_layer.reduce_results and self.tp_size > 1:
-            output = tensor_model_parallel_all_reduce(output_parallel)
-        else:
-            output = output_parallel
+        output = self.base_layer.reduce_output(output_parallel)
 
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         if not self.base_layer.return_bias:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -598,8 +598,10 @@ class ColumnParallelLinear(LinearBase):
     def forward(
         self,
         input_,
+        *,
+        sequence_parallel_unpadded_size: int | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
-        input_ = self.prepare_input(input_)
+        input_ = self.prepare_input(input_, sequence_parallel_unpadded_size)
         bias = self.bias if not self.skip_bias_add else None
 
         # Matrix multiply.
@@ -616,9 +618,15 @@ class ColumnParallelLinear(LinearBase):
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
 
-    def prepare_input(self, input_: torch.Tensor) -> torch.Tensor:
+    def prepare_input(
+        self,
+        input_: torch.Tensor,
+        unpadded_size: int | None = None,
+    ) -> torch.Tensor:
         if self.sequence_parallel and self.tp_size > 1:
-            return tensor_model_parallel_all_gather(input_, dim=0)
+            input_ = tensor_model_parallel_all_gather(input_, dim=0)
+            if unpadded_size is not None:
+                input_ = input_[:unpadded_size]
         return input_
 
     def extra_repr(self) -> str:
@@ -1798,6 +1806,10 @@ class RowParallelLinear(LinearBase):
         if not self.reduce_results or self.tp_size == 1:
             return output_parallel
         if self.sequence_parallel:
+            padding = (-output_parallel.shape[0]) % self.tp_size
+            if padding:
+                pad = (0, 0) * (output_parallel.ndim - 1) + (0, padding)
+                output_parallel = torch.nn.functional.pad(output_parallel, pad)
             return tensor_model_parallel_reduce_scatter(output_parallel, dim=0)
         return tensor_model_parallel_all_reduce(output_parallel)
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -15,6 +15,8 @@ from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    sequence_parallel_all_gather,
+    sequence_parallel_reduce_scatter,
     split_tensor_along_last_dim,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
@@ -444,6 +446,8 @@ class ColumnParallelLinear(LinearBase):
                         (e.g. model.layers.0.qkv_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
+        sequence_parallel: If true, gather token shards before the matrix
+            multiplication.
         tp_rank: Override the tensor-parallel rank used for sharding. Defaults to
             the global TP rank. Used to shard at a coarser granularity than one
             shard per rank (see ``DCPGroupColumnParallelLinear``).
@@ -466,6 +470,7 @@ class ColumnParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        sequence_parallel: bool = False,
         tp_rank: int | None = None,
         tp_size: int | None = None,
     ):
@@ -506,6 +511,7 @@ class ColumnParallelLinear(LinearBase):
 
         self._maybe_allow_fp8_block_shape_mismatch()
         self.gather_output = gather_output
+        self.sequence_parallel = sequence_parallel
 
         self.quant_method.create_weights(
             layer=self,
@@ -594,6 +600,7 @@ class ColumnParallelLinear(LinearBase):
         self,
         input_,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        input_ = self.prepare_input(input_)
         bias = self.bias if not self.skip_bias_add else None
 
         # Matrix multiply.
@@ -610,12 +617,18 @@ class ColumnParallelLinear(LinearBase):
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
 
+    def prepare_input(self, input_: torch.Tensor) -> torch.Tensor:
+        if self.sequence_parallel and self.tp_size > 1:
+            return sequence_parallel_all_gather(input_)
+        return input_
+
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size}"
         s += f", output_features={self.output_size_per_partition}"
         s += f", bias={self.bias is not None}"
         s += f", tp_size={self.tp_size}"
         s += f", gather_output={self.gather_output}"
+        s += f", sequence_parallel={self.sequence_parallel}"
         return s
 
 
@@ -684,6 +697,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, all weights matrix won't be sharded, this layer
                     will be treated as a "Replicated" MergedLinear.
+        sequence_parallel: If true, gather token shards before the matrix
+            multiplication.
     """
 
     def __init__(
@@ -699,6 +714,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        sequence_parallel: bool = False,
     ):
         self.output_sizes = output_sizes
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
@@ -716,6 +732,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             prefix=prefix,
             return_bias=return_bias,
             disable_tp=disable_tp,
+            sequence_parallel=sequence_parallel,
         )
 
     def validate_shard_id(self, shard_id: Any) -> TypeIs[int | tuple[int, ...] | None]:
@@ -1012,6 +1029,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                         (e.g. model.layers.0.qkv_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
+        sequence_parallel: If true, gather token shards before the matrix
+            multiplication.
     """
 
     def __init__(
@@ -1029,6 +1048,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         return_bias: bool = True,
         disable_tp: bool = False,
         v_head_size: int | None = None,
+        sequence_parallel: bool = False,
     ):
         self.hidden_size = hidden_size
         self.head_size = head_size
@@ -1065,6 +1085,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             prefix=prefix,
             return_bias=return_bias,
             disable_tp=disable_tp,
+            sequence_parallel=sequence_parallel,
         )
 
     def validate_shard_id(self, shard_id: Any) -> TypeIs[str | None]:
@@ -1645,6 +1666,8 @@ class RowParallelLinear(LinearBase):
                         (e.g. model.layers.0.down_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
+        sequence_parallel: If true, reduce-scatter partial outputs along the
+            token dimension instead of all-reducing them.
     """
 
     # --8<-- [end:row_parallel_linear]
@@ -1663,6 +1686,7 @@ class RowParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        sequence_parallel: bool = False,
     ):
         # Divide the weight matrix along the first dimension.
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
@@ -1685,6 +1709,7 @@ class RowParallelLinear(LinearBase):
 
         self.input_is_parallel = input_is_parallel
         self.reduce_results = reduce_results
+        self.sequence_parallel = sequence_parallel
 
         self.quant_method.create_weights(
             layer=self,
@@ -1763,15 +1788,19 @@ class RowParallelLinear(LinearBase):
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
         output_parallel = self.quant_method.apply(self, input_parallel, bias_)
 
-        if self.reduce_results and self.tp_size > 1:
-            output = tensor_model_parallel_all_reduce(output_parallel)
-        else:
-            output = output_parallel
+        output = self.reduce_output(output_parallel)
 
         if not self.return_bias:
             return output
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
+
+    def reduce_output(self, output_parallel: torch.Tensor) -> torch.Tensor:
+        if not self.reduce_results or self.tp_size == 1:
+            return output_parallel
+        if self.sequence_parallel:
+            return sequence_parallel_reduce_scatter(output_parallel)
+        return tensor_model_parallel_all_reduce(output_parallel)
 
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size_per_partition}"
@@ -1779,4 +1808,5 @@ class RowParallelLinear(LinearBase):
         s += f", bias={self.bias is not None}"
         s += f", tp_size={self.tp_size}"
         s += f", reduce_results={self.reduce_results}"
+        s += f", sequence_parallel={self.sequence_parallel}"
         return s

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -15,11 +15,10 @@ from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
-    sequence_parallel_all_gather,
-    sequence_parallel_reduce_scatter,
     split_tensor_along_last_dim,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
+    tensor_model_parallel_reduce_scatter,
 )
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
@@ -619,7 +618,7 @@ class ColumnParallelLinear(LinearBase):
 
     def prepare_input(self, input_: torch.Tensor) -> torch.Tensor:
         if self.sequence_parallel and self.tp_size > 1:
-            return sequence_parallel_all_gather(input_)
+            return tensor_model_parallel_all_gather(input_, dim=0)
         return input_
 
     def extra_repr(self) -> str:
@@ -1799,7 +1798,7 @@ class RowParallelLinear(LinearBase):
         if not self.reduce_results or self.tp_size == 1:
             return output_parallel
         if self.sequence_parallel:
-            return sequence_parallel_reduce_scatter(output_parallel)
+            return tensor_model_parallel_reduce_scatter(output_parallel, dim=0)
         return tensor_model_parallel_all_reduce(output_parallel)
 
     def extra_repr(self) -> str:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -20,6 +20,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.forward_context import is_sequence_parallel_enabled
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.determinism.batch_invariant import (
@@ -623,7 +624,7 @@ class ColumnParallelLinear(LinearBase):
         input_: torch.Tensor,
         unpadded_size: int | None = None,
     ) -> torch.Tensor:
-        if self.sequence_parallel and self.tp_size > 1:
+        if self.sequence_parallel and self.tp_size > 1 and is_sequence_parallel_enabled():
             input_ = tensor_model_parallel_all_gather(input_, dim=0)
             if unpadded_size is not None:
                 input_ = input_[:unpadded_size]
@@ -1805,7 +1806,7 @@ class RowParallelLinear(LinearBase):
     def reduce_output(self, output_parallel: torch.Tensor) -> torch.Tensor:
         if not self.reduce_results or self.tp_size == 1:
             return output_parallel
-        if self.sequence_parallel:
+        if self.sequence_parallel and is_sequence_parallel_enabled():
             padding = (-output_parallel.shape[0]) % self.tp_size
             if padding:
                 pad = (0, 0) * (output_parallel.ndim - 1) + (0, padding)

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -379,6 +379,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         prefix: str = "",
         gqa_interleaved_layout=False,
         reduce_results: bool = True,
+        sequence_parallel: bool = False,
     ) -> None:
         super().__init__(config, vllm_config, prefix)
 
@@ -424,6 +425,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             key_dim=self.key_dim,
             value_dim=self.value_dim,
             quant_config=self.quant_config,
+            sequence_parallel=sequence_parallel,
             prefix=f"{prefix}.in_proj_qkvz",
         )
 
@@ -435,6 +437,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             num_v_heads=self.num_v_heads,
             quant_config=self.quant_config,
             prefix=f"{prefix}.in_proj_ba",
+            sequence_parallel=sequence_parallel,
         )
         self.disable_tp_for_ba_proj = self.maybe_disable_tp(self.quant_config)
 
@@ -490,6 +493,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             bias=False,
             input_is_parallel=True,
             reduce_results=reduce_results,
+            sequence_parallel=sequence_parallel,
             quant_config=self.quant_config,
             prefix=f"{prefix}.out_proj",
         )
@@ -554,6 +558,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         value_dim: int,
         quant_config: QuantizationConfig | None,
         prefix: str,
+        sequence_parallel: bool = False,
     ) -> MergedColumnParallelLinear:
         # When gqa_interleaved_layout=True (Qwen3-Next), qkvz weights are
         # stored as a single fused tensor with interleaved GQA layout, so we
@@ -570,6 +575,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             output_sizes=output_sizes,
             bias=False,
             quant_config=quant_config,
+            sequence_parallel=sequence_parallel,
             prefix=prefix,
         )
 
@@ -579,6 +585,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         num_v_heads: int,
         quant_config: QuantizationConfig | None,
         prefix: str,
+        sequence_parallel: bool = False,
     ) -> MergedColumnParallelLinear:
         # When gqa_interleaved_layout=True (Qwen3-Next), in_proj_ba is stored
         # as a single fused weight [b_g0, a_g0, b_g1, a_g1, ...] interleaved
@@ -595,6 +602,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             quant_config=quant_config,
             prefix=prefix,
             disable_tp=self.maybe_disable_tp(quant_config),
+            sequence_parallel=sequence_parallel,
         )
 
     def maybe_disable_tp(self, quant_config: QuantizationConfig | None) -> bool:
@@ -857,9 +865,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         """ROCm forward using AITER Triton fused projection+attention when
         available, otherwise falling back to the generic CUDA path."""
         if GDN_AITER_TRITON_AVAILABLE:
-            num_tokens = hidden_states.size(0)
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
             projected_states_ba, _ = self.in_proj_ba(hidden_states)
+            num_tokens = projected_states_qkvz.size(0)
             projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
             projected_states_ba = projected_states_ba.view(num_tokens, -1)
             core_attn_out = torch.empty(
@@ -896,12 +904,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         2. Core attention (custom op)
         3. Output projection
         """
-        num_tokens = hidden_states.size(0)
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
         mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
         ba, _ = self.in_proj_ba(hidden_states)
+        num_tokens = mixed_qkvz.size(0)
 
         use_fused_gdn_decode = (
             self.enable_fused_gdn_decode
@@ -974,13 +982,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         2. Core attention (custom op)
         3. Output projection
         """
-        num_tokens = hidden_states.size(0)
-
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
         projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
         projected_states_ba, _ = self.in_proj_ba(hidden_states)
+        num_tokens = projected_states_qkvz.size(0)
 
         # ============================================================
         # Part 2: Core Attention
@@ -1039,7 +1046,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             z = z.reshape(z.size(0), -1, self.head_v_dim)
             b, a = ba.chunk(2, dim=-1)
 
-        num_tokens = hidden_states.size(0)
+        num_tokens = mixed_qkvz.size(0)
         core_attn_out = torch.zeros(
             (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
             dtype=hidden_states.dtype,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -836,8 +836,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        sequence_parallel_unpadded_size: int | None = None,
     ) -> torch.Tensor:
-        return self._forward_method(hidden_states)
+        return self._forward_method(hidden_states, sequence_parallel_unpadded_size)
 
     def _output_projection(
         self,
@@ -861,12 +862,19 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def forward_hip(
         self,
         hidden_states: torch.Tensor,
+        sequence_parallel_unpadded_size: int | None = None,
     ) -> torch.Tensor:
         """ROCm forward using AITER Triton fused projection+attention when
         available, otherwise falling back to the generic CUDA path."""
         if GDN_AITER_TRITON_AVAILABLE:
-            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
-            projected_states_ba, _ = self.in_proj_ba(hidden_states)
+            projected_states_qkvz, _ = self.in_proj_qkvz(
+                hidden_states,
+                sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+            )
+            projected_states_ba, _ = self.in_proj_ba(
+                hidden_states,
+                sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+            )
             num_tokens = projected_states_qkvz.size(0)
             projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
             projected_states_ba = projected_states_ba.view(num_tokens, -1)
@@ -892,11 +900,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
             return self._output_projection(core_attn_out, z)
         else:
-            return self.forward_cuda(hidden_states)
+            return self.forward_cuda(hidden_states, sequence_parallel_unpadded_size)
 
     def forward_cuda(
         self,
         hidden_states: torch.Tensor,
+        sequence_parallel_unpadded_size: int | None = None,
     ) -> torch.Tensor:
         """
         Forward pass with three parts:
@@ -907,8 +916,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        mixed_qkvz, _ = self.in_proj_qkvz(
+            hidden_states,
+            sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+        )
+        ba, _ = self.in_proj_ba(
+            hidden_states,
+            sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+        )
         num_tokens = mixed_qkvz.size(0)
 
         use_fused_gdn_decode = (
@@ -975,6 +990,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def forward_xpu(
         self,
         hidden_states: torch.Tensor,
+        sequence_parallel_unpadded_size: int | None = None,
     ) -> torch.Tensor:
         """
         Forward pass with three parts:
@@ -985,8 +1001,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        projected_states_ba, _ = self.in_proj_ba(hidden_states)
+        projected_states_qkvz, _ = self.in_proj_qkvz(
+            hidden_states,
+            sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+        )
+        projected_states_ba, _ = self.in_proj_ba(
+            hidden_states,
+            sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+        )
         num_tokens = projected_states_qkvz.size(0)
 
         # ============================================================
@@ -1023,11 +1045,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def forward_cpu(
         self,
         hidden_states: torch.Tensor,
+        sequence_parallel_unpadded_size: int | None = None,
     ) -> torch.Tensor:
         assert not hasattr(self, "in_proj_qkv"), "lora isn't supported on CPU."
 
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        mixed_qkvz, _ = self.in_proj_qkvz(
+            hidden_states,
+            sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+        )
+        ba, _ = self.in_proj_ba(
+            hidden_states,
+            sequence_parallel_unpadded_size=sequence_parallel_unpadded_size,
+        )
 
         if self.gqa_interleaved_layout:
             # Qwen3-Next: unpack the interleaved GQA layout

--- a/vllm/model_executor/models/AXK1.py
+++ b/vllm/model_executor/models/AXK1.py
@@ -120,7 +120,7 @@ class AXK1MoE(nn.Module):
         self.n_routed_experts: int = config.n_routed_experts
         self.n_shared_experts: int | None = config.n_shared_experts
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         if config.hidden_act != "silu":
             raise ValueError(

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -127,7 +127,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
             residual=None,
         )
         hidden_states = residual + hidden_states  # pre-final-norm (logits hidden)
-        if self.mtp_block.use_sequence_parallel_moe:
+        if self.mtp_block.use_sequence_parallel:
             hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
             hidden_states = hidden_states[: positions.shape[0]]
         # Recycle the post-final-norm hidden into the next draft step.

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -305,7 +305,7 @@ class DeepseekV2MoE(nn.Module):
         self.n_routed_experts: int = config.n_routed_experts
         self.n_shared_experts: int = config.n_shared_experts
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         if config.hidden_act != "silu":
             raise ValueError(
@@ -1285,8 +1285,8 @@ class DeepseekV2DecoderLayer(nn.Module):
         )
         # TODO(wentao): enable SP MoE with PP after the PP boundary logic can safely
         # send/receive sequence-parallel hidden_states across stages.
-        self.use_sequence_parallel_moe = (
-            parallel_config.use_sequence_parallel_moe
+        self.use_sequence_parallel = (
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
             and is_moe_layer
         )
@@ -1305,7 +1305,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
             topk_indices_buffer=topk_indices_buffer,
-            reduce_results=not self.use_sequence_parallel_moe,
+            reduce_results=not self.use_sequence_parallel,
         )
 
         if is_moe_layer:
@@ -1340,7 +1340,7 @@ class DeepseekV2DecoderLayer(nn.Module):
     ) -> torch.Tensor:
         full_num_tokens = positions.shape[0]
         input_is_sequence_parallel = (
-            self.use_sequence_parallel_moe
+            self.use_sequence_parallel
             and residual is not None
             and hidden_states.shape[0] != full_num_tokens
         )
@@ -1374,7 +1374,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                 # first layer.
                 residual *= 1.0 / self.routed_scaling_factor
 
-        if self.use_sequence_parallel_moe:
+        if self.use_sequence_parallel:
             tp_world_size = get_tensor_model_parallel_world_size()
             # small trick using minus, eg. -17 % 8 = 7
             sp_pad = (-hidden_states.shape[0]) % tp_world_size
@@ -1386,7 +1386,7 @@ class DeepseekV2DecoderLayer(nn.Module):
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        if self.use_sequence_parallel_moe:
+        if self.use_sequence_parallel:
             hidden_states = self.mlp(
                 hidden_states,
                 already_sequence_parallel=True,
@@ -1523,7 +1523,7 @@ class DeepseekV2Model(nn.Module):
             # all gather if we need to use the whole states
             if (
                 hidden_states.shape[0] != positions.shape[0]
-                and not layer.use_sequence_parallel_moe
+                and not layer.use_sequence_parallel
             ):
                 combined_states = torch.cat([hidden_states, residual], dim=-1)
                 combined_states = tensor_model_parallel_all_gather(combined_states, 0)

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -368,7 +368,7 @@ class MLPBlock(torch.nn.Module):
         parallel_config = vllm_config.parallel_config
 
         self.is_sequence_parallel = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and vllm_config.lora_config is None
         )
 

--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -268,7 +268,7 @@ class GraniteMoeDecoderLayer(nn.Module):
             hidden_size=config.hidden_size,
             intermediate_size=config.intermediate_size,
             quant_config=quant_config,
-            is_sequence_parallel=parallel_config.use_sequence_parallel_moe,
+            is_sequence_parallel=parallel_config.use_sequence_parallel,
             prefix=f"{prefix}.block_sparse_moe",
         )
 

--- a/vllm/model_executor/models/interns1_pro.py
+++ b/vllm/model_executor/models/interns1_pro.py
@@ -147,7 +147,7 @@ class InternS1ProMoeSparseMoeBlock(nn.Module):
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.num_experts
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         if self.tp_size > config.num_experts:
             raise ValueError(

--- a/vllm/model_executor/models/interns2_mobius.py
+++ b/vllm/model_executor/models/interns2_mobius.py
@@ -78,7 +78,7 @@ class InternS2MobiusMetaMoeBlock(nn.Module):
         self.ep_rank = get_ep_group().rank_in_group
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.num_experts
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         if self.tp_size > self.n_routed_experts:
             raise ValueError(
@@ -146,7 +146,7 @@ class InternS2MobiusSharedExpertBlock(nn.Module):
         super().__init__()
 
         config = vllm_config.model_config.hf_text_config
-        is_sequence_parallel = vllm_config.parallel_config.use_sequence_parallel_moe
+        is_sequence_parallel = vllm_config.parallel_config.use_sequence_parallel
         self.shared_expert_gate = ReplicatedLinear(
             config.hidden_size,
             1,
@@ -185,7 +185,7 @@ class InternS2MobiusDecoderLayer(nn.Module):
         self.layer_idx = extract_layer_index(prefix)
         self.num_blocks = config.num_blocks
         self.use_attn_reduce_scatter_for_moe = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
         )
 

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -92,7 +92,7 @@ class Llama4MoE(nn.Module):
 
         self.tp_size = get_tensor_model_parallel_world_size()
         self.top_k = config.num_experts_per_tok
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
         self.ep_group = get_ep_group().device_group
         self.ep_rank = get_ep_group().rank_in_group
         self.ep_size = self.ep_group.size()

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -130,7 +130,7 @@ class MiMoV2MoE(nn.Module):
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.n_routed_experts
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         if self.tp_size > config.n_routed_experts:
             raise ValueError(

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -144,7 +144,7 @@ class NemotronHMoE(nn.Module):
             config.moe_latent_size if self.use_latent_moe else config.hidden_size
         )
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         self.gate = GateLinear(
             config.hidden_size,

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -146,7 +146,7 @@ class OpenPanguMoE(nn.Module):
         self.n_routed_experts: int = config.n_routed_experts
         self.n_shared_experts: int = config.n_shared_experts
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
         check_ffn_act_fn(config.hidden_act)
 
         self.gate = ReplicatedLinear(

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -82,6 +82,7 @@ class Qwen2MoeMLP(nn.Module):
         is_sequence_parallel: bool = False,
         disable_tp: bool = False,
         prefix: str = "",
+        sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
         disable_tp = disable_tp or is_sequence_parallel
@@ -92,6 +93,7 @@ class Qwen2MoeMLP(nn.Module):
             quant_config=quant_config,
             disable_tp=disable_tp,
             prefix=f"{prefix}.gate_up_proj",
+            sequence_parallel=sequence_parallel,
         )
         self.down_proj = RowParallelLinear(
             intermediate_size,
@@ -101,6 +103,7 @@ class Qwen2MoeMLP(nn.Module):
             reduce_results=reduce_results,
             disable_tp=disable_tp,
             prefix=f"{prefix}.down_proj",
+            sequence_parallel=sequence_parallel,
         )
         if hidden_act != "silu":
             raise ValueError(

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -135,10 +135,9 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
         self.is_sequence_parallel = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
         )
-        self.use_attn_reduce_scatter_for_moe = self.is_sequence_parallel
 
         if self.layer_type == "linear_attention":
             self.linear_attn = QwenGatedDeltaNetAttention(
@@ -173,7 +172,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
-                is_sequence_parallel=self.is_sequence_parallel,
+                sequence_parallel=self.is_sequence_parallel,
                 prefix=f"{prefix}.mlp",
             )
         else:
@@ -234,7 +233,7 @@ class Qwen3_5Model(Qwen3NextModel):
         )
         parallel_config = vllm_config.parallel_config
         self.is_sequence_parallel = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
         )
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -134,12 +134,11 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
 
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
-        is_moe_layer = config.model_type == "qwen3_5_moe_text"
-        self.use_attn_reduce_scatter_for_moe = (
+        self.is_sequence_parallel = (
             parallel_config.use_sequence_parallel_moe
             and parallel_config.pipeline_parallel_size == 1
-            and is_moe_layer
         )
+        self.use_attn_reduce_scatter_for_moe = self.is_sequence_parallel
 
         if self.layer_type == "linear_attention":
             self.linear_attn = QwenGatedDeltaNetAttention(
@@ -147,7 +146,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 vllm_config=vllm_config,
                 prefix=f"{prefix}.linear_attn",
                 gqa_interleaved_layout=False,
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                sequence_parallel=self.is_sequence_parallel,
             )
         elif self.layer_type == "full_attention":
             self.self_attn = Qwen3NextAttention(
@@ -156,7 +155,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 cache_config=cache_config,
                 quant_config=quant_config,
                 prefix=f"{prefix}.self_attn",
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                sequence_parallel=self.is_sequence_parallel,
             )
         else:
             raise ValueError(f"Invalid layer_type {self.layer_type}")
@@ -174,6 +173,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
+                is_sequence_parallel=self.is_sequence_parallel,
                 prefix=f"{prefix}.mlp",
             )
         else:

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -233,6 +233,10 @@ class Qwen3_5Model(Qwen3NextModel):
             vllm_config.model_config.hf_text_config
         )
         parallel_config = vllm_config.parallel_config
+        self.is_sequence_parallel = (
+            parallel_config.use_sequence_parallel_moe
+            and parallel_config.pipeline_parallel_size == 1
+        )
 
         eplb_config = parallel_config.eplb_config
         self.num_redundant_experts = eplb_config.num_redundant_experts

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -10,6 +10,7 @@ from torch import nn
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group, tensor_model_parallel_all_gather
+from vllm.forward_context import is_sequence_parallel_enabled
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.utils import (
     is_model_fused_shared_expert_compatible,
@@ -168,7 +169,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
 
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[current_step_idx]
-        if mtp_layer.use_attn_reduce_scatter_for_moe:
+        if mtp_layer.is_sequence_parallel and is_sequence_parallel_enabled():
             assert hidden_states.shape[0] == positions.shape[-1]
             hidden_states = sequence_parallel_chunk(hidden_states)
             assert residual is None
@@ -184,7 +185,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
-        if mtp_layer.use_attn_reduce_scatter_for_moe:
+        if mtp_layer.is_sequence_parallel and is_sequence_parallel_enabled():
             hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
             hidden_states = hidden_states[: positions.shape[-1]]
         return hidden_states

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -146,7 +146,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.num_experts
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         if self.tp_size > config.num_experts:
             raise ValueError(

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -426,7 +426,10 @@ class Qwen3NextAttention(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
+        qkv, _ = self.qkv_proj(
+            hidden_states,
+            sequence_parallel_unpadded_size=positions.shape[-1],
+        )
         q, k, v, gate = self._project_qkv_gate(qkv, positions)
         attn_output = self.attn(q, k, v)
         if gate is not None:
@@ -539,7 +542,10 @@ class Qwen3NextDecoderLayer(nn.Module):
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
         if self.layer_type == "linear_attention":
-            hidden_states = self.linear_attn(hidden_states=hidden_states)
+            hidden_states = self.linear_attn(
+                hidden_states=hidden_states,
+                sequence_parallel_unpadded_size=positions.shape[-1],
+            )
         elif self.layer_type == "full_attention":
             hidden_states = self.self_attn(
                 hidden_states=hidden_states,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -16,6 +16,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
+from vllm.forward_context import is_sequence_parallel_enabled
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
 from vllm.model_executor.layers.fused_moe.utils import (
@@ -126,7 +127,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         self.ep_size = self.ep_group.size()
         self.n_routed_experts = config.num_experts
 
-        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel
 
         shared_expert_group_size = get_quark_ocp_mx_group_size(
             quant_config,
@@ -238,6 +239,8 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=hidden_states
         )
+        if replicated_shared_output is not None:
+            final_hidden_states = final_hidden_states + replicated_shared_output
 
         return final_hidden_states.view(orig_shape)
 
@@ -456,10 +459,9 @@ class Qwen3NextDecoderLayer(nn.Module):
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
         self.is_sequence_parallel = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
         )
-        self.use_attn_reduce_scatter_for_moe = self.is_sequence_parallel
 
         mlp_only_layers = (
             [] if not hasattr(config, "mlp_only_layers") else config.mlp_only_layers
@@ -500,7 +502,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
-                is_sequence_parallel=self.is_sequence_parallel,
+                sequence_parallel=self.is_sequence_parallel,
                 prefix=f"{prefix}.mlp",
             )
 
@@ -606,7 +608,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         config: Qwen3NextConfig = vllm_config.model_config.hf_text_config
         parallel_config = vllm_config.parallel_config
         self.is_sequence_parallel = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
         )
 
@@ -664,7 +666,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             else:
                 hidden_states = self.embed_input_ids(input_ids)
             residual = None
-            if self.is_sequence_parallel:
+            if self.is_sequence_parallel and is_sequence_parallel_enabled():
                 hidden_states = sequence_parallel_chunk(hidden_states)
         else:
             assert intermediate_tensors is not None
@@ -691,7 +693,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
-        if self.is_sequence_parallel:
+        if self.is_sequence_parallel and is_sequence_parallel_enabled():
             if aux_hidden_states:
                 hidden_size = hidden_states.shape[-1]
                 hidden_states = torch.cat([hidden_states, *aux_hidden_states], dim=-1)

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -15,7 +15,6 @@ from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
-    tensor_model_parallel_reduce_scatter,
 )
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
@@ -79,18 +78,6 @@ from .utils import (
 )
 
 KVCache = tuple[torch.Tensor, torch.Tensor]
-
-
-def _should_use_sequence_parallel(vllm_config: VllmConfig) -> bool:
-    config = vllm_config.model_config.hf_text_config
-    parallel_config = vllm_config.parallel_config
-    return (
-        parallel_config.use_sequence_parallel_moe
-        and parallel_config.pipeline_parallel_size == 1
-        and getattr(config, "num_experts", 0) > 0
-        and not getattr(config, "mlp_only_layers", [])
-        and getattr(config, "decoder_sparse_step", 1) == 1
-    )
 
 
 def _should_replicate_misaligned_shared_expert(
@@ -237,15 +224,11 @@ class Qwen3NextSparseMoeBlock(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        already_sequence_parallel: bool = False,
     ) -> torch.Tensor:
         # NOTE: hidden_states can have either 1D or 2D shape.
         orig_shape = hidden_states.shape
-        num_tokens, hidden_dim = hidden_states.shape
+        _, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
-
-        if self.is_sequence_parallel and not already_sequence_parallel:
-            hidden_states = sequence_parallel_chunk(hidden_states)
 
         replicated_shared_output = (
             self.shared_expert(hidden_states)
@@ -255,14 +238,6 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=hidden_states
         )
-        if replicated_shared_output is not None:
-            final_hidden_states += replicated_shared_output
-
-        if self.is_sequence_parallel and not already_sequence_parallel:
-            final_hidden_states = tensor_model_parallel_all_gather(
-                final_hidden_states, 0
-            )
-            final_hidden_states = final_hidden_states[:num_tokens]
 
         return final_hidden_states.view(orig_shape)
 
@@ -275,6 +250,7 @@ class Qwen3NextAttention(nn.Module):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
+        sequence_parallel: bool = False,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -310,6 +286,7 @@ class Qwen3NextAttention(nn.Module):
             self.total_num_kv_heads,
             bias=getattr(config, "qkv_bias", False),
             quant_config=quant_config,
+            sequence_parallel=sequence_parallel,
             prefix=f"{prefix}.qkv_proj",
         )
 
@@ -318,6 +295,7 @@ class Qwen3NextAttention(nn.Module):
             config.hidden_size,
             bias=False,
             reduce_results=reduce_results,
+            sequence_parallel=sequence_parallel,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
@@ -469,10 +447,16 @@ class Qwen3NextDecoderLayer(nn.Module):
         config = vllm_config.model_config.hf_config
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
+        parallel_config = vllm_config.parallel_config
         quant_config = vllm_config.quant_config
 
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
+        self.is_sequence_parallel = (
+            parallel_config.use_sequence_parallel_moe
+            and parallel_config.pipeline_parallel_size == 1
+        )
+        self.use_attn_reduce_scatter_for_moe = self.is_sequence_parallel
 
         mlp_only_layers = (
             [] if not hasattr(config, "mlp_only_layers") else config.mlp_only_layers
@@ -481,9 +465,6 @@ class Qwen3NextDecoderLayer(nn.Module):
             config.num_experts > 0
             and (self.layer_idx + 1) % config.decoder_sparse_step == 0
         )
-        self.use_attn_reduce_scatter_for_moe = _should_use_sequence_parallel(
-            vllm_config
-        )
 
         if self.layer_type == "linear_attention":
             self.linear_attn = QwenGatedDeltaNetAttention(
@@ -491,7 +472,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 vllm_config=vllm_config,
                 prefix=f"{prefix}.linear_attn",
                 gqa_interleaved_layout=True,
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                sequence_parallel=self.is_sequence_parallel,
             )
         elif self.layer_type == "full_attention":
             self.self_attn = Qwen3NextAttention(
@@ -499,7 +480,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 model_config=model_config,
                 cache_config=cache_config,
                 quant_config=quant_config,
-                reduce_results=not self.use_attn_reduce_scatter_for_moe,
+                sequence_parallel=self.is_sequence_parallel,
                 prefix=f"{prefix}.self_attn",
             )
         else:
@@ -516,6 +497,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
+                is_sequence_parallel=self.is_sequence_parallel,
                 prefix=f"{prefix}.mlp",
             )
 
@@ -550,17 +532,11 @@ class Qwen3NextDecoderLayer(nn.Module):
         positions: torch.Tensor,
         **kwargs: object,
     ):
-        full_num_tokens = positions.shape[-1]
-
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
-
-        if self.use_attn_reduce_scatter_for_moe:
-            hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
-            hidden_states = hidden_states[:full_num_tokens]
 
         if self.layer_type == "linear_attention":
             hidden_states = self.linear_attn(hidden_states=hidden_states)
@@ -582,23 +558,9 @@ class Qwen3NextDecoderLayer(nn.Module):
                     self.attn_layer_scale.to(hidden_states.dtype) + 1
                 )
 
-        if self.use_attn_reduce_scatter_for_moe:
-            tp_world_size = get_tensor_model_parallel_world_size()
-            # small trick using minus, eg. -17 % 8 = 7
-            sp_pad = (-hidden_states.shape[0]) % tp_world_size
-            # pad if not divisible by world size
-            hidden_states = torch.nn.functional.pad(hidden_states, (0, 0, 0, sp_pad))
-            hidden_states = tensor_model_parallel_reduce_scatter(hidden_states, 0)
-
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        if self.use_attn_reduce_scatter_for_moe:
-            hidden_states = self.mlp(
-                hidden_states,
-                already_sequence_parallel=True,
-            )
-        else:
-            hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states)
 
         if self.layer_scale:
             if len(hidden_states.shape) == 2:
@@ -637,6 +599,10 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
 
         config: Qwen3NextConfig = vllm_config.model_config.hf_text_config
         parallel_config = vllm_config.parallel_config
+        self.is_sequence_parallel = (
+            parallel_config.use_sequence_parallel_moe
+            and parallel_config.pipeline_parallel_size == 1
+        )
 
         eplb_config = parallel_config.eplb_config
         self.num_redundant_experts = eplb_config.num_redundant_experts
@@ -679,10 +645,6 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
-    @property
-    def use_sequence_parallel(self) -> bool:
-        return self.layers[self.start_layer].use_attn_reduce_scatter_for_moe
-
     def forward(
         self,
         input_ids: torch.Tensor | None,
@@ -696,16 +658,14 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             else:
                 hidden_states = self.embed_input_ids(input_ids)
             residual = None
+            if self.is_sequence_parallel:
+                hidden_states = sequence_parallel_chunk(hidden_states)
         else:
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
         full_num_tokens = positions.shape[-1]
-        if self.use_sequence_parallel:
-            hidden_states = sequence_parallel_chunk(hidden_states)
-            assert residual is None
-
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for layer_idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
@@ -725,7 +685,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
-        if self.use_sequence_parallel:
+        if self.is_sequence_parallel:
             if aux_hidden_states:
                 hidden_size = hidden_states.shape[-1]
                 hidden_states = torch.cat([hidden_states, *aux_hidden_states], dim=-1)

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -10,6 +10,7 @@ from torch import nn
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group, tensor_model_parallel_all_gather
+from vllm.forward_context import is_sequence_parallel_enabled
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.utils import (
     is_model_fused_shared_expert_compatible,
@@ -140,7 +141,7 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
 
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[current_step_idx]
-        if mtp_layer.use_attn_reduce_scatter_for_moe:
+        if mtp_layer.is_sequence_parallel and is_sequence_parallel_enabled():
             assert hidden_states.shape[0] == positions.shape[-1]
             hidden_states = sequence_parallel_chunk(hidden_states)
             assert residual is None
@@ -156,7 +157,7 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
-        if mtp_layer.use_attn_reduce_scatter_for_moe:
+        if mtp_layer.is_sequence_parallel and is_sequence_parallel_enabled():
             hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
             hidden_states = hidden_states[: positions.shape[-1]]
         return hidden_states

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -329,7 +329,7 @@ class MoEMixin(MixtureOfExperts):
                         kwargs |= dict(
                             scoring_func=fuser.scoring_func,
                             is_sequence_parallel=(
-                                self.parallel_config.use_sequence_parallel_moe
+                                self.parallel_config.use_sequence_parallel
                             ),
                             gate=gate,
                             shared_experts=shared_experts,

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -71,7 +71,7 @@ class DeepseekV32DecoderLayer(torch.nn.Module):
         self.layer_idx = layer_idx
         self.use_mha = False
         self.use_sequence_parallel = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
         )
 
@@ -176,7 +176,7 @@ class DeepseekV32Model(torch.nn.Module):
         self.vocab_size = config.vocab_size
         parallel_config = vllm_config.parallel_config
         self.use_sequence_parallel = (
-            parallel_config.use_sequence_parallel_moe
+            parallel_config.use_sequence_parallel
             and parallel_config.pipeline_parallel_size == 1
         )
         # DSA is always sparse (has index_topk); allocate the shared top-k

--- a/vllm/models/dots3_note/nvidia/model.py
+++ b/vllm/models/dots3_note/nvidia/model.py
@@ -560,7 +560,7 @@ class Dots3NoteDecoderLayer(DeepseekV32DecoderLayer):
                 prefix=f"{prefix}.mlp",
                 reduce_results=False,
             )
-        self.use_sequence_parallel_moe = False
+        self.use_sequence_parallel = False
         self.tp_size = parallel_config.tensor_parallel_size
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(

--- a/vllm/models/dots3_note/nvidia/mtp.py
+++ b/vllm/models/dots3_note/nvidia/mtp.py
@@ -90,7 +90,7 @@ class Dots3NoteMultiTokenPredictorLayer(nn.Module):
         hidden_states, residual = self.mtp_block(
             positions=positions, hidden_states=hidden_states, residual=None
         )
-        is_sequence_parallel = self.mtp_block.use_sequence_parallel_moe
+        is_sequence_parallel = self.mtp_block.use_sequence_parallel
         if not is_sequence_parallel:
             hidden_states = tensor_model_parallel_all_reduce(hidden_states)
         hidden_states, _ = self.shared_head.norm(hidden_states, residual)

--- a/vllm/models/qwen4_exp/amd/model.py
+++ b/vllm/models/qwen4_exp/amd/model.py
@@ -162,7 +162,7 @@ class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
 
     def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
         parallel_config = vllm_config.parallel_config
-        if parallel_config.use_sequence_parallel_moe:
+        if parallel_config.use_sequence_parallel:
             raise NotImplementedError(
                 "Qwen4Exp HC does not support sequence-parallel MoE"
             )
@@ -187,7 +187,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
         self.config = config
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
-        if vllm_config.parallel_config.use_sequence_parallel_moe:
+        if vllm_config.parallel_config.use_sequence_parallel:
             raise NotImplementedError(
                 "Qwen4Exp HC does not support sequence-parallel MoE"
             )

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -162,7 +162,7 @@ class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
 
     def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
         parallel_config = vllm_config.parallel_config
-        if parallel_config.use_sequence_parallel_moe:
+        if parallel_config.use_sequence_parallel:
             raise NotImplementedError(
                 "Qwen4Exp HC does not support sequence-parallel MoE"
             )
@@ -187,7 +187,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
         self.config = config
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
-        if vllm_config.parallel_config.use_sequence_parallel_moe:
+        if vllm_config.parallel_config.use_sequence_parallel:
             raise NotImplementedError(
                 "Qwen4Exp HC does not support sequence-parallel MoE"
             )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3556,7 +3556,12 @@ class GPUModelRunner(
         # Pad tokens to multiple of tensor_parallel_size when
         # enabled collective fusion for SP
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        if self.compilation_config.pass_config.enable_sp and tp_size > 1:
+        if tp_size > 1 and (
+            self.compilation_config.pass_config.enable_sp
+            or self.parallel_config.sequence_parallel_enabled_for_tokens(
+                num_scheduled_tokens
+            )
+        ):
             return round_up(num_scheduled_tokens, tp_size)
         return num_scheduled_tokens
 
@@ -4510,6 +4515,7 @@ class GPUModelRunner(
                 attn_metadata,
                 self.vllm_config,
                 num_tokens=num_tokens_padded,
+                sequence_parallel_num_tokens=num_tokens_unpadded,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_mode,
                 batch_descriptor=batch_desc,
@@ -6215,6 +6221,7 @@ class GPUModelRunner(
                     attn_metadata,
                     self.vllm_config,
                     num_tokens=num_tokens_padded,
+                    sequence_parallel_num_tokens=num_tokens_unpadded,
                     num_tokens_across_dp=num_tokens_across_dp,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,


### PR DESCRIPTION
## Purpose

This PR proposes a sequence-parallel (SP) refactor.

Today, the all-gather before attention and the reduce-scatter after attention are owned by model-specific decoder code when using SP. This couples the SP boundary to individual model implementations, duplicates collective-selection logic, and makes it easy for related paths—such as LoRA, linear attention, and other model runners—to diverge from the main attention path. Meanwhile, SP is automatically enabled under certain conditions, including DP > 1, TP > 1, EP, and supported all-to-all backends. We believe this option should also be user-configurable.

This PR moves these communication boundaries into the tensor-parallel linear layers that naturally own them, since SP is coupled to the TP group:

- `ColumnParallelLinear` gathers a sequence shard before an attention input projection.
- `RowParallelLinear` performs a reduce-scatter on the attention output when the caller requests unreduced row-parallel results.

The refactor preserves the existing MoE SP behavior while making the communication contract reusable by attention implementations that use the same parallel linear layers.

This PR also considers SP for dense models. When explicitly enabled, SP is used for dense models when the number of tokens in a step exceeds a threshold.

## Implementation
This PR primarily targets the Qwen3.5 model family. Other models can be migrated similarly.

- Add sequence-parallel collective wrappers in `communication_op.py`. These wrappers use custom device-communicator collectives when available and otherwise fall back to the TP all-gather and reduce-scatter implementations.
- Add the `enable_sequence_parallel` configuration and the `--enable-sequence-parallel` CLI option. When unset, the existing automatic MoE heuristic is preserved; `False` disables SP, while `True` requires TP > 1, allows DP = 1, and additionally requires EP and a supported all-to-all backend for MoE models. Pipeline parallelism with PP > 1 disables SP.
- Enable the linear-layer SP path for Qwen3-Next and Qwen3.5 when `use_sequence_parallel` is enabled. Other models retain their current behavior.
- Extend the dense Qwen3.5 attention and MLP paths to pass `sequence_parallel` to their parallel linear layers, so manually enabled dense SP uses the same token all-gather and reduce-scatter boundaries as the MoE path.
- Select dense SP dynamically based on the unpadded number of tokens in each step: steps with more than 1000 tokens use SP, while shorter steps retain the regular TP path. A forward-context flag derived from this unpadded token count keeps model-level chunk/gather operations and linear-layer collectives on the same path.
- Remove the duplicated attention all-gather and reduce-scatter logic from the Qwen3-Next decoder layer. The decoder remains responsible for sharding the residual when transitioning to the MoE path.
- Route the Qwen Gated DeltaNet linear-attention input through the same `ColumnParallelLinear` preparation path.
- Reuse the base linear-layer input-preparation and output-reduction logic in the LoRA wrappers so that LoRA follows the same SP boundary.
- Make the V1 GPU model runner pad SP-MoE and dense-SP batches to a token count that is divisible by the TP world size and align CUDA-graph capture sizes with this padded token count. Model-level SP helpers can therefore require padding rather than introducing it independently.

## Scope
| Configuration | MoE | Dense |
| --- | --- | --- |
| `None` (default) | Preserve the existing automatic enablement conditions: DP > 1, TP > 1, EP is enabled, and a supported all-to-all backend is selected | Not enabled automatically |
| `False` | Disabled | Disabled |
| `True` | Requires TP > 1, EP, and a supported all-to-all backend; DP = 1 is allowed | Requires TP > 1; use SP when the number of tokens in a step is > 1000 (empirical value), otherwise disable it |

## Discussion points

- Are `ColumnParallelLinear` and `RowParallelLinear` the preferred shared boundary for model SP communication, or should this be represented by a more explicit attention-level abstraction?
- Is limiting the initial rollout to specific model types acceptable, with follow-up migrations for other SP-capable models?
- Does the runner-owned padding contract provide the right separation between scheduling and model execution?
- Is it reasonable to add `--enable-sequence-parallel` as a user-facing CLI option?

## Test Plan
This PR will include targeted unit tests and TP > 1 serving-correctness results for Qwen3-Next and Qwen3.5-MoE with `--enable-sequence-parallel`.

Tested on four H20 GPUs using:
```bash
vllm serve \
  --model Qwen/Qwen3.5-35B-A3B \
  --data-parallel-size 1 \
  --tensor-parallel-size 4 \
  --enable-sequence-parallel \
  --enable-expert-parallel \
  --enforce-eager \
  --all2all-backend allgather_reducescatter 
```
Vllm bench test is conducted under `concurrency=1` and different input sequence length
## Test Results

| Stage  | Sequence length | Mean TTFT (ms) |
| --- | ---: | ---: |
| SP off | 8k | 267.40 |
| SP on | 8k | 254.02 |
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
