### PR TITLE
fix(triton_attn): support decoupled scale caches to preserve 128B memory alignment

### DIFF
--- a/tests/v1/attention/test_triton_kv_scale_alignment.py
+++ b/tests/v1/attention/test_triton_kv_scale_alignment.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import ClassVar
+
+import pytest
+import torch
+
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.attention.backends.triton_attn import (
+    TritonAttentionBackend,
+    TritonAttentionImpl,
+)
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVQuantMode
+
+
+@pytest.fixture(autouse=True)
+def should_do_global_cleanup_after_test():
+    return False
+
+
+def test_triton_attn_backend_supports_inline_scales_flag():
+    """Verify default class attribute on backend and customization behavior."""
+    assert AttentionBackend.supports_inline_scales is True
+    assert TritonAttentionBackend.supports_inline_scales is True
+
+    # Per-token-head INT8 spec with head_size=256
+    spec = FullAttentionSpec(
+        block_size=64,
+        num_kv_heads=2,
+        head_size=256,
+        dtype=torch.int8,
+        kv_quant_mode=KVQuantMode.INT8_PER_TOKEN_HEAD,
+    )
+
+    # 1. Default: inline scales pack 4-byte fp32 scale per head
+    custom_spec = TritonAttentionBackend.customize_spec(spec)
+    # hs_k=256, hs_v=256, scale_bytes=4 -> (256 + 256) * 1 + 2 * 4 = 520 bytes
+    assert custom_spec.state_content_bytes == 520
+    assert custom_spec.state_content_bytes % 128 != 0
+
+    # 2. Gather / sparse backend opting out of inline scales
+    class MockGatherAttentionBackend(TritonAttentionBackend):
+        supports_inline_scales: ClassVar[bool] = False
+
+    decoupled_spec = MockGatherAttentionBackend.customize_spec(spec)
+    # Preserves natural unpadded spec (512 bytes per slot, 128B aligned)
+    assert decoupled_spec.state_content_bytes is None
+
+
+def test_triton_attn_impl_inline_scale_caches():
+    """Verify inline scale cache views when supports_inline_scales=True."""
+    num_blocks = 2
+    nkv = 2
+    block_size = 64
+    head_size = 256
+    scale_pad = 4  # sizeof(float32) / sizeof(int8)
+    content = 2 * (head_size + scale_pad)  # 520 bytes
+
+    # Inline packed KV cache: (num_blocks, nkv, block_size, 520)
+    kv_cache = torch.zeros(
+        (num_blocks, nkv, block_size, content),
+        dtype=torch.int8,
+    )
+
+    impl = TritonAttentionImpl(
+        num_heads=4,
+        head_size=head_size,
+        scale=1.0,
+        num_kv_heads=nkv,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="int8_per_token_head",
+        supports_inline_scales=True,
+    )
+    assert impl.supports_inline_scales is True
+
+    key_cache, value_cache = impl._pth_key_value_caches(kv_cache)
+    # Padded head size: 260
+    assert key_cache.shape == (num_blocks, block_size, nkv, 260)
+    assert value_cache.shape == (num_blocks, block_size, nkv, 260)
+    assert impl._k_scale_cache is not None
+    assert impl._v_scale_cache is not None
+    assert impl._k_scale_cache.shape == (num_blocks, block_size, nkv)
+    assert impl._v_scale_cache.shape == (num_blocks, block_size, nkv)
+
+
+def test_triton_attn_impl_decoupled_side_tensor_scale_caches():
+    """Verify decoupled side-tensor scale caches when supports_inline_scales=False."""
+    num_blocks = 2
+    nkv = 2
+    block_size = 64
+    head_size = 256
+    # Natural unpadded KV cache: (num_blocks, nkv, block_size, 512)
+    content = 2 * head_size  # 512 bytes (256B K + 256B V)
+
+    kv_cache = torch.zeros(
+        (num_blocks, nkv, block_size, content),
+        dtype=torch.int8,
+    )
+
+    impl = TritonAttentionImpl(
+        num_heads=4,
+        head_size=head_size,
+        scale=1.0,
+        num_kv_heads=nkv,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="int8_per_token_head",
+        supports_inline_scales=False,
+    )
+    assert impl.supports_inline_scales is False
+
+    key_cache, value_cache = impl._pth_key_value_caches(kv_cache)
+
+    # 1. KV cache split preserves natural 128B alignment
+    assert key_cache.shape == (num_blocks, block_size, nkv, head_size)
+    assert value_cache.shape == (num_blocks, block_size, nkv, head_size)
+    assert key_cache.shape[-1] % 128 == 0
+    assert value_cache.shape[-1] % 128 == 0
+
+    # 2. Scale caches allocated as decoupled side tensors with float32
+    assert impl._k_scale_cache is not None
+    assert impl._v_scale_cache is not None
+    assert impl._k_scale_cache.shape == (num_blocks, block_size, nkv)
+    assert impl._v_scale_cache.shape == (num_blocks, block_size, nkv)
+    assert impl._k_scale_cache.dtype == torch.float32
+    assert impl._v_scale_cache.dtype == torch.float32
+    assert torch.all(impl._k_scale_cache == 1.0)
+    assert torch.all(impl._v_scale_cache == 1.0)
+
+    # 3. Decoupled tensors have distinct storage from kv_cache
+    assert impl._k_scale_cache.data_ptr() != kv_cache.data_ptr()
+    assert impl._v_scale_cache.data_ptr() != kv_cache.data_ptr()
+
+
+def test_attention_layer_forwarding_supports_inline_scales():
+    """Verify backend supports_inline_scales forwards to AttentionImpl."""
+    import inspect
+
+    class MockGatherAttentionBackend(TritonAttentionBackend):
+        supports_inline_scales: ClassVar[bool] = False
+
+    backend = MockGatherAttentionBackend()
+    impl_cls = backend.get_impl_cls()
+    sig = inspect.signature(impl_cls.__init__)
+    extra_impl_args = {}
+    if (
+        hasattr(backend, "supports_inline_scales")
+        and "supports_inline_scales" in sig.parameters
+    ):
+        extra_impl_args.setdefault(
+            "supports_inline_scales", backend.supports_inline_scales
+        )
+
+    impl = impl_cls(
+        num_heads=4,
+        head_size=256,
+        scale=1.0,
+        num_kv_heads=2,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="int8_per_token_head",
+        **extra_impl_args,
+    )
+    assert impl.supports_inline_scales is False

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -413,6 +413,16 @@ class Attention(nn.Module, AttentionLayerBase):
             if block_n is not None:
                 extra_impl_args.setdefault("block_n", block_n)
 
+        if hasattr(self.attn_backend, "supports_inline_scales"):
+            import inspect
+
+            sig = inspect.signature(self.attn_backend.get_impl_cls().__init__)
+            if "supports_inline_scales" in sig.parameters:
+                extra_impl_args.setdefault(
+                    "supports_inline_scales",
+                    self.attn_backend.supports_inline_scales,
+                )
+
         impl_cls = self.attn_backend.get_impl_cls()
         self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
             num_heads,

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -69,6 +69,13 @@ class AttentionBackend(ABC):
     # Does attention's forward() include kv cache update?
     forward_includes_kv_cache_update: bool = True
 
+    # Whether this backend supports / packs per-token-head KV scales inline
+    # with the key/value data (content dim = 2 * (hs + pad)).
+    # Gather-based and sparse attention backends can set this to False to opt into
+    # decoupled side-tensor scale allocation (_k_scale_cache / _v_scale_cache),
+    # preserving 128-byte memory alignment for coalesced cache loads.
+    supports_inline_scales: ClassVar[bool] = True
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [MultipleOf(1)]

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -272,10 +272,22 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
 
 
 class TritonAttentionBackend(AttentionBackend):
+    supports_inline_scales: ClassVar[bool] = True
+
     @classmethod
     def customize_spec(cls, spec: "AttentionSpec") -> "AttentionSpec":
         """Per-token-head modes pack inline fp32 scales after each head's
-        data, so the content is (data + one scale) per K/V side."""
+        data by default, so the content is (data + one scale) per K/V side.
+
+        Note: Inline scale packing assumes contiguous KV access and is not
+        suitable for backends that gather scattered tokens (such as sparse or
+        selective attention), where non-128B-aligned row strides can cause
+        significant kernel slowdown. Backends requiring 128B memory coalescing
+        can set `supports_inline_scales = False` to opt into decoupled side-tensor
+        scale cache allocation.
+        """
+        if not cls.supports_inline_scales:
+            return spec
         mode = spec.kv_quant_mode
         if spec.state_content_bytes is not None or not mode.is_per_token_head:
             return spec
@@ -375,13 +387,22 @@ class TritonAttentionBackend(AttentionBackend):
 
 
 class TritonAttentionImpl(AttentionImpl):
-    # Per-token-head quant: scale views carved from inline head padding.
+    # Per-token-head quant: scale views carved from inline head padding
+    # or allocated as decoupled side tensors when supports_inline_scales is False.
+    supports_inline_scales: bool = True
     _k_scale_cache: torch.Tensor | None = None
     _v_scale_cache: torch.Tensor | None = None
 
     def _ensure_scale_caches(self, kv_cache: torch.Tensor) -> None:
-        """Extract per-head scale views from the padded content dimension.
+        """Extract per-head scale views from the padded content dimension,
+        or allocate decoupled side tensors if supports_inline_scales is False.
 
+        When supports_inline_scales is False:
+        Allocates decoupled side-tensor scale caches with shape
+        (num_blocks, block_size, num_kv_heads) filled with 1.0, preserving
+        natural 128B memory alignment for KV data.
+
+        When supports_inline_scales is True:
         The KV cache is packed as logical shape
         ``(num_blocks, nkv, block_size, 2 * (hs + pad))`` where
         ``pad = sizeof(float32) / sizeof(cache_dtype)``.  The content dim holds
@@ -395,6 +416,21 @@ class TritonAttentionImpl(AttentionImpl):
         """
         if self._k_scale_cache is not None:
             return
+
+        if not getattr(self, "supports_inline_scales", True):
+            num_blocks, nkv, block_size = kv_cache.shape[:3]
+            self._k_scale_cache = torch.ones(
+                (num_blocks, block_size, nkv),
+                dtype=torch.float32,
+                device=kv_cache.device,
+            )
+            self._v_scale_cache = torch.ones(
+                (num_blocks, block_size, nkv),
+                dtype=torch.float32,
+                device=kv_cache.device,
+            )
+            return
+
         from vllm.utils.torch_utils import get_dtype_size
 
         num_blocks, nkv, block_size, content = kv_cache.shape
@@ -460,11 +496,15 @@ class TritonAttentionImpl(AttentionImpl):
         sinks: torch.Tensor | None = None,
         use_alibi_sqrt: bool = False,
         chunk_lookback: int = -1,
+        supports_inline_scales: bool | None = None,
     ) -> None:
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
         self.num_kv_heads = num_kv_heads
+        if supports_inline_scales is None:
+            supports_inline_scales = TritonAttentionBackend.supports_inline_scales
+        self.supports_inline_scales = supports_inline_scales
         if alibi_slopes is not None:
             alibi_slopes = torch.tensor(alibi_slopes, dtype=torch.float32)
         self.alibi_slopes = alibi_slopes
@@ -695,8 +735,8 @@ class TritonAttentionImpl(AttentionImpl):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Per-token-head K/V cache views (ensures scale caches; FP8 retyped)."""
         self._ensure_scale_caches(kv_cache)
-        padded_hs = kv_cache.shape[-1] // 2
-        key_cache, value_cache = kv_cache.transpose(1, 2).split(padded_hs, dim=-1)
+        split_hs = kv_cache.shape[-1] // 2
+        key_cache, value_cache = kv_cache.transpose(1, 2).split(split_hs, dim=-1)
         if self._kv_quant_mode == KVQuantMode.FP8_PER_TOKEN_HEAD:
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)


### PR DESCRIPTION
Fixes #56081.

### Description

In `TritonAttentionBackend`, per-token-head quantized KV scales are packed inline by default, appending an fp32 scale after each head's quantized data. For `head_size=256` int8 caches, each head slot becomes 260 bytes (520 bytes per K/V pair). This breaks 128-byte memory coalescing, leading to a 6.3x slowdown in gather-based and sparse attention kernels (such as QSA sparse paged attention).

This PR makes scale cache placement configurable per backend and layer:
1. Adds `supports_inline_scales: ClassVar[bool] = True` on `AttentionBackend` and `TritonAttentionBackend`.
2. Documents the alignment constraint in `customize_spec` and skips inline scale padding when `supports_inline_scales` is False, retaining natural unpadded 512-byte slot layout.
3. In `TritonAttentionImpl._ensure_scale_caches`, allocates decoupled side-tensor scale caches (`_k_scale_cache` and `_v_scale_cache`) with shape `(num_blocks, block_size, num_kv_heads)` in float32 when `supports_inline_scales` is False.
4. In `TritonAttentionImpl._pth_key_value_caches`, splits unpadded caches cleanly into 128-byte aligned key and value slices.
5. In `Attention` layer, forwards `supports_inline_scales` from backend to implementation.
6. Adds comprehensive regression unit tests in `tests/v1/attention/test_triton_kv_scale_alignment.py`.
