### PR TITLE
[Feat][Kernel] Add an opt-in deterministic FlashInfer TopK backend

### DIFF
--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -17,6 +17,7 @@ from vllm.models.qwen4_exp.nvidia.ops import qsa as qsa_ops
 from vllm.models.qwen4_exp.nvidia.ops import qsa_indexer as qsa_indexer_ops
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
+from vllm.utils.flashinfer import has_flashinfer
 
 requires_qsa_kernels = pytest.mark.skipif(
     not current_platform.is_cuda() or not HAS_TRITON,
@@ -1039,7 +1040,21 @@ def test_qsa_sparse_paged_attention_correctness(
 
 @requires_qsa_kernels
 @pytest.mark.parametrize("decode_query_len", [1, 2, 3, 4])
-def test_qsa_split_selection_correctness(workspace_init, decode_query_len: int) -> None:
+@pytest.mark.parametrize(
+    "use_flashinfer_topk",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not has_flashinfer(), reason="FlashInfer is not installed"
+            ),
+        ),
+    ],
+)
+def test_qsa_split_selection_correctness(
+    workspace_init, decode_query_len: int, use_flashinfer_topk: bool
+) -> None:
     query_lens = [decode_query_len, decode_query_len, 33]
     rows, heads, head_dim = sum(query_lens), 4, 128
     token_topk, compress_ratio = 2048, 4
@@ -1085,6 +1100,7 @@ def test_qsa_split_selection_correctness(workspace_init, decode_query_len: int) 
         compress_ratio,
         decode_query_len,
         block_indices[decode_slice],
+        use_flashinfer_topk,
     )
     prefill_slice = slice(num_decode_tokens, rows)
     qsa_indexer_ops.qsa_select_paged_prefill(
@@ -1098,6 +1114,7 @@ def test_qsa_split_selection_correctness(workspace_init, decode_query_len: int) 
         query_lens[-1],
         block_indices[prefill_slice],
         max_seq_len=sequence_lengths.max().item(),
+        use_flashinfer_topk=use_flashinfer_topk,
     )
     # +1: the packed trailing count column (never a token index; excluded
     # from the comparison).

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -207,6 +207,9 @@ LinearBackend = Literal[
     "xpu_woq",
 ]
 
+DSATopKBackend = Literal["native", "flashinfer"]
+DSATopKTieBreak = Literal["small", "large"]
+
 
 @config
 class KernelConfig:
@@ -232,6 +235,16 @@ class KernelConfig:
 
     enable_bf16x3_router_gemm: bool = False
     """If True, use the experimental SM100 BF16x3 CuteDSL router GEMM."""
+
+    dsa_topk_backend: DSATopKBackend = "native"
+    """TopK backend for sparse-attention indexers.
+
+    ``"native"`` preserves the default vLLM kernels. ``"flashinfer"`` uses
+    FlashInfer's graph-safe deterministic TopK with an explicit index tie-break.
+    """
+
+    dsa_topk_tie_break: DSATopKTieBreak = "small"
+    """Index preference for equal values with the FlashInfer TopK backend."""
 
     moe_backend: MoEBackend = "auto"
     """Backend for MoE expert computation kernels. Available options:
@@ -308,6 +321,13 @@ class KernelConfig:
     @field_validator("linear_backend", mode="before")
     @classmethod
     def _normalize_linear_backend(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower().replace("-", "_")
+        return value
+
+    @field_validator("dsa_topk_backend", "dsa_topk_tie_break", mode="before")
+    @classmethod
+    def _normalize_dsa_topk_config(cls, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower().replace("-", "_")
         return value

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -694,6 +694,12 @@ class EngineArgs:
         KernelConfig, "enable_flashinfer_autotune"
     )
     enable_bf16x3_router_gemm: bool | None = None
+    dsa_topk_backend: Literal["native", "flashinfer"] = get_field(
+        KernelConfig, "dsa_topk_backend"
+    )
+    dsa_topk_tie_break: Literal["small", "large"] = get_field(
+        KernelConfig, "dsa_topk_tie_break"
+    )
     worker_cls: str = ParallelConfig.worker_cls
     worker_extension_cls: str = ParallelConfig.worker_extension_cls
 
@@ -1648,6 +1654,12 @@ class EngineArgs:
             "--enable-bf16x3-router-gemm",
             **kernel_kwargs["enable_bf16x3_router_gemm"],
         )
+        kernel_group.add_argument(
+            "--dsa-topk-backend", **kernel_kwargs["dsa_topk_backend"]
+        )
+        kernel_group.add_argument(
+            "--dsa-topk-tie-break", **kernel_kwargs["dsa_topk_tie_break"]
+        )
         moe_backend_kwargs = kernel_kwargs["moe_backend"]
         moe_backend_kwargs["type"] = lambda s: s.lower().replace("-", "_")
         kernel_group.add_argument("--moe-backend", **moe_backend_kwargs)
@@ -2506,6 +2518,10 @@ class EngineArgs:
             kernel_config.enable_flashinfer_autotune = self.enable_flashinfer_autotune
         if self.enable_bf16x3_router_gemm is not None:
             kernel_config.enable_bf16x3_router_gemm = self.enable_bf16x3_router_gemm
+        if self.dsa_topk_backend != "native":
+            kernel_config.dsa_topk_backend = self.dsa_topk_backend
+        if self.dsa_topk_tie_break != "small":
+            kernel_config.dsa_topk_tie_break = self.dsa_topk_tie_break
         if self.moe_backend != "auto":
             kernel_config.moe_backend = self.moe_backend
         if self.linear_backend != "auto":

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -16,6 +16,10 @@ from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
 )
+from vllm.model_executor.layers.sparse_attn_topk import (
+    flashinfer_deterministic_topk,
+    flashinfer_tie_break_value,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
@@ -23,6 +27,7 @@ from vllm.utils.deep_gemm import (
     fp8_fp4_paged_mqa_logits,
     has_deep_gemm,
 )
+from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.import_utils import has_cutedsl
 from vllm.utils.torch_utils import (
     LayerNameType,
@@ -316,6 +321,8 @@ def sparse_attn_indexer(
     dcp_world_size: int = 1,
     cp_kv_cache_interleave_size: int = 1,
     skip_topk_buffer_clear: bool = False,
+    use_flashinfer_topk: bool = False,
+    flashinfer_topk_tie_break: int = 1,
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
     forward_context = get_forward_context()
@@ -329,11 +336,14 @@ def sparse_attn_indexer(
         values_spec, scales_spec = _gather_workspace_shapes(
             total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
         )
-        current_workspace_manager().get_simultaneous(
-            values_spec,
-            scales_spec,
-            ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
-        )
+        if use_flashinfer_topk:
+            current_workspace_manager().get_simultaneous(values_spec, scales_spec)
+        else:
+            current_workspace_manager().get_simultaneous(
+                values_spec,
+                scales_spec,
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
 
         # Dummy allocation to simulate for peak logits tensor memory during inference.
         # FP8 elements so elements == bytes
@@ -505,17 +515,27 @@ def sparse_attn_indexer(
                         cu_seqlen_ke,
                         clean_logits=False,
                     )
-                num_rows = logits.shape[0]
-                ops.top_k_per_row_prefill(
-                    logits,
-                    cu_seqlen_ks,
-                    cu_seqlen_ke,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
+                if use_flashinfer_topk:
+                    flashinfer_deterministic_topk(
+                        logits,
+                        cu_seqlen_ke - cu_seqlen_ks,
+                        topk_tokens,
+                        flashinfer_topk_tie_break,
+                        row_starts=cu_seqlen_ks,
+                        out=topk_indices,
+                    )
+                else:
+                    num_rows = logits.shape[0]
+                    ops.top_k_per_row_prefill(
+                        logits,
+                        cu_seqlen_ks,
+                        cu_seqlen_ke,
+                        topk_indices,
+                        num_rows,
+                        logits.stride(0),
+                        logits.stride(1),
+                        topk_tokens,
+                    )
 
             _merge_dcp_topk_global(
                 logits,
@@ -627,7 +647,15 @@ def sparse_attn_indexer(
             1024,
             2048,
         )
-        if use_cooperative_topk:
+        if use_flashinfer_topk:
+            flashinfer_deterministic_topk(
+                logits,
+                seq_lens,
+                topk_tokens,
+                flashinfer_topk_tie_break,
+                out=topk_indices,
+            )
+        elif use_cooperative_topk:
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
@@ -712,6 +740,8 @@ def sparse_attn_indexer_fake(
     dcp_world_size: int = 1,
     cp_kv_cache_interleave_size: int = 1,
     skip_topk_buffer_clear: bool = False,
+    use_flashinfer_topk: bool = False,
+    flashinfer_topk_tie_break: int = 1,
 ) -> torch.Tensor:
     return topk_indices_buffer
 
@@ -769,9 +799,32 @@ class SparseAttnIndexer(CustomOp):
         # during model construction) and pass them into the custom op, rather
         # than threading them through per-step metadata.
         vllm_config = get_current_vllm_config()
+        kernel_config = vllm_config.kernel_config
+        self.use_flashinfer_topk = kernel_config.dsa_topk_backend == "flashinfer"
+        self.flashinfer_topk_tie_break = flashinfer_tie_break_value(
+            kernel_config.dsa_topk_tie_break
+        )
+        if self.use_flashinfer_topk:
+            if not current_platform.is_cuda():
+                raise ValueError("The FlashInfer DSA TopK backend requires CUDA")
+            if not has_flashinfer():
+                raise ValueError(
+                    "The FlashInfer DSA TopK backend requires the flashinfer "
+                    "package and either nvcc or FlashInfer cubins."
+                )
+
         parallel_config = vllm_config.parallel_config
         self._parallel_config = parallel_config
         self.dcp_world_size = parallel_config.decode_context_parallel_size
+        if (
+            self.use_flashinfer_topk
+            and self.dcp_world_size > 1
+            and self.flashinfer_topk_tie_break != 1
+        ):
+            raise ValueError(
+                "DSA decode context parallelism currently supports only the "
+                "small deterministic TopK tie-break"
+            )
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.use_pcp = parallel_config.prefill_context_parallel_size > 1
         self._cp_kv_cache_interleave_size: int | None = None
@@ -869,6 +922,9 @@ class SparseAttnIndexer(CustomOp):
             self.dcp_rank,
             self.dcp_world_size,
             self.cp_kv_cache_interleave_size,
+            False,
+            self.use_flashinfer_topk,
+            self.flashinfer_topk_tie_break,
         )
 
     def forward_xpu(

--- a/vllm/model_executor/layers/sparse_attn_topk.py
+++ b/vllm/model_executor/layers/sparse_attn_topk.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Configurable TopK selection for sparse-attention indexers."""
+
+from __future__ import annotations
+
+import torch
+
+_FLASHINFER_TIE_BREAK = {"small": 1, "large": 2}
+
+
+def flashinfer_tie_break_value(mode: str) -> int:
+    """Return FlashInfer's integer code for a canonical index tie-break."""
+    try:
+        return _FLASHINFER_TIE_BREAK[mode]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported DSA TopK tie-break {mode!r}; expected 'small' or 'large'."
+        ) from exc
+
+
+def flashinfer_deterministic_topk(
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    k: int,
+    tie_break: int,
+    *,
+    row_starts: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Select a deterministic TopK with a canonical boundary tie-break.
+
+    Returned indices use the same coordinate system as ``logits``. For ragged
+    prefill rows, ``row_starts`` therefore serves as both the selection-window
+    start and the output offset.
+    """
+    if tie_break not in _FLASHINFER_TIE_BREAK.values():
+        raise ValueError("FlashInfer deterministic TopK requires a tie-break")
+
+    from flashinfer import top_k_ragged_transform
+
+    lengths = lengths.reshape(-1).to(dtype=torch.int32).contiguous()
+    if row_starts is None:
+        row_starts = torch.zeros_like(lengths)
+        selection_starts = None
+    else:
+        row_starts = row_starts.reshape(-1).to(dtype=torch.int32).contiguous()
+        selection_starts = row_starts
+
+    indices = top_k_ragged_transform(
+        logits.contiguous(),
+        row_starts,
+        lengths,
+        k,
+        deterministic=True,
+        tie_break=tie_break,
+        dsa_graph_safe=True,
+        row_starts=selection_starts,
+    )
+    if out is not None:
+        out.copy_(indices)
+        return out
+    return indices

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -458,6 +458,10 @@ class DeepseekV32Attention(MLAAttention):
                     self._vllm_config.parallel_config.cp_kv_cache_interleave_size
                 ),
                 skip_topk_buffer_clear=True,
+                use_flashinfer_topk=self.indexer.indexer_op.use_flashinfer_topk,
+                flashinfer_topk_tie_break=(
+                    self.indexer.indexer_op.flashinfer_topk_tie_break
+                ),
             )
 
         attn_metadata, _, kv_cache, layer_slot_mapping = get_attention_context(

--- a/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -13,9 +13,13 @@ from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
+from vllm.model_executor.layers.sparse_attn_topk import (
+    flashinfer_tie_break_value,
+)
 from vllm.transformers_utils.configs.qwen4_exp import (
     Qwen4ExpTextConfig,
 )
+from vllm.utils.flashinfer import has_flashinfer
 
 from ..common.qsa_cache import (
     QSACompressedKeyCache,
@@ -117,6 +121,16 @@ class QSAIndexer(nn.Module):
         self.index_head_dim = int(config.indexer_head_dim)
         self.token_topk = int(config.indexer_budget)
         self.compress_ratio = int(config.indexer_compress_ratio)
+        kernel_config = vllm_config.kernel_config
+        self.use_flashinfer_topk = kernel_config.dsa_topk_backend == "flashinfer"
+        self.flashinfer_topk_tie_break = flashinfer_tie_break_value(
+            kernel_config.dsa_topk_tie_break
+        )
+        if self.use_flashinfer_topk and not has_flashinfer():
+            raise ValueError(
+                "The FlashInfer DSA TopK backend requires the flashinfer package "
+                "and either nvcc or FlashInfer cubins."
+            )
         self.rotary_emb = rotary_emb
         self.use_fused_pre_indexer = _supports_fused_pre_indexer(
             rotary_emb,
@@ -424,6 +438,8 @@ class QSAIndexer(nn.Module):
                 self.compress_ratio,
                 decode_query_len,
                 block_indices[decode_slice],
+                self.use_flashinfer_topk,
+                self.flashinfer_topk_tie_break,
             )
 
         # Prefill requests follow the leading decode rows in the reordered batch.
@@ -441,6 +457,8 @@ class QSAIndexer(nn.Module):
                 compressed_metadata.max_query_len,
                 block_indices[prefill_slice],
                 compressed_metadata.max_seq_len,
+                self.use_flashinfer_topk,
+                self.flashinfer_topk_tie_break,
             )
         expand_qsa_block_indices(
             block_indices,

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -5,6 +5,9 @@
 import torch
 
 import vllm.envs as envs
+from vllm.model_executor.layers.sparse_attn_topk import (
+    flashinfer_deterministic_topk,
+)
 from vllm.model_executor.warmup.jit_warmup_triton_helper import (
     TritonWarmupTensor,
 )
@@ -476,10 +479,23 @@ def _topk(
     token_topk: int,
     compress_ratio: int,
     block_indices: torch.Tensor,
-    topk_workspace: torch.Tensor,
+    topk_workspace: torch.Tensor | None,
+    use_flashinfer_topk: bool = False,
+    flashinfer_topk_tie_break: int = 1,
 ) -> None:
-    # similar dispatch logic as DeepSeek indexer
     block_topk = token_topk // compress_ratio
+    if use_flashinfer_topk:
+        flashinfer_deterministic_topk(
+            logits,
+            visible_blocks,
+            block_topk,
+            flashinfer_topk_tie_break,
+            out=block_indices,
+        )
+        return
+
+    # Keep the native QSA dispatch unchanged when the opt-in backend is disabled.
+    assert topk_workspace is not None
     use_cooperative_topk = (
         logits.shape[0] <= 64
         and logits.stride(0) % 4 == 0
@@ -510,6 +526,8 @@ def qsa_select_paged_decode(
     compress_ratio: int,
     decode_query_len: int,
     block_indices: torch.Tensor,
+    use_flashinfer_topk: bool = False,
+    flashinfer_topk_tie_break: int = 1,
 ) -> None:
     """Score and select compressed blocks for a request-major decode batch.
 
@@ -568,7 +586,15 @@ def qsa_select_paged_decode(
         token_topk,
         compress_ratio,
         block_indices,
-        torch.empty((_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device),
+        (
+            None
+            if use_flashinfer_topk
+            else torch.empty(
+                (_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device
+            )
+        ),
+        use_flashinfer_topk,
+        flashinfer_topk_tie_break,
     )
 
 
@@ -583,6 +609,8 @@ def qsa_select_paged_prefill(
     max_query_len: int,
     block_indices: torch.Tensor,
     max_seq_len: int,
+    use_flashinfer_topk: bool = False,
+    flashinfer_topk_tie_break: int = 1,
 ) -> None:
     """Score and select compressed prefill blocks in bounded chunks.
 
@@ -614,8 +642,10 @@ def qsa_select_paged_prefill(
     # chunk the inputs to keep temp logits below VLLM_SPARSE_INDEXER_MAX_LOGITS_MB
     max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
     rows_per_chunk = max(1, max_logits_bytes // (logits_width * 4))
-    topk_workspace = torch.empty(
-        (_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device
+    topk_workspace = (
+        None
+        if use_flashinfer_topk
+        else torch.empty((_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device)
     )
 
     for query_start in range(0, rows, rows_per_chunk):
@@ -639,6 +669,8 @@ def qsa_select_paged_prefill(
             compress_ratio,
             block_indices[query_slice],
             topk_workspace,
+            use_flashinfer_topk,
+            flashinfer_topk_tie_break,
         )
 
 


### PR DESCRIPTION
## Motivation

Sparse-attention index selection can be non-deterministic when values tie at the TopK boundary.

This adds an opt-in backend for users who need deterministic index selection, without changing the vLLM native TopK default or its performance characteristics.

This PR does not change default inference behavior and does not claim a model-quality improvement; its purpose is reproducible TopK selection for those who need this functionality.