### PR TITLE
docs: fix SkyPilot gradio path and bench sonnet dataset path

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -734,7 +734,7 @@ Using KV cache metrics for load pattern configuration:
 vllm bench throughput \
   --model NousResearch/Hermes-3-Llama-3.1-8B \
   --dataset-name sonnet \
-  --dataset-path vllm/benchmarks/sonnet.txt \
+  --dataset-path benchmarks/sonnet.txt \
   --num-prompts 10
 ```
 

--- a/docs/deployment/frameworks/skypilot.md
+++ b/docs/deployment/frameworks/skypilot.md
@@ -305,7 +305,7 @@ It is also possible to access the Llama-3 service with a separate GUI frontend, 
 
       echo 'Starting gradio server...'
       git clone https://github.com/vllm-project/vllm.git || true
-      python vllm/examples/applications/api_client/gradio_openai_chatbot_webserver.py \
+      python vllm/examples/applications/chatbot/gradio_openai_chatbot_webserver.py \
         -m $MODEL_NAME \
         --port 8811 \
         --model-url http://$ENDPOINT/v1 \


### PR DESCRIPTION
## Summary

Two docs paths 404 on current `main`:

1. `docs/deployment/frameworks/skypilot.md` — one GUI example still runs `vllm/examples/applications/api_client/gradio_openai_chatbot_webserver.py`, but that path does not exist. The live script is under `examples/applications/chatbot/` (an earlier example in the same file already uses the correct path).
2. `docs/benchmarking/cli.md` — Offline Throughput Benchmark example uses `--dataset-path vllm/benchmarks/sonnet.txt`, which does not exist. The file is at repo-root `benchmarks/sonnet.txt` (same page's dataset table already lists that path).

## Local repro

```bash
SHA=$(gh api repos/vllm-project/vllm/commits/main --jq .sha)

# SkyPilot: stale api_client path 404; chatbot path 200
curl -sL -o /dev/null -w 'api_client=%{http_code}\n' \
  "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/examples/applications/api_client/gradio_openai_chatbot_webserver.py"
curl -sL -o /dev/null -w 'chatbot=%{http_code}\n' \
  "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/examples/applications/chatbot/gradio_openai_chatbot_webserver.py"

# Sonnet: wrong vs correct dataset path
curl -sL -o /dev/null -w 'vllm/benchmarks=%{http_code}\n' \
  "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/vllm/benchmarks/sonnet.txt"
curl -sL -o /dev/null -w 'benchmarks=%{http_code}\n' \
  "https://raw.githubusercontent.com/vllm-project/vllm/$SHA/benchmarks/sonnet.txt"

# Docs still cite the stale paths on main
gh api "repos/vllm-project/vllm/contents/docs/deployment/frameworks/skypilot.md?ref=$SHA" \
  --jq .content | base64 -d | grep -n 'api_client/gradio'
gh api "repos/vllm-project/vllm/contents/docs/benchmarking/cli.md?ref=$SHA" \
  --jq .content | base64 -d | grep -n 'vllm/benchmarks/sonnet'
```

Expected before: `api_client=404`, `chatbot=200`, `vllm/benchmarks=404`, `benchmarks=200`, and both `grep` hits present.
After this PR: both docs paths point at the existing files.

## Test plan

- [ ] Confirm only the two docs files change
- [ ] Confirm no remaining `api_client/gradio_openai_chatbot_webserver` in `skypilot.md`
- [ ] Confirm offline throughput example uses `benchmarks/sonnet.txt`