### PR TITLE
[Perf][Attention][MiniMax-M3] Select CUTLASS MSA by EAGLE3 decode shape

### DIFF
--- a/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
+++ b/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
@@ -126,6 +126,31 @@ def test_msa_cutlass_decode_static_dispatch_keeps_sm100_floor(
     assert should_prepare_decode_metadata(16, DEFAULT_QUERY_LEN, **kwargs)
 
 
+@pytest.mark.parametrize(
+    ("min_batch_size", "batch_size", "expected"),
+    [(8, 4, False), (8, 8, True), (16, 8, False), (16, 16, True)],
+)
+def test_msa_cutlass_decode_static_dispatch_honors_batch_override(
+    min_batch_size: int,
+    batch_size: int,
+    expected: bool,
+) -> None:
+    assert (
+        should_prepare_decode_metadata(
+            batch_size,
+            DEFAULT_QUERY_LEN,
+            decode_backend="cutlass",
+            num_q_heads=64,
+            num_kv_heads=4,
+            kv_cache_dtype="fp8_e4m3",
+            page_size=BLOCK_SIZE,
+            topk_blocks=TOPK,
+            min_batch_size=min_batch_size,
+        )
+        is expected
+    )
+
+
 def test_msa_cutlass_decode_static_dispatch_requires_opt_in() -> None:
     assert not should_prepare_decode_metadata(
         32,
@@ -266,6 +291,7 @@ def test_msa_metadata_builder_prepares_cutlass_for_regular_decode(
     builder.kv_cache_dtype = "fp8_e4m3"
     builder.decode_backend = "cutlass"
     builder.msa_cutlass_plan_cache = object()
+    builder.msa_cutlass_min_batch_size = None
 
     metadata = builder.build(
         0,

--- a/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
+++ b/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
@@ -63,8 +63,11 @@ SM_SCALE = HEAD_DIM**-0.5
         "expected",
     ),
     [
-        pytest.param(8, 4, 64, 4, False, id="tp1-below-min-batch"),
+        pytest.param(2, 4, 64, 4, False, id="tp1-below-min-batch"),
+        pytest.param(4, 4, 64, 4, True, id="tp1-default-min-batch"),
+        pytest.param(8, 4, 64, 4, True, id="tp1-small-batch"),
         pytest.param(16, 4, 64, 4, True, id="tp1-supported"),
+        pytest.param(4, 4, 16, 1, True, id="tp4-default-min-batch"),
         pytest.param(16, 4, 16, 1, True, id="tp4-min-batch"),
         pytest.param(24, 4, 16, 1, True, id="tp4-intermediate-batch"),
         pytest.param(32, 4, 16, 1, True, id="tp4-supported"),
@@ -94,6 +97,29 @@ def test_msa_cutlass_decode_static_dispatch(
             kv_cache_dtype="fp8_e4m3",
             page_size=BLOCK_SIZE,
             topk_blocks=TOPK,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "expected"),
+    [(8, False), (16, True)],
+)
+def test_msa_cutlass_decode_static_dispatch_original_gate(
+    batch_size: int, expected: bool
+) -> None:
+    assert (
+        should_prepare_decode_metadata(
+            batch_size,
+            DEFAULT_QUERY_LEN,
+            decode_backend="cutlass",
+            num_q_heads=64,
+            num_kv_heads=4,
+            kv_cache_dtype="fp8_e4m3",
+            page_size=BLOCK_SIZE,
+            topk_blocks=TOPK,
+            min_batch_size=16,
         )
         is expected
     )
@@ -239,6 +265,7 @@ def test_msa_metadata_builder_prepares_cutlass_for_regular_decode(
     builder.kv_cache_dtype = "fp8_e4m3"
     builder.decode_backend = "cutlass"
     builder.msa_cutlass_plan_cache = object()
+    builder.msa_cutlass_min_batch_size = 4
 
     metadata = builder.build(
         0,
@@ -434,6 +461,11 @@ def _make_topk(
         pytest.param(64, 4, 8, 8, False, id="tp1-query-len-8"),
         pytest.param(16, 1, 8, 1, True, id="tp4-query-len-1"),
         pytest.param(16, 1, 16, 4, True, id="tp4-query-len-4"),
+        # Batches below the original floor now exercise the CUTLASS path.
+        pytest.param(64, 4, 2, 1, True, id="tp1-batch-4-query-len-1"),
+        pytest.param(64, 4, 4, 4, True, id="tp1-batch-8-query-len-4"),
+        pytest.param(16, 1, 2, 1, True, id="tp4-batch-4-query-len-1"),
+        pytest.param(16, 1, 4, 4, True, id="tp4-batch-8-query-len-4"),
     ],
 )
 def test_msa_cutlass_decode_matches_triton_with_interleaved_cache(

--- a/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
+++ b/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
@@ -64,15 +64,13 @@ SM_SCALE = HEAD_DIM**-0.5
     ),
     [
         pytest.param(2, 4, 64, 4, False, id="tp1-below-min-batch"),
-        pytest.param(4, 4, 64, 4, True, id="tp1-default-min-batch"),
-        pytest.param(8, 4, 64, 4, True, id="tp1-small-batch"),
-        pytest.param(16, 4, 64, 4, True, id="tp1-supported"),
-        pytest.param(4, 4, 16, 1, True, id="tp4-default-min-batch"),
+        pytest.param(4, 4, 64, 4, True, id="tp1-min-batch"),
+        pytest.param(4, 4, 32, 2, False, id="tp2-below-min-batch"),
+        pytest.param(8, 4, 32, 2, True, id="tp2-min-batch"),
+        pytest.param(8, 4, 16, 1, False, id="tp4-below-min-batch"),
         pytest.param(16, 4, 16, 1, True, id="tp4-min-batch"),
-        pytest.param(24, 4, 16, 1, True, id="tp4-intermediate-batch"),
-        pytest.param(32, 4, 16, 1, True, id="tp4-supported"),
-        pytest.param(16, 1, 64, 4, True, id="tp1-query-len-1"),
-        pytest.param(16, 1, 16, 1, True, id="tp4-query-len-1"),
+        pytest.param(4, 1, 64, 4, False, id="regular-decode-keeps-old-floor"),
+        pytest.param(16, 1, 64, 4, True, id="regular-decode-min-batch"),
         pytest.param(16, 2, 64, 4, True, id="tp1-query-len-2"),
         pytest.param(16, 2, 16, 1, True, id="tp4-query-len-2"),
         pytest.param(16, 32, 64, 4, True, id="query-len-upper-bound"),
@@ -86,7 +84,13 @@ def test_msa_cutlass_decode_static_dispatch(
     expected: bool,
     num_q_heads: int,
     num_kv_heads: int,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability",
+        lambda capability: capability == (10, 3),
+    )
     assert (
         should_prepare_decode_metadata(
             batch_size,
@@ -102,27 +106,24 @@ def test_msa_cutlass_decode_static_dispatch(
     )
 
 
-@pytest.mark.parametrize(
-    ("batch_size", "expected"),
-    [(8, False), (16, True)],
-)
-def test_msa_cutlass_decode_static_dispatch_original_gate(
-    batch_size: int, expected: bool
+def test_msa_cutlass_decode_static_dispatch_keeps_sm100_floor(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    assert (
-        should_prepare_decode_metadata(
-            batch_size,
-            DEFAULT_QUERY_LEN,
-            decode_backend="cutlass",
-            num_q_heads=64,
-            num_kv_heads=4,
-            kv_cache_dtype="fp8_e4m3",
-            page_size=BLOCK_SIZE,
-            topk_blocks=TOPK,
-            min_batch_size=16,
-        )
-        is expected
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability",
+        lambda _: False,
     )
+    kwargs = {
+        "decode_backend": "cutlass",
+        "num_q_heads": 64,
+        "num_kv_heads": 4,
+        "kv_cache_dtype": "fp8_e4m3",
+        "page_size": BLOCK_SIZE,
+        "topk_blocks": TOPK,
+    }
+    assert not should_prepare_decode_metadata(8, DEFAULT_QUERY_LEN, **kwargs)
+    assert should_prepare_decode_metadata(16, DEFAULT_QUERY_LEN, **kwargs)
 
 
 def test_msa_cutlass_decode_static_dispatch_requires_opt_in() -> None:
@@ -265,7 +266,6 @@ def test_msa_metadata_builder_prepares_cutlass_for_regular_decode(
     builder.kv_cache_dtype = "fp8_e4m3"
     builder.decode_backend = "cutlass"
     builder.msa_cutlass_plan_cache = object()
-    builder.msa_cutlass_min_batch_size = 4
 
     metadata = builder.build(
         0,
@@ -461,11 +461,10 @@ def _make_topk(
         pytest.param(64, 4, 8, 8, False, id="tp1-query-len-8"),
         pytest.param(16, 1, 8, 1, True, id="tp4-query-len-1"),
         pytest.param(16, 1, 16, 4, True, id="tp4-query-len-4"),
-        # Batches below the original floor now exercise the CUTLASS path.
-        pytest.param(64, 4, 2, 1, True, id="tp1-batch-4-query-len-1"),
-        pytest.param(64, 4, 4, 4, True, id="tp1-batch-8-query-len-4"),
-        pytest.param(16, 1, 2, 1, True, id="tp4-batch-4-query-len-1"),
-        pytest.param(16, 1, 4, 4, True, id="tp4-batch-8-query-len-4"),
+        # Measured B300 EAGLE3 dispatch boundaries.
+        pytest.param(64, 4, 2, 4, True, id="tp1-batch-4-query-len-4"),
+        pytest.param(32, 2, 4, 4, True, id="tp2-batch-8-query-len-4"),
+        pytest.param(16, 1, 8, 4, True, id="tp4-batch-16-query-len-4"),
     ],
 )
 def test_msa_cutlass_decode_matches_triton_with_interleaved_cache(

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -90,6 +90,45 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("auto", None),
+        ("4", 4),
+        ("8", 8),
+        ("16", 16),
+        ("off", 16),
+        ("0", 16),
+    ],
+)
+def test_minimax_m3_msa_cutlass_min_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+    expected: int | None,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", value)
+
+    env_func = environment_variables["VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH"]
+    assert env_func() == expected
+
+
+@pytest.mark.parametrize("value", ["-1", "invalid"])
+def test_minimax_m3_msa_cutlass_min_batch_invalid_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    value: str,
+) -> None:
+    monkeypatch.setenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", value)
+
+    env_func = environment_variables["VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH"]
+    assert env_func() == 16
+    assert "falling back to 16" in caplog.text
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -90,33 +90,6 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [(None, 4), ("4", 4), ("8", 8), ("16", 16), ("off", 16), ("0", 16)],
-)
-def test_minimax_m3_msa_cutlass_min_batch(
-    monkeypatch: pytest.MonkeyPatch, value: str | None, expected: int
-) -> None:
-    if value is None:
-        monkeypatch.delenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", raising=False)
-    else:
-        monkeypatch.setenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", value)
-
-    env_func = environment_variables["VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH"]
-    assert env_func() == expected
-
-
-@pytest.mark.parametrize("value", ["-1", "invalid"])
-def test_minimax_m3_msa_cutlass_min_batch_invalid_falls_back(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, value: str
-) -> None:
-    monkeypatch.setenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", value)
-
-    env_func = environment_variables["VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH"]
-    assert env_func() == 16
-    assert "falling back to 16" in caplog.text
-
-
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -90,6 +90,33 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, 4), ("4", 4), ("8", 8), ("16", 16), ("off", 16), ("0", 16)],
+)
+def test_minimax_m3_msa_cutlass_min_batch(
+    monkeypatch: pytest.MonkeyPatch, value: str | None, expected: int
+) -> None:
+    if value is None:
+        monkeypatch.delenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", value)
+
+    env_func = environment_variables["VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH"]
+    assert env_func() == expected
+
+
+@pytest.mark.parametrize("value", ["-1", "invalid"])
+def test_minimax_m3_msa_cutlass_min_batch_invalid_falls_back(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, value: str
+) -> None:
+    monkeypatch.setenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH", value)
+
+    env_func = environment_variables["VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH"]
+    assert env_func() == 16
+    assert "falling back to 16" in caplog.text
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,6 +156,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_PLE_CPU_OFFLOAD: bool = False
+    VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH: int | None = None
     VLLM_DISABLE_COMPILE_CACHE: bool = False
     VLLM_REPLICATE_EMBED: bool = False
     VLLM_USE_LAYERNAME: bool = True
@@ -353,6 +354,27 @@ def maybe_convert_bool(value: str | None) -> bool | None:
     if value is None:
         return None
     return bool(int(value))
+
+
+def get_minimax_m3_msa_cutlass_min_batch() -> int | None:
+    """Resolve an optional MiniMax M3 CUTLASS MSA batch override."""
+    raw = os.getenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH")
+    if raw is None or raw.strip().lower() == "auto":
+        return None
+    value = raw.strip().lower()
+    if value in ("", "0", "false", "no", "off"):
+        return 16
+    try:
+        min_batch = int(value)
+    except ValueError:
+        min_batch = 0
+    if min_batch < 1:
+        logger.warning(
+            "Invalid VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH=%r; falling back to 16",
+            raw,
+        )
+        return 16
+    return min_batch
 
 
 def maybe_convert_scale_out_endpoints(value: str | None) -> bool | None:
@@ -1414,6 +1436,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_LOG_BATCHSIZE_INTERVAL": lambda: float(
         os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")
     ),
+    # Override the automatic MiniMax M3 CUTLASS sparse-decode crossover.
+    # Set this to 16 (or a false-like value) to restore the original gate.
+    "VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH": (get_minimax_m3_msa_cutlass_min_batch),
     "VLLM_DISABLE_COMPILE_CACHE": disable_compile_cache,
     # If set to "0", disable LayerName opaque type for layer_name
     # parameters in custom ops.  Defaults to enabled on torch >= 2.11.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,7 +156,6 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_PLE_CPU_OFFLOAD: bool = False
-    VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH: int = 4
     VLLM_DISABLE_COMPILE_CACHE: bool = False
     VLLM_REPLICATE_EMBED: bool = False
     VLLM_USE_LAYERNAME: bool = True
@@ -354,27 +353,6 @@ def maybe_convert_bool(value: str | None) -> bool | None:
     if value is None:
         return None
     return bool(int(value))
-
-
-def get_minimax_m3_msa_cutlass_min_batch() -> int:
-    """Resolve the minimum decode batch for MiniMax M3 CUTLASS MSA."""
-    raw = os.getenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH")
-    if raw is None:
-        return 4
-    value = raw.strip().lower()
-    if value in ("", "0", "false", "no", "off"):
-        return 16
-    try:
-        min_batch = int(value)
-    except ValueError:
-        min_batch = 0
-    if min_batch < 1:
-        logger.warning(
-            "Invalid VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH=%r; falling back to 16",
-            raw,
-        )
-        return 16
-    return min_batch
 
 
 def maybe_convert_scale_out_endpoints(value: str | None) -> bool | None:
@@ -1436,9 +1414,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_LOG_BATCHSIZE_INTERVAL": lambda: float(
         os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")
     ),
-    # CUTLASS sparse decode wins at some MiniMax M3 sub-16 decode batches.
-    # Set this to 16 (or a false-like value) to restore the original gate.
-    "VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH": (get_minimax_m3_msa_cutlass_min_batch),
     "VLLM_DISABLE_COMPILE_CACHE": disable_compile_cache,
     # If set to "0", disable LayerName opaque type for layer_name
     # parameters in custom ops.  Defaults to enabled on torch >= 2.11.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,6 +156,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_PLE_CPU_OFFLOAD: bool = False
+    VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH: int = 4
     VLLM_DISABLE_COMPILE_CACHE: bool = False
     VLLM_REPLICATE_EMBED: bool = False
     VLLM_USE_LAYERNAME: bool = True
@@ -353,6 +354,27 @@ def maybe_convert_bool(value: str | None) -> bool | None:
     if value is None:
         return None
     return bool(int(value))
+
+
+def get_minimax_m3_msa_cutlass_min_batch() -> int:
+    """Resolve the minimum decode batch for MiniMax M3 CUTLASS MSA."""
+    raw = os.getenv("VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH")
+    if raw is None:
+        return 4
+    value = raw.strip().lower()
+    if value in ("", "0", "false", "no", "off"):
+        return 16
+    try:
+        min_batch = int(value)
+    except ValueError:
+        min_batch = 0
+    if min_batch < 1:
+        logger.warning(
+            "Invalid VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH=%r; falling back to 16",
+            raw,
+        )
+        return 16
+    return min_batch
 
 
 def maybe_convert_scale_out_endpoints(value: str | None) -> bool | None:
@@ -1414,6 +1436,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_LOG_BATCHSIZE_INTERVAL": lambda: float(
         os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")
     ),
+    # CUTLASS sparse decode wins at some MiniMax M3 sub-16 decode batches.
+    # Set this to 16 (or a false-like value) to restore the original gate.
+    "VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH": (get_minimax_m3_msa_cutlass_min_batch),
     "VLLM_DISABLE_COMPILE_CACHE": disable_compile_cache,
     # If set to "0", disable LayerName opaque type for layer_name
     # parameters in custom ops.  Defaults to enabled on torch >= 2.11.

--- a/vllm/models/minimax_m3/nvidia/msa_cutlass_sparse_decode.py
+++ b/vllm/models/minimax_m3/nvidia/msa_cutlass_sparse_decode.py
@@ -251,12 +251,14 @@ def should_prepare_decode_metadata(
     kv_cache_dtype: str,
     page_size: int,
     topk_blocks: int,
+    min_batch_size: int | None = None,
 ) -> bool:
     """Return whether a graph shape can use the CUTLASS decode path."""
     total_q = batch_size * decode_query_len
-    min_batch_size = _min_cutlass_batch_size(
-        decode_query_len, num_q_heads, num_kv_heads
-    )
+    if min_batch_size is None:
+        min_batch_size = _min_cutlass_batch_size(
+            decode_query_len, num_q_heads, num_kv_heads
+        )
     return (
         supports_cutlass_sparse_decode(
             decode_backend=decode_backend,

--- a/vllm/models/minimax_m3/nvidia/msa_cutlass_sparse_decode.py
+++ b/vllm/models/minimax_m3/nvidia/msa_cutlass_sparse_decode.py
@@ -22,9 +22,12 @@ _TOPK = 16
 # fixed planner allocation used by the MSA decode kernel.
 _MAX_QUERY_HEAD_ROWS = 65536
 _MAX_DECODE_QUERY_LEN = 32
-# Kernel benchmarks originally put the CUTLASS crossover at 16 requests for
-# TP1 and TP4. This is a performance heuristic rather than a kernel constraint.
-_DEFAULT_MIN_CUTLASS_BATCH_SIZE = 4
+_DEFAULT_MIN_CUTLASS_BATCH_SIZE = 16
+_B300_EAGLE3_MIN_BATCH_BY_HEADS = {
+    (64, 4): 4,
+    (32, 2): 8,
+    (16, 1): 16,
+}
 
 
 @dataclass
@@ -205,6 +208,18 @@ def _supported_head_geometry(num_q_heads: int, num_kv_heads: int) -> bool:
     )
 
 
+def _min_cutlass_batch_size(
+    decode_query_len: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+) -> int:
+    if decode_query_len != 4 or not current_platform.is_device_capability((10, 3)):
+        return _DEFAULT_MIN_CUTLASS_BATCH_SIZE
+    return _B300_EAGLE3_MIN_BATCH_BY_HEADS.get(
+        (num_q_heads, num_kv_heads), _DEFAULT_MIN_CUTLASS_BATCH_SIZE
+    )
+
+
 def supports_cutlass_sparse_decode(
     *,
     decode_backend: MiniMaxM3MSADecodeBackend,
@@ -236,14 +251,12 @@ def should_prepare_decode_metadata(
     kv_cache_dtype: str,
     page_size: int,
     topk_blocks: int,
-    min_batch_size: int = _DEFAULT_MIN_CUTLASS_BATCH_SIZE,
 ) -> bool:
-    """Return whether a graph shape can use the CUTLASS decode path.
-
-    ``min_batch_size`` is a tunable performance gate; the remaining checks are
-    kernel constraints.
-    """
+    """Return whether a graph shape can use the CUTLASS decode path."""
     total_q = batch_size * decode_query_len
+    min_batch_size = _min_cutlass_batch_size(
+        decode_query_len, num_q_heads, num_kv_heads
+    )
     return (
         supports_cutlass_sparse_decode(
             decode_backend=decode_backend,

--- a/vllm/models/minimax_m3/nvidia/msa_cutlass_sparse_decode.py
+++ b/vllm/models/minimax_m3/nvidia/msa_cutlass_sparse_decode.py
@@ -22,8 +22,9 @@ _TOPK = 16
 # fixed planner allocation used by the MSA decode kernel.
 _MAX_QUERY_HEAD_ROWS = 65536
 _MAX_DECODE_QUERY_LEN = 32
-# Kernel benchmarks put the CUTLASS crossover at 16 requests for TP1 and TP4.
-_MIN_CUTLASS_BATCH_SIZE = 16
+# Kernel benchmarks originally put the CUTLASS crossover at 16 requests for
+# TP1 and TP4. This is a performance heuristic rather than a kernel constraint.
+_DEFAULT_MIN_CUTLASS_BATCH_SIZE = 4
 
 
 @dataclass
@@ -235,8 +236,13 @@ def should_prepare_decode_metadata(
     kv_cache_dtype: str,
     page_size: int,
     topk_blocks: int,
+    min_batch_size: int = _DEFAULT_MIN_CUTLASS_BATCH_SIZE,
 ) -> bool:
-    """Return whether a graph shape can use the CUTLASS decode path."""
+    """Return whether a graph shape can use the CUTLASS decode path.
+
+    ``min_batch_size`` is a tunable performance gate; the remaining checks are
+    kernel constraints.
+    """
     total_q = batch_size * decode_query_len
     return (
         supports_cutlass_sparse_decode(
@@ -248,7 +254,7 @@ def should_prepare_decode_metadata(
             topk_blocks=topk_blocks,
         )
         and 1 <= decode_query_len <= _MAX_DECODE_QUERY_LEN
-        and batch_size >= _MIN_CUTLASS_BATCH_SIZE
+        and batch_size >= min_batch_size
         and total_q * num_q_heads <= _MAX_QUERY_HEAD_ROWS
     )
 

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 import torch
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.attention import MiniMaxM3MSADecodeBackend
 from vllm.forward_context import get_forward_context
@@ -93,6 +94,7 @@ class MiniMaxM3SparseMSAMetadataBuilder(MiniMaxM3SparseMetadataBuilder):
         self.kv_cache_dtype = vllm_config.cache_config.cache_dtype
         self.decode_backend = vllm_config.attention_config.minimax_m3_msa_decode_backend
         self.msa_cutlass_plan_cache = MSACutlassDecodePlanCache()
+        self.msa_cutlass_min_batch_size = envs.VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH
 
     def build(
         self,
@@ -119,6 +121,7 @@ class MiniMaxM3SparseMSAMetadataBuilder(MiniMaxM3SparseMetadataBuilder):
             kv_cache_dtype=self.kv_cache_dtype,
             page_size=SPARSE_BLOCK_SIZE,
             topk_blocks=self.topk_blocks,
+            min_batch_size=self.msa_cutlass_min_batch_size,
         ):
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             assert seq_lens_cpu is not None

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 
 import torch
 
-from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.attention import MiniMaxM3MSADecodeBackend
 from vllm.forward_context import get_forward_context
@@ -94,7 +93,6 @@ class MiniMaxM3SparseMSAMetadataBuilder(MiniMaxM3SparseMetadataBuilder):
         self.kv_cache_dtype = vllm_config.cache_config.cache_dtype
         self.decode_backend = vllm_config.attention_config.minimax_m3_msa_decode_backend
         self.msa_cutlass_plan_cache = MSACutlassDecodePlanCache()
-        self.msa_cutlass_min_batch_size = envs.VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH
 
     def build(
         self,
@@ -121,7 +119,6 @@ class MiniMaxM3SparseMSAMetadataBuilder(MiniMaxM3SparseMetadataBuilder):
             kv_cache_dtype=self.kv_cache_dtype,
             page_size=SPARSE_BLOCK_SIZE,
             topk_blocks=self.topk_blocks,
-            min_batch_size=self.msa_cutlass_min_batch_size,
         ):
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             assert seq_lens_cpu is not None


### PR DESCRIPTION
## Problem this solves

Selecting the MiniMax M3 CUTLASS MSA decode backend does not currently mean
that common EAGLE3 verification steps use CUTLASS. The metadata builder has a
fixed `batch_size >= 16` dispatch gate, so smaller steps fall back to the Triton
split-K sparse-decode and merge path even when their shape is already faster on
CUTLASS.

A single lower request-batch floor is not safe either. MiniMax M3's TP degree
changes the rank-local query/KV head geometry, which moves the kernel crossover.
On B300 with EAGLE3 query length 4, a blanket floor of 4 would make TP2 batch 4
about 20% slower and TP4 batches 4 and 8 about 40% and 20% slower,
respectively.

## Purpose and mechanism

This PR makes the CUTLASS performance gate specific to the measured B300
EAGLE3 shape:

| Rank-local query/KV heads | Typical topology | Minimum request batch |
| ---: | --- | ---: |
| 64/4 | TP1 or attention-replicated DP/EP | 4 |
| 32/2 | TP2 | 8 |
| 16/1 | TP4 | 16 |

The lower thresholds apply only on SM103 with decode query length 4. Regular
decode, other speculative query lengths, SM100, and unrecognized head
geometries retain the existing batch-16 floor. All existing constraints remain
unchanged: CUTLASS still requires an explicitly selected CUTLASS MSA backend,
FP8 E4M3 KV cache, supported head geometry, page size 128, top-k 16, supported
query length, and the planner row bound.

The automatic policy remains tunable through
`VLLM_MINIMAX_M3_MSA_CUTLASS_MIN_BATCH`:

- unset or `auto`: use the geometry-aware default;
- a positive integer: override the automatic floor;
- `16`, `0`, an empty value, or `false`/`no`/`off`: restore the original floor
  of 16;
- an invalid or negative value: warn and safely fall back to 16.

The value is resolved once when the metadata builder is initialized and passed
to the existing dispatch predicate. It also remains registered with vLLM's
environment validation and compile-cache factors.

## Kernel evidence

The isolated benchmark uses one NVIDIA GB300, EAGLE3 query length 4, FP8 E4M3
KV cache, 16 selected pages per token/KV head, CUDA graph replay, 30 warmups,
300 iterations, and five trials. It covers request batches 1/2/4/8/16, 8K and
200K cached contexts, TP1/TP2/TP4, and concurrent DEP2/DEP4 ranks.

The conservative comparison below charges CUTLASS for a standalone BF16-to-FP8
query quantization launch even though the serving implementation can emit that
query from its fused QK-norm/RoPE/KV-insert operation:

| Local heads | Batch 4 | Batch 8 | Batch 16 | First measured win |
| ---: | ---: | ---: | ---: | ---: |
| 64/4 | 1.069x | 1.545x | 1.875x | 4 |
| 32/2 | 0.800x | 1.100x | 1.642x | 8 |
| 16/1 | 0.600x | 0.800x | 1.099x | 16 |

The 8K and 200K sweeps have the same crossover for every tested topology. All
130 rank-level CUTLASS-versus-Triton correctness comparisons passed at
`atol=0.02`, `rtol=0.02`; the maximum absolute error was 0.00006104.

The complete tables, raw-kernel and quantization-inclusive timings, benchmark
methodology, and runnable script are in this
[public benchmark Gist](https://gist.github.com/anish-shanbhag/3ce54e7314995b38b22612ab0100b260).

## End-to-end evidence

Matched MiniMax-M3-NVFP4 disaggregated EAGLE3 runs compared the original fixed
batch-16 gate with the earlier blanket batch-4 experiment. The serving topology
used one TP2 prefill worker and three TP2 decode workers:

| Concurrent sessions | Fixed-16 gate: p90 user rate / total TPS per GPU | Gate-4 experiment: p90 user rate / total TPS per GPU | Raw change |
| ---: | ---: | ---: | ---: |
| 48 | 160.97 / 40,129 | 167.28 / 40,687 | +3.92% / +1.39% |
| 60 | 128.38 / 49,164 | 137.48 / 50,172 | +7.09% / +2.05% |

The microbenchmark now separates the measured TP2 batch-8 and batch-16 wins
from the regressive batch-4 shape. Because the 60-session control band had
meaningful run-to-run variance, the end-to-end result should be interpreted as
approximately +3--5% p90 per-user output-token rate and +1--2.5% total TPS/GPU,
not as attribution of the full sequential delta to this gate alone.

## Why this is not duplicate work

PR #50032 introduced the CUTLASS MSA path and its original fixed batch-16 gate.
Searches for open MiniMax M3 CUTLASS MSA decode, small-batch, and sparse-decode
dispatch changes found no other PR implementing a B300 EAGLE3
head-geometry-aware crossover policy.

## Test plan and results

- `pre-commit run --files tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py vllm/models/minimax_m3/nvidia/msa_cutlass_sparse_decode.py`: passed, including Ruff, mypy, typos, SPDX, forbidden-import, and configuration checks.
- Focused B300 kernel suite with the revised dispatch and override implementation: `41 passed` in 237.40 seconds.
- Focused environment parser suite: `9 passed`.
- Standalone B300 microbenchmark: 50 aggregate shapes and 130 rank-level comparisons completed; all correctness checks passed.
- Existing behavior is asserted for regular decode and SM100; new boundary tests cover TP1 batch 4, TP2 batch 8, and TP4 batch 16 under EAGLE3.
- Environment tests cover automatic mode, positive overrides, original-floor rollback, false-like values, and invalid-input fallback.

## AI assistance disclosure

This change and its supporting benchmark were prepared with OpenAI Codex. The
human submitter remains responsible for reviewing every changed line and
defending the implementation and evidence end to end. The commit includes a
`Co-authored-by` trailer.
