### PR TITLE
[Bugfix][KV Offload] Prevent cache reuse across KV cache layouts

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -300,7 +300,7 @@ Implement `SecondaryTierManager` (`vllm/v1/kv_offload/tiering/base.py`) in your 
 - For single-tier (CPU-only) setups, set `cpu_bytes_to_use` larger than the aggregate GPU KV cache. Because offloading is immediate, a smaller CPU tier just mirrors what the GPU already holds and adds no hit rate.
 - `block_size` / `blocks_per_chunk`: larger offloaded chunks reduce per-block bookkeeping overhead but increase the granularity of lookups.
 - FS thread counts: tune `n_read_threads` and `n_write_threads` to the parallelism your storage can sustain. Reads are latency-sensitive on the prefill path, so prefer more read threads when prefill hit rates are high.
-- Sharing `root_dir` across runs: runs with the same model, `block_size`, parallelism layout, dtype, and KV cache layout share files under the same `<digest>` subdirectory. Changing any of these produces a new subdirectory. Namespaces created before the KV cache layout was recorded are no longer reused and can be deleted to reclaim disk.
+- Sharing `root_dir` across runs: runs with the same model, `block_size`, parallelism layout, dtype, and KV cache layout share files under the same `<digest>` subdirectory. Changing any of these produces a new subdirectory. Namespaces created before the KV cache layout was recorded are no longer reused and can be deleted to reclaim storage; namespaces written with the canonical host byte format (`canonical_layout`) keep their previous identity. Across a rolling upgrade, patched and unpatched `p2p` peers compute different compatibility fingerprints and do not share KV until every peer is upgraded.
 
 ## Per-Request Selective Offload
 

--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -300,7 +300,7 @@ Implement `SecondaryTierManager` (`vllm/v1/kv_offload/tiering/base.py`) in your 
 - For single-tier (CPU-only) setups, set `cpu_bytes_to_use` larger than the aggregate GPU KV cache. Because offloading is immediate, a smaller CPU tier just mirrors what the GPU already holds and adds no hit rate.
 - `block_size` / `blocks_per_chunk`: larger offloaded chunks reduce per-block bookkeeping overhead but increase the granularity of lookups.
 - FS thread counts: tune `n_read_threads` and `n_write_threads` to the parallelism your storage can sustain. Reads are latency-sensitive on the prefill path, so prefer more read threads when prefill hit rates are high.
-- Sharing `root_dir` across runs: runs with the same model, `block_size`, parallelism layout, and dtype share files under the same `<digest>` subdirectory. Changing any of these produces a new subdirectory; old ones are orphaned but harmless. Delete them to reclaim disk.
+- Sharing `root_dir` across runs: runs with the same model, `block_size`, parallelism layout, dtype, and KV cache layout share files under the same `<digest>` subdirectory. Changing any of these produces a new subdirectory. Namespaces created before the KV cache layout was recorded are no longer reused and can be deleted to reclaim disk.
 
 ## Per-Request Selective Offload
 

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -4,6 +4,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from vllm.v1.kv_cache_layout import KVCacheLayout
 from vllm.v1.kv_offload.base import OffloadingSpec, make_offload_key
 from vllm.v1.kv_offload.config import (
@@ -232,6 +234,11 @@ def test_direct_layout_separates_persistent_namespaces():
     assert len({fm.base_path for fm in mappers.values()}) == len(KVCacheLayout)
     for layout, fm in mappers.items():
         assert fm.fields["kv_cache_layout"] == layout.name
+
+
+def test_direct_layout_requires_resolved_layout():
+    with pytest.raises(ValueError, match="KV cache layout has not been resolved"):
+        make_mapper_from_offloading_spec(kv_cache_layout=None)
 
 
 def test_canonical_namespace_does_not_repeat_the_layout():

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -4,6 +4,7 @@
 
 from unittest.mock import MagicMock
 
+from vllm.v1.kv_cache_layout import KVCacheLayout
 from vllm.v1.kv_offload.base import OffloadingSpec, make_offload_key
 from vllm.v1.kv_offload.config import (
     OffloadingCacheConfig,
@@ -90,7 +91,7 @@ def test_get_file_name_full_structure():
     path = fm.get_file_name(key)
 
     expected_path = (
-        "/tmp/cache/test-model_de3bba26cf36_r3/000/10_g2/0001020304050607.bin"
+        "/tmp/cache/test-model_7009c7b2fce1_r3/000/10_g2/0001020304050607.bin"
     )
     assert path == expected_path
 
@@ -117,6 +118,7 @@ def test_get_run_config_fields():
         "pcp_size": 2,
         "dcp_size": 2,
         "dtype": "bfloat16",
+        "kv_cache_layout": "LBNHC",
         "kv_cache_groups": [
             {
                 "tokens_per_block": 64,
@@ -220,6 +222,24 @@ def test_canonical_layout_changes_storage_namespace():
     assert "canonical_format" not in direct.fields
     assert canonical.fields["canonical_format"] == "v1-nhd"
     assert direct.base_path != canonical.base_path
+
+
+def test_direct_layout_separates_persistent_namespaces():
+    mappers = {
+        layout: make_mapper_from_offloading_spec(kv_cache_layout=layout.name)
+        for layout in KVCacheLayout
+    }
+    assert len({fm.base_path for fm in mappers.values()}) == len(KVCacheLayout)
+    for layout, fm in mappers.items():
+        assert fm.fields["kv_cache_layout"] == layout.name
+
+
+def test_canonical_namespace_does_not_repeat_the_layout():
+    fm = make_mapper_from_offloading_spec(
+        canonical_layout=True, kv_cache_layout="LBNHC"
+    )
+    assert fm.fields["canonical_format"] == "v1-nhd"
+    assert "kv_cache_layout" not in fm.fields
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -86,6 +86,7 @@ def _make_offloading_spec(
             is_parallelism_agnostic=is_parallelism_agnostic,
         ),
         replicated_layout=replicated_layout,
+        kv_cache_layout="LBNHC",
     )
     spec.blocks_per_chunk = 1
     spec.kv_events_config = OffloadingKVEventsConfig(

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -79,6 +79,7 @@ def _make_offloading_config(
             is_parallelism_agnostic=is_parallelism_agnostic,
         ),
         replicated_layout=replicated_layout,
+        kv_cache_layout="LBNHC",
     )
 
 

--- a/vllm/v1/kv_offload/file_mapper.py
+++ b/vllm/v1/kv_offload/file_mapper.py
@@ -40,6 +40,7 @@ class FileMapper:
         parallel_agnostic: bool = False,
         replicated_layout: bool = False,
         canonical_format: str | None = None,
+        kv_cache_layout: str | None = None,
     ):
         """
         Initialize the file mapper. Each worker constructs its own, but
@@ -74,6 +75,8 @@ class FileMapper:
         # identity participates in the storage namespace.
         if canonical_format is not None:
             self.fields["canonical_format"] = canonical_format
+        elif kv_cache_layout is not None:
+            self.fields["kv_cache_layout"] = kv_cache_layout
         self.base_path: str = self._compute_base_path(root_dir, self.fields)
 
     @classmethod
@@ -116,6 +119,7 @@ class FileMapper:
             ),
             replicated_layout=(parallel_agnostic and config.replicated_layout),
             canonical_format=canonical_format,
+            kv_cache_layout=config.kv_cache_layout,
         )
 
     def get_file_name(self, key: OffloadKey) -> str:

--- a/vllm/v1/kv_offload/file_mapper.py
+++ b/vllm/v1/kv_offload/file_mapper.py
@@ -75,7 +75,12 @@ class FileMapper:
         # identity participates in the storage namespace.
         if canonical_format is not None:
             self.fields["canonical_format"] = canonical_format
-        elif kv_cache_layout is not None:
+        else:
+            if kv_cache_layout is None:
+                raise ValueError(
+                    "KV cache layout has not been resolved; the direct page "
+                    "format records it in the storage namespace."
+                )
             self.fields["kv_cache_layout"] = kv_cache_layout
         self.base_path: str = self._compute_base_path(root_dir, self.fields)
 


### PR DESCRIPTION
## Purpose

Fixes #55904.

Persistent `fs` / `obj` KV offload namespaces do not include the resolved `kv_cache_layout`.
On the direct (non-canonical) path, pages are persisted in the worker's physical KV layout, so two runs sharing a `root_dir` under different layouts can map the same prefix to the same file even though the stored bytes are not interchangeable.
The size check still passes, causing silent incorrect output.

This PR adds `kv_cache_layout` to `FileMapper.fields` for direct pages:

```python
if canonical_format is not None:
    self.fields["canonical_format"] = canonical_format
elif kv_cache_layout is not None:
    self.fields["kv_cache_layout"] = kv_cache_layout
```

The canonical path is unchanged because `canonical_format` already identifies the layout family. Since all secondary tiers construct their mapper through `FileMapper.from_offloading_spec`, the same change also makes the `p2p` compatibility fingerprint layout-aware.

All layouts, including LBHNC, are recorded. This intentionally supersedes existing direct-path namespaces once.
Keeping LBHNC on its historical digest would preserve a namespace that may already contain blocks written by another layout before the upgrade, so it would leave the silent-corruption case possible for existing caches.

I checked open PRs and issues for overlapping `FileMapper` / KV-offload namespace changes. None records the resolved KV cache layout for direct pages.
#51691 touches the same `FileMapper.from_offloading_spec` call site but only moves `canonical_format` derivation, so the overlap is textual rather than semantic.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_offload/test_file_mapper.py

.venv/bin/python -m pytest -q tests/v1/kv_offload \
    tests/v1/kv_connector/unit/offloading_connector \
    tests/v1/kv_connector/unit/test_offloading_connector.py \
    tests/v1/core/test_kv_cache_utils.py

.venv/bin/pre-commit run --files \
    vllm/v1/kv_offload/file_mapper.py \
    tests/v1/kv_offload/test_file_mapper.py \
    docs/features/kv_offloading_usage.md

.venv/bin/pre-commit run mypy-3.12 --hook-stage manual \
    --files vllm/v1/kv_offload/file_mapper.py

git diff --check upstream/main...HEAD
```

Added tests verify that:

- every `KVCacheLayout` gets a distinct direct-path namespace;
- the canonical path does not redundantly fingerprint the layout;
- the expected namespace digest and run config change.

Model-level: the two-instance reproduction from #55904.

## Test Result

On `main` @ `34b9899c8f`, RTX 4070 (sm_89), ext4 on NVMe:

- `tests/v1/kv_offload/test_file_mapper.py`: **16 passed**
- `tests/v1/kv_offload`: **572 passed, 1 skipped**
- wider suite: **1032 passed, 1 skipped, 8 failed**
    - all 8 also fail with the patch reverted;
    - 6 require the gated repo `meta-llama/Llama-3.2-1B-Instruct`, which this host cannot download;
    - the other 2 are pipeline-parallel tests in `test_kv_cache_utils.py`.
- pre-commit, mypy 3.12, and `git diff --check`: passed.

End-to-end reproduction from #55904 (`Qwen/Qwen3-0.6B`, greedy, 48 tokens):

| check | before | after |
| --- | --- | --- |
| `A_control_matches_A_cold` | True | True |
| `B_shared_reused_As_files` | True | False |
| `B_shared_matches_B_isolated` | False | True |

Before the fix, LBNHC and LBHNC reuse the same persisted files. After the fix they use separate namespaces and both produce the expected output.

## Downsides

Existing direct-path namespaces are superseded, so the first run after upgrade prefills cold. Old directories are left untouched and can be deleted to reclaim disk.

For `p2p`, patched and unpatched peers have different compatibility fingerprints, so KV sharing across a rolling-upgrade boundary stops until the upgrade completes.

## Documentation

Updated `docs/features/kv_offloading_usage.md` to include KV cache layout in the set of fields that determine a shared persistent namespace, and to document the one-time namespace change.

## AI assistance

AI assistance was used to investigate, implement, test, and write this up.
The human submitter reviewed every changed line and is responsible for the change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

