### PR TITLE
[Bugfix][Engine] Clamp span-pack node contribution to remaining world_size slots

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -710,11 +710,11 @@ class CoreEngineActorManager:
             for i in range(dp_size_to_allocate):
                 device_bundle = [{device_str: 1.0, "node:" + node_ip: 0.001}]
                 if pack_strategy == "span":
-                    collected_bundles += device_bundle * n_device_on_node
-                    assert len(collected_bundles) <= world_size, (
-                        "collected_bundles should be <= world_size, "
-                        f"but got {len(collected_bundles)=} and {world_size=}"
-                    )
+                    # Clamp the node's contribution to the remaining slots:
+                    # a node with more free GPUs than world_size would
+                    # otherwise trip the assert below and crash startup.
+                    take = min(n_device_on_node, world_size - len(collected_bundles))
+                    collected_bundles += device_bundle * max(take, 0)
 
                     # we only create a placement group if we collected enough devices
                     if len(collected_bundles) < world_size:


### PR DESCRIPTION
## Summary

The `span` pack strategy added a node's **entire** free-device count to `collected_bundles` without capping it at the remaining `world_size` slots. When a node had more free GPUs than `world_size`, the assert crashed startup:

```
# Single 8-GPU node, TP=4, DP=2 → world_size=4
# node contributes 8 bundles; assert 8 <= 4 → AssertionError
```

The contribution is now clamped to `min(n_device_on_node, world_size - len(collected_bundles))`, matching the obviously correct placement the strategy intends (take what you need from the node, no more).

## Example

Two nodes with 3 and 6 free GPUs, `world_size=4`: before, 3+6=9 > 4 → assert crash; after, 3+1=4 → correct placement.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>