### PR TITLE
[Perf] Delay DFlash2 TP reductions until after convolution

### DIFF
--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -6,7 +6,11 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from vllm.model_executor.models.qwen3_dflash2 import _grouped_conv, _score_edges
+from vllm.model_executor.models.qwen3_dflash2 import (
+    _grouped_conv,
+    _reduce_norm,
+    _score_edges,
+)
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import DFlash2Speculator
 
@@ -69,6 +73,36 @@ def test_selector_edges_match_sequential_reference():
         )
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_reduce_norm_reduces_before_residual_add(monkeypatch):
+    events = []
+
+    class FakeNorm(torch.nn.Module):
+        def forward(self, hidden_states, residual):
+            events.append("norm")
+            return hidden_states + residual, hidden_states
+
+    def fake_all_reduce(hidden_states):
+        events.append("all_reduce")
+        return hidden_states + 10
+
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_dflash2.get_tensor_model_parallel_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_dflash2.tensor_model_parallel_all_reduce",
+        fake_all_reduce,
+    )
+
+    hidden_states = torch.tensor([[1.0, 2.0]])
+    residual = torch.tensor([[3.0, 4.0]])
+    normed, new_residual = _reduce_norm(FakeNorm(), hidden_states, residual)
+
+    assert events == ["all_reduce", "norm"]
+    assert torch.equal(normed, hidden_states + 10 + residual)
+    assert torch.equal(new_residual, hidden_states + 10)
 
 
 def _stub_base(monkeypatch, draft_logits):
@@ -231,3 +265,5 @@ def test_dflash2_model_decoder_layer_cls(monkeypatch):
     # 4. Assert that the layers are DFlash2Qwen3DecoderLayer (the subclass)
     assert len(model.layers) == 2
     assert isinstance(model.layers[0], DFlash2Qwen3DecoderLayer)
+    assert not model.layers[0].self_attn.o_proj.reduce_results
+    assert not model.layers[0].mlp.down_proj.reduce_results

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -660,6 +660,13 @@ class DFlashQwen3Model(nn.Module):
                 hidden_states=hidden_states,
                 residual=residual,
             )
+        return self.final_norm(hidden_states, residual)
+
+    def final_norm(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor | None
+    ) -> torch.Tensor:
+        if residual is None:
+            return self.norm(hidden_states)
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -8,6 +8,10 @@ from torch import nn
 from vllm.compilation.backends import set_model_tag
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
+)
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
@@ -18,6 +22,16 @@ from .qwen3_dflash import (
     DFlashQwen3Model,
 )
 from .utils import maybe_prefix
+
+
+def _reduce_norm(
+    norm: nn.Module,
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if get_tensor_model_parallel_world_size() > 1:
+        hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+    return norm(hidden_states, residual)
 
 
 def _grouped_conv(
@@ -137,6 +151,8 @@ class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
         self.mlp_conv = DFlashGroupedConv(
             **conv_args, prefix=maybe_prefix(prefix, "mlp_conv")
         )
+        self.self_attn.o_proj.reduce_results = False
+        self.mlp.down_proj.reduce_results = False
 
     def forward(
         self,
@@ -148,13 +164,17 @@ class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+            hidden_states, residual = _reduce_norm(
+                self.input_layernorm, hidden_states, residual
+            )
 
         hidden_states, coefficients = self.attention_conv.prepare(hidden_states)
         hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
         hidden_states = self.attention_conv.finish(hidden_states, coefficients)
 
-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states, residual = _reduce_norm(
+            self.post_attention_layernorm, hidden_states, residual
+        )
         hidden_states, coefficients = self.mlp_conv.prepare(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = self.mlp_conv.finish(hidden_states, coefficients)
@@ -261,6 +281,14 @@ class DFlash2Qwen3Model(DFlashQwen3Model):
                 params_dtype=vllm_config.model_config.dtype,
                 prefix=maybe_prefix(prefix, "candidate_selector"),
             )
+
+    def final_norm(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor | None
+    ) -> torch.Tensor:
+        if residual is None:
+            return self.norm(hidden_states)
+        hidden_states, _ = _reduce_norm(self.norm, hidden_states, residual)
+        return hidden_states
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return super().embed_input_ids(input_ids) * self.input_embedding_scale


### PR DESCRIPTION
## Summary

- return partial outputs from DFlash2's attention output and MLP down projections
- move their TP reductions after the following grouped convolution
- place each reduction immediately before RMSNorm, allowing vLLM's existing all-reduce/RMSNorm compiler fusion to match
- route the model's final normalization through the same reduction point

The transformation relies on the grouped convolution being linear and using identical coefficients on every TP rank.

## Performance potential

On TP8 B300, vLLM's existing fused-collective benchmark measured the separate all-reduce plus RMSNorm path against the available FlashInfer MNNVL fused implementation:

| Tokens | Separate | Fused |
| ---: | ---: | ---: |
| 7 | 27 us | 7 us |
| 28 | 42 us | 8 us |
| 112 | 48 us | 10 us |

These are kernel-level measurements demonstrating the fusion opportunity, not an end-to-end DFlash2 result.

## Validation

- `.venv/bin/python -m pytest tests/v1/spec_decode/test_dflash2.py tests/v1/spec_decode/test_dflash_prepare_inputs.py tests/v1/spec_decode/test_dflash_lookahead.py tests/v1/spec_decode/test_dflash_causality.py -q`: 26 passed
- changed-file pre-commit suite: passed, including mypy, SPDX, forbidden-import, and CUDA API checks
- model evaluation: not run yet; required before marking ready because moving BF16 reduction across convolution changes floating-point association

## Duplicate work

Searched open vLLM PRs for `dflash2 allreduce` and `DFlash2 delayed all-reduce convolution`. No matching open PR was found.

AI assistance was used to analyze the upstream transformation, implement this draft, and write the tests. The submitter will review and validate every changed line before this PR is marked ready.
