### PR TITLE
[Bugfix][Core] Remove misleading Mamba prefix cache warning

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3361,21 +3361,6 @@ def test_draft_group_not_annotated_without_spec_decode():
     assert not any(g.is_eagle_group for g in groups)
 
 
-def test_unidentifiable_draft_with_mamba_warns(caplog_vllm):
-    # No group carries the draft marker, so every consumer falls back to
-    # flagging all groups -- including Mamba ones, which then can never report
-    # a hit. That is silent today; it must at least be visible.
-    groups = get_kv_cache_groups(
-        _spec_decode_grouping_config(), _hybrid_specs_with_draft(draft=False)
-    )
-
-    assert not any(g.is_eagle_group for g in groups)
-    assert "no KV cache group could be identified as the draft model's" in (
-        caplog_vllm.text
-    )
-    assert "Mamba groups" in caplog_vllm.text
-
-
 def test_no_warning_when_draft_group_is_identified(caplog_vllm):
     get_kv_cache_groups(
         _spec_decode_grouping_config(), _hybrid_specs_with_draft(draft=True)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1890,16 +1890,6 @@ def _warn_if_unannotated_eagle_mamba(
     ]
     if not mamba_groups:
         return
-    logger.warning(
-        "Speculative decoding (method=%s) is enabled but no KV cache group "
-        "could be identified as the draft model's, so every group -- "
-        "including Mamba groups %s -- will be treated as a draft group. A "
-        "Mamba group cannot satisfy the widened lookup window that implies, "
-        "so prefix-cache reuse across requests will be disabled and any "
-        "external KV offload tier will store without ever serving a hit.",
-        spec_config.method,
-        mamba_groups,
-    )
 
 
 def _largest_divisor_at_most(value: int, limit: int) -> int:


### PR DESCRIPTION
## Purpose

Remove the startup warning claiming that unidentified speculative draft groups necessarily disable prefix-cache reuse. Qwen3.5 + MTP can reuse cached prefixes with dense retention after #55760 and #55861, while this warning still fires. It incorrectly presents missing draft-group annotations as proof that all reuse is disabled.

see 

```
(APIServer pid=2576270) INFO 09-08 08:31:57 [loggers.py:310] Engine 000: Avg prompt throughput: 99.2 tokens/s, Avg generation throughput: 10.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 49.5%
(APIServer pid=2576270) INFO 09-08 08:31:57 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 2.91, Accepted throughput: 2.17 tokens/s, Drafted throughput: 3.40 tokens/s, Accepted: 65 tokens, Drafted: 102 tokens, Per-position acceptance rate: 0.794, 0.647, 0.471, Avg Draft acceptance rate: 63.7%
(APIServer pid=2576270) INFO 09-08 08:32:07 [loggers.py:310] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 49.5%
(APIServer pid=2576270) INFO:     127.0.0.1:46168 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=2576270) INFO 09-08 08:33:47 [loggers.py:310] Engine 000: Avg prompt throughput: 99.2 tokens/s, Avg generation throughput: 10.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 66.0%
(APIServer pid=2576270) INFO 09-08 08:33:47 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 2.91, Accepted throughput: 0.59 tokens/s, Drafted throughput: 0.93 tokens/s, Accepted: 65 tokens, Drafted: 102 tokens, Per-position acceptance rate: 0.794, 0.647, 0.471, Avg Draft acceptance rate: 63.7%
(APIServer pid=2576270) INFO 09-08 08:33:57 [loggers.py:310] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 66.0%
(APIServer pid=2576270) INFO:     127.0.0.1:55402 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=2576270) INFO 09-08 08:40:27 [loggers.py:310] Engine 000: Avg prompt throughput: 99.2 tokens/s, Avg generation throughput: 10.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 74.3%
(APIServer pid=2576270) INFO 09-08 08:40:27 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 2.91, Accepted throughput: 0.16 tokens/s, Drafted throughput: 0.25 tokens/s, Accepted: 65 tokens, Drafted: 102 tokens, Per-position acceptance rate: 0.794, 0.647, 0.471, Avg Draft acceptance rate: 63.7%
(APIServer pid=2576270) INFO 09-08 08:40:37 [loggers.py:310] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 74.3%
```

This release-branch change removes the `logger.warning(...)` call and the obsolete `test_unidentifiable_draft_with_mamba_warns` test.

Duplicate checks: #55519 targets `main` and suppresses the warning only when EAGLE block dropping is disabled; this warning also misreports the default MTP configuration on `releases/v0.29.0`. #55390 changes draft-group annotation rather than removing the misleading diagnostic.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py -q -k 'draft or no_warning_when'
```

Run the installed pre-commit hooks when committing.

## Test Result

- Focused tests: **6 passed, 87 deselected**.
- Commit hooks: passed, including Ruff and mypy.
- No model evaluation was run: this change removes a log call only.

AI assistance: OpenAI Codex was used to prepare and test this change.
