### PR TITLE
[Bugfix][Benchmark] Fix optional filenames and compilation flags in PyTorch export

### DIFF
--- a/tests/benchmarks/test_benchmark_utils.py
+++ b/tests/benchmarks/test_benchmark_utils.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+import json
+from enum import IntEnum
+
+import pytest
+
+from vllm.benchmarks.lib.utils import (
+    convert_to_pytorch_benchmark_format,
+    write_to_json,
+)
+
+
+class CompileMode(IntEnum):
+    NONE = 0
+    ENABLED = 3
+
+
+@pytest.mark.parametrize("field", ["output_json", "result_filename"])
+@pytest.mark.parametrize("filename", [None, "", "results.json", "eager.json"])
+def test_export_optional_filename(monkeypatch, tmp_path, field, filename):
+    monkeypatch.setenv("SAVE_TO_PYTORCH_BENCHMARK_FORMAT", "1")
+    args = argparse.Namespace(model="test-model", **{field: filename})
+    records = convert_to_pytorch_benchmark_format(args, {"latency": [1.0]}, {})
+    output = tmp_path / "results.pytorch.json"
+    write_to_json(str(output), records)
+    record = json.loads(output.read_text())[0]
+    assert record["benchmark"]["extra_info"]["use_compile"] == (
+        filename != "eager.json"
+    )
+    assert record["metric"]["benchmark_values"] == [1.0]
+
+
+@pytest.mark.parametrize("from_extra_info", [False, True])
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        (0, False),
+        ("0", False),
+        (CompileMode.NONE, False),
+        (3, True),
+        ("3", True),
+        (CompileMode.ENABLED, True),
+    ],
+)
+def test_export_compilation_mode(monkeypatch, from_extra_info, mode, expected):
+    monkeypatch.setenv("SAVE_TO_PYTORCH_BENCHMARK_FORMAT", "1")
+    args = argparse.Namespace(
+        model="test-model",
+        compilation_config=argparse.Namespace(
+            mode=(0 if expected else 3) if from_extra_info else mode
+        ),
+    )
+    extra_info = {"compilation_config.mode": mode} if from_extra_info else {}
+    record = convert_to_pytorch_benchmark_format(args, {"latency": [1.0]}, extra_info)[
+        0
+    ]
+    assert record["benchmark"]["extra_info"]["use_compile"] is expected
+
+
+def test_export_disabled_with_unset_filename(monkeypatch):
+    monkeypatch.delenv("SAVE_TO_PYTORCH_BENCHMARK_FORMAT", raising=False)
+    args = argparse.Namespace(model="test-model", result_filename=None)
+    assert convert_to_pytorch_benchmark_format(args, {"latency": [1.0]}, {}) == []

--- a/vllm/benchmarks/lib/utils.py
+++ b/vllm/benchmarks/lib/utils.py
@@ -29,9 +29,9 @@ def use_compile(args: argparse.Namespace, extra_info: dict[str, Any]) -> bool:
     Check if the benchmark is run with torch.compile
     """
     return not (
-        extract_field(args, extra_info, "compilation_config.mode") == "0"
-        or "eager" in getattr(args, "output_json", "")
-        or "eager" in getattr(args, "result_filename", "")
+        extract_field(args, extra_info, "compilation_config.mode") in (0, "0")
+        or "eager" in (getattr(args, "output_json", None) or "")
+        or "eager" in (getattr(args, "result_filename", None) or "")
     )
 
 


### PR DESCRIPTION
## Purpose

Fixes #55982.

PyTorch benchmark export can fail after a successful benchmark when `--result-filename` is omitted: the CLI leaves `args.result_filename` as `None`, and the compilation-label helper performs a substring check on it. The helper also marks integer zero and zero-valued `IntEnum` compilation modes as enabled because it only compares against the string `"0"`.

Handle unset output filenames and recognize numeric zero when building the compilation label. Preserve the existing filename-based `eager` heuristic, metadata precedence, and export format. Regression tests exercise the exporter and JSON file round trips.

Duplicate check on 2026-09-09: searched open vLLM PRs for `55982 in:body`, `use_compile`, PyTorch benchmark export, and compilation-mode benchmark fixes; no matching fix was found.

AI assistance: Codex assisted with investigation, implementation, code review and local test execution. An independent agent review found no functional regression or scope expansion.

## Test Plan

```bash
.venv/bin/python -m pytest --noconftest tests/benchmarks/test_benchmark_utils.py -q
.venv/bin/pre-commit run --files vllm/benchmarks/lib/utils.py tests/benchmarks/test_benchmark_utils.py
.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files vllm/benchmarks/lib/utils.py tests/benchmarks/test_benchmark_utils.py
```

The focused tests import the real source module on macOS arm64 with Python 3.12. `--noconftest` avoids the global model/GPU fixtures. The existing benchmark CI job already includes this directory.

## Test Result

- Before the fix: 6 failed, 15 passed.
- After the fix: 21 passed, including file writes and JSON readback.
- Source-checkout warning: generated `vllm._version` metadata is absent.
- All applicable pre-commit checks passed, including Ruff, SPDX, import checks and Python 3.10 mypy; the manual Python 3.12 mypy check also passed.
- No model evaluation or live serving benchmark was run. This patch changes post-processing of benchmark records only.
