### PR TITLE
[CI][ROCm][Disagg] Fix Kimi-K2.5-MXFP4 disagg nightly

### DIFF
--- a/.buildkite/amd-disagg/models.yaml
+++ b/.buildkite/amd-disagg/models.yaml
@@ -82,7 +82,6 @@ models:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
       VLLM_ROCM_USE_AITER_RMSNORM: "1"
-      VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
     base_flags: "--trust-remote-code --kv-cache-dtype fp8 --block-size 1"
     prefill:
       tp: "--gpu-memory-utilization 0.85"

--- a/.buildkite/amd-disagg/models.yaml
+++ b/.buildkite/amd-disagg/models.yaml
@@ -82,7 +82,8 @@ models:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
       VLLM_ROCM_USE_AITER_RMSNORM: "1"
-    base_flags: "--trust-remote-code"
+      VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
+    base_flags: "--trust-remote-code --kv-cache-dtype fp8 --block-size 1"
     prefill:
       tp: "--gpu-memory-utilization 0.85"
       ep: "--gpu-memory-utilization 0.85 --enforce-eager"


### PR DESCRIPTION
## Purpose

Kimi-K2.5-MXFP4 fails ROCm disagg CI on nightly when the catalog entry only has `--trust-remote-code`. Add the serve flags required for 1P1D bring-up and GSM8K on nightly.

## Changes

`.buildkite/amd-disagg/models.yaml` only:

* `Kimi-K2.5-MXFP4` `base_flags`: `--trust-remote-code` → `--trust-remote-code --kv-cache-dtype fp8 --block-size 1`

No launcher, MoRIIO, or harness script changes.

## Test Plan

MoRIIO **1P1D TP8** disaggregated serving, `ROUTER_TYPE=proxy`, `RUN_AFTER_HEALTH=accuracy`, image `vllm/vllm-openai-rocm:nightly`.

## Test Result

Kimi-K2.5-MXFP4, MoRIIO 1P1D TP8 (proxy). GSM8K flexible-extract, threshold 0.90.

| Variant | Health | GSM8K exact_match |
| --- | --- | --- |
| Stock `models.yaml` (no extra flags) | Fail (`moe2_layout` / health-gate) | — |
| Stock + `--kv-cache-dtype fp8` | Pass | **0.362** (FAIL) |
| Stock + `--block-size 1` | Fail (health-gate) | — |
| Stock + kv-fp8 + `block-size 1` (this PR) | Pass | **0.925** (PASS) |