### PR TITLE
[ROCm] [kimik3] [WIP] Enable shared-expert multi-stream overlap for TP deployments

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -887,6 +887,12 @@ class MoERunner(MoERunnerInterface):
         # before routed expert dispatch.
         shared_experts_overlapping = False
         if self._shared_experts is not None:
+            # Compare storage, so views over one buffer count as aliasing.
+            self._shared_experts._inputs_observed_disjoint = (
+                shared_experts_input is not None
+                and hidden_states.untyped_storage().data_ptr()
+                != shared_experts_input.untyped_storage().data_ptr()
+            )
             shared_experts_overlapping = self._shared_experts.maybe_forward_async(
                 shared_experts_input
             )

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -62,6 +62,9 @@ class SharedExperts(torch.nn.Module):
         # alias the same inputs
         self._is_multistream_safe = is_multistream_safe
 
+        # Set per forward by MoERunner, where both inputs are in scope.
+        self._inputs_observed_disjoint = False
+
         # Allow disabling of the separate shared experts stream for
         # debug purposes.
         # TODO: Remove this after more extensive testings with TP/DP
@@ -112,19 +115,15 @@ class SharedExperts(torch.nn.Module):
         if self._mk_can_overlap_shared_experts():
             return SharedExpertsOrder.MK_INTERNAL_OVERLAPPED
 
-        # On ROCm, empirically only DP-only deployments benefit from the overlap.
-        overlap_is_beneficial = not current_platform.is_rocm() or (
-            self._moe_config.moe_parallel_config.dp_size > 1
-            and self._moe_config.moe_parallel_config.tp_size == 1
-        )
-
         should_run_shared_in_aux_stream = (
             current_platform.is_cuda_alike()
             and self._stream is not None
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
-            and overlap_is_beneficial
-            and self._is_multistream_safe()
+            # _is_multistream_safe infers disjoint inputs from quantization.
+            # Also accept observing it directly, which the proxy misses when the
+            # routed input is unquantized but distinct (Kimi-K3 latent MoE).
+            and (self._is_multistream_safe() or self._inputs_observed_disjoint)
         )
 
         if should_run_shared_in_aux_stream:


### PR DESCRIPTION
Two changes to the gate in _determine_shared_experts_order, together the minimum needed to run the shared-expert overlap on ROCm at TP>1 with Kimi-K3.

1. Decide aliasing by observation, not by proxy.

The two branches may only run concurrently if their inputs live in different storage. _is_multistream_safe infers that from the routed experts being quantized, since quantization copies the input into a fresh buffer. That is a proxy, and it is False for a model whose routed input is unquantized but still distinct. Kimi-K3's latent MoE is one: apply_routed_input_transform gives the routed experts a freshly projected tensor and leaves the original activations to the shared experts, but the MXFP4 path leaves quant_dtype (the activation dtype) unset, so the proxy answers "unsafe".

MoERunner is the one place both tensors are in scope, so record the observation there and accept it alongside the proxy. Storage pointers, not tensor identity, so views over one buffer still count as aliasing. Strictly more permissive and never less safe: it only admits demonstrably disjoint buffers, and a model whose inputs do alias observes False and keeps today's behaviour.

Measured on Kimi-K3 / MI355X TP=8: 1568 consecutive decisions report multistream_safe=False with the direct test True, i.e. they disagree on every one. GSM8K over 100 samples is unchanged with the overlap active (0.99-1.00), which is where a race between the streams would surface.

2. Drop the DP-only restriction on ROCm.

overlap_is_beneficial is a performance heuristic, not a safety check; the safety check is (1). Its premise does not hold for Kimi-K3 at TP=8/DP=1 on a ROCm runtime carrying the device-resident ordering-edge work: ~+1.5% output throughput at C1 64k/1k against a ~0.4% run-to-run noise floor. On older runtimes the same arm regressed ~9%, consistent with the original observation and with the cross-stream signalling cost that work removes.
