### PR TITLE
[Refactor] Derive is_reasoning_end from the engine grammar

### DIFF
--- a/tests/parser/engine/test_gemma4_streaming_reasoning.py
+++ b/tests/parser/engine/test_gemma4_streaming_reasoning.py
@@ -1616,3 +1616,36 @@ class TestCommaInStringValueRegression:
         assert result.tools_called is True
         args = json.loads(result.tool_calls[0].function.arguments)
         assert args["destination"] == "456 Oakwood Avenue, Rivermist, 83214"
+
+
+class TestGemma4IsReasoningEnd:
+    @staticmethod
+    def _parser(thinking: bool):
+        return Gemma4Parser(
+            _make_tokenizer(_PLAIN_ANSWER_TOKENS),
+            chat_template_kwargs={"enable_thinking": thinking},
+        )
+
+    @pytest.mark.parametrize(
+        ("ids", "thinking", "ended"),
+        [
+            ([CHANNEL_START_ID, 3000, CHANNEL_END_ID], True, True),
+            ([CHANNEL_START_ID, 3000, TOOL_CALL_START_ID], True, True),
+            ([CHANNEL_START_ID, 3000], True, False),
+            ([NEW_TURN_ID, 9100], True, False),
+            ([CHANNEL_END_ID, NEW_TURN_ID, 9100], True, False),
+            ([NEW_TURN_ID, 9100], False, True),
+            # The bundled template's thinking-off prompt: closed channel.
+            ([NEW_TURN_ID, 9100, CHANNEL_START_ID, 3000, CHANNEL_END_ID], False, True),
+            # A marker still wins with thinking off: the grammar honours it.
+            ([CHANNEL_START_ID, 3000], False, False),
+            # A tool-call opener after the channel closed: still ended.
+            (
+                [CHANNEL_START_ID, 3000, CHANNEL_END_ID, TOOL_CALL_START_ID, 9200],
+                True,
+                True,
+            ),
+        ],
+    )
+    def test_is_reasoning_end(self, ids, thinking, ended):
+        assert self._parser(thinking).is_reasoning_end(ids) is ended

--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -180,9 +180,8 @@ class TestIsReasoningEnd:
         """Tool examples before the generation <think> must not end reasoning."""
         assert not parser.is_reasoning_end([_TOOL_CALL_ID, _TEXT_ID, _THINK_START_ID])
 
-    def test_paired_tool_call_not_end(self, parser):
-        """Paired <tool_call>...</tool_call> (from template) is NOT end."""
-        assert not parser.is_reasoning_end(
+    def test_completed_tool_call_after_open_think_is_end(self, parser):
+        assert parser.is_reasoning_end(
             [_THINK_START_ID, 1, _TOOL_CALL_ID, 2, _TOOL_CALL_END_ID]
         )
 
@@ -194,6 +193,43 @@ class TestIsReasoningEnd:
 
     def test_empty_ids(self, parser):
         assert not parser.is_reasoning_end([])
+
+
+class TestIsReasoningEndDerivedFromGrammar:
+    @pytest.mark.parametrize(
+        ("ids", "thinking", "ended"),
+        [
+            # Explicit close, and the implicit close on <tool_call>.
+            ([_THINK_START_ID, 1, _THINK_END_ID], True, True),
+            ([_THINK_START_ID, 1, _TOOL_CALL_ID], True, True),
+            # Still inside the block.
+            ([_THINK_START_ID, 1], True, False),
+            ([_THINK_END_ID, _THINK_START_ID, 1], True, False),
+            # Uncommitted: a bare turn, an empty sequence. Thinking on starts
+            # in REASONING, so reasoning is expected.
+            ([_IM_END_ID, _IM_START_ID, 1], True, False),
+            ([], True, False),
+            # Thinking off starts in CONTENT with no way into REASONING, so
+            # a <think> the template left behind is inert, and a silent tail
+            # is ended because no block is expected.
+            ([_THINK_START_ID, 1], False, True),
+            ([_THINK_END_ID, _THINK_START_ID, 1], False, True),
+            ([_IM_END_ID, _IM_START_ID, 1], False, True),
+            ([], False, True),
+        ],
+    )
+    def test_is_reasoning_end(self, mock_tokenizer, ids, thinking, ended):
+        parser = Qwen3Parser(
+            mock_tokenizer, chat_template_kwargs={"enable_thinking": thinking}
+        )
+        assert parser.is_reasoning_end(ids) is ended
+
+    @pytest.mark.parametrize("thinking", [True, False])
+    def test_wait_for_reasoning_follows_thinking(self, mock_tokenizer, thinking):
+        parser = Qwen3Parser(
+            mock_tokenizer, chat_template_kwargs={"enable_thinking": thinking}
+        )
+        assert parser.parser_engine_config.wait_for_reasoning is thinking
 
 
 class TestIsReasoningEndTurnBoundaries:

--- a/vllm/parser/deepseek_v32.py
+++ b/vllm/parser/deepseek_v32.py
@@ -53,6 +53,7 @@ def deepseek_v32_config() -> ParserEngineConfig:
     return ParserEngineConfig(
         name="deepseek_v32",
         initial_state=ParserState.CONTENT,
+        wait_for_reasoning=False,
         terminals={
             "TOOL_START": DSML_FUNC_START,
             "TOOL_END": DSML_FUNC_END,

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -128,6 +128,7 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
     return ParserEngineConfig(
         name="deepseek_v4",
         initial_state=ParserState.REASONING if thinking else ParserState.CONTENT,
+        wait_for_reasoning=thinking,
         terminals={
             "THINK_START": DSML_THINK_START,
             "THINK_END": DSML_THINK_END,

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -648,24 +648,28 @@ class ParserEngine(Parser):
         return None
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        end_id = self._reasoning_end_token_id
+        config = self.parser_engine_config
+        wait_for_reasoning = config.wait_for_reasoning
+        if wait_for_reasoning is None:
+            wait_for_reasoning = config.initial_state is ParserState.REASONING
+        start_transition = config.transitions.get((config.initial_state, "THINK_START"))
+        start_opens_reasoning = (
+            start_transition is not None
+            and start_transition.next_state is ParserState.REASONING
+        )
+        end_ids = self._reasoning_end_token_ids
         start_id = self._reasoning_start_token_id
-        if end_id is not None:
-            if not input_ids:
-                return self.parser_engine_config.initial_state != ParserState.REASONING
-            boundary_ids = self._turn_boundary_token_ids
-            for i in range(len(input_ids) - 1, -1, -1):
-                token_id = input_ids[i]
-                if token_id == end_id:
-                    return True
-                if start_id is not None and token_id == start_id:
+        boundary_ids = self._turn_boundary_token_ids
+        for token_id in reversed(input_ids):
+            if token_id in end_ids:
+                return True
+            if token_id == start_id:
+                if start_opens_reasoning:
                     return False
-                if token_id in boundary_ids:
-                    return (
-                        self.parser_engine_config.initial_state != ParserState.REASONING
-                    )
-            return False
-        return self._reasoning_ended
+                break
+            if token_id in boundary_ids:
+                break
+        return not wait_for_reasoning
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         end_id = self._reasoning_end_token_id

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -73,6 +73,8 @@ class ParserEngineConfig:
 
     initial_state: ParserState = ParserState.CONTENT
 
+    wait_for_reasoning: bool | None = None
+
     arg_converter: Callable[[str, bool], str] | None = None
 
     stream_arg_deltas: bool = True

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -293,10 +293,14 @@ def _gemma4_arg_converter(raw_args: str, partial: bool) -> str:
 
 
 @functools.cache
-def gemma4_config() -> ParserEngineConfig:
+def gemma4_config(thinking: bool = False) -> ParserEngineConfig:
     return ParserEngineConfig(
         name="gemma4",
         initial_state=ParserState.CONTENT,
+        # Decides a silent tail: the E-series HF templates write no marker
+        # with thinking off, and no template does after a tool response.
+        wait_for_reasoning=thinking,
+        turn_boundary_tokens=frozenset({"<|turn>", "<|tool_response>"}),
         terminals={
             "THINK_START": CHANNEL_START,
             "THINK_END": CHANNEL_END,
@@ -409,11 +413,11 @@ class Gemma4Parser(ParserEngine):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self._thinking_enabled = chat_kwargs.get("enable_thinking", False)
+        thinking = chat_kwargs.get("enable_thinking", False)
         super().__init__(
             tokenizer,
             tools,
-            parser_engine_config=gemma4_config(),
+            parser_engine_config=gemma4_config(thinking=thinking),
             **kwargs,
         )
         vocab = self.vocab
@@ -463,30 +467,6 @@ class Gemma4Parser(ParserEngine):
             delta_token_ids = [self._reasoning_start_token_id, *delta_token_ids]
 
         return delta_text, delta_token_ids
-
-    def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        end_id = self._reasoning_end_token_id
-        start_id = self._reasoning_start_token_id
-        tool_call_id = self._tool_call_token_id
-        new_turn_id = self._new_turn_token_id
-        tool_response_id = self._tool_response_token_id
-
-        if end_id is not None and not input_ids:
-            return self.parser_engine_config.initial_state != ParserState.REASONING
-
-        for i in range(len(input_ids) - 1, -1, -1):
-            tid = input_ids[i]
-            if start_id is not None and tid == start_id:
-                return False
-            if tool_call_id is not None and tid == tool_call_id:
-                return True
-            if new_turn_id is not None and tid == new_turn_id:
-                return not self._thinking_enabled
-            if tool_response_id is not None and tid == tool_response_id:
-                return not self._thinking_enabled
-            if end_id is not None and tid == end_id:
-                return True
-        return True
 
     def _prompt_ends_in_open_reasoning(self, prompt_token_ids: Sequence[int]) -> bool:
         """Whether the prompt tail is inside an open ``<|channel>`` block.

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -123,6 +123,7 @@ def glm47_moe_config(thinking: bool = True) -> ParserEngineConfig:
     return ParserEngineConfig(
         name="glm47_moe",
         initial_state=ParserState.REASONING if thinking else ParserState.CONTENT,
+        wait_for_reasoning=thinking,
         terminals={
             **reasoning_terminals,
             "TOOL_START": TOOL_CALL_START,
@@ -205,11 +206,6 @@ class Glm47MoeParser(ParserEngine):
         if 0 <= idx < len(self._tool_slots):
             self._tool_slots[idx].name = self._tool_slots[idx].name.strip()
         super()._handle_tool_end(event, deltas)
-
-    def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        if not self.thinking_enabled:
-            return True
-        return super().is_reasoning_end(input_ids)
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if not self.thinking_enabled:

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -282,6 +282,7 @@ def inkling_config() -> ParserEngineConfig:
         # `<|message_model|>`. Non-streaming parsing receives only the generated
         # suffix, so begin in the corresponding message-header state as well.
         initial_state=ParserState.MESSAGE_HEADER,
+        wait_for_reasoning=True,
         terminals=terminals,
         # Inkling content-kind markers are the grammar. When the engine is
         # used through DelegatingParser, the reasoning pass can hand the tool

--- a/vllm/parser/kimi_k2.py
+++ b/vllm/parser/kimi_k2.py
@@ -81,6 +81,7 @@ def kimi_k2_config(thinking: bool = True) -> ParserEngineConfig:
     return ParserEngineConfig(
         name="kimi_k2",
         initial_state=ParserState.REASONING if thinking else ParserState.CONTENT,
+        wait_for_reasoning=thinking,
         terminals={
             **reasoning_terminals,
             "TOOL_SECTION_START": TOOL_SECTION_START,
@@ -235,24 +236,6 @@ class KimiK2Parser(ParserEngine):
 
     def _extract_args_json(self, raw_args: str, func_name: str) -> str:
         return raw_args.strip() or "{}"
-
-    def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        if not self.thinking_enabled:
-            return True
-
-        start_id = self._start_token_id
-        end_id = self._end_token_id
-        tool_section_id = self._tool_section_start_token_id
-
-        for i in range(len(input_ids) - 1, -1, -1):
-            token_id = input_ids[i]
-            if start_id is not None and token_id == start_id:
-                return False
-            if end_id is not None and token_id == end_id:
-                return True
-            if tool_section_id is not None and token_id == tool_section_id:
-                return True
-        return False
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if not self.thinking_enabled:

--- a/vllm/parser/minimax_m2.py
+++ b/vllm/parser/minimax_m2.py
@@ -95,6 +95,7 @@ def minimax_m2_config() -> ParserEngineConfig:
     return ParserEngineConfig(
         name="minimax_m2",
         initial_state=ParserState.REASONING,
+        wait_for_reasoning=True,
         terminals={
             "THINK_START": THINK_START,
             "THINK_END": THINK_END,

--- a/vllm/parser/mistral.py
+++ b/vllm/parser/mistral.py
@@ -193,6 +193,7 @@ def mistral_config(
     return ParserEngineConfig(
         name=name,
         initial_state=ParserState.CONTENT,
+        wait_for_reasoning=reasoning_encoding != "none",
         terminals={
             **reasoning_terminals,
             "TOOL_CALLS": _TOOL_CALLS,
@@ -890,24 +891,6 @@ class MistralParser(ParserEngine):
                 delta_to_be_parsed += c
 
         return (delta_to_be_parsed, "")
-
-    def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        if self._reasoning_encoding == "none":
-            return True
-        if super().is_reasoning_end(input_ids):
-            return True
-        # [TOOL_CALLS] acts as an implicit reasoning-end marker
-        if self.bot_token_id is not None:
-            reasoning_start_id = self._reasoning_start_token_id
-            for i in range(len(input_ids) - 1, -1, -1):
-                if (
-                    reasoning_start_id is not None
-                    and input_ids[i] == reasoning_start_id
-                ):
-                    return False
-                if input_ids[i] == self.bot_token_id:
-                    return True
-        return False
 
     def extract_reasoning(
         self,

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -100,6 +100,7 @@ def qwen3_config(
     return ParserEngineConfig(
         name=name,
         initial_state=ParserState.REASONING if thinking else ParserState.CONTENT,
+        wait_for_reasoning=thinking,
         turn_boundary_tokens=turn_boundary_tokens,
         terminals={
             # Reasoning terminals
@@ -205,8 +206,8 @@ class Qwen3Parser(ParserEngine):
     """Qwen3 parser: ``<think>``/``</think>`` reasoning +
     ``<tool_call>`` XML tool calls in a single engine.
 
-    - ``<tool_call>`` as implicit reasoning end
-    - Unpaired ``<tool_call>`` token ID detection for ``is_reasoning_end``
+    - ``<tool_call>`` as implicit reasoning end (a grammar transition, so it
+      also feeds ``is_reasoning_end`` and the structured-output gate)
 
     Subclasses that share the grammar but differ only in the four wrapper
     token strings (reasoning + tool-call) override the class attributes
@@ -245,9 +246,6 @@ class Qwen3Parser(ParserEngine):
             tools,
             **kwargs,
         )
-        vocab = self.vocab
-        self._tool_call_token_id: int | None = vocab.get(self.TOOL_START)
-        self._tool_call_end_token_id: int | None = vocab.get(self.TOOL_END)
 
     def extract_reasoning(
         self,
@@ -257,28 +255,3 @@ class Qwen3Parser(ParserEngine):
         if not self.thinking_enabled:
             return None, model_output
         return super().extract_reasoning(model_output, request)
-
-    def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        if super().is_reasoning_end(input_ids):
-            return True
-        tool_call_id = self._tool_call_token_id
-        tool_call_end_id = self._tool_call_end_token_id
-        reasoning_start_id = self._reasoning_start_token_id
-        boundary_ids = self._turn_boundary_token_ids
-        if tool_call_id is not None:
-            for i in range(len(input_ids) - 1, -1, -1):
-                if (
-                    reasoning_start_id is not None
-                    and input_ids[i] == reasoning_start_id
-                ):
-                    return False
-                if input_ids[i] in boundary_ids:
-                    return False
-                if input_ids[i] == tool_call_id:
-                    if tool_call_end_id is not None and any(
-                        input_ids[j] == tool_call_end_id
-                        for j in range(i + 1, len(input_ids))
-                    ):
-                        continue
-                    return True
-        return False


### PR DESCRIPTION
## Purpose

### Context

vLLM often needs to answer one question about a list of token ids: **is the model still inside a reasoning block?** Two things depend on the answer:

- **Structured output.** When a request asks for JSON, the grammar must not be applied while the model is still thinking, or the model can never write its `<think>` block. The engine core asks `is_reasoning_end(prompt_token_ids)` once before generation, then checks each step.
- **Streaming.** Before the first token, the frontend asks the same question about the prompt to decide whether to start parsing in reasoning mode or content mode.

Both callers only have token ids. They have no text and have not fed anything into a parser. So `is_reasoning_end` has to be a plain function of the token ids.

### The problem: one grammar, three walkers
The question "what ends reasoning?" is answered in three places. Two derive from the grammar. The third is maintained by hand, per model — and it is the one the structured-output gate reads at prompt time.
<img width="853" height="325" alt="Screenshot 2026-09-10 at 1 55 41 AM" src="https://github.com/user-attachments/assets/d937a2a2-4700-4c6c-ac5e-17d9f1313988" />

### The design: one table, one executor, two projections

Every "what ends reasoning" fact now comes from the table. But the readers are not one machine: the frontend engine executes the table; the two id-only readers project it — and they read the same projected set. That shared node is the point of the drawing.
<img width="842" height="370" alt="Screenshot 2026-09-10 at 2 00 09 AM" src="https://github.com/user-attachments/assets/b3bc3e02-af18-4112-a77b-1aff482e00f9" />

## Test Plan

```
pytest tests/parser/ tests/reasoning/ tests/tool_parsers/
```

Beyond unit tests, the change was validated against real vLLM servers.

### Method

`is_reasoning_end(prompt_token_ids)` gates whether the guided-decoding bitmask applies from token 0 or is deferred. Both failure modes are silent (HTTP 200, normal `finish_reason`, nothing logged), so this was tested as an **A/B differential vs `main` (`c7e9816c6`)**: PR and `main` servers on separate GPUs, same requests at `temperature=0, seed=0` — any output difference is signal. Each pair was verified via `/proc/<pid>/maps` to have loaded different trees, so "identical" can't be a harness artifact.

Per model: plain chat / `json_schema` / tool calling, each × thinking on+off; after-tool-response turns; prior completed tool call + schema; `json_object`; forced `tool_choice`; streaming variants. Plus per-model probes: `tool_choice=required`, back-to-back tool calls, marker injection via user text, 5+ turn conversations, `continue_final_message` prefills, `structured_outputs` regex/choice/grammar, `include_reasoning=false`, `/v1/responses`.

### Results

| Model | Parser | Pairs | Result |
|---|---|---|---|
| `google/gemma-4-31B-it` | gemma4 | 41 | byte-identical |
| `google/gemma-4-E4B-it` | gemma4 (E-series) | 49 | byte-identical |
| `Qwen/Qwen3-8B` | qwen3 | ~90 | identical on all `add_generation_prompt` paths |
| `Qwen/Qwen3.6-27B-FP8` | qwen3 | 60 | byte-identical |
| `zai-org/GLM-4.7-Flash` | glm47 | 50 | byte-identical |
| `mistralai/Magistral-Small-2509` | mistral (`special_token`) | 61 | byte-identical |
| `gemma-4-E4B` via `/v1/responses` | gemma4 | 20 | byte-identical |
| offline: kimi_k2 / glm47-off / deepseek_v32 / inkling / mistral(special_token,none) / nemotron_v3 / ling3 | — | 369 | 0 disagreements |

Equivalence also confirmed mechanically: gemma4's derived `_reasoning_end_token_ids` = `{<channel|>, <|tool_call>}` and its new `turn_boundary_tokens` reproduce the deleted override's branches exactly; `kimi_k2` derives `{</think>, <|tool_calls_section_begin|>}`, matching its override term for term. `inkling`'s explicit `wait_for_reasoning=True` is load-bearing — the derived default would have made it constant `True`. `functools.cache` staleness ruled out by building configs in both orders.

### Bugs this PR fixes

| Case | `main` | this PR |
|---|---|---|
| GLM-4.7, `<tool_call>` tail, thinking+schema | fenced block, missing required key, 5 extra keys (172 tok) | conformant JSON (20 tok) |
| Qwen3-8B, 4 prefill shapes | free text / `location` instead of `city` | schema-valid |
| seed_oss, mimo, thinking off | grammar never applied | applied |
| Mistral-Small-3.2, thinking-off prefill | leading prose, violates schema | conformant |

### Reviewer notes

* `extract_content_ids` still scans only the singular `_reasoning_end_token_id` while `is_reasoning_end` uses the derived set — they disagree on a `<tool_call>`-terminated sequence. Nothing pairs them today.
* `<|tool_response>` in gemma4's new `turn_boundary_tokens` is inert — `grep -rn '"tool_responses"' vllm/` returns zero hits; `responses/utils.py:312-323` emits an ordinary `role: "tool"` message. `<|turn>` is live and load-bearing.
* `minimax_m2`, `glm47_moe`, `kimi_k2`, `deepseek_v4` declare no `turn_boundary_tokens`, so the unbounded backward scan can latch onto a tool-start token in the system prompt's own format example (shown on minimax_m2: index 173/235). Latent only because those templates end the generation prompt with a reasoning marker; `continue_final_message` breaks that shield. Declaring boundaries, as this PR does for gemma4, would close it.
* `seed_oss` requires #54264 (already on `main`), which adds `TURN_BOUNDARIES = frozenset(("<seed:bos>", "<seed:eos>"))`. Verified with this PR + #54264: boundaries resolve to `[0, 2]` and thinking-on + tools is unchanged from `main`. Rebasing onto a base older than #54264 would not be safe.