### PR TITLE
[Bugfix][Core] Shut down EngineCore and its workers when the parent process dies

### DIFF
--- a/tests/v1/engine/test_startup_watch_processes.py
+++ b/tests/v1/engine/test_startup_watch_processes.py
@@ -44,6 +44,7 @@ def test_engine_core_process_shutdown_timeout(
     manager._request_shutdown_timeout = request_timeout
     manager.manager_stopped = Event()
     manager.processes = [object()]
+    manager._death_writers = []
     detach_results = iter((object(), None))
     manager._finalizer = SimpleNamespace(detach=lambda: next(detach_results))
 

--- a/tests/v1/shutdown/test_parent_death.py
+++ b/tests/v1/shutdown/test_parent_death.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test that EngineCore and its workers exit when their parent process dies
+without shutting them down (API server SIGKILLed, OOM-killed or crashed)."""
+
+import contextlib
+import multiprocessing
+import os
+import signal
+import time
+
+import psutil
+import pytest
+
+from tests.utils import wait_for_gpu_memory_to_clear
+from tests.v1.shutdown.utils import (
+    SHUTDOWN_TEST_THRESHOLD_BYTES,
+    SHUTDOWN_TEST_TIMEOUT_SEC,
+)
+from vllm.platforms import current_platform
+from vllm.v1.engine.core import PARENT_DEATH_SHUTDOWN_TIMEOUT_S
+
+MODELS = ["hmellor/tiny-random-LlamaForCausalLM"]
+
+# Cooperative shutdown budget plus a margin for the force-kill fallback.
+ORPHAN_EXIT_TIMEOUT_SEC = PARENT_DEATH_SHUTDOWN_TIMEOUT_S + 30
+
+
+def _serve_until_killed(model: str, tensor_parallel_size: int, conn) -> None:
+    """Child process: start an LLM, report its engine process tree, then idle
+    until the test kills this process."""
+    from vllm import LLM, SamplingParams
+
+    llm = LLM(
+        model=model,
+        enforce_eager=True,
+        tensor_parallel_size=tensor_parallel_size,
+    )
+    llm.generate("Hello my name is", SamplingParams(max_tokens=1))
+    conn.send([child.pid for child in psutil.Process().children(recursive=True)])
+    conn.close()
+    while True:
+        time.sleep(1)
+
+
+def _is_running(pid: int) -> bool:
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+def _wait_until_gone(pids: list[int], timeout: float) -> list[int]:
+    """Return the pids still running after ``timeout`` seconds."""
+    deadline = time.monotonic() + timeout
+    while True:
+        alive = [pid for pid in pids if _is_running(pid)]
+        if not alive or time.monotonic() >= deadline:
+            return alive
+        time.sleep(0.5)
+
+
+def _kill_all(pids: list[int]) -> None:
+    for pid in pids:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+
+
+@pytest.mark.timeout(SHUTDOWN_TEST_TIMEOUT_SEC * 2)
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("tensor_parallel_size", [2, 1])
+def test_engine_exits_after_parent_sigkill(model: str, tensor_parallel_size: int):
+    """SIGKILL the process that owns a running LLM; EngineCore and every
+    worker must exit on their own and release GPU memory."""
+    if current_platform.device_count() < tensor_parallel_size:
+        pytest.skip(reason="Not enough CUDA devices")
+
+    ctx = multiprocessing.get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe(duplex=False)
+    proc = ctx.Process(
+        target=_serve_until_killed, args=(model, tensor_parallel_size, child_conn)
+    )
+    proc.start()
+    child_conn.close()
+    assert proc.pid is not None
+    parent_pid = proc.pid
+    engine_pids: list[int] = []
+    try:
+        assert parent_conn.poll(SHUTDOWN_TEST_TIMEOUT_SEC), "LLM did not start"
+        engine_pids = parent_conn.recv()
+        # EngineCore, plus one worker per rank when TP > 1.
+        expected = 1 + (tensor_parallel_size if tensor_parallel_size > 1 else 0)
+        assert len(engine_pids) >= expected, engine_pids
+        assert all(_is_running(pid) for pid in engine_pids)
+
+        os.kill(parent_pid, signal.SIGKILL)
+        proc.join(10)
+        assert proc.exitcode == -signal.SIGKILL
+
+        orphans = _wait_until_gone(engine_pids, ORPHAN_EXIT_TIMEOUT_SEC)
+        assert not orphans, f"engine processes outlived their parent: {orphans}"
+    finally:
+        if proc.is_alive():
+            proc.kill()
+        _kill_all(engine_pids)
+
+    wait_for_gpu_memory_to_clear(
+        devices=list(range(tensor_parallel_size)),
+        threshold_bytes=SHUTDOWN_TEST_THRESHOLD_BYTES,
+    )

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -8,7 +8,9 @@ import multiprocessing
 import os
 import signal
 import sys
+import threading
 from collections.abc import Callable, Iterator
+from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import TextIO
 
@@ -276,6 +278,35 @@ def kill_process_tree(pid: int):
     # Finally kill the parent
     with contextlib.suppress(ProcessLookupError):
         os.kill(pid, signal.SIGKILL)
+
+
+def monitor_parent_death(
+    death_pipe: Connection | None,
+    on_parent_death: Callable[[], None],
+    *,
+    name: str = "DeathPipeMonitor",
+) -> threading.Thread | None:
+    """Run ``on_parent_death`` on a daemon thread once ``death_pipe`` hits EOF.
+
+    The parent keeps the write end open and never writes to it; the kernel
+    closes it when the parent exits by any means, including SIGKILL. Forked
+    siblings must close their inherited copy of the write end.
+    """
+    if death_pipe is None:
+        return None
+
+    def death_pipe_monitor():
+        try:
+            # This will block until parent process exits (pipe closes)
+            death_pipe.recv()
+        except EOFError:
+            on_parent_death()
+        except Exception as e:
+            logger.warning("Death monitoring error: %s", e)
+
+    thread = threading.Thread(target=death_pipe_monitor, daemon=True, name=name)
+    thread.start()
+    return thread
 
 
 # Resource utilities

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -43,7 +43,12 @@ from vllm.utils.gc_utils import (
 )
 from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.utils.network_utils import make_zmq_socket
-from vllm.utils.system_utils import decorate_logs, set_process_title
+from vllm.utils.system_utils import (
+    decorate_logs,
+    kill_process_tree,
+    monitor_parent_death,
+    set_process_title,
+)
 from vllm.v1.attention.backends.utils import resolve_kv_cache_layout
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -1029,6 +1034,10 @@ class EngineCore:
         raise NotImplementedError
 
 
+# Grace for cooperative shutdown after the parent exits, before force-kill.
+PARENT_DEATH_SHUTDOWN_TIMEOUT_S = 15.0
+
+
 class EngineShutdownState(IntEnum):
     RUNNING = 0
     REQUESTED = 1
@@ -1064,6 +1073,8 @@ class EngineCoreProc(EngineCore):
         identity = self.engine_index.to_bytes(length=2, byteorder="little")
         self.engines_running = False
         self.shutdown_state = EngineShutdownState.RUNNING
+        # Parent gone: abort in-flight requests on shutdown instead of draining.
+        self.parent_exited = False
 
         # Receiver for tensor IPC
         self.tensor_ipc_receiver: TensorIpcReceiver | None = None
@@ -1305,9 +1316,36 @@ class EngineCoreProc(EngineCore):
         # Ensure we can serialize transformer config after spawning
         maybe_register_config_serialize_by_value()
 
+        death_pipe = kwargs.pop("death_pipe", None)
+        # Close write ends of death pipes inherited under fork.
+        for fd in kwargs.pop("inherited_fds", []):
+            try:
+                os.close(fd)
+            except OSError as e:
+                logger.warning("Error closing inherited fd %d: %s", fd, e)
+
         engine_core: EngineCoreProc | None = None
         signal_callback: SignalCallback | None = None
         clean_shutdown = False
+
+        def on_parent_death():
+            # Abort and tear down; force-kill the tree if that does not finish.
+            logger.warning(
+                "[shutdown] EngineCore: parent process exited, shutting down"
+            )
+            if engine_core is not None:
+                engine_core.parent_exited = True
+                engine_core.shutdown_state = EngineShutdownState.REQUESTED
+                engine_core.input_queue.put_nowait((EngineCoreRequestType.WAKEUP, None))
+                time.sleep(PARENT_DEATH_SHUTDOWN_TIMEOUT_S)
+                logger.warning(
+                    "[shutdown] EngineCore: still alive %ss after parent death, "
+                    "force-killing process tree",
+                    PARENT_DEATH_SHUTDOWN_TIMEOUT_S,
+                )
+            kill_process_tree(os.getpid())
+
+        monitor_parent_death(death_pipe, on_parent_death, name="EngineCoreDeathMonitor")
         try:
             vllm_config: VllmConfig = kwargs["vllm_config"]
             parallel_config: ParallelConfig = vllm_config.parallel_config
@@ -1394,6 +1432,8 @@ class EngineCoreProc(EngineCore):
                 signal_callback.stop()
             if engine_core is not None:
                 engine_core.shutdown()
+            if death_pipe is not None:
+                death_pipe.close()
             if clean_shutdown:
                 from vllm.platforms import current_platform
 
@@ -1507,6 +1547,8 @@ class EngineCoreProc(EngineCore):
 
         if self.shutdown_state == EngineShutdownState.REQUESTED:
             shutdown_timeout = self.vllm_config.shutdown_timeout
+            if self.parent_exited:
+                shutdown_timeout = 0
             mode = "abort" if shutdown_timeout == 0 else "drain"
 
             logger.info(

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -178,9 +178,23 @@ class CoreEngineProcManager:
 
         from vllm.v1.engine.core import EngineCoreProc
 
+        # One death pipe per engine; the engine sees EOF once this process
+        # exits by any means (see monitor_parent_death).
+        self._death_writers: list[connection.Connection] = []
+        death_readers: list[connection.Connection] = []
+        for _ in range(local_engine_count):
+            death_reader, death_writer = context.Pipe(duplex=False)
+            death_readers.append(death_reader)
+            self._death_writers.append(death_writer)
+        if context.get_start_method() == "fork":
+            # Forked engines inherit every write end; tell them which to close.
+            common_kwargs["inherited_fds"] = [
+                writer.fileno() for writer in self._death_writers
+            ]
+
         self.processes: list[BaseProcess] = []
         local_dp_ranks = []
-        for index in range(local_engine_count):
+        for index, death_reader in enumerate(death_readers):
             local_index = local_start_index + index
             global_index = start_index + index
 
@@ -191,7 +205,11 @@ class CoreEngineProcManager:
                     target=EngineCoreProc.run_engine_core,
                     name=f"EngineCore_DP{global_index}" if is_dp else "EngineCore",
                     kwargs=common_kwargs
-                    | {"dp_rank": global_index, "local_dp_rank": local_index},
+                    | {
+                        "dp_rank": global_index,
+                        "local_dp_rank": local_index,
+                        "death_pipe": death_reader,
+                    },
                 )
             )
 
@@ -205,7 +223,9 @@ class CoreEngineProcManager:
         # pickles process args at start() time, sequentially per rank.
         user_assigned_gpu_ids = vllm_config.parallel_config.assigned_physical_gpu_ids
         try:
-            for proc, local_dp_rank in zip(self.processes, local_dp_ranks):
+            for proc, local_dp_rank, death_reader in zip(
+                self.processes, local_dp_ranks, death_readers
+            ):
                 # Populate the logical-to-physical GPU mapping in DP for
                 # platforms that cannot rely on
                 # torch.accelerator.set_device_index(), and for Ray.
@@ -233,6 +253,7 @@ class CoreEngineProcManager:
                     process_kind="EngineCore",
                 ):
                     proc.start()
+                death_reader.close()
         finally:
             # Kill other procs if not all are running.
             if self.finished_procs():
@@ -252,6 +273,8 @@ class CoreEngineProcManager:
                     process_timeout,
                 )
             shutdown(self.processes, timeout=process_timeout)
+            for writer in self._death_writers:
+                writer.close()
 
     def monitor_engine_liveness(self) -> None:
         """Monitor engine core process liveness."""

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -59,6 +59,7 @@ from vllm.utils.system_utils import (
     _maybe_force_spawn,
     decorate_logs,
     get_mp_context,
+    monitor_parent_death,
     set_process_title,
 )
 from vllm.utils.torch_utils import (
@@ -825,29 +826,17 @@ class WorkerProc:
         destroy_distributed_environment()
 
     def monitor_death_pipe(self, death_pipe, shutdown_requested: threading.Event):
-        if death_pipe is None:
-            return
+        # Capture queue references directly to avoid gc issues if capturing self
+        queues_to_shutdown = [self.rpc_broadcast_mq, self.worker_response_mq]
 
-        def death_pipe_monitor(queues_to_shutdown: list[MessageQueue]):
-            try:
-                # This will block until parent process exits (pipe closes)
-                death_pipe.recv()
-            except EOFError:
-                logger.info_once("Parent process exited, terminating worker queues")
-                shutdown_requested.set()
-                for mq in queues_to_shutdown:
-                    if mq is not None:
-                        mq.shutdown()
-            except Exception as e:
-                logger.warning("Death monitoring error: %s", e)
+        def on_parent_death():
+            logger.info_once("Parent process exited, terminating worker queues")
+            shutdown_requested.set()
+            for mq in queues_to_shutdown:
+                if mq is not None:
+                    mq.shutdown()
 
-        # Pass queue references directly to avoid gc issues if passing self
-        Thread(
-            target=death_pipe_monitor,
-            args=([self.rpc_broadcast_mq, self.worker_response_mq],),
-            daemon=True,
-            name="DeathPipeMonitor",
-        ).start()
+        monitor_parent_death(death_pipe, on_parent_death)
 
     @staticmethod
     def worker_main(*args, **kwargs):


### PR DESCRIPTION
## Purpose

Fixes #55510. Same class of issue as #34643, #25850, #19849, and #43060.

When the process that launched the engine dies without running its shutdown path, for example due to SIGKILL, OOM, or a crash, `VLLM::EngineCore` and its `VLLM::Worker_TP*` processes can remain alive and continue holding GPU memory. Since the serving port is released immediately, restarting vLLM can then fail the KV-cache check or OOM while the orphaned engine is still using the GPUs.

`WorkerProc` already detects its parent death through a death pipe, but its parent is `EngineCore`. `EngineCore` itself has no equivalent parent-liveness detection, so when the frontend disappears, the engine and therefore its workers remain alive.

This PR extends the existing death-pipe mechanism to `EngineCore`:

- Extracts the worker death-pipe monitor into a shared `system_utils.monitor_parent_death()` helper. `WorkerProc` now uses the shared helper with no behavior change.
- Adds one death pipe per engine in `CoreEngineProcManager`. EOF notifies the engine when its parent exits, including SIGKILL. Under `fork`, inherited write FDs are explicitly closed so they do not keep another engine's pipe alive.
- Starts parent monitoring before engine initialization so death during model loading is also covered.
- On parent death, requests abort shutdown and wakes the engine loop so normal teardown terminates the workers.
- If shutdown does not complete within `PARENT_DEATH_SHUTDOWN_TIMEOUT_S` (15s), including when initialization is hung, the engine falls back to `kill_process_tree` to ensure GPU resources are released.
- Normal SIGTERM/SIGINT shutdown is unchanged, including `--shutdown-timeout` drain behavior.

A death pipe is used instead of relying on `prctl(PR_SET_PDEATHSIG)` because it is cross-platform and tracks the parent process rather than the thread that created the child, which is important for embedders that construct `LLM()` from a helper thread.

This also follows earlier feedback from #34816 and #27686. Prior attempts include #27686, #36055, #34816, and #40935. Thanks to @dmmdea for the report.

### Scope

Covered by this PR:

- `vllm serve`, including `--api-server-count > 1`
- `--headless`
- DP supervisor engine children
- Offline `LLM()` / `AsyncLLM`
- Parent death during engine startup/model loading

Not covered:

- Ray-backed engines, whose lifetime is managed by Ray.
- CPU-only coordinator/API-server subprocesses created by the multi-API-server DP launcher. They can still outlive a launcher SIGKILL, but do not hold GPU memory and are separate from the GPU leak addressed here (#43417 / #52299).

## Test Plan

    # 2 GPUs
    pytest tests/v1/shutdown/test_parent_death.py -v

    # CPU
    pytest tests/utils_/test_system_utils.py
    pytest tests/v1/engine/test_engine_core_death_pipe.py
    pytest tests/v1/engine/test_startup_watch_processes.py

Hardware repro: start `vllm serve`, `kill -KILL <pid>`, then monitor the process tree and GPU memory with `ps` / `nvidia-smi`.

## Test Result

Tested on 4× RTX A6000, driver 580.105.08 / CUDA 13.0, torch 2.13.0+cu130, vLLM `0.28.1rc1.dev518+g782f36cd0`.

| Scenario | Before | This PR |
|---|---|---|
| TP=2, SIGKILL API server | EngineCore + workers remain alive and hold GPU memory | All exit and GPU memory is released |
| DP=2, SIGKILL launcher | EngineCores + workers remain alive and hold GPU memory | GPU-holding EngineCores + workers exit and release GPU memory |
| SIGTERM | Clean shutdown | Clean shutdown |
| SIGTERM + `--shutdown-timeout 60`, request in flight | Request drains | Drain behavior preserved |
| SIGKILL during model load | Processes remain alive and hold GPU memory | All exit and GPU memory is released |

For DP=2, the CPU-only coordinator and API-server subprocesses can still outlive the launcher. The GPU-holding EngineCore and worker processes are cleaned up by this PR. The reported TP=2 case is fully cleaned up.

Tests on this PR:

    tests/v1/shutdown/test_parent_death.py ..... 4 passed in 94.73s

    tests/utils_/test_system_utils.py
    tests/v1/engine/test_engine_core_death_pipe.py
    tests/v1/engine/test_startup_watch_processes.py
    23 passed in 2.69s

`ruff` format/check passes. `tools/pre_commit/mypy.py 3.12` reports the same 2 pre-existing errors before and after this change.

---

AI-assisted: the patch and tests were produced with Claude Code. I reviewed every changed line and ran the tests and hardware experiments above before submitting.