### PR TITLE
[Bugfix] Restore is_torch_fx_available for trust_remote_code models on Transformers v5

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -426,12 +426,6 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "MiniCPM4ForCausalLM": _HfExamplesInfo(
         "openbmb/MiniCPM4.1-8B",
         min_transformers_version="4.56",
-        max_transformers_version="4.57",
-        transformers_version_reason={
-            "hf": "HF remote code imports removed `is_torch_fx_available`; "
-            "the upstream compatibility shim request was closed as not planned: "
-            "https://github.com/huggingface/transformers/issues/44561"
-        },
         trust_remote_code=True,
     ),
     "MiniMaxM2ForCausalLM": _HfExamplesInfo(

--- a/tests/transformers_utils/test_compat.py
+++ b/tests/transformers_utils/test_compat.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+from transformers.utils import import_utils
+
+from vllm.transformers_utils.compat import install_remote_code_shims
+
+
+@pytest.mark.parametrize(
+    "module", ["transformers.utils.import_utils", "transformers.utils"]
+)
+def test_remote_code_can_import_is_torch_fx_available(module: str):
+    """Hub modelling files import a symbol Transformers v5 removed.
+
+    Hunyuan, DeepSeek MoE and MiniCPM4 all import `is_torch_fx_available` at
+    module scope, so without the shim the Transformers backend raises
+    `ImportError` while building the model.
+    """
+    install_remote_code_shims()
+
+    namespace: dict = {}
+    exec(f"from {module} import is_torch_fx_available", namespace)
+
+    assert namespace["is_torch_fx_available"]() is True
+
+
+def test_existing_symbol_is_not_overridden(monkeypatch: pytest.MonkeyPatch):
+    sentinel = object()
+    monkeypatch.setattr(import_utils, "is_torch_fx_available", sentinel, raising=False)
+
+    install_remote_code_shims()
+
+    assert import_utils.is_torch_fx_available is sentinel

--- a/vllm/transformers_utils/__init__.py
+++ b/vllm/transformers_utils/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from vllm import envs
+from vllm.transformers_utils.compat import install_remote_code_shims
 
 if envs.VLLM_USE_MODELSCOPE:
     try:
@@ -24,3 +25,6 @@ if envs.VLLM_USE_MODELSCOPE:
             "Please install modelscope>=1.18.1 via "
             "`pip install modelscope>=1.18.1` to use ModelScope."
         ) from err
+
+# Patch here, before remote code from the Hub is executed
+install_remote_code_shims()

--- a/vllm/transformers_utils/compat.py
+++ b/vllm/transformers_utils/compat.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compatibility shims for Transformers symbols that Hub remote code imports."""
+
+
+def install_remote_code_shims() -> None:
+    """Restore Transformers symbols that `trust_remote_code` models import.
+
+    `is_torch_fx_available` was removed in Transformers v5, but modelling files
+    hosted on the Hub still import it at module scope, so the Transformers
+    backend fails when it instantiates such a model, before any weight is
+    loaded and on every device. Transformers
+    declined to carry a generic shim (huggingface/transformers#44561), so it is
+    restored here when absent. Every Transformers v5 release requires a Torch
+    version that ships `torch.fx`, making Torch availability the faithful
+    reduction of the removed check.
+    """
+    import transformers.utils
+    from transformers.utils import import_utils
+
+    if hasattr(import_utils, "is_torch_fx_available"):
+        return
+
+    def is_torch_fx_available() -> bool:
+        return import_utils.is_torch_available()
+
+    import_utils.is_torch_fx_available = is_torch_fx_available
+    transformers.utils.is_torch_fx_available = is_torch_fx_available


### PR DESCRIPTION


## Purpose

Fixes #55845.

Transformers v5.0 removed `is_torch_fx_available` (huggingface/transformers#37234), but Hub remote code still imports it at module scope, so `--trust-remote-code` loads fail with `ImportError`. Affected: `tencent/Hunyuan-A13B-Instruct`, `openbmb/MiniCPM4.1-8B`, `deepseek-ai/deepseek-moe-16b-base`.

Upstream declined a generic shim (huggingface/transformers#44561, closed `not_planned`), so this restores the symbol in vLLM when it is missing.

The crash is not during class resolution as the issue reports — that path swallows the error via `warn_on_fail=False`. It surfaces at `AutoModel.from_config` in `transformers/base.py`, where the remote `HunYuanConfig`'s `auto_map` re-enters `hunyuan.py`.

- `vllm/transformers_utils/compat.py` (new): `install_remote_code_shims()`, guarded by `hasattr` so upstream is never overridden; returns `is_torch_available()`, since every v5 release requires a Torch shipping `torch.fx`.
- `vllm/transformers_utils/__init__.py`: installed at import, next to the existing ModelScope patch. Must be process-wide to cover `AutoModel.from_config`.
- `tests/models/registry.py`: drops the now-stale `max_transformers_version="4.57"` pin on `MiniCPM4ForCausalLM`.

Fixes the load-blocking `ImportError`; not a claim that Hunyuan-A13B serves end to end. Not a duplicate of #45664 (MiniCPM4 only, closed unmerged) — #55845 asks vLLM to revisit now that a third model is affected. AI assistance was used; all lines reviewed and results reproduced by the submitter.

## Test Plan

```bash
.venv/bin/python -m pytest tests/transformers_utils/test_compat.py -v

# Crash site, with and without the shim (1 layer on meta: no GPU, no weights)
.venv/bin/python -c "
import sys, torch
if '--shim' in sys.argv: import vllm.transformers_utils
from transformers import AutoConfig, AutoModel
cfg = AutoConfig.from_pretrained('tencent/Hunyuan-A13B-Instruct', trust_remote_code=True)
cfg.num_hidden_layers = 1
with torch.device('meta'):
    print('BUILT:', type(AutoModel.from_config(cfg, dtype=torch.bfloat16, trust_remote_code=True)).__name__)"
```

## Test Result

Unit tests: 3 passed.

Crash site, same revision 290ddb9a… as the issue:

WITHOUT SHIM: FAILED: ImportError cannot import name 'is_torch_fx_available'
WITH SHIM:    BUILT: HunYuanModel

All three models resolve through vLLM's own path:

tencent/Hunyuan-A13B-Instruct:     OK -> HunYuanMoEV1ForCausalLM
openbmb/MiniCPM4.1-8B:             OK -> MiniCPMForCausalLM
deepseek-ai/deepseek-moe-16b-base: OK -> DeepseekForCausalLM

Every other symbol hunyuan.py imports still exists in v5, so this one-symbol shim does not just move the error down a line.

Limitations: runtime tests ran on Transformers 5.13.1; assumptions verified against 5.16.1 by inspection. Coverage stops at AutoModel.from_config — no full vllm serve run. No evals: no computation changes.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>