### PR TITLE
[Cohere] Bound remaining request priorities to the MessagePack int64 range

### DIFF
--- a/vllm/entrypoints/cohere/protocol.py
+++ b/vllm/entrypoints/cohere/protocol.py
@@ -170,7 +170,7 @@ class CohereChatV2Request(BaseModel):
     thinking: Thinking | None = None
 
     # Scheduling
-    priority: int | None = None
+    priority: int | None = Field(default=None, ge=-(2**63), le=2**63 - 1)
 
     # vLLM-specific extensions (not in Cohere spec). These mirror what the
     # Anthropic and OpenAI surfaces already expose so V2 callers can reach

--- a/vllm/entrypoints/generate/generative_scoring/serving.py
+++ b/vllm/entrypoints/generate/generative_scoring/serving.py
@@ -93,6 +93,8 @@ class GenerativeScoringRequest(OpenAIBaseModel):
     )
     priority: int = Field(
         default=0,
+        ge=-(2**63),
+        le=2**63 - 1,
         description=(
             "The priority of the request (lower means earlier handling; default: 0)."
         ),

--- a/vllm/entrypoints/pooling/embed/protocol.py
+++ b/vllm/entrypoints/pooling/embed/protocol.py
@@ -236,7 +236,7 @@ class CohereEmbedRequest(BaseModel):
     embedding_types: list[CohereEmbeddingType] | None = None
     truncate: CohereTruncate = "END"
     max_tokens: int | None = None
-    priority: int = 0
+    priority: int = Field(default=0, ge=-(2**63), le=2**63 - 1)
 
     @model_validator(mode="after")
     def validate_input_fields(self):


### PR DESCRIPTION
## Purpose

Cohere Chat, Cohere Embed, and Generative Scoring accepted arbitrarily large Python integers for `priority`. These values later overflow MessagePack serialization instead of producing a client validation error.

## Reproducer

```python
msgspec.msgpack.encode(
    158541820065335999920888242752337176824
)
```

Output on Main:

```text
CohereChatV2Request: accepted; MessagePack OverflowError
CohereEmbedRequest: accepted; MessagePack OverflowError
GenerativeScoringRequest: accepted; MessagePack OverflowError
```

Output on Branch:

```text
CohereChatV2Request: rejected by validation
CohereEmbedRequest: rejected by validation
GenerativeScoringRequest: rejected by validation
```

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/cohere/test_protocol.py \
  tests/entrypoints/pooling/embed/test_protocol.py \
  tests/entrypoints/generate/generative_scoring/test_generative_scoring.py -q
```

```text
51 passed in 36.17s
```

### Manual HTTP E2E

```text
Cohere Chat oversized priority:       HTTP 400
Cohere Chat valid priority:           HTTP 200
Generative Scoring oversized priority: HTTP 400 BadRequestError
Generative Scoring valid priority:     HTTP 200
MRV2 Cohere Embed oversized priority: HTTP 400
MRV2 Cohere Embed valid priority:     HTTP 200, 1 embedding
```

Models used with Cohere-compatible endpoints:
- HuggingFaceTB/SmolLM2-135M-Instruct → /v2/chat
- intfloat/multilingual-e5-small → /v2/embed
