### PR TITLE
[Perf] Pack vocab top-k candidates into one TP8 all-gather

### DIFF
--- a/tests/model_executor/layers/test_logits_processor.py
+++ b/tests/model_executor/layers/test_logits_processor.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+
+def _fake_lm_head(tp_size: int = 2, num_embeddings_padded: int = 32):
+    return SimpleNamespace(
+        tp_size=tp_size,
+        num_embeddings_padded=num_embeddings_padded,
+        shard_indices=SimpleNamespace(
+            num_org_vocab_padding=0,
+            org_vocab_start_index=0,
+        ),
+    )
+
+
+def test_get_top_k_tokens_uses_one_packed_all_gather(default_vllm_config, monkeypatch):
+    all_logits = torch.arange(64, dtype=torch.float32).view(2, 32)
+    rank_logits = all_logits.split(4, dim=-1)
+    local_logits = rank_logits[0]
+    hidden_states = torch.empty(2, 1)
+    top_k = 2
+    processor = LogitsProcessor(vocab_size=32)
+    monkeypatch.setattr(processor, "_apply_head", lambda *args: local_logits)
+
+    calls = 0
+
+    def fake_all_gather(local_candidates: torch.Tensor, dim: int):
+        nonlocal calls
+        calls += 1
+        assert dim == -1
+        assert local_candidates.dtype == torch.float32
+        assert local_candidates.shape == (2, 2 * top_k)
+        candidates = [local_candidates]
+        for rank, logits in enumerate(rank_logits[1:], start=1):
+            remote_values, remote_ids = torch.topk(logits, top_k, dim=-1)
+            remote_ids += rank * local_logits.shape[-1]
+            candidates.append(
+                torch.cat(
+                    (remote_values, remote_ids.to(torch.int32).view(torch.float32)),
+                    dim=-1,
+                )
+            )
+        return torch.cat(candidates, dim=-1)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather",
+        fake_all_gather,
+    )
+
+    ids, values = processor.get_top_k_tokens(
+        _fake_lm_head(tp_size=8), hidden_states, top_k
+    )
+
+    expected_values, expected_ids = torch.topk(all_logits, top_k, dim=-1)
+    assert calls == 1
+    assert torch.equal(ids, expected_ids)
+    torch.testing.assert_close(values, expected_values)
+
+
+def test_get_top_k_tokens_packs_large_ids_losslessly(default_vllm_config, monkeypatch):
+    local_logits = torch.tensor([[1.0, 4.0, 3.0, 2.0]])
+    remote_logits = torch.tensor([[8.0, 7.0, 6.0, 5.0]])
+    hidden_states = torch.empty(1, 1)
+    top_k = 2
+    processor = LogitsProcessor(vocab_size=2**24 + 1)
+    monkeypatch.setattr(processor, "_apply_head", lambda *args: local_logits)
+
+    calls = 0
+
+    def fake_all_gather(local_candidates: torch.Tensor, dim: int):
+        nonlocal calls
+        calls += 1
+        assert dim == -1
+        assert local_candidates.dtype == torch.float32
+        remote_values, remote_ids = torch.topk(remote_logits, top_k, dim=-1)
+        remote_ids = remote_ids.to(torch.int64) + 2**24 - 4
+        remote_candidates = [
+            torch.cat(
+                (
+                    remote_values - rank * 10,
+                    remote_ids.to(torch.int32).view(torch.float32),
+                ),
+                dim=-1,
+            )
+            for rank in range(7)
+        ]
+        return torch.cat((local_candidates, *remote_candidates), dim=-1)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather",
+        fake_all_gather,
+    )
+
+    ids, values = processor.get_top_k_tokens(
+        _fake_lm_head(tp_size=8, num_embeddings_padded=2**24 + 1),
+        hidden_states,
+        top_k,
+    )
+
+    assert calls == 1
+    assert torch.equal(ids, torch.tensor([[2**24 - 4, 2**24 - 3]]))
+    torch.testing.assert_close(values, torch.tensor([[8.0, 7.0]]))
+
+
+def test_get_top_k_tokens_keeps_separate_gathers_below_tp8(
+    default_vllm_config, monkeypatch
+):
+    local_logits = torch.tensor([[1.0, 4.0, 3.0, 2.0]])
+    hidden_states = torch.empty(1, 1)
+    top_k = 2
+    processor = LogitsProcessor(vocab_size=8)
+    monkeypatch.setattr(processor, "_apply_head", lambda *args: local_logits)
+
+    gathered_dtypes = []
+
+    def fake_all_gather(local_candidates: torch.Tensor, dim: int):
+        gathered_dtypes.append(local_candidates.dtype)
+        return torch.cat((local_candidates, local_candidates), dim=dim)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather",
+        fake_all_gather,
+    )
+
+    processor.get_top_k_tokens(_fake_lm_head(), hidden_states, top_k)
+
+    assert gathered_dtypes == [torch.float32, torch.int64]

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -25,6 +25,9 @@ from vllm.utils.flashinfer import has_flashinfer
 
 logger = init_logger(__name__)
 
+_MAX_INT32 = 2**31 - 1
+_MIN_PACKED_TOPK_TP_SIZE = 8
+
 
 @cache
 def _flashinfer_topk() -> Callable[..., tuple[torch.Tensor, torch.Tensor]] | None:
@@ -284,9 +287,24 @@ class LogitsProcessor(PluggableLayer):
         # Convert shard-local indices to global vocab indices.
         ids = ids.to(torch.int64) + lm_head.shard_indices.org_vocab_start_index
 
-        if lm_head.tp_size > 1:
-            values = tensor_model_parallel_all_gather(values, dim=-1)
-            ids = tensor_model_parallel_all_gather(ids, dim=-1)
+        tp_size = lm_head.tp_size
+        if tp_size > 1:
+            if (
+                tp_size >= _MIN_PACKED_TOPK_TP_SIZE
+                and lm_head.num_embeddings_padded <= _MAX_INT32
+            ):
+                # Bit-cast IDs so packing is lossless beyond FP32's integer range.
+                packed_ids = ids.to(torch.int32).view(torch.float32)
+                candidates = torch.cat((values.float(), packed_ids), dim=-1)
+                candidates = tensor_model_parallel_all_gather(candidates, dim=-1)
+                candidates = candidates.unflatten(-1, (tp_size, 2, k))
+                values = candidates[..., 0, :].flatten(-2)
+                ids = (
+                    candidates[..., 1, :].flatten(-2).view(torch.int32).to(torch.int64)
+                )
+            else:
+                values = tensor_model_parallel_all_gather(values, dim=-1)
+                ids = tensor_model_parallel_all_gather(ids, dim=-1)
             values, selected = _topk(values, k)
             ids = ids.gather(-1, selected)
 


### PR DESCRIPTION
## Summary

- pack local top-k values and IDs into one FP32 tensor before TP all-gather
- bit-cast IDs through int32 so packing remains lossless beyond FP32's numeric integer range
- enable the packed path only at TP8+, retaining separate gathers at TP2/TP4

This applies to the general vocab-parallel `get_top_k_tokens` path rather than being DFlash2-specific.

## Performance

Measured on one NVLink-connected NVIDIA B300 node with top-k 16, CUDA graphs, device-side synchronization, and the slowest-rank time:

| Rows | Separate gathers | Packed gather | Speedup |
| ---: | ---: | ---: | ---: |
| 8 | 48.22 us | 38.21 us | 1.26x |
| 32 | 50.21 us | 44.37 us | 1.13x |
| 128 | 52.53 us | 46.30 us | 1.13x |

TP2 was 0.92-0.98x and TP4 was mostly neutral, which is why the optimized path starts at TP8. The TP8 timing run printed valid results but aborted during benchmark teardown; a clean-exit rerun is pending before this draft is marked ready.

## Validation

- `.venv/bin/python -m pytest tests/model_executor/layers/test_logits_processor.py -q`: 3 passed
- tests cover one-collective behavior, IDs above 2^24, and the lower-TP fallback
- changed-file pre-commit suite: passed, including mypy, SPDX, forbidden-import, and CUDA API checks
- model evaluation: not run; the change is intended to be bit-exact and the focused tests compare returned IDs and values

## Duplicate work

Searched open vLLM PRs for `get_top_k_tokens` and `vocab top-k all-gather packed`. No matching open PR was found.

AI assistance was used to analyze the upstream idea, implement this draft, build the benchmark, and write the tests. The submitter will review and validate every changed line before this PR is marked ready.
