### PR TITLE
[Bugfix][Distributed] Keep cross-node MNNVL groups off CUDA IPC all-reduce

### DIFF
--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import random
+from unittest.mock import Mock
 
 import pytest
 import ray
@@ -24,6 +25,18 @@ for i, v in enumerate(test_sizes):
     test_sizes[i] -= v % 8
 
 
+@pytest.fixture
+def custom_allreduce():
+    communicator = car.CustomAllreduce.__new__(car.CustomAllreduce)
+    communicator.disabled = False
+    communicator.world_size = 2
+    communicator.max_size = 1024
+    communicator._ptr = 0
+    communicator.mnnvl_only = False
+    communicator.fully_connected = False
+    return communicator
+
+
 @pytest.mark.parametrize(
     ("dtype", "expected"),
     [
@@ -35,16 +48,72 @@ for i, v in enumerate(test_sizes):
     ],
 )
 def test_custom_allreduce_filters_dtype(
+    custom_allreduce,
     dtype: torch.dtype,
     expected: bool,
 ) -> None:
-    communicator = car.CustomAllreduce.__new__(car.CustomAllreduce)
-    communicator.disabled = False
-    communicator.world_size = 2
-    communicator.max_size = 1024
-    communicator._ptr = 0
+    assert custom_allreduce.should_custom_ar(torch.empty(16, dtype=dtype)) is expected
 
-    assert communicator.should_custom_ar(torch.empty(16, dtype=dtype)) is expected
+
+@pytest.mark.parametrize("capturing", [False, True])
+def test_cross_node_custom_allreduce_declines_without_launching_ipc(
+    custom_allreduce, monkeypatch, capturing
+):
+    custom_allreduce.mnnvl_only = True
+    custom_allreduce._IS_CAPTURING = capturing
+    custom_allreduce.all_reduce = Mock()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: capturing)
+
+    assert custom_allreduce.custom_all_reduce(torch.empty(16)) is None
+    custom_allreduce.all_reduce.assert_not_called()
+
+
+@pytest.mark.parametrize("mnnvl_only", [False, True])
+def test_graph_capture_registers_ipc_buffers_only_on_same_node(
+    custom_allreduce, monkeypatch, mnnvl_only
+):
+    custom_allreduce.mnnvl_only = mnnvl_only
+    custom_allreduce.group = object()
+    custom_allreduce.rank = 0
+    get_meta = Mock(return_value=([1], [0]))
+    register = Mock()
+
+    def share_meta(data, **kwargs):
+        data[:] = [[1], [0]]
+
+    broadcast = Mock(side_effect=share_meta)
+    monkeypatch.setattr(car.ops, "get_graph_buffer_ipc_meta", get_meta)
+    monkeypatch.setattr(car.ops, "register_graph_buffers", register)
+    monkeypatch.setattr(car.dist, "get_world_size", lambda **kwargs: 2)
+    monkeypatch.setattr(car.dist, "get_process_group_ranks", lambda **kwargs: [0, 1])
+    monkeypatch.setattr(car.dist, "broadcast_object_list", broadcast)
+
+    with custom_allreduce.capture():
+        assert custom_allreduce._IS_CAPTURING
+
+    assert not custom_allreduce._IS_CAPTURING
+    if mnnvl_only:
+        get_meta.assert_not_called()
+        broadcast.assert_not_called()
+        register.assert_not_called()
+    else:
+        get_meta.assert_called_once_with(0)
+        assert broadcast.call_count == 2
+        register.assert_called_once_with(0, [[1], [1]], [[0], [0]])
+
+
+def test_cross_node_mnnvl_all_gather_and_reduce_scatter_remain_eligible(
+    custom_allreduce, monkeypatch
+):
+    custom_allreduce.mnnvl_only = True
+    custom_allreduce.mnnvl_multicast_ptr = 1
+    custom_allreduce.max_mnnvl_all_gather_size = 1024
+    custom_allreduce.max_mnnvl_reduce_scatter_size = 1024
+    monkeypatch.setattr(car.current_platform, "is_cuda", lambda: True)
+    inp = torch.empty(16, 8)
+
+    assert custom_allreduce.should_custom_all_gather(inp)
+    assert custom_allreduce.should_custom_reduce_scatter(inp)
 
 
 @pytest.mark.parametrize(

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -136,8 +136,9 @@ class CustomAllreduce:
             device: the device to bind the CustomAllreduce to. If None,
                 it will be bound to f"cuda:{local_rank}".
         It is the caller's responsibility to make sure each communicator
-        is bind to a unique device, and all communicators in this group
-        are in the same node.
+        is bound to a unique device. CUDA IPC collectives require all ranks
+        to be on the same node; cross-node groups only support MNNVL
+        all-gather and reduce-scatter.
         """
         self._IS_CAPTURING = False
         self._ptr = 0
@@ -384,6 +385,9 @@ class CustomAllreduce:
                 self.register_graph_buffers()
 
     def register_graph_buffers(self):
+        if self.mnnvl_only:
+            # MNNVL collectives use pre-registered symmetric memory, not CUDA IPC.
+            return
         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
         logger.debug("Registering %d cuda graph addresses", len(offset))
         # We cannot directly use `dist.all_gather_object` here
@@ -403,7 +407,7 @@ class CustomAllreduce:
         ops.register_graph_buffers(self._ptr, handles, offsets)
 
     def should_custom_ar(self, inp: torch.Tensor):
-        if self.disabled or self.world_size > 8:
+        if self.disabled or self.mnnvl_only or self.world_size > 8:
             return False
         if inp.dtype not in (torch.float32, torch.float16, torch.bfloat16):
             return False


### PR DESCRIPTION
## Purpose

Addresses #52778.

**Reporter-provided multi-node GPU validation is available below; same-node GPU controls and model-output evaluation remain pending.** Local validation uses CPU tests only; this PR does not claim submitter-run GPU tests.

Cross-node MNNVL-capable groups remain enabled for custom all-gather/reduce-scatter, but cannot exchange node-local CUDA IPC handles. `should_custom_ar()` currently admits TP=2 cross-node groups; CUDA-graph teardown can subsequently exchange their IPC handles and terminate the process inside `cudaIpcOpenMemHandle`.

This patch:

- declines node-local custom all-reduce when `mnnvl_only=True`, allowing the existing caller dispatch to try another backend;
- skips IPC graph registration for those groups, whose MNNVL collectives use pre-registered symmetric memory;
- preserves same-node custom all-reduce and the existing MNNVL all-gather/reduce-scatter eligibility;
- adds regression coverage in the existing custom-all-reduce test suite.

No CUDA kernels or arithmetic implementations are changed.

## Why this is not duplicate work

Before starting, #52778 had no assignee or visible work claim. Issue/timeline checks and open-PR searches for the issue number, cross-node IPC, MNNVL custom allreduce, `mnnvl_only`, and `register_graph_buffers` found no open implementation of this specific fix. The issue-number and `mnnvl_only` searches were repeated before opening this PR.

Related changes address different mechanisms:

- Merged #53253 prevents unsupported cross-node groups from reaching MNNVL rendezvous; its description explicitly distinguishes #52778. Supported Blackwell groups still reach the paths changed here.
- Open #53377 concerns FlashInfer fusion-workspace capability checks.
- Open #46515 concerns IPC-handle lifetime rather than cross-node eligibility.
- Open #50505 changes buffer sizing for batch invariance rather than node locality.

## Test Plan

```sh
.venv/bin/python -m pytest tests/distributed/test_custom_all_reduce.py -v
.venv/bin/python -m pytest \
  tests/distributed/test_custom_all_gather_reduce_scatter.py \
  tests/distributed/test_comm_ops.py -k 'not multi_process' -v
.venv/bin/pre-commit run --files \
  vllm/distributed/device_communicators/custom_all_reduce.py \
  tests/distributed/test_custom_all_reduce.py
git diff --check
```

## Test Result

Executed locally on Apple Silicon macOS with Python 3.12.11 and PyTorch 2.13.0:

| Check | Result |
| --- | --- |
| New regression tests with unpatched production code | 3 failed, 13 passed, 4 GPU tests skipped |
| Patched custom-all-reduce suite | 16 passed, 4 GPU tests skipped |
| Adjacent communication suites | 19 passed, 1 GPU test skipped, 10 distributed tests deselected |
| Applicable pre-commit hooks, including Ruff and mypy | Passed |
| Diff whitespace check | Passed |

The three baseline failures cover eager/captured cross-node all-reduce dispatch and cross-node IPC graph registration. Positive controls cover same-node registration and MNNVL collective eligibility.

These tests exercise real production Python methods and CPU tensors, with CUDA operations and process-group calls mocked at the boundaries. They do not execute CUDA IPC, NCCL, or MNNVL kernels. The precompiled editable install was unavailable on this host; the Python tests ran through normal source imports after installing dependencies with `uv`.

## Outstanding validation

- [ ] Human-run relevant tests and final line-by-line review under the contribution policy.
- [x] Reporter-validated matched unpatched/patched startup, CUDA-graph capture, and serving benchmarks on two MNNVL-capable GB200 NVL72 nodes with TP=2.
- [ ] Same-node TP=2 control and GPU all-gather/reduce-scatter regression run.
- [ ] Model-output/evaluation results for the serving-backend change.

**External GPU validation: the issue reporter confirmed the fix on September 8, 2026.** See [the full validation report](https://github.com/vllm-project/vllm/pull/55835#issuecomment-5587236720). On two GB200 NVL72 nodes with one GPU per node, cross-node TP=2, and custom all-reduce left enabled, the unpatched control aborts with `custom_all_reduce.cuh:143`. Applying this patch as the only change allows CUDA-graph capture, server startup, and serving benchmarks at concurrency 1/16/64/128 to complete. The reporter also confirmed that MNNVL setup remains active.

The submitter still has no GPU environment. Same-node GPU controls, GPU all-gather/reduce-scatter regression runs, model-output accuracy evaluation, and the remaining human-review requirements have not been reported as complete.

## AI assistance

OpenAI Codex assisted with issue triage, investigation, patch preparation, and execution of the local CPU tests and lint checks. The patch was approved for publication by the submitter. The outstanding checklist is intentionally incomplete. External GPU results above are attributed to the issue reporter; they do not attest to submitter-run GPU tests, model-output accuracy evaluation, or completion of the remaining human-review requirements. The commit includes AI attribution and sign-off.


## Main synchronization — September 16, 2026

Merged upstream `main` (`e070573`) into the PR branch without rewriting the original validated commit. The only conflict was the constructor docstring in `custom_all_reduce.py`: the resolution retains upstream docstring formatting and the PR's node-local CUDA IPC explanation.

- Executable production AST (excluding docstrings) is unchanged from the original PR patch; the regression test file is byte-for-byte identical.
- Reran the custom-all-reduce suite: **16 passed, 4 GPU tests skipped**.
- Reran the adjacent communication suites with `-k 'not multi_process'`: **20 passed, 1 GPU test skipped, 10 distributed tests deselected**.
- Current changed-file pre-commit checks, including Ruff and mypy, and `git diff --check origin/main` passed.
- No GPU/model evaluation was rerun for this synchronization. The reporter's hardware results above remain attributed to the original patch, not a new run of the synchronized branch.

## CI status (original PR head)

The failing [`pre-run-check`](https://github.com/vllm-project/vllm/actions/runs/34190799792/job/101948293711) is the repository's CI authorization gate, not a lint/test result. It requires one of `verified`, `ready`, or `ready-run-all-tests`, or at least four merged PRs from the author; the log reports one merged PR and no qualifying label. The actual `pre-commit` job was therefore skipped. GitHub's ready-for-review status is distinct from those authorization labels. Local changed-file pre-commit checks passed as reported above; upstream CI remains unexecuted behind that gate. No CI policy or authorization controls were modified.

