### PR TITLE
[Examples] Disable APC in prefix_caching_offline baseline

### DIFF
--- a/examples/features/automatic_prefix_caching/prefix_caching_offline.py
+++ b/examples/features/automatic_prefix_caching/prefix_caching_offline.py
@@ -35,10 +35,15 @@ sampling_params = SamplingParams(temperature=0.0)
 
 
 def main():
-    # Create an LLM without prefix caching as a baseline.
-    regular_llm = LLM(model="facebook/opt-125m", gpu_memory_utilization=0.4)
+    # Create an LLM with prefix caching disabled as a baseline.
+    # APC is enabled by default for supported models, so disable it explicitly.
+    regular_llm = LLM(
+        model="facebook/opt-125m",
+        enable_prefix_caching=False,
+        gpu_memory_utilization=0.4,
+    )
 
-    print("Results without `enable_prefix_caching`")
+    print("Results with `enable_prefix_caching=False`")
 
     # ruff: noqa: E501
     # Generate texts from the prompts. The output is a list of RequestOutput objects


### PR DESCRIPTION
## Summary
- Automatic prefix caching is enabled by default for supported models (`CacheConfig.enable_prefix_caching=True`).
- The baseline `LLM()` in `examples/features/automatic_prefix_caching/prefix_caching_offline.py` did not pass `enable_prefix_caching=False`, so it was not actually a no-cache baseline.
- Set `enable_prefix_caching=False` on the baseline and update the related print/comment text.

## Test plan
- [ ] Confirm `CacheConfig.enable_prefix_caching` defaults to `True` on main
- [ ] Confirm baseline `LLM(...)` now passes `enable_prefix_caching=False`
- [ ] Smoke: example still imports / runs the two LLM constructions as intended