### PR TITLE
[ROCm] Preserve profiler runtime dependency during Python-only installation

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -441,7 +441,11 @@ RUN --mount=type=bind,from=debs,src=/app/debs,target=/install \
     pip install /install/*.whl
 
 COPY --from=build_rocprofiler_sdk /staging/ /opt/rocm/
-RUN ldconfig
+# Keep the copied profiler's runtime dependency installed across apt autoremove.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libdw1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && ldconfig
 
 ARG BASE_IMAGE
 ARG TRITON_BRANCH


### PR DESCRIPTION


- Install `libdw1` explicitly in the final ROCm image so APT retains the copied rocprofiler SDK's runtime dependency during `apt autoremove`.
- Place the runtime package installation beside the SDK copy, with APT list cleanup and the existing `ldconfig` refresh.
- Preserve the existing Python-only installation test, including package cleanup, same-build wheel selection, editable installation, and the source-edit import assertion.
- Validation: `pre-commit run --files docker/Dockerfile.rocm_base`, `git diff --check`, and `bash -n` on the changed Dockerfile `RUN` command passed. Read-only ELF inspection confirms Torch loads the profiler SDK, which requires `libdw.so.1`. A controlled `apt-get -s autoremove` simulation using copied package metadata removed automatic `libdw1` and retained it when marked manual; host package state was unchanged. A rebuilt-image execution of the installation test remains unverified because this environment has no available container runtime.
- Duplicate searches found no matching runtime-package preservation fix. AI assistance was used for investigation, implementation, and this description; this change does not modify model code.

[Buildkite build 12676's Python-only Installation job](https://buildkite.com/vllm/amd-ci/builds/12676/list?sid=01a07b43-0113-46e2-bc4c-494c4f754458&tab=output) removed `libdw1` during compiler cleanup, then failed with `ImportError: libdw.so.1` when setup imported Torch. The SDK is compiled in a separate stage with development dependencies and copied into the final image, so APT does not know that the copied library requires `libdw1`. Explicitly installing the runtime package makes that dependency part of the final image's package ownership and protects it during automatic cleanup. This addresses the observed import failure while keeping the existing installation assertions intact.
