### PR TITLE
[Bugfix][Spec Decode] Ladder cudagraph candidates per uniform query length

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -28,11 +28,14 @@ def _create_vllm_config_for_dsd(
     cudagraph_mode: str = "FULL_AND_PIECEWISE",
     use_dynamic_sd: bool = True,
     num_spec_per_batch_size: list[tuple[int, int, int]] | None = None,
+    cudagraph_capture_sizes: list[int] | None = None,
 ) -> MagicMock:
     """Create a minimal config that exercises DSD cudagraph dispatch.
 
-    The test uses an exact capture-size grid so that every valid uniform decode
-    shape has a directly matching FULL graph candidate.
+    By default the test uses an exact capture-size grid so that every valid
+    uniform decode shape has a directly matching FULL graph candidate.
+    ``cudagraph_capture_sizes`` overrides that with an explicit ladder, which
+    is what a served config actually gets.
 
     ``num_spec_per_batch_size`` lets a test supply an explicit DSD schedule of
     ``(range_start, range_end, num_speculative_tokens)`` tuples. When omitted,
@@ -41,11 +44,15 @@ def _create_vllm_config_for_dsd(
     """
 
     max_decode_query_len = max_spec_tokens + 1
-    max_capture_tokens = max_num_seqs * max_decode_query_len
+    if cudagraph_capture_sizes is None:
+        cudagraph_capture_sizes = list(
+            range(1, max_num_seqs * max_decode_query_len + 1)
+        )
+    max_capture_tokens = cudagraph_capture_sizes[-1]
 
     compilation_config = CompilationConfig(
         cudagraph_mode=cudagraph_mode,
-        cudagraph_capture_sizes=list(range(1, max_capture_tokens + 1)),
+        cudagraph_capture_sizes=cudagraph_capture_sizes,
     )
     compilation_config.max_cudagraph_capture_size = max_capture_tokens
     compilation_config.post_init_cudagraph_sizes()
@@ -431,4 +438,81 @@ def test_dynamic_sd_only_captures_scheduled_query_lengths(monkeypatch):
                 assert desc.uniform_token_count is None
                 assert desc.num_tokens == num_tokens
                 assert desc.num_reqs is None
+            assert desc.num_active_loras == 0
+
+
+def test_dynamic_sd_tier_is_not_shadowed_on_a_strided_capture_ladder(monkeypatch):
+    """A tier's decode batch must not be shadowed by another tier's graph.
+
+    Candidate ranges are laddered per uniform_token_count. The other tests here
+    pin an exact capture-size grid, where every uniform decode shape is captured
+    outright; a served config gets a strided ladder instead, so the nearest
+    captured size for one tier's batch often belongs to a different tier. With
+    a shared ladder that batch reaches only the other tier's descriptor, fails
+    the uniform_token_count check in _is_compatible, and drops to the mixed
+    PIECEWISE graph -- paying eager attention every decode step even though a
+    FULL decode graph for its own query length was captured and is wide enough
+    to serve it after request padding.
+    """
+
+    max_num_seqs = 128
+    max_spec_tokens = 6
+    max_decode_query_len = max_spec_tokens + 1
+    # (range_start, range_end, num_speculative_tokens): query lengths 7, 5, 4.
+    schedule = [(1, 8, 6), (9, 32, 4), (33, 128, 3)]
+    # The strided ladder a default config builds: 1, 2, 4, then step 8, then 16.
+    capture_sizes = sorted({1, 2, 4} | set(range(8, 256, 8)) | set(range(256, 513, 16)))
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=max_num_seqs,
+        max_spec_tokens=max_spec_tokens,
+        num_spec_per_batch_size=schedule,
+        cudagraph_capture_sizes=capture_sizes,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=max_decode_query_len,
+    )
+    manager._graphs_captured = True
+
+    captured = manager._capture_descs[CUDAGraphMode.FULL]
+    for range_start, range_end, num_spec in schedule:
+        query_len = num_spec + 1
+        for num_reqs in range(range_start, range_end + 1):
+            num_tokens = num_reqs * query_len
+            # Only assert on shapes this config actually captured a graph for;
+            # the ladder's ceiling is a separate concern.
+            servable = [
+                desc
+                for desc in captured
+                if desc.uniform_token_count == query_len
+                and desc.num_reqs >= num_reqs
+                and desc.num_tokens >= num_tokens
+            ]
+            if not servable:
+                continue
+
+            desc = manager.dispatch(
+                num_reqs=num_reqs,
+                num_tokens=num_tokens,
+                uniform_token_count=query_len,
+                num_active_loras=0,
+            )
+
+            assert desc.cg_mode == CUDAGraphMode.FULL, (
+                f"{num_reqs} requests at query length {query_len} "
+                f"({num_tokens} tokens) fell back to {desc.cg_mode} despite "
+                f"{len(servable)} captured FULL graphs able to serve it"
+            )
+            assert desc.uniform_token_count == query_len
+            assert desc.num_tokens >= num_tokens
+            assert desc.num_reqs >= num_reqs
             assert desc.num_active_loras == 0

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -330,15 +330,25 @@ class CudaGraphManager:
                 lora_descs = [
                     d for d in mode_descs if d.num_active_loras == num_active_loras
                 ]
-                current_range_start = 0
-                # Dynamic speculative decoding can produce multiple graphs with the same
-                # num_tokens. Group them so each graph covers the same candidate range.
-                for num_tokens, group in groupby(lora_descs, lambda d: d.num_tokens):
-                    matching = list(group)
-                    for i in range(current_range_start, num_tokens + 1):
-                        key = (i, num_active_loras)
-                        self._candidates.setdefault(key, []).extend(matching)
-                    current_range_start = num_tokens + 1
+                # A descriptor only serves a matching uniform_token_count, so
+                # each one needs its own ladder: dynamic SD puts several in a
+                # mode, and a shared ladder lets the nearest graph belong to
+                # another tier and shadow the one that fits.
+                by_token_count: defaultdict[
+                    int | None, list[BatchExecutionDescriptor]
+                ] = defaultdict(list)
+                for desc in lora_descs:
+                    by_token_count[desc.uniform_token_count].append(desc)
+                for token_count_descs in by_token_count.values():
+                    current_range_start = 0
+                    for num_tokens, group in groupby(
+                        token_count_descs, lambda d: d.num_tokens
+                    ):
+                        matching = list(group)
+                        for i in range(current_range_start, num_tokens + 1):
+                            key = (i, num_active_loras)
+                            self._candidates.setdefault(key, []).extend(matching)
+                        current_range_start = num_tokens + 1
 
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0


### PR DESCRIPTION
## Purpose

Under dynamic speculative decoding, decode batches that have a captured FULL decode
graph can still be dispatched to the mixed PIECEWISE graph, running attention eagerly
on the decode critical path every step. The graph is captured, holds memory, and is
never replayed.

This is the same failure #53407 fixed one level up. That PR made a uniform decode batch
pad up into a larger FULL graph instead of falling to PIECEWISE, by giving the FULL and
PIECEWISE descriptors separate candidate ladders. Dynamic SD puts **several** FULL
descriptors in that one ladder — one per scheduled query length — and they shadow each
other the same way.

**Mechanism.** `_init_candidates` assigns candidate ranges by walking descriptors in
ascending `num_tokens` and giving every token count up to that level the descriptors at
that level. Compatibility, however, is partitioned by `uniform_token_count`. With one
query length those agree. With a DSD schedule they do not: the nearest captured level
for one tier's batch frequently belongs to a different tier, so `_is_compatible` rejects
it and the batch takes the PIECEWISE descriptor sitting at the same key.

**Worked example** — schedule `[[1,8,6],[9,32,4],[33,128,3]]`, `max_num_seqs=128`,
`num_speculative_tokens=6`. A 9-request decode batch runs at K=4, i.e. query length 5,
45 tokens:

```text
candidates[(45, 0)]      FULL  num_tokens=48  num_reqs=12  uniform_token_count=4   <- rejected
                         PIECEWISE  num_tokens=48  num_reqs=None                   <- taken
smallest captured FULL graph with uniform_token_count=5 able to serve it:
                         num_tokens=50  num_reqs=10                              <- unreachable
```

42 captured FULL graphs for query length 5 are wide enough to serve this batch, the
smallest of them padding 9 requests to 10. Dispatch never sees any of them, because 48
is the nearest captured level and 48 belongs to the K=3 tier.

## Fix

Ladder the candidate ranges per `uniform_token_count`. Descriptors that constrain no
token count (PIECEWISE, varlen decode) keep their own ladder as before, so the
non-speculative and static-K paths are untouched.

The captured graph set does not change — this only affects which already-captured graph
dispatch can reach.

## Measurement

Batch sizes that dispatch to a FULL decode graph, out of those for which a captured FULL
graph of the right query length and width exists. Batches above the capture ceiling are
excluded; that ceiling is a separate, documented concern.

| schedule | `max_num_seqs` | `num_speculative_tokens` | on a FULL decode graph, before | after |
|---|---|---|---|---|
| `[[1,8,6],[9,32,4],[33,128,3]]` | 128 | 6 | 101 / 128 | 128 / 128 |
| `[[1,16,5],[17,64,3],[65,256,1]]` | 256 | 5 | 212 / 256 | 256 / 256 |
| `[[1,32,4],[33,128,2]]` | 128 | 4 | 103 / 128 | 128 / 128 |
| `[[1,32,7],[33,128,5],[129,512,2]]` | 512 | 7 | 85 / 124 | 124 / 124 |
| `[[1,16,2],[17,64,1]]` | 64 | 2 | 55 / 64 | 64 / 64 |
| `[[1,64,3],[65,128,1],[129,256,0]]` | 256 | 3 | 256 / 256 | 256 / 256 |

The last row is a schedule whose query lengths happen to divide the ladder cleanly; it
was already fully covered and is unchanged, which is the intended no-op case.

Across those six schedules, **no batch that already reached a FULL graph gets a
different descriptor.** The change is additive at dispatch: it only recovers batches
that were falling back.

The first row is the schedule shape reported in use in #48494:
`[[1,8,6],[9,32,4],[33,128,3]]` with `max_num_seqs=128` and an MTP speculator.

## Test Plan

```bash
pytest -q tests/v1/spec_decode/test_dynamic_sd_cug.py
```

New test `test_dynamic_sd_tier_is_not_shadowed_on_a_strided_capture_ladder`. The existing
tests in that file pin `cudagraph_capture_sizes` to an exact grid
(`range(1, max_num_seqs * decode_query_len + 1)`), where every uniform decode shape is
captured outright and no shadowing is possible; the new test supplies the strided ladder
a served config actually builds. `_create_vllm_config_for_dsd` grows an optional
`cudagraph_capture_sizes` argument, defaulting to the existing grid, so the other tests
are unaffected.

The test asserts only on shapes the config actually captured a servable graph for, so it
does not encode the capture ceiling.

## Test Result

The test's assertion was evaluated against both versions of `_init_candidates` by
executing the file's own source in isolation (the schedule builder and the candidate/
dispatch logic have no GPU dependency):

```text
main    : 27 of 128 batch sizes have a captured FULL graph but dispatch to PIECEWISE
patched : 0
```

with the same result on the other five schedules in the table above.

I could not run `pytest` locally: this machine has no CUDA and no vLLM build, so the
import chain in the test module does not resolve here. CI is the first full run of the
test as written. The behavioural claims above come from executing the unmodified and
modified `_init_candidates`, `_is_compatible` and `dispatch` source directly; the harness
reproduces #53407's own worked example (`decode_query_len=3`, sizes `[1,2,4,8,16,24]`,
4 requests / 12 tokens dispatching to the size-18 FULL graph) as a control.

No throughput numbers: I have no hardware to measure the recovered graphs on. The claim
here is a dispatch-coverage claim, not a speedup claim.

## Not a duplicate

Searched open PRs for `cudagraph`, `speculative`, `uniform_token_count` and
`_init_candidates`. The nearby ones do something else:

- #53407 (merged) — separated the FULL and PIECEWISE ladders. This PR is its follow-up
  for the multiple query lengths dynamic SD puts inside the FULL ladder.
- #47737 — skips `K=0` entries so `decode_query_len=0` cannot divide by zero. Different
  defect, and it predates the current `build_dynamic_sd_schedule_lookup` shape.
- #55004, #46324, #37865 — capture *sizing*; this PR changes no sizes.
- #50885, #43114, #53410 — attention backend and speculator-side changes.

## Correctness note

Dispatching a batch to a wider FULL graph of the same query length pads requests, which
is the mechanism #53407 introduced and `_is_compatible` already sanctions
(`desc.num_reqs >= num_reqs and desc.num_tokens >= num_tokens`). No new shape is replayed
that was not already replayable; the graphs involved were captured for exactly this
query length. Model outputs are unaffected, so no accuracy evaluation applies.

---

AI assistance was used for this change: the defect was found by executing the upstream
candidate-init and dispatch logic over DSD schedules, and the patch and test were drafted
with an AI assistant. I reviewed every changed line and am able to defend the change.
