### PR TITLE
[Bugfix] Recover Harmony parser after trailing parser errors

### DIFF
--- a/tests/parser/test_harmony.py
+++ b/tests/parser/test_harmony.py
@@ -174,6 +174,7 @@ def assert_parser_is_reset(harmony_parser: HarmonyParser):
     assert harmony_parser._parser is None
     assert harmony_parser._num_processed_messages == 0
     assert harmony_parser._current_message_tokens == []
+    assert harmony_parser._parser_failed is False
 
 
 class TestFlush:
@@ -244,6 +245,22 @@ class TestParse:
         assert reasoning is None
         assert content == "This is a test"
         assert tool_calls is None
+
+    def test_parser_error_after_completed_message(
+        self, harmony_parser, chat_request
+    ):
+        reasoning, content, tool_calls = harmony_parser.parse(
+            "",
+            chat_request,
+            model_output_token_ids=encode_output(
+                "<|channel|>final<|message|>Answer<|end|><|return|>"
+            ),
+        )
+
+        assert reasoning is None
+        assert content == "Answer"
+        assert tool_calls is None
+        assert_parser_is_reset(harmony_parser)
 
     def test_reasoning_and_content(self, harmony_parser, chat_request):
         response = [
@@ -532,6 +549,31 @@ class TestParseDelta:
         assert second_delta is not None
         assert second_delta.content == "Answer"
         assert second_delta.reasoning is None
+        assert_parser_is_reset(parser)
+
+    def test_parser_error_stops_future_chunks(
+        self, gpt_oss_tokenizer, chat_request
+    ):
+        parser = HarmonyParser(gpt_oss_tokenizer)
+
+        first_delta = parser.parse_delta(
+            delta_text="",
+            delta_token_ids=encode_output(
+                "<|channel|>final<|message|>Answer<|end|><|return|>"
+            ),
+            request=chat_request,
+            finished=False,
+        )
+        second_delta = parser.parse_delta(
+            delta_text="",
+            delta_token_ids=encode_output("<|return|>"),
+            request=chat_request,
+            finished=True,
+        )
+
+        assert first_delta is not None
+        assert first_delta.content == "Answer"
+        assert second_delta is None
         assert_parser_is_reset(parser)
 
     def test_multi_token(self, gpt_oss_tokenizer, chat_request):

--- a/vllm/parser/harmony.py
+++ b/vllm/parser/harmony.py
@@ -116,6 +116,7 @@ class HarmonyParser(DelegatingParser):
 
         # For error recovery
         self._current_message_tokens: list[int] = []
+        self._parser_failed = False
 
     @property
     def _harmony_parser(self) -> StreamableParser:
@@ -162,6 +163,7 @@ class HarmonyParser(DelegatingParser):
         self._parser = None
         self._num_processed_messages = 0
         self._current_message_tokens.clear()
+        self._parser_failed = False
 
         if msg is None:
             return segments
@@ -335,7 +337,18 @@ class HarmonyParser(DelegatingParser):
         segments: list[Segment] = []
         reasoning_token_count = 0
         for token_id in token_ids:
-            self._harmony_parser.process(token_id)
+            if self._parser_failed:
+                break
+
+            try:
+                self._harmony_parser.process(token_id)
+            except HarmonyError:
+                self._parser_failed = True
+                logger.warning(
+                    "Harmony parser failed; ignoring the remaining output tokens."
+                )
+                break
+
             channel = self._harmony_parser.current_channel
             recipient = self._normalize_recipient(
                 self._harmony_parser.current_recipient


### PR DESCRIPTION
## Issue Addressed

This PR fixes [#50690](https://github.com/vllm-project/vllm/issues/50690), where GPT-OSS chat completions can return HTTP 500 with:
HarmonyError: Unexpected token 200002 while expecting start token 200006, especially when ignore_eos=true.

## Root Cause

A complete message is already available after <|end|>, but a trailing <|return|> token can arrive next.
The stream parser is then in a state that expects a <|start|> token, so HarmonyParser.process_chunk() raises HarmonyError.
Because this exception was not caught there, it escapes before lush() recovery, so vLLM returns 500 even though the assistant answer was already parsed.

## Reproduction Before the Fix

On vLLM 0.27.1 + Python 3.10.12 (pure parser path, no model loading), I reproduced with:

`	ext
input: <|channel|>final<|message|>Answer<|end|><|return|>
tokens: [200005, 17196, 200008, 17045, 200007, 200002]
error_at_token: 5
error_type: HarmonyError
error: Unexpected token 200002 while expecting start token 200006
parser.messages: [Message(... content=[TextContent(text='Answer')] ...)]
`

## Fix Approach

- Catch HarmonyError inside HarmonyParser.process_chunk().
- Mark the parser as failed and stop consuming the current chunk and all later chunks after the first parser error.
- Keep existing lush() logic so completed/truncated output can still be returned.
- Reset parser error state in lush() together with existing parser state cleanup.

This preserves normal Harmony parsing and prevents a completed answer from being dropped by a trailing token.

## Result After the Fix

The same input now produces:

`	ext
parse_result: (None, 'Answer', None)
first_delta: content='Answer'
second_delta: None
reset: True 0 [] False
`

The completion now returns the parsed Answer and the parser is reset safely.

## Tests

- Added regression test for non-streaming parse: completed message followed by <|return|>.
- Added regression test for streaming chunk flow: once parser errors, subsequent chunks are ignored.
- Focused parser checks: python3 -m py_compile passed for the modified source/test files.

Fixes #50690