### PR TITLE
[Docs] Fix griffe docstring indentation warning in `SupportsMRoPE`

### DIFF
--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1782,10 +1782,9 @@ class SupportsMRoPE(Protocol):
             mm_features: Information about each multi-modal data item
 
         Returns:
-            Tuple of `(llm_positions, mrope_position_delta)`
-            - llm_positions: Tensor of shape `[num_dims, num_tokens]`, one row
-              per M-RoPE position channel (e.g. T/H/W)
-            - mrope_position_delta: Delta for position calculations
+            llm_positions: Tensor of shape `[num_dims, num_tokens]`, one row
+                per M-RoPE position channel (e.g. T/H/W).
+            mrope_position_delta: Delta for position calculations.
         """
         ...
 


### PR DESCRIPTION
## Purpose

The docs build emits:

```
WARNING - griffe: vllm/model_executor/models/interfaces.py:1786: Confusing indentation for continuation line 13 in docstring, should be 4 * 2 = 8 spaces, not 6
```

`get_mrope_input_positions` documented its return as a free-form bullet list under `Returns:`, where the wrapped line was indented 6 spaces relative to the section: more than an item (4) but less than a continuation (8), which griffe cannot classify. Rewriting the section as two named return values (`llm_positions`, `mrope_position_delta`) removes the ambiguity and lets griffe pair them with the `tuple[torch.Tensor, int]` annotation, so the docs render a proper returns table instead of three untyped entries.

This is the only occurrence of this warning class in a module included in the API reference (`vllm.vllm_flash_attn` also has some, but it is excluded in `mkdocs.yaml`).

Not duplicating an existing PR: `gh pr list --repo vllm-project/vllm --state open --search "griffe docstring indentation"` and `--search "Confusing indentation"` return no related PRs.

## Test Plan

Docstring-only change, no runtime behaviour affected, so no model evals are applicable.

## Test Result

Parsing every docstring in `interfaces.py` with `griffe.parse_google` reports no `Confusing indentation` warnings after the change (it reported the one above before). `pre-commit run --files vllm/model_executor/models/interfaces.py` passes.

AI assistance (Claude Code) was used for this change; I have reviewed every changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01695eEhXLmqRbKTeVwwSGg5