### PR TITLE
[Feature][KV Offload] Add RDMA-capable OBJ tier (#55855)

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -187,6 +187,17 @@ The object-store tier (`type: "obj"`) offloads blocks to an S3-compatible object
 | `access_key`, `secret_key`, `session_token` | no | `""` | Explicit credentials. When left empty, the NIXL OBJ plugin falls back to the AWS SDK default credential provider chain (IAM roles, environment variables, credential files), which enables workload-identity auth on Kubernetes. |
 | `region` | no | `""` | Bucket region, if the endpoint requires one. |
 | `ca_bundle` | no | `""` | CA bundle path for TLS verification. |
+| `use_virtual_addressing` | no | unset | Passed to NIXL OBJ as `true` or `false` when set. |
+| `req_checksum` | no | unset | Request checksum policy passed to NIXL OBJ. |
+| `resp_checksum` | no | unset | Response checksum policy passed to NIXL OBJ. |
+| `accelerated` | no | unset | Enables an accelerated NIXL OBJ engine when set. |
+| `type` | no | unset | Accelerated engine selector passed to NIXL OBJ. |
+| `backend_params` | no | `{}` | Additional NIXL OBJ backend parameters. Reserved object-store fields and `num_threads` cannot be overridden here. |
+
+For accelerated object-store transfers, set the NIXL OBJ parameters required by
+the selected engine through `store_config`. Unknown generic NIXL parameters can
+be passed through `backend_params`; known object-store connection fields should
+use the explicit keys above.
 
 Object keys follow the same run-configuration digest scheme as the filesystem tier (see [On-Disk Layout](#on-disk-layout)) and are stored under the optional `prefix`. The [Cross-Process Sharing](#cross-process-sharing) behavior applies to shared buckets as well, so instances sharing a bucket produce identical keys for identical content; set a shared `PYTHONHASHSEED` if you want a custom seed. At startup the tier probes object store connectivity and fails fast with a configuration error if the bucket is unreachable.
 

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -40,7 +40,11 @@ from vllm.v1.kv_offload.tiering.manager import (
     TieringOffloadingManager,
 )
 from vllm.v1.kv_offload.tiering.obj.config import ObjStoreConfig
-from vllm.v1.kv_offload.tiering.obj.manager import ObjectStoreSecondaryTierManager
+from vllm.v1.kv_offload.tiering.obj.manager import (
+    _CUOBJ_MAX_MEMORY_REG_SIZE_BYTES,
+    _build_primary_dram_descriptors,
+    ObjectStoreSecondaryTierManager,
+)
 
 # ---------------------------------------------------------------------------
 # Shared stubs
@@ -146,6 +150,7 @@ class MockNixlAgent:
         self._pending: dict[int, tuple[str, list[str]]] = {}
         self._handle_counter = 0
         self._last_obj_keys: list[str] = []
+        self.created_backends: list[tuple[str, dict[str, str]]] = []
         # Bind default implementations as instance attributes.
         self.register_memory = self._register_memory
         self.make_prepped_xfer = self._make_prepped_xfer
@@ -153,7 +158,7 @@ class MockNixlAgent:
         self.query_memory = self._query_memory
 
     def create_backend(self, backend_type, params):
-        pass
+        self.created_backends.append((backend_type, params))
 
     def _register_memory(self, descs, mem_type=None, backends=None):
         mock = MagicMock()
@@ -230,6 +235,7 @@ def _make_tier(
     num_blocks: int = 4,
     offloading_spec: SimpleNamespace = _OFFLOADING_SPEC,
     primary_kv_view: memoryview | None = None,
+    store_config: dict | None = None,
     **tier_kwargs,
 ) -> tuple[ObjectStoreSecondaryTierManager, MockNixlAgent]:
     """Create a tier backed by a fresh MockNixlAgent."""
@@ -248,7 +254,7 @@ def _make_tier(
             offloading_spec=offloading_spec,
             primary_kv_view=primary_kv_view,
             tier_type="obj",
-            store_config=_STORE_CONFIG,
+            store_config=store_config or _STORE_CONFIG,
             prefix=_RUN_PREFIX,
             **tier_kwargs,
         )
@@ -764,6 +770,127 @@ class TestObjStoreConfig:
         params = cfg.to_nixl_params()
         assert params["ca_bundle"] == "/path/to/ca.pem"
         assert "access_key" not in params
+
+    def test_accelerated_obj_params_included(self):
+        cfg = ObjStoreConfig(
+            bucket="b",
+            endpoint_override="ep",
+            use_virtual_addressing=False,
+            req_checksum="required",
+            resp_checksum="supported",
+            accelerated=True,
+            type="custom",
+        )
+        params = cfg.to_nixl_params()
+        assert params["use_virtual_addressing"] == "false"
+        assert params["req_checksum"] == "required"
+        assert params["resp_checksum"] == "supported"
+        assert params["accelerated"] == "true"
+        assert params["type"] == "custom"
+
+    def test_backend_params_pass_through(self):
+        cfg = ObjStoreConfig(
+            bucket="b",
+            endpoint_override="ep",
+            backend_params={
+                "custom_string": "value",
+                "custom_bool": True,
+                "custom_int": 7,
+            },
+        )
+        params = cfg.to_nixl_params()
+        assert params["custom_string"] == "value"
+        assert params["custom_bool"] == "true"
+        assert params["custom_int"] == "7"
+
+    def test_backend_params_cannot_override_reserved_keys(self):
+        cfg = ObjStoreConfig(
+            bucket="b",
+            endpoint_override="ep",
+            backend_params={"bucket": "other"},
+        )
+        with pytest.raises(ValueError, match="reserved object store parameters"):
+            cfg.to_nixl_params()
+
+
+def test_obj_tier_passes_accelerated_params_to_nixl_backend():
+    store_config = {
+        **_STORE_CONFIG,
+        "accelerated": True,
+        "type": "custom",
+        "use_virtual_addressing": False,
+        "backend_params": {"custom_param": "custom-value"},
+    }
+    tier, agent = _make_tier(store_config=store_config, io_threads=3)
+
+    assert agent.created_backends == [
+        (
+            "OBJ",
+            {
+                "bucket": "mock-bucket",
+                "endpoint_override": "mock:9000",
+                "scheme": "http",
+                "access_key": "mock-access",
+                "secret_key": "mock-secret",
+                "custom_param": "custom-value",
+                "use_virtual_addressing": "false",
+                "accelerated": "true",
+                "type": "custom",
+                "num_threads": "3",
+            },
+        )
+    ]
+    tier.shutdown()
+
+
+def test_primary_dram_registration_uses_single_range_below_cuobj_limit():
+    stride = 1024
+    base_addr = 0x100000
+    num_blocks = _CUOBJ_MAX_MEMORY_REG_SIZE_BYTES // stride
+
+    descriptors = _build_primary_dram_descriptors(base_addr, num_blocks, stride)
+
+    assert descriptors == [
+        (
+            base_addr,
+            num_blocks * stride,
+            0,
+            "",
+        )
+    ]
+
+
+def test_primary_dram_registration_splits_ranges_above_cuobj_limit():
+    stride = 1024
+    base_addr = 0x100000
+    blocks_per_registration = _CUOBJ_MAX_MEMORY_REG_SIZE_BYTES // stride
+    num_blocks = blocks_per_registration + 7
+
+    descriptors = _build_primary_dram_descriptors(base_addr, num_blocks, stride)
+
+    assert descriptors == [
+        (
+            base_addr,
+            blocks_per_registration * stride,
+            0,
+            "",
+        ),
+        (
+            base_addr + blocks_per_registration * stride,
+            7 * stride,
+            0,
+            "",
+        ),
+    ]
+
+
+def test_primary_dram_registration_rejects_oversized_block():
+    with pytest.raises(ValueError, match="block larger"):
+        _build_primary_dram_descriptors(
+            base_addr=0x100000,
+            num_blocks=1,
+            stride=_CUOBJ_MAX_MEMORY_REG_SIZE_BYTES + 1,
+        )
 
 
 def test_obj_tier_replicated_layout_collapses_mapper_identity():

--- a/vllm/v1/kv_offload/tiering/obj/config.py
+++ b/vllm/v1/kv_offload/tiering/obj/config.py
@@ -2,7 +2,34 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Connection configuration for the object store secondary tier."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import Any
+
+_RESERVED_BACKEND_PARAM_KEYS = frozenset(
+    {
+        "bucket",
+        "endpoint_override",
+        "access_key",
+        "secret_key",
+        "session_token",
+        "region",
+        "scheme",
+        "ca_bundle",
+        "num_threads",
+        "use_virtual_addressing",
+        "req_checksum",
+        "resp_checksum",
+        "accelerated",
+        "type",
+    }
+)
+
+
+def _to_nixl_param(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
 
 
 @dataclass
@@ -23,6 +50,12 @@ class ObjStoreConfig:
     region: str = ""
     scheme: str = "http"
     ca_bundle: str = ""
+    use_virtual_addressing: bool | str | None = None
+    req_checksum: str | None = None
+    resp_checksum: str | None = None
+    accelerated: bool | str | None = None
+    type: str | None = None
+    backend_params: Mapping[str, Any] = field(default_factory=dict, repr=False)
 
     def to_nixl_params(self) -> dict[str, str]:
         """Build the NIXL backend params dict.
@@ -43,4 +76,25 @@ class ObjStoreConfig:
             value = getattr(self, key)
             if value:
                 params[key] = value
+
+        duplicate_keys = _RESERVED_BACKEND_PARAM_KEYS.intersection(self.backend_params)
+        if duplicate_keys:
+            raise ValueError(
+                "backend_params cannot override reserved object store "
+                f"parameters: {sorted(duplicate_keys)}"
+            )
+
+        params.update(
+            {key: _to_nixl_param(value) for key, value in self.backend_params.items()}
+        )
+        for key in (
+            "use_virtual_addressing",
+            "req_checksum",
+            "resp_checksum",
+            "accelerated",
+            "type",
+        ):
+            value = getattr(self, key)
+            if value is not None and value != "":
+                params[key] = _to_nixl_param(value)
         return params

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -54,12 +54,39 @@ NIXL_DEV_ID: int = 0
 _PROBE_ADDR: int = 0
 _PROBE_LEN: int = 1
 _PROBE_DEV_ID: int = 0
+_CUOBJ_MAX_MEMORY_REG_SIZE_BYTES = 4 * 1024 * 1024 * 1024 - 64 * 1024
 
 
 class TransferEntry(NamedTuple):
     xfer_handle: "nixl_xfer_handle"
     files_desc: object
     obj_handle: "nixl_prepped_dlist_handle"
+
+
+def _build_primary_dram_descriptors(
+    base_addr: int,
+    num_blocks: int,
+    stride: int,
+    max_registration_bytes: int = _CUOBJ_MAX_MEMORY_REG_SIZE_BYTES,
+) -> list[tuple[int, int, int, str]]:
+    if stride > max_registration_bytes:
+        raise ValueError(
+            "Object store RDMA cannot register a primary-tier block larger "
+            f"than {max_registration_bytes} bytes: block size is {stride} bytes"
+        )
+    blocks_per_registration = max_registration_bytes // stride
+    descriptors = []
+    for start_block in range(0, num_blocks, blocks_per_registration):
+        block_count = min(blocks_per_registration, num_blocks - start_block)
+        descriptors.append(
+            (
+                base_addr + start_block * stride,
+                block_count * stride,
+                NIXL_DEV_ID,
+                "",
+            )
+        )
+    return descriptors
 
 
 class ObjAsyncLookupManager(AsyncLookupManager):
@@ -171,9 +198,10 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         base_addr = ctypes.addressof(ctypes.c_char.from_buffer(primary_kv_view))
         assert primary_kv_view.strides is not None
         stride = primary_kv_view.strides[0]
-        self._primary_reg = self._agent.register_memory(
-            [(base_addr, primary_kv_view.nbytes, NIXL_DEV_ID, "")], "DRAM"
+        dram_descriptors = _build_primary_dram_descriptors(
+            base_addr, len(primary_kv_view), stride
         )
+        self._primary_reg = self._agent.register_memory(dram_descriptors, "DRAM")
         self._block_size_bytes = stride
         all_blocks = [
             (base_addr + i * stride, stride, NIXL_DEV_ID)
@@ -326,8 +354,13 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
 
             transfer_time = None
             if success:
-                telemetry = self._agent.get_xfer_telemetry(entry.xfer_handle)
-                transfer_time = telemetry.xferDuration / 1e6
+                try:
+                    telemetry = self._agent.get_xfer_telemetry(entry.xfer_handle)
+                    transfer_time = telemetry.xferDuration / 1e6
+                except Exception as exc:
+                    logger.warning(
+                        "get_xfer_telemetry failed for job %d: %s", job_id, exc
+                    )
 
             try:
                 self._agent.release_xfer_handle(entry.xfer_handle)


### PR DESCRIPTION

## Purpose

Fixes #55855.

This PR adds RDMA-capable NIXL OBJ configuration support for the KV offload secondary tier.

The change keeps the existing OBJ tier JSON shape and adds support for passing accelerated object-store parameters through to the NIXL OBJ backend, including:

- `accelerated`
- `type`
- `use_virtual_addressing`
- `req_checksum`
- `resp_checksum`
- additional backend-specific parameters via `backend_params`

It also splits CPU DRAM registration descriptors so large CPU offload pools can be registered in chunks that stay below the CUFile object registration limit.

Documentation and unit coverage are updated for the new OBJ tier options.

## Test Plan

- Ran `vllm bench` against baseline vLLM and vLLM with this PR.
- Ran `lm_eval` LongBench tests against baseline vLLM and vLLM with this PR.
- Run targeted OBJ tier tests:
  - `.venv/bin/python -m pytest tests/v1/kv_offload/tiering/test_obj_tier.py -v`

## Test Result

- `vllm bench`: passed against baseline vLLM and vLLM with this PR.
- `lm_eval` LongBench: passed against baseline vLLM and vLLM with this PR.
- Targeted pytest: not run in this environment.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
