### PR TITLE
[Bugfix][ROCm][DSv4] Skip launch_pdl=True JIT warmup when PDL is unsupported

### DIFF
--- a/vllm/models/common/ops/fused_qk_rmsnorm.py
+++ b/vllm/models/common/ops/fused_qk_rmsnorm.py
@@ -126,11 +126,7 @@ class FusedQKVRMSNormKernel(VllmTritonJitKernel["FusedQKVRMSNormKernel.CompileKe
             kv_in_stride=input_stride,
             kv_out_stride=(input_stride, kv_size),
             eps=float(hf_config.rms_norm_eps),
-            # PDL is NVIDIA-only; compiling launch_pdl=True on ROCm emits
-            # griddepcontrol PTX and fails hsaco linking (#56030).
-            launch_pdl=(False, True)
-            if current_platform.is_arch_support_pdl()
-            else (False,),
+            launch_pdl=current_platform.is_arch_support_pdl(),
         )
 
     def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:

--- a/vllm/models/common/ops/fused_qk_rmsnorm.py
+++ b/vllm/models/common/ops/fused_qk_rmsnorm.py
@@ -126,7 +126,11 @@ class FusedQKVRMSNormKernel(VllmTritonJitKernel["FusedQKVRMSNormKernel.CompileKe
             kv_in_stride=input_stride,
             kv_out_stride=(input_stride, kv_size),
             eps=float(hf_config.rms_norm_eps),
-            launch_pdl=(False, True),
+            # PDL is NVIDIA-only; compiling launch_pdl=True on ROCm emits
+            # griddepcontrol PTX and fails hsaco linking (#56030).
+            launch_pdl=(False, True)
+            if current_platform.is_arch_support_pdl()
+            else (False,),
         )
 
     def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:

--- a/vllm/models/deepseek_v4/common/ops/fused_inv_rope_fp8_quant.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_inv_rope_fp8_quant.py
@@ -249,11 +249,7 @@ class FusedInvRopeFP8QuantKernel(
             rope_dim=rope_dim,
             quant_group_size=128,
             tma_aligned_scales=capability.major >= 10,
-            # PDL is NVIDIA-only; compiling launch_pdl=True on ROCm emits
-            # griddepcontrol PTX and fails hsaco linking (#56030).
-            launch_pdl=(False, True)
-            if current_platform.is_arch_support_pdl()
-            else (False,),
+            launch_pdl=current_platform.is_arch_support_pdl(),
         )
 
     def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:

--- a/vllm/models/deepseek_v4/common/ops/fused_inv_rope_fp8_quant.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_inv_rope_fp8_quant.py
@@ -249,7 +249,11 @@ class FusedInvRopeFP8QuantKernel(
             rope_dim=rope_dim,
             quant_group_size=128,
             tma_aligned_scales=capability.major >= 10,
-            launch_pdl=(False, True),
+            # PDL is NVIDIA-only; compiling launch_pdl=True on ROCm emits
+            # griddepcontrol PTX and fails hsaco linking (#56030).
+            launch_pdl=(False, True)
+            if current_platform.is_arch_support_pdl()
+            else (False,),
         )
 
     def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- JIT warmup after #50176 enumerated `launch_pdl=(False, True)` for DeepSeek V4 fused Q/KV RMSNorm and inv-RoPE FP8 quant kernels, even on platforms without PDL.
- On ROCm that compiles NVIDIA `griddepcontrol` PTX into an hsaco and `ld.lld` fails, so engine startup dies (`#56030`).
- Only include `launch_pdl=True` in the warmup space when `current_platform.is_arch_support_pdl()` is true. NVIDIA still warms both variants.

Fixes #56030

## Test plan
- [x] ROCm / gfx950: `vllm serve` DeepSeek-V4-Flash with JIT warmup enabled; startup should pass kernel warmup without `griddepcontrol` / hsaco link errors.

