### PR TITLE
[ROCm][AITER] Skip AITER norm kernels when flattening to 2D would copy

### DIFF
--- a/tests/kernels/ir/test_aiter_norm_dispatch.py
+++ b/tests/kernels/ir/test_aiter_norm_dispatch.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the AITER norm support predicates.
+
+The AITER norm wrappers flatten >2-D activations with ``Tensor.reshape``, which
+silently copies when the flattened shape is not expressible with the input's
+strides. The support predicates must reject those inputs so dispatch falls
+through to a provider that handles arbitrary strides.
+"""
+
+import pytest
+import torch
+
+from vllm.kernels.aiter_ops import flatten_to_2d_is_free
+
+
+def _qkv_slice_by_head(num_tokens, num_q_heads, num_kv_heads, head_dim):
+    """q viewed per-head from a fused QKV projection, as Qwen3-style QK-norm does."""
+    q_size, kv_size = num_q_heads * head_dim, num_kv_heads * head_dim
+    qkv = torch.empty(num_tokens, q_size + 2 * kv_size)
+    q = qkv.split([q_size, kv_size, kv_size], dim=-1)[0]
+    return q.view(*q.shape[:-1], num_q_heads, head_dim)
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        torch.empty(8, 16),
+        torch.empty(16),
+        torch.empty(2, 4, 16),
+        torch.empty(2, 1, 16),
+        # A contiguous tensor stays flattenable after a leading-dim slice.
+        torch.empty(8, 4, 16)[2:6],
+    ],
+)
+def test_flattenable(x):
+    assert flatten_to_2d_is_free(x)
+    assert x.reshape(-1, x.shape[-1]).data_ptr() == x.data_ptr()
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        _qkv_slice_by_head(8, 32, 8, 128),
+        # Non-unit last-dim stride.
+        torch.empty(4, 8, 32).transpose(-1, -2),
+        # Leading dims cannot be merged: a slice along the middle dim.
+        torch.empty(4, 8, 32)[:, :4],
+    ],
+)
+def test_not_flattenable(x):
+    assert not flatten_to_2d_is_free(x)
+    # reshape has to copy, which is exactly what the predicate guards against.
+    assert x.reshape(-1, x.shape[-1]).data_ptr() != x.data_ptr()

--- a/tests/kernels/ir/test_aiter_norm_dispatch.py
+++ b/tests/kernels/ir/test_aiter_norm_dispatch.py
@@ -11,7 +11,13 @@ through to a provider that handles arbitrary strides.
 import pytest
 import torch
 
+from vllm._aiter_ops import is_aiter_found_and_supported
 from vllm.kernels.aiter_ops import flatten_to_2d_is_free
+
+pytestmark = pytest.mark.skipif(
+    not is_aiter_found_and_supported(),
+    reason="Only test on ROCm with AITER installed and supported",
+)
 
 
 def _qkv_slice_by_head(num_tokens, num_q_heads, num_kv_heads, head_dim):

--- a/vllm/kernels/aiter_ops.py
+++ b/vllm/kernels/aiter_ops.py
@@ -34,13 +34,38 @@ direct_register_aiter_op = functools.partial(
 AITER_SUPPORTED = is_aiter_found()
 """Most kernels in this file are supported if AITER is installed."""
 
+
+def flatten_to_2d_is_free(x: Tensor) -> bool:
+    """Whether ``x.reshape(-1, x.shape[-1])`` is a view with unit-stride rows.
+
+    The AITER norm kernels only take dense 2D inputs, so the wrappers below
+    flatten the leading dims with ``Tensor.reshape``, which silently falls back
+    to ``contiguous()`` when the flattened shape is not expressible with the
+    existing strides, adding a whole-tensor device copy that costs more than
+    the kernel saves. A strided last dim flattens without a copy but not into a
+    dense buffer, so it is rejected too.
+    """
+    if x.dim() <= 2:
+        return True
+    if x.stride(-1) != 1:
+        return False
+    expected_stride = x.size(-1)
+    for i in range(x.dim() - 2, -1, -1):
+        if x.size(i) != 1 and x.stride(i) != expected_stride:
+            return False
+        expected_stride *= x.size(i)
+    return True
+
+
 rms_no_var_16bit_only = (
     lambda x, weight, epsilon, variance_size=None: variance_size is None
     and x.dtype in (torch.float16, torch.bfloat16)
     and (weight is None or weight.dtype == x.dtype)
+    and flatten_to_2d_is_free(x)
 )
 """AITER rms_norm only supports float16 and bfloat16 acts, no var_size override,
-and requires weight dtype to match x dtype."""
+requires weight dtype to match x dtype, and requires flattening the activation
+to 2D to be free."""
 
 
 @ir.ops.rms_norm.register_impl(
@@ -79,10 +104,13 @@ rms_add_no_var_16bit_only = (
     lambda x, x_residual, weight, epsilon, variance_size=None: variance_size is None
     and x.dtype in (torch.float16, torch.bfloat16)
     and (weight is None or weight.dtype == x.dtype)
+    and flatten_to_2d_is_free(x)
+    and flatten_to_2d_is_free(x_residual)
 )
 """
 AITER fused_add_rms_norm only supports 16-bit activations and no var_size override.
-Requires weight dtype to match x dtype.
+Requires weight dtype to match x dtype, and flattening both the activation and the
+residual to 2D to be free.
 """
 
 


### PR DESCRIPTION
## Purpose

The AITER norm kernels take 2-D inputs only, so the wrappers in
`vllm/kernels/aiter_ops.py` flatten the leading dims with `Tensor.reshape`:

```python
if x.dim() > 2:
    x_original_shape = x.shape
    x = x.reshape(-1, x_original_shape[-1])
```

`reshape` silently degrades to `.contiguous()` when the flattened shape is not
expressible with the input's strides, injecting a whole-tensor device copy. The
support predicates (`rms_no_var_16bit_only`, `rms_add_no_var_16bit_only`) check
only dtype and `variance_size`, so AITER is still selected in that case — and
the copy costs more than the kernel saves.

Per-head QK norm hits this on every layer: `q`/`k` are last-dim slices of the
fused QKV projection viewed as `(num_tokens, num_heads, head_dim)`, whose
leading dims cannot be merged without a copy. Qwen3-8B at 4096 tokens:

```
q_by_head  shape=(4096, 32, 128)  stride=(6144, 128, 1)  is_contiguous=False
q_by_head.reshape(-1, 128) shares storage: False   # full 4096x4096 bf16 copy
```

This adds `flatten_to_2d_is_free(x)` and requires it in both predicates. When it
returns `False`, `IrOp.dispatch` falls through to the next provider — on ROCm
`native`, i.e. Inductor codegen, which consumes arbitrary strides directly and
fuses the norm into its neighbours. Numerically equivalent; only the copy is
gone. The predicate runs once per graph node during `VllmIRLoweringPass`, not
per forward, so it costs nothing at steady state.

**Scope.** Only a rank > 2 input that is a slice of a larger buffer can be
affected; a contiguous rank-3 tensor flattens for free and still dispatches to
AITER. The dividing line is the norm class, not the model family: the 9 in-tree
files whose QK norms are `GemmaRMSNorm` (gemma, gemma2, gemma3, gemma3_mm,
qwen3_5, qwen3_next, rnj1, step3p5, step3p5_mtp) pass an fp32 weight and already
fail the pre-existing `weight.dtype == x.dtype` check, one condition *before* the
new guard, so their dispatch cannot change in either direction. The ~27 files
that build `RMSNorm(head_dim)` for per-head QK norm (qwen3, qwen3_moe, gemma4,
glm4_moe, exaone4, plamo3, lfm2, lfm2_moe, apertus, afmoe, …) are candidates for
the win.

## Test Plan

New `tests/kernels/ir/test_aiter_norm_dispatch.py` asserts the predicate agrees
with whether `reshape` preserves the storage pointer, over flattenable and
non-flattenable layouts.

End-to-end, on 1x MI355X (gfx950) and 1x MI325X (gfx942), TP=1:

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_RMSNORM=1

vllm bench throughput --model <model> \
  --input-len 1024 --output-len 128 --num-prompts 1000 \
  --no-enable-prefix-caching --trust-remote-code
```

Three interleaved base/patched pairs per model with the order alternated per
repeat, so drift and thermal ramp are shared rather than charged to one variant;
deltas are pairwise and the reported figure is the median. Each arm gets its own
`VLLM_CACHE_ROOT` **and** `TORCHINDUCTOR_CACHE_DIR` — `VLLM_DISABLE_COMPILE_CACHE`
alone does not stop Inductor's FX graph cache, and a shared cache lets the
patched arm reuse graphs the base arm compiled, erasing the difference being
measured. The change is Python-only, so both arms share the same compiled `.so`.

Kernel level: the per-head QK-norm geometries the dispatch probe actually
observed, x {1024, 2048, 4096, 8192} tokens x {q, k}, bf16, compiled through
`VllmIRLoweringPass` with priority `["aiter", "native"]`. Per-call GPU time from
replaying a captured graph over 4 rotating input buffers (so the copy is not
absorbed by Infinity Cache), refill timed separately and subtracted.

Dispatch probe: instrumented the predicate to log every distinct
`(shape, stride, dtype, verdict)` reaching it, per model, with a cold Inductor
cache so the lowering pass reruns.

## Test Result

New tests pass (8/8). Numerics match `native` within `atol=rtol=2e-2` across
bf16/fp16 and contiguous / per-head-strided shapes.

### End-to-end throughput

| Model | dispatch | MI355X (gfx950) | MI325X (gfx942) |
|---|---|---:|---:|
| Qwen3-30B-A3B (`qwen3_moe`) | 2/3 rejected | **+5.17 %** | **+6.87 %** |
| lfm2-1.2b (`lfm2`) | 2/3 rejected | **+3.19 %** | **+3.28 %** |
| gemma-4-26B-A4B-it (`gemma4`) | 4/6 rejected | **+2.37 %** | **+2.34 %** |
| Gryphe-Gemma-4-31B-StyleTune (`gemma4`) | 4/6 rejected | **+2.48 %** | — |
| Qwen3.5-122B-A10B (`qwen3_5`) | 0/4 reach the guard | no-op control | — |

Every pair is positive on both architectures, including the reversed-order
pairs. Within-variant spread is 0.06–1.03 % except lfm2-1.2b (2.2 %), whose run
is short enough that scheduler ramp dominates. Qwen3-30B-A3B is the cleanest
signal: +5.17 % against a 0.10–0.21 % spread on gfx950. KV cache size matched to
within 0.01 % between arms on every model.

Qwen3.5-122B-A10B is the control: `Qwen3NextAttention` does apply per-head QK
norm on a fused-QKV slice, so it looks like the exact target pattern, but all 28
predicate calls are rejected on weight dtype and **0** reach the flatten guard.
Same for Qwen3.5-397B-A17B-FP8 at TP=2 and TP=4 (26/26 and 44/44).

### Kernel level

Sum of best-of-3 x 200 iters over all cases:

| Input layout | `aiter` | `native` | speedup |
|---|---:|---:|---|
| gfx950 — per-head slice of fused QKV | 1601.4 us | 814.0 us | **1.97x** |
| gfx950 — contiguous per-head (control) | 1007.5 us | 689.3 us | |
| gfx942 — per-head slice of fused QKV | 2635.7 us | 671.9 us | **3.9x** |
| gfx942 — contiguous per-head (control) | 2061.3 us | 650.8 us | |

Splitting the saving by holding the provider at `aiter` and only making the input
contiguous: the hidden copy this PR removes is **75 %** of the win on gfx950 and
**29 %** on gfx942, the remainder being AITER's norm kernel trailing Inductor
codegen at `head_dim`-wide rows, independent of any copy. `native` is close to
layout-insensitive — the strided slice costs it +18 % on gfx950 and +3.2 % on
gfx942, where `aiter` pays +59 % and +28 % — confirming the patch's load-bearing
assumption that Inductor consumes arbitrary strides without materialising a copy.

On the patched tree all slice cases select `native` (814.0 us, matching the
forced-`native` control) and all contiguous cases still select `aiter`,
confirming the guard moves only the layout it targets.

### Dispatch coverage

| Model | implementation | layouts | rejected |
|---|---|---:|---:|
| Qwen3-8B / Qwen3-14B-FP8 / Qwen3-30B-A3B | `qwen3`, `qwen3_moe` | 3 | **2** |
| gemma-4-26B-A4B-it / Gryphe-Gemma-4-31B | `gemma4` | 6 | **4** |
| lfm2-1.2b | `lfm2` | 3 | **2** |
| Qwen3.5-122B-A10B-FP8 | `qwen3_5` | 0 | 0 |
| DeepSeek-V4-Flash | `deepseek_v4`, MLA | 53 | 0 |
| MiniMax-M2.7 | MoE, norms already 2-D | 4 | 0 |
| Mistral-7B-Instruct-v0.3 | no QK norm | 1 | 0 |

Qwen3-8B rejects exactly the two QK-norm layouts `(s, 32, 128)` and `(s, 8, 128)`,
both `stride=(6144, 128, 1)` — `6144` being the fused QKV row stride. Matching
counts on Qwen3-14B-FP8 show quantization is orthogonal. gemma-4 is a broader
case: 4 of 6 layouts rejected across two distinct QKV geometries, while one of
its accepted layouts is a *contiguous* rank-3 vision-tower activation
(`[1, 2048, 1152]`, stride `[2359296, 1152, 1]`), showing the guard rejects
strided slices specifically rather than rank-3 inputs generally.

Unaffected by structure, measured rather than assumed: DeepSeek-V4-Flash and
MiniMax-M2.7 reach the guard with zero rejections, every input 2-D contiguous.
GLM-5.2 (`GlmMoeDsaForCausalLM`) and Kimi-Linear-48B resolve to MLA
implementations (`deepseek_v32`, `kimi_k3`) whose norms are sized only by
`hidden_size` / `q_lora_rank` / `kv_lora_rank`, so no per-head layout can reach
the guard; Falcon-H1 and Granite-4.0-H likewise define `hidden_size` norms only.

Full per-architecture numbers, harness details and the predicate-level
instrumentation are in the comments below.

---

Found by [Hyperloom](https://github.com/AMD-AGI/Hyperloom); reviewed and measured by hand.
