### PR TITLE
[XPU][CI] skip test_phi3v temporarily

### DIFF
--- a/.buildkite/intel_jobs/models_multimodal_intel.yaml
+++ b/.buildkite/intel_jobs/models_multimodal_intel.yaml
@@ -98,7 +98,7 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh
       'pip install av &&
       cd tests &&
-      pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py  --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/processing'
+      pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py  --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/processing --deselect="tests/models/multimodal/pooling/test_phi3v.py::test_models_text[half-TIGER-Lab/VLM2Vec-Full]"'
 
 - label: Multi-Modal Processor # 44min
   key: multi-modal-processor


### PR DESCRIPTION



## Purpose
wait vllm-xpu-kenrels including https://github.com/vllm-project/vllm-xpu-kernels/pull/587 to release.

## Test Plan
`pytest -s -v models/multimodal/pooling/test_phi3v.py::test_models_text[half-TIGER-Lab/VLM2Vec-Full]`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

