### PR TITLE
[Examples] Use positional model in xLAM vllm serve Usage

### DIFF
--- a/examples/tool_calling/openai_chat_completion_client_with_tools_xlam.py
+++ b/examples/tool_calling/openai_chat_completion_client_with_tools_xlam.py
@@ -5,11 +5,11 @@
 Set up this example by starting a vLLM OpenAI-compatible server with tool call
 options enabled for xLAM-2 models:
 
-vllm serve --model Salesforce/Llama-xLAM-2-8b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
+vllm serve Salesforce/Llama-xLAM-2-8b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
 
 OR
 
-vllm serve --model Salesforce/xLAM-2-3b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
+vllm serve Salesforce/xLAM-2-3b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
 """
 
 import json

--- a/examples/tool_calling/openai_chat_completion_client_with_tools_xlam_streaming.py
+++ b/examples/tool_calling/openai_chat_completion_client_with_tools_xlam_streaming.py
@@ -5,11 +5,11 @@
 Set up this example by starting a vLLM OpenAI-compatible server with tool call
 options enabled for xLAM-2 models:
 
-vllm serve --model Salesforce/Llama-xLAM-2-8b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
+vllm serve Salesforce/Llama-xLAM-2-8b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
 
 OR
 
-vllm serve --model Salesforce/xLAM-2-3b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
+vllm serve Salesforce/xLAM-2-3b-fc-r --enable-auto-tool-choice --tool-call-parser xlam
 
 This example demonstrates streaming tool calls with xLAM models.
 """


### PR DESCRIPTION
## Summary
- Replace deprecated `vllm serve --model <model>` with positional `vllm serve <model>` in xLAM tool-calling examples.
- Matches sibling `tool_calling` clients and current `vllm serve` CLI guidance.

## Test plan
- [x] Confirmed on main `114abd1c` Usage still uses `vllm serve --model`
- [x] Confirmed FlexibleArgumentParser warns `--model` is deprecated for `vllm serve`
- [x] Diff only updates docstring Usage lines (4 occurrences across 2 files)
