### PR TITLE
[Core][Perf] Prefer contiguous KV block runs for disaggregated transfer

### DIFF
--- a/tests/v1/core/test_block_pool_contig.py
+++ b/tests/v1/core/test_block_pool_contig.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.core.block_pool import BlockPool
+
+pytestmark = pytest.mark.cpu_test
+
+
+def make_pool_with_free_order(block_ids: list[int]) -> BlockPool:
+    pool = BlockPool(
+        num_gpu_blocks=len(block_ids) + 1,
+        enable_caching=False,
+        hash_block_size=16,
+    )
+    blocks = pool.get_new_blocks(pool.get_num_free_blocks())
+    blocks_by_id = {block.block_id: block for block in blocks}
+    pool.free_blocks([blocks_by_id[block_id] for block_id in block_ids])
+    return pool
+
+
+@pytest.mark.parametrize(
+    ("free_order", "expected"),
+    [
+        (
+            [20, *range(8, 16), 1, 2, *range(18, 15, -1), *range(7, 2, -1), 19],
+            list(range(8, 16)),
+        ),
+        (
+            [20, *range(15, 7, -1), 1, 3, 2, *range(4, 8), *range(16, 20)],
+            list(range(8, 16)),
+        ),
+    ],
+)
+def test_contiguous_alloc_returns_runs_ascending(
+    free_order: list[int], expected: list[int]
+):
+    pool = make_pool_with_free_order(free_order)
+    pool.use_contiguous_allocation = True
+
+    blocks = pool.get_new_blocks(8)
+
+    assert [block.block_id for block in blocks] == expected
+
+
+def test_contiguous_alloc_fills_remainder_from_lru_head():
+    free_order = [14, 4, 5, 6, 1, 8, 2, 10, 3, 12, 13, 11, 9, 7]
+    pool = make_pool_with_free_order(free_order)
+    pool.use_contiguous_allocation = True
+
+    blocks = pool.get_new_blocks(8)
+
+    assert [block.block_id for block in blocks] == [4, 5, 6, 12, 13, 14, 1, 8]
+
+
+def test_contiguous_alloc_preserves_queue_links_after_free():
+    pool = make_pool_with_free_order([12, 4, 5, 6, 7, 8, 9, 10, 11, 3, 2, 1])
+    pool.use_contiguous_allocation = True
+
+    blocks = pool.get_new_blocks(8)
+    assert pool.get_num_free_blocks() == 4
+    assert [
+        block.block_id for block in pool.free_block_queue.get_all_free_blocks()
+    ] == [12, 3, 2, 1]
+    assert all(
+        block.prev_free_block is None and block.next_free_block is None
+        for block in blocks
+    )
+
+    pool.free_blocks(blocks)
+
+    queue = pool.free_block_queue
+    free_blocks = queue.get_all_free_blocks()
+    assert queue.num_free_blocks == 12
+    assert queue.fake_free_list_head.next_free_block is free_blocks[0]
+    assert free_blocks[0].prev_free_block is queue.fake_free_list_head
+    assert queue.fake_free_list_tail.prev_free_block is free_blocks[-1]
+    assert free_blocks[-1].next_free_block is queue.fake_free_list_tail
+    assert all(
+        left.next_free_block is right and right.prev_free_block is left
+        for left, right in zip(free_blocks, free_blocks[1:])
+    )
+
+
+def test_contiguous_alloc_disabled_keeps_lru_order():
+    free_order = [12, 4, 5, 6, 7, 8, 9, 10, 11, 3, 2, 1]
+    pool = make_pool_with_free_order(free_order)
+
+    blocks = pool.get_new_blocks(8)
+
+    assert [block.block_id for block in blocks] == free_order[:8]
+
+
+def test_contiguous_alloc_keeps_lru_order_for_small_allocations():
+    free_order = [12, 4, 5, 6, 7, 8, 9, 10, 11, 3, 2, 1]
+    pool = make_pool_with_free_order(free_order)
+    pool.use_contiguous_allocation = True
+
+    blocks = pool.get_new_blocks(7)
+
+    assert [block.block_id for block in blocks] == free_order[:7]
+
+
+def test_contiguous_alloc_search_is_bounded():
+    free_order = list(range(1, 32, 2)) + list(range(2, 33, 2)) + list(range(33, 41))
+    pool = make_pool_with_free_order(free_order)
+    pool.use_contiguous_allocation = True
+
+    blocks = pool.get_new_blocks(8)
+
+    assert [block.block_id for block in blocks] == list(range(1, 16, 2))
+
+
+def test_contiguous_alloc_enabled_from_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_KV_CONTIG_ALLOC", "1")
+
+    pool = make_pool_with_free_order([12, 4, 5, 6, 7, 8, 9, 10, 11, 3, 2, 1])
+
+    assert pool.use_contiguous_allocation

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -304,6 +304,7 @@ if TYPE_CHECKING:
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_KV_OFFLOAD_MAX_BATCH_DESCRIPTORS: int = 0
+    VLLM_KV_CONTIG_ALLOC: bool = False
     VLLM_WSL2_ENABLE_PIN_MEMORY: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
@@ -2093,6 +2094,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_KV_OFFLOAD_MAX_BATCH_DESCRIPTORS": lambda: int(
         os.getenv("VLLM_KV_OFFLOAD_MAX_BATCH_DESCRIPTORS", "0")
     ),
+    # Prefer contiguous physical block-ID runs for large KV-cache allocations.
+    "VLLM_KV_CONTIG_ALLOC": lambda: bool(int(os.getenv("VLLM_KV_CONTIG_ALLOC", "0"))),
     # On WSL2 with a compatible kernel (>= 4.19.121), pinned memory is
     # supported but disabled by default due to a small performance regression.
     # Set to 1 when pinned memory or UVA is required (e.g. CPU offloading
@@ -2370,6 +2373,8 @@ def compile_factors() -> dict[str, object]:
         "VLLM_ENABLE_CUDA_COMPATIBILITY",
         "VLLM_CUDA_COMPATIBILITY_PATH",
         "VLLM_SKIP_MODEL_NAME_VALIDATION",
+        # Changes block selection, not generated code.
+        "VLLM_KV_CONTIG_ALLOC",
         "LOCAL_RANK",
         "CUDA_VISIBLE_DEVICES",
         "NO_COLOR",

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable, Sequence
 from typing import Any
 
+from vllm import envs
 from vllm.distributed.kv_events import (
     MEDIUM_GPU,
     AllBlocksCleared,
@@ -28,6 +29,9 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+_CONTIGUOUS_ALLOC_MIN_BLOCKS = 8
+_CONTIGUOUS_ALLOC_WINDOW_FACTOR = 4
 
 
 class BlockHashToBlockMap:
@@ -171,6 +175,7 @@ class BlockPool:
         self.num_gpu_blocks = num_gpu_blocks
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size
+        self.use_contiguous_allocation = envs.VLLM_KV_CONTIG_ALLOC
         # All kv-cache blocks.
         self.blocks: list[KVCacheBlock] = [
             KVCacheBlock(idx) for idx in range(num_gpu_blocks)
@@ -669,7 +674,13 @@ class BlockPool:
         if num_blocks > self.get_num_free_blocks():
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        if (
+            not self.use_contiguous_allocation
+            or num_blocks < _CONTIGUOUS_ALLOC_MIN_BLOCKS
+        ):
+            ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        else:
+            ret = self._get_contiguous_free_blocks(num_blocks)
 
         # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:
@@ -685,6 +696,47 @@ class BlockPool:
                 block.ref_cnt += 1
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
+        return ret
+
+    def _get_contiguous_free_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
+        window_size = min(
+            self.get_num_free_blocks(),
+            _CONTIGUOUS_ALLOC_WINDOW_FACTOR * num_blocks,
+        )
+        window_blocks = []
+        if window_size:
+            for block in self.free_block_queue.iter_blocks_after(None):
+                window_blocks.append(block)
+                if len(window_blocks) == window_size:
+                    break
+
+        runs: list[list[KVCacheBlock]] = []
+        for block in window_blocks:
+            if not runs or abs(block.block_id - runs[-1][-1].block_id) != 1:
+                runs.append([])
+            runs[-1].append(block)
+
+        for run in runs:
+            if run[0].block_id > run[-1].block_id:
+                run.reverse()
+        runs.sort(key=len, reverse=True)
+
+        ret: list[KVCacheBlock] = []
+        for run in runs:
+            if len(run) == 1:
+                break
+            for block in run:
+                if len(ret) == num_blocks:
+                    return ret
+                self.free_block_queue.remove(block)
+                ret.append(block)
+
+        while len(ret) < num_blocks:
+            free_block = self.free_block_queue.fake_free_list_head.next_free_block
+            assert free_block is not None
+            assert free_block is not self.free_block_queue.fake_free_list_tail
+            self.free_block_queue.remove(free_block)
+            ret.append(free_block)
         return ret
 
     def _maybe_evict_cached_block(self, block: KVCacheBlock) -> bool:


### PR DESCRIPTION
## Problem this solves

The V1 block pool currently satisfies every allocation by taking the first
`N` entries from the free queue. That queue correctly represents cache
eviction/reuse priority, but after realistic allocation, completion, and
eviction histories its physical block IDs can be fragmented.

Fragmentation is especially expensive for disaggregated prefill/decode. KV
connectors construct transfer descriptors from the physical blocks assigned to
a request. NIXL can coalesce descriptors only when the corresponding local and
remote addresses are adjacent and appear in the same order. A logically
contiguous prompt can therefore turn into thousands of small RMA descriptors
when its block tables contain scattered IDs, increasing both CPU posting time
and transfer latency.

This was visible on a long-context agentic workload using MiniMax-M3-NVFP4,
128-token KV blocks, one TP2 prefill replica, three TP2 decode replicas, and 60
concurrent sessions. A representative per-rank READ had the following shape:

| Metric | Free-queue allocation | Contiguous-run preference |
| --- | ---: | ---: |
| Native descriptors | 23,252 | 8,926-10,222 |
| Descriptors mergeable | 9.7% | 49.4-50.7% |
| Descriptor posting time | 79.6 ms | about 32 ms |
| Transfer time | 117 ms | about 53 ms |

On a favorable handoff, the same policy reduced the request to 118
descriptors--one per KV region--with 0.4-0.5 ms posting time and 588-628 GB/s
observed bandwidth.

Two full-duration A/B repetitions against the same source base and serving
configuration produced:

| Run | p90 output tok/s/user | Total tok/s/GPU | Delta |
| --- | ---: | ---: | ---: |
| Control | 123.591 | 47,289.91 | -- |
| Contiguous allocation A | 129.297 | 49,698.86 | +4.62% / +5.09% |
| Contiguous allocation B | 127.553 | 48,828.00 | +3.21% / +3.25% |

A third run that also carried an independent metadata safety fix retained the
same direction at +6.11% p90 output tok/s/user and +3.87% total tok/s/GPU. At a
lighter 48-session operating point the end-to-end effect was smaller
(+1.58% / +0.43%), and a heterogeneous TP2-prefill/TP4-decode point was within
run-to-run variation (+1.22% / +0.29%). The policy is therefore opt-in rather
than a new default.

## Design

Set `VLLM_KV_CONTIG_ALLOC=1` to enable the policy. For allocations of at least
eight blocks, `BlockPool`:

1. examines at most `4 * num_blocks` entries from the head of the free queue;
2. identifies queue-adjacent runs whose physical block IDs are consecutive;
3. normalizes descending runs into ascending block-ID order;
4. takes the longest runs first; and
5. fills any remainder from the ordinary free-queue head.

The bounded window deliberately trades perfect global packing for approximate
LRU age. Selecting from the entire pool could repeatedly bypass old cached
blocks and undermine the queue's eviction semantics. Ascending output order is
important because transfer coalescing requires matching address direction at
both endpoints.

The environment variable is registered in `vllm.envs` and excluded from
torch.compile cache factors because it changes allocator policy, not generated
code.

## Safeguards and fallback behavior

- The feature is disabled by default. The existing `popleft_n` path is
  byte-for-byte unchanged when the variable is unset.
- Allocations smaller than eight blocks retain the existing path, avoiding
  extra CPU work where descriptor reduction has little opportunity to repay it.
- The search is bounded to four times the requested allocation. It cannot scan
  the complete free pool for normal partial allocations.
- If useful runs do not provide enough blocks, the allocator fills from the
  current queue head in normal eviction order.
- The patch changes only which free physical IDs are returned. Reference
  counts, prefix-cache eviction, block hashes, metrics, and allocation size
  continue through the existing code.

## Test plan

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest -q \
  tests/v1/core/test_block_pool_contig.py

pre-commit run --files \
  tests/v1/core/test_block_pool_contig.py \
  vllm/envs.py \
  vllm/v1/core/block_pool.py
```

The unit suite covers:

- ascending and descending physical runs;
- longest-run selection and LRU remainder filling;
- free-queue link integrity after non-head removals and reuse;
- unchanged default-off behavior;
- unchanged behavior below the eight-block threshold;
- the bounded search window; and
- activation through `VLLM_KV_CONTIG_ALLOC`.

## Test result

```text
8 passed in 0.85s
```

All applicable changed-file pre-commit hooks passed, including Ruff check and
format, typos, mypy for Python 3.10, SPDX validation, root lazy-import checks,
forbidden-import checks, and environment-variable default validation.

The full-duration treatment run completed 9,591 requests over 3,629 seconds
with no recorded request errors, cancellations, or output-length mismatches. A
separate model-quality evaluation was not run because this patch changes only
physical block selection; it does not change cached values, model computation,
or sampling.

## Duplicate-work check

I searched open PRs for contiguous KV allocation, block-ID runs, NIXL
descriptor merging, and related terms. No open PR changes
`BlockPool.get_new_blocks()` to prefer physical-ID runs. The nearest related
work concerns physical KV tensor layout, cache-capacity metrics, NIXL range
loading, or connector-defined eviction ordering; those changes operate at
different layers and do not address allocation-time descriptor fragmentation.

## AI assistance

OpenAI Codex assisted with porting the implementation to current `main`, test
preparation, and drafting this description. The human author supplied the
optimization direction and measurement evidence. This PR remains a draft
pending the human author's final line-by-line review before it is marked ready.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose and workload evidence are documented.
- [x] The test commands and results are included.
- [x] Fallback behavior and the default-off scope are explicit.
- [x] No documentation update is required for an experimental environment
  variable; it is registered in the environment-variable source of truth.

</details>
