### PR TITLE
[Examples] Fix ghost demo.py Usage in offline LLM examples

### DIFF
--- a/examples/generate/multimodal/mistral-small_offline.py
+++ b/examples/generate/multimodal/mistral-small_offline.py
@@ -49,8 +49,8 @@ from vllm.multimodal.utils import encode_image_url
 # ```
 #
 # Usage:
-#     python demo.py simple
-#     python demo.py advanced
+#     python mistral-small_offline.py simple
+#     python mistral-small_offline.py advanced
 
 # Lower max_model_len and/or max_num_seqs on low-VRAM GPUs.
 # These scripts have been tested on 2x L40 GPUs

--- a/examples/tool_calling/chat_with_tools_offline.py
+++ b/examples/tool_calling/chat_with_tools_offline.py
@@ -42,8 +42,7 @@ from vllm.sampling_params import SamplingParams
 # ```
 #
 # Usage:
-#     python demo.py simple
-#     python demo.py advanced
+#     python chat_with_tools_offline.py
 
 model_name = "mistralai/Mistral-7B-Instruct-v0.3"
 # or switch to "mistralai/Mistral-Nemo-Instruct-2407"


### PR DESCRIPTION
## Summary
- `examples/tool_calling/chat_with_tools_offline.py` Usage invoked nonexistent `demo.py simple/advanced`; the script has no CLI modes — point Usage at `python chat_with_tools_offline.py`.
- `examples/generate/multimodal/mistral-small_offline.py` Usage invoked the same ghost `demo.py`; the file itself defines `simple`/`advanced` modes — point Usage at `python mistral-small_offline.py simple|advanced`.

## Evidence (HEAD `050f29caf1c7`)
- No `examples/**/demo.py` blob in the tree.
- `chat_with_tools_offline.py` has no argparse / `simple`/`advanced` entrypoints (module-level `LLM()` script).
- `mistral-small_offline.py` `parse_args()` expects `mode` choices `simple|advanced` on that filename.

## Test plan
- [x] Confirm Usage text matches actual filenames and CLI.
- [ ] Docs/examples CI (as applicable).
