### PR TITLE
[Bugfix][Tool Calling] Fix tool call truncation on multi-token reasoning transitions (#56077)

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -2083,6 +2083,71 @@ class TestTruncatedToolOpenerStreamParity:
         assert tool_calls[0].name == "get_weather"
         assert not content
 
+    def test_speculative_chunk_think_end_preserves_tool_call(self):
+        """Regression test for #56077: N-gram speculative decoding chunks
+        must not drop tool calls when </think> and <tool_call> land in one delta.
+        """
+
+        vocab = {
+            "<think>": 90,
+            "</think>": 91,
+            "<tool_call>": 100,
+            "</tool_call>": 101,
+        }
+        tokenizer = make_mock_tokenizer(vocab)
+
+        tool = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="run_shell_command",
+                parameters={
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                },
+            ),
+        )
+
+        request = MagicMock()
+        request.tools = [tool]
+        request.tool_choice = "auto"
+        request.include_reasoning = True
+
+        parser_cls = ParserManager.get_parser(
+            tool_parser_name="qwen3_coder",
+            reasoning_parser_name="qwen3",
+            enable_auto_tools=True,
+        )
+        parser = parser_cls(tokenizer, [tool])
+
+        speculative_deltas = [
+            "<think>I should list files",
+            "</think><tool_call>\n<function=run_shell_command>\n",
+            "<parameter=command>ls</parameter>\n</function>\n</tool_call>",
+        ]
+
+        streamed_calls = []
+        arguments_collected = ""
+        for i, chunk in enumerate(speculative_deltas):
+            token_ids = [tid for t, tid in vocab.items() if t in chunk]
+            delta = parser.parse_delta(
+                chunk,
+                token_ids,
+                request,
+                finished=(i == len(speculative_deltas) - 1),
+            )
+            if delta and delta.tool_calls:
+                streamed_calls.extend(delta.tool_calls)
+                for tc in delta.tool_calls:
+                    if tc.function and tc.function.arguments:
+                        arguments_collected += tc.function.arguments
+
+        assert len(streamed_calls) > 0, "Streamed tool calls were completely dropped!"
+        assert any(
+            tc.function and tc.function.name == "run_shell_command"
+            for tc in streamed_calls
+        )
+        assert json.loads(arguments_collected) == {"command": "ls"}
+
 
 class TestThinkMarkupWithoutReasoningParser:
     """With no reasoning parser configured, reasoning markup is plain

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -891,36 +891,68 @@ class DelegatingParser(Parser):
                 current_token_ids = self.extract_content_ids(delta_token_ids)
                 # Flush whenever the reasoning parser is engine-based (not only
                 # when _engine_based is True): it buffers the post-marker text
-                # (e.g. the "<" of "<tool_call>"), surfaced via finish_streaming().
+                # (e.g. the "<" of "<tool_call>"), surfaced via
+                # finish_streaming().
+                finish_fn = getattr(reasoning_parser, "finish_streaming", None)
                 flush_delta = (
-                    reasoning_parser.finish_streaming()  # type: ignore[union-attr, attr-defined]
-                    if reasoning_parser is not None
-                    and reasoning_parser.engine_based_streaming
+                    finish_fn()
+                    if (
+                        finish_fn is not None
+                        and getattr(reasoning_parser, "engine_based_streaming", False)
+                    )
                     else None
                 )
-                current_text = (
-                    (delta_message.content if delta_message else None) or ""
-                ) + ((flush_delta.content if flush_delta else None) or "")
-                if self._engine_based:
-                    if delta_message and self._tool_parser is not None:
-                        delta_message.content = None
+
+                end_marker = None
+                parser_cfg = getattr(reasoning_parser, "parser_engine_config", None)
+                if parser_cfg is not None and getattr(parser_cfg, "terminals", None):
+                    end_marker = parser_cfg.terminals.get("THINK_END")
+                if not end_marker and reasoning_parser is not None:
+                    end_marker = getattr(
+                        reasoning_parser, "think_end_token", None
+                    ) or getattr(reasoning_parser, "reasoning_end_marker", None)
+                if not end_marker:
+                    end_marker = "</think>"
+
+                if end_marker and end_marker in delta_text:
+                    post_reasoning_text = delta_text.split(end_marker, 1)[1]
+                elif (
+                    end_marker
+                    and not state.engine_based
+                    and end_marker in (state.previous_text + delta_text)
+                ):
+                    accumulated = state.previous_text + delta_text
+                    post_reasoning_text = accumulated.split(end_marker, 1)[1]
                 else:
-                    delta_text = current_text
+                    post_reasoning_text = (
+                        (delta_message.content if delta_message else None) or ""
+                    ) + ((flush_delta.content if flush_delta else None) or "")
+
+                current_text = post_reasoning_text
+                delta_text = current_text
+
+                if (
+                    self._engine_based
+                    and delta_message
+                    and self._tool_parser is not None
+                ):
+                    delta_message.content = None
 
         # Tool call extraction
         if self._in_tool_call_phase(state):
             if not state.tool_call_text_started:
                 state.tool_call_text_started = True
-                state.previous_text = ""
-                state.previous_token_ids = []
+                if not state.engine_based:
+                    state.previous_text = ""
+                    state.previous_token_ids = []
                 delta_text = current_text
-                delta_token_ids = current_token_ids
+                delta_token_ids = []
 
             reasoning_from_this_batch = (
                 delta_message.reasoning if delta_message else None
             )
 
-            delta_message, state.function_name_returned = (
+            tool_delta, state.function_name_returned = (
                 self._extract_tool_calls_streaming(
                     previous_text=state.previous_text,
                     current_text=current_text,
@@ -934,6 +966,19 @@ class DelegatingParser(Parser):
                     function_name_returned=state.function_name_returned,
                 )
             )
+
+            if tool_delta is not None:
+                if delta_message is None:
+                    delta_message = tool_delta
+                else:
+                    if tool_delta.tool_calls:
+                        delta_message.tool_calls = (
+                            delta_message.tool_calls or []
+                        ) + tool_delta.tool_calls
+                    if tool_delta.content:
+                        delta_message.content = (
+                            delta_message.content or ""
+                        ) + tool_delta.content
 
             if reasoning_from_this_batch:
                 if delta_message is None:


### PR DESCRIPTION
## Purpose

Fixes #56077.

With speculative decoding, `</think>` and a tool call can arrive in the same chunk.

`DelegatingParser.parse_delta` used `delta_message.content`, so only `<tool_call>` was kept while the function name and arguments were lost.

Stale `delta_token_ids` could also break tool parsing and produce malformed arguments like `{"command=ls": ""}`.

### Changes

* Dynamically resolve the reasoning end terminal (`THINK_END`, `think_end_token`, or `</think>`) and preserve the full text after it from `delta_text`.
* Reset `delta_token_ids` when transitioning from reasoning to tool parsing so the remaining text is parsed through the text path.
* Add a regression test covering speculative multi-token chunks:
  `test_speculative_chunk_think_end_preserves_tool_call`

## Test Plan

Run the regression test:

```bash
pytest tests/parser/engine/test_parser_engine.py -k "test_speculative_chunk_think_end" -v
```

Run the full parser engine test suite:

```bash
pytest tests/parser/engine/ -v
```

Run pre-commit checks:

```bash
pre-commit run --files vllm/parser/abstract_parser.py tests/parser/engine/test_parser_engine.py
```

## Test Result

The regression test passes:

```text
tests/parser/engine/test_parser_engine.py::TestTruncatedToolOpenerStreamParity::test_speculative_chunk_think_end_preserves_tool_call PASSED [100%]
```

The full parser engine test suite also passes with 3,848+ tests and no regressions.

All relevant pre-commit checks pass.

<details> <summary>PR Checklist</summary>

Added a clear description of the change and linked the issue.

Added the relevant test commands.

Included the test results.

No documentation changes are needed for this fix.

</details>