### PR TITLE
[ROCm][Attention] Add RDNA4 FlyDSL SplitKV with Triton fallback

### DIFF
--- a/benchmarks/kernels/benchmark_rocm_splitkv_paged_decode.py
+++ b/benchmarks/kernels/benchmark_rocm_splitkv_paged_decode.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark ROCm paged-decode backends, including opt-in FlyDSL SplitKV.
+
+The standard page-16/page-32 rows are direct Triton diagnostics. Production
+dispatch still gives the native ROCm paged-attention kernel first refusal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from vllm import envs
+from vllm.platforms import current_platform
+from vllm.triton_utils import triton
+from vllm.v1.attention.ops.chunked_prefill_paged_decode import (
+    _choose_fallback_block_size,
+    _get_num_splits,
+    _paged_attention_2d_splitkv_decode,
+    kernel_paged_attention_2d,
+)
+from vllm.v1.attention.ops.rdna4_splitkv import get_rdna4_flydsl_splitkv_config
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    query_dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_query_heads: int
+    num_kv_heads: int
+    head_size: int
+    page_size: int
+    seq_lens: tuple[int, ...]
+    padded_stride: bool = False
+
+
+def _cases() -> tuple[list[Case], list[Case]]:
+    fp8 = current_platform.fp8_dtype()
+    general = [
+        Case("bf16-mha-d128", torch.bfloat16, torch.bfloat16, 8, 8, 128, 16, (4096,)),
+        Case(
+            "bf16-gqa4-d128",
+            torch.bfloat16,
+            torch.bfloat16,
+            16,
+            4,
+            128,
+            32,
+            (8192,),
+        ),
+        Case(
+            "bf16-mqa-d128-padded",
+            torch.bfloat16,
+            torch.bfloat16,
+            8,
+            1,
+            128,
+            544,
+            (8192, 4097, 2049, 513),
+            True,
+        ),
+        Case(
+            "bf16-gqa6-d256-padded",
+            torch.bfloat16,
+            torch.bfloat16,
+            12,
+            2,
+            256,
+            1568,
+            (8192,),
+            True,
+        ),
+        Case(
+            "bf16-gqa4-crossover",
+            torch.bfloat16,
+            torch.bfloat16,
+            16,
+            4,
+            128,
+            32,
+            (4096,) * 16,
+        ),
+        Case("fp8-mha-d128", torch.bfloat16, fp8, 8, 8, 128, 16, (8192,)),
+        Case("fp8-gqa4-d128", torch.bfloat16, fp8, 16, 4, 128, 32, (8192,)),
+        Case(
+            "fp8-mqa-d128-padded",
+            torch.float16,
+            fp8,
+            8,
+            1,
+            128,
+            528,
+            (8192, 4097, 2049, 513),
+            True,
+        ),
+        Case(
+            "fp8-gqa1-d128-direct",
+            torch.bfloat16,
+            fp8,
+            2,
+            2,
+            128,
+            544,
+            (1024,),
+        ),
+        Case(
+            "fp8-gqa6-d256-padded",
+            torch.bfloat16,
+            fp8,
+            12,
+            2,
+            256,
+            1568,
+            (8192,),
+            True,
+        ),
+        Case(
+            "fp8-gqa16-d256-padded",
+            torch.bfloat16,
+            fp8,
+            16,
+            1,
+            256,
+            1056,
+            (32768,),
+            True,
+        ),
+        Case(
+            "fp8-gqa4-crossover",
+            torch.bfloat16,
+            fp8,
+            16,
+            4,
+            128,
+            32,
+            (4096,) * 16,
+        ),
+    ]
+    qwen_lengths = (180, 1374, 4014, 8192, 32768, 131072)
+    qwen = [
+        Case(
+            f"qwen-b1-s{seq_len}",
+            torch.bfloat16,
+            fp8,
+            12,
+            2,
+            256,
+            1568,
+            (seq_len,),
+            True,
+        )
+        for seq_len in qwen_lengths
+    ]
+    qwen.extend(
+        [
+            Case(
+                "qwen-ragged-b3",
+                torch.bfloat16,
+                fp8,
+                12,
+                2,
+                256,
+                1568,
+                (32768, 16384, 8192),
+                True,
+            ),
+            Case(
+                "qwen-ragged-b13",
+                torch.bfloat16,
+                fp8,
+                12,
+                2,
+                256,
+                1568,
+                tuple(16384 - 1024 * index for index in range(13)),
+                True,
+            ),
+        ]
+    )
+    for dtype, kv_dtype in (
+        (torch.bfloat16, torch.bfloat16),
+        (torch.float16, torch.float16),
+        (torch.bfloat16, fp8),
+    ):
+        for batch in (1, 4, 16):
+            for length in (1374, 8192, 32768):
+                qwen.append(
+                    Case(
+                        f"qwen-tp4-{kv_dtype}-b{batch}-s{length}",
+                        dtype,
+                        kv_dtype,
+                        6,
+                        1,
+                        256,
+                        1568 if kv_dtype.itemsize == 1 else 784,
+                        tuple(max(1, length - i * 17) for i in range(batch)),
+                        True,
+                    )
+                )
+    return general, qwen
+
+
+def _padded_cache_views(
+    key_cache: torch.Tensor, value_cache: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_blocks = key_cache.shape[0]
+    page_elements = key_cache[0].numel()
+    backing = torch.empty(
+        num_blocks * 2 * page_elements,
+        dtype=key_cache.dtype,
+        device=key_cache.device,
+    )
+    padded_key = torch.as_strided(
+        backing,
+        key_cache.shape,
+        (2 * page_elements, *key_cache.stride()[1:]),
+    )
+    padded_value = torch.as_strided(
+        backing,
+        value_cache.shape,
+        (2 * page_elements, *value_cache.stride()[1:]),
+        page_elements,
+    )
+    padded_key.copy_(key_cache)
+    padded_value.copy_(value_cache)
+    return padded_key, padded_value
+
+
+def _broad_cases() -> list[Case]:
+    cases = []
+    for head, gqa, batch in (
+        (128, 16, 8),
+        (128, 16, 16),
+        (128, 16, 1),
+        (128, 8, 3),
+        (256, 4, 3),
+        (256, 16, 3),
+        (256, 6, 3),
+        (128, 3, 3),
+        (256, 6, 1),
+        (256, 6, 16),
+        (128, 1, 1),
+        (256, 1, 1),
+    ):
+        for dtype, kv_dtype in (
+            (torch.bfloat16, torch.bfloat16),
+            (torch.float16, torch.float16),
+            (torch.bfloat16, torch.float8_e4m3fn),
+        ):
+            for length in (257, 4097, 32767):
+                page = 1568 if kv_dtype.itemsize == 1 else 784
+                cases.append(
+                    Case(
+                        f"d{head}-g{gqa}-b{batch}-{kv_dtype}-s{length}",
+                        dtype,
+                        kv_dtype,
+                        gqa * 2,
+                        2,
+                        head,
+                        page,
+                        tuple(max(1, length - i * 17) for i in range(batch)),
+                        True,
+                    )
+                )
+    return cases
+
+
+def _make_inputs(case: Case):
+    device = current_platform.device_type
+    blocks_per_seq = [math.ceil(length / case.page_size) for length in case.seq_lens]
+    num_blocks = sum(blocks_per_seq)
+    x = 16 // case.kv_dtype.itemsize
+    query = torch.randn(
+        len(case.seq_lens),
+        case.num_query_heads,
+        case.head_size,
+        dtype=case.query_dtype,
+        device=device,
+    )
+    key_cache = torch.randn(
+        num_blocks,
+        case.num_kv_heads,
+        case.head_size // x,
+        case.page_size,
+        x,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(case.kv_dtype)
+    value_cache = torch.randn(
+        num_blocks,
+        case.num_kv_heads,
+        case.head_size,
+        case.page_size,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(case.kv_dtype)
+    if case.padded_stride:
+        key_cache, value_cache = _padded_cache_views(key_cache, value_cache)
+
+    block_tables = torch.zeros(
+        len(case.seq_lens), max(blocks_per_seq), dtype=torch.int32, device=device
+    )
+    permutation = torch.randperm(num_blocks, dtype=torch.int32, device=device)
+    cursor = 0
+    for row, num_seq_blocks in enumerate(blocks_per_seq):
+        block_tables[row, :num_seq_blocks] = permutation[
+            cursor : cursor + num_seq_blocks
+        ]
+        cursor += num_seq_blocks
+    seq_lens = torch.tensor(case.seq_lens, dtype=torch.int32, device=device)
+    k_scale = torch.tensor(0.73, dtype=torch.float32, device=device)
+    v_scale = torch.tensor(1.27, dtype=torch.float32, device=device)
+    return query, key_cache, value_cache, block_tables, seq_lens, k_scale, v_scale
+
+
+def _run_non_split(
+    query,
+    key_cache,
+    value_cache,
+    block_tables,
+    seq_lens,
+    k_scale,
+    v_scale,
+    output,
+) -> None:
+    num_query_heads = query.shape[1]
+    num_kv_heads = key_cache.shape[1]
+    head_size = query.shape[2]
+    page_size = key_cache.shape[3]
+    queries_per_kv = num_query_heads // num_kv_heads
+    kernel_paged_attention_2d[(seq_lens.shape[0], num_kv_heads)](
+        output,
+        query,
+        key_cache,
+        value_cache,
+        None,
+        block_tables,
+        seq_lens,
+        None,
+        head_size**-0.5,
+        k_scale,
+        v_scale,
+        1.0,
+        num_query_heads=num_query_heads,
+        num_queries_per_kv=queries_per_kv,
+        num_queries_per_kv_padded=max(triton.next_power_of_2(queries_per_kv), 16),
+        block_table_stride=block_tables.stride(0),
+        query_stride_0=query.stride(0),
+        query_stride_1=query.stride(1),
+        output_stride_0=output.stride(0),
+        output_stride_1=output.stride(1),
+        BLOCK_SIZE=_choose_fallback_block_size(page_size),
+        PHYSICAL_BLOCK_SIZE=page_size,
+        HEAD_SIZE=head_size,
+        HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
+        USE_ALIBI_SLOPES=False,
+        SLIDING_WINDOW=0,
+        x=key_cache.shape[4],
+        stride_k_cache_0=key_cache.stride(0),
+        stride_k_cache_1=key_cache.stride(1),
+        stride_k_cache_2=key_cache.stride(2),
+        stride_k_cache_3=key_cache.stride(3),
+        stride_k_cache_4=key_cache.stride(4),
+        stride_v_cache_0=value_cache.stride(0),
+        stride_v_cache_1=value_cache.stride(1),
+        stride_v_cache_2=value_cache.stride(2),
+        stride_v_cache_3=value_cache.stride(3),
+        filter_by_query_len=False,
+        query_start_len_ptr=None,
+        USE_SINKS=False,
+        USE_FP8=False,
+        num_warps=8 if key_cache.element_size() == 1 else 4,
+    )
+
+
+def _capture(fn):
+    fn()
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fn()
+    return graph.replay
+
+
+@torch.inference_mode()
+def benchmark_case(case: Case, warmup: int, rep: int, graph: bool) -> dict:
+    query, key, value, tables, lens, k_scale, v_scale = _make_inputs(case)
+    max_seq_len = max(case.seq_lens)
+    splits = _get_num_splits(
+        len(case.seq_lens),
+        case.num_kv_heads,
+        case.head_size,
+        case.page_size,
+        max_seq_len,
+        allow_short_context=case.kv_dtype.itemsize == 1,
+    )
+    baseline_output = torch.empty_like(query)
+    split_output = torch.empty_like(query)
+    mid_out = torch.empty(
+        len(case.seq_lens),
+        case.num_query_heads,
+        splits,
+        case.head_size,
+        dtype=torch.float32,
+        device=query.device,
+    )
+    mid_lse = torch.empty(
+        len(case.seq_lens),
+        case.num_query_heads,
+        splits,
+        dtype=torch.float32,
+        device=query.device,
+    )
+    query_start_loc = torch.arange(
+        len(case.seq_lens) + 1, dtype=torch.int32, device=query.device
+    )
+    flydsl_config = None
+    if envs.VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL:
+        flydsl_config = get_rdna4_flydsl_splitkv_config(
+            query=query,
+            key_cache=key,
+            value_cache=value,
+            output=split_output,
+            block_tables=tables,
+            seq_lens=lens,
+            query_start_loc=query_start_loc,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            scale=case.head_size**-0.5,
+            actual_max_splits=splits,
+            max_seq_len=max_seq_len,
+            filter_by_query_len=True,
+        )
+    backend = flydsl_config.route.value if flydsl_config is not None else "fallback"
+
+    def baseline() -> None:
+        _run_non_split(
+            query,
+            key,
+            value,
+            tables,
+            lens,
+            k_scale,
+            v_scale,
+            baseline_output,
+        )
+
+    def splitkv() -> None:
+        _paged_attention_2d_splitkv_decode(
+            query,
+            key,
+            value,
+            tables,
+            lens,
+            case.head_size**-0.5,
+            k_scale,
+            v_scale,
+            output=split_output,
+            actual_max_splits=splits,
+            max_seq_len=max_seq_len,
+            mid_out=mid_out,
+            mid_lse=mid_lse,
+            query_start_loc=query_start_loc,
+            filter_by_query_len=True,
+        )
+
+    def triton_splitkv() -> None:
+        enabled = envs.VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL
+        try:
+            envs.VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL = False
+            splitkv()
+        finally:
+            envs.VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL = enabled
+
+    baseline()
+    splitkv()
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(split_output, baseline_output, atol=0.02, rtol=0.02)
+    baseline_fn = _capture(baseline) if graph else baseline
+    splitkv_fn = _capture(splitkv) if graph else splitkv
+    triton_fn = _capture(triton_splitkv) if graph else triton_splitkv
+    baseline_ms = triton.testing.do_bench(
+        baseline_fn, warmup=warmup, rep=rep, return_mode="median"
+    )
+    splitkv_ms = triton.testing.do_bench(
+        splitkv_fn, warmup=warmup, rep=rep, return_mode="median"
+    )
+    triton_ms = triton.testing.do_bench(
+        triton_fn, warmup=warmup, rep=rep, return_mode="median"
+    )
+    scratch_bytes = mid_out.nbytes + mid_lse.nbytes
+    print(
+        f"| {case.name} | {backend} | {splits} | {scratch_bytes / 2**20:.2f} | "
+        f"{baseline_ms * 1000:.2f} | {splitkv_ms * 1000:.2f} | "
+        f"{baseline_ms / splitkv_ms:.2f}x | {triton_ms * 1000:.2f} | "
+        f"{triton_ms / splitkv_ms:.2f}x |",
+        flush=True,
+    )
+    return dict(
+        case=case.name,
+        backend=backend,
+        splits=splits,
+        baseline_us=baseline_ms * 1000,
+        splitkv_us=splitkv_ms * 1000,
+        triton_splitkv_us=triton_ms * 1000,
+        speedup_2d=baseline_ms / splitkv_ms,
+        speedup_triton=triton_ms / splitkv_ms,
+        graph=graph,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--suite", choices=("general", "qwen", "all", "broad"), default="all"
+    )
+    parser.add_argument("--output", type=Path, help="Save per-case timings as JSON")
+    parser.add_argument("--warmup", type=int, default=25, help="Warmup time in ms")
+    parser.add_argument("--rep", type=int, default=100, help="Measurement time in ms")
+    parser.add_argument("--graph", action="store_true")
+    parser.add_argument("--flydsl", action="store_true", help="Enable FlyDSL routing")
+    parser.add_argument("--case", help="Run one exact case name")
+    args = parser.parse_args()
+    if not current_platform.is_rocm():
+        raise RuntimeError("This benchmark requires ROCm.")
+    if args.flydsl:
+        envs.VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL = True
+
+    general, qwen = _cases()
+    cases = general if args.suite == "general" else qwen
+    if args.suite == "all":
+        cases = general + qwen
+    elif args.suite == "broad":
+        cases = _broad_cases()
+    if args.case:
+        cases = [case for case in cases if case.name == args.case]
+        if not cases:
+            parser.error(f"unknown case for the selected suite: {args.case}")
+    print(
+        f"GPU: {torch.cuda.get_device_name()} | graph={args.graph} | "
+        f"flydsl={args.flydsl}"
+    )
+    print(
+        "| case | backend | splits | scratch MiB | 2D us | SplitKV us | speedup | "
+        "Triton SplitKV us | speedup |"
+    )
+    print("|---|---|---:|---:|---:|---:|---:|---:|---:|")
+    results = []
+    for case in cases:
+        results.append(benchmark_case(case, args.warmup, args.rep, args.graph))
+        if args.output:
+            args.output.write_text(json.dumps(results, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/attention/test_splitkv_num_splits.py
+++ b/tests/kernels/attention/test_splitkv_num_splits.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.v1.attention.backends.rocm_attn import _splitkv_workspace_support
+from vllm.v1.attention.ops.chunked_prefill_paged_decode import (
+    _MAX_SPLITS,
+    _choose_compute_block_size,
+    _choose_fallback_block_size,
+    _get_num_splits,
+    _paged_attention_2d_splitkv_decode,
+    _splitkv_workspace_shapes,
+)
+from vllm.v1.attention.ops.rdna4_splitkv import _can_use_rdna4_splitkv_decode
+from vllm.v1.kv_cache_interface import AttentionSpec, KVQuantMode
+
+GFX1201_WGPS = 32
+
+
+def _can_route(**overrides) -> bool:
+    args = {
+        "query_dtype": torch.bfloat16,
+        "key_cache_dtype": torch.bfloat16,
+        "value_cache_dtype": torch.bfloat16,
+        "kv_quant_mode": KVQuantMode.NONE,
+        "is_e4m3_kv_cache": False,
+        "head_size": 256,
+        "num_query_heads": 12,
+        "num_kv_heads": 2,
+        "use_alibi_slopes": False,
+        "sliding_window": 0,
+        "has_sinks": False,
+        "has_output_scale": False,
+        "is_gfx1x": True,
+        "is_gfx12x": True,
+    }
+    args.update(overrides)
+    return _can_use_rdna4_splitkv_decode(**args)
+
+
+@pytest.mark.parametrize(
+    "physical_block_size,expected",
+    [(16, 16), (32, 32), (528, 32), (784, 32), (1056, 32), (1568, 32)],
+)
+def test_choose_compute_block_size(physical_block_size: int, expected: int) -> None:
+    assert _choose_compute_block_size(physical_block_size) == expected
+
+
+@pytest.mark.parametrize(
+    "physical_block_size,expected",
+    [(16, 16), (32, 32), (64, 64), (128, 128), (528, 32), (1568, 32)],
+)
+def test_choose_fallback_block_size(physical_block_size: int, expected: int) -> None:
+    assert _choose_fallback_block_size(physical_block_size) == expected
+
+
+def test_fp8_short_context_uses_full_wave_split_policy() -> None:
+    args = {
+        "batch_size": 1,
+        "num_kv_heads": 2,
+        "head_size": 256,
+        "physical_block_size": 1568,
+        "max_seq_len": 1374,
+        "num_sms": GFX1201_WGPS,
+    }
+    assert _get_num_splits(**args, allow_short_context=False) == 1
+    assert _get_num_splits(**args, allow_short_context=True) == 16
+
+
+@pytest.mark.parametrize("allow_short_context", [False, True])
+@pytest.mark.parametrize("num_sms", [1, 16, 32, 42, 64, 304])
+@pytest.mark.parametrize("max_num_splits", [1, 8, _MAX_SPLITS])
+def test_num_splits_stays_within_bounds(
+    allow_short_context: bool, num_sms: int, max_num_splits: int
+) -> None:
+    for physical_block_size in (16, 32, 528, 784, 1056, 1568):
+        for batch_size in (1, 4, 16):
+            for max_seq_len in (1, 512, 4096, 32768, 131072):
+                splits = _get_num_splits(
+                    batch_size,
+                    num_kv_heads=2,
+                    head_size=256,
+                    physical_block_size=physical_block_size,
+                    max_seq_len=max_seq_len,
+                    max_num_splits=max_num_splits,
+                    num_sms=num_sms,
+                    allow_short_context=allow_short_context,
+                )
+                assert 1 <= splits <= max_num_splits
+                assert splits & (splits - 1) == 0
+
+
+@pytest.mark.parametrize("allow_short_context", [False, True])
+@pytest.mark.parametrize("physical_block_size", [16, 32, 528, 1568])
+@pytest.mark.parametrize("num_kv_heads", [1, 2, 8])
+def test_workspace_envelope_covers_every_splitting_batch(
+    allow_short_context: bool,
+    physical_block_size: int,
+    num_kv_heads: int,
+) -> None:
+    max_batch_size = 64
+    max_seq_len = 8192
+    shapes = _splitkv_workspace_shapes(
+        max_batch_size,
+        num_query_heads=16,
+        num_kv_heads=num_kv_heads,
+        head_size=256,
+        physical_block_size=physical_block_size,
+        max_seq_len=max_seq_len,
+        allow_short_context=allow_short_context,
+        num_sms=GFX1201_WGPS,
+    )
+    assert shapes is not None
+    mid_out_shape, mid_lse_shape = shapes
+    assert mid_out_shape[:3] == mid_lse_shape
+
+    for batch_size in range(1, max_batch_size + 1):
+        splits = _get_num_splits(
+            batch_size,
+            num_kv_heads,
+            head_size=256,
+            physical_block_size=physical_block_size,
+            max_seq_len=max_seq_len,
+            num_sms=GFX1201_WGPS,
+            allow_short_context=allow_short_context,
+        )
+        if splits > 1:
+            assert batch_size <= mid_out_shape[0]
+            assert splits <= mid_out_shape[2]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {
+            "query_dtype": torch.float16,
+            "key_cache_dtype": torch.float16,
+            "value_cache_dtype": torch.float16,
+            "is_gfx12x": False,
+        },
+        {
+            "key_cache_dtype": torch.float8_e4m3fn,
+            "value_cache_dtype": torch.float8_e4m3fn,
+            "kv_quant_mode": KVQuantMode.FP8_PER_TENSOR,
+            "is_e4m3_kv_cache": True,
+        },
+    ],
+)
+def test_splitkv_route_accepts_validated_configs(overrides) -> None:
+    assert _can_route(**overrides)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {
+            "key_cache_dtype": torch.float8_e4m3fn,
+            "value_cache_dtype": torch.float8_e4m3fn,
+            "kv_quant_mode": KVQuantMode.FP8_PER_TENSOR,
+            "is_e4m3_kv_cache": True,
+            "is_gfx12x": False,
+        },
+        {
+            "key_cache_dtype": torch.float8_e5m2,
+            "value_cache_dtype": torch.float8_e5m2,
+            "kv_quant_mode": KVQuantMode.FP8_PER_TENSOR,
+        },
+        {
+            "kv_quant_mode": KVQuantMode.FP8_PER_TENSOR,
+            "is_e4m3_kv_cache": True,
+        },
+        {"kv_quant_mode": KVQuantMode.FP8_PER_TOKEN_HEAD},
+        {"query_dtype": torch.float32},
+        {"head_size": 64},
+        {"num_query_heads": 13},
+        {"num_query_heads": 17, "num_kv_heads": 1},
+        {"use_alibi_slopes": True},
+        {"sliding_window": 128},
+        {"has_sinks": True},
+        {"has_output_scale": True},
+        {"key_cache_dtype": torch.float16, "value_cache_dtype": torch.float16},
+        {"is_gfx1x": False, "is_gfx12x": False},
+    ],
+)
+def test_splitkv_route_rejects_unsupported_configs(overrides) -> None:
+    assert not _can_route(**overrides)
+
+
+@pytest.mark.parametrize(
+    "bad_scale",
+    [
+        1.0,
+        torch.ones(2, dtype=torch.float32),
+        torch.ones((), dtype=torch.bfloat16),
+        torch.ones((), dtype=torch.float32, device="meta"),
+    ],
+)
+def test_fp8_launcher_requires_valid_scale_tensors(bad_scale) -> None:
+    query = torch.zeros(1, 12, 256, dtype=torch.bfloat16)
+    key_cache = torch.zeros(1, 2, 16, 32, 16, dtype=torch.float8_e4m3fn)
+    value_cache = torch.zeros(1, 2, 256, 32, dtype=torch.float8_e4m3fn)
+    block_tables = torch.zeros(1, 1, dtype=torch.int32)
+    seq_lens = torch.ones(1, dtype=torch.int32)
+
+    good_scale = torch.ones((), dtype=torch.float32)
+    with pytest.raises(TypeError, match="scalar float32 tensor"):
+        _paged_attention_2d_splitkv_decode(
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            seq_lens,
+            scale=256**-0.5,
+            k_scale=bad_scale,
+            v_scale=good_scale,
+            actual_max_splits=2,
+        )
+
+
+@pytest.mark.parametrize("kv_dtype", [torch.uint8, torch.float8_e5m2])
+def test_splitkv_launcher_rejects_unsupported_byte_cache(kv_dtype) -> None:
+    query = torch.zeros(1, 12, 256, dtype=torch.bfloat16)
+    key_cache = torch.zeros(1, 2, 16, 32, 16, dtype=kv_dtype)
+    value_cache = torch.zeros(1, 2, 256, 32, dtype=kv_dtype)
+    block_tables = torch.zeros(1, 1, dtype=torch.int32)
+    seq_lens = torch.ones(1, dtype=torch.int32)
+
+    with pytest.raises(TypeError, match="E4M3 FP8"):
+        _paged_attention_2d_splitkv_decode(
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            seq_lens,
+            scale=256**-0.5,
+            k_scale=torch.ones((), dtype=torch.float32),
+            v_scale=torch.ones((), dtype=torch.float32),
+            actual_max_splits=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "dtype,quant_mode,is_e4m3,is_gfx12x,expected",
+    [
+        (torch.bfloat16, KVQuantMode.NONE, False, False, (True, False)),
+        (torch.uint8, KVQuantMode.FP8_PER_TENSOR, True, True, (True, True)),
+        (torch.uint8, KVQuantMode.FP8_PER_TENSOR, True, False, (False, False)),
+        (torch.uint8, KVQuantMode.FP8_PER_TENSOR, False, True, (False, False)),
+        (torch.uint8, KVQuantMode.NONE, False, True, (False, False)),
+    ],
+)
+def test_splitkv_workspace_supports_byte_storage_fp8_specs(
+    dtype: torch.dtype,
+    quant_mode: KVQuantMode,
+    is_e4m3: bool,
+    is_gfx12x: bool,
+    expected: tuple[bool, bool],
+) -> None:
+    spec = AttentionSpec(
+        block_size=1568,
+        num_kv_heads=2,
+        head_size=256,
+        dtype=dtype,
+        kv_quant_mode=quant_mode,
+    )
+    assert (
+        _splitkv_workspace_support(
+            spec,
+            torch.bfloat16,
+            is_e4m3_kv_cache=is_e4m3,
+            is_gfx1x=True,
+            is_gfx12x=is_gfx12x,
+        )
+        == expected
+    )

--- a/tests/kernels/attention/test_splitkv_paged_decode.py
+++ b/tests/kernels/attention/test_splitkv_paged_decode.py
@@ -1,0 +1,2588 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from tests.kernels.allclose_default import get_default_atol, get_default_rtol
+from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx1x, on_gfx12x
+from vllm.triton_utils import triton
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.ops import chunked_prefill_paged_decode as paged_decode_ops
+from vllm.v1.attention.ops.chunked_prefill_paged_decode import (
+    _choose_fallback_block_size,
+    _paged_attention_2d_splitkv_decode,
+    kernel_paged_attention_2d,
+    reserve_splitkv_workspace,
+)
+from vllm.v1.attention.ops.rdna4_splitkv import (
+    can_use_rdna4_flydsl_splitkv_paged_attention,
+)
+from vllm.v1.worker.workspace import (
+    init_workspace_manager,
+    lock_workspace,
+    reset_workspace_manager,
+)
+
+DEVICE = current_platform.device_type
+
+
+@dataclass(frozen=True)
+class SplitKVCase:
+    query_dtype: torch.dtype
+    kv_dtype: torch.dtype
+    num_query_heads: int
+    num_kv_heads: int
+    head_size: int
+    page_size: int
+    seq_lens: tuple[int, ...]
+    splits: int | None
+    k_scale: float = 1.0
+    v_scale: float = 1.0
+    check_torch_reference: bool = False
+    padded_stride: bool = False
+
+
+CASES = [
+    pytest.param(
+        SplitKVCase(torch.bfloat16, torch.bfloat16, 4, 4, 128, 16, (257,), 4),
+        id="native-bf16-mha",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.float16,
+            torch.float16,
+            16,
+            4,
+            128,
+            32,
+            (257, 513, 1025),
+            4,
+        ),
+        id="native-fp16-gqa4",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.bfloat16,
+            torch.bfloat16,
+            12,
+            2,
+            256,
+            1568,
+            (1567, 1568, 1569),
+            7,
+            check_torch_reference=True,
+            padded_stride=True,
+        ),
+        id="native-qwen-page-boundary",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            12,
+            2,
+            256,
+            1568,
+            (4014,),
+            1,
+            0.73,
+            1.27,
+            True,
+            True,
+        ),
+        id="fp8-qwen-one-split",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            12,
+            2,
+            256,
+            1568,
+            (8192,),
+            14,
+            0.73,
+            1.27,
+            padded_stride=True,
+        ),
+        id="fp8-qwen-long",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            12,
+            2,
+            256,
+            1568,
+            (32768, 16384, 8192),
+            14,
+            0.73,
+            1.27,
+            padded_stride=True,
+        ),
+        id="fp8-qwen-ragged",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.float16,
+            torch.float8_e4m3fn,
+            8,
+            1,
+            128,
+            528,
+            (527, 528, 529),
+            7,
+            0.5,
+            1.5,
+        ),
+        id="fp8-fp16-mqa-odd-page",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            16,
+            4,
+            128,
+            784,
+            (783, 784, 785),
+            16,
+            0.75,
+            1.25,
+        ),
+        id="fp8-empty-splits",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            5,
+            1,
+            256,
+            1056,
+            (1055, 1056, 1057),
+            4,
+            0.75,
+            1.25,
+        ),
+        id="fp8-odd-head-group",
+    ),
+    pytest.param(
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            4,
+            4,
+            128,
+            32,
+            (2049, 4097, 8193),
+            None,
+            0.75,
+            1.25,
+        ),
+        id="fp8-production-heuristic",
+    ),
+]
+
+
+def _pack_cache(
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    padded_stride: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_blocks, page_size, num_kv_heads, head_size = key_cache.shape
+    x = 16 // key_cache.element_size()
+    packed_key = (
+        key_cache.view(num_blocks, page_size, num_kv_heads, head_size // x, x)
+        .permute(0, 2, 3, 1, 4)
+        .contiguous()
+    )
+    packed_value = value_cache.permute(0, 2, 3, 1).contiguous()
+    if not padded_stride:
+        return packed_key, packed_value
+
+    page_elements = packed_key[0].numel()
+    backing = torch.empty(
+        num_blocks * 2 * page_elements,
+        dtype=packed_key.dtype,
+        device=packed_key.device,
+    )
+    key_cache = torch.as_strided(
+        backing,
+        size=packed_key.shape,
+        stride=(2 * page_elements, *packed_key.stride()[1:]),
+    )
+    value_cache = torch.as_strided(
+        backing,
+        size=packed_value.shape,
+        stride=(2 * page_elements, *packed_value.stride()[1:]),
+        storage_offset=page_elements,
+    )
+    key_cache.copy_(packed_key)
+    value_cache.copy_(packed_value)
+    return key_cache, value_cache
+
+
+def _make_inputs(case: SplitKVCase):
+    batch_size = len(case.seq_lens)
+    blocks_per_seq = [
+        (seq_len + case.page_size - 1) // case.page_size for seq_len in case.seq_lens
+    ]
+    num_blocks = sum(blocks_per_seq)
+    max_blocks = max(blocks_per_seq)
+
+    query = torch.randn(
+        batch_size,
+        case.num_query_heads,
+        case.head_size,
+        dtype=case.query_dtype,
+        device=DEVICE,
+    )
+    dense_key = torch.randn(
+        num_blocks,
+        case.page_size,
+        case.num_kv_heads,
+        case.head_size,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    ).to(case.kv_dtype)
+    dense_value = torch.randn(
+        num_blocks,
+        case.page_size,
+        case.num_kv_heads,
+        case.head_size,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    ).to(case.kv_dtype)
+
+    permutation = torch.randperm(num_blocks, device=DEVICE, dtype=torch.int64)
+    block_tables = torch.zeros(batch_size, max_blocks, dtype=torch.int32, device=DEVICE)
+    cursor = 0
+    for seq_idx, (seq_len, num_seq_blocks) in enumerate(
+        zip(case.seq_lens, blocks_per_seq)
+    ):
+        physical_blocks = permutation[cursor : cursor + num_seq_blocks]
+        block_tables[seq_idx, :num_seq_blocks] = physical_blocks.to(torch.int32)
+        cursor += num_seq_blocks
+        tail = seq_len % case.page_size
+        if tail:
+            last_block = physical_blocks[-1]
+            dense_key[last_block, tail:] = float("nan")
+            dense_value[last_block, tail:] = float("nan")
+
+    key_cache, value_cache = _pack_cache(
+        dense_key, dense_value, padded_stride=case.padded_stride
+    )
+    seq_lens = torch.tensor(case.seq_lens, dtype=torch.int32, device=DEVICE)
+    k_scale = torch.tensor(case.k_scale, dtype=torch.float32, device=DEVICE)
+    v_scale = torch.tensor(case.v_scale, dtype=torch.float32, device=DEVICE)
+    return (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    )
+
+
+def _run_non_split(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    output: torch.Tensor | None = None,
+    query_start_loc: torch.Tensor | None = None,
+    filter_by_query_len: bool = False,
+) -> torch.Tensor:
+    if output is None:
+        output = torch.empty_like(query)
+    num_query_heads = query.shape[1]
+    num_kv_heads = key_cache.shape[1]
+    head_size = query.shape[2]
+    page_size = key_cache.shape[3]
+    block_size = _choose_fallback_block_size(page_size)
+    num_queries_per_kv = num_query_heads // num_kv_heads
+
+    kernel_paged_attention_2d[(seq_lens.shape[0], num_kv_heads)](
+        output_ptr=output,
+        query_ptr=query,
+        key_cache_ptr=key_cache,
+        value_cache_ptr=value_cache,
+        sink_ptr=None,
+        block_tables_ptr=block_tables,
+        seq_lens_ptr=seq_lens,
+        alibi_slopes_ptr=None,
+        scale=scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        out_scale_inv=1.0,
+        num_query_heads=num_query_heads,
+        num_queries_per_kv=num_queries_per_kv,
+        num_queries_per_kv_padded=max(triton.next_power_of_2(num_queries_per_kv), 16),
+        block_table_stride=block_tables.stride(0),
+        query_stride_0=query.stride(0),
+        query_stride_1=query.stride(1),
+        output_stride_0=output.stride(0),
+        output_stride_1=output.stride(1),
+        BLOCK_SIZE=block_size,
+        PHYSICAL_BLOCK_SIZE=page_size,
+        HEAD_SIZE=head_size,
+        HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
+        USE_ALIBI_SLOPES=False,
+        SLIDING_WINDOW=0,
+        x=key_cache.shape[4],
+        stride_k_cache_0=key_cache.stride(0),
+        stride_k_cache_1=key_cache.stride(1),
+        stride_k_cache_2=key_cache.stride(2),
+        stride_k_cache_3=key_cache.stride(3),
+        stride_k_cache_4=key_cache.stride(4),
+        stride_v_cache_0=value_cache.stride(0),
+        stride_v_cache_1=value_cache.stride(1),
+        stride_v_cache_2=value_cache.stride(2),
+        stride_v_cache_3=value_cache.stride(3),
+        filter_by_query_len=filter_by_query_len,
+        query_start_len_ptr=query_start_loc,
+        USE_SINKS=False,
+        USE_FP8=False,
+        num_warps=8 if key_cache.element_size() == 1 else 4,
+    )
+    return output
+
+
+def _torch_reference(
+    query: torch.Tensor,
+    dense_key: torch.Tensor,
+    dense_value: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+    k_scale: float,
+    v_scale: float,
+) -> torch.Tensor:
+    outputs = []
+    page_size = dense_key.shape[1]
+    num_kv_heads = dense_key.shape[2]
+    repeat = query.shape[1] // num_kv_heads
+    for seq_idx, seq_len_tensor in enumerate(seq_lens):
+        seq_len = int(seq_len_tensor.item())
+        num_blocks = (seq_len + page_size - 1) // page_size
+        block_ids = block_tables[seq_idx, :num_blocks].long()
+        key = dense_key[block_ids].reshape(-1, num_kv_heads, query.shape[2])
+        value = dense_value[block_ids].reshape(-1, num_kv_heads, query.shape[2])
+        key = key[:seq_len].float() * k_scale
+        value = value[:seq_len].float() * v_scale
+        key = torch.repeat_interleave(key, repeat, dim=1)
+        value = torch.repeat_interleave(value, repeat, dim=1)
+        scores = torch.einsum("hd,shd->hs", query[seq_idx].float(), key) * scale
+        probabilities = torch.softmax(scores, dim=-1)
+        outputs.append(torch.einsum("hs,shd->hd", probabilities, value))
+    return torch.stack(outputs).to(query.dtype)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@torch.inference_mode()
+def test_rdna4_flydsl_gate_covers_generalized_batch_one() -> None:
+    """The FlyDSL gate covers fallback shapes without widening the HIP gate."""
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        7,
+        1,
+        256,
+        1056,
+        (1057,),
+        4,
+        0.73,
+        1.27,
+    )
+    (
+        query,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    gate_args = dict(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        output=output,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        query_start_loc=query_start_loc,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        scale=0.071,
+        actual_max_splits=4,
+        max_seq_len=1057,
+        filter_by_query_len=True,
+    )
+
+    assert can_use_rdna4_flydsl_splitkv_paged_attention(**gate_args)
+    assert not can_use_rdna4_flydsl_splitkv_paged_attention(
+        **(gate_args | {"seq_lens": seq_lens.repeat(2)})
+    )
+    assert can_use_rdna4_flydsl_splitkv_paged_attention(
+        **(gate_args | {"query": query[:, :5], "output": output[:, :5]})
+    )
+
+
+@pytest.mark.parametrize(
+    "query_dtype,kv_dtype,batch_size,num_query_heads,num_kv_heads,head_size",
+    [
+        (torch.float16, torch.float8_e4m3fn, 1, 9, 1, 128),
+    ],
+)
+def test_rdna4_flydsl_rejects_value_sensitive_experimental_routes(
+    query_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    batch_size: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+) -> None:
+    """Do not expose routes whose correctness depends on input magnitude."""
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        select_kernel_config,
+    )
+
+    page_size = 128
+    cache_pack = 16 // kv_dtype.itemsize
+    query = torch.empty(
+        batch_size, num_query_heads, head_size, dtype=query_dtype, device="meta"
+    )
+    key_cache = torch.empty(
+        64,
+        num_kv_heads,
+        head_size // cache_pack,
+        page_size,
+        cache_pack,
+        dtype=kv_dtype,
+        device="meta",
+    )
+    seq_lens = torch.empty(batch_size, dtype=torch.int32, device="meta")
+
+    assert select_kernel_config(query, key_cache, seq_lens, 8192) is None
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@torch.inference_mode()
+def test_rdna4_flydsl_d128_gqa1_wave8_matches_triton(monkeypatch) -> None:
+    """The faster fused Wave8 route supersedes direct-finalize for D128/GQA1."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        2,
+        2,
+        128,
+        544,
+        (1024,),
+        4,
+        0.73,
+        1.27,
+    )
+    (
+        query,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty((1, 2, 4, 128), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((1, 2, 4), dtype=torch.float32, device=DEVICE)
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, max(case.seq_lens))
+    assert config is not None
+    assert config.route == SplitKVRoute.WAVE8
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _run_non_split(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_rdna4_flydsl_native_d128_gqa16_matches_triton(
+    monkeypatch, dtype: torch.dtype
+) -> None:
+    """Exercise the four-wave direct-register schedule for both native types."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(0)
+    case = SplitKVCase(
+        dtype,
+        dtype,
+        32,
+        2,
+        128,
+        16,
+        (257, 241, 225, 209, 193, 177, 161, 145),
+        4,
+    )
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.arange(9, dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty((8, 32, 4, 128), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((8, 32, 4), dtype=torch.float32, device=DEVICE)
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 257)
+    assert config is not None
+    assert config.route == SplitKVRoute.NATIVE_D128_GQA16_DIRECT
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        1.0,
+        1.0,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_rdna4_flydsl_native_d128_gqa16_lds_matches_torch(
+    monkeypatch, dtype: torch.dtype
+) -> None:
+    """Exercise the batch-16 cooperative LDS K/V schedule."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(1)
+    case = SplitKVCase(
+        dtype,
+        dtype,
+        32,
+        2,
+        128,
+        16,
+        (
+            257,
+            249,
+            241,
+            233,
+            225,
+            217,
+            209,
+            201,
+            193,
+            185,
+            177,
+            169,
+            161,
+            153,
+            145,
+            137,
+        ),
+        4,
+    )
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.arange(17, dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty((16, 32, 4, 128), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((16, 32, 4), dtype=torch.float32, device=DEVICE)
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 257)
+    assert config is not None
+    assert config.route == SplitKVRoute.NATIVE_D128_GQA16_LDS
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        1.0,
+        1.0,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "query_dtype,kv_dtype",
+    [
+        (torch.bfloat16, torch.bfloat16),
+        (torch.float16, torch.float16),
+        (torch.bfloat16, torch.float8_e4m3fn),
+        (torch.float16, torch.float8_e4m3fnuz),
+    ],
+)
+@torch.inference_mode()
+def test_rdna4_flydsl_d128_gqa16_tile32_matches_torch(
+    monkeypatch, query_dtype: torch.dtype, kv_dtype: torch.dtype
+) -> None:
+    """Exercise the batch-one 16-wave register-PV schedule."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(2)
+    case = SplitKVCase(
+        query_dtype,
+        kv_dtype,
+        32,
+        2,
+        128,
+        32,
+        (257,),
+        4,
+        0.73,
+        1.27,
+    )
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty((1, 32, 4, 128), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((1, 32, 4), dtype=torch.float32, device=DEVICE)
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 257)
+    assert config is not None
+    assert config.route == SplitKVRoute.D128_GQA16_TILE32
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        case.k_scale if kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if kv_dtype.itemsize == 1 else 1.0,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "case",
+    [
+        SplitKVCase(
+            torch.bfloat16,
+            torch.bfloat16,
+            16,
+            2,
+            256,
+            128,
+            (257, 249, 241),
+            4,
+        ),
+        SplitKVCase(
+            torch.float16,
+            torch.float16,
+            8,
+            2,
+            256,
+            32,
+            (257, 249, 241, 233, 225, 217, 209, 201),
+            4,
+        ),
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fnuz,
+            16,
+            2,
+            256,
+            32,
+            (257,),
+            4,
+            0.73,
+            1.27,
+        ),
+    ],
+    ids=("native-bf16-gqa8", "native-fp16-gqa4", "fnuz-bf16-gqa8"),
+)
+@torch.inference_mode()
+def test_rdna4_flydsl_d256_gqa4_8_matches_torch(monkeypatch, case: SplitKVCase) -> None:
+    """Exercise the promoted D256 eight-wave two-output-block schedule."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(3)
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    batch_size = len(case.seq_lens)
+    query_start_loc = torch.arange(batch_size + 1, dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty(
+        (batch_size, case.num_query_heads, case.splits, 256),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    mid_lse = torch.empty(
+        (batch_size, case.num_query_heads, case.splits),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, max(case.seq_lens))
+    assert config is not None
+    assert config.route == SplitKVRoute.D256_GQA4_8_TILE32
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        case.k_scale if case.kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if case.kv_dtype.itemsize == 1 else 1.0,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "query_dtype,kv_dtype",
+    [
+        (torch.bfloat16, torch.bfloat16),
+        (torch.float16, torch.float16),
+        (torch.bfloat16, torch.float8_e4m3fn),
+        (torch.float16, torch.float8_e4m3fnuz),
+    ],
+)
+@torch.inference_mode()
+def test_rdna4_flydsl_d256_gqa16_matches_torch(
+    monkeypatch, query_dtype: torch.dtype, kv_dtype: torch.dtype
+) -> None:
+    """Exercise the promoted D256/GQA16 Tile32 register-PV schedule."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(4)
+    case = SplitKVCase(
+        query_dtype,
+        kv_dtype,
+        32,
+        2,
+        256,
+        32,
+        (257,),
+        4,
+        0.73,
+        1.27,
+    )
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty((1, 32, 4, 256), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((1, 32, 4), dtype=torch.float32, device=DEVICE)
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 257)
+    assert config is not None
+    assert config.route == SplitKVRoute.D256_GQA16_TILE32
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        case.k_scale if kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if kv_dtype.itemsize == 1 else 1.0,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "query_dtype,kv_dtype",
+    [
+        (torch.bfloat16, torch.float8_e4m3fn),
+        (torch.float16, torch.float8_e4m3fnuz),
+    ],
+)
+@torch.inference_mode()
+def test_rdna4_flydsl_d128_gqa8_matches_torch(
+    monkeypatch, query_dtype: torch.dtype, kv_dtype: torch.dtype
+) -> None:
+    """Exercise the promoted D128/GQA8 Tile32 register-PV schedule."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(5)
+    case = SplitKVCase(
+        query_dtype,
+        kv_dtype,
+        16,
+        2,
+        128,
+        32,
+        (257, 249, 241),
+        4,
+        0.73,
+        1.27,
+    )
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.arange(4, dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty((3, 16, 4, 128), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((3, 16, 4), dtype=torch.float32, device=DEVICE)
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 257)
+    assert config is not None
+    assert config.route == SplitKVRoute.D128_GQA8_TILE32
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        case.k_scale,
+        case.v_scale,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "case",
+    [
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            5,
+            1,
+            256,
+            16,
+            (257,),
+            8,
+            0.73,
+            1.27,
+        ),
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            13,
+            1,
+            256,
+            16,
+            (257,),
+            8,
+            0.73,
+            1.27,
+        ),
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            14,
+            1,
+            256,
+            32,
+            (257,),
+            4,
+            0.73,
+            1.27,
+        ),
+        SplitKVCase(
+            torch.bfloat16,
+            torch.bfloat16,
+            8,
+            1,
+            128,
+            16,
+            (257,),
+            4,
+        ),
+    ],
+    ids=("d256-gqa5", "d256-gqa13", "d256-gqa14", "d128-native-gqa8"),
+)
+@torch.inference_mode()
+def test_rdna4_flydsl_generic_tile32_matches_torch(
+    monkeypatch, case: SplitKVCase
+) -> None:
+    """Exercise accurate Tile32 coverage beyond the fixed named routes."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(6)
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty(
+        (1, case.num_query_heads, case.splits, case.head_size),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    mid_lse = torch.empty(
+        (1, case.num_query_heads, case.splits),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 257)
+    assert config is not None
+    assert config.route == SplitKVRoute.GENERIC_TILE32
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        case.k_scale if case.kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if case.kv_dtype.itemsize == 1 else 1.0,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "case",
+    [
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            1,
+            1,
+            256,
+            16,
+            (257,),
+            8,
+            0.73,
+            1.27,
+        ),
+        SplitKVCase(
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            3,
+            1,
+            256,
+            128,
+            (257,),
+            4,
+            0.73,
+            1.27,
+        ),
+        SplitKVCase(
+            torch.float16,
+            torch.float8_e4m3fnuz,
+            4,
+            1,
+            128,
+            32,
+            (257,),
+            4,
+            0.73,
+            1.27,
+        ),
+        SplitKVCase(
+            torch.float16,
+            torch.float16,
+            1,
+            1,
+            128,
+            16,
+            (257,),
+            4,
+        ),
+    ],
+    ids=("d256-fp8-gqa1", "d256-fp8-gqa3", "d128-fnuz-gqa4", "d128-native-gqa1"),
+)
+@torch.inference_mode()
+def test_rdna4_flydsl_wave8_matches_torch(monkeypatch, case: SplitKVCase) -> None:
+    """Exercise the accurate scalar-FP32 low-GQA fallback."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(7)
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty(
+        (1, case.num_query_heads, case.splits, case.head_size),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    mid_lse = torch.empty(
+        (1, case.num_query_heads, case.splits),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 257)
+    assert config is not None
+    assert config.route == SplitKVRoute.WAVE8
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _torch_reference(
+        query,
+        dense_key,
+        dense_value,
+        block_tables,
+        seq_lens,
+        scale,
+        case.k_scale if case.kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if case.kv_dtype.itemsize == 1 else 1.0,
+    )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@torch.inference_mode()
+def test_rdna4_flydsl_qwen38_tp2_generic_matches_triton(monkeypatch) -> None:
+    """Exercise the accurate D256/GQA6 path used by Qwen3.8 TP2."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import (
+        SplitKVRoute,
+        select_kernel_config,
+    )
+
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        12,
+        2,
+        256,
+        1568,
+        (4014,),
+        4,
+        0.73,
+        1.27,
+        padded_stride=True,
+    )
+    (
+        query,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    mid_out = torch.empty((1, 12, case.splits, 256), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((1, 12, case.splits), dtype=torch.float32, device=DEVICE)
+    scale = case.head_size**-0.5
+
+    config = select_kernel_config(query, key_cache, seq_lens, 4014)
+    assert config is not None
+    assert config.route == SplitKVRoute.GENERIC_TILE32
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    reference = _run_non_split(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@torch.inference_mode()
+def test_rdna4_flydsl_generic_preserves_prefill_rows(monkeypatch) -> None:
+    """The generic reducer must not overwrite a non-decode query span."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        12,
+        2,
+        256,
+        1568,
+        (4014,),
+        4,
+        0.73,
+        1.27,
+    )
+    (
+        _,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query = torch.randn(2, 12, 256, dtype=torch.bfloat16, device=DEVICE)
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=DEVICE)
+    output = torch.full_like(query, 7.0)
+    mid_out = torch.empty((1, 12, 4, 256), dtype=torch.float32, device=DEVICE)
+    mid_lse = torch.empty((1, 12, 4), dtype=torch.float32, device=DEVICE)
+
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        256**-0.5,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=case.splits,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+
+    torch.testing.assert_close(output, torch.full_like(output, 7.0))
+
+
+@pytest.mark.skipif(not on_gfx1x(), reason="SplitKV decode requires gfx1x")
+@pytest.mark.skipif(
+    not torch.accelerator.is_available(), reason="SplitKV decode requires a GPU"
+)
+@pytest.mark.parametrize("case", CASES)
+@torch.inference_mode()
+def test_paged_attention_2d_splitkv_decode(case: SplitKVCase) -> None:
+    if case.kv_dtype.itemsize == 1 and not on_gfx12x():
+        pytest.skip("FP8 SplitKV decode requires gfx12x")
+    set_random_seed(0)
+    (
+        query,
+        dense_key,
+        dense_value,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    scale = case.head_size**-0.5
+
+    output = _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        actual_max_splits=case.splits,
+        max_seq_len=max(case.seq_lens),
+    )
+    reference = _run_non_split(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+    )
+
+    assert output.dtype == query.dtype
+    assert torch.isfinite(output).all()
+    atol = get_default_atol(output)
+    rtol = get_default_rtol(output)
+    if case.kv_dtype.itemsize == 1:
+        atol = max(atol, 0.01)
+        rtol = max(rtol, 0.01)
+    torch.testing.assert_close(output, reference, atol=atol, rtol=rtol)
+
+    if case.check_torch_reference:
+        torch_reference = _torch_reference(
+            query,
+            dense_key,
+            dense_value,
+            block_tables,
+            seq_lens,
+            scale,
+            case.k_scale if case.kv_dtype.itemsize == 1 else 1.0,
+            case.v_scale if case.kv_dtype.itemsize == 1 else 1.0,
+        )
+        torch.testing.assert_close(output, torch_reference, atol=0.03, rtol=0.03)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FP8 SplitKV decode requires gfx12x")
+@pytest.mark.parametrize(
+    "query_lens,seq_lens",
+    [
+        ((1, 3, 0, 1), (4014, 8192, 1568, 32768)),
+        ((2, 4), (1568, 4014)),
+    ],
+)
+@pytest.mark.parametrize("use_flydsl", [False, True])
+@torch.inference_mode()
+def test_fp8_splitkv_preserves_non_decode_rows(
+    monkeypatch,
+    query_lens: tuple[int, ...],
+    seq_lens: tuple[int, ...],
+    use_flydsl: bool,
+) -> None:
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    monkeypatch.setattr(
+        rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", use_flydsl
+    )
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        12,
+        2,
+        256,
+        1568,
+        seq_lens,
+        16,
+        0.73,
+        1.27,
+    )
+    (
+        _,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens_tensor,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query = torch.randn(sum(query_lens), 12, 256, dtype=torch.bfloat16, device=DEVICE)
+    query_start_loc = torch.tensor(
+        [0] + [sum(query_lens[: index + 1]) for index in range(len(query_lens))],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    output = torch.full_like(query, 7.0)
+    reference = output.clone()
+    scale = 256**-0.5
+
+    _paged_attention_2d_splitkv_decode(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens_tensor,
+        scale,
+        k_scale,
+        v_scale,
+        output=output,
+        actual_max_splits=16,
+        max_seq_len=max(seq_lens),
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+    _run_non_split(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens_tensor,
+        scale,
+        k_scale,
+        v_scale,
+        output=reference,
+        query_start_loc=query_start_loc,
+        filter_by_query_len=True,
+    )
+
+    decode_rows = [
+        int(query_start_loc[index].item())
+        for index, query_len in enumerate(query_lens)
+        if query_len == 1
+    ]
+    if decode_rows:
+        torch.testing.assert_close(
+            output[decode_rows], reference[decode_rows], atol=0.01, rtol=0.01
+        )
+    non_decode = torch.ones(sum(query_lens), dtype=torch.bool, device=DEVICE)
+    non_decode[decode_rows] = False
+    torch.testing.assert_close(
+        output[non_decode], torch.full_like(output[non_decode], 7)
+    )
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FP8 SplitKV decode requires gfx12x")
+@torch.inference_mode()
+def test_chunked_decode_routes_padded_fp8_cache_and_forwards_scales(
+    monkeypatch,
+) -> None:
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        12,
+        2,
+        256,
+        1568,
+        (1374,),
+        None,
+        0.73,
+        1.27,
+        padded_stride=True,
+    )
+    (
+        query,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    expected = _run_non_split(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        256**-0.5,
+        k_scale,
+        v_scale,
+    )
+    key_storage = key_cache.view(torch.uint8)
+    value_storage = value_cache.view(torch.uint8)
+    original = paged_decode_ops._paged_attention_2d_splitkv_decode
+    forwarded = {}
+    flydsl_routed = []
+
+    def route_spy(*args, **kwargs):
+        forwarded["k_scale"] = kwargs["k_scale"]
+        forwarded["v_scale"] = kwargs["v_scale"]
+        forwarded["cache_dtype"] = kwargs["key_cache"].dtype
+        return original(*args, **kwargs)
+
+    def flydsl_spy(*args, **kwargs):
+        flydsl_routed.append(True)
+        args[8].copy_(expected)
+
+    monkeypatch.setattr(
+        paged_decode_ops, "_paged_attention_2d_splitkv_decode", route_spy
+    )
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    select_kernel_config, _ = rdna4_ops._load_flydsl_splitkv()
+    monkeypatch.setattr(
+        rdna4_ops,
+        "_load_flydsl_splitkv",
+        lambda: (select_kernel_config, flydsl_spy),
+    )
+    paged_decode_ops.chunked_prefill_paged_decode(
+        query=query,
+        key=None,
+        value=None,
+        output=output,
+        kv_cache_dtype="fp8",
+        key_cache=key_storage,
+        value_cache=value_storage,
+        block_table=block_tables,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        max_seq_len=1374,
+        max_query_len=1,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+
+    assert forwarded == {
+        "k_scale": k_scale,
+        "v_scale": v_scale,
+        "cache_dtype": current_platform.fp8_dtype(),
+    }
+    assert flydsl_routed == [True]
+    torch.testing.assert_close(output, expected, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx1x(), reason="BF16 SplitKV decode requires gfx1x")
+@torch.inference_mode()
+def test_chunked_decode_routes_padded_bf16_cache(monkeypatch) -> None:
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.bfloat16,
+        12,
+        2,
+        256,
+        1568,
+        (8192,),
+        None,
+        padded_stride=True,
+    )
+    (
+        query,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    expected = _run_non_split(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        256**-0.5,
+        k_scale,
+        v_scale,
+    )
+    original = paged_decode_ops._paged_attention_2d_splitkv_decode
+    routed = []
+    flydsl_routed = []
+
+    def route_spy(*args, **kwargs):
+        routed.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        paged_decode_ops, "_paged_attention_2d_splitkv_decode", route_spy
+    )
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    select_kernel_config, run_flydsl = rdna4_ops._load_flydsl_splitkv()
+
+    def flydsl_spy(*args, **kwargs):
+        flydsl_routed.append(True)
+        return run_flydsl(*args, **kwargs)
+
+    monkeypatch.setattr(
+        rdna4_ops,
+        "_load_flydsl_splitkv",
+        lambda: (select_kernel_config, flydsl_spy),
+    )
+    paged_decode_ops.chunked_prefill_paged_decode(
+        query=query,
+        key=None,
+        value=None,
+        output=output,
+        kv_cache_dtype="auto",
+        key_cache=key_cache,
+        value_cache=value_cache,
+        block_table=block_tables,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        max_seq_len=8192,
+        max_query_len=1,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+
+    assert routed == [True]
+    assert flydsl_routed == [True]
+    torch.testing.assert_close(output, expected, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx1x(), reason="Native ROCm decode requires gfx1x")
+@torch.inference_mode()
+def test_native_paged_attention_precedes_splitkv_for_standard_layout(
+    monkeypatch,
+) -> None:
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.bfloat16,
+        16,
+        4,
+        128,
+        32,
+        (257,),
+        None,
+    )
+    (
+        query,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+    output = torch.empty_like(query)
+    native_called = []
+
+    def native_spy(output, *args, **kwargs) -> None:
+        native_called.append(True)
+        output.fill_(3)
+
+    def unexpected_splitkv(*args, **kwargs):
+        raise AssertionError("SplitKV must not precede the native ROCm kernel")
+
+    monkeypatch.setattr(
+        "vllm.platforms.rocm.use_rocm_custom_paged_attention",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(paged_decode_ops.ops, "paged_attention_rocm", native_spy)
+    monkeypatch.setattr(
+        paged_decode_ops, "_paged_attention_2d_splitkv_decode", unexpected_splitkv
+    )
+    paged_decode_ops.chunked_prefill_paged_decode(
+        query=query,
+        key=None,
+        value=None,
+        output=output,
+        kv_cache_dtype="auto",
+        key_cache=key_cache,
+        value_cache=value_cache,
+        block_table=block_tables,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        max_seq_len=257,
+        max_query_len=1,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+
+    assert native_called == [True]
+    torch.testing.assert_close(output, torch.full_like(output, 3))
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FP8 SplitKV decode requires gfx12x")
+@torch.inference_mode()
+def test_fp8_splitkv_locked_workspace_cudagraph_replays_dynamic_sequence() -> None:
+    set_random_seed(0)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        12,
+        2,
+        256,
+        1568,
+        (8192,),
+        16,
+        0.73,
+        1.27,
+        padded_stride=True,
+    )
+    (
+        query,
+        _,
+        _,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+    ) = _make_inputs(case)
+    output = torch.empty_like(query)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE)
+
+    reset_workspace_manager()
+    init_workspace_manager(query.device)
+    reserve_splitkv_workspace(
+        max_batch_size=1,
+        num_query_heads=12,
+        num_kv_heads=2,
+        head_size=256,
+        physical_block_size=1568,
+        max_seq_len=8192,
+        allow_short_context=True,
+    )
+    lock_workspace()
+    seq_lens.fill_(1)
+
+    def run_splitkv() -> None:
+        _paged_attention_2d_splitkv_decode(
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            seq_lens,
+            256**-0.5,
+            k_scale,
+            v_scale,
+            output=output,
+            actual_max_splits=16,
+            max_seq_len=8192,
+            query_start_loc=query_start_loc,
+            filter_by_query_len=True,
+        )
+
+    graph = None
+    try:
+        run_splitkv()
+        torch.accelerator.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run_splitkv()
+
+        query.copy_(torch.randn_like(query))
+        seq_lens.fill_(8192)
+        graph.replay()
+        torch.accelerator.synchronize()
+        expected = _run_non_split(
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            seq_lens,
+            256**-0.5,
+            k_scale,
+            v_scale,
+        )
+        torch.testing.assert_close(output, expected, atol=0.01, rtol=0.01)
+    finally:
+        del graph
+        reset_workspace_manager()
+
+
+def _broad_splitkv_cases():
+    # Pairwise dispatch sweep: every GQA ratio and batch threshold, both heads.
+    dtypes = (
+        (torch.bfloat16, torch.bfloat16),
+        (torch.float16, torch.float16),
+        (torch.bfloat16, torch.float8_e4m3fn),
+        (torch.float16, torch.float8_e4m3fn),
+        (torch.bfloat16, torch.float8_e4m3fnuz),
+        (torch.float16, torch.float8_e4m3fnuz),
+    )
+    index = 0
+    for head in (128, 256):
+        for gqa in range(1, 17):
+            for batch in (1, 3, 7, 8, 9, 16, 33):
+                dtype, kv_dtype = dtypes[index % len(dtypes)]
+                page = (16, 32, 528, 784, 1568)[index % 5]
+                lengths = tuple(
+                    (1, page - 1, page, page + 1, 257)[i % 5] for i in range(batch)
+                )
+                kv_heads = (1, 2, 4)[index % 3]
+                yield pytest.param(
+                    SplitKVCase(
+                        dtype,
+                        kv_dtype,
+                        gqa * kv_heads,
+                        kv_heads,
+                        head,
+                        page,
+                        lengths,
+                        (2, 4, 8, 16)[index % 4],
+                        0.73,
+                        1.27,
+                        padded_stride=True,
+                    ),
+                    index % 3,
+                    id=f"dispatch-d{head}-g{gqa}-b{batch}",
+                )
+                index += 1
+    # Cross each promoted specialization with all applicable dtype pairs.
+    for head, gqa, batch in (
+        (128, 16, 8),
+        (128, 16, 16),
+        (128, 16, 1),
+        (128, 8, 3),
+        (256, 4, 3),
+        (256, 16, 3),
+        (256, 6, 3),
+        (128, 3, 3),
+    ):
+        for dtype, kv_dtype in dtypes:
+            for profile in range(3):
+                page = (16, 784, 32)[profile]
+                lengths = tuple(
+                    (31, 32, 33, 127, 128, 129, 513)[i % 7] for i in range(batch)
+                )
+                yield pytest.param(
+                    SplitKVCase(
+                        dtype,
+                        kv_dtype,
+                        gqa * 2,
+                        2,
+                        head,
+                        page,
+                        lengths,
+                        (2, 8, 16)[profile],
+                        0.73,
+                        1.27,
+                        padded_stride=True,
+                    ),
+                    profile,
+                    id=f"route-d{head}-g{gqa}-b{batch}-{dtype}-{kv_dtype}-p{profile}",
+                )
+
+    for head, gqa in ((128, 16), (256, 6)):
+        for batch in (64, 128, 256):
+            for dtype, kv_dtype in dtypes:
+                yield pytest.param(
+                    SplitKVCase(
+                        dtype,
+                        kv_dtype,
+                        gqa * 2,
+                        2,
+                        head,
+                        32,
+                        (33,) * batch,
+                        4,
+                        0.73,
+                        1.27,
+                        padded_stride=True,
+                    ),
+                    0,
+                    id=f"high-batch-d{head}-g{gqa}-b{batch}-{dtype}-{kv_dtype}",
+                )
+
+
+def _qwen_tp_splitkv_cases():
+    # Qwen's full attention has 24 Q / 4 KV heads of dimension 256.
+    # Exercise the exact TP1/TP2/TP4 local shapes, including hybrid-cache pages.
+    for tp in (1, 2, 4):
+        for dtype, kv_dtype in (
+            (torch.bfloat16, torch.bfloat16),
+            (torch.float16, torch.float16),
+            (torch.bfloat16, torch.float8_e4m3fn),
+            (torch.bfloat16, torch.float8_e4m3fnuz),
+        ):
+            hybrid_page = 1568 if kv_dtype.itemsize == 1 else 784
+            for layout, page, lengths in (
+                ("standard", 32, (31, 32, 33)),
+                (
+                    "hybrid-boundary",
+                    hybrid_page,
+                    (hybrid_page - 1, hybrid_page, hybrid_page + 1),
+                ),
+                ("batch8", hybrid_page, tuple(4095 + i for i in range(8))),
+                ("long", hybrid_page, (32767,)),
+            ):
+                for profile in range(3):
+                    yield pytest.param(
+                        SplitKVCase(
+                            dtype,
+                            kv_dtype,
+                            24 // tp,
+                            4 // tp,
+                            256,
+                            page,
+                            lengths,
+                            (2, 4, 16)[profile],
+                            0.73,
+                            1.27,
+                            padded_stride=True,
+                        ),
+                        profile,
+                        id=f"qwen-tp{tp}-{kv_dtype}-{layout}-p{profile}",
+                    )
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "case,profile", [*_broad_splitkv_cases(), *_qwen_tp_splitkv_cases()]
+)
+@torch.inference_mode()
+def test_rdna4_splitkv_dispatch_boundaries_match_torch(
+    monkeypatch, record_property, case: SplitKVCase, profile: int
+) -> None:
+    """Guard dispatch boundaries, masked NaN tails and nonuniform attention.
+
+    Exercise the public SplitKV wrapper, including unsupported-shape fallback,
+    against dense FP32 attention over the actual stored cache values. Profile 1
+    stresses peaked softmax; profile 2 stresses nearly uniform attention.
+    """
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    set_random_seed(100 + profile)
+    q, dk, dv, k, v, tables, lens, ks, vs = _make_inputs(case)
+    q.mul_((1.0, 8.0, 0.01)[profile])
+    batch = len(case.seq_lens)
+    # Noncontiguous query/output head and row strides are part of the contract.
+    query_backing = torch.empty(
+        (batch, case.num_query_heads * 2, case.head_size + 8),
+        dtype=q.dtype,
+        device=DEVICE,
+    )
+    query = query_backing[:, ::2, : case.head_size]
+    query.copy_(q)
+    output_backing = torch.full_like(query_backing, 123)
+    output = output_backing[:, ::2, : case.head_size]
+    starts = torch.arange(batch + 1, dtype=torch.int32, device=DEVICE)
+    mid = torch.empty(
+        (batch, case.num_query_heads, case.splits, case.head_size),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    lse = torch.empty(mid.shape[:-1], dtype=torch.float32, device=DEVICE)
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    kwargs = dict(
+        query=query,
+        key_cache=k,
+        value_cache=v,
+        output=output,
+        block_tables=tables,
+        seq_lens=lens,
+        query_start_loc=starts,
+        k_scale=ks,
+        v_scale=vs,
+        scale=case.head_size**-0.5,
+        actual_max_splits=case.splits,
+        max_seq_len=max(case.seq_lens),
+        filter_by_query_len=True,
+    )
+    config = rdna4_ops.get_rdna4_flydsl_splitkv_config(**kwargs)
+    used = rdna4_ops.try_rdna4_splitkv_paged_attention(
+        **kwargs, mid_out=mid, mid_lse=lse
+    )
+    assert used == (config is not None)
+    record_property("route", config.route.value if config else "triton_fallback")
+    if not used:
+        _paged_attention_2d_splitkv_decode(**kwargs, mid_out=mid, mid_lse=lse)
+    reference = _torch_reference(
+        query,
+        dk,
+        dv,
+        tables,
+        lens,
+        case.head_size**-0.5,
+        case.k_scale if case.kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if case.kv_dtype.itemsize == 1 else 1.0,
+    )
+    assert torch.isfinite(output).all()
+    record_property(
+        "max_abs_error", (output.float() - reference.float()).abs().max().item()
+    )
+    torch.testing.assert_close(output, reference, atol=0.01, rtol=0.01)
+    assert (output_backing[:, 1::2] == 123).all()
+    assert (output_backing[:, ::2, case.head_size :] == 123).all()
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "head,gqa,batch,kv_dtype",
+    [
+        (128, 16, 8, torch.bfloat16),
+        (128, 16, 16, torch.bfloat16),
+        (128, 16, 1, torch.bfloat16),
+        (128, 8, 3, torch.float8_e4m3fn),
+        (256, 4, 3, torch.bfloat16),
+        (256, 16, 3, torch.float8_e4m3fn),
+        (256, 6, 3, torch.float8_e4m3fn),
+        (128, 3, 3, torch.float8_e4m3fn),
+        (256, 3, 3, torch.float8_e4m3fnuz),
+    ],
+)
+@torch.inference_mode()
+def test_rdna4_flydsl_graph_replays_mixed_rows_and_lengths(
+    monkeypatch, head: int, gqa: int, batch: int, kv_dtype: torch.dtype
+) -> None:
+    """Every specialization must tolerate changing decode/prefill membership.
+
+    Reusing a captured graph also checks that Wave8 completion counters reset
+    between launches, including launches containing no decode rows.
+    """
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    set_random_seed(19)
+    case = SplitKVCase(
+        torch.bfloat16,
+        kv_dtype,
+        gqa * 2,
+        2,
+        head,
+        32,
+        (513,) * batch,
+        16,
+        0.73,
+        1.27,
+        padded_stride=True,
+    )
+    q, dk, dv, k, v, tables, lens, ks, vs = _make_inputs(case)
+    query = torch.randn((batch * 3, gqa * 2, head), dtype=q.dtype, device=DEVICE)
+    output = torch.full_like(query, 123)
+    starts = torch.arange(batch + 1, dtype=torch.int32, device=DEVICE)
+    mid = torch.empty((batch, gqa * 2, 16, head), dtype=torch.float32, device=DEVICE)
+    lse = torch.empty(mid.shape[:-1], dtype=torch.float32, device=DEVICE)
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+
+    def run():
+        assert rdna4_ops.try_rdna4_splitkv_paged_attention(
+            query=query,
+            key_cache=k,
+            value_cache=v,
+            output=output,
+            block_tables=tables,
+            seq_lens=lens,
+            query_start_loc=starts,
+            k_scale=ks,
+            v_scale=vs,
+            scale=head**-0.5,
+            actual_max_splits=16,
+            max_seq_len=513,
+            filter_by_query_len=True,
+            mid_out=mid,
+            mid_lse=lse,
+        )
+
+    run()
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    for step, length in enumerate((0, 1, 15, 16, 17, 31, 32, 33, 513, 0)):
+        counts = [(i + step) % 3 for i in range(batch)]
+        offsets = [0]
+        for count in counts:
+            offsets.append(offsets[-1] + count)
+        starts.copy_(torch.tensor(offsets, dtype=torch.int32, device=DEVICE))
+        lens.fill_(length)
+        query.normal_()
+        output.fill_(123)
+        for _ in range(10):
+            graph.replay()
+        torch.accelerator.synchronize()
+        ref = _torch_reference(
+            query[starts[:-1].long()],
+            dk,
+            dv,
+            tables,
+            lens,
+            head**-0.5,
+            case.k_scale if kv_dtype.itemsize == 1 else 1.0,
+            case.v_scale if kv_dtype.itemsize == 1 else 1.0,
+        )
+        untouched = torch.ones(query.shape[0], dtype=torch.bool, device=DEVICE)
+        for seq, count in enumerate(counts):
+            if count == 1:
+                row = offsets[seq]
+                torch.testing.assert_close(output[row], ref[seq], atol=0.01, rtol=0.01)
+                untouched[row] = False
+        assert (output[untouched] == 123).all()
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "head,gqa,batch", [(128, 1, 1), (128, 16, 1), (256, 8, 1), (256, 6, 3)]
+)
+@pytest.mark.parametrize(
+    "kv_dtype", [torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.bfloat16]
+)
+@pytest.mark.parametrize("code_offset", [0, 128])
+@torch.inference_mode()
+def test_rdna4_flydsl_preserves_cache_value_range(
+    monkeypatch, head, gqa, batch, kv_dtype, code_offset
+) -> None:
+    """Single-token attention must return every finite FP8 code or large BF16 V."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    case = SplitKVCase(
+        torch.bfloat16,
+        kv_dtype,
+        gqa,
+        1,
+        head,
+        32,
+        (1,) * batch,
+        4,
+        0.73,
+        1.27,
+        padded_stride=True,
+    )
+    q, dk, dv, _, _, tables, lens, ks, vs = _make_inputs(case)
+    dk.zero_()
+    if kv_dtype.itemsize == 1:
+        codes = torch.arange(256, dtype=torch.int32, device=DEVICE).to(torch.uint8)
+        values = codes.view(kv_dtype).float()
+        values.nan_to_num_(nan=0.0)
+    else:
+        values = torch.linspace(-1e5, 1e5, 256, device=DEVICE)
+    dv[:, 0, 0, :] = values[(torch.arange(head, device=DEVICE) + code_offset) % 256].to(
+        kv_dtype
+    )
+    k, v = _pack_cache(dk, dv, padded_stride=True)
+    out = torch.empty_like(q)
+    starts = torch.arange(batch + 1, dtype=torch.int32, device=DEVICE)
+    mid = torch.empty((batch, gqa, 4, head), dtype=torch.float32, device=DEVICE)
+    lse = torch.empty(mid.shape[:-1], dtype=torch.float32, device=DEVICE)
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    assert rdna4_ops.try_rdna4_splitkv_paged_attention(
+        query=q,
+        key_cache=k,
+        value_cache=v,
+        output=out,
+        block_tables=tables,
+        seq_lens=lens,
+        query_start_loc=starts,
+        k_scale=ks,
+        v_scale=vs,
+        scale=head**-0.5,
+        actual_max_splits=4,
+        max_seq_len=1,
+        filter_by_query_len=True,
+        mid_out=mid,
+        mid_lse=lse,
+    )
+    ref = _torch_reference(
+        q,
+        dk,
+        dv,
+        tables,
+        lens,
+        head**-0.5,
+        case.k_scale if kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if kv_dtype.itemsize == 1 else 1.0,
+    )
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, ref, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize("splits", [2, 4, 8, 16])
+@pytest.mark.parametrize(
+    "head,page,query_dtype,kv_dtype",
+    [
+        (128, 8, torch.bfloat16, torch.float8_e4m3fnuz),
+        (256, 24, torch.float16, torch.float8_e4m3fn),
+        (128, 24, torch.bfloat16, torch.bfloat16),
+        (256, 8, torch.float16, torch.float16),
+    ],
+)
+@torch.inference_mode()
+def test_rdna4_wave8_concurrent_streams_do_not_share_counters(
+    monkeypatch, splits, head, page, query_dtype, kv_dtype
+) -> None:
+    """Concurrent captured launches must use independent completion counters."""
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    set_random_seed(71)
+    case = SplitKVCase(
+        query_dtype,
+        kv_dtype,
+        6,
+        2,
+        head,
+        page,
+        (1, 33, 513),
+        splits,
+        0.73,
+        1.27,
+        padded_stride=True,
+    )
+    q, dk, dv, k, v, tables, lens, ks, vs = _make_inputs(case)
+    starts = torch.arange(4, dtype=torch.int32, device=DEVICE)
+    streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    outputs = [torch.empty_like(q) for _ in streams]
+    mids = [
+        torch.empty((3, 6, splits, head), dtype=torch.float32, device=DEVICE)
+        for _ in streams
+    ]
+    lses = [torch.empty(t.shape[:-1], dtype=torch.float32, device=DEVICE) for t in mids]
+    graphs = []
+    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+
+    def run(i):
+        assert rdna4_ops.try_rdna4_splitkv_paged_attention(
+            query=q,
+            key_cache=k,
+            value_cache=v,
+            output=outputs[i],
+            block_tables=tables,
+            seq_lens=lens,
+            query_start_loc=starts,
+            k_scale=ks,
+            v_scale=vs,
+            scale=head**-0.5,
+            actual_max_splits=splits,
+            max_seq_len=513,
+            filter_by_query_len=True,
+            mid_out=mids[i],
+            mid_lse=lses[i],
+        )
+
+    for i, stream in enumerate(streams):
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            run(i)
+        stream.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            run(i)
+        graphs.append(graph)
+    for _ in range(50):
+        for stream, graph in zip(streams, graphs):
+            with torch.cuda.stream(stream):
+                graph.replay()
+    torch.accelerator.synchronize()
+    ref = _torch_reference(
+        q,
+        dk,
+        dv,
+        tables,
+        lens,
+        head**-0.5,
+        case.k_scale if kv_dtype.itemsize == 1 else 1.0,
+        case.v_scale if kv_dtype.itemsize == 1 else 1.0,
+    )
+    for out in outputs:
+        assert torch.isfinite(out).all()
+        torch.testing.assert_close(out, ref, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FlyDSL SplitKV requires gfx12x")
+@pytest.mark.parametrize(
+    "gqa,batch,length,fp8,route",
+    [
+        (16, 16, 8191, False, "native_d128_gqa16_lds"),
+        (16, 16, 8192, False, "d128_gqa16_tile32"),
+        (3, 1, 2047, False, "wave8"),
+        (3, 1, 2048, False, None),
+        (2, 1, 2048, False, "wave8"),
+        (2, 2, 2048, False, None),
+        (4, 1, 2048, True, "wave8"),
+        (4, 3, 2048, True, None),
+        (8, 3, 8192, False, "generic_tile32"),
+    ],
+)
+def test_rdna4_splitkv_keeps_faster_long_context_routes(gqa, batch, length, fp8, route):
+    from vllm.v1.attention.ops.flydsl_kernels.rdna4_splitkv import select_kernel_config
+
+    query = torch.empty((batch, gqa * 2, 128), dtype=torch.bfloat16, device="meta")
+    cache = torch.empty(
+        (1, 2, 8, 784, 16),
+        dtype=torch.float8_e4m3fn if fp8 else torch.bfloat16,
+        device="meta",
+    )
+    lens = torch.empty(batch, dtype=torch.int32, device="meta")
+    config = select_kernel_config(query, cache, lens, length)
+    assert (config.route.value if config else None) == route
+
+
+@pytest.mark.skipif(not on_gfx12x(), reason="FP8 SplitKV requires gfx12x")
+@torch.inference_mode()
+def test_fp8_unsplit_d256_padded_cache_compiles_and_matches_torch():
+    """Eight warps avoid a gfx1201 register allocator abort for this layout."""
+    set_random_seed(51)
+    case = SplitKVCase(
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        2,
+        2,
+        256,
+        784,
+        (8193,),
+        1,
+        0.73,
+        1.27,
+        padded_stride=True,
+    )
+    q, dk, dv, k, v, tables, lens, ks, vs = _make_inputs(case)
+    q.mul_(8)
+    out = _paged_attention_2d_splitkv_decode(
+        q,
+        k,
+        v,
+        tables,
+        lens,
+        256**-0.5,
+        ks,
+        vs,
+        actual_max_splits=1,
+        max_seq_len=8193,
+    )
+    ref = _torch_reference(q, dk, dv, tables, lens, 256**-0.5, 0.73, 1.27)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, ref, atol=0.01, rtol=0.01)
+
+
+@pytest.mark.parametrize(
+    "namespace,missing_api",
+    [
+        ("llvm", "memory_fence"),
+        ("llvm", "atomic_add"),
+        ("llvm", "generic_store"),
+        (None, "AtomicOrdering"),
+        ("rocdl", "SyncScope"),
+    ],
+)
+def test_rdna4_flydsl_missing_memory_api_falls_back(
+    monkeypatch, namespace, missing_api
+):
+    """An older FlyDSL with scalar FP8 alone cannot safely launch Wave8."""
+    fx = pytest.importorskip("flydsl.expr")
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    rdna4_ops._load_flydsl_splitkv.cache_clear()
+    rdna4_ops.is_rdna4_flydsl_splitkv_available.cache_clear()
+    try:
+        with monkeypatch.context() as patch:
+            module = fx if namespace is None else getattr(fx, namespace)
+            patch.delattr(module, missing_api, raising=False)
+            assert not rdna4_ops.is_rdna4_flydsl_splitkv_available()
+    finally:
+        rdna4_ops._load_flydsl_splitkv.cache_clear()
+        rdna4_ops.is_rdna4_flydsl_splitkv_available.cache_clear()
+
+
+def test_rdna4_flydsl_loads_without_legacy_rocdl_memory_apis(monkeypatch):
+    fx = pytest.importorskip("flydsl.expr")
+    from vllm.v1.attention.ops import rdna4_splitkv as rdna4_ops
+
+    rdna4_ops._load_flydsl_splitkv.cache_clear()
+    rdna4_ops.is_rdna4_flydsl_splitkv_available.cache_clear()
+    try:
+        with monkeypatch.context() as patch:
+            for name in (
+                "memory_fence",
+                "atomic_fetch_add",
+                "global_store",
+                "MemoryOrder",
+            ):
+                patch.delattr(fx.rocdl, name, raising=False)
+            assert rdna4_ops.is_rdna4_flydsl_splitkv_available()
+    finally:
+        rdna4_ops._load_flydsl_splitkv.cache_clear()
+        rdna4_ops.is_rdna4_flydsl_splitkv_available.cache_clear()

--- a/tests/kernels/attention/test_splitkv_paged_decode.py
+++ b/tests/kernels/attention/test_splitkv_paged_decode.py
@@ -2125,9 +2125,10 @@ def _qwen_tp_splitkv_cases():
 @pytest.mark.parametrize(
     "case,profile", [*_broad_splitkv_cases(), *_qwen_tp_splitkv_cases()]
 )
+@pytest.mark.parametrize("use_flydsl", [False, True], ids=["triton", "flydsl"])
 @torch.inference_mode()
 def test_rdna4_splitkv_dispatch_boundaries_match_torch(
-    monkeypatch, record_property, case: SplitKVCase, profile: int
+    monkeypatch, record_property, case: SplitKVCase, profile: int, use_flydsl: bool
 ) -> None:
     """Guard dispatch boundaries, masked NaN tails and nonuniform attention.
 
@@ -2158,7 +2159,15 @@ def test_rdna4_splitkv_dispatch_boundaries_match_torch(
         device=DEVICE,
     )
     lse = torch.empty(mid.shape[:-1], dtype=torch.float32, device=DEVICE)
-    monkeypatch.setattr(rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", True)
+    monkeypatch.setattr(
+        rdna4_ops.envs, "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", use_flydsl
+    )
+    if not use_flydsl:
+
+        def unexpected_flydsl_load():
+            pytest.fail("Triton-only validation must not load FlyDSL kernels")
+
+        monkeypatch.setattr(rdna4_ops, "_load_flydsl_splitkv", unexpected_flydsl_load)
     kwargs = dict(
         query=query,
         key_cache=k,
@@ -2174,12 +2183,14 @@ def test_rdna4_splitkv_dispatch_boundaries_match_torch(
         max_seq_len=max(case.seq_lens),
         filter_by_query_len=True,
     )
-    config = rdna4_ops.get_rdna4_flydsl_splitkv_config(**kwargs)
+    config = rdna4_ops.get_rdna4_flydsl_splitkv_config(**kwargs) if use_flydsl else None
     used = rdna4_ops.try_rdna4_splitkv_paged_attention(
         **kwargs, mid_out=mid, mid_lse=lse
     )
     assert used == (config is not None)
     record_property("route", config.route.value if config else "triton_fallback")
+    record_property("kv_dtype", str(case.kv_dtype))
+    record_property("backend_requested", "flydsl" if use_flydsl else "triton")
     if not used:
         _paged_attention_2d_splitkv_decode(**kwargs, mid_out=mid, mid_lse=lse)
     reference = _torch_reference(

--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -106,6 +106,38 @@ def test_workspace_lock_blocks_growth_and_unlock_restores(monkeypatch) -> None:
     assert grown.numel() == 512
 
 
+def test_reserve_simultaneous_sizes_every_ubatch_in_current_lane(
+    monkeypatch,
+) -> None:
+    active_ubatch = [0]
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: active_ubatch[0])
+    manager = workspace.WorkspaceManager(
+        torch.device("cpu"), num_ubatches=2, num_lanes=2
+    )
+
+    manager._reserve_simultaneous(
+        ((64,), torch.float32),
+        ((16,), torch.float32),
+    )
+    assert manager._current_workspaces[0] is not None
+    assert manager._current_workspaces[2] is not None
+    assert manager._current_workspaces[1] is None
+    assert manager._current_workspaces[3] is None
+
+    manager.lock()
+    for ubatch_id in range(2):
+        active_ubatch[0] = ubatch_id
+        first, second = manager.get_simultaneous(
+            ((64,), torch.float32),
+            ((16,), torch.float32),
+        )
+        assert first.numel() == 64
+        assert second.numel() == 16
+
+    with pytest.raises(RuntimeError, match="initialization-only"):
+        manager._reserve_simultaneous(((64,), torch.float32))
+
+
 def test_workspace_lane_validation(monkeypatch) -> None:
     monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
     manager = workspace.WorkspaceManager(torch.device("cpu"), num_lanes=1)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -133,6 +133,7 @@ if TYPE_CHECKING:
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
     VLLM_ROCM_USE_AITER: bool = False
+    VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL: bool = False
     VLLM_ROCM_USE_AITER_CUSTOM_AR: bool = True
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
     VLLM_ROCM_USE_AITER_LINEAR_HIPBMM: bool = False
@@ -1256,6 +1257,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_ROCM_USE_AITER": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER", "False").lower() in ("true", "1")
+    ),
+    # Enable the vLLM-owned RDNA4 FlyDSL SplitKV paged-attention backend.
+    "VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL": lambda: (
+        os.getenv("VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL", "False").lower()
+        in ("true", "1")
     ),
     # Use AITER's CustomAllreduce as the custom-allreduce backend inside vLLM's
     # CudaCommunicator on ROCm.

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -27,17 +27,45 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
+from vllm.v1.attention.backends.utils import get_num_attention_heads_from_layers
 from vllm.v1.attention.ops.chunked_prefill_paged_decode import (
     chunked_prefill_paged_decode,
     has_native_kv_cache_layout,
+    reserve_splitkv_workspace,
 )
 from vllm.v1.attention.ops.paged_attn import PagedAttention
 from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheLayout
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheLayout, KVQuantMode
 
 logger = init_logger(__name__)
+
+
+def _splitkv_workspace_support(
+    kv_cache_spec: AttentionSpec,
+    model_dtype: torch.dtype,
+    *,
+    is_e4m3_kv_cache: bool,
+    is_gfx1x: bool,
+    is_gfx12x: bool,
+) -> tuple[bool, bool]:
+    """Return ``(supported, is_fp8)`` for SplitKV scratch reservation.
+
+    FP8 cache specs use byte storage, so the caller supplies the concrete
+    encoding retained by the cache configuration.
+    """
+    native_kv_supported = (
+        kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
+        and kv_cache_spec.dtype == model_dtype
+    )
+    fp8_kv_supported = (
+        kv_cache_spec.kv_quant_mode == KVQuantMode.FP8_PER_TENSOR
+        and kv_cache_spec.dtype.itemsize == 1
+        and is_e4m3_kv_cache
+        and is_gfx12x
+    )
+    return is_gfx1x and (native_kv_supported or fp8_kv_supported), fp8_kv_supported
 
 
 @dataclass
@@ -88,11 +116,39 @@ class RocmAttentionMetadataBuilder(AttentionMetadataBuilder[RocmAttentionMetadat
         self.block_size = kv_cache_spec.block_size
 
         model_config = vllm_config.model_config
-        self.num_heads_q = model_config.get_num_attention_heads(
-            vllm_config.parallel_config
+        self.num_heads_q = get_num_attention_heads_from_layers(
+            vllm_config, layer_names
+        ) or model_config.get_num_attention_heads(vllm_config.parallel_config)
+        self.num_heads_kv = kv_cache_spec.num_kv_heads
+        self.headdim = kv_cache_spec.head_size
+
+        from vllm.platforms.rocm import on_gfx1x, on_gfx12x
+
+        splitkv_supported, fp8_kv_supported = _splitkv_workspace_support(
+            kv_cache_spec,
+            model_config.dtype,
+            is_e4m3_kv_cache=vllm_config.cache_config.cache_dtype
+            in ("fp8", "fp8_e4m3"),
+            is_gfx1x=on_gfx1x(),
+            is_gfx12x=on_gfx12x(),
         )
-        self.num_heads_kv = model_config.get_num_kv_heads(vllm_config.parallel_config)
-        self.headdim = model_config.get_head_size()
+
+        if (
+            splitkv_supported
+            and self.headdim in (128, 256)
+            and self.num_heads_kv > 0
+            and self.num_heads_q % self.num_heads_kv == 0
+            and self.num_heads_q // self.num_heads_kv <= 16
+        ):
+            reserve_splitkv_workspace(
+                vllm_config.scheduler_config.max_num_seqs,
+                self.num_heads_q,
+                self.num_heads_kv,
+                self.headdim,
+                self.block_size,
+                model_config.max_model_len,
+                allow_short_context=fp8_kv_supported,
+            )
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -7,18 +7,52 @@
 #  - Chih-Chieh Yang <chih.chieh.yang@ibm.com>
 #  - Thomas Parnell <tpa@zurich.ibm.com>
 
+import math
+from functools import cache, lru_cache
+
 import torch
 
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.v1.kv_cache_interface import get_kv_quant_mode
+from vllm.v1.worker.workspace import (
+    current_workspace_manager,
+    is_workspace_manager_initialized,
+)
 
 from .prefix_prefill import context_attention_fwd
+from .rdna4_splitkv import (
+    _can_use_rdna4_splitkv_decode,
+    try_rdna4_splitkv_paged_attention,
+)
 
 logger = init_logger(__name__)
 
 float8_info = torch.finfo(current_platform.fp8_dtype())
+
+_MAX_SPLITS = 16
+_DEFAULT_COMPUTE_BLOCK_SIZE = 32
+
+
+def _choose_compute_block_size(physical_block_size: int) -> int:
+    """Choose the logical attention tile size inside a physical KV block."""
+    is_pow2 = physical_block_size > 0 and not (
+        physical_block_size & (physical_block_size - 1)
+    )
+    if is_pow2:
+        return min(physical_block_size, _DEFAULT_COMPUTE_BLOCK_SIZE)
+    # Stride-based addressing permits a logical tile to cross a physical page.
+    return _DEFAULT_COMPUTE_BLOCK_SIZE
+
+
+def _choose_fallback_block_size(physical_block_size: int) -> int:
+    """Match the incumbent non-split Triton launch tile."""
+    is_pow2 = physical_block_size > 0 and not (
+        physical_block_size & (physical_block_size - 1)
+    )
+    return min(physical_block_size, 128) if is_pow2 else 32
 
 
 def has_native_kv_cache_layout(
@@ -35,6 +69,15 @@ def has_native_kv_cache_layout(
         key_cache.stride(0) == key_cache.shape[1:].numel()
         and value_cache.stride(0) == value_cache.shape[1:].numel()
     )
+
+
+def _cdiv(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+@cache
+def _get_num_sms(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
 
 
 @triton.jit
@@ -94,7 +137,7 @@ def kernel_paged_attention_2d(
         cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
         cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
         cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
-        if cur_batch_query_len > 1:
+        if cur_batch_query_len != 1:
             return
     else:
         cur_batch_in_all_start_index = seq_idx
@@ -213,15 +256,10 @@ def kernel_paged_attention_2d(
                 eviction_policy="evict_last",
             )
 
-        if K_load.dtype.is_fp8():
-            K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
-        else:
-            K = K_load
+        # Keep FP8 scales in FP32; the intermediate also preserves FNUZ decoding.
+        K = K_load.to(tl.float32).to(Q.dtype) if K_load.dtype.is_fp8() else K_load
 
-        if V_load.dtype.is_fp8():
-            V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
-        else:
-            V = V_load
+        V = V_load.to(tl.float32).to(Q.dtype) if V_load.dtype.is_fp8() else V_load
 
         seq_offset = j * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         boundary = tl.full([BLOCK_SIZE], seq_len, dtype=tl.int32)
@@ -229,6 +267,8 @@ def kernel_paged_attention_2d(
 
         # First calculate the dot, then apply the mask.
         qk = scale * tl.dot(Q, K)
+        if K_load.dtype.is_fp8():
+            qk *= tl.load(k_scale)
         S = tl.where(head_mask[:, None] & seq_mask, qk, float("-inf"))
 
         context_len = seq_len - 1
@@ -266,6 +306,8 @@ def kernel_paged_attention_2d(
 
     # epilogue
     acc = acc / (L[:, None] + 1e-10)
+    if value_cache_ptr.dtype.element_ty.is_fp8():
+        acc *= tl.load(v_scale)
     if USE_FP8:
         acc = acc * tl.load(out_scale_inv)
         acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
@@ -280,6 +322,650 @@ def kernel_paged_attention_2d(
         acc,
         mask=dim_mask[None, :] & head_mask[:, None],
     )
+
+
+@triton.jit
+def kernel_paged_attention_2d_splitkv(
+    mid_out_ptr,  # [num_seqs, num_query_heads, max_num_splits, head_size]
+    mid_lse_ptr,  # [num_seqs, num_query_heads, max_num_splits]
+    query_ptr,  # [num_tokens, num_query_heads, head_size]
+    key_cache_ptr,  # [num_blocks, num_kv_heads, head_size // x, page_size, x]
+    value_cache_ptr,  # [num_blocks, num_kv_heads, head_size, page_size]
+    block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
+    seq_lens_ptr,  # [num_seqs]
+    scale,
+    k_scale,
+    v_scale,
+    num_query_heads: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+    num_queries_per_kv_padded: tl.constexpr,
+    block_table_stride: tl.int64,
+    query_stride_0: tl.int64,
+    query_stride_1: tl.int64,
+    mid_out_stride_0: tl.int64,
+    mid_out_stride_1: tl.int64,
+    mid_out_stride_2: tl.int64,
+    mid_lse_stride_0: tl.int64,
+    mid_lse_stride_1: tl.int64,
+    mid_lse_stride_2: tl.int64,
+    BLOCK_SIZE: tl.constexpr,
+    PHYSICAL_BLOCK_SIZE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+    x: tl.constexpr,
+    stride_k_cache_0: tl.int64,
+    stride_k_cache_1: tl.int64,
+    stride_k_cache_2: tl.int64,
+    stride_k_cache_3: tl.int64,
+    stride_k_cache_4: tl.int64,
+    stride_v_cache_0: tl.int64,
+    stride_v_cache_1: tl.int64,
+    stride_v_cache_2: tl.int64,
+    stride_v_cache_3: tl.int64,
+    filter_by_query_len: tl.constexpr,
+    query_start_len_ptr,  # [num_seqs + 1]
+):
+    seq_idx = tl.program_id(0)
+    kv_head_idx = tl.program_id(1)
+    split_idx = tl.program_id(2)
+
+    if filter_by_query_len:
+        query_start = tl.load(query_start_len_ptr + seq_idx)
+        query_stop = tl.load(query_start_len_ptr + seq_idx + 1)
+        if query_stop - query_start != 1:
+            return
+    else:
+        query_start = seq_idx
+
+    seq_len = tl.load(seq_lens_ptr + seq_idx)
+    num_splits = tl.num_programs(2)
+    split_len = cdiv_fn(cdiv_fn(seq_len, num_splits), BLOCK_SIZE) * BLOCK_SIZE
+    split_start = split_idx * split_len
+    split_end = tl.minimum(split_start + split_len, seq_len)
+
+    query_head_idx = kv_head_idx * num_queries_per_kv + tl.arange(
+        0, num_queries_per_kv_padded
+    )
+    head_mask = query_head_idx < (kv_head_idx + 1) * num_queries_per_kv
+    head_mask = head_mask & (query_head_idx < num_query_heads)
+
+    offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+    dim_mask = offs_d < HEAD_SIZE
+    query_offset = (
+        query_start * query_stride_0 + query_head_idx[:, None] * query_stride_1
+    )
+    Q = tl.load(
+        query_ptr + query_offset + offs_d[None, :],
+        mask=head_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    )
+
+    M = tl.full([num_queries_per_kv_padded], float("-inf"), dtype=tl.float32)
+    L = tl.zeros([num_queries_per_kv_padded], dtype=tl.float32)
+    acc = tl.zeros([num_queries_per_kv_padded, HEAD_SIZE_PADDED], dtype=tl.float32)
+
+    block_table_offset = seq_idx * block_table_stride
+    offs_n = tl.arange(0, BLOCK_SIZE)
+    for start_n in tl.range(split_start, split_end, BLOCK_SIZE):
+        abs_token_idx = start_n + offs_n
+        token_mask = abs_token_idx < split_end
+        logical_block_idx = abs_token_idx // PHYSICAL_BLOCK_SIZE
+        physical_block_idx = tl.load(
+            block_tables_ptr + block_table_offset + logical_block_idx,
+            mask=token_mask,
+            other=0,
+        )
+        internal_offsets = abs_token_idx % PHYSICAL_BLOCK_SIZE
+
+        key_offset = (
+            physical_block_idx[None, :] * stride_k_cache_0
+            + kv_head_idx * stride_k_cache_1
+            + (offs_d[:, None] // x) * stride_k_cache_2
+            + internal_offsets[None, :] * stride_k_cache_3
+            + (offs_d[:, None] % x) * stride_k_cache_4
+        )
+        K_load = tl.load(
+            key_cache_ptr + key_offset,
+            mask=dim_mask[:, None] & token_mask[None, :],
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+
+        value_offset = (
+            physical_block_idx[:, None] * stride_v_cache_0
+            + kv_head_idx * stride_v_cache_1
+            + offs_d[None, :] * stride_v_cache_2
+            + internal_offsets[:, None] * stride_v_cache_3
+        )
+        V_load = tl.load(
+            value_cache_ptr + value_offset,
+            mask=token_mask[:, None] & dim_mask[None, :],
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+
+        # Keep FP8 scales in FP32; the intermediate also preserves FNUZ decoding.
+        K = K_load.to(tl.float32).to(Q.dtype) if K_load.dtype.is_fp8() else K_load
+        V = V_load.to(tl.float32).to(Q.dtype) if V_load.dtype.is_fp8() else V_load
+
+        scores = scale * tl.dot(Q, K)
+        if K_load.dtype.is_fp8():
+            scores *= tl.load(k_scale)
+        scores = tl.where(
+            head_mask[:, None] & token_mask[None, :], scores, float("-inf")
+        )
+        new_max = tl.maximum(M, tl.max(scores, axis=1))
+        probabilities = tl.exp(scores - new_max[:, None])
+        probabilities = tl.where(new_max[:, None] == float("-inf"), 0.0, probabilities)
+        block_sum = tl.sum(probabilities, axis=1)
+        alpha = tl.exp(M - new_max)
+        alpha = tl.where(float("-inf") == M, 0.0, alpha)
+
+        acc *= alpha[:, None]
+        L = L * alpha + block_sum
+        M = new_max
+        acc += tl.dot(probabilities.to(V.dtype), V)
+
+    if value_cache_ptr.dtype.element_ty.is_fp8():
+        acc *= tl.load(v_scale)
+
+    mid_out_offset = (
+        seq_idx * mid_out_stride_0
+        + query_head_idx[:, None] * mid_out_stride_1
+        + split_idx * mid_out_stride_2
+        + offs_d[None, :]
+    )
+    mid_lse_offset = (
+        seq_idx * mid_lse_stride_0
+        + query_head_idx * mid_lse_stride_1
+        + split_idx * mid_lse_stride_2
+    )
+    has_tokens = split_end > split_start
+    tl.store(
+        mid_out_ptr + mid_out_offset,
+        acc / (L[:, None] + 1e-10),
+        mask=has_tokens & head_mask[:, None] & dim_mask[None, :],
+    )
+    tl.store(
+        mid_lse_ptr + mid_lse_offset,
+        M + tl.log(L),
+        mask=has_tokens & head_mask,
+    )
+
+
+@triton.jit
+def kernel_paged_attention_2d_splitkv_reduce(
+    output_ptr,  # [num_tokens, num_query_heads, head_size]
+    mid_out_ptr,  # [num_seqs, num_query_heads, max_num_splits, head_size]
+    mid_lse_ptr,  # [num_seqs, num_query_heads, max_num_splits]
+    seq_lens_ptr,  # [num_seqs]
+    output_stride_0: tl.int64,
+    output_stride_1: tl.int64,
+    mid_out_stride_0: tl.int64,
+    mid_out_stride_1: tl.int64,
+    mid_out_stride_2: tl.int64,
+    mid_lse_stride_0: tl.int64,
+    mid_lse_stride_1: tl.int64,
+    mid_lse_stride_2: tl.int64,
+    BLOCK_SIZE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+    MAX_NUM_SPLITS: tl.constexpr,
+    filter_by_query_len: tl.constexpr,
+    query_start_len_ptr,  # [num_seqs + 1]
+):
+    seq_idx = tl.program_id(0)
+    query_head_idx = tl.program_id(1)
+
+    if filter_by_query_len:
+        query_start = tl.load(query_start_len_ptr + seq_idx)
+        query_stop = tl.load(query_start_len_ptr + seq_idx + 1)
+        if query_stop - query_start != 1:
+            return
+    else:
+        query_start = seq_idx
+
+    seq_len = tl.load(seq_lens_ptr + seq_idx)
+    split_len = cdiv_fn(cdiv_fn(seq_len, MAX_NUM_SPLITS), BLOCK_SIZE) * BLOCK_SIZE
+    offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+    dim_mask = offs_d < HEAD_SIZE
+    M = -float("inf")
+    L = 0.0
+    acc = tl.zeros([HEAD_SIZE_PADDED], dtype=tl.float32)
+
+    for split_idx in tl.range(0, MAX_NUM_SPLITS, num_stages=2):
+        split_start = split_idx * split_len
+        split_end = tl.minimum(split_start + split_len, seq_len)
+        if split_end > split_start:
+            partial_lse = tl.load(
+                mid_lse_ptr
+                + seq_idx * mid_lse_stride_0
+                + query_head_idx * mid_lse_stride_1
+                + split_idx * mid_lse_stride_2
+            )
+            partial_out = tl.load(
+                mid_out_ptr
+                + seq_idx * mid_out_stride_0
+                + query_head_idx * mid_out_stride_1
+                + split_idx * mid_out_stride_2
+                + offs_d,
+                mask=dim_mask,
+                other=0.0,
+            )
+            new_max = tl.maximum(M, partial_lse)
+            alpha = tl.exp(M - new_max)
+            beta = tl.exp(partial_lse - new_max)
+            acc = acc * alpha + partial_out * beta
+            L = L * alpha + beta
+            M = new_max
+
+    tl.store(
+        output_ptr
+        + query_start * output_stride_0
+        + query_head_idx * output_stride_1
+        + offs_d,
+        acc / (L + 1e-10),
+        mask=dim_mask,
+    )
+
+
+@lru_cache(maxsize=256)
+def _num_splits_heuristic(
+    batch_nheads: int,
+    num_sms: int,
+    num_n_blocks: int,
+    max_splits: int,
+) -> int:
+    """Choose the smallest split count near peak wave efficiency."""
+    target_workgroups = 2 * num_sms
+    if batch_nheads >= 0.8 * target_workgroups:
+        return 1
+
+    max_splits = min(max_splits, num_sms, num_n_blocks)
+    if max_splits <= 1:
+        return 1
+
+    def is_split_eligible(num_splits: int) -> bool:
+        return num_splits == 1 or _cdiv(num_n_blocks, num_splits) != _cdiv(
+            num_n_blocks, num_splits - 1
+        )
+
+    max_efficiency = 0.0
+    efficiencies = []
+    for num_splits in range(1, max_splits + 1):
+        if not is_split_eligible(num_splits):
+            efficiencies.append(0.0)
+            continue
+        num_waves = batch_nheads * num_splits / target_workgroups
+        efficiency = num_waves / math.ceil(num_waves)
+        max_efficiency = max(max_efficiency, efficiency)
+        efficiencies.append(efficiency)
+
+    for num_splits, efficiency in enumerate(efficiencies, start=1):
+        if is_split_eligible(num_splits) and efficiency >= 0.85 * max_efficiency:
+            return num_splits
+    return 1
+
+
+def _get_num_splits(
+    batch_size: int,
+    num_kv_heads: int,
+    head_size: int,
+    physical_block_size: int,
+    max_seq_len: int,
+    max_num_splits: int = _MAX_SPLITS,
+    num_sms: int | None = None,
+    allow_short_context: bool = False,
+) -> int:
+    """Choose a capture-safe split count from host metadata."""
+    if num_sms is None:
+        num_sms = _get_num_sms(torch.accelerator.current_device_index())
+
+    block_size = _choose_compute_block_size(physical_block_size)
+    if head_size <= 64 and max_seq_len < 4096:
+        return 1
+    if max_seq_len <= block_size:
+        return 1
+
+    num_n_blocks = _cdiv(max_seq_len, block_size)
+    if not allow_short_context and num_n_blocks < 2 * num_sms:
+        return 1
+
+    max_splits = min(max_num_splits, num_sms, num_n_blocks)
+    num_splits = _num_splits_heuristic(
+        batch_size * num_kv_heads, num_sms, num_n_blocks, max_splits
+    )
+    # Bound the reduction kernel to a small, capture-warmable specialization set.
+    return min(max_num_splits, 1 << (num_splits - 1).bit_length())
+
+
+def _splitkv_workspace_shapes(
+    max_batch_size: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    physical_block_size: int,
+    max_seq_len: int,
+    allow_short_context: bool,
+    num_sms: int,
+    max_num_splits: int = _MAX_SPLITS,
+) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
+    """Return a conservative scratch envelope for every splitting batch."""
+    block_size = _choose_compute_block_size(physical_block_size)
+    num_n_blocks = _cdiv(max_seq_len, block_size)
+    if not allow_short_context and num_n_blocks < 2 * num_sms:
+        return None
+    raw_max_splits = min(max_num_splits, num_sms, num_n_blocks)
+    max_possible_splits = (
+        1
+        if raw_max_splits <= 1
+        else min(max_num_splits, 1 << (raw_max_splits - 1).bit_length())
+    )
+    best_batch_size = 0
+    for batch_size in range(1, max_batch_size + 1):
+        if batch_size * num_kv_heads < 0.8 * (2 * num_sms):
+            best_batch_size = batch_size
+    if best_batch_size == 0 or max_possible_splits <= 1:
+        return None
+
+    return (
+        (best_batch_size, num_query_heads, max_possible_splits, head_size),
+        (best_batch_size, num_query_heads, max_possible_splits),
+    )
+
+
+def reserve_splitkv_workspace(
+    max_batch_size: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    physical_block_size: int,
+    max_seq_len: int,
+    allow_short_context: bool,
+    max_num_splits: int = _MAX_SPLITS,
+) -> None:
+    """Reserve graph-stable SplitKV scratch in the shared workspace."""
+    if not is_workspace_manager_initialized():
+        return
+    shapes = _splitkv_workspace_shapes(
+        max_batch_size,
+        num_query_heads,
+        num_kv_heads,
+        head_size,
+        physical_block_size,
+        max_seq_len,
+        allow_short_context,
+        _get_num_sms(torch.accelerator.current_device_index()),
+        max_num_splits,
+    )
+    if shapes is None:
+        return
+    mid_out_shape, mid_lse_shape = shapes
+
+    current_workspace_manager()._reserve_simultaneous(
+        (mid_out_shape, torch.float32),
+        (mid_lse_shape, torch.float32),
+    )
+
+
+def _paged_attention_2d_splitkv_decode(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+    k_scale: torch.Tensor | float = 1.0,
+    v_scale: torch.Tensor | float = 1.0,
+    output: torch.Tensor | None = None,
+    actual_max_splits: int | None = None,
+    max_seq_len: int | None = None,
+    mid_out: torch.Tensor | None = None,
+    mid_lse: torch.Tensor | None = None,
+    max_num_splits: int = _MAX_SPLITS,
+    query_start_loc: torch.Tensor | None = None,
+    filter_by_query_len: bool = False,
+) -> torch.Tensor:
+    """Run paged decode with optional KV splitting."""
+    if output is None:
+        output = torch.empty_like(query)
+
+    batch_size = seq_lens.shape[0] if filter_by_query_len else query.shape[0]
+    num_query_heads = query.shape[1]
+    head_size = query.shape[2]
+    num_kv_heads = key_cache.shape[1]
+    physical_block_size = key_cache.shape[3]
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+    is_fp8_kv = key_cache.dtype in fp8_dtypes
+    if num_kv_heads <= 0 or num_query_heads % num_kv_heads != 0:
+        raise ValueError("Query heads must be divisible by non-zero KV heads.")
+    if key_cache.dtype != value_cache.dtype:
+        raise ValueError("Key and value caches must have the same dtype.")
+    if not is_fp8_kv and key_cache.dtype != query.dtype:
+        raise TypeError(
+            "SplitKV requires E4M3 FP8 caches or caches matching the query dtype."
+        )
+    if value_cache.shape[3] != physical_block_size:
+        raise ValueError("Key and value caches must use the same physical page size.")
+    if is_fp8_kv:
+        for name, value in (("K", k_scale), ("V", v_scale)):
+            if not (
+                isinstance(value, torch.Tensor)
+                and value.numel() == 1
+                and value.dtype == torch.float32
+                and value.device == query.device
+            ):
+                raise TypeError(
+                    f"FP8 SplitKV {name} scale must be a scalar float32 tensor "
+                    "on the query device."
+                )
+    block_size = _choose_compute_block_size(physical_block_size)
+    x = key_cache.shape[4]
+    num_queries_per_kv = num_query_heads // num_kv_heads
+    num_queries_per_kv_padded = max(triton.next_power_of_2(num_queries_per_kv), 16)
+    head_size_padded = triton.next_power_of_2(head_size)
+
+    if max_seq_len is None:
+        max_seq_len = block_tables.shape[1] * physical_block_size
+    if actual_max_splits is None:
+        actual_max_splits = _get_num_splits(
+            batch_size,
+            num_kv_heads,
+            head_size,
+            physical_block_size,
+            max_seq_len,
+            max_num_splits,
+            allow_short_context=is_fp8_kv,
+        )
+    if not 1 <= actual_max_splits <= max_num_splits:
+        raise ValueError(
+            f"actual_max_splits ({actual_max_splits}) must be between 1 and "
+            f"max_num_splits ({max_num_splits})."
+        )
+
+    if actual_max_splits == 1:
+        from vllm.platforms.rocm import on_gfx12x
+
+        fallback_block_size = _choose_fallback_block_size(physical_block_size)
+        kernel_paged_attention_2d[(batch_size, num_kv_heads)](
+            output_ptr=output,
+            query_ptr=query,
+            key_cache_ptr=key_cache,
+            value_cache_ptr=value_cache,
+            sink_ptr=None,
+            block_tables_ptr=block_tables,
+            seq_lens_ptr=seq_lens,
+            alibi_slopes_ptr=None,
+            scale=scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            out_scale_inv=1.0,
+            num_query_heads=num_query_heads,
+            num_queries_per_kv=num_queries_per_kv,
+            num_queries_per_kv_padded=num_queries_per_kv_padded,
+            block_table_stride=block_tables.stride(0),
+            query_stride_0=query.stride(0),
+            query_stride_1=query.stride(1),
+            output_stride_0=output.stride(0),
+            output_stride_1=output.stride(1),
+            BLOCK_SIZE=fallback_block_size,
+            PHYSICAL_BLOCK_SIZE=physical_block_size,
+            HEAD_SIZE=head_size,
+            HEAD_SIZE_PADDED=head_size_padded,
+            USE_ALIBI_SLOPES=False,
+            SLIDING_WINDOW=0,
+            x=x,
+            stride_k_cache_0=key_cache.stride(0),
+            stride_k_cache_1=key_cache.stride(1),
+            stride_k_cache_2=key_cache.stride(2),
+            stride_k_cache_3=key_cache.stride(3),
+            stride_k_cache_4=key_cache.stride(4),
+            stride_v_cache_0=value_cache.stride(0),
+            stride_v_cache_1=value_cache.stride(1),
+            stride_v_cache_2=value_cache.stride(2),
+            stride_v_cache_3=value_cache.stride(3),
+            filter_by_query_len=filter_by_query_len,
+            query_start_len_ptr=query_start_loc,
+            USE_SINKS=False,
+            USE_FP8=False,
+            num_warps=8 if is_fp8_kv and on_gfx12x() else 4,
+        )
+        return output
+
+    if (mid_out is None) != (mid_lse is None):
+        raise ValueError("mid_out and mid_lse must be provided together.")
+    if mid_out is None:
+        scratch_shapes = (
+            (batch_size, num_query_heads, actual_max_splits, head_size),
+            (batch_size, num_query_heads, actual_max_splits),
+        )
+        if is_workspace_manager_initialized():
+            mid_out, mid_lse = current_workspace_manager().get_simultaneous(
+                (scratch_shapes[0], torch.float32),
+                (scratch_shapes[1], torch.float32),
+            )
+        else:
+            mid_out = torch.empty(
+                scratch_shapes[0], device=query.device, dtype=torch.float32
+            )
+            mid_lse = torch.empty(
+                scratch_shapes[1], device=query.device, dtype=torch.float32
+            )
+    assert mid_out is not None and mid_lse is not None
+    if (
+        mid_out.ndim != 4
+        or mid_lse.ndim != 3
+        or mid_out.dtype != torch.float32
+        or mid_lse.dtype != torch.float32
+        or mid_out.device != query.device
+        or mid_lse.device != query.device
+        or mid_out.shape[0] < batch_size
+        or mid_lse.shape[0] < batch_size
+        or mid_out.shape[1] < num_query_heads
+        or mid_lse.shape[1] < num_query_heads
+        or mid_out.shape[2] < actual_max_splits
+        or mid_lse.shape[2] < actual_max_splits
+        or mid_out.shape[3] < head_size
+        or mid_out.stride(3) != 1
+    ):
+        raise ValueError(
+            "SplitKV scratch tensors have incompatible shape, dtype, device, or layout."
+        )
+
+    if try_rdna4_splitkv_paged_attention(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        output=output,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        query_start_loc=query_start_loc,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        scale=scale,
+        actual_max_splits=actual_max_splits,
+        max_seq_len=max_seq_len,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        filter_by_query_len=filter_by_query_len,
+    ):
+        return output
+
+    kernel_paged_attention_2d_splitkv[
+        (
+            batch_size,
+            num_kv_heads,
+            actual_max_splits,
+        )
+    ](
+        mid_out,
+        mid_lse,
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+        k_scale,
+        v_scale,
+        num_query_heads=num_query_heads,
+        num_queries_per_kv=num_queries_per_kv,
+        num_queries_per_kv_padded=num_queries_per_kv_padded,
+        block_table_stride=block_tables.stride(0),
+        query_stride_0=query.stride(0),
+        query_stride_1=query.stride(1),
+        mid_out_stride_0=mid_out.stride(0),
+        mid_out_stride_1=mid_out.stride(1),
+        mid_out_stride_2=mid_out.stride(2),
+        mid_lse_stride_0=mid_lse.stride(0),
+        mid_lse_stride_1=mid_lse.stride(1),
+        mid_lse_stride_2=mid_lse.stride(2),
+        BLOCK_SIZE=block_size,
+        PHYSICAL_BLOCK_SIZE=physical_block_size,
+        HEAD_SIZE=head_size,
+        HEAD_SIZE_PADDED=head_size_padded,
+        x=x,
+        stride_k_cache_0=key_cache.stride(0),
+        stride_k_cache_1=key_cache.stride(1),
+        stride_k_cache_2=key_cache.stride(2),
+        stride_k_cache_3=key_cache.stride(3),
+        stride_k_cache_4=key_cache.stride(4),
+        stride_v_cache_0=value_cache.stride(0),
+        stride_v_cache_1=value_cache.stride(1),
+        stride_v_cache_2=value_cache.stride(2),
+        stride_v_cache_3=value_cache.stride(3),
+        filter_by_query_len=filter_by_query_len,
+        query_start_len_ptr=query_start_loc,
+        num_warps=(
+            8 if is_fp8_kv and (head_size == 256 or num_queries_per_kv >= 4) else 4
+        ),
+        num_stages=1,
+        waves_per_eu=1,
+    )
+    kernel_paged_attention_2d_splitkv_reduce[(batch_size, num_query_heads)](
+        output,
+        mid_out,
+        mid_lse,
+        seq_lens,
+        output.stride(0),
+        output.stride(1),
+        mid_out.stride(0),
+        mid_out.stride(1),
+        mid_out.stride(2),
+        mid_lse.stride(0),
+        mid_lse.stride(1),
+        mid_lse.stride(2),
+        BLOCK_SIZE=block_size,
+        HEAD_SIZE=head_size,
+        HEAD_SIZE_PADDED=head_size_padded,
+        MAX_NUM_SPLITS=actual_max_splits,
+        filter_by_query_len=filter_by_query_len,
+        query_start_len_ptr=query_start_loc,
+        num_warps=4,
+        num_stages=1,
+        waves_per_eu=1,
+    )
+    return output
 
 
 def chunked_prefill_paged_decode(
@@ -368,7 +1054,11 @@ def chunked_prefill_paged_decode(
 
     num_queries_per_kv_padded = max(triton.next_power_of_2(num_queries_per_kv), 16)
 
-    from vllm.platforms.rocm import use_rocm_custom_paged_attention
+    from vllm.platforms.rocm import (
+        on_gfx1x,
+        on_gfx12x,
+        use_rocm_custom_paged_attention,
+    )
 
     use_custom = use_rocm_custom_paged_attention(
         query.dtype,
@@ -441,8 +1131,7 @@ def chunked_prefill_paged_decode(
         # (e.g. hybrid Mamba models inflate block_size to 2048).
         # The kernel handles TRITON_BLOCK_SIZE != PHYSICAL_BLOCK_SIZE
         # via the l_block_idx/internal_offsets addressing logic.
-        MAX_TRITON_BLOCK_SIZE = 128
-        TRITON_BLOCK_SIZE = min(block_size, MAX_TRITON_BLOCK_SIZE) if is_pow2 else 32
+        TRITON_BLOCK_SIZE = _choose_fallback_block_size(block_size)
         if is_block_table_ptr:
             # Using the physical base address of tensors
             kv_element_size = key_cache.element_size()
@@ -457,6 +1146,54 @@ def chunked_prefill_paged_decode(
             )
         else:
             processed_block_table = block_table.to(torch.int32)
+
+        kv_quant_mode = get_kv_quant_mode(kv_cache_dtype)
+        use_splitkv_decode = _can_use_rdna4_splitkv_decode(
+            query_dtype=query.dtype,
+            key_cache_dtype=key_cache.dtype,
+            value_cache_dtype=value_cache.dtype,
+            kv_quant_mode=kv_quant_mode,
+            is_e4m3_kv_cache=kv_cache_dtype in ("fp8", "fp8_e4m3"),
+            head_size=head_size,
+            num_query_heads=num_query_heads,
+            num_kv_heads=num_kv_heads,
+            use_alibi_slopes=use_alibi_slopes,
+            sliding_window=sliding_window,
+            has_sinks=sinks is not None,
+            has_output_scale=output_scale is not None,
+            is_gfx1x=on_gfx1x(),
+            is_gfx12x=on_gfx12x(),
+        )
+        actual_max_splits = 1
+        if use_splitkv_decode:
+            actual_max_splits = _get_num_splits(
+                num_seqs,
+                num_kv_heads,
+                head_size,
+                real_block_size,
+                max_seq_len,
+                max_num_splits=_MAX_SPLITS,
+                allow_short_context=key_cache.dtype
+                in (torch.float8_e4m3fn, torch.float8_e4m3fnuz),
+            )
+        if actual_max_splits > 1:
+            _paged_attention_2d_splitkv_decode(
+                query=query,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                block_tables=processed_block_table,
+                seq_lens=seq_lens,
+                scale=sm_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                output=output,
+                actual_max_splits=actual_max_splits,
+                max_seq_len=max_seq_len,
+                max_num_splits=_MAX_SPLITS,
+                query_start_loc=query_start_loc,
+                filter_by_query_len=True,
+            )
+            return
 
         kernel_paged_attention_2d[
             (
@@ -504,4 +1241,5 @@ def chunked_prefill_paged_decode(
             query_start_len_ptr=query_start_loc,
             USE_SINKS=sinks is not None,
             USE_FP8=output_scale is not None,
+            num_warps=(8 if key_cache.element_size() == 1 and on_gfx12x() else 4),
         )

--- a/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv.py
+++ b/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv.py
@@ -1,0 +1,651 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Public router for the RDNA4 SplitKV paged-attention kernel family."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from threading import Lock
+from typing import Any
+from weakref import ReferenceType, ref
+
+import torch
+
+from .rdna4_splitkv_common import HEAD_DIM
+from .rdna4_splitkv_gqa16_d128 import compile_gqa_stage
+from .rdna4_splitkv_native_d128 import compile_native_d128_gqa16_stage
+from .rdna4_splitkv_reduce import _launch_reduce
+from .rdna4_splitkv_wave8 import compile_wave8_stage
+from .runtime import get_compiled_static_tensors as _get_compiled_static_tensors
+from .runtime import run_compiled as _run_compiled
+
+
+@dataclass
+class _Wave8FusedLaunch:
+    query_ref: ReferenceType[torch.Tensor]
+    tensors: tuple[torch.Tensor, ...]
+    params: tuple
+    compiled: Any
+    k_scale: torch.Tensor
+    v_scale: torch.Tensor
+
+
+_WAVE8_FUSED_CACHE_SIZE = 128
+_WAVE8_FUSED_CACHE: dict[int, _Wave8FusedLaunch] = {}
+_WAVE8_COUNTER_CACHE_SIZE = 32
+_WAVE8_COUNTER_CACHE: dict[tuple[int, int], torch.Tensor] = {}
+_WAVE8_COUNTER_CACHE_LOCK = Lock()
+
+
+def _drop_wave8_fused_entry(query_ref: ReferenceType[torch.Tensor], key: int) -> None:
+    entry = _WAVE8_FUSED_CACHE.get(key)
+    if entry is not None and entry.query_ref is query_ref:
+        _WAVE8_FUSED_CACHE.pop(key, None)
+
+
+def _wave8_split_counters(
+    query: torch.Tensor,
+    stream: torch.cuda.Stream,
+    rows: int,
+) -> torch.Tensor:
+    device_index = query.device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    key = (device_index, int(stream.cuda_stream))
+    required = rows * 16
+    counters = _WAVE8_COUNTER_CACHE.get(key)
+    if counters is not None and counters.numel() >= required:
+        return counters
+    with _WAVE8_COUNTER_CACHE_LOCK:
+        counters = _WAVE8_COUNTER_CACHE.get(key)
+        if counters is None or counters.numel() < required:
+            if (
+                key not in _WAVE8_COUNTER_CACHE
+                and len(_WAVE8_COUNTER_CACHE) >= _WAVE8_COUNTER_CACHE_SIZE
+            ):
+                _WAVE8_COUNTER_CACHE.pop(next(iter(_WAVE8_COUNTER_CACHE)))
+            counters = torch.zeros(required, dtype=torch.int32, device=query.device)
+            _WAVE8_COUNTER_CACHE[key] = counters
+    return counters
+
+
+class SplitKVRoute(str, Enum):
+    """Validated RDNA4 kernel specializations."""
+
+    NATIVE_D128_GQA16_DIRECT = "native_d128_gqa16_direct"
+    NATIVE_D128_GQA16_LDS = "native_d128_gqa16_lds"
+    D128_GQA16_TILE32 = "d128_gqa16_tile32"
+    D256_GQA4_8_TILE32 = "d256_gqa4_8_tile32"
+    D256_GQA16_TILE32 = "d256_gqa16_tile32"
+    D128_GQA8_TILE32 = "d128_gqa8_tile32"
+    GENERIC_TILE32 = "generic_tile32"
+    WAVE8 = "wave8"
+
+
+@dataclass(frozen=True)
+class SplitKVConfig:
+    """A promoted kernel route selected from the runtime tensor contract."""
+
+    route: SplitKVRoute
+
+
+def select_kernel_config(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_seq_len: int,
+) -> SplitKVConfig | None:
+    """Select a specialization safe for arbitrary values in the API contract.
+
+    Only routes validated against unrestricted-value accuracy are selectable.
+    """
+    if query.ndim != 3 or key_cache.ndim != 5:
+        return None
+    num_kv_heads = int(key_cache.shape[1])
+    if num_kv_heads <= 0 or int(query.shape[1]) % num_kv_heads:
+        return None
+
+    gqa = int(query.shape[1]) // num_kv_heads
+    head_size = int(query.shape[2])
+    page_size = int(key_cache.shape[3])
+    batch_size = int(seq_lens.numel())
+    page_aligned = page_size >= 8 and page_size % 8 == 0
+
+    if (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and key_cache.dtype == query.dtype
+        and head_size == 128
+        and batch_size >= 8
+        and gqa == 16
+        and page_size >= 16
+        and page_size % 16 == 0
+    ):
+        route = (
+            SplitKVRoute.NATIVE_D128_GQA16_DIRECT
+            if batch_size == 8
+            else SplitKVRoute.NATIVE_D128_GQA16_LDS
+            if batch_size >= 16
+            else None
+        )
+        if route is not None:
+            if max_seq_len >= 8192:
+                return SplitKVConfig(SplitKVRoute.D128_GQA16_TILE32)
+            return SplitKVConfig(route)
+
+    if (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and (
+            key_cache.dtype == query.dtype
+            or key_cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+        )
+        and head_size == 128
+        and batch_size == 1
+        and gqa == 16
+        and page_size >= 16
+        and page_size % 16 == 0
+    ):
+        return SplitKVConfig(SplitKVRoute.D128_GQA16_TILE32)
+
+    if (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and key_cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+        and head_size == 128
+        and batch_size < 8
+        and gqa == 8
+        and page_size >= 16
+        and page_size % 16 == 0
+    ):
+        return SplitKVConfig(SplitKVRoute.D128_GQA8_TILE32)
+
+    supported_d256_cache = key_cache.dtype == query.dtype or key_cache.dtype in (
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+    )
+    if (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and supported_d256_cache
+        and head_size == 256
+        and batch_size < 8
+        and gqa == 16
+        and page_size >= 16
+        and page_size % 16 == 0
+    ):
+        return SplitKVConfig(SplitKVRoute.D256_GQA16_TILE32)
+
+    native_d256_gqa4_8 = key_cache.dtype == query.dtype and (
+        gqa == 4 or (1 < batch_size < 8 and gqa == 8)
+    )
+    fnuz_d256_gqa8 = (
+        key_cache.dtype == torch.float8_e4m3fnuz and batch_size == 1 and gqa == 8
+    )
+    if (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and head_size == 256
+        and page_size >= 16
+        and page_size % 16 == 0
+        and (native_d256_gqa4_8 or fnuz_d256_gqa8)
+    ):
+        return SplitKVConfig(SplitKVRoute.D256_GQA4_8_TILE32)
+
+    generic_d256 = head_size == 256 and 5 <= gqa <= 15
+    generic_d128_native_gqa8 = (
+        head_size == 128 and gqa == 8 and key_cache.dtype == query.dtype
+    )
+    if (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and supported_d256_cache
+        and page_size >= 16
+        and page_size % 16 == 0
+        and (generic_d256 or generic_d128_native_gqa8)
+    ):
+        return SplitKVConfig(SplitKVRoute.GENERIC_TILE32)
+
+    # Per-query-head Wave8 repeats native KV reads as GQA/batch grow. The
+    # grouped Triton fallback wins these long-context shapes on gfx1201.
+    if max_seq_len >= 2048 and (
+        (key_cache.dtype == query.dtype and (gqa >= 3 or (gqa == 2 and batch_size > 1)))
+        or (head_size == 128 and gqa == 4 and batch_size > 1)
+    ):
+        return None
+
+    if (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and (
+            key_cache.dtype == query.dtype
+            or key_cache.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+        )
+        and head_size in (128, 256)
+        and batch_size < 8
+        and 1 <= gqa <= 4
+        and page_aligned
+    ):
+        return SplitKVConfig(SplitKVRoute.WAVE8)
+
+    return None
+
+
+def _run_d256_tile32(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    output: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    splits: int,
+    scale: float,
+) -> torch.Tensor:
+    """Run the accuracy-validated native-query D256 Tile32 stage."""
+
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"query must be bfloat16 or float16, got {query.dtype}")
+    if key_cache.dtype != value_cache.dtype:
+        raise ValueError("key_cache and value_cache must have the same dtype")
+    if key_cache.dtype not in (
+        query.dtype,
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+    ):
+        raise ValueError(f"unsupported cache dtype {key_cache.dtype}")
+    if int(query.shape[2]) != HEAD_DIM:
+        raise ValueError(f"head dimension must be {HEAD_DIM}, got {query.shape[2]}")
+    num_kv_heads = int(key_cache.shape[1])
+    query_group_size = int(query.shape[1]) // num_kv_heads
+    if not 1 <= query_group_size <= 16:
+        raise ValueError(f"query group size must be in [1, 16], got {query_group_size}")
+    if k_scale.ndim == 0:
+        k_scale = k_scale.reshape(1)
+    if v_scale.ndim == 0:
+        v_scale = v_scale.reshape(1)
+
+    kv_dtype = (
+        "fp8fnuz"
+        if key_cache.dtype == torch.float8_e4m3fnuz
+        else (
+            "fp8"
+            if key_cache.element_size() == 1
+            else "fp16"
+            if key_cache.dtype == torch.float16
+            else "bf16"
+        )
+    )
+    stage = compile_gqa_stage(
+        dtype="fp16" if query.dtype == torch.float16 else "bf16",
+        kv_dtype=kv_dtype,
+        head_dim=HEAD_DIM,
+        splits=int(splits),
+        num_kv_heads=num_kv_heads,
+        query_group_size=query_group_size,
+        page_size=int(key_cache.shape[3]),
+        softmax_scale=float(scale),
+    )
+    stream = torch.cuda.current_stream(query.device)
+    _run_compiled(
+        stage,
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        query_start_loc,
+        k_scale,
+        v_scale,
+        mid_out,
+        mid_lse,
+        int(seq_lens.numel()),
+        int(block_tables.stride(0)),
+        int(query.stride(0)),
+        int(query.stride(1)),
+        *map(int, key_cache.stride()),
+        *map(int, value_cache.stride()),
+        *map(int, mid_out.stride()[:3]),
+        *map(int, mid_lse.stride()),
+        stream,
+    )
+    _launch_reduce(
+        query,
+        seq_lens,
+        query_start_loc,
+        output,
+        mid_out,
+        mid_lse,
+        int(splits),
+        1,
+        stream,
+    )
+    return output
+
+
+def _run_native_d128_gqa16(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    output: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    splits: int,
+    scale: float,
+    schedule: str,
+) -> torch.Tensor:
+    """Run a four-wave native D128/GQA16 schedule."""
+
+    if schedule not in ("direct", "lds", "tile32_native"):
+        raise ValueError(f"unsupported D128 schedule: {schedule!r}")
+
+    if k_scale.ndim == 0:
+        k_scale = k_scale.reshape(1)
+    if v_scale.ndim == 0:
+        v_scale = v_scale.reshape(1)
+    num_kv_heads = int(key_cache.shape[1])
+    query_group_size = int(query.shape[1]) // num_kv_heads
+    page_size = int(key_cache.shape[3])
+    dtype = "fp16" if query.dtype == torch.float16 else "bf16"
+    kv_dtype = (
+        "fp8fnuz"
+        if key_cache.dtype == torch.float8_e4m3fnuz
+        else (
+            "fp8"
+            if key_cache.element_size() == 1
+            else "fp16"
+            if key_cache.dtype == torch.float16
+            else "bf16"
+        )
+    )
+    compile_stage = (
+        compile_gqa_stage
+        if schedule == "tile32_native"
+        else compile_native_d128_gqa16_stage
+    )
+    compile_kwargs = dict(
+        dtype=dtype,
+        kv_dtype=kv_dtype,
+        splits=int(splits),
+        num_kv_heads=num_kv_heads,
+        page_size=page_size,
+        softmax_scale=float(scale),
+    )
+    if schedule == "tile32_native":
+        compile_kwargs["head_dim"] = 128
+        compile_kwargs["query_group_size"] = query_group_size
+    else:
+        compile_kwargs["schedule"] = schedule
+    stage = compile_stage(**compile_kwargs)
+    stream = torch.cuda.current_stream(query.device)
+    _run_compiled(
+        stage,
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        query_start_loc,
+        k_scale,
+        v_scale,
+        mid_out,
+        mid_lse,
+        int(seq_lens.numel()),
+        int(block_tables.stride(0)),
+        int(query.stride(0)),
+        int(query.stride(1)),
+        *map(int, key_cache.stride()),
+        *map(int, value_cache.stride()),
+        *map(int, mid_out.stride()[:3]),
+        *map(int, mid_lse.stride()),
+        stream,
+    )
+    _launch_reduce(
+        query,
+        seq_lens,
+        query_start_loc,
+        output,
+        mid_out,
+        mid_lse,
+        int(splits),
+        page_size if schedule == "direct" else 1,
+        stream,
+    )
+    return output
+
+
+def _run_wave8(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    output: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    splits: int,
+    scale: float,
+) -> torch.Tensor:
+    """Launch the fused eight-wave per-query-head stage."""
+
+    original_k_scale = k_scale
+    original_v_scale = v_scale
+    stream = torch.cuda.current_stream(query.device)
+    split_counters = _wave8_split_counters(
+        query,
+        stream,
+        int(seq_lens.numel()) * int(query.shape[1]),
+    )
+    cache_params = (int(splits), float(scale))
+    cache_tensors = (
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        query_start_loc,
+        original_k_scale,
+        original_v_scale,
+        output,
+        mid_out,
+        mid_lse,
+        split_counters,
+    )
+    cached = _WAVE8_FUSED_CACHE.get(id(query))
+    if (
+        cached is not None
+        and cached.query_ref() is query
+        and cached.params == cache_params
+        and all(
+            actual is expected
+            for actual, expected in zip(cache_tensors, cached.tensors)
+        )
+    ):
+        cached.compiled(
+            query,
+            key_cache,
+            value_cache,
+            block_tables,
+            seq_lens,
+            query_start_loc,
+            cached.k_scale,
+            cached.v_scale,
+            mid_out,
+            mid_lse,
+            output,
+            split_counters,
+            int(seq_lens.numel()),
+            stream,
+        )
+        return output
+
+    if k_scale.ndim == 0:
+        k_scale = k_scale.reshape(1)
+    if v_scale.ndim == 0:
+        v_scale = v_scale.reshape(1)
+    num_query_heads = int(query.shape[1])
+    num_kv_heads = int(key_cache.shape[1])
+    layout_tensors = (
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        query_start_loc,
+        k_scale,
+        v_scale,
+        mid_out,
+        mid_lse,
+        output,
+        split_counters,
+    )
+    layout_key = tuple(
+        (tuple(tensor.shape), tuple(tensor.stride())) for tensor in layout_tensors
+    )
+    stage = compile_wave8_stage(
+        query_dtype="fp16" if query.dtype == torch.float16 else "bf16",
+        kv_dtype=(
+            "fp8fnuz"
+            if key_cache.dtype == torch.float8_e4m3fnuz
+            else (
+                "fp8"
+                if key_cache.element_size() == 1
+                else "fp16"
+                if key_cache.dtype == torch.float16
+                else "bf16"
+            )
+        ),
+        head_dim=int(query.shape[2]),
+        splits=int(splits),
+        num_query_heads=num_query_heads,
+        num_kv_heads=num_kv_heads,
+        query_group_size=num_query_heads // num_kv_heads,
+        page_size=int(key_cache.shape[3]),
+        softmax_scale=float(scale),
+        layout_key=layout_key,
+    )
+    launch_args = (
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        query_start_loc,
+        k_scale,
+        v_scale,
+        mid_out,
+        mid_lse,
+        output,
+        split_counters,
+        int(seq_lens.numel()),
+        stream,
+    )
+    compiled = _get_compiled_static_tensors(stage, *launch_args)
+    if (
+        id(query) not in _WAVE8_FUSED_CACHE
+        and len(_WAVE8_FUSED_CACHE) >= _WAVE8_FUSED_CACHE_SIZE
+    ):
+        _WAVE8_FUSED_CACHE.pop(next(iter(_WAVE8_FUSED_CACHE)))
+    query_id = id(query)
+
+    def drop_entry(dead_ref: ReferenceType[torch.Tensor]) -> None:
+        _drop_wave8_fused_entry(dead_ref, query_id)
+
+    query_ref = ref(query, drop_entry)
+    _WAVE8_FUSED_CACHE[query_id] = _Wave8FusedLaunch(
+        query_ref=query_ref,
+        tensors=cache_tensors,
+        params=cache_params,
+        compiled=compiled,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    compiled(*launch_args)
+    return output
+
+
+def rdna4_splitkv_paged_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    output: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    splits: int,
+    scale: float,
+    max_seq_len: int,
+    config: SplitKVConfig | None = None,
+) -> SplitKVConfig:
+    """Validate, select, and launch an RDNA4 SplitKV specialization."""
+    selected_config = select_kernel_config(query, key_cache, seq_lens, max_seq_len)
+    if selected_config is None:
+        raise ValueError("RDNA4 FlyDSL SplitKV does not support this configuration")
+    if config is not None and config != selected_config:
+        raise ValueError("RDNA4 FlyDSL SplitKV configuration does not match the inputs")
+    config = selected_config
+
+    args = (
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        query_start_loc,
+        k_scale,
+        v_scale,
+        output,
+    )
+    if config.route == SplitKVRoute.NATIVE_D128_GQA16_DIRECT:
+        _run_native_d128_gqa16(
+            *args, mid_out, mid_lse, splits, scale, schedule="direct"
+        )
+    elif config.route == SplitKVRoute.NATIVE_D128_GQA16_LDS:
+        _run_native_d128_gqa16(*args, mid_out, mid_lse, splits, scale, schedule="lds")
+    elif config.route in (
+        SplitKVRoute.D128_GQA16_TILE32,
+        SplitKVRoute.D128_GQA8_TILE32,
+    ):
+        _run_native_d128_gqa16(
+            *args, mid_out, mid_lse, splits, scale, schedule="tile32_native"
+        )
+    elif config.route in (
+        SplitKVRoute.D256_GQA4_8_TILE32,
+        SplitKVRoute.D256_GQA16_TILE32,
+    ):
+        _run_d256_tile32(*args, mid_out, mid_lse, splits, scale)
+    elif config.route == SplitKVRoute.GENERIC_TILE32:
+        if int(query.shape[2]) == 256:
+            _run_d256_tile32(*args, mid_out, mid_lse, splits, scale)
+        else:
+            _run_native_d128_gqa16(
+                *args,
+                mid_out,
+                mid_lse,
+                splits,
+                scale,
+                schedule="tile32_native",
+            )
+    elif config.route == SplitKVRoute.WAVE8:
+        _run_wave8(*args, mid_out, mid_lse, splits, scale)
+    else:
+        raise AssertionError(f"unhandled RDNA4 SplitKV route: {config.route}")
+    return config
+
+
+__all__ = [
+    "SplitKVConfig",
+    "SplitKVRoute",
+    "rdna4_splitkv_paged_attention",
+    "select_kernel_config",
+]

--- a/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_common.py
+++ b/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_common.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: B008 -- FlyDSL launch signatures require typed stream defaults
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Shared constants and helpers for RDNA4 SplitKV kernels."""
+
+import flydsl.expr as fx
+from flydsl.expr import const_expr, range_constexpr
+
+HEAD_DIM = 256
+WAVE_SIZE = 32
+LOG2E = 1.4426950408889634
+
+
+def _decode_fp8(raw, byte_index, *, is_fp8fnuz: bool):
+    value = fx.Float32(fx.rocdl.cvt_f32_fp8(raw, byte_index))
+    if const_expr(is_fp8fnuz):
+        byte = (raw >> (byte_index * 8)) & 255
+        # FNUZ uses these encodings for +/-240; FN reserves them for NaN.
+        value = ((byte & 127) == 127).select(
+            ((byte & 128) != 0).select(fx.Float32(-480.0), fx.Float32(480.0)),
+            value,
+        )
+        value = (byte == 128).select(fx.Float32(float("nan")), value)
+        value = value * 0.5
+    return value
+
+
+def _dequant_fp8x8(raw, scale, output_type, *, is_fp8fnuz: bool):
+    """Decode eight packed FP8 values with scalar conversions."""
+    words = raw.bitcast(fx.Int32)
+    values = []
+    for word_index in range_constexpr(2):
+        for byte_index in range_constexpr(4):
+            value = _decode_fp8(words[word_index], byte_index, is_fp8fnuz=is_fp8fnuz)
+            values.append(value * scale)
+    return fx.Vector.from_elements(values, dtype=fx.Float32).to(output_type)
+
+
+def _flat_view(tensor: fx.Tensor) -> fx.Tensor:
+    return fx.make_view(fx.get_iter(tensor), fx.make_layout(1 << 30, 1))
+
+
+def _wave_reduce(value, mode: str):
+    result = value
+    for offset in (16, 8, 4, 2, 1):
+        peer = fx.gpu.shuffle_xor(result, offset, WAVE_SIZE)
+        result = fx.max(result, peer) if const_expr(mode == "max") else result + peer
+    return result

--- a/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_gqa16_d128.py
+++ b/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_gqa16_d128.py
@@ -1,0 +1,574 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: B008, N806 -- FlyDSL launch signatures and local tile constants
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tile32, 16-wave D128/D256 grouped-query SplitKV stage for RDNA4."""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, range_constexpr
+from flydsl.expr import math as fmath
+
+from .rdna4_splitkv_common import (
+    LOG2E,
+    WAVE_SIZE,
+    _decode_fp8,
+    _dequant_fp8x8,
+    _flat_view,
+    _wave_reduce,
+)
+
+HEAD_DIM = 128
+QUERY_ROWS = 16
+TILE_TOKENS = 32
+NUM_WAVES = 16
+QK_WAVES = 2
+PV_WAVES = 8
+BLOCK_THREADS = NUM_WAVES * WAVE_SIZE
+K_FRAGMENTS = HEAD_DIM // 16
+TOKEN_FRAGMENTS = TILE_TOKENS // 16
+
+
+@functools.lru_cache(maxsize=128)
+def compile_gqa_stage(
+    *,
+    dtype: str,
+    kv_dtype: str,
+    splits: int,
+    num_kv_heads: int,
+    page_size: int,
+    softmax_scale: float,
+    head_dim: int = 128,
+    query_group_size: int = 16,
+):
+    """Compile the Tile32 register-PV specialization."""
+
+    if head_dim not in (128, 256):
+        raise ValueError(f"head_dim must be 128 or 256, got {head_dim}")
+    if not 1 <= query_group_size <= 16:
+        raise ValueError(f"query_group_size must be in [1, 16], got {query_group_size}")
+    if dtype not in ("bf16", "fp16"):
+        raise ValueError(f"dtype must be 'bf16' or 'fp16', got {dtype!r}")
+    if kv_dtype not in ("bf16", "fp16", "fp8", "fp8fnuz"):
+        raise ValueError(f"unsupported KV dtype {kv_dtype!r}")
+    if splits < 1:
+        raise ValueError(f"splits must be positive, got {splits}")
+    if num_kv_heads < 1:
+        raise ValueError(f"num_kv_heads must be positive, got {num_kv_heads}")
+    if page_size < 16 or page_size % 16:
+        raise ValueError(f"page_size must be a multiple of 16, got {page_size}")
+    HEAD_DIM = head_dim
+    PV_WAVES = head_dim // 16
+    K_FRAGMENTS = head_dim // 16
+
+    query_type = fx.BFloat16 if dtype == "bf16" else fx.Float16
+    pv_type = fx.BFloat16 if kv_dtype == "bf16" else fx.Float16
+    cache_type = {
+        "bf16": fx.BFloat16,
+        "fp16": fx.Float16,
+        "fp8": fx.Uint8,
+        "fp8fnuz": fx.Uint8,
+    }[kv_dtype]
+    is_fp8 = kv_dtype in ("fp8", "fp8fnuz")
+    is_fp8fnuz = kv_dtype == "fp8fnuz"
+    qk_type = query_type
+    qk_bytes = 2
+    cache_pack = 16 if is_fp8 else 8
+    q_words = QUERY_ROWS * HEAD_DIM * qk_bytes // 4
+    k_words = TILE_TOKENS * HEAD_DIM * qk_bytes // 4
+    v_words = TILE_TOKENS * HEAD_DIM // 2
+
+    @fx.struct
+    class SharedStorage:
+        query_or_scores: fx.Array[fx.Int32, q_words, 16]
+        key: fx.Array[fx.Int32, k_words, 16]
+        value: fx.Array[fx.Int32, v_words, 16]
+        row_scale: fx.Array[fx.Float32, QUERY_ROWS, 16]
+
+    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
+    def stage(
+        query_ptr: fx.Tensor,
+        key_ptr: fx.Tensor,
+        value_ptr: fx.Tensor,
+        block_tables_ptr: fx.Tensor,
+        seq_lens_ptr: fx.Tensor,
+        query_start_loc_ptr: fx.Tensor,
+        k_scale_ptr: fx.Tensor,
+        v_scale_ptr: fx.Tensor,
+        mid_out_ptr: fx.Tensor,
+        mid_lse_ptr: fx.Tensor,
+        batch: fx.Int32,
+        table_stride: fx.Int32,
+        q_stride0: fx.Int32,
+        q_stride1: fx.Int32,
+        k_stride0: fx.Int32,
+        k_stride1: fx.Int32,
+        k_stride2: fx.Int32,
+        k_stride3: fx.Int32,
+        k_stride4: fx.Int32,
+        v_stride0: fx.Int32,
+        v_stride1: fx.Int32,
+        v_stride2: fx.Int32,
+        v_stride3: fx.Int32,
+        mo_stride0: fx.Int32,
+        mo_stride1: fx.Int32,
+        mo_stride2: fx.Int32,
+        ml_stride0: fx.Int32,
+        ml_stride1: fx.Int32,
+        ml_stride2: fx.Int32,
+    ):
+        tid = fx.Int32(gpu.thread_idx.x)
+        wave = tid // WAVE_SIZE
+        lane = tid % WAVE_SIZE
+        block = fx.Int32(gpu.block_idx.x)
+        split = block % splits
+        item = block // splits
+        seq = item // num_kv_heads
+        kv_head = item % num_kv_heads
+
+        query = _flat_view(query_ptr)
+        value = _flat_view(value_ptr)
+        raw_value = fx.make_view(
+            fx.recast_iter(fx.Uint8, fx.get_iter(value_ptr)),
+            fx.make_layout(1 << 30, 1),
+        )
+        block_tables = _flat_view(block_tables_ptr)
+        seq_lens = _flat_view(seq_lens_ptr)
+        query_start_loc = _flat_view(query_start_loc_ptr)
+        k_scales = _flat_view(k_scale_ptr)
+        v_scales = _flat_view(v_scale_ptr)
+        mid_out = _flat_view(mid_out_ptr)
+        mid_lse = _flat_view(mid_lse_ptr)
+
+        storage = fx.SharedAllocator().allocate(SharedStorage).peek()
+        value_tile = fx.make_view(
+            fx.recast_iter(pv_type, storage.value.ptr),
+            fx.make_layout((HEAD_DIM, TILE_TOKENS), (TILE_TOKENS, 1)),
+        )
+        scores = fx.make_view(
+            fx.recast_iter(fx.Float32, storage.query_or_scores.ptr),
+            fx.make_layout((QUERY_ROWS, TILE_TOKENS), (TILE_TOKENS, 1)),
+        )
+        weights = fx.make_view(
+            fx.recast_iter(pv_type, storage.query_or_scores.ptr),
+            fx.make_layout((QUERY_ROWS, TILE_TOKENS), (TILE_TOKENS, 1)),
+        )
+        row_scale = fx.make_view(storage.row_scale.ptr, fx.make_layout(QUERY_ROWS, 1))
+
+        def lds_barrier():
+            fx.rocdl.s_waitcnt(lgkmcnt=0)
+            gpu.barrier()
+
+        k_scale = fx.Float32(1.0)
+        v_scale = fx.Float32(1.0)
+        if const_expr(is_fp8):
+            k_scale = fx.Float32(k_scales[0])
+            v_scale = fx.Float32(v_scales[0])
+
+        query_row = fx.Int32(query_start_loc[seq])
+        is_decode = fx.Int32(query_start_loc[seq + 1]) - query_row == 1
+        length = is_decode.select(fx.Int32(seq_lens[seq]), fx.Int32(0))
+        tokens_per_split = (length + splits - 1) // splits
+        begin = fx.min(split * tokens_per_split, length)
+        end = fx.min(begin + tokens_per_split, length)
+
+        for query_iteration in range_constexpr(
+            (QUERY_ROWS * (HEAD_DIM // 4)) // BLOCK_THREADS
+        ):
+            query_word = tid + query_iteration * BLOCK_THREADS
+            query_local_row = query_word // (HEAD_DIM // 4)
+            query_live = query_local_row < query_group_size
+            safe_query_row = query_live.select(query_local_row, fx.Int32(0))
+            query_head = kv_head * query_group_size + safe_query_row
+            query_d = (query_word % (HEAD_DIM // 4)) * 4
+            query_values = []
+            for element in range_constexpr(4):
+                query_index = (
+                    query_row * q_stride0 + query_head * q_stride1 + query_d + element
+                )
+                query_value = (query_live & is_decode).select(
+                    fx.Float32(query[query_index]), fx.Float32(0.0)
+                )
+                query_values.append(query_value)
+            query_packed = (
+                fx.Vector.from_elements(query_values, dtype=fx.Float32)
+                .to(query_type)
+                .bitcast(fx.Int32)
+            )
+            for word in range_constexpr(2):
+                storage.query_or_scores[query_word * 2 + word] = query_packed[word]
+        lds_barrier()
+
+        q_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), qk_type)
+            for _ in range_constexpr(K_FRAGMENTS)
+        ]
+        fragment_row = lane % QUERY_ROWS
+        fragment_half = lane // QUERY_ROWS
+        repair_row_one = ((wave >= QK_WAVES) & (wave < 2 * QK_WAVES)).select(
+            fx.Int32(1), fragment_row
+        )
+        for k_fragment in range_constexpr(K_FRAGMENTS):
+            query_fragment_word = (
+                repair_row_one * (HEAD_DIM * qk_bytes // 4)
+                + (k_fragment * 16 + fragment_half * 8) * qk_bytes // 4
+            )
+            query_fragment_words = fx.Vector.from_elements(
+                [
+                    storage.query_or_scores[query_fragment_word + word]
+                    for word in range_constexpr(2 * qk_bytes)
+                ],
+                dtype=fx.Int32,
+            )
+            q_fragments[k_fragment].store(query_fragment_words.bitcast(qk_type))
+        if const_expr(HEAD_DIM == 256):
+            fx.rocdl.s_waitcnt(lgkmcnt=0)
+        lds_barrier()
+
+        qk_mma = fx.make_mma_atom(fx.rocdl.WMMA(16, 16, 16, qk_type, fx.Float32))
+        pv_mma = fx.make_mma_atom(fx.rocdl.WMMA(16, 16, 16, pv_type, fx.Float32))
+        neg_inf = fx.Float32(float("-inf"))
+        zero = fx.Float32(0.0)
+        init_state = [neg_inf, zero] + [zero for _ in range_constexpr(8)]
+
+        key_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), cache_type)
+            for _ in range_constexpr(HEAD_DIM // 128)
+        ]
+        key_source = fx.make_view(fx.get_iter(key_ptr), fx.make_layout(1 << 30, 1))
+        key_divided = fx.logical_divide(key_source, fx.make_layout(1, 1))
+        key_copy = fx.make_copy_atom(
+            fx.UniversalCopy64b() if is_fp8 else fx.UniversalCopy128b(),
+            cache_type,
+        )
+        score_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), fx.Float32)
+            for _ in range_constexpr(HEAD_DIM // 128)
+        ]
+        probability_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), pv_type)
+            for _ in range_constexpr(TOKEN_FRAGMENTS)
+        ]
+        value_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), pv_type)
+            for _ in range_constexpr(TOKEN_FRAGMENTS)
+        ]
+        output_fragment = fx.make_rmem_tensor(fx.make_layout(8, 1), fx.Float32)
+
+        for tile, state in range(  # type: ignore[call-overload]
+            begin, end, fx.Int32(TILE_TOKENS), init=init_state
+        ):
+            tile_i32 = fx.Int32(tile)
+            valid_tokens = fx.min(fx.Int32(TILE_TOKENS), end - tile_i32)
+
+            key_token_local = wave * 2 + lane // 16
+            key_token_valid = key_token_local < valid_tokens
+            key_token = tile_i32 + fx.min(key_token_local, valid_tokens - 1)
+            key_page = key_token // page_size
+            key_in_page = key_token - key_page * page_size
+            key_physical = fx.Int32(block_tables[seq * table_stride + key_page])
+            for key_dimension_block in range_constexpr(HEAD_DIM // 128):
+                key_d = key_dimension_block * 128 + (lane % 16) * 8
+                key_index = (
+                    key_physical * k_stride0
+                    + kv_head * k_stride1
+                    + (key_d // cache_pack) * k_stride2
+                    + key_in_page * k_stride3
+                    + (key_d % cache_pack) * k_stride4
+                )
+                fx.copy(
+                    key_copy,
+                    fx.slice(key_divided, (None, key_index)),
+                    key_fragments[key_dimension_block],
+                )
+            fx.rocdl.s_wait_loadcnt(0)
+            for key_dimension_block in range_constexpr(HEAD_DIM // 128):
+                key_d = key_dimension_block * 128 + (lane % 16) * 8
+                if const_expr(is_fp8):
+                    key_values = _dequant_fp8x8(
+                        fx.Vector(key_fragments[key_dimension_block].load()),
+                        fx.Float32(1.0),
+                        query_type,
+                        is_fp8fnuz=is_fp8fnuz,
+                    )
+                else:
+                    key_values = fx.Vector(key_fragments[key_dimension_block].load())
+                key_words_value = key_values.bitcast(fx.Int32)
+                for word in range_constexpr(4):
+                    storage.key[
+                        key_token_local * (HEAD_DIM // 2) + key_d // 2 + word
+                    ] = key_token_valid.select(key_words_value[word], fx.Int32(0))
+
+            value_token_local = lane
+            value_token_valid = value_token_local < valid_tokens
+            value_token = tile_i32 + fx.min(value_token_local, valid_tokens - 1)
+            value_page = value_token // page_size
+            value_in_page = value_token - value_page * page_size
+            value_physical = fx.Int32(block_tables[seq * table_stride + value_page])
+            for dimension_iteration in range_constexpr(HEAD_DIM // NUM_WAVES):
+                d = wave + dimension_iteration * NUM_WAVES
+                value_index = (
+                    value_physical * v_stride0
+                    + kv_head * v_stride1
+                    + d * v_stride2
+                    + value_in_page * v_stride3
+                )
+                if const_expr(is_fp8):
+                    value_element = fx.Float32(
+                        _decode_fp8(
+                            fx.Int32(raw_value[value_index]), 0, is_fp8fnuz=is_fp8fnuz
+                        )
+                    )
+                else:
+                    value_element = fx.Float32(value[value_index])
+                value_tile[d, value_token_local] = value_token_valid.select(
+                    value_element.to(pv_type), pv_type(0.0)
+                )
+            lds_barrier()
+
+            if wave < QK_WAVES:
+                token_block = wave
+                for score_part in range_constexpr(HEAD_DIM // 128):
+                    score_fragments[score_part].fill(0.0)
+                    for part_fragment in range_constexpr(8):
+                        k_fragment_index = score_part * 8 + part_fragment
+                        key_mma_fragment = fx.make_rmem_tensor(
+                            fx.make_layout(8, 1), qk_type
+                        )
+                        key_row = token_block * 16 + lane % 16
+                        key_fragment_word = (
+                            key_row * (HEAD_DIM * qk_bytes // 4)
+                            + (k_fragment_index * 16 + fragment_half * 8)
+                            * qk_bytes
+                            // 4
+                        )
+                        key_fragment_words = fx.Vector.from_elements(
+                            [
+                                storage.key[key_fragment_word + word]
+                                for word in range_constexpr(2 * qk_bytes)
+                            ],
+                            dtype=fx.Int32,
+                        )
+                        key_mma_fragment.store(key_fragment_words.bitcast(qk_type))
+                        fx.mma_atom_call(
+                            qk_mma,
+                            score_fragments[score_part],
+                            q_fragments[k_fragment_index],
+                            key_mma_fragment,
+                            score_fragments[score_part],
+                        )
+                score_values = fx.Vector(score_fragments[0].load())
+                if const_expr(HEAD_DIM == 256):
+                    score_values = score_values + fx.Vector(score_fragments[1].load())
+                score_row_base = fragment_half * 8
+                score_column = token_block * 16 + lane % 16
+                for score_row in range_constexpr(8):
+                    if const_expr(
+                        not (
+                            HEAD_DIM == 256 and query_group_size == 4 and score_row == 1
+                        )
+                    ):
+                        scores[score_row_base + score_row, score_column] = (
+                            score_values[score_row] * softmax_scale * k_scale
+                        )
+            if const_expr(HEAD_DIM == 256 and query_group_size == 4):  # noqa: SIM102
+                if (wave >= QK_WAVES) & (wave < 2 * QK_WAVES):
+                    token_block = wave - QK_WAVES
+                    for score_part in range_constexpr(HEAD_DIM // 128):
+                        score_fragments[score_part].fill(0.0)
+                        for part_fragment in range_constexpr(8):
+                            k_fragment_index = score_part * 8 + part_fragment
+                            key_mma_fragment = fx.make_rmem_tensor(
+                                fx.make_layout(8, 1), qk_type
+                            )
+                            key_row = token_block * 16 + lane % 16
+                            key_fragment_word = (
+                                key_row * (HEAD_DIM * qk_bytes // 4)
+                                + (k_fragment_index * 16 + fragment_half * 8)
+                                * qk_bytes
+                                // 4
+                            )
+                            key_fragment_words = fx.Vector.from_elements(
+                                [
+                                    storage.key[key_fragment_word + word]
+                                    for word in range_constexpr(2 * qk_bytes)
+                                ],
+                                dtype=fx.Int32,
+                            )
+                            key_mma_fragment.store(key_fragment_words.bitcast(qk_type))
+                            fx.mma_atom_call(
+                                qk_mma,
+                                score_fragments[score_part],
+                                q_fragments[k_fragment_index],
+                                key_mma_fragment,
+                                score_fragments[score_part],
+                            )
+                    repair_score = fx.Vector(score_fragments[0].load()) + fx.Vector(
+                        score_fragments[1].load()
+                    )
+                    if lane < 16:
+                        scores[1, token_block * 16 + lane] = (
+                            repair_score[0] * softmax_scale * k_scale
+                        )
+            lds_barrier()
+
+            running_max = fx.Float32(state[0])
+            running_sum = fx.Float32(state[1])
+            score = (lane < valid_tokens).select(
+                fx.Float32(scores[wave, lane]), neg_inf
+            )
+            tile_max = fx.Float32(
+                gpu.shuffle_idx(_wave_reduce(score, "max"), 0, WAVE_SIZE)
+            )
+            next_max = fx.max(running_max, tile_max)
+            old_scale = fmath.exp2((running_max - next_max) * LOG2E)
+            probability = (lane < valid_tokens).select(
+                fmath.exp2((score - next_max) * LOG2E), zero
+            )
+            tile_sum = fx.Float32(
+                gpu.shuffle_idx(_wave_reduce(probability, "sum"), 0, WAVE_SIZE)
+            )
+            next_sum = running_sum * old_scale + tile_sum
+            # Weights reuse the FP32 score storage across different waves.
+            lds_barrier()
+            weights[wave, lane] = probability.to(pv_type)
+            row_scale[wave] = old_scale
+            lds_barrier()
+
+            next_accumulators = [
+                fx.Float32(state[2 + element]) for element in range_constexpr(8)
+            ]
+            if wave < PV_WAVES:
+                for output_row in range_constexpr(8):
+                    accumulator_row = fragment_half * 8 + output_row
+                    output_fragment[output_row] = next_accumulators[
+                        output_row
+                    ] * fx.Float32(row_scale[accumulator_row])
+                d = wave * 16 + lane % 16
+                for token_fragment in range_constexpr(TOKEN_FRAGMENTS):
+                    token_base = token_fragment * 16 + fragment_half * 8
+                    for element in range_constexpr(8):
+                        probability_fragments[token_fragment][element] = weights[
+                            lane % 16, token_base + element
+                        ]
+                        value_fragments[token_fragment][element] = value_tile[
+                            d, token_base + element
+                        ]
+                    fx.mma_atom_call(
+                        pv_mma,
+                        output_fragment,
+                        probability_fragments[token_fragment],
+                        value_fragments[token_fragment],
+                        output_fragment,
+                    )
+                output_values = fx.Vector(output_fragment.load())
+                for output_row in range_constexpr(8):
+                    next_accumulators[output_row] = output_values[output_row]
+            lds_barrier()
+            results = yield [next_max, next_sum] + next_accumulators
+
+        final_sum = fx.Float32(results[1])
+        row_scale[wave] = final_sum
+        lds_barrier()
+
+        has_tokens = end > begin
+        if wave < PV_WAVES:
+            d = wave * 16 + lane % 16
+            for output_row in range_constexpr(8):
+                row = fragment_half * 8 + output_row
+                if row < query_group_size:
+                    denominator = fx.Float32(row_scale[row])
+                    partial = fx.Float32(results[2 + output_row]) / (
+                        denominator + 1.0e-10
+                    )
+                    out_index = (
+                        seq * mo_stride0
+                        + (kv_head * query_group_size + row) * mo_stride1
+                        + split * mo_stride2
+                        + d
+                    )
+                    mid_out[out_index] = has_tokens.select(partial * v_scale, zero)
+        if (lane == 0) & (wave < query_group_size):
+            lse = fx.Float32(results[0]) + fmath.log2(final_sum) / LOG2E
+            lse_index = (
+                seq * ml_stride0
+                + (kv_head * query_group_size + wave) * ml_stride1
+                + split * ml_stride2
+            )
+            mid_lse[lse_index] = has_tokens.select(lse, neg_inf)
+
+    @flyc.jit
+    def launch(
+        query: fx.Tensor,
+        key: fx.Tensor,
+        value: fx.Tensor,
+        block_tables: fx.Tensor,
+        seq_lens: fx.Tensor,
+        query_start_loc: fx.Tensor,
+        k_scale: fx.Tensor,
+        v_scale: fx.Tensor,
+        mid_out: fx.Tensor,
+        mid_lse: fx.Tensor,
+        batch: fx.Int32,
+        table_stride: fx.Int32,
+        q_stride0: fx.Int32,
+        q_stride1: fx.Int32,
+        k_stride0: fx.Int32,
+        k_stride1: fx.Int32,
+        k_stride2: fx.Int32,
+        k_stride3: fx.Int32,
+        k_stride4: fx.Int32,
+        v_stride0: fx.Int32,
+        v_stride1: fx.Int32,
+        v_stride2: fx.Int32,
+        v_stride3: fx.Int32,
+        mo_stride0: fx.Int32,
+        mo_stride1: fx.Int32,
+        mo_stride2: fx.Int32,
+        ml_stride0: fx.Int32,
+        ml_stride1: fx.Int32,
+        ml_stride2: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        stage(
+            query,
+            key,
+            value,
+            block_tables,
+            seq_lens,
+            query_start_loc,
+            k_scale,
+            v_scale,
+            mid_out,
+            mid_lse,
+            batch,
+            table_stride,
+            q_stride0,
+            q_stride1,
+            k_stride0,
+            k_stride1,
+            k_stride2,
+            k_stride3,
+            k_stride4,
+            v_stride0,
+            v_stride1,
+            v_stride2,
+            v_stride3,
+            mo_stride0,
+            mo_stride1,
+            mo_stride2,
+            ml_stride0,
+            ml_stride1,
+            ml_stride2,
+        ).launch(
+            grid=(batch * num_kv_heads * splits, 1, 1),
+            block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    return launch
+
+
+__all__ = ["compile_gqa_stage"]

--- a/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_native_d128.py
+++ b/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_native_d128.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: B008, SIM102 -- FlyDSL kernels preserve staged control flow
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Four-wave native-cache D128/GQA16 SplitKV stage for RDNA4."""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, range_constexpr
+from flydsl.expr import math as fmath
+
+from .rdna4_splitkv_common import LOG2E, WAVE_SIZE, _dequant_fp8x8, _flat_view
+
+HEAD_DIM = 128
+QUERY_ROWS = 16
+TILE_TOKENS = 16
+NUM_WAVES = 4
+BLOCK_THREADS = NUM_WAVES * WAVE_SIZE
+K_FRAGMENTS = HEAD_DIM // 16
+OUTPUT_FRAGMENTS = HEAD_DIM // 64
+
+
+@functools.lru_cache(maxsize=64)
+def compile_native_d128_gqa16_stage(
+    *,
+    dtype: str,
+    kv_dtype: str | None = None,
+    splits: int,
+    num_kv_heads: int,
+    page_size: int,
+    softmax_scale: float,
+    schedule: str = "direct",
+):
+    """Compile a four-wave direct-register or LDS D128/GQA16 stage."""
+
+    if dtype not in ("bf16", "fp16"):
+        raise ValueError(f"dtype must be 'bf16' or 'fp16', got {dtype!r}")
+    if kv_dtype is None:
+        kv_dtype = dtype
+    if kv_dtype not in ("bf16", "fp16", "fp8", "fp8fnuz"):
+        raise ValueError(f"unsupported KV dtype {kv_dtype!r}")
+    if splits < 1:
+        raise ValueError(f"splits must be positive, got {splits}")
+    if num_kv_heads < 1:
+        raise ValueError(f"num_kv_heads must be positive, got {num_kv_heads}")
+    if page_size < TILE_TOKENS or page_size % TILE_TOKENS:
+        raise ValueError(
+            f"page_size must be a multiple of {TILE_TOKENS}, got {page_size}"
+        )
+    if schedule not in ("direct", "lds"):
+        raise ValueError(f"schedule must be 'direct' or 'lds', got {schedule!r}")
+    elem_type = fx.BFloat16 if dtype == "bf16" else fx.Float16
+    is_fp8 = kv_dtype in ("fp8", "fp8fnuz")
+    is_fp8fnuz = kv_dtype == "fp8fnuz"
+    cache_pack = 16 if is_fp8 else 8
+    shared_elements = (
+        QUERY_ROWS * HEAD_DIM if schedule == "direct" else 2 * TILE_TOKENS * HEAD_DIM
+    )
+
+    @fx.struct
+    class SharedStorage:
+        words: fx.Array[fx.Int32, shared_elements // 2, 16]
+
+    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
+    def stage(
+        query_ptr: fx.Tensor,
+        key_ptr: fx.Tensor,
+        value_ptr: fx.Tensor,
+        block_tables_ptr: fx.Tensor,
+        seq_lens_ptr: fx.Tensor,
+        query_start_loc_ptr: fx.Tensor,
+        k_scale_ptr: fx.Tensor,
+        v_scale_ptr: fx.Tensor,
+        mid_out_ptr: fx.Tensor,
+        mid_lse_ptr: fx.Tensor,
+        batch: fx.Int32,
+        table_stride: fx.Int32,
+        q_stride0: fx.Int32,
+        q_stride1: fx.Int32,
+        k_stride0: fx.Int32,
+        k_stride1: fx.Int32,
+        k_stride2: fx.Int32,
+        k_stride3: fx.Int32,
+        k_stride4: fx.Int32,
+        v_stride0: fx.Int32,
+        v_stride1: fx.Int32,
+        v_stride2: fx.Int32,
+        v_stride3: fx.Int32,
+        mo_stride0: fx.Int32,
+        mo_stride1: fx.Int32,
+        mo_stride2: fx.Int32,
+        ml_stride0: fx.Int32,
+        ml_stride1: fx.Int32,
+        ml_stride2: fx.Int32,
+    ):
+        tid = fx.Int32(gpu.thread_idx.x)
+        wave = tid // WAVE_SIZE
+        lane = tid % WAVE_SIZE
+        block = fx.Int32(gpu.block_idx.x)
+        split = block % splits
+        item = block // splits
+        seq = item // num_kv_heads
+        kv_head = item % num_kv_heads
+
+        query = _flat_view(query_ptr)
+        key = _flat_view(key_ptr)
+        value = _flat_view(value_ptr)
+        block_tables = _flat_view(block_tables_ptr)
+        seq_lens = _flat_view(seq_lens_ptr)
+        query_start_loc = _flat_view(query_start_loc_ptr)
+        k_scales = _flat_view(k_scale_ptr)
+        v_scales = _flat_view(v_scale_ptr)
+        mid_out = _flat_view(mid_out_ptr)
+        mid_lse = _flat_view(mid_lse_ptr)
+
+        storage = fx.SharedAllocator().allocate(SharedStorage).peek()
+        shared = fx.make_view(
+            fx.recast_iter(elem_type, storage.words.ptr),
+            fx.make_layout(shared_elements, 1),
+        )
+        scores = fx.make_view(
+            fx.recast_iter(fx.Float32, storage.words.ptr),
+            fx.make_layout((QUERY_ROWS, TILE_TOKENS), (TILE_TOKENS, 1)),
+        )
+
+        def make_global_fragments(tensor_ptr, count, fragment_type, load_atom):
+            tensor = fx.make_view(fx.get_iter(tensor_ptr), fx.make_layout(1 << 30, 1))
+            divided = fx.logical_divide(tensor, fx.make_layout(1, 1))
+            fragments = [
+                fx.make_rmem_tensor(fx.make_layout(8, 1), fragment_type)
+                for _ in range_constexpr(count)
+            ]
+
+            def prefetch(slot, offset):
+                fx.copy(
+                    load_atom,
+                    fx.slice(divided, (None, offset)),
+                    fragments[slot],
+                )
+
+            return fragments, prefetch
+
+        k_scale = fx.Float32(1.0)
+        v_scale = fx.Float32(1.0)
+        if const_expr(is_fp8):
+            k_scale = fx.Float32(k_scales[0])
+            v_scale = fx.Float32(v_scales[0])
+
+        query_row = fx.Int32(query_start_loc[seq])
+        is_decode = fx.Int32(query_start_loc[seq + 1]) - query_row == 1
+        length = is_decode.select(fx.Int32(seq_lens[seq]), fx.Int32(0))
+        if const_expr(schedule == "direct"):
+            pages = (length + page_size - 1) // page_size
+            pages_per_split = (pages + splits - 1) // splits
+            begin = split * pages_per_split * page_size
+            end = fx.min(begin + pages_per_split * page_size, length)
+        else:
+            tokens_per_split = (length + splits - 1) // splits
+            begin = fx.min(split * tokens_per_split, length)
+            end = fx.min(begin + tokens_per_split, length)
+
+        for load_iter in range_constexpr((QUERY_ROWS * HEAD_DIM) // BLOCK_THREADS):
+            linear = tid + load_iter * BLOCK_THREADS
+            row = linear // HEAD_DIM
+            d = linear % HEAD_DIM
+            q_head = kv_head * QUERY_ROWS + row
+            shared[linear] = query[query_row * q_stride0 + q_head * q_stride1 + d].to(
+                elem_type
+            )
+        fx.rocdl.s_wait_dscnt(0)
+        gpu.barrier()
+
+        q_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), elem_type)
+            for _ in range_constexpr(K_FRAGMENTS)
+        ]
+        q_row = lane % QUERY_ROWS
+        q_half = lane // QUERY_ROWS
+        for k_fragment in range_constexpr(K_FRAGMENTS):
+            for element in range_constexpr(8):
+                d = k_fragment * 16 + q_half * 8 + element
+                q_fragments[k_fragment][element] = shared[q_row * HEAD_DIM + d]
+        fx.rocdl.s_wait_dscnt(0)
+        gpu.barrier()
+
+        mma_atom = fx.make_mma_atom(fx.rocdl.WMMA(16, 16, 16, elem_type, fx.Float32))
+        neg_inf = fx.Float32(float("-inf"))
+        zero = fx.Float32(0.0)
+        init_state = [neg_inf, zero] + [
+            zero for _ in range_constexpr(8 * OUTPUT_FRAGMENTS)
+        ]
+
+        key_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), elem_type)
+            for _ in range_constexpr(K_FRAGMENTS)
+        ]
+        value_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), elem_type)
+            for _ in range_constexpr(OUTPUT_FRAGMENTS)
+        ]
+        if const_expr(is_fp8):
+            raw_key_fragments, prefetch_key = make_global_fragments(
+                key_ptr,
+                K_FRAGMENTS,
+                fx.Uint8,
+                fx.make_copy_atom(fx.UniversalCopy64b(), fx.Uint8),
+            )
+            raw_value_fragments, prefetch_value = make_global_fragments(
+                value_ptr,
+                OUTPUT_FRAGMENTS,
+                fx.Uint8,
+                fx.make_copy_atom(fx.UniversalCopy64b(), fx.Uint8),
+            )
+        else:
+            key_fragments, prefetch_key = make_global_fragments(
+                key_ptr,
+                K_FRAGMENTS,
+                elem_type,
+                fx.make_copy_atom(fx.UniversalCopy128b(), elem_type),
+            )
+            value_fragments, prefetch_value = make_global_fragments(
+                value_ptr,
+                OUTPUT_FRAGMENTS,
+                elem_type,
+                fx.make_copy_atom(fx.UniversalCopy128b(), elem_type),
+            )
+        score_fragment = fx.make_rmem_tensor(fx.make_layout(8, 1), fx.Float32)
+        probability_fragment = fx.make_rmem_tensor(fx.make_layout(8, 1), elem_type)
+        output_fragments = [
+            fx.make_rmem_tensor(fx.make_layout(8, 1), fx.Float32)
+            for _ in range_constexpr(OUTPUT_FRAGMENTS)
+        ]
+
+        for tile, state in range(  # type: ignore[call-overload]
+            begin, end, fx.Int32(TILE_TOKENS), init=init_state
+        ):
+            tile_i32 = fx.Int32(tile)
+            token = tile_i32 + (lane // 16) * 8
+            if const_expr(schedule == "direct"):  # noqa: SIM102
+                logical_page = token // page_size
+                in_page = token - logical_page * page_size
+                physical_page = fx.Int32(
+                    block_tables[seq * table_stride + logical_page]
+                )
+
+                for output_fragment in range_constexpr(OUTPUT_FRAGMENTS):
+                    d = wave * 16 + output_fragment * 64 + lane % 16
+                    value_index = (
+                        physical_page * v_stride0
+                        + kv_head * v_stride1
+                        + d * v_stride2
+                        + in_page * v_stride3
+                    )
+                    prefetch_value(output_fragment, value_index)
+            else:
+                for token_iteration in range_constexpr(TILE_TOKENS // NUM_WAVES):
+                    token_local = wave + token_iteration * NUM_WAVES
+                    load_token = tile_i32 + token_local
+                    valid_token = load_token < end
+                    logical_page = load_token // page_size
+                    in_page = load_token - logical_page * page_size
+                    physical_page = fx.Int32(
+                        block_tables[seq * table_stride + logical_page]
+                    )
+                    for dimension_iteration in range_constexpr(HEAD_DIM // WAVE_SIZE):
+                        d = lane + dimension_iteration * WAVE_SIZE
+                        key_index = (
+                            physical_page * k_stride0
+                            + kv_head * k_stride1
+                            + (d // cache_pack) * k_stride2
+                            + in_page * k_stride3
+                            + (d % cache_pack) * k_stride4
+                        )
+                        value_index = (
+                            physical_page * v_stride0
+                            + kv_head * v_stride1
+                            + d * v_stride2
+                            + in_page * v_stride3
+                        )
+                        shared[token_local * HEAD_DIM + d] = valid_token.select(
+                            key[key_index].to(elem_type), elem_type(0.0)
+                        )
+                        shared[
+                            TILE_TOKENS * HEAD_DIM + d * TILE_TOKENS + token_local
+                        ] = valid_token.select(
+                            value[value_index].to(elem_type), elem_type(0.0)
+                        )
+                fx.rocdl.s_wait_dscnt(0)
+                fx.rocdl.s_barrier()
+
+            if wave == 0:
+                if const_expr(schedule == "direct"):
+                    key_token = tile_i32 + lane % 16
+                    key_page = key_token // page_size
+                    key_in_page = key_token - key_page * page_size
+                    key_physical = fx.Int32(block_tables[seq * table_stride + key_page])
+                    for k_fragment in range_constexpr(K_FRAGMENTS):
+                        d = k_fragment * 16 + (lane // 16) * 8
+                        key_index = (
+                            key_physical * k_stride0
+                            + kv_head * k_stride1
+                            + (d // cache_pack) * k_stride2
+                            + key_in_page * k_stride3
+                            + (d % cache_pack) * k_stride4
+                        )
+                        prefetch_key(k_fragment, key_index)
+                    if const_expr(is_fp8):
+                        for k_fragment in range_constexpr(K_FRAGMENTS):
+                            key_fragments[k_fragment].store(
+                                _dequant_fp8x8(
+                                    fx.Vector(raw_key_fragments[k_fragment].load()),
+                                    k_scale,
+                                    elem_type,
+                                    is_fp8fnuz=is_fp8fnuz,
+                                )
+                            )
+                else:
+                    key_token_local = lane % 16
+                    for k_fragment in range_constexpr(K_FRAGMENTS):
+                        for element in range_constexpr(8):
+                            d = k_fragment * 16 + (lane // 16) * 8 + element
+                            key_fragments[k_fragment][element] = shared[
+                                key_token_local * HEAD_DIM + d
+                            ]
+
+                score_fragment.fill(0.0)
+                for k_fragment in range_constexpr(K_FRAGMENTS):
+                    fx.mma_atom_call(
+                        mma_atom,
+                        score_fragment,
+                        q_fragments[k_fragment],
+                        key_fragments[k_fragment],
+                        score_fragment,
+                    )
+                score_values = fx.Vector(score_fragment.load())
+                score_row_base = (lane // 16) * 8
+                score_column = lane % 16
+                for score_row in range_constexpr(8):
+                    scores[score_row_base + score_row, score_column] = (
+                        score_values[score_row] * softmax_scale
+                    )
+            fx.rocdl.s_wait_dscnt(0)
+            fx.rocdl.s_barrier()
+
+            if const_expr(schedule == "lds"):
+                for output_fragment in range_constexpr(OUTPUT_FRAGMENTS):
+                    d = wave * 16 + output_fragment * 64 + lane % 16
+                    for element in range_constexpr(8):
+                        value_fragments[output_fragment][element] = shared[
+                            TILE_TOKENS * HEAD_DIM
+                            + d * TILE_TOKENS
+                            + (lane // 16) * 8
+                            + element
+                        ]
+            elif const_expr(is_fp8):
+                for output_fragment in range_constexpr(OUTPUT_FRAGMENTS):
+                    value_fragments[output_fragment].store(
+                        _dequant_fp8x8(
+                            fx.Vector(raw_value_fragments[output_fragment].load()),
+                            v_scale,
+                            elem_type,
+                            is_fp8fnuz=is_fp8fnuz,
+                        )
+                    )
+
+            running_max = fx.Float32(state[0])
+            running_sum = fx.Float32(state[1])
+            local_max = neg_inf
+            row = lane % QUERY_ROWS
+            token_base = (lane // QUERY_ROWS) * 8
+            score_values = []
+            for token_inner in range_constexpr(8):
+                token_local = token_base + token_inner
+                valid = tile_i32 + token_local < end
+                score = valid.select(fx.Float32(scores[row, token_local]), neg_inf)
+                score_values.append(score)
+                local_max = fx.max(local_max, score)
+            tile_max = fx.max(
+                local_max, fx.Float32(gpu.shuffle_xor(local_max, 16, WAVE_SIZE))
+            )
+            next_max = fx.max(running_max, tile_max)
+            alpha = fmath.exp2((running_max - next_max) * LOG2E)
+            local_sum = zero
+            for token_inner in range_constexpr(8):
+                probability = fmath.exp2((score_values[token_inner] - next_max) * LOG2E)
+                probability_fragment[token_inner] = probability.to(elem_type)
+                local_sum = local_sum + probability
+            tile_sum = local_sum + fx.Float32(gpu.shuffle_xor(local_sum, 16, WAVE_SIZE))
+            next_sum = running_sum * alpha + tile_sum
+
+            if const_expr(schedule == "direct"):
+                if tile_i32 + TILE_TOKENS > end:
+                    for output_fragment in range_constexpr(OUTPUT_FRAGMENTS):
+                        for element in range_constexpr(8):
+                            value_valid = token + element < end
+                            value_fragments[output_fragment][element] = (
+                                value_valid.select(
+                                    value_fragments[output_fragment][element],
+                                    elem_type(0.0),
+                                )
+                            )
+
+            next_accumulators = []
+            for output_fragment in range_constexpr(OUTPUT_FRAGMENTS):
+                for output_row in range_constexpr(8):
+                    accumulator_row = (lane // 16) * 8 + output_row
+                    alpha_row = fx.Float32(
+                        gpu.shuffle_idx(alpha, accumulator_row, WAVE_SIZE)
+                    )
+                    output_fragments[output_fragment][output_row] = (
+                        fx.Float32(state[2 + output_fragment * 8 + output_row])
+                        * alpha_row
+                    )
+                fx.mma_atom_call(
+                    mma_atom,
+                    output_fragments[output_fragment],
+                    probability_fragment,
+                    value_fragments[output_fragment],
+                    output_fragments[output_fragment],
+                )
+                output_values = fx.Vector(output_fragments[output_fragment].load())
+                for output_row in range_constexpr(8):
+                    next_accumulators.append(output_values[output_row])
+            if const_expr(schedule == "direct"):
+                gpu.barrier()
+            else:
+                fx.rocdl.s_wait_dscnt(0)
+                fx.rocdl.s_barrier()
+            results = yield [next_max, next_sum] + next_accumulators
+
+        has_tokens = end > begin
+        final_sum = fx.Float32(results[1])
+        output_row_base = (lane // 16) * 8
+        for output_fragment in range_constexpr(OUTPUT_FRAGMENTS):
+            d = wave * 16 + output_fragment * 64 + lane % 16
+            for output_row in range_constexpr(8):
+                row = output_row_base + output_row
+                q_head = kv_head * QUERY_ROWS + row
+                denominator = fx.Float32(gpu.shuffle_idx(final_sum, row, WAVE_SIZE))
+                partial = fx.Float32(results[2 + output_fragment * 8 + output_row]) / (
+                    denominator + 1.0e-10
+                )
+                out_index = (
+                    seq * mo_stride0 + q_head * mo_stride1 + split * mo_stride2 + d
+                )
+                mid_out[out_index] = has_tokens.select(partial, zero)
+        if (wave == 0) & (lane < QUERY_ROWS):
+            q_head = kv_head * QUERY_ROWS + lane
+            lse = fx.Float32(results[0]) + fmath.log2(final_sum) / LOG2E
+            lse_index = seq * ml_stride0 + q_head * ml_stride1 + split * ml_stride2
+            mid_lse[lse_index] = has_tokens.select(lse, neg_inf)
+
+    @flyc.jit
+    def launch(
+        query: fx.Tensor,
+        key: fx.Tensor,
+        value: fx.Tensor,
+        block_tables: fx.Tensor,
+        seq_lens: fx.Tensor,
+        query_start_loc: fx.Tensor,
+        k_scale: fx.Tensor,
+        v_scale: fx.Tensor,
+        mid_out: fx.Tensor,
+        mid_lse: fx.Tensor,
+        batch: fx.Int32,
+        table_stride: fx.Int32,
+        q_stride0: fx.Int32,
+        q_stride1: fx.Int32,
+        k_stride0: fx.Int32,
+        k_stride1: fx.Int32,
+        k_stride2: fx.Int32,
+        k_stride3: fx.Int32,
+        k_stride4: fx.Int32,
+        v_stride0: fx.Int32,
+        v_stride1: fx.Int32,
+        v_stride2: fx.Int32,
+        v_stride3: fx.Int32,
+        mo_stride0: fx.Int32,
+        mo_stride1: fx.Int32,
+        mo_stride2: fx.Int32,
+        ml_stride0: fx.Int32,
+        ml_stride1: fx.Int32,
+        ml_stride2: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        stage(
+            query,
+            key,
+            value,
+            block_tables,
+            seq_lens,
+            query_start_loc,
+            k_scale,
+            v_scale,
+            mid_out,
+            mid_lse,
+            batch,
+            table_stride,
+            q_stride0,
+            q_stride1,
+            k_stride0,
+            k_stride1,
+            k_stride2,
+            k_stride3,
+            k_stride4,
+            v_stride0,
+            v_stride1,
+            v_stride2,
+            v_stride3,
+            mo_stride0,
+            mo_stride1,
+            mo_stride2,
+            ml_stride0,
+            ml_stride1,
+            ml_stride2,
+        ).launch(
+            grid=(batch * num_kv_heads * splits, 1, 1),
+            block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    return launch
+
+
+__all__ = ["compile_native_d128_gqa16_stage"]

--- a/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_reduce.py
+++ b/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_reduce.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: B008 -- FlyDSL launch signatures require typed stream defaults
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Compact wave32 reducer for split-KV decode partials."""
+
+from __future__ import annotations
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+import torch
+from flydsl.expr import gpu, range_constexpr
+from flydsl.expr import math as fmath
+
+from .runtime import run_compiled as _run_compiled
+
+WAVE_SIZE = 32
+LOG2E = 1.4426950408889634
+SUPPORTED_SPLITS = (2, 4, 8, 16)
+SUPPORTED_HEAD_DIMS = (128, 256)
+
+
+def _flat_view(tensor: fx.Tensor, elem_type=None) -> fx.Tensor:
+    iterator = fx.get_iter(tensor)
+    if elem_type is not None:
+        iterator = fx.recast_iter(elem_type, iterator)
+    return fx.make_view(iterator, fx.make_layout(1 << 30, 1))
+
+
+@functools.lru_cache(maxsize=128)
+def compile_local_reduce(
+    *,
+    head_dim: int,
+    splits: int,
+    num_query_heads: int,
+    output_dtype: str,
+    split_block_size: int,
+    waves_per_block: int,
+):
+    """Compile a one-wave-per-row, split-specialized LSE reducer."""
+
+    if head_dim not in SUPPORTED_HEAD_DIMS:
+        raise ValueError(f"unsupported head dimension {head_dim}")
+    if splits not in SUPPORTED_SPLITS:
+        raise ValueError(f"unsupported split count {splits}")
+    if output_dtype not in ("bf16", "f16"):
+        raise ValueError(f"unsupported output dtype {output_dtype!r}")
+    if waves_per_block not in (1, 2, 4):
+        raise ValueError(f"unsupported waves per block {waves_per_block}")
+    out_type = fx.BFloat16 if output_dtype == "bf16" else fx.Float16
+    values_per_lane = head_dim // WAVE_SIZE
+    block_threads = WAVE_SIZE * waves_per_block
+
+    @flyc.kernel(known_block_size=(block_threads, 1, 1))
+    def reduce_kernel(
+        mid_out_ptr: fx.Tensor,
+        mid_lse_ptr: fx.Tensor,
+        seq_lens_ptr: fx.Tensor,
+        query_start_loc_ptr: fx.Tensor,
+        output_ptr: fx.Tensor,
+        batch: fx.Int32,
+        out_stride0: fx.Int32,
+        out_stride1: fx.Int32,
+        mo_stride0: fx.Int32,
+        mo_stride1: fx.Int32,
+        mo_stride2: fx.Int32,
+        ml_stride0: fx.Int32,
+        ml_stride1: fx.Int32,
+        ml_stride2: fx.Int32,
+    ):
+        tid = fx.Int32(gpu.thread_idx.x)
+        wave = tid // WAVE_SIZE
+        lane = tid % WAVE_SIZE
+        logical_row = fx.Int32(gpu.block_idx.x) * waves_per_block + wave
+        total_rows = batch * num_query_heads
+        row_valid = logical_row < total_rows
+        safe_row = row_valid.select(logical_row, fx.Int32(0))
+        seq = safe_row // num_query_heads
+        qh = safe_row % num_query_heads
+
+        mid_out = _flat_view(mid_out_ptr, fx.Float32)
+        mid_lse = _flat_view(mid_lse_ptr, fx.Float32)
+        seq_lens = _flat_view(seq_lens_ptr)
+        query_start_loc = _flat_view(query_start_loc_ptr)
+        output = _flat_view(output_ptr, out_type)
+
+        seq_len = fx.Int32(seq_lens[seq])
+        split_len = (
+            ((seq_len + splits - 1) // splits + split_block_size - 1)
+            // split_block_size
+            * split_block_size
+        )
+        query_row = fx.Int32(query_start_loc[seq])
+        is_decode = fx.Int32(query_start_loc[seq + 1]) - query_row == 1
+
+        neg_inf = fx.Float32(float("-inf"))
+        zero = fx.Float32(0.0)
+        one = fx.Float32(1.0)
+        lse_base = seq * ml_stride0 + qh * ml_stride1
+        mo_base = seq * mo_stride0 + qh * mo_stride1
+        out_base = query_row * out_stride0 + qh * out_stride1
+        init_state = [neg_inf, zero] + [zero for _ in range_constexpr(values_per_lane)]
+
+        # This is deliberately the oracle's left-to-right FP32 combine,
+        # not a global-max weighted sum. Empty tail splits are selected
+        # away without reading their uninitialized scratch rows. A runtime
+        # loop reuses the small live accumulator set; the fixed upper bound
+        # remains baked into each split-count specialization.
+        for split, state in range(  # type: ignore[call-overload]
+            fx.Int32(0), fx.Int32(splits), fx.Int32(1), init=init_state
+        ):
+            running_max = fx.Float32(state[0])
+            running_sum = fx.Float32(state[1])
+            accum = [
+                fx.Float32(state[2 + element])
+                for element in range_constexpr(values_per_lane)
+            ]
+            split_i32 = fx.Int32(split)
+            split_active = split_i32 * split_len < seq_len
+            safe_split = split_active.select(split_i32, fx.Int32(0))
+            partial_lse = fx.Float32(mid_lse[lse_base + safe_split * ml_stride2])
+            next_max = split_active.select(
+                fx.max(running_max, partial_lse), running_max
+            )
+            partial_is_new_max = partial_lse > running_max
+            rescale = fmath.exp2(
+                partial_is_new_max.select(
+                    running_max - partial_lse,
+                    partial_lse - running_max,
+                )
+                * LOG2E
+            )
+            alpha = split_active.select(partial_is_new_max.select(rescale, one), one)
+            beta = split_active.select(partial_is_new_max.select(one, rescale), zero)
+
+            for element in range_constexpr(values_per_lane):
+                d = lane + element * WAVE_SIZE
+                partial = fx.Float32(mid_out[mo_base + safe_split * mo_stride2 + d])
+                accum[element] = accum[element] * alpha + partial * beta
+            results = yield [next_max, running_sum * alpha + beta] + accum
+
+        running_sum = fx.Float32(results[1])
+        accum = [
+            fx.Float32(results[2 + element])
+            for element in range_constexpr(values_per_lane)
+        ]
+        inv_sum = one / (running_sum + 1.0e-10)
+        for element in range_constexpr(values_per_lane):
+            d = lane + element * WAVE_SIZE
+            if row_valid & is_decode:
+                output[out_base + d] = (accum[element] * inv_sum).to(out_type)
+
+    @flyc.jit
+    def launch_reduce(
+        mid_out: fx.Tensor,
+        mid_lse: fx.Tensor,
+        seq_lens: fx.Tensor,
+        query_start_loc: fx.Tensor,
+        output: fx.Tensor,
+        batch: fx.Int32,
+        out_stride0: fx.Int32,
+        out_stride1: fx.Int32,
+        mo_stride0: fx.Int32,
+        mo_stride1: fx.Int32,
+        mo_stride2: fx.Int32,
+        ml_stride0: fx.Int32,
+        ml_stride1: fx.Int32,
+        ml_stride2: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        reduce_kernel(
+            mid_out,
+            mid_lse,
+            seq_lens,
+            query_start_loc,
+            output,
+            batch,
+            out_stride0,
+            out_stride1,
+            mo_stride0,
+            mo_stride1,
+            mo_stride2,
+            ml_stride0,
+            ml_stride1,
+            ml_stride2,
+        ).launch(
+            grid=(
+                (batch * num_query_heads + waves_per_block - 1) // waves_per_block,
+                1,
+                1,
+            ),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_reduce
+
+
+def _launch_reduce(
+    query: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    output: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    splits: int,
+    split_block_size: int,
+    stream: torch.cuda.Stream,
+) -> None:
+    output_dtype = "bf16" if output.dtype == torch.bfloat16 else "f16"
+    total_rows = int(seq_lens.numel()) * int(query.shape[1])
+    # A 64-row reduction has exactly two result waves per gfx1201 WGP.
+    # Pack those waves into one workgroup so the launch presents one workgroup
+    # per WGP, while retaining the lower-overhead one-wave shape for smaller
+    # reductions and the established four-wave shape above 128 rows.
+    waves_per_block = 1 if total_rows < 64 else (2 if total_rows <= 128 else 4)
+    launch = compile_local_reduce(
+        head_dim=int(query.shape[2]),
+        splits=int(splits),
+        num_query_heads=int(query.shape[1]),
+        output_dtype=output_dtype,
+        split_block_size=int(split_block_size),
+        waves_per_block=waves_per_block,
+    )
+    _run_compiled(
+        launch,
+        mid_out,
+        mid_lse,
+        seq_lens,
+        query_start_loc,
+        output,
+        int(seq_lens.numel()),
+        int(output.stride(0)),
+        int(output.stride(1)),
+        *map(int, mid_out.stride()[:3]),
+        *map(int, mid_lse.stride()),
+        stream,
+    )

--- a/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_wave8.py
+++ b/vllm/v1/attention/ops/flydsl_kernels/rdna4_splitkv_wave8.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: B008 -- FlyDSL launch signatures require typed stream defaults
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Eight-wave per-query-head SplitKV stage for RDNA4."""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, range_constexpr
+from flydsl.expr import math as fmath
+
+from .rdna4_splitkv_common import LOG2E, WAVE_SIZE, _decode_fp8, _wave_reduce
+
+NUM_WAVES = 8
+BLOCK_THREADS = NUM_WAVES * WAVE_SIZE
+
+
+@functools.lru_cache(maxsize=128)
+def compile_wave8_stage(
+    *,
+    query_dtype: str,
+    kv_dtype: str,
+    head_dim: int,
+    splits: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    query_group_size: int,
+    page_size: int,
+    softmax_scale: float,
+    layout_key: tuple = (),
+):
+    """Compile a scalar-FP32, eight-wave token-partition stage."""
+
+    if query_dtype not in ("bf16", "fp16"):
+        raise ValueError(f"unsupported query dtype {query_dtype!r}")
+    if kv_dtype not in ("bf16", "fp16", "fp8", "fp8fnuz"):
+        raise ValueError(f"unsupported KV dtype {kv_dtype!r}")
+    if head_dim not in (128, 256):
+        raise ValueError(f"head_dim must be 128 or 256, got {head_dim}")
+    if splits < 1:
+        raise ValueError(f"splits must be positive, got {splits}")
+    if num_query_heads < 1 or num_kv_heads < 1:
+        raise ValueError("query and KV head counts must be positive")
+    if not 1 <= query_group_size <= 16:
+        raise ValueError(f"query_group_size must be in [1, 16], got {query_group_size}")
+    if page_size < 8 or page_size % 8:
+        raise ValueError(f"page_size must be a positive multiple of 8, got {page_size}")
+    if not isinstance(layout_key, tuple):
+        raise TypeError("layout_key must be a tuple")
+
+    is_fp8 = kv_dtype in ("fp8", "fp8fnuz")
+    is_fp8fnuz = kv_dtype == "fp8fnuz"
+    values_per_lane = head_dim // WAVE_SIZE
+    lds_values = NUM_WAVES * head_dim + 3 * NUM_WAVES
+
+    @fx.struct
+    class SharedStorage:
+        values: fx.Array[fx.Float32, lds_values, 16]
+
+    @flyc.kernel(known_block_size=(BLOCK_THREADS, 1, 1))
+    def stage(
+        query_ptr: fx.Tensor,
+        key_ptr: fx.Tensor,
+        value_ptr: fx.Tensor,
+        block_tables_ptr: fx.Tensor,
+        seq_lens_ptr: fx.Tensor,
+        query_start_loc_ptr: fx.Tensor,
+        k_scale_ptr: fx.Tensor,
+        v_scale_ptr: fx.Tensor,
+        mid_out_ptr: fx.Tensor,
+        mid_lse_ptr: fx.Tensor,
+        output_ptr: fx.Tensor,
+        split_counters_ptr: fx.Tensor,
+    ):
+        tid = fx.Int32(gpu.thread_idx.x)
+        wave = tid // WAVE_SIZE
+        lane = tid % WAVE_SIZE
+        query_head = fx.Int32(gpu.block_idx.x)
+        split = fx.Int32(gpu.block_idx.y)
+        seq = fx.Int32(gpu.block_idx.z)
+        kv_head = query_head // query_group_size
+
+        raw_key = fx.make_view(
+            fx.recast_iter(fx.Uint8, fx.get_iter(key_ptr)),
+            key_ptr.layout,
+        )
+        raw_value = fx.make_view(
+            fx.recast_iter(fx.Uint8, fx.get_iter(value_ptr)),
+            value_ptr.layout,
+        )
+
+        k_scale = fx.Float32(1.0)
+        v_scale = fx.Float32(1.0)
+        if const_expr(is_fp8):
+            k_scale = fx.Float32(k_scale_ptr[0])
+            v_scale = fx.Float32(v_scale_ptr[0])
+
+        query_row = fx.Int32(query_start_loc_ptr[seq])
+        query_end = fx.Int32(query_start_loc_ptr[seq + 1])
+        is_decode = query_end - query_row == 1
+        length = is_decode.select(fx.Int32(seq_lens_ptr[seq]), fx.Int32(0))
+        tokens_per_split = (length + splits - 1) // splits
+        begin = fx.min(split * tokens_per_split, length)
+        end = fx.min(begin + tokens_per_split, length)
+
+        query_loads = []
+        for element in range_constexpr(values_per_lane):
+            d = lane + element * WAVE_SIZE
+            query_loads.append(query_ptr[query_row, query_head, d])
+        query_values = []
+        for element in range_constexpr(values_per_lane):
+            query_value = is_decode.select(
+                fx.Float32(query_loads[element]), fx.Float32(0.0)
+            )
+            query_values.append(query_value * k_scale)
+
+        neg_inf = fx.Float32(float("-inf"))
+        zero = fx.Float32(0.0)
+
+        def issue_token_loads(token):
+            token_i32 = fx.Int32(token)
+            logical_page = token_i32 // page_size
+            in_page = token_i32 - logical_page * page_size
+            physical_page = fx.Int32(0)
+            if lane == 0:
+                physical_page = fx.Int32(block_tables_ptr[seq, logical_page])
+            physical_page = fx.Int32(gpu.shuffle_idx(physical_page, 0, WAVE_SIZE))
+            loads = []
+            for element in range_constexpr(values_per_lane):
+                d = lane + element * WAVE_SIZE
+                key_index = (
+                    physical_page,
+                    kv_head,
+                    d // (16 if is_fp8 else 8),
+                    in_page,
+                    d % (16 if is_fp8 else 8),
+                )
+                if const_expr(is_fp8):
+                    loads.append(raw_key[key_index])
+                else:
+                    loads.append(key_ptr[key_index])
+            for element in range_constexpr(values_per_lane):
+                d = lane + element * WAVE_SIZE
+                value_index = (physical_page, kv_head, d, in_page)
+                if const_expr(is_fp8):
+                    loads.append(raw_value[value_index])
+                else:
+                    loads.append(value_ptr[value_index])
+            return loads
+
+        def update_online_state(loads, state):
+            dot = zero
+            for element in range_constexpr(values_per_lane):
+                if const_expr(is_fp8):
+                    key_value = fx.Float32(
+                        _decode_fp8(fx.Int32(loads[element]), 0, is_fp8fnuz=is_fp8fnuz)
+                    )
+                else:
+                    key_value = fx.Float32(loads[element])
+                dot = dot + query_values[element] * key_value
+            score = (
+                fx.Float32(gpu.shuffle_idx(_wave_reduce(dot, "sum"), 0, WAVE_SIZE))
+                * softmax_scale
+            )
+            running_max = fx.Float32(state[0])
+            running_sum = fx.Float32(state[1])
+            next_max = fx.max(running_max, score)
+            old_scale = fmath.isfinite(running_max).select(
+                fmath.exp2((running_max - next_max) * LOG2E), zero
+            )
+            weight = fmath.exp2((score - next_max) * LOG2E)
+            next_accumulators = []
+            for element in range_constexpr(values_per_lane):
+                if const_expr(is_fp8):
+                    value_element = fx.Float32(
+                        _decode_fp8(
+                            fx.Int32(loads[values_per_lane + element]),
+                            0,
+                            is_fp8fnuz=is_fp8fnuz,
+                        )
+                    )
+                else:
+                    value_element = fx.Float32(loads[values_per_lane + element])
+                next_accumulators.append(
+                    fx.Float32(state[2 + element]) * old_scale + weight * value_element
+                )
+            return [
+                next_max,
+                running_sum * old_scale + weight,
+            ] + next_accumulators
+
+        init_state = [neg_inf, zero] + [zero for _ in range_constexpr(values_per_lane)]
+        for token, state in range(  # type: ignore[call-overload]
+            begin + wave, end, fx.Int32(NUM_WAVES), init=init_state
+        ):
+            results = yield update_online_state(issue_token_loads(token), state)
+
+        storage = fx.SharedAllocator().allocate(SharedStorage).peek()
+        partial = fx.make_view(
+            storage.values.ptr,
+            fx.make_layout((NUM_WAVES, head_dim), (head_dim, 1)),
+        )
+        state_max = fx.make_view(
+            fx.add_offset(storage.values.ptr, NUM_WAVES * head_dim),
+            fx.make_layout(NUM_WAVES, 1),
+        )
+        state_sum = fx.make_view(
+            fx.add_offset(storage.values.ptr, NUM_WAVES * head_dim + NUM_WAVES),
+            fx.make_layout(NUM_WAVES, 1),
+        )
+        state_weight = fx.make_view(
+            fx.add_offset(storage.values.ptr, NUM_WAVES * head_dim + 2 * NUM_WAVES),
+            fx.make_layout(NUM_WAVES, 1),
+        )
+        for element in range_constexpr(values_per_lane):
+            partial[wave, lane + element * WAVE_SIZE] = fx.Float32(results[2 + element])
+        if lane == 0:
+            state_max[wave] = fx.Float32(results[0])
+            state_sum[wave] = fx.Float32(results[1])
+        fx.rocdl.s_waitcnt(lgkmcnt=0)
+        gpu.barrier()
+
+        if tid == 0:
+            merged_max = neg_inf
+            for source_wave in range_constexpr(NUM_WAVES):
+                merged_max = fx.max(merged_max, fx.Float32(state_max[source_wave]))
+            merged_sum = zero
+            for source_wave in range_constexpr(NUM_WAVES):
+                source_max = fx.Float32(state_max[source_wave])
+                merge_weight = fmath.isfinite(source_max).select(
+                    fmath.exp2((source_max - merged_max) * LOG2E), zero
+                )
+                state_weight[source_wave] = merge_weight
+                merged_sum = (
+                    merged_sum + fx.Float32(state_sum[source_wave]) * merge_weight
+                )
+            state_max[0] = merged_max
+            state_sum[0] = merged_sum
+        fx.rocdl.s_waitcnt(lgkmcnt=0)
+        gpu.barrier()
+
+        for output_element in range_constexpr(
+            (head_dim + BLOCK_THREADS - 1) // BLOCK_THREADS
+        ):
+            d = tid + output_element * BLOCK_THREADS
+            if d < head_dim:
+                merged_value = zero
+                for source_wave in range_constexpr(NUM_WAVES):
+                    merged_value = merged_value + fx.Float32(
+                        state_weight[source_wave]
+                    ) * fx.Float32(partial[source_wave, d])
+                merged_sum = fx.Float32(state_sum[0])
+                mid_out_ptr[seq, query_head, split, d] = (merged_sum > 0.0).select(
+                    merged_value / merged_sum * v_scale, zero
+                )
+        if tid == 0:
+            merged_sum = fx.Float32(state_sum[0])
+            lse = fx.Float32(state_max[0]) + fmath.log2(merged_sum) / LOG2E
+            mid_lse_ptr[seq, query_head, split] = (merged_sum > 0.0).select(
+                lse, neg_inf
+            )
+
+        gpu.barrier()
+        old = fx.Int32(-1)
+        if tid == 0:
+            fx.llvm.memory_fence(
+                ordering=fx.AtomicOrdering.Release,
+                syncscope=fx.rocdl.SyncScope.Agent,
+            )
+            counter_index = (seq * num_query_heads + query_head) * 16
+            counter_ptr = fx.add_offset(fx.get_iter(split_counters_ptr), counter_index)
+            old = fx.llvm.atomic_add(
+                counter_ptr,
+                fx.Int32(1),
+                ordering=fx.AtomicOrdering.Monotonic,
+                syncscope=fx.rocdl.SyncScope.Agent,
+            )
+            state_weight[0] = fx.Float32(old)
+        fx.rocdl.s_waitcnt(lgkmcnt=0)
+        gpu.barrier()
+        old = fx.Int32(state_weight[0])
+
+        if old == splits - 1:
+            if tid == 0:
+                fx.llvm.memory_fence(
+                    ordering=fx.AtomicOrdering.Acquire,
+                    syncscope=fx.rocdl.SyncScope.Agent,
+                )
+                counter_index = (seq * num_query_heads + query_head) * 16
+                counter_ptr = fx.add_offset(
+                    fx.get_iter(split_counters_ptr), counter_index
+                )
+                fx.llvm.generic_store(
+                    counter_ptr,
+                    fx.Int32(0),
+                    memory_order=fx.AtomicOrdering.Monotonic,
+                    syncscope=fx.rocdl.SyncScope.Agent,
+                )
+            gpu.barrier()
+
+            if (wave == 0) & is_decode:
+                max_lse = neg_inf
+                for source_split in range_constexpr(splits):
+                    max_lse = fx.max(
+                        max_lse,
+                        fx.Float32(mid_lse_ptr[seq, query_head, source_split]),
+                    )
+                denominator = zero
+                result = [zero for _ in range_constexpr(values_per_lane)]
+                for source_split in range_constexpr(splits):
+                    partial_lse = fx.Float32(mid_lse_ptr[seq, query_head, source_split])
+                    weight = fmath.isfinite(partial_lse).select(
+                        fmath.exp2((partial_lse - max_lse) * LOG2E),
+                        zero,
+                    )
+                    denominator = denominator + weight
+                    for element in range_constexpr(values_per_lane):
+                        d = lane + element * WAVE_SIZE
+                        result[element] = result[element] + weight * fx.Float32(
+                            mid_out_ptr[seq, query_head, source_split, d]
+                        )
+                for element in range_constexpr(values_per_lane):
+                    d = lane + element * WAVE_SIZE
+                    normalized = (denominator > 0.0).select(
+                        result[element] / denominator, zero
+                    )
+                    if const_expr(query_dtype == "fp16"):
+                        output_ptr[query_row, query_head, d] = normalized.to(fx.Float16)
+                    else:
+                        output_ptr[query_row, query_head, d] = normalized.to(
+                            fx.BFloat16
+                        )
+
+    @flyc.jit
+    def launch(
+        query: fx.Tensor,
+        key: fx.Tensor,
+        value: fx.Tensor,
+        block_tables: fx.Tensor,
+        seq_lens: fx.Tensor,
+        query_start_loc: fx.Tensor,
+        k_scale: fx.Tensor,
+        v_scale: fx.Tensor,
+        mid_out: fx.Tensor,
+        mid_lse: fx.Tensor,
+        output: fx.Tensor,
+        split_counters: fx.Tensor,
+        batch: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        stage(
+            query,
+            key,
+            value,
+            block_tables,
+            seq_lens,
+            query_start_loc,
+            k_scale,
+            v_scale,
+            mid_out,
+            mid_lse,
+            output,
+            split_counters,
+        ).launch(
+            grid=(num_query_heads, splits, batch),
+            block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    return launch
+
+
+__all__ = ["compile_wave8_stage"]

--- a/vllm/v1/attention/ops/flydsl_kernels/runtime.py
+++ b/vllm/v1/attention/ops/flydsl_kernels/runtime.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Minimal FlyDSL compilation and dispatch helper."""
+
+from threading import Lock
+from weakref import WeakKeyDictionary
+
+import flydsl.compiler as flyc
+import torch
+
+_COMPILE_LOCK = Lock()
+_COMPILED: WeakKeyDictionary = WeakKeyDictionary()
+
+
+def run_compiled(executable, *args) -> None:
+    """Compile on first use and dispatch the cached function thereafter."""
+    with _COMPILE_LOCK:
+        compiled = _COMPILED.get(executable)
+        if compiled is None:
+            compiled = flyc.compile(executable, *args)
+            _COMPILED[executable] = compiled
+    compiled(*args)
+
+
+def get_compiled_static_tensors(executable, *args):
+    """Return a compiled callable with tensor layouts fixed by ``args``."""
+    with _COMPILE_LOCK:
+        compiled = _COMPILED.get(executable)
+        if compiled is None:
+            compile_args = tuple(
+                flyc.from_torch_tensor(arg) if isinstance(arg, torch.Tensor) else arg
+                for arg in args
+            )
+            compiled = flyc.compile(executable, *compile_args)
+            _COMPILED[executable] = compiled
+    return compiled

--- a/vllm/v1/attention/ops/rdna4_splitkv.py
+++ b/vllm/v1/attention/ops/rdna4_splitkv.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""RDNA4 backend selection for SplitKV paged attention."""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+from inspect import signature
+from typing import Any
+
+import torch
+
+from vllm import envs
+from vllm.logger import init_logger
+from vllm.v1.kv_cache_interface import KVQuantMode
+
+logger = init_logger(__name__)
+
+
+def _can_use_rdna4_splitkv_decode(
+    *,
+    query_dtype: torch.dtype,
+    key_cache_dtype: torch.dtype,
+    value_cache_dtype: torch.dtype,
+    kv_quant_mode: KVQuantMode,
+    is_e4m3_kv_cache: bool,
+    head_size: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    use_alibi_slopes: bool,
+    sliding_window: int,
+    has_sinks: bool,
+    has_output_scale: bool,
+    is_gfx1x: bool,
+    is_gfx12x: bool,
+) -> bool:
+    """Return whether the validated SplitKV decode route can be used."""
+    if (
+        query_dtype not in (torch.float16, torch.bfloat16)
+        or key_cache_dtype != value_cache_dtype
+        or head_size not in (128, 256)
+        or num_kv_heads <= 0
+        or num_query_heads % num_kv_heads != 0
+        or not 1 <= num_query_heads // num_kv_heads <= 16
+        or use_alibi_slopes
+        or sliding_window != 0
+        or has_sinks
+        or has_output_scale
+    ):
+        return False
+
+    if kv_quant_mode == KVQuantMode.FP8_PER_TENSOR:
+        e4m3_dtypes = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+        return is_gfx12x and is_e4m3_kv_cache and key_cache_dtype in e4m3_dtypes
+    if kv_quant_mode != KVQuantMode.NONE:
+        return False
+
+    return is_gfx1x and key_cache_dtype == query_dtype
+
+
+@lru_cache(maxsize=1)
+def _load_flydsl_splitkv() -> tuple[Any, Any]:
+    """Load the in-tree kernels without making FlyDSL a vLLM dependency."""
+    import flydsl.compiler  # noqa: F401
+    import flydsl.expr as fx
+
+    scalar_fp8_params = tuple(signature(fx.rocdl.cvt_f32_fp8).parameters)
+    if scalar_fp8_params[:2] != ("src", "byte_sel"):
+        raise RuntimeError("FlyDSL lacks the scalar FP8 conversion API")
+    required_memory_apis = (
+        (fx.llvm, "memory_fence"),
+        (fx.llvm, "atomic_add"),
+        (fx.llvm, "generic_store"),
+        (fx, "AtomicOrdering"),
+        (fx.rocdl, "SyncScope"),
+    )
+    missing = [
+        f"{module.__name__}.{name}"
+        for module, name in required_memory_apis
+        if not hasattr(module, name)
+    ]
+    if missing:
+        raise RuntimeError(f"FlyDSL lacks required ordered memory APIs: {missing}")
+
+    from .flydsl_kernels.rdna4_splitkv import (
+        rdna4_splitkv_paged_attention,
+        select_kernel_config,
+    )
+
+    return select_kernel_config, rdna4_splitkv_paged_attention
+
+
+@lru_cache(maxsize=1)
+def is_rdna4_flydsl_splitkv_available() -> bool:
+    """Return whether the FlyDSL compiler and in-tree kernels import."""
+    try:
+        _load_flydsl_splitkv()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning_once(
+            "RDNA4 FlyDSL SplitKV is unavailable (%s); using another backend.",
+            exc,
+        )
+        return False
+    return True
+
+
+def get_rdna4_flydsl_splitkv_config(
+    *,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    output: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor | None,
+    k_scale: torch.Tensor | float,
+    v_scale: torch.Tensor | float,
+    scale: float,
+    actual_max_splits: int,
+    max_seq_len: int,
+    filter_by_query_len: bool,
+) -> Any | None:
+    """Return a validated FlyDSL configuration, or ``None`` for fallback."""
+    from vllm.platforms.rocm import on_rdna4
+
+    if (
+        not on_rdna4()
+        or not is_rdna4_flydsl_splitkv_available()
+        or query.ndim != 3
+        or key_cache.ndim != 5
+        or value_cache.ndim != 4
+        or block_tables.ndim != 2
+        or seq_lens.ndim != 1
+        or query_start_loc is None
+        or query_start_loc.ndim != 1
+        or not query.is_cuda
+    ):
+        return None
+    num_query_heads = query.shape[1]
+    num_kv_heads = key_cache.shape[1]
+    head_size = query.shape[2]
+    page_size = key_cache.shape[3]
+    cache_pack = 16 // key_cache.element_size()
+    cache_groups = head_size // cache_pack
+    supported_dtypes = (
+        torch.bfloat16,
+        torch.float16,
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+    )
+    valid = (
+        query.dtype in (torch.bfloat16, torch.float16)
+        and output.dtype == query.dtype
+        and key_cache.dtype == value_cache.dtype
+        and key_cache.dtype in supported_dtypes
+        and head_size in (128, 256)
+        and output.shape == query.shape
+        and query.shape[0] >= seq_lens.numel()
+        and num_kv_heads > 0
+        and num_query_heads % num_kv_heads == 0
+        and page_size >= 8
+        and page_size % 8 == 0
+        and key_cache.shape[2:] == (cache_groups, page_size, cache_pack)
+        and value_cache.shape
+        == (key_cache.shape[0], num_kv_heads, head_size, page_size)
+        and block_tables.shape[0] == seq_lens.numel()
+        and block_tables.shape[1] * page_size >= max_seq_len
+        and query_start_loc.numel() == seq_lens.numel() + 1
+        and query.stride(2) == 1
+        and output.stride(2) == 1
+        and key_cache.stride(4) == 1
+        and value_cache.stride(3) == 1
+        and block_tables.stride(1) == 1
+        and seq_lens.stride(0) == 1
+        and query_start_loc.stride(0) == 1
+        and query.device
+        == output.device
+        == key_cache.device
+        == value_cache.device
+        == block_tables.device
+        == seq_lens.device
+        == query_start_loc.device
+        and block_tables.dtype == torch.int32
+        and seq_lens.dtype == torch.int32
+        and query_start_loc.dtype == torch.int32
+        and filter_by_query_len
+        and isinstance(k_scale, torch.Tensor)
+        and isinstance(v_scale, torch.Tensor)
+        and k_scale.dtype == torch.float32
+        and v_scale.dtype == torch.float32
+        and k_scale.device == query.device
+        and v_scale.device == query.device
+        and k_scale.numel() == 1
+        and v_scale.numel() == 1
+        and math.isfinite(scale)
+        and max_seq_len > 0
+        and actual_max_splits in (2, 4, 8, 16)
+    )
+    if not valid:
+        return None
+    select_kernel_config, _ = _load_flydsl_splitkv()
+    return select_kernel_config(query, key_cache, seq_lens, max_seq_len)
+
+
+def can_use_rdna4_flydsl_splitkv_paged_attention(**kwargs) -> bool:
+    """Return whether a validated RDNA4 FlyDSL route applies."""
+    return get_rdna4_flydsl_splitkv_config(**kwargs) is not None
+
+
+def try_rdna4_splitkv_paged_attention(
+    *,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    output: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor | None,
+    k_scale: torch.Tensor | float,
+    v_scale: torch.Tensor | float,
+    scale: float,
+    actual_max_splits: int,
+    max_seq_len: int,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    filter_by_query_len: bool,
+) -> bool:
+    """Run the selected RDNA4 FlyDSL route and report whether one was used."""
+    if not envs.VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL:
+        return False
+
+    flydsl_config = get_rdna4_flydsl_splitkv_config(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        output=output,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        query_start_loc=query_start_loc,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        scale=scale,
+        actual_max_splits=actual_max_splits,
+        max_seq_len=max_seq_len,
+        filter_by_query_len=filter_by_query_len,
+    )
+    if flydsl_config is None:
+        return False
+
+    assert query_start_loc is not None
+    assert isinstance(k_scale, torch.Tensor)
+    assert isinstance(v_scale, torch.Tensor)
+    _, launch = _load_flydsl_splitkv()
+    launch(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        query_start_loc,
+        k_scale,
+        v_scale,
+        output,
+        mid_out,
+        mid_lse,
+        actual_max_splits,
+        scale,
+        max_seq_len,
+        config=flydsl_config,
+    )
+    logger.info_once("Using RDNA4 FlyDSL SplitKV route: %s", flydsl_config.route.value)
+    return True
+
+
+__all__ = [
+    "can_use_rdna4_flydsl_splitkv_paged_attention",
+    "get_rdna4_flydsl_splitkv_config",
+    "is_rdna4_flydsl_splitkv_available",
+    "try_rdna4_splitkv_paged_attention",
+]

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -682,13 +682,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         check_attention_cp_compatibility(self.vllm_config)
         if isinstance(self.speculator, DraftModelSpeculator):
             # HACK(woosuk)
-            self.speculator.set_attn(
-                self.model_state,
-                self.kv_cache_config,
-                self.block_tables,
-                self.input_buffers,
-                self.attn_groups,
-            )
+            with use_workspace_lane(self._draft_workspace_lane):
+                self.speculator.set_attn(
+                    self.model_state,
+                    self.kv_cache_config,
+                    self.block_tables,
+                    self.input_buffers,
+                    self.attn_groups,
+                )
         if self.speculator is not None:
             # After set_attn, so the speculator can size its cudagraph mode
             # to its own attention support.

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -140,6 +140,24 @@ class WorkspaceManager:
             for i in range(len(shapes_and_dtypes))
         ]
 
+    def _reserve_simultaneous(
+        self, *shapes_and_dtypes: tuple[tuple[int, ...], torch.dtype]
+    ) -> None:
+        """Pre-size the current lane for every DBO ubatch during initialization.
+
+        This must run before execution can retain workspace views. Resizing a
+        different active ubatch would otherwise invalidate its live views.
+        """
+        if self._locked:
+            raise RuntimeError("Workspace reservation is initialization-only.")
+        actual_bytes = [
+            _compute_bytes(shape, dtype) for shape, dtype in shapes_and_dtypes
+        ]
+        required_bytes = sum(round_up(actual, 256) for actual in actual_bytes)
+        lane = _workspace_lane.get()
+        for ubatch_id in range(self._num_ubatches):
+            self._ensure_workspace_slot_size(required_bytes, ubatch_id, lane)
+
     def _ensure_workspace_size(self, required_bytes: int) -> torch.Tensor:
         """Ensure workspace is allocated and large enough, return current workspace.
 
@@ -149,8 +167,13 @@ class WorkspaceManager:
         Returns:
             The current workspace tensor.
         """
-        ubatch_id = dbo_current_ubatch_id()
-        lane = _workspace_lane.get()
+        return self._ensure_workspace_slot_size(
+            required_bytes, dbo_current_ubatch_id(), _workspace_lane.get()
+        )
+
+    def _ensure_workspace_slot_size(
+        self, required_bytes: int, ubatch_id: int, lane: int
+    ) -> torch.Tensor:
         if lane >= self._num_lanes:
             raise RuntimeError(
                 f"Workspace lane {lane} is not configured; manager has "


### PR DESCRIPTION
## Purpose

Add generalized Triton SplitKV paged decode for RDNA3 and RDNA4, with
in-tree FlyDSL kernels providing an opt-in optimized path on RDNA4.

The native BF16/FP16 Triton path is gated by `on_gfx1x()`, which includes
RDNA3. FP8 KV-cache SplitKV requires `on_gfx12x()`, and all FlyDSL routes
require `on_rdna4()`. RDNA3 therefore uses Triton for eligible BF16/FP16
workloads, even when the FlyDSL flag is enabled. The results below validate
RDNA4; RDNA3 correctness and performance have not been tested in this run.

The FlyDSL selector exposes eight routes that were promoted only after passing
unrestricted-value accuracy checks. Unsupported shapes, unavailable FlyDSL, or
disabled FlyDSL continue through Triton. The implementation supports BF16 and
FP16 queries, native and E4M3/E4M3FNUZ KV caches, head dimensions 128 and 256,
GQA ratios 1 through 16, ragged batches, and non-standard physical page sizes.

The FlyDSL path is opt-in through
`VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL=1`.

**Note: a custom build of FlyDSL is needed for FlyDSL SplitKV https://github.com/ROCm/FlyDSL/pull/1109** 

### Related work / duplicate check

This is related to and overlaps with #45916, which adds the original Triton
SplitKV fallback for native BF16/FP16, head dimension 256 on gfx1x. It is not a
duplicate: this PR extends that fallback to FP8/FNUZ, head dimension 128,
irregular physical pages, pointer block tables, workspace-manager allocation,
and CUDA/HIP graph replay, and adds the separate fast path RDNA4 FlyDSL implementation.

## Test Plan

Tests run on Radeon AI PRO R9700 (`gfx1201`) GPUs. The dtype/TP-shape matrix
explicitly selects Triton-only or FlyDSL-enabled execution; the Triton-only
cases fail if anything attempts to load FlyDSL kernels.

```bash
export PYTORCH_ROCM_ARCH=gfx1201

# Force Triton SplitKV for the complete dtype and TP-shape matrix.
VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL=0 \
  .venv/bin/python -m pytest -q \
  tests/kernels/attention/test_splitkv_paged_decode.py \
  -k 'dispatch_boundaries and triton' --junitxml=triton.xml

# Exercise FlyDSL routes and their intended Triton fallbacks on the same cases.
VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL=1 \
  .venv/bin/python -m pytest -q \
  tests/kernels/attention/test_splitkv_paged_decode.py \
  -k 'dispatch_boundaries and flydsl' --junitxml=flydsl.xml

# Remaining route-specific, graph replay, integration, and split-count tests.
VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL=0 \
  .venv/bin/python -m pytest -q \
  tests/kernels/attention/test_splitkv_paged_decode.py \
  tests/kernels/attention/test_splitkv_num_splits.py \
  -k 'not dispatch_boundaries' --junitxml=remaining.xml
```

The remaining tests include backend-specific checks that explicitly set their
own mode; that group is reported separately from the forced-Triton matrix.

## Validation results

**1,310 attention tests passed in the latest run, with no failures or skips:**
548 forced-Triton cases, 548 FlyDSL-enabled cases, and 214 remaining tests.
This comprises 1,209 paged-decode tests and 101 split-count/eligibility tests.
The implementation uses FlyDSL `9b022dee` and Torch `2.11.0+rocm7.14.0`.

### Kernel cases tested

The kernel validation covers a broad matrix of attention shapes and dtypes.
The same 548 configurations ran with forced Triton and with FlyDSL enabled.
The matrix consists of the following groups. 

| Case group | Configurations per backend mode | Coverage |
|---|---:|---|
| Dispatch boundaries | 224 | D128/D256; every GQA ratio 1–16; batches 1, 3, 7, 8, 9, 16, 33; KV-head counts 1, 2, 4; rotating dtype, page-size, split-count, and attention-profile combinations. |
| Specialized-route shapes | 144 | Eight `(head dimension, GQA, batch)` shapes, each crossed with six query/KV dtype pairs and three attention profiles. |
| Large batches | 36 | D128/GQA16 and D256/GQA6; batches 64, 128, 256; all six query/KV dtype pairs. |
| Additional D256 layouts and lengths | 144 | Q/KV head counts 24/4, 12/2, 6/1; four KV dtypes; four layout/length patterns; three attention profiles. |
| **Total** | **548** | **All passed in both modes.** |

The eight specialized-route shapes `(D, GQA, batch)` are
`(128,16,8)`, `(128,16,16)`, `(128,16,1)`, `(128,8,3)`,
`(256,4,3)`, `(256,16,3)`, `(256,6,3)`, and `(128,3,3)`.
The six query/KV dtype pairs are BF16/BF16, FP16/FP16,
BF16/FP8-E4M3, FP16/FP8-E4M3, BF16/FP8-E4M3FNUZ, and
FP16/FP8-E4M3FNUZ.

Across these groups, the cases exercise:

- Physical page sizes 16, 32, 528, 784, and 1568, with padded cache strides
  and noncontiguous query/output strides.
- Split counts 2, 4, 8, and 16.
- Ragged sequences, lengths immediately below/at/above page boundaries,
  lengths 4095–4102, and long sequences of 32,767 tokens.
- Ordinary, peaked, and nearly uniform attention profiles, masked NaN cache
  tails, preservation of untouched output storage, and FP8 scales 0.73/1.27.



### Kernel results by head dimension

| Head dimension | Forced Triton SplitKV | Actual FlyDSL route | Intended Triton fallback with FlyDSL enabled |
|---|---:|---:|---:|
| D128 | 220/220 passed | 91/91 passed | 129/129 passed |
| D256 | 328/328 passed | 310/310 passed | 18/18 passed |
| **Total** | **548/548 passed** | **401/401 passed** | **147/147 passed** |

### Kernel results by KV-cache dtype

| KV-cache dtype | Forced Triton SplitKV | Actual FlyDSL route | Intended Triton fallback with FlyDSL enabled |
|---|---:|---:|---:|
| BF16 | 104/104 passed | 86/86 passed | 18/18 passed |
| FP16 | 104/104 passed | 87/87 passed | 17/17 passed |
| FP8 E4M3 | 170/170 passed | 118/118 passed | 52/52 passed |
| FP8 E4M3FNUZ | 170/170 passed | 110/110 passed | 60/60 passed |
| **Total** | **548/548 passed** | **401/401 passed** | **147/147 passed** |

The same 548 configurations were tested in both modes. The FlyDSL-enabled
run used FlyDSL for 401 cases and Triton for 147 cases, as recorded per test;
fallback passes are not counted as FlyDSL kernel passes. Native BF16/FP16
KV caches use matching query dtypes; FP8 coverage includes BF16 and FP16
queries. Coverage includes head dimensions 128/256, GQA ratios 1–16,
ragged batches, irregular cache pages/strides, and varied attention profiles.


Earlier validation additionally passed 28 FlyDSL compiler tests, 36 long-context
checks reaching 131,071 tokens, head-partition checks with 50 graph replays per
format, and 648 accuracy-checked measurements in the old/new FlyDSL benchmark
sweeps. Those checks were not rerun as part of this backend-matrix run.


### Serving and model accuracy
A subset of the GSM8K benchmark is run comparing the baseline and the implemented SplitKv kernel

The comparative GSM8K smoke evaluation used the same 32 zero-shot questions per configuration, a brief-calculation instruction, and a 384-token cap:

| TP | Old / new correct | Same final answers  | Serving configuration |
|---|---:|---:|---|
| 2 | 31/32 / 31/32 | 32/32 |  8K context, 8 sequences |
| 4 | 31/32 / 31/32 | 32/32 |  32K context, 16 sequences |

### Online serving performance
```bash
NCCL_PROTO=Simple VLLM_ROCM_USE_RDNA4_SPLITKV_FLYDSL=1 \
vllm serve Qwen/Qwen3.8-27B-FP8 \
  -tp 4 \
  --load-format fastsafetensors \ 
  --max-num-seqs 32 \
  --max-model-len auto \
  --kv-cache-dtype fp8
```
Serving workload benchmark comparison
- Streams: 1, 2, 4, and 8
- Synthetic prompt: 2,048 tokens per turn
- Output: 512 tokens per turn
- Turns per conversation: 8

| Streams | Output tok/s, baseline → SplitKV FP8 | TPS change | Mean TTFT (ms), baseline → SplitKV FP8 | TTFT change | Mean E2E (s), baseline → SplitKV FP8 | E2E change |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 10.03 → 39.46 | **+293.5%** | 2,340 → 1,853 | **−20.8%** | 65.14 → 13.03 | **−80.0%** |
| 2 | 9.53 → 34.71 | **+264.1%** | 3,066 → 2,524 | **−17.7%** | 67.86 → 14.87 | **−78.1%** |
| 4 | 9.26 → 28.68 | **+209.6%** | 3,391 → 3,989 | +17.6% | 69.17 → 18.18 | **−73.7%** |
| 8 | 8.32 → 26.60 | **+219.7%** | 5,226 → 4,566 | **−12.6%** | 75.93 → 20.25 | **−73.3%** |

<img width="2233" height="1476" alt="compare_tp4_e2e_by_turn" src="https://github.com/user-attachments/assets/0573c939-08f3-45a9-b1e0-76d9a2a13cd9" />
<img width="2233" height="1476" alt="compare_tp4_tps_by_turn" src="https://github.com/user-attachments/assets/94a5530e-a1a5-4396-944d-8ec0f4afbec4" />
<img width="2232" height="1476" alt="compare_tp4_ttft_by_turn" src="https://github.com/user-attachments/assets/da070950-e1ed-4b49-9418-7b190f31e461" />


## AI assistance disclosure

OpenAI Codex assisted with implementation, testing, benchmarking, and this history cleanup. 
