### PR TITLE
[Docs] Fix LoRA multilora example wording (offline, not async)

### DIFF
--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -47,7 +47,7 @@ the third parameter is the path to the LoRA adapter.
     )
     ```
 
-Check out [examples/features/lora/multilora_offline.py](../../examples/features/lora/multilora_offline.py) for an example of how to use LoRA adapters with the async engine and how to use more advanced configuration options.
+Check out [examples/features/lora/multilora_offline.py](../../examples/features/lora/multilora_offline.py) for an example of how to use LoRA adapters for offline inference and how to use more advanced configuration options.
 
 ## Serving LoRA Adapters
 


### PR DESCRIPTION
## Summary
`docs/features/lora.md` linked `examples/features/lora/multilora_offline.py` but described it as an **async engine** example. That script is offline inference using `LLMEngine` (sync); its module docstring says "for offline inference." There is no async LoRA example under `examples/features/lora/`.

## Change
- Wording only: "with the async engine" → "for offline inference"
- Link path unchanged

## Local repro
```bash
# 1) Docs claim (async)
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/features/lora.md \
  | rg -n "multilora_offline"
# → "... with the async engine ..."

# 2) Example is offline + LLMEngine (not AsyncLLMEngine)
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/lora/multilora_offline.py \
  | head -20
# docstring: "for offline inference."
# imports: EngineArgs, LLMEngine (no AsyncLLMEngine)

# 3) No async LoRA example in that directory
# only: multilora_offline.py, lora_with_quantization_offline.py
```

## Test plan
- [x] Confirmed docs line vs example docstring/`LLMEngine` import mismatch on main
- [x] Single-file docs wording fix; no code/CLI changes