### PR TITLE
[Bugfix] Pin EPLB and MLA host-to-device transfer buffers

### DIFF
--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -35,9 +35,11 @@ def test_gloo_receive_staging_does_not_force_gpu_sync(monkeypatch):
     gsd._install_copy_checkers()
     monkeypatch.setattr(eplb_comm, "is_local_first_rank", lambda: False)
 
-    def receive(ops):
-        for op in ops:
-            op.tensor.fill_(7)
+    monkeypatch.setattr(eplb_comm, "P2POp", lambda op, tensor, peer, group: tensor)
+
+    def receive(tensors):
+        for tensor in tensors:
+            tensor.fill_(7)
         return []
 
     monkeypatch.setattr(eplb_comm, "batch_isend_irecv", receive)

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -32,6 +32,7 @@ def test_gloo_receive_staging_does_not_force_gpu_sync(monkeypatch):
     """Gloo receives must reach the GPU without an implicit pageable copy."""
     monkeypatch.setattr(gsd, "_SYNC_CHECK_MODE", "error")
     monkeypatch.setattr(gsd, "_sync_check_enabled", True)
+    gsd._install_copy_checkers()
     monkeypatch.setattr(eplb_comm, "is_local_first_rank", lambda: False)
 
     def receive(ops):

--- a/tests/distributed/test_eplb_execute.py
+++ b/tests/distributed/test_eplb_execute.py
@@ -7,6 +7,8 @@ import pytest
 import torch
 import torch.distributed
 
+import vllm.distributed.eplb.eplb_communicator as eplb_comm
+import vllm.utils.gpu_sync_debug as gsd
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.eplb.eplb_communicator import (
     create_eplb_communicator,
@@ -23,6 +25,26 @@ from vllm.distributed.parallel_state import (
 )
 
 from .eplb_utils import distributed_run, set_env_vars_and_device
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_gloo_receive_staging_does_not_force_gpu_sync(monkeypatch):
+    """Gloo receives must reach the GPU without an implicit pageable copy."""
+    monkeypatch.setattr(gsd, "_SYNC_CHECK_MODE", "error")
+    monkeypatch.setattr(gsd, "_sync_check_enabled", True)
+    monkeypatch.setattr(eplb_comm, "is_local_first_rank", lambda: False)
+
+    def receive(ops):
+        for op in ops:
+            op.tensor.fill_(7)
+        return []
+
+    monkeypatch.setattr(eplb_comm, "batch_isend_irecv", receive)
+    communicator = eplb_comm.TorchDistGlooStagedEplbCommunicator(cpu_group=None)
+    dst = torch.empty(32, device="cuda")
+    communicator.add_recv([dst], src_rank=1, expert_id=0)
+    gsd.with_gpu_sync_check(communicator.execute)()
+    torch.testing.assert_close(dst.cpu(), torch.full((32,), 7.0))
 
 
 def create_expert_indices_with_redundancy(

--- a/tests/v1/attention/test_mla_context_chunks.py
+++ b/tests/v1/attention/test_mla_context_chunks.py
@@ -8,6 +8,8 @@ chunk never covers a prefill without context (which is why the partial no
 longer needs an empty-span masking pass).
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -16,6 +18,9 @@ from vllm.model_executor.layers.attention.mla_attention import (
     build_mla_chunked_context_metadata,
     init_mla_context_partial,
     reorg_kvcache,
+)
+from vllm.model_executor.layers.attention.sparse_mla_attention import (
+    SparseMLACommonMetadataBuilder,
 )
 
 BLOCK_SIZE = 16
@@ -28,7 +33,6 @@ def build_chunked_context(
     block_size: int = BLOCK_SIZE,
     dcp_world_size: int = 1,
     dcp_local_block_size: int = 1,
-    device: str = "cpu",
 ):
     query_start_loc = torch.zeros(len(query_lens) + 1, dtype=torch.int32)
     query_start_loc[1:] = torch.tensor(query_lens, dtype=torch.int32).cumsum(0)
@@ -40,7 +44,7 @@ def build_chunked_context(
         chunked_prefill_workspace_size=workspace_size,
         block_size=block_size,
         align_chunk_to_block=True,
-        device=torch.device(device),
+        device=torch.device("cpu"),
         dcp_world_size=dcp_world_size,
         dcp_local_block_size=dcp_local_block_size,
         dcp_virtual_block_size=dcp_local_block_size * dcp_world_size,
@@ -48,13 +52,33 @@ def build_chunked_context(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_pageable_context_lengths_do_not_force_gpu_sync(monkeypatch):
-    """Sparse MLA supplies pageable context lengths to the shared builder."""
+def test_sparse_context_lengths_do_not_force_gpu_sync(monkeypatch):
+    """Sparse MLA must pin computed context lengths before the H2D copy."""
+    builder = SimpleNamespace(
+        chunked_prefill_workspace=torch.empty((2048, 1)),
+        chunked_prefill_workspace_size=1024,
+        kv_cache_spec=SimpleNamespace(block_size=BLOCK_SIZE),
+        device=torch.device("cuda"),
+        dcp_world_size=1,
+        dcp_local_block_size=1,
+        dcp_virtual_block_size=1,
+        dcp_manager=None,
+    )
+    common_metadata = SimpleNamespace(
+        seq_lens_cpu_upper_bound=torch.tensor([17, 2052, 324], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1, 5, 9], dtype=torch.int32),
+    )
     monkeypatch.setattr(gsd, "_SYNC_CHECK_MODE", "error")
     monkeypatch.setattr(gsd, "_sync_check_enabled", True)
     gsd._install_copy_checkers()
-    metadata = gsd.with_gpu_sync_check(build_chunked_context)(
-        [2048, 320], [4, 4], 1024, device="cuda"
+    metadata = gsd.with_gpu_sync_check(
+        SparseMLACommonMetadataBuilder._build_chunked_context_fields
+    )(
+        builder,
+        common_metadata,
+        num_decodes=1,
+        num_prefills=2,
+        prefill_query_lens_cpu=torch.tensor([4, 4], dtype=torch.int32),
     )
     assert metadata is not None
     assert metadata.context_lens.device.type == "cuda"

--- a/tests/v1/attention/test_mla_context_chunks.py
+++ b/tests/v1/attention/test_mla_context_chunks.py
@@ -52,6 +52,7 @@ def test_pageable_context_lengths_do_not_force_gpu_sync(monkeypatch):
     """Sparse MLA supplies pageable context lengths to the shared builder."""
     monkeypatch.setattr(gsd, "_SYNC_CHECK_MODE", "error")
     monkeypatch.setattr(gsd, "_sync_check_enabled", True)
+    gsd._install_copy_checkers()
     metadata = gsd.with_gpu_sync_check(build_chunked_context)(
         [2048, 320], [4, 4], 1024, device="cuda"
     )

--- a/tests/v1/attention/test_mla_context_chunks.py
+++ b/tests/v1/attention/test_mla_context_chunks.py
@@ -11,6 +11,7 @@ longer needs an empty-span masking pass).
 import pytest
 import torch
 
+import vllm.utils.gpu_sync_debug as gsd
 from vllm.model_executor.layers.attention.mla_attention import (
     build_mla_chunked_context_metadata,
     init_mla_context_partial,
@@ -27,6 +28,7 @@ def build_chunked_context(
     block_size: int = BLOCK_SIZE,
     dcp_world_size: int = 1,
     dcp_local_block_size: int = 1,
+    device: str = "cpu",
 ):
     query_start_loc = torch.zeros(len(query_lens) + 1, dtype=torch.int32)
     query_start_loc[1:] = torch.tensor(query_lens, dtype=torch.int32).cumsum(0)
@@ -38,11 +40,24 @@ def build_chunked_context(
         chunked_prefill_workspace_size=workspace_size,
         block_size=block_size,
         align_chunk_to_block=True,
-        device=torch.device("cpu"),
+        device=torch.device(device),
         dcp_world_size=dcp_world_size,
         dcp_local_block_size=dcp_local_block_size,
         dcp_virtual_block_size=dcp_local_block_size * dcp_world_size,
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_pageable_context_lengths_do_not_force_gpu_sync(monkeypatch):
+    """Sparse MLA supplies pageable context lengths to the shared builder."""
+    monkeypatch.setattr(gsd, "_SYNC_CHECK_MODE", "error")
+    monkeypatch.setattr(gsd, "_sync_check_enabled", True)
+    metadata = gsd.with_gpu_sync_check(build_chunked_context)(
+        [2048, 320], [4, 4], 1024, device="cuda"
+    )
+    assert metadata is not None
+    assert metadata.context_lens.device.type == "cuda"
+    assert metadata.context_lens.tolist() == [2048, 320]
 
 
 @pytest.mark.parametrize(

--- a/vllm/distributed/eplb/eplb_communicator.py
+++ b/vllm/distributed/eplb/eplb_communicator.py
@@ -34,6 +34,7 @@ from vllm.distributed.utils import is_weak_contiguous
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+from vllm.utils.torch_utils import PIN_MEMORY
 
 logger = init_logger(__name__)
 
@@ -204,7 +205,9 @@ class TorchDistGlooStagedEplbCommunicator(EplbCommunicator):
                         )
                     )
                     continue
-                cpu_tensor = torch.empty_like(tensor, device="cpu")
+                cpu_tensor = torch.empty_like(
+                    tensor, device="cpu", pin_memory=PIN_MEMORY
+                )
                 p2p_ops.append(
                     P2POp(
                         torch.distributed.irecv,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1966,6 +1966,8 @@ def build_mla_chunked_context_metadata(
     context_lens = context_lens_cpu.tolist()
     if max(context_lens, default=0) <= 0:
         return None
+    if PIN_MEMORY and not context_lens_cpu.is_pinned():
+        context_lens_cpu = context_lens_cpu.pin_memory()
 
     # The `gather_and_maybe_dequant_cache` kernel cannot handle chunk starts
     # that are not aligned to block_size, so a split request advances in

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1966,8 +1966,6 @@ def build_mla_chunked_context_metadata(
     context_lens = context_lens_cpu.tolist()
     if max(context_lens, default=0) <= 0:
         return None
-    if PIN_MEMORY and not context_lens_cpu.is_pinned():
-        context_lens_cpu = context_lens_cpu.pin_memory()
 
     # The `gather_and_maybe_dequant_cache` kernel cannot handle chunk starts
     # that are not aligned to block_size, so a split request advances in

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -28,7 +28,11 @@ from vllm.model_executor.layers.attention.mla_attention import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.flashinfer import has_flashinfer
-from vllm.utils.torch_utils import is_quantized_kv_cache, np_to_pinned_tensor
+from vllm.utils.torch_utils import (
+    PIN_MEMORY,
+    is_quantized_kv_cache,
+    np_to_pinned_tensor,
+)
 from vllm.v1.attention.backend import AttentionMetadata, AttentionMetadataBuilder
 from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
@@ -241,9 +245,13 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
 
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
         assert seq_lens_cpu is not None
-        context_lens_cpu = (
-            seq_lens_cpu[num_decodes : num_decodes + num_prefills]
-            - prefill_query_lens_cpu
+        context_lens_cpu = torch.empty(
+            num_prefills, dtype=seq_lens_cpu.dtype, pin_memory=PIN_MEMORY
+        )
+        torch.subtract(
+            seq_lens_cpu[num_decodes : num_decodes + num_prefills],
+            prefill_query_lens_cpu,
+            out=context_lens_cpu,
         )
         qsl_cpu = common_attn_metadata.query_start_loc_cpu
         prefill_query_start_loc_cpu = qsl_cpu[num_decodes:] - qsl_cpu[num_decodes]


### PR DESCRIPTION
Main CI build 87842 fails both Qwen3 Sync EPLB accuracy jobs and the TP1/PCP4 evaluation when strict GPU synchronization checks detect nonblocking H2D copies from pageable CPU memory.

Pin Gloo receive staging buffers and allocate sparse MLA context lengths directly in pinned CPU memory with torch.subtract(out=...), matching the dense MLA caller. Preserve the strict checks. Add focused CUDA regressions that exercise the actual transfers and verify the copied values.

Duplicate check: searched open PRs for EPLB/pinned, unpinned, context_lens_cpu, and the failure signatures. No existing PR fixes these two transfers. PCP still separately needs #55879 for autotuning memory and #55499 for FlashInfer ragged-prefill synchronization; this PR does not duplicate them.

Current revision (`a9f8512c0c`), addressing Lucas Wilkinson's review:
- Moved pinning to the sparse MLA source and removed the helper-level fallback.
- Updated the CUDA regression to exercise the sparse caller with a decode followed by two prefills under strict GPU sync checking.
- Pre-commit checks passed for all three revised files (including mypy). Local runtime tests could not run: this checkout's available local environment has no torch/CUDA.
- Exact-revision attention CI passed: https://buildkite.com/vllm/ci/builds/88262 — image build and both H100 V1 Attention shards passed at a9f8512c0cb64125e1bdc5a1bf5e85eadfe95fac.

Earlier-revision validation (does not validate the review update above):
- `pre-commit run --files vllm/distributed/eplb/eplb_communicator.py vllm/model_executor/layers/attention/mla_attention.py tests/distributed/test_eplb_execute.py tests/v1/attention/test_mla_context_chunks.py`: passed.
- H100 and B200 Qwen3 Sync EPLB accuracy passed in https://buildkite.com/vllm/ci/builds/87891 . H100 high-throughput/low-latency: 0.925/0.895; B200: 0.895/0.920 (all require 0.8). The tested production patch is 4a92099c21; later commits only finalize regression-test setup.
- Finalized regressions passed in combined build https://buildkite.com/vllm/ci/builds/87893 at a2c24ba1b09ee698e7ffa8ce6402ac8435221ede: `pytest -v -s v1/attention/test_mla_context_chunks.py` — 13 passed; `pytest -v -s distributed/test_eplb_execute.py` — 24 passed, 7 skipped. All three `test_eplb_spec_decode.py` cases skipped under their existing conditions.
- Full PCP model evaluations passed in the same combined build: TP2/PCP2 GSM8K 0.9060 and TP1/PCP4 0.9386 (minimum accepted 0.82). This validates this patch together with #55879 and #55499, not this patch alone. The combined branch adds those two existing fixes and an MLA test command; it is not proposed as another PR.
- Standalone build 87891 is not green overall: its old regression-test setup failed before the latest test-only correction, and its PCP job lacks #55879/#55499. Both standalone accuracy jobs and all finalized combined validation passed. No failures were suppressed and strict synchronization checking remained enabled.

AI assistance: implemented and validated with OpenAI Codex. The human submitter confirmed review of these changes and authorized PR submission. Test results above identify the automated validation performed.


