### PR TITLE
[CI][Spec Decode] Revamp async scheduling tests

### DIFF
--- a/tests/v1/e2e/general/async_scheduling_utils.py
+++ b/tests/v1/e2e/general/async_scheduling_utils.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Numerical checks against an independent, teacher-forced target model."""
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from functools import lru_cache
+
+import torch
+import xgrammar as xgr
+from tokenizers.decoders import DecodeStream
+
+from tests.conftest import HfRunner
+from vllm import SamplingParams
+from vllm.logprobs import Logprob
+from vllm.outputs import RequestOutput
+from vllm.tokenizers.detokenizer_utils import convert_ids_list_to_tokens
+from vllm.v1.engine.logprobs import LogprobsProcessor
+
+
+@dataclass(frozen=True)
+class AccuracyTolerance:
+    logprob_atol: float
+    greedy_atol: float
+    logprob_mean_atol: float = 0.1
+    greedy_total_atol: float = 0.5
+
+    def logprob_error(self, reference: torch.Tensor) -> torch.Tensor:
+        return torch.full_like(reference, self.logprob_atol)
+
+
+def check_logprobs(
+    scores: dict[int, Logprob],
+    reference: torch.Tensor,
+    token: int,
+    requested: int,
+    tolerance: AccuracyTolerance,
+    context: str,
+) -> torch.Tensor:
+    """Check every score, reported rank, and the complete requested top-k."""
+    assert all(0 <= token_id < reference.numel() for token_id in scores), context
+    assert token in scores, f"{context}: missing score for token {token}"
+    assert max(1, requested) <= len(scores) <= requested + 1, context
+    assert not torch.isnan(reference).any(), context
+    assert all(s.rank is not None and s.rank >= 1 for s in scores.values()), context
+    ids = torch.tensor(list(scores), device=reference.device)
+    actual = torch.tensor(
+        [score.logprob for score in scores.values()], device=reference.device
+    )
+    expected = reference[ids]
+    finite = torch.isfinite(expected)
+    assert torch.equal(torch.isfinite(actual), finite), (
+        f"{context}: finite/masked logprobs differ: {scores}"
+    )
+    assert torch.equal(actual[~finite], expected[~finite]), context
+    assert (actual[finite] <= 0).all(), f"{context}: positive log probability"
+    errors = (actual[finite] - expected[finite]).abs()
+    bounds = tolerance.logprob_error(expected[finite])
+    assert (errors <= bounds).all(), (
+        f"{context}: token IDs={ids[finite].tolist()}, "
+        f"actual={actual[finite].tolist()}, reference={expected[finite].tolist()}, "
+        f"error={errors.tolist()}, bound={bounds.tolist()}"
+    )
+
+    for token_id, score in scores.items():
+        value = reference[token_id]
+        if not torch.isfinite(value):
+            continue
+        delta = tolerance.logprob_error(value)
+        lower = 1 + int((reference > value + 2 * delta).sum())
+        upper = max(1, int((reference >= value - 2 * delta).sum()))
+        assert score.rank is not None and lower <= score.rank <= upper, (
+            f"{context}: token={token_id}, rank={score.rank}, "
+            f"reference rank interval=[{lower}, {upper}]"
+        )
+
+    if requested:
+        # The sampled token can be outside top-k even when it ties the kth
+        # score. Its strict-greater rank can therefore duplicate a top-k rank.
+        top_ids = (
+            list(scores)
+            if len(scores) == requested
+            else [t for t in scores if t != token]
+        )
+        assert len(top_ids) == requested, f"{context}: incomplete top-k"
+        assert {scores[t].rank for t in top_ids} == set(range(1, requested + 1)), (
+            context
+        )
+        ordered = sorted(top_ids, key=lambda t: scores[t].rank)
+        assert all(
+            scores[a].logprob >= scores[b].logprob for a, b in zip(ordered, ordered[1:])
+        ), f"{context}: top-k scores disagree with their reported ranks"
+        boundary = reference.topk(requested).values[-1]
+        if torch.isfinite(boundary):
+            delta = tolerance.logprob_error(boundary)
+            required = (reference > boundary + 2 * delta).nonzero().flatten()
+            assert set(required.tolist()) <= scores.keys(), (
+                f"{context}: missing an unambiguously top-{requested} token"
+            )
+            assert (reference[top_ids] >= boundary - 2 * delta).all(), (
+                f"{context}: returned token below the top-{requested} boundary"
+            )
+    return errors
+
+
+def check_greedy_token(
+    logits: torch.Tensor,
+    token: int,
+    tolerance: AccuracyTolerance,
+    context: str,
+) -> float:
+    assert not torch.isnan(logits).any(), context
+    assert torch.isfinite(logits[token]), (
+        f"{context}: selected token {token} is forbidden by the sampling parameters"
+    )
+    best = int(logits.argmax())
+    gap = float(logits[best] - logits[token])
+    assert gap <= tolerance.greedy_atol, (
+        f"{context}: selected token={token}, reference best={best}, "
+        f"logit gap={gap}, bound={tolerance.greedy_atol}"
+    )
+    return gap
+
+
+def check_accuracy_budget(errors, gaps, tolerance, context):
+    """Reject systematic sub-bound errors within each request and score stream."""
+    if errors:
+        finite_errors = torch.cat(errors)
+        if finite_errors.numel():
+            mean_error = float(finite_errors.mean())
+            assert mean_error <= tolerance.logprob_mean_atol, (
+                f"{context}: mean logprob error={mean_error}, "
+                f"bound={tolerance.logprob_mean_atol}"
+            )
+    assert sum(gaps) <= tolerance.greedy_total_atol, (
+        f"{context}: total greedy logit gap={sum(gaps)}, "
+        f"bound={tolerance.greedy_total_atol}"
+    )
+
+
+def _check_decoded_tokens(processor, scores, history, context):
+    ids = list(scores)
+    decoded = convert_ids_list_to_tokens(processor.tokenizer, ids)
+    decoded = processor._verify_tokens(decoded, ids, context_token_ids=history[-4:])
+    for token, text in zip(ids, decoded, strict=True):
+        assert scores[token].decoded_token == text, (
+            f"{context}: incorrect decoded text for token {token}"
+        )
+
+
+@torch.inference_mode()
+def check_request_accuracy(
+    hf: HfRunner,
+    request: RequestOutput,
+    params: SamplingParams,
+    tolerance: AccuracyTolerance,
+    context: str,
+) -> None:
+    """Score the actual continuation, including positions after any divergence."""
+    assert request.finished and len(request.outputs) == 1, context
+    (completion,) = request.outputs
+    prompt = request.prompt_token_ids
+    assert prompt is not None and len(prompt) > 0, context
+    tokens = list(completion.token_ids)
+    assert params.max_tokens is not None and 0 < len(tokens) <= params.max_tokens, (
+        context
+    )
+    # Incremental decoding buffers incomplete UTF-8; decoding the final token
+    # list in one call can incorrectly append a replacement character.
+    stream = DecodeStream(skip_special_tokens=params.skip_special_tokens)
+    tokenizer = hf.tokenizer.backend_tokenizer
+    for token in prompt:
+        stream.step(tokenizer, token)
+    visible = tokens
+    if completion.finish_reason == "stop" and not params.include_stop_str_in_output:
+        visible = tokens[:-1]
+    expected_text = "".join(stream.step(tokenizer, token) or "" for token in visible)
+    assert completion.text == expected_text, (
+        f"{context}: decoded text does not match generated token IDs"
+    )
+    inputs = torch.tensor([prompt + tokens], device=hf.device)
+    logits = hf.model(input_ids=inputs, use_cache=False).logits[0].float()
+    # Use the existing byte-fallback handling with an independent request
+    # history; numerical scores always come from the HF model above.
+    decoder = LogprobsProcessor(hf.tokenizer, None, None, None, None, None)
+    # Prompt token i is predicted by the causal logits at position i - 1.
+    if params.prompt_logprobs is None:
+        assert request.prompt_logprobs is None, context
+    else:
+        assert request.prompt_logprobs is not None, context
+        assert len(request.prompt_logprobs) == len(prompt), context
+        assert request.prompt_logprobs[0] is None, context
+        errors = []
+        for i, scores in enumerate(request.prompt_logprobs[1:], 1):
+            assert scores is not None, context
+            _check_decoded_tokens(decoder, scores, prompt[1:i], context)
+            errors.append(
+                check_logprobs(
+                    scores,
+                    logits[i - 1].log_softmax(-1),
+                    prompt[i],
+                    params.prompt_logprobs,
+                    tolerance,
+                    f"{context}, prompt position={i}",
+                )
+            )
+        check_accuracy_budget(errors, [], tolerance, f"{context}, prompt logprobs")
+
+    if params.logprobs is None:
+        assert completion.logprobs is None, context
+    else:
+        assert completion.logprobs is not None, context
+        assert len(completion.logprobs) == len(tokens), context
+
+    reference = SamplingReference(
+        hf.tokenizer,
+        logits.shape[-1],
+        hf.model.generation_config.to_dict(),
+        params,
+    )
+    errors = []
+    gaps = []
+    for i, token in enumerate(tokens):
+        raw, processed = reference.distributions(
+            logits[len(prompt) + i - 1], tokens[:i]
+        )
+        position = f"{context}, generated position={i}"
+        gaps.append(check_greedy_token(processed, token, tolerance, position))
+        if completion.logprobs is not None:
+            _check_decoded_tokens(decoder, completion.logprobs[i], tokens[:i], position)
+            errors.append(
+                check_logprobs(
+                    completion.logprobs[i],
+                    raw.log_softmax(-1),
+                    token,
+                    params.logprobs,
+                    tolerance,
+                    position,
+                )
+            )
+    check_accuracy_budget(errors, gaps, tolerance, f"{context}, completion")
+    # Advance the grammar through the last token too; an incomplete JSON prefix
+    # is allowed at max_tokens, but every emitted token must remain valid.
+    reference.accept_history(tokens)
+    check_stopping(
+        tokens, completion.finish_reason, reference.stop_ids, params, context
+    )
+
+
+def check_stopping(tokens, finish_reason, stop_ids, params, context):
+    assert not params.ignore_eos and not params.stop, context
+    assert not stop_ids.intersection(tokens[:-1]), (
+        f"{context}: generation continued after a stop token"
+    )
+    if tokens[-1] in stop_ids:
+        assert finish_reason == "stop", (
+            f"{context}: stop token did not terminate output"
+        )
+    else:
+        assert finish_reason == "length" and len(tokens) == params.max_tokens, context
+
+
+@lru_cache(maxsize=4)
+def _compiler(tokenizer, vocab_size: int):
+    info = xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=vocab_size)
+    return xgr.GrammarCompiler(info, max_threads=1, cache_enabled=True)
+
+
+class SamplingReference:
+    """One request's reference; histories must grow without changing their prefix."""
+
+    def __init__(
+        self,
+        tokenizer,
+        vocab_size: int,
+        generation_config: dict,
+        params: "SamplingParams",
+    ):
+        assert params.temperature == 0.0, "Only the original greedy matrix is supported"
+        assert params.presence_penalty == 0.0 and params.repetition_penalty == 1.0
+        assert params.allowed_token_ids is None and not params.logit_bias
+        self.vocab_size = vocab_size
+        self.min_tokens = params.min_tokens
+        self.frequency_penalty = params.frequency_penalty
+        self.stop_ids = set(params.stop_token_ids or [])
+        for eos in (tokenizer.eos_token_id, generation_config.get("eos_token_id")):
+            if eos is not None:
+                self.stop_ids.update([eos] if isinstance(eos, int) else eos)
+        assert all(0 <= token < vocab_size for token in self.stop_ids)
+
+        # Match public bad-word tokenization semantics without using sampler code.
+        self.bad_words: list[list[int]] = []
+        for word in params.bad_words or []:
+            plain = tokenizer.encode(word.lstrip(), add_special_tokens=False)
+            spaced = tokenizer.encode(" " + word.lstrip(), add_special_tokens=False)
+            assert plain, f"Empty bad-word tokenization: {word!r}"
+            self.bad_words.append(plain)
+            if spaced and len(spaced) == len(plain) and spaced[0] != plain[0]:
+                self.bad_words.append(spaced)
+
+        self.history: list[int] = []
+        self.matcher = None
+        self.bitmask = None
+        if params.structured_outputs is not None:
+            schema = params.structured_outputs.json
+            assert schema is not None, "Only the original JSON schema is supported"
+            # Preserve dictionary order: xgrammar's default grammar orders fields.
+            schema = schema if isinstance(schema, str) else json.dumps(schema)
+            compiled = _compiler(tokenizer, vocab_size).compile_json_schema(
+                schema, any_whitespace=True
+            )
+            self.matcher = xgr.GrammarMatcher(
+                compiled, override_stop_tokens=sorted(self.stop_ids) or None
+            )
+            self.bitmask = xgr.allocate_token_bitmask(1, vocab_size)
+
+    def accept_history(self, generated_ids: list[int]) -> bool:
+        """Validate newly generated grammar tokens, including the final EOS.
+
+        Return whether the grammar has terminated. Use this after the final
+        output token; no next-token distribution exists after termination.
+        """
+        assert generated_ids[: len(self.history)] == self.history, (
+            "Each reference belongs to one monotonically growing request history"
+        )
+        if self.matcher is not None:
+            for token in generated_ids[len(self.history) :]:
+                assert self.matcher.accept_token(token), (
+                    f"Grammar rejected token {token} at position {len(self.history)}"
+                )
+                self.history.append(token)
+            return self.matcher.is_terminated()
+        else:
+            self.history = generated_ids.copy()
+            return False
+
+    def distributions(
+        self, raw_logits: torch.Tensor, generated_ids: list[int]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return FP32 logits before and after non-grammar sampling transforms.
+
+        ``raw_logits`` scores the next token after the prompt and
+        ``generated_ids``. Returned tensors do not alias the model's tensor.
+        Normalize the first result to check reported completion logprobs;
+        the second supplies the greedy decision reference.
+        """
+        assert raw_logits.shape == (self.vocab_size,)
+        assert not self.accept_history(generated_ids), (
+            "Cannot generate a distribution after grammar EOS"
+        )
+
+        grammar_logits = raw_logits.float().clone()
+        if self.matcher is not None:
+            assert self.bitmask is not None
+            self.matcher.fill_next_token_bitmask(self.bitmask)
+            words = self.bitmask[0, :, None]
+            allowed = ((words >> torch.arange(32)) & 1).flatten()
+            allowed = allowed[: self.vocab_size].bool().to(raw_logits.device)
+            grammar_logits.masked_fill_(~allowed, -torch.inf)
+
+        processed = grammar_logits.clone()
+        for bad_word in self.bad_words:
+            prefix = bad_word[:-1]
+            if not prefix or generated_ids[-len(prefix) :] == prefix:
+                processed[bad_word[-1]] = -torch.inf
+
+        if len(generated_ids) < self.min_tokens and self.stop_ids:
+            stop_ids = sorted(self.stop_ids)
+            stop_scores = processed[stop_ids].clone()
+            processed[stop_ids] = -torch.inf
+            # A completed grammar may have no continuation except a stop token.
+            if self.matcher is not None and torch.isneginf(processed).all():
+                processed[stop_ids] = stop_scores
+
+        if self.frequency_penalty:
+            for token, count in Counter(generated_ids).items():
+                processed[token] -= self.frequency_penalty * count
+        return grammar_logits, processed

--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -1,24 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-from itertools import repeat
+from dataclasses import replace
 from typing import Any
 
 import pytest
-import torch._dynamo.config as dynamo_config
+import torch
 
+from tests.conftest import HfRunner, VllmRunner
 from tests.utils import (
     large_gpu_mark,
     single_gpu_only,
+)
+from tests.v1.e2e.general.async_scheduling_utils import (
+    AccuracyTolerance,
+    check_accuracy_budget,
+    check_greedy_token,
+    check_logprobs,
+    check_request_accuracy,
+    check_stopping,
 )
 from vllm import SamplingParams
 from vllm.logprobs import Logprob
 from vllm.platforms import current_platform
 from vllm.sampling_params import StructuredOutputsParams
 from vllm.v1.metrics.reader import Metric
-
-from ....conftest import VllmRunner
-from ....models.utils import check_outputs_equal
 
 MODEL = "Qwen/Qwen3-0.6B"
 MTP_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
@@ -44,11 +50,11 @@ default_params = dict(
 
 @single_gpu_only
 def test_without_spec_decoding(
+    vllm_runner: type[VllmRunner],
+    hf_runner: type[HfRunner],
     sample_json_schema,
-    monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test consistency of combos of async scheduling, preemption,
-    uni/multiproc executor, prefill chunking."""
+    """Check target-model accuracy across scheduling and executor configurations."""
     struct_outputs = StructuredOutputsParams(json=sample_json_schema)
     test_sampling_params: list[dict[str, Any]] = [
         dict(),
@@ -89,28 +95,17 @@ def test_without_spec_decoding(
         (True, "uni", True, None, True),
     ]
 
-    if current_platform.is_rocm():
-        # On ROCm, Only test with structured_outputs (deterministic)
-        # and skip chunk_prefill (more variable).
-        test_configs = [
-            cfg
-            for cfg in test_configs
-            if not cfg[4]  # skip chunk_prefill=True
-        ]
-        test_sampling_params = [
-            p for p in test_sampling_params if p.get("structured_outputs") is not None
-        ]
-
-    run_tests(monkeypatch, MODEL, test_configs, test_sampling_params)
+    run_tests(vllm_runner, hf_runner, MODEL, test_configs, test_sampling_params)
 
 
 @single_gpu_only
 @large_gpu_mark(min_gb=16)
-def test_with_eagle3_spec_decoding(sample_json_schema, monkeypatch: pytest.MonkeyPatch):
-    """Test consistency and acceptance rates with some different combos of
-    preemption, executor, async scheduling, prefill chunking,
-    spec decoding model length.
-    """
+def test_with_eagle3_spec_decoding(
+    vllm_runner: type[VllmRunner],
+    hf_runner: type[HfRunner],
+    sample_json_schema,
+):
+    """Check accuracy and acceptance, including drafts that exceed model length."""
 
     spec_config = {
         "method": "eagle3",
@@ -122,7 +117,7 @@ def test_with_eagle3_spec_decoding(sample_json_schema, monkeypatch: pytest.Monke
 
     struct_outputs = StructuredOutputsParams(json=sample_json_schema)
 
-    test_sampling_params = [
+    test_sampling_params: list[dict[str, Any]] = [
         dict(),
         dict(frequency_penalty=-1.0),
         dict(bad_words=["the", " the"]),
@@ -154,23 +149,17 @@ def test_with_eagle3_spec_decoding(sample_json_schema, monkeypatch: pytest.Monke
         (True, "uni", True, spec_config_short, True),
     ]
 
-    run_tests(monkeypatch, MTP_MODEL, test_configs, test_sampling_params)
+    run_tests(vllm_runner, hf_runner, MTP_MODEL, test_configs, test_sampling_params)
 
 
-@pytest.mark.flaky(reruns=2, only_on=current_platform.is_rocm())
 @pytest.mark.skipif(
     current_platform.is_xpu(),
     reason=("XPU matmul/attention kernels are not batch-invariant"),
 )
-def test_with_ngram_gpu_spec_decoding(monkeypatch: pytest.MonkeyPatch):
-    """Test ngram_gpu speculative decoding with different configurations.
-
-    This test specifically validates ngram_gpu behavior with various:
-    - Number of speculative tokens (2-6)
-    - Prompt lookup window sizes (min/max)
-    - Async scheduling enabled (as in production)
-    - Different executors and chunking settings
-    """
+def test_with_ngram_gpu_spec_decoding(
+    vllm_runner: type[VllmRunner], hf_runner: type[HfRunner]
+):
+    """Check ngram accuracy and acceptance across scheduling configurations."""
 
     # Variant with larger speculation window
     ngram_gpu_config = {
@@ -195,131 +184,82 @@ def test_with_ngram_gpu_spec_decoding(monkeypatch: pytest.MonkeyPatch):
 
     # Use MODEL (Qwen) for ngram_gpu tests as it's lighter weight
     # and ngram_gpu doesn't require a specific draft model
-    run_tests(monkeypatch, MODEL, test_configs, [{}])
+    run_tests(vllm_runner, hf_runner, MODEL, test_configs, [{}])
 
 
-@dynamo_config.patch(cache_size_limit=16)
 def run_tests(
-    monkeypatch: pytest.MonkeyPatch,
+    vllm_runner: type[VllmRunner],
+    hf_runner: type[HfRunner],
     model: str,
     test_configs: list[tuple],
     test_sampling_params: list[dict[str, Any]],
 ):
-    """Test consistency of combos of async scheduling, preemption,
-    uni/multiproc executor with spec decoding."""
-
-    # Flex attention supports float32.
-    attention_config = {"backend": "FLEX_ATTENTION"}
-
-    with monkeypatch.context() as m:
-        # lock matmul precision to full FP32 (IEEE)
-        m.setenv("VLLM_FLOAT32_MATMUL_PRECISION", "highest")
-        outputs: list[tuple[str, list, list]] = []
-        for n, (
-            test_preemption,
-            executor,
-            async_scheduling,
-            spec_config,
-            test_prefill_chunking,
-        ) in enumerate(test_configs, 1):
-            test_str = f"{n}/{len(test_configs)}"
-            test_results = run_test(
+    """Validate every original batch against an independent target model."""
+    outputs = []
+    for n, config in enumerate(test_configs, 1):
+        outputs.append(
+            run_test(
+                vllm_runner,
                 model,
-                test_str,
+                f"{n}/{len(test_configs)}",
                 test_sampling_params,
-                test_preemption,
-                executor,
-                async_scheduling,
-                spec_config,
-                test_prefill_chunking=test_prefill_chunking,
-                attention_config=attention_config,
+                *config,
             )
-            outputs.append(test_results)
+        )
 
-    baseline_config, baseline_tests, _ = outputs[0]
-    _, _, baseline_acceptances = next(
-        (o for o in outputs if o[2] is not None), (None, None, None)
-    )
+    # Natural BF16 continuations can diverge at near ties, even between two
+    # synchronous calls. Score each actual history instead of comparing text
+    # generated from different histories. Neither engine forces an attention
+    # backend, model dtype, or matmul precision.
+    # Qwen/Llama BF16 controls and Qwen holdouts measured max score error <0.38,
+    # per-stream request mean <0.073, max greedy gap 0.125, and request sum 0.25.
+    # Per-request budgets also reject systematic errors below the scalar bounds.
+    tolerance = AccuracyTolerance(logprob_atol=0.5, greedy_atol=0.25)
+    with hf_runner(model) as hf:
+        hf.model.eval()
+        for config, batches, _ in outputs:
+            assert len(batches) == len(test_sampling_params)
+            for batch, overrides in zip(batches, test_sampling_params, strict=True):
+                assert len(batch) == len(example_prompts), config
+                params = SamplingParams(**default_params, **overrides)
+                for i, (request, prompt) in enumerate(
+                    zip(batch, example_prompts, strict=True)
+                ):
+                    assert request.prompt_token_ids == hf.tokenizer.encode(prompt)
+                    check_request_accuracy(
+                        hf,
+                        request,
+                        params,
+                        tolerance,
+                        f"config=[{config}], params={overrides}, request={i}",
+                    )
+                print(f"ACCURACY PASSED: config=[{config}], params={overrides}")
 
-    print(f"BASELINE: config=[{baseline_config}], accept_rates={baseline_acceptances}")
-
-    failure = None
-    for test_config, test_outputs, test_acceptance_rates in outputs[1:]:
-        for (base_outs, base_logprobs), base_acceptance_rate, (
-            test_outs,
-            test_logprobs,
-        ), test_acceptance_rate, params in zip(
-            baseline_tests,
-            baseline_acceptances or repeat(None),
-            test_outputs,
-            test_acceptance_rates or repeat(None),
-            test_sampling_params,
-        ):
-            reason = None
-            try:
-                check_outputs_equal(
-                    outputs_0_lst=base_outs,
-                    outputs_1_lst=test_outs,
-                    name_0=f"baseline=[{baseline_config}], params={params}",
-                    name_1=f"config=[{test_config}], params={params}",
-                )
-            except AssertionError as e:
-                reason = "outputs ", e
-
-            if reason is None:
-                try:
-                    assert _all_logprobs_match(base_logprobs, test_logprobs)
-                except AssertionError as e:
-                    reason = "logprobs", e
-
-            if reason is None:
-                try:
-                    if (
-                        base_acceptance_rate is not None
-                        and test_acceptance_rate is not None
-                    ):
-                        if "spec_mml=None" in test_config:
-                            # Preemption causes more variance in acceptance rates
-                            if (
-                                current_platform.is_rocm()
-                                and "preemption=True" in test_config
-                            ):
-                                tolerance = 0.10
-                            else:
-                                tolerance = 0.05
-                            assert (
-                                test_acceptance_rate > base_acceptance_rate
-                                or test_acceptance_rate
-                                == pytest.approx(base_acceptance_rate, rel=tolerance)
-                            )
-                        else:
-                            # Currently the reported acceptance rate is expected to be
-                            # lower when we sometimes skip drafting altogether.
-                            assert test_acceptance_rate > 0.1
-                except AssertionError as e:
-                    reason = "accept  ", e
-
-            if reason is None:
-                print(
-                    f"\033[32mPASSED\033[0m:           "
-                    f"config=[{test_config}], params={params}"
-                    f" accept_rate={test_acceptance_rate}"
-                )
-            else:
-                reason_str, _ = reason
-                print(
-                    f"\033[31mFAILED\033[0m({reason_str}): "
-                    f"config=[{test_config}], params={params}"
-                    f" accept_rate={test_acceptance_rate}"
-                )
-                if failure is None:
-                    _, failure = reason
-
-    if failure is not None:
-        raise failure
+    baseline_acceptances = next((o[2] for o in outputs if o[2] is not None), None)
+    if baseline_acceptances is not None:
+        for config, _, acceptances in outputs:
+            if acceptances is None:
+                continue
+            for baseline, actual, params in zip(
+                baseline_acceptances, acceptances, test_sampling_params, strict=True
+            ):
+                context = f"config=[{config}], params={params}"
+                if "spec_mml=None" in config:
+                    # Keep the original acceptance-quality floor per batch.
+                    relative_drop = (
+                        0.10
+                        if current_platform.is_rocm() and "preemption=True" in config
+                        else 0.05
+                    )
+                    assert actual >= baseline * (1 - relative_drop), (
+                        f"{context}: acceptance={actual}, baseline={baseline}"
+                    )
+                else:
+                    assert actual > 0.1, f"{context}: acceptance={actual}"
 
 
 def run_test(
+    vllm_runner: type[VllmRunner],
     model: str,
     test_str: str,
     sampling_param_tests: list[dict[str, Any]],
@@ -328,21 +268,23 @@ def run_test(
     async_scheduling: bool,
     spec_config: dict[str, Any] | None,
     test_prefill_chunking: bool,
-    attention_config: dict[str, Any] | None = None,
 ):
     spec_decoding = spec_config is not None
+    spec_method = (spec_config or {}).get("method", "none")
+    # Chunked ngram decoding admits fewer concurrent requests under the
+    # 48-token budget. Its original 33-block cache did not preempt on ROCm.
+    # A 17-block cache forces contention while every original request fits
+    # comfortably within 256 tokens (the longest prompt plus output is 67).
+    cache_blocks = 17 if test_prefill_chunking and spec_method == "ngram_gpu" else 33
     cache_arg: dict[str, Any] = (
-        # Force preemptions: with 33 blocks (one is the reserved null block)
-        # the cache holds at most a single max-length request, so the ~34
-        # concurrent prompts contend and trigger preemption. (Prompts here are
-        # << max_model_len, so dropping max_model_len from 4096 to 512 doesn't
-        # change generation behavior.)
-        dict(num_gpu_blocks_override=33, max_model_len=512)
+        dict(
+            num_gpu_blocks_override=cache_blocks,
+            max_model_len=(cache_blocks - 1) * 16,
+        )
         if test_preemption
         else dict(gpu_memory_utilization=0.9, max_model_len=4096)
     )
     spec_mml = (spec_config or {}).get("max_model_len")
-    spec_method = (spec_config or {}).get("method", "none")
     test_config = (
         f"executor={executor}, preemption={test_preemption}, "
         f"async_sched={async_scheduling}, "
@@ -353,7 +295,7 @@ def run_test(
     print(f"---- TESTING {test_str}: {test_config}")
     print("-" * 80)
 
-    with VllmRunner(
+    with vllm_runner(
         model,
         enable_chunked_prefill=test_prefill_chunking,
         # Force prefill chunking
@@ -361,10 +303,8 @@ def run_test(
         enforce_eager=ENFORCE_EAGER,
         async_scheduling=async_scheduling,
         distributed_executor_backend=executor,
-        dtype="float32",
         speculative_config=spec_config,
         disable_log_stats=False,
-        attention_config=attention_config,
         enable_prefix_caching=False if current_platform.is_rocm() else None,
         **cache_arg,
     ) as vllm_model:
@@ -374,10 +314,9 @@ def run_test(
             metrics_before = vllm_model.llm.get_metrics()
             print(f"----------- RUNNING PARAMS: {override_params}")
             results.append(
-                vllm_model.generate(
-                    example_prompts,
+                vllm_model.llm.generate(
+                    vllm_model.get_inputs(example_prompts),
                     sampling_params=SamplingParams(**default_params, **override_params),
-                    return_logprobs=True,
                 )
             )
             metrics_after = vllm_model.llm.get_metrics()
@@ -392,62 +331,133 @@ def run_test(
                 )
                 assert preemptions > 0, "preemption test had no preemptions"
 
+    # Preserve the original parameter-effect checks across repeated batches.
     if len(results) > 1:
-        # First check that the different parameter configs
-        # actually result in different output.
-        for (other_test_outs, other_test_logprobs), params in zip(
-            results[1:], sampling_param_tests[1:]
-        ):
-            with pytest.raises(AssertionError):
-                check_outputs_equal(
-                    outputs_0_lst=results[0][0],
-                    outputs_1_lst=other_test_outs,
-                    name_0=f"baseline params={params}",
-                    name_1=f"other params={params}",
-                )
-                assert _all_logprobs_match(results[0][1], other_test_logprobs)
+        baseline = _result_signature(results[0])
+        for outputs, params in zip(results[1:], sampling_param_tests[1:], strict=True):
+            assert _result_signature(outputs) != baseline, (
+                f"{test_config}: sampling parameters had no observable effect: {params}"
+            )
+        # The old ROCm filter used schema-only as its first parameter set.
+        # Retain those comparisons after restoring the ordinary cases too.
+        schema_batches = [
+            batch
+            for batch, params in zip(results, sampling_param_tests, strict=True)
+            if params.get("structured_outputs") is not None
+        ]
+        for batch in schema_batches[1:]:
+            assert _result_signature(batch) != _result_signature(schema_batches[0]), (
+                f"{test_config}: structured sampling parameters had no effect"
+            )
 
     return test_config, results, acceptance_rates
 
 
-def _all_logprobs_match(req_a, req_b) -> bool:
-    return (
-        req_a == req_b
-        or len(req_a) == len(req_b)
-        and all(
-            len(seq_a) == len(seq_b)
-            and all(_logprobs_match(a, b) for a, b in zip(seq_a, seq_b))
-            for seq_a, seq_b in zip(req_a, req_b)
+def _result_signature(requests):
+    return [
+        (
+            list(request.outputs[0].token_ids),
+            request.outputs[0].text,
+            request.prompt_logprobs,
+            request.outputs[0].logprobs,
         )
-    )
-
-
-def _logprobs_match(
-    lps_a: dict[int, Logprob] | None,
-    lps_b: dict[int, Logprob] | None,
-) -> bool:
-    if lps_a is None or lps_b is None:
-        return lps_a is lps_b
-    rel_tol, abs_tol = 1e-3, 1e-6
-    return (
-        len(lps_a) == len(lps_b)
-        and lps_a.keys() == lps_b.keys()
-        and all(
-            a.decoded_token == b.decoded_token
-            and a.rank == pytest.approx(b.rank, rel=0.005)
-            and a.logprob == pytest.approx(b.logprob, rel=rel_tol, abs=abs_tol)
-            for a, b in ((lps_a[x], lps_b[x]) for x in lps_a)
-        )
-    )
+        for request in requests
+    ]
 
 
 def _get_acceptance_rate(before: list[Metric], after: list[Metric]) -> float:
     draft = _get_count(before, after, "vllm:spec_decode_num_draft_tokens")
     accept = _get_count(before, after, "vllm:spec_decode_num_accepted_tokens")
-    return accept / draft if draft > 0 else 0.0
+    assert draft > 0, "speculative test did not draft any tokens"
+    assert 0 <= accept <= draft, f"invalid acceptance counters: {accept=}, {draft=}"
+    return accept / draft
 
 
 def _get_count(before: list[Metric], after: list[Metric], name: str) -> int:
     before_val = next(m.value for m in before if m.name == name)
     after_val = next(m.value for m in after if m.name == name)
     return after_val - before_val
+
+
+@pytest.mark.parametrize(
+    "corruption", ["score", "rank", "top_k", "missing", "nan", "positive", "order"]
+)
+def test_accuracy_checks_reject_incorrect_logprobs(corruption):
+    second = 2.875 if corruption == "order" else 1.0
+    reference = torch.tensor([3.0, second, -2.0, -5.0]).log_softmax(-1)
+    tolerance = AccuracyTolerance(logprob_atol=0.5, greedy_atol=0.25)
+    scores = {
+        0: Logprob(logprob=float(reference[0]), rank=1, decoded_token="a"),
+        1: Logprob(logprob=float(reference[1]), rank=2, decoded_token="b"),
+    }
+    check_logprobs(scores, reference, 0, 2, tolerance, "control")
+    if corruption == "score":
+        scores[0] = replace(scores[0], logprob=scores[0].logprob - 1.0)
+    elif corruption == "rank":
+        scores[1] = replace(scores[1], rank=1)
+    elif corruption == "top_k":
+        del scores[1]
+        scores[3] = Logprob(logprob=float(reference[3]), rank=2, decoded_token="d")
+    elif corruption == "missing":
+        del scores[0]
+    elif corruption == "positive":
+        scores[0] = replace(scores[0], logprob=0.1)
+    elif corruption == "order":
+        scores[0] = replace(scores[0], rank=2)
+        scores[1] = replace(scores[1], rank=1)
+    else:
+        scores[0] = replace(scores[0], logprob=float("nan"))
+    with pytest.raises(AssertionError):
+        check_logprobs(scores, reference, 0, 2, tolerance, corruption)
+
+
+def test_accuracy_checks_distinguish_ties_from_wrong_tokens():
+    tolerance = AccuracyTolerance(logprob_atol=0.5, greedy_atol=0.25)
+    logits = torch.tensor([3.0, 2.875, -2.0, -torch.inf])
+    check_greedy_token(logits, 0, tolerance, "best")
+    check_greedy_token(logits, 1, tolerance, "near tie")
+    for token in (2, 3):
+        with pytest.raises(AssertionError):
+            check_greedy_token(logits, token, tolerance, "incorrect token")
+
+    # top-k may omit a sampled token tied at its boundary. The sampled rank
+    # can duplicate a sequential top-k rank without corrupting the result.
+    reference = torch.zeros(4).log_softmax(-1)
+    scores = {
+        token: Logprob(logprob=float(reference[token]), rank=rank)
+        for token, rank in [(3, 1), (0, 1), (1, 2)]
+    }
+    check_logprobs(scores, reference, 3, 2, tolerance, "tied top-k")
+
+    # A grammar with one allowed token still returns the requested top-k,
+    # including masked entries whose score is exactly negative infinity.
+    reference = torch.tensor([0.0, -torch.inf, -torch.inf])
+    scores = {0: Logprob(0.0, 1), 1: Logprob(-float("inf"), 2)}
+    check_logprobs(scores, reference, 0, 2, tolerance, "masked top-k")
+
+
+def test_accuracy_checks_reject_continuing_after_eos():
+    params = SamplingParams(max_tokens=3)
+    stop_ids = {2}
+    check_stopping([0, 1, 2], "stop", stop_ids, params, "EOS at length cap")
+    check_stopping([0, 1, 0], "length", stop_ids, params, "length cap")
+    for tokens, reason in [([0, 2, 1], "length"), ([0, 1, 2], "length")]:
+        with pytest.raises(AssertionError):
+            check_stopping(tokens, reason, stop_ids, params, "incorrect stopping")
+
+
+def test_accuracy_checks_reject_systematic_sub_bound_errors():
+    tolerance = AccuracyTolerance(logprob_atol=0.5, greedy_atol=0.25)
+    reference = torch.tensor([3.0, 2.75, -2.0]).log_softmax(-1)
+    scores = {i: Logprob(float(reference[i]) - 0.4, i + 1) for i in (0, 1)}
+    # Each corrupted score fits the scalar bound, but the bias must not pass.
+    errors = check_logprobs(scores, reference, 0, 2, tolerance, "biased scores")
+    with pytest.raises(AssertionError, match="mean logprob error"):
+        check_accuracy_budget([errors], [], tolerance, "biased scores")
+
+    gap = check_greedy_token(reference, 1, tolerance, "one ambiguous choice")
+    with pytest.raises(AssertionError, match="total greedy logit gap"):
+        check_accuracy_budget([], [gap] * 30, tolerance, "systematically worse choices")
+    check_accuracy_budget(
+        [torch.tensor([0.03, 0.07])], [0.125, 0.125], tolerance, "control variation"
+    )

--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -24,6 +24,7 @@ from vllm import SamplingParams
 from vllm.logprobs import Logprob
 from vllm.platforms import current_platform
 from vllm.sampling_params import StructuredOutputsParams
+from vllm.utils.torch_utils import set_default_torch_num_threads
 from vllm.v1.metrics.reader import Metric
 
 MODEL = "Qwen/Qwen3-0.6B"
@@ -215,7 +216,8 @@ def run_tests(
     # per-stream request mean <0.073, max greedy gap 0.125, and request sum 0.25.
     # Per-request budgets also reject systematic errors below the scalar bounds.
     tolerance = AccuracyTolerance(logprob_atol=0.5, greedy_atol=0.25)
-    with hf_runner(model) as hf:
+    # These short CPU reductions cost more to distribute across a thread pool.
+    with set_default_torch_num_threads(1), hf_runner(model) as hf:
         hf.model.eval()
         for config, batches, _ in outputs:
             assert len(batches) == len(test_sampling_params)


### PR DESCRIPTION
- Rewrite scheduling and speculative-decoding accuracy checks to use automatically selected attention and the model's normal dtype. Remove the forced Flex/FP32/highest-precision fixture, Dynamo-limit override, and ROCm ngram retry. Use absolute test imports and the shared `vllm_runner` / `hf_runner` fixtures throughout.
- Bound individual logprob errors at 0.5 and greedy logit gaps at 0.25, with additional per-request limits of 0.1 mean score error per stream and 0.5 total greedy gap. These BF16 criteria replace the original exact cross-run token agreement and `1e-3` relative score comparison; they do not claim the same numerical resolution.
- Preserve all original models, prompts, sampling combinations, repeated batches, target-only references, preemption checks, and acceptance-rate floors. Restore previously filtered ROCm configurations, covering 205 batches and 6,970 requests across ordinary decoding, EAGLE3, and ngram speculation. Reduce the chunked-ngram preemption fixture to 17 cache blocks and a 256-token model limit: the original requests use at most 67 tokens, and the previous 33-block cache did not trigger preemption with default ROCm attention.
- Add negative controls for corrupted scores, ranks, top-k entries, missing scores, forbidden or clearly wrong token choices, systematic sub-bound errors, and incorrect stopping. Check output text incrementally so an incomplete UTF-8 suffix is handled correctly.

The investigation began with [Buildkite build 12676's MI250 failure](https://buildkite.com/vllm/amd-ci/builds/12676/list?tab=output&jid=01a07b43-0202-4af8-ad76-abab5085071e#L1984), where EAGLE3 structured-output generation exhausted Flex's 16-variant recompilation limit. The test selected Flex explicitly to support its FP32 accuracy fixture, so it did not exercise automatic ROCm attention selection. The same is true for CUDA path. **This test is simply too stingy and can only pass reliably with Flex attention and high fp32 accuracy setting.**

Removing that fixture exposed BF16 score variation and near-tie token changes even between repeated synchronous controls, making exact comparison of subsequently different histories unreliable. This rewrite instead scores every observed history independently, preserves the original sampling constraints and coverage, and adds aggregate accuracy limits to reject systematic errors below individual tolerances. The earlier grammar-mask integration fixes address separate runtime defects and are excluded from this test rewrite.

Prepared with AI assistance (OpenAI Codex).
