### PR TITLE
[Perf][Model][Engram] Redistribute DeepSeek-V4.1 SP embeddings with all-to-all

### DIFF
--- a/tests/distributed/test_engram_parallel.py
+++ b/tests/distributed/test_engram_parallel.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Collective coverage of Engram's head-to-token redistribution."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.models.deepseek_v4_1.common.engram_parallel import exchange_heads_for_tokens
+
+
+def _exchange_worker(rank: int, world_size: int, rendezvous: str):
+    dist.init_process_group(
+        "gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        for tokens, heads in [(0, 23), (1, 1), (3, 7), (64, 24), (65, 23)]:
+            dim = 5
+            local_heads = (heads + world_size - 1) // world_size
+            chunk = (tokens + world_size - 1) // world_size
+            full = torch.arange(tokens * heads * dim, dtype=torch.float32).reshape(
+                tokens, heads, dim
+            )
+            padded = torch.nn.functional.pad(
+                full, (0, 0, 0, local_heads * world_size - heads)
+            )
+            local = padded[:, rank * local_heads : (rank + 1) * local_heads]
+
+            def exchange(rows):
+                received = torch.empty_like(rows)
+                dist.all_to_all_single(received, rows.contiguous())
+                return received
+
+            actual = exchange_heads_for_tokens(local, world_size, heads, exchange)
+            expected = torch.nn.functional.pad(
+                full, (0, 0, 0, 0, 0, chunk * world_size - tokens)
+            )[rank * chunk : (rank + 1) * chunk]
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_all_to_all_preserves_token_and_head_order(world_size, tmp_path):
+    mp.spawn(
+        _exchange_worker,
+        args=(world_size, (tmp_path / "rendezvous").as_uri()),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+def _cuda_exchange_worker(rank, tp_size, port):
+    from tests.utils import init_test_distributed_environment
+    from vllm.distributed import cleanup_dist_env_and_memory, get_tp_group
+    from vllm.models.deepseek_v4_1.common.engram import Engram
+
+    torch.accelerator.set_device_index(rank)
+    init_test_distributed_environment(tp_size, 4 // tp_size, rank, str(port), rank)
+    group = get_tp_group()
+    local_rank = group.rank_in_group
+    group_offset = group.ranks[0] * 7
+
+    def full_rows(tokens, heads, dtype, offset=0):
+        values = torch.arange(tokens * heads * 256, device="cuda")
+        return (
+            ((values % 97) + group_offset + offset).to(dtype).view(tokens, heads, 256)
+        )
+
+    def module_for(full, strided):
+        tokens, heads, dim = full.shape
+        local_heads = (heads + tp_size - 1) // tp_size
+        padded = torch.nn.functional.pad(full, (0, 0, 0, -heads % tp_size))
+        local = padded[:, local_rank * local_heads : (local_rank + 1) * local_heads]
+        rows = (
+            torch.empty(
+                tokens,
+                local_heads,
+                dim * (2 if strided else 1),
+                dtype=full.dtype,
+                device="cuda",
+            )[..., ::2]
+            if strided
+            else torch.empty_like(local, memory_format=torch.contiguous_format)
+        )
+        rows.copy_(local)
+        module = Engram.__new__(Engram)
+        torch.nn.Module.__init__(module)
+        module.embed_tokens = SimpleNamespace(tp_size=tp_size, n_hash_cols=heads)
+        module.use_sequence_parallel = True
+        module.staged_rows = rows
+        return module, torch.empty(tokens, heads, dtype=torch.int32, device="cuda")
+
+    def expected(full):
+        chunk = (len(full) + tp_size - 1) // tp_size
+        return torch.nn.functional.pad(full, (0, 0, 0, 0, 0, -len(full) % tp_size))[
+            local_rank * chunk : (local_rank + 1) * chunk
+        ]
+
+    try:
+        for tokens in sorted(
+            {
+                0,
+                1,
+                tp_size - 1,
+                tp_size,
+                tp_size + 1,
+                63,
+                64,
+                65,
+                127,
+                128,
+                129,
+                511,
+                512,
+                513,
+            }
+        ):
+            for heads in (23, 24):
+                for dtype in (torch.bfloat16, torch.float32):
+                    for strided in (False, True):
+                        full = full_rows(tokens, heads, dtype)
+                        module, ids = module_for(full, strided)
+                        torch.testing.assert_close(
+                            module.embed(ids), expected(full), rtol=0, atol=0
+                        )
+
+        # Two captures own separate buffers; ordered streams must not reuse
+        # each other's storage when fresh input is supplied on every replay.
+        captures = []
+        for offset in (0, 13):
+            full = full_rows(65, 23, torch.bfloat16, offset)
+            module, ids = module_for(full, True)
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream):
+                for _ in range(3):
+                    module.embed(ids)
+            torch.cuda.current_stream().wait_stream(stream)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=stream):
+                output = module.embed(ids)
+            captures.append((module, graph, output, stream, offset))
+        for iteration in range(100):
+            for module, graph, output, stream, offset in captures:
+                full = full_rows(65, 23, torch.bfloat16, offset + iteration % 17)
+                fresh, _ = module_for(full, True)
+                module.staged_rows.copy_(fresh.staged_rows)
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.current_stream().wait_stream(stream)
+                torch.testing.assert_close(output, expected(full), rtol=0, atol=0)
+        torch.accelerator.synchronize()
+        del captures, graph, output
+    finally:
+        cleanup_dist_env_and_memory()
+
+
+@pytest.mark.distributed(num_gpus=4)
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 4, reason="Requires four CUDA GPUs"
+)
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+def test_engram_nondefault_groups_and_changing_graph_inputs(tp_size):
+    """The production embed path preserves rows on every TP group and replay."""
+    from vllm.utils.network_utils import get_open_port
+
+    mp.spawn(_cuda_exchange_worker, args=(tp_size, get_open_port()), nprocs=4)

--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -631,6 +631,19 @@ def test_engram_head_shards_reconstruct_checkpoint(cpu_offload, tp_size, monkeyp
         monkeypatch.setattr(
             engram_ops, "get_tensor_model_parallel_rank", lambda rank=rank: rank
         )
+
+        def exchange(rows, rank=rank):
+            return torch.cat(
+                [
+                    torch.nn.functional.pad(
+                        shard, (0, 0, 0, 0, 0, (-len(ids)) % tp_size)
+                    )[rank * chunk : (rank + 1) * chunk]
+                    for shard in shards
+                ],
+                dim=0,
+            )
+
+        monkeypatch.setattr(engram_ops, "_engram_sp_exchange", exchange)
         torch.testing.assert_close(
             module.embed(ids), padded[rank * chunk : (rank + 1) * chunk], rtol=0, atol=0
         )

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -44,6 +44,7 @@ from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    get_tp_group,
     tensor_model_parallel_all_gather,
 )
 from vllm.logger import init_logger
@@ -52,12 +53,38 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
-from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+from vllm.utils.torch_utils import (
+    direct_register_custom_op,
+    get_accelerator_view_from_cpu_tensor,
+)
+
+from .engram_parallel import exchange_heads_for_tokens
 
 logger = init_logger(__name__)
 
 # Cache value for tokens that take no part in an n-gram (image spans).
 DEAD_ID = -1
+
+
+def _engram_sp_all_to_all(rows: torch.Tensor) -> torch.Tensor:
+    output = torch.empty_like(rows)
+    torch.distributed.all_to_all_single(output, rows, group=get_tp_group().device_group)
+    return output
+
+
+def _engram_sp_all_to_all_fake(rows: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(rows)
+
+
+direct_register_custom_op(
+    op_name="engram_sp_all_to_all",
+    op_func=_engram_sp_all_to_all,
+    fake_impl=_engram_sp_all_to_all_fake,
+)
+
+
+def _engram_sp_exchange(rows: torch.Tensor) -> torch.Tensor:
+    return torch.ops.vllm.engram_sp_all_to_all(rows)
 
 
 def _is_prime(n: int) -> bool:
@@ -854,28 +881,6 @@ def _fused_engram_post_wkv_kernel(
     )
 
 
-@triton.jit(do_not_specialize=["num_tokens", "token_start", "num_elements"])
-def _engram_sp_rows_kernel(
-    gathered,
-    output,
-    num_tokens,
-    token_start,
-    num_elements,
-    LOCAL_WIDTH: tl.constexpr,
-    WIDTH: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-):
-    offsets = tl.program_id(0).to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    tokens = token_start + offsets // WIDTH
-    cols = offsets % WIDTH
-    source = (cols // LOCAL_WIDTH * num_tokens + tokens) * LOCAL_WIDTH
-    source += cols % LOCAL_WIDTH
-    values = tl.load(
-        gathered + source, (offsets < num_elements) & (tokens < num_tokens), other=0
-    )
-    tl.store(output + offsets, values, offsets < num_elements)
-
-
 class Engram(nn.Module):
     """Writes an n-gram lookup into the residual stream, gated by how well it
     matches that stream.
@@ -950,22 +955,12 @@ class Engram(nn.Module):
         if self.embed_tokens.tp_size == 1:
             return rows
         if self.use_sequence_parallel:
-            tp_size = self.embed_tokens.tp_size
-            num_tokens, local_heads, dim = rows.shape
-            gathered = tensor_model_parallel_all_gather(rows, dim=0)
-            chunk = (num_tokens + tp_size - 1) // tp_size
-            rows = rows.new_empty((chunk, self.embed_tokens.n_hash_cols, dim))
-            _engram_sp_rows_kernel[(triton.cdiv(rows.numel(), 1024),)](
-                gathered,
+            return exchange_heads_for_tokens(
                 rows,
-                num_tokens,
-                get_tensor_model_parallel_rank() * chunk,
-                rows.numel(),
-                local_heads * dim,
-                self.embed_tokens.n_hash_cols * dim,
-                BLOCK_SIZE=1024,
+                self.embed_tokens.tp_size,
+                self.embed_tokens.n_hash_cols,
+                _engram_sp_exchange,
             )
-            return rows
         rows = tensor_model_parallel_all_gather(rows, dim=1)
         return rows[:, : self.embed_tokens.n_hash_cols]
 

--- a/vllm/models/deepseek_v4_1/common/engram_parallel.py
+++ b/vllm/models/deepseek_v4_1/common/engram_parallel.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Redistribute head-sharded Engram rows to sequence-parallel token owners."""
+
+from collections.abc import Callable
+
+import torch
+
+
+def exchange_heads_for_tokens(
+    rows: torch.Tensor,
+    tp_size: int,
+    num_heads: int,
+    exchange: Callable[[torch.Tensor], torch.Tensor],
+) -> torch.Tensor:
+    """Return this rank's padded token chunk with all non-padding heads.
+
+    Args:
+        rows: All tokens and this rank's padded head shard, shaped [T, H/P, D].
+        tp_size: Number of head and token owners.
+        num_heads: Unpadded global head count.
+        exchange: Equal-split all-to-all in rank order along the token dimension.
+    """
+    num_tokens, local_heads, dim = rows.shape
+    if not num_tokens:
+        return rows.new_empty((0, num_heads, dim))
+    chunk = (num_tokens + tp_size - 1) // tp_size
+    padding = chunk * tp_size - num_tokens
+    if padding:
+        rows = torch.nn.functional.pad(rows, (0, 0, 0, 0, 0, padding))
+    else:
+        rows = rows.contiguous()
+    received = exchange(rows)
+    return (
+        received.view(tp_size, chunk, local_heads, dim)
+        .permute(1, 0, 2, 3)
+        .reshape(chunk, tp_size * local_heads, dim)[:, :num_heads]
+    )


### PR DESCRIPTION
## Purpose

Redistribute DeepSeek-V4.1 Engram head shards directly to their sequence-parallel token owners with an equal-split all-to-all. The original path gathers every token's head shards on each TP rank before keeping that rank's token slice. This implementation receives the local token slice, restores head order, and trims padded heads.

The submitted candidate **C** also avoids a zero-length `F.pad` clone: already padded, contiguous lookup rows are reused directly; non-contiguous inputs are still made contiguous. Uneven token counts retain zero padding. The operation uses the actual TP device group and has a registered fake implementation for compilation. TP1 and empty-token cases do not communicate.

Stacked on #56214 (`dsv41-feat`, baseline `c9d909e802a39292f54101bff8a36096761ea605`). The diff contains only the final C implementation and its tests, across four files. It does not include experimental variants, benchmark artifacts, lookup overlap, PP changes, DP table sharding, or DBO changes.

Rebased on 2026-09-11 after the feature branch was rewritten. Changed-file Python parsing and all applicable pre-commit hooks passed. The TP2/TP4 CPU Gloo redistribution tests passed (2 passed; 3 CUDA cases skipped). GPU/full-model measurements below belong to the prior revision based on `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`; they were not rerun on this rebased head.

Duplicate-work check: #56230 shards the embedding tables across DP replicas. This PR preserves table placement and changes the existing TP head-to-SP-token redistribution, so it addresses a different operation. The related lookup-overlap and PP-boundary PRs also have separate scopes.

## Test Plan

Run the existing Engram kernel suite and the redistribution suite on four H100s:

```sh
PYTHONPATH="$PWD:$PWD/.." .venv/bin/python -m pytest --noconftest -o addopts= \
  tests/distributed/test_engram_parallel.py tests/kernels/test_engram.py -q
```

Run pre-commit for the four changed files:

```sh
.venv/bin/pre-commit run --files \
  vllm/models/deepseek_v4_1/common/engram.py \
  vllm/models/deepseek_v4_1/common/engram_parallel.py \
  tests/distributed/test_engram_parallel.py \
  tests/kernels/test_engram.py
```

For serving, compare **A**, the actual baseline source, against **C**, the final implementation, in separate source directories with the same dependencies and source-built CUDA extension loader. Each worker's source path/hash and TP membership were checked.

Configuration: one node with **4×H100 80GB HBM3**, NV18 links; `deepseek-ai/DeepSeek-V4.1-Flash` revision `df42c109f1defefcbfcedbe7d905718a12266e40`; checkpoint FP8/FP4 quantization; **DP2 × TP2, PP1, EP enabled**, `allgather_reducescatter` MoE backend, **eager**, CPU offload 8 GiB, Engram CPU offload enabled, max context 4096, max batched tokens 512, max sequences 4, GPU memory utilization 0.94, prefix caching disabled. Engram groups are `[0,1]` and `[2,3]`, with 12 local heads of dimension 256 in BF16. Runtime: PyTorch 2.13.0+cu130, CUDA 13.0, NCCL 2.29.7.

Each workload uses 16 requests, concurrency 4, seed 42, four warmup requests, and exactly 128 output tokens with EOS ignored. The benchmark targets an already running server:

```sh
.venv/bin/vllm bench serve --backend vllm \
  --base-url http://127.0.0.1:18080 --endpoint /v1/completions --model dsv41 \
  --tokenizer "$MODEL" --tokenizer-mode deepseek_v41 --dataset-name random \
  --random-input-len "$INPUT_LEN" --random-output-len 128 \
  --random-range-ratio 0 --random-prefix-len 0 --num-prompts 16 \
  --max-concurrency 4 --request-rate inf --seed 42 --num-warmups 4 \
  --ignore-eos --disable-tqdm --save-result --save-detailed \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 10,50,90,95 \
  --result-dir "$RESULTS" --result-filename "$RESULT_FILE"
```

`INPUT_LEN` is 512 or 2048. `MODEL` names the local checkpoint; `RESULTS` and `RESULT_FILE` select the output location.

## End-to-end Test Result

| Input → output tokens | Metric | A: original all-gather | C: this implementation | Change C/A |
|---|---|---:|---:|---:|
| 512 → 128 | Output tokens/s ↑ | 18.2667 | 18.4360 | +0.93% |
| 512 → 128 | p95 TTFT (ms) ↓ | 3984.89 | 3936.77 | -1.21% |
| 512 → 128 | p95 TPOT (ms) ↓ | 207.51 | 204.86 | -1.28% |
| 512 → 128 | p95 E2E latency (ms) ↓ | 29989.74 | 29954.16 | -0.12% |
| 2048 → 128 | Output tokens/s ↑ | 13.3178 | 13.4953 | +1.33% |
| 2048 → 128 | p95 TTFT (ms) ↓ | 14557.72 | 14529.45 | -0.19% |
| 2048 → 128 | p95 TPOT (ms) ↓ | 243.88 | 240.55 | -1.36% |
| 2048 → 128 | p95 E2E latency (ms) ↓ | 43624.29 | 43480.14 | -0.33% |

**One independent measurement per arm/workload.** All four measurements completed 16/16 requests with zero failures and 2,048 output tokens each. These are single-run observations, without confidence intervals; they do not establish a statistically validated speedup.

### Correctness and limitations

| Check | Result |
|---|---|
| Engram suites in the H100 environment | **70 passed** in 126.12 s; includes CPU and CUDA tests |
| Four-GPU production `Engram.embed` coverage | TP1/2/4, non-default groups, BF16/FP32, 23/24 heads, contiguous/strided inputs, empty input and token/padding boundaries; 1,248 rank-level exact comparisons passed |
| Changing-input CUDA graph replay | Two independent buffers/ordered streams, 100 replays each per TP configuration; 2,400 rank-level output checks passed |
| Existing kernel/module coverage | Lookup/dequantization, hash cache, fused consumer, prepared rows, full and breakable graphs passed |
| Pre-commit | All applicable hooks passed |
| Fixed greedy QA | A and C both 6/6 correct; identical answer text and returned token strings; largest sampled-token logprob difference approximately 0.02446 |
| Four concurrent 96-token continuations | A and C both completed all requests with finite returned values; **0/4 sequences were identical** |
| Candidate path | C's four workers recorded 11,516 Engram embed calls over the whole serving session; TP2/SP uses all-to-all, with no all-gather fallback |

**Full-model equivalence remains unresolved.** The four continuations first diverged at zero-based token positions 7, 2, 17, and 15. Some alternatives were tied or close; others showed clear ranking changes, so these differences cannot all be dismissed as rounding. Concurrent batching/quantization sensitivity has not been established as the cause. There were no observed NaN/Inf values or failed requests, but successful requests are not proof of token-level equivalence. This remains a **draft**, without an end-to-end correctness or optimization-validation claim.

A TP2, 512-token diagnostic measured redistribution temporary allocation peaks of 9 MiB/rank for A and 6 MiB/rank for C. That is a local workspace observation, not a whole-model memory claim. Startup available-KV logs were 6.74 GiB for both at the displayed precision; complete symmetric per-rank runtime/KV measurements were not obtained.

AI assistance: implementation, testing, and this description were prepared with OpenAI Codex at the author's direction.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and scope described.
- [x] Test commands and configuration included.
- [x] A/C results and unresolved model-output differences included.
- [ ] Human line-by-line review completed.

</details>
