### PR TITLE
[Bugfix][MooncakeStore] Drop stale save metadata

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -5,9 +5,13 @@ from types import SimpleNamespace
 
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
+    scheduler as scheduler_module,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     LoadSpec,
     MooncakeLookupResult,
+    MooncakeStoreConnectorMetadata,
     MooncakeStoreWorkerMetadata,
     ReqMeta,
     RequestTracker,
@@ -126,6 +130,87 @@ def _make_new_scheduler_output() -> SimpleNamespace:
         scheduled_spec_decode_tokens={},
         kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1],)),
     )
+
+
+@pytest.mark.parametrize(
+    "block_state",
+    [
+        None,
+        KVConnectorBlockState(block_ids={}, boundary_state_offloads={}),
+    ],
+)
+def test_stale_save_without_current_block_table_is_dropped(block_state, monkeypatch):
+    scheduler = _make_bare_scheduler()
+    meta = MooncakeStoreConnectorMetadata(set(), set())
+    stale_save = ReqMeta(
+        req_id="stale-request",
+        token_len_chunk=16,
+        block_ids=([7],),
+        block_hashes=[b"h0"],
+        can_save=True,
+    )
+    load_only = ReqMeta(
+        req_id="load-request",
+        token_len_chunk=16,
+        block_ids=([8],),
+        block_hashes=[b"h0"],
+        can_save=False,
+        load_spec=LoadSpec(
+            vllm_cached_tokens=0,
+            kvpool_cached_tokens=16,
+            can_load=True,
+        ),
+    )
+    meta.requests.extend([stale_save, load_only])
+    warnings = []
+    monkeypatch.setattr(
+        scheduler_module.logger,
+        "warning_once",
+        lambda message, req_id: warnings.append(message % req_id),
+    )
+
+    scheduler._apply_current_save_block_ids(
+        meta,
+        SimpleNamespace(kv_connector_block_state=block_state),
+    )
+
+    assert meta.requests == [load_only]
+    assert warnings == [
+        (
+            "Skipping Mooncake store save for request stale-request because its "
+            "current block table is missing"
+        )
+    ]
+
+
+def test_current_block_table_replaces_save_metadata_blocks(monkeypatch):
+    scheduler = _make_bare_scheduler()
+    meta = MooncakeStoreConnectorMetadata(set(), set())
+    req_meta = ReqMeta(
+        req_id="req-0",
+        token_len_chunk=16,
+        block_ids=([7],),
+        block_hashes=[b"h0"],
+        can_save=True,
+    )
+    meta.add_request(req_meta)
+    warnings = []
+    monkeypatch.setattr(
+        scheduler_module.logger,
+        "warning_once",
+        lambda *args: warnings.append(args),
+    )
+
+    scheduler._apply_current_save_block_ids(
+        meta,
+        SimpleNamespace(
+            kv_connector_block_state=_make_connector_block_state(block_ids=([3],))
+        ),
+    )
+
+    assert meta.requests == [req_meta]
+    assert req_meta.block_ids == ([3],)
+    assert warnings == []
 
 
 def test_scheduler_only_tracks_token_ids_for_kv_events():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -429,15 +429,21 @@ class MooncakeStoreScheduler:
         if not save_metas:
             return
 
-        block_state = scheduler_output.kv_connector_block_state
-        assert block_state is not None, (
-            "Current block tables are required for Mooncake store jobs"
-        )
+        block_state = getattr(scheduler_output, "kv_connector_block_state", None)
         for req_meta in save_metas:
-            block_ids = block_state.block_ids.get(req_meta.req_id)
-            assert block_ids is not None, (
-                f"Missing current block table for store request {req_meta.req_id}"
+            block_ids = (
+                block_state.block_ids.get(req_meta.req_id)
+                if block_state is not None
+                else None
             )
+            if block_ids is None:
+                logger.warning_once(
+                    "Skipping Mooncake store save for request %s because its "
+                    "current block table is missing",
+                    req_meta.req_id,
+                )
+                meta.requests.remove(req_meta)
+                continue
             req_meta.block_ids = block_ids
 
     def _reference_save_blocks(self, meta: MooncakeStoreConnectorMetadata) -> None:


### PR DESCRIPTION
## Problem this solves

MooncakeStore refreshes each save request's block IDs from the scheduler's current block table immediately before it pins those blocks and hands the save to the worker. The current table is authoritative: the append-only IDs in the request tracker may refer to blocks that have since been freed or reassigned.

Today, `_apply_current_save_block_ids()` asserts when either the step has no connector block state or a save request is absent from that state. That turns an optional external-cache write into an engine-ending failure. This can happen when save metadata becomes stale relative to request cleanup, and it is particularly undesirable on a `kv_consumer`: with `save_decode_cache=false`, the consumer is intended to load KV, not populate the store.

Current `main` already prevents normal consumer prefill/decode paths from creating these saves. This PR adds a final defensive check at the point where save metadata is reconciled with the scheduler's authoritative block ownership. If a future or concurrent metadata path still produces a stale save, vLLM now drops only that cache write instead of terminating the serving process.

## Motivation and workload evidence

This failure was reproduced with a cache-heavy MiniMax M3 FP4 workload using one disaggregated prefill worker and one decode worker, TP2 on each side, Mooncake lookup enabled on the consumer, and `save_decode_cache=false`.

- Without the guard, the long-running workload terminated about 5.5 minutes into its measured phase after stale save metadata reached the current-block-table assertion.
- With the guard, the same workload shape completed its full 3,600-second measured duration.
- The intended degradation is narrow: one stale external-cache save is skipped. Request execution and load-only metadata continue, and later requests may repopulate the missing cache entry.

This is a reliability fix, not a performance claim. No throughput improvement is attributed to this change.

## Purpose

- Treat a missing `kv_connector_block_state` or missing per-request block table as stale save metadata.
- Emit a `warning_once` message with the affected request ID so the condition remains diagnosable without flooding long-running server logs.
- Remove the stale save before `_reference_save_blocks()` can pin old block IDs or the worker can read from them.
- Preserve load-only request metadata and the existing behavior that replaces valid save metadata with current block IDs.

Using the tracker's old block IDs as a fallback would be unsafe because those IDs are deliberately superseded by the core scheduler snapshot and may already have been recycled. Skipping the optional write is therefore the conservative behavior.

## Test Plan

Focused unit coverage in `tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py` checks:

1. A save is dropped when the entire connector block state is absent.
2. A save is dropped when block state exists but has no entry for that request.
3. Load-only metadata survives both cases.
4. Each stale condition emits the warning.
5. A valid current block table still replaces the tracker's stale block IDs without warning.

Commands:

```bash
pytest -q tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
ruff check tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
ruff format --check tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
python -m py_compile vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
```

## Test Result

- `ruff check`: passed.
- `ruff format --check`: passed.
- `py_compile`: passed.
- Focused pytest collection is pending vLLM's Linux/CUDA CI environment. The available development hosts could not provide a compatible current vLLM dependency set: the macOS resolver rejects the repository's Linux CPU torch pin, while the available CPU-only Linux host lacks the CUDA runtime required by its installed torch/torchaudio packages.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described above.
- [x] The test plan and focused regression coverage are described above.
- [x] Available test results and the remaining environment limitation are reported above.
- [x] No documentation update is needed; this only changes failure handling for stale scheduler metadata.
</details>

