### PR TITLE
[Security] Honor num_frames in Molmo2 default video sampling

### DIFF
--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -369,6 +369,24 @@ def test_load_base64_jpeg_raises_on_zero_num_frames():
         videoio.load_base64("video/jpeg", data)
 
 
+def test_molmo2_backend_honors_num_frames(tmp_path):
+    """Request-selected molmo2 loader must not ignore a positive frame cap."""
+    image_path = get_vllm_public_assets(
+        filename="stop_sign.jpg", s3_prefix="vision_model_images"
+    )
+    video_path = tmp_path / "molmo2_cap.mp4"
+    create_video_from_image(str(image_path), str(video_path), num_frames=8, fps=8)
+
+    videoio = VideoMediaIO(
+        ImageMediaIO(),
+        num_frames=1,
+        video_backend="molmo2",
+    )
+    frames, _metadata = videoio.load_file(video_path)
+
+    assert frames.shape[0] == 1
+
+
 def test_pynvvideocodec_unrelated_error_propagates(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1249,6 +1249,42 @@ def test_torchcodec_backend_returns_target_frames_not_keyframes():
         )
 
 
+def _molmo2_source(total_frames: int, fps: float = 30.0) -> VideoSourceMetadata:
+    return VideoSourceMetadata(
+        total_frames_num=total_frames,
+        original_fps=fps,
+        duration=total_frames / fps if fps > 0 else 0.0,
+    )
+
+
+def test_molmo2_default_mode_honors_positive_num_frames():
+    """Unset frame_sample_mode must still respect target.num_frames."""
+    source = _molmo2_source(1800)
+    target = VideoTargetMetadata(num_frames=1, fps=-1, max_duration=-1)
+    idx = Molmo2VideoBackend.compute_frames_index_to_sample(source, target)
+
+    assert len(idx) == 1
+    assert 0 <= idx[0] < 1800
+
+
+def test_molmo2_default_mode_uniformly_caps_to_num_frames():
+    source = _molmo2_source(1800)
+    target = VideoTargetMetadata(num_frames=32, fps=-1, max_duration=-1)
+    idx = Molmo2VideoBackend.compute_frames_index_to_sample(source, target)
+
+    assert len(idx) == 32
+    assert idx[0] == 0
+    assert idx[-1] == 1799
+
+
+def test_molmo2_default_mode_keeps_all_frames_when_unlimited():
+    source = _molmo2_source(12)
+    target = VideoTargetMetadata(num_frames=-1, fps=-1, max_duration=-1)
+    idx = Molmo2VideoBackend.compute_frames_index_to_sample(source, target)
+
+    assert idx == list(range(12))
+
+
 @pytest.mark.parametrize(
     "loader_key, kwargs, expected_num_frames",
     [
@@ -1281,6 +1317,12 @@ def test_torchcodec_backend_returns_target_frames_not_keyframes():
         ),
         pytest.param(
             "openpangu", {"num_frames": 32, "fps": -1}, 32, id="openpangu-num_frames"
+        ),
+        pytest.param(
+            "molmo2",
+            {"num_frames": 1},
+            1,
+            id="molmo2-default-honors-num_frames",
         ),
         pytest.param(
             "molmo2",

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -1048,7 +1048,14 @@ class Molmo2VideoBackend(VideoLoader):
         max_fps = kwargs.get("max_fps")
         frame_sample_mode = kwargs.get("frame_sample_mode")
         if frame_sample_mode is None:
-            return list(range(0, source.total_frames_num))
+            total_num_frames = source.total_frames_num
+            num_frames = target.num_frames
+            if num_frames > 0:
+                n = min(num_frames, total_num_frames)
+                if n == total_num_frames:
+                    return list(range(total_num_frames))
+                return np.linspace(0, total_num_frames - 1, n, dtype=int).tolist()
+            return list(range(0, total_num_frames))
 
         if frame_sample_mode not in {"uniform_last_frame", "fps"}:
             raise NotImplementedError(


### PR DESCRIPTION
## Summary
The Molmo2 video loader's default sampling branch (`frame_sample_mode` unset) returned every source frame and ignored `VideoTargetMetadata.num_frames`. A client can select that CPU backend through request `media_io_kwargs` on an ordinary chat video request, so a small MP4 could expand into gigabytes of RGB even when `num_frames` was 1. This change uniformly samples at most `num_frames` when that cap is positive, and still returns all frames when the cap is unset (`num_frames <= 0`).

## Changes
- `vllm/multimodal/video.py`: honor a positive `num_frames` in `Molmo2VideoBackend.compute_frames_index_to_sample` when `frame_sample_mode` is omitted.
- `tests/multimodal/test_video.py`: unit and loader tests for capped, uniform, and unlimited default sampling.
- `tests/multimodal/media/test_video.py`: `VideoMediaIO` path with `video_backend=molmo2` and `num_frames=1`.

## Codepath coverage
- Chat / messages / responses via `MediaConnector.fetch_video` / `fetch_video_async` → `VideoMediaIO.load_bytes` / `load_file` / non-jpeg `load_base64` → Molmo2 loader: yes.
- Direct `Molmo2VideoBackend.load_bytes` (same `compute_frames_index_to_sample`): yes.
- Decoder backends that call `loader_cls.compute_frames_index_to_sample` (OpenCV/TorchCodec/etc.): yes.
- `video/jpeg` comma-split path: N/A (does not use the Molmo2 sampler).
- GPU request-level backend stripping: N/A (`molmo2` is a CPU backend).

## Duplicate-work check
Searched open and merged PRs for `Molmo2VideoBackend`, `compute_frames_index_to_sample`, `frame_sample_mode`, and `video_backend` / `num_frames`. https://github.com/vllm-project/vllm/pull/51969 clamps request-level `num_frames` so clients cannot raise the engine ceiling; it does not make Molmo2's default branch read that ceiling. Other open video PRs cover GLM sampling, empty indices, or explicit frame-index selection. No open or merged PR closes this sink.

## Tests
- `test_molmo2_default_mode_honors_positive_num_frames`
- `test_molmo2_default_mode_uniformly_caps_to_num_frames`
- `test_molmo2_default_mode_keeps_all_frames_when_unlimited`
- `test_video_loader_frames_sampling[molmo2-default-honors-num_frames]`
- `test_molmo2_backend_honors_num_frames`

Commands: `.venv/bin/pre-commit run --files <changed files>` (passed after ruff format); `.venv/bin/python -m pytest` on the tests above (7 passed).

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)