### PR TITLE
[Bugfix][Benchmark] Fix GPU-count discovery in Pareto plots

### DIFF
--- a/docs/benchmarking/sweeps.md
+++ b/docs/benchmarking/sweeps.md
@@ -244,7 +244,7 @@ vllm bench sweep plot $EXPERIMENT_DIR \
 Higher concurrency or batch size can raise GPU efficiency (per-GPU), but can add per user latency; lower concurrency improves per-user rate but underutilizes GPUs; The Pareto frontier shows the best achievable pairs across your runs.
 
 - x-axis: tokens/s/user = `output_throughput` ÷ concurrency (`--user-count-var`, default `max_concurrency`, fallback `max_concurrent_requests`).
-- y-axis: tokens/s/GPU = `output_throughput` ÷ GPU count (`--gpu-count-var` if set; else gpu_count is TP×PP*DP).
+- y-axis: tokens/s/GPU = `output_throughput` ÷ GPU count (`--gpu-count-var` if set; otherwise `num_gpus` or `gpu_count`; falls back to TP×PP×DP when no direct count is found).
 - Output: a single figure at `OUTPUT_DIR/pareto/PARETO.png`.
 - Show the configuration used in each data point `--label-by` (default: `max_concurrency,gpu_count`).
 

--- a/tests/benchmarks/sweep/test_plot_pareto_gpu_count.py
+++ b/tests/benchmarks/sweep/test_plot_pareto_gpu_count.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from pathlib import Path
+
+import pytest
+
+from vllm.benchmarks.sweep.plot_pareto import plot_pareto
+
+
+def test_standard_gpu_counts_match_explicit_plot(tmp_path: Path):
+    pytest.importorskip("seaborn")
+    records = [
+        {
+            "output_throughput": 100,
+            "max_concurrency": 1,
+            "num_gpus": 8,
+            "total_gpus": 8,
+            "tensor_parallel_size": 2,
+        },
+        {
+            "output_throughput": 200,
+            "max_concurrency": 10,
+            "gpu_count": 4,
+            "total_gpus": 4,
+            "tensor_parallel_size": 2,
+        },
+    ]
+
+    (tmp_path / "summary.json").write_text(json.dumps(records), encoding="utf-8")
+    plot_pareto(
+        output_dir=tmp_path,
+        user_count_var="max_concurrency",
+        gpu_count_var="total_gpus",
+        label_by=[],
+        dry_run=False,
+    )
+    plot_path = next(tmp_path.rglob("*.png"))
+    expected = plot_path.read_bytes()
+
+    plot_pareto(
+        output_dir=tmp_path,
+        user_count_var="max_concurrency",
+        gpu_count_var=None,
+        label_by=[],
+        dry_run=False,
+    )
+    assert plot_path.read_bytes() == expected

--- a/vllm/benchmarks/sweep/plot_pareto.py
+++ b/vllm/benchmarks/sweep/plot_pareto.py
@@ -69,7 +69,7 @@ def _infer_gpu_count(
     run_data: dict[str, object],
     gpu_count_var: str | None,
 ) -> float:
-    direct_candidates = [gpu_count_var] if gpu_count_var else []
+    direct_candidates = [gpu_count_var] if gpu_count_var else ["num_gpus", "gpu_count"]
     direct_gpu_count = _get_numeric(run_data, direct_candidates, allow_zero=False)
     if direct_gpu_count:
         return direct_gpu_count


### PR DESCRIPTION
## Purpose

I fixed GPU-count discovery in `vllm bench sweep plot_pareto`. When `--gpu-count-var` is unset, the command now uses `num_gpus` or `gpu_count` before falling back to TP × PP × DP. Previously, records using those fields could produce incorrect per-GPU throughput and Pareto frontiers.

I added a regression through the public plotting API and updated the sweep documentation. I searched open issues and PRs for `plot_pareto` and GPU-count handling: #55561 and #55607 address dominated points with tied throughput, not GPU-count discovery.

## Test Plan

- `.venv/bin/python -m pytest tests/benchmarks/sweep -q`
- `.venv/bin/vllm bench sweep plot_pareto` on one-GPU and eight-GPU records, with inspection of the generated plots.
- `.venv/bin/pre-commit run --all-files`

## Test Result

All 24 sweep tests and all pre-commit hooks passed. The new regression compares the actual plot from automatic GPU counts with an explicit equivalent count key; it fails before the fix and passes after it.

For the eight-GPU record, the plotted value changed from the incorrect 100 to 12.5 tokens/s/GPU, and the two-record Pareto frontier changed from one point to two. I personally ran the tests and checked the end-to-end result.

I used OpenAI Codex for AI assistance; this has been manually reviewed. I reviewed every changed line and understand the change.
