### PR TITLE
[Bugfix][Pooling] Reject an empty cache_salt like every other endpoint

### DIFF
--- a/tests/entrypoints/pooling/test_cache_salt_validation.py
+++ b/tests/entrypoints/pooling/test_cache_salt_validation.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""`cache_salt` must reject the empty string on the pooling endpoints too.
+
+Every other protocol that accepts `cache_salt` pins ``min_length=1`` on it:
+completions, chat completions, responses, the Anthropic messages API and the
+scale-out protocol. The pooling mixin did not, and
+``generate_block_hash_extra_keys`` tests the salt for truthiness rather than
+for ``None``, so an empty salt produced no extra key at all and shared the
+unsalted namespace instead of being rejected.
+
+A client that emits `""` by mistake would therefore be silently sharing
+prefix-cache blocks with every unsalted request, which is the failure this
+parameter exists to prevent.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.pooling.embed.protocol import EmbeddingCompletionRequest
+
+MODEL = "any-model"
+PROMPT = "hello"
+
+
+def test_pooling_rejects_empty_cache_salt():
+    with pytest.raises(ValidationError):
+        EmbeddingCompletionRequest(model=MODEL, input=PROMPT, cache_salt="")
+
+
+def test_pooling_accepts_a_real_cache_salt():
+    request = EmbeddingCompletionRequest(
+        model=MODEL, input=PROMPT, cache_salt="tenant-a"
+    )
+    assert request.cache_salt == "tenant-a"
+
+
+def test_pooling_allows_cache_salt_to_be_omitted():
+    """Omission stays valid; only the empty string is rejected."""
+    assert EmbeddingCompletionRequest(model=MODEL, input=PROMPT).cache_salt is None
+
+
+def test_pooling_matches_completions_on_empty_cache_salt():
+    """The two endpoints should agree, which is the point of the change."""
+    with pytest.raises(ValidationError):
+        CompletionRequest(model=MODEL, prompt=PROMPT, cache_salt="")
+    with pytest.raises(ValidationError):
+        EmbeddingCompletionRequest(model=MODEL, input=PROMPT, cache_salt="")

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -71,6 +71,7 @@ class PoolingBasicRequestMixin(OpenAIBaseModel):
     )
     cache_salt: str | None = Field(
         default=None,
+        min_length=1,
         description=(
             "If specified, the prefix cache will be salted with the provided "
             "string to prevent an attacker to guess prompts in multi-user "


### PR DESCRIPTION
## Purpose

`cache_salt` pins `min_length=1` on every protocol that accepts it —
completions, chat completions, responses, the Anthropic messages API and the
scale-out protocol — except the pooling mixin, which omitted it.

That matters because `generate_block_hash_extra_keys` tests the salt for
truthiness rather than for `None`:

```python
cache_salt_keys: list[str] = (
    [request.cache_salt] if (start_token_idx == 0 and request.cache_salt) else []
)
```

An empty string is falsy, so it produces no extra key at all — identical to
sending no salt. Combined with the missing validation, `cache_salt: ""` on a
pooling endpoint is accepted and lands in the unsalted namespace rather than
being rejected.

A tenant whose client emits `""` by mistake is silently sharing prefix-cache
blocks with every unsalted request, which is the outcome the parameter exists
to prevent.

## Reproduction

Against `vllm serve --runner pooling --convert embed --enable-prefix-caching`,
warming the unsalted namespace and then probing it:

```
/v1/embeddings  cache_salt=""      -> HTTP 200, reused 128 tok   <- shares
/v1/embeddings  cache_salt="real"  -> HTTP 200, reused 0 tok     <- isolated
```

## Change

One line, `min_length=1` on `PoolingBasicRequestMixin.cache_salt`, so the
pooling endpoints reject the empty string with a 422 like every other endpoint
already does. Omission stays valid; only `""` is refused.

Four validation tests, no server or GPU needed. They fail without the one-line
change and pass with it — I checked by reverting it.

## Credit

Found by @rishabhsinha17 while reviewing #55886, which is the conformance suite
for `cache_salt` partitioning across entrypoints. Their suggestion was to fix
the footgun rather than pin the current behaviour in a test, which is what this
does. #55886 carries a matching arm as a strict xfail until this lands.
