### PR TITLE
[Bugfix][CUDA] Fix the FlashInfer's fused all-reduce issue where NVLink multicast isn't available

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -46,6 +46,11 @@ _fi_ar_workspace = None
 # available on the current topology.
 _fi_ar_quant_workspace = None
 _fi_ar_workspace_groups: dict[int, ProcessGroup] = {}
+# Configurations for which workspace creation has already been attempted and
+# found unsupported on this topology. Creation is a real CUDA/fabric allocation,
+# so an uncached failure is retried on every call -- including from inside a
+# CUDA graph capture, where the failing driver call invalidates the capture.
+_fi_ar_workspace_unsupported: set[tuple] = set()
 
 
 def _get_tuned_standalone_max_size(
@@ -160,6 +165,27 @@ def _resolve_fi_ar_backend() -> tuple[str, bool]:
     return backend, allow_trtllm_fallback
 
 
+def _fi_ar_unsupported_key(
+    world_size: int,
+    max_token_num: int,
+    hidden_dim: int,
+    dtype: torch.dtype,
+    group: ProcessGroup,
+) -> tuple:
+    """Identity of a workspace request, for caching an unsupported result.
+
+    Keyed on the process group as well as the shape/dtype so that a later,
+    differently configured or re-created group is still allowed to try.
+    """
+    return (
+        world_size,
+        max_token_num,
+        hidden_dim,
+        str(dtype),
+        getattr(group, "group_name", None) or id(group),
+    )
+
+
 def get_fi_ar_workspace(
     world_size: int,
     rank: int,
@@ -178,6 +204,23 @@ def get_fi_ar_workspace(
     global _fi_ar_workspace
     if _fi_ar_workspace is not None:
         return _fi_ar_workspace
+
+    unsupported_key = _fi_ar_unsupported_key(
+        world_size, max_token_num, hidden_dim, dtype, group
+    )
+    if unsupported_key in _fi_ar_workspace_unsupported:
+        return None
+
+    if torch.cuda.is_current_stream_capturing():
+        # Creating (or failing to create) the workspace issues driver calls on
+        # the capturing stream; a failure invalidates the capture and the next
+        # allocation aborts with an invalid-capture-status assertion. Callers
+        # treat None as "fused path unavailable" and use a plain collective.
+        logger.warning_once(
+            "Skipping FlashInfer all-reduce workspace creation during CUDA "
+            "graph capture; initialize it before capture to use the fused path."
+        )
+        return None
 
     backend, allow_trtllm_fallback = _resolve_fi_ar_backend()
 
@@ -218,6 +261,7 @@ def get_fi_ar_workspace(
             f"with backend={backend}"
         )
     else:
+        _fi_ar_workspace_unsupported.add(unsupported_key)
         logger.warning_once(
             "Failed to initialize FlashInfer Allreduce norm fusion workspace "
             f"with backend={backend}"
@@ -315,6 +359,7 @@ def destroy_fi_ar_workspace():
 
         _fi_ar_workspace = _fi_ar_quant_workspace = None
         _fi_ar_workspace_groups.clear()
+        _fi_ar_workspace_unsupported.clear()
 
 
 def _fi_ar_workspaces_for_group(group: ProcessGroup) -> list[Any]:


### PR DESCRIPTION
## Purpose
Follow-up to #52861
That PR routes GLM DSA and DeepSeek V3.2 through the NVIDIA DeepSeek V3.2
implementations and adds them to `DEFAULT_BREAKABLE_CUDAGRAPH_ARCHITECTURES`,
which sets `CompilationMode.NONE`. `fused_allreduce_rms_norm` now kicks into action so those
models now probe the FlashInfer workspace for every layer.
If NVLink multicast is not available for any reason, FlashInfer's fused all-reduce workspace can't be created, and the attempt fails with CUDA error 801.
get_fi_ar_workspace() caches only success: its early return is if `_fi_ar_workspace` is not None, so a failure is never remembered and every subsequent call re-issues a real fabric allocation. Callers handle the None fine by falling back to a plain collective, so the failures are harmless — until one of those retries happens on a stream that is capturing a CUDA graph. The failing driver call invalidates the capture, and the next allocation on that stream dies with `cudaStreamCaptureStatusInvalidated`. 

The fix is to cache the failures so that the later calls on the same config would return None immediately. Also to explicitly not create during graph capture (is_current_stream_capturing)

To replicate: Run GLM-5.2 or Kimi-K3, or similar on a multi-node GB300 (i.e. tp=8 on 2x4GPU) on 0.29 or above (0.28 works through the deepseek_v2 rather than vllm.models.deepseek_v32)

## Test Plan

Run the repro from above and verify the models start normally

## Test results
GLM-5.2 tp-8 over 2 nodes, MTP-5, `FULL_AND_PIECEWISE`: fails in capture before,
starts after. Workspace attempts drop from 22 down to 1