### PR TITLE
[Bugfix] Correct W8A8 block FP8 tuning latency normalization

### DIFF
--- a/benchmarks/kernels/benchmark_w8a8_block_fp8.py
+++ b/benchmarks/kernels/benchmark_w8a8_block_fp8.py
@@ -195,7 +195,8 @@ def benchmark_config(
         end_event.record()
         end_event.synchronize()
         latencies.append(start_event.elapsed_time(end_event))
-    avg = sum(latencies) / (num_iters * 10) * 1000  # us
+    # Each measured interval contains one kernel invocation.
+    avg = sum(latencies) / num_iters * 1000  # ms -> us
     return avg
 
 

--- a/tests/benchmarks/test_w8a8_block_fp8.py
+++ b/tests/benchmarks/test_w8a8_block_fp8.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+
+from vllm.platforms import current_platform
+
+
+@pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_rocm()),
+    reason="The FP8 tuning script requires CUDA or ROCm.",
+)
+@pytest.mark.parametrize("num_iters", [1, 3, 10])
+def test_benchmark_config_returns_mean_latency_in_microseconds(monkeypatch, num_iters):
+    from benchmarks.kernels import benchmark_w8a8_block_fp8 as benchmark
+
+    start_event, end_event = Mock(), Mock()
+    start_event.elapsed_time.side_effect = [0.25 * (i + 1) for i in range(num_iters)]
+    monkeypatch.setattr(
+        benchmark.torch, "Event", Mock(side_effect=[start_event, end_event])
+    )
+    monkeypatch.setattr(benchmark.torch.accelerator, "synchronize", Mock())
+    matmul = Mock()
+    monkeypatch.setattr(benchmark, "w8a8_block_matmul", matmul)
+
+    latency_us = benchmark.benchmark_config(
+        None, None, None, None, [128, 128], {}, num_iters=num_iters
+    )
+
+    assert latency_us == pytest.approx(125 * (num_iters + 1))
+    assert matmul.call_count == 5 + num_iters  # Warmup is outside the event intervals.
+    assert start_event.record.call_count == num_iters
+    assert end_event.record.call_count == num_iters
+    assert start_event.elapsed_time.call_count == num_iters


### PR DESCRIPTION
## Purpose

Fix a factor-of-ten error in the latency returned by the W8A8 block FP8 tuning script. Each Event interval in `benchmark_config` contains one matmul invocation, but the accumulated milliseconds are divided by `num_iters * 10`. Remove the extra divisor before conversion to microseconds. For example, samples of 0.25, 0.5, and 0.75 ms should return 500 us; the old code returns 50 us.

Add a deterministic regression with 1, 3, and 10 samples, checking the returned average and that the five warmup calls remain outside the timed intervals. The current caller uses latency only to rank configurations, so the common scaling error ordinarily does not change the selected config. No kernel, serving behavior, or model output changes are intended.

Duplicate check: searched open PRs for `benchmark_w8a8_block_fp8` and related timing/normalization terms. Reviewed #52752 (multi-GPU config-file overwrite) and #41220 (additional weight shapes); neither fixes this denominator. No existing issue is claimed by this PR.

## Test Plan

In a complete vLLM development environment:

```bash
.venv/bin/python -m pytest tests/benchmarks/test_w8a8_block_fp8.py -v
.venv/bin/python -m ruff check benchmarks/kernels/benchmark_w8a8_block_fp8.py tests/benchmarks/test_w8a8_block_fp8.py
.venv/bin/python -m ruff format --check benchmarks/kernels/benchmark_w8a8_block_fp8.py tests/benchmarks/test_w8a8_block_fp8.py
git diff --check
```

## Test Result

- Isolated source-level regression: the proposed three pytest cases fail with the original function and pass with the fixed function. Expected means are 250, 500, and 1375 us; the original returns 25, 50, and 137.5 us. A local AST harness loaded the checkout's unmodified function bodies and bypassed package initialization and root conftest. This is not a successful normal upstream pytest run.
- Source-level CUDA smoke validation on RTX 4070 Laptop GPU, PyTorch 2.8.0+cu128, Triton 3.4.0: loaded the checkout's actual Triton kernel and matmul wrapper. Outputs matched a dequantized PyTorch reference at `rtol=0.01, atol=0.01` for `(M,N,K)=(16,512,512)` and `(128,1024,1024)`. Returned means matched recorded real Event samples: 81.578667 us over 3 samples and 84.582399 us over 10 samples. These numbers validate aggregation, not kernel performance.
- Commit hooks passed: Ruff 0.14.0 check and format, typos, mypy hook, SPDX, lazy/forbidden imports, filename validation, torch.cuda checks, config validation, boolean context managers, and sign-off. `git diff --check` passed. The unrelated `update-dockerfile-graph` hook was explicitly skipped after failing on Windows CRLF shell-script line endings; no Docker files are modified.
- Normal pytest currently stops while importing `tests/conftest.py` because `tblib` is absent; the complete current-main dependency environment and direct import/CI integration are not yet validated. Kept as Draft pending that validation and human submission review.
- Model evaluations are not applicable to this benchmark-only arithmetic change.

AI assistance: developed and checked with OpenAI Codex. Validation limitations are recorded above; full-environment and human review are still pending.
