### PR TITLE
[Attention] Safeguard speculative multi-query Triton split-K

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -14,6 +14,7 @@ from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.attention.ops import triton_unified_attention as attention
 from vllm.v1.attention.ops.triton_attention_helpers import (
     compute_tile_loop_bounds,
+    softmax_step,
 )
 from vllm.v1.attention.ops.triton_unified_attention import (
     reduce_segments,
@@ -188,6 +189,24 @@ def test_reduce_segments_ignores_empty_softmax_states(empty_state: str) -> None:
     torch.testing.assert_close(
         output, torch.full_like(output, 0.0 if empty_state == "all_empty" else 3.0)
     )
+
+
+@triton.jit
+def _softmax_after_empty_tile(output_ptr):
+    maximum = tl.full((1,), float("-inf"), tl.float32)
+    mass = tl.full((1,), 1.0, tl.float32)
+    empty_scores = tl.full((1, 16), float("-inf"), tl.float32)
+    maximum, mass, _, _ = softmax_step(empty_scores, maximum, mass)
+    scores = tl.full((1, 16), -1000.0, tl.float32)
+    _, mass, probabilities, _ = softmax_step(scores, maximum, mass)
+    tl.store(output_ptr + tl.arange(0, 16), tl.sum(probabilities, axis=0) / mass)
+
+
+def test_splitk_softmax_recovers_after_fully_masked_tile() -> None:
+    """A masked first tile must not suppress later, strongly negative logits."""
+    probabilities = torch.empty(16, device=DEVICE_TYPE)
+    _softmax_after_empty_tile[(1,)](probabilities)
+    torch.testing.assert_close(probabilities, torch.full_like(probabilities, 1 / 16))
 
 
 @pytest.mark.parametrize(

--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from unittest.mock import MagicMock
+
 import pytest
 import torch
 
@@ -9,10 +11,14 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.ops import triton_unified_attention as attention
 from vllm.v1.attention.ops.triton_attention_helpers import (
     compute_tile_loop_bounds,
 )
-from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.attention.ops.triton_unified_attention import (
+    reduce_segments,
+    unified_attention,
+)
 from vllm.v1.kv_cache_interface import KVQuantMode
 
 pytestmark = pytest.mark.skip_global_cleanup
@@ -34,6 +40,228 @@ NUM_BLOCKS = [32768, 2048]
 # 0: use 2D kernel for decode
 # 8: use 3D kernel for decode
 SEQ_THRESHOLD_3D_VALUES = [0, 8]
+
+
+def _uses_splitk(
+    monkeypatch,
+    query_len,
+    scratch,
+    *,
+    uniform=True,
+    causal=True,
+    threshold=8,
+    mm_prefix=None,
+):
+    query = torch.empty((2 * query_len, 8, 128), dtype=torch.bfloat16, device="cpu")
+    cache = torch.empty((1, 128, 1, 128), dtype=torch.bfloat16, device="cpu")
+    kernel = MagicMock()
+    monkeypatch.setattr(attention, "kernel_unified_attention", kernel)
+    monkeypatch.setattr(attention, "reduce_segments", MagicMock())
+    unified_attention(
+        query,
+        cache,
+        cache,
+        torch.empty_like(query),
+        torch.tensor([0, query_len, 2 * query_len], dtype=torch.int32),
+        query_len,
+        torch.tensor([128, 128], dtype=torch.int32),
+        128,
+        128**-0.5,
+        causal,
+        (-1, -1),
+        torch.zeros((2, 1), dtype=torch.int32),
+        0.0,
+        None,
+        None,
+        None,
+        is_uniform_decode=uniform,
+        seq_threshold_3D=threshold,
+        num_par_softmax_segments=16,
+        softmax_segm_output=scratch[0],
+        softmax_segm_max=scratch[1],
+        softmax_segm_expsum=scratch[2],
+        mm_prefix_range=mm_prefix,
+    )
+    return kernel.__getitem__.return_value.call_args.kwargs["IS_3D"]
+
+
+@pytest.mark.parametrize("query_len", [1, 5])
+@pytest.mark.parametrize("buffer_index", [0, 1, 2])
+@pytest.mark.parametrize(
+    "defect", [None, "rows", "shape", "rank", "dtype", "device", "stride", "missing"]
+)
+def test_splitk_validates_each_scratch_tensor(
+    monkeypatch, buffer_index, defect, query_len
+):
+    """The launch must use the supplied tensors' capacity and packed FP32 layout."""
+    query = torch.empty((2 * query_len, 8, 128), dtype=torch.bfloat16, device="cpu")
+    rows = query.shape[0]
+    shapes = [(rows, 8, 16, 128), (rows, 8, 16), (rows, 8, 16)]
+    scratch = [torch.empty(shape, device="cpu") for shape in shapes]
+    buffer = scratch[buffer_index]
+    if defect == "rows":
+        buffer = buffer[:-1]
+    elif defect == "shape":
+        buffer = torch.empty((2, 7, *buffer.shape[2:]), device="cpu")
+    elif defect == "rank":
+        buffer = buffer.flatten()
+    elif defect == "dtype":
+        buffer = buffer.to(torch.float16)
+    elif defect == "device":
+        buffer = buffer.to("meta")
+    elif defect == "stride":
+        buffer = buffer.transpose(0, 1).contiguous().transpose(0, 1)
+    elif defect == "missing":
+        buffer = None
+    scratch[buffer_index] = buffer
+    assert _uses_splitk(monkeypatch, query_len, scratch) is (defect is None)
+
+
+@pytest.mark.parametrize(
+    "query_len,options,expected",
+    [
+        (1, {"uniform": False}, True),
+        (1, {"uniform": False, "causal": False}, True),
+        (5, {}, True),
+        (5, {"uniform": False}, False),
+        (6, {}, False),
+        (5, {"causal": False}, False),
+        (5, {"causal": "per_sequence"}, False),
+        (5, {"threshold": 1}, False),
+        (5, {"batch_invariant": True}, False),
+        (5, {"mm_prefix": True}, False),
+    ],
+)
+def test_splitk_admission_preserves_decode_and_bounds_verification(
+    monkeypatch, query_len, options, expected
+):
+    options = options.copy()
+    monkeypatch.setattr(
+        attention, "is_batch_invariant", options.pop("batch_invariant", False)
+    )
+    if options.get("causal") == "per_sequence":
+        options["causal"] = torch.ones(2, dtype=torch.bool, device="cpu")
+    if options.get("mm_prefix"):
+        options["mm_prefix"] = torch.zeros((2, 1, 2), dtype=torch.int32, device="cpu")
+    scalar_shape = (2 * query_len, 8, 16)
+    scratch = [
+        torch.empty((*scalar_shape, 128), device="cpu"),
+        torch.empty(scalar_shape, device="cpu"),
+        torch.empty(scalar_shape, device="cpu"),
+    ]
+    assert _uses_splitk(monkeypatch, query_len, scratch, **options) is expected
+
+
+@pytest.mark.parametrize("empty_state", ["masked", "unvisited", "all_empty"])
+def test_reduce_segments_ignores_empty_softmax_states(empty_state: str) -> None:
+    """Empty segments must not suppress strongly negative, nonempty segments."""
+    output = torch.full((1, 1, 32), float("nan"), device=DEVICE_TYPE)
+    partial = torch.zeros((1, 1, 16, 32), device=DEVICE_TYPE)
+    maxima = torch.full((1, 1, 16), -float("inf"), device=DEVICE_TYPE)
+    masses = torch.ones_like(maxima)
+    if empty_state != "all_empty":
+        partial[:, :, 0] = 3.0
+        maxima[:, :, 0] = -1000.0
+    if empty_state in ("masked", "all_empty"):
+        maxima[:, :, 1:] = 0.0
+        masses[:, :, 1:] = 0.0
+    reduce_segments[(1, 1)](
+        output,
+        partial,
+        maxima,
+        masses,
+        torch.tensor([32], dtype=torch.int32, device=DEVICE_TYPE),
+        1,
+        1,
+        1.0,
+        output.stride(0),
+        output.stride(1),
+        1,
+        16,
+        32,
+        32,
+        torch.tensor([0, 1], dtype=torch.int32, device=DEVICE_TYPE),
+        16,
+        16,
+        False,
+    )
+    torch.testing.assert_close(
+        output, torch.full_like(output, 0.0 if empty_state == "all_empty" else 3.0)
+    )
+
+
+@pytest.mark.parametrize(
+    "query_lens,seq_lens", [([5, 0], [5, 0]), ([0], [0]), ([5], [0])]
+)
+def test_reduce_segments_leaves_graph_padding_untouched(query_lens, seq_lens) -> None:
+    """A padded reducer row must return before reading sequence or scratch data."""
+    output = torch.full((10, 1, 32), 123.0, device=DEVICE_TYPE)
+    partial = torch.zeros((10, 1, 16, 32), device=DEVICE_TYPE)
+    maxima = torch.zeros((10, 1, 16), device=DEVICE_TYPE)
+    masses = torch.ones_like(maxima)
+    query_starts = torch.tensor(
+        [0] + query_lens, dtype=torch.int32, device=DEVICE_TYPE
+    ).cumsum(0, dtype=torch.int32)
+    reduce_segments[(10, 1)](
+        output,
+        partial,
+        maxima,
+        masses,
+        torch.tensor(seq_lens, dtype=torch.int32, device=DEVICE_TYPE),
+        len(seq_lens),
+        1,
+        1.0,
+        output.stride(0),
+        output.stride(1),
+        1,
+        16,
+        32,
+        32,
+        query_starts,
+        16,
+        16,
+        False,
+    )
+    active_rows = sum(q for q, kv in zip(query_lens, seq_lens) if kv > 0)
+    torch.testing.assert_close(
+        output[:active_rows], torch.zeros_like(output[:active_rows])
+    )
+    torch.testing.assert_close(
+        output[active_rows:], torch.full_like(output[active_rows:], 123.0)
+    )
+
+
+@pytest.mark.parametrize("query_len", [2, 4, 5])
+@pytest.mark.parametrize("sliding_window", [None, 32])
+@pytest.mark.parametrize("seq_threshold_3D", [0, 8])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+def test_speculative_splitk_matches_reference(
+    query_len, sliding_window, seq_threshold_3D, dtype
+):
+    test_triton_unified_attn(
+        seq_lens=[(query_len, 128), (query_len, 129), (query_len, 257)],
+        num_heads=(8, 1),
+        head_size=128,
+        sliding_window=sliding_window,
+        dtype=dtype,
+        block_size=128,
+        soft_cap=None,
+        num_blocks=8,
+        q_dtype=None,
+        seq_threshold_3D=seq_threshold_3D,
+    )
+
+
+@pytest.mark.parametrize("seq_threshold_3D", [0, 8])
+def test_speculative_splitk_bf16_query_fp8_kv(seq_threshold_3D):
+    test_triton_unified_attn_bf16_query_fp8_kv(
+        seq_lens=[(5, 128), (5, 129), (5, 4097)],
+        num_heads=(8, 1),
+        head_size=128,
+        block_size=128,
+        num_blocks=64,
+        seq_threshold_3D=seq_threshold_3D,
+    )
 
 
 @triton.jit
@@ -422,16 +650,18 @@ def test_triton_unified_attn(
 
     num_par_softmax_segments = 16
     head_size_padded = next_power_of_2(head_size)
+    is_uniform_decode = len(set(query_lens)) == 1 and max_query_len <= 5
+    scratch_rows = seq_threshold_3D * (max_query_len if is_uniform_decode else 1)
     softmax_segm_output = torch.empty(
-        (seq_threshold_3D, num_query_heads, num_par_softmax_segments, head_size_padded),
+        (scratch_rows, num_query_heads, num_par_softmax_segments, head_size_padded),
         dtype=torch.float32,
     )
     softmax_segm_max = torch.empty(
-        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        (scratch_rows, num_query_heads, num_par_softmax_segments),
         dtype=torch.float32,
     )
     softmax_segm_expsum = torch.empty(
-        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        (scratch_rows, num_query_heads, num_par_softmax_segments),
         dtype=torch.float32,
     )
 
@@ -452,6 +682,7 @@ def test_triton_unified_attn(
         q_descale=q_descale,
         k_descale=k_descale,
         v_descale=v_descale,
+        is_uniform_decode=is_uniform_decode,
         seq_threshold_3D=seq_threshold_3D,
         num_par_softmax_segments=num_par_softmax_segments,
         softmax_segm_output=softmax_segm_output,
@@ -542,16 +773,18 @@ def test_triton_unified_attn_bf16_query_fp8_kv(
 
     num_par_softmax_segments = 16
     head_size_padded = next_power_of_2(head_size)
+    is_uniform_decode = len(set(query_lens)) == 1 and max_query_len <= 5
+    scratch_rows = seq_threshold_3D * (max_query_len if is_uniform_decode else 1)
     softmax_segm_output = torch.empty(
-        (seq_threshold_3D, num_query_heads, num_par_softmax_segments, head_size_padded),
+        (scratch_rows, num_query_heads, num_par_softmax_segments, head_size_padded),
         dtype=torch.float32,
     )
     softmax_segm_max = torch.empty(
-        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        (scratch_rows, num_query_heads, num_par_softmax_segments),
         dtype=torch.float32,
     )
     softmax_segm_expsum = torch.empty(
-        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        (scratch_rows, num_query_heads, num_par_softmax_segments),
         dtype=torch.float32,
     )
 
@@ -572,6 +805,7 @@ def test_triton_unified_attn_bf16_query_fp8_kv(
         q_descale=None,
         k_descale=k_descale,
         v_descale=v_descale,
+        is_uniform_decode=is_uniform_decode,
         seq_threshold_3D=seq_threshold_3D,
         num_par_softmax_segments=num_par_softmax_segments,
         softmax_segm_output=softmax_segm_output,

--- a/tests/v1/attention/test_triton_attention_metadata.py
+++ b/tests/v1/attention/test_triton_attention_metadata.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadataBuilder
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+
+def _builder(
+    num_speculative_tokens=4,
+    parallel_drafting=False,
+    enable_adaptive_verification=False,
+):
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            get_num_attention_heads=lambda _: 8,
+            get_num_kv_heads=lambda _: 1,
+            get_head_size=lambda: 128,
+            rswa_window=None,
+        ),
+        parallel_config=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(max_num_seqs=8),
+        speculative_config=(
+            SimpleNamespace(
+                num_speculative_tokens=num_speculative_tokens,
+                parallel_drafting=parallel_drafting,
+                enable_adaptive_verification=enable_adaptive_verification,
+            )
+            if num_speculative_tokens is not None
+            else None
+        ),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.NONE,
+            static_forward_context={},
+        ),
+    )
+    return TritonAttentionMetadataBuilder(
+        FullAttentionSpec(
+            block_size=128, num_kv_heads=1, head_size=128, dtype=torch.bfloat16
+        ),
+        ["layer.0"],
+        config,
+        torch.device("cpu"),
+    )
+
+
+def _metadata(query_lens, is_prefilling):
+    starts = torch.tensor([0, *query_lens], dtype=torch.int32, device="cpu")
+    starts = starts.cumsum(0, dtype=torch.int32)
+    num_reqs = len(query_lens)
+    return CommonAttentionMetadata(
+        query_start_loc=starts,
+        query_start_loc_cpu=starts,
+        seq_lens=torch.tensor(
+            [128 if length else 0 for length in query_lens],
+            dtype=torch.int32,
+            device="cpu",
+        ),
+        num_reqs=num_reqs,
+        num_actual_tokens=sum(query_lens),
+        max_query_len=max(query_lens),
+        max_seq_len=128,
+        block_table_tensor=torch.zeros((num_reqs, 1), dtype=torch.int32, device="cpu"),
+        slot_mapping=torch.zeros(sum(query_lens), dtype=torch.int64, device="cpu"),
+        is_prefilling=(
+            torch.tensor(is_prefilling, dtype=torch.bool, device="cpu")
+            if is_prefilling is not None
+            else None
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("query_lens", "is_prefilling", "expected"),
+    [
+        ([5, 5, 0], [False, False, True], True),
+        ([1, 1, 0], [False, False, True], False),
+        ([5, 5, 0], [False, False], True),
+        ([5, 5, 0], [False], False),
+        ([0, 5, 0], [True, False], True),
+        ([5, 4, 0], [False, False, False], False),
+        ([5, 5, 0], [False, True, False], False),
+        ([5, 5, 0], None, False),
+        ([0, 0], [False, False], False),
+    ],
+)
+def test_uniform_decode_requires_same_width_nonprefill_rows(
+    query_lens, is_prefilling, expected
+):
+    metadata = _builder().build(0, _metadata(query_lens, is_prefilling))
+    assert metadata.is_uniform_decode is expected
+
+
+def test_uniform_decode_uses_only_current_requests_and_consistent_maximum():
+    common = _metadata([5, 5, 0, 42], [False, False, True, True])
+    common.num_reqs = 3
+    common.num_actual_tokens = 10
+    common.max_query_len = 5
+    builder = _builder()
+    assert builder.build(0, common).is_uniform_decode
+    common.max_query_len = 4
+    assert not builder.build(0, common).is_uniform_decode
+
+
+def test_uniform_decode_rejects_adaptive_query_lengths_below_upper_bound():
+    common = _metadata([4, 4, 0], [False, False])
+    # Adaptive verification evenly splits the CPU budget, then redistributes
+    # it on device; max_query_len retains the original scheduled upper bound.
+    common.query_start_loc = torch.tensor([0, 3, 8, 8], dtype=torch.int32, device="cpu")
+    common.max_query_len = 5
+    assert not _builder().build(0, common).is_uniform_decode
+
+
+def test_adaptive_verification_does_not_admit_cpu_only_uniform_proof():
+    common = _metadata([5, 5, 0], [False, False, False])
+    builder = _builder(enable_adaptive_verification=True)
+    assert not builder.build(0, common).is_uniform_decode
+
+
+@pytest.mark.parametrize(
+    ("num_speculative_tokens", "parallel_drafting", "capacity"),
+    [(None, False, 8), (4, False, 40), (2, True, 40), (5, False, 8), (3, True, 8)],
+)
+def test_segment_scratch_covers_only_configured_eligible_queries(
+    num_speculative_tokens, parallel_drafting, capacity
+):
+    builder = _builder(num_speculative_tokens, parallel_drafting)
+    assert builder.softmax_segm_output.shape == (capacity, 8, 16, 128)
+    assert builder.softmax_segm_max.shape == (capacity, 8, 16)
+    assert builder.softmax_segm_expsum.shape == (capacity, 8, 16)
+
+
+@pytest.mark.parametrize("query_len", [1, 5])
+def test_graph_dummy_lengths_cover_queries_and_reuse_segment_buffers(query_len):
+    builder = _builder()
+    common = _metadata([query_len, query_len, 0], [False, False, True])
+    first = builder.build(0, common)
+    captured = builder.build_for_cudagraph_capture(common)
+    assert captured.seq_lens.tolist() == [query_len] * 3
+    assert captured.softmax_segm_output is first.softmax_segm_output
+    assert captured.softmax_segm_max is first.softmax_segm_max
+    assert captured.softmax_segm_expsum is first.softmax_segm_expsum

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -39,7 +39,10 @@ from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
     triton_reshape_and_cache_flash_per_token_head_quant,
 )
-from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.attention.ops.triton_unified_attention import (
+    MAX_UNIFORM_DECODE_QUERY_LEN,
+    unified_attention,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVQuantMode,
@@ -94,6 +97,7 @@ class TritonAttentionMetadata:
     mm_prefix_range_tensor: torch.Tensor | None = None
     rswa_prefix_lens: torch.Tensor | None = None
     rswa_window: int | None = None
+    is_uniform_decode: bool = False
 
 
 class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMetadata]):
@@ -153,9 +157,23 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
 
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
+        max_query_len_3d = 1
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None:
+            num_speculative_tokens = speculative_config.num_speculative_tokens or 0
+            query_len = 1 + num_speculative_tokens * (
+                2 if speculative_config.parallel_drafting else 1
+            )
+            if query_len <= MAX_UNIFORM_DECODE_QUERY_LEN:
+                max_query_len_3d = query_len
+        # Scratch is indexed by query token, including verification tokens.
+        max_num_tokens_3d = (
+            min(self.seq_threshold_3D, vllm_config.scheduler_config.max_num_seqs)
+            * max_query_len_3d
+        )
         self.softmax_segm_output = torch.empty(
             (
-                self.seq_threshold_3D,
+                max_num_tokens_3d,
                 self.num_heads_q,
                 self.num_par_softmax_segments,
                 headdim_padded,
@@ -164,12 +182,12 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             device=device,
         )
         self.softmax_segm_max = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (max_num_tokens_3d, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
         self.softmax_segm_expsum = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (max_num_tokens_3d, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
@@ -188,8 +206,11 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         attn_metadata = self.build(0, common_attn_metadata)
         # When doing full graph capture, setting seq_lens to
         # max_model_len will cause graph capture to be extremely
-        # slow, so here we set it to 1.
-        attn_metadata.seq_lens.fill_(1)
+        # slow. Uniform verification still needs seq_len >= query_len.
+        capture_seq_len = (
+            attn_metadata.max_query_len if attn_metadata.is_uniform_decode else 1
+        )
+        attn_metadata.seq_lens.fill_(capture_seq_len)
         return attn_metadata
 
     def build(
@@ -201,6 +222,29 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         max_query_len = common_attn_metadata.max_query_len
+        is_uniform_decode = False
+        is_prefilling = common_attn_metadata.is_prefilling
+        speculative_config = self.vllm_config.speculative_config
+        if (
+            1 < max_query_len <= MAX_UNIFORM_DECODE_QUERY_LEN
+            and is_prefilling is not None
+            and not (
+                speculative_config is not None
+                and speculative_config.enable_adaptive_verification
+            )
+        ):
+            query_starts = common_attn_metadata.query_start_loc_cpu[: num_reqs + 1]
+            query_lens = query_starts[1:] - query_starts[:-1]
+            # MRV2 pads query offsets but keeps prefill flags at the active size.
+            num_phase_rows = min(num_reqs, len(is_prefilling))
+            is_uniform_decode = bool(
+                torch.any(query_lens > 0)
+                and torch.all((query_lens == 0) | (query_lens == max_query_len))
+                and torch.all(
+                    (query_lens[:num_phase_rows] == 0) | ~is_prefilling[:num_phase_rows]
+                )
+                and torch.all(query_lens[num_phase_rows:] == 0)
+            )
 
         max_seq_len = common_attn_metadata.max_seq_len
         query_start_loc = common_attn_metadata.query_start_loc
@@ -228,6 +272,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         attn_metadata = TritonAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
             max_query_len=max_query_len,
+            is_uniform_decode=is_uniform_decode,
             query_start_loc=query_start_loc,
             max_seq_len=max_seq_len,
             seq_lens=seq_lens,
@@ -668,6 +713,7 @@ class TritonAttentionImpl(AttentionImpl):
             q_descale=q_descale,
             k_descale=k_descale,
             v_descale=v_descale,
+            is_uniform_decode=attn_metadata.is_uniform_decode,
             seq_threshold_3D=seq_threshold_3D,
             num_par_softmax_segments=num_par_softmax_segments,
             softmax_segm_output=softmax_segm_output,

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -466,15 +466,15 @@ def softmax_step(S, M, L):
     # compute running maximum
     # m_j : (BLOCK_M,)
     m_j = tl.maximum(M, tl.max(S, axis=1))
-    # For sliding window there's a chance the max is -inf due to masking of
-    # the entire row. In this case we need to set m_j 0 to avoid NaN
-    m_j = tl.where(m_j > float("-inf"), m_j, 0.0)
+    # Keep an empty row's maximum at -inf for later tiles; use a finite shift
+    # only for the exponent arithmetic below.
+    safe_m_j = tl.where(m_j > float("-inf"), m_j, 0.0)
     # P : (BLOCK_M, TILE_SIZE)
-    P = tl.exp(S - m_j[:, None])
+    P = tl.exp(S - safe_m_j[:, None])
     # l_j : (BLOCK_M,)
     l_j = tl.sum(P, axis=1)
     # alpha : (BLOCK_M, )
-    alpha = tl.exp(M - m_j)
+    alpha = tl.exp(M - safe_m_j)
     # update constants
     L_new = L * alpha + l_j
     return m_j, L_new, P, alpha

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -746,8 +746,8 @@ def reduce_segments(
     )
     segm_max = tl.load(segm_max_ptr + segm_offset, mask=segm_mask, other=float("-inf"))
     segm_expsum = tl.load(segm_expsum_ptr + segm_offset, mask=segm_mask, other=0.0)
-    # Fully masked tiles have M=0,L=0; unvisited tiles have M=-inf,L=1.
-    # Neither may set the maximum, even when all real scores are negative.
+    # Empty segments must not set the maximum. Unvisited segments retain
+    # the M=-inf,L=1 initial state.
     valid_segment = segm_mask & (segm_expsum > 0) & (segm_max != float("-inf"))
     segm_max = tl.where(valid_segment, segm_max, float("-inf"))
     overall_max = tl.max(segm_max)

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -33,6 +33,7 @@ from vllm.v1.kv_cache_interface import KVQuantMode
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
+MAX_UNIFORM_DECODE_QUERY_LEN = 5
 
 
 @triton.jit
@@ -713,12 +714,18 @@ def reduce_segments(
     query_token_idx = tl.program_id(0)
     query_head_idx = tl.program_id(1)
 
+    # Graph padding must be rejected before sequence lookup or scratch access.
+    if query_token_idx >= tl.load(query_start_len_ptr + num_seqs):
+        return
+
     seq_idx = find_seq_idx(
         query_start_len_ptr, query_token_idx, num_seqs, BLOCK_Q, False
     )
 
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
+    if seq_len <= 0:
+        return
 
     # number of segments for this particular sequence
     num_segments = NUM_SEGMENTS_PER_SEQ
@@ -738,11 +745,16 @@ def reduce_segments(
         + tl.arange(0, NUM_SEGMENTS_PER_SEQ)
     )
     segm_max = tl.load(segm_max_ptr + segm_offset, mask=segm_mask, other=float("-inf"))
+    segm_expsum = tl.load(segm_expsum_ptr + segm_offset, mask=segm_mask, other=0.0)
+    # Fully masked tiles have M=0,L=0; unvisited tiles have M=-inf,L=1.
+    # Neither may set the maximum, even when all real scores are negative.
+    valid_segment = segm_mask & (segm_expsum > 0) & (segm_max != float("-inf"))
+    segm_max = tl.where(valid_segment, segm_max, float("-inf"))
     overall_max = tl.max(segm_max)
 
     # load and rescale segment exp sums
-    segm_expsum = tl.load(segm_expsum_ptr + segm_offset, mask=segm_mask, other=0.0)
-    segm_expsum = segm_expsum * tl.exp(segm_max - overall_max)
+    segment_scale = tl.where(valid_segment, tl.exp(segm_max - overall_max), 0.0)
+    segm_expsum = segm_expsum * segment_scale
     overall_expsum = tl.sum(segm_expsum)
 
     # load, rescale, and add segment attention outputs
@@ -758,7 +770,7 @@ def reduce_segments(
         mask=segm_mask[:, None] & dim_mask[None, :],
         other=0.0,
     )
-    segm_output *= tl.exp(segm_max - overall_max)[:, None]
+    segm_output *= segment_scale[:, None]
     acc_sum = tl.sum(segm_output, axis=0)
     # safely divide by overall_expsum, returning 0.0 if overall_expsum is 0
     acc = tl.where(overall_expsum == 0.0, 0.0, acc_sum / overall_expsum)
@@ -852,6 +864,7 @@ def unified_attention(
     # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window.
     # Default False keeps the original behavior for every other model.
     mm_prefix_clamp_sliding_window: bool = False,
+    is_uniform_decode: bool = False,
 ):
     # Resolve causal: bool or per-seq tensor.
     use_per_seq_causal = isinstance(causal, torch.Tensor)
@@ -1038,21 +1051,44 @@ def unified_attention(
             f"(out.stride(1) = {out.stride(1)} != head_size = {head_size})."
         )
 
-    # Launch the 2D kernel if
-    # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
-    # 2. The batch includes at least one prefill request, or
-    # 3. The number of sequences exceeds the configured threshold, or
-    # 4. Batch invariance is enabled
+    # Preserve single-query dispatch; multi-query split-K requires proven decode
+    # metadata and the bounded causal verification shape.
     use_3d = not (
         seq_threshold_3D is None
         or num_par_softmax_segments is None
         or softmax_segm_output is None
         or softmax_segm_max is None
         or softmax_segm_expsum is None
-        or max_seqlen_q > 1
+        or num_par_softmax_segments <= 0
+        or (
+            max_seqlen_q > 1
+            and (
+                not is_uniform_decode
+                or max_seqlen_q > MAX_UNIFORM_DECODE_QUERY_LEN
+                or not use_causal
+                or use_per_seq_causal
+                or use_mm_prefix
+            )
+        )
         or num_seqs > seq_threshold_3D
         or is_batch_invariant
     )
+    if use_3d:
+        # Both kernels use packed FP32 offsets, without scratch stride arguments.
+        scalar_shape = (num_query_heads, num_par_softmax_segments)
+        use_3d = all(
+            buffer.ndim == len(shape) + 1
+            and buffer.shape[0] >= q.shape[0]
+            and buffer.shape[1:] == shape
+            and buffer.dtype == torch.float32
+            and buffer.device == q.device
+            and buffer.is_contiguous()
+            for buffer, shape in (
+                (softmax_segm_output, (*scalar_shape, head_size_padded)),
+                (softmax_segm_max, scalar_shape),
+                (softmax_segm_expsum, scalar_shape),
+            )
+        )
 
     # The kernel signature is the same for 2D and 3D — only the launch
     # grid + a handful of constexpr toggles differ.  Per-token-head scale


### PR DESCRIPTION
## Review readiness — September 17, 2026

**Ready for review.** Retained standalone model execution now covers the supported six-query route, five-query padded route, and seven-query fallback on the current public Python source with compatible reused native binaries. This supplements the numerical, graph-replay and scratch-capacity tests recorded below; it is not a claim of universal non-regression or upstream CI success.

| Model route | Retained real GPU evidence | Diagnostic outcome |
| --- | --- | --- |
| Six queries | 2,475 3D producer/reducer pairs; full-width capture/replay | Both model requests succeeded; the old 20-second profiler stop and duplicate stop failed |
| Five queries, padded to ten | 2,772 3D producer/reducer pairs; actual padded graph replay and source/JIT-backed unvisited-segment coverage | Both model requests succeeded; the single 60-second profiler stop failed |
| Seven-query fallback | 2,508 2D launches in verification graphs without reducers; ordinary Q1 decoding separately retains its reducer path | Both model requests, single profiler stop, original response assertions and owned cleanup completed; model step exited 0 |

All six first/repeat responses returned HTTP 200 with 131 prompt and 128 generated tokens, with cached prompt tokens increasing from 0 to 112. They deliberately finish at the configured token limit and are not complete-answer accuracy measurements. The unchanged response validator also passes a new **offline** check of all six preserved response sets. This does not turn the earlier Q5/Q6 failed sessions into passes or manufacture their missing post-stop metrics.

Raw archives and trace counts, source/helper bindings, retained JIT artifacts and cleanup evidence were independently checked. No new Q5/Q6 GPU replay was used for this reconciliation. Review readiness rests on the observed intended paths, existing kernel regression coverage and the clean Q7 full lifecycle—not on a claim that all three profiler sessions were clean. Historical failures and performance tradeoffs below remain applicable. Human review and upstream CI remain outstanding.


## Historical workload and follow-up status — September 16, 2026

**Earlier draft status: the reviewed six-query recovery was included in the public diff.** It enables six physical query rows only for one non-prefill request on exact CUDA SM120, preserving the general widths-2–5 policy, 16 segments, scratch safety, masks and kernel/reducer arithmetic. No experimental 64-segment change or diagnostic tooling is included.

The production changes correspond to the source tested in the combined runtime. The model results below are **composed-runtime evidence, not isolated PR speedup, standalone-public-checkout validation or universal non-regression**. The historical latency-reference performance remains unreproduced. Submitting-human line-by-line review and independent execution are not claimed complete.

### Focused validation of the six-query recovery

- Same 105 imported route/capacity controls: **baseline 4 assertion failures / 101 passes → candidate 105 passes**, after successful dependency/source checks.
- **8 native GPU cases passed** on RTX PRO 6000 Blackwell SM120: three BF16-query/FP8-KV numerical cases with actual 3D-launch/scratch-write assertions, two same-buffer graph-replay/padding cases, and three undersized-scratch fallback cases. Numerical oracles and tolerances were not relaxed.
- **Two additional FP8-query native cases passed**, covering the one-head and eight-head KV families, for **10 focused native GPU cases total**. These extend coverage without rerunning or relabeling the first eight cases. This is not a paired ten-case GPU RED/GREEN claim.
- One real MiniMax-M3 TP8/PP1 EAGLE3 K5 request using the V2 runner confirmed six-query 3D producer/reducer graph replay on all eight ranks. A separate config-only V1 request also completed and preserved target-associated six-query graph execution, but its draft-associated attention path differs. Literal graph operand dtypes and draft-step labels are not inferred from eager operands alone.
- The earlier stack's four-iteration trace had six-query generation on safe 2D and a single-query 3D family. That earlier trace is not relabeled as six-query activation.
- An earlier package-manifest harness mismatch failed before tests. It was traced to package-name normalization and fixed without changing dependency versions; it is not kernel regression RED.
- During publication, required commit hooks rejected three CUDA-specific synchronization calls in the new tests. Those barriers now use the project's accelerator-neutral synchronization API. Required hooks pass, including Ruff, type checking and the CUDA API policy. Production, test inputs, oracles and tolerances are unchanged.
- **Fresh public-source GPU check completed September 16:** all **five exact public native cases passed in 13.16 seconds** on one RTX PRO 6000 Blackwell SM120 GPU: two six-query same-buffer graph-replay/padding cases and three undersized-scratch fallback cases. This directly checks the published synchronization-API adjustment. All 15 setup/call/teardown phases passed with zero failures or skips; CUDA initialization, exact test/production import origins, source/native postflight and owned cleanup were verified. The whole allocation lasted 1 minute 44 seconds. The run used the full public Python source with a pinned compatible native-library carrier, repository conftest loading disabled and external plugin autoload disabled. It does **not** claim repository-wide fixture qualification, a fresh native build, another model benchmark or new paired GPU RED/GREEN evidence.

Focused repository selections for reproduction in a dependency-complete environment:

```bash
uv run --no-sync python -m pytest --noconftest --pyargs tests.v1.attention.test_triton_attention_metadata tests.kernels.attention.test_triton_unified_attention -k 'not native and (six_query or test_splitk_validates_each_scratch_tensor or test_splitk_admission_preserves_decode_and_bounds_verification or test_uniform_decode or test_adaptive_verification or test_segment_scratch or test_graph_dummy_lengths)' --tb=short -q
uv run --no-sync python -m pytest --noconftest --pyargs tests.kernels.attention.test_triton_unified_attention -k 'test_six_query_native' --tb=short -q
```

### Composed-model results and sampling scope

The source-linked combined stack completed full 1,319-question real-rejection evaluations and hour-long serving runs for TP4/PP2 and TP8/PP1. These are not isolated PR results.

The six-query, 16-segment candidate passed the full **1,319-question C1 GSM8K evaluation**: **97.2707% strict match (1,283/1,319)** and **97.1948% flexible extract (1,282/1,319)**, with no empty or invalid responses and no recorded transport, read or observer errors. Evaluator and client exited zero in **1,182.89 seconds**; retained native results and samples were independently hash-verified. Owned full-phase cleanup was confirmed, with the held controller explicitly terminated rather than reported as a normal successful controller exit.

A separate matched cached-prefix real-model diagnostic improved nonstreaming continuation latency from **1.919720 to 1.511800 seconds (21.25% lower)**. This is one request pair, not a TTFT/ITL/p90 measurement or demonstrated full latency-reference recovery.

The candidate also completed the canonical **one-hour C1 serving run**: all 393 corpus traces loaded, **11 clean warmup requests and 204 successful measured requests**, no error-dropped records or native cancellation, client/serving-step exit 0, and existing replay/validity/metrics gates passed. Retained native exports were independently hash-verified; owned cleanup and allocation release were confirmed. Native measurements are **1,479.97401 input-plus-output tokens/s/GPU and 6.62234 ms p90 full-response ITL**, versus **941.77878 tokens/s/GPU / 19.85351 ms** for the earlier combined stack and **1,574.71189 tokens/s/GPU / 5.72987 ms** for the historical C1 reference. This improves on the earlier stack but **does not reproduce the historical leader**. The native throughput denominator is **3,607.41284 seconds**, distinct from the **3,600-second sending window**; a single-run comparison is not isolated PR causality or a universal non-regression claim.

**Sampling scope:** the full accuracy evaluation used standard, real rejection sampling. The serving run used the existing canonical synthetic-rejection policy with requested acceptance length **3.35**, matching the earlier combined-stack serving controls. These serving measurements are not a real-rejection serving result.

The source/test correspondence does not turn the combined-stack evaluations into isolated public-head validation. Earlier standalone native and sanitizer results below retain their original scope; they were not rerun for the new six-query cases. No minimum-sufficiency or historical-leader recovery claim is made.

## Purpose

Speculative verification supplies several query tokens per request, but Triton unified attention previously excluded those batches from split-K. This draft admits proven same-width, non-prefill query lengths 2–5, plus the strictly bounded single-request six-row SM120 case, and allocates scratch per query token. It checks actual row capacity, dimensions, FP32 dtype, device and contiguous layout of all three scratch tensors before selecting split-K. Ordinary single-query admission and the 16-segment default are preserved. Unsupported hardware, mixed/prefill batches, inconsistent offsets and insufficient scratch retain their safe fallback behavior.

The accompanying correctness safeguards give graph capture valid dummy sequence lengths, reject padded reducer rows before sequence lookup, and exclude fully masked or unvisited softmax segments from the reduction. This prevents empty segments from suppressing valid negative logits. Metadata handling covers MRV2's unpadded prefill flags and conservatively excludes adaptive verification, whose device query boundaries may differ from its CPU metadata.

This main-based draft overlaps #52879's query-row scratch/admission change and adds independently useful correctness safeguards and regression tests absent at the snapshot previously reviewed. It is intended for coordination and consolidation with #52879; the shared enablement should land once. The earlier overlap review also checked #45450, #44652 and #46724; none contained this complete set of guards/tests at the reviewed snapshots. Related threshold work #54191/#47520 is outside this change. This does not change prefill index-score splitting or DiffKV's separate launcher.

## Historical standalone validation — original scope preserved

These records concern earlier revisions of this draft and its original widths-2–5 safeguards. They are not new six-query executions or current combined-stack performance attribution.

- Real metadata-builder CPU tests: **19 passed**.
- Triton interpreter and dispatcher tests: **79 passed**, including 12 FP16 reference cases across query widths 2, 4 and 5, 2D/3D paths and sliding windows; the subsequent empty-maximum regression brought that local CPU/interpreter suite to **80 passed**.
- Changed-file pre-commit hooks and manual Python 3.12 mypy: **passed** at those revisions.
- Offline SM120 compilation: **6 captured launches, 5 unique cubins**, covering BF16 queries with BF16/FP8 KV, 2D/3D attention and reducers. This is compiler validation, not GPU execution.

Those CPU checks used Python 3.12, torch 2.13.0+cpu, Triton 3.8.0 and an editable source installation. They imported the implementation normally; `--noconftest` avoided unrelated engine fixtures. Dispatch-only cases recorded launches rather than executing GPU kernels. BF16 interpreter experiments failed even on the existing 2D path and are not counted as correctness validation; Triton documents BF16 interpreter limitations. Masked-arithmetic and Torch JIT deprecation warnings were retained.

### Earlier native correctness and sanitizers

Native correctness passed on RTX PRO 6000 Blackwell SM120 with Torch 2.13.0+cu130 and Triton 3.7.1. Unchanged native inputs, 406 active dependency versions and 17 native-library identities were verified.

| Check | Passed | Failed | Skipped | Scope |
| --- | ---: | ---: | ---: | --- |
| Focused upstream suite | 91 | 0 | 0 | 33 GPU attention/helper/reducer cases; 58 CPU dispatch guards |
| Supplemental native BF16/FP8 KV cases | 67 | 0 | 0 | Widths 1–5/width-8 fallback, scratch layout/device/dtype, padding, dummy lengths, negative logits and zero mass |
| Compute Sanitizer memcheck | 65 | 0 | 0 | 0 memory errors |
| Compute Sanitizer racecheck | 12 | 0 | 0 | 0 hazards |

Actual CUDA graph capture/replay passed: **10 captures and 60 replays** across changing active/padded request counts per suite; sanitizer suites repeated those cases. Actual producer/reducer launches were observed. BF16/FP8 producers used 64/102 registers per thread and 12,928/16,512 bytes shared memory; the reducer used 39 registers and 2,048 bytes. These establish the original launch/resource scope, not paired model performance.

Testing found an additional earlier bug: an entirely masked first tile stored a running maximum of zero, underflowing later valid negative logits. The fix preserves the true maximum at negative infinity while using a separate finite exponent shift. Its regression failed before the fix. The shared helper and DiffKV/INT4 callers received AI-peer review; their launchers were unchanged.

Failed attempts remain preserved rather than relabeled: package-inventory and UUID-format helper failures, followed by an earlier numerical run with 90 public passes, 65 supplemental passes/2 numerical failures, 63 memcheck passes/2 numerical failures with zero memory errors, and 10 racecheck passes/2 numerical failures with zero hazards. The later successful suites validated the numerical correction for BF16 and FP8 KV.

### Earlier paired operator timings and retained regressions

The earlier paired attention benchmark completed **64/64 cases** with **256 eager/graph reference checks passing** across both arms in **68.80 seconds**. The matrix was C1/C8 × query widths 1/2/4/5 × KV 128/4096/32768/131072 × BF16/FP8 KV, with BF16 queries, 8 query heads/1 KV head, head/page size 128, and 16 segments. CUPTI measured the entire captured attention operation including the reducer, cold L2, three alternating rounds and 40 samples per arm/round. Each arm used its own bound attention and softmax-helper source.

Verification widths 2/4/5 at KV ≥4096 were **4.25–9.34× faster** over 36 cases. At KV128, ratios ranged **0.950–1.259×**. Representative C8 results, base→candidate median microseconds:

| Query width | KV length | BF16 KV | FP8 KV |
| --- | ---: | --- | --- |
| 4 | 4096 | 184.192→42.369 (4.35×) | 203.969→34.033 (5.99×) |
| 4 | 32768 | 1339.815→195.522 (6.85×) | 1445.719→182.993 (7.90×) |
| 5 | 4096 | 184.962→43.520 (4.25×) | 189.905→35.968 (5.28×) |
| 5 | 32768 | 1332.999→205.985 (6.47×) | 1416.231→206.785 (6.85×) |

**Regressions retained:** all 16 single-query rows were **0.17–5.53% slower** (2.12% geometric-mean latency increase), and C8/query-width-5/BF16/KV128 was **5.22% slower** (8.576→9.024 µs). AI-peer review found that these costs persisted across reversed-order rounds, without timer or launch-recorder contamination. The reducer added 34 SASS instructions for its guards; main instruction counts/resources were unchanged, with scheduling/register-operand differences. Exact per-kernel attribution was not established. The reviewed decision retained the correctness safeguards and documented the tradeoff; no threshold or segment-default change was justified by that matrix. These are operator timings, not model throughput; separate host-enqueue measurements excluded metadata-builder cost.

### Historical model attempts and recovery limitations

An earlier exact-base MiniMax-M3 attempt failed before readiness with `No common block size for 16`; zero questions ran. A replacement used 128-token blocks and Triton attention for both target and EAGLE3 draft without changing weights, evaluator, dataset or sampler.

One historical evaluator completed all **1,319 questions** and exited zero after **1,640.10 seconds**, but its wrapper failed because Python `splitlines()` split literal U+2028 characters inside a logged prompt. The failed wrapper status was preserved. LF-only parsing of the unchanged output validated **2,638 records**, all documents per filter, and **1,269/1,319 correct (96.20925%)** for both filters; this postvalidation did not turn the original failed attempt into a qualified run.

A strict baseline retry subsequently completed with same-step sealing: **1,265/1,319 strict-match (95.90599%)** and **1,264/1,319 flexible-extract (95.83017%)**, above the 90% floor, in **1,594.41 seconds**. Source/library-origin checks, descriptor closure, zero API errors and owned teardown were verified. Shutdown-only EngineDeadError/resource-tracker diagnostics were retained. Mean acceptance length **3.1156** was cumulative across smoke, pilot and full evaluation, not a full-only metric.

The parser correction had **84 passing CPU control tests**, including three real-file Unicode regressions and 11 collector-interface checks. These were private execution-control checks, not added production functionality or isolated PR model-performance evidence. Older recovery-era candidate work was still unrun at that time, and all old execution grants were retired. Historical baseline reuse was conditional on exact matching, not evidence for later runtimes. The newer composed-model results at the top do not rewrite those original failures or recovery limits.

Earlier GitHub checks were contributor-eligibility gated, and a successful CodeRabbit status reported that review was skipped. Neither is claimed as current upstream CI or human review completion. No CI trigger was retried for this update.

AI assistance: implementation and AI-peer review used OpenAI GPT-6 Astra with xhigh reasoning effort; the listed execution was agent/coordinator-driven. Published as a user-authorized **draft** for submitting-human review. Human line-by-line review, independent human execution and publication readiness are not asserted complete.
