### PR TITLE
[Proposal] Simplify noncompiled cudagraph fallback

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -500,51 +500,63 @@ def test_resolve_cudagraph_mode_adjusts_spec_decode_sizes_only_for_v1(
 
 
 @pytest.mark.parametrize(
-    ("mode", "piecewise_capture_available", "expected"),
+    ("mode", "piecewise_capture_available", "attention_support", "expected"),
     [
-        (CUDAGraphMode.PIECEWISE, False, CUDAGraphMode.NONE),
-        (
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            False,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-        ),
-        (CUDAGraphMode.FULL_DECODE_ONLY, False, CUDAGraphMode.FULL_DECODE_ONLY),
-        (
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            True,
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-        ),
+        ("PIECEWISE", False, "ALWAYS", "NONE"),
+        ("FULL_AND_PIECEWISE", False, "ALWAYS", "FULL_DECODE_ONLY"),
+        ("FULL_DECODE_ONLY", False, "ALWAYS", "FULL_DECODE_ONLY"),
+        ("FULL_DECODE_ONLY", False, "NEVER", "NONE"),
     ],
 )
 def test_resolve_cudagraph_mode_uses_loaded_piecewise_provider(
-    mode, piecewise_capture_available, expected
+    mode, piecewise_capture_available, attention_support, expected
 ):
-    compilation_config = CompilationConfig(cudagraph_mode=mode)
-
-    resolved = compilation_config.resolve_cudagraph_mode_and_sizes(
-        AttentionCGSupport.ALWAYS,
-        "FakeAttentionBackend",
-        piecewise_capture_available=piecewise_capture_available,
-    )
-
-    assert resolved == expected
-    assert compilation_config.cudagraph_mode == expected
-
-
-def test_resolve_cudagraph_mode_normalizes_attention_fallback():
     compilation_config = CompilationConfig(
         mode=CompilationMode.VLLM_COMPILE,
-        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+        cudagraph_mode=CUDAGraphMode[mode],
         use_inductor_graph_partition=True,
     )
 
     resolved = compilation_config.resolve_cudagraph_mode_and_sizes(
-        AttentionCGSupport.NEVER,
+        AttentionCGSupport[attention_support],
         "FakeAttentionBackend",
-        piecewise_capture_available=False,
+        piecewise_capture_available=piecewise_capture_available,
     )
 
-    assert resolved == CUDAGraphMode.NONE
+    assert resolved.name == expected
+    assert compilation_config.cudagraph_mode == resolved
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="Requires CUDA graph support"
+)
+@pytest.mark.parametrize(
+    "engine_kwargs",
+    [
+        {"runner": "pooling", "convert": "embed"},
+        pytest.param(
+            {"prefill_context_parallel_size": 2, "tensor_parallel_size": 2},
+            marks=pytest.mark.skipif(
+                not current_platform.is_rocm(), reason="ROCm PCP graph restriction"
+            ),
+        ),
+    ],
+)
+def test_late_piecewise_restrictions_without_compilation(monkeypatch, engine_kwargs):
+    """Late compatibility overrides must not restore unavailable piecewise graphs."""
+    from vllm.engine.arg_utils import EngineArgs
+
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    config = EngineArgs(
+        model="facebook/opt-125m",
+        compilation_config=CompilationConfig(mode=CompilationMode.NONE),
+        **engine_kwargs,
+    ).create_engine_config()
+
+    assert config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+    assert config.compilation_config.cudagraph_capture_sizes == []
+    assert config.compilation_config.max_cudagraph_capture_size == 0
 
 
 def test_resolve_cudagraph_mode_skips_mamba_block_check_while_profiling():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,7 +239,8 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
 
 
 def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
-    """ROCm keeps the DSA models on MRV1 and off breakable graphs by default."""
+    """ROCm keeps the DSA models (DeepSeek V3.2/V4, GLM-5.2) on their compiled
+    MRV1 paths and off breakable cudagraphs by default."""
     from vllm.config.vllm import (
         ROCM_DEFAULT_MRV1_ARCHITECTURES,
         default_breakable_cudagraph_architectures,
@@ -268,6 +269,44 @@ def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
         assert VllmConfig.use_v2_model_runner.fget(config) is False
     finally:
         default_breakable_cudagraph_architectures.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("architecture", "use_v2", "mode", "expected"),
+    [
+        ("DeepseekV4ForCausalLM", True, None, CUDAGraphMode.NONE),
+        ("DeepseekV4ForConditionalGeneration", True, None, CUDAGraphMode.NONE),
+        ("DeepseekV4ForCausalLM", False, None, None),
+        ("LlamaForCausalLM", True, None, None),
+        (
+            "DeepseekV4ForCausalLM",
+            True,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+    ],
+)
+def test_rocm_gfx950_deepseek_v4_cudagraph_default(
+    monkeypatch, architecture, use_v2, mode, expected
+):
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.platforms import rocm
+
+    monkeypatch.setattr(rocm, "on_gfx950", lambda: True)
+    monkeypatch.setattr(rocm_aiter_ops, "is_fused_moe_enabled", lambda: False)
+    monkeypatch.setattr(rocm_aiter_ops, "is_linear_fp8_enabled", lambda: False)
+    monkeypatch.setattr(
+        rocm_aiter_ops, "is_fusion_moe_shared_experts_enabled", lambda: False
+    )
+    config = SimpleNamespace(
+        compilation_config=CompilationConfig(cudagraph_mode=mode),
+        model_config=SimpleNamespace(architecture=architecture),
+        use_v2_model_runner=use_v2,
+    )
+
+    rocm.RocmPlatform.apply_config_platform_defaults(config)
+
+    assert config.compilation_config.cudagraph_mode == expected
 
 
 @pytest.mark.parametrize(
@@ -328,63 +367,6 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
         default_breakable_cudagraph_architectures.cache_clear()
 
 
-class _CudagraphConfigStub(SimpleNamespace):
-    _uses_breakable_cudagraph_by_default = (
-        VllmConfig._uses_breakable_cudagraph_by_default
-    )
-    _uses_noncompiled_cudagraph_path = VllmConfig._uses_noncompiled_cudagraph_path
-    _piecewise_cudagraph_provider_available = (
-        VllmConfig._piecewise_cudagraph_provider_available
-    )
-
-
-@pytest.fixture
-def make_cudagraph_config(monkeypatch):
-    from vllm.config.vllm import default_breakable_cudagraph_architectures
-
-    def make(
-        architecture="DeepseekV4ForConditionalGeneration",
-        *,
-        rocm=True,
-        gfx950=False,
-        breakable=False,
-        optimization_level=OptimizationLevel.O2,
-        compilation_mode=None,
-        cudagraph_mode=None,
-        use_v2=True,
-        compilation_config=None,
-    ):
-        if breakable is None:
-            monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
-        else:
-            monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", str(int(breakable)))
-        monkeypatch.setattr(current_platform, "is_cuda", lambda: not rocm)
-        monkeypatch.setattr(current_platform, "is_rocm", lambda: rocm)
-        monkeypatch.setattr(
-            current_platform,
-            "is_device_capability",
-            lambda value: gfx950 and value == 95,
-        )
-        default_breakable_cudagraph_architectures.cache_clear()
-        resolved_compilation_config = (
-            compilation_config
-            if compilation_config is not None
-            else CompilationConfig(mode=compilation_mode, cudagraph_mode=cudagraph_mode)
-        )
-        return _CudagraphConfigStub(
-            model_config=SimpleNamespace(
-                architecture=architecture, architectures=[architecture]
-            ),
-            compilation_config=resolved_compilation_config,
-            optimization_level=optimization_level,
-            use_v2_model_runner=use_v2,
-        )
-
-    yield make
-    os.environ.pop("VLLM_USE_BREAKABLE_CUDAGRAPH", None)
-    default_breakable_cudagraph_architectures.cache_clear()
-
-
 @pytest.mark.parametrize(
     ("architecture", "is_rocm", "expected"),
     [
@@ -392,8 +374,6 @@ def make_cudagraph_config(monkeypatch):
         ("DeepseekV32ForCausalLM", True, False),
         ("DeepseekV32MTPModel", False, True),
         ("DeepseekV32MTPModel", True, False),
-        ("DeepseekV4ForCausalLM", False, True),
-        ("DeepseekV4ForCausalLM", True, False),
         ("GlmMoeDsaForCausalLM", False, True),
         ("GlmMoeDsaForCausalLM", True, False),
         ("Qwen4ExpForCausalLM", False, True),
@@ -405,378 +385,29 @@ def make_cudagraph_config(monkeypatch):
     ],
 )
 def test_breakable_cudagraph_platform_default(
-    make_cudagraph_config, architecture, is_rocm, expected
+    monkeypatch, architecture, is_rocm, expected
 ):
-    config = make_cudagraph_config(
-        architecture,
-        rocm=is_rocm,
-        breakable=None,
-        use_v2=not is_rocm,
+    from vllm.config.vllm import default_breakable_cudagraph_architectures
+    from vllm.platforms import current_platform
+
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: is_rocm)
+    default_breakable_cudagraph_architectures.cache_clear()
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(architectures=[architecture]),
+        compilation_config=CompilationConfig(),
+    )
+    config._uses_breakable_cudagraph_by_default = lambda: (
+        VllmConfig._uses_breakable_cudagraph_by_default(config)
     )
 
-    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is expected
-    if expected:
-        assert config.compilation_config.mode == CompilationMode.NONE
-    else:
-        assert config.compilation_config.mode is None
-        assert config.compilation_config.cudagraph_mode is None
-
-
-@pytest.mark.parametrize(
-    "architecture",
-    sorted(vllm_config_module.NON_COMPILED_CUDAGRAPH_FALLBACK_ARCHITECTURES),
-)
-def test_noncompiled_architectures_fall_back_when_breakable_disabled(
-    make_cudagraph_config, architecture
-):
-    config = make_cudagraph_config(architecture, rocm=False)
-
-    assert not VllmConfig._maybe_enable_breakable_cudagraph(config)
-    assert config.compilation_config.mode is None
-    assert config.compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
-
-
-@pytest.mark.parametrize(
-    ("optimization_level", "expected_cudagraph_mode"),
-    [
-        (OptimizationLevel.O0, CUDAGraphMode.NONE),
-        (OptimizationLevel.O1, CUDAGraphMode.NONE),
-        (OptimizationLevel.O2, CUDAGraphMode.FULL_DECODE_ONLY),
-        (OptimizationLevel.O3, CUDAGraphMode.FULL_DECODE_ONLY),
-    ],
-)
-def test_noncompiled_cudagraph_fallback_respects_optimization_level(
-    make_cudagraph_config, optimization_level, expected_cudagraph_mode
-):
-    config = make_cudagraph_config(
-        optimization_level=optimization_level,
-    )
-
-    assert not VllmConfig._maybe_enable_breakable_cudagraph(config)
-    assert config.compilation_config.mode is None
-    assert config.compilation_config.cudagraph_mode == expected_cudagraph_mode
-
-
-@pytest.mark.parametrize(
-    ("architecture", "expected_cudagraph_mode"),
-    [
-        ("DeepseekV4ForCausalLM", CUDAGraphMode.FULL_DECODE_ONLY),
-        ("DeepseekV32MTPModel", None),
-        ("DeepseekV32ForCausalLM", None),
-        ("GlmMoeDsaForCausalLM", None),
-    ],
-)
-def test_rocm_forced_v2_only_falls_back_for_noncompiled_dsa_model(
-    make_cudagraph_config, architecture, expected_cudagraph_mode
-):
-    config = make_cudagraph_config(architecture)
-
-    assert not VllmConfig._maybe_enable_breakable_cudagraph(config)
-    assert config.compilation_config.mode is None
-    assert config.compilation_config.cudagraph_mode == expected_cudagraph_mode
-
-
-@pytest.mark.parametrize(
-    ("architecture", "use_v2", "input_mode", "expected_compile", "expected_graph"),
-    [
-        ("DeepseekV4ForCausalLM", True, None, None, CUDAGraphMode.NONE),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            True,
-            None,
-            None,
-            CUDAGraphMode.NONE,
-        ),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            True,
-            CUDAGraphMode.FULL,
-            None,
-            CUDAGraphMode.FULL,
-        ),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            True,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-            None,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-        ),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            True,
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            None,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-        ),
-        (
-            "KimiK3ForConditionalGeneration",
-            True,
-            None,
-            None,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-        ),
-    ],
-)
-def test_rocm_gfx950_noncompiled_cudagraph_policy(
-    make_cudagraph_config,
-    architecture,
-    use_v2,
-    input_mode,
-    expected_compile,
-    expected_graph,
-):
-    config = make_cudagraph_config(
-        architecture, gfx950=True, cudagraph_mode=input_mode, use_v2=use_v2
-    )
-
-    breakable_enabled = VllmConfig._maybe_enable_breakable_cudagraph(config)
-    VllmConfig._normalize_unavailable_piecewise_cudagraphs(
-        config, breakable_cudagraph_enabled=breakable_enabled
-    )
-
-    assert not breakable_enabled
-    assert config.compilation_config.mode == expected_compile
-    assert config.compilation_config.cudagraph_mode == expected_graph
-
-
-@pytest.mark.parametrize(
-    ("compile_mode", "graph_mode", "expected_graph", "should_raise"),
-    [
-        (None, CUDAGraphMode.NONE, CUDAGraphMode.NONE, False),
-        (None, CUDAGraphMode.PIECEWISE, CUDAGraphMode.NONE, False),
-        (None, CUDAGraphMode.FULL, CUDAGraphMode.FULL, False),
-        (None, CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.FULL_DECODE_ONLY, False),
-        (
-            None,
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-            False,
-        ),
-        (
-            CompilationMode.VLLM_COMPILE,
-            None,
-            None,
-            True,
-        ),
-        pytest.param(
-            CompilationMode.VLLM_COMPILE,
-            CUDAGraphMode.NONE,
-            CUDAGraphMode.NONE,
-            False,
-            id="ngram-gpu-auxiliary-config",
-        ),
-        (
-            CompilationMode.VLLM_COMPILE,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-            False,
-        ),
-        (CompilationMode.VLLM_COMPILE, CUDAGraphMode.PIECEWISE, None, True),
-        (
-            CompilationMode.VLLM_COMPILE,
-            CUDAGraphMode.FULL,
-            CUDAGraphMode.FULL,
-            False,
-        ),
-        (
-            CompilationMode.VLLM_COMPILE,
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            None,
-            True,
-        ),
-    ],
-)
-def test_noncompiled_cudagraph_fallback_validates_explicit_modes(
-    make_cudagraph_config,
-    compile_mode,
-    graph_mode,
-    expected_graph,
-    should_raise,
-):
-    config = make_cudagraph_config(
-        compilation_mode=compile_mode, cudagraph_mode=graph_mode
-    )
-    if should_raise:
-        with pytest.raises(ValueError, match="unavailable piecewise capture"):
-            VllmConfig._maybe_enable_breakable_cudagraph(config)
-        return
-
-    breakable_enabled = VllmConfig._maybe_enable_breakable_cudagraph(config)
-    VllmConfig._normalize_unavailable_piecewise_cudagraphs(
-        config, breakable_cudagraph_enabled=breakable_enabled
-    )
-
-    assert not breakable_enabled
-    assert config.compilation_config.mode == compile_mode
-    assert config.compilation_config.cudagraph_mode == expected_graph
-
-
-@pytest.mark.parametrize(
-    "architecture",
-    ["Qwen4ExpForCausalLM", "Qwen4ExpForConditionalGeneration", "Qwen4ExpMTP"],
-)
-@pytest.mark.parametrize("use_v2", [False, True])
-@pytest.mark.parametrize(
-    "graph_mode", [CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE]
-)
-def test_rocm_qwen_preserves_compiled_piecewise_cudagraphs(
-    make_cudagraph_config, architecture, use_v2, graph_mode
-):
-    config = make_cudagraph_config(
-        architecture,
-        use_v2=use_v2,
-        compilation_mode=CompilationMode.VLLM_COMPILE,
-        cudagraph_mode=graph_mode,
-    )
-
-    breakable_enabled = VllmConfig._maybe_enable_breakable_cudagraph(config)
-    assert not breakable_enabled
-    assert config._piecewise_cudagraph_provider_available(
-        breakable_cudagraph_enabled=breakable_enabled
-    )
-    VllmConfig._normalize_unavailable_piecewise_cudagraphs(
-        config, breakable_cudagraph_enabled=breakable_enabled
-    )
-
-    assert config.compilation_config.mode == CompilationMode.VLLM_COMPILE
-    assert config.compilation_config.cudagraph_mode == graph_mode
-
-
-@pytest.mark.parametrize(
-    ("architecture", "breakable", "expected_enabled", "expected_compile"),
-    [
-        ("LlamaForCausalLM", False, False, None),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            True,
-            True,
-            CompilationMode.NONE,
-        ),
-    ],
-)
-def test_noncompiled_cudagraph_fallback_controls(
-    make_cudagraph_config,
-    architecture,
-    breakable,
-    expected_enabled,
-    expected_compile,
-):
-    config = make_cudagraph_config(architecture, breakable=breakable)
-
-    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is expected_enabled
-    assert config.compilation_config.mode == expected_compile
-    assert config.compilation_config.cudagraph_mode is None
-
-
-@pytest.mark.parametrize(
-    (
-        "architecture",
-        "compile_mode",
-        "graph_mode",
-        "breakable",
-        "expected_graph",
-        "expected_sizes",
-    ),
-    [
-        (
-            "DeepseekV4ForConditionalGeneration",
-            CompilationMode.NONE,
-            CUDAGraphMode.NONE,
-            False,
-            CUDAGraphMode.NONE,
-            [],
-        ),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            CompilationMode.NONE,
-            CUDAGraphMode.PIECEWISE,
-            False,
-            CUDAGraphMode.NONE,
-            [],
-        ),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            CompilationMode.NONE,
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            False,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-            [1, 2, 4],
-        ),
-        (
-            "DeepseekV4ForConditionalGeneration",
-            CompilationMode.NONE,
-            CUDAGraphMode.PIECEWISE,
-            True,
-            CUDAGraphMode.PIECEWISE,
-            [1, 2, 4],
-        ),
-        (
-            "LlamaForCausalLM",
-            CompilationMode.VLLM_COMPILE,
-            CUDAGraphMode.PIECEWISE,
-            False,
-            CUDAGraphMode.PIECEWISE,
-            [1, 2, 4],
-        ),
-    ],
-)
-def test_late_piecewise_override_is_normalized_by_available_provider(
-    make_cudagraph_config,
-    architecture,
-    compile_mode,
-    graph_mode,
-    breakable,
-    expected_graph,
-    expected_sizes,
-):
-    compilation_config = CompilationConfig(
-        mode=compile_mode,
-        cudagraph_mode=graph_mode,
-        cudagraph_capture_sizes=[1, 2, 4],
-        max_cudagraph_capture_size=4,
-    )
-    config = make_cudagraph_config(
-        architecture,
-        breakable=breakable,
-        compilation_config=compilation_config,
-    )
-
-    VllmConfig._normalize_unavailable_piecewise_cudagraphs(
-        config, breakable_cudagraph_enabled=breakable
-    )
-
-    assert compilation_config.cudagraph_mode == expected_graph
-    assert compilation_config.cudagraph_capture_sizes == expected_sizes
-    expected_max_size = 0 if expected_graph == CUDAGraphMode.NONE else 4
-    assert compilation_config.max_cudagraph_capture_size == expected_max_size
-
-
-@pytest.mark.parametrize(
-    ("mode", "graph_mode", "should_raise"),
-    [
-        (CompilationMode.NONE, CUDAGraphMode.FULL_DECODE_ONLY, False),
-        (CompilationMode.VLLM_COMPILE, CUDAGraphMode.FULL_AND_PIECEWISE, False),
-        (CompilationMode.NONE, CUDAGraphMode.NONE, True),
-        (CompilationMode.VLLM_COMPILE, CUDAGraphMode.PIECEWISE, True),
-    ],
-)
-def test_adaptive_verification_requires_full_cudagraphs(
-    make_cudagraph_config, mode, graph_mode, should_raise
-):
-    config = make_cudagraph_config(
-        compilation_mode=mode,
-        cudagraph_mode=graph_mode,
-    )
-    config.speculative_config = SimpleNamespace(enable_adaptive_verification=True)
-    config.lora_config = None
-    config.parallel_config = SimpleNamespace(pipeline_parallel_size=1)
-
-    validate = lambda: VllmConfig._validate_adaptive_verification(config)
-    if should_raise:
-        with pytest.raises(ValueError, match="requires full CUDA graphs"):
-            validate()
-    else:
-        validate()
+    try:
+        assert VllmConfig._maybe_enable_breakable_cudagraph(config) is expected
+        if expected:
+            assert config.compilation_config.mode == CompilationMode.NONE
+    finally:
+        os.environ.pop("VLLM_USE_BREAKABLE_CUDAGRAPH", None)
+        default_breakable_cudagraph_architectures.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -868,6 +499,54 @@ def test_resolve_cudagraph_mode_adjusts_spec_decode_sizes_only_for_v1(
     assert compilation_config.cudagraph_capture_sizes == expected_capture_sizes
 
 
+@pytest.mark.parametrize(
+    ("mode", "piecewise_capture_available", "expected"),
+    [
+        (CUDAGraphMode.PIECEWISE, False, CUDAGraphMode.NONE),
+        (
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            False,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+        (CUDAGraphMode.FULL_DECODE_ONLY, False, CUDAGraphMode.FULL_DECODE_ONLY),
+        (
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            True,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+    ],
+)
+def test_resolve_cudagraph_mode_uses_loaded_piecewise_provider(
+    mode, piecewise_capture_available, expected
+):
+    compilation_config = CompilationConfig(cudagraph_mode=mode)
+
+    resolved = compilation_config.resolve_cudagraph_mode_and_sizes(
+        AttentionCGSupport.ALWAYS,
+        "FakeAttentionBackend",
+        piecewise_capture_available=piecewise_capture_available,
+    )
+
+    assert resolved == expected
+    assert compilation_config.cudagraph_mode == expected
+
+
+def test_resolve_cudagraph_mode_normalizes_attention_fallback():
+    compilation_config = CompilationConfig(
+        mode=CompilationMode.VLLM_COMPILE,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+        use_inductor_graph_partition=True,
+    )
+
+    resolved = compilation_config.resolve_cudagraph_mode_and_sizes(
+        AttentionCGSupport.NEVER,
+        "FakeAttentionBackend",
+        piecewise_capture_available=False,
+    )
+
+    assert resolved == CUDAGraphMode.NONE
+
+
 def test_resolve_cudagraph_mode_skips_mamba_block_check_while_profiling():
     """Cudagraph memory profiling uses a minimal KV cache, so the Mamba
     block-count guard must only fire for the real cache sizing."""
@@ -901,6 +580,30 @@ def test_resolve_cudagraph_mode_skips_mamba_block_check_while_profiling():
         is_profiling=True,
     )
     assert cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+
+
+@pytest.mark.parametrize(
+    ("graph_mode", "should_raise"),
+    [
+        (CUDAGraphMode.FULL_DECODE_ONLY, False),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, False),
+        (CUDAGraphMode.NONE, True),
+        (CUDAGraphMode.PIECEWISE, True),
+    ],
+)
+def test_adaptive_verification_requires_full_cudagraphs(graph_mode, should_raise):
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(enable_adaptive_verification=True),
+        lora_config=None,
+        compilation_config=CompilationConfig(cudagraph_mode=graph_mode),
+        parallel_config=SimpleNamespace(pipeline_parallel_size=1),
+    )
+
+    if should_raise:
+        with pytest.raises(ValueError, match="requires full CUDA graphs"):
+            VllmConfig._validate_adaptive_verification(config)
+    else:
+        VllmConfig._validate_adaptive_verification(config)
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/spec_decode/test_adaptive_verification.py
+++ b/tests/v1/spec_decode/test_adaptive_verification.py
@@ -41,28 +41,19 @@ def make_manager(
 @pytest.mark.parametrize(
     ("mode", "piecewise_capture_available", "expected"),
     [
-        (CUDAGraphMode.FULL_DECODE_ONLY, True, CUDAGraphMode.FULL_DECODE_ONLY),
-        (CUDAGraphMode.FULL_DECODE_ONLY, False, CUDAGraphMode.FULL_DECODE_ONLY),
-        (CUDAGraphMode.FULL, True, CUDAGraphMode.FULL_AND_PIECEWISE),
-        (CUDAGraphMode.FULL, False, CUDAGraphMode.FULL_DECODE_ONLY),
-        (
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            True,
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-        ),
-        (
-            CUDAGraphMode.FULL_AND_PIECEWISE,
-            False,
-            CUDAGraphMode.FULL_DECODE_ONLY,
-        ),
+        ("FULL_DECODE_ONLY", True, "FULL_DECODE_ONLY"),
+        ("FULL", True, "FULL_AND_PIECEWISE"),
+        ("FULL", False, "FULL_DECODE_ONLY"),
+        ("FULL_AND_PIECEWISE", True, "FULL_AND_PIECEWISE"),
+        ("FULL_AND_PIECEWISE", False, "FULL_DECODE_ONLY"),
     ],
 )
 def test_resolve_adaptive_cudagraph_mode(mode, piecewise_capture_available, expected):
     assert (
         resolve_adaptive_cudagraph_mode(
-            mode, piecewise_capture_available=piecewise_capture_available
+            CUDAGraphMode[mode], piecewise_capture_available=piecewise_capture_available
         )
-        == expected
+        == CUDAGraphMode[expected]
     )
 
 

--- a/tests/v1/spec_decode/test_adaptive_verification.py
+++ b/tests/v1/spec_decode/test_adaptive_verification.py
@@ -45,7 +45,16 @@ def make_manager(
         (CUDAGraphMode.FULL_DECODE_ONLY, False, CUDAGraphMode.FULL_DECODE_ONLY),
         (CUDAGraphMode.FULL, True, CUDAGraphMode.FULL_AND_PIECEWISE),
         (CUDAGraphMode.FULL, False, CUDAGraphMode.FULL_DECODE_ONLY),
-        (CUDAGraphMode.FULL_AND_PIECEWISE, False, CUDAGraphMode.FULL_DECODE_ONLY),
+        (
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            True,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        (
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            False,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
     ],
 )
 def test_resolve_adaptive_cudagraph_mode(mode, piecewise_capture_available, expected):

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -77,6 +77,13 @@ class CUDAGraphMode(enum.Enum):
     def requires_piecewise_compilation(self) -> bool:
         return self.has_mode(CUDAGraphMode.PIECEWISE)
 
+    def without_piecewise(self) -> "CUDAGraphMode":
+        if self == CUDAGraphMode.PIECEWISE:
+            return CUDAGraphMode.NONE
+        if self == CUDAGraphMode.FULL_AND_PIECEWISE:
+            return CUDAGraphMode.FULL_DECODE_ONLY
+        return self
+
     def max_cudagraph_mode(self) -> "CUDAGraphMode":
         return CUDAGraphMode(max(self.value)) if self.separate_routine() else self
 
@@ -1382,6 +1389,7 @@ class CompilationConfig:
         kv_cache_config: "KVCacheConfig | None" = None,
         max_num_reqs: int | None = None,
         is_profiling: bool = False,
+        piecewise_capture_available: bool = True,
     ) -> CUDAGraphMode:
         from vllm.v1.attention.backend import AttentionCGSupport
 
@@ -1463,6 +1471,20 @@ class CompilationConfig:
                 msg += "; setting cudagraph_mode=NONE"
                 cudagraph_mode = CUDAGraphMode.NONE
             logger.warning(msg)
+
+        if (
+            not piecewise_capture_available
+            and cudagraph_mode.requires_piecewise_compilation()
+        ):
+            fallback_mode = cudagraph_mode.without_piecewise()
+            logger.warning_once(
+                "Cudagraph mode %s requires piecewise capture, but the loaded "
+                "model provides neither a compiled submodule nor breakable CUDA "
+                "graphs. Overriding to %s.",
+                cudagraph_mode,
+                fallback_mode,
+            )
+            cudagraph_mode = fallback_mode
 
         # double check that we can support full cudagraph if they are requested
         # even after automatic downgrades

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -72,11 +72,7 @@ ROCM_DEFAULT_MRV1_ARCHITECTURES = frozenset(
     {"DeepseekV32ForCausalLM", "DeepseekV4ForCausalLM", "GlmMoeDsaForCausalLM"}
 )
 
-# At least one platform implementation of each architecture below has no
-# active torch.compile boundary and uses breakable graphs for PIECEWISE
-# capture. Platform-specific compiled implementations are carved out by
-# _uses_noncompiled_cudagraph_path(), including compatibility-policy exceptions.
-NON_COMPILED_CUDAGRAPH_FALLBACK_ARCHITECTURES = frozenset(
+DEFAULT_BREAKABLE_CUDAGRAPH_ARCHITECTURES = frozenset(
     {
         "DeepseekV32MTPModel",
         "DeepseekV32ForCausalLM",
@@ -98,31 +94,6 @@ NON_COMPILED_CUDAGRAPH_FALLBACK_ARCHITECTURES = frozenset(
         "KimiLinearForCausalLM",
         "MiniMaxM3SparseForCausalLM",
         "MiniMaxM3SparseForConditionalGeneration",
-        "Qwen4ExpForCausalLM",
-        "Qwen4ExpForConditionalGeneration",
-        "Qwen4ExpMTP",
-    }
-)
-
-# These implementations also define the current default policy. Keep the
-# capability set separately named because policy can change independently.
-DEFAULT_BREAKABLE_CUDAGRAPH_ARCHITECTURES = (
-    NON_COMPILED_CUDAGRAPH_FALLBACK_ARCHITECTURES
-)
-
-# DeepSeek V3.2 and its MTP model use their noncompiled implementations on
-# CUDA, but the shared implementations selected elsewhere are compiled.
-NON_CUDA_COMPILED_CUDAGRAPH_ARCHITECTURES = frozenset(
-    {
-        "DeepseekV32MTPModel",
-        "DeepseekV32ForCausalLM",
-        "GlmMoeDsaForCausalLM",
-    }
-)
-
-# Qwen4Exp retains torch.compile in its ROCm implementations.
-ROCM_COMPILED_CUDAGRAPH_ARCHITECTURES = frozenset(
-    {
         "Qwen4ExpForCausalLM",
         "Qwen4ExpForConditionalGeneration",
         "Qwen4ExpMTP",
@@ -747,39 +718,6 @@ class VllmConfig:
         architectures = set(model_config.architectures)
         return bool(architectures & default_breakable_cudagraph_architectures())
 
-    def _uses_noncompiled_cudagraph_path(self) -> bool:
-        """Whether the selected path needs the noncompiled graph fallback."""
-        model_config = self.model_config
-        if model_config is None:
-            return False
-
-        architecture = model_config.architecture
-        if architecture not in NON_COMPILED_CUDAGRAPH_FALLBACK_ARCHITECTURES:
-            return False
-
-        from vllm.platforms import current_platform
-
-        if (
-            not current_platform.is_cuda()
-            and architecture in NON_CUDA_COMPILED_CUDAGRAPH_ARCHITECTURES
-        ):
-            return False
-
-        if (
-            current_platform.is_rocm()
-            and architecture in ROCM_COMPILED_CUDAGRAPH_ARCHITECTURES
-        ):
-            return False
-
-        # Compatibility policy: keep DeepSeek V4's existing ROCm MRV1 graph
-        # defaults unchanged. MRV2 adds a runtime provider guard and therefore
-        # needs the fallback when explicitly selected.
-        return not (
-            current_platform.is_rocm()
-            and architecture == "DeepseekV4ForCausalLM"
-            and not self.use_v2_model_runner
-        )
-
     def _maybe_enable_breakable_cudagraph(self) -> bool:
         if (
             "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ
@@ -798,52 +736,6 @@ class VllmConfig:
         enabled = is_breakable_cudagraph_enabled()
         if enabled:
             self.compilation_config.mode = CompilationMode.NONE
-        elif self._uses_noncompiled_cudagraph_path():
-            # These architectures do not have an active torch.compile wrapper,
-            # so PIECEWISE capture is unavailable without breakable graphs. Keep
-            # full graphs for uniform decode at O2/O3 and run other batches
-            # eagerly. This also handles platforms such as ROCm that deliberately
-            # leave breakable graphs disabled by default for performance.
-            compilation_config = self.compilation_config
-            cudagraph_mode = compilation_config.cudagraph_mode
-            if compilation_config.mode == CompilationMode.VLLM_COMPILE and (
-                cudagraph_mode is None
-                or cudagraph_mode.requires_piecewise_compilation()
-            ):
-                raise ValueError(
-                    f"{self.model_config.architecture} does not expose an active "
-                    "torch.compile boundary, so compilation mode VLLM_COMPILE "
-                    "cannot be honored and later CUDA graph resolution can require "
-                    "unavailable piecewise capture. Use compilation mode NONE with "
-                    "cudagraph mode NONE/FULL_DECODE_ONLY, or enable breakable CUDA "
-                    "graphs."
-                )
-            if compilation_config.cudagraph_mode is None:
-                from vllm.platforms import current_platform
-
-                architecture = self.model_config.architecture
-                unsafe_full_graph = (
-                    current_platform.is_rocm()
-                    and current_platform.is_device_capability(95)
-                    and self.use_v2_model_runner
-                    and architecture
-                    in {
-                        "DeepseekV4ForCausalLM",
-                        "DeepseekV4ForConditionalGeneration",
-                    }
-                )
-                compilation_config.cudagraph_mode = (
-                    CUDAGraphMode.FULL_DECODE_ONLY
-                    if self.optimization_level >= OptimizationLevel.O2
-                    and not unsafe_full_graph
-                    else CUDAGraphMode.NONE
-                )
-                logger.info_once(
-                    "Breakable CUDA graphs are disabled for a model without "
-                    "torch.compile support; defaulting cudagraph mode to %s.",
-                    compilation_config.cudagraph_mode.name,
-                )
-
         return enabled
 
     @property
@@ -1079,51 +971,6 @@ class VllmConfig:
             speculative_config.num_speculative_tokens,
         )
         speculative_config.num_speculative_tokens_per_batch_size = None
-
-    def _normalize_unavailable_piecewise_cudagraphs(
-        self, *, breakable_cudagraph_enabled: bool
-    ) -> None:
-        """Remove piecewise graphs when no capture implementation is active."""
-        compilation_config = self.compilation_config
-        if compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
-            compilation_config.max_cudagraph_capture_size = 0
-            compilation_config.cudagraph_capture_sizes = []
-            return
-
-        piecewise_capture_available = (
-            VllmConfig._piecewise_cudagraph_provider_available(
-                self,
-                breakable_cudagraph_enabled=breakable_cudagraph_enabled,
-            )
-        )
-        if (
-            compilation_config.cudagraph_mode.requires_piecewise_compilation()
-            and not piecewise_capture_available
-        ):
-            fallback_mode = (
-                CUDAGraphMode.FULL_DECODE_ONLY
-                if compilation_config.cudagraph_mode.has_full_cudagraphs()
-                else CUDAGraphMode.NONE
-            )
-            logger.info_once(
-                "Cudagraph mode %s is not compatible with compilation mode %s. "
-                "Overriding to %s.",
-                compilation_config.cudagraph_mode,
-                compilation_config.mode,
-                fallback_mode,
-            )
-            compilation_config.cudagraph_mode = fallback_mode
-            if fallback_mode == CUDAGraphMode.NONE:
-                compilation_config.max_cudagraph_capture_size = 0
-                compilation_config.cudagraph_capture_sizes = []
-
-    def _piecewise_cudagraph_provider_available(
-        self, *, breakable_cudagraph_enabled: bool
-    ) -> bool:
-        return breakable_cudagraph_enabled or (
-            self.compilation_config.mode == CompilationMode.VLLM_COMPILE
-            and not self._uses_noncompiled_cudagraph_path()
-        )
 
     def _post_init_kv_transfer_config(self) -> None:
         """Update KVTransferConfig based on top-level configs in VllmConfig.
@@ -1568,7 +1415,7 @@ class VllmConfig:
             )
         ):
             logger.warning_once(
-                "Inductor compilation is disabled by configuration, "
+                "Inductor compilation was disabled by user settings, "
                 "optimizations settings that are only active during "
                 "inductor compilation will be ignored."
             )
@@ -1629,6 +1476,21 @@ class VllmConfig:
 
         self._maybe_disable_dynamic_sd_for_data_parallel()
         self._maybe_override_dynamic_sd_cudagraph_mode()
+
+        if (
+            self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
+            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
+            and not breakable_cudagraph_enabled
+        ):
+            fallback_mode = self.compilation_config.cudagraph_mode.without_piecewise()
+            logger.info_once(
+                "Cudagraph mode %s is not compatible with compilation mode %s."
+                "Overriding to %s.",
+                self.compilation_config.cudagraph_mode,
+                self.compilation_config.mode,
+                fallback_mode,
+            )
+            self.compilation_config.cudagraph_mode = fallback_mode
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config
@@ -1741,9 +1603,6 @@ class VllmConfig:
             else:
                 self.compilation_config.cudagraph_num_of_warmups = 1
 
-            self._normalize_unavailable_piecewise_cudagraphs(
-                breakable_cudagraph_enabled=breakable_cudagraph_enabled
-            )
             self._set_cudagraph_sizes()
 
         else:
@@ -1799,13 +1658,6 @@ class VllmConfig:
                 "to True to enable."
             )
         current_platform.check_and_update_config(self)
-
-        # Platform and connector compatibility checks above can replace a full
-        # graph mode with PIECEWISE. Re-normalize after those late updates and
-        # before validating consumers of the resolved mode.
-        self._normalize_unavailable_piecewise_cudagraphs(
-            breakable_cudagraph_enabled=breakable_cudagraph_enabled
-        )
 
         self._resolve_allow_missing_mm_embeddings()
         self._resolve_mm_processor_device()

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -972,6 +972,28 @@ class VllmConfig:
         )
         speculative_config.num_speculative_tokens_per_batch_size = None
 
+    def _normalize_piecewise_cudagraph_mode(
+        self, *, breakable_cudagraph_enabled: bool
+    ) -> None:
+        compilation_config = self.compilation_config
+        if (
+            compilation_config.cudagraph_mode.requires_piecewise_compilation()
+            and compilation_config.mode != CompilationMode.VLLM_COMPILE
+            and not breakable_cudagraph_enabled
+        ):
+            fallback_mode = compilation_config.cudagraph_mode.without_piecewise()
+            logger.info_once(
+                "Cudagraph mode %s is not compatible with compilation mode %s. "
+                "Overriding to %s.",
+                compilation_config.cudagraph_mode,
+                compilation_config.mode,
+                fallback_mode,
+            )
+            compilation_config.cudagraph_mode = fallback_mode
+            if fallback_mode == CUDAGraphMode.NONE:
+                compilation_config.max_cudagraph_capture_size = 0
+                compilation_config.cudagraph_capture_sizes = []
+
     def _post_init_kv_transfer_config(self) -> None:
         """Update KVTransferConfig based on top-level configs in VllmConfig.
 
@@ -1477,20 +1499,9 @@ class VllmConfig:
         self._maybe_disable_dynamic_sd_for_data_parallel()
         self._maybe_override_dynamic_sd_cudagraph_mode()
 
-        if (
-            self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
-            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-            and not breakable_cudagraph_enabled
-        ):
-            fallback_mode = self.compilation_config.cudagraph_mode.without_piecewise()
-            logger.info_once(
-                "Cudagraph mode %s is not compatible with compilation mode %s."
-                "Overriding to %s.",
-                self.compilation_config.cudagraph_mode,
-                self.compilation_config.mode,
-                fallback_mode,
-            )
-            self.compilation_config.cudagraph_mode = fallback_mode
+        self._normalize_piecewise_cudagraph_mode(
+            breakable_cudagraph_enabled=breakable_cudagraph_enabled
+        )
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config
@@ -1658,6 +1669,10 @@ class VllmConfig:
                 "to True to enable."
             )
         current_platform.check_and_update_config(self)
+
+        self._normalize_piecewise_cudagraph_mode(
+            breakable_cudagraph_enabled=breakable_cudagraph_enabled
+        )
 
         self._resolve_allow_missing_mm_embeddings()
         self._resolve_mm_processor_device()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -880,8 +880,8 @@ class RocmPlatform(Platform):
                 "DeepseekV4ForConditionalGeneration",
             }
         ):
-            # Full cudagraphs are not yet accurate for DeepSeek V4 with MRV2
-            # on gfx950. Explicit user choices remain unchanged.
+            # Default to eager after reported gfx950/MRV2 accuracy regressions:
+            # https://github.com/vllm-project/vllm/issues/52644
             compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         use_aiter_fused_moe = rocm_aiter_ops.is_fused_moe_enabled()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -865,8 +865,25 @@ class RocmPlatform(Platform):
     @classmethod
     def apply_config_platform_defaults(cls, vllm_config: "VllmConfig") -> None:
         from vllm._aiter_ops import rocm_aiter_ops
+        from vllm.config.compilation import CUDAGraphMode
 
         compilation_config = vllm_config.compilation_config
+        model_config = vllm_config.model_config
+        if (
+            compilation_config.cudagraph_mode is None
+            and model_config is not None
+            and on_gfx950()
+            and vllm_config.use_v2_model_runner
+            and model_config.architecture
+            in {
+                "DeepseekV4ForCausalLM",
+                "DeepseekV4ForConditionalGeneration",
+            }
+        ):
+            # Full cudagraphs are not yet accurate for DeepSeek V4 with MRV2
+            # on gfx950. Explicit user choices remain unchanged.
+            compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+
         use_aiter_fused_moe = rocm_aiter_ops.is_fused_moe_enabled()
         use_aiter_fp8_linear = rocm_aiter_ops.is_linear_fp8_enabled()
         use_aiter_fused_se = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -661,13 +661,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.kv_cache_config,
             use_replayssm=self.vllm_config.cache_config.use_replayssm,
         )
+        piecewise_capture_available = bool(
+            envs.VLLM_USE_BREAKABLE_CUDAGRAPH or has_compiled_submodule(self.model)
+        )
         if self.adaptive_verification is not None:
             self.compilation_config.cudagraph_mode = resolve_adaptive_cudagraph_mode(
                 self.compilation_config.cudagraph_mode,
-                piecewise_capture_available=(
-                    envs.VLLM_USE_BREAKABLE_CUDAGRAPH
-                    or has_compiled_submodule(self.model)
-                ),
+                piecewise_capture_available=piecewise_capture_available,
             )
         cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
             attn_cg_support.min_cg_support,
@@ -678,6 +678,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             kv_cache_config=self.kv_cache_config,
             max_num_reqs=self.max_num_reqs,
             is_profiling=is_profiling,
+            piecewise_capture_available=piecewise_capture_available,
         )
         self.cudagraph_manager = ModelCudaGraphManager(
             self.vllm_config,


### PR DESCRIPTION
## Summary

Stacked follow-up to #55095 that keeps its fallback behavior while moving the decision to the point where the model's actual runtime capability is known.

- Detect piecewise capture support after the V2 runner loads the model.
- Map PIECEWISE to NONE and FULL_AND_PIECEWISE to FULL_DECODE_ONLY when neither an active compiled submodule nor breakable CUDA graphs are available.
- Keep the gfx950 DeepSeek V4 accuracy restriction as a ROCm platform default.
- Preserve the adaptive-verification requirement for full CUDA graphs.

This removes the architecture capability tables, their platform-specific exception tables, and the duplicated early/late normalization from #55095. The combined change is 210 additions instead of 638.

## Why

Architecture names are a policy hint for enabling breakable graphs, but they are not a reliable proxy for the implementation selected at runtime. The tables in #55095 duplicate model/platform selection knowledge and require exceptions whenever an implementation changes.

The V2 runner already has the loaded model before it resolves its CUDA graph manager. Checking has_compiled_submodule(self.model) there makes the fallback follow the implementation that was actually loaded and also covers attention-driven mode changes in one place.

## Stacking

This draft targets the head branch of #55095 and is intended to be reviewed as an alternative simplification of that PR.

## Duplicate-work check

- Checked issue/PR references for #55095.
- Searched open PRs for noncompiled cudagraph fallback.
- No separate open PR implementing this refactor was found.

## Tests

- .venv/bin/python -m pytest tests/test_config.py tests/v1/spec_decode/test_adaptive_verification.py -q
  - 277 passed
- .venv/bin/python -m pytest tests/test_config.py -k 'cudagraph or adaptive_verification' tests/v1/spec_decode/test_adaptive_verification.py -q
  - 48 passed, 229 deselected
- .venv/bin/pre-commit run --files <changed files>
  - Passed, including ruff and mypy

Model evaluation / GPU end-to-end validation was not run. This is a draft control-flow refactor and still needs validation with an affected noncompiled model, plus DeepSeek V4 on gfx950.

## AI assistance

AI assistance was used to review #55095, implement this alternative, and run the checks above. The human submitter must review and understand every changed line before this is marked ready.
