### PR TITLE
[Bugfix][Kernel] NVFP4 KV: write V block scales linearly on SM120/SM121

### DIFF
--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -183,9 +183,11 @@ __global__ void reshape_and_cache_nvfp4_kernel(
     const int64_t data_block_stride,         // data cache stride for dim 0
     const int64_t data_head_stride,          // data cache stride for heads
     const int64_t data_block_offset_stride,  // data cache stride for tokens
-    const int64_t scale_block_stride,        // scale cache stride for dim 0
-    const int64_t scale_head_stride,         // scale cache stride for heads
-    const int64_t scale_block_offset_stride  // scale cache stride for tokens
+    const int64_t scale_block_stride,         // scale cache stride for dim 0
+    const int64_t scale_head_stride,          // scale cache stride for heads
+    const int64_t scale_block_offset_stride,  // scale cache stride for tokens
+    const bool swizzle_v_sf  // V scale layout: true = SM100 trtllm-gen 4-token
+                             // swizzle; false = linear (FlashInfer FA2 sm12x)
 ) {
   using CudaType = typename CUDATypeConverter<scalar_t>::Type;
   using PVec = PackedVec<CudaType, CVT_FP4_PACK16>;
@@ -280,12 +282,14 @@ __global__ void reshape_and_cache_nvfp4_kernel(
 #endif
 
       // Write block scale to scale cache.
-      // K (kv==0): linear layout (no swizzle).
-      // V (kv==1): swizzled layout for SM100 trtllm-gen MHA kernel.
+      // K (kv==0): always linear layout (no swizzle).
+      // V (kv==1): swizzled layout for the SM100 trtllm-gen MHA kernel when
+      //   swizzle_v_sf is true; linear (same as K) when false, which the
+      //   FlashInfer FA2 paged nvfp4 reader on sm120/sm121 requires.
       if (sf_out_ptr != nullptr) {
         int scale_idx = group_in_head;
         uint8_t* __restrict__ scale_dst;
-        if (kv == 0) {
+        if (kv == 0 || !swizzle_v_sf) {
           scale_dst = scale_block + head * scale_head_stride +
                       block_offset * scale_block_offset_stride + scale_idx;
         } else {
@@ -332,9 +336,37 @@ void reshape_and_cache_nvfp4_dispatch(
 
   STD_TORCH_CHECK(head_size % 16 == 0,
                   "head_size must be divisible by 16 for NVFP4 KV cache");
-  STD_TORCH_CHECK(block_size % 4 == 0,
-                  "block_size must be divisible by 4 for NVFP4 KV cache "
-                  "swizzle");
+
+  // Select the cache's device before querying its capability: get_device_prop()
+  // reads the *active* device, so on a heterogeneous host an unguarded query
+  // could pick another GPU's architecture and write an incompatible V-scale
+  // layout. The guard stays in scope for the launch below.
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      key.get_device_index());
+
+  // SM120/SM121 (consumer Blackwell) serve NVFP4 KV via the FlashInfer FA2
+  // paged reader, which takes the scale-factor strides from the SF tensor
+  // itself and reads V scales linearly; the SM100 trtllm-gen reader keeps
+  // its 4-token V scale swizzle. Both consume the same per-page
+  // [K_data | K_scale | V_data | V_scale] layout, so only the V-scale
+  // swizzle is arch-conditional.
+  const bool swizzle_v_sf = get_device_prop()->major < 12;
+
+  STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
+                  "block_size must be divisible by 4 for NVFP4 KV cache V "
+                  "scale-factor swizzle (SM100 trtllm-gen path)");
+
+  // swizzle_scale_offset() reshapes a page's scales as [T//4, 4, 4, S//4], so
+  // S = scale_dim must itself be a multiple of 4. head_size=80 gives
+  // scale_dim=5: s_group becomes 1, swizzled_t runs past the token's group of
+  // four and writes into the next head or page. head_size<64 is worse still,
+  // giving s_group=0 and a division by zero in the kernel. SM12x writes V
+  // scales linearly and is unaffected.
+  STD_TORCH_CHECK(!swizzle_v_sf || scale_dim % 4 == 0,
+                  "head_size must be divisible by 64 (scale_dim divisible by "
+                  "4) for the NVFP4 KV cache V scale-factor swizzle (SM100 "
+                  "trtllm-gen path); got head_size=",
+                  head_size);
 
   // Detect physical layout from strides (based on full_dim).
   // HND: head stride > block_offset stride.
@@ -381,8 +413,6 @@ void reshape_and_cache_nvfp4_dispatch(
   dim3 grid(num_tokens);
   dim3 block(num_threads);
 
-  const torch::stable::accelerator::DeviceGuard device_guard(
-      key.get_device_index());
   const cudaStream_t stream = get_current_cuda_stream();
 
   VLLM_STABLE_DISPATCH_HALF_TYPES(
@@ -400,7 +430,7 @@ void reshape_and_cache_nvfp4_dispatch(
                   num_heads, head_size, block_size, data_block_stride,
                   data_head_stride, data_block_offset_stride,
                   scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
+                  scale_block_offset_stride, swizzle_v_sf);
         } else if (kv_cache_dtype == "nvfp4_4over6") {
           vllm::reshape_and_cache_nvfp4_kernel<
               scalar_t, vllm::NVFP4KVScaleSearch::FOUR_OVER_SIX>
@@ -414,10 +444,23 @@ void reshape_and_cache_nvfp4_dispatch(
                   num_heads, head_size, block_size, data_block_stride,
                   data_head_stride, data_block_offset_stride,
                   scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
+                  scale_block_offset_stride, swizzle_v_sf);
         } else {
           STD_TORCH_CHECK(false,
                           "Unsupported NVFP4 KV cache dtype: ", kv_cache_dtype);
         }
+        // A launch against a binary with no SASS for this device fails with
+        // cudaErrorNoKernelImageForDevice and, unchecked, silently writes
+        // nothing -- which then surfaces as NaN/garbage "quantization"
+        // downstream. Fail loudly here instead.
+        const cudaError_t launch_err = cudaGetLastError();
+        STD_TORCH_CHECK(launch_err == cudaSuccess,
+                        "reshape_and_cache_nvfp4 launch failed: ",
+                        cudaGetErrorString(launch_err),
+                        " (device compute capability ",
+                        get_device_prop()->major, ".",
+                        get_device_prop()->minor,
+                        "; was the extension built with SASS for this "
+                        "arch, e.g. TORCH_CUDA_ARCH_LIST including it?)");
       });
 }


### PR DESCRIPTION
## Summary

`reshape_and_cache_nvfp4_kernel` writes K block scales linearly and V block scales in the SM100 trtllm-gen 4-token swizzle, unconditionally. Consumer Blackwell does not read them that way: NVFP4 KV on SM120/SM121 is served by the FlashInfer FA2 paged reader, which takes scale-factor strides from the SF tensor and reads V scales linearly. The cache is written in a layout its reader does not expect, and V dequantizes to garbage.

This makes the V-scale swizzle conditional on the cache's own device. K is untouched, always linear, and the per-page `[K_data | K_scale | V_data | V_scale]` layout is unchanged, so SM100 behaviour is bit-identical.

Fixes #50084.

## Why this is visible now

Since #55908, the in-tree test already encodes the correct contract: `test_reshape_and_cache_flash[...nvfp4...]` dequantizes K linearly and V per architecture. On SM120/SM121 against current `main` it fails on the V assertion, because the writer still swizzles. The B200 job added there is SM100, where writer and test agree, so CI does not surface it.

No new test is needed — this turns that existing test green on consumer Blackwell.

## Also in this file

All on the swizzle path or its diagnostics:

- **DeviceGuard moved ahead of the capability query.** `get_device_prop()` reads the *active* device, so an unguarded query on a heterogeneous host could read another GPU's architecture and select the wrong V-scale layout.
- **`block_size % 4` gated on the swizzle actually being used, plus the matching `scale_dim % 4` check.** `swizzle_scale_offset()` reshapes a page's scales as `[T//4, 4, 4, S//4]`. `head_size=80` gives `scale_dim=5`, so `s_group` becomes 1 and writes run past the token's group of four into the next head or page; `head_size<64` gives `s_group=0` and divides by zero.
- **`cudaGetLastError()` checked after launch.** A binary with no SASS for the device fails with `cudaErrorNoKernelImageForDevice` and, unchecked, writes nothing — which surfaces downstream as NaN "quantization" rather than an error.

## Test plan and results

`pytest tests/kernels/attention/test_cache.py -k nvfp4`, against `main` with #55908, one architecture per row, writer swapped and nothing else:

| GPU | arch | `main` as-is | with this change |
|---|---|---|---|
| RTX PRO 4500 Blackwell | sm_120 | 24 failed / 0 passed | 24 passed |
| GB10 / DGX Spark | sm_121 | 24 failed / 0 passed | 24 passed |

Measured by @TensorRaya (sm_120) and @hclsys (sm_121); see vllm-project/vllm#46329 for their raw reports. The failing assertion is V only, with the K assertion immediately above it passing and NaN as the greatest difference, which is the signature of a swizzled write read linearly rather than a magnitude error.

SM100 is unchanged by construction (`major < 12` is false there, so the swizzle branch is taken exactly as before).

## Not duplicating an existing PR

This is carved out of #46329, which is mine and stays open for the rest of that work (the FA2 gate, routing, and the Gemma-4 VO split). Splitting it out was proposed on that thread so the writer fix can be reviewed on its own; #46329 will rebase on top once this lands. No other open PR touches `nvfp4_kv_cache_kernels.cu`.

## AI assistance

AI assistance was used for this change. Every line was reviewed and the behaviour verified on hardware before submission.
