### PR TITLE
[ROCm][MLA] Enable AITER mask0 decode for DSpark

### DIFF
--- a/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
@@ -16,6 +16,7 @@ if not current_platform.is_rocm():
 
 from vllm.v1.attention.backends.mla import rocm_aiter_mla  # noqa: E402
 from vllm.v1.attention.backends.mla.rocm_aiter_mla import (  # noqa: E402
+    AiterMLABackend,
     AiterMLAHelper,
     AiterMLAImpl,
     AiterMLAMetadataBuilder,
@@ -87,6 +88,7 @@ def _builder(
     kv_cache_dtype: str = "auto",
     dcp_world_size: int = 1,
     dcp_rank: int = 0,
+    non_causal: bool = False,
 ):
     stub = SimpleNamespace(
         device=torch.device("cpu"),
@@ -96,6 +98,7 @@ def _builder(
         _decode_num_heads=num_heads * dcp_world_size,
         dcp_world_size=dcp_world_size,
         dcp_rank=dcp_rank,
+        non_causal_multi_token_decode=non_causal,
         cp_kv_cache_interleave_size=1,
         # Mirrors the production constructor: configuration decides whether the
         # segmented route is available, query length decides per batch.
@@ -153,6 +156,42 @@ def test_backend_declares_uniform_batch_support():
         AiterMLAMetadataBuilder._cudagraph_support
         == rocm_aiter_mla.AttentionCGSupport.UNIFORM_BATCH
     )
+
+
+def test_non_causal_capability_fails_closed_on_old_aiter(monkeypatch):
+    import vllm.platforms.rocm as rocm_platform
+
+    def old_decode(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(rocm_platform, "on_gfx950", lambda: True)
+    monkeypatch.setitem(
+        sys.modules, "aiter.mla", SimpleNamespace(mla_decode_fwd=old_decode)
+    )
+    rocm_aiter_mla._aiter_mla_non_causal_supported.cache_clear()
+    try:
+        assert not AiterMLABackend.supports_non_causal()
+    finally:
+        rocm_aiter_mla._aiter_mla_non_causal_supported.cache_clear()
+
+
+def test_non_causal_capability_accepts_aiter_mask0_api(monkeypatch):
+    import vllm.platforms.rocm as rocm_platform
+
+    def mask0_decode(*args, causal=True, **kwargs):
+        pass
+
+    monkeypatch.setattr(rocm_platform, "on_gfx950", lambda: True)
+    monkeypatch.setitem(
+        sys.modules, "aiter.mla", SimpleNamespace(mla_decode_fwd=mask0_decode)
+    )
+    rocm_aiter_mla._aiter_mla_non_causal_supported.cache_clear()
+    try:
+        assert AiterMLABackend.supports_non_causal()
+        assert AiterMLAMetadataBuilder.supports_non_causal_multi_token_decode
+        assert AiterMLAMetadataBuilder.supports_non_causal_multi_token_dcp
+    finally:
+        rocm_aiter_mla._aiter_mla_non_causal_supported.cache_clear()
 
 
 def test_dcp_verify_row_view_is_causal_per_row():
@@ -241,7 +280,7 @@ def test_dcp_verify_row_view_uses_static_graph_bound():
     assert view.max_kv_seq_len == 3072
 
 
-def test_dcp_fp8_verify_build_uses_segmented(monkeypatch):
+def test_dcp_fp8_causal_warmup_uses_segmented_for_noncausal_group(monkeypatch):
     qlen = 4
     monkeypatch.setattr(rocm_aiter_mla, "_segmented_mla_decode_supported", lambda: True)
 
@@ -251,6 +290,7 @@ def test_dcp_fp8_verify_build_uses_segmented(monkeypatch):
             dcp_world_size=2,
             kv_cache_dtype="fp8",
             kernel_block_size=2,
+            non_causal=True,
         ),
         block_table_tensor=torch.tensor([[0, 1, 2], [10, 11, 12]], dtype=torch.int32),
         seq_lens_device=torch.tensor([5, 6], dtype=torch.int32),
@@ -319,6 +359,52 @@ def test_single_token_dcp_decode_returns_unpadded_lse(monkeypatch):
     assert lse is not None
     assert output.shape[1] == decode_heads
     assert lse.shape == (num_tokens, decode_heads)
+
+
+def test_non_causal_dcp_decode_calls_aiter_mask0_and_returns_lse(monkeypatch):
+    """K3 DSpark's 4-token DCP block reaches native AITER with mask0."""
+    num_heads, dcp_world_size, qlen = 8, 8, 4
+    decode_heads = num_heads * dcp_world_size
+    head_dim = 576
+    captured = {}
+
+    def fake_aiter_decode(q, kv_buffer, out, *args, **kwargs):
+        captured.update(kwargs)
+        return out, torch.zeros(qlen, q.shape[1], dtype=torch.float32)
+
+    monkeypatch.setattr(
+        rocm_aiter_mla, "_get_aiter_mla_decode", lambda: fake_aiter_decode
+    )
+
+    impl = object.__new__(AiterMLAImpl)
+    impl.num_heads = num_heads
+    impl.dcp_world_size = dcp_world_size
+    impl.kv_cache_dtype = "fp8"
+    impl.kv_lora_rank = 512
+    impl.qk_rope_head_dim = 64
+    impl.scale = head_dim**-0.5
+    decode = SimpleNamespace(
+        max_qo_len=qlen,
+        qo_indptr=torch.tensor([0, qlen], dtype=torch.int32),
+        paged_kv_indptr=torch.tensor([0, 8], dtype=torch.int32),
+        paged_kv_indices=torch.arange(8, dtype=torch.int32),
+        paged_kv_last_page_len=torch.ones(1, dtype=torch.int32),
+        use_gluon_decode=False,
+        use_gluon_verify=False,
+        dcp_verify=None,
+        has_persistent_metadata=False,
+        attn_out_dtype=torch.bfloat16,
+    )
+    attn_metadata = SimpleNamespace(decode=decode, causal=False, work_meta_data=None)
+    layer = SimpleNamespace(_q_scale=torch.tensor(1.0), _k_scale=torch.tensor(1.0))
+    q = torch.zeros(qlen, decode_heads, head_dim, dtype=torch.bfloat16)
+
+    output, lse = impl.forward_mqa(q, torch.zeros(1, 1, head_dim), attn_metadata, layer)
+
+    assert captured["causal"] is False
+    assert captured["return_lse"] is True
+    assert output.shape == (qlen, decode_heads, 512)
+    assert lse is not None and lse.shape == (qlen, decode_heads)
 
 
 def test_verify_partial_attention_merge():
@@ -623,6 +709,45 @@ def test_mtp_decode_qlen4_keeps_uniform_rows_with_metadata(monkeypatch):
     assert metadata.has_persistent_metadata
     assert get_mla_metadata_v1.call_args.kwargs["max_seqlen_qo"] == 4
     assert get_mla_metadata_v1.call_args.kwargs["uni_seqlen_qo"] == 4
+
+
+def test_non_causal_dcp_uses_native_mask0_metadata(monkeypatch):
+    """DSpark DCP must use AITER mask0 metadata, not causal segmented verify."""
+    get_mla_metadata_v1 = mock.MagicMock()
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter",
+        SimpleNamespace(get_mla_metadata_v1=get_mla_metadata_v1),
+    )
+    monkeypatch.setattr(
+        rocm_aiter_mla, "_expand_page_indices_kernel", _NoOpTritonKernel()
+    )
+
+    builder = _builder(
+        mtp_decode_qlen=4,
+        num_heads=8,
+        kv_cache_dtype="fp8",
+        dcp_world_size=8,
+        non_causal=True,
+    )
+    # Prove causality, rather than missing segmented-kernel support, selects the
+    # native path.
+    builder._supports_segmented_dcp_verify = True
+    builder._current_build_is_causal = False
+    metadata = AiterMLAMetadataBuilder._build_decode(
+        builder,
+        block_table_tensor=torch.arange(16, dtype=torch.int32).view(2, 8),
+        seq_lens_device=torch.tensor([7, 5], dtype=torch.int32),
+        max_seq_len=7,
+        query_start_loc_cpu=torch.tensor([0, 4, 8], dtype=torch.int32),
+        query_start_loc_device=torch.tensor([0, 4, 8], dtype=torch.int32),
+        num_decode_tokens=8,
+        dcp_tot_seq_lens_device=torch.tensor([56, 40], dtype=torch.int32),
+    )
+
+    assert metadata.dcp_verify is None
+    assert metadata.has_persistent_metadata
+    assert get_mla_metadata_v1.call_args.args[5] is False
 
 
 def test_min_kv_seq_len_ignores_cudagraph_padding_rows(monkeypatch):

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -598,7 +598,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 assert non_spec_state_indices_tensor is not None
                 decode_conv_indices = non_spec_state_indices_tensor[
                     : mixed_qkv_ns.size(0)
-                ]
+                ].contiguous()
                 # Sibling beta and, for full-rank gates, output-gate views
                 # remain live, so write the conv output separately.
                 packed_conv_out = torch.empty(

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import functools
+import inspect
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, Final
@@ -144,6 +145,26 @@ def _aiter_mla_native_h24_supported() -> bool:
 
 
 @functools.lru_cache(maxsize=1)
+def _aiter_mla_non_causal_supported() -> bool:
+    """Whether AITER ships the gfx950 MLA mask0 API used by DSpark.
+
+    AITER added the ``causal`` argument and the corresponding persistent mask0
+    kernels in v0.1.21. Older wheels silently have causal-only MLA decode, so
+    capability selection must fail closed instead of routing DSpark into them.
+    """
+    try:
+        from vllm.platforms.rocm import on_gfx950
+
+        if not on_gfx950():
+            return False
+        from aiter.mla import mla_decode_fwd
+
+        return "causal" in inspect.signature(mla_decode_fwd).parameters
+    except (ImportError, ModuleNotFoundError, ValueError, TypeError):
+        return False
+
+
+@functools.lru_cache(maxsize=1)
 def _gluon_mla_decode_supported() -> bool:
     """The small-head Gluon MLA decode kernel only has a gfx950 (CDNA4) build.
 
@@ -259,6 +280,10 @@ class AiterMLABackend(MLACommonBackend):
     def get_builder_cls() -> type["AiterMLAMetadataBuilder"]:
         return AiterMLAMetadataBuilder
 
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        return _aiter_mla_non_causal_supported()
+
 
 @dataclass
 class AiterMLADCPVerifyMetadata:
@@ -346,6 +371,8 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
     #  https://github.com/vllm-project/vllm/issues/22945
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+    supports_non_causal_multi_token_decode: ClassVar[bool] = True
+    supports_non_causal_multi_token_dcp: ClassVar[bool] = True
 
     @staticmethod
     def _uniform_padded_mtp_qo_len(
@@ -918,6 +945,9 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         dcp_tot_seq_lens_device: torch.Tensor | None,
     ) -> AiterMLADecodeMetadata:
         device = self.device
+        # build() sets this for the synchronous super().build() call. Use a
+        # causal default for direct helper calls in tests and future callers.
+        is_causal = getattr(self, "_current_build_is_causal", True)
         num_reqs = seq_lens_device.size(0)
         qo_len = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         max_qo_len = qo_len.max().item()
@@ -963,14 +993,17 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             int(max_qo_len),
             self._kv_cache_dtype_str,
         )
-        use_gluon_verify = AiterMLAHelper.use_gluon_verify(
-            self._decode_num_heads,
-            int(max_qo_len),
-            self._kv_cache_dtype_str,
-            self.dcp_world_size,
+        use_gluon_verify = (
+            AiterMLAHelper.use_gluon_verify(
+                self._decode_num_heads,
+                int(max_qo_len),
+                self._kv_cache_dtype_str,
+                self.dcp_world_size,
+            )
+            and is_causal
         )
         use_segmented_dcp_verify = (
-            self._supports_segmented_dcp_verify and max_qo_len > 1
+            self._supports_segmented_dcp_verify and max_qo_len > 1 and is_causal
         )
 
         # Segmented DCP verify carries its own per-row subpage table, so the
@@ -1065,7 +1098,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 paged_kv_last_page_len,
                 self._num_attention_heads,
                 1,
-                True,
+                is_causal,
                 self._mla_work_meta_data,
                 self._mla_work_info_set,
                 self._mla_work_indptr,
@@ -1135,9 +1168,13 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> AiterMLAMetadata:
-        attn_metadata = super().build(
-            common_prefix_len, common_attn_metadata, fast_build
-        )
+        self._current_build_is_causal = common_attn_metadata.causal
+        try:
+            attn_metadata = super().build(
+                common_prefix_len, common_attn_metadata, fast_build
+            )
+        finally:
+            del self._current_build_is_causal
         if (
             attn_metadata.decode is not None
             and attn_metadata.decode.has_persistent_metadata
@@ -1889,7 +1926,11 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 decode.attn_out_dtype,
             )
 
-        if self.dcp_world_size > 1 and int(decode.max_qo_len) > 1:
+        if (
+            attn_metadata.causal
+            and self.dcp_world_size > 1
+            and int(decode.max_qo_len) > 1
+        ):
             raise RuntimeError(
                 "ROCM_AITER_MLA DCP multi-token verify requires segmented MLA."
             )
@@ -1940,7 +1981,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             )
 
         lse = None
-        if self.dcp_world_size > 1:
+        if self.dcp_world_size > 1 or not attn_metadata.causal:
             # The vLLM custom-op wrapper exposes only the in-place output and
             # drops aiter's final LSE, which the cross-shard merge needs, so go
             # through aiter's native entry point on the DCP path.
@@ -1954,13 +1995,15 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 decode.paged_kv_last_page_len,
                 decode.max_qo_len,
                 sm_scale=self.scale,
-                return_lse=True,
+                return_lse=self.dcp_world_size > 1,
+                causal=attn_metadata.causal,
                 **mla_kwargs,
             )
-            assert lse is not None, (
-                "aiter mla_decode_fwd(return_lse=True) returned no LSE; upgrade "
-                "aiter to a build with decode LSE support."
-            )
+            if self.dcp_world_size > 1:
+                assert lse is not None, (
+                    "aiter mla_decode_fwd(return_lse=True) returned no LSE; "
+                    "upgrade aiter to a build with decode LSE support."
+                )
         else:
             rocm_aiter_ops.mla_decode_fwd(
                 mla_padded_q,


### PR DESCRIPTION
## Purpose

Enable `ROCM_AITER_MLA` for Kimi-K3 DSpark's non-causal multi-token
decode path on gfx950.

DSpark generates a query block in parallel. Every query in that block must
attend to the same committed KV prefix, rather than to a causal triangular
suffix within the draft block. Older AITER builds expose only causal MLA
decode, so vLLM currently selects `TRITON_MLA` for the draft model even when
the target model uses `ROCM_AITER_MLA`.

AITER v0.1.21.post1 includes the `causal` decode argument and gfx950 mask0
persistent kernels from ROCm/aiter#4565. This PR wires that capability into
the ROCm MLA backend while preserving all existing causal target paths.

## Changes

- Detect the AITER `causal` API at runtime and advertise non-causal support
  only on gfx950. Older AITER installations fail closed during backend
  selection.
- Pass the current batch's causality to AITER metadata generation and native
  `mla_decode_fwd`.
- Route non-causal DSpark decode around the causal-only Gluon verify and
  segmented DCP verify paths.
- Keep causal target verification unchanged:
  - non-DCP small-head BF16 verification may use Gluon;
  - DCP multi-token verification uses segmented MLA;
  - ordinary target decode uses native AITER MLA.
- Return per-row LSE from non-causal DCP decode so the existing cross-rank
  reducer can merge partial attention results.
- Materialize the speculative KDA state-index slice as contiguous before the
  fused kernel consumes it. This is a separate prerequisite commit for
  full/piecewise graph execution.

The AITER implementation changes only
`vllm/v1/attention/backends/mla/rocm_aiter_mla.py`. It does not modify common
MLA interfaces or CUDA/non-ROCm attention backends.

For Kimi-K3 DSpark K=4 with FP8 draft KV, the observed kernels are:

| Topology | Draft shape | AITER kernel |
| --- | --- | --- |
| TP8 | padded H16, Q4 | `mla_a8w8_qh16_qseqlen4_gqaratio16_msk0_v3_ps` |
| TP8/DCP8 | gathered H64, Q4 | `mla_a8w8_qh32_qseqlen4_gqaratio32_msk0_lse_ps` |

The DCP shape is internally folded from H64/Q4 to the H32/Q4 kernel
configuration. The `_lse` variant supplies the statistics required for DCP
merge. Non-causal decode does not need causal round-robin position remapping.

## Test Plan

```bash
ruff check \
  vllm/v1/attention/backends/mla/rocm_aiter_mla.py \
  tests/v1/attention/test_rocm_aiter_mla_mtp_split.py

ruff format --check \
  vllm/v1/attention/backends/mla/rocm_aiter_mla.py \
  tests/v1/attention/test_rocm_aiter_mla_mtp_split.py

python3 -m pytest -q \
  tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
```

Hardware validation used MI355X and:

```text
vllm/vllm-openai-rocm@sha256:67d4317ba8aa9e60171c4eaa74eda3d1e877011c809aa186687b524ab4472aaa
AITER v0.1.21.post1
Kimi-K3 TP8 and TP8/DCP8
DSpark K=4
FP8 target and draft KV caches
```

## Test Result

### Unit and static tests

- `ruff check`: passed
- `ruff format --check`: passed
- Python compile check: passed
- `test_rocm_aiter_mla_mtp_split.py`: **55 passed**
- The capability tests verify that old AITER APIs fail closed and the new
  `causal` API enables the backend.
- Routing tests cover causal warmup, non-causal metadata, DCP LSE, and the
  native mask0 call.

### Kernel correctness

Standalone gfx950 numerical comparison for FP8 Q/KV, H64, Q4, QK dimension
576, value dimension 512, `causal=False`, and `return_lse=True`:

| Metric | Result |
| --- | ---: |
| Output maximum absolute error | 0.010949 |
| Output mean absolute error | 0.001723 |
| LSE maximum absolute error | 0.000005 |

The run loaded
`mla_a8w8_qh32_qseqlen4_gqaratio32_msk0_lse_ps`.

### End-to-end correctness

Real-weight Kimi-K3 TP8/DCP8 with DSpark K4, FP8 target/draft KV, greedy
sampling, and real block rejection:

| Evaluation | Accuracy | Invalid responses | Output tokens | Duration |
| --- | ---: | ---: | ---: | ---: |
| GSM8K 5-shot, N=50, concurrency=64 | **50/50** | **0/50** | 5,339 | 28.18 s |

A dummy-weight `FULL_AND_PIECEWISE` graph capture/replay also completed a
routed request while loading the FP8 mask0+LSE kernel on all eight ranks.

### Performance

Isolated draft-MLA kernel timing on one MI355X:

| Batch | Rank-local context | Triton | AITER | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1,024 | 54.44 us | 55.58 us | 0.98x |
| 8 | 1,024 | 69.11 us | 54.71 us | 1.26x |
| 8 | 8,192 | 553.36 us | 58.86 us | 9.40x |
| 16 | 8,192 | 1,095.28 us | 76.24 us | 14.37x |

Real-weight fixed-random serving used 65,536 input tokens, 512 output tokens,
greedy sampling, `ignore_eos`, two warmup requests, full graphs, and synthetic
acceptance length 3.36 for K4:

| Topology | Variant | Output tok/s | Mean TTFT | Mean TPOT | Errors |
| --- | --- | ---: | ---: | ---: | ---: |
| TP8, concurrency 1 | no spec | 36.72 | 4.338 s | 18.79 ms | 0 |
| TP8, concurrency 1 | Triton K4 | 64.14 | 4.248 s | 7.31 ms | 0 |
| TP8, concurrency 1 | AITER K4 | 65.65 | 4.251 s | 6.94 ms | 0 |
| TP8/DCP8, concurrency 40 | no spec | 99.39 | 102.853 s | 169.92 ms | 0 |
| TP8/DCP8, concurrency 40 | Triton K4 | 107.75 | 99.501 s | 145.03 ms | 0 |
| TP8/DCP8, concurrency 40 | AITER K4 | 108.78 | 98.776 s | 143.69 ms | 0 |

AITER versus Triton improves output throughput by 2.35% at TP8/concurrency 1
and 0.96% at TP8/DCP8/concurrency 40. The larger isolated-kernel gain shows
that draft MLA is accelerated, while the end-to-end result remains bounded by
the draft MoE, target verification, collectives, and prefill work.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan and commands are provided.
- [x] Unit, numerical, end-to-end correctness, and performance results are
  included.
- [x] No documentation update is required for a backend capability change.

</details>

**BEFORE SUBMITTING, PLEASE READ
<https://docs.vllm.ai/en/latest/contributing>**
