### PR TITLE
[Bugfix][KV Connector] Wait for KV transfers before freeing aborted requests

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2696,6 +2696,8 @@ def assert_scheduler_empty(scheduler: Scheduler):
     assert len(scheduler.waiting) == 0
     assert len(scheduler.running) == 0
     assert len(scheduler.finished_req_ids) == 0
+    assert len(scheduler._finished_req_ids_pending_kv_recv) == 0
+    assert len(scheduler._finished_req_ids_pending_kv_send) == 0
 
     # EncoderCacheManager.
     assert len(scheduler.encoder_cache_manager.freed) == 0
@@ -5071,6 +5073,43 @@ def test_abort_request_finished_recving():
     assert not scheduler.finished_recving_kv_req_ids
 
 
+@pytest.mark.parametrize(
+    "outputs",
+    [
+        pytest.param([("recv",), ("send",)], id="recv_then_send"),
+        pytest.param([("send",), ("recv",)], id="send_then_recv"),
+        pytest.param([("recv", "send")], id="same_output"),
+    ],
+)
+def test_aborted_request_waits_for_all_kv_transfers(outputs):
+    scheduler = create_scheduler(use_kv_connector=True)
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    # Async recv in flight (recv claim) plus an async save started by the
+    # connector on teardown (send claim).
+    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.connector.request_finished = Mock(return_value=(True, None))
+    scheduler.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
+    # Normally drained by the next schedule() call.
+    scheduler.finished_req_ids.clear()
+    assert request.request_id in scheduler.requests
+
+    for i, directions in enumerate(outputs):
+        scheduler._update_from_kv_xfer_finished(
+            KVConnectorOutput(
+                finished_recving={request.request_id} if "recv" in directions else None,
+                finished_sending={request.request_id} if "send" in directions else None,
+            )
+        )
+        if i < len(outputs) - 1:
+            assert request.request_id in scheduler.requests
+        else:
+            assert request.request_id not in scheduler.requests
+
+    assert_scheduler_empty(scheduler)
+
+
 def test_delayed_kv_connector_free_keeps_scheduler_active():
     scheduler = create_scheduler(use_kv_connector=True)
     queued_request, request = create_requests(
@@ -5080,8 +5119,9 @@ def test_delayed_kv_connector_free_keeps_scheduler_active():
 
     assert not scheduler.has_finished_requests()
 
-    request.status = RequestStatus.FINISHED_STOPPED
-    scheduler.requests[request.request_id] = request
+    scheduler.add_request(request)
+    scheduler.connector.request_finished = Mock(return_value=(True, None))
+    scheduler.finish_requests(request.request_id, RequestStatus.FINISHED_STOPPED)
     scheduler.finished_req_ids = set()
 
     assert scheduler.has_finished_requests()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -222,6 +222,11 @@ class Scheduler(SchedulerInterface):
         self.finished_recving_kv_req_ids: set[str] = set()
         self.failed_recving_kv_req_ids: set[str] = set()
 
+        # Finished requests whose blocks are still owned by an async transfer.
+        # Recv and send are independent owners, so they are tracked separately.
+        self._finished_req_ids_pending_kv_recv: set[str] = set()
+        self._finished_req_ids_pending_kv_send: set[str] = set()
+
         # Grammar compilation failures to finish as per-request errors in
         # update_from_output.
         self.grammar_compile_error_reqs: set[str] = set()
@@ -2586,6 +2591,13 @@ class Scheduler(SchedulerInterface):
         if self.finished_req_ids_dict is not None:
             self.finished_req_ids_dict[request.client_index].add(request_id)
 
+        # Register each block owner so that the last completion to
+        # arrive is the one that frees.
+        if delay_free_blocks:
+            self._finished_req_ids_pending_kv_recv.add(request_id)
+        if connector_delay_free_blocks:
+            self._finished_req_ids_pending_kv_send.add(request_id)
+
         delay_free_blocks |= connector_delay_free_blocks
         if not delay_free_blocks:
             self._free_blocks(request)
@@ -2594,6 +2606,8 @@ class Scheduler(SchedulerInterface):
 
     def _free_blocks(self, request: Request):
         assert request.is_finished()
+        self._finished_req_ids_pending_kv_recv.discard(request.request_id)
+        self._finished_req_ids_pending_kv_send.discard(request.request_id)
         self._free_request_blocks(request)
         del self.requests[request.request_id]
 
@@ -2997,6 +3011,14 @@ class Scheduler(SchedulerInterface):
             f"{request.status.name} for request {request.request_id}"
         )
 
+    def _free_blocks_if_no_pending_kv_transfer(self, request: Request) -> None:
+        request_id = request.request_id
+        if (
+            request_id not in self._finished_req_ids_pending_kv_recv
+            and request_id not in self._finished_req_ids_pending_kv_send
+        ):
+            self._free_blocks(request)
+
     def _update_from_kv_xfer_finished(self, kv_connector_output: KVConnectorOutput):
         """
         KV Connector: update the scheduler state based on the output.
@@ -3020,11 +3042,15 @@ class Scheduler(SchedulerInterface):
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                assert req_id in self._finished_req_ids_pending_kv_recv
+                self._finished_req_ids_pending_kv_recv.remove(req_id)
+                self._free_blocks_if_no_pending_kv_transfer(req)
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
             assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            assert req_id in self._finished_req_ids_pending_kv_send
+            self._finished_req_ids_pending_kv_send.remove(req_id)
+            self._free_blocks_if_no_pending_kv_transfer(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose

Fixes #46240.

When a request is aborted with both KV recv and send pending, the first completion frees the request and the second hits `assert req_id in self.requests`, taking down EngineCore.  This change tracks pending recv and send separately and frees blocks only after both complete. It covers recv -> send, send -> recv, and both in the same step.

## Test Plan

### Unit tests

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/v1/core/test_scheduler.py -q
```

`test_aborted_request_waits_for_all_kv_transfers` covers all three completion orders (recv -> send, send -> recv, and both completions in the same output) and checks that the request is removed only after both completions.

### Abort reproduction
Run the abort reproduction described in #46240 with the fix applied.

### Trace replay

I also ran the `Conversation`, `Tool and Agent`, and `Synthetic` workloads from the [Mooncake FAST'25 traces](https://github.com/kvcache-ai/Mooncake/blob/main/FAST25-release/README.md#workloads).

## Test Result
### Unit tests

165 passed, 16 warnings (the warnings are mostly noise from Python/third-party SWIG bindings and upstream PyTorch deprecations):

```text
$ VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/v1/core/test_scheduler.py -q
Running 165 items in this shard
.....................................................................................................................................................................            [100%]
=============================================================== warnings summary ===============================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /root/liubingjie/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
165 passed, 16 warnings in 123.31s (0:02:03)
```
### Abort reproduction
Before the fix, decode EngineCore failed within 10 requests. After the fix, the 200-request run finished without this failure.

```text
$ .venv/bin/python repro_pd_abort_kv_race.py --url http://10.0.0.98:30800/v1/chat/completions  \
--model /models/Qwen3-14B \
--requests 200 \
--concurrency 64 \
--prompt-tokens 24000 \
--abort-lo 0.5 --abort-hi 2.0
...
summary: in_window=51 late=149
```
### Trace replay
No pod restarts or disconnections were observed during these runs.

| Workload       | Duration (s) | Mean requests/s | p95 TTFT (ms) | 
| -------------- | ------------ | --------------- | ------------- | 
| Synthetic      | 1023.4       | 3.3             | 2778.6        | 
| Conversation   | 3545.7       | 3.2             | 2791.5        | 
| Tool and Agent | 3545.1       | 6.4             | 2493.9        | 

All three workloads completed without errors, with performance in line with expectations

Synthetic: full benchmark output
```text
ℹ Run Summary Info
|===========|==========|==========|========|======|======|============|=====|=====|==========|=====|=====|
| Benchmark | Timings                                ||||| Input Tokens         ||| Output Tokens      |||
| Strategy  | Start    | End      | Dur    | Warm | Cool | Comp       | Inc | Err | Comp     | Inc | Err |
|           |          |          | Sec    | Sec  | Sec  | Tot        | Tot | Tot | Tot      | Tot | Tot |
|-----------|----------|----------|--------|------|------|------------|-----|-----|----------|-----|-----|
| trace     | 07:34:50 | 07:51:54 | 1023.4 | 0.0  | 0.0  | 30973684.0 | 0.0 | 0.0 | 578536.0 | 0.0 | 0.0 |
|===========|==========|==========|========|======|======|============|=====|=====|==========|=====|=====|


ℹ Text Metrics Statistics (Completed Requests)
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|=========|==========|
| Benchmark | Input Tokens                      |||| Input Words                       |||| Input Characters                     ||||
| Strategy  | Per Request     || Per Second       || Per Request     || Per Second       || Per Request       || Per Second        ||
|           | Mdn    | p95     | Mdn     | Mean    | Mdn    | p95     | Mdn     | Mean    | Mdn     | p95      | Mdn     | Mean     |
|-----------|--------|---------|---------|---------|--------|---------|---------|---------|---------|----------|---------|----------|
| trace     | 5028.0 | 27971.0 | 12110.3 | 30327.5 | 4188.0 | 23381.0 | 10161.2 | 25340.3 | 28284.0 | 157205.0 | 68544.8 | 170559.8 |
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|=========|==========|
| Benchmark | Output Tokens                     |||| Output Words                      |||| Output Characters                    ||||
| Strategy  | Per Request     || Per Second       || Per Request     || Per Second       || Per Request       || Per Second        ||
|           | Mdn    | p95     | Mdn     | Mean    | Mdn    | p95     | Mdn     | Mean    | Mdn     | p95      | Mdn     | Mean     |
|-----------|--------|---------|---------|---------|--------|---------|---------|---------|---------|----------|---------|----------|
| trace     | 105.0  | 554.0   | 260.3   | 566.5   | 74.0   | 404.0   | 187.3   | 411.1   | 440.0   | 2437.0   | 1095.0  | 2497.1   |
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|=========|==========|


ℹ Request Token Statistics (Completed Requests)
|===========|========|=========|=======|=======|========|=========|=======|=======|=========|========|
| Benchmark | Input Tok       || Output Tok   || Total Tok       || Stream Iter  || Output Tok      ||
| Strategy  | Per Req         || Per Req      || Per Req         || Per Req      || Per Stream Iter ||
|           | Mdn    | p95     | Mdn   | p95   | Mdn    | p95     | Mdn   | p95   | Mdn     | p95    |
|-----------|--------|---------|-------|-------|--------|---------|-------|-------|---------|--------|
| trace     | 5028.0 | 27971.0 | 105.0 | 554.0 | 5119.0 | 27977.0 | 107.0 | 556.0 | 1.0     | 1.0    |
|===========|========|=========|=======|=======|========|=========|=======|=======|=========|========|


ℹ Request Latency Statistics (Completed Requests)
|===========|=========|========|=======|========|=======|========|======|======|======|======|
| Benchmark | Request Latency || TTFT          || TTFOT         || ITL        || TPOT       ||
| Strategy  | Sec             || ms            || ms            || ms         || ms         ||
|           | Mdn     | p95    | Mdn   | p95    | Mdn   | p95    | Mdn  | p95  | Mdn  | p95  |
|-----------|---------|--------|-------|--------|-------|--------|------|------|------|------|
| trace     | 2.6     | 7.3    | 640.6 | 2778.6 | 640.6 | 2778.6 | 11.7 | 13.0 | 12.8 | 26.9 |
|===========|=========|========|=======|========|=======|========|======|======|======|======|


ℹ Server Throughput Statistics (All Requests)
|===========|=======|======|=========|==============|===============|==============|
| Benchmark | Requests             ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy  | Concurrency || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|           | Mdn   | Mean | Mean                                               ||||
|-----------|-------|------|---------|--------------|---------------|--------------|
| trace     | 10.0  | 9.7  | 3.3     | 30345.1      | 566.3         | 30882.4      |
|===========|=======|======|=========|==============|===============|==============|
```
Conversation: full benchmark output
```text
ℹ Run Summary Info
|===========|==========|==========|========|======|======|============|=====|=====|===========|=====|=====|
| Benchmark | Timings                                ||||| Input Tokens         ||| Output Tokens       |||
| Strategy  | Start    | End      | Dur    | Warm | Cool | Comp       | Inc | Err | Comp      | Inc | Err |
|           |          |          | Sec    | Sec  | Sec  | Tot        | Tot | Tot | Tot       | Tot | Tot |
|-----------|----------|----------|--------|------|------|------------|-----|-----|-----------|-----|-----|
| trace     | 08:49:52 | 09:48:58 | 3545.7 | 0.0  | 0.0  | 96502808.0 | 0.0 | 0.0 | 3773129.0 | 0.0 | 0.0 |
|===========|==========|==========|========|======|======|============|=====|=====|===========|=====|=====|


ℹ Text Metrics Statistics (Completed Requests)
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|=========|==========|
| Benchmark | Input Tokens                      |||| Input Words                       |||| Input Characters                     ||||
| Strategy  | Per Request     || Per Second       || Per Request     || Per Second       || Per Request       || Per Second        ||
|           | Mdn    | p95     | Mdn     | Mean    | Mdn    | p95     | Mdn     | Mean    | Mdn     | p95      | Mdn     | Mean     |
|-----------|--------|---------|---------|---------|--------|---------|---------|---------|---------|----------|---------|----------|
| trace     | 6156.0 | 25191.0 | 14644.6 | 27221.2 | 5150.0 | 21048.0 | 12242.5 | 22756.4 | 34693.0 | 141684.0 | 82537.5 | 153304.3 |
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|=========|==========|
| Benchmark | Output Tokens                     |||| Output Words                      |||| Output Characters                    ||||
| Strategy  | Per Request     || Per Second       || Per Request     || Per Second       || Per Request       || Per Second        ||
|           | Mdn    | p95     | Mdn     | Mean    | Mdn    | p95     | Mdn     | Mean    | Mdn     | p95      | Mdn     | Mean     |
|-----------|--------|---------|---------|---------|--------|---------|---------|---------|---------|----------|---------|----------|
| trace     | 347.0  | 688.0   | 714.5   | 1064.3  | 260.0  | 541.0   | 539.9   | 810.9   | 1525.0  | 3207.0   | 3160.8  | 4779.0   |
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|=========|==========|


ℹ Request Token Statistics (Completed Requests)
|===========|========|=========|=======|=======|========|=========|=======|=======|=========|========|
| Benchmark | Input Tok       || Output Tok   || Total Tok       || Stream Iter  || Output Tok      ||
| Strategy  | Per Req         || Per Req      || Per Req         || Per Req      || Per Stream Iter ||
|           | Mdn    | p95     | Mdn   | p95   | Mdn    | p95     | Mdn   | p95   | Mdn     | p95    |
|-----------|--------|---------|-------|-------|--------|---------|-------|-------|---------|--------|
| trace     | 6156.0 | 25191.0 | 347.0 | 688.0 | 6483.0 | 25555.0 | 349.0 | 690.0 | 1.0     | 1.0    |
|===========|========|=========|=======|=======|========|=========|=======|=======|=========|========|


ℹ Request Latency Statistics (Completed Requests)
|===========|========|=========|=======|========|=======|========|======|======|======|======|
| Benchmark | Request Latency || TTFT          || TTFOT         || ITL        || TPOT       ||
| Strategy  | Sec             || ms            || ms            || ms         || ms         ||
|           | Mdn    | p95     | Mdn   | p95    | Mdn   | p95    | Mdn  | p95  | Mdn  | p95  |
|-----------|--------|---------|-------|--------|-------|--------|------|------|------|------|
| trace     | 5.5    | 10.9    | 746.1 | 2791.5 | 746.1 | 2791.5 | 13.1 | 15.6 | 15.0 | 22.4 |
|===========|========|=========|=======|========|=======|========|======|======|======|======|


ℹ Server Throughput Statistics (All Requests)
|===========|=======|======|=========|==============|===============|==============|
| Benchmark | Requests             ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy  | Concurrency || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|           | Mdn   | Mean | Mean                                               ||||
|-----------|-------|------|---------|--------------|---------------|--------------|
| trace     | 17.0  | 17.3 | 3.2     | 27268.9      | 1064.2        | 28282.9      |
|===========|=======|======|=========|==============|===============|==============|
```

Tool and Agent: full benchmark output

```text
ℹ Run Summary Info
|===========|==========|==========|========|======|======|=============|=====|=====|===========|=====|=====|
| Benchmark | Timings                                ||||| Input Tokens          ||| Output Tokens       |||
| Strategy  | Start    | End      | Dur    | Warm | Cool | Comp        | Inc | Err | Comp      | Inc | Err |
|           |          |          | Sec    | Sec  | Sec  | Tot         | Tot | Tot | Tot       | Tot | Tot |
|-----------|----------|----------|--------|------|------|-------------|-----|-----|-----------|-----|-----|
| trace     | 11:39:03 | 12:38:08 | 3545.1 | 0.0  | 0.0  | 160999246.0 | 0.0 | 0.0 | 3952721.0 | 0.0 | 0.0 |
|===========|==========|==========|========|======|======|=============|=====|=====|===========|=====|=====|


ℹ Text Metrics Statistics (Completed Requests)
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|==========|==========|
| Benchmark | Input Tokens                      |||| Input Words                       |||| Input Characters                      ||||
| Strategy  | Per Request     || Per Second       || Per Request     || Per Second       || Per Request       || Per Second         ||
|           | Mdn    | p95     | Mdn     | Mean    | Mdn    | p95     | Mdn     | Mean    | Mdn     | p95      | Mdn      | Mean     |
|-----------|--------|---------|---------|---------|--------|---------|---------|---------|---------|----------|----------|----------|
| trace     | 6267.0 | 19391.0 | 24390.9 | 45422.2 | 5218.0 | 16192.0 | 20376.3 | 37911.6 | 35123.0 | 109097.0 | 137066.0 | 255216.8 |
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|==========|==========|
| Benchmark | Output Tokens                     |||| Output Words                      |||| Output Characters                     ||||
| Strategy  | Per Request     || Per Second       || Per Request     || Per Second       || Per Request       || Per Second         ||
|           | Mdn    | p95     | Mdn     | Mean    | Mdn    | p95     | Mdn     | Mean    | Mdn     | p95      | Mdn      | Mean     |
|-----------|--------|---------|---------|---------|--------|---------|---------|---------|---------|----------|----------|----------|
| trace     | 29.0   | 589.0   | 509.2   | 1115.2  | 22.0   | 458.0   | 388.7   | 849.6   | 136.0   | 2712.0   | 2287.8   | 5011.8   |
|===========|========|=========|=========|=========|========|=========|=========|=========|=========|==========|==========|==========|


ℹ Request Token Statistics (Completed Requests)
|===========|========|=========|======|=======|========|=========|======|=======|=========|========|
| Benchmark | Input Tok       || Output Tok  || Total Tok       || Stream Iter || Output Tok      ||
| Strategy  | Per Req         || Per Req     || Per Req         || Per Req     || Per Stream Iter ||
|           | Mdn    | p95     | Mdn  | p95   | Mdn    | p95     | Mdn  | p95   | Mdn     | p95    |
|-----------|--------|---------|------|-------|--------|---------|------|-------|---------|--------|
| trace     | 6267.0 | 19391.0 | 29.0 | 589.0 | 6313.0 | 19775.0 | 31.0 | 590.0 | 1.0     | 1.0    |
|===========|========|=========|======|=======|========|=========|======|=======|=========|========|


ℹ Request Latency Statistics (Completed Requests)
|===========|=========|========|=======|========|=======|========|======|======|======|======|
| Benchmark | Request Latency || TTFT          || TTFOT         || ITL        || TPOT       ||
| Strategy  | Sec             || ms            || ms            || ms         || ms         ||
|           | Mdn     | p95    | Mdn   | p95    | Mdn   | p95    | Mdn  | p95  | Mdn  | p95  |
|-----------|---------|--------|-------|--------|-------|--------|------|------|------|------|
| trace     | 1.3     | 9.7    | 605.5 | 2493.9 | 605.5 | 2493.9 | 13.3 | 16.2 | 15.7 | 28.1 |
|===========|=========|========|=======|========|=======|========|======|======|======|======|


ℹ Server Throughput Statistics (All Requests)
|===========|=======|======|=========|==============|===============|==============|
| Benchmark | Requests             ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy  | Concurrency || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|           | Mdn   | Mean | Mean                                               ||||
|-----------|-------|------|---------|--------------|---------------|--------------|
| trace     | 19.0  | 20.7 | 6.4     | 45501.2      | 1115.1        | 46534.8      |
|===========|=======|======|=========|==============|===============|==============|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

