### PR TITLE
[CI][XPU] Disable model runner V2 for XPU quantization test for some partially  pre-quantized models

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -145,10 +145,16 @@ steps:
     source_file_dependencies:
       - vllm/
       - .buildkite/intel_jobs/test-intel.yaml 
+    # TODO: XPU fused MoE + model runner V2 currently hangs on some
+    # pre-quantized models, e.g.
+    # quantization/test_online.py::test_online_quantization_loads_real_weights[nm-testing/tinysmokeqwen3moe-W4A16-first-only-CTstable]
+    # Remove the VLLM_USE_V2_MODEL_RUNNER=0 override below once the hang is
+    # root-caused and fixed.
     commands:
       - >-
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'cd tests &&
+        export VLLM_USE_V2_MODEL_RUNNER=0 &&
         pytest -v -s quantization/test_auto_round.py &&
         pytest -v -s quantization/test_online.py'
   - label: "XPU compressed tensors FP8 test"


### PR DESCRIPTION
**Purpose:**
The XPU quantization CI job sets VLLM_USE_V2_MODEL_RUNNER=0 to work around a hang.

On XPU, fused MoE combined with Model Runner V2 currently hangs on some pre-quantized models, e.g.:

`quantization/test_online.py::test_online_quantization_loads_real_weights[nm-testing/tinysmokeqwen3moe-W4A16-first-only-CTstable]`