### PR TITLE
Fix HashableDict/HashableList nested values crashing lru_cache

### DIFF
--- a/tests/transformers_utils/test_processor.py
+++ b/tests/transformers_utils/test_processor.py
@@ -2,11 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import importlib
+from functools import lru_cache
 
 from transformers.processing_utils import ProcessingKwargs
 from typing_extensions import Unpack
 
 from vllm.transformers_utils.processor import (
+    HashableDict,
+    HashableList,
     get_processor_kwargs_keys,
     get_processor_kwargs_type,
 )
@@ -65,3 +68,32 @@ def test_get_processor_kwargs_from_processor_module_scan_returns_full_union():
     proc = _ProcWithoutUnpack()
     keys = get_processor_kwargs_keys(get_processor_kwargs_type(proc))  # type: ignore[arg-type]
     _assert_has_all_expected(keys)
+
+
+def test_hashable_dict_handles_nested_values():
+    # Regression for unhashable nested dict/list values fed to lru_cache.
+    nested = HashableDict({"images_kwargs": {"num_buckets": 4}, "tags": ["a", "b"]})
+    assert hash(nested) == hash(
+        HashableDict({"images_kwargs": {"num_buckets": 4}, "tags": ["a", "b"]})
+    )
+
+
+def test_hashable_list_handles_dicts():
+    nested = HashableList([{"a": 1}, {"b": [2, 3]}])
+    assert hash(nested) == hash(HashableList([{"a": 1}, {"b": [2, 3]}]))
+
+
+@lru_cache
+def _identity(**kwargs: object) -> int:
+    return len(kwargs)
+
+
+def test_nested_kwargs_usable_in_lru_cache():
+    # Mirrors _merge_mm_kwargs: each top-level value is wrapped as a
+    # HashableDict/HashableList whose own nested values stay native dicts.
+    _identity.cache_clear()
+    kwargs = {"images_kwargs": HashableDict({"num_buckets": 4})}
+    _identity(**kwargs)
+    # Second call with equal keys must hit the cache rather than raise.
+    _identity(**kwargs)
+    assert _identity.cache_info().hits == 1

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -79,6 +79,15 @@ _I = TypeVar("_I", bound=BaseImageProcessor, default=BaseImageProcessor)
 _V = TypeVar("_V", bound=BaseVideoProcessor, default=BaseVideoProcessor)
 
 
+def _make_hashable(value: Any) -> Any:
+    """Recursively wrap native dicts/lists so nested values hash for lru_cache."""
+    if isinstance(value, dict):
+        return HashableDict(value)
+    if isinstance(value, list):
+        return HashableList(value)
+    return value
+
+
 class HashableDict(dict):
     """
     A dictionary that can be hashed by lru_cache.
@@ -87,7 +96,7 @@ class HashableDict(dict):
     # NOTE: pythonic dict is not hashable,
     # we override on it directly for simplicity
     def __hash__(self) -> int:  # type: ignore[override]
-        return hash(frozenset(self.items()))
+        return hash(frozenset((k, _make_hashable(v)) for k, v in self.items()))
 
 
 class HashableList(list):
@@ -96,7 +105,7 @@ class HashableList(list):
     """
 
     def __hash__(self) -> int:  # type: ignore[override]
-        return hash(tuple(self))
+        return hash(tuple(_make_hashable(v) for v in self))
 
 
 def _get_processor_factory_fn(processor_cls: type | tuple[type, ...]):


### PR DESCRIPTION
## Summary

`HashableDict` / `HashableList` (in `vllm/transformers_utils/processor.py`) wrap top-level `mm_processor_kwargs` values so they can be used as `lru_cache` keys for processor caching (`cached_get_processor`, and the OV2 `_load_ov2_processor`). Their `__hash__` implementations (`hash(frozenset(self.items()))` / `hash(tuple(self))`) only hashed the top level — when a wrapped value is itself a nested dict or list (e.g. `{"images_kwargs": {"num_buckets": 4}}`, or a list containing a dict), hashing raised `TypeError: unhashable type: 'dict'` and processor loading crashed.

This PR adds a `_make_hashable` helper and makes both `__hash__` methods recurse into nested dicts/lists. No call sites change; values passed to `from_pretrained(**kwargs)` stay native nested dicts, so runtime behavior is unchanged — only cache-key hashing is fixed.

## Why this is not a duplicate

Checked open PRs before opening:
- `gh pr list --repo vllm-project/vllm --state open --search "HashableDict in:title,body"` → no match
- `gh pr list --repo vllm-project/vllm --state open --search "processor kwargs unhashable in:title,body"` → no match

#46801 ("handle non-str chat template in HF renderer") is unrelated.

## Test commands and results

Environment: CPU-only venv (python 3.12, torch CPU build, transformers, pytest, ruff) — no GPU required.

```bash
.venv/bin/python -m pytest tests/transformers_utils/test_processor.py -v
.venv/bin/ruff check vllm/transformers_utils/processor.py tests/transformers_utils/test_processor.py
```

```
tests/transformers_utils/test_processor.py::test_get_processor_kwargs_from_processor_unpack_path_returns_full_union PASSED
tests/transformers_utils/test_processor.py::test_get_processor_kwargs_from_processor_module_scan_returns_full_union PASSED
tests/transformers_utils/test_processor.py::test_hashable_dict_handles_nested_values PASSED
tests/transformers_utils/test_processor.py::test_hashable_list_handles_dicts PASSED
tests/transformers_utils/test_processor.py::test_nested_kwargs_usable_in_lru_cache PASSED

========================= 5 passed, 1 warning in 3.04s =========================
ruff: All checks passed!
```

Before-fix regression check (old `__hash__`, confirming the new tests catch the bug):

```python
class HashableDict(dict):
    def __hash__(self):
        return hash(frozenset(self.items()))   # old

class HashableList(list):
    def __hash__(self):
        return hash(tuple(self))               # old
```

```
hash(HashableDict({'images_kwargs': {'num_buckets': 4}}))   # TypeError: unhashable type: 'dict'
hash(HashableList([{'a': 1}]))                              # TypeError: unhashable type: 'dict'
```

Both raise `TypeError` on the old implementation; the new recursive `_make_hashable` resolves them and the `lru_cache` hit assertion passes.

## Model evaluation

Not applicable. This is a pure container-hashing fix in processor caching with no effect on model output or accuracy.

## AI assistance

This change was developed with AI assistance (Claude Code). Every changed line was reviewed by a human submitter, and the tests above were run by the submitter.