### PR TITLE
[Bugfix][Kernel] Fix clustered BF16 router synchronization

### DIFF
--- a/tests/kernels/test_ll_bf16_gemm.py
+++ b/tests/kernels/test_ll_bf16_gemm.py
@@ -2,6 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for cuteDSL low-latency router GEMM (dot-product + split-K)."""
 
+import shutil
+import subprocess
+import sys
+import textwrap
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -164,6 +169,44 @@ def test_splitk_K_sweep(K):
     a = torch.randn(8, K, dtype=torch.bfloat16, device="cuda")
     b = torch.randn(64, K, dtype=torch.bfloat16, device="cuda")
     _assert_close(_gemm(a, b), _ref(a, b), context=f"splitk K={K}")
+
+
+def test_splitk_producer_consumer_barriers():
+    """Partial-block MMA barriers must not rendezvous with DMA exit barriers."""
+    sanitizer = shutil.which("compute-sanitizer")
+    if sanitizer is None:
+        pytest.skip("compute-sanitizer is required to check barrier participation")
+    assert sanitizer is not None
+    code = textwrap.dedent("""
+        import torch
+        from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import ll_bf16_gemm
+
+        for rows, width, experts in ((5, 2048, 17), (16, 4096, 256)):
+            a = torch.ones((rows, width), device="cuda", dtype=torch.bfloat16)
+            b = torch.ones((experts, width), device="cuda", dtype=torch.bfloat16)
+            output = ll_bf16_gemm(a, b)
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(
+                output, torch.full_like(output, width), rtol=0, atol=0
+            )
+    """)
+    result = subprocess.run(
+        [
+            sanitizer,
+            "--tool",
+            "synccheck",
+            "--error-exitcode",
+            "86",
+            sys.executable,
+            "-c",
+            code,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ERROR SUMMARY: 0 errors" in result.stdout + result.stderr
 
 
 # =================================================================

--- a/vllm/model_executor/kernels/linear/cute_dsl/_ll_bf16_splitk.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/_ll_bf16_splitk.py
@@ -357,6 +357,19 @@ class LLBf16SplitK:
             consumer_group=consumer_group,
         )
 
+        num_elems: cutlass.Constexpr = self.num_epilogue_elems
+        elems_per_thread: cutlass.Constexpr = self.epilogue_elems_per_thread
+        partials = cute.make_tensor(
+            cute.arch.alloc_smem(
+                cutlass.Float32, num_elems * self.split_k, alignment=16
+            ),
+            cute.make_layout((self.split_k, num_elems), stride=(num_elems, 1)),
+        )
+        cta_rank = cute.arch.block_idx_in_cluster()
+        # A peer's DSMEM may be accessed only after that CTA has started.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
+
         # Round-robin split-K: split z handles tiles z, z+split_k, ...
         K_total = cute.size(mA, mode=[1])
         k_tile_count = cute.size(gA, mode=[2])
@@ -497,8 +510,6 @@ class LLBf16SplitK:
 
             # Cluster reduction epilogue.
             # Reduce per-warp accumulators within this CTA.
-            num_elems: cutlass.Constexpr = self.num_epilogue_elems
-            elems_per_thread: cutlass.Constexpr = self.epilogue_elems_per_thread
             # Map MMA threads to linear CTA output elements.
             epilogue_thread_layout = cute.make_layout(
                 (elems_per_thread, self.num_mma_threads),
@@ -519,16 +530,8 @@ class LLBf16SplitK:
             )
             tCsC_partial = thr_mma.partition_C(smem_warp)
             cute.autovec_copy(tCrC, tCsC_partial)
-            cute.arch.sync_threads()
-
-            # Layout: (split-K rank, linear MN element).
-            partials = cute.make_tensor(
-                cute.arch.alloc_smem(
-                    cutlass.Float32, num_elems * self.split_k, alignment=16
-                ),
-                cute.make_layout((self.split_k, num_elems), stride=(num_elems, 1)),
-            )
-            cta_rank = cute.arch.block_idx_in_cluster()
+            # DMA warps drain the copy pipeline independently of MMA reduction.
+            cute.arch.barrier(barrier_id=1, number_of_threads=self.num_mma_threads)
 
             for ei in cutlass.range_constexpr(elems_per_thread):
                 elem_idx = epilogue_slots[ei, mma_tidx]
@@ -547,7 +550,7 @@ class LLBf16SplitK:
                     total = total * scale
                 partials[cta_rank, elem_idx] = total
 
-            cute.arch.sync_threads()
+            cute.arch.barrier(barrier_id=1, number_of_threads=self.num_mma_threads)
 
             # Broadcast this CTA's partials to peer DSMEM.
             for ei in cutlass.range_constexpr(elems_per_thread):
@@ -558,28 +561,31 @@ class LLBf16SplitK:
                     remote = set_block_rank(my_slot, cutlass.Int32(peer))
                     st_shared_remote_f32(remote, my_val)
 
-            cute.arch.cluster_arrive()
-            cute.arch.cluster_wait()  # peer DSMEM stores are now visible
+        # All producer and consumer warps participate. No CTA can exit while a
+        # peer still writes its partials into that CTA's distributed shared memory.
+        cute.arch.cluster_arrive()
+        cute.arch.cluster_wait()
 
+        if not is_dma_warp:
             if const_expr(self.use_pdl) and mma_tidx == 0:
                 cute.arch.griddepcontrol_launch_dependents()
-            cute.arch.sync_threads()
 
-            # Reduce split-K partials and write global output.
-            for ei in cutlass.range_constexpr(elems_per_thread):
-                elem_idx = epilogue_slots[ei, mma_tidx]
-                local_coord = cute.select(epilogue_slot_coords[elem_idx], mode=[1, 0])
-                global_coord = cC[local_coord]
-                if cute.elem_less(global_coord, mC.shape):
-                    acc = (
-                        partials[None, elem_idx]
-                        .load()
-                        .reduce(
-                            cute.ReductionOp.ADD,
-                            init_val=cutlass.Float32(0.0),
-                            reduction_profile=0,
+            # One CTA owns each global output; peer CTAs must not race its stores.
+            if cta_rank == 0:
+                for ei in cutlass.range_constexpr(elems_per_thread):
+                    elem_idx = ei * self.num_mma_threads + mma_tidx
+                    local_coord = (elem_idx // bN, elem_idx % bN)
+                    global_coord = cC[local_coord]
+                    if cute.elem_less(global_coord, mC.shape):
+                        acc = (
+                            partials[None, elem_idx]
+                            .load()
+                            .reduce(
+                                cute.ReductionOp.ADD,
+                                init_val=cutlass.Float32(0.0),
+                                reduction_profile=0,
+                            )
                         )
-                    )
-                    gC[local_coord] = acc
+                        gC[local_coord] = acc
 
         cute.arch.sync_threads()


### PR DESCRIPTION
## Purpose

Fix synchronization and output-store ownership in the clustered BF16 router
GEMM, `LLBf16SplitK`. The affected path computes FP32 outputs from BF16 inputs
with more than four rows and a reduction width of at least 2,048.

- Scope the two consumer-reduction barriers to the 128 MMA threads. Whole-CTA
  barriers inside that branch cannot safely rendezvous with producer exit.
- Synchronize every cluster thread before peer shared-memory access and after
  producer/consumer work. Peer storage must exist before access and remain
  alive until remote writes complete.
- Give cluster rank zero sole ownership of global output stores.

The [CUDA distributed shared-memory contract](https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/writing-cuda-kernels.html#distributed-shared-memory)
requires those peer-existence and lifetime guarantees. The public API,
BF16 operands, FP32 reduction order, dispatch, copy pipeline and programmatic
dependent launch remain unchanged. No fallback or configuration switch is added.

The implementation originates in Roberto L. Castro's #42562. This patch
preserves its attribution and ports the synchronization correction from
local-inference-lab/vllm#723. Searches for clustered BF16 router barriers and
synccheck found no duplicate open fix. #50091/#50177 concern warmup; #56152
changes FP32-router dispatch, not these BF16-kernel barriers.

## Test Plan

Use a supported CUDA GPU and an isolated vLLM development environment with
`compute-sanitizer` on PATH:

```bash
.venv/bin/python -m pytest --noconftest -q tests/kernels/test_ll_bf16_gemm.py

.venv/bin/pre-commit run --files \
  vllm/model_executor/kernels/linear/cute_dsl/_ll_bf16_splitk.py \
  tests/kernels/test_ll_bf16_gemm.py
```

The added regression runs synccheck in a subprocess for `(M,K,N)` shapes
`(5,2048,17)` and `(16,4096,256)`, verifies exact all-ones products, and requires
zero sanitizer errors. Retaining that test outside the checkout allows the
same test to be run against the unmodified parent.

Bounded eager/graph memory check, without the suite's cuBLAS reference products:

```bash
compute-sanitizer --tool memcheck --error-exitcode 86 .venv/bin/python - <<'PY'
import torch
from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import ll_bf16_gemm

for m, k, n in ((5, 2048, 17), (16, 4096, 256)):
    a = torch.ones((m, k), device="cuda", dtype=torch.bfloat16)
    b = torch.ones((n, k), device="cuda", dtype=torch.bfloat16)
    out = ll_bf16_gemm(a, b)
    torch.accelerator.synchronize()
    expected = torch.full_like(out, k)
    torch.testing.assert_close(out, expected, rtol=0, atol=0)
    graph = torch.cuda.CUDAGraph()
    with torch.cuda.graph(graph):
        captured = ll_bf16_gemm(a, b)
    for _ in range(4):
        graph.replay()
    torch.accelerator.synchronize()
    torch.testing.assert_close(captured, expected, rtol=0, atol=0)
PY
```

## Test Result

Upstream source boundary: `6983a0883dc831d33ffa2713b955159894a350d7`.
Validation uses an isolated editable checkout, official vLLM 0.29.0
precompiled native artifacts, Torch 2.13.0, CUTLASS DSL 4.6.2, QuACK 0.6.4,
CUDA 13.3, and one RTX PRO 6000 Max-Q Workstation GPU (SM120). The host's
existing +6000 VRAM offset is unchanged; these are correctness tests, not
stock-clock performance measurements.

| Check | Result |
|---|---|
| Unmodified upstream, added synccheck regression | Fails on the first shape with 800 divergent-barrier errors and a launch failure |
| Patched upstream, complete router suite | 135 pass; two existing SM120 dispatch tests fail |
| Unmodified upstream, those same two dispatch tests | Both fail identically; no additional failures in the patched suite |
| Patched upstream, both reproducer shapes, eager and four graph replays | Exact outputs; memcheck reports zero errors |
| Pre-commit, including mypy; additional mypy-3.12 | Pass |

The two dispatch tests expect `GateLinear` to enable BF16 routing, but its
architecture gate enables SM90/SM100 and excludes SM120. This patch does not
modify dispatch or suppress those failures. The direct kernel, shape, graph,
and synchronization checks exercise the supported CuTe operation independently.

Separate fork serving evidence is recorded in
[local-inference-lab/vllm#723](https://github.com/local-inference-lab/vllm/pull/723):
two stock-clock DS4 Vision TP2/FP8/LMCache runs of 600 seconds completed with
529 and 501 HTTP 200 responses and no HTTP errors. These are not upstream
model-quality evaluations or proof that every serving failure has this cause.

### Validation limits

The broader pytest-under-memcheck attempt was stopped after more than five
minutes in sanitizer instrumentation without a result; that run is unqualified.
The bounded memory check above completed successfully without kernel filtering.

Racecheck still reports asynchronous operand-stage hazards in the unchanged
copy pipeline. An independent CUDA-only reproducer also reports them while
returning exact generation-specific values. A sanitizer limitation is plausible
but is not vendor-confirmed; **passing racecheck is not claimed**. SM90/SM100
hardware qualification and a controlled performance comparison are not included.

AI assistance: Codex assisted with implementation and test execution. The human
submitter reviewed and validated the change; authorship and AI attribution are
retained in the commit.
