### PR TITLE
[Refactor] Extract maybe_run_omni() and defer CLI imports past omni early-return

### DIFF
--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -14,7 +14,32 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
+def maybe_run_omni() -> bool:
+    # If `--omni` arg is passed to the CLI, delegate to vLLM Omni's entrypoint handling
+    if "--omni" not in sys.argv:
+        return False
+
+    # NOTE: Check the spec instead of importing directly here, since things could
+    # fail with ImportError due to mismatched versions if things are moved around.
+    spec = find_spec("vllm_omni")
+    if spec is None:
+        logger.error(
+            "--omni flag requires a valid instance of vllm-omni to be installed."
+        )
+        sys.exit(1)
+
+    from vllm_omni.entrypoints.cli.main import main as omni_main
+
+    logger.info("Delegating entrypoint handling to vllm-omni")
+    omni_main()
+
+    return True
+
+
 def main():
+    if maybe_run_omni():
+        return
+
     import vllm.entrypoints.cli.benchmark.main
     import vllm.entrypoints.cli.collect_env
     import vllm.entrypoints.cli.launch
@@ -38,65 +63,49 @@ def main():
 
     cli_env_setup()
 
-    # If `--omni` arg is passed to the CLI, delegate to vLLM Omni's entrypoint handling
-    if "--omni" in sys.argv:
-        # NOTE: Check the spec instead of importing directly here, since things could
-        # fail with ImportError due to mismatched versions if things are moved around.
-        spec = find_spec("vllm_omni")
-        if spec is None:
-            logger.error(
-                "--omni flag requires a valid instance of vllm-omni to be installed."
+    vllm.entrypoints.cli.benchmark.main.maybe_exec_rust_bench()
+
+    # For 'vllm bench *': use CPU instead of UnspecifiedPlatform by default
+    if len(sys.argv) > 1 and sys.argv[1] == "bench":
+        logger.debug(
+            "Bench command detected, must ensure current platform is not "
+            "UnspecifiedPlatform to avoid device type inference error"
+        )
+        from vllm import platforms
+
+        if platforms.current_platform.is_unspecified():
+            from vllm.platforms.cpu import CpuPlatform
+
+            platforms.current_platform = CpuPlatform()
+            logger.info(
+                "Unspecified platform detected, switching to CPU Platform instead."
             )
-            sys.exit(1)
 
-        from vllm_omni.entrypoints.cli.main import main as omni_main
+    parser = FlexibleArgumentParser(
+        description="vLLM CLI",
+        epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=importlib.metadata.version("vllm"),
+    )
+    subparsers = parser.add_subparsers(required=False, dest="subparser")
+    cmds = {}
+    for cmd_module in CMD_MODULES:
+        new_cmds = cmd_module.cmd_init()
+        for cmd in new_cmds:
+            cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
+            cmds[cmd.name] = cmd
+    args = parser.parse_args()
+    if args.subparser in cmds:
+        cmds[args.subparser].validate(args)
 
-        logger.info("Delegating entrypoint handling to vllm-omni")
-        omni_main()
+    if hasattr(args, "dispatch_function"):
+        args.dispatch_function(args)
     else:
-        vllm.entrypoints.cli.benchmark.main.maybe_exec_rust_bench()
-
-        # For 'vllm bench *': use CPU instead of UnspecifiedPlatform by default
-        if len(sys.argv) > 1 and sys.argv[1] == "bench":
-            logger.debug(
-                "Bench command detected, must ensure current platform is not "
-                "UnspecifiedPlatform to avoid device type inference error"
-            )
-            from vllm import platforms
-
-            if platforms.current_platform.is_unspecified():
-                from vllm.platforms.cpu import CpuPlatform
-
-                platforms.current_platform = CpuPlatform()
-                logger.info(
-                    "Unspecified platform detected, switching to CPU Platform instead."
-                )
-
-        parser = FlexibleArgumentParser(
-            description="vLLM CLI",
-            epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
-        )
-        parser.add_argument(
-            "-v",
-            "--version",
-            action="version",
-            version=importlib.metadata.version("vllm"),
-        )
-        subparsers = parser.add_subparsers(required=False, dest="subparser")
-        cmds = {}
-        for cmd_module in CMD_MODULES:
-            new_cmds = cmd_module.cmd_init()
-            for cmd in new_cmds:
-                cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
-                cmds[cmd.name] = cmd
-        args = parser.parse_args()
-        if args.subparser in cmds:
-            cmds[args.subparser].validate(args)
-
-        if hasattr(args, "dispatch_function"):
-            args.dispatch_function(args)
-        else:
-            parser.print_help()
+        parser.print_help()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Move omni delegation logic into a dedicated `maybe_run_omni()` function so that all CLI module imports and `cli_env_setup()` are skipped on the `--omni` path. Previously, every non-omni import ran unconditionally before the omni check, and vllm's `cli_env_setup()` would run even when omni has its own initialization.

## Purpose
Extract the `--omni` delegation logic into a dedicated `maybe_run_omni()` function and move all CLI module imports after the early-return guard.

Previously, all `vllm.entrypoints.cli.*` imports and `cli_env_setup()` ran unconditionally before the `--omni` check, defeating the lazy-import design stated at the top of the file. Since `vllm-omni` has its own `cli_env_setup()`, running vLLM's version first could also cause double initialization.

## Test Plan
- Verified the omni early-return path via AST analysis: all CLI imports and `cli_env_setup()` now live after `if maybe_run_omni(): return`.

- Manual smoke test: `vllm --help`, `vllm serve --help`, `vllm bench --help` all print expected output.

- No existing tests cover `main()` directly; the change is structural (import ordering and function extraction) with no behavioral change to the non-omni code path.

## Test Result.    
All existing CLI-related tests pass. No regressions observed on the non-omni path. The omni path cannot be tested without a `vllm-omni` installation, but the delegation logic is unchanged — only its placement in the call stack differs.

Additionally, `vllm-omni` defines its own `cli_env_setup()` in its entrypoint (see [vllm_omni/entrypoints/cli/main.py](https://github.com/vllm-project/vllm-omni/blob/6fb7b0a05e3758e41e3871804598cea18a0b42fb/vllm_omni/entrypoints/cli/main.py#L37)). With the original code, vLLM's `cli_env_setup()` would run before delegating to `omni_main()`, resulting in double initialization. The refactor ensures that on the `--omni` path, only omni's own `cli_env_setup()` runs.