### PR TITLE
docs: fix DeltaMessage import path in reasoning_outputs

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -430,7 +430,7 @@ You can add a new `ReasoningParser` similar to [vllm/reasoning/deepseek_r1_reaso
 
     from vllm.reasoning import ReasoningParser, ReasoningParserManager
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-    from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+    from vllm.entrypoints.generate.base.protocol import DeltaMessage
 
     # define a reasoning parser and register it to vllm
     # the name list in register_module can be used


### PR DESCRIPTION
## Summary
Update the example `DeltaMessage` import in `docs/features/reasoning_outputs.md` to the current module path after the entrypoints restructure.

## Local repro
1. On main (`a97dacb7106ee49f39f3d1fc6ae1800ff724e01d`), the documented import path is gone:
   ```bash
   curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/entrypoints/openai/engine/protocol.py | head -1
   # HTTP/2 404
   ```
2. `DeltaMessage` now lives at `vllm/entrypoints/generate/base/protocol.py` (class around line 351):
   ```bash
   rg -n "class DeltaMessage" vllm/entrypoints/generate/base/protocol.py
   ```
3. Docs still show the stale import:
   ```bash
   rg -n "openai.engine.protocol import DeltaMessage" docs/features/reasoning_outputs.md
   ```

## Test plan
- [ ] Confirm old module path 404s on main
- [ ] Confirm `DeltaMessage` exists at `vllm.entrypoints.generate.base.protocol`
- [ ] Confirm docs example import matches the live module