### PR TITLE
[XPU] Isolate multiprocessing workers to assigned devices

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -209,9 +209,7 @@ class CoreEngineProcManager:
                 # Populate the logical-to-physical GPU mapping in DP for
                 # platforms that cannot rely on
                 # torch.accelerator.set_device_index(), and for Ray.
-                needs_device_env_isolation = not (
-                    current_platform.is_cuda_alike() or current_platform.is_xpu()
-                )
+                needs_device_env_isolation = not current_platform.is_cuda_alike()
                 if is_dp and (
                     needs_device_env_isolation or vllm_config.parallel_config.use_ray
                 ):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -745,7 +745,40 @@ class WorkerProc:
         with numa_utils.configure_subprocess(
             vllm_config, local_rank, process_kind="worker"
         ):
-            proc.start()
+            if current_platform.is_xpu():
+                assigned = (
+                    vllm_config.parallel_config.assigned_physical_gpu_ids
+                )
+
+                if assigned is not None:
+                    physical_device_id = assigned[local_rank]
+                else:
+                    physical_device_id = (
+                        current_platform.device_id_to_physical_device_id(
+                            local_rank
+                        )
+                    )
+
+                env_name = current_platform.device_control_env_var
+                old_device_env = os.environ.get(env_name)
+
+                try:
+                    os.environ[env_name] = str(physical_device_id)
+                    logger.debug(
+                        "Starting XPU worker rank=%d local_rank=%d with %s=%s",
+                        rank,
+                        local_rank,
+                        env_name,
+                        physical_device_id,
+                    )
+                    proc.start()
+                finally:
+                    if old_device_env is None:
+                        os.environ.pop(env_name, None)
+                    else:
+                        os.environ[env_name] = old_device_env
+            else:
+                proc.start()
 
         # Close child ends of pipes here in the parent
         ready_writer.close()

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -40,11 +40,21 @@ class XPUWorker(Worker):
         assert current_platform.is_xpu()
 
     def init_device(self):
-        # In DP mode, XPU workers see all visible devices.
-        # Offset local_rank by the local DP shard.
+        affinity_mask = os.environ.get(
+            current_platform.device_control_env_var, ""
+        )
+        affinity_devices = [
+            device for device in affinity_mask.split(",") if device
+        ]
+        worker_is_device_isolated = len(affinity_devices) == 1
+
+        # When this process has already been isolated to one physical XPU
+        # by the parent, DP placement is already resolved and must not be
+        # applied again here.
         parallel_config = self.parallel_config
         if (
-            parallel_config.distributed_executor_backend
+            not worker_is_device_isolated
+            and parallel_config.distributed_executor_backend
             not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"
             and (
@@ -130,12 +140,16 @@ class XPUWorker(Worker):
             and device.type == "xpu"
             and current_platform.is_xpu()
         ):
-            self.device = torch.device(f"xpu:{self.local_rank}")
+            device_index = (
+                0 if worker_is_device_isolated else self.local_rank
+            )
+
+            self.device = torch.device(f"xpu:{device_index}")
             torch.accelerator.set_device_index(self.device)
             current_platform.check_if_supports_dtype(self.model_config.dtype)
             torch.accelerator.empty_cache()
             self.init_gpu_memory = torch.xpu.get_device_properties(
-                self.local_rank
+                device_index
             ).total_memory
         else:
             raise RuntimeError(f"Unsupported device type: {self.device_config.device}")


### PR DESCRIPTION
## Purpose

Fix XPU multiprocessing workers inheriting visibility of all physical GPUs.

On multi-XPU systems, each spawned worker can initialize against all visible Level Zero devices even though the worker is assigned to a single GPU. This can result in large host-backed/shared memory mappings and exhaust host RAM during multi-GPU execution.

This PR isolates each XPU worker to its assigned physical GPU by setting `ZE_AFFINITY_MASK` in the parent process immediately around `proc.start()`, before the child process can initialize the XPU runtime.

It also integrates XPU with the existing `assigned_physical_gpu_ids` device-assignment machinery and preserves existing outer `ZE_AFFINITY_MASK` mappings.

An isolated worker sees only its assigned physical GPU and therefore uses visible device ordinal `xpu:0`, while its logical distributed rank remains unchanged.

Fixes #53822.

## Test Plan

Tested on:

* 2 x Intel Arc Pro B60 24 GB
* XPU backend
* multiprocessing executor
* oneCCL/XCCL distributed backend

### Tensor Parallel: TP=2

```bash
unset ZE_AFFINITY_MASK
unset ONEAPI_DEVICE_SELECTOR

export VLLM_TARGET_DEVICE=xpu
export ZE_ENABLE_PCI_ID_DEVICE_ORDER=1
export VLLM_LOGGING_LEVEL=DEBUG

vllm serve Qwen/Qwen3-0.6B \
    --tensor-parallel-size 2 \
    --dtype bfloat16 \
    --max-model-len 4096
```

Expected worker mapping:

```text
TP rank 0 -> ZE_AFFINITY_MASK=0 -> xpu:0
TP rank 1 -> ZE_AFFINITY_MASK=1 -> xpu:0
```

### Data Parallel: DP=2, TP=1

```bash
unset ZE_AFFINITY_MASK
unset ONEAPI_DEVICE_SELECTOR

export VLLM_TARGET_DEVICE=xpu
export ZE_ENABLE_PCI_ID_DEVICE_ORDER=1
export VLLM_LOGGING_LEVEL=DEBUG

vllm serve Qwen/Qwen3-0.6B \
    --data-parallel-size 2 \
    --tensor-parallel-size 1 \
    --dtype bfloat16 \
    --max-model-len 4096
```

Expected worker mapping:

```text
DP rank 0 -> physical GPU 0 -> ZE_AFFINITY_MASK=0
DP rank 1 -> physical GPU 1 -> ZE_AFFINITY_MASK=1
```

### Larger TP workload

Also tested with:

```text
cyankiwi/Qwen3.8-27B-AWQ-INT4
tensor_parallel_size=2
max_model_len=64000
kv_cache_dtype=fp8
```

This was used to validate that a larger real-world workload can successfully load and serve across both isolated XPU workers.

## Test Result

### Before

Without per-worker XPU isolation, TP=2 workers inherited visibility of both physical GPUs.

This caused host memory consumption to grow significantly during initialization and resulted in a worker being terminated by the host OOM killer. The remaining worker subsequently reported a secondary oneCCL communication failure.

### After

TP=2 successfully starts with separate per-worker affinity masks:

```text
Starting XPU worker rank=0 local_rank=0 with ZE_AFFINITY_MASK=0
Starting XPU worker rank=1 local_rank=1 with ZE_AFFINITY_MASK=1
```

Both workers initialize successfully and the API server reaches:

```text
Application startup complete.
```

DP=2, TP=1 also correctly assigns each independent DP worker to a different physical GPU:

```text
EngineCore_DP0 ... Starting XPU worker rank=0 local_rank=0 with ZE_AFFINITY_MASK=0
EngineCore_DP1 ... Starting XPU worker rank=0 local_rank=0 with ZE_AFFINITY_MASK=1
```

Both DP engines initialize successfully.

The larger TP=2 workload also loaded successfully, with approximately:

```text
Model memory per worker:   9.15 GiB
Available KV cache memory: 9.32 GiB
GPU KV cache capacity:     530,086 tokens
```

A serving benchmark using 2048-token inputs and 512-token outputs completed with zero failed requests.

At concurrency 1:

```text
Output token throughput: 29.79 tok/s
Mean TTFT:               1099 ms
Mean TPOT:               31.48 ms
```

At concurrency 2:

```text
Successful requests:      20
Failed requests:           0
Output token throughput:  54.78 tok/s
Mean TPOT:                33.25 ms
```

oneCCL emits warnings that each process has a narrowed device affinity mask, for example:

```text
comm_dev_uuids is not sub-vector of node_dev_uuids
this may happen due to narrow device affinity mask
```

These warnings are expected with the per-worker device isolation and were non-fatal in the tested configurations.

No documentation changes are required because this PR changes XPU worker device isolation rather than user-facing functionality or model support.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

* [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
* [x] The test plan, such as providing test command.
* [x] The test results, such as pasting the results comparison before and after, or e2e results
* [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>
