### PR TITLE
[Bugfix] Preserve decode ordering for stateful attention

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1741,6 +1741,28 @@ def test_reorder_batch_threshold_preserves_required_decode_ordering():
     assert runner.reorder_batch_threshold == 4
 
 
+def test_reorder_batch_threshold_keeps_minimum_for_optional_ordering():
+    runner = object.__new__(GPUModelRunner)
+    first_builder = SimpleNamespace(
+        reorder_batch_threshold=1,
+        requires_decode_ordering=False,
+    )
+    second_builder = SimpleNamespace(
+        reorder_batch_threshold=4,
+        requires_decode_ordering=False,
+    )
+    runner.attn_groups = [
+        [
+            SimpleNamespace(get_metadata_builder=lambda: first_builder),
+            SimpleNamespace(get_metadata_builder=lambda: second_builder),
+        ]
+    ]
+
+    GPUModelRunner.calculate_reorder_batch_threshold(runner)
+
+    assert runner.reorder_batch_threshold == 1
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda(),
     reason="Attention backend FLASHINFER is only supported on CUDA.",

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1719,6 +1719,28 @@ def test_is_uniform_decode() -> None:
     )
 
 
+def test_reorder_batch_threshold_preserves_required_decode_ordering():
+    runner = object.__new__(GPUModelRunner)
+    optional_builder = SimpleNamespace(
+        reorder_batch_threshold=1,
+        requires_decode_ordering=False,
+    )
+    required_builder = SimpleNamespace(
+        reorder_batch_threshold=4,
+        requires_decode_ordering=True,
+    )
+    runner.attn_groups = [
+        [
+            SimpleNamespace(get_metadata_builder=lambda: optional_builder),
+            SimpleNamespace(get_metadata_builder=lambda: required_builder),
+        ]
+    ]
+
+    GPUModelRunner.calculate_reorder_batch_threshold(runner)
+
+    assert runner.reorder_batch_threshold == 4
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda(),
     reason="Attention backend FLASHINFER is only supported on CUDA.",

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -598,6 +598,9 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     # If not, set this to None. Otherwise set it to the query
     # length that will be pulled into the front of the batch.
     reorder_batch_threshold: int | None = None
+    # Whether lowering the threshold can misclassify multi-token decodes as
+    # prefills and corrupt stateful attention backends.
+    requires_decode_ordering: bool = False
     # Does this backend/builder support updating the block table in existing
     # metadata
     supports_update_block_table: bool = False

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -84,6 +84,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
     _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
 
     reorder_batch_threshold: int = 1
+    requires_decode_ordering = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/linear_attn.py
+++ b/vllm/v1/attention/backends/linear_attn.py
@@ -48,6 +48,7 @@ class LinearAttentionMetadata:
 class LinearAttentionMetadataBuilder(AttentionMetadataBuilder[LinearAttentionMetadata]):
     kv_cache_spec: MambaSpec
     reorder_batch_threshold: int = 1
+    requires_decode_ordering = True
 
     _cudagraph_support = AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -90,6 +90,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
     kv_cache_spec: MambaSpec
     metadata_cls: type[M]
     reorder_batch_threshold: int = 1
+    requires_decode_ordering = True
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
 
     # Will be disabled if speculative decoding is used

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7313,20 +7313,37 @@ class GPUModelRunner(
         Choose the minimum reorder batch threshold from all attention groups.
         Backends should be able to support lower threshold then what they request
         just may have a performance penalty due to that backend treating decodes
-        as prefills.
+        as prefills. Stateful backends can require a higher threshold to keep
+        multi-token decodes ahead of prefills.
         """
         min_none_high = lambda a, b: a if b is None else b if a is None else min(a, b)
 
-        reorder_batch_thresholds: list[int | None] = [
-            group.get_metadata_builder().reorder_batch_threshold
-            for group in self._attn_group_iterator()
+        builders = [
+            group.get_metadata_builder() for group in self._attn_group_iterator()
+        ]
+        reorder_batch_thresholds = [
+            builder.reorder_batch_threshold for builder in builders
         ]
         # If there are no attention groups (attention-free model) or no backend
         # reports a threshold, leave reordering disabled.
         if len(reorder_batch_thresholds) == 0:
             self.reorder_batch_threshold = None
             return
-        self.reorder_batch_threshold = reduce(min_none_high, reorder_batch_thresholds)  # type: ignore[assignment]
+
+        self.reorder_batch_threshold = reduce(min_none_high, reorder_batch_thresholds)
+        required_thresholds = [
+            builder.reorder_batch_threshold
+            for builder in builders
+            if builder.requires_decode_ordering
+            and builder.reorder_batch_threshold is not None
+        ]
+        if required_thresholds:
+            required_threshold = max(required_thresholds)
+            if (
+                self.reorder_batch_threshold is None
+                or required_threshold > self.reorder_batch_threshold
+            ):
+                self.reorder_batch_threshold = required_threshold
 
     def may_reinitialize_input_batch(
         self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]


### PR DESCRIPTION
## Summary

Fixes #55894.

When MTP speculative decoding is used with a hybrid model, the target and
drafter attention groups can report different `reorder_batch_threshold` values.
The runner currently chooses the minimum value across groups. This can place
multi-token decode rows behind a chunked prefill, causing stateful Mamba/GDN
attention backends to process those rows with prefill kernels and corrupt their
recurrent state.

This change adds a `requires_decode_ordering` capability to attention metadata
builders. Stateful Mamba, GDN, linear-attention, and short-convolution builders
set it, and the runner raises the global threshold to the largest required
threshold while preserving the existing minimum for backends that only tolerate
lower thresholds.

## Why this is not duplicate work

I checked the issue, its timeline and comments, and searched open PRs for
`55894`, `reorder_batch_threshold`, `requires_decode_ordering`, and hybrid
Mamba/MTP work. No open PR addressed this threshold-aggregation fix. Existing
related Mamba/speculative-decoding PRs address different cache, state-lifecycle,
or kernel issues.

## Test plan

The new regression test verifies that a stateful backend's required threshold
is preserved when another backend reports a lower threshold.

```text
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_model_runner.py \
  -k 'is_uniform_decode or reorder_batch_threshold_preserves_required_decode_ordering' \
  -v --confcutdir=tests/v1/worker
```

Result: 2 passed, 41 deselected.

```text
pre-commit run --files \
  vllm/v1/attention/backend.py \
  vllm/v1/attention/backends/gdn_attn.py \
  vllm/v1/attention/backends/linear_attn.py \
  vllm/v1/attention/backends/mamba_attn.py \
  vllm/v1/worker/gpu_model_runner.py \
  tests/v1/worker/test_gpu_model_runner.py
git diff --check
```

Both checks passed, including ruff, mypy, SPDX, and configuration validation.


Those GPU end-to-end checks should be run in a compatible CUDA environment.

## AI assistance disclosure

AI assistance was used for code investigation, implementation, test execution,
and drafting this description. The human submitter must review every changed
line and be able to explain and defend the change before merge.
