### PR TITLE
[Model][PP] Validate DeepSeek-V4.1 sharing dependencies before construction

### DIFF
--- a/tests/models/test_deepseek_v41_pipeline.py
+++ b/tests/models/test_deepseek_v41_pipeline.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.models.deepseek_v4_1.common.pipeline import (
+    get_sharing_dependencies,
+    validate_local_sharing,
+)
+
+
+def _config():
+    return SimpleNamespace(
+        num_hidden_layers=40,
+        compress_ratios=[0, 0] + [2] * 18 + [1] * 20,
+        kv_source_layer_ids=[2, 8, 14, 20],
+        index_source_layer_ids=[2, 8, 14, 20, 24, 28, 32, 36],
+        candidate_source_layer_id=20,
+        candidate_topk_blocks=2048,
+    )
+
+
+@pytest.mark.parametrize(
+    "ranges", [[(0, 40)], [(0, 20), (20, 40)], [(0, 8), (8, 14), (14, 20), (20, 40)]]
+)
+def test_group_aligned_pipeline_cuts_keep_all_sources_local(ranges):
+    validate_local_sharing(get_sharing_dependencies(_config(), ranges))
+
+
+def test_equal_pp4_reports_cross_stage_kv_index_and_candidates():
+    dependencies = get_sharing_dependencies(
+        _config(), [(0, 10), (10, 20), (20, 30), (30, 40)]
+    )
+    cross = {
+        (d.kind, d.source_layer, d.consumer_layer)
+        for d in dependencies
+        if d.source_stage != d.consumer_stage
+    }
+    assert {("kv", 8, 10), ("index", 28, 30), ("candidate", 20, 32)} <= cross
+    with pytest.raises(NotImplementedError, match="source layer 8.*stage 0.*stage 1"):
+        validate_local_sharing(dependencies)
+
+
+@pytest.mark.parametrize("values", [[8, 2], [2, 2], [0, 2], [-1, 2], [2, 40]])
+def test_invalid_source_lists_fail_before_layer_construction(values):
+    config = _config()
+    config.kv_source_layer_ids = values
+    with pytest.raises(ValueError, match="kv_source_layer_ids"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_compressed_consumer_requires_an_earlier_source():
+    config = _config()
+    config.kv_source_layer_ids = [8, 14, 20]
+    with pytest.raises(ValueError, match="layer 2 has no preceding kv source"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_candidate_source_must_publish_indices():
+    config = _config()
+    config.candidate_source_layer_id = 21
+    with pytest.raises(ValueError, match="candidate source must be an index source"):
+        get_sharing_dependencies(config, [(0, 40)])

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1328,6 +1328,30 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_pp_empty_uniform_group_does_not_allocate_remote_layers():
+    """An empty projected group retains its type, but must allocate no layers."""
+    spec = new_kv_cache_spec()
+    remote_spec = UniformTypeKVCacheSpecs(
+        block_size=spec.block_size,
+        kv_cache_specs={"remote": spec},
+    )
+    groups = kv_cache_utils._project_kv_cache_groups_to_worker(
+        [
+            KVCacheGroupSpec(["remote"], remote_spec),
+            KVCacheGroupSpec(["local"], spec),
+        ],
+        {"local": spec},
+    )
+    config = VllmConfig()
+    config.cache_config.kv_cache_layout = "BLHNC"
+    cache = kv_cache_utils.get_kv_cache_config_from_groups(
+        config, groups, spec.page_size_bytes * 4
+    )
+    assert cache.num_blocks == 4
+    assert [tensor.layers for tensor in cache.kv_cache_tensors] == [["local"]]
+    assert cache.kv_cache_groups[0].layer_names == []
+
+
 def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
     dcp = 8
     full = FullAttentionSpec(

--- a/vllm/models/deepseek_v4_1/common/pipeline.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-sharing dependencies of a DeepSeek V4.1 pipeline partition."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SharingDependency:
+    kind: str
+    source_layer: int
+    consumer_layer: int
+    source_stage: int
+    consumer_stage: int
+
+
+def get_sharing_dependencies(
+    config: Any, stage_ranges: list[tuple[int, int]]
+) -> tuple[SharingDependency, ...]:
+    """Resolve KV, index and candidate sources before constructing any layers."""
+    num_layers = config.num_hidden_layers
+    if (
+        not stage_ranges
+        or stage_ranges[0][0] != 0
+        or stage_ranges[-1][1] != num_layers
+        or any(start >= end for start, end in stage_ranges)
+        or any(a[1] != b[0] for a, b in zip(stage_ranges, stage_ranges[1:]))
+    ):
+        raise ValueError("DeepSeek V4.1 pipeline stages must partition all layers")
+    owners = {
+        layer: stage
+        for stage, (start, end) in enumerate(stage_ranges)
+        for layer in range(start, end)
+    }
+    ratios = config.compress_ratios
+    if len(ratios) < num_layers:
+        raise ValueError(
+            "DeepSeek V4.1 compress_ratios must cover every backbone layer"
+        )
+
+    sources = {}
+    for kind, field in (
+        ("kv", "kv_source_layer_ids"),
+        ("index", "index_source_layer_ids"),
+    ):
+        values = tuple(getattr(config, field, None) or ())
+        if (
+            any(
+                type(layer) is not int or not 0 <= layer < num_layers
+                for layer in values
+            )
+            or values != tuple(sorted(set(values)))
+            or any(ratios[layer] == 0 for layer in values)
+        ):
+            raise ValueError(
+                f"DeepSeek V4.1 {field} must contain sorted, unique compressed layers"
+            )
+        sources[kind] = values
+
+    if not set(sources["kv"]).issubset(sources["index"]):
+        raise ValueError("DeepSeek V4.1 KV sources must also publish index keys")
+
+    dependencies = []
+
+    def append(kind: str, source: int, consumer: int) -> None:
+        if source != consumer:
+            dependencies.append(
+                SharingDependency(
+                    kind, source, consumer, owners[source], owners[consumer]
+                )
+            )
+
+    for layer in range(num_layers):
+        if ratios[layer] == 0:
+            continue
+        for kind, values in sources.items():
+            preceding = [source for source in values if source <= layer]
+            if not preceding:
+                raise ValueError(
+                    f"DeepSeek V4.1 layer {layer} has no preceding {kind} source"
+                )
+            append(kind, preceding[-1], layer)
+            if kind == "kv" and layer in sources["index"]:
+                append("index_k", preceding[-1], layer)
+
+    candidate = getattr(config, "candidate_source_layer_id", -1)
+    if candidate >= 0 and getattr(config, "candidate_topk_blocks", 0) > 0:
+        if candidate not in sources["index"]:
+            raise ValueError("DeepSeek V4.1 candidate source must be an index source")
+        for layer in sources["index"]:
+            if layer > candidate:
+                append("candidate", candidate, layer)
+    return tuple(dependencies)
+
+
+def validate_local_sharing(dependencies: tuple[SharingDependency, ...]) -> None:
+    """Reject stage cuts that require sharing tensors between pipeline ranks."""
+    cross_stage = [d for d in dependencies if d.source_stage != d.consumer_stage]
+    if cross_stage:
+        detail = "; ".join(
+            f"{d.kind} source layer {d.source_layer} (stage {d.source_stage}) -> "
+            f"layer {d.consumer_layer} (stage {d.consumer_stage})"
+            for d in cross_stage[:4]
+        )
+        raise NotImplementedError(
+            "DeepSeek V4.1 pipeline partition crosses layer-sharing dependencies: "
+            f"{detail}. Keep each sharing group on one pipeline stage."
+        )

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -76,6 +76,7 @@ from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 from ..common.engram import Engram, EngramLayout, NgramHashState
 from ..common.mm_preprocess import IMAGE_SENTINEL_BASE_ID, image_sentinel_mask
+from ..common.pipeline import get_sharing_dependencies, validate_local_sharing
 
 if typing.TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
@@ -391,6 +392,14 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        from vllm.distributed.utils import get_pp_indices
+
+        pp_size = get_pp_group().world_size
+        stage_ranges = [
+            get_pp_indices(config.num_hidden_layers, rank, pp_size)
+            for rank in range(pp_size)
+        ]
+        validate_local_sharing(get_sharing_dependencies(config, stage_ranges))
         self.config = config
         self.quant_config = quant_config
         self.parallel_config = vllm_config.parallel_config

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1725,13 +1725,9 @@ def get_kv_cache_config_from_groups(
 
     kv_cache_tensors = []
     for group in kv_cache_groups:
-        group_spec = group.kv_cache_spec
         layers_by_spec: defaultdict[KVCacheSpec, list[str]] = defaultdict(list)
-        if isinstance(group_spec, UniformTypeKVCacheSpecs):
-            for layer_name, spec in group_spec.kv_cache_specs.items():
-                layers_by_spec[spec].append(layer_name)
-        elif group.layer_names:
-            layers_by_spec[group_spec].extend(group.layer_names)
+        for layer_name in group.layer_names:
+            layers_by_spec[_get_per_layer_spec(group, layer_name)].append(layer_name)
 
         byte_offset = 0
         for spec, layer_names in layers_by_spec.items():


### PR DESCRIPTION
## Purpose

Resolve each KV, index-key, top-k and candidate dependency before constructing pipeline layers. Invalid source lists and stage cuts now report the source/consumer layers and stages instead of failing later during layer/cache setup. Valid sharing-group-aligned cuts continue to work.

Also allocate cache tensors only for a projected group's local `layer_names`: an empty `UniformTypeKVCacheSpecs` group must not allocate its remote layers. This allocation repair is a prerequisite shared with #56222 and #56223. This PR does not enable cross-stage transfer; #56223 contains that separate opt-in implementation.

Searched open V4.1/pipeline-sharing PRs and the #56214 references. No other open PR found implements this V4.1 source-dependency precheck plus empty projected-group allocation fix.

Based on #56214 (`dsv41-feat`, `c9d909e802a39292f54101bff8a36096761ea605`). The PR targets that feature branch so the model implementation is not repeated in this diff.

Rebased on 2026-09-11 after the feature branch was rewritten. Changed-file Python parsing and all applicable pre-commit hooks passed. The pipeline dependency suite passed (11 CPU tests). GPU/full-model measurements below belong to the prior revision based on `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`; they were not rerun on this rebased head.

AI assistance: OpenAI Codex assisted with implementation, review, test execution and preparation of this PR. This draft does not claim that a human has completed a line-by-line review.

## Test Plan

Fresh split: **11 CPU tests passed** in `tests/models/test_deepseek_v41_pipeline.py`, using a standalone dependency-light loader (`pytest -q --noconftest -o addopts=` after loading the actual pure dependency module). All applicable pre-commit hooks and changed-file Python parsing passed.

The integration also ran the projected-cache-group tests in `tests/v1/core/test_kv_cache_utils.py` on H100. The allocation implementation and its regression test are unchanged by the split.

## Test Result

Recorded full-model runs used `deepseek-ai/DeepSeek-V4.1-Flash`, revision `df42c109f1defefcbfcedbe7d905718a12266e40`, on 4×SXM H100 80 GiB. Each positive matrix case checked six short questions, cold/cached long input with chunked prefill, and four unequal-length concurrent requests. “Text equal” means short-answer text equality to the TP4 reference, not logits/token-probability parity or a standard accuracy benchmark.

**Evidence scope:** GPU results below come from the earlier combined integration based on #56214, including companion changes. The isolated PR has not had a new full-model GPU run. Fresh split checks are listed separately; passing the integrated run does not establish isolated-branch equivalence.

| Integrated configuration / check | Observed result | Meaning |
| --- | --- | --- |
| PP2×TP2, 20/20 layers | QA 6/6 correct and text-equal; long/prefix 2/2; concurrent 4/4 | Valid partition completes full-model serving checks |
| PP4×TP1, equal 10/10/10/10 layers, sharing disabled | Expected dependency rejection before layer construction | Invalid partition fails early with source/consumer information |
| H100 projected-cache-group regression tests | 2/2 PASS | Empty stage-local groups do not allocate remote-layer caches |

| Fresh split validation | Result |
| --- | --- |
| Pure pipeline dependency tests | 11/11 CPU PASS, using the standalone loader below |
| Applicable pre-commit hooks and changed Python parsing | PASS; 5 changed files |

This change establishes partition validation and correct local allocation. No measured throughput or GPU-memory reduction is attributed to it.

---
<details>
<summary>PR description checklist</summary>

- [x] Purpose and related work described.
- [x] Test plan and actual results stated.
- [x] Model evaluation limitations stated.
- [x] AI assistance disclosed.

</details>

<details>
<summary>Standalone CPU validation loader</summary>

Saved as `run_cpu_checks.py`; set `DSV41_SPLIT_REPO` to the checked-out branch and pass the test paths listed above. This avoids CUDA model-registry imports on macOS while executing the actual leaf-module implementation, tests and tensor/collective operations. It is not a CUDA or full-model test.

```python
"""Run unchanged CPU test functions against split source without CUDA imports.

Preload only dependency-light leaf modules, as in the integration validation
driver. CUDA-only tests keep their own skip conditions. No tensor operations or
collectives are mocked by this loader.
"""
import importlib.util
import os
from pathlib import Path
import sys

import pytest

ROOT = Path(os.environ["DSV41_SPLIT_REPO"])
for name in (
    "vllm.models.deepseek_v4_1.common.pipeline",
    "vllm.models.deepseek_v4_1.common.pipeline_transfer",
    "vllm.v1.worker.ubatch_inputs",
):
    path = ROOT / (name.replace(".", "/") + ".py")
    if not path.is_file():
        continue
    spec = importlib.util.spec_from_file_location(name, path)
    module = importlib.util.module_from_spec(spec)
    sys.modules[name] = module
    spec.loader.exec_module(module)

if __name__ == "__main__":
    raise SystemExit(pytest.main(["-q", "--noconftest", "-o", "addopts=", *sys.argv[1:]]))
```

</details>
