### PR TITLE
[WIP][Kernel] Enable GDN batch-invariant prefix caching

### DIFF
--- a/tests/v1/determinism/run_gdn_prefix_cache_bench.sh
+++ b/tests/v1/determinism/run_gdn_prefix_cache_bench.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# TTFT smoke: shared 2000-token prefix, BI=1, prefix cache on vs off.
+#
+# Start two servers yourself (or one at a time), then point BASE_URL here.
+#
+#   export VLLM_BATCH_INVARIANT=1
+#   export CUDA_VISIBLE_DEVICES=0,1
+#   vllm serve "$VLLM_GDN_PC_TEST_MODEL" \
+#     --tensor-parallel-size 2 \
+#     --max-model-len 3264 \
+#     --max-num-seqs 64 \
+#     --gpu-memory-utilization 0.95 \
+#     --trust-remote-code \
+#     --enable-prefix-caching \
+#     --port 8000
+#
+#   BASE_URL=http://127.0.0.1:8000 TAG=on \
+#     bash tests/v1/determinism/run_gdn_prefix_cache_bench.sh
+#
+# Repeat with --no-enable-prefix-caching and TAG=off.
+set -euo pipefail
+
+MODEL="${VLLM_GDN_PC_TEST_MODEL:?set VLLM_GDN_PC_TEST_MODEL to a GDN checkpoint}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:8000}"
+TAG="${TAG:-on}"
+RESULT_DIR="${RESULT_DIR:-./gdn_pc_bench_results}"
+mkdir -p "${RESULT_DIR}"
+
+bench_one() {
+  local conc="$1"
+  local nprompt="$2"
+  local rep="$3"
+  vllm bench serve \
+    --backend openai \
+    --base-url "${BASE_URL}" \
+    --model "${MODEL}" \
+    --endpoint /v1/completions \
+    --dataset-name prefix_repetition \
+    --prefix-repetition-prefix-len 2000 \
+    --prefix-repetition-suffix-len 0 \
+    --prefix-repetition-num-prefixes 1 \
+    --prefix-repetition-output-len 200 \
+    --num-prompts "${nprompt}" \
+    --max-concurrency "${conc}" \
+    --request-rate inf \
+    --percentile-metrics ttft,tpot,itl \
+    --save-result \
+    --result-dir "${RESULT_DIR}" \
+    --result-filename "bench_${TAG}_c${conc}_r${rep}.json"
+}
+
+echo "warmup TAG=${TAG} BASE_URL=${BASE_URL}"
+bench_one 1 4 warmup || true
+for REP in 1 2; do
+  bench_one 1 8 "${REP}"
+  bench_one 16 32 "${REP}"
+done

--- a/tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py
+++ b/tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GDN hybrid: VLLM_BATCH_INVARIANT=1 + prefix caching, same-path bitwise.
+
+Skipped in default CI. Needs a GDN checkpoint (Qwen3.5 / Qwen3-Next):
+
+    export VLLM_BATCH_INVARIANT=1
+    export VLLM_GDN_PC_TEST_MODEL=/path/to/Qwen3.5-35B-A3B
+    export VLLM_TP_SIZE=2
+    export VLLM_ENABLE_V1_MULTIPROCESSING=0
+    pytest tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py -s -v
+
+Same-path: both runs hit the same cached prefix (BS=1 vs mixed BS=N).
+Cold vs hit is logged only; bf16 SSM cache is not required to match.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+
+import pytest
+from utils import skip_if_not_cuda
+
+from vllm import LLM, SamplingParams
+
+MODEL = os.getenv("VLLM_GDN_PC_TEST_MODEL")
+
+pytestmark = [
+    skip_if_not_cuda,
+    pytest.mark.skipif(
+        not MODEL,
+        reason="Set VLLM_GDN_PC_TEST_MODEL to a Qwen3.5/Qwen3-Next GDN checkpoint",
+    ),
+    pytest.mark.timeout(1800),
+]
+
+
+def _extract(request_output):
+    out = request_output.outputs[0]
+    token_ids = list(out.token_ids)
+    step_logprobs = []
+    if not out.logprobs:
+        return token_ids, None
+    for step in out.logprobs:
+        chosen = token_ids[len(step_logprobs)]
+        lp = step.get(chosen)
+        if lp is None:
+            return token_ids, None
+        step_logprobs.append(float(lp.logprob))
+    return token_ids, step_logprobs
+
+
+def _words(rng: random.Random, n: int) -> str:
+    vocab = ["alpha", "beta", "gamma", "delta", "the", "of", "and", "to"]
+    return " ".join(rng.choice(vocab) for _ in range(n))
+
+
+def _prefix_of_n_tokens(tok, rng: random.Random, n_tokens: int, chunk: int) -> str:
+    text = _words(rng, max(chunk, n_tokens // 2))
+    while len(tok.encode(text)) < n_tokens:
+        text += " " + _words(rng, chunk)
+    return tok.decode(tok.encode(text)[:n_tokens])
+
+
+def _run_same_path(
+    llm: LLM,
+    tok,
+    rng: random.Random,
+    prefix_text: str,
+    label: str,
+    suffix: str,
+    sampling: SamplingParams,
+    warm_sp: SamplingParams,
+    batch_size: int,
+) -> None:
+    needle = prefix_text + suffix
+    needle_ids = tok.encode(needle)
+    prefix_ids = tok.encode(prefix_text)
+    print(
+        f"=== {label} prefix_tokens={len(prefix_ids)} "
+        f"needle_tokens={len(needle_ids)} ==="
+    )
+
+    llm.reset_prefix_cache()
+    cold = llm.generate([needle], sampling, use_tqdm=False)[0]
+    cold_tokens, cold_lps = _extract(cold)
+
+    llm.reset_prefix_cache()
+    llm.generate([{"prompt_token_ids": prefix_ids}], warm_sp, use_tqdm=False)
+    hit_bs1 = llm.generate([needle], sampling, use_tqdm=False)[0]
+    hit_bs1_tokens, hit_bs1_lps = _extract(hit_bs1)
+
+    llm.reset_prefix_cache()
+    llm.generate([{"prompt_token_ids": prefix_ids}], warm_sp, use_tqdm=False)
+    prompts = [_words(rng, 24) + suffix for _ in range(batch_size)]
+    pos = rng.randrange(batch_size)
+    prompts[pos] = needle
+    outs = llm.generate(prompts, sampling, use_tqdm=False)
+    hit_bsn_tokens, hit_bsn_lps = _extract(outs[pos])
+
+    print(f"cold tokens={cold_tokens}")
+    print(f"hit_bs1 tokens={hit_bs1_tokens}")
+    print(f"hit_bsN tokens={hit_bsn_tokens}")
+
+    assert hit_bs1_tokens == hit_bsn_tokens and hit_bs1_lps == hit_bsn_lps, (
+        f"{label}: same-path hit BS=1 vs BS=N mismatch"
+    )
+    print(f"PASS {label}: same-path hit BS=1 vs BS=N bitwise")
+
+    if cold_tokens == hit_bs1_tokens and cold_lps == hit_bs1_lps:
+        print(f"INFO {label}: cold vs hit also bitwise (fp32-cache-like)")
+    else:
+        print(
+            f"INFO {label}: cold vs hit diverged "
+            "(expected with default bf16 SSM cache)"
+        )
+
+
+def test_gdn_prefix_cache_same_path_bitwise(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+    model = MODEL
+    assert model is not None
+    tp = int(os.getenv("VLLM_TP_SIZE", "2"))
+    seed = int(os.getenv("VLLM_TEST_SEED", "12345"))
+    batch_size = int(os.getenv("VLLM_NEEDLE_BATCH_SIZE", "4"))
+    max_tokens = int(os.getenv("VLLM_NEEDLE_MAX_TOKENS", "8"))
+    gpu_mem = float(os.getenv("VLLM_GPU_MEMORY_UTILIZATION", "0.90"))
+    max_model_len = int(os.getenv("VLLM_MAX_MODEL_LEN", "4096"))
+
+    print(
+        f"model={model} tp={tp} "
+        f"VLLM_BATCH_INVARIANT={os.environ.get('VLLM_BATCH_INVARIANT')}"
+    )
+
+    llm = LLM(
+        model=model,
+        tensor_parallel_size=tp,
+        max_model_len=max_model_len,
+        max_num_seqs=max(batch_size, 8),
+        gpu_memory_utilization=gpu_mem,
+        dtype="bfloat16",
+        trust_remote_code=True,
+        enable_prefix_caching=True,
+        enforce_eager=os.getenv("VLLM_ENFORCE_EAGER", "0") == "1",
+    )
+    print("SMOKE: engine started with prefix caching + BI")
+
+    sampling = SamplingParams(
+        temperature=0.0,
+        max_tokens=max_tokens,
+        logprobs=5,
+        seed=seed,
+    )
+    warm_sp = SamplingParams(temperature=0.0, max_tokens=1, seed=seed)
+    tok = llm.get_tokenizer()
+    rng = random.Random(seed)
+    suffix = " Explain batch invariance in one sentence."
+
+    _run_same_path(
+        llm,
+        tok,
+        rng,
+        _prefix_of_n_tokens(tok, rng, 1100, 32),
+        "prefix-1100",
+        suffix,
+        sampling,
+        warm_sp,
+        batch_size,
+    )
+    _run_same_path(
+        llm,
+        tok,
+        rng,
+        _prefix_of_n_tokens(tok, rng, 200, 8),
+        "ragged-200",
+        suffix,
+        sampling,
+        warm_sp,
+        batch_size,
+    )
+    print("RESULT: PASS")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-s", "-v"]))

--- a/tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py
+++ b/tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py
@@ -39,7 +39,7 @@ pytestmark = [
 def _extract(request_output):
     out = request_output.outputs[0]
     token_ids = list(out.token_ids)
-    step_logprobs = []
+    step_logprobs: list[float] = []
     if not out.logprobs:
         return token_ids, None
     for step in out.logprobs:
@@ -111,10 +111,9 @@ def _run_same_path(
     if cold_tokens == hit_bs1_tokens and cold_lps == hit_bs1_lps:
         print(f"INFO {label}: cold vs hit also bitwise (fp32-cache-like)")
     else:
-        print(
-            f"INFO {label}: cold vs hit diverged "
-            "(expected with default bf16 SSM cache)"
-        )
+            print(
+                f"INFO {label}: cold vs hit diverged (expected with default bf16 SSM cache)"
+            )
 
 
 def test_gdn_prefix_cache_same_path_bitwise(monkeypatch: pytest.MonkeyPatch):

--- a/tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py
+++ b/tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py
@@ -111,9 +111,9 @@ def _run_same_path(
     if cold_tokens == hit_bs1_tokens and cold_lps == hit_bs1_lps:
         print(f"INFO {label}: cold vs hit also bitwise (fp32-cache-like)")
     else:
-            print(
-                f"INFO {label}: cold vs hit diverged (expected with default bf16 SSM cache)"
-            )
+        print(
+            f"INFO {label}: cold vs hit diverged (expected with default bf16 SSM cache)"
+        )
 
 
 def test_gdn_prefix_cache_same_path_bitwise(monkeypatch: pytest.MonkeyPatch):

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -986,6 +986,9 @@ class CompilationConfig:
             and "benchmark_combo_kernel" not in self.inductor_compile_config
             # (fixme @boyuan) combo kernel does not support cpu yet.
             and not current_platform.is_cpu()
+            # Timed combo-kernel selection depends on batch shape and is not
+            # batch-invariant (finetunej / vllm#49827).
+            and not envs.VLLM_BATCH_INVARIANT
         ):
             # use horizontal fusion, which is useful for fusing qk-norm and
             # qk-rope when query and key have different shapes.

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -313,6 +313,12 @@ class RMSNormGated(CustomOp):
     def forward_cuda(
         self, x: torch.Tensor, z: torch.Tensor | None = None
     ) -> torch.Tensor:
+        if envs.VLLM_BATCH_INVARIANT:
+            # rmsnorm_fn uses calc_rows_per_block which selects ROWS_PER_BLOCK
+            # based on M. Different M values compile different Triton binaries
+            # with different FP reduction orders, breaking batch invariance.
+            # Fall back to the native PyTorch path which is row-independent.
+            return self.forward_native(x, z)
         from vllm.third_party.flash_linear_attention.ops.layernorm_guard import (
             rmsnorm_fn,
         )

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1423,6 +1423,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             # - "cache_indices" updates the conv_state cache in positions
             #   pointed to by "state_indices_tensor"
             if envs.VLLM_BATCH_INVARIANT:
+                assert non_spec_query_start_loc is not None
+                assert non_spec_state_indices_tensor is not None
                 device = mixed_qkv_non_spec_T.device
                 cu_list = non_spec_query_start_loc.tolist()
                 num_non_spec_seqs = non_spec_query_start_loc.numel() - 1
@@ -1437,9 +1439,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                         else None
                     )
                     _cache_idx = non_spec_state_indices_tensor[_pi : _pi + 1]
-                    _cu = torch.tensor(
-                        [0, _pe - _ps], dtype=torch.int32, device=device
-                    )
+                    _cu = torch.tensor([0, _pe - _ps], dtype=torch.int32, device=device)
                     _conv_out = causal_conv1d_fn(
                         _chunk_T,
                         conv_weights,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -57,6 +57,10 @@ from vllm.third_party.flash_linear_attention.ops import (
     fused_sigmoid_gating_delta_rule_update,
 )
 from vllm.third_party.flash_linear_attention.ops.chunk import l2norm_fwd
+from vllm.third_party.flash_linear_attention.ops.index import (
+    prepare_chunk_indices,
+    prepare_chunk_offsets,
+)
 from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.triton_utils import tl, triton
@@ -218,6 +222,9 @@ def fi_chunk_gated_delta_rule(
         initial_state=fi_state,
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
+        # "auto" selects a kernel from the batch shape. Pin one implementation
+        # so a sequence follows the same numeric path in every BIC batch.
+        use_cp=False if envs.VLLM_BATCH_INVARIANT else "auto",
     )
     # FlashInfer returns (output, state) when output_final_state=True,
     # or just output when output_final_state=False.
@@ -790,6 +797,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         return mixed_qkv_out, z_out, b_out, a_out
 
+    def _bi_cu01(self, device: torch.device) -> torch.Tensor:
+        """Cached [0, 1] cu_seqlens for per-sequence decode under
+        VLLM_BATCH_INVARIANT. Building this with torch.tensor() inside the
+        decode loop is an H2D copy from pageable memory, which CUDA graph
+        capture rejects.
+        """
+        t = getattr(self, "_bi_cu01_cache", None)
+        if t is None or t.device != device:
+            t = torch.tensor([0, 1], dtype=torch.int32, device=device)
+            self._bi_cu01_cache = t
+        return t
+
     def rearrange_mixed_qkv(self, mixed_qkv):
         """Split packed qkv into contiguous (1, seq, heads, dim) tensors.
 
@@ -901,11 +920,46 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        # When VLLM_BATCH_INVARIANT: project each request independently so the
+        # GEMM M dimension is identical to the BS=1 case.
+        _bi_cu: list[int] | None = None
+        if envs.VLLM_BATCH_INVARIANT and num_tokens > 1:
+            _fc = get_forward_context()
+            _attn_raw = _fc.attn_metadata
+            if isinstance(_attn_raw, dict) and self.prefix in _attn_raw:
+                _meta = _attn_raw[self.prefix]
+                if isinstance(_meta, GDNAttentionMetadata):
+                    if _meta.num_spec_decodes > 0:
+                        raise RuntimeError(
+                            "VLLM_BATCH_INVARIANT is not supported with "
+                            "speculative decoding on GDN_ATTN."
+                        )
+                    if _meta.num_prefills == 0:
+                        _bi_cu = list(range(num_tokens + 1))
+                    elif _meta.non_spec_query_start_loc is not None:
+                        _bi_cu = _meta.non_spec_query_start_loc.tolist()
+        if _bi_cu is not None:
+            mixed_qkvz = torch.cat(
+                [
+                    self.in_proj_qkvz(hidden_states[_bi_cu[i] : _bi_cu[i + 1]])[0]
+                    for i in range(len(_bi_cu) - 1)
+                ],
+                dim=0,
+            )
+            ba = torch.cat(
+                [
+                    self.in_proj_ba(hidden_states[_bi_cu[i] : _bi_cu[i + 1]])[0]
+                    for i in range(len(_bi_cu) - 1)
+                ],
+                dim=0,
+            )
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
 
         use_fused_gdn_decode = (
             self.enable_fused_gdn_decode
+            and not envs.VLLM_BATCH_INVARIANT
             and hidden_states.dtype == torch.bfloat16
             and self.norm.weight.dtype in (torch.bfloat16, torch.float32)
         )
@@ -1286,6 +1340,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         if (
             self.enable_packed_recurrent_decode
+            and not envs.VLLM_BATCH_INVARIANT  # per-seq loop required for BI
             and attn_metadata.spec_sequence_masks is None
             and attn_metadata.num_prefills == 0
             and attn_metadata.num_decodes > 0
@@ -1367,17 +1422,48 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
             # - "cache_indices" updates the conv_state cache in positions
             #   pointed to by "state_indices_tensor"
-            mixed_qkv_non_spec = causal_conv1d_fn(
-                mixed_qkv_non_spec_T,
-                conv_weights,
-                self.conv1d.bias,
-                activation=self.activation,
-                conv_states=conv_state,
-                has_initial_state=has_initial_state,
-                cache_indices=non_spec_state_indices_tensor,
-                query_start_loc=non_spec_query_start_loc,
-                metadata=attn_metadata,
-            ).transpose(0, 1)
+            if envs.VLLM_BATCH_INVARIANT:
+                device = mixed_qkv_non_spec_T.device
+                cu_list = non_spec_query_start_loc.tolist()
+                num_non_spec_seqs = non_spec_query_start_loc.numel() - 1
+                chunks = []
+                for _pi in range(num_non_spec_seqs):
+                    _ps = cu_list[_pi]
+                    _pe = cu_list[_pi + 1]
+                    _chunk_T = mixed_qkv_non_spec_T[:, _ps:_pe]
+                    _has_init = (
+                        has_initial_state[_pi : _pi + 1]
+                        if has_initial_state is not None
+                        else None
+                    )
+                    _cache_idx = non_spec_state_indices_tensor[_pi : _pi + 1]
+                    _cu = torch.tensor(
+                        [0, _pe - _ps], dtype=torch.int32, device=device
+                    )
+                    _conv_out = causal_conv1d_fn(
+                        _chunk_T,
+                        conv_weights,
+                        self.conv1d.bias,
+                        activation=self.activation,
+                        conv_states=conv_state,
+                        has_initial_state=_has_init,
+                        cache_indices=_cache_idx,
+                        query_start_loc=_cu,
+                    ).transpose(0, 1)
+                    chunks.append(_conv_out)
+                mixed_qkv_non_spec = torch.cat(chunks, dim=0)
+            else:
+                mixed_qkv_non_spec = causal_conv1d_fn(
+                    mixed_qkv_non_spec_T,
+                    conv_weights,
+                    self.conv1d.bias,
+                    activation=self.activation,
+                    conv_states=conv_state,
+                    has_initial_state=has_initial_state,
+                    cache_indices=non_spec_state_indices_tensor,
+                    query_start_loc=non_spec_query_start_loc,
+                    metadata=attn_metadata,
+                ).transpose(0, 1)
         elif attn_metadata.num_decodes > 0:
             assert mixed_qkv_non_spec is not None
             mixed_qkv_non_spec = causal_conv1d_update(
@@ -1486,22 +1572,45 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(
                 mixed_qkv_non_spec[:num_decode_tokens]  # type: ignore[index]
             )
-            core_attn_out_decode, _ = fused_sigmoid_gating_delta_rule_update(
-                A_log=self.A_log,
-                a=a[:num_decode_tokens],
-                b=b[:num_decode_tokens],
-                dt_bias=self.dt_bias,
-                q=query_decode,
-                k=key_decode,
-                v=value_decode,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
-                    : attn_metadata.num_decodes + 1
-                ],
-                ssm_state_indices=non_spec_state_indices_tensor,
-                use_qk_l2norm_in_kernel=True,
-            )
+            if envs.VLLM_BATCH_INVARIANT:
+                assert non_spec_state_indices_tensor is not None
+                device_sd = query_decode.device
+                sd_outputs: list[torch.Tensor] = []
+                for _i in range(attn_metadata.num_decodes):
+                    _si_sd = non_spec_state_indices_tensor[_i : _i + 1]
+                    o_sd, _ = fused_sigmoid_gating_delta_rule_update(
+                        A_log=self.A_log,
+                        a=a[_i : _i + 1],
+                        b=b[_i : _i + 1],
+                        dt_bias=self.dt_bias,
+                        q=query_decode[:, _i : _i + 1],
+                        k=key_decode[:, _i : _i + 1],
+                        v=value_decode[:, _i : _i + 1],
+                        initial_state=ssm_state,
+                        inplace_final_state=True,
+                        cu_seqlens=self._bi_cu01(device_sd),
+                        ssm_state_indices=_si_sd,
+                        use_qk_l2norm_in_kernel=True,
+                    )
+                    sd_outputs.append(o_sd)
+                core_attn_out_decode = torch.cat(sd_outputs, dim=1)
+            else:
+                core_attn_out_decode, _ = fused_sigmoid_gating_delta_rule_update(
+                    A_log=self.A_log,
+                    a=a[:num_decode_tokens],
+                    b=b[:num_decode_tokens],
+                    dt_bias=self.dt_bias,
+                    q=query_decode,
+                    k=key_decode,
+                    v=value_decode,
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
+                        : attn_metadata.num_decodes + 1
+                    ],
+                    ssm_state_indices=non_spec_state_indices_tensor,
+                    use_qk_l2norm_in_kernel=True,
+                )
         else:
             core_attn_out_decode = None
 
@@ -1517,22 +1626,55 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             assert prefill_has_initial_state is not None
             initial_state = ssm_state[prefill_state_indices]
             initial_state[~prefill_has_initial_state, ...] = 0
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = self.chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
-                g=g_non_spec,
-                beta=beta_non_spec,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=attn_metadata.prefill_query_start_loc,
-                chunk_indices=attn_metadata.chunk_indices,
-                chunk_offsets=attn_metadata.chunk_offsets,
-                use_qk_l2norm_in_kernel=False,
-            )
+            if envs.VLLM_BATCH_INVARIANT:
+                assert attn_metadata.prefill_query_start_loc is not None
+                cu_seqlens_list = attn_metadata.prefill_query_start_loc.tolist()
+                device = query_non_spec.device
+                outputs: list[torch.Tensor] = []
+                last_states: list[torch.Tensor] = []
+                for i in range(attn_metadata.num_prefills):
+                    start = cu_seqlens_list[i]
+                    end = cu_seqlens_list[i + 1]
+                    seq_len = end - start
+                    cu_seq_i_cpu = torch.tensor([0, seq_len], dtype=torch.int32)
+                    out_i, state_i = self.chunk_gated_delta_rule(
+                        q=query_non_spec[:, start:end],
+                        k=key_non_spec[:, start:end],
+                        v=value_non_spec[:, start:end],
+                        g=g_non_spec[:, start:end],
+                        beta=beta_non_spec[:, start:end],
+                        initial_state=initial_state[i : i + 1],
+                        output_final_state=True,
+                        cu_seqlens=cu_seq_i_cpu.to(device),
+                        chunk_indices=prepare_chunk_indices(
+                            cu_seq_i_cpu, FLA_CHUNK_SIZE
+                        ).to(device),
+                        chunk_offsets=prepare_chunk_offsets(
+                            cu_seq_i_cpu, FLA_CHUNK_SIZE
+                        ).to(device),
+                        use_qk_l2norm_in_kernel=False,
+                    )
+                    outputs.append(out_i)
+                    last_states.append(state_i)
+                core_attn_out_non_spec = torch.cat(outputs, dim=1)
+                last_recurrent_state = torch.cat(last_states, dim=0)
+            else:
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = self.chunk_gated_delta_rule(
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    g=g_non_spec,
+                    beta=beta_non_spec,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    cu_seqlens=attn_metadata.prefill_query_start_loc,
+                    chunk_indices=attn_metadata.chunk_indices,
+                    chunk_offsets=attn_metadata.chunk_offsets,
+                    use_qk_l2norm_in_kernel=False,
+                )
             # Init cache
             ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
 
@@ -1543,25 +1685,49 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     [core_attn_out_decode, core_attn_out_non_spec], dim=1
                 )
         elif attn_metadata.num_decodes > 0:
-            core_attn_out_non_spec, last_recurrent_state = (
-                fused_sigmoid_gating_delta_rule_update(
-                    A_log=self.A_log,
-                    a=a,
-                    b=b,
-                    dt_bias=self.dt_bias,
-                    q=query_non_spec,
-                    k=key_non_spec,
-                    v=value_non_spec,
-                    initial_state=ssm_state,
-                    inplace_final_state=True,
-                    cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
-                        : attn_metadata.num_decodes
-                        + 1  # type: ignore[attr-defined]
-                    ],
-                    ssm_state_indices=non_spec_state_indices_tensor,
-                    use_qk_l2norm_in_kernel=True,
+            if envs.VLLM_BATCH_INVARIANT:
+                assert non_spec_state_indices_tensor is not None
+                device = query_non_spec.device
+                dec_outputs: list[torch.Tensor] = []
+                for _i in range(attn_metadata.num_decodes):
+                    _si_dec = non_spec_state_indices_tensor[_i : _i + 1]
+                    out_i, _ = fused_sigmoid_gating_delta_rule_update(
+                        A_log=self.A_log,
+                        a=a[_i : _i + 1],
+                        b=b[_i : _i + 1],
+                        dt_bias=self.dt_bias,
+                        q=query_non_spec[:, _i : _i + 1],
+                        k=key_non_spec[:, _i : _i + 1],
+                        v=value_non_spec[:, _i : _i + 1],
+                        initial_state=ssm_state,
+                        inplace_final_state=True,
+                        cu_seqlens=self._bi_cu01(device),
+                        ssm_state_indices=_si_dec,
+                        use_qk_l2norm_in_kernel=True,
+                    )
+                    dec_outputs.append(out_i)
+                core_attn_out_non_spec = torch.cat(dec_outputs, dim=1)
+                last_recurrent_state = None
+            else:
+                core_attn_out_non_spec, last_recurrent_state = (
+                    fused_sigmoid_gating_delta_rule_update(
+                        A_log=self.A_log,
+                        a=a,
+                        b=b,
+                        dt_bias=self.dt_bias,
+                        q=query_non_spec,
+                        k=key_non_spec,
+                        v=value_non_spec,
+                        initial_state=ssm_state,
+                        inplace_final_state=True,
+                        cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
+                            : attn_metadata.num_decodes
+                            + 1  # type: ignore[attr-defined]
+                        ],
+                        ssm_state_indices=non_spec_state_indices_tensor,
+                        use_qk_l2norm_in_kernel=True,
+                    )
                 )
-            )
         else:
             core_attn_out_non_spec, last_recurrent_state = None, None
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import torch
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -938,6 +939,25 @@ class Platform:
 
         if cache_config.mamba_cache_mode == "align":
             cache_config.mamba_block_size = cache_config.block_size
+
+        # Under BI, FLA chunks on 64. If hybrid page alignment picked a
+        # block_size not divisible by 64, lcm(64, block) becomes 2*block
+        # (e.g. 1056 → 2112) and short prefixes never hit. Round up so the
+        # align grid itself is a 64-multiple (1056 → 1088, lcm=1088).
+        if envs.VLLM_BATCH_INVARIANT and cache_config.mamba_cache_mode == "align":
+            fla_chunk = 64  # FLA_CHUNK_SIZE
+            bs = cache_config.block_size
+            rounded = ((bs + fla_chunk - 1) // fla_chunk) * fla_chunk
+            if rounded != bs:
+                cache_config.block_size = rounded
+                cache_config.mamba_block_size = rounded
+                logger.info(
+                    "Raised hybrid block_size from %d to %d so it is a "
+                    "multiple of FLA chunk size %d under batch invariance.",
+                    bs,
+                    rounded,
+                    fla_chunk,
+                )
 
         # Pad mamba page size to exactly match attention page size
         attn_page_size = cache_config.block_size * attn_page_size_1_token

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -201,6 +201,11 @@ class AttentionBackend(ABC):
         return False
 
     @classmethod
+    def get_batch_invariant_prefill_chunk_size(cls) -> int | None:
+        """Return the canonical prefill partition required for BIC."""
+        return None
+
+    @classmethod
     def supports_kv_connector(cls) -> bool:
         return True
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -8,6 +8,7 @@ from typing import Literal
 import torch
 
 from vllm.config import VllmConfig
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -36,6 +37,20 @@ class GDNAttentionBackend(AttentionBackend):
     @classmethod
     def is_ssm(cls) -> bool:
         return True
+
+    @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        # Validated for NVIDIA CUDA (SM80+ Triton, SM90+ FlashInfer).
+        # ROCm AITER and XPU paths still use batch-shaped projections
+        # and the fused norm kernel, which are not batch-invariant.
+        # Inline import: vllm.platforms imports attention backends.
+        from vllm.platforms import current_platform
+
+        return current_platform.is_cuda() and current_platform.has_device_capability(80)
+
+    @classmethod
+    def get_batch_invariant_prefill_chunk_size(cls) -> int:
+        return FLA_CHUNK_SIZE
 
 
 @dataclass

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, overload
 
+import vllm.envs as envs
 from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
@@ -172,6 +173,9 @@ class KVCacheManager:
         # admitting waiting/preempted requests, to avoid frequent preemptions.
         assert watermark >= 0.0, "watermark must be non-negative"
         self.watermark_blocks = int(watermark * kv_cache_config.num_blocks)
+        # Set by the scheduler after combining FLA chunk size with mamba
+        # block size. 0 disables canonical hit truncation.
+        self.batch_invariant_hit_alignment = 0
         self.kv_cache_event_metadata = tuple(
             (
                 get_kv_cache_spec_kind(group.kv_cache_spec).value,
@@ -261,6 +265,25 @@ class KVCacheManager:
                 request.block_hashes, max_cache_hit_length
             )
         )
+
+        chunk = self.batch_invariant_hit_alignment
+        if (
+            envs.VLLM_BATCH_INVARIANT
+            and chunk > 1
+            and 0 < num_new_computed_tokens < request.num_tokens - 1
+        ):
+            canonical_tokens = num_new_computed_tokens // chunk * chunk
+            if canonical_tokens != num_new_computed_tokens:
+                tmp_blocks = self.create_kv_cache_blocks(computed_blocks)
+                if canonical_tokens == 0:
+                    computed_blocks = tuple([] for _ in range(len(computed_blocks)))
+                    num_new_computed_tokens = 0
+                else:
+                    tmp_blocks = self.truncate_computed_blocks(
+                        tmp_blocks, canonical_tokens
+                    )
+                    computed_blocks = tuple(list(g) for g in tmp_blocks.blocks)
+                    num_new_computed_tokens = canonical_tokens
 
         # When kv_cache_report_mode is "full", emit BlockStored events
         # for the reused prefix cache blocks so that external consumers

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -342,6 +343,19 @@ class Scheduler(SchedulerInterface):
         )
         needs_mamba_cache_alignment = self.need_mamba_block_aligned_split
         self.needs_mamba_cache_alignment = needs_mamba_cache_alignment
+        mamba_block_sizes = {
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        }
+        if len(mamba_block_sizes) > 1:
+            raise ValueError(
+                "All Mamba cache groups must use the same block size for "
+                "batch-invariant prefix-cache alignment."
+            )
+        self.mamba_state_block_size = next(
+            iter(mamba_block_sizes), self.cache_config.block_size
+        )
         batch_invariant_prefill_chunk_sizes: set[int] = set()
         if envs.VLLM_BATCH_INVARIANT:
             for group in kv_cache_config.kv_cache_groups:
@@ -363,9 +377,11 @@ class Scheduler(SchedulerInterface):
             )
             if batch_invariant_prefill_chunk_size is not None:
                 if needs_mamba_cache_alignment:
-                    raise NotImplementedError(
-                        "Batch-invariant recurrent prefill does not yet "
-                        "support Mamba cache alignment."
+                    # One grid for FLA chunk partitions and align-mode state
+                    # saves (PR #46592 architecture; GDN uses FLA_CHUNK_SIZE).
+                    batch_invariant_prefill_chunk_size = math.lcm(
+                        batch_invariant_prefill_chunk_size,
+                        self.mamba_state_block_size,
                     )
                 if self.max_num_scheduled_tokens < batch_invariant_prefill_chunk_size:
                     raise ValueError(
@@ -386,8 +402,24 @@ class Scheduler(SchedulerInterface):
             batch_invariant_prefill_chunk_size = None
 
         self.mamba_prefill_alignment = batch_invariant_prefill_chunk_size or (
-            self.cache_config.block_size if needs_mamba_cache_alignment else 1
+            self.mamba_state_block_size if needs_mamba_cache_alignment else 1
         )
+        self.kv_cache_manager.batch_invariant_hit_alignment = (
+            self.mamba_prefill_alignment
+            if (
+                envs.VLLM_BATCH_INVARIANT
+                and needs_mamba_cache_alignment
+                and batch_invariant_prefill_chunk_size is not None
+            )
+            else 0
+        )
+        if self.kv_cache_manager.batch_invariant_hit_alignment:
+            logger.info(
+                "Batch-invariant prefix caching: prefill/hit alignment=%s "
+                "(FLA chunk lcm mamba_state_block_size=%s)",
+                self.mamba_prefill_alignment,
+                self.mamba_state_block_size,
+            )
         if self.mamba_prefill_alignment > 1:
             self.need_mamba_block_aligned_split = True
         # TODO: Support models with multiple Mamba specs that require different

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -378,7 +378,7 @@ class Scheduler(SchedulerInterface):
             if batch_invariant_prefill_chunk_size is not None:
                 if needs_mamba_cache_alignment:
                     # One grid for FLA chunk partitions and align-mode state
-                    # saves (PR #46592 architecture; GDN uses FLA_CHUNK_SIZE).
+                    # saves. GDN uses FLA_CHUNK_SIZE.
                     batch_invariant_prefill_chunk_size = math.lcm(
                         batch_invariant_prefill_chunk_size,
                         self.mamba_state_block_size,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any
 
+import vllm.envs as envs
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import KVEventsConfig, VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (
@@ -339,6 +340,56 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        needs_mamba_cache_alignment = self.need_mamba_block_aligned_split
+        self.needs_mamba_cache_alignment = needs_mamba_cache_alignment
+        batch_invariant_prefill_chunk_sizes: set[int] = set()
+        if envs.VLLM_BATCH_INVARIANT:
+            for group in kv_cache_config.kv_cache_groups:
+                spec = group.kv_cache_spec
+                if not isinstance(spec, MambaSpec):
+                    continue
+                chunk_size = (
+                    spec.mamba_type.get_class().get_batch_invariant_prefill_chunk_size()
+                )
+                if chunk_size is not None:
+                    batch_invariant_prefill_chunk_sizes.add(chunk_size)
+            if len(batch_invariant_prefill_chunk_sizes) > 1:
+                raise ValueError(
+                    "All recurrent backends must use the same batch-invariant "
+                    "prefill chunk size."
+                )
+            batch_invariant_prefill_chunk_size = next(
+                iter(batch_invariant_prefill_chunk_sizes), None
+            )
+            if batch_invariant_prefill_chunk_size is not None:
+                if needs_mamba_cache_alignment:
+                    raise NotImplementedError(
+                        "Batch-invariant recurrent prefill does not yet "
+                        "support Mamba cache alignment."
+                    )
+                if self.max_num_scheduled_tokens < batch_invariant_prefill_chunk_size:
+                    raise ValueError(
+                        "The effective scheduler token budget must be at least the "
+                        "batch-invariant prefill chunk size "
+                        f"({batch_invariant_prefill_chunk_size})."
+                    )
+                long_prefill_threshold = (
+                    self.scheduler_config.long_prefill_token_threshold
+                )
+                if 0 < long_prefill_threshold < batch_invariant_prefill_chunk_size:
+                    raise ValueError(
+                        "long_prefill_token_threshold must be zero or at least the "
+                        "batch-invariant prefill chunk size "
+                        f"({batch_invariant_prefill_chunk_size})."
+                    )
+        else:
+            batch_invariant_prefill_chunk_size = None
+
+        self.mamba_prefill_alignment = batch_invariant_prefill_chunk_size or (
+            self.cache_config.block_size if needs_mamba_cache_alignment else 1
+        )
+        if self.mamba_prefill_alignment > 1:
+            self.need_mamba_block_aligned_split = True
         # TODO: Support models with multiple Mamba specs that require different
         # prefill checkpoint alignments instead of selecting the first one.
         self.mamba_prefill_checkpoint_alignment = next(
@@ -427,7 +478,11 @@ class Scheduler(SchedulerInterface):
         if start >= prefill_end:
             return num_new_tokens
 
-        block_size = self.cache_config.block_size
+        block_size = (
+            self.mamba_prefill_alignment
+            if envs.VLLM_BATCH_INVARIANT and self.mamba_prefill_alignment > 1
+            else self.cache_config.block_size
+        )
         # The last block-aligned position whose state can be cached. With
         # Eagle, FullAttn prunes the last matching block, so back off one
         # block to avoid a Mamba cache miss.


### PR DESCRIPTION
## Purpose

Enable `VLLM_BATCH_INVARIANT=1` together with prefix caching on Qwen GDN hybrid models.

Today this fails at scheduler init (`NotImplementedError: ... does not yet support Mamba cache alignment`) because prefix cache puts GDN into mamba `align` mode while BIC needs a 64-token FLA grid.

This PR:

- Uses one shared grid `lcm(FLA_CHUNK_SIZE=64, mamba_state_block_size)` for prefill chunks and prefix-cache hits (hits are floored onto the grid; a full-prompt hit is not).
- Rounds hybrid `block_size` up to a multiple of 64 (1056 → 1088) so the grid stays usable for short prefixes.
- Temporarily includes GDN BIC from #49827 / #45819 so CI can run while those PRs are still open. Drop that commit when they land. 

Related: #49827, #45819, #48613, #42960.

## Test Plan

Set `VLLM_GDN_PC_TEST_MODEL` to a GDN checkpoint (e.g. Qwen3.5-35B-A3B). Tests skip without it.

```bash
export VLLM_BATCH_INVARIANT=1
export VLLM_GDN_PC_TEST_MODEL=/path/to/Qwen3.5-35B-A3B
export VLLM_TP_SIZE=2
export VLLM_ENABLE_V1_MULTIPROCESSING=0
pytest tests/v1/determinism/test_gdn_prefix_cache_batch_invariant.py -s -v
```

TTFT (start `vllm serve` with BI=1, then PC on / off):

```bash
BASE_URL=http://127.0.0.1:8000 TAG=on \
  bash tests/v1/determinism/run_gdn_prefix_cache_bench.sh
```

Hardware for the numbers below: 2× L20, TP=2, Qwen3.5-35B-A3B, `vllm-openai:v0.28.0` overlay with the same changes.

## Test Result

**Before:** engine does not start (`NotImplementedError` above).

**After (bitwise):** engine starts, `block_size` 1056 → 1088, alignment=1088. Same-path hit BS=1 vs BS=N is bitwise identical (`prefix-1100` real hit; `ragged-200` floors to 0). `RESULT: PASS`.

**After (TTFT, shared 2000-token prefix, BI=1):**


| prefix cache | c   | mean TTFT (ms) | median TTFT (ms) | mean TPOT (ms) |
| ------------ | --- | -------------- | ---------------- | -------------- |
| off          | 1   | 261            | 262              | 18.7           |
| on           | 1   | 210            | 203              | 18.5           |
| off          | 16  | 2154           | 2020             | 145.8          |
| on           | 16  | 1670           | 1469             | 153.3          |


c=1 TTFT **−19%**, c=16 median TTFT **−27%**. TPOT unchanged. 2000 tokens only skip the first 1088-token page, so this is not decode-only TTFT.
