### PR TITLE
[Examples] Fix kv_events subscriber path and mooncake connector link

### DIFF
--- a/examples/disaggregated/disaggregated_serving/README.md
+++ b/examples/disaggregated/disaggregated_serving/README.md
@@ -6,4 +6,4 @@ This example contains scripts that demonstrate the disaggregated serving feature
 
 - `disagg_proxy_demo.py` - Demonstrates XpYd (X prefill instances, Y decode instances).
 - `kv_events.sh` - Demonstrates KV cache event publishing.
-- `mooncake_connector` - A proxy demo for MooncakeConnector.
+- [`mooncake_connector`](../mooncake_connector/) - A proxy demo for MooncakeConnector.

--- a/examples/disaggregated/disaggregated_serving/kv_events.sh
+++ b/examples/disaggregated/disaggregated_serving/kv_events.sh
@@ -47,7 +47,7 @@ wait_for_server 8100
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-python3 "$SCRIPT_DIR/kv_events_subscriber.py" &
+python3 "$SCRIPT_DIR/../../features/kv_events/kv_events_subscriber.py" &
 sleep 1
 
 # serve two example requests


### PR DESCRIPTION
## Summary
- Point `kv_events.sh` at `examples/features/kv_events/kv_events_subscriber.py` (sibling path 404).
- Link `mooncake_connector` in the disaggregated serving README to the sibling directory.

## Test plan
- [x] Confirm sibling `kv_events_subscriber.py` absent; live at `examples/features/kv_events/kv_events_subscriber.py`
- [x] Confirm `examples/disaggregated/mooncake_connector/` exists
- [ ] Maintainer: smoke `kv_events.sh` path resolves