### PR TITLE
[Bugfix][XPU] Register EmulationNvFp4LinearKernel for NVFP4 checkpoints

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -554,6 +554,9 @@ _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
     PlatformEnum.ROCM: [
         EmulationNvFp4LinearKernel,
     ],
+    PlatformEnum.XPU: [
+        EmulationNvFp4LinearKernel,
+    ],
 }
 
 _POSSIBLE_MXFP6_KERNELS: dict[PlatformEnum, list[type[MxFp6LinearKernel]]] = {


### PR DESCRIPTION
## Bug

`_POSSIBLE_NVFP4_KERNELS` only registers kernels for CUDA and ROCM, so on XPU `init_nvfp4_linear_kernel()` raises:

```
Failed to find a kernel that can implement the NVFP4 linear layer. Reasons:
```

with an empty reasons list, on any NVFP4 checkpoint.

## Fix

`EmulationNvFp4LinearKernel` has no CUDA-specific code (`is_supported`/`can_implement` always return `True`), and is already registered for ROCM. This registers the same kernel for XPU — a 3-line, purely additive change to the platform-dispatch dict.

## Testing

- **XPU (Battlemage B70):** reproduced the reported failure on unmodified `main`. After this change: `Using EmulationNvFp4LinearKernel for NVFP4 GEMM` is selected, `RedHatAI/gemma-4-26B-A4B-it-NVFP4` loads, and the engine runs `generate()` without error.
- **CUDA regression check (H200):** this only adds a new dict key, so CUDA/ROCM dispatch is unaffected — confirmed on real hardware that `_POSSIBLE_NVFP4_KERNELS[CUDA]` resolution (`SELECTED KERNEL: MarlinNvFp4LinearKernel`) is bit-identical before/after the patch.

## Known limitation (pre-existing, not introduced by this change)

With this specific checkpoint, `EmulationNvFp4LinearKernel` loads and runs but generates degenerate/repetitive text (not a crash). The engine itself warns during loading:

```
the weight global scale is different for parallel layers (e.g. q_proj, k_proj, v_proj)... likely reduced accuracy
```

I confirmed this is **not XPU-specific**: forcing `EmulationNvFp4LinearKernel` on native CUDA (H200) with the same checkpoint reproduces the identical warning and qualitatively the same degenerate output. This is an existing accuracy limitation of the emulation kernel with this checkpoint's per-layer global-scale layout, independent of platform. This PR only unblocks kernel *dispatch* on XPU (replacing a hard failure with the same behavior ROCM already has); it does not attempt to fix the emulation kernel's accuracy on this checkpoint, which is out of scope here.