### PR TITLE
[Examples] Point structured-outputs Usage/entry at structured_outputs_client

### DIFF
--- a/examples/features/structured_outputs/README.md
+++ b/examples/features/structured_outputs/README.md
@@ -34,19 +34,19 @@ See [feature docs](https://docs.vllm.ai/en/latest/features/structured_outputs.ht
 Run all constraints, non-streaming:
 
 ```bash
-uv run structured_outputs_offline.py
+uv run structured_outputs_client.py
 ```
 
 Run all constraints, streaming:
 
 ```bash
-uv run structured_outputs_offline.py --stream
+uv run structured_outputs_client.py --stream
 ```
 
 Run certain constraints, for example `structural_tag` and `regex`, streaming:
 
 ```bash
-uv run structured_outputs_offline.py \
+uv run structured_outputs_client.py \
     --constraint structural_tag regex \
     --stream
 ```
@@ -54,5 +54,5 @@ uv run structured_outputs_offline.py \
 Run all constraints, with reasoning models and streaming:
 
 ```bash
-uv run structured_outputs_offline.py --reasoning --stream
+uv run structured_outputs_client.py --reasoning --stream
 ```

--- a/examples/features/structured_outputs/pyproject.toml
+++ b/examples/features/structured_outputs/pyproject.toml
@@ -5,4 +5,4 @@ dependencies = ["openai==1.78.1", "pydantic==2.11.4"]
 version = "0.0.0"
 
 [project.scripts]
-structured-outputs = "structured_outputs:main"
+structured-outputs = "structured_outputs_client:main"


### PR DESCRIPTION
## Summary
- `examples/features/structured_outputs/pyproject.toml` entry point `structured-outputs = "structured_outputs:main"` pointed at a missing `structured_outputs.py` (404). Point it at `structured_outputs_client:main` so `uvx ... structured-outputs` works.
- `examples/features/structured_outputs/README.md` Usage examples invoked `structured_outputs_offline.py` with `--stream` / `--constraint` / `--reasoning`, but those CLI flags exist only on `structured_outputs_client.py` (offline has no argparse).

## Local repro
```bash
SHA=050f29caf1c7dc4648cfa454b987da62b837660d
BASE=https://raw.githubusercontent.com/vllm-project/vllm/$SHA/examples/features/structured_outputs

# Ghost module for entry point
curl -sL -o /dev/null -w '%{http_code}\n' $BASE/structured_outputs.py   # 404
curl -sL -o /dev/null -w '%{http_code}\n' $BASE/structured_outputs_client.py  # 200

# Entry points at missing module
curl -sL $BASE/pyproject.toml | rg 'structured-outputs'

# Offline has no CLI flags; client does
curl -sL $BASE/structured_outputs_offline.py | rg 'ArgumentParser|add_argument' || echo 'no argparse'
curl -sL $BASE/structured_outputs_client.py | rg 'add_argument' 

# README Usage names offline + flags
curl -sL $BASE/README.md | rg 'structured_outputs_offline|stream|constraint|reasoning'
```

## Test plan
- [ ] Confirm `pyproject.toml` entry resolves to `structured_outputs_client:main`
- [ ] Confirm README Usage commands match client CLI flags
- [ ] Optional: `uvx --from git+https://github.com/...#subdirectory=examples/features/structured_outputs structured-outputs --help` against this branch