### PR TITLE
[Bugfix][V1] Bound hybrid shared-prefix checkpoints by all full-attention hits

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1187,6 +1187,48 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
     manager.free(req_2)
 
 
+@pytest.mark.parametrize("block_size", [16, 32])
+@pytest.mark.parametrize("draft_first", [False, True])
+@pytest.mark.parametrize("checkpoint_blocks", [4, 5])
+def test_hybrid_mamba_shared_prefix_is_bounded_by_draft_hit(
+    block_size, draft_first, checkpoint_blocks
+):
+    """Only a missing Mamba state within both dense prefixes is a junction."""
+    checkpoint = checkpoint_blocks * block_size
+    config = _make_hybrid_kv_cache_config(
+        block_size, 100, ["full", "full", "mamba_align"]
+    )
+    draft = config.kv_cache_groups[1]
+    # Distinct specs keep target and draft in separate lookup groups.
+    draft.kv_cache_spec = replace(draft.kv_cache_spec, head_size=8)
+    draft.is_eagle_group = True
+    if draft_first:
+        config.kv_cache_groups.reverse()
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+        retention_interval=0,
+    )
+    token_ids = list(range(6 * block_size + 11))
+    cold = make_request("cold", token_ids, block_size, sha256)
+    cold.shared_prefix_boundary = checkpoint
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(cold)
+    assert num_computed == 0
+    assert manager.allocate_slots(cold, checkpoint, 0, computed_blocks) is not None
+    cold.num_computed_tokens = checkpoint
+    manager.new_step_starts()
+    assert manager.allocate_slots(cold, len(token_ids) - checkpoint) is not None
+    manager.free(cold)
+
+    warm = make_request("warm", token_ids, block_size, sha256)
+    _, num_computed, shared_prefix_boundary = manager.get_computed_blocks(warm)
+    assert num_computed == checkpoint
+    assert shared_prefix_boundary == (5 * block_size if checkpoint_blocks < 5 else 0)
+
+
 def test_hybrid_model_mamba_align_with_dynamic_draft_tokens():
     """Regression test for https://github.com/vllm-project/vllm/issues/39271.
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -919,11 +919,14 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate every full-attention group (target and draft) blocks
-        # to final hit_length.
+        # Bound shared checkpoints by every full-attention group's reusable
+        # prefix before truncating target and draft blocks to final hit_length.
         for group in self.attention_groups:
             if not isinstance(group.spec, FullAttentionSpec):
                 continue
+            longest_hit_length = min(
+                longest_hit_length, hit_length_by_group[group.group_ids[0]]
+            )
             group_block_size = self.single_type_managers[group.group_ids[0]].block_size
             num_blocks = cdiv(hit_length, group_block_size)
             for group_id in group.group_ids:
@@ -931,9 +934,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     del blks[num_blocks:]
                     hit_length_by_group[group_id] = hit_length
 
-        # Uncached shared prefix detection: if any attn. group cached a longer
-        # prefix than the reconciled hit, it is an uncached common prefix across
-        # requests that a sparse-retention group hasn't cached yet.
+        # A shared prefix reachable by all full-attention groups may still
+        # need a checkpoint in a sparse-retention group.
         num_uncached_common_prefix_tokens = longest_hit_length - hit_length
         cache_hit_blocks = tuple(
             blocks if blocks is not None else [] for blocks in hit_blocks_by_group

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -301,8 +301,9 @@ class KVCacheManager:
 
         # The junction to pin is where the lagging sparse-retention group stops
         # (``num_new_computed_tokens``) plus the uncached shared prefix -- i.e.
-        # the longest single-group hit. Sub-block gaps are left to the mask,
-        # which floors to the alignment boundary (a no-op there).
+        # the shared prefix reachable by all full-attention groups.
+        # Sub-block gaps are left to the mask, which floors to the alignment
+        # boundary (a no-op there).
         shared_prefix_boundary = (
             num_new_computed_tokens + num_uncached if num_uncached else 0
         )


### PR DESCRIPTION
## Purpose

Fix an unnecessary warm-prefill split when a target full-attention group reports a longer reusable prefix than the draft group. The hybrid coordinator currently retains the longest single-group hit as a shared checkpoint, even when another full-attention group cannot reuse that boundary.

| Target / draft / Mamba hits | Current shared boundary | Expected shared boundary |
|---|---:|---:|
| 96 / 80 / 80 | 96 | 0: no missing checkpoint |
| 96 / 80 / 64 | 96 | 80: preserve the useful checkpoint |

Cap the checkpoint candidate by every full-attention group's discovered reusable hit **before** truncating the hit lists and overwriting their lengths. The reconciled cache-hit length, EAGLE proof-block drop, and retention policy remain unchanged. Add eight regression cases through `KVCacheManager.get_computed_blocks`, covering block sizes 16/32, target/draft order, and both checkpoint conditions.

Why the bound is taken here: each full-attention group's discovered hit is still available before final truncation overwrites it. Taking the minimum afterwards would lose a useful checkpoint (80 in the second example). The final reconciled hit is already no larger than every dense hit, so the cap cannot produce a negative gap.

## Test Plan

The focused regression uses cache-manager fixtures and synthetic token IDs; it does not download model weights:

```bash
.venv/bin/python -m pytest tests/v1/core/test_prefix_caching.py \
  -k hybrid_mamba_shared_prefix_is_bounded_by_draft_hit -q
```

On base `c69d5d72a6018db6ff55efc66097d377c25828cc` with just the regression added: **4 failed / 4 passed**. With this fix: **8 passed**. The failures are the target-first boundary cases; reversed order is included to guard existing behavior.

Broader validation:

```bash
.venv/bin/python -m pytest \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/v1/core/prefix_cache/test_mamba_eagle_resume_checkpoint.py -q

.venv/bin/pre-commit run --files \
  tests/v1/core/test_prefix_caching.py \
  vllm/v1/core/kv_cache_coordinator.py \
  vllm/v1/core/kv_cache_manager.py
```

## Test Result

- **165 passed** in the three cache suites (41.24 s; 14 dependency deprecation warnings); applicable pre-commit hooks passed.
- Supplemental real-manager matrix: **64/64 passed**, versus 10 failures with the original method. It covers coarse/fine hash sizes, EAGLE on/off, spec grouping, lookup order and checkpoint position.
- Public target/draft model validation on two H100s: raw main and raw main plus this fix each pass four generation smoke requests. The conditional experiment below removes the extra warm chunk in **160/160** measurements.
- Public LongBench evaluation is included below. Cold outputs are unchanged across the patch; observed cold/warm equality rises to 32/32. Warm subset scores decrease to the cold baseline; this is not an accuracy or general bitwise-determinism claim.

**Dependency and evidence scope:** this code change and its unit regression stand alone. The GPU performance comparison uses the separate draft-ownership fix #56026 on both sides; that PR is still open and is not included here. Raw main's ownership fallback masks the GPU symptom in the selected model configuration. The 39–37% timing reductions below are conditional, instrumented, sequential-run results, not a stock-main or production-throughput claim. The clean CUDA bootstrap recipe remains unvalidated.

[Public scripts, pinned model/input manifests and results](https://gist.github.com/youweizengumd-cyber/8227c50430ca760ea2dd42ecba570ca4) · [Pre-outreach audit](https://gist.github.com/youweizengumd-cyber/8227c50430ca760ea2dd42ecba570ca4#file-pre_outreach_review-md)

<details>
<summary>Public GPU reproduction, model evaluation, measurements and limitations</summary>

Working and GPU benchmark base: upstream main `c69d5d72a6018db6ff55efc66097d377c25828cc`, fetched on 2026-09-09 (commit time 18:10:26 UTC).

Public GPU reproduction: 2 × H100 80 GB, TP=2, BF16, Python 3.12.11, Torch 2.13.0+cu129, Transformers 5.16.1, FlashInfer 0.6.18, Triton 3.7.1. FA3, DFlash 15 draft tokens, prefix caching, chunked prefill, async scheduling, `-O3`, max model length 65536 and max batched tokens 32768.

| Component | Public repository | Pinned revision |
|---|---|---|
| Target | `Qwen/Qwen3.5-35B-A3B` | `59d61f3ce65a6d9863b86d2e96597125219dc754` |
| Draft | `z-lab/Qwen3.5-35B-A3B-DFlash` | `a6ab3a277f856d91c43f28711611e7929073d56d` |
| Dataset | `zai-org/LongBench` | `5e628be450b7e67fb7ae6e201bd6d8f7056f7672` |
| Prompts/scorers | `THUDM/LongBench` | `2e00731f8d0bff23dc4325161044d0ed8af94c1e` |

The draft is the public 8-layer full-attention version explicitly paired with this target in its model card. Both models load and generate successfully, with nonzero speculative acceptance. Select 16 Qasper and 16 GovReport examples using seed 20260909; disable thinking, temperature 0, output limits 512/2048. The [public reproduction files](https://gist.github.com/youweizengumd-cyber/8227c50430ca760ea2dd42ecba570ca4) include download/file manifests, input preparation, pinned launch and measurement scripts, test logs and aggregate results. Running the scripts regenerates request-level records and raw GPU traces.

Native extensions were built from `474839f8469ed4d47bffa18c6a063547a148bf2c` and reused after verifying no differences in native sources, build configuration, requirements or custom-op bindings at the new base. The bundle records this check and binary SHA256 values. All Python source uses the new base and the explicitly listed variant patches. The provided fresh-environment bootstrap recipe has not itself been validated end to end.

**Reproduction scope:** raw main's default ownership fallback marks all groups as draft in this model configuration, masking the GPU symptom. The conditional GPU comparison applies #56026 (`506a4bdcead0520301f67e455391b8f71b4eb7c4`) on both sides. The unit regression reproduces on raw main with explicit draft ownership. A separate raw-main versus raw-main-plus-this-patch control checks the standalone change.

## Test Result

- **165 passed in 41.24 s** in the pre-outreach rerun on the pinned base with only this patch, 14 dependency deprecation warnings; pre-commit passed again. The original recorded run took 37.40 s.
- A supplemental 64-case real-manager matrix also passes on the pinned base (10 cases fail with the original method), covering coarse/fine hash sizes, EAGLE on/off, equal/distinct full-attention specs, lookup order, and both checkpoint conditions. This matrix is in the reproduction gist; the PR keeps the eight focused regression cases.
- On unmodified new main, the eight added regression cases yield **4 failed / 4 passed**, failing on the expected target-first boundary cases.
- Both conditional variants complete 96 full-generation requests and 320 single-token requests. All 160 formal warm prefill measurements change from two chunks to one. Cold requests retain two chunks.
- A sibling-prefix control restores a hit from 0 to 3504 tokens; repeating it hits 25696 tokens, and changing the cache salt hits 0.

Conditional warm engine prefill **with audit wrappers enabled**, one output token, five repetitions per input:

| Task | Before ms | After ms | Reduction | Paired-input bootstrap 95% CI |
|---|---:|---:|---:|---|
| LongBench Qasper (16) | 165.128 | 99.891 | 39.51% | 33.31–44.29% |
| LongBench GovReport (16) | 162.978 | 102.596 | 37.05% | 30.45–42.37% |

Warm TTFT changes from 173.117 to 107.219 ms (Qasper) and 173.701 to 112.369 ms (GovReport). Cold single-token prefill increases by 1.01% and 1.47%; sequential variant runs leave temporal drift unresolved. Bootstrap intervals resample prompts, keeping all five repetitions together.

Full-output cold/warm equality improves from 12/32 to 32/32; warm/repeat remains 32/32. Cold outputs are identical across the patch. Paired first-token equality improves from 155/160 to 160/160; maximum cold/warm top-20 logprob delta decreases from 1.007612 to 0, and minimum overlap increases from 18 to 20. No formal generation reaches its output cap.

| Official LongBench subset score | Cold, unchanged across patch | Before warm | After warm |
|---|---:|---:|---:|
| Qasper QA F1 | 37.8218 | 39.9790 | 37.8218 |
| GovReport ROUGE-L | 32.4515 | 32.5920 | 32.4515 |

Scores return to the cold baseline and decrease relative to the previous warm path. This is an unnecessary-split fix with improved observed cold/warm agreement, not an accuracy-improvement claim. Changed chunking can change floating-point execution; output differences alone do not establish a cache-corruption bug, and these results do not guarantee bitwise invariance across other inputs or batches. Changed output lengths confound full-generation decode/E2E comparisons, so the performance claim uses one-token measurements.

Separate representative TP0 warm traces show fused MoE calls 160 → 80 for both tasks. Some asynchronous GPU activities remain unattributed to steps in these traces; they are retained, not silently excluded from inventories. Profiling is separate from latency measurements, and TP-rank times are not added as wall time.

Raw main and raw main plus only this patch each pass a four-request public generation smoke test and retain one warm chunk. These controls do not constitute a full stock-main performance comparison. All reported 39–37% improvements are conditional on correct draft ownership.

Limits: concurrency one, sequential variant runs, 16 examples per task, and incomplete trace step attribution. Timing includes synchronous JSON audit writes at cache lookup and prefill scheduling. Both variants use the same wrappers, but removing a split also removes an audit write. A wrapper-free, interleaved A/B run is still needed to isolate production latency without instrumentation or temporal drift. Confidence intervals describe input variation, not temporal machine drift. This does not establish production throughput or broad model-quality equivalence.


</details>

## Related work

#56026 fixes draft ownership annotation; #53479 changes Mamba state materialization/back-off; #52527 adds shared-prefix loss metrics; #52371 adds other Mamba/EAGLE boundary tests; #54163 changes DFlash block-drop policy. #55403 changes sparse block eviction priority; #55868 targets GDN batch-invariant execution. These changes do not contain this full-attention hit cap. This PR does not include #56026.

### AI assistance

OpenAI Codex assisted with code inspection, implementation, tests, and experiment analysis. The numerical logs above were produced by the agent. The submitting human separately confirmed reviewing every changed line, running and passing the relevant cache tests, and agreeing to the DCO. The commit includes AI attribution and the human submitter's Signed-off-by trailer.
