### PR TITLE
[WIP][Bugfix][HiSparse] Restore host mirror state before FULL CUDA graph replay

### DIFF
--- a/tests/v1/e2e/general/test_hisparse.py
+++ b/tests/v1/e2e/general/test_hisparse.py
@@ -3,8 +3,10 @@
 
 import prometheus_client
 import pytest
+import torch
 
 from tests.conftest import VllmRunner
+from vllm import SamplingParams
 from vllm.config import AttentionConfig, HiSparseConfig, KVTransferConfig
 from vllm.platforms import current_platform
 
@@ -44,6 +46,74 @@ def _offload_load_bytes() -> float:
         for sample in metric.samples
         if sample.name == "vllm:kv_offload_load_bytes_total"
     )
+
+
+def _check_last_token_host_mirrors(model) -> int:
+    torch.accelerator.synchronize()
+    checked = set()
+    for layer in model.modules():
+        cache = getattr(layer, "hisparse_cache", None)
+        if cache is None or id(cache) in checked:
+            continue
+        assert cache.view is not None
+        source_slot = int(cache.slot_mapping[0].item())
+        host_slot = int(cache.mirror_slot_mapping[0].item())
+        assert source_slot >= 0 and host_slot >= 0
+        block, row = divmod(source_slot, cache.view.block_size)
+        expected = cache.view.cache[block, row].cpu().view(torch.uint8)
+        actual = cache.runtime.host_cache[host_slot].view(torch.uint8)
+        assert torch.equal(actual, expected), "Decode KV was not mirrored to host"
+        checked.add(id(cache))
+    return len(checked)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="HiSparse requires NVIDIA CUDA"
+)
+def test_hisparse_fullgraph_decode_mirrors_written_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    vllm_runner: type[VllmRunner],
+):
+    """Graph-replayed decode must mirror KV before any page is spilled."""
+    capability = current_platform.get_device_capability()
+    if capability is None or capability.major < 9:
+        pytest.skip("Sparse MLA requires Hopper or newer")
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("VLLM_DEEP_GEMM_WARMUP", "skip")
+
+    with vllm_runner(
+        MODEL,
+        load_format="dummy",
+        hf_overrides=_shrink_config,
+        attention_config=AttentionConfig(
+            hisparse_config=HiSparseConfig(
+                device_buffer_size=512, eager_host_mirror=True
+            )
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="HiSparseConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={"host_pool_gib": 1},
+        ),
+        block_size=64,
+        max_model_len=320,
+        max_num_batched_tokens=1024,
+        max_num_seqs=4,
+        num_gpu_blocks_override=128,
+        enable_chunked_prefill=True,
+        enable_prefix_caching=False,
+        async_scheduling=True,
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [1, 4],
+        },
+    ) as runner:
+        runner.llm.generate(
+            [{"prompt_token_ids": [1000 + i % 64 for i in range(32)]}],
+            SamplingParams(temperature=0, max_tokens=8, ignore_eos=True),
+        )
+        assert all(runner.llm.apply_model(_check_last_token_host_mirrors))
 
 
 @pytest.mark.skipif(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hisparse/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hisparse/worker.py
@@ -822,6 +822,11 @@ class HiSparseConnectorWorker:
     def _finish_mirror_phase(self, ready_event: torch.Event | None = None) -> None:
         state = self._slot_mapping_staging
         if state is not None and state.num_tokens:
+            if not any(handle.num_actual_tokens for handle in self.cache_handles):
+                raise RuntimeError(
+                    "HiSparse has scheduled KV writes but no active mirror metadata. "
+                    "Prepare mirror state before CUDA graph replay."
+                )
             # Measured free: blocking here costs no throughput (26.7 vs 27.6
             # gen tok/s) and lets every step mirror exactly the written rows.
             state.event.synchronize()

--- a/vllm/v1/hisparse/runtime.py
+++ b/vllm/v1/hisparse/runtime.py
@@ -997,6 +997,18 @@ class HiSparseCacheHandle:
         )
 
 
+def prepare_hisparse_for_graph_replay(
+    attn_metadata: dict[str, Any],
+    forward_context: dict[str, Any],
+) -> None:
+    """Refresh host-side mirror state skipped by FULL CUDA graph replay."""
+    for layer_name, metadata in attn_metadata.items():
+        layer = forward_context.get(layer_name)
+        cache = getattr(layer, "hisparse_cache", None)
+        if cache is not None and cache.runtime.is_group_leader:
+            cache.prepare_group_for_batch(metadata)
+
+
 def create_hisparse_cache_handle(
     vllm_config: VllmConfig,
     model_top_k: int,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -66,6 +66,7 @@ from vllm.utils.gc_utils import freeze_gc_for_cudagraph_capture
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+from vllm.v1.hisparse.runtime import prepare_hisparse_for_graph_replay
 from vllm.v1.kv_cache_interface import (
     CircularBufferSpec,
     HiSparseHotSpec,
@@ -1839,6 +1840,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 input_batch.idx_mapping,
                 input_batch.req_ids,
             )
+            if not dummy_run and self.kv_cache_config.hisparse_host_num_blocks:
+                assert attn_metadata is not None
+                prepare_hisparse_for_graph_replay(
+                    attn_metadata, self.compilation_config.static_forward_context
+                )
             model_output = self.cudagraph_manager.run_fullgraph(batch_desc)
         else:
             # For piecewise and eager mode, just call model().


### PR DESCRIPTION
## Purpose

Fix missing host KV writes during HiSparse FULL CUDA graph decode. Once GPU-resident pages are spilled, subsequent host fetches can read unwritten KV and corrupt generation without raising a serving error.

WIP, targeting `feat/hisparse-metrics` (#53782). This contains only the mirror-state correction, a guard against silently missing mirror metadata, and one regression test. CUDA graphs and async scheduling remain enabled.

## Reproduction and cause

We reproduced the issue with GLM-5.3 on two nodes / 16 H200 GPUs, EP16/TP1, using 1,024 concurrent fresh generations from 32 frozen long-reasoning math prompts. The configuration used FP8 KV, 4,096 hot rows, eager host mirroring, a 160 GiB host KV pool per rank, FULL decode graphs, async scheduling, and prefix caching disabled.

Output was initially readable. Resident KV reached capacity around 13.2k median context, and unrelated numeric-word garbling appeared around 13.9k as decoding began relying on host fetches. This happened without client errors or preemptions.

The connector clears per-batch mirror metadata at the beginning of each step. Eager execution rebuilds it in the Python attention path, but FULL graph replay bypasses that Python preparation. Newly written decode KV can therefore be left uncopied on the host. Later spills under eager mirroring trust the host copy, so the problem becomes visible only when those rows are fetched again.

The smaller regression isolates that missing write without a long benchmark: a dummy-weight sparse-MLA model performs FULL-graph decode with eager mirroring and async scheduling, then compares the final decoded token's host KV bytes with its resident GPU bytes. On the original implementation the host row is zero while the GPU row is nonzero.

## Change

- Prepare each HiSparse index-sharing group's per-batch mirror state after `kv_connector.pre_forward()` and before `run_fullgraph()` for real HiSparse batches.
- Raise an error when mirror completion has scheduled KV writes but no active mirror metadata, instead of silently skipping the write.
- Add the small GPU regression to the existing HiSparse E2E test file.

Four files: 23 production lines and 70 test lines. The separate DeepEP allocation optimization, benchmark scripts, output files, and validation instrumentation are excluded.

## Test plan and results

Targeted regression command run:

```bash
python -m pytest --import-mode=importlib -v -s \
  tests/v1/e2e/general/test_hisparse.py::test_hisparse_fullgraph_decode_mirrors_written_rows
```

- Original code: fails with `Decode KV was not mirrored to host`.
- Patched code: passes in 33.18 seconds.
- Pre-commit checks on the four changed files passed on both the tested revision and the updated PR base (including mypy):

```bash
pre-commit run --files \
  tests/v1/e2e/general/test_hisparse.py \
  vllm/distributed/kv_transfer/kv_connector/v1/hisparse/worker.py \
  vllm/v1/hisparse/runtime.py \
  vllm/v1/worker/gpu/model_runner.py
```

Model-serving validation with this fix, preserving the original 1,024-request configuration:

| Check | Result |
| --- | --- |
| Mean and median context gate | Both ≥40,960 tokens |
| Measurement after reaching the gate | 182.21 seconds |
| Aggregate generation throughput | 8,869.80 tokens/sec |
| Final median context | 42,839.5 tokens |
| Client errors / worker errors / preemptions | 0 / 0 / 0 |
| Saved responses | 1,038: 14 natural completions, 1,024 deliberate window-end cancellations |

Validation-only instrumentation periodically compared host/GPU mirror spans across all 78 layers and all 16 ranks. All 2,704 logged checks matched; this count is cumulative across the serving allocation, including an earlier interrupted warmup. Host fetching remained active above the gate. The instrumentation is excluded from this PR and its synchronization is included in the reported throughput.

All saved responses were screened for the reproduced numeric-word degeneration. The 66 heuristic flags were assessed through literal-command classification and manual match-inventory/ending-excerpt review; no original garbling was observed within that scope. This is not exhaustive text validation or a mathematical accuracy evaluation.

GPU regression and serving results above were obtained on `f17f8b4819c6d62077b66446ff35424c269d7f69` plus this patch. The same patch applies cleanly to the current target `a2a8d4e106b3ff25791136b267db8012a20efc66`; GPU validation has not been repeated on that updated base. This remains WIP for maintainer review and CI.

## Related work and AI assistance

Checked open HiSparse PRs, open PRs mentioning #53782, graph/mirror PRs, and related issue search. The metrics and cache-placement PRs cover different changes; no existing PR addressing this skipped FULL-replay mirror preparation was found. This is a correctness follow-up to #53782, rather than another metrics implementation.

AI assistance (Codex) was used to investigate, implement, test, and draft this change. Human review remains pending; this is a draft PR.
