### PR TITLE
[Docs] Fix O0 custom_ops default in optimization levels

### DIFF
--- a/docs/design/optimization_levels.md
+++ b/docs/design/optimization_levels.md
@@ -35,7 +35,7 @@ This level is good for initial phases of development and debugging.
 Settings:
 
 - `-cc.cudagraph_mode=NONE`
-- `-cc.mode=NONE` (also resulting in `-cc.custom_ops=["none"]`)
+- `-cc.mode=NONE` (also resulting in `-cc.custom_ops=["all"]`)
 - `-cc.pass_config.fuse_...=False` (all fusions disabled)
 - `--kernel-config.enable_flashinfer_autotune=False`
 


### PR DESCRIPTION
## Summary

Under `-O0`, compilation mode is set to `NONE`. The docs claimed this also results in `-cc.custom_ops=["none"]`, but the defaulting logic in `vllm/config/vllm.py` appends `"all"` whenever `mode == CompilationMode.NONE` (the inductor + non-`NONE` path is what appends `"none"`). Update the O0 settings bullet to match the code.

## Reproduction

```bash
# Docs claim (wrong) at tip:
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/design/optimization_levels.md \
  | sed -n '35,40p'
# Shows: -cc.mode=NONE (also resulting in -cc.custom_ops=["none"])

# Code truth:
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/config/vllm.py \
  | sed -n '1455,1462p'
# if all(s not in ... ("all", "none")):
#   if backend == "inductor" and mode != CompilationMode.NONE:
#       custom_ops.append("none")
#   else:
#       custom_ops.append("all")   # <-- taken when mode is NONE (O0)
```

## Change

In `docs/design/optimization_levels.md`, change the O0 bullet from `-cc.custom_ops=["none"]` to `-cc.custom_ops=["all"]` (one line only).