### PR TITLE
[Bugfix][ROCm] Bound kpool prefill tail-seed stores by NUM_TAIL_BLOCKS

### DIFF
--- a/vllm/models/glm5next/amd/ops/kpool_compress.py
+++ b/vllm/models/glm5next/amd/ops/kpool_compress.py
@@ -365,6 +365,7 @@ def _kpool_tail_seed_kernel(
     HEAD_DIM: tl.constexpr,
     KPOOL: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    NUM_TAIL_BLOCKS: tl.constexpr,
 ):
     """Copy token ``i``'s raw K + gate into its request's tail block.
 
@@ -378,6 +379,11 @@ def _kpool_tail_seed_kernel(
     if t < 0:
         return
     blk = t // KPOOL  # t >= 0 here, so trunc == floor
+    # Prefill seed used to address tail[blk] with a physical id that can be
+    # main-KV magnitude after prefix-cache churn. Decode already bounds this;
+    # skip OOB stores (vllm#56037 Crash D).
+    if blk >= NUM_TAIL_BLOCKS:
+        return
     ahead = tl.load(tslot_ptr + i + KPOOL, mask=i + KPOOL < n_tokens, other=-1).to(
         tl.int64
     )
@@ -423,6 +429,7 @@ def kpool_seed_tail_cache(
         HEAD_DIM=head_dim,
         KPOOL=kpool,
         BLOCK_D=triton.next_power_of_2(head_dim),
+        NUM_TAIL_BLOCKS=int(tail_kv_cache.shape[0]),
     )
 
 

--- a/vllm/models/glm5next/nvidia/ops/kpool_compress.py
+++ b/vllm/models/glm5next/nvidia/ops/kpool_compress.py
@@ -378,6 +378,7 @@ def _kpool_tail_seed_kernel(
     HEAD_DIM: tl.constexpr,
     KPOOL: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    NUM_TAIL_BLOCKS: tl.constexpr,
 ):
     """Copy token ``i``'s raw K + gate into its request's tail block.
 
@@ -391,6 +392,8 @@ def _kpool_tail_seed_kernel(
     if t < 0:
         return
     blk = t // KPOOL  # t >= 0 here, so trunc == floor
+    if blk >= NUM_TAIL_BLOCKS:
+        return
     ahead = tl.load(tslot_ptr + i + KPOOL, mask=i + KPOOL < n_tokens, other=-1).to(
         tl.int64
     )
@@ -431,6 +434,7 @@ def kpool_seed_tail_cache(
         HEAD_DIM=head_dim,
         KPOOL=kpool,
         BLOCK_D=triton.next_power_of_2(head_dim),
+        NUM_TAIL_BLOCKS=int(tail_kv_cache.shape[0]),
     )
 
 


### PR DESCRIPTION
Prefill `_kpool_tail_seed_kernel` stores into `tail[blk]` using `blk = tslot // kpool`. After prefix-cache churn, `tslot` can carry a **main-KV-magnitude physical id** while the tail tensor is a 1-block-per-request ring (`n_tail` << physical id). Decode already skipped `block >= n_tail`; seed did not.

## Measured (gfx942, GLM-5.3-Flash TP4)

See https://github.com/vllm-project/vllm/issues/56037 **Crash D** (2026-09-07).

- Dying step: chunked prefill, computed=211200, scheduled=2338 (`2338 % 4 == 2` so the last chunk must seed the tail ring), `scheduled_spec_decode_tokens={}`, `new_block_ids` around 3535–3578.
- `HIP_LAUNCH_BLOCKING=1` + `AMD_LOG_LEVEL=3` on the dying image, GPU 0 only:

```
hipModuleGetFunction(..., _kpool_tail_seed_kernel)
ShaderName : _kpool_tail_seed_kernel
Memory Fault Error
Memory access fault by GPU node-2
```

Same probe with `if blk >= NUM_TAIL_BLOCKS: return` does not fault.

## This PR

Pass `NUM_TAIL_BLOCKS = tail_kv_cache.shape[0]` into the prefill seed kernel (AMD + NVIDIA copies) and return before the store when `blk` is out of range.

**Out of scope:** mixed-length MTP decode (Crash C) and equal-length short MTP decode (Crash E) in #56037. Those are separate paths; do not close #56037 on this PR alone.
