### PR TITLE
[core] Introduce dedicated hash-hit free list to reduce premature eviction of cache-hit blocks

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -179,6 +179,8 @@ class BlockPool:
         # list of free blocks (including eviction candidates when caching is
         # enabled).
         self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
+        # Free blocks with non-empty block_hash are tracked separately.
+        self.free_cached_block_queue = FreeKVCacheBlockQueue([])
 
         # Cache for block lookup
         self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
@@ -658,7 +660,14 @@ class BlockPool:
         if num_blocks > self.get_num_free_blocks():
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        ret: list[KVCacheBlock] = []
+        num_from_free = min(num_blocks, self.free_block_queue.num_free_blocks)
+        if num_from_free > 0:
+            ret.extend(self.free_block_queue.popleft_n(num_from_free))
+
+        num_remaining = num_blocks - len(ret)
+        if num_remaining > 0:
+            ret.extend(self.free_cached_block_queue.popleft_n(num_remaining))
 
         # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:
@@ -711,8 +720,10 @@ class BlockPool:
             # ref_cnt=0 means this block is in the free list (i.e. eviction
             # candidate), so remove it.
             if block.ref_cnt == 0 and not block.is_null:
-                self.free_block_queue.remove(block)
+                assert block.block_hash is not None
+                self.free_cached_block_queue.remove(block)
             block.ref_cnt += 1
+            block.is_hit = True
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
@@ -726,6 +737,7 @@ class BlockPool:
         """
         # Identify blocks with hash (LRU cache) and without it (never match APC)
         blocks_to_evict_last = []
+        blocks_to_evict_second = []
         blocks_to_evict_first = []
         for block in ordered_blocks:
             block.ref_cnt -= 1
@@ -733,14 +745,18 @@ class BlockPool:
                 if block.block_hash is None or not self.enable_caching:
                     # LIFO reuse of non-cached blocks for better GPU locality.
                     blocks_to_evict_first.append(block)
+                elif not block.is_hit:
+                    blocks_to_evict_second.append(block)
                 else:
                     # FIFO reuse of cached blocks for LRU eviction behavior.
                     blocks_to_evict_last.append(block)
 
         # Blocks to reuse first are prepended to the front of the free queue.
         self.free_block_queue.prepend_n(blocks_to_evict_first)
-        # Blocks to reuse last are appended to the end of the free queue.
-        self.free_block_queue.append_n(blocks_to_evict_last)
+        # Blocks to reuse second are prepended to the front of the free cached queue.
+        self.free_cached_block_queue.prepend_n(blocks_to_evict_second)
+        # Blocks to reuse last are appended to the end of the free cached queue.
+        self.free_cached_block_queue.append_n(blocks_to_evict_last)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
@@ -803,7 +819,10 @@ class BlockPool:
         Returns:
             The number of free blocks.
         """
-        return self.free_block_queue.num_free_blocks
+        return (
+            self.free_block_queue.num_free_blocks
+            + self.free_cached_block_queue.num_free_blocks
+        )
 
     def get_usage(self) -> float:
         """Get the KV cache usage.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -137,6 +137,8 @@ class KVCacheBlock:
 
     # Whether the block is a null block that should never be cached.
     is_null: bool = False
+    # Whether the block has been hit since its latest allocation.
+    is_hit: bool = False
 
     @property
     def block_hash(self) -> BlockHashWithGroupId | None:
@@ -161,6 +163,7 @@ class KVCacheBlock:
         """Reset the block hash when the block is evicted."""
         self._block_hash = None
         self._block_hash_num_tokens = None
+        self.is_hit = False
 
     def __repr__(self) -> str:
         # Use block_id instead of KVCacheBlock object to avoid calling __repr__
@@ -173,7 +176,8 @@ class KVCacheBlock:
             f"_block_hash={self._block_hash!r}, "
             f"_block_hash_num_tokens={self._block_hash_num_tokens}, "
             f"prev_free_block={prev_block_id}, "
-            f"next_free_block={next_block_id})"
+            f"next_free_block={next_block_id}, "
+            f"is_hit={self.is_hit})"
         )
 
 


### PR DESCRIPTION




## Purpose
Currently the hit blocks interleave with miss/non-cached blocks in the free list.
However we wish all hit blocks can be placed in the tail of the free list so that
the hit blocks can be hit more and more before they are allocated out.

So we introduce a new free list called hash-hit free list that is allocated after
the original free list and to park hash-hit free blocks separately.

So this can decrease the eviction amount of hit blocks.

## Test Plan
default testcases
python -m pytest tests/v1/core/test_kv_cache_utils.py -v
python -m pytest tests/v1/core/test_prefix_caching.py -v
python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v
## Test Result
default testcases
python -m pytest tests/v1/core/test_kv_cache_utils.py -v
76 passed, 14 warnings

python -m pytest tests/v1/core/test_prefix_caching.py -v
89 passed, 14 warnings

python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v
9 passed, 14 warnings

---


