### PR TITLE
[ROCm] Let aiter's tuned decode GEMM win over the skinny kernels

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -257,6 +257,28 @@ def use_aiter_triton_gemm(n, m, k, dtype):
     )
 
 
+def use_aiter_decode_gemm(n, m, k, dtype, bias):
+    """True when aiter has a tuned decode-GEMM row for this exact shape.
+
+    The skinny kernels below return early for every small-token shape, so
+    aiter's tuned_gemm is unreachable even where its decode kernel is
+    measurably faster. Rather than duplicate a shape table here, ask aiter:
+    the tuned-config lookup answers only for shapes somebody actually tuned,
+    and reports a different backend for everything else.
+    """
+    if not rocm_aiter_ops.is_tgemm_enabled():
+        return False
+    if dtype not in [torch.float16, torch.bfloat16]:
+        return False
+    try:
+        from aiter.tuned_gemm import get_GEMM_A16W16_config
+
+        cfg = get_GEMM_A16W16_config(n, m, k, bias is not None, str(dtype), str(dtype))
+    except Exception:  # aiter absent, or no configs for this arch
+        return False
+    return cfg is not None and cfg.get("libtype") == "flydsl_decode"
+
+
 def rocm_unquantized_gemm_impl(
     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
 ) -> torch.Tensor:
@@ -315,6 +337,13 @@ def rocm_unquantized_gemm_impl(
         from aiter.ops.triton.gemm_a16w16 import gemm_a16w16
 
         return gemm_a16w16(x, weight, bias)
+
+    # A tuned aiter decode row means somebody measured this exact shape against
+    # the skinny kernels below and the decode kernel won, so take it directly.
+    if use_aiter_decode_gemm(n, m, k, x.dtype, bias):
+        from aiter.tuned_gemm import tgemm
+
+        return tgemm.mm(x, weight, bias)
 
     use_skinny = (
         envs.VLLM_ROCM_USE_SKINNY_GEMM


### PR DESCRIPTION
Claude generated:  
  
## Purpose

On gfx950 the skinny-GEMM branch in `rocm_unquantized_gemm_impl` returns early for
every small-token shape, so `tgemm.mm` further down is unreachable and aiter's
tuned A16W16 config is never consulted — even for shapes where aiter has a tuned
decode kernel that is measurably faster than `wvSplitK`.

This adds a single guard: defer to aiter only when its tuned config actually
names a decode kernel for this exact shape. Nothing else changes.

Deliberately **not** a shape table in vLLM. A `flydsl_decode` row exists only
where somebody tuned that shape and the decode kernel won; every other shape,
model and architecture reports a different backend and keeps today's path. The
criterion lives in aiter's config and is updated by re-tuning, not by editing
vLLM.

The helper is a no-op unless `VLLM_ROCM_USE_AITER` and
`VLLM_ROCM_USE_AITER_LINEAR` are set and the platform is gfx950, and it fails
closed if aiter is missing or raises.

Depends on ROCm/aiter#4114, which adds the decode kernel and the tuned
rows this patch keys off. Until that lands, `get_GEMM_A16W16_config`
reports a different backend for these shapes and this patch is a no-op

## Test Plan

Kimi-K3 TP8 decode shapes at M=1, bf16, on MI355X (gfx950, 256 CUs),
ROCm 7.2.4, aiter at `ROCm/aiter@main` + the tuned rows for these shapes.

1. **Which kernel actually runs** — call `rocm_unquantized_gemm_impl` for each
   shape and read the kernel name out of the profiler trace, with and without
   `VLLM_ROCM_USE_AITER`.

2. **Kernel-level comparison** — decode kernel vs `ops.wvSplitK`, both launched
   directly, ten alternating pairs in one process, medians reported. Two guards
   against the drift that made earlier attempts unreliable:
   * both kernels are checked against a torch reference first;
   * `wvSplitK` is also timed **against itself** as a null control, which
     measures the noise floor instead of assuming it.

3. **CUDA graph vs eager** — the same calls under a captured graph and eagerly,
   since vLLM captures decode by default.

## Test Result

**Dispatch is correct.** With the patch, the twelve shapes that have a tuned
decode row launch `flydsl_decode_agfx950_m1_n<N>_k<K>_...`; `shared down`
(7168x768), whose tuned row names FlyDSL HGEMM rather than decode, still runs
`wvSplitK_hf_sml_`. Without the patch all thirteen run `wvSplitK`.

**Kernel level** (10 pairs, medians in us; null control came out within ±2%,
which is the noise floor):

| shape | N | K | decode | wvSplitK | gain | decode won |
|---|---|---|---|---|---|---|
| MLA gate | 1536 | 7168 | 5.52 | 7.48 | 26% | 10/10 |
| router | 896 | 7168 | 4.58 | 5.71 | 20% | 10/10 |
| MLA qb | 2304 | 1536 | 3.63 | 4.15 | 13% | 10/10 |
| MLA fused | 2112 | 7168 | 6.93 | 7.87 | 12% | 10/10 |
| latent up | 7168 | 3584 | 8.77 | 9.90 | 11% | 10/10 |
| latent down | 3584 | 7168 | 9.22 | 9.93 | 7% | 10/10 |
| attention O | 7168 | 1536 | 5.50 | 5.88 | 6% | 10/10 |
| dense down | 7168 | 4224 | 11.11 | 11.53 | 4% | 10/10 |
| KDA merged | 6288 | 7168 | 15.06 | 15.54 | 3% | 9/10 |
| vocab head | 20480 | 7168 | 43.66 | 43.86 | 0% | 9/10 |
| dense gate/up | 8448 | 7168 | 19.82 | 19.83 | 0% | 6/10 |
| KDA small-K | 1536 | 128 | 2.37 | 2.36 | -0% | 5/10 |

Sum of medians 136.2 us vs 144.0 us, **+5.5%**. Eight shapes are faster beyond
the noise floor and won every pair; four are ties; none is slower. Both kernels
agree with the torch reference to the same maximum relative error.

**Under a captured CUDA graph** the margin holds and grows on the small shapes,
which is the configuration vLLM decodes in by default:

| shape | aiter | wvSplitK | gain |
|---|---|---|---|
| router | 2.67 | 3.78 | 29% |
| MLA gate | 3.94 | 5.89 | 33% |
| latent down | 7.88 | 8.09 | 3% |
| vocab head | 42.82 | 42.61 | 0% |

**Caveat for eager mode.** aiter's dispatch path costs about 11.8 us of host
time per call against 4.5 us for `ops.wvSplitK`, so with `enforce_eager` the
patched path is slower on everything except the largest shapes, where the kernel
runtime hides it. Under graph capture that cost is paid once, which is why the
graph numbers above are unaffected. Reducing it is being worked on in aiter
separately — re-parsing the tuned kernel name per launch has already been cached
away (4.4 us) — but it is host-side only and does not affect the kernel results
here.

**Shapes not covered.** These are decode shapes at M=1. `use_skinny_reduce_counting`
(10 <= n <= 128) is not reached at M=1 and is untouched.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>