### PR TITLE
[Docs] Remove MiniMaxVL01 from supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -592,7 +592,6 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `MiniCPMO` | MiniCPM-O | T + I<sup>E+</sup> + V<sup>E+</sup> + A<sup>E+</sup> | `openbmb/MiniCPM-o-2_6`, etc. | ✅︎ | ✅︎ |
 | `MiniCPMV` | MiniCPM-V | T + I<sup>E+</sup> + V<sup>E+</sup> | `openbmb/MiniCPM-V-2` (see note), `openbmb/MiniCPM-Llama3-V-2_5`, `openbmb/MiniCPM-V-2_6`, `openbmb/MiniCPM-V-4`, `openbmb/MiniCPM-V-4_5`, `openbmb/MiniCPM-V-4_6`, etc. | ✅︎ | |
 | `MiniMaxM3SparseForConditionalGeneration` | MiniMax-M3 | T + I<sup>+</sup> + V<sup>+</sup> | `MiniMaxAI/MiniMax-M3`, `MiniMaxAI/MiniMax-M3-MXFP8`, etc. | | ✅︎ |
-| `MiniMaxVL01ForConditionalGeneration` | MiniMax-VL | T + I<sup>E+</sup> | `MiniMaxAI/MiniMax-VL-01`, etc. | | ✅︎ |
 | `Mistral3ForConditionalGeneration` | Mistral3 (HF Transformers) | T + I<sup>+</sup> | `mistralai/Mistral-Small-3.1-24B-Instruct-2503`, etc. | ✅︎ | ✅︎ |
 | `MolmoForCausalLM` | Molmo | T + I<sup>+</sup> | `allenai/Molmo-7B-D-0924`, `allenai/Molmo-7B-O-0924`, etc. | ✅︎ | ✅︎ |
 | `Molmo2ForConditionalGeneration` | Molmo2 | T + I<sup>+</sup> / V | `allenai/Molmo2-4B`, `allenai/Molmo2-8B`, `allenai/Molmo2-O-7B`, `allenai/MolmoWeb-4B`<sup>^</sup>, `allenai/MolmoWeb-8B`<sup>^</sup> | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary

`MiniMaxVL01ForConditionalGeneration` is still listed in `docs/models/supported_models.md` as a supported multimodal architecture, but the model registry treats it as previously supported only through **v0.23.0**.

In `vllm/model_executor/models/registry.py`, `_PREVIOUSLY_SUPPORTED_MODELS` maps:

```python
"MiniMaxVL01ForConditionalGeneration": "0.23.0",
```

Resolving that architecture now raises `ValueError` ("was supported in vLLM until v0.23.0, and is not supported anymore"). This PR removes the stale docs row. Current MiniMax support remains documented via `MiniMaxM2ForCausalLM` / `MiniMaxM3Sparse*`.

## Local repro / verification

```bash
# 1) Confirm registry marks MiniMaxVL01 as previously supported (until 0.23.0)
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/model_executor/models/registry.py \
  | rg -n 'MiniMaxVL01ForConditionalGeneration|_PREVIOUSLY_SUPPORTED_MODELS'

# 2) Confirm docs still list it as supported (pre-fix)
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/models/supported_models.md \
  | rg -n 'MiniMaxVL01ForConditionalGeneration'

# 3) Confirm active MiniMax arches remain registered
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/model_executor/models/registry.py \
  | rg -n 'MiniMaxM2ForCausalLM|MiniMaxM3Sparse'
```

Expected before this PR: docs row present, registry previously-supported entry present.
Expected after: docs row removed; registry previously-supported entry unchanged.

## Test plan

- [x] Raw file compare: docs row exists on main; registry `_PREVIOUSLY_SUPPORTED_MODELS` entry present
- [x] Neighboring MiniMax M2/M3 rows retained
- [ ] Docs preview / CI