### PR TITLE
[Bugfix][Spec Decode] Use identity hidden rows for DSpark anchor sampling

### DIFF
--- a/tests/v1/spec_decode/test_dspark_topk.py
+++ b/tests/v1/spec_decode/test_dspark_topk.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
 
 
 def _markov_head(weight: torch.Tensor) -> DSparkMarkovHead:
@@ -15,6 +16,29 @@ def _markov_head(weight: torch.Tensor) -> DSparkMarkovHead:
     )
     head.markov_w2.weight.data.copy_(weight)
     return head
+
+
+def test_anchor_sampling_uses_contiguous_hidden_rows():
+    speculator = DSparkSpeculator.__new__(DSparkSpeculator)
+    speculator.sample_from_anchor = True
+    # Deliberately stale values must not affect the anchor identity mapping.
+    speculator.sample_indices = torch.tensor([3, 2, 1, 0])
+    hidden = torch.arange(12).view(6, 2)
+
+    result = speculator._select_sample_hidden(hidden, 4)
+
+    torch.testing.assert_close(result, hidden[:4])
+
+
+def test_non_anchor_sampling_gathers_hidden_rows():
+    speculator = DSparkSpeculator.__new__(DSparkSpeculator)
+    speculator.sample_from_anchor = False
+    speculator.sample_indices = torch.tensor([3, 1, 4, 0])
+    hidden = torch.arange(12).view(6, 2)
+
+    result = speculator._select_sample_hidden(hidden, 3)
+
+    torch.testing.assert_close(result, hidden[[3, 1, 4]])
 
 
 def test_gathered_markov_bias_overwrites_dense_logits():

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -150,6 +150,17 @@ class DSparkSpeculator(DFlashSpeculator):
             use_fp64=self.use_fp64_gumbel,
         )
 
+    def _select_sample_hidden(
+        self, head_hidden: torch.Tensor, num_sample: int
+    ) -> torch.Tensor:
+        """Select backbone rows consumed by the sequential Markov head."""
+        if self.sample_from_anchor:
+            # Every query row is sampled and the query layout is already
+            # contiguous (request, step). Avoid depending on the asynchronously
+            # prepared sample-index buffer for this identity mapping.
+            return head_hidden[:num_sample]
+        return head_hidden[self.sample_indices[:num_sample]]
+
     def _sample_sequential(self, num_reqs: int, head_hidden: torch.Tensor) -> None:
         if self._draft_topk is not None:
             self._sample_sequential_topk(num_reqs, head_hidden)
@@ -158,8 +169,7 @@ class DSparkSpeculator(DFlashSpeculator):
         # Sequential Markov sampling over the backbone's output hidden states.
         n_spec = self.num_speculative_steps
         num_sample = num_reqs * n_spec
-        # Per-(req, position) head hidden, ordered (req, step).
-        sample_hidden = head_hidden[self.sample_indices[:num_sample]]
+        sample_hidden = self._select_sample_hidden(head_hidden, num_sample)
         # Draft-vocab logits; sampled ids are remapped to target vocab below.
         base_logits = self.model.compute_draft_logits(sample_hidden)
         vocab_size = base_logits.shape[-1]
@@ -206,7 +216,7 @@ class DSparkSpeculator(DFlashSpeculator):
         assert self._draft_topk is not None
         n_spec = self.num_speculative_steps
         num_sample = num_reqs * n_spec
-        sample_hidden = head_hidden[self.sample_indices[:num_sample]]
+        sample_hidden = self._select_sample_hidden(head_hidden, num_sample)
         base_logits = self.model.compute_draft_logits(sample_hidden)
         base_logits = base_logits.view(num_reqs, n_spec, -1)
         base_values, draft_indices = base_logits.topk(self._draft_topk, dim=-1)


### PR DESCRIPTION
## Summary

- use the already-contiguous query rows directly for DSpark's
  `sample_from_anchor=True` Markov head;
- retain indexed hidden-row selection for non-anchor DSpark layouts; and
- share the selection logic between dense and top-k Markov sampling.

## Why

With `sample_from_anchor=True`, every draft query row is sampled and the
prepared query layout is already `(request, step)` contiguous. The associated
`sample_indices` mapping is therefore an identity mapping. Gathering through
that asynchronously prepared auxiliary buffer is unnecessary and makes the
Markov head depend on index contents for a mapping whose correct value is
known structurally.

This change slices the contiguous hidden rows for the anchor layout while
preserving the existing gather for layouts where the anchor is not sampled.
Both the dense and top-k paths now use the same helper so they cannot diverge.

## Existing-work check

I searched current open and recently merged PRs for DSpark anchor sampling,
`sample_from_anchor`, and `sample_indices` changes. #48909 covers DSpark query
width and KV allocation for bonus-anchor layouts; it does not change Markov
hidden-row selection. #54416 addresses PP-safe draft weight loading, and
#55745 addresses PP draft-broadcast buffer lifetime. This change does not
overlap those PRs.

## Test plan

- Added focused tests showing that anchor sampling ignores deliberately stale
  index contents and that non-anchor sampling still gathers the requested
  rows.
- All four functions in `tests/v1/spec_decode/test_dspark_topk.py` passed
  against the built vLLM runtime.
- Repository pre-commit checks passed, including Ruff, formatting, mypy, SPDX,
  and configuration validation.

As an integration sanity check, Kimi-K3 with DSpark, TP8 x PP2, and
`sample_from_anchor=True` completed a 192-request C64 B200 benchmark with zero
request errors, zero output-length mismatches, and valid speculative decode.
That run used a broader integration branch, so no performance change is
attributed to this isolated patch.

AI assistance was used for investigation, code editing, testing, and drafting
this description. I reviewed the changes and results.
