### PR TITLE
[Docs] Fix DeltaMessage import path in reasoning_outputs

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -430,7 +430,7 @@ You can add a new `ReasoningParser` similar to [vllm/reasoning/deepseek_r1_reaso
 
     from vllm.reasoning import ReasoningParser, ReasoningParserManager
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+    from vllm.entrypoints.generate.base.protocol import DeltaMessage
 
     # define a reasoning parser and register it to vllm
     # the name list in register_module can be used


### PR DESCRIPTION
## Why

The custom reasoning parser example in `docs/features/reasoning_outputs.md` imports `DeltaMessage` from `vllm.entrypoints.openai.engine.protocol`, which no longer exists on main. The class now lives in `vllm.entrypoints.generate.base.protocol`.

## Change

Replace the stale import with:

```python
from vllm.entrypoints.generate.base.protocol import DeltaMessage
```

## Repro

```bash
# Old module path is gone
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/entrypoints/openai/engine/protocol.py | head -1
# Expect: HTTP/2 404

# Class is defined on the new path
rg -n "class DeltaMessage" vllm/entrypoints/generate/base/protocol.py

# Docs still reference the old import
rg -n "openai.engine.protocol import DeltaMessage" docs/features/reasoning_outputs.md
```
