### PR TITLE
[Bugfix] Finish a request that can never fit in the KV cache with an error instead of re-prefilling it forever

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3588,6 +3588,7 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     scheduler.finished_req_ids = set()
     scheduler.finished_req_ids_dict = None
     scheduler.grammar_compile_error_reqs = set()
+    scheduler.kv_capacity_error_reqs = set()
     scheduler.vllm_config = Mock()
     scheduler.vllm_config.model_config.enable_return_routed_experts = False
     scheduler.enable_return_routed_experts = False
@@ -6515,3 +6516,60 @@ def test_update_draft_token_ids_in_output_strips_padding(monkeypatch):
         -1,
     ]
     assert scheduler_output.num_invalid_spec_tokens == {request.request_id: 2}
+
+
+def test_request_that_never_fits_is_failed_not_respun():
+    """A lone request whose KV footprint exceeds the whole pool must be finished
+    with an error once it has preempted itself twice, not re-prefilled forever."""
+    scheduler = create_scheduler(
+        max_num_seqs=1,
+        max_num_batched_tokens=64,
+        block_size=16,
+        num_blocks=11,  # 10 usable blocks = 160 tokens; block 0 is the null block.
+        max_model_len=1024,
+        enable_prefix_caching=False,
+    )
+    request = create_requests(num_requests=1, num_tokens=200, block_size=16)[0]
+
+    # Mimic a hybrid layout whose full-sequence admission estimate undercounts
+    # the blocks the chunked prefill really consumes: admit the request, then
+    # let each chunk allocate for real.
+    coordinator = scheduler.kv_cache_manager.coordinator
+    real_get_num_blocks_to_allocate = coordinator.get_num_blocks_to_allocate
+
+    def optimistic_admission(*args, **kwargs):
+        if kwargs.get("apply_admission_cap"):
+            return 0
+        return real_get_num_blocks_to_allocate(*args, **kwargs)
+
+    coordinator.get_num_blocks_to_allocate = optimistic_admission
+    scheduler.add_request(request)
+
+    error_output = None
+    for _ in range(40):
+        scheduler_output = scheduler.schedule()
+        req_ids = list(scheduler_output.num_scheduled_tokens)
+        model_output = ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index={rid: i for i, rid in enumerate(req_ids)},
+            sampled_token_ids=[[] for _ in req_ids],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+        outputs = scheduler.update_from_output(scheduler_output, model_output)
+        for eco in outputs.values():
+            for out in eco.outputs:
+                if out.request_id == request.request_id and (
+                    out.finish_reason == FinishReason.ERROR
+                ):
+                    error_output = out
+        if error_output is not None:
+            break
+
+    assert error_output is not None, "request kept spinning instead of failing"
+    assert request.status == RequestStatus.FINISHED_ERROR
+    assert request.num_preemptions == 2
+    assert not scheduler.running
+    assert len(scheduler.waiting) == 0
+

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -225,6 +225,10 @@ class Scheduler(SchedulerInterface):
         # Grammar compilation failures to finish as per-request errors in
         # update_from_output.
         self.grammar_compile_error_reqs: set[str] = set()
+        # Requests that preempted themselves with no other request holding KV
+        # blocks: they can never fit and are finished with an error in
+        # update_from_output instead of re-prefilling forever.
+        self.kv_capacity_error_reqs: set[str] = set()
 
         # Encoder-related.
         # Calculate encoder cache size if applicable
@@ -785,6 +789,25 @@ class Scheduler(SchedulerInterface):
                     preempted_reqs.append(preempted_req)
                     if preempted_req == request:
                         # No more request to preempt. Cannot schedule this request.
+                        if not self.running and request.num_preemptions >= 2:
+                            # Nothing else holds KV blocks and this request still
+                            # cannot get its next chunk, so it can never fit in
+                            # the pool even though admission let it in. Fail it
+                            # instead of re-prefilling forever: a preempted
+                            # request whose groups get no prefix hit (hybrid
+                            # Mamba groups) recomputes from token zero each time.
+                            logger.error(
+                                "Request %s cannot fit in the KV cache: %d prompt "
+                                "tokens, preempted %d times with no other request "
+                                "holding blocks (pool: %d blocks of %d tokens). "
+                                "Finishing it with an error.",
+                                request.request_id,
+                                request.num_prompt_tokens,
+                                request.num_preemptions,
+                                self.kv_cache_manager.block_pool.num_gpu_blocks,
+                                self.block_size,
+                            )
+                            self.kv_capacity_error_reqs.add(request.request_id)
                         break
 
             if new_blocks is None:
@@ -2190,6 +2213,8 @@ class Scheduler(SchedulerInterface):
 
         error_req_ids = set(self.grammar_compile_error_reqs)
         self.grammar_compile_error_reqs.clear()
+        error_req_ids.update(self.kv_capacity_error_reqs)
+        self.kv_capacity_error_reqs.clear()
         if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
             error_req_ids.update(failed_kv_load_req_ids)
         if self.ec_connector is not None:


### PR DESCRIPTION
## Purpose

When a running request cannot get blocks for its next prefill chunk and there is no other request to preempt, `Scheduler.schedule()` preempts the request itself and prepends it to the waiting queue. If admission let the request in although its real footprint exceeds the pool, the next step schedules it again from token zero (a preempted request whose Mamba groups get no prefix hit recomputes everything) and the cycle never ends: the KV usage gauge saw-tooths to ~100% every few seconds, no token is ever produced, the API server logs nothing (stats are only emitted on steps with output) and the client only sees its own timeout.

Observed on Qwen3.8-Flash-Next (GDN + QSA + MTP, one RTX PRO 6000): a 249,950-token prompt cycled for 16 minutes (six full re-prefills in a 150 s sample) on a branch based before #53906, where the QSA ring buffer's 8-token block size dragged `cache_config.block_size` down and the align-mode Mamba managers took a fresh state block every chunk, so a request needed 1.9x the blocks the capacity estimate assumed. Any future accounting drift reproduces the same silent spin.

## Fix

Track a request that preempted itself twice with the running queue empty (`request.num_preemptions >= 2 and not self.running`): nothing else holds KV blocks, so it can never fit. Finish it with `FinishReason.ERROR` in `update_from_output`, the path already used for grammar compile failures, so the client gets a 500 immediately and the engine log names the request, its prompt length and the pool size. The second self-preemption is required rather than the first to stay clear of any transient one-off.

## Test Plan

```bash
pytest tests/v1/core/test_scheduler.py -q
```

New: `test_request_that_never_fits_is_failed_not_respun` (single request larger than a 10-block pool, full-sequence admission mocked as optimistic like the hybrid layout above; the request must be finished with `FinishReason.ERROR` after exactly two self-preemptions, leaving nothing running or waiting).

## Test Result

`163 passed` on `main` (d2906091b), CPU. Live: with the guard in the serving branch, a request that cannot fit returns HTTP 500 within one re-prefill cycle instead of spinning until the client times out; on the fixed accounting no request has hit the guard across a full replay (0 guard errors, 8 of 8 prompts up to 261,802 tokens correct).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

https://claude.ai/code/session_01LqPLAsuNFXRF7yoojyna8j