### PR TITLE
[Bugfix] Reject unsafe attention fusion CUDA graph config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,7 +35,7 @@ from vllm.config import (
     WatermarkConfig,
     update_config,
 )
-from vllm.config.compilation import CompilationMode, CUDAGraphMode
+from vllm.config.compilation import CompilationMode, CUDAGraphMode, PassConfig
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
 from vllm.config.mamba import MambaBackendEnum
@@ -559,6 +559,23 @@ def test_late_piecewise_restrictions_without_compilation(monkeypatch, engine_kwa
     assert config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
     assert config.compilation_config.cudagraph_capture_sizes == []
     assert config.compilation_config.max_cudagraph_capture_size == 0
+
+
+def test_resolve_cudagraph_mode_rejects_unsafe_attn_fusion():
+    compilation_config = CompilationConfig(
+        mode=CompilationMode.VLLM_COMPILE,
+        pass_config=PassConfig(fuse_attn_quant=True),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+    )
+    compilation_config.set_splitting_ops_for_v1("fake", data_parallel_size=1)
+
+    with pytest.raises(
+        ValueError, match="fuse_attn_quant without use_inductor_graph_partition"
+    ):
+        compilation_config.resolve_cudagraph_mode_and_sizes(
+            AttentionCGSupport.UNIFORM_BATCH,
+            "FakeAttentionBackend",
+        )
 
 
 def test_resolve_cudagraph_mode_skips_mamba_block_check_while_profiling():

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1403,6 +1403,18 @@ class CompilationConfig:
             cudagraph_mode.mixed_mode() == CUDAGraphMode.FULL
             and min_cg_support != AttentionCGSupport.ALWAYS
         ):
+            if (
+                self.pass_config.fuse_attn_quant
+                and not self.use_inductor_graph_partition
+            ):
+                raise ValueError(
+                    "fuse_attn_quant without use_inductor_graph_partition "
+                    "requires an attention backend that supports FULL "
+                    "cudagraphs for mixed batches; "
+                    f"{min_cg_attn_backend} only supports {min_cg_support}. "
+                    "Either enable use_inductor_graph_partition or disable "
+                    "fuse_attn_quant."
+                )
             msg = (
                 f"CUDAGraphMode.{cudagraph_mode.name} is not supported "
                 f"with {min_cg_attn_backend} backend (support: "


### PR DESCRIPTION
## Summary

Fixes #55722.

When fuse_attn_quant=True and use_inductor_graph_partition=False, CompilationConfig can force FULL CUDA graphs even when the attention backend only supports uniform batches. The existing fallback silently changes this to FULL_DECODE_ONLY after clearing attention splitting ops, which drops all piecewise CUDA graphs for mixed batches.

This change raises a clear ValueError for that unsupported combination and points users to enabling use_inductor_graph_partition or disabling fuse_attn_quant.

## Validation

- pytest tests/test_config.py -k resolve_cudagraph_mode_adjusts_spec_decode_sizes_only_for_v1 or rejects_unsafe_attn_fusion (3 passed)
- Ruff check and format checks passed
- git diff --check passed
- Python compile checks passed

The full configuration test module still has unrelated failures in this macOS/CPU environment due to missing vLLM compiled extensions and Triton, restricted Hugging Face model access, and platform-specific defaults.