### PR TITLE
[Bugfix] Tolerate misspelled DSML tool_calls wrapper

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -1363,7 +1363,14 @@ class TestMalformedDsmlNoise:
         tokens = [
             (900, wrapper) if tid == start_id else (tid, text) for tid, text in tokens
         ]
-        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        # Only the think markers are single tokens in the real
+        # DeepSeek-V4-Flash vocab; the DSML wrappers are ordinary text and
+        # must be matched by the lexer. Mirror that here.
+        vocab = {
+            DSML_THINK_START: _DSV4_FULL_VOCAB[DSML_THINK_START],
+            DSML_THINK_END: _DSV4_FULL_VOCAB[DSML_THINK_END],
+        }
+        tokenizer = MockTokenizer(vocab=vocab, tokens=tokens)
         parser = _DeepSeekV4Delegating(
             tokenizer, chat_template_kwargs={"thinking": True}
         )

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -1297,19 +1297,57 @@ class TestMalformedDsmlNoise:
         )
         assert [tc.function.name for tc in result.tool_calls] == ["get_weather"]
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Fullwidth bars, DSML namespace, but not a registered spelling.
+            "see <｜DSML｜foo> and <｜DSML｜tool_call> here",
+            # Unclosed prefix.
+            "see <｜DSML｜ here\nnext line",
+            # ASCII pipes are not the DSML sigil.
+            "see <|DSML|tool> and <|DSML|toolcalls> there",
+        ],
+    )
     def test_unregistered_markup_is_ordinary_content(
-        self, mock_tokenizer, mock_request
+        self, mock_tokenizer, mock_request, text
     ):
         """Only the registered spellings are treated as wrappers."""
-        text = "see <｜DSML｜ here and <|DSML|tool> there\nnext line"
-
         result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+        assert result.tools_called is False
         assert result.content == text
 
         results = simulate_tool_streaming(
             self._parser(mock_tokenizer), mock_request, list(text)
         )
         assert collect_content(results) == text
+
+    @pytest.mark.parametrize("wrapper", _WRAPPER_VARIANTS)
+    def test_prose_mention_matches_canonical_wrapper(
+        self, mock_tokenizer, mock_request, wrapper
+    ):
+        """A registered spelling mentioned in prose behaves exactly like a
+        prose mention of the real wrapper: the opener starts a tool block and
+        the rest of the message is dropped. That is pre-existing behavior of
+        ``<｜DSML｜tool_calls>``; the variants must not differ from it either
+        way."""
+        template = "The opener looks like {} and then params follow. Done."
+        text = template.format(wrapper)
+        reference = template.format(DSML_TOOL_START)
+
+        result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+        expected = self._parser(mock_tokenizer).extract_tool_calls(
+            reference, mock_request
+        )
+        assert result.tools_called == expected.tools_called
+        assert result.content == expected.content
+
+        results = simulate_tool_streaming(
+            self._parser(mock_tokenizer), mock_request, list(text)
+        )
+        expected_results = simulate_tool_streaming(
+            self._parser(mock_tokenizer), mock_request, list(reference)
+        )
+        assert collect_content(results) == collect_content(expected_results)
 
     @pytest.mark.parametrize("wrapper", _WRAPPER_VARIANTS)
     @pytest.mark.parametrize("chunk_size", [1, 3, None], ids=lambda c: f"chunk={c}")

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -30,6 +30,7 @@ from vllm.parser.deepseek_v4 import (
     DSML_THINK_START,
     DSML_TOOL_END,
     DSML_TOOL_START,
+    DSML_TOOL_START_VARIANTS,
     DeepSeekV4Parser,
     _dsml_arg_converter,
     _unwrap_wrapper_args,
@@ -1229,3 +1230,119 @@ class TestDelegatingParserLargeDelta:
         assert eos_text not in output.reasoning
         assert output.content == ""
         assert output.tool_calls == []
+
+
+# ── Malformed DSML markup must not leak into content (#51914) ─────────
+
+_WRAPPER_VARIANTS = list(DSML_TOOL_START_VARIANTS)
+
+
+class TestMalformedDsmlNoise:
+    """DeepSeek-V4-Flash intermittently misspells the tool-call opener, e.g.
+    ``<｜DSML｜toolcalls>``. Known corrupted openers open a tool block like
+    the real wrapper so the markup never surfaces as assistant content.
+    """
+
+    _INNER = (
+        f"{DSML_INVOKE_PREFIX}get_weather{DSML_INVOKE_NAME_END}\n"
+        f"{_param('city', 'true', 'Seoul')}\n"
+        f"{DSML_INVOKE_END}\n"
+        f"{DSML_TOOL_END}"
+    )
+
+    @staticmethod
+    def _parser(mock_tokenizer, thinking: bool = False):
+        return DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": thinking}
+        )
+
+    @pytest.mark.parametrize("wrapper", _WRAPPER_VARIANTS)
+    @pytest.mark.parametrize("preamble", ["", "Let me check.\n"])
+    def test_corrupted_wrapper_behaves_like_real_one(
+        self, mock_tokenizer, mock_request, wrapper, preamble
+    ):
+        text = f"{preamble}{wrapper}\n{self._INNER}"
+        reference = f"{preamble}{DSML_TOOL_START}\n{self._INNER}"
+
+        result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+        expected = self._parser(mock_tokenizer).extract_tool_calls(
+            reference, mock_request
+        )
+        assert [tc.function.name for tc in result.tool_calls] == ["get_weather"]
+        assert json.loads(result.tool_calls[0].function.arguments) == {"city": "Seoul"}
+        assert result.content == expected.content
+        assert "DSML" not in (result.content or "")
+
+        results = simulate_tool_streaming(
+            self._parser(mock_tokenizer), mock_request, list(text)
+        )
+        assert collect_function_name(results) == "get_weather"
+        assert json.loads(collect_tool_arguments(results)) == {"city": "Seoul"}
+        assert collect_content(results) == (expected.content or "")
+
+    @pytest.mark.parametrize("wrapper", _WRAPPER_VARIANTS)
+    def test_corrupted_wrapper_ends_reasoning(
+        self, mock_tokenizer, mock_request, wrapper
+    ):
+        """Like the real wrapper, a corrupted one inside ``<think>`` closes
+        the reasoning block and starts the tool call."""
+        text = f"thinking{wrapper}\n{self._INNER}"
+        parser = self._parser(mock_tokenizer, thinking=True)
+        reasoning, content = parser.extract_reasoning(text, mock_request)
+        assert reasoning == "thinking"
+        assert "DSML" not in (content or "")
+
+        result = self._parser(mock_tokenizer, thinking=True).extract_tool_calls(
+            text, mock_request
+        )
+        assert [tc.function.name for tc in result.tool_calls] == ["get_weather"]
+
+    def test_unregistered_markup_is_ordinary_content(
+        self, mock_tokenizer, mock_request
+    ):
+        """Only the registered spellings are treated as wrappers."""
+        text = "see <｜DSML｜ here and <|DSML|tool> there\nnext line"
+
+        result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+        assert result.content == text
+
+        results = simulate_tool_streaming(
+            self._parser(mock_tokenizer), mock_request, list(text)
+        )
+        assert collect_content(results) == text
+
+    @pytest.mark.parametrize("wrapper", _WRAPPER_VARIANTS)
+    @pytest.mark.parametrize("chunk_size", [1, 3, None], ids=lambda c: f"chunk={c}")
+    def test_delegating_parser_corrupted_wrapper(self, wrapper, chunk_size):
+        """The serving-layer shape: reasoning and tool adapters on separate
+        engines, with the corrupted opener arriving as plain text."""
+        tokens = _dsv4_tokens(
+            reasoning="Checking the weather.",
+            tool_name="get_weather",
+            params=[("city", "true", "Seoul")],
+        )
+        start_id = _DSV4_FULL_VOCAB[DSML_TOOL_START]
+        tokens = [
+            (900, wrapper) if tid == start_id else (tid, text) for tid, text in tokens
+        ]
+        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=chunk_size,
+            finished_on_last=True,
+            tools=DUMMY_TOOLS,
+        )
+        output = collect_output(deltas)
+
+        assert "Checking" in output.reasoning
+        assert len(output.tool_calls) == 1, (
+            f"reasoning={output.reasoning!r}, content={output.content!r}"
+        )
+        assert output.tool_calls[0]["name"] == "get_weather"
+        assert json.loads(output.tool_calls[0]["arguments"]) == {"city": "Seoul"}
+        assert "DSML" not in (output.content or "")

--- a/tests/parser/engine/test_delegating_replay.py
+++ b/tests/parser/engine/test_delegating_replay.py
@@ -197,7 +197,7 @@ def test_delegating_parse_tool_choice_none(parser_cls, parser_name, sample):
     cfg = parser._tool_parser._parser_engine.parser_engine_config
     terminals = sorted(
         v
-        for v in set(cfg.terminals.values()) | set(cfg.token_id_terminals.values())
+        for v in cfg.terminal_literals | set(cfg.token_id_terminals.values())
         if len(v) > 1
     )
     assert_no_terminal_leakage(

--- a/tests/parser/engine/test_engine.py
+++ b/tests/parser/engine/test_engine.py
@@ -957,16 +957,12 @@ class TestSkipToolParsingFromMessageHeader:
 
 # ── Terminals with several spellings ──────────────────────────────────
 
-_ALIAS_START_ID = 60
-_ALIAS_END_ID = 61
-
 
 def _alias_config() -> ParserEngineConfig:
     """``TOOL_START`` has a canonical spelling and one corrupted alias."""
     return ParserEngineConfig(
         name="alias_test",
         terminals={"TOOL_START": ("<tc>", "<tcx>"), "TOOL_END": "</tc>"},
-        token_id_terminals={"TOOL_START": "<tc>", "TOOL_END": "</tc>"},
         transitions={
             (ParserState.CONTENT, "TOOL_START"): Transition(
                 ParserState.TOOL_ARGS,
@@ -983,10 +979,6 @@ def _alias_config() -> ParserEngineConfig:
         },
         tool_args_json=False,
     )
-
-
-def _alias_tokenizer():
-    return make_mock_tokenizer({"<tc>": _ALIAS_START_ID, "</tc>": _ALIAS_END_ID})
 
 
 class TestTerminalAliases:
@@ -1006,28 +998,16 @@ class TestTerminalAliases:
         assert cfg.terminal_literals == {"<tc>", "<tcx>", "</tc>"}
 
     @pytest.mark.parametrize("spelling", ["<tc>", "<tcx>"])
-    def test_every_spelling_shares_transitions_in_text_mode(self, spelling):
-        engine = StreamingParserEngine(_alias_config(), _alias_tokenizer())
-        events = engine.feed(f"{spelling}a</tc>", [])
+    @pytest.mark.parametrize("char_by_char", [False, True])
+    def test_every_spelling_shares_transitions(self, spelling, char_by_char):
+        engine = StreamingParserEngine(_alias_config(), None)
+        text = f"{spelling}a</tc>"
+        events = []
+        for chunk in list(text) if char_by_char else [text]:
+            events.extend(engine.feed(chunk, []))
         events.extend(engine.finish())
         assert [e.type for e in events] == [
             EventType.TOOL_CALL_START,
             EventType.ARG_VALUE_CHUNK,
             EventType.TOOL_CALL_END,
         ]
-
-    def test_alias_keeps_meaning_in_token_id_mode(self):
-        """Only the spelling that has a token id is demoted when it arrives
-        as text; an alias has no token to arrive by."""
-        engine = StreamingParserEngine(_alias_config(), _alias_tokenizer())
-        events = engine.feed("<tcx>a</tc>", [7, 8, _ALIAS_END_ID])
-        events.extend(engine.finish())
-        assert EventType.TOOL_CALL_START in [e.type for e in events]
-        text = "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
-        assert "<tcx>" not in text
-
-    def test_canonical_spelling_as_text_still_demoted_in_token_id_mode(self):
-        engine = StreamingParserEngine(_alias_config(), _alias_tokenizer())
-        events = engine.feed("<tc>a</tc>", [7, 8, _ALIAS_END_ID])
-        events.extend(engine.finish())
-        assert EventType.TOOL_CALL_START not in [e.type for e in events]

--- a/tests/parser/engine/test_engine.py
+++ b/tests/parser/engine/test_engine.py
@@ -953,3 +953,81 @@ class TestSkipToolParsingFromMessageHeader:
         assert types[0] == EventType.TEXT_CHUNK
         assert events[0].value == "<tool_call>"
         assert engine._message_header_buffer == ""
+
+
+# ── Terminals with several spellings ──────────────────────────────────
+
+_ALIAS_START_ID = 60
+_ALIAS_END_ID = 61
+
+
+def _alias_config() -> ParserEngineConfig:
+    """``TOOL_START`` has a canonical spelling and one corrupted alias."""
+    return ParserEngineConfig(
+        name="alias_test",
+        terminals={"TOOL_START": ("<tc>", "<tcx>"), "TOOL_END": "</tc>"},
+        token_id_terminals={"TOOL_START": "<tc>", "TOOL_END": "</tc>"},
+        transitions={
+            (ParserState.CONTENT, "TOOL_START"): Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
+            ),
+        },
+        content_events={
+            ParserState.CONTENT: EventType.TEXT_CHUNK,
+            ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
+        },
+        tool_args_json=False,
+    )
+
+
+def _alias_tokenizer():
+    return make_mock_tokenizer({"<tc>": _ALIAS_START_ID, "</tc>": _ALIAS_END_ID})
+
+
+class TestTerminalAliases:
+    def test_terminal_defs_expand_every_spelling(self):
+        defs = terminals_from_literals({"A": ("x", "y"), "B": "z"})
+        assert [(d.name, d.literal) for d in defs] == [
+            ("A", "x"),
+            ("A", "y"),
+            ("B", "z"),
+        ]
+
+    def test_terminal_literal_is_canonical_spelling(self):
+        cfg = _alias_config()
+        assert cfg.terminal_literal("TOOL_START") == "<tc>"
+        assert cfg.terminal_literal("TOOL_END") == "</tc>"
+        assert cfg.terminal_literal("MISSING") is None
+        assert cfg.terminal_literals == {"<tc>", "<tcx>", "</tc>"}
+
+    @pytest.mark.parametrize("spelling", ["<tc>", "<tcx>"])
+    def test_every_spelling_shares_transitions_in_text_mode(self, spelling):
+        engine = StreamingParserEngine(_alias_config(), _alias_tokenizer())
+        events = engine.feed(f"{spelling}a</tc>", [])
+        events.extend(engine.finish())
+        assert [e.type for e in events] == [
+            EventType.TOOL_CALL_START,
+            EventType.ARG_VALUE_CHUNK,
+            EventType.TOOL_CALL_END,
+        ]
+
+    def test_alias_keeps_meaning_in_token_id_mode(self):
+        """Only the spelling that has a token id is demoted when it arrives
+        as text; an alias has no token to arrive by."""
+        engine = StreamingParserEngine(_alias_config(), _alias_tokenizer())
+        events = engine.feed("<tcx>a</tc>", [7, 8, _ALIAS_END_ID])
+        events.extend(engine.finish())
+        assert EventType.TOOL_CALL_START in [e.type for e in events]
+        text = "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
+        assert "<tcx>" not in text
+
+    def test_canonical_spelling_as_text_still_demoted_in_token_id_mode(self):
+        engine = StreamingParserEngine(_alias_config(), _alias_tokenizer())
+        events = engine.feed("<tc>a</tc>", [7, 8, _ALIAS_END_ID])
+        events.extend(engine.finish())
+        assert EventType.TOOL_CALL_START not in [e.type for e in events]

--- a/tests/parser/engine/test_replay.py
+++ b/tests/parser/engine/test_replay.py
@@ -83,7 +83,7 @@ def _discover_parsers() -> list[_ParserInfo]:
             raise RuntimeError(
                 f"{obj.__name__} config missing 'TOOL_END' in token_id_terminals"
             )
-        all_vals = set(cfg.terminals.values()) | set(cfg.token_id_terminals.values())
+        all_vals = cfg.terminal_literals | set(cfg.token_id_terminals.values())
         found.append(
             _ParserInfo(
                 parser_cls=obj,
@@ -91,12 +91,13 @@ def _discover_parsers() -> list[_ParserInfo]:
                 samples=build_samples(cfg.name),
                 terminals=sorted(v for v in all_vals if len(v) > 1),
                 tool_end=tool_end,
-                think_end=cfg.terminals.get("THINK_END", ""),
+                think_end=cfg.terminal_literal("THINK_END") or "",
                 tool_start=(
-                    cfg.terminals["TOOL_SECTION_START"]
+                    cfg.terminal_literal("TOOL_SECTION_START")
                     if (ParserState.CONTENT, "TOOL_SECTION_START") in cfg.transitions
-                    else cfg.terminals.get("TOOL_START", "")
-                ),
+                    else cfg.terminal_literal("TOOL_START")
+                )
+                or "",
             )
         )
     if missing_builders:

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -50,6 +50,12 @@ DSML_INVOKE_END = f"</{_DSML}invoke>"
 DSML_PARAM_START = f"<{_DSML}parameter"
 DSML_PARAM_CLOSE = f"</{_DSML}parameter>"
 
+# Spellings variants of ``DSML_TOOL_START`` observed in production.
+DSML_TOOL_START_VARIANTS: tuple[str, ...] = (
+    f"<{_DSML}toolcalls>",
+    f"<{_DSML}tool>",
+)
+
 _ESCAPED_DSML = re.escape(_DSML)
 _PARAM_RE = re.compile(
     rf'<{_ESCAPED_DSML}parameter\s+name="([^"]+)"\s+string="(true|false)">'
@@ -131,7 +137,7 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
         terminals={
             "THINK_START": DSML_THINK_START,
             "THINK_END": DSML_THINK_END,
-            "TOOL_START": DSML_TOOL_START,
+            "TOOL_START": (DSML_TOOL_START, *DSML_TOOL_START_VARIANTS),
             "TOOL_END": DSML_TOOL_END,
             "INVOKE_PREFIX": DSML_INVOKE_PREFIX,
             "INVOKE_NAME_END": DSML_INVOKE_NAME_END,

--- a/vllm/parser/engine/incremental_lexer.py
+++ b/vllm/parser/engine/incremental_lexer.py
@@ -5,6 +5,7 @@ tokens, with prefix-match buffering for ambiguous boundaries."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 import regex as re
@@ -285,7 +286,7 @@ class IncrementalLexer:
 
 
 def terminals_from_literals(
-    literals: dict[str, str | tuple[str, ...]],
+    literals: Mapping[str, str | tuple[str, ...]],
 ) -> list[TerminalDef]:
     return [
         TerminalDef(

--- a/vllm/parser/engine/incremental_lexer.py
+++ b/vllm/parser/engine/incremental_lexer.py
@@ -284,7 +284,9 @@ class IncrementalLexer:
         return n
 
 
-def terminals_from_literals(literals: dict[str, str]) -> list[TerminalDef]:
+def terminals_from_literals(
+    literals: dict[str, str | tuple[str, ...]],
+) -> list[TerminalDef]:
     return [
         TerminalDef(
             name=name,
@@ -292,5 +294,6 @@ def terminals_from_literals(literals: dict[str, str]) -> list[TerminalDef]:
             is_literal=True,
             literal=lit,
         )
-        for name, lit in literals.items()
+        for name, value in literals.items()
+        for lit in ((value,) if isinstance(value, str) else value)
     ]

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -158,11 +158,11 @@ class ParserEngine(Parser):
 
     @property
     def reasoning_start_str(self) -> str | None:
-        return self.parser_engine_config.terminals.get("THINK_START")
+        return self.parser_engine_config.terminal_literal("THINK_START")
 
     @property
     def reasoning_end_str(self) -> str | None:
-        return self.parser_engine_config.terminals.get("THINK_END")
+        return self.parser_engine_config.terminal_literal("THINK_END")
 
     @cached_property
     def vocab(self) -> dict[str, int]:

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -54,7 +54,8 @@ class ParserEngineConfig:
 
     name: str
 
-    terminals: dict[str, str] = field(default_factory=dict)
+    # A terminal may carry several spellings; the first spelling is the canonical one.
+    terminals: dict[str, str | tuple[str, ...]] = field(default_factory=dict)
 
     token_id_terminals: dict[str, str] = field(default_factory=dict)
 
@@ -99,6 +100,22 @@ class ParserEngineConfig:
 
     # Reject tool calls whose names are absent from the request tools.
     validate_tool_names: bool = False
+
+    def terminal_literal(self, name: str) -> str | None:
+        """Canonical spelling of terminal *name*, or ``None`` if undeclared."""
+        value = self.terminals.get(name)
+        if isinstance(value, tuple):
+            return value[0] if value else None
+        return value
+
+    @property
+    def terminal_literals(self) -> frozenset[str]:
+        """Every declared spelling across all terminals."""
+        return frozenset(
+            lit
+            for value in self.terminals.values()
+            for lit in ((value,) if isinstance(value, str) else value)
+        )
 
     @cached_property
     def terminal_defs(self):

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -17,7 +17,7 @@ Each model format is described by a :class:`ParserEngineConfig` that specifies:
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from functools import cached_property
@@ -55,7 +55,7 @@ class ParserEngineConfig:
     name: str
 
     # A terminal may carry several spellings; the first spelling is the canonical one.
-    terminals: dict[str, str | tuple[str, ...]] = field(default_factory=dict)
+    terminals: Mapping[str, str | tuple[str, ...]] = field(default_factory=dict)
 
     token_id_terminals: dict[str, str] = field(default_factory=dict)
 

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -34,6 +34,7 @@ from vllm.parser.engine.token_id_scanner import (
 class _DropInfo:
     lexer_shape: LexerShape
     extra_token_ids: dict[int, str]
+    drop_texts: frozenset[str]
 
 
 def _build_drop_info(
@@ -51,7 +52,7 @@ def _build_drop_info(
 
     configured_texts = (
         set(config.token_id_terminals.values())
-        | set(config.terminals.values())
+        | config.terminal_literals
         | config.preserve_tokens
     )
 
@@ -83,6 +84,7 @@ def _build_drop_info(
     return _DropInfo(
         lexer_shape=lexer_shape,
         extra_token_ids=extra_token_ids,
+        drop_texts=frozenset(drop_texts),
     )
 
 
@@ -148,6 +150,15 @@ class StreamingParserEngine:
         self._token_id_terminal_names: frozenset[str] = frozenset(
             resolved_token_ids.values()
         )
+        # Demote only spellings backed by special token IDs;
+        # text-only aliases remain terminals.
+        self._token_id_terminal_texts: dict[str, frozenset[str]] = {
+            name: frozenset({text})
+            for name, text in config.token_id_terminals.items()
+            if name in self._token_id_terminal_names
+        }
+        if drop_info is not None:
+            self._token_id_terminal_texts[DROP_TERMINAL] = drop_info.drop_texts
 
         self._lexer = IncrementalLexer(lexer_shape, content_terminal=CONTENT_TERMINAL)
 
@@ -346,7 +357,11 @@ class StreamingParserEngine:
         events: list[SemanticEvent] = []
         strict = self._token_id_terminal_names if self._ever_had_token_ids else None
         for tok in tokens:
-            if tok.terminal == CONTENT_TERMINAL or (strict and tok.terminal in strict):
+            if tok.terminal == CONTENT_TERMINAL or (
+                strict
+                and tok.terminal in strict
+                and tok.value in self._token_id_terminal_texts.get(tok.terminal, ())
+            ):
                 events.extend(self._on_content(tok.value, tok.token_count))
             else:
                 events.extend(

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -34,7 +34,6 @@ from vllm.parser.engine.token_id_scanner import (
 class _DropInfo:
     lexer_shape: LexerShape
     extra_token_ids: dict[int, str]
-    drop_texts: frozenset[str]
 
 
 def _build_drop_info(
@@ -84,7 +83,6 @@ def _build_drop_info(
     return _DropInfo(
         lexer_shape=lexer_shape,
         extra_token_ids=extra_token_ids,
-        drop_texts=frozenset(drop_texts),
     )
 
 
@@ -150,15 +148,6 @@ class StreamingParserEngine:
         self._token_id_terminal_names: frozenset[str] = frozenset(
             resolved_token_ids.values()
         )
-        # Demote only spellings backed by special token IDs;
-        # text-only aliases remain terminals.
-        self._token_id_terminal_texts: dict[str, frozenset[str]] = {
-            name: frozenset({text})
-            for name, text in config.token_id_terminals.items()
-            if name in self._token_id_terminal_names
-        }
-        if drop_info is not None:
-            self._token_id_terminal_texts[DROP_TERMINAL] = drop_info.drop_texts
 
         self._lexer = IncrementalLexer(lexer_shape, content_terminal=CONTENT_TERMINAL)
 
@@ -357,11 +346,7 @@ class StreamingParserEngine:
         events: list[SemanticEvent] = []
         strict = self._token_id_terminal_names if self._ever_had_token_ids else None
         for tok in tokens:
-            if tok.terminal == CONTENT_TERMINAL or (
-                strict
-                and tok.terminal in strict
-                and tok.value in self._token_id_terminal_texts.get(tok.terminal, ())
-            ):
+            if tok.terminal == CONTENT_TERMINAL or (strict and tok.terminal in strict):
                 events.extend(self._on_content(tok.value, tok.token_count))
             else:
                 events.extend(


### PR DESCRIPTION
## Purpose

Partially addresses #51914.

DeepSeek-V4-Flash intermittently misspells the DSML tool-call opener while the rest of the block stays well-formed:

```diff
-<｜DSML｜tool_calls>
+<｜DSML｜toolcalls>            # also observed: <｜DSML｜tool>
 <｜DSML｜invoke name="get_weather">
 <｜DSML｜parameter name="city" string="true">Seoul</｜DSML｜parameter>
 </｜DSML｜invoke>
 </｜DSML｜tool_calls>
```

The parser matches markers literally, so the misspelled opener matches nothing, no `tool_calls` are produced, and the whole block is returned as assistant `content`.

### Fix

Let a terminal carry several spellings. `ParserEngineConfig.terminals` now accepts `str | tuple[str, ...]`; every spelling lexes to the same terminal name and shares its transitions. DeepSeek-V4 registers the observed corruptions as spellings of `TOOL_START`:

```python
"TOOL_START": (DSML_TOOL_START, *DSML_TOOL_START_VARIANTS),
```

### Alternatives considered

| Approach | Why not |
|---|---|
| One terminal name per spelling, transitions duplicated in the config | Transitions describe meaning; a spelling is a lexing detail. Every `TOOL_START` transition and every engine-derived classification (openers, exits, reasoning markup, skip-mode projection) would need to be kept in sync by hand, with silent drift as the failure mode. |
| Treat any unknown `<｜DSML｜…>` tag as protocol noise and drop it | Covers unseen corruptions, but cannot distinguish noise from the model deliberately quoting a tag. Registering only observed spellings keeps anything unlisted as untouched content. |

## Test Plan
```bash
pytest tests/parser
```