### PR TITLE
[Spec Decode] Reuse EAGLE3 CPU query offsets with Triton attention

### DIFF
--- a/tests/v1/spec_decode/test_llm_base_proposer.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer.py
@@ -11,12 +11,24 @@ processes, so anything derived from iteration order must not leak into
 ``block_size``.
 """
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
+import torch
 
 import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
+from vllm.config import CUDAGraphMode
+from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.triton_attn import (
+    TritonAttentionBackend,
+    TritonAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import FullAttentionSpec
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.worker.utils import AttentionGroup
 
 SCHEDULER_BLOCK_SIZE = 256
 KERNEL_BLOCK_SIZE = 64
@@ -110,3 +122,228 @@ def test_draft_layer_iteration_is_deterministic(monkeypatch: pytest.MonkeyPatch)
         assert len(proposer.draft_attn_groups) == 1
         assert proposer.draft_attn_groups[0].layer_names == expected_order
         assert proposer.block_size == KERNEL_BLOCK_SIZE
+
+
+@pytest.fixture
+def draft_metadata():
+    """Real CPU metadata builder, without loading draft weights or running kernels."""
+    config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.PIECEWISE, static_forward_context={}
+        ),
+        model_config=SimpleNamespace(
+            get_num_attention_heads=lambda _: 8,
+            get_num_kv_heads=lambda _: 8,
+            get_head_size=lambda: 64,
+            rswa_window=None,
+        ),
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1, decode_context_parallel_size=1
+        ),
+    )
+    spec = FullAttentionSpec(
+        block_size=128, num_kv_heads=8, head_size=64, dtype=torch.float32
+    )
+    names = ["draft.attn"]
+    builder = TritonAttentionMetadataBuilder(spec, names, config, torch.device("cpu"))
+    proposer = EagleProposer.__new__(EagleProposer)
+    proposer.method = "eagle3"
+    proposer.device = torch.device("cpu")
+    proposer.vllm_config = config
+    proposer.speculative_config = SimpleNamespace(disable_padded_drafter_batch=False)
+    proposer.parallel_drafting = False
+    proposer.constant_draft_positions = False
+    proposer.needs_extra_input_slots = False
+    proposer.supports_mm_inputs = False
+    proposer.uses_mrope = False
+    proposer.draft_model_config = SimpleNamespace(uses_mrope=False)
+    proposer.num_speculative_tokens = 3
+    proposer._draft_attn_layer_names = set(names)
+    proposer.draft_attn_groups = [
+        AttentionGroup(TritonAttentionBackend, names, spec, 0, [builder])
+    ]
+    proposer._draft_query_start_loc_cpu_cache = {}
+    proposer.token_arange_np = np.arange(16, dtype=np.int32)
+    common = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2, 5], dtype=torch.int32),
+        seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+        num_reqs=2,
+        num_actual_tokens=5,
+        max_query_len=3,
+        max_seq_len=20,
+        block_table_tensor=torch.tensor([[0, 1], [2, 3]], dtype=torch.int32),
+        slot_mapping=torch.tensor([9, 10, 275, 276, 277], dtype=torch.int64),
+    )
+    return proposer, builder, common
+
+
+def _propose_until_decode(monkeypatch, proposer, builder, common, k=3):
+    """Run propose through real metadata construction; omit GPU/model execution."""
+
+    class DraftDecodeReady(Exception):
+        pass
+
+    class TestEagle(Eagle3LlamaForCausalLM):
+        def __init__(self):
+            torch.nn.Module.__init__(self)
+
+        def combine_hidden_states(self, hidden_states):
+            return hidden_states
+
+        def forward(self, **kwargs):
+            hidden = torch.zeros(common.num_actual_tokens, 2)
+            return hidden, hidden
+
+    proposer.model = TestEagle()
+    proposer.hidden_size = 2
+    proposer._share_mtp_indices = False
+    proposer.eplb_state = None
+    proposer.positions = torch.arange(16)
+    proposer.arange = torch.arange(16, dtype=torch.int32)
+    proposer.allowed_attn_types = None
+    proposer.block_size = 128
+    proposer.use_heterogeneous_vocab = False
+    monkeypatch.setattr(
+        llm_base_proposer, "set_forward_context", lambda *a, **kw: nullcontext()
+    )
+    monkeypatch.setattr(proposer, "_get_slot_mapping", lambda *a: None)
+    monkeypatch.setattr(
+        proposer,
+        "_determine_batch_execution_and_padding",
+        lambda n: (CUDAGraphMode.PIECEWISE, n, None),
+    )
+    monkeypatch.setattr(
+        proposer,
+        "set_inputs_first_pass",
+        lambda **kw: (common.num_actual_tokens, torch.arange(common.num_reqs), common),
+    )
+    monkeypatch.setattr(
+        proposer,
+        "build_model_inputs_first_pass",
+        lambda *a: ({}, common.num_actual_tokens),
+    )
+    monkeypatch.setattr(
+        proposer,
+        "_sample_draft_tokens",
+        lambda *a: (torch.zeros(common.num_reqs, dtype=torch.int64), None),
+    )
+
+    def update_positions(positions, metadata, *args):
+        metadata.seq_lens.add_(1)
+        metadata.max_seq_len += 1
+        return positions + 1
+
+    monkeypatch.setattr(
+        proposer, "_update_positions_dependent_metadata", update_positions
+    )
+
+    build = builder.build_for_drafting
+    captured = []
+
+    def capture(common_attn_metadata, draft_index):
+        result = build(common_attn_metadata, draft_index)
+        if draft_index == 1:
+            captured.append(result)
+            raise DraftDecodeReady
+        return result
+
+    with monkeypatch.context() as patch:
+        patch.setattr(builder, "build_for_drafting", capture)
+        with pytest.raises(DraftDecodeReady):
+            proposer.propose(
+                k,
+                torch.zeros(common.num_reqs, dtype=torch.int32),
+                torch.arange(common.num_reqs),
+                torch.zeros(common.num_reqs, 2),
+                torch.zeros(common.num_reqs, dtype=torch.int32),
+                None,
+                common,
+                None,
+            )
+    metadata = captured[0]
+    assert metadata.max_query_len == 1
+    assert metadata.num_actual_tokens == common.num_reqs
+    assert metadata.seq_lens is common.seq_lens
+    assert metadata.max_seq_len == common.max_seq_len
+    assert metadata.block_table is common.block_table_tensor
+    assert metadata.slot_mapping is common.slot_mapping
+    assert common.query_start_loc_cpu.tolist() == list(range(common.num_reqs + 1))
+    return common.query_start_loc_cpu
+
+
+def test_propose_reuses_cpu_query_offsets_across_batch_and_draft_length_changes(
+    monkeypatch, draft_metadata
+):
+    proposer, builder, common = draft_metadata
+    first = _propose_until_decode(monkeypatch, proposer, builder, common)
+    smaller = common.replace(
+        num_reqs=1, num_actual_tokens=1, seq_lens=common.seq_lens[:1]
+    )
+    _propose_until_decode(monkeypatch, proposer, builder, smaller, k=2)
+    common.seq_lens = torch.tensor([40, 50], dtype=torch.int32)
+    common.max_seq_len = 50
+    common.slot_mapping = common.slot_mapping + 2
+    second = _propose_until_decode(monkeypatch, proposer, builder, common, k=4)
+    assert second is first
+    assert common.seq_lens.tolist() == [41, 51]
+    assert common.max_seq_len == 51
+    proposer.token_arange_np[:] = -1
+    assert first.tolist() == [0, 1, 2]
+
+
+def test_propose_cpu_offsets_fall_back_for_unrecognized_builder(
+    monkeypatch, draft_metadata
+):
+    proposer, builder, common = draft_metadata
+    cached = _propose_until_decode(monkeypatch, proposer, builder, common)
+
+    class OtherBuilder(TritonAttentionMetadataBuilder):
+        pass
+
+    builder.__class__ = OtherBuilder
+    first = _propose_until_decode(monkeypatch, proposer, builder, common)
+    first.fill_(-1)
+    second = _propose_until_decode(monkeypatch, proposer, builder, common)
+    assert second is not first
+    assert second.tolist() == [0, 1, 2]
+    assert cached.tolist() == [0, 1, 2]
+
+
+@pytest.mark.parametrize("num_dims", [3, 4])
+def test_cpu_query_offsets_mrope_fallback_has_private_storage(draft_metadata, num_dims):
+    proposer, _, _ = draft_metadata
+    proposer.draft_model_config = SimpleNamespace(
+        uses_mrope=True, mrope_num_dims=num_dims
+    )
+    proposer.uses_mrope = proposer.draft_model_config.uses_mrope
+    first = proposer._get_draft_query_start_loc_cpu(2)
+    first.fill_(-1)
+    assert proposer._get_draft_query_start_loc_cpu(2).tolist() == [0, 1, 2]
+
+
+def test_cpu_query_offsets_released_on_backend_reinitialization(
+    monkeypatch, draft_metadata
+):
+    proposer, builder, _ = draft_metadata
+    first = proposer._get_draft_query_start_loc_cpu(2)
+    monkeypatch.setattr(
+        llm_base_proposer,
+        "get_layers_from_vllm_config",
+        lambda *a, **kw: {
+            "draft.attn": SimpleNamespace(
+                get_attn_backend=lambda: TritonAttentionBackend
+            )
+        },
+    )
+    kv_config = SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=["draft.attn"], kv_cache_spec=builder.kv_cache_spec
+            )
+        ]
+    )
+    proposer.initialize_attn_backend(kv_config)
+    second = proposer._get_draft_query_start_loc_cpu(2)
+    assert second is not first
+    assert second.tolist() == [0, 1, 2]

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -40,7 +40,11 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
-from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
+from vllm.v1.attention.backends.triton_attn import (
+    TritonAttentionBackend,
+    TritonAttentionMetadata,
+    TritonAttentionMetadataBuilder,
+)
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -153,6 +157,7 @@ class SpecDecodeBaseProposer:
         )
 
         self.draft_attn_groups: list[AttentionGroup] = []
+        self._draft_query_start_loc_cpu_cache: dict[int, torch.Tensor] = {}
         self.kv_cache_gid: int = -1
         self.eagle3_use_aux_hidden_state: bool = (
             self._get_eagle3_use_aux_hidden_state_from_config()
@@ -659,9 +664,9 @@ class SpecDecodeBaseProposer:
         common_attn_metadata.num_actual_tokens = batch_size
         common_attn_metadata.max_query_len = 1
         common_attn_metadata.query_start_loc = self.arange[: batch_size + 1]
-        common_attn_metadata.query_start_loc_cpu = torch.from_numpy(
-            self.token_arange_np[: batch_size + 1]
-        ).clone()
+        common_attn_metadata.query_start_loc_cpu = self._get_draft_query_start_loc_cpu(
+            batch_size
+        )
 
         # In padded drafter batch, we need to adjust the sequence lengths
         # to remove the "padding" (i.e. rejected tokens).
@@ -990,6 +995,26 @@ class SpecDecodeBaseProposer:
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
         return per_group_attn_metadata, per_layer_attn_metadata
+
+    def _get_draft_query_start_loc_cpu(self, batch_size: int) -> torch.Tensor:
+        # Triton does not mutate CPU query offsets. Other builders keep receiving
+        # private storage, including extensions with their own metadata handling.
+        can_reuse = (
+            self.method == "eagle3"
+            and not self.uses_mrope
+            and len(self.draft_attn_groups) == 1
+            and self.draft_attn_groups[0].backend is TritonAttentionBackend
+            and type(self.draft_attn_groups[0].get_metadata_builder())
+            is TritonAttentionMetadataBuilder
+        )
+        if can_reuse:
+            cached = self._draft_query_start_loc_cpu_cache.get(batch_size)
+            if cached is not None:
+                return cached
+        offsets = torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone()
+        if can_reuse:
+            self._draft_query_start_loc_cpu_cache[batch_size] = offsets
+        return offsets
 
     def model_returns_tuple(self) -> bool:
         if self.method == "mtp":
@@ -1721,6 +1746,7 @@ class SpecDecodeBaseProposer:
         Initialize AttentionGroups for draft layers using kv_cache_config.
         Called from the model runner's initialize_metadata_builders.
         """
+        self._draft_query_start_loc_cpu_cache = {}
         all_attn_layers = get_layers_from_vllm_config(
             self.vllm_config,
             AttentionLayerBase,  # type: ignore[type-abstract]


### PR DESCRIPTION
## Retained true-parent control — September 17, 2026

Offline comparison of two already-completed uncached true-parent GPU runs found **24/44 requests and 952 output-token positions differ**, despite identical production source, recorded model/native identities, GPU, prompts, sampling and declared compilation settings. Each run repeats its own output exactly. The previously investigated batch-8 token split also occurs between these unchanged-parent runs, so it is not unique to the cached candidate.

Observer helpers, separate process/compilation state and physical KV block/slot mappings differ; their causal contribution is unresolved. This is a useful negative control, **not cache exoneration or a production root cause**. The latest candidate/parent **16/44-request, 400-position FAIL remains unchanged**, and the PR stays draft. No new GPU run, production change, tolerance relaxation or performance claim was made. AI assistance was used.

## Latest paired GPU result — September 17, 2026, 13:07 UTC

**Draft: strict candidate/parent output-token parity still FAILED.** The current public candidate and true parent completed a revised same-SM120-GPU Llama-3.1-8B-Instruct/EAGLE3 diagnostic, BF16/K3 with Triton attention and PIECEWISE graphs. The unchanged batch matrix 1/2/4/8/4/2/1 ran twice: **44 checked requests and 2,816 generated tokens per source; 88 requests and 5,632 tokens combined**. **16 of 44 paired requests differ across 400 output-token positions.** Prompt equality and both within-source repeats passed; successful model exits do not waive the strict failure.

Two complete target transactions per source now include selected first-layer attention query/output rows at the actual compiled-attention host boundary. These selected rows match byte-for-byte in both transactions, while final selected hidden states/logits differ. The selected request's full output is equal in this pair, so these captures do not include the actual first emitted mismatch; the historical token-level witness was not reproduced. This is bounded tensor evidence, not full KV/weight/other-row equality, an identified production defect, or cache exoneration. Candidate execution recorded **662 getter calls, 661 hits and 3,952 draft graph replays**, with no original probe errors.

Source/native/result checks passed; native artifacts were reused, not rebuilt. Both model steps completed successfully; owned cleanup found no assigned-GPU processes and zero GPU memory before allocation release. The paired allocation lasted under eight minutes. Production source and numerical acceptance are unchanged. The earlier 24/44-request, 952-position failure and earlier passing/failing pairs remain below as independent history, not an improvement claim. No full quality/performance, universal non-regression, review-readiness or upstream-CI success is asserted. AI assistance was used.

## Retained paired diagnostic — September 17, 2026, 10:49 UTC

**This pair's strict candidate/parent output-token comparison FAILED.** Both current-public-candidate and true-parent model runs completed on the same SM120 GPU, using Llama-3.1-8B-Instruct/EAGLE3, BF16/K3, Triton attention and PIECEWISE graphs. Each ran the original 1/2/4/8/4/2/1 batch matrix twice: 44 checked requests and 2,816 generated tokens per source, 88 requests and 5,632 tokens combined. **24 of 44 paired requests differed across 952 output-token positions.** Prompt-token comparison and both within-source repeats passed; successful model exits do not waive the failed comparison.

The corrected private observer retained two complete target transactions per source, including the actual 32-target-layer plus one-draft-layer metadata layout. The candidate recorded 662 getter calls, 661 cache hits and 3,952 draft CUDA-graph replays. Selected hidden state and logits differ before sampling for the captured differing target step, while recorded forward-input, dispatch and sampling controls agree. This is useful localization, **not a proven production root cause**: KV contents, per-layer intermediate tensors and in-memory weight equality remain unestablished.

Source/native/result checks and owned cleanup passed, with no assigned-GPU processes and zero reported GPU memory before release. The earlier strict pair PASS and earlier failures remain retained below; no pair substitutes for another. No production fix, relaxed tolerance, full accuracy/performance, universal non-regression, review-readiness or upstream-CI success is claimed. See the September 17 GPU-validation follow-up comments. AI assistance was used.

## Retained validation history

### Retained earlier passing pair — September 17, 2026 UTC

The current public candidate and its true parent each completed real one-SM120 Llama-3.1-8B-Instruct/EAGLE3 generation, BF16/K3 with PIECEWISE graphs and Triton attention. Each arm ran the original batch matrix 1/2/4/8/4/2/1 twice: **44 checked requests and 2,816 generated tokens per source; 88 requests and 5,632 tokens combined**. The unchanged strict comparison passed exact prompt/output-token parity, with zero differing requests or positions; both within-source repeats passed.

The changed path was directly observed: **664 getter calls and 664 cache hits**, 1,992 metadata builds and 3,964 draft CUDA-graph replays, with no original probe errors. The true parent had the same build/replay counts and no cache getter. Model steps, source/native identity checks and owned cleanup passed. Separate retained cache-reset and cached/forced-miss/restored-cache tests keep their original scope; this pair did not rerun backend reset.

The optional target-row diagnostic was **INCONCLUSIVE** because both observers rejected an unexpected attention-metadata layout. It is not a new qualification requirement and is not evidence of a production defect. The fresh strict pair PASS also does not explain or erase the earlier cross-source failures, including 20/44 requests and 600 positions. **The PR remains draft while that contradictory evidence is reconciled.** No full model-quality, performance, universal non-regression, human-approval or upstream-CI claim is made. AI assistance was used. The detailed update is in the September 17 GPU-validation comment; earlier results remain below as history, not the latest result.

## Retained validation history — September 16–17, 2026

### New standalone result (EDT): path/reset PASS; baseline parity FAIL

The current public candidate and its baseline both completed real Llama-3.1-8B-Instruct/EAGLE3 K3 generation on one RTX PRO 6000 Blackwell GPU, runner v1, BF16 and PIECEWISE graphs. Seven batches (1, 2, 4, 8, 4, 2, 1) generated 64 tokens per request; candidate execution repeated after backend reinitialization: **44 candidate plus 22 baseline requests, 4,224 checked output tokens**.

The retained validation helper's instrumented candidate/reset mode and baseline run mode both exited zero. Its unchanged comparison mode exited one: **9 of 22 paired requests differ, across 398 output-token positions**, despite identical prompt-token sequences. Candidate instrumentation differs from baseline, and identical prompts also differ at some batch positions within baseline. These observations do not isolate a cache-PR regression; the failed comparison is not waived. Matched-instrumentation comparison remains the causal gap, and this PR remains a draft.

The changed getter/cache was directly observed: **330 / 324 cache hits**, **993 / 993 metadata builds**, and **1,974 / 1,974 draft graph replays** before/after reset. Reset cleared the cache and subsequent generation repopulated it; candidate prompt/output tokens match exactly across reset. Source/native checks and assigned-GPU cleanup passed. Compatible native artifacts were reused, not rebuilt. This establishes standalone path/reset execution, not full model quality, performance, a positive speculative-rejection count or universal non-regression. The historical evidence below retains its original scope.

**Draft; not qualified by the latest combined MiniMax workload runs.** The completed TP4/PP2 and TP8/PP1 MiniMax serving logs both select model runner v2. Their source routes through `EagleSpeculator` / `AutoRegressiveSpeculator`, not the runner-v1 `EagleProposer` / `SpecDecodeBaseProposer` changed here. Consequently, neither those full accuracy/serving results nor other PRs' observed kernel launches demonstrate use of this CPU-offset cache.

The existing 31 CPU tests and 38 model-free native cases below retain their original scope. A subsequent, separate MiniMax runner-v1 diagnostic completed one real GPU request at TP8/PP1, draft TP8/K5, capture width 6: HTTP 200, 1,239 prompt tokens and 136 completion tokens. Runner-v1/base-proposer setup was observed. Exact-source analysis supports getter reachability, but the trace does not record the changed getter's invocation, cache eligibility, or a cache hit. This is not a full accuracy/serving run, a cache-benefit measurement, or qualification of this PR. Human review and standalone runner-v1 qualification remain pending; neither minimum-stack necessity nor dispensability is established.

<!-- retained-eagle-k3-model-evidence-20260916:start -->
## Retained real GPU cache/reset evidence — September 16, 2026

A retained September 15 run provides direct, path-specific evidence beyond the separate MiniMax diagnostic: real Llama-3.1-8B-Instruct with its EAGLE3 draft on one RTX PRO 6000 Blackwell GPU, runner v1, BF16, K3 and PIECEWISE graphs. Seven batches (1, 2, 4, 8, 4, 2, 1) generated 64 tokens per sequence, totaling 1,408 tokens per round, before and after backend reinitialization.

The changed offset getter was directly observed: 331 calls / 330 cache hits before reset and 331 calls / 324 hits afterward, with no probe errors. Reset returned an empty cache and subsequent real generation repopulated it. Prompt and output token IDs matched exactly across reset; graph replay calls were observed inside draft proposal. Source/native checks and the recorded postflight passed, and the assigned-GPU process observation was empty afterward.

All non-test source files in the current public snapshot are byte-identical to that retained model run; only the metadata-fixture test file differs. This is historical runtime evidence plus source equivalence, not a new execution of the amended whole head, baseline-versus-candidate token parity, full model-quality evaluation, MiniMax performance recovery, or universal non-regression. The run is instrumented correctness evidence, not a timing result. The PR remains a draft; fresh isolated-head validation is being prepared and no human review is claimed.
<!-- retained-eagle-k3-model-evidence-20260916:end -->

## Purpose

After the first EAGLE3 draft pass in model runner v1, each request contributes one query token. The proposer currently allocates a fresh CPU `[0, ..., batch_size]` tensor on every proposal. This change reuses an owned tensor for each batch size with the exact Triton attention builder. Other builders and multidimensional positions retain private clones, and backend initialization clears the cache.

The metadata-builder API and dynamic attention metadata rebuilding are unchanged. This applies to model runner v1 (`VLLM_USE_V2_MODEL_RUNNER=0` or an existing fallback); it does not change the default runner-v2 path. The change was rebased onto main `8c87c333b84c85908b1d11f0044457692277c6f3`.

Non-duplication: #46849 and #54790 optimize runner-v2 draft chains, #53301 reuses metadata across cache groups, #55292 refactors builder capabilities, and #55978 removes other runner-v2 loop overhead. Their actual diffs and focused CPU-offset searches were checked; none reuses this runner-v1 CPU offset tensor.

Validation:

- `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/v1/spec_decode/test_llm_base_proposer.py tests/v1/worker/test_gpu_autoregressive_speculator.py tests/v1/spec_decode/test_eagle_draft_attn_metadata.py -q`: 31 passed on the rebased head.
- `.venv/bin/pre-commit run --files vllm/v1/spec_decode/llm_base_proposer.py tests/v1/spec_decode/test_llm_base_proposer.py`: passed.
- `.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files vllm/v1/spec_decode/llm_base_proposer.py tests/v1/spec_decode/test_llm_base_proposer.py`: passed.

The CPU tests exercise `propose()` through real Triton metadata construction, covering nonuniform first-pass queries, changing batch sizes and draft lengths, fresh dynamic metadata, fallback storage, three/four-channel M-RoPE, and backend reinitialization. Model forward and GPU position updates are substituted for these CPU tests. The earlier workstation CPU run used Python 3.12.13 and Torch 2.13.0+cpu; native extensions were unbuilt in that environment. The tests report the existing missing generated-version and Torch deprecation warnings.

Validation limits: the retained bounded runner-v1 Llama/EAGLE3 K3 graph/reset run is described above. Full model evaluation including real-sampler GSM8K, matched serving A/B measurements, and execution of the amended whole head are not established by it. Actual Austin native initialization and model-free correctness results are recorded below. No serving throughput, model-quality, or per-patch Pareto improvement is claimed. This PR remains a draft for human review and completion of GPU/model validation.

AI assistance: GPT-6 Astra xhigh assisted implementation, source comparison, testing and independent review. Human review of every changed line and relevant human-run tests remain pending.
<!-- austin-native-validation:start -->

Austin native validation, September 9–10, 2026:

- Tested head `e8ff0a4099bd5e9e2a8c7c21b1ff2a25d33f4a3f` and baseline `8c87c333b84c85908b1d11f0044457692277c6f3` on an actual ComputeLab Austin RTX PRO 6000 Blackwell Server Edition, compute capability 12.0. Runtime: Python 3.12.13, Torch 2.13.0+cu130, CUDA 13.0, driver 595.58.03.
- Used the official Python-only editable workflow with the exact-base native wheel (SHA-256 `e81a71acdfa363029263dc13fc6f42c9834534cd9b4c82ad3a70c68411264caf`). Native/build inputs are unchanged by this PR. Both installed environments pass dependency checks; all 199 non-vLLM package versions match. Actual imported source commits and loaded native hashes were verified.
- Both arms passed a real BF16 CUDA `torch.ops._C.silu_and_mul` check against an FP32 reference cast to BF16, with matching output and loaded-native hashes.
- **38 tests passed, zero failures/errors/skips.** This comprises the 31 CPU-level regression cases listed above, three upstream EAGLE fused slot/sequence-update CUDA tests, and four standalone CUDA integration cases for batch sizes 1/2/4/8. The integration cases performed 12 actual stock-kernel CUDA graph replays while changing persistent positions, sequence lengths and block-table contents, checking fresh metadata/offset values and bindings, offset reuse, and backend reinitialization.

This establishes model-free native correctness. The captured graph above contains the EAGLE update kernel; it is not a full draft-model graph. No model weights, GSM8K evaluation, HTTP serving benchmark, or performance measurement ran in this phase. Full model and performance checks remain pending; the PR remains a draft.
<!-- austin-native-validation:end -->

<!-- austin-ci-note:start -->

CI status: the upstream `pre-run-check` jobs [34403567716](https://github.com/vllm-project/vllm/actions/runs/34403567716) and [34403623764](https://github.com/vllm-project/vllm/actions/runs/34403623764) failed the repository's contributor-eligibility gate (label/merged-PR threshold), so their pre-commit jobs did not run. The logs do not identify a code/test failure. Local pre-commit, the focused CPU tests, and the Austin native results above are separate evidence. No eligibility labels or workflow rules were changed.
<!-- austin-ci-note:end -->

<!-- austin-control-preparation:start -->

Validation-harness review, September 10 (off-node; source head unchanged): private controls assert observed draft K, eager mode with zero draft replay, and the assigned worker/source/arm/job/step/UUID. Live-origin collection uses a shared, reviewed interface with immutable startup/run receipts; continuation requires complete collection and closed descriptors. Full GSM8K authorization is checked separately, and errors/interruption retain failed status before safe cleanup.

`.venv/bin/python -m pytest slop/eagle_metadata_cache/austin/test_phase_gates.py slop/eagle_metadata_cache/austin/test_origin_hook.py -q`: **32 passed, zero failures/skips** (19 control/lifecycle cases and 13 origin-hook cases). Expected pre-fix failures are preserved. These are private harness checks, not additional Austin model or serving passes. Matched Llama-3.1-8B/EAGLE3 base/head model checks, full1319 GSM8K, live library-origin collection, and host/HTTP A/B remain pending. MiniMax baseline results are not reused for this fixture.
<!-- austin-control-preparation:end -->

<!-- eagle-recovery-20260911:start -->

Recovery reconciliation, September 11: the local, fork, and PR heads remain `e8ff0a4099bd5e9e2a8c7c21b1ff2a25d33f4a3f`. The historical 38-case native suite ran on that candidate; baseline `8c87c333b84c85908b1d11f0044457692277c6f3` has a separate passing native preflight, not another 38-case suite. The shared allocation has terminated with failure and all prior execution/continuation grants are retired. This recovery performed off-node receipt and denial-guard checks only; it did not rerun GPU tests or start a model.

This recovery snapshot predates the retained runner-v1 Llama/EAGLE3 K3/reset run documented above. That later run observes cache hits, graph replay and across-reset token parity only; it does not establish the other variants, baseline/no-spec parity, full1319 GSM8K comparisons, full process-mapped library closure or host/HTTP A/B. Scheduler or reboot records do not establish direct process/descriptor closure. No shared MiniMax baseline or compound C12/C14 result is used as this PR's validation or individual speedup. There are no source changes or new commits from recovery; the PR remains a draft pending fresh resource authorization and the remaining tests.
<!-- eagle-recovery-20260911:end -->


<!-- proposer-fixture-compatibility-update:start -->
## Fixture compatibility update

The existing draft-metadata fixture now supplies the builder's optional speculative configuration and two-request scheduler capacity. Only these two fixture fields change; production offset caching and the existing test assertions remain unchanged. This belongs in the existing PR rather than a duplicate test-fix PR.

Changed-file `pre-commit run --files`, syntax compilation, and `git diff --check` passed using existing tools without dependency installation. Normal commit hooks also passed. The earlier Mac imported baseline/candidate attempts stopped during collection because NumPy was missing: zero behavior tests executed in those attempts.

September 17 update: all eight public proposer regression cases now pass through normal Torch/NumPy/pytest imports against the current public source and unchanged test fixtures: eight executed, zero failures, errors or skips. Coverage includes kernel-block sizing, deterministic draft-layer ordering, CPU-offset reuse through real Triton metadata construction while batch size and draft length change, fallback storage, three/four-channel M-RoPE and backend reinitialization. Existing test substitutions for model forward and GPU position updates remain unchanged.

This used a CPU-only allocation of two CPUs and 8 GiB for 66 seconds, with no GPUs allocated. CUDA availability and initialization remained false before and after pytest; imported source/test identities and all 17 unchanged native-carrier hashes were checked, and tracked source remained unchanged afterward. No dependency installation, native rebuild, model load, GPU kernel execution or serving benchmark was performed in this phase. This is a current-candidate imported test pass, not a new pre-fix RED/GREEN result, and it does not resolve the separate retained GPU cross-source token-parity failure. The PR remains a draft.

AI assistance was used for this update, reusing the existing independent static fixture review. Human line-by-line review and relevant human-run tests are not confirmed by this update; the PR remains a draft.

## Assembly alternative: omit this PR

The offset-off alternative means omitting this PR's V1 CPU-offset cache from an assembly and retaining the baseline per-call clone. It is not an additive mainline fix, proven sufficient stack, historical C1 performance recovery, or no-regression result. The active PR retains its offset cache unchanged and remains open; no removal patch is added here. Combined workload results do not isolate this PR's benefit or establish that omitting it reproduces either historical leader.
<!-- proposer-fixture-compatibility-update:end -->
