### PR TITLE
[Kimi-K3] Reduce RecoverSSM state commit overhead

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -612,9 +612,13 @@ def test_kda_spec_decode_correctness(
         pytest.param(True, False, None, True, id="aligned"),
     ],
 )
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("accepted", [(2, 8), (1, 4)])
 @torch.inference_mode()
 def test_kda_recoverssm_verify_and_group_commit(
     monkeypatch: pytest.MonkeyPatch,
+    state_dtype: torch.dtype,
+    accepted: tuple[int, int],
     lower_bound: float | None,
     use_request_indices: bool,
     conv_state_dim_first: bool,
@@ -658,7 +662,6 @@ def test_kda_recoverssm_verify_and_group_commit(
     state_indices = torch.tensor(
         [5, 6] if align_mode else [1, 2], dtype=torch.int32, device=DEVICE
     )
-    accepted = [2, 8]
     if use_request_indices:
         global_num_accepted = torch.tensor(
             [0, accepted[0], 0, accepted[1]],
@@ -712,6 +715,7 @@ def test_kda_recoverssm_verify_and_group_commit(
             dtype=torch.float32,
             device=DEVICE,
         )
+        checkpoint = checkpoint.to(state_dtype)
         conv_shape = (
             (num_blocks, conv_dim, history_len + query_len - 1)
             if conv_state_dim_first

--- a/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
+++ b/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
@@ -137,8 +137,13 @@ def _kda_recoverssm_verify_kernel(
         + offs_v[:, None] * stride_state_v
         + offs_k[None, :] * stride_state_k
     )
-    state = tl.load(state_ptrs, mask=mask_state, other=0.0).to(tl.float32)
+    state = tl.load(
+        state_ptrs, mask=mask_state, other=0.0, eviction_policy="evict_first"
+    ).to(tl.float32)
     A = tl.exp(tl.load(A_log_ptr + pid_h).to(tl.float32))
+    dt_bias = tl.load(dt_bias_ptr + pid_h * K + offs_k, mask=mask_k, other=0.0).to(
+        tl.float32
+    )
 
     for token_offset in tl.static_range(SPEC_QUERY_LEN):
         token_valid = token_offset < query_len
@@ -157,6 +162,7 @@ def _kda_recoverssm_verify_kernel(
             v_ptr + token * stride_v_token + pid_h * V + offs_v,
             mask=token_valid & mask_v,
             other=0.0,
+            eviction_policy="evict_first",
         ).to(tl.float32)
         raw_g = tl.load(
             raw_g_ptr + token * stride_g_token + pid_h * K + offs_k,
@@ -170,9 +176,6 @@ def _kda_recoverssm_verify_kernel(
         ).to(tl.float32)
 
         q *= tl.rsqrt(tl.sum(q * q) + 1e-6) * (K**-0.5)
-        dt_bias = tl.load(dt_bias_ptr + pid_h * K + offs_k, mask=mask_k, other=0.0).to(
-            tl.float32
-        )
         updated_state, correction = _kda_recurrent_step(
             state,
             k,
@@ -191,6 +194,7 @@ def _kda_recoverssm_verify_kernel(
             out_ptr + token * stride_out_token + pid_h * V + offs_v,
             out,
             mask=token_valid & mask_v,
+            eviction_policy="evict_first",
         )
 
         correction_ptr = (
@@ -661,7 +665,10 @@ def kda_recoverssm_verify(
         return out
 
     block_k = triton.next_power_of_2(key_dim)
-    block_v = min(triton.next_power_of_2(value_dim), 32)
+    block_v = min(
+        triton.next_power_of_2(value_dim),
+        (4 if batch <= 8 else 8) if key_dim == 128 else 32,
+    )
     grid = (triton.cdiv(value_dim, block_v), batch, num_heads)
     _kda_recoverssm_verify_kernel[grid](
         q,
@@ -705,7 +712,7 @@ def kda_recoverssm_verify(
         BV=block_v,
         SPEC_QUERY_LEN=spec_query_len,
         USE_LOWER_BOUND=lower_bound is not None,
-        num_warps=4,
+        num_warps=1 if key_dim == 128 else 4,
         num_stages=2,
     )
     return out

--- a/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
+++ b/vllm/models/kimi_k3/nvidia/ops/recoverssm.py
@@ -494,7 +494,7 @@ def _commit_kda_state_kernel(
         + offs_v[:, None] * stride_state_v
         + offs_k[None, :] * stride_state_k
     )
-    initial_state = tl.load(state_ptrs, mask=mask_state, other=0.0).to(tl.float32)
+    state = tl.load(state_ptrs, mask=mask_state, other=0.0).to(tl.float32)
     A = tl.exp(
         tl.load(A_log_ptr + pid_l * stride_A_layer + pid_h * stride_A_head).to(
             tl.float32
@@ -509,13 +509,9 @@ def _commit_kda_state_kernel(
         mask=mask_k,
         other=0.0,
     ).to(tl.float32)
-    final_decay = tl.full([BK], 1.0, tl.float32)
-    final_correction = tl.zeros([BV, BK], tl.float32)
-    boundary_decay = tl.full([BK], 1.0, tl.float32)
-    boundary_correction = tl.zeros([BV, BK], tl.float32)
-
-    for reverse_offset in range(commit_len):
-        token_offset = commit_len - reverse_offset - 1
+    # Replay cached rank-one updates in FP32. Save a boundary only when reached,
+    # rather than retaining separate full-matrix correction accumulators.
+    for token_offset in range(commit_len):
         correction_ptr = (
             correction_cache_ptr + token_offset * stride_correction_cache_pos
         )
@@ -545,32 +541,19 @@ def _commit_kda_state_kernel(
         )
         update = correction[:, None] * normalized_k[None, :]
         decay = tl.exp(gate)
-        final_correction += update * final_decay[None, :]
-        final_decay *= decay
-        if ALIGN_MODE:
-            before_boundary = token_offset < boundary_recovery_len
-            boundary_correction += tl.where(
-                before_boundary,
-                update * boundary_decay[None, :],
-                0.0,
-            )
-            boundary_decay *= tl.where(before_boundary, decay, 1.0)
-
-    state = initial_state * final_decay[None, :] + final_correction
-    if ALIGN_MODE:
-        boundary_ptrs = (
-            state_ptr
-            + boundary_state_idx * state_block_stride
-            + pid_h * stride_state_head
-            + offs_v[:, None] * stride_state_v
-            + offs_k[None, :] * stride_state_k
-        )
-        boundary_state = initial_state * boundary_decay[None, :] + boundary_correction
-        tl.store(
-            boundary_ptrs,
-            boundary_state,
-            mask=mask_state & (boundary_state_idx > null_block_id),
-        )
+        state = state * decay[None, :] + update
+        if ALIGN_MODE:  # noqa: SIM102 -- keep the non-align branch compile-time dead
+            if (boundary_state_idx > null_block_id) & (
+                token_offset + 1 == boundary_recovery_len
+            ):
+                boundary_ptrs = (
+                    state_ptr
+                    + boundary_state_idx * state_block_stride
+                    + pid_h * stride_state_head
+                    + offs_v[:, None] * stride_state_v
+                    + offs_k[None, :] * stride_state_k
+                )
+                tl.store(boundary_ptrs, state, mask=mask_state)
 
     final_ptrs = (
         state_ptr
@@ -1012,7 +995,7 @@ class KDARecoverSSMCommitContext:
         state_ref = self.checkpoints[0]
         _, num_heads, value_dim, key_dim = state_ref.shape
         block_k = triton.next_power_of_2(key_dim)
-        block_v = min(triton.next_power_of_2(value_dim), 32)
+        block_v = min(triton.next_power_of_2(value_dim), 8 if key_dim == 128 else 32)
         grid = (
             triton.cdiv(value_dim, block_v),
             batch,
@@ -1059,7 +1042,7 @@ class KDARecoverSSMCommitContext:
             NUM_HEADS=num_heads,
             USE_LOWER_BOUND=self.lower_bound is not None,
             ALIGN_MODE=block_table is not None,
-            num_warps=4,
+            num_warps=1 if key_dim == 128 else 4,
             num_stages=2,
         )
 


### PR DESCRIPTION
## Purpose

Speed up Kimi-K3 RecoverSSM with forward FP32 state recovery, tuned value tiles/warps, loop-invariant bias loads and cache eviction hints. Add BF16 and boundary-recovery tests.

Overlaps with #52993; this draft provides B200-specific tuning and additional tests for consolidation.

## Test Result

### End-to-end serving: RecoverSSM kernel-only A/B

Two 8×B200 nodes, TP8+PP2 (DCP1, no EP), K3 MXFP4 weights / FP8 KV, D-Spark8 with synthetic acceptance length 4, 8,192 input / 1,024 output tokens. Only `ops/recoverssm.py` changes from `474839f846` to `3561aa5aab`; both runs retain the same local PP RecoverSSM adaptation and draft-broadcast lifetime fix, which are **not included in this PR**. The optimized kernel file matches the PR byte-for-byte.

Each configuration gets one full warmup and two measured runs of 128 requests, resetting prefix cache before every run. Values below are arithmetic means; CUDA launch blocking is disabled. Positive latency reduction means faster.

| Concurrency | Metric | Baseline | Optimized | Gain / reduction |
|---:|---|---:|---:|---:|
| 16 | Output throughput (tok/s) | 1208.93 | 1237.48 | +2.36% |
| 16 | Mean TPOT (ms) | 11.44 | 11.16 | +2.43% |
| 96 | Output throughput (tok/s) | 1708.76 | 1724.13 | +0.90% |
| 96 | Mean TPOT (ms) | 37.44 | 37.10 | +0.91% |

All 1,024 measured requests succeeded. Every run produced 131,072 tokens with 32,768 draft rounds and 98,304 accepted draft tokens (acceptance length 4.00); no worker ERROR/assert. These are small observed gains, not statistically established improvements: only two repeats, with ~3.2% throughput variation between optimized C16 runs. C16 P99 ITL worsened (see raw results). Synthetic acceptance is not a quality evaluation, and 128 requests at C96 is a short mixed prefill/decode test.

<details>
<summary>Raw measured runs</summary>

| C | Kernel | Run | Duration (s) | Output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | P95 TPOT (ms) | P99 ITL (ms) |
|---:|---|---:|---:|---:|---:|---:|---:|---:|
| 16 | baseline | 1 | 108.84 | 1204.24 | 1849.04 | 11.48 | 12.69 | 596.70 |
| 16 | baseline | 2 | 108.00 | 1213.61 | 1838.03 | 11.39 | 12.63 | 595.88 |
| 16 | optimized | 1 | 107.63 | 1217.77 | 1837.02 | 11.35 | 12.40 | 600.72 |
| 16 | optimized | 2 | 104.26 | 1257.20 | 1798.62 | 10.97 | 12.10 | 677.62 |
| 96 | baseline | 1 | 76.74 | 1707.96 | 13039.04 | 37.44 | 49.47 | 1337.06 |
| 96 | baseline | 2 | 76.67 | 1709.55 | 12998.15 | 37.43 | 49.44 | 1335.78 |
| 96 | optimized | 1 | 76.07 | 1722.96 | 12963.34 | 37.13 | 49.31 | 1335.79 |
| 96 | optimized | 2 | 75.97 | 1725.30 | 12990.71 | 37.07 | 49.26 | 1333.11 |

</details>

<details>
<summary>Serving and benchmark commands</summary>

These expand the local shell scripts used for the measurements. PP requires the local adaptations noted above; this PR alone does not enable PP RecoverSSM. Set `MODEL`, `DRAFT_MODEL`, `HEAD_IP`, and `NET_IF` for the cluster. Run on both nodes, using the corresponding node arguments.

```bash
unset CUDA_LAUNCH_BLOCKING
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export VLLM_USE_V2_MODEL_RUNNER=1 VLLM_SERVER_DEV_MODE=1
export GLOO_SOCKET_IFNAME="$NET_IF" NCCL_SOCKET_IFNAME="$NET_IF" NCCL_DEBUG=INFO

# Head; on worker use: NODE_ARGS=(--node-rank 1 --headless)
NODE_ARGS=(--node-rank 0 --host 0.0.0.0 --port 8008)
vllm serve "$MODEL" \
  --trust-remote-code --served-model-name k3 \
  --tensor-parallel-size 8 --pipeline-parallel-size 2 --nnodes 2 \
  --distributed-executor-backend mp --master-addr "$HEAD_IP" --master-port 29501 \
  --attention-backend FLASHINFER_MLA \
  --attention-config '{"mla_prefill_backend":"FLASHINFER","use_prefill_query_quantization":true}' \
  --kv-cache-dtype fp8 --no-enable-flashinfer-autotune \
  --max-model-len 1048576 --max-num-batched-tokens 16000 \
  --max-num-seqs 96 --gpu-memory-utilization 0.90 \
  --enable-prompt-tokens-details \
  --speculative-config "{\"method\":\"dspark\",\"model\":\"$DRAFT_MODEL\",\"num_speculative_tokens\":8,\"enable_adaptive_verification\":false,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":4}" \
  --mamba-backend triton --mamba-cache-mode align --enable-prefix-caching \
  --additional-config '{"kda_decode_backend":"triton"}' --use-replayssm \
  "${NODE_ARGS[@]}"
```

On the head, for each kernel version and `C=16` / `C=96`, run once for warmup and twice for measurement. Check that the reset response contains `"success":true` before proceeding.

```bash
curl -fsS -X POST http://127.0.0.1:8008/reset_prefix_cache
vllm bench serve --backend vllm --base-url http://127.0.0.1:8008 \
  --endpoint /v1/completions --model k3 --tokenizer "$MODEL" --trust-remote-code \
  --dataset-name random --random-input-len 8192 --random-output-len 1024 \
  --random-range-ratio 0 --random-prefix-len 0 \
  --num-prompts 128 --max-concurrency "$C" --request-rate inf \
  --ignore-eos --temperature 0 --seed 42 \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 50,95,99 \
  --save-result --result-dir ./kernel-ab-results
```

</details>

**Baseline `474839f846` → PR `3561aa5aab`.** B200, H12/D128, BF16 inputs, FP32 state, five independent layers. CUDA-graph event timing with reversed A/B order; units are **µs for all five layers**. Reduction = (baseline − optimized) / baseline.

B = per-rank batch; T = verification window; A = committed tokens including the normal token. Align has no boundary crossing; cross reaches a boundary at token 1. These are synthetic hot-cache measurements, excluding host, sampling and communication costs.

### Commit: plan + conv compaction + state recovery

<details>
<summary>align: all B/T/A results</summary>

| Mode | B | T | A | Commit baseline (µs) | Commit optimized (µs) | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| align | 1 | 2 | 1 | 7.40 | 7.01 | 5.3% |
| align | 1 | 2 | 2 | 7.84 | 7.40 | 5.7% |
| align | 1 | 3 | 1 | 7.41 | 7.00 | 5.7% |
| align | 1 | 3 | 2 | 7.85 | 7.41 | 5.7% |
| align | 1 | 3 | 3 | 8.63 | 7.85 | 8.9% |
| align | 1 | 5 | 1 | 7.23 | 6.99 | 3.4% |
| align | 1 | 5 | 3 | 8.44 | 7.82 | 7.4% |
| align | 1 | 5 | 5 | 9.66 | 9.04 | 6.4% |
| align | 1 | 8 | 1 | 7.45 | 7.00 | 6.0% |
| align | 1 | 8 | 4 | 9.06 | 8.44 | 6.8% |
| align | 1 | 8 | 8 | 10.89 | 10.47 | 3.9% |
| align | 4 | 2 | 1 | 14.16 | 10.68 | 24.6% |
| align | 4 | 2 | 2 | 16.02 | 11.54 | 28.0% |
| align | 4 | 3 | 1 | 14.18 | 10.64 | 24.9% |
| align | 4 | 3 | 2 | 16.22 | 11.82 | 27.1% |
| align | 4 | 3 | 3 | 18.26 | 12.73 | 30.3% |
| align | 4 | 5 | 1 | 14.21 | 10.68 | 24.8% |
| align | 4 | 5 | 3 | 18.26 | 12.72 | 30.3% |
| align | 4 | 5 | 5 | 22.13 | 14.98 | 32.3% |
| align | 4 | 8 | 1 | 14.17 | 10.58 | 25.3% |
| align | 4 | 8 | 4 | 20.09 | 13.63 | 32.2% |
| align | 4 | 8 | 8 | 28.48 | 18.68 | 34.4% |
| align | 8 | 2 | 1 | 21.52 | 13.91 | 35.3% |
| align | 8 | 2 | 2 | 25.24 | 15.60 | 38.2% |
| align | 8 | 3 | 1 | 21.35 | 13.70 | 35.8% |
| align | 8 | 3 | 2 | 25.22 | 15.60 | 38.2% |
| align | 8 | 3 | 3 | 28.94 | 17.52 | 39.4% |
| align | 8 | 5 | 1 | 21.56 | 13.87 | 35.7% |
| align | 8 | 5 | 3 | 29.11 | 17.43 | 40.1% |
| align | 8 | 5 | 5 | 35.73 | 21.24 | 40.6% |
| align | 8 | 8 | 1 | 21.37 | 13.94 | 34.7% |
| align | 8 | 8 | 4 | 32.39 | 19.33 | 40.3% |
| align | 8 | 8 | 8 | 46.70 | 27.49 | 41.1% |
| align | 16 | 2 | 1 | 37.52 | 21.61 | 42.4% |
| align | 16 | 2 | 2 | 45.83 | 25.81 | 43.7% |
| align | 16 | 3 | 1 | 38.08 | 21.82 | 42.7% |
| align | 16 | 3 | 2 | 45.34 | 25.11 | 44.6% |
| align | 16 | 3 | 3 | 53.67 | 29.09 | 45.8% |
| align | 16 | 5 | 1 | 37.13 | 22.50 | 39.4% |
| align | 16 | 5 | 3 | 57.51 | 29.51 | 48.7% |
| align | 16 | 5 | 5 | 73.24 | 37.77 | 48.4% |
| align | 16 | 8 | 1 | 37.54 | 21.84 | 41.8% |
| align | 16 | 8 | 4 | 63.31 | 34.05 | 46.2% |
| align | 16 | 8 | 8 | 98.22 | 48.85 | 50.3% |
| align | 32 | 2 | 1 | 82.51 | 52.07 | 36.9% |
| align | 32 | 2 | 2 | 102.98 | 61.20 | 40.6% |
| align | 32 | 3 | 1 | 82.39 | 52.06 | 36.8% |
| align | 32 | 3 | 2 | 102.62 | 61.26 | 40.3% |
| align | 32 | 3 | 3 | 122.03 | 68.30 | 44.0% |
| align | 32 | 5 | 1 | 82.47 | 51.78 | 37.2% |
| align | 32 | 5 | 3 | 121.91 | 68.85 | 43.5% |
| align | 32 | 5 | 5 | 161.30 | 83.73 | 48.1% |
| align | 32 | 8 | 1 | 83.00 | 52.09 | 37.2% |
| align | 32 | 8 | 4 | 141.63 | 76.23 | 46.2% |
| align | 32 | 8 | 8 | 219.55 | 107.42 | 51.1% |
| align | 48 | 2 | 1 | 124.03 | 73.27 | 40.9% |
| align | 48 | 2 | 2 | 151.33 | 86.68 | 42.7% |
| align | 48 | 3 | 1 | 123.96 | 73.49 | 40.7% |
| align | 48 | 3 | 2 | 151.24 | 86.64 | 42.7% |
| align | 48 | 3 | 3 | 179.28 | 98.89 | 44.8% |
| align | 48 | 5 | 1 | 124.32 | 73.40 | 41.0% |
| align | 48 | 5 | 3 | 179.69 | 98.81 | 45.0% |
| align | 48 | 5 | 5 | 237.61 | 122.29 | 48.5% |
| align | 48 | 8 | 1 | 123.65 | 73.36 | 40.7% |
| align | 48 | 8 | 4 | 208.41 | 110.52 | 47.0% |
| align | 48 | 8 | 8 | 325.39 | 158.52 | 51.3% |
| align | 96 | 2 | 1 | 236.12 | 139.70 | 40.8% |
| align | 96 | 2 | 2 | 295.08 | 164.77 | 44.2% |
| align | 96 | 3 | 1 | 236.78 | 139.17 | 41.2% |
| align | 96 | 3 | 2 | 294.77 | 165.57 | 43.8% |
| align | 96 | 3 | 3 | 354.29 | 189.62 | 46.5% |
| align | 96 | 5 | 1 | 236.75 | 138.82 | 41.4% |
| align | 96 | 5 | 3 | 353.88 | 190.35 | 46.2% |
| align | 96 | 5 | 5 | 470.49 | 233.24 | 50.4% |
| align | 96 | 8 | 1 | 236.41 | 138.99 | 41.2% |
| align | 96 | 8 | 4 | 412.60 | 211.21 | 48.8% |
| align | 96 | 8 | 8 | 644.34 | 302.93 | 53.0% |

</details>

<details>
<summary>none: all B/T/A results</summary>

| Mode | B | T | A | Commit baseline (µs) | Commit optimized (µs) | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| none | 1 | 3 | 1 | 6.80 | 6.79 | 0.1% |
| none | 1 | 3 | 2 | 7.27 | 7.37 | -1.4% |
| none | 1 | 3 | 3 | 7.90 | 7.67 | 3.0% |
| none | 1 | 8 | 1 | 6.79 | 6.60 | 2.9% |
| none | 1 | 8 | 4 | 8.32 | 8.22 | 1.2% |
| none | 1 | 8 | 8 | 10.49 | 10.47 | 0.2% |
| none | 8 | 3 | 1 | 16.27 | 12.94 | 20.5% |
| none | 8 | 3 | 2 | 19.29 | 14.29 | 25.9% |
| none | 8 | 3 | 3 | 21.92 | 15.82 | 27.8% |
| none | 8 | 8 | 1 | 16.42 | 13.04 | 20.6% |
| none | 8 | 8 | 4 | 24.67 | 17.51 | 29.0% |
| none | 8 | 8 | 8 | 35.72 | 24.63 | 31.0% |
| none | 48 | 3 | 1 | 89.75 | 70.58 | 21.4% |
| none | 48 | 3 | 2 | 111.41 | 78.63 | 29.4% |
| none | 48 | 3 | 3 | 129.47 | 87.63 | 32.3% |
| none | 48 | 8 | 1 | 90.18 | 70.37 | 22.0% |
| none | 48 | 8 | 4 | 147.59 | 95.08 | 35.6% |
| none | 48 | 8 | 8 | 226.12 | 129.87 | 42.6% |
| none | 96 | 3 | 1 | 172.43 | 132.84 | 23.0% |
| none | 96 | 3 | 2 | 218.40 | 144.73 | 33.7% |
| none | 96 | 3 | 3 | 252.88 | 163.86 | 35.2% |
| none | 96 | 8 | 1 | 172.28 | 132.55 | 23.1% |
| none | 96 | 8 | 4 | 288.98 | 178.45 | 38.2% |
| none | 96 | 8 | 8 | 443.94 | 245.07 | 44.8% |

</details>

<details>
<summary>cross: all B/T/A results</summary>

| Mode | B | T | A | Commit baseline (µs) | Commit optimized (µs) | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| cross | 1 | 3 | 1 | 8.16 | 7.73 | 5.2% |
| cross | 1 | 3 | 2 | 8.64 | 8.03 | 7.1% |
| cross | 1 | 3 | 3 | 9.05 | 8.43 | 6.8% |
| cross | 1 | 8 | 1 | 8.01 | 7.61 | 5.0% |
| cross | 1 | 8 | 4 | 9.65 | 9.04 | 6.4% |
| cross | 1 | 8 | 8 | 11.70 | 11.09 | 5.2% |
| cross | 8 | 3 | 1 | 27.08 | 18.49 | 31.7% |
| cross | 8 | 3 | 2 | 29.67 | 19.20 | 35.3% |
| cross | 8 | 3 | 3 | 34.17 | 20.93 | 38.7% |
| cross | 8 | 8 | 1 | 26.37 | 18.29 | 30.6% |
| cross | 8 | 8 | 4 | 37.18 | 22.41 | 39.7% |
| cross | 8 | 8 | 8 | 58.17 | 33.28 | 42.8% |
| cross | 48 | 3 | 1 | 151.12 | 104.07 | 31.1% |
| cross | 48 | 3 | 2 | 176.54 | 107.45 | 39.1% |
| cross | 48 | 3 | 3 | 204.82 | 116.65 | 43.0% |
| cross | 48 | 8 | 1 | 150.86 | 104.19 | 30.9% |
| cross | 48 | 8 | 4 | 234.30 | 128.17 | 45.3% |
| cross | 48 | 8 | 8 | 351.53 | 176.57 | 49.8% |
| cross | 96 | 3 | 1 | 292.31 | 200.17 | 31.5% |
| cross | 96 | 3 | 2 | 349.61 | 207.84 | 40.6% |
| cross | 96 | 3 | 3 | 409.24 | 224.56 | 45.1% |
| cross | 96 | 8 | 1 | 294.10 | 200.53 | 31.8% |
| cross | 96 | 8 | 4 | 467.65 | 244.39 | 47.7% |
| cross | 96 | 8 | 8 | 700.85 | 340.40 | 51.4% |

</details>

### Complete RecoverSSM chain: conv + verify + norm + commit

<details>
<summary>All configurations</summary>

| Mode | B | T | A | Total baseline (µs) | Total optimized (µs) | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| align | 1 | 2 | 1 | 41.16 | 40.78 | 0.9% |
| align | 1 | 2 | 2 | 40.98 | 41.25 | -0.7% |
| align | 1 | 3 | 1 | 49.15 | 48.39 | 1.5% |
| align | 1 | 3 | 2 | 49.36 | 49.39 | -0.1% |
| align | 1 | 3 | 3 | 50.46 | 49.54 | 1.8% |
| align | 1 | 5 | 1 | 60.46 | 60.11 | 0.6% |
| align | 1 | 5 | 3 | 61.86 | 61.89 | -0.0% |
| align | 1 | 5 | 5 | 63.88 | 63.16 | 1.1% |
| align | 1 | 8 | 1 | 78.32 | 77.38 | 1.2% |
| align | 1 | 8 | 4 | 79.46 | 79.13 | 0.4% |
| align | 1 | 8 | 8 | 82.85 | 82.20 | 0.8% |
| align | 4 | 2 | 1 | 50.87 | 47.20 | 7.2% |
| align | 4 | 2 | 2 | 52.89 | 48.39 | 8.5% |
| align | 4 | 3 | 1 | 58.25 | 54.77 | 6.0% |
| align | 4 | 3 | 2 | 61.08 | 55.93 | 8.4% |
| align | 4 | 3 | 3 | 63.14 | 57.45 | 9.0% |
| align | 4 | 5 | 1 | 70.52 | 67.19 | 4.7% |
| align | 4 | 5 | 3 | 75.32 | 69.14 | 8.2% |
| align | 4 | 5 | 5 | 80.50 | 73.25 | 9.0% |
| align | 4 | 8 | 1 | 88.73 | 85.32 | 3.8% |
| align | 4 | 8 | 4 | 96.03 | 88.93 | 7.4% |
| align | 4 | 8 | 8 | 105.42 | 95.84 | 9.1% |
| align | 8 | 2 | 1 | 65.77 | 58.07 | 11.7% |
| align | 8 | 2 | 2 | 70.23 | 60.13 | 14.4% |
| align | 8 | 3 | 1 | 75.51 | 67.85 | 10.2% |
| align | 8 | 3 | 2 | 79.95 | 69.62 | 12.9% |
| align | 8 | 3 | 3 | 83.84 | 72.07 | 14.0% |
| align | 8 | 5 | 1 | 93.37 | 84.93 | 9.0% |
| align | 8 | 5 | 3 | 101.72 | 89.29 | 12.2% |
| align | 8 | 5 | 5 | 109.45 | 93.57 | 14.5% |
| align | 8 | 8 | 1 | 118.76 | 111.61 | 6.0% |
| align | 8 | 8 | 4 | 131.34 | 118.10 | 10.1% |
| align | 8 | 8 | 8 | 148.33 | 126.66 | 14.6% |
| align | 16 | 2 | 1 | 95.35 | 79.22 | 16.9% |
| align | 16 | 2 | 2 | 103.91 | 82.94 | 20.2% |
| align | 16 | 3 | 1 | 108.12 | 91.68 | 15.2% |
| align | 16 | 3 | 2 | 115.06 | 94.42 | 17.9% |
| align | 16 | 3 | 3 | 123.15 | 98.63 | 19.9% |
| align | 16 | 5 | 1 | 133.76 | 118.57 | 11.4% |
| align | 16 | 5 | 3 | 150.74 | 123.80 | 17.9% |
| align | 16 | 5 | 5 | 165.45 | 131.19 | 20.7% |
| align | 16 | 8 | 1 | 172.04 | 156.35 | 9.1% |
| align | 16 | 8 | 4 | 195.11 | 166.50 | 14.7% |
| align | 16 | 8 | 8 | 227.57 | 181.36 | 20.3% |
| align | 32 | 2 | 1 | 168.65 | 138.64 | 17.8% |
| align | 32 | 2 | 2 | 186.19 | 145.33 | 21.9% |
| align | 32 | 3 | 1 | 189.17 | 159.01 | 15.9% |
| align | 32 | 3 | 2 | 206.94 | 165.82 | 19.9% |
| align | 32 | 3 | 3 | 225.66 | 172.86 | 23.4% |
| align | 32 | 5 | 1 | 233.13 | 202.94 | 12.9% |
| align | 32 | 5 | 3 | 268.34 | 217.93 | 18.8% |
| align | 32 | 5 | 5 | 304.33 | 230.87 | 24.1% |
| align | 32 | 8 | 1 | 302.71 | 271.15 | 10.4% |
| align | 32 | 8 | 4 | 356.31 | 292.91 | 17.8% |
| align | 32 | 8 | 8 | 429.38 | 321.72 | 25.1% |
| align | 48 | 2 | 1 | 236.10 | 186.91 | 20.8% |
| align | 48 | 2 | 2 | 262.64 | 198.17 | 24.5% |
| align | 48 | 3 | 1 | 266.29 | 217.31 | 18.4% |
| align | 48 | 3 | 2 | 293.98 | 227.73 | 22.5% |
| align | 48 | 3 | 3 | 319.41 | 239.70 | 25.0% |
| align | 48 | 5 | 1 | 332.16 | 280.99 | 15.4% |
| align | 48 | 5 | 3 | 384.02 | 305.13 | 20.5% |
| align | 48 | 5 | 5 | 440.59 | 325.70 | 26.1% |
| align | 48 | 8 | 1 | 437.55 | 387.79 | 11.4% |
| align | 48 | 8 | 4 | 521.68 | 422.87 | 18.9% |
| align | 48 | 8 | 8 | 636.19 | 468.45 | 26.4% |
| align | 96 | 2 | 1 | 421.04 | 324.65 | 22.9% |
| align | 96 | 2 | 2 | 478.98 | 347.33 | 27.5% |
| align | 96 | 3 | 1 | 486.46 | 387.58 | 20.3% |
| align | 96 | 3 | 2 | 542.55 | 413.73 | 23.7% |
| align | 96 | 3 | 3 | 601.81 | 436.49 | 27.5% |
| align | 96 | 5 | 1 | 621.55 | 522.68 | 15.9% |
| align | 96 | 5 | 3 | 739.03 | 573.72 | 22.4% |
| align | 96 | 5 | 5 | 855.28 | 616.28 | 27.9% |
| align | 96 | 8 | 1 | 843.87 | 744.71 | 11.8% |
| align | 96 | 8 | 4 | 1021.08 | 816.68 | 20.0% |
| align | 96 | 8 | 8 | 1252.99 | 909.06 | 27.4% |
| none | 1 | 3 | 1 | 48.96 | 48.56 | 0.8% |
| none | 1 | 3 | 2 | 49.37 | 48.62 | 1.5% |
| none | 1 | 3 | 3 | 49.91 | 49.64 | 0.5% |
| none | 1 | 8 | 1 | 77.34 | 77.31 | 0.0% |
| none | 1 | 8 | 4 | 80.32 | 78.12 | 2.7% |
| none | 1 | 8 | 8 | 82.68 | 81.53 | 1.4% |
| none | 8 | 3 | 1 | 70.78 | 67.64 | 4.4% |
| none | 8 | 3 | 2 | 73.74 | 68.48 | 7.1% |
| none | 8 | 3 | 3 | 77.17 | 70.11 | 9.1% |
| none | 8 | 8 | 1 | 113.51 | 110.51 | 2.6% |
| none | 8 | 8 | 4 | 123.30 | 115.38 | 6.4% |
| none | 8 | 8 | 8 | 135.64 | 122.57 | 9.6% |
| none | 48 | 3 | 1 | 234.51 | 214.46 | 8.6% |
| none | 48 | 3 | 2 | 253.23 | 221.60 | 12.5% |
| none | 48 | 3 | 3 | 269.46 | 228.93 | 15.0% |
| none | 48 | 8 | 1 | 405.84 | 384.50 | 5.3% |
| none | 48 | 8 | 4 | 460.67 | 408.60 | 11.3% |
| none | 48 | 8 | 8 | 538.51 | 441.59 | 18.0% |
| none | 96 | 3 | 1 | 420.78 | 381.64 | 9.3% |
| none | 96 | 3 | 2 | 466.53 | 392.21 | 15.9% |
| none | 96 | 3 | 3 | 501.19 | 410.76 | 18.0% |
| none | 96 | 8 | 1 | 779.63 | 740.95 | 5.0% |
| none | 96 | 8 | 4 | 897.04 | 785.22 | 12.5% |
| none | 96 | 8 | 8 | 1052.68 | 851.82 | 19.1% |
| cross | 1 | 3 | 1 | 50.40 | 49.19 | 2.4% |
| cross | 1 | 3 | 2 | 50.21 | 49.23 | 2.0% |
| cross | 1 | 3 | 3 | 51.72 | 50.07 | 3.2% |
| cross | 1 | 8 | 1 | 78.82 | 78.26 | 0.7% |
| cross | 1 | 8 | 4 | 80.24 | 80.08 | 0.2% |
| cross | 1 | 8 | 8 | 84.51 | 83.84 | 0.8% |
| cross | 8 | 3 | 1 | 83.32 | 73.66 | 11.6% |
| cross | 8 | 3 | 2 | 86.01 | 74.87 | 13.0% |
| cross | 8 | 3 | 3 | 90.44 | 77.18 | 14.7% |
| cross | 8 | 8 | 1 | 126.75 | 118.21 | 6.7% |
| cross | 8 | 8 | 4 | 138.69 | 122.31 | 11.8% |
| cross | 8 | 8 | 8 | 156.53 | 131.73 | 15.8% |
| cross | 48 | 3 | 1 | 297.03 | 249.84 | 15.9% |
| cross | 48 | 3 | 2 | 321.72 | 253.43 | 21.2% |
| cross | 48 | 3 | 3 | 348.29 | 261.38 | 25.0% |
| cross | 48 | 8 | 1 | 465.91 | 419.32 | 10.0% |
| cross | 48 | 8 | 4 | 549.64 | 442.25 | 19.5% |
| cross | 48 | 8 | 8 | 665.15 | 488.07 | 26.6% |
| cross | 96 | 3 | 1 | 542.66 | 449.15 | 17.2% |
| cross | 96 | 3 | 2 | 599.56 | 456.23 | 23.9% |
| cross | 96 | 3 | 3 | 659.42 | 472.57 | 28.3% |
| cross | 96 | 8 | 1 | 903.60 | 809.62 | 10.4% |
| cross | 96 | 8 | 4 | 1078.31 | 852.50 | 20.9% |
| cross | 96 | 8 | 8 | 1312.42 | 948.37 | 27.7% |

</details>

### Snapshot regression control

Snapshot kernels and dispatch are unchanged. Separate-buffer controls varied from −8.5% to +4.3%. Rechecking outliers with the **same callable and buffers** reduced differences to ±0.21%; this is a timing control, not a comparison of different implementations.

| Mode | B | T | A | Matched control baseline (µs) | Matched control optimized label (µs) | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| align | 8 | 2 | 1 | 52.03 | 52.04 | -0.02% |
| align | 8 | 2 | 2 | 49.64 | 49.67 | -0.07% |
| none | 8 | 3 | 1 | 73.93 | 73.90 | 0.04% |
| cross | 8 | 3 | 2 | 73.35 | 73.21 | 0.20% |
| cross | 8 | 3 | 3 | 70.84 | 70.80 | 0.06% |

<details>
<summary>Snapshot controls, all configurations</summary>

| Mode | B | T | A | Snapshot baseline (µs) | Snapshot optimized (µs) | Reduction |
|---|---:|---:|---:|---:|---:|---:|
| align | 1 | 2 | 1 | 34.46 | 34.24 | 0.6% |
| align | 1 | 2 | 2 | 34.25 | 34.25 | -0.0% |
| align | 1 | 3 | 1 | 38.56 | 39.16 | -1.6% |
| align | 1 | 3 | 2 | 38.96 | 38.95 | 0.0% |
| align | 1 | 3 | 3 | 38.94 | 39.17 | -0.6% |
| align | 1 | 5 | 1 | 47.36 | 47.52 | -0.3% |
| align | 1 | 5 | 3 | 47.57 | 47.57 | -0.0% |
| align | 1 | 5 | 5 | 47.50 | 47.01 | 1.0% |
| align | 1 | 8 | 1 | 60.43 | 59.90 | 0.9% |
| align | 1 | 8 | 4 | 61.04 | 60.27 | 1.3% |
| align | 1 | 8 | 8 | 60.35 | 60.40 | -0.1% |
| align | 4 | 2 | 1 | 45.15 | 44.94 | 0.5% |
| align | 4 | 2 | 2 | 44.68 | 44.66 | 0.1% |
| align | 4 | 3 | 1 | 60.61 | 58.81 | 3.0% |
| align | 4 | 3 | 2 | 59.77 | 60.50 | -1.2% |
| align | 4 | 3 | 3 | 60.59 | 59.31 | 2.1% |
| align | 4 | 5 | 1 | 76.19 | 77.00 | -1.1% |
| align | 4 | 5 | 3 | 77.55 | 78.19 | -0.8% |
| align | 4 | 5 | 5 | 77.67 | 76.01 | 2.1% |
| align | 4 | 8 | 1 | 119.04 | 118.90 | 0.1% |
| align | 4 | 8 | 4 | 118.92 | 118.67 | 0.2% |
| align | 4 | 8 | 8 | 118.97 | 118.94 | 0.0% |
| align | 8 | 2 | 1 | 54.21 | 49.61 | 8.5% |
| align | 8 | 2 | 2 | 50.20 | 48.34 | 3.7% |
| align | 8 | 3 | 1 | 74.78 | 75.74 | -1.3% |
| align | 8 | 3 | 2 | 74.54 | 75.39 | -1.2% |
| align | 8 | 3 | 3 | 74.33 | 73.81 | 0.7% |
| align | 8 | 5 | 1 | 107.54 | 107.51 | 0.0% |
| align | 8 | 5 | 3 | 107.58 | 107.42 | 0.1% |
| align | 8 | 5 | 5 | 107.35 | 107.21 | 0.1% |
| align | 8 | 8 | 1 | 146.22 | 146.05 | 0.1% |
| align | 8 | 8 | 4 | 146.21 | 146.49 | -0.2% |
| align | 8 | 8 | 8 | 146.33 | 147.48 | -0.8% |
| align | 16 | 2 | 1 | 74.01 | 74.46 | -0.6% |
| align | 16 | 2 | 2 | 73.98 | 74.36 | -0.5% |
| align | 16 | 3 | 1 | 90.18 | 90.28 | -0.1% |
| align | 16 | 3 | 2 | 90.62 | 90.83 | -0.2% |
| align | 16 | 3 | 3 | 90.44 | 90.66 | -0.3% |
| align | 16 | 5 | 1 | 120.07 | 121.09 | -0.8% |
| align | 16 | 5 | 3 | 121.36 | 120.56 | 0.7% |
| align | 16 | 5 | 5 | 121.75 | 121.93 | -0.1% |
| align | 16 | 8 | 1 | 169.00 | 168.61 | 0.2% |
| align | 16 | 8 | 4 | 167.62 | 168.41 | -0.5% |
| align | 16 | 8 | 8 | 167.95 | 168.74 | -0.5% |
| align | 32 | 2 | 1 | 111.86 | 110.71 | 1.0% |
| align | 32 | 2 | 2 | 111.01 | 111.45 | -0.4% |
| align | 32 | 3 | 1 | 139.27 | 139.36 | -0.1% |
| align | 32 | 3 | 2 | 139.03 | 139.66 | -0.5% |
| align | 32 | 3 | 3 | 138.56 | 139.30 | -0.5% |
| align | 32 | 5 | 1 | 192.51 | 192.47 | 0.0% |
| align | 32 | 5 | 3 | 192.55 | 192.43 | 0.1% |
| align | 32 | 5 | 5 | 192.42 | 192.58 | -0.1% |
| align | 32 | 8 | 1 | 273.16 | 273.11 | 0.0% |
| align | 32 | 8 | 4 | 273.14 | 273.84 | -0.3% |
| align | 32 | 8 | 8 | 272.87 | 273.82 | -0.3% |
| align | 48 | 2 | 1 | 146.69 | 146.63 | 0.0% |
| align | 48 | 2 | 2 | 147.15 | 145.13 | 1.4% |
| align | 48 | 3 | 1 | 184.41 | 184.78 | -0.2% |
| align | 48 | 3 | 2 | 184.51 | 184.26 | 0.1% |
| align | 48 | 3 | 3 | 184.08 | 184.51 | -0.2% |
| align | 48 | 5 | 1 | 263.53 | 265.66 | -0.8% |
| align | 48 | 5 | 3 | 263.67 | 265.71 | -0.8% |
| align | 48 | 5 | 5 | 264.01 | 263.22 | 0.3% |
| align | 48 | 8 | 1 | 393.38 | 394.98 | -0.4% |
| align | 48 | 8 | 4 | 394.67 | 394.24 | 0.1% |
| align | 48 | 8 | 8 | 394.29 | 394.50 | -0.1% |
| align | 96 | 2 | 1 | 251.88 | 250.85 | 0.4% |
| align | 96 | 2 | 2 | 251.36 | 252.62 | -0.5% |
| align | 96 | 3 | 1 | 336.36 | 337.62 | -0.4% |
| align | 96 | 3 | 2 | 336.16 | 339.13 | -0.9% |
| align | 96 | 3 | 3 | 332.50 | 340.69 | -2.5% |
| align | 96 | 5 | 1 | 505.21 | 502.30 | 0.6% |
| align | 96 | 5 | 3 | 504.32 | 504.93 | -0.1% |
| align | 96 | 5 | 5 | 505.01 | 506.57 | -0.3% |
| align | 96 | 8 | 1 | 757.24 | 758.23 | -0.1% |
| align | 96 | 8 | 4 | 756.53 | 756.90 | -0.0% |
| align | 96 | 8 | 8 | 755.53 | 756.90 | -0.2% |
| none | 1 | 3 | 1 | 38.96 | 38.84 | 0.3% |
| none | 1 | 3 | 2 | 38.73 | 38.55 | 0.5% |
| none | 1 | 3 | 3 | 38.86 | 38.76 | 0.3% |
| none | 1 | 8 | 1 | 59.82 | 60.11 | -0.5% |
| none | 1 | 8 | 4 | 60.02 | 60.26 | -0.4% |
| none | 1 | 8 | 8 | 59.87 | 60.04 | -0.3% |
| none | 8 | 3 | 1 | 70.60 | 73.61 | -4.3% |
| none | 8 | 3 | 2 | 72.42 | 74.49 | -2.9% |
| none | 8 | 3 | 3 | 70.85 | 71.97 | -1.6% |
| none | 8 | 8 | 1 | 146.61 | 146.33 | 0.2% |
| none | 8 | 8 | 4 | 147.02 | 146.65 | 0.2% |
| none | 8 | 8 | 8 | 146.78 | 146.64 | 0.1% |
| none | 48 | 3 | 1 | 183.94 | 184.92 | -0.5% |
| none | 48 | 3 | 2 | 184.17 | 184.10 | 0.0% |
| none | 48 | 3 | 3 | 183.74 | 184.06 | -0.2% |
| none | 48 | 8 | 1 | 377.87 | 377.52 | 0.1% |
| none | 48 | 8 | 4 | 378.31 | 379.35 | -0.3% |
| none | 48 | 8 | 8 | 380.58 | 380.48 | 0.0% |
| none | 96 | 3 | 1 | 323.50 | 324.43 | -0.3% |
| none | 96 | 3 | 2 | 322.12 | 324.71 | -0.8% |
| none | 96 | 3 | 3 | 323.02 | 324.90 | -0.6% |
| none | 96 | 8 | 1 | 732.07 | 732.02 | 0.0% |
| none | 96 | 8 | 4 | 732.25 | 731.92 | 0.0% |
| none | 96 | 8 | 8 | 733.58 | 731.88 | 0.2% |
| cross | 1 | 3 | 1 | 38.71 | 38.76 | -0.1% |
| cross | 1 | 3 | 2 | 38.56 | 39.26 | -1.8% |
| cross | 1 | 3 | 3 | 38.12 | 38.96 | -2.2% |
| cross | 1 | 8 | 1 | 60.13 | 59.92 | 0.3% |
| cross | 1 | 8 | 4 | 60.23 | 59.44 | 1.3% |
| cross | 1 | 8 | 8 | 59.82 | 59.61 | 0.4% |
| cross | 8 | 3 | 1 | 76.00 | 73.78 | 2.9% |
| cross | 8 | 3 | 2 | 72.77 | 75.68 | -4.0% |
| cross | 8 | 3 | 3 | 71.16 | 73.87 | -3.8% |
| cross | 8 | 8 | 1 | 146.44 | 146.45 | -0.0% |
| cross | 8 | 8 | 4 | 146.33 | 146.23 | 0.1% |
| cross | 8 | 8 | 8 | 146.64 | 147.05 | -0.3% |
| cross | 48 | 3 | 1 | 184.31 | 184.80 | -0.3% |
| cross | 48 | 3 | 2 | 184.13 | 183.96 | 0.1% |
| cross | 48 | 3 | 3 | 184.12 | 184.05 | 0.0% |
| cross | 48 | 8 | 1 | 380.75 | 382.05 | -0.3% |
| cross | 48 | 8 | 4 | 380.78 | 382.52 | -0.5% |
| cross | 48 | 8 | 8 | 381.77 | 381.40 | 0.1% |
| cross | 96 | 3 | 1 | 323.82 | 325.41 | -0.5% |
| cross | 96 | 3 | 2 | 324.45 | 326.79 | -0.7% |
| cross | 96 | 3 | 3 | 325.02 | 326.44 | -0.4% |
| cross | 96 | 8 | 1 | 731.39 | 732.50 | -0.2% |
| cross | 96 | 8 | 4 | 733.53 | 735.02 | -0.2% |
| cross | 96 | 8 | 8 | 736.46 | 734.60 | 0.3% |

</details>

AI-assisted (Codex). Human review and real-sampling quality validation pending. Forward recovery is tolerance-checked, not bitwise identical.
