### PR TITLE
[Docs] Fix ghost --grpc-port in security guide

### DIFF
--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -351,7 +351,7 @@ vLLM supports loading out-of-tree HTTP routes via the `vllm.endpoint_plugins` en
 
 ## gRPC Interface
 
-vLLM provides optional gRPC `Inference` and `Control` services on a separate TCP port, enabled via the `--grpc-port` flag. When not specified, no gRPC server is started. The gRPC listener binds to the same host address as the HTTP server.
+vLLM provides optional gRPC `Inference` and `Control` services, enabled by passing `--grpc` to `vllm serve`. When `--grpc` is not set, the OpenAI-compatible HTTP server is started instead. With `--grpc`, the gRPC listener binds using the same `--host` / `--port` flags as the HTTP frontend (there is no separate `--grpc-port` flag).
 
 **Warning:** The gRPC interface is **insecure by default** — it does not implement authentication, authorization, or encryption. It should be considered a private, internal interface intended for use only between co-located services within a trusted network. Do not expose the gRPC port to the public internet or untrusted clients. If you enable the gRPC interface, protect it via network-level access controls such as firewall rules, network segmentation, or deployment on an isolated private network.
 
@@ -366,7 +366,7 @@ An attacker who can reach the gRPC port can:
 
 ### Recommendations
 
-- Only enable `--grpc-port` when you have a specific need for gRPC-based inference
+- Only enable `--grpc` when you have a specific need for gRPC-based inference
 - Ensure the gRPC port is only accessible from trusted hosts or services
 - Use firewall rules to block external access to the gRPC port
 - Consider deploying the gRPC interface on a dedicated internal network interface


### PR DESCRIPTION
## Summary
`docs/usage/security.md` documented a top-level `--grpc-port` flag for enabling the gRPC interface. That flag is not registered on the CLI.

Live wiring:
- `vllm/entrypoints/launchers/cli_args.py` `make_arg_parser` registers `--grpc` (`store_true`) to launch a gRPC server instead of the HTTP OpenAI-compatible server.
- There is no `--grpc-port` argument anywhere in the serve / launchers / grpc entrypoints.
- `vllm/entrypoints/cli/serve.py` routes to `serve_grpc(args)` when `args.grpc` is true.
- `vllm/entrypoints/grpc_server.py` binds `f"{host}:{args.port}"` using the shared FrontendArgs `--host` / `--port`.

This PR updates the security guide to describe `--grpc` and the shared `--host` / `--port` binding. Security warning text is unchanged.

## Local repro
```bash
# At main tip
# 1) Doc claim
curl -sL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/usage/security.md | rg -n 'grpc-port'
# expect: enabled via the `--grpc-port` flag; Only enable `--grpc-port`...

# 2) CLI registers --grpc, not --grpc-port
python - <<'PY'
from vllm.utils.argparse_utils import FlexibleArgumentParser
from vllm.entrypoints.launchers.cli_args import make_arg_parser
p = make_arg_parser(FlexibleArgumentParser())
opts = sorted({o for a in p._actions for o in a.option_strings})
print('has --grpc', '--grpc' in opts)
print('has --grpc-port', '--grpc-port' in opts)
print([o for o in opts if 'grpc' in o])
PY
# expect: has --grpc True; has --grpc-port False; ['--grpc']
```

## Test plan
- [ ] Confirm `make_arg_parser` still exposes `--grpc` and not `--grpc-port`
- [ ] Confirm `vllm serve --grpc` still routes to `serve_grpc` via `entrypoints/cli/serve.py`
- [ ] Docs render check for the gRPC Interface section