### PR TITLE
[Bugfix][Kernel] Mamba: store a short prefill chunk's conv state in its own block

### DIFF
--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -392,3 +392,137 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+def _apc_prefill_chunk(
+    x_chunk,
+    weight,
+    bias,
+    conv_states,
+    cache_indices,
+    initial_state_idx,
+    block_idx_last,
+    num_computed_tokens,
+    block_size,
+    has_initial_state,
+):
+    """Run one prefill chunk of a single sequence through the prefix-caching path."""
+    device = conv_states.device
+    i32 = {"dtype": torch.int32, "device": device}
+    return causal_conv1d_fn(
+        x_chunk,
+        weight,
+        bias,
+        conv_states=conv_states,
+        query_start_loc=torch.tensor([0, x_chunk.shape[-1]], **i32),
+        cache_indices=torch.tensor([cache_indices], **i32),
+        has_initial_state=torch.tensor([has_initial_state], device=device),
+        activation="silu",
+        block_idx_first_scheduled_token=torch.tensor([block_idx_last], **i32),
+        block_idx_last_scheduled_token=torch.tensor([block_idx_last], **i32),
+        initial_state_idx=torch.tensor([initial_state_idx], **i32),
+        num_computed_tokens=torch.tensor([num_computed_tokens], **i32),
+        block_size_to_align=block_size,
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="the prefix-caching conv-state path is exercised on CUDA-alike only",
+)
+@pytest.mark.parametrize("dim", [64, 4096])
+@pytest.mark.parametrize("width", [4])
+def test_causal_conv1d_apc_short_chunk_writes_last_scheduled_block(dim, width):
+    """A prefill chunk shorter than the conv state must store to its own block.
+
+    With prefix caching the initial conv state is read from a shared prefix
+    block, which is not the block of the sequence's last scheduled token. A
+    chunk shorter than ``width - 1`` takes the "shift left" branch; if that
+    branch stores through the pointer it read the initial state from, the
+    sequence's own block is never written and the shared prefix block is
+    overwritten. The next chunk then convolves whatever bytes its block holds,
+    and every later sequence that reuses the prefix reads a corrupted state.
+    """
+    device = DEVICE
+    set_random_seed(0)
+    state_len = width - 1
+    block_size = 16
+    n_blocks = 4
+    dtype = torch.float32
+    # Blocks: 0 is the null block, 1 is the shared prefix block holding the
+    # initial state, 2 is the sequence's own block for the short chunk, 3 is
+    # its block for the chunk after that.
+    prefix_block, own_block, next_block = 1, 2, 3
+
+    weight = torch.randn(dim, width, device=device, dtype=dtype)
+    bias = torch.randn(dim, device=device, dtype=dtype)
+    initial_state = torch.randn(dim, state_len, device=device, dtype=dtype)
+    # (dim, tokens): the kernel takes x channel-last.
+    x = torch.randn(5, dim, device=device, dtype=dtype).T.contiguous()
+
+    def fresh_states():
+        states = torch.zeros(n_blocks, dim, state_len, device=device, dtype=dtype)
+        states[prefix_block] = initial_state
+        return states
+
+    # Reference: the same five tokens as one chunk long enough to take the
+    # regular branch, from the same initial state.
+    ref_states = fresh_states()
+    out_ref = _apc_prefill_chunk(
+        x,
+        weight,
+        bias,
+        ref_states,
+        cache_indices=[prefix_block, next_block],
+        initial_state_idx=0,
+        block_idx_last=1,
+        num_computed_tokens=block_size,
+        block_size=block_size,
+        has_initial_state=True,
+    )
+
+    states = fresh_states()
+    # Seed the sequence's own block with the bytes a released block can hold, so
+    # a missing store is loud rather than plausible.
+    states[own_block] = float("nan")
+
+    # Chunk A: two tokens, shorter than the three-token conv state.
+    out_a = _apc_prefill_chunk(
+        x[:, :2],
+        weight,
+        bias,
+        states,
+        cache_indices=[prefix_block, own_block],
+        initial_state_idx=0,
+        block_idx_last=1,
+        num_computed_tokens=block_size,
+        block_size=block_size,
+        has_initial_state=True,
+    )
+
+    assert torch.equal(states[prefix_block], initial_state), (
+        "the shared prefix block must not be written by a later sequence's chunk"
+    )
+    expected_own = torch.cat([initial_state[:, 2:], x[:, :2]], dim=-1)
+    assert torch.allclose(states[own_block], expected_own), (
+        "the short chunk's conv state must land in its own block"
+    )
+    assert torch.allclose(out_a, out_ref[:, :2], rtol=1e-4, atol=1e-4)
+
+    # Chunk B: the next three tokens, whose initial state is chunk A's block.
+    out_b = _apc_prefill_chunk(
+        x[:, 2:],
+        weight,
+        bias,
+        states,
+        cache_indices=[own_block, next_block],
+        initial_state_idx=0,
+        block_idx_last=1,
+        num_computed_tokens=block_size + 2,
+        block_size=block_size,
+        has_initial_state=True,
+    )
+    assert torch.isfinite(out_b).all()
+    assert torch.allclose(out_b, out_ref[:, 2:], rtol=1e-4, atol=1e-4), (
+        "two chunks over a cached prefix must equal the same tokens in one chunk"
+    )

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -202,6 +202,18 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
 
         # STEP 2:
         # here prepare data for updating conv_state
+        # The new conv state belongs to the block of the LAST scheduled token. With
+        # prefix caching enabled that is not the block the initial state was read
+        # from (conv_states_base), so resolve the destination once here and use it
+        # in every branch below.
+        conv_states_output_coord = tl.load(
+            conv_state_indices_ptr + idx_seq * stride_cache_indices + current_last_index
+        ).to(tl.int64)
+        conv_states_out_base = (
+            conv_states_ptr
+            + (conv_states_output_coord * stride_conv_state_seq)  # Offset from seq
+            + (idx_feats * stride_conv_state_dim)
+        )  # [BLOCK_N,]
         if (
             state_len <= seqlen
         ):  # SMALL_CACHE=True (only move part of 'x' into conv_state cache)
@@ -224,20 +236,10 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
             loaded_x = tl.load(x_ptrs, mask_x, 0.0)
             idx_tokens_conv = tl.arange(0, NP2_STATELEN)  # [BLOCK_M]
 
-            # Compute the offset where the last block should be written in the conv_states
-            conv_states_output_coord = tl.load(
-                conv_state_indices_ptr
-                + idx_seq * stride_cache_indices
-                + current_last_index
-            ).to(tl.int64)
-
             conv_states_ptrs_target = (
-                conv_states_ptr
-                + (conv_states_output_coord * stride_conv_state_seq)  # Offset from seq
-                + (idx_feats * stride_conv_state_dim)
-            )[None, :] + (  # [BLOCK_N,]
-                idx_tokens_conv * stride_conv_state_tok
-            )[:, None]
+                conv_states_out_base
+                + (idx_tokens_conv * stride_conv_state_tok)[:, None]
+            )  # [BLOCK_M, BLOCK_N]
 
             mask = (idx_tokens_conv < state_len)[:, None] & (idx_feats < dim)[None, :]
             tl.debug_barrier()  #  NOTE: use this due to bug in Triton compiler
@@ -280,7 +282,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
                     mask, conv_state, loaded_x
                 )  # BUG in 'tl.where'  which requires a barrier before this
                 conv_states_ptrs_target = (
-                    conv_states_base
+                    conv_states_out_base
                     + (idx_tokens_conv * stride_conv_state_tok)[:, None]
                 )  # [BLOCK_M, BLOCK_N]
                 mask = (idx_tokens_conv < state_len)[:, None] & (idx_feats < dim)[
@@ -307,7 +309,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
                 new_conv_state = tl.load(x_ptrs, mask_x, 0.0)
 
                 conv_states_ptrs_target = (
-                    conv_states_base
+                    conv_states_out_base
                     + (idx_tokens_conv * stride_conv_state_tok)[:, None]
                 )  # [BLOCK_M, BLOCK_N]
                 mask = (idx_tokens_conv < state_len)[:, None] & (idx_feats < dim)[


### PR DESCRIPTION
## Purpose

With prefix caching enabled, a Mamba prefill chunk shorter than the conv state writes
its new conv state into the shared prefix block instead of its own block.

`_causal_conv1d_fwd_kernel` reads a sequence's initial conv state from the block named
by `initial_state_idx` and writes the new state to the block named by
`block_idx_last_scheduled_token`. When a prefill chunk is shorter than the conv state
(`width - 1` tokens, so 3 for a width-4 model) the kernel takes one of two "shift left"
branches, and both stored through `conv_states_base`, the pointer the initial state was
read from:

```python
conv_states_ptrs_target = (
    conv_states_base
    + (idx_tokens_conv * stride_conv_state_tok)[:, None]
)  # [BLOCK_M, BLOCK_N]
```

With prefix caching those two blocks are different, and two things go wrong at once:

1. the sequence's own block is never written, so its next chunk convolves whatever bytes
   that block happens to hold;
2. the shared prefix block is overwritten, so every later sequence that reuses that
   prefix reads a conv state belonging to this one.

How visible it is depends on what the block holds. Zeros decode plausibly, a previous
occupant's state decodes as subtly wrong text, and non-finite bytes give NaN logits and a
tail of token 0. The last is how we found it: in a setup that leaves non-finite bytes in
freed blocks, affected requests came back as a run of `<unk>`.

The trigger is a scheduling accident rather than a property of a request: a chunked
prefill whose last chunk is a 2-token remainder of the token budget. A 1-token chunk is
routed as a decode by the Mamba metadata builder, so it does not reach this kernel. On
one production-shaped workload that was roughly 1 event in 2,300 first turns; with the
schedule forced to produce a 2-token chunk it is deterministic.

The fix resolves the destination block once at the top of the conv-state update and uses
it in all three branches. The `state_len <= seqlen` branch already computed the same
value inline, so this removes a duplicate rather than adding one. With prefix caching off
both indices are 0, so the resolved block is the block the code already used and behavior
is unchanged. The second short-chunk branch, the one with no initial state, is changed
for the same reason; we did not find a case where its two indices differ, and it is
changed so the two branches cannot drift apart.

Present on `main` at 41cffa9af0b7317d71838262004186b68e976773. I did not find an existing
issue for this. #53912 reports prefix-caching corruption on hybrid models with a
different attributed cause.

## Test Plan

`tests/kernels/mamba/test_causal_conv1d.py::test_causal_conv1d_apc_short_chunk_writes_last_scheduled_block`,
added in this PR, runs one sequence through the prefix-caching path as two chunks: a
2-token chunk whose initial state sits in a shared prefix block, then a 3-token chunk
whose initial state is the first chunk's own block. The sequence's own block is seeded
with NaN first, so a missing store is loud rather than plausible. It asserts that the
prefix block is untouched, that the sequence's own block holds the shifted state, and
that the two-chunk output equals the same five tokens convolved in one chunk.

```
pytest -q tests/kernels/mamba/test_causal_conv1d.py
pytest -q tests/kernels/mamba/
```

## Test Result

On one H100 with CUDA 13.0, torch 2.14.0 and triton 3.8.0:

| | result |
|---|---|
| new test on `main` without this fix | **2 failed**, on `the shared prefix block must not be written by a later sequence's chunk` |
| new test with this fix | **2 passed** |
| whole `test_causal_conv1d.py` with this fix | **166 passed**, 164 existing plus 2 new, 154 s |
| whole `tests/kernels/mamba/` with this fix | **no failures**, exit 0 under `-x` |

`pre-commit`'s pinned ruff 0.14.0 `check` and `format --check` are clean on both changed
files.

Separately, on a pinned older vLLM release carrying the same two branches, the equivalent
one-address change cleared a forced 2-token schedule that failed 9 of 9 trials unpatched
and 0 of 20 patched, and took a production-shaped load from 17 corruption events in
39,360 first turns to 0 in 10,240.

---

AI assistance: this change was drafted with Claude Code, and the commit carries a
`Co-authored-by:` trailer. Opening as a draft while I finish my own line-by-line
review of it; I will mark it ready for review once I have, and not before.
