### PR TITLE
[Pooling] Report LoRA adapter names in responses

### DIFF
--- a/vllm/entrypoints/pooling/base/serving.py
+++ b/vllm/entrypoints/pooling/base/serving.py
@@ -108,7 +108,6 @@ class PoolingBaseServing(ABC, BaseServing):
         request: AnyPoolingRequest,
         raw_request: Request | None = None,
     ):
-        model_name = self.models.model_name()
         base_request_id = self._base_request_id(
             raw_request, getattr(request, "request_id", None)
         )
@@ -117,6 +116,7 @@ class PoolingBaseServing(ABC, BaseServing):
 
         pooling_params = io_processor.create_pooling_params(request)
         lora_request = self._maybe_get_adapters(request)
+        model_name = self.models.model_name(lora_request)
         priorities = getattr(request, "priority", 0)
         prompt_extras = {
             k: v

--- a/vllm/entrypoints/pooling/scoring/serving.py
+++ b/vllm/entrypoints/pooling/scoring/serving.py
@@ -79,7 +79,7 @@ class ServingScores(PoolingServing):
         final_res_batch = ctx.final_res_batch
         request_id = ctx.request_id
         created_time = ctx.created_time
-        model_name = self.models.model_name()
+        model_name = ctx.model_name
 
         if isinstance(ctx.request, ScoreRequest):
             return self._request_output_to_score_response(


### PR DESCRIPTION
## Purpose

Pooling requests that selected a LoRA adapter were executed with that adapter, but their responses reported the base model name. `PoolingBaseServing._init_ctx` captured the model name before resolving the request's adapter, and the scoring path independently replaced the context's model name with the base model again.

This PR resolves the adapter before selecting the response model name and preserve that name through score and rerank response construction. This makes pooling response metadata consistent with the chat, completion, responses, and generative-scoring serving paths.


## Reproducer

Run this from the repository root on `main` and on this branch:

```bash
PATH="$PWD/.venv/bin:$PATH" .venv/bin/python - <<'PY'
import asyncio
from types import SimpleNamespace
from unittest.mock import AsyncMock, MagicMock

from vllm.config import ModelConfig
from vllm.engine.protocol import EngineClient
from vllm.entrypoints.openai.models.protocol import BaseModelPath
from vllm.entrypoints.openai.models.serving import OpenAIServingModels
from vllm.entrypoints.pooling.base.serving import PoolingBaseServing
from vllm.lora.request import LoRARequest


class Serving(PoolingBaseServing):
    request_id_prefix = "pooling"

    def get_io_processor(self, request):
        raise NotImplementedError

    def _build_response(self, ctx):
        raise NotImplementedError


async def main():
    engine = MagicMock(spec=EngineClient)
    engine.model_config = MagicMock(spec=ModelConfig)
    engine.model_config.max_model_len = 2048
    engine.input_processor = MagicMock()
    engine.renderer = MagicMock()
    models = OpenAIServingModels(
        engine, [BaseModelPath(name="base", model_path="base")]
    )
    adapter = LoRARequest("adapter", 1, "/tmp/adapter")
    models.lora_requests["adapter"] = adapter

    serving = Serving.__new__(Serving)
    serving.models = models
    serving._check_model = AsyncMock(return_value=None)
    serving._validate_request = lambda ctx: None
    io_processor = SimpleNamespace(
        create_pooling_params=lambda request: SimpleNamespace()
    )

    for requested in ("base", "adapter"):
        ctx = await serving._init_ctx(
            io_processor, SimpleNamespace(model=requested)
        )
        scheduled_lora = (
            ctx.lora_request.lora_name if ctx.lora_request else None
        )
        print(
            {
                "requested": requested,
                "scheduled_lora": scheduled_lora,
                "response_model": ctx.model_name,
            }
        )


asyncio.run(main())
PY
```

## Output on `main`

```text
{'requested': 'base', 'scheduled_lora': None, 'response_model': 'base'}
{'requested': 'adapter', 'scheduled_lora': 'adapter', 'response_model': 'base'}
```

## Output on this branch

```text
{'requested': 'base', 'scheduled_lora': None, 'response_model': 'base'}
{'requested': 'adapter', 'scheduled_lora': 'adapter', 'response_model': 'adapter'}
```

## AI assistance disclosure

OpenAI Codex (GPT-5.6) assisted with drafting the code