### PR TITLE
[Feature] Switch EP groups between prefill and decode

### DIFF
--- a/docs/features/runtime_pd_role_switching.md
+++ b/docs/features/runtime_pd_role_switching.md
@@ -1,15 +1,13 @@
 # Runtime prefill/decode role switching
 
-Runtime P/D switching changes the serving role of an entire engine group while
-keeping its workers, model weights, KV registrations, expert placement, process
-groups, and CUDA graphs alive. The group stops admitting requests while it drains.
-A router can keep the service available by sending new work to other ready groups.
+Runtime P/D switching moves an entire engine group between prefill and decode.
+Workers, model weights, KV registrations, expert placement, communicators, and
+CUDA graphs stay resident. The group drains before switching; the router sends
+new work to other ready groups.
 
-This experimental implementation keeps both KV transfer capabilities enabled at
-startup. It changes admission state; it does not resize EP or change the all-to-all
-backend. In particular, DeepEP v2 can serve both roles through its existing
-graph-compatible execution path. Switching to separately optimized communication
-paths is outside this feature.
+This experimental feature keeps both KV transfer capabilities enabled at startup.
+EP membership and the all-to-all backend stay fixed. DeepEP v2 serves both roles
+through its existing graph-compatible path.
 
 ## Configuration
 
@@ -22,20 +20,18 @@ vllm serve Qwen/Qwen3-30B-A3B \
   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","pd_role":"prefill"}'
 ```
 
-The first implementation requires NIXL pull transfer, one Python API process with
+Switching requires NIXL pull transfer, one Python API process with
 internal DP load balancing, PP=PCP=DCP=1, and a text generation model. Speculative
 decoding, bidirectional KV reuse, sleep mode, and concurrent elastic EP resizing
-are unsupported. The model, precision, topology, and memory allocation remain
-fixed. Size the initial configuration for both roles and enable the CUDA graphs
-needed by decode at startup.
+are unsupported. Size the initial configuration for both roles and enable decode
+CUDA graphs at startup.
 
 With switching enabled, inference uses `/v1/completions` or
 `/v1/chat/completions`. Each request must carry the current
 `X-vLLM-PD-Role` and `X-vLLM-PD-Epoch` headers. The NIXL request parameters must
 select exactly one direction: `do_remote_decode` on prefill, or
 `do_remote_prefill` on decode. Other mutating endpoints are unavailable in this
-mode. The ordinary health, metrics, model information, and tokenization endpoints
-remain available.
+mode; health, metrics, model information, and tokenization remain available.
 
 ## Transition protocol
 
@@ -45,10 +41,9 @@ Read the group's current role, epoch, and phase:
 curl http://localhost:8000/v1/pd_role
 ```
 
-Before requesting a transition, the router must stop assigning new work to this
-group. It must also account for already assigned handoffs: a decode reservation
-may still be waiting for its prefill response. Deliver these reserved requests
-before closing admission. Existing accepted streams continue normally.
+Before requesting a transition, the router must stop assigning new work to the
+group and deliver reserved handoffs, including decode requests still waiting for
+their prefill response. Accepted streams continue normally.
 
 ```bash
 curl -X POST http://localhost:8000/v1/pd_role \
@@ -61,25 +56,18 @@ incremented epoch are reported with `phase="ready"`, then add the group to the
 new routing pool. The operation continues if its HTTP caller disconnects. Use
 the configured API key when authentication is enabled.
 
-Admission closes before any asynchronous work starts. Accepted HTTP requests,
-including preprocessing, queued work, and streaming responses, complete first.
-Every engine rank then prepares the new epoch while scheduling continues to
-release outstanding NIXL transfers and retained KV blocks. The frontend publishes
-the new role only after every engine has acknowledged commit. No cache reset,
-worker restart, communicator reconstruction, or graph capture is performed by the
-transition.
+Admission closes before asynchronous work starts. Accepted HTTP requests finish,
+including preprocessing and streaming responses. Every engine core then prepares
+the new epoch while scheduling drains queued work, NIXL transfers, and retained
+KV. The frontend publishes readiness after every core acknowledges commit.
 
 Requests with stale role/epoch headers, and new requests arriving during a
 transition, receive HTTP 409 before inference. A router may retry those requests
 on another ready group. It must not retry requests whose execution has started.
-The router remains responsible for reserved handoffs and for retaining enough
-prefill and decode capacity throughout the transition.
+The router must retain enough prefill and decode capacity during the transition.
 
-A drain timeout restores admission only after every prepared rank has cancelled
-the old transaction. The group stays fenced with `phase="rolling_back"` until
-cancellation is acknowledged. A failed cancellation or uncertain commit leaves
-the group fenced with `phase="failed"`; it must not be returned to routing
-automatically. A successful
-transition preserves request execution, but draining and temporarily reduced
-fleet capacity can affect latency. Continuous availability requires another ready
-group for each role.
+A drain timeout keeps admission closed with `phase="rolling_back"` until every
+core acknowledges cancellation, then restores the old role. Failed cancellation
+or an uncertain commit leaves `phase="failed"` and requires operator recovery.
+Draining and reduced capacity can affect latency; continuous availability requires
+another ready group for each role.

--- a/docs/features/runtime_pd_role_switching.md
+++ b/docs/features/runtime_pd_role_switching.md
@@ -1,0 +1,83 @@
+# Runtime prefill/decode role switching
+
+Runtime P/D switching changes the serving role of an entire engine group while
+keeping its workers, model weights, KV registrations, expert placement, process
+groups, and CUDA graphs alive. The group stops admitting requests while it drains.
+A router can keep the service available by sending new work to other ready groups.
+
+This experimental implementation keeps both KV transfer capabilities enabled at
+startup. It changes admission state; it does not resize EP or change the all-to-all
+backend. In particular, DeepEP v2 can serve both roles through its existing
+graph-compatible execution path. Switching to separately optimized communication
+paths is outside this feature.
+
+## Configuration
+
+Set the initial role with `pd_role` in the KV transfer configuration:
+
+```bash
+vllm serve Qwen/Qwen3-30B-A3B \
+  --data-parallel-size 2 --api-server-count 1 \
+  --enable-expert-parallel --all2all-backend deepep_v2 \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","pd_role":"prefill"}'
+```
+
+The first implementation requires NIXL pull transfer, one Python API process with
+internal DP load balancing, PP=PCP=DCP=1, and a text generation model. Speculative
+decoding, bidirectional KV reuse, sleep mode, and concurrent elastic EP resizing
+are unsupported. The model, precision, topology, and memory allocation remain
+fixed. Size the initial configuration for both roles and enable the CUDA graphs
+needed by decode at startup.
+
+With switching enabled, inference uses `/v1/completions` or
+`/v1/chat/completions`. Each request must carry the current
+`X-vLLM-PD-Role` and `X-vLLM-PD-Epoch` headers. The NIXL request parameters must
+select exactly one direction: `do_remote_decode` on prefill, or
+`do_remote_prefill` on decode. Other mutating endpoints are unavailable in this
+mode. The ordinary health, metrics, model information, and tokenization endpoints
+remain available.
+
+## Transition protocol
+
+Read the group's current role, epoch, and phase:
+
+```bash
+curl http://localhost:8000/v1/pd_role
+```
+
+Before requesting a transition, the router must stop assigning new work to this
+group. It must also account for already assigned handoffs: a decode reservation
+may still be waiting for its prefill response. Deliver these reserved requests
+before closing admission. Existing accepted streams continue normally.
+
+```bash
+curl -X POST http://localhost:8000/v1/pd_role \
+  -H 'Content-Type: application/json' \
+  -d '{"role":"decode","expected_epoch":0,"drain_timeout":120}'
+```
+
+The endpoint returns HTTP 202. Poll `GET /v1/pd_role` until the requested role and
+incremented epoch are reported with `phase="ready"`, then add the group to the
+new routing pool. The operation continues if its HTTP caller disconnects. Use
+the configured API key when authentication is enabled.
+
+Admission closes before any asynchronous work starts. Accepted HTTP requests,
+including preprocessing, queued work, and streaming responses, complete first.
+Every engine rank then prepares the new epoch while scheduling continues to
+release outstanding NIXL transfers and retained KV blocks. The frontend publishes
+the new role only after every engine has acknowledged commit. No cache reset,
+worker restart, communicator reconstruction, or graph capture is performed by the
+transition.
+
+Requests with stale role/epoch headers, and new requests arriving during a
+transition, receive HTTP 409 before inference. A router may retry those requests
+on another ready group. It must not retry requests whose execution has started.
+The router remains responsible for reserved handoffs and for retaining enough
+prefill and decode capacity throughout the transition.
+
+A drain timeout restores admission only after every prepared rank has cancelled
+the old transaction. A failed or uncertain commit leaves the group fenced with
+`phase="failed"`; it must not be returned to routing automatically. A successful
+transition preserves request execution, but draining and temporarily reduced
+fleet capacity can affect latency. Continuous availability requires another ready
+group for each role.

--- a/docs/features/runtime_pd_role_switching.md
+++ b/docs/features/runtime_pd_role_switching.md
@@ -76,8 +76,10 @@ The router remains responsible for reserved handoffs and for retaining enough
 prefill and decode capacity throughout the transition.
 
 A drain timeout restores admission only after every prepared rank has cancelled
-the old transaction. A failed or uncertain commit leaves the group fenced with
-`phase="failed"`; it must not be returned to routing automatically. A successful
+the old transaction. The group stays fenced with `phase="rolling_back"` until
+cancellation is acknowledged. A failed cancellation or uncertain commit leaves
+the group fenced with `phase="failed"`; it must not be returned to routing
+automatically. A successful
 transition preserves request execution, but draining and temporarily reduced
 fleet capacity can affect latency. Continuous availability requires another ready
 group for each role.

--- a/tests/entrypoints/launchers/test_cli_args.py
+++ b/tests/entrypoints/launchers/test_cli_args.py
@@ -151,6 +151,29 @@ def test_multiple_valid_inputs(serve_parser):
 
 
 ### Tests for serve argument validation that run prior to loading
+@pytest.mark.parametrize("frontend", ["http", "grpc", "rust"])
+@pytest.mark.parametrize("enable_pd_role", [False, True])
+def test_pd_role_requires_python_http_frontend(
+    serve_parser, monkeypatch, frontend, enable_pd_role
+):
+    kv_config = {"kv_connector": "NixlConnector", "kv_role": "kv_both"}
+    if enable_pd_role:
+        kv_config["pd_role"] = "prefill"
+    cli_args = ["--kv-transfer-config", json.dumps(kv_config)]
+    if frontend == "grpc":
+        cli_args.append("--grpc")
+    monkeypatch.setattr(
+        cli_args_module.envs, "VLLM_USE_RUST_FRONTEND", frontend == "rust"
+    )
+    args = serve_parser.parse_args(cli_args)
+
+    if enable_pd_role and frontend != "http":
+        with pytest.raises(ValueError, match="requires the Python HTTP frontend"):
+            validate_parsed_serve_args(args)
+    else:
+        validate_parsed_serve_args(args)
+
+
 def test_enable_auto_choice_passes_without_tool_call_parser(serve_parser):
     """Ensure validation fails if tool choice is enabled with no call parser"""
     # If we enable-auto-tool-choice, explode with no tool-call-parser

--- a/tests/entrypoints/serve/middleware/test_pd_role.py
+++ b/tests/entrypoints/serve/middleware/test_pd_role.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from starlette.responses import StreamingResponse
+
+from vllm.entrypoints.serve.pd_role.middleware import PDRoleMiddleware
+from vllm.entrypoints.serve.pd_role.state import PDRoleState
+
+
+@pytest.mark.asyncio
+async def test_role_switch_waits_for_http_and_kv_drain():
+    """An accepted stream and delayed KV ownership both precede role commit."""
+    release_stream = asyncio.Event()
+    entered_stream = asyncio.Event()
+    prepared = asyncio.Event()
+    release_kv = asyncio.Event()
+    calls = []
+
+    async def call_all(method, *args):
+        calls.append(method)
+        if method == "prepare_pd_role":
+            prepared.set()
+        committed = method == "commit_pd_role"
+        return [
+            {
+                "role": "decode" if committed else "prefill",
+                "epoch": int(committed),
+                "drained": release_kv.is_set(),
+            }
+        ] * 2
+
+    state = PDRoleState("prefill", 2, call_all)
+    app = FastAPI()
+    app.state.pd_role = state
+    app.add_middleware(PDRoleMiddleware)
+
+    @app.post("/v1/completions")
+    async def completion():
+        async def stream():
+            entered_stream.set()
+            yield b"first token\n"
+            await release_stream.wait()
+            yield b"last token\n"
+
+        return StreamingResponse(stream())
+
+    headers = {"x-vllm-pd-role": "prefill", "x-vllm-pd-epoch": "0"}
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app), base_url="http://test"
+    ) as client:
+        accepted = asyncio.create_task(client.post("/v1/completions", headers=headers))
+        await asyncio.wait_for(entered_stream.wait(), 1)
+        state.start("decode", 0, 2)
+        rejected = await client.post("/v1/completions", headers=headers)
+        assert rejected.status_code == 409
+        assert state.active_requests == 1
+        assert not prepared.is_set()
+
+        release_stream.set()
+        response = await accepted
+        assert response.text == "first token\nlast token\n"
+        await asyncio.wait_for(prepared.wait(), 1)
+        assert "commit_pd_role" not in calls
+        release_kv.set()
+        await state.task
+        assert state.status()["phase"] == "ready"
+        assert (state.role, state.epoch) == ("decode", 1)
+        stale = await client.post("/v1/completions", headers=headers)
+        assert stale.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("partial_commit", [False, True])
+async def test_role_switch_recovers_only_before_commit(partial_commit):
+    """A drain failure restores admission; an uncertain commit stays fenced."""
+    calls = []
+
+    async def call_all(method, *args):
+        calls.append(method)
+        if method == "get_pd_role_status" and not partial_commit:
+            raise TimeoutError("delayed KV transfer")
+        if method == "commit_pd_role":
+            raise RuntimeError("one rank did not acknowledge")
+        return [
+            {"role": "prefill", "epoch": 0, "drained": True, "pending_role": None}
+        ] * 2
+
+    state = PDRoleState("prefill", 2, call_all)
+    state.start("decode", 0, 1)
+    with pytest.raises(ValueError, match="in progress"):
+        state.start("decode", 0, 1)
+    await state.task
+    assert (state.role, state.epoch) == ("prefill", 0)
+    if partial_commit:
+        assert state.phase == "failed"
+        assert "cancel_pd_role" not in calls
+    else:
+        assert state.phase == "ready"
+        assert calls[-1] == "cancel_pd_role"
+
+
+@pytest.mark.asyncio
+async def test_http_drain_timeout_keeps_existing_request_and_epoch():
+    async def call_all(*args):
+        pytest.fail("Engine preparation must wait for admitted HTTP requests")
+
+    state = PDRoleState("decode", 2, call_all)
+    state.active_requests = 1
+    state.idle.clear()
+    state.start("prefill", 0, 0.01)
+    await state.task
+    assert state.phase == "ready"
+    assert state.active_requests == 1
+    assert (state.role, state.epoch) == ("decode", 0)
+    assert "TimeoutError" in state.error
+
+
+@pytest.mark.asyncio
+async def test_role_switch_requires_every_rank_acknowledgement():
+    async def call_all(method, *args):
+        return [{"role": "prefill", "epoch": 0, "drained": True}]
+
+    state = PDRoleState("prefill", 2, call_all)
+    state.start("decode", 0, 1)
+    await state.task
+    assert state.phase == "failed"
+    assert state.epoch == 0
+
+
+@pytest.mark.asyncio
+async def test_prepare_timeout_cancels_every_prepared_rank():
+    prepared_roles: list[str | None] = [None, None]
+    calls = []
+
+    async def call_all(method, *args):
+        calls.append(method)
+        if method == "prepare_pd_role":
+            prepared_roles[:] = ["decode", "decode"]
+            await asyncio.Event().wait()
+        if method == "cancel_pd_role":
+            prepared_roles[:] = [None, None]
+        return [
+            {"role": "prefill", "epoch": 0, "pending_role": role}
+            for role in prepared_roles
+        ]
+
+    state = PDRoleState("prefill", 2, call_all)
+    state.start("decode", 0, 0.01)
+    await state.task
+    assert calls == ["prepare_pd_role", "cancel_pd_role"]
+    assert prepared_roles == [None, None]
+    assert state.phase == "ready"
+    assert state.epoch == 0

--- a/tests/entrypoints/serve/middleware/test_pd_role.py
+++ b/tests/entrypoints/serve/middleware/test_pd_role.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 from starlette.responses import StreamingResponse
 
+from vllm.entrypoints.serve.pd_role.api_router import router
 from vllm.entrypoints.serve.pd_role.middleware import PDRoleMiddleware
 from vllm.entrypoints.serve.pd_role.state import PDRoleState
 
@@ -134,8 +135,11 @@ async def test_role_switch_requires_every_rank_acknowledgement():
 
 @pytest.mark.asyncio
 async def test_prepare_timeout_cancels_every_prepared_rank():
+    """Rollback remains nonterminal and fenced until every rank acknowledges."""
     prepared_roles: list[str | None] = [None, None]
     calls = []
+    cancelling = asyncio.Event()
+    release_cancel = asyncio.Event()
 
     async def call_all(method, *args):
         calls.append(method)
@@ -143,6 +147,8 @@ async def test_prepare_timeout_cancels_every_prepared_rank():
             prepared_roles[:] = ["decode", "decode"]
             await asyncio.Event().wait()
         if method == "cancel_pd_role":
+            cancelling.set()
+            await release_cancel.wait()
             prepared_roles[:] = [None, None]
         return [
             {"role": "prefill", "epoch": 0, "pending_role": role}
@@ -150,8 +156,37 @@ async def test_prepare_timeout_cancels_every_prepared_rank():
         ]
 
     state = PDRoleState("prefill", 2, call_all)
-    state.start("decode", 0, 0.01)
-    await state.task
+    app = FastAPI()
+    app.state.pd_role = state
+    app.include_router(router)
+    app.add_middleware(PDRoleMiddleware)
+
+    @app.post("/v1/completions")
+    async def completion():
+        return {"accepted": True}
+
+    headers = {"x-vllm-pd-role": "prefill", "x-vllm-pd-epoch": "0"}
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app), base_url="http://test"
+    ) as client:
+        state.start("decode", 0, 1)
+        try:
+            await asyncio.wait_for(cancelling.wait(), 2)
+            status = (await client.get("/v1/pd_role")).json()
+            assert status["phase"] == "rolling_back"
+            assert (status["role"], status["epoch"]) == ("prefill", 0)
+            assert prepared_roles == ["decode", "decode"]
+            rejected = await client.post("/v1/completions", headers=headers)
+            assert rejected.status_code == 409
+            assert rejected.json()["phase"] == "rolling_back"
+        finally:
+            release_cancel.set()
+            await state.task
+        status = (await client.get("/v1/pd_role")).json()
+        assert status["phase"] == "ready"
+        assert (
+            await client.post("/v1/completions", headers=headers)
+        ).status_code == 200
     assert calls == ["prepare_pd_role", "cancel_pd_role"]
     assert prepared_roles == [None, None]
     assert state.phase == "ready"

--- a/tests/entrypoints/serve/middleware/test_pd_role.py
+++ b/tests/entrypoints/serve/middleware/test_pd_role.py
@@ -15,18 +15,23 @@ from vllm.entrypoints.serve.pd_role.state import PDRoleState
 
 @pytest.mark.asyncio
 async def test_role_switch_waits_for_http_and_kv_drain():
-    """An accepted stream and delayed KV ownership both precede role commit."""
     release_stream = asyncio.Event()
     entered_stream = asyncio.Event()
     prepared = asyncio.Event()
     release_kv = asyncio.Event()
     calls = []
+    committed_status = []
 
     async def call_all(method, *args):
         calls.append(method)
         if method == "prepare_pd_role":
             prepared.set()
         committed = method == "commit_pd_role"
+        if committed:
+            # Observe wait_for's scheduling gap on Python 3.10/3.11.
+            asyncio.get_running_loop().call_soon(
+                lambda: committed_status.append(state.status())
+            )
         return [
             {
                 "role": "decode" if committed else "prefill",
@@ -69,27 +74,30 @@ async def test_role_switch_waits_for_http_and_kv_drain():
         assert "commit_pd_role" not in calls
         release_kv.set()
         await state.task
+        status = committed_status[0]
+        assert status["phase"] != "ready" or status["transition_seconds"] is not None
         assert state.status()["phase"] == "ready"
+        assert state.duration is not None
         assert (state.role, state.epoch) == ("decode", 1)
         stale = await client.post("/v1/completions", headers=headers)
         assert stale.status_code == 409
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("partial_commit", [False, True])
-async def test_role_switch_recovers_only_before_commit(partial_commit):
-    """A drain failure restores admission; an uncertain commit stays fenced."""
+@pytest.mark.parametrize("failure", ["drain", "commit", "cancel"])
+async def test_role_switch_recovers_only_before_commit(failure):
     calls = []
 
     async def call_all(method, *args):
         calls.append(method)
-        if method == "get_pd_role_status" and not partial_commit:
+        if method == "get_pd_role_status" and failure != "commit":
             raise TimeoutError("delayed KV transfer")
         if method == "commit_pd_role":
             raise RuntimeError("one rank did not acknowledge")
+        num_ranks = 1 if method == "cancel_pd_role" and failure == "cancel" else 2
         return [
             {"role": "prefill", "epoch": 0, "drained": True, "pending_role": None}
-        ] * 2
+        ] * num_ranks
 
     state = PDRoleState("prefill", 2, call_all)
     state.start("decode", 0, 1)
@@ -97,12 +105,8 @@ async def test_role_switch_recovers_only_before_commit(partial_commit):
         state.start("decode", 0, 1)
     await state.task
     assert (state.role, state.epoch) == ("prefill", 0)
-    if partial_commit:
-        assert state.phase == "failed"
-        assert "cancel_pd_role" not in calls
-    else:
-        assert state.phase == "ready"
-        assert calls[-1] == "cancel_pd_role"
+    assert state.phase == ("ready" if failure == "drain" else "failed")
+    assert ("cancel_pd_role" in calls) == (failure != "commit")
 
 
 @pytest.mark.asyncio
@@ -119,18 +123,6 @@ async def test_http_drain_timeout_keeps_existing_request_and_epoch():
     assert state.active_requests == 1
     assert (state.role, state.epoch) == ("decode", 0)
     assert "TimeoutError" in state.error
-
-
-@pytest.mark.asyncio
-async def test_role_switch_requires_every_rank_acknowledgement():
-    async def call_all(method, *args):
-        return [{"role": "prefill", "epoch": 0, "drained": True}]
-
-    state = PDRoleState("prefill", 2, call_all)
-    state.start("decode", 0, 1)
-    await state.task
-    assert state.phase == "failed"
-    assert state.epoch == 0
 
 
 @pytest.mark.asyncio
@@ -189,5 +181,4 @@ async def test_prepare_timeout_cancels_every_prepared_rank():
         ).status_code == 200
     assert calls == ["prepare_pd_role", "cancel_pd_role"]
     assert prepared_roles == [None, None]
-    assert state.phase == "ready"
     assert state.epoch == 0

--- a/tests/v1/engine/test_pd_role.py
+++ b/tests/v1/engine/test_pd_role.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+from collections import deque
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.v1.core.utils import create_requests, create_scheduler
+from vllm.config import KVTransferConfig
+from vllm.v1.core.sched.interface import PauseState
+from vllm.v1.engine import EngineCoreRequestType
+from vllm.v1.engine.core import EngineCoreProc
+from vllm.v1.engine.core_client import DPLBAsyncMPClient
+from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
+from vllm.v1.request import RequestStatus
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"kv_role": "kv_producer"},
+        {"kv_role": "kv_consumer"},
+        {"kv_connector_extra_config": {"bidirectional_kv_xfer": True}},
+    ],
+)
+def test_pd_role_requires_both_capabilities_without_bidirectional_transfer(overrides):
+    config = {
+        "kv_connector": "NixlConnector",
+        "kv_role": "kv_both",
+        "pd_role": "prefill",
+        **overrides,
+    }
+    with pytest.raises(ValueError, match="pd_role requires NixlConnector"):
+        KVTransferConfig(**config)
+
+
+def test_pd_role_keeps_both_transfer_capabilities():
+    config = KVTransferConfig(
+        kv_connector="NixlConnector", kv_role="kv_both", pd_role="decode"
+    )
+    assert config.is_kv_producer and config.is_kv_consumer
+
+
+def _pd_role_engine_core() -> EngineCoreProc:
+    core = object.__new__(EngineCoreProc)
+    core.batch_queue = None
+    core.scheduler = create_scheduler(use_kv_connector=True)
+    core.vllm_config = core.scheduler.vllm_config
+    core._pd_role = "prefill"
+    core._pd_role_epoch = 0
+    core._pending_pd_role = None
+    return core
+
+
+def test_pd_role_commit_waits_for_queued_requests_and_kv_release():
+    core = _pd_role_engine_core()
+    scheduler = core.scheduler
+    queued, retained = create_requests(num_requests=2)
+    scheduler.add_request(queued)
+    retained.status = RequestStatus.FINISHED_STOPPED
+    scheduler.requests[retained.request_id] = retained
+
+    status = core.prepare_pd_role("decode", expected_epoch=0)
+    assert not status["drained"]
+    assert status["waiting"] == 1
+    assert scheduler.pause_state == PauseState.UNPAUSED
+    with pytest.raises(ValueError, match="still draining"):
+        core.commit_pd_role("decode", expected_epoch=0)
+
+    scheduler.finish_requests(queued.request_id, RequestStatus.FINISHED_ABORTED)
+    scheduler_output = scheduler.schedule()
+    assert not scheduler.has_unfinished_requests()
+    assert not core.get_pd_role_status()["drained"]
+    with pytest.raises(ValueError, match="still draining"):
+        core.commit_pd_role("decode", expected_epoch=0)
+
+    scheduler.update_from_output(
+        scheduler_output,
+        ModelRunnerOutput(
+            req_ids=[],
+            req_id_to_index={},
+            kv_connector_output=KVConnectorOutput(
+                finished_sending={retained.request_id}
+            ),
+        ),
+    )
+    assert core.get_pd_role_status()["drained"]
+    core.batch_queue = deque([(Future(), scheduler_output, Future())])
+    with pytest.raises(ValueError, match="still draining"):
+        core.commit_pd_role("decode", expected_epoch=0)
+    core.batch_queue.clear()
+    status = core.commit_pd_role("decode", expected_epoch=0)
+    assert status["role"] == "decode"
+    assert status["epoch"] == 1
+    assert core.commit_pd_role("decode", expected_epoch=0) == status
+    with pytest.raises(ValueError, match="committed or stale"):
+        core.cancel_pd_role(expected_epoch=0)
+    with pytest.raises(ValueError, match="Stale"):
+        core.prepare_pd_role("prefill", expected_epoch=0)
+
+
+def test_pd_role_cancel_preserves_active_role_and_admission():
+    core = _pd_role_engine_core()
+    request = create_requests(num_requests=1)[0]
+    request.kv_transfer_params = {"do_remote_decode": True}
+    assert not core._rejects_pd_role_request(request)
+    core.prepare_pd_role("decode", expected_epoch=0)
+    assert core._rejects_pd_role_request(request)
+    status = core.cancel_pd_role(expected_epoch=0)
+    assert status["role"] == "prefill" and status["epoch"] == 0
+    assert not core._rejects_pd_role_request(request)
+
+
+@pytest.mark.parametrize(
+    "params,pending",
+    [
+        ({"do_remote_prefill": True}, False),
+        ({"do_remote_prefill": True, "do_remote_decode": True}, False),
+        ({"do_remote_decode": True}, True),
+    ],
+    ids=["wrong-role", "ambiguous-role", "pending-transition"],
+)
+def test_pd_role_rejection_releases_kv_without_duplicate_output(params, pending):
+    core = _pd_role_engine_core()
+    core._reject_add_in_shutdown = MagicMock(return_value=False)
+    core._send_error_outputs_to_client = MagicMock()
+    core._send_abort_outputs_to_client = MagicMock()
+    connector = core.scheduler.connector
+    connector.request_finished = MagicMock(return_value=(False, None))
+    request = create_requests(num_requests=1)[0]
+    request.kv_transfer_params = params
+    if pending:
+        core.prepare_pd_role("decode", expected_epoch=0)
+    core._handle_client_request(EngineCoreRequestType.ADD, (request, 0))
+    core._send_error_outputs_to_client.assert_called_once_with(
+        [request.request_id], request.client_index
+    )
+    core._send_abort_outputs_to_client.assert_not_called()
+    assert request.status == RequestStatus.FINISHED_ABORTED
+    connector.request_finished.assert_called_once_with(request, [])
+    assert core.scheduler.get_request_counts() == (0, 0)
+
+    cleanup = create_requests(num_requests=1, req_ids=["cleanup"])[0]
+    cleanup.kv_transfer_params = params
+    cleanup.abort_immediately = True
+    core._handle_client_request(EngineCoreRequestType.ADD, (cleanup, 0))
+    assert cleanup.status == RequestStatus.FINISHED_ABORTED
+    assert connector.request_finished.call_count == 2
+    assert core._send_error_outputs_to_client.call_count == 1
+
+
+def _pd_role_client(num_engines: int = 3) -> DPLBAsyncMPClient:
+    client = object.__new__(DPLBAsyncMPClient)
+    client.core_engines = [bytes([i, 0]) for i in range(num_engines)]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_dplb_utility_all_returns_every_rank():
+    client = _pd_role_client()
+
+    async def utility(method, *args, engine):
+        return {"rank": int.from_bytes(engine, "little"), "epoch": args[0]}
+
+    client._call_utility_async = utility
+    statuses = await client.call_utility_all_async("get_pd_role_status", 7)
+    assert statuses == [{"rank": rank, "epoch": 7} for rank in range(3)]
+
+
+@pytest.mark.asyncio
+async def test_dplb_utility_all_waits_for_other_ranks_on_error():
+    client = _pd_role_client(num_engines=2)
+    failed = asyncio.Event()
+    release = asyncio.Event()
+    completed = []
+
+    async def utility(method, *args, engine):
+        if engine == client.core_engines[0]:
+            failed.set()
+            raise ValueError("Stale P/D role epoch")
+        await release.wait()
+        completed.append(engine)
+
+    client._call_utility_async = utility
+    task = asyncio.create_task(
+        client.call_utility_all_async("prepare_pd_role", "decode", 0)
+    )
+    await failed.wait()
+    await asyncio.sleep(0)
+    assert not task.done()
+    release.set()
+    with pytest.raises(ValueError, match="Stale P/D role epoch"):
+        await task
+    assert completed == [client.core_engines[1]]

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -42,6 +42,11 @@ class KVTransferConfig:
     """Whether this vLLM instance produces, consumes KV cache, or both. Choices
     are 'kv_producer', 'kv_consumer', and 'kv_both'."""
 
+    pd_role: Literal["prefill", "decode"] | None = None
+    """Opt into runtime P/D role switching, with this initial serving role.
+    Requires NixlConnector with kv_role='kv_both'; the transfer capability
+    remains fixed for the lifetime of the engine."""
+
     kv_rank: int | None = None
     """The rank of this vLLM instance in the KV cache transfer. Typical value:
     0 for prefill instance, 1 for decode instance.
@@ -92,6 +97,16 @@ class KVTransferConfig:
     def __post_init__(self) -> None:
         if self.engine_id is None:
             self.engine_id = str(uuid.uuid4())
+
+        if self.pd_role is not None and (
+            self.kv_connector != "NixlConnector"
+            or self.kv_role != "kv_both"
+            or self.get_from_extra_config("bidirectional_kv_xfer", False)
+        ):
+            raise ValueError(
+                "pd_role requires NixlConnector with kv_role='kv_both' "
+                "and bidirectional_kv_xfer disabled"
+            )
 
         if self.kv_role is not None and self.kv_role not in get_args(KVRole):
             raise ValueError(

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -43,9 +43,8 @@ class KVTransferConfig:
     are 'kv_producer', 'kv_consumer', and 'kv_both'."""
 
     pd_role: Literal["prefill", "decode"] | None = None
-    """Opt into runtime P/D role switching, with this initial serving role.
-    Requires NixlConnector with kv_role='kv_both'; the transfer capability
-    remains fixed for the lifetime of the engine."""
+    """Initial serving role for runtime P/D switching. Requires NixlConnector
+    with kv_role='kv_both'; KV transfer capabilities remain fixed."""
 
     kv_rank: int | None = None
     """The rank of this vLLM instance in the KV cache transfer. Typical value:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1776,6 +1776,27 @@ class VllmConfig:
         # before the HMA check below, which inspects the connector class.
         self._post_init_kv_transfer_config()
 
+        if self.kv_transfer_config and self.kv_transfer_config.pd_role is not None:
+            parallel = self.parallel_config
+            if (
+                parallel._api_process_count != 1
+                or parallel.data_parallel_external_lb
+                or parallel.data_parallel_hybrid_lb
+                or parallel.pipeline_parallel_size != 1
+                or parallel.prefill_context_parallel_size != 1
+                or parallel.decode_context_parallel_size != 1
+                or parallel.enable_elastic_ep
+                or self.speculative_config is not None
+                or self.model_config.enable_sleep_mode
+                or self.model_config.is_multimodal_model
+                or self.model_config.runner_type != "generate"
+            ):
+                raise ValueError(
+                    "Runtime P/D role switching requires one API process, internal "
+                    "DP load balancing, PP=PCP=DCP=1, and a text generation model "
+                    "without speculation, sleep mode, or elastic EP resizing."
+                )
+
         if self.is_mm_encoder_only and self.cache_config.enable_prefix_caching:
             # Such an instance publishes encoder embeddings and runs no language
             # model, so it holds no KV cache for prefix caching to reuse and its

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -67,6 +67,11 @@ async def serve_grpc(args: argparse.Namespace):
 
     # Create engine args
     engine_args = AsyncEngineArgs.from_cli_args(args)
+    if (
+        engine_args.kv_transfer_config is not None
+        and engine_args.kv_transfer_config.pd_role is not None
+    ):
+        raise ValueError("Runtime P/D role switching requires the Python HTTP frontend")
 
     # Build vLLM config
     vllm_config = engine_args.create_engine_config(

--- a/vllm/entrypoints/launchers/api_server/app_state.py
+++ b/vllm/entrypoints/launchers/api_server/app_state.py
@@ -63,6 +63,17 @@ async def init_app_state(
     state.engine_client = engine_client
     state.log_stats = not args.disable_log_stats
     state.vllm_config = vllm_config
+    if vllm_config.kv_transfer_config and vllm_config.kv_transfer_config.pd_role:
+        from vllm.entrypoints.serve.pd_role.state import PDRoleState
+        from vllm.v1.engine.async_llm import AsyncLLM
+
+        if not isinstance(engine_client, AsyncLLM):
+            raise ValueError("Runtime P/D role switching requires AsyncLLM")
+        state.pd_role = PDRoleState(
+            vllm_config.kv_transfer_config.pd_role,
+            vllm_config.parallel_config.data_parallel_size,
+            engine_client.engine_core.call_utility_all_async,
+        )
     state.args = args
     resolved_chat_template = load_chat_template(args.chat_template)
     default_chat_template_kwargs = resolve_default_chat_template_kwargs(args)

--- a/vllm/entrypoints/launchers/api_server/routers.py
+++ b/vllm/entrypoints/launchers/api_server/routers.py
@@ -49,6 +49,10 @@ def register_api_routers(
 
         elastic_ep_attach_router(app)
 
+        from vllm.entrypoints.serve.pd_role.api_router import router as pd_role_router
+
+        app.include_router(pd_role_router)
+
     if "generate" in supported_tasks or "render" in supported_tasks:
         from vllm.entrypoints.scale_out.factories import register_scale_out_api_routers
 

--- a/vllm/entrypoints/launchers/cli_args.py
+++ b/vllm/entrypoints/launchers/cli_args.py
@@ -434,6 +434,14 @@ def validate_parsed_serve_args(args: argparse.Namespace):
     if hasattr(args, "subparser") and args.subparser not in ("serve", "launch"):
         return
 
+    kv_transfer_config = getattr(args, "kv_transfer_config", None)
+    if (
+        kv_transfer_config is not None
+        and kv_transfer_config.pd_role is not None
+        and (getattr(args, "grpc", False) or envs.VLLM_USE_RUST_FRONTEND)
+    ):
+        raise ValueError("Runtime P/D role switching requires the Python HTTP frontend")
+
     # Ensure that the chat template is valid; raises if it likely isn't
     validate_chat_template(args.chat_template)
 

--- a/vllm/entrypoints/serve/middleware/register.py
+++ b/vllm/entrypoints/serve/middleware/register.py
@@ -46,6 +46,10 @@ def init_entrypoints_middleware(
 
         app.add_middleware(ScalingMiddleware)
 
+        from vllm.entrypoints.serve.pd_role.middleware import PDRoleMiddleware
+
+        app.add_middleware(PDRoleMiddleware)
+
     if "realtime" in supported_tasks:
         # Add WebSocket metrics middleware
         from vllm.entrypoints.speech_to_text.realtime.metrics import (

--- a/vllm/entrypoints/serve/pd_role/__init__.py
+++ b/vllm/entrypoints/serve/pd_role/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/serve/pd_role/api_router.py
+++ b/vllm/entrypoints/serve/pd_role/api_router.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from .state import PDRole, PDRoleState
+
+router = APIRouter()
+
+
+class PDRoleRequest(BaseModel):
+    role: PDRole
+    expected_epoch: int = Field(ge=0)
+    drain_timeout: float = Field(default=120, gt=0, le=3600)
+
+
+def role_state(request: Request) -> PDRoleState:
+    state = getattr(request.app.state, "pd_role", None)
+    if state is None:
+        raise HTTPException(404, "Runtime P/D role switching is not enabled")
+    return state
+
+
+@router.get("/v1/pd_role")
+async def get_pd_role(request: Request):
+    return role_state(request).status()
+
+
+@router.post("/v1/pd_role")
+async def switch_pd_role(body: PDRoleRequest, request: Request):
+    state = role_state(request)
+    try:
+        state.start(body.role, body.expected_epoch, body.drain_timeout)
+    except ValueError as exc:
+        raise HTTPException(409, str(exc)) from exc
+    return JSONResponse(state.status(), status_code=202)

--- a/vllm/entrypoints/serve/pd_role/middleware.py
+++ b/vllm/entrypoints/serve/pd_role/middleware.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from starlette.datastructures import Headers
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from .state import PDRoleState
+
+
+class PDRoleMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        state: PDRoleState | None = getattr(scope["app"].state, "pd_role", None)
+        if state is None or scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope["path"].removeprefix(scope.get("root_path", ""))
+        if scope["method"] in ("GET", "HEAD", "OPTIONS") or path in (
+            "/v1/pd_role",
+            "/tokenize",
+            "/detokenize",
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        if path not in ("/v1/completions", "/v1/chat/completions"):
+            await JSONResponse(
+                {"error": "This endpoint is unsupported with runtime P/D switching"},
+                status_code=409,
+            )(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        if (
+            state.phase != "ready"
+            or headers.get("x-vllm-pd-role") != state.role
+            or headers.get("x-vllm-pd-epoch") != str(state.epoch)
+        ):
+            await JSONResponse(
+                {"error": "P/D admission rejected", **state.status()},
+                status_code=409,
+            )(scope, receive, send)
+            return
+
+        # No await between checking the fence and registering admission.
+        state.active_requests += 1
+        state.idle.clear()
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            state.active_requests -= 1
+            if state.active_requests == 0:
+                state.idle.set()

--- a/vllm/entrypoints/serve/pd_role/state.py
+++ b/vllm/entrypoints/serve/pd_role/state.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+
+PDRole = Literal["prefill", "decode"]
+
+
+class PDRoleState:
+    """Coordinate a drained role change across every engine behind one frontend."""
+
+    def __init__(
+        self,
+        role: PDRole,
+        num_engines: int,
+        call_all: Callable[..., Awaitable[list[dict[str, Any]]]],
+    ) -> None:
+        self.role = role
+        self.epoch = 0
+        self.phase = "ready"
+        self.active_requests = 0
+        self.idle = asyncio.Event()
+        self.idle.set()
+        self.num_engines = num_engines
+        self.call_all = call_all
+        self.task: asyncio.Task | None = None
+        self.error: str | None = None
+        self.target_role: PDRole | None = None
+        self.started_at: float | None = None
+        self.duration: float | None = None
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "epoch": self.epoch,
+            "phase": self.phase,
+            "target_role": self.target_role,
+            "active_requests": self.active_requests,
+            "error": self.error,
+            "transition_seconds": self.duration,
+        }
+
+    def start(self, role: PDRole, expected_epoch: int, timeout: float) -> None:
+        if self.phase != "ready":
+            raise ValueError("A role transition is already in progress or failed")
+        if self.role == role and expected_epoch in (self.epoch, self.epoch - 1):
+            return
+        if expected_epoch != self.epoch:
+            raise ValueError("Stale role epoch")
+        self.phase = "draining"
+        self.target_role = role
+        self.error = None
+        self.duration = None
+        self.started_at = time.monotonic()
+        # The operation outlives its HTTP caller, including caller disconnects.
+        self.task = asyncio.create_task(self._switch(role, expected_epoch, timeout))
+
+    def _check_ranks(
+        self, statuses: list[dict[str, Any]], role: PDRole, epoch: int
+    ) -> None:
+        if len(statuses) != self.num_engines or any(
+            s["role"] != role or s["epoch"] != epoch for s in statuses
+        ):
+            raise RuntimeError("Engine ranks disagree on the serving role or epoch")
+
+    async def _prepare_and_commit(self, role: PDRole, epoch: int) -> None:
+        # Keep stepping all accepted work, including requests still in
+        # HTTP preprocessing and requests waiting for scheduler capacity.
+        await self.idle.wait()
+        self.phase = "preparing"
+        statuses = await self.call_all("prepare_pd_role", role, epoch)
+        self._check_ranks(statuses, self.role, epoch)
+        while True:
+            statuses = await self.call_all("get_pd_role_status")
+            self._check_ranks(statuses, self.role, epoch)
+            if all(s["drained"] for s in statuses):
+                break
+            await asyncio.sleep(0.01)
+
+        self.phase = "committing"
+        statuses = await self.call_all("commit_pd_role", role, epoch)
+        self._check_ranks(statuses, role, epoch + 1)
+        self.role = role
+        self.epoch = epoch + 1
+        self.phase = "ready"
+
+    async def _switch(self, role: PDRole, epoch: int, timeout: float) -> None:
+        try:
+            await asyncio.wait_for(self._prepare_and_commit(role, epoch), timeout)
+        except Exception as exc:
+            prepared = self.phase == "preparing"
+            committing = self.phase == "committing"
+            self.error = f"{type(exc).__name__}: {exc}"
+            self.phase = "failed"
+            if not committing:
+                try:
+                    if prepared:
+                        statuses = await asyncio.wait_for(
+                            self.call_all("cancel_pd_role", epoch), timeout
+                        )
+                        self._check_ranks(statuses, self.role, epoch)
+                        if any(s["pending_role"] is not None for s in statuses):
+                            raise RuntimeError("Engine ranks are still fenced")
+                    self.phase = "ready"
+                except Exception as rollback_exc:
+                    self.error += f"; rollback failed: {rollback_exc}"
+            # A possibly partial commit remains fenced; never publish readiness.
+        finally:
+            assert self.started_at is not None
+            self.duration = time.monotonic() - self.started_at

--- a/vllm/entrypoints/serve/pd_role/state.py
+++ b/vllm/entrypoints/serve/pd_role/state.py
@@ -94,7 +94,7 @@ class PDRoleState:
             prepared = self.phase == "preparing"
             committing = self.phase == "committing"
             self.error = f"{type(exc).__name__}: {exc}"
-            self.phase = "failed"
+            self.phase = "failed" if committing else "rolling_back"
             if not committing:
                 try:
                     if prepared:
@@ -106,6 +106,7 @@ class PDRoleState:
                             raise RuntimeError("Engine ranks are still fenced")
                     self.phase = "ready"
                 except Exception as rollback_exc:
+                    self.phase = "failed"
                     self.error += f"; rollback failed: {rollback_exc}"
             # A possibly partial commit remains fenced; never publish readiness.
         finally:

--- a/vllm/entrypoints/serve/pd_role/state.py
+++ b/vllm/entrypoints/serve/pd_role/state.py
@@ -55,7 +55,7 @@ class PDRoleState:
         self.error = None
         self.duration = None
         self.started_at = time.monotonic()
-        # The operation outlives its HTTP caller, including caller disconnects.
+        # Keep the transition alive after caller disconnects.
         self.task = asyncio.create_task(self._switch(role, expected_epoch, timeout))
 
     def _check_ranks(
@@ -67,8 +67,7 @@ class PDRoleState:
             raise RuntimeError("Engine ranks disagree on the serving role or epoch")
 
     async def _prepare_and_commit(self, role: PDRole, epoch: int) -> None:
-        # Keep stepping all accepted work, including requests still in
-        # HTTP preprocessing and requests waiting for scheduler capacity.
+        # Finish admitted HTTP work before fencing engine requests.
         await self.idle.wait()
         self.phase = "preparing"
         statuses = await self.call_all("prepare_pd_role", role, epoch)
@@ -85,15 +84,16 @@ class PDRoleState:
         self._check_ranks(statuses, role, epoch + 1)
         self.role = role
         self.epoch = epoch + 1
-        self.phase = "ready"
 
     async def _switch(self, role: PDRole, epoch: int, timeout: float) -> None:
         try:
             await asyncio.wait_for(self._prepare_and_commit(role, epoch), timeout)
+            self.phase = "ready"
         except Exception as exc:
             prepared = self.phase == "preparing"
             committing = self.phase == "committing"
             self.error = f"{type(exc).__name__}: {exc}"
+            # Do not reopen admission after an uncertain commit.
             self.phase = "failed" if committing else "rolling_back"
             if not committing:
                 try:
@@ -108,7 +108,6 @@ class PDRoleState:
                 except Exception as rollback_exc:
                     self.phase = "failed"
                     self.error += f"; rollback failed: {rollback_exc}"
-            # A possibly partial commit remains fenced; never publish readiness.
         finally:
             assert self.started_at is not None
             self.duration = time.monotonic() - self.started_at

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -129,6 +129,12 @@ class EngineCore:
         self.log_stats = log_stats
         # Opaque weight version supplied by the caller.
         self._weight_version = "default"
+        kv_transfer_config = vllm_config.kv_transfer_config
+        self._pd_role: str | None = (
+            kv_transfer_config.pd_role if kv_transfer_config is not None else None
+        )
+        self._pd_role_epoch = 0
+        self._pending_pd_role: str | None = None
 
         # Setup Model.
         self.model_executor = executor_class(vllm_config)
@@ -447,6 +453,9 @@ class EngineCore:
         `request_wave`: indicate which wave of requests this is expected to
         belong to in DP case
         """
+        if self._rejects_pd_role_request(request):
+            raise ValueError("Request does not match the active P/D role")
+
         # Validate the request_id type.
         if not isinstance(request.request_id, str):
             raise TypeError(
@@ -875,6 +884,83 @@ class EngineCore:
     def is_scheduler_paused(self) -> bool:
         """Return whether the scheduler is in any pause state."""
         return self.scheduler.pause_state != PauseState.UNPAUSED
+
+    def get_pd_role_status(self) -> dict[str, Any]:
+        running, waiting = self.scheduler.get_request_counts()
+        pending_batches = len(self.batch_queue) if self.batch_queue else 0
+        # Unlike get_num_unfinished_requests(), these counts include queued
+        # streaming inputs. has_requests() also includes delayed connector frees.
+        drained = (
+            running == 0
+            and waiting == 0
+            and not self.scheduler.has_requests()
+            and pending_batches == 0
+        )
+        return {
+            "dp_rank": self.vllm_config.parallel_config.data_parallel_rank,
+            "role": self._pd_role,
+            "epoch": self._pd_role_epoch,
+            "pending_role": self._pending_pd_role,
+            "pending_epoch": (
+                self._pd_role_epoch + 1 if self._pending_pd_role is not None else None
+            ),
+            "running": running,
+            "waiting": waiting,
+            "pending_batches": pending_batches,
+            "drained": drained,
+        }
+
+    def prepare_pd_role(self, role: str, expected_epoch: int) -> dict[str, Any]:
+        if self._pd_role is None:
+            raise ValueError("P/D role switching was not enabled at startup")
+        if role not in ("prefill", "decode"):
+            raise ValueError(f"Invalid P/D role: {role}")
+        if expected_epoch != self._pd_role_epoch:
+            raise ValueError("Stale P/D role epoch")
+        if self.is_scheduler_paused():
+            raise ValueError("Cannot change P/D role while scheduling is paused")
+        if self._pending_pd_role not in (None, role):
+            raise ValueError("Another P/D role change is already prepared")
+        # Fence new adds without pausing the scheduler: existing requests and
+        # NIXL lease holders must continue through their normal completion path.
+        self._pending_pd_role = role
+        return self.get_pd_role_status()
+
+    def commit_pd_role(self, role: str, expected_epoch: int) -> dict[str, Any]:
+        if role not in ("prefill", "decode"):
+            raise ValueError(f"Invalid P/D role: {role}")
+        if (
+            self._pd_role == role
+            and self._pd_role_epoch == expected_epoch + 1
+            and self._pending_pd_role is None
+        ):
+            return self.get_pd_role_status()
+        if expected_epoch != self._pd_role_epoch or self._pending_pd_role != role:
+            raise ValueError("P/D role change does not match the prepared epoch")
+        if self.is_scheduler_paused() or not self.get_pd_role_status()["drained"]:
+            raise ValueError("P/D requests or KV transfers are still draining")
+        self._pd_role = role
+        self._pd_role_epoch += 1
+        self._pending_pd_role = None
+        return self.get_pd_role_status()
+
+    def cancel_pd_role(self, expected_epoch: int) -> dict[str, Any]:
+        if expected_epoch != self._pd_role_epoch:
+            raise ValueError("Cannot cancel a committed or stale P/D role epoch")
+        self._pending_pd_role = None
+        return self.get_pd_role_status()
+
+    def _rejects_pd_role_request(self, request: Request) -> bool:
+        if self._pd_role is None or request.abort_immediately:
+            return False
+        if self._pending_pd_role is not None:
+            return True
+        params = request.kv_transfer_params or {}
+        remote_decode = bool(params.get("do_remote_decode"))
+        remote_prefill = bool(params.get("do_remote_prefill"))
+        if remote_decode == remote_prefill:
+            return True
+        return self._pd_role != ("prefill" if remote_decode else "decode")
 
     def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None | Future:
         """Put the engine to sleep at the specified level.
@@ -1539,6 +1625,14 @@ class EngineCoreProc(EngineCore):
         elif request_type == EngineCoreRequestType.ADD:
             req, request_wave = request
             if self._reject_add_in_shutdown(req):
+                return
+            if self._rejects_pd_role_request(req):
+                if req.kv_transfer_params:
+                    # Run the connector's pre-admission cleanup hook so a
+                    # rejected decode does not strand its remote prefill KV.
+                    req.abort_immediately = True
+                    self.add_request(req, request_wave)
+                self._send_error_outputs_to_client([req.request_id], req.client_index)
                 return
             self.add_request(req, request_wave)
         elif request_type == EngineCoreRequestType.ABORT:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -888,8 +888,7 @@ class EngineCore:
     def get_pd_role_status(self) -> dict[str, Any]:
         running, waiting = self.scheduler.get_request_counts()
         pending_batches = len(self.batch_queue) if self.batch_queue else 0
-        # Unlike get_num_unfinished_requests(), these counts include queued
-        # streaming inputs. has_requests() also includes delayed connector frees.
+        # Include streaming-input waiters and delayed connector cleanup.
         drained = (
             running == 0
             and waiting == 0
@@ -921,8 +920,7 @@ class EngineCore:
             raise ValueError("Cannot change P/D role while scheduling is paused")
         if self._pending_pd_role not in (None, role):
             raise ValueError("Another P/D role change is already prepared")
-        # Fence new adds without pausing the scheduler: existing requests and
-        # NIXL lease holders must continue through their normal completion path.
+        # Keep accepted requests and KV cleanup running while new adds are fenced.
         self._pending_pd_role = role
         return self.get_pd_role_status()
 
@@ -1628,8 +1626,7 @@ class EngineCoreProc(EngineCore):
                 return
             if self._rejects_pd_role_request(req):
                 if req.kv_transfer_params:
-                    # Run the connector's pre-admission cleanup hook so a
-                    # rejected decode does not strand its remote prefill KV.
+                    # Release remote prefill KV owned by the rejected request.
                     req.abort_immediately = True
                     self.add_request(req, request_wave)
                 self._send_error_outputs_to_client([req.request_id], req.client_index)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1615,8 +1615,7 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         )[0]
 
     async def call_utility_all_async(self, method: str, *args) -> list[Any]:
-        # Wait for every rank before reporting a failed mutation, so its caller
-        # can safely query or cancel a partially prepared transaction.
+        # Wait for every rank before the caller can roll back a partial prepare.
         results = await asyncio.gather(
             *[
                 self._call_utility_async(method, *args, engine=engine)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -264,6 +264,10 @@ class EngineCoreClient(ABC):
     async def get_supported_tasks_async(self) -> tuple[SupportedTask, ...]:
         raise NotImplementedError
 
+    async def call_utility_all_async(self, method: str, *args) -> list[Any]:
+        """Call a utility on every managed engine and return all results."""
+        raise NotImplementedError
+
     async def add_request_async(self, request: EngineCoreRequest) -> None:
         raise NotImplementedError
 
@@ -1199,6 +1203,9 @@ class AsyncMPClient(MPClient):
     async def call_utility_async(self, method: str, *args) -> Any:
         return await self._call_utility_async(method, *args, engine=self.core_engine)
 
+    async def call_utility_all_async(self, method: str, *args) -> list[Any]:
+        return [await self._call_utility_async(method, *args, engine=self.core_engine)]
+
     async def _call_utility_async(
         self, method: str, *args, engine: EngineIdentity
     ) -> Any:
@@ -1606,6 +1613,21 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                 ]
             )
         )[0]
+
+    async def call_utility_all_async(self, method: str, *args) -> list[Any]:
+        # Wait for every rank before reporting a failed mutation, so its caller
+        # can safely query or cancel a partially prepared transaction.
+        results = await asyncio.gather(
+            *[
+                self._call_utility_async(method, *args, engine=engine)
+                for engine in self.core_engines
+            ],
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+        return results
 
     @staticmethod
     async def process_engine_outputs(


### PR DESCRIPTION
Related to #56133 and #43807.

Adds opt-in switching of a running EP group between prefill and decode. The router stops new assignments; vLLM drains accepted work and retained KV, commits the role on every core, then publishes readiness at the next epoch. Workers, weights, communicators, and CUDA graphs stay resident while other groups keep serving.

The initial scope is NIXL pull transfer, one Python frontend, and internal DP load balancing. EP membership and the communication backend remain fixed.

## Tests

- Final revision `69e0448`: 66 control, frontend, and CLI tests passed. The Python 3.11 readiness regression fails before the fix and passes after it.
- GPU prototype: 6 H100 80GB GPUs, three EP2 groups, OLMoE, DeepSeek-V2-Lite, and Qwen3-30B-A3B. All 60 switches and 3,060 requests passed with matching reference outputs and unchanged process, graph, and communication identities. Held-KV timeout recovery and stale-epoch rejection passed.

[Validation and commands](https://github.com/Etelis/vllm/blob/ff89426a0d23b0d5509e50d0bfa69a36d0174459/VALIDATION.md) distinguish the final checks from the GPU build, which includes a separate unmerged Triton MoE fix. EP16 and multi-node operation remain untested.
