### PR TITLE
Flatten rank-3 input in triton_scaled_mm for Whisper W8A8

### DIFF
--- a/tests/kernels/quantization/test_triton_scaled_mm.py
+++ b/tests/kernels/quantization/test_triton_scaled_mm.py
@@ -160,3 +160,24 @@ def test_scaled_mm_td_matches_plain(M, N, K, in_dtype, use_scalar_scale_a, use_b
     out_plain = triton_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias, use_td=False)
     out_td = triton_scaled_mm(a, b, scale_a, scale_b, out_dtype, bias, use_td=True)
     torch.testing.assert_close(out_td, out_plain, rtol=0, atol=0)
+
+
+def test_scaled_mm_rank3_input():
+    # Regression test for #56024: a rank-3 activation (e.g. from the Whisper
+    # encoder) must be flattened to 2D and restored to its original shape.
+    set_random_seed(0)
+    B, M, K, N = 2, 64, 128, 256
+    in_dtype = torch.int8
+    out_dtype = torch.bfloat16
+
+    a = torch.randint(-32, 32, (B, M, K), dtype=in_dtype, device=device)
+    b = torch.randint(-32, 32, (K, N), dtype=in_dtype, device=device)
+    scale_a = 0.25 * torch.rand((B * M, 1), device=device)
+    scale_b = 0.25 * torch.rand((N, 1), device=device)
+
+    out = triton_scaled_mm(a, b, scale_a, scale_b, out_dtype)
+    assert out.shape == (B, M, N)
+
+    flat = a.reshape(-1, K)
+    expected = torch_scaled_mm(flat, b, scale_a, scale_b, out_dtype).reshape(B, M, N)
+    torch.testing.assert_close(out, expected, rtol=1e-1, atol=1e-1)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
@@ -187,6 +187,13 @@ def triton_scaled_mm(
     use_heuristic=True,
     use_td: bool | None = None,
 ) -> torch.Tensor:
+    # Flatten the leading dims of rank > 2 inputs (e.g. the Whisper encoder's
+    # [batch, seq, hidden] activation) so the 2D kernel can run, then restore
+    # them on the result. See #56024.
+    target_shape = (*input.shape[:-1], weight.shape[1])
+    if input.dim() > 2:
+        input = input.reshape(-1, input.shape[-1])
+
     M, K = input.shape
     N = weight.shape[1]
 
@@ -279,4 +286,4 @@ def triton_scaled_mm(
         B_T=b_t,
     )
 
-    return result.to(out_dtype)
+    return result.to(out_dtype).reshape(*target_shape)


### PR DESCRIPTION
## Summary

`triton_scaled_mm` (the ROCm Triton fallback for `TritonInt8ScaledMMLinearKernel`) assumes a 2D `[M, K]` input and unpacks `M, K = input.shape`. When the Whisper encoder produces a rank-3 `[batch, seq, hidden]` activation, this raises `ValueError: too many values to unpack (expected 2)` during engine initialization for `RedHatAI/whisper-large-v3-quantized.w8a8` on ROCm.

This change flattens the leading dimensions of rank > 2 inputs before the 2D matmul and restores them on the result, matching the pattern already applied to `cutlass_scaled_mm` in #22278 and to the CPU oneDNN path in #33727.

Fixes #56024.

## Why this is not a duplicate

Searched open PRs for #56024 and for "rank-3 scaled_mm" / "triton scaled_mm" and found none. The issue is open with no linked pull request.

## Testing

- Added `test_scaled_mm_rank3_input` to `tests/kernels/quantization/test_triton_scaled_mm.py`, which feeds a rank-3 int8 input to `triton_scaled_mm`, asserts the output shape is restored, and checks the result against a flattened reference computation. This test fails on the previous code with the "too many values to unpack" error.
- `ruff check` and `ruff format --check` pass on both changed files.
- Full kernel test requires a CUDA/ROCm GPU and was not run in this environment.
