### PR TITLE
docs: point sharded checkpoint conversion at save_sharded_state_offline.py

### DIFF
--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -23,7 +23,7 @@ llm = LLM(model="ibm-granite/granite-3.1-8b-instruct", tensor_parallel_size=2)
 !!! note
     With tensor parallelism enabled, each process will read the whole model and split it into chunks, which makes the disk reading time even longer (proportional to the size of tensor parallelism).
 
-    You can convert the model checkpoint to a sharded checkpoint using [examples/features/sharded_state/load_sharded_state_offline.py](../../examples/features/sharded_state/load_sharded_state_offline.py). The conversion process might take some time, but later you can load the sharded checkpoint much faster. The model loading time should remain constant regardless of the size of tensor parallelism.
+    You can convert the model checkpoint to a sharded checkpoint using [examples/features/sharded_state/save_sharded_state_offline.py](../../examples/features/sharded_state/save_sharded_state_offline.py). The conversion process might take some time, but later you can load the sharded checkpoint much faster. The model loading time should remain constant regardless of the size of tensor parallelism.
 
 ## Quantization
 


### PR DESCRIPTION
## Summary
- `docs/configuration/conserving_memory.md` told readers to convert a model to a sharded checkpoint via `examples/features/sharded_state/load_sharded_state_offline.py`.
- That script only **loads/validates** an already-saved sharded checkpoint. Conversion is done by `save_sharded_state_offline.py` (`--model` → `--output`).
- Update the guide link/text to the save script.

## Local repro
```bash
# Docs still point conversion at load_* on main tip
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/configuration/conserving_memory.md | rg -n 'sharded_state'

# save_* docstring: conversion/save usage
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/sharded_state/save_sharded_state_offline.py | head -30

# load_* docstring: validates loading after save
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/sharded_state/load_sharded_state_offline.py | head -35
```

## Test plan
- [x] Confirmed both scripts exist under `examples/features/sharded_state/`
- [x] Confirmed save script performs conversion; load script validates load
- [x] Single-file docs change only