### PR TITLE
[ROCm][Bugfix] Fix profiler in TheRock image

### DIFF
--- a/docker/Dockerfile.rock_base
+++ b/docker/Dockerfile.rock_base
@@ -327,10 +327,6 @@ RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
 
 FROM base AS final
 
-# torch 2.12 implicitly attaches rocprofiler-sdk; its queue interposition hangs at HSA
-# teardown, so disable it. TODO: drop once ROCm's stock rocprofiler carries the fix.
-ENV ROCPROFILER_QUEUE_INTERPOSITION=0
-
 COPY --from=build_rocm_runtime /staging/lib/ ${SDK_DEV}/lib/
 # Hard link the patched library onto every stock file name, in both SDK trees, so that the
 # SONAME lookup and the hard coded paths all resolve to it. Hard links rather than symlinks

--- a/docker/Dockerfile.rock_base
+++ b/docker/Dockerfile.rock_base
@@ -327,6 +327,10 @@ RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
 
 FROM base AS final
 
+# torch 2.12 implicitly attaches rocprofiler-sdk; its queue interposition hangs at HSA
+# teardown, so disable it. TODO: drop once ROCm's stock rocprofiler carries the fix.
+ENV ROCPROFILER_QUEUE_INTERPOSITION=0
+
 COPY --from=build_rocm_runtime /staging/lib/ ${SDK_DEV}/lib/
 # Hard link the patched library onto every stock file name, in both SDK trees, so that the
 # SONAME lookup and the hard coded paths all resolve to it. Hard links rather than symlinks

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -138,7 +138,7 @@ def _maybe_promote_torch_symbols_for_rocm():
             )
             if not deps:
                 return
-            ctypes.CDLL(deps[0], mode=ctypes.RTLD_GLOBAL)
+            ctypes.CDLL(deps[0], mode=ctypes.RTLD_LOCAL)
             ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
     except Exception:
         return

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -5,21 +5,28 @@ import importlib.util
 import os
 
 
-def _get_torch_cuda_version():
-    """Peripheral function to _maybe_set_cuda_compatibility_path().
+def _get_torch_root():
+    """Locate the installed torch package without importing it."""
+    spec = importlib.util.find_spec("torch")
+    if not spec:
+        return None
+    if spec.origin:
+        return os.path.dirname(spec.origin)
+    if spec.submodule_search_locations:
+        return spec.submodule_search_locations[0]
+    return None
+
+
+def _get_torch_version_attr(attr):
+    """Read an attribute of torch.version without importing torch.
+
     PyTorch version must not be determined by importing directly
     because it will trigger the CUDA initialization, losing the
     chance to set the LD_LIBRARY_PATH beforehand.
     """
     try:
-        spec = importlib.util.find_spec("torch")
-        if not spec:
-            return None
-        if spec.origin:
-            torch_root = os.path.dirname(spec.origin)
-        elif spec.submodule_search_locations:
-            torch_root = spec.submodule_search_locations[0]
-        else:
+        torch_root = _get_torch_root()
+        if not torch_root:
             return None
         version_path = os.path.join(torch_root, "version.py")
         if not os.path.exists(version_path):
@@ -31,9 +38,14 @@ def _get_torch_cuda_version():
         module = importlib.util.module_from_spec(ver_spec)
         # Avoid registering in sys.modules to not confuse future imports
         ver_spec.loader.exec_module(module)
-        return getattr(module, "cuda", None)
+        return getattr(module, attr, None)
     except Exception:
         return None
+
+
+def _get_torch_cuda_version():
+    """Peripheral function to _maybe_set_cuda_compatibility_path()."""
+    return _get_torch_version_attr("cuda")
 
 
 def _maybe_set_cuda_compatibility_path():
@@ -82,7 +94,58 @@ def _maybe_set_cuda_compatibility_path():
     os.environ["LD_LIBRARY_PATH"] = os.pathsep.join(new_paths)
 
 
+def _maybe_promote_torch_symbols_for_rocm():
+    """Put libtorch_cpu.so in the global symbol scope on ROCm, for GPU profiling.
+
+    Must run before 'import torch'. libkineto advertises itself to
+    rocprofiler-sdk by exporting rocprofiler_configure from libtorch_cpu.so,
+    and rocprofiler-sdk looks for that symbol exactly once, from a lazy
+    initializer that runs *during* 'import torch'. CPython loads extension
+    modules RTLD_LOCAL, so unless something has already placed the symbol in
+    the global scope the lookup misses and no client is ever registered.
+
+    The failure is silent and total: no queue interception, so roctracer
+    yields no GPU records, while torch.profiler still writes a complete
+    CPU-only trace and reports success.
+
+    Best effort. If the library cannot be loaded early we leave the process
+    exactly as it would have been, losing only GPU tracing.
+    """
+    if _get_torch_version_attr("hip") is None:
+        return
+    try:
+        import ctypes
+        import glob
+
+        torch_root = _get_torch_root()
+        if not torch_root:
+            return
+        lib = os.path.join(torch_root, "lib", "libtorch_cpu.so")
+        if not os.path.exists(lib):
+            return
+        try:
+            ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
+        except OSError:
+            # Some ROCm wheel layouts leave a stale RUNPATH in libtorch_cpu.so,
+            # so a dependency that resolves once torch has set things up does
+            # not resolve for a standalone load. Satisfy it by search, then
+            # retry; give up quietly if it is not where we expect.
+            site_root = os.path.dirname(torch_root)
+            deps = glob.glob(
+                os.path.join(
+                    site_root, "_rocm_sdk_*", "lib", "*", "lib", "librocm-openblas.so.*"
+                )
+            )
+            if not deps:
+                return
+            ctypes.CDLL(deps[0], mode=ctypes.RTLD_GLOBAL)
+            ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
+    except Exception:
+        return
+
+
 _maybe_set_cuda_compatibility_path()
+_maybe_promote_torch_symbols_for_rocm()
 
 import torch
 


### PR DESCRIPTION


## Purpose
vLLM's profiling doesn't work reliably in the ROCm 10 image because of subtleties during `import torch` in how TheRock's `rocm_sdk` wheel preloads the ROCm library and how `rocprofiler`'s `find_clients` operates (it's a one-shot `static`). It was observed that some models (e.g. DeepSeek V4) generated no GPU work in traces. This PR works around the issue by trying to preload `libtorch_cpu.so` (which exports `rocprofiler_configure`) as `RTLD_GLOBAL` on ROCm.

## Test Plan
Full AMD CI was run at https://buildkite.com/vllm/amd-ci/builds/12793

## Test Result
There were no new regressions.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

