### PR TITLE
[Kimi-K3] Support RecoverSSM with pipeline parallelism on V2

### DIFF
--- a/tests/v1/worker/test_mamba_hybrid_model_state.py
+++ b/tests/v1/worker/test_mamba_hybrid_model_state.py
@@ -136,3 +136,74 @@ def test_recoverssm_align_tracks_mixed_batch_state_and_neutralizes_copy_bias() -
     assert state._mamba_state_idx_gpu.tolist() == expected_state_indices
     expected_accepted = [9, 1, 9, 2, 9]
     assert state.num_accepted_tokens_gpu.tolist() == expected_accepted
+
+
+def test_recoverssm_deferred_step_masks_freed_slots_and_survives_next_batch():
+    state = RecoverSSMState()
+    old = Mock(spec=RecoverSSMMetadata)
+    saved = Mock(spec=RecoverSSMMetadata)
+    saved.commit_recoverssm_state.return_value = None
+    old.snapshot_for_deferred_commit.return_value = saved
+    group = SimpleNamespace(layer_names=["layer"])
+    state.record_step({"layer": old}, [[group]], for_capture=False)
+    restore = state.defer_step()
+    newer = Mock(spec=RecoverSSMMetadata)
+    state.record_step({"layer": newer}, [[group]], for_capture=False)
+    restore_newer = state.defer_step()
+    restore()
+    state.commit_step(
+        torch.tensor([3, 2]),
+        torch.tensor([4, -1]),
+        state_indices=None,
+        num_accepted_tokens=torch.ones(5, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        saved.commit_recoverssm_state.call_args.args[0], torch.tensor([3, 0])
+    )
+    newer.commit_recoverssm_state.assert_not_called()
+    restore_newer()
+    assert state._step == (newer.snapshot_for_deferred_commit.return_value,)
+
+
+def test_kda_deferred_metadata_owns_inputs_but_shares_commit_context():
+    from vllm.models.kimi_k3.nvidia.kda_metadata import (
+        KDARecoverSSMAlignMetadata,
+        KDARecoverSSMCommitMetadata,
+        KimiK3KDAMetadata,
+    )
+
+    values = torch.arange(6, dtype=torch.int32).view(2, 3)
+    context = Mock()
+    meta = KimiK3KDAMetadata(
+        num_prefills=0,
+        num_prefill_tokens=0,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_spec_decodes=2,
+        num_spec_decode_tokens=6,
+        num_actual_tokens=6,
+        recoverssm_commit=KDARecoverSSMCommitMetadata(
+            state_indices=values,
+            query_start_loc=values[0],
+            request_indices=values[:, 0],
+            align=KDARecoverSSMAlignMetadata(values, values[:, 1], 8),
+        ),
+        recoverssm_context=context,
+    )
+    saved = meta.snapshot_for_deferred_commit()
+    values.fill_(-1)
+    commit = saved.recoverssm_commit
+    assert commit is not None and commit.align is not None
+    torch.testing.assert_close(
+        commit.state_indices, torch.arange(6, dtype=torch.int32).view(2, 3)
+    )
+    torch.testing.assert_close(
+        commit.query_start_loc, torch.tensor([0, 1, 2], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        commit.request_indices, torch.tensor([0, 3], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        commit.align.num_computed_tokens, torch.tensor([1, 4], dtype=torch.int32)
+    )
+    assert saved.recoverssm_context is context

--- a/tests/v1/worker/test_pp_utils.py
+++ b/tests/v1/worker/test_pp_utils.py
@@ -81,3 +81,37 @@ def test_decode_row_ahead_of_a_prefill_chunk():
 
     assert mask is not None
     assert mask.tolist() == [True, False]
+
+
+def test_deferred_state_restored_after_receive_before_postprocess():
+    from collections import deque
+    from unittest.mock import Mock
+
+    import torch
+
+    handler = pp_utils.PPHandler.__new__(pp_utils.PPHandler)
+    handler.main_stream = Mock()
+    handler.req_idx_gen_np = np.zeros(2, dtype=np.int32)
+    events = []
+    handler.main_stream.wait_event.side_effect = lambda event: events.append("wait")
+    slot = pp_utils.PendingRecv(
+        event=Mock(),
+        sampled_tokens=torch.zeros(2, 3, dtype=torch.int64),
+        num_sampled=torch.tensor([2, 3]),
+        num_rejected=torch.tensor([1, 0]),
+        idx_mapping=torch.tensor([0, 1]),
+        idx_mapping_np=np.array([0, 1]),
+        need_sampled_mask=np.array([True, True]),
+        gen_at_receive_np=np.zeros(2, dtype=np.int32),
+        restore_model_state=lambda: events.append("restore"),
+    )
+    handler.queue = deque([slot])
+    result = handler.get_prev_sampled_outputs()
+    assert events == ["wait", "restore"]
+    assert result is not None
+    torch.testing.assert_close(result["num_sampled"], slot.num_sampled)
+    # Aborted requests must discard the pending state without restoring it.
+    handler.queue = deque([slot])
+    handler.req_idx_gen_np[:] = 1
+    assert handler.get_prev_sampled_outputs() is None
+    assert events == ["wait", "restore"]

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2941,10 +2941,11 @@ class VllmConfig:
                 raise ValueError(
                     "RecoverSSM with align mode requires VLLM_USE_V2_MODEL_RUNNER=1"
                 )
-            if self.parallel_config.pipeline_parallel_size > 1:
-                raise ValueError(
-                    "RecoverSSM currently requires pipeline_parallel_size=1"
-                )
+            if (
+                self.parallel_config.pipeline_parallel_size > 1
+                and not self.use_v2_model_runner
+            ):
+                raise ValueError("RecoverSSM with PP requires Model Runner V2")
             if self.mamba_config.backend != MambaBackendEnum.TRITON:
                 raise ValueError("RecoverSSM requires --mamba-backend triton")
         elif self.cache_config.mamba_cache_mode == "all":

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -11,7 +11,7 @@ For Kimi-K3 speculative decoding, ``--use-replayssm`` selects the simplified
 RecoverSSM path implemented here instead of the Mamba2 ReplaySSM kernel.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from functools import cache
 from typing import TYPE_CHECKING
 
@@ -277,6 +277,32 @@ class KimiK3KDAMetadata(GDNAttentionMetadata, RecoverSSMMetadata):
         default=None, repr=False, compare=False
     )
     checkpoint: KDACheckpointMetadata | None = None
+
+    def snapshot_for_deferred_commit(self) -> "KimiK3KDAMetadata":
+        commit = self.recoverssm_commit
+        if commit is None:
+            return replace(self)
+        align = commit.align
+        if align is not None:
+            align = replace(
+                align,
+                block_table=align.block_table.clone(),
+                num_computed_tokens=align.num_computed_tokens.clone(),
+            )
+        return replace(
+            self,
+            recoverssm_commit=replace(
+                commit,
+                state_indices=commit.state_indices.clone(),
+                query_start_loc=commit.query_start_loc.clone(),
+                request_indices=(
+                    commit.request_indices.clone()
+                    if commit.request_indices is not None
+                    else None
+                ),
+                align=align,
+            ),
+        )
 
     def commit_recoverssm_state(
         self, num_accepted_tokens: torch.Tensor

--- a/vllm/v1/attention/backends/recoverssm_metadata.py
+++ b/vllm/v1/attention/backends/recoverssm_metadata.py
@@ -19,6 +19,9 @@ class RecoverSSMPostprocessMetadata:
 
 
 class RecoverSSMMetadata(abc.ABC):
+    def snapshot_for_deferred_commit(self) -> "RecoverSSMMetadata":
+        raise NotImplementedError("Deferred RecoverSSM commit is not supported")
+
     @abc.abstractmethod
     def commit_recoverssm_state(
         self, num_accepted_tokens: torch.Tensor

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1917,7 +1917,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # IntermediateTensors instead of final hidden states. Receive the
             # sampled tokens broadcast from the last rank and update local state.
             assert self.pp_handler is not None
-            all_decode_next = self.pp_handler.receive(input_batch)
+            all_decode_next = self.pp_handler.receive(
+                input_batch, self.model_state.defer_postprocess_state()
+            )
             # Optimistically update num_computed_tokens for entire batch here.
             # Will be adjusted for rejections if necessary in update_requests.
             self.postprocess_num_computed_tokens(input_batch)

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, ClassVar, cast
 
 import torch
@@ -145,6 +146,9 @@ class ModelState(ABC):
         """Hook run on real batches before the forward pass (after block tables
         are gathered). Used by mamba "align" prefix caching to pre-copy state
         across block boundaries. No-op by default."""
+        return None
+
+    def defer_postprocess_state(self) -> Callable[[], None] | None:
         return None
 
     def postprocess_state(

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -336,6 +337,9 @@ class MambaHybridModelState(DefaultModelState):
                 for_capture=for_capture,
             )
         return attn_metadata
+
+    def defer_postprocess_state(self) -> Callable[[], None] | None:
+        return self.recoverssm.defer_step() if self.recoverssm is not None else None
 
     def postprocess_state(
         self,

--- a/vllm/v1/worker/gpu/model_states/recoverssm.py
+++ b/vllm/v1/worker/gpu/model_states/recoverssm.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Callable
 from typing import Any
 
 import torch
@@ -15,6 +16,7 @@ class RecoverSSMState:
 
     def __init__(self) -> None:
         self._step: tuple[RecoverSSMMetadata, ...] | None = None
+        self._deferred = False
 
     def record_step(
         self,
@@ -35,6 +37,21 @@ class RecoverSSMState:
                     step.append(metadata)
         self._step = tuple(step)
 
+    def defer_step(self) -> Callable[[], None]:
+        step = self._step
+        self._step = None
+        snapshot = (
+            tuple(meta.snapshot_for_deferred_commit() for meta in step)
+            if step is not None
+            else None
+        )
+
+        def restore() -> None:
+            self._step = snapshot
+            self._deferred = True
+
+        return restore
+
     def commit_step(
         self,
         num_sampled: torch.Tensor | int,
@@ -45,8 +62,13 @@ class RecoverSSMState:
     ) -> None:
         step = self._step
         self._step = None
+        deferred = self._deferred
+        self._deferred = False
         if isinstance(num_sampled, int) or step is None:
             return
+        if deferred:
+            # PP can free/reuse request slots while sampled outputs are in flight.
+            num_sampled = torch.where(idx_mapping >= 0, num_sampled, 0)
 
         for metadata in step:
             postprocess_meta = metadata.commit_recoverssm_state(num_sampled)

--- a/vllm/v1/worker/gpu/pp_utils.py
+++ b/vllm/v1/worker/gpu/pp_utils.py
@@ -3,6 +3,7 @@
 """Pipeline Parallelism utils for V2 Model Runner."""
 
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
@@ -32,6 +33,7 @@ class PendingRecv:
     # detect requests aborted since then.
     gen_at_receive_np: np.ndarray  # [num_reqs]
     draft_tokens: torch.Tensor | None = None  # [num_reqs, num_speculative_steps]
+    restore_model_state: Callable[[], None] | None = None
 
 
 def compute_need_sampled_mask(input_batch: InputBatch) -> np.ndarray | None:
@@ -141,6 +143,8 @@ class PPHandler:
             idx_mapping = async_copy_to_gpu(idx_mapping_np, device=self.device)
 
         self.main_stream.wait_event(slot.event)
+        if slot.restore_model_state is not None:
+            slot.restore_model_state()
         if slot.draft_tokens is not None and draft_tokens_to_update is not None:
             draft_tokens = slot.draft_tokens
             draft_idx_mapping = slot.idx_mapping
@@ -175,7 +179,11 @@ class PPHandler:
             )
             send.record_stream(self.broadcast_stream)
 
-    def receive(self, input_batch: InputBatch) -> bool:
+    def receive(
+        self,
+        input_batch: InputBatch,
+        restore_model_state: Callable[[], None] | None = None,
+    ) -> bool:
         """Returns True iff sampled tokens need to be gathered from *all*
         requests in the batch."""
         assert not self.is_last_rank
@@ -230,6 +238,7 @@ class PPHandler:
             need_sampled_mask,
             gen_at_receive_np,
             draft_tokens,
+            restore_model_state,
         )
         return bool(need_sampled_mask.all())
 


### PR DESCRIPTION
## Purpose

Enable Kimi-K3 RecoverSSM with pipeline parallelism on Model Runner V2. Earlier PP stages receive acceptance counts several steps later; retain each step's commit metadata until its receive completes, mask freed request slots, and commit the accepted state before the next forward. Keep the V1 restriction.

This adds deferred metadata ownership and PP postprocessing, not the kernel tuning in #56082 or the KV transport in #55215. The separate PP draft-broadcast lifetime fix is tracked by #55745 and is needed for reliable asynchronous PP speculation; it is not duplicated here.

## Test Plan

```bash
pre-commit run
.venv/bin/python -m pytest \
  tests/v1/worker/test_pp_utils.py \
  tests/v1/worker/test_mamba_hybrid_model_state.py -q
```

Worker tests cover metadata reuse across batches, deferred restore after the receive event, and excluded/freed request slots. Tests run against this isolated branch using the existing B200 wheel environment; pre-commit runs on the CPU host.

### End-to-end configuration

Reused the recorded two-node runs with the original `474839f846` RecoverSSM kernels, this PP adaptation, and a local equivalent of #55745. Other local model changes were also present, so these are integration evidence, not a clean-branch quality evaluation.

- 2×8 B200, K3 MXFP4, TP8+PP2, DP1/DCP1, no EP; Model Runner V2.
- FP8 KV, FlashInfer MLA with FP8 prefill queries; Triton KDA, `--use-replayssm`, `--mamba-cache-mode align`.
- D-Spark8, synthetic acceptance length 4, adaptive verification disabled; `CUDA_LAUNCH_BLOCKING` unset.
- `max-model-len=1048576`, `max-num-batched-tokens=16000`, `max-num-seqs=96`, GPU memory utilization 0.90.
- Random 8192-input/1024-output requests, temperature 0, seed 42, ignore EOS; 128 requests per run. One warmup and two measured runs per concurrency, resetting prefix cache before every run.

## Test Result

| Check | Result |
|---|---|
| CPU pre-commit, including mypy | Passed |
| Isolated-branch worker tests | 12 passed |
| C16 serving, two measured runs | 256 successful, 0 failed |
| C96 serving, two measured runs | 256 successful, 0 failed |
| Acceptance length | 4.00 in every run |
| Head/worker ERROR or device assert | None in the recorded runs |

Synthetic acceptance validates execution, not generated-text quality. Real-sampling quality comparison, cancellation under load, and PP sizes beyond 2 remain unverified. The non-last stages incur per-step metadata clones. Draft pending human review and quality validation; AI-assisted (Codex).
