### PR TITLE
[Examples] Point DummyLogitsProcessor at tests/v1/logits_processors/utils.py

### DIFF
--- a/examples/features/logits_processor/README.md
+++ b/examples/features/logits_processor/README.md
@@ -32,7 +32,7 @@ python examples/features/logits_processor/custom_req_init.py
 
 - **Batch-level vs. request-level**: vLLM processes logits at the batch level for efficiency. If you have a per-request processor, you need to wrap it using the patterns shown in `custom_req.py` and `custom_req_init.py`.
 - **`SamplingParams.extra_args`**: Use this to pass custom keyword arguments to your logits processor on a per-request basis (e.g., `target_token`).
-- **`DummyLogitsProcessor`**: A reference implementation available in `vllm/test_utils.py` that can be used as a starting point for custom processors.
+- **`DummyLogitsProcessor`**: A reference implementation available in `tests/v1/logits_processors/utils.py` that can be used as a starting point for custom processors.
 
 ## Further Reading
 

--- a/examples/features/logits_processor/custom.py
+++ b/examples/features/logits_processor/custom.py
@@ -5,7 +5,7 @@
 class object.
 
 For a basic example of implementing a custom logits processor, see
-the `DummyLogitsProcessor` implementation in `vllm/test_utils.py`.
+the `DummyLogitsProcessor` implementation in `tests/v1/logits_processors/utils.py`.
 
 For testing purposes, a dummy logits processor is employed which, if
 `target_token` is passed as a keyword argument to `SamplingParams.extra_args`,


### PR DESCRIPTION
## Summary
- Point `DummyLogitsProcessor` references from nonexistent `vllm/test_utils.py` to the live reference at `tests/v1/logits_processors/utils.py`.
- Touches only `examples/features/logits_processor/README.md` and the `custom.py` module docstring.

## Local repro
```bash
# Ghost path (404)
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/vllm/test_utils.py | head -1
# -> HTTP/2 404

# Live reference (200) with DummyLogitsProcessor
curl -sI https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/logits_processors/utils.py | head -1
# -> HTTP/2 200
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/logits_processors/utils.py | rg -n 'class DummyLogitsProcessor|DUMMY_LOGITPROC_MODULE'
# DUMMY_LOGITPROC_MODULE = "tests.v1.logits_processors.utils"

# Drifted docs still name the ghost path
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/logits_processor/README.md | rg -n 'test_utils'
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/logits_processor/custom.py | rg -n 'test_utils'
```

## Test plan
- [x] Confirmed `vllm/test_utils.py` is 404 on current main HEAD
- [x] Confirmed `DummyLogitsProcessor` exists in `tests/v1/logits_processors/utils.py`
- [x] Grepped open PRs for logits/test_utils coverage — none
- [ ] CI / docs checks pass