### PR TITLE
[Security][Rust Frontend] Normalize HTTP method labels in metrics

### DIFF
--- a/rust/src/server/src/middleware/metrics.rs
+++ b/rust/src/server/src/middleware/metrics.rs
@@ -4,6 +4,7 @@
 use std::time::Instant;
 
 use axum::extract::{MatchedPath, Request};
+use axum::http::Method;
 use axum::middleware::Next;
 use axum::response::Response;
 use vllm_metrics::{HttpHandlerLabels, HttpRequestLabels, METRICS};
@@ -29,10 +30,29 @@ const EXCLUDED_HANDLERS: &[&str] = &[
     "/is_sleeping",
 ];
 
+/// Map the request method to a bounded Prometheus label.
+///
+/// HTTP parsers accept arbitrary method tokens. Recording the raw token as a
+/// label would let unique values create unbounded time series.
+pub(crate) fn http_metrics_method(method: &Method) -> &'static str {
+    match method.as_str() {
+        "GET" => "GET",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "PATCH" => "PATCH",
+        "DELETE" => "DELETE",
+        "HEAD" => "HEAD",
+        "OPTIONS" => "OPTIONS",
+        "CONNECT" => "CONNECT",
+        "TRACE" => "TRACE",
+        _ => "other",
+    }
+}
+
 /// Record API-server HTTP metrics with Python-compatible
 /// (`PrometheusFastApiInstrumentator` style) family names and labels.
 pub async fn track_http_metrics(req: Request, next: Next) -> Response {
-    let method = req.method().as_str().to_string();
+    let method = http_metrics_method(req.method()).to_string();
     let handler = req
         .extensions()
         .get::<MatchedPath>()
@@ -78,5 +98,35 @@ fn status_group(status: u16) -> &'static str {
         4 => "4xx",
         5 => "5xx",
         _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_methods_keep_their_names() {
+        for (method, expected) in [
+            (Method::GET, "GET"),
+            (Method::POST, "POST"),
+            (Method::PUT, "PUT"),
+            (Method::PATCH, "PATCH"),
+            (Method::DELETE, "DELETE"),
+            (Method::HEAD, "HEAD"),
+            (Method::OPTIONS, "OPTIONS"),
+            (Method::CONNECT, "CONNECT"),
+            (Method::TRACE, "TRACE"),
+        ] {
+            assert_eq!(http_metrics_method(&method), expected);
+        }
+    }
+
+    #[test]
+    fn unknown_methods_collapse_to_other() {
+        let method = Method::from_bytes(b"XVULNCARD000001").expect("valid token");
+        assert_eq!(http_metrics_method(&method), "other");
+        let other = Method::from_bytes(b"XVULNCARD000002").expect("valid token");
+        assert_eq!(http_metrics_method(&other), "other");
     }
 }

--- a/rust/src/server/src/middleware/metrics.rs
+++ b/rust/src/server/src/middleware/metrics.rs
@@ -34,17 +34,17 @@ const EXCLUDED_HANDLERS: &[&str] = &[
 ///
 /// HTTP parsers accept arbitrary method tokens. Recording the raw token as a
 /// label would let unique values create unbounded time series.
-pub(crate) fn http_metrics_method(method: &Method) -> &'static str {
-    match method.as_str() {
-        "GET" => "GET",
-        "POST" => "POST",
-        "PUT" => "PUT",
-        "PATCH" => "PATCH",
-        "DELETE" => "DELETE",
-        "HEAD" => "HEAD",
-        "OPTIONS" => "OPTIONS",
-        "CONNECT" => "CONNECT",
-        "TRACE" => "TRACE",
+pub(crate) fn http_metrics_method(method: &Method) -> &str {
+    match *method {
+        Method::GET
+        | Method::POST
+        | Method::PUT
+        | Method::PATCH
+        | Method::DELETE
+        | Method::HEAD
+        | Method::OPTIONS
+        | Method::CONNECT
+        | Method::TRACE => method.as_str(),
         _ => "other",
     }
 }

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -3117,6 +3117,64 @@ async fn http_metrics_group_error_statuses() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn http_metrics_collapse_unknown_methods() {
+    let mut app = test_app().await;
+    let before = METRICS.render().unwrap();
+
+    for (method, path) in [
+        ("XVULNCARD000001", "/tokenize"),
+        ("XVULNCARD000002", "/tokenize"),
+        ("XVULNCARD000003", "/detokenize"),
+    ] {
+        let response = app
+            .call(
+                Request::builder()
+                    .method(method)
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("call app");
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    let after = METRICS.render().unwrap();
+    assert!(
+        !after.contains("XVULNCARD"),
+        "raw method tokens must not appear in metrics: {after}"
+    );
+    assert_eq!(
+        metric_delta(
+            &before,
+            &after,
+            "http_requests_total",
+            Some("method=\"other\",status=\"4xx\",handler=\"/tokenize\""),
+        ),
+        2.0
+    );
+    assert_eq!(
+        metric_delta(
+            &before,
+            &after,
+            "http_requests_total",
+            Some("method=\"other\",status=\"4xx\",handler=\"/detokenize\""),
+        ),
+        1.0
+    );
+    assert_eq!(
+        metric_delta(
+            &before,
+            &after,
+            "http_request_duration_seconds_count",
+            Some("method=\"other\",handler=\"/tokenize\""),
+        ),
+        2.0
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn load_endpoint_tracks_chat_stream_lifecycle() {
     let (app, engine_task) = test_app_with_engine_handle().await;
 


### PR DESCRIPTION
## Summary

The Rust frontend HTTP metrics middleware recorded the raw request method token as a Prometheus label. HTTP parsers accept arbitrary method tokens, so unique values could insert unbounded time series. This change maps methods to a small allowlist (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`, `CONNECT`, `TRACE`) and collapses everything else to `other` before labels are created.

## Changes

- `rust/src/server/src/middleware/metrics.rs`: map the method through `http_metrics_method` before recording `http_requests` and `http_request_duration_seconds`.
- `rust/src/server/src/routes/tests.rs`: assert that unknown method tokens on `/tokenize` and `/detokenize` do not appear in the scrape and are counted under `method="other"`.

## Codepath coverage

- All registered HTTP routes, including 405s on `/tokenize` and `/detokenize`, go through `track_http_metrics` and are covered.
- Unmatched paths (`handler="none"`) use the same middleware and are covered.
- `/metrics` remains excluded from HTTP request metrics (unchanged).
- Python FastAPI instrumentator and gRPC are a different frontend and are out of this change.

## Duplicate-work check

Searched open, draft, and recently merged PRs for `track_http_metrics`, Rust HTTP metrics, Prometheus method cardinality, and `HttpRequestLabels`. https://github.com/vllm-project/vllm/pull/44900 touches the same metrics middleware for `--root-path` nesting only and does not bound method labels. https://github.com/vllm-project/vllm/pull/53160 filters Prometheus names on the Python instrumentator, not this sink. No open or merged PR already closes this root cause on this path.

## Tests

- `known_methods_keep_their_names`: standard methods keep their names.
- `unknown_methods_collapse_to_other`: non-standard tokens map to `other`.
- `http_metrics_collapse_unknown_methods`: three 405s with distinct unknown methods on `/tokenize` and `/detokenize`; scrape has no raw tokens; counts land on `method="other"`.

Commands:

```
cargo fmt -p vllm-server
cargo test -p vllm-server --lib http_metrics -- --test-threads=1
cargo test -p vllm-server --lib known_methods -- --test-threads=1
pre-commit run --files rust/src/server/src/middleware/metrics.rs rust/src/server/src/routes/tests.rs
```

All passed.

## AI assistance

This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)