### PR TITLE
[Model][PP] Add DeepSeek-V4.1 sequence-parallel stage boundaries

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,55 @@ def _write_json(path: Path, value: object) -> None:
     path.write_text(json.dumps(value), encoding="utf-8")
 
 
+@pytest.mark.parametrize("enabled", [False, True])
+def test_deepseek_v41_pp_sp_initializes_single_dp_communication(enabled):
+    import torch
+
+    from vllm.forward_context import DPMetadata
+    from vllm.model_executor.models.config import DeepseekV4ForCausalLMConfig
+
+    parallel = ParallelConfig(
+        tensor_parallel_size=2,
+        pipeline_parallel_size=2,
+        enable_expert_parallel=True,
+        is_moe_model=True,
+    )
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="deepseek_v41")
+        ),
+        parallel_config=parallel,
+        additional_config={"deepseek_v41_pp_sp": enabled},
+    )
+    DeepseekV4ForCausalLMConfig.verify_and_update_config(cast(VllmConfig, config))
+    assert parallel.use_sequence_parallel_moe == enabled
+    assert parallel.use_all2all == enabled
+    if enabled:
+        metadata = DPMetadata.make(parallel, 7, torch.tensor([7]))
+        with metadata.sp_local_sizes(2):
+            assert metadata.get_chunk_sizes_across_dp_rank() == [4, 4]
+
+
+def test_deepseek_v41_single_dp_pp_sp_rejects_unvalidated_collectives():
+    from vllm.model_executor.models.config import DeepseekV4ForCausalLMConfig
+
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="deepseek_v41")
+        ),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            pipeline_parallel_size=2,
+            enable_expert_parallel=True,
+            is_moe_model=True,
+            all2all_backend="deepep_high_throughput",
+        ),
+        additional_config={"deepseek_v41_pp_sp": True},
+    )
+    with pytest.raises(ValueError, match="requires allgather_reducescatter"):
+        DeepseekV4ForCausalLMConfig.verify_and_update_config(cast(VllmConfig, config))
+
+
 def test_kda_recoverssm_derivation_is_revalidated():
     config = SimpleNamespace(
         cache_config=SimpleNamespace(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1328,6 +1328,30 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_pp_empty_uniform_group_does_not_allocate_remote_layers():
+    """An empty projected group retains its type, but must allocate no layers."""
+    spec = new_kv_cache_spec()
+    remote_spec = UniformTypeKVCacheSpecs(
+        block_size=spec.block_size,
+        kv_cache_specs={"remote": spec},
+    )
+    groups = kv_cache_utils._project_kv_cache_groups_to_worker(
+        [
+            KVCacheGroupSpec(["remote"], remote_spec),
+            KVCacheGroupSpec(["local"], spec),
+        ],
+        {"local": spec},
+    )
+    config = VllmConfig()
+    config.cache_config.kv_cache_layout = "BLHNC"
+    cache = kv_cache_utils.get_kv_cache_config_from_groups(
+        config, groups, spec.page_size_bytes * 4
+    )
+    assert cache.num_blocks == 4
+    assert [tensor.layers for tensor in cache.kv_cache_tensors] == [["local"]]
+    assert cache.kv_cache_groups[0].layer_names == []
+
+
 def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
     dcp = 8
     full = FullAttentionSpec(

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -205,6 +205,12 @@ class ParallelConfig:
     - "nixl_ep": Use nixl-ep kernels
     - "flashinfer_nvlink_one_sided": Use flashinfer high-throughput a2a kernels
     - "flashinfer_nvlink_two_sided": Use flashinfer two-sided kernels for mnnvl"""
+    enable_sequence_parallel_moe: bool = False
+    """Allow model-selected sequence-parallel MoE with a single DP rank.
+
+    Model config hooks enable this before communication groups are created.
+    The model must shard its inputs and set FusedMoE's is_sequence_parallel.
+    """
 
     max_parallel_loading_workers: int | None = Field(default=None, ge=1)
     """Maximum number of parallel loading workers when loading model
@@ -722,7 +728,7 @@ class ParallelConfig:
             )
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1
-            and self.data_parallel_size > 1
+            and (self.data_parallel_size > 1 or self.enable_sequence_parallel_moe)
         )
 
     @property

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -326,6 +326,27 @@ class DiffusionGemmaModelForBlockDiffusionConfig(VerifyAndUpdateConfig):
 
 class DeepseekV4ForCausalLMConfig(VerifyAndUpdateConfig):
     @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        model_config = vllm_config.model_config
+        additional = vllm_config.additional_config
+        if (
+            model_config is None
+            or getattr(model_config.hf_config, "model_type", None) != "deepseek_v41"
+            or not isinstance(additional, dict)
+            or not additional.get("deepseek_v41_pp_sp", False)
+        ):
+            return
+        parallel = vllm_config.parallel_config
+        if not parallel.enable_expert_parallel or parallel.tensor_parallel_size < 2:
+            raise ValueError("DeepSeek V4.1 PP+SP requires EP and TP >= 2")
+        if parallel.data_parallel_size == 1:
+            if parallel.all2all_backend != "allgather_reducescatter":
+                raise ValueError(
+                    "DeepSeek V4.1 PP+SP with DP=1 requires allgather_reducescatter"
+                )
+            parallel.enable_sequence_parallel_moe = True
+
+    @staticmethod
     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
         quant_config = getattr(model_config.hf_config, "quantization_config", None)
         if quant_config is not None and quant_config.get("quant_method") == "fp8":

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -152,11 +152,19 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
 def _use_sequence_parallel(vllm_config: VllmConfig) -> bool:
     parallel_config = vllm_config.parallel_config
     use_mega_moe = vllm_config.kernel_config.moe_backend in MEGA_MOE_BACKENDS
+    additional_config = vllm_config.additional_config
+    pp_sp_enabled = isinstance(additional_config, dict) and additional_config.get(
+        "deepseek_v41_pp_sp", False
+    )
     return (
-        parallel_config.pipeline_parallel_size == 1
+        (parallel_config.pipeline_parallel_size == 1 or pp_sp_enabled)
         and parallel_config.enable_expert_parallel
         and parallel_config.tensor_parallel_size > 1
-        and (use_mega_moe or parallel_config.data_parallel_size > 1)
+        and (
+            use_mega_moe
+            or parallel_config.data_parallel_size > 1
+            or parallel_config.enable_sequence_parallel_moe
+        )
     )
 
 
@@ -319,6 +327,12 @@ class DeepseekV4DecoderLayer(nn.Module):
                 )
             else:
                 residual = x
+                if self.engram is not None and engram_hashes is not None:
+                    residual = self.engram(
+                        residual,
+                        engram_hashes[:, self.engram.layer_hash_index],
+                        engram_mask,
+                    )
                 post_mix, res_mix, x, attn_pre = mhc_pre_delayed_tilelang(
                     residual,
                     self.hc_attn_fn,
@@ -603,6 +617,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                         )
 
         full_num_tokens = positions.shape[0]
+        pre_mix: torch.Tensor | None = None
+        if not get_pp_group().is_first_rank:
+            assert intermediate_tensors is not None
+            pre_mix = intermediate_tensors["pre_mix"]
         if self.use_sequence_parallel:
             if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
                 forward_context = get_forward_context()
@@ -610,13 +628,12 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     forward_context.is_padding, hidden_states
                 )
             hidden_states = sp_shard(hidden_states)
-            input_ids = sp_shard(input_ids)
+            if input_ids is not None:
+                input_ids = sp_shard(input_ids)
+            if pre_mix is not None:
+                pre_mix = sp_shard(pre_mix)
 
         residual, post_mix, res_mix = None, None, None
-        pre_mix: torch.Tensor | None = None
-        if not get_pp_group().is_first_rank:
-            assert intermediate_tensors is not None
-            pre_mix = intermediate_tensors["pre_mix"]
         aux_hidden_states: list[torch.Tensor] = []
         final_aux_recon: torch.Tensor | None = None  # avoid duplicate mhc_post call
         for idx, layer in enumerate(
@@ -654,6 +671,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 )
 
         if not get_pp_group().is_last_rank:
+            if self.use_sequence_parallel:
+                hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
+                assert pre_mix is not None
+                pre_mix = sp_all_gather(pre_mix)[:full_num_tokens]
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "pre_mix": pre_mix}
             )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1725,13 +1725,9 @@ def get_kv_cache_config_from_groups(
 
     kv_cache_tensors = []
     for group in kv_cache_groups:
-        group_spec = group.kv_cache_spec
         layers_by_spec: defaultdict[KVCacheSpec, list[str]] = defaultdict(list)
-        if isinstance(group_spec, UniformTypeKVCacheSpecs):
-            for layer_name, spec in group_spec.kv_cache_specs.items():
-                layers_by_spec[spec].append(layer_name)
-        elif group.layer_names:
-            layers_by_spec[group_spec].extend(group.layer_names)
+        for layer_name in group.layer_names:
+            layers_by_spec[_get_per_layer_spec(group, layer_name)].append(layer_name)
 
         byte_offset = 0
         for spec, layer_names in layers_by_spec.items():


### PR DESCRIPTION
## Purpose

Add the default-off `--additional-config '{"deepseek_v41_pp_sp":true}'` path. Gather and trim both hidden states and delayed `pre_mix` at a pipeline exit, then shard both at the next stage. Apply Engram at a stage's first decoder layer before its attention pre-mix. Initialize single-DP sequence-parallel MoE communication before groups are created; require EP, TP≥2 and, for DP=1, `allgather_reducescatter`.

Includes the small local cache-allocation prerequisite from #56221. Cross-stage sharing is separate in #56223; the upstream Engram all-gather implementation is retained. The duplicate check found #53191 for DeepSeek-V2/Qwen3 models; it does not handle the V4.1 delayed mHC `pre_mix` and Engram stage boundary addressed here.

Based on #56214 (`dsv41-feat`, `c9d909e802a39292f54101bff8a36096761ea605`). The PR targets that feature branch so the model implementation is not repeated in this diff.

Rebased on 2026-09-11 after the feature branch was rewritten. Changed-file Python parsing and all applicable pre-commit hooks passed. GPU/full-model measurements below belong to the prior revision based on `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`; they were not rerun on this rebased head.

AI assistance: OpenAI Codex assisted with implementation, review, test execution and preparation of this PR. This draft does not claim that a human has completed a line-by-line review.

## Test Plan

Fresh split: all applicable pre-commit hooks passed for the six changed files; all changed Python files parsed successfully. The new cases in `tests/test_config.py` cover disabled/enabled DP=1 communication and rejection of an unvalidated collective backend. Those three cases passed in the earlier H100 integration, together with the cache-group checks; they were not rerun as GPU/model tests on the split branch.

## Test Result

Recorded full-model runs used `deepseek-ai/DeepSeek-V4.1-Flash`, revision `df42c109f1defefcbfcedbe7d905718a12266e40`, on 4×SXM H100 80 GiB. Each positive matrix case checked six short questions, cold/cached long input with chunked prefill, and four unequal-length concurrent requests. “Text equal” means short-answer text equality to the TP4 reference, not logits/token-probability parity or a standard accuracy benchmark.

**Evidence scope:** GPU results below come from the earlier combined integration based on #56214, including companion changes. The isolated PR has not had a new full-model GPU run. Fresh split checks are listed separately; passing the integrated run does not establish isolated-branch equivalence.

| Integrated configuration | QA answers correct | QA text equal to TP4 | Long / chunked + prefix | Concurrent requests | Strict result |
| --- | --- | --- | --- | --- | --- |
| PP2×TP2 SP eager, 20/20, synchronous lookup | 6/6 | 5/6 | 2/2 correct; cache reuse checked | 4/4 correct | Text mismatch; strict check not passed |
| PP2×TP2 SP eager, 20/20, lookup overlap (#56220) | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| PP2×TP2 SP + sharing (#56223), 19/21, synchronous | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| PP2×TP2 SP + sharing + overlap, 19/21 | 6/6 | 5/6 | 2/2 correct; cache reuse checked | 4/4 correct | Text mismatch; strict check not passed |
| PP2×TP2 SP breakable decode graph, synchronous | 6/6 | 5/6 | 2/2 correct; cache reuse checked | 4/4 correct | Text mismatch; strict check not passed |
| PP2×TP2 SP breakable decode graph, overlap option | 6/6 | 5/6 | 2/2 correct; cache reuse checked | 4/4 correct | Text mismatch; strict check not passed |

All four workers confirmed that SP was active. Graph rows completed capture and generation with `FULL_DECODE_ONLY`, sizes `[1,2,4]`, and Torch compile disabled. **Only 2/6 configurations passed the strict short-answer text comparison.** The remaining four differed on the sequence question's wording; the cause is unresolved. This remains Draft for isolated-branch GPU/output validation.

**Short-request serving with the companion sharing implementation**

| Integrated configuration | Input → output | Successful requests | Concurrency | Output tokens/s | Median TTFT / TPOT ms |
| --- | --- | --- | --- | --- | --- |
| PP2×TP2+SP + #56223 sharing, 19/21 layers | 512 → 128 | 16/16 | 4 | 11.458 | 8235.85 / 294.05 |

One measured run after warmup, eager, prefix cache off, CPU weight offload 8 GiB. This is an absolute result for a configuration that requires sharing; disabling sharing rejects this partition. It does not establish an A/B speedup attributable to SP. **No measured GPU-memory reduction is established for PP+SP.**

| Validation | Result | Origin |
| --- | --- | --- |
| SP configuration / collective initialization | 3/3 PASS | Earlier H100 integration |
| Projected-cache-group regression | 2/2 PASS | Earlier H100 integration; prerequisite from #56221 |
| Applicable pre-commit hooks and changed Python parsing | PASS; 6 changed files | Fresh isolated split |

---
<details>
<summary>PR description checklist</summary>

- [x] Purpose and related work described.
- [x] Test plan and actual results stated.
- [x] Model evaluation limitations stated.
- [x] AI assistance disclosed.

</details>
