### PR TITLE
[Bugfix][Compile] Preserve control dependencies during defunctionalization

### DIFF
--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -273,6 +273,7 @@ def test_defunctionalize_preserves_control_dependencies(use_return_value):
         target = torch.ops.vllm.function_with_mutated_args_without_return.default
     graph = torch.fx.Graph()
     arg = graph.placeholder("arg")
+    independent = graph.placeholder("independent")
     functionalized = graph.call_function(
         auto_functionalized, args=(target,), kwargs={"x": arg}
     )
@@ -285,10 +286,10 @@ def test_defunctionalize_preserves_control_dependencies(use_return_value):
     output = graph.call_function(torch.ops.aten.add.Tensor, args=(returned, mutated))
     graph.output(output)
     module = torch.fx.GraphModule(torch.nn.Module(), graph)
-    preserve_node_ordering(graph, {output: OrderedSet([functionalized])})
+    preserve_node_ordering(graph, {output: OrderedSet([independent, functionalized])})
     module.recompile()
     x = torch.arange(4, dtype=torch.float32, device="cpu")
-    expected = module(x.clone())
+    expected = module(x.clone(), x.clone())
 
     func_pass = FixFunctionalizationPass(VllmConfig())
     func_pass.nodes_to_remove = []
@@ -300,9 +301,9 @@ def test_defunctionalize_preserves_control_dependencies(use_return_value):
 
     mutation = next(node for node in graph.nodes if is_func(node, target))
     ordered = next(node for node in graph.nodes if is_func(node, control_deps))
-    assert ordered.args[0] == ((mutation, arg),)
+    assert ordered.args[0] == (independent, mutation, arg)
     assert find_auto_fn_maybe(graph.nodes, target) is None
-    torch.testing.assert_close(module(x.clone()), expected)
+    torch.testing.assert_close(module(x.clone(), x.clone()), expected)
 
 
 MODELS_AND_DO_FUSION = {

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -288,7 +288,7 @@ def test_defunctionalize_preserves_control_dependencies(use_return_value):
     module = torch.fx.GraphModule(torch.nn.Module(), graph)
     preserve_node_ordering(graph, {output: OrderedSet([independent, functionalized])})
     module.recompile()
-    x = torch.arange(4, dtype=torch.float32, device="cpu")
+    x = torch.arange(4, dtype=torch.float32, device=current_platform.device_type)
     expected = module(x.clone(), x.clone())
 
     func_pass = FixFunctionalizationPass(VllmConfig())

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -2,16 +2,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import copy
+import operator
 
 import pytest
 import torch
+from torch._higher_order_ops.auto_functionalize import auto_functionalized
+from torch._inductor.fx_passes.control_dependencies import (
+    control_deps,
+    preserve_node_ordering,
+)
+from torch.utils._ordered_set import OrderedSet
 
 from tests.compile.backend import TestBackend
 from tests.utils import TestFP8Layer
-from vllm.compilation.passes.fusion.act_quant_fusion import (
-    ActivationQuantFusionPass,
-)
-from vllm.compilation.passes.fusion.rms_quant_fusion import RMSNormQuantFusionPass
 from vllm.compilation.passes.fx_utils import find_auto_fn, find_auto_fn_maybe, is_func
 from vllm.compilation.passes.utility.fix_functionalization import (
     FixFunctionalizationPass,
@@ -251,6 +254,57 @@ class TestFunctionWithMutatedArgsAndReturn(torch.nn.Module):
         return []
 
 
+@pytest.mark.parametrize("use_return_value", [False, True])
+def test_defunctionalize_preserves_control_dependencies(use_return_value):
+    if use_return_value:
+        TestFunctionWithMutatedArgsAndReturn.register_test_custom_op()
+        target = torch.ops.vllm.function_with_mutated_args_and_return.default
+    else:
+
+        def mutate_only(x: torch.Tensor) -> None:
+            x.add_(2)
+
+        direct_register_custom_op(
+            op_name="function_with_mutated_args_without_return",
+            op_func=mutate_only,
+            mutates_args=["x"],
+            fake_impl=lambda x: None,
+        )
+        target = torch.ops.vllm.function_with_mutated_args_without_return.default
+    graph = torch.fx.Graph()
+    arg = graph.placeholder("arg")
+    functionalized = graph.call_function(
+        auto_functionalized, args=(target,), kwargs={"x": arg}
+    )
+    mutated = graph.call_function(operator.getitem, args=(functionalized, 1))
+    returned = (
+        graph.call_function(operator.getitem, args=(functionalized, 0))
+        if use_return_value
+        else mutated
+    )
+    output = graph.call_function(torch.ops.aten.add.Tensor, args=(returned, mutated))
+    graph.output(output)
+    module = torch.fx.GraphModule(torch.nn.Module(), graph)
+    preserve_node_ordering(graph, {output: OrderedSet([functionalized])})
+    module.recompile()
+    x = torch.arange(4, dtype=torch.float32, device="cpu")
+    expected = module(x.clone())
+
+    func_pass = FixFunctionalizationPass(VllmConfig())
+    func_pass.nodes_to_remove = []
+    func_pass.defunctionalize(graph, functionalized, mutated_args={1: "x"})
+    for node in func_pass.nodes_to_remove:
+        graph.erase_node(node)
+    graph.lint()
+    module.recompile()
+
+    mutation = next(node for node in graph.nodes if is_func(node, target))
+    ordered = next(node for node in graph.nodes if is_func(node, control_deps))
+    assert ordered.args[0] == ((mutation, arg),)
+    assert find_auto_fn_maybe(graph.nodes, target) is None
+    torch.testing.assert_close(module(x.clone()), expected)
+
+
 MODELS_AND_DO_FUSION = {
     TestSiluMul: [True, False],
     TestFusedAddRMSNorm: [True, False],
@@ -276,6 +330,11 @@ MODELS_AND_DO_FUSION = {
 def test_fix_functionalization(
     model_class: torch.nn.Module, do_fusion: bool, dtype: torch.dtype
 ):
+    from vllm.compilation.passes.fusion.act_quant_fusion import (
+        ActivationQuantFusionPass,
+    )
+    from vllm.compilation.passes.fusion.rms_quant_fusion import RMSNormQuantFusionPass
+
     torch.set_default_device("cuda")
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -10,6 +10,7 @@ from torch._higher_order_ops.auto_functionalize import (
     get_mutable_args,
 )
 from torch._inductor.fx_passes.control_dependencies import control_deps
+from torch.utils._pytree import tree_leaves
 
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -367,15 +368,14 @@ class FixFunctionalizationPass(VllmInductorPass):
                     fn_node,
                     *(node.kwargs[name] for name in mutable_args),
                 )
-                user.update_arg(
-                    0,
-                    torch.fx.map_arg(
-                        user.args[0],
-                        lambda dep, replacement=dependencies: (
-                            replacement if dep is node else dep
-                        ),
+                dependencies = torch.fx.map_arg(
+                    user.args[0],
+                    lambda dep, replacement=dependencies: (
+                        replacement if dep is node else dep
                     ),
                 )
+                # Older PyTorch lowerings only recognize flat dependency lists.
+                user.update_arg(0, tuple(tree_leaves(dependencies)))
 
         # If the function returns a value as well as mutating args inplace,
         # the functionalized node will have a getitem[0] user that holds this value

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -5,7 +5,11 @@ import operator
 from collections.abc import Iterable
 
 import torch
-from torch._higher_order_ops.auto_functionalize import auto_functionalized
+from torch._higher_order_ops.auto_functionalize import (
+    auto_functionalized,
+    get_mutable_args,
+)
+from torch._inductor.fx_passes.control_dependencies import control_deps
 
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -354,6 +358,24 @@ class FixFunctionalizationPass(VllmInductorPass):
                     node.kwargs[arg] if isinstance(arg, str) else arg for arg in args
                 )
                 fn_node = graph.call_function(function, args=args)
+
+        for user in list(node.users):
+            if is_func(user, control_deps):
+                # Keep dependencies on mutated buffers even when the op returns None.
+                mutable_args, _ = get_mutable_args(function)
+                dependencies = (
+                    fn_node,
+                    *(node.kwargs[name] for name in mutable_args),
+                )
+                user.update_arg(
+                    0,
+                    torch.fx.map_arg(
+                        user.args[0],
+                        lambda dep, replacement=dependencies: (
+                            replacement if dep is node else dep
+                        ),
+                    ),
+                )
 
         # If the function returns a value as well as mutating args inplace,
         # the functionalized node will have a getitem[0] user that holds this value


### PR DESCRIPTION
## Purpose

Fixes #56041.

`FixFunctionalizationPass` rewrites `getitem` users before removing an `auto_functionalized` node. A `control_deps` ordering edge can still reference that node, causing FX to abort compilation when removing it.

Redirect the ordering edge to the replacement operation and its mutated arguments, preserving unrelated dependencies. The buffer dependencies retain scheduling constraints for operators returning `None`; flattening the dependency sequence also makes them visible to PyTorch 2.12 lowering.

Extend the existing functionalization suite with returned-tensor and mutation-only regressions. Inputs follow the current platform so the tests run on CPU and CUDA. GPU fusion imports move into their existing GPU test to allow CPU collection.

Before modifying a wrapper, retain it if a user cannot be rewritten: this includes returning the whole wrapper or passing it as a `control_deps` data argument. Supported dependency-list users still take the optimized path. The full-pass regression covers these boundaries, multiple control users, and mixed graphs where ordinary wrappers should still be optimized.

The fallback is computed before graph edits and propagated through data descendants, including views and successive consumers. This prevents downstream reinplacing from overwriting retained outputs. Pure scheduling dependencies do not propagate protection. This conservative approach can keep copies across fresh allocations; it does not perform precise alias/liveness analysis.

### Collaboration

Thanks to @DengZhiyuan-math for identifying the whole-wrapper-output and mixed-graph cases, raising the control-payload case, and suggesting dependency rewiring combined with a conservative fallback. These suggestions informed the new guard and regression coverage. The follow-up commit credits his publicly used Git identity (`Yomathnotcool`) with a `Co-authored-by` trailer. See [the discussion](https://github.com/vllm-project/vllm/pull/56213#issuecomment-5641702626).

DengZhiyuan-math subsequently supplied [22f83b641](https://github.com/DengZhiyuan-math/vllm/commit/22f83b641dea24a33405b94fe948ad12bae8f97c), identifying and fixing connected-output corruption. It was cherry-picked as `0bce7a030f32e62a550f065d442b0e299fd5ad7a` with his authorship and sign-off retained.

### Duplicate-work check

Read #56041 and its comments, and searched open PRs by `56041 in:body`, `control_deps`, and `functionalization`. No other open PR addressing this fix was found. Another contributor has [expressed interest in the issue](https://github.com/vllm-project/vllm/issues/56041#issuecomment-5600616544); this check does not establish that no one else is working on it.

## Validation

Baseline: `9e2570656013a90cb601b391723af4bf9b3207d4`. Previous published head: `f8b15e8ce08d1389a965ca05c4485f2e62235630`. Follow-up: `0bce7a030f32e62a550f065d442b0e299fd5ad7a`.

| Check | Result |
|---|---|
| Regression cases applied to otherwise unmodified baseline, CPU | Both fail with the original node-removal error |
| Four connected-output regressions applied to `f8b15e8` | All four fail numerically |
| Three unsupported-user cases applied to `ee75179` | All three fail with node-removal errors; supported dependency-list case passes |
| Functionalization suite, Apple Silicon, Python 3.12.9, actual Torch 2.12.0 and 2.13.0 | 10 passed, 14 GPU tests skipped on each version |
| Functionalization suite, NVIDIA L20, Python 3.12.12, Torch 2.13.0+cu129 | **24 passed, no skips**; baseline's existing 14 cases previously passed |
| Qwen3-0.6B compiled/eager output and logprob comparison on L20, previous head `ee75179` | **1 passed** |
| Applicable pre-commit hooks, manual Python 3.12 all-files mypy, `git diff --check` | Passed locally |

Commands for the repository checks:

```bash
# CPU environment
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/compile/passes/test_functionalization.py -v
# CUDA environment
.venv/bin/python -m pytest tests/compile/passes/test_functionalization.py -v
VLLM_DISABLE_COMPILE_CACHE=1 .venv/bin/python -m pytest \
  'tests/compile/test_dynamic_shapes_compilation.py::test_dynamic_shapes_compilation[Qwen3-0.6B-backed-aot0-hook1]' -v
.venv/bin/pre-commit run --files \
  vllm/compilation/passes/utility/fix_functionalization.py \
  tests/compile/passes/test_functionalization.py
.venv/bin/pre-commit run mypy-3.12 --all-files --hook-stage manual
git diff --check
```

Supplemental local CPU and CUDA Inductor harnesses check compiled values, execution order, and actual lowered buffer dependencies. The CUDA baseline fails with the original node-removal error; the fix passes. Negative controls show that a void operator alone loses the buffer constraints, as do nested dependencies on Torch 2.12. Eight additional CPU graph cases per Torch version cover multiple ordering users, unrelated dependencies, multiple mutable arguments, optional tensors, tensor lists, and the special RoPE split/slice-scatter path; six per version exercise the complete pass. These supplemental harnesses are not additions to the repository suite.

### Model evaluation

Used the existing `tests.evals.gsm8k.gsm8k_eval.evaluate_gsm8k_offline` evaluator with **the first 64 GSM8K test questions**, 5 shots, greedy completion, and 256 maximum output tokens. Model: `Qwen/Qwen3-0.6B`, revision `c1899de289a04d12100db370d81485cdf75e47ca`, BF16, seed 42. Both runs used `VLLM_COMPILE`, Inductor, `custom_ops=["all"]`, CUDA graphs disabled, separate Inductor cache directories, and vLLM compile caching disabled.

| Metric | Baseline | Fixed |
|---|---:|---:|
| Accuracy | 21/64 (32.8125%) | 21/64 (32.8125%) |
| Invalid answers | 0 | 0 |
| Output tokens | 6,252 | 6,252 |

All 64 recorded token sequences, texts, and finish reasons are identical. This is a small regression evaluation, not a full GSM8K quality or performance evaluation.

The follow-up `f8b15e8` was evaluated again with a fresh Inductor cache and the same configuration: 21/64 correct, no invalid answers, 6,252 output tokens, and all 64 recorded completions identical to the baseline.

The retained whole-wrapper-output and control-payload graphs also pass real CPU Inductor compilation and numerical/input-preservation checks on both Torch 2.12 and 2.13. The harness normalizes outputs to the compiler's flat tuple contract and seeds FakeTensor metadata before creating control subgraphs. An initial harness missing that metadata failed in Torch 2.13 even without the vLLM pass; supplying it resolves that validation setup error.

<details>
<summary>Reproduce the GSM8K configuration</summary>

The local runner additionally recorded each completion for comparison. Its evaluation call is equivalent to the following script, run separately in each checkout with its environment active:

```python
# Save as /tmp/vllm-gsm8k-smoke.py.
from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k_offline
from vllm import LLM

if __name__ == "__main__":
    llm = LLM(
        model="Qwen/Qwen3-0.6B",
        revision="c1899de289a04d12100db370d81485cdf75e47ca",
        dtype="bfloat16",
        seed=42,
        max_model_len=4096,
        max_num_seqs=8,
        max_num_batched_tokens=4096,
        gpu_memory_utilization=0.6,
        enable_prefix_caching=False,
        compilation_config={
            "mode": 3, "backend": "inductor",
            "custom_ops": ["all"], "cudagraph_mode": "NONE",
        },
    )
    print(evaluate_gsm8k_offline(
        llm, num_questions=64, num_shots=5,
        max_tokens=256, temperature=0,
    ))
```

```bash
PYTHONPATH="$PWD" VLLM_DISABLE_COMPILE_CACHE=1 VLLM_USE_AOT_COMPILE=0 \
  .venv/bin/python /tmp/vllm-gsm8k-smoke.py
```

</details>

GPU validation used the official cu129 precompiled artifact at `2a02f6efe319c885e3ccbcecde402e0028f9ec1e` with editable Python sources; the GPU kernel/build sources are unchanged between that artifact commit and the baseline. Both checkouts shared the same compiled dependencies. CUDA 12.9 compatibility libraries were loaded locally for the machine's 535.161.07 driver. A first diagnostic run hit a depyf/Torch 2.13 interface mismatch while dumping graphs; evaluation succeeded with debug dumping disabled.

Four connected-output cases additionally pass real CPU Inductor compilation and numerical checks on both Torch 2.12 and 2.13. These use the repository regression graphs, with FakeTensor metadata populated before control-subgraph creation and outputs flattened for the compiler entry point.

On `0bce7a0`, all four connected graphs also pass real CUDA Inductor compilation, numerical checks, and protected-input preservation on the L20. The GSM8K evaluation was rerun on this commit with a fresh Inductor cache: 21/64 correct, zero invalid answers, 6,252 output tokens, and all 64 recorded completions identical to the baseline. The previous head’s model results are not used as a substitute for this new run.

### Scope and remaining review

The controlled graphs exercise the problematic ordering edge. The Qwen workload does not establish natural reproduction of the reporter's out-of-tree MoE workload. That platform and ROCm remain untested.

The submitter has confirmed reviewing every changed line, including the contributor’s connected-output patch, and personally ran the CPU verification script. The supplied transcript records `0bce7a030f32e62a550f065d442b0e299fd5ad7a` and 10 passed / 14 GPU tests skipped on each Torch version. Other validation reported here is AI-run unless explicitly stated otherwise. DCO passed on the previous public head. Upstream pre-commit was skipped because the contributor eligibility gate failed; this is not a full upstream CI pass.

### AI assistance

OpenAI Codex assisted with diagnosis, implementation, tests, validation, and this description. Commits include AI co-author attribution and DCO sign-off.
