### PR TITLE
[Frontend] enable engine based parsing for cohere parsers

### DIFF
--- a/requirements/test/cpu.txt
+++ b/requirements/test/cpu.txt
@@ -127,7 +127,7 @@ cloudpickle==3.1.2
     # via -r requirements/test/../common.txt
 cohere==7.0.8
     # via -r requirements/test/cuda.in
-cohere-melody==0.11.1
+cohere-melody==0.14.0
     # via -r requirements/test/cuda.in
 colorama==0.4.6
     # via

--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -70,7 +70,7 @@ gpt-oss >= 0.0.7; python_version > '3.11'
 
 perceptron # required for isaac test
 kaldi-native-fbank >= 1.18.7 # required for fireredasr2 test
-cohere_melody>=0.11.1 # required for cohere command reasoning/tool parser tests
+cohere_melody>=0.14.0 # required for cohere command reasoning/tool parser tests
 cohere>=7.0.0 # required for cohere chat v2 api tests (protocol/serving import cohere.types)
 
 # Newer versions of datasets require torchcoded, that makes the tests fail in CI because of a missing library.

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -132,7 +132,7 @@ cloudpickle==3.1.2
     # via -r requirements/test/../common.txt
 cohere==7.0.8
     # via -r requirements/test/cuda.in
-cohere-melody==0.11.1
+cohere-melody==0.14.0
     # via -r requirements/test/cuda.in
 colorama==0.4.6
     # via

--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -69,7 +69,7 @@ gpt-oss>=0.0.7; python_version > '3.11'
 
 perceptron # required for isaac test
 kaldi-native-fbank>=1.18.7 # required for fireredasr2 test
-cohere_melody>=0.11.1 # required for cohere command reasoning/tool parser tests
+cohere_melody>=0.14.0 # required for cohere command reasoning/tool parser tests
 cohere>=7.0.0 # required for cohere chat v2 api tests (protocol/serving import cohere.types)
 
 # Newer versions of datasets require torchcoded, that makes the tests fail in CI because of a missing library.

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -134,7 +134,7 @@ cloudpickle==3.1.2
     #   tilelang
 cohere==7.0.8
     # via -r requirements/test/rocm.in
-cohere-melody==0.11.1
+cohere-melody==0.14.0
     # via -r requirements/test/rocm.in
 colorama==0.4.6
     # via

--- a/tests/reasoning/test_cohere_command_reasoning_parser.py
+++ b/tests/reasoning/test_cohere_command_reasoning_parser.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import itertools
 import json
 from collections import UserDict
 from dataclasses import dataclass
@@ -10,6 +11,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import regex as re
 from pydantic import ValidationError
 
 from vllm.entrypoints.generate.base.protocol import (
@@ -21,6 +23,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.parser import ParserManager
 from vllm.reasoning.cohere_command_reasoning_parser import (
     CohereCommand3ReasoningParser,
     CohereCommand4ReasoningParser,
@@ -106,21 +109,35 @@ REASONING_CASES = [
 ]
 
 
+_SPECIAL_TOKEN_RE = re.compile(r"(<\|[A-Z_]+\|>)")
+
+
 class MockCohereTokenizer:
     """Minimal byte-level stand-in for the Cohere tokenizer.
 
-    ``encode``/``decode`` round-trip through UTF-8 bytes so splitting a
-    multi-byte character (e.g. an emoji) across "tokens" reproduces the
-    trailing U+FFFD buffering that real streaming exhibits. Cohere special
-    tokens map to distinct synthetic ids; everything else shares a default id.
-    ``adjust_request`` only needs the token ids, not real tokenization.
+    Text round-trips through UTF-8 bytes so splitting a multi-byte character
+    (e.g. an emoji) across "tokens" reproduces the trailing U+FFFD buffering
+    that real streaming exhibits. Cohere special tokens are single ids (>= 256)
+    so token-id based reasoning-end detection works as with the real tokenizer.
     """
 
     _SPECIAL_TOKEN_IDS = {
-        "<|START_THINKING|>": -1,
-        "<|END_THINKING|>": -2,
-        "<|CHATBOT_TOKEN|>": -3,
+        tok: 256 + i
+        for i, tok in enumerate(
+            (
+                "<|START_THINKING|>",
+                "<|END_THINKING|>",
+                "<|CHATBOT_TOKEN|>",
+                "<|START_RESPONSE|>",
+                "<|END_RESPONSE|>",
+                "<|START_TEXT|>",
+                "<|END_TEXT|>",
+                "<|START_ACTION|>",
+                "<|END_ACTION|>",
+            )
+        )
     }
+    _ID_TO_SPECIAL_TOKEN = {v: k for k, v in _SPECIAL_TOKEN_IDS.items()}
 
     def convert_tokens_to_ids(self, token: str) -> int:
         return self._SPECIAL_TOKEN_IDS.get(token, 0)
@@ -129,10 +146,24 @@ class MockCohereTokenizer:
         return {}
 
     def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
-        return list(text.encode("utf-8"))
+        ids: list[int] = []
+        for part in _SPECIAL_TOKEN_RE.split(text):
+            if part in self._SPECIAL_TOKEN_IDS:
+                ids.append(self._SPECIAL_TOKEN_IDS[part])
+            else:
+                ids.extend(part.encode("utf-8"))
+        return ids
 
     def decode(self, ids: list[int], skip_special_tokens: bool = False) -> str:
-        return bytes(ids).decode("utf-8", errors="replace")
+        out: list[str] = []
+        for special, run in itertools.groupby(
+            ids, self._ID_TO_SPECIAL_TOKEN.__contains__
+        ):
+            if not special:
+                out.append(bytes(run).decode("utf-8", errors="replace"))
+            elif not skip_special_tokens:
+                out.extend(self._ID_TO_SPECIAL_TOKEN[i] for i in run)
+        return "".join(out)
 
 
 @pytest.fixture(scope="module")
@@ -148,14 +179,15 @@ def request_obj():
 REPLACEMENT_CHAR = "\ufffd"
 
 
-def _token_deltas(tokenizer, text: str) -> list[str]:
+def _token_deltas(tokenizer, text: str, chunk_size: int = 1) -> list[str]:
     """Progressively decode the token sequence and return per-step string
-    deltas.  Incomplete multi-byte sequences (trailing U+FFFD) are buffered
-    until the next token completes them, matching real streaming behaviour."""
+    deltas of ``chunk_size`` tokens.  Incomplete multi-byte sequences (trailing
+    U+FFFD) are buffered until the next step completes them, matching real
+    streaming behaviour."""
     ids = tokenizer.encode(text, add_special_tokens=False)
     deltas: list[str] = []
     prev = ""
-    for i in range(1, len(ids) + 1):
+    for i in range(chunk_size, len(ids) + chunk_size, chunk_size):
         current = tokenizer.decode(ids[:i], skip_special_tokens=False)
         if current.endswith(REPLACEMENT_CHAR):
             continue
@@ -794,3 +826,60 @@ class TestParserStreamingEndToEnd:
         # boundary and never emits a delta with both fields set.
         for d in deltas:
             assert not (d.reasoning is not None and d.content is not None)
+
+
+class TestDelegatingParserStreaming:
+    @staticmethod
+    def _stream(parser, chunks: list[str], request):
+        results = [
+            parser.parse_delta(
+                chunk,
+                parser.model_tokenizer.encode(chunk),
+                request,
+                finished=i == len(chunks) - 1,
+            )
+            for i, chunk in enumerate(chunks)
+        ]
+        reasoning = "".join(r.reasoning for r in results if r and r.reasoning)
+        content = "".join(r.content for r in results if r and r.content)
+        tool_calls = [tc for r in results if r and r.tool_calls for tc in r.tool_calls]
+        return reasoning, content, tool_calls
+
+    @pytest.mark.parametrize(
+        ("parser_name", "content_tags"),
+        [
+            pytest.param(
+                "cohere_command4", ("<|START_TEXT|>", "<|END_TEXT|>"), id="cmd4"
+            ),
+            pytest.param(
+                "cohere_command3", ("<|START_RESPONSE|>", "<|END_RESPONSE|>"), id="cmd3"
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("chunk_size", [1, 4], ids=["per_token", "batched"])
+    @pytest.mark.parametrize("with_tools", [False, True], ids=["no_tools", "tools"])
+    def test_content_framing_tokens_stripped(
+        self, tokenizer, parser_name, content_tags, chunk_size, with_tools
+    ):
+        parser_cls = ParserManager.get_parser(
+            parser_name, parser_name, enable_auto_tools=True
+        )
+        parser = parser_cls(tokenizer)
+        tools = [{"type": "function", "function": {"name": "foo"}}]
+        request = ChatCompletionRequest(
+            messages=[], model="test-model", tools=tools if with_tools else None
+        )
+        parser.adjust_request(request)
+
+        start_tag, end_tag = content_tags
+        generation = (
+            f"<|START_THINKING|>Think deeply. The user greets us.<|END_THINKING|>"
+            f"{start_tag}I'm doing well, thank you{end_tag}"
+        )
+        chunks = _token_deltas(tokenizer, generation, chunk_size)
+
+        reasoning, content, tool_calls = self._stream(parser, chunks, request)
+
+        assert reasoning == "Think deeply. The user greets us."
+        assert tool_calls == []
+        assert content == "I'm doing well, thank you"

--- a/vllm/reasoning/cohere_command_reasoning_parser.py
+++ b/vllm/reasoning/cohere_command_reasoning_parser.py
@@ -11,12 +11,12 @@ import regex as re
 import xgrammar as xgr
 
 try:
-    from cohere_melody import PyFilter, PyFilterOptions
+    from cohere_melody import FilterAggregatedResult, PyFilter, PyFilterOptions
 except ImportError as e:
     raise ImportError(
         "The Cohere reasoning parser requires the `cohere_melody` "
         "package, which is not installed. Install it with:\n"
-        "    pip install 'cohere-melody>=0.11.1'"
+        "    pip install 'cohere-melody>=0.14.0'"
     ) from e
 
 
@@ -487,6 +487,8 @@ def _melody_citations_to_vllm(
 
 
 class BaseCohereCommandReasoningParser(ReasoningParser):
+    engine_based_streaming = True
+
     def __init__(
         self,
         tokenizer: TokenizerLike,
@@ -546,7 +548,15 @@ class BaseCohereCommandReasoningParser(ReasoningParser):
         current_token_ids: Sequence[int],
         delta_token_ids: Sequence[int],
     ) -> DeltaMessage | None:
-        r = self.melody_streaming.write_decoded(delta_text)
+        return self._to_delta(self.melody_streaming.write_decoded(delta_text))
+
+    def has_engine_confirmed_reasoning_end(self) -> bool:
+        return not self.melody_streaming.is_reasoning()
+
+    def finish_streaming(self) -> DeltaMessage | None:
+        return self._to_delta(self.melody_streaming.flush_partials())
+
+    def _to_delta(self, r: FilterAggregatedResult) -> CohereDeltaMessage | None:
         citations = _melody_citations_to_vllm(
             getattr(r, "citations", None), self._position_to_source
         )

--- a/vllm/tool_parsers/cohere_command_tool_parser.py
+++ b/vllm/tool_parsers/cohere_command_tool_parser.py
@@ -4,12 +4,12 @@
 from collections.abc import Sequence
 
 try:
-    from cohere_melody import PyFilter, PyFilterOptions
+    from cohere_melody import FilterAggregatedResult, PyFilter, PyFilterOptions
 except ImportError as e:
     raise ImportError(
         "The Cohere tool parser requires the `cohere_melody` "
         "package, which is not installed. Install it with:\n"
-        "    pip install 'cohere-melody>=0.11.1'"
+        "    pip install 'cohere-melody>=0.14.0'"
     ) from e
 
 from vllm.entrypoints.generate.base.protocol import (
@@ -32,6 +32,8 @@ from vllm.tool_parsers.utils import Tool
 
 
 class BaseCohereCommandToolParser(ToolParser):
+    engine_based_streaming = True
+
     def __init__(
         self,
         tokenizer: TokenizerLike,
@@ -62,7 +64,12 @@ class BaseCohereCommandToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        r = self.melody_streaming.write_decoded(delta_text)
+        return self._to_delta(self.melody_streaming.write_decoded(delta_text))
+
+    def finish_streaming(self) -> DeltaMessage | None:
+        return self._to_delta(self.melody_streaming.flush_partials())
+
+    def _to_delta(self, r: FilterAggregatedResult) -> DeltaMessage | None:
         if r.content is not None:
             return DeltaMessage(content=r.content)
         if r.reasoning is not None:


### PR DESCRIPTION
## Purpose

Update the Cohere Command Reasoning & Tool parser to use `engine_based_streaming = True` since they are powered by melody which is a stateful parsing library. This helps resolve a bug where the special answer tokens (`<|START_TEXT|>` / `<|END_TEXT|>`) are not correctly extracted when tool choice is None

## Test Plan

```
vllm serve CohereLabs/command-a-plus-05-2026-w4a4 --enable-auto-tool-choice --tool-call-parser=cohere_command4 --reasoning-parser=cohere_command4 --max-model-len=128000

...

curl -sN http://localhost:8000/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{
      "stream": true,
      "messages": [{"role": "user", "content": "Hello, how are you?"}]
    }' | grep "<|START_TEXT|>"
```

## Test Result

After these changes the special tokens are correctly parsed out

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

