### PR TITLE
docs: fix O0 custom_ops default in optimization_levels

### DIFF
--- a/docs/design/optimization_levels.md
+++ b/docs/design/optimization_levels.md
@@ -35,7 +35,7 @@ This level is good for initial phases of development and debugging.
 Settings:
 
 - `-cc.cudagraph_mode=NONE`
-- `-cc.mode=NONE` (also resulting in `-cc.custom_ops=["none"]`)
+- `-cc.mode=NONE` (also resulting in `-cc.custom_ops=["all"]`)
 - `-cc.pass_config.fuse_...=False` (all fusions disabled)
 - `--kernel-config.enable_flashinfer_autotune=False`
 


### PR DESCRIPTION
## Summary
- Fix `docs/design/optimization_levels.md` `-O0` settings: `-cc.mode=NONE` results in `-cc.custom_ops=["all"]`, not `["none"]`.
- Matches `VllmConfig` initialization: when `custom_ops` has neither `all` nor `none`, mode `NONE` appends `"all"` (inductor + non-NONE appends `"none"`).

## Test plan
- [x] Compared docs line against `vllm/config/vllm.py` custom_ops defaulting logic on `main` HEAD
- [ ] Docs CI / pre-commit as applicable