### PR TITLE
[Security] Bound media-cache entries and skip failed downloads

### DIFF
--- a/tests/multimodal/media/test_connector.py
+++ b/tests/multimodal/media/test_connector.py
@@ -21,6 +21,7 @@ from vllm.assets.base import VLLM_S3_BUCKET_URL
 from vllm.multimodal.image import convert_image_mode
 from vllm.multimodal.inputs import PlaceholderRange
 from vllm.multimodal.media import MediaConnector
+from vllm.multimodal.media.connector import _MEDIA_CACHE_MIN_ENTRY_BYTES
 
 # Test different image extensions (JPG/PNG) and formats (gray/RGB/RGBA)
 TEST_IMAGE_ASSETS = [
@@ -570,3 +571,96 @@ def test_get_cached_bytes_file_deleted_before_read():
         connector._media_cache_path(url).unlink()
 
         assert connector._get_cached_bytes(url) is None
+
+
+class _StaticBytesConnection:
+    """HTTP connection stub that always returns a fixed payload."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def get_bytes(self, url, **kwargs):
+        return self.payload
+
+    async def async_get_bytes(self, url, **kwargs):
+        return self.payload
+
+
+def _cache_filenames(cache_dir: str) -> list[str]:
+    return [name for name in os.listdir(cache_dir) if not name.startswith(".")]
+
+
+def _tiny_png() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), (0, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_empty_payload_not_cached():
+    """Empty downloads must not create a cache file."""
+    with TemporaryDirectory() as cache_dir:
+        connector = _make_cached_connector(cache_dir)
+        connector._put_cached_bytes("https://example.com/empty.png", b"")
+
+        assert _cache_filenames(cache_dir) == []
+        assert connector._get_cached_bytes("https://example.com/empty.png") is None
+
+
+def test_tiny_entries_count_toward_size_budget():
+    """Tiny files are billed at the minimum entry size so LRU still fires."""
+    with TemporaryDirectory() as cache_dir:
+        connector = _make_cached_connector(cache_dir, max_mb=0)
+        connector._media_cache_max_bytes = _MEDIA_CACHE_MIN_ENTRY_BYTES * 2
+
+        urls = [f"https://example.com/{i}.bin" for i in range(3)]
+        for i, url in enumerate(urls):
+            connector._put_cached_bytes(url, b"x")
+            path = connector._media_cache_path(url)
+            os.utime(path, (time.time() + i, time.time() + i))
+
+        assert connector._get_cached_bytes(urls[0]) is None
+        assert connector._get_cached_bytes(urls[2]) == b"x"
+
+
+def test_undecodable_http_media_not_cached():
+    """Failed image decode must not leave a cache file (sync path)."""
+    with TemporaryDirectory() as cache_dir:
+        connector = _make_cached_connector(cache_dir)
+        connector.connection = _StaticBytesConnection(b"")
+        connector.allowed_media_domains = ["example.com"]
+
+        with pytest.raises(ValueError, match="Failed to load image"):
+            connector.fetch_image("https://example.com/empty.png")
+
+        assert _cache_filenames(cache_dir) == []
+
+
+def test_undecodable_http_media_not_cached_async():
+    """Failed image decode must not leave a cache file (async path)."""
+
+    async def _run() -> None:
+        with TemporaryDirectory() as cache_dir:
+            connector = _make_cached_connector(cache_dir)
+            connector.connection = _StaticBytesConnection(b"")
+            connector.allowed_media_domains = ["example.com"]
+
+            with pytest.raises(ValueError, match="Failed to load image"):
+                await connector.fetch_image_async("https://example.com/empty.png")
+
+            assert _cache_filenames(cache_dir) == []
+
+    asyncio.run(_run())
+
+
+def test_valid_http_media_is_cached_after_decode():
+    """Successful fetches still populate the download cache."""
+    payload = _tiny_png()
+    url = "https://example.com/tiny.png"
+    with TemporaryDirectory() as cache_dir:
+        connector = _make_cached_connector(cache_dir)
+        connector.connection = _StaticBytesConnection(payload)
+        connector.allowed_media_domains = ["example.com"]
+
+        connector.fetch_image(url)
+
+        assert connector._get_cached_bytes(url) == payload

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -969,7 +969,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # from URLs during inference). Empty string disables caching.
     "VLLM_MEDIA_CACHE": lambda: os.getenv("VLLM_MEDIA_CACHE", ""),
     # Maximum cache size in MB. When exceeded, least-recently-used entries
-    # are evicted. Default is 5120 (5 GB).
+    # are evicted. Each entry is billed at least 4 KiB so empty or tiny
+    # files cannot bypass the budget. Default is 5120 (5 GB).
     "VLLM_MEDIA_CACHE_MAX_SIZE_MB": lambda: int(
         os.getenv("VLLM_MEDIA_CACHE_MAX_SIZE_MB", "5120")
     ),

--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -46,6 +46,10 @@ global_thread_pool = ThreadPoolExecutor(
 )
 atexit.register(global_thread_pool.shutdown)
 
+# Empty/tiny payloads have st_size 0 (or a few bytes) and would never
+# consume the byte budget. Bill each file at least one filesystem block.
+_MEDIA_CACHE_MIN_ENTRY_BYTES = 4096
+
 MEDIA_CONNECTOR_REGISTRY = ExtensionManager()
 
 MODALITY_IO_MAP: dict[str, type[MediaIO]] = {
@@ -251,7 +255,7 @@ class MediaConnector:
 
     def _put_cached_bytes(self, url: str, data: bytes) -> None:
         """Store downloaded bytes and evict if over budget."""
-        if not self._media_cache_dir:
+        if not self._media_cache_dir or not data:
             return
         cache_path = self._media_cache_path(url)
         # Atomic write via temp file + rename
@@ -289,11 +293,12 @@ class MediaConnector:
             if age > self._media_cache_ttl_secs:
                 expired.append(f)
                 continue
-            total_size += stat.st_size
+            charged = max(stat.st_size, _MEDIA_CACHE_MIN_ENTRY_BYTES)
+            total_size += charged
             # Never evict the file we just wrote
             if exclude is not None and f.name == exclude.name:
                 continue
-            entries.append((stat.st_mtime, stat.st_size, f))
+            entries.append((stat.st_mtime, charged, f))
 
         # Evict items according to LRU policy
         entries.sort(key=lambda e: e[0], reverse=True)
@@ -309,6 +314,16 @@ class MediaConnector:
         url_hash = hashlib.sha256(url.encode()).hexdigest()[:20]
         ext = Path(url.split("?", 1)[0]).suffix or ""
         return Path(self._media_cache_dir) / f"{url_hash}{ext}"  # type: ignore[arg-type]
+
+    def _decode_then_cache(
+        self,
+        url: str,
+        media_io: MediaIO[_M],
+        data: bytes,
+    ) -> _M:  # type: ignore[type-var]
+        loaded = media_io.load_bytes(data)
+        self._put_cached_bytes(url, data)
+        return loaded
 
     def _load_data_url(
         self,
@@ -397,8 +412,7 @@ class MediaConnector:
                     raise wrapped from e
                 raise
 
-            self._put_cached_bytes(url, data)
-            return media_io.load_bytes(data)
+            return self._decode_then_cache(url, media_io, data)
 
         if url_spec.scheme == "file":
             return self._load_file_url(url_spec, media_io)
@@ -450,11 +464,9 @@ class MediaConnector:
                     raise wrapped from e
                 raise
 
-            await loop.run_in_executor(
-                global_thread_pool, self._put_cached_bytes, url, data
+            return await loop.run_in_executor(
+                global_thread_pool, self._decode_then_cache, url, media_io, data
             )
-            future = loop.run_in_executor(global_thread_pool, media_io.load_bytes, data)
-            return await future
 
         if url_spec.scheme == "file":
             future = loop.run_in_executor(


### PR DESCRIPTION
## Summary
When the optional media download cache is enabled, HTTP bytes were written to disk before decode and eviction counted only `stat.st_size`. Empty or otherwise undecodable responses therefore never consumed the configured byte budget, so unique URLs could fill the cache directory with files and make every later insert scan a growing directory. This change decodes first (so failed loads are not stored), skips empty payloads, and bills each file at least 4 KiB toward the LRU budget.

## Changes
- `vllm/multimodal/media/connector.py`: decode-then-cache on the sync and async HTTP paths; do not persist empty bodies; charge `max(st_size, 4096)` during eviction.
- `vllm/envs.py`: document the 4 KiB per-entry floor on `VLLM_MEDIA_CACHE_MAX_SIZE_MB`.
- `tests/multimodal/media/test_connector.py`: empty payload, tiny-entry eviction, failed sync/async decode, and successful cache-after-decode.

## Codepath coverage
- All HTTP media fetches go through `MediaConnector.load_from_url` / `load_from_url_async` (`fetch_image`, `fetch_audio`, `fetch_video` and async variants), used by chat completions, messages, responses, `/invocations`, render, and batch. There is no separate Rust download cache.
- `data:` and `file:` URLs do not use this cache (unchanged).

## Duplicate-work check
Searched open and recently merged PRs for `MediaConnector`, `VLLM_MEDIA_CACHE`, `_maybe_evict`, and `_put_cached_bytes`. Related PRs change UUID cache keys or processor-cache lookups and do not close this eviction/decode-order sink.

## Tests
- `test_empty_payload_not_cached`
- `test_tiny_entries_count_toward_size_budget`
- `test_undecodable_http_media_not_cached`
- `test_undecodable_http_media_not_cached_async`
- `test_valid_http_media_is_cached_after_decode`

```
.venv/bin/python -m pytest tests/multimodal/media/test_connector.py -k 'empty_payload or tiny_entries or undecodable_http or valid_http_media or cache_put or cache_ttl or cache_lru or put_cached_bytes_missing or get_cached_bytes_file' -v
```
11 passed.

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)