### PR TITLE
[Bugfix] Guard against None in convert_ids_list_to_tokens

### DIFF
--- a/tests/tokenizers_/test_detokenize.py
+++ b/tests/tokenizers_/test_detokenize.py
@@ -274,11 +274,12 @@ class _MockTokenizer:
 
     def convert_ids_to_tokens(
         self, ids: list[int], skip_special_tokens: bool = False
-    ) -> list[str]:
-        return [self._raw[tid] for tid in ids]
+    ) -> list[str | None]:
+        # Real tokenizers return None for an id outside the vocabulary.
+        return [self._raw.get(tid) for tid in ids]
 
     def decode(self, ids: list[int], skip_special_tokens: bool = False) -> str:
-        return "".join(self._decoded[tid] for tid in ids)
+        return "".join(self._decoded.get(tid, "") for tid in ids)
 
 
 def test_sentencepiece_leading_space_preserved():
@@ -357,3 +358,23 @@ def test_logprobs_count_stable_across_k():
     assert len(top4) == 4
     assert len(top10) == 10
     assert top4[" true"] == top10[" true"]
+
+
+def test_out_of_vocab_id_does_not_raise():
+    """An id past the end of the vocabulary must not blow up.
+
+    convert_ids_to_tokens() returns None for such an id. This is reachable
+    whenever a model's config vocab_size exceeds the tokenizer's piece count,
+    for example a vocabulary padded for tensor parallelism, or dummy weights.
+    Without the guard, _restore_leading_spaces() iterates None and raises
+    TypeError inside AsyncLLM.output_handler, which kills the output handler
+    for every in-flight request rather than failing the one request.
+    """
+    tok = _MockTokenizer(
+        raw_tokens={0: "\u2581Hello", 1: "\u2581world"},
+        decoded_tokens={0: "Hello", 1: "world"},
+    )
+
+    result = convert_ids_list_to_tokens(tok, [0, 1, 7])
+
+    assert result == [" Hello", " world", ""]

--- a/vllm/tokenizers/detokenizer_utils.py
+++ b/vllm/tokenizers/detokenizer_utils.py
@@ -164,6 +164,10 @@ def convert_ids_list_to_tokens(
     if marker is None:
         return [tokenizer.decode([tid]) or "" for tid in token_ids]
     raw_tokens = tokenizer.convert_ids_to_tokens(token_ids)
+    # This is required to guard against out-of-vocab token ids, which
+    # convert_ids_to_tokens returns as None. The marker-is-None branch
+    # above is already protected by `or ""`; this one was not.
+    _replace_none_with_empty(raw_tokens)  # type: ignore[arg-type]
     return [
         _restore_leading_spaces(raw, tokenizer.decode([tid]) or "", marker)
         for tid, raw in zip(token_ids, raw_tokens)


### PR DESCRIPTION



## Purpose

convert_ids_list_to_tokens() raises TypeError when the tokenizer reports out-of-vocab token id.
convert_ids_to_tokens() returns None for such ids. Later this is passed into _restore_leading_spaces, where it tries to iterate it:
`File "vllm/v1/engine/logprobs.py", line 97, in _update_sample_logprobs
    decoded_tokens_list = convert_ids_list_to_tokens(
  File "vllm/tokenizers/detokenizer_utils.py", line 168, in convert_ids_list_to_tokens
    _restore_leading_spaces(raw, tokenizer.decode([tid]) or "", marker)
  File "vllm/tokenizers/detokenizer_utils.py", line 108, in _restore_leading_spaces
    for ch in raw_token:
TypeError: 'NoneType' object is not iterable`

Only the Metaspace branch is affected, and when config.json vocab_size exceeds tokenizer's piece count.

The Metaspace branch added in #48674 did not carry it across. _replace_none_with_empty() is already defined in this file and used at two other call sites; this adds the third.

This failure on a request raises into AsyncLLM.output_handler, and all requests after this return 500 Internal server error, until server is restarted.

## Test Plan

Adds test_out_of_vocab_id_does_not_raise, with _MockTokenizer behaviour changed (returning None instead of KeyError, as in real tokenizers), tests convert_ids_list_to_tokens does not raise

## Test Result

Before:
```console
$ pytest tests/tokenizers_/test_detokenize.py::test_out_of_vocab_id_does_not_raise -v

raw_token = None, token_str = '', marker = '▁'

    def _restore_leading_spaces(raw_token: str, token_str: str, marker: str) -> str:
        """Restore leading spaces that decode() stripped from a raw vocab piece."""
        num_markers = 0
>       for ch in raw_token:
E       TypeError: 'NoneType' object is not iterable

/usr/local/lib/python3.12/dist-packages/vllm/tokenizers/detokenizer_utils.py:108: TypeError
====================== 1 failed, 826 deselected in 28.35s ======================
```

After:
```console
$ pytest tests/tokenizers_/test_detokenize.py::test_out_of_vocab_id_does_not_raise -v
====================== 1 passed, 826 deselected in 27.86s ======================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

