### PR TITLE
[Perf][Frontend] Defer reasoning usage recounts for non-continuous chat streams

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -796,52 +796,126 @@ async def test_chat_streaming_metrics_ride_on_usage_chunk():
 
 
 @pytest.mark.asyncio
-async def test_streaming_reasoning_usage_counts_across_deltas():
-    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
-    serving._include_reasoning_tokens_details = True
+@pytest.mark.parametrize("n", [1, 2])
+@pytest.mark.parametrize("include_reasoning", [True, False])
+@pytest.mark.parametrize("include_details", [True, False])
+@pytest.mark.parametrize("separate_finish", [True, False])
+@pytest.mark.parametrize(
+    "stream_options, force_usage, include_usage, continuous_usage",
+    [
+        (None, False, False, False),
+        ({"include_usage": True}, False, True, False),
+        ({"include_usage": True, "continuous_usage_stats": True}, False, True, True),
+        ({"include_usage": False, "continuous_usage_stats": True}, False, False, False),
+        (None, True, True, True),
+    ],
+)
+async def test_streaming_reasoning_usage_counts_across_deltas(
+    n,
+    include_reasoning,
+    include_details,
+    separate_finish,
+    stream_options,
+    force_usage,
+    include_usage,
+    continuous_usage,
+):
+    """Final usage needs one recount per choice, not per streamed delta."""
+    serving = _build_minimal_metrics_serving_chat(
+        enable_per_request_metrics=False, enable_force_include_usage=force_usage
+    )
+    serving._include_reasoning_tokens_details = include_details
     serving.model_config = None
 
-    parser = MagicMock()
-    parser.parse_delta.side_effect = [
-        DeltaMessage(reasoning="reasoning"),
-        DeltaMessage(content="answer"),
-    ]
-    parser.count_reasoning_tokens.side_effect = lambda token_ids: sum(
-        token_id == 20 for token_id in token_ids
-    )
-    serving.parser_cls = MagicMock(return_value=parser)
-
-    first = _make_metrics_request_output(metrics=None, token_ids=(10, 20))
-    first.outputs[0].text = "<think>reasoning"
-    first.outputs[0].finish_reason = None
-    second = _make_metrics_request_output(metrics=None, token_ids=(11, 30))
-    second.outputs[0].text = "</think>answer"
+    parsers = [MagicMock() for _ in range(n)]
+    request_outputs = []
+    num_steps = 3 if separate_finish else 2
+    for parser in parsers:
+        parser.parse_delta.side_effect = [
+            DeltaMessage(reasoning="reasoning") if include_reasoning else None,
+            DeltaMessage(content="answer"),
+            DeltaMessage(),
+        ]
+        parser.count_reasoning_tokens.side_effect = lambda token_ids: sum(
+            token_id == 20 for token_id in token_ids
+        )
+    serving.parser_cls = MagicMock(side_effect=parsers)
+    for step in range(num_steps):
+        for i in reversed(range(n)):
+            tokens = ((10,) + (20,) * (i + 1), (11, 20, 30), ())[step]
+            result = _make_metrics_request_output(metrics=None, token_ids=tokens)
+            result.outputs[0].index = i
+            result.outputs[0].text = ("<think>reasoning", "</think>answer", "")[step]
+            finished = step == num_steps - 1
+            result.outputs[0].finish_reason = "stop" if finished else None
+            result.finished = finished and i == 0
+            request_outputs.append(result)
 
     request = ChatCompletionRequest(
         model="test-model",
         messages=[{"role": "user", "content": "Test prompt"}],
         max_tokens=10,
         stream=True,
-        stream_options={"include_usage": True},
+        n=n,
+        include_reasoning=include_reasoning,
+        return_token_ids=True,
+        stream_options=stream_options,
     )
+    metadata = RequestResponseMetadata(request_id="chatcmpl-test-id")
     chunks: list[dict[str, Any]] = []
     async for line in serving.chat_completion_stream_generator(
         request,
-        _stream_request_outputs(first, second),
+        _stream_request_outputs(*request_outputs),
         "chatcmpl-test-id",
         "test-model",
         conversation=[{"role": "user", "content": "Test"}],
         tokenizer=MagicMock(),
-        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+        request_metadata=metadata,
     ):
         payload = line.removeprefix("data: ").strip()
         if payload != "[DONE]":
             chunks.append(json.loads(payload))
 
-    usage_chunks = [chunk for chunk in chunks if chunk.get("usage")]
-    assert usage_chunks[-1]["usage"]["completion_tokens_details"] == {
-        "reasoning_tokens": 1
-    }
+    assert all("error" not in chunk for chunk in chunks)
+    expected_count = sum(i + 2 for i in range(n))
+    expected_details = {"reasoning_tokens": expected_count} if include_details else None
+    assert metadata.final_usage_info is not None
+    assert metadata.final_usage_info.model_dump()["completion_tokens_details"] == (
+        expected_details
+    )
+    final_chunks = [chunk for chunk in chunks if not chunk["choices"]]
+    assert len(final_chunks) == int(include_usage)
+    if include_usage:
+        assert final_chunks[0]["usage"].get("completion_tokens_details") == (
+            expected_details
+        )
+    for i, parser in enumerate(parsers):
+        expected_calls = (
+            (num_steps if continuous_usage else 1) if include_details else 0
+        )
+        assert parser.count_reasoning_tokens.call_count == expected_calls
+        if include_details:
+            assert parser.count_reasoning_tokens.call_args.args == (
+                (10,) + (20,) * (i + 1) + (11, 20, 30),
+            )
+        choices = [
+            chunk
+            for chunk in chunks
+            if chunk["choices"] and chunk["choices"][0]["index"] == i
+        ]
+        assert (
+            "".join(c["choices"][0]["delta"].get("content") or "" for c in choices)
+            == "answer"
+        )
+        if not include_reasoning:
+            assert all(c["choices"][0].get("token_ids") is None for c in choices)
+        if continuous_usage and include_details:
+            counts = [
+                c["usage"]["completion_tokens_details"]["reasoning_tokens"]
+                for c in choices
+            ]
+            expected_counts = [0, i + 1] if include_reasoning else [0]
+            assert counts == expected_counts + [i + 2] * (num_steps - 1)
 
 
 @dataclass

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -671,11 +671,14 @@ class OpenAIServingChat(GenerateBaseServing):
 
                     # set the previous values for the next iteration
                     previous_num_tokens[i] += len(output.token_ids)
-                    if parser is not None:
+                    if parser is not None and self._include_reasoning_tokens_details:
                         generated_token_ids[i].extend(output.token_ids)
-                        previous_reasoning_tokens[i] = parser.count_reasoning_tokens(
-                            tuple(generated_token_ids[i])
-                        )
+                        if include_continuous_usage:
+                            previous_reasoning_tokens[i] = (
+                                parser.count_reasoning_tokens(
+                                    tuple(generated_token_ids[i])
+                                )
+                            )
 
                     # if the message delta is None (e.g. because it was a
                     # "control token" for tool calls or the parser otherwise
@@ -812,6 +815,13 @@ class OpenAIServingChat(GenerateBaseServing):
 
                     data = chunk.model_dump_json(exclude_unset=True)
                     yield f"data: {data}\n\n"
+
+            if self._include_reasoning_tokens_details and not include_continuous_usage:
+                for i, parser in enumerate(parsers):
+                    if parser is not None and generated_token_ids[i]:
+                        previous_reasoning_tokens[i] = parser.count_reasoning_tokens(
+                            tuple(generated_token_ids[i])
+                        )
 
             # once the final token is handled, if stream_options.include_usage
             # is sent, send the usage


### PR DESCRIPTION
## Summary

Chat streaming recounts reasoning tokens from the full generated history on every delta, even when continuous usage is disabled. For Qwen's parser with thinking disabled, this falls back to repeatedly decoding and parsing the entire history.

Count once per nonempty choice before final usage and middleware metadata. Preserve per-delta counting for continuous/forced usage, and skip accounting-only work when reasoning usage details are disabled. No changes to parser counting rules, sampling, or model computation.

## Results

Historical A/B, pinned source `114abd1c`; one L40S, TP1, existing `Qwen3.8-27B-FP8` model directory (config: `Qwen3_5ForConditionalGeneration`). Same environment and default compile/CUDA graphs for both versions. Reverse-order repeat:

| Output workload | API CPU seconds: before → after | Reduction | Output tok/s: before → after |
|---|---:|---:|---:|
| 8 requests × 2,048 tokens | 21.45 → 3.34 | 84.4% | 184.23 → 184.25 |
| 1 request × 8,192 tokens | 46.81 → 5.87 | 87.5% | 25.177 → 25.182 |

CPU seconds measure API-process user+system time, not request wall time. **No meaningful model-throughput gain was observed.** Requests used temperature=0, seed=42 and ignore_eos for fixed lengths; this is serving validation, not a task-accuracy benchmark.

All single-request scenarios matched token IDs, text and usage. Replaying the same 25,344 model tokens through both frontends produced identical SSE and final usage in all five scenarios.

## Tests

Branch is merged with current `main` (`1596fa5f`). The serving hunk still matches HEAD: per-delta `count_reasoning_tokens` only when continuous/forced usage is on; otherwise one recount per nonempty choice before final usage.

Linux CPU re-run on GitHub main `1c3ef2ad` plus this patch (`CUDA_VISIBLE_DEVICES` empty, `VLLM_TARGET_DEVICE=cpu`):

```bash
python3 -m pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py \
  -k streaming_reasoning_usage -q --tb=line
```

- 119 passed, 47 deselected.
- 80 parametrized recount combinations (`n`, details on/off, continuous/forced/none).
- 39 lifecycle cases (13 × 3 usage modes): empty generator/outputs/finish/prefill, one empty choice, uneven finish, empty final delta, ignore finished choice, exception before/after, `finish_reason=error`, cancel, and `aclose`.
- Baseline still over-counts on the 64 excess-recount combinations; this patch reduces those to one call per nonempty choice when continuous usage is off.

## Related work

No same-scope open fix. #55216 optimizes membership checks inside reasoning extraction, not usage recount frequency. #44398 is an older reasoning-usage feature with a final-counting precedent; this patch optimizes the already-merged implementation while preserving continuous usage. #54238/#54585/#50240 change parser counting rules, not how often serving recounts. #56129 covers the reasoning field round-trip, not usage accounting.

AI assistance was used for implementation and validation. The submitter reviewed the changes and reran the relevant tests.
