### PR TITLE
[Security] Bound MiniMax M3 VL pixel budgets before resize

### DIFF
--- a/tests/models/multimodal/processing/test_minimax_m3.py
+++ b/tests/models/multimodal/processing/test_minimax_m3.py
@@ -136,3 +136,85 @@ def test_video_volumetric_cap_raises():
             max_long_side_pixel=1008,
             return_tensors="pt",
         )
+
+
+def test_smart_resize_rejects_inverted_pixel_budget():
+    with pytest.raises(ValueError, match="min_pixels must be less than or equal"):
+        smart_resize(
+            224,
+            224,
+            factor=28,
+            min_pixels=100_000_000,
+            max_pixels=768 * 28 * 28,
+        )
+
+
+def test_smart_resize_rejects_non_positive_pixel_budget():
+    with pytest.raises(ValueError, match="must be positive"):
+        smart_resize(224, 224, factor=28, min_pixels=0, max_pixels=1000)
+    with pytest.raises(ValueError, match="must be positive"):
+        smart_resize(224, 224, factor=28, min_pixels=100, max_pixels=-1)
+
+
+def test_smart_resize_area_path_honors_max_total_pixels():
+    with pytest.raises(ValueError, match="max_total_pixels"):
+        smart_resize(
+            5000,
+            5000,
+            factor=28,
+            min_pixels=4 * 28 * 28,
+            max_pixels=10**12,
+            max_total_pixels=IMAGE_MAX_TOTAL_PIXELS,
+        )
+
+
+@pytest.mark.parametrize(
+    "processor_kwargs",
+    [
+        {"min_pixels": 100_000_000},
+        {"min_pixels": 100_000_000, "max_pixels": 100_000_000},
+    ],
+)
+def test_video_preprocess_rejects_inverted_min_pixels(
+    monkeypatch: pytest.MonkeyPatch, processor_kwargs: dict[str, int]
+):
+    proc = MiniMaxM3VLVideoProcessor()
+
+    def _must_not_resize(*args, **kwargs):
+        raise AssertionError("resize must not run for over-budget geometry")
+
+    monkeypatch.setattr(proc, "resize", _must_not_resize)
+    video = torch.zeros((4, 3, 224, 224), dtype=torch.uint8)
+    with pytest.raises(ValueError, match="min_pixels must be less than or equal"):
+        proc.preprocess(
+            videos=[video],
+            do_resize=True,
+            return_tensors="pt",
+            **processor_kwargs,
+        )
+
+
+def test_image_preprocess_does_not_raise_max_pixels_ceiling():
+    proc = MiniMaxM3VLImageProcessor()
+    image = torch.randint(0, 255, (3, 256, 256), dtype=torch.uint8)
+    baseline = proc.preprocess([image], do_resize=True, return_tensors="pt")
+    oversized = proc.preprocess(
+        [image], do_resize=True, max_pixels=10**12, return_tensors="pt"
+    )
+    assert torch.equal(baseline["image_grid_thw"], oversized["image_grid_thw"])
+
+
+def test_video_area_resize_enforces_volumetric_cap(monkeypatch: pytest.MonkeyPatch):
+    proc = MiniMaxM3VLVideoProcessor()
+    monkeypatch.setattr(
+        "vllm.transformers_utils.processors.minimax_m3.smart_resize",
+        lambda *args, **kwargs: (10_024, 10_024),
+    )
+
+    def _must_not_resize(*args, **kwargs):
+        raise AssertionError("resize must not run for over-budget geometry")
+
+    monkeypatch.setattr(proc, "resize", _must_not_resize)
+    video = torch.zeros((4, 3, 28, 28), dtype=torch.uint8)
+    with pytest.raises(ValueError, match="max_total_pixels"):
+        proc.preprocess(videos=[video], do_resize=True, return_tensors="pt")

--- a/vllm/transformers_utils/processors/minimax_m3.py
+++ b/vllm/transformers_utils/processors/minimax_m3.py
@@ -120,7 +120,13 @@ def smart_resize(
     When ``max_long_side_pixel`` is set, use the MiniMax-M3 long-side resize
     spec (see :func:`_smart_resize_by_long_side`). Otherwise fall back to the
     Qwen-VL area bound, keeping the total area within ``[min_pixels, max_pixels]``.
+    ``min_pixels`` must not exceed ``max_pixels``; a request cannot enlarge a
+    frame past the max by inverting those bounds.
     """
+    if min_pixels <= 0 or max_pixels <= 0:
+        raise ValueError("min_pixels and max_pixels must be positive.")
+    if min_pixels > max_pixels:
+        raise ValueError("min_pixels must be less than or equal to max_pixels.")
     if max(height, width) / min(height, width) > MAX_RATIO:
         raise ValueError(
             f"absolute aspect ratio must be smaller than {MAX_RATIO}, "
@@ -145,6 +151,11 @@ def smart_resize(
         beta = math.sqrt(min_pixels / (height * width))
         h_bar = ceil_by_factor(height * beta, factor)
         w_bar = ceil_by_factor(width * beta, factor)
+    if max_total_pixels is not None and h_bar * w_bar > max_total_pixels:
+        raise ValueError(
+            f"image area {h_bar * w_bar} exceeds max_total_pixels "
+            f"{max_total_pixels} after resizing"
+        )
     return h_bar, w_bar
 
 
@@ -216,6 +227,8 @@ class MiniMaxM3VLImageProcessor(BaseImageProcessorFast):
         for shape, stacked_images in grouped_images.items():
             height, width = stacked_images.shape[-2:]
             if do_resize:
+                # Request kwargs may lower ``max_pixels`` but cannot raise it.
+                max_pixels = min(max_pixels, type(self).max_pixels)
                 resized_height, resized_width = smart_resize(
                     height,
                     width,
@@ -312,6 +325,7 @@ class MiniMaxM3VLImageProcessor(BaseImageProcessorFast):
         max_long_side_pixel = images_kwargs.get(
             "max_long_side_pixel", self.max_long_side_pixel
         )
+        max_pixels = min(max_pixels, type(self).max_pixels)
 
         resized_height, resized_width = smart_resize(
             height,
@@ -400,6 +414,8 @@ class MiniMaxM3VLVideoProcessor(BaseVideoProcessor):
             batch_size, num_frames, channels, height, width = stacked_videos.shape
             resized_height, resized_width = height, width
             if do_resize:
+                # Request kwargs may lower ``max_pixels`` but cannot raise it.
+                max_pixels = min(max_pixels, type(self).max_pixels)
                 resized_height, resized_width = smart_resize(
                     height,
                     width,
@@ -412,11 +428,9 @@ class MiniMaxM3VLVideoProcessor(BaseVideoProcessor):
                     # is enforced below once num_frames is known.
                     max_total_pixels=None,
                 )
-                if (
-                    max_long_side_pixel is not None
-                    and resized_height * resized_width * num_frames
-                    > self.max_total_pixels
-                ):
+                # Area-resize (default ``max_long_side_pixel=None``) must still
+                # honor the volumetric ``width * height * frames`` budget.
+                if resized_height * resized_width * num_frames > self.max_total_pixels:
                     raise ValueError(
                         f"video area {resized_height * resized_width * num_frames} "
                         f"(width * height * frames) exceeds max_total_pixels "


### PR DESCRIPTION
## Summary
MiniMax M3 VL video preprocessing honored request `min_pixels` even when it exceeded `max_pixels`, and skipped the volumetric `width * height * frames` budget unless long-side resize was enabled. A small video could therefore be enlarged into multi-gigabyte tensors before engine admission. This change rejects an inverted pixel budget, keeps request `max_pixels` from raising the processor ceiling, and always enforces the volumetric cap before `resize`.

## Changes
- `vllm/transformers_utils/processors/minimax_m3.py`: reject non-positive or inverted `min_pixels`/`max_pixels` in `smart_resize`; honor `max_total_pixels` on the area-resize path; clamp request `max_pixels` to the class default; always apply the video volumetric cap.
- `tests/models/multimodal/processing/test_minimax_m3.py`: regression coverage for inverted budgets and completeness coverage for the area-path volumetric cap and image `max_pixels` ceiling.

## Codepath coverage
- Chat, responses, tokenize, batch, invocations, gRPC, and offline `LLM` all reach the MiniMax image/video processors; the sink guards in `smart_resize` and video `_preprocess` cover those entry points.
- Image `get_number_of_image_patches` uses the same `max_pixels` ceiling so token counts cannot track a raised request cap.

## Duplicate-work check
Searched open and merged PRs for MiniMax `min_pixels` / `smart_resize` / request-controlled geometry. The closed geometry-bound PR does not touch MiniMax processors. The private request-kwargs opt-in work is a different control at the API boundary and does not close this processor sink.

## Tests
- `test_smart_resize_rejects_inverted_pixel_budget`
- `test_smart_resize_rejects_non_positive_pixel_budget`
- `test_smart_resize_area_path_honors_max_total_pixels`
- `test_video_preprocess_rejects_inverted_min_pixels` (min-only and min+max raised)
- `test_image_preprocess_does_not_raise_max_pixels_ceiling`
- `test_video_area_resize_enforces_volumetric_cap`

Commands: `.venv/bin/python -m pytest tests/models/multimodal/processing/test_minimax_m3.py -v` (16 passed); `.venv/bin/pre-commit run --files vllm/transformers_utils/processors/minimax_m3.py tests/models/multimodal/processing/test_minimax_m3.py` (passed).

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)