### PR TITLE
[XPU] fix online fp8_per_channel quantization

### DIFF
--- a/.buildkite/intel_jobs/quantization.yaml
+++ b/.buildkite/intel_jobs/quantization.yaml
@@ -25,5 +25,7 @@ steps:
   - >-
     bash .buildkite/scripts/hardware_ci/run-intel-test.sh
     'VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s tests/quantization/test_per_token_kv_cache.py --deselect="tests/quantization/test_per_token_kv_cache.py::test_triton_unified_attention_per_token_head_scale[int4-16-128-num_heads0-seq_lens1]"
-    && VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s tests/quantization/test_auto_awq.py'
+    && VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s tests/quantization/test_auto_awq.py
+    && VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s tests/quantization/test_fp8_per_channel.py
+  && VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s tests/models/quantization/test_fp8_per_channel.py'
 

--- a/tests/quantization/test_fp8_per_channel.py
+++ b/tests/quantization/test_fp8_per_channel.py
@@ -61,7 +61,9 @@ def test_scaled_fp8_quant_per_channel_shape() -> None:
     weight to `ops.scaled_fp8_quant` with `use_per_token_if_dynamic=True`
     yields one scale per output row -- a [N, 1] fp32 tensor.
     """
-    x = (torch.randn(size=(96, 256), device="cuda") * 13).to(torch.bfloat16)
+    x = (torch.randn(size=(96, 256), device=current_platform.device_type) * 13).to(
+        torch.bfloat16
+    )
     y, s = ops.scaled_fp8_quant(x, scale=None, use_per_token_if_dynamic=True)
     assert y.shape == (96, 256)
     assert y.dtype == current_platform.fp8_dtype()

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -123,6 +123,7 @@ class XPUPlatform(Platform):
         "mxfp8",
         "fp8_per_tensor",
         "fp8_per_block",
+        "fp8_per_channel",
         "online",
         "gpt_oss_mxfp4",
         "modelopt",


### PR DESCRIPTION



## Purpose
This PR relax `fp8_per_channel` online quantization on XPU platform and add corresponding UT in CI.

## Test Plan
```
pytest -v -s tests/quantization/test_fp8_per_channel.py
pytest -v -s tests/models/quantization/test_fp8_per_channel.py
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

