### PR TITLE
[Frontend] Add VLLM_FORCE_STRICT_TOOL_CALLING to enforce tool grammars server-side

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -8,6 +8,7 @@ import pytest
 from xgrammar import Grammar, StructuralTag
 from xgrammar.testing import _is_grammar_accept_string
 
+from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedFunction,
     ChatCompletionNamedToolChoiceParam,
@@ -537,6 +538,50 @@ def test_auto_tool_choice_skips_structural_tag_without_strict(
     )
 
     assert tag is None
+
+
+@pytest.mark.parametrize("model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS))
+def test_force_strict_tool_calling_attaches_tag_without_strict(
+    model: str,
+    sample_tools: list[ChatCompletionToolsParam],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """VLLM_FORCE_STRICT_TOOL_CALLING overrides the per-tool opt-in.
+
+    Without it, `tool_choice="auto"` and no strict tool means free-form decoding, and a
+    drifted tool call still returns HTTP 200 with `tool_calls: null`. Operators serving
+    clients they cannot patch need a server-side way to enforce the grammar.
+    """
+    monkeypatch.setattr(envs, "VLLM_FORCE_STRICT_TOOL_CALLING", True)
+
+    tag = get_model_structural_tag(
+        model=model,
+        tools=sample_tools,
+        tool_choice="auto",
+        reasoning=False,
+    )
+
+    assert tag is not None
+    assert isinstance(tag, StructuralTag)
+
+
+@pytest.mark.parametrize("model", sorted(XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS))
+def test_force_strict_tool_calling_defaults_off(
+    model: str,
+    sample_tools: list[ChatCompletionToolsParam],
+):
+    """The override must be opt-in: the default must not change existing behaviour."""
+    assert envs.VLLM_FORCE_STRICT_TOOL_CALLING is False
+
+    assert (
+        get_model_structural_tag(
+            model=model,
+            tools=sample_tools,
+            tool_choice="auto",
+            reasoning=False,
+        )
+        is None
+    )
 
 
 def test_get_function_parameters_relaxes_function_strict_false():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -238,6 +238,7 @@ if TYPE_CHECKING:
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_ENFORCE_STRICT_TOOL_CALLING: bool = True
+    VLLM_FORCE_STRICT_TOOL_CALLING: bool = False
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS: int = 5
@@ -1776,6 +1777,23 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enforce function parameter schemas in structural-tag based tool calling.
     "VLLM_ENFORCE_STRICT_TOOL_CALLING": lambda: (
         os.getenv("VLLM_ENFORCE_STRICT_TOOL_CALLING", "True").lower() in ("true", "1")
+    ),
+    # Treat every tool as strict for structural-tag tool calling, even when the
+    # request marks no tool `strict` and uses `tool_choice: "auto"`.
+    #
+    # By default a structural tag is attached only if the client opts in per
+    # tool. Clients that never set `strict` therefore decode tool calls
+    # free-form, and when that drifts the response is still HTTP 200 with
+    # `finish_reason: "stop"` and `tool_calls: null` -- the malformed call is
+    # left in `content`, so an agent loop reads it as a finished turn rather
+    # than an error. Operators serving fixed, trusted clients they cannot patch
+    # can set this to enforce the grammar server-side.
+    #
+    # Off by default: it constrains decoding for every request, and a tool
+    # schema that xgrammar cannot compile becomes a request error instead of a
+    # free-form answer.
+    "VLLM_FORCE_STRICT_TOOL_CALLING": lambda: (
+        os.getenv("VLLM_FORCE_STRICT_TOOL_CALLING", "False").lower() in ("true", "1")
     ),
     # Control the max chunk bytes (in MB) for the rpc message queue.
     # Object larger than this threshold will be broadcast to worker

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -30,6 +30,7 @@ from xgrammar.structural_tag import (
     TriggeredTagsFormat,
 )
 
+from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
@@ -114,7 +115,11 @@ def get_model_structural_tag(
     if not tools or tool_choice == "none":
         return None
 
-    if tool_choice == "auto" and not _any_tool_strict(tools):
+    if (
+        tool_choice == "auto"
+        and not _any_tool_strict(tools)
+        and not envs.VLLM_FORCE_STRICT_TOOL_CALLING
+    ):
         return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]


### PR DESCRIPTION
## Purpose

`get_model_structural_tag()` attaches a structural tag on `tool_choice="auto"` only when the request marks at least one tool `strict`:

```python
if tool_choice == "auto" and not _any_tool_strict(tools):
    return None
```

Clients that never set `strict` therefore decode tool calls free-form. When the model drifts, the response is still **HTTP 200** with `finish_reason: "stop"` and `tool_calls: null`, and the malformed call is left in `content`. An agent loop reads that as a *finished turn* rather than an error, so it fails silently instead of retrying — there is no 4xx, no log line, and no metric that distinguishes it from a model that simply chose not to call a tool.

That per-tool opt-in is the right default. But it leaves an operator no recourse when the client is fixed and cannot be patched — a packaged desktop agent, a vendored binary, an app whose serializer has no `strict` field at all. This adds an opt-in server-side override, `VLLM_FORCE_STRICT_TOOL_CALLING`, **off by default**, so existing behaviour is unchanged.

It is deliberately a separate variable rather than making `VLLM_ENFORCE_STRICT_TOOL_CALLING` tri-state, which would change that variable's type from `bool` and break typed access.

Trade-offs, stated in the env var's docstring: it constrains decoding for every request, and a tool schema xgrammar cannot compile becomes a request error rather than a free-form answer. That is why it is opt-in.

## Test Plan

```bash
pytest tests/tool_parsers/test_structural_tag_registry.py -k force_strict
```

Two tests, parametrized over `XGRAMMAR_BUILTIN_STRUCTURAL_TAG_MODELS`:

- `test_force_strict_tool_calling_attaches_tag_without_strict` — with the flag set, an unmarked tool list under `tool_choice="auto"` yields a `StructuralTag`.
- `test_force_strict_tool_calling_defaults_off` — asserts the default is `False` and that behaviour is byte-identical to today (the negative control; without it "it fires" is only half a test).

## Test Result

Executed the patched `get_model_structural_tag` inside a running vLLM 0.28.1 container serving `Qwen3.8-Flash-Next-NVFP4`, against a real 60-tool client payload with no tool marked strict:

```
VLLM_FORCE_STRICT_TOOL_CALLING=False -> None            # unchanged default
VLLM_FORCE_STRICT_TOOL_CALLING=True  -> StructuralTag   # grammar attached
```

Motivating measurement on that deployment (hermes parser, `tool_choice: "auto"`, n=24 per arm), counting responses that returned a real `tool_calls` array:

| tool surface | unmarked | grammar attached |
|---|---|---|
| 4 tools | 18/24 (75.0%) | **24/24 (100%)** |
| 14 tools | 33/36 (91.7%) | **36/36 (100%)** |
| 60 tools (real client) | 7/12 (58.3%) | **12/12 (100%)** |

Pooled 9/60 vs 0/60 failures on the two smaller surfaces, Fisher exact p = 0.0028. Drift on the unconstrained arm was Qwen3-Coder XML (`</invoke>`, `</parameter></function>`) and malformed JSON (`{"function": "read_file", ...}`), all at HTTP 200.

Control for the obvious confound: adding the field changes the rendered prompt (the chat template embeds each tool with `tool | tojson`), so `strict: false` was measured too — it changes the prompt identically and still leaked 4/24, while `strict: true` was 24/24. The grammar is doing the work, not the prompt change.

`ruff check` and `ruff format --check` clean on all three files.