### PR TITLE
[Bugfix][CPU][MoE] Fix out-of-bounds write and segfault when router weights are fp32

### DIFF
--- a/tests/model_executor/test_cpu_unquantized_gemm_dispatch.py
+++ b/tests/model_executor/test_cpu_unquantized_gemm_dispatch.py
@@ -7,6 +7,7 @@ import torch
 
 from vllm.model_executor.layers import utils
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_default_torch_dtype
 
 
 @pytest.fixture(scope="module")
@@ -89,3 +90,25 @@ def test_dispatch_cpu_unquantized_gemm_logs_zentorch_dispatch(monkeypatch):
             expected_prepacked,
         )
     ]
+
+
+@pytest.mark.usefixtures("_mock_zentorch_linear_unary")
+@pytest.mark.parametrize("weight_dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_dispatch_cpu_unquantized_gemm_remove_weight_keeps_dtype(
+    monkeypatch, weight_dtype
+):
+    monkeypatch.setattr(current_platform, "is_zen_cpu", lambda: True)
+
+    layer = torch.nn.Linear(16, 8, bias=False, dtype=weight_dtype)
+    loading_dtype = (
+        torch.float32 if weight_dtype is not torch.float32 else torch.bfloat16
+    )
+    with set_default_torch_dtype(loading_dtype):
+        utils.dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
+
+    assert layer.weight.numel() == 0
+    assert layer.weight.dtype is weight_dtype
+
+    x = torch.randn(4, 16, dtype=weight_dtype)
+    output = layer.cpu_linear(x, layer.weight, None)
+    assert not output.isnan().any()

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -482,7 +482,10 @@ def dispatch_cpu_unquantized_gemm(
             )
         )
         if remove_weight:
-            layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)
+            layer.weight = torch.nn.Parameter(
+                torch.empty(0, dtype=dtype, device=layer.weight.device),
+                requires_grad=False,
+            )
         logger.debug_once(
             "CPU unquantized GEMM dispatch: using zentorch_linear_unary (prepacked=%s)",
             is_prepacked,
@@ -508,7 +511,10 @@ def dispatch_cpu_unquantized_gemm(
             bias,
         )
         if remove_weight:
-            layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)
+            layer.weight = torch.nn.Parameter(
+                torch.empty(0, dtype=dtype, device=layer.weight.device),
+                requires_grad=False,
+            )
         logger.debug_once(
             "CPU unquantized GEMM dispatch: using sgl-kernel weight_packed_linear"
         )
@@ -523,7 +529,10 @@ def dispatch_cpu_unquantized_gemm(
             handler = ops.create_onednn_mm(origin_weight.t(), 32)
             layer.cpu_linear = lambda x, weight, bias: ops.onednn_mm(handler, x, bias)
             if remove_weight:
-                layer.weight = torch.nn.Parameter(torch.empty(0), requires_grad=False)
+                layer.weight = torch.nn.Parameter(
+                    torch.empty(0, dtype=dtype, device=layer.weight.device),
+                    requires_grad=False,
+                )
             logger.debug_once("CPU unquantized GEMM dispatch: using oneDNN onednn_mm")
             return
         except RuntimeError as e:


### PR DESCRIPTION

## Purpose

On the CPU backend, serving an MoE model whose router weights are fp32 corrupts the heap on every router GEMM, and the process dies with a SIGSEGV or a glibc abort. Hunyuan-V3 crashes during warmup, before it answers a single request. MiniMax-M2 and Nemotron-H build their routers the same way. Models that set only `out_dtype=torch.float32` keep bf16 weights and are unaffected.

How it happens:

1. `GateLinear` stores MoE router weights in fp32, and decides whether to upcast the bf16 activation by comparing `x.dtype` to `self.weight.dtype`.
2. `dispatch_cpu_unquantized_gemm` builds the GEMM primitive from the real fp32 weight, then with `remove_weight=True` frees the weight by rebinding it to placeholder `torch.empty(0)` without explicitly setting `dtype`. The original weight dtype is forgotten in the process and replaced by the default torch dtype, let's say bf16
3. In forward with a bf16 input, `GateLinear` skips the upcast, and passes a bf16 `x` to `ops.onednn_mm`, which sizes the output buffer from `x.dtype` while the primitive it calls still writes fp32, leading to invalid memory access.

This PR sets `dtype` explicitly at the three removal sites, using the `dtype` already captured above them, so the placeholder keeps the weight's dtype and step 1 compares against the real one.

Related: #27465 fixed a different route to the same corruption, and named the assumption this one breaks — *"I supposed all handler should use same dtype in a inference instance (process)"*.

## Test Plan

New parametrized case in the existing dispatch test, over the three weight dtypes:

```bash
pytest tests/model_executor/test_cpu_unquantized_gemm_dispatch.py -v
pre-commit run -a
```

It forces the zentorch branch through the file's existing `_mock_zentorch_linear_unary` fixture, so it is deterministic on any host and needs no oneDNN dtype support.

Manual check of the real crash, before the fix:

```python
import torch
from vllm.model_executor.layers.utils import cpu_unquantized_gemm, dispatch_cpu_unquantized_gemm
from vllm.utils.torch_utils import set_default_torch_dtype

layer = torch.nn.Linear(4096, 192, bias=False, dtype=torch.float32)  # an fp32 MoE router
with set_default_torch_dtype(torch.bfloat16):  # what base_loader.py does while loading a model
    dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
print("weight dtype:", layer.weight.dtype, flush=True)  # bfloat16, was float32

x = torch.randn(1, 4096, dtype=torch.bfloat16)
cpu_unquantized_gemm(layer, x, layer.weight, None)  # writes 768 bytes into a 384-byte buffer
```

## Test Result

Before, the three new cases fail and the placeholder's dtype is the ambient default:

```
test_dispatch_cpu_unquantized_gemm_remove_weight_keeps_dtype[weight_dtype0] FAILED
test_dispatch_cpu_unquantized_gemm_remove_weight_keeps_dtype[weight_dtype1] FAILED
test_dispatch_cpu_unquantized_gemm_remove_weight_keeps_dtype[weight_dtype2] FAILED
E       assert torch.float32 is torch.bfloat16
E       assert torch.float32 is torch.float16
E       assert torch.bfloat16 is torch.float32
3 failed, 3 passed
```

After: `6 passed`. The manual script above runs to completion instead of aborting, and a 4-layer Hunyuan-V3 serve that previously died during warmup now completes a request.

AI assistance: root cause, patch and test were produced with Claude Code; I reviewed and ran everything.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>
