### PR TITLE
[Security] Cap Cohere2 Vision max_patches to prevent request-driven resource exhaustion

### DIFF
--- a/tests/models/multimodal/processing/test_cohere2_vision.py
+++ b/tests/models/multimodal/processing/test_cohere2_vision.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Cohere2 Vision request max_patches bounds."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.exceptions import VLLMValidationError
+from vllm.model_executor.models.cohere2_max_patches import (
+    validate_cohere2_max_patches,
+)
+
+_LIMIT = 12
+
+
+@pytest.mark.parametrize(
+    "mm_kwargs",
+    [
+        {"max_patches": 20000},
+        {"images_kwargs": {"max_patches": 20000}},
+        {"max_patches": 1, "images_kwargs": {"max_patches": 20000}},
+        {"max_patches": 0},
+        {"max_patches": -1},
+        {"max_patches": 13},
+        {"max_patches": True},
+        {"max_patches": "12"},
+        {"max_patches": 12.0},
+    ],
+)
+def test_invalid_max_patches_rejected(mm_kwargs: dict[str, object]):
+    with pytest.raises(VLLMValidationError, match="max_patches"):
+        validate_cohere2_max_patches(mm_kwargs, _LIMIT)
+
+
+@pytest.mark.parametrize(
+    "mm_kwargs",
+    [
+        {},
+        {"max_patches": 1},
+        {"max_patches": _LIMIT},
+        {"images_kwargs": {"max_patches": 4}},
+        {"images_kwargs": "not-a-mapping"},
+    ],
+)
+def test_valid_max_patches_accepted(mm_kwargs: dict[str, object]):
+    validate_cohere2_max_patches(mm_kwargs, _LIMIT)
+
+
+def test_non_mapping_mm_kwargs_rejected():
+    with pytest.raises(VLLMValidationError, match="must be a mapping"):
+        validate_cohere2_max_patches(["max_patches", 20000], _LIMIT)  # type: ignore[arg-type]
+
+
+def _processing_info(
+    *,
+    processor_limit: int = _LIMIT,
+    configured: dict[str, object] | None = None,
+):
+    if "torchvision" not in sys.modules:
+        try:
+            import torchvision  # noqa: F401
+        except ModuleNotFoundError:
+            sys.modules["torchvision"] = MagicMock()
+            sys.modules["torchvision.transforms"] = MagicMock()
+            sys.modules["torchvision.transforms.v2"] = MagicMock()
+            sys.modules["torchvision.transforms.v2.functional"] = MagicMock()
+
+    from vllm.model_executor.models.cohere2_vision import (
+        Cohere2VisionProcessingInfo,
+    )
+
+    ctx = MagicMock()
+    ctx.get_hf_processor.return_value.image_processor.max_patches = processor_limit
+    mm_config = MagicMock()
+    mm_config.mm_processor_kwargs = configured
+    ctx.model_config.get_multimodal_config.return_value = mm_config
+    ctx.get_merged_mm_kwargs.side_effect = lambda kwargs: dict(kwargs)
+    return Cohere2VisionProcessingInfo(ctx), ctx
+
+
+def test_get_hf_processor_rejects_oversized_max_patches():
+    info, ctx = _processing_info()
+
+    with pytest.raises(VLLMValidationError, match="max_patches"):
+        info.get_hf_processor(max_patches=20000)
+
+    for call in ctx.get_hf_processor.call_args_list:
+        assert call.kwargs.get("max_patches") != 20000
+
+
+def test_get_num_patches_rejects_oversized_max_patches():
+    info, _ctx = _processing_info()
+    processor = MagicMock()
+
+    with pytest.raises(VLLMValidationError, match="max_patches"):
+        info.get_num_patches(
+            image_width=64,
+            image_height=64,
+            processor=processor,
+            mm_kwargs={"max_patches": 20000},
+        )
+
+    processor.image_processor.get_number_of_image_patches.assert_not_called()
+
+
+def test_get_num_patches_rejects_nested_oversized_max_patches():
+    info, _ctx = _processing_info()
+    processor = MagicMock()
+
+    with pytest.raises(VLLMValidationError, match="max_patches"):
+        info.get_num_patches(
+            image_width=64,
+            image_height=64,
+            processor=processor,
+            mm_kwargs={"images_kwargs": {"max_patches": 20000}},
+        )
+
+    processor.image_processor.get_number_of_image_patches.assert_not_called()
+
+
+def test_get_num_patches_forwards_in_range_max_patches():
+    info, _ctx = _processing_info()
+    processor = MagicMock()
+    processor.image_processor.get_number_of_image_patches.return_value = 2
+
+    result = info.get_num_patches(
+        image_width=64,
+        image_height=64,
+        processor=processor,
+        mm_kwargs={"max_patches": 4},
+    )
+
+    assert result == 2
+    processor.image_processor.get_number_of_image_patches.assert_called_once()
+
+
+def test_operator_max_patches_is_the_request_cap():
+    info, ctx = _processing_info(configured={"max_patches": 24})
+
+    info.get_hf_processor(max_patches=24)
+    ctx.get_hf_processor.assert_called()
+
+    with pytest.raises(VLLMValidationError, match="max_patches"):
+        info.get_hf_processor(max_patches=25)

--- a/vllm/model_executor/models/cohere2_max_patches.py
+++ b/vllm/model_executor/models/cohere2_max_patches.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Bounds for Cohere2 Vision request ``max_patches`` overrides."""
+
+from collections.abc import Mapping
+
+from vllm.exceptions import VLLMValidationError
+
+
+def iter_max_patches_values(
+    mm_kwargs: Mapping[str, object],
+) -> list[tuple[str, object]]:
+    """Yield request ``max_patches`` from flat and image-scoped kwargs."""
+    values: list[tuple[str, object]] = []
+    if "max_patches" in mm_kwargs:
+        values.append(("max_patches", mm_kwargs["max_patches"]))
+    nested = mm_kwargs.get("images_kwargs")
+    if isinstance(nested, Mapping) and "max_patches" in nested:
+        values.append(("images_kwargs.max_patches", nested["max_patches"]))
+    return values
+
+
+def validate_cohere2_max_patches(
+    mm_kwargs: Mapping[str, object],
+    limit: int,
+) -> None:
+    """Reject request ``max_patches`` that are not ints in ``[1, limit]``."""
+    if not isinstance(mm_kwargs, Mapping):
+        raise VLLMValidationError(
+            "mm_processor_kwargs must be a mapping",
+            parameter="mm_processor_kwargs",
+            value=mm_kwargs,
+        )
+    for name, value in iter_max_patches_values(mm_kwargs):
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise VLLMValidationError(
+                f"{name} must be a positive integer not greater than {limit}",
+                parameter=name,
+                value=value,
+            )
+        if value < 1 or value > limit:
+            raise VLLMValidationError(
+                f"{name} must be a positive integer not greater than {limit}",
+                parameter=name,
+                value=value,
+            )

--- a/vllm/model_executor/models/cohere2_vision.py
+++ b/vllm/model_executor/models/cohere2_vision.py
@@ -45,6 +45,7 @@ from vllm.multimodal.processing import (
 from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
+from .cohere2_max_patches import validate_cohere2_max_patches
 from .interfaces import (
     MultiModalEmbeddings,
     SupportsMultiModal,
@@ -151,7 +152,29 @@ class Cohere2VisionProcessingInfo(BaseProcessingInfo):
     def get_hf_config(self) -> Cohere2VisionConfig:
         return self.ctx.get_hf_config(Cohere2VisionConfig)
 
+    def _max_patches_limit(self) -> int:
+        """Server-owned cap: operator config overlay, else processor default."""
+        processor = self.ctx.get_hf_processor(Cohere2VisionProcessor)
+        default = processor.image_processor.max_patches
+        configured = (
+            self.ctx.model_config.get_multimodal_config().mm_processor_kwargs or {}
+        )
+        if not isinstance(configured, Mapping):
+            return default
+        nested = configured.get("images_kwargs")
+        if isinstance(nested, Mapping) and "max_patches" in nested:
+            value = nested["max_patches"]
+        elif "max_patches" in configured:
+            value = configured["max_patches"]
+        else:
+            return default
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            return default
+        return value
+
     def get_hf_processor(self, **kwargs: object) -> Cohere2VisionProcessor:
+        if kwargs:
+            validate_cohere2_max_patches(kwargs, self._max_patches_limit())
         return self.ctx.get_hf_processor(Cohere2VisionProcessor, **kwargs)
 
     def get_image_processor(self, **kwargs: object):
@@ -179,6 +202,7 @@ class Cohere2VisionProcessingInfo(BaseProcessingInfo):
         Calculate the number of image patches for a given image.
         Uses the HF processor to determine the actual number of patches.
         """
+        validate_cohere2_max_patches(mm_kwargs, self._max_patches_limit())
         image_processor: Cohere2VisionImageProcessorFast = processor.image_processor
 
         return image_processor.get_number_of_image_patches(


### PR DESCRIPTION
## Summary

- Reject request-level `mm_processor_kwargs.max_patches` (including nested `images_kwargs.max_patches`) when the value is not a positive integer or exceeds the server-owned Cohere2 Vision cap.
- Treat the processor default, or operator `--mm-processor-kwargs`, as the authority for that cap so a client cannot raise the Hugging Face tile-enumeration budget.
- Add regression tests covering oversized, nested, non-integer, and in-range overrides, plus the operator-configured cap.

## Root Cause

Cohere2 Vision forwards per-request `mm_processor_kwargs` into Hugging Face `get_number_of_image_patches` / processor construction with no upper bound. The Transformers helper enumerates tile aspect ratios with nested loops bounded by `max_patches`, so a small valid image plus a large override (for example `max_patches=20000`) causes quadratic CPU work during multimodal preprocessing, before normal inference limits apply. Distinct values also miss the helper's small LRU cache.

## Fix

Two checks on the Cohere2 Vision processing path, using the server/model configuration as the cap:

1. **Validate in `get_hf_processor`** -- request kwargs are rejected before the HF processor is constructed or called, so `__call__` never sees an oversized `max_patches`.
2. **Validate in `get_num_patches`** -- the same bound is applied before `get_number_of_image_patches`, covering prompt-update and fallback patch-count paths.

Both flat `max_patches` and nested `images_kwargs.max_patches` are checked. Values must be integers in `[1, limit]`; `bool`, strings, floats, zero, and negatives are rejected.

## Test Plan

- [x] `test_invalid_max_patches_rejected` -- `20000`, nested `images_kwargs`, `0`, negative, above-limit, `bool`, `str`, and `float` raise `VLLMValidationError`.
- [x] `test_valid_max_patches_accepted` -- missing key, `1`, equal to the limit, and nested in-range values are accepted.
- [x] `test_non_mapping_mm_kwargs_rejected` -- a non-mapping kwargs object is rejected.
- [x] `test_get_hf_processor_rejects_oversized_max_patches` -- oversized kwargs never reach HF processor construction.
- [x] `test_get_num_patches_rejects_oversized_max_patches` -- HF `get_number_of_image_patches` is not called for oversized or nested oversized values.
- [x] `test_get_num_patches_forwards_in_range_max_patches` -- an in-range override is forwarded.
- [x] `test_operator_max_patches_is_the_request_cap` -- a server-configured cap is honored; values above it are rejected.
- [x] Pre-commit hooks pass.

Made with [Cursor](https://cursor.com)