### PR TITLE
[MoE] add VLLM_EXPERTS_LOAD_DEVICE=cpu for GPU/CPU mixed expert placement

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
     VLLM_MEDIA_CONNECTOR: str = "http"
     VLLM_MM_HASHER_ALGORITHM: str = "blake3"
     VLLM_TARGET_DEVICE: str = "cuda"
+    VLLM_EXPERTS_LOAD_DEVICE: Literal["gpu", "cpu"] = "gpu"
     VLLM_MAIN_CUDA_VERSION: str = "13.0"
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
@@ -615,6 +616,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Target device of vLLM, supporting [cuda (by default),
     # rocm, cpu]
     "VLLM_TARGET_DEVICE": lambda: os.getenv("VLLM_TARGET_DEVICE", "cuda").lower(),
+    # Device that holds the routed-expert weights. "cpu" enables the
+    # GPU/CPU mixed mode: attention and every other layer stay on the
+    # compute device while expert weights are constructed and kept on the
+    # host, so a MoE whose experts exceed device memory no longer OOMs at
+    # model construction. Orthogonal to VLLM_TARGET_DEVICE.
+    "VLLM_EXPERTS_LOAD_DEVICE": env_with_choices(
+        "VLLM_EXPERTS_LOAD_DEVICE", "gpu", ["gpu", "cpu"], case_sensitive=False
+    ),
     # Main CUDA version of vLLM. This follows PyTorch but can be overridden.
     "VLLM_MAIN_CUDA_VERSION": lambda: (
         os.getenv("VLLM_MAIN_CUDA_VERSION", "").lower() or "13.0"

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -577,6 +577,19 @@ def select_mxfp4_moe_backend(
         assert last_error is not None
         raise last_error
 
+    # GPU/CPU mixed mode: expert weights live on the host (see
+    # VLLM_EXPERTS_LOAD_DEVICE), so a GPU expert kernel cannot consume them.
+    # Select the CPU backend unconditionally rather than preferring the GPU
+    # kernels (Marlin WNA16 etc.), which would only fail with "not on GPU".
+    if envs.VLLM_EXPERTS_LOAD_DEVICE == "cpu":
+        return _return_or_raise(
+            Mxfp4MoeBackend.CPU,
+            config,
+            kMxfp4Static,
+            None,
+            activation_format,
+        )
+
     if _requires_qwen38_tep8_emulation(config, requested_activation_key):
         backend = Mxfp4MoeBackend.EMULATION
         logger.warning_once(
@@ -627,7 +640,10 @@ def select_mxfp4_moe_backend(
             activation_format,
         )
 
-    if current_platform.is_cpu():
+    # CPU/GPU mixed mode: the expert weights live on the host while the rest of
+    # the model runs on the GPU, so the CPU backend is a valid fallback even
+    # though the platform is not CPU-only.
+    if current_platform.is_cpu() or envs.VLLM_EXPERTS_LOAD_DEVICE == "cpu":
         backend = Mxfp4MoeBackend.CPU
         logger.info_once(_make_log_backend(backend))
         return _return_or_raise(
@@ -1302,6 +1318,19 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
         from vllm.model_executor.layers.fused_moe.experts.cpu_moe import (
             prepare_mxfp4_moe_layer_for_cpu,
         )
+
+        if envs.VLLM_EXPERTS_LOAD_DEVICE == "cpu":
+            # GPU/CPU mixed mode: the CPU backend is an out-of-tree engine that
+            # consumes the raw [E, 2I, H//2] / [E, H, I//2] uint8 weights and
+            # raw e8m0 scales directly, so skip the AMX prepack.
+            return (
+                w13_weight.data,
+                w2_weight.data,
+                w13_weight_scale.data,
+                w2_weight_scale.data,
+                w13_bias,
+                w2_bias,
+            )
 
         packed_w13, packed_w2, packed_w13_scale, packed_w2_scale = (
             prepare_mxfp4_moe_layer_for_cpu(

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import torch
 
+from vllm import envs
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
@@ -168,7 +169,25 @@ class RoutedExperts(PluggableLayer):
             "global_num_experts": moe_config.num_experts,
         }
 
-        self.quant_method.create_weights(layer=self, **moe_quant_params)
+        # need full intermediate size pre-sharding for WNA16 act order
+        if self._needs_intermediate_size_param(self.quant_method):
+            moe_quant_params["intermediate_size_full"] = (
+                self.moe_config.intermediate_size
+            )
+
+        # GPU/CPU mixed mode: construct the expert weights on the host when
+        # VLLM_EXPERTS_LOAD_DEVICE=cpu. create_weights() allocates with no
+        # explicit device, so a scoped default device keeps the parameters on
+        # CPU from construction onward (the weight loaders then copy into them
+        # in place). Everything else the layer owns -- router tables, expert
+        # maps, the shared experts -- keeps its normal device, so only the
+        # expert weights move. This is what lets a MoE whose experts exceed
+        # device memory build without OOM.
+        if envs.VLLM_EXPERTS_LOAD_DEVICE == "cpu":
+            with torch.device("cpu"):
+                self.quant_method.create_weights(layer=self, **moe_quant_params)
+        else:
+            self.quant_method.create_weights(layer=self, **moe_quant_params)
 
         self.lora_base_layer_prefix = ""
 


### PR DESCRIPTION
## Goal

Make a MoE model whose **routed-expert weights do not fit in device memory** constructible and
servable in mainline vLLM, by keeping those weights on the host while everything else
(attention, router, shared experts, KV cache) stays on the GPU.

This is the enabling switch for a hybrid CPU/GPU MoE serving mode; it changes **no default
behaviour**.

## Problem

- DeepSeek-V4-Flash has 43 layers × 256 routed experts × **3.19 GiB** of raw MXFP4 weights per
  layer = **~137 GiB**. On a single 40 GB A100 the model OOMs *during construction*, before a
  single token is served.
- vLLM's existing offload machinery (`model_executor/offloader/prefetch.py`) moves weights that
  have already been constructed; it cannot prevent the construction-time allocation.
- Mainline has no way to say "build the routed-expert weights on the host". The MXFP4 oracle
  always prefers a GPU backend, which then fails with `b_q_weight is not on GPU` once the
  weights live on the host.
- ktransformers / lk_moe solve the same problem by keeping experts on the host and computing
  them on the CPU, which is what we do downstream — but they need a fork.

## Design

1. **`vllm/envs.py`** — new `VLLM_EXPERTS_LOAD_DEVICE` (`"gpu"` default, `"cpu"` opt-in).
   Orthogonal to `VLLM_TARGET_DEVICE`: the target device is still CUDA, only the routed-expert
   *parameters* live on the host.
2. **`routed_experts.py`** — when the switch is set, `create_weights()` runs inside
   `with torch.device("cpu")`. `create_weights()` allocates with no explicit device, so a scoped
   default device keeps the parameters on CPU from construction onward and the existing weight
   loaders copy into them in place. Everything else the layer owns (router tables, expert maps,
   shared experts) keeps its normal device.
3. **`fused_moe/oracle/mxfp4.py`** — with the switch set:
   - select the CPU backend unconditionally instead of preferring the GPU kernels, and
   - skip the AMX prepack, because the consumer is an out-of-tree CPU engine that reads the raw
     `[E, 2I, H//2]` / `[E, H, I//2]` uint8 weights and the raw e8m0 block scales directly.

   With `VLLM_EXPERTS_LOAD_DEVICE=gpu` (default) the oracle takes exactly the same path as before.

## Data layout the CPU backend consumes (context for reviewers)

| tensor | shape | meaning |
|---|---|---|
| `w13_weight` | `[E, 2I, H//2]` u8 | MXFP4 e2m1 nibbles, gate rows `[0,I)` then up rows `[I,2I)` |
| `w13_weight_scale` | `[E, 2I, H//32]` u8 | e8m0 block scales (`2^(byte-127)`), groupK = 32 |
| `w2_weight` | `[E, H, I//2]` u8 | MXFP4 e2m1 nibbles |
| `w2_weight_scale` | `[E, H, I//32]` u8 | e8m0 block scales |

This is the checkpoint's on-disk layout, so no repack is needed on load — which is the point of
skipping the AMX prepack.

## Why this is useful (measured on our box)

2× A100-PCIE-40GB (SM80), AMD EPYC 9654, DeepSeek-V4-Flash, CPU experts + GPU attention:

| prompt tokens | CPU prefill (hybrid) | GPU prefill (layerwise weight streaming) |
|---|---:|---:|
| 2 091 | 112.9 s | **5.6 s** |
| 4 137 | 439.4 s | **5.8 s** |
| 16 039 | – | **17.7 s** |

The CPU path is what this PR enables; the GPU path (stream one layer's weights H2D, compute,
free) is a separate, out-of-tree mechanism. Full report, code and raw data:
<https://github.com/yeungtuzi/vllm-xtu-moe>.

## Testing

- 2× A100-PCIE-40GB + EPYC 9654, DeepSeek-V4-Flash + out-of-tree CPU MoE engine: the model
  constructs and serves where it previously OOM'd at construction.
- `VLLM_EXPERTS_LOAD_DEVICE=gpu` (default): unchanged behaviour, existing GPU backends unaffected.
- No kernel changes; the diff is three files, +59/−2.

## Related

- #56119 fixes DeepSeek-V4 `o_proj` on SM8.x (needed for correct output on A100).
- #56120 adds the portable SM80 Triton path so DeepSeek-V4 builds on Ampere at all.
- An RFC for a generic "layerwise GPU prefill for CPU-offloaded experts" hook will follow.
