### PR TITLE
[Security] Scan DeepSeek-V3.2 tool messages in linear time

### DIFF
--- a/tests/test_request_input_bounds.py
+++ b/tests/test_request_input_bounds.py
@@ -286,6 +286,142 @@ def test_encode_messages_scans_last_user_once_per_conversation(
     assert calls == 1
 
 
+def _openai_tool_call(name: str = "fn") -> dict:
+    return {
+        "type": "function",
+        "function": {"name": name, "arguments": '{"x": 1}'},
+    }
+
+
+def _tool_conversation(num_tools: int) -> list[dict]:
+    tool_calls = [_openai_tool_call(f"fn{i}") for i in range(num_tools)]
+    messages: list[dict] = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "tool_calls": tool_calls},
+    ]
+    messages.extend(
+        {"role": "tool", "content": f"r{i}", "tool_call_id": str(i)}
+        for i in range(num_tools)
+    )
+    messages.append({"role": "user", "content": "go"})
+    return messages
+
+
+def test_encode_messages_preserves_tool_result_prompt():
+    prompt = deepseek_v32_encoding.encode_messages(
+        _tool_conversation(2),
+        thinking_mode="chat",
+    )
+
+    assert prompt == (
+        "<｜begin▁of▁sentence｜><｜User｜>hi<｜Assistant｜></think>"
+        "\n\n<｜DSML｜function_calls>\n"
+        '<｜DSML｜invoke name="fn0">\n'
+        '<｜DSML｜parameter name="x" string="false">1</｜DSML｜parameter>\n'
+        "</｜DSML｜invoke>\n"
+        '<｜DSML｜invoke name="fn1">\n'
+        '<｜DSML｜parameter name="x" string="false">1</｜DSML｜parameter>\n'
+        "</｜DSML｜invoke>\n"
+        "</｜DSML｜function_calls><｜end▁of▁sentence｜>"
+        "\n\n<function_results>\n<result>r0</result>\n<result>r1</result>\n"
+        "</function_results>\n\n</think>"
+        "<｜User｜>go<｜Assistant｜></think>"
+    )
+
+
+def test_encode_messages_does_not_rescan_each_tool_message(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = 0
+    original = deepseek_v32_encoding._previous_non_tool_index
+
+    def counted_previous_non_tool_index(messages, index):
+        nonlocal calls
+        calls += 1
+        return original(messages, index)
+
+    monkeypatch.setattr(
+        deepseek_v32_encoding,
+        "_previous_non_tool_index",
+        counted_previous_non_tool_index,
+    )
+
+    deepseek_v32_encoding.encode_messages(
+        _tool_conversation(80),
+        thinking_mode="chat",
+    )
+
+    assert calls == 1
+
+
+def test_encode_messages_rejects_tool_output_without_assistant():
+    with pytest.raises(ValueError, match="Invalid messages at"):
+        deepseek_v32_encoding.encode_messages(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "tool", "content": "r", "tool_call_id": "1"},
+            ],
+            thinking_mode="chat",
+        )
+
+
+def test_encode_messages_rejects_tool_output_without_matching_tool_calls():
+    with pytest.raises(ValueError, match="No tool calls but found tool output"):
+        deepseek_v32_encoding.encode_messages(
+            [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [_openai_tool_call()],
+                },
+                {"role": "tool", "content": "r0", "tool_call_id": "0"},
+                {"role": "tool", "content": "r1", "tool_call_id": "1"},
+            ],
+            thinking_mode="chat",
+        )
+
+
+def test_encode_messages_tool_results_follow_context_assistant():
+    context = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [_openai_tool_call("a"), _openai_tool_call("b")],
+        },
+    ]
+    prompt = deepseek_v32_encoding.encode_messages(
+        [
+            {"role": "tool", "content": "ra", "tool_call_id": "0"},
+            {"role": "tool", "content": "rb", "tool_call_id": "1"},
+        ],
+        thinking_mode="chat",
+        context=context,
+        add_default_bos_token=False,
+    )
+
+    assert prompt == (
+        "\n\n<function_results>\n<result>ra</result>\n<result>rb</result>\n"
+        "</function_results>\n\n</think>"
+    )
+
+
+def test_render_message_resolves_tool_owner_without_cached_index():
+    messages = _tool_conversation(2)
+    last_user_idx = deepseek_v32_encoding.find_last_user_index(messages)
+
+    text = deepseek_v32_encoding.render_message(
+        3,
+        messages,
+        thinking_mode="chat",
+        last_user_idx=last_user_idx,
+    )
+
+    assert "<result>r1</result>" in text
+    assert "</function_results>" in text
+
+
 @pytest.mark.parametrize(
     "encoding_module",
     ENCODING_MODULES,

--- a/vllm/tokenizers/deepseek_v32_encoding.py
+++ b/vllm/tokenizers/deepseek_v32_encoding.py
@@ -118,11 +118,19 @@ def find_last_user_index(messages: list[dict[str, Any]]) -> int:
     return last_user_index
 
 
+def _previous_non_tool_index(messages: list[dict[str, Any]], index: int) -> int:
+    prev = index - 1
+    while prev >= 0 and messages[prev].get("role") == "tool":
+        prev -= 1
+    return prev
+
+
 def render_message(
     index: int,
     messages: list[dict[str, Any]],
     thinking_mode: str,
     last_user_idx: int | None = None,
+    last_non_tool_idx: int | None = None,
 ) -> str:
     if not (0 <= index < len(messages)):
         raise ValueError(
@@ -189,19 +197,19 @@ def render_message(
             prompt += thinking_end_token
 
     elif role == "tool":
-        prev_assistant_idx = index - 1
-        assistant_msg = messages[prev_assistant_idx]
-        while prev_assistant_idx >= 0 and assistant_msg.get("role") == "tool":
-            prev_assistant_idx -= 1
-            assistant_msg = messages[prev_assistant_idx]
-
-        if not (
-            index == 0
-            or prev_assistant_idx >= 0
-            and assistant_msg.get("role") == "assistant"
+        prev_assistant_idx = (
+            last_non_tool_idx
+            if last_non_tool_idx is not None
+            else _previous_non_tool_index(messages, index)
+        )
+        if (
+            prev_assistant_idx < 0
+            or messages[prev_assistant_idx].get("role") != "assistant"
         ):
-            raise ValueError(f"Invalid messages at {index}:\n{assistant_msg}")
+            invalid = messages[prev_assistant_idx] if prev_assistant_idx >= 0 else msg
+            raise ValueError(f"Invalid messages at {index}:\n{invalid}")
 
+        assistant_msg = messages[prev_assistant_idx]
         tool_call_order = index - prev_assistant_idx
         assistant_tool_calls = assistant_msg.get("tool_calls")
         if not (assistant_tool_calls and len(assistant_tool_calls) >= tool_call_order):
@@ -300,13 +308,18 @@ def encode_messages(
         full_messages = drop_thinking_messages(full_messages)
 
     last_user_idx = find_last_user_index(full_messages)
+    last_non_tool_idx = _previous_non_tool_index(full_messages, len(context))
 
     for idx in range(len(messages)):
+        full_idx = idx + len(context)
         prompt += render_message(
-            idx + len(context),
+            full_idx,
             full_messages,
             thinking_mode=thinking_mode,
             last_user_idx=last_user_idx,
+            last_non_tool_idx=last_non_tool_idx,
         )
+        if full_messages[full_idx].get("role") != "tool":
+            last_non_tool_idx = full_idx
 
     return prompt


### PR DESCRIPTION
## Summary
DeepSeek-V3.2 chat-template encoding walked backward through the preceding tool block for every `role: tool` message, so a long run of tool results was quadratic in the renderer worker. The encoder now remembers the previous non-tool message while encoding, so each tool result is resolved in constant time. Tool results that are not immediately after an assistant message are rejected.

## Changes
- `vllm/tokenizers/deepseek_v32_encoding.py`: cache the previous non-tool index in `encode_messages` and use it in `render_message`.
- `tests/test_request_input_bounds.py`: golden tool-result prompt, no per-tool rescan, invalid tool blocks, and the uncached `render_message` fallback.

## Codepath coverage
- All chat rendering for `--tokenizer-mode deepseek_v32` goes through `encode_messages` (`DeepseekV32Tokenizer.apply_chat_template` → renderer). That covers `/v1/chat/completions` (including batch), `/tokenize`, `/v1/responses`, Anthropic/Cohere conversions, pooling chat, `/invocations`, and `LLM.chat`.
- DeepSeek-V4 already merges tool messages in a linear pass. Kimi-K3 walks a tool block once forward. No other encoder had this backward re-scan.

## Tests
- `test_encode_messages_preserves_tool_result_prompt`
- `test_encode_messages_does_not_rescan_each_tool_message`
- `test_encode_messages_rejects_tool_output_without_assistant`
- `test_encode_messages_rejects_tool_output_without_matching_tool_calls`
- `test_encode_messages_tool_results_follow_context_assistant`
- `test_render_message_resolves_tool_owner_without_cached_index`

Commands run:
- `.venv/bin/python -m pytest tests/test_request_input_bounds.py -v` — 30 passed
- `pre-commit run --files vllm/tokenizers/deepseek_v32_encoding.py tests/test_request_input_bounds.py` — passed

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)