### PR TITLE
[Core] Extend GPU sync linter with cross-variable flow analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -259,6 +259,14 @@ repos:
     language: python
     types: [python]
     additional_dependencies: [regex]
+  # Static analog of the runtime sync check landing in #53491: flag
+  # `non_blocking=True` CPU<->CUDA copies whose CPU side is an unpinned
+  # `torch.from_numpy(...)` / `torch.tensor(...)` construction.
+  - id: check-gpu-sync-patterns
+    name: "Flag non_blocking CPU->GPU copies from unpinned tensors"
+    entry: python tools/pre_commit/check_gpu_sync_patterns.py
+    language: python
+    types: [python]
   - id: validate-config
     name: Validate configuration has default values and that each field has a docstring
     entry: python tools/pre_commit/validate_config.py

--- a/tests/tools/test_check_gpu_sync_patterns.py
+++ b/tests/tools/test_check_gpu_sync_patterns.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for tools/pre_commit/check_gpu_sync_patterns.py."""
+
+# Load the linter as a module under test.
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_LINTER = _ROOT / "tools" / "pre_commit" / "check_gpu_sync_patterns.py"
+_spec = importlib.util.spec_from_file_location("check_gpu_sync_patterns", _LINTER)
+assert _spec is not None and _spec.loader is not None
+linter = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(linter)
+
+
+def _check(tmp_path: Path, source: str) -> int:
+    path = tmp_path / "sample.py"
+    path.write_text(textwrap.dedent(source), encoding="utf-8")
+    return linter.scan_file(str(path))
+
+
+# --- bad cases: the linter must flag ------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # from_numpy -> .to(cuda, non_blocking=True)
+        "torch.from_numpy(x).to(device, non_blocking=True)",
+        # from_numpy -> .cuda(non_blocking=True)
+        "torch.from_numpy(x).cuda(non_blocking=True)",
+        # explicit device="cpu" then push
+        'torch.tensor(indices, dtype=torch.int32, device="cpu")'
+        ".to(device, non_blocking=True)",
+        # no pin_memory kwarg — implicit unpinned
+        "torch.tensor(indices, dtype=torch.int32).to(device, non_blocking=True)",
+        # zeros() without pin_memory
+        "torch.zeros(1024).to(device, non_blocking=True)",
+        # .copy_(unpinned source)
+        "buf.copy_(torch.from_numpy(x), non_blocking=True)",
+        # .copy_(torch.tensor(list)) — no pin_memory
+        "buf.copy_(torch.tensor(indices, dtype=torch.int32), non_blocking=True)",
+    ],
+)
+def test_bad_cases_flagged(tmp_path: Path, snippet: str) -> None:
+    assert _check(tmp_path, snippet) == 1
+
+
+# --- good cases: the linter must stay silent ----------------------------- #
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # No non_blocking kwarg — different concern
+        "torch.from_numpy(x).to(device)",
+        # Explicit pin_memory=True
+        "torch.tensor(indices, pin_memory=True).to(device, non_blocking=True)",
+        # Truthy pin_memory reference (e.g., a module-level flag)
+        "torch.tensor(indices, pin_memory=PIN_MEMORY).to(device, non_blocking=True)",
+        # Constructed directly on device (device=some_name)
+        "torch.zeros(1024, device=device).to(device, non_blocking=True)",
+        # Constructed on a literal non-cpu device string
+        'torch.zeros(1024, device="cuda:0").to(device, non_blocking=True)',
+        # D2H via .to("cpu", non_blocking=True) — torch allocates a pinned dest
+        'gpu_t.to("cpu", non_blocking=True)',
+        # Escape hatch: gpu-sync-ok pragma
+        "torch.from_numpy(x).to(device, non_blocking=True)  # gpu-sync-ok: legacy",
+        # .copy_ from a variable — we can't statically prove unpinnedness
+        "buf.copy_(pinned_src, non_blocking=True)",
+        # .to without non_blocking — blocking copy, not this bug class
+        "torch.from_numpy(x).to(device)",
+    ],
+)
+def test_good_cases_silent(tmp_path: Path, snippet: str) -> None:
+    assert _check(tmp_path, snippet) == 0
+
+
+def test_pragma_only_mutes_its_own_line(tmp_path: Path) -> None:
+    source = """
+    torch.from_numpy(a).to(device, non_blocking=True)  # gpu-sync-ok: reason
+    torch.from_numpy(b).to(device, non_blocking=True)
+    """
+    assert _check(tmp_path, source) == 1  # still flags line without the pragma
+
+
+def test_syntax_error_returns_zero(tmp_path: Path) -> None:
+    # Malformed source shouldn't crash the linter or fail the file.
+    assert _check(tmp_path, "def broken(:\n") == 0

--- a/tests/tools/test_check_gpu_sync_patterns.py
+++ b/tests/tools/test_check_gpu_sync_patterns.py
@@ -91,3 +91,64 @@ def test_pragma_only_mutes_its_own_line(tmp_path: Path) -> None:
 def test_syntax_error_returns_zero(tmp_path: Path) -> None:
     # Malformed source shouldn't crash the linter or fail the file.
     assert _check(tmp_path, "def broken(:\n") == 0
+
+
+# --- cross-variable flow: two-line shape ---------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # Assign then push in the same function
+        """
+        def f(x):
+            t = torch.from_numpy(x)
+            return t.to(device, non_blocking=True)
+        """,
+        # Assign then use as .copy_ source
+        """
+        def f(buf, x):
+            src = torch.from_numpy(x)
+            buf.copy_(src, non_blocking=True)
+        """,
+        # Augmented assign preserves taint
+        """
+        def f(x):
+            t = torch.from_numpy(x)
+            t += 1
+            return t.to(device, non_blocking=True)
+        """,
+    ],
+)
+def test_two_line_bad_flagged(tmp_path: Path, snippet: str) -> None:
+    assert _check(tmp_path, snippet) == 1
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # Reassignment to a safe value clears the taint
+        """
+        def f(x):
+            t = torch.from_numpy(x)
+            t = safe_helper(t)
+            return t.to(device, non_blocking=True)
+        """,
+        # Taint doesn't cross function boundaries
+        """
+        def f(x):
+            t = torch.from_numpy(x)
+            def inner():
+                return t.to(device, non_blocking=True)
+            return inner
+        """,
+        # Tuple unpack from an unknown call — don't taint anything
+        """
+        def f(x):
+            a, b = something(x)
+            return a.to(device, non_blocking=True)
+        """,
+    ],
+)
+def test_two_line_good_silent(tmp_path: Path, snippet: str) -> None:
+    assert _check(tmp_path, snippet) == 0

--- a/tests/utils_/test_gpu_sync_debug.py
+++ b/tests/utils_/test_gpu_sync_debug.py
@@ -162,7 +162,9 @@ def test_without_env_set(monkeypatch):
 
 def _pageable_h2d_nonblocking():
     # Pageable source: the "async" copy is staged through pageable memory.
-    torch.zeros(4).to("cuda", non_blocking=True)
+    torch.zeros(4).to(
+        "cuda", non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _pinned_h2d_nonblocking():
@@ -188,11 +190,15 @@ def _dtype_converting_h2d_nonblocking():
 
 
 def _pageable_h2d_via_cuda():
-    torch.zeros(4).cuda(non_blocking=True)
+    torch.zeros(4).cuda(
+        non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _pageable_h2d_via_copy_():
-    torch.zeros(4, device="cuda").copy_(torch.zeros(4), non_blocking=True)
+    torch.zeros(4, device="cuda").copy_(
+        torch.zeros(4), non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _d2h_via_to():
@@ -225,7 +231,9 @@ def _transposed_d2h_via_copy_():
 
 def _empty_h2d_nonblocking():
     # Empty (e.g. first-step penalties): no CUDA call is issued at all.
-    torch.zeros(0).to("cuda", non_blocking=True)
+    torch.zeros(0).to(
+        "cuda", non_blocking=True
+    )  # gpu-sync-ok: fixture for runtime sync checker
 
 
 def _dtype_converting_d2h_via_copy_():

--- a/tools/pre_commit/check_gpu_sync_patterns.py
+++ b/tools/pre_commit/check_gpu_sync_patterns.py
@@ -133,6 +133,20 @@ class SyncPatternChecker(ast.NodeVisitor):
         self.path = path
         self.source_lines = source_lines
         self.violations: list[tuple[int, str]] = []
+        # Per-function tainted-name tracking. Each entry maps a bare local
+        # name (`t`) to the line where it was last bound to an unpinned CPU
+        # tensor construction; used to catch the two-line shape:
+        #     t = torch.from_numpy(x)
+        #     ...
+        #     t.to(device, non_blocking=True)
+        # A reassignment to any non-unpinned expression clears the name;
+        # augmented assignment leaves it alone. Inline calls (single-line
+        # shape) still route through `_check_h2d` / `_check_copy` directly.
+        self._scopes: list[dict[str, int]] = [{}]
+
+    @property
+    def _tainted(self) -> dict[str, int]:
+        return self._scopes[-1]
 
     def _call_muted(self, call: ast.Call) -> bool:
         """Check the whole call span for a `gpu-sync-ok` comment.
@@ -155,6 +169,65 @@ class SyncPatternChecker(ast.NodeVisitor):
                 return True
         return False
 
+    def _enter_scope(self) -> None:
+        self._scopes.append({})
+
+    def _exit_scope(self) -> None:
+        self._scopes.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self._enter_scope()
+        self.generic_visit(node)
+        self._exit_scope()
+
+    def visit_AsyncFunctionDef(  # noqa: N802
+        self, node: ast.AsyncFunctionDef
+    ) -> None:
+        self._enter_scope()
+        self.generic_visit(node)
+        self._exit_scope()
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:  # noqa: N802
+        self._enter_scope()
+        self.generic_visit(node)
+        self._exit_scope()
+
+    def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802
+        self.generic_visit(node)
+        tainted = _produces_unpinned_cpu_tensor(node.value)
+        for target in node.targets:
+            self._update_binding(target, tainted, node.lineno)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:  # noqa: N802
+        self.generic_visit(node)
+        if node.value is None:
+            # Bare annotation without a value doesn't establish a binding.
+            return
+        tainted = _produces_unpinned_cpu_tensor(node.value)
+        self._update_binding(node.target, tainted, node.lineno)
+
+    def visit_AugAssign(  # noqa: N802
+        self, node: ast.AugAssign
+    ) -> None:
+        # `t += ...` doesn't rebind `t` to a fresh construction, so leave
+        # any existing taint state alone.
+        self.generic_visit(node)
+
+    def _update_binding(self, target: ast.AST, tainted: bool, lineno: int) -> None:
+        if isinstance(target, ast.Name):
+            if tainted:
+                self._tainted[target.id] = lineno
+            else:
+                self._tainted.pop(target.id, None)
+        elif isinstance(target, ast.Tuple | ast.List):
+            # Tuple unpacking of a mixed-value construction: we can't tell
+            # which element is unpinned from the AST alone, so treat each
+            # target as safe. This trades a rare false negative for zero
+            # false positives on the common `a, b = ...` pattern.
+            for elt in target.elts:
+                if isinstance(elt, ast.Name):
+                    self._tainted.pop(elt.id, None)
+
     def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
         func = node.func
         if isinstance(func, ast.Attribute):
@@ -163,6 +236,12 @@ class SyncPatternChecker(ast.NodeVisitor):
             elif func.attr == "copy_":
                 self._check_copy(node)
         self.generic_visit(node)
+
+    def _source_is_unpinned(self, expr: ast.AST) -> bool:
+        """Inline construction OR a locally-tainted name."""
+        if _produces_unpinned_cpu_tensor(expr):
+            return True
+        return isinstance(expr, ast.Name) and expr.id in self._tainted
 
     def _check_h2d(self, call: ast.Call) -> None:
         if not _kwarg_equals(call, "non_blocking", True):
@@ -173,21 +252,23 @@ class SyncPatternChecker(ast.NodeVisitor):
         # conservatively treat as CUDA). Explicit `.to("cpu")` is safe.
         if not _targets_cuda(call):
             return
-        if not _produces_unpinned_cpu_tensor(func.value):
+        if not self._source_is_unpinned(func.value):
             return
         if self._call_muted(call):
             return
+        origin = self._origin_hint(func.value)
         self.violations.append(
             (
                 call.lineno,
                 (
-                    "unpinned CPU tensor pushed via `non_blocking=True`; the "
-                    "CUDA driver stages such copies through pageable memory "
-                    "and blocks the host (see #53491). Use "
-                    "`async_tensor_h2d(...)` from `vllm.utils.torch_utils` or "
-                    "pass `pin_memory=PIN_MEMORY` on the CPU-side "
-                    "construction. Suppress with a `# gpu-sync-ok: <reason>` "
-                    "comment on this line."
+                    f"unpinned CPU tensor{origin} pushed via "
+                    "`non_blocking=True`; the CUDA driver stages such copies "
+                    "through pageable memory and blocks the host (see "
+                    "#53491). Use `async_tensor_h2d(...)` from "
+                    "`vllm.utils.torch_utils` or pass "
+                    "`pin_memory=PIN_MEMORY` on the CPU-side construction. "
+                    "Suppress with a `# gpu-sync-ok: <reason>` comment on "
+                    "this line."
                 ),
             )
         )
@@ -198,23 +279,32 @@ class SyncPatternChecker(ast.NodeVisitor):
         if not call.args:
             return
         source = call.args[0]
-        if not _produces_unpinned_cpu_tensor(source):
+        if not self._source_is_unpinned(source):
             return
         if self._call_muted(call):
             return
+        origin = self._origin_hint(source)
         self.violations.append(
             (
                 call.lineno,
                 (
-                    "unpinned CPU source in `.copy_(..., non_blocking=True)`; "
-                    "same silent host stall as above (see #53491). Materialize "
-                    "the source via `np_to_pinned_tensor(...)` from "
-                    "`vllm.utils.torch_utils` or set `pin_memory=PIN_MEMORY` "
-                    "on the construction. Suppress with a "
-                    "`# gpu-sync-ok: <reason>` comment on this line."
+                    f"unpinned CPU source{origin} in "
+                    "`.copy_(..., non_blocking=True)`; same silent host "
+                    "stall as above (see #53491). Materialize the source "
+                    "via `np_to_pinned_tensor(...)` from "
+                    "`vllm.utils.torch_utils` or set "
+                    "`pin_memory=PIN_MEMORY` on the construction. Suppress "
+                    "with a `# gpu-sync-ok: <reason>` comment on this line."
                 ),
             )
         )
+
+    def _origin_hint(self, expr: ast.AST) -> str:
+        """Human-readable pointer to where the taint started, if any."""
+        if isinstance(expr, ast.Name) and expr.id in self._tainted:
+            src_line = self._tainted[expr.id]
+            return f" (bound at line {src_line})"
+        return ""
 
 
 def scan_file(path: str) -> int:

--- a/tools/pre_commit/check_gpu_sync_patterns.py
+++ b/tools/pre_commit/check_gpu_sync_patterns.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static detection of non_blocking CPU<->CUDA copies that silently sync.
+
+vLLM #53491 adds a runtime checker that raises when a `non_blocking=True`
+copy touches a CPU tensor that is not pinned or not densely laid out; the
+CUDA driver silently stages such copies through pageable memory and blocks
+the host, so the `non_blocking=True` hint is dropped. This script catches
+the two most common source-level shapes of that bug at commit time:
+
+    # (1) unpinned CPU tensor pushed H2D via .to / .cuda
+    torch.from_numpy(x).to(device, non_blocking=True)
+    torch.tensor([...], device="cpu").to(device, non_blocking=True)
+
+    # (2) unpinned CPU source used in .copy_(..., non_blocking=True)
+    gpu_buffer.copy_(torch.from_numpy(x), non_blocking=True)
+
+Both shapes should either route through `async_tensor_h2d`
+(vllm/utils/torch_utils.py) or set `pin_memory=PIN_MEMORY` on the CPU-side
+construction.
+
+Escape hatch: a `# gpu-sync-ok: <reason>` comment on the line where the call
+starts silences the check.
+"""
+
+import ast
+import sys
+
+# Torch tensor constructors that produce an unpinned CPU tensor by default.
+# `torch.from_numpy` never pins; the others need explicit `pin_memory=True`
+# (or a truthy `pin_memory=<var>`) to end up pinned.
+_ALWAYS_UNPINNED = frozenset({"from_numpy"})
+_UNPINNED_UNLESS_KWARG = frozenset(
+    {"tensor", "zeros", "empty", "ones", "full", "arange"}
+)
+
+_PRAGMA = "gpu-sync-ok"
+
+
+def _is_torch_ctor(expr: ast.AST, names: frozenset[str]) -> bool:
+    """Return True when `expr` is `torch.<name>(...)` for name in `names`."""
+    if not isinstance(expr, ast.Call):
+        return False
+    func = expr.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in names
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "torch"
+    )
+
+
+def _kwarg_is_truthy(call: ast.Call, key: str) -> bool:
+    """Return True when `call` has `key=<truthy>` (constant True or non-`False`
+    name reference like `PIN_MEMORY`)."""
+    for kw in call.keywords:
+        if kw.arg != key:
+            continue
+        value = kw.value
+        if isinstance(value, ast.Constant):
+            return bool(value.value)
+        # A bare Name (e.g. PIN_MEMORY) is treated as opt-in.
+        if isinstance(value, ast.Name):
+            return True
+        # Any other expression: treat as truthy (best-effort, we don't want
+        # false positives on `pin_memory=some_flag`).
+        return True
+    return False
+
+
+def _kwarg_equals(call: ast.Call, key: str, value: object) -> bool:
+    """Return True when `call` has `key=<constant value>`."""
+    for kw in call.keywords:
+        if kw.arg == key and isinstance(kw.value, ast.Constant):
+            return kw.value.value == value
+    return False
+
+
+def _produces_unpinned_cpu_tensor(expr: ast.AST) -> bool:
+    """Best-effort: does `expr` construct an unpinned CPU tensor?"""
+    if _is_torch_ctor(expr, _ALWAYS_UNPINNED):
+        return True
+    if _is_torch_ctor(expr, _UNPINNED_UNLESS_KWARG):
+        assert isinstance(expr, ast.Call)
+        if _kwarg_is_truthy(expr, "pin_memory"):
+            return False
+        # A tensor constructed directly on a non-CPU device isn't the CPU
+        # staging bug we are chasing. Treat `device=<anything except the
+        # literal string "cpu">` as non-CPU (a bare Name like `self.device`
+        # is almost always a device, and a false negative there is safer
+        # than a false positive that flags perfectly fine on-device work).
+        for kw in expr.keywords:
+            if kw.arg == "device":
+                # Explicit `device="cpu"` keeps this as an unpinned CPU
+                # construction; anything else means the tensor lands on a
+                # non-CPU device and is not our concern.
+                return (
+                    isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                    and kw.value.value == "cpu"
+                )
+        return True
+    return False
+
+
+def _targets_cuda(call: ast.Call) -> bool:
+    """Rough: does `.to(...)` / `.cuda(...)` land the tensor on CUDA?"""
+    func = call.func
+    assert isinstance(func, ast.Attribute)
+    if func.attr == "cuda":
+        return True
+    # `.to(device=..., ...)` — device kwarg wins.
+    for kw in call.keywords:
+        if kw.arg == "device":
+            return _value_looks_like_device(kw.value)
+    # `.to(<positional>, ...)` — first positional arg is the device.
+    if call.args:
+        return _value_looks_like_device(call.args[0])
+    return False
+
+
+def _value_looks_like_device(node: ast.AST) -> bool:
+    """`node` is a device argument. Return False only when we are sure it is
+    'cpu' — anything else (name reference, attribute like `self.device`,
+    formatted string) is assumed to be a CUDA-like destination."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value.lower() != "cpu"
+    return True
+
+
+class SyncPatternChecker(ast.NodeVisitor):
+    def __init__(self, path: str, source_lines: list[str]) -> None:
+        self.path = path
+        self.source_lines = source_lines
+        self.violations: list[tuple[int, str]] = []
+
+    def _call_muted(self, call: ast.Call) -> bool:
+        """Check the whole call span for a `gpu-sync-ok` comment.
+
+        Formatters routinely break a long call across lines and land the
+        trailing comment on the closing paren line, so checking only the
+        call's opening line loses the pragma. Iterate `lineno`..`end_lineno`
+        inclusive (Python 3.8+ populates `end_lineno`); if either is out of
+        range the check falls back to a no-mute rather than crashing.
+        """
+        start = getattr(call, "lineno", None)
+        end = getattr(call, "end_lineno", None) or start
+        if start is None:
+            return False
+        for lineno in range(start, end + 1):
+            if (
+                1 <= lineno <= len(self.source_lines)
+                and _PRAGMA in self.source_lines[lineno - 1]
+            ):
+                return True
+        return False
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            if func.attr in ("to", "cuda"):
+                self._check_h2d(node)
+            elif func.attr == "copy_":
+                self._check_copy(node)
+        self.generic_visit(node)
+
+    def _check_h2d(self, call: ast.Call) -> None:
+        if not _kwarg_equals(call, "non_blocking", True):
+            return
+        func = call.func
+        assert isinstance(func, ast.Attribute)
+        # Only flag when the destination is CUDA (or unknown, which we
+        # conservatively treat as CUDA). Explicit `.to("cpu")` is safe.
+        if not _targets_cuda(call):
+            return
+        if not _produces_unpinned_cpu_tensor(func.value):
+            return
+        if self._call_muted(call):
+            return
+        self.violations.append(
+            (
+                call.lineno,
+                (
+                    "unpinned CPU tensor pushed via `non_blocking=True`; the "
+                    "CUDA driver stages such copies through pageable memory "
+                    "and blocks the host (see #53491). Use "
+                    "`async_tensor_h2d(...)` from `vllm.utils.torch_utils` or "
+                    "pass `pin_memory=PIN_MEMORY` on the CPU-side "
+                    "construction. Suppress with a `# gpu-sync-ok: <reason>` "
+                    "comment on this line."
+                ),
+            )
+        )
+
+    def _check_copy(self, call: ast.Call) -> None:
+        if not _kwarg_equals(call, "non_blocking", True):
+            return
+        if not call.args:
+            return
+        source = call.args[0]
+        if not _produces_unpinned_cpu_tensor(source):
+            return
+        if self._call_muted(call):
+            return
+        self.violations.append(
+            (
+                call.lineno,
+                (
+                    "unpinned CPU source in `.copy_(..., non_blocking=True)`; "
+                    "same silent host stall as above (see #53491). Materialize "
+                    "the source via `np_to_pinned_tensor(...)` from "
+                    "`vllm.utils.torch_utils` or set `pin_memory=PIN_MEMORY` "
+                    "on the construction. Suppress with a "
+                    "`# gpu-sync-ok: <reason>` comment on this line."
+                ),
+            )
+        )
+
+
+def scan_file(path: str) -> int:
+    with open(path, encoding="utf-8") as f:
+        source = f.read()
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return 0
+    lines = source.splitlines()
+    checker = SyncPatternChecker(path, lines)
+    checker.visit(tree)
+    for lineno, msg in checker.violations:
+        print(f"{path}:{lineno}: \033[91merror:\033[0m {msg}")
+    return 1 if checker.violations else 0
+
+
+def main() -> int:
+    rc = 0
+    for path in sys.argv[1:]:
+        rc |= scan_file(path)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm/models/dots3_note/nvidia/attention.py
+++ b/vllm/models/dots3_note/nvidia/attention.py
@@ -19,7 +19,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.utils.torch_utils import is_quantized_kv_cache
+from vllm.utils.torch_utils import PIN_MEMORY, is_quantized_kv_cache
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionLayer,
@@ -231,8 +231,12 @@ def _build_sliding_window_metadata(
         query_lens = query_lens_cpu[req_start:req_end]
         kv_lens = kv_lens_cpu[req_start:req_end]
         num_reqs = req_end - req_start
-        cu_seq_lens_q_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
-        cu_seq_lens_k_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)
+        cu_seq_lens_q_cpu = torch.zeros(
+            num_reqs + 1, dtype=torch.int32, pin_memory=PIN_MEMORY
+        )
+        cu_seq_lens_k_cpu = torch.zeros(
+            num_reqs + 1, dtype=torch.int32, pin_memory=PIN_MEMORY
+        )
         torch.cumsum(query_lens, 0, out=cu_seq_lens_q_cpu[1:])
         torch.cumsum(kv_lens, 0, out=cu_seq_lens_k_cpu[1:])
         token_to_seq_cpu = torch.repeat_interleave(


### PR DESCRIPTION
## Summary

Follow-up to #56202. The base linter caught the **inline** shape:

```python
torch.from_numpy(x).to(device, non_blocking=True)   # flagged
```

This PR adds function-scope tainted-name tracking so the **two-line** shape is caught too:

```python
t = torch.from_numpy(x)
...
t.to(device, non_blocking=True)                     # now flagged
```

Tracking is per-function (each `FunctionDef` / `AsyncFunctionDef` / `Lambda` pushes a scope); reassignment to a non-unpinned value clears the binding, `t += ...` keeps it, `a, b = something()` never taints.

## Bugs surfaced (and fixed here)

Running the extended pass across the tree turned up two real sites in `vllm/models/dots3_note/nvidia/attention.py` that were silent under the inline-only pass:

```python
cu_seq_lens_q_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)   # unpinned
cu_seq_lens_k_cpu = torch.zeros(num_reqs + 1, dtype=torch.int32)   # unpinned
...
cu_seq_lens_q_cpu.to(device, non_blocking=True)   # silent pageable stall
cu_seq_lens_k_cpu.to(device, non_blocking=True)   # silent pageable stall
```

Both go into a sliding-window attention metadata dict that is consumed on the GPU, so the `non_blocking=True` hint is dropped and the stream stalls. Fix: `pin_memory=PIN_MEMORY` on the `torch.zeros` sites. Tree stays at zero hits after this lands.

## Stack

Stacked on #56202 — this PR only makes sense once the base file lands. If reviewers prefer to fold the two commits into one PR, happy to squash.

## Testing

- Extended `tests/tools/test_check_gpu_sync_patterns.py` with 3 bad + 3 good two-line snippets (reassignment clears taint, function boundaries block taint, tuple-unpack never taints).
- `.venv/bin/python -m pre_commit run --files tools/pre_commit/check_gpu_sync_patterns.py tests/tools/test_check_gpu_sync_patterns.py vllm/models/dots3_note/nvidia/attention.py` — passed.
- Full-tree sweep is zero hits after the `dots3_note/nvidia/attention.py` fix.

## Duplicate-work check

Only #56202 (base linter) is in flight. No other cross-variable sync detection PRs.

AI assistance was used for prototype scaffolding; every line was reviewed by the submitter.
