### PR TITLE
[KVConnector][NIXL] Route Mamba/SSM layers through the PP push member-identity path

### DIFF
--- a/docs/design/nixl_kv_push_connector.md
+++ b/docs/design/nixl_kv_push_connector.md
@@ -181,6 +181,45 @@ The completion notif sent from P to D after a WRITE is the existing
 is D's own request id, taken from the registration), so the D-side
 accounting code is unchanged.
 
+## Pipeline parallelism and hybrid KV caches
+
+The pull connector requires the local and remote workers to expose a
+congruent list of KV regions — region *i* here corresponds to region
+*i* there. That assumption breaks under pipeline parallelism (PP)
+combined with a hybrid (HMA) KV layout:
+
+* a PP-sharded prefiller (**P**) holds only a slice of the model's
+  layers while the `PP=1` decoder (**D**) holds them all, so region
+  counts differ;
+* with HMA, several layer names are pooled into one region and the layer
+  that represents a pooled region can differ between P and D.
+
+`NixlPushConnector` handles this for PP-sharded producers by routing
+**by layer-name (member) identity** instead of by region index. Each
+worker advertises which layer names back each of its NIXL regions in the
+handshake metadata (`NixlAgentMetadata.region_members`). A producer that
+needs member routing derives its member-major layout once, when it
+registers its KV caches, and every transfer it issues uses that order.
+`add_remote_agent` then selects exactly the remote regions this stage
+owns and reorders them to match, so both sides stay paired regardless of
+how each remote rank happens to order its metadata.
+
+Invariants enforced when the remote regions are aligned:
+
+* every locally owned member must be advertised exactly once by the
+  remote; a missing member fails the handshake rather than silently
+  leaving that layer's KV stale, and remote-only members (owned by other
+  PP stages) are ignored;
+* a remote that omits member metadata while the local layout requires
+  member routing fails the handshake instead of falling back to
+  region-index routing;
+* member order is a property of the local layout alone, so the same local
+  source descriptors serve every remote engine and TP rank; only the
+  remote descriptor list is rebuilt per rank.
+
+Decode-side PP is unsupported because completions are counted per
+consumer rank. Mamba/SSM hybrids are unsupported under PP.
+
 ## Scheduler-side responsibilities
 
 `NixlPushConnectorScheduler` extends the base scheduler with:

--- a/docs/design/nixl_kv_push_connector.md
+++ b/docs/design/nixl_kv_push_connector.md
@@ -204,6 +204,11 @@ registers its KV caches, and every transfer it issues uses that order.
 owns and reorders them to match, so both sides stay paired regardless of
 how each remote rank happens to order its metadata.
 
+Addresses, block lengths, strides, and per-region capacities follow the same
+member order. Descriptor offsets use each member's region capacity, so P and
+D need not allocate the same number of blocks. Physical allocations are still
+registered once, even when multiple members share them.
+
 Invariants enforced when the remote regions are aligned:
 
 * every locally owned member must be advertised exactly once by the

--- a/docs/design/nixl_kv_push_connector.md
+++ b/docs/design/nixl_kv_push_connector.md
@@ -209,6 +209,19 @@ member order. Descriptor offsets use each member's region capacity, so P and
 D need not allocate the same number of blocks. Physical allocations are still
 registered once, even when multiple members share them.
 
+Packed MLA caches interleave layer pages within each block. PP stages can
+pack different members at different offsets and block strides. A PP producer
+registers one logical transfer region per member, while memory registration
+still covers the shared allocation once. A `PP=1` peer keeps whole-row
+transfers and advertises each member's byte offset and page size through
+`packed_member_layouts`. The producer folds those offsets into the remote
+region addresses; the ordinary descriptor builders then use each side's
+own `block_strides`. Aliased members remain distinct when their page sizes
+differ. Pull-mode registration and transfers are unchanged.
+Packed push hashes the sorted attention-backend names, since PP can change
+their discovery order without changing the cache format. A different backend
+set still fails the compatibility check.
+
 Invariants enforced when the remote regions are aligned:
 
 * every locally owned member must be advertised exactly once by the
@@ -223,7 +236,9 @@ Invariants enforced when the remote regions are aligned:
   remote descriptor list is rebuilt per rank.
 
 Decode-side PP is unsupported because completions are counted per
-consumer rank. Mamba/SSM hybrids are unsupported under PP.
+consumer rank. Mamba/SSM hybrids are unsupported under PP. Packed PP push
+requires MLA caches and equal P/D block sizes. MLA pages are replicated
+across TP ranks, so producer TP1 to consumer TP2 is supported.
 
 ## Scheduler-side responsibilities
 

--- a/docs/features/nixl_connector_compatibility.md
+++ b/docs/features/nixl_connector_compatibility.md
@@ -120,7 +120,8 @@ Current push PP + HMA limitations:
 - Only the prefiller (producer) may be PP-sharded; decode-side PP is not supported.
 - Hybrid SSM/Mamba layouts are not supported under PP.
 - HMA requires the same block size on P and D.
-- Attention-HMA member routing requires decode TP to be no greater than prefill TP.
+- Non-MLA attention-HMA member routing requires decode TP to be no greater than prefill TP.
+- Packed layouts under PP require MLA caches. Local and remote packed block strides may differ; member pages must have equal sizes. MLA supports decode TP greater than prefill TP because its KV is replicated.
 
 ### Quantized KV cache
 

--- a/docs/features/nixl_connector_compatibility.md
+++ b/docs/features/nixl_connector_compatibility.md
@@ -120,6 +120,7 @@ Current push PP + HMA limitations:
 - Only the prefiller (producer) may be PP-sharded; decode-side PP is not supported.
 - Hybrid SSM/Mamba layouts are not supported under PP.
 - HMA requires the same block size on P and D.
+- Attention-HMA member routing requires decode TP to be no greater than prefill TP.
 
 ### Quantized KV cache
 

--- a/docs/features/nixl_connector_compatibility.md
+++ b/docs/features/nixl_connector_compatibility.md
@@ -104,6 +104,23 @@ By default, a **compatibility hash** is checked during handshake. P and D instan
 - `LBNHC` (token-major, formerly `NHD`) layout is supported but does **not** allow heterogeneous TP head splitting.
 - Experimental `LBHNC` ↔ `LBNHC` permute: enable via `--kv-transfer-config '{"enable_permute_local_kv": true}'`. Not supported with HMA.
 
+### Pipeline parallelism
+
+The default (pull) NixlConnector does **not** support
+`pipeline-parallel-size > 1` together with a hybrid KV cache (HMA)
+layout: region indices are not a stable identity across the
+prefill/decode layer split, so the connector raises at startup. Use the
+push connector (`NixlPushConnector`) for pipeline parallelism with
+hybrid KV caches — it routes transfers by layer-name (member) identity,
+so a PP-sharded prefiller can write into a `PP=1` decoder. See
+[NIXL push-mode KV transfer](../design/nixl_kv_push_connector.md).
+
+Current push PP + HMA limitations:
+
+- Only the prefiller (producer) may be PP-sharded; decode-side PP is not supported.
+- Hybrid SSM/Mamba layouts are not supported under PP.
+- HMA requires the same block size on P and D.
+
 ### Quantized KV cache
 
 [Quantized KV cache](quantization/quantized_kvcache.md) (e.g., FP8) requires both P and D instances to use the **same** `cache_dtype`. Mismatched cache dtypes will fail the compatibility hash check during handshake.

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -862,6 +862,7 @@ def _make_mock_worker_for_desc_ids(
     worker = MagicMock(spec=NixlConnectorWorker)
     worker.num_regions = num_regions
     worker._uses_region_group_mapping = False
+    worker._member_group_ids = ()
     worker._has_mamba = has_mamba
     worker._group_spec_types = group_spec_types
     worker.block_len_per_layer = block_len_per_layer or [100]

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -1867,6 +1867,78 @@ def test_register_kv_caches_hybrid_mla_dual_purpose_regions():
 
 
 @pytest.mark.cpu_test
+def test_register_kv_caches_hybrid_mla_pp_stage_routes_by_member():
+    """A PP producer stage of the same hybrid registers by member identity:
+    each pooled region carries its MLA and KDA layer names, FA descriptors are
+    emitted per attention member and conv + temporal descriptors per KDA
+    member, and the FA/mamba boundary counts attention members, not regions."""
+    from unittest.mock import MagicMock
+
+    from vllm.config import set_current_vllm_config
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
+        NixlPushConnectorWorker,
+    )
+
+    kv_cache_config = _make_hybrid_mla_kv_cache_config()
+    unified_page = kv_cache_config.kv_cache_groups[0].kv_cache_spec.page_size_bytes
+    vllm_config = create_vllm_config(block_size=12, kv_role="kv_producer")
+    vllm_config.kv_transfer_config.kv_buffer_device = "cuda"
+    vllm_config.parallel_config.pipeline_parallel_size = 2
+
+    fake_backend = MagicMock()
+    fake_backend.get_supported_kernel_block_sizes.return_value = [4]
+    fake_backend.get_name.return_value = "FLASHMLA"
+    fake_backend.full_cls_name.return_value = "fake.FLASHMLA"
+    fake_platform = MagicMock()
+    fake_platform.device_type = "cuda"
+    fake_platform.get_nixl_memory_type.return_value = "VRAM"
+
+    with (
+        patch.object(bw, "NixlWrapper"),
+        patch.object(bw, "get_tensor_model_parallel_rank", return_value=0),
+        patch.object(bw, "get_tensor_model_parallel_world_size", return_value=1),
+        patch.object(bw, "get_current_attn_backends", return_value=[fake_backend]),
+        patch.object(bw, "current_platform", fake_platform),
+        patch(
+            "vllm.model_executor.layers.mamba.mamba_utils.get_conv_state_layout",
+            return_value="DS",
+        ),
+        set_current_vllm_config(vllm_config),
+    ):
+        worker = NixlPushConnectorWorker(vllm_config, "test-engine", kv_cache_config)
+        worker.use_mla = True
+        worker.nixl_wrapper.get_agent_metadata.return_value = b"fake-agent-metadata"
+        tensors = [torch.zeros(4 * unified_page, dtype=torch.uint8) for _ in range(2)]
+        worker.register_kv_caches(
+            {
+                "kda_a.0": tensors[0],
+                "mla.0": tensors[0],
+                "kda_b.0": tensors[0],
+                "kda_a.1": tensors[1],
+                "mla.1": tensors[1],
+                "kda_b.1": tensors[1],
+            }
+        )
+        # register_kv_caches starts the push writer thread.
+        worker.shutdown()
+
+    assert worker._requires_member_identity()
+    assert worker.region_members == [
+        ["kda_a.0", "mla.0", "kda_b.0"],
+        ["kda_a.1", "mla.1", "kda_b.1"],
+    ]
+    assert worker._member_local_regions == (0, 0, 0, 1, 1, 1)
+    assert worker._member_attention_positions == (1, 4)
+    assert worker._member_ssm_positions == (0, 2, 3, 5)
+    # FA/mamba boundary: 2 attention members x 12 kernel blocks.
+    assert worker.num_regions == 2 and worker.num_descs == 24
+    assert worker._fa_desc_replicated(worker.num_descs) == [True] * 24
+    # 4 KDA members x (3 conv sub-projections + 1 ssm) x 4 logical blocks.
+    assert worker.src_blocks_data.shape == (24 + 64, 3)
+
+
+@pytest.mark.cpu_test
 def test_push_write_hybrid_mla_replicates_attention():
     """Hybrid MLA+SSM push with P_TP < D_TP: attention blocks must be
     written to every covered D rank (replicated MLA latent) while SSM state

--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -24,7 +24,13 @@ from .utils import create_vllm_config
 
 
 def _make_packed_mla_worker(
-    layouts, block_stride, *, pp_size=1, push=True, backend_names=("FLASHMLA",)
+    layouts,
+    block_stride,
+    *,
+    num_blocks=4,
+    pp_size=1,
+    push=True,
+    backend_names=("FLASHMLA",),
 ):
     """Register real strided views; only NIXL and distributed runtime are fake."""
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
@@ -43,7 +49,7 @@ def _make_packed_mla_worker(
         create_kv_cache_views,
     )
 
-    num_blocks, block_size = 4, 16
+    block_size = 16
     raw = torch.zeros(num_blocks * block_stride, dtype=torch.int8)
     tensors, groups, caches = [], [], {}
     for name, (offset, page_size) in layouts.items():
@@ -139,7 +145,10 @@ def test_packed_push_compatibility_hash_uses_all_backends_in_stable_order(
     assert (producer.compat_hash == consumer.compat_hash) is compatible
 
 
-def test_packed_mla_pp_pairs_asymmetric_strides_and_overlapping_members():
+@pytest.mark.parametrize("p_num_blocks, d_num_blocks", [(4, 4), (4, 6), (6, 4)])
+def test_packed_mla_pp_pairs_asymmetric_strides_and_overlapping_members(
+    p_num_blocks, d_num_blocks
+):
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
         NixlAgentMetadata,
     )
@@ -147,16 +156,26 @@ def test_packed_mla_pp_pairs_asymmetric_strides_and_overlapping_members():
     # Different cache groups overlay pages of different sizes at the same address.
     # PP also changes both the placement and the stride of the matching D pages.
     producer, p_raw = _make_packed_mla_worker(
-        {"L2": (0, 128), "L2.swa": (0, 64), "L3": (128, 64)}, 192, pp_size=2
+        {"L2": (0, 128), "L2.swa": (0, 64), "L3": (128, 64)},
+        192,
+        num_blocks=p_num_blocks,
+        pp_size=2,
     )
     consumer, d_raw = _make_packed_mla_worker(
         {"L0": (0, 128), "L2": (128, 128), "L2.swa": (0, 64), "L3": (64, 64)},
         256,
+        num_blocks=d_num_blocks,
     )
     assert producer.block_len_per_layer == [128, 64, 64]
     assert producer._member_group_ids == (0, 1, 2)
-    local_ids = producer._compute_desc_ids([[1], [2], [3]], 4, None, 1)
-    remote_ids = producer._compute_desc_ids([[3], [1], [2]], 4, None, 1)
+    assert producer.num_descs == 3 * p_num_blocks
+    local_ids = producer._compute_desc_ids(
+        [[1], [2], [3]],
+        producer.num_blocks,
+        None,
+        1,
+        region_num_blocks=producer.dst_region_num_blocks[producer.engine_id],
+    )
     assert producer.src_blocks_data[local_ids].tolist() == [
         [p_raw.data_ptr() + 192, 128, 0],
         [p_raw.data_ptr() + 2 * 192, 64, 0],
@@ -169,8 +188,18 @@ def test_packed_mla_pp_pairs_asymmetric_strides_and_overlapping_members():
             type=NixlAgentMetadata,
         )
         producer.add_remote_agent(metadata, remote_tp_rank=rank, remote_tp_size=2)
+        assert metadata.region_num_blocks == [d_num_blocks] * 3
+        assert metadata.region_names == ["L2", "L2.swa", "L3"]
+        remote_ids = producer._compute_desc_ids(
+            [[3], [1], [2]],
+            metadata.num_blocks,
+            None,
+            1,
+            region_num_blocks=producer.dst_region_num_blocks[consumer.engine_id],
+        )
         handle = producer.dst_xfer_side_handles[consumer.engine_id][rank]
         remote_descs = producer.nixl_wrapper.dlists[handle]
+        assert len(remote_descs) == 3 * d_num_blocks
         assert remote_descs[remote_ids].tolist() == [
             [d_raw.data_ptr() + 128 + 3 * 256, 128, 0],
             [d_raw.data_ptr() + 256, 64, 0],
@@ -376,8 +405,8 @@ def test_overlaid_transfer_groups_share_region_geometry(push_pp):
     worker.src_xfer_handles_by_block_size = {}
     worker.kv_caches_base_addr = defaultdict(dict)
     worker._mamba_ssm_size = (0, 0)
-    worker.kv_cache_layout = "NHD"
-    worker.host_buffer_kv_cache_layout = "NHD"
+    worker.kv_cache_layout = "LBNHC"
+    worker.host_buffer_kv_cache_layout = "LBNHC"
     worker._physical_blocks_per_logical_kv_block = 1
     worker._logical_num_blocks = num_blocks
     worker.region_group_ids = []

--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -15,11 +15,193 @@ from collections import defaultdict
 from threading import Event, Lock
 from unittest.mock import MagicMock, patch
 
+import msgspec
 import numpy as np
 import pytest
 import torch
 
 from .utils import create_vllm_config
+
+
+def _make_packed_mla_worker(
+    layouts, block_stride, *, pp_size=1, push=True, backend_names=("FLASHMLA",)
+):
+    """Register real strided views; only NIXL and distributed runtime are fake."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
+        NixlPushConnectorWorker,
+    )
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+    from vllm.v1.kv_cache_interface import (
+        KVCacheConfig,
+        KVCacheGroupSpec,
+        KVCacheLayout,
+        KVCacheTensor,
+        MLAAttentionSpec,
+        create_kv_cache_views,
+    )
+
+    num_blocks, block_size = 4, 16
+    raw = torch.zeros(num_blocks * block_stride, dtype=torch.int8)
+    tensors, groups, caches = [], [], {}
+    for name, (offset, page_size) in layouts.items():
+        spec = MLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=page_size // block_size,
+            dtype=torch.uint8,
+        )
+        tensor = KVCacheTensor(
+            size=raw.nbytes,
+            layers=[name],
+            layer_stride=page_size,
+            block_stride=block_stride,
+            offset=offset,
+        )
+        tensors.append(tensor)
+        groups.append(KVCacheGroupSpec([name], spec))
+        (caches[name],) = create_kv_cache_views(
+            raw, spec, num_blocks, KVCacheLayout.BLHNC, tensor
+        )
+
+    config = create_vllm_config(block_size=block_size)
+    config.parallel_config.pipeline_parallel_size = pp_size
+    config.kv_transfer_config.kv_role = "kv_producer"
+    config.cache_config.kv_cache_layout = "BLHNC"
+    backends = []
+    for name in backend_names:
+        backend = MagicMock()
+        backend.get_supported_kernel_block_sizes.return_value = [block_size]
+        backend.get_name.return_value = name
+        backend.full_cls_name.return_value = f"fake.{name}"
+        backends.append(backend)
+    worker_cls = NixlPushConnectorWorker if push else NixlConnectorWorker
+    with (
+        patch.object(bw, "NixlWrapper", _RecordingNixl),
+        patch.object(bw, "get_tensor_model_parallel_rank", return_value=0),
+        patch.object(bw, "get_tensor_model_parallel_world_size", return_value=1),
+        patch.object(bw, "get_current_attn_backends", return_value=backends),
+        patch("threading.Thread"),
+    ):
+        worker = worker_cls(
+            config,
+            "producer" if pp_size > 1 else "consumer",
+            KVCacheConfig(num_blocks, tensors, groups),
+        )
+        worker.use_mla = True
+        worker.register_kv_caches(caches)
+    return worker, raw
+
+
+@pytest.mark.parametrize("push", [False, True])
+@pytest.mark.parametrize("num_members", [1, 2])
+def test_packed_mla_pp1_preserves_whole_row_transfers(push, num_members):
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+        NixlAgentMetadata,
+    )
+
+    layouts = {f"L{i}": (i * 128, 128) for i in range(num_members)}
+    stride = num_members * 128
+    worker, raw = _make_packed_mla_worker(layouts, stride, push=push)
+    assert worker._registered_descs == [[(raw.data_ptr(), raw.nbytes, 0, "")]]
+    assert worker.src_blocks_data.tolist() == [
+        [raw.data_ptr() + block * stride, stride, 0] for block in range(4)
+    ]
+    assert worker._member_group_ids == ()
+    metadata = msgspec.msgpack.decode(
+        worker.xfer_handshake_metadata.agent_metadata_bytes, type=NixlAgentMetadata
+    )
+    assert metadata.packed_member_layouts == (layouts if push else {})
+
+
+@pytest.mark.parametrize(
+    "remote_backends, compatible",
+    [
+        (("INDEXER", "FLASHMLA"), True),
+        (("FLASHMLA", "OTHER"), False),
+        (("FLASHMLA",), False),
+    ],
+)
+def test_packed_push_compatibility_hash_uses_all_backends_in_stable_order(
+    remote_backends, compatible
+):
+    producer, _ = _make_packed_mla_worker(
+        {"L0": (0, 128)},
+        128,
+        pp_size=2,
+        backend_names=("FLASHMLA", "INDEXER"),
+    )
+    consumer, _ = _make_packed_mla_worker(
+        {"L0": (0, 128)}, 128, backend_names=remote_backends
+    )
+    assert (producer.compat_hash == consumer.compat_hash) is compatible
+
+
+def test_packed_mla_pp_pairs_asymmetric_strides_and_overlapping_members():
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+        NixlAgentMetadata,
+    )
+
+    # Different cache groups overlay pages of different sizes at the same address.
+    # PP also changes both the placement and the stride of the matching D pages.
+    producer, p_raw = _make_packed_mla_worker(
+        {"L2": (0, 128), "L2.swa": (0, 64), "L3": (128, 64)}, 192, pp_size=2
+    )
+    consumer, d_raw = _make_packed_mla_worker(
+        {"L0": (0, 128), "L2": (128, 128), "L2.swa": (0, 64), "L3": (64, 64)},
+        256,
+    )
+    assert producer.block_len_per_layer == [128, 64, 64]
+    assert producer._member_group_ids == (0, 1, 2)
+    local_ids = producer._compute_desc_ids([[1], [2], [3]], 4, None, 1)
+    remote_ids = producer._compute_desc_ids([[3], [1], [2]], 4, None, 1)
+    assert producer.src_blocks_data[local_ids].tolist() == [
+        [p_raw.data_ptr() + 192, 128, 0],
+        [p_raw.data_ptr() + 2 * 192, 64, 0],
+        [p_raw.data_ptr() + 128 + 3 * 192, 64, 0],
+    ]
+    # Each decoder TP rank receives the complete MLA page, without head slicing.
+    for rank in (0, 1):
+        metadata = msgspec.msgpack.decode(
+            consumer.xfer_handshake_metadata.agent_metadata_bytes,
+            type=NixlAgentMetadata,
+        )
+        producer.add_remote_agent(metadata, remote_tp_rank=rank, remote_tp_size=2)
+        handle = producer.dst_xfer_side_handles[consumer.engine_id][rank]
+        remote_descs = producer.nixl_wrapper.dlists[handle]
+        assert remote_descs[remote_ids].tolist() == [
+            [d_raw.data_ptr() + 128 + 3 * 256, 128, 0],
+            [d_raw.data_ptr() + 256, 64, 0],
+            [d_raw.data_ptr() + 64 + 2 * 256, 64, 0],
+        ]
+        aligned = msgspec.msgpack.encode(metadata)
+        producer._align_remote_regions_by_member(metadata)
+        assert msgspec.msgpack.encode(metadata) == aligned
+
+
+@pytest.mark.parametrize("remote_block_size", [8, 32])
+def test_packed_mla_rejects_unequal_block_sizes_before_peer_registration(
+    remote_block_size,
+):
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+        NixlAgentMetadata,
+    )
+
+    producer, _ = _make_packed_mla_worker({"L0": (0, 128)}, 128, pp_size=2)
+    metadata = msgspec.msgpack.decode(
+        producer.xfer_handshake_metadata.agent_metadata_bytes, type=NixlAgentMetadata
+    )
+    metadata.engine_id = "remote"
+    metadata.block_size = remote_block_size
+    with pytest.raises(NotImplementedError, match="identical P/D block sizes"):
+        producer.add_remote_agent(metadata)
+    assert len(producer.nixl_wrapper.dlists) == 1  # Only the local list exists.
+    assert producer.tp_mappings == {}
+    assert "remote" not in producer.dst_num_blocks
+    with pytest.raises(KeyError):
+        producer.transfer_topo.get_engine_info("remote")
 
 
 class _RecordingNixl:

--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -12,6 +12,7 @@ mid-decode (silent corruption of an unrelated request).
 """
 
 from collections import defaultdict
+from threading import Event, Lock
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -119,13 +120,17 @@ def test_local_descriptors_follow_each_region_pool_capacity():
 
 
 @pytest.mark.cpu_test
-def test_overlaid_transfer_groups_share_region_geometry():
+@pytest.mark.parametrize("push_pp", [False, True])
+def test_overlaid_transfer_groups_share_region_geometry(push_pp):
     """Groups overlaid on one allocation share its transfer region."""
     import msgspec
 
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
         NixlAgentMetadata,
+    )
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
+        NixlPushConnectorWorker,
     )
     from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
         NixlConnectorWorker,
@@ -153,7 +158,14 @@ def test_overlaid_transfer_groups_share_region_geometry():
     }
     groups = [KVCacheGroupSpec([layer_name], spec) for layer_name in caches]
 
-    worker = object.__new__(NixlConnectorWorker)
+    worker_cls = NixlPushConnectorWorker if push_pp else NixlConnectorWorker
+    worker = object.__new__(worker_cls)
+    if push_pp:
+        worker._push_writer_stop = Event()
+        worker._push_writer_wake = Event()
+        worker._push_writer_thread = MagicMock()
+        worker._sending_transfers_lock = Lock()
+        worker._sending_transfers = defaultdict(list)
     worker.tp_rank = 0
     worker.world_size = 1
     worker.block_size = 4
@@ -198,7 +210,8 @@ def test_overlaid_transfer_groups_share_region_geometry():
     worker.use_host_buffer = False
     worker.host_xfer_buffers = {}
     worker.device_kv_caches = {}
-    worker.pp_size = 1
+    worker.pp_size = 2 if push_pp else 1
+    worker._is_hma_required = True
     worker.dcp_size = 1
     worker.pcp_size = 1
     worker.kv_buffer_device = "cuda"
@@ -233,7 +246,10 @@ def test_overlaid_transfer_groups_share_region_geometry():
     expected_addrs = [
         backing.data_ptr() + block * block_stride for block in range(num_blocks)
     ]
-    assert worker.src_blocks_data[:, 0].tolist() == expected_addrs
+    num_members = 2 if push_pp else 1
+    assert worker.src_blocks_data[:, 0].tolist() == expected_addrs * num_members
+    assert worker.num_descs == num_blocks * num_members
+    assert worker.dst_region_num_blocks[worker.engine_id] == [num_blocks] * num_members
 
     metadata = msgspec.msgpack.decode(
         worker.xfer_handshake_metadata.agent_metadata_bytes,
@@ -241,6 +257,7 @@ def test_overlaid_transfer_groups_share_region_geometry():
     )
     assert metadata.region_group_ids == [-1]
     assert metadata.region_num_blocks == [num_blocks]
+    assert metadata.region_members == ([["layer.0", "layer.1"]] if push_pp else [])
     assert worker._block_ids_by_region(([0], [2]), worker.region_group_ids) == [[0, 2]]
 
 

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -1383,6 +1383,7 @@ def _agent_metadata(
     region_members: list[list[str]],
     base_addresses: list[int],
     block_lens: list[int],
+    block_strides: list[int] | None = None,
 ) -> NixlAgentMetadata:
     return NixlAgentMetadata(
         engine_id="remote-engine",
@@ -1391,7 +1392,7 @@ def _agent_metadata(
         device_id=7,
         num_blocks=2,
         block_lens=block_lens,
-        block_strides=list(block_lens),
+        block_strides=list(block_lens if block_strides is None else block_strides),
         kv_cache_layout="HND",
         block_size=16,
         ssm_sizes=(0, 0),
@@ -1409,12 +1410,27 @@ def _member_worker(
 ) -> _StubWriterWorker:
     worker = _StubWriterWorker.fresh()
     worker.pp_size = pp_size
+    worker.dcp_size = 1
     worker._has_mamba = False
     worker._is_hma_required = is_hma
     worker._layer_name_to_kv_group_index = group_by_member
     worker.transfer_topo = MagicMock()
     worker._set_region_members(region_members)
     return worker
+
+
+def test_member_group_ids_route_descriptor_blocks():
+    worker = _StubWriterWorker.fresh()
+    worker._has_mamba = False
+    worker.num_regions = 3
+    desc_ids = worker._compute_desc_ids(
+        block_ids=[[1, 2], [5]],
+        dst_num_blocks=10,
+        block_size_ratio=None,
+        physical_blocks_per_logical=1,
+        region_group_ids=(0, 1, 0),
+    )
+    assert desc_ids.tolist() == [1, 2, 15, 21, 22]
 
 
 def test_member_metadata_round_trip():
@@ -1441,6 +1457,127 @@ def test_member_identity_gate_preserves_the_non_hma_path():
     assert _member_worker([["a"]], {"a": 0}, pp_size=1)._member_local_regions == ()
 
 
+def test_member_alignment_fails_loud_when_remote_omits_members():
+    # Falling back to region-index routing here would silently transfer stale
+    # KV, so an unannounced peer must fail the handshake instead.
+    worker = _member_worker([["a"]], {"a": 0})
+    with pytest.raises(AssertionError, match="no region_members"):
+        worker._align_remote_regions_by_member(_agent_metadata([], [0xA000], [128]))
+
+
+def test_member_alignment_expands_pooled_regions():
+    worker = _member_worker([["a", "a.swa"], ["b"]], {"a": 0, "a.swa": 1, "b": 0})
+    assert worker._member_names == ("a", "a.swa", "b")
+    assert worker._member_local_regions == (0, 0, 1)
+    assert worker._member_group_ids == (0, 1, 0)
+
+    metadata = _agent_metadata([["a", "a.swa"], ["b"]], [0xA000, 0xB000], [128, 128])
+    worker._align_remote_regions_by_member(metadata)
+
+    assert metadata.kv_caches_base_addr == [0xA000, 0xA000, 0xB000]
+    assert metadata.block_lens == [128, 128, 128]
+    assert metadata.block_strides == [128, 128, 128]
+    assert metadata.region_members == [["a"], ["a.swa"], ["b"]]
+
+
+def test_member_alignment_filters_and_reorders_a_pp_stage():
+    worker = _member_worker([["l2"], ["l3"]], {"l2": 0, "l3": 1})
+    metadata = _agent_metadata(
+        [["l2"], ["l0"], ["l3"], ["l1"]],
+        [0xC000, 0xA000, 0xD000, 0xB000],
+        [65536, 65536, 32768, 32768],
+        [131072, 131072, 65536, 65536],
+    )
+
+    worker._align_remote_regions_by_member(metadata)
+
+    assert worker._member_local_regions == (0, 1)
+    assert worker._member_group_ids == (0, 1)
+    assert metadata.kv_caches_base_addr == [0xC000, 0xD000]
+    assert metadata.block_lens == [65536, 32768]
+    assert metadata.block_strides == [131072, 65536]
+
+
+def test_member_alignment_handles_asymmetric_pp_split():
+    """A PP split can leave each stage a different mix of attention types.
+
+    Stage 1 owns L3 (full) pooled with L4 (sliding) in region 0, and L5 (full)
+    alone in region 1. The consumer holds every layer and pools them
+    differently, so region indices cannot be paired positionally.
+    """
+    worker = _member_worker([["L3", "L4"], ["L5"]], {"L3": 0, "L4": 1, "L5": 0})
+    assert worker._member_names == ("L3", "L4", "L5")
+    assert worker._member_local_regions == (0, 0, 1)
+    assert worker._member_group_ids == (0, 1, 0)
+
+    consumer = _agent_metadata(
+        [["L0", "L1"], ["L3", "L2"], ["L5", "L4"]],
+        [0xA000, 0xB000, 0xC000],
+        [128, 128, 128],
+    )
+    worker._align_remote_regions_by_member(consumer)
+
+    # L3 -> remote region 1, L4 -> 2, L5 -> 2. Pairing by index would have sent
+    # L5 to region 1 and L4 to region 2's sibling.
+    assert consumer.kv_caches_base_addr == [0xB000, 0xC000, 0xC000]
+
+
+def test_member_alignment_is_canonical_across_remote_orderings():
+    local, groups = [["x"], ["y"]], {"x": 0, "y": 1}
+    rank0 = _agent_metadata([["x"], ["y"]], [0x1000, 0x2000], [64, 128], [256, 512])
+    rank1 = _agent_metadata([["y"], ["x"]], [0x2000, 0x1000], [128, 64], [512, 256])
+
+    _member_worker(local, groups)._align_remote_regions_by_member(rank0)
+    _member_worker(local, groups)._align_remote_regions_by_member(rank1)
+
+    assert rank0.kv_caches_base_addr == rank1.kv_caches_base_addr == [0x1000, 0x2000]
+    assert rank0.block_lens == rank1.block_lens == [64, 128]
+    assert rank0.block_strides == rank1.block_strides == [256, 512]
+
+
+def test_member_alignment_is_idempotent():
+    worker = _member_worker([["a", "a.swa"], ["b"]], {"a": 0, "a.swa": 1, "b": 0})
+    metadata = _agent_metadata([["a", "a.swa"], ["b"]], [0xA000, 0xB000], [128, 128])
+
+    worker._align_remote_regions_by_member(metadata)
+    aligned = (
+        list(metadata.kv_caches_base_addr),
+        list(metadata.block_lens),
+        list(metadata.block_strides),
+    )
+    worker._align_remote_regions_by_member(metadata)
+
+    assert (
+        metadata.kv_caches_base_addr,
+        metadata.block_lens,
+        metadata.block_strides,
+    ) == aligned
+
+
+def test_member_alignment_rejects_missing_local_member():
+    worker = _member_worker([["l0"], ["l1"]], {"l0": 0, "l1": 1})
+    metadata = _agent_metadata([["l0"]], [0xA000], [128])
+
+    with pytest.raises(AssertionError, match="missing locally owned layers"):
+        worker._align_remote_regions_by_member(metadata)
+
+
+def test_member_alignment_rejects_duplicate_remote_member():
+    worker = _member_worker([["a"]], {"a": 0})
+    metadata = _agent_metadata([["a"], ["a"]], [0xA000, 0xB000], [128, 128])
+
+    with pytest.raises(AssertionError, match="in multiple regions"):
+        worker._align_remote_regions_by_member(metadata)
+
+
+def test_member_alignment_rejects_inconsistent_remote_metadata():
+    worker = _member_worker([["a"]], {"a": 0})
+    metadata = _agent_metadata([["a"], ["b"]], [0xA000], [128])
+
+    with pytest.raises(AssertionError, match="lengths disagree"):
+        worker._align_remote_regions_by_member(metadata)
+
+
 def test_set_region_members_rejects_duplicate_local_member():
     with pytest.raises(AssertionError, match="spans multiple NIXL regions"):
         _member_worker([["a"], ["a"]], {"a": 0})
@@ -1449,3 +1586,15 @@ def test_set_region_members_rejects_duplicate_local_member():
 def test_set_region_members_rejects_layer_outside_any_kv_group():
     with pytest.raises(AssertionError, match="outside any local group"):
         _member_worker([["a"], ["b"]], {"a": 0})
+
+
+def test_attention_member_routing_rejects_decode_tp_fanout():
+    metadata = _agent_metadata([["a"]], [0xA000], [128])
+    worker = _member_worker([["a"]], {"a": 0})
+    worker.use_mla = False
+    worker.transfer_topo.get_engine_info.return_value.remote_tp_size = 2
+    worker.transfer_topo.get_engine_info.return_value.remote_dcp_size = 1
+    worker.transfer_topo.tp_ratio.return_value = -2
+
+    with pytest.raises(NotImplementedError, match="decode TP greater"):
+        worker._validate_remote_agent_handshake(metadata, 2)

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -30,6 +30,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import msgspec
+import numpy as np
 import pytest
 
 from vllm.distributed.kv_transfer.kv_connector.utils import TransferTopology
@@ -48,7 +49,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import TPMappi
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
     get_base_request_id,
 )
-from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+    MambaConvSplitInfo,
+)
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, MLAAttentionSpec
 from vllm.v1.outputs import KVConnectorOutput
 
 from .utils import create_request, make_nixl_push_scheduler
@@ -1448,6 +1452,8 @@ def _member_worker(
     worker.block_size = 16
     worker._has_mamba = False
     worker._is_hma_required = is_hma
+    num_groups = max(group_by_member.values(), default=0) + 1
+    worker._group_spec_types = (FullAttentionSpec,) * num_groups
     worker.kv_cache_config = MagicMock(transfer_group_index_by_layer=group_by_member)
     worker.transfer_topo = MagicMock()
     worker._set_region_members(region_members)
@@ -1774,3 +1780,124 @@ def test_member_handshake_rejects_unsupported_geometry(
     assert not worker.kv_caches_base_addr
     with pytest.raises(KeyError):
         worker.transfer_topo.get_engine_info(metadata.engine_id)
+
+
+# KimiLinear-shaped stage: one MLA layer pooled with two KDA layers per region.
+_HYBRID_MEMBERS = [["mla.0", "kda_a.0", "kda_b.0"], ["mla.1", "kda_a.1", "kda_b.1"]]
+_HYBRID_GROUPS = {
+    "mla.0": 0,
+    "kda_a.0": 1,
+    "kda_b.0": 2,
+    "mla.1": 0,
+    "kda_a.1": 1,
+    "kda_b.1": 2,
+}
+# GDN-style conv Q|K|V = 2|2|4 columns x 3 rows of fp16, then 64 bytes of state.
+_HYBRID_CONV = MambaConvSplitInfo(
+    conv_rows=3, local_proj_dims=(2, 2, 4), conv_dtype_size=2, ssm_sizes=(48, 64)
+)
+_HYBRID_SSM_OFFSETS = [(0, 12), (12, 12), (24, 24), (48, 64)]
+_PAGE = 256
+
+
+def _hybrid_member_worker(num_blocks: int = 4) -> _StubWriterWorker:
+    worker = _StubWriterWorker.fresh()
+    worker.pp_size = 2
+    worker.dcp_size = 1
+    worker.block_size = 16
+    worker.use_mla = True
+    worker._has_mamba = True
+    worker._is_hma_required = True
+    worker._group_spec_types = (MLAAttentionSpec, MambaSpec, MambaSpec)
+    worker._conv_decomp = _HYBRID_CONV
+    worker._mamba_ssm_size = _HYBRID_CONV.ssm_sizes
+    worker._ssm_region_indices = [0, 1]
+    worker._ple_region_index = None
+    worker._ple_group_index = None
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.num_blocks = num_blocks
+    worker._logical_num_blocks = num_blocks
+    worker.block_len_per_layer = [_PAGE, _PAGE]
+    worker.block_stride_per_layer = [_PAGE, _PAGE]
+    worker.region_num_blocks = [num_blocks, num_blocks]
+    worker._region_is_mla = [True, True]
+    worker.device_id = 0
+    worker.kv_cache_config = MagicMock(transfer_group_index_by_layer=_HYBRID_GROUPS)
+    worker.transfer_topo = MagicMock()
+    worker._set_region_members(_HYBRID_MEMBERS)
+    return worker
+
+
+def _ssm_rows(block_addr: int, device_id: int) -> list[list[int]]:
+    return [[block_addr + off, size, device_id] for off, size in _HYBRID_SSM_OFFSETS]
+
+
+def test_hybrid_members_split_by_cache_kind():
+    worker = _hybrid_member_worker()
+    assert worker._requires_member_identity()
+    assert worker._member_attention_positions == (0, 3)
+    assert worker._member_ssm_positions == (1, 2, 4, 5)
+
+
+def test_hybrid_member_descriptors_address_each_kind_once_per_layer():
+    """A pooled region backs one MLA and two KDA layers. Each member's blocks
+    must resolve to that layer's own descriptors: the FA page for the MLA
+    member, the conv sub-projections and temporal state for the KDA members."""
+    worker = _hybrid_member_worker()
+    bases = [0x10000, 0x20000]
+    descs = np.concatenate(
+        [
+            worker._build_fa_local(bases, block_size_ratio=1),
+            worker._build_mamba_local(bases),
+        ]
+    )
+    # 2 attention members x 4 blocks, then 4 SSM members x 4 sub-regions x 4 blocks.
+    assert descs.shape == (8 + 64, 3)
+
+    rows = descs[worker._compute_desc_ids([[1], [2], [3]], 4, None, 1)].tolist()
+    assert rows[0] == [0x10000 + _PAGE, _PAGE, 0]
+    assert rows[1:5] == _ssm_rows(0x10000 + 2 * _PAGE, 0)
+    assert rows[5:9] == _ssm_rows(0x10000 + 3 * _PAGE, 0)
+    assert rows[9] == [0x20000 + _PAGE, _PAGE, 0]
+    assert rows[10:14] == _ssm_rows(0x20000 + 2 * _PAGE, 0)
+    assert rows[14:18] == _ssm_rows(0x20000 + 3 * _PAGE, 0)
+
+
+def test_hybrid_member_alignment_pairs_layers_with_an_unsharded_consumer():
+    """A PP stage writing to a PP=1 consumer that pools the same layer kinds per
+    region but advertises them in another order and holds layers we do not."""
+    worker = _hybrid_member_worker()
+    consumer = _agent_metadata(
+        [
+            ["mla.9", "kda_a.9", "kda_b.9"],
+            ["mla.1", "kda_a.1", "kda_b.1"],
+            ["mla.0", "kda_a.0", "kda_b.0"],
+        ],
+        [0xC000, 0xB000, 0xA000],
+        [_PAGE, _PAGE, _PAGE],
+    )
+    consumer.num_blocks = 4
+    consumer.ssm_sizes = _HYBRID_CONV.ssm_sizes
+    worker._align_remote_regions_by_member(consumer)
+    assert consumer.kv_caches_base_addr == [0xA000] * 3 + [0xB000] * 3
+
+    plan = TPMapping(((0,), (0,), (0,)), (0,), {0: 0}, 0)
+    transfer_info = MagicMock(remote_physical_blocks_per_logical=1)
+    descs = np.concatenate(
+        [
+            worker._build_fa_remote(plan, consumer, block_size_ratio=1),
+            worker._build_mamba_remote(
+                consumer, tp_ratio=1, transfer_info=transfer_info
+            ),
+        ]
+    )
+    assert descs.shape == (8 + 64, 3)
+
+    dev = consumer.device_id
+    rows = descs[worker._compute_desc_ids([[0], [1], [2]], 4, None, 1)].tolist()
+    assert rows[0] == [0xA000, _PAGE, dev]
+    assert rows[1:5] == _ssm_rows(0xA000 + _PAGE, dev)
+    assert rows[5:9] == _ssm_rows(0xA000 + 2 * _PAGE, dev)
+    assert rows[9] == [0xB000, _PAGE, dev]
+    assert rows[10:14] == _ssm_rows(0xB000 + _PAGE, dev)
+    assert rows[14:18] == _ssm_rows(0xB000 + 2 * _PAGE, dev)

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -1481,6 +1481,40 @@ def test_member_metadata_round_trip():
     assert msgspec.msgpack.Decoder(NixlAgentMetadata).decode(encoded) == metadata
 
 
+@pytest.mark.parametrize(
+    "layouts, error",
+    [
+        ({"L0": (-1, 64)}, "escapes its block"),
+        ({"L0": (0, 0)}, "escapes its block"),
+        ({"L0": (200, 64)}, "escapes its block"),
+        ({"L1": (0, 64)}, "has no layout"),
+        ({"L0": (0, 32)}, "page sizes must match"),
+    ],
+)
+def test_packed_member_alignment_rejects_invalid_page_layout(layouts, error):
+    worker = _member_worker([["L0"]], {"L0": 0})
+    worker.block_len_per_layer = [64]
+    metadata = _agent_metadata([["L0", "L1"]], [0x10000], [256])
+    metadata.packed_member_layouts = layouts
+    with pytest.raises(AssertionError, match=error):
+        worker._align_remote_regions_by_member(metadata)
+
+
+def test_member_alignment_preserves_nonpacked_regions_alongside_packed_members():
+    worker = _member_worker([["a"], ["b"]], {"a": 0, "b": 1})
+    worker.block_len_per_layer = [64, 128]
+    metadata = _agent_metadata(
+        [["a", "other"], ["b"]], [0x1000, 0x2000], [192, 128], [256, 128]
+    )
+    metadata.packed_member_layouts = {"a": (64, 64), "other": (128, 64)}
+
+    worker._align_remote_regions_by_member(metadata)
+
+    assert metadata.kv_caches_base_addr == [0x1040, 0x2000]
+    assert metadata.block_lens == [64, 128]
+    assert metadata.block_strides == [256, 128]
+
+
 def test_member_identity_gate_preserves_the_non_hma_path():
     assert _member_worker([["a"]], {"a": 0})._member_local_regions == (0,)
 

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -1626,7 +1626,7 @@ def test_set_region_members_rejects_layer_outside_any_kv_group():
 def test_member_handshake_rejects_unsupported_geometry(
     local_block_size: int, remote_block_size: int, remote_tp_size: int, error: str
 ):
-    """Reject unsupported peers before ratio math or descriptor construction."""
+    """Reject unsupported peers without registering agents or transfer state."""
     metadata = _agent_metadata([["a"]], [0xA000], [128])
     metadata.block_size = remote_block_size
     worker = _member_worker([["a"]], {"a": 0})
@@ -1650,4 +1650,10 @@ def test_member_handshake_rejects_unsupported_geometry(
 
     with pytest.raises(NotImplementedError, match=error):
         worker.add_remote_agent(metadata, remote_tp_size=remote_tp_size)
+    worker.nixl_wrapper.add_remote_agent.assert_not_called()
     worker.nixl_wrapper.prep_xfer_dlist.assert_not_called()
+    assert not worker.tp_mappings
+    assert not worker.dst_num_blocks
+    assert not worker.kv_caches_base_addr
+    with pytest.raises(KeyError):
+        worker.transfer_topo.get_engine_info(metadata.engine_id)

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -1411,6 +1411,7 @@ def _member_worker(
     worker = _StubWriterWorker.fresh()
     worker.pp_size = pp_size
     worker.dcp_size = 1
+    worker.block_size = 16
     worker._has_mamba = False
     worker._is_hma_required = is_hma
     worker._layer_name_to_kv_group_index = group_by_member
@@ -1586,6 +1587,25 @@ def test_set_region_members_rejects_duplicate_local_member():
 def test_set_region_members_rejects_layer_outside_any_kv_group():
     with pytest.raises(AssertionError, match="outside any local group"):
         _member_worker([["a"], ["b"]], {"a": 0})
+
+
+@pytest.mark.parametrize(
+    ("local_block_size", "remote_block_size"),
+    [(32, 16), (16, 32)],
+)
+def test_attention_member_routing_rejects_heterogeneous_block_sizes(
+    local_block_size: int, remote_block_size: int
+):
+    metadata = _agent_metadata([["a"]], [0xA000], [128])
+    metadata.block_size = remote_block_size
+    worker = _member_worker([["a"]], {"a": 0})
+    worker.block_size = local_block_size
+    remote_info = worker.transfer_topo.get_engine_info.return_value
+    remote_info.remote_tp_size = 1
+    remote_info.remote_dcp_size = 1
+
+    with pytest.raises(NotImplementedError, match="identical P/D block sizes"):
+        worker._validate_remote_agent_handshake(metadata, 1)
 
 
 def test_attention_member_routing_rejects_decode_tp_fanout():

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock, patch
 import msgspec
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.utils import TransferTopology
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
@@ -43,6 +44,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
     NixlPushConnectorWorker,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import TPMapping
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
     get_base_request_id,
 )
@@ -1393,7 +1395,7 @@ def _agent_metadata(
         num_blocks=2,
         block_lens=block_lens,
         block_strides=list(block_lens if block_strides is None else block_strides),
-        kv_cache_layout="HND",
+        kv_cache_layout="LBHNC",
         block_size=16,
         ssm_sizes=(0, 0),
         attn_backend_name="FLASH_ATTN",
@@ -1414,22 +1416,19 @@ def _member_worker(
     worker.block_size = 16
     worker._has_mamba = False
     worker._is_hma_required = is_hma
-    worker._layer_name_to_kv_group_index = group_by_member
+    worker.kv_cache_config = MagicMock(transfer_group_index_by_layer=group_by_member)
     worker.transfer_topo = MagicMock()
     worker._set_region_members(region_members)
     return worker
 
 
 def test_member_group_ids_route_descriptor_blocks():
-    worker = _StubWriterWorker.fresh()
-    worker._has_mamba = False
-    worker.num_regions = 3
+    worker = _member_worker([["a", "a.swa"], ["b"]], {"a": 0, "a.swa": 1, "b": 0})
     desc_ids = worker._compute_desc_ids(
         block_ids=[[1, 2], [5]],
         dst_num_blocks=10,
         block_size_ratio=None,
         physical_blocks_per_logical=1,
-        region_group_ids=(0, 1, 0),
     )
     assert desc_ids.tolist() == [1, 2, 15, 21, 22]
 
@@ -1499,7 +1498,7 @@ def test_member_alignment_filters_and_reorders_a_pp_stage():
     assert metadata.block_strides == [131072, 65536]
 
 
-def test_member_alignment_handles_asymmetric_pp_split():
+def test_member_descriptors_pair_layers_across_asymmetric_pp_split():
     """A PP split can leave each stage a different mix of attention types.
 
     Stage 1 owns L3 (full) pooled with L4 (sliding) in region 0, and L5 (full)
@@ -1507,20 +1506,47 @@ def test_member_alignment_handles_asymmetric_pp_split():
     differently, so region indices cannot be paired positionally.
     """
     worker = _member_worker([["L3", "L4"], ["L5"]], {"L3": 0, "L4": 1, "L5": 0})
-    assert worker._member_names == ("L3", "L4", "L5")
-    assert worker._member_local_regions == (0, 0, 1)
-    assert worker._member_group_ids == (0, 1, 0)
+    worker.block_len_per_layer = [128, 128]
+    worker.block_stride_per_layer = [256, 512]
+    worker._region_is_mla = [False, False]
+    worker.num_blocks = 4
+    worker.device_id = 0
 
     consumer = _agent_metadata(
         [["L0", "L1"], ["L3", "L2"], ["L5", "L4"]],
         [0xA000, 0xB000, 0xC000],
         [128, 128, 128],
+        [256, 512, 1024],
     )
+    consumer.num_blocks = 4
     worker._align_remote_regions_by_member(consumer)
 
     # L3 -> remote region 1, L4 -> 2, L5 -> 2. Pairing by index would have sent
     # L5 to region 1 and L4 to region 2's sibling.
     assert consumer.kv_caches_base_addr == [0xB000, 0xC000, 0xC000]
+
+    plan = TPMapping(((0,), (0,)), (0,), {0: 0}, 0)
+    local_descs = worker._build_fa_local([0x1000, 0x2000], block_size_ratio=1)
+    remote_descs = worker._build_fa_remote(plan, consumer, block_size_ratio=1)
+    local_ids = worker._compute_desc_ids([[1, 2], [3]], 4, None, 1)
+    remote_ids = worker._compute_desc_ids([[0, 1], [2]], 4, None, 1)
+
+    # Each pair addresses the same layer's blocks despite different pooling
+    # and strides. L3 and L5 use group 0; L4 uses group 1.
+    assert local_descs[local_ids].tolist() == [
+        [0x1100, 128, 0],
+        [0x1200, 128, 0],
+        [0x1300, 128, 0],
+        [0x2200, 128, 0],
+        [0x2400, 128, 0],
+    ]
+    assert remote_descs[remote_ids].tolist() == [
+        [0xB000, 128, 7],
+        [0xB200, 128, 7],
+        [0xC800, 128, 7],
+        [0xC000, 128, 7],
+        [0xC400, 128, 7],
+    ]
 
 
 def test_member_alignment_is_canonical_across_remote_orderings():
@@ -1590,31 +1616,38 @@ def test_set_region_members_rejects_layer_outside_any_kv_group():
 
 
 @pytest.mark.parametrize(
-    ("local_block_size", "remote_block_size"),
-    [(32, 16), (16, 32)],
+    ("local_block_size", "remote_block_size", "remote_tp_size", "error"),
+    [
+        (32, 16, 1, "identical P/D block sizes"),
+        (16, 32, 1, "identical P/D block sizes"),
+        (16, 16, 2, "decode TP greater"),
+    ],
 )
-def test_attention_member_routing_rejects_heterogeneous_block_sizes(
-    local_block_size: int, remote_block_size: int
+def test_member_handshake_rejects_unsupported_geometry(
+    local_block_size: int, remote_block_size: int, remote_tp_size: int, error: str
 ):
+    """Reject unsupported peers before ratio math or descriptor construction."""
     metadata = _agent_metadata([["a"]], [0xA000], [128])
     metadata.block_size = remote_block_size
     worker = _member_worker([["a"]], {"a": 0})
     worker.block_size = local_block_size
-    remote_info = worker.transfer_topo.get_engine_info.return_value
-    remote_info.remote_tp_size = 1
-    remote_info.remote_dcp_size = 1
-
-    with pytest.raises(NotImplementedError, match="identical P/D block sizes"):
-        worker._validate_remote_agent_handshake(metadata, 1)
-
-
-def test_attention_member_routing_rejects_decode_tp_fanout():
-    metadata = _agent_metadata([["a"]], [0xA000], [128])
-    worker = _member_worker([["a"]], {"a": 0})
+    worker.block_len_per_layer = [128]
     worker.use_mla = False
-    worker.transfer_topo.get_engine_info.return_value.remote_tp_size = 2
-    worker.transfer_topo.get_engine_info.return_value.remote_dcp_size = 1
-    worker.transfer_topo.tp_ratio.return_value = -2
+    worker.nixl_wrapper = MagicMock()
+    worker.kv_caches_base_addr = defaultdict(dict)
+    worker.dst_num_blocks = {}
+    worker.tp_mappings = {}
+    worker.transfer_topo = TransferTopology(
+        tp_rank=0,
+        tp_size=1,
+        block_size=local_block_size,
+        engine_id=worker.engine_id,
+        is_mla=False,
+        is_mamba=False,
+        total_num_kv_heads=8,
+        attn_backends=[],
+    )
 
-    with pytest.raises(NotImplementedError, match="decode TP greater"):
-        worker._validate_remote_agent_handshake(metadata, 2)
+    with pytest.raises(NotImplementedError, match=error):
+        worker.add_remote_agent(metadata, remote_tp_size=remote_tp_size)
+    worker.nixl_wrapper.prep_xfer_dlist.assert_not_called()

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -32,6 +32,9 @@ from unittest.mock import MagicMock, patch
 import msgspec
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+    NixlBaseConnectorWorker,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
     NixlAgentMetadata,
@@ -348,12 +351,14 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         # Base worker fields touched by start_load_kv / _get_new_notifs.
         w._recving_metadata = {}
         w._recving_transfers = defaultdict(list)
+        w._is_hma_required = False
         w._reqs_to_process = set()
         w._reqs_to_send = {}
         w.consumer_notification_counts_by_req = defaultdict(int)
         w.tp_rank = 0
         w.pcp_rank = 0
         w.world_size = 1
+        w.pp_size = 1
         w.engine_id = "test-decode-engine"
         w._remote_agents = {}
         w._physical_blocks_per_logical_kv_block = 1
@@ -1372,3 +1377,75 @@ class TestPushPrefixCaching:
         local, remote = self._written_block_ids(w)
         assert local == [10, 11, 12]
         assert remote == [500, 501, 502]
+
+
+def _agent_metadata(
+    region_members: list[list[str]],
+    base_addresses: list[int],
+    block_lens: list[int],
+) -> NixlAgentMetadata:
+    return NixlAgentMetadata(
+        engine_id="remote-engine",
+        agent_metadata=b"agent",
+        kv_caches_base_addr=base_addresses,
+        device_id=7,
+        num_blocks=2,
+        block_lens=block_lens,
+        block_strides=list(block_lens),
+        kv_cache_layout="HND",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name="FLASH_ATTN",
+        physical_blocks_per_logical_kv_block=1,
+        region_members=region_members,
+    )
+
+
+def _member_worker(
+    region_members: list[list[str]],
+    group_by_member: dict[str, int],
+    pp_size: int = 2,
+    is_hma: bool = True,
+) -> _StubWriterWorker:
+    worker = _StubWriterWorker.fresh()
+    worker.pp_size = pp_size
+    worker._has_mamba = False
+    worker._is_hma_required = is_hma
+    worker._layer_name_to_kv_group_index = group_by_member
+    worker.transfer_topo = MagicMock()
+    worker._set_region_members(region_members)
+    return worker
+
+
+def test_member_metadata_round_trip():
+    metadata = _agent_metadata([["L0", "L1"]], [0x10000], [256])
+
+    encoded = msgspec.msgpack.encode(metadata)
+    assert msgspec.msgpack.Decoder(NixlAgentMetadata).decode(encoded) == metadata
+
+
+def test_member_identity_gate_preserves_the_non_hma_path():
+    assert _member_worker([["a"]], {"a": 0})._member_local_regions == (0,)
+
+    # A bare base worker (pull) never routes by member identity, and reading
+    # the derived state must not require a fully constructed worker.
+    pull = object.__new__(NixlBaseConnectorWorker)
+    pull._set_region_members([["a"]])
+    assert pull._member_local_regions == ()
+
+    # A non-HMA local layout does not require member routing.
+    assert _member_worker([["a"]], {"a": 0}, is_hma=False)._member_local_regions == ()
+
+    # PP=1 has congruent local/remote regions and keeps the region route even
+    # when its allocator is hybrid.
+    assert _member_worker([["a"]], {"a": 0}, pp_size=1)._member_local_regions == ()
+
+
+def test_set_region_members_rejects_duplicate_local_member():
+    with pytest.raises(AssertionError, match="spans multiple NIXL regions"):
+        _member_worker([["a"], ["a"]], {"a": 0})
+
+
+def test_set_region_members_rejects_layer_outside_any_kv_group():
+    with pytest.raises(AssertionError, match="outside any local group"):
+        _member_worker([["a"], ["b"]], {"a": 0})

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -1422,19 +1422,28 @@ def _member_worker(
     return worker
 
 
-def test_member_group_ids_route_descriptor_blocks():
+@pytest.mark.parametrize(
+    ("region_num_blocks", "expected"),
+    [(None, [1, 2, 15, 21, 22]), ([4, 7, 5], [1, 2, 9, 12, 13])],
+)
+def test_member_group_ids_route_descriptor_blocks(region_num_blocks, expected):
     worker = _member_worker([["a", "a.swa"], ["b"]], {"a": 0, "a.swa": 1, "b": 0})
     desc_ids = worker._compute_desc_ids(
         block_ids=[[1, 2], [5]],
         dst_num_blocks=10,
         block_size_ratio=None,
         physical_blocks_per_logical=1,
+        region_num_blocks=region_num_blocks,
     )
-    assert desc_ids.tolist() == [1, 2, 15, 21, 22]
+    assert desc_ids.tolist() == expected
 
 
 def test_member_metadata_round_trip():
     metadata = _agent_metadata([["L0", "L1"]], [0x10000], [256])
+    metadata.region_num_blocks = [4]
+    metadata.region_group_ids = [-1]
+    metadata.region_names = ["L0"]
+    metadata.region_mem_types = ["VRAM"]
 
     encoded = msgspec.msgpack.encode(metadata)
     assert msgspec.msgpack.Decoder(NixlAgentMetadata).decode(encoded) == metadata
@@ -1472,12 +1481,20 @@ def test_member_alignment_expands_pooled_regions():
     assert worker._member_group_ids == (0, 1, 0)
 
     metadata = _agent_metadata([["a", "a.swa"], ["b"]], [0xA000, 0xB000], [128, 128])
+    metadata.region_num_blocks = [4, 6]
+    metadata.region_group_ids = [-1, 0]
+    metadata.region_names = ["a", "b"]
+    metadata.region_mem_types = ["VRAM", "VRAM"]
     worker._align_remote_regions_by_member(metadata)
 
     assert metadata.kv_caches_base_addr == [0xA000, 0xA000, 0xB000]
     assert metadata.block_lens == [128, 128, 128]
     assert metadata.block_strides == [128, 128, 128]
     assert metadata.region_members == [["a"], ["a.swa"], ["b"]]
+    assert metadata.region_num_blocks == [4, 4, 6]
+    assert metadata.region_group_ids == [-1, -1, 0]
+    assert metadata.region_names == ["a", "a.swa", "b"]
+    assert metadata.region_mem_types == ["VRAM", "VRAM", "VRAM"]
 
 
 def test_member_alignment_filters_and_reorders_a_pp_stage():
@@ -1488,6 +1505,10 @@ def test_member_alignment_filters_and_reorders_a_pp_stage():
         [65536, 65536, 32768, 32768],
         [131072, 131072, 65536, 65536],
     )
+    metadata.region_num_blocks = [4, 6, 8, 10]
+    metadata.region_group_ids = [0, 0, 1, 1]
+    metadata.region_names = ["l2", "l0", "l3", "l1"]
+    metadata.region_mem_types = ["VRAM"] * 4
 
     worker._align_remote_regions_by_member(metadata)
 
@@ -1496,9 +1517,19 @@ def test_member_alignment_filters_and_reorders_a_pp_stage():
     assert metadata.kv_caches_base_addr == [0xC000, 0xD000]
     assert metadata.block_lens == [65536, 32768]
     assert metadata.block_strides == [131072, 65536]
+    assert metadata.region_num_blocks == [4, 8]
+    assert metadata.region_group_ids == [0, 1]
+    assert metadata.region_names == ["l2", "l3"]
+    assert metadata.region_mem_types == ["VRAM", "VRAM"]
 
 
-def test_member_descriptors_pair_layers_across_asymmetric_pp_split():
+@pytest.mark.parametrize(
+    ("local_num_blocks", "remote_num_blocks"),
+    [([4, 4], [4, 4, 4]), ([4, 6], [3, 5, 7])],
+)
+def test_member_descriptors_pair_layers_across_asymmetric_pp_split(
+    local_num_blocks, remote_num_blocks
+):
     """A PP split can leave each stage a different mix of attention types.
 
     Stage 1 owns L3 (full) pooled with L4 (sliding) in region 0, and L5 (full)
@@ -1510,6 +1541,7 @@ def test_member_descriptors_pair_layers_across_asymmetric_pp_split():
     worker.block_stride_per_layer = [256, 512]
     worker._region_is_mla = [False, False]
     worker.num_blocks = 4
+    worker.region_num_blocks = local_num_blocks
     worker.device_id = 0
 
     consumer = _agent_metadata(
@@ -1519,6 +1551,7 @@ def test_member_descriptors_pair_layers_across_asymmetric_pp_split():
         [256, 512, 1024],
     )
     consumer.num_blocks = 4
+    consumer.region_num_blocks = remote_num_blocks
     worker._align_remote_regions_by_member(consumer)
 
     # L3 -> remote region 1, L4 -> 2, L5 -> 2. Pairing by index would have sent
@@ -1528,8 +1561,15 @@ def test_member_descriptors_pair_layers_across_asymmetric_pp_split():
     plan = TPMapping(((0,), (0,)), (0,), {0: 0}, 0)
     local_descs = worker._build_fa_local([0x1000, 0x2000], block_size_ratio=1)
     remote_descs = worker._build_fa_remote(plan, consumer, block_size_ratio=1)
-    local_ids = worker._compute_desc_ids([[1, 2], [3]], 4, None, 1)
-    remote_ids = worker._compute_desc_ids([[0, 1], [2]], 4, None, 1)
+    local_counts = [local_num_blocks[i] for i in worker._member_local_regions]
+    local_ids = worker._compute_desc_ids(
+        [[1, 2], [3]], 4, None, 1, region_num_blocks=local_counts
+    )
+    remote_ids = worker._compute_desc_ids(
+        [[0, 1], [2]], 4, None, 1, region_num_blocks=consumer.region_num_blocks
+    )
+    assert len(local_descs) == sum(local_counts)
+    assert len(remote_descs) == sum(consumer.region_num_blocks)
 
     # Each pair addresses the same layer's blocks despite different pooling
     # and strides. L3 and L5 use group 0; L4 uses group 1.
@@ -1565,20 +1605,16 @@ def test_member_alignment_is_canonical_across_remote_orderings():
 def test_member_alignment_is_idempotent():
     worker = _member_worker([["a", "a.swa"], ["b"]], {"a": 0, "a.swa": 1, "b": 0})
     metadata = _agent_metadata([["a", "a.swa"], ["b"]], [0xA000, 0xB000], [128, 128])
+    metadata.region_num_blocks = [4, 6]
+    metadata.region_group_ids = [-1, 0]
+    metadata.region_names = ["a", "b"]
+    metadata.region_mem_types = ["VRAM", "VRAM"]
 
     worker._align_remote_regions_by_member(metadata)
-    aligned = (
-        list(metadata.kv_caches_base_addr),
-        list(metadata.block_lens),
-        list(metadata.block_strides),
-    )
+    aligned = msgspec.msgpack.encode(metadata)
     worker._align_remote_regions_by_member(metadata)
 
-    assert (
-        metadata.kv_caches_base_addr,
-        metadata.block_lens,
-        metadata.block_strides,
-    ) == aligned
+    assert msgspec.msgpack.encode(metadata) == aligned
 
 
 def test_member_alignment_rejects_missing_local_member():
@@ -1603,6 +1639,21 @@ def test_member_alignment_rejects_inconsistent_remote_metadata():
 
     with pytest.raises(AssertionError, match="lengths disagree"):
         worker._align_remote_regions_by_member(metadata)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["region_num_blocks", "region_group_ids", "region_names", "region_mem_types"],
+)
+def test_member_alignment_rejects_inconsistent_region_geometry(field):
+    worker = _member_worker([["a"]], {"a": 0})
+    metadata = _agent_metadata([["a"], ["b"]], [0xA000, 0xB000], [128, 128])
+    setattr(metadata, field, [])
+    original = msgspec.msgpack.encode(metadata)
+
+    with pytest.raises(AssertionError, match="lengths disagree"):
+        worker._align_remote_regions_by_member(metadata)
+    assert msgspec.msgpack.encode(metadata) == original
 
 
 def test_set_region_members_rejects_duplicate_local_member():

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -727,6 +727,38 @@ def test_stale_engine_evicted_on_push():
 
 
 class TestPushWriterNotifs:
+    @pytest.mark.parametrize(("pp_size", "is_hma"), [(1, False), (2, True)])
+    def test_completed_writes_release_the_producer_lease(self, pp_size, is_hma):
+        """WRITE completion does not depend on receive-side request metadata."""
+        w = _StubWriterWorker.fresh()
+        w.pp_size = pp_size
+        w._is_hma_required = is_hma
+        w.transfer_topo = MagicMock()
+        w.nixl_wrapper = MagicMock()
+        w.xfer_stats = MagicMock()
+        w._failed_recv_reqs = queue.Queue()
+        w._pending_recv_notifs = {}
+        w._reqs_to_process.add("req-send")
+        w._reqs_to_send["req-send"] = time.perf_counter() + 60
+        w._sending_transfers["req-send"] = [1, 2]
+        w.nixl_wrapper.check_xfer_state.side_effect = ["DONE", "PROC", "DONE"]
+
+        # The lease stays active until every destination handle completes.
+        assert w.get_finished() == (set(), set())
+        assert w._sending_transfers["req-send"] == [2]
+        assert "req-send" in w._reqs_to_send
+
+        assert w.get_finished() == ({"req-send"}, set())
+        assert not w._sending_transfers
+        assert not w._reqs_to_send
+        assert not w._reqs_to_process
+        assert not w._recving_metadata
+        assert w._evict_finished_inbox.get_nowait() == "req-send"
+        assert w.get_finished() == (set(), set())
+        assert w._evict_finished_inbox.empty()
+        assert w.nixl_wrapper.release_xfer_handle.call_count == 2
+        w.xfer_stats.record_kv_expired_req.assert_not_called()
+
     def test_get_new_notifs_processes_forwarded_completion_notif(self):
         """Non-PUSH_REG notifs forwarded by the writer thread are drained
         on the engine main thread inside ``_get_new_notifs``."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2095,9 +2095,20 @@ class NixlBaseConnectorWorker:
             )
             return self._remote_agents[engine_id][(0, remote_tp_rank)]
 
+        assert self.transfer_topo is not None
+        transfer_topo = self.transfer_topo
         # Number of physical regions registered locally (one per layer/tensor).
         num_local_regions = len(self.block_len_per_layer)
         if self._member_local_regions:
+            if self.block_size != nixl_agent_meta.block_size:
+                raise NotImplementedError(
+                    "Attention-HMA push requires identical P/D block sizes."
+                )
+            if remote_tp_size > transfer_topo.tp_size and not self.use_mla:
+                raise NotImplementedError(
+                    "Attention-HMA push does not support decode TP greater than "
+                    "prefill TP yet"
+                )
             self._align_remote_regions_by_member(nixl_agent_meta)
         elif (
             self.pp_size > 1
@@ -2130,8 +2141,6 @@ class NixlBaseConnectorWorker:
                 ]
 
         ### Register remote engine in TransferTopology (idempotent).
-        assert self.transfer_topo is not None
-        transfer_topo = self.transfer_topo
         physical_blocks_per_logical = (
             nixl_agent_meta.physical_blocks_per_logical_kv_block
         )
@@ -2163,6 +2172,8 @@ class NixlBaseConnectorWorker:
         # remote:               | 0| 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|
         # local origin:|          0|          1|          8|         12|
         # local mapped:| 0| 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|13|14|15|
+        block_size_ratio = transfer_topo.block_size_ratio(nixl_agent_meta.block_size)
+
         if engine_id not in self.dst_num_blocks:
             num_remote_regions = len(nixl_agent_meta.kv_caches_base_addr)
             self.dst_num_blocks[engine_id] = nixl_agent_meta.num_blocks
@@ -2190,7 +2201,6 @@ class NixlBaseConnectorWorker:
         self._validate_remote_agent_handshake(
             nixl_agent_meta, remote_tp_size, remote_dcp_size
         )
-        block_size_ratio = transfer_topo.block_size_ratio(nixl_agent_meta.block_size)
 
         # This is 1 when P and D `--tensor-parallel-size` match. Otherwise,
         # this is the ratio between the two sizes.
@@ -2322,20 +2332,10 @@ class NixlBaseConnectorWorker:
             f"remote={remote_dcp_size} (engine {remote_engine_id})."
         )
 
-        member_order = bool(self._member_local_regions)
-        if member_order and self.block_size != nixl_agent_meta.block_size:
-            raise NotImplementedError(
-                "Attention-HMA push requires identical P/D block sizes."
-            )
         tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
         block_size_ratio = self.transfer_topo.block_size_ratio(
             nixl_agent_meta.block_size
         )
-        if member_order and tp_ratio < 0 and not self.use_mla:
-            raise NotImplementedError(
-                "Attention-HMA push does not support decode TP greater than "
-                "prefill TP yet"
-            )
         # num_kv_heads > tp_size with P_TP > D_TP not supported for non-mamba.
         # Mamba models can have replicated FA KV with tp_ratio < 0.
         # MLA models do not need to handle kv replication.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -167,6 +167,11 @@ class NixlBaseConnectorWorker:
     _member_names: tuple[str, ...] = ()
     _member_local_regions: tuple[int, ...] = ()
     _member_group_ids: tuple[int, ...] = ()
+    # Member positions by cache kind. Attention members are described by FA
+    # descriptors and SSM members by conv + temporal descriptors, so a pooled
+    # region backing both kinds (KDA + MLA) is addressed once per kind.
+    _member_attention_positions: tuple[int, ...] = ()
+    _member_ssm_positions: tuple[int, ...] = ()
     _has_packed_cache: bool = False
 
     def _compute_desc_ids(
@@ -181,6 +186,7 @@ class NixlBaseConnectorWorker:
     ) -> np.ndarray:
         """Compute NIXL descriptor IDs for given block IDs."""
         num_ssm_regions = 0
+        ssm_regions_per_layer = 0
         if self._has_mamba:
             assert self._conv_decomp is not None
             # NIXL regions per SSM layer = conv sub-projections + 1 SSM temporal
@@ -209,12 +215,34 @@ class NixlBaseConnectorWorker:
 
         if self._member_group_ids:
             # Member-major descriptors, using each member's KV-cache group.
-            return np.concatenate(
-                [
-                    np.asarray(block_ids[g], dtype=np.int32) + region_offsets[k]
-                    for k, g in enumerate(self._member_group_ids)
-                ]
-            )
+            # Layout follows _build_fa_local / _build_mamba_local emission
+            # order: one block run per attention member, then
+            # ssm_regions_per_layer block runs per SSM member.
+            fa_positions = self._member_attention_positions
+            fa_counts = [region_num_blocks[k] for k in fa_positions]
+            fa_offsets = dict(zip(fa_positions, np.cumsum([0, *fa_counts[:-1]])))
+            num_fa_descs = sum(fa_counts)
+            ssm_ordinal = {k: j for j, k in enumerate(self._member_ssm_positions)}
+            logical_blocks = dst_num_blocks // physical_blocks_per_logical
+            parts: list[np.ndarray] = []
+            for k, g in enumerate(self._member_group_ids):
+                group_arr = np.asarray(block_ids[g], dtype=np.int32)
+                if k in fa_offsets:
+                    parts.append(group_arr + fa_offsets[k])
+                    continue
+                ssm_base = (
+                    num_fa_descs
+                    + ssm_ordinal[k] * ssm_regions_per_layer * logical_blocks
+                )
+                sub_region_ids = np.arange(ssm_regions_per_layer, dtype=np.int32)
+                parts.append(
+                    (
+                        sub_region_ids[:, None] * logical_blocks
+                        + group_arr[None, :]
+                        + ssm_base
+                    ).ravel()
+                )
+            return np.concatenate(parts)
 
         # All-attention fast path: single vectorized broadcast.
         if num_ssm_regions == 0:
@@ -379,12 +407,17 @@ class NixlBaseConnectorWorker:
         (region-major; one desc per block, with K/V packed). Length ``num_fa_descs``.
         """
         assert self.transfer_topo is not None
-        n_regions = len(self.block_len_per_layer)
-        if n_regions == 0 or self.num_regions == 0:
+        if self._member_local_regions:
+            fa_regions = [
+                self._member_local_regions[k] for k in self._member_attention_positions
+            ]
+        else:
+            fa_regions = list(range(len(self.block_len_per_layer)))
+        if not fa_regions or self.num_regions == 0:
             return [False] * num_fa_descs
-        nblk = num_fa_descs // self.num_regions
+        nblk = num_fa_descs // len(fa_regions)
         flags: list[bool] = []
-        for i in range(n_regions):
+        for i in fa_regions:
             replicated = self._is_region_replicated(i)
             flags.extend([replicated] * nblk)
         assert len(flags) == num_fa_descs, (
@@ -420,6 +453,19 @@ class NixlBaseConnectorWorker:
             for _ in region
         )
         self._member_group_ids = tuple(group_by_member[member] for member in members)
+        attention: list[int] = []
+        ssm: list[int] = []
+        for position, group_id in enumerate(self._member_group_ids):
+            if _is_ssm_spec(self._group_spec_types[group_id]):
+                ssm.append(position)
+            else:
+                attention.append(position)
+        if ssm and self._is_csa_linear:
+            raise NotImplementedError(
+                "PP push member routing does not support CSA-linear PLE caches"
+            )
+        self._member_attention_positions = tuple(attention)
+        self._member_ssm_positions = tuple(ssm)
 
     def _requires_member_identity(self) -> bool:
         """Whether PP push must match HMA/packed layers by name, not region index."""
@@ -427,7 +473,6 @@ class NixlBaseConnectorWorker:
             self._supports_member_identity
             and self.pp_size > 1
             and (self._is_hma_required or self._has_packed_cache)
-            and not self._has_mamba
         )
 
     def _align_remote_regions_by_member(
@@ -750,13 +795,6 @@ class NixlBaseConnectorWorker:
                 "NixlConnector (pull) does not support pipeline_parallel_size "
                 "> 1 with hybrid KV cache layouts (HMA); use NixlPushConnector "
                 "for PP + HMA."
-            )
-        # PP push routes HMA (hybrid) attention layouts by pooled-member
-        # identity; Mamba/SSM hybrids are not yet supported under PP.
-        if self.pp_size > 1 and self._has_mamba:
-            raise NotImplementedError(
-                "NixlPushConnector does not support pipeline_parallel_size > 1 "
-                "with Mamba/SSM hybrid KV cache layouts yet."
             )
         # Decode-side PP is unsupported (completions counted per consumer rank).
         if vllm_config.kv_transfer_config.kv_role == "kv_consumer" and self.pp_size > 1:
@@ -1403,7 +1441,9 @@ class NixlBaseConnectorWorker:
             self._requires_member_identity()
             and self._has_packed_cache
             and any(
-                not isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+                not isinstance(
+                    spec, (MLAAttentionSpec, SlidingWindowMLASpec, MambaSpec)
+                )
                 for spec in self._layer_specs.values()
             )
         ):
@@ -1434,10 +1474,8 @@ class NixlBaseConnectorWorker:
             ):
                 compressed_region_owners.setdefault(cache.data_ptr(), cache)
 
-        track_region_members = (
-            self._supports_member_identity
-            and (self._is_hma_required or self._has_packed_cache)
-            and not self._has_mamba
+        track_region_members = self._supports_member_identity and (
+            self._is_hma_required or self._has_packed_cache
         )
         region_members: list[list[str]] = []
         packed_member_layouts: dict[str, tuple[int, int]] = {}
@@ -1715,12 +1753,20 @@ class NixlBaseConnectorWorker:
             self._remote_region_offset = regions_per_layer * start_layer
 
         # Total local FA descriptors (boundary between FA and mamba descs).
-        xfer_region_num_blocks = (
-            [self.region_num_blocks[i] for i in self._member_local_regions]
-            if self._member_local_regions
-            else self.region_num_blocks
-        )
-        self.num_descs = sum(xfer_region_num_blocks)
+        # Member routing emits one FA run per attention member; a pooled region
+        # can carry several members, and its SSM members are described by
+        # _build_mamba_local instead.
+        if self._member_local_regions:
+            xfer_region_num_blocks = [
+                self.region_num_blocks[i] for i in self._member_local_regions
+            ]
+            fa_region_num_blocks = [
+                xfer_region_num_blocks[k] for k in self._member_attention_positions
+            ]
+        else:
+            xfer_region_num_blocks = self.region_num_blocks
+            fa_region_num_blocks = xfer_region_num_blocks
+        self.num_descs = sum(fa_region_num_blocks)
 
         for mem_type in sorted(set(region_mem_types)):
             ranges = [
@@ -1841,7 +1887,14 @@ class NixlBaseConnectorWorker:
         block_arange = np.arange(num_blocks, dtype=np.uint64)
         parts: list[np.ndarray] = []
 
-        region_indices = self._ssm_region_indices or range(len(base_addresses))
+        if self._member_ssm_positions:
+            region_indices = [
+                self._member_local_regions[k] for k in self._member_ssm_positions
+            ]
+        else:
+            region_indices = list(
+                self._ssm_region_indices or range(len(base_addresses))
+            )
         for i in region_indices:
             base_addr = base_addresses[i]
             block_stride = self.block_stride_per_layer[i] * physical_per_logical
@@ -1894,9 +1947,14 @@ class NixlBaseConnectorWorker:
         parts: list[np.ndarray] = []
         # NOTE (ZhanqiuHu): use per-layer block_lens[i], not [0], in case
         # block lengths vary across layers (e.g. MLA).
-        region_indices = self._ssm_region_indices or range(
-            len(nixl_agent_meta.kv_caches_base_addr)
-        )
+        if self._member_ssm_positions:
+            # Remote lists are in local member order after alignment.
+            region_indices = list(self._member_ssm_positions)
+        else:
+            region_indices = list(
+                self._ssm_region_indices
+                or range(len(nixl_agent_meta.kv_caches_base_addr))
+            )
         for i in region_indices:
             base_addr = nixl_agent_meta.kv_caches_base_addr[i]
             block_stride = (
@@ -1951,7 +2009,14 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         assert base_addresses, "Local KV cache base addresses must not be empty."
         device_id = self.device_id
-        region_indices = self._member_local_regions or range(len(base_addresses))
+        if self._member_local_regions:
+            # Attention members only; an SSM member over the same pooled region
+            # is described by _build_mamba_local.
+            region_indices = [
+                self._member_local_regions[k] for k in self._member_attention_positions
+            ]
+        else:
+            region_indices = list(range(len(base_addresses)))
         parts: list[np.ndarray] = []
         for i in region_indices:
             base_addr = base_addresses[i]
@@ -1995,9 +2060,16 @@ class NixlBaseConnectorWorker:
         device_id = nixl_agent_meta.device_id
         block_strides = nixl_agent_meta.block_strides
         parts: list[np.ndarray] = []
-        member_order = bool(self._member_local_regions)
-        for i, base_addr in enumerate(nixl_agent_meta.kv_caches_base_addr):
-            local_region = self._member_local_regions[i] if member_order else i
+        if self._member_local_regions:
+            # Remote lists are in local member order; attention members only.
+            entries = [
+                (k, self._member_local_regions[k])
+                for k in self._member_attention_positions
+            ]
+        else:
+            entries = [(i, i) for i in range(len(nixl_agent_meta.kv_caches_base_addr))]
+        for i, local_region in entries:
+            base_addr = nixl_agent_meta.kv_caches_base_addr[i]
             replicated = self._is_region_replicated(local_region)
             # Read our whole local region size from remote..
             local_block_len = self.block_len_per_layer[local_region]
@@ -2503,12 +2575,13 @@ class NixlBaseConnectorWorker:
             # match up to the kernel block size ratio even under
             # heterogeneous TP (remote kernel blocks may be smaller).
             # SSM geometry is validated via ssm_sizes/conv offsets instead.
-            assert self.block_len_per_layer == [
+            local_lens = [self.block_len_per_layer[i] for i in local_regions]
+            assert local_lens == [
                 block_len * block_size_ratio for block_len in nixl_agent_meta.block_lens
             ], (
                 "Hybrid MLA kernel-granularity block lengths must match "
                 f"between P and D (block_size_ratio={block_size_ratio}): "
-                f"local={self.block_len_per_layer}, "
+                f"local={local_lens}, "
                 f"remote={nixl_agent_meta.block_lens}."
             )
         elif not self._has_mamba:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -195,15 +195,25 @@ class NixlBaseConnectorWorker:
         num_blocks = dst_num_blocks
         if block_size_ratio is not None:
             num_blocks = int(num_blocks * block_size_ratio)
+        num_regions = len(self._member_group_ids) or self.num_regions
         if region_num_blocks is None:
-            region_num_blocks = [num_blocks] * self.num_regions
+            region_num_blocks = [num_blocks] * num_regions
         elif block_size_ratio is not None:
             region_num_blocks = [
                 int(count * block_size_ratio) for count in region_num_blocks
             ]
-        assert len(region_num_blocks) == self.num_regions
+        assert len(region_num_blocks) == num_regions
         region_offsets = np.cumsum([0, *region_num_blocks[:-1]])
         num_fa_descs = sum(region_num_blocks)
+
+        if self._member_group_ids:
+            # Member-major descriptors, using each member's KV-cache group.
+            return np.concatenate(
+                [
+                    np.asarray(block_ids[g], dtype=np.int32) + region_offsets[k]
+                    for k, g in enumerate(self._member_group_ids)
+                ]
+            )
 
         # All-attention fast path: single vectorized broadcast.
         if num_ssm_regions == 0:
@@ -425,6 +435,67 @@ class NixlBaseConnectorWorker:
             and self._is_hma_required
             and not self._has_mamba
         )
+
+    def _align_remote_regions_by_member(
+        self, nixl_agent_meta: NixlAgentMetadata
+    ) -> None:
+        """Select remote regions for this PP stage in local member order."""
+        remote_members = nixl_agent_meta.region_members
+        # Region-index routing here would silently transfer stale KV.
+        assert remote_members, "Remote advertised no region_members"
+        assert (
+            len(nixl_agent_meta.kv_caches_base_addr)
+            == len(nixl_agent_meta.block_lens)
+            == len(nixl_agent_meta.block_strides)
+            == len(remote_members)
+        ), "Remote region metadata lengths disagree"
+        assert all(
+            values is None or len(values) == len(remote_members)
+            for values in (
+                nixl_agent_meta.region_num_blocks,
+                nixl_agent_meta.region_group_ids,
+                nixl_agent_meta.region_names,
+                nixl_agent_meta.region_mem_types,
+            )
+        ), "Remote region metadata lengths disagree"
+
+        remote_region_by_member: dict[str, int] = {}
+        for region_idx, members in enumerate(remote_members):
+            for member in members:
+                assert member not in remote_region_by_member, (
+                    f"Remote advertised layer {member!r} in multiple regions"
+                )
+                remote_region_by_member[member] = region_idx
+
+        missing = [m for m in self._member_names if m not in remote_region_by_member]
+        assert not missing, f"Remote is missing locally owned layers: {missing}"
+
+        remote_regions = [remote_region_by_member[m] for m in self._member_names]
+        nixl_agent_meta.kv_caches_base_addr = [
+            nixl_agent_meta.kv_caches_base_addr[i] for i in remote_regions
+        ]
+        nixl_agent_meta.block_lens = [
+            nixl_agent_meta.block_lens[i] for i in remote_regions
+        ]
+        nixl_agent_meta.block_strides = [
+            nixl_agent_meta.block_strides[i] for i in remote_regions
+        ]
+        if nixl_agent_meta.region_num_blocks is not None:
+            nixl_agent_meta.region_num_blocks = [
+                nixl_agent_meta.region_num_blocks[i] for i in remote_regions
+            ]
+        if nixl_agent_meta.region_group_ids is not None:
+            nixl_agent_meta.region_group_ids = [
+                nixl_agent_meta.region_group_ids[i] for i in remote_regions
+            ]
+        if nixl_agent_meta.region_mem_types is not None:
+            nixl_agent_meta.region_mem_types = [
+                nixl_agent_meta.region_mem_types[i] for i in remote_regions
+            ]
+        if nixl_agent_meta.region_names is not None:
+            nixl_agent_meta.region_names = list(self._member_names)
+        # One member per region keeps a second alignment pass a no-op.
+        nixl_agent_meta.region_members = [[m] for m in self._member_names]
 
     def __init__(
         self,
@@ -655,11 +726,22 @@ class NixlBaseConnectorWorker:
         # transfers into the matching sub-range of a PP=1 remote's regions.
         self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
         self._remote_region_offset = 0
-        # PP push slices regions per layer (uniform count); HMA breaks that.
-        if self.pp_size > 1 and self._is_hma_required:
+        if (
+            self.pp_size > 1
+            and self._is_hma_required
+            and not self._supports_member_identity
+        ):
+            raise NotImplementedError(
+                "NixlConnector (pull) does not support pipeline_parallel_size "
+                "> 1 with hybrid KV cache layouts (HMA); use NixlPushConnector "
+                "for PP + HMA."
+            )
+        # PP push routes HMA (hybrid) attention layouts by pooled-member
+        # identity; Mamba/SSM hybrids are not yet supported under PP.
+        if self.pp_size > 1 and self._has_mamba:
             raise NotImplementedError(
                 "NixlPushConnector does not support pipeline_parallel_size > 1 "
-                "with hybrid KV cache layouts (HMA) yet."
+                "with Mamba/SSM hybrid KV cache layouts yet."
             )
         # Decode-side PP is unsupported (completions counted per consumer rank).
         if vllm_config.kv_transfer_config.kv_role == "kv_consumer" and self.pp_size > 1:
@@ -1571,7 +1653,7 @@ class NixlBaseConnectorWorker:
 
         self._set_region_members(region_members)
 
-        if self.pp_size > 1:
+        if self.pp_size > 1 and not self._is_hma_required:
             start_layer, end_layer = self.model_config.get_layers_start_end_indices(
                 self.vllm_config.parallel_config
             )
@@ -1581,7 +1663,12 @@ class NixlBaseConnectorWorker:
             self._remote_region_offset = regions_per_layer * start_layer
 
         # Total local FA descriptors (boundary between FA and mamba descs).
-        self.num_descs = sum(self.region_num_blocks)
+        xfer_region_num_blocks = (
+            [self.region_num_blocks[i] for i in self._member_local_regions]
+            if self._member_local_regions
+            else self.region_num_blocks
+        )
+        self.num_descs = sum(xfer_region_num_blocks)
 
         for mem_type in sorted(set(region_mem_types)):
             ranges = [
@@ -1598,7 +1685,7 @@ class NixlBaseConnectorWorker:
 
         self.device_kv_caches = kv_caches
         self.dst_num_blocks[self.engine_id] = self.num_blocks
-        self.dst_region_num_blocks[self.engine_id] = self.region_num_blocks
+        self.dst_region_num_blocks[self.engine_id] = xfer_region_num_blocks
         self.dst_region_group_ids[self.engine_id] = self.region_group_ids
         self.dst_uses_region_group_mapping[self.engine_id] = (
             self._uses_region_group_mapping
@@ -1807,12 +1894,19 @@ class NixlBaseConnectorWorker:
         base_addresses: list[int],
         block_size_ratio: int,
     ) -> np.ndarray:
-        """Build local FA descriptors for all layers as an Nx3 uint64 array."""
+        """Build local FA descriptors as an Nx3 uint64 array."""
         assert self.transfer_topo is not None
         assert base_addresses, "Local KV cache base addresses must not be empty."
         device_id = self.device_id
+        if self._member_local_regions:
+            region_iter = [
+                (region, base_addresses[region])
+                for region in self._member_local_regions
+            ]
+        else:
+            region_iter = list(enumerate(base_addresses))
         parts: list[np.ndarray] = []
-        for i, base_addr in enumerate(base_addresses):
+        for i, base_addr in region_iter:
             block_len = self.block_len_per_layer[i] // block_size_ratio
             logical_blocks = np.repeat(
                 np.arange(self.region_num_blocks[i], dtype=np.uint64),
@@ -1836,7 +1930,7 @@ class NixlBaseConnectorWorker:
         nixl_agent_meta: NixlAgentMetadata,
         block_size_ratio: int,
     ) -> np.ndarray:
-        """Build remote FA descriptors for all layers as an Nx3 uint64 array."""
+        """Build remote FA descriptors as an Nx3 uint64 array."""
         assert self.transfer_topo is not None
         assert nixl_agent_meta.kv_caches_base_addr, (
             "Remote KV cache base addresses must not be empty."
@@ -1853,10 +1947,12 @@ class NixlBaseConnectorWorker:
         device_id = nixl_agent_meta.device_id
         block_strides = nixl_agent_meta.block_strides
         parts: list[np.ndarray] = []
+        member_order = bool(self._member_local_regions)
         for i, base_addr in enumerate(nixl_agent_meta.kv_caches_base_addr):
-            replicated = self._is_region_replicated(i)
+            local_region = self._member_local_regions[i] if member_order else i
+            replicated = self._is_region_replicated(local_region)
             # Read our whole local region size from remote..
-            local_block_len = self.block_len_per_layer[i]
+            local_block_len = self.block_len_per_layer[local_region]
             remote_kv_block_len = local_block_len // block_size_ratio
             if block_size_ratio > 1:
                 # ..using remote kv_block_len as transfer unit
@@ -2014,37 +2110,41 @@ class NixlBaseConnectorWorker:
             )
             return self._remote_agents[engine_id][(0, remote_tp_rank)]
 
-        # Number of physical regions registered locally (one per layer/tensor).
-        num_local_regions = len(self.block_len_per_layer)
-        if (
-            self.pp_size > 1
-            and len(nixl_agent_meta.kv_caches_base_addr) > num_local_regions
-        ):
-            # This worker holds a PP layer-slice; the PP=1 remote registered
-            # the full model. Slice its regions to our layer window so the
-            # logic below sees congruent local/remote lists.
-            start = self._remote_region_offset
-            end = start + num_local_regions
-            assert len(nixl_agent_meta.kv_caches_base_addr) >= end
-            nixl_agent_meta.kv_caches_base_addr = nixl_agent_meta.kv_caches_base_addr[
-                start:end
-            ]
-            nixl_agent_meta.block_lens = nixl_agent_meta.block_lens[start:end]
-            nixl_agent_meta.block_strides = nixl_agent_meta.block_strides[start:end]
-            if nixl_agent_meta.region_num_blocks is not None:
-                nixl_agent_meta.region_num_blocks = nixl_agent_meta.region_num_blocks[
+        member_order = bool(self._member_local_regions)
+        if member_order:
+            self._align_remote_regions_by_member(nixl_agent_meta)
+        else:
+            # Number of physical regions registered locally (one per layer/tensor).
+            num_local_regions = len(self.block_len_per_layer)
+            if (
+                self.pp_size > 1
+                and len(nixl_agent_meta.kv_caches_base_addr) > num_local_regions
+            ):
+                # This worker holds a PP layer-slice; the PP=1 remote registered
+                # the full model. Slice its regions to our layer window so the
+                # logic below sees congruent local/remote lists.
+                start = self._remote_region_offset
+                end = start + num_local_regions
+                assert len(nixl_agent_meta.kv_caches_base_addr) >= end
+                nixl_agent_meta.kv_caches_base_addr = nixl_agent_meta.kv_caches_base_addr[
                     start:end
                 ]
-            if nixl_agent_meta.region_group_ids is not None:
-                nixl_agent_meta.region_group_ids = nixl_agent_meta.region_group_ids[
-                    start:end
-                ]
-            if nixl_agent_meta.region_names is not None:
-                nixl_agent_meta.region_names = nixl_agent_meta.region_names[start:end]
-            if nixl_agent_meta.region_mem_types is not None:
-                nixl_agent_meta.region_mem_types = nixl_agent_meta.region_mem_types[
-                    start:end
-                ]
+                nixl_agent_meta.block_lens = nixl_agent_meta.block_lens[start:end]
+                nixl_agent_meta.block_strides = nixl_agent_meta.block_strides[start:end]
+                if nixl_agent_meta.region_num_blocks is not None:
+                    nixl_agent_meta.region_num_blocks = nixl_agent_meta.region_num_blocks[
+                        start:end
+                    ]
+                if nixl_agent_meta.region_group_ids is not None:
+                    nixl_agent_meta.region_group_ids = nixl_agent_meta.region_group_ids[
+                        start:end
+                    ]
+                if nixl_agent_meta.region_names is not None:
+                    nixl_agent_meta.region_names = nixl_agent_meta.region_names[start:end]
+                if nixl_agent_meta.region_mem_types is not None:
+                    nixl_agent_meta.region_mem_types = nixl_agent_meta.region_mem_types[
+                        start:end
+                    ]
 
         ### Register remote engine in TransferTopology (idempotent).
         assert self.transfer_topo is not None
@@ -2244,6 +2344,12 @@ class NixlBaseConnectorWorker:
         block_size_ratio = self.transfer_topo.block_size_ratio(
             nixl_agent_meta.block_size
         )
+        member_order = bool(self._member_local_regions)
+        if member_order and tp_ratio < 0 and not self.use_mla:
+            raise NotImplementedError(
+                "Attention-HMA push does not support decode TP greater than "
+                "prefill TP yet"
+            )
         # num_kv_heads > tp_size with P_TP > D_TP not supported for non-mamba.
         # Mamba models can have replicated FA KV with tp_ratio < 0.
         # MLA models do not need to handle kv replication.
@@ -2354,8 +2460,15 @@ class NixlBaseConnectorWorker:
                 f"remote={nixl_agent_meta.block_lens}."
             )
         elif not self._has_mamba:
-            assert len(self.block_len_per_layer) == len(nixl_agent_meta.block_lens), (
-                "Number of KV layers must match between prefill and decode"
+            if member_order:
+                local_lens = [
+                    self.block_len_per_layer[region]
+                    for region in self._member_local_regions
+                ]
+            else:
+                local_lens = self.block_len_per_layer
+            assert len(local_lens) == len(nixl_agent_meta.block_lens), (
+                "Number of KV layers/members must match between prefill and decode"
             )
             model_replicated = self.use_mla or self.transfer_topo.is_kv_replicated(
                 remote_engine_id
@@ -2363,8 +2476,9 @@ class NixlBaseConnectorWorker:
             total_kv_heads = self.transfer_topo.total_num_kv_heads
             local_heads = self.transfer_topo.local_physical_heads
             remote_heads = max(1, total_kv_heads // remote_tp_size)
-            for i, local_len in enumerate(self.block_len_per_layer):
-                replicated = model_replicated or self._is_region_replicated(i)
+            for i, local_len in enumerate(local_lens):
+                region_idx = self._member_local_regions[i] if member_order else i
+                replicated = model_replicated or self._is_region_replicated(region_idx)
                 remote_len = nixl_agent_meta.block_lens[i]
                 if replicated:
                     assert local_len // block_size_ratio == remote_len, (
@@ -2395,8 +2509,12 @@ class NixlBaseConnectorWorker:
 
         # TP workers that handhshake with same remote have same #blocks.
         assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
-        # Same number of regions/~layers.
-        assert len(nixl_agent_meta.kv_caches_base_addr) == len(self.block_len_per_layer)
+        expected_regions = (
+            len(self._member_local_regions)
+            if member_order
+            else len(self.block_len_per_layer)
+        )
+        assert len(nixl_agent_meta.kv_caches_base_addr) == expected_regions
         num_remote_regions = len(nixl_agent_meta.kv_caches_base_addr)
         if nixl_agent_meta.region_num_blocks is not None:
             assert len(nixl_agent_meta.region_num_blocks) == num_remote_regions
@@ -2412,7 +2530,10 @@ class NixlBaseConnectorWorker:
         if nixl_agent_meta.region_group_ids is not None:
             assert len(nixl_agent_meta.region_group_ids) == num_remote_regions
         if nixl_agent_meta.region_names is not None:
-            assert nixl_agent_meta.region_names == self.region_names, (
+            expected_names = (
+                list(self._member_names) if member_order else self.region_names
+            )
+            assert nixl_agent_meta.region_names == expected_names, (
                 "NIXL transfer regions must name the same model caches in the "
                 "same order"
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2863,11 +2863,14 @@ class NixlBaseConnectorWorker:
                     new_expiry,
                 )
 
-    def _pop_done_transfers(self, transfers: dict[str, list[int]]) -> set[str]:
+    def _pop_done_transfers(
+        self, transfers: dict[str, list[int]], *, is_send: bool = False
+    ) -> set[str]:
         """
         Pop completed xfers by checking for DONE state.
         Args:
             transfers: dict of req_id -> list[running_xfer]
+            is_send: Whether these are outgoing WRITEs rather than incoming READs.
         Returns:
             set of req_ids that have all done xfers
         """
@@ -2904,12 +2907,14 @@ class NixlBaseConnectorWorker:
 
             if not in_progress:
                 # Only report request as completed when all transfers are done.
-                # A request failed in an earlier poll was already reported via
+                # A receive failed in an earlier poll was already reported via
                 # _failed_recv_reqs and its metadata popped by get_finished();
                 # don't report it again, just drop the remaining handles.
-                if req_id in self._recving_metadata:
+                # Outgoing WRITEs have no receive-side metadata.
+                if is_send or req_id in self._recving_metadata:
                     done_req_ids.add(req_id)
-                    self._send_pending_recv_notifs(req_id)
+                    if not is_send:
+                        self._send_pending_recv_notifs(req_id)
                 del transfers[req_id]
             else:
                 transfers[req_id] = in_progress

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -409,7 +409,8 @@ class NixlBaseConnectorWorker:
         self.region_members: list[list[str]] = region_members
         if not self._requires_member_identity():
             return
-        ungrouped = [m for m in members if m not in self._layer_name_to_kv_group_index]
+        group_by_member = self.kv_cache_config.transfer_group_index_by_layer
+        ungrouped = [m for m in members if m not in group_by_member]
         assert not ungrouped, f"KV cache layers outside any local group: {ungrouped}"
         self._member_names = tuple(members)
         self._member_local_regions = tuple(
@@ -417,18 +418,10 @@ class NixlBaseConnectorWorker:
             for region_idx, region in enumerate(region_members)
             for _ in region
         )
-        self._member_group_ids = tuple(
-            self._layer_name_to_kv_group_index[member] for member in members
-        )
+        self._member_group_ids = tuple(group_by_member[member] for member in members)
 
     def _requires_member_identity(self) -> bool:
-        """Whether this worker's local layout must be routed by layer name.
-
-        True for a PP-sharded push producer whose local KV layout is hybrid
-        (HMA): region indices are not a stable identity across the P/D layer
-        split, so transfers must be keyed by member name. Independent of the
-        remote peer.
-        """
+        """Whether PP push must match HMA layers by name, not region index."""
         return (
             self._supports_member_identity
             and self.pp_size > 1
@@ -874,9 +867,6 @@ class NixlBaseConnectorWorker:
 
         # Member metadata is populated for HMA layouts.
         self.region_members = []
-        self._layer_name_to_kv_group_index = (
-            self.kv_cache_config.transfer_group_index_by_layer
-        )
         # Per-engine TP mappings. Generated during handshake.
         self.tp_mappings: dict[EngineId, TPMapping] = {}
 
@@ -1898,15 +1888,10 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         assert base_addresses, "Local KV cache base addresses must not be empty."
         device_id = self.device_id
-        if self._member_local_regions:
-            region_iter = [
-                (region, base_addresses[region])
-                for region in self._member_local_regions
-            ]
-        else:
-            region_iter = list(enumerate(base_addresses))
+        region_indices = self._member_local_regions or range(len(base_addresses))
         parts: list[np.ndarray] = []
-        for i, base_addr in region_iter:
+        for i in region_indices:
+            base_addr = base_addresses[i]
             block_len = self.block_len_per_layer[i] // block_size_ratio
             logical_blocks = np.repeat(
                 np.arange(self.region_num_blocks[i], dtype=np.uint64),
@@ -2110,41 +2095,39 @@ class NixlBaseConnectorWorker:
             )
             return self._remote_agents[engine_id][(0, remote_tp_rank)]
 
-        member_order = bool(self._member_local_regions)
-        if member_order:
+        # Number of physical regions registered locally (one per layer/tensor).
+        num_local_regions = len(self.block_len_per_layer)
+        if self._member_local_regions:
             self._align_remote_regions_by_member(nixl_agent_meta)
-        else:
-            # Number of physical regions registered locally (one per layer/tensor).
-            num_local_regions = len(self.block_len_per_layer)
-            if (
-                self.pp_size > 1
-                and len(nixl_agent_meta.kv_caches_base_addr) > num_local_regions
-            ):
-                # This worker holds a PP layer-slice; the PP=1 remote registered
-                # the full model. Slice its regions to our layer window so the
-                # logic below sees congruent local/remote lists.
-                start = self._remote_region_offset
-                end = start + num_local_regions
-                assert len(nixl_agent_meta.kv_caches_base_addr) >= end
-                nixl_agent_meta.kv_caches_base_addr = nixl_agent_meta.kv_caches_base_addr[
+        elif (
+            self.pp_size > 1
+            and len(nixl_agent_meta.kv_caches_base_addr) > num_local_regions
+        ):
+            # This worker holds a PP layer-slice; the PP=1 remote registered
+            # the full model. Slice its regions to our layer window so the
+            # logic below sees congruent local/remote lists.
+            start = self._remote_region_offset
+            end = start + num_local_regions
+            assert len(nixl_agent_meta.kv_caches_base_addr) >= end
+            nixl_agent_meta.kv_caches_base_addr = nixl_agent_meta.kv_caches_base_addr[
+                start:end
+            ]
+            nixl_agent_meta.block_lens = nixl_agent_meta.block_lens[start:end]
+            nixl_agent_meta.block_strides = nixl_agent_meta.block_strides[start:end]
+            if nixl_agent_meta.region_num_blocks is not None:
+                nixl_agent_meta.region_num_blocks = nixl_agent_meta.region_num_blocks[
                     start:end
                 ]
-                nixl_agent_meta.block_lens = nixl_agent_meta.block_lens[start:end]
-                nixl_agent_meta.block_strides = nixl_agent_meta.block_strides[start:end]
-                if nixl_agent_meta.region_num_blocks is not None:
-                    nixl_agent_meta.region_num_blocks = nixl_agent_meta.region_num_blocks[
-                        start:end
-                    ]
-                if nixl_agent_meta.region_group_ids is not None:
-                    nixl_agent_meta.region_group_ids = nixl_agent_meta.region_group_ids[
-                        start:end
-                    ]
-                if nixl_agent_meta.region_names is not None:
-                    nixl_agent_meta.region_names = nixl_agent_meta.region_names[start:end]
-                if nixl_agent_meta.region_mem_types is not None:
-                    nixl_agent_meta.region_mem_types = nixl_agent_meta.region_mem_types[
-                        start:end
-                    ]
+            if nixl_agent_meta.region_group_ids is not None:
+                nixl_agent_meta.region_group_ids = nixl_agent_meta.region_group_ids[
+                    start:end
+                ]
+            if nixl_agent_meta.region_names is not None:
+                nixl_agent_meta.region_names = nixl_agent_meta.region_names[start:end]
+            if nixl_agent_meta.region_mem_types is not None:
+                nixl_agent_meta.region_mem_types = nixl_agent_meta.region_mem_types[
+                    start:end
+                ]
 
         ### Register remote engine in TransferTopology (idempotent).
         assert self.transfer_topo is not None
@@ -2180,8 +2163,6 @@ class NixlBaseConnectorWorker:
         # remote:               | 0| 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|
         # local origin:|          0|          1|          8|         12|
         # local mapped:| 0| 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|13|14|15|
-        block_size_ratio = transfer_topo.block_size_ratio(nixl_agent_meta.block_size)
-
         if engine_id not in self.dst_num_blocks:
             num_remote_regions = len(nixl_agent_meta.kv_caches_base_addr)
             self.dst_num_blocks[engine_id] = nixl_agent_meta.num_blocks
@@ -2209,6 +2190,7 @@ class NixlBaseConnectorWorker:
         self._validate_remote_agent_handshake(
             nixl_agent_meta, remote_tp_size, remote_dcp_size
         )
+        block_size_ratio = transfer_topo.block_size_ratio(nixl_agent_meta.block_size)
 
         # This is 1 when P and D `--tensor-parallel-size` match. Otherwise,
         # this is the ratio between the two sizes.
@@ -2448,6 +2430,9 @@ class NixlBaseConnectorWorker:
         # the per-rank KV head ratio rather than the raw tp_ratio, because GQA
         # replication caps per-rank heads at 1 when tp > total_kv_heads
         # (issue #45330). Mamba uses the ssm_sizes counterpart, so skip here.
+        local_regions = self._member_local_regions or range(
+            len(self.block_len_per_layer)
+        )
         if self._has_mamba and self.use_mla:
             # Hybrid MLA+SSM (e.g. KimiLinear's KDA+MLA): regions are
             # kernel-granularity views of the mamba-unified page. The MLA
@@ -2464,14 +2449,7 @@ class NixlBaseConnectorWorker:
                 f"remote={nixl_agent_meta.block_lens}."
             )
         elif not self._has_mamba:
-            if member_order:
-                local_lens = [
-                    self.block_len_per_layer[region]
-                    for region in self._member_local_regions
-                ]
-            else:
-                local_lens = self.block_len_per_layer
-            assert len(local_lens) == len(nixl_agent_meta.block_lens), (
+            assert len(local_regions) == len(nixl_agent_meta.block_lens), (
                 "Number of KV layers/members must match between prefill and decode"
             )
             model_replicated = self.use_mla or self.transfer_topo.is_kv_replicated(
@@ -2480,8 +2458,8 @@ class NixlBaseConnectorWorker:
             total_kv_heads = self.transfer_topo.total_num_kv_heads
             local_heads = self.transfer_topo.local_physical_heads
             remote_heads = max(1, total_kv_heads // remote_tp_size)
-            for i, local_len in enumerate(local_lens):
-                region_idx = self._member_local_regions[i] if member_order else i
+            for i, region_idx in enumerate(local_regions):
+                local_len = self.block_len_per_layer[region_idx]
                 replicated = model_replicated or self._is_region_replicated(region_idx)
                 remote_len = nixl_agent_meta.block_lens[i]
                 if replicated:
@@ -2513,12 +2491,7 @@ class NixlBaseConnectorWorker:
 
         # TP workers that handhshake with same remote have same #blocks.
         assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
-        expected_regions = (
-            len(self._member_local_regions)
-            if member_order
-            else len(self.block_len_per_layer)
-        )
-        assert len(nixl_agent_meta.kv_caches_base_addr) == expected_regions
+        assert len(nixl_agent_meta.kv_caches_base_addr) == len(local_regions)
         num_remote_regions = len(nixl_agent_meta.kv_caches_base_addr)
         if nixl_agent_meta.region_num_blocks is not None:
             assert len(nixl_agent_meta.region_num_blocks) == num_remote_regions
@@ -2535,7 +2508,7 @@ class NixlBaseConnectorWorker:
             assert len(nixl_agent_meta.region_group_ids) == num_remote_regions
         if nixl_agent_meta.region_names is not None:
             expected_names = (
-                list(self._member_names) if member_order else self.region_names
+                list(self._member_names) if self._member_names else self.region_names
             )
             assert nixl_agent_meta.region_names == expected_names, (
                 "NIXL transfer regions must name the same model caches in the "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2340,11 +2340,15 @@ class NixlBaseConnectorWorker:
             f"remote={remote_dcp_size} (engine {remote_engine_id})."
         )
 
+        member_order = bool(self._member_local_regions)
+        if member_order and self.block_size != nixl_agent_meta.block_size:
+            raise NotImplementedError(
+                "Attention-HMA push requires identical P/D block sizes."
+            )
         tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
         block_size_ratio = self.transfer_topo.block_size_ratio(
             nixl_agent_meta.block_size
         )
-        member_order = bool(self._member_local_regions)
         if member_order and tp_ratio < 0 and not self.use_mla:
             raise NotImplementedError(
                 "Attention-HMA push does not support decode TP greater than "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -167,6 +167,7 @@ class NixlBaseConnectorWorker:
     _member_names: tuple[str, ...] = ()
     _member_local_regions: tuple[int, ...] = ()
     _member_group_ids: tuple[int, ...] = ()
+    _has_packed_cache: bool = False
 
     def _compute_desc_ids(
         self,
@@ -421,11 +422,11 @@ class NixlBaseConnectorWorker:
         self._member_group_ids = tuple(group_by_member[member] for member in members)
 
     def _requires_member_identity(self) -> bool:
-        """Whether PP push must match HMA layers by name, not region index."""
+        """Whether PP push must match HMA/packed layers by name, not region index."""
         return (
             self._supports_member_identity
             and self.pp_size > 1
-            and self._is_hma_required
+            and (self._is_hma_required or self._has_packed_cache)
             and not self._has_mamba
         )
 
@@ -463,6 +464,9 @@ class NixlBaseConnectorWorker:
         missing = [m for m in self._member_names if m not in remote_region_by_member]
         assert not missing, f"Remote is missing locally owned layers: {missing}"
 
+        packed_regions = {
+            remote_region_by_member[m] for m in nixl_agent_meta.packed_member_layouts
+        }
         remote_regions = [remote_region_by_member[m] for m in self._member_names]
         nixl_agent_meta.kv_caches_base_addr = [
             nixl_agent_meta.kv_caches_base_addr[i] for i in remote_regions
@@ -487,6 +491,24 @@ class NixlBaseConnectorWorker:
             ]
         if nixl_agent_meta.region_names is not None:
             nixl_agent_meta.region_names = list(self._member_names)
+        if nixl_agent_meta.packed_member_layouts:
+            for i, member in enumerate(self._member_names):
+                if remote_regions[i] not in packed_regions:
+                    continue
+                assert member in nixl_agent_meta.packed_member_layouts, (
+                    f"Remote packed layer {member!r} has no layout"
+                )
+                offset, page_size = nixl_agent_meta.packed_member_layouts[member]
+                assert (
+                    0 <= offset < offset + page_size <= nixl_agent_meta.block_lens[i]
+                ), f"Remote packed layer {member!r} escapes its block"
+                local_region = self._member_local_regions[i]
+                assert page_size == self.block_len_per_layer[local_region], (
+                    f"Packed MLA page sizes must match for layer {member!r}"
+                )
+                nixl_agent_meta.kv_caches_base_addr[i] += offset
+                nixl_agent_meta.block_lens[i] = page_size
+            nixl_agent_meta.packed_member_layouts = {}
         # One member per region keeps a second alignment pass a no-op.
         nixl_agent_meta.region_members = [[m] for m in self._member_names]
 
@@ -1309,6 +1331,7 @@ class NixlBaseConnectorWorker:
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""
 
+        self._has_packed_cache = KVCacheLayout[self.kv_cache_layout].is_block_outermost
         self.transfer_topo = TransferTopology(
             tp_rank=self.tp_rank,
             tp_size=self.world_size,
@@ -1326,9 +1349,15 @@ class NixlBaseConnectorWorker:
             else None,
             is_mamba=self._has_mamba,
         )
+        backend_name = self.backend_name
+        if self._supports_member_identity and self._has_packed_cache:
+            # PP can reorder the same backends across stages of a packed model.
+            backend_name = ",".join(
+                sorted(backend.get_name() for backend in self.attn_backends)
+            )
         self.compat_hash = compute_nixl_compatibility_hash(
             self.vllm_config,
-            self.backend_name,
+            backend_name,
             transfer_mode=self._TRANSFER_MODE,
         )
 
@@ -1370,6 +1399,15 @@ class NixlBaseConnectorWorker:
         # CSA-linear needs separate logical regions for attention and state
         # aliases even though every view shares one block-major allocation.
         packed_storage = packed_storage and not self._is_csa_linear
+        if (
+            self._requires_member_identity()
+            and self._has_packed_cache
+            and any(
+                not isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+                for spec in self._layer_specs.values()
+            )
+        ):
+            raise NotImplementedError("PP push with packed KV caches requires MLA")
 
         layer_specs: dict[str, KVCacheSpec] = {}
         compressed_region_owners: dict[int, torch.Tensor] = {}
@@ -1398,10 +1436,11 @@ class NixlBaseConnectorWorker:
 
         track_region_members = (
             self._supports_member_identity
-            and self._is_hma_required
+            and (self._is_hma_required or self._has_packed_cache)
             and not self._has_mamba
         )
         region_members: list[list[str]] = []
+        packed_member_layouts: dict[str, tuple[int, int]] = {}
 
         # K and V are packed into the content dim, so each attention layer is a
         # single NIXL region whose block transfers as one unit. Mamba layers instead
@@ -1533,6 +1572,27 @@ class NixlBaseConnectorWorker:
                     region_specs = [
                         (storage_addr, storage_block_len, storage_block_len)
                     ]
+                    if track_region_members and is_mla_region:
+                        offset = cache.data_ptr() - storage_addr
+                        assert (
+                            offset >= 0 and offset + physical_page_size <= block_stride
+                        )
+                        if self._requires_member_identity():
+                            # A PP producer transfers only its own layer pages.
+                            region_specs = [
+                                (
+                                    cache.data_ptr(),
+                                    physical_page_size,
+                                    block_stride,
+                                )
+                            ]
+                        else:
+                            # PP=1 keeps whole-row transfers, but advertises the
+                            # slices a PP producer needs to address this cache.
+                            packed_member_layouts[layer_name] = (
+                                offset,
+                                physical_page_size,
+                            )
                 elif storage_is_block_major:
                     region_specs = [
                         (cache.data_ptr(), physical_page_size, block_stride)
@@ -1562,7 +1622,9 @@ class NixlBaseConnectorWorker:
                     ]
 
             for base_addr, block_len, block_stride in region_specs:
-                if base_addr in seen_base_addresses:
+                if base_addr in seen_base_addresses and not (
+                    self._has_packed_cache and self._requires_member_identity()
+                ):
                     region_index = seen_base_addresses.index(base_addr)
                     assert region_mem_types[region_index] == mem_type
                     self._region_is_mla[region_index] |= is_mla_region
@@ -1643,7 +1705,7 @@ class NixlBaseConnectorWorker:
 
         self._set_region_members(region_members)
 
-        if self.pp_size > 1 and not self._is_hma_required:
+        if self.pp_size > 1 and not self._requires_member_identity():
             start_layer, end_layer = self.model_config.get_layers_start_end_indices(
                 self.vllm_config.parallel_config
             )
@@ -1726,6 +1788,7 @@ class NixlBaseConnectorWorker:
             dcp_size=self.dcp_size,
             pcp_size=self.pcp_size,
             region_members=self.region_members,
+            packed_member_layouts=packed_member_layouts,
         )
         # Wrap metadata in payload with hash for defensive decoding
         assert self.compat_hash is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -159,6 +159,15 @@ class NixlBaseConnectorWorker:
     # Overridden by NixlPushConnectorWorker.
     _TRANSFER_MODE: str = "pull"
 
+    # Member-major routing is supported only by NixlPushConnector for HMA KV
+    # caches under PP.
+    _supports_member_identity = False
+    # Local member-major layout, set by ``_set_region_members`` only when this
+    # worker must route by layer name. Empty means region-index routing.
+    _member_names: tuple[str, ...] = ()
+    _member_local_regions: tuple[int, ...] = ()
+    _member_group_ids: tuple[int, ...] = ()
+
     def _compute_desc_ids(
         self,
         block_ids: BlockIds,
@@ -381,6 +390,41 @@ class NixlBaseConnectorWorker:
         block_len_per_layer without register_kv_caches).
         """
         return region_idx < len(self._region_is_mla) and self._region_is_mla[region_idx]
+
+    def _set_region_members(self, region_members: list[list[str]]) -> None:
+        members = [member for region in region_members for member in region]
+        assert len(members) == len(set(members)), (
+            "A KV cache layer spans multiple NIXL regions"
+        )
+        self.region_members: list[list[str]] = region_members
+        if not self._requires_member_identity():
+            return
+        ungrouped = [m for m in members if m not in self._layer_name_to_kv_group_index]
+        assert not ungrouped, f"KV cache layers outside any local group: {ungrouped}"
+        self._member_names = tuple(members)
+        self._member_local_regions = tuple(
+            region_idx
+            for region_idx, region in enumerate(region_members)
+            for _ in region
+        )
+        self._member_group_ids = tuple(
+            self._layer_name_to_kv_group_index[member] for member in members
+        )
+
+    def _requires_member_identity(self) -> bool:
+        """Whether this worker's local layout must be routed by layer name.
+
+        True for a PP-sharded push producer whose local KV layout is hybrid
+        (HMA): region indices are not a stable identity across the P/D layer
+        split, so transfers must be keyed by member name. Independent of the
+        remote peer.
+        """
+        return (
+            self._supports_member_identity
+            and self.pp_size > 1
+            and self._is_hma_required
+            and not self._has_mamba
+        )
 
     def __init__(
         self,
@@ -746,6 +790,11 @@ class NixlBaseConnectorWorker:
         # within a block (BLHNC/BHLNC), where stride > block_len.
         self.block_stride_per_layer = list[int]()
 
+        # Member metadata is populated for HMA layouts.
+        self.region_members = []
+        self._layer_name_to_kv_group_index = (
+            self.kv_cache_config.transfer_group_index_by_layer
+        )
         # Per-engine TP mappings. Generated during handshake.
         self.tp_mappings: dict[EngineId, TPMapping] = {}
 
@@ -1275,6 +1324,13 @@ class NixlBaseConnectorWorker:
             ):
                 compressed_region_owners.setdefault(cache.data_ptr(), cache)
 
+        track_region_members = (
+            self._supports_member_identity
+            and self._is_hma_required
+            and not self._has_mamba
+        )
+        region_members: list[list[str]] = []
+
         # K and V are packed into the content dim, so each attention layer is a
         # single NIXL region whose block transfers as one unit. Mamba layers instead
         # register separate conv/ssm sub-regions (see `_build_mamba_local`).
@@ -1451,6 +1507,12 @@ class NixlBaseConnectorWorker:
                     region_mem_types.append(mem_type)
                     self._region_is_mla.append(is_mla_region)
 
+                if track_region_members:
+                    if region_index == len(region_members):
+                        region_members.append([layer_name])
+                    else:
+                        region_members[region_index].append(layer_name)
+
                 if isinstance(layer_spec, MambaSpec):
                     if layer_spec.tp_replicated:
                         assert self._is_csa_linear
@@ -1506,6 +1568,8 @@ class NixlBaseConnectorWorker:
         self._mixed_mem_types = len(set(region_mem_types)) > 1
         if self._has_mamba:
             self.region_num_blocks = [self.num_blocks] * self.num_regions
+
+        self._set_region_members(region_members)
 
         if self.pp_size > 1:
             start_layer, end_layer = self.model_config.get_layers_start_end_indices(
@@ -1584,6 +1648,7 @@ class NixlBaseConnectorWorker:
             region_mem_types=self.region_mem_types,
             dcp_size=self.dcp_size,
             pcp_size=self.pcp_size,
+            region_members=self.region_members,
         )
         # Wrap metadata in payload with hash for defensive decoding
         assert self.compat_hash is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Metadata dataclasses and helpers for the NIXL connector."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from vllm.config import VllmConfig
@@ -47,8 +47,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   9: Add block_strides
 #  10: Add dense virtual transfer pages for compressed MLA caches
 #  11: Add per-region transfer geometry and memory types to NixlAgentMetadata
+#  12: Add per-region member names for PP push
 #
-NIXL_CONNECTOR_VERSION: int = 11
+NIXL_CONNECTOR_VERSION: int = 12
 
 
 @dataclass
@@ -71,6 +72,8 @@ class NixlAgentMetadata:
     region_mem_types: list[str] | None = None
     dcp_size: int = 1
     pcp_size: int = 1
+    # Layer names sharing each advertised region, in region order.
+    region_members: list[list[str]] = field(default_factory=list)
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -48,8 +48,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #  10: Add dense virtual transfer pages for compressed MLA caches
 #  11: Add per-region transfer geometry and memory types to NixlAgentMetadata
 #  12: Add per-region member names for PP push
+#  13: Add packed-member layouts and order-independent packed-push backend hashes
 #
-NIXL_CONNECTOR_VERSION: int = 12
+NIXL_CONNECTOR_VERSION: int = 13
 
 
 @dataclass
@@ -74,6 +75,8 @@ class NixlAgentMetadata:
     pcp_size: int = 1
     # Layer names sharing each advertised region, in region order.
     region_members: list[list[str]] = field(default_factory=list)
+    # Packed member -> (byte offset in its region's block, bytes per page).
+    packed_member_layouts: dict[str, tuple[int, int]] = field(default_factory=dict)
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -80,6 +80,8 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
     # Distinguishes push from pull in the NIXL compatibility hash.
     _TRANSFER_MODE: str = "push"
 
+    _supports_member_identity = True
+
     def __init__(
         self,
         vllm_config: "VllmConfig",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -514,6 +514,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         plan = self.tp_mappings[engine_id]
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        member_groups = self._member_group_ids or None
 
         # Expand D's logical IDs using the ratio learned during the
         # NIXL handshake. ``meta`` is freshly built by
@@ -591,6 +592,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                region_group_ids=member_groups,
             )
             if handle is not None:
                 handles.append(handle)
@@ -610,6 +612,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        region_group_ids: tuple[int, ...] | None = None,
     ) -> int | None:
         """Post a WRITE point-to-point xfer request.
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -514,7 +514,6 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         plan = self.tp_mappings[engine_id]
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
-        member_groups = self._member_group_ids or None
 
         # Expand D's logical IDs using the ratio learned during the
         # NIXL handshake. ``meta`` is freshly built by
@@ -592,7 +591,6 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
-                region_group_ids=member_groups,
             )
             if handle is not None:
                 handles.append(handle)
@@ -612,7 +610,6 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
-        region_group_ids: tuple[int, ...] | None = None,
     ) -> int | None:
         """Post a WRITE point-to-point xfer request.
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -790,7 +790,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # ``_pop_done_transfers`` mutates ``_sending_transfers``; the
         # writer thread also appends to it, so guard the pop.
         with self._sending_transfers_lock:
-            done_pushing = self._pop_done_transfers(self._sending_transfers)
+            done_pushing = self._pop_done_transfers(
+                self._sending_transfers, is_send=True
+            )
         for req_id in done_pushing:
             self._reqs_to_send.pop(req_id, None)
             self._reqs_to_process.discard(req_id)


### PR DESCRIPTION
> **Depends on #50499; land after it** (which in turn depends on #50494). All
> three target `main`, so GitHub also displays the parent commits. The
> incremental diff is 3 files, +312/−40:
> [`0f6c6aa68f...misunp/k3-ssm-members-on-50499-0f6c6aa`](https://github.com/mispa-ms/vllm/compare/0f6c6aa68f...mispa-ms:vllm:misunp/k3-ssm-members-on-50499-0f6c6aa).
>
> **Churn ahead, flagged rather than hidden.** #50494 has since added
> `6209b817c9`, which renames the vocabulary this builds on:
> `_supports_member_identity` → `_supports_pp_hma`, `_member_local_regions` →
> `_transfer_layer_region_indices`, `_set_region_members` →
> `_set_region_layers`, `_requires_member_identity` →
> `_requires_layer_name_routing`, `_align_remote_regions_by_member` →
> `_align_remote_regions_by_layer`, and the wire field `region_members` →
> `region_layers`. #50499 has not rebased onto that yet. When it does I will
> re-derive this on the new names and re-run everything below; the design is
> unaffected, only the identifiers move. Opening now so the approach and the
> hardware evidence are visible while the parents settle — @zixi-qi, if you
> would rather fold this into #50499 directly, say so and I will close it.

## Purpose

#50494 and #50499 route pipeline-parallel NIXL push by pooled-member identity
so a PP stage transfers exactly the KV pages it owns. Both deliberately stop at
attention: the routing is gated off for Mamba/SSM hybrids
(`... and not self._has_mamba`) and the worker refuses outright at init:

```
NixlPushConnector does not support pipeline_parallel_size > 1 with Mamba/SSM hybrid KV cache layouts yet.
```

Kimi-K3 is exactly that shape. Its KV cache pools one MLA layer with two KDA
(Mamba/SSM) layers per physical region, so a single region carries members of
two cache kinds and every PP-disaggregated topology for the model stops at that
refusal.

This change extends the existing framework rather than adding a second one:
split the member list by cache kind and let each kind emit the descriptors it
already knows how to emit.

- `_set_region_members` additionally records
  `_member_attention_positions` / `_member_ssm_positions` by asking
  `_is_ssm_spec` about each member's KV cache group.
- `_build_fa_local` / `_build_fa_remote` iterate the attention members;
  `_build_mamba_local` / `_build_mamba_remote` iterate the SSM members. A
  pooled KDA+MLA region is therefore addressed once per kind, not once per
  region.
- `_compute_desc_ids` lays descriptor ids out member-major in the same emission
  order: the per-member block runs for attention members, then
  `ssm_regions_per_layer` runs per SSM member. Block counts come per member
  from `region_num_blocks`, so pools of unequal capacity stay correct.
- `num_descs`, the FA/mamba boundary, counts attention members rather than
  regions, and `_fa_desc_replicated` follows the same member list.
- The hybrid MLA block-length assert compares in member order.
- The two gates (`_requires_member_identity`, `track_region_members`) drop
  `and not self._has_mamba`, and the init refusal goes.
- CSA-linear PLE caches are refused explicitly rather than silently
  mis-addressed: they alias one block-major allocation in a way this member
  split does not describe.

Decode-side PP stays unsupported, and PP=1 and pull behaviour are untouched.

## Why this is not duplicating an existing PR

**#51053** (`Fix/kimi nixl pp mamba`, draft) has the same intent: Kimi KDA+MLA
members over PP push. It is stacked on the *old* #50494 with the separate
`member_transfer.py` planner that upstream has since dropped, has been
conflicting since 2026-08-10, and states it could not run Kimi-K3 end to end
("the available 8×MI355X host cannot simultaneously hold a Kimi-K3 producer and
consumer"), so its Kimi path is covered by unit tests only.

This change is against the current structure — no new module, no second
planner, just the cache-kind split inside #50499's `_member_*` layout — and it
carries a GB300 end-to-end result on the model in question. @LiuYinfeng01, if
you would rather refresh #51053 on the current base, I am glad to hand over the
evidence and close this.

Also checked: #55215 (hybrid KDA RecoverSSM target-state transport) is a
different mechanism, and #53360 is the pull path.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_nixl_push_connector.py
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_nixl_push_connector.py -k hybrid_member
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_nixl_connector_hma.py
.venv/bin/python -m ruff check   vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py tests/v1/kv_connector/unit/test_nixl_push_connector.py tests/v1/kv_connector/unit/test_nixl_connector_hma.py
.venv/bin/python -m ruff format --check <same three files>
```

New tests, written before the change, on a KimiLinear-shaped stage (one MLA
layer pooled with two KDA layers per region, GDN conv Q|K|V split):

| test | asserts |
|---|---|
| `test_hybrid_members_split_by_cache_kind` | members partition into attention (0, 3) and SSM (1, 2, 4, 5) |
| `test_hybrid_member_descriptors_address_each_kind_once_per_layer` | each member's blocks resolve to that layer's own descriptors — the FA page for MLA, conv sub-projections plus temporal state for each KDA member |
| `test_hybrid_member_alignment_pairs_layers_with_an_unsharded_consumer` | a PP stage writing into a PP=1 consumer that pools the same kinds in another order, and holds layers this stage does not |
| `test_register_kv_caches_hybrid_mla_pp_stage_routes_by_member` (HMA suite) | real `register_kv_caches` on a PP2 producer: region members, the attention/SSM split, `num_descs`, and the descriptor count |

End to end: Kimi-K3 (MXFP4) on 24× GB300, 1P1D, prefill TP8×DCP8×**PP2** →
decode TP8×DCP8, `NixlPushConnector`, with and without the DSpark drafter,
60-minute agentic runs at concurrency 64 plus GSM8K.

## Test Result

- `test_nixl_push_connector.py`: **78 passed** (75 existing + 3 new).
  The three hybrid tests fail on the unpatched branch and pass with it.
- `test_nixl_connector_hma.py`: 73 passed, 3 failed. The three failures
  (`test_fewer_blocks_with_hma[google/gemma-3-1b-it-512]`,
  `test_post_process_zeroes_untransferred_tail`,
  `test_register_kv_caches_hybrid_mla_dual_purpose_regions`) reproduce
  identically on pristine `main` and on pristine `0f6c6aa68f` on this host and
  are not caused by this change. The new PP2 register test in that file needs
  the same host support as its PP1 sibling
  (`test_register_kv_caches_hybrid_mla_dual_purpose_regions`) and shares its
  fate; it passes wherever that one does.
- ruff check and format clean.

**End to end, an A/B where this patch is the only variable.** Both arms ran the
same image and the same upstream chain; `K3_OURS=ssm` adds only this change:

| arm | result |
|---|---|
| without | prefill dies at init: `NixlPushConnector does not support pipeline_parallel_size > 1 with Mamba/SSM hybrid KV cache layouts yet` |
| with | handshake completes, KV and SSM state transfer, 60-minute runs finish |

| Kimi-K3 MXFP4, 1P1D, P TP8×DCP8×PP2 → D TP8×DCP8, 24 GPU, c64 | tok/s/GPU | ITL p90 | TTFT p50 | requests |
|---|---|---|---|---|
| DSpark, 2026-09-09 nightly | 8,771.1 | 28.32 ms | 2.14 s | 6,250 |
| DSpark, 2026-09-08 nightly | 8,773.0 | 28.62 ms | 2.05 s | 6,238 |
| no speculative decoding | 5,369.2 | 57.9 ms | 2.0 s | 3,964 |
| mooncake tier enabled, no spec | 5,360.6 | 58.3 ms | — | 3,948 |

For scale: on the same topology and concurrency, the best pinned pre-nightly
stack we have reaches 8,400 tok/s/GPU, so PP-disaggregated Kimi-K3 over this
path is not paying for the routing.

## Model evaluation

GSM8K (`lm_eval`, strict match), Kimi-K3 MXFP4, same 1P1D GB300 topology, KV and
SSM state moved through this path:

| arm | strict match | invalid |
|---|---|---|
| no speculative decoding | **0.9500** | 0.08 % |
| DSpark drafter | **0.9530** | 0.08 % |

An aggregated reference on the same checkpoint scores 0.947. The recurrent state
this path moves is what a wrong SSM member mapping would corrupt first, so the
match is the substantive check, not a smoke test.

## Limitations

- Producer-side PP only. Decode-side PP keeps its existing refusal.
- CSA-linear PLE caches are refused when SSM members are present.
- Exercised on KimiLinear-shaped pooling (MLA + KDA sharing one region). Other
  hybrids should work by construction but are covered by unit tests only.

## AI assistance

Written with Claude Code. The submitter reviewed every changed line and ran the
unit tests, the A/B, the end-to-end runs and the evaluations above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
