### PR TITLE
[CI][IR] Speed up vLLM IR test group

### DIFF
--- a/tests/ir/test_inplace_op.py
+++ b/tests/ir/test_inplace_op.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
 import torch
 from torch import Tensor
 from torch.fx.experimental.proxy_tensor import make_fx
 
 import vllm.ir.op
 from vllm.ir.op import IrOp, IrOpInplaceOverload
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 @vllm.ir.register_op(allow_inplace=True)

--- a/tests/ir/test_op.py
+++ b/tests/ir/test_op.py
@@ -13,6 +13,8 @@ from torch.fx.experimental.proxy_tensor import make_fx
 import vllm.ir.op
 from vllm.ir.op import RESERVED_PROVIDERS, IrOp, IrOpImpl
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 
 class CustomError(Exception):
     pass

--- a/tests/kernels/ir/test_ir_ops.py
+++ b/tests/kernels/ir/test_ir_ops.py
@@ -8,8 +8,12 @@ Per-op correctness tests live alongside their op definitions
 (e.g. tests/kernels/ir/test_layernorm.py).
 """
 
+import pytest
+
 import vllm.kernels  # noqa: F401 — registers provider implementations
 from vllm.ir.op import IrOp
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 def test_all_ops_have_input_generator():

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -16,6 +16,8 @@ from tests.utils import set_random_seed
 from vllm import ir
 from vllm.platforms import current_platform
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 rms_norm_native = ir.ops.rms_norm.impls["native"].impl_fn
 
 IS_GPGPU_DEVICE = current_platform.is_cuda_alike() or current_platform.is_xpu()


### PR DESCRIPTION
## Purpose

Every test in this group runs `cleanup_dist_env_and_memory()` (a full `gc.collect()` plus an emptied caching allocator). This cleanup dominates the runtime: the IR tests only allocate plain activation tensors and never initialize distributed or engine state, so it costs far more than the tests themselves.

This adds `pytestmark = pytest.mark.skip_global_cleanup` to the four test modules in the group, following the same approach as existing CI speedups for other test groups.

## Test Plan

```bash
pytest -v -s tests/ir
pytest -v -s tests/kernels/ir
```

Both commands were run on a single MI300 GPU, before and after the change, and
the reported pass/skip counts compared.

## Test Result

Identical results before and after — `45 passed` for `tests/ir` and
`2047 passed, 120 skipped` for `tests/kernels/ir`:

| | Before | After |
|---|---|---|
| `pytest -v -s tests/ir` | 9.33s | 0.49s |
| `pytest -v -s tests/kernels/ir` | 1119.26s (18m39s) | 63.38s (1m03s) |
| **Total** | **18m49s** | **1m04s** |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

