### PR TITLE
[Docs] Fix stale disaggregated encoder example script names

### DIFF
--- a/docs/features/disagg_encoder.md
+++ b/docs/features/disagg_encoder.md
@@ -53,7 +53,7 @@ Disaggregated encoding is implemented by running two parts:
 
 * **Encoder instance** – a vLLM instance to performs vision encoding.  
 * **Prefill/Decode (PD) instance(s)** – runs language pre-fill and decode.
-    * PD can be in either a single normal instance with `disagg_encoder_example.sh` (E->PD) or in disaggregated instances with `disagg_epd_example.sh` (E->P->D)
+    * PD can be in either a single normal instance with `disagg_1e1pd_example.sh` (E->PD) or in disaggregated instances with `disagg_1e1p1d_example.sh` (E->P->D)
 
 A connector transfers encoder-cache (EC) embeddings from the encoder instance to the PD instance.  
 All related code is under `vllm/distributed/ec_transfer`.

--- a/examples/disaggregated/disaggregated_encoder/README.md
+++ b/examples/disaggregated/disaggregated_encoder/README.md
@@ -53,7 +53,7 @@ To support local image inputs (from your ```MEDIA_PATH``` directory), add the fo
 --allowed-local-media-path $MEDIA_PATH
 ```
 
-The vllm instances and `disagg_encoder_proxy` supports local URIs with ```{"url": "file://'"$MEDIA_PATH_FILENAME"'}``` as multimodal inputs. Each URI is passed unchanged from the `disagg_encoder_proxy` to the encoder instance so that the encoder can load the media locally.
+The vllm instances and `disagg_epd_proxy.py` supports local URIs with ```{"url": "file://'"$MEDIA_PATH_FILENAME"'}``` as multimodal inputs. Each URI is passed unchanged from the `disagg_epd_proxy.py` to the encoder instance so that the encoder can load the media locally.
 
 ## EC connector and KV transfer
 
@@ -110,7 +110,7 @@ Example usage:
 For E + PD setup:
 
 ```bash
-$ python disagg_encoder_proxy.py \
+$ python disagg_epd_proxy.py \
       --encode-servers-urls "http://e1:8001,http://e2:8002" \
       --prefill-servers-urls "disable" \
       --decode-servers-urls "http://pd1:8003,http://pd2:8004"
@@ -119,7 +119,7 @@ $ python disagg_encoder_proxy.py \
 For E + P + D setup:
 
 ```bash
-$ python disagg_encoder_proxy.py \
+$ python disagg_epd_proxy.py \
       --encode-servers-urls "http://e1:8001,http://e2:8001" \
       --prefill-servers-urls "http://p1:8003,http://p2:8004" \ 
       --decode-servers-urls "http://d1:8005,http://d2:8006"

--- a/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
+++ b/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-disagg_encoder_proxy.py
+disagg_epd_proxy.py
 
 Proxy that routes OpenAI-compatible “/v1/chat/completions” requests to two
 clusters:


### PR DESCRIPTION
## Summary
Docs and examples still name removed disaggregated-encoder scripts. Point them at the files that exist on `main`:

| Stale name | Actual file |
|---|---|
| `disagg_encoder_proxy` / `disagg_encoder_proxy.py` | `disagg_epd_proxy.py` |
| `disagg_encoder_example.sh` | `disagg_1e1pd_example.sh` |
| `disagg_epd_example.sh` | `disagg_1e1p1d_example.sh` |

Also align the module docstring title in `disagg_epd_proxy.py`.

## Files
- `examples/disaggregated/disaggregated_encoder/README.md`
- `docs/features/disagg_encoder.md`
- `examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py`

## Repro
```bash
# On main HEAD bf7eee9d7b2788bafe69f0c21fde6af22a2d3319
# Ghost names referenced by docs:
rg -n 'disagg_encoder_proxy|disagg_encoder_example\.sh|disagg_epd_example\.sh' \
  examples/disaggregated/disaggregated_encoder/README.md \
  docs/features/disagg_encoder.md \
  examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py

# Actual directory contents (no disagg_encoder_proxy.py / *_example.sh above):
ls examples/disaggregated/disaggregated_encoder/
# README.md  disagg_1e1p1d_example.sh  disagg_1e1pd_example.sh  disagg_epd_proxy.py

# Example scripts already invoke the real proxy name:
rg -n 'python disagg_' examples/disaggregated/disaggregated_encoder/*.sh
```

## Test plan
- [x] Confirmed ghost paths 404 via Contents API; real paths exist
- [x] Confirmed shell helpers already call `python disagg_epd_proxy.py`
- [x] Diff limited to name corrections (no behavior change)
