### PR TITLE
[Bugfix][Quantization] Detect NVFP4 in ModelOpt mixed-precision checkpoints

### DIFF
--- a/tests/config/test_modelopt_mixed_nvfp4.py
+++ b/tests/config/test_modelopt_mixed_nvfp4.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVFP4 detection for ModelOpt MIXED_PRECISION checkpoints.
+
+A checkpoint that quantizes some layers to NVFP4 and others to FP8 declares
+``quant_algo: MIXED_PRECISION`` and resolves to ``modelopt_mixed``, so NVFP4
+has to be detected from the per-layer algorithms.
+"""
+
+import pytest
+
+from vllm.config.model import _modelopt_mixed_has_nvfp4
+
+
+def _quantized_layers(*algos: str) -> dict:
+    return {
+        "quantized_layers": {
+            f"model.layers.{i}.proj": {"quant_algo": algo}
+            for i, algo in enumerate(algos)
+        }
+    }
+
+
+def test_detects_nvfp4_alongside_another_algorithm():
+    """The shipped shape: FP8 attention projections, NVFP4 MLP."""
+    assert _modelopt_mixed_has_nvfp4(_quantized_layers("FP8", "NVFP4", "FP8"))
+
+
+def test_ignores_a_checkpoint_with_no_nvfp4_layer():
+    assert not _modelopt_mixed_has_nvfp4(_quantized_layers("FP8", "MXFP8"))
+
+
+def test_weight_only_nvfp4_does_not_count():
+    """W4A16_NVFP4 leaves activations in high precision, so nothing to fuse."""
+    assert not _modelopt_mixed_has_nvfp4(_quantized_layers("FP8", "W4A16_NVFP4"))
+
+
+@pytest.mark.parametrize(
+    "quant_config",
+    [None, {}, {"quantized_layers": None}, {"quantized_layers": ["NVFP4"]}],
+)
+def test_absent_or_malformed_config_is_not_nvfp4(quant_config):
+    assert not _modelopt_mixed_has_nvfp4(quant_config)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -115,6 +115,22 @@ _RUNNER_CONVERTS: dict[RunnerType, list[ConvertType]] = {
     "draft": [],
 }
 
+
+def _modelopt_mixed_has_nvfp4(quant_config: dict[str, Any] | None) -> bool:
+    """Whether a ModelOpt MIXED_PRECISION checkpoint quantizes any layer to NVFP4.
+
+    ``W4A16_NVFP4`` is excluded on purpose: it quantizes weights only, so there
+    is no activation quantization for the fusion passes to act on.
+    """
+    layers = (quant_config or {}).get("quantized_layers")
+    if not isinstance(layers, dict):
+        return False
+    return any(
+        isinstance(info, dict) and info.get("quant_algo") == "NVFP4"
+        for info in layers.values()
+    )
+
+
 AttnTypeStr = Literal[
     "decoder", "encoder", "encoder_only", "encoder_decoder", "attention_free", "hybrid"
 ]
@@ -2160,13 +2176,20 @@ class ModelConfig:
         return getattr(self.hf_config, "quantization_config", None) is not None
 
     def is_nvfp4_quantized(self) -> bool:
+        quant_config = self.model_arch_config.quantization_config
+
         # ModelOpt NVFP4 checkpoints resolve to modelopt_fp4 quantization method
         if self.quantization in ("modelopt_fp4",):
             return True
 
+        # A checkpoint mixing NVFP4 with another algorithm declares
+        # quant_algo MIXED_PRECISION and resolves to modelopt_mixed, so the
+        # per-layer algorithms decide.
+        if self.quantization == "modelopt_mixed":
+            return _modelopt_mixed_has_nvfp4(quant_config)
+
         # For Compressed Tensors we look for `"format": "nvfp4-pack-quantized"`
         # in the quantization config
-        quant_config = self.model_arch_config.quantization_config
         return (
             self.quantization == "compressed-tensors"
             and quant_config is not None


### PR DESCRIPTION
## Purpose

`ModelConfig.is_nvfp4_quantized()` detects ModelOpt NVFP4 by checking that the resolved quantization method is `modelopt_fp4`. A checkpoint that quantizes some layers to NVFP4 and others to FP8 declares `quant_algo: MIXED_PRECISION`, so `ModelOptMixedPrecisionConfig.override_quantization_method` claims it and `self.quantization` becomes `modelopt_mixed`. The check returns False even though most of the model is NVFP4.

The consequence is not cosmetic. `enable_act_fusion()` (`vllm/config/vllm.py`) enables `pass_config.fuse_act_quant` for FP4 models precisely because, in its own words, *"FP4 quant is always custom so Inductor cannot fuse it"*. With NVFP4 undetected, `fuse_act_quant` stays False at **every** optimization level, `ActivationQuantFusionPass` never runs, and the fused CUDA op `silu_and_mul_nvfp4_quant` is unreachable, since that pass is its only caller. The model then runs SiLU-and-mul and `scaled_fp4_quant` as two kernels with a bf16 intermediate written to and read back from DRAM.

Affected checkpoints include `nvidia/Qwen3.8-27B-NVFP4` and `RadixArk/Qwen3.8-27B-NVFP4`, both `MIXED_PRECISION` with 208 FP8 layers and 193 NVFP4 layers:

```
config.json -> quantization_config
  quant_algo: MIXED_PRECISION
  group_0: W8 A8   (208 targets, attention projections)
  group_1: W4 A4   (193 targets, MLP + lm_head)
```

Passing `--quantization modelopt_fp4` explicitly does not help: `override_quantization_method` overwrites `self.quantization` and breaks out, so the resolved value is `modelopt_mixed` regardless.

## Fix

When the resolved method is `modelopt_mixed`, decide from the per-layer algorithms. `W4A16_NVFP4` is excluded deliberately: it quantizes weights only, so there is no activation quantization for the fusion passes to act on.

## Not a duplicate of #55367

#55367 fixes the same function for **compressed-tensors** mixed-precision checkpoints, where the top-level `format` is `mixed-precision` and NVFP4 has to be read out of `config_groups`. This change fixes the **ModelOpt** branch, where `quant_algo` is `MIXED_PRECISION` and the resolved method is `modelopt_mixed`. That PR's diff does not reference modelopt at all, so the ModelOpt path stays broken after it merges, and this change leaves the compressed-tensors path untouched.

The two touch the same function and will conflict textually. Either order works; whichever lands second needs a trivial rebase. Happy to fold this into #55367 instead if maintainers prefer a single change.

## Test

```
pre-commit run --files vllm/config/model.py tests/config/test_modelopt_mixed_nvfp4.py
```

All hooks pass, including `ruff check`, `ruff format` and `mypy-3.10`.

New unit test `tests/config/test_modelopt_mixed_nvfp4.py` covers NVFP4 mixed with another algorithm, a mixed checkpoint with no NVFP4 layer, weight-only `W4A16_NVFP4`, and absent or malformed configs. A separate filename is used so it does not collide with the test file added by #55367.

The predicate was also run against the published `nvidia/Qwen3.8-27B-NVFP4` `config.json`, which returns True where it previously returned False.

## Measured effect

DGX Spark (GB10, sm121), `RadixArk/Qwen3.8-27B-NVFP4`, `vllm/vllm-openai:v0.28.0`.

Kernel level, median of 50 CUDA-event timings after 10 warmups, `intermediate_size=17408`, 64 layers:

| M | unfused pair | fused | per forward pass |
|---|---|---|---|
| 2048 | 1.413 ms/layer | 0.755 | 90.4 -> 48.3 ms |
| 8192 | 5.437 ms/layer | 2.920 | 347.9 -> 186.9 ms |

End to end, TTFT at BS1 with `max_tokens=1` and randomised `prompt_token_ids` so prefix caching cannot serve them, median of 15, four arms in one server lifecycle each on one node:

| vs no fusion | M=1024 | M=2048 | M=4096 | M=8192 |
|---|---|---|---|---|
| `fuse_act_quant` | -6.7% | -30.8% | -4.4% | -6.7% |
| `fuse_norm_quant` | -1.9% | -26.8% | +0.0% | -1.7% |
| both | -4.6% | -29.6% | -4.0% | -5.9% |

No arm is slower than baseline at any prefill length. The M=2048 column overstates: the unfused baseline is bimodal at that shape across server restarts (859.8 ms and 1172.1 ms for identical config in two runs), while M=8192 reproduced within 2%. The other columns are the trustworthy ones.

Decode was checked separately at 32K cached prefix + 2K ISL + 256 OSL with MTP-3, concurrency 1/4/8, both arms as cells of one sweep on one node, prefix cache hit rate 85.3% in both:

| concurrency | ITL | output throughput |
|---|---|---|
| 1 | 38.06 -> 37.99 ms | 20.03 -> 20.00 tok/s |
| 4 | 53.44 -> 52.74 ms | 46.39 -> 46.40 tok/s |
| 8 | 82.51 -> 81.46 ms | 60.27 -> 61.50 tok/s |

Inter-token latency is flat to slightly better at every concurrency, so enabling the fusion does not cost decode.

## Accuracy

This change does not introduce or modify a kernel. It only lets an existing, already-default fusion pass apply to a checkpoint class it was being skipped for, and the same pass and fused op already run by default for non-mixed NVFP4 checkpoints. Greedy decoding was smoke-tested on both arms and produced identical output. A full accuracy eval was not run, so if maintainers want one before merging, please say which suite.

## AI assistance

AI assistance was used for this change. I have reviewed every changed line, run the tests and hooks above, and collected the measurements myself.
