### PR TITLE
[Test][MLA] Cover padded spec-decode context lengths in the DSA indexer

### DIFF
--- a/tests/v1/attention/test_indexer_native_next_n.py
+++ b/tests/v1/attention/test_indexer_native_next_n.py
@@ -7,11 +7,22 @@ asserts both that the architecture implements the requested `next_n` and that
 the schedule metadata was sized for the matching slot count.
 """
 
-import pytest
+from dataclasses import replace
+from types import SimpleNamespace
 
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import _paged_mqa_logits_schedule_slots
 from vllm.v1.attention.backends.mla import indexer
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
+from vllm.v1.worker.block_table import get_block_table_width
 
 NUM_SMS = 114  # H100 PCIe
 
@@ -73,3 +84,54 @@ def test_multicast_is_sm90_only(monkeypatch, family):
     _set_arch(monkeypatch, family)
     for next_n in (1, 2, 3, 4):
         assert _paged_mqa_logits_schedule_slots(NUM_SMS, next_n) == NUM_SMS
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("use_flattening", [False, True])
+def test_padded_spec_decode_request_gets_zero_context_length(use_flattening):
+    """A FULL-CUDA-graph replay pads the batch with requests whose seq_len is
+    0. With next_n > 1 the per-token context length of such a request's first
+    row is seq_len - next_n + 1 and would be negative without the clamp from
+    #51538; the top-k kernels consume it as uint32 (#51593). Cover the native
+    (B, next_n) path and the flattened uniform-decode kernel path."""
+    device = torch.device("cuda")
+    next_n, block_size, ctx = 2, 64, 300
+    vllm_config = create_vllm_config(
+        model_name="deepseek-ai/DeepSeek-V2-Lite-Chat",
+        max_model_len=1024,
+        block_size=block_size,
+    )
+    vllm_config.speculative_config = SimpleNamespace(
+        num_speculative_tokens=next_n - 1, enable_adaptive_verification=False
+    )
+    kv_cache_spec = MLAAttentionSpec(
+        block_size=block_size, num_kv_heads=1, head_size=576, dtype=torch.bfloat16
+    )
+    block_table_width = get_block_table_width(
+        kv_cache_spec.max_num_blocks_per_req(vllm_config, 1024), block_size
+    )
+    builder = indexer.DeepseekV32IndexerMetadataBuilder(
+        kv_cache_spec=kv_cache_spec,
+        layer_names=["dummy"],
+        vllm_config=vllm_config,
+        device=device,
+        block_table_width=block_table_width,
+    )
+    builder.use_flattening = use_flattening
+    builder.supports_varlen = False
+
+    # Three live requests plus one CUDA-graph padding request (seq_len 0).
+    batch = BatchSpec(seq_lens=[ctx, ctx, ctx, 0], query_lens=[next_n] * 4)
+    common = create_common_attn_metadata(batch, block_size, device)
+    common = replace(
+        common,
+        block_table_tensor=torch.zeros(
+            (4, block_table_width), dtype=torch.int32, device=device
+        ),
+    )
+
+    md = builder.build(common_prefix_len=0, common_attn_metadata=common)
+
+    assert md.num_decodes == 4 and md.decode is not None
+    lens = md.decode.seq_lens.reshape(-1).tolist()
+    assert lens == [ctx - 1, ctx] * 3 + [0, 0], lens


### PR DESCRIPTION
## Purpose

**What.** Minimal regression coverage for the padded spec-decode context-length invariant fixed in #51538: for MTP (`next_n = 2`) with three live requests and one CUDA-graph padding request (`seq_len = 0`), the DSA indexer's per-token context lengths for the padded request must be `[0, 0]`, not `[-1, 0]`. One parametrised test (58 lines) in the existing `tests/v1/attention/test_indexer_native_next_n.py`, built on the real `DeepseekV32IndexerMetadataBuilder`, covering both the native `(B, next_n)` path and the flattened uniform-decode kernel path. No production change.

**Why.** A downstream fork that predates #51538 reproduced the old defect while serving with FlashInfer sparse MLA on SM12x, where it presented as a FlashInfer decode hang (flashinfer-ai/flashinfer#5015). The investigation showed the FlashInfer launch was queued on the same stream behind vLLM's already-wedged `persistent_topk`, which had read the unclamped `-1` as `uint32` (#51593). The producer clamps landed in #51538 without a direct test; this pins them so the invariant cannot silently regress again.

## Duplicate check

- #51538 (merged) already contains the production fix (producer clamps in `indexer.py` and the `persistent_topk` length guard). This PR does **not** duplicate that fix; it adds the regression coverage that was missing from the merged change.
- Searched `gh pr list --state open` for `persistent_topk`, `indexer padded`, `51593 in:body`, `51538 in:body`, `flashinfer 5015`. The only overlap is the *kernel-side* invariant: open #55122 (`[Kernel] Make persistent_topk deterministic`) adds `test_persistent_topk_degenerate_lengths` (row length `0` / `-1` → all `-1`). I therefore deliberately did **not** add a kernel-side negative-length test here; this PR covers only the producer side, which no open PR tests. #43970 touches `indexer.py` for block-table alignment and does not cover the clamp.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/attention/test_indexer_native_next_n.py
.venv/bin/python -m pytest -q tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
.venv/bin/python -m pytest -q tests/kernels/test_top_k_per_row.py -k persistent_topk
pre-commit run --files tests/v1/attention/test_indexer_native_next_n.py
```

## Test Result

RTX PRO 6000 Blackwell Server Edition (SM120, cc 12.0), driver 580.173.02, torch 2.13.0+cu132, vLLM main `fc6b6e1feb` with the precompiled `_C` (`VLLM_USE_PRECOMPILED=1 uv pip install -e .`).

| command | result |
|---|---|
| `pytest -q tests/v1/attention/test_indexer_native_next_n.py` | **11 passed** (9 existing + 2 new, 16.9 s) |
| negative control: same file with the two #51538 producer clamps temporarily removed from `indexer.py` | **2 failed**, both new cases: `At index 6 diff: -1 != 0` (then restored) |
| `pytest -q tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py tests/v1/attention/test_indexer_dcp_localize.py tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py` | 45 passed, 1 failed — `test_indexer_builder_deepseek_v4_compressed_slot_mapping_uses_num_states` fails in this environment on the gated `meta-llama/Meta-Llama-3-8B` config download (HTTP 401, no HF token on the box); unrelated to this change |
| `pytest -q tests/kernels/test_top_k_per_row.py -k persistent_topk` | 54 passed, 136 deselected |
| `pytest -q tests/kernels/test_top_k_per_row.py` (full) | 120 passed, 19 skipped, 51 failed — all 51 are `cooperative_topk` parametrisations (0 `persistent_topk`), a backend vLLM excludes on the SM120 family; identical on unmodified main, unrelated to this change |
| `pre-commit run --files tests/v1/attention/test_indexer_native_next_n.py` | all hooks passed (ruff check/format, typos, mypy 3.10, SPDX, …) |

## Model eval

Not applicable: test-only change, no serving or model-output path is modified.

## AI assistance

AI assistance (Claude Code) was used to investigate the issue, write the test and run the validation on the hardware above. The human submitter reviewed every changed line and the test results before submission.
