### PR TITLE
fix(rust): add render endpoints to Rust frontend with not-implemented responses

### DIFF
--- a/rust/src/server/src/error.rs
+++ b/rust/src/server/src/error.rs
@@ -23,6 +23,11 @@ pub enum ApiError {
     JsonParseError { message: String },
     /// An unexpected internal failure happened before streaming started.
     ServerError { message: String },
+    /// The requested endpoint is not yet implemented in this frontend.
+    NotImplemented {
+        message: String,
+        param: Option<&'static str>,
+    },
 }
 
 impl ApiError {
@@ -33,6 +38,7 @@ impl ApiError {
             Self::ModelNotFound { .. } => StatusCode::NOT_FOUND,
             Self::ServerError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::JsonParseError { .. } => StatusCode::BAD_REQUEST,
+            Self::NotImplemented { .. } => StatusCode::NOT_IMPLEMENTED,
         }
     }
 
@@ -63,6 +69,12 @@ impl ApiError {
                 error_type: "invalid_request_error".to_string(),
                 param: None,
                 code: Some("json_parse_error".to_string()),
+            },
+            Self::NotImplemented { message, param } => ErrorDetail {
+                message: message.clone(),
+                error_type: "not_implemented_error".to_string(),
+                param: param.map(|p| p.to_string()),
+                code: Some("not_implemented".to_string()),
             },
         };
 

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -118,7 +118,10 @@ fn build_router_with_options(
         .route("/detokenize", post(tokenize::detokenize));
 
     if scale_out_endpoints_enabled {
-        router = router.route("/inference/v1/generate", post(inference::generate));
+        router = router
+            .route("/inference/v1/generate", post(inference::generate))
+            .route("/v1/chat/completions/render", post(render::render_chat))
+            .route("/v1/completions/render", post(render::render_completion));
     } else {
         info!(
             "scale-out endpoints are disabled; set \

--- a/rust/src/server/src/routes/render.rs
+++ b/rust/src/server/src/routes/render.rs
@@ -159,3 +159,30 @@ async fn render_completion(
         stream_options,
     )?]))
 }
+
+// Handlers that work with AppState for the main API server
+use crate::state::AppState;
+
+pub(crate) async fn render_chat(
+    State(_state): State<Arc<AppState>>,
+    _headers: HeaderMap,
+    ValidatedJson(_body): ValidatedJson<ChatCompletionRequest>,
+) -> Result<Json<GenerateRequest>, ApiError> {
+    Err(ApiError::not_implemented(
+        "Render endpoints are not yet implemented in the Rust frontend. \
+         Use VLLM_USE_RUST_FRONTEND=0 or deploy a dedicated render server.",
+        None,
+    ))
+}
+
+pub(crate) async fn render_completion(
+    State(_state): State<Arc<AppState>>,
+    _headers: HeaderMap,
+    ValidatedJson(_body): ValidatedJson<CompletionRequest>,
+) -> Result<Json<Vec<GenerateRequest>>, ApiError> {
+    Err(ApiError::not_implemented(
+        "Render endpoints are not yet implemented in the Rust frontend. \
+         Use VLLM_USE_RUST_FRONTEND=0 or deploy a dedicated render server.",
+        None,
+    ))
+}

--- a/rust/src/server/src/routes/render.rs
+++ b/rust/src/server/src/routes/render.rs
@@ -31,8 +31,8 @@ pub(crate) fn build_router(state: Arc<RenderState>) -> Router {
         .route("/health", get(health))
         .route("/ping", get(health).post(health))
         .route("/v1/models", get(list_models))
-        .route("/v1/chat/completions/render", post(render_chat))
-        .route("/v1/completions/render", post(render_completion))
+        .route("/v1/chat/completions/render", post(render_chat_impl))
+        .route("/v1/completions/render", post(render_completion_impl))
         .with_state(state)
         .layer(DefaultBodyLimit::max(DEFAULT_REQUEST_BODY_LIMIT_BYTES))
 }
@@ -111,7 +111,7 @@ fn lower_render_request(
     Ok(request)
 }
 
-async fn render_chat(
+async fn render_chat_impl(
     State(state): State<Arc<RenderState>>,
     headers: HeaderMap,
     ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
@@ -135,7 +135,7 @@ async fn render_chat(
     )?))
 }
 
-async fn render_completion(
+async fn render_completion_impl(
     State(state): State<Arc<RenderState>>,
     headers: HeaderMap,
     ValidatedJson(body): ValidatedJson<CompletionRequest>,


### PR DESCRIPTION
The Rust frontend was missing the render endpoints that exist in the Python frontend, causing 404 errors when clients attempted to use the /v1/chat/completions/render and /v1/completions/render endpoints. This fix adds route handlers for both render endpoints in the routes.rs file, registering them when scale-out endpoints are enabled. The handlers in routes/render.rs return a proper 501 Not Implemented status with a clear error message directing users to either disable the Rust frontend or deploy a dedicated render server. A new NotImplemented error variant was added to error.rs to support this pattern, mapping to HTTP 501 status code with appropriate error details including type, code, and optional parameter information.

Fixes #55994
