### PR TITLE
[Spec Decode][Model Runner V2] Reuse shared AR for standalone drafts

### DIFF
--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -126,6 +126,7 @@ steps:
     - >-
       pytest -v -s
       v1/e2e/spec_decode/draft_model/test_draft_model.py::test_draft_model_tensor_parallelism
+      v1/e2e/spec_decode/draft_model/test_draft_model.py::test_draft_model_v2_tensor_parallelism
       v1/e2e/spec_decode/draft_model/test_draft_model.py::test_draft_model_engine_args_tensor_parallelism
   mirror:
     amd:

--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -21,15 +21,17 @@ from vllm.platforms import current_platform
 
 @pytest.mark.cpu_test
 @pytest.mark.parametrize(
-    ("draft_tp", "draft_max_len", "unsupported"),
+    ("draft_tp", "draft_max_len", "draft_eager", "unsupported"),
     [
-        (1, 2048, None),
-        (2, 2048, "distributed standalone drafting"),
-        (1, 1024, "standalone drafting with a shorter draft context"),
+        (1, 2048, None, None),
+        (2, 2048, None, "distributed standalone drafting"),
+        (1, 1024, None, "standalone drafting with a shorter draft context"),
+        (1, 2048, False, None),
+        (1, 2048, True, "standalone drafting with a different draft eager setting"),
     ],
 )
 def test_standalone_draft_runner_selection(
-    monkeypatch, draft_tp, draft_max_len, unsupported
+    monkeypatch, draft_tp, draft_max_len, draft_eager, unsupported
 ):
     """Unsupported drafts fall back by default and explain forced-V2 failures."""
     monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
@@ -48,6 +50,7 @@ def test_standalone_draft_runner_selection(
             is_hybrid=False,
             is_moe=False,
             enable_prompt_embeds=False,
+            enforce_eager=False,
             max_model_len=2048,
             logits_processors=None,
         ),
@@ -64,6 +67,7 @@ def test_standalone_draft_runner_selection(
             draft_model_config=draft_model_config,
             use_heterogeneous_vocab=False,
             parallel_drafting=False,
+            enforce_eager=draft_eager,
         ),
     )
 

--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -21,17 +21,19 @@ from vllm.platforms import current_platform
 
 @pytest.mark.cpu_test
 @pytest.mark.parametrize(
-    ("draft_tp", "draft_max_len", "draft_eager", "unsupported"),
+    ("target_tp", "draft_tp", "draft_max_len", "draft_eager", "unsupported"),
     [
-        (1, 2048, None, None),
-        (2, 2048, None, "distributed standalone drafting"),
-        (1, 1024, None, "standalone drafting with a shorter draft context"),
-        (1, 2048, False, None),
-        (1, 2048, True, "standalone drafting with a different draft eager setting"),
+        (1, 1, 2048, None, None),
+        (2, 2, 2048, None, None),
+        (1, 2, 2048, None, "standalone drafting with different TP sizes"),
+        (2, 1, 2048, None, "standalone drafting with different TP sizes"),
+        (1, 1, 1024, None, "standalone drafting with a shorter draft context"),
+        (1, 1, 2048, False, None),
+        (1, 1, 2048, True, "standalone drafting with a different draft eager setting"),
     ],
 )
 def test_standalone_draft_runner_selection(
-    monkeypatch, draft_tp, draft_max_len, draft_eager, unsupported
+    monkeypatch, target_tp, draft_tp, draft_max_len, draft_eager, unsupported
 ):
     """Unsupported drafts fall back by default and explain forced-V2 failures."""
     monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
@@ -41,6 +43,7 @@ def test_standalone_draft_runner_selection(
     config = object.__new__(VllmConfig)
     config.compilation_config = CompilationConfig()
     config.parallel_config = ParallelConfig()
+    config.parallel_config.tensor_parallel_size = target_tp
     config.cache_config = CacheConfig()
     config.lora_config = None
     config.model_config = cast(

--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -1,9 +1,80 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+from typing import cast
+
 import pytest
 
+from vllm.config import (
+    CacheConfig,
+    CompilationConfig,
+    ModelConfig,
+    ParallelConfig,
+    SpeculativeConfig,
+    VllmConfig,
+)
+from vllm.config import vllm as vllm_config_module
 from vllm.engine.arg_utils import EngineArgs
 from vllm.model_executor.layers.quantization.quark.utils import deep_compare
+from vllm.platforms import current_platform
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("draft_tp", "draft_max_len", "unsupported"),
+    [
+        (1, 2048, None),
+        (2, 2048, "distributed standalone drafting"),
+        (1, 1024, "standalone drafting with a shorter draft context"),
+    ],
+)
+def test_standalone_draft_runner_selection(
+    monkeypatch, draft_tp, draft_max_len, unsupported
+):
+    """Unsupported drafts fall back by default and explain forced-V2 failures."""
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: False)
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda **kwargs: ())
+    config = object.__new__(VllmConfig)
+    config.compilation_config = CompilationConfig()
+    config.parallel_config = ParallelConfig()
+    config.cache_config = CacheConfig()
+    config.lora_config = None
+    config.model_config = cast(
+        ModelConfig,
+        SimpleNamespace(
+            is_multimodal_model=False,
+            is_hybrid=False,
+            is_moe=False,
+            enable_prompt_embeds=False,
+            max_model_len=2048,
+            logits_processors=None,
+        ),
+    )
+    draft_model_config = SimpleNamespace(**vars(config.model_config))
+    draft_model_config.max_model_len = draft_max_len
+    draft_parallel_config = ParallelConfig()
+    draft_parallel_config.tensor_parallel_size = draft_tp
+    config.speculative_config = cast(
+        SpeculativeConfig,
+        SimpleNamespace(
+            method="draft_model",
+            draft_parallel_config=draft_parallel_config,
+            draft_model_config=draft_model_config,
+            use_heterogeneous_vocab=False,
+            parallel_drafting=False,
+        ),
+    )
+
+    assert config.use_v2_model_runner is (unsupported is None)
+    if unsupported is None:
+        config._validate_v2_model_runner()
+    else:
+        monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+        assert config.use_v2_model_runner
+        with pytest.raises(ValueError, match=unsupported):
+            config._validate_v2_model_runner()
 
 
 def test_cuda_empty_vs_unset_configs(monkeypatch: pytest.MonkeyPatch):

--- a/tests/v1/e2e/spec_decode/draft_model/test_draft_model.py
+++ b/tests/v1/e2e/spec_decode/draft_model/test_draft_model.py
@@ -164,6 +164,73 @@ def test_draft_model_tensor_parallelism(vllm_runner):
     assert_draft_model_correctness(sd_case, vllm_runner)
 
 
+@pytest.mark.parametrize("enforce_eager", [True, False], ids=["eager", "graph"])
+@pytest.mark.parametrize("draft_sample_method", ["greedy", "probabilistic"])
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="V2 requires CUDA")
+@multi_gpu_only(num_gpus=2)
+def test_draft_model_v2_tensor_parallelism(
+    monkeypatch, enforce_eager, draft_sample_method, vllm_runner
+):
+    """Both models must be sharded across actual V2 workers, without fallback."""
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+    def check_worker(worker, eager):
+        from vllm.distributed import get_tp_group
+        from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+        from vllm.v1.worker.gpu.spec_decode.draft_model.speculator import (
+            StandaloneDraftModelSpeculator,
+        )
+
+        runner = worker.model_runner
+        assert worker.use_v2_model_runner
+        assert isinstance(runner, GPUModelRunner)
+        assert isinstance(runner.speculator, StandaloneDraftModelSpeculator)
+        tp_group = get_tp_group()
+        assert tp_group.world_size == 2
+        for model in (runner.model, runner.speculator.model):
+            assert model.lm_head.tp_size == 2
+            assert model.lm_head.tp_rank == tp_group.rank_in_group
+        decode_cg = runner.speculator.decode_cudagraph_manager
+        assert decode_cg is not None
+        assert bool(decode_cg.graphs) is not eager
+        return tp_group.rank_in_group
+
+    prompts = get_test_prompts(mm_enabled=False, num_prompts=20)
+    with vllm_runner(
+        "Qwen/Qwen3-1.7B",
+        tensor_parallel_size=2,
+        speculative_config={
+            "model": "Qwen/Qwen3-0.6B",
+            "method": "draft_model",
+            "num_speculative_tokens": 3,
+            "draft_tensor_parallel_size": 2,
+            "draft_sample_method": draft_sample_method,
+            "enforce_eager": enforce_eager,
+        },
+        max_model_len=2048,
+        max_num_seqs=len(prompts),
+        gpu_memory_utilization=0.5,
+        enforce_eager=enforce_eager,
+        disable_log_stats=False,
+    ) as runner:
+        assert sorted(runner.collective_rpc(check_worker, args=(enforce_eager,))) == [
+            0,
+            1,
+        ]
+        sampling = (
+            SamplingParams(temperature=1.0, seed=42, max_tokens=10)
+            if draft_sample_method == "probabilistic"
+            else greedy_sampling()
+        )
+        outputs = runner.llm.chat(prompts, sampling)
+        assert len(outputs) == len(prompts)
+        assert all(output.outputs and output.outputs[0].token_ids for output in outputs)
+        metrics = runner.llm.get_metrics()
+        assert compute_acceptance_rate(metrics) > 0
+        assert compute_acceptance_len(metrics) > 1
+
+
 @multi_gpu_only(num_gpus=2)
 def test_draft_model_engine_args_tensor_parallelism():
     """Ensure the vllm_config for the draft model is created correctly,

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -30,7 +30,6 @@ from vllm.v1.worker.gpu.attn_utils import (
     get_query_lens_mismatch_unsupported_backend,
     init_attn_backend,
 )
-from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 from vllm.v1.worker.utils import (
     AttentionGroup,
@@ -59,10 +58,7 @@ class _DraftBackend:
         return False
 
 
-@pytest.mark.parametrize("separate_target_group", [False, True])
-def test_draft_metadata_preserves_allocated_kernel_block_size(
-    monkeypatch, separate_target_group
-):
+def test_draft_metadata_preserves_allocated_kernel_block_size(monkeypatch):
     """Filtering layers must not change the page unit of an allocated KV cache."""
 
     class Builder(_FakeMetadataBuilder):
@@ -113,42 +109,28 @@ def test_draft_metadata_preserves_allocated_kernel_block_size(
     spec = FullAttentionSpec(
         block_size=128, num_kv_heads=1, head_size=128, dtype=torch.bfloat16
     )
-    kv_groups = [KVCacheGroupSpec(["target", "draft"], spec)]
-    if separate_target_group:
-        kv_groups.insert(
-            0, KVCacheGroupSpec(["target_only"], spec.copy_with_new_block_size(32))
-        )
-    draft_group_idx = int(separate_target_group)
     kv_config = KVCacheConfig(
         num_blocks=8,
         kv_cache_tensors=[],
-        kv_cache_groups=kv_groups,
+        kv_cache_groups=[
+            KVCacheGroupSpec(["target_only"], spec.copy_with_new_block_size(32)),
+            KVCacheGroupSpec(["target", "draft"], spec),
+        ],
     )
     config = SimpleNamespace(parallel_config=ParallelConfig())
     device = torch.device("cpu")
     _, _, sizes = init_attn_backend(kv_config, config, device)
-    assert sizes == ([32, 64] if separate_target_group else [64])
-    # Only the page-size contract is needed; full construction allocates UVA.
-    block_tables = object.__new__(BlockTables)
-    block_tables.kernel_block_sizes = sizes
-    draft_only, _, _ = init_attn_backend(
-        kv_config, config, device, active_layer_names={"draft"}
-    )
-    assert (
-        draft_only[draft_group_idx][0].get_metadata_builder().block_size_at_init == 128
-    )
+    assert sizes == [32, 64]
+    block_tables = SimpleNamespace(kernel_block_sizes=sizes)
 
     speculator = SimpleNamespace(
         device=device, attn_vllm_config=config, draft_attn_layer_names={"draft"}
     )
     DraftModelSpeculator.set_attn(speculator, None, kv_config, block_tables, None, [])
-    draft_group = speculator.attn_groups[draft_group_idx][0]
-    assert draft_group.kv_cache_group_id == draft_group_idx
+    draft_group = speculator.attn_groups[1][0]
+    assert draft_group.kv_cache_group_id == 1
     builder = draft_group.get_metadata_builder()
-    assert (
-        builder.block_size_at_init == block_tables.kernel_block_sizes[draft_group_idx]
-    )
-    assert builder.kernel_block_size == block_tables.kernel_block_sizes[draft_group_idx]
+    assert builder.block_size_at_init == builder.kernel_block_size == sizes[1]
 
 
 def test_attention_checks_preserve_global_and_target_scoped_support():

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -7,11 +7,14 @@ while keeping per-block content compact, so padding bytes at the end of each pag
 never addressed by the logical view.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from tests.v1.attention.utils import dense_kv_cache_views
-from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.config import ParallelConfig
+from vllm.v1.attention.backend import AttentionCGSupport, MultipleOf
 from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -25,7 +28,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.worker.gpu.attn_utils import (
     get_attn_cg_support,
     get_query_lens_mismatch_unsupported_backend,
+    init_attn_backend,
 )
+from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 from vllm.v1.worker.utils import (
     AttentionGroup,
     allocate_kv_cache,
@@ -51,6 +57,98 @@ class _DraftBackend:
     @classmethod
     def supports_device_cpu_query_lens_mismatch(cls) -> bool:
         return False
+
+
+@pytest.mark.parametrize("separate_target_group", [False, True])
+def test_draft_metadata_preserves_allocated_kernel_block_size(
+    monkeypatch, separate_target_group
+):
+    """Filtering layers must not change the page unit of an allocated KV cache."""
+
+    class Builder(_FakeMetadataBuilder):
+        requires_block_table_width = False
+
+        def __init__(self, spec, *_args):
+            super().__init__(AttentionCGSupport.ALWAYS)
+            self.block_size_at_init = spec.block_size
+
+        def set_kernel_block_size(self, size):
+            self.kernel_block_size = size
+
+    class TargetBackend:
+        @classmethod
+        def full_cls_name(cls):
+            return (__name__, cls.__name__)
+
+        @staticmethod
+        def get_supported_kernel_block_sizes():
+            return [16, 32, 64]
+
+        @staticmethod
+        def get_builder_cls():
+            return Builder
+
+    class DraftBackend(TargetBackend):
+        @staticmethod
+        def get_supported_kernel_block_sizes():
+            return [MultipleOf(16)]
+
+    layers = {
+        "target_only": SimpleNamespace(
+            get_attn_backend=lambda: TargetBackend, kv_sharing_target_layer_name=None
+        ),
+        "target": SimpleNamespace(
+            get_attn_backend=lambda: TargetBackend, kv_sharing_target_layer_name=None
+        ),
+        "draft": SimpleNamespace(
+            get_attn_backend=lambda: DraftBackend, kv_sharing_target_layer_name=None
+        ),
+    }
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.attn_utils.get_layers_from_vllm_config",
+        lambda config, layer_type, names=None: (
+            layers if names is None else {name: layers[name] for name in names}
+        ),
+    )
+    spec = FullAttentionSpec(
+        block_size=128, num_kv_heads=1, head_size=128, dtype=torch.bfloat16
+    )
+    kv_groups = [KVCacheGroupSpec(["target", "draft"], spec)]
+    if separate_target_group:
+        kv_groups.insert(
+            0, KVCacheGroupSpec(["target_only"], spec.copy_with_new_block_size(32))
+        )
+    draft_group_idx = int(separate_target_group)
+    kv_config = KVCacheConfig(
+        num_blocks=8,
+        kv_cache_tensors=[],
+        kv_cache_groups=kv_groups,
+    )
+    config = SimpleNamespace(parallel_config=ParallelConfig())
+    device = torch.device("cpu")
+    _, _, sizes = init_attn_backend(kv_config, config, device)
+    assert sizes == ([32, 64] if separate_target_group else [64])
+    # Only the page-size contract is needed; full construction allocates UVA.
+    block_tables = object.__new__(BlockTables)
+    block_tables.kernel_block_sizes = sizes
+    draft_only, _, _ = init_attn_backend(
+        kv_config, config, device, active_layer_names={"draft"}
+    )
+    assert (
+        draft_only[draft_group_idx][0].get_metadata_builder().block_size_at_init == 128
+    )
+
+    speculator = SimpleNamespace(
+        device=device, attn_vllm_config=config, draft_attn_layer_names={"draft"}
+    )
+    DraftModelSpeculator.set_attn(speculator, None, kv_config, block_tables, None, [])
+    draft_group = speculator.attn_groups[draft_group_idx][0]
+    assert draft_group.kv_cache_group_id == draft_group_idx
+    builder = draft_group.get_metadata_builder()
+    assert (
+        builder.block_size_at_init == block_tables.kernel_block_sizes[draft_group_idx]
+    )
+    assert builder.kernel_block_size == block_tables.kernel_block_sizes[draft_group_idx]
 
 
 def test_attention_checks_preserve_global_and_target_scoped_support():

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -7,8 +7,10 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from transformers import Qwen3Config
 
 from vllm.config.compilation import CUDAGraphMode
+from vllm.engine.arg_utils import EngineArgs
 from vllm.model_executor.models import supports_multimodal_embeddings
 from vllm.model_executor.models.exaone4_5_mtp import Exaone4_5_MTP
 from vllm.model_executor.models.llama4_eagle import EagleLlama4ForCausalLM
@@ -17,13 +19,21 @@ from vllm.model_executor.models.mistral_eagle import EagleMistralForCausalLM
 from vllm.model_executor.models.mistral_large_3_eagle import (
     EagleMistralLarge3ForCausalLM,
 )
+from vllm.platforms import current_platform
 from vllm.v1.attention.backends import flash_attn as flash_attn_module
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
+from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
     AutoRegressiveSpeculator,
+    prepare_decode_inputs,
+)
+from vllm.v1.worker.gpu.spec_decode.draft_model.speculator import (
+    StandaloneDraftModelSpeculator,
+    prepare_draft_model_prefill_inputs,
 )
 from vllm.v1.worker.gpu.spec_decode.multi_module_mtp.speculator import (
     MultiModuleMTPSpeculator,
@@ -85,14 +95,15 @@ def _mock_base_model_load(monkeypatch):
 def _make_speculator(
     monkeypatch,
     output: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
-) -> _TestSpeculator:
+    speculator_cls=_TestSpeculator,
+) -> AutoRegressiveSpeculator:
     monkeypatch.setattr(
         spec_module,
         "set_forward_context",
         lambda *args, **kwargs: nullcontext(),
     )
 
-    speculator = object.__new__(_TestSpeculator)
+    speculator = object.__new__(speculator_cls)
     speculator.supports_mm_inputs = False
     speculator.vllm_config = None
     speculator.input_buffers = SimpleNamespace(
@@ -143,6 +154,54 @@ def test_speculator_uses_draft_model_hidden_size(monkeypatch, hc_mult, expected)
     speculator = _TestSpeculator(vllm_config, torch.device("cpu"))
 
     assert speculator.hidden_size == expected
+
+
+@pytest.mark.cpu_test
+def test_standalone_constructor_expands_only_the_draft_scheduler(tmp_path):
+    """Draft capacity must not expand the target's warmup beyond its buffers."""
+    Qwen3Config(
+        architectures=["Qwen3ForCausalLM"],
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+    ).save_pretrained(tmp_path)
+    config = EngineArgs(
+        model=str(tmp_path),
+        speculative_config={
+            "model": str(tmp_path),
+            "method": "draft_model",
+            "num_speculative_tokens": 2,
+        },
+        max_model_len=32,
+        max_num_batched_tokens=16,
+        max_num_seqs=2,
+        enable_chunked_prefill=True,
+        enforce_eager=True,
+        skip_tokenizer_init=True,
+        dtype="float32",
+    ).create_engine_config()
+    target_scheduler = config.scheduler_config
+    target_compilation = config.compilation_config
+    target_compile_ranges = list(target_compilation.compile_ranges_endpoints)
+
+    speculator = StandaloneDraftModelSpeculator(config, torch.device("cpu"))
+
+    assert target_scheduler.max_num_batched_tokens == 16
+    assert speculator.draft_vllm_config.scheduler_config is not target_scheduler
+    assert speculator.draft_vllm_config.scheduler_config.max_num_batched_tokens == 18
+    assert speculator.input_buffers.input_ids.numel() == 18
+    draft_compilation = speculator.draft_vllm_config.compilation_config
+    assert target_compilation.compile_ranges_endpoints == target_compile_ranges
+    assert draft_compilation is not target_compilation
+    assert max(draft_compilation.compile_ranges_endpoints) == 18
+    assert (
+        draft_compilation.static_forward_context
+        is target_compilation.static_forward_context
+    )
 
 
 def test_mm_support_configured_after_model_load(monkeypatch):
@@ -325,6 +384,232 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
 
     assert actual_logits_hidden is hidden
     assert actual_feedback_hidden is hidden
+
+
+@pytest.mark.parametrize(
+    "speculator_cls", [_TestSpeculator, StandaloneDraftModelSpeculator]
+)
+def test_run_model_only_passes_hidden_states_to_conditioned_drafters(
+    monkeypatch, speculator_cls
+):
+    speculator = _make_speculator(monkeypatch, torch.zeros(4, 3), speculator_cls)
+    speculator.model = Mock(return_value=torch.zeros(4, 3))
+
+    speculator._run_model(4, None, None, None)
+
+    kwargs = speculator.model.call_args.kwargs
+    if speculator_cls is StandaloneDraftModelSpeculator:
+        assert "hidden_states" not in kwargs
+    else:
+        assert torch.equal(kwargs["hidden_states"], speculator.hidden_states)
+
+
+@pytest.mark.parametrize(
+    ("speculator_cls", "expected_positions"),
+    [(_TestSpeculator, [2, 4]), (StandaloneDraftModelSpeculator, [1, 3])],
+)
+def test_prefill_samples_from_the_position_consumed_by_each_drafter(
+    monkeypatch, speculator_cls, expected_positions
+):
+    speculator = _make_speculator(monkeypatch, torch.zeros(4, 3), speculator_cls)
+    speculator.last_token_indices = torch.tensor([1, 3])
+    speculator.idx_mapping = torch.tensor([0, 1])
+    speculator.draft_tokens = torch.zeros((2, 1), dtype=torch.int64)
+    speculator.sample_src_positions = torch.zeros(2, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.temperature = speculator.seeds = speculator.draft_logits = None
+    speculator.sample_draft = Mock(return_value=torch.tensor([5, 6]))
+
+    speculator._prefill(2, 4, None, None, None)
+
+    assert speculator.sample_draft.call_args.args[1].tolist() == expected_positions
+    assert speculator.sample_src_positions.tolist() == expected_positions
+    assert speculator.input_buffers.positions[:2].tolist() == [1, 3]
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+def test_standalone_prefill_preserves_tokens_and_right_aligns_rejected_queries():
+    """A stale target MoE mask must not hide accepted tokens from draft KV."""
+    device = torch.device("cuda")
+
+    def tensor(values, dtype=None):
+        return torch.tensor(values, dtype=dtype, device=device)
+
+    buffers = InputBuffers(5, 16, device)
+    buffers.input_ids.fill_(-99)
+    buffers.positions.fill_(-99)
+    batch = InputBatch.make_dummy(3, 9, InputBuffers(5, 16, device))
+    batch.input_ids = tensor([10, 11, 12, 20, 21, 30, 31, 98, 99], torch.int32)
+    batch.positions = tensor([4, 5, 6, 6, 7, 10, 11, 12, 13])
+    batch.query_start_loc = tensor([0, 3, 5, 9], torch.int32)
+    batch.query_start_loc_np[:] = [0, 3, 5, 9]
+    batch.num_scheduled_tokens[:] = [3, 2, 4]
+    batch.seq_lens = tensor([7, 8, 14], torch.int32)
+    batch.seq_lens_cpu_upper_bound[:] = torch.tensor([7, 8, 14])
+    batch.idx_mapping = tensor([2, 0, 1], torch.int32)
+    # Real batches can retain the dummy mask when VLLM_MOE_SKIP_PADDING=0.
+    batch.is_padding.fill_(True)
+    last_indices = tensor([-99] * 5)
+    current_step = tensor(3)
+    speculator = object.__new__(StandaloneDraftModelSpeculator)
+    speculator.input_buffers = buffers
+    speculator.last_token_indices = last_indices
+    speculator.current_draft_step = current_step
+    speculator.max_num_reqs = 5
+    speculator.max_model_len = 32
+    speculator.is_dummy_run = tensor(True)
+
+    expanded = speculator.prepare_inputs(
+        batch,
+        torch.empty(0),
+        None,
+        tensor([0, 1, 2], torch.int32),
+        tensor([0, 0, 2], torch.int32),
+        tensor([22, 32, 999, 999, 999], torch.int64),
+        tensor([[777, 777, 13, 777, 777], [888] * 5], torch.int32),
+    )
+
+    assert expanded.num_tokens == expanded.num_tokens_after_padding == 12
+    assert expanded.num_scheduled_tokens.tolist() == [4, 3, 5]
+    assert expanded.seq_lens_cpu_upper_bound.tolist() == [8, 9, 15]
+    assert expanded.query_start_loc_np.tolist() == [0, 4, 7, 12]
+    assert batch.num_tokens == 9
+    assert buffers.query_start_loc.tolist() == [0, 4, 7, 12, 12, 12]
+    assert buffers.seq_lens.tolist() == [8, 9, 13, 0, 0]
+    assert last_indices.tolist() == [3, 6, 11, 0, 0]
+    assert current_step.item() == 0
+    assert not speculator.is_dummy_run.item()
+    assert buffers.is_padding.tolist() == (
+        [False] * 7 + [True] * 2 + [False] * 3 + [True] * 4
+    )
+    valid = ~buffers.is_padding
+    assert buffers.input_ids[valid].tolist() == [10, 11, 12, 13, 20, 21, 22, 30, 31, 32]
+    assert buffers.positions[valid].tolist() == [4, 5, 6, 7, 6, 7, 8, 10, 11, 12]
+
+    speculator.idx_mapping = batch.idx_mapping
+    speculator.block_tables = BlockTables([4], 5, 16, [8], device, [4])
+    for state in range(3):
+        speculator.block_tables.append_block_ids(
+            state, (list(range(state * 8 + 1, state * 8 + 9)),), overwrite=True
+        )
+    speculator.block_tables.apply_staged_writes()
+    speculator.kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(layer_names=["draft"])]
+    )
+    speculator._build_draft_attn_metadata = Mock(return_value={})
+
+    _, slots = speculator.prepare_attn(
+        expanded, BatchExecutionDescriptor(CUDAGraphMode.NONE, 16, 5)
+    )
+
+    assert slots["draft"].tolist() == (
+        [72, 73, 74, 75, 10, 11, 12, -1, -1, 46, 47, 48] + [-1] * 4
+    )
+    assert slots["draft"].data_ptr() == speculator.block_tables.slot_mappings.data_ptr()
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+@pytest.mark.parametrize("seq_len", [15, 16])
+@pytest.mark.parametrize("num_rejected", [0, 1, 3])
+def test_standalone_prefill_keeps_causal_origin_at_context_boundary(
+    seq_len, num_rejected
+):
+    device = torch.device("cuda")
+    buffers = InputBuffers(1, 5, device)
+    batch = SimpleNamespace(
+        num_reqs=1,
+        num_tokens=4,
+        input_ids=torch.arange(10, 14, device=device),
+        positions=torch.arange(seq_len - 4, seq_len, device=device),
+        is_padding=torch.zeros(4, dtype=torch.bool, device=device),
+        query_start_loc=torch.tensor([0, 4], device=device),
+        seq_lens=torch.tensor([seq_len], device=device),
+        idx_mapping=torch.tensor([0], device=device),
+    )
+    last_indices = torch.zeros(1, dtype=torch.int64, device=device)
+    prepare_draft_model_prefill_inputs(
+        last_indices,
+        torch.zeros((), dtype=torch.int64, device=device),
+        buffers,
+        batch,
+        torch.tensor([4 - num_rejected], device=device),
+        torch.tensor([num_rejected], device=device),
+        torch.tensor([42], device=device),
+        torch.tensor([99], device=device),
+        1,
+        16,
+    )
+
+    has_bonus = seq_len - num_rejected < 16
+    num_padding = num_rejected + (not has_bonus)
+    valid_ids = list(range(10, 14 - num_rejected)) + ([42] if has_bonus else [])
+    assert buffers.is_padding.tolist() == [True] * num_padding + [False] * len(
+        valid_ids
+    )
+    assert buffers.input_ids[num_padding:].tolist() == valid_ids
+    assert buffers.positions[num_padding:].tolist() == list(
+        range(seq_len - 4, seq_len - num_rejected + has_bonus)
+    )
+    assert buffers.seq_lens.item() <= 16
+    assert buffers.seq_lens.item() - 5 + num_padding == seq_len - 4
+    assert last_indices.item() == 4
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+@pytest.mark.parametrize("seq_len_offset", [0, 1])
+def test_decode_inputs_include_standalone_bonus_without_changing_existing_drafters(
+    seq_len_offset,
+):
+    device = torch.device("cuda")
+    buffers = InputBuffers(4, 4, device)
+    buffers.positions[:3] = torch.tensor([7, 12, 15], device=device)
+    sample_positions = torch.tensor([7, 12, 15, 0], device=device)
+
+    prepare_decode_inputs(
+        torch.tensor([11, 22, 33], device=device),
+        torch.tensor([8, 14, 16], device=device),
+        torch.tensor([0, 2, 0], device=device),
+        buffers,
+        sample_positions,
+        max_model_len=16,
+        max_num_reqs=4,
+        seq_len_offset=seq_len_offset,
+    )
+
+    assert buffers.input_ids[:3].tolist() == [11, 22, 33]
+    assert buffers.positions[:3].tolist() == [8, 13, 15]
+    assert sample_positions.tolist() == [8, 13, 16, 0]
+    assert buffers.seq_lens.tolist() == [9 + seq_len_offset, 13 + seq_len_offset, 16, 0]
+    assert buffers.query_start_loc.tolist() == [0, 1, 2, 3, 3]
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+def test_standalone_decode_slots_mask_context_limit_and_dummy_runs():
+    """Clamped positions must not overwrite the final live KV token."""
+    device = torch.device("cuda")
+    speculator = object.__new__(StandaloneDraftModelSpeculator)
+    speculator.max_model_len = 16
+    speculator.input_buffers = InputBuffers(3, 4, device)
+    speculator.input_buffers.positions[:2] = 15
+    speculator.input_buffers.query_start_loc[:] = torch.tensor(
+        [0, 1, 2, 2], device=device
+    )
+    speculator.idx_mapping = torch.tensor([0, 1], device=device)
+    speculator.sample_src_positions = torch.tensor([15, 16, 0], device=device)
+    speculator.is_dummy_run = torch.zeros((), dtype=torch.bool, device=device)
+    speculator.block_tables = BlockTables([4], 3, 4, [4], device, [4])
+    for state in range(2):
+        speculator.block_tables.append_block_ids(
+            state, (list(range(state * 4 + 1, state * 4 + 5)),), overwrite=True
+        )
+    speculator.block_tables.apply_staged_writes()
+
+    for dummy_run in (False, True, False):
+        speculator.is_dummy_run.fill_(dummy_run)
+        slots = speculator.compute_decode_slot_mappings(2, 3)
+
+        assert slots.tolist() == [[-1 if dummy_run else 19, -1, -1]]
+        assert slots.data_ptr() == speculator.block_tables.slot_mappings.data_ptr()
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from transformers import Qwen3Config
 
+from vllm.config.cache import CacheConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.engine.arg_utils import EngineArgs
 from vllm.model_executor.models import supports_multimodal_embeddings
@@ -22,6 +23,7 @@ from vllm.model_executor.models.mistral_large_3_eagle import (
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends import flash_attn as flash_attn_module
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
+from vllm.v1.attention.backends.utils import record_kv_cache_layout
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
@@ -31,6 +33,7 @@ from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
     AutoRegressiveSpeculator,
     prepare_decode_inputs,
 )
+from vllm.v1.worker.gpu.spec_decode.draft_model import speculator as draft_spec_module
 from vllm.v1.worker.gpu.spec_decode.draft_model.speculator import (
     StandaloneDraftModelSpeculator,
     prepare_draft_model_prefill_inputs,
@@ -202,6 +205,107 @@ def test_standalone_constructor_expands_only_the_draft_scheduler(tmp_path):
         draft_compilation.static_forward_context
         is target_compilation.static_forward_context
     )
+
+
+def test_standalone_receives_resolved_layout_before_building_attention(monkeypatch):
+    """A layer's existing draft config reference sees the engine's final layout."""
+    target_cache = CacheConfig()
+    draft_cache = CacheConfig(cache_dtype="bfloat16")
+    speculator = object.__new__(StandaloneDraftModelSpeculator)
+    speculator.vllm_config = SimpleNamespace(cache_config=target_cache)
+    speculator.draft_vllm_config = SimpleNamespace(cache_config=draft_cache)
+    speculator.device = torch.device("cpu")
+    speculator.max_num_tokens = 4
+    speculator.model = object()
+    block_tables = SimpleNamespace(num_kv_cache_groups=1)
+    # Resolve after the separate draft config and layer reference already exist.
+    record_kv_cache_layout(target_cache, "LBNHC")
+
+    def build_attention(self, *args):
+        assert self.draft_vllm_config.cache_config is draft_cache
+        assert draft_cache.get_resolved_kv_cache_layout().name == "LBNHC"
+
+    monkeypatch.setattr(AutoRegressiveSpeculator, "set_attn", build_attention)
+    monkeypatch.setattr(draft_spec_module, "DefaultModelState", lambda *args: None)
+    speculator.set_attn(None, None, block_tables, None, [])
+    speculator.set_attn(None, None, block_tables, None, [])
+    assert draft_cache.cache_dtype == "bfloat16"
+    assert (
+        target_cache.get_resolved_kv_cache_layout()
+        == draft_cache.get_resolved_kv_cache_layout()
+    )
+
+
+@pytest.mark.parametrize(
+    ("speculator_cls", "backend", "threshold", "mode", "prefill_mode"),
+    [
+        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "FULL_DECODE_ONLY", "NONE"),
+        (
+            StandaloneDraftModelSpeculator,
+            "FLASHINFER",
+            4,
+            "FULL_AND_PIECEWISE",
+            "PIECEWISE",
+        ),
+        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "FULL", "NONE"),
+        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "PIECEWISE", "PIECEWISE"),
+        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "NONE", "NONE"),
+        (
+            StandaloneDraftModelSpeculator,
+            "FLASHINFER",
+            5,
+            "FULL_DECODE_ONLY",
+            "FULL_DECODE_ONLY",
+        ),
+        (
+            StandaloneDraftModelSpeculator,
+            "FLASH_ATTN",
+            1,
+            "FULL_DECODE_ONLY",
+            "FULL_DECODE_ONLY",
+        ),
+        (_TestSpeculator, "FLASHINFER", 4, "FULL_DECODE_ONLY", "FULL_DECODE_ONLY"),
+    ],
+)
+def test_prefill_graph_respects_backend_query_width(
+    monkeypatch, speculator_cls, backend, threshold, mode, prefill_mode
+):
+    """Only the unsupported prefill FULL path falls back; q1 graphs survive."""
+    speculator = object.__new__(speculator_cls)
+    speculator.num_speculative_steps = 3
+    speculator.device = torch.device("cpu")
+    speculator.vllm_config = object()
+    builder = SimpleNamespace(reorder_batch_threshold=threshold)
+    other_group = SimpleNamespace(
+        backend=SimpleNamespace(get_name=lambda: "FLASH_ATTN"),
+        get_metadata_builder=lambda: SimpleNamespace(reorder_batch_threshold=1),
+    )
+    speculator.attn_groups = [
+        [other_group],
+        [
+            SimpleNamespace(
+                backend=SimpleNamespace(get_name=lambda: backend),
+                get_metadata_builder=lambda: builder,
+            )
+        ],
+    ]
+
+    def manager(config, device, mode, decode_query_len):
+        return SimpleNamespace(mode=mode, query_len=decode_query_len)
+
+    monkeypatch.setattr(spec_module, "SpeculatorCudaGraphManager", manager)
+    original_mode = CUDAGraphMode[mode]
+    speculator.init_cudagraph_manager(original_mode)
+    assert speculator.prefill_cudagraph_manager.mode == CUDAGraphMode[prefill_mode]
+    assert speculator.prefill_cudagraph_manager.query_len == (
+        4 + speculator.prefill_seq_len_offset
+    )
+    assert speculator.decode_cudagraph_manager.mode == (
+        CUDAGraphMode.FULL_DECODE_ONLY
+        if original_mode.decode_mode() == CUDAGraphMode.FULL
+        else CUDAGraphMode.NONE
+    )
+    assert speculator.decode_cudagraph_manager.query_len == 1
 
 
 def test_mm_support_configured_after_model_load(monkeypatch):

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -308,6 +308,76 @@ def test_prefill_graph_respects_backend_query_width(
     assert speculator.decode_cudagraph_manager.query_len == 1
 
 
+@pytest.mark.parametrize(
+    ("query_starts", "num_reqs", "num_reqs_padded", "leading_padding", "expected"),
+    [
+        pytest.param([0, 3, 6], 2, 2, 0, 6, id="six-queries-eight-model-tokens"),
+        pytest.param([0, 5], 1, 1, 2, 5, id="leading-query-padding-counts"),
+        pytest.param([0, 2, 4, 6], 3, 4, 0, 6, id="padded-request-empty-query"),
+        pytest.param([0, 3, 6, 99], 2, 2, 0, 6, id="ignore-unused-boundary-tail"),
+        pytest.param(None, 3, 4, 0, 8, id="uniform-path-keeps-padded-count"),
+    ],
+)
+def test_draft_metadata_excludes_only_graph_token_padding(
+    query_starts, num_reqs, num_reqs_padded, leading_padding, expected
+):
+    """Attention counts query rows, including in-query PAD, but not graph tails."""
+
+    class RecordingBuilder:
+        def build(self, common_prefix_len, common_attn_metadata):
+            return common_attn_metadata
+
+    boundaries = (
+        list(range(num_reqs + 1))
+        if query_starts is None
+        else query_starts[: num_reqs + 1]
+    )
+    boundaries += [boundaries[-1]] * (num_reqs_padded - num_reqs)
+    slots = torch.arange(8, dtype=torch.int64).reshape(1, 8)
+    slots[:, :leading_padding] = -1
+    slots[:, boundaries[-1] :] = -1
+    speculator = object.__new__(_TestSpeculator)
+    speculator.arange = torch.arange(num_reqs_padded + 1, dtype=torch.int32)
+    speculator.max_model_len = speculator.draft_max_seq_len = 32
+    speculator.input_buffers = SimpleNamespace(
+        query_start_loc=torch.tensor(boundaries, dtype=torch.int32),
+        seq_lens=torch.full((num_reqs_padded,), 16, dtype=torch.int32),
+    )
+    speculator.block_tables = SimpleNamespace(
+        input_block_tables=[torch.zeros((num_reqs_padded, 2), dtype=torch.int32)],
+        slot_mappings=slots,
+        cp_size=1,
+    )
+    speculator.kv_cache_config = SimpleNamespace(kv_cache_groups=[None])
+    speculator.attn_groups = [
+        [
+            SimpleNamespace(
+                layer_names=["draft"],
+                get_metadata_builder=lambda _: RecordingBuilder(),
+            )
+        ]
+    ]
+
+    metadata = speculator._build_draft_attn_metadata(
+        num_reqs=num_reqs,
+        num_reqs_padded=num_reqs_padded,
+        num_tokens_padded=8,
+        seq_lens_cpu_upper_bound=torch.full((num_reqs,), 16, dtype=torch.int32),
+        step=0,
+        query_start_loc_np=(
+            None
+            if query_starts is None
+            else torch.tensor(query_starts, dtype=torch.int32).numpy()
+        ),
+    )["draft"]
+    assert metadata.num_actual_tokens == expected
+    assert metadata.num_reqs == num_reqs_padded
+    assert metadata.query_start_loc_cpu.tolist() == boundaries
+    assert metadata.query_start_loc.tolist() == boundaries
+    assert metadata.slot_mapping.numel() == 8
+    assert metadata.slot_mapping.data_ptr() == slots.data_ptr()
+
+
 def test_mm_support_configured_after_model_load(monkeypatch):
     target_model_config = object()
     draft_model_config = object()

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -228,93 +228,67 @@ def test_standalone_receives_resolved_layout_before_building_attention(monkeypat
     monkeypatch.setattr(AutoRegressiveSpeculator, "set_attn", build_attention)
     monkeypatch.setattr(draft_spec_module, "DefaultModelState", lambda *args: None)
     speculator.set_attn(None, None, block_tables, None, [])
-    speculator.set_attn(None, None, block_tables, None, [])
     assert draft_cache.cache_dtype == "bfloat16"
-    assert (
-        target_cache.get_resolved_kv_cache_layout()
-        == draft_cache.get_resolved_kv_cache_layout()
-    )
 
 
 @pytest.mark.parametrize(
-    ("speculator_cls", "backend", "threshold", "mode", "prefill_mode"),
+    ("backend", "threshold", "mode", "prefill_mode"),
     [
-        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "FULL_DECODE_ONLY", "NONE"),
-        (
-            StandaloneDraftModelSpeculator,
-            "FLASHINFER",
-            4,
-            "FULL_AND_PIECEWISE",
-            "PIECEWISE",
-        ),
-        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "FULL", "NONE"),
-        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "PIECEWISE", "PIECEWISE"),
-        (StandaloneDraftModelSpeculator, "FLASHINFER", 4, "NONE", "NONE"),
-        (
-            StandaloneDraftModelSpeculator,
-            "FLASHINFER",
-            5,
-            "FULL_DECODE_ONLY",
-            "FULL_DECODE_ONLY",
-        ),
-        (
-            StandaloneDraftModelSpeculator,
-            "FLASH_ATTN",
-            1,
-            "FULL_DECODE_ONLY",
-            "FULL_DECODE_ONLY",
-        ),
-        (_TestSpeculator, "FLASHINFER", 4, "FULL_DECODE_ONLY", "FULL_DECODE_ONLY"),
+        ("FLASHINFER", 4, "FULL_DECODE_ONLY", "NONE"),
+        ("FLASHINFER", 4, "FULL_AND_PIECEWISE", "PIECEWISE"),
+        ("FLASHINFER", 4, "FULL", "NONE"),
+        ("FLASHINFER", 4, "PIECEWISE", "PIECEWISE"),
+        ("FLASHINFER", 4, "NONE", "NONE"),
+        ("FLASHINFER", 5, "FULL_DECODE_ONLY", "FULL_DECODE_ONLY"),
+        ("FLASH_ATTN", 1, "FULL_DECODE_ONLY", "FULL_DECODE_ONLY"),
     ],
 )
 def test_prefill_graph_respects_backend_query_width(
-    monkeypatch, speculator_cls, backend, threshold, mode, prefill_mode
+    monkeypatch, backend, threshold, mode, prefill_mode
 ):
-    """Only the unsupported prefill FULL path falls back; q1 graphs survive."""
-    speculator = object.__new__(speculator_cls)
+    """Only unsupported standalone prefill falls back; q1 and shared AR survive."""
+    speculator = object.__new__(StandaloneDraftModelSpeculator)
     speculator.num_speculative_steps = 3
     speculator.device = torch.device("cpu")
-    speculator.vllm_config = object()
-    builder = SimpleNamespace(reorder_batch_threshold=threshold)
-    other_group = SimpleNamespace(
-        backend=SimpleNamespace(get_name=lambda: "FLASH_ATTN"),
-        get_metadata_builder=lambda: SimpleNamespace(reorder_batch_threshold=1),
+    speculator.vllm_config = None
+
+    def group(name):
+        return SimpleNamespace(
+            backend=SimpleNamespace(get_name=lambda: name),
+            get_metadata_builder=lambda: SimpleNamespace(
+                reorder_batch_threshold=threshold
+            ),
+        )
+
+    speculator.attn_groups = [[group("FLASH_ATTN")], [group(backend)]]
+    monkeypatch.setattr(
+        spec_module,
+        "SpeculatorCudaGraphManager",
+        lambda config, device, mode, decode_query_len: SimpleNamespace(
+            mode=mode, query_len=decode_query_len
+        ),
     )
-    speculator.attn_groups = [
-        [other_group],
-        [
-            SimpleNamespace(
-                backend=SimpleNamespace(get_name=lambda: backend),
-                get_metadata_builder=lambda: builder,
-            )
-        ],
-    ]
-
-    def manager(config, device, mode, decode_query_len):
-        return SimpleNamespace(mode=mode, query_len=decode_query_len)
-
-    monkeypatch.setattr(spec_module, "SpeculatorCudaGraphManager", manager)
     original_mode = CUDAGraphMode[mode]
     speculator.init_cudagraph_manager(original_mode)
     assert speculator.prefill_cudagraph_manager.mode == CUDAGraphMode[prefill_mode]
-    assert speculator.prefill_cudagraph_manager.query_len == (
-        4 + speculator.prefill_seq_len_offset
-    )
+    assert speculator.prefill_cudagraph_manager.query_len == 5
+    assert speculator.decode_cudagraph_manager.query_len == 1
     assert speculator.decode_cudagraph_manager.mode == (
         CUDAGraphMode.FULL_DECODE_ONLY
         if original_mode.decode_mode() == CUDAGraphMode.FULL
         else CUDAGraphMode.NONE
     )
-    assert speculator.decode_cudagraph_manager.query_len == 1
+    assert (
+        AutoRegressiveSpeculator.get_prefill_cudagraph_mode(speculator, original_mode)
+        == original_mode
+    )
 
 
 @pytest.mark.parametrize(
     ("query_starts", "num_reqs", "num_reqs_padded", "leading_padding", "expected"),
     [
-        pytest.param([0, 3, 6], 2, 2, 0, 6, id="six-queries-eight-model-tokens"),
         pytest.param([0, 5], 1, 1, 2, 5, id="leading-query-padding-counts"),
-        pytest.param([0, 2, 4, 6], 3, 4, 0, 6, id="padded-request-empty-query"),
-        pytest.param([0, 3, 6, 99], 2, 2, 0, 6, id="ignore-unused-boundary-tail"),
+        pytest.param([0, 2, 4, 6, 99], 3, 4, 0, 6, id="graph-padding-unused-tail"),
         pytest.param(None, 3, 4, 0, 8, id="uniform-path-keeps-padded-count"),
     ],
 )
@@ -561,24 +535,6 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "speculator_cls", [_TestSpeculator, StandaloneDraftModelSpeculator]
-)
-def test_run_model_only_passes_hidden_states_to_conditioned_drafters(
-    monkeypatch, speculator_cls
-):
-    speculator = _make_speculator(monkeypatch, torch.zeros(4, 3), speculator_cls)
-    speculator.model = Mock(return_value=torch.zeros(4, 3))
-
-    speculator._run_model(4, None, None, None)
-
-    kwargs = speculator.model.call_args.kwargs
-    if speculator_cls is StandaloneDraftModelSpeculator:
-        assert "hidden_states" not in kwargs
-    else:
-        assert torch.equal(kwargs["hidden_states"], speculator.hidden_states)
-
-
-@pytest.mark.parametrize(
     ("speculator_cls", "expected_positions"),
     [(_TestSpeculator, [2, 4]), (StandaloneDraftModelSpeculator, [1, 3])],
 )
@@ -593,9 +549,13 @@ def test_prefill_samples_from_the_position_consumed_by_each_drafter(
     speculator.current_draft_step = torch.tensor(0)
     speculator.temperature = speculator.seeds = speculator.draft_logits = None
     speculator.sample_draft = Mock(return_value=torch.tensor([5, 6]))
+    speculator.model = Mock(wraps=speculator.model)
 
     speculator._prefill(2, 4, None, None, None)
 
+    assert ("hidden_states" in speculator.model.call_args.kwargs) is (
+        speculator_cls is _TestSpeculator
+    )
     assert speculator.sample_draft.call_args.args[1].tolist() == expected_positions
     assert speculator.sample_src_positions.tolist() == expected_positions
     assert speculator.input_buffers.positions[:2].tolist() == [1, 3]

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2606,6 +2606,13 @@ class VllmConfig:
                     unsupported.append(
                         "standalone drafting with a shorter draft context"
                     )
+                if (
+                    speculative_config.enforce_eager is not None
+                    and speculative_config.enforce_eager != model_config.enforce_eager
+                ):
+                    unsupported.append(
+                        "standalone drafting with a different draft eager setting"
+                    )
             elif speculative_config.method not in (
                 "eagle",
                 "eagle3",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2574,6 +2574,38 @@ class VllmConfig:
             # TODO: ngram / ngram_gpu are not supported by the v2 model runner yet
             if speculative_config.method in ("ngram", "ngram_gpu"):
                 unsupported.append("ngram/ngram_gpu speculative decoding")
+            elif speculative_config.method == "draft_model":
+                parallel = self.parallel_config
+                draft_parallel = speculative_config.draft_parallel_config
+                if (
+                    parallel.tensor_parallel_size != 1
+                    or parallel.pipeline_parallel_size != 1
+                    or parallel.data_parallel_size != 1
+                    or parallel.decode_context_parallel_size != 1
+                    or parallel.prefill_context_parallel_size != 1
+                    or draft_parallel.tensor_parallel_size != 1
+                ):
+                    unsupported.append("distributed standalone drafting")
+                if speculative_config.use_heterogeneous_vocab:
+                    unsupported.append(
+                        "standalone drafting with heterogeneous vocabularies"
+                    )
+                draft_config = speculative_config.draft_model_config
+                if any(
+                    config.is_multimodal_model or config.is_hybrid or config.is_moe
+                    for config in (model_config, draft_config)
+                ):
+                    unsupported.append(
+                        "standalone drafting with multimodal, hybrid, or MoE models"
+                    )
+                if model_config.enable_prompt_embeds or self.lora_config:
+                    unsupported.append(
+                        "standalone drafting with prompt embeddings or LoRA"
+                    )
+                if draft_config.max_model_len < model_config.max_model_len:
+                    unsupported.append(
+                        "standalone drafting with a shorter draft context"
+                    )
             elif speculative_config.method not in (
                 "eagle",
                 "eagle3",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2578,14 +2578,14 @@ class VllmConfig:
                 parallel = self.parallel_config
                 draft_parallel = speculative_config.draft_parallel_config
                 if (
-                    parallel.tensor_parallel_size != 1
-                    or parallel.pipeline_parallel_size != 1
+                    parallel.pipeline_parallel_size != 1
                     or parallel.data_parallel_size != 1
                     or parallel.decode_context_parallel_size != 1
                     or parallel.prefill_context_parallel_size != 1
-                    or draft_parallel.tensor_parallel_size != 1
                 ):
                     unsupported.append("distributed standalone drafting")
+                if draft_parallel.tensor_parallel_size != parallel.tensor_parallel_size:
+                    unsupported.append("standalone drafting with different TP sizes")
                 if speculative_config.use_heterogeneous_vocab:
                     unsupported.append(
                         "standalone drafting with heterogeneous vocabularies"

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -80,6 +80,7 @@ def init_attn_backend(
     vllm_config: VllmConfig,
     device: torch.device,
     active_layer_names: set[str] | None = None,
+    kernel_block_sizes: list[int] | None = None,
 ) -> tuple[list[list[AttentionGroup]], AttentionCGSupportInfo, list[int]]:
     # Phase 1: discover attention groups for each kv cache group.
     attn_groups: list[list[AttentionGroup]] = []
@@ -126,9 +127,10 @@ def init_attn_backend(
 
         attn_groups.append([group_map[key] for key in group_order])
 
-    # Phase 2: pick a kernel block size per kv cache group that is supported
-    # by all backends within that group.
-    kernel_block_sizes = prepare_kernel_block_sizes(kv_cache_config, attn_groups)
+    # Phase 2: reuse the allocated cache's sizes, or select sizes supported
+    # by all backends within each group.
+    if kernel_block_sizes is None:
+        kernel_block_sizes = prepare_kernel_block_sizes(kv_cache_config, attn_groups)
 
     # Phase 3: create metadata builders and determine cudagraph support.
     attn_backend_workspace: torch.Tensor | None = None

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -8,7 +8,13 @@ from vllm.config import VllmConfig
 def init_speculator(vllm_config: VllmConfig, device: torch.device):
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
-    if speculative_config.method == "extract_hidden_states":
+    if speculative_config.method == "draft_model":
+        from vllm.v1.worker.gpu.spec_decode.draft_model.speculator import (
+            StandaloneDraftModelSpeculator,
+        )
+
+        return StandaloneDraftModelSpeculator(vllm_config, device)
+    elif speculative_config.method == "extract_hidden_states":
         from vllm.v1.worker.gpu.spec_decode.extract_hidden_states import (
             ExtractHiddenStatesSpeculator,
         )

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -178,12 +178,17 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 ", ".join(unsupported_backends),
             )
 
+    def get_prefill_cudagraph_mode(
+        self, cudagraph_mode: CUDAGraphMode
+    ) -> CUDAGraphMode:
+        return cudagraph_mode
+
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         # Initialize cudagraph manager for draft prefill (draft position 0).
         self.prefill_cudagraph_manager = SpeculatorCudaGraphManager(
             self.vllm_config,
             self.device,
-            cudagraph_mode,
+            self.get_prefill_cudagraph_mode(cudagraph_mode),
             self.num_speculative_steps + 1 + self.prefill_seq_len_offset,
         )
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -27,6 +27,11 @@ logger = init_logger(__name__)
 
 
 class AutoRegressiveSpeculator(DraftModelSpeculator):
+    reuse_target_attn_metadata = True
+    pass_hidden_states_to_model = True
+    prefill_sample_position_offset = 1
+    prefill_seq_len_offset = 0
+
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
 
@@ -70,6 +75,55 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
     def on_multi_step_decode_begin(self, num_reqs: int) -> None: ...
 
     def on_multi_step_decode_end(self, num_reqs: int) -> None: ...
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        last_hidden_states: torch.Tensor,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        dummy_run: bool = False,
+    ) -> InputBatch:
+        if aux_hidden_states:
+            assert self.method == "eagle3"
+            hidden_states = self.model.combine_hidden_states(
+                torch.cat(aux_hidden_states, dim=-1)
+            )
+        else:
+            hidden_states = last_hidden_states
+        self.hidden_states[: input_batch.num_tokens_after_padding].copy_(hidden_states)
+        prepare_prefill_inputs(
+            self.last_token_indices,
+            self.current_draft_step,
+            self.input_buffers,
+            input_batch,
+            num_sampled,
+            num_rejected,
+            last_sampled,
+            next_prefill_tokens,
+            self.max_num_reqs,
+        )
+        return input_batch
+
+    def prepare_attn(
+        self,
+        input_batch: InputBatch,
+        batch_desc: BatchExecutionDescriptor,
+    ) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor]]:
+        raise NotImplementedError
+
+    def compute_decode_slot_mappings(
+        self, num_reqs: int, num_tokens: int
+    ) -> torch.Tensor:
+        return self.block_tables.compute_slot_mappings(
+            self.idx_mapping[:num_reqs],
+            self.input_buffers.query_start_loc[: num_reqs + 1],
+            self.input_buffers.positions[:num_reqs],
+            num_tokens,
+        )
 
     @property
     def advance_draft_positions(self) -> bool:
@@ -130,7 +184,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.vllm_config,
             self.device,
             cudagraph_mode,
-            self.num_speculative_steps + 1,
+            self.num_speculative_steps + 1 + self.prefill_seq_len_offset,
         )
 
         # PIECEWISE cudagraphs are not supported for draft decodes.
@@ -170,9 +224,13 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         self.prefill_cudagraph_manager.capture(
             self._prefill,
             self.model_state,
-            self.target_input_buffers,
+            self.target_input_buffers
+            if self.reuse_target_attn_metadata
+            else self.input_buffers,
             self.block_tables,
-            self.target_attn_groups,
+            self.target_attn_groups
+            if self.reuse_target_attn_metadata
+            else self.attn_groups,
             self.kv_cache_config,
             progress_bar_desc="Capturing prefill CUDA graphs",
         )
@@ -204,7 +262,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
     def propose(
         self,
         input_batch: InputBatch,
-        attn_metadata: dict[str, Any],
+        attn_metadata: dict[str, Any] | None,
         slot_mappings: dict[str, torch.Tensor],
         # [num_tokens, hidden_size]
         last_hidden_states: torch.Tensor,
@@ -228,29 +286,25 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
     ) -> torch.Tensor:
-        num_tokens = input_batch.num_tokens
-        num_tokens_padded = input_batch.num_tokens_after_padding
+        prefill_input_batch = self.prepare_inputs(
+            input_batch,
+            last_hidden_states,
+            aux_hidden_states,
+            num_sampled,
+            num_rejected,
+            last_sampled,
+            next_prefill_tokens,
+            dummy_run=dummy_run,
+        )
+        num_tokens = prefill_input_batch.num_tokens
+        num_tokens_padded = prefill_input_batch.num_tokens_after_padding
         num_reqs = input_batch.num_reqs
-        max_query_len = input_batch.num_scheduled_tokens.max()
+        max_query_len = prefill_input_batch.num_scheduled_tokens.max()
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
         self.draft_max_seq_len = min(
-            max_seq_len + self.num_speculative_steps, self.max_model_len
+            max_seq_len + self.num_speculative_steps + self.prefill_seq_len_offset,
+            self.max_model_len,
         )
-
-        # NOTE(woosuk): To avoid CPU-GPU synchronization without CPU knowing the
-        # number of rejected tokens, we maintain the size of input_ids and
-        # hidden_states the same as the target model's. This means, we pad each
-        # request's query length to include any rejected positions. By doing so,
-        # we can also reuse the attention metadata (e.g., query_start_loc,
-        # seq_lens) of the target model.
-        if aux_hidden_states:
-            assert self.method == "eagle3"
-            hidden_states = self.model.combine_hidden_states(
-                torch.cat(aux_hidden_states, dim=-1)
-            )
-        else:
-            hidden_states = last_hidden_states
-        self.hidden_states[:num_tokens_padded].copy_(hidden_states)
 
         self._copy_request_inputs(
             num_reqs,
@@ -259,21 +313,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             seeds,
         )
 
-        # Get the input ids and last token indices for the speculator.
-        prepare_prefill_inputs(
-            self.last_token_indices,
-            self.current_draft_step,
-            self.input_buffers,
-            input_batch,
-            num_sampled,
-            num_rejected,
-            last_sampled,
-            next_prefill_tokens,
-            self.max_num_reqs,
-        )
-
-        # When all requests are decoding (no true prefills), each has
-        # num_speculative_steps + 1 tokens, enabling FULL graph replay.
+        # Uniform decode-only batches can replay a FULL prefill graph.
         uniform_token_count = get_uniform_decode_token_count(
             num_reqs,
             # Use the actual number of tokens without padding added by
@@ -300,15 +340,19 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         self._prepare_eplb_forward(num_tokens)
 
+        if not self.reuse_target_attn_metadata and not (
+            dummy_run and skip_attn_for_dummy_run
+        ):
+            attn_metadata, slot_mappings = self.prepare_attn(
+                prefill_input_batch, prefill_batch_desc
+            )
+
         self.on_prefill_begin(num_reqs)
         if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
             # Replay the full graph for draft prefill.
             assert self.prefill_cudagraph_manager is not None
             self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
         else:
-            # The target model's attention metadata and slot mappings
-            # can directly be used for draft prefill, because of the
-            # identical batch shape and KV cache layout.
             self._prefill(
                 num_reqs,
                 prefill_batch_desc.num_tokens,
@@ -334,6 +378,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.max_model_len,
             self.max_num_reqs,
             advance_draft_positions=self.advance_draft_positions,
+            seq_len_offset=self.prefill_seq_len_offset,
         )
 
         decode_batch_sync, num_batch_tokens = (
@@ -371,7 +416,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             dummy_run and skip_attn_for_dummy_run,
             decode_batch_desc,
             num_tokens_across_dp,
-            input_batch.seq_lens_cpu_upper_bound,
+            prefill_input_batch.seq_lens_cpu_upper_bound,
         )
         self.on_multi_step_decode_end(num_reqs)
 
@@ -415,9 +460,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             model_inputs = dict(
                 input_ids=self.input_buffers.input_ids[:num_tokens],
                 positions=self.input_buffers.positions[:num_tokens],
-                hidden_states=self.hidden_states[:num_tokens],
                 inputs_embeds=inputs_embeds,
             )
+            if self.pass_hidden_states_to_model:
+                model_inputs["hidden_states"] = self.hidden_states[:num_tokens]
             if cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE:
                 # Draft prefill with PIECEWISE cudagraph (compiled PW or breakable),
                 # chosen inside run_pw_graph.
@@ -449,10 +495,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
     ) -> None:
         last_token_indices = self.last_token_indices[:num_reqs]
         positions = self.input_buffers.positions[last_token_indices]
-        # The output hidden state at position P (= positions) and the token id
-        # at P+1 are used to draft the token at P+2. Sampling keys a draw by the
-        # position before the sampled token, so the net adjustment is +1.
-        sample_src_positions = positions + 1
+        # EAGLE/MTP pair hidden state P with token P+1; standalone models
+        # consume token P at its own position.
+        sample_src_positions = positions + self.prefill_sample_position_offset
         idx_mapping = self.idx_mapping[:num_reqs]
 
         last_hidden_states, hidden_states = self._run_model(
@@ -489,20 +534,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         seq_lens_cpu_upper_bound: torch.Tensor,
     ) -> None:
-        positions = self.input_buffers.positions[:num_reqs]
-        query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
-        idx_mapping = self.idx_mapping[:num_reqs]
-
         attn_metadata = None
         slot_mappings_by_layer = None
         for step in range(1, self.num_speculative_steps):
             # Rebuild every step when positions advance, or just once
             # on the first step when positions are constant (Gemma4 MTP).
             if not skip_attn and (self.advance_draft_positions or step == 1):
-                slot_mappings = self.block_tables.compute_slot_mappings(
-                    idx_mapping,
-                    query_start_loc,
-                    positions,
+                slot_mappings = self.compute_decode_slot_mappings(
+                    num_reqs,
                     batch_desc.num_tokens,
                 )
                 slot_mappings_by_layer = build_slot_mappings_by_layer(
@@ -539,17 +578,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         seq_lens_cpu_upper_bound: torch.Tensor,
     ) -> None:
-        positions = self.input_buffers.positions[:num_reqs]
-        query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
-        idx_mapping = self.idx_mapping[:num_reqs]
-
         attn_metadata = None
         slot_mappings_by_layer = None
         if not skip_attn:
-            slot_mappings = self.block_tables.compute_slot_mappings(
-                idx_mapping,
-                query_start_loc,
-                positions,
+            slot_mappings = self.compute_decode_slot_mappings(
+                num_reqs,
                 batch_desc.num_tokens,
             )
             if batch_desc.cg_mode != CUDAGraphMode.FULL:
@@ -587,9 +620,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     ) -> None:
-        idx_mapping = self.idx_mapping[:num_reqs]
-        positions = self.input_buffers.positions[:num_reqs]
-        query_start_loc = self.input_buffers.query_start_loc[: num_reqs + 1]
         attn_groups = (
             [group for groups in self.attn_groups for group in groups]
             if attn_metadata is not None
@@ -611,10 +641,8 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 and attn_metadata is not None
                 and self.advance_draft_positions
             ):
-                self.block_tables.compute_slot_mappings(
-                    idx_mapping,
-                    query_start_loc,
-                    positions,
+                self.compute_decode_slot_mappings(
+                    num_reqs,
                     num_tokens_padded,
                 )
                 for attn_group in attn_groups:
@@ -807,6 +835,7 @@ def _prepare_decode_inputs_kernel(
     max_num_reqs,
     BLOCK_SIZE: tl.constexpr,
     ADVANCE_DRAFT_POSITIONS: tl.constexpr,
+    SEQ_LEN_OFFSET: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     num_reqs = tl.num_programs(0) - 1
@@ -835,7 +864,7 @@ def _prepare_decode_inputs_kernel(
 
     target_seq_len = tl.load(target_seq_lens_ptr + req_idx)
     num_rejected = tl.load(num_rejected_ptr + req_idx)
-    seq_len = target_seq_len - num_rejected
+    seq_len = target_seq_len - num_rejected + SEQ_LEN_OFFSET
     if ADVANCE_DRAFT_POSITIONS:
         # Compute position and seq_lens.
         # NOTE(woosuk): To prevent out-of-range access, we clamp these values
@@ -856,6 +885,7 @@ def prepare_decode_inputs(
     max_model_len: int,
     max_num_reqs: int,
     advance_draft_positions: bool = True,
+    seq_len_offset: int = 0,
 ):
     num_reqs = draft_tokens.shape[0]
     _prepare_decode_inputs_kernel[(num_reqs + 1,)](
@@ -872,6 +902,7 @@ def prepare_decode_inputs(
         max_num_reqs,
         BLOCK_SIZE=1024,
         ADVANCE_DRAFT_POSITIONS=advance_draft_positions,
+        SEQ_LEN_OFFSET=seq_len_offset,
     )
 
 

--- a/vllm/v1/worker/gpu/spec_decode/draft_model/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/draft_model/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/worker/gpu/spec_decode/draft_model/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/draft_model/speculator.py
@@ -9,9 +9,10 @@ import torch
 import torch.nn as nn
 
 from vllm.config import VllmConfig, replace
+from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.model_loader import get_model
 from vllm.triton_utils import tl, triton
-from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID, record_kv_cache_layout
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
@@ -86,6 +87,11 @@ class StandaloneDraftModelSpeculator(AutoRegressiveSpeculator):
         target_input_buffers: InputBuffers,
         target_attn_groups: list[list[AttentionGroup]],
     ) -> None:
+        # The engine resolves the target layout after the draft config is copied.
+        record_kv_cache_layout(
+            self.draft_vllm_config.cache_config,
+            self.vllm_config.cache_config.get_resolved_kv_cache_layout().name,
+        )
         super().set_attn(
             model_state,
             kv_cache_config,
@@ -106,6 +112,27 @@ class StandaloneDraftModelSpeculator(AutoRegressiveSpeculator):
         self.model_state = DefaultModelState(
             self.draft_vllm_config, self.model, None, self.device
         )
+
+    def get_prefill_cudagraph_mode(
+        self, cudagraph_mode: CUDAGraphMode
+    ) -> CUDAGraphMode:
+        if not cudagraph_mode.has_full_cudagraphs():
+            return cudagraph_mode
+        query_len = self.num_speculative_steps + 1 + self.prefill_seq_len_offset
+        for groups in self.attn_groups:
+            for group in groups:
+                if group.backend.get_name() != "FLASHINFER":
+                    continue
+                threshold = group.get_metadata_builder().reorder_batch_threshold
+                if threshold is not None and query_len > threshold:
+                    # FlashInfer's uniform graph support covers its decode path,
+                    # but the extra standalone row routes this batch to prefill.
+                    return (
+                        CUDAGraphMode.PIECEWISE
+                        if cudagraph_mode.has_piecewise_cudagraphs()
+                        else CUDAGraphMode.NONE
+                    )
+        return cudagraph_mode
 
     def prepare_inputs(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/draft_model/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/draft_model/speculator.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from copy import copy
+from dataclasses import replace as dataclass_replace
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig, replace
+from vllm.model_executor.model_loader import get_model
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
+from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+from vllm.v1.worker.gpu.model_states.default import DefaultModelState
+from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
+    AutoRegressiveSpeculator,
+)
+from vllm.v1.worker.utils import AttentionGroup
+
+
+class StandaloneDraftModelSpeculator(AutoRegressiveSpeculator):
+    reuse_target_attn_metadata = False
+    pass_hidden_states_to_model = False
+    prefill_sample_position_offset = 0
+    prefill_seq_len_offset = 1
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        super().__init__(vllm_config, device)
+        spec = self.speculative_config
+        parallel = vllm_config.parallel_config
+        unsupported = vllm_config._get_v2_model_runner_unsupported_features()
+        if unsupported:
+            raise ValueError(f"V2 standalone drafting does not support {unsupported}")
+        spec.verify_equal_vocab_size_if_draft_model()
+        self.is_dummy_run = torch.zeros((), dtype=torch.bool, device=device)
+
+        self.draft_vllm_config = replace(
+            vllm_config,
+            model_config=self.draft_model_config,
+            quant_config=None,
+            parallel_config=replace(spec.draft_parallel_config, rank=parallel.rank),
+            compilation_config=copy(vllm_config.compilation_config),
+            scheduler_config=replace(
+                vllm_config.scheduler_config,
+                max_num_batched_tokens=self.max_num_tokens,
+                max_model_len=self.draft_model_config.max_model_len,
+                is_encoder_decoder=self.draft_model_config.is_encoder_decoder,
+            ),
+            attention_config=replace(
+                vllm_config.attention_config, backend=spec.attention_backend
+            ),
+            cache_config=replace(
+                vllm_config.cache_config,
+                cache_dtype=spec.kv_cache_dtype or vllm_config.cache_config.cache_dtype,
+            ),
+        )
+
+    @property
+    def attn_vllm_config(self) -> VllmConfig:
+        return self.draft_vllm_config
+
+    def load_draft_model(
+        self, target_model: nn.Module, target_attn_layer_names: set[str]
+    ) -> nn.Module:
+        from vllm.compilation.backends import set_model_tag
+
+        with set_model_tag("draft_model"):
+            return get_model(
+                vllm_config=self.draft_vllm_config,
+                prefix="draft_model",
+                load_config=self.speculative_config.draft_load_config,
+            )
+
+    def set_attn(
+        self,
+        model_state: ModelState,
+        kv_cache_config: KVCacheConfig,
+        block_tables: BlockTables,
+        target_input_buffers: InputBuffers,
+        target_attn_groups: list[list[AttentionGroup]],
+    ) -> None:
+        super().set_attn(
+            model_state,
+            kv_cache_config,
+            block_tables,
+            target_input_buffers,
+            target_attn_groups,
+        )
+        # Share the scheduler's block tables, but use an expanded, persistent
+        # slot buffer for both graph capture and replay.
+        self.block_tables = copy(block_tables)
+        self.block_tables.max_num_batched_tokens = self.max_num_tokens
+        self.block_tables.slot_mappings = torch.full(
+            (block_tables.num_kv_cache_groups, self.max_num_tokens),
+            PAD_SLOT_ID,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.model_state = DefaultModelState(
+            self.draft_vllm_config, self.model, None, self.device
+        )
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        last_hidden_states: torch.Tensor,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        dummy_run: bool = False,
+    ) -> InputBatch:
+        self.is_dummy_run.fill_(dummy_run)
+        prepare_draft_model_prefill_inputs(
+            self.last_token_indices,
+            self.current_draft_step,
+            self.input_buffers,
+            input_batch,
+            num_sampled,
+            num_rejected,
+            last_sampled,
+            next_prefill_tokens,
+            self.max_num_reqs,
+            self.max_model_len,
+        )
+        num_reqs = input_batch.num_reqs
+        num_tokens = input_batch.num_tokens + num_reqs
+        query_start_loc_np = input_batch.query_start_loc_np[: num_reqs + 1] + np.arange(
+            num_reqs + 1, dtype=np.int32
+        )
+        return dataclass_replace(
+            input_batch,
+            num_tokens=num_tokens,
+            num_tokens_after_padding=num_tokens,
+            num_scheduled_tokens=input_batch.num_scheduled_tokens + 1,
+            input_ids=self.input_buffers.input_ids[:num_tokens],
+            positions=self.input_buffers.positions[:num_tokens],
+            is_padding=self.input_buffers.is_padding[:num_tokens],
+            query_start_loc=self.input_buffers.query_start_loc[: num_reqs + 1],
+            query_start_loc_np=query_start_loc_np,
+            seq_lens=self.input_buffers.seq_lens[:num_reqs],
+            seq_lens_cpu_upper_bound=(input_batch.seq_lens_cpu_upper_bound + 1).clamp(
+                max=self.max_model_len
+            ),
+        )
+
+    def prepare_attn(
+        self, input_batch: InputBatch, batch_desc: BatchExecutionDescriptor
+    ) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor]]:
+        self.block_tables.gather_block_tables(
+            self.idx_mapping[: input_batch.num_reqs], self.max_num_reqs
+        )
+        slot_mappings = self.block_tables.compute_slot_mappings(
+            self.idx_mapping[: input_batch.num_reqs],
+            self.input_buffers.query_start_loc[: input_batch.num_reqs + 1],
+            self.input_buffers.positions,
+            batch_desc.num_tokens,
+        )
+        slot_mappings.masked_fill_(
+            self.input_buffers.is_padding[None, : batch_desc.num_tokens]
+            | self.is_dummy_run,
+            PAD_SLOT_ID,
+        )
+        attn_metadata = self._build_draft_attn_metadata(
+            num_reqs=input_batch.num_reqs,
+            num_reqs_padded=batch_desc.num_reqs or input_batch.num_reqs,
+            num_tokens_padded=batch_desc.num_tokens,
+            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+            step=0,
+            query_start_loc_np=input_batch.query_start_loc_np,
+        )
+        return attn_metadata, build_slot_mappings_by_layer(
+            slot_mappings, self.kv_cache_config
+        )
+
+    def compute_decode_slot_mappings(
+        self, num_reqs: int, num_tokens: int
+    ) -> torch.Tensor:
+        slot_mappings = super().compute_decode_slot_mappings(num_reqs, num_tokens)
+        # Positions clamp at the context limit, but these draws are discarded.
+        # Keep their KV writes from replacing the last valid cached token.
+        slot_mappings.masked_fill_(
+            (self.sample_src_positions[None, :num_tokens] >= self.max_model_len)
+            | self.is_dummy_run,
+            PAD_SLOT_ID,
+        )
+        return slot_mappings
+
+
+@triton.jit
+def _prepare_draft_model_prefill_inputs_kernel(
+    last_token_indices_ptr,
+    current_step_ptr,
+    draft_input_ids_ptr,
+    draft_positions_ptr,
+    draft_is_padding_ptr,
+    draft_query_start_loc_ptr,
+    draft_seq_lens_ptr,
+    target_input_ids_ptr,
+    target_positions_ptr,
+    target_query_start_loc_ptr,
+    target_seq_lens_ptr,
+    idx_mapping_ptr,
+    num_sampled_ptr,
+    num_rejected_ptr,
+    last_sampled_ptr,
+    next_prefill_tokens_ptr,
+    max_num_reqs: tl.constexpr,
+    max_num_tokens: tl.constexpr,
+    max_model_len: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    num_reqs = tl.num_programs(0) - 1
+    if req_idx == num_reqs:
+        end = tl.load(target_query_start_loc_ptr + num_reqs) + num_reqs
+        for i in range(end, max_num_tokens, BLOCK_SIZE):
+            idx = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(draft_input_ids_ptr + idx, 0, idx < max_num_tokens)
+            tl.store(draft_positions_ptr + idx, 0, idx < max_num_tokens)
+            tl.store(draft_is_padding_ptr + idx, True, idx < max_num_tokens)
+        for i in range(num_reqs, max_num_reqs + 1, BLOCK_SIZE):
+            idx = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(draft_query_start_loc_ptr + idx, end, idx <= max_num_reqs)
+            tl.store(draft_seq_lens_ptr + idx, 0, idx < max_num_reqs)
+            tl.store(last_token_indices_ptr + idx, 0, idx < max_num_reqs)
+        tl.store(current_step_ptr, 0)
+        return
+
+    start = tl.load(target_query_start_loc_ptr + req_idx)
+    end = tl.load(target_query_start_loc_ptr + req_idx + 1)
+    query_len = end - start
+    rejected = tl.load(num_rejected_ptr + req_idx)
+    accepted = query_len - rejected
+    seq_len = tl.load(target_seq_lens_ptr + req_idx) - rejected
+    append = seq_len < max_model_len
+    valid_len = accepted + append.to(tl.int32)
+    # Right alignment preserves causal positions while keeping CPU-visible
+    # query lengths independent of the device's rejection counts.
+    pad = query_len + 1 - valid_len
+    draft_start = start + req_idx
+    state_idx = tl.load(idx_mapping_ptr + req_idx)
+    sampled = tl.load(num_sampled_ptr + req_idx)
+    if sampled > 0:
+        next_token = tl.load(last_sampled_ptr + state_idx).to(tl.int32)
+    else:
+        next_token = tl.load(next_prefill_tokens_ptr + state_idx).to(tl.int32)
+
+    for i in range(0, query_len + 1, BLOCK_SIZE):
+        idx = i + tl.arange(0, BLOCK_SIZE)
+        src_idx = idx - pad
+        is_target = (src_idx >= 0) & (src_idx < accepted)
+        token = tl.load(target_input_ids_ptr + start + src_idx, is_target, other=0)
+        position = tl.load(target_positions_ptr + start + src_idx, is_target, other=0)
+        is_bonus = append & (src_idx == accepted)
+        token = tl.where(is_bonus, next_token, token)
+        position = tl.where(is_bonus, seq_len, position)
+        is_padding = ~(is_target | is_bonus)
+        tl.store(draft_input_ids_ptr + draft_start + idx, token, idx <= query_len)
+        tl.store(draft_positions_ptr + draft_start + idx, position, idx <= query_len)
+        tl.store(draft_is_padding_ptr + draft_start + idx, is_padding, idx <= query_len)
+    tl.store(draft_query_start_loc_ptr + req_idx, draft_start)
+    tl.store(draft_seq_lens_ptr + req_idx, tl.minimum(seq_len + 1, max_model_len))
+    tl.store(last_token_indices_ptr + req_idx, end + req_idx)
+
+
+def prepare_draft_model_prefill_inputs(
+    last_token_indices: torch.Tensor,
+    current_draft_step: torch.Tensor,
+    input_buffers: InputBuffers,
+    input_batch: InputBatch,
+    num_sampled: torch.Tensor,
+    num_rejected: torch.Tensor,
+    last_sampled: torch.Tensor,
+    next_prefill_tokens: torch.Tensor,
+    max_num_reqs: int,
+    max_model_len: int,
+) -> None:
+    _prepare_draft_model_prefill_inputs_kernel[(input_batch.num_reqs + 1,)](
+        last_token_indices,
+        current_draft_step,
+        input_buffers.input_ids,
+        input_buffers.positions,
+        input_buffers.is_padding,
+        input_buffers.query_start_loc,
+        input_buffers.seq_lens,
+        input_batch.input_ids,
+        input_batch.positions,
+        input_batch.query_start_loc,
+        input_batch.seq_lens,
+        input_batch.idx_mapping,
+        num_sampled,
+        num_rejected,
+        last_sampled,
+        next_prefill_tokens,
+        max_num_reqs,
+        input_buffers.max_num_tokens,
+        max_model_len,
+        BLOCK_SIZE=1024,
+    )

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -265,6 +265,7 @@ class DraftModelSpeculator(BaseSpeculator):
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
+        num_actual_tokens = num_tokens_padded
         if query_start_loc_np is not None:
             # Non-uniform query layout (e.g. multi-module MTP's mixed
             # prefill/decode queries); num_query_per_req is ignored.
@@ -273,6 +274,7 @@ class DraftModelSpeculator(BaseSpeculator):
                 query_start_loc_np[: num_reqs + 1]
             )
             query_start_loc_cpu[num_reqs:] = query_start_loc_cpu[num_reqs]
+            num_actual_tokens = int(query_start_loc_np[num_reqs])
             max_query_len = int(
                 (query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]).max()
             )
@@ -313,7 +315,7 @@ class DraftModelSpeculator(BaseSpeculator):
         attn_metadata = build_attn_metadata(
             attn_groups=self.attn_groups,
             num_reqs=num_reqs_padded,
-            num_tokens=num_tokens_padded,
+            num_tokens=num_actual_tokens,
             query_start_loc_gpu=self.input_buffers.query_start_loc[
                 : num_reqs_padded + 1
             ],

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -99,6 +99,9 @@ class DraftModelSpeculator(BaseSpeculator):
         self.scheduler_config = vllm_config.scheduler_config
         self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        if self.method == "draft_model":
+            # Standalone prefill consumes the target's new token as well.
+            self.max_num_tokens += self.max_num_reqs
         self.max_model_len = vllm_config.model_config.max_model_len
         self.draft_max_seq_len = self.max_model_len
         # We need to get the hidden size from the draft model config because
@@ -112,7 +115,7 @@ class DraftModelSpeculator(BaseSpeculator):
         # that hook rather than hc_mult alone -- HY V4 runs iHC in its backbone
         # (hc_mult=4) but its MTP head consumes the collapsed states, so
         # widening it feeds propose() a 4x-too-wide buffer.
-        if _target_feeds_hc_residual(vllm_config):
+        if self.method != "draft_model" and _target_feeds_hc_residual(vllm_config):
             hc_mult = getattr(self.draft_model_config.hf_config, "hc_mult", 1)
             self.hidden_size = self.hidden_size * hc_mult
         self.vocab_size = self.draft_model_config.get_vocab_size()

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -243,6 +243,7 @@ class DraftModelSpeculator(BaseSpeculator):
             self.attn_vllm_config,
             self.device,
             active_layer_names=self.draft_attn_layer_names,
+            kernel_block_sizes=block_tables.kernel_block_sizes,
         )
         self.block_tables = block_tables
         # The target model runner's buffers and attention groups. Draft


### PR DESCRIPTION
## Purpose

Enable `method="draft_model"` in Model Runner V2 by reusing `AutoRegressiveSpeculator` for sampling, multi-step generation and CUDA graphs.

- Load and run the draft model independently, with its own token inputs and attention metadata.
- Handle rejection, KV-cache writes and graph padding while preserving existing EAGLE/MTP behavior.
- Support equal target/draft TP, including two-GPU execution.

This follows the shared-AR approach requested in the review of [wxsIcey's #43091](https://github.com/vllm-project/vllm/pull/43091), which implements the feature with a separate execution loop.

## Test Plan

```bash
# 1. Focused regression tests
.venv/bin/python -m pytest -o addopts= \
  tests/v1/worker/test_gpu_autoregressive_speculator.py \
  tests/v1/worker/test_attn_utils.py tests/config/test_config_generation.py \
  -k 'not test_config_generation or standalone' -q

# 2. TP2: eager/graph x greedy/probabilistic drafting
.venv/bin/python -m pytest \
  tests/v1/e2e/spec_decode/draft_model/test_draft_model.py::test_draft_model_v2_tensor_parallelism -v -s

# 3. Model evaluation: TP1 (one visible GPU), then TP2 (two GPUs)
CUDA_VISIBLE_DEVICES=0 VLLM_USE_V2_MODEL_RUNNER=1 .venv/bin/python -m pytest \
  tests/v1/e2e/spec_decode/draft_model/test_draft_model.py::test_draft_model_correctness -v -s
VLLM_USE_V2_MODEL_RUNNER=1 .venv/bin/python -m pytest \
  tests/v1/e2e/spec_decode/draft_model/test_draft_model.py::test_draft_model_tensor_parallelism -v -s
```

## Test Result

### Draft generation and output checks

RTX 5090, Qwen3-1.7B/0.6B, BF16, TP1, K3; 9 requests / 288 output tokens per run.

| Test | Result |
| --- | --- |
| Input layout, padding and configuration checks (CPU) | 37 passed |
| FlashInfer eager / FULL / PIECEWISE | All 9 requests completed in each mode |
| FlashAttention2 FULL | All 9 requests completed with draft prefill graph replay |

### Two-GPU execution and model quality

On 2x RTX 3090, both models used TP2 and generated accepted draft tokens in all four eager/graph x greedy/probabilistic cases.

GSM8K: 1,319 questions, 5-shot, greedy, 256 output tokens. Acceptance uses 200 separate chat prompts.

| Target / draft | Configuration | GSM8K accuracy | Acceptance |
| --- | --- | ---: | ---: |
| Qwen3-0.6B / 0.6B | TP1 eager / graph | 38.6% / 40.0% | 100% / 99% |
| Qwen3-1.7B / 0.6B | TP1 eager / graph | 67.2% / 66.4% | 91% / 91% |
| Qwen3-1.7B / 0.6B | TP2 graph | 66.6% | 92% |

### Offline performance

Qwen3-1.7B/0.6B, TP1, TRITON_ATTN; natural chat prompts, 128 output tokens, 4 GiB KV, two warmups and five repeats. Median output tokens/s:

| Mode / batch | V2 target-only | V1 standalone | V2 standalone | V2 / V1 |
| --- | ---: | ---: | ---: | ---: |
| eager / 1 | 46.84 | 37.95 | 37.72 | 0.991 |
| eager / 16 | 682.39 | 505.93 | 513.31 | 1.009 |
| graph / 1 | 171.62 | 108.00 | 274.36 | 2.540 |
| graph / 16 | 2065.95 | 1305.23 | 2893.08 | 2.234 |