### PR TITLE
[CI][XPU] skip test_sampling_mask_tensors_match_finite_support on XPU

### DIFF
--- a/tests/v1/test_outputs.py
+++ b/tests/v1/test_outputs.py
@@ -77,6 +77,11 @@ def test_sampling_mask_lists_to_nested_list():
 
 
 @pytest.mark.parametrize("max_num_kept", [512, 20_001])
+@pytest.skipif(
+    current_platform.is_xpu(),
+    reason="CI failed on XPU with Triton, Skipped until sycl kernel merged. "
+    "See https://github.com/vllm-project/vllm/pull/55851",
+)
 def test_sampling_mask_tensors_match_finite_support(max_num_kept):
     """Whatever its size (empty, one, around the compact width, beyond the
     cap, the whole vocab), a sampled row's mask is exactly the ascending set

--- a/tests/v1/test_outputs.py
+++ b/tests/v1/test_outputs.py
@@ -77,7 +77,7 @@ def test_sampling_mask_lists_to_nested_list():
 
 
 @pytest.mark.parametrize("max_num_kept", [512, 20_001])
-@pytest.skipif(
+@pytest.mark.skipif(
     current_platform.is_xpu(),
     reason="CI failed on XPU with Triton, Skipped until sycl kernel merged. "
     "See https://github.com/vllm-project/vllm/pull/55851",


### PR DESCRIPTION
As this PR show, replace triton kernel by torch reference function can fix CI failure.
https://github.com/vllm-project/vllm/pull/55638
The failure root cause is unknown, and the failure is hard to reproduce by running only the UT case.
But torch reference is slow, so will use sycl kernel to replace triton kernel.
https://github.com/vllm-project/vllm-xpu-kernels/pull/582
https://github.com/vllm-project/vllm/pull/55851