### PR TITLE
Refactor cpu offloading - calculate gpu pointers and introduce fs ABC

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
@@ -25,6 +25,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.kv_offload.base import (
     CanonicalKVCacheRef,
     CanonicalKVCaches,
+    CanonicalKVCacheTensor,
     GPULoadStoreSpec,
     LoadStoreSpec,
     OffloadingManager,
@@ -117,6 +118,15 @@ def _make_worker(
         kv_cache_config=kv_cache_config,
     )
     worker.worker = MagicMock()
+
+    page_size = 128
+    tensor = torch.zeros(NUM_BLOCKS, page_size, dtype=torch.int8, device=DEVICE_TYPE)
+    worker._kv_caches = CanonicalKVCaches(
+        tensors=[CanonicalKVCacheTensor(tensor=tensor, page_size_bytes=page_size)],
+        group_data_refs=[
+            [CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=page_size)]
+        ],
+    )
 
     return worker, spec
 

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -79,7 +79,8 @@ class MockLoadStoreSpec(LoadStoreSpec):
 
 
 class MockOffloadingWorker(OffloadingWorker):
-    def __init__(self):
+    def __init__(self, gpu_spec_map: dict[int, "GPULoadStoreSpec"]):
+        self._gpu_spec_map = gpu_spec_map
         self.transfer_specs: dict[int, tuple[LoadStoreSpec, LoadStoreSpec]] = {}
         self.completed_transfers: list[TransferResult] = []
         self.waiting_jobs: set[int] = set()
@@ -94,16 +95,16 @@ class MockOffloadingWorker(OffloadingWorker):
     def submit_store(
         self, job_id: int, device_ptrs: DevicePointers, dst_spec: LoadStoreSpec
     ) -> bool:
-        assert device_ptrs.device_spec is not None
-        self.transfer_specs[job_id] = (device_ptrs.device_spec, dst_spec)
+        gpu_spec = self._gpu_spec_map.pop(id(device_ptrs))
+        self.transfer_specs[job_id] = (gpu_spec, dst_spec)
         self.waiting_jobs.add(job_id)
         return True
 
     def submit_load(
         self, job_id: int, src_spec: LoadStoreSpec, device_ptrs: DevicePointers
     ) -> bool:
-        assert device_ptrs.device_spec is not None
-        self.transfer_specs[job_id] = (src_spec, device_ptrs.device_spec)
+        gpu_spec = self._gpu_spec_map.pop(id(device_ptrs))
+        self.transfer_specs[job_id] = (src_spec, gpu_spec)
         self.waiting_jobs.add(job_id)
         return True
 
@@ -134,7 +135,21 @@ class MockOffloadingSpec(OffloadingSpec):
         self.manager.lookup.return_value = LookupResult.MISS
         self.manager.get_stats.return_value = None
         self.manager.on_new_request.return_value = RequestOffloadingContext()
-        self.handler = MockOffloadingWorker()
+
+        self._gpu_spec_map: dict[int, GPULoadStoreSpec] = {}
+        self.handler = MockOffloadingWorker(self._gpu_spec_map)
+
+        import vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker as _cm
+        from vllm.v1.kv_offload.base import resolve_device_pointers as _orig
+
+        def _tracking_resolve(
+            device_spec: GPULoadStoreSpec, kv_caches: CanonicalKVCaches
+        ) -> DevicePointers:
+            result = _orig(device_spec, kv_caches)
+            self._gpu_spec_map[id(result)] = device_spec
+            return result
+
+        _cm.resolve_device_pointers = _tracking_resolve
 
     def get_manager(self) -> OffloadingManager:
         return self.manager

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -44,6 +44,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_offload.base import (
     CanonicalKVCaches,
+    DevicePointers,
     GPULoadStoreSpec,
     LoadStoreSpec,
     LookupResult,
@@ -91,16 +92,18 @@ class MockOffloadingWorker(OffloadingWorker):
         return finished
 
     def submit_store(
-        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec
-    ) -> bool:  # type: ignore[override]
-        self.transfer_specs[job_id] = (src_spec, dst_spec)
+        self, job_id: int, device_ptrs: DevicePointers, dst_spec: LoadStoreSpec
+    ) -> bool:
+        assert device_ptrs.device_spec is not None
+        self.transfer_specs[job_id] = (device_ptrs.device_spec, dst_spec)
         self.waiting_jobs.add(job_id)
         return True
 
     def submit_load(
-        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec
-    ) -> bool:  # type: ignore[override]
-        self.transfer_specs[job_id] = (src_spec, dst_spec)
+        self, job_id: int, src_spec: LoadStoreSpec, device_ptrs: DevicePointers
+    ) -> bool:
+        assert device_ptrs.device_spec is not None
+        self.transfer_specs[job_id] = (src_spec, device_ptrs.device_spec)
         self.waiting_jobs.add(job_id)
         return True
 

--- a/tests/v1/kv_offload/cpu/test_canonical_layout.py
+++ b/tests/v1/kv_offload/cpu/test_canonical_layout.py
@@ -9,9 +9,12 @@ import torch
 
 from vllm.v1.kv_offload.base import (
     CanonicalKVCacheRef,
+    CanonicalKVCaches,
+    CanonicalKVCacheTensor,
     CanonicalPageMapping,
     CopyRun,
     GPULoadStoreSpec,
+    resolve_device_pointers,
 )
 from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.cpu.gpu_worker import (
@@ -93,14 +96,14 @@ def _whole_page_mapping() -> CanonicalPageMapping:
     return CanonicalPageMapping(2048, 2048, (identity,), 1, 0, True)
 
 
-def _transfer(handler, num_blocks: int, gpu_to_cpu: bool) -> None:
+def _transfer(handler, kv_caches, num_blocks: int, gpu_to_cpu: bool) -> None:
     block_ids = list(range(num_blocks))
     gpu_spec = GPULoadStoreSpec(
         block_ids, group_sizes=(num_blocks,), block_indices=(0,)
     )
     cpu_spec = CPULoadStoreSpec(block_ids)
-    src, dst = (gpu_spec, cpu_spec) if gpu_to_cpu else (cpu_spec, gpu_spec)
-    assert handler.transfer_async(0, src, dst)
+    device_ptrs = resolve_device_pointers(gpu_spec, kv_caches)
+    assert handler.transfer_async(0, device_ptrs, cpu_spec)
     deadline = time.time() + 30
     while time.time() < deadline:
         if handler.get_finished():
@@ -109,11 +112,20 @@ def _transfer(handler, num_blocks: int, gpu_to_cpu: bool) -> None:
     raise TimeoutError("transfer did not complete")
 
 
-def _canonical_handler(gpu_tensor, cpu_tensor, mapping, gpu_to_cpu):
+def _make_kv_caches(gpu_tensor, mapping):
+    page = mapping.local_page_size_bytes
+    return CanonicalKVCaches(
+        tensors=[CanonicalKVCacheTensor(tensor=gpu_tensor, page_size_bytes=page)],
+        group_data_refs=[
+            [CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=page, mapping=mapping)]
+        ],
+    )
+
+
+def _canonical_handler(cpu_tensor, mapping, gpu_to_cpu):
     page = mapping.local_page_size_bytes
     refs = [[CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=page, mapping=mapping)]]
     return SingleDirectionOffloadingHandler(
-        gpu_tensors=[gpu_tensor],
         cpu_tensors=[cpu_tensor],
         blocks_per_chunk=1,
         layer_refs_per_group=refs,
@@ -136,10 +148,10 @@ def test_gpu_roundtrip_assembles_canonical_page_across_ranks():
     cpu_canonical = torch.zeros(num_blocks, 2048, dtype=torch.int8, pin_memory=True)
 
     for rank in (0, 1):
-        store = _canonical_handler(
-            gpu_rank[rank], cpu_canonical, _tp2_rank_mapping(rank), gpu_to_cpu=True
-        )
-        _transfer(store, num_blocks, gpu_to_cpu=True)
+        mapping = _tp2_rank_mapping(rank)
+        kv_caches = _make_kv_caches(gpu_rank[rank], mapping)
+        store = _canonical_handler(cpu_canonical, mapping, gpu_to_cpu=True)
+        _transfer(store, kv_caches, num_blocks, gpu_to_cpu=True)
     torch.accelerator.synchronize()
 
     # independent oracle: replay each rank's runs in numpy
@@ -157,19 +169,19 @@ def test_gpu_roundtrip_assembles_canonical_page_across_ranks():
 
     # each rank reloads its shard bit-exact
     gpu_back = torch.zeros(num_blocks, 1024, dtype=torch.int8, device="cuda")
-    load = _canonical_handler(
-        gpu_back, cpu_canonical, _tp2_rank_mapping(0), gpu_to_cpu=False
-    )
-    _transfer(load, num_blocks, gpu_to_cpu=False)
+    mapping = _tp2_rank_mapping(0)
+    kv_caches = _make_kv_caches(gpu_back, mapping)
+    load = _canonical_handler(cpu_canonical, mapping, gpu_to_cpu=False)
+    _transfer(load, kv_caches, num_blocks, gpu_to_cpu=False)
     torch.accelerator.synchronize()
     assert torch.equal(gpu_back, gpu_rank[0])
 
     # a whole-page reader (TP1 topology) sees the assembled page
     gpu_full = torch.zeros(num_blocks, 2048, dtype=torch.int8, device="cuda")
-    load_full = _canonical_handler(
-        gpu_full, cpu_canonical, _whole_page_mapping(), gpu_to_cpu=False
-    )
-    _transfer(load_full, num_blocks, gpu_to_cpu=False)
+    mapping = _whole_page_mapping()
+    kv_caches = _make_kv_caches(gpu_full, mapping)
+    load_full = _canonical_handler(cpu_canonical, mapping, gpu_to_cpu=False)
+    _transfer(load_full, kv_caches, num_blocks, gpu_to_cpu=False)
     torch.accelerator.synchronize()
     assert torch.equal(gpu_full.cpu(), cpu_canonical)
 
@@ -245,25 +257,28 @@ def test_cross_topology_roundtrip(writer_tp: int, reader_tp: int):
 
     try:
         for rank in range(writer_tp):
+            mapping = _nhd_shard_mapping(writer_tp, rank)
+            gpu_shard = _head_shard(full_kv, writer_tp, rank).cuda()
+            kv_caches = _make_kv_caches(gpu_shard, mapping)
             store = _canonical_handler(
-                _head_shard(full_kv, writer_tp, rank).cuda(),
                 canonical_view(rank, writer_tp),
-                _nhd_shard_mapping(writer_tp, rank),
+                mapping,
                 gpu_to_cpu=True,
             )
-            _transfer(store, num_blocks, gpu_to_cpu=True)
+            _transfer(store, kv_caches, num_blocks, gpu_to_cpu=True)
         torch.accelerator.synchronize()
 
         for rank in range(reader_tp):
             expected = _head_shard(full_kv, reader_tp, rank)
             gpu_out = torch.zeros_like(expected, device="cuda")
+            mapping = _nhd_shard_mapping(reader_tp, rank)
+            kv_caches = _make_kv_caches(gpu_out, mapping)
             load = _canonical_handler(
-                gpu_out,
                 canonical_view(rank, reader_tp),
-                _nhd_shard_mapping(reader_tp, rank),
+                mapping,
                 gpu_to_cpu=False,
             )
-            _transfer(load, num_blocks, gpu_to_cpu=False)
+            _transfer(load, kv_caches, num_blocks, gpu_to_cpu=False)
             torch.accelerator.synchronize()
             assert torch.equal(gpu_out.cpu(), expected), (
                 f"reader tp={reader_tp} rank={rank} bytes diverge from the "

--- a/tests/v1/kv_offload/cpu/test_canonical_layout.py
+++ b/tests/v1/kv_offload/cpu/test_canonical_layout.py
@@ -96,7 +96,7 @@ def _whole_page_mapping() -> CanonicalPageMapping:
     return CanonicalPageMapping(2048, 2048, (identity,), 1, 0, True)
 
 
-def _transfer(handler, kv_caches, num_blocks: int, gpu_to_cpu: bool) -> None:
+def _transfer(handler, kv_caches, num_blocks: int) -> None:
     block_ids = list(range(num_blocks))
     gpu_spec = GPULoadStoreSpec(
         block_ids, group_sizes=(num_blocks,), block_indices=(0,)
@@ -151,7 +151,7 @@ def test_gpu_roundtrip_assembles_canonical_page_across_ranks():
         mapping = _tp2_rank_mapping(rank)
         kv_caches = _make_kv_caches(gpu_rank[rank], mapping)
         store = _canonical_handler(cpu_canonical, mapping, gpu_to_cpu=True)
-        _transfer(store, kv_caches, num_blocks, gpu_to_cpu=True)
+        _transfer(store, kv_caches, num_blocks)
     torch.accelerator.synchronize()
 
     # independent oracle: replay each rank's runs in numpy
@@ -172,7 +172,7 @@ def test_gpu_roundtrip_assembles_canonical_page_across_ranks():
     mapping = _tp2_rank_mapping(0)
     kv_caches = _make_kv_caches(gpu_back, mapping)
     load = _canonical_handler(cpu_canonical, mapping, gpu_to_cpu=False)
-    _transfer(load, kv_caches, num_blocks, gpu_to_cpu=False)
+    _transfer(load, kv_caches, num_blocks)
     torch.accelerator.synchronize()
     assert torch.equal(gpu_back, gpu_rank[0])
 
@@ -181,7 +181,7 @@ def test_gpu_roundtrip_assembles_canonical_page_across_ranks():
     mapping = _whole_page_mapping()
     kv_caches = _make_kv_caches(gpu_full, mapping)
     load_full = _canonical_handler(cpu_canonical, mapping, gpu_to_cpu=False)
-    _transfer(load_full, kv_caches, num_blocks, gpu_to_cpu=False)
+    _transfer(load_full, kv_caches, num_blocks)
     torch.accelerator.synchronize()
     assert torch.equal(gpu_full.cpu(), cpu_canonical)
 
@@ -265,7 +265,7 @@ def test_cross_topology_roundtrip(writer_tp: int, reader_tp: int):
                 mapping,
                 gpu_to_cpu=True,
             )
-            _transfer(store, kv_caches, num_blocks, gpu_to_cpu=True)
+            _transfer(store, kv_caches, num_blocks)
         torch.accelerator.synchronize()
 
         for rank in range(reader_tp):
@@ -278,7 +278,7 @@ def test_cross_topology_roundtrip(writer_tp: int, reader_tp: int):
                 mapping,
                 gpu_to_cpu=False,
             )
-            _transfer(load, kv_caches, num_blocks, gpu_to_cpu=False)
+            _transfer(load, kv_caches, num_blocks)
             torch.accelerator.synchronize()
             assert torch.equal(gpu_out.cpu(), expected), (
                 f"reader tp={reader_tp} rank={rank} bytes diverge from the "

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -19,6 +19,7 @@ from vllm.v1.kv_offload.base import (
     CanonicalKVCacheTensor,
     GPULoadStoreSpec,
     TransferResult,
+    resolve_device_pointers,
 )
 from vllm.v1.kv_offload.cpu import gpu_worker
 from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
@@ -164,8 +165,7 @@ def test_handler_shutdown_skips_transfers_after_event_sync_failure() -> None:
     handler._stream_pool = [MagicMock()]
     handler._event_pool = [MagicMock()]
     handler._buffer_pool = [(MagicMock(), MagicMock(), MagicMock())]
-    handler.src_tensors = [MagicMock()]
-    handler.dst_tensors = [MagicMock()]
+    handler.cpu_tensors = [MagicMock()]
 
     with pytest.raises(RuntimeError, match="device lost"):
         handler.shutdown()
@@ -176,8 +176,7 @@ def test_handler_shutdown_skips_transfers_after_event_sync_failure() -> None:
     assert not handler._stream_pool
     assert not handler._event_pool
     assert not handler._buffer_pool
-    assert not handler.src_tensors
-    assert not handler.dst_tensors
+    assert not handler.cpu_tensors
 
 
 @pytest.mark.parametrize("device_sync_fails", [False, True])
@@ -324,40 +323,43 @@ def test_transfer(
         gpu_blocks = gpu_blocks[blocks_to_skip:]
         cpu_blocks_expanded = cpu_blocks_expanded[blocks_to_skip:]
 
-    # set transfer direction
+    # build specs and resolve device pointers
+    gpu_spec = GPULoadStoreSpec(
+        gpu_blocks, group_sizes=(len(gpu_blocks),), block_indices=(blocks_to_skip,)
+    )
+    cpu_spec = CPULoadStoreSpec(cpu_blocks)
+    device_ptrs = resolve_device_pointers(gpu_spec, kv_caches)
+
+    handler = worker._store_handler if gpu_to_cpu else worker._load_handler
     if gpu_to_cpu:
-        handler = worker._store_handler
-        src_spec = GPULoadStoreSpec(
-            gpu_blocks, group_sizes=(len(gpu_blocks),), block_indices=(blocks_to_skip,)
-        )
-        dst_spec = CPULoadStoreSpec(cpu_blocks)
         dst_to_src = dict(zip(cpu_blocks_expanded, gpu_blocks))
-        num_dst_sub_blocks = num_gpu_blocks
     else:
-        handler = worker._load_handler
-        src_spec = CPULoadStoreSpec(cpu_blocks)
-        dst_spec = GPULoadStoreSpec(
-            gpu_blocks, group_sizes=(len(gpu_blocks),), block_indices=(blocks_to_skip,)
-        )
         dst_to_src = dict(zip(gpu_blocks, cpu_blocks_expanded))
-        num_dst_sub_blocks = num_gpu_blocks
+    num_dst_sub_blocks = num_gpu_blocks
 
-    # randomize src and dst tensors before transfer
-    for tensor in handler.src_tensors:
+    # collect gpu and cpu tensor lists for verification
+    gpu_tensors = [t.tensor for t in kv_caches.tensors]
+    cpu_tensors = handler.cpu_tensors
+
+    # randomize all tensors before transfer
+    for tensor in gpu_tensors:
         tensor.random_()
-    for tensor in handler.dst_tensors:
+    for tensor in cpu_tensors:
         tensor.random_()
 
-    # clone src and dst tensors before transfer
-    orig_src_tensors = [x.clone() for x in handler.src_tensors]
-    orig_dst_tensors = [x.clone() for x in handler.dst_tensors]
+    # re-resolve after randomization (pointers are stable, data changed)
+    device_ptrs = resolve_device_pointers(gpu_spec, kv_caches)
+
+    # clone tensors before transfer
+    orig_gpu_tensors = [x.clone() for x in gpu_tensors]
+    orig_cpu_tensors = [x.clone() for x in cpu_tensors]
 
     # call transfer function via public API
     start_time = time.time()
     if gpu_to_cpu:
-        assert worker.submit_store(1, src_spec, dst_spec)
+        assert worker.submit_store(1, device_ptrs, cpu_spec)
     else:
-        assert worker.submit_load(1, src_spec, dst_spec)
+        assert worker.submit_load(1, cpu_spec, device_ptrs)
     assert {x.job_id for x in handler._transfers} == {1}
 
     # wait for transfer to complete
@@ -376,15 +378,21 @@ def test_transfer(
             break
         time.sleep(0.1)
 
+    # determine src/dst by direction
+    if gpu_to_cpu:
+        src_tensors, dst_tensors = gpu_tensors, cpu_tensors
+        orig_src_tensors, orig_dst_tensors = orig_gpu_tensors, orig_cpu_tensors
+    else:
+        src_tensors, dst_tensors = cpu_tensors, gpu_tensors
+        orig_src_tensors, orig_dst_tensors = orig_cpu_tensors, orig_gpu_tensors
+
     # verify src tensors did not change
-    for orig_tensor, tensor in zip(orig_src_tensors, handler.src_tensors):
+    for orig_tensor, tensor in zip(orig_src_tensors, src_tensors):
         assert torch.equal(orig_tensor, tensor)
 
     # verify dst tensors at gpu-page granularity.
     for src_tensor, dst_tensor, orig_dst_tensor in zip(
-        handler.src_tensors,
-        handler.dst_tensors,
-        orig_dst_tensors,
+        src_tensors, dst_tensors, orig_dst_tensors
     ):
         # view both GPU and CPU tensors as (n, gpu_page_size_bytes) for comparison.
         src_view = src_tensor.reshape(-1, gpu_page_size_bytes)
@@ -528,12 +536,15 @@ def test_transfer_multi_group(
     # block_indices: only relevant for unaligned transfers
     block_indices: list[int] = [0, 0, sub_blocks_to_skip]
 
+    # build specs and resolve device pointers
+    gpu_spec = GPULoadStoreSpec(
+        gpu_blocks, group_sizes=group_sizes, block_indices=block_indices
+    )
+    cpu_spec = CPULoadStoreSpec(cpu_blocks)
+    device_ptrs = resolve_device_pointers(gpu_spec, canonical_kv_caches)
+
+    handler = worker._store_handler if gpu_to_cpu else worker._load_handler
     if gpu_to_cpu:
-        handler = worker._store_handler
-        src_spec = GPULoadStoreSpec(
-            gpu_blocks, group_sizes=group_sizes, block_indices=block_indices
-        )
-        dst_spec = CPULoadStoreSpec(cpu_blocks)
         # per-group mapping: cpu sub-block -> gpu sub-block
         dst_to_src_per_group = [
             dict(zip(expanded, gpu_blks))
@@ -543,11 +554,6 @@ def test_transfer_multi_group(
         ]
         num_dst_sub_blocks = num_cpu_blocks * blocks_per_chunk
     else:
-        handler = worker._load_handler
-        src_spec = CPULoadStoreSpec(cpu_blocks)
-        dst_spec = GPULoadStoreSpec(
-            gpu_blocks, group_sizes=group_sizes, block_indices=block_indices
-        )
         # per-group mapping: gpu sub-block -> cpu sub-block
         dst_to_src_per_group = [
             dict(zip(gpu_blks, expanded))
@@ -557,19 +563,26 @@ def test_transfer_multi_group(
         ]
         num_dst_sub_blocks = num_gpu_blocks
 
-    # randomize src and dst tensors before transfer
-    for tensor in handler.src_tensors:
+    # collect gpu and cpu tensor lists for verification
+    gpu_tensors = [t.tensor for t in canonical_kv_caches.tensors]
+    cpu_tensors = handler.cpu_tensors
+
+    # randomize all tensors before transfer
+    for tensor in gpu_tensors:
         tensor.random_()
-    for tensor in handler.dst_tensors:
+    for tensor in cpu_tensors:
         tensor.random_()
 
-    orig_src_tensors = [x.clone() for x in handler.src_tensors]
-    orig_dst_tensors = [x.clone() for x in handler.dst_tensors]
+    # re-resolve after randomization
+    device_ptrs = resolve_device_pointers(gpu_spec, canonical_kv_caches)
+
+    orig_gpu_tensors = [x.clone() for x in gpu_tensors]
+    orig_cpu_tensors = [x.clone() for x in cpu_tensors]
 
     if gpu_to_cpu:
-        assert worker.submit_store(1, src_spec, dst_spec)
+        assert worker.submit_store(1, device_ptrs, cpu_spec)
     else:
-        assert worker.submit_load(1, src_spec, dst_spec)
+        assert worker.submit_load(1, cpu_spec, device_ptrs)
     assert {x.job_id for x in handler._transfers} == {1}
 
     end_time = time.time() + 10
@@ -588,16 +601,24 @@ def test_transfer_multi_group(
             break
         time.sleep(0.1)
 
+    # determine src/dst by direction
+    if gpu_to_cpu:
+        src_tensors, dst_tensors = gpu_tensors, cpu_tensors
+        orig_src_tensors, orig_dst_tensors = orig_gpu_tensors, orig_cpu_tensors
+    else:
+        src_tensors, dst_tensors = cpu_tensors, gpu_tensors
+        orig_src_tensors, orig_dst_tensors = orig_cpu_tensors, orig_gpu_tensors
+
     # verify src tensors did not change
-    for orig_tensor, tensor in zip(orig_src_tensors, handler.src_tensors):
+    for orig_tensor, tensor in zip(orig_src_tensors, src_tensors):
         assert torch.equal(orig_tensor, tensor)
 
     # verify dst tensors at gpu-page granularity
     for group_idx, dst_to_src in enumerate(dst_to_src_per_group):
         group_tensor_offset = group_idx * tensors_per_group
         for tensor_idx in range(tensors_per_group):
-            src_tensor = handler.src_tensors[group_tensor_offset + tensor_idx]
-            dst_tensor = handler.dst_tensors[group_tensor_offset + tensor_idx]
+            src_tensor = src_tensors[group_tensor_offset + tensor_idx]
+            dst_tensor = dst_tensors[group_tensor_offset + tensor_idx]
             orig_dst_tensor = orig_dst_tensors[group_tensor_offset + tensor_idx]
             src_view = src_tensor.view(-1, gpu_page_size_bytes)
             dst_view = dst_tensor.view(-1, gpu_page_size_bytes)
@@ -632,21 +653,20 @@ def test_load_waits_for_pending_compute_stream_writes(default_vllm_config) -> No
         (num_blocks, page_size_bytes), dtype=torch.int8, device=device
     )
     loaded_block_ids = torch.tensor(loaded_blocks, dtype=torch.long, device=device)
+    kv_caches = CanonicalKVCaches(
+        tensors=[
+            CanonicalKVCacheTensor(tensor=gpu_tensor, page_size_bytes=page_size_bytes)
+        ],
+        group_data_refs=[
+            [CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=page_size_bytes)]
+        ],
+    )
     worker = CPUOffloadingWorker(
-        kv_caches=CanonicalKVCaches(
-            tensors=[
-                CanonicalKVCacheTensor(
-                    tensor=gpu_tensor, page_size_bytes=page_size_bytes
-                )
-            ],
-            group_data_refs=[
-                [CanonicalKVCacheRef(tensor_idx=0, page_size_bytes=page_size_bytes)]
-            ],
-        ),
+        kv_caches=kv_caches,
         blocks_per_chunk=1,
         num_cpu_blocks=num_blocks,
     )
-    worker._load_handler.src_tensors[0].fill_(sentinel)
+    worker._load_handler.cpu_tensors[0].fill_(sentinel)
     expected = torch.full((page_size_bytes,), sentinel, dtype=torch.int8)
 
     try:
@@ -660,14 +680,16 @@ def test_load_waits_for_pending_compute_stream_writes(default_vllm_config) -> No
             torch.cuda._sleep(50_000_000)
             gpu_tensor.index_fill_(0, loaded_block_ids, 0)
 
+            gpu_spec = GPULoadStoreSpec(
+                loaded_blocks,
+                group_sizes=(len(loaded_blocks),),
+                block_indices=(0,),
+            )
+            device_ptrs = resolve_device_pointers(gpu_spec, kv_caches)
             assert worker.submit_load(
                 trial + 1,
                 CPULoadStoreSpec(loaded_blocks),
-                GPULoadStoreSpec(
-                    loaded_blocks,
-                    group_sizes=(len(loaded_blocks),),
-                    block_indices=(0,),
-                ),
+                device_ptrs,
             )
             deadline = time.time() + 10
             finished: list[TransferResult] = []

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -347,9 +347,6 @@ def test_transfer(
     for tensor in cpu_tensors:
         tensor.random_()
 
-    # re-resolve after randomization (pointers are stable, data changed)
-    device_ptrs = resolve_device_pointers(gpu_spec, kv_caches)
-
     # clone tensors before transfer
     orig_gpu_tensors = [x.clone() for x in gpu_tensors]
     orig_cpu_tensors = [x.clone() for x in cpu_tensors]
@@ -572,9 +569,6 @@ def test_transfer_multi_group(
         tensor.random_()
     for tensor in cpu_tensors:
         tensor.random_()
-
-    # re-resolve after randomization
-    device_ptrs = resolve_device_pointers(gpu_spec, canonical_kv_caches)
 
     orig_gpu_tensors = [x.clone() for x in gpu_tensors]
     orig_cpu_tensors = [x.clone() for x in cpu_tensors]

--- a/tests/v1/kv_offload/fs/test_fs_worker.py
+++ b/tests/v1/kv_offload/fs/test_fs_worker.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for FSOffloadingWorker._submit_io block_indices handling."""
+
+import numpy as np
+
+from vllm.v1.kv_offload.base import DevicePointers
+from vllm.v1.kv_offload.file_mapper import FileMapper
+from vllm.v1.kv_offload.fs.worker import FSOffloadingWorker
+
+
+class RecordingFSWorker(FSOffloadingWorker):
+    """Concrete FSOffloadingWorker that records I/O ops instead of doing I/O."""
+
+    def __init__(self, block_size_factor: int):
+        mapper = FileMapper("/tmp/test", ".bin")
+        super().__init__(file_mapper=mapper, block_size_factor=block_size_factor)
+        self.recorded: list[tuple[str, list[tuple[int, int, int]]]] = []
+
+    def write_block(self, file_path, ops):
+        self.recorded.append((file_path, ops))
+
+    def read_block(self, file_path, ops):
+        self.recorded.append((file_path, ops))
+
+
+def _make_device_ptrs(
+    n_blocks: int,
+    n_data_refs: int,
+    block_size: int,
+    block_indices: tuple[int, ...],
+) -> DevicePointers:
+    """Build a single-group DevicePointers with sequential fake pointers."""
+    n_ops = n_blocks * n_data_refs
+    ptrs = np.arange(1000, 1000 + n_ops, dtype=np.uint64) * block_size
+    sizes = np.full(n_ops, block_size, dtype=np.uint64)
+    return DevicePointers(
+        ptrs=ptrs,
+        sizes=sizes,
+        group_block_counts=(n_blocks,),
+        group_data_ref_counts=(n_data_refs,),
+        block_indices=block_indices,
+    )
+
+
+def test_offset_within_single_file():
+    """block_size_factor=3, block_indices=(1,), 2 blocks → 1 file at positions 1,2."""
+    worker = RecordingFSWorker(block_size_factor=3)
+    block_size = 64
+    device_ptrs = _make_device_ptrs(
+        n_blocks=2, n_data_refs=1, block_size=block_size, block_indices=(1,)
+    )
+    keys = ["key0"]
+
+    futures, total_bytes = worker._submit_io(device_ptrs, keys, is_store=True)
+    for f in futures:
+        f.result()
+
+    assert len(worker.recorded) == 1
+    _, ops = worker.recorded[0]
+    assert len(ops) == 2
+    # file offsets should be at positions 1 and 2, not 0 and 1
+    assert ops[0][2] == 1 * block_size
+    assert ops[1][2] == 2 * block_size
+
+
+def test_offset_spanning_two_files():
+    """block_size_factor=3, block_indices=(2,), 3 blocks → 2 files.
+
+    First file: 1 block at position 2.
+    Second file: 2 blocks at positions 0,1.
+    """
+    worker = RecordingFSWorker(block_size_factor=3)
+    block_size = 64
+    device_ptrs = _make_device_ptrs(
+        n_blocks=3, n_data_refs=1, block_size=block_size, block_indices=(2,)
+    )
+    keys = ["key0", "key1"]
+
+    futures, total_bytes = worker._submit_io(device_ptrs, keys, is_store=True)
+    for f in futures:
+        f.result()
+
+    assert len(worker.recorded) == 2
+
+    # First file: 1 block at file position 2
+    _, ops0 = worker.recorded[0]
+    assert len(ops0) == 1
+    assert ops0[0][2] == 2 * block_size
+
+    # Second file: 2 blocks at file positions 0,1
+    _, ops1 = worker.recorded[1]
+    assert len(ops1) == 2
+    assert ops1[0][2] == 0 * block_size
+    assert ops1[1][2] == 1 * block_size

--- a/tests/v1/kv_offload/fs/test_fs_worker.py
+++ b/tests/v1/kv_offload/fs/test_fs_worker.py
@@ -4,16 +4,31 @@
 
 import numpy as np
 
-from vllm.v1.kv_offload.base import DevicePointers
+from vllm.v1.kv_offload.base import DevicePointers, make_offload_key
 from vllm.v1.kv_offload.file_mapper import FileMapper
 from vllm.v1.kv_offload.fs.worker import FSOffloadingWorker
+
+
+def _keys(n: int):
+    return [make_offload_key(f"k{i}".encode().ljust(8, b"\0"), 0) for i in range(n)]
 
 
 class RecordingFSWorker(FSOffloadingWorker):
     """Concrete FSOffloadingWorker that records I/O ops instead of doing I/O."""
 
     def __init__(self, block_size_factor: int):
-        mapper = FileMapper("/tmp/test", ".bin")
+        mapper = FileMapper(
+            root_dir="/tmp/test",
+            model_name="test",
+            tokens_per_hash=16,
+            blocks_per_file=block_size_factor,
+            tp_size=1,
+            pp_size=1,
+            pcp_size=1,
+            dcp_size=1,
+            rank=0,
+            dtype="float16",
+        )
         super().__init__(file_mapper=mapper, block_size_factor=block_size_factor)
         self.recorded: list[tuple[str, list[tuple[int, int, int]]]] = []
 
@@ -50,7 +65,7 @@ def test_offset_within_single_file():
     device_ptrs = _make_device_ptrs(
         n_blocks=2, n_data_refs=1, block_size=block_size, block_indices=(1,)
     )
-    keys = ["key0"]
+    keys = _keys(1)
 
     futures, total_bytes = worker._submit_io(device_ptrs, keys, is_store=True)
     for f in futures:
@@ -75,7 +90,7 @@ def test_offset_spanning_two_files():
     device_ptrs = _make_device_ptrs(
         n_blocks=3, n_data_refs=1, block_size=block_size, block_indices=(2,)
     )
-    keys = ["key0", "key1"]
+    keys = _keys(2)
 
     futures, total_bytes = worker._submit_io(device_ptrs, keys, is_store=True)
     for f in futures:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -30,6 +30,7 @@ from vllm.v1.kv_offload.base import (
     LoadStoreSpec,
     OffloadingSpec,
     OffloadingWorker,
+    resolve_device_pointers,
 )
 
 logger = init_logger(__name__)
@@ -61,6 +62,7 @@ class OffloadingConnectorWorker:
         self._connector_worker_meta = OffloadingWorkerMetadata()
 
     def _init_worker(self, kv_caches: CanonicalKVCaches) -> None:
+        self._kv_caches = kv_caches
         self.worker = self.spec.get_worker(kv_caches)
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
@@ -225,7 +227,8 @@ class OffloadingConnectorWorker:
         # Submit deferred stores from previous step (and jobs_to_flush above).
         for job_id, src_spec, dst_spec in self._unsubmitted_store_jobs:
             assert isinstance(src_spec, GPULoadStoreSpec)
-            success = self.worker.submit_store(job_id, src_spec, dst_spec)
+            device_ptrs = resolve_device_pointers(src_spec, self._kv_caches)
+            success = self.worker.submit_store(job_id, device_ptrs, dst_spec)
             assert success
         self._unsubmitted_store_jobs.clear()
 
@@ -235,14 +238,17 @@ class OffloadingConnectorWorker:
     def start_kv_transfers(self, metadata: OffloadingConnectorMetadata):
         assert self.worker is not None
         for job_id, src_spec, dst_spec in self._unsubmitted_store_jobs:
-            success = self.worker.submit_store(job_id, src_spec, dst_spec)
+            assert isinstance(src_spec, GPULoadStoreSpec)
+            device_ptrs = resolve_device_pointers(src_spec, self._kv_caches)
+            success = self.worker.submit_store(job_id, device_ptrs, dst_spec)
             assert success
         self._unsubmitted_store_jobs.clear()
 
         for job_id, entry in metadata.load_jobs.items():
             self._load_jobs[job_id] = entry.req_id
             assert isinstance(entry.dst_spec, GPULoadStoreSpec)
-            success = self.worker.submit_load(job_id, entry.src_spec, entry.dst_spec)
+            device_ptrs = resolve_device_pointers(entry.dst_spec, self._kv_caches)
+            success = self.worker.submit_load(job_id, entry.src_spec, device_ptrs)
             assert success
 
     def prepare_store_kv(self, metadata: OffloadingConnectorMetadata):

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -593,14 +593,13 @@ def resolve_device_pointers(
         if group_size == 0:
             continue
         group_block_ids = block_ids[blk_offset : blk_offset + group_size]
+        group_block_ids_u64 = group_block_ids.astype(np.uint64)
         for data_ref in data_refs:
             tensor = kv_caches.tensors[data_ref.tensor_idx].tensor
             base_ptr = np.uint64(tensor.data_ptr())
             row_stride = np.uint64(tensor.stride(0))
             end_idx = op_idx + group_size
-            ptrs[op_idx:end_idx] = (
-                base_ptr + group_block_ids.astype(np.uint64) * row_stride
-            )
+            ptrs[op_idx:end_idx] = base_ptr + group_block_ids_u64 * row_stride
             sizes[op_idx:end_idx] = data_ref.page_size_bytes
             op_idx = end_idx
         blk_offset += group_size

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -143,17 +143,6 @@ class LoadStoreSpec:
     """
 
 
-class FSLoadStoreSpec(LoadStoreSpec):
-    """Spec for loading/storing KV blocks from a filesystem tier.
-
-    Carries content-addressed OffloadKeys that the worker resolves to
-    file paths via a FileMapper.
-    """
-
-    def __init__(self, keys: list["OffloadKey"]):
-        self.keys = keys
-
-
 @dataclass
 class PrepareStoreOutput:
     keys_to_store: list[OffloadKey]
@@ -573,6 +562,13 @@ def resolve_device_pointers(
     Called once at the OffloadingConnectorWorker boundary.
     GPU blocks_per_chunk is always 1, so resolution is a direct
     vectorized lookup: base_ptr + block_id * row_stride.
+
+    See also compute_sub_block_ptrs in cpu/gpu_worker.py which does
+    the analogous resolution for CPU tensors, including sub-block
+    expansion for blocks_per_chunk > 1. Both functions could share
+    the inner pointer computation, but the sub block expansion in
+    compute_sub_block_ptrs make them different with the common part
+    being just being the base_ptr+block_id*stride calculation.
     """
     block_ids = device_spec.block_ids
     group_sizes = device_spec.group_sizes

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -561,6 +561,7 @@ class DevicePointers:
     group_block_counts: tuple[int, ...]  # device blocks per group
     group_data_ref_counts: tuple[int, ...]  # data_refs per group
     block_indices: tuple[int, ...]  # logical block offset per group
+    device_spec: "GPULoadStoreSpec | None" = None  # original spec (debugging)
 
 
 def resolve_device_pointers(
@@ -613,6 +614,7 @@ def resolve_device_pointers(
         group_block_counts=tuple(group_sizes),
         group_data_ref_counts=tuple(len(refs) for refs in group_data_refs),
         block_indices=tuple(block_indices),
+        device_spec=device_spec,
     )
 
 

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -5,13 +5,15 @@ Core abstractions for KV cache offloading in vLLM v1.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, NewType, TypeVar
 
 import numpy as np
 import torch
+
+from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
     from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
@@ -550,7 +552,39 @@ class DevicePointers:
     group_block_counts: tuple[int, ...]  # device blocks per group
     group_data_ref_counts: tuple[int, ...]  # data_refs per group
     block_indices: tuple[int, ...]  # logical block offset per group
-    device_spec: "GPULoadStoreSpec | None" = None  # original spec (debugging)
+
+    def iter_groups(self, blocks_per_chunk: int) -> "Iterator[DevicePointerGroupInfo]":
+        """Iterate non-empty groups with pre-computed chunk/skip metadata."""
+        dev_ptr_offset = 0
+        for group_idx, (group_size, n_data_refs, block_idx) in enumerate(
+            zip(
+                self.group_block_counts,
+                self.group_data_ref_counts,
+                self.block_indices,
+            )
+        ):
+            if group_size == 0:
+                continue
+            skip = block_idx % blocks_per_chunk
+            n_chunks = cdiv(group_size + skip, blocks_per_chunk)
+            yield DevicePointerGroupInfo(
+                group_idx=group_idx,
+                group_size=group_size,
+                n_data_refs=n_data_refs,
+                skip=skip,
+                n_chunks=n_chunks,
+                dev_ptr_offset=dev_ptr_offset,
+            )
+            dev_ptr_offset += group_size * n_data_refs
+
+
+class DevicePointerGroupInfo(NamedTuple):
+    group_idx: int
+    group_size: int
+    n_data_refs: int
+    skip: int
+    n_chunks: int
+    dev_ptr_offset: int
 
 
 def resolve_device_pointers(
@@ -558,17 +592,8 @@ def resolve_device_pointers(
     kv_caches: CanonicalKVCaches,
 ) -> DevicePointers:
     """Convert logical block IDs to device memory pointers.
-
-    Called once at the OffloadingConnectorWorker boundary.
     GPU blocks_per_chunk is always 1, so resolution is a direct
     vectorized lookup: base_ptr + block_id * row_stride.
-
-    See also compute_sub_block_ptrs in cpu/gpu_worker.py which does
-    the analogous resolution for CPU tensors, including sub-block
-    expansion for blocks_per_chunk > 1. Both functions could share
-    the inner pointer computation, but the sub block expansion in
-    compute_sub_block_ptrs make them different with the common part
-    being just being the base_ptr+block_id*stride calculation.
     """
     block_ids = device_spec.block_ids
     group_sizes = device_spec.group_sizes
@@ -610,7 +635,6 @@ def resolve_device_pointers(
         group_block_counts=tuple(group_sizes),
         group_data_ref_counts=tuple(len(refs) for refs in group_data_refs),
         block_indices=tuple(block_indices),
-        device_spec=device_spec,
     )
 
 

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -143,6 +143,17 @@ class LoadStoreSpec:
     """
 
 
+class FSLoadStoreSpec(LoadStoreSpec):
+    """Spec for loading/storing KV blocks from a filesystem tier.
+
+    Carries content-addressed OffloadKeys that the worker resolves to
+    file paths via a FileMapper.
+    """
+
+    def __init__(self, keys: list["OffloadKey"]):
+        self.keys = keys
+
+
 @dataclass
 class PrepareStoreOutput:
     keys_to_store: list[OffloadKey]
@@ -445,8 +456,10 @@ class CanonicalKVCacheTensor:
     """
     A canonicalized KV cache tensor whose first dimension is num_blocks.
 
-    With standardized layouts (RFC #42082) num_blocks is always the leading
-    logical dimension.
+    For attention backends where the raw tensor has num_blocks at a
+    non-leading physical dimension (e.g. FlashAttention's
+    (2, num_blocks, ...) layout), the tensor is split so that each
+    resulting CanonicalKVCacheTensor starts with (num_blocks, ...).
     """
 
     # The KV cache tensor with shape (num_blocks, ...)
@@ -533,6 +546,78 @@ class CanonicalKVCaches:
 
 
 @dataclass
+class DevicePointers:
+    """Pre-resolved device pointers for a transfer.
+
+    Flat arrays in canonical order:
+        for each group:
+            for each data_ref in group:
+                for each block in group:
+                    ptrs[i], sizes[i]
+    """
+
+    ptrs: np.ndarray  # uint64, device memory addresses
+    sizes: np.ndarray  # uint64, byte sizes per copy op
+    group_block_counts: tuple[int, ...]  # device blocks per group
+    group_data_ref_counts: tuple[int, ...]  # data_refs per group
+    block_indices: tuple[int, ...]  # logical block offset per group
+
+
+def resolve_device_pointers(
+    device_spec: "GPULoadStoreSpec",
+    kv_caches: CanonicalKVCaches,
+) -> DevicePointers:
+    """Convert logical block IDs to device memory pointers.
+
+    Called once at the OffloadingConnectorWorker boundary.
+    GPU blocks_per_chunk is always 1, so resolution is a direct
+    vectorized lookup: base_ptr + block_id * row_stride.
+    """
+    block_ids = device_spec.block_ids
+    group_sizes = device_spec.group_sizes
+    block_indices = device_spec.block_indices
+    group_data_refs = kv_caches.group_data_refs
+
+    assert len(group_sizes) == len(group_data_refs)
+    assert len(block_indices) == len(group_sizes)
+
+    num_copy_ops = sum(gs * len(refs) for gs, refs in zip(group_sizes, group_data_refs))
+
+    ptrs = np.empty(num_copy_ops, dtype=np.uint64)
+    sizes = np.empty(num_copy_ops, dtype=np.uint64)
+
+    blk_offset = 0
+    op_idx = 0
+
+    for group_size, data_refs in zip(group_sizes, group_data_refs):
+        if group_size == 0:
+            continue
+        group_block_ids = block_ids[blk_offset : blk_offset + group_size]
+        for data_ref in data_refs:
+            tensor = kv_caches.tensors[data_ref.tensor_idx].tensor
+            base_ptr = np.uint64(tensor.data_ptr())
+            row_stride = np.uint64(tensor.stride(0))
+            end_idx = op_idx + group_size
+            ptrs[op_idx:end_idx] = (
+                base_ptr + group_block_ids.astype(np.uint64) * row_stride
+            )
+            sizes[op_idx:end_idx] = data_ref.page_size_bytes
+            op_idx = end_idx
+        blk_offset += group_size
+
+    assert blk_offset == len(block_ids)
+    assert op_idx == num_copy_ops
+
+    return DevicePointers(
+        ptrs=ptrs,
+        sizes=sizes,
+        group_block_counts=tuple(group_sizes),
+        group_data_ref_counts=tuple(len(refs) for refs in group_data_refs),
+        block_indices=tuple(block_indices),
+    )
+
+
+@dataclass
 class TransferResult:
     job_id: int
     success: bool
@@ -547,15 +632,15 @@ class OffloadingWorker(ABC):
 
     @abstractmethod
     def submit_store(
-        self, job_id: int, src_spec: GPULoadStoreSpec, dst_spec: LoadStoreSpec
+        self, job_id: int, device_ptrs: DevicePointers, dst_spec: LoadStoreSpec
     ) -> bool:
-        """Async GPU -> offloaded medium."""
+        """Async device -> offloaded medium."""
 
     @abstractmethod
     def submit_load(
-        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: GPULoadStoreSpec
+        self, job_id: int, src_spec: LoadStoreSpec, device_ptrs: DevicePointers
     ) -> bool:
-        """Async offloaded medium -> GPU."""
+        """Async offloaded medium -> device."""
 
     @abstractmethod
     def get_finished(self) -> list[TransferResult]: ...

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -551,6 +551,7 @@ class SingleDirectionOffloadingHandler:
             dev_ptr_offset += group_size * n_data_refs
 
         assert cpu_offset == num_cpu_blocks
+        assert dev_ptr_offset == len(device_ptrs.ptrs)
         # Writer rotation may skip non-writer blocks, leaving op_idx below
         # the sized upper bound
         assert op_idx <= num_copy_ops
@@ -706,13 +707,9 @@ class CPUOffloadingWorker(OffloadingWorker):
             else None
         )
 
-        gpu_tensors: list[torch.Tensor] = []
         cpu_tensors: list[torch.Tensor] = []
         for t_idx, kv_cache_tensor in enumerate(kv_caches.tensors):
             gpu_page_size_bytes = kv_cache_tensor.page_size_bytes
-            gpu_tensor = kv_cache_tensor.tensor.view(torch.int8).view(
-                (-1, gpu_page_size_bytes)
-            )
             cpu_page_size_bytes = gpu_page_size_bytes * blocks_per_chunk
 
             if canonical_bytes_per_block is not None:
@@ -738,7 +735,6 @@ class CPUOffloadingWorker(OffloadingWorker):
                     time.monotonic() - t0,
                 )
 
-            gpu_tensors.append(gpu_tensor)
             cpu_tensors.append(cpu_tensor)
 
         self._store_handler = SingleDirectionOffloadingHandler(

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -14,7 +14,6 @@ from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, triton
-from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.kv_offload.base import (
     BlockIDsLoadStoreSpec,
@@ -343,25 +342,17 @@ class SingleDirectionOffloadingHandler:
 
             ptr_start = dev_ptr_offset + d * group_size
             gpu_ptrs = device_ptrs.ptrs[ptr_start : ptr_start + group_size]
-            if self.gpu_to_cpu:
-                all_src[op_idx:end_idx] = gpu_ptrs
-                compute_sub_block_ptrs(
-                    cpu_block_ids,
-                    self.blocks_per_chunk,
-                    all_dst[op_idx:end_idx],
-                    self.cpu_tensors[t_idx],
-                    skip_count=cpu_skip_count,
-                )
-            else:
-                all_dst[op_idx:end_idx] = gpu_ptrs
-                compute_sub_block_ptrs(
-                    cpu_block_ids,
-                    self.blocks_per_chunk,
-                    all_src[op_idx:end_idx],
-                    self.cpu_tensors[t_idx],
-                    skip_count=cpu_skip_count,
-                )
-
+            gpu_out, cpu_out = (
+                (all_src, all_dst) if self.gpu_to_cpu else (all_dst, all_src)
+            )
+            gpu_out[op_idx:end_idx] = gpu_ptrs
+            compute_sub_block_ptrs(
+                cpu_block_ids,
+                self.blocks_per_chunk,
+                cpu_out[op_idx:end_idx],
+                self.cpu_tensors[t_idx],
+                skip_count=cpu_skip_count,
+            )
             all_sizes[op_idx:end_idx] = data_ref.page_size_bytes
             num_bytes += group_size * data_ref.page_size_bytes
             op_idx = end_idx
@@ -494,12 +485,7 @@ class SingleDirectionOffloadingHandler:
         assert cpu_blocks.ndim == 1
         num_cpu_blocks = len(cpu_blocks)
 
-        group_sizes = device_ptrs.group_block_counts
-        block_indices = device_ptrs.block_indices
-        assert len(group_sizes) == len(self.layer_refs_per_group)
-        assert len(block_indices) == len(self.layer_refs_per_group)
-
-        num_copy_ops = self._estimate_max_copy_ops(group_sizes)
+        num_copy_ops = self._estimate_max_copy_ops(device_ptrs.group_block_counts)
 
         # reuse a pooled buffer set, growing it if this transfer needs more room
         batch_src, batch_dst, batch_sizes = (
@@ -518,29 +504,19 @@ class SingleDirectionOffloadingHandler:
         all_sizes = sizes.numpy()
 
         cpu_offset = 0
-        dev_ptr_offset = 0
         op_idx = 0
         num_transfer_bytes = 0
-        for g_idx, (group_size, block_idx) in enumerate(
-            zip(group_sizes, block_indices)
-        ):
-            n_data_refs = len(self.layer_refs_per_group[g_idx])
-            if group_size == 0:
-                continue
-
-            cpu_skip = block_idx % self.blocks_per_chunk
-            cpu_logical_count = group_size + cpu_skip
-            cpu_blocks_count = cdiv(cpu_logical_count, self.blocks_per_chunk)
-            cpu_end_offset = cpu_offset + cpu_blocks_count
+        for g in device_ptrs.iter_groups(self.blocks_per_chunk):
+            cpu_end_offset = cpu_offset + g.n_chunks
             assert cpu_end_offset <= num_cpu_blocks
 
             op_idx, group_bytes = self._fill_group_ops(
-                g_idx,
+                g.group_idx,
                 device_ptrs=device_ptrs,
-                dev_ptr_offset=dev_ptr_offset,
+                dev_ptr_offset=g.dev_ptr_offset,
                 cpu_block_ids=cpu_blocks[cpu_offset:cpu_end_offset],
-                group_size=group_size,
-                cpu_skip_count=cpu_skip,
+                group_size=g.group_size,
+                cpu_skip_count=g.skip,
                 all_src=all_src,
                 all_dst=all_dst,
                 all_sizes=all_sizes,
@@ -548,10 +524,8 @@ class SingleDirectionOffloadingHandler:
             )
             num_transfer_bytes += group_bytes
             cpu_offset = cpu_end_offset
-            dev_ptr_offset += group_size * n_data_refs
 
         assert cpu_offset == num_cpu_blocks
-        assert dev_ptr_offset == len(device_ptrs.ptrs)
         # Writer rotation may skip non-writer blocks, leaving op_idx below
         # the sized upper bound
         assert op_idx <= num_copy_ops

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -21,7 +21,7 @@ from vllm.v1.kv_offload.base import (
     CanonicalKVCacheRef,
     CanonicalKVCaches,
     CanonicalPageMapping,
-    GPULoadStoreSpec,
+    DevicePointers,
     LoadStoreSpec,
     OffloadingWorker,
     TransferResult,
@@ -243,69 +243,36 @@ class SingleDirectionOffloadingHandler:
 
     def __init__(
         self,
-        gpu_tensors: list[torch.Tensor],
         cpu_tensors: list[torch.Tensor],
         blocks_per_chunk: int,
         layer_refs_per_group: list[list[CanonicalKVCacheRef]],
         gpu_to_cpu: bool,
         canonical_layout: bool = False,
     ):
-        """
-        Initialize a SingleDirectionOffloadingHandler.
+        """Initialize a SingleDirectionOffloadingHandler.
 
         Args:
-            gpu_tensors: list of GPU KV cache tensors.
-                Each of shape (num_gpu_blocks, gpu_page_size_bytes) with dtype int8.
             cpu_tensors: list of CPU KV cache tensors.
                 Each of shape (num_cpu_blocks, cpu_page_size_bytes) with dtype int8.
-                Order should match gpu_tensors.
             layer_refs_per_group: list of CanonicalKVCacheRef per group.
             gpu_to_cpu: if True, transfer from GPU to CPU; otherwise CPU to GPU.
             canonical_layout: if True, CPU pages use the canonical layout
                 described by the refs' mappings.
         """
-        assert len(gpu_tensors) == len(cpu_tensors)
-        assert len(gpu_tensors) > 0
+        assert len(cpu_tensors) > 0
 
-        canonical_bytes_per_block = (
-            _canonical_block_sizes(layer_refs_per_group, len(gpu_tensors))
-            if canonical_layout
-            else None
-        )
-
-        # assert input tensors are as expected
-        for t_idx, (gpu_tensor, cpu_tensor) in enumerate(zip(gpu_tensors, cpu_tensors)):
-            assert gpu_tensor.dtype == torch.int8
-            assert gpu_tensor.ndim == 2
-            assert gpu_tensor.is_cuda or gpu_tensor.is_xpu
+        for cpu_tensor in cpu_tensors:
             assert cpu_tensor.dtype == torch.int8
             assert cpu_tensor.ndim == 2
             assert cpu_tensor.device.type == "cpu"
-            _, gpu_page_size = gpu_tensor.shape
-            _, cpu_page_size = cpu_tensor.shape
-            if canonical_bytes_per_block is not None:
-                assert (
-                    cpu_page_size == canonical_bytes_per_block[t_idx] * blocks_per_chunk
-                )
-            else:
-                assert cpu_page_size == gpu_page_size * blocks_per_chunk
 
-        self.src_tensors: list[torch.Tensor] = (
-            gpu_tensors if gpu_to_cpu else cpu_tensors
-        )
-        self.dst_tensors: list[torch.Tensor] = (
-            cpu_tensors if gpu_to_cpu else gpu_tensors
-        )
+        self.cpu_tensors = cpu_tensors
         self.gpu_to_cpu: bool = gpu_to_cpu
         self.layer_refs_per_group = layer_refs_per_group
         self._swap_blocks_batch = _select_swap_blocks_fn(
             layer_refs_per_group, gpu_to_cpu
         )
-
-        # GPU blocks may be smaller
-        # cpu_page_size = gpu_page_size * blocks_per_chunk.
-        self.src_blocks_per_chunk = 1 if self.gpu_to_cpu else blocks_per_chunk
-        self.dst_blocks_per_chunk = blocks_per_chunk if self.gpu_to_cpu else 1
+        self.blocks_per_chunk = blocks_per_chunk
 
         # Per (group, ref) static copy plans for the canonical layout
         self._canonical_copy_plans: list[list[CopyPlan]] | None = (
@@ -321,9 +288,8 @@ class SingleDirectionOffloadingHandler:
         )
         # Reusable per-block base-pointer scratch for the canonical fill,
         # sized to the largest possible group (grown on demand)
-        num_scratch_blocks = gpu_tensors[0].shape[0] if canonical_layout else 0
-        self._scratch_bases_src = np.empty(num_scratch_blocks, dtype=np.uint64)
-        self._scratch_bases_dst = np.empty(num_scratch_blocks, dtype=np.uint64)
+        num_scratch_blocks = cpu_tensors[0].shape[0] if canonical_layout else 0
+        self._scratch_bases_cpu = np.empty(num_scratch_blocks, dtype=np.uint64)
 
         # job_id -> event
         self._transfer_events: dict[int, torch.Event] = {}
@@ -356,11 +322,11 @@ class SingleDirectionOffloadingHandler:
     def _fill_direct_ops(
         self,
         g_idx: int,
-        group_src: np.ndarray,
-        group_dst: np.ndarray,
+        device_ptrs: DevicePointers,
+        dev_ptr_offset: int,
+        cpu_block_ids: np.ndarray,
         group_size: int,
-        src_skip_count: int,
-        dst_skip_count: int,
+        cpu_skip_count: int,
         all_src: np.ndarray,
         all_dst: np.ndarray,
         all_sizes: np.ndarray,
@@ -371,24 +337,30 @@ class SingleDirectionOffloadingHandler:
 
         Returns (op_idx past the filled descriptors, bytes added)."""
         num_bytes = 0
-        for data_ref in self.layer_refs_per_group[g_idx]:
+        for d, data_ref in enumerate(self.layer_refs_per_group[g_idx]):
             t_idx = data_ref.tensor_idx
             end_idx = op_idx + group_size
 
-            compute_sub_block_ptrs(
-                group_src,
-                self.src_blocks_per_chunk,
-                all_src[op_idx:end_idx],
-                self.src_tensors[t_idx],
-                skip_count=src_skip_count,
-            )
-            compute_sub_block_ptrs(
-                group_dst,
-                self.dst_blocks_per_chunk,
-                all_dst[op_idx:end_idx],
-                self.dst_tensors[t_idx],
-                skip_count=dst_skip_count,
-            )
+            ptr_start = dev_ptr_offset + d * group_size
+            gpu_ptrs = device_ptrs.ptrs[ptr_start : ptr_start + group_size]
+            if self.gpu_to_cpu:
+                all_src[op_idx:end_idx] = gpu_ptrs
+                compute_sub_block_ptrs(
+                    cpu_block_ids,
+                    self.blocks_per_chunk,
+                    all_dst[op_idx:end_idx],
+                    self.cpu_tensors[t_idx],
+                    skip_count=cpu_skip_count,
+                )
+            else:
+                all_dst[op_idx:end_idx] = gpu_ptrs
+                compute_sub_block_ptrs(
+                    cpu_block_ids,
+                    self.blocks_per_chunk,
+                    all_src[op_idx:end_idx],
+                    self.cpu_tensors[t_idx],
+                    skip_count=cpu_skip_count,
+                )
 
             all_sizes[op_idx:end_idx] = data_ref.page_size_bytes
             num_bytes += group_size * data_ref.page_size_bytes
@@ -398,11 +370,11 @@ class SingleDirectionOffloadingHandler:
     def _fill_canonical_ops(
         self,
         g_idx: int,
-        group_src: np.ndarray,
-        group_dst: np.ndarray,
+        device_ptrs: DevicePointers,
+        dev_ptr_offset: int,
+        cpu_block_ids: np.ndarray,
         group_size: int,
-        src_skip_count: int,
-        dst_skip_count: int,
+        cpu_skip_count: int,
         all_src: np.ndarray,
         all_dst: np.ndarray,
         all_sizes: np.ndarray,
@@ -418,35 +390,38 @@ class SingleDirectionOffloadingHandler:
         # buffers' int64 are bit-equivalent for addresses
         all_src_u64 = all_src.view(np.uint64)
         all_dst_u64 = all_dst.view(np.uint64)
-        if group_size > len(self._scratch_bases_src):
-            self._scratch_bases_src = np.empty(group_size, dtype=np.uint64)
-            self._scratch_bases_dst = np.empty(group_size, dtype=np.uint64)
+        if group_size > len(self._scratch_bases_cpu):
+            self._scratch_bases_cpu = np.empty(group_size, dtype=np.uint64)
 
         num_bytes = 0
-        for plan, data_ref in zip(
-            self._canonical_copy_plans[g_idx], self.layer_refs_per_group[g_idx]
+        for d, (plan, data_ref) in enumerate(
+            zip(
+                self._canonical_copy_plans[g_idx],
+                self.layer_refs_per_group[g_idx],
+            )
         ):
             if plan.num_frags == 0:
                 continue
             t_idx = data_ref.tensor_idx
 
             # 1. Base byte pointer of every block on each side
-            block_bases_src = self._scratch_bases_src[:group_size]
-            block_bases_dst = self._scratch_bases_dst[:group_size]
+            ptr_start = dev_ptr_offset + d * group_size
+            gpu_bases = device_ptrs.ptrs[ptr_start : ptr_start + group_size]
+            cpu_bases = self._scratch_bases_cpu[:group_size]
             compute_sub_block_ptrs(
-                group_src,
-                self.src_blocks_per_chunk,
-                block_bases_src,
-                self.src_tensors[t_idx],
-                skip_count=src_skip_count,
+                cpu_block_ids,
+                self.blocks_per_chunk,
+                cpu_bases,
+                self.cpu_tensors[t_idx],
+                skip_count=cpu_skip_count,
             )
-            compute_sub_block_ptrs(
-                group_dst,
-                self.dst_blocks_per_chunk,
-                block_bases_dst,
-                self.dst_tensors[t_idx],
-                skip_count=dst_skip_count,
-            )
+
+            if self.gpu_to_cpu:
+                block_bases_src = gpu_bases
+                block_bases_dst = cpu_bases
+            else:
+                block_bases_src = cpu_bases
+                block_bases_dst = gpu_bases
 
             # 2. On store, keep only the blocks this rank is elected to write
             mapping = data_ref.mapping
@@ -456,9 +431,9 @@ class SingleDirectionOffloadingHandler:
                     block_bases_src,
                     block_bases_dst,
                     mapping,
-                    group_dst,
+                    cpu_block_ids,
                     group_size,
-                    dst_skip_count,
+                    cpu_skip_count,
                 )
             num_active_blocks = len(block_bases_src)
 
@@ -493,63 +468,35 @@ class SingleDirectionOffloadingHandler:
         block_bases_src: np.ndarray,
         block_bases_dst: np.ndarray,
         mapping: CanonicalPageMapping,
-        group_dst: np.ndarray,
+        cpu_block_ids: np.ndarray,
         group_size: int,
-        dst_skip_count: int,
+        cpu_skip_count: int,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Keep only the blocks this rank writes: replicated ranks take turns
         writing shared canonical pages, keyed by the rank-consistent CPU-side
         canonical page id."""
         cpu_page_ids = _canonical_page_ids(
-            group_dst,
-            self.dst_blocks_per_chunk,
+            cpu_block_ids,
+            self.blocks_per_chunk,
             group_size,
-            dst_skip_count,
+            cpu_skip_count,
         )
         writer_mask = cpu_page_ids % mapping.num_writers == mapping.writer_index
         return block_bases_src[writer_mask], block_bases_dst[writer_mask]
 
     def transfer_async(
-        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec
+        self,
+        job_id: int,
+        device_ptrs: DevicePointers,
+        cpu_spec: BlockIDsLoadStoreSpec,
     ) -> bool:
-        assert isinstance(src_spec, BlockIDsLoadStoreSpec)
-        assert isinstance(dst_spec, BlockIDsLoadStoreSpec)
+        cpu_blocks = cpu_spec.block_ids
+        assert cpu_blocks.ndim == 1
+        num_cpu_blocks = len(cpu_blocks)
 
-        src_blocks = src_spec.block_ids
-        dst_blocks = dst_spec.block_ids
-        assert src_blocks.ndim == 1
-        assert dst_blocks.ndim == 1
-
-        num_src_blocks = len(src_blocks)
-        num_dst_blocks = len(dst_blocks)
-
-        # There are 2 types of transfers:
-        # 1. GPU -> CPU
-        # 2. CPU -> GPU
-        #
-        # transfers are also to CPU blocks, EXCEPT MAYBE for the first and last block.
-        # i.e. the first and last CPU blocks in src_blocks can match against
-        # a smaller (byte-wise) set of GPU blocks in dst_blocks.
-        # In such cases, we may need to skip some gpu-sized sub-blocks,
-        # and start reading/writing from the middle of the first CPU block.
-        # If we have multiple KV cache groups (when using HMA with hybrid models),
-        # we may have a partial first/last CPU block per each group.
-        # The group_sizes parameter encodes the size of each group of blocks
-        # in the GPU dst_blocks.
-        # If group_sizes is None, we assume all blocks belong to a single group.
-        # The logical_offset parameter maps each group of blocks to its logical
-        # offset inside the request, counting in GPU blocks.
-        # This allows us to find the correct starting position
-        # in the matching first CPU block.
-
-        # extract group_sizes from the GPU spec
-        gpu_spec = src_spec if self.gpu_to_cpu else dst_spec
-        assert isinstance(gpu_spec, GPULoadStoreSpec)
-        group_sizes = gpu_spec.group_sizes
+        group_sizes = device_ptrs.group_block_counts
+        block_indices = device_ptrs.block_indices
         assert len(group_sizes) == len(self.layer_refs_per_group)
-
-        # extract block indices from the GPU spec
-        block_indices = gpu_spec.block_indices
         assert len(block_indices) == len(self.layer_refs_per_group)
 
         num_copy_ops = self._estimate_max_copy_ops(group_sizes)
@@ -570,49 +517,40 @@ class SingleDirectionOffloadingHandler:
         all_dst = dst.numpy()
         all_sizes = sizes.numpy()
 
-        src_offset = 0
-        dst_offset = 0
+        cpu_offset = 0
+        dev_ptr_offset = 0
         op_idx = 0
-        # count total number of bytes copied
         num_transfer_bytes = 0
         for g_idx, (group_size, block_idx) in enumerate(
             zip(group_sizes, block_indices)
         ):
+            n_data_refs = len(self.layer_refs_per_group[g_idx])
             if group_size == 0:
                 continue
 
-            src_logical_blocks_to_skip = block_idx % self.src_blocks_per_chunk
-            dst_logical_blocks_to_skip = block_idx % self.dst_blocks_per_chunk
-            src_logical_blocks_count = group_size + src_logical_blocks_to_skip
-            dst_logical_blocks_count = group_size + dst_logical_blocks_to_skip
-
-            dst_blocks_count = cdiv(dst_logical_blocks_count, self.dst_blocks_per_chunk)
-            dst_end_offset = dst_offset + dst_blocks_count
-            assert dst_end_offset <= num_dst_blocks
-
-            src_blocks_count = cdiv(src_logical_blocks_count, self.src_blocks_per_chunk)
-            src_end_offset = src_offset + src_blocks_count
-            assert src_end_offset <= num_src_blocks
+            cpu_skip = block_idx % self.blocks_per_chunk
+            cpu_logical_count = group_size + cpu_skip
+            cpu_blocks_count = cdiv(cpu_logical_count, self.blocks_per_chunk)
+            cpu_end_offset = cpu_offset + cpu_blocks_count
+            assert cpu_end_offset <= num_cpu_blocks
 
             op_idx, group_bytes = self._fill_group_ops(
                 g_idx,
-                group_src=src_blocks[src_offset:src_end_offset],
-                group_dst=dst_blocks[dst_offset:dst_end_offset],
+                device_ptrs=device_ptrs,
+                dev_ptr_offset=dev_ptr_offset,
+                cpu_block_ids=cpu_blocks[cpu_offset:cpu_end_offset],
                 group_size=group_size,
-                src_skip_count=src_logical_blocks_to_skip,
-                dst_skip_count=dst_logical_blocks_to_skip,
+                cpu_skip_count=cpu_skip,
                 all_src=all_src,
                 all_dst=all_dst,
                 all_sizes=all_sizes,
                 op_idx=op_idx,
             )
             num_transfer_bytes += group_bytes
+            cpu_offset = cpu_end_offset
+            dev_ptr_offset += group_size * n_data_refs
 
-            src_offset = src_end_offset
-            dst_offset = dst_end_offset
-
-        assert src_offset == num_src_blocks
-        assert dst_offset == num_dst_blocks
+        assert cpu_offset == num_cpu_blocks
         # Writer rotation may skip non-writer blocks, leaving op_idx below
         # the sized upper bound
         assert op_idx <= num_copy_ops
@@ -731,8 +669,7 @@ class SingleDirectionOffloadingHandler:
         self._stream_pool.clear()
         self._event_pool.clear()
         self._buffer_pool.clear()
-        self.src_tensors.clear()
-        self.dst_tensors.clear()
+        self.cpu_tensors.clear()
         if sync_error is not None:
             raise sync_error
 
@@ -805,7 +742,6 @@ class CPUOffloadingWorker(OffloadingWorker):
             cpu_tensors.append(cpu_tensor)
 
         self._store_handler = SingleDirectionOffloadingHandler(
-            gpu_tensors=gpu_tensors,
             cpu_tensors=cpu_tensors,
             blocks_per_chunk=blocks_per_chunk,
             layer_refs_per_group=kv_caches.group_data_refs,
@@ -814,7 +750,6 @@ class CPUOffloadingWorker(OffloadingWorker):
         )
 
         self._load_handler = SingleDirectionOffloadingHandler(
-            gpu_tensors=gpu_tensors,
             cpu_tensors=cpu_tensors,
             blocks_per_chunk=blocks_per_chunk,
             layer_refs_per_group=kv_caches.group_data_refs,
@@ -823,16 +758,18 @@ class CPUOffloadingWorker(OffloadingWorker):
         )
 
     def submit_store(
-        self, job_id: int, src_spec: GPULoadStoreSpec, dst_spec: LoadStoreSpec
+        self, job_id: int, device_ptrs: DevicePointers, dst_spec: LoadStoreSpec
     ) -> bool:
         """Async GPU -> CPU."""
-        return self._store_handler.transfer_async(job_id, src_spec, dst_spec)
+        assert isinstance(dst_spec, BlockIDsLoadStoreSpec)
+        return self._store_handler.transfer_async(job_id, device_ptrs, dst_spec)
 
     def submit_load(
-        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: GPULoadStoreSpec
+        self, job_id: int, src_spec: LoadStoreSpec, device_ptrs: DevicePointers
     ) -> bool:
         """Async CPU -> GPU."""
-        return self._load_handler.transfer_async(job_id, src_spec, dst_spec)
+        assert isinstance(src_spec, BlockIDsLoadStoreSpec)
+        return self._load_handler.transfer_async(job_id, device_ptrs, src_spec)
 
     def get_finished(self) -> list[TransferResult]:
         return self._store_handler.get_finished() + self._load_handler.get_finished()

--- a/vllm/v1/kv_offload/factory.py
+++ b/vllm/v1/kv_offload/factory.py
@@ -67,8 +67,3 @@ OffloadingSpecFactory.register_spec(
     "vllm.v1.kv_offload.tiering.spec",
     "TieringOffloadingSpec",
 )
-OffloadingSpecFactory.register_spec(
-    "GDSOffloadingSpec",
-    "vllm.v1.kv_offload.gds.spec",
-    "GDSOffloadingSpec",
-)

--- a/vllm/v1/kv_offload/factory.py
+++ b/vllm/v1/kv_offload/factory.py
@@ -67,3 +67,8 @@ OffloadingSpecFactory.register_spec(
     "vllm.v1.kv_offload.tiering.spec",
     "TieringOffloadingSpec",
 )
+OffloadingSpecFactory.register_spec(
+    "GDSOffloadingSpec",
+    "vllm.v1.kv_offload.gds.spec",
+    "GDSOffloadingSpec",
+)

--- a/vllm/v1/kv_offload/fs/__init__.py
+++ b/vllm/v1/kv_offload/fs/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/kv_offload/fs/__init__.py
+++ b/vllm/v1/kv_offload/fs/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/kv_offload/fs/worker.py
+++ b/vllm/v1/kv_offload/fs/worker.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Abstract base for filesystem-backed offloading workers."""
+
+import time
+from abc import abstractmethod
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.kv_offload.base import (
+    DevicePointers,
+    FSLoadStoreSpec,
+    LoadStoreSpec,
+    OffloadingWorker,
+    TransferResult,
+)
+from vllm.v1.kv_offload.file_mapper import FileMapper
+
+logger = init_logger(__name__)
+
+DEFAULT_MAX_THREADS = 400
+
+
+@dataclass
+class _Transfer:
+    job_id: int
+    futures: list[Future]
+    num_bytes: int
+    start_time: float
+
+
+class FSOffloadingWorker(OffloadingWorker):
+    """Abstract base for device <-> filesystem offloading workers.
+
+    Handles: key->path resolution, per-key pointer grouping, thread pool
+    management, and completion tracking. Subclasses implement the actual
+    I/O via write_block() and read_block().
+    """
+
+    def __init__(
+        self,
+        file_mapper: FileMapper,
+        block_size_factor: int,
+        max_io_threads: int = DEFAULT_MAX_THREADS,
+        pool_initializer=None,
+    ):
+        self._file_mapper = file_mapper
+        self._block_size_factor = block_size_factor
+        self._pool = ThreadPoolExecutor(
+            max_workers=max_io_threads, initializer=pool_initializer
+        )
+        self._transfers: dict[int, _Transfer] = {}
+
+    # --- Abstract methods for subclasses ---
+
+    @abstractmethod
+    def write_block(
+        self, file_path: str, ops: list[tuple[int, int, int]]
+    ) -> object | None:
+        """Write device data to a file.
+
+        Args:
+            file_path: destination file path.
+            ops: list of (device_ptr, size_bytes, file_offset) tuples.
+        """
+
+    @abstractmethod
+    def read_block(
+        self, file_path: str, ops: list[tuple[int, int, int]]
+    ) -> object | None:
+        """Read file data into device memory.
+
+        Args:
+            file_path: source file path.
+            ops: list of (device_ptr, size_bytes, file_offset) tuples.
+        """
+
+    def shutdown_backend(self) -> None:
+        """Optional backend cleanup (e.g. cuFileBufDeregister)."""
+
+    # --- OffloadingWorker interface ---
+
+    def submit_store(
+        self, job_id: int, device_ptrs: DevicePointers, dst_spec: LoadStoreSpec
+    ) -> bool:
+        assert isinstance(dst_spec, FSLoadStoreSpec)
+        torch.cuda.current_stream().synchronize()
+        futures, num_bytes = self._submit_io(device_ptrs, dst_spec.keys, is_store=True)
+        self._transfers[job_id] = _Transfer(
+            job_id=job_id,
+            futures=futures,
+            num_bytes=num_bytes,
+            start_time=time.perf_counter(),
+        )
+        return True
+
+    def submit_load(
+        self, job_id: int, src_spec: LoadStoreSpec, device_ptrs: DevicePointers
+    ) -> bool:
+        assert isinstance(src_spec, FSLoadStoreSpec)
+        futures, num_bytes = self._submit_io(device_ptrs, src_spec.keys, is_store=False)
+        self._transfers[job_id] = _Transfer(
+            job_id=job_id,
+            futures=futures,
+            num_bytes=num_bytes,
+            start_time=time.perf_counter(),
+        )
+        return True
+
+    def get_finished(self) -> list[TransferResult]:
+        results: list[TransferResult] = []
+        finished_ids: list[int] = []
+        for job_id, t in self._transfers.items():
+            if all(f.done() for f in t.futures):
+                for f in t.futures:
+                    f.result()
+                elapsed = time.perf_counter() - t.start_time
+                results.append(
+                    TransferResult(
+                        job_id=t.job_id,
+                        success=True,
+                        transfer_size=t.num_bytes,
+                        transfer_time=elapsed,
+                    )
+                )
+                finished_ids.append(job_id)
+        for job_id in finished_ids:
+            del self._transfers[job_id]
+        return results
+
+    def wait(self, job_ids: set[int]) -> None:
+        for job_id in job_ids:
+            t = self._transfers.get(job_id)
+            if t is not None:
+                for f in t.futures:
+                    f.result()
+
+    def shutdown(self) -> None:
+        for t in self._transfers.values():
+            for f in t.futures:
+                f.result()
+        self._transfers.clear()
+        self._pool.shutdown(wait=True)
+        self.shutdown_backend()
+
+    # --- Internal: group device pointers per key and submit I/O ---
+
+    def _submit_io(
+        self,
+        device_ptrs: DevicePointers,
+        keys: list,
+        is_store: bool,
+    ) -> tuple[list[Future], int]:
+        """Group device pointers by offload key and submit per-file I/O."""
+        futures: list[Future] = []
+        total_bytes = 0
+
+        group_block_counts = device_ptrs.group_block_counts
+        group_data_ref_counts = device_ptrs.group_data_ref_counts
+
+        key_idx = 0
+        ptr_offset = 0
+
+        for group_size, n_data_refs in zip(group_block_counts, group_data_ref_counts):
+            if group_size == 0:
+                continue
+
+            n_files = cdiv(group_size, self._block_size_factor)
+            for i in range(n_files):
+                key = keys[key_idx]
+                key_idx += 1
+
+                blk_start = i * self._block_size_factor
+                blk_end = min(blk_start + self._block_size_factor, group_size)
+                n_blks = blk_end - blk_start
+
+                ops: list[tuple[int, int, int]] = []
+                file_offset = 0
+                for d in range(n_data_refs):
+                    base = ptr_offset + d * group_size + blk_start
+                    for b in range(n_blks):
+                        idx = base + b
+                        dev_ptr = int(device_ptrs.ptrs[idx])
+                        size = int(device_ptrs.sizes[idx])
+                        ops.append((dev_ptr, size, file_offset))
+                        file_offset += size
+                        total_bytes += size
+
+                file_path = self._file_mapper.get_file_name(key)
+                if is_store:
+                    future = self._pool.submit(self.write_block, file_path, ops)
+                else:
+                    future = self._pool.submit(self.read_block, file_path, ops)
+                futures.append(future)
+
+            ptr_offset += n_data_refs * group_size
+
+        return futures, total_bytes

--- a/vllm/v1/kv_offload/fs/worker.py
+++ b/vllm/v1/kv_offload/fs/worker.py
@@ -102,6 +102,7 @@ class FSOffloadingWorker(OffloadingWorker):
         self, job_id: int, src_spec: LoadStoreSpec, device_ptrs: DevicePointers
     ) -> bool:
         assert isinstance(src_spec, FSLoadStoreSpec)
+        torch.cuda.current_stream().synchronize()
         futures, num_bytes = self._submit_io(device_ptrs, src_spec.keys, is_store=False)
         self._transfers[job_id] = _Transfer(
             job_id=job_id,

--- a/vllm/v1/kv_offload/fs/worker.py
+++ b/vllm/v1/kv_offload/fs/worker.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 import torch
 
 from vllm.logger import init_logger
-from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_offload.base import (
     DevicePointers,
     LoadStoreSpec,
@@ -67,8 +66,6 @@ class FSOffloadingWorker(OffloadingWorker):
         )
         self._transfers: dict[int, _Transfer] = {}
 
-    # --- Abstract methods for subclasses ---
-
     @abstractmethod
     def write_block(
         self, file_path: str, ops: list[tuple[int, int, int]]
@@ -93,8 +90,6 @@ class FSOffloadingWorker(OffloadingWorker):
 
     def shutdown_backend(self) -> None:
         """Optional backend cleanup (e.g. cuFileBufDeregister)."""
-
-    # --- OffloadingWorker interface ---
 
     def submit_store(
         self, job_id: int, device_ptrs: DevicePointers, dst_spec: LoadStoreSpec
@@ -167,8 +162,6 @@ class FSOffloadingWorker(OffloadingWorker):
             self._pool.shutdown(wait=True)
             self.shutdown_backend()
 
-    # --- Internal: group device pointers per key and submit I/O ---
-
     def _submit_io(
         self,
         device_ptrs: DevicePointers,
@@ -178,47 +171,40 @@ class FSOffloadingWorker(OffloadingWorker):
         """Group device pointers by offload key and submit per-file I/O."""
         futures: list[Future] = []
         total_bytes = 0
-
-        group_block_counts = device_ptrs.group_block_counts
-        group_data_ref_counts = device_ptrs.group_data_ref_counts
-
         key_idx = 0
-        ptr_offset = 0
+        io_fn = self.write_block if is_store else self.read_block
 
-        for group_size, n_data_refs in zip(group_block_counts, group_data_ref_counts):
-            if group_size == 0:
-                continue
-
-            n_files = cdiv(group_size, self._block_size_factor)
-            for i in range(n_files):
+        for g in device_ptrs.iter_groups(self._block_size_factor):
+            dev_blk = 0
+            for i in range(g.n_chunks):
                 key = keys[key_idx]
                 key_idx += 1
 
-                blk_start = i * self._block_size_factor
-                blk_end = min(blk_start + self._block_size_factor, group_size)
-                n_blks = blk_end - blk_start
+                file_blk_start = g.skip if i == 0 else 0
+                capacity = self._block_size_factor - file_blk_start
+                n_blks = min(capacity, g.group_size - dev_blk)
 
                 ops: list[tuple[int, int, int]] = []
-                file_offset = 0
-                for d in range(n_data_refs):
-                    base = ptr_offset + d * group_size + blk_start
+                for d in range(g.n_data_refs):
+                    base = g.dev_ptr_offset + d * g.group_size + dev_blk
+                    blk_size = int(device_ptrs.sizes[base])
                     for b in range(n_blks):
                         idx = base + b
-                        dev_ptr = int(device_ptrs.ptrs[idx])
-                        size = int(device_ptrs.sizes[idx])
-                        ops.append((dev_ptr, size, file_offset))
-                        file_offset += size
-                        total_bytes += size
+                        file_offset = (
+                            d * self._block_size_factor + file_blk_start + b
+                        ) * blk_size
+                        ops.append(
+                            (
+                                int(device_ptrs.ptrs[idx]),
+                                int(device_ptrs.sizes[idx]),
+                                file_offset,
+                            )
+                        )
+                        total_bytes += int(device_ptrs.sizes[idx])
 
                 file_path = self._file_mapper.get_file_name(key)
-                if is_store:
-                    future = self._pool.submit(self.write_block, file_path, ops)
-                else:
-                    future = self._pool.submit(self.read_block, file_path, ops)
-                futures.append(future)
-
-            ptr_offset += n_data_refs * group_size
+                futures.append(self._pool.submit(io_fn, file_path, ops))
+                dev_blk += n_blks
 
         assert key_idx == len(keys)
-        assert ptr_offset == len(device_ptrs.ptrs)
         return futures, total_bytes

--- a/vllm/v1/kv_offload/fs/worker.py
+++ b/vllm/v1/kv_offload/fs/worker.py
@@ -116,13 +116,18 @@ class FSOffloadingWorker(OffloadingWorker):
         finished_ids: list[int] = []
         for job_id, t in self._transfers.items():
             if all(f.done() for f in t.futures):
+                success = True
                 for f in t.futures:
-                    f.result()
+                    try:
+                        f.result()
+                    except Exception:
+                        logger.exception("I/O failed for job %d", job_id)
+                        success = False
                 elapsed = time.perf_counter() - t.start_time
                 results.append(
                     TransferResult(
                         job_id=t.job_id,
-                        success=True,
+                        success=success,
                         transfer_size=t.num_bytes,
                         transfer_time=elapsed,
                     )

--- a/vllm/v1/kv_offload/fs/worker.py
+++ b/vllm/v1/kv_offload/fs/worker.py
@@ -13,14 +13,26 @@ from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_offload.base import (
     DevicePointers,
-    FSLoadStoreSpec,
     LoadStoreSpec,
     OffloadingWorker,
+    OffloadKey,
     TransferResult,
 )
 from vllm.v1.kv_offload.file_mapper import FileMapper
 
 logger = init_logger(__name__)
+
+
+class FSLoadStoreSpec(LoadStoreSpec):
+    """Spec for loading/storing KV blocks from a filesystem tier.
+
+    Carries content-addressed OffloadKeys that the worker resolves to
+    file paths via a FileMapper.
+    """
+
+    def __init__(self, keys: list[OffloadKey]):
+        self.keys = keys
+
 
 DEFAULT_MAX_THREADS = 400
 
@@ -146,12 +158,14 @@ class FSOffloadingWorker(OffloadingWorker):
                     f.result()
 
     def shutdown(self) -> None:
-        for t in self._transfers.values():
-            for f in t.futures:
-                f.result()
-        self._transfers.clear()
-        self._pool.shutdown(wait=True)
-        self.shutdown_backend()
+        try:
+            for t in self._transfers.values():
+                for f in t.futures:
+                    f.result()
+        finally:
+            self._transfers.clear()
+            self._pool.shutdown(wait=True)
+            self.shutdown_backend()
 
     # --- Internal: group device pointers per key and submit I/O ---
 
@@ -205,4 +219,6 @@ class FSOffloadingWorker(OffloadingWorker):
 
             ptr_offset += n_data_refs * group_size
 
+        assert key_idx == len(keys)
+        assert ptr_offset == len(device_ptrs.ptrs)
         return futures, total_bytes


### PR DESCRIPTION

## Purpose
As described in RFC #54777, the kv OffloadingWorker interface passes logical device block IDs to workers, which then internally resolve them to device pointers. This duplicates tensor layout logic in every worker implementation. As part of our GDS implementation, we refactor the worker interface so that device pointer resolution happens once and workers receive pre-resolved device pointers.

We also introduce FSOffloadingWorker, an abstract base for file-based device offloading, so that different filesystem backends (GDS/cuFile, POSIX, NIXL, etc.) can be added without duplicating logic. Following this PR, we will introduce the GDS component as a concrete class inheriting from the FSOffloadingWorker ABC.

## Test Plan
- The connector worker tests (exercises _make_worker / _kv_caches fix)
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_worker.py -v

- The scheduler tests (exercises MockOffloadingWorker / _parse_transfers)
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py -v

- All offloading connector tests at once
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/ -v

- The CPU worker/handler tests
.venv/bin/python -m pytest tests/v1/kv_offload/cpu/ -v

## Test Result
All pass clean.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
This PR is the initial phase of #54777 in preparation of enabling GDS kv offloading.

- [X] The test plan, such as providing test command.
Described in the main section above.

- [X] The test results, such as pasting the results comparison before and after, or e2e results
All passing clean.

- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

