### PR TITLE
[Perf][Engram] Overlap DeepSeek-V4.1 lookup with decoder compute

### DIFF
--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -662,13 +662,14 @@ def test_engram_lookup_matches_torch(cpu_offload, background, num_tokens):
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
 @pytest.mark.parametrize("cpu_offload", [False, True])
 @pytest.mark.parametrize("capture", ["eager", "full", "breakable"])
-def test_engram_prepared_rows_survive_graph_breaks(cpu_offload, capture):
+@pytest.mark.parametrize("overlap", [False, True])
+def test_engram_prepared_rows_survive_graph_breaks(cpu_offload, capture, overlap):
     """Consume early lookup results after a break, with fresh IDs each replay."""
-    _run_engram_prepared_rows(cpu_offload, capture)
+    _run_engram_prepared_rows(cpu_offload, capture, overlap=overlap)
 
 
 def _run_engram_prepared_rows(
-    cpu_offload, capture, tp_size=1, rank=0, use_sequence_parallel=False
+    cpu_offload, capture, tp_size=1, rank=0, use_sequence_parallel=False, overlap=False
 ):
     from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 
@@ -689,6 +690,7 @@ def _run_engram_prepared_rows(
         dtype=torch.bfloat16,
         device="cuda",
     )
+    engram._init_lookup_staging(1, overlap)
     # Match the non-contiguous per-layer slice of the model hash tensor.
     hashes = torch.randint(
         0,
@@ -762,17 +764,28 @@ def _engram_tp_worker(rank, tp_size, port):
         for cpu_offload in (False, True):
             for sp in (False, True):
                 for capture in ("eager", "compiled", "full", "breakable"):
-                    _run_engram_prepared_rows(cpu_offload, capture, tp_size, rank, sp)
+                    for overlap in (False, True):
+                        _run_engram_prepared_rows(
+                            cpu_offload, capture, tp_size, rank, sp, overlap=overlap
+                        )
     finally:
         cleanup_dist_env_and_memory()
 
 
-@pytest.mark.distributed(num_gpus=2)
+@pytest.mark.parametrize(
+    "tp_size",
+    [
+        pytest.param(2, marks=pytest.mark.distributed(num_gpus=2)),
+        pytest.param(4, marks=pytest.mark.distributed(num_gpus=4)),
+    ],
+)
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
-def test_engram_head_collectives_survive_graph_breaks():
-    """All-gather preserves head order and local SP tokens across graph replay."""
+def test_engram_head_collectives_survive_graph_breaks(tp_size):
+    """All-gather preserves staged SP tokens across graph and compile replay."""
     from vllm.utils.network_utils import get_open_port
 
-    if torch.accelerator.device_count() < 2:
-        pytest.skip("Requires two GPUs")
-    torch.multiprocessing.spawn(_engram_tp_worker, args=(2, get_open_port()), nprocs=2)
+    if torch.accelerator.device_count() < tp_size:
+        pytest.skip(f"Requires {tp_size} GPUs")
+    torch.multiprocessing.spawn(
+        _engram_tp_worker, args=(tp_size, get_open_port()), nprocs=tp_size
+    )

--- a/vllm/config/engram.py
+++ b/vllm/config/engram.py
@@ -47,6 +47,9 @@ class EngramConfig:
     """Shard embeddings across TP and all DP ranks when enabled.
     Otherwise, each DP rank has a separate TP-sharded embedding replica."""
 
+    lookup_overlap: bool = False
+    """Prefetch Engram rows on a separate CUDA stream while decoder layers run."""
+
     def verify_model_config(self, model_config: "ModelConfig | None") -> None:
         """Reject Engram configuration for models without n-gram embeddings."""
         from vllm.platforms import current_platform

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -40,6 +40,7 @@ import numpy as np
 import torch
 from torch import nn
 
+from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -53,6 +54,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 logger = init_logger(__name__)
 
@@ -939,14 +941,70 @@ class Engram(nn.Module):
             layout.head_dim,
             dtype=torch.bfloat16,
         )
+        parallel_config = get_current_vllm_config().parallel_config
+        self._init_lookup_staging(
+            parallel_config.num_ubatches if parallel_config.use_ubatching else 1,
+            engram_config.lookup_overlap if engram_config else False,
+        )
 
-    def prepare_embeddings(self, hash_ids: torch.Tensor) -> None:
-        """Gather this layer's rows on the main stream before decoder layers."""
-        self.embed_tokens.lookup(hash_ids, self.staged_rows[: hash_ids.shape[0]])
+    def _init_lookup_staging(self, num_slots: int, overlap: bool) -> None:
+        self._lookup_rows = [self.staged_rows] + [
+            torch.empty_like(self.staged_rows) for _ in range(num_slots - 1)
+        ]
+        self._lookup_streams = (
+            [
+                torch.cuda.Stream(device=self.staged_rows.device)
+                for _ in range(num_slots)
+            ]
+            if overlap
+            else []
+        )
+        self._lookup_ready = [torch.cuda.Event() for _ in self._lookup_streams]
 
-    def embed(self, hash_ids: torch.Tensor) -> torch.Tensor:
+    def _lookup_slot(self) -> int:
+        rows = getattr(self, "_lookup_rows", None)
+        return dbo_current_ubatch_id() if rows is not None and len(rows) > 1 else 0
+
+    def wait_for_embeddings(self) -> None:
+        if (
+            getattr(self, "_lookup_streams", None)
+            and not BreakableCUDAGraphCapture.is_active()
+        ):
+            torch.cuda.current_stream().wait_event(
+                self._lookup_ready[self._lookup_slot()]
+            )
+
+    def prepare_embeddings(self, hash_ids: torch.Tensor) -> torch.Tensor:
+        """Stage local heads after hashing, optionally overlapping decoder compute."""
+        slot = self._lookup_slot()
+        buffers = getattr(self, "_lookup_rows", None)
+        rows = (buffers[slot] if buffers is not None else self.staged_rows)[
+            : hash_ids.shape[0]
+        ]
+        streams = getattr(self, "_lookup_streams", None)
+        if streams and not BreakableCUDAGraphCapture.is_active():
+            stream = streams[slot]
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream):
+                self.embed_tokens.lookup(hash_ids, rows, background=True)
+                self._lookup_ready[slot].record(stream)
+        else:
+            self.embed_tokens.lookup(hash_ids, rows)
+        return rows
+
+    def embed(
+        self, hash_ids: torch.Tensor, prepared_rows: torch.Tensor | None = None
+    ) -> torch.Tensor:
         """Gather heads, returning only local tokens when SP is enabled."""
-        rows = self.staged_rows[: hash_ids.shape[0]]
+        if prepared_rows is None:
+            self.wait_for_embeddings()
+            buffers = getattr(self, "_lookup_rows", None)
+            prepared_rows = (
+                buffers[self._lookup_slot()]
+                if buffers is not None
+                else self.staged_rows
+            )
+        rows = prepared_rows[: hash_ids.shape[0]]
         if self.embed_tokens.tp_size == 1:
             return rows
         if self.use_sequence_parallel:
@@ -974,11 +1032,12 @@ class Engram(nn.Module):
         hidden_states: torch.Tensor,
         hash_ids: torch.Tensor,
         token_mask: torch.Tensor | None = None,
+        prepared_rows: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """hidden_states: [T, hc_mult, dim]; hash_ids: [T, n_hash_cols] (all
         tokens, pre sequence-parallel shard); token_mask: [T], False shuts
         the gate so those positions pass through untouched."""
-        kv = self.wkv(self.embed(hash_ids).flatten(-2))
+        kv = self.wkv(self.embed(hash_ids, prepared_rows).flatten(-2))
         num_kv_tokens = hash_ids.shape[0]
         assert token_mask is None or token_mask.shape == (num_kv_tokens,)
         if self.use_sequence_parallel:

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -293,6 +293,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         residual: torch.Tensor | None = None,
         engram_hashes: torch.Tensor | None = None,
         engram_mask: torch.Tensor | None = None,
+        engram_rows: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         # The reference collapses each sublayer's input with the *previous*
         # sublayer's pre-mix: attention uses the pre-mix carried in (identity
@@ -343,6 +344,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                     residual,
                     engram_hashes[:, self.engram.layer_hash_index],
                     engram_mask,
+                    prepared_rows=engram_rows,
                 )
             post_mix, res_mix, x, attn_pre = mhc_pre_delayed_tilelang(
                 residual,
@@ -556,6 +558,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # profile runs (KV cache unbound).
         engram_hashes: torch.Tensor | None = None
         engram_mask: torch.Tensor | None = None
+        engram_rows: dict[int, torch.Tensor] = {}
         if (
             self.engram_hash is not None
             and input_ids is not None
@@ -598,8 +601,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 for layer in islice(self.layers, self.start_layer, self.end_layer):
                     engram = getattr(layer, "engram", None)
                     if engram is not None:
-                        engram.prepare_embeddings(
-                            engram_hashes[:, engram.layer_hash_index]
+                        engram_rows[engram.layer_hash_index] = (
+                            engram.prepare_embeddings(
+                                engram_hashes[:, engram.layer_hash_index]
+                            )
                         )
 
         full_num_tokens = positions.shape[0]
@@ -623,6 +628,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
+            prepared_rows = None
+            if layer.engram is not None and engram_hashes is not None:
+                layer.engram.wait_for_embeddings()
+                prepared_rows = engram_rows[layer.engram.layer_hash_index]
             hidden_states, residual, post_mix, res_mix, pre_mix = layer(
                 hidden_states,
                 positions,
@@ -633,6 +642,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 residual,
                 engram_hashes,
                 engram_mask,
+                prepared_rows,
             )
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models


### PR DESCRIPTION
## Purpose

Add the default-off `--engram-config '{"lookup_overlap":true}'` option. Stage each Engram layer's local embedding rows on its own CUDA stream, then wait for the completion event immediately before the decoder consumes those rows. Keep staging storage separate between microbatches and pass the prepared tensor through the decoder call. Breakable CUDA graph capture uses the existing main-stream lookup path.

This change preserves the upstream SP all-gather exchange. It does not include the all-to-all work in #56219 or the lookback reconstruction in #56224. The duplicate-work check also found #56230, which changes DP table ownership/communication; that is different from the lookup scheduling here.

Based on #56214 (`dsv41-feat`, `c9d909e802a39292f54101bff8a36096761ea605`). The PR targets that feature branch so the model implementation is not repeated in this diff.

Rebased on 2026-09-11 after the feature branch was rewritten. Changed-file Python parsing and all applicable pre-commit hooks passed. The older H100 integration measurements below belong to the prior revision based on `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`. A selected same-head H200 screening result is reported separately below, with an unresolved concurrent-output difference.

AI assistance: OpenAI Codex assisted with implementation, review, test execution and preparation of this PR. This draft does not claim that a human has completed a line-by-line review.

## Test Plan

Fresh split: all applicable pre-commit hooks passed for the four changed files, and all changed Python files parsed successfully.

The existing GPU tests were extended for lookup overlap on/off, eager/full/breakable capture, CPU/GPU table placement and TP2/TP4. The integration validation ran the prepared-row and collective graph tests in `tests/kernels/test_engram.py`; CUDA execution was not repeated on the split branch.

## Test Result

### 2026-09-11: selected positive H200 workload on the current head

Both arms used `2ae34345ee5919130a6a08fe91f969d174b8b69e` with `lookup_overlap=false/true`, the pinned V4.1 Flash checkpoint, 4 x H200 NVL over PCIe (no NVLink), TP4/PP1/DP1 + EP, eager V1, Engram CPU offload and zero generic CPU offload. Prefix caching was enabled; the cache was reset before four warmup requests and sixteen measured requests per arm.

| Input → output tokens | Concurrency | Overlap off, output tokens/s | Overlap on, output tokens/s | Observed change |
| --- | ---: | ---: | ---: | ---: |
| 512 → 128 | 4 | 71.39797 | 72.97452 | **+2.21%** |

All sixteen measured requests per arm succeeded and generated exactly 128 output tokens. This is one A/B pair and a selected positive workload, not the complete workload matrix or evidence of a general/statistically established speedup. Startup time is excluded.

Correctness remains unresolved: the separate serial and fixed-prefix probes matched, but one of four concurrent responses diverged at the fifth generated token; no A/A repeat was run to establish the cause. This result is not an output-equivalence or merge qualification.

[Benchmark timing records, exact flags and provenance](https://github.com/0z5a/vllm/tree/codex/dsv41-h200-positive512-20260911/benchmarks/results/deepseek-v41-h200-20260911-positive512). OpenAI Codex assisted with execution and reporting.

### Earlier combined H100 integration evidence

Recorded full-model runs used `deepseek-ai/DeepSeek-V4.1-Flash`, revision `df42c109f1defefcbfcedbe7d905718a12266e40`, on 4×SXM H100 80 GiB. Each positive matrix case checked six short questions, cold/cached long input with chunked prefill, and four unequal-length concurrent requests. “Text equal” means short-answer text equality to the TP4 reference, not logits/token-probability parity or a standard accuracy benchmark.

**Evidence scope:** GPU results below come from the earlier combined integration based on #56214, including companion changes. These older rows do not describe the separate same-head H200 screening reported above. Fresh split checks are listed separately; passing the integrated run does not establish isolated-branch equivalence.

| Integrated configuration | QA answers correct | QA text equal to TP4 | Long / chunked + prefix | Concurrent requests | Strict result |
| --- | --- | --- | --- | --- | --- |
| TP4 eager, synchronous reference | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| TP4 eager, lookup overlap | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| TP4 breakable decode graph, synchronous | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| TP4 breakable decode graph, overlap option | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| DP2×TP2 SP eager, synchronous | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| DP2×TP2 SP eager, overlap | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| DP2×TP2 SP breakable graph, synchronous | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| DP2×TP2 SP breakable graph, overlap option | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |

Breakable graph capture was confirmed with `FULL_DECODE_ONLY`, sizes `[1,2,4]`, and Torch compile disabled. During capture the overlap option uses the main-stream fallback. The DP2×TP2 integration also included the companion SP exchange; this PR retains upstream all-gather.

**Serving A/B — TP4 eager, synchronous lookup → overlap**

| Input → output tokens | Synchronous output tokens/s | Overlap output tokens/s | Observed throughput change | TTFT median ms, sync → overlap | TPOT median ms, sync → overlap |
| --- | --- | --- | --- | --- | --- |
| 512 → 128 | 40.15 | 40.57 | +1.04% | 421.1 → 419.1 | 96.13 → 95.70 |
| 2048 → 128 | 38.07 | 38.38 | +0.82% | 764.0 → 758.1 | 98.03 → 97.20 |

Each side ran three repeats of 16 requests at concurrency 4 after warmup, with fixed inputs, prefix cache disabled, and the same default sampling settings. Values are medians across repeats; percent changes use unrounded data. These small observed changes are not a statistically established speedup. No graph-overlap speedup is claimed.

| Validation / memory measurement | Result | Scope |
| --- | --- | --- |
| Fresh split pre-commit and changed Python parsing | PASS; 4 changed files | This PR's isolated source |
| Model-loading footprint, sync → overlap | 71.22 → 71.22 GiB | Rank 0 startup log; no measured reduction |
| Available KV budget, sync → overlap | 1.96 → 1.96 GiB | Rounded startup values, not request peak memory |

---
<details>
<summary>PR description checklist</summary>

- [x] Purpose and related work described.
- [x] Test plan and actual results stated.
- [x] Model evaluation limitations stated.
- [x] AI assistance disclosed.

</details>
