### PR TITLE
[Bugfix] Don't abort custom allreduce when expandable_segments is enabled

### DIFF
--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -161,8 +161,28 @@ class CustomAllreduce {
       if (cuPointerGetAttribute(&base_ptr, rangeStartAddrAttr,
                                 (CUdeviceptr)ptr) != CUDA_SUCCESS)
         throw std::runtime_error("failed to get pointer attr");
-      CUDACHECK(cudaIpcGetMemHandle(
-          (cudaIpcMemHandle_t*)&handles[i * handle_sz], base_ptr));
+      // Not CUDACHECK: that macro calls exit(EXIT_FAILURE), which kills the
+      // worker with only "Failed: Cuda error custom_all_reduce.cuh:<line>
+      // 'invalid argument'" and no Python traceback. cudaIpcGetMemHandle
+      // rejects any pointer not backed by a single cudaMalloc allocation --
+      // most often because PyTorch's expandable_segments allocator placed this
+      // graph buffer in a CUDA VMM range. Throw so the failure surfaces with
+      // an actionable message (see #42609, #49101, #56180).
+      cudaError_t ipc_err = cudaIpcGetMemHandle(
+          (cudaIpcMemHandle_t*)&handles[i * handle_sz], base_ptr);
+      if (ipc_err != cudaSuccess) {
+        throw std::runtime_error(
+            std::string(
+                "custom allreduce failed to get an IPC handle for a CUDA "
+                "graph buffer: ") +
+            cudaGetErrorString(ipc_err) +
+            ". This usually means the buffer is not backed by a single "
+            "cudaMalloc allocation, e.g. because PyTorch's "
+            "expandable_segments allocator placed it in a CUDA VMM range. "
+            "Unset expandable_segments:True in PYTORCH_ALLOC_CONF / "
+            "PYTORCH_CUDA_ALLOC_CONF, or run with "
+            "--disable-custom-all-reduce.");
+      }
       offsets[i] = ((char*)ptr) - ((char*)base_ptr);
     }
     return std::make_pair(handles, offsets);

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -215,3 +215,70 @@ def test_custom_allreduce(
     if world_size > torch.accelerator.device_count():
         pytest.skip("Not enough GPUs to run the test.")
     multi_process_parallel(monkeypatch, tp_size, pipeline_parallel_size, test_target)
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({}, False),
+        ({"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}, True),
+        ({"PYTORCH_ALLOC_CONF": "expandable_segments:True"}, True),
+        (
+            {"PYTORCH_ALLOC_CONF": "max_split_size_mb:512,expandable_segments:True"},
+            True,
+        ),
+        ({"PYTORCH_ALLOC_CONF": "expandable_segments:False"}, False),
+        ({"PYTORCH_ALLOC_CONF": ""}, False),
+    ],
+)
+def test_expandable_segments_enabled(monkeypatch, env, expected):
+    for var in ("PYTORCH_ALLOC_CONF", "PYTORCH_CUDA_ALLOC_CONF"):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in env.items():
+        monkeypatch.setenv(var, value)
+
+    assert car._expandable_segments_enabled() is expected
+
+
+class _ReachedP2PProbe(Exception):
+    """Sentinel proving __init__ ran past the expandable-segments guard."""
+
+
+@pytest.mark.parametrize("expandable_segments", [True, False])
+def test_custom_allreduce_disabled_with_expandable_segments(
+    monkeypatch,
+    expandable_segments,
+):
+    """expandable_segments must disable custom allreduce rather than abort.
+
+    The CUDA VMM allocations it produces cannot be shared via
+    cudaIpcGetMemHandle, which the C++ side calls behind CUDACHECK in
+    get_graph_buffer_ipc_meta -- so the worker used to die with a bare
+    "Failed: Cuda error custom_all_reduce.cuh:164 'invalid argument'".
+    See #42609, #49101, #56180.
+    """
+    monkeypatch.setattr(car, "custom_ar", True)
+    monkeypatch.setattr(car.dist, "get_backend", lambda _group: "gloo")
+    monkeypatch.setattr(car, "in_the_same_node_as", lambda *_a, **_kw: [True, True])
+    monkeypatch.setattr(car.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(car.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        car, "_expandable_segments_enabled", lambda: expandable_segments
+    )
+
+    def get_device_capability(*_args, **_kwargs):
+        raise _ReachedP2PProbe
+
+    monkeypatch.setattr(
+        car.current_platform, "get_device_capability", get_device_capability
+    )
+
+    communicator = car.CustomAllreduce.__new__(car.CustomAllreduce)
+    if expandable_segments:
+        communicator.__init__(group=object(), device=0)
+        assert communicator.disabled is True
+    else:
+        # Without the env var the guard is inert and init walks on into the
+        # regular capability/P2P probing.
+        with pytest.raises(_ReachedP2PProbe):
+            communicator.__init__(group=object(), device=0)

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -82,6 +83,18 @@ def _group_can_attempt_mnnvl(
         group=group,
     )
     return bool(group_support.item())
+
+
+def _expandable_segments_enabled() -> bool:
+    """Whether PyTorch's expandable-segments (CUDA VMM) allocator is enabled.
+
+    PyTorch reads this from ``PYTORCH_ALLOC_CONF``, falling back to the legacy
+    ``PYTORCH_CUDA_ALLOC_CONF`` name, so honour both.
+    """
+    for var in ("PYTORCH_ALLOC_CONF", "PYTORCH_CUDA_ALLOC_CONF"):
+        if "expandable_segments:True" in os.environ.get(var, ""):
+            return True
+    return False
 
 
 def _can_p2p(rank: int, world_size: int) -> bool:
@@ -187,6 +200,32 @@ class CustomAllreduce:
                 "warning, specify disable_custom_all_reduce=True explicitly.",
                 world_size,
                 str(CustomAllreduce._SUPPORTED_WORLD_SIZES),
+            )
+            return
+
+        if _expandable_segments_enabled():
+            # PyTorch's expandable-segments allocator backs tensors with CUDA
+            # VMM ranges (cuMemAddressReserve + cuMemMap) rather than a single
+            # cudaMalloc allocation. Custom allreduce shares its CUDA graph
+            # buffers across ranks with cudaIpcGetMemHandle, which rejects
+            # VMM-backed pointers with cudaErrorInvalidValue. Because that call
+            # sits behind the CUDACHECK macro, the worker dies via exit(1)
+            # printing only "Failed: Cuda error custom_all_reduce.cuh:<line>
+            # 'invalid argument'", with no Python traceback and no hint at the
+            # cause. Fall back to NCCL instead. See #42609, #49101, #56180.
+            #
+            # Note: the cumem allocator is deliberately *not* exempted here.
+            # It only disables expandable segments around its own memory pool,
+            # which does not cover CUDA graph capture, and #42609 reproduces
+            # both with and without sleep mode.
+            logger.warning(
+                "Custom allreduce is disabled because expandable_segments:True "
+                "is set in PYTORCH_ALLOC_CONF/PYTORCH_CUDA_ALLOC_CONF. Its CUDA "
+                "VMM allocations cannot be shared between ranks via CUDA IPC, "
+                "which custom allreduce needs in order to register CUDA graph "
+                "buffers. Unset expandable_segments:True to re-enable custom "
+                "allreduce. To silence this warning, specify "
+                "disable_custom_all_reduce=True explicitly."
             )
             return
 


### PR DESCRIPTION
## Purpose

Fixes #42609. Also fixes #49101 and #56180, which are the same bug reported against different hardware.

With `expandable_segments:True` set, a TP>1 server dies immediately after CUDA graph capture with nothing but:

```
Failed: Cuda error /workspace/csrc/custom_all_reduce.cuh:164 'invalid argument'
(EngineCore) ERROR Worker proc VllmWorker-0 died unexpectedly (exit code: None)
```

No Python traceback, no indication of the cause. Reported on 4xH200 and 2xRTX 3090 (#42609), 4xH100 (#49101) and 2xRTX 5090 (#56180); in every case the workaround is unsetting `expandable_segments:True` or passing `--disable-custom-all-reduce`.

**Root cause.** PyTorch's expandable-segments allocator backs tensors with CUDA VMM ranges (`cuMemAddressReserve` + `cuMemMap`) rather than a single `cudaMalloc` allocation. `CustomAllreduce` shares its CUDA graph buffers across ranks via `cudaIpcGetMemHandle` in `get_graph_buffer_ipc_meta`, and that API rejects VMM-backed pointers with `cudaErrorInvalidValue`. The call sits behind `CUDACHECK`, which `printf`s and calls `exit(EXIT_FAILURE)` — hence the opaque death.

**Fix.** Disable custom allreduce up front when expandable segments are enabled, so we degrade to NCCL with an explanatory warning instead of aborting. This matches how `CustomAllreduce.__init__` already handles every other unsupported configuration (unsupported world size, non-fully-connected PCIe, no P2P), and follows the existing precedent in `VllmConfig._verify_kv_transfer_compat`, which rejects the same env var for KV connectors.

Two notes on the approach:

- **The cumem allocator is deliberately not exempted**, unlike the KV connector check. It only turns expandable segments off around its own memory pool, which does not cover CUDA graph capture, and #42609 reports reproducing both with and without `--enable-sleep-mode`.
- **`PYTORCH_ALLOC_CONF` is checked alongside the legacy `PYTORCH_CUDA_ALLOC_CONF`**, since recent PyTorch reads the former.

Secondly, the `cudaIpcGetMemHandle` call site no longer goes through `CUDACHECK`. It throws `std::runtime_error` with an actionable message instead, consistent with the `throw` two lines above it, so any *other* trigger for this failure surfaces as a Python exception with a traceback rather than a bare `exit(1)`.

#42609 suggests an alternative: temporarily toggle expandable segments off around graph buffer allocation, preserving custom allreduce's performance instead of falling back to NCCL. That would be the better outcome, but it is considerably more invasive and I don't have multi-GPU hardware to validate it. Happy to pursue that instead if maintainers prefer it.

## Test Plan

New CPU-only unit tests in `tests/distributed/test_custom_all_reduce.py`, written in the same monkeypatch style as the existing tests there:

- `test_expandable_segments_enabled` — parametrized over both env var names, comma-separated values, `:False`, empty and unset.
- `test_custom_allreduce_disabled_with_expandable_segments` — drives `__init__` and asserts `disabled is True` when the allocator is on; asserts init walks past the guard into the normal capability/P2P probing when it is off.

```bash
pytest tests/distributed/test_custom_all_reduce.py -k "expandable"
```

## Test Result

```
8 passed, 15 deselected
```

Whole file, GPU tests aside: `14 passed, 4 skipped, 5 deselected`.

`ruff check` / `ruff format` clean; `clang-format` (v21.1.2, the pinned pre-commit rev) clean on `csrc/custom_all_reduce.cuh`.

**I do not have a multi-GPU machine, so this is not verified end-to-end.** The Python-side behaviour is covered by the unit tests above, but I would appreciate a confirmation run from anyone with a 2+ GPU box — @mgabor3141's model-free reproducer in #42609 exercises exactly this path and should now log the warning and complete instead of aborting.
