### PR TITLE
[Bugfix][Frontend] Preserve metadata slots across modalities

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py
@@ -5,6 +5,7 @@ Roundtrip tests for multimodal serde used by the
 token_in_token_out generate endpoint.
 """
 
+import pytest
 import torch
 from pydantic import ValidationError
 
@@ -22,7 +23,7 @@ from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
     MultiModalFeatures,
     PlaceholderRangeInfo,
 )
-from vllm.inputs import mm_input
+from vllm.inputs import MultiModalInput, mm_input
 from vllm.multimodal.inputs import (
     MultiModalBatchedField,
     MultiModalFieldElem,
@@ -127,7 +128,7 @@ def _image_engine_input(
     *,
     pixel_keep_on_cpu: bool = False,
     grid_keep_on_cpu: bool = True,
-) -> tuple[object, MultiModalFieldElem, MultiModalFieldElem]:
+) -> tuple[MultiModalInput, MultiModalFieldElem, MultiModalFieldElem]:
     pixel_values = MultiModalFieldElem(
         data=torch.randn(5, 3, dtype=torch.float32),
         field=MultiModalBatchedField(keep_on_cpu=pixel_keep_on_cpu),
@@ -186,6 +187,47 @@ def test_extract_includes_declared_placeholder_metadata_fields():
     metadata = decode_mm_kwargs_item(features.mm_metadata["image"][0])
     assert set(metadata) == {"image_grid_thw"}
     assert torch.equal(metadata["image_grid_thw"].data, image_grid_thw.data)
+
+
+@pytest.mark.parametrize("metadata_source", ["cpu", "declared", "none"])
+def test_render_preserves_metadata_slots_across_modalities(metadata_source: str):
+    """Metadata stays aligned when only some modalities have metadata fields."""
+    engine_input, _, _ = _image_engine_input(grid_keep_on_cpu=metadata_source == "cpu")
+    audio = MultiModalFieldElem(
+        data=torch.ones(2, 3),
+        field=MultiModalBatchedField(),
+    )
+    engine_input["mm_kwargs"]["audio"] = [
+        MultiModalKwargsItem({"input_audio_embeds": audio}),
+        None,
+    ]
+    engine_input["mm_hashes"]["audio"] = ["audio", "cached-audio"]
+    engine_input["mm_placeholders"]["audio"] = [
+        PlaceholderRange(offset=1, length=1),
+        PlaceholderRange(offset=2, length=1),
+    ]
+
+    features = extract_mm_features(
+        engine_input,
+        metadata_fields_for=lambda modality: (
+            {"image_grid_thw"}
+            if modality == "image" and metadata_source == "declared"
+            else set()
+        ),
+    )
+    assert features is not None
+    features = MultiModalFeatures.model_validate_json(features.model_dump_json())
+    if metadata_source == "none":
+        assert features.mm_metadata is None
+    else:
+        assert features.mm_metadata is not None
+        assert features.mm_metadata["audio"] == [None, None]
+
+    restored = mm_kwargs_from_features(features)
+    assert restored["audio"][1] is None
+    audio_item = restored["audio"][0]
+    assert audio_item is not None
+    assert torch.equal(audio_item["input_audio_embeds"].data, audio.data)
 
 
 def test_legacy_kwargs_only_generate_keeps_full_payload():

--- a/vllm/entrypoints/scale_out/token_in_token_out/mm_features.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/mm_features.py
@@ -84,10 +84,17 @@ def _encode_mm_kwargs_with_metadata(
             else set()
         )
         metadata_items = _encode_metadata_items(items, declared=declared)
-        if any(item is not None for item in metadata_items):
-            metadata_by_modality[modality] = metadata_items
+        metadata_by_modality[modality] = metadata_items
 
-    mm_metadata = metadata_by_modality or None
+    mm_metadata = (
+        metadata_by_modality
+        if any(
+            item is not None
+            for items in metadata_by_modality.values()
+            for item in items
+        )
+        else None
+    )
     return kwargs_data, mm_metadata
 
 


### PR DESCRIPTION
## Purpose

Rendering a request with image and audio inputs fails if only the image has metadata. The encoder omits the audio key from `mm_metadata`, but `MultiModalFeatures` requires its modality keys to match `mm_hashes`.

Keep the all-`None` metadata slots for modalities without metadata. If no item has metadata, continue returning `mm_metadata=None`.

This PR can be merged independently of the per-item EC validation fix in #56070. It fixes the parallel fields produced by render; the other fix checks individual items after field alignment has been validated.

## Test Plan

Add an image/audio regression covering CPU metadata, declared metadata, and no metadata. Check that the JSON roundtrip preserves the audio payload and cache-hit slots.

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py \
  tests/entrypoints/scale_out/token_in_token_out/test_protocol.py -v

PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files \
  vllm/entrypoints/scale_out/token_in_token_out/mm_features.py \
  tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py
```

## Test Result

- Before the fix: the CPU and declared metadata cases fail with `mm_metadata must use the same modalities as mm_hashes`; the no-metadata control passes.
- After the fix: **23 passed** on macOS, including the existing serde and protocol tests.
- All applicable pre-commit checks passed.

The same before/after test results were reproduced on a Linux A10 host using four current Python files over a fixed `d9fbe526c078` base image, with the tests isolated from the repository's parent conftest.

Also ran an HTTP smoke test on a single A10 with `microsoft/Phi-4-multimodal-instruct` and its vision LoRA, using a red image and a one-second audio tone:

- Before: `POST /v1/chat/completions/render` returned 400 with the modality-mismatch error above.
- After: render returned 200 with `mm_metadata["audio"] == [None]`. Passing the rendered request to `/inference/v1/generate` returned 200, and `/detokenize` produced `Red<|end|>`.

The HTTP runs reused the `d9fbe526c078` image's native runtime, with five Python files from the tested commits and the same serving compatibility adapter (usage types and `mm_kwargs_from_features`). Only `mm_features.py` differed between baseline `c7e9816c6a` and fix `70e3bc59f697`. This exercised real model inference on one GPU.

Also reported in [this CodeRabbit review comment on #54659](https://github.com/vllm-project/vllm/pull/54659#discussion_r3944098664). No equivalent fix was found in the duplicate check on September 9, 2026.

AI assistance: Codex helped with the investigation, implementation, and tests.
