### PR TITLE
[Bugfix][Metrics] Record aborted requests in per-request stats

### DIFF
--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -1448,3 +1448,43 @@ def test_abort_requests(runner: str, abort_by: str, dummy_test_vectors):
             output_processor.abort_requests([request.request_id], internal=True)
         else:
             output_processor.abort_requests([request.external_req_id], internal=False)
+
+
+@pytest.mark.parametrize("runner", ["generate", "pooling"])
+def test_abort_requests_updates_finished_stats(runner: str):
+    output_processor = OutputProcessor(None, log_stats=True)
+    request = EngineCoreRequest(
+        request_id="request-0",
+        external_req_id="external-0",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+        sampling_params=(
+            SamplingParams(detokenize=False) if runner == "generate" else None
+        ),
+        pooling_params=PoolingParams(task="embed") if runner == "pooling" else None,
+    )
+    queue = RequestOutputCollector(
+        output_kind=(
+            request.sampling_params.output_kind
+            if runner == "generate"
+            else request.pooling_params.output_kind
+        ),
+        request_id=request.request_id,
+    )
+    output_processor.add_request(request, None, queue=queue)
+
+    iteration_stats = IterationStats()
+    output_processor.abort_requests(
+        [request.request_id], internal=True, iteration_stats=iteration_stats
+    )
+
+    assert len(iteration_stats.finished_requests) == 1
+    finished = iteration_stats.finished_requests[0]
+    assert finished.finish_reason == FinishReason.ABORT
+    assert finished.request_id == request.external_req_id
+    assert finished.num_prompt_tokens == len(request.prompt_token_ids or [])
+    assert not output_processor.has_unfinished_requests()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -839,8 +839,16 @@ class AsyncLLM(EngineClient):
         request_ids = (
             (request_id,) if isinstance(request_id, str) else as_list(request_id)
         )
-        all_request_ids = self.output_processor.abort_requests(request_ids, internal)
+        iteration_stats = IterationStats() if self.log_stats else None
+        all_request_ids = self.output_processor.abort_requests(
+            request_ids, internal, iteration_stats
+        )
         await self.engine_core.abort_requests_async(all_request_ids)
+        if self.logger_manager is not None and iteration_stats is not None:
+            self.logger_manager.record(
+                scheduler_stats=None,
+                iteration_stats=iteration_stats,
+            )
 
         if self.log_requests:
             logger.info("Aborted request(s) %s.", ",".join(request_ids))

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -217,8 +217,16 @@ class LLMEngine:
     def abort_request(self, request_ids: list[str], internal: bool = False) -> None:
         """Remove request_ids from EngineCore and Detokenizer."""
 
-        request_ids = self.output_processor.abort_requests(request_ids, internal)
+        iteration_stats = IterationStats() if self.log_stats else None
+        request_ids = self.output_processor.abort_requests(
+            request_ids, internal, iteration_stats
+        )
         self.engine_core.abort_requests(request_ids)
+        if self.logger_manager is not None and iteration_stats is not None:
+            self.logger_manager.record(
+                scheduler_stats=None,
+                iteration_stats=iteration_stats,
+            )
 
     def add_request(
         self,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -492,7 +492,12 @@ class OutputProcessor:
             assert state.queue is not None
             state.queue.put(e)
 
-    def abort_requests(self, request_ids: Iterable[str], internal: bool) -> list[str]:
+    def abort_requests(
+        self,
+        request_ids: Iterable[str],
+        internal: bool,
+        iteration_stats: IterationStats | None = None,
+    ) -> list[str]:
         """Abort a list of requests.
 
         The request_ids may be either external request IDs (those passed to
@@ -528,7 +533,12 @@ class OutputProcessor:
         for request_id in internal_req_ids:
             req_state = self.request_states.pop(request_id, None)
             if req_state is not None:
-                self.lora_states.request_finished(request_id, req_state.lora_name)
+                if iteration_stats is not None:
+                    self._update_stats_from_finished(
+                        req_state, FinishReason.ABORT, iteration_stats
+                    )
+                else:
+                    self.lora_states.request_finished(request_id, req_state.lora_name)
                 request_ids_to_abort.append(request_id)
                 # Produce final abort output.
                 if req_state.queue is not None and (
@@ -550,7 +560,11 @@ class OutputProcessor:
                 # Abort children prior to removing the parent.
                 if parent.child_requests:
                     child_reqs = list(parent.child_requests)
-                    child_reqs = self.abort_requests(child_reqs, internal=True)
+                    child_reqs = self.abort_requests(
+                        child_reqs,
+                        internal=True,
+                        iteration_stats=iteration_stats,
+                    )
                     request_ids_to_abort.extend(child_reqs)
                 self.parent_requests.pop(request_id, None)
         return request_ids_to_abort


### PR DESCRIPTION
## Issue

Fixes #55634.

Aborted requests were removed from `OutputProcessor.request_states` and emitted with `FinishReason.ABORT`, but they never entered `IterationStats.finished_requests`. As a result, per-request histograms and the existing `finished_reason=abort` success counter stayed unchanged.

## Changes

- Pass an optional `IterationStats` through the synchronous and asynchronous abort paths.
- Record aborted requests through the same finished-request accounting used by normal completions.
- Flush those stats immediately through the configured logger manager.
- Preserve the existing cleanup behavior when request statistics are disabled.

## Tests

- `uv run --no-project --with pytest pytest -q tests/v1/engine/test_output_processor.py -k 'test_abort_requests_updates_finished_stats' --disable-warnings --maxfail=1` (2 passed)
- `uv run --no-project --with pytest pytest -q tests/v1/metrics/test_stats.py --disable-warnings --maxfail=1` (12 passed)
- `uvx ruff check ...` (passed)
- `uvx ruff format --check ...` (passed)
- `python3 -m compileall ...` (passed)
- `git diff --check` (passed)

The existing output-processor abort parametrization could not start locally because its shared fixture downloads the gated `meta-llama/Llama-3.2-1B` tokenizer and this environment has no Hugging Face credentials.

Co-authored-by: rpc-772 <rpc-772@users.noreply.github.com>
Co-authored-by: muyu-or <muyu-or@users.noreply.github.com>
