### PR TITLE
[Bugfix][Attention] Support int4_per_token_head on non-power-of-two head sizes

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -508,6 +508,49 @@ def test_per_head_quant_scales_backend_selection(
             assert backend_name in str(exc_info.value)
 
 
+@pytest.mark.skipif(
+    CudaPlatform is None, reason="CUDA platform is required for this test"
+)
+@pytest.mark.parametrize("head_size", [64, 128, 256])
+def test_int4_per_token_head_accepts_power_of_two_head_size(head_size: int):
+    """INT4 per-token-head KV cache is selectable on power-of-two head sizes."""
+    vllm_config = VllmConfig(cache_config=CacheConfig(block_size=64))
+    with (
+        set_current_vllm_config(vllm_config),
+        patch("vllm.platforms.current_platform", CudaPlatform()),
+    ):
+        backend = get_attn_backend(
+            head_size=head_size,
+            dtype=torch.float16,
+            kv_cache_dtype="int4_per_token_head",
+        )
+        assert backend.get_name() == "TRITON_ATTN"
+
+
+@pytest.mark.skipif(
+    CudaPlatform is None, reason="CUDA platform is required for this test"
+)
+@pytest.mark.parametrize("head_size", [80, 96, 192])
+def test_int4_per_token_head_rejects_non_power_of_two_head_size(head_size: int):
+    """The INT4 write path rotates K/V with a Hadamard transform, which is only
+    defined on power-of-two rows, so such configs must fail at selection time
+    instead of crashing inside the kernel."""
+    vllm_config = VllmConfig(cache_config=CacheConfig(block_size=64))
+    with (
+        set_current_vllm_config(vllm_config),
+        patch("vllm.platforms.current_platform", CudaPlatform()),
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            get_attn_backend(
+                head_size=head_size,
+                dtype=torch.float16,
+                kv_cache_dtype="int4_per_token_head",
+            )
+        assert "int4_per_token_head requires a power-of-two head_size" in str(
+            exc_info.value
+        )
+
+
 @pytest.mark.parametrize(
     "backend_name,use_non_causal,should_succeed",
     [

--- a/vllm/utils/math_utils.py
+++ b/vllm/utils/math_utils.py
@@ -17,6 +17,11 @@ def next_power_of_2(n: int) -> int:
     return 1 if n < 1 else 1 << (n - 1).bit_length()
 
 
+def is_power_of_2(n: int) -> bool:
+    """Whether n is a power of 2."""
+    return n > 0 and n & (n - 1) == 0
+
+
 def round_up(x: int, y: int) -> int:
     """Round up x to the nearest multiple of y."""
     return ((x + y - 1) // y) * y

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -18,7 +18,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
-from vllm.utils.math_utils import next_power_of_2
+from vllm.utils.math_utils import is_power_of_2, next_power_of_2
 from vllm.utils.torch_utils import get_dtype_size, is_quantized_kv_cache
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -312,6 +312,26 @@ class TritonAttentionBackend(AttentionBackend):
         if block_size is None:
             return True
         return block_size % 16 == 0
+
+    @classmethod
+    def validate_configuration(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        kv_cache_dtype: CacheDType | None,
+        *args,
+        **kwargs,
+    ) -> list[str]:
+        invalid_reasons = super().validate_configuration(
+            head_size, dtype, kv_cache_dtype, *args, **kwargs
+        )
+        # INT4 rotates K/V with a Hadamard transform before packing, which is
+        # only defined on power-of-two rows.
+        if kv_cache_dtype == "int4_per_token_head" and not is_power_of_2(head_size):
+            invalid_reasons.append(
+                "int4_per_token_head requires a power-of-two head_size"
+            )
+        return invalid_reasons
 
     forward_includes_kv_cache_update: bool = False
 


### PR DESCRIPTION
## Purpose

Fixes #56197.

`--kv-cache-dtype int4_per_token_head` is accepted for every head size, but the
mode's write path rotates K/V with a Hadamard transform:

```
reshape_and_cache_int4 -> single_rht -> fast_hadamard_transform
  assert d & (d - 1) == 0, f"Requires power-of-2 dim, got {d}"
```

so a model with a non-power-of-two head size (e.g. 96) selected TRITON_ATTN,
logged "reduces the GPU memory footprint and boosts the performance", and then
aborted during engine initialization. The assertion is raised inside the
engine-core process, so the user only sees:

```
RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
```

This PR rejects the combination during backend selection instead:

```
ValueError: No valid attention backend found for cuda with
AttentionSelectorConfig(head_size=96, ..., kv_cache_dtype=int4_per_token_head, ...).
Reasons: {..., TRITON_ATTN: [int4_per_token_head requires a power-of-two head_size], ...}
```

Changes:

* `TritonAttentionBackend.validate_configuration` rejects
  `int4_per_token_head` when `head_size` is not a power of two.
* `vllm/utils/math_utils.py` gains `is_power_of_2` for the check.

No supported configuration changes behaviour: power-of-two head sizes still
select TRITON_ATTN exactly as before. (Padding the rotation to
`next_power_of_2(head_size)` would keep the config working instead; it costs up
to 2x extra work per row and is a separate policy decision.)

### Why this is not a duplicate

Checked on 2026-09-10 against `vllm-project/vllm`:

```
gh search issues -R vllm-project/vllm --include-prs "int4_per_token_head"     # no power-of-two item
gh search issues -R vllm-project/vllm --include-prs "Requires power-of-2 dim" # empty
gh search issues -R vllm-project/vllm --include-prs "power-of-two head_size"  # only old prefill-kernel items
gh pr list     -R vllm-project/vllm --state open --search "int4_per_token_head"
```

Open items in the same area and why they differ:

* #54341 "Stop advertising fp8_e5m2 where the KV writer stores e4m3" - same
  class of fix (backend advertising a dtype its writer cannot store), but a
  different dtype and a different constraint; it edits the
  `supported_kv_cache_dtypes` list, this PR adds a `head_size` check. The two
  touch disjoint regions of `triton_attn.py` and can land independently.
* #48842 / #48721 - `int4_per_token_head` crash with SWA models; different root
  cause (sliding-window metadata), not head size.
* #51091, #51691 - per-token-head scale-region init and KV-connector layout.
* #56164 - decoupled scale caches for 128B alignment (page layout), unrelated.

The assertion is still present on `origin/main` `2a02f6e`
(`vllm/v1/attention/ops/int4_per_token_head.py:1084`), and none of the four
files touched here changed between `94848ed` and `2a02f6e`.

## Test Plan

```bash
# new unit tests
pytest tests/kernels/attention/test_attention_selector.py -k int4_per_token_head -v

# whole file, with and without the patch
pytest tests/kernels/attention/test_attention_selector.py -q

# lint
pre-commit run --files vllm/utils/math_utils.py \
  vllm/v1/attention/backends/triton_attn.py \
  tests/kernels/attention/test_attention_selector.py
pre-commit run mypy-3.12 --files <same files> --hook-stage manual
```

End-to-end reproduction (synthetic Qwen2-shaped model, `head_dim=96`;
`int8_per_token_head` and `fp8_per_token_head` on the same model are the
controls):

```python
from transformers import Qwen2Config, Qwen2ForCausalLM
cfg = Qwen2Config(vocab_size=512, hidden_size=192, intermediate_size=256,
                  num_hidden_layers=2, num_attention_heads=2,
                  num_key_value_heads=1, head_dim=96,
                  max_position_embeddings=4096, tie_word_embeddings=True)
Qwen2ForCausalLM(cfg).save_pretrained("/tmp/tiny-hd96")
```

```python
from vllm import LLM, SamplingParams
llm = LLM(model="/tmp/tiny-hd96", kv_cache_dtype="int4_per_token_head",
          max_model_len=1024, gpu_memory_utilization=0.10)
llm.generate([{"prompt_token_ids": list(range(1, 65))}],
             SamplingParams(temperature=0.0, max_tokens=8, ignore_eos=True))
```

## Test Result

New tests: 6 passed

```
test_int4_per_token_head_accepts_power_of_two_head_size[64/128/256] PASSED
test_int4_per_token_head_rejects_non_power_of_two_head_size[80/96/192] PASSED
```

Whole selector file (H200, sm_90a, vLLM 0.29.0 wheel + these files from main):

```
with patch:    68 passed, 14 skipped, 13 errors
without patch: 65 passed, 14 skipped, 13 errors
               (+3 failures = the new rejection cases, nothing else changed)
```

The 13 errors are MLA-sparse backends that are absent from the 0.29.0 wheel used
for this run; the failure set is byte-identical with and without the patch.

Lint: `ruff-check`, `ruff-format`, `typos`, `mypy-3.10`, `mypy-3.12` (manual
stage), SPDX headers, root-lazy-imports, forbidden-imports, `torch.cuda` API,
config-defaults and boolean-context-manager hooks all pass.
`markdownlint-cli2` and `actionlint` were skipped: their hook environments need
node/Go downloads from this host (unrelated to the changed files).

End to end:

| command | before | after |
| --- | --- | --- |
| `tiny-hd96` + `int4_per_token_head` | `AssertionError: Requires power-of-2 dim, got 96` | `ValueError: ... TRITON_ATTN: [int4_per_token_head requires a power-of-two head_size]` |
| `tiny-hd96` + `int8_per_token_head` | PASS | PASS |
| `tiny-hd96` + `fp8_per_token_head` | PASS | PASS |
| Qwen2.5-1.5B-Instruct (`head_size=128`) + `int4_per_token_head` | PASS | PASS |

The crash also reproduces on the *unmodified* 0.29.0 release wheel, so it does
not depend on any local source overlay.

## Model evaluation

Not applicable: this change only affects a configuration that previously
aborted during engine initialization. No kernel, numerics, or supported serving
configuration is modified; no model output changes.

## AI assistance

This change was developed with AI assistance. The submitter has reviewed every
changed line and re-ran the commands above.
