### PR TITLE
[Rust Frontend] Add pythonic tool parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -405,7 +405,7 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, hy_v4, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml, seed_oss)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, hy_v4, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, llama4_pythonic, minimax_m2, minimax_m3, mistral, phi4_mini_json, pythonic, qwen3_coder, qwen3_xml, seed_oss)"].assert_eq(&error.to_report_string());
     }
 
     #[test]

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -8,9 +8,10 @@ use std::sync::{Arc, LazyLock};
 pub use vllm_parser::tool::{
     DeepSeekV3ToolParser, DeepSeekV4ToolParser, DeepSeekV31ToolParser, DeepSeekV32ToolParser,
     Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser,
-    Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, MinimaxM2ToolParser,
-    MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser,
-    Qwen3XmlToolParser, SeedOssToolParser, ToolParser, ToolParserError,
+    Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, Llama4PythonicToolParser,
+    MinimaxM2ToolParser, MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser,
+    PythonicToolParser, Qwen3CoderToolParser, Qwen3XmlToolParser, SeedOssToolParser, ToolParser,
+    ToolParserError,
 };
 
 use crate::parser::ParserFactory;
@@ -37,10 +38,12 @@ pub mod names {
     pub const KIMI_K3: &str = "kimi_k3";
     pub const LLAMA3_JSON: &str = "llama3_json";
     pub const LLAMA4_JSON: &str = "llama4_json";
+    pub const LLAMA4_PYTHONIC: &str = "llama4_pythonic";
     pub const MINIMAX_M2: &str = "minimax_m2";
     pub const MINIMAX_M3: &str = "minimax_m3";
     pub const MISTRAL: &str = "mistral";
     pub const PHI4_MINI_JSON: &str = "phi4_mini_json";
+    pub const PYTHONIC: &str = "pythonic";
     pub const QWEN3_CODER: &str = "qwen3_coder";
     pub const QWEN3_XML: &str = "qwen3_xml";
     pub const SEED_OSS: &str = "seed_oss";
@@ -84,10 +87,12 @@ impl ToolParserFactory {
             .register_unified_dummy(names::KIMI_K3)
             .register_parser::<Llama3JsonToolParser>(names::LLAMA3_JSON)
             .register_parser::<Llama3JsonToolParser>(names::LLAMA4_JSON)
+            .register_parser::<Llama4PythonicToolParser>(names::LLAMA4_PYTHONIC)
             .register_parser::<MinimaxM2ToolParser>(names::MINIMAX_M2)
             .register_parser::<MinimaxM3ToolParser>(names::MINIMAX_M3)
             .register_parser::<MistralToolParser>(names::MISTRAL)
             .register_parser::<Phi4MiniJsonToolParser>(names::PHI4_MINI_JSON)
+            .register_parser::<PythonicToolParser>(names::PYTHONIC)
             .register_parser::<Qwen3XmlToolParser>(names::QWEN3_XML)
             .register_parser::<Qwen3CoderToolParser>(names::QWEN3_CODER)
             .register_parser::<SeedOssToolParser>(names::SEED_OSS);

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -248,3 +248,36 @@ fn factory_new_registers_phi4_mini_json_by_name() {
     assert!(factory.contains(names::PHI4_MINI_JSON));
     factory.create(names::PHI4_MINI_JSON, &[]).unwrap();
 }
+
+#[test]
+fn factory_new_registers_pythonic_parsers_by_name() {
+    // Pythonic parsers are selected explicitly with `--tool-call-parser
+    // pythonic` / `llama4_pythonic`, matching Python; model-name routing for
+    // `llama-4` stays on the JSON parser.
+    let factory = ToolParserFactory::new();
+
+    for name in [names::PYTHONIC, names::LLAMA4_PYTHONIC] {
+        assert!(factory.contains(name));
+        factory.create(name, &[]).unwrap();
+    }
+    assert_eq!(
+        factory.resolve_name_for_model("meta-llama/Llama-4-Scout-17B-16E-Instruct"),
+        Some(names::LLAMA4_JSON)
+    );
+}
+
+#[test]
+fn factory_parses_pythonic_tool_call_list() {
+    let factory = ToolParserFactory::new();
+
+    let mut parser = factory.create(names::PYTHONIC, &[]).unwrap();
+    let mut output = ToolParserOutput::default();
+    parser.parse_into("[get_weather(city='Tokyo', days=3)]", &mut output).unwrap();
+    output.append(parser.finish().unwrap());
+    let output = output.coalesce();
+
+    assert!(output.normal_text().is_empty());
+    assert_eq!(output.calls().len(), 1);
+    assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+    assert_eq!(output.calls()[0].arguments, r#"{"city":"Tokyo","days":3}"#);
+}

--- a/rust/src/parser/Cargo.toml
+++ b/rust/src/parser/Cargo.toml
@@ -80,5 +80,10 @@ name = "granite4"
 harness = false
 required-features = ["test-util"]
 
+[[bench]]
+name = "pythonic"
+harness = false
+required-features = ["test-util"]
+
 [lints]
 workspace = true

--- a/rust/src/parser/benches/pythonic.rs
+++ b/rust/src/parser/benches/pythonic.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::time::Duration;
+
+use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use tool_parser::parsers::PythonicParser as ExternalPythonicParser;
+use vllm_parser::tool::test_utils::{split_by_chars, test_tools};
+use vllm_parser::tool::{PythonicToolParser, Tool, ToolParser};
+
+mod utils;
+use utils::{feed_external_parser, feed_parser, openai_tools};
+
+const CHUNK_CHARS: usize = 7;
+const LONG_ARGUMENT_BYTES: usize = 64 * 1024;
+const LONG_NORMAL_TEXT_REPEATS: usize = 2048;
+
+fn mixed_fixture() -> String {
+    "[get_weather(city='Hangzhou', days=3), \
+     convert(whole=42.5, flag=True, payload={'nested': ['x', None]}, items=[1, 2, 3], empty='')]"
+        .to_string()
+}
+
+fn long_string_argument_fixture() -> String {
+    format!("[convert(empty='{}')]", "x".repeat(LONG_ARGUMENT_BYTES))
+}
+
+fn long_normal_text_fixture() -> String {
+    let line = "This is ordinary assistant text with no pythonic tool call at the root.\n";
+    line.repeat(LONG_NORMAL_TEXT_REPEATS)
+}
+
+fn native_parser(tools: &[Tool]) -> Box<dyn ToolParser> {
+    PythonicToolParser::create(tools).expect("pythonic parser should initialize")
+}
+
+fn run_stream_group(
+    c: &mut Criterion,
+    name: &str,
+    tools: &[Tool],
+    text: &str,
+    expected_normal_text: &str,
+    expected_native_calls_len: usize,
+) {
+    let chunks = split_by_chars(text, CHUNK_CHARS);
+    let openai_tools = openai_tools(tools);
+
+    let mut group = c.benchmark_group(name);
+    group.sample_size(50);
+    group.warm_up_time(Duration::from_millis(300));
+    group.measurement_time(Duration::from_secs(2));
+    group.throughput(Throughput::Bytes(text.len() as u64));
+
+    group.bench_function("native_reuse_parser", |b| {
+        let mut parser = native_parser(tools);
+        b.iter(|| {
+            let result = feed_parser(&mut *parser, black_box(&chunks));
+            debug_assert_eq!(result.0, expected_normal_text);
+            debug_assert_eq!(result.1, expected_native_calls_len);
+            black_box(result);
+        })
+    });
+
+    group.bench_function("native_create_parser", |b| {
+        b.iter_batched(
+            || native_parser(tools),
+            |mut parser| {
+                let result = feed_parser(&mut *parser, black_box(&chunks));
+                debug_assert_eq!(result.0, expected_normal_text);
+                debug_assert_eq!(result.1, expected_native_calls_len);
+                black_box(result);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("external_reuse_parser", |b| {
+        let mut parser = ExternalPythonicParser::new();
+        b.iter(|| {
+            let result = feed_external_parser(&mut parser, &openai_tools, black_box(&chunks));
+            black_box(result);
+        })
+    });
+
+    group.bench_function("external_create_parser", |b| {
+        b.iter_batched(
+            ExternalPythonicParser::new,
+            |mut parser| {
+                let result = feed_external_parser(&mut parser, &openai_tools, black_box(&chunks));
+                black_box(result);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+fn bench_pythonic(c: &mut Criterion) {
+    let tools = test_tools();
+    let mixed_text = mixed_fixture();
+    let long_string_argument = long_string_argument_fixture();
+    let long_normal_text = long_normal_text_fixture();
+
+    run_stream_group(c, "pythonic/tool_call_list", &tools, &mixed_text, "", 2);
+    run_stream_group(
+        c,
+        "pythonic/long_string_argument",
+        &tools,
+        &long_string_argument,
+        "",
+        1,
+    );
+    run_stream_group(
+        c,
+        "pythonic/long_normal_text",
+        &tools,
+        &long_normal_text,
+        &long_normal_text,
+        0,
+    );
+}
+
+criterion_group!(benches, bench_pythonic);
+criterion_main!(benches);

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -14,6 +14,7 @@ mod kimi_k2;
 mod minimax_m2;
 mod minimax_m3;
 mod parameters;
+mod pythonic;
 mod qwen_coder;
 mod seed_oss;
 #[cfg(any(test, feature = "test-util"))]
@@ -32,6 +33,7 @@ pub use json::{
 pub use kimi_k2::KimiK2ToolParser;
 pub use minimax_m2::MinimaxM2ToolParser;
 pub use minimax_m3::MinimaxM3ToolParser;
+pub use pythonic::{Llama4PythonicToolParser, PythonicToolParser};
 pub use qwen_coder::Qwen3CoderToolParser;
 pub use seed_oss::SeedOssToolParser;
 use serde::{Deserialize, Serialize};

--- a/rust/src/parser/src/tool/pythonic/llama4.rs
+++ b/rust/src/parser/src/tool/pythonic/llama4.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use super::{LLAMA4_PYTHONIC_CONFIG, PythonicToolParser};
+use crate::tool::{Result, Tool, ToolParser, ToolParserOutput};
+
+/// Tool parser for Llama 4 pythonic tool calls.
+///
+/// Example tool call content:
+///
+/// ```text
+/// <|python_start|>[get_weather(city='LA', metric='C')]<|python_end|>
+/// ```
+///
+/// Llama 4 emits the same Python list of keyword-argument calls as
+/// [`PythonicToolParser`], sometimes wrapped in `<|python_start|>` /
+/// `<|python_end|>`. Only those two markers differ, so this delegates to a
+/// [`PythonicToolParser`] configured to drop them, mirroring how the Python
+/// `Llama4PythonicToolParser` strips them before parsing.
+///
+/// The markers are tokenizer special tokens, so they are already gone under the
+/// production default `skip_special_tokens = true` and the list starts at `[`;
+/// the trait default `preserve_special_tokens() == false` is therefore correct
+/// and stripping them is only needed when they do survive decoding.
+pub struct Llama4PythonicToolParser {
+    inner: PythonicToolParser,
+}
+
+impl Llama4PythonicToolParser {
+    /// Create a Llama 4 pythonic tool parser.
+    fn new(_tools: &[Tool]) -> Self {
+        Self {
+            inner: PythonicToolParser::with_config(LLAMA4_PYTHONIC_CONFIG),
+        }
+    }
+}
+
+impl ToolParser for Llama4PythonicToolParser {
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        self.inner.parse_into(chunk, output)
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        self.inner.finish()
+    }
+
+    fn reset(&mut self) -> String {
+        self.inner.reset()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+
+    use super::Llama4PythonicToolParser;
+    use crate::tool::pythonic::{LLAMA4_PYTHONIC_CONFIG, parse_chunkings};
+    use crate::tool::test_utils::test_tools;
+    use crate::tool::{ToolParser, ToolParserTestExt as _};
+
+    const SIMPLE_CALL: &str = "[get_weather(city='LA', metric='C')]";
+
+    fn parse(text: &str) -> crate::tool::ToolParserOutput {
+        parse_chunkings(LLAMA4_PYTHONIC_CONFIG, text)
+    }
+
+    #[test]
+    fn llama4_pythonic_strips_python_markers() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"LA\",\"metric\":\"C\"}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse(&format!(
+            "<|python_start|>{SIMPLE_CALL}<|python_end|>"
+        )));
+    }
+
+    #[test]
+    fn llama4_pythonic_parses_bare_call_list() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"LA\",\"metric\":\"C\"}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse(SIMPLE_CALL));
+    }
+
+    #[test]
+    fn llama4_pythonic_keeps_plain_text() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    Text(
+                        "How can I help you today?",
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse("How can I help you today?"));
+    }
+
+    #[test]
+    fn llama4_pythonic_creates_through_tool_parser_trait() {
+        let mut parser = Llama4PythonicToolParser::create(&test_tools()).unwrap();
+        let output = parser
+            .parse_complete("<|python_start|>[register_user(name='Doe', age=9)]<|python_end|>")
+            .unwrap();
+
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "register_user",
+                            ),
+                            arguments: "{\"name\":\"Doe\",\"age\":9}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&output);
+    }
+}

--- a/rust/src/parser/src/tool/pythonic/mod.rs
+++ b/rust/src/parser/src/tool/pythonic/mod.rs
@@ -1,0 +1,921 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Shared parser core for pythonic tool calls.
+
+mod llama4;
+mod value;
+
+pub use llama4::Llama4PythonicToolParser;
+use value::{
+    StringRun, decode_string_run, json_object_key, json_string_content, python_value, string_quote,
+};
+use winnow::ascii::multispace0 as ws0;
+use winnow::combinator::{alt, opt, preceded, seq};
+use winnow::error::{ContextError, ErrMode, ModalResult, StrContext};
+use winnow::prelude::*;
+use winnow::stream::Partial;
+use winnow::token::{literal, one_of, take_while};
+
+use super::utils::{incomplete, parse_buffered_event};
+use super::{Result, Tool, ToolCallDelta, ToolParser, ToolParserOutput};
+
+type PythonicInput<'i> = Partial<&'i str>;
+
+/// Model-specific configuration for the shared pythonic grammar.
+///
+/// Only the optional markers wrapping the tool-call list vary across models
+/// that reuse this grammar; the list itself is byte-identical.
+#[derive(Debug, Clone, Copy)]
+struct PythonicConfig {
+    /// Human-readable parser name used in error messages.
+    parser_name: &'static str,
+    /// Marker that may precede the tool-call list.
+    start_marker: Option<&'static str>,
+    /// Marker that may follow the tool-call list.
+    end_marker: Option<&'static str>,
+}
+
+const PYTHONIC_CONFIG: PythonicConfig = PythonicConfig {
+    parser_name: "pythonic",
+    start_marker: None,
+    end_marker: None,
+};
+
+const LLAMA4_PYTHONIC_CONFIG: PythonicConfig = PythonicConfig {
+    parser_name: "Llama 4 pythonic",
+    start_marker: Some("<|python_start|>"),
+    end_marker: Some("<|python_end|>"),
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PythonicMode {
+    Start,
+    Passthrough,
+    ListStart,
+    ListNext,
+    Arguments { first: bool },
+    StringValue { quote: char },
+    Done,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PythonicEvent {
+    CallStart {
+        name: String,
+    },
+    Argument {
+        key: String,
+        value: serde_json::Value,
+    },
+    StringArgumentStart {
+        key: String,
+        quote: char,
+    },
+    StringChunk {
+        text: String,
+    },
+    StringEnd {
+        text: String,
+    },
+    CallEnd,
+    ListEnd,
+}
+
+/// Tool parser for pythonic tool calls.
+///
+/// The whole assistant output is a Python list of keyword-argument calls, as
+/// produced by Llama 3.2, Llama 4 and ToolACE:
+///
+/// ```text
+/// [get_weather(city='San Francisco', metric='celsius'), get_weather(city='New York', metric='celsius')]
+/// ```
+///
+/// Argument values are Python literals (strings, numbers, `True` / `False` /
+/// `None`, lists and dicts) and are converted to JSON while streaming: the
+/// function name is emitted as soon as `name(` is parsed, then `{`, then one
+/// `"key":<json>` fragment per completed argument, then `}` at `)`. String
+/// values are streamed as they arrive, so a long string argument (file
+/// contents, code) does not stall the stream. JSON-style `true` / `false` /
+/// `null` are accepted as well, mirroring `_JSON_NAME_LITERALS` in the Python
+/// parser.
+///
+/// Natural text at the beginning of the stream permanently disables tool
+/// parsing for that assistant output, like `Llama3JsonToolParser` does: the
+/// model must not mix text and tool calls in one generation. Whitespace before
+/// the opening `[` is tolerated, which the Python `TOOL_CALL_REGEX` match does
+/// not do.
+///
+/// Text that opens with `[` but is not a list of calls (`[1, 2, 3]`, `[]`,
+/// `[not a call`) is a parse error rather than plain text, matching the JSON
+/// parsers of this frontend. The streaming layer recovers such errors by
+/// re-emitting the buffered text as content, which is what the Python parser
+/// does for a whole output that does not match its tool-call pattern.
+///
+/// Structured-output tags are intentionally unsupported: the trait default
+/// `structural_tag_builder() -> None` is kept because xgrammar has no
+/// structural tag for the pythonic format, and the Python parser leaves
+/// `structural_tag_model = None` as well.
+pub struct PythonicToolParser {
+    buffer: String,
+    mode: PythonicMode,
+    active_tool_index: Option<usize>,
+    emitted_tool_count: usize,
+    config: PythonicConfig,
+}
+
+impl PythonicToolParser {
+    /// Create a pythonic tool parser.
+    fn new(_tools: &[Tool]) -> Self {
+        Self::with_config(PYTHONIC_CONFIG)
+    }
+
+    /// Create a parser for a model that wraps the same list in markers.
+    fn with_config(config: PythonicConfig) -> Self {
+        Self {
+            buffer: String::new(),
+            mode: PythonicMode::Start,
+            active_tool_index: None,
+            emitted_tool_count: 0,
+            config,
+        }
+    }
+
+    /// Commit the stream to pythonic parsing or permanent passthrough.
+    fn commit_start(&mut self) -> bool {
+        if !matches!(self.mode, PythonicMode::Start) {
+            return true;
+        }
+
+        let Some(rest) = self.strip_start_marker(self.buffer.trim_start()) else {
+            return false;
+        };
+        let Some(first) = rest.trim_start().chars().next() else {
+            return false;
+        };
+
+        self.mode = if first == '[' {
+            PythonicMode::ListStart
+        } else {
+            PythonicMode::Passthrough
+        };
+        true
+    }
+
+    /// Strip the configured start marker from buffered text.
+    ///
+    /// Returns `None` while the buffered text may still grow into the marker.
+    fn strip_start_marker<'a>(&self, text: &'a str) -> Option<&'a str> {
+        let Some(marker) = self.config.start_marker else {
+            return Some(text);
+        };
+        match text.strip_prefix(marker) {
+            Some(rest) => Some(rest),
+            None if marker.starts_with(text) => None,
+            None => Some(text),
+        }
+    }
+
+    /// Strip the configured end marker from text after the tool-call list.
+    fn strip_end_marker<'a>(&self, text: &'a str) -> &'a str {
+        let Some(marker) = self.config.end_marker else {
+            return text;
+        };
+        text.strip_suffix(marker).unwrap_or(text).trim_end()
+    }
+
+    /// Apply one parsed pythonic event to parser state and output.
+    fn apply_event(&mut self, event: PythonicEvent, output: &mut ToolParserOutput) -> Result<()> {
+        match event {
+            PythonicEvent::CallStart { name } => {
+                let tool_index = self.emitted_tool_count;
+                self.emitted_tool_count += 1;
+                self.active_tool_index = Some(tool_index);
+                self.mode = PythonicMode::Arguments { first: true };
+                output.push_call(ToolCallDelta {
+                    tool_index,
+                    name: Some(name),
+                    arguments: String::new(),
+                });
+                self.push_arguments("{", output)?;
+            }
+            PythonicEvent::Argument { key, value } => {
+                let key = json_object_key(&key)?;
+                let value = serde_json::to_string(&value)
+                    .map_err(|error| parsing_failed!("failed to serialize argument: {}", error))?;
+                let fragment = format!("{}{key}:{value}", self.argument_separator());
+                self.push_arguments(&fragment, output)?;
+                self.mode = PythonicMode::Arguments { first: false };
+            }
+            PythonicEvent::StringArgumentStart { key, quote } => {
+                let key = json_object_key(&key)?;
+                let fragment = format!("{}{key}:\"", self.argument_separator());
+                self.push_arguments(&fragment, output)?;
+                self.mode = PythonicMode::StringValue { quote };
+            }
+            PythonicEvent::StringChunk { text } => {
+                self.push_arguments(&json_string_content(&text)?, output)?;
+            }
+            PythonicEvent::StringEnd { text } => {
+                let fragment = format!("{}\"", json_string_content(&text)?);
+                self.push_arguments(&fragment, output)?;
+                self.mode = PythonicMode::Arguments { first: false };
+            }
+            PythonicEvent::CallEnd => {
+                self.push_arguments("}", output)?;
+                self.active_tool_index = None;
+                self.mode = PythonicMode::ListNext;
+            }
+            PythonicEvent::ListEnd => {
+                self.mode = PythonicMode::Done;
+            }
+        }
+        Ok(())
+    }
+
+    /// Return the JSON separator that precedes the next argument.
+    fn argument_separator(&self) -> &'static str {
+        match self.mode {
+            PythonicMode::Arguments { first: false } => ",",
+            _ => "",
+        }
+    }
+
+    /// Append one argument-JSON fragment for the active tool call.
+    fn push_arguments(&self, arguments: &str, output: &mut ToolParserOutput) -> Result<()> {
+        let Some(tool_index) = self.active_tool_index else {
+            return Err(parsing_failed!(
+                "pythonic arguments without an active tool call"
+            ));
+        };
+        if arguments.is_empty() {
+            return Ok(());
+        }
+        output.push_call(ToolCallDelta {
+            tool_index,
+            name: None,
+            arguments: arguments.to_string(),
+        });
+        Ok(())
+    }
+
+    fn reset(&mut self) -> String {
+        self.mode = PythonicMode::Start;
+        self.active_tool_index = None;
+        self.emitted_tool_count = 0;
+        std::mem::take(&mut self.buffer)
+    }
+}
+
+impl ToolParser for PythonicToolParser {
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        self.buffer.push_str(chunk);
+
+        if !self.commit_start() {
+            return Ok(());
+        }
+
+        if matches!(self.mode, PythonicMode::Passthrough) {
+            output.push_text(&self.buffer);
+            self.buffer.clear();
+            return Ok(());
+        }
+
+        let config = self.config;
+        while let Some((event, consumed_len)) = parse_buffered_event(&self.buffer, |input| {
+            parse_next_pythonic_event(input, &self.mode, config)
+        })? {
+            self.apply_event(event, output)?;
+            self.buffer.drain(..consumed_len);
+        }
+
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        let mut output = ToolParserOutput::default();
+        match self.mode {
+            PythonicMode::Start | PythonicMode::Passthrough => output.push_text(&self.buffer),
+            PythonicMode::Done => {
+                if !self.strip_end_marker(self.buffer.trim()).is_empty() {
+                    return Err(parsing_failed!(
+                        "trailing text after {} tool calls",
+                        self.config.parser_name
+                    ));
+                }
+            }
+            _ => {
+                return Err(parsing_failed!(
+                    "incomplete {} tool call",
+                    self.config.parser_name
+                ));
+            }
+        }
+        let _ = self.reset();
+        Ok(output)
+    }
+
+    fn reset(&mut self) -> String {
+        PythonicToolParser::reset(self)
+    }
+}
+
+/// Parse a pythonic event for the current parser mode.
+fn parse_next_pythonic_event(
+    input: &mut PythonicInput<'_>,
+    mode: &PythonicMode,
+    config: PythonicConfig,
+) -> ModalResult<PythonicEvent> {
+    match mode {
+        PythonicMode::Start | PythonicMode::Passthrough => {
+            unreachable!("pythonic parser driver must commit before parsing events")
+        }
+        PythonicMode::ListStart => list_start_event(input, config),
+        PythonicMode::ListNext => list_next_event(input),
+        PythonicMode::Arguments { first } => arguments_event(input, *first),
+        PythonicMode::StringValue { quote } => string_value_event(input, *quote),
+        // Text after the closing `]` is only reported once, at `finish()`.
+        PythonicMode::Done => incomplete(),
+    }
+}
+
+/// Parse the opening `[` and the first call of a pythonic tool-call list.
+fn list_start_event(
+    input: &mut PythonicInput<'_>,
+    config: PythonicConfig,
+) -> ModalResult<PythonicEvent> {
+    preceded(
+        (ws0, optional_marker(config.start_marker), literal("["), ws0),
+        call_start_event,
+    )
+    .context(StrContext::Label("pythonic tool call list"))
+    .parse_next(input)
+}
+
+/// Parse the separator or terminator after one pythonic call.
+fn list_next_event(input: &mut PythonicInput<'_>) -> ModalResult<PythonicEvent> {
+    preceded(
+        ws0,
+        alt((
+            list_end_event,
+            preceded((literal(","), ws0), alt((list_end_event, call_start_event))),
+        )),
+    )
+    .parse_next(input)
+}
+
+/// Parse the closing `]` of a pythonic tool-call list.
+fn list_end_event(input: &mut PythonicInput<'_>) -> ModalResult<PythonicEvent> {
+    literal("]").value(PythonicEvent::ListEnd).parse_next(input)
+}
+
+/// Parse the start of one pythonic call, up to its opening `(`.
+fn call_start_event(input: &mut PythonicInput<'_>) -> ModalResult<PythonicEvent> {
+    seq!(function_name, _: literal("("))
+        .map(|(name,)| PythonicEvent::CallStart {
+            name: name.to_string(),
+        })
+        .parse_next(input)
+}
+
+/// Parse the next event inside a pythonic argument list.
+fn arguments_event(input: &mut PythonicInput<'_>, first: bool) -> ModalResult<PythonicEvent> {
+    if first {
+        return preceded(ws0, alt((call_end_event, argument_event)))
+            .context(StrContext::Label("pythonic tool call arguments"))
+            .parse_next(input);
+    }
+    preceded(
+        ws0,
+        alt((
+            call_end_event,
+            preceded((literal(","), ws0), alt((call_end_event, argument_event))),
+        )),
+    )
+    .context(StrContext::Label("pythonic tool call arguments"))
+    .parse_next(input)
+}
+
+/// Parse the closing `)` of one pythonic call.
+fn call_end_event(input: &mut PythonicInput<'_>) -> ModalResult<PythonicEvent> {
+    literal(")").value(PythonicEvent::CallEnd).parse_next(input)
+}
+
+/// Parse one keyword argument of a pythonic call, up to its value.
+fn argument_event(input: &mut PythonicInput<'_>) -> ModalResult<PythonicEvent> {
+    let (key,) = seq!(identifier, _: ws0, _: literal("="), _: ws0).parse_next(input)?;
+    let key = key.to_string();
+
+    // A string value is streamed as it arrives; any other literal is only
+    // emitted once it is complete.
+    alt((
+        string_quote.map(|quote| PythonicEvent::StringArgumentStart {
+            key: key.clone(),
+            quote,
+        }),
+        python_value.map(|value| PythonicEvent::Argument {
+            key: key.clone(),
+            value,
+        }),
+    ))
+    .parse_next(input)
+}
+
+/// Parse the next run of a streaming pythonic string argument.
+fn string_value_event(input: &mut PythonicInput<'_>, quote: char) -> ModalResult<PythonicEvent> {
+    let StringRun {
+        text,
+        consumed,
+        closed,
+    } = decode_string_run(input, quote)?;
+
+    if consumed == 0 {
+        return incomplete();
+    }
+    Ok(if closed {
+        PythonicEvent::StringEnd { text }
+    } else {
+        PythonicEvent::StringChunk { text }
+    })
+}
+
+/// Parse an optional marker wrapping the tool-call list.
+fn optional_marker<'i>(
+    marker: Option<&'static str>,
+) -> impl Parser<PythonicInput<'i>, (), ErrMode<ContextError>> {
+    move |input: &mut PythonicInput<'i>| match marker {
+        Some(marker) => opt(literal(marker)).void().parse_next(input),
+        None => Ok(()),
+    }
+}
+
+/// Parse a pythonic function name.
+///
+/// Dotted names are accepted because the Python parser keeps them as the tool
+/// name (`handle_single_tool` walks `ast.Attribute` chains).
+fn function_name<'i>(input: &mut PythonicInput<'i>) -> ModalResult<&'i str> {
+    (
+        one_of(('a'..='z', 'A'..='Z', '_')),
+        take_while(0.., ('a'..='z', 'A'..='Z', '0'..='9', '_', '.')),
+    )
+        .take()
+        .parse_next(input)
+}
+
+/// Parse a Python identifier.
+fn identifier<'i>(input: &mut PythonicInput<'i>) -> ModalResult<&'i str> {
+    (
+        one_of(('a'..='z', 'A'..='Z', '_')),
+        take_while(0.., ('a'..='z', 'A'..='Z', '0'..='9', '_')),
+    )
+        .take()
+        .parse_next(input)
+}
+
+/// Feed `chunks` through a parser, recovering parse errors as plain text the
+/// way the streaming frontend does.
+#[cfg(test)]
+fn parse_recovering(config: PythonicConfig, chunks: &[&str]) -> ToolParserOutput {
+    let mut parser = PythonicToolParser::with_config(config);
+    let mut output = ToolParserOutput::default();
+    let mut failed = false;
+
+    for chunk in chunks {
+        if failed {
+            output.push_text(*chunk);
+            continue;
+        }
+        if parser.parse_into(chunk, &mut output).is_err() {
+            failed = true;
+            output.push_text(parser.reset());
+        }
+    }
+
+    if !failed {
+        match parser.finish() {
+            Ok(finished) => output.append(finished),
+            Err(_) => output.push_text(parser.reset()),
+        }
+    }
+    output.coalesce()
+}
+
+/// Parse `text` whole and in 1- and 3-character chunks, asserting that every
+/// chunking commits the same output.
+#[cfg(test)]
+fn parse_chunkings(config: PythonicConfig, text: &str) -> ToolParserOutput {
+    use crate::tool::test_utils::split_by_chars;
+
+    let whole = parse_recovering(config, &[text]);
+    for chunk_chars in [1, 3] {
+        let chunked = parse_recovering(config, &split_by_chars(text, chunk_chars));
+        assert_eq!(chunked, whole, "{chunk_chars}-char chunks must match");
+    }
+    whole
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+    use thiserror_ext::AsReport;
+
+    use super::{PYTHONIC_CONFIG, PythonicToolParser, parse_chunkings};
+    use crate::tool::test_utils::test_tools;
+    use crate::tool::{ToolParser, ToolParserOutput, ToolParserTestExt as _};
+
+    // Fixtures shared with `tests/tool_parsers/test_pythonic_tool_parser.py`.
+    const SIMPLE_CALL: &str = "get_weather(city='San Francisco', metric='celsius')";
+    const MORE_TYPES_CALL: &str = "register_user(name='John Doe', \
+         age=37, \
+         address={'city': 'San Francisco', 'state': 'CA'}, \
+         role=None, \
+         passed_test=True, \
+         aliases=['John', 'Johnny'])";
+    const ESCAPED_STRING_CALL: &str =
+        r#"get_weather(city='Martha\'s Vineyard', metric='\"cool units\"')"#;
+
+    fn parse(text: &str) -> ToolParserOutput {
+        parse_chunkings(PYTHONIC_CONFIG, text)
+    }
+
+    #[test]
+    fn pythonic_extracts_simple_call() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"San Francisco\",\"metric\":\"celsius\"}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse(&format!("[{SIMPLE_CALL}]")));
+    }
+
+    #[test]
+    fn pythonic_extracts_parallel_calls() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"San Francisco\",\"metric\":\"celsius\"}",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 1,
+                            name: Some(
+                                "register_user",
+                            ),
+                            arguments: "{\"name\":\"John Doe\",\"age\":37,\"address\":{\"city\":\"San Francisco\",\"state\":\"CA\"},\"role\":null,\"passed_test\":true,\"aliases\":[\"John\",\"Johnny\"]}",
+                        },
+                    ),
+                ],
+            }
+        "#]].assert_debug_eq(&parse(&format!("[{SIMPLE_CALL}, {MORE_TYPES_CALL}]")));
+    }
+
+    #[test]
+    fn pythonic_converts_python_literals_to_json() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "register_user",
+                            ),
+                            arguments: "{\"name\":\"John Doe\",\"age\":37,\"address\":{\"city\":\"San Francisco\",\"state\":\"CA\"},\"role\":null,\"passed_test\":true,\"aliases\":[\"John\",\"Johnny\"]}",
+                        },
+                    ),
+                ],
+            }
+        "#]].assert_debug_eq(&parse(&format!("[{MORE_TYPES_CALL}]")));
+    }
+
+    #[test]
+    fn pythonic_extracts_empty_arguments() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{}",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 1,
+                            name: Some(
+                                "do_something_cool",
+                            ),
+                            arguments: "{\"additional_data\":{}}",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 2,
+                            name: Some(
+                                "do_something_cool",
+                            ),
+                            arguments: "{\"steps\":[]}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse(
+            "[get_weather(), do_something_cool(additional_data={}), do_something_cool(steps=[])]",
+        ));
+    }
+
+    #[test]
+    fn pythonic_decodes_escaped_strings() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"Martha's Vineyard\",\"metric\":\"\\\"cool units\\\"\"}",
+                        },
+                    ),
+                ],
+            }
+        "#]].assert_debug_eq(&parse(&format!("[{ESCAPED_STRING_CALL}]")));
+    }
+
+    #[test]
+    fn pythonic_decodes_escapes_split_across_chunks() {
+        // Every escape form must survive arriving one character at a time.
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "send",
+                            ),
+                            arguments: "{\"text\":\"☃ 😀 🚀 AA é\",\"raw\":\"a\\tb\\nc\"}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse(
+            r"[send(text='☃ \U0001f600 🚀 \x41\101 é', raw='a\tb\nc')]",
+        ));
+    }
+
+    #[test]
+    fn pythonic_keeps_brackets_inside_string_arguments() {
+        // Brackets, commas and quotes inside a string must not end the call.
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "run",
+                            ),
+                            arguments: "{\"cmd\":\"grep -F \\\"]\\\" a.txt\",\"note\":\"one, two)\",\"flag\":true}",
+                        },
+                    ),
+                ],
+            }
+        "#]].assert_debug_eq(&parse(
+            r#"[run(cmd='grep -F "]" a.txt', note="one, two)", flag=True)]"#,
+        ));
+    }
+
+    #[test]
+    fn pythonic_accepts_signed_numbers() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "locate",
+                            ),
+                            arguments: "{\"lat\":-33.87,\"lon\":151,\"delta\":-2}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse("[locate(lat=-33.87, lon=151, delta=-2)]"));
+    }
+
+    #[test]
+    fn pythonic_accepts_whitespace_between_calls_and_arguments() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "{\"city\":\"San Francisco\",\"metric\":\"celsius\"}",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 1,
+                            name: Some(
+                                "add",
+                            ),
+                            arguments: "{\"x\":1,\"y\":2}",
+                        },
+                    ),
+                ],
+            }
+        "#]].assert_debug_eq(&parse(
+            "[\n  get_weather(\n    city = 'San Francisco',\n    metric = 'celsius',\n  ),\n  add(x=1, y=2),\n]",
+        ));
+    }
+
+    #[test]
+    fn pythonic_keeps_plain_text() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    Text(
+                        "How can I help you today?",
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse("How can I help you today?"));
+    }
+
+    #[test]
+    fn pythonic_passthrough_never_reenters_tool_parsing() {
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    Text(
+                        "Let me check. [get_weather(city='San Francisco', metric='celsius')]",
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&parse(&format!("Let me check. [{SIMPLE_CALL}]")));
+    }
+
+    #[test]
+    fn pythonic_recovers_lists_that_are_not_tool_calls() {
+        for text in ["[1, 2, 3]", "[not a call", "[]", "[3.14]"] {
+            let output = parse(text);
+            assert_eq!(output.normal_text(), text, "{text:?} should stay text");
+            assert!(output.calls().is_empty(), "{text:?} should have no calls");
+        }
+    }
+
+    #[test]
+    fn pythonic_streams_name_and_argument_fragments() {
+        let mut parser = PythonicToolParser::new(&test_tools());
+        let mut output = ToolParserOutput::default();
+        parser.parse_into(&format!("[{SIMPLE_CALL}]"), &mut output).unwrap();
+        output.append(parser.finish().unwrap());
+
+        expect![[r#"
+            ToolParserOutput {
+                events: [
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: Some(
+                                "get_weather",
+                            ),
+                            arguments: "",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: None,
+                            arguments: "{",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: None,
+                            arguments: "\"city\":\"",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: None,
+                            arguments: "San Francisco\"",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: None,
+                            arguments: ",\"metric\":\"",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: None,
+                            arguments: "celsius\"",
+                        },
+                    ),
+                    ToolCall(
+                        ToolCallDelta {
+                            tool_index: 0,
+                            name: None,
+                            arguments: "}",
+                        },
+                    ),
+                ],
+            }
+        "#]]
+        .assert_debug_eq(&output);
+    }
+
+    #[test]
+    fn pythonic_streams_long_string_arguments_before_the_call_closes() {
+        let mut parser = PythonicToolParser::new(&test_tools());
+        let long_value = "x".repeat(4096);
+
+        let output = parser.parse_chunk(&format!("[run(script='{long_value}")).unwrap();
+
+        // The string content is committed before the call is closed.
+        assert_eq!(output.calls().len(), 4);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("run"));
+        assert_eq!(output.calls()[1].arguments, "{");
+        assert_eq!(output.calls()[2].arguments, "\"script\":\"");
+        assert_eq!(output.calls()[3].arguments, long_value);
+    }
+
+    #[test]
+    fn pythonic_finish_fails_incomplete_call() {
+        let mut parser = PythonicToolParser::new(&test_tools());
+        parser.parse_chunk("[get_weather(city='San").unwrap();
+
+        let error = parser.finish().unwrap_err();
+
+        expect!["tool parser parsing failed: incomplete pythonic tool call"]
+            .assert_eq(&error.to_report_string());
+    }
+
+    #[test]
+    fn pythonic_rejects_trailing_text_after_the_list() {
+        let mut parser = PythonicToolParser::new(&test_tools());
+        parser.parse_chunk(&format!("[{SIMPLE_CALL}] and that is all")).unwrap();
+
+        let error = parser.finish().unwrap_err();
+
+        expect!["tool parser parsing failed: trailing text after pythonic tool calls"]
+            .assert_eq(&error.to_report_string());
+    }
+
+    #[test]
+    fn pythonic_reports_malformed_arguments() {
+        let mut parser = PythonicToolParser::new(&test_tools());
+
+        let error = parser.parse_chunk("[get_weather(city=@)]").unwrap_err();
+
+        expect![[
+            r#"tool parser parsing failed: near "city=@)]": invalid pythonic tool call arguments"#
+        ]]
+        .assert_eq(&error.to_report_string());
+    }
+}

--- a/rust/src/parser/src/tool/pythonic/value.rs
+++ b/rust/src/parser/src/tool/pythonic/value.rs
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Python literal values inside pythonic tool calls.
+//!
+//! Tool call arguments are Python literals while the OpenAI API expects JSON
+//! text, so every value parsed here is converted into a `serde_json::Value`
+//! (`True` -> `true`, `None` -> `null`, `'text'` -> `"text"`, ...).
+
+use serde_json::{Number, Value};
+use winnow::ascii::multispace0 as ws0;
+use winnow::combinator::{alt, delimited, opt, separated, terminated};
+use winnow::error::{ContextError, ErrMode, ModalResult, StrContext};
+use winnow::prelude::*;
+use winnow::token::{literal, one_of, take_while};
+
+use super::PythonicInput;
+use crate::tool::Result;
+use crate::utils::incomplete;
+use crate::utils::recursion::ParserRecursionGuard;
+
+/// One decoded run of a Python string literal body.
+pub(super) struct StringRun {
+    /// Decoded text of this run.
+    pub(super) text: String,
+    /// Bytes consumed from the input.
+    pub(super) consumed: usize,
+    /// Whether the run ended at the literal's closing quote.
+    pub(super) closed: bool,
+}
+
+/// Parse the opening quote of a Python string literal.
+pub(super) fn string_quote(input: &mut PythonicInput<'_>) -> ModalResult<char> {
+    one_of(['\'', '"']).parse_next(input)
+}
+
+/// Parse a Python literal value.
+///
+/// A value is only emitted once it is complete, so a nested container is
+/// buffered until its closing bracket arrives; only a top-level string argument
+/// is streamed incrementally (see [`decode_string_run`]).
+///
+/// TODO: the Python `get_parameter_value` also accepts tuples, sets,
+/// placeholder-free f-strings and non-string dict keys. Those are rejected here
+/// so far; models emitting them fall back to plain text.
+pub(super) fn python_value(input: &mut PythonicInput<'_>) -> ModalResult<Value> {
+    alt((
+        python_string.map(Value::String),
+        python_list,
+        python_dict,
+        python_keyword,
+        python_number,
+    ))
+    .parse_next(input)
+}
+
+/// Parse a Python string literal.
+fn python_string(input: &mut PythonicInput<'_>) -> ModalResult<String> {
+    let quote = string_quote.parse_next(input)?;
+    let run = decode_string_run(input, quote)?;
+    if !run.closed {
+        return incomplete();
+    }
+    Ok(run.text)
+}
+
+/// Parse a Python list literal.
+fn python_list(input: &mut PythonicInput<'_>) -> ModalResult<Value> {
+    literal("[").parse_next(input)?;
+    let _guard = ParserRecursionGuard::enter()?;
+    terminated(python_items, literal("]")).map(Value::Array).parse_next(input)
+}
+
+/// Parse the comma-separated items of a Python list literal.
+fn python_items(input: &mut PythonicInput<'_>) -> ModalResult<Vec<Value>> {
+    delimited(
+        ws0,
+        terminated(
+            separated(0.., python_value, comma_separator),
+            opt(comma_separator),
+        ),
+        ws0,
+    )
+    .parse_next(input)
+}
+
+/// Parse a Python dict literal.
+fn python_dict(input: &mut PythonicInput<'_>) -> ModalResult<Value> {
+    literal("{").parse_next(input)?;
+    let _guard = ParserRecursionGuard::enter()?;
+    terminated(python_entries, literal("}"))
+        .map(|entries: Vec<(String, Value)>| Value::Object(entries.into_iter().collect()))
+        .parse_next(input)
+}
+
+/// Parse the comma-separated entries of a Python dict literal.
+fn python_entries(input: &mut PythonicInput<'_>) -> ModalResult<Vec<(String, Value)>> {
+    delimited(
+        ws0,
+        terminated(
+            separated(0.., python_entry, comma_separator),
+            opt(comma_separator),
+        ),
+        ws0,
+    )
+    .parse_next(input)
+}
+
+/// Parse one `'key': value` entry of a Python dict literal.
+///
+/// JSON object keys are strings, so only string keys are accepted here.
+fn python_entry(input: &mut PythonicInput<'_>) -> ModalResult<(String, Value)> {
+    (
+        python_string,
+        delimited(ws0, literal(":"), ws0),
+        python_value,
+    )
+        .map(|(key, _, value)| (key, value))
+        .parse_next(input)
+}
+
+/// Parse a comma separator between Python literals.
+fn comma_separator(input: &mut PythonicInput<'_>) -> ModalResult<()> {
+    delimited(ws0, literal(","), ws0).void().parse_next(input)
+}
+
+/// Parse a Python keyword literal.
+///
+/// JSON-style spellings are accepted as well because some models (e.g. OLMo 3)
+/// emit `true` / `false` / `null` inside otherwise pythonic calls, matching
+/// `_JSON_NAME_LITERALS` in the Python parser.
+fn python_keyword(input: &mut PythonicInput<'_>) -> ModalResult<Value> {
+    alt((
+        literal("True").value(Value::Bool(true)),
+        literal("False").value(Value::Bool(false)),
+        literal("None").value(Value::Null),
+        literal("true").value(Value::Bool(true)),
+        literal("false").value(Value::Bool(false)),
+        literal("null").value(Value::Null),
+    ))
+    .parse_next(input)
+}
+
+/// Parse a Python numeric literal.
+///
+/// Signs are part of the literal here; Python parses `-1` as a unary operation
+/// over a constant, which the Python parser converts back into a number.
+fn python_number(input: &mut PythonicInput<'_>) -> ModalResult<Value> {
+    let raw = take_while(1.., ('0'..='9', '.', 'e', 'E', '+', '-')).parse_next(input)?;
+    number_value(raw).ok_or_else(|| cut_error("Python number"))
+}
+
+/// Convert a Python numeric literal into a JSON number.
+fn number_value(raw: &str) -> Option<Value> {
+    if let Ok(value) = raw.parse::<i64>() {
+        return Some(value.into());
+    }
+    if let Ok(value) = raw.parse::<u64>() {
+        return Some(value.into());
+    }
+    // Non-finite floats have no JSON representation and are rejected here, like
+    // `_is_json_finite` does on the Python side.
+    Number::from_f64(raw.parse::<f64>().ok()?).map(Value::Number)
+}
+
+/// Decode the body of a Python string literal up to its closing `quote`.
+///
+/// Decoding stops at the closing quote or at the last complete escape sequence,
+/// so a trailing partial escape stays buffered until the next chunk arrives.
+/// The input is advanced past the decoded run.
+pub(super) fn decode_string_run(
+    input: &mut PythonicInput<'_>,
+    quote: char,
+) -> ModalResult<StringRun> {
+    let text = **input;
+    let mut decoded = String::new();
+    let mut index = 0;
+
+    while let Some(char) = text[index..].chars().next() {
+        if char == quote {
+            let consumed = index + char.len_utf8();
+            input.next_slice(consumed);
+            return Ok(StringRun {
+                text: decoded,
+                consumed,
+                closed: true,
+            });
+        }
+        if char == '\\' {
+            let Some(len) = decode_escape(&text[index..], &mut decoded)? else {
+                break;
+            };
+            index += len;
+            continue;
+        }
+        decoded.push(char);
+        index += char.len_utf8();
+    }
+
+    input.next_slice(index);
+    Ok(StringRun {
+        text: decoded,
+        consumed: index,
+        closed: false,
+    })
+}
+
+/// Decode one Python escape sequence at the start of `text`.
+///
+/// Returns the number of bytes consumed, or `None` when the sequence is cut
+/// short by the end of the buffered input.
+fn decode_escape(text: &str, decoded: &mut String) -> ModalResult<Option<usize>> {
+    let Some(escape) = text[1..].chars().next() else {
+        return Ok(None);
+    };
+    let end = 1 + escape.len_utf8();
+
+    match escape {
+        // A backslash before a line break is a line continuation.
+        '\n' => Ok(Some(end)),
+        '\\' | '\'' | '"' => Ok(Some(push_escaped(decoded, escape, end))),
+        'a' => Ok(Some(push_escaped(decoded, '\u{7}', end))),
+        'b' => Ok(Some(push_escaped(decoded, '\u{8}', end))),
+        'f' => Ok(Some(push_escaped(decoded, '\u{c}', end))),
+        'n' => Ok(Some(push_escaped(decoded, '\n', end))),
+        'r' => Ok(Some(push_escaped(decoded, '\r', end))),
+        't' => Ok(Some(push_escaped(decoded, '\t', end))),
+        'v' => Ok(Some(push_escaped(decoded, '\u{b}', end))),
+        '0'..='7' => decode_octal_escape(text, decoded),
+        'x' => decode_fixed_escape(text, decoded, 2),
+        'u' => decode_unicode_escape(text, decoded),
+        'U' => decode_fixed_escape(text, decoded, 8),
+        // Python keeps unknown escapes such as `\d` verbatim (with a syntax
+        // warning that the Python parser suppresses), and so does this.
+        // TODO: `\N{NAME}` named escapes need a Unicode name table and are
+        // kept verbatim for now.
+        _ => {
+            decoded.push('\\');
+            Ok(Some(push_escaped(decoded, escape, end)))
+        }
+    }
+}
+
+/// Push one decoded escape character and return the bytes it consumed.
+fn push_escaped(decoded: &mut String, char: char, end: usize) -> usize {
+    decoded.push(char);
+    end
+}
+
+/// Decode a Python octal escape such as `\101`.
+fn decode_octal_escape(text: &str, decoded: &mut String) -> ModalResult<Option<usize>> {
+    const MAX_DIGITS: usize = 3;
+
+    let mut end = 1;
+    let mut value = 0;
+    for digit in text[1..].chars().take(MAX_DIGITS).map_while(|char| char.to_digit(8)) {
+        value = value * 8 + digit;
+        end += 1;
+    }
+
+    // Fewer than three digits at the end of the buffer may still grow.
+    if end < 1 + MAX_DIGITS && end == text.len() {
+        return Ok(None);
+    }
+    let Some(char) = char::from_u32(value) else {
+        return Err(cut_error("Python string escape"));
+    };
+    Ok(Some(push_escaped(decoded, char, end)))
+}
+
+/// Decode a fixed-width Python escape such as `\xff` or `\U0001f600`.
+fn decode_fixed_escape(
+    text: &str,
+    decoded: &mut String,
+    digits: usize,
+) -> ModalResult<Option<usize>> {
+    let Some((value, end)) = escape_code_point(text, digits)? else {
+        return Ok(None);
+    };
+    let Some(char) = char::from_u32(value) else {
+        return Err(cut_error("Python string escape"));
+    };
+    Ok(Some(push_escaped(decoded, char, end)))
+}
+
+/// Decode a `\uXXXX` escape, pairing surrogates like JSON does.
+fn decode_unicode_escape(text: &str, decoded: &mut String) -> ModalResult<Option<usize>> {
+    const LEADING: std::ops::RangeInclusive<u32> = 0xD800..=0xDBFF;
+    const TRAILING: std::ops::RangeInclusive<u32> = 0xDC00..=0xDFFF;
+
+    let Some((leading, end)) = escape_code_point(text, 4)? else {
+        return Ok(None);
+    };
+    if !LEADING.contains(&leading) {
+        return decode_fixed_escape(text, decoded, 4);
+    }
+
+    // A leading surrogate only forms a character together with the trailing
+    // surrogate that follows it, like a JSON `😀` pair.
+    let rest = &text[end..];
+    if !rest.starts_with("\\u") {
+        if "\\u".starts_with(rest) {
+            return Ok(None);
+        }
+        return Err(cut_error("Python string escape"));
+    }
+    let Some((trailing, trailing_end)) = escape_code_point(rest, 4)? else {
+        return Ok(None);
+    };
+    if !TRAILING.contains(&trailing) {
+        return Err(cut_error("Python string escape"));
+    }
+
+    let value = 0x10000 + ((leading - 0xD800) << 10) + (trailing - 0xDC00);
+    let Some(char) = char::from_u32(value) else {
+        return Err(cut_error("Python string escape"));
+    };
+    Ok(Some(push_escaped(decoded, char, end + trailing_end)))
+}
+
+/// Read the `digits` hex digits of an escape sequence at the start of `text`.
+///
+/// Returns the code point and the byte offset just past the sequence, or `None`
+/// when the buffered text may still grow into a complete sequence.
+fn escape_code_point(text: &str, digits: usize) -> ModalResult<Option<(u32, usize)>> {
+    let end = 2 + digits;
+    let hex_digits = |text: &str| text.chars().all(|char| char.is_ascii_hexdigit());
+    let Some(raw) = text.get(2..end).filter(|raw| hex_digits(raw)) else {
+        // A short tail of hex digits can still be completed by the next chunk.
+        if hex_digits(&text[2..]) {
+            return Ok(None);
+        }
+        return Err(cut_error("Python string escape"));
+    };
+    let value = u32::from_str_radix(raw, 16).map_err(|_| cut_error("Python string escape"))?;
+    Ok(Some((value, end)))
+}
+
+/// Encode a key as a quoted JSON object key.
+pub(super) fn json_object_key(key: &str) -> Result<String> {
+    serde_json::to_string(key)
+        .map_err(|error| parsing_failed!("failed to serialize argument name: {}", error))
+}
+
+/// Encode decoded text as JSON string content, without the enclosing quotes.
+///
+/// String arguments are streamed between the quotes emitted when the argument
+/// starts, so only the escaped content belongs in the delta.
+pub(super) fn json_string_content(text: &str) -> Result<String> {
+    let encoded = serde_json::to_string(text)
+        .map_err(|error| parsing_failed!("failed to serialize string argument: {}", error))?;
+    encoded
+        .strip_prefix('"')
+        .and_then(|content| content.strip_suffix('"'))
+        .map(str::to_string)
+        .ok_or_else(|| parsing_failed!("JSON string argument is not quoted"))
+}
+
+/// Build a cut error for an invalid Python literal.
+fn cut_error(label: &'static str) -> ErrMode<ContextError> {
+    let mut error = ContextError::new();
+    error.push(StrContext::Label(label));
+    ErrMode::Cut(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+    use winnow::error::ErrMode;
+    use winnow::stream::Partial;
+
+    use super::{PythonicInput, python_value};
+
+    fn parse(text: &str) -> String {
+        let mut input = Partial::new(text);
+        let value = python_value(&mut input).expect("value should parse");
+        format!("{value} | rest {:?}", *input)
+    }
+
+    fn error(text: &str) -> ErrMode<winnow::error::ContextError> {
+        let mut input: PythonicInput<'_> = Partial::new(text);
+        python_value(&mut input).expect_err("value should not parse")
+    }
+
+    #[test]
+    fn python_value_converts_scalars_to_json() {
+        expect![[r#"37 | rest " ""#]].assert_eq(&parse("37 "));
+        expect!["-2.5 | rest \")\""].assert_eq(&parse("-2.5)"));
+        expect!["1000.0 | rest \")\""].assert_eq(&parse("1e3)"));
+        expect!["true | rest \"\""].assert_eq(&parse("True"));
+        expect!["false | rest \"\""].assert_eq(&parse("False"));
+        expect!["null | rest \"\""].assert_eq(&parse("None"));
+        expect!["true | rest \"\""].assert_eq(&parse("true"));
+        expect!["null | rest \"\""].assert_eq(&parse("null"));
+    }
+
+    #[test]
+    fn python_value_decodes_string_escapes() {
+        expect![[r#""Martha's Vineyard" | rest """#]].assert_eq(&parse(r"'Martha\'s Vineyard'"));
+        expect![[r#""\"cool units\"" | rest """#]].assert_eq(&parse(r#"'\"cool units\"'"#));
+        expect![[r#""a\nb\tc" | rest """#]].assert_eq(&parse(r"'a\nb\tc'"));
+        expect![[r#""ünïcødé ☃ 😀" | rest """#]].assert_eq(&parse(r"'ün\xefc\xf8dé ☃ 😀'"));
+        expect![[r#""A\\d" | rest """#]].assert_eq(&parse(r"'\101\d'"));
+        expect![[r#""one line" | rest """#]].assert_eq(&parse("'one \\\nline'"));
+    }
+
+    #[test]
+    fn python_value_parses_nested_containers() {
+        expect![[r#"{"city":"SF","tags":["a","b"],"nested":{"deep":[1,{"ok":true}]}} | rest """#]]
+            .assert_eq(&parse(
+                "{'city': 'SF', 'tags': ['a', 'b'], 'nested': {'deep': [1, {'ok': True}]}}",
+            ));
+        expect![[r#"[] | rest """#]].assert_eq(&parse("[]"));
+        expect![[r#"{} | rest """#]].assert_eq(&parse("{}"));
+        expect![[r#"[1,2] | rest """#]].assert_eq(&parse("[1, 2,]"));
+    }
+
+    #[test]
+    fn python_value_reports_incomplete_for_partial_literals() {
+        for text in [
+            "'unterminated",
+            r"'trailing escape \",
+            r"'short unicode \u12",
+            r"'lone leading surrogate \ud83d",
+            "[1, 2",
+            "{'k': ",
+            "Tru",
+            "1.5",
+        ] {
+            assert!(
+                matches!(error(text), ErrMode::Incomplete(_)),
+                "{text:?} should be incomplete"
+            );
+        }
+    }
+
+    #[test]
+    fn python_value_rejects_unsupported_literals() {
+        for text in [
+            "f'formatted'",
+            "(1, 2)",
+            "{1: 'int key'}",
+            "'bad \\ud83d\\u0041'",
+        ] {
+            assert!(
+                !matches!(error(text), ErrMode::Incomplete(_)),
+                "{text:?} should fail"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Part of the Rust frontend parser-parity work tracked in #44280.

The Python frontend ships `pythonic` and `llama4_pythonic` tool parsers for models whose tool calls are a Python list of keyword-argument calls (Llama 3.2, Llama 4, ToolACE, ...), but the Rust frontend had no parser for that format: `--tool-call-parser pythonic` / `llama4_pythonic` were not registered and `llama-4` could only be served through the JSON parser. This PR ports the format to the Rust frontend as a streaming parser:

- `rust/src/parser/src/tool/pythonic/mod.rs`: `PythonicToolParser`, a winnow/`Partial` buffered-event parser in the same shape as `Llama3JsonToolParser` (explicit mode enum, `parse_buffered_event` loop). The list must be the whole output; leading text permanently switches the parser to passthrough, exactly like the JSON parsers. Text that opens with `[` but is not a call list (`[1, 2, 3]`, `[]`, `[not a call`) is a `ParsingFailed` error; because the opening `[` is only consumed together with the first `name(`, `reset()` still returns the whole original text and the chat layer re-emits it as content, which reproduces the Python parser's "does not match the pattern, treat as text" behaviour. Trailing non-whitespace after `]` and an incomplete call at `finish()` are errors, following the same convention as `Llama3JsonToolParser`.
- `rust/src/parser/src/tool/pythonic/value.rs`: Python literal parsers producing `serde_json::Value` (single/double-quoted strings with full Python escape decoding incl. `\xhh`, octal, `\uXXXX` with surrogate pairing, `\UXXXXXXXX`, line continuation; ints, floats and signed numbers; `True`/`False`/`None` plus JSON-style `true`/`false`/`null`; nested lists and dicts with string keys, bounded by the existing `ParserRecursionGuard`), and an incremental Python-string decoder used for streaming. Tuples, sets, f-strings, non-string dict keys and `\N{...}` escapes are rejected and left as `TODO`s in the code.
- `rust/src/parser/src/tool/pythonic/llama4.rs`: `Llama4PythonicToolParser`, a thin wrapper over the same core that also strips the `<|python_start|>` / `<|python_end|>` markers Llama 4 sometimes emits.
- Streaming is fully incremental: the name delta is emitted at `name(`, then `{`, then one `"key":<json>` fragment per completed argument (with `,` separators) and `}` at `)`. String arguments are streamed as the Python literal arrives (opening quote, decoded runs, closing quote), so long string arguments such as file contents do not stall the stream; non-string values (numbers, keywords, nested lists/dicts) are emitted once complete. Arguments are compact `serde_json` text, matching the other Rust parsers that synthesize JSON (`qwen_coder`, `glm_xml`).
- Registration: `pythonic` and `llama4_pythonic` in `rust/src/chat/src/parser/tool/mod.rs`. No model-name routing changes: `llama-4` still resolves to `llama4_json`, and the pythonic parsers are selected explicitly with `--tool-call-parser`, the same as in Python. `structural_tag_builder()` stays `None` (xgrammar has no structural tag for this format; the Python parser also has `structural_tag_model = None`).
- `rust/src/parser/benches/pythonic.rs`: native-vs-external comparison bench in the same shape as the existing per-parser benches.

Duplicate check: no open PR adds a pythonic parser to the Rust frontend (`is:pr pythonic in:title` only lists Python-side fixes); the open `[Rust Frontend]` parser PRs cover ERNIE 4.5 (#52841), Hunyuan A13B (#52133) and MiMo (#54393).

## Test Plan

Unit tests live next to the code (`expect-test` snapshots, `rust/AGENTS.md` conventions): simple / parallel / parameterless calls, empty dict and list arguments, nested containers, escaped strings (the `ESCAPED_STRING_FUNCTION_OUTPUT` case from the Python tests plus `\n`/`\t`/unicode/octal/hex escapes), `True`/`False`/`None` and JSON literals, signed numbers, whitespace and newlines between calls and arguments, plain-text passthrough, non-call lists and malformed input (asserting the original text is handed back), the Llama 4 markers split across chunk boundaries, `finish()` on incomplete calls and trailing text, and a 4096-character string argument that must be committed before the call closes. Every parse test runs through a `parse_chunkings` helper that asserts the coalesced output is byte-identical for the whole text, 3-character chunks and 1-character chunks. Registry tests in `rust/src/chat/src/parser/tool/tests.rs` cover creation by name and that `llama-4` model routing is unchanged.

```bash
cd rust
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo test -p vllm-parser --all-features --locked
cargo test -p vllm-chat --all-features --locked --lib
cargo bench -p vllm-parser --features test-util --bench pythonic -- --test
pre-commit run --files <changed files>
```

## Test Result

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean.
- `cargo test -p vllm-parser --all-features --locked`: 467 passed, 0 failed (26 new pythonic tests).
- `cargo test -p vllm-chat --all-features --locked --lib`: 293 passed, 0 failed.
- `cargo test --workspace --all-features --locked --lib --no-fail-fast`: everything passes except the pre-existing tests that download `Qwen/Qwen3-0.6B` from the Hugging Face Hub (`vllm-text` `lower_text_request_uses_real_qwen_generation_defaults` and the `vllm-chat` `roundtrip` integration tests), which cannot run in my sandbox and are unrelated to this change.
- `cargo bench -p vllm-parser --features test-util --bench pythonic -- --test`: all groups succeed.
- `pre-commit run --files <changed files>`: all applicable hooks pass (SPDX headers and the rust fmt hook included).
- No Python code is touched, so there is no model-output or accuracy impact for the Python frontend; the Rust frontend gains a new opt-in parser.

AI assistance was used while developing this change (drafting the parser and tests); I reviewed every line and ran the commands above myself.