### PR TITLE
[CI] Increase ColQwen3 pooling test memory budget on H200 MIG

### DIFF
--- a/tests/models/multimodal/pooling/test_colqwen3.py
+++ b/tests/models/multimodal/pooling/test_colqwen3.py
@@ -45,7 +45,9 @@ TEXT_DOCUMENTS = [
 ]
 
 DTYPE = "half"
-GPU_MEMORY_UTILIZATION = 0.7
+# The Tomoro model needs room for its vision encoder and a 4096-token KV cache
+# on the 16 GiB devices used by the H200 MIG test lane.
+GPU_MEMORY_UTILIZATION = 0.8
 
 
 def _make_base64_image(


### PR DESCRIPTION
The H200 MIG extended-pooling lane fails all six Tomoro ColQwen3 cases before they reach their assertions. In [main build 87636](https://buildkite.com/vllm/ci/builds/87636#01a07f9c-18f1-4a56-9b9e-8b14ada30794), the device reports 16 GiB, while these tests reserve only 70% (11.2 GiB). After loading the model and profiling its vision encoder, 0.08 GiB remains for KV cache, below the 0.56 GiB required for the existing 4096-token context.

Increase the shared ColQwen3 test budget to 80% (12.8 GiB on this lane), preserving every model, input, context-length setting and embedding/scoring assertion. This keeps 3.2 GiB outside the engine budget on the CI device. The current failure is capacity validation, not the earlier Transformers weight-tying problem.

Duplicate checks: open PR searches for `ColQwen3` and `Tomoro memory` found no matching capacity fix. #55588 unskipped these tests; it did not adjust their memory budget. No matching issue was found for this capacity failure.

Validation:
- Public main CI image `537af2c3a4ba7462ddc9bc94ec7a4ea496da6d2e` on idle H200 GPU 1. The ColQwen3 test and model implementation are unchanged between that image and this branch's base.
- A temporary pytest plugin sets the existing budget constant to `budget_bytes / total_device_memory`, preserving the absolute 11.2/12.8 GiB budgets of a 16 GiB CI device on a full H200. Python runs through `uv venv --system-site-packages .venv` and `.venv/bin/python`.
- Old 11.2 GiB budget: first Tomoro test fails engine startup with negative available KV-cache memory (-0.15 GiB); stopped at first failure. This reproduces memory exhaustion, though the exact available-byte count differs from the MIG log.
- Proposed 12.8 GiB budget: all six Tomoro cases pass, 12 other-model cases deselected, in 206.08 seconds. The run reports 1.45 GiB available for KV cache. Coverage includes token embedding shape/normalization, manual MaxSim equivalence, relevance ordering, and all three multimodal scoring variants.
- `pre-commit run --files tests/models/multimodal/pooling/test_colqwen3.py` and `git diff --check`: passed.
- Exact H200 MIG CI remains required; a full H200 with the same absolute engine memory budget is not identical to a MIG device. The other 12 parametrizations were not rerun locally.

AI assistance was used for investigation, implementation, and validation. Draft for human review; exact MIG CI remains required before merge. This changes test resource configuration, not model implementation.
