### PR TITLE
Corrected docstring in moe_align_block_size function example explanation

### DIFF
--- a/vllm/model_executor/layers/fused_moe/moe_align_block_size.py
+++ b/vllm/model_executor/layers/fused_moe/moe_align_block_size.py
@@ -159,7 +159,7 @@ def batched_moe_align_block_size(
       The gemm kernel using this sorted_token_ids is expected to skip the
       gemm computation when it encounters this invalid index.
 
-      expert_ids will be [0, 1, 3, 3, 4, 5, 5, -1, -1, (rest all -1) ...]
+      expert_ids will be [0, 1, 3, 3, 4, 4, -1, -1, (rest all -1) ...]
       Here, -1 represents an invalid expert. The gemm kernel using this
       expert_ids is expected to skip the gemm computation when it encounters
       an expert of id -1.


### PR DESCRIPTION



## Purpose
Fixes a typo in the example docstring of `batched_moe_align_block_size` where `expert_ids` incorrectly included out-of-bounds batch indices and an incorrect block count.
## Test Plan
In the example given in `batched_moe_align_block_size`:
- `num_batches = 5` (valid batch indices: 0, 1, 2, 3, 4)
- `block_size = 4`
- `expert_num_tokens = [2, 3, 0, 6, 8]`
Calculating the required blocks per batch:
- **Batch 0** (2 tokens): 1 block $\rightarrow$ `0`
- **Batch 1** (3 tokens): 1 block $\rightarrow$ `1`
- **Batch 2** (0 tokens): 0 blocks
- **Batch 3** (6 tokens): 2 blocks $\rightarrow$ `3, 3`
- **Batch 4** (8 tokens): 2 blocks $\rightarrow$ `4, 4`

Total valid blocks = 6 blocks (24 tokens, consistent with `num_tokens_post_pad = 24`).
The previous docstring stated:
```python
expert_ids will be [0, 1, 3, 3, 4, 5, 5, -1, -1, (rest all -1) ...]
```
This had two issues:

    Index 5 does not exist since num_batches = 5.

    It listed 7 valid blocks (28 padded tokens), which conflicted with num_tokens_post_pad = 24.
Updated to:
```python
expert_ids will be [0, 1, 3, 3, 4, 4, -1, -1, (rest all -1) ...]
```

This is easy to confirm in the C++ cuda code that the function calls. 

In the following code the expert_ids are passed from python in place of the batch_ids argument
```
void batched_moe_align_block_size(int64_t max_tokens_per_batch,
                                  int64_t block_size,
                                  const torch::stable::Tensor& batch_num_tokens,
                                  torch::stable::Tensor sorted_ids,
                                  torch::stable::Tensor batch_ids,
                                  torch::stable::Tensor num_tokens_post_pad) {
  namespace batched_kernel = vllm::moe::batched_moe_align_block_size;

  const torch::stable::accelerator::DeviceGuard device_guard(
      batch_num_tokens.get_device_index());
  const cudaStream_t stream =
      get_current_cuda_stream(batch_num_tokens.get_device_index());
  int32_t const B = batch_num_tokens.size(0);
  int32_t const num_blocks_per_batch =
      round_to_next_multiple_of(max_tokens_per_batch, block_size) / block_size;
  int32_t const num_blocks = num_blocks_per_batch * B;
  int64_t const sorted_ids_size = num_blocks * block_size;

  STD_TORCH_CHECK(sorted_ids.size(0) == sorted_ids_size);
  STD_TORCH_CHECK(batch_ids.size(0) == sorted_ids_size / block_size);
  STD_TORCH_CHECK(num_tokens_post_pad.size(0) == 1);
  STD_TORCH_CHECK(B <= batched_kernel::num_threads);

  batched_kernel::batched_moe_align_block_size_kernel<<<
      batched_kernel::num_blocks, batched_kernel::num_threads, 0, stream>>>(
      B, max_tokens_per_batch, block_size,
      reinterpret_cast<const int32_t*>(batch_num_tokens.const_data_ptr()),
      reinterpret_cast<int32_t*>(sorted_ids.mutable_data_ptr()),
      reinterpret_cast<int32_t*>(batch_ids.mutable_data_ptr()),
      reinterpret_cast<int32_t*>(num_tokens_post_pad.mutable_data_ptr()));
}
```

the batch ids are then passed in the following kernel for the block_ids argument - 
```
__global__ void batched_moe_align_block_size_kernel(
    int32_t const num_batches, int32_t const max_tokens_per_batch,
    int32_t const block_size, int32_t const* __restrict__ batch_num_tokens,
    int32_t* __restrict__ sorted_ids, int32_t* __restrict__ block_ids,
    int32_t* __restrict__ num_tokens_post_pad) {
  // TODO(varun): This is a naive implementation. Could be optimized.

  size_t const batch_id = threadIdx.x;
  size_t const stride = blockDim.x * gridDim.x;
  int32_t const num_blocks_per_batch =
      CEILDIV(max_tokens_per_batch, block_size);
  int32_t const sorted_ids_size =
      num_blocks_per_batch * num_batches * block_size;
  int32_t const block_ids_size = sorted_ids_size / block_size;
  int32_t const SENTINEL =
      num_batches * max_tokens_per_batch;  // To denote invalid entries.
  // Initialize sorted_ids
  for (size_t i = threadIdx.x; i < sorted_ids_size; i += stride) {
    sorted_ids[i] = SENTINEL;
  }
  // Initialize expert_ids with -1
  for (size_t i = threadIdx.x; i < block_ids_size; i += stride) {
    block_ids[i] = -1;
  }

  int32_t b_num_tokens = 0;
  if (batch_id < num_batches) {
    b_num_tokens = batch_num_tokens[batch_id];
  }
  int32_t const ceil_b_num_tokens =
      CEILDIV(b_num_tokens, block_size) * block_size;

  // Compute prefix sum over token counts per expert
  using BlockScan = cub::BlockScan<int32_t, 1024>;
  __shared__ typename BlockScan::TempStorage temp_storage;
  int cumsum_val;
  BlockScan(temp_storage).ExclusiveSum(ceil_b_num_tokens, cumsum_val);
  __syncthreads();

  bool const is_last_batch = batch_id == (num_batches - 1);
  if (is_last_batch) {
    *num_tokens_post_pad = cumsum_val + ceil_b_num_tokens;
  }

  if (batch_id < num_batches) {
    int32_t const batch_offset = batch_id * max_tokens_per_batch;
    for (size_t i = 0; i < b_num_tokens; ++i) {
      sorted_ids[cumsum_val + i] = batch_offset + i;
    }

    int32_t const block_start = cumsum_val / block_size;
    int32_t const num_blocks = ceil_b_num_tokens / block_size;
    for (size_t i = 0; i < num_blocks; ++i) {
      block_ids[block_start + i] = batch_id;
    }
  }
}
```

and the above ensures that each block id only gets a valid batchid which for the example case is from 0 to 4 both inclusive. as block_ids aka expert_ids in python could never be set to 5 due to the if guard at the end of the code before block_ids/expert_ids is set to the batch_id.


I also ran the small python script with the example data on the function - 

```
import torch
from vllm.utils.math_utils import round_up
from vllm import _custom_ops as ops

assert torch.cuda.is_available(), "This custom kernel requires a CUDA device."
device = torch.device("cuda")

# Inputs matching the docstring example
num_batches = 5
max_tokens_per_batch = 8
block_size = 4
expert_num_tokens = torch.tensor([2, 3, 0, 6, 8], dtype=torch.int32, device=device)

# Run kernel
B = expert_num_tokens.size(0)
device = expert_num_tokens.device

# Round up so each batch can be split to blocks evenly.
max_num_tokens_padded = B * round_up(max_tokens_per_batch, block_size)

sorted_ids = torch.empty((max_num_tokens_padded,), dtype=torch.int32, device=device)
assert max_num_tokens_padded % block_size == 0
max_num_m_blocks = max_num_tokens_padded // block_size
expert_ids = torch.empty((max_num_m_blocks,), dtype=torch.int32, device=device)
num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=device)

ops.batched_moe_align_block_size(
    max_tokens_per_batch=max_tokens_per_batch,
    block_size=block_size,
    expert_num_tokens=expert_num_tokens,
    sorted_ids=sorted_ids,
    expert_ids=expert_ids,
    num_tokens_post_pad=num_tokens_post_pad,
)

# Expected outputs
expected_num_tokens_post_pad = 24
expected_expert_ids_prefix = [0, 1, 3, 3, 4, 4, -1, -1]
expected_sorted_ids_prefix = [
    0, 1, 40, 40,       # Batch 0 (2 tokens + 2 pad)
    8, 9, 10, 40,       # Batch 1 (3 tokens + 1 pad)
    24, 25, 26, 27,     # Batch 3 block 1 (4 tokens)
    28, 29, 40, 40,     # Batch 3 block 2 (2 tokens + 2 pad)
    32, 33, 34, 35,     # Batch 4 block 1 (4 tokens)
    36, 37, 38, 39,     # Batch 4 block 2 (4 tokens)
    40, 40, 40, 40,     # Remaining blocks padded to sentinel (40)
]

# Assertions
actual_num_tokens = num_tokens_post_pad.item()
actual_expert_prefix = expert_ids[: len(expected_expert_ids_prefix)].tolist()
actual_sorted_prefix = sorted_ids[: len(expected_sorted_ids_prefix)].tolist()

assert actual_num_tokens == expected_num_tokens_post_pad, (
    f"Mismatch in num_tokens_post_pad: expected {expected_num_tokens_post_pad}, "
    f"got {actual_num_tokens}"
)

assert actual_expert_prefix == expected_expert_ids_prefix, (
    f"Mismatch in expert_ids: expected prefix {expected_expert_ids_prefix}, "
    f"got {actual_expert_prefix}"
)

assert actual_sorted_prefix == expected_sorted_ids_prefix, (
    f"Mismatch in sorted_token_ids: expected prefix {expected_sorted_ids_prefix}, "
    f"got {actual_sorted_prefix}"
)

print("Verification passed successfully:")
print(f"  num_tokens_post_pad : {actual_num_tokens}")
print(f"  expert_ids[:8]      : {actual_expert_prefix}")
print(f"  sorted_ids[:28]     : {actual_sorted_prefix}")

```
and the output confirmed my correction - 

Verification passed successfully:
  num_tokens_post_pad : 24
  expert_ids[:8]      : [0, 1, 3, 3, 4, 4, -1, -1]
  sorted_ids[:28]     : [0, 1, 40, 40, 8, 9, 10, 40, 24, 25, 26, 27, 28, 29, 40, 40, 32, 33, 34, 35, 36, 37, 38, 39, 40, 40, 40, 40]

## Test Result
The tests that I conducted show that the correct expert_ids on executing the moe align function is the one I suggested
Verification passed successfully:
  num_tokens_post_pad : 24
  expert_ids[:8]      : [0, 1, 3, 3, 4, 4, -1, -1]
  sorted_ids[:28]     : [0, 1, 40, 40, 8, 9, 10, 40, 24, 25, 26, 27, 28, 29, 40, 40, 32, 33, 34, 35, 36, 37, 38, 39, 40, 40, 40, 40]

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

