### PR TITLE
[Docs] Avoid CUDA IPC fallback in same host NIXL Docker deployments

### DIFF
--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -108,6 +108,49 @@ python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
   --decoder-ports 8200
 ```
 
+### Running in Separate Docker Containers
+
+This example runs the prefiller and decoder in separate containers on the same host, sharing a PID namespace and exposing both participating GPUs to each worker.
+
+!!! note
+    Separate PID namespaces can cause CUDA IPC failures. While requests may still succeed, KV transfers can fall back to TCP and become significantly slower.
+
+First, create a container to hold the shared PID namespace:
+
+```bash
+docker run -d --name pd-namespace \
+  --entrypoint sleep \
+  vllm/vllm-openai:latest infinity
+```
+
+Start the prefiller on GPU 0:
+
+```bash
+docker run -d --name nixl-prefiller \
+  --gpus all --network host \
+  --pid=container:pd-namespace \
+  -e CUDA_VISIBLE_DEVICES=0,1 \
+  -e VLLM_NIXL_SIDE_CHANNEL_PORT=5600 \
+  vllm/vllm-openai:latest \
+  Qwen/Qwen3-0.6B --port 8100 --enforce-eager \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_load_failure_policy":"fail"}'
+```
+
+Start the decoder on GPU 1:
+
+```bash
+docker run -d --name nixl-decoder \
+  --gpus all --network host \
+  --pid=container:pd-namespace \
+  -e CUDA_VISIBLE_DEVICES=1,0 \
+  -e VLLM_NIXL_SIDE_CHANNEL_PORT=5601 \
+  vllm/vllm-openai:latest \
+  Qwen/Qwen3-0.6B --port 8200 --enforce-eager \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_load_failure_policy":"fail"}'
+```
+
+Once both servers are ready, start the proxy on the host by following [proxy server](#proxy-server). Keep `pd-namespace` running until both workers stop.
+
 ## Environment Variables
 
 - `VLLM_NIXL_SIDE_CHANNEL_PORT`: Port for NIXL handshake communication


### PR DESCRIPTION
## Purpose

Running prefill and decode in separate Docker containers can produce successful responses while KV transfers silently fall back to TCP instead of using CUDA IPC. This makes deployment appear healthy even when its KV transfer performance is severely degraded.

This PR adds same-host Docker example with a shared PID namespace and mutual GPU visibility, so users can configure CUDA IPC correctly.

### Test Plan

Ran a PID-only A/B test using the unmodified NixlConnector:
- 2 × H100 SXM5 80GB
- vLLM v0.28.0
- Qwen/Qwen3-0.6B
- `UCX_LOG_LEVEL=debug`
- One identical request per configuration: 1,689 input tokens, 16 output tokens
- only A uses shared PID namespace (`--pid=container:pd-namespace`)

### Test Result

Both requests completed successfully (HTTP 200). However without PID sharing, CUDA IPC failed and KV transfers fell back to TCP. With PID sharing, UCX selected CUDA IPC zero-copy:

PID namespace | CUDA IPC | Selected transport
-- | -- | --
Shared | Succeeded | CUDA IPC zero-copy
Isolated | invalid device context | TCP software emulation

<details>
<summary>UCX logs</summary>

**A. shared PID namespace (`--pid=container:pd-namespace`):**

```bash
[1788868092.568310] [inst-1onle-devrel-rdma-pool:876  :0]   +--------------------------------+--------------------------------------------------------------------------+
[1788868092.568311] [inst-1onle-devrel-rdma-pool:876  :0]   | ucp_context_0 intra-node cfg#2 | remote memory read by ucp_get*(multi) into cuda/GPU0 from cuda/dev[0]    |
[1788868092.568312] [inst-1onle-devrel-rdma-pool:876  :0]   +--------------------------------+----------------------------------------------------------+---------------+
[1788868092.568312] [inst-1onle-devrel-rdma-pool:876  :0]   |                         0..inf | zero-copy                                                | cuda_ipc/cuda |
[1788868092.568313] [inst-1onle-devrel-rdma-pool:876  :0]   +--------------------------------+----------------------------------------------------------+---------------+
```

**B. isolated PID namespaces (no `--pid`)**:

```bash
[1788868163.270095] [inst-1onle-devrel-rdma-pool:403  :2]  cuda_ipc_cache.c:285  UCX  DEBUG   cuIpcOpenMemHandle() failed: invalid device context
# ...
[1788868163.385914] [inst-1onle-devrel-rdma-pool:403  :0]   +--------------------------------+-------------------------------------------------------------------+
[1788868163.385915] [inst-1onle-devrel-rdma-pool:403  :0]   | ucp_context_0 intra-node cfg#2 | remote memory read by ucp_get*(multi) into cuda/GPU0 from cuda    |
[1788868163.385915] [inst-1onle-devrel-rdma-pool:403  :0]   +--------------------------------+-------------------------------------------------------+-----------+
[1788868163.385916] [inst-1onle-devrel-rdma-pool:403  :0]   |                         0..inf | software emulation                                    | tcp/rdma0 |
[1788868163.385916] [inst-1onle-devrel-rdma-pool:403  :0]   +--------------------------------+-------------------------------------------------------+-----------+
```
</details>

### Performance Impact

The same issue affected KV transfer performance in a larger serving deployment:

- 8 × H100 SXM5 GPUs on a single node
- Qwen3-235B-A22B-FP8
- 1 Prefill 1 Decode with TP4+EP for each workers
- vLLM v0.26.0

At RPS 5.5 with 2,000 ISL / 1,000 OSL per request:

| Configuration | KV transfer rate |
|---|---|
| **Shared PID namespaces** | **890–1,334 MiB/s** |
| Isolated containers | 75–307 MiB/s |