### PR TITLE
[Bugfix][ROCm] Honor VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION on RDNA

### DIFF
--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -146,6 +146,39 @@ def test_standard_attention_backend_selection(
 
 
 @pytest.mark.parametrize(
+    "unified_attn_enabled, expect_selected",
+    [
+        # VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION unset (default False): the
+        # RDNA unified-attn kernel exceeds RDNA's LDS limit on some shapes, so
+        # it must not be force-selected just because aiter is enabled.
+        (False, False),
+        # Explicit opt-in still works.
+        (True, True),
+    ],
+)
+def test_rdna_unified_attn_backend_respects_flag(unified_attn_enabled, expect_selected):
+    """On RDNA (no CDNA aiter support), ROCM_AITER_UNIFIED_ATTN must only be
+    prioritized when VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION is enabled, not
+    merely because VLLM_ROCM_USE_AITER is set (see #56021)."""
+    from vllm.platforms.rocm import _get_backend_priorities
+
+    with (
+        patch("vllm._aiter_ops.is_aiter_found_and_supported", return_value=False),
+        patch("vllm._aiter_ops.rocm_aiter_ops.is_mha_enabled", return_value=False),
+        patch(
+            "vllm._aiter_ops.rocm_aiter_ops.is_rdna_unified_attn_enabled",
+            return_value=unified_attn_enabled,
+        ),
+    ):
+        backends = _get_backend_priorities(use_mla=False, use_sparse=False)
+
+    if expect_selected:
+        assert backends[0] == AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN
+    else:
+        assert AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN not in backends
+
+
+@pytest.mark.parametrize(
     "env_vars, selected_backend, block_size, expected_backend_path, should_raise",
     [
         # Test Case 1: TRITON_MLA with block_size != 1

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1736,6 +1736,14 @@ class rocm_aiter_ops:
         return cls.is_rdna_aiter_enabled() and cls._LINEAR_ENABLED
 
     @classmethod
+    def is_rdna_unified_attn_enabled(cls) -> bool:
+        """RDNA4 (gfx12) analog of is_triton_unified_attn_enabled(). Unlike the
+        other rdna helpers this also honours VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION,
+        so the kernel can be avoided (it exceeds RDNA's LDS limit on some shapes)
+        without giving up aiter's other Triton paths, e.g. linear GEMM."""
+        return cls.is_rdna_aiter_enabled() and cls._TRITON_UNIFIED_ATTN_ENABLED
+
+    @classmethod
     @if_aiter_supported
     def is_linear_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._LINEAR_ENABLED

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -476,7 +476,7 @@ def _get_backend_priorities(
         backends.append(AttentionBackendEnum.ROCM_AITER_FA)
     if is_aiter_found_and_supported():
         backends.append(AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
-    elif rocm_aiter_ops.is_rdna_aiter_enabled():
+    elif rocm_aiter_ops.is_rdna_unified_attn_enabled():
         backends.insert(0, AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN)
     backends.append(AttentionBackendEnum.TRITON_ATTN)
     backends.append(AttentionBackendEnum.TURBOQUANT)


### PR DESCRIPTION
## Purpose

On RDNA (gfx12), `VLLM_ROCM_USE_AITER=1` force-selects `ROCM_AITER_UNIFIED_ATTN`
at priority 0, ignoring `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION` — the env var
documented to control that specific backend. That kernel requests 65792 bytes
of LDS against RDNA's 65536 byte limit on some shapes, so once concurrency or
prompt length trips the split-KV path, the engine dies with
`triton.runtime.errors.OutOfResources`. There was no supported way to use
aiter's other Triton kernels (e.g. linear GEMM) on RDNA while avoiding this one.

Fixes #56021

## Fix

Adds `rocm_aiter_ops.is_rdna_unified_attn_enabled()` in `vllm/_aiter_ops.py`,
following the existing `is_rdna_linear_enabled()` pattern, and switches the
RDNA branch of `_get_backend_priorities()` in `vllm/platforms/rocm.py` to use
it instead of `is_rdna_aiter_enabled()`. The `insert(0, ...)` priority
ordering flagged as an open question in the issue is left unchanged — the
reporter noted that needs a maintainer decision, not a magic-number guess.

## Not a duplicate

Checked before starting:
- `gh issue view 56021 --comments` — one automated CC comment only, no claim.
- GitHub search for open PRs referencing `#56021`, `is_rdna_unified_attn_enabled`,
  and `ROCM_AITER_UNIFIED_ATTN RDNA` — no existing PR found.

## Test Plan / Test Result

Added `test_rdna_unified_attn_backend_respects_flag` to
`tests/v1/attention/test_rocm_attention_backends_selection.py`, exercising
`_get_backend_priorities()` directly with the RDNA path mocked
(`is_aiter_found_and_supported=False`, `is_rdna_unified_attn_enabled` mocked
True/False) to assert the flag is actually honored.

```bash
pytest tests/v1/attention/test_rocm_attention_backends_selection.py -v
```

**Limitation:** this environment has no ROCm/CUDA GPU — `vllm.platforms.rocm`
fails to import here (`torch.cuda.get_device_properties` requires a real
device), which is also why the existing suite gates itself with
`pytestmark = pytest.mark.skipif(not current_platform.is_rocm(), ...)`. I
verified the change by:
- Confirming the exact function/line-level match against current
  `vllm-project/vllm:main` (`vllm/platforms/rocm.py` RDNA branch, lines
  489–491, matching the issue's citation).
- Manually tracing `is_rdna_unified_attn_enabled()` →
  `is_rdna_aiter_enabled() and _TRITON_UNIFIED_ATTN_ENABLED`, mirroring
  `is_rdna_linear_enabled()`.
- `python -m py_compile` on all three changed files.

The new test itself has not been executed against real ROCm hardware — that
needs to happen on CI or an RDNA4 box (e.g. gfx1201) before merge; I could not
access one in this environment.

No model-output or accuracy impact — this only changes attention *backend
selection*, not computation, so no model eval was run.

## AI assistance disclosure

This change was prepared with AI assistance (Claude Code). I reviewed every
changed line and the reasoning above myself before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt95xmcafe7Mnff5y8Ah1d
