### PR TITLE
[Core] Add static linter for non_blocking CPU->GPU copies from unpinned tensors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -259,6 +259,14 @@ repos:
     language: python
     types: [python]
     additional_dependencies: [regex]
+  # Static analog of the runtime sync check landing in #53491: flag
+  # `non_blocking=True` CPU<->CUDA copies whose CPU side is an unpinned
+  # `torch.from_numpy(...)` / `torch.tensor(...)` construction.
+  - id: check-gpu-sync-patterns
+    name: "Flag non_blocking CPU->GPU copies from unpinned tensors"
+    entry: python tools/pre_commit/check_gpu_sync_patterns.py
+    language: python
+    types: [python]
   - id: validate-config
     name: Validate configuration has default values and that each field has a docstring
     entry: python tools/pre_commit/validate_config.py

--- a/tests/tools/test_check_gpu_sync_patterns.py
+++ b/tests/tools/test_check_gpu_sync_patterns.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for tools/pre_commit/check_gpu_sync_patterns.py."""
+
+# Load the linter as a module under test.
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_LINTER = _ROOT / "tools" / "pre_commit" / "check_gpu_sync_patterns.py"
+_spec = importlib.util.spec_from_file_location("check_gpu_sync_patterns", _LINTER)
+assert _spec is not None and _spec.loader is not None
+linter = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(linter)
+
+
+def _check(tmp_path: Path, source: str) -> int:
+    path = tmp_path / "sample.py"
+    path.write_text(textwrap.dedent(source), encoding="utf-8")
+    return linter.scan_file(str(path))
+
+
+# --- bad cases: the linter must flag ------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # from_numpy -> .to(cuda, non_blocking=True)
+        "torch.from_numpy(x).to(device, non_blocking=True)",
+        # from_numpy -> .cuda(non_blocking=True)
+        "torch.from_numpy(x).cuda(non_blocking=True)",
+        # explicit device="cpu" then push
+        'torch.tensor(indices, dtype=torch.int32, device="cpu")'
+        ".to(device, non_blocking=True)",
+        # no pin_memory kwarg — implicit unpinned
+        "torch.tensor(indices, dtype=torch.int32).to(device, non_blocking=True)",
+        # zeros() without pin_memory
+        "torch.zeros(1024).to(device, non_blocking=True)",
+        # .copy_(unpinned source)
+        "buf.copy_(torch.from_numpy(x), non_blocking=True)",
+        # .copy_(torch.tensor(list)) — no pin_memory
+        "buf.copy_(torch.tensor(indices, dtype=torch.int32), non_blocking=True)",
+    ],
+)
+def test_bad_cases_flagged(tmp_path: Path, snippet: str) -> None:
+    assert _check(tmp_path, snippet) == 1
+
+
+# --- good cases: the linter must stay silent ----------------------------- #
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # No non_blocking kwarg — different concern
+        "torch.from_numpy(x).to(device)",
+        # Explicit pin_memory=True
+        "torch.tensor(indices, pin_memory=True).to(device, non_blocking=True)",
+        # Truthy pin_memory reference (e.g., a module-level flag)
+        "torch.tensor(indices, pin_memory=PIN_MEMORY).to(device, non_blocking=True)",
+        # Constructed directly on device (device=some_name)
+        "torch.zeros(1024, device=device).to(device, non_blocking=True)",
+        # Constructed on a literal non-cpu device string
+        'torch.zeros(1024, device="cuda:0").to(device, non_blocking=True)',
+        # D2H via .to("cpu", non_blocking=True) — torch allocates a pinned dest
+        'gpu_t.to("cpu", non_blocking=True)',
+        # Escape hatch: gpu-sync-ok pragma
+        "torch.from_numpy(x).to(device, non_blocking=True)  # gpu-sync-ok: legacy",
+        # .copy_ from a variable — we can't statically prove unpinnedness
+        "buf.copy_(pinned_src, non_blocking=True)",
+        # .to without non_blocking — blocking copy, not this bug class
+        "torch.from_numpy(x).to(device)",
+    ],
+)
+def test_good_cases_silent(tmp_path: Path, snippet: str) -> None:
+    assert _check(tmp_path, snippet) == 0
+
+
+def test_pragma_only_mutes_its_own_line(tmp_path: Path) -> None:
+    source = """
+    torch.from_numpy(a).to(device, non_blocking=True)  # gpu-sync-ok: reason
+    torch.from_numpy(b).to(device, non_blocking=True)
+    """
+    assert _check(tmp_path, source) == 1  # still flags line without the pragma
+
+
+def test_syntax_error_returns_zero(tmp_path: Path) -> None:
+    # Malformed source shouldn't crash the linter or fail the file.
+    assert _check(tmp_path, "def broken(:\n") == 0

--- a/tests/utils_/test_gpu_sync_debug.py
+++ b/tests/utils_/test_gpu_sync_debug.py
@@ -162,7 +162,9 @@ def test_without_env_set(monkeypatch):
 
 def _pageable_h2d_nonblocking():
     # Pageable source: the "async" copy is staged through pageable memory.
-    torch.zeros(4).to("cuda", non_blocking=True)
+    torch.zeros(4).to(
+        "cuda", non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _pinned_h2d_nonblocking():
@@ -188,11 +190,15 @@ def _dtype_converting_h2d_nonblocking():
 
 
 def _pageable_h2d_via_cuda():
-    torch.zeros(4).cuda(non_blocking=True)
+    torch.zeros(4).cuda(
+        non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _pageable_h2d_via_copy_():
-    torch.zeros(4, device="cuda").copy_(torch.zeros(4), non_blocking=True)
+    torch.zeros(4, device="cuda").copy_(
+        torch.zeros(4), non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _d2h_via_to():
@@ -225,7 +231,9 @@ def _transposed_d2h_via_copy_():
 
 def _empty_h2d_nonblocking():
     # Empty (e.g. first-step penalties): no CUDA call is issued at all.
-    torch.zeros(0).to("cuda", non_blocking=True)
+    torch.zeros(0).to(
+        "cuda", non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _dtype_converting_d2h_via_copy_():

--- a/tools/pre_commit/check_gpu_sync_patterns.py
+++ b/tools/pre_commit/check_gpu_sync_patterns.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static detection of non_blocking CPU<->CUDA copies that silently sync.
+
+vLLM #53491 adds a runtime checker that raises when a `non_blocking=True`
+copy touches a CPU tensor that is not pinned or not densely laid out; the
+CUDA driver silently stages such copies through pageable memory and blocks
+the host, so the `non_blocking=True` hint is dropped. This script catches
+the two most common source-level shapes of that bug at commit time:
+
+    # (1) unpinned CPU tensor pushed H2D via .to / .cuda
+    torch.from_numpy(x).to(device, non_blocking=True)
+    torch.tensor([...], device="cpu").to(device, non_blocking=True)
+
+    # (2) unpinned CPU source used in .copy_(..., non_blocking=True)
+    gpu_buffer.copy_(torch.from_numpy(x), non_blocking=True)
+
+Both shapes should either route through `async_tensor_h2d`
+(vllm/utils/torch_utils.py) or set `pin_memory=PIN_MEMORY` on the CPU-side
+construction.
+
+Escape hatch: a `# gpu-sync-ok: <reason>` comment on the line where the call
+starts silences the check.
+"""
+
+import ast
+import sys
+
+# Torch tensor constructors that produce an unpinned CPU tensor by default.
+# `torch.from_numpy` never pins; the others need explicit `pin_memory=True`
+# (or a truthy `pin_memory=<var>`) to end up pinned.
+_ALWAYS_UNPINNED = frozenset({"from_numpy"})
+_UNPINNED_UNLESS_KWARG = frozenset(
+    {"tensor", "zeros", "empty", "ones", "full", "arange"}
+)
+
+_PRAGMA = "gpu-sync-ok"
+
+
+def _is_torch_ctor(expr: ast.AST, names: frozenset[str]) -> bool:
+    """Return True when `expr` is `torch.<name>(...)` for name in `names`."""
+    if not isinstance(expr, ast.Call):
+        return False
+    func = expr.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in names
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "torch"
+    )
+
+
+def _kwarg_is_truthy(call: ast.Call, key: str) -> bool:
+    """Return True when `call` has `key=<truthy>` (constant True or non-`False`
+    name reference like `PIN_MEMORY`)."""
+    for kw in call.keywords:
+        if kw.arg != key:
+            continue
+        value = kw.value
+        if isinstance(value, ast.Constant):
+            return bool(value.value)
+        # A bare Name (e.g. PIN_MEMORY) is treated as opt-in.
+        if isinstance(value, ast.Name):
+            return True
+        # Any other expression: treat as truthy (best-effort, we don't want
+        # false positives on `pin_memory=some_flag`).
+        return True
+    return False
+
+
+def _kwarg_equals(call: ast.Call, key: str, value: object) -> bool:
+    """Return True when `call` has `key=<constant value>`."""
+    for kw in call.keywords:
+        if kw.arg == key and isinstance(kw.value, ast.Constant):
+            return kw.value.value == value
+    return False
+
+
+def _produces_unpinned_cpu_tensor(expr: ast.AST) -> bool:
+    """Best-effort: does `expr` construct an unpinned CPU tensor?"""
+    if _is_torch_ctor(expr, _ALWAYS_UNPINNED):
+        return True
+    if _is_torch_ctor(expr, _UNPINNED_UNLESS_KWARG):
+        assert isinstance(expr, ast.Call)
+        if _kwarg_is_truthy(expr, "pin_memory"):
+            return False
+        # A tensor constructed directly on a non-CPU device isn't the CPU
+        # staging bug we are chasing. Treat `device=<anything except the
+        # literal string "cpu">` as non-CPU (a bare Name like `self.device`
+        # is almost always a device, and a false negative there is safer
+        # than a false positive that flags perfectly fine on-device work).
+        for kw in expr.keywords:
+            if kw.arg == "device":
+                # Explicit `device="cpu"` keeps this as an unpinned CPU
+                # construction; anything else means the tensor lands on a
+                # non-CPU device and is not our concern.
+                return (
+                    isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                    and kw.value.value == "cpu"
+                )
+        return True
+    return False
+
+
+def _targets_cuda(call: ast.Call) -> bool:
+    """Rough: does `.to(...)` / `.cuda(...)` land the tensor on CUDA?"""
+    func = call.func
+    assert isinstance(func, ast.Attribute)
+    if func.attr == "cuda":
+        return True
+    # `.to(device=..., ...)` — device kwarg wins.
+    for kw in call.keywords:
+        if kw.arg == "device":
+            return _value_looks_like_device(kw.value)
+    # `.to(<positional>, ...)` — first positional arg is the device.
+    if call.args:
+        return _value_looks_like_device(call.args[0])
+    return False
+
+
+def _value_looks_like_device(node: ast.AST) -> bool:
+    """`node` is a device argument. Return False only when we are sure it is
+    'cpu' — anything else (name reference, attribute like `self.device`,
+    formatted string) is assumed to be a CUDA-like destination."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value.lower() != "cpu"
+    return True
+
+
+class SyncPatternChecker(ast.NodeVisitor):
+    def __init__(self, path: str, source_lines: list[str]) -> None:
+        self.path = path
+        self.source_lines = source_lines
+        self.violations: list[tuple[int, str]] = []
+
+    def _call_muted(self, call: ast.Call) -> bool:
+        """Check the whole call span for a `gpu-sync-ok` comment.
+
+        Formatters routinely break a long call across lines and land the
+        trailing comment on the closing paren line, so checking only the
+        call's opening line loses the pragma. Iterate `lineno`..`end_lineno`
+        inclusive (Python 3.8+ populates `end_lineno`); if either is out of
+        range the check falls back to a no-mute rather than crashing.
+        """
+        start = getattr(call, "lineno", None)
+        end = getattr(call, "end_lineno", None) or start
+        if start is None:
+            return False
+        for lineno in range(start, end + 1):
+            if (
+                1 <= lineno <= len(self.source_lines)
+                and _PRAGMA in self.source_lines[lineno - 1]
+            ):
+                return True
+        return False
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            if func.attr in ("to", "cuda"):
+                self._check_h2d(node)
+            elif func.attr == "copy_":
+                self._check_copy(node)
+        self.generic_visit(node)
+
+    def _check_h2d(self, call: ast.Call) -> None:
+        if not _kwarg_equals(call, "non_blocking", True):
+            return
+        func = call.func
+        assert isinstance(func, ast.Attribute)
+        # Only flag when the destination is CUDA (or unknown, which we
+        # conservatively treat as CUDA). Explicit `.to("cpu")` is safe.
+        if not _targets_cuda(call):
+            return
+        if not _produces_unpinned_cpu_tensor(func.value):
+            return
+        if self._call_muted(call):
+            return
+        self.violations.append(
+            (
+                call.lineno,
+                (
+                    "unpinned CPU tensor pushed via `non_blocking=True`; the "
+                    "CUDA driver stages such copies through pageable memory "
+                    "and blocks the host (see #53491). Use "
+                    "`async_tensor_h2d(...)` from `vllm.utils.torch_utils` or "
+                    "pass `pin_memory=PIN_MEMORY` on the CPU-side "
+                    "construction. Suppress with a `# gpu-sync-ok: <reason>` "
+                    "comment on this line."
+                ),
+            )
+        )
+
+    def _check_copy(self, call: ast.Call) -> None:
+        if not _kwarg_equals(call, "non_blocking", True):
+            return
+        if not call.args:
+            return
+        source = call.args[0]
+        if not _produces_unpinned_cpu_tensor(source):
+            return
+        if self._call_muted(call):
+            return
+        self.violations.append(
+            (
+                call.lineno,
+                (
+                    "unpinned CPU source in `.copy_(..., non_blocking=True)`; "
+                    "same silent host stall as above (see #53491). Materialize "
+                    "the source via `np_to_pinned_tensor(...)` from "
+                    "`vllm.utils.torch_utils` or set `pin_memory=PIN_MEMORY` "
+                    "on the construction. Suppress with a "
+                    "`# gpu-sync-ok: <reason>` comment on this line."
+                ),
+            )
+        )
+
+
+def scan_file(path: str) -> int:
+    with open(path, encoding="utf-8") as f:
+        source = f.read()
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return 0
+    lines = source.splitlines()
+    checker = SyncPatternChecker(path, lines)
+    checker.visit(tree)
+    for lineno, msg in checker.violations:
+        print(f"{path}:{lineno}: \033[91merror:\033[0m {msg}")
+    return 1 if checker.violations else 0
+
+
+def main() -> int:
+    rc = 0
+    for path in sys.argv[1:]:
+        rc |= scan_file(path)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Static analog of the runtime sync checker landing in #53491: an AST-based `pre-commit` hook that flags `non_blocking=True` CPU->CUDA copies whose CPU side is an unpinned `torch.from_numpy(...)` / `torch.tensor(...)` construction. Catches the two most common source-level shapes of the bug class the sync sweep of the past few weeks (#54266, #54292, #54293, #54295, #54299, #54375, #54471) has been chasing:

```python
torch.from_numpy(x).to(device, non_blocking=True)
torch.tensor(indices, device="cpu").to(device, non_blocking=True)
buf.copy_(torch.from_numpy(x), non_blocking=True)
```

Author flow: at commit time, ruff-style error naming the file/line and pointing at `async_tensor_h2d(...)` / `np_to_pinned_tensor(...)` / `pin_memory=PIN_MEMORY`. A `# gpu-sync-ok: <reason>` comment on the offending line silences the check when the exception is genuinely wanted.

## Why static + runtime, not either alone

- #53491 fires only in CI and only when a test actually exercises the failing path. On code that is unit-tested via mocks or that only runs under specific model configurations, the runtime checker can miss regressions for weeks.
- This linter fires on every PR that touches Python files, before CI even starts, and is deterministic on the source alone. It cannot replace #53491 (dense-vs-gapped detection needs runtime tensor strides), but it does catch the pinned-source failures at the earliest possible layer.
- Zero hits on the current tree, so no cleanup PR is required.

## Scope

- Only Python source. C++/CUDA and shell code are out of scope.
- Only flags calls where the CPU-side tensor is constructed *inline* (`torch.from_numpy(x).to(...)` on one expression). We do not attempt to prove unpinnedness across variable assignments because that requires flow analysis and would either miss real bugs (`t = torch.from_numpy(x); t.to(...)`) or false-positive on pinned buffers passed as arguments. The runtime checker in #53491 covers the multi-line case.
- Only flags when the destination is CUDA (or unknown, which we conservatively treat as CUDA). Explicit `.to("cpu", non_blocking=True)` is not flagged; torch allocates a pinned destination for that case and the copy stays async.
- Pinned constructions (`pin_memory=True` or `pin_memory=PIN_MEMORY`) are silent, as are on-device constructions (`device=<anything except the literal "cpu">`).

## Verification

- Full-tree sweep: `find vllm -name "*.py" -not -path "*/third_party/*" | xargs python tools/pre_commit/check_gpu_sync_patterns.py` -> 0 hits (the recent sync sweep left the tree clean).
- Regression sanity: running the linter against pre-fix versions of the sites from #54292 / #54293 / #54295 / #54375 / #54471 flags all of them.
- Unit tests in `tests/tools/test_check_gpu_sync_patterns.py` cover 7 bad and 9 good shapes, plus the pragma escape hatch and syntax-error fallback.

## Follow-up work not in this PR

- **Strided-slice D2H/H2D detection**: matching `buf[i:j, k:l].copy_(...)` when the slice is gapped requires tensor-shape knowledge that is not statically available, so this shape is left to #53491's runtime check.
- **Cross-variable flow**: catching `t = torch.from_numpy(x); ...; t.to(cuda, non_blocking=True)` would need a lightweight escape analysis. Deferred until we see enough real regressions of that shape to justify the complexity.

## Duplicate-work check

Searched open PRs for `check_gpu_sync_patterns`, `sync linter`, and `#53491 in:body`; no overlap.

## Testing

- `.venv/bin/python -m pre_commit run --files tools/pre_commit/check_gpu_sync_patterns.py tests/tools/test_check_gpu_sync_patterns.py .pre-commit-config.yaml` — passed (ruff, ruff-format, mypy, typos, SPDX, plus the new hook running on itself).
- Inline case sweep against 7 bad + 9 good snippets — all correct classifications.

AI assistance was used for prototype scaffolding and test drafting; every line was reviewed by the submitter.
