### PR TITLE
[Security] Bound unread engine output queued per request

### DIFF
--- a/rust/src/engine-core-client/src/client/imp.rs
+++ b/rust/src/engine-core-client/src/client/imp.rs
@@ -15,7 +15,9 @@ use tracing::{debug, info, trace, warn};
 use vllm_metrics::METRICS;
 use zeromq::RouterSendHalf;
 
-use crate::client::state::{OutputReceiver, RequestRegistry, UtilityReceiver, UtilityRegistry};
+use crate::client::state::{
+    OutputReceiver, OutputSender, RequestRegistry, UtilityReceiver, UtilityRegistry,
+};
 use crate::client::stream::EngineCoreStreamOutput;
 use crate::client::{AbortCause, AbortRequest};
 use crate::error::{client_closed, dispatcher_closed, unexpected_dispatcher_output};
@@ -147,7 +149,7 @@ impl ClientInner {
     pub fn take_senders_for_outputs<'a>(
         &self,
         outputs: impl IntoIterator<Item = &'a EngineCoreOutput>,
-    ) -> Vec<Option<mpsc::UnboundedSender<Result<EngineCoreStreamOutput>>>> {
+    ) -> Vec<Option<OutputSender>> {
         self.request_reg.lock().senders_for_outputs(outputs)
     }
 
@@ -156,7 +158,7 @@ impl ClientInner {
     pub fn finish_requests<'a>(
         &self,
         request_ids: impl IntoIterator<Item = &'a String>,
-    ) -> Vec<mpsc::UnboundedSender<Result<EngineCoreStreamOutput>>> {
+    ) -> Vec<OutputSender> {
         self.request_reg.lock().finish_many(request_ids)
     }
 
@@ -197,7 +199,7 @@ impl ClientInner {
 
         // Notify all ongoing requests that the client is closed.
         for sender in request_senders {
-            let _ = sender.send(Err(Error::Shared(persistent_error.clone())));
+            let _ = sender.try_send(Err(Error::Shared(persistent_error.clone())));
         }
         for sender in utility_senders {
             let _ = sender.send(Err(Error::Shared(persistent_error.clone())));
@@ -416,6 +418,7 @@ pub(crate) async fn run_output_dispatcher_loop(
             match outputs {
                 EngineCoreOutputs::RequestBatch(batch) => {
                     let senders = inner.take_senders_for_outputs(&batch.outputs);
+                    let mut slow_consumers: BTreeMap<EngineId, Vec<String>> = BTreeMap::new();
                     for (output, sender) in batch.outputs.into_iter().zip(senders) {
                         let request_id = output.request_id.clone();
                         let Some(sender) = sender else {
@@ -428,8 +431,29 @@ pub(crate) async fn run_output_dispatcher_loop(
                             timestamp: batch.timestamp,
                             output,
                         };
-                        if sender.send(Ok(wrapped_output)).is_err() {
-                            debug!(request_id, "request output stream receiver dropped");
+                        match sender.try_send(Ok(wrapped_output)) {
+                            Ok(()) => {}
+                            Err(mpsc::error::TrySendError::Closed(_)) => {
+                                debug!(request_id, "request output stream receiver dropped");
+                            }
+                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                warn!(request_id, "aborting request: unread output queue is full");
+                                if let Some(engine_id) = inner.take_auto_abort_target(&request_id) {
+                                    slow_consumers.entry(engine_id).or_default().push(request_id);
+                                }
+                            }
+                        }
+                    }
+
+                    for (engine_id, request_ids) in slow_consumers {
+                        if let Err(error) = inner.do_abort_requests(&engine_id, &request_ids).await
+                        {
+                            warn!(
+                                ?engine_id,
+                                ?request_ids,
+                                error = %error.as_report(),
+                                "failed to abort slow-consumer request streams"
+                            );
                         }
                     }
 
@@ -534,5 +558,53 @@ mod tests {
             inner.health_error().as_deref(),
             Some(Error::EngineCoreDead)
         ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unread_output_overflow_removes_request_for_abort() {
+        use crate::client::state::MAX_QUEUED_OUTPUTS_PER_REQUEST;
+
+        let inner = test_inner().await;
+        let request_id = "req-slow".to_string();
+        let (_engine_id, mut rx) = inner.register_request(request_id.clone(), None, None).unwrap();
+
+        let output = EngineCoreOutput {
+            request_id: request_id.clone(),
+            ..Default::default()
+        };
+        let sender = inner
+            .take_senders_for_outputs(std::slice::from_ref(&output))
+            .into_iter()
+            .next()
+            .flatten()
+            .expect("active request");
+
+        let wrapped = EngineCoreStreamOutput {
+            engine_index: 0,
+            timestamp: 0.0,
+            output: output.clone(),
+        };
+        for _ in 0..MAX_QUEUED_OUTPUTS_PER_REQUEST {
+            sender
+                .try_send(Ok(wrapped.clone()))
+                .expect("queue should accept up to the bound");
+        }
+        assert!(matches!(
+            sender.try_send(Ok(wrapped)),
+            Err(mpsc::error::TrySendError::Full(_))
+        ));
+
+        let engine_id = inner
+            .take_auto_abort_target(&request_id)
+            .expect("overflow must still abort the engine request");
+        assert_eq!(engine_id, EngineId::from(b"engine-0"));
+        assert!(inner.take_auto_abort_target(&request_id).is_none());
+        drop(sender);
+
+        let mut drained = 0usize;
+        while rx.try_recv().is_ok() {
+            drained += 1;
+        }
+        assert_eq!(drained, MAX_QUEUED_OUTPUTS_PER_REQUEST);
     }
 }

--- a/rust/src/engine-core-client/src/client/state.rs
+++ b/rust/src/engine-core-client/src/client/state.rs
@@ -15,8 +15,15 @@ use crate::protocol::stats::SchedulerStats;
 use crate::protocol::utility::UtilityOutput;
 use crate::transport::ConnectedEngine;
 
-pub type OutputSender = mpsc::UnboundedSender<Result<EngineCoreStreamOutput>>;
-pub type OutputReceiver = mpsc::UnboundedReceiver<Result<EngineCoreStreamOutput>>;
+/// Maximum unread engine outputs buffered for one request.
+///
+/// The output dispatcher never awaits the HTTP consumer. Without a bound, a
+/// slow SSE client can retain finished token and logprob payloads after the
+/// request has left scheduler accounting.
+pub(crate) const MAX_QUEUED_OUTPUTS_PER_REQUEST: usize = 256;
+
+pub type OutputSender = mpsc::Sender<Result<EngineCoreStreamOutput>>;
+pub type OutputReceiver = mpsc::Receiver<Result<EngineCoreStreamOutput>>;
 pub type UtilitySender = oneshot::Sender<Result<UtilityOutput>>;
 pub type UtilityReceiver = oneshot::Receiver<Result<UtilityOutput>>;
 
@@ -133,7 +140,7 @@ impl RequestRegistry {
         }
 
         let engine_id = self.choose_engine_for_request(data_parallel_rank)?;
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(MAX_QUEUED_OUTPUTS_PER_REQUEST);
         let lora = lora_name.map(|adapter_name| LoraRequestState {
             adapter_name,
             phase: LoraPhase::Waiting,
@@ -322,7 +329,7 @@ impl RequestRegistry {
                     ..EngineCoreOutput::default()
                 },
             };
-            let _ = sender.send(Ok(output));
+            let _ = sender.try_send(Ok(output));
             aborted.push(request_id.clone());
         }
         aborted
@@ -457,8 +464,10 @@ mod tests {
 
     use crate::EngineId;
     use crate::client::state::{
-        EngineLoadSnapshot, EngineRoutingState, RequestRegistry, UtilityRegistry,
+        EngineLoadSnapshot, EngineRoutingState, MAX_QUEUED_OUTPUTS_PER_REQUEST, RequestRegistry,
+        UtilityRegistry,
     };
+    use crate::client::stream::EngineCoreStreamOutput;
     use crate::mock_engine::default_ready_response;
     use crate::protocol::output::{
         EngineCoreEvent, EngineCoreEventType, EngineCoreFinishReason, EngineCoreOutput,
@@ -930,5 +939,90 @@ mod tests {
         registry.unregister_many([call_id, 42, 9999]);
 
         assert!(!registry.contains(call_id));
+    }
+
+    fn queued_stream_output(request_id: &str) -> EngineCoreStreamOutput {
+        EngineCoreStreamOutput {
+            engine_index: 0,
+            timestamp: 0.0,
+            output: EngineCoreOutput {
+                request_id: request_id.to_string(),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn request_output_channel_rejects_unread_overflow() {
+        let mut registry = RequestRegistry::new(&[connected_engine(EngineId::from(b"engine-0"))]);
+        let (_, mut rx) = registry.register("req-slow".to_string(), None, None).unwrap();
+        let sender = registry
+            .sender_for_output(&EngineCoreOutput {
+                request_id: "req-slow".to_string(),
+                ..Default::default()
+            })
+            .expect("active request");
+
+        for _ in 0..MAX_QUEUED_OUTPUTS_PER_REQUEST {
+            sender
+                .try_send(Ok(queued_stream_output("req-slow")))
+                .expect("queue should accept up to the bound");
+        }
+        let overflow = sender
+            .try_send(Ok(queued_stream_output("req-slow")))
+            .expect_err("bound must reject further unread items");
+        assert!(matches!(
+            overflow,
+            tokio::sync::mpsc::error::TrySendError::Full(_)
+        ));
+        assert!(registry.contains("req-slow"));
+
+        let removed = registry.remove("req-slow");
+        assert!(removed.is_some());
+        drop(sender);
+        drop(removed);
+
+        let mut drained = 0usize;
+        while rx.try_recv().is_ok() {
+            drained += 1;
+        }
+        assert_eq!(drained, MAX_QUEUED_OUTPUTS_PER_REQUEST);
+        assert!(matches!(
+            rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
+    }
+
+    #[test]
+    fn abort_many_does_not_block_when_output_queue_is_full() {
+        let mut registry = RequestRegistry::new(&[connected_engine(EngineId::from(b"engine-0"))]);
+        let (_, mut rx) = registry.register("req-slow".to_string(), None, None).unwrap();
+        let sender = registry
+            .sender_for_output(&EngineCoreOutput {
+                request_id: "req-slow".to_string(),
+                ..Default::default()
+            })
+            .expect("active request");
+
+        for _ in 0..MAX_QUEUED_OUTPUTS_PER_REQUEST {
+            sender
+                .try_send(Ok(queued_stream_output("req-slow")))
+                .expect("queue should accept up to the bound");
+        }
+
+        let aborted = registry.abort_many([&"req-slow".to_string()], 1.0);
+        assert_eq!(aborted, vec!["req-slow".to_string()]);
+        assert!(!registry.contains("req-slow"));
+        drop(sender);
+
+        let mut drained = 0usize;
+        while rx.try_recv().is_ok() {
+            drained += 1;
+        }
+        assert_eq!(drained, MAX_QUEUED_OUTPUTS_PER_REQUEST);
+        assert!(matches!(
+            rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
     }
 }


### PR DESCRIPTION
## Summary
The Rust frontend buffers each request's engine outputs in an unbounded channel and the dispatcher `send`s without waiting for the HTTP consumer. A slow streaming client can retain finished token and logprob payloads after the request has left scheduler accounting. This bounds the per-request queue and aborts a request that falls behind instead of blocking the shared dispatcher.

## Changes
- `rust/src/engine-core-client/src/client/state.rs`: create a bounded per-request output channel (`MAX_QUEUED_OUTPUTS_PER_REQUEST = 256`) and use non-blocking `try_send` on abort/close.
- `rust/src/engine-core-client/src/client/imp.rs`: dispatcher `try_send`s; a full queue drops the request from the registry and aborts it on the engine.

## Codepath coverage
- All `EngineCoreClient::call` streams share this registry channel: `/v1/chat/completions`, `/v1/completions`, `/inference/v1/generate`, and gRPC generate/stream.
- Non-streaming collect uses the same stream and is covered by the bound.
- Internal abort and coordinator channels are not HTTP-consumer-backed and are unchanged.

## Duplicate-work check
Searched open and merged PRs for `unbounded_channel`, `OutputSender`, engine-core-client output channel, and related Rust streaming work. https://github.com/vllm-project/vllm/pull/53454 touches the same files for resumable sessions but keeps an unbounded output channel. https://github.com/vllm-project/vllm/pull/51321 only optimizes SSE serialization. https://github.com/vllm-project/vllm/pull/49330 bounds the Python waiting queue. No existing PR closes this sink.

## Tests
- `request_output_channel_rejects_unread_overflow` — unread items past the bound are rejected; draining then observes close.
- `abort_many_does_not_block_when_output_queue_is_full` — abort still retires a full queue without blocking.
- `unread_output_overflow_removes_request_for_abort` — overflow still yields an engine abort target.

Commands:
```
cd rust && cargo test -p vllm-engine-core-client --lib
cd rust && cargo clippy -p vllm-engine-core-client --all-targets -- -D warnings
```
105 tests passed; clippy clean.

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)