### PR TITLE
[Security] Roll back request registration if engine add fails

### DIFF
--- a/tests/entrypoints/unit_tests/test_sampling_int_bounds.py
+++ b/tests/entrypoints/unit_tests/test_sampling_int_bounds.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Reject sampling integers that cannot round-trip through engine transport."""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.anthropic.protocol import AnthropicMessagesRequest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    BatchChatCompletionRequest,
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+pytestmark = pytest.mark.cpu_test
+
+_INT64_MAX = 2**63 - 1
+_OVERFLOW = 2**64
+_CHAT_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.parametrize(
+    ("cls", "kwargs"),
+    [
+        (CompletionRequest, {"model": "m", "prompt": "hi"}),
+        (
+            ChatCompletionRequest,
+            {"model": "m", "messages": _CHAT_MESSAGES},
+        ),
+    ],
+)
+def test_oversized_stream_interval_rejected(cls, kwargs):
+    with pytest.raises(ValidationError):
+        cls(**kwargs, stream_interval=_OVERFLOW)
+
+
+@pytest.mark.parametrize(
+    ("cls", "kwargs"),
+    [
+        (CompletionRequest, {"model": "m", "prompt": "hi"}),
+        (
+            ChatCompletionRequest,
+            {"model": "m", "messages": _CHAT_MESSAGES},
+        ),
+    ],
+)
+def test_max_stream_interval_accepted(cls, kwargs):
+    req = cls(**kwargs, stream_interval=_INT64_MAX)
+    assert req.stream_interval == _INT64_MAX
+
+
+@pytest.mark.parametrize(
+    ("cls", "kwargs"),
+    [
+        (CompletionRequest, {"model": "m", "prompt": "hi"}),
+        (
+            ChatCompletionRequest,
+            {"model": "m", "messages": _CHAT_MESSAGES},
+        ),
+        (
+            BatchChatCompletionRequest,
+            {"model": "m", "messages": [_CHAT_MESSAGES]},
+        ),
+        (ResponsesRequest, {"model": "m", "input": "hi"}),
+        (
+            AnthropicMessagesRequest,
+            {"model": "m", "max_tokens": 1, "messages": _CHAT_MESSAGES},
+        ),
+    ],
+)
+def test_oversized_top_k_rejected(cls, kwargs):
+    with pytest.raises(ValidationError):
+        cls(**kwargs, top_k=_OVERFLOW)
+
+
+@pytest.mark.parametrize(
+    ("cls", "kwargs"),
+    [
+        (CompletionRequest, {"model": "m", "prompt": "hi"}),
+        (
+            ChatCompletionRequest,
+            {"model": "m", "messages": _CHAT_MESSAGES},
+        ),
+    ],
+)
+def test_negative_stream_interval_rejected(cls, kwargs):
+    with pytest.raises(ValidationError):
+        cls(**kwargs, stream_interval=-1)

--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -64,6 +64,16 @@ def test_extra_args_accepts_messagepack_integer_boundaries(value):
     assert SamplingParams(extra_args=extra_args).extra_args == extra_args
 
 
+@pytest.mark.parametrize("kwargs", [{"top_k": 2**64}, {"stream_interval": 2**64}])
+def test_sampling_params_reject_integers_beyond_messagepack(kwargs: dict):
+    with pytest.raises(VLLMValidationError, match="must be at most"):
+        SamplingParams(**kwargs)
+
+
+def test_sampling_params_accept_messagepack_integer_boundaries():
+    SamplingParams(top_k=2**64 - 1, stream_interval=2**64 - 1)
+
+
 def test_extra_args_preserves_custom_objects_and_shared_containers():
     custom = object()
     shared = [custom, (None, "value", 1.5)]

--- a/tests/v1/engine/test_add_request_rollback.py
+++ b/tests/v1/engine/test_add_request_rollback.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Roll back local request registration when engine add fails."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
+from vllm.v1.serial_utils import MsgpackEncoder
+
+pytestmark = pytest.mark.cpu_test
+
+_OVERFLOW = 2**64
+
+
+def _engine_request(
+    request_id: str = "req-0",
+    *,
+    sampling_params: SamplingParams | None = None,
+) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=request_id,
+        external_req_id=request_id,
+        prompt_token_ids=[1],
+        mm_features=None,
+        sampling_params=sampling_params
+        or SamplingParams(detokenize=False, max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def _make_async_llm(add_request_async) -> AsyncLLM:
+    llm = AsyncLLM.__new__(AsyncLLM)
+    llm.output_handler = None
+    llm.vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(kv_sharing_fast_prefill=False)
+    )
+    llm.output_processor = OutputProcessor(tokenizer=None, log_stats=False)
+    llm.scheduler_config = SimpleNamespace(
+        max_num_queued_reqs=None,
+        max_num_queued_tokens=None,
+    )
+    llm.input_processor = SimpleNamespace(assign_request_id=lambda _req: None)
+    llm.log_requests = False
+    llm._run_output_handler = lambda: None
+    llm.engine_core = SimpleNamespace(
+        add_request_async=add_request_async,
+        abort_requests_async=AsyncMock(),
+        resources=SimpleNamespace(engine_dead=False),
+        shutdown=MagicMock(),
+    )
+    return llm
+
+
+def _make_llm_engine(add_request) -> LLMEngine:
+    engine = LLMEngine.__new__(LLMEngine)
+    engine.output_processor = OutputProcessor(tokenizer=None, log_stats=False)
+    engine.input_processor = SimpleNamespace(assign_request_id=lambda _req: None)
+    engine.engine_core = SimpleNamespace(
+        add_request=add_request,
+        abort_requests=MagicMock(),
+    )
+    return engine
+
+
+def test_async_add_request_rolls_back_on_encode_overflow():
+    encoder = MsgpackEncoder()
+
+    async def add_request_async(request: EngineCoreRequest) -> None:
+        encoder.encode(request)
+
+    llm = _make_async_llm(add_request_async)
+    request = _engine_request()
+    request.priority = _OVERFLOW
+    queue = RequestOutputCollector(RequestOutputKind.CUMULATIVE, request.request_id)
+
+    async def _run() -> None:
+        with pytest.raises(OverflowError):
+            await llm._add_request(request, None, None, 0, queue)
+
+    asyncio.run(_run())
+
+    assert llm.output_processor.request_states == {}
+    assert llm.output_processor.parent_requests == {}
+
+
+def test_async_add_request_keeps_state_when_engine_accepts():
+    llm = _make_async_llm(AsyncMock())
+    request = _engine_request()
+    queue = RequestOutputCollector(RequestOutputKind.CUMULATIVE, request.request_id)
+
+    asyncio.run(llm._add_request(request, None, None, 0, queue))
+
+    assert request.request_id in llm.output_processor.request_states
+
+
+def test_async_parallel_add_rolls_back_siblings_on_later_send_failure():
+    calls = 0
+
+    async def add_request_async(_request: EngineCoreRequest) -> None:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise OverflowError("can't serialize ints")
+
+    llm = _make_async_llm(add_request_async)
+    params = SamplingParams(n=2, detokenize=False, max_tokens=1)
+    request = _engine_request(sampling_params=params)
+
+    async def _run() -> None:
+        with pytest.raises(OverflowError):
+            await llm.add_request("req-0", request, params)
+
+    asyncio.run(_run())
+
+    assert llm.output_processor.request_states == {}
+    assert llm.output_processor.parent_requests == {}
+
+
+def test_sync_add_request_rolls_back_on_engine_send_failure():
+    encoder = MsgpackEncoder()
+
+    def add_request(request: EngineCoreRequest) -> None:
+        encoder.encode(request)
+
+    engine = _make_llm_engine(add_request)
+    request = _engine_request()
+    request.priority = _OVERFLOW
+
+    with pytest.raises(OverflowError):
+        engine.add_request("req-0", request, request.sampling_params)
+
+    assert engine.output_processor.request_states == {}
+    assert engine.output_processor.parent_requests == {}
+
+
+def test_sync_parallel_add_rolls_back_siblings_on_later_send_failure():
+    calls = 0
+
+    def add_request(_request: EngineCoreRequest) -> None:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise OverflowError("can't serialize ints")
+
+    engine = _make_llm_engine(add_request)
+    params = SamplingParams(n=2, detokenize=False, max_tokens=1)
+    request = _engine_request(sampling_params=params)
+
+    with pytest.raises(OverflowError):
+        engine.add_request("req-0", request, params)
+
+    assert engine.output_processor.request_states == {}
+    assert engine.output_processor.parent_requests == {}

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 import vllm.envs as envs
 
+_INT64_MAX = 2**63 - 1
+
 
 class AnthropicError(BaseModel):
     """Error structure for Anthropic API"""
@@ -134,7 +136,7 @@ class AnthropicMessagesRequest(BaseModel):
     temperature: float | None = None
     tool_choice: AnthropicToolChoice | None = None
     tools: list[AnthropicTool] | None = None
-    top_k: int | None = None
+    top_k: int | None = Field(None, ge=-1, le=_INT64_MAX)
     top_p: float | None = None
 
     # vLLM-specific fields that are not in Anthropic spec

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -264,7 +264,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
     # --8<-- [start:chat-completion-sampling-params]
     use_beam_search: bool = False
-    top_k: int | None = None
+    top_k: int | None = Field(None, ge=-1, le=_INT64_MAX)
     min_p: float | None = None
     repetition_penalty: float | None = None
     watermarking: bool = True
@@ -509,7 +509,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
         "can detect such behavior and terminate early, saving time and tokens.",
     )
 
-    stream_interval: Annotated[int, Field(ge=1)] | None = Field(
+    stream_interval: Annotated[int, Field(ge=1, le=_INT64_MAX)] | None = Field(
         default=None,
         description=(
             "Number of tokens to batch into each streamed chunk. Raises the "
@@ -1105,7 +1105,7 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
     # vLLM extensions
     best_of: int | None = None
     use_beam_search: bool = False
-    top_k: int | None = None
+    top_k: int | None = Field(None, ge=-1, le=_INT64_MAX)
     min_p: float | None = None
     repetition_penalty: float | None = None
     length_penalty: float | None = 1.0

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -72,7 +72,7 @@ class CompletionRequest(OpenAIBaseModel):
 
     # --8<-- [start:completion-sampling-params]
     use_beam_search: bool = False
-    top_k: int | None = None
+    top_k: int | None = Field(None, ge=-1, le=_INT64_MAX)
     min_p: float | None = None
     repetition_penalty: float | None = None
     watermarking: bool = True
@@ -250,7 +250,7 @@ class CompletionRequest(OpenAIBaseModel):
         ),
     )
 
-    stream_interval: Annotated[int, Field(ge=1)] | None = Field(
+    stream_interval: Annotated[int, Field(ge=1, le=_INT64_MAX)] | None = Field(
         default=None,
         description=(
             "Number of tokens to batch into each streamed chunk. Raises the "

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -180,7 +180,7 @@ class ResponsesRequest(OpenAIBaseModel):
     tools: list[Tool] = Field(default_factory=list)
     top_logprobs: int | None = 0
     top_p: float | None = None
-    top_k: int | None = None
+    top_k: int | None = Field(None, ge=-1, le=_INT64_MAX)
     truncation: Literal["auto", "disabled"] | None = "disabled"
     user: str | None = None
     skip_special_tokens: bool = True

--- a/vllm/entrypoints/speech_to_text/transcription/protocol.py
+++ b/vllm/entrypoints/speech_to_text/transcription/protocol.py
@@ -156,7 +156,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     smallest possible set whose cumulative probability exceeds `p`.
     """
 
-    top_k: int | None = None
+    top_k: int | None = Field(None, ge=-1, le=_LONG_INFO.max)
     """Limits sampling to the `k` most probable tokens at each step."""
 
     min_p: float | None = None

--- a/vllm/entrypoints/speech_to_text/translation/protocol.py
+++ b/vllm/entrypoints/speech_to_text/translation/protocol.py
@@ -107,7 +107,7 @@ class TranslationRequest(OpenAIBaseModel):
     smallest possible set whose cumulative probability exceeds `p`.
     """
 
-    top_k: int | None = None
+    top_k: int | None = Field(None, ge=-1, le=_LONG_INFO.max)
     """Limits sampling to the `k` most probable tokens at each step."""
 
     min_p: float | None = None

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -601,6 +601,12 @@ class SamplingParams(
             raise VLLMValidationError(
                 f"top_k must be an integer, got {type(self.top_k).__name__}"
             )
+        if self.top_k > 2**64 - 1:
+            raise VLLMValidationError(
+                f"top_k must be at most {2**64 - 1}, got {self.top_k}.",
+                parameter="top_k",
+                value=self.top_k,
+            )
         if not 0.0 <= self.min_p <= 1.0:
             raise VLLMValidationError(f"min_p must be in [0, 1], got {self.min_p}.")
         if self.max_tokens is not None and self.max_tokens < 1:
@@ -618,12 +624,20 @@ class SamplingParams(
                 f"min_tokens must be less than or equal to "
                 f"max_tokens={self.max_tokens}, got {self.min_tokens}."
             )
-        if self.stream_interval is not None and self.stream_interval < 1:
-            raise VLLMValidationError(
-                f"stream_interval must be at least 1, got {self.stream_interval}.",
-                parameter="stream_interval",
-                value=self.stream_interval,
-            )
+        if self.stream_interval is not None:
+            if self.stream_interval < 1:
+                raise VLLMValidationError(
+                    f"stream_interval must be at least 1, got {self.stream_interval}.",
+                    parameter="stream_interval",
+                    value=self.stream_interval,
+                )
+            if self.stream_interval > 2**64 - 1:
+                raise VLLMValidationError(
+                    f"stream_interval must be at most {2**64 - 1}, "
+                    f"got {self.stream_interval}.",
+                    parameter="stream_interval",
+                    value=self.stream_interval,
+                )
         if self.logprobs is not None and self.logprobs != -1 and self.logprobs < 0:
             raise VLLMValidationError(
                 f"logprobs must be non-negative or -1, got {self.logprobs}.",

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -471,24 +471,28 @@ class AsyncLLM(EngineClient):
         # Use cloned params that may have been updated in process_inputs()
         params = request.params
 
-        if is_pooling or params.n == 1:
-            await self._add_request(request, prompt_text, None, 0, queue)
+        try:
+            if is_pooling or params.n == 1:
+                await self._add_request(request, prompt_text, None, 0, queue)
+                return queue
+
+            parent_params = params
+            assert isinstance(parent_params, SamplingParams)
+
+            # Fan out child requests (for n>1).
+            parent_request = ParentRequest(request)
+            for idx in range(parent_params.n):
+                request_id, child_params = parent_request.get_child_info(idx)
+                child_request = request if idx == parent_params.n - 1 else copy(request)
+                child_request.request_id = request_id
+                child_request.sampling_params = child_params
+                await self._add_request(
+                    child_request, prompt_text, parent_request, idx, queue
+                )
             return queue
-
-        parent_params = params
-        assert isinstance(parent_params, SamplingParams)
-
-        # Fan out child requests (for n>1).
-        parent_request = ParentRequest(request)
-        for idx in range(parent_params.n):
-            request_id, child_params = parent_request.get_child_info(idx)
-            child_request = request if idx == parent_params.n - 1 else copy(request)
-            child_request.request_id = request_id
-            child_request.sampling_params = child_params
-            await self._add_request(
-                child_request, prompt_text, parent_request, idx, queue
-            )
-        return queue
+        except BaseException:
+            await self.abort(queue.request_id, internal=True)
+            raise
 
     async def _add_request(
         self,
@@ -506,8 +510,12 @@ class AsyncLLM(EngineClient):
         # Register locally before the first await so concurrent tasks see this request.
         self.output_processor.add_request(request, prompt, parent_req, index, queue)
 
-        # Add the EngineCoreRequest to EngineCore (separate process).
-        await self.engine_core.add_request_async(request)
+        try:
+            # Add the EngineCoreRequest to EngineCore (separate process).
+            await self.engine_core.add_request_async(request)
+        except BaseException:
+            await self.abort(request.request_id, internal=True)
+            raise
 
         if self.log_requests:
             logger.info("Added request %s.", request.request_id)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -277,28 +277,30 @@ class LLMEngine:
 
         n = params.n if isinstance(params, SamplingParams) else 1
 
-        if n == 1:
-            # Make a new RequestState and queue.
-            self.output_processor.add_request(request, prompt_text, None, 0)
-            # Add the request to EngineCore.
-            self.engine_core.add_request(request)
-            return req_id
+        try:
+            if n == 1:
+                # Make a new RequestState and queue.
+                self.output_processor.add_request(request, prompt_text, None, 0)
+                # Add the request to EngineCore.
+                self.engine_core.add_request(request)
+            else:
+                # Fan out child requests (for n>1).
+                parent_req = ParentRequest(request)
+                for idx in range(n):
+                    request_id, child_params = parent_req.get_child_info(idx)
+                    child_request = request if idx == n - 1 else copy(request)
+                    child_request.request_id = request_id
+                    child_request.sampling_params = child_params
 
-        # Fan out child requests (for n>1).
-        parent_req = ParentRequest(request)
-        for idx in range(n):
-            request_id, child_params = parent_req.get_child_info(idx)
-            child_request = request if idx == n - 1 else copy(request)
-            child_request.request_id = request_id
-            child_request.sampling_params = child_params
-
-            # Make a new RequestState and queue.
-            self.output_processor.add_request(
-                child_request, prompt_text, parent_req, idx
-            )
-            # Add the request to EngineCore.
-            self.engine_core.add_request(child_request)
-
+                    # Make a new RequestState and queue.
+                    self.output_processor.add_request(
+                        child_request, prompt_text, parent_req, idx
+                    )
+                    # Add the request to EngineCore.
+                    self.engine_core.add_request(child_request)
+        except BaseException:
+            self.abort_request([req_id], internal=True)
+            raise
         return req_id
 
     def step(self) -> list[RequestOutput | PoolingRequestOutput]:


### PR DESCRIPTION
## Summary

`AsyncLLM` and `LLMEngine` register a request in the output processor before sending it to EngineCore. If that send fails (for example MessagePack cannot encode an oversized integer), the local `RequestState` was left behind with no abort path. This change rolls back registration when engine add fails, and rejects oversized `stream_interval` / `top_k` values at the API and `SamplingParams` layers.

## Changes
- `vllm/v1/engine/async_llm.py`: abort the registered request if `add_request_async` fails; abort already-sent siblings when `n>1` fan-out fails.
- `vllm/v1/engine/llm_engine.py`: same rollback for the sync add path.
- `vllm/sampling_params.py`: reject `top_k` and `stream_interval` above the MessagePack integer range.
- OpenAI / Anthropic / speech-to-text protocols: bound `top_k` and `stream_interval` like neighboring int64 fields.

## Codepath coverage
- HTTP generate (`/v1/chat/completions`, `/v1/completions`, `/v1/messages`, `/v1/responses`, `/invocations`) via `AsyncLLM._add_request`.
- Streaming-input chunks that call `_add_request`.
- Parallel sampling (`n>1`) sibling rollback on `AsyncLLM.add_request` and `LLMEngine.add_request`.
- Offline `LLMEngine.add_request`.
- Protocol and `SamplingParams` validation for the reported oversized integer triggers.

## Duplicate-work check
Searched open and merged PRs for `async_llm _add_request`, `stream_interval`, `RequestState leak`, `top_k int64`, and rollback/abort of failed engine add. Related but incomplete: #51629 (ParentRequest leftover on `n>1` abort; does not wrap register-then-send), #50101 / #55226 (`stream_interval` semantics, not bounds or leak), #49754 (exposed per-request `stream_interval`). No open or merged PR closes this register-then-send window.

## Tests
- `test_async_add_request_rolls_back_on_encode_overflow` / `test_sync_add_request_rolls_back_on_engine_send_failure`: real MessagePack overflow after register leaves no `RequestState`.
- `test_async_parallel_add_rolls_back_siblings_on_later_send_failure` / sync counterpart: later child send failure aborts already-sent siblings.
- `test_async_add_request_keeps_state_when_engine_accepts`: happy path still registers.
- Protocol tests reject oversized `stream_interval` / `top_k`; `SamplingParams` rejects values above the MessagePack range.

Commands: `.venv/bin/python -m pytest tests/v1/engine/test_add_request_rollback.py tests/entrypoints/unit_tests/test_sampling_int_bounds.py tests/test_sampling_params.py -v` (38 passed). `pre-commit run --files` on the changed files (passed).

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)