### PR TITLE
[ROCm][CI] Use a platform-independent GEMM in the merged-column fuser test

### DIFF
--- a/tests/models/transformers/fusers/test_linear.py
+++ b/tests/models/transformers/fusers/test_linear.py
@@ -1145,11 +1145,16 @@ def test_merged_column_fuser_supports_any_number_of_linears(
     from vllm.model_executor import parameter
     from vllm.model_executor.layers import linear
     from vllm.model_executor.layers.linear import MergedColumnParallelLinear
-    from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
+    from vllm.model_executor.layers.utils import default_unquantized_gemm
     from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
 
     monkeypatch.setattr(linear, "get_tensor_model_parallel_rank", lambda: 0)
     monkeypatch.setattr(linear, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(
+        linear,
+        "dispatch_unquantized_gemm",
+        lambda linear_backend="auto": default_unquantized_gemm,
+    )
     monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 0)
     monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 1)
     with torch.device("meta"):
@@ -1176,7 +1181,6 @@ def test_merged_column_fuser_supports_any_number_of_linears(
 
     merged = getattr(fused, fuser.merged_name)
     assert isinstance(merged, MergedColumnParallelLinear)
-    dispatch_cpu_unquantized_gemm(merged, remove_weight=False)
     for actual, reference in zip(fused(x), expected):
         torch.testing.assert_close(actual, reference)
 


### PR DESCRIPTION
## Purpose

Fix `test_merged_column_fuser_supports_any_number_of_linears` failing on AMD CI. The test constructs a `MergedColumnParallelLinear` through the fuser. `UnquantizedLinearMethod` binds the platform-specific GEMM at construction, so on ROCm the forward calls `rocm_unquantized_gemm` on the test's CPU tensors:

```
NotImplementedError: Could not run 'vllm::rocm_unquantized_gemm' with arguments
from the 'CPU' backend.
```

Monkeypatch `dispatch_unquantized_gemm` to use `default_unquantized_gemm` and remove the now-unnecessary `dispatch_cpu_unquantized_gemm` call. This keeps the test independent of the platform-specific GEMM backend and focused on validating merged-column fuser behavior.

## Test Plan

On a ROCm build:

```
cd tests
pytest -v -s models/test_utils.py models/test_vision.py \
    models/test_adapters.py models/transformers/fusers/
```

## Test Result

Before: `2 failed` with the `NotImplementedError` above.
After: `143 passed, 2 skipped`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

