### PR TITLE
[Bugfix] Enable adaptive DSpark verification for GLM-5.2 sparse MLA on SM90

### DIFF
--- a/tests/v1/attention/test_dspark_noncausal_sparse_mla.py
+++ b/tests/v1/attention/test_dspark_noncausal_sparse_mla.py
@@ -56,6 +56,9 @@ if not current_platform.is_cuda():
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backends.mla.flashattn_mla_sparse import (
+    FlashAttnMLASparseBackend,
+)
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseTRTLLMBackend,
 )
@@ -419,16 +422,30 @@ def _skip_if_backend_unavailable(backend_cls, kv_cache_dtype: str, block_size: i
         cap = current_platform.get_device_capability()
         if cap is None or not backend_cls.supports_compute_capability(cap):
             pytest.skip("FlashInferMLASparseTRTLLMBackend requires SM 10.x capability")
+    elif backend_cls is FlashAttnMLASparseBackend:
+        from vllm.v1.attention.backends.fa_utils import flash_attn_supports_mla
+
+        cap = current_platform.get_device_capability()
+        if cap is None or not backend_cls.supports_compute_capability(cap):
+            pytest.skip("FlashAttnMLASparseBackend requires SM 9.x capability")
+        if not flash_attn_supports_mla():
+            pytest.skip("FlashAttention MLA is not available")
 
 
-def test_flashinfer_sparse_mla_adaptive_varlen_matches_sdpa(
+@pytest.mark.parametrize(
+    "backend_cls,kv_cache_dtype",
+    [(FlashInferMLASparseTRTLLMBackend, "fp8"), (FlashAttnMLASparseBackend, "auto")],
+    ids=["SM100-FlashInfer", "SM90-FlashAttention"],
+)
+def test_sparse_mla_adaptive_varlen_matches_sdpa(
     default_vllm_config,
     dist_init,
     workspace_init,
+    backend_cls,
+    kv_cache_dtype,
 ):
-    """Adaptive request boundaries must drive SM100 sparse index conversion."""
-    backend_cls = FlashInferMLASparseTRTLLMBackend
-    _skip_if_backend_unavailable(backend_cls, "fp8", 64)
+    """Adaptive request boundaries must drive sparse index conversion."""
+    _skip_if_backend_unavailable(backend_cls, kv_cache_dtype, 64)
     assert (
         backend_cls.get_builder_cls().get_cudagraph_support(None, None)
         == AttentionCGSupport.ALWAYS
@@ -450,7 +467,7 @@ def test_flashinfer_sparse_mla_adaptive_varlen_matches_sdpa(
         seq_lens,
         query_lens,
         sparse_indices,
-        "fp8",
+        kv_cache_dtype,
         64,
         16,
         device,

--- a/vllm/v1/attention/backends/mla/flashattn_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla_sparse.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import torch
 
@@ -29,6 +29,9 @@ from vllm.v1.attention.backends.mla.sparse_utils import (
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.vllm_flash_attn.flash_attn_interface import flash_attn_varlen_func
+
+if TYPE_CHECKING:
+    from vllm.v1.attention.backend import CommonAttentionMetadata
 
 
 class FlashAttnMLASparseBackend(AttentionBackend):
@@ -132,7 +135,7 @@ class FlashAttnMLASparseMetadataBuilder(
     SparseMLACommonMetadataBuilder[FlashAttnMLASparseMetadata]
 ):
     metadata_cls = FlashAttnMLASparseMetadata
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
 
     def __init__(
         self,
@@ -148,6 +151,12 @@ class FlashAttnMLASparseMetadataBuilder(
         )
         threshold = {16: 128, 32: 128, 64: 256, 128: 256}.get(num_q_heads, 256)
         self._init_reorder_batch_threshold(threshold, supports_spec_as_decode=True)
+
+    def _build_req_id_per_token(
+        self,
+        common_attn_metadata: "CommonAttentionMetadata",
+    ) -> torch.Tensor:
+        return common_attn_metadata.token_to_req_indices(self.req_id_per_token_buffer)
 
 
 class FlashAttnMLASparseImpl(SparseMLACommonImpl[FlashAttnMLASparseMetadata]):


### PR DESCRIPTION
Build the request-per-token mapping from device-side query boundaries so adaptive verification can use per-request draft lengths with FlashAttention sparse MLA. Advertise variable-batch CUDA graph support and cover SM90 with the existing SDPA regression.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

