### PR TITLE
[CI] Fix ARM64 test dependency builds with GCC 15

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -373,7 +373,10 @@ RUN case "$(uname -m)" in \
     aarch64|arm64) sed -i '/^decord==/d; /^terratorch==/d' requirements/test/cpu.txt ;; \
     esac
 
+# pytrec-eval-terrier bundles pre-C23 trec_eval sources. GCC 15 defaults to C23;
+# use C17 for test dependency builds without changing the vLLM compiler flags.
 RUN --mount=type=cache,target=/root/.cache/uv \
+    export CFLAGS="${CFLAGS:+${CFLAGS} }-std=gnu17" && \
     if [ "${PYTORCH_NIGHTLY}" = "1" ]; then \
         python3 /workspace/use_existing_torch.py --prefix \
         && uv pip install -r requirements/test/cpu.txt \
@@ -408,7 +411,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 COPY --from=vllm-test-deps /vllm-workspace/requirements/test/cpu.txt requirements/test/cpu.txt
 
+# vllm-dev installs the same test dependencies in its own environment.
 RUN --mount=type=cache,target=/root/.cache/uv \
+    export CFLAGS="${CFLAGS:+${CFLAGS} }-std=gnu17" && \
     uv pip install -r requirements/lint.txt && \
     if [ "${PYTORCH_NIGHTLY}" = "1" ]; then \
         uv pip install -r requirements/test/cpu.txt \


### PR DESCRIPTION
The CPU ARM64 image fails while building `pytrec-eval-terrier==0.5.7` from source under GCC 15. In [main build 87636](https://buildkite.com/vllm/ci/builds/87636#01a07f9c-181f-4987-b1ca-62e8aa7e4b37), its bundled trec_eval code uses pre-C23 function declarations; GCC 15's default C23 mode produces incompatible qsort callbacks and conflicting function definitions.

Build Python test dependencies in GNU C17 mode in both `vllm-test-deps` and `vllm-dev`. Keep the GCC 15/C++ toolchain and the vLLM production build flags unchanged, including AMX FP8 support. This is a functional image-build regression fix, not a warning suppression.

Duplicate checks: no open matching PR was found by searches for `pytrec`, `trec_eval`, `GCC C23`, or `49410 in:body`. No matching issue was found; unrelated search results were not used as issue links.

Validation:
- Local Linux aarch64 container, Ubuntu 25.10, GCC 15.2.0, uv-managed Python 3.12, package pinned to the exact CI version.
- `uv pip install --no-cache --no-binary pytrec-eval-terrier pytrec-eval-terrier==0.5.7`: failed with the same qsort callback and conflicting-definition errors as CI.
- `CFLAGS=-std=gnu17 uv pip install --no-cache --no-binary pytrec-eval-terrier pytrec-eval-terrier==0.5.7`: passed.
- `.venv/bin/python` retrieval-metric smoke test: imported the built extension and computed MAP/NDCG of 1.0 for both known-perfect rankings; passed.
- `pre-commit run --files docker/Dockerfile.cpu` and `git diff --check`: passed.
- Follow-up: the actual `docker/Dockerfile.cpu` target `vllm-test-deps` built successfully on Linux ARM64 / Ubuntu 25.04 with its full pinned dependency set: `docker build --platform linux/arm64 --target vllm-test-deps --build-arg max_jobs=2 --build-arg USE_SCCACHE=0 -t codex-ci-cpu-test-deps-c17-20260908 -f docker/Dockerfile.cpu .`. The resulting image uses GCC 15.0.1 and the installed pytrec-eval-terrier 0.5.7 extension passes the two-query MAP/NDCG smoke. The final vLLM wheel/test image and dev image have not been built.

AI assistance was used for investigation, implementation, and validation. Draft for human review; final image CI remains required before merge. No model runtime or output behavior changes.
