### PR TITLE
[Bugfix] Fix computed-token metadata for requests split across DBO microbatches

### DIFF
--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -390,6 +390,20 @@ def test_prefill_split_across_ubatches(
     # Second ubatch: first request (continuation) seq_len should be full
     #  original
     assert int(second_meta.seq_lens[0]) == seq_lens[split_req_idx]
+
+    # Tokens processed for the first chunk become computed context for the
+    # continuation. The original metadata must remain unchanged.
+    assert first_meta._num_computed_tokens_cpu is not None
+    assert second_meta._num_computed_tokens_cpu is not None
+    assert common._num_computed_tokens_cpu is not None
+    assert int(first_meta._num_computed_tokens_cpu[-1]) == context_lens[split_req_idx]
+    assert int(second_meta._num_computed_tokens_cpu[0]) == (
+        context_lens[split_req_idx] + tokens_in_first_chunk
+    )
+    assert int(common._num_computed_tokens_cpu[split_req_idx]) == context_lens[
+        split_req_idx
+    ]
+
     # Any following full requests in second ubatch should match originals
     for j in range(1, second_meta.num_reqs):
         # Map to original request index

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -296,6 +296,11 @@ def _make_metadata_with_slice(
         if attn_metadata._num_computed_tokens_cpu is not None
         else None
     )
+    if splits_first_request and num_computed_tokens_cpu is not None:
+        # Tokens from the preceding microbatch are now part of this request's
+        # computed context. Clone to avoid mutating the parent metadata.
+        num_computed_tokens_cpu = num_computed_tokens_cpu.clone()
+        num_computed_tokens_cpu[0] += first_tok - start_locs[first_req]
 
     if splits_last_request:
         # NOTE: We use start_locs (the original query_start_loc_cpu) to calculate


### PR DESCRIPTION
# [Bugfix] Fix computed-token metadata for requests split across DBO microbatches

## Purpose

When DBO splits a prefill request across microbatches, `_make_metadata_with_slice()` adjusts the continuation slice's `query_start_loc`, but it only slices the cached `_num_computed_tokens_cpu` by request. It does not account for query tokens from the same request that were placed in an earlier microbatch.

For example, consider a request with 24 computed tokens and 8 scheduled query tokens, split after the first 4 query tokens:

| Metadata | First slice | Continuation slice |
|---|---:|---:|
| `seq_lens` | 28 | 32 |
| Query length in this slice | 4 | 4 |
| Expected computed tokens | 24 | 28 |
| Cached value before this fix | 24 | 24 |
| Cached value after this fix | 24 | 28 |

For the continuation slice, the expected value is `seq_lens - query_len = 32 - 4 = 28`. However, the cached value previously remained 24. When `_num_computed_tokens_cpu` is populated, the `num_computed_tokens_cpu` property returns that cache directly instead of recomputing it from the sliced metadata.

This PR updates the continuation slice when a request is split internally:

1. Clone the sliced cache tensor so the parent metadata and sibling slices are not mutated.
2. Add the number of query tokens from the same request that were assigned to the preceding microbatch.

Splits at request boundaries and the path where the CPU cache is absent retain their existing behavior. This is an internal metadata-consistency fix and does not change the public API or attention kernels.

Although this cached field is deprecated, it is still constructed, propagated, and exposed in the current code path. While it remains present, each sliced value should preserve the semantics of the corresponding slice.

I searched the open pull requests for `num_computed_tokens_cpu` with microbatch/DBO terms and did not find an open PR implementing this correction.

## Test plan

Extended the existing parameterized `test_prefill_split_across_ubatches` test in `tests/v1/attention/test_attention_splitting.py`. The assertions cover:

- an internal split of the first request;
- an internal split of a later request;
- the first slice retaining its original computed-token count;
- the continuation slice including query tokens from the preceding slice; and
- the parent metadata cache remaining unchanged.

Focused test command:

```bash
pytest -q tests/v1/attention/test_attention_splitting.py \
  -k prefill_split_across_ubatches
```

## Test results

Validated on NVIDIA H100 80GB with vLLM 0.25.1, PyTorch 2.11.0+cu130:

```text
Unpatched code with the new assertions: 2 failed, 20 deselected
Patched code with the new assertions:   2 passed, 20 deselected
Patched full test file:                 22 passed
```

The unpatched failures reported `actual=32, expected=36` and `actual=24, expected=28`. Both failures exercise the continuation-slice computed-token assertion. Community CI should validate the latest-main test matrix.