### PR TITLE
[Bugfix][Core] Apply dense prefix cache default to hybrid models

### DIFF
--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -55,24 +55,27 @@ def test_prefix_caching_from_cli():
 
 
 @pytest.mark.parametrize(
-    ("has_inner_state", "use_eagle", "explicit", "expected"),
+    ("is_hybrid", "has_inner_state", "use_eagle", "explicit", "expected"),
     [
-        pytest.param(True, True, "unset", None, id="mamba-eagle-dense"),
-        pytest.param(True, True, 0, 0, id="mamba-eagle-explicit-zero"),
-        pytest.param(True, True, None, None, id="mamba-eagle-explicit-none"),
-        pytest.param(True, True, 64, 64, id="mamba-eagle-explicit-interval"),
-        pytest.param(True, False, "unset", 0, id="mamba-without-eagle"),
-        pytest.param(False, True, "unset", 0, id="eagle-without-mamba"),
-        pytest.param(False, False, "unset", 0, id="plain-model"),
+        pytest.param(True, False, True, "unset", None, id="hybrid-eagle-dense"),
+        pytest.param(True, True, True, "unset", None, id="hybrid-with-inner-state"),
+        pytest.param(True, False, True, 0, 0, id="hybrid-eagle-explicit-zero"),
+        pytest.param(True, False, True, None, None, id="hybrid-eagle-explicit-none"),
+        pytest.param(True, False, True, 64, 64, id="hybrid-eagle-explicit-interval"),
+        pytest.param(True, False, False, "unset", 0, id="hybrid-without-eagle"),
+        pytest.param(False, True, True, "unset", 0, id="non-hybrid-inner-state"),
+        pytest.param(False, False, True, "unset", 0, id="eagle-without-hybrid"),
+        pytest.param(False, False, False, "unset", 0, id="plain-model"),
     ],
 )
 def test_prefix_cache_retention_interval_default_resolution(
-    monkeypatch, has_inner_state, use_eagle, explicit, expected
+    monkeypatch, is_hybrid, has_inner_state, use_eagle, explicit, expected
 ):
-    """An unset ``prefix_cache_retention_interval`` resolves to dense (None)
-    for Mamba models with EAGLE-style speculative decoding — sparse retention
-    (0) leaves no reachable Mamba state checkpoints under EAGLE, so prefix
-    caching never hits — and to 0 otherwise. Explicit values are respected."""
+    """Default to dense for hybrid + EAGLE.
+
+    Non-hybrid defaults and explicit retention values must remain unchanged.
+    """
+    monkeypatch.setattr(ModelConfig, "is_hybrid", property(lambda self: is_hybrid))
     monkeypatch.setattr(
         ModelConfig, "has_inner_state", property(lambda self: has_inner_state)
     )

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2392,7 +2392,7 @@ class EngineArgs:
 
         if (
             retention_interval_unset
-            and model_config.has_inner_state
+            and model_config.is_hybrid
             and speculative_config is not None
             and speculative_config.use_eagle()
         ):
@@ -2402,7 +2402,7 @@ class EngineArgs:
             # to dense checkpoints instead.
             cache_config.prefix_cache_retention_interval = None
             logger.info_once(
-                "Mamba model with EAGLE speculative decoding: defaulting "
+                "Hybrid model with EAGLE speculative decoding: defaulting "
                 "prefix_cache_retention_interval to dense checkpointing."
             )
 


### PR DESCRIPTION
## Purpose

Qwen3.5 + MTP still defaults to sparse prefix-cache retention after #55760 because `Qwen3_5ForConditionalGeneration` declares `is_hybrid=True` but `has_inner_state=False`. The default-resolution branch is skipped, leaving `prefix_cache_retention_interval=0` and repeated prompts without cache hits in the reported run.

Use `model_config.is_hybrid` to select dense retention (`None`) for hybrid models with EAGLE-style speculative decoding, including MTP. Explicit retention values remain unchanged. Extend the existing parameterized test to cover hybrid models with either internal-state flag value and preserve non-hybrid defaults.

This is a follow-up to #55760 targeting `releases/v0.29.0`: that PR merged before the follow-up commit was included. Duplicate-work checks found no open PR for this default-resolution fix. Related #54713, #53479, and #45614 modify retention, scheduling, or cache lookup mechanics rather than this model-selection condition.

## Test Plan

```bash
.venv/bin/python -m pytest tests/config/test_config_utils.py tests/v1/engine/test_engine_args.py tests/engine/test_arg_utils.py -q
.venv/bin/python -m pytest tests/v1/core/test_prefix_caching.py -q -k 'retention or mamba or eagle'
.venv/bin/pre-commit run --files vllm/engine/arg_utils.py tests/v1/engine/test_engine_args.py
```

## Test Result

- Configuration and argument tests: **134 passed**.
- Prefix-cache tests: **35 passed, 57 deselected**.
- Pre-commit: passed.
- Actual CLI configuration resolution for `Qwen/Qwen3.5-4B` with MTP and 3 speculative tokens: `has_inner_state=False`, `is_hybrid=True`, `use_eagle=True`; resolved retention changes from `0` to `None` and the dense-default log is emitted.
- Submitter-provided serving smoke test with repeated 100K-token prompts: the logged aggregate prefix-cache hit rate increased from 0% before the fix to 49.5% after restarting with it. This is an aggregate metric, not a per-request measurement. No model accuracy evaluation was run.

The cherry-picked branch has an identical tracked tree to the tested commit.

AI assistance: OpenAI Codex was used to investigate, implement, and test this change.
