### PR TITLE
[Performance] Add RTX 5090 BF16 MoE config for Qwen3 TP4

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=128,N=192,device_name=NVIDIA_GeForce_RTX_5090.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=128,N=192,device_name=NVIDIA_GeForce_RTX_5090.json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.7.1",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}


### PR DESCRIPTION
## Purpose

Add an NVIDIA GeForce RTX 5090 BF16 fused-MoE configuration for the Qwen3-30B-A3B / Qwen3-Omni-30B-A3B TP=4 per-rank shape (`E=128`, `N=192`).

RTX 5090 currently falls back to the generic fused-MoE configuration for this shape. This addresses the missing consumer-Blackwell configuration reported in #48732. The change is data-only and is selected through the existing device-specific configuration loader.

## Test Plan

- Hardware: NVIDIA GeForce RTX 5090, SM120
- Software: current `main` at `613ab20f7f9082244240f4e9b2e7a4ee6769c38f`, PyTorch 2.13.0+cu132, Triton 3.7.1
- Shape: BF16, `E=128`, per-rank `N=192`, hidden size 2048, top-k 8, TP=4 model layout
- Token counts: `1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 256, 512, 1024, 1536, 2048, 3072, 4096`
- Performance: three randomized interleaved repeats of current default versus the proposed config, 80 benchmark iterations per arm and token count
- Correctness: run `fused_experts` with identical random BF16 inputs, routing weights and expert ids under the default and proposed configurations for all 18 token counts
- Integration: verify `get_config_file_name(128, 192, None)` and `get_moe_configs(128, 192, None)` automatically resolve and load the new file on RTX 5090

The candidate configurations were selected by a bounded exact-shape transfer screen over existing A100, H100, H20-3e, H20 and H200 configs. This is not a claim of exhaustive autotuning.

## Test Result

All 18 token counts improved. The geometric mean of the median paired speedups is **1.1690x**. The minimum speedup among all 54 individual paired observations is **1.0404x**.

| M | Default (us) | RTX 5090 config (us) | Speedup |
|---:|---:|---:|---:|
| 1 | 20.655 | 16.862 | 1.225x |
| 2 | 25.337 | 20.362 | 1.244x |
| 4 | 41.307 | 27.781 | 1.487x |
| 8 | 86.228 | 79.873 | 1.080x |
| 16 | 144.277 | 134.220 | 1.075x |
| 24 | 173.455 | 158.750 | 1.093x |
| 32 | 191.469 | 178.276 | 1.074x |
| 48 | 203.861 | 194.895 | 1.046x |
| 64 | 208.072 | 199.745 | 1.042x |
| 96 | 218.040 | 205.460 | 1.061x |
| 128 | 245.391 | 204.067 | 1.203x |
| 256 | 246.227 | 207.534 | 1.186x |
| 512 | 250.470 | 216.512 | 1.157x |
| 1024 | 310.892 | 237.020 | 1.312x |
| 1536 | 324.506 | 269.846 | 1.203x |
| 2048 | 439.442 | 328.093 | 1.339x |
| 3072 | 572.376 | 459.966 | 1.244x |
| 4096 | 718.628 | 669.771 | 1.073x |

Correctness passed for every token count. With the fixed random test inputs, the outputs were bit-identical (`max_abs=0`, `mean_abs=0`). The normal loader resolved all 18 entries from `E=128,N=192,device_name=NVIDIA_GeForce_RTX_5090.json`.

This PR currently claims kernel-level improvement only. A TP=4 online-serving result will be added when four RTX 5090 GPUs are simultaneously available; no end-to-end speedup is inferred from the kernel result.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described and linked to #48732.
- [x] The test plan includes hardware, shape, commands/protocol and correctness coverage.
- [x] The test result includes before/after measurements.
- [x] No documentation update is required for a device-specific tuning data file.

</details>
