### PR TITLE
[Docs] Fix O0 custom_ops default in optimization levels

### DIFF
--- a/docs/design/optimization_levels.md
+++ b/docs/design/optimization_levels.md
@@ -35,7 +35,7 @@ This level is good for initial phases of development and debugging.
 Settings:
 
 - `-cc.cudagraph_mode=NONE`
-- `-cc.mode=NONE` (also resulting in `-cc.custom_ops=["none"]`)
+- `-cc.mode=NONE` (also resulting in `-cc.custom_ops=["all"]`)
 - `-cc.pass_config.fuse_...=False` (all fusions disabled)
 - `--kernel-config.enable_flashinfer_autotune=False`
 


### PR DESCRIPTION
## Summary
`docs/design/optimization_levels.md` claimed that `-O0` results in `-cc.custom_ops=["none"]`.

On current `main`, when `compilation_config.mode` is unset, `-O0` sets `CompilationMode.NONE`. The follow-on defaulting logic in `vllm/config/vllm.py` then appends `"all"` to `custom_ops` whenever neither `"all"` nor `"none"` is already present and the mode is `NONE` (or the backend is not inductor). `"none"` is only the default for inductor + non-`NONE` mode (O1+).

This PR updates the `-O0` bullet to `custom_ops=["all"]`.

## Local repro
```bash
# Docs (HEAD ce6c241ddcc722ee7f26fb4db132461150dad18e):
# docs/design/optimization_levels.md claims:
#   -cc.mode=NONE (also resulting in -cc.custom_ops=["none"])

# Code path in vllm/config/vllm.py:
# 1) if compilation_config.mode is None:
#      O0 -> CompilationMode.NONE
#      O1+ -> CompilationMode.VLLM_COMPILE
# 2) if custom_ops has neither "all" nor "none":
#      inductor and mode != NONE -> append "none"
#      else -> append "all"

python3 - <<'PY2'
from enum import IntEnum
class CompilationMode(IntEnum):
    NONE = 0
    VLLM_COMPILE = 3

def resolve(optimization_level: int, backend="inductor"):
    mode = CompilationMode.VLLM_COMPILE if optimization_level > 0 else CompilationMode.NONE
    custom_ops = []
    if all(s not in custom_ops for s in ("all", "none")):
        if backend == "inductor" and mode != CompilationMode.NONE:
            custom_ops.append("none")
        else:
            custom_ops.append("all")
    return mode.name, custom_ops

print("O0", resolve(0))  # ('NONE', ['all'])  -- docs previously said ["none"]
print("O1", resolve(1))  # ('VLLM_COMPILE', ['none'])
PY2
```