### PR TITLE
[Fast Start] Daemon 2 Daemon

### DIFF
--- a/tests/model_executor/model_loader/test_weight_cache_seed.py
+++ b/tests/model_executor/model_loader/test_weight_cache_seed.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for daemon-to-daemon weight-cache metadata and copying."""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.model_executor.model_loader.weight_cache.protocol import TensorEntry
+from vllm.model_executor.model_loader.weight_cache.seed import (
+    PeerIpcSeedSource,
+    build_manifest,
+    manifest_dtype,
+    manifest_nbytes,
+)
+
+
+def _entries():
+    return {
+        "weight": TensorEntry.from_tensor(
+            torch.zeros(2, 3, dtype=torch.float16), "param"
+        ),
+        "scale": TensorEntry.from_tensor(torch.ones(4, dtype=torch.float32), "buffer"),
+    }
+
+
+def test_manifest_describes_all_exported_tensors():
+    manifest = build_manifest(_entries())
+    assert manifest == {
+        "weight": {"shape": [2, 3], "dtype": "float16", "is_param": True},
+        "scale": {"shape": [4], "dtype": "float32", "is_param": False},
+    }
+    assert manifest_nbytes(manifest) == 2 * 3 * 2 + 4 * 4
+    assert manifest_dtype("bfloat16") is torch.bfloat16
+
+
+def test_unknown_manifest_dtype_fails_loudly():
+    with pytest.raises(RuntimeError, match="unsupported dtype"):
+        manifest_dtype("not_a_torch_dtype")
+
+
+def test_peer_seed_copy_owns_new_tensors():
+    entries = _entries()
+    source = PeerIpcSeedSource()
+    manifest = build_manifest(entries)
+    with patch.object(torch.accelerator, "synchronize"):
+        result = source.fill(
+            manifest,
+            {"source_device_index": 0, "entries": entries},
+            torch.device("cpu"),
+        )
+    assert torch.equal(result["weight"], torch.zeros(2, 3, dtype=torch.float16))
+    assert torch.equal(result["scale"], torch.ones(4, dtype=torch.float32))
+    assert result["weight"].data_ptr() != entries["weight"].cpu_tensor.data_ptr()

--- a/vllm/model_executor/model_loader/weight_cache/__init__.py
+++ b/vllm/model_executor/model_loader/weight_cache/__init__.py
@@ -11,10 +11,16 @@ from vllm.model_executor.model_loader.weight_cache.protocol import (
     check_ipc_quant_support,
     is_ipc_quant_supported,
 )
+from vllm.model_executor.model_loader.weight_cache.seed import (
+    PEER_IPC_SEED_SOURCE,
+    RDMA_SEED_SOURCE,
+)
 
 __all__ = [
     "CacheConfigMismatchError",
     "IpcModelLoader",
+    "PEER_IPC_SEED_SOURCE",
+    "RDMA_SEED_SOURCE",
     "TensorEntry",
     "UnsupportedQuantForIPCError",
     "WeightCacheKey",

--- a/vllm/model_executor/model_loader/weight_cache/daemon.py
+++ b/vllm/model_executor/model_loader/weight_cache/daemon.py
@@ -12,6 +12,13 @@ Launch one daemon per TP rank with a single command:
     python -m vllm.model_executor.model_loader.weight_cache.daemon \\
         --model /path/to/model --tensor-parallel-size 4
 
+A second replica can seed its daemons from the first replica without
+reading the checkpoint again. Pass one source Unix socket per TP rank for
+same-host peer copies, or one ``host:port`` per rank with
+``--weight-cache-seed-backend rdma`` for cross-host Mooncake copies. The source
+must expose ``--weight-cache-listen-addr host:base_port`` and
+``--weight-cache-seed-token`` for cross-host transfers.
+
 Engines then load from the daemons with:
 
     vllm serve /path/to/model --tensor-parallel-size 4 \\
@@ -23,13 +30,16 @@ are rejected at launch.
 
 import contextlib
 import fcntl
+import hmac
 import multiprocessing
 import os
 import queue
+import select
 import signal
 import socket
 import sys
 from collections.abc import Callable
+from typing import Any
 
 import torch
 
@@ -50,10 +60,45 @@ from vllm.model_executor.model_loader.weight_cache.protocol import (
     recv_msg,
     send_msg,
     verify_peer_is_owner,
+    verify_socket_owner,
+)
+from vllm.model_executor.model_loader.weight_cache.seed import (
+    PEER_IPC_SEED_SOURCE,
+    build_manifest,
+    get_seed_source,
 )
 from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
+
+
+def _split_seed_addresses(value: str | None) -> list[str]:
+    return [address.strip() for address in (value or "").split(",") if address.strip()]
+
+
+def _seed_address(value: str | None, tp_rank: int) -> str | None:
+    addresses = _split_seed_addresses(value)
+    if not addresses:
+        return None
+    if len(addresses) == 1:
+        return addresses[0]
+    if tp_rank >= len(addresses):
+        raise ValueError(
+            f"--weight-cache-seed has {len(addresses)} addresses but TP rank "
+            f"{tp_rank} needs an address; pass one address per TP rank"
+        )
+    return addresses[tp_rank]
+
+
+def _listen_address(value: str | None, tp_rank: int) -> tuple[str, int] | None:
+    if not value:
+        return None
+    host, separator, port = value.rpartition(":")
+    if not separator or not host or not port.isdigit():
+        raise ValueError(
+            f"--weight-cache-listen-addr must be host:base_port, got {value!r}"
+        )
+    return host, int(port) + tp_rank
 
 
 def _report_ready(message: str) -> None:
@@ -122,14 +167,24 @@ class WeightCacheDaemon:
         tp_rank: int,
         distributed_init_method: str,
         socket_dir: str | None = None,
+        seed_addr: str | None = None,
+        seed_backend: str = PEER_IPC_SEED_SOURCE,
+        listen_addr: tuple[str, int] | None = None,
+        seed_token: str | None = None,
     ):
         self.vllm_config = vllm_config
         self.tp_rank = tp_rank
         self.distributed_init_method = distributed_init_method
         self.socket_dir = socket_dir
+        self.seed_addr = seed_addr
+        self.seed_backend = seed_backend
+        self.listen_addr = listen_addr
+        self.seed_token = seed_token
         self.model: torch.nn.Module | None = None
         self.entries: dict[str, TensorEntry] = {}
         self.aliases: dict[str, str] = {}
+        self.state_tensors: dict[str, torch.Tensor] = {}
+        self._seed_sources: dict[str, Any] = {}
         # Fingerprint before loading: process_weights_after_loading may
         # mutate hf_config.quantization_config.
         self.cache_config = WeightCacheKey.from_model_config(
@@ -141,19 +196,22 @@ class WeightCacheDaemon:
     def load_model(self) -> None:
         from vllm.model_executor.model_loader import get_model
 
-        tp_size = self.cache_config.tp_size
         torch.accelerator.set_device_index(self.tp_rank)
-        init_distributed_environment(
-            world_size=tp_size,
-            rank=self.tp_rank,
-            distributed_init_method=self.distributed_init_method,
-            local_rank=self.tp_rank,
-            backend=current_platform.dist_backend,
-        )
-        with set_current_vllm_config(self.vllm_config):
-            ensure_model_parallel_initialized(tp_size, 1)
-            self.model = get_model(vllm_config=self.vllm_config)
-        self._export_entries()
+        if self.seed_addr is not None:
+            self._load_from_seed()
+        else:
+            tp_size = self.cache_config.tp_size
+            init_distributed_environment(
+                world_size=tp_size,
+                rank=self.tp_rank,
+                distributed_init_method=self.distributed_init_method,
+                local_rank=self.tp_rank,
+                backend=current_platform.dist_backend,
+            )
+            with set_current_vllm_config(self.vllm_config):
+                ensure_model_parallel_initialized(tp_size, 1)
+                self.model = get_model(vllm_config=self.vllm_config)
+            self._export_entries()
         logger.info(
             "Weight cache daemon rank %d cached %d tensors",
             self.tp_rank,
@@ -163,6 +221,90 @@ class WeightCacheDaemon:
     def _export_entries(self) -> None:
         assert self.model is not None
         self.entries, self.aliases = export_entries(self.model)
+        self.state_tensors = {}
+        for name, tensor in self.model.named_parameters(remove_duplicate=False):
+            if name in self.entries:
+                self.state_tensors[name] = tensor.detach()
+        for name, tensor in self.model.named_buffers(remove_duplicate=False):
+            if name in self.entries:
+                self.state_tensors[name] = tensor.detach()
+
+    def _connect_seed(self) -> tuple[socket.socket, bool]:
+        assert self.seed_addr is not None
+        if self.seed_addr.startswith("/") or self.seed_addr.startswith("./"):
+            verify_socket_owner(self.seed_addr, strict_perms=False)
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            target: Any = self.seed_addr
+            remote = False
+        else:
+            host, separator, port = self.seed_addr.rpartition(":")
+            if not separator or not host or not port.isdigit():
+                raise ValueError(
+                    "Seed address must be an absolute Unix socket path or host:port"
+                )
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            target = (host, int(port))
+            remote = True
+        sock.settimeout(300.0)
+        try:
+            sock.connect(target)
+        except OSError:
+            sock.close()
+            raise
+        return sock, remote
+
+    def _load_from_seed(self) -> None:
+        sock, remote = self._connect_seed()
+        try:
+            request: dict[str, Any] = {
+                "cmd": "fetch_manifest",
+                "seed_backend": self.seed_backend,
+            }
+            if remote:
+                request["token"] = self.seed_token
+            send_msg(sock, request)
+            response = recv_msg(sock)
+        finally:
+            sock.close()
+        if response.get("status") != "ok":
+            raise RuntimeError(
+                f"Seed daemon {self.seed_addr} refused the mirror request: "
+                f"{response.get('message', response)}"
+            )
+        source_config = response.get("cache_config")
+        if not isinstance(source_config, WeightCacheKey):
+            raise RuntimeError("Seed daemon returned no compatible cache config")
+        mismatched = self.cache_config.mismatched_fields(source_config)
+        if mismatched:
+            raise RuntimeError(
+                f"Seed daemon cache differs on fields {mismatched}; refusing "
+                "to mirror a different weight shard"
+            )
+        source = self._seed_sources.get(self.seed_backend)
+        if source is None:
+            source = get_seed_source(self.seed_backend)
+            self._seed_sources[self.seed_backend] = source
+        manifest = response["manifest"]
+        tensors = source.fill(
+            manifest, response["seed"], torch.device("cuda", self.tp_rank)
+        )
+        if set(tensors) != set(manifest):
+            raise RuntimeError("Seed backend did not fill the complete tensor manifest")
+        self.entries = {
+            name: TensorEntry.from_tensor(
+                tensors[name], "param" if metadata["is_param"] else "buffer"
+            )
+            for name, metadata in manifest.items()
+        }
+        self.aliases = response.get("aliases", {})
+        self.state_tensors = tensors
+        self.cache_config = source_config
+        logger.info(
+            "Weight cache daemon rank %d mirrored %d tensors from %s",
+            self.tp_rank,
+            len(self.entries),
+            self.seed_addr,
+        )
 
     def serve_forever(self, ready_callback: Callable[[], None] | None = None) -> None:
         """Serve requests until terminated.
@@ -188,6 +330,13 @@ class WeightCacheDaemon:
         server.bind(socket_path)
         os.chmod(socket_path, 0o600)
         server.listen()
+        tcp_server = None
+        if self.listen_addr is not None:
+            tcp_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            tcp_server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            tcp_server.bind(self.listen_addr)
+            tcp_server.listen()
+        listeners = [server] + ([tcp_server] if tcp_server is not None else [])
         logger.info(
             "Weight cache daemon rank %d serving on %s", self.tp_rank, socket_path
         )
@@ -198,21 +347,28 @@ class WeightCacheDaemon:
             ready_callback()
         try:
             while True:
-                conn, _ = server.accept()
-                with conn:
-                    try:
-                        verify_peer_is_owner(conn)
-                        self._handle_connection(conn)
-                    except (ConnectionError, EOFError):
-                        logger.warning("Client disconnected mid-request")
-                    except Exception:
-                        # A single malformed or malicious request must not take
-                        # down the daemon for every other engine on this GPU.
-                        logger.exception(
-                            "Error handling weight cache client; continuing"
-                        )
+                readable, _, _ = select.select(listeners, [], [], 1.0)
+                for listener in readable:
+                    conn, _ = listener.accept()
+                    with conn:
+                        try:
+                            remote = listener is tcp_server
+                            if not remote:
+                                verify_peer_is_owner(conn)
+                            self._handle_connection(conn, remote=remote)
+                        except (ConnectionError, EOFError):
+                            logger.warning("Client disconnected mid-request")
+                        except Exception:
+                            # A malformed peer must not take down all clients.
+                            logger.exception(
+                                "Error handling weight cache client; continuing"
+                            )
         finally:
             server.close()
+            if tcp_server is not None:
+                tcp_server.close()
+            for source in self._seed_sources.values():
+                source.close()
             if os.path.exists(socket_path):
                 os.unlink(socket_path)
             os.close(lock_fd)
@@ -242,11 +398,25 @@ class WeightCacheDaemon:
             gpu_id = device_index
         return get_socket_path(gpu_id, self.socket_dir)
 
-    def _handle_connection(self, conn: socket.socket) -> None:
+    def _handle_connection(self, conn: socket.socket, *, remote: bool = False) -> None:
         request = recv_msg(conn)
+        if remote:
+            presented = request.get("token")
+            if (
+                not self.seed_token
+                or not isinstance(presented, str)
+                or not hmac.compare_digest(presented, self.seed_token)
+                or request.get("cmd") != "fetch_manifest"
+            ):
+                send_msg(
+                    conn, {"status": "error", "message": "Unauthorized seed request"}
+                )
+                return
         cmd = request.get("cmd")
         if cmd == "get_state":
             self._handle_get_state(conn, request)
+        elif cmd == "fetch_manifest":
+            self._handle_fetch_manifest(conn, request)
         elif cmd == "release":
             self._handle_release(conn)
         else:
@@ -275,9 +445,39 @@ class WeightCacheDaemon:
             },
         )
 
+    def _handle_fetch_manifest(self, conn: socket.socket, request: dict) -> None:
+        if not self.entries:
+            send_msg(conn, {"status": "error", "message": "Weights were released"})
+            return
+        backend = request.get("seed_backend", PEER_IPC_SEED_SOURCE)
+        source = self._seed_sources.get(backend)
+        if source is None:
+            source = get_seed_source(backend)
+            self._seed_sources[backend] = source
+        try:
+            seed = source.prepare_seed(
+                self.entries,
+                self.state_tensors,
+                get_physical_device_id(torch.accelerator.current_device_index()),
+            )
+        except Exception as error:
+            send_msg(conn, {"status": "error", "message": str(error)})
+            return
+        send_msg(
+            conn,
+            {
+                "status": "ok",
+                "cache_config": self.cache_config,
+                "manifest": build_manifest(self.entries),
+                "aliases": self.aliases,
+                "seed": seed,
+            },
+        )
+
     def _handle_release(self, conn: socket.socket) -> None:
         self.entries.clear()
         self.aliases.clear()
+        self.state_tensors.clear()
         self.model = None
         torch.accelerator.empty_cache()
         logger.info("Weight cache daemon rank %d released cached weights", self.tp_rank)
@@ -295,10 +495,21 @@ def _run_daemon(
     vllm_config: VllmConfig,
     distributed_init_method: str,
     socket_dir: str | None,
+    seed_addr: str | None,
+    seed_backend: str,
+    listen_addr: tuple[str, int] | None,
+    seed_token: str | None,
     ready_queue: "multiprocessing.Queue[int]",
 ) -> None:
     daemon = WeightCacheDaemon(
-        vllm_config, tp_rank, distributed_init_method, socket_dir
+        vllm_config,
+        tp_rank,
+        distributed_init_method,
+        socket_dir,
+        seed_addr,
+        seed_backend,
+        listen_addr,
+        seed_token,
     )
     daemon.load_model()
     daemon.serve_forever(ready_callback=lambda: ready_queue.put(tp_rank))
@@ -334,9 +545,37 @@ def main() -> None:
         default=None,
         help="Directory for the daemon Unix sockets (default: tempdir).",
     )
+    parser.add_argument(
+        "--weight-cache-seed",
+        type=str,
+        default=None,
+        help="Comma-separated source daemon socket/host addresses, one per TP rank.",
+    )
+    parser.add_argument(
+        "--weight-cache-seed-backend",
+        choices=[PEER_IPC_SEED_SOURCE, "rdma"],
+        default=PEER_IPC_SEED_SOURCE,
+        help="Daemon-to-daemon mover: peer_ipc or rdma.",
+    )
+    parser.add_argument(
+        "--weight-cache-listen-addr",
+        type=str,
+        default=None,
+        help="host:base_port for the cross-node seed control plane.",
+    )
+    parser.add_argument(
+        "--weight-cache-seed-token",
+        type=str,
+        default=None,
+        help="Shared secret required by the cross-node seed control plane.",
+    )
     args = parser.parse_args()
     engine_args = EngineArgs.from_cli_args(args)
     vllm_config = engine_args.create_engine_config()
+    if args.weight_cache_listen_addr and not args.weight_cache_seed_token:
+        raise ValueError(
+            "--weight-cache-listen-addr requires --weight-cache-seed-token"
+        )
     if vllm_config.load_config.load_format == "ipc_cache":
         raise ValueError(
             "The weight cache daemon itself must load from disk; use the "
@@ -360,6 +599,10 @@ def main() -> None:
                 vllm_config,
                 distributed_init_method,
                 args.weight_cache_socket_dir,
+                _seed_address(args.weight_cache_seed, rank),
+                args.weight_cache_seed_backend,
+                _listen_address(args.weight_cache_listen_addr, rank),
+                args.weight_cache_seed_token,
                 ready_queue,
             ),
             name=f"vllm-weight-cache-daemon-{rank}",

--- a/vllm/model_executor/model_loader/weight_cache/protocol.py
+++ b/vllm/model_executor/model_loader/weight_cache/protocol.py
@@ -364,18 +364,21 @@ class TensorEntry:
     """Either "param" or "buffer"."""
     ipc_args: tuple | None = None
     cpu_tensor: torch.Tensor | None = None
+    shape: tuple[int, ...] = ()
+    dtype: str = ""
 
     @classmethod
     def from_tensor(cls, tensor: torch.Tensor, kind: str) -> "TensorEntry":
         from torch.multiprocessing.reductions import reduce_tensor
 
         tensor = tensor.detach()
+        metadata = {"shape": tuple(tensor.shape), "dtype": str(tensor.dtype)}
         if tensor.is_cuda:
             _, ipc_args = reduce_tensor(tensor)
-            return cls(kind=kind, ipc_args=ipc_args)
-        return cls(kind=kind, cpu_tensor=tensor.cpu())
+            return cls(kind=kind, ipc_args=ipc_args, **metadata)
+        return cls(kind=kind, cpu_tensor=tensor.cpu(), **metadata)
 
-    def rebuild(self, device_index: int) -> torch.Tensor:
+    def rebuild(self, device_index: int, *, retarget: bool = True) -> torch.Tensor:
         if self.ipc_args is None:
             assert self.cpu_tensor is not None
             return self.cpu_tensor
@@ -383,9 +386,11 @@ class TensorEntry:
 
         args = list(self.ipc_args)
         # Index 6 of the args from reduce_tensor is the device index. It must
-        # be retargeted to the local index since the daemon and the engine may
-        # have different CUDA_VISIBLE_DEVICES mappings.
-        args[6] = device_index
+        # normally be retargeted to the local index since the daemon and the
+        # engine may have different CUDA_VISIBLE_DEVICES mappings. A daemon
+        # mirror leaves it at the source index while opening a peer handle.
+        if retarget:
+            args[6] = device_index
         return rebuild_cuda_tensor(*args)
 
 

--- a/vllm/model_executor/model_loader/weight_cache/seed.py
+++ b/vllm/model_executor/model_loader/weight_cache/seed.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Daemon-to-daemon seeding for the IPC weight cache."""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+
+PEER_IPC_SEED_SOURCE = "peer_ipc"
+RDMA_SEED_SOURCE = "rdma"
+logger = init_logger(__name__)
+
+
+def build_manifest(entries: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    """Describe every exported tensor so a mirror can allocate it."""
+    return {
+        name: {
+            "shape": list(entry.shape),
+            "dtype": entry.dtype.removeprefix("torch."),
+            "is_param": entry.kind == "param",
+        }
+        for name, entry in entries.items()
+    }
+
+
+def manifest_dtype(dtype_name: str) -> torch.dtype:
+    dtype = getattr(torch, dtype_name, None)
+    if not isinstance(dtype, torch.dtype):
+        raise RuntimeError(
+            f"Weight-cache seed manifest uses unsupported dtype {dtype_name!r}"
+        )
+    return dtype
+
+
+def manifest_nbytes(manifest: Mapping[str, Mapping[str, Any]]) -> int:
+    total = 0
+    for metadata in manifest.values():
+        numel = 1
+        for dimension in metadata["shape"]:
+            numel *= dimension
+        total += numel * manifest_dtype(metadata["dtype"]).itemsize
+    return total
+
+
+class WeightCacheSeedSource(ABC):
+    name: str
+
+    @abstractmethod
+    def prepare_seed(
+        self,
+        entries: Mapping[str, Any],
+        state_tensors: Mapping[str, torch.Tensor],
+        gpu_id: int | None,
+    ) -> dict[str, Any]:
+        """Prepare source-side transfer metadata."""
+
+    @abstractmethod
+    def fill(
+        self,
+        manifest: Mapping[str, Mapping[str, Any]],
+        seed: Mapping[str, Any],
+        device: torch.device,
+    ) -> dict[str, torch.Tensor]:
+        """Copy source weights into the mirror and return local tensors."""
+
+    def close(self) -> None:
+        return None
+
+
+class PeerIpcSeedSource(WeightCacheSeedSource):
+    """Copy tensors through CUDA IPC handles on the same host."""
+
+    name = PEER_IPC_SEED_SOURCE
+
+    def prepare_seed(self, entries, state_tensors, gpu_id):
+        return {
+            "backend": self.name,
+            "entries": dict(entries),
+            "source_device_index": torch.accelerator.current_device_index(),
+            "source_gpu_id": gpu_id,
+        }
+
+    def fill(self, manifest, seed, device):
+        source_index = seed["source_device_index"]
+        source_gpu_id = seed.get("source_gpu_id")
+        if source_gpu_id is not None:
+            from vllm.model_executor.model_loader.weight_cache.protocol import (
+                get_physical_device_id,
+            )
+
+            if get_physical_device_id(source_index) != source_gpu_id:
+                raise RuntimeError(
+                    "Source CUDA IPC handle uses a device that is not visible at "
+                    "the same logical index in the mirror; use matching "
+                    "CUDA_VISIBLE_DEVICES mappings."
+                )
+        source_entries = seed["entries"]
+        result: dict[str, torch.Tensor] = {}
+        by_entry: dict[int, torch.Tensor] = {}
+        started = time.perf_counter()
+        for name, metadata in manifest.items():
+            entry = source_entries.get(name)
+            if entry is None:
+                raise RuntimeError(f"Source daemon omitted manifest entry {name!r}")
+            cached = by_entry.get(id(entry))
+            if cached is not None:
+                result[name] = cached
+                continue
+            source = entry.rebuild(source_index, retarget=False)
+            expected_dtype = manifest_dtype(metadata["dtype"])
+            expected_shape = torch.Size(metadata["shape"])
+            if source.shape != expected_shape or source.dtype != expected_dtype:
+                raise RuntimeError(
+                    f"Source entry {name!r} does not match its manifest: "
+                    f"{source.shape}/{source.dtype} vs "
+                    f"{expected_shape}/{expected_dtype}"
+                )
+            target = torch.empty_like(source, device=device)
+            target.copy_(source, non_blocking=True)
+            result[name] = target
+            by_entry[id(entry)] = target
+        torch.accelerator.synchronize()
+        total_bytes = manifest_nbytes(manifest)
+        elapsed = time.perf_counter() - started
+        logger.info(
+            "Copied %.2f GiB from peer weight-cache daemon in %.2fs (%.1f GiB/s)",
+            total_bytes / 1024**3,
+            elapsed,
+            total_bytes / 1024**3 / max(elapsed, 1e-9),
+        )
+        return result
+
+
+class RdmaSeedSource(WeightCacheSeedSource):
+    """Pull weights through the Mooncake TransferEngine."""
+
+    name = RDMA_SEED_SOURCE
+
+    def __init__(self, protocol: str = "rdma"):
+        self.protocol = protocol
+        self._engine = None
+        self._source_ptrs: list[int] = []
+        self._source_session: str | None = None
+
+    def _get_engine(self):
+        if self._engine is None:
+            from mooncake.engine import TransferEngine
+
+            from vllm.utils.network_utils import get_ip
+
+            engine = TransferEngine()
+            if engine.initialize(get_ip(), "P2PHANDSHAKE", self.protocol, "") != 0:
+                raise RuntimeError("Mooncake TransferEngine initialization failed")
+            self._engine = engine
+            self._source_session = f"{get_ip()}:{engine.get_rpc_port()}"
+        return self._engine
+
+    def prepare_seed(self, entries, state_tensors, gpu_id):
+        engine = self._get_engine()
+        regions: dict[str, tuple[int, int]] = {}
+        unique: dict[int, int] = {}
+        for name in entries:
+            tensor = state_tensors[name]
+            if not tensor.is_contiguous():
+                raise RuntimeError(f"Weight-cache tensor {name!r} is not contiguous")
+            pointer, length = tensor.data_ptr(), tensor.nbytes
+            regions[name] = (pointer, length)
+            unique[pointer] = max(unique.get(pointer, 0), length)
+        pointers, lengths = list(unique), list(unique.values())
+        if engine.batch_register_memory(pointers, lengths) != 0:
+            raise RuntimeError("Mooncake failed to register weight-cache tensors")
+        self._source_ptrs = pointers
+        return {
+            "backend": self.name,
+            "session": self._source_session,
+            "regions": regions,
+        }
+
+    def fill(self, manifest, seed, device):
+        from mooncake.engine import TransferEngine
+
+        from vllm.utils.network_utils import get_ip
+
+        session = seed.get("session")
+        if not session:
+            raise RuntimeError("Source daemon did not publish a Mooncake session")
+        engine = TransferEngine()
+        if engine.initialize(get_ip(), "P2PHANDSHAKE", self.protocol, "") != 0:
+            raise RuntimeError("Mooncake TransferEngine initialization failed")
+        result: dict[str, torch.Tensor] = {}
+        local_ptrs: list[int] = []
+        remote_ptrs: list[int] = []
+        lengths: list[int] = []
+        by_region: dict[tuple[int, int, str], torch.Tensor] = {}
+        for name, metadata in manifest.items():
+            remote_ptr, remote_length = seed["regions"][name]
+            dtype = manifest_dtype(metadata["dtype"])
+            shape = torch.Size(metadata["shape"])
+            key = (remote_ptr, remote_length, str(shape))
+            if key in by_region:
+                result[name] = by_region[key]
+                continue
+            target = torch.empty(shape, dtype=dtype, device=device)
+            if target.nbytes != remote_length:
+                raise RuntimeError(f"Weight-cache region size mismatch for {name!r}")
+            result[name] = by_region[key] = target
+            local_ptrs.append(target.data_ptr())
+            remote_ptrs.append(remote_ptr)
+            lengths.append(target.nbytes)
+        if engine.batch_register_memory(local_ptrs, lengths) != 0:
+            raise RuntimeError("Mooncake failed to register mirror tensors")
+        try:
+            ret = engine.batch_transfer_sync_read(
+                session, local_ptrs, remote_ptrs, lengths
+            )
+        finally:
+            engine.batch_unregister_memory(local_ptrs)
+        if ret != 0:
+            raise RuntimeError(f"Mooncake weight-cache read failed with status {ret}")
+        return result
+
+    def close(self) -> None:
+        if self._engine is not None and self._source_ptrs:
+            self._engine.batch_unregister_memory(self._source_ptrs)
+            self._source_ptrs = []
+
+
+def get_seed_source(name: str) -> WeightCacheSeedSource:
+    if name == PEER_IPC_SEED_SOURCE:
+        return PeerIpcSeedSource()
+    if name == RDMA_SEED_SOURCE:
+        return RdmaSeedSource()
+    raise ValueError(f"Unknown weight-cache seed backend {name!r}")


### PR DESCRIPTION



## Purpose

The weight cache daemon keeps loaded, quantized, and TP-sharded model weights
in GPU memory. Later vLLM engines can start quickly through CUDA IPC without
reading the checkpoint again.

## Test Plan


### 1. Start the source daemon

```bash
.venv/bin/python -m vllm.model_executor.model_loader.weight_cache.daemon \
  --model /path/to/model \
  --tensor-parallel-size 2 \
  --weight-cache-socket-dir /tmp/vllm-weight-cache
```

### 2. Start an engine using the daemon

```bash
vllm serve /path/to/model \
  --tensor-parallel-size 2 \
  --load-format ipc_cache \
  --model-loader-extra-config '{"socket_dir":"/tmp/vllm-weight-cache","fallback":false}'
```

`fallback=false` makes the engine fail if the daemon is unavailable. For
debugging, set it to `true` to fall back to regular disk loading.

### 3. Daemon-to-daemon transfer

#### Same host: `peer_ipc`

The second group of daemons copies weights from the first group:

```bash
.venv/bin/python -m vllm.model_executor.model_loader.weight_cache.daemon \
  --model /path/to/model \
  --tensor-parallel-size 2 \
  --weight-cache-socket-dir /tmp/vllm-weight-cache-mirror \
  --weight-cache-seed \
    /tmp/vllm-weight-cache/vllm_weight_cache_gpu0.sock,/tmp/vllm-weight-cache/vllm_weight_cache_gpu1.sock \
  --weight-cache-seed-backend peer_ipc
```

#### Cross host: `rdma`

Start the control plane on the source machine:

```bash
.venv/bin/python -m vllm.model_executor.model_loader.weight_cache.daemon \
  --model /path/to/model \
  --tensor-parallel-size 2 \
  --weight-cache-listen-addr 0.0.0.0:29700 \
  --weight-cache-seed-token my-secret
```

Start the mirror on the target machine:

```bash
.venv/bin/python -m vllm.model_executor.model_loader.weight_cache.daemon \
  --model /path/to/model \
  --tensor-parallel-size 2 \
  --weight-cache-seed 10.0.0.1:29700,10.0.0.1:29701 \
  --weight-cache-seed-backend rdma \
  --weight-cache-seed-token my-secret
```

### Notes

- Multiple `--weight-cache-seed` addresses are ordered by TP rank.
- The source and target must use the same model, revision, dtype, quantization
  configuration, and TP configuration.
- `peer_ipc` requires CUDA IPC visibility. Use `rdma` across hosts and install
  the Mooncake TransferEngine.
- `--weight-cache-seed-token` is used only for the cross-host TCP control plane;
  use a long random string.


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

