### PR TITLE
[Bugfix][Layers] Scale cos/sin cache length in NTK and Dynamic NTK RoPE

### DIFF
--- a/tests/model_executor/layers/test_ntk_rope.py
+++ b/tests/model_executor/layers/test_ntk_rope.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for NTK and Dynamic NTK RoPE cos/sin cache length."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.rotary_embedding.dynamic_ntk_scaling_rope import (
+    DynamicNTKScalingRotaryEmbedding,
+)
+from vllm.model_executor.layers.rotary_embedding.ntk_scaling_rope import (
+    NTKScalingRotaryEmbedding,
+)
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+HEAD_SIZE = 64
+ROTARY_DIM = 64
+
+
+def _make_ntk(max_position, scaling_factor, mixed_b=None):
+    return NTKScalingRotaryEmbedding(
+        head_size=HEAD_SIZE,
+        rotary_dim=ROTARY_DIM,
+        max_position_embeddings=max_position,
+        base=10000.0,
+        is_neox_style=True,
+        scaling_factor=scaling_factor,
+        dtype=torch.float32,
+        mixed_b=mixed_b,
+    )
+
+
+def _make_dynamic_ntk(max_position, max_trained_positions, scaling_factor):
+    return DynamicNTKScalingRotaryEmbedding(
+        head_size=HEAD_SIZE,
+        rotary_dim=ROTARY_DIM,
+        max_position_embeddings=max_position,
+        max_trained_positions=max_trained_positions,
+        base=10000.0,
+        is_neox_style=True,
+        scaling_factor=scaling_factor,
+        dtype=torch.float32,
+    )
+
+
+def _rotate(rope, positions):
+    query = torch.randn(len(positions), 1, HEAD_SIZE, dtype=torch.float32)
+    key = torch.randn(len(positions), 1, HEAD_SIZE, dtype=torch.float32)
+    return rope.forward_native(torch.tensor(positions, dtype=torch.long), query, key)
+
+
+@pytest.mark.parametrize("mixed_b", [None, 0.5])
+def test_ntk_cache_covers_scaled_context(default_vllm_config, mixed_b):
+    rope = _make_ntk(2048, 2.0, mixed_b)
+
+    assert rope.cos_sin_cache.shape == (4096, ROTARY_DIM)
+
+
+def test_ntk_rotates_positions_beyond_unscaled_length(default_vllm_config):
+    rope = _make_ntk(2048, 2.0)
+
+    out_q, out_k = _rotate(rope, [0, 2047, 2048, 4095])
+
+    assert not torch.isnan(out_q).any()
+    assert out_k is not None and not torch.isnan(out_k).any()
+
+
+def test_ntk_cache_never_shrinks_below_unscaled_length(default_vllm_config):
+    rope = _make_ntk(2048, 0.5)
+
+    assert rope.cos_sin_cache.shape == (2048, ROTARY_DIM)
+
+
+def test_dynamic_ntk_cache_covers_scaled_context(default_vllm_config):
+    rope = _make_dynamic_ntk(2048, 2048, 2.0)
+
+    assert rope.cos_sin_cache.shape == (4096, ROTARY_DIM)
+
+
+def test_dynamic_ntk_rotates_positions_beyond_unscaled_length(default_vllm_config):
+    rope = _make_dynamic_ntk(2048, 2048, 2.0)
+
+    out_q, out_k = _rotate(rope, [0, 2047, 2048, 4095])
+
+    assert not torch.isnan(out_q).any()
+    assert out_k is not None and not torch.isnan(out_k).any()
+
+
+def test_dynamic_ntk_cache_is_not_rescaled_when_caller_passes_served_length(
+    default_vllm_config,
+):
+    """Callers such as NomicBertModelConfig pass the already-scaled served
+    length as max_position_embeddings, so scaling it again would over-allocate.
+    """
+    rope = _make_dynamic_ntk(8192, 2048, 4.0)
+
+    assert rope.cos_sin_cache.shape == (8192, ROTARY_DIM)

--- a/vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/dynamic_ntk_scaling_rope.py
@@ -51,10 +51,9 @@ class DynamicNTKScalingRotaryEmbedding(RotaryEmbedding):
         )
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
-        # NOTE(woosuk): self.max_position_embeddings is the original
-        # maximum length before applying the rope scaling.
-        # Thus, the maximum length after applying the rope scaling is
-        # self.max_position_embeddings * self.scaling_factor.
+        # max_trained_positions is the length the model was trained on;
+        # max_position_embeddings is the length being served, which some callers
+        # have already scaled. The cache must cover whichever is longer.
         base = self.base * (
             (
                 self.scaling_factor
@@ -64,7 +63,11 @@ class DynamicNTKScalingRotaryEmbedding(RotaryEmbedding):
             - (self.scaling_factor - 1)
         ) ** (self.rotary_dim / (self.rotary_dim - 2))
         inv_freq = self._compute_inv_freq(base)
-        t = torch.arange(self.max_position_embeddings, dtype=torch.float)
+        max_len = max(
+            self.max_position_embeddings,
+            int(self.max_trained_positions * self.scaling_factor),
+        )
+        t = torch.arange(max_len, dtype=torch.float)
 
         freqs = torch.einsum("i,j -> ij", t, inv_freq)
         cos = freqs.cos()

--- a/vllm/model_executor/layers/rotary_embedding/ntk_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/ntk_scaling_rope.py
@@ -45,3 +45,17 @@ class NTKScalingRotaryEmbedding(RotaryEmbedding):
             inv_freq = inv_freq / lambda_1_m
 
         return inv_freq
+
+    def _compute_cos_sin_cache(self) -> torch.Tensor:
+        inv_freq = self._compute_inv_freq(self.base)
+        max_len = max(
+            self.max_position_embeddings,
+            int(self.max_position_embeddings * self.scaling_factor),
+        )
+        t = torch.arange(max_len, dtype=torch.float)
+
+        freqs = torch.einsum("i,j -> ij", t, inv_freq)
+        cos = freqs.cos()
+        sin = freqs.sin()
+        cache = torch.cat((cos, sin), dim=-1)
+        return cache


### PR DESCRIPTION
## Purpose

Fixes an out-of-bounds index crash when serving extended contexts with
`rope_type` set to `"ntk"` or `"dynamic"`.

`_get_and_verify_max_len` scales `derived_max_model_len` by the RoPE scaling
factor for every `rope_type` except `su`, `longrope` and `llama3`, so such a
model accepts positions past its unscaled `max_position_embeddings`. Neither
NTK class sized its cos/sin cache to match:

- `NTKScalingRotaryEmbedding` never overrode `_compute_cos_sin_cache`, so it
  inherited `RotaryEmbeddingBase`'s `torch.arange(self.max_position_embeddings)`.
- `DynamicNTKScalingRotaryEmbedding` built its position range from
  `max_position_embeddings` alone.

A position at or past the unscaled length then raises `IndexError` from
`cos_sin_cache.index_select(0, positions)` on CPU, and trips a device-side
assert on GPU.

`LinearScalingRotaryEmbedding` and `YaRNScalingRotaryEmbedding` already size
their caches by the scaling factor; this brings the two NTK classes in line.

Dynamic NTK scales `max_trained_positions` rather than
`max_position_embeddings`, because callers disagree on what the latter means:
most pass the unscaled config value, while `NomicBertModelConfig` passes the
already-scaled `max_model_len`. Scaling that a second time would over-allocate
the cache fourfold for Nomic, so the change is written to leave that path at
its current size. `test_dynamic_ntk_cache_is_not_rescaled_when_caller_passes_served_length`
guards it.

The change is additive: for every position that already worked, the cache
values are unchanged, so no model output moves. Verified by comparing the
first `max_position_embeddings` rows before and after (identical, max abs
difference `0.0`) for both classes.

`DynamicNTKAlphaRotaryEmbedding` is not affected. It is selected by the
`alpha` field, so `rope_parameters.get("factor", 1.0)` leaves
`derived_max_model_len` unscaled and its cache is already the right size.

## Why this is not duplicating an existing PR

`gh pr list --state open --search "NTKScalingRotaryEmbedding"` returns nothing.
The only open PR touching either file is #52675, which changes the *base*
calculation in `dynamic_ntk_scaling_rope.py` when the served length is below
the trained length. It does not change cache length and does not touch
`ntk_scaling_rope.py`. The two do overlap textually in
`_compute_cos_sin_cache`; happy to rebase on whichever lands first.

## Test Plan

```
pytest tests/model_executor/layers/test_ntk_rope.py -v
```

New device-free tests, marked `cpu_test`, covering: cache length for fixed NTK
(with and without `mixed_b`) and Dynamic NTK, rotation at positions past the
unscaled length, the lower bound under a downscaling factor, and the
prescaled-caller case described above.

## Test Result

```
7 passed
```

Reverting both production changes and re-running the same file gives
`5 failed, 2 passed` — the two that still pass are the bounds guards, which
are expected to hold before and after.

`pre-commit run --files <the three changed files>` is green, including
`mypy-3.10` and the SPDX check.
