### PR TITLE
[Docs] Fix docstring typos (output_dytpe, kwrags, Abbrivations)

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -896,7 +896,7 @@ def w8a8_triton_block_scaled_mm(
         Bs: The per-block quantization scale for `B`.
         block_size: The block size for per-block quantization. It should
         be 2-dim, e.g., [128, 128].
-        output_dytpe: The dtype of the returned tensor.
+        output_dtype: The dtype of the returned tensor.
     Returns:
         torch.Tensor: The result of matmul.
     """

--- a/vllm/transformers_utils/processors/ovis.py
+++ b/vllm/transformers_utils/processors/ovis.py
@@ -110,7 +110,7 @@ class OvisProcessor(ProcessorMixin):
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
         and `kwargs` arguments to Qwen2TokenizerFast's [`~Qwen2TokenizerFast.__call__`] if `text` is not `None` to encode
-        the text. To prepare the vision inputs, this method forwards the `vision_infos` and `kwrags` arguments to
+        the text. To prepare the vision inputs, this method forwards the `vision_infos` and `kwargs` arguments to
         Qwen2VLImageProcessor's [`~Qwen2VLImageProcessor.__call__`] if `vision_infos` is not `None`.
             Args:
                 images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `list[PIL.Image.Image]`, `list[np.ndarray]`, `list[torch.Tensor]`):

--- a/vllm/transformers_utils/processors/ovis2_5.py
+++ b/vllm/transformers_utils/processors/ovis2_5.py
@@ -115,7 +115,7 @@ class Ovis2_5Processor(ProcessorMixin):
         and image(s). This method forwards the `text`and `kwargs` arguments
         to Qwen2TokenizerFast's [`~Qwen2TokenizerFast.__call__`] if `text`
         is not `None` to encode the text. To prepare the vision inputs,
-        this method forwards the `vision_infos` and `kwrags` arguments to
+        this method forwards the `vision_infos` and `kwargs` arguments to
         Qwen2VLImageProcessor's [`~Qwen2VLImageProcessor.__call__`]
         if `vision_infos` is not `None`.
             Args:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -426,7 +426,7 @@ class KVCacheManager:
         ----------------------------------------------------------------------
         ```
 
-        Abbrivations:
+        Abbreviations:
 
         ```
         comp      = request.num_computed_tokens


### PR DESCRIPTION
Three docstring typos bundled:

- `vllm/model_executor/layers/quantization/utils/fp8_utils.py`: `w8a8_triton_block_scaled_mm` documents `output_dytpe`; the parameter is `output_dtype`
- `vllm/transformers_utils/processors/ovis.py` + `ovis2_5.py`: "forwards the `vision_infos` and **kwrags** arguments" — scrambled `kwargs`, copied from the Qwen2VL processor docstring
- `vllm/v1/core/kv_cache_manager.py`: `Abbrivations:` → `Abbreviations:`

Docs/comments only, no behavior change.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>