### PR TITLE
[Test] Use real NVFP4 weights for sequence-parallel correctness

### DIFF
--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -394,7 +394,8 @@ def test_tp_sp_nvfp4_generation(num_gpus_available: int):
         "auto",
         SPTestOptions(
             multi_node_only=False,
-            load_format="dummy",
+            # Dummy loading leaves packed integer NVFP4 weights uninitialized.
+            load_format="auto",
             model_info=NVFP4_MODEL_INFO,
         ),
         num_gpus_available,


### PR DESCRIPTION
The B200 Sequence Parallel Correctness job compares two independently started NVFP4 servers, but its dummy loader leaves the packed uint8 weights uninitialized on CUDA. Main build 87842 produced different streaming output in `test_tp_sp_nvfp4_generation`.

Load the actual `nvidia/Llama-3.1-8B-Instruct-NVFP4` checkpoint for this test. This avoids both the uninitialized packed weights and the dummy-only model downsizing, while preserving the existing sequence-parallel settings and exact output assertions.

Duplicate check: searched open PRs for the exact test name and NVFP4 sequence-parallel/dummy-weight failures; no matching fix found.

Validation: all applicable pre-commit hooks passed. Exact-head B200 suite build https://buildkite.com/vllm/ci/builds/87894 PASSED: `pytest -v -s tests/compile/correctness_e2e/test_sequence_parallel.py` — 4 passed in 1182.74 seconds (19m42s), including the corrected NVFP4 test. Logs confirm both NVFP4 servers use `load_format=auto`. Exact validated commit: `9c3a1593c38b3c020c8a609d611a384f2162b13d`.

The unchanged original main job passed on retry (4 passed in 19m20s): https://buildkite.com/vllm/ci/builds/87842#01a085a3-9f60-484f-8c8b-8dc05a937c90 . The original failure is intermittent; this retry does not establish that uninitialized dummy weights are safe.

AI assistance: implemented and validated with OpenAI Codex. The human submitter confirmed review of these changes and authorized PR submission. Test results above identify the automated validation performed.
