### PR TITLE
[KVConnector][NIXL] Allow push with DCP when both instances shard identically

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -37,6 +37,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     NixlAgentMetadata,
     NixlConnectorMetadata,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_worker import (
+    NixlPullConnectorWorker,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
     NixlPushConnectorWorker,
 )
@@ -1372,3 +1375,51 @@ class TestPushPrefixCaching:
         local, remote = self._written_block_ids(w)
         assert local == [10, 11, 12]
         assert remote == [500, 501, 502]
+
+
+class TestPushHandshakeDCP:
+    """``NixlPushConnector`` writes rank-to-rank, so it supports DCP only when
+    both instances shard the KV cache the same way. The pull path keeps
+    #50611's cross-sharding support."""
+
+    @staticmethod
+    def _worker(cls, dcp_size: int):
+        w = object.__new__(cls)
+        w.pcp_size = 1
+        w.dcp_size = dcp_size
+        return w
+
+    @staticmethod
+    def _peer(dcp_size: int) -> NixlAgentMetadata:
+        return NixlAgentMetadata(
+            engine_id="remote-engine",
+            agent_metadata=b"agent",
+            kv_caches_base_addr=[0x1000],
+            device_id=0,
+            num_blocks=4,
+            block_lens=[256],
+            block_strides=[256],
+            kv_cache_layout="LBHNC",
+            block_size=16,
+            ssm_sizes=(0, 0),
+            attn_backend_name="FLASH_ATTN",
+            physical_blocks_per_logical_kv_block=1,
+            dcp_size=dcp_size,
+        )
+
+    def test_push_accepts_equal_dcp(self):
+        w = self._worker(NixlPushConnectorWorker, 8)
+        NixlPushConnectorWorker._validate_remote_parallel_config(w, self._peer(8))
+
+    def test_push_rejects_unequal_dcp(self):
+        """A P side that shards its KV 8 ways cannot WRITE into a D side that
+        replicates it: the write is rank-to-rank and would land the wrong slice."""
+        w = self._worker(NixlPushConnectorWorker, 8)
+        with pytest.raises(NotImplementedError, match="shard identically"):
+            NixlPushConnectorWorker._validate_remote_parallel_config(w, self._peer(1))
+
+    def test_pull_still_allows_unequal_dcp(self):
+        """The READ path resolves the source ranks per block, so it keeps
+        supporting different DCP degrees across the two instances."""
+        w = self._worker(NixlPullConnectorWorker, 8)
+        NixlPullConnectorWorker._validate_remote_parallel_config(w, self._peer(1))

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -530,8 +530,10 @@ class NixlBaseConnectorWorker:
         # DCP support is scoped to MLA, with dcp_size in (1, tp_size): either fully
         # replicated or fully sharded. A DCP rank is always derivable this way.
         self.dcp_rank = self.tp_rank % self.dcp_size
-        if self._has_mamba and self.dcp_size > 1:
+        if self._has_mamba and self.dcp_size > 1 and self._TRANSFER_MODE != "push":
             # Prefix-cache-aware DCP slicing isn't implemented for the Mamba group.
+            # Push never slices: it writes rank-to-rank between identically
+            # sharded instances (enforced at handshake).
             raise ValueError("DCP is not supported for hybrid MLA+Mamba models.")
 
         self.num_blocks = kv_cache_config.num_blocks
@@ -768,6 +770,12 @@ class NixlBaseConnectorWorker:
                 "on both instances. "
                 f"Local PCP/DCP={local_pcp_size}/{local_dcp_size}; "
                 f"remote PCP/DCP={remote_pcp_size}/{remote_dcp_size}."
+            )
+        if self._TRANSFER_MODE == "push" and local_dcp_size != remote_dcp_size:
+            raise NotImplementedError(
+                "NixlPushConnector supports decode_context_parallel_size > 1 only "
+                "when both instances shard identically (push writes rank-to-rank). "
+                f"Local DCP={local_dcp_size}; remote DCP={remote_dcp_size}."
             )
 
     def _sync_block_size_with_kernel(self) -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -369,10 +369,9 @@ class NixlPushConnector(NixlBaseConnector):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, role, kv_cache_config)
-        if vllm_config.parallel_config.decode_context_parallel_size > 1:
-            raise ValueError(
-                "NixlPushConnector does not support decode_context_parallel_size > 1."
-            )
+        # DCP is validated at handshake (_validate_remote_parallel_config): push
+        # writes rank-to-rank, so it is supported when both instances shard the
+        # KV cache identically and refused otherwise.
         self.connector_scheduler: NixlPushConnectorScheduler | None = None
         self.connector_worker: NixlPushConnectorWorker | None = None
         if role == KVConnectorRole.SCHEDULER:


### PR DESCRIPTION
## Purpose

`NixlPushConnector` refuses decode context parallelism outright, so no
P/D-disaggregated topology with DCP can use the WRITE path:

```
NixlPushConnector does not support decode_context_parallel_size > 1.
```

#50611 added DCP to the NIXL **pull** path and, being scoped to READ, guarded
the other two cases with blanket refusals: `NixlPushConnector.__init__` rejects
`decode_context_parallel_size > 1`, and `NixlBaseConnectorWorker.__init__`
rejects hybrid MLA+Mamba with `dcp_size > 1`.

Push does not need the general solution the pull path needed. A WRITE goes
rank to rank and never slices a block across ranks, and for equal TP and DCP on
both sides `dcp_source_ranks(8, 8)` reduces to `[local_dcp_rank]` with
`dcp_consumer_count == 1` — the identity mapping. What push actually requires is
that the two instances shard the KV cache the same way.

So this PR replaces the two refusals with one precondition, checked where the
two configurations first meet:

- `NixlPushConnector.__init__`: drop the DCP refusal.
- `NixlBaseConnectorWorker.__init__`: keep the hybrid+DCP refusal for the pull
  path (`self._TRANSFER_MODE != "push"`), where prefix-cache-aware DCP slicing
  for the Mamba group really is unimplemented.
- `_validate_remote_parallel_config`: refuse push when
  `local_dcp_size != remote_dcp_size`, with a message that names both sides.

Net effect: symmetric DCP works over push; asymmetric DCP is rejected at
handshake instead of at construction; the pull path is untouched.

Production diff is 10 added / 5 removed lines across two files.

## Why this is not duplicating an existing PR

**#55531** (`[KV Connector] Support symmetric DCP disagg for hybrid mamba
models`, draft) is the adjacent one, and I would rather see the two composed
than raced — @wzhao18, tagging you so this is not a surprise. It removes the
*worker* hybrid+DCP refusal unconditionally, drops the config-time
`is_hybrid and dcp_size > 1` assert, adds a hybrid equal-DCP check in
`_validate_remote_agent_handshake`, and fixes DCP prefix caching for SSM groups
on the pull path.

It does **not** touch `NixlPushConnector.__init__`, which is the refusal that
blocks the WRITE path: with #55531 alone a push connector still raises at
construction, so push + DCP stays impossible. That one hunk plus the
push-scoped handshake check is what this PR adds. Where the two do overlap — the
worker-level hybrid refusal — this PR scopes it to pull and #55531 removes it
outright; whichever lands first, the other should rebase onto it, and I am
happy for that to be this one. If folding the push hunk into #55531 is simpler,
I will close this instead.

No other open PR matched `NixlPushConnector decode_context_parallel`,
`push connector DCP` or `nixl push dcp`.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_nixl_push_connector.py
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_nixl_push_connector.py -k PushHandshakeDCP
.venv/bin/python -m ruff check   vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py tests/v1/kv_connector/unit/test_nixl_push_connector.py
.venv/bin/python -m ruff format --check <same three files>
```

Three new tests in `TestPushHandshakeDCP`, written before the change:

| test | asserts |
|---|---|
| `test_push_accepts_equal_dcp` | DCP 8 → DCP 8 handshakes |
| `test_push_rejects_unequal_dcp` | DCP 8 → DCP 1 raises `NotImplementedError` naming both sides |
| `test_pull_still_allows_unequal_dcp` | the READ path keeps #50611's cross-sharding support |

End to end: Kimi-K3 (MXFP4) on 24× GB300, 1P1D, prefill TP8×DCP8×PP2 → decode
TP8×DCP8, `NixlPushConnector`, 60-minute agentic run at concurrency 64, plus a
GSM8K run on the same topology.

## Test Result

- `test_nixl_push_connector.py`: **47 passed** (44 existing + 3 new). On
  unpatched `main` the new `test_push_rejects_unequal_dcp` fails with
  `DID NOT RAISE NotImplementedError`; the other two pass before and after, which
  is what pins the change to the push path. ruff check and format clean.
- Without this patch, every arm of the topology above dies at engine-core
  init on `NixlPushConnector does not support decode_context_parallel_size > 1`.
  With it, the same stack serves and completes 60-minute runs.

| Kimi-K3 MXFP4, 1P1D, P TP8×DCP8×PP2 → D TP8×DCP8, 24 GPU, c64 | tok/s/GPU | ITL p90 | TTFT p50 | requests |
|---|---|---|---|---|
| DSpark, 2026-09-09 nightly | 8,771.1 | 28.32 ms | 2.14 s | 6,250 |
| DSpark, 2026-09-08 nightly | 8,773.0 | 28.62 ms | 2.05 s | 6,238 |
| no speculative decoding | 5,369.2 | 57.9 ms | 2.0 s | 3,964 |

Symmetric DCP is the only mode exercised here; the asymmetric case is refused at
handshake by construction and covered by the unit test rather than a run.

## Model evaluation

GSM8K (`lm_eval`, strict match) on the same 1P1D GB300 topology through the
push path with DCP 8 on both sides, Kimi-K3 MXFP4:

| arm | strict match | invalid |
|---|---|---|
| no speculative decoding | **0.9500** | 0.08 % |
| DSpark drafter | **0.9530** | 0.08 % |

An aggregated reference on the same checkpoint scores 0.947, so KV moved over
push with DCP 8 → DCP 8 is not degrading generation.

## Limitations

- Only `dcp_size in (1, tp_size)` is meaningful here, which is the invariant
  #50611 already assumes for NIXL.
- Asymmetric DCP over push is refused, not implemented. Making it work means
  slicing a block across remote ranks on the WRITE side, which is a different
  change and should follow the pull path's design.
- Hybrid MLA+Mamba over push with DCP is what motivated this; the pull-path
  refusal for that combination is left in place.

## AI assistance

Written with Claude Code. The submitter reviewed every changed line and ran the
unit tests, the end-to-end runs and the evaluations above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
