### PR TITLE
[Bugfix][ROCm] Avoid unsupported PDL warmup for fused QKV RMSNorm

### DIFF
--- a/vllm/models/common/ops/fused_qk_rmsnorm.py
+++ b/vllm/models/common/ops/fused_qk_rmsnorm.py
@@ -126,7 +126,7 @@ class FusedQKVRMSNormKernel(VllmTritonJitKernel["FusedQKVRMSNormKernel.CompileKe
             kv_in_stride=input_stride,
             kv_out_stride=(input_stride, kv_size),
             eps=float(hf_config.rms_norm_eps),
-            launch_pdl=(False, True),
+            launch_pdl=current_platform.is_arch_support_pdl(),
         )
 
     def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:


### PR DESCRIPTION
## Purpose

Fix DeepSeek-V4 startup on ROCm when generic JIT kernel warmup is enabled.

`FusedQKVRMSNormKernel` runtime dispatch selects `launch_pdl` with `current_platform.is_arch_support_pdl()`, but its warmup keys currently enumerate both `False` and `True`. On ROCm, compiling the unreachable `True` specialization lowers the CUDA GDC operations to `griddepcontrol.wait` and `griddepcontrol.launch_dependents`, which the AMDGPU linker rejects.

This mismatch was introduced by [#50176](https://github.com/vllm-project/vllm/pull/50176), which migrated the kernel to the shared warmup contract and added the unconditional `(False, True)` warmup space. The pre-migration runtime path already used the platform capability predicate and did not compile an unreachable PDL specialization on ROCm.

This PR makes warmup use the same platform capability decision as runtime dispatch:

- CUDA SM90 and newer return `True`, so warmup retains the PDL specialization used at runtime and stops compiling the unreachable non-PDL specialization.
- CUDA architectures older than SM90 return `False`, so warmup retains the non-PDL specialization used at runtime and does not attempt unsupported PDL compilation.
- ROCm, XPU, TPU, CPU, and other platforms that inherit the default capability return `False`, so warmup retains the only specialization runtime can request.

The active platform and device are fixed within each worker process; runtime does not dynamically fall back between the two values. The change therefore removes only unreachable startup compilation. It does not alter the Triton kernel, runtime dispatch, or inference behavior on any architecture.

AI assistance was used for this PR.

## Test Plan

```bash
python3 -m pytest -q tests/kernels/core/test_fused_q_kv_rmsnorm.py
python3 -m pytest -q tests/model_executor/test_jit_warmup.py
pre-commit run --files vllm/models/common/ops/fused_qk_rmsnorm.py
```

Run an unpatched-versus-patched compile-only reproducer for `FusedQKVRMSNormKernel` on ROCm, then start stock `deepseek-ai/DeepSeek-V4-Flash-0731` on four MI355X GPUs with TP=4, no speculative decoding, eager mode, and JIT warmup enabled.

## Test Result

- Unpatched ROCm: the platform reported no PDL support, but warmup generated both values. The first `launch_pdl=True` compile failed with the expected `griddepcontrol` linker error; a `launch_pdl=False` compile passed.
- Patched ROCm: warmup generated four keys, all with `launch_pdl=False`, and all four compiled.
- Fused Q/KV RMSNorm tests: `13 passed`.
- Shared JIT warmup tests: `38 passed`.
- Changed-file pre-commit checks: passed.
- Stock DeepSeek-V4 TP4: generic JIT warmup finished on all ranks, the server reached readiness, and one 128-input/64-output request completed successfully with zero failures.