### PR TITLE
[Bugfix] Exclude SM110 (Jetson Thor) from the cooperative_topk cluster kernel

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -621,6 +621,8 @@ def sparse_attn_indexer(
             and logits.stride(0) % 4 == 0  # TMA 16-byte alignment
             and current_platform.has_device_capability(90)
             and not current_platform.is_device_capability_family(120)
+            # SM110 (Jetson Thor) cannot launch the thread-block-cluster kernel.
+            and not current_platform.is_device_capability_family(110)
         )
         use_persistent_topk = current_platform.is_cuda() and topk_tokens in (
             512,

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -485,6 +485,9 @@ def _topk(
         and logits.stride(0) % 4 == 0
         and current_platform.has_device_capability(90)
         and not current_platform.is_device_capability_family(120)
+        # SM110 (Jetson Thor) cannot launch the thread-block-cluster kernel:
+        # "cooperative_topk launch failed: ... cluster misconfiguration".
+        and not current_platform.is_device_capability_family(110)
     )
     topk_op = (
         torch.ops._C.cooperative_topk


### PR DESCRIPTION
## Purpose

Fix engine warmup failure on SM110 (Jetson AGX Thor) for models that use the sparse-attention indexer top-k (Qwen3.8-Flash-Next / `qwen4_exp` QSA indexer, and the generic `SparseAttnIndexer`). Fixes #56083.

The cooperative (thread-block-cluster) top-k kernel is selected for capability >= 9.0 unless the device is capability family 12x. SM110 passes that gate but cannot launch the cluster kernel:

```
RuntimeError: launch_cooperative_cluster, csrc/libtorch_stable/cooperative_topk.cu:48,
cooperative_topk launch failed: a kernel launch error has occurred due to cluster misconfiguration
```

This excludes family 110 at both call sites, exactly as family 120 is excluded, so SM110 uses `persistent_topk`.

## Test Plan

Jetson AGX Thor (aarch64, sm_110, JetPack R38.4, CUDA 13.0), `vllm/vllm-openai:nightly-8a728663` with the patched files bind-mounted, serving `nvidia/Qwen3.8-Flash-Next-NVFP4` with `--enforce-eager --moe-backend cutlass` (and again with FULL_DECODE_ONLY CUDA graphs).

## Test Result

- Before: engine core dies during warmup with the traceback above (100% reproducible).
- After: engine starts; greedy arithmetic exact; needle retrieved from a 24K-token prompt; coherent long-form decode; passed a 46-task agentic evaluation suite with no regressions. No behavior change on any other capability family (the added clause is False everywhere except 11.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGek5JmK5DMH5TtuDteXyR
