### PR TITLE
[Config] Actionable error hints when a draft model lacks SupportsPP

### DIFF
--- a/tests/config/test_pp_error_hints.py
+++ b/tests/config/test_pp_error_hints.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Focused tests for the pipeline-parallel `NotImplementedError` hints."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config.model import ModelConfig
+
+
+def _hint(architectures: list[str], is_draft_model: bool) -> str:
+    """Invoke `_pp_unsupported_message` against a minimal `self`."""
+    fake = SimpleNamespace(architectures=architectures)
+    return ModelConfig._pp_unsupported_message(
+        fake,  # type: ignore[arg-type]
+        is_draft_model=is_draft_model,
+    )
+
+
+def test_target_model_gets_short_message() -> None:
+    msg = _hint(["Llama3ForCausalLM"], is_draft_model=False)
+    assert "Pipeline parallelism is not supported for this model" in msg
+    assert "Llama3ForCausalLM" in msg
+    # Draft-only guidance must not appear for a plain target-model failure.
+    assert "draft" not in msg.lower()
+
+
+@pytest.mark.parametrize(
+    "arch",
+    [
+        "DeepSeekV4MTP",
+        "Qwen3_5MTP",
+        "KimiK3MTP",
+        "EagleLlamaForCausalLM",
+        "Eagle3Qwen3ForCausalLM",
+        "DFlashLagunaForCausalLM",
+        "DFlash2Qwen3ForCausalLM",
+        "Qwen3DSparkForCausalLM",
+    ],
+)
+def test_draft_looking_arch_gets_draft_hint(arch: str) -> None:
+    msg = _hint([arch], is_draft_model=False)
+    assert "speculative-decoding draft head" in msg
+    assert "SupportsPP" in msg
+    assert "make_empty_intermediate_tensors_factory" in msg
+    assert arch in msg
+
+
+def test_explicit_is_draft_forces_draft_hint() -> None:
+    # Architecture name that doesn't look like a draft on its own, but the
+    # caller (SpeculativeConfig._verify_args) says it is.
+    msg = _hint(["LlamaForCausalLM"], is_draft_model=True)
+    assert "speculative-decoding draft head" in msg
+    assert "SupportsPP" in msg
+
+
+def test_draft_hint_points_at_prior_fixes() -> None:
+    msg = _hint(["DeepSeekV4MTP"], is_draft_model=True)
+    # Point users at concrete precedent so they see the exact shape.
+    for pr in ("#52069", "#46994", "#53408", "#54635", "#55081"):
+        assert pr in msg

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -4,7 +4,7 @@
 from collections.abc import Callable
 from dataclasses import InitVar, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast, get_args
 
 import torch
 from pydantic import ConfigDict, Field, field_validator, model_validator
@@ -1417,6 +1417,8 @@ class ModelConfig:
     def verify_with_parallel_config(
         self,
         parallel_config: ParallelConfig,
+        *,
+        is_draft_model: bool = False,
     ) -> None:
         total_num_attention_heads = self.model_arch_config.total_num_attention_heads
         tensor_parallel_size = parallel_config.tensor_parallel_size
@@ -1435,8 +1437,7 @@ class ModelConfig:
             self.architectures, self
         ):
             raise NotImplementedError(
-                "Pipeline parallelism is not supported for this model. "
-                "Supported models implement the `SupportsPP` interface."
+                self._pp_unsupported_message(is_draft_model=is_draft_model)
             )
 
         decode_context_parallel_size = parallel_config.decode_context_parallel_size
@@ -1485,6 +1486,96 @@ class ModelConfig:
                 "data_parallel_size > 1 or tensor_parallel_size > 1 "
                 "or pipeline_parallel_size > 1."
             )
+
+    # Substring markers used only to shape the PP-unsupported error
+    # message; false positives here just produce a slightly more verbose
+    # hint on a plain target-model failure and never affect execution.
+    _DRAFT_ARCH_MARKERS: ClassVar[tuple[str, ...]] = (
+        "MTP",
+        "Mtp",
+        "Eagle",
+        "EAGLE",
+        "DFlash",
+        "DSpark",
+        "Drafter",
+    )
+
+    def _looks_like_draft_arch(self) -> bool:
+        """Best-effort: does at least one architecture entry look like a
+        speculative-decoding draft head (MTP / Eagle / DFlash / DSpark /
+        …)?"""
+        return any(
+            any(marker in arch for marker in self._DRAFT_ARCH_MARKERS)
+            for arch in (self.architectures or [])
+        )
+
+    def _pp_unsupported_message(self, *, is_draft_model: bool) -> str:
+        """Actionable error text for a PP>1 config whose model does not
+        implement `SupportsPP`.
+
+        We distinguish three cases:
+
+        * an explicit draft-model config (passed via ``is_draft_model``);
+        * a target-model config whose architecture *looks* like a draft
+          head (e.g. someone accidentally served ``ErnieMTP`` directly);
+        * every other target model.
+
+        The first two are the common self-serve pitfalls -- see #52069
+        for the full report and #46994 / #53408 / #54635 / #55081 for the
+        established fix pattern -- so we point users at the exact
+        modification instead of a generic "implement the interface" line.
+        """
+        base = (
+            "Pipeline parallelism is not supported for this model "
+            f"({self.architectures}). "
+            "Supported models implement the `SupportsPP` interface."
+        )
+        looks_draft = is_draft_model or self._looks_like_draft_arch()
+        if not looks_draft:
+            return base
+
+        return (
+            f"{base}\n"
+            "\n"
+            "This model looks like a speculative-decoding draft head. "
+            "The draft is only built on the last PP stage (see the "
+            "`is_last_pp_rank` guard in `vllm/v1/worker/gpu/model_runner.py`), "
+            "so the SupportsPP-shaped `forward` is never actually called "
+            "on it -- the mixin only satisfies the config verification "
+            "path that copies `pipeline_parallel_size` from the target "
+            "into `draft_parallel_config`. To fix on the draft class:\n"
+            "\n"
+            "    from vllm.model_executor.models.interfaces import SupportsPP\n"
+            "    from vllm.model_executor.models.utils import (\n"
+            "        make_empty_intermediate_tensors_factory,\n"
+            "    )\n"
+            "\n"
+            "    class YourDraft(nn.Module, SupportsPP):\n"
+            "        def __init__(self, *, vllm_config, prefix=''):\n"
+            "            super().__init__()\n"
+            "            ...\n"
+            "            self.make_empty_intermediate_tensors = (\n"
+            "                make_empty_intermediate_tensors_factory(\n"
+            "                    ['hidden_states', 'residual'],\n"
+            "                    self.config.hidden_size,\n"
+            "                )\n"
+            "            )\n"
+            "\n"
+            "        # MTP-shaped forward takes an extra positional "
+            "`hidden_states`;\n"
+            "        # the type ignore is needed because SupportsPP's "
+            "protocol\n"
+            "        # doesn't have that positional. It is never called "
+            "on the\n"
+            "        # draft under PP, so the Liskov violation is inert.\n"
+            "        def forward(  # type: ignore[override]\n"
+            "            self, input_ids, positions, hidden_states, ...\n"
+            "        ):\n"
+            "            ...\n"
+            "\n"
+            "See #52069 for the report and #46994 / #53408 / #54635 / "
+            "#55081 for landed instances of this exact pattern."
+        )
 
     def get_sliding_window(self) -> int | None:
         """Get the sliding window size from the HF text config if present."""

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1762,7 +1762,7 @@ class SpeculativeConfig:
 
         if self.draft_model_config:
             self.draft_model_config.verify_with_parallel_config(
-                self.draft_parallel_config
+                self.draft_parallel_config, is_draft_model=True
             )
 
         if self.use_heterogeneous_vocab and not self.uses_draft_model():


### PR DESCRIPTION
## Summary

The generic `NotImplementedError` from `ModelConfig.verify_with_parallel_config`:

```
NotImplementedError: Pipeline parallelism is not supported for this model.
Supported models implement the `SupportsPP` interface.
```

is not actionable for the common self-serve pitfall: trying to run a spec-decode draft head (MTP / Eagle / DFlash / DSpark) under PP>1. The class of failure has an established fix pattern — SupportsPP mixin + `make_empty_intermediate_tensors_factory` wire-up + `# type: ignore[override]` on the MTP-shaped forward — and there is landed precedent from the ongoing sweep (#46994 / #53408 / #54635 / #55081) plus an issue thread (#52069) explaining why. Show the user that fix inline when the failure looks like it came from a draft head, instead of asking them to search for it.

Every other target-model failure keeps the same short one-line error.

## When the extended hint fires

1. The caller passes `is_draft_model=True` — new keyword on `verify_with_parallel_config`, set by `SpeculativeConfig._verify_args` when it recurses into `draft_model_config`. Catches the case where the draft class name does not itself look like a draft head (e.g. Eagle drafters that inherit from `LlamaForCausalLM`).
2. Or at least one entry in `self.architectures` contains `MTP` / `Eagle` / `EAGLE` / `DFlash` / `DSpark` / `Drafter` as a substring. Catches the case where someone accidentally serves the draft class directly as the target model.

Substring markers are opt-in for the hint only; a false positive here just adds a few lines of guidance and never changes execution.

## What the extended hint contains

```
Pipeline parallelism is not supported for this model
(['DeepSeekV4MTP']). Supported models implement the
`SupportsPP` interface.

This model looks like a speculative-decoding draft head. The draft
is only built on the last PP stage (see the `is_last_pp_rank` guard
in `vllm/v1/worker/gpu/model_runner.py`), so the SupportsPP-shaped
`forward` is never actually called on it -- the mixin only satisfies
the config verification path that copies `pipeline_parallel_size`
from the target into `draft_parallel_config`. To fix on the draft
class:

    from vllm.model_executor.models.interfaces import SupportsPP
    from vllm.model_executor.models.utils import (
        make_empty_intermediate_tensors_factory,
    )

    class YourDraft(nn.Module, SupportsPP):
        def __init__(self, *, vllm_config, prefix=''):
            super().__init__()
            ...
            self.make_empty_intermediate_tensors = (
                make_empty_intermediate_tensors_factory(
                    ['hidden_states', 'residual'],
                    self.config.hidden_size,
                )
            )

        # MTP-shaped forward takes an extra positional `hidden_states`;
        # the type ignore is needed because SupportsPP's protocol
        # doesn't have that positional. It is never called on the
        # draft under PP, so the Liskov violation is inert.
        def forward(  # type: ignore[override]
            self, input_ids, positions, hidden_states, ...
        ):
            ...

See #52069 for the report and #46994 / #53408 / #54635 / #55081 for
landed instances of this exact pattern.
```

## Testing

- `tests/config/test_pp_error_hints.py` — 4 test functions, 8 parametrized architecture names covering MTP / Eagle / Eagle3 / DFlash / DFlash2 / DSpark, plus a check that every landed-precedent PR link appears when the hint fires.
- `.venv/bin/python -m pre_commit run --files vllm/config/model.py vllm/config/speculative.py tests/config/test_pp_error_hints.py` — passed.

## Duplicate-work check

Searched open PRs for `PP hint`, `draft model PP`, `#52069 in:body`. Only #46994 (parent) and my #53408 / #54635 / #55081 are in flight; none touch the error message.

AI assistance was used for the message and test scaffolding; every line was reviewed by the submitter.
