### PR TITLE
[Frontend] Add parameter-assertion coverage for harmony_utils VLLMValidationError

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -11,6 +11,8 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
     create_tool_definition,
     extract_function_from_recipient,
+    extract_instructions_from_messages,
+    get_developer_message,
     get_system_message,
     has_custom_tools,
     is_function_recipient,
@@ -981,6 +983,38 @@ class TestGetSystemMessage:
         ) as exc_info:
             get_system_message(reasoning_effort="max")
         assert exc_info.value.parameter == "reasoning_effort"
+
+
+class TestGetDeveloperMessage:
+    """Tests for get_developer_message tool validation."""
+
+    def test_unsupported_tool_type_raises_validation_error(self) -> None:
+        tool = ChatCompletionToolsParam(
+            function={
+                "name": "report_status",
+                "parameters": _TOOL_PARAMETERS,
+            }
+        )
+        # A tool type that is neither a builtin nor "function" is invalid input.
+        tool.type = "unsupported_tool_type"
+        with pytest.raises(
+            VLLMValidationError, match="tool type 'unsupported_tool_type'"
+        ) as exc_info:
+            get_developer_message(tools=[tool])
+        assert exc_info.value.parameter == "tools"
+
+
+class TestExtractInstructionsFromMessages:
+    """Tests for extract_instructions_from_messages input validation."""
+
+    def test_unknown_message_type_raises_validation_error(self) -> None:
+        # A message that is neither a dict nor has to_dict/model_dump is
+        # invalid user input.
+        with pytest.raises(
+            VLLMValidationError, match="Unknown message type"
+        ) as exc_info:
+            extract_instructions_from_messages([123])
+        assert exc_info.value.parameter == "input"
 
 
 class TestResponseInputToHarmonyReasoningItem:


### PR DESCRIPTION
Test hardening for the `VLLMValidationError` migration (follow-up to #50257, #55701, #55735). Test-only; **no source changes**.

## Purpose

Two request-input validation branches in `parser/harmony_utils.py` already raise `VLLMValidationError(..., parameter=...)`, but had no test asserting the raise or the `parameter` attribution:

- `get_developer_message`: unsupported tool type → `parameter="tools"`
- `extract_instructions_from_messages`: unknown message type → `parameter="input"`

This closes those gaps, matching the existing coverage style for the `reasoning_effort` branch (`test_unsupported_reasoning_effort_raises_clear_error`), which already asserts `exc_info.value.parameter`.

## Test Plan

```
pytest tests/entrypoints/openai/parser/test_harmony_utils.py -q
```

Two new tests:
- `TestGetDeveloperMessage::test_unsupported_tool_type_raises_validation_error`
- `TestExtractInstructionsFromMessages::test_unknown_message_type_raises_validation_error`

Both assert the exception type **and** `exc_info.value.parameter`.

## Test Result

To be confirmed by CI.