### PR TITLE
[KVConnector][Mooncake] Accept PP handshake metadata in MooncakeStoreConnector

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -159,6 +159,29 @@ def test_scheduler_role_initializes_store_scheduler_only():
     mock_scheduler.return_value.bind_gpu_block_pool.assert_called_once_with(block_pool)
 
 
+def test_pp_aware_handshake_metadata_is_accepted_and_ignored():
+    """A pipeline-parallel producer hands every connector handshake metadata
+    keyed by (pp_rank, tp_rank). The store connector never reads it, so PP
+    shards must not make it refuse to start."""
+    vllm_config = _make_vllm_config()
+    kv_cache_config = _make_kv_cache_config()
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+            "connector.MooncakeStoreScheduler"
+        ),
+    ):
+        connector = mooncake_store_connector.MooncakeStoreConnector(
+            vllm_config, KVConnectorRole.SCHEDULER, kv_cache_config
+        )
+
+    connector.set_xfer_handshake_metadata_pp_aware(
+        {(0, 0): MagicMock(), (1, 0): MagicMock()}
+    )
+
+
 def test_worker_methods_delegate_to_store_worker():
     vllm_config = _make_vllm_config()
     kv_cache_config = _make_kv_cache_config()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -25,6 +25,7 @@ from vllm.distributed.kv_events import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
+    KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
     KVConnectorRole,
     KVConnectorWorkerMetadata,
@@ -189,6 +190,19 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
             )
         else:
             self.connector_worker = MooncakeStoreWorker(vllm_config, kv_cache_config)
+
+    def set_xfer_handshake_metadata_pp_aware(
+        self, metadata: dict[tuple[int, int], KVConnectorHandshakeMetadata]
+    ) -> None:
+        """Discard peer handshake metadata, PP shards included.
+
+        Producers and consumers meet in MooncakeDistributedStore, not through
+        each other's transfer agents, so this connector never reads handshake
+        metadata -- the base class's setter for it is a no-op here. The base
+        PP-aware setter still rejects ``pp_rank > 0`` to protect connectors that
+        do read it, which stops PP-disaggregated serving from starting over a
+        value this one throws away.
+        """
 
     def shutdown(self):
         """Release connector resources on teardown.


### PR DESCRIPTION
## Purpose

`MooncakeStoreConnector` cannot start as a `MultiConnector` member alongside a
pipeline-parallel `NixlPushConnector` producer.

The engine core forwards every connector the producer's handshake metadata keyed
by `(pp_rank, tp_rank)` through `set_xfer_handshake_metadata_pp_aware`
(`vllm/v1/engine/core.py`, dispatched by `multi_connector.py`). The base-class
default rejects any `pp_rank > 0`:

```
MooncakeStoreConnector received pp_rank > 0 handshake metadata but does not support PP-disaggregated KV transfer.
```

That guard protects connectors that *consume* peer handshake metadata.
`MooncakeStoreConnector` never reads it: producers and consumers meet in
`MooncakeDistributedStore`, not through each other's transfer agents, and its
`set_xfer_handshake_metadata` is already the inherited no-op. The refusal
therefore aborts engine-core startup over a value this connector discards.

This PR overrides `set_xfer_handshake_metadata_pp_aware` in
`MooncakeStoreConnector` as a documented no-op (14 lines) and adds one unit
test. Nothing changes for PP=1, for the NIXL connectors, or for
`MooncakeConnector` (P2P), which keeps the base guard.

## Why this is not duplicating an existing PR

Searched open PRs for `MooncakeStoreConnector pp_rank`,
`set_xfer_handshake_metadata_pp_aware` and `mooncake pipeline parallel
handshake`. The closest is #46004 (DeepSeek-V4 Mooncake PP/PD shared KV
metadata), which works on `mooncake/mooncake_connector.py` — the P2P connector —
and does not touch the store connector or the PP-aware setter. No open PR adds
this override.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_mooncake_store_connector.py
.venv/bin/python -m ruff check   vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py tests/v1/kv_connector/unit/test_mooncake_store_connector.py
.venv/bin/python -m ruff format --check <same two files>
```

End to end: Kimi-K3 (MXFP4) on 24× GB300, 1P1D, prefill TP8×DCP8×PP2 → decode
TP8×DCP8, `MultiConnector[NixlPushConnector, MooncakeStoreConnector]`, no
speculative decoding, 60-minute agentic run at concurrency 64. The only variable
toggled between the two arms is this override.

## Test Result

`test_mooncake_store_connector.py`: **40 passed** (39 existing plus the new
`test_pp_aware_handshake_metadata_is_accepted_and_ignored`). That test fails on
an unpatched connector with the `ValueError` quoted above and passes with the
override. ruff check and format clean.

End to end, same image and stack, override the only difference:

| MooncakeStore + PP2 push producer | result |
|---|---|
| without this patch | engine core dies at init: `MooncakeStoreConnector received pp_rank > 0 handshake metadata but does not support PP-disaggregated KV transfer` |
| with this patch | completes the 60-minute run: 3,948 requests, 5,361 tok/s/GPU, ITL p90 58.3 ms; the store tier served 588 M prompt tokens |

The same stack with the store disabled reaches 5,369 tok/s/GPU over 3,964
requests, so the override changes startup, not throughput.

## Model evaluation

Not applicable to accuracy: the change is a no-op setter on a metadata object
the connector already discards; no KV bytes, block ids or transfer descriptors
are affected. The GSM8K result for the surrounding stack (0.9500 no-spec,
0.9530 with the drafter, Kimi-K3 MXFP4, same 1P1D GB300 topology) is reported in
the companion PRs.

## AI assistance

Written with Claude Code. The submitter reviewed every changed line and ran the
unit tests and the end-to-end runs above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
