### PR TITLE
[Bugfix][NIXL] Defer recv-failure reporting until sibling transfers finish

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -4,8 +4,10 @@
 import contextlib
 import inspect
 import os
+import queue
 import tempfile
 import textwrap
+import threading
 import time
 import uuid
 from collections import defaultdict
@@ -2881,18 +2883,16 @@ def test_failed_request_skips_kv_postprocessing(
 def test_handles_failing_in_separate_polls_do_not_kill_the_engine(
     default_vllm_config, dist_init
 ):
-    """A request whose handles fail in different polls must not crash the engine.
+    """A request's failure report waits for its sibling handles to finish.
 
     One transfer handle is created per remote rank, and when a peer goes away
     they do not all fail in the same poll: one errors while another is still
-    PROC. The first failure reports the request via _failed_recv_reqs and
-    get_finished() pops its metadata; when the remaining handles fail in a
-    later poll, the request must be cleaned up without being reported again.
+    PROC. Reporting on the first failure lets the scheduler invalidate the
+    blocks and reassign them while the remaining handles may still be posting
+    RDMA writes into them, corrupting whichever request owns them next.
 
-    Reporting twice kills the EngineCore: the scheduler's assert in
-    _update_from_kv_xfer_finished only expects a finished recv for a request
-    still waiting for KVs, having moved this one out of
-    WAITING_FOR_REMOTE_KVS to recompute locally after the first report.
+    The report (and the block invalidation) is therefore deferred until every
+    handle of the request is terminal, and issued exactly once.
     """
     vllm_config = create_vllm_config()
     connector = NixlConnector(
@@ -2931,6 +2931,8 @@ def test_handles_failing_in_separate_polls_do_not_kill_the_engine(
     worker._recving_transfers[request_id] = [first, second]
 
     # Poll 1: the first handle has failed, the second is still running.
+    # The report must be deferred: the blocks are not invalidated while the
+    # sibling handle may still be writing into them.
     def first_failed(handle):
         return "ERR" if handle is first else "PROC"
 
@@ -2939,20 +2941,75 @@ def test_handles_failing_in_separate_polls_do_not_kill_the_engine(
     ):
         _, done_recving = connector.get_finished(finished_req_ids=set())
 
-    assert request_id in done_recving
-    assert request_id not in worker._recving_metadata
+    assert request_id not in done_recving
+    assert request_id in worker._recving_metadata
     assert worker._recving_transfers[request_id] == [second]
+    assert connector.get_block_ids_with_load_errors() == set()
 
-    # Poll 2: the second handle fails too. The request was already reported,
-    # so it must not be reported a second time: the scheduler has since moved
-    # it out of WAITING_FOR_REMOTE_KVS to recompute locally, and asserts on a
-    # finished recv for a request in that state. Its remaining handles are
-    # still released and the transfer entry removed.
+    # Poll 2: the second handle fails too. All handles are now terminal, so
+    # the request is reported exactly once, its blocks invalidated, and its
+    # remaining state cleaned up.
     with patch.object(worker.nixl_wrapper, "check_xfer_state", return_value="ERR"):
         _, done_recving = connector.get_finished(finished_req_ids=set())
 
-    assert request_id not in done_recving
+    assert request_id in done_recving
+    assert request_id not in worker._recving_metadata
     assert request_id not in worker._recving_transfers
+    assert connector.get_block_ids_with_load_errors() == {1, 2, 3}
+
+
+def _bare_worker_for_pop_done() -> NixlConnectorWorker:
+    """Minimal worker state for polling transfer handles directly."""
+    worker = object.__new__(NixlConnectorWorker)
+    worker._failed_recv_pending = set()
+    worker._failed_recv_reported = set()
+    worker._failed_recv_lock = threading.Lock()
+    worker._failed_recv_reqs = queue.Queue()
+    worker._invalid_block_ids = queue.Queue()
+    worker._recving_metadata = {}
+    worker._is_hma_required = False
+    worker.xfer_stats = MagicMock()
+    worker._log_failure = MagicMock()
+    worker.nixl_wrapper = MagicMock()
+    return worker
+
+
+def test_send_side_transfer_failures_do_not_report_recv_failure():
+    """A failed WRITE is logged and cleaned up, never a receive failure.
+
+    The push worker polls its send handles through the same helper as the
+    receive path; reporting a send failure through the recv channel would
+    make the scheduler treat a purely outbound write error as a KV load
+    failure.
+    """
+    worker = _bare_worker_for_pop_done()
+    worker.nixl_wrapper.check_xfer_state.return_value = "ERR"
+
+    done = worker._pop_done_transfers({"send-req": [1]}, is_recv=False)
+    assert done == {"send-req"}
+    assert worker._failed_recv_reqs.empty()
+    assert worker._invalid_block_ids.empty()
+    assert worker._failed_recv_pending == set()
+
+    # The same failure on the receive side is reported exactly once.
+    assert worker._pop_done_transfers({"recv-req": [1]}, is_recv=True) == set()
+    assert worker._failed_recv_reqs.get_nowait() == "recv-req"
+
+
+def test_report_failed_recv_invalidates_all_block_groups():
+    """A failed recv invalidates every transfer group's blocks.
+
+    Heterogeneous caches give one request blocks in multiple groups;
+    invalidating only the first group would leave the rest reusable while
+    the failed transfer never wrote them.
+    """
+    worker = _bare_worker_for_pop_done()
+    worker._recving_metadata["req"] = SimpleNamespace(local_block_ids=([1, 2], [7], []))
+
+    worker._report_failed_recv("req")
+
+    assert worker._invalid_block_ids.get_nowait() == {1, 2, 7}
+    assert worker._failed_recv_reqs.get_nowait() == "req"
 
 
 def _set_test_speculative_config(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Base worker-side logic for the NIXL connector."""
 
+import contextlib
 import itertools
 import logging
 import os
@@ -607,6 +608,11 @@ class NixlBaseConnectorWorker:
         # Uses Queue for thread-safe cross-thread coordination with the
         # background handshake thread, matching the _ready_requests pattern.
         self._failed_recv_reqs: queue.Queue[ReqId] = queue.Queue()
+        # Requests whose failure report is deferred until their remaining
+        # transfers are terminal, and those already reported (exactly once).
+        self._failed_recv_pending: set[ReqId] = set()
+        self._failed_recv_reported: set[ReqId] = set()
+        self._failed_recv_lock = threading.Lock()
 
         # Handshake metadata of this worker for NIXL transfers.
         self.xfer_handshake_metadata: NixlHandshakePayload | None = None
@@ -2321,7 +2327,7 @@ class NixlBaseConnectorWorker:
         """
         assert self.transfer_topo is not None
         done_sending = self._get_new_notifs()
-        done_recving = self._pop_done_transfers(self._recving_transfers)
+        done_recving = self._pop_done_transfers(self._recving_transfers, is_recv=True)
 
         # Drain queue of requests where handshake or transfer setup failed.
         failed_recv_reqs = set[ReqId]()
@@ -2330,6 +2336,11 @@ class NixlBaseConnectorWorker:
                 failed_recv_reqs.add(self._failed_recv_reqs.get_nowait())
             except queue.Empty:
                 break
+
+        # Drained: a later request reusing the same id (abort + resubmit) is
+        # a distinct lifecycle and may fail again.
+        with self._failed_recv_lock:
+            self._failed_recv_reported.difference_update(failed_recv_reqs)
 
         # Add failed requests to done_recving for scheduler tracking
         # (blocks are already marked invalid, scheduler will handle recompute)
@@ -2480,11 +2491,14 @@ class NixlBaseConnectorWorker:
                     new_expiry,
                 )
 
-    def _pop_done_transfers(self, transfers: dict[str, list[int]]) -> set[str]:
+    def _pop_done_transfers(
+        self, transfers: dict[str, list[int]], *, is_recv: bool = False
+    ) -> set[str]:
         """
         Pop completed xfers by checking for DONE state.
         Args:
             transfers: dict of req_id -> list[running_xfer]
+            is_recv: Whether failures require receive-side invalidation and reporting.
         Returns:
             set of req_ids that have all done xfers
         """
@@ -2505,28 +2519,45 @@ class NixlBaseConnectorWorker:
                     else:
                         self._log_failure(
                             failure_type="transfer_failed",
-                            msg="Marking blocks as invalid",
+                            msg="Deferring request completion until its last "
+                            "xfer is terminal",
                             req_id=req_id,
                             xfer_state=xfer_state,
                         )
-                        self._handle_failed_transfer(req_id, handle)
+                        # ERR is terminal; PROC handles remain in_progress.
+                        # Posted transfers cannot be aborted, so failure
+                        # reporting waits until the request's remaining
+                        # handles are terminal.
+                        with contextlib.suppress(Exception):
+                            self.nixl_wrapper.release_xfer_handle(handle)
+                        self.xfer_stats.record_failed_transfer()
+                        if is_recv:
+                            with self._failed_recv_lock:
+                                self._failed_recv_pending.add(req_id)
                 except Exception as e:
                     self._log_failure(
                         failure_type="transfer_exception",
-                        msg="Marking blocks as invalid",
+                        msg="Handle is unpollable; treating it as terminal",
                         req_id=req_id,
                         error=e,
                     )
-                    self._handle_failed_transfer(req_id, handle)
+                    self.xfer_stats.record_failed_transfer()
+                    with contextlib.suppress(Exception):
+                        self.nixl_wrapper.release_xfer_handle(handle)
+                    if is_recv:
+                        with self._failed_recv_lock:
+                            self._failed_recv_pending.add(req_id)
 
             if not in_progress:
                 # Only report request as completed when all transfers are done.
-                # A request failed in an earlier poll was already reported via
-                # _failed_recv_reqs and its metadata popped by get_finished();
-                # don't report it again, just drop the remaining handles.
-                if req_id in self._recving_metadata:
-                    done_req_ids.add(req_id)
                 del transfers[req_id]
+                with self._failed_recv_lock:
+                    failed = req_id in self._failed_recv_pending
+                    self._failed_recv_pending.discard(req_id)
+                if failed:
+                    self._report_failed_recv(req_id)
+                    continue
+                done_req_ids.add(req_id)
             else:
                 transfers[req_id] = in_progress
         return done_req_ids
@@ -2540,18 +2571,31 @@ class NixlBaseConnectorWorker:
             req_id: The request ID.
             handle: The transfer handle.
         """
-        # (multi-read) One handle is created per remote rank, and they do not
-        # all fail in the same _pop_done_transfers poll. The request is
-        # reported failed on the first one, which pops its metadata in
-        # get_finished(); on the later failures only the handle cleanup is left.
-        # TODO (NickLucche) handle failed transfer for HMA.
-        if (meta := self._recving_metadata.get(req_id)) is not None:
-            if not self._is_hma_required:
-                self._invalid_block_ids.put(set(meta.local_block_ids[0]))
-            self._failed_recv_reqs.put(req_id)
         if handle is not None:
             self.nixl_wrapper.release_xfer_handle(handle)
         self.xfer_stats.record_failed_transfer()
+        # Posted transfers cannot be aborted, so defer the report while
+        # sibling transfers of the request remain in flight.
+        with self._failed_recv_lock:
+            if self._recving_transfers.get(req_id):
+                self._failed_recv_pending.add(req_id)
+                return
+            self._failed_recv_pending.discard(req_id)
+        self._report_failed_recv(req_id)
+
+    def _report_failed_recv(self, req_id: str) -> None:
+        """Report a failed recv exactly once and invalidate its blocks."""
+        with self._failed_recv_lock:
+            if req_id in self._failed_recv_reported:
+                return
+            self._failed_recv_reported.add(req_id)
+        # Use .get() here as the metadata cleanup is handled by get_finished()
+        # TODO (NickLucche) handle failed transfer for HMA.
+        if (meta := self._recving_metadata.get(req_id)) and not self._is_hma_required:
+            self._invalid_block_ids.put(
+                {block_id for group in meta.local_block_ids for block_id in group}
+            )
+        self._failed_recv_reqs.put(req_id)
 
     def _send_heartbeats(self, metadata: NixlConnectorMetadata) -> None:
         """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -776,9 +776,13 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         done_sending, done_recving = super().get_finished()
 
         # ``_pop_done_transfers`` mutates ``_sending_transfers``; the
-        # writer thread also appends to it, so guard the pop.
+        # writer thread also appends to it, so guard the pop. Send-side
+        # failures are outbound only: they must not be reported through
+        # the recv-failure channel.
         with self._sending_transfers_lock:
-            done_pushing = self._pop_done_transfers(self._sending_transfers)
+            done_pushing = self._pop_done_transfers(
+                self._sending_transfers, is_recv=False
+            )
         for req_id in done_pushing:
             self._reqs_to_send.pop(req_id, None)
             self._reqs_to_process.discard(req_id)


### PR DESCRIPTION
Superseeded by https://github.com/vllm-project/vllm/pull/56104