### PR TITLE
[Examples] Use --eplb-config.num_redundant_experts in elastic EP script

### DIFF
--- a/examples/ray_serving/elastic_ep/serve_deepseek_v2.sh
+++ b/examples/ray_serving/elastic_ep/serve_deepseek_v2.sh
@@ -65,7 +65,7 @@ vllm serve "$MODEL_NAME" \
     --enable-expert-parallel \
     --enable-eplb \
     --all2all-backend allgather_reducescatter \
-    --num-redundant-experts "$REDUNDANT_EXPERTS" \
+    --eplb-config.num_redundant_experts "$REDUNDANT_EXPERTS" \
     --trust-remote-code \
     --host "$HOST" \
     --port "$PORT"


### PR DESCRIPTION
## Summary
`examples/ray_serving/elastic_ep/serve_deepseek_v2.sh` still passes `--num-redundant-experts`, which is not a registered EngineArgs flag. Redundant-expert count is configured via EPLB as `--eplb-config.num_redundant_experts` (or JSON `--eplb-config`).

## Local repro
```bash
# On main tip: no top-level flag
rg -n '"--num-redundant-experts"' vllm/engine/arg_utils.py   # no matches
rg -n '"--eplb-config"' vllm/engine/arg_utils.py             # registered
rg -n 'num_redundant_experts' vllm/config/parallel.py        # EPLBConfig field

# Docs SoT for dotted / JSON forms
rg -n 'eplb-config.num_redundant_experts' docs/serving/expert_parallel_deployment.md

# Script still uses the ghost flag
rg -n 'num-redundant-experts' examples/ray_serving/elastic_ep/serve_deepseek_v2.sh
```

## Test plan
- [ ] Confirm argparse only exposes `--eplb-config` / dotted nested keys, not `--num-redundant-experts`
- [ ] Confirm script line matches docs/serving/expert_parallel_deployment.md dotted form
