### PR TITLE
docs: fix ghost --kv-ip/--kv-port in security guide

### DIFF
--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -18,8 +18,8 @@ The following options control internode communications in vLLM:
 
 #### 2. **KV Cache Transfer Configuration:**
 
-- `--kv-ip`: The IP address for KV cache transfer communications (default: 127.0.0.1)
-- `--kv-port`: The port for KV cache transfer communications (default: 14579)
+- `--kv-transfer-config.kv_ip` (or via `--kv-transfer-config '{"kv_ip":"..."}'`): The IP address for KV cache transfer communications (default: 127.0.0.1)
+- `--kv-transfer-config.kv_port` (or via `--kv-transfer-config '{"kv_port":...}'`): The port for KV cache transfer communications (default: 14579)
 
 #### 3. **Data Parallel Configuration:**
 


### PR DESCRIPTION
## Summary
- `docs/usage/security.md` listed top-level `--kv-ip` / `--kv-port` under KV Cache Transfer Configuration.
- Live `EngineArgs` only exposes these as fields of `KVTransferConfig` via `--kv-transfer-config` (see `vllm/config/kv_transfer.py`: `kv_ip`, `kv_port`).
- Update the security guide to the nested CLI forms (`--kv-transfer-config.kv_ip` / `.kv_port`, or JSON), matching other disagg docs.

## Test plan
- [ ] Confirm `KVTransferConfig` still defines `kv_ip` / `kv_port` with the documented defaults
- [ ] Confirm no top-level `--kv-ip` / `--kv-port` in `EngineArgs.add_cli_args`
- [ ] Docs render check for the two bullet lines