### PR TITLE
[CI] Reuse ColQwen3 models across pooling tests

### DIFF
--- a/tests/models/multimodal/pooling/test_colqwen3.py
+++ b/tests/models/multimodal/pooling/test_colqwen3.py
@@ -48,6 +48,20 @@ DTYPE = "half"
 GPU_MEMORY_UTILIZATION = 0.7
 
 
+@pytest.fixture(scope="module", params=MODELS)
+def colqwen3_model(request, vllm_runner):
+    model = request.param
+    with vllm_runner(
+        model,
+        runner="pooling",
+        dtype=DTYPE,
+        max_model_len=4096,
+        enforce_eager=True,
+        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+    ) as vllm_model:
+        yield model, vllm_model
+
+
 def _make_base64_image(
     width: int = 64, height: int = 64, color: tuple[int, int, int] = (255, 0, 0)
 ) -> str:
@@ -85,75 +99,51 @@ def _make_text_mm_param(text: str) -> ScoreMultiModalParam:
 
 
 def _run_token_embed_test(
-    vllm_runner: type[VllmRunner],
+    vllm_model: VllmRunner,
     model: str,
-    *,
-    dtype: str,
 ) -> None:
     """Verify per-token embedding shape and L2 normalization."""
-    with vllm_runner(
-        model,
-        runner="pooling",
-        dtype=dtype,
-        max_model_len=4096,
-        enforce_eager=True,
-        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-    ) as vllm_model:
-        outputs = vllm_model.token_embed([TEXT_QUERIES[0]])
+    outputs = vllm_model.token_embed([TEXT_QUERIES[0]])
 
-        assert len(outputs) == 1
-        emb = torch.tensor(outputs[0])
-        # Token embeddings should be 2D: [num_tokens, embed_dim]
-        assert emb.dim() == 2
-        assert emb.shape[1] == EMBED_DIMS[model]
-        assert emb.shape[0] > 1
+    assert len(outputs) == 1
+    emb = torch.tensor(outputs[0])
+    # Token embeddings should be 2D: [num_tokens, embed_dim]
+    assert emb.dim() == 2
+    assert emb.shape[1] == EMBED_DIMS[model]
+    assert emb.shape[0] > 1
 
-        # Verify L2 normalization
-        norms = torch.norm(emb, p=2, dim=-1)
-        torch.testing.assert_close(
-            norms,
-            torch.ones_like(norms),
-            rtol=1e-2,
-            atol=1e-2,
-        )
+    # Verify L2 normalization
+    norms = torch.norm(emb, p=2, dim=-1)
+    torch.testing.assert_close(
+        norms,
+        torch.ones_like(norms),
+        rtol=1e-2,
+        atol=1e-2,
+    )
 
 
 def _run_late_interaction_test(
-    vllm_runner: type[VllmRunner],
-    model: str,
-    *,
-    dtype: str,
+    vllm_model: VllmRunner,
 ) -> None:
     """Verify MaxSim scoring matches manual computation."""
     from vllm.entrypoints.pooling.scoring.utils import compute_maxsim_score
 
-    with vllm_runner(
-        model,
-        runner="pooling",
-        dtype=dtype,
-        max_model_len=4096,
-        enforce_eager=True,
-        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-    ) as vllm_model:
-        q_outputs = vllm_model.token_embed([TEXT_QUERIES[0]])
-        d_outputs = vllm_model.token_embed([TEXT_DOCUMENTS[0]])
+    q_outputs = vllm_model.token_embed([TEXT_QUERIES[0]])
+    d_outputs = vllm_model.token_embed([TEXT_DOCUMENTS[0]])
 
-        q_emb = torch.tensor(q_outputs[0])
-        d_emb = torch.tensor(d_outputs[0])
+    q_emb = torch.tensor(q_outputs[0])
+    d_emb = torch.tensor(d_outputs[0])
 
-        manual_score = compute_maxsim_score(q_emb, d_emb).item()
+    manual_score = compute_maxsim_score(q_emb, d_emb).item()
 
-        vllm_scores = vllm_model.score(TEXT_QUERIES[0], TEXT_DOCUMENTS[0])
+    vllm_scores = vllm_model.score(TEXT_QUERIES[0], TEXT_DOCUMENTS[0])
 
-        assert len(vllm_scores) == 1
-        assert vllm_scores[0] == pytest.approx(manual_score, rel=0.01)
+    assert len(vllm_scores) == 1
+    assert vllm_scores[0] == pytest.approx(manual_score, rel=0.01)
 
 
 def _run_relevance_test(
-    vllm_runner: type[VllmRunner],
-    model: str,
-    *,
-    dtype: str,
+    vllm_model: VllmRunner,
 ) -> None:
     """Verify that relevant documents score higher than irrelevant ones."""
     query = "What is machine learning?"
@@ -163,59 +153,33 @@ def _run_relevance_test(
         "Deep learning uses neural networks for complex tasks.",
     ]
 
-    with vllm_runner(
-        model,
-        runner="pooling",
-        dtype=dtype,
-        max_model_len=4096,
-        enforce_eager=True,
-        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-    ) as vllm_model:
-        scores = vllm_model.score(query, documents)
+    scores = vllm_model.score(query, documents)
 
-        assert len(scores) == 3
-        assert scores[0] > scores[1], "ML doc should score higher than weather doc"
-        assert scores[2] > scores[1], "DL doc should score higher than weather doc"
+    assert len(scores) == 3
+    assert scores[0] > scores[1], "ML doc should score higher than weather doc"
+    assert scores[2] > scores[1], "DL doc should score higher than weather doc"
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("dtype", [DTYPE])
-def test_colqwen3_token_embed(
-    vllm_runner,
-    model: str,
-    dtype: str,
-) -> None:
-    _run_token_embed_test(vllm_runner, model, dtype=dtype)
+def test_colqwen3_token_embed(colqwen3_model) -> None:
+    model, vllm_model = colqwen3_model
+    _run_token_embed_test(vllm_model, model)
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("dtype", [DTYPE])
-def test_colqwen3_late_interaction_scoring(
-    vllm_runner,
-    model: str,
-    dtype: str,
-) -> None:
-    _run_late_interaction_test(vllm_runner, model, dtype=dtype)
+def test_colqwen3_late_interaction_scoring(colqwen3_model) -> None:
+    _, vllm_model = colqwen3_model
+    _run_late_interaction_test(vllm_model)
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("dtype", [DTYPE])
-def test_colqwen3_relevance_ordering(
-    vllm_runner,
-    model: str,
-    dtype: str,
-) -> None:
-    _run_relevance_test(vllm_runner, model, dtype=dtype)
+def test_colqwen3_relevance_ordering(colqwen3_model) -> None:
+    _, vllm_model = colqwen3_model
+    _run_relevance_test(vllm_model)
 
 
 # ── Multimodal scoring tests ────────────────────────────────
 
 
 def _run_multimodal_text_query_image_docs_test(
-    vllm_runner: type[VllmRunner],
-    model: str,
-    *,
-    dtype: str,
+    vllm_model: VllmRunner,
 ) -> None:
     """Score a text query against image documents via the multimodal path.
 
@@ -231,26 +195,15 @@ def _run_multimodal_text_query_image_docs_test(
         _make_image_mm_param(blue_image),
     ]
 
-    with vllm_runner(
-        model,
-        runner="pooling",
-        dtype=dtype,
-        max_model_len=4096,
-        enforce_eager=True,
-        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-    ) as vllm_model:
-        scores = vllm_model.llm.score(query, image_docs)
+    scores = vllm_model.llm.score(query, image_docs)
 
-        assert len(scores) == 2
-        for s in scores:
-            assert isinstance(s.outputs.score, float)
+    assert len(scores) == 2
+    for s in scores:
+        assert isinstance(s.outputs.score, float)
 
 
 def _run_multimodal_mixed_docs_test(
-    vllm_runner: type[VllmRunner],
-    model: str,
-    *,
-    dtype: str,
+    vllm_model: VllmRunner,
 ) -> None:
     """Score a text query against a mix of text and image documents.
 
@@ -266,28 +219,17 @@ def _run_multimodal_mixed_docs_test(
         _make_image_mm_param(red_image),
     ]
 
-    with vllm_runner(
-        model,
-        runner="pooling",
-        dtype=dtype,
-        max_model_len=4096,
-        enforce_eager=True,
-        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-    ) as vllm_model:
-        scores = vllm_model.llm.score(query, documents)
+    scores = vllm_model.llm.score(query, documents)
 
-        assert len(scores) == 2
-        for s in scores:
-            assert isinstance(s.outputs.score, float)
-        # Text document about France should score higher than a random image
-        assert scores[0].outputs.score > scores[1].outputs.score
+    assert len(scores) == 2
+    for s in scores:
+        assert isinstance(s.outputs.score, float)
+    # Text document about France should score higher than a random image
+    assert scores[0].outputs.score > scores[1].outputs.score
 
 
 def _run_multimodal_image_query_text_docs_test(
-    vllm_runner: type[VllmRunner],
-    model: str,
-    *,
-    dtype: str,
+    vllm_model: VllmRunner,
 ) -> None:
     """Score an image query against text documents.
 
@@ -302,46 +244,23 @@ def _run_multimodal_image_query_text_docs_test(
         "The weather forecast shows rain tomorrow.",
     ]
 
-    with vllm_runner(
-        model,
-        runner="pooling",
-        dtype=dtype,
-        max_model_len=4096,
-        enforce_eager=True,
-        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-    ) as vllm_model:
-        scores = vllm_model.llm.score(image_query, documents)
+    scores = vllm_model.llm.score(image_query, documents)
 
-        assert len(scores) == 2
-        for s in scores:
-            assert isinstance(s.outputs.score, float)
+    assert len(scores) == 2
+    for s in scores:
+        assert isinstance(s.outputs.score, float)
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("dtype", [DTYPE])
-def test_colqwen3_multimodal_text_query_image_docs(
-    vllm_runner,
-    model: str,
-    dtype: str,
-) -> None:
-    _run_multimodal_text_query_image_docs_test(vllm_runner, model, dtype=dtype)
+def test_colqwen3_multimodal_text_query_image_docs(colqwen3_model) -> None:
+    _, vllm_model = colqwen3_model
+    _run_multimodal_text_query_image_docs_test(vllm_model)
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("dtype", [DTYPE])
-def test_colqwen3_multimodal_mixed_docs(
-    vllm_runner,
-    model: str,
-    dtype: str,
-) -> None:
-    _run_multimodal_mixed_docs_test(vllm_runner, model, dtype=dtype)
+def test_colqwen3_multimodal_mixed_docs(colqwen3_model) -> None:
+    _, vllm_model = colqwen3_model
+    _run_multimodal_mixed_docs_test(vllm_model)
 
 
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("dtype", [DTYPE])
-def test_colqwen3_multimodal_image_query_text_docs(
-    vllm_runner,
-    model: str,
-    dtype: str,
-) -> None:
-    _run_multimodal_image_query_text_docs_test(vllm_runner, model, dtype=dtype)
+def test_colqwen3_multimodal_image_query_text_docs(colqwen3_model) -> None:
+    _, vllm_model = colqwen3_model
+    _run_multimodal_image_query_text_docs_test(vllm_model)


### PR DESCRIPTION
- Load each of the three ColQwen3 models once per test module, reducing model initialization from 18 loads to three.
- Reuse that model across its six existing text embedding, scoring, relevance, and multimodal tests.
- Keep all 18 cases, inputs, assertions, and engine settings, following the neighboring ColQwen3.5 fixture pattern.

`git bisect run` identified [PR #55588](https://github.com/vllm-project/vllm/pull/55588) as the change enabling these 18 cases on Transformers 5; [nightly 12674](https://buildkite.com/vllm/amd-ci/builds/12674) had skipped them. All 18 passed in [build 12711's MI300 Extended Pooling job](https://buildkite.com/vllm/amd-ci/builds/12711#01a08040-53ea-4a7f-9b74-767fe77193a6), but repeated model loading added about 31 minutes to a suite that previously took about 23 minutes, exceeding its 50-minute budget. A slower checkout also contributed to the timeout; the bisect established test enablement, while CI timings established the added workload. 

This fix was developed with AI assistance and removes repeated startup while retaining the full test coverage.
