### PR TITLE
[XPU][Bugfix] Fix FalconH1 pipeline-parallel execution

### DIFF
--- a/vllm/model_executor/models/falcon_h1.py
+++ b/vllm/model_executor/models/falcon_h1.py
@@ -449,8 +449,10 @@ class FalconH1Model(nn.Module):
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
         )
+        # FalconH1ParallelHybrid recomputes residual internally each layer,
+        # it is never threaded across the PP boundary.
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
-            ["hidden_states", "residual"], config.hidden_size
+            ["hidden_states"], config.hidden_size
         )
         if get_pp_group().is_last_rank:
             self.final_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
### Purpose
FalconH1Model.make_empty_intermediate_tensors (used for pipeline-parallel intermediate-tensor buffers) declares two keys: ["hidden_states", "residual"]. But FalconH1Model.forward() only ever returns IntermediateTensors({"hidden_states": hidden_states}) at the PP boundary, and only reads intermediate_tensors["hidden_states"] on the receiving side — "residual" is never produced or consumed.

This is because FalconH1ParallelHybrid (the model's decoder layer) doesn't thread residual through its forward() signature at all — it recomputes residual = hidden_states internally at the start of each layer, unlike standard dense/hybrid models (llama, jamba, nemotron_h, mamba2, qwen3_next) where residual is genuinely carried across layers and PP ranks.

Because the receiving PP rank's local intermediate-tensor buffer (allocated via the declared schema) does have a "residual" slot, but the incoming IntermediateTensors sent from the previous rank does not, the copy loop in model_runner.py (v[:n].copy_(intermediate_tensors.tensors[k][:n])) raises:
`KeyError: 'residual'`

This reproduces with --pipeline-parallel-size 2 on tiiuae/Falcon-H1-34B-Base, on both eager and torch.compile paths — not XPU-specific, any backend with PP>1 hits it. Verified this is isolated to FalconH1: all other PP-capable models correctly declare and thread residual, so this is not a general PP regression, and FalconH1 is likely the only model in our test scope actually exercising PP+hybrid-attention, explaining why it wasn't caught by broader CI.

### Fix
Drop the unused "residual" key from make_empty_intermediate_tensors_factory in FalconH1Model.__init__, matching what the layer actually produces/consumes.

### Test Plan
`vllm serve tiiuae/Falcon-H1-34B-Base --dtype bfloat16 --tensor-parallel-size 2 \
  --max-model-len 4096 --gpu-memory-utilization 0.91 \
  -cc '{"inductor_compile_config":{"benchmark_combo_kernel":false}}' \
  --port 8001 --pipeline-parallel-size 2 --trust-remote-code`

### Test Result
Before fix: worker crashes during kernel warmup with KeyError: 'residual' on non-first PP ranks server never comes up.

After fix: server starts successfully with the above command (confirmed working on BMG B70 XPU, PP=2/TP=2).