### PR TITLE
[Kimi Bug] Fix kda ima `Triton Error [CUDA]: an illegal memory access was encountered`

### DIFF
--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -415,7 +415,7 @@ def _store_cache_checkpoints_kernel(
     # store checkpoints to cache
     seq_idx = tl.program_id(0)
     cols = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    state_idx = tl.load(checkpoint_state_indices_ptr + seq_idx)
+    state_idx = tl.load(checkpoint_state_indices_ptr + seq_idx).to(tl.int64)
     checkpoint_offset = tl.load(
         checkpoint_offsets_ptr + seq_idx * checkpoint_offset_stride
     )


### PR DESCRIPTION
## Purpose

```bash

vllm serve moonshotai/Kimi-K3 \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --load-format fastsafetensors \
  --gpu-memory-utilization 0.9 \
  --enable-prefix-caching \
  --reasoning-parser kimi_k3 \
  --enable-auto-tool-choice \
  --tool-call-parser kimi_k3 \
  --host 0.0.0.0 \
  --port 30000 \
  --max-model-len auto \
  --max-num-seqs 48 \
  --speculative-config '{"model":"RedHatAI/Kimi-K3-speculator.dspark","method":"dspark","num_speculative_tokens":8,"draft_sample_method":"probabilistic","rejection_sample_method":"standard"}'   --use-replayssm 



HF_HUB_CACHE=/data/engine/hub_cache HF_HUB_OFFLINE=1 guidellm run   --backend '{"kind":"openai_http","target":"http://127.0.0.1:30000","model":"moonshotai/Kimi-K3","request_format":"/v1/chat/completions","timeout":100000,"extras":{"body":{"reasoning_effort":"max","temperature":1.0,"top_p":0.95}}}'   --tokenizer '{"kind":"huggingface_auto","model":"moonshotai/Kimi-K3","load_kwargs":{"trust_remote_code":true,"local_files_only":true}}'   --data 'kind=synthetic_text,prompt_tokens=8000,output_tokens=1000'   --profile 'kind=concurrent,warmup=0.1,cooldown=0.1'   --override profile.streams '1,4,16'   --constraint 'kind=max_duration,seconds=150'   --constraint 'kind=max_errors,count=10'   --seed 'kind=static,value=42'   --metrics 'kind=generative,sample_size=20'   --output 'kind=json,path=/home/yewentao256/guidellm-results/output_vllm_kimik3_8k1k.json'
```

Will raise

```bash
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/kda.py", line 945, in _forward
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]     _store_cache_checkpoints_kernel[
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/triton/runtime/jit.py", line 370, in <lambda>
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/triton/runtime/jit.py", line 761, in run
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]     kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/triton/backends/nvidia/driver.py", line 328, in __call__
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055]     self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
(Worker_TP6 pid=2241799) ERROR 09-07 23:43:36 [multiproc_executor.py:1055] RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

`state_stride_0` can be `516,096`, `state_idx` can be 4000+, will be bigger than int32

This PR fixes the error

Now  works

```bash
(APIServer pid=2576289) INFO 09-08 01:24:51 [loggers.py:310] Engine 000: Avg prompt throughput: 12940.2 tokens/s, Avg generation throughput: 50.5 tokens/s, Running: 16 reqs, Waiting: 0 reqs, GPU KV cache usage: 15.8%, Prefix cache hit rate: 0.0%
```