### PR TITLE
[Core][Diffusion] Add reduced sampling support for DiffusionGemma

### DIFF
--- a/tests/model_executor/test_diffusion_gemma_tp_sampling.py
+++ b/tests/model_executor/test_diffusion_gemma_tp_sampling.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from vllm.model_executor.models import diffusion_gemma as dg
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
+
+def _sampling_states(
+    *,
+    vocab_size: int,
+    logprobs: int = dg.NO_LOGPROBS,
+    seed_set: bool = False,
+    top_k: int | None = None,
+    top_p: float = 1.0,
+    min_p: float = 0.0,
+):
+    top_k_value = vocab_size if top_k is None else top_k
+    return SimpleNamespace(
+        vocab_size=vocab_size,
+        seeds_set=np.array([seed_set]),
+        top_k=SimpleNamespace(np=np.array([top_k_value], dtype=np.int32)),
+        top_p=SimpleNamespace(np=np.array([top_p], dtype=np.float32)),
+        min_p=SimpleNamespace(np=np.array([min_p], dtype=np.float32)),
+        max_num_logprobs=lambda slots: logprobs,
+    )
+
+
+def _local_sampler(
+    *,
+    vocab_size: int = 8,
+    canvas_length: int = 3,
+    tp_size: int = 2,
+    tp_rank: int = 0,
+    sc_vocab_start: int = 0,
+    sc_vocab_end: int = 4,
+    sampling_states=None,
+):
+    sampler = dg.DiffusionSampler.__new__(dg.DiffusionSampler)
+    sampler.vocab_size = vocab_size
+    sampler.canvas_length = canvas_length
+    sampler.tp_size = tp_size
+    sampler.tp_rank = tp_rank
+    sampler.sc_vocab_start = sc_vocab_start
+    sampler.sc_vocab_end = sc_vocab_end
+    sampler.embed_weight = torch.empty(sc_vocab_end - sc_vocab_start, 2)
+    sampler.sampling_states = sampling_states or _sampling_states(
+        vocab_size=vocab_size
+    )
+    return sampler
+
+
+def _input_batch(*, num_reqs: int = 1, num_draft_tokens: int = 3, num_logits=3):
+    return SimpleNamespace(
+        num_reqs=num_reqs,
+        num_draft_tokens=num_draft_tokens,
+        cu_num_logits_np=np.array([0, num_logits], dtype=np.int32),
+        idx_mapping_np=np.array([0], dtype=np.int32),
+    )
+
+
+def test_dense_compatible_local_uniform_consumes_full_vocab_rng():
+    device = torch.device("cpu")
+
+    torch.manual_seed(1234)
+    local = dg._dense_compatible_local_uniform((2, 3), 11, 4, 9, device)
+    next_after_local = torch.randint(0, 11, (2, 3), device=device)
+
+    torch.manual_seed(1234)
+    dense = torch.rand((2, 3, 11), device=device, dtype=torch.float32)
+    next_after_dense = torch.randint(0, 11, (2, 3), device=device)
+
+    torch.testing.assert_close(local, dense[..., 4:9])
+    assert torch.equal(next_after_local, next_after_dense)
+
+
+def test_global_token_argmax_breaks_tp_ties_by_lowest_global_id(monkeypatch):
+    local_values = torch.tensor([[5.0, 7.0, 1.0]])
+    local_indices = torch.tensor([[4, 5, 0]])
+    other_pair = torch.tensor([[[5.0, 2.0], [6.0, 1.0], [1.0, 7.0]]])
+
+    def fake_all_gather(tensor, tp_size, tp_group_name):
+        return torch.cat([tensor, other_pair], dim=-1)
+
+    monkeypatch.setattr(dg, "_tp_all_gather_last_dim", fake_all_gather)
+
+    tokens = dg._global_token_argmax(
+        local_values, local_indices, vocab_size=8, tp_size=2, tp_group_name="tp"
+    )
+
+    assert torch.equal(tokens, torch.tensor([[2, 5, 0]]))
+
+
+def test_local_sample_step_matches_dense_step_for_unsharded_vocab():
+    vocab_size = 7
+    canvas_length = 3
+    hidden_size = 4
+    stability_threshold = 2
+    logits = torch.randn(canvas_length, vocab_size)
+    embed_weight = torch.randn(vocab_size, hidden_size)
+    normalizer = torch.tensor(1.5)
+
+    def tensors():
+        return {
+            "canvas": torch.zeros(1, canvas_length, dtype=torch.int64),
+            "argmax_canvas": torch.zeros(1, canvas_length, dtype=torch.int64),
+            "step": torch.zeros(1, dtype=torch.int32),
+            "is_encoder_phase": torch.zeros(1, dtype=torch.bool),
+            "confident": torch.zeros(1, dtype=torch.bool),
+            "sc_embeds": torch.zeros(1, canvas_length, hidden_size),
+            "history": torch.zeros(
+                1, stability_threshold, canvas_length, dtype=torch.int64
+            ),
+            "history_len": torch.zeros(1, dtype=torch.int32),
+            "sampled": torch.zeros(1, canvas_length, dtype=torch.int32),
+            "num_sampled": torch.zeros(1, dtype=torch.int32),
+            "draft_tokens": torch.zeros(1, canvas_length, dtype=torch.int64),
+        }
+
+    common = {
+        "decode_slots": torch.tensor([0], dtype=torch.int64),
+        "decode_idx": torch.tensor([0], dtype=torch.int64),
+        "all_slots": torch.tensor([0], dtype=torch.int64),
+        "valid_canvas_len": torch.tensor([canvas_length], dtype=torch.int64),
+        "embed_weight": embed_weight,
+        "normalizer": normalizer,
+        "max_denoising_steps": 8.0,
+        "t_min": 0.2,
+        "t_max": 1.0,
+        "confidence_threshold": 100.0,
+        "vocab_size": vocab_size,
+        "CL": canvas_length,
+        "ST": stability_threshold,
+        "entropy_bound": 0.5,
+        "tp_size": 1,
+        "tp_group_name": "",
+    }
+
+    dense = tensors()
+    torch.manual_seed(123)
+    dense_sample_step = getattr(
+        dg._compiled_sample_step, "__wrapped__", dg._compiled_sample_step
+    )
+    dense_sample_step(
+        logits,
+        common["decode_slots"],
+        common["decode_idx"],
+        common["all_slots"],
+        common["valid_canvas_len"],
+        dense["canvas"],
+        dense["argmax_canvas"],
+        dense["step"],
+        dense["is_encoder_phase"],
+        dense["confident"],
+        dense["sc_embeds"],
+        common["embed_weight"],
+        common["normalizer"],
+        dense["history"],
+        dense["history_len"],
+        dense["sampled"],
+        dense["num_sampled"],
+        dense["draft_tokens"],
+        common["max_denoising_steps"],
+        common["t_min"],
+        common["t_max"],
+        common["confidence_threshold"],
+        common["vocab_size"],
+        common["CL"],
+        common["ST"],
+        common["entropy_bound"],
+        0,
+        vocab_size,
+        common["tp_size"],
+        common["tp_group_name"],
+    )
+    next_after_dense = torch.randint(0, vocab_size, (2,))
+
+    local = tensors()
+    torch.manual_seed(123)
+    dg._diffusion_gemma_local_sample_step(
+        logits,
+        common["decode_slots"],
+        common["decode_idx"],
+        common["all_slots"],
+        common["valid_canvas_len"],
+        local["canvas"],
+        local["argmax_canvas"],
+        local["step"],
+        local["is_encoder_phase"],
+        local["confident"],
+        local["sc_embeds"],
+        common["embed_weight"],
+        common["normalizer"],
+        local["history"],
+        local["history_len"],
+        local["sampled"],
+        local["num_sampled"],
+        local["draft_tokens"],
+        common["max_denoising_steps"],
+        common["t_min"],
+        common["t_max"],
+        common["confidence_threshold"],
+        common["vocab_size"],
+        common["CL"],
+        common["ST"],
+        common["entropy_bound"],
+        0,
+        vocab_size,
+        common["tp_size"],
+        common["tp_group_name"],
+    )
+    next_after_local = torch.randint(0, vocab_size, (2,))
+
+    assert torch.equal(next_after_local, next_after_dense)
+    for key in dense:
+        torch.testing.assert_close(local[key], dense[key])
+
+
+def test_local_logits_eligibility_fails_closed_for_full_vocab_consumers():
+    sampler = _local_sampler()
+    assert sampler.can_sample_local_logits(_input_batch())
+
+    assert not _local_sampler(
+        sampling_states=_sampling_states(vocab_size=8, logprobs=1)
+    ).can_sample_local_logits(_input_batch())
+    assert not _local_sampler(
+        sampling_states=_sampling_states(vocab_size=8, top_k=4)
+    ).can_sample_local_logits(_input_batch())
+    assert not _local_sampler(
+        sampling_states=_sampling_states(vocab_size=8, top_p=0.5)
+    ).can_sample_local_logits(_input_batch())
+    assert not _local_sampler(
+        sampling_states=_sampling_states(vocab_size=8, min_p=0.1)
+    ).can_sample_local_logits(_input_batch())
+    assert not _local_sampler(
+        sampling_states=_sampling_states(vocab_size=8, seed_set=True)
+    ).can_sample_local_logits(_input_batch())
+
+
+def test_local_logits_eligibility_fails_closed_for_geometry_and_routing():
+    assert not _local_sampler(tp_size=1).can_sample_local_logits(_input_batch())
+    assert not _local_sampler(vocab_size=9, sc_vocab_end=4).can_sample_local_logits(
+        _input_batch()
+    )
+    assert not _local_sampler(sc_vocab_start=1, sc_vocab_end=5).can_sample_local_logits(
+        _input_batch()
+    )
+    assert not _local_sampler().can_sample_local_logits(
+        _input_batch(num_logits=2)
+    )
+    assert not _local_sampler().can_sample_local_logits(
+        _input_batch(), grammar_output=object()
+    )
+
+
+def test_runner_uses_local_logits_only_after_sampler_accepts():
+    hidden_states = torch.randn(3, 2)
+    input_batch = SimpleNamespace(
+        num_reqs=1,
+        num_draft_tokens=3,
+        logits_indices=torch.tensor([0, 1, 2]),
+    )
+    output = SimpleNamespace(
+        num_sampled=torch.tensor([0]), num_rejected=torch.tensor([0])
+    )
+
+    class FakeSampler:
+        def __init__(self, enabled):
+            self.enabled = enabled
+            self.local_called = False
+            self.dense_called = False
+
+        def can_sample_local_logits(self, batch, grammar_output):
+            return self.enabled
+
+        def sample_local_logits(self, logits, batch):
+            self.local_called = True
+            assert logits.item() == 1
+            return output
+
+        def __call__(self, logits, batch):
+            self.dense_called = True
+            assert logits.item() == 2
+            return output
+
+    class FakeModel:
+        def __init__(self):
+            self.local_called = False
+            self.dense_called = False
+
+        def compute_diffusion_logits_local(self, states):
+            self.local_called = True
+            return torch.tensor(1)
+
+        def compute_logits(self, states):
+            self.dense_called = True
+            return torch.tensor(2)
+
+    runner = SimpleNamespace(
+        sampler=FakeSampler(enabled=True),
+        rejection_sampler=None,
+        model=FakeModel(),
+        batch_sharder=None,
+    )
+    sampler_output, _, _ = GPUModelRunner.sample(
+        runner, hidden_states, input_batch, grammar_output=None
+    )
+    assert sampler_output is output
+    assert runner.model.local_called
+    assert runner.sampler.local_called
+    assert not runner.model.dense_called
+
+    runner = SimpleNamespace(
+        sampler=FakeSampler(enabled=False),
+        rejection_sampler=None,
+        model=FakeModel(),
+        batch_sharder=None,
+    )
+    sampler_output, _, _ = GPUModelRunner.sample(
+        runner, hidden_states, input_batch, grammar_output=None
+    )
+    assert sampler_output is output
+    assert runner.model.dense_called
+    assert runner.sampler.dense_called
+    assert not runner.model.local_called

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -59,6 +59,7 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_scores
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.penalties import use_penalty
+from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS
 from vllm.v1.worker.gpu.states import RequestState
 
 from .interfaces import (
@@ -333,6 +334,15 @@ class DiffusionGemmaForConditionalGeneration(
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
         logits = self.logits_processor(self.lm_head, hidden_states)
         if logits is not None and self.final_logit_softcapping is not None:
+            logits = _softcap_logits(logits, self.final_logit_softcapping)
+        return logits
+
+    def compute_diffusion_logits_local(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        logits = self.logits_processor(self.lm_head, hidden_states, skip_gather=True)
+        assert logits is not None
+        if self.final_logit_softcapping is not None:
             logits = _softcap_logits(logits, self.final_logit_softcapping)
         return logits
 
@@ -657,6 +667,214 @@ def _compiled_sample_step(
     return scaled
 
 
+def _tp_all_reduce_sum(
+    tensor: torch.Tensor, tp_size: int, tp_group_name: str
+) -> torch.Tensor:
+    if tp_size == 1:
+        return tensor
+    return torch.ops.vllm.all_reduce(tensor, group_name=tp_group_name)
+
+
+def _tp_all_gather_last_dim(
+    tensor: torch.Tensor, tp_size: int, tp_group_name: str
+) -> torch.Tensor:
+    if tp_size == 1:
+        return tensor
+    return torch.ops.vllm.all_gather(tensor, -1, tp_size, group_name=tp_group_name)
+
+
+def _dense_compatible_local_uniform(
+    shape: tuple[int, int],
+    vocab_size: int,
+    vocab_start: int,
+    vocab_end: int,
+    device: torch.device,
+) -> torch.Tensor:
+    full = torch.rand((*shape, vocab_size), device=device, dtype=torch.float32)
+    return full[..., vocab_start:vocab_end]
+
+
+def _global_token_argmax(
+    local_values: torch.Tensor,
+    local_indices: torch.Tensor,
+    vocab_size: int,
+    tp_size: int,
+    tp_group_name: str,
+) -> torch.Tensor:
+    if tp_size == 1:
+        return local_indices
+
+    pair = torch.stack([local_values.float(), local_indices.float()], dim=-1)
+    gathered = _tp_all_gather_last_dim(pair, tp_size, tp_group_name)
+    gathered = gathered.view(*local_values.shape, tp_size, 2)
+    values = gathered[..., 0]
+    indices = gathered[..., 1].to(torch.int64)
+    max_values = values.max(dim=-1, keepdim=True).values
+    tied_indices = torch.where(values == max_values, indices, vocab_size)
+    return tied_indices.min(dim=-1).values
+
+
+def _diffusion_gemma_local_sample_step(
+    # Local logits from this TP rank [num_decode * CL, local_vocab]
+    local_logits: torch.Tensor,
+    # Request mapping
+    decode_slots: torch.Tensor,
+    decode_idx: torch.Tensor,
+    all_slots: torch.Tensor,
+    valid_canvas_len: torch.Tensor,
+    # State tensors (modified in-place)
+    canvas: torch.Tensor,
+    argmax_canvas: torch.Tensor,
+    step_tensor: torch.Tensor,
+    is_encoder_phase: torch.Tensor,
+    confident_tensor: torch.Tensor,
+    sc_embeds: torch.Tensor,
+    embed_weight: torch.Tensor,
+    normalizer: torch.Tensor,
+    history: torch.Tensor,
+    history_len_tensor: torch.Tensor,
+    # Output tensors (modified in-place)
+    sampled: torch.Tensor,
+    num_sampled: torch.Tensor,
+    draft_tokens: torch.Tensor,
+    # Scalar config
+    max_denoising_steps: float,
+    t_min: float,
+    t_max: float,
+    confidence_threshold: float,
+    vocab_size: int,
+    CL: int,
+    ST: int,
+    entropy_bound: float,
+    local_vocab_start: int,
+    local_vocab_end: int,
+    tp_size: int,
+    tp_group_name: str,
+) -> None:
+    num_decode = decode_slots.shape[0]
+    device = decode_slots.device
+
+    steps_f = step_tensor[decode_slots].float()
+    remaining = (max_denoising_steps - steps_f).clamp(min=1.0)
+    temp = t_min + (t_max - t_min) * (remaining / max_denoising_steps)
+
+    local_logits_3d = local_logits.reshape(num_decode, CL, -1).float()
+    scaled_local = local_logits_3d / temp[:, None, None].clamp(min=1e-10)
+
+    u_local = _dense_compatible_local_uniform(
+        (num_decode, CL), vocab_size, local_vocab_start, local_vocab_end, device
+    ).clamp(min=1e-20)
+    gumbel_local = -torch.log(-torch.log(u_local))
+    noisy_local = scaled_local + gumbel_local * (temp[:, None, None] > 0).float()
+
+    local_noisy_vals, local_noisy_idx = noisy_local.max(dim=-1)
+    local_argmax_vals, local_argmax_idx = scaled_local.max(dim=-1)
+    local_noisy_idx = local_noisy_idx + local_vocab_start
+    local_argmax_idx = local_argmax_idx + local_vocab_start
+    new_tokens = _global_token_argmax(
+        local_noisy_vals, local_noisy_idx, vocab_size, tp_size, tp_group_name
+    )
+    argmax_tokens = _global_token_argmax(
+        local_argmax_vals, local_argmax_idx, vocab_size, tp_size, tp_group_name
+    )
+
+    local_max = local_argmax_vals
+    gathered_max = _tp_all_gather_last_dim(
+        local_max.unsqueeze(-1), tp_size, tp_group_name
+    )
+    global_max = gathered_max.max(dim=-1).values
+    exp_shifted = torch.exp(scaled_local - global_max.unsqueeze(-1))
+    local_exp_sum = exp_shifted.sum(dim=-1)
+    local_exp_x_sum = (exp_shifted * scaled_local).sum(dim=-1)
+    stats = torch.stack([local_exp_sum, local_exp_x_sum], dim=-1)
+    stats = _tp_all_reduce_sum(stats, tp_size, tp_group_name)
+    global_exp_sum = stats[..., 0]
+    global_exp_x_sum = stats[..., 1]
+
+    token_entropy = (
+        torch.log(global_exp_sum) + global_max - global_exp_x_sum / global_exp_sum
+    )
+    mean_entropy = token_entropy.mean(dim=-1)
+    confident_tensor[decode_slots] = mean_entropy < confidence_threshold
+
+    sorted_ent, sorted_idx = torch.sort(token_entropy, dim=-1)
+    cumsum_ent = torch.cumsum(sorted_ent, dim=-1)
+    cummax_ent = torch.cummax(sorted_ent, dim=-1).values
+    sorted_mask = (cumsum_ent - cummax_ent) <= entropy_bound
+    eb_mask = torch.zeros_like(sorted_mask)
+    eb_mask.scatter_(1, sorted_idx, sorted_mask)
+
+    is_commit = is_encoder_phase[decode_slots]
+    is_denoise = ~is_commit
+    cur_step = step_tensor[decode_slots].float()
+    new_step_val = torch.where(
+        is_denoise,
+        (cur_step + 1).to(step_tensor.dtype),
+        step_tensor.new_zeros(num_decode),
+    )
+    step_tensor[decode_slots] = new_step_val
+
+    random_tokens = torch.randint(
+        0, vocab_size, (num_decode, CL), device=device, dtype=canvas.dtype
+    )
+    denoise_canvas = torch.where(eb_mask, new_tokens, random_tokens)
+    canvas[decode_slots] = torch.where(
+        is_commit.unsqueeze(1), random_tokens, denoise_canvas
+    )
+
+    hist_len = history_len_tensor[decode_slots]
+    write_pos = hist_len % ST
+    for i in range(ST):
+        write_here = ((write_pos == i) & is_denoise).unsqueeze(1)
+        history[decode_slots, i] = torch.where(
+            write_here, argmax_tokens, history[decode_slots, i]
+        )
+
+    argmax_canvas[decode_slots] = torch.where(
+        is_denoise.unsqueeze(1), argmax_tokens, argmax_canvas[decode_slots]
+    )
+
+    new_hist_len = torch.where(is_denoise, hist_len + 1, hist_len.new_zeros(num_decode))
+    history_len_tensor[decode_slots] = new_hist_len
+
+    sampled[decode_idx] = argmax_canvas[decode_slots].to(
+        sampled.dtype
+    ) * is_commit.unsqueeze(1).to(sampled.dtype)
+    num_sampled[decode_idx] = is_commit.to(num_sampled.dtype) * valid_canvas_len.to(
+        num_sampled.dtype
+    )
+
+    ref = history[decode_slots, 0]
+    mismatch = torch.zeros(num_decode, device=device, dtype=torch.int32)
+    for h in range(1, ST):
+        mismatch = mismatch + (ref != history[decode_slots, h]).sum(dim=-1).int()
+    stable = mismatch == 0
+
+    step_after = step_tensor[decode_slots]
+    converged = (stable & confident_tensor[decode_slots] & (new_hist_len >= ST)) | (
+        step_after >= max_denoising_steps
+    )
+    is_encoder_phase[decode_slots] = torch.where(
+        is_commit, is_commit.new_zeros(num_decode), converged
+    )
+
+    sc_keep = (is_denoise & ~is_encoder_phase[decode_slots])[:, None, None]
+    local_probs = (exp_shifted / global_exp_sum.unsqueeze(-1)).to(embed_weight.dtype)
+    soft_embeds = torch.matmul(
+        local_probs, embed_weight[: local_vocab_end - local_vocab_start]
+    )
+    soft_embeds = _tp_all_reduce_sum(soft_embeds, tp_size, tp_group_name)
+    soft_embeds = soft_embeds * normalizer
+    sc_embeds[decode_slots] = soft_embeds * sc_keep
+
+    newly_converged = (converged & is_denoise).unsqueeze(1)
+    canvas[decode_slots] = torch.where(
+        newly_converged, argmax_canvas[decode_slots], canvas[decode_slots]
+    )
+
+    draft_tokens[all_slots, :CL] = canvas[all_slots]
+
+
 class DiffusionGemmaRequestStates:
     """Pre-allocated GPU tensors for DiffusionGemma per-request state.
 
@@ -856,6 +1074,7 @@ class DiffusionGemmaModelState(ModelState):
             sc_vocab_start=shard.org_vocab_start_index,
             sc_vocab_end=shard.org_vocab_end_index,
             tp_size=tp_group.world_size,
+            tp_rank=tp_group.rank_in_group,
             tp_group_name=tp_group.unique_name,
         ), None
 
@@ -1064,6 +1283,7 @@ class DiffusionSampler:
         sc_vocab_start: int = 0,
         sc_vocab_end: int | None = None,
         tp_size: int = 1,
+        tp_rank: int = 0,
         tp_group_name: str = "",
     ):
         self.sampling_states = sampler.sampling_states
@@ -1079,6 +1299,7 @@ class DiffusionSampler:
         self.sc_vocab_start = sc_vocab_start
         self.sc_vocab_end = sc_vocab_end if sc_vocab_end is not None else vocab_size
         self.tp_size = tp_size
+        self.tp_rank = tp_rank
         self.tp_group_name = tp_group_name
         self.canvas_length = (
             diffusion_config.canvas_length if diffusion_config is not None else 32
@@ -1112,6 +1333,50 @@ class DiffusionSampler:
         # Populated after the post-sample kernel detects convergence; consumed
         # on the subsequent commit step when num_sampled=CANVAS_LEN.
         self._pending_logprobs: dict[int, LogprobsTensors] = {}
+
+    def _has_exact_local_vocab_shard(self) -> bool:
+        if self.tp_size <= 1:
+            return False
+        if self.vocab_size % self.tp_size != 0:
+            return False
+        local_vocab_size = self.vocab_size // self.tp_size
+        return (
+            self.sc_vocab_end - self.sc_vocab_start == local_vocab_size
+            and self.sc_vocab_start == self.tp_rank * local_vocab_size
+            and self.sc_vocab_end == (self.tp_rank + 1) * local_vocab_size
+            and self.embed_weight.shape[0] >= local_vocab_size
+        )
+
+    def can_sample_local_logits(
+        self, input_batch: Any, grammar_output: Any | None = None
+    ) -> bool:
+        if grammar_output is not None or input_batch.num_draft_tokens == 0:
+            return False
+        if not self._has_exact_local_vocab_shard():
+            return False
+        if input_batch.num_reqs != 1:
+            return False
+
+        per_req_nlogits_np = np.diff(
+            input_batch.cu_num_logits_np[: input_batch.num_reqs + 1]
+        )
+        if (
+            per_req_nlogits_np.shape[0] != 1
+            or per_req_nlogits_np[0] != self.canvas_length
+        ):
+            return False
+
+        slots_np = input_batch.idx_mapping_np[: input_batch.num_reqs]
+        states = self.sampling_states
+        if states.max_num_logprobs(slots_np) != NO_LOGPROBS:
+            return False
+        if np.any(states.seeds_set[slots_np]):
+            return False
+        if np.any(states.top_k.np[slots_np] != states.vocab_size):
+            return False
+        if np.any(states.top_p.np[slots_np] != 1.0):
+            return False
+        return not np.any(states.min_p.np[slots_np] != 0.0)
 
     def add_request(self, req_idx: int, prompt_len: int, sampling_params: Any) -> None:
         if use_penalty(sampling_params):
@@ -1424,4 +1689,77 @@ class DiffusionSampler:
             per_req_nlogits_np,
             device,
             logprobs_tensors=logprobs_tensors,
+        )
+
+    def sample_local_logits(
+        self,
+        local_logits: torch.Tensor,
+        input_batch: Any,
+    ) -> SamplerOutput:
+        num_reqs = input_batch.num_reqs
+        device = local_logits.device
+        states = self.diffusion_states
+        CL = self.canvas_length
+
+        per_req_nlogits_np = np.diff(input_batch.cu_num_logits_np[: num_reqs + 1])
+        decode_indices_np = np.where(per_req_nlogits_np > 0)[0]
+        decode_slots_np = input_batch.idx_mapping_np[:num_reqs][decode_indices_np]
+        num_decode = len(decode_indices_np)
+
+        self._decode_slots.np[:num_decode] = decode_slots_np
+        self._decode_idx.np[:num_decode] = decode_indices_np
+        self._decode_slots.copy_to_uva()
+        self._decode_idx.copy_to_uva()
+        decode_slots = self._decode_slots.gpu[:num_decode]
+        decode_idx = self._decode_idx.gpu[:num_decode]
+
+        valid_canvas_len_np = per_req_nlogits_np[per_req_nlogits_np > 0]
+        valid_canvas_len = async_copy_to_gpu(
+            valid_canvas_len_np.astype(np.int64), device=device
+        )
+
+        sampled = self._sampled[:num_reqs]
+        num_sampled = self._num_sampled[:num_reqs]
+        sampled.zero_()
+        num_sampled.zero_()
+
+        _diffusion_gemma_local_sample_step(
+            local_logits,
+            decode_slots,
+            decode_idx,
+            input_batch.idx_mapping[:num_reqs],
+            valid_canvas_len,
+            states.canvas,
+            states.argmax_canvas,
+            states.step,
+            states.is_encoder_phase,
+            states.confident,
+            states.self_conditioning_embeds,
+            self.embed_weight,
+            self.normalizer,
+            states.accepted_canvas_history,
+            states.accepted_canvas_history_len,
+            sampled,
+            num_sampled,
+            self.req_states.draft_tokens,
+            max_denoising_steps=float(states.max_denoising_steps),
+            t_min=self.t_min,
+            t_max=self.t_max,
+            confidence_threshold=self.confidence_threshold,
+            vocab_size=self.vocab_size,
+            CL=CL,
+            ST=states.stability_threshold,
+            entropy_bound=self.entropy_bound,
+            local_vocab_start=self.sc_vocab_start,
+            local_vocab_end=self.sc_vocab_end,
+            tp_size=self.tp_size,
+            tp_group_name=self.tp_group_name,
+        )
+
+        return self._build_output(
+            input_batch,
+            sampled,
+            num_sampled,
+            per_req_nlogits_np,
+            device,
         )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -22,7 +22,7 @@ import gc
 import time
 from contextlib import AbstractContextManager
 from copy import deepcopy
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, cast
 
 import numpy as np
 import torch
@@ -1467,7 +1467,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor]:
         shard_metadata = None
         global_input_batch = input_batch
-        if self.batch_sharder is not None:
+        can_sample_local_logits = getattr(self.sampler, "can_sample_local_logits", None)
+        compute_local_logits = getattr(
+            self.model, "compute_diffusion_logits_local", None
+        )
+        use_diffusion_local_logits = (
+            self.rejection_sampler is None
+            and callable(can_sample_local_logits)
+            and callable(compute_local_logits)
+            and can_sample_local_logits(input_batch, grammar_output)
+        )
+        if use_diffusion_local_logits:
+            sample_hidden_states = hidden_states[input_batch.logits_indices]
+            logits = compute_local_logits(sample_hidden_states)
+        elif self.batch_sharder is not None:
             # Shard the inputs along the batch dimension to sample in parallel
             # across TP ranks.
             input_batch, sorted_logits_indices, grammar_output, shard_metadata = (
@@ -1501,7 +1514,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             sampler_output = None
         elif input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:
             assert self.sampler is not None
-            sampler_output = self.sampler(logits, input_batch)
+            if use_diffusion_local_logits:
+                sampler_output = cast(Any, self.sampler).sample_local_logits(
+                    logits, input_batch
+                )
+            else:
+                sampler_output = self.sampler(logits, input_batch)
         else:
             # Rejection sampling for spec decoding.
             assert self.rejection_sampler is not None


### PR DESCRIPTION
> **Status:** This PR is now a standalone DiffusionGemma-specific change. #54332 is related generic reduced-sampling work, but is not a dependency of this PR.

## Summary

This PR adds a DiffusionGemma-specific vocabulary-stationary TP sampling path, keeping vocabulary-sharded logits local through the supported custom diffusion sampler instead of materializing replicated full-vocabulary logits and FP32 sampler intermediates on every TP rank.

The Diffusion-specific path:
- makes DiffusionGemma's final-logit softcap capturable inside `LogitsProcessor` while preserving FP32 semantics;
- adds pre-logits eligibility so unsupported cases fall back to the existing dense path before local-logit capture;
- computes distributed clean/noisy winners with deterministic lowest-global-token-ID tie breaking;
- computes entropy from distributed sufficient statistics;
- forms globally normalized local probabilities for the already-existing TP-local self-conditioning matmul + all-reduce;
- deliberately preserves the dense RNG trajectory by drawing the same full-shaped FP32 random tensor on every rank and consuming only the local vocabulary slice.

Request tiling and TP-local self-conditioning matmul/all-reduce are already upstream and are not reintroduced here. This PR also does not add a second generic reduced-sampling framework.

## Scope / fallback

The initial scope is deliberately narrow: TP > 1, one active request, and standard contiguous/equal vocabulary shards.

Grammar, requested logprobs/logprob token IDs, top-k, top-p, min-p, multi-request sampling, TP1, and unsupported shard geometries select the existing dense `compute_logits` path before `compute_local_logits` is attempted.

Exact RNG preservation is intentional; RNG compression is out of scope.

## Motivation

DiffusionGemma sampling operates over `[num_decode, canvas_length, vocab_size]`. The full logits plus FP32 scaled/Gumbel/probability intermediates create a substantial replicated-memory floor per TP rank. This is related to the sampler memory pressure discussed in #50699. Request tiling reduces the multi-request multiplier but does not eliminate the single-request full-vocabulary floor.

## Validation

Source-bound TP8 component/integration validation used Ascend 910B2 with `CL=256`, `V=262144`, and `H=2816`, with real BF16 local LM-head projections producing `[256, 32768]` logits per rank.

- 8/8 ranks matched the dense oracle for primary sampler/state outputs.
- Clean and noisy/Gumbel token IDs matched, including lowest-global-ID ties.
- Next `randint`, RNG state, and cross-rank RNG synchronization matched.
- A 255-token visible canvas padded to 256 also matched.
- No full-vocabulary logits gather occurred on the supported local path.
- Matched TP8 self-conditioning embedding max-abs was `0.00390625` (acceptance threshold `<= 0.005`).
- Unsupported-feature probes selected dense `compute_logits` before local capture.

Source-bound component measurements:
- median latency: `20.187 ms` dense vs `12.496 ms` local (~38.1% lower);
- peak-extra HBM: `2,523,837,440` bytes dense vs `980,324,864` bytes local (~61.2% lower).

These are **source-bound component measurements, not a full-model E2E or production performance claim**.

Focused numerical-equivalence, eligibility, static, and source-level rebase-equivalence checks also passed. Standard local pytest collection was unavailable on the development host because `tblib` was missing; CI results are pending.

## Related work

#54332 (`[Core] Add reduced sampling for tensor-parallel decoding`) is related generic reduced-sampling work, but this PR does not depend on it. The implementation here remains deliberately DiffusionGemma-specific and does not introduce a competing generic reduced-sampling framework.
