### PR TITLE
[Bugfix][Frontend] Reject unsupported Responses API input items with 400 instead of 500

### DIFF
--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -336,7 +336,13 @@ def _construct_message_from_response_item(
                     prev_assistant_msg["content"] = text
                     return None
             return {"role": "assistant", "content": text}
-    return item  # type: ignore[arg-type]
+    if isinstance(item, dict) and "role" in item:
+        return item  # type: ignore[return-value]
+    item_type = item.get("type") if isinstance(item, dict) else item.type
+    raise VLLMValidationError(
+        f"Unsupported input item type: {item_type}",
+        parameter="input",
+    )
 
 
 def extract_function_tool_names(tools: list[Tool]) -> frozenset[str]:


### PR DESCRIPTION
## Purpose

On non-Harmony models, `/v1/responses` returns HTTP 500 for any input item that pydantic accepts through the openai SDK union but that vLLM does not handle. Examples are `item_reference`, `computer_call_output`, and `mcp_call`.

`_construct_message_from_response_item` in `vllm/entrypoints/openai/responses/utils.py` returned such items unchanged. `chat_utils.py` then failed on `message["role"]`, and the client saw `{"message": "'role'", "type": "InternalServerError"}`. SDK model items such as `McpCall` leaked a Python `TypeError` message as a 400 instead.

This raises `VLLMValidationError` naming the item type, with `parameter="input"`. It is the same error class the function already raises for encrypted reasoning content, and the same approach #55701 applied to the Harmony path. Plain dicts that already carry a `role` still pass through unchanged, so user, system, and developer messages are unaffected. The assistant dict with `content=[]` is owned by #48237 and #49130 and is not touched here.

Not a duplicate. Open Responses PRs #55662, #35508, #50975, #54786, #54297 each handle one specific item type and leave the fall-through in place. Searches for `item_reference 500`, `responses KeyError role`, and `unsupported input item type` return nothing.

## Test Plan

```bash
pytest tests/entrypoints/openai/responses/test_responses_utils.py -q
pre-commit run --files vllm/entrypoints/openai/responses/utils.py tests/entrypoints/openai/responses/test_responses_utils.py
```

Repro against a running server, any non-Harmony model:

```bash
curl -s localhost:8000/v1/responses -H 'Content-Type: application/json' -d '{
  "model": "MODEL",
  "input": [{"type": "item_reference", "id": "msg_1"}]
}'
```

## Test Result

HTTP bodies from a FastAPI TestClient wired to the real exception handlers.

Before:

```
item_reference        500 {"error":{"message":"'role'","type":"InternalServerError","param":null,"code":500}}
computer_call_output  500 {"error":{"message":"'role'","type":"InternalServerError","param":null,"code":500}}
mcp_call              400 {"error":{"message":"'McpCall' object is not subscriptable","type":"BadRequestError","param":null,"code":400}}
```

After:

```
item_reference        400 {"error":{"message":"Unsupported input item type: item_reference (parameter=input)","type":"BadRequestError","param":"input","code":400}}
computer_call_output  400 {"error":{"message":"Unsupported input item type: computer_call_output (parameter=input)","type":"BadRequestError","param":"input","code":400}}
mcp_call              400 {"error":{"message":"Unsupported input item type: mcp_call (parameter=input)","type":"BadRequestError","param":"input","code":400}}
```

New parametrized test with the fix reverted: `3 failed, 40 passed` (`DID NOT RAISE VLLMValidationError`). With the fix: `43 passed`. pre-commit clean.

AI assistance was used for this change. I reviewed every changed line and ran the tests above myself.
