### PR TITLE
[Rust Frontend] Support --enable-force-include-usage

### DIFF
--- a/rust/src/cmd/src/cli.rs
+++ b/rust/src/cmd/src/cli.rs
@@ -319,6 +319,15 @@ pub struct SharedRuntimeArgs {
     #[serde(default)]
     pub enable_request_id_headers: bool,
 
+    /// If set to True, including usage on every request.
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1
+    )]
+    #[serde(default)]
+    pub enable_force_include_usage: bool,
+
     /// If provided, the server will require one of these keys to be presented
     /// in the Authorization header.
     #[educe(Debug(ignore))]
@@ -565,6 +574,7 @@ impl SharedRuntimeArgs {
             enable_log_requests: self.enable_log_requests,
             enable_prompt_tokens_details: self.enable_prompt_tokens_details,
             enable_request_id_headers: self.enable_request_id_headers,
+            enable_force_include_usage: self.enable_force_include_usage,
         }
     }
 

--- a/rust/src/cmd/src/cli/tests.rs
+++ b/rust/src/cmd/src/cli/tests.rs
@@ -179,6 +179,7 @@ fn serve_args_forward_python_flags_with_separator() {
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
                         enable_request_id_headers: false,
+                        enable_force_include_usage: false,
                         disable_log_stats: false,
                         served_model_name: [],
                         allowed_origins: JsonStringList(
@@ -541,6 +542,23 @@ fn serve_passes_enable_prompt_tokens_details_into_config() {
 }
 
 #[test]
+fn serve_passes_enable_force_include_usage_into_config() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "serve",
+        "Qwen/Qwen3-0.6B",
+        "--enable-force-include-usage",
+    ])
+    .unwrap();
+
+    let Command::Serve(args) = cli.command else {
+        panic!("expected serve args");
+    };
+    let config = args.to_frontend_config("tcp://127.0.0.1:62100".to_string());
+    assert!(config.api_server_options.enable_force_include_usage);
+}
+
+#[test]
 fn serve_passes_tls_into_config() {
     let cli = Cli::try_parse_from([
         "vllm-rs",
@@ -795,6 +813,29 @@ fn frontend_args_json_passes_lora_modules_into_config() {
 }
 
 #[test]
+fn frontend_args_json_passes_enable_force_include_usage_into_config() {
+    let cli = Cli::try_parse_from([
+        "vllm-rs",
+        "frontend",
+        "--listen-fd",
+        "3",
+        "--input-address",
+        "ipc:///tmp/input.sock",
+        "--output-address",
+        "ipc:///tmp/output.sock",
+        "--args-json",
+        r#"{"model_tag":"Qwen/Qwen3-0.6B","enable_force_include_usage":true}"#,
+    ])
+    .unwrap();
+
+    let Command::Frontend(args) = cli.command else {
+        panic!("expected frontend args");
+    };
+    let config = args.into_config();
+    assert!(config.api_server_options.enable_force_include_usage);
+}
+
+#[test]
 fn serve_passes_api_keys_into_config() {
     let cli = Cli::try_parse_from([
         "vllm-rs",
@@ -998,6 +1039,7 @@ fn frontend_args_accept_json() {
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
                         enable_request_id_headers: false,
+                        enable_force_include_usage: false,
                         disable_log_stats: false,
                         served_model_name: [],
                         allowed_origins: JsonStringList(
@@ -1595,6 +1637,7 @@ fn serve_args_accept_handshake_aliases() {
                         enable_log_requests: false,
                         enable_prompt_tokens_details: false,
                         enable_request_id_headers: false,
+                        enable_force_include_usage: false,
                         disable_log_stats: false,
                         served_model_name: [],
                         allowed_origins: JsonStringList(
@@ -1745,6 +1788,7 @@ fn serve_frontend_config_uses_dp_address_as_advertised_host() {
                 enable_log_requests: false,
                 enable_prompt_tokens_details: false,
                 enable_request_id_headers: false,
+                enable_force_include_usage: false,
             },
             cors: CorsConfig {
                 allow_origins: [
@@ -1832,6 +1876,7 @@ fn serve_frontend_config_keeps_tcp_transport_for_non_local_only_topology() {
                 enable_log_requests: false,
                 enable_prompt_tokens_details: false,
                 enable_request_id_headers: false,
+                enable_force_include_usage: false,
             },
             cors: CorsConfig {
                 allow_origins: [
@@ -1940,6 +1985,7 @@ fn frontend_config_uses_external_coordinator_when_coordinator_address_is_present
                 enable_log_requests: false,
                 enable_prompt_tokens_details: false,
                 enable_request_id_headers: false,
+                enable_force_include_usage: false,
             },
             cors: CorsConfig {
                 allow_origins: [

--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -433,15 +433,6 @@ pub struct ServerUnsupportedArgs {
     )]
     pub enable_server_load_tracking: Option<Noop>,
 
-    /// If set to True, including usage on every request.
-    #[arg(
-        long,
-        visible_alias = "no-enable-force-include-usage",
-        default_missing_value = "true",
-        num_args = 0..=1
-    )]
-    pub enable_force_include_usage: Option<Unsupported>,
-
     /// Enable the `/tokenizer_info` endpoint. May expose chat
     /// templates and other tokenizer configuration.
     ///

--- a/rust/src/server/src/config.rs
+++ b/rust/src/server/src/config.rs
@@ -55,6 +55,8 @@ pub struct ApiServerOptions {
     pub enable_prompt_tokens_details: bool,
     /// When `true`, set `X-Request-Id` on every HTTP response.
     pub enable_request_id_headers: bool,
+    /// When `true`, include usage in every streamed OpenAI response chunk.
+    pub enable_force_include_usage: bool,
 }
 
 /// CORS settings mirroring Python's `CORSMiddleware`; the default is permissive.

--- a/rust/src/server/src/routes/openai/chat_completions.rs
+++ b/rust/src/server/src/routes/openai/chat_completions.rs
@@ -254,6 +254,7 @@ async fn chat_completion_chunk_stream(
     ApiServerOptions {
         enable_log_requests,
         enable_prompt_tokens_details,
+        enable_force_include_usage,
         ..
     }: ApiServerOptions,
     ResponseOptions {
@@ -277,6 +278,8 @@ async fn chat_completion_chunk_stream(
         created,
         response_model,
     ));
+    let include_usage = enable_force_include_usage || include_usage;
+    let include_continuous_usage = enable_force_include_usage || include_continuous_usage;
     let mut saw_tool_calls = false;
     // `LogprobsDelta` is emitted after all chat events for one decoded update.
     // If that update contains hidden reasoning, including delimiter-only block

--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -241,6 +241,7 @@ async fn completion_chunk_stream(
     ApiServerOptions {
         enable_log_requests,
         enable_prompt_tokens_details,
+        enable_force_include_usage,
         ..
     }: ApiServerOptions,
     ResponseOptions {
@@ -256,6 +257,8 @@ async fn completion_chunk_stream(
     }: ResponseOptions,
     mut y: TryYielder<CompletionSseChunk, ApiError>,
 ) -> Result<(), ApiError> {
+    let include_usage = enable_force_include_usage || include_usage;
+    let include_continuous_usage = enable_force_include_usage || include_continuous_usage;
     pin_mut!(stream);
     let envelope = Arc::new(StreamResponseEnvelope::new(
         request_id,

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -851,6 +851,24 @@ async fn test_app_with_request_id_headers() -> (axum::Router, MockEngineTask) {
     (app, engine_task)
 }
 
+async fn test_app_with_force_include_usage() -> (axum::Router, MockEngineTask) {
+    let (chat, engine_task) = test_models_with_engine_outputs_and_backend(
+        b"engine-openai-force-usage",
+        default_stream_output_specs(),
+        Arc::new(FakeChatBackend::new()),
+    )
+    .await;
+    let app = build_router(Arc::new(
+        AppState::new(vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()], chat).with_api_server_options(
+            ApiServerOptions {
+                enable_force_include_usage: true,
+                ..Default::default()
+            },
+        ),
+    ));
+    (app, engine_task)
+}
+
 async fn test_app_with_api_keys(api_keys: Vec<String>) -> (axum::Router, MockEngineTask) {
     let (chat, engine_task) = test_models_with_engine_outputs_and_backend(
         b"engine-openai-api-key",
@@ -3394,6 +3412,56 @@ async fn stream_continuous_usage_stats_adds_usage_to_chat_chunks() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn force_include_usage_adds_usage_to_all_chat_chunks() {
+    let (app, engine_task) = test_app_with_force_include_usage().await;
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "stream": true,
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let text = String::from_utf8(body.to_vec()).expect("utf8 body");
+    let payloads = sse_json_payloads(&text);
+
+    assert!(
+        payloads.iter().all(|payload| payload.get("usage").is_some()),
+        "{text}"
+    );
+    assert!(
+        payloads.iter().any(|payload| {
+            payload["choices"].as_array().is_some_and(|choices| !choices.is_empty())
+                && payload["usage"]["completion_tokens"] == json!(1)
+        }),
+        "{text}"
+    );
+    let usage_chunk = payloads
+        .iter()
+        .find(|payload| payload["choices"] == json!([]))
+        .expect("final usage chunk");
+    assert_eq!(usage_chunk["usage"]["prompt_tokens"], 22);
+    assert_eq!(usage_chunk["usage"]["completion_tokens"], 3);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn stream_without_include_usage_keeps_existing_shape() {
     let (app, engine_task) = test_app_with_stream_output_specs(default_stream_output_specs()).await;
     let response = app
@@ -4766,6 +4834,55 @@ async fn completions_stream_continuous_usage_stats_adds_usage_to_chunks() {
                             "include_usage": true,
                             "continuous_usage_stats": true
                         }
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    engine_task.await.expect("mock engine task");
+    let text = String::from_utf8(body.to_vec()).expect("utf8 body");
+    let payloads = sse_json_payloads(&text);
+
+    assert!(
+        payloads.iter().all(|payload| payload.get("usage").is_some()),
+        "{text}"
+    );
+    assert!(
+        payloads.iter().any(|payload| {
+            payload["choices"].as_array().is_some_and(|choices| !choices.is_empty())
+                && payload["usage"]["completion_tokens"] == json!(1)
+        }),
+        "{text}"
+    );
+    let usage_chunk = payloads
+        .iter()
+        .find(|payload| payload["choices"] == json!([]))
+        .expect("final usage chunk");
+    assert_eq!(usage_chunk["usage"]["completion_tokens"], 3);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn force_include_usage_adds_usage_to_all_completion_chunks() {
+    let (app, engine_task) = test_app_with_force_include_usage().await;
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "prompt": "hello",
+                        "stream": true
                     })
                     .to_string(),
                 ))


### PR DESCRIPTION
## Purpose

Implements the `--enable-force-include-usage` server flag in the Rust frontend, which was previously listed in `unsupported.rs` and rejected at startup. When enabled, streaming `/v1/chat/completions` and `/v1/completions` responses always include usage in every chunk, regardless of per-request `stream_options`.

Behavior matches the Python frontend's `should_include_usage` (`vllm/entrypoints/serve/utils/api_utils.py`): when force is on, both `include_usage` and `include_continuous_usage` are forced to `true`. The flag is off by default, so existing behavior is unchanged.

## Changes

- `rust/src/cmd/src/cli.rs`: add `--enable-force-include-usage` to `SharedRuntimeArgs` (same definition pattern as neighboring flags), wired into the frontend config
- `rust/src/cmd/src/cli/unsupported.rs`: drop the now-supported entry
- `rust/src/server/src/config.rs`: add `enable_force_include_usage` to `ApiServerOptions`
- `rust/src/server/src/routes/openai/chat_completions.rs` / `completions.rs`: OR the server-level flag into `include_usage` / `include_continuous_usage` at the top of each chunk stream

## Not a duplicate

Searched open PRs for `force-include-usage` (title) and `enable-force-include-usage` (full text) — no existing PR implements this flag in the Rust frontend. No open issue requests it either.

## Testing

```
cargo fmt --all -- --check                       # pass
cargo clippy -p vllm-cmd -p vllm-server --all-targets   # pass, no warnings
cargo test -p vllm-cmd                           # 65 passed
cargo test -p vllm-server routes::               # 254 passed
```

New tests cover both entry points (`serve` flag and `frontend --args-json`) flowing into config, and streaming responses without `stream_options.include_usage` getting usage in every chunk for both `/v1/chat/completions` and `/v1/completions`.

Flag-gated change with no effect when off; no model eval needed (does not affect generation output).

This PR was prepared with AI assistance; every changed line has been reviewed and tested by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
