### PR TITLE
[CI][ROCm][Disagg] Enable breakable CUDA graphs for MiniMax-M3-MXFP8 decode

### DIFF
--- a/.buildkite/amd-disagg/models.yaml
+++ b/.buildkite/amd-disagg/models.yaml
@@ -51,7 +51,7 @@ models:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
       VLLM_ROCM_USE_AITER_RMSNORM: "1"
-      VLLM_USE_BREAKABLE_CUDAGRAPH: "0"
+      VLLM_USE_BREAKABLE_CUDAGRAPH: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT6"
     base_flags: "--trust-remote-code --attention-backend TRITON_ATTN --block-size 128 --language-model-only --kv-cache-dtype fp8"
     prefill:


### PR DESCRIPTION
## Purpose

Follow-up to [#54782](https://github.com/vllm-project/vllm/pull/54782). After that merge, MiniMax-M3-MXFP8 decode fails in our ROCm disagg CI:

```
RuntimeError: piecewise CUDA graphs (cudagraph_mode=FULL_AND_PIECEWISE) unavailable ...
Set VLLM_USE_BREAKABLE_CUDAGRAPH=1
```

Prefill runs eager; decode uses piecewise graphs. Set `VLLM_USE_BREAKABLE_CUDAGRAPH: "1"` in `models.yaml` so bring-up and GSM8K pass on nightly.

## Changes

`.buildkite/amd-disagg/models.yaml` only:

* `MiniMax-M3-MXFP8` env: `VLLM_USE_BREAKABLE_CUDAGRAPH: "0"` → `"1"`

No launcher, MoRIIO, or harness script changes.

## Test Plan

MoRIIO **1P1D TP8** disaggregated serving, `ROUTER_TYPE=proxy`, `RUN_AFTER_HEALTH=accuracy`, image `vllm/vllm-openai-rocm:nightly`.

### MiniMax-M3-MXFP8 — 1P1D TP8

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_RMSNORM=1
export VLLM_USE_BREAKABLE_CUDAGRAPH=1
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT6

# PREFILL — node0
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $PREFILL_IP --port 8100 -tp 8 \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_port":"14579",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"8100","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'

# DECODE — node1
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $DECODE_IP --port 8200 -tp 8 \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_port":"14579",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"8200","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'
```

### GSM8K evaluation

```bash
lm_eval --model local-completions \
    --tasks gsm8k \
    --model_args "model=/data/models2/MiniMax-M3-MXFP8,base_url=http://127.0.0.1:10001/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True,timeout=7200" \
    --limit 250
```

## Test Result

MiniMax-M3-MXFP8, MoRIIO 1P1D TP8 (proxy). GSM8K flexible-extract, threshold 0.90.

| Variant | Health | GSM8K exact_match |
| --- | --- | --- |
| [#54782](https://github.com/vllm-project/vllm/pull/54782) + upstream `models.yaml` (`VLLM_USE_BREAKABLE_CUDAGRAPH=0`) | Fail (decode `piecewise CUDA graphs unavailable`) | — |
| [#54782](https://github.com/vllm-project/vllm/pull/54782) + this fix | Pass | **0.9128** (PASS) |