### PR TITLE
[CI][ROCm] Increase timeout for AMD MI355 Language Models (Standard)

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -3742,7 +3742,7 @@ steps:
   - pytest -v -s models/language/generation_ppl_test
 
 - label: ":amd: (MI355) Language Models (Standard)" # TBD
-  timeout_in_minutes: 40
+  timeout_in_minutes: 60
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
   dind: false
   agent_pool: mi355_1


### PR DESCRIPTION
The MI355 Language Models (Standard) job was calibrated down from 180 to 40 minutes in #54695, but the suite takes ~44 minutes on mi355_1, so the step is now cancelled by Buildkite partway through the last test. Raise the timeout to 60 minutes, matching the corrections made for the MI300 jobs in #55919.