### PR TITLE
[Bugfix][Core] Don't kill the engine on a duplicate KV recv completion

### DIFF
--- a/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
@@ -740,3 +740,70 @@ def test_async_loads_both_admitted_when_pool_fits():
 
     for req in reqs:
         assert req.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+
+def test_duplicate_finished_recving_is_ignored():
+    """A repeated finished_recving for an already-promoted request is dropped
+    rather than taking down the engine.
+
+    `MultiConnector` aggregates finished_recving from every sub-connector
+    without the de-duplication it applies to finished_sending, so a load
+    completed by one connector can be reported again by another one some steps
+    later. By then the request is running and its blocks are live, so they must
+    not be freed.
+    """
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+    BLOCK_SIZE = vllm_config.cache_config.block_size
+
+    request = create_request(
+        request_id=1,
+        block_size=BLOCK_SIZE,
+        num_tokens=int(BLOCK_SIZE * 2.5),
+        do_remote_prefill=True,
+    )
+    scheduler.add_request(request)
+    request_id = request.request_id
+    req_to_blocks = scheduler.kv_cache_manager.coordinator.single_type_managers[
+        0
+    ].req_to_blocks
+
+    # Park the request on the remote load, then complete that load.
+    scheduler_output = scheduler.schedule()
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
+
+    scheduler_output = scheduler.schedule()
+    scheduler.update_from_output(
+        scheduler_output,
+        create_model_runner_output(reqs=[], finished_recving={request_id}),
+    )
+
+    # The request is now live and holds the blocks it loaded into.
+    scheduler_output = scheduler.schedule()
+    assert len(scheduler.running) == 1
+    scheduler.update_from_output(
+        scheduler_output, create_model_runner_output([request])
+    )
+    assert request.status == RequestStatus.RUNNING
+    block_ids_before = [block.block_id for block in req_to_blocks[request_id]]
+
+    # A second connector reports the same load as finished.
+    scheduler_output = scheduler.schedule()
+    scheduler.update_from_output(
+        scheduler_output,
+        create_model_runner_output([request], finished_recving={request_id}),
+    )
+
+    assert request.status == RequestStatus.RUNNING
+    assert [block.block_id for block in req_to_blocks[request_id]] == block_ids_before
+    assert all(block.ref_cnt == 1 for block in req_to_blocks[request_id])
+
+    # The request still finishes cleanly and leaves no state behind.
+    scheduler_output = scheduler.schedule()
+    engine_core_outputs = scheduler.update_from_output(
+        scheduler_output, create_model_runner_output([request], use_eos=True)
+    )
+    scheduler.schedule()
+    assert engine_core_outputs[0].outputs[0].finish_reason == FinishReason.STOP
+    assert_scheduler_empty(scheduler)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -3018,9 +3018,19 @@ class Scheduler(SchedulerInterface):
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
-            else:
-                assert RequestStatus.is_finished(req.status)
+            elif RequestStatus.is_finished(req.status):
                 self._free_blocks(self.requests[req_id])
+            else:
+                # Duplicate signal: an earlier one already promoted the
+                # request. Its blocks are in use by a live request, so
+                # freeing them here would corrupt it.
+                logger.warning(
+                    "Ignoring duplicate finished_recving for request %s in "
+                    "state %s: a KV connector reported the same load as "
+                    "finished more than once.",
+                    req_id,
+                    req.status.name,
+                )
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
             assert req_id in self.requests


### PR DESCRIPTION
## Purpose

A KV connector that reports the same load as finished twice takes down EngineCore. Reported in #51786 against `MultiConnector` with `NixlConnector` + `LMCacheMPConnector` in a disaggregated P/D deployment; both of those connectors are in-tree, so this is a shipped configuration.

The first `finished_recving` promotes the request out of `WAITING_FOR_REMOTE_KVS`. By the time a second one arrives the request is `RUNNING`, which is neither waiting nor finished, so `_update_from_kv_xfer_finished` trips `assert RequestStatus.is_finished(req.status)` and the engine dies. `/health` stays green until the process goes down, and only a restart recovers.

This ignores the duplicate instead. Freeing the blocks in that branch is not an option — they belong to a request that is still running, so freeing them would corrupt it — hence the extra signal is logged and dropped.

`MultiConnector` is one way to produce this pairing: it aggregates `finished_recving` from every sub-connector with a bare set update, while `finished_sending` is de-duplicated through `_extra_async_saves` a few lines below. But any connector can emit a late or repeated completion, so the scheduler is the right place to be robust about it.

## Why this is not duplicating an existing PR

Three open PRs touch this function or its callers. I ran the regression test from this PR against each one's actual branch head; all three still crash with the same assertion:

| PR | branch head | result with this PR's test |
| --- | --- | --- |
| #53079 | `6a2dbe173` | `AssertionError` at `scheduler.py:2830` |
| #46304 | `1455c0507` | `AssertionError` at `scheduler.py:2458` |
| #51864 | `0ffb93238` | `AssertionError` at `scheduler.py:2824` |

#53079 and #46304 both handle the case where the request was aborted and is already gone from `self.requests`, and deliberately leave the status branch alone. That is a different code path from the one here, where the request is still present and still running. They are complementary to this change, not overlapping.

#51864 changes `MultiConnector` rather than the scheduler, so it does not touch this assertion at all.

## Test Plan

```
pytest tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
pytest tests/v1/kv_connector/unit/ -m cpu_test
pytest tests/v1/core/ -m cpu_test
pre-commit run --files vllm/v1/core/sched/scheduler.py tests/v1/kv_connector/unit/test_remote_prefill_lifecycle.py
```

## Test Result

`test_duplicate_finished_recving_is_ignored` fails on `main` at `vllm/v1/core/sched/scheduler.py:3022: AssertionError` — the assertion this PR removes — and passes with the change applied.

- `test_remote_prefill_lifecycle.py`: 10 passed
- `tests/v1/kv_connector/unit/ -m cpu_test`: 343 passed, 2 skipped (7 files skipped locally, they import `ray`)
- `tests/v1/core/ -m cpu_test`: 527 passed
- `pre-commit` on both changed files: all hooks pass, including mypy

Five failures showed up in those runs (2 in `test_config.py`, 2 in `test_kv_cache_utils.py`, 1 in `test_scheduler.py`). I re-ran each on a pristine tree with this branch's changes stashed and they fail identically there, so they are pre-existing in my environment and unrelated to this change.

No model evaluation is included because this change cannot affect model output: it only replaces an engine-fatal assertion with a logged no-op on a path that previously aborted the process.

## AI assistance

This change was developed with AI assistance (Claude Opus 5). I have reviewed every changed line, ran the tests above myself, and can defend the change end to end.
