### PR TITLE
[Perf] Trim redundant per-step Python work on the GDN decode and V2 spec-decode paths

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1331,9 +1331,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         a = a[:num_actual_tokens]
 
         # 1. Convolution sequence transformation
-        conv_weights = self.conv1d.weight.view(
-            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-        )
+        w = self.conv1d.weight
+        conv_weights = w.view(w.size(0), w.size(2))
 
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
@@ -1609,9 +1608,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         ssm_state = self_kv_cache[1]
 
         # 1. Convolution sequence transformation
-        conv_weights = self.conv1d.weight.view(
-            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-        )
+        w = self.conv1d.weight
+        conv_weights = w.view(w.size(0), w.size(2))
 
         mixed_qkv_non_spec, b, a = (
             gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
@@ -1681,9 +1679,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         b = b[:num_actual_tokens]
         a = a[:num_actual_tokens]
 
-        conv_weights = self.conv1d.weight.view(
-            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-        )
+        w = self.conv1d.weight
+        conv_weights = w.view(w.size(0), w.size(2))
         mixed_qkv_non_spec = causal_conv1d_update(
             mixed_qkv,
             conv_state,
@@ -1731,9 +1728,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             if is_conv_state_dim_first()
             else self.kv_cache[0].transpose(-1, -2)
         )
-        conv_weights = self.conv1d.weight.view(
-            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
-        )
+        w = self.conv1d.weight
+        conv_weights = w.view(w.size(0), w.size(2))
         mixed_qkv = causal_conv1d_update(
             mixed_qkv[:num_actual_tokens],
             conv_state,

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import next_power_of_2
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
 
 
@@ -577,7 +578,7 @@ def causal_conv1d_fn(
     dim, cu_seqlen = x.shape
     _, width = weight.shape
     state_len = width - 1
-    np2_statelen = triton.next_power_of_2(state_len)
+    np2_statelen = next_power_of_2(state_len)
 
     padded_batch = query_start_loc.size(0) - 1
     stride_x_dim = x.stride(0)
@@ -756,7 +757,7 @@ def causal_conv1d_fn(
         num_stages=2,
         launch_pdl=current_platform.is_arch_support_pdl(),
     )
-    return out.to(original_x_dtype)
+    return out if out.dtype == original_x_dtype else out.to(original_x_dtype)
 
 
 @triton.jit(do_not_specialize_on_alignment=["num_cache_lines"])
@@ -1157,7 +1158,9 @@ def causal_conv1d_update(
         assert activation in ["silu", "swish"]
 
     original_x_dtype = x.dtype
-    x = x.to(conv_state.dtype)
+    conv_state_dtype = conv_state.dtype
+    if original_x_dtype != conv_state_dtype:
+        x = x.to(conv_state_dtype)
     if out is None:
         out = x
     else:
@@ -1221,7 +1224,7 @@ def causal_conv1d_update(
         state_len = width - 1 + (seqlen - 1)  # effective state_len needed
     else:
         state_len = width - 1
-    np2_statelen = triton.next_power_of_2(state_len)
+    np2_statelen = next_power_of_2(state_len)
 
     def grid(META):
         return (
@@ -1276,7 +1279,7 @@ def causal_conv1d_update(
     )
     if unsqueeze:
         out = out.squeeze(-1)
-    return out.to(original_x_dtype)
+    return out if out.dtype == original_x_dtype else out.to(original_x_dtype)
 
 
 if current_platform.is_cpu():

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -288,6 +288,13 @@ def build_attn_metadata(
     attn_metadata: dict[str, Any] = {}
     num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
     for i in range(num_kv_cache_groups):
+        groups = attn_groups[i]
+        if not groups:
+            # This model owns no layer in this KV cache group. A drafter builds
+            # its attention groups from active_layer_names only, so
+            # init_attn_backend appends [] for every group it does not own, and
+            # everything below would be constructed and immediately discarded.
+            continue
         block_table = block_tables[i]
         slot_mapping = slot_mappings[i]
         # Per-group causal for hybrid drafters (mixed SWA/full attention).
@@ -325,7 +332,7 @@ def build_attn_metadata(
             **common_attn_metadata_extra_kwargs,
         )
 
-        for attn_group in attn_groups[i]:
+        for attn_group in groups:
             attn_metadata_builder = attn_group.get_metadata_builder(ubatch_idx)
             if for_cudagraph_capture:
                 metadata = attn_metadata_builder.build_for_cudagraph_capture(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1243,8 +1243,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 count=num_reqs,
             )
             num_bonus_tokens = self.model_state.num_new_sampled_tokens_per_step
-            total_num_draft_tokens = int(num_draft_tokens_per_req.sum())
-            total_num_logits = num_reqs * num_bonus_tokens + total_num_draft_tokens
             num_logits = num_draft_tokens_per_req + num_bonus_tokens
             # combine_sampled_and_draft_tokens places a request's logits rows
             # at [query_end - num_logits, query_end). Fewer query rows than
@@ -1253,6 +1251,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cu_num_logits_np = np.empty(num_reqs + 1, dtype=np.int32)
             cu_num_logits_np[0] = 0
             np.cumsum(num_logits, out=cu_num_logits_np[1:])
+            # The cumsum's last element IS the total, so the separate .sum()
+            # above was a second pass over the same data.
+            total_num_logits = int(cu_num_logits_np[-1])
+            total_num_draft_tokens = total_num_logits - num_reqs * num_bonus_tokens
             cu_num_logits = async_copy_to_gpu(cu_num_logits_np, device=self.device)
 
         adaptive_verification = (

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -211,8 +211,16 @@ class RejectionSampler:
         for start, end in request_chunks:
             lo = int(cu_num_logits_np[start])
             hi = int(cu_num_logits_np[end])
-            chunk_cu_num_logits_np = cu_num_logits_np[start : end + 1] - lo
-            chunk_cu_num_logits = input_batch.cu_num_logits[start : end + 1] - lo
+            if lo:
+                chunk_cu_num_logits_np = cu_num_logits_np[start : end + 1] - lo
+                chunk_cu_num_logits = input_batch.cu_num_logits[start : end + 1] - lo
+            else:
+                # cu_num_logits always starts at 0, so the single-chunk case
+                # (and the first chunk of a split batch) rebases by nothing.
+                # Skip the GPU sub: a kernel launch and an allocation for a no-op.
+                # NOTE: these are read-only views of the input batch buffers.
+                chunk_cu_num_logits_np = cu_num_logits_np[start : end + 1]
+                chunk_cu_num_logits = input_batch.cu_num_logits[start : end + 1]
             # draft_logits uses persistent request-state indices and stays global.
             processed_logits, sampled, num_sampled = self._verify(
                 logits[lo:hi],

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -315,7 +315,9 @@ class DraftModelSpeculator(BaseSpeculator):
             ],
             query_start_loc_cpu=query_start_loc_cpu,
             max_query_len=max_query_len,
-            seq_lens=self.input_buffers.seq_lens[:num_reqs_padded],
+            # build_attn_metadata re-applies this exact bound as its first
+            # statement, so pre-slicing here only builds a throwaway view.
+            seq_lens=self.input_buffers.seq_lens,
             dcp_local_seq_lens=(
                 None
                 if dcp_local_seq_lens is None


### PR DESCRIPTION
## Purpose

Eleven small, semantics-preserving rewrites on lines that run once to forty-eight times per engine step, in the GDN/causal-conv1d decode path and in the V2 runner's speculative-decoding path. No configuration is touched, no new state or invariant is introduced; every hunk is a local rewrite whose output is the same object, value, dtype and shape as before.

Why it matters: with piecewise cudagraphs the CPU sits on the critical path of every step. On the deployment this was written against (Qwen3.8-27B hybrid, 48 GDN + 16 full-attention layers, MTP k=3, FlashInfer, RTX 4090) an nsys profile put the GPU idle for 4.16 ms of a 24.73 ms step across ~1445 launches -- the GPU is waiting on Python. These are the Python lines that were doing redundant work on that path, each measured.

### What changes, and how often it runs

**`vllm/model_executor/layers/mamba/` -- once per GDN layer per step (48x on this model), both runners**

| hunk | before | after | per call |
|---|---|---|---|
| `qwen_gdn_linear_attn.py`, 4 sites | `self.conv1d.weight` read 3x to build one view (each read = two `nn.Module.__getattr__` hops) | bound once | 0.92 µs |
| `causal_conv1d.py` dtype-in | `x = x.to(conv_state.dtype)` dispatched unconditionally | guarded on dtype inequality | 0.31 µs |
| `causal_conv1d.py` dtype-out, 2 sites | `return out.to(original_x_dtype)` | same guard | 0.31 µs |
| `causal_conv1d.py` next_power_of_2, 2 sites | `triton.next_power_of_2` (8-step twiddle) | `vllm.utils.math_utils.next_power_of_2` (one shift), already used by 18 modules | 0.19 µs |

`Tensor.to(same_dtype)` returns `self`, so the guards yield the identical object and only skip the ATen dispatch; under the default `mamba_cache_dtype="auto"` the conv state has the model dtype and both conversions were no-ops. The two `next_power_of_2` implementations agree for every n ≥ 1; `state_len` here is `width-1` (or `width-1 + seqlen-1` on the spec path) with `width ≥ 2`.

**`vllm/v1/worker/gpu/` -- once or twice per step, V2 runner**

| hunk | what goes away | per step |
|---|---|---|
| `model_runner.py` cumsum | a separate `.sum()` pass; the total is the cumsum's last element | ~0.7 µs |
| `rejection_sampler.py` zero rebase | `- lo` when `lo == 0` (the single-chunk case, i.e. the common one): one `aten::sub` dispatch, one allocation, one `cudaLaunchKernel`, on the gap between target forward and first draft | ~2 µs + 1 launch |
| `speculator.py` double slice | `buf[:n][:n]` -- `build_attn_metadata` re-applies the same bound as its first statement | 0.7 µs × 2 |
| `attn_utils.py` empty groups | building and discarding a 27-field `CommonAttentionMetadata` plus tensor selects for every KV-cache group the drafter owns no layer in (3 of 4 on this model) | 6.8 → 1.9 µs × 2 builds |

The rejection-sampler change swaps a fresh tensor for a view of the input-batch buffer when `lo == 0`. Every consumer of `chunk_cu_num_logits` only reads it (the verify kernels `tl.load`; the one escaping use is cloned), so the aliasing is not observable; the guard tests the value rather than trusting the invariant, so it stays correct if a chunk ever starts at a non-zero offset.

Total on a V2 deployment of this shape, from the per-call numbers: roughly 100 µs per step, ≈0.4 % of a 25 ms step. This is offered as cleanup with a measured benefit, not as a headline win. Happy to split it by area (`mamba/` vs `v1/worker/gpu/`) if that is preferred.

### Verified and deliberately left out

Two further hunks were verified to the same standard and dropped from this PR: a dirty flag to skip `num_blocks.copy_to_uva()` on steps with no block appends, and caching `slot_mappings.shape[1]`/`stride(0)`. Both add state for ≤4 µs per step; the risk/benefit did not clear the bar.

## Test Plan

**Component-level differential test (GPU).** The real functions were run under the stock tree and under this branch with fixed seeded inputs and the produced bytes hashed: `causal_conv1d_update` across bfloat16/float16/float32 decode and across 24 `(kernel_width, query_len)` combinations on the spec-decode varlen path (the range over which `NP2_STATELEN` actually varies); `causal_conv1d_fn` (the chunked-prefill path, which carries two of the patched lines) across 3 widths × 3 sequence layouts; the `nn.Module` attribute-identity property the weight hoist relies on, checked against `ColumnParallelLinear`'s MRO for a `weight` property or pre-hook; `next_power_of_2` vs `triton.next_power_of_2` for n in 1..19999; the cumsum identity over 1080 random batch shapes including `num_reqs == 0`; slice-minus-zero and double-slice view identity on device. The harness fails hard if any case raises, so a case that raises identically in both trees cannot pass as a false match.

**CPU equivalence checks.** 29 property checks pinning exactly what each rewrite depends on (`.to(same)` is `self` incl. non-contiguous and 0-dim; `x[a:b] - 0` is value/dtype-identical to `x[a:b]`; empty-group loop contributes nothing across five layouts; etc.).

**Premise re-check against current `main`.** The hunks were authored against v0.28.0; `main` has since changed five of the six files (`attn_utils.py` by 463 lines, `model_runner.py` by 493). Every anchor still matches verbatim, and each hunk's premise was re-established statement by statement against the code as it is now (e.g. all three `get_extra_common_attn_kwargs` implementations return a fresh dict; `CommonAttentionMetadata` has no `__post_init__`; every `seq_lens` consumer sees the callee's slice, never the full buffer).

**Lint.** `ruff check` and `ruff format --check` clean on all six files.

**Upstream tests, on the branch itself.** Every test file that imports one of the six touched modules (16 files), run against this branch using the documented Python-only build -- `VLLM_USE_PRECOMPILED=1 pip install -e .` in a fresh venv, which pairs the branch's Python with the compiled extensions published for its base commit `5af4cc33e` -- on an RTX 4090.

**End-to-end.** Greedy (temperature 0, fixed seed) completions on four prompts are byte-identical to a control build of the same compile provenance.

## Test Result

- Component-level: **bit-identical** to stock in every case, 11 cases, 0 raised.
- CPU equivalence: 29/29 pass.
- ruff: clean.
- Upstream tests on the branch (`VLLM_USE_PRECOMPILED=1` over `5af4cc33e`, RTX 4090): **275 passed, 2 skipped, 0 failed.**

| file | result |
|---|---|
| `tests/kernels/mamba/test_causal_conv1d.py` | 164 passed |
| `tests/v1/worker/test_gpu_autoregressive_speculator.py` | 19 passed |
| `tests/v1/worker/test_gpu_batch_shard.py` | 17 passed |
| `tests/v1/worker/test_attn_utils.py` | 16 passed |
| `tests/kernels/mamba/test_gdn_fused_mtp.py` | 16 passed |
| `tests/v1/worker/test_gpu_batch_ordering.py` | 10 passed |
| `tests/v1/spec_decode/test_adaptive_verification.py` | 7 passed |
| `tests/v1/worker/test_gpu_model_runner_v2.py` | 7 passed |
| `tests/v1/worker/test_gpu_rejection_sampler_chunking.py` | 5 passed |
| `tests/v1/spec_decode/test_eagle_draft_attn_metadata.py` | 4 passed |
| `tests/v1/worker/test_gpu_extract_hidden_states_speculator.py` | 4 passed |
| `tests/v1/worker/test_kv_cache_allocation_scope.py` | 3 passed |
| `tests/v1/streaming_input/test_gpu_model_runner_v2_streaming.py` | 2 passed |
| `tests/kernels/mamba/test_gdn_prefill_flashinfer.py` | 1 passed |
| `tests/kernels/mamba/test_gdn_forward_core_split.py` | skipped -- CuteDSL prefill backend, requires SM10x |
| `tests/kernels/mamba/cpu/test_cpu_gdn_ops.py` | skipped -- CPU-only |

**Timing, stated honestly.** On the author's deployment the engine selects the **V1** model runner, so of the eleven hunks only the five under `model_executor/layers/mamba/` execute there; the V2-runner hunks are exercised by the component tests above and by CI, not by this timing run. A 6-round paired study (stock / compile-matched sham / this branch, arm order rotated through a Latin square, seed shared within a round, rounds as the independent unit) measured this branch against the sham at

```
ITL median:  +0.016 %   CI95 [−0.063, +0.095]   p = 0.63   MDE(80 %) = 0.107 %
```

i.e. neutral within a resolution of ~0.1 %. Two methodological notes that may be useful to others measuring small changes here: (1) any edit to files under `model_executor/` invalidates the `torch.compile` AOT artifact and the build is recompiled on every launch, so the control arm must touch the same files or it does not control that axis -- on this rig that asymmetry alone measured +0.117 % (p = 0.034); (2) with `benchmark_combo_kernel=True` two builds with different source hashes can select different combo kernels, which is why the byte-identical output check is done against a same-provenance control rather than against stock.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) Documentation update -- none needed
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
