### PR TITLE
[Perf][Models] Keep cu_seqlens on CPU for non-flash Qwen VL encoder attention

### DIFF
--- a/tests/kernels/attention/test_mha_attn.py
+++ b/tests/kernels/attention/test_mha_attn.py
@@ -253,6 +253,50 @@ def test_mha_attn_varlen_forward(
 
 
 @pytest.mark.parametrize("var_seq_len", VAR_SEQ_LENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("num_kv_heads", NUM_KV_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("device", devices)
+def test_mha_attn_varlen_forward_sdpa_cpu_cu_seqlens(
+    default_vllm_config,
+    var_seq_len: list[int],
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    device: str,
+):
+    """Non-flash (SDPA) varlen forward must not require cu_seqlens on GPU.
+
+    The Qwen VL vision encoders keep cu_seqlens on CPU for the TORCH_SDPA
+    backend (it is only consumed on the host to derive split sizes), so
+    passing a CPU cu_seqlens tensor must yield identical output.
+    """
+    set_random_seed(0)
+    torch.set_default_device(device)
+    torch.set_default_dtype(dtype)
+
+    q = torch.randn(1, sum(var_seq_len), num_heads, head_size)
+    k = torch.randn(1, sum(var_seq_len), num_kv_heads, head_size)
+    v = torch.randn(1, sum(var_seq_len), num_kv_heads, head_size)
+    cu_seqlens = torch.tensor(
+        [0] + list(itertools.accumulate(var_seq_len)), dtype=torch.int32
+    )
+    scale = 1.0 / head_size**0.5
+    attn = MMEncoderAttention(
+        num_heads, head_size, scale=scale, num_kv_heads=num_kv_heads
+    )
+    if attn.attn_backend != AttentionBackendEnum.TORCH_SDPA:
+        pytest.skip("Test only applies to the non-flash (SDPA) encoder backend.")
+
+    max_seqlen = torch.tensor(max(var_seq_len))
+    output_device = attn(q, k, v, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+    output_cpu = attn(q, k, v, cu_seqlens=cu_seqlens.cpu(), max_seqlen=max_seqlen.cpu())
+    torch.testing.assert_close(output_cpu, output_device, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("var_seq_len", VAR_SEQ_LENS)
 @pytest.mark.parametrize(
     "dtype",
     [torch.bfloat16, torch.half],

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -1035,22 +1035,29 @@ class Qwen2_5_VisionTransformer(nn.Module):
         # FlashInfer uses backend-specific cu_seqlens offsets into the flattened
         # Q/K/O and V buffers. Other backends receive the original cumulative
         # token offsets unchanged.
-        cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
-            self.attn_backend,
-            cu_seqlens_np,
-            self.hidden_size,
-            self.tp_size,
-            device,
-            fp8_padded_hidden_size=self.fp8_padded_hidden_size,
-        )
-        cu_window_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
-            self.attn_backend,
-            cu_window_seqlens_np,
-            self.hidden_size,
-            self.tp_size,
-            device,
-            fp8_padded_hidden_size=self.fp8_padded_hidden_size,
-        )
+        # The non-flash (SDPA) backend splits the packed sequence with Python
+        # sizes derived from cu_seqlens in every block, so keep it on CPU to
+        # avoid a device-to-host sync per layer. Kernel backends need it on GPU.
+        if self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
+            cu_seqlens = torch.from_numpy(cu_seqlens_np)
+            cu_window_seqlens = torch.from_numpy(cu_window_seqlens_np)
+        else:
+            cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+                self.attn_backend,
+                cu_seqlens_np,
+                self.hidden_size,
+                self.tp_size,
+                device,
+                fp8_padded_hidden_size=self.fp8_padded_hidden_size,
+            )
+            cu_window_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+                self.attn_backend,
+                cu_window_seqlens_np,
+                self.hidden_size,
+                self.tp_size,
+                device,
+                fp8_padded_hidden_size=self.fp8_padded_hidden_size,
+            )
         rotary_pos_emb_cos = rotary_pos_emb_cos.to(device=device, non_blocking=True)
         rotary_pos_emb_sin = rotary_pos_emb_sin.to(device=device, non_blocking=True)
         window_index = async_tensor_h2d(window_index, device)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -705,10 +705,18 @@ class Qwen2VisionTransformer(nn.Module):
         else:
             max_seqlen = torch.tensor(max_seqlen_override, dtype=torch.int32)
 
+        # The non-flash (SDPA) backend splits the packed sequence with Python
+        # sizes derived from cu_seqlens in every block, so keep it on CPU to
+        # avoid a device-to-host sync per layer. Kernel backends need it on GPU.
+        if self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
+            cu_seqlens_device = cu_seqlens
+        else:
+            cu_seqlens_device = async_tensor_h2d(cu_seqlens, device)
+
         return {
             "rotary_pos_emb_cos": rotary_pos_emb_cos,
             "rotary_pos_emb_sin": rotary_pos_emb_sin,
-            "cu_seqlens": async_tensor_h2d(cu_seqlens, device),
+            "cu_seqlens": cu_seqlens_device,
             "max_seqlen": max_seqlen,
         }
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -114,6 +114,7 @@ from vllm.utils.cache import LRUCache
 from vllm.utils.collection_utils import is_list_of
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.torch_utils import PIN_MEMORY
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.encoder_cudagraph_defs import EncoderCudaGraphReplayBuffers
 
 from ...utils.gpu_sync_debug import gpu_sync_allowed
@@ -834,15 +835,21 @@ class Qwen3_VisionTransformer(nn.Module):
         # graphs without changing behavior (the scalar is baked at capture).
         metadata["max_seqlen"] = torch.tensor(max_seqlen_val, dtype=torch.int32)
 
-        # Recompute cu_seqlens (backend-specific transformation)
-        metadata["cu_seqlens"] = MMEncoderAttention.maybe_recompute_cu_seqlens(
-            self.attn_backend,
-            cu_seqlens,
-            self.hidden_size,
-            self.tp_size,
-            device,
-            fp8_padded_hidden_size=self.fp8_padded_hidden_size,
-        )
+        # Recompute cu_seqlens (backend-specific transformation).
+        # The non-flash (SDPA) backend splits the packed sequence with Python
+        # sizes derived from cu_seqlens in every block, so keep it on CPU to
+        # avoid a device-to-host sync per layer. Kernel backends need it on GPU.
+        if self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
+            metadata["cu_seqlens"] = torch.from_numpy(cu_seqlens)
+        else:
+            metadata["cu_seqlens"] = MMEncoderAttention.maybe_recompute_cu_seqlens(
+                self.attn_backend,
+                cu_seqlens,
+                self.hidden_size,
+                self.tp_size,
+                device,
+                fp8_padded_hidden_size=self.fp8_padded_hidden_size,
+            )
 
         return metadata
 


### PR DESCRIPTION
## Purpose

Ports the spirit of huggingface/transformers#47703 ("Fix D2H sync in Qwen VL vision encoder") into vLLM for the remaining real sync point.

The `TORCH_SDPA` multimodal-encoder attention backend splits the packed vision sequence per block using Python sizes derived from `cu_seqlens`. Because every Qwen VL vision tower previously moved `cu_seqlens` to GPU unconditionally, the per-block `.tolist()` in `vit_torch_sdpa_wrapper` (`vllm/v1/attention/ops/vit_attn_wrappers.py:277`) forced a device-to-host sync on every attention layer of every eager forward. `grid_thw` is host metadata to begin with, so this change keeps `cu_seqlens` (and `cu_window_seqlens` for Qwen2.5-VL) on CPU when the SDPA backend is selected, eliminating those syncs. Kernel backends (FlashAttention / Triton / FlashInfer) still receive the GPU tensor and are unchanged.

The other two sync classes HF #47703 targeted were already mitigated in vLLM (`grid_thw` stays CPU host metadata via `keep_on_cpu`, `max_seqlen` is kept on CPU per #37139, and the mrope position path is CPU/numpy), so they are intentionally not touched here.

## Why this is not duplicating an existing PR

Searched `vllm-project/vllm` for open PRs matching "D2H", "Qwen VL", and vision-encoder sync fixes (e.g. #37139, #37239, #37316, #42850). None address the non-flash/SDPA encoder `cu_seqlens` D2H sync. HF #47703 is a transformers PR (separate repository).

## Test plan

Added `test_mha_attn_varlen_forward_sdpa_cpu_cu_seqlens` in `tests/kernels/attention/test_mha_attn.py`, asserting the SDPA varlen forward produces identical output with a CPU `cu_seqlens` tensor (the mechanism the fix relies on):

```
pytest tests/kernels/attention/test_mha_attn.py -k sdpa_cpu_cu_seqlens -v
```

- `ruff check`, `ruff format`, mypy, and all pre-commit hooks: clean.
- Behavior is preserved by construction (identical split sizes; only the device of an intermediate control tensor changes), so generated embeddings are bit-for-bit unchanged.

## GPU / model-eval results (PENDING — required before merge)

No GPU is available in the authoring environment, so the following must be run by a reviewer/submitter on a CUDA runner before merge:

- Profiler before/after on `Qwen/Qwen3-VL-2B` (and Qwen2.5-VL / Qwen2-VL) with `--mm-encoder-attn-backend torch_sdpa` in eager mode: expect per-layer `_local_scalar_dense` + D2H `cudaMemcpyAsync` events per forward to drop to ~0.
- Image-caption parity check (outputs must be identical before/after).

## AI-assistance statement

This PR was authored with AI assistance (opencode). The change, test, and analysis were reviewed by the submitting human (Mahnoor Zaffar).