### PR TITLE
[Perf] Improve BF16x3 router GEMM accuracy and make it default on sm100

### DIFF
--- a/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
+++ b/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for the experimental SM100 BF16x3 router GEMM."""
+"""Tests for the SM100 BF16x3 router GEMM."""
 
 import pytest
 import torch
@@ -20,7 +20,16 @@ def _requires_sm100_cutedsl():
 
 @pytest.mark.parametrize(
     ("num_tokens", "hidden_dim", "num_experts"),
-    [(48, 6144, 128), (96, 3072, 256), (129, 3072, 17)],
+    [
+        (48, 6144, 128),
+        (96, 3072, 256),
+        (129, 3072, 17),
+        # long-K cases exercise the multi-accumulation path (the split-K
+        # heuristic leaves chains of 15 and 32 K-tiles here, above the
+        # kernel's num_tmem_acc bound)
+        (1024, 8192, 256),
+        (2048, 8192, 256),
+    ],
 )
 def test_bf16x3_router_gemm_matches_reference(
     num_tokens: int, hidden_dim: int, num_experts: int
@@ -36,8 +45,9 @@ def test_bf16x3_router_gemm_matches_reference(
     # Match the observed router weight scale
     w *= 0.053
     out = bf16x3_router_gemm(x, w)
-    ref = torch.nn.functional.linear(x.float(), w)
+    # FP64 reference: the FP32 reference itself drifts by ~5e-6 at N=2048
+    ref = torch.nn.functional.linear(x.double(), w.double())
 
     assert out.shape == (num_tokens, num_experts)
     assert out.dtype == torch.float32
-    assert torch.mean(torch.abs(out - ref)).item() < 5e-6
+    assert torch.mean(torch.abs(out.double() - ref)).item() < 5e-6

--- a/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
+++ b/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
@@ -51,30 +51,3 @@ def test_bf16x3_router_gemm_matches_reference(
     assert out.shape == (num_tokens, num_experts)
     assert out.dtype == torch.float32
     assert torch.mean(torch.abs(out.double() - ref)).item() < 5e-6
-
-
-def test_bf16x3_warmup_configs_cover_reachable_tiles():
-    from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
-        _bf16x3_warmup_configs,
-    )
-
-    configs = _bf16x3_warmup_configs(
-        [
-            (3072, 256, 33),
-            (6144, 128, 33),
-            (3072, 17, 1),
-        ],
-        max_num_tokens=512,
-        num_sms=152,
-    )
-
-    assert configs == (
-        (3072, 8),
-        (3072, 16),
-        (3072, 32),
-        (3072, 64),
-        (3072, 128),
-        (6144, 32),
-        (6144, 64),
-        (6144, 128),
-    )

--- a/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
+++ b/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
@@ -24,9 +24,9 @@ def _requires_sm100_cutedsl():
         (48, 6144, 128),
         (96, 3072, 256),
         (129, 3072, 17),
-        # long-K cases exercise the multi-accumulation path (the split-K
-        # heuristic leaves chains of 15 and 32 K-tiles here, above the
-        # kernel's num_tmem_acc bound)
+        # Long-K cases exercise the multi-accumulation path: the split-K
+        # heuristic leaves chains of 15 and 32 K-tiles, above the eight-tile
+        # accumulation bound.
         (1024, 8192, 256),
         (2048, 8192, 256),
     ],
@@ -51,3 +51,30 @@ def test_bf16x3_router_gemm_matches_reference(
     assert out.shape == (num_tokens, num_experts)
     assert out.dtype == torch.float32
     assert torch.mean(torch.abs(out.double() - ref)).item() < 5e-6
+
+
+def test_bf16x3_warmup_configs_cover_reachable_tiles():
+    from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
+        _bf16x3_warmup_configs,
+    )
+
+    configs = _bf16x3_warmup_configs(
+        [
+            (3072, 256, 33),
+            (6144, 128, 33),
+            (3072, 17, 1),
+        ],
+        max_num_tokens=512,
+        num_sms=152,
+    )
+
+    assert configs == (
+        (3072, 8),
+        (3072, 16),
+        (3072, 32),
+        (3072, 64),
+        (3072, 128),
+        (6144, 32),
+        (6144, 64),
+        (6144, 128),
+    )

--- a/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
+++ b/tests/kernels/test_bf16x3_router_gemm_cutedsl.py
@@ -24,9 +24,9 @@ def _requires_sm100_cutedsl():
         (48, 6144, 128),
         (96, 3072, 256),
         (129, 3072, 17),
-        # Long-K cases exercise the multi-accumulation path: the split-K
-        # heuristic leaves chains of 15 and 32 K-tiles, above the eight-tile
-        # accumulation bound.
+        # long-K cases exercise the multi-accumulation path (the split-K
+        # heuristic leaves chains of 15 and 32 K-tiles here, above the
+        # kernel's num_tmem_acc bound)
         (1024, 8192, 256),
         (2048, 8192, 256),
     ],

--- a/tests/kernels/test_ll_bf16_gemm.py
+++ b/tests/kernels/test_ll_bf16_gemm.py
@@ -441,7 +441,7 @@ def test_gate_linear_uses_ll_bf16_for_bf16_fast_path(monkeypatch):
     assert calls[0][1] is gate.weight
 
 
-def test_gate_linear_fp32_weight_falls_back(monkeypatch):
+def test_gate_linear_fp32_weight_path(monkeypatch):
     gate = _make_gate_linear(monkeypatch, params_dtype=torch.float32)
     assert not gate.allow_ll_bf16_gemm
     x = torch.randn(4, 2048, dtype=torch.bfloat16, device="cuda")
@@ -456,6 +456,11 @@ def test_gate_linear_fp32_weight_falls_back(monkeypatch):
     out, _ = gate(x)
     assert out.shape == (4, 64)
     assert out.dtype == torch.float32
+
+    if gate.allow_bf16x3_router_gemm:
+        compiled_gate = torch.compile(gate, backend="eager", fullgraph=True)
+        compiled_out, _ = compiled_gate(x)
+        torch.testing.assert_close(compiled_out, out)
 
 
 def test_gate_linear_non_bf16_activation_falls_back(monkeypatch):

--- a/tests/kernels/test_ll_bf16_gemm.py
+++ b/tests/kernels/test_ll_bf16_gemm.py
@@ -441,7 +441,7 @@ def test_gate_linear_uses_ll_bf16_for_bf16_fast_path(monkeypatch):
     assert calls[0][1] is gate.weight
 
 
-def test_gate_linear_fp32_weight_path(monkeypatch):
+def test_gate_linear_fp32_weight_falls_back(monkeypatch):
     gate = _make_gate_linear(monkeypatch, params_dtype=torch.float32)
     assert not gate.allow_ll_bf16_gemm
     x = torch.randn(4, 2048, dtype=torch.bfloat16, device="cuda")
@@ -456,11 +456,6 @@ def test_gate_linear_fp32_weight_path(monkeypatch):
     out, _ = gate(x)
     assert out.shape == (4, 64)
     assert out.dtype == torch.float32
-
-    if gate.allow_bf16x3_router_gemm:
-        compiled_gate = torch.compile(gate, backend="eager", fullgraph=True)
-        compiled_out, _ = compiled_gate(x)
-        torch.testing.assert_close(compiled_out, out)
 
 
 def test_gate_linear_non_bf16_activation_falls_back(monkeypatch):

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -230,9 +230,6 @@ class KernelConfig:
     enable_jit_warmup: bool = True
     """If True, run JIT compile warmup during kernel warmup."""
 
-    enable_bf16x3_router_gemm: bool = False
-    """If True, use the experimental SM100 BF16x3 CuteDSL router GEMM."""
-
     moe_backend: MoEBackend = "auto"
     """Backend for MoE expert computation kernels. Available options:
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -693,7 +693,6 @@ class EngineArgs:
     enable_flashinfer_autotune: bool = get_field(
         KernelConfig, "enable_flashinfer_autotune"
     )
-    enable_bf16x3_router_gemm: bool | None = None
     worker_cls: str = ParallelConfig.worker_cls
     worker_extension_cls: str = ParallelConfig.worker_extension_cls
 
@@ -1651,10 +1650,6 @@ class EngineArgs:
             "--enable-flashinfer-autotune",
             **kernel_kwargs["enable_flashinfer_autotune"],
         )
-        kernel_group.add_argument(
-            "--enable-bf16x3-router-gemm",
-            **kernel_kwargs["enable_bf16x3_router_gemm"],
-        )
         moe_backend_kwargs = kernel_kwargs["moe_backend"]
         moe_backend_kwargs["type"] = lambda s: s.lower().replace("-", "_")
         kernel_group.add_argument("--moe-backend", **moe_backend_kwargs)
@@ -2514,8 +2509,6 @@ class EngineArgs:
                     "are mutually exclusive"
                 )
             kernel_config.enable_flashinfer_autotune = self.enable_flashinfer_autotune
-        if self.enable_bf16x3_router_gemm is not None:
-            kernel_config.enable_bf16x3_router_gemm = self.enable_bf16x3_router_gemm
         if self.moe_backend != "auto":
             kernel_config.moe_backend = self.moe_backend
         if self.linear_backend != "auto":

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -467,7 +467,7 @@ def _splitk_reduce_kernel(
 
 
 def _splitk_reduce_config(split_k: int) -> tuple[int, int, int]:
-    block_s = 1 << (split_k - 1).bit_length()
+    block_s = triton.next_power_of_2(split_k)
     if block_s >= 64:
         return 1, 32, block_s
     if block_s >= 8:
@@ -496,37 +496,43 @@ def splitk_reduce_triton(partials: torch.Tensor, out: torch.Tensor):
     )
 
 
-# Tuned (BN, split_k) for mid-range token counts, from GB300 sweeps of the
-# FP32-router-weight models (MiniMax-M2/M3, Hunyuan-V3/V4, K=8192/M=256).
-# Selection is accuracy-constrained: per cell the fastest config whose MAE vs
-# FP64 is <= max(old-rule MAE, cuBLAS FP32 MAE), i.e. never worse than either
-# baseline. Lower split_k lengthens per-CTA TMEM accumulation chains and
-# raises MAE, so several cells keep high split_k. Outside this N range the
-# generic rule is within ~2%, so no rows are needed there.
-#
-# Rows are keyed by (K, M) = (hidden_size, num_experts) and cover the N
-# buckets (64, 128, 256, 512); N rounds up to the next bucket. Untabled shapes
-# use the shared default row. (128, 19) entries at N=512 reproduce the generic
-# rule because no faster config meets the accuracy bar there.
-_MID_RANGE_BUCKETS = (64, 128, 256, 512)
-_MID_RANGE_DEFAULT = ((16, 16), (32, 16), (64, 16), (128, 16))
-_MID_RANGE_TUNED = {
-    (4096, 192): ((32, 32), (64, 32), (128, 32), (128, 19)),  # Hunyuan-V3
-    (6144, 128): ((32, 64), (64, 64), (64, 32), (128, 32)),  # MiniMax-M3
-    (8192, 256): ((64, 64), (64, 32), (128, 32), (128, 19)),
+# Accuracy-constrained overrides from GB300 sweeps. Other shapes use
+# ``(next_power_of_2(N) // 4, 16)`` in this token range.
+_TILE_CONFIG_OVERRIDES = {
+    (4096, 192): {  # Hunyuan-V3
+        64: (32, 32),
+        128: (64, 32),
+        256: (128, 32),
+        512: (128, 19),
+    },
+    (6144, 128): {  # MiniMax-M3
+        64: (32, 64),
+        128: (64, 64),
+        256: (64, 32),
+        512: (128, 32),
+    },
+    (8192, 256): {
+        64: (64, 64),
+        128: (64, 32),
+        256: (128, 32),
+        512: (128, 19),
+    },
 }
 
 
-@cache
 def _pick_tile_config(N: int, K: int, M: int, num_sms: int) -> tuple[int, int]:
     """Return (BN, split_k): tuned table mid-range, generic rule otherwise."""
     k_tiles = math_utils.cdiv(K, 64)
 
     if 32 < N <= 512:
-        rows = _MID_RANGE_TUNED.get((K, M), _MID_RANGE_DEFAULT)
-        for bucket, (BN, split_k) in zip(_MID_RANGE_BUCKETS, rows):
-            if bucket >= N:
-                return BN, min(split_k, k_tiles)
+        token_bucket = triton.next_power_of_2(N)
+        overrides = _TILE_CONFIG_OVERRIDES.get((K, M))
+        BN, split_k = (
+            overrides[token_bucket]
+            if overrides is not None
+            else (token_bucket // 4, 16)
+        )
+        return BN, min(split_k, k_tiles)
 
     # next power of 2 within 8 and 128
     BN = triton.next_power_of_2(N)
@@ -550,7 +556,7 @@ def _bf16x3_warmup_configs(
         if min_num_tokens > max_num_tokens:
             continue
 
-        table_limit = min(max_num_tokens, _MID_RANGE_BUCKETS[-1])
+        table_limit = min(max_num_tokens, 512)
         for N in range(min_num_tokens, table_limit + 1):
             BN, _ = _pick_tile_config(N, K, M, num_sms)
             configs.add((K, BN))

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -12,7 +12,6 @@ boundaries the epilogue warps drain the main-term accumulator into a register
 master accumulator and the MMA warp resets it.
 """
 
-from collections.abc import Iterable
 from functools import cache
 
 import cutlass
@@ -546,100 +545,60 @@ def _pick_tile_config(N: int, K: int, M: int, num_sms: int) -> tuple[int, int]:
     return BN, split_k
 
 
-def _bf16x3_warmup_configs(
-    router_specs: Iterable[tuple[int, int, int]],
+def warmup_bf16x3_router_gemm(
+    K: int,
+    M: int,
+    min_num_tokens: int,
     max_num_tokens: int,
-    num_sms: int,
-) -> tuple[tuple[int, int], ...]:
-    """Return the reachable ``(K, BN)`` compile configurations."""
-    configs: set[tuple[int, int]] = set()
-    for K, M, min_num_tokens in router_specs:
-        if min_num_tokens > max_num_tokens:
-            continue
-
-        table_limit = min(max_num_tokens, 512)
-        for N in range(min_num_tokens, table_limit + 1):
-            BN, _ = _pick_tile_config(N, K, M, num_sms)
-            configs.add((K, BN))
-
-        if max_num_tokens > table_limit:
-            BN, _ = _pick_tile_config(max_num_tokens, K, M, num_sms)
-            configs.add((K, BN))
-
-    return tuple(sorted(configs))
-
-
-def _bf16x3_reduce_warmup_configs(
-    router_specs: Iterable[tuple[int, int, int]],
-    max_num_tokens: int,
-    num_sms: int,
-) -> tuple[tuple[int, int, int, int, int, int, int], ...]:
-    """Return the reachable Triton split-K reduction specializations."""
+) -> tuple[int, ...]:
+    """Compile every BF16x3 router GEMM configuration reachable at runtime."""
     from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+        TritonWarmupTensor,
         triton_scalar_specialization_rep,
     )
 
-    configs: set[tuple[int, int, int, int, int, int, int]] = set()
-    for K, M, min_num_tokens in router_specs:
-        for N in range(min_num_tokens, max_num_tokens + 1):
-            _, split_k = _pick_tile_config(N, K, M, num_sms)
-            if split_k == 1:
-                continue
-            BN, BM, block_s = _splitk_reduce_config(split_k)
-            configs.add(
-                (
-                    triton_scalar_specialization_rep(N),
-                    M,
-                    triton_scalar_specialization_rep(N * M),
-                    triton_scalar_specialization_rep(split_k),
-                    BN,
-                    BM,
-                    block_s,
-                )
-            )
-    return tuple(sorted(configs))
-
-
-def _warmup_splitk_reduce(
-    config: tuple[int, int, int, int, int, int, int],
-) -> None:
-    from vllm.model_executor.warmup.jit_warmup_triton_helper import (
-        TritonWarmupTensor,
-    )
-
-    N, M, split_stride, split_k, BN, BM, block_s = config
-    partials = TritonWarmupTensor(torch.float32, shape=(split_k, N, M))
-    out = TritonWarmupTensor(torch.float32, shape=(N, M))
-    _splitk_reduce_kernel.warmup(
-        partials,
-        out,
-        N,
-        M,
-        split_stride,
-        split_k,
-        BN=BN,
-        BM=BM,
-        BS=block_s,
-        USE_PDL=True,
-        num_warps=4,
-        launch_pdl=True,
-        grid=(1, 1),
-    )
-
-
-def warmup_bf16x3_router_gemm(
-    router_specs: Iterable[tuple[int, int, int]],
-    max_num_tokens: int,
-) -> tuple[tuple[int, int], ...]:
-    """Compile every BF16x3 router GEMM configuration reachable at runtime."""
-    router_specs = tuple(router_specs)
     device = torch.accelerator.current_device_index()
     num_sms = torch.cuda.get_device_properties(device).multi_processor_count
-    configs = _bf16x3_warmup_configs(router_specs, max_num_tokens, num_sms)
-    for K, BN in configs:
+    gemm_configs: set[int] = set()
+    reduce_configs: set[tuple[int, int, int, int, int, int]] = set()
+    for N in range(min_num_tokens, max_num_tokens + 1):
+        BN, split_k = _pick_tile_config(N, K, M, num_sms)
+        gemm_configs.add(BN)
+        if split_k == 1:
+            continue
+        reduce_BN, reduce_BM, block_s = _splitk_reduce_config(split_k)
+        reduce_configs.add(
+            (
+                triton_scalar_specialization_rep(N),
+                triton_scalar_specialization_rep(N * M),
+                triton_scalar_specialization_rep(split_k),
+                reduce_BN,
+                reduce_BM,
+                block_s,
+            )
+        )
+
+    configs = tuple(sorted(gemm_configs))
+    for BN in configs:
         Sm100BF16x3RouterGemm.compile(K, BN)
-    for config in _bf16x3_reduce_warmup_configs(router_specs, max_num_tokens, num_sms):
-        _warmup_splitk_reduce(config)
+    for N, split_stride, split_k, BN, BM, block_s in sorted(reduce_configs):
+        partials = TritonWarmupTensor(torch.float32)
+        out = TritonWarmupTensor(torch.float32)
+        _splitk_reduce_kernel.warmup(
+            partials,
+            out,
+            N,
+            M,
+            split_stride,
+            split_k,
+            BN=BN,
+            BM=BM,
+            BS=block_s,
+            USE_PDL=True,
+            num_warps=4,
+            launch_pdl=True,
+            grid=(1, 1),
+        )
     return configs
 
 

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -6,6 +6,10 @@ Computes ``X @ W.T`` for BF16 ``X`` with shape ``[N, K]`` and FP32 router
 weights ``W`` with shape ``[M, K]`` by decomposing each FP32 weight value into
 three BF16 residual terms inside the kernel, then accumulating the three BF16
 MMA results into FP32 TMEM output.
+
+The TMEM accumulation chain is bounded to ``num_tmem_acc`` K-tiles: at chunk
+boundaries the epilogue warps drain the main-term accumulator into a register
+master accumulator and the MMA warp resets it.
 """
 
 from functools import cache
@@ -82,6 +86,7 @@ class Sm100BF16x3RouterGemm:
         self.cta_tile = (BN, 128, 64)
         self.num_stages = 2
         self.num_warps = 10
+        self.num_tmem_acc = 8
 
     @cute.jit
     def _make_tma(self, tensor: cute.Tensor, BM: int, BK: int):
@@ -129,6 +134,7 @@ class Sm100BF16x3RouterGemm:
 
         BN, BM, BK = self.cta_tile
         num_stages = self.num_stages
+        num_tmem_acc = self.num_tmem_acc
 
         N, K = X_tma.tma_tensor.shape
         M, _ = W_tma.tma_tensor.shape
@@ -151,7 +157,8 @@ class Sm100BF16x3RouterGemm:
         tma_full_mbar = smem.allocate_array(Int64, num_stages)
         tma_empty_mbar = smem.allocate_array(Int64, num_stages)
         w_full_mbar = smem.allocate_array(Int64, num_stages)
-        mma_mbar = smem.allocate_array(Int64, 1)
+        acc_full_mbar = smem.allocate_array(Int64, 1)
+        acc_empty_mbar = smem.allocate_array(Int64, 1)
         taddr = smem.allocate(Int32, 4)
 
         BAR_TMEM_ALLOC = 1
@@ -171,7 +178,8 @@ class Sm100BF16x3RouterGemm:
                     cute.arch.mbarrier_init(tma_full_mbar + i, 1)
                     cute.arch.mbarrier_init(tma_empty_mbar + i, 1)
                     cute.arch.mbarrier_init(w_full_mbar + i, 128)
-                cute.arch.mbarrier_init(mma_mbar, 1)
+                cute.arch.mbarrier_init(acc_full_mbar, 1)
+                cute.arch.mbarrier_init(acc_empty_mbar, 128)
                 cute.arch.mbarrier_init_fence()
         elif warp_id == 1:
             cpasync.prefetch_descriptor(X_tma.atom)
@@ -213,40 +221,52 @@ class Sm100BF16x3RouterGemm:
 
         elif warp_id == 8:
             # MMA warp
-            stage_id = 0
-            parity = 0
+            tma_stage_id = 0
+            tma_parity = 0
+
+            tmem_acc_count = 0
+            tmem_parity = 1
 
             idesc = _tcgen05.make_bf16_idesc(BM, BN)
             sdesc = _tcgen05.make_sdesc_128B_swizzle(0)
 
             for tile_k in cutlass.range(bid_k, k_tiles, split_k, unroll=1):
-                cute.arch.mbarrier_wait(tma_full_mbar + stage_id, parity)
-                cute.arch.mbarrier_wait(w_full_mbar + stage_id, parity)
+                if tmem_acc_count == 0:
+                    cute.arch.mbarrier_wait(acc_empty_mbar, tmem_parity)
+                cute.arch.mbarrier_wait(tma_full_mbar + tma_stage_id, tma_parity)
+                cute.arch.mbarrier_wait(w_full_mbar + tma_stage_id, tma_parity)
                 _tcgen05.fence_after_thread_sync()
 
-                w_tmem = w_tmem_base + stage_id * (BK // 2 * 3)
-                x_desc = sdesc | (sX[None, None, stage_id].iterator.toint() >> 4)
+                w_tmem = w_tmem_base + tma_stage_id * (BK // 2 * 3)
+                x_desc = sdesc | (sX[None, None, tma_stage_id].iterator.toint() >> 4)
 
                 for k in cutlass.range_constexpr(BK // 16):
-                    enable_d = (tile_k > bid_k) or (k > 0)
+                    enable_d_main = (tmem_acc_count > 0) or (k > 0)
+                    enable_d_res = (tile_k > bid_k) or (k > 0)
                     _tcgen05.mma_ts_f16(
-                        acc_main, w_tmem + k * 8, x_desc, idesc, enable_d
+                        acc_main, w_tmem + k * 8, x_desc, idesc, enable_d_main
                     )
                     _tcgen05.mma_ts_f16(
-                        acc_res, w_tmem + 32 + k * 8, x_desc, idesc, enable_d
+                        acc_res, w_tmem + 32 + k * 8, x_desc, idesc, enable_d_res
                     )
                     _tcgen05.mma_ts_f16(
                         acc_res, w_tmem + 64 + k * 8, x_desc, idesc, True
                     )
                     x_desc += 32 >> 4
 
-                _tcgen05.commit(tma_empty_mbar + stage_id)
+                _tcgen05.commit(tma_empty_mbar + tma_stage_id)
 
-                stage_id = (stage_id + 1) % self.num_stages
-                if stage_id == 0:
-                    parity ^= 1
+                tma_stage_id = (tma_stage_id + 1) % num_stages
+                if tma_stage_id == 0:
+                    tma_parity ^= 1
 
-            _tcgen05.commit(mma_mbar)
+                tmem_acc_count = (tmem_acc_count + 1) % num_tmem_acc
+                if tmem_acc_count == 0:
+                    _tcgen05.commit(acc_full_mbar)
+                    tmem_parity ^= 1
+
+            if tmem_acc_count != 0:
+                _tcgen05.commit(acc_full_mbar)
 
         elif warp_id >= 4:
             # prep warps: decompose FP32 W into 3xBF16
@@ -303,39 +323,93 @@ class Sm100BF16x3RouterGemm:
                 _tcgen05.alloc(taddr)
             cute.arch.barrier(barrier_id=BAR_TMEM_ALLOC, number_of_threads=128)
 
-            if warp_id == 0:
-                cute.arch.mbarrier_wait(mma_mbar, 0)
-            cute.arch.barrier(barrier_id=BAR_EPI, number_of_threads=128)
-            _tcgen05.fence_after_thread_sync()
-
-            cute.arch.griddepcontrol_launch_dependents()
+            tiles_local = cute.ceil_div(k_tiles - bid_k, split_k)
+            num_chunks = cute.ceil_div(tiles_local, num_tmem_acc)
 
             WIDTH = 8
-            for i in cutlass.range_constexpr(BN // WIDTH):
-                tcol = i * WIDTH
-                main_regs = cute.make_rmem_tensor(WIDTH, Float32)
-                res_regs = cute.make_rmem_tensor(WIDTH, Float32)
-                main_regs.store(_tcgen05.ld(warp_id * 32, tcol, "32x32b", WIDTH))
-                res_regs.store(_tcgen05.ld(warp_id * 32, BN + tcol, "32x32b", WIDTH))
-                _tcgen05.wait_ld()
+            main_regs = cute.make_rmem_tensor(WIDTH, Float32)
+            res_regs = cute.make_rmem_tensor(WIDTH, Float32)
 
-                # CuteDSL will codegen add.f32x2
-                for j in cutlass.range(WIDTH, vectorize=True):
-                    main_regs[j] += res_regs[j]
-
+            if num_chunks == 1:
+                # single chunk
+                cute.arch.mbarrier_wait(acc_full_mbar, 0)
+                _tcgen05.fence_after_thread_sync()
                 w_row_idx = bid_m * BM + tid
-                for j in cutlass.range_constexpr(WIDTH):
-                    x_row_idx = bid_n * BN + i * WIDTH + j
-                    if x_row_idx < N and w_row_idx < M:
-                        out[bid_k, x_row_idx, w_row_idx] = main_regs[j]
+                for i in cutlass.range_constexpr(BN // WIDTH):
+                    tcol = i * WIDTH
+                    main_regs.store(_tcgen05.ld(warp_id * 32, tcol, "32x32b", WIDTH))
+                    res_regs.store(
+                        _tcgen05.ld(warp_id * 32, BN + tcol, "32x32b", WIDTH)
+                    )
+                    _tcgen05.wait_ld()
 
+                    # CuteDSL will codegen add.f32x2
+                    for j in cutlass.range(WIDTH, vectorize=True):
+                        main_regs[j] += res_regs[j]
+
+                    for j in cutlass.range_constexpr(WIDTH):
+                        x_row_idx = bid_n * BN + i * WIDTH + j
+                        if x_row_idx < N and w_row_idx < M:
+                            out[bid_k, x_row_idx, w_row_idx] = main_regs[j]
+
+            else:
+                # multiple chunks
+                master_acc = cute.make_rmem_tensor(BN, Float32)
+
+                # chunk 0: pure TMEM load, no accumulation.
+                cute.arch.mbarrier_wait(acc_full_mbar, 0)
+                _tcgen05.fence_after_thread_sync()
+                master_acc.store(_tcgen05.ld(warp_id * 32, 0, "32x32b", BN))
+                _tcgen05.wait_ld()
+                _tcgen05.fence_before_thread_sync()
+                cute.arch.mbarrier_arrive(acc_empty_mbar)
+
+                # accumulate main tmem acc
+                for chunk in cutlass.range(1, num_chunks, unroll=1):
+                    cute.arch.mbarrier_wait(acc_full_mbar, chunk & 1)
+                    _tcgen05.fence_after_thread_sync()
+
+                    for i in cutlass.range_constexpr(BN // WIDTH):
+                        tcol = i * WIDTH
+                        main_regs.store(
+                            _tcgen05.ld(warp_id * 32, tcol, "32x32b", WIDTH)
+                        )
+                        _tcgen05.wait_ld()
+                        # CuteDSL refuses to compile
+                        # master_acc[i * WIDTH + j] += main_regs[j]
+                        # when vectorize=True
+                        master_view = cute.local_tile(master_acc, (WIDTH,), (i,))
+                        for j in cutlass.range(WIDTH, vectorize=True):
+                            master_view[j] += main_regs[j]
+
+                    _tcgen05.fence_before_thread_sync()
+                    cute.arch.mbarrier_arrive(acc_empty_mbar)
+
+                # fold in the residual accumulator
+                for i in cutlass.range_constexpr(BN // WIDTH):
+                    tcol = i * WIDTH
+                    res_regs.store(
+                        _tcgen05.ld(warp_id * 32, BN + tcol, "32x32b", WIDTH)
+                    )
+                    _tcgen05.wait_ld()
+                    master_view = cute.local_tile(master_acc, (WIDTH,), (i,))
+                    for j in cutlass.range(WIDTH, vectorize=True):
+                        master_view[j] += res_regs[j]
+
+                    w_row_idx = bid_m * BM + tid
+                    for j in cutlass.range_constexpr(WIDTH):
+                        x_row_idx = bid_n * BN + i * WIDTH + j
+                        if x_row_idx < N and w_row_idx < M:
+                            out[bid_k, x_row_idx, w_row_idx] = master_acc[i * WIDTH + j]
+
+            cute.arch.griddepcontrol_launch_dependents()
             cute.arch.barrier(barrier_id=BAR_EPI, number_of_threads=128)
             if warp_id == 0:
                 _tcgen05.dealloc()
 
     @cache
     @staticmethod
-    def compile(BN: int = 128, K: int = 6144):
+    def compile(K: int, BN: int = 128):
         N = cute.sym_int()
         M = cute.sym_int()
         SPLIT_K = cute.sym_int()
@@ -419,27 +493,56 @@ def splitk_reduce_triton(partials: torch.Tensor, out: torch.Tensor):
     )
 
 
+# Tuned (BN, split_k) for mid-range token counts, from GB300 sweeps of the
+# FP32-router-weight models (MiniMax-M2/M3, Hunyuan-V3/V4, K=8192/M=256).
+# The generic rule below already loses 10-45% at N=64..512; the tuned rows
+# are within ~4% of the per-shape optimum. Outside this N range the generic
+# rule is within ~2%, so no rows are needed there.
+#
+# Rows are keyed by (K, M) = (hidden_size, num_experts) and cover the N
+# buckets (64, 128, 256, 512); N rounds up to the next bucket. Shapes without
+# an entry use _MID_RANGE_DEFAULT, which the three M>=192 shapes (2816/256,
+# 3072/256, 4096/192) share.
+_MID_RANGE_BUCKETS = (64, 128, 256, 512)
+_MID_RANGE_DEFAULT = ((16, 16), (32, 16), (64, 16), (64, 8))
+_MID_RANGE_TUNED = {
+    (6144, 128): ((32, 64), (64, 64), (32, 16), (64, 16)),  # MiniMax-M3
+    (8192, 256): ((64, 64), (32, 16), (64, 16), (128, 16)),
+}
+
+
+@cache
+def _pick_tile_config(N: int, K: int, M: int, num_sms: int) -> tuple[int, int]:
+    """Return (BN, split_k): tuned table mid-range, generic rule otherwise."""
+    k_tiles = math_utils.cdiv(K, 64)
+
+    if 32 < N <= 512:
+        rows = _MID_RANGE_TUNED.get((K, M), _MID_RANGE_DEFAULT)
+        for bucket, (BN, split_k) in zip(_MID_RANGE_BUCKETS, rows):
+            if bucket >= N:
+                return BN, min(split_k, k_tiles)
+
+    # next power of 2 within 8 and 128
+    BN = triton.next_power_of_2(N)
+    BN = min(max(BN, 8), 128)
+
+    grid_m = math_utils.cdiv(M, 128)
+    grid_n = math_utils.cdiv(N, BN)
+    base_ctas = grid_m * grid_n
+    split_k = min(k_tiles, max(1, num_sms // base_ctas))
+    return BN, split_k
+
+
 def bf16x3_router_gemm(X: torch.Tensor, W: torch.Tensor) -> torch.Tensor:
     """Return ``X @ W.T`` using the SM100 BF16x3 router GEMM kernel."""
     N, K = X.shape
     M, _ = W.shape
     num_sms = torch.cuda.get_device_properties(X.device).multi_processor_count
 
-    # next power of 2 within 8 and 128
-    BN = triton.next_power_of_2(N)
-    BN = min(max(BN, 8), 128)
-
-    BM = 128
-    BK = 64
-    k_tiles = math_utils.cdiv(K, BK)
-    grid_m = math_utils.cdiv(M, BM)
-    grid_n = math_utils.cdiv(N, BN)
-
-    base_ctas = grid_m * grid_n
-    split_k = min(k_tiles, max(1, num_sms // base_ctas))
+    BN, split_k = _pick_tile_config(N, K, M, num_sms)
 
     partials = X.new_empty(split_k, N, M, dtype=torch.float32)
-    Sm100BF16x3RouterGemm.compile(BN, K)(X, W, partials, split_k)
+    Sm100BF16x3RouterGemm.compile(K, BN)(X, W, partials, split_k)
 
     if split_k == 1:
         return partials.squeeze(0)

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -496,9 +496,20 @@ def splitk_reduce_triton(partials: torch.Tensor, out: torch.Tensor):
     )
 
 
-# Accuracy-constrained overrides from GB300 sweeps. Other shapes use
-# ``(next_power_of_2(N) // 4, 16)`` in this token range.
+# Accuracy-constrained (BN, split_k) configs from GB300 sweeps.
 _TILE_CONFIG_OVERRIDES = {
+    (2816, 256): {  # Hunyuan-V4
+        64: (16, 16),
+        128: (32, 16),
+        256: (64, 16),
+        512: (128, 16),
+    },
+    (3072, 256): {  # MiniMax-M2
+        64: (16, 16),
+        128: (32, 16),
+        256: (64, 16),
+        512: (128, 16),
+    },
     (4096, 192): {  # Hunyuan-V3
         64: (32, 32),
         128: (64, 32),
@@ -527,12 +538,9 @@ def _pick_tile_config(N: int, K: int, M: int, num_sms: int) -> tuple[int, int]:
     if 32 < N <= 512:
         token_bucket = triton.next_power_of_2(N)
         overrides = _TILE_CONFIG_OVERRIDES.get((K, M))
-        BN, split_k = (
-            overrides[token_bucket]
-            if overrides is not None
-            else (token_bucket // 4, 16)
-        )
-        return BN, min(split_k, k_tiles)
+        if overrides is not None:
+            BN, split_k = overrides[token_bucket]
+            return BN, min(split_k, k_tiles)
 
     # next power of 2 within 8 and 128
     BN = triton.next_power_of_2(N)

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -7,11 +7,12 @@ weights ``W`` with shape ``[M, K]`` by decomposing each FP32 weight value into
 three BF16 residual terms inside the kernel, then accumulating the three BF16
 MMA results into FP32 TMEM output.
 
-The TMEM accumulation chain is bounded to ``num_tmem_acc`` K-tiles: at chunk
-boundaries the epilogue warps drain the main-term accumulator into a register
-master accumulator and the MMA warp resets it.
+The TMEM accumulation chain is bounded to eight K-tiles. At chunk boundaries,
+the epilogue warps drain the main-term accumulator into registers and the MMA
+warp resets it.
 """
 
+from collections.abc import Iterable
 from functools import cache
 
 import cutlass
@@ -38,7 +39,7 @@ def _decompose_fp32x2_to_3xbf16x2(
     loc=None,
     ip=None,
 ) -> tuple[Uint32, Uint32, Uint32]:
-    # this PTX snippets does the following
+    # This PTX snippet does the following:
     #   out0 = BF16(in);   res =  in - FP32(out0)
     #   out1 = BF16(res);  res = res - FP32(out1)
     #   out2 = BF16(res)
@@ -86,7 +87,7 @@ class Sm100BF16x3RouterGemm:
         self.cta_tile = (BN, 128, 64)
         self.num_stages = 2
         self.num_warps = 10
-        self.num_tmem_acc = 8
+        self.tiles_per_tmem_accumulator = 8
 
     @cute.jit
     def _make_tma(self, tensor: cute.Tensor, BM: int, BK: int):
@@ -134,7 +135,7 @@ class Sm100BF16x3RouterGemm:
 
         BN, BM, BK = self.cta_tile
         num_stages = self.num_stages
-        num_tmem_acc = self.num_tmem_acc
+        tiles_per_tmem_accumulator = self.tiles_per_tmem_accumulator
 
         N, K = X_tma.tma_tensor.shape
         M, _ = W_tma.tma_tensor.shape
@@ -260,7 +261,7 @@ class Sm100BF16x3RouterGemm:
                 if tma_stage_id == 0:
                     tma_parity ^= 1
 
-                tmem_acc_count = (tmem_acc_count + 1) % num_tmem_acc
+                tmem_acc_count = (tmem_acc_count + 1) % tiles_per_tmem_accumulator
                 if tmem_acc_count == 0:
                     _tcgen05.commit(acc_full_mbar)
                     tmem_parity ^= 1
@@ -324,14 +325,14 @@ class Sm100BF16x3RouterGemm:
             cute.arch.barrier(barrier_id=BAR_TMEM_ALLOC, number_of_threads=128)
 
             tiles_local = cute.ceil_div(k_tiles - bid_k, split_k)
-            num_chunks = cute.ceil_div(tiles_local, num_tmem_acc)
+            num_chunks = cute.ceil_div(tiles_local, tiles_per_tmem_accumulator)
 
             WIDTH = 8
             main_regs = cute.make_rmem_tensor(WIDTH, Float32)
             res_regs = cute.make_rmem_tensor(WIDTH, Float32)
 
             if num_chunks == 1:
-                # single chunk
+                # Single accumulation chunk.
                 cute.arch.mbarrier_wait(acc_full_mbar, 0)
                 _tcgen05.fence_after_thread_sync()
                 w_row_idx = bid_m * BM + tid
@@ -353,10 +354,10 @@ class Sm100BF16x3RouterGemm:
                             out[bid_k, x_row_idx, w_row_idx] = main_regs[j]
 
             else:
-                # multiple chunks
+                # Multiple accumulation chunks.
                 master_acc = cute.make_rmem_tensor(BN, Float32)
 
-                # chunk 0: pure TMEM load, no accumulation.
+                # Seed the register accumulator from the first chunk.
                 cute.arch.mbarrier_wait(acc_full_mbar, 0)
                 _tcgen05.fence_after_thread_sync()
                 master_acc.store(_tcgen05.ld(warp_id * 32, 0, "32x32b", BN))
@@ -364,7 +365,7 @@ class Sm100BF16x3RouterGemm:
                 _tcgen05.fence_before_thread_sync()
                 cute.arch.mbarrier_arrive(acc_empty_mbar)
 
-                # accumulate main tmem acc
+                # Accumulate subsequent main-term chunks.
                 for chunk in cutlass.range(1, num_chunks, unroll=1):
                     cute.arch.mbarrier_wait(acc_full_mbar, chunk & 1)
                     _tcgen05.fence_after_thread_sync()
@@ -375,9 +376,8 @@ class Sm100BF16x3RouterGemm:
                             _tcgen05.ld(warp_id * 32, tcol, "32x32b", WIDTH)
                         )
                         _tcgen05.wait_ld()
-                        # CuteDSL refuses to compile
-                        # master_acc[i * WIDTH + j] += main_regs[j]
-                        # when vectorize=True
+                        # CuTeDSL cannot vectorize the dynamically indexed
+                        # master_acc expression without a tiled view.
                         master_view = cute.local_tile(master_acc, (WIDTH,), (i,))
                         for j in cutlass.range(WIDTH, vectorize=True):
                             master_view[j] += main_regs[j]
@@ -385,7 +385,7 @@ class Sm100BF16x3RouterGemm:
                     _tcgen05.fence_before_thread_sync()
                     cute.arch.mbarrier_arrive(acc_empty_mbar)
 
-                # fold in the residual accumulator
+                # Fold in the residual accumulator.
                 for i in cutlass.range_constexpr(BN // WIDTH):
                     tcol = i * WIDTH
                     res_regs.store(
@@ -466,16 +466,19 @@ def _splitk_reduce_kernel(
     )
 
 
+def _splitk_reduce_config(split_k: int) -> tuple[int, int, int]:
+    block_s = 1 << (split_k - 1).bit_length()
+    if block_s >= 64:
+        return 1, 32, block_s
+    if block_s >= 8:
+        return 1, 256, block_s
+    return min(16, 32 // block_s), 32, block_s
+
+
 def splitk_reduce_triton(partials: torch.Tensor, out: torch.Tensor):
     split_k, N, M = partials.shape
-    block_s = 1 << (split_k - 1).bit_length()
     split_stride = partials.stride(0)
-    if block_s >= 64:
-        BN, BM = 1, 32
-    elif block_s >= 8:
-        BN, BM = 1, 256
-    else:
-        BN, BM = min(16, 32 // block_s), 32
+    BN, BM, block_s = _splitk_reduce_config(split_k)
     grid = (triton.cdiv(N, BN), triton.cdiv(M, BM))
     _splitk_reduce_kernel[grid](
         partials,
@@ -502,10 +505,9 @@ def splitk_reduce_triton(partials: torch.Tensor, out: torch.Tensor):
 # generic rule is within ~2%, so no rows are needed there.
 #
 # Rows are keyed by (K, M) = (hidden_size, num_experts) and cover the N
-# buckets (64, 128, 256, 512); N rounds up to the next bucket. Shapes without
-# an entry use _MID_RANGE_DEFAULT, which the K<=3072 M=256 shapes (2816/256,
-# 3072/256) share. (128, 19) entries at N=512 reproduce the generic rule:
-# no faster config meets the accuracy bar there.
+# buckets (64, 128, 256, 512); N rounds up to the next bucket. Untabled shapes
+# use the shared default row. (128, 19) entries at N=512 reproduce the generic
+# rule because no faster config meets the accuracy bar there.
 _MID_RANGE_BUCKETS = (64, 128, 256, 512)
 _MID_RANGE_DEFAULT = ((16, 16), (32, 16), (64, 16), (128, 16))
 _MID_RANGE_TUNED = {
@@ -535,6 +537,103 @@ def _pick_tile_config(N: int, K: int, M: int, num_sms: int) -> tuple[int, int]:
     base_ctas = grid_m * grid_n
     split_k = min(k_tiles, max(1, num_sms // base_ctas))
     return BN, split_k
+
+
+def _bf16x3_warmup_configs(
+    router_specs: Iterable[tuple[int, int, int]],
+    max_num_tokens: int,
+    num_sms: int,
+) -> tuple[tuple[int, int], ...]:
+    """Return the reachable ``(K, BN)`` compile configurations."""
+    configs: set[tuple[int, int]] = set()
+    for K, M, min_num_tokens in router_specs:
+        if min_num_tokens > max_num_tokens:
+            continue
+
+        table_limit = min(max_num_tokens, _MID_RANGE_BUCKETS[-1])
+        for N in range(min_num_tokens, table_limit + 1):
+            BN, _ = _pick_tile_config(N, K, M, num_sms)
+            configs.add((K, BN))
+
+        if max_num_tokens > table_limit:
+            BN, _ = _pick_tile_config(max_num_tokens, K, M, num_sms)
+            configs.add((K, BN))
+
+    return tuple(sorted(configs))
+
+
+def _bf16x3_reduce_warmup_configs(
+    router_specs: Iterable[tuple[int, int, int]],
+    max_num_tokens: int,
+    num_sms: int,
+) -> tuple[tuple[int, int, int, int, int, int, int], ...]:
+    """Return the reachable Triton split-K reduction specializations."""
+    from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+        triton_scalar_specialization_rep,
+    )
+
+    configs: set[tuple[int, int, int, int, int, int, int]] = set()
+    for K, M, min_num_tokens in router_specs:
+        for N in range(min_num_tokens, max_num_tokens + 1):
+            _, split_k = _pick_tile_config(N, K, M, num_sms)
+            if split_k == 1:
+                continue
+            BN, BM, block_s = _splitk_reduce_config(split_k)
+            configs.add(
+                (
+                    triton_scalar_specialization_rep(N),
+                    M,
+                    triton_scalar_specialization_rep(N * M),
+                    triton_scalar_specialization_rep(split_k),
+                    BN,
+                    BM,
+                    block_s,
+                )
+            )
+    return tuple(sorted(configs))
+
+
+def _warmup_splitk_reduce(
+    config: tuple[int, int, int, int, int, int, int],
+) -> None:
+    from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+        TritonWarmupTensor,
+    )
+
+    N, M, split_stride, split_k, BN, BM, block_s = config
+    partials = TritonWarmupTensor(torch.float32, shape=(split_k, N, M))
+    out = TritonWarmupTensor(torch.float32, shape=(N, M))
+    _splitk_reduce_kernel.warmup(
+        partials,
+        out,
+        N,
+        M,
+        split_stride,
+        split_k,
+        BN=BN,
+        BM=BM,
+        BS=block_s,
+        USE_PDL=True,
+        num_warps=4,
+        launch_pdl=True,
+        grid=(1, 1),
+    )
+
+
+def warmup_bf16x3_router_gemm(
+    router_specs: Iterable[tuple[int, int, int]],
+    max_num_tokens: int,
+) -> tuple[tuple[int, int], ...]:
+    """Compile every BF16x3 router GEMM configuration reachable at runtime."""
+    router_specs = tuple(router_specs)
+    device = torch.accelerator.current_device_index()
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    configs = _bf16x3_warmup_configs(router_specs, max_num_tokens, num_sms)
+    for K, BN in configs:
+        Sm100BF16x3RouterGemm.compile(K, BN)
+    for config in _bf16x3_reduce_warmup_configs(router_specs, max_num_tokens, num_sms):
+        _warmup_splitk_reduce(config)
+    return configs
 
 
 def bf16x3_router_gemm(X: torch.Tensor, W: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -495,19 +495,23 @@ def splitk_reduce_triton(partials: torch.Tensor, out: torch.Tensor):
 
 # Tuned (BN, split_k) for mid-range token counts, from GB300 sweeps of the
 # FP32-router-weight models (MiniMax-M2/M3, Hunyuan-V3/V4, K=8192/M=256).
-# The generic rule below already loses 10-45% at N=64..512; the tuned rows
-# are within ~4% of the per-shape optimum. Outside this N range the generic
-# rule is within ~2%, so no rows are needed there.
+# Selection is accuracy-constrained: per cell the fastest config whose MAE vs
+# FP64 is <= max(old-rule MAE, cuBLAS FP32 MAE), i.e. never worse than either
+# baseline. Lower split_k lengthens per-CTA TMEM accumulation chains and
+# raises MAE, so several cells keep high split_k. Outside this N range the
+# generic rule is within ~2%, so no rows are needed there.
 #
 # Rows are keyed by (K, M) = (hidden_size, num_experts) and cover the N
 # buckets (64, 128, 256, 512); N rounds up to the next bucket. Shapes without
-# an entry use _MID_RANGE_DEFAULT, which the three M>=192 shapes (2816/256,
-# 3072/256, 4096/192) share.
+# an entry use _MID_RANGE_DEFAULT, which the K<=3072 M=256 shapes (2816/256,
+# 3072/256) share. (128, 19) entries at N=512 reproduce the generic rule:
+# no faster config meets the accuracy bar there.
 _MID_RANGE_BUCKETS = (64, 128, 256, 512)
-_MID_RANGE_DEFAULT = ((16, 16), (32, 16), (64, 16), (64, 8))
+_MID_RANGE_DEFAULT = ((16, 16), (32, 16), (64, 16), (128, 16))
 _MID_RANGE_TUNED = {
-    (6144, 128): ((32, 64), (64, 64), (32, 16), (64, 16)),  # MiniMax-M3
-    (8192, 256): ((64, 64), (32, 16), (64, 16), (128, 16)),
+    (4096, 192): ((32, 32), (64, 32), (128, 32), (128, 19)),  # Hunyuan-V3
+    (6144, 128): ((32, 64), (64, 64), (64, 32), (128, 32)),  # MiniMax-M3
+    (8192, 256): ((64, 64), (64, 32), (128, 32), (128, 19)),
 }
 
 

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -26,6 +26,7 @@ from quack.compile_utils import make_fake_tensor
 from vllm.cute_utils import _tcgen05, simple_tma_copy
 from vllm.triton_utils import tl, triton
 from vllm.utils import math_utils
+from vllm.utils.torch_utils import direct_register_custom_op
 
 __all__ = ["bf16x3_router_gemm"]
 
@@ -522,12 +523,6 @@ _TILE_CONFIG_OVERRIDES = {
         256: (64, 32),
         512: (128, 32),
     },
-    (8192, 256): {
-        64: (64, 64),
-        128: (64, 32),
-        256: (128, 32),
-        512: (128, 19),
-    },
 }
 
 
@@ -610,7 +605,7 @@ def warmup_bf16x3_router_gemm(
     return configs
 
 
-def bf16x3_router_gemm(X: torch.Tensor, W: torch.Tensor) -> torch.Tensor:
+def _bf16x3_router_gemm(X: torch.Tensor, W: torch.Tensor) -> torch.Tensor:
     """Return ``X @ W.T`` using the SM100 BF16x3 router GEMM kernel."""
     N, K = X.shape
     M, _ = W.shape
@@ -627,3 +622,21 @@ def bf16x3_router_gemm(X: torch.Tensor, W: torch.Tensor) -> torch.Tensor:
     out = X.new_empty(N, M, dtype=torch.float32)
     splitk_reduce_triton(partials, out)
     return out
+
+
+def _bf16x3_router_gemm_fake(
+    X: torch.Tensor,
+    W: torch.Tensor,
+) -> torch.Tensor:
+    return X.new_empty((X.shape[0], W.shape[0]), dtype=torch.float32)
+
+
+direct_register_custom_op(
+    op_name="bf16x3_router_gemm",
+    op_func=_bf16x3_router_gemm,
+    fake_impl=_bf16x3_router_gemm_fake,
+)
+
+
+def bf16x3_router_gemm(X: torch.Tensor, W: torch.Tensor) -> torch.Tensor:
+    return torch.ops.vllm.bf16x3_router_gemm(X, W)

--- a/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
+++ b/vllm/model_executor/layers/fused_moe/router/bf16x3_router_gemm_cutedsl.py
@@ -7,9 +7,9 @@ weights ``W`` with shape ``[M, K]`` by decomposing each FP32 weight value into
 three BF16 residual terms inside the kernel, then accumulating the three BF16
 MMA results into FP32 TMEM output.
 
-The TMEM accumulation chain is bounded to eight K-tiles. At chunk boundaries,
-the epilogue warps drain the main-term accumulator into registers and the MMA
-warp resets it.
+The TMEM accumulation chain is bounded to ``num_tmem_acc`` K-tiles: at chunk
+boundaries the epilogue warps drain the main-term accumulator into a register
+master accumulator and the MMA warp resets it.
 """
 
 from collections.abc import Iterable
@@ -39,7 +39,7 @@ def _decompose_fp32x2_to_3xbf16x2(
     loc=None,
     ip=None,
 ) -> tuple[Uint32, Uint32, Uint32]:
-    # This PTX snippet does the following:
+    # this PTX snippets does the following
     #   out0 = BF16(in);   res =  in - FP32(out0)
     #   out1 = BF16(res);  res = res - FP32(out1)
     #   out2 = BF16(res)
@@ -87,7 +87,7 @@ class Sm100BF16x3RouterGemm:
         self.cta_tile = (BN, 128, 64)
         self.num_stages = 2
         self.num_warps = 10
-        self.tiles_per_tmem_accumulator = 8
+        self.num_tmem_acc = 8
 
     @cute.jit
     def _make_tma(self, tensor: cute.Tensor, BM: int, BK: int):
@@ -135,7 +135,7 @@ class Sm100BF16x3RouterGemm:
 
         BN, BM, BK = self.cta_tile
         num_stages = self.num_stages
-        tiles_per_tmem_accumulator = self.tiles_per_tmem_accumulator
+        num_tmem_acc = self.num_tmem_acc
 
         N, K = X_tma.tma_tensor.shape
         M, _ = W_tma.tma_tensor.shape
@@ -261,7 +261,7 @@ class Sm100BF16x3RouterGemm:
                 if tma_stage_id == 0:
                     tma_parity ^= 1
 
-                tmem_acc_count = (tmem_acc_count + 1) % tiles_per_tmem_accumulator
+                tmem_acc_count = (tmem_acc_count + 1) % num_tmem_acc
                 if tmem_acc_count == 0:
                     _tcgen05.commit(acc_full_mbar)
                     tmem_parity ^= 1
@@ -325,14 +325,14 @@ class Sm100BF16x3RouterGemm:
             cute.arch.barrier(barrier_id=BAR_TMEM_ALLOC, number_of_threads=128)
 
             tiles_local = cute.ceil_div(k_tiles - bid_k, split_k)
-            num_chunks = cute.ceil_div(tiles_local, tiles_per_tmem_accumulator)
+            num_chunks = cute.ceil_div(tiles_local, num_tmem_acc)
 
             WIDTH = 8
             main_regs = cute.make_rmem_tensor(WIDTH, Float32)
             res_regs = cute.make_rmem_tensor(WIDTH, Float32)
 
             if num_chunks == 1:
-                # Single accumulation chunk.
+                # single chunk
                 cute.arch.mbarrier_wait(acc_full_mbar, 0)
                 _tcgen05.fence_after_thread_sync()
                 w_row_idx = bid_m * BM + tid
@@ -354,10 +354,10 @@ class Sm100BF16x3RouterGemm:
                             out[bid_k, x_row_idx, w_row_idx] = main_regs[j]
 
             else:
-                # Multiple accumulation chunks.
+                # multiple chunks
                 master_acc = cute.make_rmem_tensor(BN, Float32)
 
-                # Seed the register accumulator from the first chunk.
+                # chunk 0: pure TMEM load, no accumulation.
                 cute.arch.mbarrier_wait(acc_full_mbar, 0)
                 _tcgen05.fence_after_thread_sync()
                 master_acc.store(_tcgen05.ld(warp_id * 32, 0, "32x32b", BN))
@@ -365,7 +365,7 @@ class Sm100BF16x3RouterGemm:
                 _tcgen05.fence_before_thread_sync()
                 cute.arch.mbarrier_arrive(acc_empty_mbar)
 
-                # Accumulate subsequent main-term chunks.
+                # accumulate main tmem acc
                 for chunk in cutlass.range(1, num_chunks, unroll=1):
                     cute.arch.mbarrier_wait(acc_full_mbar, chunk & 1)
                     _tcgen05.fence_after_thread_sync()
@@ -376,8 +376,9 @@ class Sm100BF16x3RouterGemm:
                             _tcgen05.ld(warp_id * 32, tcol, "32x32b", WIDTH)
                         )
                         _tcgen05.wait_ld()
-                        # CuTeDSL cannot vectorize the dynamically indexed
-                        # master_acc expression without a tiled view.
+                        # CuteDSL refuses to compile
+                        # master_acc[i * WIDTH + j] += main_regs[j]
+                        # when vectorize=True
                         master_view = cute.local_tile(master_acc, (WIDTH,), (i,))
                         for j in cutlass.range(WIDTH, vectorize=True):
                             master_view[j] += main_regs[j]
@@ -385,7 +386,7 @@ class Sm100BF16x3RouterGemm:
                     _tcgen05.fence_before_thread_sync()
                     cute.arch.mbarrier_arrive(acc_empty_mbar)
 
-                # Fold in the residual accumulator.
+                # fold in the residual accumulator
                 for i in cutlass.range_constexpr(BN // WIDTH):
                     tcol = i * WIDTH
                     res_regs.store(

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -219,8 +219,8 @@ def fp32_router_gemm_dispatch_impl(
 ) -> torch.Tensor:
     """
     Dynamically run fp32 specialized gemm if num_tokens <= FP32_MAX_TOKENS,
-    otherwise optionally run the experimental BF16x3 kernel for medium/large
-    SM100 router batches, then fall back to F.linear.
+    otherwise run the BF16x3 kernel for eligible SM100 router batches, then
+    fall back to F.linear.
     This must be wrapped in a custom op because our torch.compile integration
     does not support runtime dispatching on num_tokens.
     """

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -4,14 +4,10 @@ import torch
 from torch.nn.parameter import Parameter
 
 import vllm._custom_ops as ops
-from vllm.config import get_current_vllm_config_or_none
-from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
-
-logger = init_logger(__name__)
 
 
 @PluggableLayer.register("gate_linear")
@@ -22,7 +18,7 @@ class GateLinear(ReplicatedLinear):
        K divisible by 8)
     2. fp32 specialized kernel (SM90+ or gfx950, bf16/fp32 in, fp32 out,
        M<=32, model-specific shapes)
-    3. experimental bf16x3 CuteDSL kernel (opt-in, SM100, bf16 in, fp32 weight)
+    3. bf16x3 CuteDSL kernel (SM100, bf16 in, fp32 weight)
     4. cuBLAS bf16×bf16→fp32 (SM90+ + bf16 weight + fp32 out_dtype)
     5. F.linear via ReplicatedLinear (ultimate fallback)
 
@@ -85,11 +81,6 @@ class GateLinear(ReplicatedLinear):
         self.allow_specialized_router_gemm = can_use_specialized_kernels
 
         # fp32 specialized kernel eligibility (exact dims, fp32 weight)
-        vllm_config = get_current_vllm_config_or_none()
-        enable_bf16x3_router_gemm = (
-            vllm_config is not None
-            and vllm_config.kernel_config.enable_bf16x3_router_gemm
-        )
         self.allow_fp32_router_gemm = (
             not bias
             and self.weight.dtype == torch.float32
@@ -108,10 +99,7 @@ class GateLinear(ReplicatedLinear):
             and current_platform.is_cuda()
             and is_blackwell
             and input_size % 8 == 0
-            and enable_bf16x3_router_gemm
         )
-        if self.allow_bf16x3_router_gemm:
-            logger.info_once("Enabled experimental SM100 BF16x3 router GEMM.")
 
         # Fused bf16 x bf16 -> fp32 GEMM eligibility. torch.mm's out_dtype
         # epilogue folds the fp32 cast into the GEMM, removing the standalone
@@ -198,7 +186,7 @@ class GateLinear(ReplicatedLinear):
             )
             return output, None
 
-        # Tier 3: experimental bf16x3 CuteDSL kernel for fp32 router weights
+        # Tier 3: bf16x3 CuteDSL kernel for fp32 router weights
         if self.allow_bf16x3_router_gemm and x.dtype == torch.bfloat16:
             from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
                 bf16x3_router_gemm,

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -188,7 +188,11 @@ class GateLinear(ReplicatedLinear):
 
         # Tier 3: bf16x3 CuteDSL kernel for fp32 router weights
         if self.allow_bf16x3_router_gemm and x.dtype == torch.bfloat16:
-            output = torch.ops.vllm.bf16x3_router_gemm(x, self.weight)
+            from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
+                bf16x3_router_gemm,
+            )
+
+            output = bf16x3_router_gemm(x, self.weight)
             return output, None
 
         # Tier 4: cuBLAS bf16→fp32
@@ -206,24 +210,6 @@ class GateLinear(ReplicatedLinear):
 
 
 _FP32_ROUTER_GEMM_MAX_TOKENS = GateLinear.FP32_MAX_TOKENS
-
-
-def bf16x3_router_gemm_impl(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-) -> torch.Tensor:
-    from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
-        bf16x3_router_gemm,
-    )
-
-    return bf16x3_router_gemm(x, weight)
-
-
-def bf16x3_router_gemm_fake(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-) -> torch.Tensor:
-    return x.new_empty((x.shape[0], weight.shape[0]), dtype=torch.float32)
 
 
 def fp32_router_gemm_dispatch_impl(
@@ -253,10 +239,10 @@ def fp32_router_gemm_dispatch_impl(
 
     if allow_bf16x3_router_gemm and x.dtype == torch.bfloat16:
         from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
-            bf16x3_router_gemm,
+            _bf16x3_router_gemm,
         )
 
-        return bf16x3_router_gemm(x, weight)
+        return _bf16x3_router_gemm(x, weight)
 
     return torch.nn.functional.linear(x.float(), weight)
 
@@ -268,12 +254,6 @@ def fp32_router_gemm_dispatch_fake(
 ) -> torch.Tensor:
     return x.new_empty((x.shape[0], weight.shape[0]), dtype=torch.float32)
 
-
-direct_register_custom_op(
-    op_name="bf16x3_router_gemm",
-    op_func=bf16x3_router_gemm_impl,
-    fake_impl=bf16x3_router_gemm_fake,
-)
 
 direct_register_custom_op(
     op_name="fp32_router_gemm_dispatch",

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -188,11 +188,7 @@ class GateLinear(ReplicatedLinear):
 
         # Tier 3: bf16x3 CuteDSL kernel for fp32 router weights
         if self.allow_bf16x3_router_gemm and x.dtype == torch.bfloat16:
-            from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
-                bf16x3_router_gemm,
-            )
-
-            output = bf16x3_router_gemm(x, self.weight)
+            output = torch.ops.vllm.bf16x3_router_gemm(x, self.weight)
             return output, None
 
         # Tier 4: cuBLAS bf16→fp32
@@ -210,6 +206,24 @@ class GateLinear(ReplicatedLinear):
 
 
 _FP32_ROUTER_GEMM_MAX_TOKENS = GateLinear.FP32_MAX_TOKENS
+
+
+def bf16x3_router_gemm_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
+        bf16x3_router_gemm,
+    )
+
+    return bf16x3_router_gemm(x, weight)
+
+
+def bf16x3_router_gemm_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return x.new_empty((x.shape[0], weight.shape[0]), dtype=torch.float32)
 
 
 def fp32_router_gemm_dispatch_impl(
@@ -254,6 +268,12 @@ def fp32_router_gemm_dispatch_fake(
 ) -> torch.Tensor:
     return x.new_empty((x.shape[0], weight.shape[0]), dtype=torch.float32)
 
+
+direct_register_custom_op(
+    op_name="bf16x3_router_gemm",
+    op_func=bf16x3_router_gemm_impl,
+    fake_impl=bf16x3_router_gemm_fake,
+)
 
 direct_register_custom_op(
     op_name="fp32_router_gemm_dispatch",

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -219,8 +219,8 @@ def fp32_router_gemm_dispatch_impl(
 ) -> torch.Tensor:
     """
     Dynamically run fp32 specialized gemm if num_tokens <= FP32_MAX_TOKENS,
-    otherwise run the BF16x3 kernel for eligible SM100 router batches, then
-    fall back to F.linear.
+    otherwise optionally run the experimental BF16x3 kernel for medium/large
+    SM100 router batches, then fall back to F.linear.
     This must be wrapped in a custom op because our torch.compile integration
     does not support runtime dispatching on num_tokens.
     """

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -101,6 +101,43 @@ def _warmup_ll_bf16_router_gemm(model: torch.nn.Module) -> None:
     )
 
 
+def _bf16x3_router_specs_from_model(
+    model: torch.nn.Module,
+) -> tuple[tuple[int, int, int], ...]:
+    """Return ``(K, M, min_num_tokens)`` for eligible router layers."""
+    from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
+
+    specs: set[tuple[int, int, int]] = set()
+    for module in model.modules():
+        if not isinstance(module, GateLinear) or not module.allow_bf16x3_router_gemm:
+            continue
+        min_num_tokens = module.FP32_MAX_TOKENS + 1
+        if not module.allow_fp32_router_gemm:
+            min_num_tokens = 1
+        specs.add((module.input_size, module.output_size, min_num_tokens))
+    return tuple(sorted(specs))
+
+
+def _warmup_bf16x3_router_gemm(
+    model: torch.nn.Module,
+    max_num_tokens: int,
+) -> None:
+    from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
+        warmup_bf16x3_router_gemm,
+    )
+
+    specs = _bf16x3_router_specs_from_model(model)
+    if not specs:
+        logger.debug_once(
+            "Skipping BF16x3 router GEMM warmup: no eligible GateLinear shapes found."
+        )
+        return
+
+    logger.info_once("Warming up BF16x3 router GEMM specs: %s.", specs)
+    configs = warmup_bf16x3_router_gemm(specs, max_num_tokens)
+    logger.info_once("Warmed up BF16x3 router GEMM configs: %s.", configs)
+
+
 def _warmup_kimi_k3_gemm_rs_ar() -> None:
     # Kimi-K3 model construction imports this module only when GEMM-RS/AR is
     # enabled and initializes its singleton before kernel_warmup runs. Avoid
@@ -131,7 +168,8 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
         if zeroer is not None:
             zeroer.warmup(worker.model_runner.kv_cache_config.num_blocks)
 
-    if worker.vllm_config.kernel_config.enable_jit_warmup:
+    enable_jit_warmup = worker.vllm_config.kernel_config.enable_jit_warmup
+    if enable_jit_warmup:
         logger.info("JIT kernel warmup starting.")
         jit_warmup_start = time.perf_counter()
         try:
@@ -164,10 +202,16 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
     )
 
     # Run next so input-prep kernels JIT against pristine runner state.
-    if worker.vllm_config.kernel_config.enable_jit_warmup:
+    if enable_jit_warmup:
         kimi_k3_triton_warmup(worker)
         spec_decode_rejection_warmup(worker)
         qwen4_exp_qsa_triton_warmup(worker)
+
+    if enable_jit_warmup and current_platform.is_device_capability_family(100):
+        _warmup_bf16x3_router_gemm(
+            worker.get_model(),
+            worker.scheduler_config.max_num_batched_tokens,
+        )
 
     if current_platform.has_device_capability(90):
         _warmup_ll_bf16_router_gemm(worker.get_model())

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -101,23 +101,6 @@ def _warmup_ll_bf16_router_gemm(model: torch.nn.Module) -> None:
     )
 
 
-def _bf16x3_router_specs_from_model(
-    model: torch.nn.Module,
-) -> tuple[tuple[int, int, int], ...]:
-    """Return ``(K, M, min_num_tokens)`` for eligible router layers."""
-    from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
-
-    specs: set[tuple[int, int, int]] = set()
-    for module in model.modules():
-        if not isinstance(module, GateLinear) or not module.allow_bf16x3_router_gemm:
-            continue
-        min_num_tokens = module.FP32_MAX_TOKENS + 1
-        if not module.allow_fp32_router_gemm:
-            min_num_tokens = 1
-        specs.add((module.input_size, module.output_size, min_num_tokens))
-    return tuple(sorted(specs))
-
-
 def _warmup_bf16x3_router_gemm(
     model: torch.nn.Module,
     max_num_tokens: int,
@@ -125,16 +108,34 @@ def _warmup_bf16x3_router_gemm(
     from vllm.model_executor.layers.fused_moe.router.bf16x3_router_gemm_cutedsl import (  # noqa: E501
         warmup_bf16x3_router_gemm,
     )
+    from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 
-    specs = _bf16x3_router_specs_from_model(model)
-    if not specs:
+    gate = next(
+        (
+            module
+            for module in model.modules()
+            if isinstance(module, GateLinear) and module.allow_bf16x3_router_gemm
+        ),
+        None,
+    )
+    if gate is None:
         logger.debug_once(
-            "Skipping BF16x3 router GEMM warmup: no eligible GateLinear shapes found."
+            "Skipping BF16x3 router GEMM warmup: no eligible GateLinear found."
         )
         return
 
-    logger.info_once("Warming up BF16x3 router GEMM specs: %s.", specs)
-    configs = warmup_bf16x3_router_gemm(specs, max_num_tokens)
+    min_num_tokens = gate.FP32_MAX_TOKENS + 1 if gate.allow_fp32_router_gemm else 1
+    logger.info_once(
+        "Warming up BF16x3 router GEMM for K=%d, M=%d.",
+        gate.input_size,
+        gate.output_size,
+    )
+    configs = warmup_bf16x3_router_gemm(
+        gate.input_size,
+        gate.output_size,
+        min_num_tokens,
+        max_num_tokens,
+    )
     logger.info_once("Warmed up BF16x3 router GEMM configs: %s.", configs)
 
 


### PR DESCRIPTION
## Purpose

Follow up on #47973. This only concerns router GEMM with FP32 weights i.e. BF16xFP32->FP32

This PR adds master rmem accumulator for long accumulation chain, restoring accuracy against FP32, hence making BF16x3 GEMM suitable as FP32 GEMM replacement whenever the kernel is supported (sm100 family). Custom op wrapper is needed for torch.compile support since torch.compile-based models will execute this new kernel as well.

I also take this opportunity to add some features:
- Tuning table specifically for models using FP32 router weights: Minimax M2/M3 and Hunyuan-V3/V4. We can add new entries for future models as they are added to vLLM too.
- Warmup logic

## Microbenchmarks

GB300. MAE is computed against FP64 reference.

### Minimax M3 (hidden_size=6144, num_experts=128)

| num_tokens | Before us | After us | FP32 us | Before MAE | After MAE | FP32 MAE |
|---|---|---|---|---|---|---|
| 64 | 9.41 | 8.10 | 15.36 | 3.3e-7 | 4.1e-7 | 7.2e-7 |
| 256 | 14.05 | 12.03 | 21.95 | 3.8e-7 | 6.2e-7 | 7.4e-7 |
| 1024 | 19.46 | 19.07 | 53.66 | 9.8e-7 | 9.8e-7 | 1.1e-6 |
| 4096 | 38.59 | 38.21 | 174.43 | 5.1e-6 | 1.6e-6 | 4.1e-6 |
| 16384 | 102.62 | 100.19 | 438.72 | 2.2e-5 | 1.6e-6 | 4.1e-6 |

### Hunyuan-V4 (hidden_size=2816, num_experts=256)

| num_tokens | Before us | After us | FP32 us | Before MAE | After MAE | FP32 MAE |
|---|---|---|---|---|---|---|
| 64 | 9.22 | 8.42 | 13.09 | 2.1e-7 | 3.9e-7 | 4.2e-7 |
| 256 | 14.37 | 11.42 | 20.86 | 2.3e-7 | 3.8e-7 | 4.5e-7 |
| 1024 | 17.98 | 17.54 | 44.48 | 6.4e-7 | 6.4e-7 | 5.3e-7 |
| 4096 | 32.96 | 32.26 | 111.20 | 3.1e-6 | 9.8e-7 | 1.9e-6 |
| 16384 | 98.50 | 96.22 | 401.41 | 6.4e-6 | 1.0e-6 | 1.9e-6 |

Better accuracy than FP32, while slightly faster than Before column thanks to better tuning

## Test Plan

Unit test `tests/kernels/test_bf16x3_router_gemm_cutedsl.py`

Minimax M3, TP4 on GB300
- AIME25 (4 epochs, max_tokens=98304): exact_match=0.9, pass@4=0.9667

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

