### PR TITLE
[Bugfix][Engine] Skip stream-interval buffering for pooling requests

### DIFF
--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -296,8 +296,7 @@ class RequestState:
             # Only the final output is required in FINAL_ONLY mode.
             return None
 
-        if self.stream_interval > 1:
-            assert self.detokenizer is not None
+        if self.stream_interval > 1 and self.detokenizer is not None:
 
             # Send output request only when
             # 1. It has finished, or


### PR DESCRIPTION
## Summary

Pooling/embedding `RequestState`s are built with `detokenizer = None` (streaming detokenization is meaningless for pooling output). With `--stream-interval > 1`, the `assert self.detokenizer is not None` fired on **every** finished pooling request, crashing the engine via "AsyncLLM output_handler failed".

The buffering block is now skipped (not asserted) for pooling requests — stream-interval buffering has no effect on pooling output.

## Repro

Start a pooling server with `--stream-interval 8` and send any `PoolingParams` request → `AssertionError` on every request.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>