### PR TITLE
[Docs] Explain cross-mode numerical variance (eager vs compile vs CUDA graphs)

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -149,6 +149,28 @@ When batch invariance is enabled, vLLM:
 !!! note
     Enabling batch invariance may impact performance compared to the default non-deterministic mode. This trade-off is intentional to guarantee reproducibility.
 
+## Cross-Mode Numerical Variance
+
+Batch invariance makes the output deterministic inside one execution configuration. It does not make different configurations agree. Eager execution, `torch.compile` without CUDA graphs, and the default path with CUDA graphs use different kernels. Their outputs differ by a small amount for the same input.
+
+Three configurations matter:
+
+- `--enforce-eager`: turns off `torch.compile` and CUDA graphs.
+- `compilation_config=CompilationConfig(cudagraph_mode="NONE")`: keeps `torch.compile`, turns off CUDA graphs.
+- default: `torch.compile` with CUDA graphs.
+
+Each configuration gives the same output when you run it again. But two configurations do not give the same output as each other. For BF16 models, the top-1 logprob differs by about 0.1 to 0.5 between configurations. Tokens far down the list can differ more.
+
+### Greedy sampling at a near tie
+
+Sometimes the two best tokens are almost equal. The gap between them is then very small. A small cross-mode difference can change the selected token. If this happens at the sampled position, greedy decoding returns a different token in each configuration. This is normal variance between valid kernels. It is not a kernel bug. See [#55238](https://github.com/vllm-project/vllm/issues/55238) for a measured example.
+
+When you debug a report about different outputs across configurations:
+
+- Compare the top-1 logprob and the gap between the top two tokens at each position. Do not use the largest difference over the top-k logprobs. Tokens far down the list make that number large without any effect on the output.
+- Set the configuration explicitly on both sides of the comparison. Use `--enforce-eager` or `-cc.cudagraph_mode=NONE`. See [debugging vLLM compile](../design/debug_vllm_compile.md) for the exact flags.
+- `VLLM_BATCH_INVARIANT=1` removes variance from the batch shape. It does not make eager and compiled kernels agree.
+
 ## Future Improvements
 
 The batch invariance feature is under active development. Planned improvements include:


### PR DESCRIPTION
## Purpose

Context: #55238. Users comparing `--enforce-eager` against the default path see changed greedy tokens and assume a kernel bug. Measurements in the issue show this is cross-mode numerical variance. This PR documents it in the batch invariance guide.

- `--enforce-eager` disables both torch.compile and CUDA graphs, so such a comparison changes two variables at once.
- Each execution configuration is internally deterministic, but configurations do not agree with each other. Greedy outputs can flip where the top two logits are nearly tied.
- Adds debugging guidance: compare the top-1 logprob and the top1-top2 gap per position instead of worst-case top-k logprob deltas, and pin the configuration on both sides of a comparison.

Measured basis (A100, latest main, data in #55238): argmax flips occurred only at positions with a top1-top2 margin below ~0.7. A Qwen2.5-7B control flipped only at its 0.125-margin position, while its sampled token (margin > 5) stayed stable across modes.

## Not a duplicate

No open PR documents this behavior. #55271 only touched the `enforce_eager` docstring in `vllm/config/model.py`.

## AI assistance

I used it a bit for verification on Modal.com

## Test plan

- `pre-commit run --files docs/features/batch_invariance.md` — all hooks passed (typos, markdownlint-cli2, and others).