### PR TITLE
[XPU][Bugfix] Add forward_xpu to Ernie4_5_VLRotaryEmbedding

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/ernie45_vl_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/ernie45_vl_rope.py
@@ -80,3 +80,14 @@ class Ernie4_5_VLRotaryEmbedding(MRotaryEmbedding):
         key: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         return self.forward_native(positions, query, key)
+
+    def forward_xpu(  # type: ignore[override]
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        # No fused XPU kernel for this 3D t/h/w rope; base
+        # MRotaryEmbedding.forward_xpu forwards an extra `offsets` arg that
+        # this class's forward_cuda override doesn't accept. Use native path.
+        return self.forward_native(positions, query, key)


### PR DESCRIPTION
### Purpose
Ernie4_5_VLRotaryEmbedding overrides forward_native/forward_cuda with a 3-arg signature (positions, query, key) but doesn't override forward_xpu. The inherited MRotaryEmbedding.forward_xpu forwards an extra offsets arg into self.forward_cuda(positions, query, key, offsets), which resolves to this subclass's narrower override and raises:


This only triggers under --enforce-eager (or any config forcing custom_ops=['all']) on XPU — that's the only path where CustomOp.dispatch_forward() selects platform-specific forward_xpu/forward_cuda directly. Under the default torch.compile path (custom_ops=[]), dispatch returns forward_native directly (optionally Inductor-compiled), bypassing forward_xpu/forward_cuda entirely — so torch.compile mode was never affected.

CUDA is unaffected for a different reason: its forward_cuda is called directly by CustomOp.forward() with exactly the 3 args the model passes (positions, query, key) — no offsets involved, so the arity mismatch never surfaces. Note this class's forward_cuda doesn't use the fused triton_mrope kernel either (unlike the base MRotaryEmbedding.forward_cuda); it delegates straight to forward_native, since this model's h/w/t 3-section cos/sin splitting doesn't match the generic mrope kernel's expected layout. So CUDA eager, CUDA compiled, and XPU compiled all already ran the same native math — only XPU eager crashed.

Add forward_xpu delegating to forward_native, mirroring how forward_cpu already handles this class (inherited, unchanged) and consistent with the pattern used in #52174 for a similar rope-dispatch gap.

### Test Plan

`vllm serve baidu/ERNIE-4.5-VL-28B-A3B-PT --dtype bfloat16 --tensor-parallel-size 4
  --max-model-len 8192 --gpu-memory-utilization 0.85
  -cc '{"inductor_compile_config":{"benchmark_combo_kernel":false}}'
  --port 8000 --trust-remote-code --enforce-eager
  --limit-mm-per-prompt '{"image": 1}'`

### Test Result
Before fix: worker crashes during profile_run with TypeError: Ernie4_5_VLRotaryEmbedding.forward_cuda() takes from 3 to 4 positional arguments but 5 were given (see attached BME-078-S-server.log), EngineCore fails to start.

After fix: confirmed working — server starts successfully with the above command (BMG B70 XPU, TP=4, --enforce-eager).