### PR TITLE
[Bugfix] Merge rope_theta into rope_parameters for BailingMoeV2

### DIFF
--- a/vllm/model_executor/models/bailing_moe.py
+++ b/vllm/model_executor/models/bailing_moe.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Inference-only BailingMoE model compatible with HuggingFace weights."""
 
+import copy
 from collections.abc import Iterable
 from itertools import islice
 
@@ -66,6 +67,24 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
+
+
+def _build_rope_parameters(config: PretrainedConfig) -> dict:
+    rope_parameters = copy.deepcopy(getattr(config, "rope_parameters", None)) or {}
+    # Under Transformers v5 the top-level ``rope_theta`` is no longer auto-merged
+    # into ``rope_parameters``, so without this bridge get_rope falls back to
+    # base=10000 and misaligns the whole RoPE spectrum.
+    if "rope_theta" not in rope_parameters and hasattr(config, "rope_theta"):
+        rope_parameters["rope_theta"] = config.rope_theta
+
+    rope_scaling = getattr(config, "rope_scaling", None)
+    if isinstance(rope_scaling, dict):
+        rope_scaling = copy.deepcopy(rope_scaling)
+        if "type" in rope_scaling and "rope_type" not in rope_scaling:
+            rope_scaling["rope_type"] = rope_scaling.pop("type")
+        rope_parameters.update(rope_scaling)
+
+    return rope_parameters
 
 
 class BailingAttention(nn.Module):
@@ -132,12 +151,19 @@ class BailingAttention(nn.Module):
             rotary_dim = int(self.head_dim * partial_rotary_factor)
         if rotary_dim is None:
             rotary_dim = self.head_dim
-        config.rope_parameters["partial_rotary_factor"] = rotary_dim / self.head_dim
+
+        # Hand get_rope a bridged copy, not config.rope_parameters directly:
+        # _build_rope_parameters merges the top-level rope_theta + rope_scaling that
+        # Transformers v5 leaves out of config.rope_parameters (without it get_rope
+        # falls back to base=10000). partial_rotary_factor is set on this local copy
+        # so the shared config is not mutated.
+        rope_parameters = _build_rope_parameters(config)
+        rope_parameters["partial_rotary_factor"] = rotary_dim / self.head_dim
 
         self.rotary_emb = get_rope(
             self.head_dim,
             max_position=config.max_position_embeddings,
-            rope_parameters=config.rope_parameters,
+            rope_parameters=rope_parameters,
             is_neox_style=True,
         )
 


### PR DESCRIPTION
# [Bugfix] Merge rope_theta into rope_parameters for BailingMoeV2

BailingMoeV2 passed `config.rope_parameters` straight to `get_rope` without
bridging the top-level `config.rope_theta`, unlike BailingMoeV3. Under
Transformers v5, `config.rope_parameters` does not carry `rope_theta`, so
`get_rope` fell back to `base=10000` while the model's real `rope_theta` is far
larger. This misaligns the whole RoPE spectrum and causes immediate repetition
loops from the first token.

Add `_build_rope_parameters` (V3-style, V2-adapted) to merge the top-level
`rope_theta` and the `rope_scaling` override (with legacy `"type"` -> `"rope_type"`)
into the dict handed to `get_rope`. `partial_rotary_factor` is now written on
this local copy instead of mutating the shared config.

## Purpose

Fix a RoPE base-frequency regression in `BailingMoeV2ForCausalLM` that causes
immediate repetition loops (no EOS; generation runs to `max_model_len`) from the
very first token, independent of context length.

- **Affected models:** any `BailingMoeV2ForCausalLM` checkpoint whose
  `rope_theta` lives at the top level of `config.json` and is not already inside
  `rope_parameters` -- e.g. `MedAIBase/AntAngelMed` and the public
  same-architecture `inclusionAI/Ling-flash-2.0` / `inclusionAI/Ling-mini-2.0`.
- **Root cause:** upstream commit `a8b70304d` migrated V2 to read
  `config.rope_parameters` and pass it to `get_rope`, but -- unlike the sibling
  `BailingMoeV3` (`bailing_moe_v3.py:_build_rope_parameters`) -- never bridged the
  top-level `config.rope_theta` into `rope_parameters`. `get_rope` then computes
  `base = rope_parameters.get("rope_theta", 10000)`
  (`vllm/model_executor/layers/rotary_embedding/__init__.py:64`) and falls back to
  `10000` while the trained base is `600000` (~60x off), rotating every position
  wrongly from token 1.
- `patch_rope_parameters` (`vllm/transformers_utils/config.py:550`) does not copy
  `rope_theta` into the `rope_parameters` dict (it only sets the top-level
  attribute and defers to transformers' `standardize_rope_params`), and
  `BailingMoeV3`'s own explicit merge is the in-repo proof that the top-level
  `rope_theta` is not auto-merged under Transformers v5. This PR gives V2 the same
  bridge V3 already has.

Triggering config (AntAngelMed, verified):

```jsonc
{
  "architectures": ["BailingMoeV2ForCausalLM"],
  "max_position_embeddings": 32768,
  "rope_theta": 600000,
  "partial_rotary_factor": 0.5,
  "rope_scaling": null            // yarn supplied via --hf-overrides
}
```

### Not duplicating an existing PR

#44158 (open) / #42624 (closed) "Fix(rope): preserve `rope_theta` in
`rope_parameters` ..." touch `transformers_utils/config.py:patch_rope_parameters`
for a different scenario: a v5-saved checkpoint (where `rope_theta` is already
inside `rope_parameters`) being overwritten by the bundled v4 transformers
default. Its guard ("don't overwrite an already-present `rope_theta`") does not
help here, because AntAngelMed's native `rope_parameters` has no `rope_theta` to
protect -- the value is never copied in. This PR fixes the model-layer merge V2 is
missing (mirroring V3), so the two are complementary.

## Test Plan

Verified end-to-end on Ascend 910B (vllm-ascend) with AntAngelMed
(`BailingMoeV2ForCausalLM`, `rope_theta=600000`):

```bash
vllm serve /mnt/models \
  --served-model-name=antangelmed-910b-64k-6xw6fvvqvfx70ew818oeh8 \
  --port=8080 --host=0.0.0.0 \
  --max-num-seqs=32 --max-num-batched-tokens=8192 \
  --tensor-parallel-size=4 --gpu-memory-utilization=0.94 \
  --max-model-len=65536 --block-size=32 \
  --trust-remote-code --enable-log-requests \
  --enable_expert_parallel \
  --compilation-config='{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
  --reasoning-parser=deepseek_r1 \
  --hf-overrides='{"rope_scaling":{"rope_type":"yarn","factor":2,"original_max_position_embeddings":32768}}'
```

Then issue a short chat request against the served endpoint and observe
generation.

## Test Result

- **Before fix:** from the first token the model repeats the same token/phrase in
  a loop and never emits EOS, running until `max_model_len` (65536) is exhausted
  (RoPE `base` effectively `10000` instead of `600000`).
- **After fix:** normal, coherent generation that terminates with EOS on the same
  prompts.

<!-- TODO(submitter): paste 2-3 before/after request/response snippets or a short
     log excerpt here to make the result concrete. -->

### AI assistance

Developed with AI assistance (Claude). The submitter reviewed every changed line.

---

Essential Elements of an Effective PR Description Checklist:

- [x] The purpose of the PR (fix the RoPE `base` regression in BailingMoeV2;
      affected models listed).
- [x] The test plan (serve command above).
- [x] The test results (before/after behavior; raw-snippet placeholder pending).
- [ ] (Optional) Documentation update -- not needed (behavior fix, no new model).
