### PR TITLE
[Bugfix][Multimodal] Validate mm splice/feature token counts at P0 so a bad item fails the request, not the engine

### DIFF
--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -6,11 +6,13 @@ from contextlib import nullcontext
 
 import numpy as np
 import pytest
+import torch
 
 from vllm.config import ModelConfig
 from vllm.exceptions import VLLMValidationError
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.hasher import MultiModalHasher
+from vllm.multimodal.inputs import MultiModalKwargsItem, MultiModalKwargsItems
 from vllm.multimodal.parse import MultiModalDataParser
 from vllm.multimodal.processing.context import (
     InputProcessingContext,
@@ -19,6 +21,7 @@ from vllm.multimodal.processing.context import (
 from vllm.multimodal.processing.inputs import ProcessorInputs
 from vllm.multimodal.processing.processor import (
     BaseMultiModalProcessor,
+    MultiModalProcessingInfo,
     PlaceholderFeaturesInfo,
     PromptIndexTargets,
     PromptInsertion,
@@ -1142,6 +1145,121 @@ class _TextFallbackProcessor(BaseMultiModalProcessor):
 
 def _text_fallback_processor() -> BaseMultiModalProcessor:
     return _TextFallbackProcessor(_FakeTokenizer())
+
+
+class _CountingProcessingInfo(_FakeProcessingInfo):
+    def __init__(self, tokenizer, feature_tokens: int | None) -> None:
+        super().__init__(tokenizer)
+        self.feature_tokens = feature_tokens
+
+    def get_mm_feature_token_count(self, modality: str, kwargs_item) -> int | None:
+        return self.feature_tokens
+
+
+class _CountValidatingProcessor(BaseMultiModalProcessor):
+    """Only the validator surface: a controllable feature count and cache."""
+
+    def __init__(self, tokenizer, feature_tokens: int | None, cache) -> None:
+        self.info = _CountingProcessingInfo(tokenizer, feature_tokens)
+        self.cache = cache
+
+    def _get_mm_fields_config(self, hf_inputs, hf_processor_mm_kwargs):
+        raise NotImplementedError
+
+    def _get_prompt_updates(self, mm_items, hf_processor_mm_kwargs, out_mm_kwargs):
+        raise NotImplementedError
+
+
+class _RecordingCache:
+    def __init__(self) -> None:
+        self.invalidated: list[str] = []
+
+    def invalidate(self, mm_hash: str) -> None:
+        self.invalidated.append(mm_hash)
+
+
+def _feature_count_mm_info(n_placeholders: int, is_embed: torch.Tensor | None = None):
+    mm_info = MultiModalProcessingInfo(
+        kwargs=MultiModalKwargsItems({"audio": [MultiModalKwargsItem.dummy()]}),
+        hashes={"audio": ["audio-hash-1"]},
+        prompt_updates={},
+    )
+    placeholders = {
+        "audio": [
+            [
+                PlaceholderFeaturesInfo(
+                    modality="audio",
+                    item_idx=0,
+                    start_idx=0,
+                    tokens=[7] * n_placeholders,
+                    is_embed=is_embed,
+                )
+            ]
+        ]
+    }
+    return mm_info, placeholders
+
+
+@pytest.mark.parametrize("feature_tokens", [None, 8])
+def test_validate_mm_feature_counts_passes(feature_tokens):
+    """Matching (or unknown) feature counts pass; the cache is untouched."""
+    mm_info, placeholders = _feature_count_mm_info(8)
+    cache = _RecordingCache()
+    processor = _CountValidatingProcessor(_FakeTokenizer(), feature_tokens, cache)
+
+    processor._validate_mm_feature_counts(mm_info, placeholders)
+
+    assert cache.invalidated == []
+
+
+def test_validate_mm_feature_counts_mismatch_fails_request_and_invalidates():
+    """A splice/features count mismatch fails the request at P0 — instead of
+    a fatal engine error at model execution (#55546) — and evicts the stale
+    entry so a client retry reprocesses it."""
+    mm_info, placeholders = _feature_count_mm_info(8)
+    cache = _RecordingCache()
+    processor = _CountValidatingProcessor(_FakeTokenizer(), 5, cache)
+
+    with pytest.raises(ValueError, match="5 feature tokens but .* 8 placeholder"):
+        processor._validate_mm_feature_counts(mm_info, placeholders)
+
+    assert cache.invalidated == ["audio-hash-1"]
+
+
+def test_validate_mm_feature_counts_counts_embed_positions_only():
+    """Only positions marked by ``is_embed`` receive feature embeddings."""
+    is_embed = torch.tensor([True] * 5 + [False] * 5)
+    mm_info, placeholders = _feature_count_mm_info(10, is_embed=is_embed)
+    cache = _RecordingCache()
+    ok = _CountValidatingProcessor(_FakeTokenizer(), 5, cache)
+    ok._validate_mm_feature_counts(mm_info, placeholders)
+    assert cache.invalidated == []
+
+    bad = _CountValidatingProcessor(_FakeTokenizer(), 10, _RecordingCache())
+    with pytest.raises(ValueError, match="10 feature tokens but .* 5 placeholder"):
+        bad._validate_mm_feature_counts(mm_info, placeholders)
+
+
+def test_gemma4_audio_feature_token_count():
+    """Gemma4's hook must replicate the audio tower's sequence-length
+    arithmetic (two /2 conv subsamplings over the mel frames) exactly."""
+    from vllm.model_executor.models.gemma4_mm import Gemma4ProcessingInfo
+    from vllm.multimodal.inputs import MultiModalFieldElem, MultiModalSharedField
+
+    info = object.__new__(Gemma4ProcessingInfo)
+    frames = 2999  # 30 s of 16 kHz audio -> 750 tokens
+    item = MultiModalKwargsItem(
+        {
+            "input_features_padded": MultiModalFieldElem(
+                data=torch.zeros((1, frames, 80)),
+                field=MultiModalSharedField(batch_size=1),
+            )
+        }
+    )
+
+    assert info.get_mm_feature_token_count("audio", item) == 750
+    assert info.get_mm_feature_token_count("audio", None) is None
+    assert info.get_mm_feature_token_count("image", item) is None
 
 
 def test_apply_prompt_updates_falls_back_to_text_matching():

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -249,6 +249,30 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
             )
         super().validate_num_items(modality, num_items)
 
+    def get_mm_feature_token_count(
+        self,
+        modality: str,
+        kwargs_item: MultiModalKwargsItem | None,
+    ) -> int | None:
+        # Replicates the audio tower's sequence-length arithmetic
+        # (two Conv2d subsampling layers over the mel frames, i.e.
+        # ceil(frames / 4)) so that a prompt splice which disagrees with
+        # the processed features fails the request at P0 instead of
+        # escalating to a fatal engine error during model execution.
+        if modality != "audio" or kwargs_item is None:
+            return None
+
+        field = kwargs_item.get("input_features_padded")
+        if field is None:
+            return None
+
+        data = field.data
+        if not isinstance(data, torch.Tensor) or data.ndim < 2:
+            return None
+
+        batch_size = math.prod(data.shape[:-2])
+        return batch_size * math.ceil(data.shape[-2] / 4)
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         limits: dict[str, int | None] = {"image": None}
         if self.get_hf_config().audio_config is not None:

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from transformers.processing_utils import ProcessorMixin
 
     from vllm.config import ModelConfig
+    from vllm.inputs import MultiModalKwargsItem
     from vllm.renderers import TokenizeParams
 else:
     PretrainedConfig = object
@@ -390,6 +391,24 @@ class BaseProcessingInfo:
         specific kwargs from model config or user inputs.
         """
         return self.ctx.get_hf_processor(**kwargs)
+
+    def get_mm_feature_token_count(
+        self,
+        modality: str,
+        kwargs_item: "MultiModalKwargsItem | None",
+    ) -> int | None:
+        """
+        Number of feature tokens the model's multimodal encoder will
+        produce for a processed item.
+
+        Used by :meth:`BaseMultiModalProcessor.apply` to check that the
+        prompt splice reserves exactly this many placeholder positions,
+        so a count mismatch fails the request at P0 instead of escalating
+        to a fatal engine error during model execution. ``None`` (the
+        default) means the count cannot be cheaply determined and the
+        check is skipped.
+        """
+        return None
 
     def get_default_tok_params(self) -> TokenizeParams:
         """Construct the default parameters for tokenization."""

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1741,6 +1741,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                 mm_prompt_updates=mm_info.prompt_updates,
             )
 
+        self._validate_mm_feature_counts(mm_info, mm_placeholders)
+
         mm_placeholder_ranges = {
             modality: [item.to_range() for item in placeholders]
             for modality, placeholders in mm_placeholders.items()
@@ -1752,6 +1754,61 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_hashes=mm_info.hashes,
             mm_placeholders=mm_placeholder_ranges,
         )
+
+    def _validate_mm_feature_counts(
+        self,
+        mm_info: MultiModalProcessingInfo,
+        mm_placeholders: Mapping[str, Sequence[PlaceholderFeaturesInfo]],
+    ) -> None:
+        """Check that each item's prompt splice reserves exactly as many
+        placeholder positions as the encoder will produce feature tokens.
+
+        A mismatch previously surfaced during model execution in
+        ``_merge_multimodal_embeddings``, which V1 treats as a fatal
+        engine error: one bad item tears down the whole engine tree
+        (#55546). Common causes are a stale multimodal cache entry (a
+        UUID reused for a different payload, #55547) or a prompt-splice
+        formula that disagrees with the HF processor output. Failing
+        here is request-scoped, and the offending item's cache entry is
+        invalidated so a client retry reprocesses it.
+        """
+        for modality, placeholders in mm_placeholders.items():
+            hashes = mm_info.hashes.get(modality, [])
+            kwargs_items = mm_info.kwargs.get(modality, [])
+
+            for item_idx, item_placeholders in enumerate(placeholders):
+                if item_idx >= len(kwargs_items) or item_idx >= len(hashes):
+                    continue
+
+                n_placeholders = sum(
+                    (
+                        int(ph.is_embed.sum().item())
+                        if ph.is_embed is not None
+                        else ph.length
+                    )
+                    for ph in item_placeholders
+                )
+                n_features = self.info.get_mm_feature_token_count(
+                    modality, kwargs_items[item_idx]
+                )
+                if n_features is None or n_features == n_placeholders:
+                    continue
+
+                mm_hash = hashes[item_idx]
+                if self.cache is not None:
+                    self.cache.invalidate(mm_hash)
+
+                raise ValueError(
+                    f"Multimodal '{modality}' item {mm_hash!r} produces "
+                    f"{n_features} feature tokens but its prompt replacement "
+                    f"reserves {n_placeholders} placeholder positions. This "
+                    "usually means the multimodal processor cache served a "
+                    "stale entry (e.g. a UUID reused for a different "
+                    "payload) or the model's prompt-splice arithmetic "
+                    "disagrees with the processor output. The cache entry "
+                    "has been invalidated; retrying the request reprocesses "
+                    "the item."
+                )
 
 
 class EncDecMultiModalProcessor(BaseMultiModalProcessor[_I]):


### PR DESCRIPTION
## Purpose

Fail a multimodal request at P0 (request-scoped `ValueError`) when its prompt splice reserves a different number of placeholder positions than the encoder will produce feature tokens — instead of letting the mismatch surface during model execution, where V1 treats it as a fatal engine error that tears down the entire engine tree.

## Problem

`_merge_multimodal_embeddings` raises when an item's feature count disagrees with its placeholder count, and V1 turns that into an engine-wide death: the offending `EngineCore` dies, every API server's `add_request` then raises `EngineDeadError`, and the whole process group (all DP ranks + all API servers) tears down. One bad item — or one poisoned processor-cache entry — is a total outage requiring a restart (#55546).

Common causes of the mismatch:
- A **stale multimodal cache entry**: a client UUID reused for a different payload (the caches key on client-supplied UUIDs with no content binding, #55547). We observed this in a DP8 internal-LB deployment: a request spliced 638 placeholder slots and was served 138-token stale features — all 8 engines and all 8 API servers died mid-serving.
- A prompt-splice formula that disagrees with the HF processor output for the same bytes.

## Fix

- New `BaseProcessingInfo.get_mm_feature_token_count(modality, kwargs_item)` hook: the number of feature tokens the model's encoder will produce for a processed item. Default `None` = count unknown, check skipped.
- New validation in `BaseMultiModalProcessor.apply`, right after the prompt updates are applied: per item, the number of embed positions the splice reserved (`is_embed` mask count, else `length`) must equal the expected feature count.
- On mismatch: **invalidate the offending item's cache entry** (`cache.invalidate(mm_hash)` — the existing P0/P1 drift-recovery primitive, so a client retry reprocesses the item) and raise a `ValueError`, which fails the request as a 400. The engine survives.
- Gemma4 audio implements the hook by replicating the audio tower's sequence-length arithmetic (`ceil(padded frames / 4)` over `input_features_padded`), keeping the check in lockstep with the encoder. Other models can adopt the hook incrementally.

Complementary to #55549, which prevents different-sized payloads from ever sharing a UUID cache key (the root-cause fix for the length-collision class); this PR catches any residual splice/features disagreement before the engine, whatever its origin.

## Test Plan

- `test_validate_mm_feature_counts_passes` — matching (or unknown) counts pass; cache untouched.
- `test_validate_mm_feature_counts_mismatch_fails_request_and_invalidates` — mismatch raises with an actionable message and evicts the stale entry.
- `test_validate_mm_feature_counts_counts_embed_positions_only` — only `is_embed` positions count as placeholders.
- `test_gemma4_audio_feature_token_count` — the hook replicates the tower arithmetic (2999 frames → 750 tokens) and stays `None` for non-audio/`None` items.
- Full `tests/multimodal/test_{processing,hasher,cache}.py` run locally: failure set byte-identical to pristine `main` (residual failures are environment-unsuitable model-processor tests, unchanged by this PR).

Partially addresses #55546 (pre-engine catch for models implementing the hook; a general engine-side error channel for arbitrary merge failures is a larger V1 design discussion this PR deliberately does not attempt).

---
**[{F}ixes](https://cla-assistant.io/pull/badge/cla_signed)**: I will sign the vLLM CLA via cla-assistant once the check appears on this PR.
