### PR TITLE
[warmup][HY V4] Register Triton iHC kernels for JIT warmup

### DIFF
--- a/vllm/models/hy_v4/nvidia/hc.py
+++ b/vllm/models/hy_v4/nvidia/hc.py
@@ -22,6 +22,9 @@ from transformers import PretrainedConfig
 from vllm.model_executor.layers.hpc import HpcIHCHead, HpcIHCPost, HpcIHCPre
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.models.hy_v4.nvidia.triton_ihc import (
+    _IHC_POST_KERNEL,
+    _IHC_PRE_STAGE1_KERNEL,
+    _IHC_PRE_STAGE2_KERNEL,
     triton_ihc_post,
     triton_ihc_pre,
     triton_ihc_supported,
@@ -85,6 +88,9 @@ class HYV4HCPreLayer(nn.Module):
                 norm_eps=layernorm_epsilon,
                 fallback_op=self,
             )
+        else:
+            _IHC_PRE_STAGE1_KERNEL.register_warmup()
+            _IHC_PRE_STAGE2_KERNEL.register_warmup()
 
     def reset_parameters(self, init_std: float, base_noise_std: float = 0.0) -> None:
         """Initialize the gate scale and per-channel gate bias."""
@@ -173,6 +179,8 @@ class HYV4HCPostLayer(nn.Module):
         hc_mult = getattr(config, "hc_mult", 0)
         if HpcIHCPost.support(hc_mult, config.hidden_size):
             self.hpc_op = HpcIHCPost(hc_mult=hc_mult, hidden_size=config.hidden_size)
+        else:
+            _IHC_POST_KERNEL.register_warmup()
 
     def forward(
         self, x: torch.Tensor, residual: torch.Tensor, post: torch.Tensor

--- a/vllm/models/hy_v4/nvidia/triton_ihc.py
+++ b/vllm/models/hy_v4/nvidia/triton_ihc.py
@@ -6,9 +6,18 @@ Adapted from the SGLang HY V4 implementation:
 https://github.com/sgl-project/sglang/pull/36805
 """
 
+from dataclasses import dataclass
+from typing import Any
+
 import torch
 
 from vllm import envs
+from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+    LaunchSpec,
+    TritonWarmupTensor,
+    VllmTritonJitKernel,
+    kernel_launcher,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, tl, triton
 
@@ -196,6 +205,359 @@ def _ihc_post_kernel(
         )
 
 
+def _get_ihc_warmup_config(
+    vllm_config: Any,
+) -> tuple[torch.dtype, int, int, float, float, float] | None:
+    dtype = vllm_config.model_config.dtype
+    if (
+        not HAS_TRITON
+        or not current_platform.is_cuda()
+        or dtype not in (torch.float16, torch.bfloat16)
+        or envs.VLLM_BATCH_INVARIANT
+    ):
+        return None
+
+    config = vllm_config.model_config.hf_config
+    if not getattr(config, "enable_ihc", False):
+        return None
+    return (
+        dtype,
+        int(config.hidden_size),
+        int(config.hc_mult),
+        float(config.hc_magnitude),
+        float(config.hc_eps),
+        float(config.rms_norm_eps),
+    )
+
+
+class IHCPreStage1Kernel(
+    VllmTritonJitKernel["IHCPreStage1Kernel.CompileKey"]
+):
+    @dataclass(frozen=True)
+    class CompileKey:
+        dtype: torch.dtype
+        k_total: int
+        hc_mult: int
+        hc_pow2: int
+        num_splits: int
+        block_k: int
+        partial_stride: int
+
+    kernel = staticmethod(_ihc_pre_stage1)
+
+    def dispatch(  # type: ignore[override]
+        self,
+        *,
+        dtype: torch.dtype,
+        hidden_size: int,
+        hc_mult: int,
+    ) -> CompileKey:
+        k_total = hc_mult * hidden_size
+        hc_pow2 = triton.next_power_of_2(hc_mult)
+        num_splits = triton.cdiv(k_total, _BLOCK_K)
+        partial_stride = 1 + 2 * hc_pow2
+        return self.CompileKey(
+            dtype=dtype,
+            k_total=k_total,
+            hc_mult=hc_mult,
+            hc_pow2=hc_pow2,
+            num_splits=num_splits,
+            block_k=_BLOCK_K,
+            partial_stride=partial_stride,
+        )
+
+    def get_warmup_keys(self, vllm_config: Any) -> list[CompileKey]:
+        warmup_config = _get_ihc_warmup_config(vllm_config)
+        if warmup_config is None:
+            return []
+        dtype, hidden_size, hc_mult, _, _, _ = warmup_config
+        return self._trace_dispatch(self.dispatch)(
+            dtype=dtype,
+            hidden_size=hidden_size,
+            hc_mult=hc_mult,
+        )
+
+    def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:
+        hidden_size = compile_key.k_total // compile_key.hc_mult
+        return dict(
+            x=TritonWarmupTensor(
+                compile_key.dtype,
+                shape=(1, compile_key.hc_mult, hidden_size),
+            ),
+            weight=TritonWarmupTensor(
+                torch.float32,
+                shape=(2 * compile_key.hc_mult, compile_key.k_total),
+            ),
+            _partial=TritonWarmupTensor(
+                torch.float32,
+                shape=(1, compile_key.num_splits, compile_key.partial_stride),
+            ),
+        )
+
+    @kernel_launcher
+    def __call__(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        *,
+        _partial: Any | None = None,
+    ) -> LaunchSpec:
+        num_tokens, hc_mult, hidden_size = x.shape
+        k_total = hc_mult * hidden_size
+        hc_pow2 = triton.next_power_of_2(hc_mult)
+        num_splits = triton.cdiv(k_total, _BLOCK_K)
+        partial_stride = 1 + 2 * hc_pow2
+        if _partial is None:
+            _partial = torch.empty(
+                (num_tokens, num_splits, partial_stride),
+                dtype=torch.float32,
+                device=x.device,
+            )
+        return (
+            (num_tokens, num_splits),
+            dict(
+                partial_ptr=_partial,
+                K_TOTAL=k_total,
+                HC_MULT=hc_mult,
+                HC_POW2=hc_pow2,
+                NUM_SPLITS=num_splits,
+                BLOCK_K=_BLOCK_K,
+                PARTIAL_STRIDE=partial_stride,
+                num_warps=8,
+                enable_fp_fusion=False,
+            ),
+            _partial,
+        )
+
+
+class IHCPreStage2Kernel(
+    VllmTritonJitKernel["IHCPreStage2Kernel.CompileKey"]
+):
+    @dataclass(frozen=True)
+    class CompileKey:
+        dtype: torch.dtype
+        hidden_size: int
+        k_total: int
+        hc_mult: int
+        hc_pow2: int
+        num_splits: int
+        partial_stride: int
+        block_d: int
+        magnitude: float
+        norm_eps: float
+        hc_eps: float
+
+    kernel = staticmethod(_ihc_pre_stage2)
+
+    def dispatch(  # type: ignore[override]
+        self,
+        *,
+        dtype: torch.dtype,
+        hidden_size: int,
+        hc_mult: int,
+        magnitude: float,
+        norm_eps: float,
+        hc_eps: float,
+    ) -> CompileKey:
+        k_total = hc_mult * hidden_size
+        hc_pow2 = triton.next_power_of_2(hc_mult)
+        num_splits = triton.cdiv(k_total, _BLOCK_K)
+        partial_stride = 1 + 2 * hc_pow2
+        return self.CompileKey(
+            dtype=dtype,
+            hidden_size=hidden_size,
+            k_total=k_total,
+            hc_mult=hc_mult,
+            hc_pow2=hc_pow2,
+            num_splits=num_splits,
+            partial_stride=partial_stride,
+            block_d=_BLOCK_D,
+            magnitude=magnitude,
+            norm_eps=norm_eps,
+            hc_eps=hc_eps,
+        )
+
+    def get_warmup_keys(self, vllm_config: Any) -> list[CompileKey]:
+        warmup_config = _get_ihc_warmup_config(vllm_config)
+        if warmup_config is None:
+            return []
+        dtype, hidden_size, hc_mult, magnitude, hc_eps, norm_eps = warmup_config
+        return self._trace_dispatch(self.dispatch)(
+            dtype=dtype,
+            hidden_size=hidden_size,
+            hc_mult=hc_mult,
+            magnitude=magnitude,
+            norm_eps=norm_eps,
+            hc_eps=hc_eps,
+        )
+
+    def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:
+        return dict(
+            x=TritonWarmupTensor(
+                compile_key.dtype,
+                shape=(1, compile_key.hc_mult, compile_key.hidden_size),
+            ),
+            partial=TritonWarmupTensor(
+                torch.float32,
+                shape=(1, compile_key.num_splits, compile_key.partial_stride),
+            ),
+            scale=TritonWarmupTensor(torch.float32, shape=(2,)),
+            base=TritonWarmupTensor(
+                torch.float32,
+                shape=(2 * compile_key.hc_mult,),
+            ),
+            magnitude=compile_key.magnitude,
+            hc_eps=compile_key.hc_eps,
+            norm_eps=compile_key.norm_eps,
+            _outputs=(
+                TritonWarmupTensor(
+                    compile_key.dtype,
+                    shape=(1, compile_key.hidden_size),
+                ),
+                TritonWarmupTensor(
+                    torch.float32,
+                    shape=(1, compile_key.hc_mult),
+                ),
+            ),
+        )
+
+    @kernel_launcher
+    def __call__(
+        self,
+        x: torch.Tensor,
+        partial: torch.Tensor,
+        scale: torch.Tensor,
+        base: torch.Tensor,
+        magnitude: float,
+        hc_eps: float,
+        norm_eps: float,
+        *,
+        _outputs: tuple[Any, Any] | None = None,
+    ) -> LaunchSpec:
+        num_tokens, hc_mult, hidden_size = x.shape
+        k_total = hc_mult * hidden_size
+        hc_pow2 = triton.next_power_of_2(hc_mult)
+        num_splits = triton.cdiv(k_total, _BLOCK_K)
+        partial_stride = 1 + 2 * hc_pow2
+        if _outputs is None:
+            _outputs = (
+                torch.empty(
+                    (num_tokens, hidden_size), dtype=x.dtype, device=x.device
+                ),
+                torch.empty(
+                    (num_tokens, hc_mult), dtype=torch.float32, device=x.device
+                ),
+            )
+        output, post = _outputs
+        return (
+            (num_tokens, triton.cdiv(hidden_size, _BLOCK_D)),
+            dict(
+                output_ptr=output,
+                post_ptr=post,
+                HIDDEN_SIZE=hidden_size,
+                K_TOTAL=k_total,
+                HC_MULT=hc_mult,
+                HC_POW2=hc_pow2,
+                NUM_SPLITS=num_splits,
+                PARTIAL_STRIDE=partial_stride,
+                BLOCK_D=_BLOCK_D,
+                MAGNITUDE=magnitude,
+                NORM_EPS=norm_eps,
+                HC_EPS=hc_eps,
+                num_warps=4,
+                enable_fp_fusion=False,
+            ),
+            _outputs,
+        )
+
+
+class IHCPostKernel(VllmTritonJitKernel["IHCPostKernel.CompileKey"]):
+    @dataclass(frozen=True)
+    class CompileKey:
+        dtype: torch.dtype
+        hidden_size: int
+        hc_mult: int
+        hc_pow2: int
+        block_d: int
+
+    kernel = staticmethod(_ihc_post_kernel)
+
+    def dispatch(  # type: ignore[override]
+        self,
+        *,
+        dtype: torch.dtype,
+        hidden_size: int,
+        hc_mult: int,
+    ) -> CompileKey:
+        return self.CompileKey(
+            dtype=dtype,
+            hidden_size=hidden_size,
+            hc_mult=hc_mult,
+            hc_pow2=triton.next_power_of_2(hc_mult),
+            block_d=_BLOCK_D,
+        )
+
+    def get_warmup_keys(self, vllm_config: Any) -> list[CompileKey]:
+        warmup_config = _get_ihc_warmup_config(vllm_config)
+        if warmup_config is None:
+            return []
+        dtype, hidden_size, hc_mult, _, _, _ = warmup_config
+        return self._trace_dispatch(self.dispatch)(
+            dtype=dtype,
+            hidden_size=hidden_size,
+            hc_mult=hc_mult,
+        )
+
+    def warmup_inputs(self, compile_key: CompileKey) -> dict[str, Any]:
+        return dict(
+            x=TritonWarmupTensor(
+                compile_key.dtype,
+                shape=(1, compile_key.hidden_size),
+            ),
+            residual=TritonWarmupTensor(
+                compile_key.dtype,
+                shape=(1, compile_key.hc_mult, compile_key.hidden_size),
+            ),
+            post=TritonWarmupTensor(
+                torch.float32,
+                shape=(1, compile_key.hc_mult),
+            ),
+            _output=TritonWarmupTensor(
+                compile_key.dtype,
+                shape=(1, compile_key.hc_mult, compile_key.hidden_size),
+            ),
+        )
+
+    @kernel_launcher
+    def __call__(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post: torch.Tensor,
+        *,
+        _output: Any | None = None,
+    ) -> LaunchSpec:
+        num_tokens, hidden_size = x.shape
+        hc_mult = post.shape[-1]
+        if _output is None:
+            _output = torch.empty(
+                (num_tokens, hc_mult, hidden_size), dtype=x.dtype, device=x.device
+            )
+        return (
+            (num_tokens, triton.cdiv(hidden_size, _BLOCK_D)),
+            dict(
+                output_ptr=_output,
+                HIDDEN_SIZE=hidden_size,
+                HC_MULT=hc_mult,
+                HC_POW2=triton.next_power_of_2(hc_mult),
+                BLOCK_D=_BLOCK_D,
+                num_warps=4,
+                enable_fp_fusion=False,
+            ),
+            _output,
+        )
+
+
 def triton_ihc_pre(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -227,51 +589,19 @@ def triton_ihc_pre(
             torch.empty((0, hc_mult), dtype=torch.float32, device=x.device),
         )
 
-    output = torch.empty((num_tokens, hidden_size), dtype=x.dtype, device=x.device)
-    post = torch.empty((num_tokens, hc_mult), dtype=torch.float32, device=x.device)
-    hc_pow2 = triton.next_power_of_2(hc_mult)
-    num_splits = triton.cdiv(k_total, _BLOCK_K)
-    partial_stride = 1 + 2 * hc_pow2
-    partial = torch.empty(
-        (num_tokens, num_splits, partial_stride),
-        dtype=torch.float32,
-        device=x.device,
-    )
-
-    _ihc_pre_stage1[(num_tokens, num_splits)](
+    partial = _IHC_PRE_STAGE1_KERNEL(
         x,
         weight,
-        partial,
-        K_TOTAL=k_total,
-        HC_MULT=hc_mult,
-        HC_POW2=hc_pow2,
-        NUM_SPLITS=num_splits,
-        BLOCK_K=_BLOCK_K,
-        PARTIAL_STRIDE=partial_stride,
-        num_warps=8,
-        enable_fp_fusion=False,
     )
-    _ihc_pre_stage2[(num_tokens, triton.cdiv(hidden_size, _BLOCK_D))](
+    return _IHC_PRE_STAGE2_KERNEL(
         x,
         partial,
         scale,
         base,
-        output,
-        post,
-        HIDDEN_SIZE=hidden_size,
-        K_TOTAL=k_total,
-        HC_MULT=hc_mult,
-        HC_POW2=hc_pow2,
-        NUM_SPLITS=num_splits,
-        PARTIAL_STRIDE=partial_stride,
-        BLOCK_D=_BLOCK_D,
-        MAGNITUDE=magnitude,
-        NORM_EPS=norm_eps,
-        HC_EPS=hc_eps,
-        num_warps=4,
-        enable_fp_fusion=False,
+        magnitude,
+        hc_eps,
+        norm_eps,
     )
-    return output, post
 
 
 def triton_ihc_post(
@@ -295,19 +625,13 @@ def triton_ihc_post(
     if num_tokens == 0:
         return torch.empty((0, hc_mult, hidden_size), dtype=x.dtype, device=x.device)
 
-    output = torch.empty(
-        (num_tokens, hc_mult, hidden_size), dtype=x.dtype, device=x.device
-    )
-    _ihc_post_kernel[(num_tokens, triton.cdiv(hidden_size, _BLOCK_D))](
+    return _IHC_POST_KERNEL(
         x,
         residual,
         post,
-        output,
-        HIDDEN_SIZE=hidden_size,
-        HC_MULT=hc_mult,
-        HC_POW2=triton.next_power_of_2(hc_mult),
-        BLOCK_D=_BLOCK_D,
-        num_warps=4,
-        enable_fp_fusion=False,
     )
-    return output
+
+
+_IHC_PRE_STAGE1_KERNEL = IHCPreStage1Kernel()
+_IHC_PRE_STAGE2_KERNEL = IHCPreStage2Kernel()
+_IHC_POST_KERNEL = IHCPostKernel()

--- a/vllm/models/hy_v4/nvidia/triton_ihc.py
+++ b/vllm/models/hy_v4/nvidia/triton_ihc.py
@@ -230,9 +230,7 @@ def _get_ihc_warmup_config(
     )
 
 
-class IHCPreStage1Kernel(
-    VllmTritonJitKernel["IHCPreStage1Kernel.CompileKey"]
-):
+class IHCPreStage1Kernel(VllmTritonJitKernel["IHCPreStage1Kernel.CompileKey"]):
     @dataclass(frozen=True)
     class CompileKey:
         dtype: torch.dtype
@@ -330,9 +328,7 @@ class IHCPreStage1Kernel(
         )
 
 
-class IHCPreStage2Kernel(
-    VllmTritonJitKernel["IHCPreStage2Kernel.CompileKey"]
-):
+class IHCPreStage2Kernel(VllmTritonJitKernel["IHCPreStage2Kernel.CompileKey"]):
     @dataclass(frozen=True)
     class CompileKey:
         dtype: torch.dtype
@@ -441,9 +437,7 @@ class IHCPreStage2Kernel(
         partial_stride = 1 + 2 * hc_pow2
         if _outputs is None:
             _outputs = (
-                torch.empty(
-                    (num_tokens, hidden_size), dtype=x.dtype, device=x.device
-                ),
+                torch.empty((num_tokens, hidden_size), dtype=x.dtype, device=x.device),
                 torch.empty(
                     (num_tokens, hc_mult), dtype=torch.float32, device=x.device
                 ),


### PR DESCRIPTION

## Summary

- Register the HY V4 Triton iHC pre-stage1, pre-stage2, and post kernels with the shared JIT warmup infrastructure.
- Add kernel-owned compile keys and compile-only warmup inputs.
- Avoid Triton kernel JIT compilation during inference.

This follows the JIT warmup migration proposed in #47456 and applies it to the kernels introduced in #55059.

AI assistance was used to implement and test this change.