### PR TITLE
[Bugfix][Beam Search] Respect skip_special_tokens during decoding

### DIFF
--- a/tests/samplers/test_beam_search_online.py
+++ b/tests/samplers/test_beam_search_online.py
@@ -11,8 +11,13 @@ from vllm.sampling_params import BeamSearchParams
 
 class _Tokenizer:
     eos_token_id = 0
+    special_token_id = eos_token_id
 
-    def decode(self, token_ids: list[int]) -> str:
+    def decode(self, token_ids: list[int], skip_special_tokens: bool = False) -> str:
+        if skip_special_tokens:
+            token_ids = [
+                token_id for token_id in token_ids if token_id != self.special_token_id
+            ]
         return " ".join(str(token_id) for token_id in token_ids)
 
 
@@ -72,3 +77,34 @@ async def test_beam_search_handles_extra_logprob_candidates() -> None:
     assert outputs[0].outputs[0].finish_reason == "stop"
     assert outputs[0].outputs[0].token_ids == []
     assert outputs[0].outputs[0].cumulative_logprob == pytest.approx(-0.1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("skip_special_tokens", "expected_text"),
+    [
+        pytest.param(True, "", id="skip"),
+        pytest.param(False, "0", id="keep"),
+    ],
+)
+async def test_beam_search_respects_skip_special_tokens(
+    skip_special_tokens: bool, expected_text: str
+) -> None:
+    prompt = {
+        "type": "token",
+        "prompt": "prompt",
+        "prompt_token_ids": [1],
+    }
+    params = BeamSearchParams(
+        beam_width=1,
+        max_tokens=1,
+        ignore_eos=True,
+        skip_special_tokens=skip_special_tokens,
+    )
+
+    outputs = [
+        output async for output in _Serving().beam_search(prompt, "request", params)
+    ]
+
+    assert outputs[0].outputs[0].text == expected_text
+    assert outputs[0].outputs[0].token_ids == [_Tokenizer.special_token_id]

--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -186,7 +186,9 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
             best_beams = sorted_completed[:beam_width]
 
             for beam in best_beams:
-                beam.text = tokenizer.decode(beam.tokens)
+                beam.text = tokenizer.decode(
+                    beam.tokens, skip_special_tokens=params.skip_special_tokens
+                )
 
             outputs.append(BeamSearchOutput(sequences=best_beams))
 

--- a/vllm/entrypoints/generate/beam_search/online.py
+++ b/vllm/entrypoints/generate/beam_search/online.py
@@ -197,7 +197,9 @@ class BeamSearchOnlineMixin(ABC):
                 tokens = beam.tokens[tokenized_length:-1]
             else:
                 tokens = beam.tokens[tokenized_length:]
-            beam.text = tokenizer.decode(tokens)
+            beam.text = tokenizer.decode(
+                tokens, skip_special_tokens=params.skip_special_tokens
+            )
 
         yield RequestOutput(
             request_id=request_id,

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -659,6 +659,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             temperature=temperature,
             length_penalty=self.length_penalty,
             include_stop_str_in_output=self.include_stop_str_in_output,
+            skip_special_tokens=self.skip_special_tokens,
         )
 
     def extract_structured_outputs(self) -> StructuredOutputsParams | None:

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -303,6 +303,7 @@ class CompletionRequest(OpenAIBaseModel):
             temperature=temperature,
             length_penalty=self.length_penalty,
             include_stop_str_in_output=self.include_stop_str_in_output,
+            skip_special_tokens=self.skip_special_tokens,
         )
 
     def extract_structured_outputs(self) -> StructuredOutputsParams | None:

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1313,6 +1313,7 @@ class BeamSearchParams(
     length_penalty: float = 1.0
     include_stop_str_in_output: bool = False
     structured_outputs: StructuredOutputsParams | None = None
+    skip_special_tokens: bool = True
 
     def __post_init__(self) -> None:
         _verify_num_sequences(self.beam_width, "beam_width")


### PR DESCRIPTION
## Purpose

Fixes #56209.

Online and Offline Beam Search did not honor `skip_special_tokens` during final detokenization. As a result, models such as
`mistralai/Voxtral-Mini-4B-Realtime-2602` exposed internal control tokens, including `[STREAMING_PAD]` and `[STREAMING_WORD]`, in user-facing text.

This PR:
- Adds `skip_special_tokens` to `BeamSearchParams`.
- Propagates the option from Chat and Completion requests.
- Applies it during final Online and Offline Beam Search decoding.
- Preserves special tokens when users explicitly set `skip_special_tokens=False`.

The option defaults to `True`, consistent with `SamplingParams` and the OpenAI request defaults. The change only affects decoded text; it does not modify generated token IDs, logits, or beam ranking.

I searched the open vLLM issues and PRs for `skip_special_tokens`, Beam Search, and Voxtral control-token leakage and did not find an existing change addressing the same problem.

## Test Plan & Result

### offline test

`test_voxtral_offline_beam.py `

```python
import os

from mistral_common.protocol.transcription.request import (
    StreamingMode,
    TranscriptionRequest,
)
from mistral_common.tokens.tokenizers.audio import Audio
from mistral_common.tokens.tokenizers.mistral import MistralTokenizer

from vllm import LLM
from vllm.sampling_params import BeamSearchParams


MODEL = "mistralai/Voxtral-Mini-4B-Realtime-2602"
tokenizer = MistralTokenizer.from_hf_hub(MODEL)
audio = Audio.from_file(os.environ["AUDIO_FILE"], strict=False)
tokenized = tokenizer.instruct_tokenizer.encode_transcription(
    TranscriptionRequest(
        audio=audio.to_base64(audio.format),
        streaming=StreamingMode.OFFLINE,
        language="en",
    )
)

prompt = {
    "prompt_token_ids": tokenized.tokens,
    "multi_modal_data": {
        "audio": [(tokenized.audios[0].audio_array, None)],
    },
}

llm = LLM(
    model=MODEL,
    tokenizer_mode="mistral",
    config_format="mistral",
    load_format="mistral",
    trust_remote_code=True,
    max_model_len=8192,
    max_num_seqs=1,
    gpu_memory_utilization=0.92,
    enforce_eager=True,
)

params = BeamSearchParams(
    beam_width=2,
    max_tokens=256,
)

result = llm.beam_search([prompt], params)[0]
for sequence in result.sequences:
    print(sequence.text or "")

```

```python
AUDIO_FILE=/data/home/xli49/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg \
VLLM_USE_FLASHINFER_SAMPLER=0 \
.venv/bin/python test_voxtral_offline_beam.py 
```

**output before fix**

```python
<s>[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] First[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] words, I[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] spoke in[STREAMING_PAD][STREAMING_WORD] the[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] original[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] phonograph.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] A[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] little[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] piece of[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] practical[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] poetry.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] Mary[STREAMING_PAD][STREAMING_WORD] had a[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] little[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] lamb, its[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] fleece was[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] quite a[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] slow, and[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] everywhere that[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] Mary[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] went, the[STREAMING_PAD][STREAMING_WORD] lamb[STREAMING_PAD][STREAMING_WORD] was[STREAMING_PAD][STREAMING_WORD] sure to[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] go.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD]
<s>[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] First[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] words, I[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] spoke in[STREAMING_PAD][STREAMING_WORD] the[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] original[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] phonograph.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] A[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] little[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] piece of[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] practical[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] poetry.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] Mary[STREAMING_PAD][STREAMING_WORD] had a[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] little[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] lamb, it[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] sleeps with[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] quite a[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] snow, and[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] everywhere that[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] Mary[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] went, the[STREAMING_PAD][STREAMING_WORD] lamb[STREAMING_PAD][STREAMING_WORD] was[STREAMING_PAD][STREAMING_WORD] sure to[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] go.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD]
```



**output after fix**

```python
 First words, I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, its fleece was quitea slow, and everywhere that Mary went, the lamb was sure to go.
 First words, I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, it sleeps with quitea snow, and everywhere that Mary went, the lamb was sure to go.
```


### Online Test

```python
vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 \
  --tokenizer-mode mistral \
  --compilation-config '{"cudagraph_mode":"PIECEWISE"}' \
  --max-model-len 8192 \
  --max-num-seqs 1 \
  --gpu-memory-utilization 0.92 \
  --port 8002
```

```python
AUDIO_FILE="$HOME/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg" \
curl \
  http://127.0.0.1:8002/v1/audio/transcriptions \
  -F "file=@$AUDIO_FILE;type=audio/ogg" \
  -F "model=mistralai/Voxtral-Mini-4B-Realtime-2602" \
  -F "language=en" \
  -F "temperature=0" \
  -F "use_beam_search=true" \
  -F "n=2" \
  -F "max_completion_tokens=256"
```

**output before fix**

```python
{"text":"[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] First[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] words[STREAMING_PAD][STREAMING_WORD] I[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] spoke in[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] the[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] original[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] phonograph.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] A[STREAMING_PAD][STREAMING_WORD] little[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] piece of[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] practical[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] poetry.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] Mary[STREAMING_PAD][STREAMING_WORD] had a[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] little[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] lamb, it[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] sleeps with[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] quite a[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] slow, and[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] everywhere[STREAMING_PAD][STREAMING_WORD] that[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] Mary[STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] went, the[STREAMING_PAD][STREAMING_WORD] lamb[STREAMING_PAD][STREAMING_WORD] was[STREAMING_PAD][STREAMING_WORD] sure to[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_WORD] go.[STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD][STREAMING_PAD]","usage":{"type":"duration","seconds":16}}
```



**output after fix**

```python
{"text":" First words I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, it sleeps with quite a slow, and everywhere that Mary went, the lamb was sure to go.","usage":{"type":"duration","seconds":16}}
```



### regression test (new)

Verifies that Online Beam Search filters special tokens when `skip_special_tokens=True`, preserves them when `skip_special_tokens=False`, and leaves the generated token IDs unchanged in both cases.

```python
.venv/bin/python -m pytest \
  tests/samplers/test_beam_search_online.py::test_beam_search_respects_skip_special_tokens \
  -v
```

````
Running 2 items in this shard: tests/samplers/test_beam_search_online.py::test_beam_search_respects_skip_special_tokens[True-], tests/samplers/test_beam_search_online.py::test_beam_search_respects_skip_special_tokens[False-0]

tests/samplers/test_beam_search_online.py::test_beam_search_respects_skip_special_tokens[True-] PASSED                                 [ 50%]
tests/samplers/test_beam_search_online.py::test_beam_search_respects_skip_special_tokens[False-0] PASSED                               [100%]

======================================================= 2 passed, 14 warnings in 1.31s =======================================================
````



### regression test (existing)

The change does not break the existing Offline Beam Search path.

```
VLLM_USE_FLASHINFER_SAMPLER=0 \
CUDA_VISIBLE_DEVICES=1 \
.venv/bin/python -m pytest \
  tests/samplers/test_beam_search.py::test_beam_search_single_input \
  -v
```

```python
Running 1 items in this shard: tests/samplers/test_beam_search.py::test_beam_search_single_input[4-64-half-TinyLlama/TinyLlama-1.1B-Chat-v1.0]

tests/samplers/test_beam_search.py::test_beam_search_single_input[4-64-half-TinyLlama/TinyLlama-1.1B-Chat-v1.0] PASSED                     [100%]
=================================================== 1 passed, 14 warnings in 71.14s (0:01:11) ================================================
```

After the fix, the response contains only the transcription text. The textual content remains unchanged apart from filtering tokenizer-defined special tokens. No documentation update is required because this fixes the behavior of an existing option and does not introduce a new public endpoint or model.

## AI Assistance
OpenAI Codex was used to assist with code analysis, test development, and wording. I reviewed the changed code and ran the tests listed above.