### PR TITLE
[CI][Test][Spec Decode] Fix CI failure of Qwen3 Omni DSpark loader mock

### DIFF
--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -347,10 +347,11 @@ def test_dspark_shares_target_embedding_with_smaller_draft_vocabulary():
     vllm_config = SimpleNamespace(
         speculative_config=SimpleNamespace(
             draft_model_config=draft_model_config,
-            draft_parallel_config=SimpleNamespace(),
+            draft_parallel_config=SimpleNamespace(tensor_parallel_size=1),
             attention_backend=None,
             kv_cache_dtype=None,
         ),
+        parallel_config=SimpleNamespace(tensor_parallel_size=1),
         attention_config=SimpleNamespace(backend=None),
         cache_config=SimpleNamespace(),
         model_config=SimpleNamespace(get_vocab_size=Mock(return_value=100)),


### PR DESCRIPTION
## Purpose

PR #55472 changed `load_dspark_model` to derive the draft parallel configuration from the target `vllm_config.parallel_config`, but missed updating text fixture in unit test `test_qwen3_omni.py`.

The test uses an incomplete `SimpleNamespace` mock and fails with:
```sh
FAILED model_executor/test_qwen3_omni.py::test_dspark_shares_target_embedding_with_smaller_draft_vocabulary - AttributeError: 'types.SimpleNamespace' object has no attribute 'parallel_config'
```

This PR add the missing `parallel_config`.

Thanks @gau-nernst for the catch!

## Test Plan

The main unit test:
- tests/model_executor/test_qwen3_omni.py

and some related:
- tests/v1/worker/test_eagle3_aux_hidden_states_pp.py
- tests/v1/worker/test_spec_decode_embed_sharing_pp.py
- tests/models/kimi_k3/test_aux_attn_res_stream.py
- tests/v1/worker/test_pp_utils.py
- tests/models/kimi_k3/test_eagle3.py

## Test Result

All (8 + 32) passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>