### PR TITLE
[Docs] Add Ministral3 and HfMoondream HF architecture keys

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -447,7 +447,7 @@ th {
 | `MiniCPM3ForCausalLM` | MiniCPM3 | `openbmb/MiniCPM3-4B`, etc. | ✅︎ | ✅︎ |
 | `MiniMaxM2ForCausalLM` | MiniMax-M2, MiniMax-M2.1 | `MiniMaxAI/MiniMax-M2`, etc. | ✅︎ | ✅︎ |
 | `MiniMaxM3SparseForCausalLM` | MiniMax-M3 | `MiniMaxAI/MiniMax-M3`, `MiniMaxAI/MiniMax-M3-MXFP8`, etc. | | ✅︎ |
-| `MistralForCausalLM` | Ministral-3, Mistral, Mistral-Instruct | `mistralai/Ministral-3-3B-Instruct-2512`, `mistralai/Mistral-7B-v0.1`, `mistralai/Mistral-7B-Instruct-v0.1`, etc. | ✅︎ | ✅︎ |
+| `Ministral3ForCausalLM`, `MistralForCausalLM` | Ministral-3, Mistral, Mistral-Instruct | `mistralai/Ministral-3-3B-Instruct-2512`, `mistralai/Mistral-7B-v0.1`, `mistralai/Mistral-7B-Instruct-v0.1`, etc. | ✅︎ | ✅︎ |
 | `MistralLarge3ForCausalLM` | Mistral-Large-3-675B-Base-2512, Mistral-Large-3-675B-Instruct-2512 | `mistralai/Mistral-Large-3-675B-Base-2512`, `mistralai/Mistral-Large-3-675B-Instruct-2512`, etc. | ✅︎ | ✅︎ |
 | `MixtralForCausalLM` | Mixtral-8x7B, Mixtral-8x7B-Instruct | `mistralai/Mixtral-8x7B-v0.1`, `mistralai/Mixtral-8x7B-Instruct-v0.1`, `mistral-community/Mixtral-8x22B-v0.1`, etc. | ✅︎ | ✅︎ |
 | `NemotronForCausalLM` | Nemotron-3, Nemotron-4, Minitron | `nvidia/Minitron-8B-Base`, `mgoin/Nemotron-4-340B-Base-hf-FP8`, etc. | ✅︎ | ✅︎ |
@@ -598,7 +598,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Molmo2ForConditionalGeneration` | Molmo2 | T + I<sup>+</sup> / V | `allenai/Molmo2-4B`, `allenai/Molmo2-8B`, `allenai/Molmo2-O-7B`, `allenai/MolmoWeb-4B`<sup>^</sup>, `allenai/MolmoWeb-8B`<sup>^</sup> | ✅︎ | ✅︎ |
 | `MossAudioModel` | MOSS-Audio | T + A<sup>+</sup> | `OpenMOSS-Team/MOSS-Audio-4B-Instruct`, `OpenMOSS-Team/MOSS-Audio-4B-Thinking`, `OpenMOSS-Team/MOSS-Audio-8B-Instruct`, `OpenMOSS-Team/MOSS-Audio-8B-Thinking` | ✅︎ | ✅︎ |
 | `MossTranscribeDiarizeForConditionalGeneration` | MOSS-Transcribe-Diarize | T + A | `OpenMOSS-Team/MOSS-Transcribe-Diarize` | | ✅︎ |
-| `Moondream3ForCausalLM` | Moondream3 | T + I | `moondream/moondream3-preview` | | ✅︎ |
+| `HfMoondream`, `Moondream3ForCausalLM` | Moondream3 | T + I | `moondream/moondream3-preview` | | ✅︎ |
 | `MuseGlimmerForCausalLM`, `MuseGlimmerForConditionalGeneration` | Muse Glimmer | T + I<sup>+</sup> + V<sup>+</sup> | `meta-models/Muse-Glimmer-30B` | ✅︎ | ✅︎ |
 | `NVLM_D_Model` | NVLM-D 1.0 | T + I<sup>+</sup> | `nvidia/NVLM-D-72B`, etc. | | ✅︎ |
 | `OpenCUAForConditionalGeneration` | OpenCUA-7B | T + I<sup>E+</sup> | `xlangai/OpenCUA-7B` | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary
- List `Ministral3ForCausalLM` alongside `MistralForCausalLM` in the text supported-models table (Ministral-3 HF `architectures` / registry key).
- List `HfMoondream` alongside `Moondream3ForCausalLM` in the multimodal table (registered alias for the same Moondream3 implementation).

Docs state that native support is determined by matching `config.json` `"architectures"` to the Architecture column. These registry aliases were missing, so readers matching HF keys would miss the rows.

## Local repro
```bash
SHA=5db652225f00b55783823ae6606d36925e3e3efe

# Registry aliases
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/vllm/model_executor/models/registry.py" \
  | rg -n 'Ministral3ForCausalLM|HfMoondream'
# Ministral3ForCausalLM -> mistral.MistralForCausalLM
# HfMoondream -> moondream3.Moondream3ForCausalLM

# Tests treat Ministral-3 architectures as Ministral3ForCausalLM
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/tests/test_config.py" \
  | rg -n 'Ministral3ForCausalLM'
# architectures=["Ministral3ForCausalLM"]

# Docs (pre-fix) Architecture column omitted those keys
curl -fsSL "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/docs/models/supported_models.md" \
  | rg -n 'MistralForCausalLM|Moondream3ForCausalLM|Ministral3ForCausalLM|HfMoondream'
# MistralForCausalLM row (no Ministral3ForCausalLM); Moondream3ForCausalLM only
```

## Test plan
- [ ] Confirm Architecture column text matches registry keys for Ministral-3 / Moondream3
- [ ] No other table rows changed