### PR TITLE
[CPU][Profiler] Group torch profiler tables by input shape when record_shapes is on

### DIFF
--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -19,6 +19,7 @@ import vllm.version
 from vllm.config import ProfilerConfig
 from vllm.config.profiler import _is_uri_path
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -259,9 +260,14 @@ class TorchProfilerWrapper(WorkerProfiler):
         sort_key: str,
         row_limit: int | None = None,
     ) -> str:
+        group_by_input_shape = (
+            current_platform.is_cpu()
+            and self.profiler_config.torch_profiler_record_shapes
+        )
+        averages = self.profiler.key_averages(group_by_input_shape=group_by_input_shape)
         if row_limit is None:  # use profiler default row limit of 100
-            return self.profiler.key_averages().table(sort_by=sort_key)
-        return self.profiler.key_averages().table(
+            return averages.table(sort_by=sort_key)
+        return averages.table(
             sort_by=sort_key,
             row_limit=row_limit,
         )


### PR DESCRIPTION
## Purpose

Group PyTorch profiler `key_averages` tables by input shape on the CPU platform when the user enables `--profiler-config.torch_profiler_record_shapes=true`.

Without this, CPU dumps collapse every call of an op into one row, which hides prefill vs decode and GEMM size differences. GPU dumps are unchanged: `group_by_input_shape` is only set when `current_platform.is_cpu()` and `torch_profiler_record_shapes` are both true. Recording shapes remains user-controlled; it is not forced on the CPU platform.

## Test Plan

CPU throughput bench with torch profiler, shapes on:

```bash
export CUDA_VISIBLE_DEVICES=""
export VLLM_CPU_KVCACHE_SPACE=8

vllm bench throughput \
  --model Qwen/Qwen3.5-4B --language-model-only --dtype bfloat16 \
  --max-model-len 2048 --max-num-seqs 8 --num-prompts 16 \
  --random-input-len 16 --random-output-len 16 \
  --profile \
  --profiler-config "{\"profiler\": \"torch\", \"torch_profiler_dir\": \"torch-logs\", \"torch_profiler_with_stack\": false, \"torch_profiler_use_gzip\":false, \"torch_profiler_record_shapes\":true}"
```

Also confirm that `"torch_profiler_record_shapes": false` still prints an ungrouped table, and that a GPU run does not pass `group_by_input_shape=True`.

## Test Result

CPU dump (`torch_profiler_record_shapes=true`) now has an **Input Shapes** column. The same op is split by GEMM / sequence shape (decode `8` vs prefill `128`):

```
Name                                   Self CPU %   Self CPU    # of Calls   Input Shapes
vllm::cpu_gdn_attention_core             2.15%       77.060ms  720          [[8, 8192], [8, 32], [8, 32], [8, 32, 128], []]
vllm::cpu_gdn_attention_core             0.59%       21.323ms   48          [[128, 8192], [128, 32], [128, 32], [128, 32, 128], []]
_C::cpu_attention_with_kv_cache        0.25%        8.829ms  240          [[8, 16, 256], [409, 4, 640, 256], ...]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

