### PR TITLE
[Docs] Point Completions client example at openai_completion_client.py

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -264,7 +264,7 @@ Since this server is compatible with OpenAI API, you can use it as a drop-in rep
     print("Completion result:", completion)
     ```
 
-A more detailed client example can be found here: [examples/basic/offline_inference/basic.py](../../examples/basic/offline_inference/basic.py)
+A more detailed client example can be found here: [examples/basic/online_serving/openai_completion_client.py](../../examples/basic/online_serving/openai_completion_client.py)
 
 ### OpenAI Chat Completions API with vLLM
 


### PR DESCRIPTION
## Summary

Under **OpenAI Completions API with vLLM** in `docs/getting_started/quickstart.md`, the "more detailed client example" link pointed at `examples/basic/offline_inference/basic.py`. That file is an offline `LLM.generate` script, not an OpenAI Completions client.

Point the link at `examples/basic/online_serving/openai_completion_client.py`, which uses `client.completions.create` against a running vLLM server.

The earlier offline-inference link to `basic.py` in the same doc is left unchanged.

## Repro

```bash
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/docs/getting_started/quickstart.md | rg -n 'more detailed client example'
# links to examples/basic/offline_inference/basic.py

curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/basic/offline_inference/basic.py | rg -n 'from vllm import LLM|llm\.generate'
# offline LLM.generate

curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/examples/basic/online_serving/openai_completion_client.py | rg -n 'OpenAI|completions\.create'
# Completions client
```

## Test plan

- [x] Diff limited to the Completions-section link in `docs/getting_started/quickstart.md`
- [x] Offline `basic.py` link in the offline section unchanged
- [x] Target path exists on `main` and uses Completions API