### PR TITLE
docs: clarify APC is enabled by default

### DIFF
--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -7,9 +7,16 @@ Automatic Prefix Caching (APC in short) caches the KV cache of existing queries,
 !!! note
     Technical details on how vLLM implements APC can be found [here](../design/prefix_caching.md).
 
-## Enabling APC in vLLM
+## Using APC in vLLM
 
-Set `enable_prefix_caching=True` in vLLM engine to enable APC. Here is an example:
+Automatic Prefix Caching is **enabled by default** for models that support it (`enable_prefix_caching=True` in the cache config). You do not need to pass any extra flag for typical generative workloads.
+
+To disable APC:
+
+- Python: `LLM(..., enable_prefix_caching=False)`
+- CLI: `vllm serve ... --no-enable-prefix-caching`
+
+Example that demonstrates APC reuse across prompts that share a long prefix:
 
 [examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py](../../examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py)
 

--- a/examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py
+++ b/examples/features/automatic_prefix_caching/automatic_prefix_caching_offline.py
@@ -7,8 +7,8 @@ Automatic Prefix Caching (APC) allows the vLLM engine to reuse cached
 KV (key-value) pairs from previous prompts if a new query shares the same
 prefix. This reduces redundant computation and improves inference speed.
 
-To enable APC, set `enable_prefix_caching=True` when initializing the
-vLLM engine.
+APC is enabled by default for supported models. This example still passes
+`enable_prefix_caching=True` explicitly for clarity.
 
 This script uses a long Markdown table as the shared prompt prefix and
 compares the generation time for two queries that share the same prefix
@@ -76,7 +76,7 @@ def get_generation_time(llm, sampling_params, prompts):
 
 
 def main():
-    # set enable_prefix_caching=True to enable APC
+    # APC is on by default; True is explicit for this demo
     llm = LLM(model="lmsys/longchat-13b-16k", enable_prefix_caching=True)
 
     sampling_params = SamplingParams(temperature=0, max_tokens=100)


### PR DESCRIPTION
## Summary
- Clarify that Automatic Prefix Caching (APC) is **enabled by default** for models that support it (`CacheConfig.enable_prefix_caching=True`; `EngineArgs` defaults from `is_prefix_caching_supported`).
- Document how to disable: `LLM(..., enable_prefix_caching=False)` / `vllm serve ... --no-enable-prefix-caching`.
- Soften comments in the APC offline example so they no longer imply an opt-in `enable_prefix_caching=True` is required.

## Repro
```bash
# Docs still instruct enabling APC
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/114abd1c1131ceb5e2364b77f114ddca2957c734/docs/features/automatic_prefix_caching.md | sed -n "10,14p"
# CacheConfig default is True
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/114abd1c1131ceb5e2364b77f114ddca2957c734/vllm/config/cache.py | rg -n "enable_prefix_caching"
# EngineArgs: CLI --enable-prefix-caching (BooleanOptionalAction) + default from is_prefix_caching_supported
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/114abd1c1131ceb5e2364b77f114ddca2957c734/vllm/engine/arg_utils.py | rg -n "enable.prefix.caching|is_prefix_caching_supported|_set_default_chunked_prefill_and_prefix_caching"
```

## Test plan
- [ ] Docs render: Using APC in vLLM states default-on + disable paths
- [ ] Example comments no longer say set True to enable
- [ ] No code/behavior change
