### PR TITLE
[BugFix] Fix is_supported of cutlass FP8 linear (selected and fails on A100)

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     CUTLASS_BLOCK_FP8_SUPPORTED,
     convert_to_channelwise,
+    cutlass_fp8_supported,
 )
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
@@ -164,8 +165,8 @@ class CutlassFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
     def is_supported(
         cls, compute_capability: int | None = None
     ) -> tuple[bool, str | None]:
-        if not current_platform.is_cuda():
-            return False, "requires CUDA."
+        if not cutlass_fp8_supported():
+            return False, "CUTLASS FP8 kernels not available"
         return True, None
 
     @classmethod


### PR DESCRIPTION

## Purpose

When running models with FP8 linear layers on A100 vLLM fails because `CutlassFP8ScaledMMLinearKernel` is selected  (Ampere / sm80 doesn't support this linear backend).

This PR uses `cutlass_fp8_supported` in `CutlassFP8ScaledMMLinearKernel.is_supported` and picks a valid linear backend (`MarlinFP8ScaledMMLinearKernel`) when running on A100.

## Test Plan

Run lm-eval GSM8K on A100 with a Nemotron-3 model (the model that originally failed without this fix).

## Test Result

vLLM does not fail (`MarlinFP8ScaledMMLinearKernel` is used).

GSM8K score is valid.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

