### PR TITLE
[BugFix][Core] Make the structured-output grammar poll non-blocking

### DIFF
--- a/tests/v1/structured_output/test_request.py
+++ b/tests/v1/structured_output/test_request.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for StructuredOutputRequest grammar-future polling."""
+
+from concurrent.futures import Future
+
+from vllm.sampling_params import StructuredOutputsParams
+from vllm.v1.structured_output.request import StructuredOutputRequest
+
+
+def _request_with_future(fut: Future) -> StructuredOutputRequest:
+    req = StructuredOutputRequest(params=StructuredOutputsParams(regex="a+"))
+    req.grammar = fut
+    return req
+
+
+def test_pending_grammar_future_is_not_ready():
+    req = _request_with_future(Future())
+    assert not req.is_grammar_ready
+    assert req.grammar is None
+
+
+def test_grammar_compile_raising_timeout_error_is_a_failure():
+    """A compile that raised TimeoutError must be treated as a failed compile,
+    not as still-compiling (#53130)."""
+    fut: Future = Future()
+    fut.set_exception(TimeoutError("compiler timed out"))
+    req = _request_with_future(fut)
+    assert req.is_grammar_ready
+    assert isinstance(req.grammar, TimeoutError)

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -4,7 +4,6 @@ import dataclasses
 import functools
 import json
 from concurrent.futures import Future
-from concurrent.futures._base import TimeoutError
 from typing import TYPE_CHECKING, Any, cast
 
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
@@ -49,11 +48,10 @@ class StructuredOutputRequest:
 
     def _check_grammar_completion(self) -> bool:
         if isinstance(self._grammar, Future):
-            try:
-                # We will check whether the future is ready within 100 us
-                self._grammar = self._grammar.result(timeout=0.0001)
-            except TimeoutError:
+            if not self._grammar.done():
                 return False
+            try:
+                self._grammar = self._grammar.result()
             except Exception as e:
                 self._grammar = e
         return True


### PR DESCRIPTION
## Purpose

Split out of #53772 at @arpera's request so it can land independently (context: #53130).

`StructuredOutputRequest._check_grammar_completion()` polled the grammar future with `result(timeout=0.0001)`, which:

- blocks 100 µs per pending future on every poll — the scheduler polls each parked structured-output request every step it traverses `skipped_waiting`, so at the backlog seen in #53130 (473 parked requests) that is ~47 ms of pure waiting per step; and
- treats any `TimeoutError` as "still compiling". Since Python 3.11 `concurrent.futures.TimeoutError` *is* the builtin `TimeoutError`, so a grammar compile that **raised** `TimeoutError` (e.g. from a compile-timeout guard) was classified as pending forever instead of as a failed compile, leaving the request parked indefinitely.

The fix checks `done()` first (non-blocking) and lets `result()` surface the real exception, which is then stored as the failed-compile marker exactly as before.

**Not a duplicate**: no open PR touches this poll; the same change was previously part of #53772 and has been removed from there.

## Test Plan

```
pytest tests/v1/structured_output/test_request.py
```

- `test_pending_grammar_future_is_not_ready` — a pending future still reports not-ready and `grammar is None`.
- `test_grammar_compile_raising_timeout_error_is_a_failure` — a future whose compile raised `TimeoutError` is reported ready with the exception as its grammar (fails on `main`, passes with this change).

## Test Result

- `tests/v1/structured_output/test_request.py`: **2 passed**.
- `pre-commit run`: all hooks passed.
- Model evals: not applicable — polling mechanics only; grammar results and sampling are unchanged.

---

This PR was developed with AI assistance (Claude Code). I have reviewed every changed line and run all reported tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
